### PR TITLE
fix: crash-log rotation, startup guards, and the v6.2.x freeze cluster

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -42,7 +42,20 @@ namespace ConditioningControlPanel
         private static bool _mutexOwned = false;
         private const string MutexName = "ConditioningControlPanel_SingleInstance_Mutex";
         private const string ShowSignalName = "ConditioningControlPanel_ShowWindow_Signal";
+        // Acknowledgment gate for the single-instance handshake. A second instance sets the
+        // show-signal, then waits on this for the primary to confirm — from its UI thread — that
+        // it actually surfaced a window. A wedged (render-thread deadlock) or headless primary
+        // never runs the dispatcher callback, so it never acks; the second instance then presumes
+        // the primary is dead, kills it, and takes over instead of silently exiting. Without this
+        // ack, a zombie process kept the mutex alive and every relaunch quietly Shutdown()'d,
+        // which is the "app freezes on startup, have to relaunch several times" report.
+        private const string ShowAckSignalName = "ConditioningControlPanel_ShowAck_Signal";
+        // Generous: exceeds a normal cold start so a healthy but still-initializing primary
+        // (whose dispatcher isn't pumping yet) acks in time and is never mistaken for wedged.
+        private const int ShowAckTimeoutMs = 10000;
         private static EventWaitHandle? _showSignal;
+        private static EventWaitHandle? _showAckSignal;
+        private static bool _recoveredFromStaleInstance;
         private SplashScreen? _splash;
         private static Thread? _showSignalThread;
         private readonly TaskCompletionSource _patreonInitDone = new();
@@ -825,26 +838,86 @@ namespace ConditioningControlPanel
             _mutexOwned = createdNew; // Track if we actually own the mutex
             if (!createdNew)
             {
-                // Another instance is already running - signal it to show its window
+                // Another instance holds the single-instance mutex. Ask it to show its window —
+                // but confirm it's actually alive before we bow out. A wedged/headless primary
+                // keeps the mutex forever, and the old "signal then Shutdown()" left every
+                // relaunch a silent no-op until the zombie finally died. Now we wait for an ack
+                // and, if none comes, kill the stale process and take over as primary.
+
+                // Write the "Open with CCP" handoff BEFORE signaling so a live primary can read it.
+                if (_pendingFileOpenAction != null && _pendingFileOpenPath != null)
+                {
+                    try { WriteFileOpenHandoff(_pendingFileOpenAction, _pendingFileOpenPath); } catch { }
+                }
+
+                EventWaitHandle? ackWait = null;
+                try { ackWait = EventWaitHandle.OpenExisting(ShowAckSignalName); } catch { ackWait = null; }
+
+                if (ackWait == null)
+                {
+                    // Primary predates the ack handshake (mid-upgrade) or its kernel objects are
+                    // gone. Preserve the legacy behavior: poke it to show, then exit quietly —
+                    // never kill a process we can't positively identify as wedged.
+                    try
+                    {
+                        var signal = EventWaitHandle.OpenExisting(ShowSignalName);
+                        signal.Set();
+                        signal.Dispose();
+                    }
+                    catch { }
+
+                    splash.Close();
+                    Shutdown();
+                    return;
+                }
+
+                // Clear any stale ack from a prior handshake, poke the primary, then wait for it
+                // to confirm liveness from its UI thread.
+                try { ackWait.Reset(); } catch { }
                 try
                 {
-                    if (_pendingFileOpenAction != null && _pendingFileOpenPath != null)
-                    {
-                        WriteFileOpenHandoff(_pendingFileOpenAction, _pendingFileOpenPath);
-                    }
                     var signal = EventWaitHandle.OpenExisting(ShowSignalName);
                     signal.Set();
                     signal.Dispose();
                 }
                 catch { }
 
-                splash.Close();
-                Shutdown();
-                return;
+                bool acknowledged = false;
+                try { acknowledged = ackWait.WaitOne(ShowAckTimeoutMs); } catch { }
+                try { ackWait.Dispose(); } catch { }
+
+                if (acknowledged)
+                {
+                    // Primary is alive and surfaced its window — nothing more to do.
+                    splash.Close();
+                    Shutdown();
+                    return;
+                }
+
+                // No acknowledgment within the window: the primary is wedged or headless. Kill it
+                // and take over. (Logger isn't up yet here; we record the recovery once it is.)
+                _recoveredFromStaleInstance = true;
+                KillStaleInstances();
+
+                // Claim single-instance ownership now that the zombie is gone. If it died holding
+                // the mutex, WaitOne throws AbandonedMutexException but we DO acquire it.
+                try { if (_mutex!.WaitOne(TimeSpan.FromSeconds(3))) _mutexOwned = true; }
+                catch (AbandonedMutexException) { _mutexOwned = true; }
+                catch { }
+
+                // We kept the parsed _pendingFileOpen* fields and will fulfill them ourselves, so
+                // drop any on-disk handoff to avoid a spurious re-open on a later signal.
+                try { ConsumeFileOpenHandoff(); } catch { }
+
+                // Fall through — this instance is now the primary.
             }
 
-            // Create signal for other instances to request showing our window
+            // Create signal for other instances to request showing our window, plus the ack gate
+            // a second instance waits on to prove this instance's UI thread is responsive.
             _showSignal = new EventWaitHandle(false, EventResetMode.AutoReset, ShowSignalName);
+            // ManualReset: a second instance Reset()s it just before signaling, so a leftover
+            // ack from a prior handshake can't be mistaken for a fresh one.
+            _showAckSignal = new EventWaitHandle(false, EventResetMode.ManualReset, ShowAckSignalName);
             _showSignalThread = new Thread(() =>
             {
                 while (_showSignal != null)
@@ -862,7 +935,8 @@ namespace ConditioningControlPanel
                                 var mainWin = MainWindowRef ?? (MainWindow as MainWindow);
                                 if (mainWin != null)
                                 {
-                                    mainWin.ShowFromTray();
+                                    try { mainWin.ShowFromTray(); }
+                                    catch (Exception ex) { Logger?.Warning(ex, "ShowFromTray failed"); }
                                     var (action, path) = ConsumeFileOpenHandoff();
                                     if (action != null && path != null)
                                     {
@@ -870,6 +944,12 @@ namespace ConditioningControlPanel
                                         catch (Exception ex) { Logger?.Warning(ex, "HandlePendingFileOpen failed"); }
                                     }
                                 }
+
+                                // Reaching here means the UI thread is alive and pumping — ack the
+                                // waiting second instance so it exits instead of killing us. Sent
+                                // even when mainWin is null (still starting): a responsive
+                                // dispatcher is proof enough that we are not wedged.
+                                try { _showAckSignal?.Set(); } catch { }
                             });
                         }
                     }
@@ -925,6 +1005,11 @@ namespace ConditioningControlPanel
             // working-set baseline anchors the chaos OOM telemetry.
             Logger.Information("Application starting v{Version} | workingSet {WS}MB",
                 Services.UpdateService.AppVersion, Environment.WorkingSet / (1024 * 1024));
+
+            // Surface a single-instance takeover (a prior wedged/headless process was killed so
+            // this launch could proceed). Recorded here because Logger isn't up during the handshake.
+            if (_recoveredFromStaleInstance)
+                Logger.Warning("[LIFECYCLE] Previous instance was unresponsive (no show-ack within {Ms}ms) — killed it and took over as primary", ShowAckTimeoutMs);
 
             // If a Rabbit Hole run was live when the process last died, the native vanish left nothing
             // in crash.log — but the chaos sentinel file is still on disk. Report+consume it so the
@@ -1512,6 +1597,49 @@ namespace ConditioningControlPanel
                     Settings.Save();
                 }), System.Windows.Threading.DispatcherPriority.Loaded);
             }
+        }
+
+        // Terminate any OTHER running CCP process that shares our executable path. Called from the
+        // single-instance handshake only after the existing instance failed to acknowledge within
+        // ShowAckTimeoutMs — i.e. it is wedged (render-thread deadlock) or headless and is keeping
+        // the single-instance mutex alive. Matching on the full exe path avoids nuking an unrelated
+        // same-named process or a separate install; ProcessName is a best-effort fallback when the
+        // other process's MainModule can't be read (access denied). Runs before Logger init.
+        private static void KillStaleInstances()
+        {
+            try
+            {
+                int selfId = Environment.ProcessId;
+                string? selfPath = null;
+                try { selfPath = Process.GetCurrentProcess().MainModule?.FileName; } catch { }
+                string selfName = Process.GetCurrentProcess().ProcessName;
+
+                foreach (var proc in Process.GetProcessesByName(selfName))
+                {
+                    try
+                    {
+                        if (proc.Id == selfId) continue;
+
+                        // Prefer an exact executable-path match; fall back to name-only if the
+                        // path is unreadable (e.g. the target is elevated).
+                        bool pathMatches = true;
+                        if (selfPath != null)
+                        {
+                            string? otherPath = null;
+                            try { otherPath = proc.MainModule?.FileName; } catch { otherPath = null; }
+                            if (otherPath != null)
+                                pathMatches = string.Equals(otherPath, selfPath, StringComparison.OrdinalIgnoreCase);
+                        }
+                        if (!pathMatches) continue;
+
+                        proc.Kill();
+                        proc.WaitForExit(5000);
+                    }
+                    catch { /* process may have exited on its own, or we lack rights — skip it */ }
+                    finally { try { proc.Dispose(); } catch { } }
+                }
+            }
+            catch { /* enumeration failed — takeover still proceeds; the mutex re-acquire is best-effort */ }
         }
 
         // Standard WPF "bring to front" sequence. Activate() alone is silently
@@ -2845,6 +2973,11 @@ Application State:
             _showSignal = null;
             signal?.Set(); // Unblock the listener thread
             signal?.Dispose();
+
+            // Dispose the single-instance ack gate
+            var ackSignal = _showAckSignal;
+            _showAckSignal = null;
+            try { ackSignal?.Dispose(); } catch { }
 
             // Release single instance mutex (only if we own it)
             if (_mutexOwned && _mutex != null)

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1006,6 +1006,11 @@ namespace ConditioningControlPanel
             Logger.Information("Application starting v{Version} | workingSet {WS}MB",
                 Services.UpdateService.AppVersion, Environment.WorkingSet / (1024 * 1024));
 
+            // Rotate crash.log so a bug report only carries crashes from THIS build. The log is
+            // append-only, so without this it accumulates months of old crashes and the reporter
+            // ships them all (the last 120KB), burying the real failure and polluting triage.
+            RotateCrashLogForVersion(logPath);
+
             // Surface a single-instance takeover (a prior wedged/headless process was killed so
             // this launch could proceed). Recorded here because Logger isn't up during the handshake.
             if (_recoveredFromStaleInstance)
@@ -2599,6 +2604,56 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Rotate <c>crash.log</c> at startup so a bug report only carries crashes from the running
+        /// build. crash.log is append-only (see <see cref="LogCrashDetails"/>) and the bug reporter
+        /// attaches its tail, so left alone it drags months of unrelated crashes into every report.
+        /// We rotate when the app version changes (each entry is version-tagged) and cap runaway
+        /// growth within a single version. Best-effort: any failure is swallowed. Keeps ONE archive
+        /// (<c>crash.log.prev</c>) for local post-mortems.
+        /// </summary>
+        private static void RotateCrashLogForVersion(string logDir)
+        {
+            const long MaxCrashLogBytes = 512 * 1024; // per-version runaway guard
+            try
+            {
+                var crashLogPath = Path.Combine(logDir, "crash.log");
+                if (!File.Exists(crashLogPath)) return;
+
+                var markerPath = Path.Combine(logDir, "crash.log.version");
+                string current = Services.UpdateService.AppVersion;
+                string previous = "";
+                try { if (File.Exists(markerPath)) previous = File.ReadAllText(markerPath).Trim(); } catch { }
+
+                long size = 0;
+                try { size = new FileInfo(crashLogPath).Length; } catch { }
+
+                bool versionChanged = !string.Equals(previous, current, StringComparison.Ordinal);
+                if (versionChanged || size > MaxCrashLogBytes)
+                {
+                    var archive = Path.Combine(logDir, "crash.log.prev");
+                    try { if (File.Exists(archive)) File.Delete(archive); } catch { }
+                    try
+                    {
+                        File.Move(crashLogPath, archive);
+                    }
+                    catch
+                    {
+                        // Locked/denied — truncate in place so we still drop the stale entries.
+                        try { File.WriteAllText(crashLogPath, string.Empty); } catch { }
+                    }
+                    Logger?.Information("[CRASHLOG] rotated crash.log (versionChanged={V}, prevVer={P}, size={S}KB)",
+                        versionChanged, string.IsNullOrEmpty(previous) ? "(none)" : previous, size / 1024);
+                }
+
+                try { File.WriteAllText(markerPath, current); } catch { }
+            }
+            catch (Exception ex)
+            {
+                Logger?.Debug("[CRASHLOG] rotation skipped: {Msg}", ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Log detailed crash information to both main log and a dedicated crash log file.
         /// This helps debug random crashes by capturing full context.
         /// </summary>
@@ -2617,6 +2672,7 @@ namespace ConditioningControlPanel
 ================================================================================
 CRASH REPORT - {DateTime.Now:yyyy-MM-dd HH:mm:ss}
 ================================================================================
+App Version: {Services.UpdateService.AppVersion}
 Source: {source}
 Exception Type: {ex.GetType().FullName}
 Message: {ex.Message}

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -484,6 +484,18 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Monitor topology / resolution / DPI changed. Refresh the screen cache and quiesce the
+        /// layered-window spawn paths for a beat (WPF is rebuilding composition surfaces; adding new
+        /// ones now risks desktop-heap/GPU-surface exhaustion — the freeze cluster). Fires on the UI
+        /// thread via SystemEvents' WPF message pump.
+        /// </summary>
+        private static void OnDisplaySettingsChanged(object? sender, EventArgs e)
+        {
+            InvalidateScreenCache();
+            Services.UI.DisplayChangeCoordinator.NotifyDisplayChange("display-settings");
+        }
+
+        /// <summary>
         /// Returns the monitor the user picked for webcam calibration / Quick
         /// Recal / Tracker Test, falling back to the primary screen if their
         /// saved choice is "Primary" or no longer present (monitor unplugged
@@ -1020,6 +1032,11 @@ namespace ConditioningControlPanel
             // in crash.log — but the chaos sentinel file is still on disk. Report+consume it so the
             // crash self-documents (with last-known context) in this session's log.
             Services.Chaos.ChaosCrashSentinel.ConsumeAndReport(Logger);
+
+            // React to monitor topology / resolution changes (unplug, res change, DPI): drop the stale
+            // screen cache AND pause layered-window spawns briefly so we don't create fresh surfaces
+            // during the composition rebuild storm (freeze cluster — see DisplayChangeCoordinator).
+            try { SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged; } catch { }
 
             // Hang forensics: the recurring freezes are render-thread deadlocks (Application
             // Hang 1002, nothing in crash.log). The watchdog writes one minidump per session
@@ -2907,6 +2924,8 @@ Application State:
         protected override void OnExit(ExitEventArgs e)
         {
             Logger?.Information("Application shutting down...");
+
+            try { SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch { }
 
             // A clean shutdown — even mid-run — is NOT a crash. Clear the chaos sentinel so the next
             // launch doesn't false-report it as an abnormal exit.

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -329,6 +329,16 @@ namespace ConditioningControlPanel
             base.OnClosing(e);
         }
 
+        protected override void OnDpiChanged(System.Windows.DpiScale oldDpi, System.Windows.DpiScale newDpi)
+        {
+            // Moving to a monitor with a different scale factor makes WPF rebuild every visible layered
+            // window's composition surface synchronously. Pause new flash/bubble/overlay spawns for a
+            // beat so we don't pile fresh surfaces onto that rebuild burst (desktop-heap/GPU exhaustion
+            // -> "Not enough quota" crash / render-thread wedge). See DisplayChangeCoordinator.
+            Services.UI.DisplayChangeCoordinator.NotifyDisplayChange("dpi-changed");
+            base.OnDpiChanged(oldDpi, newDpi);
+        }
+
         protected override void OnStateChanged(EventArgs e)
         {
             base.OnStateChanged(e);

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -24,6 +24,11 @@ public class BubbleService : IDisposable
 {
     private const int MAX_BUBBLES = 3;          // per-window fallback cap (SetWindowPos-bound — keep small)
     private const int MAX_BUBBLES_HOST = 40;    // shared-host cap: a dense ambient field is cheap on the Canvas
+    // Trigger/effect bubbles ALWAYS render per-window (forceWindowMode) even with the shared host on,
+    // and each is a WS_EX_LAYERED window repositioned via SetWindowPos every frame. So they must be
+    // capped independently of the (Canvas-cheap) host field cap — otherwise a high trigger chance puts
+    // dozens of layered windows on screen and starves desktop-heap/GPU surfaces (freeze cluster #448/#431).
+    private const int MAX_TRIGGER_WINDOWS = 4;
     /// <summary>Concurrent ambient cap. The per-window path stays at 3 (each move is a SetWindowPos);
     /// the shared-host path repositions via batched Canvas.SetLeft/Top, so it carries a dense field.</summary>
     private int MaxAmbientBubbles => _ambientHost ? MAX_BUBBLES_HOST : MAX_BUBBLES;
@@ -823,6 +828,8 @@ public class BubbleService : IDisposable
     private void SpawnBubble()
     {
         if (!_isRunning) return;
+        // Hold off spawning while a monitor/DPI change settles (freeze cluster — see DisplayChangeCoordinator).
+        if (Services.UI.DisplayChangeCoordinator.SpawnsSuppressed) return;
         if (_bubbles.Count >= MaxAmbientBubbles)
         {
             App.Logger?.Debug("Max bubbles reached, skipping spawn");
@@ -867,6 +874,17 @@ public class BubbleService : IDisposable
         {
             try
             {
+                // Hold off while a monitor/DPI change settles (freeze cluster — see DisplayChangeCoordinator).
+                if (Services.UI.DisplayChangeCoordinator.SpawnsSuppressed) return;
+
+                // Respect the concurrent cap (SpawnBubble does; keyword-triggered spawns must too, or a
+                // held-down trigger floods layered windows). Checked before starting the timer.
+                if (_bubbles.Count >= MaxAmbientBubbles)
+                {
+                    App.Logger?.Debug("SpawnOnce: max bubbles reached, skipping trigger spawn");
+                    return;
+                }
+
                 if (_bubbleImage == null)
                     LoadBubbleImage();
 
@@ -988,6 +1006,11 @@ public class BubbleService : IDisposable
     private Bubble CreateAmbientBubble(System.Windows.Forms.Screen screen, bool isClickable)
     {
         var spec = RollTriggerSpec();
+        // Trigger bubbles are per-window layered windows; keep their concurrent count low regardless of
+        // the overall (host-rendered) field cap. Past the ceiling, fall back to a plain bubble so the
+        // dashboard stays lively without a layered-window pileup.
+        if (spec != null && _bubbles.Count(b => b.IsAmbientEffectBubble) >= MAX_TRIGGER_WINDOWS)
+            spec = null;
         if (spec == null)
             return new Bubble(screen, _bubbleImage, _random, OnPop, OnMiss, OnDestroy, isClickable);
         return new Bubble(screen, _bubbleImage, _random, onPop: null, onMiss: OnMiss, onDestroy: OnDestroy,

--- a/ConditioningControlPanel/Services/BugReportService.cs
+++ b/ConditioningControlPanel/Services/BugReportService.cs
@@ -321,7 +321,7 @@ namespace ConditioningControlPanel.Services
                 long tail = Math.Min(info.Length, MaxCrashLogChars);
                 fs.Seek(info.Length - tail, SeekOrigin.Begin);
                 using var sr = new StreamReader(fs, Encoding.UTF8);
-                return FilterBenignCrashes(sr.ReadToEnd());
+                return FilterToCurrentVersion(FilterBenignCrashes(sr.ReadToEnd()));
             }
             catch (Exception ex)
             {
@@ -364,6 +364,38 @@ namespace ConditioningControlPanel.Services
 
             if (dropped > 0)
                 App.Logger?.Debug("[BugReport] filtered {Count} benign exit-cleanup crash entries", dropped);
+            return kept.ToString();
+        }
+
+        /// <summary>
+        /// Keep only crash entries emitted by the CURRENTLY-running build. crash.log is append-only,
+        /// so even after startup rotation a report could catch a crash logged just before an in-place
+        /// update; more importantly this guards against a rotation that failed (locked/denied file).
+        /// Each entry is tagged with "App Version: X.Y.Z" (see App.LogCrashDetails). Entries from other
+        /// versions — and legacy untagged entries from before this change — are dropped so triage sees
+        /// only crashes relevant to the reported build. If the log has no delimited entries, it's
+        /// returned untouched.
+        /// </summary>
+        private static string FilterToCurrentVersion(string log)
+        {
+            if (string.IsNullOrEmpty(log)) return log;
+            const string marker = "CRASH REPORT - ";
+            var entries = log.Split(new[] { marker }, StringSplitOptions.None);
+            if (entries.Length <= 1) return log; // no delimited entries — leave as-is
+
+            var versionTag = "App Version: " + UpdateService.AppVersion;
+            var kept = new System.Text.StringBuilder(entries[0]);
+            int dropped = 0;
+            for (int i = 1; i < entries.Length; i++)
+            {
+                if (entries[i].Contains(versionTag, StringComparison.Ordinal))
+                    kept.Append(marker).Append(entries[i]);
+                else
+                    dropped++;
+            }
+
+            if (dropped > 0)
+                App.Logger?.Debug("[BugReport] dropped {Count} crash entries from other app versions", dropped);
             return kept.ToString();
         }
 

--- a/ConditioningControlPanel/Services/Content/ContentPackService.cs
+++ b/ConditioningControlPanel/Services/Content/ContentPackService.cs
@@ -93,18 +93,41 @@ namespace ConditioningControlPanel.Services
             _packsFolder = Path.Combine(App.EffectiveAssetsPath, ".packs");
             _manifestCachePath = Path.Combine(_packsFolder, ".manifest_cache.enc");
 
-            // Create hidden directory
-            if (!Directory.Exists(_packsFolder))
-            {
-                var di = Directory.CreateDirectory(_packsFolder);
-                di.Attributes |= FileAttributes.Hidden;
-            }
+            // Create hidden directory. Guarded: EffectiveAssetsPath can be a user-chosen
+            // custom drive (D:\, S:\, a network/removable volume) that is read-only, denied,
+            // or offline. An unguarded CreateDirectory here threw UnauthorizedAccessException /
+            // IOException straight out of OnStartup and hard-crashed the app before the window
+            // showed. Degrade gracefully instead: content packs are unavailable this session,
+            // but the app starts. (crash reports #450/#451/#452)
+            TryCreateHiddenPacksFolder();
 
             // Scan for orphaned packs (on disk but not in settings) and register them
             ScanAndRegisterOrphanedPacks();
 
             // Load installed pack manifests
             LoadInstalledManifests();
+        }
+
+        /// <summary>
+        /// Create <see cref="_packsFolder"/> as a hidden directory, swallowing the failure modes
+        /// that can occur on a user-chosen custom assets path (denied ACL, read-only/offline drive).
+        /// Never throws — callers must tolerate the folder being absent afterwards (the scan/load
+        /// paths already guard on <c>Directory.Exists</c>).
+        /// </summary>
+        private void TryCreateHiddenPacksFolder()
+        {
+            try
+            {
+                if (!Directory.Exists(_packsFolder))
+                {
+                    var di = Directory.CreateDirectory(_packsFolder);
+                    di.Attributes |= FileAttributes.Hidden;
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ContentPackService: could not create packs folder {Path} — content packs disabled this session", _packsFolder);
+            }
         }
 
         /// <summary>
@@ -126,12 +149,8 @@ namespace ConditioningControlPanel.Services
             _packsFolder = newPacksFolder;
             _manifestCachePath = Path.Combine(_packsFolder, ".manifest_cache.enc");
 
-            // Create hidden directory if it doesn't exist
-            if (!Directory.Exists(_packsFolder))
-            {
-                var di = Directory.CreateDirectory(_packsFolder);
-                di.Attributes |= FileAttributes.Hidden;
-            }
+            // Create hidden directory if it doesn't exist (guarded — see TryCreateHiddenPacksFolder)
+            TryCreateHiddenPacksFolder();
 
             // Scan for orphaned packs (on disk but not in settings) and register them
             ScanAndRegisterOrphanedPacks();

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -266,6 +266,9 @@ namespace ConditioningControlPanel.Services
         public void TriggerFlash()
         {
             if (!_isRunning || _isBusy) return;
+            // Skip spawning a fresh layered flash window while a monitor/DPI change is settling — one
+            // dropped flash is invisible; a new surface during the composition rebuild is not (freeze cluster).
+            if (Services.UI.DisplayChangeCoordinator.SpawnsSuppressed) return;
 
             _isBusy = true;
             _soundPlayingForCurrentFlash = false; // Reset for new flash event
@@ -281,6 +284,11 @@ namespace ConditioningControlPanel.Services
             if (_isBusy)
             {
                 App.Logger?.Debug("FlashService: TriggerFlashOnce skipped - busy");
+                return;
+            }
+            if (Services.UI.DisplayChangeCoordinator.SpawnsSuppressed)
+            {
+                App.Logger?.Debug("FlashService: TriggerFlashOnce skipped - display change in progress");
                 return;
             }
 

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -62,6 +62,13 @@ public class OverlayService : IDisposable
     private double? _rampSpiralOpacity;
     private double? _rampBrainDrainOpacity;
     private int _consecutiveTopmostLossCount;
+    // Recreate-overlays backoff. Destroying + recreating every layered overlay window on a 3s cadence
+    // is a GDI/composition-surface churn engine (feeds the "not enough quota" exhaustion, and the
+    // render-thread close/create is the freeze class). If a few recreations don't win topmost back,
+    // stop recreating and just keep forcing z-order — recreation isn't helping and only burns surfaces.
+    // Reset to 0 whenever topmost is regained, so a genuinely transient loss can still recreate later.
+    private int _recreateAttempts;
+    private const int MaxRecreateAttempts = 3;
     // Tick counter for periodic topmost-layer "kick". The 500ms timer drives this;
     // every ~5s (10 ticks) we re-issue HWND_TOPMOST even if the WS_EX_TOPMOST flag
     // is set, because Windows can reorder within the topmost layer (fullscreen
@@ -421,12 +428,30 @@ public class OverlayService : IDisposable
             if (_consecutiveTopmostLossCount >= 6) // 6 x 500ms = 3 seconds of continuous loss
             {
                 _consecutiveTopmostLossCount = 0;
-                RecreateOverlays();
+                if (Services.UI.DisplayChangeCoordinator.SpawnsSuppressed)
+                {
+                    // A monitor/DPI change is settling — topmost loss is expected and transient. Just
+                    // reassert; don't tear down + recreate windows into the composition rebuild storm,
+                    // and don't spend the recreate budget on it.
+                    ReassertZOrder(force: true);
+                }
+                else if (_recreateAttempts < MaxRecreateAttempts)
+                {
+                    _recreateAttempts++;
+                    RecreateOverlays();
+                }
+                else
+                {
+                    // Backed off: recreation didn't win topmost back after several tries. Keep forcing
+                    // z-order instead of churning layered surfaces every 3s (freeze cluster #431/#451).
+                    ReassertZOrder(force: true);
+                }
             }
         }
         else
         {
             _consecutiveTopmostLossCount = 0;
+            _recreateAttempts = 0; // topmost regained — allow recreation to help again on a future loss
         }
 
         // Periodic unconditional kick to handle in-layer reordering even when the
@@ -1855,9 +1880,10 @@ public class OverlayService : IDisposable
 
         if (hadPinkFilter && settings.PinkFilterEnabled) StartPinkFilter();
         if (hadSpiral && settings.SpiralEnabled) StartSpiral();
-        // Brain drain is started externally, so just log if it was active
-        if (hadBrainDrain)
-            App.Logger?.Debug("Brain drain blur was active before recreation — must be restarted externally");
+        // Brain drain was previously only logged here, so a braindrain overlay that was the one losing
+        // topmost got torn down and never came back. Restart it too (same intensity source the other
+        // reconcile paths use) so recreation doesn't silently kill the effect.
+        if (hadBrainDrain && settings.BrainDrainEnabled) StartBrainDrainBlur((int)settings.BrainDrainIntensity);
     }
 
     /// <summary>
@@ -2188,6 +2214,18 @@ public class OverlayService : IDisposable
         _isRunning = false;
         _updateTimer?.Stop();
         _updateTimer = null;
+
+        // Dispose previously stopped only _updateTimer, leaving the capture + GIF timers running with
+        // _brainDrainImages populated — so BrainDrainCaptureTick kept grabbing the screen every tick
+        // after teardown, and the native capture DC/HBITMAP leaked. Stop them all and free the handles.
+        _brainDrainCaptureTimer?.Stop();
+        _brainDrainCaptureTimer = null;
+        _gifFrameTimer?.Stop();
+        _gifFrameTimer = null;
+        _gifLoopTimer?.Stop();
+        _gifLoopTimer = null;
+        _brainDrainImages.Clear();
+        CleanupCaptureResources();
 
         // Unsubscribe from settings changes
         if (App.Settings?.Current != null)

--- a/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
@@ -143,16 +143,34 @@ public class BouncingTextService : IDisposable
         _zReassertAccum = 0;
         CompositionTarget.Rendering -= Animate; // guard against a double subscribe
         CompositionTarget.Rendering += Animate;
-        
-        App.Logger?.Information("BouncingTextService started - Text: {Text}, Size: {W}x{H}", 
+
+        // During mandatory video the old code kept Animate subscribed and hid the windows + returned
+        // every vsync — a permanent no-op render callback that never let the composition loop sleep
+        // (a contributor to the idle/long-session freeze, #453). Instead, pause the loop entirely on
+        // VideoStarted and resume on VideoEnded.
+        if (App.Video != null)
+        {
+            App.Video.VideoStarted -= OnVideoStartedPause;
+            App.Video.VideoStarted += OnVideoStartedPause;
+            App.Video.VideoEnded -= OnVideoEndedResume;
+            App.Video.VideoEnded += OnVideoEndedResume;
+            if (App.Video.IsPlaying) OnVideoStartedPause(null, EventArgs.Empty);
+        }
+
+        App.Logger?.Information("BouncingTextService started - Text: {Text}, Size: {W}x{H}",
             _currentText, _textWidth, _textHeight);
     }
 
     public void Stop()
     {
         _isRunning = false;
-        
+
         CompositionTarget.Rendering -= Animate;
+        if (App.Video != null)
+        {
+            App.Video.VideoStarted -= OnVideoStartedPause;
+            App.Video.VideoEnded -= OnVideoEndedResume;
+        }
 
         // Always close and clear windows, even if we thought we weren't running
         foreach (var window in _windows)
@@ -160,8 +178,32 @@ public class BouncingTextService : IDisposable
             try { window.Close(); } catch { }
         }
         _windows.Clear();
-        
+
         App.Logger?.Information("BouncingTextService stopped");
+    }
+
+    /// <summary>Sleep the bounce render loop while a mandatory video plays (VideoStarted). Marshals to
+    /// the UI thread since the video event can fire off a playback thread.</summary>
+    private void OnVideoStartedPause(object? sender, EventArgs e)
+    {
+        var disp = System.Windows.Application.Current?.Dispatcher;
+        if (disp == null) return;
+        if (!disp.CheckAccess()) { try { disp.BeginInvoke(new Action(() => OnVideoStartedPause(sender, e))); } catch { } return; }
+        CompositionTarget.Rendering -= Animate;
+        foreach (var w in _windows) { try { if (w.IsLoaded) w.Hide(); } catch { } }
+    }
+
+    /// <summary>Resume the bounce render loop when the video ends (VideoEnded), if still running.</summary>
+    private void OnVideoEndedResume(object? sender, EventArgs e)
+    {
+        var disp = System.Windows.Application.Current?.Dispatcher;
+        if (disp == null) return;
+        if (!disp.CheckAccess()) { try { disp.BeginInvoke(new Action(() => OnVideoEndedResume(sender, e))); } catch { } return; }
+        if (!_isRunning) return;
+        foreach (var w in _windows) { try { if (w.IsLoaded && !w.IsVisible) w.Show(); } catch { } }
+        _lastRenderTime = TimeSpan.MinValue; // reset dt so the first resumed frame doesn't jump
+        CompositionTarget.Rendering -= Animate;
+        CompositionTarget.Rendering += Animate;
     }
 
     private void SelectRandomText(List<string>? pool = null)

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -625,8 +625,16 @@ namespace ConditioningControlPanel.Services
         private Window GetOrCreateScreenWindow(System.Windows.Forms.Screen screen)
         {
             var key = screen.DeviceName ?? "primary";
-            if (_screenWindows.TryGetValue(key, out var cached) && cached.IsLoaded)
-                return cached;
+            if (_screenWindows.TryGetValue(key, out var cached))
+            {
+                if (cached.IsLoaded)
+                    return cached;
+                // Stale entry (the window was closed, or a display topology change left it unloaded).
+                // Close it before replacing the slot so we don't orphan a live layered window that then
+                // lingers until Dispose — accumulates across monitor plug/unplug cycles.
+                try { cached.Close(); } catch { }
+                _screenWindows.Remove(key);
+            }
 
             // Use EXACTLY the same approach as OverlayService.GetWpfScreenBounds
             // which works correctly for multi-monitor DPI setups

--- a/ConditioningControlPanel/Services/UI/DisplayChangeCoordinator.cs
+++ b/ConditioningControlPanel/Services/UI/DisplayChangeCoordinator.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+namespace ConditioningControlPanel.Services.UI
+{
+    /// <summary>
+    /// Central "a display change is in progress" signal used to briefly quiesce the layered-window
+    /// spawn paths (flash images, bubbles, overlay recreation).
+    ///
+    /// Why: the app keeps many WS_EX_LAYERED / AllowsTransparency top-level windows alive at once, and
+    /// each owns a DWM composition surface. When the main window crosses onto a monitor with a different
+    /// DPI, WPF synchronously rebuilds every visible window's composition surface (the
+    /// HwndTarget.UpdateWindowSettings/OnShowWindow path). If a fresh flash/bubble window is *also*
+    /// created in that same window (or overlays are torn down and recreated), the burst of surface
+    /// allocation can exhaust desktop-heap / GPU-committed memory — the "Not enough quota is available"
+    /// crash — or wedge the render thread (the freeze on monitor move). See the freeze-cluster diagnosis.
+    ///
+    /// This does NOT stop existing windows from being rebuilt (WPF owns that); it just avoids ADDING new
+    /// layered surfaces during the volatile window right after a display change. Callers that skip a
+    /// spawn simply drop one transient effect — invisible to the user, and everything resumes ~1s later.
+    /// </summary>
+    public static class DisplayChangeCoordinator
+    {
+        // Monotonic tick (ms) until which layered-window spawns should be skipped. Read/written from the
+        // UI thread and from spawn callbacks that may run on worker threads, so accessed via Interlocked.
+        private static long _quietUntilTick;
+
+        /// <summary>How long to hold spawns after a display change. A DPI transition + surface rebuild
+        /// settles well under a second; a drag across monitors fires repeated changes that each extend
+        /// the window, so the quiet period naturally covers the whole move.</summary>
+        private const long QuietMs = 900;
+
+        /// <summary>Note that the display topology / DPI just changed; suppress spawns for a short window.</summary>
+        public static void NotifyDisplayChange(string reason)
+        {
+            Interlocked.Exchange(ref _quietUntilTick, Environment.TickCount64 + QuietMs);
+            App.Logger?.Debug("[DISPLAY] change ({Reason}) — pausing layered-window spawns for {Ms}ms", reason, QuietMs);
+        }
+
+        /// <summary>True while spawns should be skipped (a display change happened within the last <see cref="QuietMs"/> ms).</summary>
+        public static bool SpawnsSuppressed => Environment.TickCount64 < Interlocked.Read(ref _quietUntilTick);
+    }
+}

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -102,15 +102,22 @@ public static class UiHangWatchdog
             {
                 var rundll = Path.Combine(Environment.SystemDirectory, "rundll32.exe");
                 var comsvcs = Path.Combine(Environment.SystemDirectory, "comsvcs.dll");
+                // Compact minidump (NO "full"): comsvcs "full" writes MiniDumpWithFullMemory — the
+                // ENTIRE process memory (multi-GB for this app), which piles IO/commit pressure onto a
+                // process that is often ALREADY at desktop-heap/GPU-surface exhaustion when the watchdog
+                // fires, and can itself produce 0-byte/partial dumps. A normal minidump still carries
+                // every thread's stack + module list — enough to identify the render-thread deadlock
+                // that these hangs are. (If deep managed-heap inspection is ever needed, the in-proc
+                // fallback below captures private RW memory.)
                 using var dumper = Process.Start(new ProcessStartInfo
                 {
                     FileName = rundll,
-                    Arguments = $"\"{comsvcs}\", MiniDump {proc.Id} \"{path}\" full",
+                    Arguments = $"\"{comsvcs}\", MiniDump {proc.Id} \"{path}\"",
                     UseShellExecute = false,
                     CreateNoWindow = true,
                 });
-                if (dumper != null && dumper.WaitForExit(120_000)
-                    && File.Exists(path) && new FileInfo(path).Length > 1_000_000)
+                if (dumper != null && dumper.WaitForExit(60_000)
+                    && File.Exists(path) && new FileInfo(path).Length > 100_000)
                 {
                     App.Logger?.Error("[WATCHDOG] hang dump written (external) after {Sec:F0}s of silence: {Path}", silenceMs / 1000.0, path);
                     return;


### PR DESCRIPTION
Triage of the v6.2.2/v6.2.3 crash-report spike (#429–#453). Key finding: most reports were **freezes/hangs or behaviour bugs**, and the attached crash logs were **stale** — `crash.log` is append-only and the reporter ships its 120KB tail, so every report dragged months of unrelated crashes. Several "top" signatures were already fixed in HEAD. This PR fixes the real, current issues plus the meta-bug that was blinding triage.

## Commits

### `964382a2` fix(startup): acked single-instance handshake + kill-stale takeover
A wedged/headless zombie could hold the single-instance mutex while every relaunch silently `Shutdown()`, so the app appeared to "not launch" until many retries. Adds an acknowledged show-handshake with a kill-stale takeover (re-acquires the mutex, tolerates `AbandonedMutexException`).

### `9f65690d` fix(crashlog,startup): rotate crash.log per version + guard packs-folder create
- Tag each crash entry with the app version; rotate `crash.log` → `crash.log.prev` on a version change or a 512KB per-version cap at startup; filter the reporter to current-version entries only. **Reports now carry only crashes from the running build.**
- Guard `ContentPackService`'s ctor: `Directory.CreateDirectory(.packs)` ran unguarded in `OnStartup`, so a custom assets path on a denied/read-only/offline drive hard-crashed before the window showed. Now degrades gracefully.

### `fc21047a` fix(freeze): tame layered-window pressure + coordinate monitor/DPI moves
Root cause of the freeze + "Not enough quota" cluster (#431/#451/#453/#448): many `WS_EX_LAYERED` windows alive at once, spawn bursts, and no coordination during a monitor/DPI change (WPF rebuilds every window's composition surface).
- **New `DisplayChangeCoordinator`**: pause layered-window spawns ~900ms after a display change. Driven by `MainWindow.OnDpiChanged` + `App.DisplaySettingsChanged` (also invalidates the screen cache). Gates flash, bubble, and overlay-recreate spawns.
- **Bubbles**: independent cap on per-window trigger bubbles (`MAX_TRIGGER_WINDOWS=4`, fall back to a plain bubble); add the missing concurrency cap to `SpawnOnce`.
- **OverlayService**: back off the 3s destroy/recreate loop after `MaxRecreateAttempts` (was churning surfaces indefinitely); actually restart brain drain on recreate.
- **BouncingText**: sleep the render loop during mandatory video (unsubscribe `CompositionTarget.Rendering`, resume on `VideoEnded`) instead of a per-vsync no-op.
- **Leaks**: SubliminalService closes stale keep-alive windows before replacing; `OverlayService.Dispose` stops capture/GIF timers + frees GDI handles; `UiHangWatchdog` external dump downgraded full → compact.

## Testing
- `dotnet build`: 0 errors (296 pre-existing platform warnings).
- **NOT runtime-tested** — the freeze fixes need a real-hardware pass: drag across monitors (ideally different-DPI) with the full engine running; confirm no freeze/quota crash, overlays recover topmost, brain drain survives a recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)