### PR TITLE
fix: resolve flash-window CompleteRender UI hangs + add hang-hunt harness

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -824,6 +824,59 @@ namespace ConditioningControlPanel
             }
         }
 
+        // HANG HUNT stress driver — see the `--stress` call site in OnStartup. Runs entirely on the UI
+        // thread via a fast DispatcherTimer (mirrors how chaos/triggers really drive these services), so
+        // when the render thread deadlocks the ticks simply stop and the external watcher captures it.
+        private void StartHangStressMode()
+        {
+            int EnvInt(string name, int fallback) =>
+                int.TryParse(Environment.GetEnvironmentVariable(name), out int v) && v > 0 ? v : fallback;
+
+            int tickMs      = EnvInt("CCP_STRESS_TICK_MS", 12);   // loop period
+            int spawnPer    = EnvInt("CCP_STRESS_SPAWN", 3);      // bubble spawns per tick (layered-window churn)
+            int flashEvery  = EnvInt("CCP_STRESS_FLASH_EVERY", 6);// flash-window churn cadence (in ticks)
+            int toggleEvery = EnvInt("CCP_STRESS_TOGGLE_EVERY", 40); // shared-host create/close churn cadence
+
+            try { Logger?.Warning("[STRESS] Hang-hunt stress mode ON — tick={Tick}ms spawn={Spawn} flashEvery={Flash} toggleEvery={Toggle}", tickMs, spawnPer, flashEvery, toggleEvery); } catch { }
+
+            // Make sure the bubble engine is actually running so spawns render (bypass the level gate).
+            try { Bubbles?.Start(bypassLevelCheck: true); } catch { }
+
+            long tick = 0;
+            var timer = new System.Windows.Threading.DispatcherTimer(System.Windows.Threading.DispatcherPriority.Normal)
+            {
+                Interval = TimeSpan.FromMilliseconds(tickMs)
+            };
+            timer.Tick += (s, _) =>
+            {
+                tick++;
+                // Bubble spawns — SpawnOnce self-marshals and respects its own cap, so continuous calls
+                // keep create/destroy churn at the cap indefinitely.
+                for (int i = 0; i < spawnPer; i++)
+                    try { Bubbles?.SpawnOnce(); } catch { }
+
+                // Flash windows — pool churn (create/show/hide of layered flash surfaces).
+                if (tick % flashEvery == 0)
+                    try { Flash?.TriggerFlashOnce(); } catch { }
+
+                // The prime suspect: flip the shared-host flag so the click-through host window is
+                // created and closed repeatedly — the keep-alive contract warns this deadlocks the
+                // render thread. This is the single most likely provocateur of the hang.
+                if (tick % toggleEvery == 0 && Settings?.Current != null)
+                {
+                    try
+                    {
+                        Settings.Current.BubbleSharedHost = !Settings.Current.BubbleSharedHost;
+                        Settings.Current.ChaosBubbleSharedHost = Settings.Current.BubbleSharedHost;
+                    }
+                    catch { }
+                }
+            };
+            timer.Start();
+            _hangStressTimer = timer; // root it so it isn't collected
+        }
+        private System.Windows.Threading.DispatcherTimer? _hangStressTimer;
+
         protected override void OnStartup(StartupEventArgs e)
         {
             // Dump-writer mode: spawned by UiHangWatchdog in a WEDGED sibling CCP process
@@ -1600,6 +1653,14 @@ namespace ConditioningControlPanel
             // Same problem hits anywhere code does `Application.Current.MainWindow as MainWindow`
             // — popups, feature controls, etc. Expose a stable static reference.
             MainWindowRef = mainWindow;
+
+            // HANG HUNT: `--stress` drives the layered-window subsystems (bubbles, flash, shared-host
+            // create/close) at max rate to provoke the recurring render-thread deadlock quickly, so the
+            // external watcher (hang-hunt.ps1) can auto-capture a stack the moment the UI thread wedges.
+            // Dead code in every normal launch — only runs when the flag is passed. Intensity is tunable
+            // via env vars so the harness can dial it without a rebuild.
+            if (e.Args.Contains("--stress"))
+                StartHangStressMode();
 
             // Arm the offline mic features (wake word / push-to-talk) at startup if the user left them
             // on. They're decoupled from Takeover ("She's Listening" owns them), so they no longer wait

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -46,6 +46,15 @@ namespace ConditioningControlPanel.Services
         // (which both starved CompleteRender into the resize deadlock and drove the native-memory
         // ramp — managed heap stayed ~82MB while private memory hit 3GB). 10 relieves both.
         private const int MAX_CONCURRENT_FLASH = 10;
+        // Per-window shells are sized to a coarse bucket grid so the pool recycles by size instead of
+        // realizing a fresh window on nearly every (image-sized, so almost-always-unique) flash. A fresh
+        // Window.Show() runs a synchronous MediaContext.CompleteRender on first realization; under a
+        // backed-up render thread that call never returns and wedges the whole UI (dump-confirmed
+        // 2026-07-05). Bucketing => the pool hits => almost no fresh realizations on the hot path.
+        // SLACK guarantees the bucket is large enough to center the glow border inside without clipping.
+        private const int FLASH_SHELL_BUCKET = 128;
+        private const int FLASH_SHELL_SLACK = 64;
+        private static int BucketUp(int v) => ((Math.Max(0, v) + FLASH_SHELL_SLACK + FLASH_SHELL_BUCKET - 1) / FLASH_SHELL_BUCKET) * FLASH_SHELL_BUCKET;
         private List<string> _imageList = new();  // Cached image list for random selection
         private List<(string PackId, PackFileEntry File)> _packImageList = new();  // Cached pack images for random selection
         private Queue<string> _soundQueue = new();  // Performance: Changed to Queue for O(1) dequeue
@@ -1059,9 +1068,15 @@ namespace ConditioningControlPanel.Services
                 // on the compositor and deadlocks the UI thread under chaos load (see AcquireFlashWindow).
                 // Left/Top is a move (no surface resize) and is safe on a live window.
                 // (A host-mode state bag has no hwnd, so sizing it is plain property storage.)
+                // True display size (from the image geometry) vs. the bucketed per-window shell that
+                // the pool recycles. Host mode has no window shell, so it stays at true size.
+                int trueW = geom.Width, trueH = geom.Height;
+                int shellW = useHost ? trueW : BucketUp(trueW);
+                int shellH = useHost ? trueH : BucketUp(trueH);
+
                 window = useHost
-                    ? new FlashWindow { UsesHost = true, Width = geom.Width, Height = geom.Height }
-                    : AcquireFlashWindow(geom.Width, geom.Height);
+                    ? new FlashWindow { UsesHost = true, Width = trueW, Height = trueH }
+                    : AcquireFlashWindow(shellW, shellH);
                 window.Left = finalX;
                 window.Top = finalY;
                 window.Frames = imageData.Frames;
@@ -1100,7 +1115,11 @@ namespace ConditioningControlPanel.Services
                 var image = new Image
                 {
                     Stretch = Stretch.Uniform,
-                    Source = imageData.Frames[0]
+                    Source = imageData.Frames[0],
+                    // Pin the display size so centering the flash inside the (larger) bucketed shell
+                    // never rescales it — the visual stays exactly the size/aspect it was before.
+                    Width = trueW,
+                    Height = trueH,
                 };
                 // Cheaper resampling — after decode-at-display-size there is little residual
                 // scaling, so the quality difference is imperceptible while saving GPU fill cost.
@@ -1196,13 +1215,19 @@ namespace ConditioningControlPanel.Services
                     content = border;
                     window.GlowEffect = glowEffect;   // tracked so SafeCloseFlashWindow can stop its animations + free the native blur target
 
-                    // Expand window to accommodate glow padding (in host mode this keeps the
-                    // Left/Top/Width/Height bookkeeping — the gaze rect — matching the visual).
-                    var padding = blurRadius / 2;
-                    window.Width += padding * 2;
-                    window.Height += padding * 2;
-                    window.Left -= padding;
-                    window.Top -= padding;
+                    // Host mode expands the bookkeeping rect (the gaze rect) to match the glow-expanded
+                    // visual. Per-window mode must NOT resize the window here: the shell is already
+                    // bucketed with slack to fit the glow, and the glow border is centered inside it
+                    // (see the shell wrap below). Resizing a pooled/realized layered window is itself a
+                    // synchronous-CompleteRender deadlock trigger — this used to run on every glow flash.
+                    if (useHost)
+                    {
+                        var padding = blurRadius / 2;
+                        window.Width += padding * 2;
+                        window.Height += padding * 2;
+                        window.Left -= padding;
+                        window.Top -= padding;
+                    }
 
                     // Pulsing golden animation for lucky procs
                     if (isLucky)
@@ -1224,11 +1249,10 @@ namespace ConditioningControlPanel.Services
                 }
                 else
                 {
-                    // In host mode the image is a Canvas child, so it needs the black backing and
-                    // explicit size a window shell would otherwise provide.
-                    content = useHost
-                        ? new Border { Background = System.Windows.Media.Brushes.Black, Child = image }
-                        : image;
+                    // The image gets the black backing the window shell used to provide directly: the
+                    // per-window shell background is Transparent now (so the bucket padding stays
+                    // invisible), and host mode needs it because the image is a bare Canvas child.
+                    content = new Border { Background = System.Windows.Media.Brushes.Black, Child = image };
                 }
 
                 if (useHost)
@@ -1260,6 +1284,26 @@ namespace ConditioningControlPanel.Services
                 }
                 else
                 {
+                    // Bucket shell: the window is sized to the pool-recyclable bucket, so render the
+                    // true-size flash CENTERED inside it with invisible transparent padding. Centering
+                    // keeps the visual exactly where it was positioned regardless of shell/glow padding
+                    // (the content's centre == the shell's centre == the intended image centre).
+                    if (shellW > trueW || shellH > trueH)
+                    {
+                        content.HorizontalAlignment = System.Windows.HorizontalAlignment.Center;
+                        content.VerticalAlignment = System.Windows.VerticalAlignment.Center;
+                        content = new Grid
+                        {
+                            Width = shellW,
+                            Height = shellH,
+                            Background = System.Windows.Media.Brushes.Transparent,
+                            Children = { content },
+                        };
+                        window.Left = finalX - (shellW - trueW) / 2.0;
+                        window.Top = finalY - (shellH - trueH) / 2.0;
+                    }
+                    // Shell padding is invisible: the window itself must not paint an opaque background.
+                    window.Background = System.Windows.Media.Brushes.Transparent;
                     window.Content = content;
                     window.Opacity = 0;
 
@@ -2299,6 +2343,17 @@ namespace ConditioningControlPanel.Services
             }
         }
 
+        // WndProc hook for flash windows: drop WM_DPICHANGED so WPF never runs its auto DPI-rescale
+        // (OnDpiChanged -> OnResize -> CompleteRender), which deadlocks the UI thread. See the hook
+        // registration in HideFromAltTab.
+        private static IntPtr SwallowDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            const int WM_DPICHANGED = 0x02E0;
+            if (msg == WM_DPICHANGED)
+                handled = true;   // consume it; WPF's HwndTarget never sees the resize
+            return IntPtr.Zero;
+        }
+
         private void HideFromAltTab(Window window)
         {
             try
@@ -2310,6 +2365,15 @@ namespace ConditioningControlPanel.Services
                     var extendedStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE);
                     NativeMethods.SetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE,
                         extendedStyle | NativeMethods.WS_EX_TOOLWINDOW | NativeMethods.WS_EX_NOACTIVATE);
+
+                    // Swallow WM_DPICHANGED on flash windows. These are transient overlays whose
+                    // per-monitor geometry is already computed manually (CalculateGeometry uses the
+                    // target monitor's DpiScale), so WPF's automatic DPI rescale is unwanted — and its
+                    // OnDpiChanged -> OnResize -> synchronous MediaContext.CompleteRender deadlocks the
+                    // UI thread on a backed-up render thread, especially re-entrantly while a flash window
+                    // is closing (dump-confirmed 2026-07-05). Fired only on cross-DPI-monitor moves, so
+                    // dropping it never affects the initial render.
+                    System.Windows.Interop.HwndSource.FromHwnd(hwnd)?.AddHook(SwallowDpiChanged);
                 };
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/hang-hunt.ps1
+++ b/ConditioningControlPanel/hang-hunt.ps1
@@ -1,0 +1,243 @@
+﻿<#
+.SYNOPSIS
+    Automated UI-hang hunter for Conditioning Control Panel.
+
+    Launches the app in `--stress` mode (hammers bubbles / flash / shared-host churn - the
+    render-thread-deadlock suspects), pings its window a few times a second, and the INSTANT
+    the UI thread stops responding it auto-captures:
+      * a plain-text all-thread managed stack   (dotnet-stack report)   <- read this first
+      * a full process dump                      (dotnet-dump collect)   <- for deep WinDbg/SOS
+      * the tail of the app log + last [CHAOSMEM]/[WATCHDOG]/[STRESS] lines
+    then kills the wedged process, relaunches, and keeps hunting - unattended, for as long as
+    you leave it running. Walk away; come back to a folder of frozen-stack reports.
+
+.EXAMPLE
+    # Just run it and leave. Ctrl+C to stop.
+    powershell -ExecutionPolicy Bypass -File .\hang-hunt.ps1
+
+.EXAMPLE
+    # Hunt harder (more bubbles/tick, flip the shared host more often), stop after 3 catches.
+    .\hang-hunt.ps1 -SpawnPerTick 5 -ToggleEvery 20 -MaxCaptures 3
+
+.NOTES
+    Requires dotnet-stack + dotnet-dump (already installed under ~\.dotnet\tools).
+    Nothing here ships to users - `--stress` is dead code in every normal launch.
+#>
+[CmdletBinding()]
+param(
+    [int]    $HangSeconds  = 6,      # consecutive unresponsive seconds before we call it a hang
+    [int]    $SpawnPerTick = 3,      # bubbles spawned per stress tick   (env CCP_STRESS_SPAWN)
+    [int]    $TickMs       = 12,     # stress loop period in ms           (env CCP_STRESS_TICK_MS)
+    [int]    $FlashEvery   = 6,      # flash-window churn cadence (ticks) (env CCP_STRESS_FLASH_EVERY)
+    [int]    $ToggleEvery  = 40,     # shared-host create/close cadence   (env CCP_STRESS_TOGGLE_EVERY)
+    [int]    $MaxCaptures  = 0,      # stop after N hangs caught (0 = run forever)
+    [int]    $MaxRuntimeMinutes = 0, # self-terminate after N minutes with a survival report (0 = forever)
+    [string] $DumpType     = 'Full', # dotnet-dump type: Full | Heap | Mini | None
+    [string] $ExePath      = '',     # explicit exe path; auto-discovered (newest build) if blank
+    [string] $OutDir       = ''      # where captures land; default = logs\hang-hunt
+)
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# --- Resolve the exe (newest ConditioningControlPanel.exe under bin) ---------------------------
+if (-not $ExePath) {
+    $ExePath = Get-ChildItem -Path (Join-Path $scriptDir 'bin') -Recurse -Filter 'ConditioningControlPanel.exe' -ErrorAction SilentlyContinue |
+               Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $ExePath -or -not (Test-Path $ExePath)) {
+    throw "Could not find ConditioningControlPanel.exe. Build first (dotnet build) or pass -ExePath."
+}
+
+# --- Resolve tooling ---------------------------------------------------------------------------
+$toolsDir     = Join-Path $env:USERPROFILE '.dotnet\tools'
+$dotnetStack  = Join-Path $toolsDir 'dotnet-stack.exe'
+$dotnetDump   = Join-Path $toolsDir 'dotnet-dump.exe'
+if (-not (Test-Path $dotnetStack)) { $dotnetStack = 'dotnet-stack' }
+if (-not (Test-Path $dotnetDump))  { $dotnetDump  = 'dotnet-dump' }
+
+# --- Output dir + app log --------------------------------------------------------------------
+if (-not $OutDir) { $OutDir = Join-Path $env:LOCALAPPDATA 'ConditioningControlPanel\logs\hang-hunt' }
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$logDir   = Join-Path $env:LOCALAPPDATA 'ConditioningControlPanel\logs'
+$manifest = Join-Path $OutDir 'captures.log'
+
+# --- Win32: probe whether the main window is pumping messages ---------------------------------
+if (-not ([System.Management.Automation.PSTypeName]'HangProbe').Type) {
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public static class HangProbe {
+    [DllImport("user32.dll", SetLastError=true)]
+    static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam,
+                                             uint flags, uint timeout, out IntPtr result);
+    [DllImport("user32.dll")] static extern bool IsHungAppWindow(IntPtr hWnd);
+    const uint WM_NULL = 0x0000;
+    const uint SMTO_ABORTIFHUNG = 0x0002;
+    // true = window answered the ping; false = it's wedged / not pumping.
+    public static bool IsResponsive(IntPtr hWnd, uint timeoutMs) {
+        if (hWnd == IntPtr.Zero) return true;            // no window yet (splash/startup) - not a hang
+        // Fast path: OS ghost-window flag. Guarded - this API is undocumented and may be absent
+        // on some builds; if the entry point is missing, fall through to SendMessageTimeout.
+        try { if (IsHungAppWindow(hWnd)) return false; } catch { }
+        IntPtr res;
+        IntPtr ok = SendMessageTimeout(hWnd, WM_NULL, IntPtr.Zero, IntPtr.Zero, SMTO_ABORTIFHUNG, timeoutMs, out res);
+        return ok != IntPtr.Zero;
+    }
+}
+'@
+}
+
+function Write-Line($msg, $color = 'Gray') {
+    $ts = (Get-Date).ToString('HH:mm:ss')
+    Write-Host "[$ts] $msg" -ForegroundColor $color
+}
+
+# --- Capture the frozen state of a wedged pid --------------------------------------------------
+function Capture-Hang([int]$procId) {
+    $stamp = (Get-Date).ToString('yyyyMMdd_HHmmss')
+    $stackFile = Join-Path $OutDir "stack_${stamp}_pid${procId}.txt"
+    $dumpFile  = Join-Path $OutDir "dump_${stamp}_pid${procId}.dmp"
+    $ctxFile   = Join-Path $OutDir "context_${stamp}_pid${procId}.txt"
+
+    Write-Line "HANG on pid $procId - capturing frozen stacks..." 'Yellow'
+
+    # 1) The money shot: every thread's managed stack, as plain text. The diagnostics IPC is served
+    #    by a runtime thread, so this answers even though the UI thread is deadlocked.
+    try {
+        & $dotnetStack report -p $procId *> $stackFile
+        Write-Line "  stack  -> $stackFile" 'Green'
+    } catch { Write-Line "  dotnet-stack FAILED: $($_.Exception.Message)" 'Red' }
+
+    # 2) Full dump for deep analysis (WinDbg / dotnet-dump analyze).
+    if ($DumpType -ne 'None') {
+        try {
+            & $dotnetDump collect -p $procId --type $DumpType -o $dumpFile *>> $ctxFile
+            Write-Line "  dump   -> $dumpFile ($DumpType)" 'Green'
+        } catch { Write-Line "  dotnet-dump FAILED: $($_.Exception.Message)" 'Red' }
+    }
+
+    # 3) Context: tail of today's app log + the telemetry lines that matter.
+    try {
+        $appLog = Get-ChildItem -Path $logDir -Filter 'app-*.log' -ErrorAction SilentlyContinue |
+                  Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($appLog) {
+            "===== last 120 log lines ($($appLog.Name)) =====" | Out-File $ctxFile -Append -Encoding utf8
+            Get-Content $appLog.FullName -Tail 120 | Out-File $ctxFile -Append -Encoding utf8
+            "`n===== last [CHAOSMEM]/[WATCHDOG]/[STRESS] lines =====" | Out-File $ctxFile -Append -Encoding utf8
+            Select-String -Path $appLog.FullName -Pattern '\[CHAOSMEM\]|\[WATCHDOG\]|\[STRESS\]' |
+                Select-Object -Last 25 | ForEach-Object { $_.Line } | Out-File $ctxFile -Append -Encoding utf8
+        }
+        Write-Line "  context-> $ctxFile" 'Green'
+    } catch { }
+
+    # 4) Quick triage: show the UI-thread frames right in the console.
+    try {
+        if (Test-Path $stackFile) {
+            $lines = Get-Content $stackFile
+            $uiIdx = ($lines | Select-String -Pattern 'Thread.*0x' | Select-Object -First 1)
+            Write-Line "  --- top managed frames (see file for all threads) ---" 'Cyan'
+            $lines | Where-Object { $_ -match 'ConditioningControlPanel|System\.Windows|MS\.Internal|SkiaSharp|NAudio' } |
+                Select-Object -First 12 | ForEach-Object { Write-Host "      $_" -ForegroundColor DarkCyan }
+        }
+    } catch { }
+
+    "$stamp  pid=$procId  stack=$([IO.Path]::GetFileName($stackFile))  dump=$([IO.Path]::GetFileName($dumpFile))" |
+        Out-File $manifest -Append -Encoding utf8
+}
+
+# --- Main hunt loop ----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==================== CCP HANG HUNT ====================" -ForegroundColor Magenta
+Write-Line "exe        : $ExePath"
+Write-Line "captures   : $OutDir"
+Write-Line "stress     : spawn=$SpawnPerTick/tick tick=${TickMs}ms flashEvery=$FlashEvery toggleEvery=$ToggleEvery"
+Write-Line "hang after : ${HangSeconds}s unresponsive   dump=$DumpType   maxCaptures=$MaxCaptures"
+Write-Host "======================================================" -ForegroundColor Magenta
+Write-Host "Leave this running. Ctrl+C to stop." -ForegroundColor DarkGray
+Write-Host ""
+
+# Push stress knobs to the child via env (read by App.StartHangStressMode).
+$env:CCP_STRESS_SPAWN        = $SpawnPerTick
+$env:CCP_STRESS_TICK_MS      = $TickMs
+$env:CCP_STRESS_FLASH_EVERY  = $FlashEvery
+$env:CCP_STRESS_TOGGLE_EVERY = $ToggleEvery
+
+$captures  = 0
+$run       = 0
+$probeMs   = 700          # per-ping timeout
+$sampleMs  = 500          # gap between pings
+$needSamples = [int][math]::Ceiling(($HangSeconds * 1000.0) / $sampleMs)
+$huntStart   = Get-Date
+$deadline    = if ($MaxRuntimeMinutes -gt 0) { $huntStart.AddMinutes($MaxRuntimeMinutes) } else { $null }
+function Past-Deadline { $deadline -ne $null -and (Get-Date) -gt $deadline }
+
+try {
+    while ($true) {
+        if (Past-Deadline) {
+            $mins = [int]((Get-Date) - $huntStart).TotalMinutes
+            Write-Line "SURVIVED ${mins}min with $captures capture(s) - no new hang. (ran to MaxRuntimeMinutes)" 'Green'
+            break
+        }
+        $run++
+        Write-Line "launch #$run ..." 'White'
+        $proc = Start-Process -FilePath $ExePath -ArgumentList '--stress' -PassThru
+        Start-Sleep -Seconds 18  # heavy cold start: main window handle only appears ~15-20s in.
+                                 # (Handle==0 is treated as alive anyway, so this just keeps logs clean.)
+
+        $unresponsive = 0
+        while (-not $proc.HasExited) {
+            Start-Sleep -Milliseconds $sampleMs
+            if (Past-Deadline) {
+                Write-Line "reached MaxRuntimeMinutes with the app alive - stopping this instance" 'DarkGray'
+                try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {}
+                break
+            }
+            try { $proc.Refresh() } catch {}
+            if ($proc.HasExited) { break }
+
+            $hwnd = $proc.MainWindowHandle
+            $alive = [HangProbe]::IsResponsive($hwnd, [uint32]$probeMs)
+
+            if ($alive) {
+                if ($unresponsive -ge 2) { Write-Line "recovered after $unresponsive samples" 'DarkGray' }
+                $unresponsive = 0
+            }
+            else {
+                $unresponsive++
+                if ($unresponsive -eq 2) { Write-Line "window not answering... ($unresponsive)" 'DarkYellow' }
+                if ($unresponsive -ge $needSamples) {
+                    Capture-Hang $proc.Id
+                    $captures++
+                    Write-Line "kill wedged pid $($proc.Id) and relaunch" 'DarkGray'
+                    try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch {}
+                    # kill the watchdog's dump-writer sibling if it spawned
+                    Get-Process -Name 'ConditioningControlPanel' -ErrorAction SilentlyContinue |
+                        Where-Object { $_.Id -ne $proc.Id } | Stop-Process -Force -ErrorAction SilentlyContinue
+                    break
+                }
+            }
+        }
+
+        if ($proc.HasExited -and $unresponsive -lt $needSamples) {
+            $code = try { $proc.ExitCode } catch { 'unknown' }
+            if ($code -ne 0) {
+                Write-Line "process EXITED code=$code (crash, not a hang) - logging + relaunching" 'Red'
+                Capture-Hang $proc.Id 2>$null   # pid's gone; grabs the crash context from the log
+            } else {
+                Write-Line "process exited cleanly (code 0) - you closed it? relaunching" 'DarkGray'
+            }
+        }
+
+        if ($MaxCaptures -gt 0 -and $captures -ge $MaxCaptures) {
+            Write-Line "reached MaxCaptures=$MaxCaptures - done. Captures in: $OutDir" 'Magenta'
+            break
+        }
+        Start-Sleep -Seconds 2
+    }
+}
+finally {
+    Write-Host ""
+    Write-Line "HUNT ENDED. $captures capture(s). Open: $OutDir" 'Magenta'
+    Get-Process -Name 'ConditioningControlPanel' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
Fixes two dump-confirmed UI-thread deadlocks in the flash-window path, both wedging the UI thread in `MediaContext.CompleteRender()` under render-thread load — the recurring "app freezes/crashes" hang. Root-caused and validated with a new automated hang-hunt harness rather than manual repro.

## The two deadlocks

**1. `Window.Show()` first-realization** — flash windows are sized per-image, which defeated the exact-size window pool, so a brand-new layered window was realized on nearly every flash. A fresh `Show()` runs a synchronous `CompleteRender()` that never returns when the render thread is backed up.
- Fix: bucket the per-window shell to a 128px grid (+slack) so the pool recycles by size. The true-size flash is rendered centered in the bucketed shell with invisible transparent padding, so the visual is unchanged.
- Also scoped the glow/lucky path's `window.Width +=` to host mode only — it was live-resizing already-realized pooled windows, itself a `CompleteRender` deadlock trigger.

**2. `WM_DPICHANGED` during flash close** — `FlashService.SafeCloseFlashWindow -> Window.WmClose` pumps the message queue, dispatching a pending `WM_DPICHANGED` whose `OnDpiChanged -> OnResize -> CompleteRender` wedges. Mixed-DPI multi-monitor only (flashes spawn across monitors).
- Fix: flash windows swallow `WM_DPICHANGED` via an `HwndSource` hook. Safe because flash geometry is already computed per-target-monitor manually, so WPF's auto-rescale is unwanted; the message only fires on cross-DPI moves, never the initial render.

## Validation
Added `hang-hunt.ps1` + a gated `--stress` launch flag (dead code in normal runs). The watcher pings the window and auto-captures `dotnet-stack` + `dotnet-dump` the instant the UI thread wedges. The same aggressive stress that wedged the app in ~8 min (deadlock 1) then ~20 min (deadlock 2) now survives extended runs.

## Notes
- The `WM_DPICHANGED` deadlock could recur on other layered surfaces (bubbles, subliminals, shared host) — same one-line fix if it surfaces there.
- Minor intended side-effect: flashes are marginally easier to gaze-pop (hit-rect is now the bucketed shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)