### PR TITLE
fix(video): close the strict-mode hole in the attention-check retry gap

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -146,6 +146,12 @@ namespace ConditioningControlPanel.Services
         // message window. Cleared by every real end-of-run path (Stop / ForceCleanup / Cleanup), by
         // the start of any new video, and by the retry callback's own finally.
         private bool _strictRetryPending;
+        // Bumped whenever a queued attention-fail retry becomes stale. The retry fires from a bare
+        // Task.Delay continuation that nothing can cancel, so instead of cancelling it we let it run
+        // and have it discover it is obsolete: it captures this value when scheduled and bails if it
+        // no longer matches. Without this, panic during the message window announced "we're stopping,
+        // you're safe" and then started another mandatory video ~2s later.
+        private int _retryGeneration;
         // True while THIS video holds an audio-duck ref (App.Audio.Duck is ref-counted). Balanced
         // 1:1 with the Duck in PlayVideo by an Unduck in CloseAll — every teardown path (natural end,
         // attention retry / troll "watch again" loop, engine Stop, ForceCleanup) runs through CloseAll,
@@ -910,7 +916,7 @@ namespace ConditioningControlPanel.Services
             // deferred ~1s to a background task.
             _videoPlaying = false;
             _strictActive = false;
-            _strictRetryPending = false;
+            CancelPendingRetry();
             try
             {
                 CloseAll(synchronous: false);
@@ -1271,7 +1277,7 @@ namespace ConditioningControlPanel.Services
             _videoPlaying = false;
             _triggerInProgress = false;
             _strictActive = false;
-            _strictRetryPending = false;
+            CancelPendingRetry();
             CloseAll(synchronous);
             App.Audio?.ForceUnduck();
             _penalties = 0;
@@ -1308,7 +1314,7 @@ namespace ConditioningControlPanel.Services
             {
                 _videoPlaying = true;
                 _strictActive = false;
-                _strictRetryPending = false;
+                CancelPendingRetry();
 
                 var allScreens = App.GetAllScreensCached().ToList();
                 if (allScreens.Count == 0) return;
@@ -1625,7 +1631,7 @@ namespace ConditioningControlPanel.Services
             // A video is on screen again, so whatever gap we were covering is over. Cleared HERE,
             // after the two flags above are already set, so a reader on another thread never sees a
             // moment where neither the gap flag nor (_videoPlaying && _strictActive) is true.
-            _strictRetryPending = false;
+            CancelPendingRetry();
             _retryPath = path;
             _startTime = DateTime.Now;
             _hits = _total = 0;
@@ -3403,11 +3409,20 @@ namespace ConditioningControlPanel.Services
                     // captured `strict` PARAMETER instead of re-reading the field. Same trick here.
                     var strictForRetry = _strictActive;
                     _strictRetryPending = strictForRetry;
+                    var retryGen = _retryGeneration;
 
                     Action replay = () =>
                     {
                         try
                         {
+                            // Did anything end or replace this run while the message was up? Panic is
+                            // the case that matters: it reaches Stop(), which tears the run down and
+                            // speaks "we're stopping, you're safe" - and then this callback, which no
+                            // one can cancel, used to start another mandatory video ~2s later and make
+                            // a liar of it. The delay still elapses; the retry just no longer acts.
+                            if (_retryGeneration != retryGen)
+                                return;
+
                             // ShowMessage already set _videoPlaying = false and called CloseAll()
                             // Reset attention tracking for retry
                             _hits = 0;
@@ -3460,6 +3475,17 @@ namespace ConditioningControlPanel.Services
                 _lastWatchPositionMs = _duration * 1000.0;
 
             Cleanup();
+        }
+
+        /// <summary>
+        /// Marks any attention-fail retry that is still sitting in a Task.Delay as obsolete, and ends
+        /// the strict gap. Called from every path that ends or replaces a run - the teardowns (Stop,
+        /// ForceCleanup, Cleanup) and the start of any new video (PlayVideo, PlayUrl).
+        /// </summary>
+        private void CancelPendingRetry()
+        {
+            _strictRetryPending = false;
+            _retryGeneration++;
         }
 
         private void ShowMessage(string text, int ms, Action then)
@@ -4453,7 +4479,7 @@ namespace ConditioningControlPanel.Services
             // duck ref exactly once (#526). No Unduck here — a second call would decrement a duck ref
             // that another consumer (subliminal/session) may legitimately hold.
             _strictActive = false;
-            _strictRetryPending = false;
+            CancelPendingRetry();
             _penalties = 0;
 
             // Resume bubbles now that video is done

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -133,6 +133,19 @@ namespace ConditioningControlPanel.Services
         private bool _videoPlaying;
         private bool _triggerInProgress; // Guards the 800ms freeze delay window in TriggerVideo
         private bool _strictActive;
+        // True across the strict retry GAP: from the moment a strict run's attention check fails
+        // until the replacement video is actually on screen. ShowMessage deliberately clears
+        // _videoPlaying for the ~2s "TRY AGAIN" window (the strict Closing veto reads that field and
+        // would otherwise refuse to let the message windows replace the video), which made
+        // IsStrictActive report false for the whole gap — precisely the moment a frustrated user
+        // shouts "stop the video", and the voice guards would have waved it through.
+        //
+        // Scoped to the retry gap ON PURPOSE rather than mirroring _strictActive everywhere: that
+        // keeps the `_videoPlaying &&` conjunct in IsStrictActive protecting every other path, so a
+        // stuck value here can't wedge the user out of their own stop controls for longer than one
+        // message window. Cleared by every real end-of-run path (Stop / ForceCleanup / Cleanup), by
+        // the start of any new video, and by the retry callback's own finally.
+        private bool _strictRetryPending;
         // True while THIS video holds an audio-duck ref (App.Audio.Duck is ref-counted). Balanced
         // 1:1 with the Duck in PlayVideo by an Unduck in CloseAll — every teardown path (natural end,
         // attention retry / troll "watch again" loop, engine Stop, ForceCleanup) runs through CloseAll,
@@ -319,8 +332,12 @@ namespace ConditioningControlPanel.Services
         /// bypass the main Stop button's lockdown guard (e.g. the avatar's quick menu)
         /// must respect this — stopping the engine mid-strict-video both defeats the
         /// lock and races the LibVLC teardown (#479).
+        ///
+        /// "Actively playing" includes the attention-fail retry gap: no video is on screen for
+        /// those ~2 seconds, but the strict run has not ended and must not be escapable through
+        /// it. See <see cref="_strictRetryPending"/>.
         /// </summary>
-        public bool IsStrictActive => _videoPlaying && _strictActive;
+        public bool IsStrictActive => (_videoPlaying && _strictActive) || _strictRetryPending;
 
         /// <summary>
         /// Whether any video windows still exist. Stays true through teardown after
@@ -893,6 +910,7 @@ namespace ConditioningControlPanel.Services
             // deferred ~1s to a background task.
             _videoPlaying = false;
             _strictActive = false;
+            _strictRetryPending = false;
             try
             {
                 CloseAll(synchronous: false);
@@ -1253,6 +1271,7 @@ namespace ConditioningControlPanel.Services
             _videoPlaying = false;
             _triggerInProgress = false;
             _strictActive = false;
+            _strictRetryPending = false;
             CloseAll(synchronous);
             App.Audio?.ForceUnduck();
             _penalties = 0;
@@ -1289,6 +1308,7 @@ namespace ConditioningControlPanel.Services
             {
                 _videoPlaying = true;
                 _strictActive = false;
+                _strictRetryPending = false;
 
                 var allScreens = App.GetAllScreensCached().ToList();
                 if (allScreens.Count == 0) return;
@@ -1602,6 +1622,10 @@ namespace ConditioningControlPanel.Services
 
             _videoPlaying = true;
             _strictActive = strict;
+            // A video is on screen again, so whatever gap we were covering is over. Cleared HERE,
+            // after the two flags above are already set, so a reader on another thread never sees a
+            // moment where neither the gap flag nor (_videoPlaying && _strictActive) is true.
+            _strictRetryPending = false;
             _retryPath = path;
             _startTime = DateTime.Now;
             _hits = _total = 0;
@@ -3365,22 +3389,66 @@ namespace ConditioningControlPanel.Services
                 if (_penalties >= 3 && settings.MercySystemEnabled)
                     ShowMessage(App.Mods?.GetAttentionCheckMercyMessage() ?? "BAMBI GETS MERCY", 2500, Cleanup);
                 else
-                    ShowMessage(troll ? "GOOD GIRL!\nWATCH AGAIN 😜" : (App.Mods?.GetAttentionCheckFailMessage() ?? "DUMB BAMBI!\nTRY AGAIN"), 2000, () =>
+                {
+                    // Snapshot the strict flag NOW, while the run is still live, and keep the run
+                    // marked strict across the message window.
+                    //
+                    // The retry fires from a bare Task.Delay continuation inside ShowMessage that
+                    // Stop() has no way to cancel, and Stop() clears _strictActive. Reading the
+                    // FIELD from inside that callback therefore let a stop landing during the ~2s
+                    // message window silently downgrade the replacement video to non-strict: Esc
+                    // dismissed it, panic worked, Alt+F4 worked. The vout self-heal retry further
+                    // down this file (~:3856) has the identical "_videoPlaying = false, close, then
+                    // replay" shape and is immune for exactly this reason — it re-passes its
+                    // captured `strict` PARAMETER instead of re-reading the field. Same trick here.
+                    var strictForRetry = _strictActive;
+                    _strictRetryPending = strictForRetry;
+
+                    Action replay = () =>
                     {
-                        // ShowMessage already set _videoPlaying = false and called CloseAll()
-                        // Reset attention tracking for retry
-                        _hits = 0;
-                        _spawnTimes.Clear();
-                        // Extend the stuck detection timeout to prevent InteractionQueue from
-                        // auto-completing Video during the retry gap, which would let queued
-                        // interactions (e.g. BubbleCount) start while the retry video plays.
-                        App.InteractionQueue?.ExtendTimeout(300, InteractionQueueService.InteractionType.Video);
-                        // Pick a fresh video for the retry — replaying the same video makes
-                        // attention checks easier to game (memorize the timing) and was a
-                        // user-reported inconsistency vs. BubbleCount which always picks new.
-                        var retryVideo = GetNextVideo();
-                        PlayVideo(string.IsNullOrEmpty(retryVideo) ? _retryPath! : retryVideo, _strictActive);
-                    });
+                        try
+                        {
+                            // ShowMessage already set _videoPlaying = false and called CloseAll()
+                            // Reset attention tracking for retry
+                            _hits = 0;
+                            _spawnTimes.Clear();
+                            // Extend the stuck detection timeout to prevent InteractionQueue from
+                            // auto-completing Video during the retry gap, which would let queued
+                            // interactions (e.g. BubbleCount) start while the retry video plays.
+                            App.InteractionQueue?.ExtendTimeout(300, InteractionQueueService.InteractionType.Video);
+                            // Pick a fresh video for the retry — replaying the same video makes
+                            // attention checks easier to game (memorize the timing) and was a
+                            // user-reported inconsistency vs. BubbleCount which always picks new.
+                            var retryVideo = GetNextVideo();
+                            PlayVideo(string.IsNullOrEmpty(retryVideo) ? _retryPath! : retryVideo, strictForRetry);
+                        }
+                        finally
+                        {
+                            // The gap is over either way. PlayVideo already clears this on its
+                            // success path; this covers the paths that never reach that line (it
+                            // early-returns when another video grabbed the slot, or something in
+                            // here threw). A gap flag that leaked true would lock the user out of
+                            // their own stop controls indefinitely, which is far worse than the
+                            // hole it closes.
+                            _strictRetryPending = false;
+                        }
+                    };
+
+                    try
+                    {
+                        ShowMessage(troll ? "GOOD GIRL!\nWATCH AGAIN 😜" : (App.Mods?.GetAttentionCheckFailMessage() ?? "DUMB BAMBI!\nTRY AGAIN"), 2000, replay);
+                    }
+                    catch
+                    {
+                        // ShowMessage itself blew up (window creation on a machine mid screen
+                        // reconfiguration, say), so the callback that would have cleared the gap
+                        // flag never gets scheduled. Clear it before letting the exception carry on
+                        // as it always has - leaving it set would strand the user locked out with no
+                        // video on screen and nothing left running to end the run.
+                        _strictRetryPending = false;
+                        throw;
+                    }
+                }
                 return;
             }
 
@@ -4385,6 +4453,7 @@ namespace ConditioningControlPanel.Services
             // duck ref exactly once (#526). No Unduck here — a second call would decrement a duck ref
             // that another consumer (subliminal/session) may legitimately hold.
             _strictActive = false;
+            _strictRetryPending = false;
             _penalties = 0;
 
             // Resume bubbles now that video is done


### PR DESCRIPTION
Stacked on PR #76 (`fix/triage-0727`). Based on that branch so this diff shows only the one change - GitHub will retarget it automatically once #76 merges. `VideoService.cs` is already modified on `fix/triage-0727` by the video-audio fix, so branching anywhere else would have guaranteed a conflict.

**Not play-tested.** A play-test runs after this lands in review.

## The gap

When a strict video's attention check fails, `ShowMessage` tears the video down, shows "DUMB BAMBI! TRY AGAIN" for ~2000ms (2500ms on the mercy path), and then plays a fresh retry video. It sets `_videoPlaying = false` before `CloseAll()` deliberately - the strict-mode `Closing` handlers read that field and would veto the teardown - and just as deliberately leaves `_strictActive` true.

That leaves ~2 seconds where the strict run has not ended but nothing in the service says so. Two ways out of a strict video lived in it.

`_videoPlaying = false` in `ShowMessage` is untouched by this PR.

## 1. The retry replayed unlocked

The retry callback passed the `_strictActive` **field** to `PlayVideo`, and it fires from a bare `Task.Delay(...).ContinueWith(...)` that `Stop()` has no way to cancel. Any `Stop()` landing inside the message window cleared `_strictActive` first, so the replacement video came up non-strict: Esc dismissed it, panic worked, Alt+F4 worked.

There was already a correct precedent for this in the same file. The vout self-heal retry at ~`:3856` has the identical "clear `_videoPlaying`, `CloseAll()`, replay" shape and has never had this problem, because it re-passes its captured `strict` **parameter** rather than re-reading the field. The attention path now does the same: it snapshots the flag into a local while the run is still live and passes that local to `PlayVideo`.

## 2. `IsStrictActive` was false for the whole window

`IsStrictActive` is `_videoPlaying && _strictActive`, so it read false for the entire message window. The voice-command guard (`StopLocked()` in `AutonomyService.VoiceCommands.cs`) therefore accepted "stop the video" and "pause" during exactly the stretch where a frustrated user is most likely to shout at the app - and a `Stop()` accepted there is what set up part 1.

Adds `_strictRetryPending`: a distinct notion of "a strict run is in progress, including across the retry gap", OR'd into `IsStrictActive`.

It is scoped to the retry gap rather than mirroring `_strictActive` everywhere, so the `_videoPlaying` conjunct still protects every other path and a stuck value cannot outlive one message window. A flag that leaked true would wedge the user out of their own stop controls - worse than the bug being fixed - so every exit was walked:

- `Stop()`, `ForceCleanup()`, `Cleanup()` - the three real end-of-run paths, each already clearing `_videoPlaying`/`_strictActive` together
- `PlayUrl()` - browser fullscreen, explicitly non-strict
- top of `PlayVideo()`, right after `_strictActive = strict`, so a reader on another thread never sees a moment where neither the gap flag nor `(_videoPlaying && _strictActive)` is true
- a `finally` in the retry callback, covering a `PlayVideo` early-return (another video grabbed the slot) or a throw
- a `catch` around the `ShowMessage` call itself, covering the case where window creation throws and the callback never gets scheduled

The mercy path is left alone: it ends the run via `Cleanup` rather than replaying, and `Cleanup` clears everything.

## Verification

- Build: 0 errors, 302 warnings (unchanged baseline; `VideoService.cs` contributes the same 4 pre-existing nullable warnings it did before)
- Tests: 189/189 passing
