### PR TITLE
fix: lock cards repeat + hard 60s bark cooldown + keep bounce text in tray

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -315,8 +315,12 @@ namespace ConditioningControlPanel
                 _trayIcon?.MinimizeToTray();
                 HideAvatarTube();
 
-                // Stop bouncing text when minimizing to tray (user expects app to be "closed")
-                App.BouncingText?.Stop();
+                // NOTE: bouncing/subliminal text is intentionally LEFT RUNNING while in the tray.
+                // It's an unowned, topmost, click-through overlay, so it keeps rendering over the
+                // desktop with MainWindow hidden — which is the point of a background conditioning
+                // tool. This also matches every other minimize-to-tray path (start-minimized,
+                // scheduler auto-start, remote), which never stopped it. (Reported: bounce text
+                // vanished when the app went to tray via the X button.)
             }
 
             // Make sure the Blink Trainer demo timer + live subscription are

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -66,6 +66,16 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private const int GlobalMinGapMs = 60000;
 
+        /// <summary>
+        /// Triggers that skip ONLY the hard global min-gap floor above (they keep their own per-rule
+        /// cooldown_ms and every other gate). These are FUNCTIONAL corrections that must keep their
+        /// authored cadence rather than flavor chatter — currently the mandatory-video attention-check
+        /// fail ("eyes on the screen, pay attention"), which authors a 20s cooldown. Trigger keys are
+        /// app-raised constants, so a mod's rule under this trigger inherits the exemption.
+        /// </summary>
+        private static readonly HashSet<string> GlobalGapExemptTriggers =
+            new(StringComparer.OrdinalIgnoreCase) { "AttentionCheckFail" };
+
         /// <summary>Barks at/above this priority (or any non-Normal class) speak via GigglePriority; lower ones queue via Giggle.</summary>
         private const int PriorityBarkThreshold = 100;
 
@@ -1350,10 +1360,15 @@ namespace ConditioningControlPanel.Services
                 if (!willPreempt && (App.AvatarWindow?.IsSpeaking ?? false))
                     return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = "speaking" };
 
-                // Global min-gap.
-                var sinceGlobal = (DateTime.UtcNow - _globalLastFireUtc).TotalMilliseconds;
-                if (sinceGlobal < GlobalMinGapMs)
-                    return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = $"min-gap ({sinceGlobal:F0}/{GlobalMinGapMs}ms)" };
+                // Global min-gap. Functional triggers (e.g. the video attention-check correction) skip
+                // ONLY this floor and keep their own per-rule cooldown below, so a needed correction
+                // still speaks even when recent chatter would otherwise wall it off for a full minute.
+                if (!GlobalGapExemptTriggers.Contains(rule.Trigger))
+                {
+                    var sinceGlobal = (DateTime.UtcNow - _globalLastFireUtc).TotalMilliseconds;
+                    if (sinceGlobal < GlobalMinGapMs)
+                        return new GateDecision { WouldFire = false, VariantIndex = -1, Reason = $"min-gap ({sinceGlobal:F0}/{GlobalMinGapMs}ms)" };
+                }
 
                 // Per-bark cooldown.
                 if (rule.CooldownMs > 0 && _lastFiredUtc.TryGetValue(rule.Id, out var last))

--- a/ConditioningControlPanel/Services/Companion/BarkService.cs
+++ b/ConditioningControlPanel/Services/Companion/BarkService.cs
@@ -56,8 +56,15 @@ namespace ConditioningControlPanel.Services
         /// <summary>How many distinct just-spoken lines to avoid replaying across all rules.</summary>
         private const int RecentlySpokenMemory = 8;
 
-        /// <summary>Global minimum gap between any two barks.</summary>
-        private const int GlobalMinGapMs = 4000;
+        /// <summary>
+        /// Hard global cooldown between any two reactive/idle barks (temporary — a user-facing slider
+        /// is the planned follow-up). Users reported she "runs her mouth constantly" and that reactive
+        /// lines (esp. the webcam FaceFound "back into frame" line) ignore the interval sliders; a 60s
+        /// floor keeps her from firing more than once a minute. Safety (Panic) and `guaranteed` barks
+        /// bypass this (see the `!bypass` block in EvaluateGate), so this never mutes a panic response
+        /// or a one-shot milestone.
+        /// </summary>
+        private const int GlobalMinGapMs = 60000;
 
         /// <summary>Barks at/above this priority (or any non-Normal class) speak via GigglePriority; lower ones queue via Giggle.</summary>
         private const int PriorityBarkThreshold = 100;

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -111,8 +111,11 @@ namespace ConditioningControlPanel.Services
         {
             DispatcherHelper.RunOnUISync(() =>
             {
-                // Prevent stacking multiple lock cards
-                if (Application.Current.Windows.OfType<LockCardWindow>().Any())
+                // Prevent stacking multiple lock cards.
+                // Gate on the visible set (IsAnyOpen), NOT Application.Current.Windows: since 6.2.10 the
+                // window is keep-alive pooled (dismiss => Hide(), not Close()), so a hidden pooled instance
+                // lingers in Application.Current.Windows forever and would block every card after the first.
+                if (LockCardWindow.IsAnyOpen())
                 {
                     App.Logger?.Information("LockCardService: A lock card is already open. Skipping.");
                     return;

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -176,6 +176,11 @@ namespace ConditioningControlPanel.Services
                 catch (Exception ex)
                 {
                     App.Logger?.Error("Failed to show lock card: {Error}", ex.Message);
+                    // If ShowOnAllMonitors threw mid-show a half-registered window can linger in
+                    // LockCardWindow's visible set, leaving IsAnyOpen() permanently true and silently
+                    // skipping every future lock card until the next stop. Force-close clears that set
+                    // so the guard can't stay armed with zero visible cards.
+                    try { LockCardWindow.ForceCloseAll(); } catch { }
                     App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.LockCard);
                 }
             });


### PR DESCRIPTION
Three user-reported issues from ask-support.

## 1. Lock cards only play once (reflex) — regression from 6.2.10
The 6.2.10 freeze fix (`d4926d71`) converted `LockCardWindow` to a keep-alive pool: on dismiss the window is now `Hide()`d and pooled instead of `Close()`d. But the trigger guard in `LockCardService.ShowLockCard` still checked `Application.Current.Windows.OfType<LockCardWindow>().Any()` — a **hidden** window is still in that collection, so after the first card dismissed, one lingered forever and every subsequent tick logged "already open. Skipping."

**Fix:** gate on the visible-only `LockCardWindow.IsAnyOpen()` signal the class already maintains (used elsewhere, e.g. the bubble-count poller).

## 2. Companion talks too much / reactive lines ignore the sliders (Miss Jenny, Nardda)
There's no middle ground between *mute entirely* and *runs her mouth constantly*, and reactive/webcam lines (esp. the FaceFound "back into frame" line) feel like they ignore the interval settings — they only had a hardcoded 4s global gap + a 20s per-rule cooldown.

**Fix (temporary hard cap):** raise `BarkService.GlobalMinGapMs` 4s → **60s**. It lives inside `EvaluateGate`'s `!bypass` block, so **Panic/safety and `guaranteed` one-shot barks still fire**. Commands, Bambi Takeover, Deeper "Speak" prompts and AI chat replies don't route through BarkService and are unaffected. A user-facing cooldown slider + preset persistence + per-video rules is the planned follow-up feature.

## 3. Bounce/subliminal text vanishes in the tray (AhrySiss)
`MainWindow.WindowChrome` deliberately called `App.BouncingText?.Stop()` — but **only** on the X-button → minimize-to-tray path. Every other tray route (start-minimized, scheduler, remote) left it running.

**Fix:** removed the `Stop()`. The overlay is unowned, topmost and click-through, so it keeps rendering over the desktop while the app is in the tray — which is the point of a background conditioning tool.

Build: green (0 errors). Targets a 6.2.11 hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)