### PR TITLE
fix: 6.2.11 green bugfix batch (quiz archetype, voice [unk], bubble presets)

### DIFF
--- a/ConditioningControlPanel/Models/Preset.cs
+++ b/ConditioningControlPanel/Models/Preset.cs
@@ -100,6 +100,13 @@ namespace ConditioningControlPanel.Models
         public bool BubblesEnabled { get; set; } = false;
         public int BubblesFrequency { get; set; } = 5;
 
+        // Trigger Bubbles (ambient bubbles that fire a Chaos effect on pop)
+        public bool BubbleTriggersEnabled { get; set; } = false;
+        public int BubbleTriggerChance { get; set; } = 10;
+        public int BubbleSpeedBoost { get; set; } = 0;
+        public List<string> BubbleTriggerVariants { get; set; } = new() { "flash", "subliminal", "pink", "spiral", "glitch", "htlink", "video" };
+        public bool BubbleAvatarEggEnabled { get; set; } = true;
+
         // Lock Card Settings (Level 35+)
         public bool LockCardEnabled { get; set; } = false;
         public int LockCardFrequency { get; set; } = 2;
@@ -360,6 +367,11 @@ namespace ConditioningControlPanel.Models
             // Bubbles
             settings.BubblesEnabled = BubblesEnabled;
             settings.BubblesFrequency = BubblesFrequency;
+            settings.BubbleTriggersEnabled = BubbleTriggersEnabled;
+            settings.BubbleTriggerChance = BubbleTriggerChance;
+            settings.BubbleSpeedBoost = BubbleSpeedBoost;
+            settings.BubbleTriggerVariants = BubbleTriggerVariants != null ? new List<string>(BubbleTriggerVariants) : new List<string>();
+            settings.BubbleAvatarEggEnabled = BubbleAvatarEggEnabled;
 
             // Lock Card
             settings.LockCardEnabled = LockCardEnabled;
@@ -461,6 +473,11 @@ namespace ConditioningControlPanel.Models
                 // Bubbles
                 BubblesEnabled = settings.BubblesEnabled,
                 BubblesFrequency = settings.BubblesFrequency,
+                BubbleTriggersEnabled = settings.BubbleTriggersEnabled,
+                BubbleTriggerChance = settings.BubbleTriggerChance,
+                BubbleSpeedBoost = settings.BubbleSpeedBoost,
+                BubbleTriggerVariants = settings.BubbleTriggerVariants != null ? new List<string>(settings.BubbleTriggerVariants) : new List<string>(),
+                BubbleAvatarEggEnabled = settings.BubbleAvatarEggEnabled,
 
                 // Lock Card
                 LockCardEnabled = settings.LockCardEnabled,

--- a/ConditioningControlPanel/Services/Quiz/QuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/QuizService.cs
@@ -288,14 +288,19 @@ namespace ConditioningControlPanel.Services
             char answerLetter = (char)('A' + answerIndex);
 
             string userMsg;
-            if (_currentCategory == QuizCategory.Sissy)
+            // Custom categories (EnumCategory == null) must never fall into the hardcoded
+            // Sissy/Bambi archetype branches — StartQuizAsync collapses their enum to Sissy
+            // for internal bookkeeping, so gate the built-in branches on the definition being
+            // an actual built-in. Otherwise a custom category emits "Sissy Princess" etc. (#501).
+            bool isCustomCategory = _currentCategoryDefinition != null && _currentCategoryDefinition.EnumCategory == null;
+            if (!isCustomCategory && _currentCategory == QuizCategory.Sissy)
             {
                 userMsg = $"I chose {answerLetter} ({points} pts). Final score: {_totalScore}/{MaxPossibleScore}. " +
                     "Quiz over. Based on my score and specific answers, generate my personality profile. " +
                     "Assign one of these archetypes: Curious Newcomer (0-25%), Closet Sissy (26-50%), Sissy in Training (51-70%), Sissy Princess (71-85%), Full Sissy (86-100%). " +
                     "Start with \"You are a [ARCHETYPE].\" then write 2-3 sentences about my specific personality based on which answers I gravitated toward. Be validating, playful, and make me feel seen. End with a teasing one-liner.";
             }
-            else if (_currentCategory == QuizCategory.Bambi)
+            else if (!isCustomCategory && _currentCategory == QuizCategory.Bambi)
             {
                 userMsg = $"I chose {answerLetter} ({points} pts). Final score: {_totalScore}/{MaxPossibleScore}. " +
                     "Quiz over. Based on my score and specific answers, generate my personality profile. " +

--- a/ConditioningControlPanel/Services/Speech/SpeechService.cs
+++ b/ConditioningControlPanel/Services/Speech/SpeechService.cs
@@ -608,23 +608,34 @@ namespace ConditioningControlPanel.Services.Speech
             var a = target.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var b = heard.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (a.Length == 0) return b.Length == 0 ? 1 : 0;
+            // Costs are scaled x2 so an "[unk]" substitution can cost half a word (see
+            // WordEditDistance). Denominator scales to match, keeping the ratio identical
+            // to the old integer distance for phrases with no unknown words.
             int dist = WordEditDistance(a, b);
-            double wordSim = 1.0 - (double)dist / Math.Max(a.Length, b.Length);
+            double wordSim = 1.0 - (double)dist / (2.0 * Math.Max(a.Length, b.Length));
             return Math.Clamp(wordSim, 0, 1);
         }
 
         private static int WordEditDistance(string[] a, string[] b)
         {
+            // All costs scaled x2: match=0, real substitution/indel=2. A heard "[unk]"
+            // token (Vosk's out-of-vocabulary marker, normalized to "unk") substitutes for
+            // any target word at HALF cost (1). This forgives kink/OOV words like "cockslut"
+            // or "gooning" that the small model can't recognize, without letting a fully
+            // mumbled all-"unk" transcript pass the match threshold (#505).
             var prev = new int[b.Length + 1];
             var cur = new int[b.Length + 1];
-            for (int j = 0; j <= b.Length; j++) prev[j] = j;
+            for (int j = 0; j <= b.Length; j++) prev[j] = j * 2;
             for (int i = 1; i <= a.Length; i++)
             {
-                cur[0] = i;
+                cur[0] = i * 2;
                 for (int j = 1; j <= b.Length; j++)
                 {
-                    int cost = a[i - 1] == b[j - 1] ? 0 : 1;
-                    cur[j] = Math.Min(Math.Min(prev[j] + 1, cur[j - 1] + 1), prev[j - 1] + cost);
+                    int cost;
+                    if (a[i - 1] == b[j - 1]) cost = 0;
+                    else if (b[j - 1] == "unk") cost = 1;   // out-of-vocab word heard: half penalty
+                    else cost = 2;
+                    cur[j] = Math.Min(Math.Min(prev[j] + 2, cur[j - 1] + 2), prev[j - 1] + cost);
                 }
                 (prev, cur) = (cur, prev);
             }


### PR DESCRIPTION
Low-risk batch fixing four v6.2.11 bug reports. Build clean (0 errors). Not yet play-tested.

## Fixes

### #501 - Custom quiz category emits hardcoded "Sissy Princess" archetypes
`QuizService.StartQuizAsync(def)` collapses a custom category's `EnumCategory == null` to `QuizCategory.Sissy` for internal bookkeeping, so the result-prompt dispatch in `SubmitFinalAnswerAndGetResultAsync` hit the hardcoded Sissy branch and ignored the user's archetype table. Now the built-in Sissy/Bambi branches are gated on `isCustomCategory` being false, so custom categories fall through to the dynamic-archetype branch that reads `_currentCategoryDefinition.Archetypes`.

### #505 - Voice lock cards choke on out-of-vocabulary words ("cockslut", "gooning")
The Vosk small model can't pronounce these words, so it emits `[unk]` (normalized to `"unk"`). Each `[unk]` counted as a full-word substitution; two or more dropped the fuzzy match score below the 0.62 threshold, looping "try again, slower".

Fix scales `WordEditDistance` costs x2 (match=0, real sub/indel=2) and charges an `[unk]` substitution **half a word** (1). Deliberately half-cost rather than a free wildcard, so a fully-mumbled all-`[unk]` transcript still fails the threshold and can't bypass a lock card. The similarity denominator scales x2 to match, so ratios are **identical** to the old behaviour for any phrase with no unknown words.

### #502 / #503 - Trigger ("special") bubbles do nothing / not saved to presets
`Models/Preset.cs` only carried `BubblesEnabled` + `BubblesFrequency`. It dropped every trigger-bubble property, so saving/loading a preset silently reset `BubbleTriggersEnabled` (which defaults **off**) - making the feature appear inert (#502 is a symptom of #503). Added `BubbleTriggersEnabled`, `BubbleTriggerChance`, `BubbleSpeedBoost`, `BubbleTriggerVariants` (deep-copied list), and `BubbleAvatarEggEnabled` to the class body, `ApplyTo`, and `FromSettings`.

## Not included (from same triage, larger scope)
- #499 update-restart no-op (needs external updater helper)
- #506 / #508 overlay z-order family
- #504 multi-monitor Deeper video loop
- #507 always-listening voice commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8K3fDYUsmV96sJszQgW3e