### PR TITLE
fix(dtrh): smooth tube lines at low fall speed (screen-space AA)

### DIFF
--- a/ConditioningControlPanel/Resources/web/dtrh/engine/junctions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/junctions.js
@@ -79,7 +79,8 @@ const VEIN_FRAG = `
 
   float lineMask(float coord, float w) {
     float di = 0.5 - abs(fract(coord) - 0.5);
-    return 1.0 - smoothstep(0.0, w, di);
+    float aa = max(w, 1.5 * fwidth(coord)); // screen-space AA: no sub-pixel line crawl when the fall hovers at a fork
+    return 1.0 - smoothstep(0.0, aa, di);
   }
 
   void main() {
@@ -239,6 +240,7 @@ export function createJunctions({ scene, layout, nav, tunnel, spawner }) {
       transparent: true,
       side: THREE.DoubleSide,
       depthWrite: false,
+      extensions: { derivatives: true }, // fwidth() line AA (core on WebGL2)
     });
     const tube = new THREE.Mesh(tubeGeo, mat);
     scene.add(tube);

--- a/ConditioningControlPanel/Resources/web/dtrh/engine/junctions.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/junctions.js
@@ -79,7 +79,7 @@ const VEIN_FRAG = `
 
   float lineMask(float coord, float w) {
     float di = 0.5 - abs(fract(coord) - 0.5);
-    float aa = max(w, 1.5 * fwidth(coord)); // screen-space AA: no sub-pixel line crawl when the fall hovers at a fork
+    float aa = clamp(1.5 * fwidth(coord), w, 0.5); // screen-space AA (clamped so grazing rings don't wash out): no sub-pixel crawl when the fall hovers at a fork
     return 1.0 - smoothstep(0.0, aa, di);
   }
 

--- a/ConditioningControlPanel/Resources/web/dtrh/engine/tunnel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/tunnel.js
@@ -117,7 +117,10 @@ const TUBE_FRAG = `
   // hairline line snaps pixel-to-pixel. Screen-space AA keeps slow motion fluid.
   float lineMask(float coord, float w) {
     float di = 0.5 - abs(fract(coord) - 0.5); // distance to nearest integer
-    float aa = max(w, 1.5 * fwidth(coord));   // never sharper than a soft pixel
+    // never sharper than the designed width, never so wide the line stops fully
+    // darkening at the midpoint (di maxes at 0.5) - that upper clamp keeps rings
+    // crisp instead of washing to a bright fill at grazing/foreshortened angles.
+    float aa = clamp(1.5 * fwidth(coord), w, 0.5);
     return 1.0 - smoothstep(0.0, aa, di);
   }
   // sharp periodic pulse (mostly dark, brief bright peaks = intermittent).

--- a/ConditioningControlPanel/Resources/web/dtrh/engine/tunnel.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/engine/tunnel.js
@@ -109,10 +109,16 @@ const TUBE_FRAG = `
   uniform int uCutOn;
   uniform float uCutLo, uCutHi;   // arc-length window [0..1]; if hi<lo the window wraps the seam
 
-  // 1.0 on the line (integer coord), fading to 0 within half-width w.
+  // 1.0 on the line (integer coord), fading to 0 within half-width w. The edge
+  // is widened to at least ~1.5 screen pixels (fwidth) so a far-off or grazing
+  // (tube-wall side, seen near edge-on) line is never sub-pixel-thin. That
+  // sub-pixel thinness is what makes the rings appear to "skip"/step when the
+  // fall is slow - at speed the per-frame motion hides it, but crawling slowly a
+  // hairline line snaps pixel-to-pixel. Screen-space AA keeps slow motion fluid.
   float lineMask(float coord, float w) {
     float di = 0.5 - abs(fract(coord) - 0.5); // distance to nearest integer
-    return 1.0 - smoothstep(0.0, w, di);
+    float aa = max(w, 1.5 * fwidth(coord));   // never sharper than a soft pixel
+    return 1.0 - smoothstep(0.0, aa, di);
   }
   // sharp periodic pulse (mostly dark, brief bright peaks = intermittent).
   float pulse(float p, float k) { return pow(0.5 + 0.5 * sin(p), k); }
@@ -222,6 +228,7 @@ export function createTunnel(layout) {
     vertexShader: TUBE_VERT,
     fragmentShader: TUBE_FRAG,
     side: THREE.BackSide,
+    extensions: { derivatives: true }, // fwidth() line AA (core on WebGL2; flag is a WebGL1 safety net)
   });
   let geoRef = geo;
   const mesh = new THREE.Mesh(geo, mat);


### PR DESCRIPTION
## What
The DtRH tube appeared to **skip / step frames whenever the fall slowed** — the intro/calm start, holding a card, pendulum slow-mo, freeze, and junction hover. Framerate was fine the whole time.

## Why
The camera fall (`depth += speed*dt`) and the wall ring/spiral scroll (`tunnelTime += dt*(0.5+speed/12)`) are both continuous, so pure slow speed can't drop frames. The real cause is a rendering artifact: `lineMask` antialiased the lines with a **fixed width in UV space**. Far-off lines — and especially the **grazing-angle tube walls off to the sides** — end up thinner than one screen pixel, so a slowly-crawling line can only snap pixel-to-pixel. At speed the per-frame motion hides it; slow, it reads as juddery "frame skipping."

## Fix
Screen-space antialiasing via derivatives, so line edges stay ~1.5px soft at every distance and angle:

```glsl
float aa = max(w, 1.5 * fwidth(coord));   // never sharper than a soft pixel
return 1.0 - smoothstep(0.0, aa, di);
```

- `engine/tunnel.js` — main tube rings/spiral/streak
- `engine/junctions.js` — fork/vein rings (junction hover is one of the slow cases)
- `extensions: { derivatives: true }` on both materials — core on WebGL2 (guaranteed in WebView2/Chromium), a safety net for WebGL1.

`max(w, …)` preserves the original crispness up close and only softens where lines would otherwise go sub-pixel.

## Test
- `node --check` passes on both files (GLSL only compiles at runtime).
- ⚠️ **Not yet play-tested** — please verify in a live run at a slow tube state (intro, hold a card, freeze, junction). If any residual shimmer remains it'll be the softer `pulse()` glow terms, which are separate from `lineMask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)