### PR TITLE
SP3 fix: apply user data to settings on device-code confirm

### DIFF
--- a/ConditioningControlPanel/LoginDialog.xaml.cs
+++ b/ConditioningControlPanel/LoginDialog.xaml.cs
@@ -813,10 +813,24 @@ namespace ConditioningControlPanel
                 return;
             }
 
-            // Store auth_token via DPAPI (same protection as legacy paths).
-            // unified_id is plaintext in settings.json — same as every other provider.
-            if (App.Settings?.Current != null)
+            // Apply full user data when the server included it (SP3 fix).
+            // ApplyUserDataToSettings populates DisplayName / Level / XP /
+            // PatreonTier / season info, which lets the post-login flow in
+            // MainWindow.OpenUnifiedLoginDialog clear ProfileSyncService's
+            // anti-cheat guard ("local looks like fresh defaults — refuse
+            // to push") so the cloud profile actually round-trips. Without
+            // a populated user, the desktop stays at defaults forever for
+            // device-code logins. Mirrors the Patreon/Discord legacy flow.
+            if (result.User != null)
             {
+                new V2AuthService().ApplyUserDataToSettings(result.User, result.AuthToken);
+            }
+            else if (App.Settings?.Current != null)
+            {
+                // Older proxy build without user piggyback, or server-side
+                // user fetch failed. Fall back to bare token + uid storage —
+                // the user's UI will show defaults until they re-auth via
+                // Patreon or Discord, but at least authenticated calls work.
                 App.Settings.Current.AuthToken = result.AuthToken;
                 App.Settings.Current.UnifiedId = result.UnifiedId;
                 App.Settings.Save();

--- a/ConditioningControlPanel/Services/V2DeviceCodeService.cs
+++ b/ConditioningControlPanel/Services/V2DeviceCodeService.cs
@@ -72,6 +72,14 @@ namespace ConditioningControlPanel.Services
             public string? AuthToken { get; set; }
             public string? UnifiedId { get; set; }
             public bool IsNewUser { get; set; }
+
+            // Server-provided user object on confirmed (post-fix proxy build).
+            // Null on older proxy builds or if the server's user-fetch failed —
+            // caller falls back to bare token+id storage in that case, which
+            // leaves the UI at defaults until the user re-auths via Patreon
+            // or Discord. See HandleDeviceCodeConfirmed in LoginDialog for
+            // how this gets applied via V2AuthService.ApplyUserDataToSettings.
+            public V2AuthService.V2User? User { get; set; }
         }
 
         public async Task<InitiateResponse> InitiateAsync(CancellationToken ct = default)
@@ -155,14 +163,36 @@ namespace ConditioningControlPanel.Services
                         var authToken = obj["auth_token"]?.ToString();
                         var unifiedId = obj["unified_id"]?.ToString();
                         var isNewUser = (bool?)obj["is_new_user"] ?? false;
+
+                        // SP3 fix: server now piggybacks user data on confirmed
+                        // (mirrors /v2/auth/patreon and /v2/auth/discord shape)
+                        // so the desktop can populate local AppSettings before
+                        // ProfileSync's anti-cheat guard refuses the post-login
+                        // round-trip. Older proxy builds omit this field;
+                        // null is handled gracefully by the caller.
+                        V2AuthService.V2User? user = null;
+                        var userToken = obj["user"];
+                        if (userToken != null && userToken.Type == JTokenType.Object)
+                        {
+                            try
+                            {
+                                user = userToken.ToObject<V2AuthService.V2User>();
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Warning(ex, "[DeviceCode] Failed to parse user from poll response");
+                            }
+                        }
+
                         // Never log auth_token.
-                        Log.Information("[DeviceCode] Confirmed uid={Uid} new={New}", unifiedId, isNewUser);
+                        Log.Information("[DeviceCode] Confirmed uid={Uid} new={New} hasUser={HasUser}", unifiedId, isNewUser, user != null);
                         return new PollResponse
                         {
                             Status = PollStatus.Confirmed,
                             AuthToken = authToken,
                             UnifiedId = unifiedId,
-                            IsNewUser = isNewUser
+                            IsNewUser = isNewUser,
+                            User = user
                         };
                     }
                     case 202:


### PR DESCRIPTION
## Summary

Desktop half of the SP3 fix — pairs with [CC-Labs-llc/CCP-Server#13](https://github.com/CC-Labs-llc/CCP-Server/pull/13) which adds a `user` object to `/v2/auth/device/poll` confirmed responses. With both deployed, a device-code login populates `display_name / level / xp / season / patreon_tier` in local AppSettings before the post-login profile sync runs, clearing `ProfileSyncService`'s anti-cheat guard.

## Root cause recap

`HandleDeviceCodeConfirmed` only stored `auth_token + unified_id` from `/poll`. `MainWindow.OpenUnifiedLoginDialog`'s post-login flow called `LoadProfileAsync`, which for V2 users delegates to `SyncProfileAsync` (push). The anti-cheat guard at `ProfileSyncService.cs:400-408` ("local looks like fresh defaults, refuse to push") fires correctly, returns false, falls through to V1 path which needs an OAuth token SP3 doesn't have. `_hasLoadedProfile` never flips, UI stays at defaults forever.

The guard is doing exactly what it was designed to do (`anticheat_defended_path` memory). The missing piece was a path that pulls cloud → local for device-code logins. Server returns the user shape on `/poll` confirmed; desktop applies it via the existing `V2AuthService.ApplyUserDataToSettings` helper that `/v2/auth/patreon` and `/v2/auth/discord` already use.

## Changes

- `Services/V2DeviceCodeService.cs` — `PollResponse` gets a new optional `User` field of type `V2AuthService.V2User?`. `PollAsync` case 200 parses the user object out of the response. Older proxy builds without the field decode as null and fall back to the previous bare-token storage (no regression).
- `LoginDialog.xaml.cs` — `HandleDeviceCodeConfirmed` calls `new V2AuthService().ApplyUserDataToSettings(result.User, result.AuthToken)` when the user is present. Falls back to bare token+uid storage on the null path. The "take higher" XP merge logic in ApplyUserDataToSettings prevents progress regression on a stale cloud read.

## Verified

- `dotnet build -c Debug` — 0 CS errors. (MSB3027 file-copy errors during local dev when the app is running are pre-existing.)
- Manual smoke pending: requires closing the running app and rebuilding before signing in via "Sign in via Web" again.

## Test plan

- [ ] CCP-Server PR #13 deployed (already done — `codebambi-proxy.vercel.app`)
- [ ] Close running app, rebuild
- [ ] Sign in via Web with the same Discord identity that's already linked to the CodeBambi account
- [ ] Confirm: avatar tube shows `display_name`, level/xp render correctly, no need to follow up with Patreon login
- [ ] Sign out, sign in again — same outcome, bound `supabase_index` fast-paths to the right account
- [ ] Regression check: legacy Patreon login still works

## Out of scope

- Cleanup of yesterday's two stale orphans (`u_mowqdqofca4691532463`, `u_mowqqeaj5f1f4c0d1db9`) and any `supabase_index` entries pointing at them — admin task, defer until soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
