### PR TITLE
SP3: graduate device-code login (point at /dashboard/link-device, drop Lab-tier gate)

### DIFF
--- a/ConditioningControlPanel/LoginDialog.xaml
+++ b/ConditioningControlPanel/LoginDialog.xaml
@@ -61,14 +61,12 @@
                     </StackPanel>
                 </Button>
 
-                <!-- SP3: Sign in via Web (device-code flow). Visibility gated at runtime
-                     on AppSettings.PatreonTier >= 2 (Lab-tier soak). -->
+                <!-- SP3: Sign in via Web (device-code flow). -->
                 <Button x:Name="BtnLoginDeviceCode"
                         Padding="20,15" Margin="0,0,0,15"
                         Background="#9333EA" Foreground="White"
                         BorderThickness="0" FontWeight="Bold" FontSize="16"
-                        Cursor="Hand" Click="BtnLoginDeviceCode_Click"
-                        Visibility="Collapsed">
+                        Cursor="Hand" Click="BtnLoginDeviceCode_Click">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="Sign in via Web" VerticalAlignment="Center"/>
                     </StackPanel>

--- a/ConditioningControlPanel/LoginDialog.xaml.cs
+++ b/ConditioningControlPanel/LoginDialog.xaml.cs
@@ -54,14 +54,6 @@ namespace ConditioningControlPanel
         {
             InitializeComponent();
 
-            // SP3 Lab gate: cached PatreonTier >= 2 from a prior legacy login.
-            // Removed when SP3 promotes from Lab to stable.
-            var tier = App.Settings?.Current?.PatreonTier ?? 0;
-            if (tier >= 2)
-            {
-                BtnLoginDeviceCode.Visibility = Visibility.Visible;
-            }
-
             // SP3: cancel any in-flight device-code polling on dialog close so
             // alt+F4 / parent .Close() / session-end don't leave an orphan loop
             // hammering /poll against a hidden window until 15min server expiry.

--- a/ConditioningControlPanel/Services/V2DeviceCodeService.cs
+++ b/ConditioningControlPanel/Services/V2DeviceCodeService.cs
@@ -21,8 +21,10 @@ namespace ConditioningControlPanel.Services
         private const string SERVER_URL = "https://codebambi-proxy.vercel.app";
 
         // Hardcoded: /v2/auth/device/initiate doesn't return a verification_url.
-        // Switch this single constant if cclabs-web adds a dedicated /pair page.
-        public const string VerificationUrl = "https://app.cclabs.app/login";
+        // /dashboard/link-device is the canonical pairing page on cclabs-web;
+        // the layout's auth gate handles the not-signed-in case via a ?next=
+        // round-trip back to this path.
+        public const string VerificationUrl = "https://app.cclabs.app/dashboard/link-device";
 
         static V2DeviceCodeService()
         {


### PR DESCRIPTION
## Summary

Two changes to graduate SP3 device-code login from Lab-tier soak to general availability.

**1. Point at the right page.** `V2DeviceCodeService.VerificationUrl` was sending users to `https://app.cclabs.app/login`, but the cclabs-web pairing page lives at `/dashboard/link-device`. After sign-in users landed on `/dashboard` with no hint that they were mid-pair, so the end-to-end flow could never complete. Pairs with [CodeBambi/cclabs-web#3](https://github.com/CodeBambi/cclabs-web/pull/3), which threads `?next=` through the sign-in detour so a deep link survives the round-trip and lands the user back on `/dashboard/link-device` ready to enter the code.

**2. Drop the Lab-tier gate.** `BtnLoginDeviceCode.Visibility` was hidden unless cached `PatreonTier >= 2`. The gate was a soak guardrail; with cclabs-web#3 closing the loop it's no longer earning its keep — first-time users with no Patreon login are exactly the cohort the magic-link path is designed for. The button now renders alongside the other three login methods for everyone.

## Changes

- `Services/V2DeviceCodeService.cs:25` — `VerificationUrl` → `https://app.cclabs.app/dashboard/link-device`
- `LoginDialog.xaml` — drop `Visibility="Collapsed"` default and the soak-rationale comment
- `LoginDialog.xaml.cs` — drop the `PatreonTier >= 2` runtime gate in the constructor (Closed handler that cancels in-flight polling is preserved)

## Verified

- `dotnet build -c Debug` — 0 errors, 244 warnings (all pre-existing).

## Test plan

- [ ] cclabs-web PR #3 deployed first
- [ ] Fresh install on a non-Patreon account: "Sign in via Web" visible alongside Patreon/Discord/Account
- [ ] Click "Sign in via Web" → browser opens at `/dashboard/link-device` if signed in, or via `/login?next=/dashboard/link-device` if not
- [ ] Code entered → desktop poll receives 200 → dialog closes
- [ ] Conflict path: desktop polling stays on "Waiting for browser confirmation..." while user resolves on `/dashboard/merge-accounts`, then continues cleanly after merge
- [ ] Existing legacy login paths (Patreon OAuth, Discord OAuth, invite-code) all still function — regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
