### PR TITLE
SP3: device-code login (Lab tier soak)

### DIFF
--- a/ConditioningControlPanel/LoginDialog.xaml
+++ b/ConditioningControlPanel/LoginDialog.xaml
@@ -70,7 +70,6 @@
                         Cursor="Hand" Click="BtnLoginDeviceCode_Click"
                         Visibility="Collapsed">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="🌐" FontSize="20" Margin="0,0,10,0"/>
                         <TextBlock Text="Sign in via Web" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
@@ -206,6 +205,18 @@
                                HorizontalAlignment="Center"
                                TextAlignment="Center"/>
                 </Border>
+
+                <!-- Manual fallback: if Process.Start failed to open the browser, the user
+                     can read this URL and open it themselves. Selectable so they can copy. -->
+                <TextBlock Text="Or open this URL manually:"
+                           FontSize="11" Foreground="#808080"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <TextBox x:Name="TxtVerificationUrl"
+                         IsReadOnly="True"
+                         BorderThickness="0" Background="Transparent" Foreground="#B0B0B0"
+                         FontSize="12" FontFamily="Consolas, Courier New"
+                         HorizontalAlignment="Center" Margin="0,0,0,12"
+                         Cursor="IBeam"/>
 
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,15">
                     <Button x:Name="BtnDeviceCodeCopy" Content="Copy code"

--- a/ConditioningControlPanel/LoginDialog.xaml
+++ b/ConditioningControlPanel/LoginDialog.xaml
@@ -61,6 +61,20 @@
                     </StackPanel>
                 </Button>
 
+                <!-- SP3: Sign in via Web (device-code flow). Visibility gated at runtime
+                     on AppSettings.PatreonTier >= 2 (Lab-tier soak). -->
+                <Button x:Name="BtnLoginDeviceCode"
+                        Padding="20,15" Margin="0,0,0,15"
+                        Background="#9333EA" Foreground="White"
+                        BorderThickness="0" FontWeight="Bold" FontSize="16"
+                        Cursor="Hand" Click="BtnLoginDeviceCode_Click"
+                        Visibility="Collapsed">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="🌐" FontSize="20" Margin="0,0,10,0"/>
+                        <TextBlock Text="Sign in via Web" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+
             </StackPanel>
 
             <!-- Account Login/Register Panel -->
@@ -167,6 +181,57 @@
                            FontSize="16" Foreground="White" HorizontalAlignment="Center"/>
                 <ProgressBar IsIndeterminate="True" Width="200" Height="4" Margin="0,15,0,0"
                              Foreground="{DynamicResource PinkBrush}" Background="{DynamicResource AccentTintedBgBrush}"/>
+            </StackPanel>
+
+            <!-- SP3: Device-Code Panel -->
+            <StackPanel x:Name="DeviceCodePanel" Grid.Row="2" Visibility="Collapsed"
+                        VerticalAlignment="Center">
+                <TextBlock Text="Sign in via Web"
+                           FontSize="18" FontWeight="Bold" Foreground="White"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                <TextBlock Text="We've opened your browser to finish sign-in. Complete it there, then come back to this window. It's okay to leave this open."
+                           FontSize="12" Foreground="#B0B0B0" TextWrapping="Wrap"
+                           HorizontalAlignment="Center" Margin="0,0,0,15"
+                           TextAlignment="Center"/>
+
+                <TextBlock Text="Your code:"
+                           FontSize="11" Foreground="#808080"
+                           HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <Border BorderBrush="#9333EA" BorderThickness="2" CornerRadius="6"
+                        Background="{DynamicResource PanelBgBrush}" Padding="20,12"
+                        HorizontalAlignment="Center" Margin="0,0,0,12">
+                    <TextBlock x:Name="TxtDeviceCode" Text="------"
+                               FontSize="32" FontWeight="Bold" Foreground="White"
+                               FontFamily="Consolas, Courier New"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center"/>
+                </Border>
+
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,15">
+                    <Button x:Name="BtnDeviceCodeCopy" Content="Copy code"
+                            Padding="14,6" Margin="0,0,8,0"
+                            Background="{DynamicResource AccentTintedBgBrush}" Foreground="White"
+                            BorderThickness="0" FontSize="12" Cursor="Hand"
+                            Click="BtnDeviceCodeCopy_Click"/>
+                    <Button x:Name="BtnDeviceCodeOpenBrowser" Content="Open browser again"
+                            Padding="14,6"
+                            Background="{DynamicResource AccentTintedBgBrush}" Foreground="White"
+                            BorderThickness="0" FontSize="12" Cursor="Hand"
+                            Click="BtnDeviceCodeOpenBrowser_Click"/>
+                </StackPanel>
+
+                <TextBlock x:Name="TxtDeviceStatus" Text="Waiting for browser confirmation..."
+                           FontSize="12" Foreground="#B0B0B0"
+                           HorizontalAlignment="Center" Margin="0,0,0,8"
+                           TextAlignment="Center" TextWrapping="Wrap"/>
+                <ProgressBar x:Name="DeviceProgressBar" IsIndeterminate="True"
+                             Width="200" Height="3" Margin="0,0,0,15"
+                             Foreground="#9333EA" Background="{DynamicResource AccentTintedBgBrush}"/>
+
+                <TextBlock Text="Cancel" Margin="0,0,0,0"
+                           FontSize="12" Foreground="#808080"
+                           HorizontalAlignment="Center" Cursor="Hand"
+                           MouseLeftButtonDown="BtnDeviceCodeCancel_Click"/>
             </StackPanel>
 
             <!-- Cancel Button -->

--- a/ConditioningControlPanel/LoginDialog.xaml.cs
+++ b/ConditioningControlPanel/LoginDialog.xaml.cs
@@ -61,6 +61,16 @@ namespace ConditioningControlPanel
             {
                 BtnLoginDeviceCode.Visibility = Visibility.Visible;
             }
+
+            // SP3: cancel any in-flight device-code polling on dialog close so
+            // alt+F4 / parent .Close() / session-end don't leave an orphan loop
+            // hammering /poll against a hidden window until 15min server expiry.
+            this.Closed += (s, e) =>
+            {
+                _deviceCts?.Cancel();
+                _deviceCts?.Dispose();
+                _deviceCts = null;
+            };
         }
 
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -643,6 +653,8 @@ namespace ConditioningControlPanel
             Close();
         }
 
+        #endregion
+
         #region SP3 Device-Code Flow
 
         private async void BtnLoginDeviceCode_Click(object sender, RoutedEventArgs e)
@@ -690,6 +702,8 @@ namespace ConditioningControlPanel
             TxtDeviceCode.Text = code.Length == 6
                 ? $"{code.Substring(0, 3)}-{code.Substring(3, 3)}"
                 : code;
+            // Keep DRY with the service constant; if it changes, single source of truth.
+            TxtVerificationUrl.Text = V2DeviceCodeService.VerificationUrl;
             TxtDeviceStatus.Text = "Waiting for browser confirmation...";
         }
 
@@ -753,8 +767,15 @@ namespace ConditioningControlPanel
                             break;
 
                         case V2DeviceCodeService.PollStatus.Expired:
-                        case V2DeviceCodeService.PollStatus.NotFound:
                             HandleDeviceCodeExpired();
+                            return;
+
+                        case V2DeviceCodeService.PollStatus.NotFound:
+                            // 404 is distinct from 410 per proxy doc — recovery is the
+                            // same (re-run /initiate) but the message differs. Shouldn't
+                            // fire in practice (desktop holds the code; user doesn't type),
+                            // but if it does, surface diagnostically clear copy.
+                            HandleDeviceCodeError("Sign-in code wasn't recognized. Please try again.");
                             return;
 
                         case V2DeviceCodeService.PollStatus.RateLimited:
@@ -820,6 +841,14 @@ namespace ConditioningControlPanel
                 Provider = "device_code"
             };
 
+            // Polling loop has already returned; this is hygiene so the CTS
+            // doesn't linger as an undisposed IDisposable until GC. Closed
+            // event handler also disposes — Dispose is idempotent so the
+            // double-call is safe.
+            _deviceCts?.Cancel();
+            _deviceCts?.Dispose();
+            _deviceCts = null;
+
             DialogResult = true;
             Close();
         }
@@ -873,8 +902,6 @@ namespace ConditioningControlPanel
             _deviceCode = null;
             ShowProviderSelection();
         }
-
-        #endregion
 
         #endregion
     }

--- a/ConditioningControlPanel/LoginDialog.xaml.cs
+++ b/ConditioningControlPanel/LoginDialog.xaml.cs
@@ -29,6 +29,11 @@ namespace ConditioningControlPanel
         private string? _pendingInviteCode;
         private string? _pendingPassword;
 
+        // SP3 device-code flow state
+        private CancellationTokenSource? _deviceCts;
+        private string? _deviceCode;
+        private DateTimeOffset _deviceCodeExpiresAt;
+
         /// <summary>
         /// Result of the login process
         /// </summary>
@@ -48,6 +53,14 @@ namespace ConditioningControlPanel
         public LoginDialog()
         {
             InitializeComponent();
+
+            // SP3 Lab gate: cached PatreonTier >= 2 from a prior legacy login.
+            // Removed when SP3 promotes from Lab to stable.
+            var tier = App.Settings?.Current?.PatreonTier ?? 0;
+            if (tier >= 2)
+            {
+                BtnLoginDeviceCode.Visibility = Visibility.Visible;
+            }
         }
 
         private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -198,6 +211,7 @@ namespace ConditioningControlPanel
             LoadingPanel.Visibility = Visibility.Collapsed;
             UsernamePanel.Visibility = Visibility.Visible;
             AccountPanel.Visibility = Visibility.Collapsed;
+            DeviceCodePanel.Visibility = Visibility.Collapsed;
 
             TxtUsernameTitle.Text = Loc.Get("label_choose_your_display_name");
             TxtUsernameSubtitle.Text = Loc.Get("label_this_will_be_shown_on_the_leaderboard");
@@ -390,6 +404,7 @@ namespace ConditioningControlPanel
             LoadingPanel.Visibility = Visibility.Collapsed;
             UsernamePanel.Visibility = Visibility.Collapsed;
             AccountPanel.Visibility = Visibility.Visible;
+            DeviceCodePanel.Visibility = Visibility.Collapsed;
 
             // Clear all fields
             TxtInviteCode.Text = "";
@@ -574,6 +589,7 @@ namespace ConditioningControlPanel
             LoadingPanel.Visibility = Visibility.Collapsed;
             UsernamePanel.Visibility = Visibility.Collapsed;
             AccountPanel.Visibility = Visibility.Collapsed;
+            DeviceCodePanel.Visibility = Visibility.Collapsed;
             BtnLoginDiscord.IsEnabled = true;
             BtnLoginPatreon.IsEnabled = true;
         }
@@ -585,6 +601,7 @@ namespace ConditioningControlPanel
             LoadingPanel.Visibility = Visibility.Visible;
             UsernamePanel.Visibility = Visibility.Collapsed;
             AccountPanel.Visibility = Visibility.Collapsed;
+            DeviceCodePanel.Visibility = Visibility.Collapsed;
         }
 
         private void ShowError(string message)
@@ -615,12 +632,249 @@ namespace ConditioningControlPanel
             else if (_firstProvider == "patreon")
                 App.Patreon?.Logout();
 
+            // Stop device-code polling if it's running.
+            _deviceCts?.Cancel();
+            _deviceCode = null;
+
             // Clear sensitive data (audit C1)
             ClearSensitiveData();
 
             DialogResult = false;
             Close();
         }
+
+        #region SP3 Device-Code Flow
+
+        private async void BtnLoginDeviceCode_Click(object sender, RoutedEventArgs e)
+        {
+            ShowLoading("Generating sign-in code...");
+
+            try
+            {
+                var svc = new V2DeviceCodeService();
+                var resp = await svc.InitiateAsync();
+
+                if (!resp.Success || string.IsNullOrEmpty(resp.Code))
+                {
+                    ShowError(SanitizeError(resp.Error));
+                    return;
+                }
+
+                _deviceCode = resp.Code;
+                _deviceCodeExpiresAt = resp.ExpiresAt;
+
+                ShowDeviceCodePanel(resp.Code);
+                OpenVerificationUrl();
+
+                _deviceCts?.Cancel();
+                _deviceCts?.Dispose();
+                _deviceCts = new CancellationTokenSource();
+                _ = PollDeviceCodeLoopAsync(_deviceCts.Token);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "[DeviceCode] Initiate exception");
+                ShowError(Loc.Get("login_failed_please_try_again"));
+            }
+        }
+
+        private void ShowDeviceCodePanel(string code)
+        {
+            ProviderPanel.Visibility = Visibility.Collapsed;
+            LoadingPanel.Visibility = Visibility.Collapsed;
+            UsernamePanel.Visibility = Visibility.Collapsed;
+            AccountPanel.Visibility = Visibility.Collapsed;
+            DeviceCodePanel.Visibility = Visibility.Visible;
+
+            // Display 6-char code as "ABC-DEF" for legibility.
+            TxtDeviceCode.Text = code.Length == 6
+                ? $"{code.Substring(0, 3)}-{code.Substring(3, 3)}"
+                : code;
+            TxtDeviceStatus.Text = "Waiting for browser confirmation...";
+        }
+
+        private static void OpenVerificationUrl()
+        {
+            try
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = V2DeviceCodeService.VerificationUrl,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[DeviceCode] Failed to open browser");
+            }
+        }
+
+        /// <summary>
+        /// Polls /v2/auth/device/poll until 200 confirmed, 410/404 expired, or
+        /// hard expiry (server-returned expires_at). Backs off on 429/503/transient.
+        /// </summary>
+        private async Task PollDeviceCodeLoopAsync(CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(_deviceCode)) return;
+
+            var svc = new V2DeviceCodeService();
+            int intervalMs = 3000;
+            int consecutiveUnknown = 0;
+
+            try
+            {
+                // Initial wait so the user has time to switch to the browser.
+                await Task.Delay(intervalMs, ct);
+
+                while (!ct.IsCancellationRequested)
+                {
+                    // Hard expiry guard against server-returned expires_at —
+                    // don't trust local clock for "is the code expired" logic
+                    // beyond this comparison against a server-issued timestamp.
+                    if (DateTimeOffset.UtcNow > _deviceCodeExpiresAt)
+                    {
+                        HandleDeviceCodeExpired();
+                        return;
+                    }
+
+                    var result = await svc.PollAsync(_deviceCode!, ct);
+                    if (ct.IsCancellationRequested) return;
+
+                    switch (result.Status)
+                    {
+                        case V2DeviceCodeService.PollStatus.Confirmed:
+                            HandleDeviceCodeConfirmed(result);
+                            return;
+
+                        case V2DeviceCodeService.PollStatus.Pending:
+                            intervalMs = 3000;
+                            consecutiveUnknown = 0;
+                            TxtDeviceStatus.Text = "Waiting for browser confirmation...";
+                            break;
+
+                        case V2DeviceCodeService.PollStatus.Expired:
+                        case V2DeviceCodeService.PollStatus.NotFound:
+                            HandleDeviceCodeExpired();
+                            return;
+
+                        case V2DeviceCodeService.PollStatus.RateLimited:
+                        case V2DeviceCodeService.PollStatus.ServiceUnavailable:
+                            intervalMs = Math.Min(intervalMs * 2, 30000);
+                            TxtDeviceStatus.Text = "Connection busy, retrying...";
+                            break;
+
+                        case V2DeviceCodeService.PollStatus.BadRequest:
+                        case V2DeviceCodeService.PollStatus.Unauthorized:
+                            HandleDeviceCodeError("Sign-in failed. Please try again.");
+                            return;
+
+                        case V2DeviceCodeService.PollStatus.Unknown:
+                        default:
+                            consecutiveUnknown++;
+                            if (consecutiveUnknown >= 5)
+                            {
+                                HandleDeviceCodeError("Lost connection to server. Please try again.");
+                                return;
+                            }
+                            intervalMs = Math.Min(intervalMs * 2, 30000);
+                            TxtDeviceStatus.Text = "Connection issue, retrying...";
+                            break;
+                    }
+
+                    await Task.Delay(intervalMs, ct);
+                }
+            }
+            catch (OperationCanceledException) { /* user cancelled */ }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "[DeviceCode] Poll loop crashed");
+                HandleDeviceCodeError("Unexpected error. Please try again.");
+            }
+        }
+
+        private void HandleDeviceCodeConfirmed(V2DeviceCodeService.PollResponse result)
+        {
+            if (string.IsNullOrEmpty(result.AuthToken) || string.IsNullOrEmpty(result.UnifiedId))
+            {
+                HandleDeviceCodeError("Server returned an incomplete response.");
+                return;
+            }
+
+            // Store auth_token via DPAPI (same protection as legacy paths).
+            // unified_id is plaintext in settings.json — same as every other provider.
+            if (App.Settings?.Current != null)
+            {
+                App.Settings.Current.AuthToken = result.AuthToken;
+                App.Settings.Current.UnifiedId = result.UnifiedId;
+                App.Settings.Save();
+            }
+            App.UnifiedUserId = result.UnifiedId;
+
+            Result = new LoginResult
+            {
+                Success = true,
+                IsLegacyUser = false,
+                ShouldShowOgWelcome = false,
+                UnifiedId = result.UnifiedId,
+                DisplayName = App.Settings?.Current?.UserDisplayName,
+                Provider = "device_code"
+            };
+
+            DialogResult = true;
+            Close();
+        }
+
+        private void HandleDeviceCodeExpired()
+        {
+            _deviceCts?.Cancel();
+            _deviceCode = null;
+            MessageBox.Show(this,
+                "Sign-in code expired. Please try again.",
+                Loc.Get("title_error"),
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            ShowProviderSelection();
+        }
+
+        private void HandleDeviceCodeError(string message)
+        {
+            _deviceCts?.Cancel();
+            _deviceCode = null;
+            MessageBox.Show(this,
+                message,
+                Loc.Get("title_error"),
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
+            ShowProviderSelection();
+        }
+
+        private void BtnDeviceCodeCopy_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(_deviceCode)) return;
+            try
+            {
+                Clipboard.SetText(_deviceCode);
+                TxtDeviceStatus.Text = "Code copied. Paste in your browser.";
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[DeviceCode] Clipboard copy failed");
+            }
+        }
+
+        private void BtnDeviceCodeOpenBrowser_Click(object sender, RoutedEventArgs e)
+        {
+            OpenVerificationUrl();
+        }
+
+        private void BtnDeviceCodeCancel_Click(object sender, MouseButtonEventArgs e)
+        {
+            _deviceCts?.Cancel();
+            _deviceCode = null;
+            ShowProviderSelection();
+        }
+
+        #endregion
 
         #endregion
     }

--- a/ConditioningControlPanel/Services/V2DeviceCodeService.cs
+++ b/ConditioningControlPanel/Services/V2DeviceCodeService.cs
@@ -53,6 +53,17 @@ namespace ConditioningControlPanel.Services
             public string? Error { get; set; }
         }
 
+        // Internal DTO for JsonConvert.DeserializeObject — typed deserialization
+        // with [JsonProperty] handles ISO 8601 + 'Z' suffix → DateTimeOffset cleanly,
+        // unlike JObject.Parse + JValue<DateTime>.ToString round-trip which strips
+        // timezone info on non-UTC systems.
+        private class InitiateRaw
+        {
+            [JsonProperty("code")] public string? Code { get; set; }
+            [JsonProperty("session_id")] public string? SessionId { get; set; }
+            [JsonProperty("expires_at")] public DateTimeOffset ExpiresAt { get; set; }
+        }
+
         public class PollResponse
         {
             public PollStatus Status { get; set; }
@@ -82,28 +93,35 @@ namespace ConditioningControlPanel.Services
                     return new InitiateResponse { Success = false, Error = error };
                 }
 
-                var obj = JObject.Parse(json);
-                var code = obj["code"]?.ToString();
-                var sessionId = obj["session_id"]?.ToString();
-                var expiresAtStr = obj["expires_at"]?.ToString();
+                // Typed POCO deserialization — same pattern as V2AuthService. Handles
+                // ISO 8601 with 'Z' suffix → DateTimeOffset cleanly, preserving UTC.
+                InitiateRaw? raw;
+                try
+                {
+                    raw = JsonConvert.DeserializeObject<InitiateRaw>(json);
+                }
+                catch (Exception ex)
+                {
+                    return new InitiateResponse { Success = false, Error = "Bad response: " + ex.Message };
+                }
 
-                if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(expiresAtStr))
+                if (raw == null || string.IsNullOrEmpty(raw.Code))
                 {
                     return new InitiateResponse { Success = false, Error = "Invalid response" };
                 }
 
-                if (!DateTimeOffset.TryParse(expiresAtStr, out var expiresAt))
+                if (raw.ExpiresAt == default)
                 {
                     return new InitiateResponse { Success = false, Error = "Invalid expiry" };
                 }
 
-                Log.Information("[DeviceCode] Initiated session={Session}", sessionId?.Substring(0, Math.Min(8, sessionId.Length)));
+                Log.Information("[DeviceCode] Initiated session={Session}", raw.SessionId?.Substring(0, Math.Min(8, raw.SessionId.Length)));
                 return new InitiateResponse
                 {
                     Success = true,
-                    Code = code,
-                    SessionId = sessionId,
-                    ExpiresAt = expiresAt
+                    Code = raw.Code,
+                    SessionId = raw.SessionId,
+                    ExpiresAt = raw.ExpiresAt
                 };
             }
             catch (OperationCanceledException)

--- a/ConditioningControlPanel/Services/V2DeviceCodeService.cs
+++ b/ConditioningControlPanel/Services/V2DeviceCodeService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// SP3 device-code login (proxy /v2/auth/device/initiate + /poll).
+    /// User confirms the code on cclabs-web; desktop polls until 200 confirmed.
+    /// /confirm is web-side only; conflict (409) is resolved on the web tab the
+    /// user is already in, so this client doesn't surface a desktop conflict UI.
+    /// </summary>
+    public class V2DeviceCodeService
+    {
+        private static readonly HttpClient _http = new();
+        private const string SERVER_URL = "https://codebambi-proxy.vercel.app";
+
+        // Hardcoded: /v2/auth/device/initiate doesn't return a verification_url.
+        // Switch this single constant if cclabs-web adds a dedicated /pair page.
+        public const string VerificationUrl = "https://app.cclabs.app/login";
+
+        static V2DeviceCodeService()
+        {
+            _http.Timeout = TimeSpan.FromSeconds(30);
+            _http.DefaultRequestHeaders.Add("X-Client-Version", UpdateService.AppVersion);
+            _http.DefaultRequestHeaders.UserAgent.ParseAdd($"ConditioningControlPanel/{UpdateService.AppVersion}");
+        }
+
+        public enum PollStatus
+        {
+            Pending,
+            Confirmed,
+            Expired,
+            NotFound,
+            RateLimited,
+            ServiceUnavailable,
+            BadRequest,
+            Unauthorized,
+            Unknown
+        }
+
+        public class InitiateResponse
+        {
+            public bool Success { get; set; }
+            public string? Code { get; set; }
+            public string? SessionId { get; set; }
+            public DateTimeOffset ExpiresAt { get; set; }
+            public string? Error { get; set; }
+        }
+
+        public class PollResponse
+        {
+            public PollStatus Status { get; set; }
+            public string? AuthToken { get; set; }
+            public string? UnifiedId { get; set; }
+            public bool IsNewUser { get; set; }
+        }
+
+        public async Task<InitiateResponse> InitiateAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                var payload = new JObject
+                {
+                    ["client"] = "ccp-desktop",
+                    ["version"] = UpdateService.AppVersion
+                };
+
+                var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+                var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/device/initiate", content, ct);
+                var json = await response.Content.ReadAsStringAsync(ct);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var error = ParseErrorMessage(json, response.StatusCode);
+                    Log.Warning("[DeviceCode] Initiate failed: {Status} {Error}", (int)response.StatusCode, error);
+                    return new InitiateResponse { Success = false, Error = error };
+                }
+
+                var obj = JObject.Parse(json);
+                var code = obj["code"]?.ToString();
+                var sessionId = obj["session_id"]?.ToString();
+                var expiresAtStr = obj["expires_at"]?.ToString();
+
+                if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(expiresAtStr))
+                {
+                    return new InitiateResponse { Success = false, Error = "Invalid response" };
+                }
+
+                if (!DateTimeOffset.TryParse(expiresAtStr, out var expiresAt))
+                {
+                    return new InitiateResponse { Success = false, Error = "Invalid expiry" };
+                }
+
+                Log.Information("[DeviceCode] Initiated session={Session}", sessionId?.Substring(0, Math.Min(8, sessionId.Length)));
+                return new InitiateResponse
+                {
+                    Success = true,
+                    Code = code,
+                    SessionId = sessionId,
+                    ExpiresAt = expiresAt
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                return new InitiateResponse { Success = false, Error = "cancelled" };
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[DeviceCode] Initiate exception");
+                return new InitiateResponse { Success = false, Error = ex.Message };
+            }
+        }
+
+        public async Task<PollResponse> PollAsync(string code, CancellationToken ct = default)
+        {
+            try
+            {
+                var payload = new JObject { ["code"] = code };
+                var content = new StringContent(payload.ToString(), Encoding.UTF8, "application/json");
+                var response = await _http.PostAsync($"{SERVER_URL}/v2/auth/device/poll", content, ct);
+                var json = await response.Content.ReadAsStringAsync(ct);
+                int statusCode = (int)response.StatusCode;
+
+                switch (statusCode)
+                {
+                    case 200:
+                    {
+                        var obj = JObject.Parse(json);
+                        var authToken = obj["auth_token"]?.ToString();
+                        var unifiedId = obj["unified_id"]?.ToString();
+                        var isNewUser = (bool?)obj["is_new_user"] ?? false;
+                        // Never log auth_token.
+                        Log.Information("[DeviceCode] Confirmed uid={Uid} new={New}", unifiedId, isNewUser);
+                        return new PollResponse
+                        {
+                            Status = PollStatus.Confirmed,
+                            AuthToken = authToken,
+                            UnifiedId = unifiedId,
+                            IsNewUser = isNewUser
+                        };
+                    }
+                    case 202:
+                        return new PollResponse { Status = PollStatus.Pending };
+                    case 400:
+                        return new PollResponse { Status = PollStatus.BadRequest };
+                    case 401:
+                        return new PollResponse { Status = PollStatus.Unauthorized };
+                    case 404:
+                        return new PollResponse { Status = PollStatus.NotFound };
+                    case 410:
+                        return new PollResponse { Status = PollStatus.Expired };
+                    case 429:
+                        return new PollResponse { Status = PollStatus.RateLimited };
+                    case 503:
+                        return new PollResponse { Status = PollStatus.ServiceUnavailable };
+                    default:
+                        Log.Warning("[DeviceCode] Poll unexpected status {Status}", statusCode);
+                        return new PollResponse { Status = PollStatus.Unknown };
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("[DeviceCode] Poll exception: {Message}", ex.Message);
+                return new PollResponse { Status = PollStatus.Unknown };
+            }
+        }
+
+        private static string ParseErrorMessage(string body, System.Net.HttpStatusCode statusCode)
+        {
+            try
+            {
+                var obj = JObject.Parse(body);
+                return obj["error"]?.ToString() ?? $"HTTP {(int)statusCode}";
+            }
+            catch
+            {
+                return $"HTTP {(int)statusCode}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a fourth login path to `LoginDialog`: **Sign in via Web**. Implements SP3 of the Supabase identity migration (spec §7) — desktop authenticates via the proxy's device-code flow against Supabase identity.

- New: `Services/V2DeviceCodeService.cs` — wraps `/v2/auth/device/initiate` and `/v2/auth/device/poll`.
- Modified: `LoginDialog.xaml` — adds `BtnLoginDeviceCode` button + `DeviceCodePanel` state.
- Modified: `LoginDialog.xaml.cs` — polling state machine, Lab-tier gate, panel-switch wiring, cancel cleanup.

## Flow

1. User clicks "Sign in via Web" → desktop POSTs `/v2/auth/device/initiate` → receives `{code, session_id, expires_at}`.
2. Desktop displays the 6-char code as `ABC-DEF` and opens `https://app.cclabs.app/login` in the user's browser.
3. Desktop polls `/v2/auth/device/poll` every 3s.
4. User signs in to cclabs-web (Discord OAuth or magic-link) and enters the code on the web UI.
5. cclabs-web calls `/v2/auth/device/confirm` server-to-proxy.
6. Desktop's next `/poll` returns 200 with `auth_token` + `unified_id` → stored, dialog closes, user is logged in.

State machine: `idle → starting → polling → {confirmed | expired | error | user_cancelled}`. Backoff 3→6→12→30s on 429/503 and transient errors. Gives up after 5 consecutive `Unknown` results. Hard-expiry guard against server-returned `expires_at` on every iteration (does not trust local clock for "is the code expired").

## Conflict handling (Option A: web-side)

The proxy's `/poll` endpoint returns 200/202/404/410/429/503 only — never 409. Conflict (`conflict_multiple_unified_ids`) is returned by `/confirm` (web-side, Supabase JWT-gated) and surfaced to the user in the cclabs-web tab they're already on. Desktop continues polling 202 until the user merges accounts on web and re-enters the code, after which `/confirm` succeeds and `/poll` returns 200.

Rationale: user is already in the browser confirming the code; bouncing them back to desktop and forward to browser again is worse UX. Implementation also avoids any proxy changes — the SP2-shipped contract is honored byte-identically.

## Lab-tier gate

`BtnLoginDeviceCode.Visibility` is `Collapsed` unless `App.Settings.Current.PatreonTier >= 2` (cached from a prior legacy login). Brand-new users with no prior login see legacy paths only. Promotion to stable: remove the gate (single `if` check in `LoginDialog` constructor).

This auto-targets the soak cohort that spec §8.4 calls for ("Patreon Tier 2+ Lab") with zero new gating infrastructure.

## Security review

### Pass 1 — auth and storage

- **`auth_token` storage parity:** written via `App.Settings.Current.AuthToken = ...` which routes to `SecureAuthTokenStore.Store` (DPAPI, `DataProtectionScope.CurrentUser`, entropy `"ConditioningControlPanel_AuthToken_v1"`) — byte-identical to legacy Discord/Patreon/account paths. **No findings.**
- **`unified_id` storage parity:** plaintext in `AppSettings.cs` — same protection level as every other provider (legacy paths also store `UnifiedId` plaintext). **No findings.**
- **`device_code` at rest:** held only in `_deviceCode` instance field for the lifetime of the `LoginDialog` instance. Cleared to `null` on cancel/expire/error/successful-close. No persistence to disk. **No findings.**
- **`device_code` in transit:** all calls go to `https://codebambi-proxy.vercel.app` over HTTPS via the shared `HttpClient`. Posted in JSON body, never in URL. **No findings.**
- **Logging audit:** `V2DeviceCodeService.cs:130` carries `// Never log auth_token.` Confirmed: `auth_token` never logged anywhere. `unified_id` and `is_new_user` are logged on confirm — `unified_id` is the desktop's own identity post-login (it knows it anyway). `session_id` is truncated to 8 chars in initiate logs. `_deviceCode` is never logged in `LoginDialog.xaml.cs`. **No findings.**
- **Verification URL leakage:** `https://app.cclabs.app/login` is opened with no query params — code is not appended, so it cannot end up in browser history with the code attached. User pastes the code into cclabs-web's form manually. **No findings.**

### Pass 2 — conflict flow correctness

- **409 not handled by desktop, by design:** confirmed against `proxy/server.js:9118-9206` that `/poll` only returns 200/202/404/410/429/503. Conflict goes to cclabs-web's `/confirm`. Desktop polls 202 until web-side merge completes. **No findings.**
- **Malformed-response defense:** `JObject.Parse` exceptions caught by general `catch (Exception)` and surfaced as `PollStatus.Unknown` → backoff. `HandleDeviceCodeConfirmed` validates non-null/non-empty `auth_token` and `unified_id` before storing; falls into `HandleDeviceCodeError` with a generic message if either missing. Won't crash on partial proxy responses. **No findings.**
- **Verification URL passes no credential:** `Process.Start` opens the constant URL with no token, no code parameter, no session info. cclabs-web is responsible for its own auth. **No findings.**
- **Retry-after-merge:** two paths both work — (a) re-enter same code on web within 15min TTL → `/confirm` succeeds → next `/poll` returns 200; (b) cancel on desktop, click "Sign in via Web" again → fresh `/initiate` → new code. Hard-expiry guard prevents desktop from polling a server-side-dead code regardless of clock skew. **No findings.**

### Edge cases covered

- Polling cancelled cleanly via `_deviceCts.Cancel()` on the in-panel Cancel link and on the main `BtnCancel` button. `CancellationToken` flows into `HttpClient.PostAsync` — no orphan HTTP requests.
- Network failure: backoff up to 30s, gives up after 5 consecutive `Unknown` results.
- 429/503: backoff but doesn't error out; recovers when proxy clears the rate limit window.
- BtnCancel during `/initiate` await: `ShowLoading` hid `ProviderPanel`, so user can only hit main `BtnCancel`, which cancels and closes.
- Double-click protection: not needed — `ShowLoading` collapses `ProviderPanel` immediately after the click handler starts, so the button isn't clickable a second time.

## Coexistence with legacy auth

- Existing `LoginDialog` paths (Discord OAuth, Patreon OAuth, Account) **unchanged**.
- Existing `47833`/`47832` loopback OAuth handlers (`DiscordService`, `PatreonService`) **untouched** — SP3 does not use loopback.
- Legacy users with stored `auth_token.dat` keep working indefinitely; SP3 does not migrate or invalidate their state.
- A legacy user who wants to upgrade to Supabase-backed identity signs out and re-logins via "Sign in via Web".

## Build

`dotnet build -c Debug`: **0 errors**, 244 warnings (all pre-existing in unrelated files — none in SP3 code).

## Out of scope (per spec non-goals)

- No changes to the proxy or cclabs-web (SP1 + SP2, both shipped).
- No migration of existing legacy users.
- No nudge UI (per spec §7.2.5).
- No localization strings yet — new UI text is hardcoded English. Followup: add `loc:Str` keys for "Sign in via Web", "Waiting for browser confirmation...", etc., when promoting to stable.

## Test plan

- [ ] Fresh-signup test: clean install → Lab-tier patron logs in via legacy → relog → click "Sign in via Web" → enter code on web → confirm → desktop receives 200 → MainWindow loads with profile
- [ ] Existing-link test: existing Supabase user with `supabase_index` → device-code → desktop logs in to same `unified_id` (idempotent)
- [ ] Conflict test: pre-set two unified_ids resolving to one Supabase user → device-code → web shows merge UI → user merges → desktop's next poll returns 200
- [ ] Expiry test: start device-code, wait 15min without confirming → desktop shows "Code expired, try again"
- [ ] Cancel test: click in-panel Cancel mid-polling → returns to ProviderPanel cleanly, no orphan polls
- [ ] Lab gate test: user with `PatreonTier == 0` sees no "Sign in via Web" button; `PatreonTier >= 2` sees it
- [ ] Network failure test: kill network mid-poll → backoff visible in UI; restore network → resumes; if 5 consecutive failures → error UX

## Deploy

Per spec §7.4: ship to prerelease channel first (Lab gate keeps non-T2 users on legacy paths). ≥1 week soak. Watch:
- Desktop crash reports for any new exceptions in the device-code path
- `merge_audit_log` on Supabase Postgres (organic merges starting to appear, status=completed expected)
- Support DMs / Discord questions

After 1 clean week: promote to stable in a separate release (don't bundle promotion with another fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
