### PR TITLE
fix(flash): guard against unsupported image formats causing ArgumentE…

### DIFF
--- a/ConditioningControlPanel/Services/FlashService.cs
+++ b/ConditioningControlPanel/Services/FlashService.cs
@@ -448,22 +448,10 @@ namespace ConditioningControlPanel.Services
                 // Scale is percentage: 50-250%, stored as 50-250, so divide by 100
                 var scale = (size ?? settings.ImageScale) / 100.0;
 
-                // Load images in parallel on background threads
-                var loadTasks = images.Select(imagePath => LoadImageAsync(imagePath)).ToArray();
-                var results = await Task.WhenAll(loadTasks);
-
-                var loadedImages = new List<LoadedImageData>();
-                foreach (var data in results)
-                {
-                    if (data != null)
-                    {
-                        var monitor = PickMonitor(settings);
-                        var geometry = CalculateGeometry(data.Width, data.Height, monitor, scale);
-                        data.Geometry = geometry;
-                        data.Monitor = monitor;
-                        loadedImages.Add(data);
-                    }
-                }
+                // Load images, retrying with fresh picks if some are corrupted/unsupported,
+                // until we reach the requested count or run out of candidates.
+                var targetCount = amount ?? settings.SimultaneousImages;
+                var loadedImages = await LoadImagesUntilAsync(targetCount);
 
                 if (loadedImages.Count == 0)
                 {
@@ -482,6 +470,48 @@ namespace ConditioningControlPanel.Services
                 App.Logger.Error(ex, "Error loading flash images");
                 _isBusy = false;
             }
+        }
+
+        /// <summary>
+        /// Loads up to <paramref name="targetCount"/> images, retrying with new candidates
+        /// when a file is missing, corrupted, or uses an unsupported codec. Stops when the
+        /// target is reached or no new candidates remain.
+        /// </summary>
+        private async Task<List<LoadedImageData>> LoadImagesUntilAsync(int targetCount)
+        {
+            var loaded = new List<LoadedImageData>(targetCount);
+            var attempted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var settings = App.Settings.Current;
+            var scale = settings.ImageScale / 100.0;
+            int attempts = 0;
+            int maxAttempts = Math.Max(targetCount * 5, 20);
+
+            while (loaded.Count < targetCount && attempts < maxAttempts)
+            {
+                int need = targetCount - loaded.Count;
+                var candidates = GetNextImages(need);
+                if (candidates.Count == 0) break;
+
+                var newCandidates = candidates.Where(c => attempted.Add(c)).ToList();
+                if (newCandidates.Count == 0) break;
+
+                var results = await Task.WhenAll(newCandidates.Select(LoadImageAsync));
+                foreach (var data in results)
+                {
+                    if (data == null) continue;
+                    if (loaded.Count >= targetCount) break;
+
+                    var monitor = PickMonitor(settings);
+                    var geometry = CalculateGeometry(data.Width, data.Height, monitor, scale);
+                    data.Geometry = geometry;
+                    data.Monitor = monitor;
+                    loaded.Add(data);
+                }
+
+                attempts += newCandidates.Count;
+            }
+
+            return loaded;
         }
 
         private async Task<LoadedImageData?> LoadImageAsync(string path)
@@ -521,7 +551,7 @@ namespace ConditioningControlPanel.Services
                     {
                         LoadGifFrames(path, data, decodeMax);
                     }
-                    else if (IsSupportedStaticImageExtension(extension))
+                    else
                     {
                         // Load static image, downscaling to the decode cap if larger.
                         using var bitmap = new System.Drawing.Bitmap(path);
@@ -1619,18 +1649,6 @@ namespace ConditioningControlPanel.Services
 
         #region Media Queue
 
-        /// <summary>
-        /// Extensions that System.Drawing.Common can reliably decode for static images.
-        /// WebP/HEIC/AVIF are excluded because they throw ArgumentException on this runtime.
-        /// </summary>
-        private static readonly HashSet<string> _supportedStaticImageExtensions = new(StringComparer.OrdinalIgnoreCase)
-        {
-            ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".bmp", ".tif", ".tiff"
-        };
-
-        private static bool IsSupportedStaticImageExtension(string extension)
-            => !string.IsNullOrEmpty(extension) && _supportedStaticImageExtensions.Contains(extension);
-
         private List<string> GetNextImages(int count)
         {
             lock (_lockObj)
@@ -1708,7 +1726,7 @@ namespace ConditioningControlPanel.Services
 
             // Load regular images (include common extensions and variants)
             // GetMediaFiles has its own 60-second cache, so this is efficient
-            _imageList = GetMediaFiles(_imagesPath, new[] { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".bmp", ".tif", ".tiff" });
+            _imageList = GetMediaFiles(_imagesPath, new[] { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".webp", ".bmp", ".tif", ".tiff", ".heic", ".avif", ".ico" });
 
             // Load pack images from active packs
             _packImageList = App.ContentPacks?.GetAllActivePackImages() ?? new List<(string, PackFileEntry)>();

--- a/ConditioningControlPanel/Services/FlashService.cs
+++ b/ConditioningControlPanel/Services/FlashService.cs
@@ -511,11 +511,17 @@ namespace ConditioningControlPanel.Services
                     var extension = Path.GetExtension(path).ToLowerInvariant();
                     var data = new LoadedImageData { FilePath = path };
 
+                    if (!File.Exists(path))
+                    {
+                        App.Logger?.Debug("FlashService: image file not found: {Path}", path);
+                        return null;
+                    }
+
                     if (extension == ".gif")
                     {
                         LoadGifFrames(path, data, decodeMax);
                     }
-                    else
+                    else if (IsSupportedStaticImageExtension(extension))
                     {
                         // Load static image, downscaling to the decode cap if larger.
                         using var bitmap = new System.Drawing.Bitmap(path);
@@ -1613,6 +1619,18 @@ namespace ConditioningControlPanel.Services
 
         #region Media Queue
 
+        /// <summary>
+        /// Extensions that System.Drawing.Common can reliably decode for static images.
+        /// WebP/HEIC/AVIF are excluded because they throw ArgumentException on this runtime.
+        /// </summary>
+        private static readonly HashSet<string> _supportedStaticImageExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".bmp", ".tif", ".tiff"
+        };
+
+        private static bool IsSupportedStaticImageExtension(string extension)
+            => !string.IsNullOrEmpty(extension) && _supportedStaticImageExtensions.Contains(extension);
+
         private List<string> GetNextImages(int count)
         {
             lock (_lockObj)
@@ -1690,7 +1708,7 @@ namespace ConditioningControlPanel.Services
 
             // Load regular images (include common extensions and variants)
             // GetMediaFiles has its own 60-second cache, so this is efficient
-            _imageList = GetMediaFiles(_imagesPath, new[] { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".webp", ".bmp", ".tif", ".tiff", ".heic", ".avif" });
+            _imageList = GetMediaFiles(_imagesPath, new[] { ".png", ".jpg", ".jpeg", ".jpe", ".jfif", ".gif", ".bmp", ".tif", ".tiff" });
 
             // Load pack images from active packs
             _packImageList = App.ContentPacks?.GetAllActivePackImages() ?? new List<(string, PackFileEntry)>();

--- a/ConditioningControlPanel/Services/FlashService.cs
+++ b/ConditioningControlPanel/Services/FlashService.cs
@@ -474,8 +474,8 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Loads up to <paramref name="targetCount"/> images, retrying with new candidates
-        /// when a file is missing, corrupted, or uses an unsupported codec. Stops when the
-        /// target is reached or no new candidates remain.
+        /// when a file is missing, corrupted, or uses an unsupported codec. Images are used
+        /// as soon as they decode successfully; slow or broken files do not block the others.
         /// </summary>
         private async Task<List<LoadedImageData>> LoadImagesUntilAsync(int targetCount)
         {
@@ -485,30 +485,46 @@ namespace ConditioningControlPanel.Services
             var scale = settings.ImageScale / 100.0;
             int attempts = 0;
             int maxAttempts = Math.Max(targetCount * 5, 20);
+            var pending = new List<Task<LoadedImageData?>>();
 
             while (loaded.Count < targetCount && attempts < maxAttempts)
             {
                 int need = targetCount - loaded.Count;
-                var candidates = GetNextImages(need);
-                if (candidates.Count == 0) break;
 
-                var newCandidates = candidates.Where(c => attempted.Add(c)).ToList();
-                if (newCandidates.Count == 0) break;
-
-                var results = await Task.WhenAll(newCandidates.Select(LoadImageAsync));
-                foreach (var data in results)
+                // Keep a generous pipeline of decode tasks running.
+                int fetch = Math.Min(Math.Max(need * 3, 3), maxAttempts - attempts - pending.Count);
+                if (fetch > 0)
                 {
-                    if (data == null) continue;
-                    if (loaded.Count >= targetCount) break;
+                    var candidates = GetNextImages(fetch);
+                    if (candidates.Count == 0 && pending.Count == 0) break;
 
+                    var newCandidates = candidates.Where(c => attempted.Add(c)).ToList();
+                    if (newCandidates.Count == 0 && pending.Count == 0) break;
+
+                    pending.AddRange(newCandidates.Select(LoadImageAsync));
+                    attempts += newCandidates.Count;
+                }
+
+                if (pending.Count == 0) break;
+
+                // Use the first image that finishes decoding, whether it succeeds or fails.
+                var completed = await Task.WhenAny(pending);
+                pending.Remove(completed);
+                var data = await completed;
+                if (data != null && loaded.Count < targetCount)
+                {
                     var monitor = PickMonitor(settings);
                     var geometry = CalculateGeometry(data.Width, data.Height, monitor, scale);
                     data.Geometry = geometry;
                     data.Monitor = monitor;
                     loaded.Add(data);
                 }
+            }
 
-                attempts += newCandidates.Count;
+            // Drain any stragglers so unobserved exceptions don't linger.
+            if (pending.Count > 0)
+            {
+                try { await Task.WhenAll(pending); } catch { /* individual tasks are already guarded */ }
             }
 
             return loaded;


### PR DESCRIPTION
This pull request improves the robustness and flexibility of image loading in the `FlashService` by introducing a retry mechanism for loading images, better handling of missing or corrupted files, and expanding supported image formats. The changes ensure that the requested number of images are loaded whenever possible, and failures due to file issues are handled gracefully.

**Robust image loading and error handling:**

* Replaced the previous parallel image loading logic in `LoadAndShowImages` with a call to a new method that retries with fresh image candidates if some files are corrupted or unsupported, ensuring the target number of images is loaded or all candidates are exhausted.
* Added the `LoadImagesUntilAsync` method, which attempts to load up to the requested number of images, skipping over missing, corrupted, or unsupported files and retrying with new candidates until the target is reached or no new candidates remain.
* Improved `LoadImageAsync` to explicitly check for file existence and log a debug message if the file is missing, returning `null` in that case.

**Expanded image format support:**

* Updated the list of supported image extensions in `RefreshImageLists` to include `.ico`, allowing icon files to be loaded as images.Fix bug and improves the reliability of static image loading in the `FlashService`.
This pull request improves the robustness and reliability of the image loading process in the `FlashService` by introducing a retry mechanism for loading images, handling missing files more gracefully, and expanding supported image formats. The changes ensure that the requested number of images are loaded even if some files are missing or corrupted, and that `.ico` files are now supported.

**Image loading robustness and error handling:**
* Added a new method, `LoadImagesUntilAsync`, which attempts to load the requested number of images, retrying with fresh candidates if some are missing, corrupted, or unsupported, and stops when the target is reached or no new candidates remain. This replaces the previous parallel loading logic. [[1]](diffhunk://#diff-e0e2c0aae0cb589289a52bb1632a2495d9648e8e79121c01598755dfb31db23dL451-R454) [[2]](diffhunk://#diff-e0e2c0aae0cb589289a52bb1632a2495d9648e8e79121c01598755dfb31db23dR475-R516)
* Improved error handling in `LoadImageAsync` by checking if the file exists before attempting to load, and logging a debug message if the file is missing.

**Supported image formats:**
* Added `.ico` to the list of supported image file extensions in the image list refresh logic, allowing icon files to be loaded and displayed.