### PR TITLE
fix(season): season recap card never fires - client never learns the season rolled

### DIFF
--- a/ConditioningControlPanel/Services/Progression/SeasonRecapService.cs
+++ b/ConditioningControlPanel/Services/Progression/SeasonRecapService.cs
@@ -49,6 +49,30 @@ namespace ConditioningControlPanel.Services
             && int.TryParse(k.Substring(0, 4), out _)
             && int.TryParse(k.Substring(5, 2), out _);
 
+        /// <summary>
+        /// Whether a season key just handed to us by the server should replace the local
+        /// <see cref="Models.AppSettings.CurrentSeason"/>.
+        ///
+        /// This exists because the key is what makes the recap fire at all: everything downstream
+        /// compares <see cref="CurrentSeasonKey"/> against LastSeasonResetSeen / SeasonStatsSeason,
+        /// and CurrentSeasonKey prefers the stored server value over wall-clock. A client that
+        /// never learns the new key therefore compares "2026-07" with "2026-07" and silently
+        /// decides nothing happened — which is exactly how the August 1 rollover produced no card.
+        ///
+        /// Adopt only a well-formed key that is strictly AFTER what we hold (or when we hold
+        /// nothing usable). Seasons only ever move forward, so a backward key is a desync or a
+        /// stale read, and taking it would let the recap fire a second time for a season already
+        /// recapped, or roll the live stats bucket backwards.
+        /// </summary>
+        internal static bool ShouldAdoptServerSeason(string? serverSeason, string? localSeason)
+        {
+            if (string.IsNullOrWhiteSpace(serverSeason) || !LooksLikeMonthKey(serverSeason!))
+                return false;
+            if (string.IsNullOrWhiteSpace(localSeason) || !LooksLikeMonthKey(localSeason!))
+                return true;
+            return string.CompareOrdinal(serverSeason!, localSeason!) > 0;
+        }
+
         // ---------- live counter mutations (call from feature hook points) ----------
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -343,6 +343,35 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Ask the UI to present the season recap if it is due. No-ops harmlessly when MainWindow
+        /// is not up yet (early boot) — the startup call in MainWindow covers that case, and by
+        /// then the season key we just adopted is already saved.
+        /// </summary>
+        private static void NudgeSeasonRecap()
+        {
+            try
+            {
+                var dispatcher = System.Windows.Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                dispatcher.BeginInvoke(new Action(() =>
+                {
+                    try
+                    {
+                        (System.Windows.Application.Current?.MainWindow as ConditioningControlPanel.MainWindow)?.TryPresentSeasonRecap();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning(ex, "Season recap nudge failed");
+                    }
+                }));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Season recap nudge could not be dispatched");
+            }
+        }
+
+        /// <summary>
         /// When local progression looks like fresh defaults at boot (Level 1, &lt;100 XP),
         /// the push-guard in <see cref="SyncProfileAsync"/> skips the round-trip, so a
         /// settings reset / restore never pulls the real level back down (#293). This does
@@ -366,6 +395,22 @@ namespace ConditioningControlPanel.Services
                 var v2Auth = new V2AuthService();
                 var user = await v2Auth.GetUserProfileAsync(unifiedId);
                 if (user == null) return false;
+
+                // Adopt the season key here, ahead of every early return below. This fetch already
+                // carries current_season (the profile projection always included it), but the
+                // "server is also at defaults" return further down threw the whole payload away —
+                // and a season reset is PRECISELY when local and server both sit at Level 1 / 0 XP,
+                // so the one path that could have healed a stale key bailed out exactly when it
+                // mattered. Doing it before ApplyUserDataToSettings also means it lands even when
+                // there is no level/XP progress to adopt.
+                if (Services.SeasonRecapService.ShouldAdoptServerSeason(user.CurrentSeason, settings.CurrentSeason))
+                {
+                    App.Logger?.Information("Boot heal: season key advanced {Old} -> {New} via read-only profile fetch",
+                        string.IsNullOrEmpty(settings.CurrentSeason) ? "(none)" : settings.CurrentSeason, user.CurrentSeason);
+                    settings.CurrentSeason = user.CurrentSeason;
+                    App.Settings?.Save();
+                    NudgeSeasonRecap();
+                }
 
                 // Apply server-side whitelist even when level/xp are at season-reset
                 // defaults. The flag normally rides the sync POST response, but the
@@ -823,6 +868,26 @@ namespace ConditioningControlPanel.Services
                                 }
                             }
                             if (needsCompanionSave) App.Settings?.Save();
+                        }
+
+                        // Adopt the server's season key BEFORE the level_reset handler below, because
+                        // that handler is what nudges the recap — and the recap's whole decision is a
+                        // comparison against this key. Getting these the wrong way round is the actual
+                        // August 1 bug: the rollover arrived, the recap ran, and it compared the old
+                        // key with itself and concluded the season had not changed.
+                        var serverSeason = v2Result?.User?.CurrentSeason;
+                        if (Services.SeasonRecapService.ShouldAdoptServerSeason(serverSeason, settings.CurrentSeason))
+                        {
+                            App.Logger?.Information("V2 Sync: season key advanced {Old} -> {New} (server-authoritative)",
+                                string.IsNullOrEmpty(settings.CurrentSeason) ? "(none)" : settings.CurrentSeason, serverSeason);
+                            settings.CurrentSeason = serverSeason;
+                            App.Settings?.Save();
+
+                            // Nudge the recap on the key change itself, not only on level_reset.
+                            // level_reset is one-shot from the server, so relying on it alone means a
+                            // client that misses that single response can never recap that season.
+                            // Cheap to call: TryPresentSeasonRecap shows at most once per app run.
+                            NudgeSeasonRecap();
                         }
 
                         // Handle level_reset — server admin reset all levels, force client to accept
@@ -2925,6 +2990,13 @@ namespace ConditioningControlPanel.Services
 
             [JsonProperty("highest_level_ever")]
             public int? HighestLevelEver { get; set; }
+
+            // The sync endpoint is what PERFORMS the season rollover, so it is the first thing
+            // that knows the new key — but it used to omit it from its response projection while
+            // the auth projections included it, leaving sync-only clients permanently on the old
+            // season. Null on servers older than that fix; ShouldAdoptServerSeason ignores null.
+            [JsonProperty("current_season")]
+            public string? CurrentSeason { get; set; }
 
             [JsonProperty("achievements")]
             public List<string>? Achievements { get; set; }

--- a/Tests/ConditioningControlPanel.Tests/SeasonKeyAdoptionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SeasonKeyAdoptionTests.cs
@@ -1,0 +1,73 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The August 1 2026 season rollover produced no recap card for anyone who did not re-login
+/// across the boundary. The server rolled the season correctly; the /v2/profile/sync response
+/// that performed the rollover just never mentioned the new key, and nothing on the sync path
+/// wrote AppSettings.CurrentSeason. SeasonRecapService.CurrentSeasonKey prefers that stored
+/// value over wall-clock, so the recap compared "2026-07" against "2026-07", concluded nothing
+/// had happened, cleared its pending latch and returned - without logging.
+///
+/// ShouldAdoptServerSeason is the guard that decides when to take a server key. It has to be
+/// permissive enough to unstick that state and strict enough not to undo the two July fixes
+/// that stopped the recap firing early (premature wall-clock roll) or twice (backward desync).
+/// </summary>
+public class SeasonKeyAdoptionTests
+{
+    [Fact]
+    public void AdvancingKeyIsAdopted()
+        => Assert.True(SeasonRecapService.ShouldAdoptServerSeason("2026-08", "2026-07"));
+
+    [Fact]
+    public void TheAugustFirstCaseIsUnstuck()
+    {
+        // The exact stuck state: local believes July, server has rolled to August.
+        Assert.True(SeasonRecapService.ShouldAdoptServerSeason("2026-08", "2026-07"));
+        // ...and once adopted, re-running the same sync must be a no-op rather than re-firing.
+        Assert.False(SeasonRecapService.ShouldAdoptServerSeason("2026-08", "2026-08"));
+    }
+
+    [Fact]
+    public void YearBoundaryAdvances()
+        => Assert.True(SeasonRecapService.ShouldAdoptServerSeason("2027-01", "2026-12"));
+
+    [Theory]
+    [InlineData("2026-07", "2026-07")] // same season - nothing happened
+    [InlineData("2026-06", "2026-07")] // backward: desync or stale read
+    [InlineData("2025-12", "2026-01")] // backward across a year
+    public void NonAdvancingKeyIsIgnored(string server, string local)
+        => Assert.False(SeasonRecapService.ShouldAdoptServerSeason(server, local));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("2026-8")]      // not zero-padded, so ordinal compare would misorder it
+    [InlineData("2026/08")]
+    [InlineData("august")]
+    [InlineData("2026-08-01")]  // a full date, not a month key
+    public void MalformedOrAbsentServerKeyIsNeverAdopted(string? server)
+    {
+        // An older server omits the field entirely. Adopting garbage would poison CurrentSeasonKey,
+        // which is compared with CompareOrdinal against real keys.
+        Assert.False(SeasonRecapService.ShouldAdoptServerSeason(server, "2026-07"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-key")]
+    public void UnusableLocalKeyAcceptsAnyWellFormedServerKey(string? local)
+    {
+        // Fresh install, or a local value we cannot order against. Taking the server's key is
+        // strictly better than leaving CurrentSeasonKey to fall through to wall-clock.
+        Assert.True(SeasonRecapService.ShouldAdoptServerSeason("2026-08", local));
+    }
+
+    [Fact]
+    public void UnusableLocalKeyStillRejectsAnUnusableServerKey()
+        => Assert.False(SeasonRecapService.ShouldAdoptServerSeason("junk", "junk"));
+}


### PR DESCRIPTION
The Aug 1 2026 season rollover produced **no recap card for anyone** who did not log out and back in across the boundary. Not account-specific - a universal miss.

## What actually happened

The rollover worked. The server rolled the season, granted the streak-fix charge (`oopsie_credits 3 -> 4`) and sent `level_reset: true`. What never happened is the client finding out the new season key.

`AppSettings.CurrentSeason` is written in exactly one place - `V2AuthService.ApplyUserDataToSettings` - which runs only on login/auth paths. `/v2/profile/sync`, the endpoint that *performs* the rollover, omitted `current_season` from its response projection while both auth projections (`server.js:274`, `:304`) included it.

`SeasonRecapService.CurrentSeasonKey` prefers that stored value over wall-clock, so the guard in `MainWindow.Marquee.cs:206-246` compared `"2026-07"` against `"2026-07"`:

| Guard | Value | Result |
|---|---|---|
| `_seasonRecapShown` | false | pass |
| `highestLevel < 2` | 130 | pass |
| `monthRolled` = `current > lastSeen` | `"2026-07" > "2026-07"` | **fail** |
| `reallyPending` = `pending && current > statsSeason` | `true && ("2026-07" > "2026-07")` | **fail** |
| `!monthRolled && !reallyPending` | taken - **clears the latch**, returns | swallowed |

The early return logs nothing, which is why no log anywhere - across every retained log from 7/23 to 8/1 - contains a `Presenting season recap` line or any failure.

## Why now

`ed15b73e` (the `reallyPending` guard) and `bddb791f` (prefer the server key over wall-clock) both landed on **2026-07-01, about two hours after the last recap that ever worked**. Aug 1 is the first season boundary since, and it failed.

## The fix

Server: `CCP-Server@acf4434` adds `current_season` to the sync projection - **deployed to prod**, health 200.

Client, two adoption points:

- **The V2 sync response**, taken *before* the `level_reset` handler, because that handler nudges the recap and the recap's whole decision is a comparison against this key.
- **The #293 boot heal**, which already fetched a profile carrying `current_season` and then discarded it at the "server is also at defaults" early return. A season reset is precisely when local and server both sit at Level 1 / 0 XP, so the one path that could have healed a stale key bailed out exactly when it mattered. **This half works against the old server too.**

The recap is now also nudged on the key change itself, not only on `level_reset` - which is one-shot from the server, so a client that missed that single response could never recap that season.

`ShouldAdoptServerSeason` takes only a well-formed `yyyy-MM` key strictly after the one held. Seasons move forward only; a backward key is a desync, and taking it would re-fire a recap for an already-recapped season or roll the live stats bucket backwards. Note this is deliberately **not** "fall back to wall-clock", which would reintroduce the premature-roll bug `bddb791f` fixed.

## Tests

714 pass, 0 fail. 14 new in `SeasonKeyAdoptionTests`, including the exact stuck state, idempotency after adoption, year boundaries, backward keys, and malformed/absent keys from an older server.

## Not covered here

- **Shipped v6.6.0 clients need this release to recover.** Until then the only recovery is log out / back in, which routes through `ApplyUserDataToSettings`.
- **The July bucket is still accruing August activity** for stuck clients, and `2026-08-01` has already been appended to it as an extra July active-day. The sooner this ships, the cleaner the card.
- Branched off `origin/main` (v6.6.0), not stacked on #93, so it can ship on its own.
- Not play-tested - unit tests and code trace only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)