### PR TITLE
fix: Takeover pacing + per-mode lock card phrases (6.2.9)

### DIFF
--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -83,6 +83,11 @@ namespace ConditioningControlPanel.Services
         private DispatcherTimer? _heartbeatTimer;
         private bool _forceTestMode = false; // When true, use 30s interval instead of settings
 
+        // When a random tick fires but she can't act yet (cooldown, a fullscreen interaction, or a
+        // web video), we re-check after this short window instead of waiting a whole fresh interval —
+        // so she acts the moment she's free and the countdown bar stays honest.
+        private const double RetryIntervalSeconds = 12;
+
         // State
         private DateTime _lastActionTime = DateTime.MinValue;
         private DateTime _lastUserActivity = DateTime.Now;
@@ -667,7 +672,7 @@ namespace ConditioningControlPanel.Services
             ScheduleNextRandomTick();
         }
 
-        private void ScheduleNextRandomTick()
+        private void ScheduleNextRandomTick(bool retry = false)
         {
             var settings = App.Settings?.Current;
             if (settings == null) return;
@@ -675,7 +680,16 @@ namespace ConditioningControlPanel.Services
             double actualSeconds;
             string modeInfo;
 
-            if (_forceTestMode)
+            if (retry)
+            {
+                // A tick fired but she couldn't act (cooldown / fullscreen interaction / web video).
+                // Re-check soon instead of burning a whole fresh interval — otherwise the countdown
+                // bar completes with nothing happening and her real cadence drifts far below the
+                // slider. ~12–24s jittered so it doesn't hammer while a long video is on screen.
+                actualSeconds = RetryIntervalSeconds + _random.NextDouble() * RetryIntervalSeconds;
+                modeInfo = "retry (was blocked)";
+            }
+            else if (_forceTestMode)
             {
                 // Force test mode: always use 30 seconds
                 actualSeconds = 30;
@@ -689,7 +703,18 @@ namespace ConditioningControlPanel.Services
                 var baseSeconds = settings.AutonomyRandomIntervalSeconds;
                 var variance = (2.0 / 3.0) + _random.NextDouble() * (2.0 / 3.0); // 0.667 to 1.333
                 actualSeconds = baseSeconds * variance;
-                modeInfo = $"base: {baseSeconds}s (±33%)";
+
+                // Time-of-day pacing: when "time aware" is on, a higher activity multiplier means she's
+                // MORE active, so the gap shrinks at night and stretches in the morning. Until now
+                // GetTimeMultiplier() was computed but never applied anywhere, so the toggle (and every
+                // morning/afternoon/evening/night multiplier) did nothing at all.
+                var timeMult = GetTimeMultiplier();
+                if (timeMult > 0)
+                    actualSeconds /= timeMult;
+
+                // Keep the result sane no matter how jitter and the multiplier combine.
+                actualSeconds = Math.Clamp(actualSeconds, 15, 900);
+                modeInfo = $"base: {baseSeconds}s (±33%, timeMult {timeMult:0.00})";
             }
 
             _randomTimer?.Stop();
@@ -831,15 +856,18 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
-            // Schedule next tick regardless of whether we take action
-            ScheduleNextRandomTick();
-
             if (!CanTakeAction())
             {
-                App.Logger?.Warning("AutonomyService: Random tick - cannot take action (cooldown or busy)");
+                // Temporarily blocked — schedule a short retry rather than a full fresh interval, so
+                // she acts as soon as she's free instead of skipping a whole cycle every time she's
+                // briefly busy (which made the interval feel much slower than the slider).
+                App.Logger?.Debug("AutonomyService: Random tick - cannot take action (cooldown or busy), retrying soon");
+                ScheduleNextRandomTick(retry: true);
                 return;
             }
 
+            // Free to act — schedule the next full interval, then go.
+            ScheduleNextRandomTick();
             App.Logger?.Information("AutonomyService: Random interval triggered - executing action!");
             ExecuteAutonomousAction(AutonomyTriggerSource.Random);
         }

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -1433,12 +1433,20 @@ namespace ConditioningControlPanel.Services
             // Lock-card / bouncing-text / custom-trigger pools: same rule as subliminals —
             // when there's no per-mod backup, keep the loaded flat pool instead of stamping
             // defaults over the user's customizations.
-            if (settings.LockCardPhrasesByMod?.TryGetValue(modId, out var savedLock) == true)
-                settings.LockCardPhrases = new Dictionary<string, bool>(savedLock);
-            else
-                settings.LockCardPhrases = settings.LockCardPhrases is { Count: > 0 }
+            Dictionary<string, bool>? savedLock = null;
+            var hadLockBackup = settings.LockCardPhrasesByMod?.TryGetValue(modId, out savedLock) == true;
+            settings.LockCardPhrases = hadLockBackup && savedLock != null
+                ? new Dictionary<string, bool>(savedLock)
+                : settings.LockCardPhrases is { Count: > 0 }
                     ? new Dictionary<string, bool>(settings.LockCardPhrases)
                     : new Dictionary<string, bool>(GetDefaultLockCardPhrases());
+
+            // Make the lock-card pool actually match the active mod: strip phrases that are some
+            // OTHER built-in mod's default (the baked-in cross-mod leak that made every mode show
+            // Circe's Lock phrases) and seed this mod's own themed defaults. Mirrors the subliminal
+            // PruneCrossMod pass — lock cards previously had neither a prune nor a top-up, so
+            // switching modes never actually changed the phrases.
+            ReconcileLockCardPhrasesWithActiveMod(modId, settings, hadLockBackup);
 
             if (settings.CustomTriggersByMod?.TryGetValue(modId, out var savedTriggers) == true)
                 settings.CustomTriggers = new List<string>(savedTriggers);
@@ -1503,6 +1511,57 @@ namespace ConditioningControlPanel.Services
             if (toRemove.Count > 0)
                 _log?.Information("Pruned {Count} cross-mod subliminal entries from the active pool: {Keys}",
                     toRemove.Count, string.Join(", ", toRemove));
+        }
+
+        /// <summary>
+        /// Aligns the active lock-card phrase pool with the active mod. Removes phrases that are some
+        /// OTHER built-in mod's default (cross-mod contamination) and — when building a fresh pool, or
+        /// when the prune left the pool with none of this mod's own defaults — seeds the active mod's
+        /// themed phrases. Phrases matching no built-in mod's default are treated as user-added and
+        /// always kept; kept phrases' enable/disable state is never touched (the top-up is additive
+        /// only). This is why switching modes now actually swaps the phrases instead of forever showing
+        /// the last-used mod's set (typically Circe's Lock).
+        /// </summary>
+        private void ReconcileLockCardPhrasesWithActiveMod(string modId, Models.AppSettings settings, bool hadBackup)
+        {
+            var activeDefaults = GetDefaultLockCardPhrases();
+            if (activeDefaults.Count == 0) return; // mod ships no lock-card phrases — nothing to reconcile against
+
+            settings.LockCardPhrases ??= new Dictionary<string, bool>();
+            var activeKeys = new HashSet<string>(activeDefaults.Keys, StringComparer.OrdinalIgnoreCase);
+
+            var foreignDefaults = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var allBuiltIn = new[]
+            {
+                Models.BuiltInMods.CCPDefault, Models.BuiltInMods.BambiSleep,
+                Models.BuiltInMods.SissyHypno, Models.BuiltInMods.Dronification,
+                Models.BuiltInMods.Locked
+            };
+            foreach (var m in allBuiltIn)
+                if (m.LockCardPhrases != null)
+                    foreach (var key in m.LockCardPhrases.Keys)
+                        foreignDefaults.Add(key);
+
+            // Strip other mods' default phrases that aren't part of the active mod. A phrase in NO
+            // built-in default is user-added, so it survives; a phrase shared with the active mod
+            // (in activeKeys) is kept too.
+            var removed = settings.LockCardPhrases.Keys
+                .Where(k => foreignDefaults.Contains(k) && !activeKeys.Contains(k))
+                .ToList();
+            foreach (var k in removed)
+                settings.LockCardPhrases.Remove(k);
+
+            // Seed this mod's own themed defaults when building a fresh pool, or when the prune left
+            // the pool holding none of them (a previously fully-contaminated backup). Additive only —
+            // TryAdd never overwrites a phrase the user kept or toggled off.
+            var hasOwnDefault = settings.LockCardPhrases.Keys.Any(activeKeys.Contains);
+            if (!hadBackup || !hasOwnDefault)
+                foreach (var kvp in activeDefaults)
+                    settings.LockCardPhrases.TryAdd(kvp.Key, true);
+
+            if (removed.Count > 0)
+                _log?.Information("Reconciled lock-card phrases for mod {ModId}: pruned {Count} cross-mod phrase(s): {Keys}",
+                    modId, removed.Count, string.Join(", ", removed));
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Progression/AchievementService.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementService.cs
@@ -25,7 +25,15 @@ public class AchievementService : IDisposable
     private DateTime _lastMindWipeCheck = DateTime.Now;
     private DateTime _lastDeeperCheck = DateTime.Now;
     private DateTime _lastAutonomyCheck = DateTime.Now;
-    
+
+    // Per-tick credit ceiling for Takeover quest time. The tracking timer fires every 1s, but when
+    // the app is backgrounded or busy with a fullscreen takeover video the tick gets starved and can
+    // slip well past that. Crediting min(elapsed, cap) still counts that legitimately-active time
+    // (fixing the "15-min quest took an hour, foreground/background changed the timing" report) while
+    // a single long stall — sleep/resume, the app suspended for minutes — can only ever add 10s.
+    private const double AutonomyTickCreditCapMinutes = 10.0 / 60.0;
+
+
     public event EventHandler<Achievement>? AchievementUnlocked;
 
     /// <summary>
@@ -256,9 +264,12 @@ public class AchievementService : IDisposable
         if (App.Autonomy?.IsEnabled == true)
         {
             var elapsed = (now - _lastAutonomyCheck).TotalMinutes;
-            if (elapsed > 0 && elapsed < 0.1) // sanity: max ~6s between ticks
+            if (elapsed > 0)
             {
-                App.Quests?.TrackAutonomyMinutes(elapsed);
+                // Credit the elapsed time, capping a single tick so a starved/backgrounded tick still
+                // counts (the old hard "< 6s or drop it" guard silently threw away real active time,
+                // which is why the quest crawled) while a long stall can't dump minutes in at once.
+                App.Quests?.TrackAutonomyMinutes(Math.Min(elapsed, AutonomyTickCreditCapMinutes));
             }
             _lastAutonomyCheck = now;
         }


### PR DESCRIPTION
Four fixes from the 0705 Discord thread (Bambi Takeover) plus the owner's lock-card question. All in the 6.2.9 line.

## Bambi Takeover (Autonomy)
**1. Interval now respected.** `OnRandomTick` scheduled the next full interval *before* checking `CanTakeAction()`, so any time she was briefly blocked (cooldown / fullscreen interaction / web video) the countdown bar completed with nothing happening and her real cadence drifted far below the slider. Now a full interval is only scheduled when she actually acts; a blocked tick re-checks in ~12-24s (`RetryIntervalSeconds`).

**2. "Time aware" toggle was dead.** `GetTimeMultiplier()` (morning/afternoon/evening/night multipliers) was computed but never applied anywhere. Wired into `ScheduleNextRandomTick` (`actualSeconds /= timeMult`, clamped 15-900s). Off by default, so no behavior change unless enabled.

## Takeover quest (the "15-min quest took an hour")
**3. Quest stops discarding backgrounded active time.** The 1s tracking tick (`AchievementService.TrackTimeBasedProgress`) guarded autonomy time with `elapsed < 0.1` (6s) and **dropped** anything longer. When the app is backgrounded or busy with a fullscreen takeover video the tick gets starved past 6s, so that legitimately-active time was silently thrown away — exactly the reporter's "foreground/background changed the timing." Now credits `min(elapsed, 10s)`: starved ticks count, while one long sleep/resume stall can only ever add 10s (no AFK/sleep farm). Surgical to autonomy — spiral/brain-drain/deeper guards left untouched. (AFK with the app running still counts, per owner's call.)

## Lock card phrases
**4. Switching modes now swaps the phrases.** Each built-in mod ships its own themed `LockCardPhrases`, but `ModService` had a cross-mod prune + defaults top-up for subliminals and **none** for lock cards. So the first switch to a mod with no backup kept the previous mod's phrases and baked them into that mod's per-mod backup permanently — every mode showed Circe's Lock. New `ReconcileLockCardPhrasesWithActiveMod` strips other mods' default phrases, seeds the active mod's own, keeps hand-added phrases, and heals already-contaminated backups on the next switch.

**Known tradeoff:** no `UserAddedLockCardPhrases` tracker exists (subliminals have one), so a hand-typed phrase identical to another built-in mod's canonical line, on a mod that doesn't ship it, gets pruned. Niche; acceptable given the feature was fully broken. Easy follow-up if needed.

## Test
- `dotnet build -c Debug` green (0 errors).
- Lock card phrases confirmed distinct per built-in mod (Sissy vs Circe share no keys).
- Runtime GUI verification of the mode-switch phrase swap still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)