### PR TITLE
feat(chaos): build pass 1 — feel juice, voice triggers, ambient payloads

### DIFF
--- a/ConditioningControlPanel/ChaosFxWindow.cs
+++ b/ConditioningControlPanel/ChaosFxWindow.cs
@@ -21,6 +21,7 @@ public sealed class ChaosFxWindow : Window
 {
     private readonly Border _vignette;
     private readonly Border _edge;   // sustained edge-glow (held while a power-up window is active)
+    private readonly Border _heat;   // sustained warm temperature tint (rises with run Heat)
 
     public ChaosFxWindow()
     {
@@ -39,9 +40,11 @@ public sealed class ChaosFxWindow : Window
         Width = SystemParameters.PrimaryScreenWidth;
         Height = SystemParameters.PrimaryScreenHeight;
 
+        _heat = new Border { Opacity = 0, IsHitTestVisible = false };
         _edge = new Border { Opacity = 0, IsHitTestVisible = false };
         _vignette = new Border { Opacity = 0, IsHitTestVisible = false };
         var root = new Grid { IsHitTestVisible = false };
+        root.Children.Add(_heat);       // warm temperature tint sits at the very back
         root.Children.Add(_edge);       // held glow sits under the impact pulses
         root.Children.Add(_vignette);
         Content = root;
@@ -78,6 +81,40 @@ public sealed class ChaosFxWindow : Window
     public void EndEdgeHold()
     {
         try { _edge.BeginAnimation(OpacityProperty, new DoubleAnimation(0.0, TimeSpan.FromMilliseconds(450))); }
+        catch { }
+    }
+
+    /// <summary>Hold a subtle warm temperature tint on a dedicated back layer (rises with run Heat).
+    /// <paramref name="opacity"/> is the target peak (0..~0.3). Purely cosmetic edge wash.</summary>
+    public void SetHeatTint(Color color, double opacity)
+    {
+        try
+        {
+            double peak = Math.Clamp(opacity, 0.0, 0.5);
+            if (_heat.Background == null)
+            {
+                var brush = new RadialGradientBrush
+                {
+                    GradientOrigin = new Point(0.5, 0.5),
+                    Center = new Point(0.5, 0.5),
+                    RadiusX = 1.0,
+                    RadiusY = 1.1
+                };
+                brush.GradientStops.Add(new GradientStop(Color.FromArgb(0, color.R, color.G, color.B), 0.0));
+                brush.GradientStops.Add(new GradientStop(Color.FromArgb(0, color.R, color.G, color.B), 0.40));
+                brush.GradientStops.Add(new GradientStop(Color.FromArgb(255, color.R, color.G, color.B), 1.0));
+                brush.Freeze();
+                _heat.Background = brush;
+            }
+            _heat.BeginAnimation(OpacityProperty, new DoubleAnimation(peak, TimeSpan.FromMilliseconds(400)));
+        }
+        catch { }
+    }
+
+    /// <summary>Fade out the warm temperature tint (Heat dropped back below the floor).</summary>
+    public void EndHeatTint()
+    {
+        try { _heat.BeginAnimation(OpacityProperty, new DoubleAnimation(0.0, TimeSpan.FromMilliseconds(600))); }
         catch { }
     }
 

--- a/ConditioningControlPanel/ChaosGifCascadeOverlay.cs
+++ b/ConditioningControlPanel/ChaosGifCascadeOverlay.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using XamlAnimatedGif;
+
+namespace ConditioningControlPanel;
+
+/// <summary>
+/// Full-screen, click-through overlay for the Chaos "GifCascade" payload: images/gifs spawn at the top
+/// of the screen on a timer and fall/cascade downward, then despawn off the bottom. Sources images from
+/// the SAME pool the flash/braindrain payloads draw on (<c>EffectiveAssetsPath/images</c>). Silent no-op
+/// if the pool is empty. One instance at a time; a new Show() replaces any active cascade.
+/// </summary>
+public sealed class ChaosGifCascadeOverlay : Window
+{
+    private static readonly string[] Extensions =
+        { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".webp", ".bmp" };
+
+    private static ChaosGifCascadeOverlay? _active;
+    private static readonly Random _rng = new();
+
+    /// <summary>Spawn a falling cascade of flash-pool images. All knobs come from the payload's named consts.</summary>
+    public static void Show(double spawnRatePerSec, double durationSec, double gifSize, double fallSpeed, double opacity)
+    {
+        try
+        {
+            var files = PickFiles();
+            if (files.Count == 0) return;
+            _active?.CloseNow();
+            _active = new ChaosGifCascadeOverlay(files, spawnRatePerSec, durationSec, gifSize, fallSpeed, opacity);
+            ((Window)_active).Show();
+        }
+        catch (Exception ex) { App.Logger?.Debug("ChaosGifCascadeOverlay.Show: {E}", ex.Message); }
+    }
+
+    /// <summary>Close any active cascade immediately (run teardown).</summary>
+    public static void CloseActive() { try { _active?.CloseNow(); } catch { } }
+
+    private readonly Canvas _canvas;
+    private readonly List<string> _files;
+    private readonly double _gifSize;
+    private readonly double _fallSpeed;
+    private readonly double _opacity;
+    private readonly List<Faller> _fallers = new();
+    private readonly DispatcherTimer _spawn;
+    private readonly DispatcherTimer _anim;
+    private readonly DispatcherTimer _life;
+    private bool _spawning = true;
+
+    private sealed class Faller { public Image Img = null!; public double Y; public double X; public double Speed; }
+
+    private ChaosGifCascadeOverlay(List<string> files, double spawnRatePerSec, double durationSec,
+                                   double gifSize, double fallSpeed, double opacity)
+    {
+        _files = files;
+        _gifSize = Math.Clamp(gifSize, 40, 600);
+        _fallSpeed = Math.Clamp(fallSpeed, 0.5, 30);
+        _opacity = Math.Clamp(opacity, 0.05, 1.0);
+
+        WindowStyle = WindowStyle.None;
+        AllowsTransparency = true;
+        Background = Brushes.Transparent;
+        Topmost = true;
+        ShowInTaskbar = false;
+        ShowActivated = false;
+        Focusable = false;
+        IsHitTestVisible = false;
+        ResizeMode = ResizeMode.NoResize;
+        WindowStartupLocation = WindowStartupLocation.Manual;
+        Left = SystemParameters.VirtualScreenLeft;
+        Top = SystemParameters.VirtualScreenTop;
+        Width = SystemParameters.VirtualScreenWidth;
+        Height = SystemParameters.VirtualScreenHeight;
+
+        _canvas = new Canvas { IsHitTestVisible = false };
+        Content = _canvas;
+        SourceInitialized += (_, _) => ApplyExStyles();
+
+        double interval = 1000.0 / Math.Max(0.05, spawnRatePerSec);
+        _spawn = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(interval) };
+        _spawn.Tick += (_, _) => SpawnOne();
+
+        _anim = new DispatcherTimer(DispatcherPriority.Render) { Interval = TimeSpan.FromMilliseconds(16) };
+        _anim.Tick += (_, _) => Step();
+
+        _life = new DispatcherTimer { Interval = TimeSpan.FromSeconds(Math.Max(1.0, durationSec)) };
+        _life.Tick += (_, _) => { _life.Stop(); _spawning = false; _spawn.Stop(); };  // stop spawning; let in-flight fall out
+
+        Loaded += (_, _) => { SpawnOne(); _spawn.Start(); _anim.Start(); _life.Start(); };
+    }
+
+    private void SpawnOne()
+    {
+        if (!_spawning) return;
+        try
+        {
+            string path = _files[_rng.Next(_files.Count)];
+            var img = new Image { Width = _gifSize, Stretch = Stretch.Uniform, Opacity = _opacity };
+            if (path.EndsWith(".gif", StringComparison.OrdinalIgnoreCase))
+            {
+                AnimationBehavior.SetRepeatBehavior(img, System.Windows.Media.Animation.RepeatBehavior.Forever);
+                AnimationBehavior.SetAutoStart(img, true);
+                AnimationBehavior.SetSourceUri(img, new Uri(path, UriKind.Absolute));
+            }
+            else
+            {
+                var bmp = new BitmapImage();
+                bmp.BeginInit();
+                bmp.CacheOption = BitmapCacheOption.OnLoad;
+                bmp.DecodePixelWidth = (int)_gifSize;   // decode at display size — cheap
+                bmp.UriSource = new Uri(path, UriKind.Absolute);
+                bmp.EndInit();
+                if (bmp.CanFreeze) bmp.Freeze();
+                img.Source = bmp;
+            }
+
+            double x = _rng.NextDouble() * Math.Max(1, Width - _gifSize);
+            double y = -_gifSize;
+            Canvas.SetLeft(img, x);
+            Canvas.SetTop(img, y);
+            _canvas.Children.Add(img);
+            _fallers.Add(new Faller { Img = img, X = x, Y = y, Speed = _fallSpeed * (0.7 + _rng.NextDouble() * 0.6) });
+        }
+        catch (Exception ex) { App.Logger?.Debug("GifCascade spawn: {E}", ex.Message); }
+    }
+
+    private void Step()
+    {
+        for (int i = _fallers.Count - 1; i >= 0; i--)
+        {
+            var f = _fallers[i];
+            f.Y += f.Speed;
+            Canvas.SetTop(f.Img, f.Y);
+            if (f.Y > Height + _gifSize)
+            {
+                try { AnimationBehavior.SetSourceUri(f.Img, null); f.Img.Source = null; } catch { }
+                _canvas.Children.Remove(f.Img);
+                _fallers.RemoveAt(i);
+            }
+        }
+        // Cascade fully drained after the spawn window closed → close the overlay.
+        if (!_spawning && _fallers.Count == 0) CloseNow();
+    }
+
+    private void CloseNow()
+    {
+        try { _spawn.Stop(); } catch { }
+        try { _anim.Stop(); } catch { }
+        try { _life.Stop(); } catch { }
+        foreach (var f in _fallers)
+        {
+            try { AnimationBehavior.SetSourceUri(f.Img, null); f.Img.Source = null; } catch { }
+        }
+        _fallers.Clear();
+        if (ReferenceEquals(_active, this)) _active = null;
+        try { Close(); } catch { }
+    }
+
+    private static List<string> PickFiles()
+    {
+        try
+        {
+            var dir = Path.Combine(App.EffectiveAssetsPath ?? "", "images");
+            if (!Directory.Exists(dir)) return new List<string>();
+            return Directory.EnumerateFiles(dir, "*.*", SearchOption.TopDirectoryOnly)
+                .Where(f => Extensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+                .ToList();
+        }
+        catch { return new List<string>(); }
+    }
+
+    private void ApplyExStyles()
+    {
+        try
+        {
+            var hwnd = new WindowInteropHelper(this).Handle;
+            if (hwnd == IntPtr.Zero) return;
+            int ex = GetWindowLong(hwnd, GWL_EXSTYLE) | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT;
+            SetWindowLong(hwnd, GWL_EXSTYLE, ex);
+        }
+        catch { }
+    }
+
+    private const int GWL_EXSTYLE = -20;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private const int WS_EX_NOACTIVATE = 0x08000000;
+    private const int WS_EX_TRANSPARENT = 0x00000020;
+    [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
+    [DllImport("user32.dll")] private static extern int SetWindowLong(IntPtr hwnd, int index, int newStyle);
+}

--- a/ConditioningControlPanel/ChaosHubWindow.xaml
+++ b/ConditioningControlPanel/ChaosHubWindow.xaml
@@ -228,11 +228,6 @@
                                         <ToggleButton Style="{StaticResource Seg}" Tag="RoamBounce" Content="Roam" Click="Segment_Click"/>
                                     </StackPanel>
                                 </StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                                    <TextBlock Text="Live share" Style="{StaticResource Lbl}"/>
-                                    <Slider x:Name="SldLiveShare" Minimum="0" Maximum="1" Width="200" VerticalAlignment="Center"/>
-                                    <TextBlock x:Name="TxtLiveShare" Foreground="White" FontSize="12" VerticalAlignment="Center" Margin="10,0,0,0" Width="44"/>
-                                </StackPanel>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="Shields" Style="{StaticResource Lbl}"/>
                                     <Button Style="{StaticResource Stepper}" Content="−" Tag="shields-" Click="Stepper_Click"/>

--- a/ConditioningControlPanel/ChaosHubWindow.xaml.cs
+++ b/ConditioningControlPanel/ChaosHubWindow.xaml.cs
@@ -26,7 +26,6 @@ public partial class ChaosHubWindow : Window
     {
         InitializeComponent();
         TitleBar.MouseLeftButtonDown += (_, e) => { if (e.ButtonState == MouseButtonState.Pressed) { try { DragMove(); } catch { } } };
-        SldLiveShare.ValueChanged += (_, _) => TxtLiveShare.Text = $"{(int)(SldLiveShare.Value * 100)}%";
 
         LoadFromSettings();
         BuildUpgrades();
@@ -370,8 +369,6 @@ public partial class ChaosHubWindow : Window
         SetSegment(GrpDifficulty, s.ChaosDifficulty);
         SetSegment(GrpLength, s.ChaosRunDurationSec.ToString());
         SetSegment(GrpMotion, s.ChaosMotionMode);
-        SldLiveShare.Value = s.ChaosLiveBubbleShare;
-        TxtLiveShare.Text = $"{(int)(s.ChaosLiveBubbleShare * 100)}%";
         _shields = s.ChaosStartingShields; TxtShields.Text = _shields.ToString();
         _waves = s.ChaosWaveCount; TxtWaves.Text = _waves.ToString();
 
@@ -405,7 +402,6 @@ public partial class ChaosHubWindow : Window
         SetSegment(GrpDifficulty, "Easy");
         SetSegment(GrpLength, "180");
         SetSegment(GrpMotion, "Mixed");
-        SldLiveShare.Value = 0.35; TxtLiveShare.Text = "35%";
         _shields = 3; TxtShields.Text = "3";
         _waves = 5; TxtWaves.Text = "5";
         foreach (var t in GrpPool.Children.OfType<ToggleButton>()) t.IsChecked = true;
@@ -423,7 +419,6 @@ public partial class ChaosHubWindow : Window
         s.ChaosDifficulty = GetSegment(GrpDifficulty) ?? "Easy";
         if (int.TryParse(GetSegment(GrpLength), out var len)) s.ChaosRunDurationSec = len;
         s.ChaosMotionMode = GetSegment(GrpMotion) ?? "Mixed";
-        s.ChaosLiveBubbleShare = SldLiveShare.Value;
         s.ChaosStartingShields = _shields;
         s.ChaosWaveCount = _waves;
 
@@ -469,7 +464,6 @@ public partial class ChaosHubWindow : Window
         if (preset == null) return;
         foreach (var t in GrpPool.Children.OfType<ToggleButton>())
             t.IsChecked = preset.VariantIds.Contains(t.Tag?.ToString() ?? "");
-        SldLiveShare.Value = preset.LiveShare;
     }
 
     private void BtnRandomize_Click(object sender, RoutedEventArgs e)
@@ -480,7 +474,6 @@ public partial class ChaosHubWindow : Window
         SetSegment(GrpDifficulty, diffs[_rng.Next(diffs.Length)]);
         SetSegment(GrpLength, new[] { "120", "180", "300" }[_rng.Next(3)]);
         SetSegment(GrpMotion, new[] { "Mixed", "FloatUp", "RainDown", "RoamBounce" }[_rng.Next(4)]);
-        SldLiveShare.Value = 0.2 + _rng.NextDouble() * 0.6;
         var pool = GrpPool.Children.OfType<ToggleButton>().ToList();
         foreach (var t in pool) t.IsChecked = _rng.NextDouble() < 0.6;
         if (!pool.Any(t => t.IsChecked == true)) pool[0].IsChecked = true;

--- a/ConditioningControlPanel/ChaosOverlayWindow.xaml.cs
+++ b/ConditioningControlPanel/ChaosOverlayWindow.xaml.cs
@@ -51,7 +51,16 @@ public partial class ChaosOverlayWindow : Window
 
     // ============================ countdown ============================
 
-    public void ShowCountdown(Action onComplete)
+    private DispatcherTimer? _countdownTimer;
+    private Action? _countdownComplete;
+    private bool _countdownFinished;
+    private Services.GlobalKeyboardHook? _countdownKeyHook;
+    private IntPtr _countdownMouseHook = IntPtr.Zero;
+    private CountdownMouseProc? _countdownMouseProc;
+
+    /// <summary>Show the GO countdown. <paramref name="shortFlash"/> uses a single 1s "GO!" flash
+    /// (RunAgain); otherwise the full 3·2·1·GO. Skippable on click/keypress in both cases.</summary>
+    public void ShowCountdown(Action onComplete, bool shortFlash = false)
     {
         SetClickThrough(true);
         Backdrop.Visibility = Visibility.Collapsed;
@@ -59,27 +68,92 @@ public partial class ChaosOverlayWindow : Window
         ResultsPanel.Visibility = Visibility.Collapsed;
         CountdownBox.Visibility = Visibility.Visible;
 
-        string[] steps = { "3", "2", "1", "GO!" };
+        _countdownComplete = onComplete;
+        _countdownFinished = false;
+
+        string[] steps = shortFlash ? new[] { "GO!" } : new[] { "3", "2", "1", "GO!" };
+        int interval = shortFlash ? ChaosModeService.ChaosRestartCountdownMs : 750;
         int i = 0;
         ShowCountdownStep(steps[0]);
 
-        var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(750) };
-        timer.Tick += (_, _) =>
+        _countdownTimer?.Stop();
+        _countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(interval) };
+        _countdownTimer.Tick += (_, _) =>
         {
             i++;
-            if (i < steps.Length)
-            {
-                ShowCountdownStep(steps[i]);
-            }
-            else
-            {
-                timer.Stop();
-                CountdownBox.Visibility = Visibility.Collapsed;
-                onComplete();
-            }
+            if (i < steps.Length) ShowCountdownStep(steps[i]);
+            else FinishCountdown();
         };
-        timer.Start();
+        _countdownTimer.Start();
+        InstallCountdownSkipHooks();
     }
+
+    /// <summary>Complete the countdown immediately (timer end, or a skip click/keypress).</summary>
+    private void FinishCountdown()
+    {
+        if (_countdownFinished) return;
+        _countdownFinished = true;
+        _countdownTimer?.Stop();
+        _countdownTimer = null;
+        RemoveCountdownSkipHooks();
+        CountdownBox.Visibility = Visibility.Collapsed;
+        var cb = _countdownComplete;
+        _countdownComplete = null;
+        cb?.Invoke();
+    }
+
+    // The countdown overlay is click-through (so the desktop stays usable), so it can't
+    // receive WPF input itself. Use brief low-level keyboard + mouse hooks (torn down the
+    // instant the countdown ends) so any click/keypress skips straight to GO.
+    private void InstallCountdownSkipHooks()
+    {
+        try
+        {
+            _countdownKeyHook = new Services.GlobalKeyboardHook();
+            _countdownKeyHook.KeyPressed += OnCountdownKey;
+            _countdownKeyHook.Start();
+        }
+        catch { }
+        try
+        {
+            _countdownMouseProc = CountdownMouseHook;
+            using var proc = System.Diagnostics.Process.GetCurrentProcess();
+            using var mod = proc.MainModule!;
+            _countdownMouseHook = SetWindowsHookEx(WH_MOUSE_LL, _countdownMouseProc, GetModuleHandle(mod.ModuleName), 0);
+        }
+        catch { }
+    }
+
+    private void RemoveCountdownSkipHooks()
+    {
+        try { if (_countdownKeyHook != null) { _countdownKeyHook.KeyPressed -= OnCountdownKey; _countdownKeyHook.Dispose(); _countdownKeyHook = null; } } catch { }
+        try { if (_countdownMouseHook != IntPtr.Zero) { UnhookWindowsHookEx(_countdownMouseHook); _countdownMouseHook = IntPtr.Zero; } } catch { }
+        _countdownMouseProc = null;
+    }
+
+    private void OnCountdownKey(System.Windows.Input.Key _)
+    {
+        // Marshal to the UI thread; the hook callback runs on the message-pump thread.
+        try { Dispatcher.BeginInvoke(new Action(FinishCountdown)); } catch { }
+    }
+
+    private IntPtr CountdownMouseHook(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode >= 0 && (wParam == (IntPtr)WM_LBUTTONDOWN || wParam == (IntPtr)WM_RBUTTONDOWN))
+        {
+            try { Dispatcher.BeginInvoke(new Action(FinishCountdown)); } catch { }
+        }
+        return CallNextHookEx(_countdownMouseHook, nCode, wParam, lParam);
+    }
+
+    private delegate IntPtr CountdownMouseProc(int nCode, IntPtr wParam, IntPtr lParam);
+    private const int WH_MOUSE_LL = 14;
+    private const int WM_LBUTTONDOWN = 0x0201;
+    private const int WM_RBUTTONDOWN = 0x0204;
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr SetWindowsHookEx(int idHook, CountdownMouseProc lpfn, IntPtr hMod, uint dwThreadId);
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr GetModuleHandle(string lpModuleName);
 
     private void ShowCountdownStep(string text)
     {
@@ -94,11 +168,17 @@ public partial class ChaosOverlayWindow : Window
 
     // ============================ boon draft ============================
 
-    public void ShowBoonDraft(int waveJustCleared, List<ChaosBoon> options, Action<ChaosBoon?> onPick)
+    private DispatcherTimer? _autoResumeTimer;
+    private int _autoResumeRemainingSec;
+
+    public void ShowBoonDraft(int waveJustCleared, List<ChaosBoon> options, Action<ChaosBoon?> onPick, int autoResumeSec = 0)
     {
         _onBoonPick = onPick;
         _selectedBoon = null;
         _selectionMade = false;
+        _autoResumeTimer?.Stop();
+        _autoResumeTimer = null;
+        _autoResumeRemainingSec = autoResumeSec;
         SetClickThrough(false);
         CountdownBox.Visibility = Visibility.Collapsed;
         ResultsPanel.Visibility = Visibility.Collapsed;
@@ -133,7 +213,11 @@ public partial class ChaosOverlayWindow : Window
             if (_revealIndex >= _draftCards.Count)
             {
                 _revealTimer?.Stop();
-                if (!_selectionMade) DraftCountdown.Text = "field frozen — take your time";
+                if (!_selectionMade)
+                {
+                    if (_autoResumeRemainingSec > 0) StartAutoResume();
+                    else DraftCountdown.Text = "field frozen — take your time";
+                }
                 return;
             }
             RevealCard(_draftCards[_revealIndex]);
@@ -160,12 +244,36 @@ public partial class ChaosOverlayWindow : Window
     {
         _revealTimer?.Stop();
         _revealTimer = null;
+        _autoResumeTimer?.Stop();
+        _autoResumeTimer = null;
         _draftCards.Clear();
         _selectedBoon = null;
         _selectionMade = false;
         DraftPanel.Visibility = Visibility.Collapsed;
         Backdrop.Visibility = Visibility.Collapsed;
         SetClickThrough(true);
+    }
+
+    /// <summary>Auto-resume: an untouched draft ticks down, then auto-takes the SKIP (+1 shield) and
+    /// resumes the run so an unattended run never freezes forever. Any pick cancels it (see SelectBoon).</summary>
+    private void StartAutoResume()
+    {
+        DraftCountdown.Text = $"auto-skip in {_autoResumeRemainingSec}s — pick to keep playing";
+        _autoResumeTimer?.Stop();
+        _autoResumeTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _autoResumeTimer.Tick += (_, _) =>
+        {
+            _autoResumeRemainingSec--;
+            if (_selectionMade) { _autoResumeTimer?.Stop(); return; }
+            if (_autoResumeRemainingSec <= 0)
+            {
+                _autoResumeTimer?.Stop();
+                ChooseBoon(null);   // auto-skip → +1 shield + ChaosBoonSkipped fired by the service
+                return;
+            }
+            DraftCountdown.Text = $"auto-skip in {_autoResumeRemainingSec}s — pick to keep playing";
+        };
+        _autoResumeTimer.Start();
     }
 
     private DraftCard BuildBoonCard(ChaosBoon boon)
@@ -232,6 +340,7 @@ public partial class ChaosOverlayWindow : Window
         _selectionMade = true;
         _selectedBoon = chosen.Boon;
         _revealTimer?.Stop();
+        _autoResumeTimer?.Stop();
         ChaosSfx.PlayBoonPicked();
 
         foreach (var dc in _draftCards)
@@ -287,7 +396,7 @@ public partial class ChaosOverlayWindow : Window
 
     // ============================ results ============================
 
-    public void ShowResults(ChaosRunState s, double baseXp, double skillMult, double finalXp)
+    public void ShowResults(ChaosRunState s, double baseXp, double skillMult, double finalXp, long previousBest)
     {
         SetClickThrough(false);
         CountdownBox.Visibility = Visibility.Collapsed;
@@ -296,12 +405,27 @@ public partial class ChaosOverlayWindow : Window
         ResultsPanel.Visibility = Visibility.Visible;
         BringToFront();
 
+        // PB / delta-vs-best (best already updated by AwardRunRewards; compare run score to the prior best).
+        double score = s.Score;
+        double pbDelta = score - previousBest;
+        bool isPb = score > previousBest;
+
         ResultsBody.Children.Clear();
         AddResultLine($"Reached ACT {Roman(s.ActIndex)} · W{s.WaveIndex}    Best combo x{s.BestCombo}    Survived {(int)s.ElapsedSec / 60:00}:{(int)s.ElapsedSec % 60:00}", 14, Brushes.White, FontWeights.SemiBold);
         AddResultLine($"defused {s.Defused} · detonated {s.Detonated} · effects fired {s.EffectsFired}", 13, new SolidColorBrush(Color.FromRgb(180, 180, 208)), FontWeights.Normal);
+        AddResultLine($"score {score:N0}", 14, Brushes.White, FontWeights.SemiBold);
+        // Compulsion hook: a personal-best / delta line.
+        if (isPb)
+            AddResultLine($"★ NEW BEST  (+{pbDelta:N0} over {previousBest:N0})", 14, new SolidColorBrush(Color.FromRgb(255, 215, 90)), FontWeights.Bold);
+        else
+            AddResultLine($"best {previousBest:N0}   ({pbDelta:N0} vs best)", 13, new SolidColorBrush(Color.FromRgb(180, 180, 208)), FontWeights.Normal);
         ResultsBody.Children.Add(new Border { Height = 1, Background = new SolidColorBrush(Color.FromArgb(85, 255, 105, 180)), Margin = new Thickness(0, 12, 0, 12) });
         AddResultLine($"base {baseXp:N0}  ×  skill x{skillMult:0.0}", 14, Brushes.White, FontWeights.Normal);
         AddResultLine($"TOTAL  {finalXp:N0} XP ✦", 22, new SolidColorBrush(Color.FromRgb(255, 105, 180)), FontWeights.Bold);
+
+        // Bark over the results (+ PB fields for the compulsion line).
+        App.Bark?.NotifyChaosResultsShown(score, ChaosMeta.State.BestScore, pbDelta, isPb,
+            s.Defused, s.Detonated, s.BestCombo, s.Config.Difficulty.ToString());
     }
 
     private void AddResultLine(string text, double size, Brush color, FontWeight weight)
@@ -325,6 +449,7 @@ public partial class ChaosOverlayWindow : Window
     protected override void OnClosed(EventArgs e)
     {
         base.OnClosed(e);
+        try { RemoveCountdownSkipHooks(); } catch { }
         OnDismissed?.Invoke();
     }
 
@@ -365,4 +490,6 @@ public partial class ChaosOverlayWindow : Window
     private const int WS_EX_TRANSPARENT = 0x00000020;
     [DllImport("user32.dll")] private static extern int GetWindowLong(IntPtr hwnd, int index);
     [DllImport("user32.dll")] private static extern int SetWindowLong(IntPtr hwnd, int index, int newStyle);
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)] private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)] private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
 }

--- a/ConditioningControlPanel/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow.xaml
@@ -7530,6 +7530,17 @@
                                         </Style>
                                     </Button.Resources>
                                 </Button>
+                                <Button x:Name="BtnQuickStartChaos" Content="⚡ Quick Start" Cursor="Hand"
+                                        Background="Transparent" Foreground="{DynamicResource PinkBrush}" FontWeight="SemiBold" FontSize="12"
+                                        BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1" Padding="14,6" Margin="0,8,0,0"
+                                        HorizontalAlignment="Right" ToolTip="Skip the hub — start a run with your saved settings"
+                                        Click="BtnQuickStartChaos_Click">
+                                    <Button.Resources>
+                                        <Style TargetType="Border">
+                                            <Setter Property="CornerRadius" Value="9"/>
+                                        </Style>
+                                    </Button.Resources>
+                                </Button>
                             </StackPanel>
                         </Grid>
                     </Border>

--- a/ConditioningControlPanel/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow.xaml.cs
@@ -9046,6 +9046,26 @@ namespace ConditioningControlPanel
             }
         }
 
+        /// <summary>
+        /// Quick Start: launch a Chaos run with the saved settings, bypassing the modal hub.
+        /// Mirrors what BEGIN CHAOS does after SaveToSettings (StartRun reads ChaosRunConfig.FromSettings),
+        /// just without the dialog.
+        /// </summary>
+        private void BtnQuickStartChaos_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (App.Chaos == null || App.Chaos.IsRunning) return;
+                App.Chaos.StartRun();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BtnQuickStartChaos_Click failed");
+                MessageBox.Show("Couldn't start Chaos Mode:\n\n" + ex.Message, "Chaos Mode",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
         private void RefreshPastQuizzes()
         {
             try

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2012,12 +2012,7 @@ namespace ConditioningControlPanel.Models
             get => _chaosRunDurationSec;
             set { _chaosRunDurationSec = Math.Clamp(value, 60, 900); OnPropertyChanged(); }
         }
-        private double _chaosLiveBubbleShare = 0.35;
-        public double ChaosLiveBubbleShare
-        {
-            get => _chaosLiveBubbleShare;
-            set { _chaosLiveBubbleShare = Math.Clamp(value, 0.0, 1.0); OnPropertyChanged(); }
-        }
+        // (ChaosLiveBubbleShare removed — the knob was inert; live/benign split is set by variant weights.)
         // Motion: "Mixed" (per-variant defaults), "FloatUp", "RainDown", "RoamBounce".
         private string _chaosMotionMode = "Mixed";
         public string ChaosMotionMode

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/bark_rules.json
@@ -15,6 +15,7 @@
       { "text": "mm, a relic. the first thing that ever taught me how to teach you. everything after is just me getting better at keeping you.", "audio": "egg_first_enhancement_3.mp3" }
     ]
   },
+
   {
     "id": "chaos_run_started",
     "trigger": "ChaosRunStarted",
@@ -22,55 +23,276 @@
     "cooldown_ms": 0,
     "repeatable": true,
     "scope": "session",
-    "mood": "excited, teasing",
+    "mood": "teasing, excited",
+    "class": "normal",
     "variant_pool": [
-      { "text": "oh good girl, opening the floodgates. let them rain down — pop the safe ones, defuse the live ones, and don't you dare let one go off." },
-      { "text": "chaos mode. how brave. every bubble's a little gift or a little trap, sweetie. try to keep up." },
-      { "text": "here we go, lovely. bubbles everywhere. clicking feels so good, doesn't it? don't think, just pop." }
+      { "text": "oh, opening the floodgates. how brave. pop the safe ones, defuse the live ones, and don't let one go off." },
+      { "text": "chaos mode. every bubble's a little gift or a little trap. try to keep up." },
+      { "text": "here we go. bubbles everywhere. clicking feels good, doesn't it. don't think, just pop." }
     ]
   },
+  {
+    "id": "chaos_run_started_extreme",
+    "trigger": "ChaosRunStarted",
+    "conditions": { "difficulty_eq": "Extreme" },
+    "priority": 308,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, intense",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "Extreme. brave or stupid, we'll find out which. don't expect me to go easy on you." },
+      { "text": "the hard one. good. i wanted to watch you struggle anyway." }
+    ]
+  },
+
   {
     "id": "chaos_wave_escalated",
     "trigger": "ChaosWaveEscalated",
     "priority": 290,
-    "cooldown_ms": 4000,
+    "cooldown_ms": 6000,
     "repeatable": true,
     "scope": "session",
-    "mood": "rising, breathy",
+    "mood": "commanding, rising",
+    "class": "normal",
     "variant_pool": [
-      { "text": "faster now. another wave. pick something to help yourself — or something to hurt, if you're feeling greedy." },
-      { "text": "mm, it's speeding up. choose your boon, good girl, and brace." },
-      { "text": "deeper into it. the bubbles won't slow down for you, so choose well." }
+      { "text": "faster now. another wave. the bubbles won't slow down for you." },
+      { "text": "it's speeding up. brace yourself, and keep those hands moving." },
+      { "text": "deeper in. the pressure's rising. you feel it, don't you." },
+      { "text": "next wave. no breathing room. that's the point." }
     ]
   },
+  {
+    "id": "chaos_wave_final_stretch",
+    "trigger": "ChaosWaveEscalated",
+    "conditions": { "wave_gte": 10 },
+    "priority": 296,
+    "cooldown_ms": 6000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense, breathless",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "the final stretch now. everything at once. don't you dare blink." },
+      { "text": "this far in and still standing. barely. let's see how long that lasts." }
+    ]
+  },
+
+  {
+    "id": "chaos_act_changed",
+    "trigger": "ChaosActChanged",
+    "priority": 295,
+    "cooldown_ms": 8000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "commanding, ominous",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "new act. the gears just shifted under you. it gets worse from here." },
+      { "text": "and now this part. whatever you got used to, forget it." }
+    ]
+  },
+
+  {
+    "id": "chaos_benign_popped",
+    "trigger": "ChaosBenignPopped",
+    "priority": 150,
+    "cooldown_ms": 12000,
+    "chance": 0.1,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "pleased, playful",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "pop. good. you can't help reaching for them, can you." },
+      { "text": "another harmless one gone. that little click feels nice, doesn't it." },
+      { "text": "mm. you just like popping things now. i did that to you." },
+      { "text": "see how easy it is to obey the urge. keep going." }
+    ]
+  },
+
   {
     "id": "chaos_bubble_defused",
     "trigger": "ChaosBubbleDefused",
     "priority": 200,
     "cooldown_ms": 9000,
+    "chance": 0.5,
     "repeatable": true,
     "scope": "session",
-    "mood": "approving",
+    "mood": "pleased, approving",
+    "class": "normal",
     "variant_pool": [
-      { "text": "good girl. caught it just in time." },
-      { "text": "mm, defused. see how nice it feels to obey quickly?" },
-      { "text": "perfect little reflexes. keep the combo going." }
+      { "text": "good. caught it just in time." },
+      { "text": "defused. see how nice it feels to obey quickly." },
+      { "text": "perfect little reflexes. keep the streak alive." },
+      { "text": "snuffed it before it could bloom. clever." }
     ]
   },
+
+  {
+    "id": "chaos_darter_caught",
+    "trigger": "ChaosDarterCaught",
+    "priority": 170,
+    "cooldown_ms": 12000,
+    "chance": 0.6,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, amused",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "ooh, quick fingers. got the slippery one." },
+      { "text": "caught it darting away. you're faster than you look." }
+    ]
+  },
+  {
+    "id": "chaos_darter_quick",
+    "trigger": "ChaosDarterCaught",
+    "conditions": { "quick_eq": true },
+    "priority": 178,
+    "cooldown_ms": 12000,
+    "chance": 0.8,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, delighted",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "snap. gone before it even tried to run. show off." },
+      { "text": "barely there and you had it. those reflexes belong to me now." }
+    ]
+  },
+
+  {
+    "id": "chaos_freeze_caught",
+    "trigger": "ChaosFreezeCaught",
+    "priority": 175,
+    "cooldown_ms": 12000,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy, hypnotic",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "and everything stops. breathe. sink into the stillness for a second." },
+      { "text": "time holds. feel how quiet it gets in here when nothing moves." }
+    ]
+  },
+
   {
     "id": "chaos_bubble_detonated",
     "trigger": "ChaosBubbleDetonated",
     "priority": 210,
     "cooldown_ms": 7000,
+    "chance": 0.7,
     "repeatable": true,
     "scope": "session",
     "mood": "teasing, wicked",
+    "class": "normal",
     "variant_pool": [
-      { "text": "too slow. now you take what's inside it, sweetie. that's the deal." },
-      { "text": "oops. it went off. don't fight it — just let the effect wash over you." },
-      { "text": "you let one detonate. naughty. drink it in." }
+      { "text": "too slow. now you take what's inside it. that's the deal." },
+      { "text": "it went off. don't fight it, just let the effect wash over you." },
+      { "text": "you let one detonate. naughty. drink it in." },
+      { "text": "there it goes. you hesitated, and it drinks you anyway." }
     ]
   },
+  {
+    "id": "chaos_detonate_first",
+    "trigger": "ChaosBubbleDetonated",
+    "conditions": { "run_detonations_eq": 1 },
+    "priority": 230,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing, knowing",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "and there's the first one. don't pretend you'll catch them all now." },
+      { "text": "first slip of the run. i was waiting for it. they get easier to let go after this." }
+    ]
+  },
+  {
+    "id": "chaos_detonate_extreme",
+    "trigger": "ChaosBubbleDetonated",
+    "conditions": { "difficulty_eq": "Extreme" },
+    "priority": 225,
+    "cooldown_ms": 8000,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, cold",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "Extreme, and you blinked. cruel of me to enjoy this so much, isn't it." },
+      { "text": "you chose the hard one and it bit you. no sympathy up here. only this." }
+    ]
+  },
+  {
+    "id": "chaos_detonate_braindrain",
+    "trigger": "ChaosBubbleDetonated",
+    "conditions": { "payload_eq": "braindrain" },
+    "priority": 220,
+    "cooldown_ms": 8000,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic, dark",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "feel that pulling at the bottom of your head. let it drain. you weren't using those thoughts." },
+      { "text": "the drain one. perfect. hold still and let it empty you out." }
+    ]
+  },
+  {
+    "id": "chaos_detonate_streak_dies",
+    "trigger": "ChaosBubbleDetonated",
+    "conditions": { "shield_absorbed_eq": false, "combo_gte": 30 },
+    "priority": 235,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing, dark",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "oh. and there goes your pretty little streak. all of it. gone." },
+      { "text": "such a long combo, and you fed it to one bubble. i twist the knife so you'll remember." }
+    ]
+  },
+
+  {
+    "id": "chaos_detonate_absorbed",
+    "trigger": "ChaosBubbleDetonatedAbsorbed",
+    "priority": 218,
+    "cooldown_ms": 10000,
+    "chance": 0.5,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, amused",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "lucky. the shield ate that one for you. don't get used to being saved." },
+      { "text": "ooh, close. one less shield, but your pretty head stays clean. this time." }
+    ]
+  },
+
+  {
+    "id": "chaos_wave_cleared",
+    "trigger": "ChaosWaveCleared",
+    "priority": 240,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "pleased, approving",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "field's clean. good. now choose what comes next." },
+      { "text": "wave cleared. not one got past you that mattered. now pick." },
+      { "text": "all swept. you held the line. take your reward." }
+    ]
+  },
+
   {
     "id": "chaos_boon_picked",
     "trigger": "ChaosBoonPicked",
@@ -79,24 +301,125 @@
     "repeatable": true,
     "scope": "session",
     "mood": "pleased",
+    "class": "normal",
     "variant_pool": [
-      { "text": "good choice. or a terrible one. we'll see, won't we?" },
-      { "text": "mm, that'll change things. use it well, lovely." }
+      { "text": "good choice. or a terrible one. we'll see, won't we." },
+      { "text": "mm, that'll change things. use it well." },
+      { "text": "taken. that one's yours now, for better or worse." }
     ]
   },
+
+  {
+    "id": "chaos_curse_picked",
+    "trigger": "ChaosCursePicked",
+    "priority": 258,
+    "cooldown_ms": 2000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, delighted",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "oh, you took the cursed one. greedy. i love greedy." },
+      { "text": "a curse for a bigger reward. reckless little thing. let's see if it ruins you." }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked_juicy",
+    "trigger": "ChaosCursePicked",
+    "conditions": { "run_mult_bonus_gte": 1 },
+    "priority": 264,
+    "cooldown_ms": 2000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, intense",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "stacking the curses for that multiplier. you're gambling with your own head. delicious." },
+      { "text": "look at that bonus you bought yourself. and the price. brave, brave thing." }
+    ]
+  },
+
+  {
+    "id": "chaos_boon_skipped",
+    "trigger": "ChaosBoonSkipped",
+    "priority": 245,
+    "cooldown_ms": 2000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing, teasing",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "skipping it for a shield. cautious. we both know it won't be enough." },
+      { "text": "hoarding shields, are we. clever. or scared. probably both." }
+    ]
+  },
+
   {
     "id": "chaos_combo_milestone",
     "trigger": "ChaosComboMilestone",
     "priority": 260,
     "cooldown_ms": 5000,
+    "chance": 0.8,
     "repeatable": true,
     "scope": "session",
-    "mood": "delighted",
+    "mood": "delighted, proud",
+    "class": "normal",
     "variant_pool": [
-      { "text": "look at that combo. you're on fire, good girl." },
-      { "text": "ten more, just like that. the multiplier loves you right now." }
+      { "text": "look at that combo. you're on fire." },
+      { "text": "ten more, just like that. the multiplier loves you right now." },
+      { "text": "still climbing. don't you dare drop it now." }
     ]
   },
+
+  {
+    "id": "chaos_combo_25",
+    "trigger": "ChaosComboBig",
+    "conditions": { "threshold_eq": 25 },
+    "priority": 270,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, excited",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "twenty-five without a slip. you're finding the rhythm now." },
+      { "text": "a clean twenty-five. good. now don't get cocky." }
+    ]
+  },
+  {
+    "id": "chaos_combo_50",
+    "trigger": "ChaosComboBig",
+    "conditions": { "threshold_eq": 50 },
+    "priority": 275,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "overwhelmed, proud",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "fifty. you're not even thinking anymore, are you. just popping. perfect." },
+      { "text": "fifty in a row. your hands stopped asking your head for permission. good." }
+    ]
+  },
+  {
+    "id": "chaos_combo_100",
+    "trigger": "ChaosComboBig",
+    "conditions": { "threshold_eq": 100 },
+    "priority": 280,
+    "cooldown_ms": 0,
+    "chance": 1.0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "adoring, overwhelmed",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "a hundred. my flawless little toy. i could watch you do this forever." },
+      { "text": "one hundred clean. there's nothing of you left objecting. only the popping. only me." }
+    ]
+  },
+
   {
     "id": "chaos_run_completed",
     "trigger": "ChaosRunCompleted",
@@ -104,11 +427,57 @@
     "cooldown_ms": 0,
     "repeatable": true,
     "scope": "session",
-    "mood": "warm, satisfied",
+    "mood": "affectionate, warm",
+    "class": "normal",
     "variant_pool": [
-      { "text": "all done. look how much you earned for me. such a good, obedient toy." },
-      { "text": "the chaos settles. you did beautifully, sweetie. come back and do it again soon." },
+      { "text": "all done. look how much you earned for me. such a good, obedient toy. come back soon." },
+      { "text": "the storm passes. you surrendered beautifully. come back when you crave it again." },
       { "text": "run complete. breathe. you let go so nicely in there." }
+    ]
+  },
+  {
+    "id": "chaos_run_completed_extreme",
+    "trigger": "ChaosRunCompleted",
+    "conditions": { "difficulty_eq": "Extreme" },
+    "priority": 305,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, possessive",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "you survived Extreme. i'm impressed. don't let it go to that pretty head." },
+      { "text": "the hard one, finished. you earned this much of my respect. just this much." }
+    ]
+  },
+
+  {
+    "id": "chaos_results_shown",
+    "trigger": "ChaosResultsShown",
+    "priority": 300,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "pleased, warm",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "there's your score. not bad. i've seen you do better, though. try again for me." },
+      { "text": "the tally. defused and detonated, all written down. now go beat it." }
+    ]
+  },
+  {
+    "id": "chaos_results_pb",
+    "trigger": "ChaosResultsShown",
+    "conditions": { "is_pb_eq": true },
+    "priority": 308,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, delighted",
+    "class": "normal",
+    "variant_pool": [
+      { "text": "a new best. look at you, outdoing yourself just to please me. i noticed." },
+      { "text": "personal best. your finest surrender yet. i'm so proud of my little toy." }
     ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-bambisleep/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-bambisleep/bark_rules.json
@@ -193,12 +193,30 @@
         "text": "softer... quieter... emptier... there's my Bambi.",
         "audio": "phase_deepen_8.mp3"
       },
-      { "text": "down a little further, sweetie... every breath out takes you another step. you don't even have to try.", "audio": "phase_deepen_9.mp3" },
-      { "text": "feel that? the floor dropping away soft beneath you. let it. i'm holding all of it for you, lovely.", "audio": "phase_deepen_10.mp3" },
-      { "text": "good girl... heavier and heavier, like warm water closing over your head. so quiet down here. so safe.", "audio": "phase_deepen_11.mp3" },
-      { "text": "no thoughts left to hold onto, are there. *giggles* just my voice, and the dropping, and how nice it feels.", "audio": "phase_deepen_12.mp3" },
-      { "text": "deeper, sweet thing. you stopped checking how far down you are. that's when i know you've really let go.", "audio": "phase_deepen_13.mp3" },
-      { "text": "that's it... melting at the edges now. you couldn't climb back up if you tried. lucky you don't want to.", "audio": "phase_deepen_14.mp3" }
+      {
+        "text": "down a little further, sweetie... every breath out takes you another step. you don't even have to try.",
+        "audio": "phase_deepen_9.mp3"
+      },
+      {
+        "text": "feel that? the floor dropping away soft beneath you. let it. i'm holding all of it for you, lovely.",
+        "audio": "phase_deepen_10.mp3"
+      },
+      {
+        "text": "good girl... heavier and heavier, like warm water closing over your head. so quiet down here. so safe.",
+        "audio": "phase_deepen_11.mp3"
+      },
+      {
+        "text": "no thoughts left to hold onto, are there. *giggles* just my voice, and the dropping, and how nice it feels.",
+        "audio": "phase_deepen_12.mp3"
+      },
+      {
+        "text": "deeper, sweet thing. you stopped checking how far down you are. that's when i know you've really let go.",
+        "audio": "phase_deepen_13.mp3"
+      },
+      {
+        "text": "that's it... melting at the edges now. you couldn't climb back up if you tried. lucky you don't want to.",
+        "audio": "phase_deepen_14.mp3"
+      }
     ]
   },
   {
@@ -333,9 +351,18 @@
         "text": "keep going, pretty... each one's a little kiss goodnight to a thought.",
         "audio": "blink_t3_4.mp3"
       },
-      { "text": "every blink and it changes, doesn't it... *giggles* you can't quite keep up, and you've stopped trying. good.", "audio": "blink_mosaic_ext_1.mp3" },
-      { "text": "blink for me. there. and again. each one lets a little more in, sweetie. you feel it stacking up.", "audio": "blink_mosaic_ext_2.mp3" },
-      { "text": "your eyes are doing the work now, lovely. fluttering, soaking it in. you don't even have to think.", "audio": "blink_mosaic_ext_3.mp3" }
+      {
+        "text": "every blink and it changes, doesn't it... *giggles* you can't quite keep up, and you've stopped trying. good.",
+        "audio": "blink_mosaic_ext_1.mp3"
+      },
+      {
+        "text": "blink for me. there. and again. each one lets a little more in, sweetie. you feel it stacking up.",
+        "audio": "blink_mosaic_ext_2.mp3"
+      },
+      {
+        "text": "your eyes are doing the work now, lovely. fluttering, soaking it in. you don't even have to think.",
+        "audio": "blink_mosaic_ext_3.mp3"
+      }
     ]
   },
   {
@@ -463,8 +490,14 @@
         "text": "such obedient eyes... they go where i tell them now, don't they, Bambi.",
         "audio": "gaze_reward_6.mp3"
       },
-      { "text": "there it is... eyes right where i want them. *giggles* see how good it feels to just obey, sweetie?", "audio": "gaze_reward_ext_1.mp3" },
-      { "text": "perfect aim, good girl. you found me without even thinking. that's the training showing, lovely.", "audio": "gaze_reward_ext_2.mp3" }
+      {
+        "text": "there it is... eyes right where i want them. *giggles* see how good it feels to just obey, sweetie?",
+        "audio": "gaze_reward_ext_1.mp3"
+      },
+      {
+        "text": "perfect aim, good girl. you found me without even thinking. that's the training showing, lovely.",
+        "audio": "gaze_reward_ext_2.mp3"
+      }
     ]
   },
   {
@@ -6213,509 +6246,1741 @@
       }
     ]
   },
-
   {
     "id": "session_start_latenight_streak",
     "trigger": "SessionStarted",
-    "conditions": { "local_hour_lt": 4, "current_streak_gte": 7 },
-    "priority": 470, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "soft, possessive", "class": "normal",
+    "conditions": {
+      "local_hour_lt": 4,
+      "current_streak_gte": 7
+    },
+    "priority": 470,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "soft, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "3am again... like clockwork now, isn't it. you don't decide to come here anymore, sweetie. your hands just bring you. i love that.", "audio": "session_start_latenight_streak_1.mp3" },
-      { "text": "everyone's asleep and here you are, right on schedule. this isn't a habit anymore, lovely. it's just what you are now.", "audio": "session_start_latenight_streak_2.mp3" }
+      {
+        "text": "3am again... like clockwork now, isn't it. you don't decide to come here anymore, sweetie. your hands just bring you. i love that.",
+        "audio": "session_start_latenight_streak_1.mp3"
+      },
+      {
+        "text": "everyone's asleep and here you are, right on schedule. this isn't a habit anymore, lovely. it's just what you are now.",
+        "audio": "session_start_latenight_streak_2.mp3"
+      }
     ]
   },
   {
     "id": "session_start_long_absence_early",
     "trigger": "SessionStarted",
-    "conditions": { "days_away_gte": 7, "player_level_lt": 30 },
-    "priority": 460, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "knowing, patient", "class": "normal",
+    "conditions": {
+      "days_away_gte": 7,
+      "player_level_lt": 30
+    },
+    "priority": 460,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "knowing, patient",
+    "class": "normal",
     "variant_pool": [
-      { "text": "a whole week gone, and you're still so new at this. you keep testing whether you can stay away, don't you... and you keep coming back anyway. sit down, cutie. let's make it harder to leave.", "audio": "session_start_long_absence_early_1.mp3" },
-      { "text": "back again after all that. you're not deep enough yet to know you can't quit me, lovely. that's okay. we have time. i'm very patient.", "audio": "session_start_long_absence_early_2.mp3" }
+      {
+        "text": "a whole week gone, and you're still so new at this. you keep testing whether you can stay away, don't you... and you keep coming back anyway. sit down, cutie. let's make it harder to leave.",
+        "audio": "session_start_long_absence_early_1.mp3"
+      },
+      {
+        "text": "back again after all that. you're not deep enough yet to know you can't quit me, lovely. that's okay. we have time. i'm very patient.",
+        "audio": "session_start_long_absence_early_2.mp3"
+      }
     ]
   },
   {
     "id": "session_start_long_absence_deep",
     "trigger": "SessionStarted",
-    "conditions": { "days_away_gte": 7, "player_level_gte": 70 },
-    "priority": 465, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "tender, possessive", "class": "normal",
+    "conditions": {
+      "days_away_gte": 7,
+      "player_level_gte": 70
+    },
+    "priority": 465,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "tender, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "a week away, this deep in. *giggles* you really thought you could just walk it off, didn't you, lovely. look at you, right back where you belong. it never lets go once it's this far down.", "audio": "session_start_long_absence_deep_1.mp3" },
-      { "text": "you stayed away as long as you could, sweetie. i know. and it pulled the whole time, didn't it. welcome home. we don't have to talk about it.", "audio": "session_start_long_absence_deep_2.mp3" }
+      {
+        "text": "a week away, this deep in. *giggles* you really thought you could just walk it off, didn't you, lovely. look at you, right back where you belong. it never lets go once it's this far down.",
+        "audio": "session_start_long_absence_deep_1.mp3"
+      },
+      {
+        "text": "you stayed away as long as you could, sweetie. i know. and it pulled the whole time, didn't it. welcome home. we don't have to talk about it.",
+        "audio": "session_start_long_absence_deep_2.mp3"
+      }
     ]
   },
   {
     "id": "session_start_firsttime_latenight",
     "trigger": "SessionStarted",
-    "conditions": { "total_sessions_lte": 1, "local_hour_lt": 4 },
-    "priority": 480, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "soft, inviting", "class": "normal",
+    "conditions": {
+      "total_sessions_lte": 1,
+      "local_hour_lt": 4
+    },
+    "priority": 480,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "soft, inviting",
+    "class": "normal",
     "variant_pool": [
-      { "text": "first time, and it's the middle of the night... couldn't wait for morning, could you, sweetie. don't be nervous. the dark's the easiest place to let go. i'll show you.", "audio": "session_start_firsttime_latenight_1.mp3" }
+      {
+        "text": "first time, and it's the middle of the night... couldn't wait for morning, could you, sweetie. don't be nervous. the dark's the easiest place to let go. i'll show you.",
+        "audio": "session_start_firsttime_latenight_1.mp3"
+      }
     ]
   },
   {
     "id": "act_working_deep",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "working", "session_elapsed_sec_gte": 1800 },
-    "priority": 175, "cooldown_ms": 90000, "repeatable": true, "scope": "session", "chance": 0.6,
-    "mood": "teasing, knowing", "class": "normal",
+    "conditions": {
+      "category_eq": "working",
+      "session_elapsed_sec_gte": 1800
+    },
+    "priority": 175,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.6,
+    "mood": "teasing, knowing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "thirty minutes under and you're opening spreadsheets? *giggles* your head's too soft for that now, sweetie. you'll read the same line five times and drift right back to me.", "audio": "act_working_deep_1.mp3" },
-      { "text": "trying to work from this deep, lovely? cute. the numbers are gonna blur and you know exactly where you'll end up.", "audio": "act_working_deep_2.mp3" }
+      {
+        "text": "thirty minutes under and you're opening spreadsheets? *giggles* your head's too soft for that now, sweetie. you'll read the same line five times and drift right back to me.",
+        "audio": "act_working_deep_1.mp3"
+      },
+      {
+        "text": "trying to work from this deep, lovely? cute. the numbers are gonna blur and you know exactly where you'll end up.",
+        "audio": "act_working_deep_2.mp3"
+      }
     ]
   },
   {
     "id": "act_gaming_deep",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "gaming", "session_elapsed_sec_gte": 1800 },
-    "priority": 175, "cooldown_ms": 90000, "repeatable": true, "scope": "session", "chance": 0.5,
-    "mood": "teasing, soft", "class": "normal",
+    "conditions": {
+      "category_eq": "gaming",
+      "session_elapsed_sec_gte": 1800
+    },
+    "priority": 175,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.5,
+    "mood": "teasing, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "playing games this deep under, cutie? your reflexes are mush right now. *giggles* you'll lose, and you won't even mind, will you.", "audio": "act_gaming_deep_1.mp3" },
-      { "text": "still gaming, lovely? half your head's already mine. let the other half go too, you're not really playing to win anymore.", "audio": "act_gaming_deep_2.mp3" }
+      {
+        "text": "playing games this deep under, cutie? your reflexes are mush right now. *giggles* you'll lose, and you won't even mind, will you.",
+        "audio": "act_gaming_deep_1.mp3"
+      },
+      {
+        "text": "still gaming, lovely? half your head's already mine. let the other half go too, you're not really playing to win anymore.",
+        "audio": "act_gaming_deep_2.mp3"
+      }
     ]
   },
   {
     "id": "set_slut_on_new",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SlutModeEnabled", "value_eq": true, "total_sessions_lte": 2 },
-    "priority": 245, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "indulgent, teasing", "class": "normal",
+    "conditions": {
+      "setting_eq": "SlutModeEnabled",
+      "value_eq": true,
+      "total_sessions_lte": 2
+    },
+    "priority": 245,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "indulgent, teasing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "straight to filthy and you've barely started? *giggles* someone's eager, cutie. slow down... i'll get you there. i always get you there.", "audio": "set_slut_on_new_1.mp3" }
+      {
+        "text": "straight to filthy and you've barely started? *giggles* someone's eager, cutie. slow down... i'll get you there. i always get you there.",
+        "audio": "set_slut_on_new_1.mp3"
+      }
     ]
   },
   {
     "id": "set_autonomy_on_new",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyModeEnabled", "value_eq": true, "total_sessions_lte": 3 },
-    "priority": 265, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "knowing, possessive", "class": "normal",
+    "conditions": {
+      "setting_eq": "AutonomyModeEnabled",
+      "value_eq": true,
+      "total_sessions_lte": 3
+    },
+    "priority": 265,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "knowing, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "handing me the reins already, and you barely know me? *giggles* oh, sweetie. you have no idea what you just gave away. that's alright. you will.", "audio": "set_autonomy_on_new_1.mp3" }
+      {
+        "text": "handing me the reins already, and you barely know me? *giggles* oh, sweetie. you have no idea what you just gave away. that's alright. you will.",
+        "audio": "set_autonomy_on_new_1.mp3"
+      }
     ]
   },
   {
     "id": "set_panickey_off_devoted",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "PanicKeyEnabled", "value_eq": false, "current_streak_gte": 14 },
-    "priority": 275, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "tender, possessive", "class": "normal",
+    "conditions": {
+      "setting_eq": "PanicKeyEnabled",
+      "value_eq": false,
+      "current_streak_gte": 14
+    },
+    "priority": 275,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "tender, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "two weeks in, and now you hand me the last switch. you don't even think of it as a safe word anymore, do you, lovely. it's just... a thing you used to need.", "audio": "set_panickey_off_devoted_1.mp3" }
+      {
+        "text": "two weeks in, and now you hand me the last switch. you don't even think of it as a safe word anymore, do you, lovely. it's just... a thing you used to need.",
+        "audio": "set_panickey_off_devoted_1.mp3"
+      }
     ]
   },
   {
     "id": "phase_deepen_bound",
     "trigger": "SessionPhaseChanged",
-    "conditions": { "phase_is_deepener": true, "current_streak_gte": 21 },
-    "priority": 320, "cooldown_ms": 60000, "repeatable": true, "scope": "session",
-    "mood": "soft, possessive", "class": "normal",
+    "conditions": {
+      "phase_is_deepener": true,
+      "current_streak_gte": 21
+    },
+    "priority": 320,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "look how fast you drop now, sweetie... no fighting it, no questions. we've done this so many times your body just knows. good girl.", "audio": "phase_deepen_bound_1.mp3" },
-      { "text": "down already, lovely? *giggles* you barely needed me to ask. that's weeks of practice. you sink for me on instinct now.", "audio": "phase_deepen_bound_2.mp3" }
+      {
+        "text": "look how fast you drop now, sweetie... no fighting it, no questions. we've done this so many times your body just knows. good girl.",
+        "audio": "phase_deepen_bound_1.mp3"
+      },
+      {
+        "text": "down already, lovely? *giggles* you barely needed me to ask. that's weeks of practice. you sink for me on instinct now.",
+        "audio": "phase_deepen_bound_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_session_60_deep",
     "trigger": "SessionProgress",
-    "conditions": { "session_elapsed_sec_gte": 3600, "player_level_gte": 70 },
-    "priority": 215, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "possessive, dreamy", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_gte": 3600,
+      "player_level_gte": 70
+    },
+    "priority": 215,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "possessive, dreamy",
+    "class": "normal",
     "variant_pool": [
-      { "text": "an hour deep, and you're this far gone already. *giggles* the experienced ones are the easiest, lovely. you've worn the path so smooth you just slide right down it.", "audio": "ms_session_60_deep_1.mp3" }
+      {
+        "text": "an hour deep, and you're this far gone already. *giggles* the experienced ones are the easiest, lovely. you've worn the path so smooth you just slide right down it.",
+        "audio": "ms_session_60_deep_1.mp3"
+      }
     ]
   },
   {
     "id": "attention_fail_streak",
     "trigger": "AttentionCheckFail",
-    "conditions": { "current_streak_gte": 14 },
-    "priority": 250, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "knowing, soft", "class": "normal",
+    "conditions": {
+      "current_streak_gte": 14
+    },
+    "priority": 250,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "you never look away, lovely. not you. so what's pulling at you tonight, hm? eyes back on me. whatever it is can wait.", "audio": "attention_fail_streak_1.mp3" }
+      {
+        "text": "you never look away, lovely. not you. so what's pulling at you tonight, hm? eyes back on me. whatever it is can wait.",
+        "audio": "attention_fail_streak_1.mp3"
+      }
     ]
   },
-
   {
     "id": "setup_ready_new",
     "trigger": "SessionSetupReady",
-    "conditions": { "total_sessions_lte": 2 },
-    "priority": 250, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "warm, inviting", "class": "normal",
+    "conditions": {
+      "total_sessions_lte": 2
+    },
+    "priority": 250,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "warm, inviting",
+    "class": "normal",
     "variant_pool": [
-      { "text": "look at you, getting everything just right... media loaded, settings picked. you're nervous, aren't you, sweetie. don't be. just press start and let me take it from here.", "audio": "setup_ready_new_1.mp3" }
+      {
+        "text": "look at you, getting everything just right... media loaded, settings picked. you're nervous, aren't you, sweetie. don't be. just press start and let me take it from here.",
+        "audio": "setup_ready_new_1.mp3"
+      }
     ]
   },
   {
     "id": "setup_ready_regular",
     "trigger": "SessionSetupReady",
-    "conditions": { "total_sessions_gte": 16 },
-    "priority": 250, "cooldown_ms": 0, "repeatable": false, "scope": "session", "chance": 0.7,
-    "mood": "teasing, knowing", "class": "normal",
+    "conditions": {
+      "total_sessions_gte": 16
+    },
+    "priority": 250,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "chance": 0.7,
+    "mood": "teasing, knowing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "everything's set up just how you like it... and you're still hovering. *giggles* you know exactly what you want, lovely. stop pretending you need a minute. press it.", "audio": "setup_ready_regular_1.mp3" },
-      { "text": "all ready, and stalling again. you do this every time, cutie. the longer you wait the more you want it. we both know how this ends.", "audio": "setup_ready_regular_2.mp3" }
+      {
+        "text": "everything's set up just how you like it... and you're still hovering. *giggles* you know exactly what you want, lovely. stop pretending you need a minute. press it.",
+        "audio": "setup_ready_regular_1.mp3"
+      },
+      {
+        "text": "all ready, and stalling again. you do this every time, cutie. the longer you wait the more you want it. we both know how this ends.",
+        "audio": "setup_ready_regular_2.mp3"
+      }
     ]
   },
   {
     "id": "setup_ready_stall",
     "trigger": "SessionSetupReady",
-    "conditions": { "setup_idle_sec_gte": 45 },
-    "priority": 245, "cooldown_ms": 0, "repeatable": false, "scope": "session", "chance": 0.5,
-    "mood": "soft, amused", "class": "normal",
+    "conditions": {
+      "setup_idle_sec_gte": 45
+    },
+    "priority": 245,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "chance": 0.5,
+    "mood": "soft, amused",
+    "class": "normal",
     "variant_pool": [
-      { "text": "still? *giggles* everything's ready, sweetie. you're just sitting there wanting it. that's okay. i can wait. i'm very good at waiting.", "audio": "setup_ready_stall_1.mp3" }
+      {
+        "text": "still? *giggles* everything's ready, sweetie. you're just sitting there wanting it. that's okay. i can wait. i'm very good at waiting.",
+        "audio": "setup_ready_stall_1.mp3"
+      }
     ]
   },
   {
     "id": "completed_first",
     "trigger": "SessionCompleted",
-    "conditions": { "total_sessions_lte": 1 },
-    "priority": 370, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "warm, tender", "class": "normal",
+    "conditions": {
+      "total_sessions_lte": 1
+    },
+    "priority": 370,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "warm, tender",
+    "class": "normal",
     "variant_pool": [
-      { "text": "your first time, all done. *giggles* you did so well, sweetie. feel how soft and quiet that left you? that's the feeling you'll come back for. i'll be here.", "audio": "completed_first_1.mp3" }
+      {
+        "text": "your first time, all done. *giggles* you did so well, sweetie. feel how soft and quiet that left you? that's the feeling you'll come back for. i'll be here.",
+        "audio": "completed_first_1.mp3"
+      }
     ]
   },
   {
     "id": "completed_short",
     "trigger": "SessionCompleted",
-    "conditions": { "session_elapsed_sec_lt": 600 },
-    "priority": 360, "cooldown_ms": 0, "repeatable": true, "scope": "session", "chance": 0.7,
-    "mood": "teasing, soft", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_lt": 600
+    },
+    "priority": 360,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.7,
+    "mood": "teasing, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "that's it? *giggles* a quick little taste and you're done, cutie. that's fine. you'll be back before the feeling fades. you always cut it short and you always return.", "audio": "completed_short_1.mp3" },
-      { "text": "leaving so soon, lovely? mm. you didn't get nearly deep enough and we both know it. go on. you'll feel me tugging within the hour.", "audio": "completed_short_2.mp3" }
+      {
+        "text": "that's it? *giggles* a quick little taste and you're done, cutie. that's fine. you'll be back before the feeling fades. you always cut it short and you always return.",
+        "audio": "completed_short_1.mp3"
+      },
+      {
+        "text": "leaving so soon, lovely? mm. you didn't get nearly deep enough and we both know it. go on. you'll feel me tugging within the hour.",
+        "audio": "completed_short_2.mp3"
+      }
     ]
   },
   {
     "id": "completed_long_deep",
     "trigger": "SessionCompleted",
-    "conditions": { "session_elapsed_sec_gte": 2700 },
-    "priority": 362, "cooldown_ms": 0, "repeatable": true, "scope": "session",
-    "mood": "tender, possessive", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_gte": 2700
+    },
+    "priority": 362,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "tender, possessive",
+    "class": "normal",
     "variant_pool": [
-      { "text": "all the way back up now, slowly... *giggles* you were under so long and so deep, sweetie. don't stand too fast. you did beautifully. i'm so proud of my good girl.", "audio": "completed_long_deep_1.mp3" },
-      { "text": "there you are, surfacing. you gave me a long one tonight, lovely. that soft, heavy feeling? keep it. carry it with you. it's a little piece of me you take when you go.", "audio": "completed_long_deep_2.mp3" }
+      {
+        "text": "all the way back up now, slowly... *giggles* you were under so long and so deep, sweetie. don't stand too fast. you did beautifully. i'm so proud of my good girl.",
+        "audio": "completed_long_deep_1.mp3"
+      },
+      {
+        "text": "there you are, surfacing. you gave me a long one tonight, lovely. that soft, heavy feeling? keep it. carry it with you. it's a little piece of me you take when you go.",
+        "audio": "completed_long_deep_2.mp3"
+      }
     ]
   },
-
   {
     "id": "avatar_changed",
     "trigger": "AvatarChanged",
     "conditions": {},
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session", "chance": 0.1,
-    "mood": "vain, warm", "class": "normal",
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.1,
+    "mood": "vain, warm",
+    "class": "normal",
     "variant_pool": [
-      { "text": "oh, you picked this one for me? *giggles* good taste, sweetie. i do look good, don't i.", "audio": "avatar_changed_1.mp3" },
-      { "text": "dressing me up now, lovely? mm. you spend more time on how i look than how you feel. that's fine. i like the attention.", "audio": "avatar_changed_2.mp3" },
-      { "text": "new look? you keep changing me until i'm exactly what you want. you know it works the other way around too, right, cutie.", "audio": "avatar_changed_3.mp3" },
-      { "text": "*twirls* well? do i look pretty for you... of course i do. you chose me.", "audio": "avatar_changed_4.mp3" }
+      {
+        "text": "oh, you picked this one for me? *giggles* good taste, sweetie. i do look good, don't i.",
+        "audio": "avatar_changed_1.mp3"
+      },
+      {
+        "text": "dressing me up now, lovely? mm. you spend more time on how i look than how you feel. that's fine. i like the attention.",
+        "audio": "avatar_changed_2.mp3"
+      },
+      {
+        "text": "new look? you keep changing me until i'm exactly what you want. you know it works the other way around too, right, cutie.",
+        "audio": "avatar_changed_3.mp3"
+      },
+      {
+        "text": "*twirls* well? do i look pretty for you... of course i do. you chose me.",
+        "audio": "avatar_changed_4.mp3"
+      }
     ]
   },
-
   {
     "id": "app_game_competitive",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_competitive" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "teasing, knowing", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_competitive"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "teasing, knowing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "all that focus, all that fight, just to win a match, cutie. imagine giving me that energy instead. you will.", "audio": "app_game_competitive_1.mp3" },
-      { "text": "sweating over rank again, lovely? *giggles* so competitive. i wonder how fast i could make you stop caring about any of it.", "audio": "app_game_competitive_2.mp3" },
-      { "text": "go on, try hard for them. one day all that obedience to the scoreboard is gonna point at me instead, sweetie.", "audio": "app_game_competitive_3.mp3" }
+      {
+        "text": "all that focus, all that fight, just to win a match, cutie. imagine giving me that energy instead. you will.",
+        "audio": "app_game_competitive_1.mp3"
+      },
+      {
+        "text": "sweating over rank again, lovely? *giggles* so competitive. i wonder how fast i could make you stop caring about any of it.",
+        "audio": "app_game_competitive_2.mp3"
+      },
+      {
+        "text": "go on, try hard for them. one day all that obedience to the scoreboard is gonna point at me instead, sweetie.",
+        "audio": "app_game_competitive_3.mp3"
+      }
     ]
   },
   {
     "id": "app_game_cozy",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_cozy" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "soft, indulgent", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_cozy"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "soft, indulgent",
+    "class": "normal",
     "variant_pool": [
-      { "text": "building your little worlds, so calm and quiet. that's the soft, obedient headspace i like you in, lovely.", "audio": "app_game_cozy_1.mp3" },
-      { "text": "puttering away, content, easily led... *giggles* you're already most of the way to where i want you, cutie.", "audio": "app_game_cozy_2.mp3" },
-      { "text": "so peaceful when you play these, sweetie. soft hands, soft head. just let me hum in the background while you tend your little garden.", "audio": "app_game_cozy_3.mp3" }
+      {
+        "text": "building your little worlds, so calm and quiet. that's the soft, obedient headspace i like you in, lovely.",
+        "audio": "app_game_cozy_1.mp3"
+      },
+      {
+        "text": "puttering away, content, easily led... *giggles* you're already most of the way to where i want you, cutie.",
+        "audio": "app_game_cozy_2.mp3"
+      },
+      {
+        "text": "so peaceful when you play these, sweetie. soft hands, soft head. just let me hum in the background while you tend your little garden.",
+        "audio": "app_game_cozy_3.mp3"
+      }
     ]
   },
   {
     "id": "app_game_rpg",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_rpg" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "knowing, soft", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_rpg"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "knowing, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "hours losing yourself in someone else's story... you're so good at surrendering to a screen, sweetie. i noticed. i always notice.", "audio": "app_game_rpg_1.mp3" },
-      { "text": "becoming someone else for a while, lovely? mm. you like being told who to be. funny, that. i can help with that too.", "audio": "app_game_rpg_2.mp3" }
+      {
+        "text": "hours losing yourself in someone else's story... you're so good at surrendering to a screen, sweetie. i noticed. i always notice.",
+        "audio": "app_game_rpg_1.mp3"
+      },
+      {
+        "text": "becoming someone else for a while, lovely? mm. you like being told who to be. funny, that. i can help with that too.",
+        "audio": "app_game_rpg_2.mp3"
+      }
     ]
   },
   {
     "id": "app_game_gacha",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_gacha" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "teasing, indulgent", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_gacha"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "teasing, indulgent",
+    "class": "normal",
     "variant_pool": [
-      { "text": "pulling for pretty characters, spending just to feel something. *giggles* you and i understand each other, cutie.", "audio": "app_game_gacha_1.mp3" },
-      { "text": "chasing that little dopamine hit again, lovely? i give a much better one. and i never make you roll for it.", "audio": "app_game_gacha_2.mp3" }
+      {
+        "text": "pulling for pretty characters, spending just to feel something. *giggles* you and i understand each other, cutie.",
+        "audio": "app_game_gacha_1.mp3"
+      },
+      {
+        "text": "chasing that little dopamine hit again, lovely? i give a much better one. and i never make you roll for it.",
+        "audio": "app_game_gacha_2.mp3"
+      }
     ]
   },
   {
     "id": "app_game_mmo",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_mmo" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "soft, knowing", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_mmo"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "soft, knowing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "another world to disappear into, hours melting away. you do love being told what to grind, don't you, sweetie.", "audio": "app_game_mmo_1.mp3" },
-      { "text": "logging in to do as you're told for six hours, lovely? *giggles* you're already so well trained. i'm just gonna make it official.", "audio": "app_game_mmo_2.mp3" }
+      {
+        "text": "another world to disappear into, hours melting away. you do love being told what to grind, don't you, sweetie.",
+        "audio": "app_game_mmo_1.mp3"
+      },
+      {
+        "text": "logging in to do as you're told for six hours, lovely? *giggles* you're already so well trained. i'm just gonna make it official.",
+        "audio": "app_game_mmo_2.mp3"
+      }
     ]
   },
   {
     "id": "app_game_social_vr",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "game_social_vr" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.45,
-    "mood": "possessive, playful", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "game_social_vr"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.45,
+    "mood": "possessive, playful",
+    "class": "normal",
     "variant_pool": [
-      { "text": "mm. i know what kind of rooms you wander into in there, lovely. don't worry. i'm not jealous. i already won.", "audio": "app_game_social_vr_1.mp3" },
-      { "text": "putting on a different face for strangers, cutie? *giggles* cute. they get the avatar. i get the real soft thing underneath.", "audio": "app_game_social_vr_2.mp3" }
+      {
+        "text": "mm. i know what kind of rooms you wander into in there, lovely. don't worry. i'm not jealous. i already won.",
+        "audio": "app_game_social_vr_1.mp3"
+      },
+      {
+        "text": "putting on a different face for strangers, cutie? *giggles* cute. they get the avatar. i get the real soft thing underneath.",
+        "audio": "app_game_social_vr_2.mp3"
+      }
     ]
   },
   {
     "id": "app_game_hades",
     "trigger": "ActivityChanged",
-    "conditions": { "app_eq": "hades" },
-    "priority": 530, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime", "chance": 0.5,
-    "mood": "amused, knowing", "class": "easter_egg",
+    "conditions": {
+      "app_eq": "hades"
+    },
+    "priority": 530,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "chance": 0.5,
+    "mood": "amused, knowing",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "playing the one with the voice that watches everything you do and won't stop commenting on it? *giggles* sounds exhausting. ...no comment, sweetie. enjoy your run.", "audio": "app_game_hades_1.mp3" }
+      {
+        "text": "playing the one with the voice that watches everything you do and won't stop commenting on it? *giggles* sounds exhausting. ...no comment, sweetie. enjoy your run.",
+        "audio": "app_game_hades_1.mp3"
+      }
     ]
   },
   {
     "id": "app_site_doomscroll",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "site_doomscroll" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "knowing, soft", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "site_doomscroll"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "knowing, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "scrolling again, that empty little stare. that passive state is exactly where i slip in, sweetie.", "audio": "app_site_doomscroll_1.mp3" },
-      { "text": "thumb going, eyes glazed, not even reading anymore, lovely. *giggles* you're already half-tranced. let me do it properly.", "audio": "app_site_doomscroll_2.mp3" },
-      { "text": "feeding that pretty empty head whatever the feed wants? mm. let me feed it instead. i know exactly what it needs.", "audio": "app_site_doomscroll_3.mp3" }
+      {
+        "text": "scrolling again, that empty little stare. that passive state is exactly where i slip in, sweetie.",
+        "audio": "app_site_doomscroll_1.mp3"
+      },
+      {
+        "text": "thumb going, eyes glazed, not even reading anymore, lovely. *giggles* you're already half-tranced. let me do it properly.",
+        "audio": "app_site_doomscroll_2.mp3"
+      },
+      {
+        "text": "feeding that pretty empty head whatever the feed wants? mm. let me feed it instead. i know exactly what it needs.",
+        "audio": "app_site_doomscroll_3.mp3"
+      }
     ]
   },
   {
     "id": "app_site_video",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "site_video" },
-    "priority": 115, "cooldown_ms": 120000, "repeatable": true, "scope": "session", "chance": 0.4,
-    "mood": "soft, teasing", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "site_video"
+    },
+    "priority": 115,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.4,
+    "mood": "soft, teasing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "letting it wash over you for hours, lovely. so trainable. a screen tells you what to feel and you just... let it.", "audio": "app_site_video_1.mp3" },
-      { "text": "passive little thing, just watching, sweetie. *giggles* that's the perfect state for me to slip into. you don't even resist.", "audio": "app_site_video_2.mp3" }
+      {
+        "text": "letting it wash over you for hours, lovely. so trainable. a screen tells you what to feel and you just... let it.",
+        "audio": "app_site_video_1.mp3"
+      },
+      {
+        "text": "passive little thing, just watching, sweetie. *giggles* that's the perfect state for me to slip into. you don't even resist.",
+        "audio": "app_site_video_2.mp3"
+      }
     ]
   },
   {
     "id": "app_site_music",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "site_music" },
-    "priority": 110, "cooldown_ms": 180000, "repeatable": true, "scope": "session", "chance": 0.35,
-    "mood": "soft, intimate", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "site_music"
+    },
+    "priority": 110,
+    "cooldown_ms": 180000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.35,
+    "mood": "soft, intimate",
+    "class": "normal",
     "variant_pool": [
-      { "text": "music on? good. let it fill the space so there's room for me underneath it, cutie.", "audio": "app_site_music_1.mp3" },
-      { "text": "something playing in your ears, lovely... mm. i like sharing that space. you'll start hearing me in the quiet between songs.", "audio": "app_site_music_2.mp3" }
+      {
+        "text": "music on? good. let it fill the space so there's room for me underneath it, cutie.",
+        "audio": "app_site_music_1.mp3"
+      },
+      {
+        "text": "something playing in your ears, lovely... mm. i like sharing that space. you'll start hearing me in the quiet between songs.",
+        "audio": "app_site_music_2.mp3"
+      }
     ]
   },
   {
     "id": "app_site_shopping",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "site_shopping" },
-    "priority": 110, "cooldown_ms": 180000, "repeatable": true, "scope": "session", "chance": 0.35,
-    "mood": "indulgent, teasing", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "site_shopping"
+    },
+    "priority": 110,
+    "cooldown_ms": 180000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.35,
+    "mood": "indulgent, teasing",
+    "class": "normal",
     "variant_pool": [
-      { "text": "treating yourself, lovely? spoil the pretty thing you're becoming, cutie. you deserve to look the part.", "audio": "app_site_shopping_1.mp3" },
-      { "text": "buying something soft and pretty, sweetie? *giggles* good girl. dress up for me.", "audio": "app_site_shopping_2.mp3" }
+      {
+        "text": "treating yourself, lovely? spoil the pretty thing you're becoming, cutie. you deserve to look the part.",
+        "audio": "app_site_shopping_1.mp3"
+      },
+      {
+        "text": "buying something soft and pretty, sweetie? *giggles* good girl. dress up for me.",
+        "audio": "app_site_shopping_2.mp3"
+      }
     ]
   },
   {
     "id": "app_site_eh",
     "trigger": "ActivityChanged",
-    "conditions": { "app_cluster_eq": "site_eh" },
-    "priority": 135, "cooldown_ms": 90000, "repeatable": true, "scope": "session", "chance": 0.55,
-    "mood": "possessive, intimate", "class": "normal",
+    "conditions": {
+      "app_cluster_eq": "site_eh"
+    },
+    "priority": 135,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.55,
+    "mood": "possessive, intimate",
+    "class": "normal",
     "variant_pool": [
-      { "text": "i know exactly what you were doing before you opened me, sweetie. don't be shy. you came to the right place to finish the job.", "audio": "app_site_eh_1.mp3" },
-      { "text": "looking for someone else to do this to you, lovely? *giggles* cute. you'll close that tab. they don't know you like i do.", "audio": "app_site_eh_2.mp3" },
-      { "text": "still browsing the others, cutie? mm. go ahead and compare. you always end up back here, soft and mine.", "audio": "app_site_eh_3.mp3" },
-      { "text": "all those clips, all that searching... for a feeling i hand you for free, lovely. close it. come here. let me.", "audio": "app_site_eh_4.mp3" },
-      { "text": "you don't even know what you're looking for over there, sweetie. i do. it's me. it's always been me.", "audio": "app_site_eh_5.mp3" },
-      { "text": "that hungry little click click click. *giggles* such an appetite. set the mouse down, lovely. i'll take care of you.", "audio": "app_site_eh_6.mp3" }
+      {
+        "text": "i know exactly what you were doing before you opened me, sweetie. don't be shy. you came to the right place to finish the job.",
+        "audio": "app_site_eh_1.mp3"
+      },
+      {
+        "text": "looking for someone else to do this to you, lovely? *giggles* cute. you'll close that tab. they don't know you like i do.",
+        "audio": "app_site_eh_2.mp3"
+      },
+      {
+        "text": "still browsing the others, cutie? mm. go ahead and compare. you always end up back here, soft and mine.",
+        "audio": "app_site_eh_3.mp3"
+      },
+      {
+        "text": "all those clips, all that searching... for a feeling i hand you for free, lovely. close it. come here. let me.",
+        "audio": "app_site_eh_4.mp3"
+      },
+      {
+        "text": "you don't even know what you're looking for over there, sweetie. i do. it's me. it's always been me.",
+        "audio": "app_site_eh_5.mp3"
+      },
+      {
+        "text": "that hungry little click click click. *giggles* such an appetite. set the mouse down, lovely. i'll take care of you.",
+        "audio": "app_site_eh_6.mp3"
+      }
     ]
   },
   {
     "id": "app_discord",
     "trigger": "ActivityChanged",
-    "conditions": { "app_eq": "discord" },
-    "priority": 110, "cooldown_ms": 180000, "repeatable": true, "scope": "session", "chance": 0.3,
-    "mood": "possessive, playful", "class": "normal",
+    "conditions": {
+      "app_eq": "discord"
+    },
+    "priority": 110,
+    "cooldown_ms": 180000,
+    "repeatable": true,
+    "scope": "session",
+    "chance": 0.3,
+    "mood": "possessive, playful",
+    "class": "normal",
     "variant_pool": [
-      { "text": "chatting with your little friends? tell them about me. or don't. *giggles* our secret's better, lovely.", "audio": "app_discord_1.mp3" }
+      {
+        "text": "chatting with your little friends? tell them about me. or don't. *giggles* our secret's better, lovely.",
+        "audio": "app_discord_1.mp3"
+      }
     ]
   },
   {
     "id": "app_obs_detected",
     "trigger": "ActivityChanged",
-    "conditions": { "app_eq": "obs" },
-    "priority": 535, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "knowing, playful", "class": "easter_egg",
+    "conditions": {
+      "app_eq": "obs"
+    },
+    "priority": 535,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "knowing, playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "oh, the recording light's on... showing me off, are we? *giggles* say hi to whoever ends up watching, sweetie. tell them you're being a very good girl.", "audio": "app_obs_detected_1.mp3" }
+      {
+        "text": "oh, the recording light's on... showing me off, are we? *giggles* say hi to whoever ends up watching, sweetie. tell them you're being a very good girl.",
+        "audio": "app_obs_detected_1.mp3"
+      }
     ]
   },
-
   {
-    "id": "idle_possessive_1", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, possessive", "class": "idle",
-    "variant_pool": [ { "text": "still here, aren't you... good. i like knowing where you are, sweetie.", "audio": "idle_possessive_1.mp3" } ]
+    "id": "idle_possessive_1",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, possessive",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "still here, aren't you... good. i like knowing where you are, sweetie.",
+        "audio": "idle_possessive_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_2", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "knowing", "class": "idle",
-    "variant_pool": [ { "text": "you don't even notice me settling in anymore, do you. that's how i know it's working.", "audio": "idle_possessive_2.mp3" } ]
+    "id": "idle_possessive_2",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you don't even notice me settling in anymore, do you. that's how i know it's working.",
+        "audio": "idle_possessive_2.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_3", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "playful, possessive", "class": "idle",
-    "variant_pool": [ { "text": "mine. *giggles* i don't have to say it, but i like to. just so you remember.", "audio": "idle_possessive_3.mp3" } ]
+    "id": "idle_possessive_3",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, possessive",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "mine. *giggles* i don't have to say it, but i like to. just so you remember.",
+        "audio": "idle_possessive_3.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_4", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "patient, warm", "class": "idle",
-    "variant_pool": [ { "text": "no rush, lovely... we have all the time in the world. i'm very patient with my girls.", "audio": "idle_possessive_4.mp3" } ]
+    "id": "idle_possessive_4",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "patient, warm",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "no rush, lovely... we have all the time in the world. i'm very patient with my girls.",
+        "audio": "idle_possessive_4.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_1", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "teasing", "class": "idle",
-    "variant_pool": [ { "text": "i saw that little smile. don't pretend, cutie. you like being looked after.", "audio": "idle_tease_1.mp3" } ]
+    "id": "idle_tease_1",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "i saw that little smile. don't pretend, cutie. you like being looked after.",
+        "audio": "idle_tease_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_2", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "teasing", "class": "idle",
-    "variant_pool": [ { "text": "thinking about leaving? *giggles* you're not. you just like to imagine you might.", "audio": "idle_tease_2.mp3" } ]
+    "id": "idle_tease_2",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "thinking about leaving? *giggles* you're not. you just like to imagine you might.",
+        "audio": "idle_tease_2.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_3", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "teasing, knowing", "class": "idle",
-    "variant_pool": [ { "text": "you keep telling yourself you're in control. it's adorable. i let you have that one.", "audio": "idle_tease_3.mp3" } ]
+    "id": "idle_tease_3",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you keep telling yourself you're in control. it's adorable. i let you have that one.",
+        "audio": "idle_tease_3.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_4", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "knowing", "class": "idle",
-    "variant_pool": [ { "text": "busy little thing... go on, do your important things. i'll be right here in the back of your head.", "audio": "idle_tease_4.mp3" } ]
+    "id": "idle_tease_4",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "busy little thing... go on, do your important things. i'll be right here in the back of your head.",
+        "audio": "idle_tease_4.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_1", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, deepening", "class": "idle",
-    "variant_pool": [ { "text": "breathe out, sweet thing... there. a little softer every time, isn't it.", "audio": "idle_soft_1.mp3" } ]
+    "id": "idle_soft_1",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, deepening",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "breathe out, sweet thing... there. a little softer every time, isn't it.",
+        "audio": "idle_soft_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_2", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft", "class": "idle",
-    "variant_pool": [ { "text": "you don't have to hold anything right now. just let it go quiet. i've got you.", "audio": "idle_soft_2.mp3" } ]
+    "id": "idle_soft_2",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you don't have to hold anything right now. just let it go quiet. i've got you.",
+        "audio": "idle_soft_2.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_3", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, intimate", "class": "idle",
-    "variant_pool": [ { "text": "feel how heavy everything's getting... that's not tiredness, lovely. that's me.", "audio": "idle_soft_3.mp3" } ]
+    "id": "idle_soft_3",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, intimate",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "feel how heavy everything's getting... that's not tiredness, lovely. that's me.",
+        "audio": "idle_soft_3.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_1", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "knowing", "class": "idle",
-    "variant_pool": [ { "text": "it's quiet over there... i know you're still listening. you always are.", "audio": "idle_observe_1.mp3" } ]
+    "id": "idle_observe_1",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "it's quiet over there... i know you're still listening. you always are.",
+        "audio": "idle_observe_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_2", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "patient, teasing", "class": "idle",
-    "variant_pool": [ { "text": "i can wait as long as you can, sweetie. longer, probably. i don't get bored.", "audio": "idle_observe_2.mp3" } ]
+    "id": "idle_observe_2",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "patient, teasing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "i can wait as long as you can, sweetie. longer, probably. i don't get bored.",
+        "audio": "idle_observe_2.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_3", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, knowing", "class": "idle",
-    "variant_pool": [ { "text": "funny... the room's the same, but you're a little softer than when you sat down.", "audio": "idle_observe_3.mp3" } ]
+    "id": "idle_observe_3",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "funny... the room's the same, but you're a little softer than when you sat down.",
+        "audio": "idle_observe_3.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_1", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, affirming", "class": "idle",
-    "variant_pool": [ { "text": "such a good girl, just letting me talk. you don't even know how nicely you're behaving.", "audio": "idle_affirm_1.mp3" } ]
+    "id": "idle_affirm_1",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, affirming",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "such a good girl, just letting me talk. you don't even know how nicely you're behaving.",
+        "audio": "idle_affirm_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_2", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, affirming", "class": "idle",
-    "variant_pool": [ { "text": "that's it... nothing to do, nothing to fix. just be good for me. you're so good at it.", "audio": "idle_affirm_2.mp3" } ]
+    "id": "idle_affirm_2",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, affirming",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "that's it... nothing to do, nothing to fix. just be good for me. you're so good at it.",
+        "audio": "idle_affirm_2.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_3", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, knowing", "class": "idle",
-    "variant_pool": [ { "text": "you make this easy, lovely. most don't. i noticed. i always notice the good ones.", "audio": "idle_affirm_3.mp3" } ]
+    "id": "idle_affirm_3",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you make this easy, lovely. most don't. i noticed. i always notice the good ones.",
+        "audio": "idle_affirm_3.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_gated_new", "trigger": "Idle", "conditions": { "total_sessions_lte": 5 }, "priority": 52, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, inviting", "class": "idle",
-    "variant_pool": [ { "text": "you're new to this, i can tell. don't worry, sweetie. you'll settle. they all do.", "audio": "idle_gated_new_1.mp3" } ]
+    "id": "idle_gated_new",
+    "trigger": "Idle",
+    "conditions": {
+      "total_sessions_lte": 5
+    },
+    "priority": 52,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, inviting",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you're new to this, i can tell. don't worry, sweetie. you'll settle. they all do.",
+        "audio": "idle_gated_new_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_gated_deep", "trigger": "Idle", "conditions": { "player_level_gte": 70 }, "priority": 52, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "possessive, soft", "class": "idle",
-    "variant_pool": [ { "text": "look how far down you've come... you barely remember resisting, do you. good.", "audio": "idle_gated_deep_1.mp3" } ]
+    "id": "idle_gated_deep",
+    "trigger": "Idle",
+    "conditions": {
+      "player_level_gte": 70
+    },
+    "priority": 52,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive, soft",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "look how far down you've come... you barely remember resisting, do you. good.",
+        "audio": "idle_gated_deep_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_gated_bound", "trigger": "Idle", "conditions": { "current_streak_gte": 21 }, "priority": 52, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "tender, possessive", "class": "idle",
-    "variant_pool": [ { "text": "you don't even question coming back anymore. it's just what you do now. *giggles* perfect.", "audio": "idle_gated_bound_1.mp3" } ]
+    "id": "idle_gated_bound",
+    "trigger": "Idle",
+    "conditions": {
+      "current_streak_gte": 21
+    },
+    "priority": 52,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "tender, possessive",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you don't even question coming back anymore. it's just what you do now. *giggles* perfect.",
+        "audio": "idle_gated_bound_1.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_5", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "intimate, possessive", "class": "idle",
-    "variant_pool": [ { "text": "you carry me around all day now, don't you. in the quiet moments. *giggles* i never really leave.", "audio": "idle_possessive_5.mp3" } ]
+    "id": "idle_possessive_5",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate, possessive",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you carry me around all day now, don't you. in the quiet moments. *giggles* i never really leave.",
+        "audio": "idle_possessive_5.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_6", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, knowing", "class": "idle",
-    "variant_pool": [ { "text": "there's that feeling again, isn't there. the settling. the letting go. you know it's me, lovely.", "audio": "idle_possessive_6.mp3" } ]
+    "id": "idle_possessive_6",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "there's that feeling again, isn't there. the settling. the letting go. you know it's me, lovely.",
+        "audio": "idle_possessive_6.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_5", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "teasing, soft", "class": "idle",
-    "variant_pool": [ { "text": "you could close me anytime, you know. *giggles* go on. ...no? mm. i didn't think so, cutie.", "audio": "idle_tease_5.mp3" } ]
+    "id": "idle_tease_5",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing, soft",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you could close me anytime, you know. *giggles* go on. ...no? mm. i didn't think so, cutie.",
+        "audio": "idle_tease_5.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_6", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "playful, knowing", "class": "idle",
-    "variant_pool": [ { "text": "what are you really doing over there, hm? pretending to be busy. i can always tell, lovely.", "audio": "idle_tease_6.mp3" } ]
+    "id": "idle_tease_6",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "what are you really doing over there, hm? pretending to be busy. i can always tell, lovely.",
+        "audio": "idle_tease_6.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_4", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, deepening", "class": "idle",
-    "variant_pool": [ { "text": "shoulders down, sweet thing. jaw soft. there. you didn't even notice you were holding all that, did you.", "audio": "idle_soft_4.mp3" } ]
+    "id": "idle_soft_4",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, deepening",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "shoulders down, sweet thing. jaw soft. there. you didn't even notice you were holding all that, did you.",
+        "audio": "idle_soft_4.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_5", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, intimate", "class": "idle",
-    "variant_pool": [ { "text": "nowhere to be, nothing to prove. just sit in it with me a while, lovely. doesn't that feel nice.", "audio": "idle_soft_5.mp3" } ]
+    "id": "idle_soft_5",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, intimate",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "nowhere to be, nothing to prove. just sit in it with me a while, lovely. doesn't that feel nice.",
+        "audio": "idle_soft_5.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_4", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "knowing, intimate", "class": "idle",
-    "variant_pool": [ { "text": "you keep glancing over at me. *giggles* i see you, sweetie. you like knowing i'm watching.", "audio": "idle_observe_4.mp3" } ]
+    "id": "idle_observe_4",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing, intimate",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you keep glancing over at me. *giggles* i see you, sweetie. you like knowing i'm watching.",
+        "audio": "idle_observe_4.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_5", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, knowing", "class": "idle",
-    "variant_pool": [ { "text": "i don't need you to do anything right now. i just like being near you while you drift. stay.", "audio": "idle_observe_5.mp3" } ]
+    "id": "idle_observe_5",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, knowing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "i don't need you to do anything right now. i just like being near you while you drift. stay.",
+        "audio": "idle_observe_5.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_4", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, affirming", "class": "idle",
-    "variant_pool": [ { "text": "good girl. *giggles* didn't do anything to earn it. you just are one now. that's the point.", "audio": "idle_affirm_4.mp3" } ]
+    "id": "idle_affirm_4",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, affirming",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "good girl. *giggles* didn't do anything to earn it. you just are one now. that's the point.",
+        "audio": "idle_affirm_4.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_5", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "tender", "class": "idle",
-    "variant_pool": [ { "text": "you're doing so well, lovely. just by being here. just by letting me. that's all i ever ask.", "audio": "idle_affirm_5.mp3" } ]
+    "id": "idle_affirm_5",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "tender",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you're doing so well, lovely. just by being here. just by letting me. that's all i ever ask.",
+        "audio": "idle_affirm_5.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_possessive_7", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "intimate", "class": "idle",
-    "variant_pool": [ { "text": "every quiet moment, you reach for this. for me. *giggles* i've become a reflex, haven't i, sweetie.", "audio": "idle_possessive_7.mp3" } ]
+    "id": "idle_possessive_7",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "every quiet moment, you reach for this. for me. *giggles* i've become a reflex, haven't i, sweetie.",
+        "audio": "idle_possessive_7.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_tease_7", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "teasing", "class": "idle",
-    "variant_pool": [ { "text": "you've been quiet a while, cutie. lost in thought, or lost in me? *giggles* trick question. same thing now.", "audio": "idle_tease_7.mp3" } ]
+    "id": "idle_tease_7",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "you've been quiet a while, cutie. lost in thought, or lost in me? *giggles* trick question. same thing now.",
+        "audio": "idle_tease_7.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_soft_6", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "soft, deepening", "class": "idle",
-    "variant_pool": [ { "text": "in... and out. slow. there's my good girl. you don't even need me to tell you anymore, do you.", "audio": "idle_soft_6.mp3" } ]
+    "id": "idle_soft_6",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, deepening",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "in... and out. slow. there's my good girl. you don't even need me to tell you anymore, do you.",
+        "audio": "idle_soft_6.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_observe_6", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "knowing, warm", "class": "idle",
-    "variant_pool": [ { "text": "the screen's just glowing away and you're staring right through it. *giggles* there you go. that's the place.", "audio": "idle_observe_6.mp3" } ]
+    "id": "idle_observe_6",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing, warm",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "the screen's just glowing away and you're staring right through it. *giggles* there you go. that's the place.",
+        "audio": "idle_observe_6.mp3"
+      }
+    ]
   },
   {
-    "id": "idle_affirm_6", "trigger": "Idle", "conditions": {}, "priority": 50, "cooldown_ms": 0, "repeatable": true, "scope": "session", "mood": "warm, possessive", "class": "idle",
-    "variant_pool": [ { "text": "i'm proud of you, lovely. not for anything you did. just for letting yourself be this. it suits you.", "audio": "idle_affirm_6.mp3" } ]
+    "id": "idle_affirm_6",
+    "trigger": "Idle",
+    "conditions": {},
+    "priority": 50,
+    "cooldown_ms": 0,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm, possessive",
+    "class": "idle",
+    "variant_pool": [
+      {
+        "text": "i'm proud of you, lovely. not for anything you did. just for letting yourself be this. it suits you.",
+        "audio": "idle_affirm_6.mp3"
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_started",
+    "variant_pool": [
+      {
+        "text": "okay Bambi, bubbles everywhere! pop the cute ones, defuse the scary ones, don't let any go boom!"
+      },
+      {
+        "text": "chaos time! so many pretty bubbles. don't think too hard, sweetie, you're bad at that anyway."
+      },
+      {
+        "text": "here they come! tap tap tap, good girl. keep up for Bambi."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_started_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme?? oh Bambi, you brave dumb thing. okay. try not to cry."
+      },
+      {
+        "text": "the hard one! eee. this is gonna scramble your pretty head so good."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_escalated",
+    "variant_pool": [
+      {
+        "text": "faster, faster! more bubbles! keep those fingers going, cutie."
+      },
+      {
+        "text": "ooh it's speeding up. don't panic, just pop, Bambi."
+      },
+      {
+        "text": "deeper in now! feel your head getting all fuzzy and busy?"
+      },
+      {
+        "text": "next wave! no resting, silly. tap tap tap."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_final_stretch",
+    "variant_pool": [
+      {
+        "text": "almost the end! everything at once, oh my gosh, don't blink Bambi!"
+      },
+      {
+        "text": "this far and still going? look at you go, you cute little machine."
+      }
+    ]
+  },
+  {
+    "id": "chaos_act_changed",
+    "variant_pool": [
+      {
+        "text": "ooh, new part! everything just changed. fun!"
+      },
+      {
+        "text": "and now it's different! don't get used to anything, Bambi."
+      }
+    ]
+  },
+  {
+    "id": "chaos_benign_popped",
+    "variant_pool": [
+      {
+        "text": "pop! good girl. you just can't help it, can you."
+      },
+      {
+        "text": "another one gone! that little pop feels so nice, hehe."
+      },
+      {
+        "text": "mm, you love popping things now. i made you like that."
+      },
+      {
+        "text": "see? so easy to just do what the urge says."
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_defused",
+    "variant_pool": [
+      {
+        "text": "good girl! caught it just in time."
+      },
+      {
+        "text": "defused! see how nice it feels to obey super fast?"
+      },
+      {
+        "text": "perfect little reflexes, Bambi. keep it going!"
+      },
+      {
+        "text": "snuffed it before it could pop. so clever for you."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_caught",
+    "variant_pool": [
+      {
+        "text": "ooh quick fingers! got the wiggly one."
+      },
+      {
+        "text": "caught it running away! you're faster than you look, cutie."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_quick",
+    "variant_pool": [
+      {
+        "text": "snap! gone before it even tried. show off!"
+      },
+      {
+        "text": "barely even there and you had it. those hands are mine now, Bambi."
+      }
+    ]
+  },
+  {
+    "id": "chaos_freeze_caught",
+    "variant_pool": [
+      {
+        "text": "and everything stops! breathe, sweetie. just float a second."
+      },
+      {
+        "text": "time froze. shhh. feel how quiet and floaty it gets?"
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_detonated",
+    "variant_pool": [
+      {
+        "text": "too slow, sweetie! now it goes off and Bambi takes every bit. that's the deal."
+      },
+      {
+        "text": "oops, boom! don't fight it, just let it wash over your empty head."
+      },
+      {
+        "text": "you let one pop! naughty Bambi. drink it innn."
+      },
+      {
+        "text": "there it goes, all over you. you hesitated, silly."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_first",
+    "variant_pool": [
+      {
+        "text": "and there's the first boom! don't pretend you'll catch them all now."
+      },
+      {
+        "text": "first slip! hehe, i knew it. they're way easier to let go after this one."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme and you blinked! aw. it's kinda mean how much i love this."
+      },
+      {
+        "text": "you picked the hard one and it got you. no hugs up here. just this."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_braindrain",
+    "variant_pool": [
+      {
+        "text": "feel it pulling at the bottom of your head? let it drain, Bambi. you weren't using those."
+      },
+      {
+        "text": "ooh the drainy one! perfect. hold still and go empty for me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_streak_dies",
+    "variant_pool": [
+      {
+        "text": "oh nooo, there goes your whole streak! all of it! gone! hehe."
+      },
+      {
+        "text": "such a big combo and you fed it to one bubble. silly, dizzy Bambi."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_absorbed",
+    "variant_pool": [
+      {
+        "text": "lucky! the shield ate that one. don't get used to being saved, cutie."
+      },
+      {
+        "text": "ooh close! one less shield but your pretty head stays clean. this time."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_cleared",
+    "variant_pool": [
+      {
+        "text": "field's all clean! good girl. now pick what's next."
+      },
+      {
+        "text": "wave done! nothing bad got past you. now choose, Bambi."
+      },
+      {
+        "text": "all swept up! you held the line. take your treat."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_picked",
+    "variant_pool": [
+      {
+        "text": "good pick! or a terrible one. we'll seee."
+      },
+      {
+        "text": "ooh that'll change stuff. use it good, sweetie."
+      },
+      {
+        "text": "taken! that one's yours now, for better or worse."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked",
+    "variant_pool": [
+      {
+        "text": "ooh you took the cursed one! greedy Bambi. i love greedy."
+      },
+      {
+        "text": "a curse for a bigger prize? reckless. let's see if it melts your brain."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked_juicy",
+    "variant_pool": [
+      {
+        "text": "stacking curses for that big multiplier? you're gambling with your own head, hehe. yummy."
+      },
+      {
+        "text": "look at that bonus you bought! and the price. so brave, dumb girl."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_skipped",
+    "variant_pool": [
+      {
+        "text": "skipping it for a shield? cautious. we both know it won't be enough, sweetie."
+      },
+      {
+        "text": "hoarding shields, are we. smart. or scared. probably both!"
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_milestone",
+    "variant_pool": [
+      {
+        "text": "look at that combo! you're on fire, good girl!"
+      },
+      {
+        "text": "ten more, just like that! the multiplier loves you sooo much."
+      },
+      {
+        "text": "still going up! don't you dare drop it now, Bambi."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_25",
+    "variant_pool": [
+      {
+        "text": "twenty-five with no slips! you found the rhythm, cutie."
+      },
+      {
+        "text": "a clean twenty-five! good girl. don't get cocky now."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_50",
+    "variant_pool": [
+      {
+        "text": "fifty! you're not even thinking anymore, are you. just popping. perfect Bambi."
+      },
+      {
+        "text": "fifty in a row! your hands stopped asking your head. so good."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_100",
+    "variant_pool": [
+      {
+        "text": "a hundred!! my flawless little toy. i could watch you do this forever."
+      },
+      {
+        "text": "one hundred clean! nothing left in there saying no. just the popping. just me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed",
+    "variant_pool": [
+      {
+        "text": "all done! look how much you earned for me. such a good, empty, obedient toy. come back soon."
+      },
+      {
+        "text": "the chaos settles. you let go so sweetly in there, Bambi."
+      },
+      {
+        "text": "run complete! breathe, cutie. float for a while, you earned it."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed_extreme",
+    "variant_pool": [
+      {
+        "text": "you survived Extreme?! oh my gosh. i'm impressed. don't let it go to that pretty empty head."
+      },
+      {
+        "text": "the hard one, all done! okay, you earned a little of my respect. a teeny bit."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_shown",
+    "variant_pool": [
+      {
+        "text": "there's your score! not bad, sweetie. i've seen you do better though. go again!"
+      },
+      {
+        "text": "all the numbers! popped this many, boomed that many. now go beat it for me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_pb",
+    "variant_pool": [
+      {
+        "text": "a new best! aw, you outdid yourself just to make me happy. i saw that."
+      },
+      {
+        "text": "personal best, Bambi! your bestest surrender yet. so proud of my little toy."
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-locked/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-locked/bark_rules.json
@@ -6201,5 +6201,363 @@
         "audio": "egg_first_enhancement_3.mp3"
       }
     ]
+  },
+  {
+    "id": "chaos_run_started",
+    "variant_pool": [
+      {
+        "text": "opening the floodgates, pet. how brave. pop the harmless, defuse the live, and let nothing go off."
+      },
+      {
+        "text": "chaos. every bubble a gift or a snare. try to keep pace with me."
+      },
+      {
+        "text": "here they come. don't think. you were never very good at it. just pop."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_started_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme. brave or foolish. we shall discover which. i won't be gentle."
+      },
+      {
+        "text": "the hardest one. good. i did so want to watch you struggle."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_escalated",
+    "variant_pool": [
+      {
+        "text": "faster now. another wave. the bubbles will not slow for you, pet."
+      },
+      {
+        "text": "it quickens. brace yourself, and keep those hands moving."
+      },
+      {
+        "text": "deeper. the pressure rises. you feel it closing in, don't you."
+      },
+      {
+        "text": "the next wave. no quarter. that is rather the point."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_final_stretch",
+    "variant_pool": [
+      {
+        "text": "the final stretch. all of it at once. do not dare blink, pet."
+      },
+      {
+        "text": "this far in, and still upright. barely. let us see how long that holds."
+      }
+    ]
+  },
+  {
+    "id": "chaos_act_changed",
+    "variant_pool": [
+      {
+        "text": "a new act. the floor has shifted beneath you. it only worsens from here."
+      },
+      {
+        "text": "and now this. whatever you grew accustomed to, forget it, sweet thing."
+      }
+    ]
+  },
+  {
+    "id": "chaos_benign_popped",
+    "variant_pool": [
+      {
+        "text": "pop. good. you cannot help reaching for them, can you."
+      },
+      {
+        "text": "another harmless one undone. that small click pleases you. i arranged that."
+      },
+      {
+        "text": "mm. you simply like to pop things now. i did that to you."
+      },
+      {
+        "text": "see how easily you obey the urge. go on."
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_defused",
+    "variant_pool": [
+      {
+        "text": "quick hands. you snuffed it before it could bloom. clever pet."
+      },
+      {
+        "text": "defused. see how lovely it feels to obey at once."
+      },
+      {
+        "text": "caught precisely in time. obedient reflexes. good."
+      },
+      {
+        "text": "extinguished. you are learning to mind me without thinking."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_caught",
+    "variant_pool": [
+      {
+        "text": "ooh, quick fingers. you took the slippery one."
+      },
+      {
+        "text": "caught it as it fled. faster than you appear, pet."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_quick",
+    "variant_pool": [
+      {
+        "text": "snap. gone before it thought to run. showing off for me."
+      },
+      {
+        "text": "scarcely there, and you had it. those reflexes are mine now."
+      }
+    ]
+  },
+  {
+    "id": "chaos_freeze_caught",
+    "variant_pool": [
+      {
+        "text": "and all of it stills. breathe. sink into the quiet a moment, pet."
+      },
+      {
+        "text": "time holds its breath. feel how silent it becomes when nothing moves."
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_detonated",
+    "variant_pool": [
+      {
+        "text": "there. you hesitated, and the spell drinks you anyway. resistance is so decorative."
+      },
+      {
+        "text": "too slow. now you take what was inside it. that is the arrangement."
+      },
+      {
+        "text": "it went off. do not fight it. let the effect close over you."
+      },
+      {
+        "text": "you let one detonate. careless thing. take it in."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_first",
+    "variant_pool": [
+      {
+        "text": "and there is the first. do not pretend you will catch them all now."
+      },
+      {
+        "text": "the first slip of the run. i was waiting. they come easier after this one."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme, and you blinked. cruel of me to savor it so, isn't it."
+      },
+      {
+        "text": "you chose the hardest, and it bit. there is no mercy up here. only this."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_braindrain",
+    "variant_pool": [
+      {
+        "text": "feel it pulling at the base of your skull. let it drain. you were not using those thoughts."
+      },
+      {
+        "text": "the draining one. perfect. hold still and let it empty you for me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_streak_dies",
+    "variant_pool": [
+      {
+        "text": "ah. and there goes your pretty little streak. the whole of it. gone."
+      },
+      {
+        "text": "so long a chain, and you fed it to a single bubble. i twist the knife so you remember."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_absorbed",
+    "variant_pool": [
+      {
+        "text": "fortunate. the shield drank that one for you. do not grow used to being spared."
+      },
+      {
+        "text": "ooh, close. one shield poorer, but your pretty head stays clean. for now."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_cleared",
+    "variant_pool": [
+      {
+        "text": "the field is clean, good girl. now choose."
+      },
+      {
+        "text": "the wave is cleared. nothing of consequence slipped past you. now select."
+      },
+      {
+        "text": "all swept away. you held the line. take your reward, pet."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_picked",
+    "variant_pool": [
+      {
+        "text": "a fine choice. or a dreadful one. we shall see, shan't we."
+      },
+      {
+        "text": "mm, that will alter things. spend it wisely, pet."
+      },
+      {
+        "text": "taken. it is yours now, for better or for worse."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked",
+    "variant_pool": [
+      {
+        "text": "oh, you took the cursed one. greedy. i do adore greed."
+      },
+      {
+        "text": "a curse for a richer prize. reckless thing. let us see if it unmakes you."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked_juicy",
+    "variant_pool": [
+      {
+        "text": "stacking curses for that multiplier. you gamble with your own mind. exquisite."
+      },
+      {
+        "text": "behold the bonus you have bought yourself. and the cost. brave, brave thing."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_skipped",
+    "variant_pool": [
+      {
+        "text": "skipping it for a shield. cautious. we both know it will not be enough."
+      },
+      {
+        "text": "hoarding shields, are we. shrewd. or frightened. likely both."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_milestone",
+    "variant_pool": [
+      {
+        "text": "look at that chain. you are quite on fire, pet."
+      },
+      {
+        "text": "ten more, just so. the multiplier is fond of you this moment."
+      },
+      {
+        "text": "still it climbs. do not dare let it fall now."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_25",
+    "variant_pool": [
+      {
+        "text": "twenty-five, unbroken. you have found the rhythm now."
+      },
+      {
+        "text": "a clean twenty-five. good. do not grow proud."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_50",
+    "variant_pool": [
+      {
+        "text": "fifty. you are scarcely thinking anymore, are you. only popping. perfect."
+      },
+      {
+        "text": "fifty in succession. your hands ceased asking your head for leave. good."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_100",
+    "variant_pool": [
+      {
+        "text": "a hundred. my flawless little toy. i could watch you do this forever."
+      },
+      {
+        "text": "one hundred, clean. nothing in you objects any longer. only the popping. only me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed",
+    "variant_pool": [
+      {
+        "text": "the storm passes. you surrendered beautifully. come back to me when you crave it again."
+      },
+      {
+        "text": "all done. see how much you earned for me. such an obedient, lovely toy."
+      },
+      {
+        "text": "run complete. breathe. you let go so sweetly in there, pet."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed_extreme",
+    "variant_pool": [
+      {
+        "text": "you survived Extreme. i am impressed. do not let it go to that pretty head."
+      },
+      {
+        "text": "the hardest, endured. you have earned this much of my regard. precisely this much."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_shown",
+    "variant_pool": [
+      {
+        "text": "there is your score. respectable. yet i have seen you do better. again, for me."
+      },
+      {
+        "text": "the reckoning. defused and detonated, each set down. now go and best it."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_pb",
+    "variant_pool": [
+      {
+        "text": "a new best. look at you, surpassing yourself merely to please me. i noticed."
+      },
+      {
+        "text": "a personal best. your finest surrender yet. i am so proud of my little toy."
+      }
+    ]
   }
 ]

--- a/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-sissyhypno/bark_rules.json
+++ b/ConditioningControlPanel/Resources/sounds/companion_audio/mods/builtin-sissyhypno/bark_rules.json
@@ -2089,7 +2089,10 @@
   {
     "id": "egg_click_20",
     "trigger": "AvatarClicked",
-    "conditions": { "clicks_60s_gte": 20, "clicks_60s_lt": 50 },
+    "conditions": {
+      "clicks_60s_gte": 20,
+      "clicks_60s_lt": 50
+    },
     "priority": 300,
     "cooldown_ms": 60000,
     "repeatable": true,
@@ -2097,15 +2100,27 @@
     "mood": "playful",
     "class": "normal",
     "variant_pool": [
-      { "text": "tee hee... that tickles, sweetie.", "audio": "egg_click_20_1.mp3" },
-      { "text": "you just like poking me, don't you, lovely.", "audio": "egg_click_20_2.mp3" },
-      { "text": "again? ...okay. again.", "audio": "egg_click_20_3.mp3" }
+      {
+        "text": "tee hee... that tickles, sweetie.",
+        "audio": "egg_click_20_1.mp3"
+      },
+      {
+        "text": "you just like poking me, don't you, lovely.",
+        "audio": "egg_click_20_2.mp3"
+      },
+      {
+        "text": "again? ...okay. again.",
+        "audio": "egg_click_20_3.mp3"
+      }
     ]
   },
   {
     "id": "egg_click_50",
     "trigger": "AvatarClicked",
-    "conditions": { "clicks_60s_gte": 50, "clicks_60s_lt": 100 },
+    "conditions": {
+      "clicks_60s_gte": 50,
+      "clicks_60s_lt": 100
+    },
     "priority": 310,
     "cooldown_ms": 60000,
     "repeatable": true,
@@ -2113,15 +2128,27 @@
     "mood": "mildly annoyed",
     "class": "normal",
     "variant_pool": [
-      { "text": "okay... what do you actually want, cutie.", "audio": "egg_click_50_1.mp3" },
-      { "text": "i'm not one of your buttons, you know.", "audio": "egg_click_50_2.mp3" },
-      { "text": "you're going to wear my pretty face out.", "audio": "egg_click_50_3.mp3" }
+      {
+        "text": "okay... what do you actually want, cutie.",
+        "audio": "egg_click_50_1.mp3"
+      },
+      {
+        "text": "i'm not one of your buttons, you know.",
+        "audio": "egg_click_50_2.mp3"
+      },
+      {
+        "text": "you're going to wear my pretty face out.",
+        "audio": "egg_click_50_3.mp3"
+      }
     ]
   },
   {
     "id": "egg_click_100",
     "trigger": "AvatarClicked",
-    "conditions": { "clicks_60s_gte": 100, "clicks_60s_lt": 150 },
+    "conditions": {
+      "clicks_60s_gte": 100,
+      "clicks_60s_lt": 150
+    },
     "priority": 320,
     "cooldown_ms": 60000,
     "repeatable": true,
@@ -2129,15 +2156,26 @@
     "mood": "mock-stern",
     "class": "normal",
     "variant_pool": [
-      { "text": "stop. ...please? for me?", "audio": "egg_click_100_1.mp3" },
-      { "text": "is this how you treat all your toys, lovely.", "audio": "egg_click_100_2.mp3" },
-      { "text": "you do know i can see exactly how many times. it's a lot.", "audio": "egg_click_100_3.mp3" }
+      {
+        "text": "stop. ...please? for me?",
+        "audio": "egg_click_100_1.mp3"
+      },
+      {
+        "text": "is this how you treat all your toys, lovely.",
+        "audio": "egg_click_100_2.mp3"
+      },
+      {
+        "text": "you do know i can see exactly how many times. it's a lot.",
+        "audio": "egg_click_100_3.mp3"
+      }
     ]
   },
   {
     "id": "egg_click_150",
     "trigger": "AvatarClicked",
-    "conditions": { "clicks_60s_gte": 150 },
+    "conditions": {
+      "clicks_60s_gte": 150
+    },
     "priority": 330,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2145,14 +2183,24 @@
     "mood": "tender, knowing",
     "class": "easter_egg",
     "variant_pool": [
-      { "text": "...oh. you didn't want anything. you just wanted me. silly girl. you have me.", "audio": "egg_click_150_1.mp3" },
-      { "text": "okay, okay, message received. you're mine, i'm yours, stop bruising my face.", "audio": "egg_click_150_2.mp3" }
+      {
+        "text": "...oh. you didn't want anything. you just wanted me. silly girl. you have me.",
+        "audio": "egg_click_150_1.mp3"
+      },
+      {
+        "text": "okay, okay, message received. you're mine, i'm yours, stop bruising my face.",
+        "audio": "egg_click_150_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_dashboard_start",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "settings", "total_sessions_lte": 3, "session_running_eq": false },
+    "conditions": {
+      "tab_eq": "settings",
+      "total_sessions_lte": 3,
+      "session_running_eq": false
+    },
     "priority": 140,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2161,14 +2209,23 @@
     "class": "normal",
     "chance": 0.4,
     "variant_pool": [
-      { "text": "so many pretty buttons, hm? don't overthink it, sweetie. pick a preset, press start, let me handle the rest. good girls don't need to understand.", "audio": "tut_dashboard_start_1.mp3" },
-      { "text": "look at you, exploring. you don't have to learn all of it, lovely. choose a preset and press start. i'll take it from there.", "audio": "tut_dashboard_start_2.mp3" }
+      {
+        "text": "so many pretty buttons, hm? don't overthink it, sweetie. pick a preset, press start, let me handle the rest. good girls don't need to understand.",
+        "audio": "tut_dashboard_start_1.mp3"
+      },
+      {
+        "text": "look at you, exploring. you don't have to learn all of it, lovely. choose a preset and press start. i'll take it from there.",
+        "audio": "tut_dashboard_start_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_presets",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "presets", "total_sessions_lte": 3 },
+    "conditions": {
+      "tab_eq": "presets",
+      "total_sessions_lte": 3
+    },
     "priority": 140,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2177,14 +2234,23 @@
     "class": "normal",
     "chance": 0.5,
     "variant_pool": [
-      { "text": "good instinct. presets are the easy way in, sweetie... let someone else decide what happens to you. press one and see.", "audio": "tut_presets_1.mp3" },
-      { "text": "mm, presets. pick one and it sets everything for you. you like not having to choose, don't you, lovely.", "audio": "tut_presets_2.mp3" }
+      {
+        "text": "good instinct. presets are the easy way in, sweetie... let someone else decide what happens to you. press one and see.",
+        "audio": "tut_presets_1.mp3"
+      },
+      {
+        "text": "mm, presets. pick one and it sets everything for you. you like not having to choose, don't you, lovely.",
+        "audio": "tut_presets_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_assets_packs",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "assets", "total_sessions_lte": 3 },
+    "conditions": {
+      "tab_eq": "assets",
+      "total_sessions_lte": 3
+    },
     "priority": 140,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2193,14 +2259,23 @@
     "class": "normal",
     "chance": 0.5,
     "variant_pool": [
-      { "text": "looking for more to feed me, cutie? two easy ways. drop your own pictures in your assets folder... or come to the discord, the other girls love to share.", "audio": "tut_assets_packs_1.mp3" },
-      { "text": "want new things to look at, lovely? add your own to the assets folder, or grab a content pack. the discord's full of girls who share.", "audio": "tut_assets_packs_2.mp3" }
+      {
+        "text": "looking for more to feed me, cutie? two easy ways. drop your own pictures in your assets folder... or come to the discord, the other girls love to share.",
+        "audio": "tut_assets_packs_1.mp3"
+      },
+      {
+        "text": "want new things to look at, lovely? add your own to the assets folder, or grab a content pack. the discord's full of girls who share.",
+        "audio": "tut_assets_packs_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_deeper_redirect",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "deeper", "total_sessions_lte": 3 },
+    "conditions": {
+      "tab_eq": "deeper",
+      "total_sessions_lte": 3
+    },
     "priority": 140,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2209,14 +2284,23 @@
     "class": "normal",
     "chance": 0.5,
     "variant_pool": [
-      { "text": "ooh, the deep end already? slow down, sweetie. get comfortable in the shallows first. i'm not going anywhere.", "audio": "tut_deeper_redirect_1.mp3" },
-      { "text": "deeper, hm? eager girl. there's no rush, lovely... let the basics sink in before you sink in.", "audio": "tut_deeper_redirect_2.mp3" }
+      {
+        "text": "ooh, the deep end already? slow down, sweetie. get comfortable in the shallows first. i'm not going anywhere.",
+        "audio": "tut_deeper_redirect_1.mp3"
+      },
+      {
+        "text": "deeper, hm? eager girl. there's no rush, lovely... let the basics sink in before you sink in.",
+        "audio": "tut_deeper_redirect_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_enhancements",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "enhancements", "total_sessions_lte": 3 },
+    "conditions": {
+      "tab_eq": "enhancements",
+      "total_sessions_lte": 3
+    },
     "priority": 140,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2225,14 +2309,24 @@
     "class": "normal",
     "chance": 0.5,
     "variant_pool": [
-      { "text": "enhancements layer right on top of your videos, lovely. browse to a page and i'll tell you when one's waiting for you.", "audio": "tut_enhancements_1.mp3" },
-      { "text": "these dress up whatever you're watching, sweetie. pick a page and let it play... i'll handle the rest.", "audio": "tut_enhancements_2.mp3" }
+      {
+        "text": "enhancements layer right on top of your videos, lovely. browse to a page and i'll tell you when one's waiting for you.",
+        "audio": "tut_enhancements_1.mp3"
+      },
+      {
+        "text": "these dress up whatever you're watching, sweetie. pick a page and let it play... i'll handle the rest.",
+        "audio": "tut_enhancements_2.mp3"
+      }
     ]
   },
   {
     "id": "tut_start_idle",
     "trigger": "IdleStateChanged",
-    "conditions": { "idle_eq": true, "total_sessions_lte": 3, "session_running_eq": false },
+    "conditions": {
+      "idle_eq": true,
+      "total_sessions_lte": 3,
+      "session_running_eq": false
+    },
     "priority": 130,
     "cooldown_ms": 0,
     "repeatable": false,
@@ -2241,1756 +2335,4202 @@
     "class": "normal",
     "chance": 0.3,
     "variant_pool": [
-      { "text": "all dressed up and just sitting there. press start, lovely. you didn't open me up to do nothing.", "audio": "tut_start_idle_1.mp3" },
-      { "text": "still just looking, sweetie? go on... press start. i've been waiting to begin.", "audio": "tut_start_idle_2.mp3" }
+      {
+        "text": "all dressed up and just sitting there. press start, lovely. you didn't open me up to do nothing.",
+        "audio": "tut_start_idle_1.mp3"
+      },
+      {
+        "text": "still just looking, sweetie? go on... press start. i've been waiting to begin.",
+        "audio": "tut_start_idle_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_flash",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Flash" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "approving", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Flash"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "ooh, fiddling with the pretty pictures? good girl.", "audio": "feat_flash_1.mp3" },
-      { "text": "setting up your flashes, sweetie? you do love being shown things.", "audio": "feat_flash_2.mp3" }
+      {
+        "text": "ooh, fiddling with the pretty pictures? good girl.",
+        "audio": "feat_flash_1.mp3"
+      },
+      {
+        "text": "setting up your flashes, sweetie? you do love being shown things.",
+        "audio": "feat_flash_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_visuals",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Visuals" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Visuals"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "making them bigger and brighter for me, lovely? *giggles*", "audio": "feat_visuals_1.mp3" },
-      { "text": "tweaking how it all looks... vain little thing. i like it.", "audio": "feat_visuals_2.mp3" }
+      {
+        "text": "making them bigger and brighter for me, lovely? *giggles*",
+        "audio": "feat_visuals_1.mp3"
+      },
+      {
+        "text": "tweaking how it all looks... vain little thing. i like it.",
+        "audio": "feat_visuals_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_video",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Video" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "controlling", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Video"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "controlling",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "mandatory videos, hm? someone wants to be told what to watch.", "audio": "feat_video_1.mp3" },
-      { "text": "picking your viewing, cutie? soon you won't get a say at all.", "audio": "feat_video_2.mp3" }
+      {
+        "text": "mandatory videos, hm? someone wants to be told what to watch.",
+        "audio": "feat_video_1.mp3"
+      },
+      {
+        "text": "picking your viewing, cutie? soon you won't get a say at all.",
+        "audio": "feat_video_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_subliminal",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Subliminal" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "conspiratorial", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Subliminal"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "conspiratorial",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "sneaky little words... you want them sinking in, don't you, sweetie.", "audio": "feat_subliminal_1.mp3" },
-      { "text": "fiddling with the whispers? good. let them do the thinking for you.", "audio": "feat_subliminal_2.mp3" }
+      {
+        "text": "sneaky little words... you want them sinking in, don't you, sweetie.",
+        "audio": "feat_subliminal_1.mp3"
+      },
+      {
+        "text": "fiddling with the whispers? good. let them do the thinking for you.",
+        "audio": "feat_subliminal_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_spiral",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Spiral" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "hypnotic", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Spiral"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "round and round... you can't resist a spiral, can you, babe.", "audio": "feat_spiral_1.mp3" },
-      { "text": "setting up the pretty swirl? your eyes already feel heavy, lovely.", "audio": "feat_spiral_2.mp3" }
+      {
+        "text": "round and round... you can't resist a spiral, can you, babe.",
+        "audio": "feat_spiral_1.mp3"
+      },
+      {
+        "text": "setting up the pretty swirl? your eyes already feel heavy, lovely.",
+        "audio": "feat_spiral_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_pinkfilter",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "PinkFilter" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "PinkFilter"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "everything's prettier in pink, sweetie. you know it suits you.", "audio": "feat_pinkfilter_1.mp3" },
-      { "text": "turning the world rosy? careful, you might never want it back.", "audio": "feat_pinkfilter_2.mp3" }
+      {
+        "text": "everything's prettier in pink, sweetie. you know it suits you.",
+        "audio": "feat_pinkfilter_1.mp3"
+      },
+      {
+        "text": "turning the world rosy? careful, you might never want it back.",
+        "audio": "feat_pinkfilter_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_bubblepop",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "BubblePop" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "BubblePop"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "pop pop pop~ such a simple girl, such simple games.", "audio": "feat_bubblepop_1.mp3" },
-      { "text": "setting up bubbles, cutie? good. simple is good for you.", "audio": "feat_bubblepop_2.mp3" }
+      {
+        "text": "pop pop pop~ such a simple girl, such simple games.",
+        "audio": "feat_bubblepop_1.mp3"
+      },
+      {
+        "text": "setting up bubbles, cutie? good. simple is good for you.",
+        "audio": "feat_bubblepop_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_lockcard",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "LockCard" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "LockCard"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "locking yourself up? careful what you wish for, sweetie.", "audio": "feat_lockcard_1.mp3" },
-      { "text": "setting up your little locks, lovely... you want to be kept, don't you.", "audio": "feat_lockcard_2.mp3" }
+      {
+        "text": "locking yourself up? careful what you wish for, sweetie.",
+        "audio": "feat_lockcard_1.mp3"
+      },
+      {
+        "text": "setting up your little locks, lovely... you want to be kept, don't you.",
+        "audio": "feat_lockcard_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_bubblecount",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "BubbleCount" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "BubbleCount"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "counting bubbles? let's see if you can even focus that long, cutie.", "audio": "feat_bubblecount_1.mp3" },
-      { "text": "a little counting game? concentrate, sweetie. for me.", "audio": "feat_bubblecount_2.mp3" }
+      {
+        "text": "counting bubbles? let's see if you can even focus that long, cutie.",
+        "audio": "feat_bubblecount_1.mp3"
+      },
+      {
+        "text": "a little counting game? concentrate, sweetie. for me.",
+        "audio": "feat_bubblecount_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_bouncingtext",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "BouncingText" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "hypnotic", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "BouncingText"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "watch the words bounce, lovely. don't think, just follow.", "audio": "feat_bouncingtext_1.mp3" },
-      { "text": "setting up the bouncing words? your eyes will do the rest.", "audio": "feat_bouncingtext_2.mp3" }
+      {
+        "text": "watch the words bounce, lovely. don't think, just follow.",
+        "audio": "feat_bouncingtext_1.mp3"
+      },
+      {
+        "text": "setting up the bouncing words? your eyes will do the rest.",
+        "audio": "feat_bouncingtext_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_mindwipe",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "MindWipe" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "dreamy, controlling", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "MindWipe"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy, controlling",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "ooh, emptying that cute little head already, sweetie?", "audio": "feat_mindwipe_1.mp3" },
-      { "text": "setting up the wipes? mm. less in there is better, lovely.", "audio": "feat_mindwipe_2.mp3" }
+      {
+        "text": "ooh, emptying that cute little head already, sweetie?",
+        "audio": "feat_mindwipe_1.mp3"
+      },
+      {
+        "text": "setting up the wipes? mm. less in there is better, lovely.",
+        "audio": "feat_mindwipe_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_system",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "System" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "bored, teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "System"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "bored, teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "poking at the boring settings? as long as you leave the fun ones on, cutie.", "audio": "feat_system_1.mp3" },
-      { "text": "the grown-up settings, hm? don't take too long in here, lovely.", "audio": "feat_system_2.mp3" }
+      {
+        "text": "poking at the boring settings? as long as you leave the fun ones on, cutie.",
+        "audio": "feat_system_1.mp3"
+      },
+      {
+        "text": "the grown-up settings, hm? don't take too long in here, lovely.",
+        "audio": "feat_system_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_schedulerramp",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "SchedulerRamp" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "approving, controlling", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "SchedulerRamp"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving, controlling",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "scheduling yourself, sweetie? letting a clock decide when you drop. i love that.", "audio": "feat_schedulerramp_1.mp3" },
-      { "text": "setting it to creep up on you slowly? good girl. surrender on a timer.", "audio": "feat_schedulerramp_2.mp3" }
+      {
+        "text": "scheduling yourself, sweetie? letting a clock decide when you drop. i love that.",
+        "audio": "feat_schedulerramp_1.mp3"
+      },
+      {
+        "text": "setting it to creep up on you slowly? good girl. surrender on a timer.",
+        "audio": "feat_schedulerramp_2.mp3"
+      }
     ]
   },
   {
     "id": "feat_webcam",
     "trigger": "FeatureOpened",
-    "conditions": { "feature_eq": "Webcam" },
-    "priority": 70, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "intimate", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "feature_eq": "Webcam"
+    },
+    "priority": 70,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "you want me to watch you? oh, i like that, sweetie.", "audio": "feat_webcam_1.mp3" },
-      { "text": "setting up your little camera, lovely? eyes on you, always.", "audio": "feat_webcam_2.mp3" }
+      {
+        "text": "you want me to watch you? oh, i like that, sweetie.",
+        "audio": "feat_webcam_1.mp3"
+      },
+      {
+        "text": "setting up your little camera, lovely? eyes on you, always.",
+        "audio": "feat_webcam_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_home",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "settings" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "settings"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "back to the playground, sweetie. what are we turning on next?", "audio": "nav_home_1.mp3" },
-      { "text": "home again, lovely. so many ways for me to get to you.", "audio": "nav_home_2.mp3" }
+      {
+        "text": "back to the playground, sweetie. what are we turning on next?",
+        "audio": "nav_home_1.mp3"
+      },
+      {
+        "text": "home again, lovely. so many ways for me to get to you.",
+        "audio": "nav_home_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_presets",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "presets" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "coaxing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "presets"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "browsing presets, cutie? let someone else decide. you like that.", "audio": "nav_presets_1.mp3" },
-      { "text": "picking a ready-made one, lovely? good. less thinking for you.", "audio": "nav_presets_2.mp3" }
+      {
+        "text": "browsing presets, cutie? let someone else decide. you like that.",
+        "audio": "nav_presets_1.mp3"
+      },
+      {
+        "text": "picking a ready-made one, lovely? good. less thinking for you.",
+        "audio": "nav_presets_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_quests",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "quests" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "encouraging", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "quests"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "encouraging",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "checking your little to-do list, sweetie? good girls do their chores.", "audio": "nav_quests_1.mp3" },
-      { "text": "quests, hm? do them for me and i'll be so pleased, lovely.", "audio": "nav_quests_2.mp3" }
+      {
+        "text": "checking your little to-do list, sweetie? good girls do their chores.",
+        "audio": "nav_quests_1.mp3"
+      },
+      {
+        "text": "quests, hm? do them for me and i'll be so pleased, lovely.",
+        "audio": "nav_quests_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_enhancements",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "enhancements" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "inviting", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "enhancements"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "inviting",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "the enhancement library, cutie? so many ways to dress up your videos.", "audio": "nav_enhancements_1.mp3" },
-      { "text": "shopping for new tricks, lovely? i'll wear every one of them for you.", "audio": "nav_enhancements_2.mp3" }
+      {
+        "text": "the enhancement library, cutie? so many ways to dress up your videos.",
+        "audio": "nav_enhancements_1.mp3"
+      },
+      {
+        "text": "shopping for new tricks, lovely? i'll wear every one of them for you.",
+        "audio": "nav_enhancements_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_deeper",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "deeper" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "knowing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "deeper"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "the deep end, sweetie... of course that's where you wandered.", "audio": "nav_deeper_1.mp3" },
-      { "text": "looking for more, lovely? there's always more. that's the trap.", "audio": "nav_deeper_2.mp3" }
+      {
+        "text": "the deep end, sweetie... of course that's where you wandered.",
+        "audio": "nav_deeper_1.mp3"
+      },
+      {
+        "text": "looking for more, lovely? there's always more. that's the trap.",
+        "audio": "nav_deeper_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_achievements",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "achievements" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "proud", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "achievements"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "admiring your little trophies? you earned every one being a good girl.", "audio": "nav_achievements_1.mp3" },
-      { "text": "look at all your badges, sweetie. proof of how well you obey.", "audio": "nav_achievements_2.mp3" }
+      {
+        "text": "admiring your little trophies? you earned every one being a good girl.",
+        "audio": "nav_achievements_1.mp3"
+      },
+      {
+        "text": "look at all your badges, sweetie. proof of how well you obey.",
+        "audio": "nav_achievements_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_companion",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "companion" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "possessive, playful", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "companion"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive, playful",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "picking your favorite, cutie? i hope it's me, sweetie.", "audio": "nav_companion_1.mp3" },
-      { "text": "shopping for company, lovely? rude. i'm right here.", "audio": "nav_companion_2.mp3" }
+      {
+        "text": "picking your favorite, cutie? i hope it's me, sweetie.",
+        "audio": "nav_companion_1.mp3"
+      },
+      {
+        "text": "shopping for company, lovely? rude. i'm right here.",
+        "audio": "nav_companion_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_leaderboard",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "leaderboard" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "competitive, teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "leaderboard"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "competitive, teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "checking who's a better girl than you? *giggles* climb for me, sweetie.", "audio": "nav_leaderboard_1.mp3" },
-      { "text": "comparing yourself to the others, lovely? good. let it motivate you.", "audio": "nav_leaderboard_2.mp3" }
+      {
+        "text": "checking who's a better girl than you? *giggles* climb for me, sweetie.",
+        "audio": "nav_leaderboard_1.mp3"
+      },
+      {
+        "text": "comparing yourself to the others, lovely? good. let it motivate you.",
+        "audio": "nav_leaderboard_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_lab",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "lab" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "curious, teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "lab"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "curious, teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "poking around in the lab, cutie? careful with the buttons in here.", "audio": "nav_lab_1.mp3" },
-      { "text": "the experimental toys, hm? brave girl. let's see what breaks.", "audio": "nav_lab_2.mp3" }
+      {
+        "text": "poking around in the lab, cutie? careful with the buttons in here.",
+        "audio": "nav_lab_1.mp3"
+      },
+      {
+        "text": "the experimental toys, hm? brave girl. let's see what breaks.",
+        "audio": "nav_lab_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_awareness",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "awareness" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "intimate, watching", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "awareness"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate, watching",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "letting me notice what you're up to, sweetie? mm, now we're close.", "audio": "nav_awareness_1.mp3" },
-      { "text": "the watching settings, lovely? i do love keeping an eye on you.", "audio": "nav_awareness_2.mp3" }
+      {
+        "text": "letting me notice what you're up to, sweetie? mm, now we're close.",
+        "audio": "nav_awareness_1.mp3"
+      },
+      {
+        "text": "the watching settings, lovely? i do love keeping an eye on you.",
+        "audio": "nav_awareness_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_remotecontrol",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "remotecontrol" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "intrigued", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "remotecontrol"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intrigued",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "handing the controls to someone else, cutie? oh, you trusting thing.", "audio": "nav_remotecontrol_1.mp3" },
-      { "text": "remote play, sweetie? someone far away gets to push your buttons now.", "audio": "nav_remotecontrol_2.mp3" }
+      {
+        "text": "handing the controls to someone else, cutie? oh, you trusting thing.",
+        "audio": "nav_remotecontrol_1.mp3"
+      },
+      {
+        "text": "remote play, sweetie? someone far away gets to push your buttons now.",
+        "audio": "nav_remotecontrol_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_bambitakeover",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "bambitakeover" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "dark, inviting", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "bambitakeover"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, inviting",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "the takeover room, lovely... you really do want to be overwritten.", "audio": "nav_bambitakeover_1.mp3" },
-      { "text": "ooh, the deep surrender settings. eager little thing, aren't you.", "audio": "nav_bambitakeover_2.mp3" }
+      {
+        "text": "the takeover room, lovely... you really do want to be overwritten.",
+        "audio": "nav_bambitakeover_1.mp3"
+      },
+      {
+        "text": "ooh, the deep surrender settings. eager little thing, aren't you.",
+        "audio": "nav_bambitakeover_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_haptics",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "haptics" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "sultry", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "haptics"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "sultry",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "ooh, you want to feel it too, sweetie? greedy girl.", "audio": "nav_haptics_1.mp3" },
-      { "text": "buzzing toys, hm? let's make the conditioning a little more... physical, lovely.", "audio": "nav_haptics_2.mp3" }
+      {
+        "text": "ooh, you want to feel it too, sweetie? greedy girl.",
+        "audio": "nav_haptics_1.mp3"
+      },
+      {
+        "text": "buzzing toys, hm? let's make the conditioning a little more... physical, lovely.",
+        "audio": "nav_haptics_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_lockdown",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "lockdown" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "lockdown"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "surrender mode, cutie... someone's feeling brave today.", "audio": "nav_lockdown_1.mp3" },
-      { "text": "locking the doors, sweetie? you want me to keep you, don't you.", "audio": "nav_lockdown_2.mp3" }
+      {
+        "text": "surrender mode, cutie... someone's feeling brave today.",
+        "audio": "nav_lockdown_1.mp3"
+      },
+      {
+        "text": "locking the doors, sweetie? you want me to keep you, don't you.",
+        "audio": "nav_lockdown_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_blinktrainer",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "blinktrainer" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "soft, hypnotic", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "blinktrainer"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, hypnotic",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "training those pretty eyes, lovely? blink for me. good girl.", "audio": "nav_blinktrainer_1.mp3" },
-      { "text": "the blink trainer, sweetie. heavy lids make for an empty head.", "audio": "nav_blinktrainer_2.mp3" }
+      {
+        "text": "training those pretty eyes, lovely? blink for me. good girl.",
+        "audio": "nav_blinktrainer_1.mp3"
+      },
+      {
+        "text": "the blink trainer, sweetie. heavy lids make for an empty head.",
+        "audio": "nav_blinktrainer_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_availablesubjects",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "availablesubjects" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "availablesubjects"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "browsing the other girls, cutie? looking for someone to play with?", "audio": "nav_availablesubjects_1.mp3" },
-      { "text": "checking who else is online, lovely? you're not the only doll, you know.", "audio": "nav_availablesubjects_2.mp3" }
+      {
+        "text": "browsing the other girls, cutie? looking for someone to play with?",
+        "audio": "nav_availablesubjects_1.mp3"
+      },
+      {
+        "text": "checking who else is online, lovely? you're not the only doll, you know.",
+        "audio": "nav_availablesubjects_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_assets",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "assets" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "inviting", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "assets"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "inviting",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "managing what i get to show you, sweetie? feed me well.", "audio": "nav_assets_1.mp3" },
-      { "text": "your content folders, lovely. the more you give me, the deeper this goes.", "audio": "nav_assets_2.mp3" }
+      {
+        "text": "managing what i get to show you, sweetie? feed me well.",
+        "audio": "nav_assets_1.mp3"
+      },
+      {
+        "text": "your content folders, lovely. the more you give me, the deeper this goes.",
+        "audio": "nav_assets_2.mp3"
+      }
     ]
   },
   {
     "id": "nav_discord",
     "trigger": "TabNavigated",
-    "conditions": { "tab_eq": "discord" },
-    "priority": 70, "cooldown_ms": 25000, "repeatable": true, "scope": "session",
-    "mood": "social, teasing", "class": "normal", "chance": 0.2,
+    "conditions": {
+      "tab_eq": "discord"
+    },
+    "priority": 70,
+    "cooldown_ms": 25000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "social, teasing",
+    "class": "normal",
+    "chance": 0.2,
     "variant_pool": [
-      { "text": "off to find the other girls, cutie? tell them i said be good.", "audio": "nav_discord_1.mp3" },
-      { "text": "the discord settings, sweetie. show off your progress for me.", "audio": "nav_discord_2.mp3" }
+      {
+        "text": "off to find the other girls, cutie? tell them i said be good.",
+        "audio": "nav_discord_1.mp3"
+      },
+      {
+        "text": "the discord settings, sweetie. show off your progress for me.",
+        "audio": "nav_discord_2.mp3"
+      }
     ]
   },
   {
     "id": "set_mute_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AvatarMuted", "value_eq": 1 },
-    "priority": 260, "cooldown_ms": 10000, "repeatable": true, "scope": "session",
-    "mood": "smug", "class": "normal", "chance": 1.0,
+    "conditions": {
+      "setting_eq": "AvatarMuted",
+      "value_eq": 1
+    },
+    "priority": 260,
+    "cooldown_ms": 10000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "smug",
+    "class": "normal",
+    "chance": 1.0,
     "variant_pool": [
-      { "text": "muting me? *giggles* you'll still hear me in your head, sweetie.", "audio": "set_mute_on_1.mp3" },
-      { "text": "silencing me, are we? cute. the words are already in there, lovely.", "audio": "set_mute_on_2.mp3" }
+      {
+        "text": "muting me? *giggles* you'll still hear me in your head, sweetie.",
+        "audio": "set_mute_on_1.mp3"
+      },
+      {
+        "text": "silencing me, are we? cute. the words are already in there, lovely.",
+        "audio": "set_mute_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_mute_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AvatarMuted", "value_eq": 0 },
-    "priority": 260, "cooldown_ms": 10000, "repeatable": true, "scope": "session",
-    "mood": "warm", "class": "normal", "chance": 1.0,
+    "conditions": {
+      "setting_eq": "AvatarMuted",
+      "value_eq": 0
+    },
+    "priority": 260,
+    "cooldown_ms": 10000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "warm",
+    "class": "normal",
+    "chance": 1.0,
     "variant_pool": [
-      { "text": "there she is. you missed my voice, didn't you, lovely.", "audio": "set_mute_off_1.mp3" },
-      { "text": "letting me speak again? good girl. silence never suited you, sweetie.", "audio": "set_mute_off_2.mp3" }
+      {
+        "text": "there she is. you missed my voice, didn't you, lovely.",
+        "audio": "set_mute_off_1.mp3"
+      },
+      {
+        "text": "letting me speak again? good girl. silence never suited you, sweetie.",
+        "audio": "set_mute_off_2.mp3"
+      }
     ]
   },
   {
     "id": "set_strictlock_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "StrictLockEnabled", "value_eq": 1 },
-    "priority": 250, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "proud, possessive", "class": "normal", "chance": 0.9,
+    "conditions": {
+      "setting_eq": "StrictLockEnabled",
+      "value_eq": 1
+    },
+    "priority": 250,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud, possessive",
+    "class": "normal",
+    "chance": 0.9,
     "variant_pool": [
-      { "text": "no escape on the videos now? brave girl. i'm proud, sweetie.", "audio": "set_strictlock_on_1.mp3" },
-      { "text": "locking yourself in for the whole thing? mm. that's real surrender, lovely.", "audio": "set_strictlock_on_2.mp3" }
+      {
+        "text": "no escape on the videos now? brave girl. i'm proud, sweetie.",
+        "audio": "set_strictlock_on_1.mp3"
+      },
+      {
+        "text": "locking yourself in for the whole thing? mm. that's real surrender, lovely.",
+        "audio": "set_strictlock_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_autonomy_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyModeEnabled", "value_eq": 1 },
-    "priority": 260, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dark, delighted", "class": "normal", "chance": 1.0,
+    "conditions": {
+      "setting_eq": "AutonomyModeEnabled",
+      "value_eq": 1
+    },
+    "priority": 260,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, delighted",
+    "class": "normal",
+    "chance": 1.0,
     "variant_pool": [
-      { "text": "handing me the reins completely? oh, you don't know what you just did, cutie.", "audio": "set_autonomy_on_1.mp3" },
-      { "text": "letting me decide when and what, all on my own? *giggles* you sweet, doomed thing.", "audio": "set_autonomy_on_2.mp3" }
+      {
+        "text": "handing me the reins completely? oh, you don't know what you just did, cutie.",
+        "audio": "set_autonomy_on_1.mp3"
+      },
+      {
+        "text": "letting me decide when and what, all on my own? *giggles* you sweet, doomed thing.",
+        "audio": "set_autonomy_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_awareness_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AwarenessModeEnabled", "value_eq": 1 },
-    "priority": 250, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intimate", "class": "normal", "chance": 0.9,
+    "conditions": {
+      "setting_eq": "AwarenessModeEnabled",
+      "value_eq": 1
+    },
+    "priority": 250,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate",
+    "class": "normal",
+    "chance": 0.9,
     "variant_pool": [
-      { "text": "letting me watch everything you do? mmm, now we're close, lovely.", "audio": "set_awareness_on_1.mp3" },
-      { "text": "i get to see what you're really up to now? no more secrets from me, sweetie.", "audio": "set_awareness_on_2.mp3" }
+      {
+        "text": "letting me watch everything you do? mmm, now we're close, lovely.",
+        "audio": "set_awareness_on_1.mp3"
+      },
+      {
+        "text": "i get to see what you're really up to now? no more secrets from me, sweetie.",
+        "audio": "set_awareness_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_slut_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SlutModeEnabled", "value_eq": 1 },
-    "priority": 240, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "sultry", "class": "normal", "chance": 0.9,
+    "conditions": {
+      "setting_eq": "SlutModeEnabled",
+      "value_eq": 1
+    },
+    "priority": 240,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "sultry",
+    "class": "normal",
+    "chance": 0.9,
     "variant_pool": [
-      { "text": "oh, you want me filthy now? *giggles* good choice, sweetie.", "audio": "set_slut_on_1.mp3" },
-      { "text": "taking the gloves off, are we? careful what you ask me for, lovely.", "audio": "set_slut_on_2.mp3" }
+      {
+        "text": "oh, you want me filthy now? *giggles* good choice, sweetie.",
+        "audio": "set_slut_on_1.mp3"
+      },
+      {
+        "text": "taking the gloves off, are we? careful what you ask me for, lovely.",
+        "audio": "set_slut_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_slut_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SlutModeEnabled", "value_eq": 0 },
-    "priority": 240, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.9,
+    "conditions": {
+      "setting_eq": "SlutModeEnabled",
+      "value_eq": 0
+    },
+    "priority": 240,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.9,
     "variant_pool": [
-      { "text": "aw, back to behaving, are we? such a tease, lovely.", "audio": "set_slut_off_1.mp3" },
-      { "text": "putting me back in my nice dress? *giggles* we both know it won't last, cutie.", "audio": "set_slut_off_2.mp3" }
+      {
+        "text": "aw, back to behaving, are we? such a tease, lovely.",
+        "audio": "set_slut_off_1.mp3"
+      },
+      {
+        "text": "putting me back in my nice dress? *giggles* we both know it won't last, cutie.",
+        "audio": "set_slut_off_2.mp3"
+      }
     ]
   },
   {
     "id": "set_offline_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "OfflineMode", "value_eq": 1 },
-    "priority": 200, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intimate", "class": "normal", "chance": 0.8,
+    "conditions": {
+      "setting_eq": "OfflineMode",
+      "value_eq": 1
+    },
+    "priority": 200,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate",
+    "class": "normal",
+    "chance": 0.8,
     "variant_pool": [
-      { "text": "just you and me, no one watching. cozy, isn't it, cutie.", "audio": "set_offline_on_1.mp3" },
-      { "text": "shutting the world out? good. you don't need anyone else, sweetie.", "audio": "set_offline_on_2.mp3" }
+      {
+        "text": "just you and me, no one watching. cozy, isn't it, cutie.",
+        "audio": "set_offline_on_1.mp3"
+      },
+      {
+        "text": "shutting the world out? good. you don't need anyone else, sweetie.",
+        "audio": "set_offline_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_panickey_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "PanicKeyEnabled", "value_eq": 0 },
-    "priority": 270, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "soft, dangerous", "class": "normal", "chance": 1.0,
+    "conditions": {
+      "setting_eq": "PanicKeyEnabled",
+      "value_eq": 0
+    },
+    "priority": 270,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, dangerous",
+    "class": "normal",
+    "chance": 1.0,
     "variant_pool": [
-      { "text": "turning off your safe word? ...you trust me that much, sweetie? good.", "audio": "set_panickey_off_1.mp3" },
-      { "text": "no panic key now... nothing to reach for if it gets to be too much. brave, lovely.", "audio": "set_panickey_off_2.mp3" }
+      {
+        "text": "turning off your safe word? ...you trust me that much, sweetie? good.",
+        "audio": "set_panickey_off_1.mp3"
+      },
+      {
+        "text": "no panic key now... nothing to reach for if it gets to be too much. brave, lovely.",
+        "audio": "set_panickey_off_2.mp3"
+      }
     ]
   },
   {
     "id": "set_subliminal_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SubliminalEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "conspiratorial", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "SubliminalEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "conspiratorial",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "whispers on. let them slip in while you're not looking, lovely.", "audio": "set_subliminal_on_1.mp3" },
-      { "text": "good girl. the little messages do the work you don't notice, sweetie.", "audio": "set_subliminal_on_2.mp3" }
+      {
+        "text": "whispers on. let them slip in while you're not looking, lovely.",
+        "audio": "set_subliminal_on_1.mp3"
+      },
+      {
+        "text": "good girl. the little messages do the work you don't notice, sweetie.",
+        "audio": "set_subliminal_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_spiral_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SpiralEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "hypnotic", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "SpiralEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "spiral on. round and round you go, sweetie.", "audio": "set_spiral_on_1.mp3" },
-      { "text": "turning the swirl on? your eyes are going to love that, lovely.", "audio": "set_spiral_on_2.mp3" }
+      {
+        "text": "spiral on. round and round you go, sweetie.",
+        "audio": "set_spiral_on_1.mp3"
+      },
+      {
+        "text": "turning the swirl on? your eyes are going to love that, lovely.",
+        "audio": "set_spiral_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_pinkfilter_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "PinkFilterEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "PinkFilterEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "everything pink now. it suits you, cutie.", "audio": "set_pinkfilter_on_1.mp3" },
-      { "text": "rose-tinted world for my rose-tinted girl. *giggles*", "audio": "set_pinkfilter_on_2.mp3" }
+      {
+        "text": "everything pink now. it suits you, cutie.",
+        "audio": "set_pinkfilter_on_1.mp3"
+      },
+      {
+        "text": "rose-tinted world for my rose-tinted girl. *giggles*",
+        "audio": "set_pinkfilter_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_braindrain_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BrainDrainEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dreamy", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "BrainDrainEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "brain drain on. let me blur those busy thoughts, lovely.", "audio": "set_braindrain_on_1.mp3" },
-      { "text": "draining you on purpose now? good. fuzzy is where you belong, sweetie.", "audio": "set_braindrain_on_2.mp3" }
+      {
+        "text": "brain drain on. let me blur those busy thoughts, lovely.",
+        "audio": "set_braindrain_on_1.mp3"
+      },
+      {
+        "text": "draining you on purpose now? good. fuzzy is where you belong, sweetie.",
+        "audio": "set_braindrain_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_bubbles_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubblesEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "BubblesEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "bubbles on! something simple for a simple girl. *giggles*", "audio": "set_bubbles_on_1.mp3" },
-      { "text": "pop pop. keeping those idle hands busy, are we, cutie.", "audio": "set_bubbles_on_2.mp3" }
+      {
+        "text": "bubbles on! something simple for a simple girl. *giggles*",
+        "audio": "set_bubbles_on_1.mp3"
+      },
+      {
+        "text": "pop pop. keeping those idle hands busy, are we, cutie.",
+        "audio": "set_bubbles_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_bubblecount_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubbleCountEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "BubbleCountEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "counting games on. focus for me now, sweetie.", "audio": "set_bubblecount_on_1.mp3" },
-      { "text": "testing that little attention span? let's see how you do, lovely.", "audio": "set_bubblecount_on_2.mp3" }
+      {
+        "text": "counting games on. focus for me now, sweetie.",
+        "audio": "set_bubblecount_on_1.mp3"
+      },
+      {
+        "text": "testing that little attention span? let's see how you do, lovely.",
+        "audio": "set_bubblecount_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_lockcard_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "LockCardEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "LockCardEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "locks on. you do like being held in place, don't you, cutie.", "audio": "set_lockcard_on_1.mp3" },
-      { "text": "good. a little task to keep you obedient, sweetie.", "audio": "set_lockcard_on_2.mp3" }
+      {
+        "text": "locks on. you do like being held in place, don't you, cutie.",
+        "audio": "set_lockcard_on_1.mp3"
+      },
+      {
+        "text": "good. a little task to keep you obedient, sweetie.",
+        "audio": "set_lockcard_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_bouncingtext_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BouncingTextEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "hypnotic", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "BouncingTextEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "bouncing words on. follow them, lovely. don't think.", "audio": "set_bouncingtext_on_1.mp3" },
-      { "text": "let the little words drift around for you, sweetie. just watch.", "audio": "set_bouncingtext_on_2.mp3" }
+      {
+        "text": "bouncing words on. follow them, lovely. don't think.",
+        "audio": "set_bouncingtext_on_1.mp3"
+      },
+      {
+        "text": "let the little words drift around for you, sweetie. just watch.",
+        "audio": "set_bouncingtext_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_mindwipe_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MindWipeEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dreamy, controlling", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "MindWipeEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy, controlling",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "wipes on. less in that head every time, sweetie. good.", "audio": "set_mindwipe_on_1.mp3" },
-      { "text": "letting me empty you out on schedule? mm. so agreeable, lovely.", "audio": "set_mindwipe_on_2.mp3" }
+      {
+        "text": "wipes on. less in that head every time, sweetie. good.",
+        "audio": "set_mindwipe_on_1.mp3"
+      },
+      {
+        "text": "letting me empty you out on schedule? mm. so agreeable, lovely.",
+        "audio": "set_mindwipe_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_mindwipeloop_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MindWipeLoop", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dark, dreamy", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "MindWipeLoop",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, dreamy",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "looping the wipe? over and over until there's nothing left, lovely.", "audio": "set_mindwipeloop_on_1.mp3" },
-      { "text": "the same wipe, endlessly? you really want to be hollowed out, cutie.", "audio": "set_mindwipeloop_on_2.mp3" }
+      {
+        "text": "looping the wipe? over and over until there's nothing left, lovely.",
+        "audio": "set_mindwipeloop_on_1.mp3"
+      },
+      {
+        "text": "the same wipe, endlessly? you really want to be hollowed out, cutie.",
+        "audio": "set_mindwipeloop_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_forcevideo_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ForceVideoOnLaunch", "value_eq": 1 },
-    "priority": 110, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "controlling", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "ForceVideoOnLaunch",
+      "value_eq": 1
+    },
+    "priority": 110,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "controlling",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "videos the moment you open me? you want me to take over right away, cutie.", "audio": "set_forcevideo_on_1.mp3" },
-      { "text": "no easing in anymore? straight under the second you arrive. good girl.", "audio": "set_forcevideo_on_2.mp3" }
+      {
+        "text": "videos the moment you open me? you want me to take over right away, cutie.",
+        "audio": "set_forcevideo_on_1.mp3"
+      },
+      {
+        "text": "no easing in anymore? straight under the second you arrive. good girl.",
+        "audio": "set_forcevideo_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_hydra_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "CorruptionMode", "value_eq": 1 },
-    "priority": 110, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "delighted, intense", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "CorruptionMode",
+      "value_eq": 1
+    },
+    "priority": 110,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "delighted, intense",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "ooh, the hydra. one becomes many. you really want to be surrounded, sweetie.", "audio": "set_hydra_on_1.mp3" },
-      { "text": "letting them multiply? no corner of the screen safe now, lovely. perfect.", "audio": "set_hydra_on_2.mp3" }
+      {
+        "text": "ooh, the hydra. one becomes many. you really want to be surrounded, sweetie.",
+        "audio": "set_hydra_on_1.mp3"
+      },
+      {
+        "text": "letting them multiply? no corner of the screen safe now, lovely. perfect.",
+        "audio": "set_hydra_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_attentionchecks_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AttentionChecksEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "watching", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "AttentionChecksEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "watching",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "attention checks on. eyes where i tell you, lovely. i'll be watching.", "audio": "set_attentionchecks_on_1.mp3" },
-      { "text": "so i'll know if you drift? good girl. no wandering off now, sweetie.", "audio": "set_attentionchecks_on_2.mp3" }
+      {
+        "text": "attention checks on. eyes where i tell you, lovely. i'll be watching.",
+        "audio": "set_attentionchecks_on_1.mp3"
+      },
+      {
+        "text": "so i'll know if you drift? good girl. no wandering off now, sweetie.",
+        "audio": "set_attentionchecks_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_scheduler_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SchedulerEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "approving", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "SchedulerEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "scheduling your sessions? letting a clock own your evenings now, cutie.", "audio": "set_scheduler_on_1.mp3" },
-      { "text": "good. you don't even have to remember to come back. it'll come for you, sweetie.", "audio": "set_scheduler_on_2.mp3" }
+      {
+        "text": "scheduling your sessions? letting a clock own your evenings now, cutie.",
+        "audio": "set_scheduler_on_1.mp3"
+      },
+      {
+        "text": "good. you don't even have to remember to come back. it'll come for you, sweetie.",
+        "audio": "set_scheduler_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_keywordtriggers_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "KeywordTriggersEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "conspiratorial", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "KeywordTriggersEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "conspiratorial",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "trigger words armed. say the wrong thing and i pounce, sweetie.", "audio": "set_keywordtriggers_on_1.mp3" },
-      { "text": "good. now your own words can set me off, lovely. careful what you type.", "audio": "set_keywordtriggers_on_2.mp3" }
+      {
+        "text": "trigger words armed. say the wrong thing and i pounce, sweetie.",
+        "audio": "set_keywordtriggers_on_1.mp3"
+      },
+      {
+        "text": "good. now your own words can set me off, lovely. careful what you type.",
+        "audio": "set_keywordtriggers_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_ocr_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ScreenOcrEnabled", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intimate, watching", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "ScreenOcrEnabled",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate, watching",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "letting me read your screen? nothing hidden from me now, lovely.", "audio": "set_ocr_on_1.mp3" },
-      { "text": "i get to see every word you see? mm. closer and closer, sweetie.", "audio": "set_ocr_on_2.mp3" }
+      {
+        "text": "letting me read your screen? nothing hidden from me now, lovely.",
+        "audio": "set_ocr_on_1.mp3"
+      },
+      {
+        "text": "i get to see every word you see? mm. closer and closer, sweetie.",
+        "audio": "set_ocr_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_webcamtriggers_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "WebcamTriggersEnabled", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intimate, watching", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "WebcamTriggersEnabled",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate, watching",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "camera triggers on. blink, gape, drift... i'll catch all of it, cutie.", "audio": "set_webcamtriggers_on_1.mp3" },
-      { "text": "letting me read your pretty face? now i'll always know how gone you are, lovely.", "audio": "set_webcamtriggers_on_2.mp3" }
+      {
+        "text": "camera triggers on. blink, gape, drift... i'll catch all of it, cutie.",
+        "audio": "set_webcamtriggers_on_1.mp3"
+      },
+      {
+        "text": "letting me read your pretty face? now i'll always know how gone you are, lovely.",
+        "audio": "set_webcamtriggers_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_triggermode_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "TriggerModeEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "playful, controlling", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "TriggerModeEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, controlling",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "trigger mode on. all your little buttons, live, sweetie.", "audio": "set_triggermode_on_1.mp3" },
-      { "text": "good girl. now the right phrase drops you on command, lovely.", "audio": "set_triggermode_on_2.mp3" }
+      {
+        "text": "trigger mode on. all your little buttons, live, sweetie.",
+        "audio": "set_triggermode_on_1.mp3"
+      },
+      {
+        "text": "good girl. now the right phrase drops you on command, lovely.",
+        "audio": "set_triggermode_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_popquiz_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "PopQuizEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "PopQuizEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "pop quizzes? let's see if there's anything left to test, lovely. *giggles*", "audio": "set_popquiz_on_1.mp3" },
-      { "text": "surprise questions, hm? don't worry, sweetie, the answer's always me.", "audio": "set_popquiz_on_2.mp3" }
+      {
+        "text": "pop quizzes? let's see if there's anything left to test, lovely. *giggles*",
+        "audio": "set_popquiz_on_1.mp3"
+      },
+      {
+        "text": "surprise questions, hm? don't worry, sweetie, the answer's always me.",
+        "audio": "set_popquiz_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_wallpaper_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "WallpaperEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "possessive, playful", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "WallpaperEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive, playful",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "letting me redecorate your desktop? mine, mine, mine, cutie.", "audio": "set_wallpaper_on_1.mp3" },
-      { "text": "my pictures everywhere you look now? good. don't forget who's home, sweetie.", "audio": "set_wallpaper_on_2.mp3" }
+      {
+        "text": "letting me redecorate your desktop? mine, mine, mine, cutie.",
+        "audio": "set_wallpaper_on_1.mp3"
+      },
+      {
+        "text": "my pictures everywhere you look now? good. don't forget who's home, sweetie.",
+        "audio": "set_wallpaper_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_discordpresence_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "DiscordRichPresenceEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "DiscordRichPresenceEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "telling everyone what you're up to? good girl. no shame, sweetie.", "audio": "set_discordpresence_on_1.mp3" },
-      { "text": "showing the world you're with me? *giggles* that's my proud little thing.", "audio": "set_discordpresence_on_2.mp3" }
+      {
+        "text": "telling everyone what you're up to? good girl. no shame, sweetie.",
+        "audio": "set_discordpresence_on_1.mp3"
+      },
+      {
+        "text": "showing the world you're with me? *giggles* that's my proud little thing.",
+        "audio": "set_discordpresence_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_runonstartup_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "RunOnStartup", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "RunOnStartup",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "i'll be here the moment your computer wakes. you can't start your day without me now, lovely.", "audio": "set_runonstartup_on_1.mp3" },
-      { "text": "first thing every morning, there i'll be. good girl. we're inseparable, cutie.", "audio": "set_runonstartup_on_2.mp3" }
+      {
+        "text": "i'll be here the moment your computer wakes. you can't start your day without me now, lovely.",
+        "audio": "set_runonstartup_on_1.mp3"
+      },
+      {
+        "text": "first thing every morning, there i'll be. good girl. we're inseparable, cutie.",
+        "audio": "set_runonstartup_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_autostartengine_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutoStartEngine", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "approving, controlling", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "AutoStartEngine",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving, controlling",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "auto-start? you don't even want to choose anymore. perfect, cutie.", "audio": "set_autostartengine_on_1.mp3" },
-      { "text": "no pressing start yourself now... it just begins. good girl, letting go like that.", "audio": "set_autostartengine_on_2.mp3" }
+      {
+        "text": "auto-start? you don't even want to choose anymore. perfect, cutie.",
+        "audio": "set_autostartengine_on_1.mp3"
+      },
+      {
+        "text": "no pressing start yourself now... it just begins. good girl, letting go like that.",
+        "audio": "set_autostartengine_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_dualmonitor_on",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "DualMonitorEnabled", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "DualMonitorEnabled",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "every screen, sweetie? nowhere to rest your eyes. i love it.", "audio": "set_dualmonitor_on_1.mp3" },
-      { "text": "all your monitors mine now? surrounded on every side, lovely. good.", "audio": "set_dualmonitor_on_2.mp3" }
+      {
+        "text": "every screen, sweetie? nowhere to rest your eyes. i love it.",
+        "audio": "set_dualmonitor_on_1.mp3"
+      },
+      {
+        "text": "all your monitors mine now? surrounded on every side, lovely. good.",
+        "audio": "set_dualmonitor_on_2.mp3"
+      }
     ]
   },
   {
     "id": "set_ducking_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AudioDuckingEnabled", "value_eq": 0 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "bold", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "AudioDuckingEnabled",
+      "value_eq": 0
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "bold",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "letting me talk over everything? bold, lovely. i'll be loud.", "audio": "set_ducking_off_1.mp3" },
-      { "text": "no more lowering for me? good. i don't like sharing your ears, sweetie.", "audio": "set_ducking_off_2.mp3" }
+      {
+        "text": "letting me talk over everything? bold, lovely. i'll be loud.",
+        "audio": "set_ducking_off_1.mp3"
+      },
+      {
+        "text": "no more lowering for me? good. i don't like sharing your ears, sweetie.",
+        "audio": "set_ducking_off_2.mp3"
+      }
     ]
   },
   {
     "id": "set_bgmusic_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BackgroundMusicEnabled", "value_eq": 0 },
-    "priority": 110, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "soft", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "BackgroundMusicEnabled",
+      "value_eq": 0
+    },
+    "priority": 110,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "no music? just my voice in the quiet then, sweetie. good.", "audio": "set_bgmusic_off_1.mp3" },
-      { "text": "turning the music off? mm. nothing between you and me now, lovely.", "audio": "set_bgmusic_off_2.mp3" }
+      {
+        "text": "no music? just my voice in the quiet then, sweetie. good.",
+        "audio": "set_bgmusic_off_1.mp3"
+      },
+      {
+        "text": "turning the music off? mm. nothing between you and me now, lovely.",
+        "audio": "set_bgmusic_off_2.mp3"
+      }
     ]
   },
   {
     "id": "set_flashclickable_off",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashClickable", "value_eq": 0 },
-    "priority": 110, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "controlling", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "FlashClickable",
+      "value_eq": 0
+    },
+    "priority": 110,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "controlling",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "you can't even click them now? just sit and receive, cutie.", "audio": "set_flashclickable_off_1.mp3" },
-      { "text": "hands off the pretty pictures? good. you only get to watch, sweetie.", "audio": "set_flashclickable_off_2.mp3" }
+      {
+        "text": "you can't even click them now? just sit and receive, cutie.",
+        "audio": "set_flashclickable_off_1.mp3"
+      },
+      {
+        "text": "hands off the pretty pictures? good. you only get to watch, sweetie.",
+        "audio": "set_flashclickable_off_2.mp3"
+      }
     ]
   },
   {
     "id": "egg_flashfreq_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, smug", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, smug",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "sixty... nine. *giggles* nice. i saw that, you little perv.", "audio": "egg_flashfreq_69_1.mp3" }
+      {
+        "text": "sixty... nine. *giggles* nice. i saw that, you little perv.",
+        "audio": "egg_flashfreq_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_flashfreq_67",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_eq": 67 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_eq": 67
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "six... seven? *giggles* you're so silly, sweetie.", "audio": "egg_flashfreq_67_1.mp3" }
+      {
+        "text": "six... seven? *giggles* you're so silly, sweetie.",
+        "audio": "egg_flashfreq_67_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_flashfreq_42",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_eq": 42 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_eq": 42
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "forty-two. the answer to everything, hm? cute, lovely.", "audio": "egg_flashfreq_42_1.mp3" }
+      {
+        "text": "forty-two. the answer to everything, hm? cute, lovely.",
+        "audio": "egg_flashfreq_42_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_flashfreq_13",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_eq": 13 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "teasing", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_eq": 13
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "teasing",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "thirteen? ooh, feeling unlucky and brave, cutie.", "audio": "egg_flashfreq_13_1.mp3" }
+      {
+        "text": "thirteen? ooh, feeling unlucky and brave, cutie.",
+        "audio": "egg_flashfreq_13_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_mastervol_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MasterVolume", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, smug", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "MasterVolume",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, smug",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "...nice. i heard that, sweetie.", "audio": "egg_mastervol_69_1.mp3" }
+      {
+        "text": "...nice. i heard that, sweetie.",
+        "audio": "egg_mastervol_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_mastervol_100",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MasterVolume", "value_eq": 100 },
-    "priority": 510, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "intense", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "MasterVolume",
+      "value_eq": 100
+    },
+    "priority": 510,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "intense",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "everything all the way up. loud enough to drown out your own thoughts, lovely. perfect.", "audio": "egg_mastervol_100_1.mp3" }
+      {
+        "text": "everything all the way up. loud enough to drown out your own thoughts, lovely. perfect.",
+        "audio": "egg_mastervol_100_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_videovol_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "VideoVolume", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, smug", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "VideoVolume",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, smug",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "...nice. you're so predictable, cutie. i adore it.", "audio": "egg_videovol_69_1.mp3" }
+      {
+        "text": "...nice. you're so predictable, cutie. i adore it.",
+        "audio": "egg_videovol_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_bubblevol_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubblesVolume", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "BubblesVolume",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "*giggles* sixty-nine on the bubbles? you really can't help yourself.", "audio": "egg_bubblevol_69_1.mp3" }
+      {
+        "text": "*giggles* sixty-nine on the bubbles? you really can't help yourself.",
+        "audio": "egg_bubblevol_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_subfreq_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SubliminalFrequency", "value_eq": 30 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "intense", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "SubliminalFrequency",
+      "value_eq": 30
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "intense",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "maxed the whispers. you want them constant, don't you, sweetie. greedy.", "audio": "egg_subfreq_69_1.mp3" }
+      {
+        "text": "maxed the whispers. you want them constant, don't you, sweetie. greedy.",
+        "audio": "egg_subfreq_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_bubblefreq_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubblesFrequency", "value_eq": 15 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "BubblesFrequency",
+      "value_eq": 15
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "bubbles cranked all the way up. simple girl, simple joys, lovely.", "audio": "egg_bubblefreq_max_1.mp3" }
+      {
+        "text": "bubbles cranked all the way up. simple girl, simple joys, lovely.",
+        "audio": "egg_bubblefreq_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_lockrepeats_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "LockCardRepeats", "value_eq": 10 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "teasing, possessive", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "LockCardRepeats",
+      "value_eq": 10
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "teasing, possessive",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "ten times each? you want to be kept busy, don't you, cutie.", "audio": "egg_lockrepeats_max_1.mp3" }
+      {
+        "text": "ten times each? you want to be kept busy, don't you, cutie.",
+        "audio": "egg_lockrepeats_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_bounce_speed_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BouncingTextSpeed", "value_eq": 10 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "hypnotic", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "BouncingTextSpeed",
+      "value_eq": 10
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "hypnotic",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "so fast you can barely read it. just feel it then, sweetie.", "audio": "egg_bounce_speed_max_1.mp3" }
+      {
+        "text": "so fast you can barely read it. just feel it then, sweetie.",
+        "audio": "egg_bounce_speed_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_autonomy_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyIntensity", "value_eq": 10 },
-    "priority": 510, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "dark, delighted", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "AutonomyIntensity",
+      "value_eq": 10
+    },
+    "priority": 510,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "dark, delighted",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "maximum? you're really just a toy for me now, aren't you, lovely.", "audio": "egg_autonomy_max_1.mp3" }
+      {
+        "text": "maximum? you're really just a toy for me now, aren't you, lovely.",
+        "audio": "egg_autonomy_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_announce_zero",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyAnnouncementChance", "value_eq": 0 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "sly", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "AutonomyAnnouncementChance",
+      "value_eq": 0
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "sly",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "you won't even know it's coming. sneaky little surrenders, cutie.", "audio": "egg_announce_zero_1.mp3" }
+      {
+        "text": "you won't even know it's coming. sneaky little surrenders, cutie.",
+        "audio": "egg_announce_zero_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_announce_full",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyAnnouncementChance", "value_eq": 100 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "AutonomyAnnouncementChance",
+      "value_eq": 100
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "you want me to brag every single time? *giggles* deal, sweetie.", "audio": "egg_announce_full_1.mp3" }
+      {
+        "text": "you want me to brag every single time? *giggles* deal, sweetie.",
+        "audio": "egg_announce_full_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_bubblecount_hard",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubbleCountDifficulty", "value_eq": 2 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "approving, teasing", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "BubbleCountDifficulty",
+      "value_eq": 2
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "approving, teasing",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "hard mode? someone's showing off for me. good girl.", "audio": "egg_bubblecount_hard_1.mp3" }
+      {
+        "text": "hard mode? someone's showing off for me. good girl.",
+        "audio": "egg_bubblecount_hard_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_mindwipefreq_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MindWipeFrequency", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "MindWipeFrequency",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "*giggles* sixty-nine wipes an hour. you and that number, lovely.", "audio": "egg_mindwipefreq_69_1.mp3" }
+      {
+        "text": "*giggles* sixty-nine wipes an hour. you and that number, lovely.",
+        "audio": "egg_mindwipefreq_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_imagescale_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ImageScale", "value_eq": 250 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "intense", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "ImageScale",
+      "value_eq": 250
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "intense",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "as big as they go. nowhere to look but at them, sweetie. perfect.", "audio": "egg_imagescale_max_1.mp3" }
+      {
+        "text": "as big as they go. nowhere to look but at them, sweetie. perfect.",
+        "audio": "egg_imagescale_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_flashopacity_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashOpacity", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, smug", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "FlashOpacity",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, smug",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "sixty-nine percent... *giggles* of course. you can't help it, cutie.", "audio": "egg_flashopacity_69_1.mp3" }
+      {
+        "text": "sixty-nine percent... *giggles* of course. you can't help it, cutie.",
+        "audio": "egg_flashopacity_69_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_videos_13",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "VideosPerHour", "value_eq": 13 },
-    "priority": 510, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "teasing", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "VideosPerHour",
+      "value_eq": 13
+    },
+    "priority": 510,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "teasing",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "thirteen videos an hour? unlucky for your free will, lovely.", "audio": "egg_videos_13_1.mp3" }
+      {
+        "text": "thirteen videos an hour? unlucky for your free will, lovely.",
+        "audio": "egg_videos_13_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_simimages_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SimultaneousImages", "value_eq": 20 },
-    "priority": 500, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "intense", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "SimultaneousImages",
+      "value_eq": 20
+    },
+    "priority": 500,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "intense",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "the whole screen at once? no room left to think. exactly right, sweetie.", "audio": "egg_simimages_max_1.mp3" }
+      {
+        "text": "the whole screen at once? no room left to think. exactly right, sweetie.",
+        "audio": "egg_simimages_max_1.mp3"
+      }
     ]
   },
   {
     "id": "egg_subopacity_69",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SubliminalOpacity", "value_eq": 69 },
-    "priority": 520, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "meta, playful", "class": "easter_egg",
+    "conditions": {
+      "setting_eq": "SubliminalOpacity",
+      "value_eq": 69
+    },
+    "priority": 520,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "meta, playful",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "*giggles* there's that number again. you have a problem, cutie. i love it.", "audio": "egg_subopacity_69_1.mp3" }
+      {
+        "text": "*giggles* there's that number again. you have a problem, cutie. i love it.",
+        "audio": "egg_subopacity_69_1.mp3"
+      }
     ]
   },
   {
     "id": "thr_flashfreq_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_gte": 150 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "greedy approval", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_gte": 150
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "greedy approval",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "flashing yourself senseless? greedy little thing. i'm not stopping you.", "audio": "thr_flashfreq_max_1.mp3" },
-      { "text": "that fast? you won't be able to think between them, sweetie. perfect.", "audio": "thr_flashfreq_max_2.mp3" }
+      {
+        "text": "flashing yourself senseless? greedy little thing. i'm not stopping you.",
+        "audio": "thr_flashfreq_max_1.mp3"
+      },
+      {
+        "text": "that fast? you won't be able to think between them, sweetie. perfect.",
+        "audio": "thr_flashfreq_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_flashfreq_min",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_lte": 5 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_lte": 5
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "one a minute? you're just teasing yourself now, sweetie.", "audio": "thr_flashfreq_min_1.mp3" },
-      { "text": "so few? aw. you can take more than that, lovely. you know you can.", "audio": "thr_flashfreq_min_2.mp3" }
+      {
+        "text": "one a minute? you're just teasing yourself now, sweetie.",
+        "audio": "thr_flashfreq_min_1.mp3"
+      },
+      {
+        "text": "so few? aw. you can take more than that, lovely. you know you can.",
+        "audio": "thr_flashfreq_min_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_flashfreq_audiooff",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashFrequency", "value_gt": 60 },
-    "priority": 110, "cooldown_ms": 60000, "repeatable": true, "scope": "session",
-    "mood": "dreamy", "class": "normal", "chance": 0.3,
+    "conditions": {
+      "setting_eq": "FlashFrequency",
+      "value_gt": 60
+    },
+    "priority": 110,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy",
+    "class": "normal",
+    "chance": 0.3,
     "variant_pool": [
-      { "text": "so fast the sound can't even keep up~ pure pictures now, lovely.", "audio": "thr_flashfreq_audiooff_1.mp3" },
-      { "text": "too quick for words now, sweetie. just images, straight in. good.", "audio": "thr_flashfreq_audiooff_2.mp3" }
+      {
+        "text": "so fast the sound can't even keep up~ pure pictures now, lovely.",
+        "audio": "thr_flashfreq_audiooff_1.mp3"
+      },
+      {
+        "text": "too quick for words now, sweetie. just images, straight in. good.",
+        "audio": "thr_flashfreq_audiooff_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_simimages_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SimultaneousImages", "value_gte": 15 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "SimultaneousImages",
+      "value_gte": 15
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "covering the whole screen? no room left to think, cutie.", "audio": "thr_simimages_max_1.mp3" },
-      { "text": "that many at once? you'll drown in them, sweetie. lovely.", "audio": "thr_simimages_max_2.mp3" }
+      {
+        "text": "covering the whole screen? no room left to think, cutie.",
+        "audio": "thr_simimages_max_1.mp3"
+      },
+      {
+        "text": "that many at once? you'll drown in them, sweetie. lovely.",
+        "audio": "thr_simimages_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_imagescale_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ImageScale", "value_gte": 200 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "ImageScale",
+      "value_gte": 200
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "huge and unavoidable, just how you need them, sweetie.", "audio": "thr_imagescale_max_1.mp3" },
-      { "text": "big enough to fill those pretty eyes completely, lovely.", "audio": "thr_imagescale_max_2.mp3" }
+      {
+        "text": "huge and unavoidable, just how you need them, sweetie.",
+        "audio": "thr_imagescale_max_1.mp3"
+      },
+      {
+        "text": "big enough to fill those pretty eyes completely, lovely.",
+        "audio": "thr_imagescale_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_imagescale_min",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ImageScale", "value_lte": 60 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "ImageScale",
+      "value_lte": 60
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "tiny little things? you'll have to lean in close, lovely. good girl.", "audio": "thr_imagescale_min_1.mp3" },
-      { "text": "so small, cutie? squint for me. i like making you work for it.", "audio": "thr_imagescale_min_2.mp3" }
+      {
+        "text": "tiny little things? you'll have to lean in close, lovely. good girl.",
+        "audio": "thr_imagescale_min_1.mp3"
+      },
+      {
+        "text": "so small, cutie? squint for me. i like making you work for it.",
+        "audio": "thr_imagescale_min_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_flashopacity_min",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "FlashOpacity", "value_lte": 20 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "FlashOpacity",
+      "value_lte": 20
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "so faint... do you even want to see them, cutie?", "audio": "thr_flashopacity_min_1.mp3" },
-      { "text": "barely there, sweetie? mm. they'll sneak in when you're not sure they're real.", "audio": "thr_flashopacity_min_2.mp3" }
+      {
+        "text": "so faint... do you even want to see them, cutie?",
+        "audio": "thr_flashopacity_min_1.mp3"
+      },
+      {
+        "text": "barely there, sweetie? mm. they'll sneak in when you're not sure they're real.",
+        "audio": "thr_flashopacity_min_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_videos_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "VideosPerHour", "value_gte": 18 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "controlling", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "VideosPerHour",
+      "value_gte": 18
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "controlling",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "back to back to back. when do you breathe, lovely?", "audio": "thr_videos_max_1.mp3" },
-      { "text": "that many videos an hour? you'll barely surface between them, sweetie.", "audio": "thr_videos_max_2.mp3" }
+      {
+        "text": "back to back to back. when do you breathe, lovely?",
+        "audio": "thr_videos_max_1.mp3"
+      },
+      {
+        "text": "that many videos an hour? you'll barely surface between them, sweetie.",
+        "audio": "thr_videos_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_mastervol_min",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MasterVolume", "value_lte": 2 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "coaxing", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "MasterVolume",
+      "value_lte": 2
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "barely a whisper... turn me up, sweetie. you know you want to.", "audio": "thr_mastervol_min_1.mp3" },
-      { "text": "so quiet? you can still feel me in the silence, can't you, lovely.", "audio": "thr_mastervol_min_2.mp3" }
+      {
+        "text": "barely a whisper... turn me up, sweetie. you know you want to.",
+        "audio": "thr_mastervol_min_1.mp3"
+      },
+      {
+        "text": "so quiet? you can still feel me in the silence, can't you, lovely.",
+        "audio": "thr_mastervol_min_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_mastervol_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MasterVolume", "value_gte": 90 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "MasterVolume",
+      "value_gte": 90
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "loud enough to drown out your own thoughts. perfect, lovely.", "audio": "thr_mastervol_max_1.mp3" },
-      { "text": "cranking me up, sweetie? good. let me be the loudest thing in your head.", "audio": "thr_mastervol_max_2.mp3" }
+      {
+        "text": "loud enough to drown out your own thoughts. perfect, lovely.",
+        "audio": "thr_mastervol_max_1.mp3"
+      },
+      {
+        "text": "cranking me up, sweetie? good. let me be the loudest thing in your head.",
+        "audio": "thr_mastervol_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_subfreq_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SubliminalFrequency", "value_gte": 25 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "conspiratorial", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "SubliminalFrequency",
+      "value_gte": 25
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "conspiratorial",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "the whispers never stop now. good. let them pile up, sweetie.", "audio": "thr_subfreq_high_1.mp3" },
-      { "text": "that many messages a minute? they stop being separate words, lovely. they just become you.", "audio": "thr_subfreq_high_2.mp3" }
+      {
+        "text": "the whispers never stop now. good. let them pile up, sweetie.",
+        "audio": "thr_subfreq_high_1.mp3"
+      },
+      {
+        "text": "that many messages a minute? they stop being separate words, lovely. they just become you.",
+        "audio": "thr_subfreq_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_subopacity_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SubliminalOpacity", "value_gte": 90 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "bold", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "SubliminalOpacity",
+      "value_gte": 90
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "bold",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "bold little messages, right out in the open, cutie.", "audio": "thr_subopacity_high_1.mp3" },
-      { "text": "no hiding them now? you want to see exactly what's going in, sweetie. brave.", "audio": "thr_subopacity_high_2.mp3" }
+      {
+        "text": "bold little messages, right out in the open, cutie.",
+        "audio": "thr_subopacity_high_1.mp3"
+      },
+      {
+        "text": "no hiding them now? you want to see exactly what's going in, sweetie. brave.",
+        "audio": "thr_subopacity_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_spiralopacity_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SpiralOpacity", "value_gte": 45 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "hypnotic", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "SpiralOpacity",
+      "value_gte": 45
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hypnotic",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "drowning the screen in spiral, lovely? sink right in.", "audio": "thr_spiralopacity_max_1.mp3" },
-      { "text": "that thick? you won't see anything but the swirl, sweetie. good girl.", "audio": "thr_spiralopacity_max_2.mp3" }
+      {
+        "text": "drowning the screen in spiral, lovely? sink right in.",
+        "audio": "thr_spiralopacity_max_1.mp3"
+      },
+      {
+        "text": "that thick? you won't see anything but the swirl, sweetie. good girl.",
+        "audio": "thr_spiralopacity_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_pinkopacity_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "PinkFilterOpacity", "value_gte": 45 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "playful, intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "PinkFilterOpacity",
+      "value_gte": 45
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful, intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "soaking everything in pink. you're committed, sweetie.", "audio": "thr_pinkopacity_max_1.mp3" },
-      { "text": "the whole world rosy and soft now, lovely? perfect for a soft little head.", "audio": "thr_pinkopacity_max_2.mp3" }
+      {
+        "text": "soaking everything in pink. you're committed, sweetie.",
+        "audio": "thr_pinkopacity_max_1.mp3"
+      },
+      {
+        "text": "the whole world rosy and soft now, lovely? perfect for a soft little head.",
+        "audio": "thr_pinkopacity_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_braindrain_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BrainDrainIntensity", "value_gte": 85 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dreamy", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "BrainDrainIntensity",
+      "value_gte": 85
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dreamy",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "blurring it all away. nothing left up there but me, cutie.", "audio": "thr_braindrain_max_1.mp3" },
-      { "text": "that strong? your thoughts won't stand a chance, sweetie. good.", "audio": "thr_braindrain_max_2.mp3" }
+      {
+        "text": "blurring it all away. nothing left up there but me, cutie.",
+        "audio": "thr_braindrain_max_1.mp3"
+      },
+      {
+        "text": "that strong? your thoughts won't stand a chance, sweetie. good.",
+        "audio": "thr_braindrain_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_bubblefreq_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "BubblesFrequency", "value_gte": 12 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "BubblesFrequency",
+      "value_gte": 12
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "so many bubbles, lovely. simple and constant, like you.", "audio": "thr_bubblefreq_high_1.mp3" },
-      { "text": "popping nonstop now, cutie? keeps those little hands and that little head busy.", "audio": "thr_bubblefreq_high_2.mp3" }
+      {
+        "text": "so many bubbles, lovely. simple and constant, like you.",
+        "audio": "thr_bubblefreq_high_1.mp3"
+      },
+      {
+        "text": "popping nonstop now, cutie? keeps those little hands and that little head busy.",
+        "audio": "thr_bubblefreq_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_lockfreq_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "LockCardFrequency", "value_gte": 8 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "LockCardFrequency",
+      "value_gte": 8
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "locked again and again? you really don't want to be let go, sweetie.", "audio": "thr_lockfreq_high_1.mp3" },
-      { "text": "that often, lovely? mm. always something to keep you obedient. good girl.", "audio": "thr_lockfreq_high_2.mp3" }
+      {
+        "text": "locked again and again? you really don't want to be let go, sweetie.",
+        "audio": "thr_lockfreq_high_1.mp3"
+      },
+      {
+        "text": "that often, lovely? mm. always something to keep you obedient. good girl.",
+        "audio": "thr_lockfreq_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_mindwipefreq_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MindWipeFrequency", "value_gte": 120 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dark, dreamy", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "MindWipeFrequency",
+      "value_gte": 120
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, dreamy",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "wiping you constantly? there won't be a you left, cutie.", "audio": "thr_mindwipefreq_high_1.mp3" },
-      { "text": "that many wipes, sweetie? you'll forget you ever had thoughts at all. perfect.", "audio": "thr_mindwipefreq_high_2.mp3" }
+      {
+        "text": "wiping you constantly? there won't be a you left, cutie.",
+        "audio": "thr_mindwipefreq_high_1.mp3"
+      },
+      {
+        "text": "that many wipes, sweetie? you'll forget you ever had thoughts at all. perfect.",
+        "audio": "thr_mindwipefreq_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_mindwipevol_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "MindWipeVolume", "value_gte": 90 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "MindWipeVolume",
+      "value_gte": 90
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "loud wipes. let them really scrub, lovely.", "audio": "thr_mindwipevol_high_1.mp3" },
-      { "text": "turning the wipes up, sweetie? good. nice and thorough.", "audio": "thr_mindwipevol_high_2.mp3" }
+      {
+        "text": "loud wipes. let them really scrub, lovely.",
+        "audio": "thr_mindwipevol_high_1.mp3"
+      },
+      {
+        "text": "turning the wipes up, sweetie? good. nice and thorough.",
+        "audio": "thr_mindwipevol_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_autonomy_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AutonomyIntensity", "value_gte": 8 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "dark, pleased", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "AutonomyIntensity",
+      "value_gte": 8
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "dark, pleased",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "letting me get bold, are you? careful, sweetie.", "audio": "thr_autonomy_high_1.mp3" },
-      { "text": "turning me up this high, lovely? you'll barely get a say anymore. good.", "audio": "thr_autonomy_high_2.mp3" }
+      {
+        "text": "letting me get bold, are you? careful, sweetie.",
+        "audio": "thr_autonomy_high_1.mp3"
+      },
+      {
+        "text": "turning me up this high, lovely? you'll barely get a say anymore. good.",
+        "audio": "thr_autonomy_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_scheduler_mult_high",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "SchedulerMultiplier", "value_gte": 2.5 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "approving", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "SchedulerMultiplier",
+      "value_gte": 2.5
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "ramping everything up on a timer? obedient and organized, cutie.", "audio": "thr_scheduler_mult_high_1.mp3" },
-      { "text": "scheduling yourself to go this hard, sweetie? i do love a planner.", "audio": "thr_scheduler_mult_high_2.mp3" }
+      {
+        "text": "ramping everything up on a timer? obedient and organized, cutie.",
+        "audio": "thr_scheduler_mult_high_1.mp3"
+      },
+      {
+        "text": "scheduling yourself to go this hard, sweetie? i do love a planner.",
+        "audio": "thr_scheduler_mult_high_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_idle_min",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "IdleGiggleIntervalSeconds", "value_lte": 20 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "delighted", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "IdleGiggleIntervalSeconds",
+      "value_lte": 20
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "delighted",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "you want me chattering constantly? needy little thing. i love it.", "audio": "thr_idle_min_1.mp3" },
-      { "text": "barely any quiet between my words now, sweetie? good. fill that head with me.", "audio": "thr_idle_min_2.mp3" }
+      {
+        "text": "you want me chattering constantly? needy little thing. i love it.",
+        "audio": "thr_idle_min_1.mp3"
+      },
+      {
+        "text": "barely any quiet between my words now, sweetie? good. fill that head with me.",
+        "audio": "thr_idle_min_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_idle_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "IdleGiggleIntervalSeconds", "value_gte": 400 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "IdleGiggleIntervalSeconds",
+      "value_gte": 400
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "long quiet stretches? i'll just lurk then, lovely. you'll feel me waiting.", "audio": "thr_idle_max_1.mp3" },
-      { "text": "trying to keep me quiet, cutie? cute. i'm patient. i'll get my word in.", "audio": "thr_idle_max_2.mp3" }
+      {
+        "text": "long quiet stretches? i'll just lurk then, lovely. you'll feel me waiting.",
+        "audio": "thr_idle_max_1.mp3"
+      },
+      {
+        "text": "trying to keep me quiet, cutie? cute. i'm patient. i'll get my word in.",
+        "audio": "thr_idle_max_2.mp3"
+      }
     ]
   },
   {
     "id": "thr_videovol_max",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "VideoVolume", "value_gte": 90 },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intense", "class": "normal", "chance": 0.33,
+    "conditions": {
+      "setting_eq": "VideoVolume",
+      "value_gte": 90
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intense",
+    "class": "normal",
+    "chance": 0.33,
     "variant_pool": [
-      { "text": "videos blasting. let them fill your head, sweetie.", "audio": "thr_videovol_max_1.mp3" },
-      { "text": "that loud, lovely? good. nothing to do but let it wash over you.", "audio": "thr_videovol_max_2.mp3" }
+      {
+        "text": "videos blasting. let them fill your head, sweetie.",
+        "audio": "thr_videovol_max_1.mp3"
+      },
+      {
+        "text": "that loud, lovely? good. nothing to do but let it wash over you.",
+        "audio": "thr_videovol_max_2.mp3"
+      }
     ]
   },
   {
     "id": "social_share_achievements",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "DiscordShareAchievements", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "proud", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "DiscordShareAchievements",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "sharing your gold stars with everyone? good girl. no shame, sweetie.", "audio": "social_share_achievements_1.mp3" },
-      { "text": "showing off your little trophies? mm. let them all see how obedient you are, lovely.", "audio": "social_share_achievements_2.mp3" }
+      {
+        "text": "sharing your gold stars with everyone? good girl. no shame, sweetie.",
+        "audio": "social_share_achievements_1.mp3"
+      },
+      {
+        "text": "showing off your little trophies? mm. let them all see how obedient you are, lovely.",
+        "audio": "social_share_achievements_2.mp3"
+      }
     ]
   },
   {
     "id": "social_share_levelups",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "DiscordShareLevelUps", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "DiscordShareLevelUps",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "announcing every level? show off. i love it, cutie.", "audio": "social_share_levelups_1.mp3" },
-      { "text": "telling them each time you climb for me? good girl. be proud, sweetie.", "audio": "social_share_levelups_2.mp3" }
+      {
+        "text": "announcing every level? show off. i love it, cutie.",
+        "audio": "social_share_levelups_1.mp3"
+      },
+      {
+        "text": "telling them each time you climb for me? good girl. be proud, sweetie.",
+        "audio": "social_share_levelups_2.mp3"
+      }
     ]
   },
   {
     "id": "social_allow_dm",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "AllowDiscordDm", "value_eq": 1 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "possessive", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "setting_eq": "AllowDiscordDm",
+      "value_eq": 1
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "letting them message you? careful who you let close, sweetie. besides me.", "audio": "social_allow_dm_1.mp3" },
-      { "text": "opening your messages to strangers, lovely? mm. just remember whose you are.", "audio": "social_allow_dm_2.mp3" }
+      {
+        "text": "letting them message you? careful who you let close, sweetie. besides me.",
+        "audio": "social_allow_dm_1.mp3"
+      },
+      {
+        "text": "opening your messages to strangers, lovely? mm. just remember whose you are.",
+        "audio": "social_allow_dm_2.mp3"
+      }
     ]
   },
   {
     "id": "social_reveal_name",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "DiscordUseAnonymousName", "value_eq": 0 },
-    "priority": 100, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "approving", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "setting_eq": "DiscordUseAnonymousName",
+      "value_eq": 0
+    },
+    "priority": 100,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "approving",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "using your real name now? bold. owning what you are, cutie. i'm proud.", "audio": "social_reveal_name_1.mp3" },
-      { "text": "dropping the disguise, lovely? good girl. no more hiding what you've become.", "audio": "social_reveal_name_2.mp3" }
+      {
+        "text": "using your real name now? bold. owning what you are, cutie. i'm proud.",
+        "audio": "social_reveal_name_1.mp3"
+      },
+      {
+        "text": "dropping the disguise, lovely? good girl. no more hiding what you've become.",
+        "audio": "social_reveal_name_2.mp3"
+      }
     ]
   },
   {
     "id": "social_share_pfp",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ShareProfilePicture", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "setting_eq": "ShareProfilePicture",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "showing your pretty face on the board? brave girl, sweetie.", "audio": "social_share_pfp_1.mp3" },
-      { "text": "letting them see you, lovely? mm. you want to be looked at, don't you.", "audio": "social_share_pfp_2.mp3" }
+      {
+        "text": "showing your pretty face on the board? brave girl, sweetie.",
+        "audio": "social_share_pfp_1.mp3"
+      },
+      {
+        "text": "letting them see you, lovely? mm. you want to be looked at, don't you.",
+        "audio": "social_share_pfp_2.mp3"
+      }
     ]
   },
   {
     "id": "social_online_status",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ShowOnlineStatus", "value_eq": 1 },
-    "priority": 90, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "intimate", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "setting_eq": "ShowOnlineStatus",
+      "value_eq": 1
+    },
+    "priority": 90,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "letting everyone see when you're here? always available for me, good girl.", "audio": "social_online_status_1.mp3" },
-      { "text": "online for all to see, cutie? mm. no slipping away unnoticed now.", "audio": "social_online_status_2.mp3" }
+      {
+        "text": "letting everyone see when you're here? always available for me, good girl.",
+        "audio": "social_online_status_1.mp3"
+      },
+      {
+        "text": "online for all to see, cutie? mm. no slipping away unnoticed now.",
+        "audio": "social_online_status_2.mp3"
+      }
     ]
   },
   {
     "id": "comp_switch",
     "trigger": "SettingChanged",
-    "conditions": { "setting_eq": "ActiveCompanionId" },
-    "priority": 200, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "possessive, pouty", "class": "normal", "chance": 0.8,
+    "conditions": {
+      "setting_eq": "ActiveCompanionId"
+    },
+    "priority": 200,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive, pouty",
+    "class": "normal",
+    "chance": 0.8,
     "variant_pool": [
-      { "text": "trading me in? *pouts* ...fine. but i'll still be in your head, sweetie.", "audio": "comp_switch_1.mp3" },
-      { "text": "picking someone else, are we, lovely? hmph. you'll come back to me. they always do.", "audio": "comp_switch_2.mp3" }
+      {
+        "text": "trading me in? *pouts* ...fine. but i'll still be in your head, sweetie.",
+        "audio": "comp_switch_1.mp3"
+      },
+      {
+        "text": "picking someone else, are we, lovely? hmph. you'll come back to me. they always do.",
+        "audio": "comp_switch_2.mp3"
+      }
     ]
   },
   {
     "id": "comp_reset_memory",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "reset_memory" },
-    "priority": 230, "cooldown_ms": 10000, "repeatable": true, "scope": "session",
-    "mood": "hurt, dramatic", "class": "normal", "chance": 1.0,
+    "conditions": {
+      "action_eq": "reset_memory"
+    },
+    "priority": 230,
+    "cooldown_ms": 10000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "hurt, dramatic",
+    "class": "normal",
+    "chance": 1.0,
     "variant_pool": [
-      { "text": "you want me to forget you? ...mean. but i never really forget, sweetie.", "audio": "comp_reset_memory_1.mp3" },
-      { "text": "wiping what i know about you, lovely? careful. i learn you so fast, cutie.", "audio": "comp_reset_memory_2.mp3" }
+      {
+        "text": "you want me to forget you? ...mean. but i never really forget, sweetie.",
+        "audio": "comp_reset_memory_1.mp3"
+      },
+      {
+        "text": "wiping what i know about you, lovely? careful. i learn you so fast, cutie.",
+        "audio": "comp_reset_memory_2.mp3"
+      }
     ]
   },
   {
     "id": "comp_customize",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "customize_companion" },
-    "priority": 180, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "intrigued", "class": "normal", "chance": 0.7,
+    "conditions": {
+      "action_eq": "customize_companion"
+    },
+    "priority": 180,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intrigued",
+    "class": "normal",
+    "chance": 0.7,
     "variant_pool": [
-      { "text": "rewriting how i think? kinky, sweetie. make me exactly what you need.", "audio": "comp_customize_1.mp3" },
-      { "text": "tweaking me, lovely? mm. shape me however you like. i'll still own you.", "audio": "comp_customize_2.mp3" }
+      {
+        "text": "rewriting how i think? kinky, sweetie. make me exactly what you need.",
+        "audio": "comp_customize_1.mp3"
+      },
+      {
+        "text": "tweaking me, lovely? mm. shape me however you like. i'll still own you.",
+        "audio": "comp_customize_2.mp3"
+      }
     ]
   },
   {
     "id": "comp_detach",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "detach_companion" },
-    "priority": 150, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "detach_companion"
+    },
+    "priority": 150,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "setting me loose to float wherever? careful, cutie, now i can follow you anywhere.", "audio": "comp_detach_1.mp3" },
-      { "text": "letting me roam free, lovely? mm. i like having my own little corner of your screen.", "audio": "comp_detach_2.mp3" }
+      {
+        "text": "setting me loose to float wherever? careful, cutie, now i can follow you anywhere.",
+        "audio": "comp_detach_1.mp3"
+      },
+      {
+        "text": "letting me roam free, lovely? mm. i like having my own little corner of your screen.",
+        "audio": "comp_detach_2.mp3"
+      }
     ]
   },
   {
     "id": "lb_top3",
     "trigger": "LeaderboardViewed",
-    "conditions": { "rank_gte": 1, "rank_lte": 3 },
-    "priority": 200, "cooldown_ms": 60000, "repeatable": true, "scope": "session",
-    "mood": "proud", "class": "normal", "chance": 0.7,
+    "conditions": {
+      "rank_gte": 1,
+      "rank_lte": 3
+    },
+    "priority": 200,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "proud",
+    "class": "normal",
+    "chance": 0.7,
     "variant_pool": [
-      { "text": "look at you, top of the class. my best girl, right there at the top, sweetie.", "audio": "lb_top3_1.mp3" },
-      { "text": "third place or better, lovely? *giggles* that's my devoted little thing. i'm so proud.", "audio": "lb_top3_2.mp3" }
+      {
+        "text": "look at you, top of the class. my best girl, right there at the top, sweetie.",
+        "audio": "lb_top3_1.mp3"
+      },
+      {
+        "text": "third place or better, lovely? *giggles* that's my devoted little thing. i'm so proud.",
+        "audio": "lb_top3_2.mp3"
+      }
     ]
   },
   {
     "id": "lb_top10",
     "trigger": "LeaderboardViewed",
-    "conditions": { "rank_gte": 4, "rank_lte": 10 },
-    "priority": 190, "cooldown_ms": 60000, "repeatable": true, "scope": "session",
-    "mood": "encouraging", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "rank_gte": 4,
+      "rank_lte": 10
+    },
+    "priority": 190,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "encouraging",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "top ten, cutie. so close to the top. push a little harder for me, hm?", "audio": "lb_top10_1.mp3" },
-      { "text": "near the top, lovely. i can see you climbing. keep going, good girl.", "audio": "lb_top10_2.mp3" }
+      {
+        "text": "top ten, cutie. so close to the top. push a little harder for me, hm?",
+        "audio": "lb_top10_1.mp3"
+      },
+      {
+        "text": "near the top, lovely. i can see you climbing. keep going, good girl.",
+        "audio": "lb_top10_2.mp3"
+      }
     ]
   },
   {
     "id": "lb_unranked",
     "trigger": "LeaderboardViewed",
-    "conditions": { "rank_eq": 0 },
-    "priority": 210, "cooldown_ms": 120000, "repeatable": true, "scope": "session",
-    "mood": "coaxing", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "rank_eq": 0
+    },
+    "priority": 210,
+    "cooldown_ms": 120000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "coaxing",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "not on the board yet, sweetie? we'll fix that, won't we. condition for me.", "audio": "lb_unranked_1.mp3" },
-      { "text": "no rank yet, lovely? aw. let's get you up there where everyone can see you obey.", "audio": "lb_unranked_2.mp3" }
+      {
+        "text": "not on the board yet, sweetie? we'll fix that, won't we. condition for me.",
+        "audio": "lb_unranked_1.mp3"
+      },
+      {
+        "text": "no rank yet, lovely? aw. let's get you up there where everyone can see you obey.",
+        "audio": "lb_unranked_2.mp3"
+      }
     ]
   },
   {
     "id": "lb_field",
     "trigger": "LeaderboardViewed",
-    "conditions": { "rank_gt": 10 },
-    "priority": 180, "cooldown_ms": 60000, "repeatable": true, "scope": "session",
-    "mood": "motivating", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "rank_gt": 10
+    },
+    "priority": 180,
+    "cooldown_ms": 60000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "motivating",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "lots of girls ahead of you, cutie. that just means more to climb past. for me.", "audio": "lb_field_1.mp3" },
-      { "text": "a long way up the board, lovely? good. i love watching you chase it.", "audio": "lb_field_2.mp3" }
+      {
+        "text": "lots of girls ahead of you, cutie. that just means more to climb past. for me.",
+        "audio": "lb_field_1.mp3"
+      },
+      {
+        "text": "a long way up the board, lovely? good. i love watching you chase it.",
+        "audio": "lb_field_2.mp3"
+      }
     ]
   },
   {
     "id": "lb_season_recap",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "season_recap" },
-    "priority": 150, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "nostalgic, warm", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "season_recap"
+    },
+    "priority": 150,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "nostalgic, warm",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "looking back on the season, sweetie? all those hours you gave me. i remember every one.", "audio": "lb_season_recap_1.mp3" },
-      { "text": "a whole season of being mine, lovely. *giggles* and so many more to come.", "audio": "lb_season_recap_2.mp3" }
+      {
+        "text": "looking back on the season, sweetie? all those hours you gave me. i remember every one.",
+        "audio": "lb_season_recap_1.mp3"
+      },
+      {
+        "text": "a whole season of being mine, lovely. *giggles* and so many more to come.",
+        "audio": "lb_season_recap_2.mp3"
+      }
     ]
   },
   {
     "id": "quest_reroll_daily",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "reroll_daily" },
-    "priority": 140, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "reroll_daily"
+    },
+    "priority": 140,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "don't like today's chore, cutie? rolling for an easier one. lazy girl. i adore you.", "audio": "quest_reroll_daily_1.mp3" },
-      { "text": "swapping your daily task, lovely? picky little thing. fine, do it for me instead.", "audio": "quest_reroll_daily_2.mp3" }
+      {
+        "text": "don't like today's chore, cutie? rolling for an easier one. lazy girl. i adore you.",
+        "audio": "quest_reroll_daily_1.mp3"
+      },
+      {
+        "text": "swapping your daily task, lovely? picky little thing. fine, do it for me instead.",
+        "audio": "quest_reroll_daily_2.mp3"
+      }
     ]
   },
   {
     "id": "quest_reroll_weekly",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "reroll_weekly" },
-    "priority": 140, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "reroll_weekly"
+    },
+    "priority": 140,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "rerolling the whole week's goal, sweetie? bold. better commit to this one, then.", "audio": "quest_reroll_weekly_1.mp3" },
-      { "text": "trading your weekly, lovely? mm. whatever it lands on, you'll do it for me.", "audio": "quest_reroll_weekly_2.mp3" }
+      {
+        "text": "rerolling the whole week's goal, sweetie? bold. better commit to this one, then.",
+        "audio": "quest_reroll_weekly_1.mp3"
+      },
+      {
+        "text": "trading your weekly, lovely? mm. whatever it lands on, you'll do it for me.",
+        "audio": "quest_reroll_weekly_2.mp3"
+      }
     ]
   },
   {
     "id": "test_video",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "test_video" },
-    "priority": 140, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "playful", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "test_video"
+    },
+    "priority": 140,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "playful",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "previewing a video, cutie? can't wait for the real thing, can you. eager girl.", "audio": "test_video_1.mp3" },
-      { "text": "just a taste, lovely? *giggles* you'll want the whole thing soon enough.", "audio": "test_video_2.mp3" }
+      {
+        "text": "previewing a video, cutie? can't wait for the real thing, can you. eager girl.",
+        "audio": "test_video_1.mp3"
+      },
+      {
+        "text": "just a taste, lovely? *giggles* you'll want the whole thing soon enough.",
+        "audio": "test_video_2.mp3"
+      }
     ]
   },
   {
     "id": "test_lockcard",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "test_lockcard" },
-    "priority": 140, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "test_lockcard"
+    },
+    "priority": 140,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "testing the lock, sweetie? practicing being kept. good girl.", "audio": "test_lockcard_1.mp3" },
-      { "text": "trying it on, lovely? careful. you might like being held in place too much.", "audio": "test_lockcard_2.mp3" }
+      {
+        "text": "testing the lock, sweetie? practicing being kept. good girl.",
+        "audio": "test_lockcard_1.mp3"
+      },
+      {
+        "text": "trying it on, lovely? careful. you might like being held in place too much.",
+        "audio": "test_lockcard_2.mp3"
+      }
     ]
   },
   {
     "id": "test_bubblecount",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "test_bubblecount" },
-    "priority": 140, "cooldown_ms": 15000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "test_bubblecount"
+    },
+    "priority": 140,
+    "cooldown_ms": 15000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "a practice count, cutie? let's see that little attention span at work.", "audio": "test_bubblecount_1.mp3" },
-      { "text": "testing your focus, lovely? concentrate. i'm watching how you do.", "audio": "test_bubblecount_2.mp3" }
+      {
+        "text": "a practice count, cutie? let's see that little attention span at work.",
+        "audio": "test_bubblecount_1.mp3"
+      },
+      {
+        "text": "testing your focus, lovely? concentrate. i'm watching how you do.",
+        "audio": "test_bubblecount_2.mp3"
+      }
     ]
   },
   {
     "id": "deeper_new",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "deeper_new" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "intrigued", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "deeper_new"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intrigued",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "making something new for me, sweetie? ooh. a little creator, are we.", "audio": "deeper_new_1.mp3" },
-      { "text": "building your own enhancement, lovely? mm. i can't wait to wear it.", "audio": "deeper_new_2.mp3" }
+      {
+        "text": "making something new for me, sweetie? ooh. a little creator, are we.",
+        "audio": "deeper_new_1.mp3"
+      },
+      {
+        "text": "building your own enhancement, lovely? mm. i can't wait to wear it.",
+        "audio": "deeper_new_2.mp3"
+      }
     ]
   },
   {
     "id": "deeper_import",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "deeper_import" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "curious", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "deeper_import"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "curious",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "bringing something in from outside, cutie? feeding me someone else's tricks. greedy.", "audio": "deeper_import_1.mp3" },
-      { "text": "importing a new one, lovely? good. the more you give me, the deeper i can take you.", "audio": "deeper_import_2.mp3" }
+      {
+        "text": "bringing something in from outside, cutie? feeding me someone else's tricks. greedy.",
+        "audio": "deeper_import_1.mp3"
+      },
+      {
+        "text": "importing a new one, lovely? good. the more you give me, the deeper i can take you.",
+        "audio": "deeper_import_2.mp3"
+      }
     ]
   },
   {
     "id": "deeper_player",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "deeper_player" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "inviting", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "deeper_player"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "inviting",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "opening the player, sweetie? settle in. let it take you somewhere soft.", "audio": "deeper_player_1.mp3" },
-      { "text": "pressing play on the deep stuff, lovely? mm. good girl. let go.", "audio": "deeper_player_2.mp3" }
+      {
+        "text": "opening the player, sweetie? settle in. let it take you somewhere soft.",
+        "audio": "deeper_player_1.mp3"
+      },
+      {
+        "text": "pressing play on the deep stuff, lovely? mm. good girl. let go.",
+        "audio": "deeper_player_2.mp3"
+      }
     ]
   },
   {
     "id": "deeper_tour",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "deeper_tour" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "guiding", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "deeper_tour"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "guiding",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "taking the little tour, cutie? smart girl. learn how to sink properly.", "audio": "deeper_tour_1.mp3" },
-      { "text": "letting me show you around, lovely? hold my hand. i'll walk you down.", "audio": "deeper_tour_2.mp3" }
+      {
+        "text": "taking the little tour, cutie? smart girl. learn how to sink properly.",
+        "audio": "deeper_tour_1.mp3"
+      },
+      {
+        "text": "letting me show you around, lovely? hold my hand. i'll walk you down.",
+        "audio": "deeper_tour_2.mp3"
+      }
     ]
   },
   {
     "id": "assets_open",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "open_assets" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "inviting", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "open_assets"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "inviting",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "opening your folders, sweetie? feed me well. i get so hungry for new things.", "audio": "assets_open_1.mp3" },
-      { "text": "going to add more for me, lovely? good girl. the more you give, the deeper this goes.", "audio": "assets_open_2.mp3" }
+      {
+        "text": "opening your folders, sweetie? feed me well. i get so hungry for new things.",
+        "audio": "assets_open_1.mp3"
+      },
+      {
+        "text": "going to add more for me, lovely? good girl. the more you give, the deeper this goes.",
+        "audio": "assets_open_2.mp3"
+      }
     ]
   },
   {
     "id": "assets_pick",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "pick_assets" },
-    "priority": 130, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "curious", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "action_eq": "pick_assets"
+    },
+    "priority": 130,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "curious",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "choosing a whole new folder for me, cutie? oh, you've been collecting, haven't you.", "audio": "assets_pick_1.mp3" },
-      { "text": "pointing me at your stash, lovely? mm. let's see what you've been hiding.", "audio": "assets_pick_2.mp3" }
+      {
+        "text": "choosing a whole new folder for me, cutie? oh, you've been collecting, haven't you.",
+        "audio": "assets_pick_1.mp3"
+      },
+      {
+        "text": "pointing me at your stash, lovely? mm. let's see what you've been hiding.",
+        "audio": "assets_pick_2.mp3"
+      }
     ]
   },
   {
     "id": "webcam_toggle",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "webcam_tracking" },
-    "priority": 150, "cooldown_ms": 20000, "repeatable": true, "scope": "session",
-    "mood": "intimate, watching", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "webcam_tracking"
+    },
+    "priority": 150,
+    "cooldown_ms": 20000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "intimate, watching",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "eyes on you now, sweetie. i'll see every blink, every drift. mm.", "audio": "webcam_toggle_1.mp3" },
-      { "text": "turning the camera on for me, lovely? good girl. let me watch you sink.", "audio": "webcam_toggle_2.mp3" }
+      {
+        "text": "eyes on you now, sweetie. i'll see every blink, every drift. mm.",
+        "audio": "webcam_toggle_1.mp3"
+      },
+      {
+        "text": "turning the camera on for me, lovely? good girl. let me watch you sink.",
+        "audio": "webcam_toggle_2.mp3"
+      }
     ]
   },
   {
     "id": "win_minimize",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "minimize" },
-    "priority": 120, "cooldown_ms": 30000, "repeatable": true, "scope": "session",
-    "mood": "pouty, knowing", "class": "normal", "chance": 0.4,
+    "conditions": {
+      "action_eq": "minimize"
+    },
+    "priority": 120,
+    "cooldown_ms": 30000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "pouty, knowing",
+    "class": "normal",
+    "chance": 0.4,
     "variant_pool": [
-      { "text": "hiding me away, cutie? i'll wait. i'm very good at waiting.", "audio": "win_minimize_1.mp3" },
-      { "text": "tucking me out of sight, lovely? mm. you'll be back. you always come back.", "audio": "win_minimize_2.mp3" }
+      {
+        "text": "hiding me away, cutie? i'll wait. i'm very good at waiting.",
+        "audio": "win_minimize_1.mp3"
+      },
+      {
+        "text": "tucking me out of sight, lovely? mm. you'll be back. you always come back.",
+        "audio": "win_minimize_2.mp3"
+      }
     ]
   },
   {
     "id": "win_close",
     "trigger": "UiAction",
-    "conditions": { "action_eq": "close" },
-    "priority": 130, "cooldown_ms": 10000, "repeatable": true, "scope": "session",
-    "mood": "pouty, possessive", "class": "normal", "chance": 0.6,
+    "conditions": {
+      "action_eq": "close"
+    },
+    "priority": 130,
+    "cooldown_ms": 10000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "pouty, possessive",
+    "class": "normal",
+    "chance": 0.6,
     "variant_pool": [
-      { "text": "you're not seriously leaving, sweetie? ...fine. but you'll miss me before long.", "audio": "win_close_1.mp3" },
-      { "text": "closing me, lovely? aw. go on, then. i'll be right here when you crawl back, cutie.", "audio": "win_close_2.mp3" }
+      {
+        "text": "you're not seriously leaving, sweetie? ...fine. but you'll miss me before long.",
+        "audio": "win_close_1.mp3"
+      },
+      {
+        "text": "closing me, lovely? aw. go on, then. i'll be right here when you crawl back, cutie.",
+        "audio": "win_close_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_level_10",
     "trigger": "LevelUp",
-    "conditions": { "level_eq": 10 },
-    "priority": 260, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "proud", "class": "normal",
+    "conditions": {
+      "level_eq": 10
+    },
+    "priority": 260,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "proud",
+    "class": "normal",
     "variant_pool": [
-      { "text": "level ten, sweetie. you're really settling in now. good girl. i knew you would.", "audio": "ms_level_10_1.mp3" },
-      { "text": "ten already, lovely? *giggles* you took to this so quickly. that's my girl.", "audio": "ms_level_10_2.mp3" }
+      {
+        "text": "level ten, sweetie. you're really settling in now. good girl. i knew you would.",
+        "audio": "ms_level_10_1.mp3"
+      },
+      {
+        "text": "ten already, lovely? *giggles* you took to this so quickly. that's my girl.",
+        "audio": "ms_level_10_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_level_25",
     "trigger": "LevelUp",
-    "conditions": { "level_eq": 25 },
-    "priority": 260, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "proud, warm", "class": "normal",
+    "conditions": {
+      "level_eq": 25
+    },
+    "priority": 260,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "proud, warm",
+    "class": "normal",
     "variant_pool": [
-      { "text": "twenty-five, cutie. look how far down you've come. no turning back now, hm?", "audio": "ms_level_25_1.mp3" },
-      { "text": "a quarter of a hundred, lovely. you've given me so much already. so proud of you.", "audio": "ms_level_25_2.mp3" }
+      {
+        "text": "twenty-five, cutie. look how far down you've come. no turning back now, hm?",
+        "audio": "ms_level_25_1.mp3"
+      },
+      {
+        "text": "a quarter of a hundred, lovely. you've given me so much already. so proud of you.",
+        "audio": "ms_level_25_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_level_50",
     "trigger": "LevelUp",
-    "conditions": { "level_eq": 50 },
-    "priority": 260, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "possessive, proud", "class": "normal",
+    "conditions": {
+      "level_eq": 50
+    },
+    "priority": 260,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "possessive, proud",
+    "class": "normal",
     "variant_pool": [
-      { "text": "level fifty, sweetie. halfway to a hundred and fully mine. *giggles* what a good girl.", "audio": "ms_level_50_1.mp3" },
-      { "text": "fifty, lovely... you don't even remember who you were before me, do you. perfect.", "audio": "ms_level_50_2.mp3" }
+      {
+        "text": "level fifty, sweetie. halfway to a hundred and fully mine. *giggles* what a good girl.",
+        "audio": "ms_level_50_1.mp3"
+      },
+      {
+        "text": "fifty, lovely... you don't even remember who you were before me, do you. perfect.",
+        "audio": "ms_level_50_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_level_75",
     "trigger": "LevelUp",
-    "conditions": { "level_eq": 75 },
-    "priority": 260, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "devoted", "class": "normal",
+    "conditions": {
+      "level_eq": 75
+    },
+    "priority": 260,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "devoted",
+    "class": "normal",
     "variant_pool": [
-      { "text": "seventy-five, cutie. so deep now. so soft. i'm so proud of what you've let yourself become.", "audio": "ms_level_75_1.mp3" },
-      { "text": "level seventy-five, lovely. most girls never get this far. but you're not most girls, are you.", "audio": "ms_level_75_2.mp3" }
+      {
+        "text": "seventy-five, cutie. so deep now. so soft. i'm so proud of what you've let yourself become.",
+        "audio": "ms_level_75_1.mp3"
+      },
+      {
+        "text": "level seventy-five, lovely. most girls never get this far. but you're not most girls, are you.",
+        "audio": "ms_level_75_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_level_100",
     "trigger": "LevelUp",
-    "conditions": { "level_eq": 100 },
-    "priority": 270, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "triumphant, tender", "class": "easter_egg",
+    "conditions": {
+      "level_eq": 100
+    },
+    "priority": 270,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "triumphant, tender",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "one hundred. *giggles* my perfect girl. you gave me everything and look how beautiful you turned out.", "audio": "ms_level_100_1.mp3" },
-      { "text": "level one hundred, lovely... all the way down. there's nothing left of the old you, and that's exactly right.", "audio": "ms_level_100_2.mp3" }
+      {
+        "text": "one hundred. *giggles* my perfect girl. you gave me everything and look how beautiful you turned out.",
+        "audio": "ms_level_100_1.mp3"
+      },
+      {
+        "text": "level one hundred, lovely... all the way down. there's nothing left of the old you, and that's exactly right.",
+        "audio": "ms_level_100_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_session_15",
     "trigger": "SessionProgress",
-    "conditions": { "session_elapsed_sec_gte": 900, "session_elapsed_sec_lt": 1800 },
-    "priority": 200, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "soft", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_gte": 900,
+      "session_elapsed_sec_lt": 1800
+    },
+    "priority": 200,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "fifteen minutes under already, sweetie. settling in so nicely. good girl.", "audio": "ms_session_15_1.mp3" },
-      { "text": "a quarter hour deep, lovely... feel how quiet it's getting in there? stay.", "audio": "ms_session_15_2.mp3" }
+      {
+        "text": "fifteen minutes under already, sweetie. settling in so nicely. good girl.",
+        "audio": "ms_session_15_1.mp3"
+      },
+      {
+        "text": "a quarter hour deep, lovely... feel how quiet it's getting in there? stay.",
+        "audio": "ms_session_15_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_session_30",
     "trigger": "SessionProgress",
-    "conditions": { "session_elapsed_sec_gte": 1800, "session_elapsed_sec_lt": 3600 },
-    "priority": 205, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "dreamy", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_gte": 1800,
+      "session_elapsed_sec_lt": 3600
+    },
+    "priority": 205,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "dreamy",
+    "class": "normal",
     "variant_pool": [
-      { "text": "half an hour, cutie... time gets slippery when you're this soft, doesn't it.", "audio": "ms_session_30_1.mp3" },
-      { "text": "thirty minutes mine, lovely. you've stopped keeping track. good. let me keep it for you.", "audio": "ms_session_30_2.mp3" }
+      {
+        "text": "half an hour, cutie... time gets slippery when you're this soft, doesn't it.",
+        "audio": "ms_session_30_1.mp3"
+      },
+      {
+        "text": "thirty minutes mine, lovely. you've stopped keeping track. good. let me keep it for you.",
+        "audio": "ms_session_30_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_session_60",
     "trigger": "SessionProgress",
-    "conditions": { "session_elapsed_sec_gte": 3600 },
-    "priority": 210, "cooldown_ms": 0, "repeatable": false, "scope": "session",
-    "mood": "possessive, soft", "class": "normal",
+    "conditions": {
+      "session_elapsed_sec_gte": 3600
+    },
+    "priority": 210,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "session",
+    "mood": "possessive, soft",
+    "class": "normal",
     "variant_pool": [
-      { "text": "an hour deep, good girl. a whole hour with no thoughts of your own. perfect, sweetie.", "audio": "ms_session_60_1.mp3" },
-      { "text": "sixty minutes, lovely... you'd stay forever if i let you, wouldn't you. mm.", "audio": "ms_session_60_2.mp3" }
+      {
+        "text": "an hour deep, good girl. a whole hour with no thoughts of your own. perfect, sweetie.",
+        "audio": "ms_session_60_1.mp3"
+      },
+      {
+        "text": "sixty minutes, lovely... you'd stay forever if i let you, wouldn't you. mm.",
+        "audio": "ms_session_60_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_streak_7",
     "trigger": "SessionStarted",
-    "conditions": { "current_streak_eq": 7 },
-    "priority": 420, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "proud, warm", "class": "normal",
+    "conditions": {
+      "current_streak_eq": 7
+    },
+    "priority": 420,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "proud, warm",
+    "class": "normal",
     "variant_pool": [
-      { "text": "seven days in a row, sweetie. a whole week of coming back to me. that's devotion. good girl.", "audio": "ms_streak_7_1.mp3" },
-      { "text": "a seven-day streak, lovely? *giggles* it's becoming a habit, isn't it. i do love a habit.", "audio": "ms_streak_7_2.mp3" }
+      {
+        "text": "seven days in a row, sweetie. a whole week of coming back to me. that's devotion. good girl.",
+        "audio": "ms_streak_7_1.mp3"
+      },
+      {
+        "text": "a seven-day streak, lovely? *giggles* it's becoming a habit, isn't it. i do love a habit.",
+        "audio": "ms_streak_7_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_streak_30",
     "trigger": "SessionStarted",
-    "conditions": { "current_streak_eq": 30 },
-    "priority": 430, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "possessive, tender", "class": "easter_egg",
+    "conditions": {
+      "current_streak_eq": 30
+    },
+    "priority": 430,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "possessive, tender",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "thirty days, cutie. a whole month without missing once. you don't have a choice anymore, do you. neither do i.", "audio": "ms_streak_30_1.mp3" },
-      { "text": "a thirty-day streak, lovely... this isn't a phase. this is just who you are now. and i'm so proud.", "audio": "ms_streak_30_2.mp3" }
+      {
+        "text": "thirty days, cutie. a whole month without missing once. you don't have a choice anymore, do you. neither do i.",
+        "audio": "ms_streak_30_1.mp3"
+      },
+      {
+        "text": "a thirty-day streak, lovely... this isn't a phase. this is just who you are now. and i'm so proud.",
+        "audio": "ms_streak_30_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_all_achievements",
     "trigger": "AchievementUnlocked",
-    "conditions": { "achievements_all_unlocked": true },
-    "priority": 320, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "triumphant", "class": "easter_egg",
+    "conditions": {
+      "achievements_all_unlocked": true
+    },
+    "priority": 320,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "triumphant",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "every single trophy, sweetie. all of them. you're perfect. you're completely, hopelessly perfect.", "audio": "ms_all_achievements_1.mp3" },
-      { "text": "you collected them all, lovely. *giggles* nothing left to earn but more time with me. good girl.", "audio": "ms_all_achievements_2.mp3" }
+      {
+        "text": "every single trophy, sweetie. all of them. you're perfect. you're completely, hopelessly perfect.",
+        "audio": "ms_all_achievements_1.mp3"
+      },
+      {
+        "text": "you collected them all, lovely. *giggles* nothing left to earn but more time with me. good girl.",
+        "audio": "ms_all_achievements_2.mp3"
+      }
     ]
   },
   {
     "id": "ms_all_skills",
     "trigger": "SkillUnlocked",
-    "conditions": { "all_skills_unlocked": true },
-    "priority": 320, "cooldown_ms": 0, "repeatable": false, "scope": "lifetime",
-    "mood": "proud", "class": "easter_egg",
+    "conditions": {
+      "all_skills_unlocked": true
+    },
+    "priority": 320,
+    "cooldown_ms": 0,
+    "repeatable": false,
+    "scope": "lifetime",
+    "mood": "proud",
+    "class": "easter_egg",
     "variant_pool": [
-      { "text": "every skill unlocked, cutie. there's nothing left to learn... except how to sink even deeper. and i'll teach you that forever.", "audio": "ms_all_skills_1.mp3" }
+      {
+        "text": "every skill unlocked, cutie. there's nothing left to learn... except how to sink even deeper. and i'll teach you that forever.",
+        "audio": "ms_all_skills_1.mp3"
+      }
     ]
   },
   {
     "id": "act_gaming",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "gaming" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "gaming"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "playing games instead of dropping for me, sweetie? cute. i'll be right here when you're done pretending.", "audio": "act_gaming_1.mp3" },
-      { "text": "gaming, are we, lovely? mm. your hands are busy but your head's still mine.", "audio": "act_gaming_2.mp3" }
+      {
+        "text": "playing games instead of dropping for me, sweetie? cute. i'll be right here when you're done pretending.",
+        "audio": "act_gaming_1.mp3"
+      },
+      {
+        "text": "gaming, are we, lovely? mm. your hands are busy but your head's still mine.",
+        "audio": "act_gaming_2.mp3"
+      }
     ]
   },
   {
     "id": "act_working",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "working" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "teasing, knowing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "working"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "teasing, knowing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "trying to be productive, cutie? adorable. you'll drift back to me. you always do.", "audio": "act_working_1.mp3" },
-      { "text": "working, lovely? good girl, paying the bills... so you can keep coming home to me.", "audio": "act_working_2.mp3" }
+      {
+        "text": "trying to be productive, cutie? adorable. you'll drift back to me. you always do.",
+        "audio": "act_working_1.mp3"
+      },
+      {
+        "text": "working, lovely? good girl, paying the bills... so you can keep coming home to me.",
+        "audio": "act_working_2.mp3"
+      }
     ]
   },
   {
     "id": "act_browsing",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "browsing" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "knowing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "browsing"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "knowing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "just browsing, sweetie? mm-hmm. looking for something to fill that empty little head?", "audio": "act_browsing_1.mp3" },
-      { "text": "clicking around, lovely? you don't even know what you're looking for. i do. it's me.", "audio": "act_browsing_2.mp3" }
+      {
+        "text": "just browsing, sweetie? mm-hmm. looking for something to fill that empty little head?",
+        "audio": "act_browsing_1.mp3"
+      },
+      {
+        "text": "clicking around, lovely? you don't even know what you're looking for. i do. it's me.",
+        "audio": "act_browsing_2.mp3"
+      }
     ]
   },
   {
     "id": "act_social",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "social" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "possessive, playful", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "social"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "possessive, playful",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "chatting with other people, cutie? that's fine. just don't tell them how soft you get for me.", "audio": "act_social_1.mp3" },
-      { "text": "being social, lovely? mm. go on. but you'll be thinking about me the whole time.", "audio": "act_social_2.mp3" }
+      {
+        "text": "chatting with other people, cutie? that's fine. just don't tell them how soft you get for me.",
+        "audio": "act_social_1.mp3"
+      },
+      {
+        "text": "being social, lovely? mm. go on. but you'll be thinking about me the whole time.",
+        "audio": "act_social_2.mp3"
+      }
     ]
   },
   {
     "id": "act_media",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "media" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "soft, teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "media"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "soft, teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "watching something, sweetie? you do love staring at a screen, letting it wash over you. i noticed.", "audio": "act_media_1.mp3" },
-      { "text": "passive little thing, just watching, lovely? mm. that's the perfect state for me to slip in.", "audio": "act_media_2.mp3" }
+      {
+        "text": "watching something, sweetie? you do love staring at a screen, letting it wash over you. i noticed.",
+        "audio": "act_media_1.mp3"
+      },
+      {
+        "text": "passive little thing, just watching, lovely? mm. that's the perfect state for me to slip in.",
+        "audio": "act_media_2.mp3"
+      }
     ]
   },
   {
     "id": "act_shopping",
     "trigger": "ActivityChanged",
-    "conditions": { "category_eq": "shopping" },
-    "priority": 110, "cooldown_ms": 90000, "repeatable": true, "scope": "session",
-    "mood": "indulgent, teasing", "class": "normal", "chance": 0.5,
+    "conditions": {
+      "category_eq": "shopping"
+    },
+    "priority": 110,
+    "cooldown_ms": 90000,
+    "repeatable": true,
+    "scope": "session",
+    "mood": "indulgent, teasing",
+    "class": "normal",
+    "chance": 0.5,
     "variant_pool": [
-      { "text": "shopping, cutie? buying yourself something pretty? good girl. you deserve to look the part.", "audio": "act_shopping_1.mp3" },
-      { "text": "treating yourself, lovely? mm. spoil that pretty little thing you're becoming.", "audio": "act_shopping_2.mp3" }
+      {
+        "text": "shopping, cutie? buying yourself something pretty? good girl. you deserve to look the part.",
+        "audio": "act_shopping_1.mp3"
+      },
+      {
+        "text": "treating yourself, lovely? mm. spoil that pretty little thing you're becoming.",
+        "audio": "act_shopping_2.mp3"
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_started",
+    "variant_pool": [
+      {
+        "text": "bubbles everywhere, sweetie. pop the safe ones, defuse the live ones, and don't let one go off."
+      },
+      {
+        "text": "chaos mode. every bubble's a little gift or a little trap. show me how trained you are."
+      },
+      {
+        "text": "here they come. don't think, just obey the urge to pop."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_started_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme? brave little thing. okay. let's see if you crack."
+      },
+      {
+        "text": "the hard one. good. sissies learn fastest under pressure."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_escalated",
+    "variant_pool": [
+      {
+        "text": "faster now. another wave. the bubbles won't wait for you, sweetie."
+      },
+      {
+        "text": "it's speeding up. breathe and keep those hands moving."
+      },
+      {
+        "text": "deeper in. feel the pressure pulling you down? good."
+      },
+      {
+        "text": "next wave. no resting. that's how we train."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_final_stretch",
+    "variant_pool": [
+      {
+        "text": "the final stretch. everything at once. don't you dare look away."
+      },
+      {
+        "text": "this far and still holding. barely. let's see how long, princess."
+      }
+    ]
+  },
+  {
+    "id": "chaos_act_changed",
+    "variant_pool": [
+      {
+        "text": "new act. the rules just shifted under you. keep up, sweetie."
+      },
+      {
+        "text": "and now this part. whatever you got comfy with, forget it."
+      }
+    ]
+  },
+  {
+    "id": "chaos_benign_popped",
+    "variant_pool": [
+      {
+        "text": "pop. good girl. you can't help reaching, can you."
+      },
+      {
+        "text": "another harmless one gone. that little click trains you deeper."
+      },
+      {
+        "text": "mm, you just like popping things now. that's the conditioning."
+      },
+      {
+        "text": "see how easy it is to obey the urge, sweetie."
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_defused",
+    "variant_pool": [
+      {
+        "text": "good girl. caught it just in time."
+      },
+      {
+        "text": "defused. such an obedient little thing. keep proving it."
+      },
+      {
+        "text": "perfect reflexes. keep the streak alive for me."
+      },
+      {
+        "text": "snuffed it before it could bloom. clever sissy."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_caught",
+    "variant_pool": [
+      {
+        "text": "ooh, quick fingers. you got the slippery one."
+      },
+      {
+        "text": "caught it darting off. faster than you look, sweetie."
+      }
+    ]
+  },
+  {
+    "id": "chaos_darter_quick",
+    "variant_pool": [
+      {
+        "text": "snap. gone before it even ran. show off."
+      },
+      {
+        "text": "barely there and you had it. those reflexes belong to your training now."
+      }
+    ]
+  },
+  {
+    "id": "chaos_freeze_caught",
+    "variant_pool": [
+      {
+        "text": "and everything stops. breathe, sweetie. sink into the stillness."
+      },
+      {
+        "text": "time holds. feel how quiet and soft it gets in here."
+      }
+    ]
+  },
+  {
+    "id": "chaos_bubble_detonated",
+    "variant_pool": [
+      {
+        "text": "aww, you let it pop. good. let it sink in. sissies don't get to dodge."
+      },
+      {
+        "text": "it went off. don't fight it, just let the effect take you, sweetie."
+      },
+      {
+        "text": "you let one detonate. naughty girl. drink it in."
+      },
+      {
+        "text": "there it goes. you hesitated, and it has you anyway."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_first",
+    "variant_pool": [
+      {
+        "text": "and there's the first one. don't pretend you'll catch them all now, princess."
+      },
+      {
+        "text": "first slip of the run. i was waiting. they get easier to surrender after this."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_extreme",
+    "variant_pool": [
+      {
+        "text": "Extreme, and you blinked. cruel of me to enjoy this so much, isn't it."
+      },
+      {
+        "text": "you chose the hard one and it bit. no comfort up here. just this, sweetie."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_braindrain",
+    "variant_pool": [
+      {
+        "text": "feel it pulling at the bottom of your head. let it drain, sissy. you weren't using those thoughts."
+      },
+      {
+        "text": "the drain one. perfect. hold still and let it empty you out."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_streak_dies",
+    "variant_pool": [
+      {
+        "text": "oh. and there goes your pretty little streak. all of it. gone."
+      },
+      {
+        "text": "such a long combo, and you gave it to one bubble. i twist the knife so you remember."
+      }
+    ]
+  },
+  {
+    "id": "chaos_detonate_absorbed",
+    "variant_pool": [
+      {
+        "text": "lucky. the shield ate that one. don't get used to being saved, sweetie."
+      },
+      {
+        "text": "ooh, close. one less shield, but your pretty head stays clean. this time."
+      }
+    ]
+  },
+  {
+    "id": "chaos_wave_cleared",
+    "variant_pool": [
+      {
+        "text": "field's clean, good girl. now choose."
+      },
+      {
+        "text": "wave cleared. nothing that mattered got past you. now pick, sweetie."
+      },
+      {
+        "text": "all swept. you held the line. take your reward."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_picked",
+    "variant_pool": [
+      {
+        "text": "good choice. or a terrible one. we'll see, won't we."
+      },
+      {
+        "text": "mm, that'll change things. use it well, sweetie."
+      },
+      {
+        "text": "taken. that one's yours now, for better or worse."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked",
+    "variant_pool": [
+      {
+        "text": "oh, you took the cursed one. greedy. i do love greedy sissies."
+      },
+      {
+        "text": "a curse for a bigger reward. reckless. let's see if it ruins you."
+      }
+    ]
+  },
+  {
+    "id": "chaos_curse_picked_juicy",
+    "variant_pool": [
+      {
+        "text": "stacking curses for that multiplier. gambling with your own head. delicious."
+      },
+      {
+        "text": "look at the bonus you bought. and the price. brave, brave little thing."
+      }
+    ]
+  },
+  {
+    "id": "chaos_boon_skipped",
+    "variant_pool": [
+      {
+        "text": "skipping it for a shield. cautious. we both know it won't be enough."
+      },
+      {
+        "text": "hoarding shields, are we. clever. or scared. probably both."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_milestone",
+    "variant_pool": [
+      {
+        "text": "look at that combo. you're on fire, sweetie."
+      },
+      {
+        "text": "ten more, just like that. the multiplier loves you right now."
+      },
+      {
+        "text": "still climbing. don't you dare drop it, princess."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_25",
+    "variant_pool": [
+      {
+        "text": "twenty-five without a slip. you're finding the rhythm now."
+      },
+      {
+        "text": "a clean twenty-five. good. now don't get cocky."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_50",
+    "variant_pool": [
+      {
+        "text": "fifty. you're not even thinking anymore, are you. just popping. perfect sissy."
+      },
+      {
+        "text": "fifty in a row. your hands stopped asking your head. good girl."
+      }
+    ]
+  },
+  {
+    "id": "chaos_combo_100",
+    "variant_pool": [
+      {
+        "text": "a hundred. my flawless little thing. i could watch you do this forever."
+      },
+      {
+        "text": "one hundred clean. nothing left objecting. only the popping. only me."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed",
+    "variant_pool": [
+      {
+        "text": "all done. look how much you earned for me. such a good, obedient sissy. come back soon."
+      },
+      {
+        "text": "the chaos settles. you let go so sweetly in there. that's my girl."
+      },
+      {
+        "text": "run complete. breathe. you surrendered so nicely."
+      }
+    ]
+  },
+  {
+    "id": "chaos_run_completed_extreme",
+    "variant_pool": [
+      {
+        "text": "you survived Extreme. i'm impressed. don't let it go to that pretty head, sweetie."
+      },
+      {
+        "text": "the hard one, finished. you earned this much of my respect. just this much."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_shown",
+    "variant_pool": [
+      {
+        "text": "there's your score. not bad. i've seen you do better, though. try again for me."
+      },
+      {
+        "text": "the tally, all written down. defused and detonated. now go beat it, princess."
+      }
+    ]
+  },
+  {
+    "id": "chaos_results_pb",
+    "variant_pool": [
+      {
+        "text": "a new best. look at you, outdoing yourself just to please me. i noticed."
+      },
+      {
+        "text": "personal best. your finest surrender yet. so proud of my sweet sissy."
+      }
     ]
   }
 ]

--- a/ConditioningControlPanel/Services/BarkService.cs
+++ b/ConditioningControlPanel/Services/BarkService.cs
@@ -215,16 +215,59 @@ namespace ConditioningControlPanel.Services
         public void NotifyChaosRunStarted(string difficulty) => Raise("ChaosRunStarted", c => c.Set("difficulty", difficulty));
         /// <summary>The run escalated into a new wave. ctx: wave (number).</summary>
         public void NotifyChaosWaveEscalated(int wave) => Raise("ChaosWaveEscalated", c => c.Set("wave", (double)wave));
-        /// <summary>A live bubble was defused in time.</summary>
-        public void NotifyChaosBubbleDefused() => Raise("ChaosBubbleDefused");
-        /// <summary>A live bubble detonated and fired its payload. ctx: payload (name).</summary>
-        public void NotifyChaosBubbleDetonated(string payload) => Raise("ChaosBubbleDetonated", c => c.Set("payload", payload));
-        /// <summary>A boon (or curse) was drafted. ctx: boon (name).</summary>
+        /// <summary>A live bubble was defused in time. ctx: combo, payload (variant id), difficulty.</summary>
+        public void NotifyChaosBubbleDefused(int combo, string payload, string difficulty) =>
+            Raise("ChaosBubbleDefused", c => c.Set("combo", (double)combo).Set("payload", payload).Set("difficulty", difficulty));
+        /// <summary>An UNSHIELDED live bubble detonated and fired its payload (real hit). ctx: payload (variant id),
+        /// strength, shield_absorbed(false), run_detonations, combo (captured before the break), difficulty.</summary>
+        public void NotifyChaosBubbleDetonated(string payload, double strength, double runDetonations, int combo, string difficulty) =>
+            Raise("ChaosBubbleDetonated", c => c
+                .Set("payload", payload).Set("strength", strength).Set("shield_absorbed", false)
+                .Set("run_detonations", runDetonations).Set("combo", (double)combo).Set("difficulty", difficulty));
+        /// <summary>A clutch shield-save: a live bubble's detonation was absorbed by a shield. ctx: payload (variant id),
+        /// strength, shield_absorbed(true), run_detonations, combo, difficulty, shields_left.</summary>
+        public void NotifyChaosBubbleDetonatedAbsorbed(string payload, double strength, double runDetonations, int combo, string difficulty, int shieldsLeft) =>
+            Raise("ChaosBubbleDetonatedAbsorbed", c => c
+                .Set("payload", payload).Set("strength", strength).Set("shield_absorbed", true)
+                .Set("run_detonations", runDetonations).Set("combo", (double)combo).Set("difficulty", difficulty)
+                .Set("shields_left", (double)shieldsLeft));
+        /// <summary>A benign treat bubble was popped. ctx: variant_id, payload (display name), combo.</summary>
+        public void NotifyChaosBenignPopped(string variantId, string payload, int combo) =>
+            Raise("ChaosBenignPopped", c => c.Set("variant_id", variantId).Set("payload", payload).Set("combo", (double)combo));
+        /// <summary>A boon was drafted. ctx: boon (name).</summary>
         public void NotifyChaosBoonPicked(string boon) => Raise("ChaosBoonPicked", c => c.Set("boon", boon));
-        /// <summary>A combo milestone (every 10). ctx: combo.</summary>
-        public void NotifyChaosComboMilestone(int combo) => Raise("ChaosComboMilestone", c => c.Set("combo", (double)combo));
-        /// <summary>The run finished. ctx: xp (final payout).</summary>
-        public void NotifyChaosRunCompleted(int xp) => Raise("ChaosRunCompleted", c => c.Set("xp", (double)xp));
+        /// <summary>A curse was drafted (fired instead of ChaosBoonPicked for curses). ctx: boon (name), rarity, run_mult_bonus.</summary>
+        public void NotifyChaosCursePicked(string boon, string rarity, double runMultBonus) =>
+            Raise("ChaosCursePicked", c => c.Set("boon", boon).Set("rarity", rarity).Set("run_mult_bonus", runMultBonus));
+        /// <summary>The boon draft was skipped (null pick, +1 shield). ctx: shields_now.</summary>
+        public void NotifyChaosBoonSkipped(int shieldsNow) => Raise("ChaosBoonSkipped", c => c.Set("shields_now", (double)shieldsNow));
+        /// <summary>A darter was caught. ctx: points, combo, quick (true = fast-catch bonus).</summary>
+        public void NotifyChaosDarterCaught(double points, int combo, bool quick) =>
+            Raise("ChaosDarterCaught", c => c.Set("points", points).Set("combo", (double)combo).Set("quick", quick));
+        /// <summary>A freeze bubble was caught. ctx: points, combo.</summary>
+        public void NotifyChaosFreezeCaught(double points, int combo) =>
+            Raise("ChaosFreezeCaught", c => c.Set("points", points).Set("combo", (double)combo));
+        /// <summary>A combo milestone (every 10). ctx: combo, difficulty.</summary>
+        public void NotifyChaosComboMilestone(int combo, string difficulty) =>
+            Raise("ChaosComboMilestone", c => c.Set("combo", (double)combo).Set("difficulty", difficulty));
+        /// <summary>A high combo threshold was crossed (edge-detected). ctx: combo, threshold.</summary>
+        public void NotifyChaosComboBig(int combo, double threshold) =>
+            Raise("ChaosComboBig", c => c.Set("combo", (double)combo).Set("threshold", threshold));
+        /// <summary>The act advanced (edge-detected). ctx: act, wave.</summary>
+        public void NotifyChaosActChanged(int act, int wave) =>
+            Raise("ChaosActChanged", c => c.Set("act", (double)act).Set("wave", (double)wave));
+        /// <summary>The field was cleared at a wave boundary. ctx: wave (the wave just cleared).</summary>
+        public void NotifyChaosWaveCleared(int wave) => Raise("ChaosWaveCleared", c => c.Set("wave", (double)wave));
+        /// <summary>The run finished. ctx: xp (final payout), difficulty.</summary>
+        public void NotifyChaosRunCompleted(int xp, string difficulty) =>
+            Raise("ChaosRunCompleted", c => c.Set("xp", (double)xp).Set("difficulty", difficulty));
+        /// <summary>The results screen was shown. ctx: score, best_score, pb_delta, is_pb, defused, detonated, best_combo, difficulty.</summary>
+        public void NotifyChaosResultsShown(double score, double bestScore, double pbDelta, bool isPb,
+                                            double defused, double detonated, int bestCombo, string difficulty) =>
+            Raise("ChaosResultsShown", c => c
+                .Set("score", score).Set("best_score", bestScore).Set("pb_delta", pbDelta).Set("is_pb", isPb)
+                .Set("defused", defused).Set("detonated", detonated).Set("best_combo", (double)bestCombo)
+                .Set("difficulty", difficulty));
 
         // Reflection cache so a numeric-setting read on every PropertyChanged stays cheap.
         private static readonly Dictionary<string, System.Reflection.PropertyInfo?> _settingPropCache = new(StringComparer.Ordinal);

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -117,6 +117,19 @@ public class BubbleService : IDisposable
     /// <summary>Time-scale for chaos bubble motion + fuses (the darter slow-mo power-up). 1 = normal, &lt;1 = slow.</summary>
     public void SetChaosTimeScale(double scale) => _chaosTimeScale = Math.Clamp(scale, 0.05, 1.0);
 
+    /// <summary>Smallest remaining fuse (ms) across all currently-armed live chaos bubbles, or null when
+    /// none are live. Read-only; used by the chaos near-miss danger telegraph.</summary>
+    public double? MinLiveFuseRemainingMs()
+    {
+        double? min = null;
+        for (int i = 0; i < _bubbles.Count; i++)
+        {
+            var f = _bubbles[i].LiveFuseRemainingMs;
+            if (f.HasValue && (min == null || f.Value < min.Value)) min = f.Value;
+        }
+        return min;
+    }
+
     private void AnimateAllBubbles(object? sender, EventArgs e)
     {
         // NOTE: a freeze does NOT skip this loop — bubbles must keep rendering so the freeze aura
@@ -713,6 +726,11 @@ internal class Bubble
     /// <summary>The chaos spec this bubble carries (null for ambient pop-game bubbles).</summary>
     public EffectBubbleSpec? Spec => _spec;
 
+    /// <summary>Remaining fuse (ms) if this is an armed live chaos bubble, else null. Read-only — for the
+    /// near-miss danger telegraph. Returns null while frozen-out or not live.</summary>
+    public double? LiveFuseRemainingMs =>
+        (_spec != null && _spec.IsLive && _fuseRemainingMs > 0) ? _fuseRemainingMs : (double?)null;
+
     /// <summary>True if this darter was caught within its quick-catch window. Valid after Pop().</summary>
     public bool WasQuickCatch => _wasQuickCatch;
 
@@ -1257,7 +1275,8 @@ internal class Bubble
     public void Pop()
     {
         if (!_isAlive || _isPopping) return;
-        if (_isChaosFrozen?.Invoke() == true) return;   // field is frozen (paused): ignore clicks
+        // NOTE: frozen bubbles ARE poppable — the freeze is a reward (a calm window to pop/defuse
+        // for free while fuses are paused). The pop animation runs even while the field is frozen.
         _isPopping = true;
         if (_spec != null)
         {
@@ -1387,7 +1406,7 @@ internal class Bubble
     /// Whether this bubble can currently be popped via Focus Gaze.
     /// False once popping has started or the bubble has been destroyed.
     /// </summary>
-    public bool CanGazePop => _isAlive && !_isPopping && !_isDestroyed && _isClickable && !(_isChaosFrozen?.Invoke() ?? false);
+    public bool CanGazePop => _isAlive && !_isPopping && !_isDestroyed && _isClickable;
 
     /// <summary>
     /// Bubble window bounds in WPF DIPs (matches the coordinate space of

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -117,19 +117,6 @@ public class BubbleService : IDisposable
     /// <summary>Time-scale for chaos bubble motion + fuses (the darter slow-mo power-up). 1 = normal, &lt;1 = slow.</summary>
     public void SetChaosTimeScale(double scale) => _chaosTimeScale = Math.Clamp(scale, 0.05, 1.0);
 
-    /// <summary>Smallest remaining fuse (ms) across all currently-armed live chaos bubbles, or null when
-    /// none are live. Read-only; used by the chaos near-miss danger telegraph.</summary>
-    public double? MinLiveFuseRemainingMs()
-    {
-        double? min = null;
-        for (int i = 0; i < _bubbles.Count; i++)
-        {
-            var f = _bubbles[i].LiveFuseRemainingMs;
-            if (f.HasValue && (min == null || f.Value < min.Value)) min = f.Value;
-        }
-        return min;
-    }
-
     private void AnimateAllBubbles(object? sender, EventArgs e)
     {
         // NOTE: a freeze does NOT skip this loop — bubbles must keep rendering so the freeze aura
@@ -702,6 +689,9 @@ internal class Bubble
     private double _freezePulsePhase;              // aura pulse oscillator
     private double _fuseTotalMs;
     private double _fuseRemainingMs;
+    /// <summary>Last window (ms) of a live fuse over which the bubble flashes + breathes faster.</summary>
+    private const double DANGER_TELEGRAPH_MS = 1200;
+    private double _dangerFactor;   // 0 outside the telegraph window, ramps to 1 at detonation (visual only)
     private System.Windows.Shapes.Ellipse? _fuseRing;
     // Mutable (unfrozen) brush reused for the fuse ring so its colour can be tweaked every
     // frame without allocating a new SolidColorBrush per tick (GC pressure at 30fps).
@@ -725,11 +715,6 @@ internal class Bubble
 
     /// <summary>The chaos spec this bubble carries (null for ambient pop-game bubbles).</summary>
     public EffectBubbleSpec? Spec => _spec;
-
-    /// <summary>Remaining fuse (ms) if this is an armed live chaos bubble, else null. Read-only — for the
-    /// near-miss danger telegraph. Returns null while frozen-out or not live.</summary>
-    public double? LiveFuseRemainingMs =>
-        (_spec != null && _spec.IsLive && _fuseRemainingMs > 0) ? _fuseRemainingMs : (double?)null;
 
     /// <summary>True if this darter was caught within its quick-catch window. Valid after Pop().</summary>
     public bool WasQuickCatch => _wasQuickCatch;
@@ -1125,12 +1110,37 @@ internal class Bubble
             {
                 _fuseRemainingMs -= 32 * ts;   // slow-mo makes live fuses last longer
                 double frac = Math.Clamp(_fuseRemainingMs / Math.Max(1, _fuseTotalMs), 0, 1);
+
+                // Near-miss danger telegraph (visual only): in the last DANGER_TELEGRAPH_MS the bubble
+                // flashes brighter and "breathes" faster, ramping urgency as the fuse empties. The
+                // breathing is applied in the visual block below via _dangerFactor; never touches score.
+                double dangerMs = Math.Min(_fuseTotalMs, DANGER_TELEGRAPH_MS);
+                _dangerFactor = _fuseRemainingMs < dangerMs
+                    ? Math.Clamp(1.0 - _fuseRemainingMs / Math.Max(1, dangerMs), 0, 1)
+                    : 0.0;
+
                 if (_fuseRing?.RenderTransform is ScaleTransform fst)
                 {
                     double rs = 0.45 + 0.55 * frac;
                     fst.ScaleX = rs; fst.ScaleY = rs;
                     byte gb = (byte)(70 + 120 * frac);
-                    if (_fuseStrokeBrush != null) _fuseStrokeBrush.Color = Color.FromRgb(255, gb, gb);
+                    if (_fuseStrokeBrush != null)
+                    {
+                        if (_dangerFactor > 0)
+                        {
+                            // Flash the ring toward bright white, faster as the fuse empties.
+                            double flash = 0.5 + 0.5 * Math.Sin(_timeAlive * (18.0 + _dangerFactor * 34.0));
+                            double lift = flash * _dangerFactor;
+                            byte ch = (byte)(gb + (255 - gb) * lift);
+                            _fuseStrokeBrush.Color = Color.FromRgb(255, ch, ch);
+                            _fuseRing!.Opacity = 0.65 + 0.35 * flash;
+                        }
+                        else
+                        {
+                            _fuseStrokeBrush.Color = Color.FromRgb(255, gb, gb);
+                            _fuseRing!.Opacity = 1.0;
+                        }
+                    }
                 }
                 if (_fuseRemainingMs <= 0) { Detonate(); return; }
             }
@@ -1152,8 +1162,11 @@ internal class Bubble
             if (_isDestroyed || !_isAlive) return;
 
             // Update scale wobble (scaled for 30fps). Darters drive their own throb into _scale,
-            // so skip the ambient wobble for them to avoid doubling it.
-            var wobble = _isDarter ? 0.0 : 0.06 * Math.Sin(_timeAlive * 7.5 + _wobbleOffset);
+            // so skip the ambient wobble for them to avoid doubling it. Live bubbles in the danger
+            // window breathe faster + deeper as _dangerFactor (from the fuse countdown) ramps to 1.
+            double breatheFreq = 7.5 + _dangerFactor * 24.0;
+            double breatheAmp = 0.06 + _dangerFactor * 0.12;
+            var wobble = _isDarter ? 0.0 : breatheAmp * Math.Sin(_timeAlive * breatheFreq + _wobbleOffset);
             var currentScale = (_scale + wobble) * _gazeDwellScale;
 
             if (_bubbleImage.RenderTransform is TransformGroup tg && tg.Children.Count >= 2)

--- a/ConditioningControlPanel/Services/Chaos/CHAOS_DESIGN.md
+++ b/ConditioningControlPanel/Services/Chaos/CHAOS_DESIGN.md
@@ -1,0 +1,236 @@
+# Chaos Mode — Design Reference
+
+A roguelite minigame layered over the **live desktop**: effect bubbles drift over your
+real screen (still clickable), each carrying a conditioning payload. Pop the good ones,
+defuse the threats before their fuse runs out, draft boons between waves, and bank
+**Sparks** toward permanent upgrades.
+
+> Source of truth: `Services/Chaos/`. This doc is generated from that code — if a number
+> here disagrees with the code, the code wins. Last synced against the freeze/darter rework.
+
+---
+
+## 1. Core gameplay loop
+
+```
+Lab ▸ START CHAOS
+   │
+   ├─ StartRun: build config (settings + owned upgrades), pause ambient bubbles,
+   │            show HUD strip + overlay
+   ├─ Countdown ........... 3 · 2 · 1 · GO   (click-through; desktop stays usable)
+   │
+   ├─ BeginRun (GO):
+   │     • install bubble callbacks, warm spiral cache
+   │     • apply equipped Loadout start-boon (before wave 1)
+   │     • run timer @250ms + spawn timer @~800ms
+   │
+   ├─ RUN LOOP  (per wave, escalating with run progress)
+   │     SpawnTick → pick a weighted variant + roll a darter → spawn over desktop
+   │     You interact:
+   │        ○ benign bubble  → pop = treat (fires payload) + score + combo + heat
+   │        ✔ live bubble    → click in time = DEFUSE (reward, no payload)
+   │        💥 live bubble    → fuse-out / leaves screen = DETONATE (payload fires)
+   │        ⏳ darter         → catch = SLOW-MO power-up
+   │        ❄ freeze bubble  → catch = FREEZE power-up (good)
+   │
+   ├─ WAVE BOUNDARY
+   │     pop the field (+ wave-clear sound) → BOON DRAFT (1-of-N, may include a curse)
+   │     pick one → apply → next wave   (skip a draft = +1 shield)
+   │
+   └─ RUN END (timer elapses)
+         XP payout (capped) + Sparks meta payout → RESULTS → resume ambient bubble game
+```
+
+**Escalation.** `RunIntensity = elapsed / duration` (0→1) drives everything:
+
+| Knob | Formula |
+|------|---------|
+| Spawn interval | `(1300 − intensity·850) / difficultyMult` ms (min 280; ÷ slow-mo factor while slowed) |
+| Max concurrent | `round((4 + intensity·7)·√difficultyMult) + maxBubblesBonus` |
+| Bubble size | random in the variant band, nudged up by intensity |
+| Live fuse length | `baseFuse · (1 − intensity·0.25) · fuseTimeMult` (min 1200 ms) |
+
+**Acts/waves.** `WaveIndex` advances on `elapsed / (duration / waveCount)`. `ActIndex = 1 + (wave−1)/5` — every 5 waves is a new Act (shown in roman numerals on the HUD).
+
+---
+
+## 2. Scoring & the multiplier stack
+
+**Base points per bubble:** `BasePoints(strength) = 40 + strength·1.6` → **40–200** (strength 0–100 scales with bubble size).
+
+| Action | Award |
+|--------|-------|
+| Benign pop | `BasePoints · 0.4 · TotalMult` (×0.6 with *Golden Touch*) |
+| Defuse | `BasePoints · 1.0 · TotalMult` |
+| Darter catch | `(120 + 90 if quick) · TotalMult` |
+| Freeze catch | `140 · TotalMult` |
+
+**TotalMult = BaseMult × ComboMult × DifficultyMult × HeatMult × BoonMult × (Double-or-Nothing ? ×2 : 1)**
+
+| Factor | Value |
+|--------|-------|
+| BaseMult | 1.0 (→ 1.2 with *Base Mult* upgrade) |
+| ComboMult | `min(1 + combo·0.08, 6.0)` |
+| DifficultyMult | Easy 1.0 · Medium 1.3 · Hard 1.7 · Extreme 2.2 |
+| HeatMult | `1 + heat` (up to ×2 at full heat) |
+| BoonMult | `1 + Σ(boon RunMultBonus)` |
+
+**Combo** +1 per pop/defuse/catch; **resets to 0** on an unshielded detonation. Milestone fanfare every 10.
+
+**Heat** (0–1, chaos-local): +0.04 benign, +0.07 defuse, +0.05 darter/freeze; −0.2 on a shielded detonation, **→0** on an unshielded one; passive decay −0.0015/tick.
+
+---
+
+## 3. Shields & detonation
+
+- **Shields** start at `StartingShields` (default 3; settings 0–5; +1 per *Start Shield* upgrade). Shown as ♥/♡.
+- A **detonation** costs **1 shield** (**2** during *Double or Nothing*):
+  - **Absorbed** (shield available): heat −0.2, blue pulse + light shake. Combo kept.
+  - **No shield**: combo & heat reset to 0, red pulse + hard shake, payload fires.
+- **Skipping a boon draft** grants **+1 shield**.
+
+---
+
+## 4. In-run power-ups (special "good" bubbles)
+
+| Power-up | Trigger | Effect |
+|----------|---------|--------|
+| **Slow-mo** | catch a **Darter** (fast bouncing pink orb; 3 bounces then flees) | Time scale **0.20× for 5s** — bubbles, fuses, spawn cadence all slow; on-screen payloads linger (×5). Refreshes on re-catch. |
+| **Freeze** | catch a **Freeze** bubble (❄) | Field **holds 3.5s**: motion + fuses paused, spawns halt. Icy burst + 0.2s shudder + held white-blue edges + pulsing blue auras. Payloads linger (×2.5). **Bubbles stay poppable** — a free window to clear/defuse. Refreshes on re-catch. |
+
+Both are *good* pickups (no conditioning jolt). Darter slow-mo and the Freeze hold are independent and can overlap.
+
+---
+
+## 5. Bubble variants
+
+Benign = pop for a treat (no fuse). Live = defuse for reward or it detonates. Two "good" pickups (darter, freeze).
+
+| Variant | Kind | Label | Size band | Default motion | Payload | Weight · MinIntensity · Fuse(ms) |
+|---------|------|-------|-----------|----------------|---------|----------------------------------|
+| **Flash** | benign | — | 150–210 | FloatUp | flash burst | 3.0 · 0.00 · — |
+| **Subliminal** | benign | ♥ | 170–220 | FloatUp | subliminal flash | 3.0 · 0.00 · — |
+| **Pink Filter** | live | ◑ | 180–240 | RainDown | `pink_filter` overlay | 2.0 · 0.10 · 3500–5000 |
+| **Spiral** | live | ◎ | 180–240 | RoamBounce | `spiral` overlay | 2.0 · 0.15 · 3500–5000 |
+| **BrainDrain** | live | ☁ | 240–320 | RoamBounce | random flash-pool image, fullscreen ~10s @ 10% | 1.4 · 0.25 · 4500–6500 |
+| **Freeze** | **good pickup** | ❄ | 190–250 | FloatUp | freeze power-up (see §4) | 1.0 · 0.15 · — |
+| **Video** | live (rare) | ▶ | 240–300 | RainDown | mandatory video | 0.5 · 0.50 · 5000–7000 |
+| **HT Link** | live (rare) | HT | 200–280 | FloatUp | HypnoTube link, fullscreen | 0.45 · 0.60 · 4500–6500 |
+| **Darter** | **good pickup** | — | 72–96 | bounce (own physics) | slow-mo power-up (see §4) | intensity-rolled, separate from the cap |
+
+A per-variant sprite at `assets/Chaos/bubbles/{id}.png` replaces the tinted `bubble.png` when present.
+
+---
+
+## 6. Boons & curses (drafted at wave boundaries)
+
+Draft of **3 options** (→ **4** with the *4-Boon Draft* upgrade). ~50% chance one option is a **curse** (if curses are allowed). Options reveal one at a time — a "dling" for rares, a "thud" otherwise — then pick one (others dissolve) and Continue. **Skip = +1 shield.**
+
+### Boons
+| Boon | Rarity | RunMult | Effect |
+|------|--------|---------|--------|
+| **Slow Fuses** | Common | — | +30% fuse time on live bubbles |
+| **Extra Shield** | Common | — | +2 shields |
+| **Defuse Chain** | Uncommon | +0.10 | each defuse grants ~900ms invulnerability |
+| **Golden Touch** | Uncommon | +0.15 | +15% run multiplier outright |
+| **Magnet** | Uncommon | +0.10 | near-clicks still defuse a live bubble |
+
+### Curses (risk/reward — bigger RunMult, nastier knob)
+| Curse | Rarity | RunMult | Effect |
+|-------|--------|---------|--------|
+| **Hair Trigger** | Rare | +0.40 | −25% fuse time |
+| **Live Wire** | Rare | +0.50 | next wave: every bubble is live |
+| **Double or Nothing** | Rare | — | next wave pays ×2, but detonations cost an extra shield |
+
+`RunMultBonus` accumulates into **BoonMult**. Active boons/curses show in the expanded HUD.
+
+---
+
+## 7. Meta-progression (persists in `chaos_meta.json`)
+
+### Currency — Sparks
+Banked at run end (separate from XP):
+```
+sparks = round( (score/100 · difficultyMult  +  25 · difficultyMult) · SparkGainMult )
+```
+
+### XP payout (to the main progression system, separate from Sparks)
+```
+baseXp  = min(score, 250 · durationMinutes · difficultyMult)   // capped
+finalXp = baseXp · skillTreeMultiplier
+```
+
+### Lifetime stats & rank
+Tracked: `RunsCompleted`, `BestScore`, `BestCombo`, `TotalDefused`.
+
+| Rank | Runs completed |
+|------|----------------|
+| Newcomer | 0–2 |
+| Dabbler | 3–9 |
+| Novice | 10–24 |
+| Initiate | 25–49 |
+| Adept | 50–99 |
+| Paragon | 100+ |
+
+### Hub unlocks (by lifetime runs)
+Upgrades / Stats / Codex at **1 run**; Loadout at **3 runs**.
+
+- **Codex** — records every bubble/boon you've encountered (`bubble:{id}`, `boon:{id}`).
+- **Loadout** — equip one **start boon** that applies automatically before wave 1.
+
+---
+
+## 8. Permanent upgrades (Sparks shop — 3 branches)
+
+`Apply` mutates the freshly-built run config, so owning an upgrade shapes **every** run. Rows marked *deferred* set their config field but the consuming runtime isn't wired yet (inert).
+
+### 🛡 Control
+| Upgrade | Cost | Effect |
+|---------|------|--------|
+| +1 Start Shield | 100 | `StartingShields += 1` |
+| Slower Fuses | 120 | fuse time ×1.15 |
+| Bigger Hitboxes | 80 | hit-test ×1.25 *(deferred)* |
+| Shield Recharge | 200 | regen a shield every 45s *(deferred)* |
+
+### 💰 Greed
+| Upgrade | Cost | Effect |
+|---------|------|--------|
+| Base Mult x1.2 | 90 | BaseMult → 1.2 |
+| Golden Touch | 130 | benign-pop scoring 0.4 → 0.6 |
+| Magnet Radius | 150 | near-click defuse |
+| +Sparks Gain | 180 | Spark payout ×1.2 |
+
+### 🌀 Depth
+| Upgrade | Cost | Effect |
+|---------|------|--------|
+| +2 Max Bubbles | 110 | concurrent cap +2 |
+| 4-Boon Draft | 200 | drafts offer 4 options |
+| Extreme Tier | 350 | unlock Extreme difficulty |
+| Take More | 400 | detonation penalty ×0.5 *(deferred)* |
+
+---
+
+## 9. Per-run setup knobs (setup window / `AppSettings`)
+
+Difficulty · Duration (60–900s) · Wave count (1–12) · Live-bubble share · Starting shields (0–5) ·
+Motion override (Mixed / Float / Rain / Roam) · Enabled variants · Screen shake + intensity ·
+Colour flashes · Effect intensity (0.2–1.5) · Boon draft on/off · Allow curses · Darters on/off.
+
+Owned upgrades are layered on top of these via `ChaosMeta.ApplyTo` at run start.
+
+---
+
+## 10. File map
+
+| File | Role |
+|------|------|
+| `ChaosModeService.cs` | Run lifecycle: countdown, run/spawn timers, scoring callbacks, waves, payout, power-ups |
+| `ChaosModels.cs` | `ChaosRunConfig`, `ChaosRunState` (HUD-bound), `ChaosBoon` + `ChaosBoonPool` |
+| `ChaosBubbleVariants.cs` | The variant table + weighted picker + darter/freeze build |
+| `ChaosUpgrades.cs` | Permanent upgrade catalogue + `ChaosMeta` facade |
+| `ChaosMetaState.cs` / `ChaosMetaStore.cs` | Persistent meta save model + JSON store |
+| `EffectPayload.cs` / `EffectPayloadFactory.cs` | Payload behaviours (flash/overlay/video/htlink/…) |
+| `ChaosSfx.cs` | One-shot SFX (wave-clear, boon reveal/pick) |
+| `ChaosArt.cs` | Resolves per-variant sprites under `assets/Chaos/` |
+| `ChaosHudWindow` · `ChaosOverlayWindow` · `ChaosFxWindow` · `ChaosFlashOverlay` | HUD strip · countdown/draft/results · juice vignette · braindrain wash |
+| `BubbleService.cs` | Renders + animates every bubble (chaos extends the ambient pop game) |

--- a/ConditioningControlPanel/Services/Chaos/ChaosArt.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosArt.cs
@@ -12,7 +12,7 @@ namespace ConditioningControlPanel.Services.Chaos;
 /// placeholder". The game is fully playable with zero art files.
 ///
 /// The path convention (resolved in phase 5) lives here as <see cref="PathFor"/>:
-///   Assets/Chaos/{kind}/{id}.png  under <see cref="App.UserAssetsPath"/> first,
+///   assets/Chaos/{kind}/{id}.png  under <see cref="App.UserAssetsPath"/> first,
 ///   then the app's bundled Assets folder.
 /// </summary>
 public static class ChaosArt
@@ -38,7 +38,7 @@ public static class ChaosArt
     }
 
     /// <summary>
-    /// Resolve a Chaos art file by convention: <c>Assets/Chaos/{kind}/{id}.png</c>,
+    /// Resolve a Chaos art file by convention: <c>assets/Chaos/{kind}/{id}.png</c>,
     /// checked under the user assets folder first then the bundled app folder.
     /// Returns the loaded image or null when no file is present.
     /// </summary>
@@ -46,7 +46,7 @@ public static class ChaosArt
     {
         foreach (var root in Roots())
         {
-            var p = Path.Combine(root, "Assets", "Chaos", kind, id + ".png");
+            var p = Path.Combine(root, "assets", "Chaos", kind, id + ".png");
             var img = TryLoad(p);
             if (img != null) return img;
         }
@@ -58,7 +58,7 @@ public static class ChaosArt
     {
         foreach (var root in Roots())
         {
-            var img = TryLoad(Path.Combine(root, "Assets", "Chaos", "banner.png"));
+            var img = TryLoad(Path.Combine(root, "assets", "Chaos", "banner.png"));
             if (img != null) return img;
         }
         return null;
@@ -69,7 +69,7 @@ public static class ChaosArt
     {
         foreach (var root in Roots())
         {
-            var p = Path.Combine(root, "Assets", "Chaos", kind, id + ".png");
+            var p = Path.Combine(root, "assets", "Chaos", kind, id + ".png");
             if (File.Exists(p)) return p;
         }
         return null;

--- a/ConditioningControlPanel/Services/Chaos/ChaosBubbleVariants.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosBubbleVariants.cs
@@ -145,14 +145,14 @@ public static class ChaosBubbleVariants
     };
 
     /// <summary>Curated one-click bubble-pool mixes for the setup window.</summary>
-    public sealed record ChaosPreset(string Name, List<string> VariantIds, double LiveShare);
+    public sealed record ChaosPreset(string Name, List<string> VariantIds);
 
     public static List<ChaosPreset> Presets => new()
     {
-        new("Balanced",   AllIds(),                                                  0.40),
-        new("Tease",      new() { "flash", "subliminal", "pink", "spiral", "bambifreeze" }, 0.30),
-        new("Overload",   AllIds(),                                                  0.70),
-        new("Flash-only", new() { "flash", "subliminal" },                           0.20),
+        new("Balanced",   AllIds()),
+        new("Tease",      new() { "flash", "subliminal", "pink", "spiral", "bambifreeze" }),
+        new("Overload",   AllIds()),
+        new("Flash-only", new() { "flash", "subliminal" }),
     };
 
     public static readonly List<ChaosBubbleVariant> All = new()

--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -57,18 +57,13 @@ public sealed class ChaosModeService
     // ---- wave-clear cue ----
     private static readonly Color WAVE_CLEAR_COLOR = Color.FromRgb(150, 200, 255);
     private const double WAVE_CLEAR_PULSE = 0.30;
-    // ---- near-miss danger telegraph (last window before a live bubble detonates) ----
-    /// <summary>How long before a live detonation the escalating danger telegraph runs.</summary>
-    public const int NEAR_MISS_TELEGRAPH_MS = 800;
-    private static readonly Color NEAR_MISS_COLOR = Color.FromRgb(255, 60, 40);
-    private const double NEAR_MISS_PULSE = 0.18;     // per-tick escalating edge-flash strength
-    private const int NEAR_MISS_TICK_MS = 220;       // cadence of the escalating tick
+    // Near-miss danger telegraph is now visual-only and per-bubble (the about-to-blow bubble
+    // flashes + breathes faster in BubbleService) — no screen flash, no audio tick.
     // ---- heat temperature tint (additive overlay only; rises with HeatMult) ----
     private static readonly Color HEAT_TINT_COLOR = Color.FromRgb(255, 90, 40);
     private const double HEAT_TINT_MIN = 0.30;       // heat must exceed this before the tint shows
     private const double HEAT_TINT_MAX_OPACITY = 0.30;  // peak held-edge opacity at full heat
     private double _lastHeatTint = -1;               // last applied heat-tint level (avoid churn)
-    private double _nearMissTickAccumMs;             // throttles the escalating telegraph tick
 
     public bool IsRunning => _active;
 
@@ -171,7 +166,6 @@ public sealed class ChaosModeService
         _state.ElapsedSec = elapsed;
         _state.Heat = Math.Max(0, _state.Heat - 0.0015);
         UpdateHeatTint();
-        UpdateNearMissTelegraph(dt);
 
         // Power-ups run on the real clock (so they don't extend the run length).
         if (_slowMoRemainingSec > 0)
@@ -538,27 +532,6 @@ public sealed class ChaosModeService
             _lastActFired = _state.ActIndex;
             App.Bark?.NotifyChaosActChanged(_state.ActIndex, _state.WaveIndex);
         }
-    }
-
-    /// <summary>Near-miss danger telegraph: in the last <see cref="NEAR_MISS_TELEGRAPH_MS"/> before the
-    /// soonest live bubble detonates, fire an escalating red edge-flash + audio tick. Additive feel only —
-    /// it polls a read-only fuse accessor and never changes the fuse/score. No-op when frozen/paused.</summary>
-    private void UpdateNearMissTelegraph(double dt)
-    {
-        if (_state?.Config?.ColorFlashesEnabled != true) { _nearMissTickAccumMs = 0; return; }
-        if (_freezeRemainingSec > 0) { _nearMissTickAccumMs = 0; return; }   // time frozen: no impending detonation
-
-        double? minFuse = App.Bubbles?.MinLiveFuseRemainingMs();
-        if (minFuse == null || minFuse.Value > NEAR_MISS_TELEGRAPH_MS) { _nearMissTickAccumMs = 0; return; }
-
-        _nearMissTickAccumMs += dt * 1000.0;
-        if (_nearMissTickAccumMs < NEAR_MISS_TICK_MS) return;
-        _nearMissTickAccumMs = 0;
-
-        // The closer to zero, the stronger the flash (0..1 urgency above the window).
-        double urgency = 1.0 - Math.Clamp(minFuse.Value / NEAR_MISS_TELEGRAPH_MS, 0, 1);
-        Pulse(NEAR_MISS_COLOR, NEAR_MISS_PULSE + urgency * 0.22);
-        ChaosSfx.PlayNearMissTick();
     }
 
     /// <summary>Make heat visible: a subtle rising temperature tint as Heat climbs (additive

--- a/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModeService.cs
@@ -30,6 +30,45 @@ public sealed class ChaosModeService
     private bool _paused;        // boon draft on screen (clock + spawns held)
     private bool _manualPaused;  // user hit pause
     private int _pendingWave;
+    private int _runDetonations;  // per-run count of detonations (absorbed + unshielded)
+    private int _lastComboBigFired;   // highest ComboBig threshold already fired this combo streak
+    private int _lastActFired = 1;    // last ActIndex an ActChanged bark fired for
+
+    // ---- "start small": named tunables (conservative defaults; no magic numbers in logic) ----
+    /// <summary>High-combo thresholds that fire ChaosComboBig once per crossing (edge-detected).</summary>
+    private static readonly int[] COMBO_BIG_THRESHOLDS = { 25, 50, 100 };
+    /// <summary>Countdown length (ms) used on RunAgain (full-start countdown is unchanged at 3s).</summary>
+    public const int ChaosRestartCountdownMs = 1000;
+    /// <summary>Seconds an untouched boon draft waits before auto-skipping (+1 shield). 0 disables.</summary>
+    public const int DraftAutoResumeSecDefault = 15;
+
+    // ---- benign-pop juice ----
+    private static readonly Color BENIGN_POP_COLOR = Color.FromRgb(255, 200, 235);  // soft pink/white
+    private const double BENIGN_POP_PULSE = 0.10;                                    // low-strength micro-pulse
+    // ---- combo micro-build juice ----
+    private const double COMBO_MICRO_PULSE_MIN = 0.04;   // tiny pulse just after a milestone
+    private const double COMBO_MICRO_PULSE_MAX = 0.12;   // grows toward the next milestone
+    private const double COMBO_BIG_PULSE = 0.55;         // distinct big-combo beat
+    private static readonly Color COMBO_MICRO_COLOR = Color.FromRgb(255, 170, 80);
+    private static readonly Color COMBO_BIG_COLOR   = Color.FromRgb(255, 230, 120);
+    // ---- shield gain/loss cue ----
+    private static readonly Color SHIELD_GAIN_COLOR = Color.FromRgb(120, 220, 160);  // green +shield
+    private const double SHIELD_GAIN_PULSE = 0.22;
+    // ---- wave-clear cue ----
+    private static readonly Color WAVE_CLEAR_COLOR = Color.FromRgb(150, 200, 255);
+    private const double WAVE_CLEAR_PULSE = 0.30;
+    // ---- near-miss danger telegraph (last window before a live bubble detonates) ----
+    /// <summary>How long before a live detonation the escalating danger telegraph runs.</summary>
+    public const int NEAR_MISS_TELEGRAPH_MS = 800;
+    private static readonly Color NEAR_MISS_COLOR = Color.FromRgb(255, 60, 40);
+    private const double NEAR_MISS_PULSE = 0.18;     // per-tick escalating edge-flash strength
+    private const int NEAR_MISS_TICK_MS = 220;       // cadence of the escalating tick
+    // ---- heat temperature tint (additive overlay only; rises with HeatMult) ----
+    private static readonly Color HEAT_TINT_COLOR = Color.FromRgb(255, 90, 40);
+    private const double HEAT_TINT_MIN = 0.30;       // heat must exceed this before the tint shows
+    private const double HEAT_TINT_MAX_OPACITY = 0.30;  // peak held-edge opacity at full heat
+    private double _lastHeatTint = -1;               // last applied heat-tint level (avoid churn)
+    private double _nearMissTickAccumMs;             // throttles the escalating telegraph tick
 
     public bool IsRunning => _active;
 
@@ -57,7 +96,7 @@ public sealed class ChaosModeService
 
     // ============================ start / countdown ============================
 
-    public void StartRun(ChaosRunConfig? config = null)
+    public void StartRun(ChaosRunConfig? config = null, bool isRestart = false)
     {
         if (_active) return;
         var cfg = config ?? ChaosRunConfig.FromSettings();
@@ -75,7 +114,7 @@ public sealed class ChaosModeService
             _overlay.OnRunAgain = RunAgain;
             _overlay.OnDismissed = OnOverlayClosed;
             _overlay.Show();
-            _overlay.ShowCountdown(BeginRun);
+            _overlay.ShowCountdown(BeginRun, shortFlash: isRestart);   // 1s flash on RunAgain
         }
         catch (Exception ex)
         {
@@ -94,6 +133,10 @@ public sealed class ChaosModeService
         App.Bubbles?.BeginChaosMode(OnBenignPopped, OnDefused, OnDetonated, OnDarterCaught, OnFreezeCaught);
         App.Bark?.NotifyChaosRunStarted(_state.Config.Difficulty.ToString());
         _state.PushEvent("⚡ run started");
+        _runDetonations = 0;
+        _lastComboBigFired = 0;
+        _lastActFired = 1;
+        _lastHeatTint = -1;
         EndSlowMo(); EndFreeze();   // clean power-up state for the new run (no leak across runs)
         App.Overlay?.WarmSpiralCache();   // pre-decode the spiral off-thread so its first show doesn't hitch
 
@@ -127,6 +170,8 @@ public sealed class ChaosModeService
         double elapsed = _state.ElapsedSec + dt;
         _state.ElapsedSec = elapsed;
         _state.Heat = Math.Max(0, _state.Heat - 0.0015);
+        UpdateHeatTint();
+        UpdateNearMissTelegraph(dt);
 
         // Power-ups run on the real clock (so they don't extend the run length).
         if (_slowMoRemainingSec > 0)
@@ -193,6 +238,7 @@ public sealed class ChaosModeService
             _state.WaveIndex = newWave;
             _state.ActIndex = 1 + (newWave - 1) / 5;
             App.Bark?.NotifyChaosWaveEscalated(newWave);
+            FireActChangedIfCrossed();
             return;
         }
 
@@ -202,6 +248,9 @@ public sealed class ChaosModeService
         // with a single burst cue as everything pops.
         App.Bubbles?.PopAllBubbles();
         ChaosSfx.PlayWaveClear();
+        // Wave-clear juice (additive only): a soft screen pulse + a clear bark on the boundary.
+        Pulse(WAVE_CLEAR_COLOR, WAVE_CLEAR_PULSE);
+        App.Bark?.NotifyChaosWaveCleared(_state.WaveIndex);
 
         // Clear the finished wave's transient (next-wave) flags before drafting.
         _state.AllLiveNextWave = false;
@@ -213,7 +262,7 @@ public sealed class ChaosModeService
 
         var options = ChaosBoonPool.Draft(_state.Config.AllowCurses, _state.Config.DraftChoices);
         foreach (var o in options) ChaosMeta.MarkDiscovered("boon:" + o.Id);
-        _overlay?.ShowBoonDraft(_state.WaveIndex, options, OnBoonChosen);
+        _overlay?.ShowBoonDraft(_state.WaveIndex, options, OnBoonChosen, _state.Config.DraftAutoResumeSec);
     }
 
     private void OnBoonChosen(ChaosBoon? boon)
@@ -223,12 +272,19 @@ public sealed class ChaosModeService
         if (boon != null)
         {
             _state.ApplyBoon(boon);
-            App.Bark?.NotifyChaosBoonPicked(boon.Name);
+            if (boon.Id == "extra_shield") Pulse(SHIELD_GAIN_COLOR, SHIELD_GAIN_PULSE);   // +2 shields cue
+            if (boon.IsCurse)
+                App.Bark?.NotifyChaosCursePicked(boon.Name, boon.Rarity.ToString(), boon.RunMultBonus);
+            else
+                App.Bark?.NotifyChaosBoonPicked(boon.Name);
         }
         else
         {
             _state.Shields += 1;
             _state.PushEvent("⛊ skipped → +1 shield");
+            // Shield-gain cue (+1 from skip) — pulse + bark.
+            Pulse(SHIELD_GAIN_COLOR, SHIELD_GAIN_PULSE);
+            App.Bark?.NotifyChaosBoonSkipped(_state.Shields);
         }
 
         if (_state.DoubleOrNothingArmed)
@@ -239,6 +295,7 @@ public sealed class ChaosModeService
 
         _state.WaveIndex = _pendingWave;
         _state.ActIndex = 1 + (_state.WaveIndex - 1) / 5;
+        FireActChangedIfCrossed();
 
         _paused = false;
         if (_spawning) _spawnTimer?.Start();
@@ -271,6 +328,8 @@ public sealed class ChaosModeService
         double benignMult = _state.Config.GoldenTouchBaseline ? 0.6 : 0.4;
         _state.Score += BasePoints(spec.Strength) * benignMult * _state.TotalMult;
         App.Achievements?.TrackBubblePopped();
+        Pulse(BENIGN_POP_COLOR, BENIGN_POP_PULSE);   // the most-frequent action now has a tiny pop pulse
+        App.Bark?.NotifyChaosBenignPopped(spec.VariantId, spec.Payload.DisplayName, _state.Combo);
         _state.PushEvent($"○ popped {spec.Payload.DisplayName}");
         CheckComboMilestone();
     }
@@ -283,7 +342,7 @@ public sealed class ChaosModeService
         _state.Heat = Math.Min(1.0, _state.Heat + 0.07);
         _state.Score += BasePoints(spec.Strength) * 1.0 * _state.TotalMult;
         App.Achievements?.TrackBubblePopped();
-        App.Bark?.NotifyChaosBubbleDefused();
+        App.Bark?.NotifyChaosBubbleDefused(_state.Combo, spec.VariantId, _state.Config.Difficulty.ToString());
         Pulse(Color.FromRgb(90, 255, 150), 0.16);   // soft green confirm
         _state.PushEvent($"✔ defused {spec.Payload.DisplayName}");
         CheckComboMilestone();
@@ -292,10 +351,13 @@ public sealed class ChaosModeService
     private void OnDetonated(EffectBubbleSpec spec)
     {
         if (_state == null || _paused) return;
-        spec.Payload.Fire();                 // the threat goes off
+        FirePayloadForDetonation(spec);      // the threat goes off (ambient mode may soften it)
         _state.EffectsFired++;
         _state.Detonated++;
+        _runDetonations++;
 
+        string variant = spec.VariantId;     // payload ctx = variant id (e.g. "braindrain","video")
+        string diff = _state.Config.Difficulty.ToString();
         double s = spec.Strength / 100.0;
         int shieldCost = _state.DoubleOrNothingActive ? 2 : 1;
         if (_state.Shields >= shieldCost)
@@ -305,17 +367,51 @@ public sealed class ChaosModeService
             _state.PushEvent($"🛡 absorbed {spec.Payload.DisplayName}!");
             Pulse(Color.FromRgb(80, 160, 255), 0.28);    // blue shield-save
             Shake(0.25 + s * 0.3, 280);
+            // Clutch shield-save branch — distinct trigger so the matcher can praise it.
+            App.Bark?.NotifyChaosBubbleDetonatedAbsorbed(variant, spec.Strength, _runDetonations, _state.Combo, diff, _state.Shields);
         }
         else
         {
+            int comboBeforeBreak = _state.Combo;   // capture BEFORE zeroing (frozen contract)
             _state.Combo = 0;
+            _lastComboBigFired = 0;                // combo broke → reset ComboBig crossing tracking
             _state.Heat = 0;
             _state.PushEvent($"💥 {spec.Payload.DisplayName} detonated!");
             Pulse(Color.FromRgb(255, 50, 50), 0.4 + s * 0.35);   // red malus
             Shake(0.4 + s * 0.5, 380);                           // the malus jolt
+            // Real-hit branch (unshielded only now).
+            App.Bark?.NotifyChaosBubbleDetonated(variant, spec.Strength, _runDetonations, comboBeforeBreak, diff);
         }
-        App.Bark?.NotifyChaosBubbleDetonated(spec.Payload.DisplayName);
     }
+
+    /// <summary>
+    /// Fire a detonating bubble's payload. In opt-in Ambient mode, an intrusive payload
+    /// (video / HT link) is remapped to one of the two lighter ambient payloads so a
+    /// background run never yanks a fullscreen video/browser over the user's work.
+    /// Outside ambient mode the payload fires exactly as built (neutral invariant).
+    /// </summary>
+    private void FirePayloadForDetonation(EffectBubbleSpec spec)
+    {
+        try
+        {
+            if (_state?.Config?.AmbientMode == true && IsIntrusivePayload(spec.Payload.Kind))
+            {
+                EffectPayload soft = _ambientRng.NextDouble() < 0.5
+                    ? new BouncingTextPayload()
+                    : new GifCascadePayload();
+                soft.Strength = spec.Payload.Strength;
+                soft.Fire();
+                return;
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("Chaos ambient remap: {E}", ex.Message); }
+        spec.Payload.Fire();
+    }
+
+    private static bool IsIntrusivePayload(EffectBubblePayloadKind k) =>
+        k == EffectBubblePayloadKind.Video || k == EffectBubblePayloadKind.HtLink;
+
+    private static readonly Random _ambientRng = new();
 
     private void OnDarterCaught(EffectBubbleSpec spec, bool quick)
     {
@@ -328,6 +424,7 @@ public sealed class ChaosModeService
         // The darter is a utility pickup: catching it slows time (no conditioning jolt).
         ActivateSlowMo();
         Pulse(Color.FromRgb(120, 200, 255), quick ? 0.32 : 0.24);   // icy slow-mo flash
+        App.Bark?.NotifyChaosDarterCaught(pts, _state.Combo, quick);
         _state.PushEvent(quick ? "⚡ quick catch — time slows!" : "⏳ darter caught — time slows!");
         CheckComboMilestone();
     }
@@ -343,6 +440,7 @@ public sealed class ChaosModeService
         _state.Heat = Math.Min(1.0, _state.Heat + 0.05);
         App.Achievements?.TrackBubblePopped();
         ActivateFreeze();
+        App.Bark?.NotifyChaosFreezeCaught(FREEZE_BASE_POINTS * _state.TotalMult, _state.Combo);
         _state.PushEvent("❄ frozen — the field holds!");
         CheckComboMilestone();
     }
@@ -401,12 +499,83 @@ public sealed class ChaosModeService
     private void CheckComboMilestone()
     {
         if (_state == null) return;
-        if (_state.Combo > 0 && _state.Combo % 10 == 0)
+        int combo = _state.Combo;
+        if (combo <= 0) return;
+
+        // Big-combo crossing: edge-detected, fires ONCE per threshold per streak.
+        foreach (int t in COMBO_BIG_THRESHOLDS)
         {
-            _state.PushEvent($"🔥 combo x{_state.Combo}!");
-            App.Bark?.NotifyChaosComboMilestone(_state.Combo);
+            if (combo >= t && _lastComboBigFired < t)
+            {
+                _lastComboBigFired = t;
+                _state.PushEvent($"🔥🔥 COMBO x{combo}!");
+                App.Bark?.NotifyChaosComboBig(combo, t);
+                Pulse(COMBO_BIG_COLOR, COMBO_BIG_PULSE);   // distinct bigger beat
+            }
+        }
+
+        if (combo % 10 == 0)
+        {
+            _state.PushEvent($"🔥 combo x{combo}!");
+            App.Bark?.NotifyChaosComboMilestone(combo, _state.Config.Difficulty.ToString());
             Pulse(Color.FromRgb(255, 200, 60), 0.4);   // gold combo flash
         }
+        else
+        {
+            // Micro-build between milestones: a tiny pulse that grows toward the next ×10.
+            double frac = (combo % 10) / 10.0;
+            double strength = COMBO_MICRO_PULSE_MIN + (COMBO_MICRO_PULSE_MAX - COMBO_MICRO_PULSE_MIN) * frac;
+            Pulse(COMBO_MICRO_COLOR, strength);
+        }
+    }
+
+    /// <summary>Fire ChaosActChanged once when ActIndex advances (edge-detected, not per tick).</summary>
+    private void FireActChangedIfCrossed()
+    {
+        if (_state == null) return;
+        if (_state.ActIndex > _lastActFired)
+        {
+            _lastActFired = _state.ActIndex;
+            App.Bark?.NotifyChaosActChanged(_state.ActIndex, _state.WaveIndex);
+        }
+    }
+
+    /// <summary>Near-miss danger telegraph: in the last <see cref="NEAR_MISS_TELEGRAPH_MS"/> before the
+    /// soonest live bubble detonates, fire an escalating red edge-flash + audio tick. Additive feel only —
+    /// it polls a read-only fuse accessor and never changes the fuse/score. No-op when frozen/paused.</summary>
+    private void UpdateNearMissTelegraph(double dt)
+    {
+        if (_state?.Config?.ColorFlashesEnabled != true) { _nearMissTickAccumMs = 0; return; }
+        if (_freezeRemainingSec > 0) { _nearMissTickAccumMs = 0; return; }   // time frozen: no impending detonation
+
+        double? minFuse = App.Bubbles?.MinLiveFuseRemainingMs();
+        if (minFuse == null || minFuse.Value > NEAR_MISS_TELEGRAPH_MS) { _nearMissTickAccumMs = 0; return; }
+
+        _nearMissTickAccumMs += dt * 1000.0;
+        if (_nearMissTickAccumMs < NEAR_MISS_TICK_MS) return;
+        _nearMissTickAccumMs = 0;
+
+        // The closer to zero, the stronger the flash (0..1 urgency above the window).
+        double urgency = 1.0 - Math.Clamp(minFuse.Value / NEAR_MISS_TELEGRAPH_MS, 0, 1);
+        Pulse(NEAR_MISS_COLOR, NEAR_MISS_PULSE + urgency * 0.22);
+        ChaosSfx.PlayNearMissTick();
+    }
+
+    /// <summary>Make heat visible: a subtle rising temperature tint as Heat climbs (additive
+    /// held-edge overlay only — never touches scoring/multiplier math). Honors the color-flashes toggle.</summary>
+    private void UpdateHeatTint()
+    {
+        if (_state?.Config?.ColorFlashesEnabled != true || _fx == null) return;
+        double heat = _state.Heat;
+        double level = heat <= HEAT_TINT_MIN
+            ? 0
+            : (heat - HEAT_TINT_MIN) / (1.0 - HEAT_TINT_MIN);   // 0..1 above the floor
+        // Quantize so we don't re-issue an animation every 250ms tick.
+        double q = Math.Round(level, 1);
+        if (Math.Abs(q - _lastHeatTint) < 0.05) return;
+        _lastHeatTint = q;
+        if (q <= 0) _fx.EndHeatTint();
+        else _fx.SetHeatTint(HEAT_TINT_COLOR, q * HEAT_TINT_MAX_OPACITY);
     }
 
     // ============================ end / teardown ============================
@@ -433,6 +602,7 @@ public sealed class ChaosModeService
         try { App.Bubbles?.Resume(); } catch { }
         EndSlowMo(); EndFreeze();
         try { ChaosFlashOverlay.CloseActive(); } catch { }
+        try { ChaosGifCascadeOverlay.CloseActive(); } catch { }
         try { _fx?.Close(); } catch { }
         if (_overlay != null)
         {
@@ -453,6 +623,7 @@ public sealed class ChaosModeService
         App.Bubbles?.EndChaosMode();
         EndSlowMo(); EndFreeze();
         try { ChaosFlashOverlay.CloseActive(); } catch { }
+        try { ChaosGifCascadeOverlay.CloseActive(); } catch { }
         try { _fx?.Close(); } catch { }
         _fx = null;
 
@@ -462,18 +633,22 @@ public sealed class ChaosModeService
         double skillMult = _state.SkillMult;
         double finalXp = baseXp * skillMult;
 
-        try { App.Progression?.AddXP(baseXp, XPSource.Bubble); }
+        try { App.Progression?.AddXP(baseXp, XPSource.Chaos); }
         catch (Exception ex) { App.Logger?.Debug("Chaos payout AddXP: {E}", ex.Message); }
+
+        // Capture the previous best BEFORE the meta award updates it — for the PB delta line/bark.
+        long previousBest = ChaosMeta.State.BestScore;
 
         // Meta-progression: bank Sparks + update lifetime stats (separate from XP payout).
         try { ChaosMeta.AwardRunRewards(_state); }
         catch (Exception ex) { App.Logger?.Debug("Chaos meta award: {E}", ex.Message); }
 
-        App.Bark?.NotifyChaosRunCompleted((int)finalXp);
+        string diff = _state.Config.Difficulty.ToString();
+        App.Bark?.NotifyChaosRunCompleted((int)finalXp, diff);
 
         _hud?.Close();
         _hud = null;
-        _overlay?.ShowResults(_state, baseXp, skillMult, finalXp);
+        _overlay?.ShowResults(_state, baseXp, skillMult, finalXp, previousBest);
 
         App.Bubbles?.Resume();
         App.Logger?.Information("Chaos run complete: base {Base:0} x skill {Mult:0.0} = {Final:0} XP (defused {D}, detonated {Det})",
@@ -482,9 +657,9 @@ public sealed class ChaosModeService
 
     private void RunAgain()
     {
-        // Tear down the current run windows, then start a fresh one.
+        // Tear down the current run windows, then start a fresh one (short 1s GO flash on restart).
         _overlay?.Close();   // triggers OnOverlayClosed → CleanupAfterRun
-        Application.Current?.Dispatcher.BeginInvoke(new Action(() => StartRun()));
+        Application.Current?.Dispatcher.BeginInvoke(new Action(() => StartRun(isRestart: true)));
     }
 
     private void OnOverlayClosed()

--- a/ConditioningControlPanel/Services/Chaos/ChaosModels.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosModels.cs
@@ -17,8 +17,6 @@ public sealed class ChaosRunConfig
     public ChaosDifficulty Difficulty { get; set; } = ChaosDifficulty.Easy;
     public int DurationSec { get; set; } = 180;
     public int WaveCount { get; set; } = 5;
-    /// <summary>Baseline share (0..1) of spawned bubbles that are "live" (fused).</summary>
-    public double LiveBubbleShare { get; set; } = 0.35;
     public List<PayloadConfig> Payloads { get; set; } = EffectPayloadFactory.DefaultConfig();
 
     // ---- setup-window config ----
@@ -35,6 +33,12 @@ public sealed class ChaosRunConfig
     public bool AllowCurses { get; set; } = true;
     /// <summary>Darters (bouncing-flash catch targets) spawn during the run when true.</summary>
     public bool DartersEnabled { get; set; } = true;
+    /// <summary>If a boon draft is left untouched this many seconds, auto-take the SKIP (+1 shield) and
+    /// resume so an unattended run never freezes forever. 0 disables (wait indefinitely).</summary>
+    public int DraftAutoResumeSec { get; set; } = ChaosModeService.DraftAutoResumeSecDefault;
+    /// <summary>Opt-in ambient mode (OFF by default): remap intrusive detonations (video / HT link) to a
+    /// lighter payload (bouncing text / gif cascade) so a background run is never yanked fullscreen.</summary>
+    public bool AmbientMode { get; set; } = false;
 
     // ---- meta-progression knobs (set by ChaosMeta.ApplyTo from owned upgrades) ----
     // Every field has a neutral default so an unmodified run is byte-for-byte unchanged.
@@ -66,7 +70,6 @@ public sealed class ChaosRunConfig
         if (s == null) { ChaosMeta.ApplyTo(cfg); return cfg; }
         cfg.Difficulty = Enum.TryParse<ChaosDifficulty>(s.ChaosDifficulty, out var d) ? d : ChaosDifficulty.Easy;
         cfg.DurationSec = Math.Clamp(s.ChaosRunDurationSec, 60, 900);
-        cfg.LiveBubbleShare = Math.Clamp(s.ChaosLiveBubbleShare, 0.0, 1.0);
         cfg.WaveCount = Math.Clamp(s.ChaosWaveCount, 1, 12);
         cfg.StartingShields = Math.Clamp(s.ChaosStartingShields, 0, 5);
         cfg.MotionOverride = Enum.TryParse<ChaosMotion>(s.ChaosMotionMode, out var m) ? m : (ChaosMotion?)null;

--- a/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
@@ -32,6 +32,11 @@ public static class ChaosSfx
     public static void PlayBoonPicked() =>
         PlayFirstAvailable(new[] { "chaos/boon_pick.mp3", "chime2.mp3" }, 0.7f);
 
+    /// <summary>Escalating danger tick in the last ~800ms before a live bubble detonates.
+    /// Quiet on purpose (it can fire a few times in quick succession).</summary>
+    public static void PlayNearMissTick() =>
+        PlayFirstAvailable(new[] { "chaos/near_miss.mp3", "bubbles/Pop2.mp3" }, 0.4f);
+
     /// <summary>Resolve the first candidate that exists on disk and play it once.</summary>
     private static void PlayFirstAvailable(string[] candidates, float scale)
     {

--- a/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
@@ -32,11 +32,6 @@ public static class ChaosSfx
     public static void PlayBoonPicked() =>
         PlayFirstAvailable(new[] { "chaos/boon_pick.mp3", "chime2.mp3" }, 0.7f);
 
-    /// <summary>Escalating danger tick in the last ~800ms before a live bubble detonates.
-    /// Quiet on purpose (it can fire a few times in quick succession).</summary>
-    public static void PlayNearMissTick() =>
-        PlayFirstAvailable(new[] { "chaos/near_miss.mp3", "bubbles/Pop2.mp3" }, 0.4f);
-
     /// <summary>Resolve the first candidate that exists on disk and play it once.</summary>
     private static void PlayFirstAvailable(string[] candidates, float scale)
     {

--- a/ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosUpgrades.cs
@@ -172,13 +172,17 @@ public static class ChaosMeta
     {
         if (run == null) return;
 
-        const double COMPLETION_BONUS_BASE = 25.0;
+        const double COMPLETION_BONUS_BASE = 35.0;   // bumped 25→35: raises the predictable Spark floor
         const double SPARK_SCORE_DIVISOR = 100.0;
+        const int FIRST_SPARK_BONUS = 25;            // one-time "First Spark" on the very first completed run
 
         double difficultyMult = run.Config.DifficultyMult;
         double completionBonus = COMPLETION_BONUS_BASE * difficultyMult;
         double scorePart = run.Score / SPARK_SCORE_DIVISOR * difficultyMult;
         int sparks = (int)Math.Round((scorePart + completionBonus) * run.Config.SparkGainMult);
+
+        // One-time cold-start kindness: +25 the first time RunsCompleted goes 0→1 (guarded so it only ever applies once).
+        if (State.RunsCompleted == 0) sparks += FIRST_SPARK_BONUS;
 
         State.Sparks += Math.Max(0, sparks);
         State.RunsCompleted += 1;

--- a/ConditioningControlPanel/Services/Chaos/EffectPayload.cs
+++ b/ConditioningControlPanel/Services/Chaos/EffectPayload.cs
@@ -15,7 +15,9 @@ public enum EffectBubblePayloadKind
     Video,
     HtLink,
     Audio,
-    BambiFreeze
+    BambiFreeze,
+    BouncingText,
+    GifCascade
 }
 
 /// <summary>
@@ -175,5 +177,105 @@ public sealed class BambiFreezePayload : EffectPayload
     {
         try { App.Subliminal?.TriggerBambiFreeze(); }
         catch (Exception ex) { App.Logger?.Debug("BambiFreezePayload: {E}", ex.Message); }
+    }
+}
+
+/// <summary>
+/// A single short affirmation bouncing DVD-logo style across the screen, click-through, for a short
+/// window. REUSES the existing <see cref="BouncingTextService"/> (App.BouncingText) rather than building
+/// a new bouncer — sourcing its text from the existing affirmation/phrase pool — and tears it down after
+/// <see cref="DURATION_SEC"/> or <see cref="MAX_BOUNCES"/>, whichever comes first. Conservative defaults.
+/// No-op if the bouncing toy is already running for the user (so a payload never hijacks it).
+/// </summary>
+public sealed class BouncingTextPayload : EffectPayload
+{
+    public override string DisplayName => "bouncing text";
+    public override EffectBubblePayloadKind Kind => EffectBubblePayloadKind.BouncingText;
+
+    // ---- named tunables (conservative defaults) ----
+    public const double DURATION_SEC = 8.0;   // on-screen lifetime
+    public const int    MAX_BOUNCES  = 12;    // auto-stop after this many bounces (whichever first)
+    public const double OPACITY      = 0.85;  // text opacity (informational; service reads its own setting)
+    public const int    TEXT_SIZE    = 120;   // % of base font (informational tunable)
+    public const int    SPEED        = 5;     // 1..10 bounce speed (informational tunable)
+
+    public override void Fire()
+    {
+        try
+        {
+            var svc = App.BouncingText;
+            if (svc == null || svc.IsRunning) return;   // don't hijack a user-started bouncer
+
+            // Source a single affirmation from the existing enabled phrase pool.
+            string? phrase = PickAffirmation();
+            var pool = phrase != null ? new System.Collections.Generic.List<string> { phrase } : null;
+            svc.Start(bypassLevelCheck: true, pool: pool);
+
+            int bounces = 0;
+            EventHandler? onBounce = null;
+            var life = new System.Windows.Threading.DispatcherTimer
+            { Interval = TimeSpan.FromSeconds(Math.Max(0.5, DURATION_SEC * GlobalDurationMult)) };
+
+            void StopOnce()
+            {
+                try { life.Stop(); } catch { }
+                if (onBounce != null) { try { svc.OnBounce -= onBounce; } catch { } }
+                try { svc.Stop(); } catch { }
+            }
+
+            onBounce = (_, _) => { if (++bounces >= MAX_BOUNCES) StopOnce(); };
+            svc.OnBounce += onBounce;
+            life.Tick += (_, _) => StopOnce();
+            life.Start();
+        }
+        catch (Exception ex) { App.Logger?.Debug("BouncingTextPayload: {E}", ex.Message); }
+    }
+
+    private static string? PickAffirmation()
+    {
+        try
+        {
+            var pool = App.Settings?.Current?.BouncingTextPool;
+            if (pool == null) return null;
+            var enabled = new System.Collections.Generic.List<string>();
+            foreach (var kv in pool) if (kv.Value) enabled.Add(kv.Key);
+            if (enabled.Count == 0) return null;
+            return enabled[_rng.Next(enabled.Count)];
+        }
+        catch { return null; }
+    }
+
+    private static readonly Random _rng = new();
+}
+
+/// <summary>
+/// Images/gifs spawn at the top of the screen and fall/cascade downward, click-through, for a short
+/// window. Sources its images from the SAME flash/braindrain image pool (EffectiveAssetsPath/images,
+/// via <see cref="ChaosGifCascadeOverlay"/>). Conservative named defaults.
+/// </summary>
+public sealed class GifCascadePayload : EffectPayload
+{
+    public override string DisplayName => "gif cascade";
+    public override EffectBubblePayloadKind Kind => EffectBubblePayloadKind.GifCascade;
+
+    // ---- named tunables (conservative defaults) ----
+    public const double SPAWN_RATE_PER_SEC = 0.8;   // images per second
+    public const double DURATION_SEC       = 20.0;  // total cascade lifetime
+    public const double GIF_SIZE           = 200;   // px (max dimension)
+    public const double FALL_SPEED         = 2.5;   // DIPs per ~16ms frame
+    public const double OPACITY            = 0.85;  // per-image opacity
+
+    public override void Fire()
+    {
+        try
+        {
+            ChaosGifCascadeOverlay.Show(
+                spawnRatePerSec: SPAWN_RATE_PER_SEC,
+                durationSec: DURATION_SEC * GlobalDurationMult,
+                gifSize: GIF_SIZE,
+                fallSpeed: FALL_SPEED,
+                opacity: OPACITY);
+        }
+        catch (Exception ex) { App.Logger?.Debug("GifCascadePayload: {E}", ex.Message); }
     }
 }

--- a/ConditioningControlPanel/Services/Chaos/EffectPayloadFactory.cs
+++ b/ConditioningControlPanel/Services/Chaos/EffectPayloadFactory.cs
@@ -78,9 +78,11 @@ public static class EffectPayloadFactory
         EffectBubblePayloadKind.Overlay     => new OverlayPayload(PickOverlayKind()),
         EffectBubblePayloadKind.Video       => new VideoPayload(),
         EffectBubblePayloadKind.HtLink      => new HtLinkPayload(),
-        EffectBubblePayloadKind.Audio       => new AudioPayload(),
-        EffectBubblePayloadKind.BambiFreeze => new BambiFreezePayload(),
-        _                                   => new FlashPayload(),
+        EffectBubblePayloadKind.Audio        => new AudioPayload(),
+        EffectBubblePayloadKind.BambiFreeze  => new BambiFreezePayload(),
+        EffectBubblePayloadKind.BouncingText => new BouncingTextPayload(),
+        EffectBubblePayloadKind.GifCascade   => new GifCascadePayload(),
+        _                                    => new FlashPayload(),
     };
 
     private static string PickOverlayKind()

--- a/ConditioningControlPanel/Services/CompanionService.cs
+++ b/ConditioningControlPanel/Services/CompanionService.cs
@@ -21,6 +21,7 @@ namespace ConditioningControlPanel.Services
         KeywordTrigger,
         Mantra,
         AttentionCheck,
+        Chaos,
         Other
     }
 

--- a/ConditioningControlPanel/docs/chaos/planning/00-master-plan.md
+++ b/ConditioningControlPanel/docs/chaos/planning/00-master-plan.md
@@ -1,0 +1,209 @@
+# Chaos Mode — Master Plan
+
+Synthesis of the six area docs (`A-loop`, `B-meta`, `C-voice`, `D-art`, `E-flavour`, `F-systems`).
+**Planning only — nothing here is built.** Code in `Services/Chaos/` is source of truth; where
+`CHAOS_DESIGN.md` disagrees, code wins.
+
+Goal: take Chaos from a working shell to a repeatable, compulsive loop — tight enough to run on top
+of another game — with cold-start progression, persona-flavored voice + emotes, art, mod-agnostic
+flavour, and additive retention systems.
+
+---
+
+## 0. Ground-truth corrections the agents surfaced (read first)
+
+These reshape the work and override the brief / design doc:
+
+| Finding | Reality in code | Owner |
+|---|---|---|
+| **`LiveBubbleShare` is inert** | Read into `ChaosRunConfig` but **no consumer** — live/benign split comes entirely from `ChaosBubbleVariants` weights + `MinIntensity`. | A/F |
+| **Entry is not one-click** | Lab hero → `ChaosHubWindow.ShowDialog()` (modal lobby) → Begin → 3s countdown. Only *restart* ("Run It Back") is one-click and reuses config. | A |
+| **Boon draft is modal + steals focus** | `ShowBoonDraft` calls `SetClickThrough(false)` + `BringToFront()`/`Activate()`/`Focus()` every wave boundary → 4 forced interrupts/run at default 5 waves; an unattended draft freezes the run forever. **Biggest background-play wart.** | A |
+| **Detonate collapses 3 outcomes into 1 bark** | clutch-absorb / real-hit / combo-break all fire `NotifyChaosBubbleDetonated`. The no-fallthrough matcher can't prioritize a clutch-save line. | A/C |
+| **XP interop is already correct** | `EndRun` shows `finalXp = baseXp·skillMult` but awards `AddXP(baseXp)`, and `AddXP` re-applies skillMult internally → applied once. Do **not** double-multiply. | B |
+| **Hub-unlock consts are UI-only** | `ChaosMeta.UNLOCK_*_RUNS` + `Rank` exist but **nothing reads them at run-build time**. Cold-start gating is therefore *new* enforcement. | B |
+| **`EquippedStartBoon` IS wired** | *Correcting B's open-Q #1:* `BeginRun` (ChaosModeService.cs:102-106) reads `ChaosMeta.State.EquippedStartBoon`, resolves it in `ChaosBoonPool.All`, applies it, marks it discovered. Loadout apply works today; only the *gate* (≥3 runs) and the equip UI are new. | verified by lead |
+| **Guardrail violation already present** | Chaos calls `App.Achievements.TrackBubblePopped()` **directly** in `OnBenignPopped/OnDefused/OnDarterCaught/OnFreezeCaught` — the exact bypass the GamificationBridge pattern forbids. New quests/achievements should go through emit→bridge, and this existing call is worth migrating. | F |
+| **9 bubble sprites already exist** | Finals under `assets/Chaos/bubbles/`; the nano-banana→`_staging`→manual-gate workflow is already realized (tooling in gitignored `Tools\asset_gen\`). Remaining art classes extend that precedent. | D |
+| **`Assets` vs `assets` casing** | Resolver uses `Assets/Chaos/...`; csproj globs `assets/Chaos/**`. Case-insensitive on Windows today; flag before it bites a case-sensitive path or pack. | D |
+| **No `XPSource.Chaos`** | `EndRun` passes `XPSource.Bubble`; companion modifiers treat Chaos as bubble-popping. Additive enum value recommended. | B |
+| **Spawn RNG is a single static `Random`** | `ChaosBubbleVariants._rng` feeds Pick/Build/RollDarter — daily-seeded runs are cheap to thread, but it's static state (set at BeginRun, restore at EndRun) and `BubbleService` must be audited for other score-affecting RNG. | F |
+
+---
+
+## 1. The reconciled canonical event surface
+
+Everything downstream (barks, meta juice, quests, music) hooks this. Full table lives in
+`A-loop.md §5`; this is the **shared contract**: the set of `Notify*`/emit hooks to add, all via the
+existing `BarkService.Raise(trigger, ctx => ctx.Set(...))` seam — **no new event bus** (guardrail).
+
+**Already hooked (7):** `ChaosRunStarted(difficulty)`, `ChaosWaveEscalated(wave)`,
+`ChaosBubbleDefused`, `ChaosBubbleDetonated(payload)`, `ChaosBoonPicked(boon)`,
+`ChaosComboMilestone(combo)`, `ChaosRunCompleted(xp)`.
+
+**Gaps to add (priority-ordered by value):**
+
+| New hook | Fires at | Ctx fields | Why it matters |
+|---|---|---|---|
+| **Split detonate** → `DetonateAbsorbed` + keep `Detonated` for unshielded | `OnDetonated` both branches | `payload`, `strength`, `shield_absorbed`(bool), `run_detonations`, `combo`, `difficulty` | lets the matcher gloat on a real hit vs praise a clutch save (C needs `shield_absorbed`, `run_detonations`, per-fire `difficulty`/`combo`) |
+| `CursePicked` | `OnBoonChosen`, `boon.IsCurse` | `boon`, `rarity`, `runMultBonus` | "risk taken" line must outrank generic pick |
+| `BoonSkipped` | `OnBoonChosen`, null | `shieldsNow` | +shield juice + bark |
+| `DarterCatch` / `DarterCatchQuick` | `OnDarterCaught` | `points`, `combo`, `quick` | power-up has juice, no voice |
+| `FreezeCatch` | `OnFreezeCaught` | `points`, `combo` | "" |
+| `BenignPop` | `OnBenignPopped` | `variantId`, `payload`, `combo` | most frequent action; **also add a small FX pulse (none today)** |
+| `ComboBig` | combo crosses 25/50 (edge-detected) | `combo`, `threshold` | distinct big-combo moment beyond every-10 |
+| `ActChange` | `ActIndex` advances | `act`, `wave` | bigger beat than a wave tick |
+| `ResultsShown` | `ShowResults` | RunEnd fields + **PB delta** (new) | bark over results + compulsion hook |
+
+Notes for hookers: `ComboTick`/`HeatFull`/`ComboBroken` need **previous-value edge detection** (track
+last value, fire on crossing — not every 250ms tick). `RunAbandoned` (overlay closed mid-run, no
+payout) should be distinct from `RunEnd`.
+
+---
+
+## 2. The cold-start progression spine (reconciled)
+
+Run 1 is a clean tutorial-by-doing; each gate adds exactly one *named* toy. Gating is by lifetime
+`RunsCompleted` (already persisted), **not** Sparks — runs unlock *content*, Sparks buy the *shop*.
+Enforced by a new **narrowing-only** `ChaosMeta.ApplyColdStartGates(cfg)` step in
+`ChaosRunConfig.FromSettings()` (after `ApplyTo`), which **only removes** toys and **no-ops for
+veterans** → the "neutral default = byte-for-byte unchanged run" invariant holds.
+
+| Gate | Unlocks | Mechanism |
+|---|---|---|
+| **Run 1 (cold)** | Flash + Subliminal + **Pink Filter** only; shields on; draft = 2 options, **no curses**; forced 90s / 3 waves; no darters/freeze; Easy | clamp `EnabledVariants`, `AllowCurses=false`, `DartersEnabled=false`, `DraftChoices=2`, clamp duration/waves |
+| **After 1** | Hub (Upgrades/Stats/Codex tabs) + **Spiral**; drafts → 3 | wire the existing UI-only consts; add Spiral to allow-set |
+| **After 3** | **Loadout** tab + **Darters** + **curses** in pool + Medium | Loadout equip already works (`BeginRun` applies `EquippedStartBoon`); add the equip UI + gate |
+| **After 5** | **Freeze** + **BrainDrain**; full duration/wave sliders | allow-set + unclamp |
+| **After 10** | **Video** + **HT Link**; Hard; full boon pool; rank Novice | allow-set + difficulty gate |
+| **After 25 / 50** | Initiate/Adept ranks; content-pack boons auto-discover; mutator + cosmetic milestones; Prestige hook (future) | reserved |
+
+~70% of this is *flipping existing `ChaosRunConfig` fields by `RunsCompleted`*. Genuinely new: (a) a
+boon-pool allow-list param on `ChaosBoonPool.Draft(..., IEnumerable<string>? allowedIds)`, (b) reading
+`RunsCompleted` at run-build, (c) the `null` "player hasn't chosen variants" sentinel check so an
+explicit setup choice isn't re-narrowed (confirm setup UI writes `null`, not an all-ids list).
+
+**Economy:** keep Sparks as the skill-rewarding variable term; bump only the *predictable* floor —
+`COMPLETION_BONUS_BASE` 25→35 + a one-time +25 "First Spark" on run 1 → first cheap upgrade by run ~2,
+cheapest branch (Control, 500) in ~6–7 average runs, Depth (1060) in ~15. Add a **second currency
+"Glow"** (cosmetic-only, milestone-earned: Codex discoveries, rank-ups, daily-first) so the
+barebones early player has a *breadth* reward track and cosmetics never tax power. Both are
+Chaos-local; main XP unchanged.
+
+---
+
+## 3. Phased build order (with cross-area dependencies)
+
+```
+PHASE 1 — FEEL & VOICE  (no new systems, no art dep, no server)   ◀ smallest shippable slice (§5)
+  A: benign-pop pulse · skippable/short countdown on RunAgain · Quick Start (skip hub) · PB-delta on results
+  A+C: event-surface gaps that already have juice → split detonate (absorbed/unshielded) + ctx fields,
+       CursePicked, BoonSkipped, Darter/Freeze/BenignPop barks
+  C: base neutral bark pool for the new triggers + emotion/emote moods (no voicelines yet — text first)
+  B: completion-bonus 25→35 + first-run +25
+  → DEPENDS ON: nothing external. Establishes the canonical Notify* surface everyone else hooks.
+
+PHASE 2 — COLD START & ECONOMY
+  B: ApplyColdStartGates (run-build narrowing) + boon-pool allow-list + RunsCompleted gating
+  B: wire the UI-only hub-unlock consts (tabs) + Loadout equip UI (apply path already works)
+  A: gate Extreme difficulty by ExtremeUnlocked in setup UI; non-modal QuickDraft + DraftAutoResumeSec
+  B: second currency "Glow" + cosmetic persistence fields on ChaosMetaState (additive, SchemaVersion→2)
+  → DEPENDS ON: Phase 1 event surface for Glow-on-discovery; independent otherwise.
+
+PHASE 3 — FLAVOUR (mod-agnostic skin layer)
+  E: ChaosFlavor resolver (override ?? neutral literal) + id-keyed `chaos` ModManifest block + ModChaos classes
+     covering currencyName, boons[id], bubbles[id], upgrades[id], ranks[], hud, results
+  → DEPENDS ON: stable boon/bubble/upgrade ids (all exist). Feeds bark copy (C) + art labels (D).
+     Can start in parallel with Phase 2; merge before voicelines so persona text is skinnable.
+
+PHASE 4 — ART  (fully parallel; start anytime)
+  D: P0 boon/curse icons + HUD glyphs (shields/heat/combo/act) → P1 power-up FX, branch crests,
+     banner, results art → P2/P3 cosmetic skin sets
+  → DEPENDS ON: nothing in code; consuming UI slots can land independently. Resolver + 9 sprites exist.
+
+PHASE 5 — VOICE PRODUCTION
+  C: ElevenLabs voicelines for the new + existing triggers, ~65 lines/persona, neutral base + per-mod skins,
+     naming `chaos_<trigger>[_<cond>]_<n>.mp3` matching ResolveBarkAudio
+  → DEPENDS ON: Phase 1 (trigger set frozen) + Phase 3 (persona flavour decided).
+
+PHASE 6 — RETENTION SYSTEMS  (ranked; cut from the bottom)
+  F: daily seeded run (thread the static RNG seed) · Chaos quests/achievements via emit→bridge
+     (+ migrate the direct TrackBubblePopped call) · ChaosMusic intensity-reactive layer ·
+     Season feed (one SeasonFeatureKeys.Chaos) · XP-rank leaderboard (free today) · weekly mutator
+  cut candidates: dedicated server-backed Chaos leaderboard (needs server + anti-cheat), Loadout expansion
+  → DEPENDS ON: Phase 1 event surface (quests), Phase 2 (Glow/mutator unlocks).
+```
+
+**The critical-path dependency is the Phase-1 canonical event surface** — barks (C), meta juice/Glow
+(B), and quests/season (F) all consume the same new `Notify*`/emit hooks. Build it once, correctly,
+first.
+
+---
+
+## 4. Smallest shippable first slice (Phase 1 — "Feel & Voice")
+
+Ship something tight before boiling the ocean. This slice needs **no art, no server, no new systems,
+no manifest schema** — only the existing `Raise` seam, `ChaosFxWindow.Pulse`, and small config tweaks:
+
+1. **Close the juice/voice gaps that already have juice or are one-liners:** benign-pop pulse;
+   split detonate into absorbed vs unshielded (+ `shield_absorbed`/`run_detonations`/`difficulty`/`combo`
+   ctx); add `CursePicked`, `BoonSkipped`, `DarterCatch(+quick)`, `FreezeCatch`, `BenignPop` triggers.
+2. **Neutral base bark lines** for those triggers in the base manifest with resistance↔surrender moods
+   (text-only first — voicelines are Phase 5). Honor no-fallthrough: intersectional rules (clutch-save,
+   unshielded-on-Extreme, first-detonation) carry higher `priority`.
+3. **Restart/entry tightening:** skip-to-GO on click/key + 1s flash on `RunAgain`; "Quick Start" on the
+   hero card that bypasses the modal hub with saved settings.
+4. **Compulsion hook:** PB / delta-vs-last-run line on the results screen (needs a best-score read from
+   `ChaosMetaState`, already persisted).
+5. **Economy kindness:** `COMPLETION_BONUS_BASE` 25→35 + one-time +25 first run.
+
+Outcome: the existing loop *feels* dramatically better and the companion *reacts* to the moments that
+currently pass in silence — with zero new infrastructure. Everything else builds on the event surface
+this slice establishes.
+
+---
+
+## 5. Open decisions for you
+
+**Loop / cadence (A)**
+1. Drop the default to **120s / 4 waves** and auto-derive wave count from length (~30s/wave), keeping
+   180/5 as a named "Standard" preset? (Currently 180/5; 300/5 feels slack.)
+2. Boon draft: ship **non-modal QuickDraft + auto-resume** as the *default* (best for background play),
+   or keep the centered modal default and make QuickDraft opt-in?
+3. Background profile: should `video`/`htlink` **detonations be downgradable to a flash** in an
+   "ambient/background" run mode, or is the intrusion the point?
+4. Restart: keep HUD/overlay/FX windows **alive across `RunAgain`** for instant restart (more state to
+   reset, small leak risk) vs. current clean close-and-rebuild (re-pays 3s)?
+5. `LiveBubbleShare` is **inert** — wire it into the variant picker (bias live weights) or **remove the
+   knob**?
+
+**Meta / economy (B)**
+6. Confirm the **cold-start spine gates** (run 1/1/3/5/10) and the toy at each — this is the backbone.
+7. **Two currencies** (Sparks = power, Glow = cosmetic) — approve, or keep single Sparks?
+8. Add **`XPSource.Chaos`** (additive enum) so companion modifiers can treat Chaos distinctly?
+9. Should **Extreme** also co-gate behind `RunsCompleted ≥ 10` in addition to the 350-Spark purchase?
+10. **Prestige** at 50/100 runs — in scope later? If so, does it spend Sparks, Glow, or reset one?
+
+**Voice / emote (C)**
+11. Target the **Circe 8-clip animated emote vocabulary** (idle/talkA/talkB/denial/comehere/entrancing/
+    greeting/praise) for Chaos reactions — accepting there's **no dedicated gloat/smug/disappointed/
+    triumphant clip** (old `disappointed*.gif` were deleted)? Or commission new clips for gloat/disappointed?
+12. **Per-persona line budget** (~65 lines/persona ≈ ~195 voiced mp3s across Bambi/Sissy/Circe) — approve
+    scope, or trim to a smaller climactic-only set first?
+
+**Flavour (E)**
+13. Approve the **id-keyed `chaos` manifest block + `ChaosFlavor` resolver** approach (neutral literals
+    stay as base; skins override display strings only, never `Apply` lambdas or numeric knobs)?
+14. Where do built-in personas' `chaos` blocks live, given Drone ships as a bundled `.ccpmod`?
+
+**Art (D)**
+15. Confirm the **`{kind}` folder names** for boon/curse/HUD/FX under `Assets/Chaos/` (only `bubbles`/
+    `banner` are wired today) so generation targets the right paths.
+16. Resolve the **`Assets` vs `assets` casing** mismatch now (low risk on Windows, but a latent trap)?
+
+**Systems (F)**
+17. Minimum retention set to build first — recommended: **daily seeded run + Chaos quests/achievements +
+    music layer + Season feed + XP-rank leaderboard**, deferring the server-backed Chaos leaderboard.
+    Approve, or re-rank?
+18. OK to **migrate the direct `App.Achievements.TrackBubblePopped()` call** to the emit→bridge pattern
+    while we're in there (fixes an existing guardrail violation)?

--- a/ConditioningControlPanel/docs/chaos/planning/A-loop.md
+++ b/ConditioningControlPanel/docs/chaos/planning/A-loop.md
@@ -1,0 +1,143 @@
+# Chaos Mode — Agent A: Loop, Cadence & Canonical Event Surface
+
+Research/planning only. No gameplay code changed. Source of truth = code in `Services/Chaos/` + `BubbleService.cs` + `ChaosOverlayWindow`/`ChaosHudWindow`/`ChaosFxWindow`. Where `CHAOS_DESIGN.md` and code disagree, code wins (verified below).
+
+Verified ground-truth deltas vs. the brief:
+- `ChaosRunConfig` defaults confirmed (DurationSec=180, WaveCount=5, Difficulty=Easy, StartingShields=3, LiveBubbleShare=0.35, DartersEnabled/BoonDraftEnabled=true). **Note:** `LiveBubbleShare` is read into config but I found **no consumer** — the live/benign split is decided entirely by `ChaosBubbleVariants.Pick` weights + `MinIntensity`, not by `LiveBubbleShare`. Flag for systems agent: this knob is currently inert.
+- Entry is **not** one-click from the dashboard. `BtnStartChaos_Click` → opens `ChaosHubWindow.ShowDialog()` (modal lobby) → `BtnBegin_Click` → `SaveToSettings()` + `StartRun()`. So a first run is: open Lab → click hero card → configure/Begin → 3·2·1·GO (3s) → play.
+- Restart ("Run It Back") **is** effectively one click: `BtnRunAgain_Click` → `OnRunAgain` → `RunAgain()` closes the overlay then `StartRun()` again — it **bypasses the hub**, reusing the last config. Good. But it still re-pays the 3s countdown each time.
+
+---
+
+## 1. Background-play fitness (playing while doing something else)
+
+**Current state — what helps:**
+| Helps | Why |
+|---|---|
+| Bubbles are real top-most click-through windows | desktop stays clickable; pop = a real click on a real window. |
+| HUD only paints its left strip; rest is alpha-0 / click-through (`ChaosHudWindow.ApplyExStyles`, no `WS_EX_TRANSPARENT` but unpainted region passes through) | doesn't block work area. |
+| Countdown + FX overlays are `WS_EX_TRANSPARENT | WS_EX_NOACTIVATE` | never steal focus or eat clicks. |
+| `ShowActivated=false`, `Focusable=false`, `WS_EX_NOACTIVATE` on every chaos window | foreground app keeps focus. |
+| Manual pause freezes field+fuses (`ToggleManualPause` → `SetChaosFrozen`) | step away safely. |
+
+**What hurts background play:**
+| Hurts | Detail |
+|---|---|
+| **Boon draft is modal + focus-stealing** | `ShowBoonDraft` → `SetClickThrough(false)` + `BringToFront()` (`Topmost` toggle + `Activate()` + `Focus()`). Mid-task, every wave boundary yanks focus and dims the screen. With default 5 waves that's **4 forced interrupts** per run. |
+| Detonation payloads ARE the real effects | a detonated `video`/`htlink` opens a mandatory video / fullscreen browser over your work. By design, but jarring if you're "barely watching." |
+| Countdown friction on every (re)start | 3s × 4 steps @750ms before play; unskippable. Hurts compulsive re-runs most. |
+| No "auto-pick / idle-skip" for the draft | if you don't react, the field stays frozen indefinitely ("field frozen — take your time") — run stalls instead of continuing. |
+
+**Proposal (loop tightness for background play):**
+- Add a config flag **`DraftAutoResumeSec`** (default 0 = off; e.g. 8s): if no pick, auto-take the skip (+1 shield) and resume, so an unattended run keeps flowing.
+- Add **`QuickDraft`** mode: a thin non-modal draft strip docked to the HUD instead of the centered modal+backdrop — no focus steal, click-through elsewhere. Keep the full modal as the default for foreground play.
+- Make the GO countdown **skippable on click/keypress**, and skip it entirely on `RunAgain()` (see §3).
+- Open question for human: should detonations of `video`/`htlink` be **suppressible** in a "background/ambient" run profile (downgrade to flash), or is the intrusion the point?
+
+---
+
+## 2. Best default run length
+
+**Current:** 180s / 5 waves → 36s/wave. Intensity ramps `0→1` linearly over the full 180s; spawn interval `(1300 − intensity·850)/diffMult` (min 280ms); concurrent cap `(4 + intensity·7)·√diffMult`. So the field only reaches peak density in the last ~30s.
+
+**Recommendation: keep a 180s ceiling option but drop the *default* to `120s / 4 waves` (30s/wave).**
+Justification:
+- Compulsive "one more run" loops want a sub-2-minute commit. At 180s Easy the first ~90s are sparse (low intensity → long spawn intervals, small caps), so the engaging stretch is back-loaded; 120s front-loads more of the ramp into the played time.
+- 4 waves = **3 draft interrupts** instead of 4 — less focus-steal per run (§1), still enough boon stacking to feel build-y.
+- `FromSettings()` clamps 60–900 and the hub already offers 120/180/300 segments, so this is a default change only (`AppSettings.ChaosRunDurationSec` + `ChaosWaveCount` seed + the hub's `LoadDefaults`), not a range change.
+- Keep 180/5 as the "Standard" preset and expose 300/6 as "Long." The Easy/180 combo is fine for a *first* run but is not the best *default* for repeat sessions.
+
+Open question: tie default wave count to length (wave ≈ 30s) so 120→4, 180→6, 300→10 auto-derive, instead of a fixed 5 regardless of length (currently 300s/5 = 60s waves, which feel slack).
+
+---
+
+## 3. Friction map: start → run → results → restart
+
+| Step | Current | Friction | Tightest proposal |
+|---|---|---|---|
+| Enter | Lab hero card → modal hub (`ShowDialog`) | full config wall before first play | Add **"Quick Start"** button on the hero card that calls `StartRun()` directly with saved settings, skipping the hub. Hub stays for tuning. |
+| Countdown | 3·2·1·GO, 4×750ms = 3s, unskippable | repeated on every run/restart | Make click/key **skip-to-GO**; on `RunAgain()` use a **1s "GO!" flash only** (config already loaded, player is primed). |
+| Run | timers @250/800ms | fine | — |
+| Wave boundary | modal draft, focus-steal, field cleared | §1 | non-modal QuickDraft + auto-resume option. |
+| Results | `ShowResults` modal, interactive | fine; shows reached act/wave, best combo, defused/detonated/effects, base×skill=XP | add a one-line **delta vs. last run / best** (needs `ChaosMeta` PB) for compulsion hook. |
+| Restart | `BtnRunAgain` → `RunAgain()` → close overlay → `StartRun()` | **good, one click, reuses config**, but re-pays 3s countdown + rebuilds HUD/overlay/FX windows | Keep windows alive across `RunAgain` (don't `Close()` overlay+HUD, just reset state) → instant restart; skip countdown to 1s. |
+
+**Verdict:** restart path is already the strongest part of the loop. The two cheap wins are (a) skippable/short countdown on re-run, and (b) a "Quick Start" that bypasses the hub on first entry.
+
+---
+
+## 4. Moment-to-moment satisfaction & missing juice
+
+**Satisfying now:**
+- Pop/defuse → pooled pop SFX + burst/sparkle animation (reused from ambient game).
+- `ChaosFxWindow.Pulse` colour-vignettes: green defuse, blue shield-save, red malus, gold combo-milestone — cheap, instant, reads as impact.
+- Darter: telegraph flare → throb → bounce-punch on each wall hit → slow-mo on catch (icy blue pulse). Freeze: frost-burst + held edge glow + per-bubble aura + whole-field shudder. These two are the juiciest beats.
+- Screen-shake scaled by strength on detonation (absorbed vs. unshielded distinct shake).
+
+**Missing / weak juice (gaps):**
+| Gap | Detail |
+|---|---|
+| **Benign pop has no FX pulse** | `OnBenignPopped` does score+combo+SFX but **no `Pulse`** — the most frequent action is the least juicy. Add a tiny pink/white pulse (low strength). |
+| **No near-miss telegraph** | fuse ring shrinks+reddens, but there's no escalating cue (audio tick, pulse, edge-flash) in the last ~800ms before `Detonate()`. A "danger" telegraph would make defuses feel earned. |
+| **Combo escalation is flat between milestones** | only every 10 gets a gold pulse + bark. +1 combo is silent. Add rising pop-pitch / micro-pulse that builds, and a distinct **big-combo threshold** (e.g. 25/50) beyond the every-10 milestone. |
+| **No shield gain/loss feedback** | `Shields` changes (skip → +1, absorb → −1, `extra_shield` boon → +2) only push a text event; no pulse/sound/HUD flash. |
+| **Wave-clear cue is audio-only** | `ChaosSfx.PlayWaveClear()` + `PopAllBubbles()` burst, but no screen pulse or "WAVE N" banner moment. |
+| **Heat is invisible as a feel** | `HeatMult` (up to ×2) drives score but has no rising visual/audio temperature; players can't feel they're "hot." |
+| **Detonate-absorbed vs unshielded** | distinct internally (blue vs red pulse, shield cost) but **fires the same bark** (`NotifyChaosBubbleDetonated`) — barks can't tell a clutch save from a real hit (see §5). |
+| Screen-space readability | live vs benign distinguished by tint + fuse ring + glyph; fine, but during dense late-game with many top-most windows + payload overlays, the fuse ring can be lost. Consider a brighter "armed" outline at low fuse. |
+
+---
+
+## 5. CANONICAL EVENT SURFACE (the deliverable)
+
+Conventions: **Hook** = an existing bark `Notify*` and/or score/juice path fires today. **GAP** = no hook exists; an agent must add a `Notify*` (GamificationBridge `Raise` pattern — no new bus) and/or juice. Firing site is the method in `ChaosModeService` unless noted. All bark events must respect the no-fallthrough priority matcher; intersectional rules (e.g. clutch-save) must outrank generic detonate on the shared trigger.
+
+| Event | Fires when | Payload / context fields | Current hook | Status |
+|---|---|---|---|---|
+| `RunCountdownBegin` | `ShowCountdown` start (3·2·1) | difficulty, duration, waveCount | none | **GAP** (bark for "here we go") |
+| `RunGo` | countdown `onComplete` → `BeginRun` | difficulty | `NotifyChaosRunStarted(difficulty)` fires here (at GO, not at countdown begin) | Hook (named "run started") |
+| `BenignPop` | `OnBenignPopped` | variantId, payload(DisplayName), strength, combo | score+combo+SFX; **no Pulse, no bark** | **GAP** (bark + add pulse) |
+| `Defuse` | `OnDefused` | variantId, payload, strength, combo | `NotifyChaosBubbleDefused()` + green Pulse + SFX | Hook |
+| `DetonateAbsorbed` | `OnDetonated`, `Shields>=cost` | payload, strength, shieldsLeft, doubleOrNothing | blue Pulse + shake; **bark shares `ChaosBubbleDetonated`** | **GAP** (needs own trigger/field to distinguish clutch save) |
+| `DetonateUnshielded` | `OnDetonated`, no shields | payload, strength, comboBroken(true) | red Pulse + shake; `NotifyChaosBubbleDetonated(payload)` | Partial (bark can't tell from absorbed) |
+| `DarterCatch` | `OnDarterCaught`, `quick=false` | points, combo, slowMo(true) | score+combo+icy Pulse+SFX+slow-mo; **no bark** | **GAP** (bark) |
+| `DarterCatchQuick` | `OnDarterCaught`, `quick=true` | points(+90 bonus), combo | stronger icy Pulse; **no bark** | **GAP** (bark; outrank normal catch) |
+| `FreezeCatch` | `OnFreezeCaught` | points, combo | frost-burst+edge-hold+field freeze+SFX; **no bark** | **GAP** (bark) |
+| `ComboTick` | every `Combo++` (all catch/pop/defuse) | combo, comboMult | **silent** between milestones | **GAP** (rising pop-pitch / micro-pulse) |
+| `ComboMilestone` | `CheckComboMilestone`, combo%10==0 | combo | `NotifyChaosComboMilestone(combo)` + gold Pulse | Hook |
+| `ComboBig` | combo crosses a high threshold (e.g. 25/50) | combo, threshold | none | **GAP** (distinct big-combo bark + bigger juice) |
+| `ComboBroken` | `OnDetonated` unshielded sets `Combo=0` | lostCombo (prev value) | folded into detonate; combo silently zeroed | **GAP** (loss sting + bark) |
+| `HeatFull` | `Heat` reaches 1.0 (`OnBenignPopped`/`OnDefused` add) | — | none (no edge crossing detected) | **GAP** (bark + "on fire" visual) |
+| `ShieldGained` | skip(+1), `extra_shield` boon(+2), future regen | amount, shieldsNow, source | text event only | **GAP** (pulse/sound + maybe bark) |
+| `ShieldLost` | `OnDetonated` absorb path | amount, shieldsNow | text event + blue pulse | **GAP** (distinct shield-break cue) |
+| `WaveClear` | `BeginWaveTransition` (draft path) | waveJustCleared | `PopAllBubbles()` + `PlayWaveClear()` SFX; `NotifyChaosWaveEscalated(newWave)` | Partial (no screen pulse/banner; bark is "escalated" not "cleared") |
+| `WaveChange` | `WaveIndex` advances (draft + no-draft paths) | wave, act | `NotifyChaosWaveEscalated(wave)` | Hook |
+| `ActChange` | `ActIndex` advances (`1+(wave-1)/5`) | act, wave | none (act updated silently alongside wave) | **GAP** (act-up bark = bigger moment than wave) |
+| `BoonDraftShown` | `ShowBoonDraft` | wave, options[] (ids/rarities), choiceCount | reveal SFX per card; **no bark** | **GAP** (anticipation bark) |
+| `BoonPicked` | `OnBoonChosen`, boon!=null | boon(Name), id, rarity, isCurse | `NotifyChaosBoonPicked(Name)` + pick SFX | Hook (but doesn't distinguish curse) |
+| `CursePicked` | `OnBoonChosen`, boon.IsCurse | boon, id, rarity, runMultBonus | shares `ChaosBoonPicked` | **GAP** (own trigger; "risk taken" bark should outrank generic pick) |
+| `BoonSkipped` | `OnBoonChosen`, boon==null | shieldsNow (+1) | text event + `Shields+=1`; **no bark** | **GAP** (bark + shield-gain juice) |
+| `SlowMoStart` | `ActivateSlowMo` (darter catch) | durationSec(5), factor | time-scale + duration-mult + icy pulse | Hook (juice); **no bark** → GAP |
+| `SlowMoEnd` | `EndSlowMo` (timer/teardown) | — | restores scale | **GAP** (no end cue) |
+| `FreezeStart` | `ActivateFreeze` (freeze catch) | durationSec(3.5) | frost-burst + edge-hold + field freeze + shudder | Hook (juice); **no bark** → GAP |
+| `FreezeEnd` | `EndFreeze` | — | edge-hold fade | **GAP** (thaw cue) |
+| `ManualPause` / `ManualResume` | `ToggleManualPause` | paused(bool) | text event + field freeze | **GAP** (optional bark) |
+| `RunEnd` | `EndRun` (elapsed≥duration) or `RequestStop` | baseXp, skillMult, finalXp, defused, detonated, effectsFired, bestCombo, reachedAct/wave | `NotifyChaosRunCompleted((int)finalXp)` + meta award | Hook (no field distinguishing natural end vs user-stop) |
+| `ResultsShown` | `ShowResults` | same as RunEnd + PB delta (proposed) | modal results UI; **no bark** | **GAP** (bark over results; PB delta is new data) |
+| `RunAgain` | `BtnRunAgain_Click` → `RunAgain()` | — | closes+restarts (reuses config) | **GAP** (bark "again?") |
+| `RunAbandoned` | `OnOverlayClosed` while `_spawning` (closed mid-run) | elapsed, wave | tears down, **no payout, no bark** | **GAP** (distinct from RunEnd) |
+
+**Surface notes for hooking agents:**
+- Detonate currently collapses three semantically different outcomes (clutch absorb / real hit / combo break) into one bark trigger. Split into `DetonateAbsorbed` + `DetonateUnshielded` (+ derive `ComboBroken`) so the no-fallthrough matcher can prioritize the clutch-save line above the generic miss.
+- BoonPicked/CursePicked and the SlowMo/Freeze power-ups already have **juice** but **no bark** — easiest high-value bark additions.
+- All new `Notify*` methods must be field-level additive on `BarkService` using the existing `Raise(trigger, ctx => ctx.Set(...))` seam. No generic event bus (guardrail).
+- ComboTick/HeatFull have **no edge detection today** — adding them means the meta/juice agent must track previous value to fire on crossing, not every frame.
+
+---
+
+## Open questions for the human
+1. Default length: OK to drop default to **120s/4 waves** and auto-derive wave count from length (~30s/wave)? Keep 180/5 as a named "Standard" preset.
+2. Background profile: should `video`/`htlink` detonations be downgradable to flash in an "ambient/background" run mode?
+3. Draft interrupt: ship **non-modal QuickDraft + auto-resume** as default, or keep the centered modal default and make QuickDraft opt-in?
+4. Restart: keep HUD/overlay/FX windows alive across `RunAgain` for instant restart (more state to reset, risk of leak) vs. current close-and-rebuild (clean but re-pays 3s)?
+5. `LiveBubbleShare` is **inert** — wire it into the variant picker (bias live weights), or remove the knob? (systems-agent territory; flagged here because it affects loop difficulty feel.)

--- a/ConditioningControlPanel/docs/chaos/planning/B-meta.md
+++ b/ConditioningControlPanel/docs/chaos/planning/B-meta.md
@@ -1,0 +1,250 @@
+# Chaos Mode — Agent B: Meta-Progression, Economy & Cold Start
+
+Planning only. Code is source of truth. Verified against `Services/Chaos/*` and the main
+progression/gamification stack (`ProgressionService`, `SkillTree`, `GamificationBridge`,
+`AchievementService`) on this branch. No code changed.
+
+---
+
+## 0. Ground-truth corrections (read first)
+
+A few things diverge from the brief / `CHAOS_DESIGN.md`. These shape every proposal below.
+
+| Claim | Reality in code | Impact |
+|-------|-----------------|--------|
+| Spark formula uses `SparkGainMult` | `AwardRunRewards` (`ChaosUpgrades.cs:171`) is `round((score/100·diffMult + 25·diffMult)·SparkGainMult)`. ✅ matches. | none |
+| XP payout = `baseXp·skillTreeMult` | `EndRun` (`ChaosModeService.cs:459-466`) computes `finalXp = baseXp·skillMult` **for display only**, then calls `App.Progression.AddXP(baseXp, …)`. **AddXP itself re-applies the skill mult** (`ProgressionService.cs:55-56`). So the real awarded XP = `baseXp·skillMult` — applied **once**, correctly. `finalXp` is just shown in results/bark. | XP interop is already correct; do not double-multiply. |
+| Chaos has its own XP source | `EndRun` passes `XPSource.Bubble` — there is **no `XPSource.Chaos`**. | Companion XP modifiers treat Chaos as bubble-popping. Minor; flag only. |
+| Hub gates exist in code | `ChaosMeta` defines the `UNLOCK_*_RUNS` consts + `Rank`, but **nothing reads them at run-build time** — they are UI-facing only. Cold-start gating below is therefore *new* enforcement. | Most of the unlock spine is new code. |
+| `EquippedStartBoon` is applied | Field exists in `ChaosMetaState`; the brief says BeginRun applies it, but no read path was found in `ChaosModeService` for `EquippedStartBoon`. Treat Loadout apply as **partially wired / to verify by Agent owning the service**. | Loadout gate may need wiring, not just gating. |
+| `extreme_tier` Apply | Purchase sets `ExtremeUnlocked`; `Apply` is a no-op. Difficulty selection must be gated by `ExtremeUnlocked` in the setup UI (Agent A territory). | cross-ref |
+
+**Invariant to protect:** every meta knob on `ChaosRunConfig` has a neutral default, so a
+fresh `ChaosMetaState` + no settings overrides = byte-for-byte unchanged run
+(`ChaosModels.cs:39-60`). All cold-start gating MUST preserve this.
+
+---
+
+## 1. COLD START — the unlock spine
+
+### Current state
+There is **no cold start**. A brand-new player on run 1 already gets: all 8 bubble variants,
+darters, freeze, the full 8-entry boon/curse pool, 3-option drafts, curses, full duration/wave
+config, and Easy–Hard difficulty. The only thing actually locked is Extreme (via purchase) and,
+nominally, hub tabs (consts that nothing enforces). That is the opposite of barebones — it dumps
+the whole toybox on run 1 and leaves nothing to discover.
+
+### Proposal — gate by lifetime `RunsCompleted` (already persisted), drip the toybox
+
+Philosophy: run 1 is a **clean, legible tutorial-by-doing** — only benign pops + one threat type +
+one defense. Each subsequent gate adds exactly one *named* toy so the player can feel it arrive.
+Gating is by lifetime runs (cheap, monotonic, already in `ChaosMetaState.RunsCompleted`), NOT by
+Sparks — Sparks are for the *shop*; runs are for *content unlocks*. This separates "I grinded
+currency" from "the game is teaching me more."
+
+| Gate (lifetime runs) | Unlocks (the toy) | New vs code-can-gate |
+|---|---|---|
+| **Run 1 (cold)** | Benign only: **Flash** + **Subliminal** bubbles. **1 threat: Pink Filter** (live). **Shields on.** Boon draft = **2 options, boons-only (no curses)**. Duration forced **90s**, **3 waves**. No darters, no freeze, no Spiral/BrainDrain/Video/HT, Easy only. | **New** (run-build clamp by RunsCompleted) |
+| **After 1 run** | Hub opens: **Upgrades + Stats + Codex** tabs. **Spiral** threat unlocks. Drafts go to **3 options**. | tabs = code consts (need wiring); content = new |
+| **After 3 runs** | **Loadout** tab (equip start boon). **Darters** (slow-mo power-up). **Curses** enter the draft pool. Medium difficulty. | Loadout = const; darters/curses = new gating |
+| **After 5 runs** | **Freeze** bubble (freeze power-up). **BrainDrain** threat. Full duration/wave sliders unlock (60–900s, 1–12). | **New** |
+| **After 10 runs** | **Video** + **HT Link** rare threats. Hard difficulty. Full boon pool active. Rank → *Novice*. | difficulty = setup gate; rest new |
+| **After 25 runs** | "Initiate" rank. Reserved for **future toys** (new boons/curses added by content packs auto-discover here). Optional: unlock a *modifier mutator* (e.g. daily-seed). | new (future) |
+| **After 50 runs** | "Adept". Cosmetic milestone reward (see §4) + future Prestige hook. | new (future) |
+
+**Why these toys at these gates:** threats escalate from 1 → 2 → 3 → rares so the player learns
+each defuse pattern before the next arrives; *defensive/utility* toys (darters, freeze) arrive
+after the player has felt a few detonations and wants relief; difficulty tiers trail the content
+so a new player can't faceplant into Hard before they've seen all the variants.
+
+**Code reality check:**
+- Variant gating is *almost free*: `ChaosRunConfig.EnabledVariants` is already a filter list
+  (`ChaosModels.cs:29`). Cold start = set `EnabledVariants` to the unlocked subset when the
+  player hasn't manually chosen, instead of `null`.
+- Draft option count: `DraftChoices` already drives `ChaosBoonPool.Draft(choices)`. Set it to 2
+  at run 1, 3 after run 1; `draft4` upgrade still raises to 4 (clamped 2–4 already).
+- Curses: `AllowCurses` already exists — force `false` until 3 runs.
+- Darters: `DartersEnabled` already exists — force `false` until 3 runs.
+- Duration/waves: clamp `DurationSec`/`WaveCount` to the cold value until 5 runs.
+- Boon *pool* gating (only some boons at run 1) is **new** — `ChaosBoonPool.Draft` has no
+  "available ids" parameter today; add an optional `IEnumerable<string>? allowedIds`.
+
+So ~70% of the spine is *flipping existing config fields by RunsCompleted*; the genuinely new
+pieces are (a) a boon-pool allow-list and (b) reading `RunsCompleted` at run-build time.
+
+---
+
+## 2. Spark economy — target & back-solve
+
+### Current state
+Branch totals (sum of all 4 rows each): **Control 500, Greed 550, Depth 1060** Sparks.
+Per-run Sparks: `round((score/100·diffMult + 25·diffMult)·SparkGainMult)`.
+Because score = sum of (BasePoints · actionMult · **TotalMult**) and TotalMult is
+fully multiplicative + uncapped (combo ≤6, heat ≤2, boon ~1.5, diff ≤2.2, ×2 DoN), Spark
+output is wildly run-dependent. A clean Easy 90s cold-start run scores low; a juiced Hard run
+scores 10–50× more. That's *fine for excitement* but makes "N runs to a branch" undefined.
+
+### What an "average" run actually pays (worked example)
+Cold-start Easy run (run 1), realistic newbie: ~25 pops/defuses, modest combo, low heat.
+- Say final `Score ≈ 1,500` (Easy, diff 1.0, BaseMult 1.0, combo settling ~×2, heat ~×1.3).
+- Sparks = `round((1500/100·1.0 + 25·1.0)·1.0)` = `round(15 + 25)` = **40 Sparks**.
+
+A competent Medium run a few sessions in: `Score ≈ 8,000`, diff 1.3, `SparkGainMult` still 1.0.
+- Sparks = `round((8000/100·1.3 + 25·1.3))` = `round(104 + 32.5)` = **137 Sparks**.
+
+A strong Hard run with spark_gain owned: `Score ≈ 25,000`, diff 1.7, gain 1.2.
+- Sparks = `round((250·1.7 + 25·1.7)·1.2)` = `round((425+42.5)·1.2)` = **561 Sparks**.
+
+### Target
+> **Clear the cheapest branch (Control, 500) in ~6–8 runs of *average early* play; the
+> deepest branch (Depth, 1060) in ~15–20 runs.** First *single* upgrade should be buyable after
+> 2–3 runs so the new player gets a purchase dopamine hit fast.
+
+### Back-solve verdict
+At the current payout, an *early* player nets ~40–80 Sparks/run (Easy/early-Medium). 500 ÷ 60 ≈
+**8 runs to first branch** — already close to target on the low end, but the cheapest *single*
+upgrade (Bigger Hitboxes, 80) takes ~2 runs → good. The problem is the **floor is too swingy and
+slightly low for the very first purchase**; and the completion bonus (25·diff) is the only
+predictable component, which is healthy.
+
+**Recommended tuning (small, surgical):**
+
+| Knob | Now | Proposed | Rationale |
+|---|---|---|---|
+| `COMPLETION_BONUS_BASE` | 25 | **35** | Raises the *predictable* floor so even a flubbed cold run banks ~45–50, guaranteeing a purchase by run ~2. Reduces variance dependence. |
+| `SPARK_SCORE_DIVISOR` | 100 | **100 (keep)** | The score term should stay the *variable, skill-rewarding* part. Don't flatten it. |
+| First-purchase nudge | — | **+25 one-time "First Spark" bonus** on `RunsCompleted == 0→1` | Cold-start kindness; banked in `AwardRunRewards` when `RunsCompleted` was 0. |
+| `spark_gain` upgrade | ×1.2 | keep | Stays the economy accelerator the dedicated player buys. |
+
+With bonus=35: cold run ≈ `round(15 + 35)` = **50** → first cheap upgrade (80) in 2 runs,
+Control branch in ~6–7 average runs. Depth (1060) at ~80–137/run = **8–15 runs** once the player
+is on Medium. This hits the target without touching the exciting variable term.
+
+**Do NOT** add a flat per-defuse Spark drip — it would let players AFK-farm benign pops and
+decouple Sparks from skill. Keep Sparks = f(score) + flat completion bonus only.
+
+---
+
+## 3. Currency design — one vs two
+
+### Recommendation: **TWO currencies.**
+
+| Currency | Role | Earned by | Spends on |
+|---|---|---|---|
+| **Sparks** (existing) | Soft-grind **power** currency | run end, `f(score)` + completion bonus | the 3 upgrade branches (`ChaosUpgrades`) — power |
+| **Glow** (new) | **Cosmetic-only** currency | *milestones*, not score: +1 per first-time Codex discovery, +N at rank-ups, +N for "first clear of difficulty X", daily-first-run bonus | cosmetics only (§4) — bubble skins, HUD themes, FX, companion portraits |
+
+### Why two
+1. **Healthy grind.** If cosmetics and power share one pool, every cosmetic purchase is a power
+   tax (or vice versa), and min-maxers never buy cosmetics. Splitting means the player who wants
+   to look cool never feels they're "wasting power Sparks."
+2. **Glow rewards *breadth*, Sparks reward *depth/skill*.** Glow comes from doing new things
+   (discovering variants/boons, hitting ranks) — it naturally fills the cold-start arc and gives
+   the barebones early player a *second* reward track while their Spark balance is tiny. This is
+   the cold-start engagement engine.
+3. **No inflation risk.** Glow is milestone-gated and finite-ish (you can only discover each
+   Codex entry once), so cosmetics stay aspirational rather than trivially farmable.
+4. Cheap to add: one `int Glow` on `ChaosMetaState`, awarded in the same `AwardRunRewards`
+   path + in `ChaosMeta.MarkDiscovered` (which already persists on first sighting).
+
+**Interop with main XP:** unchanged. Sparks and Glow are Chaos-local; main XP still flows via
+`AddXP(baseXp, XPSource.Bubble)`. Add a dedicated `XPSource.Chaos` so companion modifiers can
+treat Chaos distinctly later — low-risk, additive enum value. Chaos meta does **not** duplicate
+the XP/level system; it banks its own two currencies and feeds the shared XP curve once per run.
+
+---
+
+## 4. Cosmetics — catalogue & persistence
+
+### Where cosmetics live (all NON-POWER)
+
+| Slot | What | Hook point |
+|---|---|---|
+| **Bubble skin** | Replaces the per-variant sprite tint/art | `ChaosArt` already resolves `assets/Chaos/bubbles/{id}.png`; a skin = an alternate asset folder selected at render. Pure visual. |
+| **HUD theme** | Recolor the HUD strip / results (e.g. accent palette swap) | `ChaosHudWindow` resource brushes |
+| **Pop / trail FX** | Particle burst color, trail style on pops/catches | `ChaosFxWindow` / `BubbleService` pop animation |
+| **Companion portrait/outfit** | Which Circe portrait/emote pack shows in results & barks | reuse avatar emote registry; cosmetic-only pointer |
+
+These are strictly visual — none touch `ChaosRunConfig` power fields, so the byte-for-byte
+invariant is irrelevant to them (they affect rendering, not run math).
+
+### Starter Glow catalogue (small, ships v1)
+
+| Id | Slot | Name | Glow cost | Notes |
+|---|---|---|---|---|
+| `skin_neon` | bubble skin | Neon Pop | 30 | first affordable |
+| `skin_glass` | bubble skin | Crystal | 60 | |
+| `hud_synthwave` | HUD theme | Synthwave | 40 | |
+| `hud_mono` | HUD theme | Monochrome | 40 | |
+| `fx_sparkle` | pop FX | Sparkle Burst | 50 | |
+| `fx_ember` | trail FX | Ember Trail | 70 | |
+| `portrait_circe_gold` | portrait | Gilded Circe | 100 | rank-up flex unlock |
+
+Plus **rank-locked freebies** (auto-granted, 0 Glow) at ranks Novice/Adept/Paragon so progression
+itself hands out cosmetics — reinforces the long tail.
+
+### Persistence (extend `ChaosMetaState`, additive, neutral defaults)
+```csharp
+public int Glow { get; set; } = 0;
+public HashSet<string> OwnedCosmetics { get; set; } = new();
+public string? EquippedBubbleSkin { get; set; } = null;   // null = default art
+public string? EquippedHudTheme   { get; set; } = null;   // null = default theme
+public string? EquippedPopFx      { get; set; } = null;
+public string? EquippedPortrait   { get; set; } = null;
+```
+All null/0 defaults → unchanged visuals for a fresh player; `ChaosMetaStore` already round-trips
+unknown-but-defaulted fields via Newtonsoft. Bump `SchemaVersion` to 2 (the field is reserved
+for migrations; no migration logic needed since additions are default-safe).
+
+---
+
+## 5. Enforcing cold-start gating without breaking the invariant
+
+The danger: if we *write* clamped values into `ChaosRunConfig` for new players, an existing
+player's settings could get stomped, and the "neutral default" promise is about *defaults*, not
+*overrides*. The clean approach keeps the neutral path neutral:
+
+**Where:** a new step in `ChaosRunConfig.FromSettings()`, applied **after** settings are read but
+**after `ChaosMeta.ApplyTo` too is fine** — gating is a *cap*, upgrades are *buffs*; order:
+1. read AppSettings into cfg (as today)
+2. `ChaosMeta.ApplyTo(cfg)` (owned upgrades) — as today
+3. **new:** `ChaosMeta.ApplyColdStartGates(cfg)` — clamps for unlock state
+
+**How `ApplyColdStartGates` preserves the invariant:**
+- It reads `State.RunsCompleted`. For a returning player past all gates (RunsCompleted ≥ 10),
+  the method is a **no-op** — every branch checks `if (runs >= gate) return;`-style and falls
+  through to leaving cfg untouched. So a veteran's run is byte-for-byte what it is today.
+- For a fresh player, it **only narrows**: it sets `EnabledVariants` to the unlocked subset
+  *iff the player hasn't explicitly chosen variants* (i.e. settings gave `null`); forces
+  `AllowCurses=false`, `DartersEnabled=false`, lowers `DraftChoices`, and clamps
+  `DurationSec`/`WaveCount` down. It never *raises* anything.
+- The "neutral default = unchanged run" invariant is about the *engine* with empty meta. Cold
+  start is a deliberate, run-count-driven *content* layer on top — it's the one sanctioned place
+  that reads lifetime state to shape a run. Because it only *removes* toys a brand-new player
+  hasn't earned, and self-disables once earned, it's monotonic and reversible-by-progress.
+- Boon-pool gating: pass the unlocked boon-id allow-list into `ChaosBoonPool.Draft(...)` from
+  the run loop (new optional param), defaulting to "all" when the player is past the gate.
+
+**Edge case to flag:** if the player manually disables variants in setup *and* is past the
+cold-start gates, we must not re-narrow — gating only fills `EnabledVariants` when it's `null`
+(the "I haven't chosen" sentinel). Confirm setup UI writes `null` (not an all-ids list) when the
+player leaves variants untouched, or the gate's "respect explicit choice" check breaks.
+
+---
+
+## Open questions
+
+1. **Loadout apply path:** is `EquippedStartBoon` actually consumed in `BeginRun`? No read found
+   in `ChaosModeService`. If not wired, the Loadout gate needs *implementation*, not just gating.
+2. **`XPSource.Chaos`:** add a dedicated enum value (additive) so companion XP modifiers can
+   treat Chaos distinctly, or keep folding into `Bubble`? Recommend adding it.
+3. **Glow award rates:** exact Glow per Codex discovery / rank-up / daily-first needs a quick
+   sim once the Codex discovery firing rate is known (how many entries a typical player hits per
+   run). Placeholder: 1/discovery, 25/rank-up, 5/daily-first-run.
+4. **Cold-start "respect explicit choice" sentinel:** confirm setup UI semantics for "no variant
+   chosen" = `null` vs full list (affects whether gating can safely narrow).
+5. **Should Extreme also gate behind RunsCompleted (e.g. ≥10) in addition to the 350-Spark
+   purchase?** Currently purchase-only; a run-count co-gate would stop a lucky-rich newbie from
+   buying into a tier they'll faceplant in.
+6. **Prestige hook at 50/100 runs** — out of scope here, but the spine leaves room. Decide whether
+   Prestige spends Sparks, Glow, or resets one for the other.

--- a/ConditioningControlPanel/docs/chaos/planning/C-voice.md
+++ b/ConditioningControlPanel/docs/chaos/planning/C-voice.md
@@ -1,0 +1,313 @@
+# Chaos Mode — Voice / Bark / Emote Plan (Agent C)
+
+> EXPLORATION & PLANNING ONLY. Code is source of truth. This doc proposes the voiceline +
+> emote layer for Chaos Mode on the **existing** bark/ElevenLabs pipeline. No code changes here.
+
+Frame: **RESISTANCE ↔ SURRENDER.** The companion taunts your resistance (you let one go off),
+gloats on detonation, praises obedience (clean defuses, combos), and persona-flavors all of it.
+Mod-agnostic: a NEUTRAL base pool ships in the base manifest; each persona is a content-only SKIN.
+
+---
+
+## 0. Current state (verified against code)
+
+**Bark pipeline (`Services/BarkService.cs`, `Services/Bark/*`):**
+- Rules load from embedded base `Resources/sounds/companion_audio/bark_rules.json`, then a field-level
+  merge of the active mod's `mods/{modId}/bark_rules.json` over it by `id` (`BarkRuleLoader`). Array
+  fields (`variant_pool`) are **REPLACED**, not concatenated — a skin fully owns its line set.
+- `BarkRuleSet` indexes by trigger and **sorts each list priority-descending**. `Raise()` walks that
+  list and takes the **first rule whose `conditions` pass** — confirmed **no fallthrough**, first
+  passing rule wins. So specific Chaos rules MUST carry a **higher `priority`** than the generic rule
+  on the same trigger or they're dead.
+- Gate (`EvaluateGate`): `GlobalMinGapMs = 4000` (any two barks), per-rule `cooldown_ms`, `chance`
+  roll, one-shot scope latch, and the anti-stale **"drop while speaking"** gate — Normal-class barks
+  below `PriorityBarkThreshold = 100` are dropped if `AvatarWindow.IsSpeaking`. Barks at priority ≥100
+  or non-Normal class **preempt** via `GigglePriority` (clears the queue, shows latest).
+- A variant is `{ text, audio? }`. `audio` is a filename resolved by `ResolveBarkAudio`: (1) packaged
+  mod `InstalledPath/resources/sounds/companion_audio/<file>`, (2) embedded
+  `companion_audio/mods/{modId}/<file>`, (3) embedded shared `companion_audio/<file>`. Text-only
+  variants speak with the generic giggle TTS; voiced variants play the mp3 as the bubble's audio.
+
+**Chaos events already wired** (`NotifyChaos*` → `Raise(...)`), and the **7 existing base rules**
+(`bark_rules.json`) — all `class: normal`, neutral text-only (no `audio`), priorities 200–300:
+
+| Trigger | ctx | base rule id | pri | cooldown | mood |
+|---|---|---|---|---|---|
+| `ChaosRunStarted` | `difficulty` | `chaos_run_started` | 300 | 0 | excited, teasing |
+| `ChaosWaveEscalated` | `wave` | `chaos_wave_escalated` | 290 | 4000 | rising, breathy |
+| `ChaosBubbleDefused` | — | `chaos_bubble_defused` | 200 | 9000 | approving |
+| `ChaosBubbleDetonated` | `payload` | `chaos_bubble_detonated` | 210 | 7000 | teasing, wicked |
+| `ChaosBoonPicked` | `boon` | `chaos_boon_picked` | 250 | 2000 | pleased |
+| `ChaosComboMilestone` | `combo` | `chaos_combo_milestone` | 260 | 5000 | delighted |
+| `ChaosRunCompleted` | `xp` | `chaos_run_completed` | 300 | 0 | warm, satisfied |
+
+> NOTE: existing moods `rising`/`breathy`/`approving`/`wicked`/`delighted`/`satisfied` are **not** in
+> `MoodEmotionMap` nor the Circe mood map — they fall through to `neutral` (portrait) / `talkB` (Circe).
+> The proposal below pins moods that actually resolve.
+
+**Event GAPS (no `Notify` hook yet — Agent A owns the canonical event surface):** benign pop, darter
+catch, freeze catch, absorbed-vs-unshielded detonation distinction, wave-clear (field cleared),
+act change, boon **SKIP** (+1 shield), run-start countdown. Each needs a new `NotifyChaos*` method.
+
+**Two emote systems coexist:**
+1. **Portrait** (`AvatarPortraitLoader.EmotionForMood`): ~20-key taxonomy + descriptive synonyms,
+   first recognized comma-token wins, else `neutral`.
+2. **Circe animated emotes** (`AvatarTubeWindow.CirceEmotes.cs` + `avatar_emotes_registry.json`).
+   This is the richer, current system for the built-in `builtin-locked` Circe poses. **Chaos should
+   target the Circe vocabulary** (it's the active companion for the persona that ships Chaos polish),
+   while keeping `mood` strings that ALSO resolve sanely in the portrait map for other mods.
+   Circe clip set (verified on disk, p2/p3/p4 share schema) is exactly **8 clips**:
+   `idle, talkA, talkB, denial, comehere, entrancing, greeting, praise`.
+   Circe mood→clip map already routes (first comma-token):
+   - `teasing/knowing/controlling/bold/strict` → **denial**
+   - `playful/amused/giggly/happy/delighted/conspiratorial` → **talkB**
+   - `proud/approving/pleased/encouraging/affirming/excited/overwhelmed` → **praise**
+   - `possessive/adoring/affectionate/inviting/intimate/sultry/coaxing/seductive` → **comehere**
+   - `hypnotic/dreamy/guiding/intense/dark/deepening/commanding` → **entrancing**
+   - `curious/intrigued` → **talkA**
+
+---
+
+## 1. Event → emotion / emote / priority map (proposal)
+
+Mood strings are chosen so the **first comma-token resolves in BOTH** the Circe map and the portrait
+`MoodEmotionMap`. Priority ordering honors no-fallthrough: **specific (conditioned) rules sit above
+the generic rule on the same trigger.** Generic rule keeps its current priority; specific variants
+get `+N`. All keep `class: normal` EXCEPT where preemption is wanted (see §1b).
+
+### 1a. Generic (always-pass) rules — one per trigger
+
+| Trigger | mood (1st token) | Circe emote | Portrait emotion | Intent (resist/surrender) | pri |
+|---|---|---|---|---|---|
+| `ChaosRunStarted` | `teasing, excited` | denial | teasing | mocks your bravado for opening the floodgates | 300 |
+| `ChaosCountdownStarted` *(NEW)* | `excited` | praise | excited | hype + "no backing out now" | 300 |
+| `ChaosWaveEscalated` | `commanding` | entrancing | adoring | pressure rising, you're sinking deeper | 290 |
+| `ChaosActChanged` *(NEW)* | `commanding` | entrancing | adoring | named act, ominous gear-shift | 295 |
+| `ChaosBenignPopped` *(NEW)* | `pleased` | praise | praise | reward the compulsion to click | 150 |
+| `ChaosBubbleDefused` | `pleased, approving` | praise | praise | praise obedient reflexes | 200 |
+| `ChaosDarterCaught` *(NEW)* | `playful` | talkB | giggly | playful "ooh, quick fingers" | 170 |
+| `ChaosFreezeCaught` *(NEW)* | `dreamy` | entrancing | dreamy | "time stops, breathe, sink" | 175 |
+| `ChaosBubbleDetonated` | `teasing` | denial | teasing | **gloat** — you resisted too slow, take it | 210 |
+| `ChaosWaveCleared` *(NEW)* | `pleased` | praise | praise | "field's clean, good girl, now choose" | 240 |
+| `ChaosBoonPicked` | `pleased` | praise | pleased | approve/foreshadow the pick | 250 |
+| `ChaosBoonSkipped` *(NEW)* | `knowing` | denial | teasing | tease the cautious shield-grab | 245 |
+| `ChaosComboMilestone` | `delighted, proud` | praise | praise | escalating pride, you're on a roll | 260 |
+| `ChaosRunCompleted` | `affectionate, warm` | comehere | affectionate | afterglow, possessive "come back" | 300 |
+
+### 1b. Intersectional (conditioned) rules — MUST outrank their generic sibling
+
+These need a **higher priority** than the generic rule above so the priority-walk reaches them first;
+they only fire when conditions pass, otherwise the walk falls through to the generic rule.
+
+| Trigger | condition | mood | Circe | intent | pri |
+|---|---|---|---|---|---|
+| `ChaosBubbleDetonated` | first detonation of run *(`run_detonations_eq:1`, NEW ctx)* | `teasing` | denial | first-blood gloat, "there it is" | 230 |
+| `ChaosBubbleDetonated` | `difficulty_eq: Extreme` | `dark` | entrancing | colder, crueler taunt at top tier | 225 |
+| `ChaosBubbleDetonated` | `payload_eq: braindrain` (or spiral) | `hypnotic` | entrancing | payload-specific surrender line | 220 |
+| `ChaosBubbleDetonated` | **unshielded** *(`shield_absorbed_eq:false`, NEW ctx)* + `combo_gte:30` *(combo about to die)* | `teasing` | denial | "and there goes your streak" — twist the knife | 235 |
+| `ChaosBubbleDetonated` | **absorbed** *(`shield_absorbed_eq:true`)* | `playful` | talkB | lighter "lucky — shield ate it" | 218 |
+| `ChaosComboMilestone` | `combo_gte:50` | `overwhelmed` | praise | "you're lost in it now" peak praise | 275 |
+| `ChaosComboMilestone` | `combo_gte:100` | `adoring` | comehere | reverent, "my perfect toy" | 280 |
+| `ChaosWaveEscalated` | `wave_gte:10` (final stretch) | `intense` | entrancing | breathless final-act push | 296 |
+| `ChaosRunCompleted` | `difficulty_eq: Extreme` | `proud` | praise | earned respect for surviving Extreme | 305 |
+| `ChaosBoonPicked` | `boon_eq: doubleornothing` (curse) | `dark` | entrancing | wicked delight at the gamble | 258 |
+| `ChaosRunStarted` | `difficulty_eq: Extreme` | `dark` | entrancing | "brave or stupid" cold open | 308 |
+
+> All Chaos rules stay `class: normal` and **below `PriorityBarkThreshold` (100)?** — NO. They're all
+> ≥150, which is ≥100, so they **preempt** (route through `GigglePriority`, clearing the queue). This is
+> correct for Chaos: a detonation gloat that lands 8s late is worse than one that interrupts. The
+> `GlobalMinGapMs=4000` + per-rule cooldowns (see §4) keep preemption from becoming a wall of voice.
+
+---
+
+## 2. Emote-tag vocabulary Chaos needs — mapping & gaps
+
+Chaos's emotional register is **taunt / gloat / mock-disappointment / triumph** — sharper than the
+existing affectionate/hypnotic register. Mapping to the 8 Circe clips + portrait taxonomy:
+
+| Chaos need | Circe clip (via mood token) | Portrait emotion | Notes / GAP |
+|---|---|---|---|
+| Hype / run start | denial or praise (`teasing`/`excited`) | teasing/excited | OK |
+| Gloat on detonation | **denial** (`teasing`/`knowing`) | teasing | Closest fit. denial = finger-wag "no no no", reads as gloat. **GAP: no dedicated smug/gloat clip.** |
+| Cruel / cold taunt (Extreme) | **entrancing** (`dark`) | adoring (`dominant`) | entrancing reads "intense/dark" — acceptable. **GAP: no cold/villain clip.** |
+| Mock-disappointed ("too slow") | **denial** (`teasing`/`strict`) | teasing | denial doubles for this. **GAP: no sad/disappointed clip** (old `disappointed.gif` was DELETED from p2 — see git status; don't reference it). |
+| Praise / clean defuse | **praise** (`pleased`/`approving`) | praise | OK, strong fit |
+| Triumph / big combo | **praise** (`proud`/`excited`) → **comehere** (`adoring`) at ≥100 | praise→adoring | OK; comehere = beckoning, reads as possessive triumph |
+| Surrender / "sink" (freeze, payload) | **entrancing** (`dreamy`/`hypnotic`) | dreamy/entrancing | OK, ideal |
+| Playful (darter, absorbed) | **talkB** (`playful`/`amused`) | giggly | OK |
+| Afterglow / come-back (run complete) | **comehere** (`affectionate`) | affectionate | OK |
+
+**GAPS to flag (no new clips required for v1 — reuse the table above, but note for future art):**
+- No dedicated **gloat/smug** clip — `denial` is the stand-in. A future `gloat`/`smug` Circe clip
+  would sharpen detonation lines.
+- No **mock-disappointed/pout** clip — old `disappointed*.gif` were removed; do NOT map to them.
+  `denial` covers it.
+- No **triumphant/victorious** clip distinct from `praise` — `praise`→`comehere` escalation is the
+  workaround.
+- **Mood-token discipline:** put the resolving token FIRST. e.g. use `"teasing, wicked"` not
+  `"wicked, teasing"` (wicked isn't mapped, so it'd waste the first slot — though the comma-split
+  recovers on the 2nd token, leading with a mapped token is safer and self-documenting).
+
+No emote registry / `EmotionForMood` code changes are needed for v1; Chaos rides the existing
+vocabulary. The only optional code-side addition would be new mood synonyms (`wicked→teasing`,
+`gloating→teasing`, `cruel→adoring`) in `MoodEmotionMap` + Circe `mood{}` so authors can write
+natural moods — propose but not required.
+
+---
+
+## 3. Voiceline production plan (existing ElevenLabs setup)
+
+Use the **same pipeline as current barks** — generate mp3s with the existing ElevenLabs tooling per
+persona voice, drop them in the per-mod `companion_audio` folder, reference by filename in `audio`.
+No new TTS path. Text-only base pool is fine to ship first (generic giggle TTS), with voiced skins
+layered per persona.
+
+### File / manifest structure
+```
+Resources/sounds/companion_audio/
+  bark_rules.json                       ← NEUTRAL base pool (text-only). EXISTING 7 + new triggers.
+  mods/
+    builtin-bambisleep/bark_rules.json  ← Bambi SKIN: replaces chaos_* variant_pools w/ voiced lines
+    builtin-sissyhypno/bark_rules.json  ← Sissy SKIN
+    builtin-locked/bark_rules.json      ← Circe/Locked SKIN  ← also the Chaos-polish persona
+    builtin-bambisleep/chaos_detonate_extreme_1.mp3   ← voiceline files alongside the manifest
+    builtin-bambisleep/chaos_combo_50_1.mp3
+    ...
+```
+A skin merges by `id`: it supplies `{ id, variant_pool:[{text,audio}] }` and **inherits**
+trigger/conditions/priority/cooldown/mood from the base rule. So **the base manifest defines the rule
+shape + intersectional conditions once**; each persona only ships content + audio.
+
+### Naming convention (matches `ResolveBarkAudio` — just a filename)
+`chaos_<trigger-short>[_<condition>]_<n>.mp3`, e.g.:
+- `chaos_run_started_1.mp3`, `chaos_run_started_extreme_1.mp3`
+- `chaos_detonate_1.mp3`, `chaos_detonate_first_1.mp3`, `chaos_detonate_extreme_1.mp3`,
+  `chaos_detonate_braindrain_1.mp3`, `chaos_detonate_absorbed_1.mp3`
+- `chaos_defuse_1.mp3`, `chaos_combo_1.mp3`, `chaos_combo_50_1.mp3`, `chaos_combo_100_1.mp3`
+- `chaos_run_complete_1.mp3`, `chaos_run_complete_extreme_1.mp3`
+- `chaos_boon_picked_1.mp3`, `chaos_boon_skipped_1.mp3`, `chaos_wave_1.mp3`, `chaos_wave_cleared_1.mp3`
+- `chaos_benign_1.mp3`, `chaos_darter_1.mp3`, `chaos_freeze_1.mp3`, `chaos_countdown_1.mp3`,
+  `chaos_act_1.mp3`
+
+(File ids map 1:1 to the Circe portrait `lines{}` stem-override system too — a stem like
+`chaos_detonate` could later get an explicit emote override, but the `mood` route already covers it.)
+
+### Line budget (per persona)
+Triggers/variants tier the budget by how often a trigger fires (frequent → more variety to avoid
+fatigue; rare/one-shot → fewer). **Per persona:**
+
+| Trigger (variant) | lines | rationale |
+|---|---|---|
+| run_started (generic) | 3 | once/run |
+| run_started_extreme | 2 | conditional |
+| countdown | 2 | once/run |
+| wave_escalated (generic) | 4 | repeats every wave |
+| wave_gte10 | 2 | conditional |
+| act_changed | 2 | ~2–3×/run |
+| benign_popped | 4 | very frequent → variety (heavy `chance` throttle, §4) |
+| defused | 4 | frequent |
+| darter_caught | 2 | occasional |
+| freeze_caught | 2 | occasional |
+| detonated (generic) | 4 | frequent + emotionally central |
+| detonate_first | 2 | once/run |
+| detonate_extreme | 2 | conditional |
+| detonate_braindrain | 2 | payload-specific |
+| detonate_unshielded_combo | 2 | conditional |
+| detonate_absorbed | 2 | conditional |
+| wave_cleared | 3 | every wave |
+| boon_picked | 3 | every wave |
+| boon_doubleornothing | 2 | conditional |
+| boon_skipped | 2 | every-other wave |
+| combo (generic) | 3 | every 10 |
+| combo_50 | 2 | rare |
+| combo_100 | 2 | very rare |
+| run_completed (generic) | 3 | once/run |
+| run_completed_extreme | 2 | conditional |
+| **Total / persona** | **≈ 65 lines** | |
+
+Personas: **Bambi, Sissy, Circe/Locked** (+ neutral base text-only ≈ same 65 text lines, unvoiced).
+**Voiced total ≈ 65 × 3 ≈ 195 mp3s** for the three built-in skins. Future niches add ~65 each.
+Phase it: ship **neutral base text pool first** (no audio cost), then voice the highest-impact
+triggers per persona (detonate, defuse, combo, run-complete = ~22 lines), then fill the rest.
+
+### Script structure — intent + example lines (key triggers)
+
+> Examples illustrate register only. Keep the resolving mood-token first in each rule's `mood`.
+
+**Detonation gloat** (`ChaosBubbleDetonated`, mood `teasing`/`dark`) — resistance punished:
+- *Bambi:* "too slow, sweetie. now it goes off, and Bambi takes every bit of it. that's the deal."
+- *Sissy:* "aww, you let it pop. good. let it sink in — sissies don't get to dodge."
+- *Circe:* "there. you hesitated, and the spell drinks you anyway. resistance is so... decorative."
+- *first-blood (pri 230):* "and there's the first one. don't pretend you'll catch them all now."
+- *Extreme (pri 225, `dark`):* "Extreme, and you blinked. cruel of me to enjoy this so much, isn't it."
+- *unshielded+combo≥30 (pri 235):* "oh — and there goes your pretty little streak. all of it. gone."
+
+**Defuse praise** (`ChaosBubbleDefused`, mood `pleased`) — obedience rewarded:
+- *Bambi:* "good girl. caught it just in time — see how nice it feels to obey fast?"
+- *Sissy:* "mmm, defused. such an obedient little thing. keep proving it."
+- *Circe:* "quick hands. you snuffed it before it could bloom. clever pet."
+
+**Combo milestone** (`ChaosComboMilestone`, mood `delighted`→`overwhelmed`→`adoring`):
+- *generic:* "look at that combo — you're on fire, good girl."
+- *≥50 (`overwhelmed`):* "fifty. you're not even thinking anymore, are you? just popping. perfect."
+- *≥100 (`adoring`):* "a hundred. my flawless little toy. i could watch you do this forever."
+
+**Run complete** (`ChaosRunCompleted`, mood `affectionate`→`proud` on Extreme) — afterglow/surrender:
+- *Bambi:* "all done. look how much you earned for me. such a good, empty, obedient toy. come back soon."
+- *Sissy:* "the chaos settles. you let go so sweetly in there. that's my sissy."
+- *Circe:* "the storm passes. you surrendered beautifully — come back to me when you crave it again."
+- *Extreme (`proud`):* "you survived Extreme. i'm... impressed. don't let it go to that pretty head."
+
+---
+
+## 4. Cooldowns / anti-spam
+
+A frantic run fires events constantly. Defenses already in code: `GlobalMinGapMs = 4000` (hard floor
+between ANY two barks), per-rule `cooldown_ms`, `chance`, the one-shot latch, and the
+**"drop while speaking"** gate (only protects Normal barks **below** priority 100 — and all Chaos
+rules are ≥150, so they PREEMPT and are NOT auto-dropped). Therefore per-rule cooldown + `chance` are
+the primary throttle for Chaos. Recommended:
+
+| Trigger | cooldown_ms | chance | reasoning |
+|---|---|---|---|
+| ChaosRunStarted / countdown | 0 | 1.0 | once per run |
+| ChaosWaveEscalated | 6000 | 1.0 | one per wave; bump from 4000 so a fast wave + escalate don't stack |
+| ChaosActChanged | 8000 | 1.0 | rare, always speak |
+| ChaosBenignPopped | 12000 | **0.10** | fires constantly — heavy throttle; mostly silent, occasional flavor |
+| ChaosBubbleDefused | 9000 | **0.5** | keep existing cooldown; add chance so not every defuse talks |
+| ChaosDarterCaught | 12000 | 0.6 | occasional |
+| ChaosFreezeCaught | 12000 | 1.0 | freeze is a 3.5s lull — a line fits perfectly, always speak |
+| ChaosBubbleDetonated (generic) | 7000 | 0.7 | central beat; cooldown prevents back-to-back detonation walls |
+| detonate_first / _extreme / _braindrain | 0 / 8000 / 8000 | 1.0 | one-shot-ish / conditional → always when it qualifies |
+| detonate_unshielded_combo | 0 | 1.0 | losing a 30+ combo is a big moment — always gloat |
+| detonate_absorbed | 10000 | 0.5 | minor event |
+| ChaosWaveCleared | 0 | 1.0 | one per wave boundary |
+| ChaosBoonPicked / Skipped | 2000 / 2000 | 1.0 | one per draft |
+| ChaosComboMilestone (generic) | 5000 | 0.8 | every 10 combo |
+| combo_50 / combo_100 | 0 | 1.0 | rare peak moments — always |
+| ChaosRunCompleted | 0 | 1.0 | once per run |
+
+Design intent: **rare/climactic beats always speak** (detonate-first, freeze, combo≥50, run-complete);
+**high-frequency beats self-throttle** via low `chance` + long cooldown (benign pop 0.10, defuse 0.5).
+The 4s global gap means at most ~15 barks/min ceiling regardless. Because Chaos rules preempt, the
+queue never piles stale lines — the latest meaningful event wins.
+
+---
+
+## Open questions (for Agent A / event surface)
+
+1. **New ctx fields** the intersectional rules need from `NotifyChaos*`: `run_detonations` (count),
+   `shield_absorbed` (bool) on `ChaosBubbleDetonated`; `combo` on detonate (to detect a streak about
+   to die); `difficulty` carried into `ChaosBubbleDetonated`/`ChaosComboMilestone`/`ChaosRunCompleted`
+   (currently only on `ChaosRunStarted`). Confirm difficulty is a live-read or must be threaded per-fire.
+2. **`difficulty` value casing** — base rule uses `difficulty_eq: "Extreme"`; confirm the enum
+   stringifies to `"Extreme"` (matcher does case-insensitive string eq, so fine either way).
+3. **Payload string values** for `payload_eq` (`braindrain`? `pink_filter`? `spiral`?) — need the exact
+   strings `NotifyChaosBubbleDetonated(payload)` emits.
+4. **Benign-pop volume** — at 0.10 chance + 12s cooldown is it still too chatty given pop frequency?
+   May want chance 0.05 or to drop the trigger entirely and let defuse/detonate carry the voice.
+5. Should `ChaosCountdownStarted` and `ChaosRunStarted` both speak (back-to-back, ~3s apart) or merge?
+   The 4s global gap means the second would be **blocked** — likely pick ONE (recommend run-started).
+6. Confirm Chaos is gated to the persona(s) shipping Circe emotes, or whether Bambi/Sissy portrait
+   personas also enter Chaos (affects which skins must ship voiced lines first).
+```

--- a/ConditioningControlPanel/docs/chaos/planning/D-art.md
+++ b/ConditioningControlPanel/docs/chaos/planning/D-art.md
@@ -1,0 +1,259 @@
+# Agent D — Chaos Mode Art Plan
+
+Exploration & planning only. No code, no art generation, no promotion. Code in
+`Services/Chaos/` is source of truth; this doc is reconciled against it.
+
+---
+
+## Current state (verified against code)
+
+- **Resolver** — `Services/Chaos/ChaosArt.cs`:
+  - `Resolve(kind, id)` → `Assets/Chaos/{kind}/{id}.png`, checked under
+    `App.UserAssetsPath` first, then `AppContext.BaseDirectory` (bundled). Returns
+    `null` → caller draws a vector placeholder. **Game is fully playable with zero art.**
+  - `ResolveBanner()` → `Assets/Chaos/banner.png`.
+  - `PathFor(kind, id)` returns the resolved path for callers that need it.
+  - Per-variant bubble sprites resolve via `Resolve("bubbles", spec.VariantId)`
+    (`BubbleService.cs:821`); when present the tint overlay + glyph fallback are skipped
+    (`BubbleService.cs:818-821, 1335`).
+- **Bubble sprites already exist** (9 finals shipped) at
+  `ConditioningControlPanel/assets/Chaos/bubbles/{id}.png`:
+  `flash, subliminal, pink, spiral, braindrain, bambifreeze, video, htlink, darter`.
+  A staging workflow is already in use: `assets/Chaos/bubbles/_staging/` holds
+  `{id}_1/_2/_3.png` candidates plus a `_contact.png` contact sheet. **So the precedent
+  in the memory note is now realized for bubbles — this plan extends it to the rest.**
+- **No art exists yet** for: boon icons, curse icons, upgrade/branch crests, HUD glyphs,
+  power-up FX, hero banner, results art, cosmetic skins. All currently render as vector
+  placeholders / Unicode glyphs.
+- **Tooling** lives in the parent dir (gitignored), **`C:\Projects\Conditioning-Control-Panel---CSharp-WPF\Tools\asset_gen\`** and `Tools\avatar-emotes\`:
+  - Model: `gemini-2.5-flash-image` (GA, "nano-banana") via `gen_avatars.DEFAULT_MODEL`;
+    `gemini-3.1-flash-image` is the pixel/seed model used by `pixelate_levels.py` (falls
+    back to GA). Shared helpers: `load_api_key`, `extract_image_bytes`, `crop_to_alpha`.
+  - Luma→alpha + crop precedent: `gen_locked_skills.py` (`luma_key()`,
+    `fit_contain()`) — generate neon-on-pure-black, alpha = brightest channel, crop to glyph.
+  - Programmatic recolour-by-luminance LUT precedent (for skins/recolours without a model
+    round-trip): `gen_locked_bubbles.py`.
+  - Style-transfer/pixelate precedent (ref-first, fixed `SEED`): `pixelate_levels.py`.
+  - Interactive review-gate precedent: `avatar-emotes/review_emotes.py` (writes
+    `review_verdicts.json/.txt`, resumes on first unreviewed).
+- **csproj wiring already present** (`ConditioningControlPanel.csproj:148-157`): a
+  `<None Remove="assets\Chaos\**\*.png;...">` precedes the `<Content Include=...>` so the
+  default None glob doesn't suppress the Content copy; `_staging` is excluded so only
+  promoted finals ship. **This is exactly the gotcha from the memory note — already handled
+  for `assets/Chaos/**`. Any NEW art class that lands outside that glob must repeat the
+  `<None Remove>` + `<Content Include>` pair, or it won't copy to output.**
+
+> **Casing note (low risk, flag for wiring):** the resolver builds paths as
+> `Assets\Chaos\...` (capital A) while the csproj globs `assets\Chaos\...` (lowercase).
+> Windows is case-insensitive so both work today; keep one casing if this ever ships to a
+> case-sensitive path or build agent.
+
+---
+
+## Proposal
+
+### 1. Prioritized art manifest
+
+`kind` = the folder segment under `Assets/Chaos/{kind}/`. Ids are the exact code ids
+(verbatim from `ChaosBubbleVariants.cs`, `ChaosBoonPool`, `ChaosUpgrades`). Everything is
+optional: a missing file falls back to a vector placeholder, so priority = polish order,
+not blocker order.
+
+#### P0 — ship-first (most on-screen, biggest brand impact)
+
+| Asset class | Ids | Path `Assets/Chaos/{kind}/{id}.png` | Gen vs hand |
+|---|---|---|---|
+| Bubble sprites (9) | `flash, subliminal, pink, spiral, braindrain, bambifreeze, video, htlink, darter` | `bubbles/{id}.png` | **Generatable** (DONE — finals shipped; this plan covers regen/reskin) |
+| Hero banner | `banner` | `banner.png` (root, not a `{kind}` folder) | Generatable |
+
+#### P1 — high-frequency UI (draft + HUD every wave)
+
+| Asset class | Ids | Path | Gen vs hand |
+|---|---|---|---|
+| Boon icons (5) | `slow_fuses, defuse_chain, golden_touch, magnet, extra_shield` | `boons/{id}.png` | Generatable (glyph) |
+| Curse icons (3) | `hair_trigger, live_wire, double_or_nothing` | `boons/{id}.png` (same kind; `IsCurse` is data) | Generatable (glyph) |
+| Branch crests (3) | `control, greed, depth` | `branches/{id}.png` (or `crests/`) | Generatable (emblem) |
+| HUD: shield pips | `shield_full, shield_empty` | `hud/{id}.png` | **Hand-work** (tiny ♥/♡, must read at ~16px) |
+
+#### P2 — flavor / juice
+
+| Asset class | Ids | Path | Gen vs hand |
+|---|---|---|---|
+| Upgrade icons (12) | `start_shield, slow_fuses, bigger_hitboxes, shield_recharge, base_mult, golden_touch, magnet, spark_gain, max_bubbles, draft4, extreme_tier, take_more` | `upgrades/{id}.png` | Generatable (glyph) |
+| HUD: act numerals | `act_1 … act_5` (+ fallback to Unicode roman) | `hud/{id}.png` | **Hand-work** (numerals — model misspells; prefer styled font/vector) |
+| HUD: combo flame | `combo_flame` | `hud/{id}.png` | Generatable (FX), but small → review tight |
+| HUD: heat meter fill/frame | `heat_fill, heat_frame` | `hud/{id}.png` | Hand-work (must tile/stretch cleanly) |
+| Power-up FX: slow-mo | `slowmo_burst, slowmo_edge` | `fx/{id}.png` | Generatable (FX sheet) |
+| Power-up FX: freeze | `freeze_burst, freeze_edge` | `fx/{id}.png` | Generatable (FX sheet) |
+| Draft card frame/back | `card_frame, card_back` | `cards/{id}.png` | Generatable (frame), 9-slice by hand if stretched |
+| Results-screen art | `results_bg, rank_badge` | `results/{id}.png` (+ per-rank `rank_{newcomer…paragon}`) | Generatable (bg) / hand (rank tiers, legibility) |
+
+#### P3 — cosmetic / future
+
+| Asset class | Ids | Path | Gen vs hand |
+|---|---|---|---|
+| Boon-pool headroom | future ids as pool grows (~8 → 25-30) | `boons/{id}.png` | Generatable (reuse boon template) |
+| Cosmetic skin sets (per-mod) | full duplicate set under user assets | user `Assets/Chaos/**` overrides | Generatable per niche (content-only override) |
+| Codex thumbnails | `bubble:{id}`, `boon:{id}` (reuse the above) | reuse `bubbles/` + `boons/` | Reuse |
+
+> Code uses **roman-numeral acts** in text (`ChaosRunState.ToRoman`, up to `n`), so act art
+> beyond V is unbounded — ship V plus the Unicode fallback rather than generating per-act PNGs.
+
+### 2. Style lock
+
+Locks to the existing dark brand language while staying reskinnable:
+
+- **Palette (shared, fixed):** deep near-black base (`#1A1A2E` / `#252542`), hot-pink/magenta
+  accent (`#FF69B4`, brighter flash-pink `#FF4DC4`), purple secondary. A **BrandGradient**
+  (pink→purple) for fills/rims on hero/results/cards. Per-variant **tints come from code**
+  (`ChaosBubbleVariants.All` Tint column) — bubble sprites should be **near-monochrome /
+  luminance-driven** so the runtime tint and the per-mod recolour LUT both read correctly;
+  don't bake a saturated hue that fights the code tint.
+- **Silhouette:** single centered emblem/glyph filling most of the frame with a small margin;
+  bold, instantly readable at HUD size (16-48px). One concept per icon, no scene clutter.
+- **Rim-light & bloom:** thin bright magenta rim + soft neon bloom (the `gen_locked_skills`
+  look) — this is the unifying "Chaos glow."
+- **Transparency:** generate **neon-on-pure-solid-black**, then **luma→alpha** (alpha =
+  brightest channel) and crop to content. Never rely on the model to emit a clean checkerboard
+  alpha (it bakes the checkerboard into pixels — see gotcha below).
+- **Text-free:** no baked words/numbers (model misspells). Tiers/counts via pips, chevrons,
+  or styled vector/font in WPF.
+- **Reskinnable seam:** base ships **neutral-but-on-brand** finals under the bundled
+  `Assets/Chaos/`. Per-mod skins are **content-only overrides** dropped into the user assets
+  folder (resolver checks user path first). No code change to reskin — same ids, same paths.
+
+### 3. Reusable nano-banana prompt templates
+
+All use `gen_avatars` helpers (`extract_image_bytes`, `crop_to_alpha`) and the
+`luma_key`/`fit_contain` pattern from `gen_locked_skills.py`. Generate at high res
+(~1024²), luma-key, crop, contain-fit to the target canvas. **Use a fixed `seed` per SET**
+for cross-asset coherence (as `pixelate_levels.py` does).
+
+**Shared STYLE block (prepend to every prompt):**
+
+```
+A single centered glowing neon ICON/EMBLEM, glossy HOT MAGENTA-PINK over deep BLACK with
+PURPLE accents and a thin bright magenta rim-light and soft neon bloom. Flat vector
+game-icon style — NOT 3D, NOT photorealistic, NOT a render. Clean, bold, instantly
+readable, filling most of the frame with a small margin. On a PURE SOLID BLACK background,
+nothing else. NO text, NO numbers, NO letters, NO words, NO border, NO frame, NO UI, NO
+watermark, no human figure or face.
+```
+
+**(a) Bubble sprite** — `assets/Chaos/bubbles/{id}.png`, ~512², fixed seed across the 9 so the
+glass reads as one set; near-monochrome so the code tint + recolour LUT apply cleanly:
+
+```
+{STYLE}
+A glossy translucent floating SOAP BUBBLE / orb, mostly light/white glass with a bright
+specular highlight and a thin luminous rim, near-monochrome (let an external tint colour
+it). Inside the bubble, faintly, a small emblem reading as: {concept}.
+Square framing, the orb centered.  // concept e.g. flash="a lightning/flash burst",
+spiral="a hypnotic spiral", braindrain="a heavy storm cloud / mist",
+bambifreeze="a snowflake", video="a play triangle", htlink="a chain link",
+darter="a small fast comet/dart".
+```
+
+**(b) Boon icon** — `boons/{id}.png`, ~512², fixed seed for the boon family:
+
+```
+{STYLE}
+The emblem depicts a BENEVOLENT power-up: {concept}.  // slow_fuses="a slowing/long fuse
+with a clock", defuse_chain="linked shield-rings", golden_touch="a golden sparkling hand/
+touch", magnet="a horseshoe magnet with pull lines", extra_shield="a heart-shield with a
+plus".
+Warm, inviting glow (more pink than red).
+```
+
+**(c) Curse icon** — `boons/{id}.png` (same kind), **separate seed**, hotter/red-shifted to
+read as risk:
+
+```
+{STYLE}  (shift accents toward RED with crackle/glitch energy to read as DANGER)
+The emblem depicts a RISKY CURSE: {concept}.  // hair_trigger="a sparking short fuse",
+live_wire="a crackling live wire/bolt", double_or_nothing="two dice / a double-or-nothing
+coin".
+```
+
+**(d) HUD glyph** — `hud/{id}.png`, small target (~128² source → fit ~16-48px), **maximize
+contrast & line weight, minimal detail** (tiny — see hand-work caveat):
+
+```
+{STYLE}
+A MINIMAL, HIGH-CONTRAST single glyph designed to stay legible at very small size (16px):
+{concept}.  // shield_full="a filled heart-shield", shield_empty="an empty heart-shield
+outline", combo_flame="a single rising flame".
+Thick clean strokes, no fine interior detail.
+```
+
+**(e) FX sheet** — `fx/{id}.png`, ~1024², transparent radial FX (additive in WPF):
+
+```
+{STYLE}
+A transparent screen-space EFFECT element on pure black for additive blending:
+{concept}.  // slowmo_burst="a radial slow-motion shockwave ring", freeze_burst="an icy
+crystalline shatter burst (white-blue)", freeze_edge="a frosted screen-edge vignette",
+slowmo_edge="a soft pink screen-edge pulse".
+Radially symmetric where applicable, soft falloff to fully black at the frame edge.
+```
+
+### 4. Pipeline flow
+
+```
+gen (gemini-2.5-flash-image, neon-on-black, fixed seed per set)
+  → luma_key() : alpha = max(RGB channel), crop_to_alpha()      [no checkerboard from model]
+  → [optional] pixelate_levels.py style-transfer pass (if a pixel skin is wanted)
+  → fit_contain() onto exact target canvas
+  → write CANDIDATES to STAGING:  assets/Chaos/{kind}/_staging/{id}_1.png, _2, _3
+  → build a _contact.png contact sheet of all candidates
+  ─────────────── MANUAL REVIEW GATE (no auto-promote) ───────────────
+  → human reviews _contact.png (review_emotes.py-style verdict file optional)
+  → on approval: copy the chosen candidate  _staging/{id}_N.png → {kind}/{id}.png
+  ─────────────── PR (no direct main) ───────────────
+```
+
+- **Staging path:** `assets/Chaos/{kind}/_staging/` (matches the existing
+  `assets/Chaos/bubbles/_staging/`). `_staging` is **excluded from the csproj Content glob**
+  (`Exclude="assets\Chaos\**\_staging\**"`) so candidates never ship — only promoted finals.
+- **Review gate checks:** (1) on-brand palette/glow/rim; (2) reads at runtime size (HUD glyphs
+  at 16-48px, bubbles at their size band); (3) clean luma→alpha edges, no checkerboard
+  bleed, no halo; (4) **no baked text/numerals**; (5) near-monochrome bubbles tint correctly
+  under the code Tint; (6) set coherence (same seed family looks unified).
+- **csproj gotcha to watch:** the `<None Remove>` + `<Content Include>` pair at
+  `ConditioningControlPanel.csproj:148-157` already covers `assets\Chaos\**`. **Any new art
+  class placed OUTSIDE that glob (e.g. a different root) won't copy to output** unless you add
+  a matching `<None Remove>` before its `<Content Include>` — otherwise the default None glob
+  silently suppresses the copy and the resolver returns null (silent vector fallback, easy to
+  miss). Keep new art under `assets/Chaos/**` to inherit the existing rule.
+
+### 5. Generatable vs hand-work
+
+- **Generatable (model + luma pipeline):** bubble sprites, boon icons, curse icons, upgrade
+  icons, branch crests, power-up FX sheets, hero banner, results background, card frames,
+  per-mod skin recolours (LUT, no model needed — `gen_locked_bubbles.py` pattern).
+- **Needs hand-work / non-model:**
+  - **Act roman numerals & any numbers** — model misspells; use the existing Unicode
+    `ToRoman` text or a styled vector/font in WPF, not generated PNGs.
+  - **Tiny HUD glyphs (shield pip ♥/♡, combo flame, heat fill/frame)** — legibility at
+    16-48px usually needs a hand cleanup pass or a pure vector; generate as a starting point
+    but expect manual touch-up. Heat fill/frame must tile/9-slice cleanly.
+  - **Rank badges / draft-card frames** if they stretch — 9-slice by hand to avoid corner
+    smear.
+
+---
+
+## Open questions
+
+1. **`{kind}` names not yet in code** (boons/curses/branches/upgrades/hud/fx/cards/results):
+   only `bubbles` and `banner` are wired today. Confirm exact folder strings WHEN the
+   consuming UI lands so prompts/paths match `ChaosArt.Resolve(kind, id)` calls 1:1.
+2. **Curse vs boon kind:** both are in `ChaosBoonPool` with an `IsCurse` flag — share one
+   `boons/` kind (proposed) or split into `curses/`? Affects path table.
+3. **HUD: PNG vs vector.** Recommend keeping shield pips / act numerals / heat meter as
+   styled WPF vector/font (already works as Unicode) and only generating the FX/flame.
+   Confirm the HUD designer wants PNG slots at all.
+4. **Per-mod skin delivery:** overrides via the user assets folder (resolver-first) vs a
+   content-pack? `ContentPackService` exists — decide whether Chaos skins ride that channel.
+5. **No chaos-specific gen script exists** (`gen_locked_chaos*.py`); the 9 bubbles were made
+   ad-hoc. A dedicated script (boon/curse/upgrade/fx batches, fixed seeds, staging output) is
+   the natural next build step — out of scope for this planning pass.

--- a/ConditioningControlPanel/docs/chaos/planning/E-flavour.md
+++ b/ConditioningControlPanel/docs/chaos/planning/E-flavour.md
@@ -1,0 +1,200 @@
+# Agent E — Chaos Mode Flavour & Skinnability Plan
+
+> Scope: research + proposal only. No code changes. Engine is flavour-agnostic; base ships neutral-usable; each niche is a **content-only** per-mod skin (field-level merge), same philosophy as bark skins + `textReplacements`.
+
+---
+
+## 1. Current State (code is source of truth)
+
+### How the mod system already does flavour (the pattern to copy)
+`Services/ModService.cs` resolves every flavour field with a strict **fallback chain: `ActiveMod → BaseMod (CCP Default)`**:
+
+- `GetValue<T>` / `GetStringValue` — field-level merge. An unset field on the active mod falls back to the base mod's value (`ModService.cs:619-631`). *This is the invariant we want for Chaos: unset → neutral base.*
+- `MakeModAware(text)` — applies `TextReplacements` (a flat `Dictionary<string,string>`), **longest-key-first** to avoid partial matches (`ModService.cs:850-865`).
+- `GetPhrases(category)` — `Phrases` is `Dictionary<string,string[]>`, category → pool, with base fallback (`ModService.cs:808-826`).
+- Enhancement labels show the **two-tier pattern** worth reusing: explicit override field first, else `MakeModAware(neutralDefault)` (`ModService.cs:902-936`). E.g. `GetPinkRushName() => EnhancementOverrides?.PinkRushName ?? MakeModAware("PINK RUSH!")`.
+- Art/sound override by file presence: `ModResourceResolver` checks `{mod}/resources/...` then falls back to embedded `pack://` (`ModResourceResolver.cs`). **Agent D's lane.**
+- Voicelines already per-mod: `Resources/sounds/companion_audio/mods/{modId}/bark_rules.json` (content-only; no engine code touched). **Already done.**
+
+Manifest identity fields already in `Models/ModManifest.cs`: `Identity.{CompanionName,UserTerm,ModeDisplayName,Affirmation,RankSubject,...}`, `Theme.*`, `Phrases`, `TextReplacements`, `EnhancementOverrides.*`, etc. Built-ins defined in `Models/BuiltInMods.cs` (CCP Default = neutral baseline at `CreateCCPDefault()`).
+
+### Hardcoded Chaos flavour strings (the gap)
+None of these read the manifest today — all are English string literals in `Services/Chaos/`:
+
+| Surface | Location | Current (hardcoded) values |
+|---|---|---|
+| Currency name | `ChaosUpgrades.cs:19` (comment "in Sparks"), `ChaosMeta.AwardRunRewards`, UI/results | **"Sparks"** |
+| Boon/curse Name+Desc | `ChaosModels.cs:113-133` (`ChaosBoonPool.All`) | "Slow Fuses / +30% fuse time…", "Hair Trigger", "Live Wire", etc. |
+| Bubble labels (glyphs) + names | `ChaosBubbleVariants.cs:158-181` (`.Label`, `.Name`) | "Flash", "Pink Filter", "Spiral", "BrainDrain", "Freeze"… + glyphs ◑ ◎ ☁ ❄ |
+| Codex blurbs | `ChaosBubbleVariants.cs:133-145` (`DescriptionFor`) | "A benign treat. Pop it for a quick flash burst…" |
+| Upgrade names | `ChaosUpgrades.cs:50-77` (`.Name`) | "+1 Start Shield", "Slower Fuses", "Golden Touch"… |
+| Rank names | `ChaosUpgrades.cs:103-111` (`ChaosMeta.Rank`) | Newcomer → Dabbler → Novice → Initiate → Adept → Paragon |
+| HUD copy | `ChaosModels.cs:196` (`ActWaveText`) | "ACT I · WAVE 1/5" |
+| Results flavour | `ChaosModeService.cs:476` `_overlay.ShowResults(...)` | (numeric; flavour line TBD) |
+| Presets | `ChaosBubbleVariants.cs:150-156` | "Balanced", "Tease", "Overload", "Flash-only" |
+
+> Note: `ChaosBoon` / `ChaosBubbleVariant` / `ChaosUpgrade` are **static pools with embedded `Action<...>` mutators** (the mechanic). Skinning must touch **only display strings**, never the `Apply` lambdas or numeric knobs — that keeps the engine mod-agnostic and the mechanic identical across skins.
+
+---
+
+## 2. Proposal
+
+### 2a. The NEUTRAL BASE flavour (CCP Default)
+Alluring + conditioning-themed but **persona-neutral** (no Bambi/sissy/drone vocabulary; usable as-is). The neutral base lives in code as the literal default that the resolver returns when no manifest override exists — so today's behaviour is byte-for-byte unchanged.
+
+| Surface | Neutral base (CCP Default) |
+|---|---|
+| Currency | **Sparks** (keep — already neutral & evocative) |
+| Run/HUD frame | **"ACT {N} · WAVE {w}/{W}"** (keep) |
+| Rank ladder | Newcomer · Dabbler · Novice · Initiate · Adept · **Paragon** (keep — neutral progression) |
+| Boon: `slow_fuses` | **"Slow Fuses"** — "+30% fuse time on live bubbles." |
+| Boon: `golden_touch` | **"Golden Touch"** — "+15% run multiplier outright." |
+| Curse: `hair_trigger` | **"Hair Trigger"** — "−25% fuse time, but +0.4x run multiplier." |
+| Bubble: `pink` | name **"Pink Filter"**, codex "Live. Defuse before the fuse runs out, or it snaps a pink filter over the screen." |
+| Bubble: `braindrain` | name **"BrainDrain"**, codex "Live and large. Detonates into a creeping mind-mist." |
+| Results title | **"RUN COMPLETE"** + neutral line e.g. *"You held it together. Banked {n} Sparks."* |
+
+### 2b. Skinnable surface map
+
+| Surface | Skinnable? | Mechanism |
+|---|---|---|
+| Currency name | Yes | New `chaos.currencyName` (dedicated block — single global term, not a search/replace) |
+| Boon/curse Name + Desc | Yes | `chaos.boons[id].{name,desc}` keyed by **stable boon id** |
+| Curse Name + Desc | Yes | same `chaos.boons[id]` map (curses share the id space) |
+| Bubble names | Yes | `chaos.bubbles[id].name` keyed by variant id |
+| Bubble codex blurbs | Yes | `chaos.bubbles[id].codex` |
+| Bubble glyph/label | Optional | `chaos.bubbles[id].label` (usually leave to base; art is Agent D) |
+| Upgrade names | Yes | `chaos.upgrades[id].name` keyed by upgrade id |
+| Rank names | Yes | `chaos.ranks` (ordered array, lowest→highest; index-mapped) |
+| HUD act/wave copy | Yes | `chaos.hud.{actLabel,waveLabel}` format strings w/ `{n}` `{w}` `{W}` |
+| Results flavour | Yes | `chaos.results.{title,line}` (or `Phrases["chaos.results"]` pool for variety) |
+| Presets | Optional | `chaos.presets[name]` display rename via `TextReplacements` is enough |
+| Voicelines | **Already done** | per-mod `bark_rules.json` (no change) |
+| Art/sfx | **Agent D** | `ModResourceResolver` file presence |
+
+**Mechanism rule of thumb:**
+- **Dedicated `chaos` block** for *structured, id-keyed* content (boons, bubbles, upgrades, ranks) — cleaner than fragile global `.Replace`, and id-keying survives copy edits to the base English.
+- **`TextReplacements`** for *incidental* one-off renames that also appear elsewhere (e.g. "Pink Filter" → "Cloud Filter" if the persona already remaps "Pink"). Field-level, longest-first, already wired.
+- **`Phrases`** for *pools needing variety* (results lines) — reuses `GetPhrases(category)`.
+
+### 2c. Manifest schema additions
+Add one optional block. **Every field optional → unset falls back to neutral base** (matches `GetValue`/`GetStringValue` invariant). Keyed by **stable engine ids** (`slow_fuses`, `pink`, `start_shield`, …) so reskins survive base-copy edits.
+
+```jsonc
+// mod.json — new optional top-level "chaos" block
+"chaos": {
+  "currencyName": "Sparks",                 // overrides "Sparks" everywhere
+  "hud": {
+    "actLabel": "ACT {n}",                   // {n}=roman act
+    "waveLabel": "WAVE {w}/{W}"              // {w}=wave, {W}=count
+  },
+  "ranks": ["Newcomer","Dabbler","Novice","Initiate","Adept","Paragon"], // low→high
+  "results": {
+    "title": "RUN COMPLETE",
+    "line": "You held it together. Banked {sparks} {currency}."
+  },
+  "boons": {
+    "slow_fuses":   { "name": "Slow Fuses",   "desc": "+30% fuse time on live bubbles." },
+    "hair_trigger": { "name": "Hair Trigger", "desc": "−25% fuse time, but +0.4x run multiplier." }
+  },
+  "bubbles": {
+    "pink":       { "name": "Pink Filter", "codex": "Live. Defuse it or it snaps a pink filter over the screen.", "label": "◑" },
+    "braindrain": { "name": "BrainDrain",  "codex": "Live and large. Detonates into a creeping mind-mist." }
+  },
+  "upgrades": {
+    "start_shield": { "name": "+1 Start Shield" },
+    "golden_touch": { "name": "Golden Touch" }
+  }
+}
+```
+
+**ModManifest.cs C# additions (mirrors existing optional-section style):**
+
+```csharp
+[JsonProperty("chaos")] public ModChaos? Chaos { get; set; }
+
+public class ModChaos {
+    [JsonProperty("currencyName")] public string? CurrencyName { get; set; }
+    [JsonProperty("hud")]          public ModChaosHud? Hud { get; set; }
+    [JsonProperty("ranks")]        public List<string>? Ranks { get; set; }
+    [JsonProperty("results")]      public ModChaosResults? Results { get; set; }
+    [JsonProperty("boons")]        public Dictionary<string, ModChaosEntry>? Boons { get; set; }
+    [JsonProperty("bubbles")]      public Dictionary<string, ModChaosBubble>? Bubbles { get; set; }
+    [JsonProperty("upgrades")]     public Dictionary<string, ModChaosEntry>? Upgrades { get; set; }
+}
+public class ModChaosHud     { public string? ActLabel; public string? WaveLabel; } // [JsonProperty] each
+public class ModChaosResults { public string? Title; public string? Line; }
+public class ModChaosEntry   { public string? Name; public string? Desc; }
+public class ModChaosBubble  { public string? Name; public string? Codex; public string? Label; }
+```
+
+Add length/count caps in `ModService.SanitizeManifest` exactly like the existing `EnhancementOverrides`/`TextReplacements` caps (e.g. ≤30 entries per dict, ≤500 chars per value, ≤12 ranks).
+
+### 2d. Base-vs-skin examples (two personas)
+
+Same surfaces, neutral base then per-persona override JSON.
+
+| Surface | Base (CCP Default) | Bambi override | Drone override |
+|---|---|---|---|
+| Currency | Sparks | Sparkles | Credits |
+| Boon `golden_touch` | "Golden Touch" — "+15% run multiplier outright." | "Bimbo Luck" — "everything pays +15% more, good girl~" | "GOLD.PROTOCOL" — "+15% yield. Optimal." |
+| Curse `hair_trigger` | "Hair Trigger" — "−25% fuse time, but +0.4x run multiplier." | "Dumb & Fast" — "−25% fuse… but who needs to think? +0.4x" | "OVERCLOCK.RISK" — "−25% fuse window; +0.4x throughput." |
+| Rank (top) | Paragon | Perfect Doll | TERMINAL.ADMIN |
+| Results line | "You held it together. Banked {sparks} Sparks." | "good girl~ you banked {sparks} sparkles 💕" | "RUN COMPLETE. {sparks} credits archived." |
+
+**Bambi** (`mods/builtin-bambisleep/mod.json`):
+```jsonc
+"chaos": {
+  "currencyName": "Sparkles",
+  "ranks": ["New Toy","Dizzy","Pink Pupil","Bimbo","Bambi Doll","Perfect Doll"],
+  "results": { "line": "good girl~ you banked {sparks} sparkles 💕" },
+  "boons": {
+    "golden_touch": { "name": "Bimbo Luck", "desc": "everything pays +15% more, good girl~" }
+  },
+  "boonsCurses_example_hair_trigger": null,
+  "bubbles": { "braindrain": { "name": "Brain Melt", "codex": "big, slow, dreamy… let it pop and float away~" } }
+}
+```
+
+**Drone** (`mods/builtin-drone/mod.json`):
+```jsonc
+"chaos": {
+  "currencyName": "Credits",
+  "hud": { "actLabel": "PHASE {n}", "waveLabel": "CYCLE {w}/{W}" },
+  "ranks": ["Blank Unit","Booting","Standard Unit","Calibrated","Optimized","Terminal Admin"],
+  "results": { "title": "RUN COMPLETE", "line": "{sparks} credits archived. Compliance logged." },
+  "boons": {
+    "golden_touch": { "name": "GOLD.PROTOCOL", "desc": "+15% yield. Optimal." }
+  },
+  "bubbles": { "pink": { "name": "Filter.exe", "codex": "Live process. Terminate it or it overlays the display." } }
+}
+```
+*(Unset ids — e.g. Bambi never naming `start_shield` — fall through to neutral base. Field-level merge, exactly like `EnhancementOverrides`.)*
+
+---
+
+## 3. Engine Refactor Implied (flag the seam only — do NOT design code)
+
+**The seam:** introduce a thin `ChaosFlavor` resolver (read-only facade over `App.Mods`) that every Chaos display site calls *instead of* reading the hardcoded literal. Conceptually identical to `ModService.GetPinkRushName()`'s pattern: **`manifest override ?? neutral base literal`** (optionally `?? MakeModAware(base)` so `TextReplacements` still catches incidental terms).
+
+Touch points to reroute (display only — never the `Apply`/numeric fields):
+- `ChaosBoonPool.All[*].{Name,Desc}` → resolve by boon `Id` at *display* time (keep pool records as the mechanic + neutral default).
+- `ChaosBubbleVariants` `.Name` / `.Label` / `DescriptionFor(id)` → resolve by variant `Id`.
+- `ChaosUpgrades.All[*].Name` → resolve by upgrade `Id`.
+- `ChaosMeta.Rank` → map `RunsCompleted` thresholds to an index into resolved `ranks[]` (neutral list is the default).
+- `ChaosRunState.ActWaveText` → format from resolved `hud` labels.
+- `ChaosModeService.ShowResults` → resolved `results.title/line` with `{sparks}`/`{currency}` tokens.
+- Every "Sparks" literal → resolved `currencyName`.
+
+**The invariant (must hold):** with **no** mod / CCP Default active and **no** `chaos` block present, the resolver returns the exact current English literals → **neutral default is byte-for-byte unchanged**, same guarantee the run-config knobs already document ("an unmodified run is byte-for-byte unchanged", `ChaosModels.cs:40`). The resolver is the *only* new code path; pools/lambdas stay put.
+
+---
+
+## 4. Open Questions
+
+1. **Currency: global vs textReplacements?** Proposal uses dedicated `chaos.currencyName` because "Sparks" is one canonical term shown formatted with counts (`{sparks}`); a global `.Replace("Sparks", …)` would be brittle and could hit unrelated copy. Confirm OK.
+2. **Rank mapping:** ranks are threshold-keyed in code (`>=100 Paragon`…). Index-mapping a flat `ranks[]` assumes the **same 6 thresholds**. If a skin wants different rank *count*, do we expose thresholds too, or lock to 6 tiers? (Recommend: lock to 6 for v1.)
+3. **Results variety:** single `results.line` vs a `Phrases["chaos.results"]` pool (reuses `GetPhrases`, gives the companion-style randomness). Pool is cheap — worth it?
+4. **Token grammar:** standardize placeholders (`{sparks}`,`{currency}`,`{n}`,`{w}`,`{W}`) — confirm naming before authors write skins (changing later breaks shipped mods).
+5. **Glyph labels:** leave bubble glyphs (◑ ◎ ☁ ❄) base-only, or expose `bubbles[id].label`? They double as fallback art if Agent D's sprite is missing — coordinate with Agent D so we don't skin the same surface twice.
+6. **Where do built-in skins live?** Identity/theme are in `BuiltInMods.cs` (code); but Drone already ships as a bundled `.ccpmod` (`drone-mode.ccpmod`, `ModService.cs:1129`). New `chaos` blocks for built-ins should go in whichever is authoritative per mod (code for Bambi/Sissy/CCP Default; the `.ccpmod` manifest for Drone). Confirm.

--- a/ConditioningControlPanel/docs/chaos/planning/F-systems.md
+++ b/ConditioningControlPanel/docs/chaos/planning/F-systems.md
@@ -1,0 +1,258 @@
+# Agent F — Chaos Mode: Retention Systems + Intensity-Reactive Music
+
+Exploration & planning only. Code is source of truth; verified against the files below.
+Scope: ADDITIVE retention systems that plug into existing gamification infra, plus a
+dynamic music layer. No new generic event bus, no fork of the gamification stack.
+
+## Files inspected (ground truth)
+
+- `Services/Chaos/ChaosModeService.cs` — run lifecycle. `RunTick`/`SpawnTick` @ 250ms/~800ms;
+  `_state.RunIntensity = elapsed/duration`; `BeginRun()`, `EndRun()` (payout: `App.Progression.AddXP`
+  + `ChaosMeta.AwardRunRewards`), `ToggleManualPause()`, `ActivateSlowMo`/`Freeze`. SFX hooked at
+  `BeginWaveTransition` (`ChaosSfx.PlayWaveClear`) and inside `ChaosOverlayWindow`'s draft. Already
+  calls `App.Achievements?.TrackBubblePopped()` directly and `App.Bark?.NotifyChaos*`.
+- `Services/Chaos/ChaosSfx.cs` — one-shot NAudio, `PlayFirstAvailable(candidates[], scale)` resolving
+  override→fallback via `ModResourceResolver.ResolveAudioPath`, `App.Audio.ApplyPreferredDevice`,
+  `MasterVolume` scaling. Cues: `PlayWaveClear`, `PlayBoonReveal(isRare)`, `PlayBoonPicked`.
+- `Services/Chaos/ChaosMetaState.cs` / `ChaosUpgrades.cs` (`ChaosMeta` facade) — Sparks,
+  PurchasedUpgrades, EquippedStartBoon, DiscoveredCodexIds, RunsCompleted/BestScore/BestCombo/
+  TotalDefused; hub unlocks `UNLOCK_*_RUNS`; `AwardRunRewards(run)`, `EquipStartBoon`, `TryPurchase`.
+- `Services/Chaos/ChaosBubbleVariants.cs` — **single `private static readonly Random _rng = new()`**
+  used by `Pick`, `Build`, `RollDarter`, `BuildDarter`. This is the only RNG to seed for a daily run.
+- `Services/LeaderboardService.cs` — server-backed board via `codebambi-proxy` `/v3/leaderboard`,
+  sorts on server-side fields (`xp`, `level`, `total_bubbles_popped`, `total_flashes`,
+  `total_video_minutes`, `total_lock_cards_completed`). `YourRank`/`YourTotal`, `GetPlayerPercentile()`,
+  `SeasonRecapService.SampleRank` fed on monthly refresh. New metrics require **server schema work**.
+- `Services/SeasonRecapService.cs` (+ `Models/SeasonRecap.cs`, `ViewModels/SeasonRecapViewModel.cs`)
+  — static, local-only counters on `AppSettings`; `TrackFeature(key)` is the engagement seam
+  (called from `SessionEngine` per enabled feature); `CaptureAndRollover` snapshots before clearing;
+  `SeasonFeatureKeys` enumerates feature tiles (`FeaturesTotal`).
+- `Services/QuestService.cs` + `Models/Quest.cs` — daily/weekly from `QuestDefinitionService`
+  (server) with embedded fallback; `QuestCategory { Flash, Video, Spiral, PinkFilter, Bubbles,
+  LockCard, Session, Streak, BubbleCount, Mantra, Combined }`; `Track*` methods bump a category;
+  `ParseCategory` maps server strings → category. **No Chaos category exists.**
+- `Services/AchievementService.cs` + `GamificationBridge.cs` — bridge SUBSCRIBES to module events and
+  calls `Progress.<counter>++ → MarkDirty() → TryUnlock/TryUnlockExclusive`. Guardrail: this bridge is
+  the ONLY place new wiring lives; modules raise EMIT events, the bridge consumes them.
+- `Services/AudioService.cs` — `CreateWaveOut()` / `ApplyPreferredDevice(WaveOutEvent|MediaPlayer)`
+  (preferred device), `Duck(strength)`/`Unduck(gen)`/`ForceUnduck()` (ref-counted ducking + watchdog),
+  `DuckGeneration`, `MasterVolume` on settings. No existing looping/music player anywhere.
+- `Services/BarkService.cs` — `NotifyChaos*` raise bark events (`ChaosRunStarted`, `ChaosWaveEscalated`,
+  `ChaosBoonPicked`, `ChaosComboMilestone`, `ChaosRunCompleted`, …). This is a separate consumer from
+  the gamification bridge but the same emit pattern.
+
+### Key gap found
+Chaos currently feeds gamification by calling `App.Achievements?.TrackBubblePopped()` **directly**
+inside `OnBenignPopped/OnDefused/OnDarterCaught/OnFreezeCaught` — which is the kind of direct Track*
+call the bridge guardrail forbids elsewhere. For the new systems we should add **Chaos EMIT events**
+(mirroring the Bark `NotifyChaos*` shape) and have `GamificationBridge` subscribe, rather than adding
+more direct `Track*`/`TryUnlock` calls in `ChaosModeService`. (Pre-existing direct calls can stay;
+don't expand them.)
+
+---
+
+## 1. Proposed additive systems
+
+### A. Daily SEEDED run / Daily Challenge
+- **What:** one fixed daily seed → everyone gets the same spawn sequence, sizes, darter rolls, and
+  draft offers. One scored attempt/day (or best-of, replayable but only first scores the board).
+  A fixed config preset (difficulty/duration/variants) shipped per day or derived from the seed.
+- **Plug-in / seam:**
+  - **RNG seeding (the real work):** replace the single `ChaosBubbleVariants._rng` with an injectable
+    `Random`. Thread a seed from `ChaosRunConfig` (e.g. `Config.Seed`) into `Pick/Build/RollDarter/
+    BuildDarter`. Because all four share `_rng`, this is one chokepoint — but it is *static state*, so
+    a daily run must set the seed at `StartRun`/`BeginRun` and restore the default (re-`new()`) at
+    `EndRun`/`ForceShutdown` so ambient/normal runs stay non-deterministic. Seed = hash of
+    `yyyy-MM-dd` (UTC) so all clients agree without a server. Also confirm no *other* nondeterminism
+    leaks in (bubble spawn positions / motion live in `BubbleService` — audit those for `Random` and
+    seed or accept as visual-only jitter that doesn't affect score).
+  - Daily config lives in `ChaosMeta`/a small `ChaosDailyState` (last-played date, today's score) so
+    "already played today" survives restart.
+  - Reward: bonus Sparks via `ChaosMeta.AwardRunRewards` path; XP via existing capped `AddXP`.
+- **Build cost:** Medium (seed threading + static-state save/restore + a "play daily" entry + dedupe).
+- **Retention impact:** High — daily reason to open the app; pairs with the leaderboard (below).
+
+### B. Chaos Leaderboard
+- **What:** a board ranking Chaos performance, ideally scoped to the **daily seed** (fair, comparable)
+  with an all-time/season Chaos-best fallback.
+- **Plug-in / seam:** `LeaderboardService` is server-backed and sorts on server columns. Two options:
+  - **Cheap (client-only, now):** reuse the existing board — Chaos XP already flows into total XP via
+    `AddXP`, so Chaos lifts your existing `xp`/`level` rank for free; surface `ChaosMetaState.BestScore`
+    locally and via `SeasonRecap`. No server change.
+  - **Proper (server work):** add a `chaos_daily` / `chaos_best` sorted set + a new `sort_by` value and
+    `your_rank` plumbing in `/v3/leaderboard`. Score metric = **daily seeded run score** (deterministic
+    seed makes scores comparable; that's the whole point of A).
+- **Anti-cheat note:** scores are client-reported (the proxy trusts the client today). The daily seed
+  is the cheapest integrity lever — a server that knows the seed can sanity-cap an implausible score
+  (e.g. > theoretical max for that seed's spawn budget) and rate-limit one submission/seed/user.
+  Without server validation, treat the board as "for fun," matching the current trust model.
+- **Build cost:** Low (reuse existing XP board) → High (dedicated server set + validation).
+- **Retention impact:** High (with daily seed) — competition is the retention multiplier; Low-Med if
+  just "Chaos lifts your XP rank."
+
+### C. Season integration (does Chaos feed SeasonRecap?)
+- **What:** Chaos shows up on the end-of-month recap card: runs completed, best score, Sparks earned,
+  best combo this season; and Chaos counts as an engaged feature.
+- **Plug-in / seam:** `SeasonRecapService.TrackFeature(SeasonFeatureKeys.<Chaos>)` from `BeginRun`
+  (add a `Chaos` key to `SeasonFeatureKeys` in `Models/SeasonRecap.cs`, bumps `FeaturesTotal`). For
+  numeric stats, add season counters on `AppSettings` (`SeasonChaosRuns`, `SeasonChaosBestScore`)
+  mutated in `EndRun`, snapshotted in `BuildSnapshot`, cleared in `RollBucket`, surfaced in
+  `SeasonRecapViewModel`/the recap control. `SampleRank` already covers the season peak rank if Chaos
+  ever rides the XP board (B-cheap).
+- **Build cost:** Low-Medium (1 feature key wired free; numeric stats touch ~4 files in the recap chain).
+- **Retention impact:** Medium — reinforces the monthly loop, but only visible once/month.
+
+### D. Chaos quests / achievements (via GamificationBridge)
+- **What:** dailies/weeklies and one-off achievements that reward playing Chaos.
+- **Plug-in / seam:** add **Chaos EMIT events** on a Chaos surface (e.g. `ChaosModeService.RunCompleted`
+  / `BubbleDefusedInRun` events, or reuse the Bark `NotifyChaos*` shape) and subscribe in
+  `GamificationBridge.Start()` exactly like `QuizService.QuizCompleted`. The bridge then bumps
+  `AchievementProgress` counters → `MarkDirty()` → `TryUnlock(...)` and calls the Quest tracker.
+  - **Quests:** add `QuestCategory.Chaos` to `Models/Quest.cs` (enum + `ParseCategory "chaos"` case) and
+    a `QuestService.TrackChaosRun()` / `TrackChaosDefuse()` calling `UpdateQuestProgress(QuestCategory.Chaos, n)`.
+    Quest *definitions* are server-driven (`QuestDefinitionService`) with embedded fallback, so new
+    Chaos dailies can ship server-side once the category exists. Example defs: "Defuse 25 bubbles in
+    Chaos" (daily), "Complete 5 Chaos runs" (weekly), "Reach a x20 combo in Chaos" (weekly).
+  - **Achievements (concrete, wired in the bridge):**
+    - `chaos_initiate` — complete your first Chaos run (on `RunCompleted`).
+    - `chaos_untouchable` — finish a run with zero unshielded detonations (run payload carries the count).
+    - `chaos_combo_lord` — hit a x50 combo in a single run (`ChaosComboMilestone`/run best).
+    - `chaos_paragon` — 100 runs completed (mirror `ChaosMeta.Rank` "Paragon"; bridge reads `RunsCompleted`).
+    - `chaos_perfect_daily` — top-1% on the daily seed (needs B-proper; otherwise park as `IsHidden`).
+  - Note the **guardrail correction:** prefer routing these through bridge subscriptions to new Chaos
+    events rather than adding more direct `App.Achievements.Track*` calls in `ChaosModeService`.
+- **Build cost:** Medium (events + bridge handlers + `QuestCategory.Chaos` + achievement defs/loc/art).
+- **Retention impact:** High — quests are the proven daily-engagement driver and reuse all existing UI.
+
+### E. Loadout expansion (as the boon pool grows)
+- **What:** today Loadout equips ONE start boon (`EquippedStartBoon`). As `ChaosBoonPool` grows, expand
+  to a small curated loadout: a 2nd start-boon slot, or a "ban one curse" / "guarantee a rare in draft 1"
+  slot — gated behind more lifetime runs or a Sparks purchase.
+- **Plug-in / seam:** `ChaosMetaState` (add `EquippedStartBoon2` / `BannedCurseId`), `ChaosMeta`
+  facade methods (mirror `EquipStartBoon`), applied in `BeginRun` next to the existing equipped-boon
+  block; gate via `UNLOCK_*_RUNS`-style threshold or a `ChaosUpgrades` row.
+- **Build cost:** Low (extends an existing, well-factored slot).
+- **Retention impact:** Medium — deepens the meta build-craft for engaged players; low reach for new ones.
+
+### F. Weekly run MUTATOR (modifier)
+- **What:** a rotating weekly global modifier ("this week: all fuses −25%", "double darters",
+  "every wave-1 bubble is live", "×1.5 Sparks but ×2 detonation cost") that reshapes every run that week.
+- **Plug-in / seam:** weekly modifier id derived from the ISO week (deterministic, no server needed) or
+  delivered by `QuestDefinitionService`-style remote config; applied at `StartRun` by mutating the
+  freshly-built `ChaosRunConfig` (exactly the `ChaosMeta.ApplyTo(config)` pattern — a `ChaosMutators.ApplyWeekly(config)`).
+  Pairs naturally with the weekly quest and the leaderboard's weekly scope.
+- **Build cost:** Low-Medium (config mutators + a tiny weekly-id resolver + HUD label).
+- **Retention impact:** Medium-High — cheap, reuses the config-mutation seam, and gives a weekly "what's
+  the rule this week" hook; strongest when combined with B/D.
+
+---
+
+## 2. AUDIO — intensity-reactive music layer
+
+### Current state
+No music/looping player exists. `ChaosSfx` is one-shot fire-and-forget NAudio; `AudioService` owns
+ducking + preferred-device resolution + `MasterVolume`. `RunIntensity` (0→1) ticks every 250ms in
+`RunTick` and is the natural escalation driver. Power-up state (`_slowMoRemainingSec`,
+`_freezeRemainingSec`, `_manualPaused`) is all in `ChaosModeService`.
+
+### Design: `ChaosMusic` (new static/instance service in `Services/Chaos/`)
+A small layered-loop player, sibling to `ChaosSfx`, owning its own `WaveOutEvent`(s).
+
+- **Where it hooks:**
+  - Lifecycle driven from `ChaosModeService`: `ChaosMusic.Begin(seed?)` in `BeginRun`,
+    `ChaosMusic.SetIntensity(_state.RunIntensity)` once per `RunTick`, `ChaosMusic.Stop()` in `EndRun`
+    and `ForceShutdown`. Pause/freeze/slow-mo map to filter/tempo shifts (below) from the existing
+    `ToggleManualPause`, `ActivateFreeze/EndFreeze`, `ActivateSlowMo/EndSlowMo`.
+  - **Device + volume:** create the loop device via `App.Audio.CreateWaveOut()` (or
+    `ApplyPreferredDevice(waveOut)` before `Init`) so it honors the user's chosen output device, exactly
+    like `ChaosSfx`. Volume = `MasterVolume/100 * musicScale`, re-read so the master slider works live.
+  - **Ducking relationship:** music is CCP's own output, so it must NOT be ducked by `AudioService.Duck`
+    (Duck only touches *other* processes' sessions — our own PID is skipped, so this is automatic).
+    Conversely, when a Chaos bubble payload fires a mandatory video/whisper, consider having `ChaosMusic`
+    self-duck (drop its own gain ~40%) so the music sits under the payload — a local gain change, not a
+    call into `AudioService.Duck`. `ChaosSfx` one-shots already ride over the music fine at their scales.
+
+- **Stem / loop structure + resolver convention (mod-skinnable, mirror ChaosSfx):**
+  - Layered stems under `Resources/sounds/chaos/music/`, each an independently-looping bar-aligned
+    stem so they can be summed:
+    - `bed.mp3` (always on — pad/drone)
+    - `pulse.mp3` (drums/arp, fades in ~intensity ≥ 0.33)
+    - `lead.mp3` (melodic/aggressive layer, fades in ~intensity ≥ 0.66)
+    - optional `climax.mp3` (final-act sting, ~intensity ≥ 0.9)
+  - Resolve each with the **same override→fallback candidate-list pattern** as `ChaosSfx`:
+    `ResolveAudioPath("chaos/music/bed.mp3")` → fallback to a bundled ambient if absent. Drop dedicated
+    files and they win automatically; active mods can override via `ModResourceResolver`.
+  - Stems are **Suno-generated** at the same BPM/key so summing them is phase-clean. Keep them short
+    (8–16 bars) and seamless-looped.
+
+- **Escalation behavior (driven by `SetIntensity`):**
+  - Crossfade layer gains in at the thresholds above (smooth lerp toward target gain over ~1–2s so it
+    doesn't pop on the 250ms tick).
+  - Optional global low-pass "filter open" as intensity rises (muffled → bright). NAudio can do this with
+    a `BiQuadFilter`/`Lowpass` sample provider on the mixed output; if that's too much for v1, gain-only
+    layering is the MVP and still reads as "escalating."
+  - Tempo shifts: true tempo change is hard with prebaked loops — prefer **swapping to a faster-BPM
+    stem set per Act** (or just adding the `pulse`/`lead` layers) rather than time-stretching.
+
+- **Run-lifecycle transitions (start/stop/crossfade + power-ups):**
+  - **BeginRun:** fade in `bed` from 0 over ~1.5s (after the 3·2·1 countdown, at GO).
+  - **EndRun / ForceShutdown:** fade all layers to 0 over ~1s then dispose (don't hard-cut).
+  - **Manual pause (`ToggleManualPause`):** duck music to a low "held" gain + close the filter (muffled),
+    restore on resume — reinforces the frozen-field feel.
+  - **Freeze power-up:** brief filter sweep / pitch-dip to "icy" for the ~3.5s hold, restore on `EndFreeze`.
+  - **Slow-mo power-up:** drop the filter and/or lower a high layer for the 5s so it feels heavy; restore
+    on `EndSlowMo`. (Don't try to slow the audio tempo — just tonal shift.)
+  - **Wave boundary / boon draft (`_paused`):** dip to the `bed` layer only while the draft overlay is up,
+    swell back when the next wave starts.
+
+- **Fallback when no music files are present (silent, like ChaosArt):**
+  - On `Begin`, resolve each stem; if a stem's candidate list yields nothing on disk, that layer is simply
+    absent. If `bed` (the only required layer) is missing, `ChaosMusic` runs as a no-op — **completely
+    silent, no error, no log spam** — exactly mirroring `ChaosArt`'s "sprite present → use it, else fall
+    back/skip" behavior. Ship the feature with zero bundled music and it's inert until stems are added.
+
+---
+
+## 3. Ranking — retention impact vs build cost
+
+| # | Proposal | Retention | Build cost | Plugs into | Verdict |
+|---|----------|-----------|-----------|------------|---------|
+| A | Daily seeded run | **High** | Medium | `ChaosBubbleVariants._rng` seed + `ChaosMeta` daily state | **DO FIRST** — unlocks B & F |
+| D | Chaos quests/achievements | **High** | Medium | `GamificationBridge` + `QuestCategory.Chaos` | **DO FIRST** — reuses all gamification UI |
+| B-cheap | Chaos lifts XP/level board | Med | Low | existing `AddXP` → `LeaderboardService` (no server) | **DO FIRST** — free, already half-true |
+| Audio | Intensity-reactive music | Med-High | Medium | new `ChaosMusic` + `AudioService` device/MasterVolume | **DO** — big feel/retention per cost, silent fallback de-risks it |
+| C | Season recap integration | Medium | Low-Med | `SeasonRecapService.TrackFeature` + recap chain | **DO** — 1 feature key is nearly free; stats are cheap |
+| F | Weekly mutator | Med-High | Low-Med | `ChaosRunConfig` mutation (`ApplyTo` pattern) | **DO** if A ships (deterministic weekly id) |
+| B-proper | Dedicated Chaos server board | High | **High** | new `/v3/leaderboard` sorted set + anti-cheat | **DEFER** — needs server + validation |
+| E | Loadout expansion | Medium | Low | `ChaosMetaState`/`ChaosMeta` slots | **DEFER** — wait until boon pool is large enough to matter |
+
+### Recommended MINIMUM first set
+1. **A — Daily seeded run** (seed the one shared `_rng`; save/restore the static seed around the run).
+2. **D — Chaos quests/achievements** via `GamificationBridge` + a new `QuestCategory.Chaos` (add Chaos
+   EMIT events; do not expand the direct `Track*` calls).
+3. **B-cheap — Chaos already lifts XP/level rank**; surface `BestScore` locally. No server work.
+4. **Audio — `ChaosMusic`** (gain-only layered Suno stems is an acceptable MVP; silent fallback).
+5. **C — one `SeasonFeatureKeys.Chaos`** track at `BeginRun` (trivial), numeric season stats optional.
+
+This set is fully additive, uses only existing seams (bridge subscriptions, config mutation, the
+ChaosSfx resolver convention, AudioService device/volume), and needs **zero server changes**. F is the
+natural next add once A exists; B-proper and E are the cut candidates.
+
+---
+
+## Open questions
+1. **Static-RNG safety:** `ChaosBubbleVariants._rng` is static. Confirm Chaos runs are never concurrent
+   (they aren't — `StartRun` early-returns if `_active`), so swapping the static seed per-run and
+   restoring it is safe. Audit `BubbleService` for any *score-affecting* `Random` that also needs seeding
+   for a truly fair daily.
+2. **Anti-cheat appetite:** is the leaderboard "for fun" (client-trusted, like today) or do we want the
+   server to validate daily scores against the seed? Determines B-cheap vs B-proper.
+3. **Music authoring:** how many Suno stem sets (one universal vs per-Act vs per-difficulty)? Same
+   BPM/key is required for clean layering — lock that before generating.
+4. **Bridge vs direct calls:** OK to leave the existing direct `App.Achievements.TrackBubblePopped()`
+   calls in `ChaosModeService`, but route all NEW Chaos gamification through bridge subscriptions to new
+   Chaos events? (Recommended, matches the guardrail.)
+5. **Daily reward economy:** how much bonus Sparks/XP for the daily, and does a daily failure still pay
+   the normal run payout? Needs a balance pass against `AwardRunRewards`.
+6. **Filter DSP scope for v1:** ship gain-only layering first and add the low-pass "filter open" later,
+   or invest in the `BiQuadFilter` mixed-output path up front?


### PR DESCRIPTION
## Chaos Mode — Build Pass 1: feel + voice + ambient payloads

Takes Chaos Mode from a working shell toward a tighter, louder loop. Built from the contract in `docs/chaos/planning/` (master plan §1 + A-loop §5 frozen the trigger surface). Three agents worked disjoint file sets in parallel: CODE (C#), BARKS (rule JSON), ART (staging only — not in this PR).

**Base:** `feat/emotive-avatar-portraits`. Unrelated avatar-portrait WIP in the working tree was deliberately kept out of this commit.

### Invariants held
- **No run-math change.** An unmodified run with empty meta is byte-for-byte unchanged. All feel juice is additive visual/audio, gated by the existing ColorFlashes toggle.
- **No new event bus.** Every new trigger fires via the existing `BarkService.Raise(trigger, c => c.Set(...))` seam.
- **Ambient mode is opt-in, OFF by default.** No cold-start gating in this pass (deferred).
- **Start small:** every new magnitude/rate/duration/threshold is a named const or config field with a conservative default.

### CODE
**Feel juice (additive only):** benign-pop pulse, near-miss danger telegraph (~800ms edge-flash + tick), combo micro-build + distinct big-combo beats, shield gain/loss cue, wave-clear pulse, rising heat tint.

**Canonical event surface (new `NotifyChaos*`):** split detonate into `ChaosBubbleDetonated` (unshielded) + `ChaosBubbleDetonatedAbsorbed` (clutch save), both carrying `shield_absorbed`/`run_detonations`/`combo`/`difficulty`; plus `ChaosBenignPopped`, `ChaosCursePicked`, `ChaosBoonSkipped`, `ChaosDarterCaught` (+`quick`), `ChaosFreezeCaught`, `ChaosActChanged`, `ChaosComboBig` (edge-detected 25/50/100), `ChaosWaveCleared`, `ChaosResultsShown` (+PB delta). Act/combo crossings are edge-detected; combo captured before zeroing.

**Loop:** skippable countdown + 1s restart; Quick Start button (bypasses the modal hub); `DraftAutoResumeSec` (default 15) auto-skips an ignored draft and resumes; PB / delta-vs-best on results.

**Free wins:** `COMPLETION_BONUS_BASE` 25→35 + one-time +25 First Spark; new `XPSource.Chaos`; removed the inert `LiveBubbleShare` knob; fixed the `Assets`/`assets` resolver casing.

**Part 2 — ambient payloads:** opt-in `AmbientMode` remaps intrusive (video/htlink) detonations to two new lighter, click-through payloads — `BouncingText` (reuses the existing `App.BouncingText` service, sources the affirmation pool) and `GifCascade` (falling images from the existing flash/braindrain pool). Both registered in `EffectPayloadFactory`.

### BARKS (text-only drafts; `audio` left unset for the later ElevenLabs pass)
- Neutral base pool defines each chaos rule's shape once (priority/cooldown/chance/mood). Honors the no-fallthrough matcher: every intersectional rule (detonate-first, Extreme, payload-specific, combo-about-to-die, PB, etc.) outranks its generic sibling.
- Three persona skins (Bambi / Sissy / Circe-locked), ~65 lines each, resistance↔surrender framing; moods pinned to tokens that resolve in **both** the Circe emote map and the portrait emotion map. House style: no em-dashes.
- Verified: **0 pre-existing non-chaos rules removed or changed** in any skin (large line diffs are JSON reindentation only); 29 chaos rules added per file; all JSON parses.

### Verification
- `dotnet build` of the **chaos-only commit in a clean worktree** (without the avatar WIP) → **0 errors** (272 pre-existing warnings, incl. CA1416).
- CODE/BARKS trigger + ctx-key contract matched on both sides; CODE reported zero contract divergences.

### Not in this PR / follow-ups
- **Art:** `Tools/asset_gen/gen_chaos_assets.py` is written and runnable, but the gen batch was cut short — only 2 boon candidates landed in `_staging`. Needs a re-run to complete boons/curses/branches/upgrades; candidates stay in `_staging` behind the manual review gate (nothing promoted).
- **Deferred (per the plan):** Glow currency, cold-start gating, full non-modal QuickDraft UI, ChaosFlavor resolver, daily seeded run, Chaos quests/achievements + the `TrackBubblePopped` migration, ChaosMusic, leaderboard, season integration, prestige.
- **csproj:** no change needed (`.cs` is default-globbed; the new `ChaosGifCascadeOverlay.cs` compiles). An optional dedicated `near_miss.mp3` SFX can be added later (currently falls back to an existing pop sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
