### PR TITLE
fix: freeze #494 (render-thread deadlock) + Gif Rain #493 visibility

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarRandomBubble.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarRandomBubble.cs
@@ -34,6 +34,17 @@ namespace ConditioningControlPanel
         private readonly int _size;
         private readonly double _screenTop;
 
+        // KEEP-ALIVE window pool. A fresh WS_EX_LAYERED (AllowsTransparency) Window.Show() runs a
+        // synchronous HwndTarget.OnResize -> MediaContext.CompleteRender() on first realization;
+        // spawning one per bubble while the render thread is saturated (avatar emote crossfades,
+        // OCR, whispers) is a UI-thread deadlock trigger (freeze #494). Windows are a FIXED size and
+        // realized once, then Hide()/Show() reused; the bubble image is centred inside, so it can
+        // vary size without ever resizing the window (a resize is the deadlock, moving is safe).
+        private const int WINDOW_DIM = 200;   // fixed reusable size (max bubble 150 + slack)
+        private const int POOL_MAX = 6;
+        private const int WM_DPICHANGED = 0x02E0;
+        private static readonly System.Collections.Generic.Stack<Window> _pool = new();
+
         public AvatarRandomBubble(Point avatarScreenPos, Random random, Action onPop)
         {
             _random = random;
@@ -55,13 +66,15 @@ namespace ConditioningControlPanel
             _posY = avatarScreenPos.Y / dpiScale;
             _screenTop = -_size - 50; // Off top of screen
 
-            // Create bubble image
+            // Create bubble image (centred inside the fixed-size window; size varies, window doesn't)
             _bubbleImage = new Image
             {
                 Width = _size,
                 Height = _size,
                 Stretch = Stretch.Uniform,
                 RenderTransformOrigin = new Point(0.5, 0.5),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
                 Cursor = Cursors.Hand,
                 IsHitTestVisible = true
             };
@@ -118,29 +131,16 @@ namespace ConditioningControlPanel
                 e.Handled = true;
             };
 
-            // Create window
-            _window = new Window
-            {
-                WindowStyle = WindowStyle.None,
-                AllowsTransparency = true,
-                Background = Brushes.Transparent,
-                Topmost = true,
-                ShowInTaskbar = false,
-                ShowActivated = false,
-                Focusable = false,
-                Width = _size + 40,
-                Height = _size + 40,
-                Left = _posX + 2,
-                Top = _posY - 20,
-                Content = grid,
-                Cursor = Cursors.Hand,
-                IsHitTestVisible = true
-            };
+            // Rent a fixed-size, kept-alive window and drop in this bubble's content. No window-level
+            // click handler here: it would accumulate across pooled reuses. The grid + image handlers
+            // (rebuilt fresh every spawn) already cover the whole surface.
+            _window = RentWindow();
+            _window.Content = grid;
+            _window.BeginAnimation(Window.OpacityProperty, null);
+            _window.Opacity = 1;
+            UpdateWindowPos();
 
-            // Window click as final backup
-            _window.MouseLeftButtonDown += (s, e) => Pop();
-
-            // Show window
+            // Show window (realizes the hwnd on a freshly created one; un-hides a pooled one)
             _window.Show();
 
             // Hide from Alt+Tab
@@ -227,8 +227,7 @@ namespace ConditioningControlPanel
                 }
 
                 _window.Opacity = _fadeAlpha;
-                _window.Left = _posX + 2;
-                _window.Top = _posY - 20;
+                UpdateWindowPos();
             }
             catch (Exception ex)
             {
@@ -249,8 +248,73 @@ namespace ConditioningControlPanel
             if (!_isAlive) return;
             _isAlive = false;
             _animTimer.Stop();
+            ReturnWindow();
+        }
 
-            try { _window.Close(); } catch { }
+        /// <summary>Position the fixed-size window so the (centred) bubble image sits where the old
+        /// per-size window put it. WINDOW_DIM/2 = 100; the image centre carried a 22px X / 0px Y
+        /// offset from the old margins.</summary>
+        private void UpdateWindowPos()
+        {
+            _window.Left = _posX + _size / 2.0 - 78;   // (_posX + _size/2 + 22) - 100
+            _window.Top = _posY + _size / 2.0 - 100;   // (_posY + _size/2)      - 100
+        }
+
+        private Window RentWindow()
+        {
+            lock (_pool)
+            {
+                if (_pool.Count > 0) return _pool.Pop();
+            }
+            var win = new Window
+            {
+                WindowStyle = WindowStyle.None,
+                AllowsTransparency = true,
+                Background = Brushes.Transparent,
+                Topmost = true,
+                ShowInTaskbar = false,
+                ShowActivated = false,
+                Focusable = false,
+                Width = WINDOW_DIM,
+                Height = WINDOW_DIM,
+                Cursor = Cursors.Hand,
+                IsHitTestVisible = true,
+            };
+            // Swallow WM_DPICHANGED: WPF's automatic DPI rescale is another synchronous CompleteRender
+            // and the bubble floats near the avatar, which can straddle mixed-DPI monitors.
+            win.SourceInitialized += (_, _) =>
+            {
+                try
+                {
+                    System.Windows.Interop.HwndSource
+                        .FromHwnd(new System.Windows.Interop.WindowInteropHelper(win).Handle)
+                        ?.AddHook(SwallowDpiChanged);
+                }
+                catch { }
+            };
+            return win;
+        }
+
+        private void ReturnWindow()
+        {
+            var w = _window;
+            try { w.BeginAnimation(Window.OpacityProperty, null); } catch { }
+            try { w.Content = null; w.Opacity = 1; w.Hide(); } catch { }
+            lock (_pool)
+            {
+                if (_pool.Count < POOL_MAX && !_pool.Contains(w))
+                {
+                    _pool.Push(w);
+                    return;
+                }
+            }
+            try { w.Close(); } catch { }
+        }
+
+        private static IntPtr SwallowDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_DPICHANGED) handled = true;
+            return IntPtr.Zero;
         }
 
         #region Win32

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.CirceEmotes.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.CirceEmotes.cs
@@ -820,7 +820,18 @@ namespace ConditioningControlPanel
             if (!_circeEmoteMode) return;
             if (_circeQueue.Count > 0) { DoCirceCrossfade(_circeQueue.Dequeue()); return; }
             _circeReacting = false;
-            DoCirceCrossfade(PickWeightedIdle());
+            // Idle rotation is the steady-state ~1Hz churn (the bulk of [EMOTE] xfade under load). Defer the
+            // heavy two-GIF crossfade to a Background dispatcher tick so any in-flight layered-window present
+            // (a pooled Show(), a resize) finishes FIRST — the two colliding on the shared software render
+            // thread is the documented CompleteRender deadlock (see EnterCirceEmoteMode). Idle has no tight
+            // timing, unlike talk/queue which stay on the immediate path. If a reaction/talk claims the layers
+            // before this fires, skip — it drives its own crossfade.
+            var idle = PickWeightedIdle();
+            Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background, new Action(() =>
+            {
+                if (_circeEmoteMode && !_circeReacting && _circeQueue.Count == 0)
+                    DoCirceCrossfade(idle);
+            }));
         }
 
         /// <summary>

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.xaml
@@ -522,7 +522,11 @@
                             <TranslateTransform x:Name="AvatarAnimatedTranslate" Y="0"/>
                         </Image.RenderTransform>
                         <Image.Effect>
-                            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                            <!-- BlurRadius 20->10 (2026-07-05): during a crossfade BOTH animated layers
+                                 composite a full-size blur shader every frame; Gaussian cost scales ~radius^2,
+                                 so halving the radius is ~4x cheaper per layer. Cuts the render-thread load
+                                 that feeds the emote/CompleteRender freeze (#494) with only a subtly tighter glow. -->
+                            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="10" ShadowDepth="0" Opacity="0.6"/>
                         </Image.Effect>
                     </Image>
                     <!-- Second animated layer: crossfade target for Circe WebP emotes
@@ -538,7 +542,8 @@
                             <TranslateTransform x:Name="AvatarAnimatedTranslateB" Y="0"/>
                         </Image.RenderTransform>
                         <Image.Effect>
-                            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                            <!-- BlurRadius 20->10: see ImgAvatarAnimated above (halves the crossfade blur cost). -->
+                            <DropShadowEffect Color="{DynamicResource PinkColor}" BlurRadius="10" ShadowDepth="0" Opacity="0.6"/>
                         </Image.Effect>
                     </Image>
                 </Grid>

--- a/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
@@ -51,14 +51,24 @@ public sealed class ChaosGifCascadeOverlay : Window
         try
         {
             var files = PickFiles();
-            if (files.Count == 0) return;
+            if (files.Count == 0) { App.Logger?.Debug("GifCascade: no images in pool — nothing to rain"); return; }
             if (_active == null) { _active = new ChaosGifCascadeOverlay(); ((Window)_active).Show(); }
             else if (!_active.IsVisible) { try { ((Window)_active).Show(); } catch { } }   // idles hidden between cascades
+
+            // Confine the rain: dashboard triggers (no chaos run) always rain across ALL monitors so the
+            // user sees them wherever they are (#493); a chaos run keeps its per-config coverage (all
+            // screens when DualMonitor is on, primary-only when off).
+            bool chaosRun = App.Chaos?.IsRunning == true;
+            bool dual = App.Settings?.Current?.DualMonitorEnabled ?? true;
+            _active.SetSpawnSpread(fullSpread: !chaosRun || dual);
+
             ChaosWindowZ.RaiseAboveVideo(_active);   // un-hiding doesn't re-stack — kick over a playing video
             // Dashboard "cascade" trigger-bubble use (no chaos run): force the singleton topmost so a
             // stale Topmost=false from a prior Free-Desktop run can't bury the rain behind the app.
-            if (App.Chaos?.IsRunning != true) ChaosWindowZ.ForceTopmost(_active);
+            if (!chaosRun) ChaosWindowZ.ForceTopmost(_active);
             _active.Restart(files, spawnRatePerSec, durationSec, gifSize, fallSpeed, opacity, startScale);
+            App.Logger?.Information("GifCascade: raining (pool={N}, spread=[{L:F0}..{R:F0}], chaos={Chaos})",
+                files.Count, _active._spawnLeft, _active._spawnLeft + _active._spawnWidth, chaosRun);
         }
         catch (Exception ex) { App.Logger?.Debug("ChaosGifCascadeOverlay.Show: {E}", ex.Message); }
     }
@@ -83,6 +93,11 @@ public sealed class ChaosGifCascadeOverlay : Window
     private double _fallSpeed = 4;
     private double _opacity = 1.0;
     private double _startScale = 1.0;   // <1: clips spawn small at the top and grow toward _gifSize as they slide down
+    // Window-local DIP band in which clips may spawn/fall. The window always spans the full virtual
+    // screen; this confines the rain (full-width for dashboard + multi-monitor; primary-only for a
+    // single-screen chaos run). Set per-Show by SetSpawnSpread.
+    private double _spawnLeft;
+    private double _spawnWidth;
     private readonly List<Faller> _fallers = new();
     private readonly DispatcherTimer _spawn;
     private readonly DispatcherTimer _life;
@@ -114,10 +129,17 @@ public sealed class ChaosGifCascadeOverlay : Window
         IsHitTestVisible = false;
         ResizeMode = ResizeMode.NoResize;
         WindowStartupLocation = WindowStartupLocation.Manual;
-        // Single-monitor by default: confine to the primary screen unless multi-monitor is on,
-        // so the falling cascade doesn't rain across every screen (see ChaosWindowZ.StageBounds).
-        var (sl, st, sw, sh) = ChaosWindowZ.StageBounds();
-        Left = sl; Top = st; Width = sw; Height = sh;
+        // The window ALWAYS spans the full virtual screen (all monitors). A realized layered window
+        // can't be resized without risking a render-thread deadlock, and this singleton is reused across
+        // dashboard triggers AND chaos runs that want different coverage — so we size to the superset
+        // once and confine only WHERE CLIPS SPAWN, per-Show (SetSpawnSpread). This also fixes the
+        // dashboard "Gif Rain does nothing" report (#493): the old primary-only sizing rained off the
+        // visible area for multi-monitor users whose active screen wasn't the primary.
+        Left = SystemParameters.VirtualScreenLeft;
+        Top = SystemParameters.VirtualScreenTop;
+        Width = SystemParameters.VirtualScreenWidth;
+        Height = SystemParameters.VirtualScreenHeight;
+        _spawnLeft = 0; _spawnWidth = Width;
 
         _canvas = new Canvas { IsHitTestVisible = false };
         Content = _canvas;
@@ -128,6 +150,16 @@ public sealed class ChaosGifCascadeOverlay : Window
 
         _life = new DispatcherTimer { Interval = TimeSpan.FromSeconds(8) };
         _life.Tick += (_, _) => { _life.Stop(); _spawning = false; _spawn.Stop(); };  // stop spawning; let in-flight fall out
+    }
+
+    /// <summary>Set the window-local X band clips spawn/fall in. Full = the whole virtual screen (all
+    /// monitors); otherwise the primary monitor only. Window-local X = global DIP − window.Left, and the
+    /// window's Left is VirtualScreenLeft, so the primary's left edge is (0 − VirtualScreenLeft).</summary>
+    private void SetSpawnSpread(bool fullSpread)
+    {
+        if (fullSpread) { _spawnLeft = 0; _spawnWidth = Width; return; }
+        _spawnLeft = 0 - SystemParameters.VirtualScreenLeft;
+        _spawnWidth = SystemParameters.PrimaryScreenWidth;
     }
 
     /// <summary>(Re)start a cascade in the existing window — any in-flight clips are replaced.</summary>
@@ -213,7 +245,7 @@ public sealed class ChaosGifCascadeOverlay : Window
 
             // Fixed layout (Width + Canvas slot set ONCE); per-frame motion/growth are pure
             // render transforms, so no layout pass ever runs during the fall.
-            double centerX = _gifSize / 2 + _rng.NextDouble() * Math.Max(1, Width - _gifSize);
+            double centerX = _spawnLeft + _gifSize / 2 + _rng.NextDouble() * Math.Max(1, _spawnWidth - _gifSize);
             double y = -_gifSize;
             var move = new TranslateTransform(0, y);
             var grow = new ScaleTransform(ScaleAt(y), ScaleAt(y));

--- a/ConditioningControlPanel/Services/AttentionCheckService.cs
+++ b/ConditioningControlPanel/Services/AttentionCheckService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
@@ -51,9 +52,18 @@ namespace ConditioningControlPanel.Services
         private DispatcherTimer? _scheduleTimer;
         private DispatcherTimer? _tickTimer;
 
-        private Window? _activeWindow;
-        private AttentionCheckControl? _activeControl;
+        // KEEP-ALIVE pooled popup: a fresh WS_EX_LAYERED (AllowsTransparency) Window.Show()
+        // runs a synchronous HwndTarget.OnResize -> MediaContext.CompleteRender() on first
+        // realization; firing that per-check while the shared render thread is saturated (avatar
+        // emote crossfades, OCR, whispers) is a UI-thread deadlock trigger (freeze #494). So the
+        // popup is realized ONCE and thereafter repositioned (Left/Top — moving is safe) + Hide()/
+        // Show() reused; a resize never happens because the ring content is a fixed size.
+        private Window? _window;                 // realized once, then Hide/Show reused
+        private AttentionCheckControl? _control; // kept-alive content
+        private bool _checkActive;               // true while a check is on screen
         private Rect _activeBounds; // window bounds in DIPs (with slack baked in for hit-test)
+
+        private const int WM_DPICHANGED = 0x02E0;
         private DateTime _fireStartedAt;
         private double _dwellMs;
         private System.Windows.Point? _lastGazePoint;
@@ -121,6 +131,18 @@ namespace ConditioningControlPanel.Services
             _scheduleTimer?.Stop();
             _scheduleTimer = null;
             ResolveActive(passed: false, fireEvent: false);
+
+            // Hard teardown of the kept-alive popup so an unowned/hidden window can't
+            // block OnLastWindowClose (the ResolveActive fade above only Hide()s it).
+            _checkActive = false;
+            if (_window != null)
+            {
+                var win = _window;
+                _window = null;
+                _control = null;
+                try { win.BeginAnimation(Window.OpacityProperty, null); } catch { }
+                try { win.Close(); } catch { }
+            }
         }
 
         private void TrySubscribeMainWindowClosing()
@@ -222,7 +244,7 @@ namespace ConditioningControlPanel.Services
                     return;
                 }
 
-                if (_activeWindow != null)
+                if (_checkActive)
                 {
                     App.Logger?.Debug("AttentionCheck: fire skipped — popup already active");
                     ScheduleNext();
@@ -241,27 +263,18 @@ namespace ConditioningControlPanel.Services
                 var x = bounds.X + margin + _rng.Next(Math.Max(1, bounds.Width - margin * 2 - size));
                 var y = bounds.Y + margin + _rng.Next(Math.Max(1, bounds.Height - margin * 2 - size));
 
-                _activeControl = new AttentionCheckControl();
-                _activeWindow = new Window
-                {
-                    WindowStyle = WindowStyle.None,
-                    AllowsTransparency = true,
-                    Background = Brushes.Transparent,
-                    Topmost = true,
-                    ShowInTaskbar = false,
-                    ShowActivated = false,
-                    SizeToContent = SizeToContent.WidthAndHeight,
-                    ResizeMode = ResizeMode.NoResize,
-                    Left = x,
-                    Top = y,
-                    Content = _activeControl,
-                    IsHitTestVisible = false,
-                };
-                // Owner = MainWindow so the popup closes cleanly with the
-                // app (avoids the unowned-window-blocks-shutdown trap).
-                var owner = System.Windows.Application.Current?.MainWindow;
-                if (owner != null && owner.IsLoaded) _activeWindow.Owner = owner;
-                _activeWindow.Show();
+                EnsureWindow();
+                if (_window == null || _control == null) { ScheduleNext(); return; }
+
+                // Reposition (moving a realized layered window is safe; only resizing deadlocks)
+                // and reset the reused ring for a fresh check.
+                _window.Left = x;
+                _window.Top = y;
+                _control.SetProgress(0);
+                _checkActive = true;
+                _window.BeginAnimation(Window.OpacityProperty, null); // release any prior fade
+                _window.Opacity = 1;
+                _window.Show();
 
                 // Hit-test bounds with a generous slack so a near-miss
                 // counts as fixation — the user's gaze cursor has tracking
@@ -272,8 +285,7 @@ namespace ConditioningControlPanel.Services
                     size + BoundsSlackDips * 2,
                     size + BoundsSlackDips * 2);
 
-                _activeControl.StartPulse();
-                _activeControl.SetProgress(0);
+                _control.StartPulse();
 
                 _fireStartedAt = DateTime.UtcNow;
                 _dwellMs = 0;
@@ -303,6 +315,48 @@ namespace ConditioningControlPanel.Services
             }
         }
 
+        /// <summary>Realize the reusable popup ONCE (first fire), hidden, so subsequent checks only
+        /// reposition + Show() and never pay the fresh-realization CompleteRender cost that can wedge
+        /// the render thread under load (#494). A WM_DPICHANGED swallow hook prevents WPF's automatic
+        /// DPI rescale (another synchronous CompleteRender) when the ring moves between mixed-DPI
+        /// monitors.</summary>
+        private void EnsureWindow()
+        {
+            if (_window != null) return;
+            _control = new AttentionCheckControl();
+            _window = new Window
+            {
+                WindowStyle = WindowStyle.None,
+                AllowsTransparency = true,
+                Background = Brushes.Transparent,
+                Topmost = true,
+                ShowInTaskbar = false,
+                ShowActivated = false,
+                SizeToContent = SizeToContent.WidthAndHeight,
+                ResizeMode = ResizeMode.NoResize,
+                Content = _control,
+                IsHitTestVisible = false,
+                Opacity = 0,
+            };
+            // Owner = MainWindow so the popup closes cleanly with the app
+            // (avoids the unowned-window-blocks-shutdown trap).
+            var owner = System.Windows.Application.Current?.MainWindow;
+            if (owner != null && owner.IsLoaded) _window.Owner = owner;
+            _window.SourceInitialized += (_, _) =>
+            {
+                try { HwndSource.FromHwnd(new WindowInteropHelper(_window!).Handle)?.AddHook(SwallowDpiChanged); }
+                catch { }
+            };
+            // Realize the hwnd once (invisible at Opacity 0), then hide until the first check shows it.
+            try { _window.Show(); _window.Hide(); } catch { }
+        }
+
+        private static IntPtr SwallowDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_DPICHANGED) handled = true;
+            return IntPtr.Zero;
+        }
+
         private void HandleGazeMove(System.Windows.Point p)
         {
             _lastGazePoint = p;
@@ -313,7 +367,7 @@ namespace ConditioningControlPanel.Services
             try
             {
                 var settings = App.Settings?.Current;
-                if (settings == null || _activeWindow == null) { ResolveActive(passed: false); return; }
+                if (settings == null || !_checkActive) { ResolveActive(passed: false); return; }
 
                 var elapsed = (DateTime.UtcNow - _fireStartedAt).TotalMilliseconds;
                 var graceMs = settings.AttentionCheckGraceMs;
@@ -321,7 +375,7 @@ namespace ConditioningControlPanel.Services
                 if (_lastGazePoint.HasValue && _activeBounds.Contains(_lastGazePoint.Value))
                 {
                     _dwellMs += TickMs;
-                    _activeControl?.SetProgress(_dwellMs / DwellTargetMs);
+                    _control?.SetProgress(_dwellMs / DwellTargetMs);
 
                     if (_dwellMs >= DwellTargetMs)
                     {
@@ -334,7 +388,7 @@ namespace ConditioningControlPanel.Services
                     // Gaze left bounds — drain dwell quickly so a brief
                     // glance doesn't bank progress that completes later.
                     _dwellMs = Math.Max(0, _dwellMs - TickMs * 2);
-                    _activeControl?.SetProgress(_dwellMs / DwellTargetMs);
+                    _control?.SetProgress(_dwellMs / DwellTargetMs);
                 }
 
                 if (elapsed >= graceMs)
@@ -360,31 +414,40 @@ namespace ConditioningControlPanel.Services
                 _gazeSubscribed = false;
             }
 
-            if (_activeControl != null)
-            {
-                try { _activeControl.StopPulse(); } catch { }
-                _activeControl = null;
-            }
+            try { _control?.StopPulse(); } catch { }
 
-            if (_activeWindow != null)
+            // Fade out then HIDE (not Close) — the window is kept alive and reused (see EnsureWindow).
+            if (_checkActive && _window != null)
             {
-                var win = _activeWindow;
-                _activeWindow = null;
+                _checkActive = false;
+                var win = _window;
                 try
                 {
-                    // Brief fade so the dismiss isn't jarring.
                     var anim = new DoubleAnimation
                     {
                         From = win.Opacity, To = 0,
                         Duration = TimeSpan.FromMilliseconds(180),
                     };
-                    anim.Completed += (_, _) => { try { win.Close(); } catch { } };
+                    anim.Completed += (_, _) =>
+                    {
+                        try
+                        {
+                            win.BeginAnimation(Window.OpacityProperty, null);
+                            win.Opacity = 0;
+                            win.Hide();
+                        }
+                        catch { }
+                    };
                     win.BeginAnimation(Window.OpacityProperty, anim);
                 }
                 catch
                 {
-                    try { win.Close(); } catch { }
+                    try { win.BeginAnimation(Window.OpacityProperty, null); win.Opacity = 0; win.Hide(); } catch { }
                 }
+            }
+            else
+            {
+                _checkActive = false;
             }
 
             if (fireEvent)

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -981,6 +981,13 @@ public class BubbleService : IDisposable
     {
         try
         {
+            // Honor the dashboard's Motion setting (ChaosMotionMode: "Mixed"/"FloatUp"/"RainDown"/
+            // "RoamBounce") so dashboard effect bubbles move like chaos ones — e.g. "Rain" makes them fall.
+            // "Mixed" (and any unrecognised value) don't parse → null → the gentle FloatUp default below.
+            // Ambient bubbles are treats (TreatLifeMs dissolves them), so even RoamBounce is safe here.
+            ChaosMotion? motion = Enum.TryParse<ChaosMotion>(App.Settings?.Current?.ChaosMotionMode, out var mm)
+                ? mm : (ChaosMotion?)null;
+
             // Trigger effects linger longer than the brisk chaos cadence (user feedback:
             // pink filter / glitch wash were too quick on the calm dashboard).
             const double LINGER = 2.5;
@@ -999,13 +1006,13 @@ public class BubbleService : IDisposable
                     Label = "GLITCH",
                     IsLive = false,
                     FuseMs = 0,
-                    Motion = ChaosMotion.FloatUp,
+                    Motion = motion ?? ChaosMotion.FloatUp,
                     TreatLifeMs = 7000,
                 };
             }
             var v = ChaosBubbleVariants.All.FirstOrDefault(x => x.Id == id);
             if (v == null) return null;
-            var spec = ChaosBubbleVariants.Build(v, intensity: 0.3, motionOverride: ChaosMotion.FloatUp, ambient: true);
+            var spec = ChaosBubbleVariants.Build(v, intensity: 0.3, motionOverride: motion, ambient: true);
             if (spec.Payload != null) spec.Payload.DurationMult = LINGER;   // longer-lasting overlays/flashes
             return spec;
         }
@@ -1994,7 +2001,13 @@ internal class Bubble
     // allocated once per slot and recycled. A single full-screen canvas host was rejected because
     // it can't do click-through-except-on-bubbles without a global mouse hook.
     private const int WINDOW_POOL_MAX = 64;
-    private static readonly System.Collections.Generic.Stack<Window> _windowPool = new();
+    // Size-aware pool: one stack per quantized square side (128, 256, 384, …). A single shared stack meant
+    // renting a shell last sized for a DIFFERENT bucket, forcing a layered-window resize — HwndTarget.OnResize
+    // -> synchronous MediaContext.CompleteRender, which wedges the UI thread under a backed-up render thread
+    // (the #494 mechanism), on top of the native DIB realloc. Keying by size makes every rental an exact
+    // match, so a bubble window is never resized after creation.
+    private static readonly System.Collections.Generic.Dictionary<int, System.Collections.Generic.Stack<Window>> _windowPool = new();
+    private static int _windowPoolCount;   // total idle shells across all buckets, for the WINDOW_POOL_MAX cap
 
     // Shared frozen near-invisible hit brush — identical on every bubble, so one frozen instance the
     // render thread realizes once beats a fresh SolidColorBrush per spawn (alloc + per-instance realize).
@@ -2009,13 +2022,18 @@ internal class Bubble
     /// does, but driven by the AppSettings.BubbleSharedHost flag instead of the chaos one.</summary>
     internal static bool AmbientHostActive;
 
-    /// <summary>A hidden, reset transparent window shell — recycled or freshly built. UI thread only.</summary>
-    private static Window RentWindow()
+    /// <summary>A hidden, reset transparent window shell of exactly <paramref name="bucket"/> px square —
+    /// recycled from that bucket or freshly built at that size. Never resized after creation. UI thread only.</summary>
+    private static Window RentWindow(int bucket)
     {
-        while (_windowPool.Count > 0)
+        if (_windowPool.TryGetValue(bucket, out var stack))
         {
-            var w = _windowPool.Pop();
-            if (w != null) return w;
+            while (stack.Count > 0)
+            {
+                var w = stack.Pop();
+                _windowPoolCount--;
+                if (w != null) return w;
+            }
         }
         return new Window
         {
@@ -2028,19 +2046,31 @@ internal class Bubble
             Focusable = false,
             ResizeMode = ResizeMode.NoResize,
             WindowStartupLocation = WindowStartupLocation.Manual,
+            Width = bucket,
+            Height = bucket,   // sized once, here — the resize that used to happen per-spawn is gone
         };
     }
 
-    /// <summary>Reset a dead bubble's window to a bare hidden shell and return it to the pool
-    /// (or Close it if the pool is full). Drops Content/Effect so the visual tree + bitmaps
-    /// release immediately and nothing roots the old bubble. UI thread only.</summary>
-    private static void ReturnWindow(Window? w)
+    /// <summary>Reset a dead bubble's window to a bare hidden shell and return it to its size bucket
+    /// (or Close it if the pool is full). Drops Content/Effect so the visual tree + bitmaps release
+    /// immediately and nothing roots the old bubble. <paramref name="bucket"/> is the window's square
+    /// side (its _winDim) — the shell is never resized, so it stays in exactly this bucket. UI thread only.</summary>
+    private static void ReturnWindow(Window? w, int bucket)
     {
         if (w == null) return;
         // Restore the topmost default: a Free Desktop chaos bubble may have set this false, and the
         // pool is shared with ambient bubbles that must always ride on top.
         try { w.Effect = null; w.Content = null; w.Opacity = 0; w.Topmost = true; w.Hide(); } catch { }
-        if (_windowPool.Count < WINDOW_POOL_MAX) _windowPool.Push(w);
+        if (_windowPoolCount < WINDOW_POOL_MAX)
+        {
+            if (!_windowPool.TryGetValue(bucket, out var stack))
+            {
+                stack = new System.Collections.Generic.Stack<Window>();
+                _windowPool[bucket] = stack;
+            }
+            stack.Push(w);
+            _windowPoolCount++;
+        }
         else { try { w.Close(); } catch { } }
     }
 
@@ -2048,10 +2078,15 @@ internal class Bubble
     /// and would otherwise hold its hidden HWNDs for the process lifetime.</summary>
     public static void DrainWindowPool()
     {
-        while (_windowPool.Count > 0)
+        foreach (var stack in _windowPool.Values)
         {
-            try { _windowPool.Pop()?.Close(); } catch { }
+            while (stack.Count > 0)
+            {
+                try { stack.Pop()?.Close(); } catch { }
+            }
         }
+        _windowPool.Clear();
+        _windowPoolCount = 0;
     }
 
     private readonly Window? _window;   // null in shared-host mode (the grid lives on ChaosBubbleHostOverlay)
@@ -2798,8 +2833,9 @@ internal class Bubble
             // PER-WINDOW MODE (default): one pooled top-level layered Window per bubble. Quantize to a
             // 128px bucket so a recycled shell reuses its DIB back-buffer (per-spawn resize of a layered
             // window reallocs the native DIB — that was the chaos OOM; managed heap flat, GDI climbing).
-            _window = RentWindow();
-            if (_window.Width != _winDim) { _window.Width = _winDim; _window.Height = _winDim; }
+            // Rent an exact-size shell from the pool: the size-aware pool guarantees Width==Height==_winDim,
+            // so a layered-window resize (OnResize -> CompleteRender wedge + DIB realloc) never happens here.
+            _window = RentWindow((int)_winDim);
             // Null (not Transparent) background so the quantized margin around the centred grid is NOT
             // hit-testable — clicks there pass through; the click area stays exactly the grid.
             _window.Background = null;
@@ -4450,8 +4486,9 @@ internal class Bubble
         else
         {
             // Recycle the window shell instead of closing it (no per-bubble HWND churn → no
-            // finalizer-queue flood → bounded native memory). ReturnWindow hides + resets it.
-            ReturnWindow(_window);
+            // finalizer-queue flood → bounded native memory). ReturnWindow hides + resets it, filing it
+            // back under its size bucket (_winDim) so the next same-size rental needs no resize.
+            ReturnWindow(_window, (int)_winDim);
         }
 
         // Notify service to remove from list (after animation completed)

--- a/ConditioningControlPanel/Services/Chaos/ChaosBubbleVariants.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosBubbleVariants.cs
@@ -751,8 +751,11 @@ public static class ChaosBubbleVariants
 
         if (ambient)
         {
-            // Trigger-bubble use: strip the fuse/defuse so it fires on pop, and float up gently.
-            motion = ChaosMotion.FloatUp;
+            // Trigger-bubble use: strip the fuse/defuse so it fires on pop. Honor an explicit motion
+            // override (the dashboard's Motion setting, e.g. "Rain") so ambient bubbles move like chaos
+            // ones; with no override ("Mixed") default to a gentle float. Ambient bubbles are treats, so
+            // TreatLifeMs dissolves them even if the motion (e.g. RoamBounce) never exits the screen.
+            if (motionOverride == null) motion = ChaosMotion.FloatUp;
             // Payloads may tone themselves down on the calm dashboard (e.g. video skips the
             // chaos random-segment arm — there is no 15s cap outside a run, #456/#458).
             payload.Ambient = true;

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using ConditioningControlPanel.Services;
 using ConditioningControlPanel.Services.Speech;
+using ConditioningControlPanel.Services.UI;
 using ConditioningControlPanel.Localization;
 
 namespace ConditioningControlPanel
@@ -20,9 +21,10 @@ namespace ConditioningControlPanel
     /// </summary>
     public partial class LockCardWindow : Window
     {
-        private readonly string _phrase;
-        private readonly int _requiredRepeats;
-        private readonly bool _strictMode;
+        // Per-session config (mutable: a pooled window is reconfigured on every reuse — see Configure).
+        private string _phrase = "";
+        private int _requiredRepeats;
+        private bool _strictMode;
         private bool _voiceMode;   // solve by speaking instead of typing (may fall back mid-session)
         private int _completedRepeats = 0;
         private bool _isCompleted = false;
@@ -30,11 +32,25 @@ namespace ConditioningControlPanel
         private bool _voiceListening = false;
         private System.Threading.CancellationTokenSource? _voiceCts; // cancels the in-flight recognize on close/panic/privacy
         private bool _evictedAutonomy = false; // we stood the "Hey Bambi" wake/PTT mic down and must restore it
-        
+
         // Multi-monitor support
-        private readonly bool _isPrimary;
-        private static List<LockCardWindow> _allWindows = new();
+        private bool _isPrimary;
+        private System.Windows.Forms.Screen? _screen;   // remembered so re-show can reposition on reuse
+        private static List<LockCardWindow> _allWindows = new();   // the visible set (drives IsAnyOpen / sync)
         private static string _sharedInput = "";
+
+        // Keep-alive pool. A lock card is a WS_EX_LAYERED/AllowsTransparency window; a FRESH Window.Show()
+        // runs a synchronous MediaContext.CompleteRender on first realization, which — under a render thread
+        // already backed up by many animating overlays — never returns and wedges the whole UI (the #494
+        // freeze; same mechanism dump-confirmed for flashes 2026-07-05). So instead of new/Close per card we
+        // realize once, then Hide()/Show() and reconfigure. Hidden instances live here between cards.
+        private static readonly Stack<LockCardWindow> _pool = new();
+        private const int POOL_MAX = 6;   // enough for a very wide multi-monitor rig; surplus is closed
+        private static DispatcherTimer? _deferTimer;   // holds a show while a display change settles
+        private static int _deferAttempts = 0;
+        private const int DEFER_MAX_ATTEMPTS = 6;      // ~5.4s ceiling — a required card always appears
+
+        private const int WM_DPICHANGED = 0x02E0;
         
         // Achievement tracking
         private static DateTime _startTime;
@@ -63,7 +79,9 @@ namespace ConditioningControlPanel
         /// <summary>
         /// Check if any lock card window is currently open
         /// </summary>
-        public static bool IsAnyOpen() => _allWindows.Count > 0;
+        // A card is "open" if any window is visible OR a show is deferred waiting on a display change to
+        // settle (so a poller like BubbleCountResultWindow doesn't conclude the card closed before it opened).
+        public static bool IsAnyOpen() => _allWindows.Count > 0 || _deferTimer != null;
 
         /// <summary>
         /// Create a lock card window for a specific screen
@@ -73,15 +91,56 @@ namespace ConditioningControlPanel
         /// <param name="strictMode">If true, ESC is disabled</param>
         /// <param name="screen">The screen to show on (null for primary)</param>
         /// <param name="isPrimary">If true, this window handles input</param>
-        public LockCardWindow(string phrase, int repeats, bool strictMode,
-            System.Windows.Forms.Screen? screen = null, bool isPrimary = true, bool voiceMode = false)
+        // One-time shell construction. All per-session state is applied in Configure(), so a single
+        // realized instance can be reused for any later card without a fresh Window.Show() on the hot path.
+        public LockCardWindow()
         {
             InitializeComponent();
+
+            // When focus is lost, immediately reclaim it using Win32 to prevent keystrokes from leaking
+            // into other apps (e.g. Discord). Wired once and unconditionally: it reads the CURRENT
+            // session's _isPrimary/_isCompleted/_voiceMode, so it keeps working across reuse (and a
+            // hidden pooled window never raises Deactivated, with the IsVisible check as a backstop).
+            Deactivated += (s, e) =>
+            {
+                if (!_isPrimary || _isCompleted) return;
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    if (_isCompleted || !IsVisible) return;
+                    if (_hwnd != IntPtr.Zero)
+                    {
+                        SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                        SetForegroundWindow(_hwnd);
+                    }
+                    Activate();
+                    if (_voiceMode) Focus(); else TxtInput.Focus();
+                }), DispatcherPriority.Input);
+            };
+        }
+
+        /// <summary>
+        /// Apply per-session configuration to this (possibly reused) window: tear down any prior card's
+        /// state, set the phrase/mode/colors, and position it on the target screen. Safe to call repeatedly
+        /// on a pooled instance — this is what lets us avoid realizing a fresh layered window per card.
+        /// </summary>
+        private void Configure(string phrase, int repeats, bool strictMode,
+            System.Windows.Forms.Screen? screen, bool isPrimary, bool voiceMode)
+        {
+            // ── reset transient state (a pooled window still carries the previous card's) ──
+            _closeTimer?.Stop();
+            _closeTimer = null;
+            _voiceMode = false;      // force any prior voice loop to fully tear down before we reconfigure
+            StopVoiceSolve();
+            _completedRepeats = 0;
+            _isCompleted = false;
+            _sharedInput = "";
 
             _phrase = phrase;
             _requiredRepeats = repeats;
             _strictMode = strictMode;
             _isPrimary = isPrimary;
+            _screen = screen;
             // Voice mode degrades gracefully to typing if the offline engine isn't usable, so the
             // user can never be trapped behind a mic that won't cooperate.
             _voiceMode = voiceMode && App.Speech?.IsAvailable == true && App.Settings.Current.MicConsentGiven;
@@ -91,6 +150,16 @@ namespace ConditioningControlPanel
             // Set the phrase text
             TxtPhrase.Text = phrase;
 
+            // Clear any pulse/shake transform and reset input + panels to the fresh (unsolved) look —
+            // a reused window may have been left mid-completion or mid-encouragement.
+            CardBorder.RenderTransform = null;
+            TxtInput.IsEnabled = true;
+            TxtInput.Clear();
+            CompletionPanel.Visibility = Visibility.Collapsed;
+            TxtHint.Visibility = Visibility.Visible;
+            TxtHint.Foreground = new SolidColorBrush(Color.FromRgb(0x66, 0x66, 0x66));
+            TxtVoiceHeard.Text = "I heard: …";
+
             // Swap the input affordance for the voice panel when solving by voice.
             if (_voiceMode)
             {
@@ -99,22 +168,28 @@ namespace ConditioningControlPanel
                 TxtTitle.Text = "SAY IT TO UNLOCK";
                 TxtHint.Text = "Say the phrase out loud, clearly.";
                 TxtVoiceState.Text = _isPrimary ? "🎤 Listening…" : "🎤 Speak on the main monitor";
+                VoiceStateBrush.Color = VoicePink;
+                if (VoiceLevelFill.RenderTransform is ScaleTransform st) st.ScaleX = 0;
+            }
+            else
+            {
+                InputBorder.Visibility = Visibility.Visible;
+                VoicePanel.Visibility = Visibility.Collapsed;
+                TxtTitle.Text = Loc.Get("label_type_to_unlock_2");
             }
 
             // Update progress display
             UpdateProgress();
-            
+
             // Handle strict mode
-            if (_strictMode)
-            {
-                TxtStrict.Text = Loc.Get("label_strict");
-            }
+            TxtStrict.Text = _strictMode ? Loc.Get("label_strict") : "";
             // Esc always works now (even in strict mode) so always show the hint.
             TxtEscHint.Text = Loc.Get("label_press_esc_to_close");
-            
+
             // Position on screen
             if (screen != null)
             {
+                WindowState = WindowState.Normal;
                 PositionOnScreen(screen);
             }
             else
@@ -122,7 +197,7 @@ namespace ConditioningControlPanel
                 // Default to primary screen, maximized
                 WindowState = WindowState.Maximized;
             }
-            
+
             // Non-primary windows show synced text but input is read-only
             if (!_isPrimary)
             {
@@ -130,48 +205,32 @@ namespace ConditioningControlPanel
                 TxtInput.Focusable = false;
                 TxtHint.Text = Loc.Get("label_input_synced_from_primary_monitor");
             }
-            
+            else
+            {
+                TxtInput.IsReadOnly = false;
+                TxtInput.Focusable = true;
+                if (!_voiceMode) TxtHint.Text = Loc.Get("label_type_the_phrase_exactly_as_shown_above");
+            }
+
             // Apply custom colors from settings
             ApplyColors();
-            
-            // Register this window
-            _allWindows.Add(this);
-
-            // When focus is lost, immediately reclaim it using Win32 to prevent
-            // keystrokes from leaking into other apps (e.g., Discord)
-            if (_isPrimary)
-            {
-                Deactivated += (s, e) =>
-                {
-                    if (_isCompleted) return;
-                    Dispatcher.BeginInvoke(new Action(() =>
-                    {
-                        if (_isCompleted || !IsVisible) return;
-                        if (_hwnd != IntPtr.Zero)
-                        {
-                            SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                                SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-                            SetForegroundWindow(_hwnd);
-                        }
-                        Activate();
-                        if (_voiceMode) Focus(); else TxtInput.Focus();
-                    }), DispatcherPriority.Input);
-                };
-            }
         }
 
         private void PositionOnScreen(System.Windows.Forms.Screen screen)
         {
-            // Get DPI scale
-            var dpiScale = VisualTreeHelper.GetDpi(this);
-            var scaleX = dpiScale.DpiScaleX;
-            var scaleY = dpiScale.DpiScaleY;
-            
+            // Use the TARGET monitor's DPI (derived from its bounds), NOT GetDpi(this): a reused/pooled
+            // window may currently sit on a different-DPI monitor, and we now swallow WM_DPICHANGED so
+            // WPF won't auto-correct the size after the move. Getting the scale right here keeps full-
+            // screen coverage on mixed-DPI rigs — critical for a lock that must not leave the desktop
+            // reachable around the card.
+            var scale = BubbleCountWindow.GetDpiForScreen(screen);
+            if (scale <= 0) scale = 1.0;
+
             // Position window to cover the entire screen
-            Left = screen.Bounds.Left / scaleX;
-            Top = screen.Bounds.Top / scaleY;
-            Width = screen.Bounds.Width / scaleX;
-            Height = screen.Bounds.Height / scaleY;
+            Left = screen.Bounds.Left / scale;
+            Top = screen.Bounds.Top / scale;
+            Width = screen.Bounds.Width / scale;
+            Height = screen.Bounds.Height / scale;
         }
 
         private void ApplyColors()
@@ -231,28 +290,55 @@ namespace ConditioningControlPanel
             }
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        // Realization setup. OnSourceInitialized fires ONCE, synchronously during the first Show() and
+        // before Show() returns, so _hwnd is valid by the time OnShown() runs (even on the first card).
+        // Hide()/Show() reuse does NOT re-raise it, so this is strictly one-time.
+        protected override void OnSourceInitialized(EventArgs e)
         {
+            base.OnSourceInitialized(e);
             _hwnd = new WindowInteropHelper(this).Handle;
 
-            // Force this window to foreground via Win32 on primary
-            if (_isPrimary)
+            // Swallow WM_DPICHANGED: this window's geometry is computed manually per-monitor
+            // (PositionOnScreen uses the target monitor's DPI), so WPF's automatic DPI rescale is
+            // unwanted — and its OnDpiChanged -> OnResize -> synchronous MediaContext.CompleteRender
+            // deadlocks the UI thread on a backed-up render thread (the same #494 mechanism). Fired only
+            // on cross-DPI-monitor moves, so dropping it never affects the initial render.
+            if (_hwnd != IntPtr.Zero)
+                HwndSource.FromHwnd(_hwnd)?.AddHook(SwallowDpiChanged);
+        }
+
+        // XAML still wires Loaded="Window_Loaded"; keep a no-op so the binding resolves. All realization
+        // setup is in OnSourceInitialized; everything per-show is in OnShown().
+        private void Window_Loaded(object sender, RoutedEventArgs e) { }
+
+        // WndProc hook: drop WM_DPICHANGED so WPF never runs its auto DPI-rescale (which deadlocks under
+        // a backed-up render thread). Mirrors FlashService.SwallowDpiChanged.
+        private static IntPtr SwallowDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_DPICHANGED) handled = true;   // consume it; WPF's HwndTarget never sees the resize
+            return IntPtr.Zero;
+        }
+
+        // Runs on EVERY show (fresh or reused) — the foreground grab, focus, log, and voice-solve start
+        // that used to live in Window_Loaded. Called from ShowOnAllMonitors after Show().
+        private void OnShown()
+        {
+            if (!_isPrimary) return;
+
+            if (_hwnd != IntPtr.Zero)
             {
-                if (_hwnd != IntPtr.Zero)
-                {
-                    SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
-                    SetForegroundWindow(_hwnd);
-                }
-                Activate();
-                if (_voiceMode) Focus(); else TxtInput.Focus();
-
-                App.Logger?.Information("Lock Card shown - Phrase: {Phrase}, Repeats: {Repeats}, Strict: {Strict}, Voice: {Voice}, Monitors: {Count}",
-                    _phrase, _requiredRepeats, _strictMode, _voiceMode, _allWindows.Count);
-
-                // Begin the spoken-solve listen loop on the primary monitor.
-                if (_voiceMode) StartVoiceSolve();
+                SetWindowPos(_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                SetForegroundWindow(_hwnd);
             }
+            Activate();
+            if (_voiceMode) Focus(); else TxtInput.Focus();
+
+            App.Logger?.Information("Lock Card shown - Phrase: {Phrase}, Repeats: {Repeats}, Strict: {Strict}, Voice: {Voice}, Monitors: {Count}",
+                _phrase, _requiredRepeats, _strictMode, _voiceMode, _allWindows.Count);
+
+            // Begin the spoken-solve listen loop on the primary monitor.
+            if (_voiceMode) StartVoiceSolve();
         }
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
@@ -649,7 +735,7 @@ namespace ConditioningControlPanel
 
         private void CloseAllWindows()
         {
-            ForceCloseAll();
+            DismissAll();
         }
 
         /// <summary>
@@ -673,22 +759,27 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// Force close all lock card windows (used by panic button)
+        /// Dismiss all lock card windows (panic button, engine stop, remote stop, and the normal
+        /// post-completion auto-close). Windows are hidden and returned to the keep-alive pool rather
+        /// than closed, so the next card reuses a pre-realized layered window instead of realizing a
+        /// fresh one on the hot path — the fix for the #494 render-thread-deadlock freeze.
         /// </summary>
-        public static void ForceCloseAll()
+        public static void ForceCloseAll() => DismissAll();
+
+        private static void DismissAll()
         {
-            // Create a copy of the list to avoid modification during iteration
-            var windowsToClose = new List<LockCardWindow>(_allWindows);
+            // Cancel any pending deferred show so a card can't pop up after "stop everything".
+            _deferTimer?.Stop();
+            _deferTimer = null;
+            _deferAttempts = 0;
+
+            // Copy to avoid modification during iteration.
+            var windows = new List<LockCardWindow>(_allWindows);
             _allWindows.Clear();
 
-            foreach (var window in windowsToClose)
+            foreach (var window in windows)
             {
-                window._isCompleted = true; // Allow closing even in strict mode
-                try
-                {
-                    window.Close();
-                }
-                catch { }
+                try { window.DismissToPool(); } catch { }
             }
 
             // Notify InteractionQueue that lock card is complete (triggers queued items).
@@ -697,11 +788,66 @@ namespace ConditioningControlPanel
             // current (e.g. an in-flight Video), letting the session summary race the video
             // teardown (#462). The current-interaction check also dedups against OnClosing's
             // last-window release (whichever runs first wins; the other sees a foreign slot).
-            if (windowsToClose.Count > 0 &&
+            if (windows.Count > 0 &&
                 App.InteractionQueue?.CurrentInteraction == Services.InteractionQueueService.InteractionType.LockCard)
             {
                 App.InteractionQueue.Complete(Services.InteractionQueueService.InteractionType.LockCard);
             }
+        }
+
+        // Hide this window and return it to the keep-alive pool for reuse. Full teardown of voice + timers
+        // so no zombie loop survives; the window is deliberately NOT closed (closing would force a fresh
+        // layered-window realization — and its CompleteRender — on the next card's hot path).
+        private void DismissToPool()
+        {
+            _isCompleted = true;   // allow dismissal even in strict mode; also unblocks the voice loop guard
+            _closeTimer?.Stop();
+            _closeTimer = null;
+            _voiceMode = false;    // drop voice so RunVoiceSolveLoopAsync's `while (!_isCompleted && _voiceMode)` exits
+            StopVoiceSolve();
+            try { Hide(); } catch { }
+            ReturnToPool();
+        }
+
+        private void ReturnToPool()
+        {
+            if (_pool.Count < POOL_MAX)
+            {
+                if (!_pool.Contains(this)) _pool.Push(this);
+            }
+            else
+            {
+                // Over the cap (e.g. a wide multi-monitor rig shrank): close the surplus so hidden windows
+                // don't leak. This Close() is on the dismissal path, never a card show, so it's off the
+                // deadlock-prone hot path.
+                try { _isCompleted = true; Close(); } catch { }
+            }
+        }
+
+        // Take a window from the keep-alive pool, or realize a new one on a pool miss (the first card of a
+        // session, or more monitors than we've pooled). Only the miss path pays the one-time realization.
+        private static LockCardWindow RentWindow()
+        {
+            while (_pool.Count > 0)
+            {
+                var w = _pool.Pop();
+                if (w != null) return w;
+            }
+            return new LockCardWindow();
+        }
+
+        // Drop a window from the pool (it's being genuinely closed). Stack has no Remove, so rebuild.
+        private static void RemoveFromPool(LockCardWindow target)
+        {
+            if (_pool.Count == 0 || !_pool.Contains(target)) return;
+            var kept = new List<LockCardWindow>(_pool.Count);
+            while (_pool.Count > 0)
+            {
+                var w = _pool.Pop();
+                if (w != target) kept.Add(w);
+            }
+            // Restore original top-of-stack order.
+            for (int i = kept.Count - 1; i >= 0; i--) _pool.Push(kept[i]);
         }
 
         protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
@@ -722,6 +868,9 @@ namespace ConditioningControlPanel
             _voiceMode = false;
             StopVoiceSolve();
             _allWindows.Remove(this);
+            // If this window is being genuinely closed (app shutdown, Alt+F4), make sure it can't be
+            // handed back out of the keep-alive pool as a dead shell.
+            RemoveFromPool(this);
             // Non-strict cards can be closed without completing (Alt+F4, titlebar) — if this
             // was the last one, release the interaction slot or videos/lock cards stay blocked
             // for the 5-minute stuck timer. Guarded on CurrentInteraction so a close arriving
@@ -760,7 +909,40 @@ namespace ConditioningControlPanel
         /// </summary>
         public static void ShowOnAllMonitors(string phrase, int repeats, bool strictMode, bool isTest = false, bool voiceMode = false)
         {
-            // Clear any existing windows
+            // A display topology / DPI change is mid-flight: realizing or juggling layered windows during
+            // that volatile ~900ms window is exactly what backs up the render thread and wedges the UI.
+            // Defer briefly rather than drop — a lock card is a required interaction, not a transient
+            // effect — and bound the retries so the card always appears even if changes keep firing.
+            if (DisplayChangeCoordinator.SpawnsSuppressed && _deferAttempts < DEFER_MAX_ATTEMPTS)
+            {
+                _deferAttempts++;
+                _deferTimer?.Stop();
+                _deferTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(900) };
+                _deferTimer.Tick += (s, e) =>
+                {
+                    _deferTimer?.Stop();
+                    _deferTimer = null;
+                    ShowOnAllMonitors(phrase, repeats, strictMode, isTest, voiceMode);
+                };
+                _deferTimer.Start();
+                App.Logger?.Debug("LockCardWindow: display change in progress — deferring card (attempt {N})", _deferAttempts);
+                return;
+            }
+            _deferTimer?.Stop();
+            _deferTimer = null;
+            _deferAttempts = 0;
+
+            // Defensive: hide + pool any still-visible cards from a prior show before starting a new one.
+            // The interaction queue normally serializes lock cards, but a stray overlap must never leak a
+            // visible window (it would sit on screen forever, un-dismissable). Does NOT release the queue
+            // slot — we're reusing it for the new card.
+            if (_allWindows.Count > 0)
+            {
+                foreach (var w in new List<LockCardWindow>(_allWindows))
+                {
+                    try { w.DismissToPool(); } catch { }
+                }
+            }
             _allWindows.Clear();
             _sharedInput = "";
 
@@ -769,7 +951,7 @@ namespace ConditioningControlPanel
             _totalErrors = 0;
             _totalCharsTyped = 0;
             _isTest = isTest;
-            
+
             var screens = App.GetAllScreensCached();
             if (screens.Length == 0)
             {
@@ -782,7 +964,12 @@ namespace ConditioningControlPanel
             foreach (var screen in screens)
             {
                 var isPrimary = screen.Primary;
-                var window = new LockCardWindow(phrase, repeats, strictMode, screen, isPrimary, voiceMode);
+                // Reuse a pre-realized shell from the pool (or realize one on a miss). Reusing means the
+                // Show() below re-shows an existing layered window instead of realizing a fresh one —
+                // no synchronous CompleteRender on the hot path, so no render-thread deadlock (#494).
+                var window = RentWindow();
+                window.Configure(phrase, repeats, strictMode, screen, isPrimary, voiceMode);
+                _allWindows.Add(window);
 
                 if (isPrimary)
                 {
@@ -790,6 +977,7 @@ namespace ConditioningControlPanel
                 }
 
                 window.Show();
+                window.OnShown();   // per-show foreground/focus/voice (Loaded no longer re-fires on reuse)
             }
 
             // Focus primary window


### PR DESCRIPTION
Re-triaged both open 6.2.9 bugs (ccp-bugs #494/#493, user Nardda) against the **raw activity logs** rather than the report labels. Both first-pass fixes had targeted the wrong root cause; this PR fixes the actual ones and keeps the first-pass work as hardening.

## #494 — "app freezes, must kill process" (render-thread deadlock)
No managed crash. Nardda's freeze log has **zero lock-card activity** — it's dominated by avatar emote crossfades (~1/sec) + continuous OCR + whisper subliminals, with webcam gaze on. Mechanism: the emote crossfade **saturates the software render thread** (two full-size animated GIFs, each a 20px `DropShadow` blur, every frame), and a fresh `WS_EX_LAYERED` `Window.Show()` landing on that thread wedges in the synchronous `OnResize → CompleteRender`.

The two remaining unpooled fresh-`Show()` paths that fire repeatedly per session were the **triggers** (mapped via a repo-wide sweep of layered-window realizations):
- **`AttentionCheckService`** → keep-alive pooled popup (realize once, then reposition + Hide/Show reuse; `WM_DPICHANGED` swallow; hard-close on `Stop()`).
- **`AvatarRandomBubble`** → fixed-size (200px) reusable-window pool (cap 6); bubble image centred so its size varies **without ever resizing the window**; dropped the accumulating window-level click handler; DPI swallow.

Emote render-load cut so the thread is less saturated in the first place:
- `AdvanceCirce` **idle** rotation deferred to `DispatcherPriority.Background` (talk/queue stay immediate for mouth-sync).
- Animated avatar layers' `DropShadow` `BlurRadius` **20 → 10** (~4× cheaper). Deliberately *not* "drop one layer's blur" — the active layer alternates A/B, so that would blink the glow on/off.

## #493 — "Rain bubble trigger nothing" (not motion mode)
"**RAIN**" is the on-screen label of the `htlink` / dashboard-**"Cascade"** trigger bubble. Its `GifCascade` payload fires correctly, but `ChaosGifCascadeOverlay` sized itself **primary-only** (`StageBounds` when chaos DualMonitor is off), so it rained off a multi-monitor user's active screen. Now the window **always spans the full virtual screen** (never resized — a layered resize is itself a deadlock risk) and only the **clip spawn band** is confined per-`Show()`: dashboard triggers rain across **all** monitors; a chaos run keeps its per-config coverage. Added a `GifCascade: raining …` diagnostic log.

## Also folded in (first-pass hardening, kept)
`LockCardWindow` per-screen keep-alive pool, `BubbleService` size-aware window pool, and dashboard bubbles honoring `ChaosMotionMode`.

## Verification
- ✅ Debug build green (0 errors).
- ⏳ **GUI verification pending** (can't repro the multi-monitor + webcam heavy-load freeze headlessly): confirm attention checks + random avatar bubbles don't wedge under a busy session, and that popping a dashboard **RAIN**/Cascade bubble rains gifs on the active screen (watch for the new `GifCascade: raining` log line).

Closes #494, closes #493 (pending GUI confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pgDMi4iqCHEZiTqAtkX4w