### PR TITLE
fix(braindrain): restore Brain Drain overlay + add Brain Melt (#733)

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -670,7 +670,7 @@
   "deeper_editor_tip_bubble_intensity": "Burst rate. 0 = a trickle, 1 = a wall.",
   "deeper_editor_tip_subliminal_text": "Text to flash. Keep it short — under a second of reading.",
   "deeper_editor_tip_subliminal_duration": "How long the subliminal is visible, in milliseconds.",
-  "deeper_editor_tip_overlay_kind": "Which overlay to draw — Pink Filter, Spiral, or Brain Drain.",
+  "deeper_editor_tip_overlay_kind": "Which overlay to draw — Pink Filter, Spiral, Brain Drain, or Brain Melt.",
   "deeper_editor_tip_overlay_duration": "How long the overlay stays on screen, in milliseconds.",
   "deeper_editor_tip_overlay_opacity": "Overlay alpha. 0 = invisible, 1 = solid.",
   "deeper_editor_tip_effect_delete": "Delete this effect.",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -513,7 +513,7 @@
   "deeper_editor_tip_bubble_intensity": "爆发速率。0 = 涓涓细流，1 = 一面墙",
   "deeper_editor_tip_subliminal_text": "要闪烁的文字。保持简短——不到一秒的阅读时间",
   "deeper_editor_tip_subliminal_duration": "潜意识内容的可见时间，以毫秒为单位",
-  "deeper_editor_tip_overlay_kind": "绘制哪个覆盖层——粉色滤镜、螺旋或脑力流失",
+  "deeper_editor_tip_overlay_kind": "绘制哪个覆盖层——粉色滤镜、螺旋、脑力流失或脑力融化",
   "deeper_editor_tip_overlay_duration": "覆盖层在屏幕上停留的时间，以毫秒为单位",
   "deeper_editor_tip_overlay_opacity": "覆盖层透明度。0 = 不可见，1 = 实心",
   "deeper_editor_tip_effect_delete": "删除此效果",

--- a/ConditioningControlPanel/Models/Deeper/TimelineItem.cs
+++ b/ConditioningControlPanel/Models/Deeper/TimelineItem.cs
@@ -188,7 +188,8 @@ namespace ConditioningControlPanel.Models.Deeper
         public double EffectOpacity { get; set; } = 0.5;
 
         // Optional opacity ramp for overlay effects: interpolate opacity from
-        // start→end across the item's duration (pink_filter + spiral). Both absent
+        // start→end across the item's duration (all overlay kinds — braindrain maps
+        // the 0..1 ramp to blur intensity, see SetSustainedOverlayOpacity). Both absent
         // (old files) => flat EffectOpacity, no ramp. Additive; no schema bump.
         [JsonProperty("effect_opacity_start", NullValueHandling = NullValueHandling.Ignore)]
         public double? EffectOpacityStart { get; set; }

--- a/ConditioningControlPanel/Models/Deeper/TimelineItem.cs
+++ b/ConditioningControlPanel/Models/Deeper/TimelineItem.cs
@@ -66,6 +66,10 @@ namespace ConditioningControlPanel.Models.Deeper
         public const string PinkFilter = "pink_filter";
         public const string Spiral     = "spiral";
         public const string BrainDrain = "braindrain";
+        /// <summary>Melt variant of Brain Drain. Shares the one underlying blur overlay (and all of
+        /// its hold/ramp state) with <see cref="BrainDrain"/> — the two never co-exist. The melt warp
+        /// itself lands in Phase 2; today it behaves identically to <see cref="BrainDrain"/>.</summary>
+        public const string BrainDrainMelt = "braindrain_melt";
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -39,13 +39,14 @@ public sealed class BrainDrainLayer : BaseLayer
     private double _sourceRadius;               // WPF-BlurEffect-equivalent radius ON THE DOWNSCALED SOURCE
     // Alpha-mix axis (compositor path only). At low intensity the gaussian is a fraction of a
     // source pixel wide - i.e. nothing - so the *strength* has to come from how much of the blurred
-    // copy we paint over the real screen. Intensity 1..40 ramps the draw alpha linearly 0.35 -> 1.0
-    // (the real screen shows through underneath = a subtle haze); at 40 and above the layer is fully
-    // opaque and sigma alone carries the depth (sigma at 40 is already ~5 screen px at downscale 4).
-    // That makes perceived strength continuous across 1 -> 100 instead of "nothing, then blur".
-    // Pulse always paints at full alpha - a pulse is meant to slam.
-    private const int AlphaFullIntensity = 40;
-    private const double AlphaFloor = 0.35;
+    // copy we paint over the real screen. Intensity 1..100 ramps the draw alpha linearly 0.30 -> 0.85:
+    // the real screen ALWAYS ghosts through (owner call, 2026-07-31: the effect must stay subtle -
+    // full-opacity blur read as "basically illegible"). Sigma rises alongside, so perceived strength
+    // is continuous across 1 -> 100 while the ceiling stays a dreamy haze, not a wall.
+    // Pulse still paints at full alpha - a pulse is a deliberate 1-second slam.
+    private const int AlphaFullIntensity = 100;
+    private const double AlphaFloor = 0.30;
+    private const double AlphaCeiling = 0.85;
     private byte _drawAlpha = 255;
     // Melt variant ("braindrain_melt"): shares this layer and ALL of OverlayService's hold/ramp
     // state - a melt band and a plain blur band never co-exist by design.
@@ -128,37 +129,49 @@ public sealed class BrainDrainLayer : BaseLayer
         _melt = false;
     }
 
-    /// <summary>Normal/ramp/restore path - the legacy source-space radius is intensity*0.4/downscale
-    /// (the WPF BlurEffect radius was applied to the downscaled bitmap, so it is already
-    /// source-space; CapturePass just turns it into sigma = radius/3).</summary>
+    // Blur strength per intensity point, SOURCE px per unit. The legacy constant was 0.4 (radius
+    // parity with the pre-compositor BlurEffect); retuned to 0.14 on the 2026-07-31 subtle pass -
+    // max intensity is now sigma ~4.7 screen px at downscale 4 (a dreamy haze the screen structure
+    // survives) instead of ~13 (illegible). The legacy windowed path in OverlayService reads this
+    // same constant - keep them identical.
+    internal const double RadiusScale = 0.14;
+
+    /// <summary>Normal/ramp/restore path - a SOURCE-space radius (the pre-compositor BlurEffect
+    /// radius was applied to the downscaled bitmap; CapturePass turns it into sigma = radius/3).
+    /// Strength curve retuned subtle 2026-07-31, see <see cref="RadiusScale"/>.</summary>
     public void SetIntensity(int intensity)
     {
-        _sourceRadius = intensity * 0.4 / Math.Max(1, _downscale);
+        _sourceRadius = intensity * RadiusScale / Math.Max(1, _downscale);
         _drawAlpha = AlphaFor(intensity);
         // Melt amplitude curve (SOURCE px, quoted at downscale 4 then divided by the actual
-        // downscale so the on-screen warp is tier-independent):  amp = 2 + intensity * 0.12.
+        // downscale so the on-screen warp is tier-independent):  amp = 1 + intensity * 0.045.
         // A displacement map offsets by +/- amp/2, so on screen at x4 that is +/- 2*amp px:
-        //   intensity 30  -> amp 5.6  -> +/-11 screen px  = a gentle shimmer
-        //   intensity 60  -> amp 9.2  -> +/-18 screen px  = clearly liquid
-        //   intensity 100 -> amp 14.0 -> +/-28 screen px  = heavy dripping distortion
-        // Clamped at the legacy 200 ceiling (amp 26) so a runaway value cannot eat the frame.
-        _meltAmplitude = (float)((2.0 + Math.Clamp(intensity, 0, 200) * 0.12) * 4.0 / Math.Max(1, _downscale));
+        //   intensity 30  -> amp 2.35 -> +/-4.7 screen px  = a whisper of shimmer
+        //   intensity 60  -> amp 3.7  -> +/-7.4 screen px  = gently liquid
+        //   intensity 100 -> amp 5.5  -> +/-11 screen px   = clearly melting, still readable
+        // (Subtle retune 2026-07-31; the original 2 + i*0.12 read as "basically illegible".)
+        // Clamped at the legacy 200 ceiling (amp 10) so a runaway value cannot eat the frame.
+        _meltAmplitude = (float)((1.0 + Math.Clamp(intensity, 0, 200) * 0.045) * 4.0 / Math.Max(1, _downscale));
     }
 
-    /// <summary>Pulse boost - legacy PulseOverlays sets the raw radius boosted*0.4 with NO
-    /// downscale divide (deliberately much heavier than the steady state), at full opacity.</summary>
+    /// <summary>Pulse boost - a deliberate 1-second slam: full draw alpha and the boosted radius
+    /// WITHOUT the downscale divide was the legacy behavior, but post subtle-retune that would be
+    /// a white-out (sigma ~9 SOURCE px). The pulse now keeps the divide and simply rides the
+    /// boosted (2x, capped 200) intensity: ~2x the steady sigma at full alpha - still a clear kick
+    /// against an 0.85-alpha steady state.</summary>
     public void Pulse(int boostedIntensity)
     {
-        _sourceRadius = boostedIntensity * 0.4;
+        _sourceRadius = boostedIntensity * RadiusScale / Math.Max(1, _downscale);
         _drawAlpha = 255;
     }
 
-    /// <summary>Draw alpha for an intensity: 0.35 at 1, linear to fully opaque at
-    /// <see cref="AlphaFullIntensity"/> and above. See the field comment for why.</summary>
+    /// <summary>Draw alpha for an intensity: <see cref="AlphaFloor"/> at 1, linear to
+    /// <see cref="AlphaCeiling"/> at <see cref="AlphaFullIntensity"/> and above - never fully
+    /// opaque. See the field comment for why.</summary>
     private static byte AlphaFor(int intensity)
     {
         int i = Math.Clamp(intensity, 1, AlphaFullIntensity);
-        double a = AlphaFloor + (1.0 - AlphaFloor) * (i - 1) / (AlphaFullIntensity - 1.0);
+        double a = AlphaFloor + (AlphaCeiling - AlphaFloor) * (i - 1) / (AlphaFullIntensity - 1.0);
         return (byte)Math.Clamp(Math.Round(a * 255.0), 0, 255);
     }
 

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -8,8 +8,11 @@ namespace ConditioningControlPanel.Services.Compositor;
 /// screen into a persistent DIB section (1/downscale size), the small frame is blurred ONCE per
 /// capture tick on a small raster surface, and Render just upscales the blurred image over the
 /// monitor - the upscale is part of the blur, exactly like the legacy Image Stretch=Fill path.
-/// Blur radius parity with the legacy WPF BlurEffect: an on-screen radius R renders here as a
-/// source-space gaussian of sigma R/(3*downscale) applied before the xdownscale upscale.
+/// Blur radius parity with the legacy WPF BlurEffect: the legacy path set BlurEffect.Radius on the
+/// ALREADY-DOWNSCALED bitmap, so the radius SetIntensity stores is a SOURCE-space radius - the
+/// gaussian applied here is simply sigma = radius/3 (WPF's radius-to-sigma ratio), and the
+/// xdownscale upscale that follows widens it on screen exactly as it did for the legacy Image.
+/// A second /downscale here would be double-counting (it was, and it made every blur invisible).
 /// Renders on the capture-EXCLUDED surface (self-capture guard); plain SRCCOPY StretchBlt also
 /// skips layered windows entirely, so other overlays never feed back into the blur (legacy same).
 /// OverlayService owns all intensity/ramp/pulse math and pushes values; this layer only
@@ -33,7 +36,21 @@ public sealed class BrainDrainLayer : BaseLayer
     private float _lastSigma = -1f;
 
     private int _downscale = 4;
-    private double _screenRadius;               // WPF-BlurEffect-equivalent on-screen radius
+    private double _sourceRadius;               // WPF-BlurEffect-equivalent radius ON THE DOWNSCALED SOURCE
+    // Alpha-mix axis (compositor path only). At low intensity the gaussian is a fraction of a
+    // source pixel wide - i.e. nothing - so the *strength* has to come from how much of the blurred
+    // copy we paint over the real screen. Intensity 1..40 ramps the draw alpha linearly 0.35 -> 1.0
+    // (the real screen shows through underneath = a subtle haze); at 40 and above the layer is fully
+    // opaque and sigma alone carries the depth (sigma at 40 is already ~5 screen px at downscale 4).
+    // That makes perceived strength continuous across 1 -> 100 instead of "nothing, then blur".
+    // Pulse always paints at full alpha - a pulse is meant to slam.
+    private const int AlphaFullIntensity = 40;
+    private const double AlphaFloor = 0.35;
+    private byte _drawAlpha = 255;
+    // Melt variant ("braindrain_melt"): shares this layer and ALL of OverlayService's hold/ramp
+    // state - a melt band and a plain blur band never co-exist by design.
+    // TODO: melt warp rendered in Phase 2.
+    private bool _melt;
     private TimeSpan _captureInterval = TimeSpan.FromMilliseconds(33);
     private TimeSpan _sinceCapture;
 
@@ -48,9 +65,12 @@ public sealed class BrainDrainLayer : BaseLayer
     public override bool ExcludeFromCapture => true;
     public override bool WorldSpacePx => true;
 
-    /// <summary>Start capturing + blurring at the given intensity (legacy 1..200 scale).</summary>
-    public void Start(int intensity)
+    /// <summary>Start capturing + blurring at the given intensity (legacy 1..200 scale).
+    /// <paramref name="melt"/> selects the "braindrain_melt" variant (visuals land in Phase 2;
+    /// for now it renders identically to the plain blur).</summary>
+    public void Start(int intensity, bool melt = false)
     {
+        _melt = melt;
         var settings = App.Settings?.Current;
         var tier = PerformanceProfile.CurrentTier;
         _downscale = PerformanceProfile.BrainDrainDownscale(tier);
@@ -68,15 +88,34 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         SetActive(false);
         ReleaseCaptures();
+        _melt = false;
     }
 
-    /// <summary>Normal/ramp/restore path - legacy on-screen radius is intensity*0.4/downscale
-    /// (the WPF BlurEffect radius was tuned against the downscaled source).</summary>
-    public void SetIntensity(int intensity) => _screenRadius = intensity * 0.4 / Math.Max(1, _downscale);
+    /// <summary>Normal/ramp/restore path - the legacy source-space radius is intensity*0.4/downscale
+    /// (the WPF BlurEffect radius was applied to the downscaled bitmap, so it is already
+    /// source-space; CapturePass just turns it into sigma = radius/3).</summary>
+    public void SetIntensity(int intensity)
+    {
+        _sourceRadius = intensity * 0.4 / Math.Max(1, _downscale);
+        _drawAlpha = AlphaFor(intensity);
+    }
 
     /// <summary>Pulse boost - legacy PulseOverlays sets the raw radius boosted*0.4 with NO
-    /// downscale divide (deliberately much heavier than the steady state).</summary>
-    public void Pulse(int boostedIntensity) => _screenRadius = boostedIntensity * 0.4;
+    /// downscale divide (deliberately much heavier than the steady state), at full opacity.</summary>
+    public void Pulse(int boostedIntensity)
+    {
+        _sourceRadius = boostedIntensity * 0.4;
+        _drawAlpha = 255;
+    }
+
+    /// <summary>Draw alpha for an intensity: 0.35 at 1, linear to fully opaque at
+    /// <see cref="AlphaFullIntensity"/> and above. See the field comment for why.</summary>
+    private static byte AlphaFor(int intensity)
+    {
+        int i = Math.Clamp(intensity, 1, AlphaFullIntensity);
+        double a = AlphaFloor + (1.0 - AlphaFloor) * (i - 1) / (AlphaFullIntensity - 1.0);
+        return (byte)Math.Clamp(Math.Round(a * 255.0), 0, 255);
+    }
 
     public override void OnDeactivated() => ReleaseCaptures();
 
@@ -106,6 +145,10 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         // World-space: boundsPx is this monitor's rect; draw only its own capture.
         int cx = (boundsPx.Left + boundsPx.Right) / 2, cy = (boundsPx.Top + boundsPx.Bottom) / 2;
+        // Alpha mix: white-with-alpha modulates the image draw (RGB is ignored for DrawImage).
+        // Set per frame - Render, SetIntensity and Pulse are all on the UI thread, so this can
+        // never read a half-written value, and it keeps the ramp path free of paint bookkeeping.
+        _drawPaint.Color = SKColors.White.WithAlpha(_drawAlpha);
         foreach (var c in _captures)
         {
             if (c.Blurred == null || !c.Bounds.Contains(cx, cy)) continue;
@@ -197,8 +240,10 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         if (_captures.Count == 0) return;
 
-        // Rebuild the blur filter only when the radius actually changed.
-        float sigma = (float)(_screenRadius / (3.0 * Math.Max(1, _downscale)));
+        // Rebuild the blur filter only when the radius actually changed. _sourceRadius is ALREADY
+        // source-space (see SetIntensity) - dividing by _downscale again here is what made every
+        // steady-state blur invisible (max intensity landed at sigma ~0.83px, 1..6 at literally zero).
+        float sigma = (float)(_sourceRadius / 3.0);
         if (Math.Abs(sigma - _lastSigma) > 0.01f)
         {
             _lastSigma = sigma;

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -49,8 +49,44 @@ public sealed class BrainDrainLayer : BaseLayer
     private byte _drawAlpha = 255;
     // Melt variant ("braindrain_melt"): shares this layer and ALL of OverlayService's hold/ramp
     // state - a melt band and a plain blur band never co-exist by design.
-    // TODO: melt warp rendered in Phase 2.
+    // Melt = the same blur PLUS a slowly-flowing Perlin displacement warp ("melting glass"),
+    // composed into ONE filter chain on the existing small-surface draw in CapturePass. It never
+    // touches Render: warping at monitor resolution on a CPU raster surface is not affordable, and
+    // the capture cadence (30fps default) is smooth enough for a drift this slow.
     private bool _melt;
+    private float _meltTime;                    // seconds since Start, accumulated from Update's delta
+    private float _meltAmplitude;               // displacement scale, SOURCE px (see SetIntensity)
+    private SKImage? _meltNoiseTile;            // pre-rendered tileable turbulence (see EnsureNoiseTile)
+    private float _meltTileCoverage;            // surface px one tile spans
+    private int _meltNoiseShort = -1;           // short edge the cached tile was sized for
+    private SKPaint? _meltNoisePaint;           // carrier for the per-tick drifted noise shader
+    private SKPaint? _meltPaint;                // carrier for the per-tick displacement+blur chain
+
+    // Noise field. Turbulence cells are sized off the SMALL surface's short edge so the look holds
+    // across monitor sizes and performance tiers: one cell = 20% of the short edge (inside the
+    // 1/8..1/4 target), with the vertical frequency lowered so cells are ~1.5x taller than wide -
+    // that elongation is what reads as "dripping" rather than "boiling". 2 octaves; fixed seed so
+    // the pattern is reproducible run to run.
+    // Skia's RASTER Perlin shader is far too slow to evaluate per frame (2 octaves x 4 channels of
+    // scalar lattice noise per pixel measured 24ms/tick at 480x270 and 98ms at 960x540 - i.e. a
+    // whole core at the 30fps capture cadence). So the turbulence is rasterised ONCE into a small
+    // TILEABLE image and animated per tick by an image shader in Repeat mode; that is a SIMD
+    // bilinear fetch instead of noise evaluation and costs ~1.5ms at 480x270. The tile spans 12
+    // cells so its repeat period is wider than the frame - no visible tiling - and it is stored at
+    // a fixed 256px raster, upscaled bilinearly, which is lossless in practice because the smallest
+    // feature (the 2nd octave) is still ~10 tile px across.
+    private const float NoiseCellFraction = 0.20f;
+    private const float NoiseCellAspect = 0.65f; // freqY = freqX * this  =>  taller cells
+    private const int NoiseOctaves = 2;
+    private const float NoiseSeed = 7f;
+    private const int NoiseTilePx = 256;
+    private const float NoiseCellsPerTile = 12f;
+    // Drift, expressed at downscale 4 and divided by the actual downscale so the on-SCREEN flow
+    // speed is tier-independent: 6 source px/s downward (= 24 screen px/s at x4) plus a 2.5 px
+    // sinusoidal sway on a ~11s period. Melting is mostly gravity with a little wander.
+    private const float MeltDriftPxPerSec = 6f;
+    private const float MeltSwayPx = 2.5f;
+    private const float MeltSwayRate = 0.55f;    // rad/s
     private TimeSpan _captureInterval = TimeSpan.FromMilliseconds(33);
     private TimeSpan _sinceCapture;
 
@@ -66,11 +102,12 @@ public sealed class BrainDrainLayer : BaseLayer
     public override bool WorldSpacePx => true;
 
     /// <summary>Start capturing + blurring at the given intensity (legacy 1..200 scale).
-    /// <paramref name="melt"/> selects the "braindrain_melt" variant (visuals land in Phase 2;
-    /// for now it renders identically to the plain blur).</summary>
+    /// <paramref name="melt"/> selects the "braindrain_melt" variant - same blur plus an animated
+    /// Perlin displacement warp.</summary>
     public void Start(int intensity, bool melt = false)
     {
         _melt = melt;
+        _meltTime = 0f;
         var settings = App.Settings?.Current;
         var tier = PerformanceProfile.CurrentTier;
         _downscale = PerformanceProfile.BrainDrainDownscale(tier);
@@ -98,6 +135,14 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         _sourceRadius = intensity * 0.4 / Math.Max(1, _downscale);
         _drawAlpha = AlphaFor(intensity);
+        // Melt amplitude curve (SOURCE px, quoted at downscale 4 then divided by the actual
+        // downscale so the on-screen warp is tier-independent):  amp = 2 + intensity * 0.12.
+        // A displacement map offsets by +/- amp/2, so on screen at x4 that is +/- 2*amp px:
+        //   intensity 30  -> amp 5.6  -> +/-11 screen px  = a gentle shimmer
+        //   intensity 60  -> amp 9.2  -> +/-18 screen px  = clearly liquid
+        //   intensity 100 -> amp 14.0 -> +/-28 screen px  = heavy dripping distortion
+        // Clamped at the legacy 200 ceiling (amp 26) so a runaway value cannot eat the frame.
+        _meltAmplitude = (float)((2.0 + Math.Clamp(intensity, 0, 200) * 0.12) * 4.0 / Math.Max(1, _downscale));
     }
 
     /// <summary>Pulse boost - legacy PulseOverlays sets the raw radius boosted*0.4 with NO
@@ -123,6 +168,9 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         _sinceCapture += delta;
         _sinceDriftCheck += delta;
+        // Wall-clock melt phase: accumulated every tick (not only on capture ticks) so the flow
+        // speed is independent of the capture cadence. No DateTime.Now - the engine owns the clock.
+        if (_melt) _meltTime += (float)delta.TotalSeconds;
         if (_sinceCapture < _captureInterval) return;
         _sinceCapture = TimeSpan.Zero;
 
@@ -252,34 +300,137 @@ public sealed class BrainDrainLayer : BaseLayer
             _blurPaint.ImageFilter = _blurFilter;
         }
 
-        var screenDc = GetDC(IntPtr.Zero);
-        if (screenDc == IntPtr.Zero) return;
+        // Melt: compose displacement + blur into ONE chain. Only the cheap wrappers around the
+        // cached noise tile (the drifted image shader and the two filters that carry it) are
+        // rebuilt per tick; the turbulence raster itself is built once per capture size.
+        SKShader? drift = null;
+        SKImageFilter? noiseFilter = null, meltFilter = null;
+        float gutter = 0f;
+        if (_melt && _meltAmplitude > 0.05f)
+        {
+            var tile = EnsureNoiseTile();
+            if (tile != null)
+            {
+                float tierScale = 4f / Math.Max(1, _downscale);
+                // Wrapped into one tile period: the pattern repeats there anyway, and it keeps the
+                // float drift from growing without bound over a long session.
+                float dx = MeltSwayPx * tierScale * MathF.Sin(_meltTime * MeltSwayRate);
+                float dy = (MeltDriftPxPerSec * tierScale * _meltTime) % _meltTileCoverage;
+                float s = _meltTileCoverage / NoiseTilePx;
+                drift = SKShader.CreateImage(tile, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+                                             SKMatrix.CreateScaleTranslation(s, s, dx, dy));
+                // Bilinear: a nearest-sampled noise tile would quantise the warp into visible blocks.
+                (_meltNoisePaint ??= new SKPaint { FilterQuality = SKFilterQuality.Low }).Shader = drift;
+                noiseFilter = SKImageFilter.CreatePaint(_meltNoisePaint);
+                if (noiseFilter != null)
+                {
+                    // input: _blurFilter (may be null at low intensity, where sigma is sub-pixel -
+                    // the warp still applies, it just warps the unblurred capture).
+                    meltFilter = SKImageFilter.CreateDisplacementMapEffect(
+                        SKColorChannel.R, SKColorChannel.G, _meltAmplitude, noiseFilter, _blurFilter);
+                    (_meltPaint ??= new SKPaint()).ImageFilter = meltFilter;
+                    // Displacement samples outside the source bleed transparent along the frame
+                    // edges. Max |offset| is amplitude/2 (the map is centred on 0.5), +2px slack
+                    // for the CTM scale below feeding back into the mapped displacement scale.
+                    gutter = _meltAmplitude * 0.5f + 2f;
+                }
+            }
+        }
+
         try
         {
-            foreach (var c in _captures)
+            var screenDc = GetDC(IntPtr.Zero);
+            if (screenDc == IntPtr.Zero) return;
+            try
             {
-                if (c.Surface == null) continue;
-                SetStretchBltMode(c.MemDc, HALFTONE);
-                if (!StretchBlt(c.MemDc, 0, 0, c.W, c.H,
-                                screenDc, c.Bounds.X, c.Bounds.Y, c.Bounds.Width, c.Bounds.Height, SRCCOPY))
-                    continue;
-                GdiFlush();
+                foreach (var c in _captures)
+                {
+                    if (c.Surface == null) continue;
+                    SetStretchBltMode(c.MemDc, HALFTONE);
+                    if (!StretchBlt(c.MemDc, 0, 0, c.W, c.H,
+                                    screenDc, c.Bounds.X, c.Bounds.Y, c.Bounds.Width, c.Bounds.Height, SRCCOPY))
+                        continue;
+                    GdiFlush();
 
-                var info = new SKImageInfo(c.W, c.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
-                using var raw = SKImage.FromPixels(info, c.Bits, c.W * 4); // zero-copy wrap; consumed synchronously below
-                if (raw == null) continue;
+                    var info = new SKImageInfo(c.W, c.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
+                    using var raw = SKImage.FromPixels(info, c.Bits, c.W * 4); // zero-copy wrap; consumed synchronously below
+                    if (raw == null) continue;
 
-                var canvas = c.Surface.Canvas;
-                canvas.Clear(SKColors.Transparent);
-                canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
-                c.Blurred?.Dispose();
-                c.Blurred = c.Surface.Snapshot();
+                    var canvas = c.Surface.Canvas;
+                    canvas.Clear(SKColors.Transparent);
+                    if (meltFilter != null)
+                    {
+                        // Scale about the centre so the gutter falls off-frame entirely.
+                        canvas.Save();
+                        canvas.Translate(c.W * 0.5f, c.H * 0.5f);
+                        canvas.Scale((c.W + 2f * gutter) / c.W, (c.H + 2f * gutter) / c.H);
+                        canvas.Translate(-c.W * 0.5f, -c.H * 0.5f);
+                        canvas.DrawImage(raw, 0, 0, _meltPaint);
+                        canvas.Restore();
+                    }
+                    else
+                    {
+                        canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
+                    }
+                    c.Blurred?.Dispose();
+                    c.Blurred = c.Surface.Snapshot();
+                }
+            }
+            finally
+            {
+                ReleaseDC(IntPtr.Zero, screenDc);
             }
         }
         finally
         {
-            ReleaseDC(IntPtr.Zero, screenDc);
+            // Drop the per-tick wrappers the same tick they were made (the carrier paints and the
+            // turbulence tile are the only melt state that survives to the next capture).
+            if (_meltPaint != null) _meltPaint.ImageFilter = null;
+            if (_meltNoisePaint != null) _meltNoisePaint.Shader = null;
+            meltFilter?.Dispose();
+            noiseFilter?.Dispose();
+            drift?.Dispose();
         }
+    }
+
+    /// <summary>Rasterises the tileable turbulence field for the melt warp, sized off the first
+    /// capture's short edge. Rebuilt only when that size changes (downscale change / monitor swap);
+    /// costs ~14ms once, versus ~24ms EVERY tick if the Perlin shader were evaluated live.</summary>
+    private SKImage? EnsureNoiseTile()
+    {
+        if (_captures.Count == 0) return null;
+        int shortEdge = Math.Min(_captures[0].W, _captures[0].H);
+        if (_meltNoiseTile != null && _meltNoiseShort == shortEdge) return _meltNoiseTile;
+
+        _meltNoiseTile?.Dispose();
+        _meltNoiseTile = null;
+        _meltNoiseShort = shortEdge;
+        // One cell = NoiseCellFraction of the short edge, NoiseCellsPerTile cells to a tile.
+        _meltTileCoverage = Math.Max(8f, shortEdge * NoiseCellFraction) * NoiseCellsPerTile;
+        float freq = NoiseCellsPerTile / NoiseTilePx; // cycles per TILE px - Skia snaps it to tile
+        using var noise = SKShader.CreatePerlinNoiseTurbulence(
+            freq, freq * NoiseCellAspect, NoiseOctaves, NoiseSeed, new SKSizeI(NoiseTilePx, NoiseTilePx));
+        using var surface = SKSurface.Create(
+            new SKImageInfo(NoiseTilePx, NoiseTilePx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        if (surface == null) return null;
+        using var paint = new SKPaint { Shader = noise };
+        surface.Canvas.Clear(SKColors.Transparent);
+        surface.Canvas.DrawRect(0, 0, NoiseTilePx, NoiseTilePx, paint);
+        _meltNoiseTile = surface.Snapshot();
+        return _meltNoiseTile;
+    }
+
+    private void ReleaseMelt()
+    {
+        if (_meltPaint != null) _meltPaint.ImageFilter = null;
+        if (_meltNoisePaint != null) _meltNoisePaint.Shader = null;
+        _meltPaint?.Dispose();
+        _meltPaint = null;
+        _meltNoisePaint?.Dispose();
+        _meltNoisePaint = null;
+        _meltNoiseTile?.Dispose();
+        _meltNoiseTile = null;
+        _meltNoiseShort = -1;
     }
 
     private void ReleaseCaptures()
@@ -300,6 +451,7 @@ public sealed class BrainDrainLayer : BaseLayer
             catch { /* GDI cleanup best-effort */ }
         }
         _captures.Clear();
+        ReleaseMelt();
     }
 
     #region Win32

--- a/ConditioningControlPanel/Services/Deeper/EnhancementValidator.cs
+++ b/ConditioningControlPanel/Services/Deeper/EnhancementValidator.cs
@@ -185,7 +185,8 @@ namespace ConditioningControlPanel.Services.Deeper
                 case EffectTypes.Overlay:
                     if (item.EffectOverlayKind != OverlayKinds.PinkFilter
                         && item.EffectOverlayKind != OverlayKinds.Spiral
-                        && item.EffectOverlayKind != OverlayKinds.BrainDrain)
+                        && item.EffectOverlayKind != OverlayKinds.BrainDrain
+                        && item.EffectOverlayKind != OverlayKinds.BrainDrainMelt)
                     {
                         errors.Add(new ValidationError { Path = path, Message = $"Unknown overlay kind \"{item.EffectOverlayKind}\"." });
                     }
@@ -764,7 +765,8 @@ namespace ConditioningControlPanel.Services.Deeper
                     {
                         if (te.OverlayKind != OverlayKinds.PinkFilter
                             && te.OverlayKind != OverlayKinds.Spiral
-                            && te.OverlayKind != OverlayKinds.BrainDrain)
+                            && te.OverlayKind != OverlayKinds.BrainDrain
+                            && te.OverlayKind != OverlayKinds.BrainDrainMelt)
                         {
                             errors.Add(new ValidationError { Path = path, Message = $"Unknown overlay kind \"{te.OverlayKind}\"." });
                         }

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -496,7 +496,9 @@ public class OverlayService : IDisposable
             if (hasBrainDrain)
             {
                 var boostedIntensity = Math.Min(_currentBrainDrainIntensity * 2, 200);
-                double blurRadius = boostedIntensity * 0.4;
+                // Subtle retune 2026-07-31: pulse keeps the downscale divide now (the old raw
+                // boosted*0.4 radius would white-out against the retuned steady state).
+                double blurRadius = boostedIntensity * Compositor.BrainDrainLayer.RadiusScale / Math.Max(1, _brainDrainDownscale);
                 if (_brainDrainLayer?.IsActive == true)
                     _brainDrainLayer.Pulse(boostedIntensity);
                 foreach (var img in _brainDrainImages.Values)
@@ -2004,7 +2006,7 @@ public class OverlayService : IDisposable
     {
         _currentBrainDrainIntensity = intensity;
         // Keep in sync with CreateBrainDrainWindow's downscaled-source radius.
-        double blurRadius = (intensity * 0.4) / Math.Max(1, _brainDrainDownscale);
+        double blurRadius = (intensity * Compositor.BrainDrainLayer.RadiusScale) / Math.Max(1, _brainDrainDownscale);
 
         DispatcherHelper.RunOnUISync(() =>
         {
@@ -2140,7 +2142,8 @@ public class OverlayService : IDisposable
             var wpfBounds = GetWpfScreenBounds(screen);
             // The source bitmap is 1/divisor size and gets upscaled by Stretch=Fill, so a
             // proportionally smaller blur radius yields the same on-screen blur far more cheaply.
-            double blurRadius = (intensity * 0.4) / Math.Max(1, _brainDrainDownscale);
+            // Strength constant shared with the compositor layer (subtle retune 2026-07-31).
+            double blurRadius = (intensity * Compositor.BrainDrainLayer.RadiusScale) / Math.Max(1, _brainDrainDownscale);
 
             var image = new System.Windows.Controls.Image
             {

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -26,6 +26,12 @@ public class OverlayService : IDisposable
     // because the persistent feature is off. Decremented when the timed overlay's hide fires.
     private int _timedPinkHolds;
     private int _timedSpiralHolds;
+    // Brain Drain needs the SAME guards, and needs them harder: the base feature is disabled for
+    // rework, so settings.BrainDrainEnabled is false for everyone — which meant RefreshBrainDrainState
+    // tore a live Deeper braindrain band down on the next RefreshOverlays() (autonomy, remote control,
+    // or the user toggling pink/spiral on the dashboard all call it). Shared by "braindrain" and
+    // "braindrain_melt": they are ONE underlying overlay, never co-active.
+    private int _timedBrainDrainHolds;
     // Sustained holds: an overlay shown via ShowOverlaySustained (voice "go pink"/"spiral", Deeper
     // region bands) has no hide timer, so — like the timed holds above — the periodic reconcilers
     // (RefreshOverlays / UpdateOverlays) must NOT tear it down just because the persistent feature
@@ -33,6 +39,16 @@ public class OverlayService : IDisposable
     // early-return on a non-empty window list), so a repeat show + single hide must still release it.
     private bool _sustainedPinkHeld;
     private bool _sustainedSpiralHeld;
+    private bool _sustainedBrainDrainHeld;
+
+    /// <summary>
+    /// Pure teardown decision for an overlay that ad-hoc callers can hold open: tear it down only
+    /// when the persistent feature doesn't want it AND nothing ad-hoc is still holding it (a timed
+    /// overlay in flight, or a sustained Deeper band). Extracted (like ResolveZOrderAction) so the
+    /// guard the 500ms reconcilers depend on is unit-testable.
+    /// </summary>
+    internal static bool ShouldStopHeldOverlay(bool featureWantsIt, int timedHolds, bool sustainedHeld)
+        => !featureWantsIt && timedHolds == 0 && !sustainedHeld;
 
     // Deeper enhancement overlay bands are the ONE case where an overlay must sit ABOVE a playing
     // mandatory video: the pink/spiral tint IS the enhanced video's effect (pre-compositor it was a
@@ -688,9 +704,10 @@ public class OverlayService : IDisposable
 
         Action? show = kind switch
         {
-            "pink_filter" => () => ShowPinkFilterAdHoc(opacityPercent),
-            "spiral"      => () => ShowSpiralAdHoc(),
-            "braindrain"  => () => StartBrainDrainBlur(Math.Max(1, opacityPercent)),
+            "pink_filter"     => () => ShowPinkFilterAdHoc(opacityPercent),
+            "spiral"          => () => ShowSpiralAdHoc(),
+            "braindrain"      => () => StartBrainDrainBlur(Math.Max(1, opacityPercent)),
+            "braindrain_melt" => () => StartBrainDrainBlur(Math.Max(1, opacityPercent), melt: true),
             _ => null
         };
 
@@ -698,7 +715,8 @@ public class OverlayService : IDisposable
         {
             "pink_filter" => () => StopPinkFilter(),
             "spiral"      => () => StopSpiral(),
-            "braindrain"  => () => StopBrainDrainBlur(),
+            // Melt and plain braindrain are the same underlying overlay - one stop covers both.
+            "braindrain" or "braindrain_melt" => () => StopBrainDrainBlur(),
             _ => null
         };
 
@@ -743,7 +761,16 @@ public class OverlayService : IDisposable
                     }
                     else show();
                 }
-                else show();
+                else
+                {
+                    // braindrain / braindrain_melt: same hold counter (one underlying overlay).
+                    // StartBrainDrainBlur early-returns when it's already showing, so a second
+                    // timed effect just rides the live blur - the counter keeps it alive until the
+                    // LAST hide fires. No #573-style opacity bump here: braindrain's strength is a
+                    // blur radius, not an alpha, and it has no bump/restore machinery.
+                    _timedBrainDrainHolds++;
+                    show();
+                }
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlayTimed show: {E}", ex.Message); }
         };
@@ -804,9 +831,16 @@ public class OverlayService : IDisposable
                         if (!settings.SpiralEnabled) hide();
                     }
                 }
-                else // braindrain: don't tear down the user's base Brain Drain when a timed effect ends
+                else // braindrain / braindrain_melt
                 {
-                    if (!settings.BrainDrainEnabled) hide();
+                    // Same release discipline as pink/spiral: drop this hold, and only tear the blur
+                    // down when nothing else owns it - another timed effect, a sustained Deeper band,
+                    // or the user's base Brain Drain feature. Before the counter existed this branch
+                    // only checked the setting, so the first timed effect to end killed a co-active
+                    // band (the setting is false for everyone while the feature is reworked).
+                    if (_timedBrainDrainHolds > 0) _timedBrainDrainHolds--;
+                    if (ShouldStopHeldOverlay(settings.BrainDrainEnabled, _timedBrainDrainHolds, _sustainedBrainDrainHeld))
+                        hide();
                 }
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlayTimed hide: {E}", ex.Message); }
@@ -830,9 +864,10 @@ public class OverlayService : IDisposable
 
         Action? show = kind switch
         {
-            "pink_filter" => () => ShowPinkFilterAdHoc(opacityPercent),
-            "spiral"      => () => ShowSpiralAdHoc(),
-            "braindrain"  => () => StartBrainDrainBlur(Math.Max(1, opacityPercent)),
+            "pink_filter"     => () => ShowPinkFilterAdHoc(opacityPercent),
+            "spiral"          => () => ShowSpiralAdHoc(),
+            "braindrain"      => () => StartBrainDrainBlur(Math.Max(1, opacityPercent)),
+            "braindrain_melt" => () => StartBrainDrainBlur(Math.Max(1, opacityPercent), melt: true),
             _ => null
         };
 
@@ -860,6 +895,10 @@ public class OverlayService : IDisposable
                 // clears it on band exit, so the lifecycle stays symmetric.
                 if (kind == "pink_filter") { _sustainedPinkHeld = PinkShowing; if (PinkShowing) _rampPinkOpacity = opacity; }
                 else if (kind == "spiral") { _sustainedSpiralHeld = SpiralShowing; if (SpiralShowing) _rampSpiralOpacity = opacity; }
+                // braindrain / braindrain_melt share the one hold + ramp (never co-active). Gated on
+                // BrainDrainShowing for the same reason: a show() that no-oped (compositor host gone,
+                // GDI failure) must not leave a stale hold blocking a later legitimate teardown.
+                else { _sustainedBrainDrainHeld = BrainDrainShowing; if (BrainDrainShowing) _rampBrainDrainOpacity = opacity; }
             }
             catch (Exception ex) { App.Logger?.Debug("ShowOverlaySustained show: {E}", ex.Message); }
         };
@@ -891,9 +930,16 @@ public class OverlayService : IDisposable
             "pink_filter" => () => { _sustainedPinkHeld = false; _rampPinkOpacity = null; _lastAppliedPinkOpacity = -1; if (_timedPinkHolds == 0 && !settings.PinkFilterEnabled) StopPinkFilter(); },
             "spiral"      => () => { _sustainedSpiralHeld = false; _rampSpiralOpacity = null; _lastAppliedSpiralOpacity = -1; if (_timedSpiralHolds == 0 && !settings.SpiralEnabled) StopSpiral(); },
             // Guard braindrain the same way as pink/spiral: a Deeper band exit must not tear down
-            // the user's base Brain Drain feature. Clear ramp ownership, then only stop when the
-            // base feature is off (else RefreshBrainDrainState keeps it alive). (#563 consistency)
-            "braindrain"  => () => { _rampBrainDrainOpacity = null; if (!settings.BrainDrainEnabled) StopBrainDrainBlur(); },
+            // the user's base Brain Drain feature, NOR a timed braindrain effect that is still in
+            // flight. Clear ramp ownership + the sustained hold, then stop only when nothing else
+            // owns the blur. (#563 consistency)
+            "braindrain" or "braindrain_melt" => () =>
+            {
+                _sustainedBrainDrainHeld = false;
+                _rampBrainDrainOpacity = null;
+                if (ShouldStopHeldOverlay(settings.BrainDrainEnabled, _timedBrainDrainHolds, _sustainedBrainDrainHeld))
+                    StopBrainDrainBlur();
+            },
             _ => null
         };
 
@@ -937,6 +983,7 @@ public class OverlayService : IDisposable
                         ApplySpiralOpacityDirect(opacity);
                         break;
                     case "braindrain":
+                    case "braindrain_melt":   // same underlying overlay, same ramp
                         // Brain Drain ramps via blur-intensity, not alpha. Map the normalized
                         // 0..1 ramp to an intensity the same way the band's start action does
                         // (StartBrainDrainBlur uses opacity*100), so 0→max actually deepens the blur.
@@ -1841,7 +1888,11 @@ public class OverlayService : IDisposable
     private IntPtr _captureMemDc;
     private IntPtr _captureHBitmap;
 
-    public void StartBrainDrainBlur(int intensity)
+    /// <summary><paramref name="melt"/> selects the "braindrain_melt" variant. Melt and plain blur
+    /// are ONE overlay - they never co-exist by design - so the flag only picks the render mode on
+    /// the compositor layer (Phase 2; today it renders identically). The legacy per-screen-window
+    /// path ignores it.</summary>
+    public void StartBrainDrainBlur(int intensity, bool melt = false)
     {
         if (BrainDrainShowing) return;
 
@@ -1855,8 +1906,8 @@ public class OverlayService : IDisposable
                 {
                     // Compositor route: capture + blur render on the shared capture-excluded
                     // host; no per-screen layered windows, no WPF BlurEffect rasterization.
-                    GetBrainDrainLayer().Start(intensity);
-                    App.Logger?.Information("Brain Drain started on compositor layer, intensity {Intensity}%", intensity);
+                    GetBrainDrainLayer().Start(intensity, melt);
+                    App.Logger?.Information("Brain Drain started on compositor layer, intensity {Intensity}%, melt {Melt}", intensity, melt);
                     return;
                 }
 
@@ -1908,6 +1959,7 @@ public class OverlayService : IDisposable
         try
         {
             _rampBrainDrainOpacity = null; // release any Deeper ramp ownership
+            _sustainedBrainDrainHeld = false; // overlay is gone (incl. force-stop / panic) — drop any stale sustained hold
 
             // Layer route (checked by activity, not the flag - mid-run flag flips must not strand it).
             if (_brainDrainLayer?.IsActive == true)
@@ -2777,7 +2829,9 @@ public class OverlayService : IDisposable
     {
         var settings = App.Settings.Current;
 
-        // Only start/update brain drain if the overlay service is running (engine is active)
+        // Only start/update brain drain if the overlay service is running (engine is active).
+        // Unconditional stop: this is a full teardown (service not running), same as Stop()/panic —
+        // StopBrainDrainBlur clears the sustained hold so nothing stale survives it.
         if (!_isRunning)
         {
             // Don't start brain drain if engine isn't running
@@ -2785,7 +2839,8 @@ public class OverlayService : IDisposable
             return;
         }
 
-        if (settings.BrainDrainEnabled && settings.IsLevelUnlocked(70)) // Level 70 requirement for Brain Drain
+        bool featureWantsIt = settings.BrainDrainEnabled && settings.IsLevelUnlocked(70); // Level 70 requirement for Brain Drain
+        if (featureWantsIt)
         {
             if (!BrainDrainShowing)
             {
@@ -2797,7 +2852,12 @@ public class OverlayService : IDisposable
                 UpdateBrainDrainBlurOpacity((int)settings.BrainDrainIntensity);
             }
         }
-        else
+        // The base feature being off is NOT permission to kill an ad-hoc blur: a timed effect or a
+        // sustained Deeper band owns it until its own hide fires. Without this guard every
+        // RefreshOverlays() (autonomy, remote control, the user toggling pink/spiral) silently
+        // killed a live Deeper braindrain band mid-video, since the base feature is off for everyone
+        // while it's being reworked. Same discipline as pink/spiral in RefreshOverlays.
+        else if (ShouldStopHeldOverlay(featureWantsIt, _timedBrainDrainHolds, _sustainedBrainDrainHeld))
         {
             StopBrainDrainBlur();
         }

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -999,17 +999,20 @@ public class OverlayService : IDisposable
     }
 
     /// <summary>
-    /// Releases the pink/spiral ramp holds set by <see cref="SetSustainedOverlayOpacity"/>
+    /// Releases the pink/spiral/braindrain ramp holds set by <see cref="SetSustainedOverlayOpacity"/>
     /// WITHOUT tearing the overlays down. Called when a session ends but the overlays may
     /// legitimately stay up (the user had them enabled before the session): the 500ms
     /// settings-sync takes ownership again on its next tick and re-applies the user's
-    /// saved opacity. Stop/panic paths don't need this — StopPinkFilter/StopSpiral
-    /// already clear the holds.
+    /// saved opacity. Stop/panic paths don't need this — StopPinkFilter/StopSpiral/
+    /// StopBrainDrainBlur already clear the holds.
     /// </summary>
     public void ReleaseOpacityRampHolds()
     {
         _rampPinkOpacity = null;
         _rampSpiralOpacity = null;
+        // Braindrain too: a stale ramp hold makes RefreshBrainDrainState skip intensity
+        // re-sync forever (it defers to the ramp owner while the hold is set).
+        _rampBrainDrainOpacity = null;
         _lastAppliedPinkOpacity = -1;
         _lastAppliedSpiralOpacity = -1;
     }

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml
@@ -1578,8 +1578,8 @@
                                       SelectionChanged="CmbOverlayKind_SelectionChanged">
                                 <ComboBoxItem Content="Pink Filter" Tag="pink_filter"/>
                                 <ComboBoxItem Content="Spiral" Tag="spiral"/>
-                                <!-- Brain Drain temporarily removed while we test/verify the blur feature. -->
-                                <!-- <ComboBoxItem Content="Brain Drain" Tag="braindrain"/> -->
+                                <ComboBoxItem Content="Brain Drain" Tag="braindrain"/>
+                                <ComboBoxItem Content="Brain Melt" Tag="braindrain_melt"/>
                             </ComboBox>
                             <TextBlock Text="Duration (ms)" Style="{StaticResource EditorLabel}"/>
                             <TextBox x:Name="TxtOverlayDuration" Style="{StaticResource EditorTextBox}"
@@ -1593,7 +1593,7 @@
                                     ValueChanged="SliderOverlayOpacity_ValueChanged"/>
                             <CheckBox x:Name="ChkOverlayRamp"
                                       Content="Ramp opacity over the region"
-                                      ToolTip="Fade the overlay from a start opacity to an end opacity across this region's duration (pink filter + spiral)."
+                                      ToolTip="Fade the overlay from a start opacity to an end opacity across this region's duration (all overlay kinds; Brain Drain ramps its blur depth)."
                                       Click="ChkOverlayRamp_Changed"
                                       Foreground="{DynamicResource TextLightBrush}"
                                       Margin="0,0,0,6"/>

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -3544,8 +3544,9 @@ namespace ConditioningControlPanel.Views.Deeper
                 te.DurationMs, v => te.DurationMs = Math.Max(50, v));
         }
 
-        // Overlay-kind combo for TriggerEffect. Pink Filter / Spiral / Brain
-        // Drain; matches the inline overlay editor's CmbOverlayKind.
+        // Overlay-kind combo for TriggerEffect. Pink Filter / Spiral / Brain Drain /
+        // Brain Melt; matches the inline overlay editor's CmbOverlayKind (same order,
+        // same friendly labels, same Tag = raw kind constant round-trip).
         private void AddOverlayKindCombo(Panel host, TriggerEffectAction te)
         {
             host.Children.Add(new TextBlock
@@ -3558,12 +3559,14 @@ namespace ConditioningControlPanel.Views.Deeper
                 Style = (Style)FindResource("EditorComboBox"),
                 ItemContainerStyle = (Style)FindResource("EditorComboBoxItem")
             };
-            // Brain Drain temporarily withheld from the editor while we test/verify the blur
-            // feature. Constant + runtime kept so existing saved scripts still load/run.
-            string[] kinds = { OverlayKinds.PinkFilter, OverlayKinds.Spiral };
-            foreach (var k in kinds)
+            // Tag stays the raw kind constant (what gets serialized); Content is the
+            // friendly label the inline CmbOverlayKind picker shows.
+            string[] kinds = { OverlayKinds.PinkFilter, OverlayKinds.Spiral,
+                               OverlayKinds.BrainDrain, OverlayKinds.BrainDrainMelt };
+            string[] labels = { "Pink Filter", "Spiral", "Brain Drain", "Brain Melt" };
+            for (int i = 0; i < kinds.Length; i++)
             {
-                combo.Items.Add(new ComboBoxItem { Content = k, Tag = k });
+                combo.Items.Add(new ComboBoxItem { Content = labels[i], Tag = kinds[i] });
             }
             var curK = te.OverlayKind ?? OverlayKinds.PinkFilter;
             var idx = Array.IndexOf(kinds, curK);

--- a/Tests/ConditioningControlPanel.Tests/BrainDrainMeltFilterTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrainDrainMeltFilterTests.cs
@@ -27,8 +27,9 @@ public class BrainDrainMeltFilterTests
     private const float MeltSwayPx = 2.5f;
     private const float MeltSwayRate = 0.55f;
 
+    // Mirrors BrainDrainLayer.SetIntensity's melt amplitude (subtle retune 2026-07-31).
     private static float Amplitude(int intensity, int downscale) =>
-        (float)((2.0 + Math.Clamp(intensity, 0, 200) * 0.12) * 4.0 / Math.Max(1, downscale));
+        (float)((1.0 + Math.Clamp(intensity, 0, 200) * 0.045) * 4.0 / Math.Max(1, downscale));
 
     private static SKImage NoiseTile()
     {

--- a/Tests/ConditioningControlPanel.Tests/BrainDrainMeltFilterTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrainDrainMeltFilterTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Diagnostics;
+using SkiaSharp;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Replicates the melt filter chain from <c>BrainDrainLayer.CapturePass</c> (Perlin turbulence ->
+/// paint filter -> displacement map over the blur) on an offscreen surface. The layer itself owns
+/// GDI screen capture and cannot be driven headless, so the chain is rebuilt here verbatim -
+/// keep the constants below in sync with the layer.
+/// The load-bearing assertions are the two GUTTER ones: displacement pulls samples from outside
+/// the source and those bleed transparent, so the layer draws scaled up about the centre to push
+/// that band off-frame. A gaussian has its own soft edge which the plain-blur path has always
+/// shown, so melt is measured against that baseline rather than against zero.
+/// </summary>
+public class BrainDrainMeltFilterTests
+{
+    private const float NoiseCellFraction = 0.20f;
+    private const float NoiseCellAspect = 0.65f;
+    private const int NoiseOctaves = 2;
+    private const float NoiseSeed = 7f;
+    private const int NoiseTilePx = 256;
+    private const float NoiseCellsPerTile = 12f;
+    private const float MeltDriftPxPerSec = 6f;
+    private const float MeltSwayPx = 2.5f;
+    private const float MeltSwayRate = 0.55f;
+
+    private static float Amplitude(int intensity, int downscale) =>
+        (float)((2.0 + Math.Clamp(intensity, 0, 200) * 0.12) * 4.0 / Math.Max(1, downscale));
+
+    private static SKImage NoiseTile()
+    {
+        float freq = NoiseCellsPerTile / NoiseTilePx;
+        using var noise = SKShader.CreatePerlinNoiseTurbulence(
+            freq, freq * NoiseCellAspect, NoiseOctaves, NoiseSeed, new SKSizeI(NoiseTilePx, NoiseTilePx));
+        using var surface = SKSurface.Create(
+            new SKImageInfo(NoiseTilePx, NoiseTilePx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using var paint = new SKPaint { Shader = noise };
+        surface.Canvas.Clear(SKColors.Transparent);
+        surface.Canvas.DrawRect(0, 0, NoiseTilePx, NoiseTilePx, paint);
+        return surface.Snapshot();
+    }
+
+    private sealed class PassResult : IDisposable
+    {
+        public SKBitmap Frame = null!;
+        public double MsPerTick;
+        public double MinMsPerTick;
+        public int TransparentPx;
+        public void Dispose() => Frame.Dispose();
+    }
+
+    /// <summary>Runs <paramref name="ticks"/> capture passes and returns the last frame, the mean
+    /// ms/tick and the count of non-opaque pixels. <paramref name="warp"/> false = the plain-blur
+    /// path exactly as it is today; <paramref name="blur"/> false forces sigma to 0.</summary>
+    private static PassResult RunPass(int w, int h, int intensity, int downscale, int ticks,
+                                      bool warp, bool blur = true)
+    {
+        float amplitude = Amplitude(intensity, downscale);
+        float sigma = blur ? (float)(intensity * 0.4 / downscale / 3.0) : 0f;
+        float coverage = Math.Max(8f, Math.Min(w, h) * NoiseCellFraction) * NoiseCellsPerTile;
+        float tierScale = 4f / downscale;
+        float gutter = amplitude * 0.5f + 2f;
+
+        // Fully opaque source: any transparency in the output came from a filter's edge behaviour.
+        using var src = new SKBitmap(new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Opaque));
+        using (var srcCanvas = new SKCanvas(src))
+        {
+            srcCanvas.Clear(SKColors.DarkSlateBlue);
+            using var p = new SKPaint { Color = SKColors.Orange };
+            for (int i = 0; i < w; i += 17) srcCanvas.DrawRect(i, 0, 8, h, p);
+        }
+        using var raw = SKImage.FromBitmap(src);
+
+        using var surface = SKSurface.Create(new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using var blurFilter = sigma > 0.05f ? SKImageFilter.CreateBlur(sigma, sigma) : null;
+        using var blurPaint = new SKPaint { ImageFilter = blurFilter };
+        using var tile = NoiseTile();
+        using var noisePaint = new SKPaint { FilterQuality = SKFilterQuality.Low };
+        using var meltPaint = new SKPaint();
+
+        var canvas = surface.Canvas;
+        var sw = new Stopwatch();
+        double minTicks = double.MaxValue;
+        float t = 0f;
+        for (int i = 0; i < ticks; i++)
+        {
+            t += 1f / 30f;
+            long before = sw.ElapsedTicks;
+            sw.Start();
+            if (warp)
+            {
+                float dx = MeltSwayPx * tierScale * MathF.Sin(t * MeltSwayRate);
+                float dy = (MeltDriftPxPerSec * tierScale * t) % coverage;
+                float s = coverage / NoiseTilePx;
+                using var drift = SKShader.CreateImage(tile, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+                                                       SKMatrix.CreateScaleTranslation(s, s, dx, dy));
+                noisePaint.Shader = drift;
+                using var noiseFilter = SKImageFilter.CreatePaint(noisePaint);
+                using var meltFilter = SKImageFilter.CreateDisplacementMapEffect(
+                    SKColorChannel.R, SKColorChannel.G, amplitude, noiseFilter, blurFilter);
+                meltPaint.ImageFilter = meltFilter;
+
+                canvas.Clear(SKColors.Transparent);
+                canvas.Save();
+                canvas.Translate(w * 0.5f, h * 0.5f);
+                canvas.Scale((w + 2f * gutter) / w, (h + 2f * gutter) / h);
+                canvas.Translate(-w * 0.5f, -h * 0.5f);
+                canvas.DrawImage(raw, 0, 0, meltPaint);
+                canvas.Restore();
+                canvas.Flush();
+                meltPaint.ImageFilter = null;
+                noisePaint.Shader = null;
+            }
+            else
+            {
+                canvas.Clear(SKColors.Transparent);
+                canvas.DrawImage(raw, 0, 0, blurFilter != null ? blurPaint : null);
+                canvas.Flush();
+            }
+            sw.Stop();
+            minTicks = Math.Min(minTicks, sw.ElapsedTicks - before);
+        }
+
+        var frame = new SKBitmap(new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul));
+        Assert.True(surface.ReadPixels(frame.Info, frame.GetPixels(), frame.RowBytes, 0, 0));
+        int transparent = 0;
+        for (int y = 0; y < h; y++)
+            for (int x = 0; x < w; x++)
+                if (frame.GetPixel(x, y).Alpha < 250) transparent++;
+
+        return new PassResult
+        {
+            Frame = frame,
+            MsPerTick = sw.Elapsed.TotalMilliseconds / ticks,
+            MinMsPerTick = minTicks * 1000.0 / Stopwatch.Frequency,
+            TransparentPx = transparent,
+        };
+    }
+
+    /// <summary>With the blur out of the way, the centre scale-up must fully swallow the
+    /// displacement gutter - a displacement map offsets by at most +/- amplitude/2.</summary>
+    [Theory]
+    [InlineData(480, 270, 200, 4)] // 1080p, downscale 4, amplitude ceiling
+    [InlineData(480, 270, 100, 4)]
+    [InlineData(240, 135, 200, 8)] // Performance tier
+    public void Warp_LeavesNoDisplacementGutter(int w, int h, int intensity, int downscale)
+    {
+        using var melt = RunPass(w, h, intensity, downscale, 20, warp: true, blur: false);
+        Assert.True(melt.TransparentPx == 0,
+            $"{melt.TransparentPx} px of displacement gutter leaked into the {w}x{h} frame " +
+            $"(intensity {intensity}, downscale {downscale}, amplitude {Amplitude(intensity, downscale):F1}px); " +
+            "the centre scale-up no longer covers amplitude/2.");
+    }
+
+    /// <summary>Melt must not add any transparency the plain-blur path did not already have
+    /// (a gaussian fades out over ~3 sigma at the frame edge; that is pre-existing behaviour).</summary>
+    [Theory]
+    [InlineData(480, 270, 100, 4)]
+    [InlineData(480, 270, 30, 4)]
+    [InlineData(240, 135, 100, 8)]
+    public void Melt_AddsNoGutterOverThePlainBlurBaseline(int w, int h, int intensity, int downscale)
+    {
+        using var plain = RunPass(w, h, intensity, downscale, 20, warp: false);
+        using var melt = RunPass(w, h, intensity, downscale, 20, warp: true);
+        Assert.True(melt.TransparentPx <= plain.TransparentPx,
+            $"melt left {melt.TransparentPx} non-opaque px vs {plain.TransparentPx} for the same plain blur " +
+            $"({w}x{h}, intensity {intensity}, downscale {downscale}).");
+    }
+
+    /// <summary>Same source, different phase => different pixels. Guards against the displacement
+    /// chain silently degrading into a plain blur (which is what the pre-melt flag did).</summary>
+    [Fact]
+    public void Melt_ActuallyWarps_AndAnimates()
+    {
+        using var plain = RunPass(240, 135, 100, 4, 1, warp: false);
+        using var early = RunPass(240, 135, 100, 4, 1, warp: true);
+        using var late = RunPass(240, 135, 100, 4, 40, warp: true);
+
+        Assert.True(Differing(plain.Frame, early.Frame) > 240 * 135 / 10, "melt is not warping at all.");
+        Assert.True(Differing(early.Frame, late.Frame) > 240 * 135 / 10, "the melt warp is not animating.");
+    }
+
+    /// <summary>Guards the reason the turbulence is pre-rasterised into a tile instead of being
+    /// evaluated live: Skia's raster Perlin shader measured 24ms/tick at 480x270 (a whole core at
+    /// the 30fps capture cadence), the tile fetch ~1.6ms. Asserts on the FASTEST of 60 ticks so a
+    /// busy or throttled CI box cannot flake it, against a bound ~7x the observed cost.</summary>
+    [Theory]
+    [InlineData(480, 270, 100, 4)]  // 1080p, default downscale
+    [InlineData(240, 135, 100, 8)]  // Performance tier
+    public void Melt_TickStaysCheapOnTheSmallSurface(int w, int h, int intensity, int downscale)
+    {
+        using var warm = RunPass(w, h, intensity, downscale, 10, warp: true);
+        using var melt = RunPass(w, h, intensity, downscale, 60, warp: true);
+        Assert.True(melt.MinMsPerTick < 12.0,
+            $"melt tick at {w}x{h} took {melt.MinMsPerTick:F2}ms (mean {melt.MsPerTick:F2}ms) - " +
+            "the displacement chain has regressed to evaluating noise per pixel.");
+    }
+
+    private static int Differing(SKBitmap a, SKBitmap b)
+    {
+        int n = 0;
+        for (int y = 0; y < a.Height; y++)
+            for (int x = 0; x < a.Width; x++)
+                if (a.GetPixel(x, y) != b.GetPixel(x, y)) n++;
+        return n;
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/OverlayHoldGuardTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OverlayHoldGuardTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+using static ConditioningControlPanel.Services.OverlayService;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Brain Drain bands died mid-video: the base feature is disabled for rework, so
+/// settings.BrainDrainEnabled is false for everyone and RefreshBrainDrainState tore the blur down
+/// on the next RefreshOverlays() tick — killing a live Deeper band (and any timed effect) whenever
+/// autonomy, remote control, or the user toggling pink/spiral happened to poke the reconciler.
+/// The hold guard pink/spiral already had is locked in here.
+/// </summary>
+public class OverlayHoldGuardTests
+{
+    [Fact]
+    public void FeatureOff_NoHolds_TearsDown()
+    {
+        // The intended teardown: nothing ad-hoc owns the overlay and the persistent feature is off.
+        Assert.True(ShouldStopHeldOverlay(featureWantsIt: false, timedHolds: 0, sustainedHeld: false));
+    }
+
+    [Fact]
+    public void FeatureOff_SustainedBand_SurvivesTheReconciler()
+    {
+        // The regression: a Deeper braindrain band is live, base feature off — must NOT be stopped.
+        Assert.False(ShouldStopHeldOverlay(featureWantsIt: false, timedHolds: 0, sustainedHeld: true));
+    }
+
+    [Fact]
+    public void FeatureOff_TimedEffectInFlight_SurvivesUntilTheLastHoldReleases()
+    {
+        Assert.False(ShouldStopHeldOverlay(featureWantsIt: false, timedHolds: 2, sustainedHeld: false));
+        Assert.False(ShouldStopHeldOverlay(featureWantsIt: false, timedHolds: 1, sustainedHeld: false));
+        Assert.True(ShouldStopHeldOverlay(featureWantsIt: false, timedHolds: 0, sustainedHeld: false));
+    }
+
+    [Fact]
+    public void FeatureOn_NeverTearsDown_TheReconcilerOwnsIt()
+    {
+        // Base feature wants the overlay: the reconciler keeps it alive regardless of ad-hoc holds.
+        Assert.False(ShouldStopHeldOverlay(featureWantsIt: true, timedHolds: 0, sustainedHeld: false));
+        Assert.False(ShouldStopHeldOverlay(featureWantsIt: true, timedHolds: 3, sustainedHeld: true));
+    }
+}


### PR DESCRIPTION
Fixes the Brain Drain white-screen reported in ccp-bugs #733 (BUG-Y278RZB2KR, v6.6.0).

## The bug

Users on 6.6.0 hit a screen that fades to white mid-video and sometimes never recovers. Reporter traced it to the `braindrain` overlay and confirmed that deleting the overlay effect in the Deeper editor resolves it. Their log shows `Brain Drain started on compositor layer, intensity 50%` immediately before the panic.

## What's here

Five commits, already on top of the v6.6.0 bump:

- `04c4bebc` restore blur sigma parity, alpha mix, band hold guards + melt kind plumbing
- `7c16bef9` restore Brain Drain + add Brain Melt in the editor overlay pickers
- `18bd79a3` Brain Melt render mode - animated Perlin displacement warp
- `d89aa6c5` release the braindrain ramp hold on session end + stale ramp doc
- `178275b2` subtle retune - cut blur/warp strength, alpha never opaque

The white-screen itself is the alpha/blur parity regression: the retune guarantees alpha never reaches opaque, which is what produced the unrecoverable white field.

## Testing

710 tests pass, 0 failures.

Tuning was verified through an offscreen preview harness rather than live screenshots — the compositor layer does not appear in captured frames, so screenshots cannot show this effect.

## Note

This has been sitting unpushed while every 6.6.0 user still has the bug, so it is worth landing ahead of the rest of the post-6.6.0 triage batch.