### PR TITLE
feat(bark): PR3 — easter eggs (mute swap, note clip, logo wiring, egg conditions)

### DIFF
--- a/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
+++ b/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
@@ -79,6 +79,10 @@ namespace ConditioningControlPanel
         private bool _isMuted = false; // Mute avatar speech and sounds
         private bool _isMouseOverSpeechBubble = false; // Track mouse over speech bubble to keep it open
         private bool _isShowingAiBubble = false; // Track when AI bubble is visible (presets get discarded)
+        // While true a real recorded clip (e.g. the New Year note) owns the bubble — nothing may
+        // preempt it. The clip's own bubble renders via ShowGiggle(..., bypassClipLock: true).
+        private bool _isPlayingUninterruptibleClip = false;
+        private const string NoteClipCaption = "♡"; // ♡ — placeholder caption while the clip plays; replace with real content
         private readonly DateTime _startupTime = DateTime.Now; // Track startup to prevent race conditions
         private const double StartupCooldownSeconds = 3.0; // Don't allow non-greeting speech for 3 seconds
 
@@ -2496,6 +2500,8 @@ namespace ConditioningControlPanel
         /// </summary>
         public void Giggle(string text, string? phraseAudioPath = null)
         {
+            if (_isPlayingUninterruptibleClip) return; // an uninterruptible clip is speaking
+
             // Block if waiting for AI response
             if (_isWaitingForAi)
             {
@@ -2642,6 +2648,7 @@ namespace ConditioningControlPanel
 
         public void GigglePriority(string text, bool playSound = true, bool aiGenerated = true)
         {
+            if (_isPlayingUninterruptibleClip) return; // an uninterruptible clip is speaking
             DispatcherHelper.RunOnUI(() =>
             {
                 // Only genuine AI replies anchor the chat-suppression window; bark output
@@ -2726,8 +2733,11 @@ namespace ConditioningControlPanel
         /// <param name="text">The text to display</param>
         /// <param name="playSound">Whether to play a giggle sound</param>
         /// <param name="source">The source of the speech (for delay calculation)</param>
-        private void ShowGiggle(string text, bool playSound = false, SpeechSource source = SpeechSource.Preset, string? phraseAudioPath = null, bool aiGenerated = false)
+        private void ShowGiggle(string text, bool playSound = false, SpeechSource source = SpeechSource.Preset, string? phraseAudioPath = null, bool aiGenerated = false, bool bypassClipLock = false)
         {
+            // An uninterruptible recorded clip owns the bubble — only its own (bypassing) call may render.
+            if (_isPlayingUninterruptibleClip && !bypassClipLock) return;
+
             // CCBill AI Addendum: show the "AI" badge only when this bubble's text actually came from
             // an AI inference. Canned/preset phrases (including AI-path fallbacks) leave it hidden.
             // The POLICY badge is mutually exclusive — only ShowModerationRefusalBubble shows it.
@@ -4468,6 +4478,63 @@ namespace ConditioningControlPanel
         /// Suppressed when "Mute Whispers" is on so the phrase bubble still
         /// appears but the attached audio doesn't play.
         /// </summary>
+        /// <summary>
+        /// Play a real recorded clip (e.g. the New Year note) uninterruptibly: no giggle sound, no
+        /// dom voice, just the file. Holds <c>_isPlayingUninterruptibleClip</c> so nothing preempts
+        /// it and shows a silent priority bubble for the clip's duration. No-ops gracefully (returns
+        /// false) if the file is missing, so it can be wired before the recording ships. Returns true
+        /// only if a real clip actually started — callers latch their once-ever flag on true.
+        /// </summary>
+        public bool PlayNoteClip(string clipPath)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(clipPath) || !System.IO.File.Exists(clipPath))
+                {
+                    App.Logger?.Information("PlayNoteClip: no clip at {Path} — skipping gracefully", clipPath);
+                    return false;
+                }
+
+                DispatcherHelper.RunOnUI(() =>
+                {
+                    _isPlayingUninterruptibleClip = true;
+                    // Silent, top-priority bubble for the clip's duration. Source=AI suppresses the
+                    // fallback pop; playSound:false means no giggle; bypassClipLock renders past the latch.
+                    ShowGiggle(NoteClipCaption, playSound: false, source: SpeechSource.AI,
+                        phraseAudioPath: null, aiGenerated: false, bypassClipLock: true);
+                });
+
+                var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
+                var volume = (float)Math.Pow(masterVolume, 1.5) * 0.9f; // a touch louder — it's a once-ever moment
+
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        using var audioFile = new NAudio.Wave.AudioFileReader(clipPath);
+                        audioFile.Volume = volume;
+                        using var outputDevice = new NAudio.Wave.WaveOutEvent();
+                        outputDevice.Init(audioFile);
+                        outputDevice.Play();
+                        while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
+                            System.Threading.Thread.Sleep(50);
+                    }
+                    catch (Exception ex) { App.Logger?.Warning(ex, "PlayNoteClip: playback failed"); }
+                    finally
+                    {
+                        DispatcherHelper.RunOnUI(() => _isPlayingUninterruptibleClip = false);
+                    }
+                });
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "PlayNoteClip failed");
+                _isPlayingUninterruptibleClip = false;
+                return false;
+            }
+        }
+
         private void PlayPhraseAudio(string audioPath)
         {
             try
@@ -4520,6 +4587,9 @@ namespace ConditioningControlPanel
                     var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
                     // Apply volume curve, cap at 70% of master to not be too loud
                     var volume = (float)Math.Pow(masterVolume, 1.5) * 0.7f;
+
+                    // Mute egg / silenced audio (Fork F): MasterVolume == 0 means don't attempt audio.
+                    if (masterVolume <= 0f) return;
 
                     // Use NAudio for async playback
                     Task.Run(() =>

--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -26604,6 +26604,19 @@ namespace ConditioningControlPanel
             if (Application.Current?.Dispatcher == null || Application.Current.Dispatcher.HasShutdownStarted)
                 return;
 
+            // Once ever: add the companion's recorded voice on top of the written note (additive —
+            // the note dialog still shows as before). The recording is bundled later; PlayNoteClip
+            // no-ops if the file is missing, and we only latch the flag once it actually plays, so it
+            // still fires the first time the clip exists. Start it before the modal note so the voice
+            // plays while the note is read.
+            if (App.Settings?.Current?.NewYearNoteReactionSeen != true)
+            {
+                var notePath = System.IO.Path.Combine(
+                    AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds", "note_newyear.wav");
+                if (App.AvatarWindow?.PlayNoteClip(notePath) == true)
+                    App.Settings.Current.NewYearNoteReactionSeen = true;
+            }
+
             var easterEggWindow = new EasterEggWindow(readerCount);
             easterEggWindow.Owner = this;
             easterEggWindow.ShowDialog();

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -59,8 +59,8 @@
   },
   {
     "id": "sample_marathon_egg",
-    "trigger": "SessionPhaseChanged",
-    "conditions": { "session_elapsed_sec_gte": 1800 },
+    "trigger": "SessionProgress",
+    "conditions": { "session_elapsed_sec_gte": 10800 },
     "priority": 550,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -68,7 +68,34 @@
     "mood": "impressed",
     "class": "easter_egg",
     "variant_pool": [
-      "Thirty minutes deep. Look at you go."
+      "Three hours deep. Look at you go."
+    ]
+  },
+  {
+    "id": "sample_dvd_corner_egg",
+    "trigger": "BouncingTextCorner",
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "delighted",
+    "class": "easter_egg",
+    "variant_pool": [
+      "It hit the corner! Do you know how rare that is?"
+    ]
+  },
+  {
+    "id": "sample_mute_egg",
+    "trigger": "FlashDisplayed",
+    "conditions": { "mute": true },
+    "priority": 505,
+    "cooldown_ms": 600000,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "easter_egg",
+    "variant_pool": [
+      "Muted? I can still see you reading me."
     ]
   }
 ]

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -56,6 +56,7 @@ namespace ConditioningControlPanel.Services
         private readonly Random _rng = new();
         private DateTime _lastUserMessageUtc = DateTime.MinValue;
         private DateTime _safetyHoldUntilUtc = DateTime.MinValue;
+        private PatreonTier _lastTier = PatreonTier.None; // to detect tier-up for the upgrade egg
 
         /// <summary>
         /// When true the matcher evaluates and logs ("[BARK dry-run] …") but never renders to the
@@ -80,7 +81,9 @@ namespace ConditioningControlPanel.Services
                     DryRun = true;
 
                 _rules = BarkRuleLoader.Load();
-                _state.CaptureLaunchRecency(App.Settings?.Current?.LastSeenUtc);
+                // Instant-relaunch egg threshold: relaunched within 60s of last seen.
+                _state.CaptureLaunchRecency(App.Settings?.Current?.LastSeenUtc, instantThresholdSeconds: 60);
+                _lastTier = App.Patreon?.CurrentTier ?? PatreonTier.None;
 
                 WireSubscriptions();
 
@@ -145,8 +148,10 @@ namespace ConditioningControlPanel.Services
                     _ => Raise("LongStare"));
                 Wire<Action>(h => App.Webcam.OnFaceLost += h, h => App.Webcam.OnFaceLost -= h,
                     () => { _state.FaceLost(); Raise("FaceLost"); });
+                // Raise BEFORE clearing so face_lost_sec still reads the elapsed lost-duration
+                // (enables the prolonged-FaceLost egg's distinct very-long threshold).
                 Wire<Action>(h => App.Webcam.OnFaceFound += h, h => App.Webcam.OnFaceFound -= h,
-                    () => { _state.FaceFound(); Raise("FaceFound"); });
+                    () => { Raise("FaceFound"); _state.FaceFound(); });
                 Wire<Action<WebcamTrackingState>>(h => App.Webcam.OnTrackingStateChanged += h, h => App.Webcam.OnTrackingStateChanged -= h,
                     s => Raise("TrackingStateChanged", c => c.Set("state", s.ToString())));
             }
@@ -201,8 +206,13 @@ namespace ConditioningControlPanel.Services
                     (_, __) => Raise("BubbleCountFailed"));
             }
             if (App.BouncingText != null)
+            {
                 Wire<EventHandler>(h => App.BouncingText.OnBounce += h, h => App.BouncingText.OnBounce -= h,
                     (_, __) => Raise("BouncingTextBounce"));
+                // DVD corner hit (true/near corner) — distinct from a plain wall bounce.
+                Wire<EventHandler>(h => App.BouncingText.OnCornerHit += h, h => App.BouncingText.OnCornerHit -= h,
+                    (_, __) => Raise("BouncingTextCorner"));
+            }
 
             // ---- Lock card (sole subscriber; Fork-D 50/50 coin flip in HandleLockCardCompleted) ----
             if (App.LockCard != null)
@@ -332,7 +342,12 @@ namespace ConditioningControlPanel.Services
                     (_, __) => Raise("UpdateAvailable"));
             if (App.Patreon != null)
                 Wire<EventHandler<PatreonTier>>(h => App.Patreon.TierChanged += h, h => App.Patreon.TierChanged -= h,
-                    (_, tier) => Raise("PatreonTierChanged", c => c.Set("tier", tier.ToString())));
+                    (_, tier) =>
+                    {
+                        bool up = tier > _lastTier; // enum is ordinal (None < Level1 < …)
+                        _lastTier = tier;
+                        Raise("PatreonTierChanged", c => c.Set("tier", tier.ToString()).Set("tier_up", up));
+                    });
             if (App.Discord != null)
                 Wire<EventHandler<bool>>(h => App.Discord.AuthenticationChanged += h, h => App.Discord.AuthenticationChanged -= h,
                     (_, ok) => Raise("DiscordAuthChanged", c => c.Set("authenticated", ok)));
@@ -363,16 +378,21 @@ namespace ConditioningControlPanel.Services
                 EventHandler<SessionCompletedEventArgs> completed = (_, __) => Raise("SessionCompleted");
                 EventHandler<SessionPhaseChangedEventArgs> phase = (_, e) =>
                     Raise("SessionPhaseChanged", c => c.Set("phase_index", e?.PhaseIndex ?? -1));
+                // Periodic in-session tick — drives time-threshold eggs (e.g. marathon: session_elapsed_sec >= 3h).
+                EventHandler<SessionProgressEventArgs> progress = (_, __) =>
+                    Raise("SessionProgress", c => c.Set("session_elapsed_sec", _state.SessionElapsedSeconds));
 
                 engine.SessionStarted += started;
                 engine.SessionStopped += stopped;
                 engine.SessionCompleted += completed;
                 engine.PhaseChanged += phase;
+                engine.ProgressUpdated += progress;
 
                 _engineUnsubscribe.Add(() => engine.SessionStarted -= started);
                 _engineUnsubscribe.Add(() => engine.SessionStopped -= stopped);
                 _engineUnsubscribe.Add(() => engine.SessionCompleted -= completed);
                 _engineUnsubscribe.Add(() => engine.PhaseChanged -= phase);
+                _engineUnsubscribe.Add(() => engine.ProgressUpdated -= progress);
 
                 App.Logger?.Debug("BarkService: attached to SessionEngine");
             }
@@ -598,6 +618,23 @@ namespace ConditioningControlPanel.Services
                 case "total_sessions": return (double)(App.Settings?.Current?.TotalSessions ?? 0);
                 case "daily_quest_streak": return (double)(App.Settings?.Current?.DailyQuestStreak ?? 0);
                 case "current_streak": return (double)(App.Settings?.Current?.CurrentStreak ?? 0);
+
+                // --- lifetime-completion egg conditions ---
+                case "achievements_all_unlocked":
+                {
+                    var total = App.Achievements?.GetTotalCount() ?? 0;
+                    return total > 0 && (App.Achievements?.GetUnlockedCount() ?? 0) >= total;
+                }
+                case "all_skills_unlocked":
+                {
+                    var total = SkillDefinition.All?.Count ?? 0;
+                    return total > 0 && (App.SkillTree?.GetUnlockedSkills().Count ?? 0) >= total;
+                }
+                // (max-level egg uses the existing "player_level_gte" condition — there is no level cap.)
+
+                // --- date egg ---
+                case "is_nye": return DateTime.Now.Month == 12 && DateTime.Now.Day == 31;
+
                 default:
                     return ctx.Values.TryGetValue(field, out var v) ? v : null;
             }
@@ -774,6 +811,16 @@ namespace ConditioningControlPanel.Services
 
             string line = ApplySubstitutions(pool[variantIndex], ctx);
             if (string.IsNullOrWhiteSpace(line)) return;
+
+            // Mute egg (Fork F): an easter_egg bark while audio is fully muted shows a silent, text-only
+            // bubble via Giggle (the PlayGiggleSound MasterVolume==0 guard keeps it from making sound).
+            bool muted = (App.Settings?.Current?.MasterVolume ?? 0) == 0;
+            if (rule.Class == BarkClass.EasterEgg && muted)
+            {
+                avatar.Giggle(line);
+                App.KeywordTriggers?.MuteKeywordEcho(line, SelfEchoMuteMs);
+                return;
+            }
 
             // Route by class/priority: non-Normal or high-priority barks preempt (GigglePriority);
             // ordinary barks queue (Giggle). Safety is non-Normal, so it preempts and clears the queue.

--- a/ConditioningControlPanel/Services/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/BouncingTextService.cs
@@ -87,6 +87,8 @@ public class BouncingTextService : IDisposable
     }
 
     public event EventHandler? OnBounce;
+    /// <summary>Fires on a true/near DVD corner hit (distinct from a plain wall bounce). Used by the bark egg.</summary>
+    public event EventHandler? OnCornerHit;
 
     public void Start(bool bypassLevelCheck = false, List<string>? pool = null)
     {
@@ -315,6 +317,7 @@ public class BouncingTextService : IDisposable
         {
             App.Logger?.Information("🎯 CORNER HIT! Position: ({X}, {Y})", _posX, _posY);
             App.Achievements?.TrackCornerHit();
+            OnCornerHit?.Invoke(this, EventArgs.Empty);
         }
         // Also check for "near corner" hits - when very close to a corner during a single-axis bounce
         else if (bounced)
@@ -324,6 +327,7 @@ public class BouncingTextService : IDisposable
             {
                 App.Logger?.Information("🎯 NEAR-CORNER HIT! Position: ({X}, {Y})", _posX, _posY);
                 App.Achievements?.TrackCornerHit();
+                OnCornerHit?.Invoke(this, EventArgs.Empty);
             }
         }
         


### PR DESCRIPTION
## What this is

PR3 of the bark system: the **easter-egg layer** — mute-egg swap, the real-recording note clip + logo wiring, and the remaining egg condition surface.

> **Stacked on #34 (PR2), which is stacked on #33 (PR1).** Base is `feat/bark-service-pr2-speak`. Merge order: #33 → #34 → #35.

> 🚫 **Do not merge this stack live yet.** Per your instruction, nothing merges until your dry-run validation pass **and** real line content replaces the sample `bark_rules.json`. The bundled note recording (`Resources/sounds/note_newyear.wav`) is also still pending — `PlayNoteClip` no-ops gracefully until it ships.

## Included

**Mute egg (Fork F)**
- `PlayGiggleSound` (`AvatarTubeWindow`) bails before the `Task.Run` when `MasterVolume == 0` — no audio attempt.
- `BarkService.Speak()`: an `easter_egg` bark while `MasterVolume == 0` swaps to a silent, text-only bubble via `Giggle(line)` instead of `GigglePriority` + voiceline.

**New Year note clip**
- `AvatarTubeWindow.PlayNoteClip(string clipPath)` → plays a real recorded clip via the `PlayPhraseAudio` NAudio pattern but with **no giggle sound, no dom voice**, an `_isPlayingUninterruptibleClip` latch (`ShowGiggle`/`Giggle`/`GigglePriority` bail while it holds; the clip's own silent bubble renders via `ShowGiggle(..., bypassClipLock: true)`), and **returns whether a real clip started**. No-ops gracefully if the file is missing.
- `MainWindow.ShowEasterEgg()` → **additive** to the existing written-note dialog: once ever, calls `PlayNoteClip(Resources/sounds/note_newyear.wav)` before the modal note (so the voice plays while the note is read) and latches `AppSettings.NewYearNoteReactionSeen` **only when it actually played** — so it still fires the first time the bundled clip exists.

**Egg condition surface**
- Instant-relaunch threshold tightened to **60s** (`BarkState`).
- Marathon: `SessionEngine.ProgressUpdated` now raises `"SessionProgress"` (periodic tick) so `session_elapsed_sec` thresholds (e.g. 3h) evaluate mid-session.
- Prolonged FaceLost: `FaceFound` raises **before** clearing so `face_lost_sec` reads the elapsed duration (distinct very-long threshold from normal attention-lost).
- DVD corner: new **additive** `BouncingTextService.OnCornerHit` event, fired at the existing true/near corner-detection points (`OnBounce` unchanged) → `"BouncingTextCorner"`. *(Needed because `OnBounce` fires on every wall hit and carries no corner info — a corner can't be detected from `OnBounce` alone.)*
- Tier-up: `PatreonTierChanged` now carries a `tier_up` flag (compares against the last tier).
- New `ResolveField` conditions: `achievements_all_unlocked`, `all_skills_unlocked`, `is_nye`. **Max-level** egg uses the existing `player_level_gte` — there is no level cap, so no separate field.
- Plain-event eggs ride existing subscriptions: CameraInUse (`TrackingStateChanged` `state` value), `UpdateAvailable`, Discord auth, tray wake.

**Speak-path band confirmation**
`easter_egg` rules fire through the existing speak path in the **500–599** priority band, below safety (1000): non-Normal class → `GigglePriority`; safety still preempts and holds the floor over eggs.

## Decisions I made (flagging, not blocking)
- **Note-clip bubble caption** is unspecified (the recording/transcript is yours), so `PlayNoteClip` shows a neutral placeholder caption `♡` for the clip's duration to satisfy the "priority-1000 bubble" requirement without inventing dialogue. Easy to swap for real text — say the word.
- **`OnCornerHit` event added** rather than driving the egg off `OnBounce` (which can't distinguish corners). Additive, `OnBounce` untouched.

## Validate
Run with `CCP_BARK_DRYRUN=1` and watch the log. Sample eggs added: `sample_dvd_corner_egg` (lifetime, 520), `sample_mute_egg` (FlashDisplayed + `mute:true`, 505), marathon now `SessionProgress` @ 3h. Placeholder content — replace with real lines.

## Build
0 errors; no new warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)