### PR TITLE
fix: mandatory video no longer jumps above bubbles when clicked

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1299,6 +1299,12 @@ namespace ConditioningControlPanel.Services
                         if (App.Chaos?.IsRunning == true)
                             foreach (var w in _windows) MakeNonActivating(w);
 
+                        // Regardless of chaos, clicking the mandatory video (e.g. missing a bubble
+                        // and hitting the video behind it) must NOT re-raise it above whatever is
+                        // layered on top. Answer WM_MOUSEACTIVATE with MA_NOACTIVATE so the click
+                        // never triggers a z-order raise. Focus-preserving, so ESC/panic still work.
+                        foreach (var w in _windows) PreventClickRaise(w);
+
                         // Ambient bubble game: pause + clear so it doesn't fight the video for
                         // clicks / z-order (no-op during a chaos run, which isn't "running").
                         // A chaos run keeps its bubbles + HUD alive and lifts them back above the
@@ -2897,6 +2903,8 @@ namespace ConditioningControlPanel.Services
         private const int WS_EX_NOACTIVATE = 0x08000000;
         private const uint SWP_NOZORDER = 0x0004;
         private const uint SWP_NOACTIVATE = 0x0010;
+        private const int WM_MOUSEACTIVATE = 0x0021;
+        private const int MA_NOACTIVATE = 3;
 
         /// <summary>
         /// Pins a fullscreen video window to the true physical bounds of its target monitor.
@@ -2962,6 +2970,55 @@ namespace ConditioningControlPanel.Services
             {
                 App.Logger?.Debug("MakeNonActivating failed: {Error}", ex.Message);
             }
+        }
+
+        /// <summary>
+        /// Stops a fullscreen video window from being re-raised in the topmost z-band when the user
+        /// clicks it (e.g. missing a bubble and hitting the video behind it). WS_EX_NOACTIVATE alone
+        /// (MakeNonActivating) only blocks focus-driven raises; Windows still brings a topmost window
+        /// to the top of its band on mouse-down. We answer WM_MOUSEACTIVATE with MA_NOACTIVATE, which
+        /// denies the click-activation (and the z-order raise that rides on it) while KEEPING the
+        /// mouse message — so the WPF click overlay + attention targets still register — and WITHOUT
+        /// dropping existing focus, so ESC / panic-key on non-chaos videos keep working. This is the
+        /// pre-emptive counterpart to the reactive BringTargetsToFront lift. Idempotent per window.
+        /// </summary>
+        private void PreventClickRaise(Window win)
+        {
+            try
+            {
+                void Wire()
+                {
+                    try
+                    {
+                        var hwnd = new WindowInteropHelper(win).Handle;
+                        if (hwnd == IntPtr.Zero) return;
+                        HwndSource.FromHwnd(hwnd)?.AddHook(NoClickRaiseHook);
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("PreventClickRaise wire failed: {Error}", ex.Message);
+                    }
+                }
+
+                if (new WindowInteropHelper(win).Handle != IntPtr.Zero)
+                    Wire();
+                else
+                    win.SourceInitialized += (_, _) => Wire();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("PreventClickRaise failed: {Error}", ex.Message);
+            }
+        }
+
+        private static IntPtr NoClickRaiseHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_MOUSEACTIVATE)
+            {
+                handled = true;
+                return new IntPtr(MA_NOACTIVATE);
+            }
+            return IntPtr.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem
During a mandatory video, clicking the video (e.g. missing a bubble and hitting the video behind it) brought the video to the front, hiding the bubbles behind it. The z-order should **not** change when the video is clicked.

## Root cause
Mandatory-video windows are borderless `Topmost` windows. Clicking one makes Windows raise it to the top of the topmost z-band as part of click-activation, burying whatever is layered on top (chaos bubbles/HUD, attention targets).

Two existing mitigations were insufficient:
- `WS_EX_NOACTIVATE` (`MakeNonActivating`) only blocks *focus-driven* raises, and was gated to chaos runs only.
- The reactive 50ms `BringTargetsToFront` lift only re-raised the chaos game layer + attention targets *after* the fact.

## Fix
Every mandatory-video window now answers `WM_MOUSEACTIVATE` with `MA_NOACTIVATE`, denying the click-activation (and the z-order raise riding on it) pre-emptively so the video stays put.

`MA_NOACTIVATE` (not `...ANDEAT`) is deliberate:
- **keeps the mouse message** -> the WPF click overlay + attention targets still register clicks;
- **preserves existing focus** -> ESC / panic-key dismissal on non-chaos videos still work.

Applied unconditionally to all video windows, so it covers plain mandatory videos too. The existing NOACTIVATE + reactive lift remain as complementary belt-and-suspenders for focus-loss-driven raises.

## Testing
- Build green (0 errors).
- Needs a runtime confirm: start a mandatory video with bubbles on screen, click the video repeatedly - bubbles should stay on top throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)