### PR TITLE
fix: stop update from wiping lock-card phrases & subliminals + phrase export/import

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.PresetIO.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.PresetIO.cs
@@ -55,6 +55,85 @@ namespace ConditioningControlPanel
             }
         }
 
+        // ---- Phrase backup export / import ---------------------------------
+
+        private Services.PhraseBackupService? _phraseBackupService;
+
+        internal void BtnExportPhrases_Click(object sender, RoutedEventArgs e)
+        {
+            var settings = App.Settings?.Current;
+            if (settings == null) return;
+            _phraseBackupService ??= new Services.PhraseBackupService();
+
+            var dialog = new Microsoft.Win32.SaveFileDialog
+            {
+                Title = "Export Phrases",
+                Filter = "Phrase backup (*.ccpphrases.json)|*.ccpphrases.json",
+                FileName = Services.PhraseBackupService.GetExportFileName(),
+                DefaultExt = ".ccpphrases.json"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            try
+            {
+                var count = _phraseBackupService.Export(settings, dialog.FileName);
+                ShowStyledDialog("Phrases Exported",
+                    $"Saved {count} phrase(s) to:\n{dialog.FileName}", "OK", "");
+                App.Logger?.Information("Phrases exported: {Count} to {Path}", count, dialog.FileName);
+            }
+            catch (Exception ex)
+            {
+                ShowStyledDialog("Export Failed",
+                    $"Could not export phrases:\n{ex.Message}", "OK", "");
+                App.Logger?.Error(ex, "Failed to export phrases");
+            }
+        }
+
+        internal void BtnImportPhrases_Click(object sender, RoutedEventArgs e)
+        {
+            var settings = App.Settings?.Current;
+            if (settings == null) return;
+            _phraseBackupService ??= new Services.PhraseBackupService();
+
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Import Phrases",
+                Filter = "Phrase backup (*.ccpphrases.json)|*.ccpphrases.json|All files (*.*)|*.*"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            if (!_phraseBackupService.Validate(dialog.FileName, out var error))
+            {
+                ShowStyledDialog("Import Failed",
+                    $"That file isn't a valid phrase backup:\n{error}", "OK", "");
+                return;
+            }
+
+            // Importing replaces the current phrase pools — confirm first.
+            var confirm = ShowStyledDialog("Import Phrases?",
+                "This replaces your current lock-card phrases, subliminals, mantras and other " +
+                "custom text with the ones in the backup file. Continue?", "Import", "Cancel");
+            if (!confirm) return;
+
+            try
+            {
+                var count = _phraseBackupService.Import(settings, dialog.FileName);
+                App.Settings?.Save();
+                ShowStyledDialog("Phrases Imported",
+                    $"Restored {count} phrase(s). You may need to reopen any open phrase editors to see them.",
+                    "OK", "");
+                App.Logger?.Information("Phrases imported: {Count} from {Path}", count, dialog.FileName);
+            }
+            catch (Exception ex)
+            {
+                ShowStyledDialog("Import Failed",
+                    $"Could not import phrases:\n{ex.Message}", "OK", "");
+                App.Logger?.Error(ex, "Failed to import phrases");
+            }
+        }
+
         // ---- Preset drag-drop import ---------------------------------------
 
         private void HandlePresetDrop(string filePath)

--- a/ConditioningControlPanel/Services/PhraseBackupService.cs
+++ b/ConditioningControlPanel/Services/PhraseBackupService.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Exports/imports the user's editable phrase pools (lock-card phrases, subliminals,
+    /// bouncing text, attention words, mantras, custom triggers, custom companion phrases)
+    /// to a small standalone <c>.ccpphrases.json</c> file. This is a user-facing safety net
+    /// so a bad update (or a move to a new machine) can never permanently cost someone the
+    /// phrases they wrote — they can export a backup and re-import it.
+    ///
+    /// The set is captured BY PROPERTY NAME from the serialized settings rather than as a
+    /// fixed typed DTO, so adding/renaming a pool's type later can't silently drop it or
+    /// break an old backup file.
+    /// </summary>
+    public class PhraseBackupService
+    {
+        public const string Schema = "ccp-phrases/v1";
+
+        /// <summary>
+        /// AppSettings property names that hold user-editable phrase content. Each is copied
+        /// verbatim (as JSON) on export and applied back on import. Includes the per-mod /
+        /// per-mode variants and the add/remove tracking sets so a restore is faithful and the
+        /// cross-mod prune doesn't later delete restored custom phrases.
+        /// </summary>
+        internal static readonly string[] PhraseProperties =
+        {
+            // Subliminals (+ tracking so restored custom phrases survive the prune)
+            "SubliminalPool", "SubliminalPoolByMod", "SubliminalPoolByMode",
+            "UserAddedSubliminals", "RemovedDefaultSubliminals",
+            // Lock card phrases
+            "LockCardPhrases", "LockCardPhrasesByMod", "LockCardPhrasesByMode",
+            // Bouncing text
+            "BouncingTextPool", "BouncingTextPoolByMod",
+            // Attention words
+            "AttentionPool", "AttentionPoolByMod", "AttentionPoolByMode",
+            // Mantras
+            "MantraPool",
+            // Custom triggers
+            "CustomTriggers", "CustomTriggersByMod",
+            // Custom companion phrases
+            "CustomCompanionPhrases",
+        };
+
+        /// <summary>Suggested file name for an export dialog.</summary>
+        public static string GetExportFileName()
+            => $"ccp-phrases-{DateTime.Now:yyyyMMdd}.ccpphrases.json";
+
+        /// <summary>
+        /// Writes the current phrase pools to <paramref name="filePath"/>. Returns a rough
+        /// count of phrase entries written (for a confirmation message).
+        /// </summary>
+        public int Export(AppSettings settings, string filePath)
+        {
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+
+            var full = JObject.FromObject(settings);
+            var phrases = new JObject();
+            foreach (var name in PhraseProperties)
+            {
+                var token = full[name];
+                if (token != null && token.Type != JTokenType.Null)
+                    phrases[name] = token;
+            }
+
+            var backup = new JObject
+            {
+                ["schema"] = Schema,
+                ["exported_at"] = DateTime.UtcNow.ToString("o"),
+                ["app_version"] = Services.UpdateService.AppVersion,
+                ["phrases"] = phrases,
+            };
+
+            var dir = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            File.WriteAllText(filePath, backup.ToString(Formatting.Indented));
+
+            return CountEntries(phrases);
+        }
+
+        /// <summary>
+        /// Validates that <paramref name="filePath"/> is a phrase backup this app understands.
+        /// </summary>
+        public bool Validate(string filePath, out string error)
+        {
+            error = "";
+            try
+            {
+                if (!File.Exists(filePath)) { error = "File not found"; return false; }
+                var obj = JObject.Parse(File.ReadAllText(filePath));
+                var schema = obj["schema"]?.ToString();
+                if (schema != Schema) { error = $"Unrecognized file (schema '{schema}')"; return false; }
+                if (obj["phrases"] is not JObject p || !p.HasValues) { error = "No phrases in file"; return false; }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Applies the phrase pools from a backup file onto <paramref name="settings"/> in place,
+        /// REPLACING each pool (an import is a restore, not a merge). Unknown/legacy members are
+        /// skipped rather than aborting the whole import. Returns the count of entries applied.
+        /// Caller is responsible for persisting (App.Settings.Save()) and refreshing UI.
+        /// </summary>
+        public int Import(AppSettings settings, string filePath)
+        {
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+
+            var obj = JObject.Parse(File.ReadAllText(filePath));
+            if (obj["schema"]?.ToString() != Schema)
+                throw new InvalidOperationException("File is not a CCP phrase backup.");
+
+            if (obj["phrases"] is not JObject phrases)
+                throw new InvalidOperationException("Backup contains no phrases.");
+
+            // Only apply whitelisted phrase properties — never let a crafted file populate
+            // arbitrary settings (auth tokens, feature gates, etc.).
+            var filtered = new JObject();
+            foreach (var name in PhraseProperties)
+            {
+                var token = phrases[name];
+                if (token != null && token.Type != JTokenType.Null)
+                    filtered[name] = token;
+            }
+
+            var populateSettings = new JsonSerializerSettings
+            {
+                // Replace so an imported pool fully overwrites the current one (restore semantics),
+                // and tolerate a single unparseable member instead of failing the whole import.
+                ObjectCreationHandling = ObjectCreationHandling.Replace,
+                Error = (sender, args) =>
+                {
+                    App.Logger?.Warning("Skipping unimportable phrase member '{Path}': {Error}",
+                        args.ErrorContext.Path, args.ErrorContext.Error.Message);
+                    args.ErrorContext.Handled = true;
+                }
+            };
+
+            JsonConvert.PopulateObject(filtered.ToString(), settings, populateSettings);
+            App.Logger?.Information("Imported phrases from {Path}", filePath);
+            return CountEntries(filtered);
+        }
+
+        /// <summary>Rough total of phrase entries across all pools, for confirmation messages.</summary>
+        private static int CountEntries(JObject phrases)
+        {
+            int total = 0;
+            foreach (var prop in phrases.Properties())
+                total += CountToken(prop.Value);
+            return total;
+        }
+
+        private static int CountToken(JToken token)
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Array:
+                    return ((JArray)token).Count;
+                case JTokenType.Object:
+                    // Flat pool (phrase -> bool) counts its keys; nested (mod -> pool) sums children.
+                    var o = (JObject)token;
+                    if (o.Properties().All(p => p.Value.Type is JTokenType.Boolean))
+                        return o.Count;
+                    return o.Properties().Sum(p => CountToken(p.Value));
+                default:
+                    return 0;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Settings/SettingsService.cs
+++ b/ConditioningControlPanel/Services/Settings/SettingsService.cs
@@ -35,6 +35,19 @@ namespace ConditioningControlPanel.Services
         public bool WasSettingsFileMissing { get; private set; }
 
         /// <summary>
+        /// True if a settings file was present but could not be parsed and was preserved as a
+        /// <c>.corrupt-*.json</c> backup rather than overwritten. Distinct from a genuine fresh
+        /// install (<see cref="WasSettingsFileMissing"/>).
+        /// </summary>
+        public bool WasSettingsFileCorrupt { get; private set; }
+
+        /// <summary>
+        /// Path of the most recent <c>.corrupt-*.json</c> backup created by
+        /// <see cref="PreserveCorruptSettingsFile"/>, or null if none.
+        /// </summary>
+        public string? LastCorruptBackupPath { get; private set; }
+
+        /// <summary>
         /// Preset IDs that need a re-install pass after services are wired up. Populated by
         /// <see cref="MergeBuiltInAwarenessPresets"/> when an installed preset's <c>Version</c>
         /// is bumped — we can't call <c>App.KeywordPresets.InstallPreset</c> from inside
@@ -102,15 +115,36 @@ namespace ConditioningControlPanel.Services
                 {
                     var json = File.ReadAllText(_settingsPath);
 
-                    // Use explicit settings to ensure lists are REPLACED, not merged with defaults
+                    // Use explicit settings to ensure lists are REPLACED, not merged with defaults.
+                    // Error handler makes the load RESILIENT: a single unparseable member (e.g. an
+                    // enum value renamed/removed in a new release, which StringEnumConverter throws
+                    // on) must NOT discard the whole document and reset every phrase/pool to
+                    // factory defaults. We swallow per-member errors and keep everything that DID
+                    // parse. This is the fix for "my lock card phrases / subliminals get wiped
+                    // every time I update" — a new release's enum change used to throw here and
+                    // fall through to `new AppSettings()`, whose defaults then overwrote the file.
+                    var badMembers = new List<string>();
                     var serializerSettings = new JsonSerializerSettings
                     {
-                        ObjectCreationHandling = ObjectCreationHandling.Replace
+                        ObjectCreationHandling = ObjectCreationHandling.Replace,
+                        Error = (sender, args) =>
+                        {
+                            var path = args.ErrorContext.Path;
+                            badMembers.Add(path);
+                            App.Logger?.Warning(
+                                "Skipping unparseable settings member '{Path}' (kept the rest): {Error}",
+                                path, args.ErrorContext.Error.Message);
+                            args.ErrorContext.Handled = true;
+                        }
                     };
 
                     var settings = JsonConvert.DeserializeObject<AppSettings>(json, serializerSettings);
                     if (settings != null)
                     {
+                        if (badMembers.Count > 0)
+                            App.Logger?.Warning(
+                                "Settings loaded with {Count} skipped member(s); the rest were preserved: {Members}",
+                                badMembers.Count, string.Join(", ", badMembers.Distinct()));
                         App.Logger?.Information("Settings loaded from {Path} (Triggers: {TriggerCount})",
                             _settingsPath, settings.CustomTriggers?.Count ?? 0);
                         // NOTE: Don't validate level-locked features here - cloud sync hasn't happened yet.
@@ -150,14 +184,55 @@ namespace ConditioningControlPanel.Services
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("Could not load settings: {Error}", ex.Message);
+                // The file existed but could not be parsed even with per-member error tolerance
+                // (e.g. truncated/malformed JSON, or a top-level structural error). Do NOT let the
+                // fresh defaults below get silently written over it — preserve the original so the
+                // user's phrases/pools stay recoverable instead of being lost forever.
+                App.Logger?.Error(ex, "Could not load settings — preserving the unparseable file");
+                PreserveCorruptSettingsFile();
             }
 
-            WasSettingsFileMissing = true;
-            App.Logger?.Information("Using default settings (fresh install detected)");
+            // If a settings file is present here, we reached the fallback because it failed to load
+            // (not because it was missing) — preserve it before defaults overwrite it on next save.
+            if (File.Exists(_settingsPath) && !WasSettingsFileCorrupt)
+            {
+                App.Logger?.Error("Settings file present but did not load — preserving it before applying defaults");
+                PreserveCorruptSettingsFile();
+            }
+
+            if (!WasSettingsFileCorrupt)
+                WasSettingsFileMissing = true;
+            App.Logger?.Information("Using default settings ({Reason})",
+                WasSettingsFileCorrupt ? "previous file unparseable, preserved a backup" : "fresh install detected");
             var fresh = new AppSettings();
             MergeBuiltInAwarenessPresets(fresh);
             return fresh;
+        }
+
+        /// <summary>
+        /// Renames an unparseable settings.json to settings.corrupt-&lt;timestamp&gt;.json so the fresh
+        /// defaults the caller is about to use don't overwrite (and destroy) the user's real data.
+        /// The backup can be inspected or hand-restored, and gives an import path a source to pull
+        /// phrases back from. Sets <see cref="WasSettingsFileCorrupt"/>.
+        /// </summary>
+        private void PreserveCorruptSettingsFile()
+        {
+            try
+            {
+                if (!File.Exists(_settingsPath)) return;
+                var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+                var backupPath = _settingsPath.Replace(".json", $".corrupt-{stamp}.json");
+                // Move (not copy) so the next SaveImmediate writes a clean file to _settingsPath.
+                File.Move(_settingsPath, backupPath, overwrite: true);
+                LastCorruptBackupPath = backupPath;
+                WasSettingsFileCorrupt = true;
+                App.Logger?.Warning("Preserved unparseable settings to {Backup}", backupPath);
+            }
+            catch (Exception ex)
+            {
+                // If we can't even rename it, leave it in place rather than deleting anything.
+                App.Logger?.Error(ex, "Failed to preserve unparseable settings file");
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -801,6 +801,22 @@
                                     ToolTip="{loc:Str tooltip_clear_selection_use_random}"/>
                         </StackPanel>
     
+                        <!-- Phrase Backup (export/import all editable phrase pools) -->
+                        <Grid Margin="0,6,0,0"
+                              ToolTip="Save or restore your lock-card phrases, subliminals, mantras and other custom text. Use this to back up your phrases before an update or when moving to a new PC.">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <TextBlock Text="Phrase backup" Foreground="#B0B0B0" FontSize="11" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Content="📤 Export" Style="{StaticResource OutlineButton}" Padding="8,3" Margin="0,0,6,0"
+                                        Click="BtnExportPhrases_Click"
+                                        ToolTip="Save all your custom phrases to a backup file."/>
+                                <Button Content="📥 Import" Style="{StaticResource OutlineButton}" Padding="8,3"
+                                        Click="BtnImportPhrases_Click"
+                                        ToolTip="Restore custom phrases from a backup file (replaces your current phrases)."/>
+                            </StackPanel>
+                        </Grid>
+
                         <!-- Gaming Tip -->
                         <Grid Margin="0,5,0,0">
                             <TextBlock Text="{loc:Str label_use_borderless_windowed_for_overlays}" Foreground="{DynamicResource TextMutedBrush}" FontSize="10" VerticalAlignment="Center"

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
@@ -157,6 +157,16 @@ namespace ConditioningControlPanel.Views.Tabs
             if (Window.GetWindow(this) is MainWindow mw)
                 mw.BtnSubliminalSettings_Click(sender, e);
         }
+        private void BtnExportPhrases_Click(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.BtnExportPhrases_Click(sender, e);
+        }
+        private void BtnImportPhrases_Click(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.BtnImportPhrases_Click(sender, e);
+        }
         private void BtnTestAudio_Click(object sender, RoutedEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw)


### PR DESCRIPTION
## The bug

Users report **lock-card phrases and subliminals get wiped every time they update**.

It is **not** the installer — user phrases live in `%LOCALAPPDATA%\ConditioningControlPanel\settings.json`, which the installer never touches. The wipe happened inside the app on the first launch after an update:

`SettingsService.Load()` wrapped the whole load in one `try`, and on **any** deserialization exception it fell through to `new AppSettings()` (factory-default phrase pools), which the first `Save()` in `OnStartup` then wrote back over the good file. It tripped on updates specifically because several things persisted inside `settings.json` use `StringEnumConverter`, which **throws** when a release renames/removes an enum value an old file still contains (KeywordTrigger/KeywordAction/Deeper/Gaze enums). Progression/level/premium survived because they're cloud-restored, so only the local-only phrases *looked* wiped.

## Changes

**Fix (the important part) — `Services/Settings/SettingsService.cs`**
- Added a per-member Newtonsoft `Error` handler: one unparseable field (e.g. a changed enum) is skipped and **everything else is preserved**, instead of discarding the whole document.
- On a genuinely unparseable file, it's now **preserved as `settings.corrupt-<timestamp>.json`** instead of being silently overwritten by defaults. New `WasSettingsFileCorrupt` / `LastCorruptBackupPath`; `WasSettingsFileMissing` now only true on a real fresh install.

**Export / Import — new `Services/PhraseBackupService.cs` + UI**
- Export/import all editable phrase pools (lock-card, subliminal, bouncing text, attention, mantra, custom triggers, companion phrases + per-mod/mode variants + add/remove tracking) to a `*.ccpphrases.json` file.
- Name-based (schema-change resilient), import **replaces** (restore semantics), whitelist-only so a crafted file can't populate auth tokens or feature gates.
- "Phrase backup" Export/Import row added to **Settings -> System**.

## Notes
- Scoped to 5 files; unrelated in-progress `VideoService.cs` changes intentionally excluded.
- Builds clean (0 C# errors).
- **Before merge:** manual round-trip test — export, edit a phrase, import, confirm it restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)