### PR TITLE
fix: stability batch from 6.2.6-6.2.7 triage (crashes, hangs, native OOM)

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
@@ -948,9 +948,20 @@ namespace ConditioningControlPanel
         {
             if (_parentWindow is MainWindow mainWindow)
             {
+                // Mirror BtnStart_Click's guards. This menu used to call StopEngine()
+                // directly, so a right-click on the avatar could kill the engine during
+                // lockdown or a strict-locked video — defeating the lock and crashing
+                // the app in the mid-playback LibVLC teardown (#479).
+                if (App.RemoteControl?.ControllerConnected == true) return;
+
                 // Use Flash.IsRunning as proxy for engine state
                 if (App.Flash?.IsRunning == true)
                 {
+                    if (IsEngineStopLocked())
+                    {
+                        Giggle("nuh-uh~ no stopping now, you're locked in~");
+                        return;
+                    }
                     mainWindow.StopEngine();
                     Giggle("Engine stopped~");
                 }
@@ -962,6 +973,15 @@ namespace ConditioningControlPanel
                 UpdateQuickMenuState();
             }
         }
+
+        /// <summary>
+        /// True when stopping the engine must be refused: lockdown mode, a strict-locked
+        /// mandatory video, or a strict-locked bubble-count game is in progress (#479).
+        /// </summary>
+        private static bool IsEngineStopLocked() =>
+            App.Lockdown?.IsActive == true ||
+            App.Video?.IsStrictActive == true ||
+            (App.BubbleCount?.IsBusy == true && App.Settings?.Current?.BubbleCountStrictLock == true);
 
         private void MenuItemTriggerMode_Click(object sender, RoutedEventArgs e)
         {
@@ -1360,7 +1380,10 @@ namespace ConditioningControlPanel
                 // Without this the items stay stuck un-clickable after exiting remote control, because
                 // the normal section above only refreshes their Header/Foreground, never IsEnabled.
                 // (Foreground is already restored above; Takeover stays gated on Patreon access.)
-                MenuItemEngine.IsEnabled = true;
+                // Engine item stays disabled while a stop would be refused anyway
+                // (lockdown / strict-locked video or bubble game, #479) — but only
+                // when the engine is running; starting is always allowed.
+                MenuItemEngine.IsEnabled = !(App.Flash?.IsRunning == true && IsEngineStopLocked());
                 MenuItemTriggerMode.IsEnabled = true;
                 MenuItemBambiTakeover.IsEnabled = takeoverAvailable;
                 MenuItemPersonality.IsEnabled = true;

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
@@ -331,12 +331,41 @@ namespace ConditioningControlPanel
             }
         }
 
+        private const int WM_DPICHANGED = 0x02E0;
+        private DispatcherTimer? _dpiQuiesceTimer;
+
         /// <summary>
-        /// Window procedure hook (minimal - no longer forcing z-order to allow normal window switching)
+        /// Window procedure hook. Only handles WM_DPICHANGED: when a drag crosses onto a
+        /// monitor with a different scale factor, PerMonitorV2 WPF resizes this layered
+        /// window, and that resize runs a SYNCHRONOUS CompleteRender that deadlocks when
+        /// the shared AllowsTransparency render thread is busy (the documented hang in
+        /// OnFirstContentRendered — #477). Quiesce the 60fps float/breath transform writes
+        /// for the transition so the blocking present can complete, then resume.
         /// </summary>
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
-            // No longer intercepting z-order changes - let Windows handle it normally
+            if (msg == WM_DPICHANGED)
+            {
+                try
+                {
+                    if (_floatTimer?.IsEnabled == true)
+                    {
+                        _floatTimer.Stop();
+                        if (_dpiQuiesceTimer == null)
+                        {
+                            _dpiQuiesceTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(450) };
+                            _dpiQuiesceTimer.Tick += (s, e) =>
+                            {
+                                _dpiQuiesceTimer?.Stop();
+                                try { _floatTimer?.Start(); } catch { /* window tearing down */ }
+                            };
+                        }
+                        _dpiQuiesceTimer.Stop(); // restart the debounce on rapid re-crossings
+                        _dpiQuiesceTimer.Start();
+                    }
+                }
+                catch { /* never let a hook throw */ }
+            }
             return IntPtr.Zero;
         }
 
@@ -1695,8 +1724,21 @@ namespace ConditioningControlPanel
                                 || IsDescendantOf(hit, ImgTubeFrame);
                 if (!onAvatar) return;
 
+                // PointToScreen throws InvalidOperationException while the window's
+                // presentation source is torn down/rebuilt — which happens exactly when
+                // a drag crosses onto a monitor with a different DPI (#477). Unhandled
+                // here it takes down the whole app (possibly from the avatar's own UI
+                // thread), so treat a failed conversion as "drag didn't start".
+                try
+                {
+                    _dragStartPoint = PointToScreen(e.GetPosition(this));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    App.Logger?.Debug("Avatar drag start: PointToScreen failed ({Error})", ex.Message);
+                    return;
+                }
                 _isDragging = true;
-                _dragStartPoint = PointToScreen(e.GetPosition(this));
                 _dragStartLeft = Left;
                 _dragStartTop = Top;
                 CaptureMouse();
@@ -1708,9 +1750,18 @@ namespace ConditioningControlPanel
             base.OnMouseMove(e);
             if (_isDragging && !_isAttached)
             {
-                var currentPoint = PointToScreen(e.GetPosition(this));
-                Left = _dragStartLeft + (currentPoint.X - _dragStartPoint.X);
-                Top = _dragStartTop + (currentPoint.Y - _dragStartPoint.Y);
+                // Same DPI-transition guard as the drag start (#477): skip this move
+                // tick if the presentation source is mid-rebuild; the next tick lands.
+                try
+                {
+                    var currentPoint = PointToScreen(e.GetPosition(this));
+                    Left = _dragStartLeft + (currentPoint.X - _dragStartPoint.X);
+                    Top = _dragStartTop + (currentPoint.Y - _dragStartPoint.Y);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    App.Logger?.Debug("Avatar drag move: PointToScreen failed ({Error})", ex.Message);
+                }
             }
         }
 

--- a/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
@@ -116,9 +116,13 @@ public sealed class ChaosFlashOverlay : Window
 
         if (path.EndsWith(".gif", StringComparison.OrdinalIgnoreCase))
         {
-            AnimationBehavior.SetRepeatBehavior(_img, RepeatBehavior.Forever);
-            AnimationBehavior.SetAutoStart(_img, true);
-            AnimationBehavior.SetSourceUri(_img, new Uri(path, UriKind.Absolute));
+            // Was XamlAnimatedGif — which decodes at NATIVE resolution with no size cap, so a
+            // large GIF looped full-screen for the whole wash held ~100MB+ of resident BGRA
+            // and dominated the render thread (the glitch-pop frame drops / OOM crash, #476).
+            // SKCodec is format-agnostic, so GIFs ride the same capped/cached pipeline as
+            // animated webp (1280px / 40 frames, off-thread, capped-still fallback). A faint
+            // wash doesn't need native res; ClearImage's Detach already tears this down.
+            Services.AnimatedWebp.AttachAnimation(_img, path, maxDim: 1280, maxFrames: 40);
         }
         else if (path.EndsWith(".webp", StringComparison.OrdinalIgnoreCase) && Services.AnimatedWebp.IsAnimated(path))
         {

--- a/ConditioningControlPanel/MainWindow/MainWindow.DeeperTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.DeeperTab.cs
@@ -466,7 +466,26 @@ namespace ConditioningControlPanel
                           : enhanceOff ? "Yes, enable enhancement"
                           : "Yes, turn on webcam";
 
-                var confirmed = ShowStyledDialog("✨ Enhanced videos detected", sb.ToString(), yes, "Not now");
+                // Never stack on top of the update popup: both are modal on the UI
+                // thread, and whichever ShowDialog nests second owns input while the
+                // Topmost update dialog covers it - neither can be dismissed (#481).
+                // Wait for the update dialog, then take the startup-dialog flag so
+                // the update path's own wait loop defers to us symmetrically.
+                for (int i = 0; i < 60 && App.IsUpdateDialogActive; i++)
+                    await Task.Delay(500);
+                if (App.IsUpdateDialogActive) return;
+                if (!IsLoaded || Dispatcher.HasShutdownStarted || !_isRunning) return;
+
+                bool confirmed;
+                IsStartupDialogShowing = true;
+                try
+                {
+                    confirmed = ShowStyledDialog("✨ Enhanced videos detected", sb.ToString(), yes, "Not now");
+                }
+                finally
+                {
+                    IsStartupDialogShowing = false;
+                }
                 if (!confirmed) return;
 
                 if (enhanceOff)

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -989,7 +989,11 @@ public class BubbleService : IDisposable
                 return new EffectBubbleSpec
                 {
                     VariantId = "glitch",   // loads assets/Chaos/bubbles/glitch.png
-                    Payload = new OverlayPayload("braindrain", braindrainOpacity: 0.30) { Strength = 60, DurationMult = LINGER },
+                    // Glitch is exempt from LINGER: its payload is a FULL-SCREEN layered wash,
+                    // and at 2.5x (~8s) the whole desktop stayed alpha-composited every frame —
+                    // the frame drops / crashes reported when popping glitch bubbles under load
+                    // (#476). 1.2x (~4s) still reads as a lingering wash on the calm dashboard.
+                    Payload = new OverlayPayload("braindrain", braindrainOpacity: 0.30) { Strength = 60, DurationMult = 1.2 },
                     SizePx = 200,
                     Tint = System.Windows.Media.Color.FromRgb(0x9A, 0x40, 0xFF),
                     Label = "GLITCH",
@@ -4270,20 +4274,15 @@ internal class Bubble
             {
                 _teaseAnimated = true;
                 _teaseAnimatedAlive++;
-                if (isGif)
-                {
-                    XamlAnimatedGif.AnimationBehavior.SetRepeatBehavior(img, System.Windows.Media.Animation.RepeatBehavior.Forever);
-                    XamlAnimatedGif.AnimationBehavior.SetAutoStart(img, true);
-                    XamlAnimatedGif.AnimationBehavior.SetSourceUri(img, new Uri(path, UriKind.Absolute));
-                }
-                else
-                {
-                    // XamlAnimatedGif is GIF-only — webp loops via a pre-decoded (off-thread,
-                    // display-size) frame animation. Held in _teaseImg so Destroy can Detach it:
-                    // the Forever clock pins the Image until cleared.
-                    _teaseImg = img;
-                    AnimatedWebp.AttachAnimation(img, path, Math.Max(64, (int)inner));
-                }
+                // Both formats loop via a pre-decoded (off-thread, display-size) frame
+                // animation — SKCodec is format-agnostic, so GIFs ride the webp pipeline.
+                // GIFs used to go through XamlAnimatedGif, which decoded at native res AND
+                // was never torn down on Destroy (only _teaseImg gets Detached): every dead
+                // GIF tease leaked its animator + full frame buffer and stayed subscribed to
+                // CompositionTarget.Rendering (#486). Held in _teaseImg so Destroy can
+                // Detach it: the Forever clock pins the Image until cleared.
+                _teaseImg = img;
+                AnimatedWebp.AttachAnimation(img, path, Math.Max(64, (int)inner));
             }
             else
             {

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -85,17 +85,22 @@ namespace ConditioningControlPanel.Services
 
         // Image decode cache: avoids reloading/re-decoding the same images every flash
         // Key = file path, Value = (data, lastAccess)
-        private readonly Dictionary<string, (LoadedImageData data, DateTime lastAccess)> _imageDecodeCache = new();
+        // Keyed by file path ONLY (decodeMax stored alongside). Keying by path+dim let the
+        // performance tier's auto up/down-shifts cache the same file at 2-3 sizes at once,
+        // halving effective capacity and forcing extra decodes exactly when the system was
+        // already under load (#486). A hit at an equal-or-larger cached dim is served as-is;
+        // a larger request replaces the entry.
+        private readonly Dictionary<string, (LoadedImageData data, DateTime lastAccess, int decodeMax)> _imageDecodeCache = new();
         private const int MAX_IMAGE_CACHE_ENTRIES = 50;
         private const long MAX_IMAGE_CACHE_BYTES = 200L * 1024 * 1024; // 200 MB cap
         private long _imageCacheBytes;
 
         // Decode attribution (cumulative, app-lifetime) for the chaos OOM hunt. A cache MISS that
-        // runs an actual decode increments these; cache hits don't. The GIF path still uses
-        // System.Drawing/GDI+ (native-heap-retaining under churn) — if GifDecodes climbs run-over-run
-        // in lockstep with native~ in [CHAOSMEM], the GIF decode path is the residual leak.
-        public long GifDecodes;     // GDI+ (System.Drawing) decodes — the suspect path
-        public long StaticDecodes;  // WIC (BitmapImage) decodes — already off GDI+
+        // runs an actual decode increments these; cache hits don't. The GIF path was the last
+        // GDI+ consumer and was migrated to SKCodec (#486) — if native~ in [CHAOSMEM] still climbs
+        // in lockstep with GifDecodes after the migration, look beyond the decoder.
+        public long GifDecodes;     // SKCodec (SkiaSharp) animated decodes — was GDI+ until #486
+        public long StaticDecodes;  // WIC (BitmapImage) decodes — off GDI+ since the chaos OOM fix
 
         // Snapshot of file paths from the most recent FlashDisplayed batch.
         // Read by SessionLogService after FlashDisplayed fires.
@@ -590,17 +595,23 @@ namespace ConditioningControlPanel.Services
                 // resolution — a 4K image shown at ~300-1000px wastes memory + GPU fill-rate.
                 // Cap scales with the active performance tier and the user's ImageScale.
                 int decodeMax = ComputeDecodeMaxDim();
-                // Cache key includes the decode cap so the same file cached at one size isn't
-                // reused at another (only a handful of distinct caps ever occur).
-                string cacheKey = path + "|" + decodeMax;
 
-                // Check decode cache first (frozen BitmapSources are thread-safe)
+                // Check decode cache first (frozen BitmapSources are thread-safe). A cached
+                // decode serves any request at the same or smaller cap (WPF scales down for
+                // free at render). It also serves LARGER requests when the source image never
+                // hit the cap (decoded size strictly below the cached cap = native res kept).
+                // Only a genuinely capped decode being asked for more pixels re-decodes, and
+                // the store below then replaces the entry — one entry per file, always.
                 lock (_imageDecodeCache)
                 {
-                    if (_imageDecodeCache.TryGetValue(cacheKey, out var cached))
+                    if (_imageDecodeCache.TryGetValue(path, out var cached))
                     {
-                        _imageDecodeCache[cacheKey] = (cached.data, DateTime.UtcNow);
-                        return CloneImageData(cached.data);
+                        bool uncapped = Math.Max(cached.data.Width, cached.data.Height) < cached.decodeMax;
+                        if (cached.decodeMax >= decodeMax || uncapped)
+                        {
+                            _imageDecodeCache[path] = (cached.data, DateTime.UtcNow, cached.decodeMax);
+                            return CloneImageData(cached.data);
+                        }
                     }
                 }
 
@@ -671,6 +682,15 @@ namespace ConditioningControlPanel.Services
 
                     lock (_imageDecodeCache)
                     {
+                        // Replacing an existing entry for this file (re-decode at a larger
+                        // cap, or a concurrent miss that raced us)? Release its bytes first
+                        // so the accounting doesn't drift upward.
+                        if (_imageDecodeCache.TryGetValue(path, out var existing))
+                        {
+                            _imageDecodeCache.Remove(path);
+                            _imageCacheBytes -= (long)existing.data.Width * existing.data.Height * 4 * existing.data.Frames.Count;
+                        }
+
                         // Evict if over limits
                         while (_imageDecodeCache.Count >= MAX_IMAGE_CACHE_ENTRIES ||
                                _imageCacheBytes + entryBytes > MAX_IMAGE_CACHE_BYTES)
@@ -697,7 +717,7 @@ namespace ConditioningControlPanel.Services
                             else break;
                         }
 
-                        _imageDecodeCache[cacheKey] = (data, DateTime.UtcNow);
+                        _imageDecodeCache[path] = (data, DateTime.UtcNow, decodeMax);
                         _imageCacheBytes += entryBytes;
                     }
 
@@ -759,91 +779,64 @@ namespace ConditioningControlPanel.Services
 
         private void LoadGifFrames(string path, LoadedImageData data, int decodeMax)
         {
+            // SkiaSharp (SKCodec) decode — NOT System.Drawing/GDI+. This was the last
+            // GDI+ decoder in the flash pipeline: every cache-miss GIF ran each frame
+            // through Graphics.DrawImage on the native Win32 heap, which bloats and
+            // never returns pages under high-frequency decode churn — the same VMMap
+            // signature (managed heap flat, private bytes climbing to multi-GB, native
+            // OOM with an empty crash log) that got the static path migrated to WIC
+            // (#486). SKCodec composes delta frames (RequiredFrame handling) and shares
+            // the animated-webp budget: decodeMax edge, ≤60 frames, ≤30MB kept.
             try
             {
-                using var gif = System.Drawing.Image.FromFile(path);
-                var dimension = new FrameDimension(gif.FrameDimensionsList[0]);
-                var frameCount = gif.GetFrameCount(dimension);
-
-                // Target (possibly downscaled) frame size — decode once, never upscale.
-                var (frameW, frameH) = ScaledSize(gif.Width, gif.Height, decodeMax);
-
-                // Get frame delay from metadata
-                var frameDelay = 100; // Default 100ms
-                try
+                if (AnimatedWebp.DecodeFrames(path, decodeMax, maxFrames: 60, maxMemoryMb: 30.0) is { } d)
                 {
-                    var propertyItem = gif.GetPropertyItem(0x5100); // FrameDelay property
-                    if (propertyItem?.Value != null)
-                    {
-                        frameDelay = BitConverter.ToInt32(propertyItem.Value, 0) * 10;
-                        if (frameDelay < 20) frameDelay = 100;
-                    }
+                    data.Frames.AddRange(d.Frames);
+                    data.Width = d.Frames[0].PixelWidth;
+                    data.Height = d.Frames[0].PixelHeight;
+                    data.FrameDelay = d.FrameDelay;
+                    return;
                 }
-                catch { }
-
-                // Limit frames based on (decoded) image size to keep memory reasonable
-                var pixelsPerFrame = (long)frameW * frameH * 4L; // BGRA32
-                var estimatedMemoryMB = (pixelsPerFrame * frameCount) / (1024.0 * 1024.0);
-
-                const double MAX_MEMORY_MB = 30.0;
-                var maxFrames = frameCount;
-                if (estimatedMemoryMB > MAX_MEMORY_MB)
-                {
-                    maxFrames = (int)(frameCount * (MAX_MEMORY_MB / estimatedMemoryMB));
-                    maxFrames = Math.Max(10, maxFrames);
-                }
-                maxFrames = Math.Min(maxFrames, 60);
-
-                var step = frameCount > maxFrames ? frameCount / maxFrames : 1;
-
-                for (int i = 0; i < frameCount && data.Frames.Count < maxFrames; i += step)
-                {
-                    gif.SelectActiveFrame(dimension, i);
-
-                    using var frameBitmap = new System.Drawing.Bitmap(frameW, frameH);
-                    using (var g = Graphics.FromImage(frameBitmap))
-                    {
-                        g.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                        g.PixelOffsetMode = PixelOffsetMode.HighQuality;
-                        g.DrawImage(gif, 0, 0, frameW, frameH);
-                    }
-
-                    var bitmapSource = ConvertToBitmapSource(frameBitmap);
-                    bitmapSource.Freeze();
-                    data.Frames.Add(bitmapSource);
-                }
-
-                data.Width = frameW;
-                data.Height = frameH;
-                data.FrameDelay = TimeSpan.FromMilliseconds(step > 1 ? frameDelay * step : frameDelay);
             }
             catch (Exception ex)
             {
                 App.Logger.Debug("Could not load GIF frames: {Error}", ex.Message);
+            }
 
-                // Fallback: load as static image (still honoring the decode cap)
+            // Single-frame or undecodable GIF → static WIC decode, mirroring the static
+            // image branch (decode-time downscale, no full-size intermediate, no GDI+).
+            try
+            {
+                int srcW = 0, srcH = 0;
                 try
                 {
-                    using var bitmap = new System.Drawing.Bitmap(path);
-                    var (tw, th) = ScaledSize(bitmap.Width, bitmap.Height, decodeMax);
-                    BitmapSource bitmapSource;
-                    if (tw != bitmap.Width || th != bitmap.Height)
-                    {
-                        using var scaled = DownscaleBitmap(bitmap, tw, th);
-                        bitmapSource = ConvertToBitmapSource(scaled);
-                    }
-                    else
-                    {
-                        bitmapSource = ConvertToBitmapSource(bitmap);
-                    }
-                    bitmapSource.Freeze();
-
-                    data.Frames.Add(bitmapSource);
-                    data.Width = tw;
-                    data.Height = th;
-                    data.FrameDelay = TimeSpan.FromMilliseconds(100);
+                    var probe = BitmapFrame.Create(new Uri(path, UriKind.Absolute),
+                        BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
+                    srcW = probe.PixelWidth; srcH = probe.PixelHeight;
                 }
                 catch { }
+
+                var bmp = new BitmapImage();
+                bmp.BeginInit();
+                bmp.CacheOption = BitmapCacheOption.OnLoad;
+                bmp.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
+                bmp.UriSource = new Uri(path, UriKind.Absolute);
+                if (srcW > decodeMax || srcH > decodeMax)
+                {
+                    if (srcW >= srcH) bmp.DecodePixelWidth = decodeMax;
+                    else bmp.DecodePixelHeight = decodeMax;
+                }
+                bmp.EndInit();
+                bmp.Freeze();
+
+                data.Frames.Add(bmp);
+                data.Width = bmp.PixelWidth;
+                data.Height = bmp.PixelHeight;
+                data.FrameDelay = TimeSpan.FromMilliseconds(100);
+            }
+            catch (Exception ex)
+            {
+                App.Logger.Debug("Could not load GIF as static image: {Error}", ex.Message);
             }
         }
 
@@ -861,85 +854,9 @@ namespace ConditioningControlPanel.Services
             return Math.Clamp(dim, 256, 2048);
         }
 
-        /// <summary>
-        /// Aspect-preserving target size so the longest edge is at most <paramref name="maxDim"/>.
-        /// Never upscales (returns the source size if already within the cap).
-        /// </summary>
-        private static (int w, int h) ScaledSize(int srcW, int srcH, int maxDim)
-        {
-            if (srcW <= 0 || srcH <= 0) return (srcW, srcH);
-            int longest = Math.Max(srcW, srcH);
-            if (longest <= maxDim) return (srcW, srcH);
-            double ratio = (double)maxDim / longest;
-            return (Math.Max(1, (int)Math.Round(srcW * ratio)),
-                    Math.Max(1, (int)Math.Round(srcH * ratio)));
-        }
-
-        /// <summary>
-        /// Produces a downscaled 32bpp copy of <paramref name="src"/> at the given size using
-        /// high-quality bicubic resampling. Caller owns (and must dispose) the returned bitmap.
-        /// </summary>
-        private static System.Drawing.Bitmap DownscaleBitmap(System.Drawing.Bitmap src, int w, int h)
-        {
-            var scaled = new System.Drawing.Bitmap(w, h, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-            using (var g = Graphics.FromImage(scaled))
-            {
-                g.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                g.PixelOffsetMode = PixelOffsetMode.Half;
-                g.DrawImage(src, 0, 0, w, h);
-            }
-            return scaled;
-        }
-
-        private BitmapSource ConvertToBitmapSource(System.Drawing.Bitmap bitmap)
-        {
-            // Convert to 32bpp ARGB to ensure consistent format for WPF
-            // This fixes issues with JPEGs (24-bit RGB) and other formats
-            System.Drawing.Bitmap convertedBitmap;
-            bool needsDispose = false;
-
-            if (bitmap.PixelFormat != System.Drawing.Imaging.PixelFormat.Format32bppArgb)
-            {
-                convertedBitmap = new System.Drawing.Bitmap(bitmap.Width, bitmap.Height,
-                    System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-                using (var g = System.Drawing.Graphics.FromImage(convertedBitmap))
-                {
-                    g.DrawImage(bitmap, 0, 0, bitmap.Width, bitmap.Height);
-                }
-                needsDispose = true;
-            }
-            else
-            {
-                convertedBitmap = bitmap;
-            }
-
-            try
-            {
-                var bitmapData = convertedBitmap.LockBits(
-                    new System.Drawing.Rectangle(0, 0, convertedBitmap.Width, convertedBitmap.Height),
-                    ImageLockMode.ReadOnly,
-                    System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-
-                var bitmapSource = BitmapSource.Create(
-                    convertedBitmap.Width, convertedBitmap.Height,
-                    96, 96,
-                    PixelFormats.Bgra32,
-                    null,
-                    bitmapData.Scan0,
-                    bitmapData.Stride * convertedBitmap.Height,
-                    bitmapData.Stride);
-
-                convertedBitmap.UnlockBits(bitmapData);
-                return bitmapSource;
-            }
-            finally
-            {
-                if (needsDispose)
-                {
-                    convertedBitmap.Dispose();
-                }
-            }
-        }
+        // ScaledSize / DownscaleBitmap / ConvertToBitmapSource (the GDI+ decode helpers)
+        // were removed with the LoadGifFrames SKCodec migration (#486) — no flash decode
+        // path touches System.Drawing anymore.
 
         #endregion
 

--- a/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
+++ b/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
@@ -20,6 +20,11 @@ namespace ConditioningControlPanel.Services;
 /// composition (per-frame required-frame/blend handling that raw WIC frames don't give you),
 /// with no dependency on the OS "WebP Image Extensions" codec being installed.
 ///
+/// Despite the name, SKCodec is format-agnostic: since the #486 native-OOM fix these same
+/// entry points also decode animated GIFs (FlashService.LoadGifFrames, chaos wash, tease
+/// bubbles), replacing GDI+/XamlAnimatedGif's uncapped native-resolution decodes. Note GIF's
+/// rare "restore previous" disposal isn't modeled (WebP has none) — acceptable for effects.
+///
 /// Two consumption shapes:
 ///  - <see cref="DecodeFrames"/> → frozen frame list + delay for FlashService's heartbeat
 ///    frame-stepper (mirrors its LoadGifFrames memory budget).

--- a/ConditioningControlPanel/Services/Notifications/TrayIconService.cs
+++ b/ConditioningControlPanel/Services/Notifications/TrayIconService.cs
@@ -110,6 +110,13 @@ namespace ConditioningControlPanel.Services;
 
             _notifyIcon.ContextMenuStrip = contextMenu;
             _notifyIcon.DoubleClick += (s, e) => ShowWindow();
+            // Single left-click restores too — users expect it, and "clicking the tray
+            // icon does nothing" reads as the app being gone (#475). Right-click still
+            // opens the context menu; a double-click just calls ShowWindow twice (no-op).
+            _notifyIcon.MouseClick += (s, e) =>
+            {
+                if (e.Button == MouseButtons.Left) ShowWindow();
+            };
 
             App.Logger?.Debug("Tray icon initialized");
         }
@@ -146,7 +153,7 @@ namespace ConditioningControlPanel.Services;
         {
             _hasShownFirstMinimizeNotification = true;
             _notifyIcon?.ShowBalloonTip(2000, "Conditioning Control Panel",
-                "Running in background. Double-click to restore.", ToolTipIcon.Info);
+                "Running in background. Click the tray icon to restore.", ToolTipIcon.Info);
         }
     }
 
@@ -168,10 +175,50 @@ namespace ConditioningControlPanel.Services;
 
         _mainWindow.Show();
         _mainWindow.WindowState = WindowState.Normal;
+        EnsureOnScreen();
         var windowHandle = new System.Windows.Interop.WindowInteropHelper(_mainWindow).Handle;
         SetForegroundWindow(windowHandle);
+        _mainWindow.Activate();
         // Hide() is now redundant since we already set Visible = false above
         OnShowRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// MinimizeToTray uses Hide(), so the window keeps its last Left/Top. If that spot
+    /// is no longer on any live screen (monitor unplugged / display change while hidden)
+    /// the restored window is invisible and the tray icon looks broken (#475).
+    /// </summary>
+    private void EnsureOnScreen()
+    {
+        try
+        {
+            var screens = Screen.AllScreens;
+            if (screens == null || screens.Length == 0) return;
+
+            var source = System.Windows.Interop.HwndSource.FromHwnd(
+                new System.Windows.Interop.WindowInteropHelper(_mainWindow).Handle);
+            var toDevice = source?.CompositionTarget?.TransformToDevice;
+            double sx = toDevice?.M11 ?? 1.0, sy = toDevice?.M22 ?? 1.0;
+
+            var rect = new Rectangle(
+                (int)(_mainWindow.Left * sx), (int)(_mainWindow.Top * sy),
+                (int)(_mainWindow.ActualWidth * sx), (int)(_mainWindow.ActualHeight * sy));
+
+            foreach (var screen in screens)
+            {
+                var visible = Rectangle.Intersect(screen.WorkingArea, rect);
+                if (visible.Width >= 60 && visible.Height >= 30) return; // enough to grab the title bar
+            }
+
+            var wa = (Screen.PrimaryScreen ?? screens[0]).WorkingArea;
+            _mainWindow.Left = wa.Left / sx + (wa.Width / sx - _mainWindow.ActualWidth) / 2.0;
+            _mainWindow.Top = wa.Top / sy + (wa.Height / sy - _mainWindow.ActualHeight) / 2.0;
+            App.Logger?.Information("Tray restore: window was off-screen, re-centered on primary");
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("TrayIconService.EnsureOnScreen failed: {Error}", ex.Message);
+        }
     }
 
     public void ShowNotification(string title, string message, ToolTipIcon icon = ToolTipIcon.Info)

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -173,6 +173,14 @@ namespace ConditioningControlPanel.Services
         public bool IsPlaying => _videoPlaying;
 
         /// <summary>
+        /// True while a strict-locked video is actively playing. Escape hatches that
+        /// bypass the main Stop button's lockdown guard (e.g. the avatar's quick menu)
+        /// must respect this — stopping the engine mid-strict-video both defeats the
+        /// lock and races the LibVLC teardown (#479).
+        /// </summary>
+        public bool IsStrictActive => _videoPlaying && _strictActive;
+
+        /// <summary>
         /// Whether any video windows still exist. Stays true through teardown after
         /// <see cref="IsPlaying"/> has already flipped false — use this when something
         /// must not be shown until the fullscreen surfaces are really gone (#462).
@@ -566,13 +574,19 @@ namespace ConditioningControlPanel.Services
             try { Microsoft.Win32.SystemEvents.PowerModeChanged -= OnPowerModeChanged; }
             catch { }
 
-            // Force cleanup of any playing video - use synchronous disposal during stop
-            // because Stop is typically called during app shutdown
+            // Force cleanup of any playing video. Every caller of Stop() is a LIVE stop
+            // (engine stop, panic, remote control, feature toggle) — app shutdown never
+            // routes through here (OnExit ends in Environment.Exit). Use the async
+            // disposal path: synchronous disposal freed the native MediaPlayer while
+            // in-flight LibVLC callbacks could still touch it, a use-after-free that
+            // killed the whole process when the engine was stopped mid-video (#479).
+            // Windows still close immediately either way; only the player Dispose is
+            // deferred ~1s to a background task.
             _videoPlaying = false;
             _strictActive = false;
             try
             {
-                CloseAll(synchronous: true);
+                CloseAll(synchronous: false);
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
## Summary

Fixes the six stability reports from the Jul 3-4 bug-triage pass (ccp-bugs #475, #476, #477, #479, #481, #486). Two commits: a crash/hang batch and a native-memory batch.

### Crash/hang batch (4b80077a)

- **Avatar Stop Engine escape + crash (#479)**: the avatar quick-menu called `MainWindow.StopEngine()` directly, bypassing the Stop button's remote-control/lockdown guards - so a right-click on the companion could kill the engine during a strict-locked video, and the mid-playback teardown crashed the app. Added the same guards plus a new strict gate (`VideoService.IsStrictActive`, strict bubble-count check); the menu item disables while a stop would be refused. `VideoService.Stop()` now takes the async LibVLC dispose drain: the synchronous path freed native players under in-flight callbacks (use-after-free process kill), and no caller of `Stop()` is app shutdown (`OnExit` never calls it and ends in `Environment.Exit`). Windows still close immediately; only the player `Dispose` defers ~1s to a background task.
- **Companion crash when dragged between monitors (#477)**: guarded both drag-path `PointToScreen` calls against the presentation-source rebuild during a mixed-DPI crossing (previously an unhandled `InvalidOperationException`, potentially on the avatar's own UI thread), and added a `WM_DPICHANGED` handler that pauses the 60fps float/breath transform writes for 450ms so the layered window's synchronous DPI resize can't deadlock the busy render thread (the documented `CompleteRender` hang).
- **Startup modal wedge (#481)**: "Update available" and "Enhanced videos detected" are both `ShowDialog()` on the UI thread; whichever nested second owned input while the Topmost update dialog covered it - neither could be dismissed. The enhanced-videos prompt now waits out `App.IsUpdateDialogActive` and holds `IsStartupDialogShowing` while open, so the update path's existing wait loop defers to it.
- **Tray restore does nothing (#475)**: single left-click on the tray icon now restores (only `DoubleClick` was wired); restore `Activate()`s the window and re-centers it when its saved bounds are no longer on any live screen (the window is hidden with `Hide()`, so stale second-monitor coordinates made it come back invisible).

### Native-memory batch (6c46317f) - the 3GB climb (#486) + glitch pop (#476)

- **`FlashService.LoadGifFrames` migrated off GDI+ to SKCodec** via the format-agnostic `AnimatedWebp.DecodeFrames` pipeline (same 30MB/60-frame budget). GDI+ frame decodes retain native Win32 heap under churn - the "managed heap flat, private bytes to 3GB, native OOM with an empty crash log" signature that got the static path moved to WIC. The orphaned GDI+ helpers (`ScaledSize`/`DownscaleBitmap`/`ConvertToBitmapSource`) are removed; no flash decode path touches System.Drawing anymore.
- **Flash decode cache re-keyed by file path only**: performance-tier flapping cached the same file at 2-3 decode sizes, halving capacity and forcing extra decodes exactly under load. Equal-or-larger cached decodes serve smaller requests; replacement releases the old entry's byte accounting.
- **Tease-bubble GIF leak**: GIF faces now ride the same capped SKCodec animation as webp and get `Detach`ed in `Destroy` - the XamlAnimatedGif animator, its native-res frame buffer, and its `CompositionTarget.Rendering` subscription leaked on every dead GIF tease bubble.
- **Glitch bubble pop (#476)**: the full-screen wash's GIF branch decodes capped at 1280px/40 frames (was unbounded native resolution - ~100MB BGRA per large GIF, looped full-screen), and the wash linger drops from ~8s to ~4s so the whole desktop isn't alpha-composited every frame long after the pop.

## Verification

- `dotnet build`: 0 errors; remaining warnings verified pre-existing (line-shifted only).
- Smoke-launched the Debug build: startup clean, 0 `[ERR]`/`[FTL]` in the activity log over the run window, no crash.log; avatar emotes and scheduler running; instance closed cleanly.
- Not yet verified: the #477 DPI quiesce needs a real mixed-DPI two-monitor drag test; #479 needs a strict-locked video + avatar-menu attempt on a live build.

## Known tradeoffs

- `AnimatedWebp.DecodeFrames` rejects GIFs over 4096px on an edge (falls back to a capped still) and doesn't model GIF's rare "restore previous" disposal - cosmetically acceptable for flash/wash/tease effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFcG7qpBZoMTC4KrsKy734