### PR TITLE
fix(mods): mod-aware subliminal default top-up (review M1)

### DIFF
--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -1220,18 +1220,39 @@ namespace ConditioningControlPanel.Services
 
             // Restore saved customizations, or fall back to mod defaults
             if (settings.SubliminalPoolByMod?.TryGetValue(modId, out var savedPool) == true)
+            {
                 settings.SubliminalPool = new Dictionary<string, bool>(savedPool);
+
+                // Top up with any NEW defaults the active mod has shipped since this pool was
+                // saved (e.g. an app update added default subliminals to the mod), enabled by
+                // default — but never re-add ones the user explicitly removed. This is the
+                // mod-aware replacement for the old load-time merge in SettingsService, which
+                // ran before ModService existed and so couldn't see the active mod.
+                var added = new List<string>();
+                foreach (var kvp in GetDefaultSubliminalPool())
+                {
+                    if (!settings.SubliminalPool.ContainsKey(kvp.Key) &&
+                        !settings.RemovedDefaultSubliminals.Contains(kvp.Key))
+                    {
+                        settings.SubliminalPool[kvp.Key] = true;
+                        added.Add(kvp.Key);
+                    }
+                }
+                if (added.Count > 0)
+                    _log?.Information("Topped up {Count} new default subliminal(s) for mod {ModId}: {Keys}",
+                        added.Count, modId, string.Join(", ", added));
+            }
             else
+            {
+                // No saved pool for this mod yet — seed the full default set.
                 settings.SubliminalPool = new Dictionary<string, bool>(GetDefaultSubliminalPool());
+            }
 
             // Strip any cross-mod contamination from the subliminal pool. A legacy load-time
-            // merge (since fixed) could inject another mode's default subliminals into the
+            // merge (since removed) could inject another mode's default subliminals into the
             // active pool; remove keys that are some OTHER built-in mod's default and not the
             // active mod's. User-added phrases (not any mod's default) are preserved.
             PruneCrossModSubliminals(settings);
-
-            // Clear removed-defaults tracking since we're loading a fresh pool for this mod
-            settings.RemovedDefaultSubliminals.Clear();
 
             // AttentionPool has no manifest/mod default, so only restore a saved per-mod
             // copy — never wipe it to empty when none exists (it's saved by

--- a/ConditioningControlPanel/Services/SettingsService.cs
+++ b/ConditioningControlPanel/Services/SettingsService.cs
@@ -111,8 +111,11 @@ namespace ConditioningControlPanel.Services
                         // Migrate plaintext auth_token from settings.json to DPAPI-encrypted storage
                         MigrateAuthToken(json);
 
-                        // Merge any new default subliminal triggers that were added in updates
-                        MergeNewDefaultSubliminalTriggers(settings);
+                        // New-default subliminal top-up now happens in
+                        // ModService.RestorePoolsFromSettings (mod-aware, after ModService is
+                        // initialized). It used to run here, but settings load precedes
+                        // ModService, so it had no active mod and wrongly merged Bambi defaults
+                        // into every mode's pool.
 
                         // Synthesize Actions lists on any keyword triggers that predate the
                         // action-list refactor so the dispatcher can always iterate Actions.
@@ -171,49 +174,6 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Warning("Auth token migration failed: {Error}", ex.Message);
-            }
-        }
-
-        /// <summary>
-        /// Merges any new default subliminal triggers that were added in updates.
-        /// New triggers are added as disabled so users can opt-in.
-        /// </summary>
-        private void MergeNewDefaultSubliminalTriggers(AppSettings settings)
-        {
-            try
-            {
-                // Only top-up from the ACTIVE mod's defaults. This runs during settings load,
-                // which happens before ModService exists; when App.Mods is null we cannot know
-                // the active mod, so skip rather than fall back to a foreign mod's pool (the old
-                // BambiSleep fallback injected Bambi subliminals into e.g. the Locked pool every
-                // boot). The active mod's pools are seeded/restored by ModService.Initialize.
-                if (App.Mods == null) return;
-                var defaults = App.Mods.GetDefaultSubliminalPool();
-                var added = new List<string>();
-
-                foreach (var trigger in defaults.Keys)
-                {
-                    // Skip triggers the user explicitly removed
-                    if (settings.RemovedDefaultSubliminals.Contains(trigger))
-                        continue;
-
-                    if (!settings.SubliminalPool.ContainsKey(trigger))
-                    {
-                        // Add new triggers as enabled by default (matching default behavior)
-                        settings.SubliminalPool[trigger] = true;
-                        added.Add(trigger);
-                    }
-                }
-
-                if (added.Count > 0)
-                {
-                    App.Logger?.Information("Added {Count} new default subliminal triggers: {Triggers}",
-                        added.Count, string.Join(", ", added));
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning("Failed to merge new subliminal triggers: {Error}", ex.Message);
             }
         }
 


### PR DESCRIPTION
Resolves review finding **M1** from #29.

## Problem
The subliminal "top-up" (adding newly shipped default subliminals into an existing user pool) lived in `SettingsService.MergeNewDefaultSubliminalTriggers`, which runs during settings *load* — before `ModService` exists. With no active mod available it fell back to the BambiSleep pool, which was the original source of Bambi subliminals leaking into non-Bambi pools. In #29 it was guarded to a no-op, which stopped the contamination but also disabled the top-up entirely.

## Fix
- **`ModService.RestorePoolsFromSettings`** now performs the top-up, mod-aware, after `ModService` is initialized: when loading a saved per-mod pool, it adds the **active mod's** manifest defaults that are missing **and** not in `RemovedDefaultSubliminals` (enabled), and logs `Topped up N new default subliminal(s)`.
- Stopped clearing `RemovedDefaultSubliminals` on restore, so user-removed defaults stay removed and aren't re-added by the top-up.
- **Retired** `MergeNewDefaultSubliminalTriggers` (method + load-time call).
- The cross-mod prune still runs after the top-up, so foreign defaults are never topped up.

## Verification
- Build clean (0 errors).
- App boots clean; on the already-complete Locked pool the top-up adds nothing (no spurious entries) and the prune stays quiet (pool remained clean). No new errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)