### PR TITLE
fix: spiral/pink burying session videos (#497) + weekly-quest loading wedge (#496)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestsTab.cs
@@ -246,6 +246,26 @@ namespace ConditioningControlPanel
                     QuestsTab.BtnRerollWeekly.Content = remainingRerolls > 0 ? $"🔄 Reroll ({remainingRerolls} left)" : "🔄 No rerolls left";
                 }
             }
+            else if (weeklyProgress != null && weeklyProgress.IsCompleted)
+            {
+                // The stored weekly is completed but its definition no longer resolves — the server
+                // rotated the quest pool (ids change on a "20 free + 20 patron" refresh) since it was
+                // done. Without this branch the card kept its XAML defaults ("Loading…" + blank image)
+                // forever, looking broken, and reroll was refused because the quest is completed.
+                // Render a graceful "done for the week" card instead; a fresh weekly generates on the
+                // Monday rollover (IsWeeklyExpired). We do NOT regenerate a completed quest — that
+                // would hand out a second weekly reward after every server refresh. (#496)
+                QuestsTab.TxtWeeklyQuestIcon.Text = "✅";
+                QuestsTab.TxtWeeklyQuestName.Text = "Weekly quest complete!";
+                QuestsTab.TxtWeeklyQuestDesc.Text = "Nice work! Your next weekly quest arrives Monday.";
+                QuestsTab.TxtWeeklyProgress.Text = "";
+                QuestsTab.TxtWeeklyXP.Text = "";
+                QuestsTab.TxtWeeklyStreakBonus.Visibility = Visibility.Collapsed;
+                QuestsTab.TxtWeeklyRerollBonus.Visibility = Visibility.Collapsed;
+                QuestsTab.WeeklyCompletedOverlay.Visibility = Visibility.Visible;
+                QuestsTab.BtnRerollWeekly.IsEnabled = false;
+                QuestsTab.BtnRerollWeekly.Content = Loc.Get("btn_completed");
+            }
 
             // Update statistics
             QuestsTab.TxtTotalDailyCompleted.Text = questService.Progress.TotalDailyQuestsCompleted.ToString();

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -1918,6 +1918,20 @@ public class OverlayService : IDisposable
     private bool ReassertZOrder(bool force = false)
     {
         bool anyRecovered = false;
+
+        // While a mandatory/session video is playing, keep the overlays in the topmost band but
+        // pinned BELOW the video window instead of forcing them to the front. Otherwise this
+        // reconciler (and NotifyTopWindowClosed after each clip) buries the video behind the
+        // spiral/pink filter; the video window is deliberately non-re-raising, so it never
+        // recovers, and with autonomy chaining clips the next one shows "only by flashes" (#497).
+        IntPtr videoHwnd = IntPtr.Zero;
+        try
+        {
+            if (App.Video?.IsPlaying == true && App.Video.PrimaryVideoWindow is Window vw)
+                videoHwnd = new System.Windows.Interop.WindowInteropHelper(vw).Handle;
+        }
+        catch { }
+
         foreach (var list in new[] { _pinkFilterWindows, _spiralWindows, _brainDrainBlurWindows })
         {
             foreach (var window in list)
@@ -1927,7 +1941,16 @@ public class OverlayService : IDisposable
 
                 int exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
                 bool needsPin = (exStyle & WS_EX_TOPMOST) == 0;
-                if (needsPin || force)
+
+                if (videoHwnd != IntPtr.Zero && hwnd != videoHwnd)
+                {
+                    // Insert directly below the active video window: stays topmost (above the
+                    // desktop and other apps) but under the video the user is meant to watch.
+                    SetWindowPos(hwnd, videoHwnd, 0, 0, 0, 0,
+                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+                    if (needsPin) anyRecovered = true;
+                }
+                else if (needsPin || force)
                 {
                     SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);


### PR DESCRIPTION
Two v6.2.10 bug reports.

## #497 — spiral + pink filter buried session videos, required a Task Manager kill (high)
User in a session with **lock-in + takeover**: at the end of a triggered video, the spiral and pink-filter overlays stayed on top of everything; autonomy's next video only appeared "by flashes," and lockdown blocked a clean exit so they had to kill the app via Task Manager.

**Root cause:** `OverlayService`'s 500ms z-order reconciler force-pins pink/spiral to `HWND_TOPMOST` every ~5s, and `NotifyTopWindowClosed()` force-re-pins them again after each clip closes. The video window is deliberately **non-re-raising** (`MakeNonActivating`/`PreventClickRaise`), so once the overlay is bumped above it, it never recovers. There was **no path** that lowered the overlays below a live video.

**Fix:** `ReassertZOrder` is now video-aware — while `App.Video.IsPlaying`, it inserts pink/spiral/braindrain **directly below the primary video window** (still topmost over the desktop, under the video the user is meant to watch) instead of forcing them to the front. With no video playing, behavior is unchanged (front-pin). This fixes both the reconciler tick and the after-clip `NotifyTopWindowClosed` path.

## #496 — weekly quest stuck on "Loading", no image, reroll refused (medium)
**Root cause:** when a **completed** weekly's `DefinitionId` no longer resolves (the server rotates the quest pool on a "20 free + 20 patron" refresh, so ids change), the weekly render block (`if (weeklyDef != null && weeklyProgress != null)`) was skipped with **no else**, so the card kept its XAML defaults ("Loading…" + blank image) indefinitely; reroll was refused because the quest is completed. Non-completed missing-def quests already self-heal via `CheckAndGenerateQuests`; the completed case had no recovery until the Monday rollover.

**Fix:** add a graceful branch — "Weekly quest complete! — next one Monday" with the completed overlay and reroll disabled. We intentionally **do not regenerate a completed quest** (that would grant a second weekly reward after every server refresh); it self-heals on the Monday rollover. Same latent gap exists for daily but self-heals next-day — noted as a follow-up.

Build: green (Debug, 0 errors). Targets the 6.2.11 hotfix alongside #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)