### PR TITLE
fix(6.2.11): quiz + voice + trigger-bubble bugs and #499 update-restart helper

### DIFF
--- a/ConditioningControlPanel/Models/Preset.cs
+++ b/ConditioningControlPanel/Models/Preset.cs
@@ -100,6 +100,13 @@ namespace ConditioningControlPanel.Models
         public bool BubblesEnabled { get; set; } = false;
         public int BubblesFrequency { get; set; } = 5;
 
+        // Trigger Bubbles (ambient bubbles that fire a Chaos effect on pop)
+        public bool BubbleTriggersEnabled { get; set; } = false;
+        public int BubbleTriggerChance { get; set; } = 10;
+        public int BubbleSpeedBoost { get; set; } = 0;
+        public List<string> BubbleTriggerVariants { get; set; } = new() { "flash", "subliminal", "pink", "spiral", "glitch", "htlink", "video" };
+        public bool BubbleAvatarEggEnabled { get; set; } = true;
+
         // Lock Card Settings (Level 35+)
         public bool LockCardEnabled { get; set; } = false;
         public int LockCardFrequency { get; set; } = 2;
@@ -360,6 +367,11 @@ namespace ConditioningControlPanel.Models
             // Bubbles
             settings.BubblesEnabled = BubblesEnabled;
             settings.BubblesFrequency = BubblesFrequency;
+            settings.BubbleTriggersEnabled = BubbleTriggersEnabled;
+            settings.BubbleTriggerChance = BubbleTriggerChance;
+            settings.BubbleSpeedBoost = BubbleSpeedBoost;
+            settings.BubbleTriggerVariants = BubbleTriggerVariants != null ? new List<string>(BubbleTriggerVariants) : new List<string>();
+            settings.BubbleAvatarEggEnabled = BubbleAvatarEggEnabled;
 
             // Lock Card
             settings.LockCardEnabled = LockCardEnabled;
@@ -461,6 +473,11 @@ namespace ConditioningControlPanel.Models
                 // Bubbles
                 BubblesEnabled = settings.BubblesEnabled,
                 BubblesFrequency = settings.BubblesFrequency,
+                BubbleTriggersEnabled = settings.BubbleTriggersEnabled,
+                BubbleTriggerChance = settings.BubbleTriggerChance,
+                BubbleSpeedBoost = settings.BubbleSpeedBoost,
+                BubbleTriggerVariants = settings.BubbleTriggerVariants != null ? new List<string>(settings.BubbleTriggerVariants) : new List<string>(),
+                BubbleAvatarEggEnabled = settings.BubbleAvatarEggEnabled,
 
                 // Lock Card
                 LockCardEnabled = settings.LockCardEnabled,

--- a/ConditioningControlPanel/Services/Quiz/QuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/QuizService.cs
@@ -288,14 +288,19 @@ namespace ConditioningControlPanel.Services
             char answerLetter = (char)('A' + answerIndex);
 
             string userMsg;
-            if (_currentCategory == QuizCategory.Sissy)
+            // Custom categories (EnumCategory == null) must never fall into the hardcoded
+            // Sissy/Bambi archetype branches — StartQuizAsync collapses their enum to Sissy
+            // for internal bookkeeping, so gate the built-in branches on the definition being
+            // an actual built-in. Otherwise a custom category emits "Sissy Princess" etc. (#501).
+            bool isCustomCategory = _currentCategoryDefinition != null && _currentCategoryDefinition.EnumCategory == null;
+            if (!isCustomCategory && _currentCategory == QuizCategory.Sissy)
             {
                 userMsg = $"I chose {answerLetter} ({points} pts). Final score: {_totalScore}/{MaxPossibleScore}. " +
                     "Quiz over. Based on my score and specific answers, generate my personality profile. " +
                     "Assign one of these archetypes: Curious Newcomer (0-25%), Closet Sissy (26-50%), Sissy in Training (51-70%), Sissy Princess (71-85%), Full Sissy (86-100%). " +
                     "Start with \"You are a [ARCHETYPE].\" then write 2-3 sentences about my specific personality based on which answers I gravitated toward. Be validating, playful, and make me feel seen. End with a teasing one-liner.";
             }
-            else if (_currentCategory == QuizCategory.Bambi)
+            else if (!isCustomCategory && _currentCategory == QuizCategory.Bambi)
             {
                 userMsg = $"I chose {answerLetter} ({points} pts). Final score: {_totalScore}/{MaxPossibleScore}. " +
                     "Quiz over. Based on my score and specific answers, generate my personality profile. " +

--- a/ConditioningControlPanel/Services/Speech/SpeechService.cs
+++ b/ConditioningControlPanel/Services/Speech/SpeechService.cs
@@ -608,23 +608,34 @@ namespace ConditioningControlPanel.Services.Speech
             var a = target.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var b = heard.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (a.Length == 0) return b.Length == 0 ? 1 : 0;
+            // Costs are scaled x2 so an "[unk]" substitution can cost half a word (see
+            // WordEditDistance). Denominator scales to match, keeping the ratio identical
+            // to the old integer distance for phrases with no unknown words.
             int dist = WordEditDistance(a, b);
-            double wordSim = 1.0 - (double)dist / Math.Max(a.Length, b.Length);
+            double wordSim = 1.0 - (double)dist / (2.0 * Math.Max(a.Length, b.Length));
             return Math.Clamp(wordSim, 0, 1);
         }
 
         private static int WordEditDistance(string[] a, string[] b)
         {
+            // All costs scaled x2: match=0, real substitution/indel=2. A heard "[unk]"
+            // token (Vosk's out-of-vocabulary marker, normalized to "unk") substitutes for
+            // any target word at HALF cost (1). This forgives kink/OOV words like "cockslut"
+            // or "gooning" that the small model can't recognize, without letting a fully
+            // mumbled all-"unk" transcript pass the match threshold (#505).
             var prev = new int[b.Length + 1];
             var cur = new int[b.Length + 1];
-            for (int j = 0; j <= b.Length; j++) prev[j] = j;
+            for (int j = 0; j <= b.Length; j++) prev[j] = j * 2;
             for (int i = 1; i <= a.Length; i++)
             {
-                cur[0] = i;
+                cur[0] = i * 2;
                 for (int j = 1; j <= b.Length; j++)
                 {
-                    int cost = a[i - 1] == b[j - 1] ? 0 : 1;
-                    cur[j] = Math.Min(Math.Min(prev[j] + 1, cur[j - 1] + 1), prev[j - 1] + cost);
+                    int cost;
+                    if (a[i - 1] == b[j - 1]) cost = 0;
+                    else if (b[j - 1] == "unk") cost = 1;   // out-of-vocab word heard: half penalty
+                    else cost = 2;
+                    cur[j] = Math.Min(Math.Min(prev[j] + 2, cur[j - 1] + 2), prev[j - 1] + cost);
                 }
                 (prev, cur) = (cur, prev);
             }

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -547,35 +547,106 @@ Season: Jelly July";
             // Small delay to ensure processes are terminated
             System.Threading.Thread.Sleep(500);
 
-            // Build Inno Setup silent install arguments
-            // /SILENT = Show progress dialog but no user interaction required
-            // /SUPPRESSMSGBOXES = Don't show any message boxes
-            // /NORESTART = Don't restart after install (we'll handle that)
-            // /DIR="path" = Install to specific directory
-            // /CLOSEAPPLICATIONS = Close running apps that use files being updated
-            // /RESTARTAPPLICATIONS = Restart closed applications after install
-            var installerArgs = $"/SILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS";
+            // Launching the installer directly and immediately calling Shutdown() is a race:
+            // this app is a single-file self-contained exe, so it holds an exclusive lock on
+            // its own .exe until the process fully exits. The installer's file-copy phase can
+            // reach the locked exe before we're gone, and with /SUPPRESSMSGBOXES that failure
+            // is silent — the app just vanishes on the old version (#499, BUG-DYRJU5AUDM).
+            //
+            // Instead, hand off to a tiny external batch helper that: (1) waits for THIS
+            // process to fully exit (lock released), (2) runs the installer silently and waits
+            // for it, (3) relaunches the app deterministically — never depending on Inno's
+            // /RESTARTAPPLICATIONS (which needs RegisterApplicationRestart, which we never call).
+            // Every step is logged so a failure is diagnosable instead of invisible.
+            var pid = Process.GetCurrentProcess().Id;
 
-            if (!string.IsNullOrEmpty(installPath))
-            {
-                installerArgs += $" /DIR=\"{installPath}\"";
-            }
+            // The freshly-installed exe lands back in the install dir under its known name.
+            var appExe = !string.IsNullOrEmpty(installPath)
+                ? Path.Combine(installPath, "ConditioningControlPanel.exe")
+                : (Process.GetCurrentProcess().MainModule?.FileName ?? "");
 
-            App.Logger?.Information("Installer arguments: {Args}", installerArgs);
+            var logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ConditioningControlPanel", "logs", "update-helper.log");
 
-            // Start the installer directly - Inno Setup handles closing/restarting the app
+            var helperPath = WriteUpdateHelperScript(installerPath, installPath, pid, appExe, logPath);
+
+            App.Logger?.Information("Launching update helper: {Helper} (pid={Pid}, appExe={AppExe}, log={Log})",
+                helperPath, pid, appExe, logPath);
+
+            // Run the .cmd via cmd.exe (a batch file is not a PE, so UseShellExecute=false
+            // requires an explicit interpreter). CreateNoWindow keeps it fully hidden; the
+            // helper survives our exit because a WPF app doesn't job-object its children.
             var startInfo = new ProcessStartInfo
             {
-                FileName = installerPath,
-                Arguments = installerArgs,
-                UseShellExecute = true,
+                FileName = "cmd.exe",
+                Arguments = $"/c \"{helperPath}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
             };
 
             Process.Start(startInfo);
 
-            // Exit the current application
-            App.Logger?.Information("Exiting application for silent update...");
+            // Exit the current application so the helper's wait-for-exit can proceed.
+            App.Logger?.Information("Exiting application for silent update (helper will install + relaunch)...");
             Application.Current.Shutdown();
+        }
+
+        /// <summary>
+        /// Writes the external update helper batch script and returns its path. The script waits
+        /// for this process (pid) to exit, runs the installer silently, then relaunches appExe.
+        /// Values are baked in as literals (no positional-arg parsing) so paths with spaces are safe.
+        /// </summary>
+        private static string WriteUpdateHelperScript(string installerPath, string? installPath, int pid, string appExe, string logPath)
+        {
+            var helperDir = Path.GetDirectoryName(installerPath) ?? Path.GetTempPath();
+            var helperPath = Path.Combine(helperDir, "update-helper.cmd");
+
+            // Ensure the log directory exists — the first `echo > "%LOG%"` fails otherwise.
+            try { Directory.CreateDirectory(Path.GetDirectoryName(logPath)!); } catch { }
+
+            // For an in-place upgrade Inno remembers the prior dir; passing /DIR keeps it explicit
+            // and guarantees the new files land where we'll relaunch from.
+            var dirArg = string.IsNullOrEmpty(installPath) ? "" : $" /DIR=\"{installPath}\"";
+
+            var lines = new[]
+            {
+                "@echo off",
+                "setlocal enableextensions",
+                $"set \"LOG={logPath}\"",
+                $"set \"APPEXE={appExe}\"",
+                $"set \"INSTALLER={installerPath}\"",
+                $"echo [update-helper] start pid={pid} > \"%LOG%\"",
+                // Wait for the old app to fully exit (release its exe lock). The PID filter is
+                // exact; `find` just detects whether a matching row was returned. Capped at ~30
+                // iterations (~1min) so a reused PID can never hang this forever.
+                "set /a tries=0",
+                ":waitloop",
+                $"tasklist /FI \"PID eq {pid}\" /NH 2>nul | find \"{pid}\" >nul",
+                "if errorlevel 1 goto gone",
+                "set /a tries+=1",
+                "if %tries% GEQ 30 (",
+                "  echo [update-helper] wait timed out, proceeding anyway >> \"%LOG%\"",
+                "  goto gone",
+                ")",
+                "ping 127.0.0.1 -n 2 >nul",
+                "goto waitloop",
+                ":gone",
+                "echo [update-helper] old app exited (tries=%tries%), running installer >> \"%LOG%\"",
+                $"\"%INSTALLER%\" /SILENT /SUPPRESSMSGBOXES /NORESTART{dirArg}",
+                "set RC=%errorlevel%",
+                "echo [update-helper] installer exit=%RC% >> \"%LOG%\"",
+                "echo [update-helper] relaunching app >> \"%LOG%\"",
+                "start \"\" \"%APPEXE%\"",
+                "echo [update-helper] done >> \"%LOG%\"",
+                "endlocal",
+            };
+
+            var script = string.Join("\r\n", lines) + "\r\n";
+            // UTF-8 without BOM — a BOM can break batch parsing of the first line.
+            File.WriteAllText(helperPath, script, new System.Text.UTF8Encoding(false));
+            return helperPath;
         }
 
         /// <summary>

--- a/installer.iss
+++ b/installer.iss
@@ -69,6 +69,14 @@ WizardSizePercent=120
 UninstallDisplayIcon={app}\{#MyAppExeName}
 UninstallDisplayName={#MyAppName}
 
+; Restart Manager: name the app's real single-instance mutex (App.xaml.cs MutexName) so
+; Inno can detect the running app and cleanly close+restart it when files are in use during
+; a silent auto-update. Without this, /CLOSEAPPLICATIONS has nothing registered to close and
+; the in-app updater could race the still-locked exe (#499).
+AppMutex=ConditioningControlPanel_SingleInstance_Mutex
+CloseApplications=yes
+RestartApplications=yes
+
 ; Other settings
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
@@ -177,8 +185,10 @@ Filename: "{tmp}\VC_redist.x64.exe"; Parameters: "/install /quiet /norestart"; S
 
 ; Option to launch app after interactive installation (shows checkbox)
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
-; Always launch app after silent installation (auto-updates)
-Filename: "{app}\{#MyAppExeName}"; Flags: nowait postinstall skipifnotsilent
+; NOTE: No silent-install self-launch here. The in-app updater's external helper
+; (UpdateService.WriteUpdateHelperScript) owns the relaunch after a silent auto-update, so a
+; second launch here would double-start the app. (The single-instance handshake would dedup
+; it, but we keep exactly one relauncher to avoid a stray window flash.)
 
 [UninstallRun]
 ; Ensure app is closed before uninstall
@@ -484,8 +494,10 @@ begin
   // Detect existing assets
   DetectExistingAssets();
 
-  // Check if already running
-  if CheckForMutexes('{#MyAppName}_Mutex') then
+  // Check if already running. Use the app's REAL single-instance mutex name
+  // (App.xaml.cs MutexName) — the old '{#MyAppName}_Mutex' string never matched, so this
+  // guard was dead and never detected a running app (#499).
+  if CheckForMutexes('ConditioningControlPanel_SingleInstance_Mutex') then
   begin
     if MsgBox('{#MyAppName} is currently running.' + #13#10 + #13#10 +
               'Please close it before continuing installation.' + #13#10 + #13#10 +


### PR DESCRIPTION
Two independent bugfix clusters for the 6.2.11 line, carried in the working tree and now committed off post-#69 `main`.

## 51d6b35f - 6.2.11 green batch
- **#501** quiz custom category emitted "Sissy Princess": gate the hardcoded Sissy/Bambi archetype prompts on the category being a real built-in, so custom categories reach the dynamic-archetype branch.
- **#505** voice lock cards failed on out-of-vocab words ("cockslut", "gooning"): scale word-edit-distance x2 and give Vosk's `unk` token half-cost - forgives kink/OOV words without letting an all-mumble transcript pass.
- **#502/#503** trigger bubbles inert + not saved: persist the 5 Trigger-Bubble fields to presets (save/load) so they stop resetting.

## e48dadba - #499 update-restart never lands
The single-file self-contained exe locks its own `.exe` until the process fully exits, so launching the silent installer then immediately calling `Shutdown()` raced the still-locked exe - and `/SUPPRESSMSGBOXES` made the failure silent (app just vanished on the old version).
- **UpdateService**: hand off to an external `update-helper.cmd` that waits for this PID to exit, runs the installer silently, then deterministically relaunches - every step logged to `update-helper.log`.
- **installer.iss**: set `AppMutex` + `CloseApplications`/`RestartApplications` to the app's REAL single-instance mutex name (the old `{#MyAppName}_Mutex` guard never matched, so it was dead); drop the silent-install self-launch so the helper is the sole relauncher.

## Verification
- `dotnet build` - succeeded, 0 errors.
- **Not** yet play-tested: the voice/quiz/preset paths, and critically **#499 still needs a signed end-to-end upgrade test** (the self-lock race only bites intermittently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)