### PR TITLE
fix: functional batch from 6.2.6-6.2.7 triage (session timeline, corner GIF, web video length, takeover UI, season title)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -526,6 +526,18 @@ namespace ConditioningControlPanel
                                 window.chrome.webview.postMessage({ type: 'videoStarted' });
                             };
 
+                            // Report the real video length so C# can enforce it. Relying on
+                            // the 'ended' event alone let the takeover outlive the video:
+                            // sites auto-advance to the next clip after 'ended' consumes our
+                            // once-handlers, so playback just kept going (#484).
+                            const notifyDuration = () => {
+                                if (isFinite(video.duration) && video.duration > 0) {
+                                    window.chrome.webview.postMessage({ type: 'videoDuration', seconds: video.duration });
+                                }
+                            };
+                            if (video.readyState >= 1) notifyDuration();
+                            else video.addEventListener('loadedmetadata', notifyDuration, { once: true });
+
                             // Start playing and go fullscreen
                             video.muted = false;
                             video.play().then(() => {
@@ -557,6 +569,27 @@ namespace ConditioningControlPanel
             {
                 App.Logger?.Warning(ex, "Failed to auto-play/fullscreen video");
             }
+        }
+
+        /// <summary>
+        /// Force-ends a web-video takeover: pauses any playing media in the browser and
+        /// exits both page and forced fullscreen. Called by AutonomyService when playback
+        /// runs past the video's reported length (#484) — typically because the site
+        /// auto-advanced to the next clip after our once-only 'ended' handlers fired.
+        /// </summary>
+        internal void EndWebVideoTakeover()
+        {
+            try
+            {
+                _ = _browser?.WebView?.CoreWebView2?.ExecuteScriptAsync(
+                    "document.querySelectorAll('video,audio').forEach(v => { try { v.pause(); } catch (e) {} });" +
+                    "if (document.exitFullscreen) document.exitFullscreen();");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("EndWebVideoTakeover script failed: {Error}", ex.Message);
+            }
+            try { ExitBrowserFullscreen(); } catch { }
         }
 
         /// <summary>
@@ -682,6 +715,18 @@ namespace ConditioningControlPanel
                     App.Logger?.Information("Web video playback ended");
                     App.Autonomy?.OnWebVideoEnded();
                     ExitBrowserFullscreen();
+                }
+                else if (message.Contains("\"type\":\"videoDuration\""))
+                {
+                    // Real video length reported by the injected JS — lets autonomy
+                    // enforce the takeover actually ending when the video does (#484).
+                    var secMatch = System.Text.RegularExpressions.Regex.Match(message, "\"seconds\":([0-9.]+)");
+                    if (secMatch.Success && double.TryParse(secMatch.Groups[1].Value,
+                            System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture, out var seconds))
+                    {
+                        App.Autonomy?.OnWebVideoDuration(seconds);
+                    }
                 }
                 // Audio sync messages
                 else if (message.Contains("\"type\":\"audioSyncVideoDetected\""))

--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -440,8 +440,19 @@ namespace ConditioningControlPanel
             {
                 _selectedCornerGifPath = dialog.FileName;
                 PresetsTab.BtnSelectCornerGif.Content = $"📁 {System.IO.Path.GetFileName(dialog.FileName)}";
+
+                // Live update during session (#474) — the engine recreates the window
+                if (_sessionEngine != null && _sessionEngine.IsRunning)
+                {
+                    _sessionEngine.UpdateCornerGifPath(dialog.FileName);
+                }
             }
         }
+
+        // Debounce for the corner GIF size slider's live update: the engine recreates
+        // the layered window per change (in-place resize is the render-deadlock trigger
+        // that got the old live update disabled), so only apply once the slider rests.
+        private System.Windows.Threading.DispatcherTimer? _cornerGifSizeDebounce;
 
         internal void SliderCornerGifSize_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
@@ -450,8 +461,36 @@ namespace ConditioningControlPanel
                 PresetsTab.TxtCornerGifSize.Text = $"{(int)e.NewValue}px";
             }
 
-            // Don't live update during session - causes crashes with animated GIFs
-            // Size will be applied when session starts or restarts
+            // Live update during session (#474), debounced 400ms
+            if (_sessionEngine != null && _sessionEngine.IsRunning)
+            {
+                if (_cornerGifSizeDebounce == null)
+                {
+                    _cornerGifSizeDebounce = new System.Windows.Threading.DispatcherTimer
+                    {
+                        Interval = TimeSpan.FromMilliseconds(400)
+                    };
+                    _cornerGifSizeDebounce.Tick += (s, args) =>
+                    {
+                        _cornerGifSizeDebounce?.Stop();
+                        if (_sessionEngine != null && _sessionEngine.IsRunning)
+                        {
+                            _sessionEngine.UpdateCornerGifSize((int)PresetsTab.SliderCornerGifSize.Value);
+                        }
+                    };
+                }
+                _cornerGifSizeDebounce.Stop();
+                _cornerGifSizeDebounce.Start();
+            }
+        }
+
+        internal void RbCornerPos_Checked(object sender, RoutedEventArgs e)
+        {
+            // Live update during session (#474) — position-only move, no recreate
+            if (_sessionEngine != null && _sessionEngine.IsRunning)
+            {
+                _sessionEngine.UpdateCornerGifPosition(GetSelectedCornerPosition());
+            }
         }
 
         internal void SliderCornerGifOpacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)

--- a/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
@@ -179,6 +179,18 @@ namespace ConditioningControlPanel
             // Autonomy Mode
             BambiTakeoverTab.ChkAutonomyEnabled.IsChecked = s.AutonomyModeEnabled;
             UpdateAutonomyButtonState(s.AutonomyModeEnabled);
+            // Clamp persisted values into the sliders' ranges BEFORE assigning: an
+            // out-of-range stored value (old-version scale, cloud-restored settings)
+            // silently clamps the slider to full while the label below keeps its XAML
+            // default — "intensity = 5 shows a full bar" (#485). Write the clamped
+            // value back so the setting and the UI agree.
+            s.AutonomyIntensity = Math.Clamp(s.AutonomyIntensity,
+                (int)BambiTakeoverTab.SliderAutonomyIntensity.Minimum, (int)BambiTakeoverTab.SliderAutonomyIntensity.Maximum);
+            s.AutonomyCooldownSeconds = Math.Clamp(s.AutonomyCooldownSeconds,
+                (int)BambiTakeoverTab.SliderAutonomyCooldown.Minimum, (int)BambiTakeoverTab.SliderAutonomyCooldown.Maximum);
+            s.AutonomyRandomIntervalSeconds = Math.Clamp(s.AutonomyRandomIntervalSeconds,
+                (int)BambiTakeoverTab.SliderAutonomyInterval.Minimum, (int)BambiTakeoverTab.SliderAutonomyInterval.Maximum);
+            s.AutonomyAnnouncementChance = Math.Clamp(s.AutonomyAnnouncementChance, 0, 100);
             BambiTakeoverTab.SliderAutonomyIntensity.Value = s.AutonomyIntensity;
             BambiTakeoverTab.SliderAutonomyCooldown.Value = s.AutonomyCooldownSeconds;
             BambiTakeoverTab.SliderAutonomyInterval.Value = s.AutonomyRandomIntervalSeconds;
@@ -205,6 +217,14 @@ namespace ConditioningControlPanel
             BambiTakeoverTab.ChkSpeechPushToTalk.IsChecked = s.SpeechPushToTalkEnabled && s.MicConsentGiven;
             BambiTakeoverTab.TxtPttKey.Text = string.IsNullOrWhiteSpace(s.SpeechPushToTalkKey) ? "F8" : s.SpeechPushToTalkKey;
             BambiTakeoverTab.SliderAutonomyAnnounce.Value = s.AutonomyAnnouncementChance;
+            // The Slider_Changed handlers bail out while _isLoading, so the value labels
+            // next to these four bars kept their XAML defaults ("5", "60s", "30s", "50%")
+            // regardless of the loaded values — bars and numbers disagreed on startup
+            // (#485). Sync the labels explicitly, matching each handler's format.
+            BambiTakeoverTab.TxtAutonomyIntensity.Text = $"{s.AutonomyIntensity}";
+            BambiTakeoverTab.TxtAutonomyCooldown.Text = $"{s.AutonomyCooldownSeconds}s";
+            BambiTakeoverTab.TxtAutonomyInterval.Text = $"{s.AutonomyRandomIntervalSeconds}s";
+            BambiTakeoverTab.TxtAutonomyAnnounce.Text = $"{s.AutonomyAnnouncementChance}%";
             RefreshAutonomyVoiceHint(); // reflect any wake/PTT suppression in the surprise-mantras hint
 
             // Bouncing Text Size (add if not already loaded above)

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -1482,12 +1482,62 @@ namespace ConditioningControlPanel.Services
             // Also bump the watchdog generation - if a stale watchdog is still pending,
             // we don't want it firing later and overwriting state for a new video.
             _webVideoWatchdogGeneration++;
+            _webVideoDurationGeneration++;   // cancel the pending duration hard stop too
 
             if (_webVideoActive)
             {
                 _webVideoActive = false;
                 App.Logger?.Information("AutonomyService: Web video ended, autonomy actions resumed");
             }
+        }
+
+        // Generation counter for the duration-based hard stop. Separate from the load
+        // watchdog generation: OnWebVideoStarted bumps that one (and started/duration
+        // messages can arrive in either order), while only OnWebVideoEnded should cancel
+        // a scheduled hard stop.
+        private int _webVideoDurationGeneration;
+
+        /// <summary>
+        /// Called by MainWindow when the injected JS reports the video's real length.
+        /// Schedules a hard stop at duration + grace: relying on the JS 'ended' event
+        /// alone let the takeover run past the video — sites auto-advance to the next
+        /// clip after 'ended' consumes the once-only handlers (#484). The 'ended' path
+        /// is still the normal, earlier terminator.
+        /// </summary>
+        public void OnWebVideoDuration(double seconds)
+        {
+            if (!_webVideoActive) return;
+            if (double.IsNaN(seconds) || double.IsInfinity(seconds) || seconds <= 0) return; // live streams etc.
+
+            var gen = ++_webVideoDurationGeneration;
+            var cap = TimeSpan.FromSeconds(Math.Min(seconds + 15, 3600)); // +15s grace, 1h sanity ceiling
+            App.Logger?.Information("AutonomyService: Web video reports {Seconds:F0}s - hard stop scheduled at +{Cap:F0}s",
+                seconds, cap.TotalSeconds);
+
+            Task.Delay(cap).ContinueWith(_ =>
+            {
+                if (!_webVideoActive || _webVideoDurationGeneration != gen) return;
+                if (Application.Current?.Dispatcher == null) return;
+                Application.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        if (!_webVideoActive || _webVideoDurationGeneration != gen) return;
+                        App.Logger?.Information("AutonomyService: Web video ran past its reported length - force-ending takeover");
+                        var mainWindow = Application.Current?.MainWindow as MainWindow
+                            ?? Application.Current?.Windows.OfType<MainWindow>().FirstOrDefault();
+                        mainWindow?.EndWebVideoTakeover();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning(ex, "AutonomyService: web video hard stop failed");
+                    }
+                    finally
+                    {
+                        OnWebVideoEnded();
+                    }
+                });
+            });
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
@@ -64,9 +64,19 @@ public class QuestDefinitionService : IDisposable
     };
 
     /// <summary>
-    /// Current season title (from server or default month name)
+    /// Current season title (from server or default month name). The cached server
+    /// title is only trusted while it was fetched in the CURRENT UTC month: the
+    /// month-rollover refetch (IsCacheStale) fires on startup, but when it fails —
+    /// offline launch, server hiccup — RefreshFromServerAsync leaves the old cache
+    /// loaded, and the Quests header kept showing last month's season ("Juicy June"
+    /// in July, #480). Falling back to the local month name self-corrects on the 1st
+    /// even with no network; the next successful refetch restores the server title.
     /// </summary>
-    public string SeasonTitle => _cache?.SeasonTitle
+    public string SeasonTitle =>
+        (_cache?.FetchedAt is { } fetched
+            && fetched.Year == DateTime.UtcNow.Year
+            && fetched.Month == DateTime.UtcNow.Month
+            ? _cache?.SeasonTitle : null)
         ?? DefaultMonthNames.GetValueOrDefault(DateTime.Now.Month, DateTime.Now.ToString("MMMM"));
 
     public QuestDefinitionService()

--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -186,8 +186,20 @@ namespace ConditioningControlPanel.Services
             // Start Mind Wipe if enabled (escalating frequency)
             if (session.Settings.MindWipeEnabled)
             {
-                App.MindWipe.Volume = session.Settings.MindWipeVolume / 100.0;
-                App.MindWipe.StartSession(session.Settings.MindWipeBaseMultiplier);
+                if (session.Settings.MindWipeStartMinute == 0)
+                {
+                    App.MindWipe.Volume = session.Settings.MindWipeVolume / 100.0;
+                    App.MindWipe.StartSession(session.Settings.MindWipeBaseMultiplier);
+                }
+                else
+                {
+                    var mw = session.Settings;
+                    DeferFeatureStart("mind wipe", mw.MindWipeStartMinute, () =>
+                    {
+                        App.MindWipe.Volume = mw.MindWipeVolume / 100.0;
+                        App.MindWipe.StartSession(mw.MindWipeBaseMultiplier);
+                    });
+                }
             }
             
             // Start main timer (updates every second)
@@ -262,7 +274,10 @@ namespace ConditioningControlPanel.Services
             _mainTimer = null;
             _phaseTimer?.Stop();
             _phaseTimer = null;
-            
+
+            // Drop any not-yet-fired deferred feature starts (#483)
+            _pendingFeatureStarts.Clear();
+
             // Close corner GIF
             CloseCornerGif();
             
@@ -419,20 +434,22 @@ namespace ConditioningControlPanel.Services
             _mainTimer?.Start();
             _phaseTimer?.Start();
 
-            // Re-apply current session settings to restart services
+            // Re-apply current session settings to restart services. Skip features whose
+            // deferred timeline start (#483) hasn't arrived yet — CheckDelayedFeatures
+            // fires them when due; elapsed time survives the pause.
             var settings = _currentSession.Settings;
-            if (settings.FlashEnabled) App.Flash?.Start();
-            if (settings.SubliminalEnabled) App.Subliminal?.Start();
+            if (settings.FlashEnabled && !IsFeaturePending("flash")) App.Flash?.Start();
+            if (settings.SubliminalEnabled && !IsFeaturePending("subliminal")) App.Subliminal?.Start();
             if (settings.BubblesEnabled) App.Bubbles?.Start();
-            if (settings.LockCardEnabled) App.LockCard?.Start();
+            if (settings.LockCardEnabled && !IsFeaturePending("lock cards")) App.LockCard?.Start();
             if (App.Settings.Current.PopQuizEnabled) App.PopQuiz?.Start();
-            if (settings.BubbleCountEnabled) App.BubbleCount?.Start();
-            if (settings.BouncingTextEnabled) App.BouncingText?.Start();
-            if (settings.MindWipeEnabled)
+            if (settings.BubbleCountEnabled && !IsFeaturePending("bubble count")) App.BubbleCount?.Start();
+            if (settings.BouncingTextEnabled && !IsFeaturePending("bouncing text")) App.BouncingText?.Start();
+            if (settings.MindWipeEnabled && !IsFeaturePending("mind wipe"))
                 App.MindWipe?.Start(settings.MindWipeBaseMultiplier, settings.MindWipeVolume / 100.0);
             // DISABLED: Brain Drain is up for rework due to performance issues
             // if (_brainDrainActive && App.Settings.Current.IsLevelUnlocked(70)) App.BrainDrain?.Start();
-            if (settings.MandatoryVideosEnabled) App.Video?.Start();
+            if (settings.MandatoryVideosEnabled && !IsFeaturePending("mandatory videos")) App.Video?.Start();
             // Re-enable overlays via the overlay service
             App.Overlay?.Start();
 
@@ -583,7 +600,26 @@ namespace ConditioningControlPanel.Services
         {
             if (_currentSession == null) return;
             var settings = _currentSession.Settings;
-            
+
+            // Deferred feature starts queued by ApplySessionSettings (timeline start
+            // events, #483). Reverse-iterate so firing removes in place.
+            for (int i = _pendingFeatureStarts.Count - 1; i >= 0; i--)
+            {
+                var pending = _pendingFeatureStarts[i];
+                if (elapsedMinutes < pending.StartMinute) continue;
+                _pendingFeatureStarts.RemoveAt(i);
+                try
+                {
+                    pending.Start();
+                    App.Logger?.Information("Session: {Feature} started at {Minutes:F1} minutes (target was {Target})",
+                        pending.Name, elapsedMinutes, pending.StartMinute);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Warning(ex, "Session: deferred start of {Feature} failed", pending.Name);
+                }
+            }
+
             // Pink filter delayed start (use randomized time)
             if (settings.PinkFilterEnabled && !App.Settings.Current.PinkFilterEnabled)
             {
@@ -821,10 +857,29 @@ namespace ConditioningControlPanel.Services
         private Dictionary<string, bool>? _savedBouncingTextPool;
         private Dictionary<string, bool>? _savedSubliminalPool;
         private Dictionary<string, bool>? _savedLockCardPool;
-        
+
+        // Deferred feature starts (the timeline editor's "start at minute X" events).
+        // The editor serializes a StartMinute for 13 features, but the engine only ever
+        // read four of them (pink filter, spiral, bubbles, corner GIF) — flash, subliminal,
+        // whispers, bouncing text, videos, lock cards, bubble count and mind wipe all
+        // started at t=0 regardless (#483). ApplySessionSettings queues one entry per
+        // delayed feature; CheckDelayedFeatures fires each when its minute arrives. The
+        // four original features keep their bespoke delay paths (randomized starts, ramps).
+        private readonly List<(string Name, int StartMinute, Action Start)> _pendingFeatureStarts = new();
+
+        private void DeferFeatureStart(string name, int startMinute, Action start)
+        {
+            _pendingFeatureStarts.Add((name, startMinute, start));
+            App.Logger?.Information("Session: {Feature} start deferred to minute {Minute}", name, startMinute);
+        }
+
+        private bool IsFeaturePending(string name) =>
+            _pendingFeatureStarts.Any(p => p.Name == name);
+
         private void ApplySessionSettings(SessionSettings settings)
         {
             var current = App.Settings.Current;
+            _pendingFeatureStarts.Clear();
             
             // Flash Images
             current.FlashEnabled = settings.FlashEnabled;
@@ -837,9 +892,17 @@ namespace ConditioningControlPanel.Services
                 current.CorruptionMode = settings.FlashHydra;
                 current.FlashAudioEnabled = settings.FlashAudioEnabled;
 
-                // Start flash service for session
-                App.Flash?.Start();
-                App.Logger?.Information("Session: Started flash images at {Freq}/hour", settings.FlashPerHour);
+                if (settings.FlashStartMinute == 0)
+                {
+                    // Start flash service for session
+                    App.Flash?.Start();
+                    App.Logger?.Information("Session: Started flash images at {Freq}/hour", settings.FlashPerHour);
+                }
+                else
+                {
+                    App.Flash?.Stop();   // engine may already have it running
+                    DeferFeatureStart("flash", settings.FlashStartMinute, () => App.Flash?.Start());
+                }
             }
             else
             {
@@ -876,19 +939,31 @@ namespace ConditioningControlPanel.Services
                         string.Join(", ", settings.SubliminalPhrases));
                 }
 
-                // Start subliminal service for session
-                App.Subliminal?.Start();
+                if (settings.SubliminalStartMinute == 0)
+                {
+                    // Start subliminal service for session
+                    App.Subliminal?.Start();
+                }
+                else
+                {
+                    App.Subliminal?.Stop();
+                    DeferFeatureStart("subliminal", settings.SubliminalStartMinute, () => App.Subliminal?.Start());
+                }
             }
             else
             {
                 App.Subliminal?.Stop();
             }
 
-            // Audio Whispers (Sub Audio)
-            current.SubAudioEnabled = settings.AudioWhispersEnabled;
+            // Audio Whispers (Sub Audio) — flag-driven (no service Start), so a delayed
+            // start just holds the flag off until the minute arrives.
+            current.SubAudioEnabled = settings.AudioWhispersEnabled && settings.AudioWhispersStartMinute == 0;
             if (settings.AudioWhispersEnabled)
             {
                 current.SubAudioVolume = settings.WhisperVolume;
+                if (settings.AudioWhispersStartMinute > 0)
+                    DeferFeatureStart("audio whispers", settings.AudioWhispersStartMinute,
+                        () => App.Settings.Current.SubAudioEnabled = true);
             }
             
             // Audio Ducking - apply session-specific duck level
@@ -923,11 +998,19 @@ namespace ConditioningControlPanel.Services
                     }
                 }
                 
-                // Start bouncing text (bypass level requirement during sessions)
                 App.BouncingText?.Stop(); // Stop first to reset state
-                App.BouncingText?.Start(bypassLevelCheck: true);
-                App.Logger?.Information("Session: Started bouncing text with phrases: {Phrases}",
-                    string.Join(", ", settings.BouncingTextPhrases));
+                if (settings.BouncingTextStartMinute == 0)
+                {
+                    // Start bouncing text (bypass level requirement during sessions)
+                    App.BouncingText?.Start(bypassLevelCheck: true);
+                    App.Logger?.Information("Session: Started bouncing text with phrases: {Phrases}",
+                        string.Join(", ", settings.BouncingTextPhrases));
+                }
+                else
+                {
+                    DeferFeatureStart("bouncing text", settings.BouncingTextStartMinute,
+                        () => App.BouncingText?.Start(bypassLevelCheck: true));
+                }
             }
             else
             {
@@ -985,7 +1068,15 @@ namespace ConditioningControlPanel.Services
                 {
                     current.VideosPerHour = settings.VideosPerHour.Value;
                 }
-                App.Video?.Start();
+                if (settings.MandatoryVideosStartMinute == 0)
+                {
+                    App.Video?.Start();
+                }
+                else
+                {
+                    App.Video?.Stop();
+                    DeferFeatureStart("mandatory videos", settings.MandatoryVideosStartMinute, () => App.Video?.Start());
+                }
             }
             else
             {
@@ -1019,7 +1110,15 @@ namespace ConditioningControlPanel.Services
                         string.Join(", ", settings.LockCardPhrases));
                 }
 
-                App.LockCard?.Start();
+                if (settings.LockCardStartMinute == 0)
+                {
+                    App.LockCard?.Start();
+                }
+                else
+                {
+                    App.LockCard?.Stop();
+                    DeferFeatureStart("lock cards", settings.LockCardStartMinute, () => App.LockCard?.Start());
+                }
             }
             else
             {
@@ -1043,7 +1142,15 @@ namespace ConditioningControlPanel.Services
                 {
                     current.BubbleCountFrequency = settings.BubbleCountFrequency.Value;
                 }
-                App.BubbleCount?.Start();
+                if (settings.BubbleCountStartMinute == 0)
+                {
+                    App.BubbleCount?.Start();
+                }
+                else
+                {
+                    App.BubbleCount?.Stop();
+                    DeferFeatureStart("bubble count", settings.BubbleCountStartMinute, () => App.BubbleCount?.Start());
+                }
             }
             else
             {
@@ -1321,28 +1428,66 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Updates the corner GIF size during an active session
+        /// Updates the corner GIF size during an active session (#474). The window is
+        /// RECREATED, not resized in place: resizing a realized AllowsTransparency window
+        /// while its GIF is animating runs a synchronous CompleteRender that can deadlock
+        /// the render thread — the crash that originally got the size slider's live
+        /// update disabled. Close+Show is the same path the CornerGifEndMinute timer
+        /// already exercises mid-session. Callers should debounce (the UI slider does).
         /// </summary>
         public void UpdateCornerGifSize(int newSize)
         {
-            if (_cornerGifWindow == null || _currentSession == null) return;
-            if (_cornerGifWidth <= 0 || _cornerGifHeight <= 0) return; // No cached dimensions
+            if (_currentSession == null) return;
 
             try
             {
-                // Update the session settings
                 _currentSession.Settings.CornerGifSize = newSize;
+                if (_cornerGifWindow == null) return; // not shown (yet) — start timer will pick the value up
+                CloseCornerGif();
+                ShowCornerGif(_currentSession.Settings);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "Failed to update corner GIF size");
+            }
+        }
 
-                // Use cached GIF dimensions instead of reloading the file
-                double gifWidth = _cornerGifWidth;
-                double gifHeight = _cornerGifHeight;
+        /// <summary>
+        /// Swaps the corner GIF file during an active session (#474). Recreates the
+        /// window (see UpdateCornerGifSize for why in-place changes are avoided; a new
+        /// file changes the window dimensions anyway).
+        /// </summary>
+        public void UpdateCornerGifPath(string path)
+        {
+            if (_currentSession == null) return;
 
-                // Calculate new window size
-                double scale = newSize / Math.Max(gifWidth, gifHeight);
-                double windowWidth = gifWidth * scale;
-                double windowHeight = gifHeight * scale;
+            try
+            {
+                _currentSession.Settings.CornerGifPath = path;
+                if (_cornerGifWindow == null) return;
+                CloseCornerGif();
+                ShowCornerGif(_currentSession.Settings);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "Failed to update corner GIF path");
+            }
+        }
 
-                // Get screen bounds
+        /// <summary>
+        /// Moves the corner GIF to another corner during an active session (#474).
+        /// Position-only change (Left/Top) — moving a layered window doesn't touch its
+        /// render surface, so no recreate is needed.
+        /// </summary>
+        public void UpdateCornerGifPosition(CornerPosition position)
+        {
+            if (_currentSession == null) return;
+
+            try
+            {
+                _currentSession.Settings.CornerGifPosition = position;
+                if (_cornerGifWindow == null) return;
+
                 var screen = System.Windows.Forms.Screen.PrimaryScreen;
                 if (screen == null) return;
 
@@ -1354,10 +1499,11 @@ namespace ConditioningControlPanel.Services
 
                 double screenWidth = screen.Bounds.Width / dpiScale;
                 double screenHeight = screen.Bounds.Height / dpiScale;
+                double windowWidth = _cornerGifWindow.Width;
+                double windowHeight = _cornerGifWindow.Height;
 
-                // Recalculate position
                 double left = 0, top = 0;
-                switch (_currentSession.Settings.CornerGifPosition)
+                switch (position)
                 {
                     case CornerPosition.TopLeft:
                         left = 0; top = 0;
@@ -1373,15 +1519,12 @@ namespace ConditioningControlPanel.Services
                         break;
                 }
 
-                // Update window
-                _cornerGifWindow.Width = windowWidth;
-                _cornerGifWindow.Height = windowHeight;
                 _cornerGifWindow.Left = left;
                 _cornerGifWindow.Top = top;
             }
             catch (Exception ex)
             {
-                App.Logger?.Error(ex, "Failed to update corner GIF size");
+                App.Logger?.Error(ex, "Failed to update corner GIF position");
             }
         }
 

--- a/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml
@@ -513,13 +513,13 @@
                                             <RowDefinition Height="Auto"/>
                                         </Grid.RowDefinitions>
                                         <RadioButton x:Name="RbCornerTL" x:FieldModifier="internal" Content="{loc:Str btn_top_left}" Foreground="White"
-                                                     GroupName="CornerPos" Margin="0,2" FontSize="10"/>
+                                                     GroupName="CornerPos" Margin="0,2" FontSize="10" Checked="RbCornerPos_Checked"/>
                                         <RadioButton x:Name="RbCornerTR" x:FieldModifier="internal" Grid.Column="1" Content="{loc:Str btn_top_right}"
-                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10"/>
+                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10" Checked="RbCornerPos_Checked"/>
                                         <RadioButton x:Name="RbCornerBL" Grid.Row="1" Content="{loc:Str btn_bottom_left}"
-                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10" IsChecked="True"/>
+                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10" IsChecked="True" Checked="RbCornerPos_Checked"/>
                                         <RadioButton x:Name="RbCornerBR" x:FieldModifier="internal" Grid.Row="1" Grid.Column="1" Content="{loc:Str btn_bottom_right}"
-                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10"/>
+                                                     Foreground="White" GroupName="CornerPos" Margin="0,2" FontSize="10" Checked="RbCornerPos_Checked"/>
                                     </Grid>
     
                                     <!-- Size Slider -->

--- a/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/PresetsTabView.xaml.cs
@@ -97,6 +97,11 @@ namespace ConditioningControlPanel.Views.Tabs
             if (Window.GetWindow(this) is MainWindow mw)
                 mw.SessionBtn_Export(sender, e);
         }
+        private void RbCornerPos_Checked(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.RbCornerPos_Checked(sender, e);
+        }
         private void SessionCard_Click(object sender, MouseButtonEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw)


### PR DESCRIPTION
## Summary

The functional (non-crash) fixes from the Jul 3-4 triage pass: ccp-bugs #474, #480, #483, #484, #485. Companion to the stability batch in #56 - no file overlap between the two branches.

- **Session timeline start times honored (#483)**: the session editor serializes a "start at minute X" for 13 features, but `SessionEngine` only ever read four (pink filter, spiral, bubbles, corner GIF) - flash (the reported one), subliminal, audio whispers, bouncing text, mandatory videos, lock cards, bubble count and mind wipe all started at t=0 regardless. Added a generic deferred-start queue (`DeferFeatureStart`/`IsFeaturePending`) fired from the tick loop; pause/resume skips still-pending features and lets them fire when due; session stop clears the queue.
- **Corner GIF editable mid-session (#474)**: file picker, position radios, and size slider now live-update during a session. The old size updater existed but was never called - its in-place resize of a realized `AllowsTransparency` window mid-GIF-animation is the render-thread deadlock that got live updates disabled in the first place. Size/path changes now RECREATE the window (the same close+reshow path the `CornerGifEndMinute` timer already exercises); position changes move it without touching the surface; the size slider is debounced 400ms.
- **Web video takeover enforces video length (#484)**: the injected JS reports `video.duration` on loadedmetadata, and `AutonomyService.OnWebVideoDuration` schedules a hard stop at duration + 15s grace (1h ceiling) that pauses page media, exits fullscreen, and releases the takeover. Root cause: sites auto-advance to the next clip after `ended` consumed the once-only handlers, so playback just kept going; the 30s "watchdog" only unblocked autonomy without ending anything. The JS `ended` event remains the normal, earlier terminator; the hard stop cancels via its own generation counter on any real end.
- **Takeover cadence bars vs labels (#485)**: the four value labels ("5", "60s", "30s", "50%") kept their XAML defaults on startup because the `Changed` handlers bail while `_isLoading` - so the bars showed loaded values while the numbers showed defaults ("intensity = 5 shows a full bar"). Labels now sync on settings load, and persisted values are clamped into the sliders' ranges first (an out-of-range stored value silently clamped a bar to full).
- **Stale "Juicy June" season title (#480)**: the quests header preferred the cached server title unconditionally; when the month-rollover refetch failed (offline launch, server hiccup) last month's title survived. The cache is now only trusted when fetched in the current UTC month, with the local month-name fallback self-correcting on the 1st.

## Verification

- `dotnet build`: 0 errors (same pre-existing warning set).
- Smoke-launched the Debug build: alive past startup, 0 `[ERR]`/`[FTL]` in the activity log, settings-load path (which runs the new label sync + clamps) executed at boot; instance closed cleanly.
- Not yet exercised in a real session: deferred feature starts firing mid-session, corner-GIF live edits during the gamer-girl preset, and the web-video hard stop against a live HypnoTube auto-advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFcG7qpBZoMTC4KrsKy734