### PR TITLE
fix(auth): deliver server whitelist to Discord-only users (season-reset lockout)

### DIFF
--- a/ConditioningControlPanel/Models/DiscordModels.cs
+++ b/ConditioningControlPanel/Models/DiscordModels.cs
@@ -110,6 +110,25 @@ namespace ConditioningControlPanel.Models
         public string? AuthToken { get; set; }
 
         /// <summary>
+        /// Server-side whitelist status. Whitelisted Discord-only users get premium
+        /// access (Tier 2) without Patreon OAuth. Delivered here so access does not
+        /// depend on a successful profile sync (which the boot defaults-guard can
+        /// block after a season reset — see #293 / ProfileSyncService).
+        /// </summary>
+        [JsonProperty("is_whitelisted")]
+        [JsonPropertyName("is_whitelisted")]
+        public bool IsWhitelisted { get; set; }
+
+        /// <summary>
+        /// Effective Patreon tier for this user as computed by the server (already
+        /// bumped to 2 for whitelisted users). Informational — access is granted via
+        /// <see cref="IsWhitelisted"/>.
+        /// </summary>
+        [JsonProperty("patreon_tier")]
+        [JsonPropertyName("patreon_tier")]
+        public int PatreonTier { get; set; }
+
+        /// <summary>
         /// Get the display name (global_name if set, otherwise username)
         /// </summary>
         [Newtonsoft.Json.JsonIgnore]
@@ -148,6 +167,13 @@ namespace ConditioningControlPanel.Models
 
         [JsonProperty("custom_display_name")]
         public string? CustomDisplayName { get; set; }
+
+        /// <summary>
+        /// Cached server-side whitelist status, so a cache-hit validate (no network
+        /// call) still grants premium access to whitelisted Discord-only users.
+        /// </summary>
+        [JsonProperty("is_whitelisted")]
+        public bool IsWhitelisted { get; set; }
 
         [JsonProperty("last_verified")]
         public DateTime LastVerified { get; set; }

--- a/ConditioningControlPanel/Services/DiscordService.cs
+++ b/ConditioningControlPanel/Services/DiscordService.cs
@@ -471,6 +471,14 @@ namespace ConditioningControlPanel.Services
                 Avatar = user.Avatar;
                 NeedsRegistration = user.NeedsRegistration;
 
+                // Apply server-side whitelist so whitelisted Discord-only users get
+                // premium access without depending on a successful profile sync.
+                if (user.IsWhitelisted)
+                {
+                    App.Logger?.Information("Discord validate: whitelisted user — granting premium access (server tier {Tier})", user.PatreonTier);
+                }
+                ApplyWhitelistAccess(user.IsWhitelisted);
+
                 // Cache result for 24 hours
                 _tokenStorage.StoreCachedState(new DiscordCachedState
                 {
@@ -478,11 +486,12 @@ namespace ConditioningControlPanel.Services
                     Username = user.Username,
                     GlobalName = user.GlobalName,
                     Avatar = user.Avatar,
+                    IsWhitelisted = user.IsWhitelisted,
                     LastVerified = DateTime.UtcNow,
                     CacheExpiresAt = DateTime.UtcNow.AddHours(CacheHours)
                 });
 
-                App.Logger?.Information("Discord user validated: {Id}, NeedsRegistration={NeedsReg}", UserId, user.NeedsRegistration);
+                App.Logger?.Information("Discord user validated: {Id}, NeedsRegistration={NeedsReg}, Whitelisted={Whitelisted}", UserId, user.NeedsRegistration, user.IsWhitelisted);
             }
             catch (Exception ex)
             {
@@ -539,6 +548,32 @@ namespace ConditioningControlPanel.Services
             DisplayName = cachedState.DisplayName;
             Avatar = cachedState.Avatar;
             CustomDisplayName = cachedState.CustomDisplayName;
+
+            // Re-apply whitelist on a cache-hit so access survives across restarts
+            // without waiting for the next network validate.
+            ApplyWhitelistAccess(cachedState.IsWhitelisted);
+        }
+
+        /// <summary>
+        /// Grant premium/whitelist access for a whitelisted Discord-only user. Applied
+        /// from both the network-validate path and the cache-hit path so Lab access
+        /// does not depend on a successful profile sync (which the boot defaults-guard
+        /// can block after a season reset — see #293 / ProfileSyncService).
+        /// Sticky-true: only ever promote, never demote on a transient false — mirrors
+        /// the server and ProfileSyncService. Removal is admin-only server-side.
+        /// </summary>
+        private static void ApplyWhitelistAccess(bool isWhitelisted)
+        {
+            if (!isWhitelisted) return;
+
+            // Refresh the cached-premium window (25h > the 24h validate cache, so it
+            // self-renews on each network re-validate and survives restarts).
+            if (App.Settings?.Current != null)
+            {
+                App.Settings.Current.PatreonPremiumValidUntil = DateTime.UtcNow.AddHours(25);
+                App.Settings.Save();
+            }
+            App.Patreon?.SetWhitelistStatus(true);
         }
 
         private void ClearUserInfo()

--- a/ConditioningControlPanel/Services/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/ProfileSyncService.cs
@@ -367,8 +367,32 @@ namespace ConditioningControlPanel.Services
                 var user = await v2Auth.GetUserProfileAsync(unifiedId);
                 if (user == null) return false;
 
-                // Server record is itself uninitialized — nothing to adopt (genuine new user).
-                if (user.Level <= 1 && user.Xp <= 0) return false;
+                // Apply server-side whitelist even when level/xp are at season-reset
+                // defaults. The flag normally rides the sync POST response, but the
+                // defaults-guard blocks that POST for season-reset users — leaving
+                // whitelisted Discord-only users with no access. This read-only path is
+                // the safety net. Sticky-true: only ever promote (mirrors the server).
+                if (user.PatreonIsWhitelisted)
+                {
+                    if (settings != null)
+                    {
+                        settings.PatreonPremiumValidUntil = DateTime.UtcNow.AddHours(25);
+                    }
+                    App.Patreon?.SetWhitelistStatus(true);
+                    App.Logger?.Information("Boot heal (#293): whitelisted user — premium access applied via read-only fetch");
+                }
+
+                // Server record is itself at defaults (Level 1 / 0 XP) — no progress to
+                // adopt, but the record EXISTS. Mark the profile loaded (return true) so
+                // the boot defaults-guard releases on the next sync; otherwise a
+                // season-reset (or brand-new) user whose local also looks like defaults
+                // can never push and stays stuck at Level 1 — and never acknowledges
+                // pending server flags like force_skills_reset (#293).
+                if (user.Level <= 1 && user.Xp <= 0)
+                {
+                    App.Settings?.Save();
+                    return true;
+                }
 
                 App.Logger?.Warning("Boot heal (#293): local looked like defaults (Level {LL}, {LX} XP) but server has Level {SL}, {SX} XP — adopting server profile via read-only fetch (no upload).",
                     settings.PlayerLevel, (int)localTotalXp, user.Level, user.Xp);

--- a/ConditioningControlPanel/Services/V2AuthService.cs
+++ b/ConditioningControlPanel/Services/V2AuthService.cs
@@ -141,6 +141,9 @@ namespace ConditioningControlPanel.Services
 
             [JsonProperty("patreon_is_active")]
             public bool PatreonIsActive { get; set; }
+
+            [JsonProperty("patreon_is_whitelisted")]
+            public bool PatreonIsWhitelisted { get; set; }
         }
 
         public class Unlocks


### PR DESCRIPTION
## Problem
Whitelisted **Discord-only** users (no Patreon linked) only received the whitelist flag through the `/v2/user/sync` POST response. After a **season reset**, both their local and server profiles sit at Level 1 / 0 XP, which trips the `SyncProfileAsync` defaults-guard (`!_hasLoadedProfile && PlayerLevel<=1 && totalXp<100`). The guard refuses to POST, so the whitelist never arrives — the user is locked out of the Lab indefinitely, and `force_skills_reset` never acknowledges. The boot-heal also bailed when the server record was at defaults, so `_hasLoadedProfile` never flipped.

Hit live by a real user (Discord-only, whitelisted, post season reset). Mitigated for them with `nudge-xp.mjs` (sets seasonal xp>0 so the heal adopts on next launch); this PR is the permanent fix.

## Fix (client-only — server endpoints already return these fields)
- **`DiscordService` / `DiscordModels`**: read `is_whitelisted` from `/discord/validate` and apply it via a new `ApplyWhitelistAccess` helper on **both** the network-validate and cache-hit paths. A second delivery channel that bypasses the sync deadlock entirely — whitelisted users get access on next launch.
- **`ProfileSyncService.TryHealDefaultsFromServerAsync` / `V2User`**: apply `patreon_is_whitelisted` in the boot heal, and release the `_hasLoadedProfile` guard when an existing server record is at season-reset defaults — so the stuck sync (and pending `force_skills_reset`) unblocks.

## Safety
- **Sticky-true**: only ever promotes whitelist, never demotes on a transient false — mirrors the server and the existing sync-path bridge.
- **No data-loss risk** in the heal change: local is already gated to defaults; we only return-true in the branch where the server is *also* at defaults (nothing higher to overwrite). The take-higher adopt-path is unchanged when the server has real progress.
- No server changes. Builds clean against `main` (0 errors).

## Note
These same 4-file changes also exist (bundled) in `169ea56c` on `feat/rabbit-hole-ux-pass`; identical content, so that branch's eventual merge should reconcile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)