### PR TITLE
fix(bark): PR7 — hostile-review fixes (mod-switch reload, variant recycle, thread-safety)

### DIFF
--- a/ConditioningControlPanel/Services/Bark/BarkState.cs
+++ b/ConditioningControlPanel/Services/Bark/BarkState.cs
@@ -12,8 +12,14 @@ namespace ConditioningControlPanel.Services.Bark
     /// </summary>
     public class BarkState
     {
+        // Source events fire on assorted threads (webcam tracking is off the UI thread) while the
+        // matcher reads this state under BarkService's own, different lock. This lock makes the
+        // mutable collections/counters here internally consistent so a concurrent write+read can't
+        // tear a counter or throw "Collection was modified".
+        private readonly object _lock = new();
+
         // --- session engine (MainWindow-owned, attached late) for live elapsed/phase reads ---
-        private SessionEngine? _engine;
+        private volatile SessionEngine? _engine;
 
         public void AttachSessionEngine(SessionEngine engine) => _engine = engine;
 
@@ -22,31 +28,44 @@ namespace ConditioningControlPanel.Services.Bark
         public int SessionPhaseIndex => _engine?.IsRunning == true ? _engine.CurrentPhaseIndex : -1;
 
         // --- cumulative blink tally (WebcamTracking.OnBlink) ---
-        public long BlinkCount { get; private set; }
-        public void RegisterBlink() => BlinkCount++;
+        private long _blinkCount;
+        public long BlinkCount => System.Threading.Interlocked.Read(ref _blinkCount);
+        public void RegisterBlink() => System.Threading.Interlocked.Increment(ref _blinkCount);
 
         // --- prolonged face-lost timer (OnFaceLost / OnFaceFound) ---
         private DateTime? _faceLostSinceUtc;
-        public void FaceLost() => _faceLostSinceUtc ??= DateTime.UtcNow;
-        public void FaceFound() => _faceLostSinceUtc = null;
-        public double FaceLostSeconds =>
-            _faceLostSinceUtc.HasValue ? (DateTime.UtcNow - _faceLostSinceUtc.Value).TotalSeconds : 0;
+        public void FaceLost() { lock (_lock) { _faceLostSinceUtc ??= DateTime.UtcNow; } }
+        public void FaceFound() { lock (_lock) { _faceLostSinceUtc = null; } }
+        public double FaceLostSeconds
+        {
+            get
+            {
+                lock (_lock)
+                    return _faceLostSinceUtc.HasValue ? (DateTime.UtcNow - _faceLostSinceUtc.Value).TotalSeconds : 0;
+            }
+        }
 
         // --- rapid mod-switch window (ModService.ModChanged) ---
         private readonly List<DateTime> _modSwitches = new();
         public void RegisterModSwitch()
         {
-            _modSwitches.Add(DateTime.UtcNow);
-            if (_modSwitches.Count > 64) _modSwitches.RemoveRange(0, _modSwitches.Count - 64);
+            lock (_lock)
+            {
+                _modSwitches.Add(DateTime.UtcNow);
+                if (_modSwitches.Count > 64) _modSwitches.RemoveRange(0, _modSwitches.Count - 64);
+            }
         }
         public int ModSwitchesWithin(TimeSpan window)
         {
             var cutoff = DateTime.UtcNow - window;
             int n = 0;
-            for (int i = _modSwitches.Count - 1; i >= 0; i--)
+            lock (_lock)
             {
-                if (_modSwitches[i] >= cutoff) n++;
-                else break;
+                for (int i = _modSwitches.Count - 1; i >= 0; i--)
+                {
+                    if (_modSwitches[i] >= cutoff) n++;
+                    else break;
+                }
             }
             return n;
         }
@@ -65,20 +84,27 @@ namespace ConditioningControlPanel.Services.Bark
 
         // --- marathon thresholds already announced this session (fire-once-per-session) ---
         private readonly HashSet<int> _crossedMarathon = new();
-        public bool MarkMarathonCrossed(int thresholdSeconds) => _crossedMarathon.Add(thresholdSeconds);
+        public bool MarkMarathonCrossed(int thresholdSeconds)
+        {
+            lock (_lock) return _crossedMarathon.Add(thresholdSeconds);
+        }
 
         // --- current session phase name (for "deepener" conditions on non-phase events) ---
-        public string CurrentPhaseName { get; private set; } = "";
-        public void SetPhase(string? name) => CurrentPhaseName = name ?? "";
+        private volatile string _currentPhaseName = "";
+        public string CurrentPhaseName => _currentPhaseName;
+        public void SetPhase(string? name) => _currentPhaseName = name ?? "";
         public bool CurrentPhaseIsDeepener =>
-            CurrentPhaseName.IndexOf("deep", StringComparison.OrdinalIgnoreCase) >= 0;
+            _currentPhaseName.IndexOf("deep", StringComparison.OrdinalIgnoreCase) >= 0;
 
         /// <summary>Reset per-session state (called on session start).</summary>
         public void ResetSessionScoped()
         {
-            _crossedMarathon.Clear();
-            _faceLostSinceUtc = null;
-            CurrentPhaseName = "";
+            lock (_lock)
+            {
+                _crossedMarathon.Clear();
+                _faceLostSinceUtc = null;
+            }
+            _currentPhaseName = "";
         }
     }
 }

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -36,6 +36,9 @@ namespace ConditioningControlPanel.Services
         private readonly Dictionary<string, DateTime> _lastFiredUtc = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _firedOnceSession = new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, HashSet<int>> _usedVariants = new(StringComparer.OrdinalIgnoreCase);
+        // Last variant index fired per rule — used to avoid an immediate repeat when a repeatable
+        // pool is exhausted and recycled (see EvaluateGate).
+        private readonly Dictionary<string, int> _lastVariantIndex = new(StringComparer.OrdinalIgnoreCase);
         private DateTime _globalLastFireUtc = DateTime.MinValue;
 
         /// <summary>Global minimum gap between any two barks.</summary>
@@ -126,13 +129,25 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Reload rules from disk (e.g. after a mod switch so the new mod's manifest applies).
+        /// Rotation / cooldown / session one-shot state is keyed by rule id, and ids are SHARED
+        /// across mods (same id → different content), so it is cleared here: otherwise a line
+        /// fired under the old mod would suppress the same-id line under the new one. Persisted
+        /// lifetime/tier latches (AppSettings) are intentionally NOT cleared — those are once-ever.
         /// </summary>
         public void ReloadRules()
         {
             try
             {
-                _rules = BarkRuleLoader.Load();
-                App.Logger?.Information("BarkService: reloaded {Count} rules", _rules.Count);
+                var fresh = BarkRuleLoader.Load();
+                lock (_gate)
+                {
+                    _rules = fresh;
+                    _usedVariants.Clear();
+                    _firedOnceSession.Clear();
+                    _lastFiredUtc.Clear();
+                    _lastVariantIndex.Clear();
+                }
+                App.Logger?.Information("BarkService: reloaded {Count} rules (per-rule rotation state reset)", fresh.Count);
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "BarkService: rule reload failed"); }
         }
@@ -345,9 +360,18 @@ namespace ConditioningControlPanel.Services
             }
             if (App.Mods != null)
                 Wire<EventHandler<ModPackage>>(h => App.Mods.ModChanged += h, h => App.Mods.ModChanged -= h,
-                    (_, mod) => { _state.RegisterModSwitch(); Raise("ModChanged", c => c
-                        .Set("mod", mod?.Id ?? "")
-                        .Set("mod_switches_60s", _state.ModSwitchesWithin(RapidModSwitchWindow))); });
+                    (_, mod) =>
+                    {
+                        _state.RegisterModSwitch();
+                        // The new mod ships its own bark manifest — reload so its lines/voicelines
+                        // apply. ModChanged fires after ModService sets the active mod, so the
+                        // loader reads the new ActiveModId. (Raise the switch bark off the OLD set
+                        // first, since the new set may not define a ModChanged rule.)
+                        Raise("ModChanged", c => c
+                            .Set("mod", mod?.Id ?? "")
+                            .Set("mod_switches_60s", _state.ModSwitchesWithin(RapidModSwitchWindow)));
+                        ReloadRules();
+                    });
             if (App.ActivityTracker != null)
                 Wire<EventHandler<bool>>(h => App.ActivityTracker.IdleStateChanged += h, h => App.ActivityTracker.IdleStateChanged -= h,
                     (_, idle) => Raise("IdleStateChanged", c => c.Set("idle", idle)));
@@ -787,21 +811,34 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
-            // Variant selection: repeatable rotates unused (no repeat in-session); one-shot uses index 0.
+            // Variant selection:
+            //  • repeatable, pool>1 → rotate through unused; when ALL are used, RECYCLE the pool
+            //    (clear the used-set) so the bark keeps talking instead of going silent forever,
+            //    reseeding with the last index so we don't immediately repeat the line just spoken.
+            //  • one-shot, pool>1 → pick a random line (it only fires once, so use the whole pool
+            //    rather than always line 0; otherwise the extra authored variants are dead content).
             int idx = 0;
-            if (rule.Repeatable && pool.Count > 1)
+            if (pool.Count > 1)
             {
-                var used = _usedVariants.TryGetValue(rule.Id, out var set) ? set : null;
-                idx = -1;
-                for (int i = 0; i < pool.Count; i++)
+                if (rule.Repeatable)
                 {
-                    if (used == null || !used.Contains(i)) { idx = i; break; }
+                    var used = _usedVariants.TryGetValue(rule.Id, out var set) ? set : null;
+                    idx = FirstUnused(pool.Count, used);
+                    if (idx < 0)
+                    {
+                        // Exhausted → recycle. Reseed the used-set with the last-fired index so the
+                        // next pick avoids repeating the line we just played.
+                        var reseed = new HashSet<int>();
+                        if (_lastVariantIndex.TryGetValue(rule.Id, out var lastIdx))
+                            reseed.Add(lastIdx);
+                        _usedVariants[rule.Id] = reseed;
+                        idx = FirstUnused(pool.Count, reseed);
+                        if (idx < 0) idx = 0; // safety (pool>1 means reseed has ≤1 entry, so unreachable)
+                    }
                 }
-                if (idx < 0)
+                else
                 {
-                    // Exhausted: a guaranteed reaction reuses the first line; a normal bark stays quiet.
-                    if (bypass) idx = 0;
-                    else return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "variants-exhausted (session)" };
+                    idx = _rng.Next(pool.Count); // one-shot: random line from the pool
                 }
             }
 
@@ -854,7 +891,16 @@ namespace ConditioningControlPanel.Services
                     _usedVariants[rule.Id] = set;
                 }
                 set.Add(variantIndex);
+                _lastVariantIndex[rule.Id] = variantIndex; // for no-immediate-repeat on pool recycle
             }
+        }
+
+        /// <summary>First index in [0,count) not present in <paramref name="used"/>, or -1 if all are used.</summary>
+        private static int FirstUnused(int count, HashSet<int>? used)
+        {
+            for (int i = 0; i < count; i++)
+                if (used == null || !used.Contains(i)) return i;
+            return -1;
         }
 
         // ===================== speak =====================


### PR DESCRIPTION
Stacked on #38. Fixes from a hostile review of the #33–#38 bark stack. **Behavior-only fixes; no manifest/audio changes.** Builds clean (0 errors).

### 🔴 C1 — Mod switch now reloads rules
`ReloadRules()` had **zero callers**, so the rule-set was frozen to whatever mod was active at startup. Switching Bambi→Sissy mid-run kept Bambi's *lines* and — because audio resolves live by `ActiveModId` and all 248 filenames are identical across mods — played them through Sissy's *voice files* (text/voice mismatch). Now wired into the `ModChanged` handler. Reload also clears the id-keyed rotation / cooldown / session-one-shot state, since rule ids are shared across mods (a Bambi fire would otherwise suppress the same-id Sissy line). Persisted lifetime/tier latches are left intact.

### 🔴 C2 — Repeatable barks no longer go permanently silent
`_usedVariants` was only ever added to, never cleared, so once a repeatable rule used all N variants it returned `variants-exhausted` for the rest of the process. With pools of 3–6, the flash/bubble/subliminal barks fell silent within the first minute of a long run. On exhaustion the pool now recycles, reseeded with the last index so the immediate next line isn't a repeat.

### 🟠 M1 — One-shot rules use their whole pool
One-shots always spoke variant 0 (rotation was gated on `Repeatable`), leaving extra authored variants (e.g. `blink_t1..t5`) unreachable. One-shots now pick a random line.

### 🟠 M2 — `BarkState` is thread-safe
Its mutators run on off-thread source events (webcam tracking) while the matcher reads under `BarkService`'s lock — a torn counter / "Collection was modified" hazard. Now internally synchronized: `Interlocked` blink tally, a lock around the mod-switch list / face-lost timer / marathon set, and a volatile phase name.

### Not changed (by-design / your call)
English-only lines, queued-Giggle audio drop, `♡` note placeholder, raw audio in history. The default `CCPDefault` mod still has no bark manifest — fresh installs get barks once a content mod is selected (now without a restart, thanks to C1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)