### PR TITLE
feat(bark): PR1 — bark system loader + dry-run matcher (no speak path)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -267,6 +267,7 @@ namespace ConditioningControlPanel
         public static BrainDrainService BrainDrain { get; private set; } = null!;
         public static AchievementService Achievements { get; private set; } = null!;
         public static GamificationBridge? Gamification { get; private set; }
+        public static BarkService? Bark { get; private set; }
         public static QuestDefinitionService QuestDefinitions { get; private set; } = null!;
         public static QuestService Quests { get; private set; } = null!;
         public static TutorialService Tutorial { get; private set; } = null!;
@@ -1040,6 +1041,9 @@ namespace ConditioningControlPanel
             // Single seam between feature events and achievement tracking. Constructed
             // here; Start() is called later in OnStartup once feature services exist.
             Gamification = new GamificationBridge();
+            // Reactive companion-dialogue ("bark") seam. Like GamificationBridge it is
+            // constructed here and Start()ed later once feature services exist.
+            Bark = new BarkService();
             QuestDefinitions = new QuestDefinitionService();
             _ = QuestDefinitions.InitializeAsync(); // Fire and forget - will load from cache first
             Quests = new QuestService();
@@ -1251,6 +1255,10 @@ namespace ConditioningControlPanel
             // to (Mods, Companion, KeywordTriggers, RemoteControl, Webcam, BlinkTrainer,
             // Lockdown) have been constructed above.
             Gamification?.Start();
+
+            // Start the bark system (loads rule manifests, wires its own direct event
+            // subscriptions). SessionEngine/TrayIcon are attached later by MainWindow.
+            Bark?.Start();
 
             // Update quest streak tracking
             Quests?.TrackStreak(Achievements.Progress.ConsecutiveDays);

--- a/ConditioningControlPanel/Features/SpiralFeatureControl.xaml
+++ b/ConditioningControlPanel/Features/SpiralFeatureControl.xaml
@@ -70,7 +70,66 @@
                 </StackPanel>
             </Border>
 
-            <!-- Select GIF -->
+            <!-- Spiral library -->
+            <Border Background="{DynamicResource SurfaceBgBrush}"
+                    BorderBrush="{DynamicResource GlassBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="10"
+                    Padding="16,14"
+                    Margin="0,0,0,10">
+                <StackPanel>
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0"
+                                   Text="SPIRAL LIBRARY"
+                                   Foreground="White"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"/>
+                        <Button Grid.Column="1"
+                                x:Name="BtnOpenSpiralFolder"
+                                Content="Open folder"
+                                Style="{DynamicResource OutlineButton}"
+                                Padding="10,5"
+                                Margin="0,0,6,0"
+                                FontSize="11"
+                                Click="BtnOpenSpiralFolder_Click"/>
+                        <Button Grid.Column="2"
+                                x:Name="BtnRefreshSpirals"
+                                Content="⟳ Refresh"
+                                Style="{DynamicResource OutlineButton}"
+                                Padding="10,5"
+                                FontSize="11"
+                                Click="BtnRefreshSpirals_Click"/>
+                    </Grid>
+
+                    <TextBlock Text="Pick the spiral used everywhere. Drop your own .gif / image files in the folder, then Refresh."
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="10"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,10"/>
+
+                    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  MaxHeight="280">
+                        <WrapPanel x:Name="SpiralLibraryPanel" Orientation="Horizontal"/>
+                    </ScrollViewer>
+
+                    <TextBlock x:Name="SpiralEmptyState"
+                               Visibility="Collapsed"
+                               Text="No spirals in your folder yet — only the built-in spiral is available. Click &quot;Open folder&quot; to add your own."
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               FontSize="11"
+                               TextWrapping="Wrap"
+                               Margin="0,8,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Select GIF (browse anywhere) -->
             <Button x:Name="BtnSelectGif"
                     Content="{loc:Str btn_select_gif}"
                     Style="{DynamicResource OutlineButton}"

--- a/ConditioningControlPanel/Features/SpiralFeatureControl.xaml.cs
+++ b/ConditioningControlPanel/Features/SpiralFeatureControl.xaml.cs
@@ -1,9 +1,13 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services;
 
 namespace ConditioningControlPanel.Features
 {
@@ -27,6 +31,7 @@ namespace ConditioningControlPanel.Features
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             LoadFromSettings();
+            RefreshLibrary();
 
             if (App.Settings?.Current is INotifyPropertyChanged inpc)
             {
@@ -67,6 +72,10 @@ namespace ConditioningControlPanel.Features
                 e.PropertyName == nameof(Models.AppSettings.SpiralOpacity))
             {
                 Dispatcher.BeginInvoke(new Action(LoadFromSettings));
+            }
+            else if (e.PropertyName == nameof(Models.AppSettings.SpiralPath))
+            {
+                Dispatcher.BeginInvoke(new Action(UpdateSelectionHighlight));
             }
         }
 
@@ -110,6 +119,216 @@ namespace ConditioningControlPanel.Features
             }
         }
 
+        // ── Spiral library ────────────────────────────────────────────────
+
+        private static readonly string[] SpiralImageExts =
+            { ".gif", ".png", ".jpg", ".jpeg", ".webp", ".bmp" };
+        private static readonly string[] SpiralVideoExts =
+            { ".mp4", ".webm", ".mov", ".avi", ".mkv" };
+
+        private static readonly Color SelectedAccent = Color.FromRgb(0xFF, 0x69, 0xB4);
+        private static readonly Color IdleAccent = Color.FromRgb(0x33, 0x33, 0x3A);
+
+        /// <summary>User spiral folder: %LOCALAPPDATA%/ConditioningControlPanel/Spirals.</summary>
+        private static string SpiralsFolderPath => Path.Combine(App.UserDataPath, "Spirals");
+
+        private static string NormPath(string? p)
+        {
+            if (string.IsNullOrWhiteSpace(p)) return "";
+            try { return Path.GetFullPath(p).TrimEnd('\\', '/'); }
+            catch { return p.Trim(); }
+        }
+
+        /// <summary>
+        /// Rebuilds the spiral preview gallery: a "Default" card for the built-in
+        /// spiral plus one card per file dropped into the Spirals folder.
+        /// </summary>
+        private void RefreshLibrary()
+        {
+            if (SpiralLibraryPanel == null) return;
+            SpiralLibraryPanel.Children.Clear();
+
+            // Built-in spiral (active when SpiralPath is empty / missing).
+            string? defaultThumb = null;
+            try { defaultThumb = ModResourceResolver.ResolveUri("spiral.gif"); }
+            catch { /* fall back to glyph */ }
+            SpiralLibraryPanel.Children.Add(BuildSpiralCard("", "Default", defaultThumb));
+
+            int fileCount = 0;
+            try
+            {
+                var folder = SpiralsFolderPath;
+                if (Directory.Exists(folder))
+                {
+                    var files = Directory.EnumerateFiles(folder)
+                        .Where(f => SpiralImageExts.Contains(Path.GetExtension(f).ToLowerInvariant()) ||
+                                    SpiralVideoExts.Contains(Path.GetExtension(f).ToLowerInvariant()))
+                        .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var file in files)
+                    {
+                        fileCount++;
+                        bool isVideo = SpiralVideoExts.Contains(Path.GetExtension(file).ToLowerInvariant());
+                        SpiralLibraryPanel.Children.Add(
+                            BuildSpiralCard(file, Path.GetFileNameWithoutExtension(file),
+                                            isVideo ? null : file));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Spiral library: enumeration failed");
+            }
+
+            if (SpiralEmptyState != null)
+                SpiralEmptyState.Visibility = fileCount == 0 ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        /// <summary>
+        /// Builds a clickable preview card. <paramref name="path"/> is the spiral file
+        /// path ("" for the built-in default). <paramref name="thumbUri"/> is a file/pack
+        /// URI to render as a thumbnail, or null to show a glyph (video / unloadable).
+        /// </summary>
+        private Border BuildSpiralCard(string path, string display, string? thumbUri)
+        {
+            var card = new Border
+            {
+                Width = 120,
+                Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E)),
+                BorderBrush = new SolidColorBrush(IdleAccent),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(8),
+                Margin = new Thickness(0, 0, 8, 8),
+                Cursor = System.Windows.Input.Cursors.Hand,
+                Tag = path,
+                ToolTip = string.IsNullOrEmpty(path) ? "Built-in spiral" : path,
+            };
+
+            var stack = new StackPanel();
+
+            var thumbHost = new Border
+            {
+                Height = 80,
+                Background = new SolidColorBrush(Color.FromRgb(0x0A, 0x0A, 0x14)),
+                CornerRadius = new CornerRadius(6, 6, 0, 0),
+                ClipToBounds = true,
+            };
+            if (thumbUri != null)
+            {
+                try
+                {
+                    var bmp = new BitmapImage();
+                    bmp.BeginInit();
+                    bmp.UriSource = new Uri(thumbUri);
+                    bmp.DecodePixelWidth = 120;
+                    bmp.CacheOption = BitmapCacheOption.OnLoad;
+                    bmp.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+                    bmp.EndInit();
+                    bmp.Freeze();
+                    thumbHost.Child = new Image { Source = bmp, Stretch = Stretch.UniformToFill };
+                }
+                catch
+                {
+                    thumbHost.Child = SpiralGlyph("🌀");
+                }
+            }
+            else
+            {
+                thumbHost.Child = SpiralGlyph("🎬");
+            }
+            stack.Children.Add(thumbHost);
+
+            stack.Children.Add(new TextBlock
+            {
+                Text = display,
+                Foreground = Brushes.White,
+                FontWeight = FontWeights.SemiBold,
+                FontSize = 11,
+                TextTrimming = TextTrimming.CharacterEllipsis,
+                TextAlignment = TextAlignment.Center,
+                Margin = new Thickness(6, 6, 6, 8),
+            });
+
+            card.Child = stack;
+            card.MouseLeftButtonUp += (_, _) => SelectSpiral(path);
+            ApplyHighlight(card);
+            return card;
+        }
+
+        private static TextBlock SpiralGlyph(string glyph) => new TextBlock
+        {
+            Text = glyph,
+            FontSize = 32,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+            Foreground = new SolidColorBrush(Color.FromRgb(0x88, 0x88, 0x88)),
+        };
+
+        /// <summary>Sets the chosen spiral as the single active spiral.</summary>
+        private void SelectSpiral(string path)
+        {
+            var s = App.Settings?.Current;
+            if (s == null) return;
+
+            // Clicking a missing file is a no-op (keeps the previous selection).
+            if (!string.IsNullOrEmpty(path) && !File.Exists(path)) return;
+
+            if (NormPath(s.SpiralPath) == NormPath(path)) return; // already active
+
+            s.SpiralPath = path; // "" => built-in default
+            App.Settings?.Save();
+
+            UpdateSelectionHighlight();
+
+            try
+            {
+                App.Overlay?.RefreshOverlays();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Spiral select: RefreshOverlays failed");
+            }
+        }
+
+        private void UpdateSelectionHighlight()
+        {
+            if (SpiralLibraryPanel == null) return;
+            foreach (var child in SpiralLibraryPanel.Children)
+                if (child is Border b)
+                    ApplyHighlight(b);
+        }
+
+        private void ApplyHighlight(Border card)
+        {
+            var current = NormPath(App.Settings?.Current?.SpiralPath);
+            var tag = NormPath(card.Tag as string);
+            // The Default card (empty tag) is active when no valid custom spiral is set.
+            bool defaultActive = string.IsNullOrEmpty(current) ||
+                                 !File.Exists(App.Settings?.Current?.SpiralPath ?? "");
+            bool selected = string.IsNullOrEmpty(tag) ? defaultActive : tag == current;
+            card.BorderBrush = new SolidColorBrush(selected ? SelectedAccent : IdleAccent);
+        }
+
+        private void BtnOpenSpiralFolder_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var folder = SpiralsFolderPath;
+                Directory.CreateDirectory(folder);
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = folder,
+                    UseShellExecute = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Spiral library: open folder failed");
+            }
+        }
+
+        private void BtnRefreshSpirals_Click(object sender, RoutedEventArgs e) => RefreshLibrary();
+
         private void BtnSelectGif_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new Microsoft.Win32.OpenFileDialog
@@ -131,6 +350,10 @@ namespace ConditioningControlPanel.Features
 
                 s.SpiralPath = dialog.FileName;
                 App.Settings?.Save();
+
+                // Reflect the new choice in the gallery (highlights it if it lives
+                // in the Spirals folder, otherwise just clears the Default highlight).
+                RefreshLibrary();
 
                 try
                 {

--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -277,6 +277,8 @@ namespace ConditioningControlPanel
 
             // Initialize tray icon
             _trayIcon = new TrayIconService(this);
+            // Let the bark system observe tray-driven events (e.g. "wake Bambi").
+            App.Bark?.AttachTray(_trayIcon);
             _trayIcon.OnExitRequested += () =>
             {
                 if (App.Lockdown?.IsActive == true) return;
@@ -15392,6 +15394,9 @@ namespace ConditioningControlPanel
                     _sessionEngine.PhaseChanged += OnSessionPhaseChanged;
                     _sessionEngine.SessionStarted += OnSessionStarted;
                     _sessionEngine.SessionStopped += OnSessionStopped;
+                    // Attach the bark system to this session engine (it's MainWindow-owned
+                    // and created lazily, so BarkService can't subscribe at its own Start()).
+                    App.Bark?.AttachSessionEngine(_sessionEngine);
                 }
 
                 // Call StartEngine directly — BtnStart_Click returns early

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "sample_session_greeting",
+    "trigger": "SessionStarted",
+    "priority": 10,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm",
+    "class": "normal",
+    "variant_pool": [
+      "There you are. Let's begin.",
+      "Good girl. Settle in for me."
+    ]
+  },
+  {
+    "id": "sample_levelup_cheer",
+    "trigger": "LevelUp",
+    "conditions": { "level_gte": 1 },
+    "priority": 20,
+    "cooldown_ms": 5000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud",
+    "class": "normal",
+    "variant_pool": [
+      "Level up! You're getting deeper.",
+      "Another level. So obedient."
+    ]
+  },
+  {
+    "id": "sample_video_attention_fail",
+    "trigger": "AttentionCheckFail",
+    "conditions": { "video_playing": true },
+    "priority": 40,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "taunt",
+    "class": "normal",
+    "variant_pool": [
+      "Eyes on the screen, dummy.",
+      "You looked away. Try again."
+    ]
+  },
+  {
+    "id": "sample_marathon_egg",
+    "trigger": "SessionPhaseChanged",
+    "conditions": { "session_elapsed_sec_gte": 1800 },
+    "priority": 550,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "impressed",
+    "class": "easter_egg",
+    "variant_pool": [
+      "Thirty minutes deep. Look at you go."
+    ]
+  }
+]

--- a/ConditioningControlPanel/Services/Bark/BarkContext.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkContext.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// Per-fire payload handed to the matcher. Subscription handlers stamp the trigger
+    /// key plus any event-derived values (e.g. level, repeats, fail-count); the matcher
+    /// reads those — together with a few live App reads injected by the service — when
+    /// evaluating a rule's conditions.
+    /// </summary>
+    public class BarkContext
+    {
+        public string Trigger { get; }
+
+        /// <summary>Flat value bag. Numbers stored as double, flags as bool, labels as string.</summary>
+        public Dictionary<string, object> Values { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public BarkContext(string trigger)
+        {
+            Trigger = trigger ?? "";
+        }
+
+        public BarkContext Set(string key, object value)
+        {
+            if (!string.IsNullOrEmpty(key)) Values[key] = value;
+            return this;
+        }
+
+        public bool TryGetNumber(string key, out double value)
+        {
+            value = 0;
+            if (!Values.TryGetValue(key, out var raw) || raw == null) return false;
+            switch (raw)
+            {
+                case double d: value = d; return true;
+                case int i: value = i; return true;
+                case long l: value = l; return true;
+                case float f: value = f; return true;
+                case bool b: value = b ? 1 : 0; return true;
+                case string s when double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var p):
+                    value = p; return true;
+                default: return false;
+            }
+        }
+
+        public bool TryGetBool(string key, out bool value)
+        {
+            value = false;
+            if (!Values.TryGetValue(key, out var raw) || raw == null) return false;
+            switch (raw)
+            {
+                case bool b: value = b; return true;
+                case int i: value = i != 0; return true;
+                case double d: value = Math.Abs(d) > double.Epsilon; return true;
+                case string s when bool.TryParse(s, out var p): value = p; return true;
+                default: return false;
+            }
+        }
+
+        public string? GetString(string key) =>
+            Values.TryGetValue(key, out var raw) ? raw?.ToString() : null;
+    }
+}

--- a/ConditioningControlPanel/Services/Bark/BarkRule.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRule.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// Class of a bark. Drives priority banding and conflict handling:
+    /// <list type="bullet">
+    /// <item><c>Safety</c> — panic/abort lines. Highest priority, never a taunt, never preempted.</item>
+    /// <item><c>EasterEgg</c> — rare, fire-once / very-long-cooldown novelty lines.</item>
+    /// <item><c>Normal</c> — ordinary reactive barks.</item>
+    /// </list>
+    /// </summary>
+    public enum BarkClass
+    {
+        Normal = 0,
+        EasterEgg = 1,
+        Safety = 2
+    }
+
+    /// <summary>
+    /// Scope of a one-shot (only meaningful when <see cref="BarkRule.Repeatable"/> is false).
+    /// PR1 (dry-run) only enforces <c>Session</c> in memory; <c>Tier</c>/<c>Lifetime</c>
+    /// persistence (AppSettings.BarkLifetimeFired) arrives with the speak path.
+    /// </summary>
+    public enum BarkScope
+    {
+        Session = 0,
+        Tier = 1,
+        Lifetime = 2
+    }
+
+    /// <summary>
+    /// A single reactive-dialogue ("bark") rule, loaded as data from a mod-resource
+    /// JSON manifest (see <see cref="BarkRuleLoader"/>). Content (the actual lines)
+    /// is supplied separately as data; this type only describes shape + matching.
+    /// </summary>
+    public class BarkRule
+    {
+        /// <summary>Stable identifier. Used as the key for cooldown, one-fire latch and variant rotation.</summary>
+        [JsonProperty("id")]
+        public string Id { get; set; } = "";
+
+        /// <summary>Trigger key — must match a key the <see cref="BarkService"/> subscription block raises.</summary>
+        [JsonProperty("trigger")]
+        public string Trigger { get; set; } = "";
+
+        /// <summary>
+        /// Optional condition map (all must pass). Keys are evaluated against the per-fire
+        /// <see cref="BarkContext"/> plus a handful of live reads. Supported operator suffixes:
+        /// <c>_gte</c> <c>_lte</c> <c>_gt</c> <c>_lt</c> <c>_eq</c>; a bare key is equality.
+        /// </summary>
+        [JsonProperty("conditions")]
+        public Dictionary<string, object>? Conditions { get; set; }
+
+        /// <summary>Higher wins when multiple rules match the same trigger. Safety reserves the top band.</summary>
+        [JsonProperty("priority")]
+        public int Priority { get; set; }
+
+        /// <summary>Per-bark cooldown in milliseconds (reuses the last-fired-dictionary primitive).</summary>
+        [JsonProperty("cooldown_ms")]
+        public int CooldownMs { get; set; }
+
+        /// <summary>true = rotate an unused variant, no repeat in-session. false = one-shot per <see cref="Scope"/>.</summary>
+        [JsonProperty("repeatable")]
+        public bool Repeatable { get; set; } = true;
+
+        [JsonProperty("scope")]
+        public string ScopeRaw { get; set; } = "session";
+
+        [JsonProperty("mood")]
+        public string Mood { get; set; } = "";
+
+        [JsonProperty("class")]
+        public string ClassRaw { get; set; } = "normal";
+
+        /// <summary>Inline line pool. Either this or <see cref="PoolRef"/> supplies variants.</summary>
+        [JsonProperty("variant_pool")]
+        public List<string>? VariantPool { get; set; }
+
+        /// <summary>Optional reference to an existing CompanionPhraseService category (reuses recorded voicelines).</summary>
+        [JsonProperty("pool_ref")]
+        public string? PoolRef { get; set; }
+
+        [JsonIgnore]
+        public BarkClass Class =>
+            ClassRaw?.Trim().ToLowerInvariant() switch
+            {
+                "safety" => BarkClass.Safety,
+                "easter_egg" or "easteregg" or "egg" => BarkClass.EasterEgg,
+                _ => BarkClass.Normal
+            };
+
+        [JsonIgnore]
+        public BarkScope Scope =>
+            ScopeRaw?.Trim().ToLowerInvariant() switch
+            {
+                "lifetime" => BarkScope.Lifetime,
+                "tier" => BarkScope.Tier,
+                _ => BarkScope.Session
+            };
+
+        public bool IsValid() =>
+            !string.IsNullOrWhiteSpace(Id) &&
+            !string.IsNullOrWhiteSpace(Trigger) &&
+            ((VariantPool != null && VariantPool.Count > 0) || !string.IsNullOrWhiteSpace(PoolRef));
+    }
+}

--- a/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ConditioningControlPanel.Services.Bark
 {
@@ -9,8 +10,15 @@ namespace ConditioningControlPanel.Services.Bark
     /// Loads bark rule manifests from disk. Two-tier, mirroring how
     /// <see cref="CompanionPhraseService.VoiceLineFolder"/> resolves audio: the embedded
     /// base manifest ships with the app; the active mod may ship its own
-    /// <c>bark_rules.json</c> alongside its companion audio, which OVERRIDES/EXTENDS the
-    /// base by rule id (mod rule wins on id collision).
+    /// <c>bark_rules.json</c> alongside its companion audio, which overrides/extends the
+    /// base.
+    ///
+    /// Merge is FIELD-LEVEL by rule id: a mod rule that supplies only
+    /// <c>{ id, variant_pool }</c> inherits trigger / conditions / priority / cooldown /
+    /// scope / class / mood from the base rule of the same id. Only the fields the mod
+    /// actually specifies override the base (omitted fields fall back). This lets skins
+    /// (Drone/Kept/…) ship content-only manifests. Array fields (e.g. variant_pool) are
+    /// REPLACED, not concatenated, so a skin fully owns its line set.
     /// </summary>
     public static class BarkRuleLoader
     {
@@ -32,30 +40,58 @@ namespace ConditioningControlPanel.Services.Bark
             }
         }
 
+        private static readonly JsonMergeSettings MergeSettings = new()
+        {
+            MergeArrayHandling = MergeArrayHandling.Replace,      // skin owns its variant_pool outright
+            MergeNullValueHandling = MergeNullValueHandling.Ignore // explicit null in mod won't blank a base field
+        };
+
         /// <summary>
-        /// Build the active rule set: load embedded base first, then overlay the active mod's
-        /// rules (same id replaces). Never throws — a missing/garbled manifest yields whatever
-        /// loaded successfully (possibly an empty set) and is logged.
+        /// Build the active rule set: load embedded base first, then field-level merge the
+        /// active mod's rules over it (same id → per-field override). Never throws — a
+        /// missing/garbled manifest yields whatever loaded successfully (possibly empty).
         /// </summary>
         public static BarkRuleSet Load()
         {
-            // Keyed by id so the mod overlay can replace base rules deterministically.
-            var merged = new Dictionary<string, BarkRule>(StringComparer.OrdinalIgnoreCase);
+            // Merge at the JSON-object level so we can tell "field omitted" from "field = default".
+            var merged = new Dictionary<string, JObject>(StringComparer.OrdinalIgnoreCase);
 
-            int baseCount = LoadInto(merged, EmbeddedManifestPath, "embedded");
+            int baseCount = MergeFile(merged, EmbeddedManifestPath, "embedded");
             int modCount = 0;
             var modPath = ActiveModManifestPath;
             if (modPath != null)
-                modCount = LoadInto(merged, modPath, "mod");
+                modCount = MergeFile(merged, modPath, "mod");
+
+            var rules = new List<BarkRule>();
+            foreach (var obj in merged.Values)
+            {
+                try
+                {
+                    var rule = obj.ToObject<BarkRule>();
+                    if (rule != null && rule.IsValid())
+                        rules.Add(rule);
+                    else
+                        App.Logger?.Warning("BarkRuleLoader: merged rule invalid after merge (id='{Id}')", rule?.Id);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Warning(ex, "BarkRuleLoader: failed to materialize a merged rule");
+                }
+            }
 
             App.Logger?.Information(
-                "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay)",
-                merged.Count, baseCount, modCount);
+                "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay; field-level merge)",
+                rules.Count, baseCount, modCount);
 
-            return new BarkRuleSet(merged.Values);
+            return new BarkRuleSet(rules);
         }
 
-        private static int LoadInto(Dictionary<string, BarkRule> merged, string path, string source)
+        /// <summary>
+        /// Parse a manifest and merge each rule object into <paramref name="merged"/> by id.
+        /// New id → inserted; existing id → field-level merge (incoming fields win).
+        /// Returns the count of rule objects seen.
+        /// </summary>
+        private static int MergeFile(Dictionary<string, JObject> merged, string path, string source)
         {
             try
             {
@@ -63,22 +99,26 @@ namespace ConditioningControlPanel.Services.Bark
                 var json = File.ReadAllText(path);
                 if (string.IsNullOrWhiteSpace(json)) return 0;
 
-                var rules = JsonConvert.DeserializeObject<List<BarkRule>>(json);
-                if (rules == null) return 0;
-
-                int added = 0;
-                foreach (var rule in rules)
+                var arr = JArray.Parse(json);
+                int n = 0;
+                foreach (var token in arr)
                 {
-                    if (rule == null || !rule.IsValid())
+                    if (token is not JObject obj) continue;
+                    var id = obj.Value<string>("id");
+                    if (string.IsNullOrWhiteSpace(id))
                     {
-                        App.Logger?.Warning("BarkRuleLoader: skipped invalid rule in {Source} manifest (id='{Id}')",
-                            source, rule?.Id);
+                        App.Logger?.Warning("BarkRuleLoader: skipped a rule with no id in {Source} manifest", source);
                         continue;
                     }
-                    merged[rule.Id] = rule; // mod overlay replaces base on id collision
-                    added++;
+
+                    if (merged.TryGetValue(id, out var existing))
+                        existing.Merge(obj, MergeSettings); // mutates existing in place; mod fields override base
+                    else
+                        merged[id] = obj;
+
+                    n++;
                 }
-                return added;
+                return n;
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRuleLoader.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// Loads bark rule manifests from disk. Two-tier, mirroring how
+    /// <see cref="CompanionPhraseService.VoiceLineFolder"/> resolves audio: the embedded
+    /// base manifest ships with the app; the active mod may ship its own
+    /// <c>bark_rules.json</c> alongside its companion audio, which OVERRIDES/EXTENDS the
+    /// base by rule id (mod rule wins on id collision).
+    /// </summary>
+    public static class BarkRuleLoader
+    {
+        public const string ManifestFileName = "bark_rules.json";
+
+        /// <summary>Embedded base manifest: Resources/sounds/companion_audio/bark_rules.json.</summary>
+        public static string EmbeddedManifestPath =>
+            Path.Combine(CompanionPhraseService.CompanionAudioFolder, ManifestFileName);
+
+        /// <summary>Active mod's manifest, if the mod ships one. Null when no mod / no file.</summary>
+        public static string? ActiveModManifestPath
+        {
+            get
+            {
+                var modPath = App.Mods?.ActiveMod?.InstalledPath;
+                if (string.IsNullOrEmpty(modPath)) return null;
+                var p = Path.Combine(modPath, "resources", "sounds", "companion_audio", ManifestFileName);
+                return File.Exists(p) ? p : null;
+            }
+        }
+
+        /// <summary>
+        /// Build the active rule set: load embedded base first, then overlay the active mod's
+        /// rules (same id replaces). Never throws — a missing/garbled manifest yields whatever
+        /// loaded successfully (possibly an empty set) and is logged.
+        /// </summary>
+        public static BarkRuleSet Load()
+        {
+            // Keyed by id so the mod overlay can replace base rules deterministically.
+            var merged = new Dictionary<string, BarkRule>(StringComparer.OrdinalIgnoreCase);
+
+            int baseCount = LoadInto(merged, EmbeddedManifestPath, "embedded");
+            int modCount = 0;
+            var modPath = ActiveModManifestPath;
+            if (modPath != null)
+                modCount = LoadInto(merged, modPath, "mod");
+
+            App.Logger?.Information(
+                "BarkRuleLoader: loaded {Total} rules ({Base} base, {Mod} mod-overlay)",
+                merged.Count, baseCount, modCount);
+
+            return new BarkRuleSet(merged.Values);
+        }
+
+        private static int LoadInto(Dictionary<string, BarkRule> merged, string path, string source)
+        {
+            try
+            {
+                if (!File.Exists(path)) return 0;
+                var json = File.ReadAllText(path);
+                if (string.IsNullOrWhiteSpace(json)) return 0;
+
+                var rules = JsonConvert.DeserializeObject<List<BarkRule>>(json);
+                if (rules == null) return 0;
+
+                int added = 0;
+                foreach (var rule in rules)
+                {
+                    if (rule == null || !rule.IsValid())
+                    {
+                        App.Logger?.Warning("BarkRuleLoader: skipped invalid rule in {Source} manifest (id='{Id}')",
+                            source, rule?.Id);
+                        continue;
+                    }
+                    merged[rule.Id] = rule; // mod overlay replaces base on id collision
+                    added++;
+                }
+                return added;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "BarkRuleLoader: failed to read {Source} manifest at {Path}", source, path);
+                return 0;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Bark/BarkRuleSet.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRuleSet.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// Loaded, validated set of bark rules indexed by trigger key for O(1) lookup on
+    /// each event. Built by <see cref="BarkRuleLoader"/>; treated as immutable once built.
+    /// </summary>
+    public class BarkRuleSet
+    {
+        private readonly Dictionary<string, List<BarkRule>> _byTrigger =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public int Count { get; }
+
+        public BarkRuleSet(IEnumerable<BarkRule> rules)
+        {
+            foreach (var rule in rules)
+            {
+                if (rule == null || !rule.IsValid()) continue;
+                if (!_byTrigger.TryGetValue(rule.Trigger, out var list))
+                {
+                    list = new List<BarkRule>();
+                    _byTrigger[rule.Trigger] = list;
+                }
+                list.Add(rule);
+                Count++;
+            }
+
+            // Highest priority first so the matcher can take the first gate-passing rule.
+            foreach (var list in _byTrigger.Values)
+                list.Sort((a, b) => b.Priority.CompareTo(a.Priority));
+        }
+
+        /// <summary>Rules registered for a trigger key, priority-descending. Empty if none.</summary>
+        public IReadOnlyList<BarkRule> ForTrigger(string trigger) =>
+            _byTrigger.TryGetValue(trigger, out var list)
+                ? list
+                : (IReadOnlyList<BarkRule>)Array.Empty<BarkRule>();
+
+        public IEnumerable<string> Triggers => _byTrigger.Keys;
+
+        public static BarkRuleSet Empty => new(Enumerable.Empty<BarkRule>());
+    }
+}

--- a/ConditioningControlPanel/Services/Bark/BarkState.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkState.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// In-memory (session-scoped) counter/state layer for bark conditions the app does
+    /// not already expose as events or readable singletons — cumulative blink tally,
+    /// prolonged face-lost timer, rapid mod-switch window, days-away/instant-relaunch.
+    /// Fed by <see cref="BarkService"/> handlers; read at evaluate time to stamp a
+    /// <see cref="BarkContext"/>. No persistence (PR1 is dry-run only).
+    /// </summary>
+    public class BarkState
+    {
+        // --- session engine (MainWindow-owned, attached late) for live elapsed/phase reads ---
+        private SessionEngine? _engine;
+
+        public void AttachSessionEngine(SessionEngine engine) => _engine = engine;
+
+        public bool SessionRunning => _engine?.IsRunning == true;
+        public double SessionElapsedSeconds => _engine?.IsRunning == true ? _engine.ElapsedTime.TotalSeconds : 0;
+        public int SessionPhaseIndex => _engine?.IsRunning == true ? _engine.CurrentPhaseIndex : -1;
+
+        // --- cumulative blink tally (WebcamTracking.OnBlink) ---
+        public long BlinkCount { get; private set; }
+        public void RegisterBlink() => BlinkCount++;
+
+        // --- prolonged face-lost timer (OnFaceLost / OnFaceFound) ---
+        private DateTime? _faceLostSinceUtc;
+        public void FaceLost() => _faceLostSinceUtc ??= DateTime.UtcNow;
+        public void FaceFound() => _faceLostSinceUtc = null;
+        public double FaceLostSeconds =>
+            _faceLostSinceUtc.HasValue ? (DateTime.UtcNow - _faceLostSinceUtc.Value).TotalSeconds : 0;
+
+        // --- rapid mod-switch window (ModService.ModChanged) ---
+        private readonly List<DateTime> _modSwitches = new();
+        public void RegisterModSwitch()
+        {
+            _modSwitches.Add(DateTime.UtcNow);
+            if (_modSwitches.Count > 64) _modSwitches.RemoveRange(0, _modSwitches.Count - 64);
+        }
+        public int ModSwitchesWithin(TimeSpan window)
+        {
+            var cutoff = DateTime.UtcNow - window;
+            int n = 0;
+            for (int i = _modSwitches.Count - 1; i >= 0; i--)
+            {
+                if (_modSwitches[i] >= cutoff) n++;
+                else break;
+            }
+            return n;
+        }
+
+        // --- days-away / instant-relaunch, computed once from AppSettings.LastSeenUtc ---
+        public double DaysAwayAtLaunch { get; private set; }
+        public bool InstantRelaunch { get; private set; }
+
+        public void CaptureLaunchRecency(DateTime? lastSeenUtc, double instantThresholdSeconds = 90)
+        {
+            if (!lastSeenUtc.HasValue) { DaysAwayAtLaunch = 0; InstantRelaunch = false; return; }
+            var gap = DateTime.UtcNow - lastSeenUtc.Value;
+            DaysAwayAtLaunch = Math.Max(0, gap.TotalDays);
+            InstantRelaunch = gap.TotalSeconds >= 0 && gap.TotalSeconds <= instantThresholdSeconds;
+        }
+
+        // --- marathon thresholds already announced this session (fire-once-per-session) ---
+        private readonly HashSet<int> _crossedMarathon = new();
+        public bool MarkMarathonCrossed(int thresholdSeconds) => _crossedMarathon.Add(thresholdSeconds);
+
+        /// <summary>Reset per-session state (called on session start).</summary>
+        public void ResetSessionScoped()
+        {
+            _crossedMarathon.Clear();
+            _faceLostSinceUtc = null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -29,6 +29,7 @@ namespace ConditioningControlPanel.Services
         // Subscription teardown (named delegates captured so -= matches +=).
         private readonly List<Action> _unsubscribe = new();
         private readonly List<Action> _engineUnsubscribe = new();
+        private readonly List<Action> _trayUnsubscribe = new();
 
         // --- reused gate primitives (cooldown dict / global min-gap / one-fire latch / variant rotation) ---
         private readonly Dictionary<string, DateTime> _lastFiredUtc = new(StringComparer.OrdinalIgnoreCase);
@@ -77,6 +78,7 @@ namespace ConditioningControlPanel.Services
 
             RunUnsubscribers(_unsubscribe);
             RunUnsubscribers(_engineUnsubscribe);
+            RunUnsubscribers(_trayUnsubscribe);
         }
 
         private static void RunUnsubscribers(List<Action> list)
@@ -357,15 +359,21 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: AttachSessionEngine failed"); }
         }
 
-        /// <summary>Wire the MainWindow-owned tray icon (created in MainWindow's constructor).</summary>
+        /// <summary>
+        /// Wire the MainWindow-owned tray icon (created in MainWindow's constructor).
+        /// Re-attach safe: detaches any previous tray wiring before subscribing, so a
+        /// repeat call can't double-subscribe (no double-fire, no leak).
+        /// </summary>
         public void AttachTray(TrayIconService tray)
         {
             if (tray == null) return;
             try
             {
+                RunUnsubscribers(_trayUnsubscribe);
+
                 Action wake = () => Raise("WakeBambiRequested");
                 tray.OnWakeBambiRequested += wake;
-                _unsubscribe.Add(() => tray.OnWakeBambiRequested -= wake);
+                _trayUnsubscribe.Add(() => tray.OnWakeBambiRequested -= wake);
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: AttachTray failed"); }
         }

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -1,0 +1,638 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.AIService;
+using ConditioningControlPanel.Services.Bark;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Reactive companion-dialogue ("bark") system. Modeled on <see cref="GamificationBridge"/>:
+    /// a single seam that SUBSCRIBES directly to the events feature services already raise and
+    /// decides which bark — if any — should be spoken in response.
+    ///
+    /// PR1 scope: rule LOADER + full subscription block + counter layer + DRY-RUN matcher.
+    /// There is no speak path yet — every decision is logged ("[BARK dry-run] …"), nothing is
+    /// rendered to the avatar. The speak path (GigglePriority/Giggle, self-echo mute,
+    /// chat-suppression, easter-egg clip) lands in a follow-up PR.
+    /// </summary>
+    public class BarkService : IDisposable
+    {
+        private bool _started;
+        private readonly object _gate = new();
+
+        private BarkRuleSet _rules = BarkRuleSet.Empty;
+        private readonly BarkState _state = new();
+
+        // Subscription teardown (named delegates captured so -= matches +=).
+        private readonly List<Action> _unsubscribe = new();
+        private readonly List<Action> _engineUnsubscribe = new();
+
+        // --- reused gate primitives (cooldown dict / global min-gap / one-fire latch / variant rotation) ---
+        private readonly Dictionary<string, DateTime> _lastFiredUtc = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _firedOnceSession = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, HashSet<int>> _usedVariants = new(StringComparer.OrdinalIgnoreCase);
+        private DateTime _globalLastFireUtc = DateTime.MinValue;
+
+        /// <summary>Global minimum gap between any two barks. (Speak-path PR will surface this as a setting.)</summary>
+        private const int GlobalMinGapMs = 4000;
+
+        private static readonly TimeSpan RapidModSwitchWindow = TimeSpan.FromSeconds(60);
+
+        /// <summary>PR1 has no speak path; the matcher only logs. Always true for now.</summary>
+        public bool DryRun { get; set; } = true;
+
+        public BarkState State => _state;
+
+        // ===================== lifecycle =====================
+
+        public void Start()
+        {
+            if (_started) return;
+            _started = true;
+
+            try
+            {
+                _rules = BarkRuleLoader.Load();
+                _state.CaptureLaunchRecency(App.Settings?.Current?.LastSeenUtc);
+
+                WireSubscriptions();
+
+                App.Logger?.Information(
+                    "BarkService started — {Count} rules, {Triggers} trigger keys, dry-run={DryRun}",
+                    _rules.Count, _rules.Triggers.Count(), DryRun);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BarkService failed to start");
+            }
+        }
+
+        public void Stop()
+        {
+            if (!_started) return;
+            _started = false;
+
+            RunUnsubscribers(_unsubscribe);
+            RunUnsubscribers(_engineUnsubscribe);
+        }
+
+        private static void RunUnsubscribers(List<Action> list)
+        {
+            foreach (var u in list)
+            {
+                try { u(); } catch (Exception ex) { App.Logger?.Debug(ex, "BarkService: unsubscribe failed"); }
+            }
+            list.Clear();
+        }
+
+        public void Dispose() => Stop();
+
+        /// <summary>
+        /// Reload rules from disk (e.g. after a mod switch so the new mod's manifest applies).
+        /// </summary>
+        public void ReloadRules()
+        {
+            try
+            {
+                _rules = BarkRuleLoader.Load();
+                App.Logger?.Information("BarkService: reloaded {Count} rules", _rules.Count);
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: rule reload failed"); }
+        }
+
+        // ===================== subscription block =====================
+
+        private void WireSubscriptions()
+        {
+            // ---- Webcam / gaze ----
+            if (App.Webcam != null)
+            {
+                Wire<Action>(h => App.Webcam.OnBlink += h, h => App.Webcam.OnBlink -= h,
+                    () => { _state.RegisterBlink(); Raise("Blink", c => c.Set("blink_count", _state.BlinkCount)); });
+                Wire<Action>(h => App.Webcam.OnMouthOpen += h, h => App.Webcam.OnMouthOpen -= h,
+                    () => Raise("MouthOpen"));
+                Wire<Action>(h => App.Webcam.OnTongueOut += h, h => App.Webcam.OnTongueOut -= h,
+                    () => Raise("TongueOut"));
+                Wire<Action<System.Windows.Point>>(h => App.Webcam.OnLongStare += h, h => App.Webcam.OnLongStare -= h,
+                    _ => Raise("LongStare"));
+                Wire<Action>(h => App.Webcam.OnFaceLost += h, h => App.Webcam.OnFaceLost -= h,
+                    () => { _state.FaceLost(); Raise("FaceLost"); });
+                Wire<Action>(h => App.Webcam.OnFaceFound += h, h => App.Webcam.OnFaceFound -= h,
+                    () => { _state.FaceFound(); Raise("FaceFound"); });
+                Wire<Action<WebcamTrackingState>>(h => App.Webcam.OnTrackingStateChanged += h, h => App.Webcam.OnTrackingStateChanged -= h,
+                    s => Raise("TrackingStateChanged", c => c.Set("state", s.ToString())));
+            }
+
+            // ---- Gaze focus ----
+            if (App.GazeFocus != null)
+            {
+                Wire<Action>(h => App.GazeFocus.GazePopped += h, h => App.GazeFocus.GazePopped -= h,
+                    () => Raise("GazePopped"));
+                Wire<Action<bool>>(h => App.GazeFocus.OnActiveChanged += h, h => App.GazeFocus.OnActiveChanged -= h,
+                    active => Raise("GazeActiveChanged", c => c.Set("active", active)));
+            }
+
+            // ---- Blink trainer ----
+            if (App.BlinkTrainer != null)
+                Wire<Action>(h => App.BlinkTrainer.StateChanged += h, h => App.BlinkTrainer.StateChanged -= h,
+                    () => Raise("BlinkTrainerStateChanged", c => c.Set("running", App.BlinkTrainer?.IsRunning ?? false)));
+
+            // ---- Video ----
+            if (App.Video != null)
+            {
+                Wire<EventHandler>(h => App.Video.VideoAboutToStart += h, h => App.Video.VideoAboutToStart -= h,
+                    (_, __) => Raise("VideoAboutToStart"));
+                Wire<EventHandler>(h => App.Video.VideoStarted += h, h => App.Video.VideoStarted -= h,
+                    (_, __) => Raise("VideoStarted"));
+                Wire<EventHandler>(h => App.Video.VideoEnded += h, h => App.Video.VideoEnded -= h,
+                    (_, __) => Raise("VideoEnded"));
+            }
+
+            // ---- Attention checks (GATED on a video actually playing) ----
+            if (App.AttentionCheck != null)
+            {
+                Wire<Action>(h => App.AttentionCheck.OnPass += h, h => App.AttentionCheck.OnPass -= h,
+                    () => { if (App.Video?.IsPlaying == true) Raise("AttentionCheckPass", c => c.Set("video_playing", true)); });
+                Wire<Action>(h => App.AttentionCheck.OnFail += h, h => App.AttentionCheck.OnFail -= h,
+                    () => { if (App.Video?.IsPlaying == true) Raise("AttentionCheckFail", c => c.Set("video_playing", true)); });
+            }
+
+            // ---- Bubble minigames ----
+            if (App.Bubbles != null)
+            {
+                Wire<Action>(h => App.Bubbles.OnBubblePopped += h, h => App.Bubbles.OnBubblePopped -= h,
+                    () => Raise("BubblePopped"));
+                Wire<Action>(h => App.Bubbles.OnBubbleMissed += h, h => App.Bubbles.OnBubbleMissed -= h,
+                    () => Raise("BubbleMissed"));
+            }
+            if (App.BubbleCount != null)
+            {
+                Wire<EventHandler>(h => App.BubbleCount.GameCompleted += h, h => App.BubbleCount.GameCompleted -= h,
+                    (_, __) => Raise("BubbleCountCompleted"));
+                Wire<EventHandler>(h => App.BubbleCount.GameFailed += h, h => App.BubbleCount.GameFailed -= h,
+                    (_, __) => Raise("BubbleCountFailed"));
+            }
+            if (App.BouncingText != null)
+                Wire<EventHandler>(h => App.BouncingText.OnBounce += h, h => App.BouncingText.OnBounce -= h,
+                    (_, __) => Raise("BouncingTextBounce"));
+
+            // ---- Lock card (single subscriber; Fork-D coin flip lands with the speak path) ----
+            if (App.LockCard != null)
+                Wire<EventHandler<LockCardCompletedEventArgs>>(
+                    h => App.LockCard.LockCardCompleted += h, h => App.LockCard.LockCardCompleted -= h,
+                    (_, e) => Raise("LockCardCompleted", c => c
+                        .Set("phrase", e.Phrase ?? "")
+                        .Set("mistakes", e.Mistakes)
+                        .Set("repeats", e.Repeats)));
+
+            // ---- Visual fx ----
+            if (App.Flash != null)
+                Wire<EventHandler>(h => App.Flash.FlashDisplayed += h, h => App.Flash.FlashDisplayed -= h,
+                    (_, __) => Raise("FlashDisplayed"));
+            if (App.Subliminal != null)
+                Wire<EventHandler>(h => App.Subliminal.SubliminalDisplayed += h, h => App.Subliminal.SubliminalDisplayed -= h,
+                    (_, __) => Raise("SubliminalDisplayed"));
+            if (App.BrainDrain != null)
+                Wire<EventHandler>(h => App.BrainDrain.BrainDrainTriggered += h, h => App.BrainDrain.BrainDrainTriggered -= h,
+                    (_, __) => Raise("BrainDrainTriggered"));
+            if (App.MindWipe != null)
+                Wire<EventHandler>(h => App.MindWipe.MindWipeTriggered += h, h => App.MindWipe.MindWipeTriggered -= h,
+                    (_, __) => Raise("MindWipeTriggered"));
+
+            // ---- Awareness / keywords ----
+            if (App.KeywordTriggers != null)
+                Wire<EventHandler<KeywordTrigger>>(h => App.KeywordTriggers.TriggerFired += h, h => App.KeywordTriggers.TriggerFired -= h,
+                    (_, kt) => Raise("KeywordTriggerFired", c => c.Set("keyword", kt?.Keyword ?? "")));
+            if (App.WindowAwareness != null)
+            {
+                Wire<EventHandler<ActivityChangedEventArgs>>(h => App.WindowAwareness.ActivityChanged += h, h => App.WindowAwareness.ActivityChanged -= h,
+                    (_, a) => Raise("ActivityChanged", c => c.Set("activity", a?.ToString() ?? "")));
+                Wire<EventHandler<ActivityChangedEventArgs>>(h => App.WindowAwareness.StillOnActivity += h, h => App.WindowAwareness.StillOnActivity -= h,
+                    (_, a) => Raise("StillOnActivity", c => c.Set("activity", a?.ToString() ?? "")));
+            }
+
+            // ---- Progression / companion / skills ----
+            if (App.Progression != null)
+            {
+                Wire<EventHandler<int>>(h => App.Progression.LevelUp += h, h => App.Progression.LevelUp -= h,
+                    (_, lvl) => Raise("LevelUp", c => c.Set("level", lvl)));
+                Wire<EventHandler<double>>(h => App.Progression.XPChanged += h, h => App.Progression.XPChanged -= h,
+                    (_, xp) => Raise("XPChanged", c => c.Set("xp", xp)));
+            }
+            if (App.Companion != null)
+            {
+                Wire<EventHandler<(CompanionId Companion, int NewLevel)>>(
+                    h => App.Companion.CompanionLevelUp += h, h => App.Companion.CompanionLevelUp -= h,
+                    (_, e) => Raise("CompanionLevelUp", c => c.Set("level", e.NewLevel)));
+                Wire<EventHandler>(h => App.Companion.UserMessageSent += h, h => App.Companion.UserMessageSent -= h,
+                    (_, __) => Raise("UserMessageSent"));
+            }
+            if (App.SkillTree != null)
+            {
+                Wire<EventHandler<string>>(h => App.SkillTree.SkillUnlocked += h, h => App.SkillTree.SkillUnlocked -= h,
+                    (_, id) => Raise("SkillUnlocked", c => c.Set("skill", id ?? "")));
+                Wire<EventHandler<LuckyProcEventArgs>>(h => App.SkillTree.LuckyProc += h, h => App.SkillTree.LuckyProc -= h,
+                    (_, __) => Raise("LuckyProc"));
+                Wire<EventHandler>(h => App.SkillTree.PinkRushStarted += h, h => App.SkillTree.PinkRushStarted -= h,
+                    (_, __) => Raise("PinkRushStarted"));
+                Wire<EventHandler>(h => App.SkillTree.PinkRushEnded += h, h => App.SkillTree.PinkRushEnded -= h,
+                    (_, __) => Raise("PinkRushEnded"));
+            }
+
+            // ---- Achievements / roadmap / quests / quiz / mantra ----
+            if (App.Achievements != null)
+                Wire<EventHandler<Achievement>>(h => App.Achievements.AchievementUnlocked += h, h => App.Achievements.AchievementUnlocked -= h,
+                    (_, a) => Raise("AchievementUnlocked", c => c.Set("achievement", a?.Id ?? "")));
+            if (App.Roadmap != null)
+            {
+                Wire<EventHandler<RoadmapStepCompletedEventArgs>>(h => App.Roadmap.StepCompleted += h, h => App.Roadmap.StepCompleted -= h,
+                    (_, __) => Raise("RoadmapStepCompleted"));
+                Wire<EventHandler<RoadmapTrack>>(h => App.Roadmap.TrackUnlocked += h, h => App.Roadmap.TrackUnlocked -= h,
+                    (_, __) => Raise("RoadmapTrackUnlocked"));
+                Wire<EventHandler>(h => App.Roadmap.BadgeEarned += h, h => App.Roadmap.BadgeEarned -= h,
+                    (_, __) => Raise("RoadmapBadgeEarned"));
+            }
+            if (App.Quests != null)
+            {
+                Wire<EventHandler<QuestCompletedEventArgs>>(h => App.Quests.QuestCompleted += h, h => App.Quests.QuestCompleted -= h,
+                    (_, __) => Raise("QuestCompleted"));
+                Wire<EventHandler<QuestProgressEventArgs>>(h => App.Quests.QuestProgressChanged += h, h => App.Quests.QuestProgressChanged -= h,
+                    (_, __) => Raise("QuestProgressChanged"));
+                Wire<EventHandler>(h => App.Quests.QuestsRefreshed += h, h => App.Quests.QuestsRefreshed -= h,
+                    (_, __) => Raise("QuestsRefreshed"));
+            }
+            // QuizCompleted is a STATIC event — must unsubscribe in Stop() to avoid a dangling handler.
+            {
+                EventHandler<QuizCompletedEventArgs> h = (_, e) => Raise("QuizCompleted", c => c.Set("passed", e.Passed).Set("perfect", e.Perfect));
+                QuizService.QuizCompleted += h;
+                _unsubscribe.Add(() => QuizService.QuizCompleted -= h);
+            }
+            if (App.Mantra != null)
+            {
+                Wire<Action>(h => App.Mantra.MantraCompleted += h, h => App.Mantra.MantraCompleted -= h,
+                    () => Raise("MantraCompleted"));
+                Wire<Action<int>>(h => App.Mantra.StreakChanged += h, h => App.Mantra.StreakChanged -= h,
+                    streak => Raise("MantraStreakChanged", c => c.Set("streak", streak)));
+                Wire<Action>(h => App.Mantra.StreakBroken += h, h => App.Mantra.StreakBroken -= h,
+                    () => Raise("MantraStreakBroken"));
+            }
+
+            // ---- Control / system ----
+            if (App.Lockdown != null)
+            {
+                Wire<Action>(h => App.Lockdown.LockdownActivated += h, h => App.Lockdown.LockdownActivated -= h,
+                    () => Raise("LockdownActivated"));
+                Wire<Action>(h => App.Lockdown.LockdownDeactivated += h, h => App.Lockdown.LockdownDeactivated -= h,
+                    () => Raise("LockdownDeactivated"));
+                Wire<Action<TimeSpan>>(h => App.Lockdown.CountdownTick += h, h => App.Lockdown.CountdownTick -= h,
+                    ts => Raise("LockdownCountdownTick", c => c.Set("remaining_sec", ts.TotalSeconds)));
+            }
+            if (App.RemoteControl != null)
+            {
+                Wire<EventHandler<string>>(h => App.RemoteControl.CommandReceived += h, h => App.RemoteControl.CommandReceived -= h,
+                    (_, action) => Raise("RemoteCommandReceived", c => c.Set("command", action ?? "")));
+                Wire<EventHandler>(h => App.RemoteControl.ControllerConnectedChanged += h, h => App.RemoteControl.ControllerConnectedChanged -= h,
+                    (_, __) => Raise("ControllerConnectedChanged"));
+            }
+            if (App.Mods != null)
+                Wire<EventHandler<ModPackage>>(h => App.Mods.ModChanged += h, h => App.Mods.ModChanged -= h,
+                    (_, mod) => { _state.RegisterModSwitch(); Raise("ModChanged", c => c
+                        .Set("mod", mod?.Id ?? "")
+                        .Set("mod_switches_60s", _state.ModSwitchesWithin(RapidModSwitchWindow))); });
+            if (App.ActivityTracker != null)
+                Wire<EventHandler<bool>>(h => App.ActivityTracker.IdleStateChanged += h, h => App.ActivityTracker.IdleStateChanged -= h,
+                    (_, idle) => Raise("IdleStateChanged", c => c.Set("idle", idle)));
+            if (App.Update != null)
+                Wire<EventHandler<UpdateInfo>>(h => App.Update.UpdateAvailable += h, h => App.Update.UpdateAvailable -= h,
+                    (_, __) => Raise("UpdateAvailable"));
+            if (App.Patreon != null)
+                Wire<EventHandler<PatreonTier>>(h => App.Patreon.TierChanged += h, h => App.Patreon.TierChanged -= h,
+                    (_, tier) => Raise("PatreonTierChanged", c => c.Set("tier", tier.ToString())));
+            if (App.Discord != null)
+                Wire<EventHandler<bool>>(h => App.Discord.AuthenticationChanged += h, h => App.Discord.AuthenticationChanged -= h,
+                    (_, ok) => Raise("DiscordAuthChanged", c => c.Set("authenticated", ok)));
+
+            // LocalAiService.PersistentMemoryRecalled is a STATIC event — unsubscribe in Stop().
+            {
+                EventHandler h = (_, __) => Raise("PersistentMemoryRecalled");
+                LocalAiService.PersistentMemoryRecalled += h;
+                _unsubscribe.Add(() => LocalAiService.PersistentMemoryRecalled -= h);
+            }
+        }
+
+        /// <summary>
+        /// Wire SessionEngine events. SessionEngine is MainWindow-owned and created lazily on
+        /// the first session, so MainWindow calls this once it constructs the engine. Re-attach
+        /// safely detaches any previous engine wiring.
+        /// </summary>
+        public void AttachSessionEngine(SessionEngine engine)
+        {
+            if (engine == null) return;
+            try
+            {
+                RunUnsubscribers(_engineUnsubscribe);
+                _state.AttachSessionEngine(engine);
+
+                EventHandler started = (_, __) => { _state.ResetSessionScoped(); Raise("SessionStarted"); };
+                EventHandler stopped = (_, __) => Raise("SessionStopped");
+                EventHandler<SessionCompletedEventArgs> completed = (_, __) => Raise("SessionCompleted");
+                EventHandler<SessionPhaseChangedEventArgs> phase = (_, e) =>
+                    Raise("SessionPhaseChanged", c => c.Set("phase_index", e?.PhaseIndex ?? -1));
+
+                engine.SessionStarted += started;
+                engine.SessionStopped += stopped;
+                engine.SessionCompleted += completed;
+                engine.PhaseChanged += phase;
+
+                _engineUnsubscribe.Add(() => engine.SessionStarted -= started);
+                _engineUnsubscribe.Add(() => engine.SessionStopped -= stopped);
+                _engineUnsubscribe.Add(() => engine.SessionCompleted -= completed);
+                _engineUnsubscribe.Add(() => engine.PhaseChanged -= phase);
+
+                App.Logger?.Debug("BarkService: attached to SessionEngine");
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: AttachSessionEngine failed"); }
+        }
+
+        /// <summary>Wire the MainWindow-owned tray icon (created in MainWindow's constructor).</summary>
+        public void AttachTray(TrayIconService tray)
+        {
+            if (tray == null) return;
+            try
+            {
+                Action wake = () => Raise("WakeBambiRequested");
+                tray.OnWakeBambiRequested += wake;
+                _unsubscribe.Add(() => tray.OnWakeBambiRequested -= wake);
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: AttachTray failed"); }
+        }
+
+        // ===================== subscription helper =====================
+
+        private void Wire<TDelegate>(Action<TDelegate> subscribe, Action<TDelegate> unsubscribe, TDelegate handler)
+            where TDelegate : Delegate
+        {
+            try
+            {
+                subscribe(handler);
+                _unsubscribe.Add(() => unsubscribe(handler));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "BarkService: failed to wire a subscription");
+            }
+        }
+
+        // ===================== matcher (dry-run) =====================
+
+        private void Raise(string trigger, Action<BarkContext>? fill = null)
+        {
+            try
+            {
+                var rules = _rules.ForTrigger(trigger);
+                if (rules.Count == 0) return;
+
+                var ctx = new BarkContext(trigger);
+                fill?.Invoke(ctx);
+
+                lock (_gate)
+                {
+                    // Highest-priority rule whose conditions pass.
+                    BarkRule? winner = null;
+                    foreach (var rule in rules) // already priority-descending
+                    {
+                        if (ConditionsPass(rule, ctx)) { winner = rule; break; }
+                    }
+
+                    if (winner == null)
+                    {
+                        App.Logger?.Debug("[BARK dry-run] trigger={Trigger} no rule matched conditions", trigger);
+                        return;
+                    }
+
+                    var pool = ResolvePool(winner);
+                    var decision = EvaluateGate(winner, pool);
+                    LogDecision(trigger, winner, decision, ctx);
+
+                    if (decision.WouldFire)
+                        CommitFire(winner, decision.VariantIndex);
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "BarkService: Raise('{Trigger}') failed", trigger);
+            }
+        }
+
+        private bool ConditionsPass(BarkRule rule, BarkContext ctx)
+        {
+            if (rule.Conditions == null || rule.Conditions.Count == 0) return true;
+            foreach (var kvp in rule.Conditions)
+            {
+                if (!ConditionPass(kvp.Key, kvp.Value, ctx)) return false;
+            }
+            return true;
+        }
+
+        private bool ConditionPass(string key, object? expected, BarkContext ctx)
+        {
+            string field = key;
+            string op = "eq";
+            foreach (var suffix in new[] { "_gte", "_lte", "_gt", "_lt", "_eq" })
+            {
+                if (key.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    field = key.Substring(0, key.Length - suffix.Length);
+                    op = suffix.Substring(1);
+                    break;
+                }
+            }
+
+            var actual = ResolveField(field, ctx);
+            if (actual == null) return false;
+
+            if (op == "eq")
+            {
+                // bool/string equality first, numeric fallback.
+                if (expected is bool eb && TryBool(actual, out var ab)) return ab == eb;
+                if (TryDouble(expected, out var en) && TryDouble(actual, out var an))
+                    return Math.Abs(an - en) < 0.0001;
+                return string.Equals(actual.ToString(), expected?.ToString(), StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (!TryDouble(actual, out var a) || !TryDouble(expected, out var e)) return false;
+            return op switch
+            {
+                "gte" => a >= e,
+                "lte" => a <= e,
+                "gt" => a > e,
+                "lt" => a < e,
+                _ => false
+            };
+        }
+
+        /// <summary>Resolve a condition field: well-known live reads first, else the per-fire context.</summary>
+        private object? ResolveField(string field, BarkContext ctx)
+        {
+            switch (field.ToLowerInvariant())
+            {
+                case "video_playing": return App.Video?.IsPlaying ?? false;
+                case "session_running": return _state.SessionRunning;
+                case "session_elapsed_sec": return _state.SessionElapsedSeconds;
+                case "session_phase_index": return _state.SessionPhaseIndex;
+                case "blink_count": return (double)_state.BlinkCount;
+                case "face_lost_sec": return _state.FaceLostSeconds;
+                case "mod_switches_60s": return _state.ModSwitchesWithin(RapidModSwitchWindow);
+                case "days_away": return _state.DaysAwayAtLaunch;
+                case "instant_relaunch": return _state.InstantRelaunch;
+                case "master_volume": return (double)(App.Settings?.Current?.MasterVolume ?? 0);
+                case "mute": return (App.Settings?.Current?.MasterVolume ?? 0) == 0;
+                case "player_level": return (double)(App.Settings?.Current?.PlayerLevel ?? 0);
+                case "total_sessions": return (double)(App.Settings?.Current?.TotalSessions ?? 0);
+                case "daily_quest_streak": return (double)(App.Settings?.Current?.DailyQuestStreak ?? 0);
+                case "current_streak": return (double)(App.Settings?.Current?.CurrentStreak ?? 0);
+                default:
+                    return ctx.Values.TryGetValue(field, out var v) ? v : null;
+            }
+        }
+
+        private static bool TryDouble(object? raw, out double value)
+        {
+            value = 0;
+            switch (raw)
+            {
+                case null: return false;
+                case double d: value = d; return true;
+                case int i: value = i; return true;
+                case long l: value = l; return true;
+                case float f: value = f; return true;
+                case bool b: value = b ? 1 : 0; return true;
+                case string s when double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var p):
+                    value = p; return true;
+                default: return false;
+            }
+        }
+
+        private static bool TryBool(object? raw, out bool value)
+        {
+            value = false;
+            switch (raw)
+            {
+                case bool b: value = b; return true;
+                case int i: value = i != 0; return true;
+                case double d: value = Math.Abs(d) > double.Epsilon; return true;
+                case string s when bool.TryParse(s, out var p): value = p; return true;
+                default: return false;
+            }
+        }
+
+        private List<string> ResolvePool(BarkRule rule)
+        {
+            if (rule.VariantPool != null && rule.VariantPool.Count > 0) return rule.VariantPool;
+            if (!string.IsNullOrWhiteSpace(rule.PoolRef))
+            {
+                var phrases = App.Mods?.GetPhrases(rule.PoolRef!);
+                if (phrases != null && phrases.Length > 0) return phrases.ToList();
+            }
+            return new List<string>();
+        }
+
+        private readonly struct GateDecision
+        {
+            public bool WouldFire { get; init; }
+            public int VariantIndex { get; init; }
+            public string Reason { get; init; }
+        }
+
+        private GateDecision EvaluateGate(BarkRule rule, List<string> pool)
+        {
+            if (pool.Count == 0)
+                return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "empty-pool" };
+
+            // Safety bypasses cooldown / min-gap / one-fire entirely.
+            bool isSafety = rule.Class == BarkClass.Safety;
+
+            // One-shot (repeatable=false): fire once per scope. PR1 enforces session scope in memory;
+            // tier/lifetime persistence comes with the speak path.
+            if (!isSafety && !rule.Repeatable && _firedOnceSession.Contains(rule.Id))
+                return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = $"already-fired ({rule.Scope})" };
+
+            if (!isSafety)
+            {
+                // Global min-gap.
+                var sinceGlobal = (DateTime.UtcNow - _globalLastFireUtc).TotalMilliseconds;
+                if (sinceGlobal < GlobalMinGapMs)
+                    return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = $"min-gap ({sinceGlobal:F0}/{GlobalMinGapMs}ms)" };
+
+                // Per-bark cooldown.
+                if (rule.CooldownMs > 0 && _lastFiredUtc.TryGetValue(rule.Id, out var last))
+                {
+                    var sinceRule = (DateTime.UtcNow - last).TotalMilliseconds;
+                    if (sinceRule < rule.CooldownMs)
+                        return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = $"cooldown ({sinceRule:F0}/{rule.CooldownMs}ms)" };
+                }
+            }
+
+            // Variant selection: repeatable rotates unused (no repeat in-session); one-shot uses index 0.
+            int idx = 0;
+            if (rule.Repeatable && pool.Count > 1)
+            {
+                var used = _usedVariants.TryGetValue(rule.Id, out var set) ? set : null;
+                idx = -1;
+                for (int i = 0; i < pool.Count; i++)
+                {
+                    if (used == null || !used.Contains(i)) { idx = i; break; }
+                }
+                if (idx < 0)
+                    return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "variants-exhausted (session)" };
+            }
+
+            // NOTE: chat-suppression + self-echo mute are speak-path concerns (next PR); not evaluated here.
+            return new GateDecision { WouldFire = true, VariantIndex = idx, Reason = "OK" };
+        }
+
+        private void CommitFire(BarkRule rule, int variantIndex)
+        {
+            var now = DateTime.UtcNow;
+            _lastFiredUtc[rule.Id] = now;
+            _globalLastFireUtc = now;
+            if (!rule.Repeatable) _firedOnceSession.Add(rule.Id);
+            if (variantIndex >= 0)
+            {
+                if (!_usedVariants.TryGetValue(rule.Id, out var set))
+                {
+                    set = new HashSet<int>();
+                    _usedVariants[rule.Id] = set;
+                }
+                set.Add(variantIndex);
+            }
+        }
+
+        private void LogDecision(string trigger, BarkRule rule, GateDecision decision, BarkContext ctx)
+        {
+            var pool = ResolvePool(rule);
+            string preview = decision.VariantIndex >= 0 && decision.VariantIndex < pool.Count
+                ? Truncate(pool[decision.VariantIndex], 48)
+                : "(n/a)";
+
+            if (decision.WouldFire)
+            {
+                App.Logger?.Information(
+                    "[BARK dry-run] WOULD FIRE trigger={Trigger} rule={Rule} class={Class} mood={Mood} priority={Priority} variant#={Idx} line=\"{Preview}\" gate=OK",
+                    trigger, rule.Id, rule.Class, rule.Mood, rule.Priority, decision.VariantIndex, preview);
+            }
+            else
+            {
+                App.Logger?.Information(
+                    "[BARK dry-run] blocked trigger={Trigger} rule={Rule} class={Class} priority={Priority} reason={Reason}",
+                    trigger, rule.Id, rule.Class, rule.Priority, decision.Reason);
+            }
+        }
+
+        private static string Truncate(string s, int n) =>
+            string.IsNullOrEmpty(s) ? "" : (s.Length <= n ? s : s.Substring(0, n) + "…");
+    }
+}


### PR DESCRIPTION
## What this is

PR1 of the reactive companion-dialogue (\"bark\") system. **Infrastructure only — nothing is spoken yet.** It loads rule data, wires the full event-subscription seam, and logs which bark *would* fire and why. This is the safe-to-merge foundation before the speak path lands.

## What's included

**New — `Services/Bark/` + `Services/BarkService.cs`:**
- `BarkRule` / `BarkScope` / `BarkClass` — JSON rule data model (`{ trigger, conditions, priority, cooldown_ms, repeatable, scope, mood, class, variant_pool | pool_ref }`).
- `BarkRuleSet` + `BarkRuleLoader` — two-tier load (embedded base manifest + active-mod overlay, merged by `id`), mirroring how `CompanionPhraseService` resolves mod-vs-embedded resources.
- `BarkContext` — per-fire value bag handed to the matcher.
- `BarkState` — in-memory counter layer for conditions the app doesn't expose as events: cumulative blink tally, prolonged face-lost timer, rapid mod-switch window, days-away / instant-relaunch (from `AppSettings.LastSeenUtc`), marathon thresholds.
- `BarkService` — `GamificationBridge`-style `Start()/Stop()` with one subscription block over the confirmed event surface; `AttachSessionEngine`/`AttachTray` for the MainWindow-owned, lazily-created `SessionEngine` and `TrayIconService`; a **dry-run matcher** that filters by conditions and reuses the existing cooldown / global-min-gap / one-fire-latch / variant-rotation primitives, logging every decision.

**Wiring:**
- `App.xaml.cs` — construct `Bark` beside `Gamification`; `Start()` after the bridge.
- `MainWindow.xaml.cs` — `AttachTray` at tray init; `AttachSessionEngine` when the engine is created.

**Sample manifest** (`Resources/sounds/companion_audio/bark_rules.json`) — placeholder rules so dry-run is demonstrable. Real line content arrives separately as data.

## How to verify

Run the app and watch the log. Trigger events (start a session, level up, fail a video attention check, etc.) and look for:
```
[BARK dry-run] WOULD FIRE trigger=SessionStarted rule=sample_session_greeting class=Normal mood=warm priority=10 variant#=0 line=\"There you are. Let's begin.\" gate=OK
[BARK dry-run] blocked trigger=LevelUp rule=sample_levelup_cheer class=Normal priority=20 reason=cooldown (1200/5000ms)
```
No avatar output is produced — `DryRun` is always true in this PR.

## Explicitly out of scope (later PRs)
- Speak path (`GigglePriority`/`Giggle`), chat-suppression window, self-echo mute (public `MuteKeywordEcho` wrapper).
- Easter eggs: mute-swap (`MasterVolume==0`) and the New Year note clip (fires from the 100-clicks-in-60s egg at `MainWindow.ShowEasterEgg()`), Fork-D LockCard 50/50 coin flip.
- `AppSettings` lifetime-flag persistence (`NewYearNoteReactionSeen`, `BarkLifetimeFired`).
- Optional instrumentation: `VideoService._penalties` exposure, gaze-minigame pass/fail events.

## Notes
- `SessionEngine`/`TrayIconService` aren't `App.` singletons (MainWindow-private; engine is lazily created), hence the `Attach…` hooks rather than direct subscription at `Start()`.
- `AttentionCheckService.OnPass/OnFail` are gated on `VideoService.IsPlaying` (the service has its own timer).
- Builds clean (0 errors, no new warnings in the added files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)