### PR TITLE
feat(bark): PR5 — close the spec's trigger/condition gaps

### DIFF
--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -861,6 +861,10 @@ namespace ConditioningControlPanel
 
         private void HandlePanicKeyPress()
         {
+            // Let the companion say a calm, persona-neutral safety line (highest priority,
+            // bypasses the bark gate). Fired before the stop flow so it's not suppressed.
+            App.Bark?.NotifyPanic();
+
             // Dismiss any open/pinned help popover so it never lingers over a panic.
             Controls.HelpPopover.CloseActive();
 

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -85,6 +85,20 @@
     ]
   },
   {
+    "id": "sample_safety_panic",
+    "trigger": "Panic",
+    "priority": 1000,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "calm",
+    "class": "safety",
+    "variant_pool": [
+      "Okay. Everything's off. You're safe — take a breath.",
+      "All stopped. You're in control now. Breathe."
+    ]
+  },
+  {
     "id": "sample_mute_egg",
     "trigger": "FlashDisplayed",
     "conditions": { "mute": true },

--- a/ConditioningControlPanel/Services/Bark/BarkState.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkState.cs
@@ -67,11 +67,18 @@ namespace ConditioningControlPanel.Services.Bark
         private readonly HashSet<int> _crossedMarathon = new();
         public bool MarkMarathonCrossed(int thresholdSeconds) => _crossedMarathon.Add(thresholdSeconds);
 
+        // --- current session phase name (for "deepener" conditions on non-phase events) ---
+        public string CurrentPhaseName { get; private set; } = "";
+        public void SetPhase(string? name) => CurrentPhaseName = name ?? "";
+        public bool CurrentPhaseIsDeepener =>
+            CurrentPhaseName.IndexOf("deep", StringComparison.OrdinalIgnoreCase) >= 0;
+
         /// <summary>Reset per-session state (called on session start).</summary>
         public void ResetSessionScoped()
         {
             _crossedMarathon.Clear();
             _faceLostSinceUtc = null;
+            CurrentPhaseName = "";
         }
     }
 }

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -119,6 +119,12 @@ namespace ConditioningControlPanel.Services
         public void Dispose() => Stop();
 
         /// <summary>
+        /// External entry point for the panic/abort key (MainWindow.HandlePanicKeyPress). Raises the
+        /// safety-class "Panic" bark, which bypasses the gate and holds the floor.
+        /// </summary>
+        public void NotifyPanic() => Raise("Panic");
+
+        /// <summary>
         /// Reload rules from disk (e.g. after a mod switch so the new mod's manifest applies).
         /// </summary>
         public void ReloadRules()
@@ -187,7 +193,9 @@ namespace ConditioningControlPanel.Services
                 Wire<Action>(h => App.AttentionCheck.OnPass += h, h => App.AttentionCheck.OnPass -= h,
                     () => { if (App.Video?.IsPlaying == true) Raise("AttentionCheckPass", c => c.Set("video_playing", true)); });
                 Wire<Action>(h => App.AttentionCheck.OnFail += h, h => App.AttentionCheck.OnFail -= h,
-                    () => { if (App.Video?.IsPlaying == true) Raise("AttentionCheckFail", c => c.Set("video_playing", true)); });
+                    () => { if (App.Video?.IsPlaying == true) Raise("AttentionCheckFail", c => c
+                        .Set("video_playing", true)
+                        .Set("fail_count", App.Video?.PlaythroughFailCount ?? 0)); });
             }
 
             // ---- Bubble minigames ----
@@ -237,13 +245,19 @@ namespace ConditioningControlPanel.Services
             // ---- Awareness / keywords ----
             if (App.KeywordTriggers != null)
                 Wire<EventHandler<KeywordTrigger>>(h => App.KeywordTriggers.TriggerFired += h, h => App.KeywordTriggers.TriggerFired -= h,
-                    (_, kt) => Raise("KeywordTriggerFired", c => c.Set("keyword", kt?.Keyword ?? "")));
+                    (_, kt) => Raise("KeywordTriggerFired", c => c
+                        .Set("keyword", kt?.Keyword ?? "")
+                        .Set("kw_effect", kt?.VisualEffect.ToString() ?? "")));
             if (App.WindowAwareness != null)
             {
                 Wire<EventHandler<ActivityChangedEventArgs>>(h => App.WindowAwareness.ActivityChanged += h, h => App.WindowAwareness.ActivityChanged -= h,
-                    (_, a) => Raise("ActivityChanged", c => c.Set("activity", a?.ToString() ?? "")));
+                    (_, a) => Raise("ActivityChanged", c => c
+                        .Set("activity", a?.ServiceName ?? "")
+                        .Set("category", a?.Category.ToString() ?? "")));
                 Wire<EventHandler<ActivityChangedEventArgs>>(h => App.WindowAwareness.StillOnActivity += h, h => App.WindowAwareness.StillOnActivity -= h,
-                    (_, a) => Raise("StillOnActivity", c => c.Set("activity", a?.ToString() ?? "")));
+                    (_, a) => Raise("StillOnActivity", c => c
+                        .Set("activity", a?.ServiceName ?? "")
+                        .Set("still_minutes", App.WindowAwareness?.CurrentActivityDuration.TotalMinutes ?? 0)));
             }
 
             // ---- Progression / companion / skills ----
@@ -351,6 +365,9 @@ namespace ConditioningControlPanel.Services
             if (App.Discord != null)
                 Wire<EventHandler<bool>>(h => App.Discord.AuthenticationChanged += h, h => App.Discord.AuthenticationChanged -= h,
                     (_, ok) => Raise("DiscordAuthChanged", c => c.Set("authenticated", ok)));
+            if (App.Tutorial != null)
+                Wire<EventHandler>(h => App.Tutorial.TutorialCompleted += h, h => App.Tutorial.TutorialCompleted -= h,
+                    (_, __) => Raise("TutorialCompleted"));
 
             // LocalAiService.PersistentMemoryRecalled is a STATIC event — unsubscribe in Stop().
             {
@@ -377,7 +394,13 @@ namespace ConditioningControlPanel.Services
                 EventHandler stopped = (_, __) => Raise("SessionStopped");
                 EventHandler<SessionCompletedEventArgs> completed = (_, __) => Raise("SessionCompleted");
                 EventHandler<SessionPhaseChangedEventArgs> phase = (_, e) =>
-                    Raise("SessionPhaseChanged", c => c.Set("phase_index", e?.PhaseIndex ?? -1));
+                {
+                    _state.SetPhase(e?.Phase?.Name);
+                    Raise("SessionPhaseChanged", c => c
+                        .Set("phase_index", e?.PhaseIndex ?? -1)
+                        .Set("phase_name", e?.Phase?.Name ?? "")
+                        .Set("phase_is_deepener", _state.CurrentPhaseIsDeepener));
+                };
                 // Periodic in-session tick — drives time-threshold eggs (e.g. marathon: session_elapsed_sec >= 3h).
                 EventHandler<SessionProgressEventArgs> progress = (_, __) =>
                     Raise("SessionProgress", c => c.Set("session_elapsed_sec", _state.SessionElapsedSeconds));
@@ -632,8 +655,17 @@ namespace ConditioningControlPanel.Services
                 }
                 // (max-level egg uses the existing "player_level_gte" condition — there is no level cap.)
 
-                // --- date egg ---
-                case "is_nye": return DateTime.Now.Month == 12 && DateTime.Now.Day == 31;
+                // --- date / time-of-day ---
+                case "is_nye":
+                {
+                    var now = DateTime.Now; // Dec 31 or Jan 1 (local)
+                    return (now.Month == 12 && now.Day == 31) || (now.Month == 1 && now.Day == 1);
+                }
+                case "local_hour": return (double)DateTime.Now.Hour;
+
+                // --- session phase (for deepener conditions on non-phase events) ---
+                case "phase_name": return _state.CurrentPhaseName;
+                case "phase_is_deepener": return _state.CurrentPhaseIsDeepener;
 
                 default:
                     return ctx.Values.TryGetValue(field, out var v) ? v : null;

--- a/ConditioningControlPanel/Services/VideoService.cs
+++ b/ConditioningControlPanel/Services/VideoService.cs
@@ -162,6 +162,13 @@ namespace ConditioningControlPanel.Services
         public bool IsRunning => _isRunning;
 
         /// <summary>
+        /// Number of failed attention attempts in the CURRENT video playthrough (the per-video
+        /// penalty counter; reset when a new video starts). Exposed for the bark system's
+        /// "failed this video N times" reaction.
+        /// </summary>
+        public int PlaythroughFailCount => _penalties;
+
+        /// <summary>
         /// Get the shared LibVLC instance (used by BubbleCountWindow).
         /// Returns null if not yet initialized - caller should handle this.
         /// LibVLC is initialized via PreloadLibVLC() during app startup.


### PR DESCRIPTION
## What this is

PR5 of the bark stack: wires the **remaining triggers/conditions** the authored `_spoken.md` spec needs, so every one of the 84 bark ids can actually fire. Last engine piece before PR6 generates the per-mod rule files and drops in the audio.

> **Stacked on #36 (PR4) → #35 → #34 → #33.** Base is `feat/bark-service-pr4-voice`. Merge order: #33 → #34 → #35 → #36 → #37.
> 🚫 Still part of the held stack — nothing merges until your dry-run validation pass + content (PR6).

## Gaps closed (each maps to a spec tag)

| Bark | Was missing | Now |
|------|-------------|-----|
| `video_fail_3x` | spec says "needs hook" | `VideoService.PlaythroughFailCount` (`=_penalties`, per-playthrough) exposed; `AttentionCheckFail` stamps `fail_count` into ctx |
| `safety_panic` | no panic trigger | `BarkService.NotifyPanic()` raises the safety-class `"Panic"` bark, called from `MainWindow.HandlePanicKeyPress()` before the stop flow (safety bypasses the gate + holds the floor) |
| `egg_tutorial` | not subscribed | `TutorialService.TutorialCompleted` → `"TutorialCompleted"` |
| `still_5` / `still_10` | event carried no minutes | stamp `still_minutes` from `WindowAwareness.CurrentActivityDuration`; `ActivityChanged` now stamps `activity`+`category` |
| `phase_deepen` / `attention_lost_deep` | `SessionPhase` has only `Name` | "deepener" = `Name` contains "deep". `BarkState.CurrentPhaseName` tracked; `SessionPhaseChanged` stamps `phase_name`/`phase_is_deepener`; new `ResolveField` `phase_name`/`phase_is_deepener` readable on non-phase events |
| `session_start_latenight` / `egg_nye` | no time-of-day | new `ResolveField` `local_hour`; `is_nye` broadened to Dec 31 **or** Jan 1 |

After this, **all ~84 spec bark ids have their trigger + condition surface in the engine.**

## One flagged limitation
`kw_reinforce` vs `kw_offlimits`: `KeywordTrigger` has **no** reinforce/off-limits category field, so there's no clean engine signal to split them. I expose the best available (`kw_effect` = the trigger's `VisualEffect`) plus the existing `keyword` text. A proper split needs either a new category field on `KeywordTrigger` (a small user-facing feature) or the PR6 transform splitting by keyword list. **Decision for PR6: how do you want these two split?** — happy to add a `KeywordTrigger` category if you'd rather it be first-class.

## Validate
Sample `safety_panic` rule added (priority 1000, `class: safety`) — press the panic key and the companion should speak it, preempting/clearing the queue, with nothing firing over it. `CCP_BARK_DRYRUN=1` logs without speaking.

## Build
0 errors; no new warnings in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)