### PR TITLE
feat(discord): mod-aware achievement bot - send achievement_id + mod_id

### DIFF
--- a/ConditioningControlPanel/CLAUDE.md
+++ b/ConditioningControlPanel/CLAUDE.md
@@ -55,6 +55,15 @@ Use `/release X.Y.Z "Subtitle"` to automate this. Also write `../notes-vX.Y.Z.tx
 2. Add static property in `App.xaml.cs`: `public static YourService? YourService { get; private set; }`
 3. Initialize in `App.OnStartup()` after other services
 
+### Add a New Achievement
+1. Add the entry to `Models/Achievement.cs` (`Achievement.All`) + art in `Resources/achievements/`
+2. Add loc keys `achievement_<id>_name/_req/_flavor` to the 9 `Localization/Languages/*.json` files
+3. **Server side or the Discord post silently never happens:** add the id to
+   `ccp-server` `proxy/data/achievements.json` (name/requirement/image/flavor, optional
+   per-mod `flavor_overrides`) - the webhook 400s unknown ids
+4. Upload the PNG (+256px webp sibling) to `cclabs-site/achievements/` and deploy - the
+   bot hotlinks `https://cclabs.app/achievements/<image>`
+
 ### Release a New Version
 Use `/release X.Y.Z "Subtitle"` - it covers all version locations, patch notes, localization keys, and
 the Discord announce step. Version locations are also tabulated above under **Version Locations**.

--- a/ConditioningControlPanel/Services/Account/DiscordService.cs
+++ b/ConditioningControlPanel/Services/Account/DiscordService.cs
@@ -602,6 +602,31 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Map the active mod to the theme id the community bot uses to pick a voice for the post.
+        /// Community/custom mods (and anything we can't resolve) fall back to "default".
+        /// </summary>
+        private static string GetModThemeId()
+        {
+            try
+            {
+                return App.Mods?.ActiveModId switch
+                {
+                    BuiltInMods.CCPDefaultId => "default",
+                    BuiltInMods.BambiSleepId => "bambi",
+                    BuiltInMods.SissyHypnoId => "sissy",
+                    BuiltInMods.DronificationId => "drone",
+                    BuiltInMods.LockedId => "circe",
+                    _ => "default"
+                };
+            }
+            catch
+            {
+                // Never throw: this runs inside the fire-and-forget share path.
+                return "default";
+            }
+        }
+
+        /// <summary>
         /// Send achievement announcement to community Discord via server
         /// </summary>
         public async Task<bool> SendAchievementWebhookAsync(Achievement achievement, string? displayName = null)
@@ -625,7 +650,11 @@ namespace ConditioningControlPanel.Services
                     unified_id = unifiedId,
                     achievement_name = achievement.Name,
                     achievement_requirement = achievement.Requirement,
-                    image_name = achievement.ImageName
+                    image_name = achievement.ImageName,
+                    // New fields the bot composes mod-themed posts from; the legacy fields above
+                    // stay so servers that haven't rolled out yet keep working.
+                    achievement_id = achievement.Id,
+                    mod_id = GetModThemeId()
                 };
 
                 var request = new HttpRequestMessage(HttpMethod.Post, "/discord/community-webhook")
@@ -687,7 +716,9 @@ namespace ConditioningControlPanel.Services
                     display_name = name,
                     unified_id = unifiedId,
                     level = level,
-                    image_name = imageName
+                    image_name = imageName,
+                    // Lets the bot theme the post; legacy servers ignore it and keep using image_name.
+                    mod_id = GetModThemeId()
                 };
 
                 var request = new HttpRequestMessage(HttpMethod.Post, "/discord/community-webhook")


### PR DESCRIPTION
The community Discord bot's achievement/level-up posts are being made mod-aware. The server now composes posts from an id-keyed achievement table with per-mod themes (line pools, colors, footers, flavor + name overrides). This client change sends the two new fields it needs:

- `GetModThemeId()` maps `App.Mods.ActiveModId` -> `default`/`bambi`/`sissy`/`drone`/`circe` (community mods and null -> `default`), never throws
- `SendAchievementWebhookAsync` payload adds `achievement_id` + `mod_id`
- `SendLevelUpWebhookAsync` payload adds `mod_id`
- All legacy fields kept, so this client works against old and new server alike (rollout order-independent)
- CLAUDE.md gains an Add-a-New-Achievement checklist (the old bot silently 400'd all 31 post-v1 achievements because the server name whitelist + hosted images were never updated - the checklist prevents a repeat)

Server counterpart: CC-Labs-llc/CCP-Server branch `feat/modaware-community-webhook`. Images already live on cclabs.app/achievements/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1KA2Fb3XcBcfNuMf96hwW