### PR TITLE
feat(bark): PR4 — voiced barks (per-variant voiceline audio)

### DIFF
--- a/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
+++ b/ConditioningControlPanel/AvatarTubeWindow.xaml.cs
@@ -2498,7 +2498,7 @@ namespace ConditioningControlPanel
         /// Blocked while waiting for AI response or while AI bubble is visible.
         /// Plays giggle sound 1 in 5 times for preset phrases.
         /// </summary>
-        public void Giggle(string text, string? phraseAudioPath = null)
+        public void Giggle(string text, string? phraseAudioPath = null, bool barkVoice = false)
         {
             if (_isPlayingUninterruptibleClip) return; // an uninterruptible clip is speaking
 
@@ -2539,17 +2539,22 @@ namespace ConditioningControlPanel
 
                 if (timeSinceLastSpeech < requiredDelay)
                 {
-                    // Queue it and let the delay system handle it
+                    // Queue it and let the delay system handle it. NOTE: the queue tuple carries
+                    // text only, so a queued bark voiceline plays text-only. In practice barks
+                    // fire idle (global min-gap + chat-suppression), so this immediate path is the
+                    // common case; widening the queue to carry audio is a future refinement.
                     _speechQueue.Enqueue((text, SpeechSource.Preset));
                     _isGiggling = true;
                     ProcessNextSpeech();
                 }
                 else
                 {
-                    // Determine if we should play giggle sound (1 in 5 for presets)
+                    // Determine if we should play giggle sound (1 in 5 for presets). A bark voiceline
+                    // (barkVoice + phraseAudioPath) takes the audio path in ShowGiggle, so the giggle
+                    // sound is suppressed automatically.
                     _presetGiggleCounter++;
                     bool playSound = _presetGiggleCounter % 5 == 0;
-                    ShowGiggle(text, playSound, SpeechSource.Preset, phraseAudioPath);
+                    ShowGiggle(text, playSound, SpeechSource.Preset, phraseAudioPath, barkVoice: barkVoice);
                 }
             });
         }
@@ -2646,7 +2651,7 @@ namespace ConditioningControlPanel
             return windowMs > 0 && (DateTime.UtcNow - _lastAiBubbleUtc).TotalMilliseconds < windowMs;
         }
 
-        public void GigglePriority(string text, bool playSound = true, bool aiGenerated = true)
+        public void GigglePriority(string text, bool playSound = true, bool aiGenerated = true, string? phraseAudioPath = null, bool barkVoice = false)
         {
             if (_isPlayingUninterruptibleClip) return; // an uninterruptible clip is speaking
             DispatcherHelper.RunOnUI(() =>
@@ -2677,7 +2682,8 @@ namespace ConditioningControlPanel
                 // aiGenerated: when true, the bubble shows the "AI" badge. Most call sites that route
                 // through GigglePriority are AI replies, but the awareness keyword path can fall back
                 // to canned phrases when the AI is unavailable — those callers pass false.
-                ShowGiggle(text, playSound: playSound, source: SpeechSource.AI, aiGenerated: aiGenerated);
+                ShowGiggle(text, playSound: playSound, source: SpeechSource.AI, aiGenerated: aiGenerated,
+                    phraseAudioPath: phraseAudioPath, barkVoice: barkVoice);
 
                 App.Logger?.Debug("Priority speech (queue cleared): {Text}", text);
             });
@@ -2733,7 +2739,7 @@ namespace ConditioningControlPanel
         /// <param name="text">The text to display</param>
         /// <param name="playSound">Whether to play a giggle sound</param>
         /// <param name="source">The source of the speech (for delay calculation)</param>
-        private void ShowGiggle(string text, bool playSound = false, SpeechSource source = SpeechSource.Preset, string? phraseAudioPath = null, bool aiGenerated = false, bool bypassClipLock = false)
+        private void ShowGiggle(string text, bool playSound = false, SpeechSource source = SpeechSource.Preset, string? phraseAudioPath = null, bool aiGenerated = false, bool bypassClipLock = false, bool barkVoice = false)
         {
             // An uninterruptible recorded clip owns the bubble — only its own (bypassing) call may render.
             if (_isPlayingUninterruptibleClip && !bypassClipLock) return;
@@ -2777,8 +2783,12 @@ namespace ConditioningControlPanel
             // Play sound for the speech bubble
             if (phraseAudioPath != null)
             {
-                // Custom phrase audio overrides default sounds
-                PlayPhraseAudio(phraseAudioPath);
+                // Custom phrase audio overrides default sounds. Bark voicelines play through the
+                // companion-voice path (MasterVolume-gated), not the SubAudio-gated phrase path.
+                if (barkVoice)
+                    PlayBarkVoice(phraseAudioPath);
+                else
+                    PlayPhraseAudio(phraseAudioPath);
             }
             else if (playSound)
             {
@@ -4532,6 +4542,42 @@ namespace ConditioningControlPanel
                 App.Logger?.Warning(ex, "PlayNoteClip failed");
                 _isPlayingUninterruptibleClip = false;
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Play a companion bark voiceline. Like <see cref="PlayPhraseAudio"/> but gated on
+        /// MasterVolume only (NOT SubAudioEnabled — that toggle is for subliminal whispers), so
+        /// the companion's spoken barks follow the master/mute control.
+        /// </summary>
+        private void PlayBarkVoice(string audioPath)
+        {
+            try
+            {
+                if (!System.IO.File.Exists(audioPath)) return;
+
+                var masterVolume = (App.Settings?.Current?.MasterVolume ?? 0) / 100f;
+                if (masterVolume <= 0f) return; // muted
+                var volume = (float)Math.Pow(masterVolume, 1.5) * 0.85f;
+
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        using var audioFile = new NAudio.Wave.AudioFileReader(audioPath);
+                        audioFile.Volume = volume;
+                        using var outputDevice = new NAudio.Wave.WaveOutEvent();
+                        outputDevice.Init(audioFile);
+                        outputDevice.Play();
+                        while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
+                            System.Threading.Thread.Sleep(50);
+                    }
+                    catch { /* Ignore audio errors */ }
+                });
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Failed to play bark voice: {Error}", ex.Message);
             }
         }
 

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -9,7 +9,7 @@
     "mood": "warm",
     "class": "normal",
     "variant_pool": [
-      "There you are. Let's begin.",
+      { "text": "There you are. Let's begin.", "audio": "session_start_recent_1.mp3" },
       "Good girl. Settle in for me."
     ]
   },

--- a/ConditioningControlPanel/Services/Bark/BarkRule.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkRule.cs
@@ -75,9 +75,12 @@ namespace ConditioningControlPanel.Services.Bark
         [JsonProperty("class")]
         public string ClassRaw { get; set; } = "normal";
 
-        /// <summary>Inline line pool. Either this or <see cref="PoolRef"/> supplies variants.</summary>
+        /// <summary>
+        /// Inline variant pool. Either this or <see cref="PoolRef"/> supplies variants. Each entry is
+        /// a bare string (text-only) or <c>{ text, audio }</c> (a voiced line). See <see cref="BarkVariant"/>.
+        /// </summary>
         [JsonProperty("variant_pool")]
-        public List<string>? VariantPool { get; set; }
+        public List<BarkVariant>? VariantPool { get; set; }
 
         /// <summary>Optional reference to an existing CompanionPhraseService category (reuses recorded voicelines).</summary>
         [JsonProperty("pool_ref")]

--- a/ConditioningControlPanel/Services/Bark/BarkVariant.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkVariant.cs
@@ -1,0 +1,55 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Bark
+{
+    /// <summary>
+    /// One line in a bark rule's <c>variant_pool</c>. Carries the on-screen text plus an optional
+    /// voiceline audio filename (resolved against the active mod's companion_audio folder at speak
+    /// time). Deserializes from EITHER a bare JSON string (text-only) or an object
+    /// <c>{ "text": "...", "audio": "file.mp3" }</c> — so simple/sample manifests and the generated
+    /// voiced manifests both parse. <c>display</c>/<c>file</c> are accepted as aliases for the
+    /// content-side manifest shape.
+    /// </summary>
+    [JsonConverter(typeof(BarkVariantJsonConverter))]
+    public class BarkVariant
+    {
+        public string Text { get; set; } = "";
+        public string? Audio { get; set; }
+
+        public BarkVariant() { }
+        public BarkVariant(string text, string? audio = null) { Text = text; Audio = audio; }
+
+        public bool HasText => !string.IsNullOrWhiteSpace(Text);
+    }
+
+    /// <summary>Reads a <see cref="BarkVariant"/> from a bare string or a {text/display, audio/file} object.</summary>
+    public class BarkVariantJsonConverter : JsonConverter<BarkVariant>
+    {
+        public override BarkVariant ReadJson(JsonReader reader, Type objectType, BarkVariant? existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.String:
+                    return new BarkVariant((string)reader.Value! );
+                case JsonToken.StartObject:
+                {
+                    var o = JObject.Load(reader);
+                    var text = (string?)(o["text"] ?? o["display"]) ?? "";
+                    var audio = (string?)(o["audio"] ?? o["file"]);
+                    return new BarkVariant(text, string.IsNullOrWhiteSpace(audio) ? null : audio);
+                }
+                default:
+                    reader.Skip();
+                    return new BarkVariant();
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, BarkVariant? value, JsonSerializer serializer) =>
+            throw new NotSupportedException("BarkVariant is read-only from manifests.");
+
+        public override bool CanWrite => false;
+    }
+}

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -454,7 +454,7 @@ namespace ConditioningControlPanel.Services
                 // Decide under the lock; render after releasing it (GigglePriority/Giggle marshal to UI).
                 BarkRule? toSpeak = null;
                 int variantIndex = -1;
-                List<string>? pool = null;
+                List<BarkVariant>? pool = null;
 
                 lock (_gate)
                 {
@@ -670,15 +670,33 @@ namespace ConditioningControlPanel.Services
             }
         }
 
-        private List<string> ResolvePool(BarkRule rule)
+        private List<BarkVariant> ResolvePool(BarkRule rule)
         {
             if (rule.VariantPool != null && rule.VariantPool.Count > 0) return rule.VariantPool;
             if (!string.IsNullOrWhiteSpace(rule.PoolRef))
             {
                 var phrases = App.Mods?.GetPhrases(rule.PoolRef!);
-                if (phrases != null && phrases.Length > 0) return phrases.ToList();
+                if (phrases != null && phrases.Length > 0)
+                    return phrases.Select(p => new BarkVariant(p)).ToList(); // pool-ref lines are text-only
             }
-            return new List<string>();
+            return new List<BarkVariant>();
+        }
+
+        /// <summary>
+        /// Resolve a variant's voiceline filename to a full path: active mod's
+        /// companion_audio folder first, embedded fallback second. Null if absent/missing.
+        /// </summary>
+        private static string? ResolveBarkAudio(string? file)
+        {
+            if (string.IsNullOrWhiteSpace(file)) return null;
+            var modPath = App.Mods?.ActiveMod?.InstalledPath;
+            if (!string.IsNullOrEmpty(modPath))
+            {
+                var p = System.IO.Path.Combine(modPath, "resources", "sounds", "companion_audio", file);
+                if (System.IO.File.Exists(p)) return p;
+            }
+            var embedded = System.IO.Path.Combine(CompanionPhraseService.CompanionAudioFolder, file);
+            return System.IO.File.Exists(embedded) ? embedded : null;
         }
 
         private readonly struct GateDecision
@@ -688,7 +706,7 @@ namespace ConditioningControlPanel.Services
             public string Reason { get; init; }
         }
 
-        private GateDecision EvaluateGate(BarkRule rule, List<string> pool, bool guaranteed)
+        private GateDecision EvaluateGate(BarkRule rule, List<BarkVariant> pool, bool guaranteed)
         {
             if (pool.Count == 0)
                 return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "empty-pool" };
@@ -799,7 +817,7 @@ namespace ConditioningControlPanel.Services
 
         // ===================== speak =====================
 
-        private void Speak(BarkRule rule, int variantIndex, BarkContext ctx, List<string> pool)
+        private void Speak(BarkRule rule, int variantIndex, BarkContext ctx, List<BarkVariant> pool)
         {
             if (variantIndex < 0 || variantIndex >= pool.Count) return;
             var avatar = App.AvatarWindow;
@@ -809,7 +827,8 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            string line = ApplySubstitutions(pool[variantIndex], ctx);
+            var variant = pool[variantIndex];
+            string line = ApplySubstitutions(variant.Text, ctx);
             if (string.IsNullOrWhiteSpace(line)) return;
 
             // Mute egg (Fork F): an easter_egg bark while audio is fully muted shows a silent, text-only
@@ -822,13 +841,18 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
+            // Resolve the variant's voiceline (if any) to a real path under the active mod.
+            string? audioPath = ResolveBarkAudio(variant.Audio);
+
             // Route by class/priority: non-Normal or high-priority barks preempt (GigglePriority);
             // ordinary barks queue (Giggle). Safety is non-Normal, so it preempts and clears the queue.
+            // When a voiceline exists it plays as the bubble's audio (no giggle sound on top).
             bool priority = rule.Class != BarkClass.Normal || rule.Priority >= PriorityBarkThreshold;
             if (priority)
-                avatar.GigglePriority(line, playSound: true, aiGenerated: false);
+                avatar.GigglePriority(line, playSound: audioPath == null, aiGenerated: false,
+                    phraseAudioPath: audioPath, barkVoice: audioPath != null);
             else
-                avatar.Giggle(line);
+                avatar.Giggle(line, phraseAudioPath: audioPath, barkVoice: audioPath != null);
 
             // Self-echo guard so the bubble text can't trip awareness/OCR off its own output.
             App.KeywordTriggers?.MuteKeywordEcho(line, SelfEchoMuteMs);
@@ -860,7 +884,7 @@ namespace ConditioningControlPanel.Services
         {
             var pool = ResolvePool(rule);
             string preview = decision.VariantIndex >= 0 && decision.VariantIndex < pool.Count
-                ? Truncate(pool[decision.VariantIndex], 48)
+                ? Truncate(pool[decision.VariantIndex].Text, 48)
                 : "(n/a)";
             string tag = DryRun ? "[BARK dry-run]" : "[BARK]";
 


### PR DESCRIPTION
## What this is

PR4 of the bark stack: makes barks **actually speak the supplied voicelines** instead of a generic giggle. This is the engine piece that lets the 3 mods' 251 mp3s/each be heard.

> **Stacked on #35 (PR3) → #34 → #33.** Base is `feat/bark-service-pr3-eggs`. Merge order: #33 → #34 → #35 → #36.
> 🚫 Still part of the held stack — nothing merges until your dry-run validation pass + real content lands (PR6).

## Context: what the content looks like
The supplied `New Voicelines` set is 3 mods (`bambi`, `sissy`, `circe`=the Locked/Circe's Lock built-in; `drone` is the pending 4th) × 251 mp3s, each manifest entry `{ id, n, file, display, spoken }`, plus an authoritative `_spoken.md` that fully specifies every bark's `trigger · condition · priority · cooldown · scope · mood · class`. PR4 makes the engine able to *play* that audio; PR5 closes the few trigger/condition gaps the spec needs; PR6 generates the per-mod rule files and drops in the mp3s.

## Included

**Schema**
- `variant_pool` entries are now `BarkVariant { text, audio? }` and parse from **either** a bare string (text-only, back-compatible with the sample manifest) **or** an object `{ text, audio }`. `display`/`file` accepted as aliases for the content-manifest shape. `BarkRule.VariantPool` is now `List<BarkVariant>`.

**Speak path**
- `BarkService.Speak` resolves the chosen variant's audio filename against the **active mod's** `resources/sounds/companion_audio/` folder (embedded fallback) and plays it as the bubble's audio — no giggle sound on top. Priority barks → `GigglePriority`, queued → `Giggle`; both now thread the voiceline + a `barkVoice` flag.

**AvatarTubeWindow**
- `GigglePriority`/`Giggle`/`ShowGiggle` gain `phraseAudioPath`/`barkVoice` plumbing.
- New `PlayBarkVoice(path)`: NAudio playback gated on **MasterVolume only** (not `SubAudioEnabled`, which is the subliminal-whisper toggle), so companion barks follow master/mute. `MasterVolume==0` → silent.

**Loader: unchanged.** Per-mod `bark_rules.json` already resolves from each mod's `InstalledPath`, so the content side (PR6) just drops a manifest + mp3s into each mod's `companion_audio/`.

## Known limitation (flagged)
A bark routed through the `Giggle` **queue** (bubble already busy) plays **text-only** — the speech-queue tuple carries text only. Barks fire idle in practice (global min-gap + chat-suppression), so the immediate path is the common case; widening the queue to carry audio is a future refinement.

## Validate
Sample manifest now mixes a `{text, audio}` object variant and a bare string in one pool to prove both parse; the audio resolves to null gracefully (mp3 not bundled yet) → text-only. With real mp3s in a mod's `companion_audio/`, the chosen variant speaks. `CCP_BARK_DRYRUN=1` still logs without speaking.

## Build
0 errors; no new warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)