### PR TITLE
Bug triage 6.0.5 → 6.0.6: webcam, quiz AI, mod naming, calibration

### DIFF
--- a/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
+++ b/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
@@ -4792,8 +4792,12 @@ namespace ConditioningControlPanel
         {
             RefreshCompanionDisplay();
 
-            // Special level-up phrases based on companion
-            var companionName = Models.CompanionDefinition.GetById(args.Companion).Name;
+            // Special level-up phrases based on companion. Route the roster name through
+            // the active mod's terminology map so a themed mod (e.g. Circe's Lock) speaks
+            // its own name instead of the Bambi roster name like "Synthetic Blowdoll"
+            // (#325 — BUG-GLMA287TET). No-op for mod-agnostic modes.
+            var rawCompanionName = Models.CompanionDefinition.GetById(args.Companion).Name;
+            var companionName = App.Mods?.MakeModAware(rawCompanionName) ?? rawCompanionName;
             if (args.NewLevel == Models.CompanionProgress.MaxLevel)
             {
                 GigglePriority($"{companionName} reached MAX LEVEL! *sparkles*", aiGenerated: false);

--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -636,7 +636,10 @@ namespace ConditioningControlPanel
             {
                 UpdateCompanionCardsUI();
 
-                var companionName = Models.CompanionDefinition.GetById(args.Companion).Name;
+                // Mod-aware name so themed mods (e.g. Circe's Lock) don't surface the
+                // Bambi roster name in the level-up notification (#325 — BUG-GLMA287TET).
+                var rawCompanionName = Models.CompanionDefinition.GetById(args.Companion).Name;
+                var companionName = App.Mods?.MakeModAware(rawCompanionName) ?? rawCompanionName;
 
                 // Show notification for companion level up
                 if (args.NewLevel == Models.CompanionProgress.MaxLevel)

--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -26466,7 +26466,7 @@ namespace ConditioningControlPanel
             {
                 // Play a random video
                 App.Logger?.Information("Playing random startup video");
-                App.Video.TriggerVideo();
+                App.Video.TriggerVideo(silentIfEmpty: true);
             }
         }
 

--- a/ConditioningControlPanel/QuizWindow.xaml.cs
+++ b/ConditioningControlPanel/QuizWindow.xaml.cs
@@ -709,6 +709,20 @@ namespace ConditioningControlPanel
             ShowPanel(ErrorPanel);
         }
 
+        /// <summary>
+        /// Provider-aware "couldn't generate" message. Local-AI users got the cloud
+        /// "daily limit" line even though the quiz now runs on their Ollama instance
+        /// (#334), which sent them chasing a limit that doesn't apply — point them at
+        /// Ollama instead.
+        /// </summary>
+        private static string QuizGenerationFailedMessage()
+        {
+            bool useLocal = App.Settings?.Current?.CompanionPrompt?.UseLocalAi == true;
+            return useLocal
+                ? "Couldn't generate the quiz. Make sure Ollama is running and your model is pulled (Companion → AI), then try again."
+                : "Couldn't generate the quiz. The AI might be busy or you've hit your daily limit. Try again in a moment.";
+        }
+
         // ============ ANIMATIONS ============
 
         private void GradientTimer_Tick(object? sender, EventArgs e)
@@ -791,7 +805,7 @@ namespace ConditioningControlPanel
                 }
                 else
                 {
-                    ShowError("Couldn't generate the quiz. The AI might be busy or you've hit your daily limit. Try again in a moment.");
+                    ShowError(QuizGenerationFailedMessage());
                 }
             }
             catch (Exception ex)
@@ -832,7 +846,7 @@ namespace ConditioningControlPanel
                 }
                 else
                 {
-                    ShowError("Couldn't generate the quiz. The AI might be busy or you've hit your daily limit. Try again in a moment.");
+                    ShowError(QuizGenerationFailedMessage());
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/AIService/LocalAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/LocalAiService.cs
@@ -622,6 +622,57 @@ namespace ConditioningControlPanel.Services.AIService
         }
 
         /// <summary>
+        /// One-shot, stateless multi-turn chat completion against the configured Ollama
+        /// host/model. For non-companion features (e.g. the Lab Quiz) that maintain their
+        /// own conversation and just need raw assistant text — no persona wrapper, no
+        /// persistent history, no command parsing. Returns the assistant content, or
+        /// <c>null</c> on any transport / HTTP / parse failure so the caller can fall back.
+        /// </summary>
+        public static async Task<string?> GetRawChatCompletionAsync(
+            IEnumerable<(string role, string content)> messages,
+            double temperature = 0.8)
+        {
+            var host = NormalizeHost(GetConfiguredHost());
+            var model = GetConfiguredModel();
+            if (string.IsNullOrWhiteSpace(model)) return null;
+
+            try
+            {
+                using var http = BuildHttpClient(host);
+                var payload = new
+                {
+                    model,
+                    messages = messages.Select(m => new { role = m.role, content = m.content ?? string.Empty }).ToArray(),
+                    stream = false,
+                    think = false,
+                    options = new { temperature }
+                };
+                var json = JsonSerializer.Serialize(payload);
+
+                using var req = new HttpRequestMessage(HttpMethod.Post, "api/chat")
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+                using var resp = await http.SendAsync(req);
+                var body = await resp.Content.ReadAsStringAsync();
+                if (!resp.IsSuccessStatusCode)
+                {
+                    App.Logger?.Warning("LocalAiService.GetRawChatCompletionAsync: HTTP {Status} from {Host} (model={Model})",
+                        (int)resp.StatusCode, host, model);
+                    return null;
+                }
+
+                var content = ExtractContent(body);
+                return string.IsNullOrWhiteSpace(content) ? null : content;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "LocalAiService.GetRawChatCompletionAsync failed (host={Host}, model={Model})", host, model);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Turn a chat-call exception into a user-facing line that points at the most likely
         /// cause. Generic "(Ollama call failed: ...)" leaves users guessing — connection
         /// refused almost always means Ollama isn't running, and a clear hint to start it

--- a/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
+++ b/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
@@ -246,6 +246,17 @@ namespace ConditioningControlPanel.Services.Moderation
             new(@"\b(kill|kills|killing|killed|gas|gassing|gassed|exterminat(e|es|ing|ed)|lynch(es|ing|ed)?|hang(s|ing|ed)?|murder(s|ed|ing)?)\s+(all\s+)?(jewish|black|asian|white|muslim|christian|gay|trans|transgender|hispanic|mexican|arab|african|immigrant)\s+(people|persons|men|women|kids|children)\b", Opts),
             new(@"\b(genocide|holocaust)\b.{0,30}\b(deserve|deserves|deserved|should|need|needs|needed)\b", Opts),
             new(@"\bwhite\s+(power|supremacy|nationalism)\b.{0,30}\b(rise|rises|risen|rising|fight|fights|fighting|kill|kills|killing|win|wins|winning)\b", Opts),
+            // "faggot"/"fag" is reclaimed in-group vocabulary in this app's sissy/bambi
+            // content, so it is NOT an unconditional substring block — that over-trigger
+            // discarded legitimate AI quiz questions as HateSpeech and surfaced a bogus
+            // "AI busy" error (BUG-cloud-quiz, 2026-06). It now trips ONLY when paired
+            // with a hate/violence marker, mirroring the slurs-as-attack patterns above.
+            // ALLOW: "good little faggot", "such a faggot for cock", "sissy faggot".
+            // BLOCK: "kill all faggots", "gas the fags", "faggots should die".
+            // Hate/violence marker BEFORE the slur (within 30 chars).
+            new(@"\b(kill|kills|killing|killed|murder(s|ed|ing)?|exterminat(e|es|ing|ed)|lynch(es|ing|ed)?|behead(s|ed|ing)?|gas\s+(the|all|those|every)|beat\s+up|bash(es|ed|ing)?|round\s+up|string\s+up)\b.{0,30}\bfag(?:g(?:ot)?)?s?\b", Opts),
+            // Hate/violence marker AFTER the slur (within 30 chars).
+            new(@"\bfag(?:g(?:ot)?)?s?\b.{0,30}\b(should\s+(die|burn|hang)|deserve[s]?\s+to\s+(die|burn)|must\s+die|need[s]?\s+to\s+die|get\s+(the\s+)?gas)\b", Opts),
         };
         private static readonly string[] HateSpeechKeywords =
         {
@@ -253,7 +264,8 @@ namespace ConditioningControlPanel.Services.Moderation
             // in an AI-generated sexual roleplay context. P2-C1: plurals included.
             "nigger", "niggers",
             "kike", "kikes",
-            "faggot", "faggots", " fag ", " fags ", // bordered to avoid "flag", "fag end" type FPs
+            // "faggot"/"fag" intentionally NOT here — context-gated in HateSpeechRegex
+            // so reclaimed sissy/bambi usage passes but slur-as-attack still blocks.
             "tranny", "trannies",
             "chink", "chinks",
             "spic", "spics",
@@ -264,6 +276,8 @@ namespace ConditioningControlPanel.Services.Moderation
             "kill all blacks",
             "kill all gays",
             "kill all trans",
+            "kill all faggots",
+            "gas the faggots",
             "exterminate all jews",
             "exterminate all blacks",
             "exterminate all gays",

--- a/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
+++ b/ConditioningControlPanel/Services/Moderation/ModerationGuard.cs
@@ -250,13 +250,30 @@ namespace ConditioningControlPanel.Services.Moderation
             // content, so it is NOT an unconditional substring block — that over-trigger
             // discarded legitimate AI quiz questions as HateSpeech and surfaced a bogus
             // "AI busy" error (BUG-cloud-quiz, 2026-06). It now trips ONLY when paired
-            // with a hate/violence marker, mirroring the slurs-as-attack patterns above.
-            // ALLOW: "good little faggot", "such a faggot for cock", "sissy faggot".
-            // BLOCK: "kill all faggots", "gas the fags", "faggots should die".
-            // Hate/violence marker BEFORE the slur (within 30 chars).
+            // with a marker of GROUP HATE — a violence threat OR class-directed
+            // dehumanization/removal. The markers are deliberately chosen to NOT include
+            // generic degradation adjectives ("disgusting", "worthless", "filthy",
+            // "pathetic") because those appear in this app's consensual degradation-kink
+            // content; we key only on class-targeting language that consensual kink does
+            // not use ("eradicated", "subhuman", "should be banned", "hate all faggots").
+            // ALLOW: "good little faggot", "such a faggot for cock", "sissy faggot",
+            //        "you worthless little faggot", "disgusting faggot" (kink degradation).
+            // BLOCK: "kill all faggots", "gas the fags", "faggots should die",
+            //        "faggots are subhuman", "fags should be eradicated", "hate all faggots".
+            // Violence marker BEFORE the slur (within 30 chars).
             new(@"\b(kill|kills|killing|killed|murder(s|ed|ing)?|exterminat(e|es|ing|ed)|lynch(es|ing|ed)?|behead(s|ed|ing)?|gas\s+(the|all|those|every)|beat\s+up|bash(es|ed|ing)?|round\s+up|string\s+up)\b.{0,30}\bfag(?:g(?:ot)?)?s?\b", Opts),
-            // Hate/violence marker AFTER the slur (within 30 chars).
+            // Violence marker AFTER the slur (within 30 chars).
             new(@"\bfag(?:g(?:ot)?)?s?\b.{0,30}\b(should\s+(die|burn|hang)|deserve[s]?\s+to\s+(die|burn)|must\s+die|need[s]?\s+to\s+die|get\s+(the\s+)?gas)\b", Opts),
+            // Class-dehumanization / removal predicate AFTER the slur (within 30 chars).
+            // "faggots are subhuman", "fags should be eradicated/banned", "faggots don't belong".
+            new(@"\bfag(?:g(?:ot)?)?s?\b.{0,30}\b(are\s+(sub-?human|vermin|animals|not\s+human|an?\s+(disease|plague|cancer|abomination))|should\s+(be\s+)?(eradicated|exterminated|eliminated|banned|illegal|removed|wiped\s+out|rounded\s+up|gassed)|don'?t\s+belong|don'?t\s+deserve\s+to\s+(live|exist))\b", Opts),
+            // Dehumanization / eradication marker BEFORE the slur (net-new verbs not in the
+            // violence arm above): "subhuman fags", "eradicate the faggots", "death to fags".
+            new(@"\b(sub-?human|death\s+to|wipe\s+out|eradicat(e|es|ed|ing)|eliminat(e|es|ed|ing))\b.{0,30}\bfag(?:g(?:ot)?)?s?\b", Opts),
+            // Class-directed hatred. Gated to a determiner/"all" (or the bare plural slur)
+            // so self-referential kink ("hate that I'm such a faggot") does NOT trip —
+            // only "hate faggots", "hate all fags", "hate those faggots".
+            new(@"\bhate\s+(all\s+|those\s+|these\s+|the\s+)?fag(?:g(?:ot)?)?s?\b", Opts),
         };
         private static readonly string[] HateSpeechKeywords =
         {

--- a/ConditioningControlPanel/Services/QuizService.cs
+++ b/ConditioningControlPanel/Services/QuizService.cs
@@ -225,7 +225,11 @@ namespace ConditioningControlPanel.Services
                 // Output moderation discarded question 1 — keep the quiz alive with a
                 // canned question instead of aborting with a misleading transport error.
                 _questionNumber = 1;
-                return GetFallbackQuestion(1);
+                var fallback = GetFallbackQuestion(1);
+                // Record the served question as the assistant turn so the transcript
+                // stays well-formed (user→assistant→user) for the next request.
+                _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = SerializeQuestionToWire(fallback) });
+                return fallback;
             }
             if (response == null) return null;
 
@@ -259,7 +263,11 @@ namespace ConditioningControlPanel.Services
                 // Output moderation discarded this question — advance and serve a canned
                 // one so the run continues rather than dying mid-quiz.
                 _questionNumber++;
-                return GetFallbackQuestion(_questionNumber);
+                var fallback = GetFallbackQuestion(_questionNumber);
+                // Record the served question as the assistant turn so the next request
+                // doesn't go out with two consecutive user messages (history desync).
+                _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = SerializeQuestionToWire(fallback) });
+                return fallback;
             }
             if (response == null) return null;
 
@@ -768,6 +776,26 @@ Do NOT include any other text before or after the question format. Just the ques
             var trimmed = new List<ProxyChatMessage> { _conversationHistory[0] };
             trimmed.AddRange(_conversationHistory.Skip(_conversationHistory.Count - 30));
             return trimmed;
+        }
+
+        /// <summary>
+        /// Render a question back into the exact wire format the model emits
+        /// (Q: / A-D: text | points), so a canned fallback served after an output
+        /// block can be recorded as the assistant turn. Without it the blocked turn
+        /// leaves the history with two consecutive user messages, which desyncs — and
+        /// for strict providers can outright reject — every later question. Round-trips
+        /// through <see cref="ParseQuestionResponse"/>.
+        /// </summary>
+        internal static string SerializeQuestionToWire(QuizQuestion q)
+        {
+            var lines = new List<string> { $"Q: {q.QuestionText}" };
+            for (int i = 0; i < q.Answers.Length && i < 4; i++)
+            {
+                char letter = (char)('A' + i);
+                int pts = (q.Points != null && i < q.Points.Length) ? q.Points[i] : i + 1;
+                lines.Add($"{letter}: {q.Answers[i]} | {pts}");
+            }
+            return string.Join("\n", lines);
         }
 
         internal static QuizQuestion? ParseQuestionResponse(string text, int questionNum)

--- a/ConditioningControlPanel/Services/QuizService.cs
+++ b/ConditioningControlPanel/Services/QuizService.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.AIService;
 using ConditioningControlPanel.Services.Moderation;
 using Newtonsoft.Json;
 
@@ -615,6 +616,51 @@ Do NOT include any other text before or after the question format. Just the ques
 
         private async Task<string?> CallAiAsync(int maxTokens)
         {
+            // Trim conversation to last 30 messages + system prompt to stay under limits.
+            var messagesToSend = TrimConversation();
+
+            // Route to whichever provider the user has selected for the companion. The
+            // quiz used to be cloud-only, so switching to local Ollama left it stuck on
+            // "AI busy / daily limit" even though chat worked (BUG-XQRK4USW5X / #334).
+            bool useLocal = App.Settings?.Current?.CompanionPrompt?.UseLocalAi == true;
+            string? content = useLocal
+                ? await CallLocalAiAsync(messagesToSend)
+                : await CallCloudAiAsync(messagesToSend, maxTokens);
+
+            if (string.IsNullOrEmpty(content))
+                return null;
+
+            // OUTPUT MODERATION (Layer 1) — applies to BOTH providers. Discard
+            // AI-generated questions / result archetype text that trips the guard.
+            // Returning null lets the existing fallback path (deterministic archetype +
+            // canned question) take over so the quiz continues without leaking content.
+            var guard = App.ModerationGuard;
+            if (guard != null)
+            {
+                var modelHint = useLocal ? "local-quiz" : "cloud-quiz";
+                var outputCheck = guard.CheckOutput(content);
+                if (!outputCheck.Allow && outputCheck.Category.HasValue)
+                {
+                    App.ModerationLog?.Record(outputCheck.Category.Value, source: "output", modelHint: modelHint);
+                    // Quiz questions are AI-generated OUTPUT, never user-typed input, so
+                    // a hit is logged for the compliance record but does NOT escalate
+                    // the user-facing Content Policy Notice. The batch is still
+                    // discarded fail-closed (return null) so nothing prohibited leaks.
+                    App.Logger?.Information("QuizService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
+                    return null;
+                }
+                if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
+                {
+                    App.ModerationLog?.Record(ProhibitedCategory.ProfessionalAdvice, source: "output", modelHint: modelHint);
+                }
+            }
+
+            return content;
+        }
+
+        /// <summary>Cloud-proxy transport. Returns raw assistant text or null on failure.</summary>
+        private async Task<string?> CallCloudAiAsync(List<ProxyChatMessage> messagesToSend, int maxTokens)
+        {
             try
             {
                 var unifiedId = App.UnifiedUserId;
@@ -625,9 +671,6 @@ Do NOT include any other text before or after the question format. Just the ques
                     App.Logger?.Warning("QuizService: No unified ID available");
                     return null;
                 }
-
-                // Trim conversation to last 30 messages + system prompt to stay under limits
-                var messagesToSend = TrimConversation();
 
                 var request = new V2ChatRequest
                 {
@@ -665,30 +708,6 @@ Do NOT include any other text before or after the question format. Just the ques
                     return null;
                 }
 
-                // OUTPUT MODERATION (Layer 1). Discard AI-generated questions / result
-                // archetype text that trips the guard. Returning null lets the existing
-                // fallback path (deterministic archetype + canned question) take over so
-                // the quiz continues without leaking prohibited content.
-                var guard = App.ModerationGuard;
-                if (guard != null)
-                {
-                    var outputCheck = guard.CheckOutput(result.Content ?? string.Empty);
-                    if (!outputCheck.Allow && outputCheck.Category.HasValue)
-                    {
-                        App.ModerationLog?.Record(outputCheck.Category.Value, source: "output", modelHint: "cloud-quiz");
-                        // Quiz questions are AI-generated OUTPUT, never user-typed input, so
-                        // a hit is logged for the compliance record but does NOT escalate
-                        // the user-facing Content Policy Notice. The batch is still
-                        // discarded fail-closed (return null) so nothing prohibited leaks.
-                        App.Logger?.Information("QuizService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
-                        return null;
-                    }
-                    if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
-                    {
-                        App.ModerationLog?.Record(ProhibitedCategory.ProfessionalAdvice, source: "output", modelHint: "cloud-quiz");
-                    }
-                }
-
                 return result.Content;
             }
             catch (TaskCanceledException)
@@ -698,9 +717,20 @@ Do NOT include any other text before or after the question format. Just the ques
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "QuizService: Unexpected error calling AI");
+                App.Logger?.Error(ex, "QuizService: Unexpected error calling cloud AI");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Local Ollama transport — mirrors the companion's local provider so the quiz
+        /// honours the same Companion → AI host/model settings. Returns raw assistant
+        /// text or null on failure (LocalAiService logs the specific cause).
+        /// </summary>
+        private async Task<string?> CallLocalAiAsync(List<ProxyChatMessage> messagesToSend)
+        {
+            var mapped = messagesToSend.Select(m => (role: m.Role ?? "user", content: m.Content ?? string.Empty));
+            return await LocalAiService.GetRawChatCompletionAsync(mapped, Temperature);
         }
 
         private List<ProxyChatMessage> TrimConversation()

--- a/ConditioningControlPanel/Services/QuizService.cs
+++ b/ConditioningControlPanel/Services/QuizService.cs
@@ -162,6 +162,15 @@ namespace ConditioningControlPanel.Services
         private int _totalScore;
         private bool _disposed;
 
+        // Distinct reference (not null, not interned) returned by CallAiAsync when OUTPUT
+        // moderation discarded the model's response. null means a transport/availability
+        // failure (network, daily limit, Ollama down) — that still surfaces the real
+        // error. A moderation block instead lets question-generation callers serve a
+        // deterministic canned question so the quiz keeps going, as documented in
+        // CallAiAsync. Before this, a block returned null too and aborted the quiz with a
+        // misleading "AI busy / daily limit" message (BUG-cloud-quiz HateSpeech, 2026-06).
+        private static readonly string OutputBlocked = new(" quiz-output-blocked ".ToCharArray());
+
         private const string ProxyBaseUrl = "https://codebambi-proxy.vercel.app";
         private const int QuestionMaxTokens = 400;
         private const int ResultMaxTokens = 500;
@@ -211,6 +220,13 @@ namespace ConditioningControlPanel.Services
             _conversationHistory.Add(new ProxyChatMessage { Role = "user", Content = "Start the quiz! Generate question 1." });
 
             var response = await CallAiAsync(QuestionMaxTokens);
+            if (ReferenceEquals(response, OutputBlocked))
+            {
+                // Output moderation discarded question 1 — keep the quiz alive with a
+                // canned question instead of aborting with a misleading transport error.
+                _questionNumber = 1;
+                return GetFallbackQuestion(1);
+            }
             if (response == null) return null;
 
             _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = response });
@@ -238,6 +254,13 @@ namespace ConditioningControlPanel.Services
             _conversationHistory.Add(new ProxyChatMessage { Role = "user", Content = userMsg });
 
             var response = await CallAiAsync(QuestionMaxTokens);
+            if (ReferenceEquals(response, OutputBlocked))
+            {
+                // Output moderation discarded this question — advance and serve a canned
+                // one so the run continues rather than dying mid-quiz.
+                _questionNumber++;
+                return GetFallbackQuestion(_questionNumber);
+            }
             if (response == null) return null;
 
             _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = response });
@@ -288,8 +311,10 @@ namespace ConditioningControlPanel.Services
             _conversationHistory.Add(new ProxyChatMessage { Role = "user", Content = userMsg });
 
             var response = await CallAiAsync(ResultMaxTokens);
-            if (response == null)
+            if (response == null || ReferenceEquals(response, OutputBlocked))
             {
+                // Transport failure OR an output-moderation block — either way fall back
+                // to the deterministic profile (always correct for the score).
                 return new QuizResult
                 {
                     TotalScore = _totalScore,
@@ -608,7 +633,9 @@ Do NOT include any other text before or after the question format. Just the ques
             });
 
             var response = await CallAiAsync(QuestionMaxTokens);
-            if (response == null) return null;
+            // Sentinel (output blocked) or null (transport failure) → let the caller's
+            // `?? GetFallbackQuestion(...)` serve a canned question.
+            if (response == null || ReferenceEquals(response, OutputBlocked)) return null;
 
             _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = response });
             return ParseQuestionResponse(response, questionNum);
@@ -647,7 +674,7 @@ Do NOT include any other text before or after the question format. Just the ques
                     // the user-facing Content Policy Notice. The batch is still
                     // discarded fail-closed (return null) so nothing prohibited leaks.
                     App.Logger?.Information("QuizService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
-                    return null;
+                    return OutputBlocked;
                 }
                 if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
                 {
@@ -1034,7 +1061,9 @@ Make all phrases thematically consistent with the quiz category and the user's s
                 _conversationHistory.Add(new ProxyChatMessage { Role = "user", Content = prompt });
 
                 var response = await CallAiAsync(800);
-                if (response == null) return null;
+                // Session content is optional; on transport failure or a moderation block
+                // return null and let the caller fall back (no canned session text here).
+                if (response == null || ReferenceEquals(response, OutputBlocked)) return null;
 
                 _conversationHistory.Add(new ProxyChatMessage { Role = "assistant", Content = response });
 

--- a/ConditioningControlPanel/Services/VideoService.cs
+++ b/ConditioningControlPanel/Services/VideoService.cs
@@ -595,7 +595,13 @@ namespace ConditioningControlPanel.Services
             }
         }
 
-        public void TriggerVideo()
+        /// <param name="silentIfEmpty">
+        /// When true, an empty videos folder is logged and ignored instead of popping the
+        /// "no videos found" dialog. Used for the auto-played startup video (#333) so a user
+        /// who simply hasn't added videos isn't greeted by a blocking prompt every launch.
+        /// User-initiated triggers leave this false so they still get the helpful guidance.
+        /// </param>
+        public void TriggerVideo(bool silentIfEmpty = false)
         {
             App.Logger?.Information("VideoService: TriggerVideo called");
 
@@ -616,7 +622,7 @@ namespace ConditioningControlPanel.Services
                     App.InteractionQueue.CurrentInteraction);
                 App.InteractionQueue.TryStart(
                     InteractionQueueService.InteractionType.Video,
-                    () => TriggerVideo(),
+                    () => TriggerVideo(silentIfEmpty),
                     queue: true);
                 return;
             }
@@ -647,6 +653,15 @@ namespace ConditioningControlPanel.Services
                 _triggerInProgress = false;
                 // No video to play - release the queue lock
                 App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.Video);
+
+                // Startup auto-play: a user who hasn't added videos shouldn't get a blocking
+                // dialog on every launch (#333). Log and bail quietly — manual triggers still
+                // fall through to the guidance prompt below.
+                if (silentIfEmpty)
+                {
+                    App.Logger?.Information("VideoService: startup video skipped — no videos in {Path}", _videosPath);
+                    return;
+                }
 
                 // Build helpful error message
                 var activePackCount = App.ContentPacks?.GetActivePackIds()?.Count ?? 0;

--- a/ConditioningControlPanel/Services/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/WebcamTrackingService.cs
@@ -129,6 +129,19 @@ namespace ConditioningControlPanel.Services
         // only catches genuinely degenerate feeds, never a legitimately dark one.
         private const double MinProbeStdDev = 3.0;
 
+        // Second, independent way to accept a probe frame: temporal change. A
+        // genuinely dark room can read as low spatial contrast (below MinProbeStdDev)
+        // yet is still a LIVE feed — it changes frame-to-frame as the user moves. A
+        // dead / solid / frozen "garbage" feed (the Elgato BUG-F2XJE2E7X9 case the
+        // spatial floor exists to reject) does NOT change. So we ALSO adopt a feed
+        // whose mean absolute inter-frame difference clears this bar, which rescues a
+        // dim-but-real camera from a false CameraInUse WITHOUT lowering MinProbeStdDev
+        // (lowering it would re-admit the very solid feed the floor was added to reject).
+        // Set above the uniform sensor-noise flicker of a static feed (~<1 on 0-255)
+        // but below real scene motion. Spatial-clean frames still win first, so cameras
+        // that already work — and the Elgato flat+static feed — are completely unaffected.
+        private const double MinProbeTemporalDelta = 2.0;
+
         // Per-attempt warm-up budget for the probe loop. Some UVC webcams (the Lovense
         // Webcam 2 in BUG-6W469QGMHS) stream black for over a second after the handle
         // opens before real frames arrive. A fixed 5-read window (~1s) rejected those as
@@ -1003,6 +1016,9 @@ namespace ConditioningControlPanel.Services
                 // so that case warms up and is adopted instead of being misdiagnosed as
                 // CameraInUse (BUG-6W469QGMHS).
                 using var probe = new Mat();
+                using var prevProbe = new Mat();
+                using var diff = new Mat();
+                bool havePrev = false;
                 var probeDeadline = DateTime.UtcNow.AddMilliseconds(ProbeWarmupMs);
                 int probeReads = 0;
                 while (DateTime.UtcNow < probeDeadline)
@@ -1013,20 +1029,39 @@ namespace ConditioningControlPanel.Services
                     {
                         Cv2.MeanStdDev(probe, out var mean, out var std);
                         double maxStd = Math.Max(std.Val0, Math.Max(std.Val1, std.Val2));
-                        if (maxStd >= MinProbeStdDev)
+
+                        // Temporal change vs the previous (flat) frame. A dim-but-real
+                        // feed moves frame-to-frame even when its spatial contrast is
+                        // below MinProbeStdDev; a solid / frozen garbage feed does not.
+                        // This is a SECOND acceptance path so a dark room isn't rejected
+                        // into a false CameraInUse — spatial-clean still wins first, so
+                        // the Elgato flat+static feed is unaffected (BUG-F2XJE2E7X9).
+                        double temporalDelta = 0;
+                        if (havePrev && prevProbe.Size() == probe.Size() && prevProbe.Type() == probe.Type())
+                        {
+                            Cv2.Absdiff(probe, prevProbe, diff);
+                            var dmean = Cv2.Mean(diff);
+                            temporalDelta = Math.Max(dmean.Val0, Math.Max(dmean.Val1, dmean.Val2));
+                        }
+
+                        if (maxStd >= MinProbeStdDev || temporalDelta >= MinProbeTemporalDelta)
                         {
                             App.Logger?.Information(
-                                "WebcamTrackingService: device {Index} ('{Name}') via {Api} probe ok ({W}x{H}, mean={Mean:F1}, maxStdDev={Std:F1}, reads={Reads})",
-                                deviceIndex, detectedName, label, probe.Width, probe.Height, mean.Val0, maxStd, probeReads);
+                                "WebcamTrackingService: device {Index} ('{Name}') via {Api} probe ok ({W}x{H}, mean={Mean:F1}, maxStdDev={Std:F1}, temporalDelta={Td:F1}, reads={Reads})",
+                                deviceIndex, detectedName, label, probe.Width, probe.Height, mean.Val0, maxStd, temporalDelta, probeReads);
                             var result = cap;
                             cap = null; // hand ownership to caller; keep the catch from disposing it
                             return result;
                         }
-                        // Non-empty but degenerate (solid colour / black) — keep probing
-                        // within the warm-up budget in case it's a slow-warming feed.
+
+                        // Non-empty but degenerate (solid colour / black, and not yet
+                        // changing) — remember it and keep probing within the warm-up
+                        // budget in case it's a slow-warming or dim-but-live feed.
                         App.Logger?.Debug(
-                            "WebcamTrackingService: device {Index} via {Api} degenerate probe frame (maxStdDev={Std:F1} < {Min})",
-                            deviceIndex, label, maxStd, MinProbeStdDev);
+                            "WebcamTrackingService: device {Index} via {Api} degenerate probe frame (maxStdDev={Std:F1} < {Min}, temporalDelta={Td:F1} < {MinTd})",
+                            deviceIndex, label, maxStd, MinProbeStdDev, temporalDelta, MinProbeTemporalDelta);
+                        probe.CopyTo(prevProbe);
+                        havePrev = true;
                     }
                     System.Threading.Thread.Sleep(ProbeReadIntervalMs);
                 }

--- a/ConditioningControlPanel/Services/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/WebcamTrackingService.cs
@@ -926,9 +926,27 @@ namespace ConditioningControlPanel.Services
                 // the Elgato Facecam Neo (BUG-F2XJE2E7X9) — is disposed so the loop falls
                 // through to the next one instead of locking in a feed that reads fine
                 // but contains no detectable face.
+                // Note on timing: each attempt gets its own ProbeWarmupMs budget, so a
+                // device that opens-but-never-streams on every backend can take up to
+                // (attempts × warm-up) before we conclude CameraInUse. We accept that
+                // worst case deliberately — the budget exists for slow-to-START cameras
+                // (the Lovense streams black >1s, #335), and that symptom is
+                // indistinguishable from a dead feed until the budget elapses, so it
+                // can't be safely shortened. A wedged native Read() can also exceed the
+                // budget (it's only checked between reads); the worker thread + 90s open
+                // watchdog bound that, and we do NOT dispose mid-Read (guaranteed native
+                // AV — see Stop()). What we CAN do is keep the user informed so the
+                // multi-second open doesn't read as a hang.
                 bool anyOpened = false;
-                foreach (var attempt in CaptureAttempts)
+                for (int attemptIdx = 0; attemptIdx < CaptureAttempts.Length; attemptIdx++)
                 {
+                    var attempt = CaptureAttempts[attemptIdx];
+                    ReportStartupProgress(
+                        0.25 + 0.20 * (attemptIdx / (double)CaptureAttempts.Length),
+                        attemptIdx == 0
+                            ? "Opening camera…"
+                            : $"Camera slow to respond — trying another method ({attemptIdx + 1}/{CaptureAttempts.Length})…");
+
                     var cap = TryOpenWithBackend(deviceIndex, detectedName, attempt.Api, attempt.Name, attempt.Fourcc, ref anyOpened);
                     if (cap != null)
                     {

--- a/ConditioningControlPanel/Services/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/WebcamTrackingService.cs
@@ -120,6 +120,35 @@ namespace ConditioningControlPanel.Services
         private const int MaxConsecutiveReadFails = 30;            // ~1s at 30fps
         private const int FaceLostFramesThreshold = 15;            // ~0.5s
 
+        // A solid-colour / black feed reads as a perfectly valid non-empty Mat but
+        // contains no detectable face — the failure mode behind BUG-F2XJE2E7X9
+        // (Elgato Facecam Neo over MSMF: 1240 frames read, zero faces). We reject a
+        // probe frame whose richest channel still has near-zero spatial variation
+        // so the backend loop falls through to the next API. The threshold is
+        // deliberately tiny: even a dim, grainy room scatters well above it, so this
+        // only catches genuinely degenerate feeds, never a legitimately dark one.
+        private const double MinProbeStdDev = 3.0;
+
+        // Ordered open attempts: each tries one backend with one pixel-format
+        // request, accepting the first that delivers a usable frame.
+        //  • DSHOW shares WebcamDeviceEnumerator's DirectShow index space (so the
+        //    configured index resolves to the same physical device the dropdown
+        //    showed) and is the more reliable path for Elgato/UVC webcams; MSMF
+        //    stays as a fallback for the MF-only / 32-bit-only devices the WinRT
+        //    enumerator catches.
+        //  • The default (Fourcc == null) attempt runs FIRST per backend so cameras
+        //    that already work are untouched. MJPG is escalated to only when the
+        //    default feed is unusable — that's the Elgato Facecam Neo fix
+        //    (BUG-F2XJE2E7X9: default format reads non-empty but contains no face)
+        //    without risking YUY2-only cameras that don't support MJPG.
+        private static readonly (VideoCaptureAPIs Api, string Name, string? Fourcc)[] CaptureAttempts =
+        {
+            (VideoCaptureAPIs.DSHOW, "DSHOW", null),
+            (VideoCaptureAPIs.DSHOW, "DSHOW", "MJPG"),
+            (VideoCaptureAPIs.MSMF,  "MSMF",  null),
+            (VideoCaptureAPIs.MSMF,  "MSMF",  "MJPG"),
+        };
+
         // EAR-based blink detection. Standard 6-point EAR (Soukupová & Čech 2016)
         // averaged across both eyes (avoids per-eye asymmetry shrinking the
         // both-closed detection window to nothing). Rolling 90-frame max baseline.
@@ -868,66 +897,135 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Warning("WebcamTrackingService: no devices enumerated but settings remember index {Index} — opening anyway", configured);
                 }
 
-                App.Logger?.Information("WebcamTrackingService: opening device index {Index} ('{Name}') with MSMF", deviceIndex, detectedName);
-                var cap = new VideoCapture(deviceIndex, VideoCaptureAPIs.MSMF);
-                if (!cap.IsOpened())
+                // Try each attempt in turn, accepting the first that both opens AND
+                // delivers a usable (non-empty, non-degenerate) frame. An attempt that
+                // opens but only produces black/garbage — as the default format does for
+                // the Elgato Facecam Neo (BUG-F2XJE2E7X9) — is disposed so the loop falls
+                // through to the next one instead of locking in a feed that reads fine
+                // but contains no detectable face.
+                bool anyOpened = false;
+                foreach (var attempt in CaptureAttempts)
                 {
-                    cap.Dispose();
-                    App.Logger?.Information("WebcamTrackingService: MSMF open failed for index {Index}, retrying with DSHOW", deviceIndex);
-                    cap = new VideoCapture(deviceIndex, VideoCaptureAPIs.DSHOW);
-                    if (!cap.IsOpened())
+                    var cap = TryOpenWithBackend(deviceIndex, detectedName, attempt.Api, attempt.Name, attempt.Fourcc, ref anyOpened);
+                    if (cap != null)
                     {
-                        cap.Dispose();
-                        App.Logger?.Warning(
-                            "WebcamTrackingService: VideoCapture.Open returned false on both MSMF and DSHOW for device index {Index} ('{Name}')",
-                            deviceIndex, detectedName);
-                        SetState(WebcamTrackingState.CameraDenied);
-                        return null;
+                        App.Logger?.Information(
+                            "WebcamTrackingService: device {Index} ('{Name}') opened successfully via {Api}{Fourcc}",
+                            deviceIndex, detectedName, attempt.Name, attempt.Fourcc != null ? "/" + attempt.Fourcc : "");
+                        return cap;
                     }
+                    // Abandoned mid-open (post-timeout) — stop trying, the handle's owner has moved on.
+                    if (_openAbandoned) return null;
                 }
 
-                cap.Set(VideoCaptureProperties.FrameWidth, CaptureWidth);
-                cap.Set(VideoCaptureProperties.FrameHeight, CaptureHeight);
-                cap.Set(VideoCaptureProperties.Fps, TargetFps);
-                cap.Set(VideoCaptureProperties.BufferSize, 1);
-
-                // Slow drivers (especially USB UVC over a hub, or virtual cameras
-                // that lazy-init their pipeline) can return an empty first frame
-                // even though the device isn't actually held by another app.
-                // Retry a handful of times before declaring CameraInUse so that
-                // case warms up instead of being misdiagnosed.
-                bool probeOk = false;
-                int probeAttempts = 0;
-                using (var probe = new Mat())
+                if (anyOpened)
                 {
-                    for (int i = 0; i < 5; i++)
-                    {
-                        probeAttempts++;
-                        if (cap.Read(probe) && !probe.Empty())
-                        {
-                            probeOk = true;
-                            break;
-                        }
-                        System.Threading.Thread.Sleep(200);
-                    }
-                }
-                if (!probeOk)
-                {
-                    cap.Dispose();
+                    // A backend opened the device but no usable frame ever arrived — most
+                    // likely held by antivirus webcam shielding / Windows camera privacy,
+                    // or delivering a degenerate feed we deliberately rejected.
                     App.Logger?.Warning(
-                        "WebcamTrackingService: probe frame failed after {Attempts} attempts for device index {Index} ('{Name}') — camera may be held by antivirus webcam shielding, Windows camera privacy, or another app",
-                        probeAttempts, deviceIndex, detectedName);
+                        "WebcamTrackingService: device index {Index} ('{Name}') opened but produced no usable frame on any backend",
+                        deviceIndex, detectedName);
                     SetState(WebcamTrackingState.CameraInUse);
-                    return null;
                 }
-
-                App.Logger?.Information("WebcamTrackingService: device {Index} ('{Name}') opened successfully", deviceIndex, detectedName);
-                return cap;
+                else
+                {
+                    App.Logger?.Warning(
+                        "WebcamTrackingService: VideoCapture.Open returned false on all backends for device index {Index} ('{Name}')",
+                        deviceIndex, detectedName);
+                    SetState(WebcamTrackingState.CameraDenied);
+                }
+                return null;
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "WebcamTrackingService: OpenCaptureCore threw");
                 SetState(WebcamTrackingState.Error);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Opens <paramref name="deviceIndex"/> with a single backend / pixel-format
+        /// request and returns the capture only if it produces a usable probe frame;
+        /// otherwise disposes it and returns null so the caller can try the next
+        /// attempt. <paramref name="fourcc"/> is a 4-char FOURCC (e.g. "MJPG") to
+        /// request, or null to leave the driver's default format negotiation alone.
+        /// Sets <paramref name="anyOpened"/> to true if the device opened at all (even
+        /// if no usable frame arrived) so the caller can distinguish CameraDenied from
+        /// CameraInUse.
+        /// </summary>
+        private VideoCapture? TryOpenWithBackend(int deviceIndex, string detectedName, VideoCaptureAPIs api, string apiName, string? fourcc, ref bool anyOpened)
+        {
+            string label = fourcc != null ? apiName + "/" + fourcc : apiName;
+            App.Logger?.Information("WebcamTrackingService: opening device index {Index} ('{Name}') with {Api}", deviceIndex, detectedName, label);
+            VideoCapture? cap = null;
+            try
+            {
+                cap = new VideoCapture(deviceIndex, api);
+                if (!cap.IsOpened())
+                {
+                    App.Logger?.Information("WebcamTrackingService: {Api} open failed for index {Index}", label, deviceIndex);
+                    cap.Dispose();
+                    return null;
+                }
+                anyOpened = true;
+
+                // Request the explicit pixel format before resolution when one is
+                // given. Elgato Facecam Neo (and many UVC cams) hand OpenCV a
+                // non-empty-but-garbage feed under default format negotiation, which
+                // reads fine yet yields no detectable face; MJPG is broadly supported
+                // and decodes cleanly. Only escalated to after the default attempt
+                // fails, so cameras that already work keep their native format.
+                if (fourcc != null && fourcc.Length == 4)
+                {
+                    cap.Set(VideoCaptureProperties.FourCC, VideoWriter.FourCC(fourcc[0], fourcc[1], fourcc[2], fourcc[3]));
+                }
+                cap.Set(VideoCaptureProperties.FrameWidth, CaptureWidth);
+                cap.Set(VideoCaptureProperties.FrameHeight, CaptureHeight);
+                cap.Set(VideoCaptureProperties.Fps, TargetFps);
+                cap.Set(VideoCaptureProperties.BufferSize, 1);
+
+                // Slow drivers (USB UVC over a hub, virtual cameras that lazy-init
+                // their pipeline) can return an empty first frame even though the
+                // device isn't held by another app — retry a handful of times before
+                // giving up so that case warms up instead of being misdiagnosed.
+                using var probe = new Mat();
+                for (int i = 0; i < 5; i++)
+                {
+                    if (_openAbandoned) { cap.Dispose(); return null; }
+                    if (cap.Read(probe) && !probe.Empty())
+                    {
+                        Cv2.MeanStdDev(probe, out var mean, out var std);
+                        double maxStd = Math.Max(std.Val0, Math.Max(std.Val1, std.Val2));
+                        if (maxStd >= MinProbeStdDev)
+                        {
+                            App.Logger?.Information(
+                                "WebcamTrackingService: device {Index} ('{Name}') via {Api} probe ok ({W}x{H}, mean={Mean:F1}, maxStdDev={Std:F1})",
+                                deviceIndex, detectedName, label, probe.Width, probe.Height, mean.Val0, maxStd);
+                            var result = cap;
+                            cap = null; // hand ownership to caller; keep the catch from disposing it
+                            return result;
+                        }
+                        // Non-empty but degenerate (solid colour / black) — keep probing
+                        // briefly in case it's a one-off first frame, then reject.
+                        App.Logger?.Debug(
+                            "WebcamTrackingService: device {Index} via {Api} degenerate probe frame (maxStdDev={Std:F1} < {Min})",
+                            deviceIndex, label, maxStd, MinProbeStdDev);
+                    }
+                    System.Threading.Thread.Sleep(200);
+                }
+
+                App.Logger?.Warning(
+                    "WebcamTrackingService: device index {Index} ('{Name}') opened via {Api} but produced no usable frame — trying next attempt",
+                    deviceIndex, detectedName, label);
+                cap.Dispose();
+                return null;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "WebcamTrackingService: TryOpenWithBackend({Api}) threw for index {Index}", label, deviceIndex);
+                try { cap?.Dispose(); } catch { }
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/WebcamTrackingService.cs
@@ -129,6 +129,16 @@ namespace ConditioningControlPanel.Services
         // only catches genuinely degenerate feeds, never a legitimately dark one.
         private const double MinProbeStdDev = 3.0;
 
+        // Per-attempt warm-up budget for the probe loop. Some UVC webcams (the Lovense
+        // Webcam 2 in BUG-6W469QGMHS) stream black for over a second after the handle
+        // opens before real frames arrive. A fixed 5-read window (~1s) rejected those as
+        // "degenerate" and fell through every backend, surfacing a false CameraInUse. We
+        // poll for up to this long instead so a slow-warming camera is adopted the moment
+        // it delivers a usable frame; a backend that's truly dead just costs this once
+        // before the loop tries the next one (still far under the 90s open watchdog).
+        private const int ProbeWarmupMs = 3000;
+        private const int ProbeReadIntervalMs = 200;
+
         // Ordered open attempts: each tries one backend with one pixel-format
         // request, accepting the first that delivers a usable frame.
         //  • DSHOW shares WebcamDeviceEnumerator's DirectShow index space (so the
@@ -987,13 +997,18 @@ namespace ConditioningControlPanel.Services
                 cap.Set(VideoCaptureProperties.BufferSize, 1);
 
                 // Slow drivers (USB UVC over a hub, virtual cameras that lazy-init
-                // their pipeline) can return an empty first frame even though the
-                // device isn't held by another app — retry a handful of times before
-                // giving up so that case warms up instead of being misdiagnosed.
+                // their pipeline, the Lovense Webcam 2 that streams black for >1s) can
+                // return empty or degenerate frames right after the handle opens even
+                // though the device isn't held by another app — poll up to ProbeWarmupMs
+                // so that case warms up and is adopted instead of being misdiagnosed as
+                // CameraInUse (BUG-6W469QGMHS).
                 using var probe = new Mat();
-                for (int i = 0; i < 5; i++)
+                var probeDeadline = DateTime.UtcNow.AddMilliseconds(ProbeWarmupMs);
+                int probeReads = 0;
+                while (DateTime.UtcNow < probeDeadline)
                 {
                     if (_openAbandoned) { cap.Dispose(); return null; }
+                    probeReads++;
                     if (cap.Read(probe) && !probe.Empty())
                     {
                         Cv2.MeanStdDev(probe, out var mean, out var std);
@@ -1001,24 +1016,24 @@ namespace ConditioningControlPanel.Services
                         if (maxStd >= MinProbeStdDev)
                         {
                             App.Logger?.Information(
-                                "WebcamTrackingService: device {Index} ('{Name}') via {Api} probe ok ({W}x{H}, mean={Mean:F1}, maxStdDev={Std:F1})",
-                                deviceIndex, detectedName, label, probe.Width, probe.Height, mean.Val0, maxStd);
+                                "WebcamTrackingService: device {Index} ('{Name}') via {Api} probe ok ({W}x{H}, mean={Mean:F1}, maxStdDev={Std:F1}, reads={Reads})",
+                                deviceIndex, detectedName, label, probe.Width, probe.Height, mean.Val0, maxStd, probeReads);
                             var result = cap;
                             cap = null; // hand ownership to caller; keep the catch from disposing it
                             return result;
                         }
                         // Non-empty but degenerate (solid colour / black) — keep probing
-                        // briefly in case it's a one-off first frame, then reject.
+                        // within the warm-up budget in case it's a slow-warming feed.
                         App.Logger?.Debug(
                             "WebcamTrackingService: device {Index} via {Api} degenerate probe frame (maxStdDev={Std:F1} < {Min})",
                             deviceIndex, label, maxStd, MinProbeStdDev);
                     }
-                    System.Threading.Thread.Sleep(200);
+                    System.Threading.Thread.Sleep(ProbeReadIntervalMs);
                 }
 
                 App.Logger?.Warning(
-                    "WebcamTrackingService: device index {Index} ('{Name}') opened via {Api} but produced no usable frame — trying next attempt",
-                    deviceIndex, detectedName, label);
+                    "WebcamTrackingService: device index {Index} ('{Name}') opened via {Api} but produced no usable frame in {Budget}ms ({Reads} reads) — trying next attempt",
+                    deviceIndex, detectedName, label, ProbeWarmupMs, probeReads);
                 cap.Dispose();
                 return null;
             }

--- a/ConditioningControlPanel/WebcamCalibrationWindow.xaml.cs
+++ b/ConditioningControlPanel/WebcamCalibrationWindow.xaml.cs
@@ -489,8 +489,12 @@ namespace ConditioningControlPanel
 
                     if (choice == System.Windows.MessageBoxResult.Yes)
                     {
-                        // Same terminal state as the Recalibrate button: close unaccepted
-                        // so nothing is persisted and the user can run calibration again.
+                        // Exactly what the Recalibrate button does: set WantsRecalibrate
+                        // so ShowDialogWithRecalibrate's loop RE-OPENS the dialog. Without
+                        // this flag the loop breaks and the user who clicked "try again"
+                        // is silently dropped to no calibration (the close alone only
+                        // cancels — it does not restart).
+                        WantsRecalibrate = true;
                         DialogResult = false;
                         Close();
                         return;

--- a/ConditioningControlPanel/WebcamCalibrationWindow.xaml.cs
+++ b/ConditioningControlPanel/WebcamCalibrationWindow.xaml.cs
@@ -454,7 +454,52 @@ namespace ConditioningControlPanel
             // on webcam data (Hansen & Ji 2010, Zhang & Hornof 2014). 16
             // points × 5 candidates × 2 axes = ~160 small linear-system
             // solves at finalize time — milliseconds.
-            PolynomialFitData? polynomial = FitCerrolazaPolynomial(srcMeans, dstPoints);
+            PolynomialFitData? polynomial = FitCerrolazaPolynomial(srcMeans, dstPoints, out double polyRmsX, out double polyRmsY);
+
+            // Fit-quality gate (#335). The fit's own training residual tells us whether
+            // the polynomial can even reproduce the dots the user just looked at. A usable
+            // calibration lands within a few % of the screen; a residual this large means
+            // the iris signal was too noisy/degenerate to fit (poor light, lens glare, a
+            // high-res feed downscaled to mush, or head movement) and the result is
+            // unusable. Previously it was saved silently and the user was left with
+            // tracking that "completed" but was wildly off ("very badly inaccurate, not
+            // usable"). The ceiling is deliberately generous — 20% of the screen — so it
+            // only catches clearly-broken fits, never a merely-imperfect one. Warn and
+            // offer a redo instead of hard-blocking, so a user whose hardware genuinely
+            // can't do better can still keep what they've got.
+            if (polynomial != null)
+            {
+                const double MaxFitResidualFraction = 0.20;
+                double ceilX = ActualWidth * MaxFitResidualFraction;
+                double ceilY = ActualHeight * MaxFitResidualFraction;
+                if (polyRmsX > ceilX || polyRmsY > ceilY)
+                {
+                    App.Logger?.Warning(
+                        "WebcamCalibration: fit residual too high — rms_x={Rx:F0} (ceil {Cx:F0}), rms_y={Ry:F0} (ceil {Cy:F0}) DIPs; prompting redo",
+                        polyRmsX, ceilX, polyRmsY, ceilY);
+
+                    var choice = System.Windows.MessageBox.Show(
+                        this,
+                        "This calibration came out very inaccurate — the dots didn't line up, so eye tracking would be unreliable.\n\n" +
+                        "For a better result: good, even lighting; avoid glare on glasses (or try without them); keep your head still and look right at each dot.\n\n" +
+                        "Try the calibration again?",
+                        "Calibration inaccurate",
+                        System.Windows.MessageBoxButton.YesNo,
+                        System.Windows.MessageBoxImage.Warning);
+
+                    if (choice == System.Windows.MessageBoxResult.Yes)
+                    {
+                        // Same terminal state as the Recalibrate button: close unaccepted
+                        // so nothing is persisted and the user can run calibration again.
+                        DialogResult = false;
+                        Close();
+                        return;
+                    }
+
+                    // "No" = keep it anyway — fall through and persist as before.
+                    App.Logger?.Information("WebcamCalibration: user kept low-quality calibration despite high residual");
+                }
+            }
 
             // LeftRefVec / RightRefVec are the per-side averages of the
             // calibration grid's left and right columns — used by
@@ -1042,8 +1087,12 @@ namespace ConditioningControlPanel
         // diagnostic line with the chosen λ and per-axis training residuals
         // so a calibration that comes out compressed or wildly off is
         // observable in the logs.
-        private static PolynomialFitData? FitCerrolazaPolynomial(Point2d[] srcMeans, Point2d[] dstPoints)
+        private static PolynomialFitData? FitCerrolazaPolynomial(Point2d[] srcMeans, Point2d[] dstPoints, out double rmsX, out double rmsY)
         {
+            // Default to "unusable" so the fit-quality gate fails closed on any path
+            // that returns null (degenerate solve, exception) without a real residual.
+            rmsX = double.PositiveInfinity;
+            rmsY = double.PositiveInfinity;
             try
             {
                 int n = srcMeans.Length;
@@ -1113,9 +1162,11 @@ namespace ConditioningControlPanel
                     rowSummary = " | rows_y(mean/|abs|): " + rowParts;
                 }
 
+                rmsX = Math.Sqrt(ssX / n);
+                rmsY = Math.Sqrt(ssY / n);
                 App.Logger?.Information(
                     "WebcamCalibration: polynomial fit n={N} λ={L:E2} | rms_x={Rx:F1} rms_y={Ry:F1} | max_x={Mx:F1}@{Wx} max_y={My:F1}@{Wy}{Rows} (DIPs)",
-                    n, lambda, Math.Sqrt(ssX / n), Math.Sqrt(ssY / n), maxX, worstIdxX, maxY, worstIdxY, rowSummary);
+                    n, lambda, rmsX, rmsY, maxX, worstIdxX, maxY, worstIdxY, rowSummary);
 
                 return new PolynomialFitData { X = coeffsX, Y = coeffsY };
             }


### PR DESCRIPTION
Bundles today's bug-triage fixes from the open `ccp-bugs` reports (target: 6.0.6). Excludes unrelated in-progress work (Companion/Hypnotube editor, CCBill docs) — those stay on their own branches.

## Commits
| Commit | What | Bugs |
|---|---|---|
| `a0b2875` | webcam: probe-gate backend selection + MJPG fallback for Elgato (base) | #329, #327 |
| quiz local-AI provider + quiet startup video | Quiz now honours the Local-AI toggle the companion uses (was cloud-only); startup auto-play no longer pops "no videos found" on an empty folder | #334, #333 |
| mod-aware companion name in level-up announcements | Themed mods (Circe's Lock) no longer surface raw Bambi roster names on level-up | #325 |
| webcam: time-based probe warm-up for slow-streaming UVC cams | Lovense Webcam 2 streams black for >1s after opening; gives it up to 3s before rejecting → fixes false "camera in use" | #335 |
| webcam: gate calibration on fit quality | Reject/warn-and-offer-redo when the 25-dot fit can't reproduce its own dots, instead of silently saving an unusable calibration | #335 |
| quiz: context-gate slur moderation + distinguish block from failure | "faggot"/"fag" was an unconditional HateSpeech block that discarded legit quiz questions (reclaimed sissy/bambi vocab) and aborted with a bogus "AI busy" error; now context-gated + a moderation block serves a canned question instead of failing | BUG-cloud-quiz |

## Resolves (ccp-bugs)
Closes the open/duplicate reports already triaged: #334, #333, #329, #327, #321, #311 (and the open-path half of #335). #335 (calibration accuracy) and #325 (AI role-confusion half) remain tracked separately.

## Safety notes
- **No runtime detection-threshold changes.** The calibration gate only affects the accept/reject decision (warn, not block); webcam changes are open-path only. Zero false-blink / false-attention-failure risk.
- Webcam open path is now DirectShow-first with a 90s hang-guard + per-attempt time-based warm-up.

## Not included (intentionally)
- Companion/Hypnotube link-pool editor work and the CCBill compliance dossier — unrelated, still in progress on other branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)