### PR TITLE
feat(compositor): unified overlay host - default ON, review batch, 6.3.4 history

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -292,6 +292,13 @@ namespace ConditioningControlPanel
         /// <summary>Launch-scoped override: `--overlay-host` forces the unified overlay host ON
         /// without persisting the setting (A/B testing seam).</summary>
         public static bool CompositorForced { get; private set; }
+        /// <summary>Launch-scoped override: `--overlay-ulw` forces the off-thread (UpdateLayeredWindow)
+        /// present path ON for this launch only, so #550's proper fix can be A/B tested without
+        /// persisting the setting. Implies <see cref="CompositorForced"/>.</summary>
+        public static bool CompositorOffThreadForced { get; private set; }
+        /// <summary>Effective off-thread-present decision: the persisted setting OR the launch flag.</summary>
+        public static bool CompositorOffThreadPresent =>
+            CompositorOffThreadForced || Settings?.Current?.CompositorOffThreadPresent == true;
         public static OverlayService Overlay { get; private set; } = null!;
         public static ScreenShakeService ScreenShake { get; private set; } = null!;
         public static BubbleService Bubbles { get; private set; } = null!;
@@ -1677,6 +1684,15 @@ namespace ConditioningControlPanel
             {
                 CompositorForced = true;
                 Logger?.Information("Unified overlay host FORCED ON via --overlay-host (this launch only)");
+            }
+
+            // `--overlay-ulw`: force the off-thread UpdateLayeredWindow present path ON (implies the
+            // unified host) for this launch only, to A/B test the #550 proper fix.
+            if (e.Args.Contains("--overlay-ulw"))
+            {
+                CompositorForced = true;
+                CompositorOffThreadForced = true;
+                Logger?.Information("Compositor OFF-THREAD present FORCED ON via --overlay-ulw (this launch only)");
             }
 
             // Pay the compositor's one-time host costs (window + hwnd + Skia surface + paint JIT)

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -288,6 +288,7 @@ namespace ConditioningControlPanel
         public static SessionLogService SessionLog { get; private set; } = null!;
         public static ProgressionService Progression { get; private set; } = null!;
         public static SubliminalService Subliminal { get; private set; } = null!;
+        public static Services.Compositor.CompositorEngine? Compositor { get; private set; }
         public static OverlayService Overlay { get; private set; } = null!;
         public static ScreenShakeService ScreenShake { get; private set; } = null!;
         public static BubbleService Bubbles { get; private set; } = null!;
@@ -1365,6 +1366,10 @@ namespace ConditioningControlPanel
             Personality.MigrateFromLegacy(Settings.Current);
 
             Subliminal = new SubliminalService();
+            // Unified overlay host (experimental, Settings.UnifiedOverlayHost): shared per-monitor
+            // Skia surface the effect services route to instead of per-effect windows. Inert (no
+            // windows, no render tick) until a layer activates, so constructing it always is free.
+            Compositor = new Services.Compositor.CompositorEngine();
             Overlay = new OverlayService();
             ScreenShake = new ScreenShakeService();
             Bubbles = new BubbleService();
@@ -3176,6 +3181,7 @@ Application State:
             Video?.Dispose();
             Subliminal?.Dispose();
             Overlay?.Dispose();
+            Compositor?.Dispose(); // after effect services so their layers deactivate first
             ScreenShake?.Dispose();
             try { Chaos?.ForceShutdown(); } catch { }
             Bubbles?.Dispose();

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -289,6 +289,9 @@ namespace ConditioningControlPanel
         public static ProgressionService Progression { get; private set; } = null!;
         public static SubliminalService Subliminal { get; private set; } = null!;
         public static Services.Compositor.CompositorEngine? Compositor { get; private set; }
+        /// <summary>Launch-scoped override: `--overlay-host` forces the unified overlay host ON
+        /// without persisting the setting (A/B testing seam).</summary>
+        public static bool CompositorForced { get; private set; }
         public static OverlayService Overlay { get; private set; } = null!;
         public static ScreenShakeService ScreenShake { get; private set; } = null!;
         public static BubbleService Bubbles { get; private set; } = null!;
@@ -1667,6 +1670,14 @@ namespace ConditioningControlPanel
             // via env vars so the harness can dial it without a rebuild.
             if (e.Args.Contains("--stress"))
                 StartHangStressMode();
+
+            // `--overlay-host`: force the unified overlay host ON for this launch only (in-memory,
+            // not persisted) so the compositor path can be A/B tested without editing settings.
+            if (e.Args.Contains("--overlay-host"))
+            {
+                CompositorForced = true;
+                Logger?.Information("Unified overlay host FORCED ON via --overlay-host (this launch only)");
+            }
 
             // DtRH browser-game port, M0 spike (`--dtrh-spike`): verifies the WebView2 virtual-host
             // pipeline (Range-seek, CORS->WebGL, payload z-order/focus) against the user's real

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1143,6 +1143,7 @@ namespace ConditioningControlPanel
             // in crash.log — but the chaos sentinel file is still on disk. Report+consume it so the
             // crash self-documents (with last-known context) in this session's log.
             Services.Chaos.ChaosCrashSentinel.ConsumeAndReport(Logger);
+            Services.EngineCrashSentinel.ConsumeAndReport(Logger);
 
             // React to monitor topology / resolution changes (unplug, res change, DPI): drop the stale
             // screen cache AND pause layered-window spawns briefly so we don't create fresh surfaces
@@ -3106,15 +3107,21 @@ Application State:
             }
         }
 
+        [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+        private static extern IntPtr GetCurrentProcess();
+        [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
         protected override void OnExit(ExitEventArgs e)
         {
             Logger?.Information("Application shutting down...");
 
             try { SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch { }
 
-            // A clean shutdown — even mid-run — is NOT a crash. Clear the chaos sentinel so the next
-            // launch doesn't false-report it as an abnormal exit.
+            // A clean shutdown — even mid-run — is NOT a crash. Clear both dirty-shutdown
+            // sentinels so the next launch doesn't false-report an abnormal exit.
             try { Services.Chaos.ChaosCrashSentinel.Clear(); } catch { }
+            try { Services.EngineCrashSentinel.Clear(); } catch { }
 
             // DtRH browser game: dispose the WebView2 window/process if it's up.
             try { Services.Chaos.DtrhHostService.CloseActive(); } catch { }
@@ -3259,8 +3266,17 @@ Application State:
 
             base.OnExit(e);
 
-            // Force exit to ensure no background threads keep process alive
-            Environment.Exit(0);
+            // Force exit so no background threads keep the process alive — but NOT via
+            // Environment.Exit: that still raises AppDomain.ProcessExit, where WPF's own
+            // C++/CLI DirectWriteForwarder module uninitializer JITs its CRT-teardown stubs
+            // on a half-shut-down runtime and throws DllNotFoundException on another thread
+            // (0xe0434352 — WER dumps 5/28-6/28 all show <CrtImplementationDetails>.
+            // ModuleUninitializer.SingletonDomainUnload with the main thread parked in
+            // OnExit; users saw it as "crash on close"). Everything that must persist is
+            // already flushed above (SaveImmediate, CloseAndFlush), so hard-terminate:
+            // TerminateProcess skips ProcessExit handlers and finalizers entirely.
+            TerminateProcess(GetCurrentProcess(), 0);
+            Environment.Exit(0);   // unreachable fallback if TerminateProcess is refused
         }
     }
 }

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -299,6 +299,13 @@ namespace ConditioningControlPanel
         /// <summary>Effective off-thread-present decision: the persisted setting OR the launch flag.</summary>
         public static bool CompositorOffThreadPresent =>
             CompositorOffThreadForced || Settings?.Current?.CompositorOffThreadPresent == true;
+        /// <summary>THE compositor routing gate — the single source of truth every render-path
+        /// fork must use ("do effects go to the unified overlay host or the legacy per-effect
+        /// windows?"). Effective decision: the persisted toggle OR the launch flag, AND the
+        /// engine actually exists. Never inline this predicate at a call site: a per-service
+        /// copy that drifts leaves that feature split-brained on the wrong render path.</summary>
+        public static bool CompositorEnabled =>
+            (CompositorForced || Settings?.Current?.UnifiedOverlayHost == true) && Compositor != null;
         public static OverlayService Overlay { get; private set; } = null!;
         public static ScreenShakeService ScreenShake { get; private set; } = null!;
         public static BubbleService Bubbles { get; private set; } = null!;
@@ -1376,7 +1383,7 @@ namespace ConditioningControlPanel
             Personality.MigrateFromLegacy(Settings.Current);
 
             Subliminal = new SubliminalService();
-            // Unified overlay host (experimental, Settings.UnifiedOverlayHost): shared per-monitor
+            // Unified overlay host (default ON, Settings.UnifiedOverlayHost): shared per-monitor
             // Skia surface the effect services route to instead of per-effect windows. Inert (no
             // windows, no render tick) until a layer activates, so constructing it always is free.
             Compositor = new Services.Compositor.CompositorEngine();
@@ -1698,7 +1705,7 @@ namespace ConditioningControlPanel
             // Pay the compositor's one-time host costs (window + hwnd + Skia surface + paint JIT)
             // after startup settles instead of on the first effect trigger ("first load" hitch).
             // Deferred to Background priority so launch isn't slowed.
-            if (CompositorForced || Settings?.Current?.UnifiedOverlayHost == true)
+            if (CompositorEnabled)
             {
                 Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background,
                     () => Compositor?.Prewarm());

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1679,6 +1679,15 @@ namespace ConditioningControlPanel
                 Logger?.Information("Unified overlay host FORCED ON via --overlay-host (this launch only)");
             }
 
+            // Pay the compositor's one-time host costs (window + hwnd + Skia surface + paint JIT)
+            // after startup settles instead of on the first effect trigger ("first load" hitch).
+            // Deferred to Background priority so launch isn't slowed.
+            if (CompositorForced || Settings?.Current?.UnifiedOverlayHost == true)
+            {
+                Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background,
+                    () => Compositor?.Prewarm());
+            }
+
             // DtRH browser-game port, M0 spike (`--dtrh-spike`): verifies the WebView2 virtual-host
             // pipeline (Range-seek, CORS->WebGL, payload z-order/focus) against the user's real
             // assets folder, writes logs/dtrh-spike.json, then shuts the app down. Throwaway harness

--- a/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
@@ -79,6 +79,10 @@ public sealed class ChaosFlashOverlay : Window
 
     private readonly Image _img;
     private readonly DispatcherTimer _life;
+    // Hiding right when a wash faded out meant the NEXT wash re-Show()ed a full-stage layered
+    // window (DWM re-composition hitch at trigger time). The window now idles visible (Opacity 0,
+    // image cleared, click-through) through this grace, hiding only after a truly quiet spell.
+    private readonly DispatcherTimer _hideGrace;
     private (string path, int durationMs, double opacity)? _pending;   // first Display can land before Loaded
     private int _displayGen;   // guards the async still-decode against a newer wash / a clear
 
@@ -114,11 +118,19 @@ public sealed class ChaosFlashOverlay : Window
         {
             _life.Stop();
             var fade = new DoubleAnimation(Opacity, 0, TimeSpan.FromMilliseconds(700));
-            // Window stays alive but HIDES between washes. Mid-run Close() of a layered
-            // window is the render-thread deadlock trigger; an idle-but-visible full-screen
-            // layered surface costs DWM composition every frame and stutters the GIF flashes.
-            fade.Completed += (_, _) => { ClearImage(); try { Hide(); } catch { } };
+            // Window stays alive between washes. Mid-run Close() of a layered window is the
+            // render-thread deadlock trigger; it hides only after _hideGrace of quiet (an
+            // Opacity-0 cleared surface doesn't redraw, so idling visible is ~free — while
+            // hiding immediately made every wash pay a full-stage Show() hitch).
+            fade.Completed += (_, _) => { ClearImage(); _hideGrace.Stop(); _hideGrace.Start(); };
             BeginAnimation(OpacityProperty, fade);
+        };
+
+        _hideGrace = new DispatcherTimer { Interval = TimeSpan.FromSeconds(8) };
+        _hideGrace.Tick += (_, _) =>
+        {
+            _hideGrace.Stop();
+            if (!_life.IsEnabled) { try { Hide(); } catch { } }
         };
     }
 
@@ -130,6 +142,7 @@ public sealed class ChaosFlashOverlay : Window
 
     private void DisplayCore(string path, int durationMs, double opacity)
     {
+        _hideGrace.Stop();
         _life.Stop();
         ClearImage();
         int gen = ++_displayGen;
@@ -198,6 +211,7 @@ public sealed class ChaosFlashOverlay : Window
 
     private void CloseNow()
     {
+        try { _hideGrace.Stop(); } catch { }
         try { _life.Stop(); } catch { }
         ClearImage();
         if (ReferenceEquals(_active, this)) _active = null;

--- a/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
@@ -129,6 +129,7 @@ public sealed class ChaosGifCascadeOverlay : Window
     private readonly List<Faller> _fallers = new();
     private readonly DispatcherTimer _spawn;
     private readonly DispatcherTimer _life;
+    private readonly DispatcherTimer _hideGrace;
     private bool _spawning;
     // Motion runs off the composition clock (vsync-aligned) instead of a 16ms
     // DispatcherTimer, whose OS-quantized cadence beat against the refresh and made
@@ -178,6 +179,16 @@ public sealed class ChaosGifCascadeOverlay : Window
 
         _life = new DispatcherTimer { Interval = TimeSpan.FromSeconds(8) };
         _life.Tick += (_, _) => { _life.Stop(); _spawning = false; _spawn.Stop(); };  // stop spawning; let in-flight fall out
+
+        // Hiding right when the last clip landed meant the NEXT cascade re-Show()ed a
+        // full-virtual-screen layered window (DWM re-composition hitch at trigger time). The
+        // window idles visible-but-empty (no redraws) through this grace before hiding.
+        _hideGrace = new DispatcherTimer { Interval = TimeSpan.FromSeconds(8) };
+        _hideGrace.Tick += (_, _) =>
+        {
+            _hideGrace.Stop();
+            if (!_spawning && _fallers.Count == 0) { try { Hide(); } catch { } }
+        };
     }
 
     /// <summary>Set the window-local X band clips spawn/fall in. Full = the whole virtual screen (all
@@ -194,6 +205,7 @@ public sealed class ChaosGifCascadeOverlay : Window
     private void Restart(List<string> files, double spawnRatePerSec, double durationSec,
                          double gifSize, double fallSpeed, double opacity, double startScale)
     {
+        _hideGrace.Stop();
         StopAndClear();
         _files = files;
         _gifSize = Math.Clamp(gifSize, 40, 600);
@@ -335,9 +347,10 @@ public sealed class ChaosGifCascadeOverlay : Window
             if (!_spawning && _fallers.Count == 0)
             {
                 GoIdle();
-                // Cascade over: hide the window (kept alive for the next payload) — an idle
-                // visible full-virtual-screen layered surface taxes DWM composition every frame.
-                try { Hide(); } catch { }
+                // Cascade over: keep the (now empty, non-redrawing) window up for the grace so a
+                // follow-up cascade doesn't pay a full-virtual-screen Show(); hide after that.
+                _hideGrace.Stop();
+                _hideGrace.Start();
             }
         }
         catch (Exception ex) { App.Logger?.Debug("GifCascade step: {E}", ex.Message); }
@@ -373,6 +386,7 @@ public sealed class ChaosGifCascadeOverlay : Window
 
     private void CloseNow()
     {
+        try { _hideGrace.Stop(); } catch { }
         StopAndClear();
         if (ReferenceEquals(_active, this)) _active = null;
         try { Close(); } catch { }

--- a/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
@@ -48,8 +48,7 @@ public sealed class ChaosSkiaFxOverlay : Window
     // overlays are stacked"). The layer is created + registered lazily on first use and lives
     // for the app's lifetime; this window is then never created at all.
     private static Services.Compositor.ChaosFxLayer? _layer;
-    private static bool UseCompositor =>
-        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+    private static bool UseCompositor => App.CompositorEnabled;
 
     // ---- public keep-alive / draw API (all thread-safe; marshalled to the UI thread) ----
 

--- a/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
@@ -151,6 +151,13 @@ public sealed class ChaosSkiaFxOverlay : Window
     private TimeSpan _lastRender = TimeSpan.MinValue;
     private double _dpiX = 1, _dpiY = 1;
 
+    // Hiding immediately on idle meant EVERY effect-bubble pop re-Show()ed a fullscreen layered
+    // window (DWM re-composition = a visible frame hitch, and only payload bubbles paid it).
+    // The render loop still parks after ~3 idle frames; the WINDOW stays up through this grace
+    // so back-to-back pops reuse the already-presented (cleared, click-through) surface.
+    private static readonly TimeSpan HideGrace = TimeSpan.FromSeconds(8);
+    private readonly System.Windows.Threading.DispatcherTimer _hideTimer;
+
     // Cached tint filters (modulate the white soft-dot sprite to a colour without per-draw alloc).
     private static readonly SKColorFilter PinkCF = SKColorFilter.CreateBlendMode(PinkBody, SKBlendMode.Modulate);
     private static readonly SKColorFilter AmberCF = SKColorFilter.CreateBlendMode(AmberBody, SKBlendMode.Modulate);
@@ -212,6 +219,13 @@ public sealed class ChaosSkiaFxOverlay : Window
         Content = _sk;
 
         SourceInitialized += (_, _) => { ApplyExStyles(); CacheDpi(); };
+
+        _hideTimer = new System.Windows.Threading.DispatcherTimer { Interval = HideGrace };
+        _hideTimer.Tick += (_, _) =>
+        {
+            _hideTimer.Stop();
+            if (!_rendering) { try { Hide(); } catch { } }
+        };
     }
 
     /// <summary>A soft white radial dot (premultiplied), tinted + additively blended per particle.</summary>
@@ -463,7 +477,15 @@ public sealed class ChaosSkiaFxOverlay : Window
     {
         try
         {
-            if (!IsVisible) Show();
+            _hideTimer.Stop();
+            if (!IsVisible)
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                Show();
+                sw.Stop();
+                if (sw.ElapsedMilliseconds >= 20)
+                    App.Logger?.Information("[POPLAG] ChaosSkiaFx window Show() took {Ms}ms", sw.ElapsedMilliseconds);
+            }
             ChaosWindowZ.RaiseAboveVideo(this);
             _idleFrames = 0;
             if (!_rendering)
@@ -549,7 +571,9 @@ public sealed class ChaosSkiaFxOverlay : Window
 
             if (_n == 0 && _bolts.Count == 0 && _ripples.Count == 0 && !_cursorArmed)
             {
-                if (++_idleFrames > 2) { StopRendering(); try { Hide(); } catch { } }
+                // Park the render loop right away (last painted frame is already cleared), but
+                // leave the window visible for HideGrace so the next pop doesn't pay a Show().
+                if (++_idleFrames > 2) { StopRendering(); _hideTimer.Stop(); _hideTimer.Start(); }
             }
             else _idleFrames = 0;
         }

--- a/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosSkiaFxOverlay.cs
@@ -42,49 +42,81 @@ public sealed class ChaosSkiaFxOverlay : Window
 
     private static ChaosSkiaFxOverlay? _active;
 
+    // Compositor routing: when the unified overlay host is on, the whole particle field renders
+    // as a ChaosFxLayer on the shared per-monitor hosts instead of this dedicated fullscreen
+    // layered window (one fewer surface presenting during a pop surge — the "explosion lag when
+    // overlays are stacked"). The layer is created + registered lazily on first use and lives
+    // for the app's lifetime; this window is then never created at all.
+    private static Services.Compositor.ChaosFxLayer? _layer;
+    private static bool UseCompositor =>
+        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+
     // ---- public keep-alive / draw API (all thread-safe; marshalled to the UI thread) ----
 
     public static void EnsureCreated()
     {
         if (!Enabled) return;
-        OnUi(_ => { });   // OnUi creates the window if needed, then idles hidden
-        OnUi(w => { if (w.IsVisible) w.Hide(); });
+        OnFx(_ => { }, w => { if (w.IsVisible) w.Hide(); });   // realizes the window/layer, then idles
     }
 
     /// <summary>Emit a sparkle burst at a rabbit trail point (physical px). <paramref name="warm"/>
     /// picks the amber GG-sweeper spark over the default Tail-Plug pink. Same call shape as
     /// ChaosFieldFxOverlay.TrailDot so the BubbleService call sites just branch on <see cref="Enabled"/>.</summary>
     public static void TrailDot(Point centerPx, double lifeSec, bool warm = false) =>
-        OnUi(w => w.EmitTrail(centerPx, lifeSec, warm));
+        OnFx(l => l.EmitTrail(centerPx, lifeSec, warm), w => w.EmitTrail(centerPx, lifeSec, warm));
 
     /// <summary>Trail with a travel-direction hint (dx,dy, any scale) so the sparks stream BEHIND the rabbit.</summary>
     public static void TrailDot(Point centerPx, double lifeSec, bool warm, double dirX, double dirY) =>
-        OnUi(w => w.EmitTrail(centerPx, lifeSec, warm, dirX, dirY));
+        OnFx(l => l.EmitTrail(centerPx, lifeSec, warm, dirX, dirY), w => w.EmitTrail(centerPx, lifeSec, warm, dirX, dirY));
 
     /// <summary>E-Stim: draw additive lightning bolts along the given segment endpoints (physical px).</summary>
     public static void Strike(IReadOnlyList<(Point From, Point To)> boltsPx) =>
-        OnUi(w => w.AddStrike(boltsPx));
+        OnFx(l => l.AddStrike(boltsPx), w => w.AddStrike(boltsPx));
 
     /// <summary>Pop burst at a bubble's centre (physical px) in its payload colour: a white core
     /// flash + an expanding ring + radiating shards. <paramref name="scale"/> >1 makes a bigger
     /// release (e.g. a live snap). Colour is any WPF colour; tint filters are cached per colour.</summary>
     public static void Burst(Point centerPx, System.Windows.Media.Color color, double scale = 1.0) =>
-        OnUi(w => w.EmitBurst(centerPx, ChaosBoonColors.ToSk(color), (float)scale));
+        OnFx(l => l.EmitBurst(centerPx, ChaosBoonColors.ToSk(color), (float)scale),
+             w => w.EmitBurst(centerPx, ChaosBoonColors.ToSk(color), (float)scale));
 
     /// <summary>An expanding additive shockwave (the Ripple cast / Size Queen / E-Stim wave). The
     /// leading edge grows LINEARLY to <paramref name="radiusPx"/> over <paramref name="lifeMs"/> so
     /// it matches the gameplay kill-front exactly; <paramref name="strong"/> adds trailing rings, a
     /// chromatic glassy edge and more front sparks for the player's right-click cast.</summary>
     public static void Ripple(Point centerPx, double radiusPx, double lifeMs, bool strong = false) =>
-        OnUi(w => w.EmitRipple(centerPx, radiusPx, lifeMs, strong));
+        OnFx(l => l.EmitRipple(centerPx, radiusPx, lifeMs, strong), w => w.EmitRipple(centerPx, radiusPx, lifeMs, strong));
 
-    public static void ArmCursorGlow() => OnUi(w => { w._cursorArmed = true; w.StartActivity(); });
-    public static void DisarmCursorGlow() => OnUi(w => w._cursorArmed = false);
+    public static void ArmCursorGlow() =>
+        OnFx(l => l.ArmCursor(), w => { w._cursorArmed = true; w.StartActivity(); });
+
+    /// <summary>Disarm on BOTH paths: a mid-run UnifiedOverlayHost flip must not strand an armed
+    /// glow on whichever renderer armed it (the pink/spiral act-on-state lesson).</summary>
+    public static void DisarmCursorGlow()
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    _layer?.DisarmCursor();
+                    if (_active != null) _active._cursorArmed = false;
+                }
+                catch { }
+            });
+        }
+        catch { }
+    }
 
     public static void MoveCursorGlowToPx(double px, double py) =>
-        OnUi(w => { if (w._cursorArmed && w.Local(new Point(px, py)) is Point p) { w._cursorX = (float)p.X; w._cursorY = (float)p.Y; } });
+        OnFx(l => l.MoveCursor(px, py),
+             w => { if (w._cursorArmed && w.Local(new Point(px, py)) is Point p) { w._cursorX = (float)p.X; w._cursorY = (float)p.Y; } });
 
-    /// <summary>Re-stack the live window above a mandatory video (see ChaosWindowZ). UI thread only.</summary>
+    /// <summary>Re-stack the live window above a mandatory video (see ChaosWindowZ). UI thread only.
+    /// Legacy-window path only — the compositor hosts manage their own z-order.</summary>
     public static void RaiseActive() => ChaosWindowZ.RaiseTopmost(_active);
 
     public static void CloseActive()
@@ -97,6 +129,7 @@ public sealed class ChaosSkiaFxOverlay : Window
             {
                 try
                 {
+                    _layer?.Clear();   // the layer stays registered; just drop its state
                     var w = _active;
                     _active = null;
                     w?.StopRendering();
@@ -108,7 +141,9 @@ public sealed class ChaosSkiaFxOverlay : Window
         catch { }
     }
 
-    private static void OnUi(Action<ChaosSkiaFxOverlay> act)
+    /// <summary>Marshal one FX call to the UI thread and route it: compositor layer when the
+    /// unified host is on, else the legacy keep-alive window (created on first use).</summary>
+    private static void OnFx(Action<Services.Compositor.ChaosFxLayer> viaLayer, Action<ChaosSkiaFxOverlay> viaWindow)
     {
         if (!Enabled) return;
         try
@@ -119,13 +154,23 @@ public sealed class ChaosSkiaFxOverlay : Window
             {
                 try
                 {
+                    if (UseCompositor)
+                    {
+                        if (_layer == null)
+                        {
+                            _layer = new Services.Compositor.ChaosFxLayer(App.Compositor!);
+                            App.Compositor!.RegisterLayer(_layer);
+                        }
+                        viaLayer(_layer);
+                        return;
+                    }
                     if (_active == null)
                     {
                         _active = new ChaosSkiaFxOverlay();
                         ((Window)_active).Show();
                         _active.Hide();   // realize the hwnd, then idle hidden until something draws
                     }
-                    act(_active);
+                    viaWindow(_active);
                 }
                 catch (Exception ex) { App.Logger?.Debug("ChaosSkiaFx: {E}", ex.Message); }
             });

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>ConditioningControlPanel</AssemblyName>
     <RootNamespace>ConditioningControlPanel</RootNamespace>
-    <Version>6.3.3</Version>
+    <Version>6.3.4</Version>
     <Company>CodeBambi</Company>
     <Product>Conditioning Control Panel</Product>
     <Description>A professional visual conditioning application with gamification features.</Description>

--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>ConditioningControlPanel</AssemblyName>
     <RootNamespace>ConditioningControlPanel</RootNamespace>
-    <Version>6.3.2</Version>
+    <Version>6.3.3</Version>
     <Company>CodeBambi</Company>
     <Product>Conditioning Control Panel</Product>
     <Description>A professional visual conditioning application with gamification features.</Description>

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "Wenn dir das Projekt gefällt, ",
   "label_consider_supporting_it": "unterstütze es gerne",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Ein besonderer Dank an Platinum Puppets für die bereitgestellten Audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "Wenn dir das Projekt gefällt, ",
   "label_consider_supporting_it": "unterstütze es gerne",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Ein besonderer Dank an Platinum Puppets für die bereitgestellten Audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -889,6 +889,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "If you love the project please ",
   "label_consider_supporting_it": "consider supporting it",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "A special thanks to Platinum Puppets for providing the audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -891,6 +891,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "If you love the project please ",
   "label_consider_supporting_it": "consider supporting it",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "A special thanks to Platinum Puppets for providing the audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "Si te encanta el proyecto, por favor ",
   "label_consider_supporting_it": "considera apoyarlo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un agradecimiento especial a Platinum Puppets por proporcionar los audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "Si te encanta el proyecto, por favor ",
   "label_consider_supporting_it": "considera apoyarlo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un agradecimiento especial a Platinum Puppets por proporcionar los audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "Si tu aimes ce projet, ",
   "label_consider_supporting_it": "pense à le soutenir",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un merci spécial aux Platinum Puppets pour les audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "Si tu aimes ce projet, ",
   "label_consider_supporting_it": "pense à le soutenir",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un merci spécial aux Platinum Puppets pour les audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "このプロジェクトが気に入ったら",
   "label_consider_supporting_it": "ぜひ支援をご検討ください",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Platinum Puppetsのオーディオ提供に感謝します ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "このプロジェクトが気に入ったら",
   "label_consider_supporting_it": "ぜひ支援をご検討ください",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Platinum Puppetsのオーディオ提供に感謝します ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "이 프로젝트가 마음에 드셨다면 ",
   "label_consider_supporting_it": "후원을 고려해 주세요",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "오디오를 제공해 주신 Platinum Puppets에게 특별히 감사드려요 ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "이 프로젝트가 마음에 드셨다면 ",
   "label_consider_supporting_it": "후원을 고려해 주세요",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "오디오를 제공해 주신 Platinum Puppets에게 특별히 감사드려요 ❤️",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "Se você ama o projeto, por favor ",
   "label_consider_supporting_it": "considere apoiá-lo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Um agradecimento especial às Platinum Puppets por fornecerem os áudios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "Se você ama o projeto, por favor ",
   "label_consider_supporting_it": "considere apoiá-lo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Um agradecimento especial às Platinum Puppets por fornecerem os áudios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -184,6 +184,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "Если тебе нравится проект, ",
   "label_consider_supporting_it": "поддержи его",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Особая благодарность Platinum Puppets за предоставленные аудио ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -182,6 +182,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "Если тебе нравится проект, ",
   "label_consider_supporting_it": "поддержи его",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Особая благодарность Platinum Puppets за предоставленные аудио ❤️",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -776,6 +776,8 @@
   "tooltip_v6_3_1_deeper_down": "v6.3.1 - Deeper Down",
   "btn_v6_3_2_is_out": "💖 v6.3.2 IS OUT! 💖",
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
+  "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
+  "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
   "label_if_you_love_the_project_please": "如果你喜欢这个项目，请",
   "label_consider_supporting_it": "考虑支持它",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "特别感谢 Platinum Puppets 提供音频 ❤️",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -778,6 +778,8 @@
   "tooltip_v6_3_2_deeper_down": "v6.3.2 - Deeper Down",
   "btn_v6_3_3_is_out": "💖 v6.3.3 IS OUT! 💖",
   "tooltip_v6_3_3_deeper_down": "v6.3.3 - Deeper Down",
+  "btn_v6_3_4_is_out": "💖 v6.3.4 IS OUT! 💖",
+  "tooltip_v6_3_4_deeper_down": "v6.3.4 - Deeper Down",
   "label_if_you_love_the_project_please": "如果你喜欢这个项目，请",
   "label_consider_supporting_it": "考虑支持它",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "特别感谢 Platinum Puppets 提供音频 ❤️",

--- a/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
@@ -88,7 +88,7 @@ namespace ConditioningControlPanel
             SettingsTab.ChkOfflineMode.IsChecked = s.OfflineMode;
             if (SettingsTab.ChkPerformanceMode != null) SettingsTab.ChkPerformanceMode.IsChecked = s.PerformanceMode;
             if (SettingsTab.ChkAutoPerformance != null) SettingsTab.ChkAutoPerformance.IsChecked = s.AutoPerformanceMode;
-            if (SettingsTab.ChkVideoHwDecode != null) SettingsTab.ChkVideoHwDecode.IsChecked = s.VideoHardwareDecoding;
+            if (SettingsTab.ChkVideoHwDecode != null) SettingsTab.ChkVideoHwDecode.IsChecked = s.VideoForceHardwareDecoding;
             RemoteControlTab.ChkStopEffectsOnRemoteDisconnect.IsChecked = s.StopEffectsOnRemoteDisconnect;
             if (RemoteControlTab.ChkRemoteShareAvatar != null) RemoteControlTab.ChkRemoteShareAvatar.IsChecked = s.RemoteShareAvatar;
 
@@ -499,7 +499,7 @@ namespace ConditioningControlPanel
             s.OfflineMode = SettingsTab.ChkOfflineMode.IsChecked ?? false;
             if (SettingsTab.ChkPerformanceMode != null) s.PerformanceMode = SettingsTab.ChkPerformanceMode.IsChecked ?? false;
             if (SettingsTab.ChkAutoPerformance != null) s.AutoPerformanceMode = SettingsTab.ChkAutoPerformance.IsChecked ?? true;
-            if (SettingsTab.ChkVideoHwDecode != null) s.VideoHardwareDecoding = SettingsTab.ChkVideoHwDecode.IsChecked ?? true;
+            if (SettingsTab.ChkVideoHwDecode != null) s.VideoForceHardwareDecoding = SettingsTab.ChkVideoHwDecode.IsChecked ?? false;
 
             // Deeper
             if (SettingsTab.ChkEnableDeeper != null) s.EnableDeeper = SettingsTab.ChkEnableDeeper.IsChecked ?? true;

--- a/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Settings.cs
@@ -89,6 +89,7 @@ namespace ConditioningControlPanel
             if (SettingsTab.ChkPerformanceMode != null) SettingsTab.ChkPerformanceMode.IsChecked = s.PerformanceMode;
             if (SettingsTab.ChkAutoPerformance != null) SettingsTab.ChkAutoPerformance.IsChecked = s.AutoPerformanceMode;
             if (SettingsTab.ChkVideoHwDecode != null) SettingsTab.ChkVideoHwDecode.IsChecked = s.VideoForceHardwareDecoding;
+            if (SettingsTab.ChkUnifiedOverlay != null) SettingsTab.ChkUnifiedOverlay.IsChecked = s.UnifiedOverlayHost;
             RemoteControlTab.ChkStopEffectsOnRemoteDisconnect.IsChecked = s.StopEffectsOnRemoteDisconnect;
             if (RemoteControlTab.ChkRemoteShareAvatar != null) RemoteControlTab.ChkRemoteShareAvatar.IsChecked = s.RemoteShareAvatar;
 
@@ -500,6 +501,7 @@ namespace ConditioningControlPanel
             if (SettingsTab.ChkPerformanceMode != null) s.PerformanceMode = SettingsTab.ChkPerformanceMode.IsChecked ?? false;
             if (SettingsTab.ChkAutoPerformance != null) s.AutoPerformanceMode = SettingsTab.ChkAutoPerformance.IsChecked ?? true;
             if (SettingsTab.ChkVideoHwDecode != null) s.VideoForceHardwareDecoding = SettingsTab.ChkVideoHwDecode.IsChecked ?? false;
+            if (SettingsTab.ChkUnifiedOverlay != null) s.UnifiedOverlayHost = SettingsTab.ChkUnifiedOverlay.IsChecked ?? true;
 
             // Deeper
             if (SettingsTab.ChkEnableDeeper != null) s.EnableDeeper = SettingsTab.ChkEnableDeeper.IsChecked ?? true;

--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -252,6 +252,14 @@ namespace ConditioningControlPanel
             App.IsEngineRunning = true;
             UpdateStartButton();
 
+            // Arm the dirty-shutdown sentinel: if the process dies natively mid-session
+            // (no crash.log — the flash-burst 0xc0000374 shape), the next launch reports
+            // it with this context instead of the app just "vanishing".
+            Services.EngineCrashSentinel.Mark(
+                $"started {DateTime.Now:yyyy-MM-dd HH:mm:ss} | flash {settings.FlashFrequency}/min x{settings.SimultaneousImages}" +
+                $" | bubbles {(settings.BubblesEnabled ? "on" : "off")} | video {(settings.MandatoryVideosEnabled ? "on" : "off")}" +
+                $" | subliminal {(settings.SubliminalEnabled ? "on" : "off")}");
+
             // Start conditioning time tracker
             StartConditioningTimeTracker();
 
@@ -345,6 +353,9 @@ namespace ConditioningControlPanel
             _isRunning = false;
             App.IsEngineRunning = false;
             UpdateStartButton();
+
+            // Clean stop — disarm the dirty-shutdown sentinel.
+            Services.EngineCrashSentinel.Clear();
 
             // Fire event for avatar reaction
             EngineStopped?.Invoke(this, EventArgs.Empty);

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -2034,8 +2034,8 @@ namespace ConditioningControlPanel
         internal void ChkVideoHwDecode_Changed(object sender, RoutedEventArgs e)
         {
             if (_isLoading) return;
-            App.Settings.Current.VideoHardwareDecoding = SettingsTab.ChkVideoHwDecode.IsChecked ?? true;
-            App.Logger?.Information("Video hardware decoding set to {Enabled}", App.Settings.Current.VideoHardwareDecoding);
+            App.Settings.Current.VideoForceHardwareDecoding = SettingsTab.ChkVideoHwDecode.IsChecked ?? false;
+            App.Logger?.Information("Force video hardware decoding set to {Enabled}", App.Settings.Current.VideoForceHardwareDecoding);
         }
 
         internal void ChkOfflineMode_Changed(object sender, RoutedEventArgs e)

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -2038,6 +2038,13 @@ namespace ConditioningControlPanel
             App.Logger?.Information("Force video hardware decoding set to {Enabled}", App.Settings.Current.VideoForceHardwareDecoding);
         }
 
+        internal void ChkUnifiedOverlay_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            App.Settings.Current.UnifiedOverlayHost = SettingsTab.ChkUnifiedOverlay.IsChecked ?? true;
+            App.Logger?.Information("Unified overlay renderer set to {Enabled}", App.Settings.Current.UnifiedOverlayHost);
+        }
+
         internal void ChkOfflineMode_Changed(object sender, RoutedEventArgs e)
         {
             if (_isLoading) return;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -566,8 +566,8 @@
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
-                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_3_3_is_out}"
-                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_3_3_deeper_down}"
+                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_3_4_is_out}"
+                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_3_4_deeper_down}"
                             FontSize="11" FontWeight="Bold" Cursor="Hand">
                         <Button.Style>
                             <Style TargetType="Button">

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -566,8 +566,8 @@
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
-                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_3_2_is_out}"
-                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_3_2_deeper_down}"
+                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_3_3_is_out}"
+                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_3_3_deeper_down}"
                             FontSize="11" FontWeight="Bold" Cursor="Hand">
                         <Button.Style>
                             <Style TargetType="Button">

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2294,18 +2294,39 @@ namespace ConditioningControlPanel.Models
             get => _chaosBubbleSharedHost;
             set { _chaosBubbleSharedHost = value; OnPropertyChanged(); }
         }
-        private bool _unifiedOverlayHost = true;
-        /// <summary>Default ON (owner-confirmed "100x better", 2026-07-13): render the fullscreen
+        private bool _unifiedOverlayHost = false;
+        /// <summary>Default OFF (reverted 2026-07-13, bug #550): render the fullscreen
         /// effects (pink filter, spiral, brain drain, subliminals, flash, bubbles, chaos FX) as
         /// z-ordered Skia layers inside ONE shared click-through compositor window per monitor
         /// (Services/Compositor/CompositorEngine) instead of one layered Window per effect.
         /// Concurrent fullscreen layered windows were the root cause of the session-lag /
         /// mouse-stutter cluster; this is the WPF twin of the Avalonia port's compositor and the
-        /// end-state renderer. Falls back to the legacy per-effect windows when off.</summary>
+        /// end-state renderer. Was briefly default ON (72456c1e) but the host renders through a
+        /// software SKElement on the UI thread, so a continuously-active fullscreen spiral
+        /// saturates the dispatcher on some machines (~1s input latency, #550). Kept OFF until the
+        /// host moves to GPU raster (SKGLElement) / throttled invalidation. Falls back to the
+        /// legacy per-effect windows when off.</summary>
         public bool UnifiedOverlayHost
         {
             get => _unifiedOverlayHost;
             set { _unifiedOverlayHost = value; OnPropertyChanged(); }
+        }
+        private bool _compositorOffThreadPresent;
+        /// <summary>Default OFF (experimental, #550 proper fix): when the unified overlay host is on,
+        /// render each monitor's layers OFF the UI thread. The UI-thread tick still runs Update() and
+        /// records the active layers into a cheap immutable SKPicture (draw-command capture, no raster);
+        /// a dedicated per-monitor present thread then rasterizes that picture into a DIB-backed surface
+        /// and pushes it with UpdateLayeredWindow(ULW_ALPHA). This removes the fullscreen software raster
+        /// + layered composite from the UI thread (the dispatcher-starvation that made the spiral lag the
+        /// whole app on some machines) while keeping per-pixel alpha, click-through and the layers'
+        /// UI-thread contract intact (SKImage frees route through the engine's deferred-disposal so an
+        /// image referenced by an in-flight picture is never freed under the present thread). No-op when
+        /// the unified host is off. Needs play-test on a high-res / multi-monitor machine before shipping
+        /// on - the win only shows where the UI-thread raster actually saturated.</summary>
+        public bool CompositorOffThreadPresent
+        {
+            get => _compositorOffThreadPresent;
+            set { _compositorOffThreadPresent = value; OnPropertyChanged(); }
         }
         private bool _chaosDvdSharedHost = true;
         /// <summary>Default ON (proven win): render the DVD bouncing-text logos (Porn DVD /
@@ -3731,6 +3752,32 @@ namespace ConditioningControlPanel.Models
             if (_speechLoudnessThreshold >= 0.035 && _speechLoudnessThreshold <= 0.045)
                 _speechLoudnessThreshold = 0.015;
             _loudnessThresholdRelaxed = true;
+        }
+
+        private bool _migratedUnifiedOverlayHostOff;
+        /// <summary>One-shot guard for <see cref="MigrateDisableUnifiedOverlayHost"/> so a user who
+        /// later re-enables the experimental compositor toggle isn't clobbered on the next launch.</summary>
+        [JsonProperty]
+        public bool MigratedUnifiedOverlayHostOff
+        {
+            get => _migratedUnifiedOverlayHostOff;
+            set { _migratedUnifiedOverlayHostOff = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>
+        /// Force the unified overlay host OFF once for users upgrading from 6.3.3, where it was
+        /// briefly default ON (72456c1e). The host renders through a software SKElement on the UI
+        /// thread, so a continuously-active fullscreen spiral saturated the dispatcher on some
+        /// machines (~1s input latency, bug #550). Because the property has no
+        /// DefaultValueHandling.Ignore, every 6.3.3 user has "true" written to settings.json, so a
+        /// default flip alone wouldn't reach them. Nobody enabled it deliberately in the &lt;1 day it
+        /// was default ON, and the in-app toggle can turn it back on — so a one-shot force-off is safe.
+        /// </summary>
+        internal void MigrateDisableUnifiedOverlayHost()
+        {
+            if (_migratedUnifiedOverlayHostOff) return;
+            _unifiedOverlayHost = false;
+            _migratedUnifiedOverlayHostOff = true;
         }
 
         private double _speechWakeThreshold = 0.15;

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2294,14 +2294,14 @@ namespace ConditioningControlPanel.Models
             get => _chaosBubbleSharedHost;
             set { _chaosBubbleSharedHost = value; OnPropertyChanged(); }
         }
-        private bool _unifiedOverlayHost;
-        /// <summary>EXPERIMENTAL, default OFF: render the passive fullscreen effects (pink filter,
-        /// spiral, brain drain, then subliminals/flash/bubbles as they migrate) as z-ordered Skia
-        /// layers inside ONE shared click-through compositor window per monitor
+        private bool _unifiedOverlayHost = true;
+        /// <summary>Default ON (owner-confirmed "100x better", 2026-07-13): render the fullscreen
+        /// effects (pink filter, spiral, brain drain, subliminals, flash, bubbles, chaos FX) as
+        /// z-ordered Skia layers inside ONE shared click-through compositor window per monitor
         /// (Services/Compositor/CompositorEngine) instead of one layered Window per effect.
-        /// Concurrent fullscreen layered windows are the root cause of the session-lag /
+        /// Concurrent fullscreen layered windows were the root cause of the session-lag /
         /// mouse-stutter cluster; this is the WPF twin of the Avalonia port's compositor and the
-        /// intended end-state renderer. Falls back to the legacy per-effect windows when off.</summary>
+        /// end-state renderer. Falls back to the legacy per-effect windows when off.</summary>
         public bool UnifiedOverlayHost
         {
             get => _unifiedOverlayHost;

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2836,16 +2836,20 @@ namespace ConditioningControlPanel.Models
             set { _autoPerformanceMode = value; OnPropertyChanged(); }
         }
 
-        private bool _videoHardwareDecoding = true;
+        private bool _videoForceHardwareDecoding = false;
         /// <summary>
-        /// Use GPU (DXVA) hardware decoding for mandatory videos. Default on; LibVLC falls back
-        /// to software automatically if a GPU's hardware decode path is unavailable. Provided as
-        /// an escape hatch for the rare systems with flaky hardware decoders.
+        /// Force GPU (DXVA) hardware decoding for mandatory videos. Default OFF — mandatory videos
+        /// software-decode, because the LibVLC hardware path intermittently renders a white screen
+        /// and wedges cleanup on Windows 11 (build 26200) and some Win10 machines (#533/#537/#540).
+        /// These are short attention-check clips, so software decode costs little. This is an opt-in
+        /// escape hatch for users on good hardware who want GPU decode back.
+        /// NOTE: property was renamed from the old default-ON "VideoHardwareDecoding" precisely so
+        /// existing users' persisted true value stops binding and everyone lands on software decode.
         /// </summary>
-        public bool VideoHardwareDecoding
+        public bool VideoForceHardwareDecoding
         {
-            get => _videoHardwareDecoding;
-            set { _videoHardwareDecoding = value; OnPropertyChanged(); }
+            get => _videoForceHardwareDecoding;
+            set { _videoForceHardwareDecoding = value; OnPropertyChanged(); }
         }
 
         #endregion

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2294,6 +2294,19 @@ namespace ConditioningControlPanel.Models
             get => _chaosBubbleSharedHost;
             set { _chaosBubbleSharedHost = value; OnPropertyChanged(); }
         }
+        private bool _unifiedOverlayHost;
+        /// <summary>EXPERIMENTAL, default OFF: render the passive fullscreen effects (pink filter,
+        /// spiral, brain drain, then subliminals/flash/bubbles as they migrate) as z-ordered Skia
+        /// layers inside ONE shared click-through compositor window per monitor
+        /// (Services/Compositor/CompositorEngine) instead of one layered Window per effect.
+        /// Concurrent fullscreen layered windows are the root cause of the session-lag /
+        /// mouse-stutter cluster; this is the WPF twin of the Avalonia port's compositor and the
+        /// intended end-state renderer. Falls back to the legacy per-effect windows when off.</summary>
+        public bool UnifiedOverlayHost
+        {
+            get => _unifiedOverlayHost;
+            set { _unifiedOverlayHost = value; OnPropertyChanged(); }
+        }
         private bool _chaosDvdSharedHost = true;
         /// <summary>Default ON (proven win): render the DVD bouncing-text logos (Porn DVD /
         /// Intrusive Thoughts / Casting Couch) as cheap Canvas children of ONE shared click-through host

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2294,18 +2294,17 @@ namespace ConditioningControlPanel.Models
             get => _chaosBubbleSharedHost;
             set { _chaosBubbleSharedHost = value; OnPropertyChanged(); }
         }
-        private bool _unifiedOverlayHost = false;
-        /// <summary>Default OFF (reverted 2026-07-13, bug #550): render the fullscreen
+        private bool _unifiedOverlayHost = true;
+        /// <summary>Default ON (re-enabled for the 6.4 merge): render the fullscreen
         /// effects (pink filter, spiral, brain drain, subliminals, flash, bubbles, chaos FX) as
         /// z-ordered Skia layers inside ONE shared click-through compositor window per monitor
         /// (Services/Compositor/CompositorEngine) instead of one layered Window per effect.
         /// Concurrent fullscreen layered windows were the root cause of the session-lag /
         /// mouse-stutter cluster; this is the WPF twin of the Avalonia port's compositor and the
-        /// end-state renderer. Was briefly default ON (72456c1e) but the host renders through a
-        /// software SKElement on the UI thread, so a continuously-active fullscreen spiral
-        /// saturates the dispatcher on some machines (~1s input latency, #550). Kept OFF until the
-        /// host moves to GPU raster (SKGLElement) / throttled invalidation. Falls back to the
-        /// legacy per-effect windows when off.</summary>
+        /// end-state renderer. Was reverted to OFF once (2026-07-13, #550: unthrottled software
+        /// SKElement raster saturated the UI thread) — since fixed by dirty-gated invalidation,
+        /// so the compositor is the blessed path going forward. A Settings-tab toggle
+        /// ("Unified overlay renderer") lets users fall back to the legacy per-effect windows.</summary>
         public bool UnifiedOverlayHost
         {
             get => _unifiedOverlayHost;
@@ -3754,30 +3753,31 @@ namespace ConditioningControlPanel.Models
             _loudnessThresholdRelaxed = true;
         }
 
-        private bool _migratedUnifiedOverlayHostOff;
-        /// <summary>One-shot guard for <see cref="MigrateDisableUnifiedOverlayHost"/> so a user who
-        /// later re-enables the experimental compositor toggle isn't clobbered on the next launch.</summary>
+        private bool _migratedUnifiedOverlayHostOn;
+        /// <summary>One-shot guard for <see cref="MigrateEnableUnifiedOverlayHost"/> so a user who
+        /// turns the compositor toggle off afterwards isn't clobbered back on at the next launch.</summary>
         [JsonProperty]
-        public bool MigratedUnifiedOverlayHostOff
+        public bool MigratedUnifiedOverlayHostOn
         {
-            get => _migratedUnifiedOverlayHostOff;
-            set { _migratedUnifiedOverlayHostOff = value; OnPropertyChanged(); }
+            get => _migratedUnifiedOverlayHostOn;
+            set { _migratedUnifiedOverlayHostOn = value; OnPropertyChanged(); }
         }
 
         /// <summary>
-        /// Force the unified overlay host OFF once for users upgrading from 6.3.3, where it was
-        /// briefly default ON (72456c1e). The host renders through a software SKElement on the UI
-        /// thread, so a continuously-active fullscreen spiral saturated the dispatcher on some
-        /// machines (~1s input latency, bug #550). Because the property has no
-        /// DefaultValueHandling.Ignore, every 6.3.3 user has "true" written to settings.json, so a
-        /// default flip alone wouldn't reach them. Nobody enabled it deliberately in the &lt;1 day it
-        /// was default ON, and the in-app toggle can turn it back on — so a one-shot force-off is safe.
+        /// Force the unified overlay host ON once for users upgrading from 6.3.3/6.3.4. The
+        /// 6.3.4 hotfix force-migrated everyone OFF (bug #550: the host's unthrottled software
+        /// raster saturated the UI thread) and persisted "false" to settings.json, so the
+        /// default flip back to ON wouldn't reach them. #550 is fixed (dirty-gated invalidation)
+        /// and the compositor is now the blessed render path, so re-enable once; the
+        /// Settings-tab toggle ("Unified overlay renderer") lets anyone opt back out and their
+        /// choice sticks. Supersedes the retired MigrateDisableUnifiedOverlayHost — its
+        /// MigratedUnifiedOverlayHostOff sentinel key is simply ignored in old settings files.
         /// </summary>
-        internal void MigrateDisableUnifiedOverlayHost()
+        internal void MigrateEnableUnifiedOverlayHost()
         {
-            if (_migratedUnifiedOverlayHostOff) return;
-            _unifiedOverlayHost = false;
-            _migratedUnifiedOverlayHostOff = true;
+            if (_migratedUnifiedOverlayHostOn) return;
+            _unifiedOverlayHost = true;
+            _migratedUnifiedOverlayHostOn = true;
         }
 
         private double _speechWakeThreshold = 0.15;

--- a/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
+++ b/ConditioningControlPanel/Resources/web/dtrh/game/payloadFx.js
@@ -60,6 +60,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
   let liveFlash = 0, liveCascade = 0;
   let videoCardEl = null;    // the single live video card (one at a time)
   let videoCardCancel = null; // early-out for the live card (room arrival)
+  let heavyGen = 0;          // bumped by cancelHeavy; a card acquired across a bump is stale
   let disposed = false;
 
   /** Draw a URL from the user's image pool (null when the pool is empty). */
@@ -260,8 +261,13 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
     if (!media || !media.drawKind) return;
     const pickV = media.drawKind('video');
     if (!pickV) return;   // no user videos in the pool - silently skip
+    // Snapshot the heavy generation: cancelHeavy() (room arrival / endRun) can fire while
+    // we're awaiting the decrypt below, and videoCardCancel isn't wired up yet, so the card
+    // would append AFTER the run ended and sit over the recap/hub for its full 15s hold.
+    const gen = heavyGen;
     const got = await pickV.acquire();
     if (disposed || videoCardEl || !got || !got.url) return;
+    if (gen !== heavyGen) return;   // a cancelHeavy landed during acquire: this card is stale
 
     const card = document.createElement('div');
     card.className = 'sf-pfx-videocard';
@@ -309,6 +315,7 @@ export function createPayloadFx({ hud, fx, media, flashBurst }) {
    * true if anything live was actually cut. */
   function cancelHeavy() {
     let cut = false;
+    heavyGen++;   // invalidate any video card still mid-acquire (see videoCard's gen check)
     if (videoCardCancel) { try { videoCardCancel(); } catch { /* ignore */ } cut = true; }
     for (const c of cascades) { try { c.cancel(); } catch { /* ignore */ } cut = true; }
     cascades.clear();

--- a/ConditioningControlPanel/Resources/web/dtrh/styles.css
+++ b/ConditioningControlPanel/Resources/web/dtrh/styles.css
@@ -103,7 +103,10 @@ html, body {
   display: flex;
   align-items: center;
   gap: 0.6rem;
-  z-index: 12;
+  /* Above Cheshire's bottom-left corner commentary (.chc-root, z38) so her portrait
+     + chat bubble never bury Settings/audio/fullscreen; still below the full-screen
+     VN + boon-draft modals (z40+), which hide the dock via .sf-chrome-hidden anyway. */
+  z-index: 39;
   pointer-events: none;
 }
 .sf-dock-btn {

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -959,14 +959,14 @@ namespace ConditioningControlPanel.Services
                         }
                         Application.Current?.Dispatcher?.BeginInvoke(() =>
                         {
-                            PerformAction(capturedAction, source, context);
+                            PerformAction(capturedAction, source, context, announce: true);
                         });
                     });
                 }
                 else
                 {
                     App.Logger?.Information("AutonomyService: No announcement, executing action immediately...");
-                    PerformAction(actionType.Value, source, context);
+                    PerformAction(actionType.Value, source, context, announce: false);
                 }
 
                 // Start cooldown
@@ -1174,7 +1174,7 @@ namespace ConditioningControlPanel.Services
             _                                   => null,
         };
 
-        private void PerformAction(AutonomyActionType actionType, AutonomyTriggerSource source, string? context)
+        private void PerformAction(AutonomyActionType actionType, AutonomyTriggerSource source, string? context, bool announce)
         {
             App.Logger?.Information("AutonomyService: PerformAction starting - {Action}", actionType);
 
@@ -1188,12 +1188,17 @@ namespace ConditioningControlPanel.Services
 
                     // On-screen cue so a takeover-driven effect is visibly distinct from an
                     // ordinary engine effect. Fires for every effect except Comment (just a giggle).
-                    try
+                    // Gated on the announce roll (AutonomyAnnouncementChance): at 0% the user wants
+                    // silent, unannounced takeover, so the HUD banner is suppressed too (#534).
+                    if (announce)
                     {
-                        var cue = TakeoverEffectLabel(actionType);
-                        if (cue != null) TakeoverAnnouncerOverlay.Announce(cue);
+                        try
+                        {
+                            var cue = TakeoverEffectLabel(actionType);
+                            if (cue != null) TakeoverAnnouncerOverlay.Announce(cue);
+                        }
+                        catch (Exception cueEx) { App.Logger?.Debug("AutonomyService: takeover cue failed: {E}", cueEx.Message); }
                     }
-                    catch (Exception cueEx) { App.Logger?.Debug("AutonomyService: takeover cue failed: {E}", cueEx.Message); }
 
                     switch (actionType)
                     {

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -739,7 +739,9 @@ public class BubbleService : IDisposable
     private void BeginAmbientHostIfEnabled()
     {
         if (_ambientHost) return;
-        if (App.Settings?.Current?.BubbleSharedHost != true) return;
+        // Stand up when the ambient Canvas host is opted in, OR whenever the compositor is on (the
+        // BubbleLayer needs the same _ambientHost gate + hook that feed the renderer-agnostic pop path).
+        if (App.Settings?.Current?.BubbleSharedHost != true && !Bubble.UseCompositor) return;
         _ambientHost = true;
         Bubble.AmbientHostActive = true;
         ChaosBubbleHostOverlay.EnsureCreated();
@@ -2047,6 +2049,23 @@ internal class Bubble
     /// does, but driven by the AppSettings.BubbleSharedHost flag instead of the chaos one.</summary>
     internal static bool AmbientHostActive;
 
+    // ---- Compositor BubbleLayer (unified overlay host) ----
+    // When the flag is on, a bubble that WOULD ride the shared Canvas host renders on the
+    // compositor's BubbleLayer instead: same hook-pop input contract (UsesHost stays true, hit
+    // discs are renderer-agnostic), just Skia draw calls in place of a WPF _grid on a Canvas.
+    private static Compositor.BubbleLayer? s_layer;
+    internal static bool UseCompositor =>
+        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+    /// <summary>Lazily create + register the shared BubbleLayer. Null if the compositor is off.</summary>
+    private static Compositor.BubbleLayer? EnsureLayer()
+    {
+        if (s_layer != null) return s_layer;
+        if (App.Compositor == null) return null;
+        try { s_layer = new Compositor.BubbleLayer(App.Compositor); App.Compositor.RegisterLayer(s_layer); }
+        catch { s_layer = null; }
+        return s_layer;
+    }
+
     /// <summary>A hidden, reset transparent window shell of exactly <paramref name="bucket"/> px square —
     /// recycled from that bucket or freshly built at that size. Never resized after creation. UI thread only.</summary>
     private static Window RentWindow(int bucket)
@@ -2116,6 +2135,10 @@ internal class Bubble
 
     private readonly Window? _window;   // null in shared-host mode (the grid lives on ChaosBubbleHostOverlay)
     private readonly bool _useHost;     // AppSettings.ChaosBubbleSharedHost && chaos bubble — see the spawn block
+    private readonly bool _useLayer;    // UnifiedOverlayHost: render on the compositor BubbleLayer (also window-less)
+    private Compositor.BubbleLayer.BubbleItem? _layerItem;   // this bubble's draw-state on the layer (null off-layer)
+    private Image? _teaseFaceImg;       // the tease face's frame Image (read per-frame for the layer's current frame)
+    private SkiaSharp.SKPoint[][]? _crackPts;   // brittle crack polylines in DIP (0.._size box) for the layer
     private readonly FrameworkElement _fxTarget;   // where glow/opacity apply: _window (per-window) or _grid (host)
     private double _winDim;   // the (quantized) square window side this bubble uses; held so AnimateFrame can re-centre without resizing the window (see spawn — resizing churns the layered DIB)
     private System.Windows.Input.MouseButtonEventHandler? _winClickHandler;   // removed on death so the pooled window never roots a dead bubble
@@ -2462,10 +2485,11 @@ internal class Bubble
 
     // ---- Shared-host pop hit-testing (mouse-hook path; see BubbleService.OnSharedHostLeftDown) ----
 
-    /// <summary>True when this bubble renders on the shared Canvas host (vs. its own pooled layered
-    /// window). The hook-pop path targets ONLY host bubbles; per-window bubbles keep their WPF handler,
-    /// so this is the guard that prevents a double-pop across the two render paths.</summary>
-    internal bool UsesHost => _useHost;
+    /// <summary>True when this bubble renders window-less on a SHARED surface (the Canvas host OR the
+    /// compositor BubbleLayer) rather than its own pooled layered window. Both share the hook-pop input
+    /// contract (renderer-agnostic hit discs); per-window bubbles keep their WPF handler, so this is the
+    /// guard that prevents a double-pop across the render paths.</summary>
+    internal bool UsesHost => _useHost || _useLayer;
 
     /// <summary>This bubble is currently a valid left-click pop target.</summary>
     internal bool HostHitClickable => _isClickable && _isAlive && !_isDestroyed && !_isPopping && !_claimedByAvatar;
@@ -2487,6 +2511,100 @@ internal class Bubble
     /// <summary>Pop this bubble from a shared-host hook click (UI thread) — routes exactly like a
     /// real press (tease/brittle/channel/benign all handled by OnPlayerPress).</summary>
     internal void HostHookPop() => OnPlayerPress();
+
+    // ---- Compositor BubbleLayer bridge (see Services/Compositor/BubbleLayer.cs) ----
+
+    /// <summary>Build this bubble's compositor draw item from its (static) spawn state. Called once
+    /// from the ctor when _useLayer; the per-frame values are filled by <see cref="SyncLayerItem"/>.
+    /// Mirrors the WPF visual tree built above (base sprite + BuildChaosLayers), resolved from the
+    /// same flags so the two render paths match.</summary>
+    private Compositor.BubbleLayer.BubbleItem BuildLayerItem()
+    {
+        bool hasTint = _spec != null && !_hasVariantSprite;
+        var tint = _spec != null
+            ? new SkiaSharp.SKColor(_spec.Tint.R, _spec.Tint.G, _spec.Tint.B)
+            : new SkiaSharp.SKColor(0xE8, 0xE8, 0xF0);
+
+        // Glow: the DropShadow that wins on the sprite (or the spotlight halo), resolved from flags.
+        bool hasGlow = false; var glowColor = default(SkiaSharp.SKColor); float glowBlur = 0, glowOp = 0;
+        if (_spec != null)
+        {
+            if (_spec.IsSweeper) { glowColor = new SkiaSharp.SKColor(0xFF, 0x8A, 0x14); glowBlur = 36; glowOp = 1.0f; hasGlow = true; }
+            else if (_isDarter) { glowColor = tint; glowBlur = 26; glowOp = 0.9f; hasGlow = true; }
+            else if (_spec.IsGolden) { glowColor = new SkiaSharp.SKColor(0xFF, 0xD7, 0x00); glowBlur = 20; glowOp = 0.55f; hasGlow = true; }
+            else if (_spec.IsBrittle) { glowColor = new SkiaSharp.SKColor(0xBF, 0xE6, 0xFF); glowBlur = 22; glowOp = 0.6f; hasGlow = true; }
+            else if (_spec.Spotlight)
+            {
+                var tier = PerformanceProfile.CurrentTier;
+                if (PerformanceProfile.AllowGlow(tier))
+                {
+                    glowColor = new SkiaSharp.SKColor(0xFF, 0xD7, 0x00);
+                    glowBlur = (float)Math.Min(40, PerformanceProfile.MaxGlowBlurRadius(tier));
+                    glowOp = 0.85f; hasGlow = true;
+                }
+            }
+        }
+
+        var item = new Compositor.BubbleLayer.BubbleItem
+        {
+            DpiScale = (float)_dpiScale,
+            SizeDip = _size,
+            HitSizeDip = _hitSize,
+            Sprite = Compositor.BubbleLayer.ResolveSprite(_bubbleImage.Source as System.Windows.Media.Imaging.BitmapSource),
+            HasTint = hasTint,
+            Tint = tint,
+            Label = (_spec != null && !_hasVariantSprite && !string.IsNullOrEmpty(_spec.Label)) ? _spec.Label : null,
+            LabelFontDip = (float)Math.Max(14, _size * 0.30),
+            HasShine = ChaosSkiaFxOverlay.Enabled && !_hasVariantSprite && _spec != null,
+            IsEcho = _spec?.IsEcho == true,
+            EchoColor = _spec != null ? new SkiaSharp.SKColor(_spec.Tint.R, _spec.Tint.G, _spec.Tint.B, 110) : default,
+            IsTease = _isTease,
+            TeaseInnerDip = (float)(_size * 0.86),
+            HasGlow = hasGlow,
+            GlowColor = glowColor,
+            GlowBlurDip = glowBlur,
+            GlowOpacity = glowOp,
+            PrismGhost = Compositor.BubbleLayer.ResolveSprite(_prismGhost?.Source as System.Windows.Media.Imaging.BitmapSource),
+            Cracks = _crackPts,
+            HintText = (_hintEl?.Child as TextBlock)?.Text,
+            HintYOffDip = (float)(_size / 2.0 + Math.Clamp(_winPad - 24.0, 2.0, 14.0)),
+        };
+        return item;
+    }
+
+    /// <summary>Copy the frame's just-computed visual state onto the draw item. Reads the values the
+    /// (unshown) WPF animation wrote this tick — position, the composed sprite scale/opacity, and each
+    /// variant element's animated scale/colour/opacity — so the layer never re-derives animation.</summary>
+    private void SyncLayerItem(double currentScale, double opacity, double jx, double jy)
+    {
+        var it = _layerItem;
+        if (it == null) return;
+        it.CenterXPx = (_posX + _size / 2.0 + jx) * _dpiScale;
+        it.CenterYPx = (_posY + _size / 2.0 + jy) * _dpiScale;
+        it.Scale = (float)currentScale;
+        it.Angle = (float)_angle;
+        it.Opacity = (float)opacity;
+
+        if (_fuseRing != null)
+        {
+            it.FuseScale = (float)((_fuseRing.RenderTransform as ScaleTransform)?.ScaleX ?? 1.0);
+            it.FuseOpacity = (float)_fuseRing.Opacity;
+            if (_fuseStrokeBrush != null)
+            { var c = _fuseStrokeBrush.Color; it.FuseColor = new SkiaSharp.SKColor(c.R, c.G, c.B); }
+        }
+        if (_telegraphRing != null)
+        {
+            it.TelegraphScale = (float)((_telegraphRing.RenderTransform as ScaleTransform)?.ScaleX ?? 1.0);
+            it.TelegraphOpacity = _telegraphRing.Visibility == Visibility.Visible ? (float)_telegraphRing.Opacity : 0f;
+        }
+        if (_freezeAura != null) it.FreezeAuraOpacity = (float)_freezeAura.Opacity;
+        if (_brittleCracks != null) it.BrittleOpacity = (float)_brittleCracks.Opacity;
+        if (_teaseShine != null) it.TeaseShineOpacity = (float)_teaseShine.Opacity;
+        if (_teaseFaceImg != null) it.TeaseSource = _teaseFaceImg.Source as System.Windows.Media.Imaging.BitmapSource;
+        if (_shieldRing != null) it.ShieldOpacity = (float)_shieldRing.Opacity;
+        if (_prismGhost != null) it.PrismOpacity = (float)_prismGhost.Opacity;
+        if (_hintEl != null) it.HintOpacity = _hintEl.Visibility == Visibility.Visible ? (float)_hintEl.Opacity : 0f;
+    }
 
     /// <summary>The box grown by <paramref name="expand"/> about its centre — the reach of its pop burst.</summary>
     public Rect ChainReach(double expand)
@@ -2825,15 +2943,36 @@ internal class Bubble
         // BubbleSharedHost while the ambient host is standing. forceWindowMode pins per-window
         // rendering: CreateAmbientBubble sets it for a trigger bubble whose target screen the
         // host can't cover (host down, or spawn on a screen outside its stage bounds).
-        bool chaosHost = spec != null && !ambientTrigger && (App.Settings?.Current?.ChaosBubbleSharedHost ?? false);
-        bool ambientHost = (spec == null || ambientTrigger) && AmbientHostActive && (App.Settings?.Current?.BubbleSharedHost ?? false);
-        _useHost = !forceWindowMode && (chaosHost || ambientHost);
+        // Under the unified overlay host the compositor IS the shared host, so a would-be host
+        // bubble rides the BubbleLayer even when the experimental Canvas-host flags are off (the
+        // chaos run's _rippleHook / the ambient _ambientHook already give the hook-pop path).
+        bool chaosHost = spec != null && !ambientTrigger && ((App.Settings?.Current?.ChaosBubbleSharedHost ?? false) || UseCompositor);
+        bool ambientHost = (spec == null || ambientTrigger) && AmbientHostActive && ((App.Settings?.Current?.BubbleSharedHost ?? false) || UseCompositor);
+        bool wantsHost = !forceWindowMode && (chaosHost || ambientHost);
+        // Under the unified overlay host, a would-be host bubble renders on the compositor
+        // BubbleLayer instead of the Canvas host (same window-less, hook-pop contract).
+        _useLayer = wantsHost && UseCompositor && EnsureLayer() != null;
+        _useHost = wantsHost && !_useLayer;
 
         // Quantized window side (per-window mode); also a harmless notional size in host mode.
         double winNeed = Math.Max(_size, _hitSize) + _winPad * 2;
         _winDim = Math.Ceiling(winNeed / 128.0) * 128.0;
 
-        if (_useHost)
+        if (_useLayer)
+        {
+            // COMPOSITOR-LAYER MODE: no per-bubble Window and no Canvas host child. The WPF _grid
+            // tree still exists and is animated by AnimateFrame (unshown), but its computed visual
+            // state is copied into a BubbleLayer.BubbleItem each frame (SyncLayerItem) and drawn in
+            // Skia on the shared overlay host. Pops come from the global mouse hook exactly like the
+            // Canvas host (UsesHost stays true → the disc snapshot includes this bubble).
+            _window = null;
+            _fxTarget = _grid;
+            _grid.Opacity = _baseOpacity;
+            _grid.Effect = null;
+            _layerItem = BuildLayerItem();
+            s_layer?.Add(_layerItem);
+        }
+        else if (_useHost)
         {
             // SHARED-HOST MODE: no per-bubble Window. The grid is a child of the one
             // ChaosBubbleHostOverlay Canvas, repositioned each frame via Canvas.SetLeft/Top — no
@@ -2916,10 +3055,10 @@ internal class Bubble
             try { _bubbleImage.Effect = new DropShadowEffect { Color = Color.FromRgb(0xFF, 0x8A, 0x14), BlurRadius = 36, ShadowDepth = 0, Opacity = 1.0 }; } catch { }
         }
 
-        // Show + alt-tab hide (per-window mode only — the host is already shown). A recycled shell can be
-        // parked on its previous monitor; reveal chaos bubbles at zero opacity, pin to the target screen
-        // in physical px, then restore opacity, so the first visible frame is on the right monitor.
-        if (!_useHost)
+        // Show + alt-tab hide (per-window mode only — the host/layer is already shown). A recycled shell
+        // can be parked on its previous monitor; reveal chaos bubbles at zero opacity, pin to the target
+        // screen in physical px, then restore opacity, so the first visible frame is on the right monitor.
+        if (!_useHost && !_useLayer)
         {
             if (_spec != null)
             {
@@ -3507,7 +3646,14 @@ internal class Bubble
                 }
             }
             _fxTarget.Opacity = opacity;
-            if (_useHost)
+            if (_useLayer)
+            {
+                // Copy the just-computed visual state onto the compositor draw item (no window, no
+                // Canvas). currentScale/opacity are already applied to the WPF tree above; the rest
+                // (fuse/telegraph/aura/tease/etc.) is read off the elements the animation just wrote.
+                SyncLayerItem(currentScale, opacity, jx, jy);
+            }
+            else if (_useHost)
             {
                 // Cheap Canvas reposition — no SetWindowPos. Grid (_hitSize) centred on the bubble.
                 // PHYSICAL px: the host converts by its own origin/scale (mixed-DPI safe).
@@ -4150,6 +4296,7 @@ internal class Bubble
             var crackBrush = new SolidColorBrush(Color.FromArgb(0xD8, 0xEC, 0xF7, 0xFF));
             crackBrush.Freeze();
             double c = _size / 2.0;
+            var crackPts = new SkiaSharp.SKPoint[3][];   // shared with the compositor layer
             for (int i = 0; i < 3; i++)
             {
                 // Each crack: a jagged 3-segment polyline from near the centre out to the rim.
@@ -4157,19 +4304,24 @@ internal class Bubble
                 double r1 = _size * 0.12, r2 = _size * 0.27, r3 = _size * 0.44;
                 double kink1 = a + (_random.NextDouble() - 0.5) * 0.7;
                 double kink2 = kink1 + (_random.NextDouble() - 0.5) * 0.7;
+                var p0 = new Point(c + Math.Cos(a) * r1, c + Math.Sin(a) * r1);
+                var p1 = new Point(c + Math.Cos(kink1) * r2, c + Math.Sin(kink1) * r2);
+                var p2 = new Point(c + Math.Cos(kink2) * r3, c + Math.Sin(kink2) * r3);
+                crackPts[i] = new[]
+                {
+                    new SkiaSharp.SKPoint((float)p0.X, (float)p0.Y),
+                    new SkiaSharp.SKPoint((float)p1.X, (float)p1.Y),
+                    new SkiaSharp.SKPoint((float)p2.X, (float)p2.Y),
+                };
                 _brittleCracks.Children.Add(new System.Windows.Shapes.Polyline
                 {
-                    Points = new PointCollection
-                    {
-                        new Point(c + Math.Cos(a) * r1,     c + Math.Sin(a) * r1),
-                        new Point(c + Math.Cos(kink1) * r2, c + Math.Sin(kink1) * r2),
-                        new Point(c + Math.Cos(kink2) * r3, c + Math.Sin(kink2) * r3),
-                    },
+                    Points = new PointCollection { p0, p1, p2 },
                     Stroke = crackBrush,
                     StrokeThickness = 1.6,
                     IsHitTestVisible = false,
                 });
             }
+            _crackPts = crackPts;
             _grid.Children.Add(_brittleCracks);
         }
 
@@ -4377,6 +4529,7 @@ internal class Bubble
                     });
                 }
             }
+            _teaseFaceImg = img;   // layer mode reads its current Source each frame for the Skia frame
             face.Children.Add(img);
         }
 
@@ -4504,7 +4657,13 @@ internal class Bubble
         }
         catch { }
 
-        if (_useHost)
+        if (_useLayer)
+        {
+            // Layer mode: drop the draw item (disposes its owned tease frames) — no window, no Canvas child.
+            try { if (_layerItem != null) s_layer?.Remove(_layerItem); } catch { }
+            _layerItem = null;
+        }
+        else if (_useHost)
         {
             // Host mode: pull the grid off the shared Canvas — there's no per-bubble window to recycle.
             try { ChaosBubbleHostOverlay.Remove(_grid); } catch { }

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -1032,7 +1032,16 @@ public class BubbleService : IDisposable
             return new Bubble(screen, _bubbleImage, _random, OnPop, OnMiss, OnDestroy, isClickable);
         return new Bubble(screen, _bubbleImage, _random, onPop: null, onMiss: OnMiss, onDestroy: OnDestroy,
                           isClickable: isClickable, spec: spec,
-                          onBenignPop: b => { AwardAmbientPop(b); try { b.Spec?.Payload?.Fire(); } catch { } },
+                          onBenignPop: b =>
+                          {
+                              AwardAmbientPop(b);
+                              var sw = System.Diagnostics.Stopwatch.StartNew();
+                              try { b.Spec?.Payload?.Fire(); } catch { }
+                              sw.Stop();
+                              if (sw.ElapsedMilliseconds >= 20)
+                                  App.Logger?.Information("[POPLAG] payload {Kind} Fire() took {Ms}ms",
+                                      b.Spec?.Payload?.DisplayName ?? "?", sw.ElapsedMilliseconds);
+                          },
                           forceWindowMode: true);
     }
 

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -639,6 +639,13 @@ public class BubbleService : IDisposable
 
             // 3) the companion pops it — 50% louder, and the benign callback fires the effect payload
             bubble.PopByAvatar(1.5f);
+
+            // 3b) Let the payload's presentation surge settle before going home: the pop fires
+            // burst sparkles + an overlay/flash show, all damaging layered surfaces at once, and
+            // the re-attach then resizes/re-styles the avatar's OWN layered window. That exact
+            // collision produced a captured render-thread deadlock (hang_20260713_110759: render
+            // thread wedged in CWGXBitmapLockState::LockRead) — give the surge a beat to pass.
+            await Task.Delay(2500, ct);
         }
         catch (OperationCanceledException) { /* run ended / shutdown mid-egg */ }
         catch (Exception ex) { App.Logger?.Debug("Avatar bubble egg failed: {E}", ex.Message); }

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -2550,6 +2550,11 @@ internal class Bubble
             DpiScale = (float)_dpiScale,
             SizeDip = _size,
             HitSizeDip = _hitSize,
+            // Seed the spawn position (BubbleItem.Opacity defaults to 1): SyncLayerItem only runs on
+            // the next animate tick, so a compositor frame between Add() and that first sync would
+            // otherwise draw the bubble at (0,0) - a one-frame flash in the top-left corner (#553).
+            CenterXPx = (_posX + _size / 2.0) * _dpiScale,
+            CenterYPx = (_posY + _size / 2.0) * _dpiScale,
             Sprite = Compositor.BubbleLayer.ResolveSprite(_bubbleImage.Source as System.Windows.Media.Imaging.BitmapSource),
             HasTint = hasTint,
             Tint = tint,

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -24,10 +24,10 @@ public class BubbleService : IDisposable
 {
     private const int MAX_BUBBLES = 3;          // per-window fallback cap (SetWindowPos-bound — keep small)
     private const int MAX_BUBBLES_HOST = 40;    // shared-host cap: a dense ambient field is cheap on the Canvas
-    // Trigger/effect bubbles ALWAYS render per-window (forceWindowMode) even with the shared host on,
-    // and each is a WS_EX_LAYERED window repositioned via SetWindowPos every frame. So they must be
-    // capped independently of the (Canvas-cheap) host field cap — otherwise a high trigger chance puts
-    // dozens of layered windows on screen and starves desktop-heap/GPU surfaces (freeze cluster #448/#431).
+    // Trigger/effect bubbles are capped independently of the (Canvas-cheap) host field cap: in the
+    // per-window fallback each is a WS_EX_LAYERED window repositioned via SetWindowPos every frame
+    // (dozens on screen starve desktop-heap/GPU surfaces — freeze cluster #448/#431), and even when
+    // hosted, every pop fires a payload — an uncapped field spams full-screen effects.
     private const int MAX_TRIGGER_WINDOWS = 4;
     /// <summary>Concurrent ambient cap. The per-window path stays at 3 (each move is a SetWindowPos);
     /// the shared-host path repositions via batched Canvas.SetLeft/Top, so it carries a dense field.</summary>
@@ -1030,13 +1030,22 @@ public class BubbleService : IDisposable
     private Bubble CreateAmbientBubble(System.Windows.Forms.Screen screen, bool isClickable)
     {
         var spec = RollTriggerSpec();
-        // Trigger bubbles are per-window layered windows; keep their concurrent count low regardless of
-        // the overall (host-rendered) field cap. Past the ceiling, fall back to a plain bubble so the
-        // dashboard stays lively without a layered-window pileup.
+        // Cap concurrent trigger bubbles regardless of render mode: in per-window fallback each is a
+        // layered window (pileup starves desktop heap — #448/#431), and even hosted, each pop fires a
+        // payload, so an uncapped field spams effects. Past the ceiling, fall back to a plain bubble.
         if (spec != null && _bubbles.Count(b => b.IsAmbientEffectBubble) >= MAX_TRIGGER_WINDOWS)
             spec = null;
         if (spec == null)
             return new Bubble(screen, _bubbleImage, _random, OnPop, OnMiss, OnDestroy, isClickable);
+        // Trigger bubbles ride the shared ambient host like plain bubbles (hook-based pops via the
+        // UsesHost/HostHitClickable snapshots). forceWindowMode was a relic of the host being
+        // chaos-run-only: the per-pop layered-window Show/Close it forced was the residual "small
+        // frame skip on every effect-bubble click", and those topmost windows are exactly the
+        // population the layered-window render deadlock (hang_20260713_110759) lives in. Per-window
+        // is now only the fallback when the host is down or doesn't cover the target screen.
+        bool hostUp = _ambientHost && ChaosBubbleHostOverlay.IsReady
+            && ChaosBubbleHostOverlay.CoversPoint(screen.Bounds.X + screen.Bounds.Width / 2.0,
+                                                  screen.Bounds.Y + screen.Bounds.Height / 2.0);
         return new Bubble(screen, _bubbleImage, _random, onPop: null, onMiss: OnMiss, onDestroy: OnDestroy,
                           isClickable: isClickable, spec: spec,
                           onBenignPop: b =>
@@ -1049,7 +1058,7 @@ public class BubbleService : IDisposable
                                   App.Logger?.Information("[POPLAG] payload {Kind} Fire() took {Ms}ms",
                                       b.Spec?.Payload?.DisplayName ?? "?", sw.ElapsedMilliseconds);
                           },
-                          forceWindowMode: true);
+                          forceWindowMode: !hostUp, ambientTrigger: true);
     }
 
     private void OnMiss(Bubble bubble)
@@ -2530,7 +2539,8 @@ internal class Bubble
                   Action<Bubble>? onTreatExpired = null, Action<Bubble>? onClickPop = null,
                   Func<Bubble, bool>? canChannelDefuse = null, Action<Bubble, string>? onChannelBroken = null,
                   Action<Bubble>? onTeaseTouched = null, Action<Bubble>? onTeaseDenied = null,
-                  Action<Bubble>? onBrittleShattered = null, bool forceWindowMode = false)
+                  Action<Bubble>? onBrittleShattered = null, bool forceWindowMode = false,
+                  bool ambientTrigger = false)
     {
         _random = random;
         _onPop = onPop;
@@ -2609,9 +2619,9 @@ internal class Bubble
         if (spec != null) _speed *= Math.Max(0.1, spec.SpeedMult);   // golden bubbles fly
         if (spec != null) _speed *= ChaosTuning.CHAOS_SPEED_MULT;    // chaos pace bump: travel farther before rotting
         // Dashboard speed slider: up to +500% travel (6x) for the ambient game — BOTH plain and
-        // trigger bubbles — leaving chaos pacing alone (chaos bubbles carry a spec but not
-        // forceWindowMode).
-        if (spec == null || forceWindowMode)
+        // trigger bubbles — leaving chaos pacing alone (chaos bubbles carry a spec but are
+        // never ambientTrigger).
+        if (spec == null || ambientTrigger)
         {
             int speedBoost = App.Settings?.Current?.BubbleSpeedBoost ?? 0;
             if (speedBoost > 0) _speed *= 1.0 + Math.Clamp(speedBoost, 0, 500) / 100.0;
@@ -2809,14 +2819,14 @@ internal class Bubble
         // (recycled hidden shell) rather than newly created — see RentWindow / the pool above.
         // Every per-bubble property below is (re)set on each reuse so a recycled shell carries
         // no state from its previous bubble.
-        // Shared-host A/B (chaos bubbles only): one Canvas host instead of a Window per bubble.
-        // forceWindowMode pins per-window rendering for dashboard trigger bubbles — the shared
-        // ChaosBubbleHostOverlay only exists during a real chaos run.
-        // Chaos effect bubbles ride the host under ChaosBubbleSharedHost; ambient dashboard bubbles
-        // (spec == null) ride it under BubbleSharedHost while the ambient host is standing. Either way
-        // forceWindowMode (dashboard trigger bubbles) pins per-window rendering.
-        bool chaosHost = spec != null && (App.Settings?.Current?.ChaosBubbleSharedHost ?? false);
-        bool ambientHost = spec == null && AmbientHostActive && (App.Settings?.Current?.BubbleSharedHost ?? false);
+        // Shared-host A/B: one Canvas host instead of a Window per bubble.
+        // Chaos effect bubbles ride the host under ChaosBubbleSharedHost; ambient bubbles — plain
+        // (spec == null) AND dashboard trigger bubbles (ambientTrigger) — ride it under
+        // BubbleSharedHost while the ambient host is standing. forceWindowMode pins per-window
+        // rendering: CreateAmbientBubble sets it for a trigger bubble whose target screen the
+        // host can't cover (host down, or spawn on a screen outside its stage bounds).
+        bool chaosHost = spec != null && !ambientTrigger && (App.Settings?.Current?.ChaosBubbleSharedHost ?? false);
+        bool ambientHost = (spec == null || ambientTrigger) && AmbientHostActive && (App.Settings?.Current?.BubbleSharedHost ?? false);
         _useHost = !forceWindowMode && (chaosHost || ambientHost);
 
         // Quantized window side (per-window mode); also a harmless notional size in host mode.

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -2054,8 +2054,7 @@ internal class Bubble
     // compositor's BubbleLayer instead: same hook-pop input contract (UsesHost stays true, hit
     // discs are renderer-agnostic), just Skia draw calls in place of a WPF _grid on a Canvas.
     private static Compositor.BubbleLayer? s_layer;
-    internal static bool UseCompositor =>
-        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+    internal static bool UseCompositor => App.CompositorEnabled;
     /// <summary>Lazily create + register the shared BubbleLayer. Null if the compositor is off.</summary>
     private static Compositor.BubbleLayer? EnsureLayer()
     {

--- a/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
@@ -88,8 +88,22 @@ public static class ChaosSfx
         catch { return scale; }
     }
 
+    // Voice cap: each cue burns a Task.Run thread + its own WaveOutEvent for the clip's
+    // duration. "Fire rarely" stopped holding once chaos pops/subliminal payloads routed
+    // through here — WER dumps 27800 (0xc0000005) and 24012 (0xc0000409) both died with
+    // 6-15 threads inside this method mid audio storm. Excess cues are dropped, not
+    // queued: a one-shot SFX played late is worse than silence.
+    private const int MAX_VOICES = 6;
+    private static int _activeVoices;
+
     private static void PlayAsync(string path, float volume)
     {
+        if (Interlocked.Increment(ref _activeVoices) > MAX_VOICES)
+        {
+            Interlocked.Decrement(ref _activeVoices);
+            App.Logger?.Debug("ChaosSfx: voice cap ({Max}) reached, dropping {Path}", MAX_VOICES, path);
+            return;
+        }
         Task.Run(() =>
         {
             WaveOutEvent? outputDevice = null;
@@ -109,6 +123,7 @@ public static class ChaosSfx
             {
                 try { outputDevice?.Dispose(); } catch { }
                 try { audioFile?.Dispose(); } catch { }
+                Interlocked.Decrement(ref _activeVoices);
             }
         });
     }

--- a/ConditioningControlPanel/Services/Chaos/DtrhAssetManifest.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhAssetManifest.cs
@@ -40,8 +40,17 @@ internal static class DtrhAssetManifest
         try
         {
             var root = App.EffectiveAssetsPath;
-            Collect(Path.Combine(root, "images"), root, isImage: true, m);
-            Collect(Path.Combine(root, "videos"), root, isImage: false, m);
+            // Honor the user's asset selection: items unchecked in the Assets tree land in
+            // DisabledAssetPaths (relative to EffectiveAssetsPath, forward-slashed). The DtRH
+            // game consumed the raw folder before this, so deselected images/videos still fell
+            // through the tube. Match FlashService.GetMediaFiles' normalization exactly
+            // (case-insensitive, separator-agnostic) so the same unchecks that hide a flash
+            // hide it here too.
+            var disabled = new HashSet<string>(
+                (App.Settings?.Current?.DisabledAssetPaths ?? new()).Select(p => p.Replace('\\', '/')),
+                StringComparer.OrdinalIgnoreCase);
+            Collect(Path.Combine(root, "images"), root, isImage: true, m, disabled);
+            Collect(Path.Combine(root, "videos"), root, isImage: false, m, disabled);
 
             int total = m.Images.Count + m.Videos.Count;
             if (total > MaxEntries)
@@ -64,7 +73,7 @@ internal static class DtrhAssetManifest
         return m;
     }
 
-    private static void Collect(string dir, string root, bool isImage, Manifest m)
+    private static void Collect(string dir, string root, bool isImage, Manifest m, HashSet<string> disabled)
     {
         if (!Directory.Exists(dir)) return;
         var exts = isImage ? ImageExts : VideoExts;
@@ -80,6 +89,13 @@ internal static class DtrhAssetManifest
                 // random other junk (txt/db) is silently ignored.
                 if (!otherExts.Contains(ext) && IsMediaLike(ext)) m.Skipped++;
                 continue;
+            }
+            // Deselected in the Assets tree -> not disabled=skip (silently, not "skipped"):
+            // it's user intent, not an unsupported file.
+            if (disabled.Count > 0)
+            {
+                var rel = Path.GetRelativePath(root, f).Replace('\\', '/');
+                if (disabled.Contains(rel)) continue;
             }
             long len;
             try { len = new FileInfo(f).Length; } catch { continue; }

--- a/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
@@ -24,6 +24,25 @@ public abstract class BaseLayer : IWpfLayer
 
     public virtual bool WorldSpacePx => false;
 
+    public virtual bool ShouldRenderOnScreen(System.Drawing.Rectangle screenBoundsPx) => true;
+
+    /// <summary>Shared gate for fullscreen FILL layers (pink/spiral): when the user has multi-monitor
+    /// overlays off, paint only the primary monitor. Compared by origin so a mixed-DPI width/height
+    /// rounding difference can't misidentify the screen. Errs toward showing the effect on any
+    /// enumeration hiccup rather than blanking it.</summary>
+    protected static bool PrimaryOnlyUnlessDualMonitor(System.Drawing.Rectangle screenBoundsPx)
+    {
+        try
+        {
+            if (App.Settings?.Current?.DualMonitorEnabled == true) return true;
+            var primary = System.Windows.Forms.Screen.PrimaryScreen;
+            return primary != null
+                && screenBoundsPx.X == primary.Bounds.X
+                && screenBoundsPx.Y == primary.Bounds.Y;
+        }
+        catch { return true; }
+    }
+
     /// <summary>
     /// Flip layer activity. Safe from any thread; wakes the parked engine so the first frame
     /// renders promptly. The engine invokes OnActivated/OnDeactivated on the UI thread.

--- a/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
@@ -35,10 +35,14 @@ public abstract class BaseLayer : IWpfLayer
         try
         {
             if (App.Settings?.Current?.DualMonitorEnabled == true) return true;
-            var primary = System.Windows.Forms.Screen.PrimaryScreen;
-            return primary != null
-                && screenBoundsPx.X == primary.Bounds.X
-                && screenBoundsPx.Y == primary.Bounds.Y;
+            // Cached lookup: Screen.PrimaryScreen re-enumerates all monitors per call on .NET
+            // Core, and this runs per fill layer per monitor per presented frame.
+            foreach (var s in App.GetAllScreensCached())
+            {
+                if (s.Primary)
+                    return screenBoundsPx.X == s.Bounds.X && screenBoundsPx.Y == s.Bounds.Y;
+            }
+            return true; // empty cache (display transition): err toward showing
         }
         catch { return true; }
     }

--- a/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
@@ -1,0 +1,43 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Convenience base for compositor layers: activity flag with engine wake-up, no-op lifecycle
+/// hooks. Services own the state a layer renders; the layer holds no business logic.
+/// </summary>
+public abstract class BaseLayer : IWpfLayer
+{
+    private readonly CompositorEngine _engine;
+    private volatile bool _isActive;
+
+    protected BaseLayer(CompositorEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public abstract int ZIndex { get; }
+
+    public bool IsActive => _isActive;
+
+    public virtual bool ExcludeFromCapture => false;
+
+    /// <summary>
+    /// Flip layer activity. Safe from any thread; wakes the parked engine so the first frame
+    /// renders promptly. The engine invokes OnActivated/OnDeactivated on the UI thread.
+    /// </summary>
+    protected void SetActive(bool value)
+    {
+        if (_isActive == value) return;
+        _isActive = value;
+        _engine.Wake();
+    }
+
+    public virtual void OnActivated() { }
+
+    public virtual void OnDeactivated() { }
+
+    public virtual void Update(TimeSpan delta) { }
+
+    public abstract void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed);
+}

--- a/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
@@ -41,5 +41,11 @@ public abstract class BaseLayer : IWpfLayer
 
     public virtual void Update(TimeSpan delta) { }
 
+    /// <summary>Default true: repaint every active frame. Slow/static layers (spiral, pink tint)
+    /// override this with real change-tracking to throttle the fullscreen surface re-raster (#550).</summary>
+    public virtual bool Dirty => true;
+
+    public virtual void ClearDirty() { }
+
     public abstract void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed);
 }

--- a/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BaseLayer.cs
@@ -22,6 +22,8 @@ public abstract class BaseLayer : IWpfLayer
 
     public virtual bool ExcludeFromCapture => false;
 
+    public virtual bool WorldSpacePx => false;
+
     /// <summary>
     /// Flip layer activity. Safe from any thread; wakes the parked engine so the first frame
     /// renders promptly. The engine invokes OnActivated/OnDeactivated on the UI thread.

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -37,6 +37,11 @@ public sealed class BrainDrainLayer : BaseLayer
     private TimeSpan _captureInterval = TimeSpan.FromMilliseconds(33);
     private TimeSpan _sinceCapture;
 
+    // Topology drift is rare; checking (and allocating target rects) every capture tick at
+    // 30-60Hz is pure waste. ~1s detection latency on a monitor change is imperceptible.
+    private static readonly TimeSpan DriftCheckInterval = TimeSpan.FromSeconds(1);
+    private TimeSpan _sinceDriftCheck;
+
     public BrainDrainLayer(CompositorEngine engine) : base(engine) { }
 
     public override int ZIndex => CompositorLayers.BrainDrain;
@@ -55,6 +60,7 @@ public sealed class BrainDrainLayer : BaseLayer
         SetIntensity(intensity);
         RebuildCaptures(GetTargetScreens());
         _sinceCapture = _captureInterval; // capture on the very first tick
+        _sinceDriftCheck = TimeSpan.Zero; // captures just rebuilt - no immediate drift check
         SetActive(true);
     }
 
@@ -77,12 +83,17 @@ public sealed class BrainDrainLayer : BaseLayer
     public override void Update(TimeSpan delta)
     {
         _sinceCapture += delta;
+        _sinceDriftCheck += delta;
         if (_sinceCapture < _captureInterval) return;
         _sinceCapture = TimeSpan.Zero;
 
         try
         {
-            EnsureCapturesMatchScreens();
+            if (_sinceDriftCheck >= DriftCheckInterval)
+            {
+                _sinceDriftCheck = TimeSpan.Zero;
+                EnsureCapturesMatchScreens();
+            }
             CapturePass();
         }
         catch (Exception ex)
@@ -108,15 +119,17 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         try
         {
+            var screens = App.GetAllScreensCached(); // Screen.PrimaryScreen re-enumerates per call
             if (App.Settings?.Current?.DualMonitorEnabled == true)
-                return App.GetAllScreensCached().Select(s => s.Bounds).ToArray();
-            var primary = System.Windows.Forms.Screen.PrimaryScreen;
-            return primary != null ? new[] { primary.Bounds } : Array.Empty<System.Drawing.Rectangle>();
+                return screens.Select(s => s.Bounds).ToArray();
+            foreach (var s in screens)
+                if (s.Primary) return new[] { s.Bounds };
+            return Array.Empty<System.Drawing.Rectangle>();
         }
         catch { return Array.Empty<System.Drawing.Rectangle>(); }
     }
 
-    /// <summary>Cheap per-capture-tick drift check so display topology / dual-monitor changes
+    /// <summary>Throttled (~1s) drift check so display topology / dual-monitor changes
     /// mid-run re-target the captures without a restart.</summary>
     private void EnsureCapturesMatchScreens()
     {

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -1,0 +1,284 @@
+using System.Runtime.InteropServices;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the brain-drain blur windows. Per monitor, a GDI StretchBlt shrinks the
+/// screen into a persistent DIB section (1/downscale size), the small frame is blurred ONCE per
+/// capture tick on a small raster surface, and Render just upscales the blurred image over the
+/// monitor - the upscale is part of the blur, exactly like the legacy Image Stretch=Fill path.
+/// Blur radius parity with the legacy WPF BlurEffect: an on-screen radius R renders here as a
+/// source-space gaussian of sigma R/(3*downscale) applied before the xdownscale upscale.
+/// Renders on the capture-EXCLUDED surface (self-capture guard); plain SRCCOPY StretchBlt also
+/// skips layered windows entirely, so other overlays never feed back into the blur (legacy same).
+/// OverlayService owns all intensity/ramp/pulse math and pushes values; this layer only
+/// captures and draws. All methods UI thread (engine tick + OverlayService RunOnUISync).
+/// </summary>
+public sealed class BrainDrainLayer : BaseLayer
+{
+    private sealed class ScreenCapture
+    {
+        public System.Drawing.Rectangle Bounds; // monitor rect, virtual-desktop device px
+        public int W, H;                        // downscaled capture size
+        public IntPtr MemDc, HBitmap, Bits, OldObj;
+        public SKSurface? Surface;              // small blur target
+        public SKImage? Blurred;                // latest blurred frame (drawn by Render)
+    }
+
+    private readonly List<ScreenCapture> _captures = new();
+    private readonly SKPaint _blurPaint = new();
+    private readonly SKPaint _drawPaint = new() { FilterQuality = SKFilterQuality.Low }; // bilinear = WPF Image default
+    private SKImageFilter? _blurFilter;
+    private float _lastSigma = -1f;
+
+    private int _downscale = 4;
+    private double _screenRadius;               // WPF-BlurEffect-equivalent on-screen radius
+    private TimeSpan _captureInterval = TimeSpan.FromMilliseconds(33);
+    private TimeSpan _sinceCapture;
+
+    public BrainDrainLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.BrainDrain;
+    public override bool ExcludeFromCapture => true;
+    public override bool WorldSpacePx => true;
+
+    /// <summary>Start capturing + blurring at the given intensity (legacy 1..200 scale).</summary>
+    public void Start(int intensity)
+    {
+        var settings = App.Settings?.Current;
+        var tier = PerformanceProfile.CurrentTier;
+        _downscale = PerformanceProfile.BrainDrainDownscale(tier);
+        int fps = Math.Min(settings?.BrainDrainHighRefresh == true ? 60 : 30,
+                           PerformanceProfile.BrainDrainFps(tier));
+        _captureInterval = TimeSpan.FromMilliseconds(1000.0 / Math.Max(1, fps));
+        SetIntensity(intensity);
+        RebuildCaptures(GetTargetScreens());
+        _sinceCapture = _captureInterval; // capture on the very first tick
+        SetActive(true);
+    }
+
+    public void Stop()
+    {
+        SetActive(false);
+        ReleaseCaptures();
+    }
+
+    /// <summary>Normal/ramp/restore path - legacy on-screen radius is intensity*0.4/downscale
+    /// (the WPF BlurEffect radius was tuned against the downscaled source).</summary>
+    public void SetIntensity(int intensity) => _screenRadius = intensity * 0.4 / Math.Max(1, _downscale);
+
+    /// <summary>Pulse boost - legacy PulseOverlays sets the raw radius boosted*0.4 with NO
+    /// downscale divide (deliberately much heavier than the steady state).</summary>
+    public void Pulse(int boostedIntensity) => _screenRadius = boostedIntensity * 0.4;
+
+    public override void OnDeactivated() => ReleaseCaptures();
+
+    public override void Update(TimeSpan delta)
+    {
+        _sinceCapture += delta;
+        if (_sinceCapture < _captureInterval) return;
+        _sinceCapture = TimeSpan.Zero;
+
+        try
+        {
+            EnsureCapturesMatchScreens();
+            CapturePass();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("BrainDrainLayer capture failed: {Error}", ex.Message);
+        }
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        // World-space: boundsPx is this monitor's rect; draw only its own capture.
+        int cx = (boundsPx.Left + boundsPx.Right) / 2, cy = (boundsPx.Top + boundsPx.Bottom) / 2;
+        foreach (var c in _captures)
+        {
+            if (c.Blurred == null || !c.Bounds.Contains(cx, cy)) continue;
+            canvas.DrawImage(c.Blurred,
+                new SKRect(c.Bounds.X, c.Bounds.Y, c.Bounds.Right, c.Bounds.Bottom), _drawPaint);
+            return;
+        }
+    }
+
+    private static System.Drawing.Rectangle[] GetTargetScreens()
+    {
+        try
+        {
+            if (App.Settings?.Current?.DualMonitorEnabled == true)
+                return App.GetAllScreensCached().Select(s => s.Bounds).ToArray();
+            var primary = System.Windows.Forms.Screen.PrimaryScreen;
+            return primary != null ? new[] { primary.Bounds } : Array.Empty<System.Drawing.Rectangle>();
+        }
+        catch { return Array.Empty<System.Drawing.Rectangle>(); }
+    }
+
+    /// <summary>Cheap per-capture-tick drift check so display topology / dual-monitor changes
+    /// mid-run re-target the captures without a restart.</summary>
+    private void EnsureCapturesMatchScreens()
+    {
+        var screens = GetTargetScreens();
+        if (screens.Length == 0) return; // display transition - keep last frames
+        if (screens.Length == _captures.Count)
+        {
+            bool same = true;
+            for (int i = 0; i < screens.Length; i++)
+                if (_captures[i].Bounds != screens[i]) { same = false; break; }
+            if (same) return;
+        }
+        RebuildCaptures(screens);
+    }
+
+    private void RebuildCaptures(System.Drawing.Rectangle[] screens)
+    {
+        ReleaseCaptures();
+        foreach (var bounds in screens)
+        {
+            var c = CreateCapture(bounds);
+            if (c != null) _captures.Add(c);
+        }
+    }
+
+    private ScreenCapture? CreateCapture(System.Drawing.Rectangle bounds)
+    {
+        int divisor = Math.Max(1, _downscale);
+        int dw = Math.Max(2, (bounds.Width / divisor) & ~1);
+        int dh = Math.Max(2, (bounds.Height / divisor) & ~1);
+
+        var memDc = CreateCompatibleDC(IntPtr.Zero);
+        if (memDc == IntPtr.Zero) return null;
+
+        var bmi = new BITMAPINFOHEADER
+        {
+            biSize = Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = dw,
+            biHeight = -dh, // top-down so the pixel pointer reads row 0 first
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0, // BI_RGB
+        };
+        var hBitmap = CreateDIBSection(memDc, ref bmi, 0 /*DIB_RGB_COLORS*/, out var bits, IntPtr.Zero, 0);
+        if (hBitmap == IntPtr.Zero || bits == IntPtr.Zero)
+        {
+            DeleteDC(memDc);
+            return null;
+        }
+
+        return new ScreenCapture
+        {
+            Bounds = bounds,
+            W = dw,
+            H = dh,
+            MemDc = memDc,
+            HBitmap = hBitmap,
+            Bits = bits,
+            OldObj = SelectObject(memDc, hBitmap),
+            Surface = SKSurface.Create(new SKImageInfo(dw, dh, SKColorType.Bgra8888, SKAlphaType.Premul)),
+        };
+    }
+
+    private void CapturePass()
+    {
+        if (_captures.Count == 0) return;
+
+        // Rebuild the blur filter only when the radius actually changed.
+        float sigma = (float)(_screenRadius / (3.0 * Math.Max(1, _downscale)));
+        if (Math.Abs(sigma - _lastSigma) > 0.01f)
+        {
+            _lastSigma = sigma;
+            _blurFilter?.Dispose();
+            _blurFilter = sigma > 0.05f ? SKImageFilter.CreateBlur(sigma, sigma) : null;
+            _blurPaint.ImageFilter = _blurFilter;
+        }
+
+        var screenDc = GetDC(IntPtr.Zero);
+        if (screenDc == IntPtr.Zero) return;
+        try
+        {
+            foreach (var c in _captures)
+            {
+                if (c.Surface == null) continue;
+                SetStretchBltMode(c.MemDc, HALFTONE);
+                if (!StretchBlt(c.MemDc, 0, 0, c.W, c.H,
+                                screenDc, c.Bounds.X, c.Bounds.Y, c.Bounds.Width, c.Bounds.Height, SRCCOPY))
+                    continue;
+                GdiFlush();
+
+                var info = new SKImageInfo(c.W, c.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
+                using var raw = SKImage.FromPixels(info, c.Bits, c.W * 4); // zero-copy wrap; consumed synchronously below
+                if (raw == null) continue;
+
+                var canvas = c.Surface.Canvas;
+                canvas.Clear(SKColors.Transparent);
+                canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
+                c.Blurred?.Dispose();
+                c.Blurred = c.Surface.Snapshot();
+            }
+        }
+        finally
+        {
+            ReleaseDC(IntPtr.Zero, screenDc);
+        }
+    }
+
+    private void ReleaseCaptures()
+    {
+        foreach (var c in _captures)
+        {
+            try
+            {
+                c.Blurred?.Dispose();
+                c.Surface?.Dispose();
+                if (c.MemDc != IntPtr.Zero)
+                {
+                    if (c.OldObj != IntPtr.Zero) SelectObject(c.MemDc, c.OldObj);
+                    DeleteDC(c.MemDc);
+                }
+                if (c.HBitmap != IntPtr.Zero) DeleteObject(c.HBitmap);
+            }
+            catch { /* GDI cleanup best-effort */ }
+        }
+        _captures.Clear();
+    }
+
+    #region Win32
+
+    private const int SRCCOPY = 0x00CC0020;
+    private const int HALFTONE = 4;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFOHEADER
+    {
+        public int biSize;
+        public int biWidth;
+        public int biHeight;
+        public short biPlanes;
+        public short biBitCount;
+        public int biCompression;
+        public int biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public int biClrUsed;
+        public int biClrImportant;
+    }
+
+    [DllImport("user32.dll")] private static extern IntPtr GetDC(IntPtr hwnd);
+    [DllImport("user32.dll")] private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern bool DeleteDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr SelectObject(IntPtr hdc, IntPtr obj);
+    [DllImport("gdi32.dll")] private static extern bool DeleteObject(IntPtr obj);
+    [DllImport("gdi32.dll")] private static extern bool GdiFlush();
+    [DllImport("gdi32.dll")] private static extern int SetStretchBltMode(IntPtr hdc, int mode);
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFOHEADER pbmi, uint usage,
+        out IntPtr ppvBits, IntPtr hSection, uint offset);
+    [DllImport("gdi32.dll")]
+    private static extern bool StretchBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest,
+        IntPtr hdcSrc, int xSrc, int ySrc, int wSrc, int hSrc, int rop);
+
+    #endregion
+}

--- a/ConditioningControlPanel/Services/Compositor/BubbleLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BubbleLayer.cs
@@ -66,6 +66,36 @@ public sealed class BubbleLayer : BaseLayer
     private static readonly SKTypeface _bold = SKTypeface.FromFamilyName("Segoe UI", SKFontStyle.Bold)
         ?? SKTypeface.FromFamilyName(null, SKFontStyle.Bold);
 
+    // Shield dash effect cache, keyed on quantized DPI scale (the only input) - a handful of
+    // entries max (one per monitor scale). Disposed on Clear; rebuilt lazily.
+    private readonly Dictionary<float, SKPathEffect> _dashCache = new();
+
+    private SKPathEffect GetDash(float scale)
+    {
+        float q = MathF.Round(scale * 4f) / 4f;
+        if (!_dashCache.TryGetValue(q, out var fx))
+        {
+            fx = SKPathEffect.CreateDash(new[] { 3f * q, 2f * q }, 0);
+            _dashCache[q] = fx;
+        }
+        return fx;
+    }
+
+    /// <summary>Rebuild a cached blur mask filter only when the quantized sigma moves - the
+    /// FlashLayer.BlurCache pattern; churning native blur filters per bubble per frame is the
+    /// expensive part, and every sigma here derives from spawn constants + DPI.</summary>
+    private static SKMaskFilter GetCachedBlur(ref SKMaskFilter? cache, ref float cachedSigma, float sigma)
+    {
+        float q = MathF.Round(sigma * 2f) / 2f;
+        if (cache == null || Math.Abs(q - cachedSigma) > 0.01f)
+        {
+            cache?.Dispose();
+            cache = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, Math.Max(0.5f, q));
+            cachedSigma = q;
+        }
+        return cache;
+    }
+
     public BubbleItem Add(BubbleItem item)
     {
         _items.Add(item);
@@ -76,14 +106,21 @@ public sealed class BubbleLayer : BaseLayer
     public void Remove(BubbleItem item)
     {
         item.ReleaseTeaseFrames();
+        item.ReleaseEffectCaches();
         _items.Remove(item);
         if (_items.Count == 0) SetActive(false);
     }
 
     public void Clear()
     {
-        foreach (var it in _items) it.ReleaseTeaseFrames();
+        foreach (var it in _items)
+        {
+            it.ReleaseTeaseFrames();
+            it.ReleaseEffectCaches();
+        }
         _items.Clear();
+        foreach (var fx in _dashCache.Values) { try { fx.Dispose(); } catch { } }
+        _dashCache.Clear();
         SetActive(false);
     }
 
@@ -123,10 +160,9 @@ public sealed class BubbleLayer : BaseLayer
             if (item.HasGlow)
             {
                 float sigma = Math.Max(0.5f, item.GlowBlurDip * s / 3f);   // WPF blurRadius/3 convention
-                _glow.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, sigma);
+                _glow.MaskFilter = GetCachedBlur(ref item.GlowBlurCache, ref item.GlowBlurCacheSigma, sigma);
                 _glow.Color = item.GlowColor.WithAlpha((byte)(item.GlowOpacity * item.Opacity * 255f));
                 canvas.DrawCircle(cx, cy, half, _glow);
-                _glow.MaskFilter?.Dispose();
                 _glow.MaskFilter = null;
             }
 
@@ -233,10 +269,9 @@ public sealed class BubbleLayer : BaseLayer
                 _text.TextSize = item.LabelFontDip * s;
                 // Soft shadow (BlurRadius 6 -> sigma 2) then the white glyph.
                 _text.Color = SKColors.Black.WithAlpha((byte)(0.8f * item.Opacity * 255f));
-                _text.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 2f * s);
+                _text.MaskFilter = GetCachedBlur(ref item.LabelBlurCache, ref item.LabelBlurCacheSigma, 2f * s);
                 float baseline = cy + _text.TextSize * 0.35f;
                 canvas.DrawText(item.Label, cx, baseline, _text);
-                _text.MaskFilter?.Dispose();
                 _text.MaskFilter = null;
                 _text.Color = SKColors.White.WithAlpha(ga);
                 canvas.DrawText(item.Label, cx, baseline, _text);
@@ -264,9 +299,8 @@ public sealed class BubbleLayer : BaseLayer
                 float shr = (item.SizeDip + 12f) * 0.5f * s;
                 _stroke.Color = new SKColor(0x9C, 0xE8, 0xFF, (byte)(item.ShieldOpacity * item.Opacity * 255f));
                 _stroke.StrokeWidth = 3.5f * s;
-                _stroke.PathEffect = SKPathEffect.CreateDash(new[] { 3f * s, 2f * s }, 0);
+                _stroke.PathEffect = GetDash(s);
                 canvas.DrawCircle(cx, cy, shr, _stroke);
-                _stroke.PathEffect?.Dispose();
                 _stroke.PathEffect = null;
             }
 
@@ -312,10 +346,9 @@ public sealed class BubbleLayer : BaseLayer
         _fill.Color = new SKColor(0x12, 0x0A, 0x18, (byte)(0xA0 / 255f * alpha * 255f));
         canvas.DrawRoundRect(new SKRoundRect(pill, 9f * s, 9f * s), _fill);
         _text.Color = SKColors.Black.WithAlpha((byte)(0.9f * alpha * 255f));
-        _text.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 1.7f * s);
+        _text.MaskFilter = GetCachedBlur(ref item.HintBlurCache, ref item.HintBlurCacheSigma, 1.7f * s);
         float baseline = py + th * 0.35f;
         canvas.DrawText(item.HintText, cx, baseline, _text);
-        _text.MaskFilter?.Dispose();
         _text.MaskFilter = null;
         _text.Color = new SKColor(0xFF, 0xE2, 0xF2, (byte)(alpha * 255f));
         canvas.DrawText(item.HintText, cx, baseline, _text);
@@ -384,6 +417,24 @@ public sealed class BubbleLayer : BaseLayer
         public float ShieldOpacity;
         public float PrismOpacity;
         public float HintOpacity;
+
+        // Cached blur mask filters (FlashLayer.BlurCache pattern): each sigma derives from
+        // spawn constants + DPI, so these build once per item instead of per frame. Owned by
+        // the item; disposed via ReleaseEffectCaches on Remove/Clear (safe even in off-thread
+        // mode - an in-flight SKPicture holds its own native ref on anything drawn into it).
+        internal SKMaskFilter? GlowBlurCache;
+        internal float GlowBlurCacheSigma = -1f;
+        internal SKMaskFilter? LabelBlurCache;
+        internal float LabelBlurCacheSigma = -1f;
+        internal SKMaskFilter? HintBlurCache;
+        internal float HintBlurCacheSigma = -1f;
+
+        internal void ReleaseEffectCaches()
+        {
+            GlowBlurCache?.Dispose(); GlowBlurCache = null; GlowBlurCacheSigma = -1f;
+            LabelBlurCache?.Dispose(); LabelBlurCache = null; LabelBlurCacheSigma = -1f;
+            HintBlurCache?.Dispose(); HintBlurCache = null; HintBlurCacheSigma = -1f;
+        }
 
         // Tease frame: the WPF face Image's current Source (animated webp/gif frame or a still),
         // converted to an owned SKImage lazily and cached per source so repeated frames reuse.

--- a/ConditioningControlPanel/Services/Compositor/BubbleLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BubbleLayer.cs
@@ -1,0 +1,431 @@
+using System.Windows.Media.Imaging;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the ambient "Bubble Pop" field AND the chaos "Down the Rabbit Hole"
+/// bubbles. Like <see cref="FlashLayer"/> this is a pure DRAW LIST: BubbleService's existing
+/// 31Hz animation tick keeps driving every bubble's physics, fuse, danger ramp and variant
+/// animation through the (unshown) WPF <c>_grid</c> tree, then copies the COMPUTED visual
+/// state into a <see cref="BubbleItem"/> once per frame (Bubble.SyncLayerItem). So motion,
+/// lifetime, hydra, hit-testing and every variant's animation are identical by construction -
+/// the shared-Canvas host (<see cref="ChaosBubbleHostOverlay"/>) rendered the same WPF tree;
+/// this renders its state to Skia instead, killing the last per-effect layered surface.
+///
+/// Input is renderer-agnostic: the hook-pop path (BubbleService.OnSharedHostLeftDown /
+/// ChaosClickDiscsSnapshot) keys off <c>_posX/_size/_dpiScale</c>, not the host, so layer
+/// bubbles are popped by the SAME global hook with NO new hit-testing here (Bubble.UsesHost
+/// reports true for layer bubbles so they enter the disc snapshot).
+///
+/// World-space layer (<see cref="WorldSpacePx"/>): item geometry is virtual-desktop DEVICE px
+/// (center + dpi-scaled sizes), exactly the physical-px currency the hit discs already use, so
+/// it stays correct on mixed-DPI multi-monitor setups without the Canvas host's single-scale
+/// LayoutTransform compensation.
+///
+/// Threading: every member is UI-thread only (BubbleService spawn/animate/destroy and the
+/// engine tick all run on the dispatcher), so items need no locking. Base sprites are shared,
+/// immutable, never-freed SKImages (decode-once cache); per-bubble tease frames are owned by
+/// the item and disposed on <see cref="Remove"/>.
+/// </summary>
+public sealed class BubbleLayer : BaseLayer
+{
+    // Decode-once cache for the shared base sprites (bubble.png + the variant sprites from
+    // ChaosArt). Keyed by the frozen WPF BitmapSource (ChaosArt hands out one shared frozen
+    // source per file), so a whole field of one variant shares a single SKImage. Never disposed
+    // - immutable, app-lifetime handles, safe to draw from any tick (same never-freed invariant
+    // as the Avalonia BubbleLayer's _bubbleImage; a mutable/disposed shared SKImage would be a
+    // use-after-free heap-corruption class).
+    private static readonly Dictionary<BitmapSource, SKImage> _spriteCache = new();
+
+    public BubbleLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.Bubbles;
+    public override bool WorldSpacePx => true;
+
+    /// <summary>Convert a (frozen) sprite source to a cached, never-freed SKImage. Null for the
+    /// DrawingImage fallback (no bitmap) -> the layer draws a soft circle instead.</summary>
+    public static SKImage? ResolveSprite(BitmapSource? source)
+    {
+        if (source == null) return null;
+        if (_spriteCache.TryGetValue(source, out var img)) return img;
+        try { img = SkiaWpfInterop.ToSKImage(source); }
+        catch { return null; }
+        _spriteCache[source] = img;
+        return img;
+    }
+
+    private readonly List<BubbleItem> _items = new();
+
+    // Reused paints - no per-frame native churn. UI-thread single-writer (Render only).
+    private readonly SKPaint _img = new() { IsAntialias = true, FilterQuality = SKFilterQuality.Medium };
+    private readonly SKPaint _fill = new() { IsAntialias = true };
+    private readonly SKPaint _stroke = new() { IsAntialias = true, Style = SKPaintStyle.Stroke };
+    private readonly SKPaint _glow = new() { IsAntialias = true };
+    private readonly SKPaint _text = new() { IsAntialias = true, TextAlign = SKTextAlign.Center };
+    private static readonly SKTypeface _bold = SKTypeface.FromFamilyName("Segoe UI", SKFontStyle.Bold)
+        ?? SKTypeface.FromFamilyName(null, SKFontStyle.Bold);
+
+    public BubbleItem Add(BubbleItem item)
+    {
+        _items.Add(item);
+        SetActive(true);
+        return item;
+    }
+
+    public void Remove(BubbleItem item)
+    {
+        item.ReleaseTeaseFrames();
+        _items.Remove(item);
+        if (_items.Count == 0) SetActive(false);
+    }
+
+    public void Clear()
+    {
+        foreach (var it in _items) it.ReleaseTeaseFrames();
+        _items.Clear();
+        SetActive(false);
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        for (int i = 0; i < _items.Count; i++)
+        {
+            var item = _items[i];
+            if (item.Opacity <= 0.003f) continue;
+
+            float s = item.DpiScale;
+            float cx = (float)item.CenterXPx, cy = (float)item.CenterYPx;
+            // Generous cull radius: body scaled up on pop + glow/telegraph reach.
+            float reach = (Math.Max(item.SizeDip, item.HitSizeDip) * Math.Max(1f, item.Scale) * 0.75f
+                           + item.GlowBlurDip + 20f) * s;
+            if (cx + reach < boundsPx.Left || cx - reach > boundsPx.Right
+                || cy + reach < boundsPx.Top || cy - reach > boundsPx.Bottom) continue;
+
+            byte ga = (byte)Math.Clamp(item.Opacity * 255f, 0, 255);   // group alpha
+            float half = item.SizeDip * 0.5f * s;                      // body radius (unscaled) in px
+
+            // ---- Freeze aura (behind everything): icy-blue ring-glow radial ----
+            if (item.FreezeAuraOpacity > 0.003f)
+            {
+                float ar = (item.SizeDip + 6f) * 0.5f * s;
+                using var sh = SKShader.CreateRadialGradient(
+                    new SKPoint(cx, cy), ar,
+                    new[] { new SKColor(150, 210, 255, 0), new SKColor(150, 210, 255, 190), new SKColor(150, 210, 255, 0) },
+                    new[] { 0.30f, 0.66f, 1f }, SKShaderTileMode.Clamp);
+                _fill.Shader = sh;
+                _fill.Color = SKColors.White.WithAlpha((byte)(item.FreezeAuraOpacity * item.Opacity * 255f));
+                canvas.DrawCircle(cx, cy, ar, _fill);
+                _fill.Shader = null;
+            }
+
+            // ---- Glow halo (DropShadow depth-0 equivalent): spotlight/golden/darter/brittle ----
+            if (item.HasGlow)
+            {
+                float sigma = Math.Max(0.5f, item.GlowBlurDip * s / 3f);   // WPF blurRadius/3 convention
+                _glow.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, sigma);
+                _glow.Color = item.GlowColor.WithAlpha((byte)(item.GlowOpacity * item.Opacity * 255f));
+                canvas.DrawCircle(cx, cy, half, _glow);
+                _glow.MaskFilter?.Dispose();
+                _glow.MaskFilter = null;
+            }
+
+            // ---- Prism/brittle mimic ghost (revealed on pop; sits just under the sprite) ----
+            if (item.PrismGhost != null && item.PrismOpacity > 0.003f)
+            {
+                float gr = item.SizeDip * 0.9f * 0.5f * s;
+                float gy = cy + 14f * s;   // WPF Margin(0,14,0,0): peeks from under the burst
+                var dst = new SKRect(cx - gr, gy - gr, cx + gr, gy + gr);
+                _img.Color = SKColors.White.WithAlpha((byte)(item.PrismOpacity * item.Opacity * 255f));
+                canvas.DrawImage(item.PrismGhost, Fit(item.PrismGhost, dst), _img);
+            }
+
+            // ---- Base sprite (scaled + rotated about center) ----
+            int saved = canvas.Save();
+            if (item.Scale != 1f || item.Angle != 0f)
+            {
+                canvas.Translate(cx, cy);
+                if (item.Angle != 0f) canvas.RotateDegrees(item.Angle);
+                if (item.Scale != 1f) canvas.Scale(item.Scale, item.Scale);
+                canvas.Translate(-cx, -cy);
+            }
+            var body = new SKRect(cx - half, cy - half, cx + half, cy + half);
+            if (item.Sprite != null)
+            {
+                _img.Color = SKColors.White.WithAlpha(ga);
+                canvas.DrawImage(item.Sprite, Fit(item.Sprite, body), _img);
+            }
+            else
+            {
+                // No bitmap (DrawingImage fallback): soft tinted circle so the field is playable.
+                var fb = item.HasTint ? item.Tint : new SKColor(0xE8, 0xE8, 0xF0);
+                _fill.Color = fb.WithAlpha(ga);
+                canvas.DrawCircle(cx, cy, half, _fill);
+                _stroke.Color = SKColors.White.WithAlpha((byte)(ga * 0.8f));
+                _stroke.StrokeWidth = 2f * s;
+                canvas.DrawCircle(cx, cy, half, _stroke);
+            }
+            canvas.RestoreToCount(saved);
+
+            // ---- Glassy specular shine (chaos plain bubbles) ----
+            if (item.HasShine)
+            {
+                float sr = item.SizeDip * 0.32f * s;
+                var sc = new SKPoint(cx + (0.34f - 0.5f) * item.SizeDip * s, cy + (0.27f - 0.5f) * item.SizeDip * s);
+                using var sh = SKShader.CreateRadialGradient(sc, sr,
+                    new[] { new SKColor(255, 255, 255, 190), new SKColor(255, 255, 255, 70), new SKColor(255, 255, 255, 0) },
+                    new[] { 0f, 0.5f, 1f }, SKShaderTileMode.Clamp);
+                _fill.Shader = sh;
+                _fill.Color = SKColors.White.WithAlpha(ga);
+                canvas.DrawCircle(sc.X, sc.Y, sr, _fill);
+                _fill.Shader = null;
+            }
+
+            // ---- Tint overlay (radial; chaos non-variant bubbles) ----
+            if (item.HasTint)
+            {
+                var tc = new SKPoint(cx + (0.35f - 0.5f) * item.SizeDip * s, cy + (0.30f - 0.5f) * item.SizeDip * s);
+                using var sh = SKShader.CreateRadialGradient(tc, half,
+                    new[] { item.Tint.WithAlpha(150), item.Tint.WithAlpha(90) },
+                    new[] { 0f, 1f }, SKShaderTileMode.Clamp);
+                _fill.Shader = sh;
+                _fill.Color = SKColors.White.WithAlpha((byte)(0.55f * item.Opacity * 255f));
+                canvas.DrawCircle(cx, cy, half, _fill);
+                _fill.Shader = null;
+            }
+
+            // ---- Tease face (dark disc + clipped current frame + diagonal shine) ----
+            if (item.IsTease)
+            {
+                float ir = item.TeaseInnerDip * 0.5f * s;
+                int tsave = canvas.Save();
+                canvas.ClipRoundRect(new SKRoundRect(new SKRect(cx - ir, cy - ir, cx + ir, cy + ir), ir, ir), antialias: true);
+                _fill.Color = new SKColor(0x14, 0x07, 0x0C, ga);
+                canvas.DrawCircle(cx, cy, ir, _fill);
+                var frame = item.CurrentTeaseFrame();
+                if (frame != null)
+                {
+                    _img.Color = SKColors.White.WithAlpha((byte)(0.92f * item.Opacity * 255f));
+                    canvas.DrawImage(frame, FillFit(frame, new SKRect(cx - ir, cy - ir, cx + ir, cy + ir)), _img);
+                }
+                if (item.TeaseShineOpacity > 0.003f)
+                {
+                    // Diagonal white->transparent linear shine (35 deg).
+                    float rad = 35f * (float)Math.PI / 180f;
+                    var dir = new SKPoint((float)Math.Cos(rad), (float)Math.Sin(rad));
+                    using var sh = SKShader.CreateLinearGradient(
+                        new SKPoint(cx - ir * dir.X, cy - ir * dir.Y),
+                        new SKPoint(cx + ir * dir.X, cy + ir * dir.Y),
+                        new[] { new SKColor(255, 255, 255, 150), new SKColor(255, 255, 255, 0) },
+                        SKShaderTileMode.Clamp);
+                    _fill.Shader = sh;
+                    _fill.Color = SKColors.White.WithAlpha((byte)(item.TeaseShineOpacity * item.Opacity * 255f));
+                    canvas.DrawCircle(cx, cy, ir, _fill);
+                    _fill.Shader = null;
+                }
+                canvas.RestoreToCount(tsave);
+            }
+
+            // ---- Label / emoji glyph ----
+            if (!string.IsNullOrEmpty(item.Label))
+            {
+                _text.Typeface = _bold;
+                _text.TextSize = item.LabelFontDip * s;
+                // Soft shadow (BlurRadius 6 -> sigma 2) then the white glyph.
+                _text.Color = SKColors.Black.WithAlpha((byte)(0.8f * item.Opacity * 255f));
+                _text.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 2f * s);
+                float baseline = cy + _text.TextSize * 0.35f;
+                canvas.DrawText(item.Label, cx, baseline, _text);
+                _text.MaskFilter?.Dispose();
+                _text.MaskFilter = null;
+                _text.Color = SKColors.White.WithAlpha(ga);
+                canvas.DrawText(item.Label, cx, baseline, _text);
+            }
+
+            // ---- Fuse ring (live): 3-phase colour, shrinking radius ----
+            if (item.FuseOpacity > 0.003f)
+            {
+                _stroke.Color = item.FuseColor.WithAlpha((byte)(item.FuseOpacity * item.Opacity * 255f));
+                _stroke.StrokeWidth = 5f * s;
+                canvas.DrawCircle(cx, cy, half * item.FuseScale, _stroke);
+            }
+
+            // ---- Echo ghost ring (offset outline) ----
+            if (item.IsEcho)
+            {
+                _stroke.Color = item.EchoColor.WithAlpha((byte)(item.EchoColor.Alpha * item.Opacity));
+                _stroke.StrokeWidth = 3f * s;
+                canvas.DrawCircle(cx + 5f * s, cy + 4f * s, half, _stroke);
+            }
+
+            // ---- Chaperone shield (dashed icy ring) ----
+            if (item.ShieldOpacity > 0.003f)
+            {
+                float shr = (item.SizeDip + 12f) * 0.5f * s;
+                _stroke.Color = new SKColor(0x9C, 0xE8, 0xFF, (byte)(item.ShieldOpacity * item.Opacity * 255f));
+                _stroke.StrokeWidth = 3.5f * s;
+                _stroke.PathEffect = SKPathEffect.CreateDash(new[] { 3f * s, 2f * s }, 0);
+                canvas.DrawCircle(cx, cy, shr, _stroke);
+                _stroke.PathEffect?.Dispose();
+                _stroke.PathEffect = null;
+            }
+
+            // ---- Brittle cracks (jagged glass lines) ----
+            if (item.Cracks != null && item.BrittleOpacity > 0.003f)
+            {
+                _stroke.Color = new SKColor(0xEC, 0xF7, 0xFF, (byte)(0xD8 / 255f * item.BrittleOpacity * item.Opacity * 255f));
+                _stroke.StrokeWidth = 1.6f * s;
+                float bx = cx - half, by = cy - half;   // crack pts are DIP in the 0.._size box
+                foreach (var line in item.Cracks)
+                {
+                    using var path = new SKPath();
+                    path.MoveTo(bx + line[0].X * s, by + line[0].Y * s);
+                    for (int k = 1; k < line.Length; k++) path.LineTo(bx + line[k].X * s, by + line[k].Y * s);
+                    canvas.DrawPath(path, _stroke);
+                }
+            }
+
+            // ---- Darter telegraph ring (flares down to lock-on) ----
+            if (item.TelegraphOpacity > 0.003f)
+            {
+                _stroke.Color = item.Tint.WithAlpha((byte)(item.TelegraphOpacity * item.Opacity * 255f));
+                _stroke.StrokeWidth = 4f * s;
+                canvas.DrawCircle(cx, cy, half * item.TelegraphScale, _stroke);
+            }
+
+            // ---- First-contact verb-hint pill (below the bubble) ----
+            if (!string.IsNullOrEmpty(item.HintText) && item.HintOpacity > 0.003f)
+                DrawHint(canvas, item, cx, cy, s);
+        }
+    }
+
+    private void DrawHint(SKCanvas canvas, BubbleItem item, float cx, float cy, float s)
+    {
+        float alpha = item.HintOpacity * item.Opacity;
+        _text.Typeface = _bold;
+        _text.TextSize = 12.5f * s;
+        float tw = _text.MeasureText(item.HintText);
+        float padX = 8f * s, padY = 3f * s;
+        float th = _text.TextSize;
+        float py = cy + item.HintYOffDip * s;
+        var pill = new SKRect(cx - tw / 2f - padX, py - th / 2f - padY, cx + tw / 2f + padX, py + th / 2f + padY);
+        _fill.Color = new SKColor(0x12, 0x0A, 0x18, (byte)(0xA0 / 255f * alpha * 255f));
+        canvas.DrawRoundRect(new SKRoundRect(pill, 9f * s, 9f * s), _fill);
+        _text.Color = SKColors.Black.WithAlpha((byte)(0.9f * alpha * 255f));
+        _text.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 1.7f * s);
+        float baseline = py + th * 0.35f;
+        canvas.DrawText(item.HintText, cx, baseline, _text);
+        _text.MaskFilter?.Dispose();
+        _text.MaskFilter = null;
+        _text.Color = new SKColor(0xFF, 0xE2, 0xF2, (byte)(alpha * 255f));
+        canvas.DrawText(item.HintText, cx, baseline, _text);
+    }
+
+    /// <summary>Uniform (letterbox) fit of an image into a square dest - matches Stretch.Uniform.</summary>
+    private static SKRect Fit(SKImage img, SKRect dest)
+    {
+        if (img.Width <= 0 || img.Height <= 0) return dest;
+        float r = Math.Min(dest.Width / img.Width, dest.Height / img.Height);
+        float w = img.Width * r, h = img.Height * r;
+        float x = dest.MidX - w / 2f, y = dest.MidY - h / 2f;
+        return new SKRect(x, y, x + w, y + h);
+    }
+
+    /// <summary>UniformToFill fit (cover) - the clip handles overflow. Matches Stretch.UniformToFill.</summary>
+    private static SKRect FillFit(SKImage img, SKRect dest)
+    {
+        if (img.Width <= 0 || img.Height <= 0) return dest;
+        float r = Math.Max(dest.Width / img.Width, dest.Height / img.Height);
+        float w = img.Width * r, h = img.Height * r;
+        float x = dest.MidX - w / 2f, y = dest.MidY - h / 2f;
+        return new SKRect(x, y, x + w, y + h);
+    }
+
+    /// <summary>
+    /// One live bubble's render state. Static fields are set once at spawn (Bubble ctor);
+    /// dynamic fields are rewritten every frame by Bubble.SyncLayerItem from the (unshown) WPF
+    /// tree's computed values, so the layer never re-derives animation - it just draws.
+    /// </summary>
+    public sealed class BubbleItem
+    {
+        // ---- static (spawn) ----
+        public float DpiScale = 1f;
+        public float SizeDip, HitSizeDip;
+        public SKImage? Sprite;             // shared, cached, never disposed here
+        public bool HasTint;
+        public SKColor Tint;
+        public string? Label;
+        public float LabelFontDip;
+        public bool HasShine;
+        public bool IsEcho;
+        public SKColor EchoColor;
+        public bool IsTease;
+        public float TeaseInnerDip;
+        public bool HasGlow;
+        public SKColor GlowColor;
+        public float GlowBlurDip;
+        public float GlowOpacity;
+        public SKImage? PrismGhost;         // shared, cached, never disposed here
+        public SKPoint[][]? Cracks;         // DIP points in the 0.._size box
+        public string? HintText;
+        public float HintYOffDip;
+
+        // ---- dynamic (per frame) ----
+        public double CenterXPx, CenterYPx;
+        public float Scale = 1f;
+        public float Angle;
+        public float Opacity = 1f;
+        public float FuseScale = 1f, FuseOpacity;
+        public SKColor FuseColor = new(255, 210, 40);
+        public float TelegraphScale = 1f, TelegraphOpacity;
+        public float FreezeAuraOpacity;
+        public float BrittleOpacity;
+        public float TeaseShineOpacity;
+        public float ShieldOpacity;
+        public float PrismOpacity;
+        public float HintOpacity;
+
+        // Tease frame: the WPF face Image's current Source (animated webp/gif frame or a still),
+        // converted to an owned SKImage lazily and cached per source so repeated frames reuse.
+        public BitmapSource? TeaseSource;
+        private BitmapSource? _teaseKey;
+        private SKImage? _teaseImg;
+        private Dictionary<BitmapSource, SKImage>? _teaseFrames;
+
+        public SKImage? CurrentTeaseFrame()
+        {
+            var src = TeaseSource;
+            if (src == null) return _teaseImg;
+            if (ReferenceEquals(src, _teaseKey)) return _teaseImg;
+            _teaseKey = src;
+            _teaseFrames ??= new Dictionary<BitmapSource, SKImage>();
+            if (!_teaseFrames.TryGetValue(src, out var img))
+            {
+                try { img = SkiaWpfInterop.ToSKImage(src); }
+                catch { img = null; }
+                if (img != null)
+                {
+                    if (_teaseFrames.Count > 64)   // bound the per-bubble frame cache
+                    {
+                        foreach (var v in _teaseFrames.Values) { try { v.Dispose(); } catch { } }
+                        _teaseFrames.Clear();
+                    }
+                    _teaseFrames[src] = img;
+                }
+            }
+            _teaseImg = img;
+            return img;
+        }
+
+        public void ReleaseTeaseFrames()
+        {
+            if (_teaseFrames != null)
+            {
+                foreach (var v in _teaseFrames.Values) { try { v.Dispose(); } catch { } }
+                _teaseFrames.Clear();
+            }
+            _teaseImg = null;
+            _teaseKey = null;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/ChaosFxLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/ChaosFxLayer.cs
@@ -1,0 +1,496 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// The chaos FX particle field — pop bursts, rabbit sparkle trails, E-Stim lightning, ripple
+/// shockwaves and the Rabbit-Caller cursor glow — as a compositor layer. This is
+/// <see cref="ChaosSkiaFxOverlay"/>'s render loop moved onto the shared host: a pop surge no
+/// longer presents its own fullscreen layered window on top of the active overlay hosts, which
+/// was the residual "explosion lag when overlays are stacked".
+///
+/// World-space layer (<see cref="WorldSpacePx"/>): all sim state lives in VIRTUAL-DESKTOP device
+/// pixels, so the physical-px points call sites already pass (bubble centres, cursor, bolt
+/// endpoints) are used verbatim. The legacy overlay's DIP-tuned constants are multiplied by the
+/// stage scale <see cref="_s"/> (the primary monitor's DPI scale) at emit/draw — visually
+/// identical to the legacy window, which rendered the whole stage at that one scale.
+///
+/// Threading: emit methods are UI-thread only (ChaosSkiaFxOverlay's statics marshal every call);
+/// Update/Render run on the engine tick. The sim is a straight port — keep the two in lockstep
+/// until the legacy window is deleted.
+/// </summary>
+public sealed class ChaosFxLayer : BaseLayer
+{
+    private const int MAX_PARTICLES = 2400;
+
+    // Trail palette (mirrors ChaosSkiaFxOverlay): rabbit pink, GG-sweeper amber, hot gold core.
+    private static readonly SKColor PinkBody = new(0xFF, 0x4D, 0xC4);
+    private static readonly SKColor AmberBody = new(0xFF, 0x8A, 0x14);
+    private static readonly SKColor GoldCore = new(0xFF, 0xE9, 0xA0);
+    private static readonly SKColor CursorPink = new(0xFF, 0x8F, 0xC8);
+
+    public ChaosFxLayer(CompositorEngine engine) : base(engine)
+    {
+        RefreshScale();
+    }
+
+    public override int ZIndex => CompositorLayers.Fx;
+
+    public override bool WorldSpacePx => true;
+
+    // ---- sim state (all coordinates/velocities/sizes in virtual-desktop device px) ----
+
+    private struct Particle { public float X, Y, VX, VY, Life, Max, Size; public byte Kind; public uint Col; }   // Kind 0=pink,1=amber,2=custom(Col 0xRRGGBB)
+    private readonly Particle[] _p = new Particle[MAX_PARTICLES];
+    private int _n;
+    private readonly Random _rng = new();
+
+    private bool _cursorArmed;
+    private float _cursorX, _cursorY;
+    private float _breath;            // cursor-halo breathing phase (radians)
+    private float _cursorEmitAcc;     // accumulator for the halo's drifting sparks
+
+    /// <summary>Stage scale: the primary monitor's DPI/96. Multiplies every DIP-tuned legacy
+    /// constant so the layer matches the legacy window (one scale for the whole stage).</summary>
+    private float _s = 1f;
+
+    // Cached tint filters (modulate the white soft-dot sprite to a colour without per-draw alloc).
+    private static readonly SKColorFilter PinkCF = SKColorFilter.CreateBlendMode(PinkBody, SKBlendMode.Modulate);
+    private static readonly SKColorFilter AmberCF = SKColorFilter.CreateBlendMode(AmberBody, SKBlendMode.Modulate);
+    private static readonly SKColorFilter GoldCF = SKColorFilter.CreateBlendMode(GoldCore, SKBlendMode.Modulate);
+    private static readonly SKColorFilter CursorCF = SKColorFilter.CreateBlendMode(CursorPink, SKBlendMode.Modulate);
+    private static readonly SKColorFilter WhiteCF = SKColorFilter.CreateBlendMode(SKColors.White, SKBlendMode.Modulate);  // identity → bright white core
+    private readonly SKPaint _paint = new() { BlendMode = SKBlendMode.Plus, IsAntialias = true, FilterQuality = SKFilterQuality.Medium };
+    private static SKImage? _dot;
+
+    // Per-colour tint filters for pop bursts (keyed 0xRRGGBB) so arbitrary payload colours don't alloc per frame.
+    private static readonly Dictionary<uint, SKColorFilter> _tintCache = new();
+    private static SKColorFilter TintFor(uint rgb)
+    {
+        if (_tintCache.TryGetValue(rgb, out var f)) return f;
+        f = SKColorFilter.CreateBlendMode(new SKColor((byte)(rgb >> 16), (byte)(rgb >> 8), (byte)rgb, 255), SKBlendMode.Modulate);
+        _tintCache[rgb] = f;
+        return f;
+    }
+
+    // ---- E-Stim lightning bolts ----
+    private static readonly SKColorFilter ElectricCF = SKColorFilter.CreateBlendMode(new SKColor(0x42, 0xDC, 0xE6), SKBlendMode.Modulate);
+    private static readonly SKColor BoltCoreColor = new(0xBF, 0xEC, 0xFF);   // electric white-blue core
+    private readonly SKPaint _boltGlow = new() { Style = SKPaintStyle.Stroke, IsAntialias = true, BlendMode = SKBlendMode.Plus, StrokeCap = SKStrokeCap.Round, StrokeJoin = SKStrokeJoin.Round };
+    private readonly SKPaint _boltCore = new() { Style = SKPaintStyle.Stroke, IsAntialias = true, BlendMode = SKBlendMode.Plus, StrokeCap = SKStrokeCap.Round, StrokeJoin = SKStrokeJoin.Round };
+    private sealed class Bolt
+    {
+        public SKPoint A, B;
+        public SKPoint[] Main = Array.Empty<SKPoint>();
+        public readonly List<SKPoint[]> Branches = new();
+        public float Life, Max, JitterAcc;
+        public SKColor Color;
+    }
+    private readonly List<Bolt> _bolts = new();
+
+    // ---- Ripple shockwaves ----
+    private static readonly SKColor RipplePinkInner = new(0xFF, 0x4D, 0xC4);
+    private readonly SKPaint _ringGlow = new() { Style = SKPaintStyle.Stroke, IsAntialias = true, BlendMode = SKBlendMode.Plus, StrokeCap = SKStrokeCap.Round };
+    private readonly SKPaint _ringCore = new() { Style = SKPaintStyle.Stroke, IsAntialias = true, BlendMode = SKBlendMode.Plus, StrokeCap = SKStrokeCap.Round };
+    private sealed class RippleFx { public SKPoint C; public float MaxR, Age, Life; public bool Strong; public SKColor Color; }
+    private readonly List<RippleFx> _ripples = new();
+
+    /// <summary>Re-sample the primary monitor's scale and rebuild the scale-dependent blur
+    /// filters. Cheap; called at construction and whenever the layer re-activates (covers
+    /// display-topology/DPI changes without subscribing to them).</summary>
+    private void RefreshScale()
+    {
+        float s = 1f;
+        try
+        {
+            var scr = System.Windows.Forms.Screen.PrimaryScreen;
+            if (scr != null) s = (float)CompositorHostWindow.GetDpiScaleForScreen(scr);
+        }
+        catch { }
+        if (s <= 0) s = 1f;
+        if (Math.Abs(s - _s) > 0.001f || _boltGlow.MaskFilter == null)
+        {
+            _s = s;
+            try
+            {
+                _boltGlow.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 5f * s);
+                _ringGlow.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, 6f * s);
+            }
+            catch { }
+        }
+    }
+
+    public override void OnActivated() => RefreshScale();
+
+    /// <summary>A soft white radial dot (premultiplied), tinted + additively blended per particle.</summary>
+    private static SKImage Dot()
+    {
+        if (_dot != null) return _dot;
+        const int s = 128;
+        var info = new SKImageInfo(s, s, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var surf = SKSurface.Create(info);
+        var c = surf.Canvas;
+        c.Clear(SKColors.Transparent);
+        float r = s / 2f;
+        using var shader = SKShader.CreateRadialGradient(
+            new SKPoint(r, r), r,
+            new[] { new SKColor(255, 255, 255, 255), new SKColor(255, 255, 255, 160), new SKColor(255, 255, 255, 0) },
+            new[] { 0f, 0.32f, 1f }, SKShaderTileMode.Clamp);
+        using var p = new SKPaint { Shader = shader, IsAntialias = true };
+        c.DrawCircle(r, r, r, p);
+        _dot = surf.Snapshot();
+        return _dot;
+    }
+
+    // ---- emit API (UI thread; ChaosSkiaFxOverlay's statics marshal) ----
+
+    public void EmitTrail(Point centerPx, double lifeSec, bool warm, double dirX = 0, double dirY = 0)
+    {
+        float s = _s;
+        // Travel direction → a unit "behind" vector. The burst originates a touch behind the
+        // rabbit and the sparks carry a backward bias, so the trail reads as STREAMING BEHIND
+        // it rather than puffing out around it.
+        double dl = Math.Sqrt(dirX * dirX + dirY * dirY);
+        float bx = 0, by = 0;
+        double cx = centerPx.X, cy = centerPx.Y;
+        if (dl > 0.0001) { bx = (float)(-dirX / dl); by = (float)(-dirY / dl); cx += bx * 14 * s; cy += by * 14 * s; }
+
+        float life = (float)Math.Max(0.30, lifeSec) * 1.3f;   // slightly longer-lived
+        byte kind = (byte)(warm ? 1 : 0);
+
+        // A bright core flash that drifts back along the trail...
+        Add((float)cx, (float)cy, bx * 28f * s, by * 28f * s, life * 0.5f, 20f * s, kind);
+        // ...with a small spread of sparks.
+        int sparks = 3 + _rng.Next(2);
+        for (int i = 0; i < sparks; i++)
+        {
+            double ang = _rng.NextDouble() * Math.PI * 2;
+            float spd = (10f + (float)_rng.NextDouble() * 30f) * s;
+            float vx = (float)Math.Cos(ang) * spd + bx * 48f * s;
+            float vy = (float)Math.Sin(ang) * spd + by * 48f * s - 12f * s;
+            Add((float)cx, (float)cy, vx, vy, life * (0.65f + (float)_rng.NextDouble() * 0.35f),
+                (6f + (float)_rng.NextDouble() * 6f) * s, kind);
+        }
+        SetActive(true);
+    }
+
+    /// <summary>Pop burst: a white core flash, an expanding ring, and radiating shards, all in
+    /// the bubble's payload colour. Reads fast at the tail like every other particle.</summary>
+    public void EmitBurst(Point centerPx, SKColor col, float scale)
+    {
+        if (scale <= 0.05f) scale = 1f;
+        float s = _s;
+        float cx = (float)centerPx.X, cy = (float)centerPx.Y;
+        uint rgb = (uint)(col.Red << 16 | col.Green << 8 | col.Blue);
+
+        // Bright central flash (slow, fat — the "release").
+        Add(cx, cy, 0f, 0f, 0.24f, 24f * scale * s, 2, rgb);
+        // A crisp expanding ring.
+        int ring = 10 + (int)(2 * scale);
+        for (int i = 0; i < ring; i++)
+        {
+            double a = i / (double)ring * Math.PI * 2;
+            float spd = (120f + (float)_rng.NextDouble() * 40f) * scale * s;
+            Add(cx, cy, (float)Math.Cos(a) * spd, (float)Math.Sin(a) * spd, 0.34f, 6.5f * scale * s, 2, rgb);
+        }
+        // Scattered shards with a little upward bias + gravity settle.
+        int shards = 7 + _rng.Next(5);
+        for (int i = 0; i < shards; i++)
+        {
+            double a = _rng.NextDouble() * Math.PI * 2;
+            float spd = (40f + (float)_rng.NextDouble() * 150f) * scale * s;
+            Add(cx, cy, (float)Math.Cos(a) * spd, (float)Math.Sin(a) * spd - 20f * s,
+                0.30f + (float)_rng.NextDouble() * 0.35f, (5f + (float)_rng.NextDouble() * 7f) * scale * s, 2, rgb);
+        }
+        SetActive(true);
+    }
+
+    private void Add(float x, float y, float vx, float vy, float life, float size, byte kind, uint col = 0)
+    {
+        if (_n >= MAX_PARTICLES) return;
+        _p[_n++] = new Particle { X = x, Y = y, VX = vx, VY = vy, Life = life, Max = life, Size = size, Kind = kind, Col = col };
+    }
+
+    public void AddStrike(IReadOnlyList<(Point From, Point To)> boltsPx)
+    {
+        if (boltsPx == null || boltsPx.Count == 0) return;
+        var color = ChaosBoonColors.ToSk(ChaosBoonColors.Electric);
+        foreach (var (fromPx, toPx) in boltsPx)
+        {
+            var bolt = new Bolt
+            {
+                A = new SKPoint((float)fromPx.X, (float)fromPx.Y),
+                B = new SKPoint((float)toPx.X, (float)toPx.Y),
+                Life = 0.20f, Max = 0.20f, Color = color,
+            };
+            Rejitter(bolt);
+            _bolts.Add(bolt);
+        }
+        SetActive(true);
+    }
+
+    /// <summary>Build a jagged path between two points (perpendicular midpoint displacement).</summary>
+    private SKPoint[] BuildBolt(SKPoint a, SKPoint b)
+    {
+        float s = _s;
+        float dx = b.X - a.X, dy = b.Y - a.Y;
+        float len = MathF.Sqrt(dx * dx + dy * dy);
+        int mids = Math.Max(2, (int)(len / (55f * s)));
+        float px = len > 0.001f ? -dy / len : 0f, py = len > 0.001f ? dx / len : 0f;
+        var pts = new SKPoint[mids + 2];
+        pts[0] = a;
+        for (int m = 1; m <= mids; m++)
+        {
+            float f = m / (float)(mids + 1);
+            float off = (float)(_rng.NextDouble() * 2 - 1) * 16f * s;
+            pts[m] = new SKPoint(a.X + dx * f + px * off, a.Y + dy * f + py * off);
+        }
+        pts[mids + 1] = b;
+        return pts;
+    }
+
+    /// <summary>Rebuild a bolt's jagged main path + 0-2 short forks so the current dances.</summary>
+    private void Rejitter(Bolt bolt)
+    {
+        bolt.Main = BuildBolt(bolt.A, bolt.B);
+        bolt.Branches.Clear();
+        int forks = _rng.Next(3);
+        for (int k = 0; k < forks && bolt.Main.Length > 2; k++)
+        {
+            int idx = 1 + _rng.Next(bolt.Main.Length - 2);
+            var origin = bolt.Main[idx];
+            float ang = (float)(_rng.NextDouble() * Math.PI * 2);
+            float flen = (20f + (float)_rng.NextDouble() * 55f) * _s;
+            var end = new SKPoint(origin.X + MathF.Cos(ang) * flen, origin.Y + MathF.Sin(ang) * flen);
+            bolt.Branches.Add(BuildBolt(origin, end));
+        }
+    }
+
+    public void EmitRipple(Point centerPx, double radiusPx, double lifeMs, bool strong)
+    {
+        float r = (float)Math.Max(1.0, radiusPx);   // world px — no DIP conversion needed
+        float life = (float)Math.Max(0.1, lifeMs / 1000.0);
+        var col = ChaosBoonColors.ToSk(ChaosBoonColors.Electric);
+        _ripples.Add(new RippleFx { C = new SKPoint((float)centerPx.X, (float)centerPx.Y), MaxR = r, Age = 0, Life = life, Strong = strong, Color = col });
+
+        // A ring of sparks thrown outward with the front (they drag/settle, so they read as
+        // foam scattering off the wave rather than a perfect tracking ring).
+        uint rgb = (uint)(col.Red << 16 | col.Green << 8 | col.Blue);
+        int motes = strong ? 14 : 7;
+        float frontSpeed = r / life;
+        for (int i = 0; i < motes; i++)
+        {
+            double ang = Math.PI * 2 * i / motes + 0.2;
+            float ux = (float)Math.Cos(ang), uy = (float)Math.Sin(ang);
+            Add((float)centerPx.X + ux * r * 0.15f, (float)centerPx.Y + uy * r * 0.15f,
+                ux * frontSpeed * 0.85f, uy * frontSpeed * 0.85f,
+                life * 0.85f, (strong ? 6f : 4.5f) * _s, 2, rgb);
+        }
+        SetActive(true);
+    }
+
+    public void ArmCursor()
+    {
+        _cursorArmed = true;   // position lands with the first MoveCursor (same as the legacy window)
+        SetActive(true);
+    }
+
+    public void DisarmCursor() => _cursorArmed = false;
+
+    public void MoveCursor(double px, double py)
+    {
+        if (!_cursorArmed) return;
+        _cursorX = (float)px;
+        _cursorY = (float)py;
+    }
+
+    /// <summary>Run teardown (ChaosSkiaFxOverlay.CloseActive): drop everything immediately.</summary>
+    public void Clear()
+    {
+        _n = 0;
+        _bolts.Clear();
+        _ripples.Clear();
+        _cursorArmed = false;
+        SetActive(false);
+    }
+
+    // ---- engine tick ----
+
+    public override void Update(TimeSpan delta)
+    {
+        float dt = (float)delta.TotalSeconds;
+        if (dt <= 0) return;
+        if (dt > 0.1f) dt = 0.1f;   // engine clamps too; belt and braces
+        float s = _s;
+
+        // Advance particles: integrate, damp, gentle gravity, cull dead (swap-remove).
+        float drag = MathF.Exp(-2.4f * dt);
+        for (int i = _n - 1; i >= 0; i--)
+        {
+            ref var p = ref _p[i];
+            p.Life -= dt;
+            if (p.Life <= 0f) { _p[i] = _p[--_n]; continue; }
+            p.X += p.VX * dt; p.Y += p.VY * dt;
+            p.VX *= drag; p.VY *= drag;
+            p.VY += 34f * s * dt;   // settle
+        }
+
+        // Cursor halo: breathe + shed an occasional drifting spark for life.
+        if (_cursorArmed)
+        {
+            _breath += dt * (float)(Math.PI * 2 / 1.24);   // ~620ms half-cycle, matches the old halo
+            _cursorEmitAcc += dt;
+            if (_cursorEmitAcc >= 0.09f)
+            {
+                _cursorEmitAcc = 0f;
+                double ang = _rng.NextDouble() * Math.PI * 2;
+                float spd = (8f + (float)_rng.NextDouble() * 18f) * s;
+                Add(_cursorX, _cursorY, (float)Math.Cos(ang) * spd, (float)Math.Sin(ang) * spd - 10f * s,
+                    0.5f + (float)_rng.NextDouble() * 0.3f, (6f + (float)_rng.NextDouble() * 4f) * s, 0);
+            }
+        }
+
+        // Advance lightning bolts: fade over life, re-jitter during the hot window.
+        for (int i = _bolts.Count - 1; i >= 0; i--)
+        {
+            var bolt = _bolts[i];
+            bolt.Life -= dt;
+            if (bolt.Life <= 0f) { _bolts.RemoveAt(i); continue; }
+            bolt.JitterAcc += dt;
+            if (bolt.Life > bolt.Max * 0.4f && bolt.JitterAcc >= 0.04f) { bolt.JitterAcc = 0f; Rejitter(bolt); }
+        }
+
+        // Advance ripples (linear front, cull when spent).
+        for (int i = _ripples.Count - 1; i >= 0; i--)
+        {
+            var rp = _ripples[i];
+            rp.Age += dt;
+            if (rp.Age >= rp.Life) _ripples.RemoveAt(i);
+        }
+
+        if (_n == 0 && _bolts.Count == 0 && _ripples.Count == 0 && !_cursorArmed)
+            SetActive(false);   // engine paints one cleared frame on the transition
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        var img = Dot();
+        float s = _s;
+
+        // Particles: a wide dim bloom halo + the bright body, both additive.
+        for (int i = 0; i < _n; i++)
+        {
+            ref var p = ref _p[i];
+            float t = p.Life / p.Max;                 // 1 -> 0
+            float ease = t * t;                       // fade fast at the tail
+            float scale = (0.35f + 0.75f * t);        // shrink as it dies
+            float rad = p.Size * scale;
+            var cf = p.Kind switch { 1 => AmberCF, 2 => TintFor(p.Col), _ => PinkCF };
+            var coreCf = p.Kind == 2 ? WhiteCF : GoldCF;   // colour-agnostic white flash for pop bursts
+
+            DrawDot(canvas, img, p.X, p.Y, rad * 2.1f, (byte)(40 * ease), cf);    // bloom
+            DrawDot(canvas, img, p.X, p.Y, rad, (byte)(210 * ease), cf);          // body
+            DrawDot(canvas, img, p.X, p.Y, rad * 0.5f, (byte)(230 * ease), coreCf); // hot core
+        }
+
+        if (_cursorArmed)
+        {
+            float breath = 0.92f + 0.14f * MathF.Sin(_breath);
+            float baseR = 34f * s;
+            DrawDot(canvas, img, _cursorX, _cursorY, baseR * breath * 1.8f, 55, CursorCF);  // outer bloom
+            DrawDot(canvas, img, _cursorX, _cursorY, baseR * breath, 150, CursorCF);        // halo
+            DrawDot(canvas, img, _cursorX, _cursorY, baseR * breath * 0.42f, 120, GoldCF);  // gold heart
+        }
+
+        if (_ripples.Count > 0) DrawRipples(canvas, img);
+        if (_bolts.Count > 0) DrawBolts(canvas, img);
+    }
+
+    private void DrawBolts(SKCanvas canvas, SKImage img)
+    {
+        float s = _s;
+        foreach (var bolt in _bolts)
+        {
+            float t = bolt.Life / bolt.Max;                 // 1 -> 0
+            float a = t > 0.4f ? 1f : t / 0.4f;             // hold hot, then fade
+            _boltGlow.Color = bolt.Color.WithAlpha((byte)(120 * a));
+            _boltGlow.StrokeWidth = 6.5f * s;
+            _boltCore.Color = BoltCoreColor.WithAlpha((byte)(235 * a));
+            _boltCore.StrokeWidth = 1.8f * s;
+
+            DrawPolyline(canvas, bolt.Main, _boltGlow);
+            foreach (var br in bolt.Branches) DrawPolyline(canvas, br, _boltGlow);
+            DrawPolyline(canvas, bolt.Main, _boltCore);
+            _boltCore.Color = BoltCoreColor.WithAlpha((byte)(160 * a));   // forks read a touch dimmer
+            foreach (var br in bolt.Branches) DrawPolyline(canvas, br, _boltCore);
+
+            float fr = (16f * a + 6f) * s;
+            DrawDot(canvas, img, bolt.B.X, bolt.B.Y, fr, (byte)(200 * a), ElectricCF);        // strike flash
+            DrawDot(canvas, img, bolt.A.X, bolt.A.Y, fr * 0.7f, (byte)(150 * a), ElectricCF); // source spark
+        }
+    }
+
+    private static void DrawPolyline(SKCanvas canvas, SKPoint[] pts, SKPaint paint)
+    {
+        if (pts.Length < 2) return;
+        using var path = new SKPath();
+        path.MoveTo(pts[0]);
+        for (int i = 1; i < pts.Length; i++) path.LineTo(pts[i]);
+        canvas.DrawPath(path, paint);
+    }
+
+    private void DrawRipples(SKCanvas canvas, SKImage img)
+    {
+        float s = _s;
+        foreach (var rp in _ripples)
+        {
+            float t = rp.Age / rp.Life;        // 0 → 1
+            if (t >= 1f) continue;
+            float fade = 1f - t;               // overall dim as it dies
+            float lead = rp.MaxR * t;          // LINEAR front — matches the kill radius
+            var col = rp.Color;
+
+            // Cast flash at the origin (early only).
+            if (t < 0.35f)
+            {
+                float ff = 1f - t / 0.35f;
+                DrawDot(canvas, img, rp.C.X, rp.C.Y, (rp.Strong ? 34f : 22f) * s * (0.6f + 0.4f * ff), (byte)(200 * ff), ElectricCF);
+            }
+
+            // Leading wavefront: a blurred glow stroke + a hot white-blue core, thinning as it spreads.
+            float baseW = (rp.Strong ? 7f : 4.5f) * s;
+            float w = baseW * (0.5f + 0.5f * fade);
+            _ringGlow.Color = col.WithAlpha((byte)(110 * fade));
+            _ringGlow.StrokeWidth = w * 2.2f;
+            canvas.DrawCircle(rp.C, lead, _ringGlow);
+            _ringCore.Color = BoltCoreColor.WithAlpha((byte)(230 * fade));
+            _ringCore.StrokeWidth = Math.Max(1f, w * 0.5f);
+            canvas.DrawCircle(rp.C, lead, _ringCore);
+
+            if (rp.Strong)
+            {
+                // Chromatic glassy edge: cyan just outside, pink just inside the core.
+                _ringCore.Color = col.WithAlpha((byte)(90 * fade));
+                _ringCore.StrokeWidth = Math.Max(1f, w * 0.4f);
+                canvas.DrawCircle(rp.C, lead + 3f * s, _ringCore);
+                _ringCore.Color = RipplePinkInner.WithAlpha((byte)(70 * fade));
+                canvas.DrawCircle(rp.C, Math.Max(0f, lead - 3f * s), _ringCore);
+
+                // Trailing concentric rings lag behind the front for depth (look only).
+                _ringGlow.Color = col.WithAlpha((byte)(60 * fade));
+                _ringGlow.StrokeWidth = w * 1.4f;
+                if (lead > 10f * s) canvas.DrawCircle(rp.C, lead * 0.7f, _ringGlow);
+                if (lead > 20f * s) canvas.DrawCircle(rp.C, lead * 0.45f, _ringGlow);
+            }
+        }
+    }
+
+    private void DrawDot(SKCanvas canvas, SKImage img, float cx, float cy, float radius, byte alpha, SKColorFilter tint)
+    {
+        if (radius <= 0.2f || alpha == 0) return;
+        _paint.ColorFilter = tint;
+        _paint.Color = new SKColor(255, 255, 255, alpha);   // global opacity multiplier for the image draw
+        var dest = new SKRect(cx - radius, cy - radius, cx + radius, cy + radius);
+        canvas.DrawImage(img, dest, _paint);
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -37,8 +37,13 @@ public class CompositorEngine : IDisposable
     private readonly List<IWpfLayer> _layers = new();
     private readonly Dictionary<IWpfLayer, bool> _lastActiveState = new();
 
-    private readonly Dictionary<string, CompositorHostWindow> _windows = new();
-    private readonly Dictionary<string, CompositorHostWindow> _excludedWindows = new();
+    private readonly Dictionary<string, ICompositorHost> _windows = new();
+    private readonly Dictionary<string, ICompositorHost> _excludedWindows = new();
+
+    // #550 off-thread present path (CompositorOffThreadPresent): latched the first time hosts are
+    // created so a mid-run settings toggle can't mix host types on one engine.
+    private bool _offThreadMode;
+    private bool _modeLatched;
 
     private readonly Stopwatch _clock = Stopwatch.StartNew();
     private TimeSpan _lastTickElapsed;
@@ -100,6 +105,9 @@ public class CompositorEngine : IDisposable
         }
     }
 
+    /// <summary>True when this engine presents off the UI thread (the #550 fix path is active).</summary>
+    public bool OffThreadActive => _offThreadMode;
+
     /// <summary>
     /// Pay the one-time host costs (window creation, hwnd + ex-styles, Skia surface alloc, paint
     /// JIT) at startup instead of on the first effect trigger. Creates and shows the main-surface
@@ -114,10 +122,8 @@ public class CompositorEngine : IDisposable
         {
             EnsureWindows(_windows, excluded: false);
             foreach (var w in _windows.Values)
-            {
                 if (!w.IsVisible) w.Show();
-                w.InvalidateSurface();
-            }
+            PresentSurface(_windows, excluded: false); // one (empty) frame realizes the surface + JIT
             Wake(); // ticks once, finds nothing active, parks + schedules the window hide
         }
         catch (Exception ex)
@@ -145,6 +151,12 @@ public class CompositorEngine : IDisposable
         if (delta > MaxDelta) delta = MaxDelta; // hitch: drop time instead of lurching
 
         bool anyMainActive = false, anyExcludedActive = false;
+        // Dirty-gated invalidation (#550): a surface only re-rasters when one of its active layers
+        // reports changed output this frame. The tick still runs at 60fps (cheap Update()s), but a
+        // ~10fps spiral / static pink tint no longer forces a fullscreen software raster + layered
+        // composite on the UI thread every frame. Layers default Dirty=true, so continuously-
+        // animating ones (bubbles/chaos FX/flash/subliminal) keep repainting every frame.
+        bool anyMainDirty = false, anyExcludedDirty = false;
 
         IWpfLayer[] layers;
         lock (_layerLock) layers = _layers.ToArray();
@@ -167,7 +179,8 @@ public class CompositorEngine : IDisposable
             }
 
             if (!active) continue;
-            if (layer.ExcludeFromCapture) anyExcludedActive = true;
+            bool excluded = layer.ExcludeFromCapture;
+            if (excluded) anyExcludedActive = true;
             else anyMainActive = true;
 
             try { layer.Update(delta); }
@@ -175,6 +188,9 @@ public class CompositorEngine : IDisposable
             {
                 App.Logger?.Error(ex, "CompositorEngine: layer Update failed ({Layer})", layer.GetType().Name);
             }
+
+            // Read Dirty AFTER Update so this frame's advance/opacity change counts.
+            if (layer.Dirty) { if (excluded) anyExcludedDirty = true; else anyMainDirty = true; }
         }
 
         var nowUtc = DateTime.UtcNow;
@@ -184,13 +200,22 @@ public class CompositorEngine : IDisposable
         ShowSurfaceIfActive(_windows, anyMainActive, excluded: false);
         ShowSurfaceIfActive(_excludedWindows, anyExcludedActive, excluded: true);
 
-        if (anyMainActive) foreach (var w in _windows.Values) w.InvalidateSurface();
-        if (anyExcludedActive) foreach (var w in _excludedWindows.Values) w.InvalidateSurface();
+        if (anyMainActive && anyMainDirty) PresentSurface(_windows, excluded: false);
+        if (anyExcludedActive && anyExcludedDirty) PresentSurface(_excludedWindows, excluded: true);
+
+        // Reset dirty flags now this frame's invalidations are queued. Only active layers matter;
+        // an inactive layer re-marks itself dirty when it next activates.
+        foreach (var layer in layers)
+        {
+            if (!layer.IsActive) continue;
+            try { layer.ClearDirty(); }
+            catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: ClearDirty failed ({Layer})", layer.GetType().Name); }
+        }
 
         // Active -> inactive: paint ONE cleared frame. The hosts stay visible through
         // WindowHideGrace, and without this the last effect frame would linger on screen.
-        if (_wasMainActive && !anyMainActive) foreach (var w in _windows.Values) w.InvalidateSurface();
-        if (_wasExcludedActive && !anyExcludedActive) foreach (var w in _excludedWindows.Values) w.InvalidateSurface();
+        if (_wasMainActive && !anyMainActive) PresentSurface(_windows, excluded: false);
+        if (_wasExcludedActive && !anyExcludedActive) PresentSurface(_excludedWindows, excluded: true);
         _wasMainActive = anyMainActive;
         _wasExcludedActive = anyExcludedActive;
 
@@ -207,7 +232,7 @@ public class CompositorEngine : IDisposable
         }
     }
 
-    private void ShowSurfaceIfActive(Dictionary<string, CompositorHostWindow> surface, bool active, bool excluded)
+    private void ShowSurfaceIfActive(Dictionary<string, ICompositorHost> surface, bool active, bool excluded)
     {
         if (!active) return;
         EnsureWindows(surface, excluded);
@@ -249,20 +274,74 @@ public class CompositorEngine : IDisposable
         return t;
     }
 
-    private void EnsureWindows(Dictionary<string, CompositorHostWindow> surface, bool excluded)
+    private void EnsureWindows(Dictionary<string, ICompositorHost> surface, bool excluded)
     {
         System.Windows.Forms.Screen[] screens;
         try { screens = System.Windows.Forms.Screen.AllScreens; }
         catch { return; }
         if (screens.Length == 0) return; // can be empty during display transitions
 
+        if (!_modeLatched)
+        {
+            _offThreadMode = App.CompositorOffThreadPresent;
+            _modeLatched = true;
+            App.Logger?.Information("CompositorEngine: present mode = {Mode}",
+                _offThreadMode ? "OFF-THREAD (UpdateLayeredWindow)" : "UI-thread SKElement");
+        }
+
         foreach (var screen in screens)
         {
             if (surface.ContainsKey(screen.DeviceName)) continue;
-            var window = new CompositorHostWindow(screen, excluded);
-            window.PaintSurface += OnPaintSurface;
-            surface[screen.DeviceName] = window;
+            if (_offThreadMode)
+            {
+                surface[screen.DeviceName] = new LayeredCompositorHost(screen, excluded);
+            }
+            else
+            {
+                var window = new CompositorHostWindow(screen, excluded);
+                window.PaintSurface += OnPaintSurface;
+                surface[screen.DeviceName] = window;
+            }
         }
+    }
+
+    /// <summary>Present one surface's dirty frame in the active mode: WPF hosts invalidate (UI-thread
+    /// raster via <see cref="OnPaintSurface"/>); off-thread hosts get a freshly recorded picture handed
+    /// to their present thread. Also used for the single cleared frame on the active-&gt;inactive edge
+    /// (records an empty picture) and for prewarm.</summary>
+    private void PresentSurface(Dictionary<string, ICompositorHost> surface, bool excluded)
+    {
+        IWpfLayer[]? layers = null;
+        foreach (var host in surface.Values)
+        {
+            if (host is LayeredCompositorHost lh)
+            {
+                layers ??= SnapshotLayers();
+                lh.PresentPicture(RecordHost(host, layers, excluded));
+            }
+            else if (host is CompositorHostWindow ww)
+            {
+                ww.InvalidateSurface();
+            }
+        }
+    }
+
+    private IWpfLayer[] SnapshotLayers()
+    {
+        lock (_layerLock) return _layers.ToArray();
+    }
+
+    /// <summary>Record a monitor's active layers into an immutable picture, in device px, monitor-
+    /// local. Cheap (draw-command capture only); runs on the UI thread where layer state is safe to
+    /// read. The present thread rasterizes it later.</summary>
+    private SKPicture RecordHost(ICompositorHost host, IWpfLayer[] layers, bool excluded)
+    {
+        var sb = host.ScreenBoundsPx;
+        int w = Math.Max(1, sb.Width), h = Math.Max(1, sb.Height);
+        using var recorder = new SKPictureRecorder();
+        var canvas = recorder.BeginRecording(new SKRect(0, 0, w, h));
+        DrawLayers(canvas, layers, new SKRectI(0, 0, w, h), sb, host.DpiScale, excluded, _clock.Elapsed);
+        return recorder.EndRecording();
     }
 
     private void OnPaintSurface(CompositorHostWindow window, SKPaintSurfaceEventArgs e)
@@ -272,27 +351,32 @@ public class CompositorEngine : IDisposable
 
         var boundsPx = new SKRectI(0, 0, e.Info.Width, e.Info.Height);
         double dpiScale = window.ActualWidth > 0 ? e.Info.Width / window.ActualWidth : 1.0;
-        var elapsed = _clock.Elapsed;
+        IWpfLayer[] layers = SnapshotLayers();
+        DrawLayers(canvas, layers, boundsPx, window.ScreenBoundsPx, dpiScale,
+                   window.IsExcludedSurface, _clock.Elapsed);
+    }
 
-        IWpfLayer[] layers;
-        lock (_layerLock) layers = _layers.ToArray();
-
+    /// <summary>Draw the active layers for one surface onto <paramref name="canvas"/>. Shared by the
+    /// WPF live-raster path (<see cref="OnPaintSurface"/>) and the off-thread record path
+    /// (<see cref="RecordHost"/>) so layer transforms/culling are defined once.</summary>
+    private static void DrawLayers(SKCanvas canvas, IWpfLayer[] layers, SKRectI boundsPx,
+        System.Drawing.Rectangle screenBoundsPx, double dpiScale, bool excludedSurface, TimeSpan elapsed)
+    {
         foreach (var layer in layers) // already z-sorted; lower draws first
         {
-            if (!layer.IsActive || layer.ExcludeFromCapture != window.IsExcludedSurface) continue;
+            if (!layer.IsActive || layer.ExcludeFromCapture != excludedSurface) continue;
             try
             {
                 if (layer.WorldSpacePx)
                 {
                     // World-space layers draw in virtual-desktop device px. The surface is
-                    // normally exactly device-px sized (ApplyNativeState stamps physical
-                    // bounds); if WPF rasterized the SKElement at a stale scale during a
-                    // mixed-DPI transition, the scale factor re-squares it.
-                    var sb = window.ScreenBoundsPx;
+                    // normally exactly device-px sized; if WPF rasterized the SKElement at a
+                    // stale scale during a mixed-DPI transition, the scale factor re-squares it.
+                    var sb = screenBoundsPx;
                     if (sb.Width <= 0 || sb.Height <= 0) continue;
                     canvas.Save();
-                    if (e.Info.Width != sb.Width || e.Info.Height != sb.Height)
-                        canvas.Scale(e.Info.Width / (float)sb.Width, e.Info.Height / (float)sb.Height);
+                    if (boundsPx.Width != sb.Width || boundsPx.Height != sb.Height)
+                        canvas.Scale(boundsPx.Width / (float)sb.Width, boundsPx.Height / (float)sb.Height);
                     canvas.Translate(-sb.X, -sb.Y);
                     layer.Render(canvas, new SKRectI(sb.X, sb.Y, sb.X + sb.Width, sb.Y + sb.Height),
                                  dpiScale, elapsed);
@@ -330,7 +414,7 @@ public class CompositorEngine : IDisposable
         });
     }
 
-    private static void RebuildSurface(Dictionary<string, CompositorHostWindow> surface)
+    private static void RebuildSurface(Dictionary<string, ICompositorHost> surface)
     {
         System.Windows.Forms.Screen[] screens;
         try { screens = System.Windows.Forms.Screen.AllScreens; }

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -35,7 +35,16 @@ public class CompositorEngine : IDisposable
 
     private readonly object _layerLock = new();
     private readonly List<IWpfLayer> _layers = new();
+    // Copy-on-write snapshot: rebuilt in RegisterLayer under _layerLock, read lock-free on the
+    // hot paths (tick + paint). Layers are app-lifetime (no unregister), so the array is stable.
+    private volatile IWpfLayer[] _layerSnapshot = Array.Empty<IWpfLayer>();
     private readonly Dictionary<IWpfLayer, bool> _lastActiveState = new();
+
+    // One-shot present force per surface, consumed by this tick's present gate. Set when a layer
+    // deactivates (its last sprites must be erased even if the surviving layers are non-dirty)
+    // and when EnsureWindows creates a host mid-run (a layered window shows NOTHING until its
+    // first present, so static non-dirty layers would leave a new monitor blank).
+    private bool _forcePresentMain, _forcePresentExcluded;
 
     private readonly Dictionary<string, ICompositorHost> _windows = new();
     private readonly Dictionary<string, ICompositorHost> _excludedWindows = new();
@@ -75,6 +84,7 @@ public class CompositorEngine : IDisposable
             if (_layers.Contains(layer)) return;
             _layers.Add(layer);
             _layers.Sort((a, b) => a.ZIndex.CompareTo(b.ZIndex));
+            _layerSnapshot = _layers.ToArray();
             _lastActiveState[layer] = false;
         }
         Wake();
@@ -107,6 +117,23 @@ public class CompositorEngine : IDisposable
 
     /// <summary>True when this engine presents off the UI thread (the #550 fix path is active).</summary>
     public bool OffThreadActive => _offThreadMode;
+
+    /// <summary>
+    /// Native handles of every currently VISIBLE host window, for the z-order reconciler
+    /// (OverlayService.ReassertZOrder): hosts assert HWND_TOPMOST only on show/topology edges,
+    /// so without reconciliation a later topmost raise (mandatory video, chaos chrome) either
+    /// buries every compositor layer or — worse — a re-shown host buries the video (#497).
+    /// UI thread only (same thread that mutates the host dictionaries).
+    /// </summary>
+    public List<nint> GetVisibleHostHandles()
+    {
+        var handles = new List<nint>(_windows.Count + _excludedWindows.Count);
+        foreach (var dict in new[] { _windows, _excludedWindows })
+            foreach (var host in dict.Values)
+                if (host.IsVisible && host.WindowHandle != 0)
+                    handles.Add(host.WindowHandle);
+        return handles;
+    }
 
     /// <summary>
     /// Pay the one-time host costs (window creation, hwnd + ex-styles, Skia surface alloc, paint
@@ -158,8 +185,7 @@ public class CompositorEngine : IDisposable
         // animating ones (bubbles/chaos FX/flash/subliminal) keep repainting every frame.
         bool anyMainDirty = false, anyExcludedDirty = false;
 
-        IWpfLayer[] layers;
-        lock (_layerLock) layers = _layers.ToArray();
+        IWpfLayer[] layers = _layerSnapshot;
 
         foreach (var layer in layers)
         {
@@ -167,6 +193,15 @@ public class CompositorEngine : IDisposable
             if (_lastActiveState.TryGetValue(layer, out var was) && was != active)
             {
                 _lastActiveState[layer] = active;
+                // Per-layer active->inactive edge: force one re-present of its surface so the
+                // layer's last-drawn output is erased even when every surviving layer on that
+                // surface is active-but-non-dirty (static pink tint). The aggregate edge below
+                // only covers the "whole surface went inactive" case.
+                if (!active)
+                {
+                    if (layer.ExcludeFromCapture) _forcePresentExcluded = true;
+                    else _forcePresentMain = true;
+                }
                 try
                 {
                     if (active) layer.OnActivated();
@@ -200,8 +235,8 @@ public class CompositorEngine : IDisposable
         ShowSurfaceIfActive(_windows, anyMainActive, excluded: false);
         ShowSurfaceIfActive(_excludedWindows, anyExcludedActive, excluded: true);
 
-        if (anyMainActive && anyMainDirty) PresentSurface(_windows, excluded: false);
-        if (anyExcludedActive && anyExcludedDirty) PresentSurface(_excludedWindows, excluded: true);
+        if (anyMainActive && (anyMainDirty || _forcePresentMain)) PresentSurface(_windows, excluded: false);
+        if (anyExcludedActive && (anyExcludedDirty || _forcePresentExcluded)) PresentSurface(_excludedWindows, excluded: true);
 
         // Reset dirty flags now this frame's invalidations are queued. Only active layers matter;
         // an inactive layer re-marks itself dirty when it next activates.
@@ -218,6 +253,7 @@ public class CompositorEngine : IDisposable
         if (_wasExcludedActive && !anyExcludedActive) PresentSurface(_excludedWindows, excluded: true);
         _wasMainActive = anyMainActive;
         _wasExcludedActive = anyExcludedActive;
+        _forcePresentMain = _forcePresentExcluded = false; // one-shot: consumed (or moot) this tick
 
         // Fully park when everything has been idle past the grace window: unhook the tick so
         // an idle compositor costs literally zero per frame. The (visible, empty) hosts are
@@ -276,9 +312,7 @@ public class CompositorEngine : IDisposable
 
     private void EnsureWindows(Dictionary<string, ICompositorHost> surface, bool excluded)
     {
-        System.Windows.Forms.Screen[] screens;
-        try { screens = System.Windows.Forms.Screen.AllScreens; }
-        catch { return; }
+        var screens = App.GetAllScreensCached(); // called every active tick - never raw-enumerate here
         if (screens.Length == 0) return; // can be empty during display transitions
 
         if (!_modeLatched)
@@ -302,6 +336,10 @@ public class CompositorEngine : IDisposable
                 window.PaintSurface += OnPaintSurface;
                 surface[screen.DeviceName] = window;
             }
+            // A fresh host has never presented - a layered window renders nothing until its
+            // first UpdateLayeredWindow/raster, so force one even if no layer is dirty.
+            if (excluded) _forcePresentExcluded = true;
+            else _forcePresentMain = true;
         }
     }
 
@@ -326,10 +364,7 @@ public class CompositorEngine : IDisposable
         }
     }
 
-    private IWpfLayer[] SnapshotLayers()
-    {
-        lock (_layerLock) return _layers.ToArray();
-    }
+    private IWpfLayer[] SnapshotLayers() => _layerSnapshot;
 
     /// <summary>Record a monitor's active layers into an immutable picture, in device px, monitor-
     /// local. Cheap (draw-command capture only); runs on the UI thread where layer state is safe to
@@ -419,9 +454,9 @@ public class CompositorEngine : IDisposable
 
     private static void RebuildSurface(Dictionary<string, ICompositorHost> surface)
     {
-        System.Windows.Forms.Screen[] screens;
-        try { screens = System.Windows.Forms.Screen.AllScreens; }
-        catch { return; }
+        // App invalidates this cache on DisplaySettingsChanged (and this runs deferred at
+        // Background priority), so it re-enumerates fresh topology here, not a stale snapshot.
+        var screens = App.GetAllScreensCached();
         if (screens.Length == 0) return;
 
         var byName = screens.ToDictionary(s => s.DeviceName);

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -365,6 +365,9 @@ public class CompositorEngine : IDisposable
         foreach (var layer in layers) // already z-sorted; lower draws first
         {
             if (!layer.IsActive || layer.ExcludeFromCapture != excludedSurface) continue;
+            // Per-monitor opt-out (e.g. fullscreen fill layers honoring DualMonitorEnabled). The
+            // host exists on every screen; a gated-out host just records an empty (transparent) frame.
+            if (!layer.ShouldRenderOnScreen(screenBoundsPx)) continue;
             try
             {
                 if (layer.WorldSpacePx)

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -27,6 +27,12 @@ public class CompositorEngine : IDisposable
     private static readonly TimeSpan IdleGrace = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan MaxDelta = TimeSpan.FromMilliseconds(100);
 
+    // Hiding hosts right at IdleGrace meant every effect trigger after a quiet half-second
+    // re-Show()ed a fullscreen layered window (DWM re-composition = the "first load" hitch the
+    // owner reported). The TICK still parks at IdleGrace (idle engine costs zero per frame);
+    // the WINDOWS stay visible - empty and click-through - through this longer grace.
+    private static readonly TimeSpan WindowHideGrace = TimeSpan.FromSeconds(30);
+
     private readonly object _layerLock = new();
     private readonly List<IWpfLayer> _layers = new();
     private readonly Dictionary<IWpfLayer, bool> _lastActiveState = new();
@@ -41,6 +47,8 @@ public class CompositorEngine : IDisposable
     private DateTime _lastExcludedActiveUtc = DateTime.MinValue;
     private bool _renderingHooked;
     private bool _disposed;
+    private bool _wasMainActive, _wasExcludedActive;
+    private DispatcherTimer? _hideTimer;
 
     public CompositorEngine()
     {
@@ -83,11 +91,38 @@ public class CompositorEngine : IDisposable
             return;
         }
 
+        _hideTimer?.Stop();
         if (!_renderingHooked)
         {
             _renderingHooked = true;
             _lastTickElapsed = _clock.Elapsed;
             CompositionTarget.Rendering += OnRendering;
+        }
+    }
+
+    /// <summary>
+    /// Pay the one-time host costs (window creation, hwnd + ex-styles, Skia surface alloc, paint
+    /// JIT) at startup instead of on the first effect trigger. Creates and shows the main-surface
+    /// hosts (empty, transparent, click-through - invisible to the user), paints one cleared
+    /// frame, then lets the normal idle path park the tick and hide them after the grace.
+    /// Call on the UI thread once the compositor is enabled; no-op otherwise.
+    /// </summary>
+    public void Prewarm()
+    {
+        if (_disposed) return;
+        try
+        {
+            EnsureWindows(_windows, excluded: false);
+            foreach (var w in _windows.Values)
+            {
+                if (!w.IsVisible) w.Show();
+                w.InvalidateSurface();
+            }
+            Wake(); // ticks once, finds nothing active, parks + schedules the window hide
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "CompositorEngine: prewarm failed");
         }
     }
 
@@ -146,52 +181,72 @@ public class CompositorEngine : IDisposable
         if (anyMainActive) _lastAnyActiveUtc = nowUtc;
         if (anyExcludedActive) _lastExcludedActiveUtc = nowUtc;
 
-        SyncSurfaceVisibility(_windows, anyMainActive, excluded: false);
-        SyncSurfaceVisibility(_excludedWindows, anyExcludedActive, excluded: true);
+        ShowSurfaceIfActive(_windows, anyMainActive, excluded: false);
+        ShowSurfaceIfActive(_excludedWindows, anyExcludedActive, excluded: true);
 
         if (anyMainActive) foreach (var w in _windows.Values) w.InvalidateSurface();
         if (anyExcludedActive) foreach (var w in _excludedWindows.Values) w.InvalidateSurface();
 
+        // Active -> inactive: paint ONE cleared frame. The hosts stay visible through
+        // WindowHideGrace, and without this the last effect frame would linger on screen.
+        if (_wasMainActive && !anyMainActive) foreach (var w in _windows.Values) w.InvalidateSurface();
+        if (_wasExcludedActive && !anyExcludedActive) foreach (var w in _excludedWindows.Values) w.InvalidateSurface();
+        _wasMainActive = anyMainActive;
+        _wasExcludedActive = anyExcludedActive;
+
         // Fully park when everything has been idle past the grace window: unhook the tick so
-        // an idle compositor costs literally zero per frame.
+        // an idle compositor costs literally zero per frame. The (visible, empty) hosts are
+        // hidden later by the one-shot grace timer, not here.
         if (!anyMainActive && !anyExcludedActive
             && nowUtc - _lastAnyActiveUtc > IdleGrace
             && nowUtc - _lastExcludedActiveUtc > IdleGrace)
         {
             CompositionTarget.Rendering -= OnRendering;
             _renderingHooked = false;
+            ScheduleWindowHide();
         }
     }
 
-    private void SyncSurfaceVisibility(Dictionary<string, CompositorHostWindow> surface, bool active, bool excluded)
+    private void ShowSurfaceIfActive(Dictionary<string, CompositorHostWindow> surface, bool active, bool excluded)
     {
-        if (active)
+        if (!active) return;
+        EnsureWindows(surface, excluded);
+        foreach (var w in surface.Values)
         {
-            EnsureWindows(surface, excluded);
-            foreach (var w in surface.Values)
+            if (!w.IsVisible)
             {
-                if (!w.IsVisible)
-                {
-                    try { w.Show(); }
-                    catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Show failed"); }
-                }
+                try { w.Show(); }
+                catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Show failed"); }
             }
         }
-        else
+    }
+
+    /// <summary>Arm the one-shot hide of all (idle, empty) host windows, WindowHideGrace from
+    /// now. Cancelled by any Wake(); re-armed each time the engine parks. UI thread.</summary>
+    private void ScheduleWindowHide()
+    {
+        _hideTimer ??= CreateHideTimer();
+        _hideTimer.Stop();
+        _hideTimer.Start();
+    }
+
+    private DispatcherTimer CreateHideTimer()
+    {
+        var t = new DispatcherTimer { Interval = WindowHideGrace };
+        t.Tick += (_, _) =>
         {
-            var lastActive = excluded ? _lastExcludedActiveUtc : _lastAnyActiveUtc;
-            if (DateTime.UtcNow - lastActive > IdleGrace)
+            t.Stop();
+            if (_disposed || _renderingHooked) return; // re-woke during the grace: stay visible
+            foreach (var w in _windows.Values.Concat(_excludedWindows.Values))
             {
-                foreach (var w in surface.Values)
+                if (w.IsVisible)
                 {
-                    if (w.IsVisible)
-                    {
-                        try { w.Hide(); }
-                        catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Hide failed"); }
-                    }
+                    try { w.Hide(); }
+                    catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Hide failed"); }
                 }
             }
-        }
+        };
+        return t;
     }
 
     private void EnsureWindows(Dictionary<string, CompositorHostWindow> surface, bool excluded)
@@ -280,6 +335,7 @@ public class CompositorEngine : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        try { _hideTimer?.Stop(); } catch { }
         try { Microsoft.Win32.SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch { }
         if (_renderingHooked)
         {

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -1,0 +1,296 @@
+using System.Diagnostics;
+using System.Windows.Media;
+using System.Windows.Threading;
+using SkiaSharp;
+using SkiaSharp.Views.Desktop;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// The unified overlay host: renders all registered <see cref="IWpfLayer"/>s as z-ordered Skia
+/// layers inside ONE shared click-through window per monitor, replacing the historical
+/// one-window-per-effect model (whose concurrent fullscreen layered windows are the root cause
+/// of the session-lag / mouse-stutter cluster). Architecture mirrors the Avalonia port's
+/// CompositorEngine so effect code converges across the two heads.
+///
+/// Cost model: fully parked when no layer is active - no Rendering subscription, hosts hidden.
+/// Layers wake the engine via <see cref="Wake"/> (BaseLayer.SetActive does this).
+///
+/// Capture affinity: two surfaces per monitor. The MAIN surface must never be capture-excluded
+/// (subliminal/flash/spiral visibility in recordings is a product decision); layers with
+/// ExcludeFromCapture=true (brain drain) render on a separate lazily-created excluded surface.
+/// Windows are created once and hidden/re-shown, never churned (layered-window churn deadlocks
+/// the WPF render thread).
+/// </summary>
+public class CompositorEngine : IDisposable
+{
+    private static readonly TimeSpan IdleGrace = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan MaxDelta = TimeSpan.FromMilliseconds(100);
+
+    private readonly object _layerLock = new();
+    private readonly List<IWpfLayer> _layers = new();
+    private readonly Dictionary<IWpfLayer, bool> _lastActiveState = new();
+
+    private readonly Dictionary<string, CompositorHostWindow> _windows = new();
+    private readonly Dictionary<string, CompositorHostWindow> _excludedWindows = new();
+
+    private readonly Stopwatch _clock = Stopwatch.StartNew();
+    private TimeSpan _lastTickElapsed;
+    private TimeSpan _lastRenderingTime = TimeSpan.MinValue;
+    private DateTime _lastAnyActiveUtc = DateTime.MinValue;
+    private DateTime _lastExcludedActiveUtc = DateTime.MinValue;
+    private bool _renderingHooked;
+    private bool _disposed;
+
+    public CompositorEngine()
+    {
+        try
+        {
+            Microsoft.Win32.SystemEvents.DisplaySettingsChanged += OnDisplaySettingsChanged;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning(ex, "CompositorEngine: could not subscribe display-change events");
+        }
+    }
+
+    /// <summary>Register a layer. Layers live for the app's lifetime; there is no unregister path yet.</summary>
+    public void RegisterLayer(IWpfLayer layer)
+    {
+        lock (_layerLock)
+        {
+            if (_layers.Contains(layer)) return;
+            _layers.Add(layer);
+            _layers.Sort((a, b) => a.ZIndex.CompareTo(b.ZIndex));
+            _lastActiveState[layer] = false;
+        }
+        Wake();
+    }
+
+    /// <summary>
+    /// Ensure the engine is ticking. Safe from any thread and cheap when already awake;
+    /// called by layers whenever their activity or visible state changes.
+    /// </summary>
+    public void Wake()
+    {
+        if (_disposed) return;
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+
+        if (!dispatcher.CheckAccess())
+        {
+            dispatcher.BeginInvoke(DispatcherPriority.Render, Wake);
+            return;
+        }
+
+        if (!_renderingHooked)
+        {
+            _renderingHooked = true;
+            _lastTickElapsed = _clock.Elapsed;
+            CompositionTarget.Rendering += OnRendering;
+        }
+    }
+
+    private void OnRendering(object? sender, EventArgs e)
+    {
+        if (_disposed) return;
+
+        // CompositionTarget.Rendering can fire more than once per composed frame; dedupe on
+        // the composition clock so Update() advances once per real frame.
+        if (e is RenderingEventArgs args)
+        {
+            if (args.RenderingTime == _lastRenderingTime) return;
+            _lastRenderingTime = args.RenderingTime;
+        }
+
+        var now = _clock.Elapsed;
+        var delta = now - _lastTickElapsed;
+        _lastTickElapsed = now;
+        if (delta < TimeSpan.Zero) delta = TimeSpan.Zero;
+        if (delta > MaxDelta) delta = MaxDelta; // hitch: drop time instead of lurching
+
+        bool anyMainActive = false, anyExcludedActive = false;
+
+        IWpfLayer[] layers;
+        lock (_layerLock) layers = _layers.ToArray();
+
+        foreach (var layer in layers)
+        {
+            bool active = layer.IsActive;
+            if (_lastActiveState.TryGetValue(layer, out var was) && was != active)
+            {
+                _lastActiveState[layer] = active;
+                try
+                {
+                    if (active) layer.OnActivated();
+                    else layer.OnDeactivated();
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Error(ex, "CompositorEngine: layer lifecycle hook failed ({Layer})", layer.GetType().Name);
+                }
+            }
+
+            if (!active) continue;
+            if (layer.ExcludeFromCapture) anyExcludedActive = true;
+            else anyMainActive = true;
+
+            try { layer.Update(delta); }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "CompositorEngine: layer Update failed ({Layer})", layer.GetType().Name);
+            }
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        if (anyMainActive) _lastAnyActiveUtc = nowUtc;
+        if (anyExcludedActive) _lastExcludedActiveUtc = nowUtc;
+
+        SyncSurfaceVisibility(_windows, anyMainActive, excluded: false);
+        SyncSurfaceVisibility(_excludedWindows, anyExcludedActive, excluded: true);
+
+        if (anyMainActive) foreach (var w in _windows.Values) w.InvalidateSurface();
+        if (anyExcludedActive) foreach (var w in _excludedWindows.Values) w.InvalidateSurface();
+
+        // Fully park when everything has been idle past the grace window: unhook the tick so
+        // an idle compositor costs literally zero per frame.
+        if (!anyMainActive && !anyExcludedActive
+            && nowUtc - _lastAnyActiveUtc > IdleGrace
+            && nowUtc - _lastExcludedActiveUtc > IdleGrace)
+        {
+            CompositionTarget.Rendering -= OnRendering;
+            _renderingHooked = false;
+        }
+    }
+
+    private void SyncSurfaceVisibility(Dictionary<string, CompositorHostWindow> surface, bool active, bool excluded)
+    {
+        if (active)
+        {
+            EnsureWindows(surface, excluded);
+            foreach (var w in surface.Values)
+            {
+                if (!w.IsVisible)
+                {
+                    try { w.Show(); }
+                    catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Show failed"); }
+                }
+            }
+        }
+        else
+        {
+            var lastActive = excluded ? _lastExcludedActiveUtc : _lastAnyActiveUtc;
+            if (DateTime.UtcNow - lastActive > IdleGrace)
+            {
+                foreach (var w in surface.Values)
+                {
+                    if (w.IsVisible)
+                    {
+                        try { w.Hide(); }
+                        catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Hide failed"); }
+                    }
+                }
+            }
+        }
+    }
+
+    private void EnsureWindows(Dictionary<string, CompositorHostWindow> surface, bool excluded)
+    {
+        System.Windows.Forms.Screen[] screens;
+        try { screens = System.Windows.Forms.Screen.AllScreens; }
+        catch { return; }
+        if (screens.Length == 0) return; // can be empty during display transitions
+
+        foreach (var screen in screens)
+        {
+            if (surface.ContainsKey(screen.DeviceName)) continue;
+            var window = new CompositorHostWindow(screen, excluded);
+            window.PaintSurface += OnPaintSurface;
+            surface[screen.DeviceName] = window;
+        }
+    }
+
+    private void OnPaintSurface(CompositorHostWindow window, SKPaintSurfaceEventArgs e)
+    {
+        var canvas = e.Surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+
+        var boundsPx = new SKRectI(0, 0, e.Info.Width, e.Info.Height);
+        double dpiScale = window.ActualWidth > 0 ? e.Info.Width / window.ActualWidth : 1.0;
+        var elapsed = _clock.Elapsed;
+
+        IWpfLayer[] layers;
+        lock (_layerLock) layers = _layers.ToArray();
+
+        foreach (var layer in layers) // already z-sorted; lower draws first
+        {
+            if (!layer.IsActive || layer.ExcludeFromCapture != window.IsExcludedSurface) continue;
+            try { layer.Render(canvas, boundsPx, dpiScale, elapsed); }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "CompositorEngine: layer Render failed ({Layer})", layer.GetType().Name);
+            }
+        }
+    }
+
+    private void OnDisplaySettingsChanged(object? sender, EventArgs e)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+        dispatcher.BeginInvoke(DispatcherPriority.Background, () =>
+        {
+            if (_disposed) return;
+            try
+            {
+                RebuildSurface(_windows);
+                RebuildSurface(_excludedWindows);
+                Wake();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "CompositorEngine: display-change rebuild failed");
+            }
+        });
+    }
+
+    private static void RebuildSurface(Dictionary<string, CompositorHostWindow> surface)
+    {
+        System.Windows.Forms.Screen[] screens;
+        try { screens = System.Windows.Forms.Screen.AllScreens; }
+        catch { return; }
+        if (screens.Length == 0) return;
+
+        var byName = screens.ToDictionary(s => s.DeviceName);
+
+        // Topology changes are the ONE sanctioned teardown point for host windows.
+        foreach (var gone in surface.Keys.Where(k => !byName.ContainsKey(k)).ToList())
+        {
+            try { surface[gone].Close(); } catch { }
+            surface.Remove(gone);
+        }
+
+        foreach (var (name, window) in surface)
+        {
+            window.UpdateScreenBounds(byName[name]);
+        }
+        // New monitors get hosts lazily on the next active tick (EnsureWindows).
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { Microsoft.Win32.SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged; } catch { }
+        if (_renderingHooked)
+        {
+            try { CompositionTarget.Rendering -= OnRendering; } catch { }
+            _renderingHooked = false;
+        }
+        foreach (var w in _windows.Values.Concat(_excludedWindows.Values))
+        {
+            try { w.Close(); } catch { }
+        }
+        _windows.Clear();
+        _excludedWindows.Clear();
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -280,7 +280,29 @@ public class CompositorEngine : IDisposable
         foreach (var layer in layers) // already z-sorted; lower draws first
         {
             if (!layer.IsActive || layer.ExcludeFromCapture != window.IsExcludedSurface) continue;
-            try { layer.Render(canvas, boundsPx, dpiScale, elapsed); }
+            try
+            {
+                if (layer.WorldSpacePx)
+                {
+                    // World-space layers draw in virtual-desktop device px. The surface is
+                    // normally exactly device-px sized (ApplyNativeState stamps physical
+                    // bounds); if WPF rasterized the SKElement at a stale scale during a
+                    // mixed-DPI transition, the scale factor re-squares it.
+                    var sb = window.ScreenBoundsPx;
+                    if (sb.Width <= 0 || sb.Height <= 0) continue;
+                    canvas.Save();
+                    if (e.Info.Width != sb.Width || e.Info.Height != sb.Height)
+                        canvas.Scale(e.Info.Width / (float)sb.Width, e.Info.Height / (float)sb.Height);
+                    canvas.Translate(-sb.X, -sb.Y);
+                    layer.Render(canvas, new SKRectI(sb.X, sb.Y, sb.X + sb.Width, sb.Y + sb.Height),
+                                 dpiScale, elapsed);
+                    canvas.Restore();
+                }
+                else
+                {
+                    layer.Render(canvas, boundsPx, dpiScale, elapsed);
+                }
+            }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "CompositorEngine: layer Render failed ({Layer})", layer.GetType().Name);

--- a/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
@@ -13,11 +13,12 @@ namespace ConditioningControlPanel.Services.Compositor;
 /// Created once and hidden/re-shown, never destroyed mid-run (layered-window churn deadlocks
 /// the WPF render thread - see the chaos overlay keep-alive rule).
 /// </summary>
-public class CompositorHostWindow : Window
+public class CompositorHostWindow : Window, ICompositorHost
 {
     private readonly SKElement _surface;
     private readonly bool _excludeFromCapture;
     private System.Drawing.Rectangle _screenBoundsPx;
+    private readonly double _dpiScale;
     private IntPtr _hwnd = IntPtr.Zero;
 
     /// <summary>Device name of the screen this host covers (System.Windows.Forms.Screen.DeviceName).</summary>
@@ -25,6 +26,9 @@ public class CompositorHostWindow : Window
 
     /// <summary>True when this host is the capture-excluded surface (brain drain et al.).</summary>
     public bool IsExcludedSurface => _excludeFromCapture;
+
+    /// <summary>Monitor DPI scale at creation (dpi / 96).</summary>
+    public double DpiScale => _dpiScale;
 
     /// <summary>This host's monitor rectangle in device pixels (world-space layers render
     /// relative to it — see IWpfLayer.WorldSpacePx).</summary>
@@ -56,6 +60,7 @@ public class CompositorHostWindow : Window
         // mixed-DPI lesson from the lock card #539 fix: DIP layout renders with a stale scale
         // on secondary monitors, device-pixel bounds do not).
         var dpi = GetDpiScaleForScreen(screen);
+        _dpiScale = dpi;
         Left = screen.Bounds.X / dpi;
         Top = screen.Bounds.Y / dpi;
         Width = screen.Bounds.Width / dpi;

--- a/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
@@ -26,6 +26,10 @@ public class CompositorHostWindow : Window
     /// <summary>True when this host is the capture-excluded surface (brain drain et al.).</summary>
     public bool IsExcludedSurface => _excludeFromCapture;
 
+    /// <summary>This host's monitor rectangle in device pixels (world-space layers render
+    /// relative to it — see IWpfLayer.WorldSpacePx).</summary>
+    public System.Drawing.Rectangle ScreenBoundsPx => _screenBoundsPx;
+
     /// <summary>Raised by the SKElement when the surface repaints; the engine draws the layers.</summary>
     public event Action<CompositorHostWindow, SKPaintSurfaceEventArgs>? PaintSurface;
 
@@ -125,7 +129,7 @@ public class CompositorHostWindow : Window
         }
     }
 
-    private static double GetDpiScaleForScreen(System.Windows.Forms.Screen screen)
+    internal static double GetDpiScaleForScreen(System.Windows.Forms.Screen screen)
     {
         try
         {

--- a/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
@@ -1,0 +1,179 @@
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+using System.Windows.Media;
+using SkiaSharp.Views.Desktop;
+using SkiaSharp.Views.WPF;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// One shared fullscreen overlay host per monitor. Borderless, transparent, topmost, and
+/// permanently click-through at BOTH levels (WPF hit-testing off + WS_EX_TRANSPARENT), it
+/// renders all active compositor layers for its monitor through a single SKElement.
+/// Created once and hidden/re-shown, never destroyed mid-run (layered-window churn deadlocks
+/// the WPF render thread - see the chaos overlay keep-alive rule).
+/// </summary>
+public class CompositorHostWindow : Window
+{
+    private readonly SKElement _surface;
+    private readonly bool _excludeFromCapture;
+    private System.Drawing.Rectangle _screenBoundsPx;
+    private IntPtr _hwnd = IntPtr.Zero;
+
+    /// <summary>Device name of the screen this host covers (System.Windows.Forms.Screen.DeviceName).</summary>
+    public string ScreenDeviceName { get; }
+
+    /// <summary>True when this host is the capture-excluded surface (brain drain et al.).</summary>
+    public bool IsExcludedSurface => _excludeFromCapture;
+
+    /// <summary>Raised by the SKElement when the surface repaints; the engine draws the layers.</summary>
+    public event Action<CompositorHostWindow, SKPaintSurfaceEventArgs>? PaintSurface;
+
+    public CompositorHostWindow(System.Windows.Forms.Screen screen, bool excludeFromCapture)
+    {
+        ScreenDeviceName = screen.DeviceName;
+        _screenBoundsPx = screen.Bounds;
+        _excludeFromCapture = excludeFromCapture;
+
+        WindowStyle = WindowStyle.None;
+        ResizeMode = ResizeMode.NoResize;
+        AllowsTransparency = true;
+        Background = Brushes.Transparent;
+        Topmost = true;
+        ShowInTaskbar = false;
+        ShowActivated = false;
+        Focusable = false;
+        IsHitTestVisible = false;
+        SizeToContent = SizeToContent.Manual;
+        WindowStartupLocation = WindowStartupLocation.Manual;
+
+        // Approximate DIP placement so WPF opens the window on the right monitor; the exact
+        // cover is enforced in device pixels via SetWindowPos once the handle exists (the
+        // mixed-DPI lesson from the lock card #539 fix: DIP layout renders with a stale scale
+        // on secondary monitors, device-pixel bounds do not).
+        var dpi = GetDpiScaleForScreen(screen);
+        Left = screen.Bounds.X / dpi;
+        Top = screen.Bounds.Y / dpi;
+        Width = screen.Bounds.Width / dpi;
+        Height = screen.Bounds.Height / dpi;
+
+        _surface = new SKElement();
+        _surface.PaintSurface += (s, e) => PaintSurface?.Invoke(this, e);
+        Content = _surface;
+
+        SourceInitialized += OnSourceInitialized;
+        Activated += (s, e) => ApplyNativeState();
+        StateChanged += (s, e) =>
+        {
+            if (WindowState != WindowState.Normal) WindowState = WindowState.Normal;
+            ApplyNativeState();
+        };
+    }
+
+    /// <summary>Repaint the Skia surface (engine tick calls this once per frame while active).</summary>
+    public void InvalidateSurface() => _surface.InvalidateVisual();
+
+    /// <summary>Re-target the host after display topology changes.</summary>
+    public void UpdateScreenBounds(System.Windows.Forms.Screen screen)
+    {
+        _screenBoundsPx = screen.Bounds;
+        ApplyNativeState();
+    }
+
+    private void OnSourceInitialized(object? sender, EventArgs e)
+    {
+        _hwnd = new WindowInteropHelper(this).Handle;
+        ApplyNativeState();
+
+        if (_excludeFromCapture && _hwnd != IntPtr.Zero)
+        {
+            // Brain-drain surface only: keep the effect out of screenshots/streams and out of
+            // the app's own capture loops (self-capture feedback). Never apply this to the
+            // main surface - subliminal/flash/spiral visibility in capture is a product decision.
+            SetWindowDisplayAffinity(_hwnd, WDA_EXCLUDEFROMCAPTURE);
+        }
+    }
+
+    protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
+    {
+        base.OnDpiChanged(oldDpi, newDpi);
+        // Re-assert the physical cover; WPF's own DIP re-layout on DPI change is what
+        // produced stale-scale under-covering on mixed-DPI setups (#539).
+        ApplyNativeState();
+    }
+
+    /// <summary>
+    /// Applies click-through ex-styles and the exact device-pixel monitor cover. Re-run on
+    /// every native lifecycle edge (source init, activation, state/DPI change): styles and
+    /// bounds are both known to decay across those transitions.
+    /// </summary>
+    private void ApplyNativeState()
+    {
+        if (_hwnd == IntPtr.Zero) return;
+        try
+        {
+            var ex = GetWindowLong(_hwnd, GWL_EXSTYLE);
+            SetWindowLong(_hwnd, GWL_EXSTYLE,
+                ex | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+            SetWindowPos(_hwnd, HWND_TOPMOST,
+                _screenBoundsPx.X, _screenBoundsPx.Y, _screenBoundsPx.Width, _screenBoundsPx.Height,
+                SWP_NOACTIVATE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+        }
+        catch (Exception ex2)
+        {
+            App.Logger?.Warning(ex2, "CompositorHostWindow: failed to apply native state for {Screen}", ScreenDeviceName);
+        }
+    }
+
+    private static double GetDpiScaleForScreen(System.Windows.Forms.Screen screen)
+    {
+        try
+        {
+            var pt = new System.Drawing.Point(screen.Bounds.X + screen.Bounds.Width / 2,
+                                              screen.Bounds.Y + screen.Bounds.Height / 2);
+            var monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+            if (monitor != IntPtr.Zero &&
+                GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, out var dpiX, out _) == 0 && dpiX > 0)
+            {
+                return dpiX / 96.0;
+            }
+        }
+        catch { /* fall through to primary-DPI assumption */ }
+        return 1.0;
+    }
+
+    #region Win32
+
+    private const int GWL_EXSTYLE = -20;
+    private const int WS_EX_TRANSPARENT = 0x00000020;
+    private const int WS_EX_LAYERED = 0x00080000;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private const int WS_EX_NOACTIVATE = 0x08000000;
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const uint SWP_FRAMECHANGED = 0x0020;
+    private const uint SWP_SHOWWINDOW = 0x0040;
+    private const uint WDA_EXCLUDEFROMCAPTURE = 0x0011;
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
+    private const int MDT_EFFECTIVE_DPI = 0;
+
+    [DllImport("user32.dll")]
+    private static extern int GetWindowLong(IntPtr hwnd, int index);
+
+    [DllImport("user32.dll")]
+    private static extern int SetWindowLong(IntPtr hwnd, int index, int newStyle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowDisplayAffinity(IntPtr hwnd, uint affinity);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, uint flags);
+
+    [DllImport("shcore.dll")]
+    private static extern int GetDpiForMonitor(IntPtr hMonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+    #endregion
+}

--- a/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorHostWindow.cs
@@ -34,6 +34,9 @@ public class CompositorHostWindow : Window, ICompositorHost
     /// relative to it — see IWpfLayer.WorldSpacePx).</summary>
     public System.Drawing.Rectangle ScreenBoundsPx => _screenBoundsPx;
 
+    /// <summary>Native handle (Zero until SourceInitialized).</summary>
+    public nint WindowHandle => _hwnd;
+
     /// <summary>Raised by the SKElement when the surface repaints; the engine draws the layers.</summary>
     public event Action<CompositorHostWindow, SKPaintSurfaceEventArgs>? PaintSurface;
 
@@ -124,9 +127,17 @@ public class CompositorHostWindow : Window, ICompositorHost
             var ex = GetWindowLong(_hwnd, GWL_EXSTYLE);
             SetWindowLong(_hwnd, GWL_EXSTYLE,
                 ex | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+            // Only natively SHOW when the window is meant to be shown, else a topology-change
+            // UpdateScreenBounds re-shows a host the engine hid (past WindowHideGrace) while WPF
+            // IsVisible stays false - the hide timer's IsVisible check then never hides it again.
+            // Keyed off Visibility, not IsVisible: Show() sets Visibility=Visible BEFORE the hwnd
+            // is created (SourceInitialized fires mid-Show, when IsVisible is still false), so the
+            // first Show still presents; Hide() sets it to Hidden.
+            uint flags = SWP_NOACTIVATE | SWP_FRAMECHANGED;
+            if (Visibility == Visibility.Visible) flags |= SWP_SHOWWINDOW;
             SetWindowPos(_hwnd, HWND_TOPMOST,
                 _screenBoundsPx.X, _screenBoundsPx.Y, _screenBoundsPx.Width, _screenBoundsPx.Height,
-                SWP_NOACTIVATE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+                flags);
         }
         catch (Exception ex2)
         {

--- a/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
@@ -1,0 +1,20 @@
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Authoritative z-order constants for compositor layers. Lower renders first (behind).
+/// Values intentionally MATCH the Avalonia port's CompositorLayers so effect code stays
+/// portable between the two heads - do not renumber without coordinating both repos.
+/// </summary>
+public static class CompositorLayers
+{
+    public const int Video = 10;
+    public const int MandatoryVideo = 15;
+    public const int LockCard = 20;
+    public const int Flash = 30;
+    public const int Subliminal = 40;
+    public const int Bubbles = 45;
+    public const int BouncingText = 50;
+    public const int BrainDrain = 55;
+    public const int Spiral = 60;
+    public const int PinkTint = 70;
+}

--- a/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
@@ -13,11 +13,18 @@ public static class CompositorLayers
     public const int Flash = 30;
     public const int Subliminal = 40;
     public const int Bubbles = 45;
-    // WPF-side addition (not yet in the Avalonia table — coordinate before porting): the chaos
-    // FX particle field (pop bursts / trails / bolts / ripples), above bubbles, below text.
-    public const int Fx = 48;
     public const int BouncingText = 50;
     public const int BrainDrain = 55;
     public const int Spiral = 60;
     public const int PinkTint = 70;
+
+    // ---------------- Chaos band (100-199, mirrors the Avalonia table) ----------------
+    // Chaos visuals sit ABOVE the session effects (PinkTint 70): WPF re-raises chaos windows
+    // topmost on every show/arm (ChaosWindowZ), so a sparkle burst renders over the pink tint.
+    // The Avalonia head splits ChaosSkiaFxOverlay into granular layers (ChaosFieldFx=100,
+    // ChaosEStimArc=125, ChaosVibeTrail=128, ChaosCursorGlow=130; its ChaosFx=118 is the
+    // DIFFERENT edge-vignette effect). The WPF ChaosFxLayer still merges bursts/trails/bolts/
+    // ripples/cursor glow into ONE layer, so it takes a single free slot inside the band;
+    // split into the granular siblings when converging further.
+    public const int Fx = 120;
 }

--- a/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorLayers.cs
@@ -13,6 +13,9 @@ public static class CompositorLayers
     public const int Flash = 30;
     public const int Subliminal = 40;
     public const int Bubbles = 45;
+    // WPF-side addition (not yet in the Avalonia table — coordinate before porting): the chaos
+    // FX particle field (pop bursts / trails / bolts / ripples), above bubbles, below text.
+    public const int Fx = 48;
     public const int BouncingText = 50;
     public const int BrainDrain = 55;
     public const int Spiral = 60;

--- a/ConditioningControlPanel/Services/Compositor/DESIGN.md
+++ b/ConditioningControlPanel/Services/Compositor/DESIGN.md
@@ -1,0 +1,101 @@
+# Unified Overlay Host (WPF mini-compositor)
+
+Branch `feat/wpf-compositor`. Flag: `Settings.UnifiedOverlayHost` (default OFF).
+One shared fullscreen click-through Skia window per monitor (`CompositorHostWindow`)
+renders passive effects as z-ordered `IWpfLayer`s (`CompositorEngine`), replacing the
+one-window-per-effect model that causes the session-lag / mouse-stutter cluster.
+The seam (member names, z-values, rules) deliberately MIRRORS the Avalonia port's
+compositor (ObviouslyNotMich fork, `CCP.Avalonia/Compositor/`) so effect code converges.
+
+## Why (the lag mechanism)
+Bubbles + subliminals + spiral + pink + braindrain concurrently = 4-6 fullscreen
+`AllowsTransparency` windows redrawing + per-bubble windows + N `DispatcherTimer`s.
+DWM/UI-thread saturation starves the WH_MOUSE_LL hook -> system-wide mouse stutter.
+
+## House prototypes this generalizes (copy their scars, not their windows)
+- `Chaos/ChaosSkiaFxOverlay.cs` - SKElement + CompositionTarget.Rendering + keep-alive
+  click-through window + idle auto-hide (~:550) + px->DIP `Local()` (~:607).
+- `Chaos/ChaosBubbleHostOverlay.cs` - shared Canvas host, physical-px `Place()`,
+  ref-counted keep-alive, `RefreshMetrics` DPI cache (~:183).
+
+## Extracted legacy contracts (recon 2026-07-13, line numbers drift)
+
+### OverlayService (Services/Notifications/OverlayService.cs)
+- One window per screen via `App.GetAllScreensCached()`; shell = borderless transparent
+  topmost non-activating click-through; ex-styles in SourceInitialized (~:855/:1281/:1721).
+- Pink filter: `Border` + `SolidColorBrush(FromArgb(opacity*255, GetFilterRgb()))` -
+  opacity lives in the BRUSH ALPHA (~:821). No image.
+- Spiral: GIF frames decoded ONCE shared across screens (`LoadSpiralGifFrames`), animated
+  by swapping `Image.Source` on `_gifFrameTimer` (Render priority, ~:952,:1183);
+  `Stretch.UniformToFill` + ClipToBounds. Non-GIF spiral = `MediaElement` VIDEO loop
+  (~:1301) - VIDEO SPIRAL STAYS LEGACY for now (layer handles GIF path only).
+  **Spiral opacity always gets x0.1 reduction** (~:314,:729,:1306) - replicate exactly.
+- Brain drain: GDI BitBlt screen capture (P/Invokes ~:103) -> BitmapSource -> WPF
+  BlurEffect(Gaussian, radius intensity*0.4/downscale) on a timer (fps<=30/60 by perf
+  tier, ~:1489); window is WDA_EXCLUDEFROMCAPTURE (~:1724) to avoid self-capture.
+- Ramps: `_rampPinkOpacity/_rampSpiralOpacity/_rampBrainDrainOpacity` (nullable, ~:61)
+  OWN the opacity while set; `Update*Opacity()` early-returns during a ramp (~:894).
+- `PulseOverlays()` (~:282): 1s boost then restore; #535 fix = restore to RAMP value via
+  `Apply*OpacityDirect` when ramp active, else settings (~:333-361).
+- Topmost decays: re-pin HWND_TOPMOST every ~10 ticks of the 500ms `_updateTimer` (~:73,
+  :1928). Compositor host needs equivalent re-pin cadence.
+- Public API to keep working in compositor mode: Start/Stop, RefreshOverlays,
+  RefreshForDualMonitorChange, PulseOverlays, ShowOverlayTimed(kind,...),
+  Show/HideOverlaySustained(kind,...), SetSustainedOverlayOpacity, ReleaseOpacityRampHolds,
+  Start/StopBrainDrainBlur, UpdateBrainDrainBlurOpacity.
+
+### SubliminalService (Services/Subliminal/SubliminalService.cs)
+- One persistent window per screen (`_screenWindows`, keyed DeviceName, ~:844); idles at
+  Opacity=0, NEVER Hide() (hidden layered windows re-present a stale frame, ~:1221).
+- Card = outlined text: Arial Bold 120, 8 offset outline copies + main text (~:887-945);
+  colors from SubTextColor/SubBackgroundColor settings. 50ms fade-in / hold / 50ms
+  fade-out storyboard with `_showGeneration` guard (~:1178).
+- WDA_NONE deliberately applied (~:978) - subliminals STAY in capture; OCR avoids them
+  via `GetActiveTextScreenRects()` rects instead.
+- `SubliminalStealsFocus` clears WS_EX_NOACTIVATE + Activate() (~:959-965,:640) -
+  focus-steal CANNOT come from the shared host; that variant stays on legacy windows
+  (same reason solid mode falls back, ~:619).
+
+### FlashService (Services/Flash/FlashService.cs)
+- Window pool (`_windowPool`, cap ~:2397); fade driven by CompositionTarget.Rendering
+  heartbeat (~:1503), per-window lifetime CTS.
+- GIF/WebP decode: `Services/Media/AnimatedWebp.DecodeFrames` (SKCodec) behind a GLOBAL
+  `SemaphoreSlim(2,2)` decode gate (AnimatedWebp.cs:70, crash family d05d5ae4 0xc0000374).
+  ANY compositor decode fan-out must honor the same gate.
+- `ApplyClickability` (~:2319): clickable flashes clear WS_EX_TRANSPARENT per spawn.
+  FlashLayer will need hook hit-testing instead (like bubbles).
+
+### BubbleService shared-host mode (Services/BubbleService.cs)
+- Snapshots rebuilt per anim tick (~:510): `ChaosBubbleCentersSnapshot` (Point[] px),
+  `ChaosClickDiscsSnapshot` ((X,Y,R,Hold)[] px, host-rendered clickable bubbles only);
+  static immutable arrays swapped atomically, hook thread reads lock-free.
+- `OnSharedHostLeftDown(px)` on HOOK THREAD (~:546): hit -> BeginInvoke PopTopmostAt,
+  return `!needsHold` - **hold-to-defuse clicks are never swallowed** (GetAsyncKeyState
+  cannot see swallowed clicks). Preserve exactly.
+- `GlobalMouseHook` (Services/Input/GlobalMouseHook.cs): `Func<Point,bool>` callbacks,
+  synchronous on hook thread, return true = swallow; touch only immutable snapshots.
+
+### Screens / DPI
+- App manifest is PerMonitorV2: WPF DIP bounds are computed at the PRIMARY scale and are
+  WRONG on mixed-DPI secondaries - always stamp physical px via SetWindowPos after the
+  handle exists and on DpiChanged (#457/#539 lesson). `CompositorHostWindow` does this.
+- Enumerate monitors ONLY via `App.GetAllScreensCached()` (App.xaml.cs:465); invalidated
+  on display change; can be empty during transitions.
+
+## Migration order + routing pattern
+Effect services keep ALL state/math (ramps, pulses, holds, timers-for-logic); layers
+only render state. Routing: each service checks `UseCompositor` (flag + App.Compositor
+!= null) at effect-start; legacy windows when off. Order:
+1. PinkTintLayer (z70) + SpiralLayer (z60, GIF path) - DONE when this doc is committed.
+2. BrainDrainLayer (z55, ExcludeFromCapture=true, GDI capture -> SKImage -> Skia blur).
+3. SubliminalLayer (z40, capture-visible; focus-steal variant stays legacy).
+4. BubbleLayer (z45) + FlashLayer (z30) - hook hit-testing via existing snapshots.
+5. Measure vs legacy (frame pacing + mouse-hook latency), then flip default ON.
+
+## Open questions
+- Video spiral (MediaElement) as a layer needs a frame source - defer, maybe post-libmpv
+  discussions with the Avalonia port.
+- Subliminal focus-steal: keep legacy per-screen window path forever, or drop feature
+  when host mode on? Owner decision pending.
+- Engine topmost re-pin cadence vs OverlayService's 5s repin - decide when wiring video
+  interaction (video windows raise above overlays deliberately during playback).

--- a/ConditioningControlPanel/Services/Compositor/FlashLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/FlashLayer.cs
@@ -1,0 +1,214 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the flash image popups. Unlike the Avalonia port's FlashLayer (which
+/// owns fade + GIF advance), this layer is a pure DRAW LIST: FlashService's existing heartbeat
+/// keeps driving every item's opacity, frame index and gaze-dwell scale through the FlashWindow
+/// state bag - exactly the split solid mode already established - so fade speed, lifetime,
+/// hydra, gaze and XP behavior are identical by construction. Flag the split when coordinating
+/// with the Avalonia head.
+///
+/// Threading: every member is UI-thread only (spawn/remove happen on the dispatcher, and the
+/// engine ticks Update/Render there too), so items need no locking. Items OWN their SKImage
+/// frames; <see cref="Remove"/>/<see cref="Clear"/> dispose them deterministically - never
+/// dispose an item's frames from outside the layer.
+///
+/// Renders on the MAIN surface (flashes stay visible in recordings, like every non-braindrain
+/// effect). Mouse clicks can't reach the click-through host: FlashService runs a global-hook
+/// hit-test over these items (like the shared-host bubbles) for clickable flashes.
+/// </summary>
+public sealed class FlashLayer : BaseLayer
+{
+    /// <summary>One live flash. FlashService's heartbeat writes the mutable fields each tick.</summary>
+    public sealed class FlashItem
+    {
+        /// <summary>Decoded frames, owned by the layer. Null after removal.</summary>
+        internal SKImage[]? Frames;
+
+        // Bookkeeping rect in world (virtual-desktop) px - INCLUDES the glow padding,
+        // mirroring host mode's expanded rect (gaze + overlap read the same values in DIP
+        // from the FlashWindow state bag).
+        public float X, Y, W, H;
+        /// <summary>Glow inset: the image draws PaddingPx inside the rect (legacy Border.Padding).</summary>
+        public float PaddingPx;
+        public float CornerRadiusPx;
+
+        /// <summary>Fade alpha 0..1 - written by FlashService's heartbeat (VisualOpacity).</summary>
+        public double Opacity;
+        /// <summary>Current GIF frame - written by FlashService's heartbeat.</summary>
+        public int FrameIndex;
+        /// <summary>Gaze-dwell inflate about center, 1.0..1.1 (SetGazeDwellProgress parity).</summary>
+        public double DwellScale = 1.0;
+
+        // Glow (lucky / sparkle-boost tiers). Sigma is the WPF DropShadow blur radius / 3
+        // (same conversion as the brain-drain layer). LuckyPulse replicates the 400ms
+        // auto-reverse radius x1.6 / opacity 0.7->1.0 forever-animation.
+        internal bool HasGlow;
+        internal SKColor GlowColor;
+        internal float GlowSigmaPx;
+        internal double GlowOpacity;
+        internal bool LuckyPulse;
+
+        internal double ElapsedSec;          // pulse clock, advanced by Update
+        internal SKMaskFilter? BlurCache;    // rebuilt only when the quantized sigma changes
+        internal float BlurCacheSigma = -1f;
+
+        internal void ReleaseFrames()
+        {
+            var frames = Frames;
+            Frames = null;
+            if (frames == null) return;
+            foreach (var f in frames)
+            {
+                try { f.Dispose(); } catch { }
+            }
+            BlurCache?.Dispose();
+            BlurCache = null;
+        }
+    }
+
+    private readonly List<FlashItem> _items = new();
+    // Reused paints (no per-frame allocations).
+    private readonly SKPaint _imagePaint = new() { FilterQuality = SKFilterQuality.Low };
+    private readonly SKPaint _fillPaint = new();
+
+    public FlashLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.Flash;
+
+    public override bool WorldSpacePx => true;
+
+    /// <summary>
+    /// Add a flash. The layer takes ownership of <paramref name="frames"/>. Geometry is world
+    /// px; the image draws <paramref name="paddingPx"/> inside the rect (glow inset, 0 without
+    /// glow). <paramref name="glowSigmaPx"/> is the DropShadow radius/3 in px; 0 = no glow.
+    /// </summary>
+    public FlashItem Spawn(SKImage[] frames, float x, float y, float w, float h,
+        float paddingPx, float cornerRadiusPx,
+        SKColor glowColor, float glowSigmaPx, double glowOpacity, bool luckyPulse)
+    {
+        var item = new FlashItem
+        {
+            Frames = frames,
+            X = x, Y = y, W = w, H = h,
+            PaddingPx = paddingPx,
+            CornerRadiusPx = cornerRadiusPx,
+            HasGlow = glowSigmaPx > 0,
+            GlowColor = glowColor,
+            GlowSigmaPx = glowSigmaPx,
+            GlowOpacity = glowOpacity,
+            LuckyPulse = luckyPulse
+        };
+        _items.Add(item);
+        SetActive(true);
+        return item;
+    }
+
+    /// <summary>Remove an item and dispose its frames. Idempotent.</summary>
+    public void Remove(FlashItem item)
+    {
+        item.ReleaseFrames();
+        _items.Remove(item);
+        if (_items.Count == 0) SetActive(false);
+    }
+
+    public void Clear()
+    {
+        foreach (var item in _items) item.ReleaseFrames();
+        _items.Clear();
+        SetActive(false);
+    }
+
+    public override void Update(TimeSpan delta)
+    {
+        for (int i = 0; i < _items.Count; i++)
+            _items[i].ElapsedSec += delta.TotalSeconds;
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        for (int i = 0; i < _items.Count; i++)
+        {
+            var item = _items[i];
+            var frames = item.Frames;
+            if (frames == null || frames.Length == 0 || item.Opacity <= 0) continue;
+
+            var rect = new SKRect(item.X, item.Y, item.X + item.W, item.Y + item.H);
+            if (!rect.IntersectsWith(boundsPx)) continue;   // cull to this monitor
+
+            var alpha = (byte)Math.Clamp(item.Opacity * 255, 0, 255);
+            var image = frames[Math.Clamp(item.FrameIndex, 0, frames.Length - 1)];
+
+            int saves = canvas.Save();
+            // Gaze-dwell inflate about the rect center (RenderTransform ScaleTransform parity).
+            if (item.DwellScale > 1.001)
+            {
+                var s = (float)item.DwellScale;
+                canvas.Translate(rect.MidX, rect.MidY);
+                canvas.Scale(s, s);
+                canvas.Translate(-rect.MidX, -rect.MidY);
+            }
+
+            // The image sits PaddingPx inside the bookkeeping rect (glow inset), letterboxed
+            // uniform like Stretch.Uniform - geometry preserves aspect, so fit is a no-op in
+            // practice, but the 50px minimum clamp can distort slightly on tiny images.
+            var inner = new SKRect(rect.Left + item.PaddingPx, rect.Top + item.PaddingPx,
+                rect.Right - item.PaddingPx, rect.Bottom - item.PaddingPx);
+            var fit = UniformFit(image.Width, image.Height, inner);
+
+            if (item.HasGlow)
+            {
+                // Halo: blurred round-rect behind the image (DropShadow depth-0 equivalent).
+                var sigma = item.GlowSigmaPx;
+                var glowAlpha = item.GlowOpacity;
+                if (item.LuckyPulse)
+                {
+                    // 400ms auto-reverse: radius base->x1.6, opacity 0.7->1.0 (legacy anim).
+                    var tri = Math.Abs(item.ElapsedSec % 0.8 / 0.4 - 1.0);   // 1..0..1 triangle
+                    tri = 1.0 - tri;                                          // 0..1..0
+                    sigma *= (float)(1.0 + 0.6 * tri);
+                    glowAlpha = 0.7 + 0.3 * tri;
+                }
+                // Rebuild the mask filter only when the quantized sigma moves (blur filters
+                // are expensive to churn per frame; lucky pulses quantize to 0.5px steps).
+                var q = MathF.Round(sigma * 2f) / 2f;
+                if (item.BlurCache == null || Math.Abs(q - item.BlurCacheSigma) > 0.01f)
+                {
+                    item.BlurCache?.Dispose();
+                    item.BlurCache = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, Math.Max(0.5f, q));
+                    item.BlurCacheSigma = q;
+                }
+                _fillPaint.MaskFilter = item.BlurCache;
+                _fillPaint.Color = item.GlowColor.WithAlpha(
+                    (byte)Math.Clamp(glowAlpha * item.Opacity * 255, 0, 255));
+                canvas.DrawRoundRect(new SKRoundRect(fit, item.CornerRadiusPx), _fillPaint);
+                _fillPaint.MaskFilter = null;
+
+                // Rounded clip so the image corners match the glow card (legacy clip Border).
+                canvas.ClipRoundRect(new SKRoundRect(fit, item.CornerRadiusPx), antialias: true);
+            }
+            else
+            {
+                // Legacy non-glow content: black backing behind the (letterboxed) image.
+                _fillPaint.Color = new SKColor(0, 0, 0, alpha);
+                canvas.DrawRect(inner, _fillPaint);
+            }
+
+            _imagePaint.Color = new SKColor(255, 255, 255, alpha);
+            canvas.DrawImage(image, fit, _imagePaint);
+            canvas.RestoreToCount(saves);
+        }
+    }
+
+    private static SKRect UniformFit(int srcW, int srcH, SKRect dest)
+    {
+        if (srcW <= 0 || srcH <= 0 || dest.Width <= 0 || dest.Height <= 0) return dest;
+        var ratio = Math.Min(dest.Width / srcW, dest.Height / srcH);
+        float w = srcW * ratio, h = srcH * ratio;
+        var x = dest.Left + (dest.Width - w) / 2f;
+        var y = dest.Top + (dest.Height - h) / 2f;
+        return new SKRect(x, y, x + w, y + h);
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/ICompositorHost.cs
+++ b/ConditioningControlPanel/Services/Compositor/ICompositorHost.cs
@@ -26,6 +26,11 @@ internal interface ICompositorHost
     /// <summary>True while the host window is shown.</summary>
     bool IsVisible { get; }
 
+    /// <summary>Native handle of the host window (IntPtr.Zero before the hwnd exists). Lets the
+    /// z-order reconciler (OverlayService.ReassertZOrder) pin hosts below a playing mandatory
+    /// video / re-pin them topmost exactly like the legacy per-effect windows.</summary>
+    nint WindowHandle { get; }
+
     /// <summary>Show the (empty, click-through) host window. UI thread.</summary>
     void Show();
 

--- a/ConditioningControlPanel/Services/Compositor/ICompositorHost.cs
+++ b/ConditioningControlPanel/Services/Compositor/ICompositorHost.cs
@@ -1,0 +1,40 @@
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// The per-monitor overlay surface the <see cref="CompositorEngine"/> drives. Two implementations:
+///   - <see cref="CompositorHostWindow"/>: a WPF AllowsTransparency window whose SKElement rasters
+///     the layers on the UI thread (the original, default path).
+///   - <see cref="LayeredCompositorHost"/>: a raw Win32 layered window presented OFF the UI thread
+///     via UpdateLayeredWindow (the #550 proper-fix path, behind CompositorOffThreadPresent).
+/// The engine holds hosts through this interface and branches on the latched present mode only where
+/// the two genuinely differ (invalidate vs. hand-off a recorded picture).
+/// </summary>
+internal interface ICompositorHost
+{
+    /// <summary>Device name of the screen this host covers (Screen.DeviceName).</summary>
+    string ScreenDeviceName { get; }
+
+    /// <summary>True when this is the capture-excluded surface (brain drain).</summary>
+    bool IsExcludedSurface { get; }
+
+    /// <summary>This host's monitor rectangle in device pixels.</summary>
+    System.Drawing.Rectangle ScreenBoundsPx { get; }
+
+    /// <summary>Monitor DPI scale (dpi / 96); converts DIP-tuned layer math to device px.</summary>
+    double DpiScale { get; }
+
+    /// <summary>True while the host window is shown.</summary>
+    bool IsVisible { get; }
+
+    /// <summary>Show the (empty, click-through) host window. UI thread.</summary>
+    void Show();
+
+    /// <summary>Hide the host window. UI thread.</summary>
+    void Hide();
+
+    /// <summary>Tear the host down (topology change or engine dispose). UI thread.</summary>
+    void Close();
+
+    /// <summary>Re-target the host after a display-topology change. UI thread.</summary>
+    void UpdateScreenBounds(System.Windows.Forms.Screen screen);
+}

--- a/ConditioningControlPanel/Services/Compositor/ILayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/ILayer.cs
@@ -30,6 +30,15 @@ public interface IWpfLayer
     /// </summary>
     bool ExcludeFromCapture => false;
 
+    /// <summary>
+    /// True = this layer draws in VIRTUAL-DESKTOP device pixels (positional effects that span
+    /// monitors, e.g. pop bursts at a bubble's screen point). The engine translates the canvas so
+    /// world (0,0) is the desktop origin and passes <c>boundsPx</c> as THIS monitor's rectangle
+    /// in that same world space (for culling). Default (false) = monitor-local rendering:
+    /// (0,0) is the monitor's top-left and boundsPx starts at zero.
+    /// </summary>
+    bool WorldSpacePx => false;
+
     /// <summary>Called on the UI thread when IsActive transitions false -&gt; true.</summary>
     void OnActivated();
 

--- a/ConditioningControlPanel/Services/Compositor/ILayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/ILayer.cs
@@ -49,6 +49,20 @@ public interface IWpfLayer
     void Update(TimeSpan delta);
 
     /// <summary>
+    /// True if this layer's visible output changed since the last <see cref="ClearDirty"/>. The
+    /// engine only re-rasters a shared surface when at least one of its active layers is dirty, so
+    /// a slow layer (a ~10fps spiral GIF) or a static one (a steady pink tint) no longer forces the
+    /// fullscreen software surface to re-raster at 60fps on the UI thread (#550). Default true =
+    /// repaint every active frame, which is correct for continuously-animating layers (bubbles,
+    /// chaos FX, flash, subliminal); only slow/static layers override this.
+    /// </summary>
+    bool Dirty => true;
+
+    /// <summary>Engine calls this once per tick after it has queued this frame's surface
+    /// invalidations, so a layer that overrides <see cref="Dirty"/> can reset its flag.</summary>
+    void ClearDirty() { }
+
+    /// <summary>
     /// Draw onto the shared surface. <paramref name="boundsPx"/> is the full monitor surface in
     /// DEVICE PIXELS; <paramref name="dpiScale"/> converts DIP-tuned effect math to pixels.
     /// Called once per host window per tick while active. Draw persistent SKImages, never

--- a/ConditioningControlPanel/Services/Compositor/ILayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/ILayer.cs
@@ -39,6 +39,15 @@ public interface IWpfLayer
     /// </summary>
     bool WorldSpacePx => false;
 
+    /// <summary>
+    /// False = skip this layer on the given monitor (its virtual-desktop device-px bounds). The
+    /// engine hosts EVERY screen, so a fullscreen FILL layer (pink tint, spiral) that must honor
+    /// <c>DualMonitorEnabled</c> has to opt out of the non-primary monitors here - otherwise it
+    /// leaks onto screens the user disabled. Positional layers don't need this: their owning
+    /// service already places geometry only on the allowed monitor. Default: draw on every host.
+    /// </summary>
+    bool ShouldRenderOnScreen(System.Drawing.Rectangle screenBoundsPx) => true;
+
     /// <summary>Called on the UI thread when IsActive transitions false -&gt; true.</summary>
     void OnActivated();
 

--- a/ConditioningControlPanel/Services/Compositor/ILayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/ILayer.cs
@@ -1,0 +1,49 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// A z-ordered visual layer rendered by the <see cref="CompositorEngine"/> into the shared
+/// per-monitor overlay host, replacing a dedicated per-effect window.
+/// Contract mirrors the Avalonia port's ILayer/IAvaloniaLayer seam (same member names and
+/// semantics) so layer implementations stay portable between the two heads.
+///
+/// Threading: Update/Render are always called on the UI thread from the engine tick.
+/// Services own state and hand it to their layer under their own locking; layers only render.
+/// </summary>
+public interface IWpfLayer
+{
+    /// <summary>Z position from <see cref="CompositorLayers"/>. Lower renders first (behind).</summary>
+    int ZIndex { get; }
+
+    /// <summary>
+    /// True while the layer has something to show. The engine shows/hides host windows and
+    /// runs the render tick based on this; an inactive layer costs nothing.
+    /// </summary>
+    bool IsActive { get; }
+
+    /// <summary>
+    /// True routes this layer to the capture-EXCLUDED surface (WDA_EXCLUDEFROMCAPTURE), used by
+    /// brain drain to avoid self-capture feedback. Everything else stays on the main surface,
+    /// which must NEVER be capture-excluded (subliminals/flash/spiral are visible in recordings
+    /// BY DESIGN - WPF SubliminalService deliberately sets WDA_NONE).
+    /// </summary>
+    bool ExcludeFromCapture => false;
+
+    /// <summary>Called on the UI thread when IsActive transitions false -&gt; true.</summary>
+    void OnActivated();
+
+    /// <summary>Called on the UI thread when IsActive transitions true -&gt; false.</summary>
+    void OnDeactivated();
+
+    /// <summary>Advance animation state. Called once per engine tick while active.</summary>
+    void Update(TimeSpan delta);
+
+    /// <summary>
+    /// Draw onto the shared surface. <paramref name="boundsPx"/> is the full monitor surface in
+    /// DEVICE PIXELS; <paramref name="dpiScale"/> converts DIP-tuned effect math to pixels.
+    /// Called once per host window per tick while active. Draw persistent SKImages, never
+    /// per-frame SKBitmaps (allocation trap measured at ~480 MB/s in the Avalonia port).
+    /// </summary>
+    void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed);
+}

--- a/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
+++ b/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
@@ -1,0 +1,391 @@
+using System.Runtime.InteropServices;
+using System.Threading;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// #550 proper-fix host: a raw Win32 layered, click-through, topmost overlay window whose content
+/// is rasterized and presented OFF the UI thread. The engine records the monitor's active layers
+/// into an immutable <see cref="SKPicture"/> on the UI thread (cheap - draw-command capture only)
+/// and hands it here via <see cref="PresentPicture"/>; a dedicated present thread rasterizes it into
+/// a DIB-backed <see cref="SKSurface"/> and blits it with UpdateLayeredWindow(ULW_ALPHA). This keeps
+/// per-pixel alpha and click-through (exactly like the WPF AllowsTransparency host) but moves the
+/// fullscreen software raster + layered composite off the dispatcher - the dispatcher starvation that
+/// made a continuously-active fullscreen spiral lag the whole app on some machines.
+///
+/// Working purely in device pixels (no WPF DIP layout) is also why mixed-DPI cover is exact here.
+///
+/// The window is created on and owned by the UI thread (its message pump is the app's existing one;
+/// a transparent click-through tool window receives almost no messages). UpdateLayeredWindow is
+/// issued from the present thread against that hwnd - it targets the window's layered content and
+/// does not require the owning thread.
+///
+/// Resource lifetime is handled by Skia's native ref-counting, not by cross-thread coordination: an
+/// SKPicture takes its own native ref on every SKImage/mask filter drawn into it, so a layer freeing
+/// an image on the UI thread only drops the managed ref - the in-flight picture keeps the native
+/// object alive until this host disposes the picture after presenting it. SKPicture is immutable and
+/// safe to rasterize on this thread while the layers keep mutating on the UI thread.
+/// </summary>
+internal sealed class LayeredCompositorHost : ICompositorHost
+{
+    public string ScreenDeviceName { get; }
+    public bool IsExcludedSurface { get; }
+    public double DpiScale { get; }
+    public System.Drawing.Rectangle ScreenBoundsPx { get; private set; }
+    public bool IsVisible { get; private set; }
+
+    private readonly IntPtr _hwnd;
+    private readonly Thread _presentThread;
+    private readonly AutoResetEvent _signal = new(false);
+    private readonly object _slotLock = new();
+    private SKPicture? _pending;      // latest un-presented picture (superseded ones disposed here)
+    private volatile bool _stop;
+
+    // GDI/Skia present surface (owned by the present thread; deleted on Close after the join).
+    private IntPtr _memDc = IntPtr.Zero;
+    private IntPtr _dib = IntPtr.Zero;
+    private IntPtr _oldBmp = IntPtr.Zero;
+    private SKSurface? _surface;
+    private int _surfW, _surfH;
+
+    public LayeredCompositorHost(System.Windows.Forms.Screen screen, bool excludeFromCapture)
+    {
+        ScreenDeviceName = screen.DeviceName;
+        ScreenBoundsPx = screen.Bounds;
+        IsExcludedSurface = excludeFromCapture;
+        DpiScale = CompositorHostWindow.GetDpiScaleForScreen(screen);
+
+        _hwnd = CreateHostWindow(ScreenBoundsPx);
+        if (_hwnd != IntPtr.Zero && excludeFromCapture)
+            SetWindowDisplayAffinity(_hwnd, WDA_EXCLUDEFROMCAPTURE);
+
+        _presentThread = new Thread(PresentLoop)
+        {
+            IsBackground = true,
+            Name = $"Compositor-Present-{(excludeFromCapture ? "excl-" : "")}{ScreenDeviceName}"
+        };
+        _presentThread.Start();
+    }
+
+    /// <summary>Hand a freshly recorded picture (device-px, monitor-local) to the present thread.
+    /// Ownership transfers here: the host disposes it after presenting (or when superseded). UI thread.</summary>
+    public void PresentPicture(SKPicture picture)
+    {
+        if (_stop) { picture.Dispose(); return; }
+        lock (_slotLock)
+        {
+            // A picture still sitting un-presented is now stale - drop it (latest wins). Safe: the
+            // present thread moves a picture OUT of the slot before rendering, so this only ever
+            // disposes one the present thread has not started.
+            _pending?.Dispose();
+            _pending = picture;
+        }
+        _signal.Set();
+    }
+
+    public void Show()
+    {
+        if (_hwnd == IntPtr.Zero) return;
+        SetWindowPos(_hwnd, HWND_TOPMOST, ScreenBoundsPx.X, ScreenBoundsPx.Y,
+            ScreenBoundsPx.Width, ScreenBoundsPx.Height, SWP_NOACTIVATE);
+        ShowWindow(_hwnd, SW_SHOWNA);
+        IsVisible = true;
+    }
+
+    public void Hide()
+    {
+        if (_hwnd == IntPtr.Zero) return;
+        ShowWindow(_hwnd, SW_HIDE);
+        IsVisible = false;
+    }
+
+    public void UpdateScreenBounds(System.Windows.Forms.Screen screen)
+    {
+        ScreenBoundsPx = screen.Bounds;
+        if (_hwnd != IntPtr.Zero && IsVisible)
+            SetWindowPos(_hwnd, HWND_TOPMOST, ScreenBoundsPx.X, ScreenBoundsPx.Y,
+                ScreenBoundsPx.Width, ScreenBoundsPx.Height, SWP_NOACTIVATE);
+        // The present thread re-sizes its DIB to the new bounds on the next present.
+    }
+
+    public void Close()
+    {
+        _stop = true;
+        _signal.Set();
+        bool exited = false;
+        try { exited = _presentThread.Join(2000); } catch { }
+        lock (_slotLock) { _pending?.Dispose(); _pending = null; }
+
+        if (!exited)
+        {
+            // Present thread is still running (e.g. blocked in UpdateLayeredWindow). Freeing its DC /
+            // DIB / window now would be a use-after-free; leak them instead (teardown-only path).
+            App.Logger?.Warning("LayeredCompositorHost: present thread did not exit; leaking surface for {Screen}", ScreenDeviceName);
+            return;
+        }
+
+        // Present thread has quiesced: safe to free its surface + GDI objects and the window here.
+        DestroySurface();
+        if (_hwnd != IntPtr.Zero) { try { DestroyWindow(_hwnd); } catch { } }
+        _signal.Dispose();
+    }
+
+    // ---- present thread ----
+
+    private void PresentLoop()
+    {
+        while (!_stop)
+        {
+            _signal.WaitOne();
+            if (_stop) break;
+
+            SKPicture? pic;
+            lock (_slotLock)
+            {
+                pic = _pending;
+                _pending = null;   // taken - PresentPicture must not dispose it now
+            }
+            if (pic == null) continue;
+
+            try { PresentOne(pic); }
+            catch (Exception ex) { App.Logger?.Error(ex, "LayeredCompositorHost: present failed"); }
+            finally { pic.Dispose(); }
+        }
+    }
+
+    private void PresentOne(SKPicture pic)
+    {
+        var bounds = ScreenBoundsPx;
+        int w = Math.Max(1, bounds.Width), h = Math.Max(1, bounds.Height);
+        if (!EnsureSurface(w, h) || _surface == null) return;
+
+        var canvas = _surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+        canvas.DrawPicture(pic);
+        _surface.Flush();
+
+        var ptDst = new POINT { x = bounds.X, y = bounds.Y };
+        var size = new SIZE { cx = w, cy = h };
+        var ptSrc = new POINT { x = 0, y = 0 };
+        var blend = new BLENDFUNCTION
+        {
+            BlendOp = AC_SRC_OVER,
+            BlendFlags = 0,
+            SourceConstantAlpha = 255,
+            AlphaFormat = AC_SRC_ALPHA
+        };
+        UpdateLayeredWindow(_hwnd, IntPtr.Zero, ref ptDst, ref size, _memDc, ref ptSrc, 0, ref blend, ULW_ALPHA);
+    }
+
+    /// <summary>(Re)allocate the DIB-backed surface when the monitor size changes. Present thread only.</summary>
+    private bool EnsureSurface(int w, int h)
+    {
+        if (_surface != null && _surfW == w && _surfH == h) return true;
+        DestroySurface();
+
+        _memDc = CreateCompatibleDC(IntPtr.Zero);
+        if (_memDc == IntPtr.Zero) return false;
+
+        var bmi = new BITMAPINFO
+        {
+            biSize = Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = w,
+            biHeight = -h,           // top-down: row 0 is the top, matching Skia's default
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = BI_RGB
+        };
+        _dib = CreateDIBSection(_memDc, ref bmi, DIB_RGB_COLORS, out var bits, IntPtr.Zero, 0);
+        if (_dib == IntPtr.Zero || bits == IntPtr.Zero) { DestroySurface(); return false; }
+        _oldBmp = SelectObject(_memDc, _dib);
+
+        var info = new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul);
+        _surface = SKSurface.Create(info, bits, w * 4);
+        if (_surface == null) { DestroySurface(); return false; }
+        _surfW = w; _surfH = h;
+        return true;
+    }
+
+    private void DestroySurface()
+    {
+        _surface?.Dispose();
+        _surface = null;
+        if (_memDc != IntPtr.Zero)
+        {
+            if (_oldBmp != IntPtr.Zero) { SelectObject(_memDc, _oldBmp); _oldBmp = IntPtr.Zero; }
+            if (_dib != IntPtr.Zero) { DeleteObject(_dib); _dib = IntPtr.Zero; }
+            DeleteDC(_memDc);
+            _memDc = IntPtr.Zero;
+        }
+        else if (_dib != IntPtr.Zero) { DeleteObject(_dib); _dib = IntPtr.Zero; }
+        _surfW = _surfH = 0;
+    }
+
+    // ---- window creation ----
+
+    private const string ClassName = "CCPLayeredCompositorHost";
+    private static readonly WndProcDelegate s_wndProc = StaticWndProc; // kept alive for the class
+    private static bool s_classRegistered;
+    private static readonly object s_classLock = new();
+
+    private static IntPtr CreateHostWindow(System.Drawing.Rectangle bounds)
+    {
+        try
+        {
+            EnsureClassRegistered();
+            IntPtr hInstance = GetModuleHandle(null);
+            int exStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW
+                        | WS_EX_NOACTIVATE | WS_EX_TOPMOST;
+            var hwnd = CreateWindowEx(exStyle, ClassName, string.Empty, WS_POPUP,
+                bounds.X, bounds.Y, bounds.Width, bounds.Height,
+                IntPtr.Zero, IntPtr.Zero, hInstance, IntPtr.Zero);
+            if (hwnd == IntPtr.Zero)
+                App.Logger?.Warning("LayeredCompositorHost: CreateWindowEx failed ({Err})", Marshal.GetLastWin32Error());
+            return hwnd;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Error(ex, "LayeredCompositorHost: window creation threw");
+            return IntPtr.Zero;
+        }
+    }
+
+    private static void EnsureClassRegistered()
+    {
+        lock (s_classLock)
+        {
+            if (s_classRegistered) return;
+            var wc = new WNDCLASSEX
+            {
+                cbSize = Marshal.SizeOf<WNDCLASSEX>(),
+                style = 0,
+                lpfnWndProc = Marshal.GetFunctionPointerForDelegate(s_wndProc),
+                hInstance = GetModuleHandle(null),
+                lpszClassName = ClassName
+            };
+            if (RegisterClassEx(ref wc) == 0)
+            {
+                int err = Marshal.GetLastWin32Error();
+                if (err != ERROR_CLASS_ALREADY_EXISTS)
+                    App.Logger?.Warning("LayeredCompositorHost: RegisterClassEx failed ({Err})", err);
+            }
+            s_classRegistered = true;
+        }
+    }
+
+    private static IntPtr StaticWndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        => DefWindowProc(hWnd, msg, wParam, lParam);
+
+    // ---- Win32 ----
+
+    private delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    private const int WS_EX_TRANSPARENT = 0x00000020;
+    private const int WS_EX_LAYERED = 0x00080000;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private const int WS_EX_NOACTIVATE = 0x08000000;
+    private const int WS_EX_TOPMOST = 0x00000008;
+    private const uint WS_POPUP = 0x80000000;
+    private static readonly IntPtr HWND_TOPMOST = new(-1);
+    private const uint SWP_NOACTIVATE = 0x0010;
+    private const int SW_HIDE = 0;
+    private const int SW_SHOWNA = 8;
+    private const uint WDA_EXCLUDEFROMCAPTURE = 0x0011;
+    private const int ERROR_CLASS_ALREADY_EXISTS = 1410;
+    private const uint BI_RGB = 0;
+    private const uint DIB_RGB_COLORS = 0;
+    private const byte AC_SRC_OVER = 0;
+    private const byte AC_SRC_ALPHA = 1;
+    private const uint ULW_ALPHA = 0x00000002;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT { public int x, y; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SIZE { public int cx, cy; }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BLENDFUNCTION
+    {
+        public byte BlendOp, BlendFlags, SourceConstantAlpha, AlphaFormat;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFOHEADER
+    {
+        public int biSize;
+        public int biWidth, biHeight;
+        public short biPlanes, biBitCount;
+        public uint biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter, biYPelsPerMeter;
+        public uint biClrUsed, biClrImportant;
+    }
+    // Header-only BITMAPINFO (no palette needed for BI_RGB 32bpp).
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFO
+    {
+        public int biSize;
+        public int biWidth, biHeight;
+        public short biPlanes, biBitCount;
+        public uint biCompression;
+        public uint biSizeImage;
+        public int biXPelsPerMeter, biYPelsPerMeter;
+        public uint biClrUsed, biClrImportant;
+    }
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct WNDCLASSEX
+    {
+        public int cbSize;
+        public uint style;
+        public IntPtr lpfnWndProc;
+        public int cbClsExtra, cbWndExtra;
+        public IntPtr hInstance, hIcon, hCursor, hbrBackground;
+        [MarshalAs(UnmanagedType.LPWStr)] public string? lpszMenuName;
+        [MarshalAs(UnmanagedType.LPWStr)] public string lpszClassName;
+        public IntPtr hIconSm;
+    }
+
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern ushort RegisterClassEx(ref WNDCLASSEX wc);
+
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateWindowEx(int exStyle, string className, string windowName,
+        uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr hInstance, IntPtr param);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool DestroyWindow(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hwnd, int cmd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool SetWindowDisplayAffinity(IntPtr hwnd, uint affinity);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool UpdateLayeredWindow(IntPtr hwnd, IntPtr hdcDst, ref POINT pptDst, ref SIZE psize,
+        IntPtr hdcSrc, ref POINT pptSrc, int crKey, ref BLENDFUNCTION pblend, uint dwFlags);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr GetModuleHandle(string? name);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFO bmi, uint usage,
+        out IntPtr bits, IntPtr section, uint offset);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr obj);
+
+    [DllImport("gdi32.dll")]
+    private static extern bool DeleteObject(IntPtr obj);
+}

--- a/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
+++ b/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
@@ -32,8 +32,22 @@ internal sealed class LayeredCompositorHost : ICompositorHost
     public string ScreenDeviceName { get; }
     public bool IsExcludedSurface { get; }
     public double DpiScale { get; }
-    public System.Drawing.Rectangle ScreenBoundsPx { get; private set; }
+
+    // Written by the UI thread (topology changes), read by the present thread (PresentOne).
+    // Rectangle is a 4-int struct, so an unsynchronized handoff can tear mid-update and hand
+    // the present thread a mismatched DIB/UpdateLayeredWindow frame. Dedicated lock: never
+    // held across SetWindowPos/UpdateLayeredWindow, and independent of _slotLock ordering.
+    private readonly object _boundsLock = new();
+    private System.Drawing.Rectangle _screenBoundsPx;
+    public System.Drawing.Rectangle ScreenBoundsPx
+    {
+        get { lock (_boundsLock) return _screenBoundsPx; }
+        private set { lock (_boundsLock) _screenBoundsPx = value; }
+    }
+
     public bool IsVisible { get; private set; }
+
+    public nint WindowHandle => _hwnd;
 
     private readonly IntPtr _hwnd;
     private readonly Thread _presentThread;
@@ -87,8 +101,8 @@ internal sealed class LayeredCompositorHost : ICompositorHost
     public void Show()
     {
         if (_hwnd == IntPtr.Zero) return;
-        SetWindowPos(_hwnd, HWND_TOPMOST, ScreenBoundsPx.X, ScreenBoundsPx.Y,
-            ScreenBoundsPx.Width, ScreenBoundsPx.Height, SWP_NOACTIVATE);
+        var b = ScreenBoundsPx;
+        SetWindowPos(_hwnd, HWND_TOPMOST, b.X, b.Y, b.Width, b.Height, SWP_NOACTIVATE);
         ShowWindow(_hwnd, SW_SHOWNA);
         IsVisible = true;
     }
@@ -102,10 +116,10 @@ internal sealed class LayeredCompositorHost : ICompositorHost
 
     public void UpdateScreenBounds(System.Windows.Forms.Screen screen)
     {
-        ScreenBoundsPx = screen.Bounds;
+        var b = screen.Bounds;
+        ScreenBoundsPx = b;
         if (_hwnd != IntPtr.Zero && IsVisible)
-            SetWindowPos(_hwnd, HWND_TOPMOST, ScreenBoundsPx.X, ScreenBoundsPx.Y,
-                ScreenBoundsPx.Width, ScreenBoundsPx.Height, SWP_NOACTIVATE);
+            SetWindowPos(_hwnd, HWND_TOPMOST, b.X, b.Y, b.Width, b.Height, SWP_NOACTIVATE);
         // The present thread re-sizes its DIB to the new bounds on the next present.
     }
 

--- a/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
@@ -1,0 +1,42 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the pink-filter windows: a fullscreen solid tint whose opacity rides in
+/// the color's alpha channel, exactly like the legacy Border/SolidColorBrush (OverlayService
+/// owns all opacity math - ramps, pulses, holds - and just pushes the final value here).
+/// </summary>
+public class PinkTintLayer : BaseLayer
+{
+    private byte _r = 255, _g = 105, _b = 180;
+    private double _opacity;
+    private readonly SKPaint _paint = new();
+
+    public PinkTintLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.PinkTint;
+
+    /// <summary>Show the tint (or retarget a visible one). Opacity 0..1. UI thread.</summary>
+    public void Show(byte r, byte g, byte b, double opacity)
+    {
+        Set(r, g, b, opacity);
+        SetActive(true);
+    }
+
+    /// <summary>Update color + opacity without changing visibility. UI thread.</summary>
+    public void Set(byte r, byte g, byte b, double opacity)
+    {
+        _r = r; _g = g; _b = b;
+        _opacity = Math.Clamp(opacity, 0.0, 1.0);
+    }
+
+    public void Hide() => SetActive(false);
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        if (_opacity <= 0) return;
+        _paint.Color = new SKColor(_r, _g, _b, (byte)Math.Clamp(_opacity * 255, 0, 255));
+        canvas.DrawRect(boundsPx, _paint);
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
@@ -18,6 +18,11 @@ public class PinkTintLayer : BaseLayer
 
     public override int ZIndex => CompositorLayers.PinkTint;
 
+    // Fullscreen fill: honor DualMonitorEnabled (the legacy pink-filter windows did) so the tint
+    // doesn't leak onto monitors the user disabled now that the compositor hosts every screen.
+    public override bool ShouldRenderOnScreen(System.Drawing.Rectangle screenBoundsPx)
+        => PrimaryOnlyUnlessDualMonitor(screenBoundsPx);
+
     public override bool Dirty => _dirty;
     public override void ClearDirty() => _dirty = false;
 

--- a/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/PinkTintLayer.cs
@@ -11,24 +11,31 @@ public class PinkTintLayer : BaseLayer
 {
     private byte _r = 255, _g = 105, _b = 180;
     private double _opacity;
+    private bool _dirty = true;   // #550: a steady tint is static - only repaint when it changes
     private readonly SKPaint _paint = new();
 
     public PinkTintLayer(CompositorEngine engine) : base(engine) { }
 
     public override int ZIndex => CompositorLayers.PinkTint;
 
+    public override bool Dirty => _dirty;
+    public override void ClearDirty() => _dirty = false;
+
     /// <summary>Show the tint (or retarget a visible one). Opacity 0..1. UI thread.</summary>
     public void Show(byte r, byte g, byte b, double opacity)
     {
         Set(r, g, b, opacity);
+        _dirty = true;            // guarantee a paint on (re)show even if the values were unchanged
         SetActive(true);
     }
 
     /// <summary>Update color + opacity without changing visibility. UI thread.</summary>
     public void Set(byte r, byte g, byte b, double opacity)
     {
-        _r = r; _g = g; _b = b;
-        _opacity = Math.Clamp(opacity, 0.0, 1.0);
+        var o = Math.Clamp(opacity, 0.0, 1.0);
+        if (r == _r && g == _g && b == _b && o == _opacity) return;  // no visible change
+        _r = r; _g = g; _b = b; _opacity = o;
+        _dirty = true;
     }
 
     public void Hide() => SetActive(false);

--- a/ConditioningControlPanel/Services/Compositor/SkiaWpfInterop.cs
+++ b/ConditioningControlPanel/Services/Compositor/SkiaWpfInterop.cs
@@ -10,7 +10,9 @@ internal static class SkiaWpfInterop
     /// <summary>
     /// Copy a (frozen) BitmapSource into a persistent SKImage. Converts to Pbgra32 first when
     /// needed; AnimatedWebp frames already arrive as Pbgra32 so the common path is a straight
-    /// pixel copy. The returned image owns its pixels - dispose it when replaced.
+    /// pixel copy. ONE copy total: CopyPixels lands in an SKBitmap and the SKImage wraps that
+    /// buffer zero-copy, taking ownership (the release delegate disposes the SKBitmap when the
+    /// image is disposed). The returned image owns its pixels - dispose it when replaced.
     /// </summary>
     public static SKImage ToSKImage(BitmapSource source)
     {
@@ -24,9 +26,30 @@ internal static class SkiaWpfInterop
 
         int w = src.PixelWidth, h = src.PixelHeight;
         var info = new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul);
-        using var bmp = new SKBitmap(info);
-        src.CopyPixels(new Int32Rect(0, 0, w, h), bmp.GetPixels(), info.BytesSize, info.RowBytes);
-        // FromBitmap copies, so the SKBitmap can be disposed here and the SKImage lives on.
-        return SKImage.FromBitmap(bmp);
+        SKBitmap? bmp = null;
+        try
+        {
+            bmp = new SKBitmap(info);
+            src.CopyPixels(new Int32Rect(0, 0, w, h), bmp.GetPixels(), info.BytesSize, info.RowBytes);
+            bmp.SetImmutable();
+
+            // Zero-copy wrap (FromBitmap here used to be a SECOND full copy per frame - the
+            // per-spawn UI hitch at flash-burst scale): the image adopts the bitmap's pixel
+            // buffer and the release delegate frees it with the image.
+            using var pixmap = bmp.PeekPixels();
+            var image = SKImage.FromPixels(pixmap,
+                static (_, ctx) => ((SKBitmap)ctx).Dispose(), bmp);
+            if (image != null)
+            {
+                bmp = null;   // ownership transferred to the SKImage's release delegate
+                return image;
+            }
+            // Defensive fallback: wrap refused (shouldn't happen for a valid pixmap) - copy.
+            return SKImage.FromBitmap(bmp);
+        }
+        finally
+        {
+            bmp?.Dispose();
+        }
     }
 }

--- a/ConditioningControlPanel/Services/Compositor/SkiaWpfInterop.cs
+++ b/ConditioningControlPanel/Services/Compositor/SkiaWpfInterop.cs
@@ -1,0 +1,32 @@
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>WPF-imaging &lt;-&gt; Skia conversion helpers for compositor layers.</summary>
+internal static class SkiaWpfInterop
+{
+    /// <summary>
+    /// Copy a (frozen) BitmapSource into a persistent SKImage. Converts to Pbgra32 first when
+    /// needed; AnimatedWebp frames already arrive as Pbgra32 so the common path is a straight
+    /// pixel copy. The returned image owns its pixels - dispose it when replaced.
+    /// </summary>
+    public static SKImage ToSKImage(BitmapSource source)
+    {
+        BitmapSource src = source;
+        if (src.Format != PixelFormats.Pbgra32)
+        {
+            var converted = new FormatConvertedBitmap(src, PixelFormats.Pbgra32, null, 0);
+            converted.Freeze();
+            src = converted;
+        }
+
+        int w = src.PixelWidth, h = src.PixelHeight;
+        var info = new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul);
+        using var bmp = new SKBitmap(info);
+        src.CopyPixels(new Int32Rect(0, 0, w, h), bmp.GetPixels(), info.BytesSize, info.RowBytes);
+        // FromBitmap copies, so the SKBitmap can be disposed here and the SKImage lives on.
+        return SKImage.FromBitmap(bmp);
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
@@ -28,6 +28,11 @@ public class SpiralLayer : BaseLayer
 
     public override int ZIndex => CompositorLayers.Spiral;
 
+    // Fullscreen fill: honor DualMonitorEnabled (the legacy spiral windows did) so it doesn't
+    // upscale onto monitors the user disabled now that the compositor hosts every screen.
+    public override bool ShouldRenderOnScreen(System.Drawing.Rectangle screenBoundsPx)
+        => PrimaryOnlyUnlessDualMonitor(screenBoundsPx);
+
     /// <summary>True while visible OR still decoding - the 500ms settings sync polls this,
     /// so it must cover the async decode window or Show() gets re-fired mid-decode.</summary>
     public bool IsShowing => IsActive || _loading;

--- a/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
@@ -29,64 +29,35 @@ public class SpiralLayer : BaseLayer
     /// so it must cover the async decode window or Show() gets re-fired mid-decode.</summary>
     public bool IsShowing => IsActive || _loading;
 
-    /// <summary>Decode <paramref name="path"/> off-thread and show when ready. Opacity is the
-    /// FINAL value (caller applies the x0.1 spiral reduction). <paramref name="onFailed"/> runs
-    /// on the UI thread if decoding produces no frames (NOT when superseded by a newer Show),
-    /// so the caller can fall back to the legacy render path. UI thread.</summary>
-    public void Show(string path, double opacity, Action? onFailed = null)
+    /// <summary>
+    /// Show the spiral from ALREADY-DECODED (frozen) WPF frames - the caller uses the legacy
+    /// loader + cache (OverlayService.LoadSpiralGifFrames), which by construction supports every
+    /// asset source the legacy windows supported (pack:// resources, file:// mod overrides, user
+    /// paths). Conversion to persistent SKImages runs off-thread. Opacity is the FINAL value
+    /// (caller applies the x0.1 spiral reduction). UI thread.
+    /// </summary>
+    public void ShowFrames(IReadOnlyList<System.Windows.Media.Imaging.BitmapSource> sourceFrames,
+        TimeSpan frameDelay, double opacity)
     {
         _opacity = Math.Clamp(opacity, 0.0, 1.0);
         int gen = Interlocked.Increment(ref _generation);
         _loading = true;
 
-        // The default spiral resolves to a pack:// application-resource URI (only mods/user
-        // overrides are on-disk files) - SKCodec cannot open those, so materialize the resource
-        // bytes here on the UI thread (cheap, no decode) and let the background task decode
-        // from the stream.
-        byte[]? resourceBytes = null;
-        if (path.StartsWith("pack://", StringComparison.OrdinalIgnoreCase))
-        {
-            try
-            {
-                var sri = Application.GetResourceStream(new Uri(path, UriKind.Absolute));
-                if (sri?.Stream != null)
-                {
-                    using var s = sri.Stream;
-                    using var ms = new System.IO.MemoryStream();
-                    s.CopyTo(ms);
-                    resourceBytes = ms.ToArray();
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning("SpiralLayer: could not open resource {Path}: {E}", path, ex.Message);
-            }
-        }
+        // Snapshot the list; the caller's collection is cleared on StopSpiral. Frames are frozen
+        // BitmapSources, safe to read from the worker.
+        var snapshot = sourceFrames.ToArray();
+        var delay = frameDelay;
 
         Task.Run(() =>
         {
-            (List<System.Windows.Media.Imaging.BitmapSource> Frames, TimeSpan FrameDelay)? decoded = null;
             SKImage[]? frames = null;
             try
             {
-                // Same decoder + global decode gate as flashes (heap-corruption discipline,
-                // d05d5ae4). Budget mirrors the legacy spiral loader: fullscreen asset, keep
-                // the loop's motion arc.
-                if (resourceBytes != null)
-                {
-                    using var ms = new System.IO.MemoryStream(resourceBytes);
-                    decoded = AnimatedWebp.DecodeFrames(ms, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
-                }
-                else
-                {
-                    decoded = AnimatedWebp.DecodeFrames(path, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
-                }
-                if (decoded != null)
-                    frames = decoded.Value.Frames.Select(SkiaWpfInterop.ToSKImage).ToArray();
+                frames = snapshot.Select(SkiaWpfInterop.ToSKImage).ToArray();
             }
             catch (Exception ex)
             {
-                App.Logger?.Warning("SpiralLayer: decode failed for {Path}: {E}", path, ex.Message);
+                App.Logger?.Warning("SpiralLayer: frame conversion failed: {E}", ex.Message);
             }
 
             var dispatcher = Application.Current?.Dispatcher;
@@ -101,21 +72,19 @@ public class SpiralLayer : BaseLayer
             {
                 if (gen != _generation)
                 {
-                    // superseded by a newer Show/Hide while decoding
+                    // superseded by a newer Show/Hide while converting
                     if (frames != null) foreach (var f in frames) f.Dispose();
                     return;
                 }
                 _loading = false;
-                if (frames == null || frames.Length == 0 || decoded == null)
+                if (frames == null || frames.Length == 0)
                 {
-                    App.Logger?.Warning("SpiralLayer: no frames decoded from {Path}; falling back to legacy path", path);
-                    try { onFailed?.Invoke(); }
-                    catch (Exception ex) { App.Logger?.Error(ex, "SpiralLayer: fallback handler failed"); }
+                    App.Logger?.Warning("SpiralLayer: no frames converted; spiral not shown");
                     return;
                 }
                 DisposeFrames();
                 _frames = frames;
-                _frameDelay = decoded.Value.FrameDelay;
+                _frameDelay = delay > TimeSpan.Zero ? delay : TimeSpan.FromMilliseconds(50);
                 _frameIndex = 0;
                 _accum = TimeSpan.Zero;
                 SetActive(true);

--- a/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
@@ -19,7 +19,10 @@ public class SpiralLayer : BaseLayer
     private double _opacity;
     private int _generation;               // orphans stale async decodes on Show/Hide races
     private volatile bool _loading;
-    private readonly SKPaint _paint = new() { FilterQuality = SKFilterQuality.Medium };
+    private bool _dirty = true;            // #550: throttle the fullscreen re-raster to actual changes
+    // Low (bilinear) not Medium: the spiral GIF (~500px) is UPSCALED to fullscreen, and mipmaps
+    // only help minification - so Low is the same visual result as Medium here for less per-frame cost.
+    private readonly SKPaint _paint = new() { FilterQuality = SKFilterQuality.Low };
 
     public SpiralLayer(CompositorEngine engine) : base(engine) { }
 
@@ -87,13 +90,23 @@ public class SpiralLayer : BaseLayer
                 _frameDelay = delay > TimeSpan.Zero ? delay : TimeSpan.FromMilliseconds(50);
                 _frameIndex = 0;
                 _accum = TimeSpan.Zero;
+                _dirty = true;          // first frame of a freshly-shown spiral must paint
                 SetActive(true);
             });
         });
     }
 
     /// <summary>Push a new FINAL opacity (ramp/pulse/settings already folded in). UI thread.</summary>
-    public void SetOpacity(double opacity) => _opacity = Math.Clamp(opacity, 0.0, 1.0);
+    public void SetOpacity(double opacity)
+    {
+        var v = Math.Clamp(opacity, 0.0, 1.0);
+        if (v == _opacity) return;      // redundant push (e.g. 500ms settings sync): don't force a repaint
+        _opacity = v;
+        _dirty = true;
+    }
+
+    public override bool Dirty => _dirty;
+    public override void ClearDirty() => _dirty = false;
 
     public void Hide()
     {
@@ -107,12 +120,14 @@ public class SpiralLayer : BaseLayer
     public override void Update(TimeSpan delta)
     {
         if (_frames.Length < 2) return;
+        int start = _frameIndex;
         _accum += delta;
         while (_accum >= _frameDelay)
         {
             _accum -= _frameDelay;
             _frameIndex = (_frameIndex + 1) % _frames.Length;
         }
+        if (_frameIndex != start) _dirty = true;   // only repaint the surface when the frame changed
     }
 
     public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)

--- a/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
@@ -30,12 +30,38 @@ public class SpiralLayer : BaseLayer
     public bool IsShowing => IsActive || _loading;
 
     /// <summary>Decode <paramref name="path"/> off-thread and show when ready. Opacity is the
-    /// FINAL value (caller applies the x0.1 spiral reduction). UI thread.</summary>
-    public void Show(string path, double opacity)
+    /// FINAL value (caller applies the x0.1 spiral reduction). <paramref name="onFailed"/> runs
+    /// on the UI thread if decoding produces no frames (NOT when superseded by a newer Show),
+    /// so the caller can fall back to the legacy render path. UI thread.</summary>
+    public void Show(string path, double opacity, Action? onFailed = null)
     {
         _opacity = Math.Clamp(opacity, 0.0, 1.0);
         int gen = Interlocked.Increment(ref _generation);
         _loading = true;
+
+        // The default spiral resolves to a pack:// application-resource URI (only mods/user
+        // overrides are on-disk files) - SKCodec cannot open those, so materialize the resource
+        // bytes here on the UI thread (cheap, no decode) and let the background task decode
+        // from the stream.
+        byte[]? resourceBytes = null;
+        if (path.StartsWith("pack://", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var sri = Application.GetResourceStream(new Uri(path, UriKind.Absolute));
+                if (sri?.Stream != null)
+                {
+                    using var s = sri.Stream;
+                    using var ms = new System.IO.MemoryStream();
+                    s.CopyTo(ms);
+                    resourceBytes = ms.ToArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("SpiralLayer: could not open resource {Path}: {E}", path, ex.Message);
+            }
+        }
 
         Task.Run(() =>
         {
@@ -46,7 +72,15 @@ public class SpiralLayer : BaseLayer
                 // Same decoder + global decode gate as flashes (heap-corruption discipline,
                 // d05d5ae4). Budget mirrors the legacy spiral loader: fullscreen asset, keep
                 // the loop's motion arc.
-                decoded = AnimatedWebp.DecodeFrames(path, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
+                if (resourceBytes != null)
+                {
+                    using var ms = new System.IO.MemoryStream(resourceBytes);
+                    decoded = AnimatedWebp.DecodeFrames(ms, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
+                }
+                else
+                {
+                    decoded = AnimatedWebp.DecodeFrames(path, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
+                }
                 if (decoded != null)
                     frames = decoded.Value.Frames.Select(SkiaWpfInterop.ToSKImage).ToArray();
             }
@@ -74,7 +108,9 @@ public class SpiralLayer : BaseLayer
                 _loading = false;
                 if (frames == null || frames.Length == 0 || decoded == null)
                 {
-                    App.Logger?.Warning("SpiralLayer: no frames decoded from {Path}; spiral not shown", path);
+                    App.Logger?.Warning("SpiralLayer: no frames decoded from {Path}; falling back to legacy path", path);
+                    try { onFailed?.Invoke(); }
+                    catch (Exception ex) { App.Logger?.Error(ex, "SpiralLayer: fallback handler failed"); }
                     return;
                 }
                 DisposeFrames();

--- a/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SpiralLayer.cs
@@ -1,0 +1,135 @@
+using System.Threading;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the spiral GIF windows: frames decoded ONCE (via AnimatedWebp's
+/// SKCodec path, behind its global 2-permit decode gate) into persistent SKImages, stepped on
+/// the engine tick, drawn UniformToFill. OverlayService owns all opacity math (including the
+/// x0.1 spiral reduction and ramps) and pushes final values here. Video spirals stay on the
+/// legacy MediaElement windows - this layer only handles the GIF/animated path.
+/// </summary>
+public class SpiralLayer : BaseLayer
+{
+    private SKImage[] _frames = Array.Empty<SKImage>();
+    private TimeSpan _frameDelay = TimeSpan.FromMilliseconds(100);
+    private TimeSpan _accum;
+    private int _frameIndex;
+    private double _opacity;
+    private int _generation;               // orphans stale async decodes on Show/Hide races
+    private volatile bool _loading;
+    private readonly SKPaint _paint = new() { FilterQuality = SKFilterQuality.Medium };
+
+    public SpiralLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.Spiral;
+
+    /// <summary>True while visible OR still decoding - the 500ms settings sync polls this,
+    /// so it must cover the async decode window or Show() gets re-fired mid-decode.</summary>
+    public bool IsShowing => IsActive || _loading;
+
+    /// <summary>Decode <paramref name="path"/> off-thread and show when ready. Opacity is the
+    /// FINAL value (caller applies the x0.1 spiral reduction). UI thread.</summary>
+    public void Show(string path, double opacity)
+    {
+        _opacity = Math.Clamp(opacity, 0.0, 1.0);
+        int gen = Interlocked.Increment(ref _generation);
+        _loading = true;
+
+        Task.Run(() =>
+        {
+            (List<System.Windows.Media.Imaging.BitmapSource> Frames, TimeSpan FrameDelay)? decoded = null;
+            SKImage[]? frames = null;
+            try
+            {
+                // Same decoder + global decode gate as flashes (heap-corruption discipline,
+                // d05d5ae4). Budget mirrors the legacy spiral loader: fullscreen asset, keep
+                // the loop's motion arc.
+                decoded = AnimatedWebp.DecodeFrames(path, maxDim: 1280, maxFrames: 60, maxMemoryMb: 160);
+                if (decoded != null)
+                    frames = decoded.Value.Frames.Select(SkiaWpfInterop.ToSKImage).ToArray();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("SpiralLayer: decode failed for {Path}: {E}", path, ex.Message);
+            }
+
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted)
+            {
+                if (frames != null) foreach (var f in frames) f.Dispose();
+                _loading = false;
+                return;
+            }
+
+            dispatcher.BeginInvoke(() =>
+            {
+                if (gen != _generation)
+                {
+                    // superseded by a newer Show/Hide while decoding
+                    if (frames != null) foreach (var f in frames) f.Dispose();
+                    return;
+                }
+                _loading = false;
+                if (frames == null || frames.Length == 0 || decoded == null)
+                {
+                    App.Logger?.Warning("SpiralLayer: no frames decoded from {Path}; spiral not shown", path);
+                    return;
+                }
+                DisposeFrames();
+                _frames = frames;
+                _frameDelay = decoded.Value.FrameDelay;
+                _frameIndex = 0;
+                _accum = TimeSpan.Zero;
+                SetActive(true);
+            });
+        });
+    }
+
+    /// <summary>Push a new FINAL opacity (ramp/pulse/settings already folded in). UI thread.</summary>
+    public void SetOpacity(double opacity) => _opacity = Math.Clamp(opacity, 0.0, 1.0);
+
+    public void Hide()
+    {
+        Interlocked.Increment(ref _generation); // orphan any in-flight decode
+        _loading = false;
+        SetActive(false);
+    }
+
+    public override void OnDeactivated() => DisposeFrames();
+
+    public override void Update(TimeSpan delta)
+    {
+        if (_frames.Length < 2) return;
+        _accum += delta;
+        while (_accum >= _frameDelay)
+        {
+            _accum -= _frameDelay;
+            _frameIndex = (_frameIndex + 1) % _frames.Length;
+        }
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        if (_frames.Length == 0 || _opacity <= 0) return;
+        var img = _frames[Math.Min(_frameIndex, _frames.Length - 1)];
+
+        // UniformToFill: cover the monitor, preserve aspect, center-crop overflow.
+        float scale = Math.Max((float)boundsPx.Width / img.Width, (float)boundsPx.Height / img.Height);
+        float w = img.Width * scale, h = img.Height * scale;
+        float x = boundsPx.Left + (boundsPx.Width - w) / 2f;
+        float y = boundsPx.Top + (boundsPx.Height - h) / 2f;
+
+        _paint.Color = SKColors.White.WithAlpha((byte)Math.Clamp(_opacity * 255, 0, 255));
+        canvas.DrawImage(img, SKRect.Create(x, y, w, h), _paint);
+    }
+
+    private void DisposeFrames()
+    {
+        var old = _frames;
+        _frames = Array.Empty<SKImage>();
+        _frameIndex = 0;
+        foreach (var f in old) f.Dispose();
+    }
+}

--- a/ConditioningControlPanel/Services/Compositor/SubliminalLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/SubliminalLayer.cs
@@ -1,0 +1,226 @@
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// Compositor twin of the subliminal flash cards. Mirrors the Avalonia port's SubliminalLayer
+/// (queued items, per-item 50ms fade envelope, most-recent-wins render) plus the WPF
+/// outlined-text construction the Avalonia head doesn't have yet: 8 border-color offset copies
+/// under the main text, Arial Bold 120 DIP (BuildSubliminalContent parity).
+///
+/// Renders on the MAIN surface: subliminals stay visible in screen capture BY DESIGN (the
+/// legacy windows deliberately set WDA_NONE); the awareness OCR skips the text via
+/// <see cref="GetActiveTextRectsPx"/> instead. The focus-steal variant cannot come from the
+/// click-through host and stays on the legacy per-screen windows.
+///
+/// SubliminalService owns ALL state and scheduling; each Flash hands this layer a fully
+/// resolved card (colors, opacity, hold time, per-screen geometry).
+/// </summary>
+public sealed class SubliminalLayer : BaseLayer
+{
+    /// <summary>WPF AnimateSubliminal fade-in/out duration (50ms each side of the hold).</summary>
+    private const double FadeMs = 50;
+    /// <summary>Arial Bold 120 DIP (CreateTextBlock parity); multiplied by per-screen scale.</summary>
+    private const float FontDip = 120f;
+    /// <summary>Legacy OCR-rect padding (GetActiveTextScreenRects), in DIP.</summary>
+    private const float OcrPadDip = 40f;
+
+    /// <summary>WPF outline offsets in DIP (BuildSubliminalContent parity).</summary>
+    private static readonly (float X, float Y)[] Offsets =
+    {
+        (-3, -3), (3, -3), (-3, 3), (3, 3),
+        (0, -4), (0, 4), (-4, 0), (4, 0)
+    };
+
+    private static readonly SKTypeface BoldArial =
+        SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold);
+
+    /// <summary>One screen's card geometry in virtual-desktop device px.</summary>
+    public readonly struct Placement
+    {
+        public Placement(SKRectI boundsPx, float scale)
+        {
+            BoundsPx = boundsPx;
+            Scale = scale <= 0 ? 1f : scale;
+        }
+
+        /// <summary>The screen's rectangle in world (virtual-desktop) device px.</summary>
+        public SKRectI BoundsPx { get; }
+        /// <summary>Physical px per DIP on this screen - DIP-tuned text metrics multiply by it.</summary>
+        public float Scale { get; }
+    }
+
+    private sealed class Item
+    {
+        public string Text = "";
+        public SKColor Bg, TextColor, Border;
+        public bool BgTransparent;
+        public double TargetOpacity;
+        public TimeSpan Total, Remaining;
+        public Placement[] Placements = Array.Empty<Placement>();
+        // Measured text extents per placement (device px), for the OCR skip rects.
+        public float[] TextWidthPx = Array.Empty<float>();
+        public float[] TextHeightPx = Array.Empty<float>();
+
+        /// <summary>0..1 fade envelope: 50ms ramp up, hold, 50ms ramp down (WPF storyboard parity).</summary>
+        public double Envelope()
+        {
+            var elapsedMs = (Total - Remaining).TotalMilliseconds;
+            var remainingMs = Remaining.TotalMilliseconds;
+            if (elapsedMs < FadeMs) return Math.Clamp(elapsedMs / FadeMs, 0.0, 1.0);
+            if (remainingMs < FadeMs) return Math.Clamp(remainingMs / FadeMs, 0.0, 1.0);
+            return 1.0;
+        }
+    }
+
+    private readonly List<Item> _items = new();
+    private readonly object _sync = new();
+    // Reused paints, only touched under _sync (no per-frame allocations).
+    private readonly SKPaint _bgPaint = new();
+    private readonly SKPaint _textPaint = new()
+    {
+        IsAntialias = true,
+        TextAlign = SKTextAlign.Center,
+        Typeface = BoldArial
+    };
+
+    public SubliminalLayer(CompositorEngine engine) : base(engine) { }
+
+    public override int ZIndex => CompositorLayers.Subliminal;
+
+    public override bool WorldSpacePx => true;
+
+    /// <summary>
+    /// Queue a subliminal flash across the given screens. <paramref name="holdMs"/> is the hold
+    /// time; the 50ms fades are added on top (WPF parity: fade-in + hold + fade-out storyboard).
+    /// <paramref name="targetOpacity"/> scales the whole card (background AND text), 0..1 -
+    /// exactly like the legacy whole-window Opacity animation. Safe from any thread.
+    /// </summary>
+    public void Flash(IReadOnlyList<Placement> placements, string text,
+        SKColor bg, SKColor textColor, SKColor border,
+        bool bgTransparent, double targetOpacity, int holdMs)
+    {
+        if (string.IsNullOrWhiteSpace(text) || placements.Count == 0) return;
+
+        var item = new Item
+        {
+            Text = text,
+            Bg = bg,
+            TextColor = textColor,
+            Border = border,
+            BgTransparent = bgTransparent,
+            TargetOpacity = Math.Clamp(targetOpacity, 0.0, 1.0),
+            Total = TimeSpan.FromMilliseconds(holdMs + 2 * FadeMs),
+            Placements = new Placement[placements.Count],
+            TextWidthPx = new float[placements.Count],
+            TextHeightPx = new float[placements.Count]
+        };
+        item.Remaining = item.Total;
+
+        lock (_sync)
+        {
+            for (int i = 0; i < placements.Count; i++)
+            {
+                item.Placements[i] = placements[i];
+                _textPaint.TextSize = FontDip * placements[i].Scale;
+                var fm = _textPaint.FontMetrics;
+                item.TextWidthPx[i] = _textPaint.MeasureText(text);
+                item.TextHeightPx[i] = fm.Descent - fm.Ascent;
+            }
+            _items.Add(item);
+        }
+        SetActive(true);
+    }
+
+    /// <summary>Drop every live card (service Stop / mid-run flag flip). Safe from any thread.</summary>
+    public void Clear()
+    {
+        lock (_sync) { _items.Clear(); }
+        SetActive(false);
+    }
+
+    /// <summary>
+    /// Padded virtual-desktop px rects of the currently DRAWN text (the most recent card, the
+    /// only one <see cref="Render"/> shows), for the awareness OCR to skip - same contract as
+    /// the legacy GetActiveTextScreenRects window walk. Empty when nothing is visibly flashing.
+    /// </summary>
+    public System.Drawing.Rectangle[] GetActiveTextRectsPx()
+    {
+        lock (_sync)
+        {
+            if (_items.Count == 0) return Array.Empty<System.Drawing.Rectangle>();
+            var item = _items[^1];
+            if (item.TargetOpacity * item.Envelope() <= 0.01)
+                return Array.Empty<System.Drawing.Rectangle>();
+
+            var rects = new System.Drawing.Rectangle[item.Placements.Length];
+            for (int i = 0; i < item.Placements.Length; i++)
+            {
+                var p = item.Placements[i];
+                // Text bounds + the 4-DIP max outline offset, then the legacy 40-DIP OCR pad.
+                var halfW = item.TextWidthPx[i] / 2f + (4f + OcrPadDip) * p.Scale;
+                var halfH = item.TextHeightPx[i] / 2f + (4f + OcrPadDip) * p.Scale;
+                var cx = p.BoundsPx.MidX;
+                var cy = p.BoundsPx.MidY;
+                rects[i] = new System.Drawing.Rectangle(
+                    (int)Math.Floor(cx - halfW), (int)Math.Floor(cy - halfH),
+                    (int)Math.Ceiling(halfW * 2), (int)Math.Ceiling(halfH * 2));
+            }
+            return rects;
+        }
+    }
+
+    public override void Update(TimeSpan delta)
+    {
+        lock (_sync)
+        {
+            for (int i = _items.Count - 1; i >= 0; i--)
+            {
+                _items[i].Remaining -= delta;
+                if (_items[i].Remaining <= TimeSpan.Zero)
+                    _items.RemoveAt(i);
+            }
+            if (_items.Count == 0)
+                SetActive(false);
+        }
+    }
+
+    public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
+    {
+        lock (_sync)
+        {
+            if (_items.Count == 0) return;
+
+            // Most recent card wins (legacy parity: a new show replaces the previous outright).
+            var item = _items[^1];
+            var alphaScale = item.TargetOpacity * item.Envelope();
+            if (alphaScale <= 0) return;
+            var alpha = (byte)Math.Clamp(alphaScale * 255, 0, 255);
+
+            for (int i = 0; i < item.Placements.Length; i++)
+            {
+                var p = item.Placements[i];
+                if (!p.BoundsPx.IntersectsWith(boundsPx)) continue;   // cull to this monitor
+
+                if (!item.BgTransparent)
+                {
+                    // Legacy card bg is fully opaque, scaled only by the window opacity.
+                    _bgPaint.Color = item.Bg.WithAlpha(alpha);
+                    canvas.DrawRect(p.BoundsPx, _bgPaint);
+                }
+
+                _textPaint.TextSize = FontDip * p.Scale;
+                var fm = _textPaint.FontMetrics;
+                var cx = p.BoundsPx.MidX;
+                var baseline = p.BoundsPx.MidY - (fm.Ascent + fm.Descent) / 2f;
+
+                _textPaint.Color = item.Border.WithAlpha(alpha);
+                foreach (var (ox, oy) in Offsets)
+                    canvas.DrawText(item.Text, cx + ox * p.Scale, baseline + oy * p.Scale, _textPaint);
+
+                _textPaint.Color = item.TextColor.WithAlpha(alpha);
+                canvas.DrawText(item.Text, cx, baseline, _textPaint);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Deeper/VideoEnhancementBridge.cs
+++ b/ConditioningControlPanel/Services/Deeper/VideoEnhancementBridge.cs
@@ -109,6 +109,11 @@ namespace ConditioningControlPanel.Services.Deeper
                     return;
                 }
 
+                // Tell VideoService a Deeper enhancement now owns the clip's lifetime: it can loop or
+                // hold the video past its declared duration, so the safety timer must switch from a
+                // duration guillotine to a progress-based stall watch. (#536)
+                _video.SetEnhancementDriving(true);
+
                 App.Logger?.Information("VideoEnhancementBridge: bound enhancement ({Source}) for {File}",
                     resolved.Source, Path.GetFileName(path));
             }
@@ -130,6 +135,8 @@ namespace ConditioningControlPanel.Services.Deeper
 
         private void Unbind()
         {
+            // Restore the normal duration guillotine for any subsequent non-enhanced video. (#536)
+            try { _video.SetEnhancementDriving(false); } catch { }
             try { _host.UnbindEngine(); } catch { }
             try { _host.Unload(); } catch { }
             try { _source?.Dispose(); } catch { }

--- a/ConditioningControlPanel/Services/EngineCrashSentinel.cs
+++ b/ConditioningControlPanel/Services/EngineCrashSentinel.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Dirty-shutdown detector for normal engine sessions (Start button) — the counterpart of
+    /// <see cref="Chaos.ChaosCrashSentinel"/> for everything outside Rabbit Hole runs.
+    ///
+    /// A native process death (heap corruption / OOM / access violation) bypasses every managed
+    /// handler: nothing lands in crash.log, the app log just stops, and users report "the app
+    /// vanished" or "a memory leak". The 2026-07-12 leak hunt proved exactly that shape for
+    /// flash bursts (0xc0000374 in a decode storm). This flag file is armed while the engine is
+    /// running and cleared on clean stop/shutdown, so a surviving file at the next launch turns
+    /// an invisible vanish into one diagnostic line with the last-known session context.
+    /// </summary>
+    internal static class EngineCrashSentinel
+    {
+        private static string FilePath
+        {
+            get
+            {
+                // Mirror the app log location (%LOCALAPPDATA%/ConditioningControlPanel/logs).
+                string dir = Path.Combine(App.UserDataPath, "logs");
+                return Path.Combine(dir, "engine_session.active");
+            }
+        }
+
+        /// <summary>Arm/refresh the sentinel with the latest session context (idempotent overwrite).</summary>
+        public static void Mark(string contextLine)
+        {
+            try
+            {
+                string path = FilePath;
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, contextLine ?? "");
+            }
+            catch { /* diagnostics must never throw into a session */ }
+        }
+
+        /// <summary>Clear the sentinel — the engine stopped (or the app is shutting down) cleanly.</summary>
+        public static void Clear()
+        {
+            try
+            {
+                string path = FilePath;
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Called once at startup. If a sentinel survived from a prior session, the engine was
+        /// running when the process last died without a clean stop — log it loudly and consume
+        /// the file so it only reports once.
+        /// </summary>
+        public static void ConsumeAndReport(Serilog.ILogger? logger)
+        {
+            try
+            {
+                string path = FilePath;
+                if (!File.Exists(path)) return;
+                string ctx = "";
+                DateTime armed = DateTime.MinValue;
+                try { ctx = File.ReadAllText(path).Trim(); } catch { }
+                try { armed = File.GetLastWriteTime(path); } catch { }
+                logger?.Warning(
+                    "[ENGINECRASH] DETECTED: previous session ended abnormally while the engine was running " +
+                    "(no clean stop — likely a native crash/OOM, which leaves nothing in crash.log). " +
+                    "Sentinel armed {Armed}. Last context: {Context}",
+                    armed == DateTime.MinValue ? "(unknown)" : armed.ToString("yyyy-MM-dd HH:mm:ss"),
+                    string.IsNullOrWhiteSpace(ctx) ? "(unavailable)" : ctx);
+                Clear();
+            }
+            catch { }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -82,6 +82,26 @@ namespace ConditioningControlPanel.Services
         // per flash would reintroduce exactly the churn solid mode exists to remove.
         private bool _hostRefHeld;
         private bool _noImagesWarningShown;
+
+        // COMPOSITOR (unified overlay host): flashes render as items on the shared per-monitor
+        // Skia host - no per-flash window, no pooled shells, no host-canvas churn. The heartbeat
+        // keeps driving fade/frames/dwell through the FlashWindow state bag (same split as solid
+        // mode), so lifetime/hydra/gaze behavior is identical in all three modes.
+        private Compositor.FlashLayer? _flashLayer;
+        private static bool UseCompositor =>
+            (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+
+        // Clickable layer flashes: the compositor host is click-through, so clicks arrive via a
+        // global mouse hook hit-testing an immutable snapshot (same pattern as shared-host
+        // bubbles). The hook thread reads ONLY the copied rect values in _layerHits - never
+        // live WPF state. Rebuilt each heartbeat tick.
+        private GlobalMouseHook? _layerHook;
+        private sealed class LayerHit
+        {
+            public FlashWindow Win = null!;
+            public float X, Y, W, H;   // world px
+        }
+        private volatile LayerHit[] _layerHits = Array.Empty<LayerHit>();
         
         // Audio - only ONE sound per flash event
         private WaveOutEvent? _currentSound;
@@ -157,7 +177,7 @@ namespace ConditioningControlPanel.Services
                     {
                         if (w.IsFadingOut) continue;
                         if (w.UsesHost) anyHosted = true;   // no hwnd of its own — raise the shared host instead
-                        else ForceTopmost(w);
+                        else if (!w.UsesLayer) ForceTopmost(w);   // layer: the compositor host re-pins itself
                     }
                 }
                 if (anyHosted) ChaosBubbleHostOverlay.RaiseActive();
@@ -280,6 +300,7 @@ namespace ConditioningControlPanel.Services
             StopCurrentSound();
             CloseAllWindows();
             ReleaseHostRef();
+            ReleaseLayerHook();
 
             // Release cached BitmapSource objects from the LOH on stop
             ClearImageCache();
@@ -1061,6 +1082,12 @@ namespace ConditioningControlPanel.Services
                 // per-flash topmost-layered-window churn that some fullscreen games react to.
                 bool useHost = settings.FlashSolidMode;
 
+                // COMPOSITOR: takes precedence over both classic and solid mode. Same state-bag
+                // trick as solid mode, but the visual is a layer item on the shared Skia host -
+                // and clickability survives (global-hook hit-test), unlike solid mode.
+                bool useLayer = UseCompositor;
+                if (useLayer) useHost = false;
+
                 // Recycled from the pool when possible — all per-spawn state must be (re)set here.
                 // The window comes back already at geom's size (matched from the pool or freshly
                 // created at that size). NEVER assign Width/Height here: changing the size of an
@@ -1071,12 +1098,14 @@ namespace ConditioningControlPanel.Services
                 // True display size (from the image geometry) vs. the bucketed per-window shell that
                 // the pool recycles. Host mode has no window shell, so it stays at true size.
                 int trueW = geom.Width, trueH = geom.Height;
-                int shellW = useHost ? trueW : BucketUp(trueW);
-                int shellH = useHost ? trueH : BucketUp(trueH);
+                int shellW = (useHost || useLayer) ? trueW : BucketUp(trueW);
+                int shellH = (useHost || useLayer) ? trueH : BucketUp(trueH);
 
-                window = useHost
-                    ? new FlashWindow { UsesHost = true, Width = trueW, Height = trueH }
-                    : AcquireFlashWindow(shellW, shellH);
+                window = useLayer
+                    ? new FlashWindow { UsesLayer = true, Width = trueW, Height = trueH }
+                    : useHost
+                        ? new FlashWindow { UsesHost = true, Width = trueW, Height = trueH }
+                        : AcquireFlashWindow(shellW, shellH);
                 window.Left = finalX;
                 window.Top = finalY;
                 window.Frames = imageData.Frames;
@@ -1110,27 +1139,38 @@ namespace ConditioningControlPanel.Services
                     catch { }
                 });
 
-                // Create image control
+                // Create image control (layer mode has no WPF visual tree at all - the layer
+                // draws the SKImage frames directly, and the heartbeat drives FrameIndex).
                 var perfTier = PerformanceProfile.CurrentTier;
-                var image = new Image
+                Image? image = null;
+                if (!useLayer)
                 {
-                    Stretch = Stretch.Uniform,
-                    Source = imageData.Frames[0],
-                    // Pin the display size so centering the flash inside the (larger) bucketed shell
-                    // never rescales it — the visual stays exactly the size/aspect it was before.
-                    Width = trueW,
-                    Height = trueH,
-                };
-                // Cheaper resampling — after decode-at-display-size there is little residual
-                // scaling, so the quality difference is imperceptible while saving GPU fill cost.
-                RenderOptions.SetBitmapScalingMode(image, PerformanceProfile.ScalingMode(perfTier));
-                RenderOptions.SetEdgeMode(image, EdgeMode.Aliased);
+                    image = new Image
+                    {
+                        Stretch = Stretch.Uniform,
+                        Source = imageData.Frames[0],
+                        // Pin the display size so centering the flash inside the (larger) bucketed shell
+                        // never rescales it — the visual stays exactly the size/aspect it was before.
+                        Width = trueW,
+                        Height = trueH,
+                    };
+                    // Cheaper resampling — after decode-at-display-size there is little residual
+                    // scaling, so the quality difference is imperceptible while saving GPU fill cost.
+                    RenderOptions.SetBitmapScalingMode(image, PerformanceProfile.ScalingMode(perfTier));
+                    RenderOptions.SetEdgeMode(image, EdgeMode.Aliased);
 
-                window.ImageControl = image;
+                    window.ImageControl = image;
+                }
 
                 // The visual root: assigned as window.Content in per-window mode, or added to the
                 // shared host canvas in solid mode (an element can't be both — one logical parent).
-                FrameworkElement content;
+                // Stays null in layer mode (no WPF visual), which never reaches the attach branches.
+                FrameworkElement content = null!;
+
+                // Layer-mode glow parameters, filled by the glow branch below and consumed at
+                // the layer spawn (the WPF DropShadow content build is skipped entirely).
+                double layerGlowRadius = 0, layerGlowOpacity = 0;
+                System.Windows.Media.Color layerGlowColor = default;
 
                 // Roll for lucky flash BEFORE show so we can apply visual effects
                 xpAmount = _soundPlayingForCurrentFlash ? 8 : 4;
@@ -1186,6 +1226,23 @@ namespace ConditioningControlPanel.Services
                     // Cap the blur radius per tier (Quality ~24, Balanced ~18).
                     blurRadius = Math.Min(blurRadius, PerformanceProfile.MaxGlowBlurRadius(perfTier));
 
+                    // Layer mode: no WPF effect tree - stash the parameters for the layer item
+                    // and expand the bookkeeping rect exactly like host mode (the glow halo draws
+                    // outside the image, and gaze/overlap read this rect). The lucky pulse runs
+                    // inside the layer's render, so no Forever animations to leak either.
+                    if (useLayer)
+                    {
+                        layerGlowRadius = blurRadius;
+                        layerGlowOpacity = glowOpacity;
+                        layerGlowColor = glowColor;
+                        var layerPad = blurRadius / 2;
+                        window.Width += layerPad * 2;
+                        window.Height += layerPad * 2;
+                        window.Left -= layerPad;
+                        window.Top -= layerPad;
+                    }
+                    else
+                    {
                     var glowEffect = new DropShadowEffect
                     {
                         Color = glowColor,
@@ -1246,8 +1303,9 @@ namespace ConditioningControlPanel.Services
                         glowEffect.BeginAnimation(DropShadowEffect.BlurRadiusProperty, blurAnim);
                         glowEffect.BeginAnimation(DropShadowEffect.OpacityProperty, opacityAnim);
                     }
+                    }   // !useLayer (WPF glow content build)
                 }
-                else
+                else if (!useLayer)
                 {
                     // The image gets the black backing the window shell used to provide directly: the
                     // per-window shell background is Transparent now (so the bucket padding stays
@@ -1255,7 +1313,17 @@ namespace ConditioningControlPanel.Services
                     content = new Border { Background = System.Windows.Media.Brushes.Black, Child = image };
                 }
 
-                if (useHost)
+                if (useLayer)
+                {
+                    // Convert frames + spawn the layer item; the heartbeat drives it from here
+                    // via window.LayerItem (fade, GIF frames, gaze dwell).
+                    SpawnLayerVisual(window, imageData, monitor,
+                        layerGlowColor, layerGlowRadius, layerGlowOpacity, isLucky);
+
+                    if (!suppressHaptic)
+                        _ = App.Haptics?.FlashDecayVibeAsync();
+                }
+                else if (useHost)
                 {
                     // Size the root to the (possibly glow-expanded) bookkeeping rect; the glow
                     // border's own Padding re-insets the image, matching per-window layout.
@@ -1337,13 +1405,18 @@ namespace ConditioningControlPanel.Services
                 {
                     try
                     {
+                        if (window.LayerItem != null)
+                        {
+                            _flashLayer?.Remove(window.LayerItem);
+                            window.LayerItem = null;
+                        }
                         if (window.HostedRoot != null)
                         {
                             ChaosBubbleHostOverlay.Remove(window.HostedRoot);
                             window.HostedRoot = null;
                         }
                         window.LifetimeCts = null;
-                        if (!window.UsesHost) window.Close();
+                        if (!window.UsesHost && !window.UsesLayer) window.Close();
                     }
                     catch { }
                 }
@@ -1357,6 +1430,118 @@ namespace ConditioningControlPanel.Services
             {
                 App.Achievements?.TrackFlashImage();
             }
+        }
+
+        /// <summary>
+        /// COMPOSITOR: convert the decoded frames and spawn this flash's layer item. The
+        /// bookkeeping rect on <paramref name="window"/> (DIPs, already glow-expanded) converts
+        /// to world px with the spawn monitor's own scale — the same math as host mode's Place.
+        /// </summary>
+        private void SpawnLayerVisual(FlashWindow window, LoadedImageData imageData, MonitorInfo monitor,
+            System.Windows.Media.Color glowColor, double glowRadius, double glowOpacity, bool luckyPulse)
+        {
+            if (_flashLayer == null)
+            {
+                _flashLayer = new Compositor.FlashLayer(App.Compositor!);
+                App.Compositor!.RegisterLayer(_flashLayer);
+            }
+
+            // Straight pixel copies of the already-decoded (display-sized, cached) frames — no
+            // SKCodec decode here, so the global decode gate doesn't apply.
+            var frames = new SkiaSharp.SKImage[imageData.Frames.Count];
+            for (int i = 0; i < frames.Length; i++)
+                frames[i] = Compositor.SkiaWpfInterop.ToSKImage(imageData.Frames[i]);
+
+            var dpi = monitor.DpiScale > 0 ? monitor.DpiScale : 1.0;
+            var hasGlow = glowRadius > 0;
+            window.LayerItem = _flashLayer.Spawn(frames,
+                (float)(window.Left * dpi), (float)(window.Top * dpi),
+                (float)(window.Width * dpi), (float)(window.Height * dpi),
+                paddingPx: (float)(hasGlow ? glowRadius / 2 * dpi : 0),
+                cornerRadiusPx: hasGlow ? (float)(12 * dpi) : 0f,
+                new SkiaSharp.SKColor(glowColor.R, glowColor.G, glowColor.B),
+                glowSigmaPx: (float)(glowRadius * dpi / 3.0),   // WPF blur radius -> sigma (R/3)
+                glowOpacity, luckyPulse);
+
+            if (window.IsClickable)
+                EnsureLayerHook();
+        }
+
+        /// <summary>Install the click hook for layer flashes (UI thread — the hook needs this
+        /// thread's message loop). Idempotent; released when no layer flashes remain.</summary>
+        private void EnsureLayerHook()
+        {
+            if (_layerHook != null) return;
+            _layerHook = new GlobalMouseHook { LeftDown = OnLayerFlashLeftDown };
+            _layerHook.Start();
+        }
+
+        private void ReleaseLayerHook()
+        {
+            if (_layerHook == null) return;
+            try { _layerHook.Dispose(); } catch { }
+            _layerHook = null;
+            _layerHits = Array.Empty<LayerHit>();
+        }
+
+        /// <summary>
+        /// HOOK THREAD: hit-test a physical-px click against the layer-flash snapshot, topmost
+        /// (most recent spawn) first. A hit swallows the click — exactly what a clickable flash
+        /// window did by consuming it — and pops on the dispatcher.
+        /// </summary>
+        private bool OnLayerFlashLeftDown(System.Windows.Point px)
+        {
+            var hits = _layerHits;
+            for (int i = hits.Length - 1; i >= 0; i--)
+            {
+                var hit = hits[i];
+                if (px.X < hit.X || px.X > hit.X + hit.W || px.Y < hit.Y || px.Y > hit.Y + hit.H)
+                    continue;
+                var win = hit.Win;
+                System.Windows.Application.Current?.Dispatcher?.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        // Re-check on the UI thread — the flash may have expired since the snapshot.
+                        if (!win.IsFadingOut && win.LayerItem != null)
+                            OnFlashClicked(win, App.Settings.Current);
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("Layer flash pop failed: {E}", ex.Message);
+                    }
+                });
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Refresh the hook-thread hit snapshot from the live layer items (heartbeat cadence),
+        /// and drop the hook once the last layer flash is gone.
+        /// </summary>
+        private void RebuildLayerHitSnapshot()
+        {
+            if (_layerHook == null) return;
+            List<LayerHit>? hits = null;
+            bool anyLayer = false;
+            lock (_lockObj)
+            {
+                foreach (var w in _activeWindows)
+                {
+                    if (!w.UsesLayer) continue;
+                    anyLayer = true;
+                    var item = w.LayerItem;
+                    if (item == null || !w.IsClickable || w.IsFadingOut) continue;
+                    (hits ??= new List<LayerHit>()).Add(new LayerHit
+                    {
+                        Win = w,
+                        X = item.X, Y = item.Y, W = item.W, H = item.H
+                    });
+                }
+            }
+            _layerHits = hits?.ToArray() ?? Array.Empty<LayerHit>();
+            if (!anyLayer) ReleaseLayerHook();
         }
 
         private void OnFlashClicked(FlashWindow window, AppSettings settings)
@@ -1541,8 +1726,11 @@ namespace ConditioningControlPanel.Services
                 try
                 {
                     // Host-mode flashes have no hwnd — alive means their visual is still on the
-                    // shared canvas. Per-window flashes keep the loaded/visible liveness check.
-                    if (window.UsesHost ? window.HostedRoot == null : (!window.IsLoaded || !window.IsVisible))
+                    // shared canvas (layer mode: still on the compositor). Per-window flashes
+                    // keep the loaded/visible liveness check.
+                    if (window.UsesLayer ? window.LayerItem == null
+                        : window.UsesHost ? window.HostedRoot == null
+                        : (!window.IsLoaded || !window.IsVisible))
                     {
                         toRemove.Add(window);
                         continue;
@@ -1571,7 +1759,7 @@ namespace ConditioningControlPanel.Services
                     }
 
                     // Animate GIF frames
-                    if (window.Frames.Count > 1 && window.ImageControl != null)
+                    if (window.Frames.Count > 1 && (window.ImageControl != null || window.LayerItem != null))
                     {
                         var elapsed = DateTime.Now - window.StartTime;
                         var frameIndex = (int)(elapsed.TotalMilliseconds / window.FrameDelay.TotalMilliseconds) % window.Frames.Count;
@@ -1579,7 +1767,10 @@ namespace ConditioningControlPanel.Services
                         if (frameIndex != window.CurrentFrameIndex)
                         {
                             window.CurrentFrameIndex = frameIndex;
-                            window.ImageControl.Source = window.Frames[frameIndex];
+                            if (window.LayerItem != null)
+                                window.LayerItem.FrameIndex = frameIndex;
+                            else
+                                window.ImageControl!.Source = window.Frames[frameIndex];
                         }
                     }
                 }
@@ -1603,6 +1794,10 @@ namespace ConditioningControlPanel.Services
 
             if (toRemove.Count > 0)
                 App.Overlay?.NotifyTopWindowClosed();
+
+            // Layer flashes: refresh the click-hook hit snapshot (positions are static but
+            // items expire), and release the hook once the last one is gone.
+            RebuildLayerHitSnapshot();
 
             // Clear stale references in snapshot so removed windows can be GC'd
             Array.Clear(_windowsSnapshot, 0, _windowsSnapshot.Length);
@@ -2374,6 +2569,20 @@ namespace ConditioningControlPanel.Services
                     window.GlowEffect = null;
                 }
 
+                // Compositor: detach the layer item — this disposes its SKImage frames
+                // deterministically. No hwnd, nothing to pool.
+                if (window.UsesLayer)
+                {
+                    if (window.LayerItem != null)
+                    {
+                        var item = window.LayerItem;
+                        window.LayerItem = null;
+                        _flashLayer?.Remove(item);
+                    }
+                    window.IsFadingOut = false;
+                    return;
+                }
+
                 // Solid mode: just detach the visual from the shared canvas — there is no hwnd to
                 // hide/close/pool, and the host itself stays alive (see EnsureHostRef/ReleaseHostRef).
                 if (window.UsesHost)
@@ -2509,6 +2718,7 @@ namespace ConditioningControlPanel.Services
         public void Dispose()
         {
             Stop();
+            try { _flashLayer?.Clear(); } catch { }
             // Drain the recycled-window pool — the only place pooled hwnds actually close
             // (app shutdown; nothing else is animating, so the close is safe here).
             while (_windowPool.Count > 0)
@@ -2552,15 +2762,29 @@ namespace ConditioningControlPanel.Services
         public FrameworkElement? HostedRoot { get; set; }
 
         /// <summary>
+        /// Compositor mode: like solid mode, this instance is a pure state bag — the visual is a
+        /// FlashLayer item on the shared compositor host. Same DIP bookkeeping in Left/Top/
+        /// Width/Height, so gaze, hydra and the heartbeat work unchanged.
+        /// </summary>
+        public bool UsesLayer { get; set; }
+
+        /// <summary>Compositor mode only: this flash's layer item (null once torn down).</summary>
+        public Services.Compositor.FlashLayer.FlashItem? LayerItem { get; set; }
+
+        /// <summary>
         /// The fade alpha the heartbeat animates: window Opacity in per-window mode, the hosted
-        /// root's Opacity in solid mode (an unshown Window's Opacity renders nothing).
+        /// root's Opacity in solid mode, the layer item's in compositor mode (an unshown
+        /// Window's Opacity renders nothing).
         /// </summary>
         public double VisualOpacity
         {
-            get => UsesHost ? (HostedRoot?.Opacity ?? 0.0) : Opacity;
+            get => UsesLayer ? (LayerItem?.Opacity ?? 0.0)
+                 : UsesHost ? (HostedRoot?.Opacity ?? 0.0)
+                 : Opacity;
             set
             {
-                if (UsesHost) { if (HostedRoot != null) HostedRoot.Opacity = value; }
+                if (UsesLayer) { if (LayerItem != null) LayerItem.Opacity = value; }
+                else if (UsesHost) { if (HostedRoot != null) HostedRoot.Opacity = value; }
                 else Opacity = value;
             }
         }
@@ -2661,6 +2885,13 @@ namespace ConditioningControlPanel.Services
         public void SetGazeDwellProgress(double t01)
         {
             if (IsFadingOut) return;
+            if (UsesLayer)
+            {
+                // The layer draws the item scaled about its center — same 1.0 → 1.10 inflate.
+                if (LayerItem != null)
+                    LayerItem.DwellScale = 1.0 + Math.Max(0.0, Math.Min(1.0, t01)) * 0.10;
+                return;
+            }
             var fe = UsesHost ? HostedRoot : Content as FrameworkElement;
             if (fe == null) return;
             var clamped = Math.Max(0.0, Math.Min(1.0, t01));

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -88,8 +88,7 @@ namespace ConditioningControlPanel.Services
         // keeps driving fade/frames/dwell through the FlashWindow state bag (same split as solid
         // mode), so lifetime/hydra/gaze behavior is identical in all three modes.
         private Compositor.FlashLayer? _flashLayer;
-        private static bool UseCompositor =>
-            (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+        private static bool UseCompositor => App.CompositorEnabled;
 
         // Clickable layer flashes: the compositor host is click-through, so clicks arrive via a
         // global mouse hook hit-testing an immutable snapshot (same pattern as shared-host
@@ -102,6 +101,12 @@ namespace ConditioningControlPanel.Services
             public float X, Y, W, H;   // world px
         }
         private volatile LayerHit[] _layerHits = Array.Empty<LayerHit>();
+        // While a mandatory video is playing, the compositor host is pinned BELOW the video
+        // (#497 reconciler), so a layer flash under the video rect is invisible — swallowing
+        // clicks there would eat the user's attention-check clicks on a flash they can't see.
+        // Published as an immutable [x,y,w,h] physical-px array (atomic reference swap; the
+        // hook thread only ever reads the captured reference). Null = no exclusion.
+        private volatile float[]? _layerVideoExcludePx;
         
         // Audio - only ONE sound per flash event
         private WaveOutEvent? _currentSound;
@@ -170,17 +175,34 @@ namespace ConditioningControlPanel.Services
         {
             DispatcherHelper.RunOnUI(() =>
             {
-                bool anyHosted = false;
+                bool anyHosted = false, anyLayer = false;
                 lock (_lockObj)
                 {
                     foreach (var w in _activeWindows)
                     {
                         if (w.IsFadingOut) continue;
                         if (w.UsesHost) anyHosted = true;   // no hwnd of its own — raise the shared host instead
-                        else if (!w.UsesLayer) ForceTopmost(w);   // layer: the compositor host re-pins itself
+                        else if (w.UsesLayer) anyLayer = true;   // ditto — raise the compositor host
+                        else ForceTopmost(w);
                     }
                 }
                 if (anyHosted) ChaosBubbleHostOverlay.RaiseActive();
+
+                // Layer flashes live on the compositor host, which only asserts topmost on its
+                // show edge — kick it back above the chaos layer's ~1/s bubble re-raise the same
+                // way legacy flash windows are force-topmosted. Skip while a mandatory video is
+                // playing: OverlayService.ReassertZOrder deliberately pins the host BELOW the
+                // video (#497), and raising it here would just fight that reconciler.
+                if (anyLayer && App.Video?.IsPlaying != true && App.Compositor is { } engine)
+                {
+                    try
+                    {
+                        foreach (var hostHwnd in engine.GetVisibleHostHandles())
+                            NativeMethods.SetWindowPos(hostHwnd, NativeMethods.HWND_TOPMOST, 0, 0, 0, 0,
+                                NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
+                    }
+                    catch { }
+                }
             });
         }
 
@@ -1416,7 +1438,10 @@ namespace ConditioningControlPanel.Services
                             window.HostedRoot = null;
                         }
                         window.LifetimeCts = null;
-                        if (!window.UsesHost && !window.UsesLayer) window.Close();
+                        // Layer state bags still registered in Application.Windows — Close them
+                        // too (never shown, so Close is safe) or the failed spawn leaks a Window.
+                        if (window.UsesLayer) CloseStateBagWindow(window);
+                        else if (!window.UsesHost) window.Close();
                     }
                     catch { }
                 }
@@ -1436,6 +1461,11 @@ namespace ConditioningControlPanel.Services
         /// COMPOSITOR: convert the decoded frames and spawn this flash's layer item. The
         /// bookkeeping rect on <paramref name="window"/> (DIPs, already glow-expanded) converts
         /// to world px with the spawn monitor's own scale — the same math as host mode's Place.
+        /// The per-frame pixel copies (up to 60 frames × multi-MB images × concurrent spawns)
+        /// used to run synchronously on the dispatcher and hitched the UI at spawn — they now
+        /// run in Task.Run (SpiralLayer.ShowFrames pattern) and the layer item spawns on the
+        /// dispatcher when the conversion lands. window.LayerSpawnPending keeps the heartbeat
+        /// from sweeping the still-itemless window during the conversion window.
         /// </summary>
         private void SpawnLayerVisual(FlashWindow window, LoadedImageData imageData, MonitorInfo monitor,
             System.Windows.Media.Color glowColor, double glowRadius, double glowOpacity, bool luckyPulse)
@@ -1445,26 +1475,95 @@ namespace ConditioningControlPanel.Services
                 _flashLayer = new Compositor.FlashLayer(App.Compositor!);
                 App.Compositor!.RegisterLayer(_flashLayer);
             }
+            var layer = _flashLayer;
 
-            // Straight pixel copies of the already-decoded (display-sized, cached) frames — no
-            // SKCodec decode here, so the global decode gate doesn't apply.
-            var frames = new SkiaSharp.SKImage[imageData.Frames.Count];
-            for (int i = 0; i < frames.Length; i++)
-                frames[i] = Compositor.SkiaWpfInterop.ToSKImage(imageData.Frames[i]);
-
+            // Snapshot everything the worker/continuation reads. The frames are frozen
+            // BitmapSources (LoadImageAsync and AnimatedWebp freeze every frame), so reading
+            // them from a worker thread is safe.
+            var sourceFrames = imageData.Frames.ToArray();
             var dpi = monitor.DpiScale > 0 ? monitor.DpiScale : 1.0;
             var hasGlow = glowRadius > 0;
-            window.LayerItem = _flashLayer.Spawn(frames,
-                (float)(window.Left * dpi), (float)(window.Top * dpi),
-                (float)(window.Width * dpi), (float)(window.Height * dpi),
-                paddingPx: (float)(hasGlow ? glowRadius / 2 * dpi : 0),
-                cornerRadiusPx: hasGlow ? (float)(12 * dpi) : 0f,
-                new SkiaSharp.SKColor(glowColor.R, glowColor.G, glowColor.B),
-                glowSigmaPx: (float)(glowRadius * dpi / 3.0),   // WPF blur radius -> sigma (R/3)
-                glowOpacity, luckyPulse);
+            var x = (float)(window.Left * dpi);
+            var y = (float)(window.Top * dpi);
+            var w = (float)(window.Width * dpi);
+            var h = (float)(window.Height * dpi);
+            var paddingPx = (float)(hasGlow ? glowRadius / 2 * dpi : 0);
+            var cornerRadiusPx = hasGlow ? (float)(12 * dpi) : 0f;
+            var skGlowColor = new SkiaSharp.SKColor(glowColor.R, glowColor.G, glowColor.B);
+            var glowSigmaPx = (float)(glowRadius * dpi / 3.0);   // WPF blur radius -> sigma (R/3)
 
-            if (window.IsClickable)
-                EnsureLayerHook();
+            window.LayerSpawnPending = true;
+
+            _ = Task.Run(() =>
+            {
+                // Straight pixel copies of the already-decoded (display-sized, cached) frames — no
+                // SKCodec decode here, so the global decode gate doesn't apply.
+                SkiaSharp.SKImage[]? frames = null;
+                try
+                {
+                    frames = new SkiaSharp.SKImage[sourceFrames.Length];
+                    for (int i = 0; i < frames.Length; i++)
+                        frames[i] = Compositor.SkiaWpfInterop.ToSKImage(sourceFrames[i]);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("SpawnLayerVisual: frame conversion failed: {E}", ex.Message);
+                    DisposeLayerFrames(frames);
+                    frames = null;
+                }
+
+                var dispatcher = System.Windows.Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted)
+                {
+                    DisposeLayerFrames(frames);
+                    window.LayerSpawnPending = false;   // plain CLR property — safe off-thread
+                    return;
+                }
+
+                dispatcher.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        window.LayerSpawnPending = false;
+                        if (frames == null)
+                            return;   // conversion failed — the heartbeat sweeps the itemless window
+
+                        // The flash may have been clicked away, expired or torn down (Stop /
+                        // CloseAllWindows) while converting — dispose instead of spawning.
+                        bool tracked;
+                        lock (_lockObj) { tracked = _activeWindows.Contains(window); }
+                        if (!tracked || window.IsFadingOut || (!_isRunning && !_oneShotActive)
+                            || window.LifetimeCts == null || window.LifetimeCts.IsCancellationRequested)
+                        {
+                            DisposeLayerFrames(frames);
+                            return;
+                        }
+
+                        window.LayerItem = layer.Spawn(frames, x, y, w, h,
+                            paddingPx, cornerRadiusPx, skGlowColor, glowSigmaPx,
+                            glowOpacity, luckyPulse);
+                        frames = null;   // ownership transferred — FlashLayer.Remove disposes them
+
+                        if (window.IsClickable)
+                            EnsureLayerHook();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("SpawnLayerVisual: layer spawn failed: {E}", ex.Message);
+                        DisposeLayerFrames(frames);
+                    }
+                });
+            });
+        }
+
+        /// <summary>Dispose a (possibly partially filled) converted-frame array.</summary>
+        private static void DisposeLayerFrames(SkiaSharp.SKImage[]? frames)
+        {
+            if (frames == null) return;
+            foreach (var f in frames)
+            {
+                try { f?.Dispose(); } catch { }
+            }
         }
 
         /// <summary>Install the click hook for layer flashes (UI thread — the hook needs this
@@ -1491,6 +1590,14 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private bool OnLayerFlashLeftDown(System.Windows.Point px)
         {
+            // Clicks inside a playing mandatory video's rect belong to the video (attention
+            // checks) — the flash there is pinned below it and invisible, so never swallow.
+            var exclude = _layerVideoExcludePx;
+            if (exclude != null
+                && px.X >= exclude[0] && px.X <= exclude[0] + exclude[2]
+                && px.Y >= exclude[1] && px.Y <= exclude[1] + exclude[3])
+                return false;
+
             var hits = _layerHits;
             for (int i = hits.Length - 1; i >= 0; i--)
             {
@@ -1541,6 +1648,22 @@ namespace ConditioningControlPanel.Services
                 }
             }
             _layerHits = hits?.ToArray() ?? Array.Empty<LayerHit>();
+
+            // Publish the playing video's physical rect so the hook thread won't swallow
+            // clicks on a flash the video is covering (the host sits pinned below the video).
+            float[]? exclude = null;
+            try
+            {
+                if (App.Video?.IsPlaying == true && App.Video.PrimaryVideoWindow is Window vw)
+                {
+                    var vh = new System.Windows.Interop.WindowInteropHelper(vw).Handle;
+                    if (vh != IntPtr.Zero && NativeMethods.GetWindowRect(vh, out var r))
+                        exclude = new float[] { r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top };
+                }
+            }
+            catch { }
+            _layerVideoExcludePx = exclude;
+
             if (!anyLayer) ReleaseLayerHook();
         }
 
@@ -1726,9 +1849,11 @@ namespace ConditioningControlPanel.Services
                 try
                 {
                     // Host-mode flashes have no hwnd — alive means their visual is still on the
-                    // shared canvas (layer mode: still on the compositor). Per-window flashes
-                    // keep the loaded/visible liveness check.
-                    if (window.UsesLayer ? window.LayerItem == null
+                    // shared canvas (layer mode: still on the compositor, OR its off-thread
+                    // frame conversion is still pending — don't sweep a flash that hasn't had
+                    // the chance to spawn its layer item yet). Per-window flashes keep the
+                    // loaded/visible liveness check.
+                    if (window.UsesLayer ? (window.LayerItem == null && !window.LayerSpawnPending)
                         : window.UsesHost ? window.HostedRoot == null
                         : (!window.IsLoaded || !window.IsVisible))
                     {
@@ -2580,6 +2705,12 @@ namespace ConditioningControlPanel.Services
                         _flashLayer?.Remove(item);
                     }
                     window.IsFadingOut = false;
+                    // The state bag is still a real Window: constructing it registered it in
+                    // Application.Windows, and only Close() removes it — returning without a
+                    // Close leaked one Window per layer flash for the app lifetime. Close on a
+                    // never-shown Window is legal (no hwnd, so no layered-window deadlock),
+                    // and returning here keeps it out of the recycle pool below.
+                    CloseStateBagWindow(window);
                     return;
                 }
 
@@ -2593,6 +2724,9 @@ namespace ConditioningControlPanel.Services
                         window.HostedRoot = null;
                     }
                     window.IsFadingOut = false;
+                    // Same state-bag leak as the layer branch above: the never-shown Window
+                    // stays registered in Application.Windows until Close().
+                    CloseStateBagWindow(window);
                     return;
                 }
 
@@ -2618,6 +2752,30 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("Failed to close flash window: {Error}", ex.Message);
                 try { window.Close(); } catch { }
             }
+        }
+
+        /// <summary>
+        /// Close a never-shown state-bag Window (layer mode) on its dispatcher so it leaves
+        /// Application.Windows. Safe to call from any thread; Close is idempotent-ish and any
+        /// failure is swallowed (the window has no hwnd, handlers or content by this point).
+        /// </summary>
+        private static void CloseStateBagWindow(FlashWindow window)
+        {
+            try
+            {
+                if (window.Dispatcher.CheckAccess())
+                {
+                    window.Close();
+                }
+                else
+                {
+                    window.Dispatcher.BeginInvoke(() =>
+                    {
+                        try { window.Close(); } catch { }
+                    });
+                }
+            }
+            catch { }
         }
 
         // WndProc hook for flash windows: drop WM_DPICHANGED so WPF never runs its auto DPI-rescale
@@ -2770,6 +2928,13 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>Compositor mode only: this flash's layer item (null once torn down).</summary>
         public Services.Compositor.FlashLayer.FlashItem? LayerItem { get; set; }
+
+        /// <summary>
+        /// Compositor mode only: true while the off-thread frame conversion for this spawn is
+        /// still running — LayerItem is null but the flash is NOT dead, so the heartbeat must
+        /// not sweep it. Cleared by the spawn continuation whether it spawns or bails.
+        /// </summary>
+        public bool LayerSpawnPending { get; set; }
 
         /// <summary>
         /// The fade alpha the heartbeat animates: window Opacity in per-window mode, the hosted
@@ -2985,6 +3150,12 @@ namespace ConditioningControlPanel.Services
 
         [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
         public static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public struct RECT { public int Left, Top, Right, Bottom; }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll")]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
     }
 
     #endregion

--- a/ConditioningControlPanel/Services/Input/GlobalMouseHook.cs
+++ b/ConditioningControlPanel/Services/Input/GlobalMouseHook.cs
@@ -17,10 +17,20 @@ public sealed class GlobalMouseHook : IDisposable
     private const int WH_MOUSE_LL = 14;
     private const int WM_RBUTTONDOWN = 0x0204;
     private const int WM_LBUTTONDOWN = 0x0201;
+    private const int WM_LBUTTONUP = 0x0202;
+    private const int WM_RBUTTONUP = 0x0205;
 
     private IntPtr _hookId = IntPtr.Zero;
     private readonly LowLevelMouseProc _proc;
     private bool _isDisposed;
+    // When a DOWN is swallowed, its matching UP must be swallowed too. An orphaned UP still
+    // reaches the window under the cursor, and WPF surfaces wired to bare MouseLeftButtonUp
+    // (the dashboard FeatureCards, preset/skill cards) treat it as a click - so popping a
+    // hosted bubble over the dashboard also "clicked" the card beneath it. Right-clicks have
+    // the same shape via context menus, which open on right-UP. Hook-thread only: every
+    // low-level mouse message is delivered sequentially on this hook's message loop.
+    private bool _swallowNextLeftUp;
+    private bool _swallowNextRightUp;
 
     /// <summary>Right button pressed at this PHYSICAL-px screen point. Return true to swallow.</summary>
     public Func<Point, bool>? RightDown;
@@ -55,19 +65,37 @@ public sealed class GlobalMouseHook : IDisposable
 
     private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
-        if (nCode >= 0 && (wParam == (IntPtr)WM_RBUTTONDOWN || wParam == (IntPtr)WM_LBUTTONDOWN))
+        if (nCode >= 0)
         {
-            try
+            if (wParam == (IntPtr)WM_RBUTTONDOWN || wParam == (IntPtr)WM_LBUTTONDOWN)
             {
-                var info = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
-                var pt = new Point(info.pt.X, info.pt.Y);
-                var cb = wParam == (IntPtr)WM_RBUTTONDOWN ? RightDown : LeftDown;
-                if (cb?.Invoke(pt) == true)
-                    return (IntPtr)1;
+                try
+                {
+                    var info = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
+                    var pt = new Point(info.pt.X, info.pt.Y);
+                    bool isRight = wParam == (IntPtr)WM_RBUTTONDOWN;
+                    var cb = isRight ? RightDown : LeftDown;
+                    if (cb?.Invoke(pt) == true)
+                    {
+                        if (isRight) _swallowNextRightUp = true;
+                        else _swallowNextLeftUp = true;
+                        return (IntPtr)1;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("Mouse hook callback: {E}", ex.Message);
+                }
             }
-            catch (Exception ex)
+            else if (wParam == (IntPtr)WM_LBUTTONUP && _swallowNextLeftUp)
             {
-                App.Logger?.Debug("Mouse hook callback: {E}", ex.Message);
+                _swallowNextLeftUp = false;
+                return (IntPtr)1;
+            }
+            else if (wParam == (IntPtr)WM_RBUTTONUP && _swallowNextRightUp)
+            {
+                _swallowNextRightUp = false;
+                return (IntPtr)1;
             }
         }
         return CallNextHookEx(_hookId, nCode, wParam, lParam);

--- a/ConditioningControlPanel/Services/Input/GlobalMouseHook.cs
+++ b/ConditioningControlPanel/Services/Input/GlobalMouseHook.cs
@@ -22,15 +22,27 @@ public sealed class GlobalMouseHook : IDisposable
 
     private IntPtr _hookId = IntPtr.Zero;
     private readonly LowLevelMouseProc _proc;
+    private readonly object _sync = new();
     private bool _isDisposed;
     // When a DOWN is swallowed, its matching UP must be swallowed too. An orphaned UP still
     // reaches the window under the cursor, and WPF surfaces wired to bare MouseLeftButtonUp
     // (the dashboard FeatureCards, preset/skill cards) treat it as a click - so popping a
     // hosted bubble over the dashboard also "clicked" the card beneath it. Right-clicks have
-    // the same shape via context menus, which open on right-UP. Hook-thread only: every
-    // low-level mouse message is delivered sequentially on this hook's message loop.
-    private bool _swallowNextLeftUp;
-    private bool _swallowNextRightUp;
+    // the same shape via context menus, which open on right-UP. Written on the hook's message
+    // loop; volatile because Dispose reads them to decide whether to defer the unhook.
+    private volatile bool _swallowNextLeftUp;
+    private volatile bool _swallowNextRightUp;
+
+    // Deferred dispose: Dispose() was called while a swallowed DOWN's matching UP was still in
+    // flight (a real click's UP trails its DOWN by 60-100ms, and owners release the hook the
+    // same instant the last swallowed pop lands). Unhooking immediately would discard the
+    // pending swallow and the orphaned UP would ghost-click whatever sits under the cursor -
+    // the exact bug the swallow flags above exist to prevent. So the hook stays installed just
+    // long enough to swallow that UP, with a failsafe in case it never arrives (button released
+    // outside the desktop, session teardown mid-press).
+    private volatile bool _unhookPending;
+    private System.Threading.Timer? _unhookFailsafe;
+    private const int UnhookFailsafeMs = 750;   // comfortably > any real click's DOWN->UP gap
 
     /// <summary>Right button pressed at this PHYSICAL-px screen point. Return true to swallow.</summary>
     public Func<Point, bool>? RightDown;
@@ -48,18 +60,26 @@ public sealed class GlobalMouseHook : IDisposable
 
     public void Start()
     {
-        if (_hookId != IntPtr.Zero) return;
-        using var curProcess = Process.GetCurrentProcess();
-        using var curModule = curProcess.MainModule!;
-        _hookId = SetWindowsHookEx(WH_MOUSE_LL, _proc, GetModuleHandle(curModule.ModuleName), 0);
+        lock (_sync)
+        {
+            if (_isDisposed || _unhookPending || _hookId != IntPtr.Zero) return;
+            using var curProcess = Process.GetCurrentProcess();
+            using var curModule = curProcess.MainModule!;
+            _hookId = SetWindowsHookEx(WH_MOUSE_LL, _proc, GetModuleHandle(curModule.ModuleName), 0);
+        }
         App.Logger?.Debug("Global mouse hook started");
     }
 
     public void Stop()
     {
-        if (_hookId == IntPtr.Zero) return;
-        UnhookWindowsHookEx(_hookId);
-        _hookId = IntPtr.Zero;
+        IntPtr hook;
+        lock (_sync)
+        {
+            hook = _hookId;
+            _hookId = IntPtr.Zero;
+        }
+        if (hook == IntPtr.Zero) return;
+        UnhookWindowsHookEx(hook);
         App.Logger?.Debug("Global mouse hook stopped");
     }
 
@@ -90,11 +110,13 @@ public sealed class GlobalMouseHook : IDisposable
             else if (wParam == (IntPtr)WM_LBUTTONUP && _swallowNextLeftUp)
             {
                 _swallowNextLeftUp = false;
+                CompleteDeferredDisposeIfDrained();
                 return (IntPtr)1;
             }
             else if (wParam == (IntPtr)WM_RBUTTONUP && _swallowNextRightUp)
             {
                 _swallowNextRightUp = false;
+                CompleteDeferredDisposeIfDrained();
                 return (IntPtr)1;
             }
         }
@@ -103,8 +125,60 @@ public sealed class GlobalMouseHook : IDisposable
 
     public void Dispose()
     {
-        if (_isDisposed) return;
-        _isDisposed = true;
+        lock (_sync)
+        {
+            if (_isDisposed || _unhookPending) return;
+
+            // A swallowed DOWN's matching UP may still be in flight - keep the hook installed
+            // just long enough to swallow it (see the deferred-dispose field comment above).
+            // No NEW swallows can start meanwhile: the decision callbacks are cleared here.
+            if (_hookId != IntPtr.Zero && (_swallowNextLeftUp || _swallowNextRightUp))
+            {
+                _unhookPending = true;
+                RightDown = null;
+                LeftDown = null;
+                _unhookFailsafe = new System.Threading.Timer(
+                    static s => ((GlobalMouseHook)s!).CompleteDeferredDispose(),
+                    this, UnhookFailsafeMs, System.Threading.Timeout.Infinite);
+                return;
+            }
+
+            _isDisposed = true;
+        }
+        Stop();
+    }
+
+    /// <summary>Hook message loop: finish a deferred dispose once no swallow remains pending.</summary>
+    private void CompleteDeferredDisposeIfDrained()
+    {
+        if (_unhookPending && !_swallowNextLeftUp && !_swallowNextRightUp)
+            CompleteDeferredDispose();
+    }
+
+    /// <summary>
+    /// Second half of a deferred <see cref="Dispose"/>: mark disposed, kill the failsafe and
+    /// unhook. Reached from the hook callback (UP swallowed) or the failsafe timer (threadpool,
+    /// UP never arrived) - whichever fires first wins; <see cref="Stop"/>'s exchange guarantees
+    /// a single unhook either way. The unhook itself is posted to the dispatcher that installed
+    /// the hook, which also keeps it out of the hook procedure's own stack frame.
+    /// </summary>
+    private void CompleteDeferredDispose()
+    {
+        lock (_sync)
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+            _unhookPending = false;
+            _unhookFailsafe?.Dispose();
+            _unhookFailsafe = null;
+        }
+
+        var disp = Application.Current?.Dispatcher;
+        if (disp != null && !disp.HasShutdownStarted)
+        {
+            try { disp.BeginInvoke((Action)Stop); return; }
+            catch { /* dispatcher torn down between checks - fall through */ }
+        }
         Stop();
     }
 

--- a/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
+++ b/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -57,14 +58,33 @@ internal static class AnimatedWebp
         catch { return false; }
     }
 
+    // Global gate on concurrent Skia decodes, across ALL callers (flash bursts, chaos
+    // wash/cascade, tease bubbles). The per-decode memory budget below is only per-decode:
+    // a flash burst used to fire N unthrottled Task.Run decodes at once, each holding a
+    // srcW×srcH×4 composition canvas (up to 64MB at the 4096² guard) + kept frames — a
+    // 15-wide GIF burst spiked private bytes +1.1GB in ~2s and died with 0xc0000374 native
+    // heap corruption inside SkiaSharp (no crash.log; WER dump 28788 shows two threads
+    // concurrently in DecodeFrames, one mid GetPixels, one freeing an SKFileStream).
+    // Two permits bounds the aggregate at ~190MB worst-case; the same burst config that
+    // crashed at 228s survived a 15-min soak with burst width capped to 2 (A/B, 2026-07-12).
+    private static readonly SemaphoreSlim _decodeGate = new(2, 2);
+
     /// <summary>
     /// Decode an animated webp into fully-composed, frozen BGRA frames, downscaled so the
     /// longest edge is at most <paramref name="maxDim"/> and subsampled (evenly, GIF-loader
     /// style) so the kept set fits <paramref name="maxMemoryMb"/> / <paramref name="maxFrames"/>.
     /// Returns null for still/undecodable files so callers can fall back to their static path.
-    /// Heavy — call off the UI thread.
+    /// Heavy — call off the UI thread (also blocks on the global decode gate).
     /// </summary>
     public static (List<BitmapSource> Frames, TimeSpan FrameDelay)? DecodeFrames(
+        string path, int maxDim, int maxFrames, double maxMemoryMb)
+    {
+        _decodeGate.Wait();
+        try { return DecodeFramesCore(path, maxDim, maxFrames, maxMemoryMb); }
+        finally { _decodeGate.Release(); }
+    }
+
+    private static (List<BitmapSource> Frames, TimeSpan FrameDelay)? DecodeFramesCore(
         string path, int maxDim, int maxFrames, double maxMemoryMb)
     {
         using var codec = SKCodec.Create(path);

--- a/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
+++ b/ConditioningControlPanel/Services/Media/AnimatedWebp.cs
@@ -80,14 +80,35 @@ internal static class AnimatedWebp
         string path, int maxDim, int maxFrames, double maxMemoryMb)
     {
         _decodeGate.Wait();
-        try { return DecodeFramesCore(path, maxDim, maxFrames, maxMemoryMb); }
+        try
+        {
+            using var codec = SKCodec.Create(path);
+            return DecodeFramesCore(codec, maxDim, maxFrames, maxMemoryMb);
+        }
+        finally { _decodeGate.Release(); }
+    }
+
+    /// <summary>
+    /// Stream variant of <see cref="DecodeFrames(string,int,int,double)"/> for sources that are
+    /// not on-disk files (pack:// application resources, mod archives). Same global decode gate.
+    /// </summary>
+    public static (List<BitmapSource> Frames, TimeSpan FrameDelay)? DecodeFrames(
+        Stream stream, int maxDim, int maxFrames, double maxMemoryMb)
+    {
+        _decodeGate.Wait();
+        try
+        {
+            using var data = SKData.Create(stream);
+            if (data == null) return null;
+            using var codec = SKCodec.Create(data);
+            return DecodeFramesCore(codec, maxDim, maxFrames, maxMemoryMb);
+        }
         finally { _decodeGate.Release(); }
     }
 
     private static (List<BitmapSource> Frames, TimeSpan FrameDelay)? DecodeFramesCore(
-        string path, int maxDim, int maxFrames, double maxMemoryMb)
+        SKCodec? codec, int maxDim, int maxFrames, double maxMemoryMb)
     {
-        using var codec = SKCodec.Create(path);
         if (codec == null) return null;
         int frameCount = codec.FrameCount;
         if (frameCount <= 1) return null;

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -61,6 +61,39 @@ public class OverlayService : IDisposable
     private double? _rampPinkOpacity;
     private double? _rampSpiralOpacity;
     private double? _rampBrainDrainOpacity;
+
+    // Unified overlay host (Settings.UnifiedOverlayHost, experimental): pink/spiral render as
+    // compositor layers on the shared per-monitor Skia host instead of per-effect layered
+    // windows. This service keeps ALL the opacity math (ramps, pulses, holds, settings sync)
+    // and pushes final values; the layers only draw. Layers are created lazily so the engine
+    // stays fully parked when the flag is off. Route checks use "<layer>?.IsActive == true"
+    // rather than the flag so a mid-run flag flip can't strand a visible layer.
+    private Compositor.PinkTintLayer? _pinkLayer;
+    private Compositor.SpiralLayer? _spiralLayer;
+    private static bool UseCompositor =>
+        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+    private Compositor.PinkTintLayer GetPinkLayer()
+    {
+        if (_pinkLayer == null)
+        {
+            _pinkLayer = new Compositor.PinkTintLayer(App.Compositor!);
+            App.Compositor!.RegisterLayer(_pinkLayer);
+        }
+        return _pinkLayer;
+    }
+    private Compositor.SpiralLayer GetSpiralLayer()
+    {
+        if (_spiralLayer == null)
+        {
+            _spiralLayer = new Compositor.SpiralLayer(App.Compositor!);
+            App.Compositor!.RegisterLayer(_spiralLayer);
+        }
+        return _spiralLayer;
+    }
+    // "Is showing" checks must cover BOTH render paths - the 500ms sync and pulse gate on these.
+    private bool PinkShowing => _pinkFilterWindows.Count > 0 || _pinkLayer?.IsActive == true;
+    private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true;
+
     private int _consecutiveTopmostLossCount;
     // Recreate-overlays backoff. Destroying + recreating every layered overlay window on a 3s cadence
     // is a GDI/composition-surface churn engine (feeds the "not enough quota" exhaustion, and the
@@ -244,7 +277,7 @@ public class OverlayService : IDisposable
 
             if (settings.PinkFilterEnabled)
             {
-                if (_pinkFilterWindows.Count == 0)
+                if (!PinkShowing)
                     StartPinkFilter();
                 else
                     UpdatePinkFilterOpacity();
@@ -258,7 +291,7 @@ public class OverlayService : IDisposable
             if (settings.SpiralEnabled && !string.IsNullOrEmpty(spiralPath))
             {
                 _spiralPath = spiralPath;
-                if (_spiralWindows.Count == 0)
+                if (!SpiralShowing)
                     StartSpiral();
                 else
                     UpdateSpiralOpacity();
@@ -273,7 +306,7 @@ public class OverlayService : IDisposable
         });
 
         App.Logger?.Debug("Overlays refreshed - Pink: {Pink}, Spiral: {Spiral}, BrainDrain: {BrainDrain}",
-            _pinkFilterWindows.Count > 0, _spiralWindows.Count > 0, _brainDrainBlurWindows.Count > 0);
+            PinkShowing, SpiralShowing, _brainDrainBlurWindows.Count > 0);
     }
 
     /// <summary>
@@ -286,8 +319,8 @@ public class OverlayService : IDisposable
         DispatcherHelper.RunOnUISync(() =>
         {
             var settings = App.Settings.Current;
-            var hasPink = settings.PinkFilterEnabled && _pinkFilterWindows.Count > 0;
-            var hasSpiral = settings.SpiralEnabled && _spiralWindows.Count > 0;
+            var hasPink = settings.PinkFilterEnabled && PinkShowing;
+            var hasSpiral = settings.SpiralEnabled && SpiralShowing;
             var hasBrainDrain = settings.BrainDrainEnabled && _brainDrainBlurWindows.Count > 0;
 
             if (!hasPink && !hasSpiral && !hasBrainDrain) return;
@@ -298,6 +331,10 @@ public class OverlayService : IDisposable
                 var boosted = Math.Min(settings.PinkFilterOpacity * 2, 100);
                 var alpha = (byte)(boosted / 100.0 * 255);
                 var (fr, fg, fb) = GetFilterRgb();
+                if (_pinkLayer?.IsActive == true)
+                {
+                    _pinkLayer.Set(fr, fg, fb, boosted / 100.0);
+                }
                 foreach (var window in _pinkFilterWindows)
                 {
                     if (window.Content is Border border &&
@@ -312,6 +349,7 @@ public class OverlayService : IDisposable
             if (hasSpiral)
             {
                 var boostedOpacity = Math.Min((settings.SpiralOpacity / 100.0) * 0.1 * 2, 1.0);
+                _spiralLayer?.SetOpacity(boostedOpacity);
                 foreach (var image in _spiralGifImages)
                     image.Opacity = boostedOpacity;
                 foreach (var media in _spiralMediaElements)
@@ -411,30 +449,30 @@ public class OverlayService : IDisposable
     {
         var settings = App.Settings.Current;
 
-        if (settings.PinkFilterEnabled && _pinkFilterWindows.Count == 0)
+        if (settings.PinkFilterEnabled && !PinkShowing)
         {
             StartPinkFilter();
         }
-        else if (!settings.PinkFilterEnabled && _pinkFilterWindows.Count > 0 && _timedPinkHolds == 0 && !_sustainedPinkHeld)
+        else if (!settings.PinkFilterEnabled && PinkShowing && _timedPinkHolds == 0 && !_sustainedPinkHeld)
         {
             StopPinkFilter();
         }
-        else if (_pinkFilterWindows.Count > 0)
+        else if (PinkShowing)
         {
             UpdatePinkFilterOpacity();
         }
 
         var spiralPath = GetSpiralPath();
-        if (settings.SpiralEnabled && !string.IsNullOrEmpty(spiralPath) && _spiralWindows.Count == 0)
+        if (settings.SpiralEnabled && !string.IsNullOrEmpty(spiralPath) && !SpiralShowing)
         {
             _spiralPath = spiralPath;
             StartSpiral();
         }
-        else if (!settings.SpiralEnabled && _spiralWindows.Count > 0 && _timedSpiralHolds == 0 && !_sustainedSpiralHeld)
+        else if (!settings.SpiralEnabled && SpiralShowing && _timedSpiralHolds == 0 && !_sustainedSpiralHeld)
         {
             StopSpiral();
         }
-        else if (_spiralWindows.Count > 0)
+        else if (SpiralShowing)
         {
             UpdateSpiralOpacity();
         }
@@ -613,8 +651,8 @@ public class OverlayService : IDisposable
                 // Both show() and the reconcilers run on this one UI thread, so they can't interleave;
                 // gate on a window actually appearing so a no-op show (e.g. spiral with no asset) doesn't
                 // leave a stale hold that would later block a legitimate teardown.
-                if (kind == "pink_filter") _sustainedPinkHeld = _pinkFilterWindows.Count > 0;
-                else if (kind == "spiral") _sustainedSpiralHeld = _spiralWindows.Count > 0;
+                if (kind == "pink_filter") _sustainedPinkHeld = PinkShowing;
+                else if (kind == "spiral") _sustainedSpiralHeld = SpiralShowing;
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlaySustained show: {E}", ex.Message); }
         };
@@ -716,6 +754,8 @@ public class OverlayService : IDisposable
     {
         var (fr, fg, fb) = GetFilterRgb();
         byte a = (byte)Math.Clamp(opacity * 255, 0, 255);
+        if (_pinkLayer?.IsActive == true)
+            _pinkLayer.Set(fr, fg, fb, opacity);
         foreach (var window in _pinkFilterWindows)
             if (window.Content is Border border &&
                 border.Background is System.Windows.Media.SolidColorBrush brush)
@@ -727,6 +767,7 @@ public class OverlayService : IDisposable
     private void ApplySpiralOpacityDirect(double opacity)
     {
         var scaled = opacity * 0.1; // 90% reduction, matching CreateSpiralGifWindow / UpdateSpiralOpacity
+        _spiralLayer?.SetOpacity(scaled);
         foreach (var image in _spiralGifImages) image.Opacity = scaled;
         foreach (var media in _spiralMediaElements) media.Opacity = scaled;
         _lastAppliedSpiralOpacity = -1;
@@ -734,7 +775,13 @@ public class OverlayService : IDisposable
 
     private void ShowPinkFilterAdHoc(int opacityPercent)
     {
-        if (_pinkFilterWindows.Count > 0) return;
+        if (PinkShowing) return;
+        if (UseCompositor)
+        {
+            var (fr, fg, fb) = GetFilterRgb();
+            GetPinkLayer().Show(fr, fg, fb, opacityPercent / 100.0);
+            return;
+        }
         try
         {
             var settings = App.Settings?.Current;
@@ -759,7 +806,7 @@ public class OverlayService : IDisposable
         // Spiral has heavier setup (GIF/video branching, frame timer); reuse the
         // existing path. If settings have no spiral path configured, this is a
         // no-op — Deeper logs at the dispatcher.
-        if (_spiralWindows.Count > 0) return;
+        if (SpiralShowing) return;
         try
         {
             var spiralPath = GetSpiralPath();
@@ -779,7 +826,17 @@ public class OverlayService : IDisposable
 
     private void StartPinkFilter()
     {
-        if (_pinkFilterWindows.Count > 0) return;
+        if (PinkShowing) return;
+
+        if (UseCompositor)
+        {
+            var s = App.Settings.Current;
+            var (fr, fg, fb) = GetFilterRgb();
+            GetPinkLayer().Show(fr, fg, fb, s.PinkFilterOpacity / 100.0);
+            _lastAppliedPinkOpacity = s.PinkFilterOpacity / 100.0;
+            App.Logger?.Debug("Pink filter started on compositor layer at opacity {Opacity}%", s.PinkFilterOpacity);
+            return;
+        }
 
         try
         {
@@ -874,6 +931,7 @@ public class OverlayService : IDisposable
 
     internal void StopPinkFilter()
     {
+        _pinkLayer?.Hide(); // both paths cleared unconditionally - the flag may have flipped mid-run
         foreach (var window in _pinkFilterWindows.ToList())
         {
             try { window.Close(); }
@@ -896,6 +954,11 @@ public class OverlayService : IDisposable
         if (actualOpacity == _lastAppliedPinkOpacity) return;
         _lastAppliedPinkOpacity = actualOpacity;
         var (fr, fg, fb) = GetFilterRgb();
+        if (_pinkLayer?.IsActive == true)
+        {
+            _pinkLayer.Set(fr, fg, fb, actualOpacity);
+            return;
+        }
         foreach (var window in _pinkFilterWindows)
         {
             if (window.Content is Border border)
@@ -914,7 +977,19 @@ public class OverlayService : IDisposable
 
     private void StartSpiral()
     {
-        if (_spiralWindows.Count > 0) return;
+        if (SpiralShowing) return;
+
+        _isGifSpiral = _spiralPath.EndsWith(".gif", StringComparison.OrdinalIgnoreCase);
+
+        // Compositor route covers the GIF/animated path only; video spirals (MediaElement)
+        // have no layer frame source yet and always use the legacy windows.
+        if (UseCompositor && _isGifSpiral)
+        {
+            GetSpiralLayer().Show(_spiralPath, (App.Settings.Current.SpiralOpacity / 100.0) * 0.1);
+            _lastAppliedSpiralOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
+            App.Logger?.Debug("Spiral started on compositor layer ({Path})", _spiralPath);
+            return;
+        }
 
         try
         {
@@ -923,8 +998,6 @@ public class OverlayService : IDisposable
             var screens = settings.DualMonitorEnabled
                 ? App.GetAllScreensCached()
                 : new[] { System.Windows.Forms.Screen.PrimaryScreen! };
-
-            _isGifSpiral = _spiralPath.EndsWith(".gif", StringComparison.OrdinalIgnoreCase);
 
             // For GIFs, load frames once and share across all screens
             if (_isGifSpiral)
@@ -1375,6 +1448,7 @@ public class OverlayService : IDisposable
 
     internal void StopSpiral()
     {
+        _spiralLayer?.Hide(); // both paths cleared unconditionally - the flag may have flipped mid-run
         _gifFrameTimer?.Stop();
         _gifFrameTimer = null;
 
@@ -1423,6 +1497,12 @@ public class OverlayService : IDisposable
         var opacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
         if (opacity == _lastAppliedSpiralOpacity) return;
         _lastAppliedSpiralOpacity = opacity;
+
+        if (_spiralLayer?.IsActive == true)
+        {
+            _spiralLayer.SetOpacity(opacity);
+            return;
+        }
 
         // Update GIF images
         foreach (var image in _spiralGifImages)

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -92,7 +92,13 @@ public class OverlayService : IDisposable
     }
     // "Is showing" checks must cover BOTH render paths - the 500ms sync and pulse gate on these.
     private bool PinkShowing => _pinkFilterWindows.Count > 0 || _pinkLayer?.IsActive == true;
-    private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true;
+    private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true
+        || _spiralLayerDecodePending != null;
+    // Off-thread spiral decode state for the layer route: the path being decoded right now
+    // (also counts as "showing" so the 500ms sync doesn't re-enter), and the last path that
+    // produced zero frames (routed to the legacy windows instead of retrying forever).
+    private string? _spiralLayerDecodePending;
+    private string? _spiralLayerFailedPath;
 
     private int _consecutiveTopmostLossCount;
     // Recreate-overlays backoff. Destroying + recreating every layered overlay window on a 3s cadence
@@ -983,20 +989,58 @@ public class OverlayService : IDisposable
 
         // Compositor route covers the GIF/animated path only; video spirals (MediaElement)
         // have no layer frame source yet and always use the legacy windows. Frames come from
-        // the LEGACY loader + cache so asset support (pack:// resources, file:// mod overrides,
+        // the LEGACY decoder + cache so asset support (pack:// resources, file:// mod overrides,
         // user paths) is identical to the legacy windows by construction.
-        if (UseCompositor && _isGifSpiral)
+        if (UseCompositor && _isGifSpiral && _spiralPath != _spiralLayerFailedPath)
         {
-            if (LoadSpiralGifFrames())
+            var finalOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
+
+            // Cache hit: show immediately (frames are frozen, shared with the legacy cache).
+            if (_spiralFramesCacheKey == _spiralPath && _spiralFramesCache.Count > 0)
             {
-                GetSpiralLayer().ShowFrames(_spiralGifFrames, _gifFrameDelay,
-                    (App.Settings.Current.SpiralOpacity / 100.0) * 0.1);
-                _lastAppliedSpiralOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
-                App.Logger?.Debug("Spiral started on compositor layer ({Path})", _spiralPath);
+                GetSpiralLayer().ShowFrames(_spiralFramesCache, _spiralFramesCacheDelay, finalOpacity);
+                _lastAppliedSpiralOpacity = finalOpacity;
+                App.Logger?.Debug("Spiral started on compositor layer ({Path}, cached)", _spiralPath);
                 return;
             }
-            App.Logger?.Warning("Spiral: layer frame load failed for {Path}; using legacy path", _spiralPath);
-            // fall through to the legacy windows below
+
+            // Cache miss: decode OFF the UI thread. The legacy path decodes synchronously and
+            // hitches the whole UI ~1s - felt as a lag spike exactly when a spiral-payload
+            // bubble pops. SpiralShowing counts the pending decode so the sync doesn't re-enter.
+            if (_spiralLayerDecodePending != null) return;
+            var path = _spiralPath;
+            _spiralLayerDecodePending = path;
+            Task.Run(() =>
+            {
+                var (frames, delay) = DecodeGifFrames(path);
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                dispatcher.BeginInvoke(() =>
+                {
+                    _spiralLayerDecodePending = null;
+                    if (frames.Count == 0)
+                    {
+                        // Next StartSpiral routes this path to the legacy windows (no retry churn).
+                        _spiralLayerFailedPath = path;
+                        App.Logger?.Warning("Spiral: layer decode produced no frames for {Path}; legacy path will be used", path);
+                        return;
+                    }
+                    _spiralFramesCache = frames;
+                    _spiralFramesCacheKey = path;
+                    _spiralFramesCacheDelay = delay;
+                    // The user may have turned the spiral off (or swapped assets) mid-decode.
+                    var s = App.Settings.Current;
+                    bool stillWanted = _spiralPath == path
+                        && (s.SpiralEnabled || _timedSpiralHolds > 0 || _sustainedSpiralHeld);
+                    if (stillWanted && UseCompositor)
+                    {
+                        GetSpiralLayer().ShowFrames(frames, delay, (s.SpiralOpacity / 100.0) * 0.1);
+                        _lastAppliedSpiralOpacity = (s.SpiralOpacity / 100.0) * 0.1;
+                        App.Logger?.Debug("Spiral started on compositor layer ({Path}, decoded off-thread)", path);
+                    }
+                });
+            });
+            return;
         }
 
         try

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -330,16 +330,34 @@ public class OverlayService : IDisposable
                 }
             }
 
-            // Restore after 1 second
+            // Restore after 1 second. When a session/Deeper ramp owns an overlay's opacity,
+            // Update*Opacity() deliberately early-returns (it must not fight the live ramp) — so
+            // routing the restore through it left the overlay stuck at the *boosted* value, up to
+            // fully opaque, recoverable only by toggling the overlay off/on (#535). Restore to the
+            // ramp's own value when a ramp is active; otherwise fall back to the user's settings.
             Task.Delay(1000).ContinueWith(_ =>
             {
                 try
                 {
                     DispatcherHelper.RunOnUISync(() =>
                     {
-                        if (hasPink) UpdatePinkFilterOpacity();
-                        if (hasSpiral) UpdateSpiralOpacity();
-                        if (hasBrainDrain) UpdateBrainDrainBlurOpacity(_currentBrainDrainIntensity);
+                        if (hasPink)
+                        {
+                            if (_rampPinkOpacity.HasValue) ApplyPinkOpacityDirect(_rampPinkOpacity.Value);
+                            else UpdatePinkFilterOpacity();
+                        }
+                        if (hasSpiral)
+                        {
+                            if (_rampSpiralOpacity.HasValue) ApplySpiralOpacityDirect(_rampSpiralOpacity.Value);
+                            else UpdateSpiralOpacity();
+                        }
+                        if (hasBrainDrain)
+                        {
+                            if (_rampBrainDrainOpacity.HasValue)
+                                UpdateBrainDrainBlurOpacity(Math.Max(1, (int)Math.Round(_rampBrainDrainOpacity.Value * 100)));
+                            else
+                                UpdateBrainDrainBlurOpacity(_currentBrainDrainIntensity);
+                        }
                     });
                 }
                 catch { /* Window may have closed */ }

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -62,6 +62,17 @@ public class OverlayService : IDisposable
     private double? _rampSpiralOpacity;
     private double? _rampBrainDrainOpacity;
 
+    // #573: a timed overlay fired while the overlay is ALREADY showing (pink/spiral bubble pop
+    // during a base overlay or Deeper band) used to be swallowed whole by the ad-hoc shows'
+    // early-return. Instead we park a temporary intensity bump in _rampXOpacity (so the 500ms
+    // settings-sync can't stomp it) and restore the previous owner when the last timed hold
+    // releases. _bumpPrevRampX remembers what was parked before the first bump (a band's hold,
+    // or null = settings-sync owns it).
+    private bool _bumpPinkActive;
+    private double? _bumpPrevRampPink;
+    private bool _bumpSpiralActive;
+    private double? _bumpPrevRampSpiral;
+
     // Unified overlay host (Settings.UnifiedOverlayHost, experimental): pink/spiral render as
     // compositor layers on the shared per-monitor Skia host instead of per-effect layered
     // windows. This service keeps ALL the opacity math (ramps, pulses, holds, settings sync)
@@ -70,8 +81,7 @@ public class OverlayService : IDisposable
     // rather than the flag so a mid-run flag flip can't strand a visible layer.
     private Compositor.PinkTintLayer? _pinkLayer;
     private Compositor.SpiralLayer? _spiralLayer;
-    private static bool UseCompositor =>
-        (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+    private static bool UseCompositor => App.CompositorEnabled;
     private Compositor.PinkTintLayer GetPinkLayer()
     {
         if (_pinkLayer == null)
@@ -590,9 +600,37 @@ public class OverlayService : IDisposable
             try
             {
                 // Mark the timed overlay in-flight so the reconcile loops leave it alone.
-                if (kind == "pink_filter") _timedPinkHolds++;
-                else if (kind == "spiral") _timedSpiralHolds++;
-                show();
+                if (kind == "pink_filter")
+                {
+                    _timedPinkHolds++;
+                    if (PinkShowing)
+                    {
+                        // #573: show() would early-return on an already-showing overlay, silently
+                        // swallowing the boost. Bump the live opacity instead (never downward) and
+                        // park it in the ramp hold so the settings-sync can't stomp it; the hide
+                        // timer restores the previous owner.
+                        if (!_bumpPinkActive) { _bumpPinkActive = true; _bumpPrevRampPink = _rampPinkOpacity; }
+                        double current = _rampPinkOpacity ?? (App.Settings?.Current?.PinkFilterOpacity ?? 0) / 100.0;
+                        double target = Math.Max(current, opacityPercent / 100.0);
+                        _rampPinkOpacity = target;
+                        ApplyPinkOpacityDirect(target);
+                    }
+                    else show();
+                }
+                else if (kind == "spiral")
+                {
+                    _timedSpiralHolds++;
+                    if (SpiralShowing)
+                    {
+                        if (!_bumpSpiralActive) { _bumpSpiralActive = true; _bumpPrevRampSpiral = _rampSpiralOpacity; }
+                        double current = _rampSpiralOpacity ?? (App.Settings?.Current?.SpiralOpacity ?? 0) / 100.0;
+                        double target = Math.Max(current, opacityPercent / 100.0);
+                        _rampSpiralOpacity = target;
+                        ApplySpiralOpacityDirect(target);
+                    }
+                    else show();
+                }
+                else show();
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlayTimed show: {E}", ex.Message); }
         };
@@ -614,12 +652,44 @@ public class OverlayService : IDisposable
                 if (kind == "pink_filter")
                 {
                     if (_timedPinkHolds > 0) _timedPinkHolds--;
-                    if (_timedPinkHolds == 0 && !settings.PinkFilterEnabled) hide();
+                    if (_timedPinkHolds == 0)
+                    {
+                        // Undo any #573 intensity bump: hand opacity back to the previous owner (a
+                        // band's parked hold, or the settings-sync). Only touch the ramp hold while
+                        // the overlay is still up — a Stop/panic in between already cleared the
+                        // holds, and re-parking a stale value would freeze a future overlay (#563).
+                        if (_bumpPinkActive)
+                        {
+                            _bumpPinkActive = false;
+                            if (PinkShowing)
+                            {
+                                _rampPinkOpacity = _bumpPrevRampPink;
+                                if (_rampPinkOpacity is double prevPink) ApplyPinkOpacityDirect(prevPink);
+                                else _lastAppliedPinkOpacity = -1; // settings-sync re-applies next tick
+                            }
+                            _bumpPrevRampPink = null;
+                        }
+                        if (!settings.PinkFilterEnabled) hide();
+                    }
                 }
                 else if (kind == "spiral")
                 {
                     if (_timedSpiralHolds > 0) _timedSpiralHolds--;
-                    if (_timedSpiralHolds == 0 && !settings.SpiralEnabled) hide();
+                    if (_timedSpiralHolds == 0)
+                    {
+                        if (_bumpSpiralActive)
+                        {
+                            _bumpSpiralActive = false;
+                            if (SpiralShowing)
+                            {
+                                _rampSpiralOpacity = _bumpPrevRampSpiral;
+                                if (_rampSpiralOpacity is double prevSpiral) ApplySpiralOpacityDirect(prevSpiral);
+                                else _lastAppliedSpiralOpacity = -1; // settings-sync re-applies next tick
+                            }
+                            _bumpPrevRampSpiral = null;
+                        }
+                        if (!settings.SpiralEnabled) hide();
+                    }
                 }
                 else // braindrain: don't tear down the user's base Brain Drain when a timed effect ends
                 {
@@ -1287,15 +1357,35 @@ public class OverlayService : IDisposable
 
                 delay = TimeSpan.FromMilliseconds(frameDelayMs);
 
-                var maxFrames = Math.Min(frameCount, 120);
+                // Downscale + budget the frame cache (#572 "3.5 GB / laggy" report): frames were
+                // decoded at the GIF's native size with no cap — a fullscreen-sized custom spiral
+                // (SpiralPath) at 120 Bgra32 frames retains ~1 GB. The spiral is stretched over
+                // the whole screen at low opacity, so capping the long side loses nothing
+                // visually, and the byte budget bounds the worst case regardless of dimensions.
+                const int maxDimension = 1280;
+                const long maxCacheBytes = 300L * 1024 * 1024;
+
+                double frameScale = Math.Min(1.0, (double)maxDimension / Math.Max(gif.Width, gif.Height));
+                int frameW = Math.Max(1, (int)Math.Round(gif.Width * frameScale));
+                int frameH = Math.Max(1, (int)Math.Round(gif.Height * frameScale));
+                long bytesPerFrame = (long)frameW * frameH * 4;
+
+                var maxFrames = (int)Math.Min(Math.Min(frameCount, 120),
+                    Math.Max(8, maxCacheBytes / Math.Max(1, bytesPerFrame)));
                 var step = frameCount > maxFrames ? frameCount / maxFrames : 1;
+                if (maxFrames < Math.Min(frameCount, 120))
+                    App.Logger?.Warning("Spiral: frame cache capped at {Frames} frames ({W}x{H}) to stay under {MB} MB — a smaller spiral GIF will loop smoother",
+                        maxFrames, frameW, frameH, maxCacheBytes / (1024 * 1024));
 
                 for (int i = 0; i < frameCount && frames.Count < maxFrames; i += step)
                 {
                     gif.SelectActiveFrame(dimension, i);
-                    using var frameBitmap = new System.Drawing.Bitmap(gif.Width, gif.Height);
+                    using var frameBitmap = new System.Drawing.Bitmap(frameW, frameH);
                     using (var g = System.Drawing.Graphics.FromImage(frameBitmap))
-                        g.DrawImage(gif, 0, 0, gif.Width, gif.Height);
+                    {
+                        g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBilinear;
+                        g.DrawImage(gif, 0, 0, frameW, frameH);
+                    }
 
                     var bitmapSource = ConvertToBitmapSource(frameBitmap);
                     bitmapSource.Freeze();
@@ -2144,27 +2234,48 @@ public class OverlayService : IDisposable
             {
                 var hwnd = new System.Windows.Interop.WindowInteropHelper(window).Handle;
                 if (hwnd == IntPtr.Zero) continue;
-
-                int exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
-                bool needsPin = (exStyle & WS_EX_TOPMOST) == 0;
-
-                if (videoHwnd != IntPtr.Zero && hwnd != videoHwnd)
-                {
-                    // Insert directly below the active video window: stays topmost (above the
-                    // desktop and other apps) but under the video the user is meant to watch.
-                    SetWindowPos(hwnd, videoHwnd, 0, 0, 0, 0,
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-                    if (needsPin) anyRecovered = true;
-                }
-                else if (needsPin || force)
-                {
-                    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
-                        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-                    if (needsPin) anyRecovered = true;
-                }
+                ReassertOne(hwnd, videoHwnd, force, ref anyRecovered);
             }
         }
+
+        // Compositor hosts carry the SAME fullscreen effects when the unified renderer is on,
+        // but only assert HWND_TOPMOST on their show/topology edges — reconcile them exactly
+        // like the legacy windows or a later topmost raise (chaos chrome ~1/s, a mandatory
+        // video) buries every layer; worse, a host re-shown mid-video pins itself above the
+        // deliberately non-re-raising video window (#497's shape all over again).
+        try
+        {
+            if (App.Compositor is { } engine)
+                foreach (var hostHwnd in engine.GetVisibleHostHandles())
+                    ReassertOne(hostHwnd, videoHwnd, force, ref anyRecovered);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ReassertZOrder (compositor hosts) failed: {Error}", ex.Message);
+        }
         return anyRecovered;
+    }
+
+    /// <summary>One window's worth of ReassertZOrder: below the active video, else topmost.</summary>
+    private static void ReassertOne(IntPtr hwnd, IntPtr videoHwnd, bool force, ref bool anyRecovered)
+    {
+        int exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
+        bool needsPin = (exStyle & WS_EX_TOPMOST) == 0;
+
+        if (videoHwnd != IntPtr.Zero && hwnd != videoHwnd)
+        {
+            // Insert directly below the active video window: stays topmost (above the
+            // desktop and other apps) but under the video the user is meant to watch.
+            SetWindowPos(hwnd, videoHwnd, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            if (needsPin) anyRecovered = true;
+        }
+        else if (needsPin || force)
+        {
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+            if (needsPin) anyRecovered = true;
+        }
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -90,8 +90,19 @@ public class OverlayService : IDisposable
         }
         return _spiralLayer;
     }
+    private Compositor.BrainDrainLayer? _brainDrainLayer;
+    private Compositor.BrainDrainLayer GetBrainDrainLayer()
+    {
+        if (_brainDrainLayer == null)
+        {
+            _brainDrainLayer = new Compositor.BrainDrainLayer(App.Compositor!);
+            App.Compositor!.RegisterLayer(_brainDrainLayer);
+        }
+        return _brainDrainLayer;
+    }
     // "Is showing" checks must cover BOTH render paths - the 500ms sync and pulse gate on these.
     private bool PinkShowing => _pinkFilterWindows.Count > 0 || _pinkLayer?.IsActive == true;
+    private bool BrainDrainShowing => _brainDrainBlurWindows.Count > 0 || _brainDrainLayer?.IsActive == true;
     private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true
         || _spiralLayerDecodePending != null;
     // Off-thread spiral decode state for the layer route: the path being decoded right now
@@ -312,7 +323,7 @@ public class OverlayService : IDisposable
         });
 
         App.Logger?.Debug("Overlays refreshed - Pink: {Pink}, Spiral: {Spiral}, BrainDrain: {BrainDrain}",
-            PinkShowing, SpiralShowing, _brainDrainBlurWindows.Count > 0);
+            PinkShowing, SpiralShowing, BrainDrainShowing);
     }
 
     /// <summary>
@@ -327,7 +338,7 @@ public class OverlayService : IDisposable
             var settings = App.Settings.Current;
             var hasPink = settings.PinkFilterEnabled && PinkShowing;
             var hasSpiral = settings.SpiralEnabled && SpiralShowing;
-            var hasBrainDrain = settings.BrainDrainEnabled && _brainDrainBlurWindows.Count > 0;
+            var hasBrainDrain = settings.BrainDrainEnabled && BrainDrainShowing;
 
             if (!hasPink && !hasSpiral && !hasBrainDrain) return;
 
@@ -367,6 +378,8 @@ public class OverlayService : IDisposable
             {
                 var boostedIntensity = Math.Min(_currentBrainDrainIntensity * 2, 200);
                 double blurRadius = boostedIntensity * 0.4;
+                if (_brainDrainLayer?.IsActive == true)
+                    _brainDrainLayer.Pulse(boostedIntensity);
                 foreach (var img in _brainDrainImages.Values)
                 {
                     if (img.Effect is System.Windows.Media.Effects.BlurEffect blur)
@@ -1596,7 +1609,7 @@ public class OverlayService : IDisposable
 
     public void StartBrainDrainBlur(int intensity)
     {
-        if (_brainDrainBlurWindows.Count > 0) return;
+        if (BrainDrainShowing) return;
 
         _currentBrainDrainIntensity = intensity;
 
@@ -1604,6 +1617,15 @@ public class OverlayService : IDisposable
         {
             try
             {
+                if (UseCompositor)
+                {
+                    // Compositor route: capture + blur render on the shared capture-excluded
+                    // host; no per-screen layered windows, no WPF BlurEffect rasterization.
+                    GetBrainDrainLayer().Start(intensity);
+                    App.Logger?.Information("Brain Drain started on compositor layer, intensity {Intensity}%", intensity);
+                    return;
+                }
+
                 var settings = App.Settings.Current;
                 var screens = settings.DualMonitorEnabled
                     ? App.GetAllScreensCached()
@@ -1652,6 +1674,13 @@ public class OverlayService : IDisposable
         try
         {
             _rampBrainDrainOpacity = null; // release any Deeper ramp ownership
+
+            // Layer route (checked by activity, not the flag - mid-run flag flips must not strand it).
+            if (_brainDrainLayer?.IsActive == true)
+            {
+                DispatcherHelper.RunOnUISync(() => _brainDrainLayer.Stop());
+            }
+
             _brainDrainCaptureTimer?.Stop();
             _brainDrainCaptureTimer = null;
 
@@ -1690,6 +1719,10 @@ public class OverlayService : IDisposable
 
         DispatcherHelper.RunOnUISync(() =>
         {
+            if (_brainDrainLayer?.IsActive == true)
+            {
+                _brainDrainLayer.SetIntensity(intensity);
+            }
             foreach (var img in _brainDrainImages.Values)
             {
                 if (img.Effect is System.Windows.Media.Effects.BlurEffect blur)
@@ -2470,7 +2503,7 @@ public class OverlayService : IDisposable
 
         if (settings.BrainDrainEnabled && settings.IsLevelUnlocked(70)) // Level 70 requirement for Brain Drain
         {
-            if (_brainDrainBlurWindows.Count == 0)
+            if (!BrainDrainShowing)
             {
                 StartBrainDrainBlur((int)settings.BrainDrainIntensity);
             }
@@ -2507,6 +2540,7 @@ public class OverlayService : IDisposable
         _gifLoopTimer = null;
         _brainDrainImages.Clear();
         CleanupCaptureResources();
+        try { _brainDrainLayer?.Stop(); } catch { /* shutdown path - GDI freed by OS anyway */ }
 
         // Unsubscribe from settings changes
         if (App.Settings?.Current != null)

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -93,9 +93,6 @@ public class OverlayService : IDisposable
     // "Is showing" checks must cover BOTH render paths - the 500ms sync and pulse gate on these.
     private bool PinkShowing => _pinkFilterWindows.Count > 0 || _pinkLayer?.IsActive == true;
     private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true;
-    // Path the spiral LAYER failed to decode (exotic GIF SKCodec rejects): the next StartSpiral
-    // for the same path skips the layer and uses the legacy windows instead of retrying forever.
-    private string? _spiralLayerFailedPath;
 
     private int _consecutiveTopmostLossCount;
     // Recreate-overlays backoff. Destroying + recreating every layered overlay window on a 3s cadence
@@ -985,20 +982,21 @@ public class OverlayService : IDisposable
         _isGifSpiral = _spiralPath.EndsWith(".gif", StringComparison.OrdinalIgnoreCase);
 
         // Compositor route covers the GIF/animated path only; video spirals (MediaElement)
-        // have no layer frame source yet and always use the legacy windows.
-        if (UseCompositor && _isGifSpiral && _spiralPath != _spiralLayerFailedPath)
+        // have no layer frame source yet and always use the legacy windows. Frames come from
+        // the LEGACY loader + cache so asset support (pack:// resources, file:// mod overrides,
+        // user paths) is identical to the legacy windows by construction.
+        if (UseCompositor && _isGifSpiral)
         {
-            var failedPath = _spiralPath;
-            GetSpiralLayer().Show(_spiralPath, (App.Settings.Current.SpiralOpacity / 100.0) * 0.1,
-                onFailed: () =>
-                {
-                    // Remember the bad path; the 500ms sync re-enters StartSpiral, which now
-                    // routes this path to the legacy windows (self-healing, no retry churn).
-                    _spiralLayerFailedPath = failedPath;
-                });
-            _lastAppliedSpiralOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
-            App.Logger?.Debug("Spiral started on compositor layer ({Path})", _spiralPath);
-            return;
+            if (LoadSpiralGifFrames())
+            {
+                GetSpiralLayer().ShowFrames(_spiralGifFrames, _gifFrameDelay,
+                    (App.Settings.Current.SpiralOpacity / 100.0) * 0.1);
+                _lastAppliedSpiralOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
+                App.Logger?.Debug("Spiral started on compositor layer ({Path})", _spiralPath);
+                return;
+            }
+            App.Logger?.Warning("Spiral: layer frame load failed for {Path}; using legacy path", _spiralPath);
+            // fall through to the legacy windows below
         }
 
         try
@@ -1171,6 +1169,14 @@ public class OverlayService : IDisposable
         {
             Stream? gifStream = null;
             bool needsDispose = false;
+
+            // ModResourceResolver.ResolveUri returns file:// URIs for mod-override assets;
+            // File.Exists() on the raw URI string is always false, so unwrap to a local path.
+            if (path.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+            {
+                try { path = new Uri(path).LocalPath; }
+                catch (Exception ex) { App.Logger?.Debug("Spiral: bad file:// URI {Path}: {E}", path, ex.Message); }
+            }
 
             if (path.StartsWith("pack://", StringComparison.OrdinalIgnoreCase))
             {

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -93,6 +93,9 @@ public class OverlayService : IDisposable
     // "Is showing" checks must cover BOTH render paths - the 500ms sync and pulse gate on these.
     private bool PinkShowing => _pinkFilterWindows.Count > 0 || _pinkLayer?.IsActive == true;
     private bool SpiralShowing => _spiralWindows.Count > 0 || _spiralLayer?.IsShowing == true;
+    // Path the spiral LAYER failed to decode (exotic GIF SKCodec rejects): the next StartSpiral
+    // for the same path skips the layer and uses the legacy windows instead of retrying forever.
+    private string? _spiralLayerFailedPath;
 
     private int _consecutiveTopmostLossCount;
     // Recreate-overlays backoff. Destroying + recreating every layered overlay window on a 3s cadence
@@ -983,9 +986,16 @@ public class OverlayService : IDisposable
 
         // Compositor route covers the GIF/animated path only; video spirals (MediaElement)
         // have no layer frame source yet and always use the legacy windows.
-        if (UseCompositor && _isGifSpiral)
+        if (UseCompositor && _isGifSpiral && _spiralPath != _spiralLayerFailedPath)
         {
-            GetSpiralLayer().Show(_spiralPath, (App.Settings.Current.SpiralOpacity / 100.0) * 0.1);
+            var failedPath = _spiralPath;
+            GetSpiralLayer().Show(_spiralPath, (App.Settings.Current.SpiralOpacity / 100.0) * 0.1,
+                onFailed: () =>
+                {
+                    // Remember the bad path; the 500ms sync re-enters StartSpiral, which now
+                    // routes this path to the legacy windows (self-healing, no retry churn).
+                    _spiralLayerFailedPath = failedPath;
+                });
             _lastAppliedSpiralOpacity = (App.Settings.Current.SpiralOpacity / 100.0) * 0.1;
             App.Logger?.Debug("Spiral started on compositor layer ({Path})", _spiralPath);
             return;

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -621,9 +621,9 @@ public class OverlayService : IDisposable
                     if (_timedSpiralHolds > 0) _timedSpiralHolds--;
                     if (_timedSpiralHolds == 0 && !settings.SpiralEnabled) hide();
                 }
-                else
+                else // braindrain: don't tear down the user's base Brain Drain when a timed effect ends
                 {
-                    hide();
+                    if (!settings.BrainDrainEnabled) hide();
                 }
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlayTimed hide: {E}", ex.Message); }
@@ -670,8 +670,13 @@ public class OverlayService : IDisposable
                 // Both show() and the reconcilers run on this one UI thread, so they can't interleave;
                 // gate on a window actually appearing so a no-op show (e.g. spiral with no asset) doesn't
                 // leave a stale hold that would later block a legitimate teardown.
-                if (kind == "pink_filter") _sustainedPinkHeld = PinkShowing;
-                else if (kind == "spiral") _sustainedSpiralHeld = SpiralShowing;
+                // Park the ramp-ownership hold at the band's opacity so the 500ms settings-sync
+                // (UpdatePinkFilterOpacity/UpdateSpiralOpacity) early-returns and won't stomp a
+                // constant-opacity Deeper band back to the user's saved opacity within half a second
+                // (#563 symptom-1). Ramp bands overwrite this each Update tick; HideOverlaySustained
+                // clears it on band exit, so the lifecycle stays symmetric.
+                if (kind == "pink_filter") { _sustainedPinkHeld = PinkShowing; if (PinkShowing) _rampPinkOpacity = opacity; }
+                else if (kind == "spiral") { _sustainedSpiralHeld = SpiralShowing; if (SpiralShowing) _rampSpiralOpacity = opacity; }
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlaySustained show: {E}", ex.Message); }
         };
@@ -693,9 +698,19 @@ public class OverlayService : IDisposable
         var settings = App.Settings.Current;
         Action? hide = kind switch
         {
-            "pink_filter" => () => { _sustainedPinkHeld = false; if (_timedPinkHolds == 0 && !settings.PinkFilterEnabled) StopPinkFilter(); },
-            "spiral"      => () => { _sustainedSpiralHeld = false; if (_timedSpiralHolds == 0 && !settings.SpiralEnabled) StopSpiral(); },
-            "braindrain"  => () => StopBrainDrainBlur(),
+            // Release any Deeper opacity-ramp hold on band exit BEFORE the conditional teardown.
+            // A ramp (SetSustainedOverlayOpacity) parks _rampXOpacity, which makes the 500ms
+            // settings-sync early-return so it won't fight the ramp. If the base overlay feature
+            // is enabled we don't StopPinkFilter/StopSpiral here — so without clearing the hold
+            // the overlay stayed frozen at the ramp's final opacity forever (#563). Clearing it
+            // returns ownership to the reconciler, which re-applies the user's saved opacity next
+            // tick (base-on) or the overlay is torn down (base-off).
+            "pink_filter" => () => { _sustainedPinkHeld = false; _rampPinkOpacity = null; _lastAppliedPinkOpacity = -1; if (_timedPinkHolds == 0 && !settings.PinkFilterEnabled) StopPinkFilter(); },
+            "spiral"      => () => { _sustainedSpiralHeld = false; _rampSpiralOpacity = null; _lastAppliedSpiralOpacity = -1; if (_timedSpiralHolds == 0 && !settings.SpiralEnabled) StopSpiral(); },
+            // Guard braindrain the same way as pink/spiral: a Deeper band exit must not tear down
+            // the user's base Brain Drain feature. Clear ramp ownership, then only stop when the
+            // base feature is off (else RefreshBrainDrainState keeps it alive). (#563 consistency)
+            "braindrain"  => () => { _rampBrainDrainOpacity = null; if (!settings.BrainDrainEnabled) StopBrainDrainBlur(); },
             _ => null
         };
 

--- a/ConditioningControlPanel/Services/Settings/SettingsService.cs
+++ b/ConditioningControlPanel/Services/Settings/SettingsService.cs
@@ -174,10 +174,10 @@ namespace ConditioningControlPanel.Services
                         // existing users to the gentler default. One-shot.
                         settings.MigrateLoudnessThreshold();
 
-                        // #550: pull the compositor back off for 6.3.3 upgraders (it was briefly
-                        // default ON and persisted true; software SKElement on the UI thread stalled
-                        // some machines). One-shot — re-enabling the toggle later sticks.
-                        settings.MigrateDisableUnifiedOverlayHost();
+                        // Compositor is the blessed render path now that #550 is fixed: re-enable
+                        // it once for users the 6.3.4 hotfix force-migrated off (persisted false).
+                        // One-shot — turning the toggle off later sticks.
+                        settings.MigrateEnableUnifiedOverlayHost();
 
                         return settings;
                     }
@@ -248,7 +248,7 @@ namespace ConditioningControlPanel.Services
                     MergeBuiltInAwarenessPresets(settings);
                     settings.MigrateFromContentModeToMod();
                     settings.MigrateLoudnessThreshold();
-                    settings.MigrateDisableUnifiedOverlayHost();
+                    settings.MigrateEnableUnifiedOverlayHost();
 
                     App.Logger?.Warning("Settings RESTORED from daily backup {Backup} (main file was unparseable)", bakPath);
                     return settings;

--- a/ConditioningControlPanel/Services/Settings/SettingsService.cs
+++ b/ConditioningControlPanel/Services/Settings/SettingsService.cs
@@ -174,6 +174,11 @@ namespace ConditioningControlPanel.Services
                         // existing users to the gentler default. One-shot.
                         settings.MigrateLoudnessThreshold();
 
+                        // #550: pull the compositor back off for 6.3.3 upgraders (it was briefly
+                        // default ON and persisted true; software SKElement on the UI thread stalled
+                        // some machines). One-shot — re-enabling the toggle later sticks.
+                        settings.MigrateDisableUnifiedOverlayHost();
+
                         return settings;
                     }
                 }
@@ -243,6 +248,7 @@ namespace ConditioningControlPanel.Services
                     MergeBuiltInAwarenessPresets(settings);
                     settings.MigrateFromContentModeToMod();
                     settings.MigrateLoudnessThreshold();
+                    settings.MigrateDisableUnifiedOverlayHost();
 
                     App.Logger?.Warning("Settings RESTORED from daily backup {Backup} (main file was unparseable)", bakPath);
                     return settings;

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -46,6 +46,12 @@ namespace ConditioningControlPanel.Services
             public double Scale = 1.0;            // physical px per card-local DIP
         }
         private readonly List<HostedCard> _hostedCards = new();
+        // COMPOSITOR (unified overlay host): when the flag is on, cards render as a layer on
+        // the shared per-monitor Skia host - no per-screen window OR host canvas churn at all.
+        // Focus-steal still falls back to the classic windows (the host is NOACTIVATE).
+        private Compositor.SubliminalLayer? _layer;
+        private static bool UseCompositor =>
+            (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
         // One ref-counted hold on the shared host while any card could be up — NOT per show
         // (host churn is exactly what solid mode exists to remove). Released on Stop/Dispose,
         // or when a one-shot's card fades out with the service not running.
@@ -120,6 +126,11 @@ namespace ConditioningControlPanel.Services
             // (removing canvas children is safe mid-run — only window churn deadlocks).
             RemoveHostedCard(_ => true);
             ReleaseHostRef();
+
+            // Compositor: drop any live layer card (activity-check, not the flag — a mid-run
+            // flag flip must not strand a fading card on the shared host).
+            if (_layer?.IsActive == true)
+                _layer.Clear();
 
             StopAudio();
 
@@ -616,6 +627,18 @@ namespace ConditioningControlPanel.Services
                 : new[] { System.Windows.Forms.Screen.PrimaryScreen! };
             var stealsFocus = App.Settings.Current.SubliminalStealsFocus;
 
+            // Compositor: one layer call covers every target screen (solid-mode and classic
+            // rendering both collapse into the layer - bgTransparent handles the difference).
+            // Focus-steal can't come from a NOACTIVATE host, so it stays on the classic windows;
+            // a layer failure falls through to the legacy paths so a flash is never lost.
+            if (UseCompositor && !stealsFocus &&
+                ShowCompositorSubliminal(screens, text, bgColor, textColor, borderColor,
+                    bgTransparent, targetOpacity, durationMs))
+            {
+                App.InvalidateCcpWindowRectsCache();
+                return;
+            }
+
             // Solid mode can't steal focus (the shared host is NOACTIVATE by contract), so the
             // StealsFocus opt-in falls back to the classic per-screen windows.
             var useHost = App.Settings.Current.SubliminalSolidMode && !stealsFocus;
@@ -650,6 +673,48 @@ namespace ConditioningControlPanel.Services
         }
 
         private const int WS_EX_LAYERED = 0x00080000;
+
+        /// <summary>
+        /// COMPOSITOR: hand one fully resolved card (all screens at once) to the shared-host
+        /// subliminal layer. The service keeps ALL scheduling/state; the layer runs the 50ms
+        /// fade envelope itself on the engine tick. Returns false on any failure so the caller
+        /// renders classically instead - a subliminal must never be silently invisible.
+        /// </summary>
+        private bool ShowCompositorSubliminal(System.Windows.Forms.Screen?[] screens, string text,
+            Color bgColor, Color textColor, Color borderColor, bool bgTransparent,
+            double targetOpacity, int durationMs)
+        {
+            try
+            {
+                var placements = new List<Compositor.SubliminalLayer.Placement>(screens.Length);
+                foreach (var screen in screens)
+                {
+                    if (screen == null) continue;
+                    var scale = GetMonitorDpi(screen) / 96.0;
+                    var b = screen.Bounds;   // physical px
+                    placements.Add(new Compositor.SubliminalLayer.Placement(
+                        new SkiaSharp.SKRectI(b.X, b.Y, b.Right, b.Bottom), (float)scale));
+                }
+                if (placements.Count == 0) return false;
+
+                if (_layer == null)
+                {
+                    _layer = new Compositor.SubliminalLayer(App.Compositor!);
+                    App.Compositor!.RegisterLayer(_layer);
+                }
+                _layer.Flash(placements, text,
+                    new SkiaSharp.SKColor(bgColor.R, bgColor.G, bgColor.B),
+                    new SkiaSharp.SKColor(textColor.R, textColor.G, textColor.B),
+                    new SkiaSharp.SKColor(borderColor.R, borderColor.G, borderColor.B),
+                    bgTransparent, targetOpacity, durationMs);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Subliminal compositor flash failed, falling back: {E}", ex.Message);
+                return false;
+            }
+        }
 
         /// <summary>
         /// SOLID MODE (#461): render one subliminal card for <paramref name="screen"/> as a child
@@ -1073,6 +1138,11 @@ namespace ConditioningControlPanel.Services
                     if (right > left && bottom > top)
                         rects.Add(new System.Drawing.Rectangle(left, top, right - left, bottom - top));
                 }
+
+                // Compositor: the layer computes its own padded text rects (world px) from the
+                // metrics it measured at Flash time.
+                if (_layer?.IsActive == true)
+                    rects.AddRange(_layer.GetActiveTextRectsPx());
             }
             catch (Exception ex)
             {
@@ -1254,6 +1324,7 @@ namespace ConditioningControlPanel.Services
             _disposed = true;
 
             Stop();
+            try { _layer?.Clear(); } catch { }
             // App shutdown: the only place the keep-alive windows actually close.
             foreach (var win in _screenWindows.Values)
             {

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -50,8 +50,7 @@ namespace ConditioningControlPanel.Services
         // the shared per-monitor Skia host - no per-screen window OR host canvas churn at all.
         // Focus-steal still falls back to the classic windows (the host is NOACTIVATE).
         private Compositor.SubliminalLayer? _layer;
-        private static bool UseCompositor =>
-            (App.CompositorForced || App.Settings?.Current?.UnifiedOverlayHost == true) && App.Compositor != null;
+        private static bool UseCompositor => App.CompositorEnabled;
         // One ref-counted hold on the shared host while any card could be up — NOT per show
         // (host churn is exactly what solid mode exists to remove). Released on Stop/Dispose,
         // or when a one-shot's card fades out with the service not running.

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -200,8 +200,14 @@ public static class UiHangWatchdog
     // Every thread's stack + module list + handle data — enough to identify the
     // render-thread deadlocks these hangs are, at tens of MB instead of the 1-2GB
     // that MiniDumpWithPrivateReadWriteMemory produced.
+    // 2026-07-13: the previous set produced a dump WinDbg bucketed as bad_dump!missing_teb —
+    // top-of-stack frames only, no unwind (it still nailed the render thread inside
+    // CWGXBitmapLockState::LockRead, but not who held the write side). Indirectly-referenced
+    // memory + full memory info pulls in the pages the thread stacks point at, which is what
+    // stack unwinding actually needs; dumps land in the tens of MB, still far from full-RW.
     private const uint CompactDumpType = MiniDumpWithDataSegs | MiniDumpWithHandleData
-        | MiniDumpWithUnloadedModules | MiniDumpWithProcessThreadData | MiniDumpWithThreadInfo;
+        | MiniDumpWithUnloadedModules | MiniDumpWithProcessThreadData | MiniDumpWithThreadInfo
+        | MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithFullMemoryInfo;
 
     // The old full-RW dumps left multi-GB files behind (3.8GB observed in one logs folder).
     // Keep the two newest dumps, drop the rest.
@@ -227,6 +233,8 @@ public static class UiHangWatchdog
     private const uint MiniDumpWithUnloadedModules        = 0x00000020;
     private const uint MiniDumpWithProcessThreadData      = 0x00000100;
     private const uint MiniDumpWithThreadInfo             = 0x00001000;
+    private const uint MiniDumpWithIndirectlyReferencedMemory = 0x00000040;
+    private const uint MiniDumpWithFullMemoryInfo         = 0x00000800;
 
     [DllImport("dbghelp.dll", SetLastError = true)]
     private static extern bool MiniDumpWriteDump(IntPtr hProcess, uint processId, SafeFileHandle hFile,

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -20,32 +20,27 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Current application version - UPDATE THIS WHEN BUMPING VERSION
         /// </summary>
-        public const string AppVersion = "6.3.3";
+        public const string AppVersion = "6.3.4";
 
         /// <summary>
         /// Patch notes for the current version - UPDATE THIS WHEN BUMPING VERSION
         /// These are shown in the update dialog and can be used when GitHub release notes are unavailable.
         /// </summary>
-        public const string CurrentPatchNotes = @"v6.3.3 - Deeper Down
+        public const string CurrentPatchNotes = @"v6.3.4 - Deeper Down
 
-6.3.3 rebuilds how on-screen effects are drawn. Spirals, pink tint, brain drain,
-subliminals, flashes, and bubbles now share one smooth rendering layer per monitor
-instead of a stack of separate windows, so running several at once no longer stutters
-your mouse or skips frames. Plus a round of stability and video fixes.
+A hotfix for 6.3.3. The new unified overlay could lag the whole app on some setups,
+so it is now off by default while we finish the smoother renderer. Plus a batch of
+Down the Rabbit Hole and multi-monitor fixes.
 
 ⚡ PERFORMANCE & STABILITY
-- Overlays now render through a unified compositor: one shared layer per monitor instead of a stack of separate windows. Spirals, pink tint, brain drain, subliminals, flashes, and bubbles run together far more smoothly, with no more mouse stutter or frame-skipping when several effects fire at once.
-- Bounded the native fan-out from flash decodes and chaos SFX to stop silent crashes under bursty load.
-- Effect windows hold through a short idle grace instead of flickering off and back on between pops.
+- Fixed the new unified overlay making every click, tab change, and keypress lag about a second on some machines (worst with the spiral and pink filter running together). The unified overlay is now off by default and your effects fall back to the proven per-effect windows. (#550)
+- Pink filter and spiral no longer paint your other monitors when multi-monitor overlays are turned off. (#552)
 
 🔧 BUG FIXES
-- Deeper-enhanced mandatory videos no longer get cut off at their raw length.
-- Mandatory videos software-decode by default, fixing blank/white video and PC freezes on some GPUs.
-- Lock cards fully cover a second monitor at mixed DPI.
-- Pulse no longer strands the pink filter, spiral, or brain drain stuck opaque during a ramp.
-- The Takeover HUD banner stays hidden when the announce chance is 0%.
-- Closed an avatar-egg re-attach deadlock and made hang dumps readable.
-- Settings popups no longer reset through the legacy sliders.
+- Fixed a one-frame bubble flash in the top-left corner of the screen. (#553)
+- Down the Rabbit Hole: images and videos you deselect in the Assets tab no longer show up in the tube. (#546)
+- Down the Rabbit Hole: the mandatory video no longer lingers over the recap and hub after a descent ends. (#547)
+- Down the Rabbit Hole: Cheshire's corner comments no longer cover the control dock. (#548)
 
 Season: Jelly July";
 

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -20,43 +20,32 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Current application version - UPDATE THIS WHEN BUMPING VERSION
         /// </summary>
-        public const string AppVersion = "6.3.2";
+        public const string AppVersion = "6.3.3";
 
         /// <summary>
         /// Patch notes for the current version - UPDATE THIS WHEN BUMPING VERSION
         /// These are shown in the update dialog and can be used when GitHub release notes are unavailable.
         /// </summary>
-        public const string CurrentPatchNotes = @"v6.3.2 - Deeper Down
+        public const string CurrentPatchNotes = @"v6.3.3 - Deeper Down
 
-6.3.0 rebuilt Down the Rabbit Hole into a guided descent through four chambers and
-sixteen biomes, with a Warren leveling hub, boon drafts, and full voiceover. 6.3.1
-kept refining that rework. 6.3.2 is a hotfix on top - breaking a freeze that could
-lock your PC and smoothing the last rough edges.
+6.3.3 rebuilds how on-screen effects are drawn. Spirals, pink tint, brain drain,
+subliminals, flashes, and bubbles now share one smooth rendering layer per monitor
+instead of a stack of separate windows, so running several at once no longer stutters
+your mouse or skips frames. Plus a round of stability and video fixes.
 
-🩹 HOTFIX
-- Fixed a mandatory-video freeze that could hard-lock your PC; an off-thread watchdog now breaks the wedge and releases you.
-- Fixed a Rabbit Hole hang when flash-pool images decrypted on the main thread.
-- Down the Rabbit Hole: Esc now steps out cleanly (pause, then exit fullscreen, then close), with C#-owned fullscreen.
-- Rabbit Hole play-test batch: opt out of Cheshire, flash from your own media, plus video and pause fixes.
-- Webcam gaze-test window now has a mouse-clickable close button.
-- Animated tease-bubble cap now scales with your performance tier.
-
-✨ FEATURES
-- Down the Rabbit Hole: brand-new Cheshire visual-novel tutorial that walks you in, replacing the old lesson cards.
-- 3 local save slots you pick before the hole opens, so multiple runs stay separate.
-- Full biome-drift voiceover now rendered across the descent.
-
-🎨 UI/UX
-- Emote stack icon and HUD/VN polish pass.
-- Spiral overlay now pulls from a pool of 8 animated effects at random.
-- New boon card art.
-- 2-second reveal delay plus a spotlight halo on whatever a lesson or Cheshire is explaining.
-- De-stormed narration cooldown so voice lines stop overlapping.
+⚡ PERFORMANCE & STABILITY
+- Overlays now render through a unified compositor: one shared layer per monitor instead of a stack of separate windows. Spirals, pink tint, brain drain, subliminals, flashes, and bubbles run together far more smoothly, with no more mouse stutter or frame-skipping when several effects fire at once.
+- Bounded the native fan-out from flash decodes and chaos SFX to stop silent crashes under bursty load.
+- Effect windows hold through a short idle grace instead of flickering off and back on between pops.
 
 🔧 BUG FIXES
-- Fixed a boot hang where the game loader spun forever (stray backtick in a CSS template).
-- Fixed a video black-screen crash during runs.
-- Boon draft now auto-picks a random card on timeout instead of leaving you with nothing.
+- Deeper-enhanced mandatory videos no longer get cut off at their raw length.
+- Mandatory videos software-decode by default, fixing blank/white video and PC freezes on some GPUs.
+- Lock cards fully cover a second monitor at mixed DPI.
+- Pulse no longer strands the pink filter, spiral, or brain drain stuck opaque during a ramp.
+- The Takeover HUD banner stays hidden when the announce chance is 0%.
+- Closed an avatar-egg re-attach deadlock and made hang dumps readable.
+- Settings popups no longer reset through the legacy sliders.
 
 Season: Jelly July";
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1495,13 +1495,17 @@ namespace ConditioningControlPanel.Services
                     Background = Brushes.Black
                 };
 
-                // Create media player for this video
+                // Create media player for this video.
                 mediaPlayer = new LibVLCSharp.Shared.MediaPlayer(_libVLC!);
-                // Use GPU (DXVA) hardware decoding, matching the app's other players
-                // (InlineLoopVideo / HelpVideoWindow / MiniPlayerWindow). LibVLC falls back to
-                // software automatically if the GPU path is unavailable; the user setting is an
-                // escape hatch for the rare systems with broken hardware decoders.
-                mediaPlayer.EnableHardwareDecoding = App.Settings?.Current?.VideoHardwareDecoding ?? true;
+                // Mandatory-video windows default to SOFTWARE decoding. On Windows 11 (build 26200)
+                // and some Win10 machines the LibVLC hardware (DXVA/D3D11) path intermittently fails
+                // to present a frame — the window stays white and MediaEnded never fires, wedging
+                // cleanup. It hit the *primary* (audio + HW) player on both single-monitor (#537) and
+                // dual-monitor (#533, #540) setups, so it is the hardware decoder itself failing, not
+                // GPU contention between the two mirror decoders. These are short attention-check
+                // clips, so software decode is a negligible cost and eliminates the whole white-screen
+                // class. Users who want GPU decode back can flip VideoForceHardwareDecoding on (opt-in).
+                mediaPlayer.EnableHardwareDecoding = App.Settings?.Current?.VideoForceHardwareDecoding ?? false;
                 lock (_mediaPlayersLock)
                 {
                     _mediaPlayers.Add(mediaPlayer);
@@ -1709,7 +1713,19 @@ namespace ConditioningControlPanel.Services
             // Secondaries skip audio decoding entirely. Setting Mute=true after Play() opened
             // a second WASAPI session on the same MMDevice; Windows collapsed both into one
             // per-app mixer slider and the result was doubled/desynced or zero-volume audio.
-            if (!withAudio) media.AddOption(":no-audio");
+            if (!withAudio)
+            {
+                media.AddOption(":no-audio");
+            }
+
+            // Force software video decode at the media level (belt-and-suspenders with
+            // EnableHardwareDecoding=false above) to dodge the LibVLC white-screen/wedge on the
+            // hardware path (#533/#537/#540). Skipped only when the user has explicitly opted into
+            // GPU decode, in which case we honour their choice and leave the HW path enabled.
+            if (!(App.Settings?.Current?.VideoForceHardwareDecoding ?? false))
+            {
+                media.AddOption(":avcodec-hw=none");
+            }
 
             // Play the media
             mediaPlayer.Play(media);

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -122,9 +122,35 @@ namespace ConditioningControlPanel.Services
         private static readonly object _libVLCLock = new();
         private static bool _libVLCInitialized;
         private static bool _libVLCInitializing;
+        private static bool _libVLCCoreLoaded;   // Core.Initialize (native lib load) is once-per-process
         private static readonly TaskCompletionSource<bool> _libVLCReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly List<LibVLCSharp.Shared.MediaPlayer> _mediaPlayers = new();
         private readonly object _mediaPlayersLock = new();  // Thread-safe access to _mediaPlayers
+
+        // ---- LibVLC self-healing (white-screen cluster #557/#558/#559/#560/#574) ----
+        // A Stop() that stays wedged past CloseAll's extended wait leaves a stuck output thread
+        // inside the SHARED LibVLC instance; players created from it afterwards can fail to open
+        // their video/audio outputs — fullscreen white window, no sound — for every later video
+        // until app restart. When detected (wedged stop in CloseAll, or the vout watchdog), the
+        // instance is retired and a fresh one is built. Retired instances/players are parked in
+        // _quarantine and never disposed: Dispose joins the wedged output thread and can block
+        // forever (the old async Dispose in CloseAll did exactly that to a threadpool thread per
+        // wedge), and keeping them rooted also keeps their finalizers from blocking the finalizer
+        // thread. Bounded by wedge count — a leaked player beats a poisoned instance.
+        private static readonly object _quarantineLock = new();
+        private static readonly List<IDisposable> _quarantine = new();
+        private static int _libVLCGeneration;
+
+        // ---- First-frame (vout) watchdog ----
+        // LibVLC raises Vout when the video output actually presents. If it never arrives the
+        // user is staring at a white fullscreen (unpainted vout HWND) for the whole clip — the
+        // safety timer only reacts at duration+5s, and the software-decode default from
+        // #533/#537/#540 doesn't cover output-side (D3D11/WASAPI) failures. One retry on a fresh
+        // LibVLC instance, then skip the video.
+        private const int VoutTimeoutMs = 8000;
+        private volatile bool _voutSeen;
+        private int _whiteRetryCount;
+        private System.Threading.Timer? _voutWatchdog;
 
         // Primary-monitor refs for the Deeper enhancement engine. Set when the
         // audio-bearing video window is created, cleared in CloseAll. Reading
@@ -409,42 +435,48 @@ namespace ConditioningControlPanel.Services
 
                 try
                 {
-                    // Find the libvlc folder - check for libvlc.dll existence, not just folder
-                    var appDir = AppDomain.CurrentDomain.BaseDirectory;
-                    string? libvlcPath = null;
-
-                    // Try paths in order of preference
-                    var pathsToTry = new[]
+                    // Native libs only need loading once per process — a rebuild after
+                    // RetireSharedLibVLC skips straight to creating the new LibVLC instance.
+                    if (!_libVLCCoreLoaded)
                     {
-                        Path.Combine(appDir, "libvlc", "win-x64"),  // NuGet package structure
-                        Path.Combine(appDir, "libvlc"),             // Direct folder
-                        appDir                                       // Same folder as exe
-                    };
+                        // Find the libvlc folder - check for libvlc.dll existence, not just folder
+                        var appDir = AppDomain.CurrentDomain.BaseDirectory;
+                        string? libvlcPath = null;
 
-                    foreach (var path in pathsToTry)
-                    {
-                        var dllPath = Path.Combine(path, "libvlc.dll");
-                        App.Logger?.Information("Checking for LibVLC at: {Path}", dllPath);
-                        if (File.Exists(dllPath))
+                        // Try paths in order of preference
+                        var pathsToTry = new[]
                         {
-                            libvlcPath = path;
-                            App.Logger?.Information("Found libvlc.dll at: {Path}", path);
-                            break;
-                        }
-                    }
+                            Path.Combine(appDir, "libvlc", "win-x64"),  // NuGet package structure
+                            Path.Combine(appDir, "libvlc"),             // Direct folder
+                            appDir                                       // Same folder as exe
+                        };
 
-                    if (libvlcPath != null)
-                    {
-                        // Initialize LibVLCSharp core with explicit path
-                        Core.Initialize(libvlcPath);
-                        App.Logger?.Information("LibVLC core initialized from: {Path}", libvlcPath);
-                    }
-                    else
-                    {
-                        // Try default initialization (may find system-installed VLC)
-                        App.Logger?.Information("libvlc.dll not found in expected locations, trying default initialization");
-                        Core.Initialize();
-                        App.Logger?.Information("LibVLC core initialized from default location");
+                        foreach (var path in pathsToTry)
+                        {
+                            var dllPath = Path.Combine(path, "libvlc.dll");
+                            App.Logger?.Information("Checking for LibVLC at: {Path}", dllPath);
+                            if (File.Exists(dllPath))
+                            {
+                                libvlcPath = path;
+                                App.Logger?.Information("Found libvlc.dll at: {Path}", path);
+                                break;
+                            }
+                        }
+
+                        if (libvlcPath != null)
+                        {
+                            // Initialize LibVLCSharp core with explicit path
+                            Core.Initialize(libvlcPath);
+                            App.Logger?.Information("LibVLC core initialized from: {Path}", libvlcPath);
+                        }
+                        else
+                        {
+                            // Try default initialization (may find system-installed VLC)
+                            App.Logger?.Information("libvlc.dll not found in expected locations, trying default initialization");
+                            Core.Initialize();
+                            App.Logger?.Information("LibVLC core initialized from default location");
+                        }
+                        _libVLCCoreLoaded = true;
                     }
 
                     // Create LibVLC instance with audio and video options.
@@ -494,6 +526,32 @@ namespace ConditioningControlPanel.Services
                     _libVLCReady.TrySetResult(_libVLC != null);
                 }
             }
+        }
+
+        /// <summary>
+        /// Retires the shared LibVLC instance after a wedged stop / white-screen and rebuilds a
+        /// fresh one off-thread. The old instance is parked in _quarantine, NOT disposed —
+        /// disposal joins the wedged output thread and can block forever, and parking keeps its
+        /// finalizer from doing the same on the finalizer thread. SharedLibVLC consumers (bubble
+        /// count, mini player, help videos, Deeper editor) read the property at time-of-use, so
+        /// they pick up the fresh instance as soon as the rebuild completes.
+        /// </summary>
+        private void RetireSharedLibVLC(string reason)
+        {
+            LibVLC? old;
+            lock (_libVLCLock)
+            {
+                old = _libVLC;
+                if (old == null) return;
+                _libVLC = null;
+                _libVLCInitialized = false;
+                _libVLCGeneration++;
+            }
+            lock (_quarantineLock) { _quarantine.Add(old); }
+            App.Logger?.Warning(
+                "VideoService: retired shared LibVLC instance (gen {Gen}) — {Reason}. Rebuilding a fresh instance in the background.",
+                _libVLCGeneration, reason);
+            Task.Run(EnsureLibVLCInitialized);
         }
 
         /// <summary>
@@ -1289,7 +1347,7 @@ namespace ConditioningControlPanel.Services
             _scheduler.Start();
         }
 
-        private void PlayVideo(string path, bool strict)
+        private void PlayVideo(string path, bool strict, bool whiteScreenRetry = false)
         {
             App.Logger?.Information("VideoService: PlayVideo called for {File}", Path.GetFileName(path));
 
@@ -1302,6 +1360,9 @@ namespace ConditioningControlPanel.Services
             }
 
             _videoPlaying = true;
+            // Fresh video = fresh white-screen strikes; a vout-watchdog retry keeps its strike
+            // count so the second failure skips instead of looping.
+            if (!whiteScreenRetry) _whiteRetryCount = 0;
             _strictActive = strict;
             _retryPath = path;
             _startTime = DateTime.Now;
@@ -1386,6 +1447,11 @@ namespace ConditioningControlPanel.Services
                         // Use LibVLC if available (codec-independent), otherwise fall back to MediaElement
                         if (_libVLC != null)
                         {
+                            // Clear BEFORE Play() runs (inside CreateLibVLCVideoWindow) so an
+                            // instant Vout can't be erased by a late reset — that would false-
+                            // positive the watchdog and kill a healthy video.
+                            _voutSeen = false;
+
                             // Create primary screen with LibVLC VideoView (with audio)
                             var primaryWin = CreateLibVLCVideoWindow(path, primary, strict, withAudio: true);
                             _windows.Add(primaryWin);
@@ -1405,6 +1471,8 @@ namespace ConditioningControlPanel.Services
                                 App.Logger?.Information("Skipping {N} secondary video decoder(s) on {Total} monitors to avoid lag (#389); enable 'Fill all monitors with video' to override.",
                                     secondaries.Count, allScreens.Count);
                             }
+
+                            ArmVoutWatchdog();
                         }
                         else
                         {
@@ -1542,6 +1610,14 @@ namespace ConditioningControlPanel.Services
                     _lastWatchPositionMs = e.Time; // track watched position for quest crediting (#447)
                     try { PrimaryPlaybackTimeMsChanged?.Invoke(e.Time); }
                     catch (Exception ex) { App.Logger?.Debug("PrimaryPlaybackTimeMsChanged handler error: {Error}", ex.Message); }
+                };
+
+                mediaPlayer.Vout += (s, e) =>
+                {
+                    // First frame actually presented — the white-screen watchdog stands down and
+                    // the strike counter resets (a retried video that now renders is healthy).
+                    _voutSeen = true;
+                    _whiteRetryCount = 0;
                 };
 
                 mediaPlayer.LengthChanged += (s, e) =>
@@ -2507,7 +2583,12 @@ namespace ConditioningControlPanel.Services
 
                     var now = DateTime.UtcNow;
                     bool advancing = curMs >= 0 && curMs != _lastSafetyTimeMs;
-                    if (advancing || _lastSafetyTimeMs < 0)
+                    // Re-arm only on real evidence of progress: advancing, or the first transition
+                    // from unseeded (-1) to a readable time. If the player time is unreadable from
+                    // the very first tick (curMs stays -1), fall through to the stall grace instead —
+                    // re-arming there kept a wedged video alive forever and re-issued ExtendTimeout
+                    // every tick, permanently disarming the InteractionQueue backstop.
+                    if (advancing || (_lastSafetyTimeMs < 0 && curMs >= 0))
                     {
                         _lastSafetyTimeMs = curMs;
                         _lastSafetyProgressUtc = now;
@@ -2567,6 +2648,76 @@ namespace ConditioningControlPanel.Services
             _fallbackSafetyTimer.Start();
 
             App.Logger?.Debug("VideoService: Fallback safety timer started for {Duration}s", MaxVideoFallbackSeconds);
+        }
+
+        /// <summary>
+        /// Arms the one-shot first-frame watchdog for the current video. Call on the UI thread
+        /// AFTER the video windows are created (Play() has been issued); _voutSeen must be
+        /// cleared before window creation.
+        /// </summary>
+        private void ArmVoutWatchdog()
+        {
+            _voutWatchdog?.Dispose();
+            _voutWatchdog = new System.Threading.Timer(_ => VoutWatchdogFire(), null, VoutTimeoutMs, System.Threading.Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Fires once, <see cref="VoutTimeoutMs"/> after playback started. If LibVLC never created
+        /// a video output the user is staring at a white fullscreen (output-side D3D11/WASAPI
+        /// failure — the software-decode default from #533/#537/#540 doesn't cover these, see the
+        /// #557-#560/#574 cluster). Retire the shared LibVLC instance and retry once on a fresh
+        /// one; a second strike skips the video so the session recovers instead of white-screening
+        /// for the full clip duration and wedging cleanup.
+        /// </summary>
+        private void VoutWatchdogFire()
+        {
+            try
+            {
+                if (_voutSeen || !_videoPlaying || _isCleaningUp || _wedgeRescueFired) return;
+
+                var path = _retryPath;
+                var strict = _strictActive;
+                bool retry = _whiteRetryCount < 1 && !string.IsNullOrEmpty(path);
+                _whiteRetryCount++;
+
+                App.Logger?.Error(
+                    "VideoService: no video output {Ms}ms after Play — white-screen output failure. {Action}",
+                    VoutTimeoutMs,
+                    retry ? "Retiring LibVLC and retrying once on a fresh instance" : "Second strike — skipping this video");
+
+                RetireSharedLibVLC("no video output within watchdog window (white screen)");
+
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                dispatcher.BeginInvoke(() =>
+                {
+                    try
+                    {
+                        if (!_videoPlaying || _isCleaningUp) return; // torn down while we dispatched
+                        if (retry)
+                        {
+                            // CloseAll (not Cleanup): keeps the InteractionQueue slot claimed so
+                            // the retry continues the same interaction. PlayVideo re-ducks and
+                            // re-arms both watchdogs.
+                            CloseAll();
+                            PlayVideo(path!, strict, whiteScreenRetry: true);
+                        }
+                        else
+                        {
+                            Cleanup(); // full teardown — completes the interaction and moves on
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Error(ex, "VideoService: white-screen recovery failed — forcing cleanup");
+                        try { ForceCleanup(); } catch { /* last resort failed */ }
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "VideoService: vout watchdog error");
+            }
         }
 
         /// <summary>
@@ -2726,6 +2877,8 @@ namespace ConditioningControlPanel.Services
             try
             {
                 _attentionTimer?.Stop();
+                _voutWatchdog?.Dispose();
+                _voutWatchdog = null;
                 _segmentArmedAtUtc = DateTime.MinValue;   // random-segment mode is one-shot per video
 
                 lock (_targets)
@@ -2785,9 +2938,25 @@ namespace ConditioningControlPanel.Services
                         while (sw.ElapsedMilliseconds < 4000 && stopTasks.Any(t => !t.IsCompleted))
                             WaitWithMessagePump(150);
                         if (stopTasks.Any(t => !t.IsCompleted))
+                        {
                             App.Logger?.Error("CloseAll: LibVLC player STILL stopping after extended wait — detaching anyway");
+                            // A stop wedged this deep never recovers, and its stuck output thread
+                            // poisons the shared LibVLC instance — every later video comes up as a
+                            // white fullscreen with no sound until app restart (#557/#559). Park
+                            // the stuck players in quarantine (disposing them would block on the
+                            // wedged thread) and retire the instance so the next video gets a
+                            // fresh one.
+                            var wedgedPlayers = new List<LibVLCSharp.Shared.MediaPlayer>();
+                            for (int i = 0; i < stopTasks.Length; i++)
+                                if (!stopTasks[i].IsCompleted) wedgedPlayers.Add(playersCopy[i]);
+                            lock (_quarantineLock) { _quarantine.AddRange(wedgedPlayers); }
+                            playersCopy = playersCopy.Except(wedgedPlayers).ToList();
+                            RetireSharedLibVLC($"{wedgedPlayers.Count} player Stop() wedged in CloseAll");
+                        }
                         else
+                        {
                             App.Logger?.Information("CloseAll: stragglers stopped after extended wait ({Ms}ms)", sw.ElapsedMilliseconds);
+                        }
                     }
                 }
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -84,6 +84,25 @@ namespace ConditioningControlPanel.Services
         private DateTime _startTime;
         private double _duration;
 
+        // #536: a Deeper enhancement (VideoEnhancementBridge) can loop or hold the clip past its
+        // declared duration (loop_region, SpeakHoldMode.LoopRegion, speak-pauses). While one is
+        // bound the safety timer switches from a duration guillotine to a progress-based stall
+        // watch (see StartSafetyTimer) so real playback isn't cut "after the original time is over".
+        private volatile bool _enhancementDriving;
+        private long _lastSafetyTimeMs = -1;
+        private DateTime _lastSafetyProgressUtc = DateTime.MinValue;
+        // Recheck cadence + no-progress grace used only while an enhancement is driving.
+        private static readonly TimeSpan EnhancementRecheckInterval = TimeSpan.FromSeconds(15);
+        private const double EnhancementStallGraceSeconds = 90;
+
+        /// <summary>
+        /// Set by <see cref="Services.Deeper.VideoEnhancementBridge"/> while a Deeper enhancement is
+        /// bound to the primary player. Such an enhancement can loop/hold the clip well past its
+        /// declared duration, so the duration-keyed safety timer must not force-close a video that is
+        /// still genuinely advancing. Cleared on unbind and defensively in CloseAll. (#536)
+        /// </summary>
+        public void SetEnhancementDriving(bool active) => _enhancementDriving = active;
+
         // Cleanup synchronization to prevent race conditions
         private readonly object _cleanupLock = new();
         private volatile bool _isCleaningUp;
@@ -2467,9 +2486,52 @@ namespace ConditioningControlPanel.Services
             // Add 5 second buffer beyond video duration
             var timeoutSeconds = videoDurationSeconds + 5;
 
+            _lastSafetyTimeMs = -1;
+            _lastSafetyProgressUtc = DateTime.UtcNow;
+
             _safetyTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(timeoutSeconds) };
             _safetyTimer.Tick += (s, e) =>
             {
+                if (!_videoPlaying) { _safetyTimer?.Stop(); return; }
+
+                // #536: while a Deeper enhancement drives the clip it can loop or hold well past the
+                // declared duration (loop_region, SpeakHoldMode.LoopRegion, speak-pauses), so a plain
+                // duration guillotine cuts the video "after the original time is over". Switch to a
+                // progress-based stall watch: keep the video alive while playback is still advancing,
+                // slide the InteractionQueue stuck window forward too, and only force-close once it has
+                // shown zero progress for the grace window (a genuine wedge, not an intended pause).
+                if (_enhancementDriving)
+                {
+                    long curMs = -1;
+                    try { curMs = _primaryMediaPlayer?.Time ?? -1; } catch { curMs = -1; }
+
+                    var now = DateTime.UtcNow;
+                    bool advancing = curMs >= 0 && curMs != _lastSafetyTimeMs;
+                    if (advancing || _lastSafetyTimeMs < 0)
+                    {
+                        _lastSafetyTimeMs = curMs;
+                        _lastSafetyProgressUtc = now;
+                        // Keep the secondary InteractionQueue stuck-recovery backstop from cutting the
+                        // loop either (its window is min 5 min / duration+30s — a long loop can reach it).
+                        try { App.InteractionQueue?.ExtendTimeout(_duration > 0 ? _duration : MaxVideoFallbackSeconds, InteractionQueueService.InteractionType.Video); }
+                        catch (Exception ex) { App.Logger?.Debug("VideoService: safety-timer ExtendTimeout failed: {E}", ex.Message); }
+                        if (_safetyTimer != null) _safetyTimer.Interval = EnhancementRecheckInterval;
+                        return;
+                    }
+
+                    if ((now - _lastSafetyProgressUtc).TotalSeconds < EnhancementStallGraceSeconds)
+                    {
+                        if (_safetyTimer != null) _safetyTimer.Interval = EnhancementRecheckInterval;
+                        return; // paused (e.g. speak-hold) but within grace — not a wedge
+                    }
+
+                    _safetyTimer?.Stop();
+                    App.Logger?.Warning("VideoService: Enhancement-driven video stalled ~{Grace}s with no playback progress. Forcing cleanup.", EnhancementStallGraceSeconds);
+                    Cleanup();
+                    return;
+                }
+
+                // Non-enhanced video: unchanged one-shot guillotine at duration+5s.
                 _safetyTimer?.Stop();
                 if (_videoPlaying)
                 {
@@ -2689,6 +2751,10 @@ namespace ConditioningControlPanel.Services
                 // engine read sees null rather than a half-disposed handle.
                 _primaryMediaPlayer = null;
                 _primaryVideoWindow = null;
+                // The enhancement is torn down with the video; clear the driving flag so a later
+                // non-enhanced video gets the normal duration guillotine even if the bridge's
+                // Unbind races the teardown (panic/CloseAll doesn't raise VideoEnded). (#536)
+                _enhancementDriving = false;
 
                 // Stop all players in parallel with timeout to prevent one hanging player from blocking others
                 if (playersCopy.Count > 0)

--- a/ConditioningControlPanel/Views/Tabs/ProgressionTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/ProgressionTabView.xaml
@@ -189,7 +189,10 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Style="{StaticResource SettingLabel}" Text="{loc:Str label_per_min}"
                                            ToolTip="{loc:Str tooltip_bubbles_spawned_per_minute}"/>
-                                <Slider Grid.Column="1" x:Name="SliderBubbleFreq" x:FieldModifier="internal" Minimum="1" Maximum="15" Value="5" 
+                                <!-- Range MUST match BubblePopFeatureControl's SliderFreq (1-60): SaveSettings
+                                     round-trips settings through these legacy controls, so a narrower range here
+                                     CLAMPS the popup's value (bubbles snapped to 15 on engine start / panic). -->
+                                <Slider Grid.Column="1" x:Name="SliderBubbleFreq" x:FieldModifier="internal" Minimum="1" Maximum="60" Value="5"
                                         Margin="10,0" ValueChanged="SliderBubbleFreq_Changed"
                                         ToolTip="{loc:Str tooltip_bubble_spawn_rate}"/>
                                 <TextBlock x:Name="TxtBubbleFreq" x:FieldModifier="internal" Grid.Column="2" Style="{StaticResource ValueLabel}" Text="5"/>
@@ -528,7 +531,9 @@
                                 <CheckBox x:Name="ChkBrainDrainEnabled" x:FieldModifier="internal" Visibility="Collapsed"/>
                                 <StackPanel x:Name="BrainDrainSettings" Visibility="Collapsed">
                                     <TextBlock x:Name="TxtBrainDrainIntensity" x:FieldModifier="internal"/>
-                                    <Slider x:Name="SliderBrainDrainIntensity" x:FieldModifier="internal"/>
+                                    <!-- Explicit range: a WPF Slider defaults to Maximum=10, which silently
+                                         clamps this percent value in the SaveSettings round-trip. -->
+                                    <Slider x:Name="SliderBrainDrainIntensity" x:FieldModifier="internal" Minimum="1" Maximum="100"/>
                                     <CheckBox x:Name="ChkBrainDrainHighRefresh" x:FieldModifier="internal"/>
                                 </StackPanel>
                             </StackPanel>

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -780,10 +780,10 @@
                                 <TextBlock Style="{StaticResource SettingLabel}" Text="Auto performance" Margin="6,0,0,0"/>
                             </StackPanel>
                             <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Margin="0,3"
-                                        ToolTip="Use GPU hardware decoding for mandatory videos. Leave on unless videos fail to play; LibVLC falls back to software automatically.">
+                                        ToolTip="Force GPU hardware decoding for mandatory videos. Off by default — mandatory videos software-decode to avoid a white-screen bug on some Windows machines. Only turn this on if you want GPU decode and your videos play fine.">
                                 <CheckBox x:Name="ChkVideoHwDecode" x:FieldModifier="internal" Style="{StaticResource ToggleStyle}"
                                           Checked="ChkVideoHwDecode_Changed" Unchecked="ChkVideoHwDecode_Changed"/>
-                                <TextBlock Style="{StaticResource SettingLabel}" Text="Video GPU decode" Margin="6,0,0,0"/>
+                                <TextBlock Style="{StaticResource SettingLabel}" Text="Force video GPU decode" Margin="6,0,0,0"/>
                             </StackPanel>
                         </Grid>
     

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -463,7 +463,8 @@
                             </StackPanel>
                             <StackPanel Grid.Column="2" ToolTip="{loc:Str tooltip_number_of_images_shown_per_flash_event_multip}">
                                 <Grid><TextBlock Style="{StaticResource SettingLabel}" Text="{loc:Str setting_images}" FontSize="11"/><TextBlock x:Name="TxtImages" x:FieldModifier="internal" Style="{StaticResource ValueLabel}" Text="5" HorizontalAlignment="Right"/></Grid>
-                                <Slider x:Name="SliderImages" x:FieldModifier="internal" Minimum="1" Maximum="15" Value="5" Margin="0,1" ValueChanged="SliderImages_Changed"/>
+                                <!-- Range MUST match FlashFeatureControl's SliderImages (1-20): the SaveSettings round-trip clamps otherwise. -->
+                                <Slider x:Name="SliderImages" x:FieldModifier="internal" Minimum="1" Maximum="20" Value="5" Margin="0,1" ValueChanged="SliderImages_Changed"/>
                             </StackPanel>
                         </Grid>
                         

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -725,8 +725,9 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-    
+
                             <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Margin="0,3"
                                         ToolTip="{loc:Str tooltip_show_content_on_all_connected_monitors_2_3_or}">
                                 <CheckBox x:Name="ChkDualMon" x:FieldModifier="internal" Style="{StaticResource ToggleStyle}"
@@ -785,6 +786,13 @@
                                 <CheckBox x:Name="ChkVideoHwDecode" x:FieldModifier="internal" Style="{StaticResource ToggleStyle}"
                                           Checked="ChkVideoHwDecode_Changed" Unchecked="ChkVideoHwDecode_Changed"/>
                                 <TextBlock Style="{StaticResource SettingLabel}" Text="Force video GPU decode" Margin="6,0,0,0"/>
+                            </StackPanel>
+
+                            <StackPanel Grid.Row="5" Grid.Column="0" Orientation="Horizontal" Margin="0,3"
+                                        ToolTip="Render fullscreen effects (spiral, pink filter, flashes, bubbles...) in one shared overlay window per monitor. Smoother with many effects on screen. Turn off to fall back to the classic one-window-per-effect renderer if overlays misbehave.">
+                                <CheckBox x:Name="ChkUnifiedOverlay" x:FieldModifier="internal" Style="{StaticResource ToggleStyle}"
+                                          Checked="ChkUnifiedOverlay_Changed" Unchecked="ChkUnifiedOverlay_Changed"/>
+                                <TextBlock Style="{StaticResource SettingLabel}" Text="Unified overlay renderer" Margin="6,0,0,0"/>
                             </StackPanel>
                         </Grid>
     

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml.cs
@@ -367,6 +367,11 @@ namespace ConditioningControlPanel.Views.Tabs
             if (Window.GetWindow(this) is MainWindow mw)
                 mw.ChkVideoHwDecode_Changed(sender, e);
         }
+        private void ChkUnifiedOverlay_Changed(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.ChkUnifiedOverlay_Changed(sender, e);
+        }
         private void ChkWinStart_Click(object sender, RoutedEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw)

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -117,6 +117,16 @@ namespace ConditioningControlPanel
                     if (_voiceMode) Focus(); else TxtInput.Focus();
                 }), DispatcherPriority.Input);
             };
+
+            // Re-assert full-screen physical-pixel coverage whenever this window is activated. Clicking a
+            // card on a second (different-DPI) monitor as it pops was leaving it under-covering the screen
+            // (#539): we swallow WM_DPICHANGED to avoid the #494 render-thread deadlock, which also denies
+            // WPF the DPI update, so the DIP-computed bounds render at the wrong scale. Re-covering in
+            // device pixels here restores full coverage regardless of WPF's (possibly stale) DPI.
+            Activated += (s, e) =>
+            {
+                if (IsVisible) ApplyPhysicalBounds();
+            };
         }
 
         /// <summary>
@@ -231,6 +241,26 @@ namespace ConditioningControlPanel
             Top = screen.Bounds.Top / scale;
             Width = screen.Bounds.Width / scale;
             Height = screen.Bounds.Height / scale;
+
+            // Lock in exact coverage at the OS level (see ApplyPhysicalBounds). The WPF DIP sizing above
+            // is enough to realize the window on the right monitor; this guarantees pixel-exact cover even
+            // when WPF's per-monitor DPI is stale (we swallow WM_DPICHANGED for the #494 deadlock).
+            ApplyPhysicalBounds();
+        }
+
+        /// <summary>
+        /// Force the window to cover its target monitor exactly, in DEVICE PIXELS, via SetWindowPos.
+        /// WPF's DIP-based sizing can under-cover a second monitor on a mixed-DPI rig because we swallow
+        /// WM_DPICHANGED (to dodge the #494 render-thread deadlock), leaving WPF at a stale scale. The
+        /// dark overlay Grid stretches to fill the client area, so a pixel-exact window rect = full-screen
+        /// cover regardless of what DPI WPF thinks it is rendering at (#539).
+        /// </summary>
+        private void ApplyPhysicalBounds()
+        {
+            if (_hwnd == IntPtr.Zero || _screen == null) return;
+            var b = _screen.Bounds;
+            try { SetWindowPos(_hwnd, HWND_TOPMOST, b.Left, b.Top, b.Width, b.Height, SWP_SHOWWINDOW); }
+            catch (Exception ex) { App.Logger?.Debug("LockCardWindow.ApplyPhysicalBounds: {E}", ex.Message); }
         }
 
         private void ApplyColors()
@@ -304,7 +334,7 @@ namespace ConditioningControlPanel
             // deadlocks the UI thread on a backed-up render thread (the same #494 mechanism). Fired only
             // on cross-DPI-monitor moves, so dropping it never affects the initial render.
             if (_hwnd != IntPtr.Zero)
-                HwndSource.FromHwnd(_hwnd)?.AddHook(SwallowDpiChanged);
+                HwndSource.FromHwnd(_hwnd)?.AddHook(HandleDpiChanged);
         }
 
         // XAML still wires Loaded="Window_Loaded"; keep a no-op so the binding resolves. All realization
@@ -312,10 +342,18 @@ namespace ConditioningControlPanel
         private void Window_Loaded(object sender, RoutedEventArgs e) { }
 
         // WndProc hook: drop WM_DPICHANGED so WPF never runs its auto DPI-rescale (which deadlocks under
-        // a backed-up render thread). Mirrors FlashService.SwallowDpiChanged.
-        private static IntPtr SwallowDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        // a backed-up render thread). Mirrors FlashService.SwallowDpiChanged. Instance (not static) so we
+        // can re-cover the monitor in device pixels afterward: swallowing alone left WPF at a stale DPI,
+        // which under-covered a second monitor on a mixed-DPI rig (#539). Re-assert async so no work runs
+        // synchronously inside the message hook.
+        private IntPtr HandleDpiChanged(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
-            if (msg == WM_DPICHANGED) handled = true;   // consume it; WPF's HwndTarget never sees the resize
+            if (msg == WM_DPICHANGED)
+            {
+                handled = true;   // consume it; WPF's HwndTarget never sees the deadlock-prone resize
+                if (IsVisible)
+                    Dispatcher.BeginInvoke(new Action(ApplyPhysicalBounds), DispatcherPriority.Background);
+            }
             return IntPtr.Zero;
         }
 
@@ -323,6 +361,10 @@ namespace ConditioningControlPanel
         // that used to live in Window_Loaded. Called from ShowOnAllMonitors after Show().
         private void OnShown()
         {
+            // Every card window (primary AND each mirror) must cover its whole monitor — the shrink in
+            // #539 was on the SECONDARY screen, so this can't sit behind the primary-only guard below.
+            ApplyPhysicalBounds();
+
             if (!_isPrimary) return;
 
             if (_hwnd != IntPtr.Zero)

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -7,7 +7,7 @@ echo ============================================
 echo.
 
 :: Configuration
-set VERSION=6.3.3
+set VERSION=6.3.4
 set PROJECT_DIR=ConditioningControlPanel
 set PUBLISH_DIR=%PROJECT_DIR%\bin\Release\net8.0-windows10.0.19041.0\win-x64\publish
 set INSTALLER_OUTPUT=installer-output

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -7,7 +7,7 @@ echo ============================================
 echo.
 
 :: Configuration
-set VERSION=6.3.2
+set VERSION=6.3.3
 set PROJECT_DIR=ConditioningControlPanel
 set PUBLISH_DIR=%PROJECT_DIR%\bin\Release\net8.0-windows10.0.19041.0\win-x64\publish
 set INSTALLER_OUTPUT=installer-output

--- a/installer.iss
+++ b/installer.iss
@@ -13,7 +13,7 @@
 ; - Store install path in registry for Velopack updates
 
 #define MyAppName "Conditioning Control Panel"
-#define MyAppVersion "6.3.2"
+#define MyAppVersion "6.3.3"
 #define MyAppPublisher "CodeBambi"
 #define MyAppURL "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF"
 #define MyAppExeName "ConditioningControlPanel.exe"

--- a/installer.iss
+++ b/installer.iss
@@ -13,7 +13,7 @@
 ; - Store install path in registry for Velopack updates
 
 #define MyAppName "Conditioning Control Panel"
-#define MyAppVersion "6.3.3"
+#define MyAppVersion "6.3.4"
 #define MyAppPublisher "CodeBambi"
 #define MyAppURL "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF"
 #define MyAppExeName "ConditioningControlPanel.exe"

--- a/notes-v6.3.3.txt
+++ b/notes-v6.3.3.txt
@@ -1,0 +1,19 @@
+v6.3.3 - Deeper Down
+
+6.3.3 rebuilds how on-screen effects are drawn. Spirals, pink tint, brain drain, subliminals, flashes, and bubbles now share one smooth rendering layer per monitor instead of a stack of separate windows, so running several at once no longer stutters your mouse or skips frames. Plus a round of stability and video fixes.
+
+PERFORMANCE & STABILITY
+- Overlays now render through a unified compositor: one shared layer per monitor instead of a stack of separate windows. Spirals, pink tint, brain drain, subliminals, flashes, and bubbles run together far more smoothly, with no more mouse stutter or frame-skipping when several effects fire at once.
+- Bounded the native fan-out from flash decodes and chaos SFX to stop silent crashes under bursty load.
+- Effect windows hold through a short idle grace instead of flickering off and back on between pops.
+
+BUG FIXES
+- Deeper-enhanced mandatory videos no longer get cut off at their raw length.
+- Mandatory videos software-decode by default, fixing blank/white video and PC freezes on some GPUs.
+- Lock cards fully cover a second monitor at mixed DPI.
+- Pulse no longer strands the pink filter, spiral, or brain drain stuck opaque during a ramp.
+- The Takeover HUD banner stays hidden when the announce chance is 0%.
+- Closed an avatar-egg re-attach deadlock and made hang dumps readable.
+- Settings popups no longer reset through the legacy sliders.
+
+Season: Jelly July

--- a/notes-v6.3.4.txt
+++ b/notes-v6.3.4.txt
@@ -1,0 +1,15 @@
+v6.3.4 - Deeper Down
+
+A hotfix for 6.3.3. The new unified overlay could lag the whole app on some setups, so it is now off by default while we finish the smoother renderer. Plus a batch of Down the Rabbit Hole and multi-monitor fixes.
+
+PERFORMANCE & STABILITY
+- Fixed the new unified overlay making every click, tab change, and keypress lag about a second on some machines (worst with the spiral and pink filter running together). The unified overlay is now off by default and your effects fall back to the proven per-effect windows.
+- Pink filter and spiral no longer paint your other monitors when multi-monitor overlays are turned off.
+
+BUG FIXES
+- Fixed a one-frame bubble flash in the top-left corner of the screen.
+- Down the Rabbit Hole: images and videos you deselect in the Assets tab no longer show up in the tube.
+- Down the Rabbit Hole: the mandatory video no longer lingers over the recap and hub after a descent ends.
+- Down the Rabbit Hole: Cheshire's corner comments no longer cover the control dock.
+
+Season: Jelly July


### PR DESCRIPTION
## Summary

Lands the unified WPF compositor line onto main. Main is a strict ancestor of this branch, so the merge is conflict-free by construction. This includes:

- **6.3.4 "Deeper Down" release history** (released from this branch; this heals the released-from-feature-branch anomaly): #550 UI-thread raster fix (dirty-gating + off-thread ULW host), #552 dual-monitor fill-layer gating, #553 bubble spawn seed, #546-#548 DtRH fixes, #563 overlay band cluster.
- **Unpushed main fix batch** (already in this branch's ancestry): flash-burst heap corruption, #533/#537/#540 software-decode default, #534, #535, #539, #536.
- **Pre-merge review batch (`83f18eb1`)** - 10 confirmed findings fixed: compositor hosts join video-aware z-order reconciliation (#497 below-video pin + topmost recovery), ghost-click fix via deferred mouse-hook unhook, FlashWindow state-bag leaks (layer AND solid mode), off-thread + single-copy flash frame conversion, one-shot force-present (stale sprites / blank new monitor), SWP_SHOWWINDOW visibility desync, ScreenBoundsPx torn read, #536 stall-watch immortality, hot-path caching (screen enum, layer snapshot, Skia filters).
- **Default ON (`c1a3c571`)** - `UnifiedOverlayHost` defaults true + one-shot `MigrateEnableUnifiedOverlayHost` (reverses the 6.3.4 force-off), new Settings > System "Unified overlay renderer" opt-out toggle, routing gate consolidated to `App.CompositorEnabled`.

## Test plan

- Build green (warnings pre-existing).
- Play-test before next release (merge does not ship): flash click/pop during chaos + mandatory video, spiral+pink z-order under video, monitor hot-plug, toggle-off legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWrvuYPg8QtgmkeWNy4hKz