### PR TITLE
feat(nux): first-run experience - revive dead tour, feature intro cards, premium celebration

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -876,7 +876,32 @@ namespace ConditioningControlPanel
             {
                 UpdatePatreonUI();
                 UpdateUnlockablesVisibility(App.Settings?.Current?.PlayerLevel ?? 1);
+                MaybeShowPremiumCelebration();
             });
+        }
+
+        /// <summary>
+        /// One-time "premium unlocked" celebration card. Re-reads the combined entitlement
+        /// (Patreon tier + whitelist + cached grace + SubscribeStar) rather than trusting any
+        /// single event's tier argument, because several grant paths - cached state restored in
+        /// the ctor, the 14-day grace window, V2-linked accounts - never raise TierChanged at
+        /// all. Suppressed (unspent) while a session, the guided tour, or the update dialog is
+        /// on screen; MainWindow_Loaded re-checks on every launch, so suppression only delays
+        /// the card, never burns it.
+        /// </summary>
+        private void MaybeShowPremiumCelebration()
+        {
+            try
+            {
+                if (App.Patreon?.HasPremiumAccess != true) return;
+                if (_sessionEngine?.IsRunning == true) return;
+                if (App.IsUpdateDialogActive || IsStartupDialogShowing) return;
+                FeatureIntroPopup.ShowCelebrationIfFirstTime(this);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Premium celebration hook failed");
+            }
         }
 
         private void InitializePatreonTab()

--- a/ConditioningControlPanel/MainWindow/MainWindow.SubscribeStar.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.SubscribeStar.cs
@@ -43,6 +43,7 @@ namespace ConditioningControlPanel
                     // features unlock/relock based on the combined entitlement.
                     UpdatePatreonUI();
                     UpdateUnlockablesVisibility(App.Settings?.Current?.PlayerLevel ?? 1);
+                    MaybeShowPremiumCelebration();
                 }
                 catch (Exception ex)
                 {

--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -312,6 +312,7 @@ namespace ConditioningControlPanel
                     AwarenessTab.Visibility = Visibility.Visible;
                     AnimateTabIn(AwarenessTab);
                     SyncAwarenessTabUI();
+                    MaybeShowFeatureIntro("awareness");
                     break;
 
                 case "remotecontrol":
@@ -342,6 +343,7 @@ namespace ConditioningControlPanel
                     HapticsTab.Visibility = Visibility.Visible;
                     AnimateTabIn(HapticsTab);
                     UpdatePatreonUI();
+                    MaybeShowFeatureIntro("haptics");
                     break;
 
                 case "lockdown":
@@ -349,18 +351,21 @@ namespace ConditioningControlPanel
                     AnimateTabIn(LockdownTab);
                     StartLockdownPulse();
                     RefreshPremiumGate(LockdownTab.LockdownGate);
+                    MaybeShowFeatureIntro("lockdown");
                     break;
 
                 case "blinktrainer":
                     BlinkTrainerTab.Visibility = Visibility.Visible;
                     AnimateTabIn(BlinkTrainerTab);
                     RefreshBlinkTrainerTab();
+                    MaybeShowFeatureIntro("blinktrainer");
                     break;
 
                 case "shelistening":
                     SheListeningTab.Visibility = Visibility.Visible;
                     AnimateTabIn(SheListeningTab);
                     RefreshSheListeningTab();
+                    MaybeShowFeatureIntro("shelistening");
                     break;
 
                 case "gradedintake":
@@ -370,6 +375,26 @@ namespace ConditioningControlPanel
                     RefreshPastQuizzes();
                     break;
 
+            }
+        }
+
+        /// <summary>
+        /// One-shot explainer cards for tabs whose purpose isn't obvious from their controls
+        /// (see FeatureIntros for the roster). Suppressed while a session is running - a modal
+        /// must never land on top of live conditioning. FeatureIntroPopup itself guards the
+        /// guided tour (which navigates tabs through ShowTab) and paces cards so a user
+        /// clicking through every tab doesn't eat a modal per click.
+        /// </summary>
+        private void MaybeShowFeatureIntro(string key)
+        {
+            try
+            {
+                if (_sessionEngine?.IsRunning == true) return;
+                FeatureIntroPopup.ShowIfFirstTime(key, this);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Feature intro hook failed for {Key}", key);
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -428,12 +428,22 @@ namespace ConditioningControlPanel
                         await Task.Delay(500);
                     }
 
+                    // The spotlight overlay measures this window's controls, so it must not
+                    // start against a window that hasn't loaded yet (up to 10s).
+                    for (int i = 0; i < 20 && !IsLoaded; i++)
+                    {
+                        await Task.Delay(500);
+                    }
+
                     // Only start tutorial if update dialog is done
-                    if (!App.IsUpdateDialogActive)
+                    if (!App.IsUpdateDialogActive && IsLoaded)
                     {
                         StartTutorial();
                     }
-                }), System.Windows.Threading.DispatcherPriority.Loaded);
+                    // Normal, NOT Loaded: this app keeps the dispatcher busy enough (compositor
+                    // host + avatar animations) that Loaded-priority items are starved and never
+                    // run - the first-launch tour silently never started at Loaded priority.
+                }), System.Windows.Threading.DispatcherPriority.Normal);
             }
             else
             {
@@ -2098,6 +2108,12 @@ namespace ConditioningControlPanel
             {
                 App.Logger?.Warning(ex, "Blink Trainer flagship sticky: failed");
             }
+
+            // One-time premium celebration for entitlements granted silently (cached state
+            // restored in the ctor, the grace window, V2-linked accounts). The provider
+            // TierChanged handlers cover the loud grant paths; this covers the quiet ones
+            // on the next launch.
+            MaybeShowPremiumCelebration();
 
             // Catalogue submission feedback: poll for any pending Deeper
             // submissions that have been accepted/published since last launch and

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5401,6 +5401,21 @@ namespace ConditioningControlPanel.Models
 
         #endregion
 
+        #region First-time experience
+
+        // One-shot feature intro cards (Windows/FeatureIntroPopup). Each key is spent the
+        // moment its card is about to open - same contract as HasSeenProgramsIntro - so a
+        // card that fails to display burns nothing and one that displays never re-fires.
+        private List<string> _seenFeatureIntros = new();
+        [JsonProperty]
+        public List<string> SeenFeatureIntros
+        {
+            get => _seenFeatureIntros;
+            set { _seenFeatureIntros = value ?? new List<string>(); OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Deeper
 
         private bool _enableDeeper = true;

--- a/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml
+++ b/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml
@@ -1,0 +1,134 @@
+<Window x:Class="ConditioningControlPanel.FeatureIntroPopup"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Feature Intro"
+        Width="620" SizeToContent="Height" MaxHeight="640"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        PreviewKeyDown="Window_PreviewKeyDown"
+        MouseLeftButtonDown="Window_MouseLeftButtonDown">
+
+    <Border x:Name="CardBorder" Background="#F0151530" CornerRadius="14"
+            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="2"
+            Margin="10">
+        <Border.Effect>
+            <DropShadowEffect x:Name="CardShadow" Color="{DynamicResource PinkColor}" BlurRadius="20" ShadowDepth="0" Opacity="0.5"/>
+        </Border.Effect>
+
+        <!-- Two columns, same skeleton as ProgramsIntroPopup: glyph rail left, explainer right.
+             The rail is a large emoji glyph over an accent glow rather than a bitmap, so any
+             feature gets a dressed card without shipping art for it. -->
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Glyph rail -->
+            <Border Grid.Column="0" Width="172" CornerRadius="12,0,0,12" ClipToBounds="True">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0.3,1">
+                        <GradientStop Color="#3C2159" Offset="0"/>
+                        <GradientStop Color="#252542" Offset="0.55"/>
+                        <GradientStop Color="#1A1A2E" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+
+                <Grid>
+                    <!-- Ambient accent wash behind the glyph; Fill set in code from the accent. -->
+                    <Rectangle x:Name="RailGlow" Margin="8"/>
+
+                    <TextBlock x:Name="RailGlyph"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Margin="0,0,0,30"
+                               FontSize="64" TextAlignment="Center"/>
+
+                    <TextBlock x:Name="TxtRailTitle" VerticalAlignment="Bottom"
+                               Margin="12,0,12,18"
+                               FontSize="14" FontWeight="Bold"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+
+                    <!-- Hairline seam so the rail reads as part of the card. -->
+                    <Rectangle x:Name="RailSeam" Width="1" HorizontalAlignment="Right" Fill="#55FF69B4"/>
+                </Grid>
+            </Border>
+
+            <!-- Close button -->
+            <Button Content="✕"
+                    Grid.Column="1"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Width="28" Height="28" Margin="0,8,12,0"
+                    Background="Transparent" Foreground="#888888"
+                    BorderThickness="0" Cursor="Hand"
+                    Panel.ZIndex="1"
+                    Click="BtnDismiss_Click">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+
+            <StackPanel Grid.Column="1" Margin="24,22,24,20" VerticalAlignment="Center">
+                <TextBlock x:Name="TxtTitle"
+                           Foreground="{DynamicResource PinkBrush}"
+                           FontWeight="Bold" FontSize="21"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,4"/>
+
+                <TextBlock x:Name="TxtTagline"
+                           Foreground="#CCD5D5E5" FontSize="13"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,16"/>
+
+                <!-- Bullet rows are built in code from the intro content (see BuildBullets):
+                     same accent-glyph row layout ProgramsIntroPopup authors statically. -->
+                <StackPanel x:Name="BulletsHost" Margin="0,0,0,6"/>
+
+                <TextBlock x:Name="TxtFooter" Foreground="#99AAAABB" FontSize="12"
+                           TextWrapping="Wrap" LineHeight="18"
+                           Margin="0,4,0,16"/>
+
+                <Button x:Name="BtnDismiss" Content="Got it" Click="BtnDismiss_Click"
+                        HorizontalAlignment="Left"
+                        Width="132" Height="37"
+                        Cursor="Hand"
+                        FontSize="14" FontWeight="SemiBold">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Background" Value="{DynamicResource PinkBrush}"/>
+                            <Setter Property="Foreground" Value="White"/>
+                            <Setter Property="BorderThickness" Value="0"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="border" Background="{TemplateBinding Background}"
+                                                CornerRadius="18" Padding="16,6">
+                                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="border" Property="Background" Value="{DynamicResource PinkButtonHoveredBrush}"/>
+                                            </Trigger>
+                                            <Trigger Property="IsPressed" Value="True">
+                                                <Setter TargetName="border" Property="Background" Value="{DynamicResource AccentPressedBrush}"/>
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml.cs
+++ b/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// What a one-shot feature intro card says. Copy is hardcoded English on purpose, matching
+    /// ProgramsIntroPopup and the other one-shot popups (see the note there).
+    /// </summary>
+    public sealed class FeatureIntroContent
+    {
+        public string Key { get; init; } = "";
+        public string Glyph { get; init; } = "✨";
+        public string RailTitle { get; init; } = "";
+        public string Title { get; init; } = "";
+        public string Tagline { get; init; } = "";
+        public string[] Bullets { get; init; } = Array.Empty<string>();
+        public string? Footer { get; init; }
+        /// <summary>Accent hex; falls back to app pink when unset or invalid.</summary>
+        public string? Accent { get; init; }
+        public string DismissLabel { get; init; } = "Got it";
+    }
+
+    /// <summary>
+    /// One reusable first-open explainer card, generalizing what ProgramsIntroPopup does for the
+    /// Programs tab: shown once per install per feature key, dressed with a glyph rail instead of
+    /// per-feature bitmaps. All the hardening lessons from that popup are kept: the seen-flag is
+    /// spent at open time (not queue time), the open is deferred at Normal priority (Loaded is
+    /// starved in this app), and every path is guarded so an explainer can never be the reason a
+    /// tab fails to open.
+    /// </summary>
+    public partial class FeatureIntroPopup : Window
+    {
+        private FeatureIntroPopup(FeatureIntroContent content)
+        {
+            InitializeComponent();
+            ApplyContent(content);
+        }
+
+        /// <summary>Set between queueing a card and opening it, so a double-click queues one card.</summary>
+        private static bool _opening;
+
+        /// <summary>
+        /// Pacing gate: a curious first-day user clicking through every tab must not eat a modal
+        /// per click. A card suppressed by pacing is NOT spent - it shows on a later visit.
+        /// </summary>
+        private static DateTime _lastShownUtc = DateTime.MinValue;
+        private static readonly TimeSpan ShowCooldown = TimeSpan.FromMinutes(10);
+
+        /// <summary>Seen-list key for the one-time premium celebration card.</summary>
+        internal const string CelebrationKey = "premium-celebration";
+
+        /// <summary>
+        /// Shows the intro for <paramref name="key"/> once per install, then never again.
+        /// Silently does nothing while the guided tour is active (the tour navigates tabs through
+        /// ShowTab, and a modal would ambush it) or within the pacing cooldown of another card.
+        /// </summary>
+        internal static void ShowIfFirstTime(string key, Window? owner) => ShowCore(key, owner, paced: true);
+
+        /// <summary>
+        /// The premium celebration rides the same card and seen-list but skips the pacing
+        /// cooldown: it fires at most once per install and has retry points on every launch,
+        /// so suppressing it (unspent) is always safe and delaying it never is.
+        /// </summary>
+        internal static void ShowCelebrationIfFirstTime(Window? owner) => ShowCore(CelebrationKey, owner, paced: false);
+
+        private static void ShowCore(string key, Window? owner, bool paced)
+        {
+            try
+            {
+                if (!FeatureIntros.All.TryGetValue(key, out var content)) return;
+
+                var settings = App.Settings?.Current;
+                if (settings == null || settings.SeenFeatureIntros.Contains(key) || _opening) return;
+
+                if (App.Tutorial?.IsActive == true) return;
+                if (paced && DateTime.UtcNow - _lastShownUtc < ShowCooldown) return;
+
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+
+                _opening = true;
+                dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, new Action(() =>
+                {
+                    try
+                    {
+                        var live = App.Settings?.Current;
+                        if (live == null || live.SeenFeatureIntros.Contains(key)) return;
+
+                        // The celebration is queued during startup, where the What's New and
+                        // update dialogs also live. Both were checked before queueing, but they
+                        // can open in between - recheck at open time and yield (unspent; every
+                        // launch retries) rather than stack a modal on a modal.
+                        if (key == CelebrationKey &&
+                            (App.IsUpdateDialogActive || MainWindow.IsStartupDialogShowing)) return;
+
+                        var popup = new FeatureIntroPopup(content);
+                        if (owner != null && owner.IsLoaded) popup.Owner = owner;
+
+                        // Constructed without throwing, so the card is going to be shown - spend
+                        // the flag now, so being killed while it is on screen still counts as seen.
+                        live.SeenFeatureIntros.Add(key);
+                        App.Settings?.Save();
+                        _lastShownUtc = DateTime.UtcNow;
+
+                        popup.ShowDialog();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning(ex, "Feature intro popup failed to show for {Key}", key);
+                    }
+                    finally
+                    {
+                        _opening = false;
+                    }
+                }));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Feature intro gate failed for {Key}", key);
+            }
+        }
+
+        private void ApplyContent(FeatureIntroContent content)
+        {
+            Title = content.Title;
+            TxtTitle.Text = content.Title;
+            TxtTagline.Text = content.Tagline;
+            RailGlyph.Text = content.Glyph;
+            TxtRailTitle.Text = content.RailTitle;
+            BtnDismiss.Content = content.DismissLabel;
+
+            TxtFooter.Text = content.Footer ?? "";
+            TxtFooter.Visibility = string.IsNullOrWhiteSpace(content.Footer)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+
+            var accent = AccentBrush(content.Accent);
+            try
+            {
+                CardBorder.BorderBrush = accent;
+                TxtTitle.Foreground = accent;
+                TxtRailTitle.Foreground = accent;
+                RailGlow.Fill = GlowBrush(accent);
+                if (accent is SolidColorBrush solid)
+                {
+                    CardShadow.Color = solid.Color;
+                    RailSeam.Fill = new SolidColorBrush(
+                        Color.FromArgb(0x55, solid.Color.R, solid.Color.G, solid.Color.B));
+                    BtnDismiss.Background = accent;
+                }
+            }
+            catch { /* accent dressing is decoration - the pink defaults stand */ }
+
+            BuildBullets(content.Bullets, accent);
+        }
+
+        /// <summary>
+        /// Same accent-glyph row layout ProgramsIntroPopup authors statically, built here from
+        /// content so one XAML card serves every feature.
+        /// </summary>
+        private void BuildBullets(string[] bullets, Brush accent)
+        {
+            BulletsHost.Children.Clear();
+            foreach (var text in bullets)
+            {
+                var row = new Grid { Margin = new Thickness(0, 0, 0, 9) };
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+                var dot = new TextBlock
+                {
+                    Text = "●",
+                    FontSize = 9,
+                    VerticalAlignment = VerticalAlignment.Top,
+                    Margin = new Thickness(0, 5, 9, 0),
+                    Foreground = accent
+                };
+                row.Children.Add(dot);
+
+                var body = new TextBlock
+                {
+                    Text = text,
+                    Foreground = Brushes.White,
+                    FontSize = 13.5,
+                    TextWrapping = TextWrapping.Wrap,
+                    LineHeight = 20
+                };
+                Grid.SetColumn(body, 1);
+                row.Children.Add(body);
+
+                BulletsHost.Children.Add(row);
+            }
+        }
+
+        private static Brush AccentBrush(string? hex)
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(hex) && ColorConverter.ConvertFromString(hex) is Color color)
+                {
+                    var brush = new SolidColorBrush(color);
+                    brush.Freeze();
+                    return brush;
+                }
+            }
+            catch { /* a bad accent must never break the card */ }
+
+            return Application.Current?.TryFindResource("PinkBrush") as Brush ?? Brushes.HotPink;
+        }
+
+        private static Brush GlowBrush(Brush accent)
+        {
+            try
+            {
+                if (accent is SolidColorBrush solid)
+                {
+                    var c = solid.Color;
+                    var brush = new RadialGradientBrush(
+                        Color.FromArgb(90, c.R, c.G, c.B),
+                        Color.FromArgb(0, c.R, c.G, c.B))
+                    {
+                        Center = new Point(0.5, 0.42),
+                        GradientOrigin = new Point(0.5, 0.42),
+                        RadiusX = 0.7,
+                        RadiusY = 0.7
+                    };
+                    brush.Freeze();
+                    return brush;
+                }
+            }
+            catch { /* a glow failing must never break the card */ }
+
+            return Brushes.Transparent;
+        }
+
+        private void BtnDismiss_Click(object sender, RoutedEventArgs e)
+        {
+            try { Close(); } catch { }
+        }
+
+        private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Escape) return;
+            e.Handled = true;
+            try { Close(); } catch { }
+        }
+
+        /// <summary>Chromeless window, so dragging the card is the only way to move it.</summary>
+        private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            try { DragMove(); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The intro card registry. Adding an intro for a new feature is one entry here plus one
+    /// MaybeShowFeatureIntro call at its ShowTab case - no new settings property, no new XAML.
+    /// Cards deliberately show for free users too: the card explains what the gated tab IS,
+    /// which the premium overlay alone never does.
+    /// </summary>
+    internal static class FeatureIntros
+    {
+        public static readonly Dictionary<string, FeatureIntroContent> All = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["awareness"] = new FeatureIntroContent
+            {
+                Key = "awareness",
+                Glyph = "👁️",
+                RailTitle = "Awareness Engine",
+                Title = "👁️  The Awareness Engine",
+                Tagline = "She notices your words - on screen, and as you type.",
+                Accent = "#64C8FF",
+                Bullets = new[]
+                {
+                    "Choose trigger words, and she watches for them in what's on your screen and what you type.",
+                    "When one appears she can respond: a highlight, a sound, a flash, a spoken comment, haptics, a little XP.",
+                    "One-click starter packs install a themed set of triggers - or build your own, word by word.",
+                    "Cooldowns and loop protection keep it gentle, and the live feed shows you everything she noticed."
+                },
+                Footer = "Premium feature. The master switch stops screen reading and keyboard capture completely, any time."
+            },
+
+            ["shelistening"] = new FeatureIntroContent
+            {
+                Key = "shelistening",
+                Glyph = "🎙️",
+                RailTitle = "She's Listening",
+                Title = "🎙️  She's Listening",
+                Tagline = "Voice control that never leaves your PC.",
+                Accent = "#B478FF",
+                Bullets = new[]
+                {
+                    "Say the wake word - or hold push-to-talk - then speak: start effects, pause a session, ask for a mantra.",
+                    "Your safety word stops every effect, instantly, always.",
+                    "Everything runs offline on your machine. No audio is stored or uploaded, ever.",
+                    "Nothing arms until you give mic consent - and one button revokes it all just as fast."
+                },
+                Footer = "Premium feature. Needs a microphone; the title-bar pill always shows when she's listening."
+            },
+
+            ["blinktrainer"] = new FeatureIntroContent
+            {
+                Key = "blinktrainer",
+                Glyph = "😉",
+                RailTitle = "Blink Trainer",
+                Title = "😉  Blink Trainer",
+                Tagline = "Every blink changes what you see.",
+                Accent = "#FF69B4",
+                Bullets = new[]
+                {
+                    "Your webcam watches for blinks - each one swaps the full-screen overlay to something new.",
+                    "It draws from your own folders of images, GIFs and videos. Add as many as you like.",
+                    "You set the duration and the overlay opacity; it ends itself when time is up.",
+                    "Webcam consent comes first, and the demo stage below works before anything is armed."
+                },
+                Footer = "Premium feature (beta). Live mode needs webcam consent and at least one folder."
+            },
+
+            ["lockdown"] = new FeatureIntroContent
+            {
+                Key = "lockdown",
+                Glyph = "🔒",
+                RailTitle = "Lockdown",
+                Title = "🔒  Lockdown",
+                Tagline = "Lock yourself in - for as long as you dare.",
+                Accent = "#FF4D6D",
+                Bullets = new[]
+                {
+                    "Pick a duration and commit: strict lock switches on and the panic key switches off until the timer runs out.",
+                    "From five minutes to four hours. The countdown is all you'll see.",
+                    "If the app crashes mid-lockdown, your real settings are restored on the next launch - nothing stays stuck.",
+                    "And if you truly need out early... the timer keeps a secret. Ask it nicely."
+                },
+                Footer = "Premium feature. Sitting through a long lockdown counts toward achievements."
+            },
+
+            ["haptics"] = new FeatureIntroContent
+            {
+                Key = "haptics",
+                Glyph = "📳",
+                RailTitle = "Haptics",
+                Title = "📳  Haptics",
+                Tagline = "Let her reach your toys.",
+                Accent = "#F783AC",
+                Bullets = new[]
+                {
+                    "Connects to Lovense Connect or Buttplug.io / Intiface - paste the URL and hit Connect.",
+                    "Nearly everything can drive it: flashes, bubbles, videos in sync with their audio, subliminals, level-ups, keywords, blinks.",
+                    "Each feature gets its own intensity and pattern, on top of one global dial.",
+                    "No hardware yet? The Mock provider lets you feel out the settings without a device."
+                },
+                Footer = "Premium feature. Auto-connect on startup is optional."
+            },
+
+            [FeatureIntroPopup.CelebrationKey] = new FeatureIntroContent
+            {
+                Key = FeatureIntroPopup.CelebrationKey,
+                Glyph = "💖",
+                RailTitle = "Thank You",
+                Title = "💖  Premium Unlocked",
+                Tagline = "Your support keeps the Lab running - and it just opened every door.",
+                Accent = "#FF69B4",
+                Bullets = new[]
+                {
+                    "All the exclusive tabs are yours: Takeover, Remote Control, She's Listening, Blink Trainer, Haptics, Awareness, Lockdown, Graded Intake.",
+                    "Your companion's AI limits go up, and premium quests, programs and exclusive achievements switch on.",
+                    "Look for the Premium Rail on the Dashboard - one flip per feature, all in one strip.",
+                    "Each exclusive tab introduces itself the first time you open it. Wander."
+                },
+                Footer = "Everything lives under the Exclusives menu. Enjoy - you earned it.",
+                DismissLabel = "Let's go 💖"
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What

Three-part overhaul of the new-user experience, built on the existing one-shot popup pattern.

### 1. The first-launch tour was dead
The welcome-dialog -> app-tour handoff was queued at `DispatcherPriority.Loaded`, which this app's dispatcher starves (same failure mode documented inside `ProgramsIntroPopup`). New users saw the welcome card and then nothing. Now queued at Normal priority and waits for `IsLoaded` before starting, so the spotlight overlay never measures an unrendered window.

### 2. Generalized one-shot feature intro cards
New `Windows/FeatureIntroPopup.xaml(.cs)`: one reusable data-driven intro card cloned from `ProgramsIntroPopup`'s hardening (seen-flag spent at open time not queue time, deferred open at Normal priority, guarded so it can never break a tab click). Glyph rail instead of per-feature bitmaps, so no art dependency.

Wired into **Awareness, She's Listening, Blink Trainer, Lockdown, Haptics** at their `ShowTab` cases - which covers every entry path (tab bar, Exclusives submenu, toasts, deep links). Adding a future intro = one registry entry + one line.

Guards:
- never while the guided tour is active (it navigates via `ShowTab`)
- never while a session is running
- 10-minute pacing between cards - a curious user clicking every tab gets one card, not five; suppressed cards are **unspent** and show on a later visit
- persistence is a single `SeenFeatureIntros` list, not five new bools

Cards deliberately show for free users too: the premium gate overlay never explains what a locked tab *is*.

### 3. One-time "Premium Unlocked" celebration
Same card + seen-list, key `premium-celebration`, skips the pacing cooldown. Design driven by two traps found during recon:
- `PatreonService.TierChanged` fires on **every** launch for a live-validated patron (cache cleared then revalidated None->Level1), so the event alone can't trigger a one-shot.
- Several grant paths never raise it at all (ctor cached restore, 14-day grace window, V2-linked accounts) and SubscribeStar has its own event.

So the check re-reads the combined `App.Patreon.HasPremiumAccess`, hooks **both** providers' handlers plus a `MainWindow_Loaded` catch-all, and yields (unspent, retried next launch) to the update / What's New dialogs instead of stacking modals - including a re-check at open time inside the deferred action.

## Testing
- `dotnet build` green, 0 errors (all warnings pre-existing).
- Play-test checklist: fresh settings -> welcome then the tour actually starts; click the 5 wired tabs -> one card, rest arrive on later visits; premium account -> celebration exactly once, not again on relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXn98ZxSiTQbgyT6SMfdVd