### PR TITLE
fix: v6.6.2 hotfix - mandatory-video crash (LibVLC use-after-free) + duck/wedge hardening

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2133,6 +2133,10 @@ namespace ConditioningControlPanel
                     catch { /* diagnostics only — never let logging fault the continuation */ }
                 }, TaskContinuationOptions.ExecuteSynchronously);
             }
+            else
+            {
+                Logger?.Information("Achievement '{Name}' not shared to Discord: DiscordShareAchievements is off", achievement.Name);
+            }
         }
         
         /// <summary>

--- a/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
@@ -162,6 +162,15 @@ namespace ConditioningControlPanel
                     }
                 });
 
+                // First-time login is the OTHER way a Discord account gets attached: the
+                // link-an-existing-account flows offer achievement sharing, this one never did,
+                // so Discord-first users never saw the prompt and their unlocks silently never
+                // posted (#749). The method self-guards on DiscordShareAchievements, so calling
+                // it after every successful login only prompts the users who still need it.
+                if (App.Discord?.IsAuthenticated == true)
+                {
+                    OfferAchievementSharingAfterDiscordLink();
+                }
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -765,6 +765,7 @@ namespace ConditioningControlPanel
             if (App.Settings?.Current != null && sender is CheckBox chk)
             {
                 App.Settings.Current.DiscordShareAchievements = chk.IsChecked == true;
+                App.Settings.Save();
             }
         }
 
@@ -773,6 +774,7 @@ namespace ConditioningControlPanel
             if (App.Settings?.Current != null && sender is CheckBox chk)
             {
                 App.Settings.Current.DiscordShareLevelUps = chk.IsChecked == true;
+                App.Settings.Save();
             }
         }
 

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NAudio.Wave;
 using NAudio.CoreAudioApi;
@@ -60,6 +62,27 @@ namespace ConditioningControlPanel.Services
         private const int FileCountProbeCap = 500;
 
         private bool _disposed;
+
+        // ── Serialized WASAPI sweep worker (#750-#753) ────────────────────────────────────────
+        // Duck()/Unduck() are called from the UI thread (VideoService.PlayVideo, CloseAll) and used
+        // to run the whole endpoint/session enumeration inline, under _lockObj. That enumeration is
+        // unbounded work: one reporter's machine has 12 render endpoints and a single misbehaving
+        // one blocked the dispatcher for 20+ seconds the instant a mandatory video started. Every
+        // sweep now runs here instead, on ONE thread, in submission order — so a Duck immediately
+        // followed by an Unduck still nets out correctly — while the callers return immediately.
+        private readonly BlockingCollection<Action> _duckWork = new();
+        private Thread? _duckWorker;
+        private int _duckWorkerStarted;
+        private int _duckWorkDepth;                                  // queued + in-flight sweeps
+        private readonly ManualResetEventSlim _duckWorkIdle = new(true);
+        private const int WorkerFlushTimeoutMs = 4_000;              // app-exit restore budget
+        private const int SlowSweepWarnMs = 2_000;
+
+        // The sweeps' own device enumerator, created ON the worker thread. MMDeviceEnumerator is a
+        // ThreadingModel=Both COM object, so one created on the UI thread lives in that STA and every
+        // property read from another thread would marshal straight back onto the dispatcher — the
+        // exact block this worker exists to remove. _deviceEnumerator stays for the UI-side lookups.
+        private MMDeviceEnumerator? _sweepEnumerator;
 
         // Cached WebView2 process IDs to avoid slow Process.GetProcessById() on every duck
         private HashSet<int> _webView2Pids = new();
@@ -641,9 +664,25 @@ namespace ConditioningControlPanel.Services
         #region Crash Recovery
 
         /// <summary>
-        /// Check if the app crashed while audio was ducked and restore volumes.
+        /// Check if the app crashed while audio was ducked and restore volumes. The file probe is
+        /// cheap and stays inline; the restore itself is a full render-endpoint sweep, so it goes on
+        /// the worker like every other sweep — it used to run on the UI thread inside OnStartup.
         /// </summary>
         private void RecoverFromCrash()
+        {
+            try
+            {
+                if (!File.Exists(DuckingRecoveryFile)) return;
+                EnqueueDuckWork("crash-recovery", RecoverFromCrashSweep);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Could not schedule ducking crash recovery: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>Worker-thread half of <see cref="RecoverFromCrash"/>.</summary>
+        private void RecoverFromCrashSweep()
         {
             try
             {
@@ -654,7 +693,7 @@ namespace ConditioningControlPanel.Services
                 var json = File.ReadAllText(DuckingRecoveryFile);
                 var savedVolumes = JsonConvert.DeserializeObject<Dictionary<int, float>>(json);
 
-                if (savedVolumes != null && savedVolumes.Count > 0 && _deviceEnumerator != null)
+                if (savedVolumes != null && savedVolumes.Count > 0)
                 {
                     using var scope = CollectRenderSessions();
                     var sessions = scope.Sessions;
@@ -691,17 +730,21 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Save current ducking state for crash recovery.
+        /// Save current ducking state for crash recovery. Snapshots under the lock and writes
+        /// outside it — this runs on the sweep worker, where the file I/O must not pin _lockObj.
         /// </summary>
         private void SaveDuckingState()
         {
             try
             {
+                Dictionary<int, float> snapshot;
+                lock (_lockObj) { snapshot = new Dictionary<int, float>(_originalVolumes); }
+
                 var dir = Path.GetDirectoryName(DuckingRecoveryFile);
                 if (!string.IsNullOrEmpty(dir))
                     Directory.CreateDirectory(dir);
 
-                var json = JsonConvert.SerializeObject(_originalVolumes);
+                var json = JsonConvert.SerializeObject(snapshot);
                 File.WriteAllText(DuckingRecoveryFile, json);
             }
             catch (Exception ex)
@@ -837,7 +880,9 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Lower the volume of other applications
+        /// Lower the volume of other applications. Returns immediately: only the ref count, the
+        /// duck flag and the two timers are touched here — the WASAPI sweep that actually moves the
+        /// sliders is queued onto the serialized worker (#750-#753).
         /// </summary>
         /// <param name="strength">0-100 (0 = no ducking, 100 = full mute)</param>
         public void Duck(int strength = 80)
@@ -847,123 +892,158 @@ namespace ConditioningControlPanel.Services
 
             if (_deviceEnumerator == null) return;
 
+            float amount;
             lock (_lockObj)
             {
                 _duckCount++;
                 if (_isDucked) return; // Already ducked — just bump the ref count
-                
+
                 _duckAmount = Math.Clamp(strength, 0, 100) / 100.0f;
-                
-                try
+                amount = _duckAmount;
+
+                // "Ducked" is a LOGICAL state decided synchronously, before the sweep has run.
+                // Deciding it from the sweep's outcome instead would let an Unduck that arrives
+                // while the sweep is still queued see !_isDucked and skip the restore entirely.
+                _isDucked = true;
+
+                // Watchdog: force-unduck if ducking exceeds max duration.
+                // Catches leaked ref counts from cancelled Task.Delay callbacks,
+                // missing Unduck on audio failure, etc. Repeats so a single failed sweep
+                // still gets another attempt; it retires itself once nothing is ducked.
+                _duckWatchdog?.Dispose();
+                _duckWatchdog = new System.Threading.Timer(_ => DuckWatchdogTick(),
+                    null, DuckWatchdogMs, DuckWatchdogMs);
+
+                // Rescan for new sessions during the duck window — without this, a Discord
+                // notification or Steam ping that creates an audio session AFTER Duck() ran
+                // plays at full volume.
+                _duckRescanTimer?.Dispose();
+                _duckRescanTimer = new System.Threading.Timer(_ => RescanForNewSessions(),
+                    null, DuckRescanIntervalMs, DuckRescanIntervalMs);
+            }
+
+            // Our layered-audio mixer is in-process, so the session-based ducker (which skips our
+            // own PID) can't touch it — duck it cooperatively instead. (#659) In-process gain
+            // change, no COM, so it stays inline and our own layers dip on the same frame.
+            try { App.LayeredAudio?.ApplyDuck(amount); } catch { }
+
+            EnqueueDuckWork("duck", () => ApplyDuckSweep(amount, strength), trace: true);
+        }
+
+        /// <summary>
+        /// Worker-thread half of <see cref="Duck"/>: walk every render endpoint, remember each
+        /// session's original volume and lower it. Never touches _lockObj across a COM call.
+        /// </summary>
+        private void ApplyDuckSweep(float amount, int strength)
+        {
+            var currentProcessId = Environment.ProcessId;
+            var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
+            var webViewPids = excludeWebView2 ? RefreshWebView2Pids() : new HashSet<int>();
+
+            int ducked = 0;
+            using (var scope = CollectRenderSessions())
+            {
+                var sessions = scope.Sessions;
+                for (int i = 0; i < sessions.Count; i++)
                 {
-                    var currentProcessId = Environment.ProcessId;
-                    using var scope = CollectRenderSessions();
-                    var sessions = scope.Sessions;
-
-                    // Check if we should exclude BambiCloud (WebView2) from ducking
-                    var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
-
-                    // Refresh WebView2 PID cache if expired (avoids slow Process.GetProcessById per session)
-                    if (excludeWebView2 && DateTime.UtcNow - _webView2PidsCacheTime > WebView2CacheExpiry)
+                    try
                     {
-                        try
+                        var session = sessions[i];
+                        var processId = (int)session.GetProcessID;
+
+                        // Skip our own process
+                        if (processId == currentProcessId || processId == 0) continue;
+
+                        // Skip WebView2 processes if setting is enabled (for BambiCloud audio)
+                        if (excludeWebView2 && webViewPids.Contains(processId))
+                            continue;
+
+                        var currentVolume = session.SimpleAudioVolume.Volume;
+
+                        // Store original volume + process name (for fallback matching at restore time
+                        // if PID changes — e.g. user closes and reopens Firefox during the session).
+                        lock (_lockObj)
                         {
-                            var newPids = new HashSet<int>();
-                            foreach (var proc in Process.GetProcesses())
-                            {
-                                try
-                                {
-                                    var name = proc.ProcessName.ToLowerInvariant();
-                                    if (name.Contains("msedgewebview2") || name.Contains("webview2"))
-                                        newPids.Add(proc.Id);
-                                }
-                                catch { }
-                                finally { proc.Dispose(); }
-                            }
-                            _webView2Pids = newPids;
-                            _webView2PidsCacheTime = DateTime.UtcNow;
-                        }
-                        catch (Exception ex)
-                        {
-                            App.Logger?.Debug("Failed to refresh WebView2 PID cache: {Error}", ex.Message);
-                        }
-                    }
-
-                    for (int i = 0; i < sessions.Count; i++)
-                    {
-                        try
-                        {
-                            var session = sessions[i];
-                            var processId = (int)session.GetProcessID;
-
-                            // Skip our own process
-                            if (processId == currentProcessId || processId == 0) continue;
-
-                            // Skip WebView2 processes if setting is enabled (for BambiCloud audio)
-                            if (excludeWebView2 && _webView2Pids.Contains(processId))
-                                continue;
-
-                            var currentVolume = session.SimpleAudioVolume.Volume;
-
-                            // Store original volume + process name (for fallback matching at restore time
-                            // if PID changes — e.g. user closes and reopens Firefox during the session).
+                            if (!_isDucked) return;  // unducked out from under us — leave the rest alone
+                            // Never overwrite a surviving entry: after a restore that threw, the
+                            // stored value is the TRUE original and the live one is already ducked.
+                            // Recapturing it here is how volumes used to ratchet toward 0%.
+                            if (_originalVolumes.ContainsKey(processId)) continue;
                             _originalVolumes[processId] = currentVolume;
-                            _processNames[processId] = TryGetProcessName(processId);
+                        }
+                        var name = TryGetProcessName(processId);
+                        lock (_lockObj) { _processNames[processId] = name; }
 
-                            // Calculate ducked volume
-                            var newVolume = currentVolume * (1.0f - _duckAmount);
-                            session.SimpleAudioVolume.Volume = Math.Max(0.0f, newVolume);
-                        }
-                        catch (Exception ex)
-                        {
-                            // Session may have ended
-                            App.Logger?.Debug("Failed to duck audio session: {Error}", ex.Message);
-                        }
+                        // Calculate ducked volume
+                        var newVolume = currentVolume * (1.0f - amount);
+                        session.SimpleAudioVolume.Volume = Math.Max(0.0f, newVolume);
+                        ducked++;
                     }
-
-                    _isDucked = true;
-
-                    // Our layered-audio mixer is in-process, so the session-based ducker above
-                    // (which skips our own PID) can't touch it — duck it cooperatively instead. (#659)
-                    try { App.LayeredAudio?.ApplyDuck(_duckAmount); } catch { }
-
-                    // Watchdog: force-unduck if ducking exceeds max duration.
-                    // Catches leaked ref counts from cancelled Task.Delay callbacks,
-                    // missing Unduck on audio failure, etc. Repeats so a single failed sweep
-                    // still gets another attempt; it retires itself once nothing is ducked.
-                    _duckWatchdog?.Dispose();
-                    _duckWatchdog = new System.Threading.Timer(_ => DuckWatchdogTick(),
-                        null, DuckWatchdogMs, DuckWatchdogMs);
-
-                    // Rescan for new sessions during the duck window — without this, a Discord
-                    // notification or Steam ping that creates an audio session AFTER Duck() ran
-                    // plays at full volume.
-                    _duckRescanTimer?.Dispose();
-                    _duckRescanTimer = new System.Threading.Timer(_ => RescanForNewSessions(),
-                        null, DuckRescanIntervalMs, DuckRescanIntervalMs);
-
-                    // Save state for crash recovery
-                    SaveDuckingState();
-
-                    App.Logger?.Debug("Ducked {Count} audio sessions by {Amount}%", _originalVolumes.Count, strength);
+                    catch (Exception ex)
+                    {
+                        // Session may have ended
+                        App.Logger?.Debug("Failed to duck audio session: {Error}", ex.Message);
+                    }
                 }
-                catch (Exception ex)
+            }
+
+            // Save state for crash recovery
+            SaveDuckingState();
+
+            App.Logger?.Debug("Ducked {Count} audio sessions by {Amount}%", ducked, strength);
+        }
+
+        /// <summary>
+        /// Refresh the WebView2 PID cache if it has expired. Walks the whole process table, so it
+        /// only ever runs on the sweep worker. Returns the current set (never null).
+        /// </summary>
+        private HashSet<int> RefreshWebView2Pids()
+        {
+            lock (_lockObj)
+            {
+                if (DateTime.UtcNow - _webView2PidsCacheTime <= WebView2CacheExpiry)
+                    return _webView2Pids;
+            }
+
+            try
+            {
+                var newPids = new HashSet<int>();
+                foreach (var proc in Process.GetProcesses())
                 {
-                    App.Logger?.Debug("Audio ducking failed: {Error}", ex.Message);
-                    // Duck failed — compensate for the increment so ref count stays balanced
-                    _duckCount = Math.Max(0, _duckCount - 1);
+                    try
+                    {
+                        var name = proc.ProcessName.ToLowerInvariant();
+                        if (name.Contains("msedgewebview2") || name.Contains("webview2"))
+                            newPids.Add(proc.Id);
+                    }
+                    catch { }
+                    finally { proc.Dispose(); }
                 }
+                lock (_lockObj)
+                {
+                    _webView2Pids = newPids;
+                    _webView2PidsCacheTime = DateTime.UtcNow;
+                }
+                return newPids;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Failed to refresh WebView2 PID cache: {Error}", ex.Message);
+                lock (_lockObj) { return _webView2Pids; }
             }
         }
 
         /// <summary>
-        /// Restore the original volume of other applications.
+        /// Restore the original volume of other applications. Returns immediately — like
+        /// <see cref="Duck"/>, only the flags move here and the sweep is queued behind whatever
+        /// duck/rescan work is already in flight, so ordering is preserved.
         /// Pass the generation from DuckGeneration captured at Duck() time to prevent stale callbacks
         /// from interfering with newer ducking sessions.
         /// </summary>
         /// <param name="generation">Duck generation to validate against. Pass -1 to skip generation check (legacy callers).</param>
         public void Unduck(long generation = -1)
         {
+            bool restore = false;
             lock (_lockObj)
             {
                 // If a generation was specified and doesn't match current, this is a stale callback — ignore
@@ -982,137 +1062,154 @@ namespace ConditioningControlPanel.Services
                 _duckCount = Math.Max(0, _duckCount - 1);
                 if (_duckCount > 0) return; // Other consumers still need ducking
 
-                try
-                {
-                    RestoreDuckedVolumes();
-
-                    _duckWatchdog?.Dispose();
-                    _duckWatchdog = null;
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Warning("Audio unducking failed, preserving state for retry: {Error}", ex.Message);
-                    // CRITICAL: Do NOT clear _originalVolumes or set _isDucked=false here.
-                    // If we do, the next Duck() will re-read the currently-ducked volumes as
-                    // "originals", causing volumes to ratchet toward 0% over repeated cycles.
-                    // Keep state intact so the next Unduck/ForceUnduck can retry restoration.
-                    //
-                    // Restore _duckCount to 1 (not 0) so the system can recover:
-                    // If _duckCount=0 + _isDucked=true, Duck() silently returns and no future
-                    // Unduck() can ever restore volumes — audio stays permanently ducked.
-                    // The (repeating) watchdog is deliberately left armed to retry from here.
-                    _duckCount = 1;
-                    // Keep recovery file so crash recovery can restore if app exits
-                }
-                finally
-                {
-                    // #686: these MUST happen even when restoration throws. A surviving rescan
-                    // timer re-ducks every audio session on the machine every 2.5s forever
-                    // ("all audio stopped"), and the cooperative layered-audio duck would be
-                    // released only on the success path. Both are safe to repeat.
-                    _duckRescanTimer?.Dispose();
-                    _duckRescanTimer = null;
-                    try { App.LayeredAudio?.ReleaseDuck(); } catch { } // restore layered-audio gain (#659)
-                }
+                _isDucked = false;
+                _duckWatchdog?.Dispose();
+                _duckWatchdog = null;
+                // #686: the rescan timer MUST die here. A survivor re-ducks every audio session on
+                // the machine every 2.5s forever ("all audio stopped").
+                _duckRescanTimer?.Dispose();
+                _duckRescanTimer = null;
+                restore = true;
             }
+
+            try { App.LayeredAudio?.ReleaseDuck(); } catch { } // restore layered-audio gain (#659)
+
+            if (restore) EnqueueDuckWork("unduck", RestoreDuckedVolumes, trace: true);
         }
 
         /// <summary>
-        /// Restores the volumes captured at Duck() time and clears the ducked state. Caller must
-        /// hold <see cref="_lockObj"/>. Throws on unexpected failure — callers decide whether to
-        /// preserve state for a retry.
+        /// Restores the volumes captured at Duck() time. Runs ONLY on the sweep worker: it walks
+        /// every render endpoint, which is exactly the unbounded COM work that must never sit on the
+        /// UI thread (#750-#753 — one trace died inside this call, reached from CloseAll's finally).
+        /// The lock is taken only to snapshot the captured volumes and to write the result back.
         /// </summary>
         private void RestoreDuckedVolumes()
         {
-            using var scope = CollectRenderSessions();
-            var sessions = scope.Sessions;
+            Dictionary<int, float> wanted;
+            Dictionary<int, string> names;
+            lock (_lockObj)
+            {
+                wanted = new Dictionary<int, float>(_originalVolumes);
+                names = new Dictionary<int, string>(_processNames);
+            }
 
             var restored = new HashSet<int>();
-            var nameToCurrentPid = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-            for (int i = 0; i < sessions.Count; i++)
+            try
             {
-                try
-                {
-                    var session = sessions[i];
-                    var processId = (int)session.GetProcessID;
+                using var scope = CollectRenderSessions();
+                var sessions = scope.Sessions;
 
-                    if (_originalVolumes.TryGetValue(processId, out var originalVolume))
-                    {
-                        session.SimpleAudioVolume.Volume = originalVolume;
-                        restored.Add(processId);
-                    }
-                    else
-                    {
-                        // Build a name-index for fallback restoration of PIDs that no longer exist
-                        var name = TryGetProcessName(processId);
-                        if (!string.IsNullOrEmpty(name) && !nameToCurrentPid.ContainsKey(name))
-                            nameToCurrentPid[name] = processId;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Session may have ended
-                    App.Logger?.Debug("Failed to unduck audio session: {Error}", ex.Message);
-                }
-            }
+                var nameToCurrentPid = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-            // Fallback: for stored PIDs whose original session is gone, try to find a
-            // current session for the same process name (e.g. user restarted Firefox
-            // mid-session — new PID, same app).
-            foreach (var kv in _originalVolumes)
-            {
-                if (restored.Contains(kv.Key)) continue;
-                if (!_processNames.TryGetValue(kv.Key, out var name) || string.IsNullOrEmpty(name)) continue;
-                if (!nameToCurrentPid.TryGetValue(name, out var currentPid)) continue;
-
-                try
+                for (int i = 0; i < sessions.Count; i++)
                 {
-                    for (int i = 0; i < sessions.Count; i++)
+                    try
                     {
                         var session = sessions[i];
-                        if ((int)session.GetProcessID == currentPid)
+                        var processId = (int)session.GetProcessID;
+
+                        if (wanted.TryGetValue(processId, out var originalVolume))
                         {
-                            session.SimpleAudioVolume.Volume = kv.Value;
-                            restored.Add(kv.Key);
-                            break;
+                            session.SimpleAudioVolume.Volume = originalVolume;
+                            restored.Add(processId);
+                        }
+                        else
+                        {
+                            // Build a name-index for fallback restoration of PIDs that no longer exist
+                            var name = TryGetProcessName(processId);
+                            if (!string.IsNullOrEmpty(name) && !nameToCurrentPid.ContainsKey(name))
+                                nameToCurrentPid[name] = processId;
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        // Session may have ended
+                        App.Logger?.Debug("Failed to unduck audio session: {Error}", ex.Message);
+                    }
                 }
-                catch { /* session may have ended between checks */ }
+
+                // Fallback: for stored PIDs whose original session is gone, try to find a
+                // current session for the same process name (e.g. user restarted Firefox
+                // mid-session — new PID, same app).
+                foreach (var kv in wanted)
+                {
+                    if (restored.Contains(kv.Key)) continue;
+                    if (!names.TryGetValue(kv.Key, out var name) || string.IsNullOrEmpty(name)) continue;
+                    if (!nameToCurrentPid.TryGetValue(name, out var currentPid)) continue;
+
+                    try
+                    {
+                        for (int i = 0; i < sessions.Count; i++)
+                        {
+                            var session = sessions[i];
+                            if ((int)session.GetProcessID == currentPid)
+                            {
+                                session.SimpleAudioVolume.Volume = kv.Value;
+                                restored.Add(kv.Key);
+                                break;
+                            }
+                        }
+                    }
+                    catch { /* session may have ended between checks */ }
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("Audio unducking failed, preserving state for retry: {Error}", ex.Message);
+                lock (_lockObj)
+                {
+                    // CRITICAL: Do NOT clear _originalVolumes here. If we do, the next Duck() will
+                    // re-read the currently-ducked volumes as "originals", causing volumes to
+                    // ratchet toward 0% over repeated cycles. Keep state intact — and pin _isDucked
+                    // back on with _duckCount=1 (not 0) so the system can recover: _duckCount=0 +
+                    // _isDucked=true would make Duck() silently return and no future Unduck() could
+                    // ever restore. Re-arm the watchdog so it retries from here.
+                    _isDucked = true;
+                    _duckCount = 1;
+                    if (!_disposed && _duckWatchdog == null)
+                        _duckWatchdog = new System.Threading.Timer(_ => DuckWatchdogTick(),
+                            null, DuckWatchdogMs, DuckWatchdogMs);
+                }
+                // Keep the recovery file so crash recovery can restore if the app exits.
+                return;
             }
 
-            // Move any unrestored entries (PID gone, app silent / not playing) to pending
-            // and let the retry timer re-attempt as the app resumes producing audio.
-            foreach (var kv in _originalVolumes)
+            int pendingCount;
+            lock (_lockObj)
             {
-                if (!restored.Contains(kv.Key))
-                    _pendingRestores[kv.Key] = kv.Value;
+                foreach (var kv in wanted)
+                {
+                    _originalVolumes.Remove(kv.Key);
+                    // Anything we couldn't reach (PID gone, app silent / not playing) goes pending
+                    // so the retry timer can re-attempt as the app resumes producing audio.
+                    if (restored.Contains(kv.Key)) _processNames.Remove(kv.Key);
+                    else _pendingRestores[kv.Key] = kv.Value;
+                }
+
+                pendingCount = _pendingRestores.Count;
+                if (pendingCount > 0)
+                {
+                    _restoreRetryDeadline = DateTime.UtcNow + RestoreRetryWindow;
+                    _restoreRetryTimer?.Dispose();
+                    _restoreRetryTimer = new System.Threading.Timer(_ => RestoreRetryTick(),
+                        null, RestoreRetryIntervalMs, RestoreRetryIntervalMs);
+                }
+                else
+                {
+                    // All restored — process names no longer needed
+                    _processNames.Clear();
+                }
             }
 
-            _originalVolumes.Clear();
-            _isDucked = false;
-
-            if (_pendingRestores.Count > 0)
-            {
+            if (pendingCount > 0)
                 App.Logger?.Information("[Ducking] {Count} session(s) had no current audio at unduck — will retry restore for up to {Min} min",
-                    _pendingRestores.Count, RestoreRetryWindow.TotalMinutes);
-                _restoreRetryDeadline = DateTime.UtcNow + RestoreRetryWindow;
-                _restoreRetryTimer?.Dispose();
-                _restoreRetryTimer = new System.Threading.Timer(_ => RestoreRetryTick(),
-                    null, RestoreRetryIntervalMs, RestoreRetryIntervalMs);
-            }
-            else
-            {
-                // All restored — process names no longer needed
-                _processNames.Clear();
-            }
+                    pendingCount, RestoreRetryWindow.TotalMinutes);
 
             // Clear crash recovery file
             ClearDuckingState();
 
             App.Logger?.Debug("Audio unducked ({Restored} restored, {Pending} deferred)",
-                restored.Count, _pendingRestores.Count);
+                restored.Count, pendingCount);
         }
 
         /// <summary>
@@ -1123,6 +1220,7 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private void DuckWatchdogTick()
         {
+            bool restore = false;
             lock (_lockObj)
             {
                 if (_disposed) return;
@@ -1143,18 +1241,11 @@ namespace ConditioningControlPanel.Services
                 _duckGeneration++; // invalidate any in-flight stale Unduck callbacks
                 _duckRescanTimer?.Dispose();
                 _duckRescanTimer = null;
-                try { App.LayeredAudio?.ReleaseDuck(); } catch { }
-
-                try
-                {
-                    RestoreDuckedVolumes();
-                }
-                catch (Exception ex)
-                {
-                    // Volumes stay in _pendingRestores / crash-recovery for a later attempt.
-                    App.Logger?.Warning("[Ducking] Watchdog restore failed: {Error}", ex.Message);
-                }
+                restore = true;
             }
+
+            try { App.LayeredAudio?.ReleaseDuck(); } catch { }
+            if (restore) EnqueueDuckWork("watchdog-restore", RestoreDuckedVolumes, trace: true);
         }
 
         /// <summary>
@@ -1191,15 +1282,20 @@ namespace ConditioningControlPanel.Services
         /// multimedia device. A user who routes their browser / media player to a secondary
         /// output would otherwise never get ducked, since those sessions live on a different
         /// device's session manager (bug #415).
+        ///
+        /// WORKER-THREAD ONLY. A machine with a dozen endpoints (or one that answers slowly) makes
+        /// this take tens of seconds, which is the whole of #750-#753 — never call it from the UI
+        /// thread. Uses the worker's own enumerator so the COM calls stay inside its apartment.
         /// </summary>
         private RenderSessionScope CollectRenderSessions()
         {
             var scope = new RenderSessionScope();
-            if (_deviceEnumerator == null) return scope;
+            var enumerator = _sweepEnumerator ?? _deviceEnumerator;
+            if (enumerator == null) return scope;
 
             try
             {
-                var endpoints = _deviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+                var endpoints = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
                 scope.Own(endpoints);
                 for (int d = 0; d < endpoints.Count; d++)
                 {
@@ -1277,58 +1373,79 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Periodically called while ducked to catch new audio sessions (e.g. Discord notification,
         /// Steam ping) that didn't exist when Duck() ran. Without this, those play un-ducked.
+        /// Threadpool-timer entry point: it only decides whether to queue a sweep.
         /// </summary>
         private void RescanForNewSessions()
         {
+            if (_disposed) return;
             lock (_lockObj)
             {
-                if (!_isDucked || _deviceEnumerator == null || _disposed) return;
+                if (!_isDucked || _deviceEnumerator == null) return;
+            }
 
-                try
+            // A sweep is already queued or running. SKIP this cycle rather than queueing behind it:
+            // on a machine where one endpoint answers slower than the 2.5s cadence the backlog grew
+            // without bound and outlived the duck window entirely (#750-#753).
+            if (Volatile.Read(ref _duckWorkDepth) > 0) return;
+
+            EnqueueDuckWork("rescan", RescanSweep);
+        }
+
+        /// <summary>Worker-thread half of <see cref="RescanForNewSessions"/>.</summary>
+        private void RescanSweep()
+        {
+            float amount;
+            lock (_lockObj)
+            {
+                if (!_isDucked || _disposed) return;
+                amount = _duckAmount;
+            }
+
+            var currentProcessId = Environment.ProcessId;
+            var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
+            var webViewPids = excludeWebView2 ? RefreshWebView2Pids() : new HashSet<int>();
+
+            int newlyDucked = 0;
+            using (var scope = CollectRenderSessions())
+            {
+                var sessions = scope.Sessions;
+                for (int i = 0; i < sessions.Count; i++)
                 {
-                    var currentProcessId = Environment.ProcessId;
-                    var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
-                    using var scope = CollectRenderSessions();
-                    var sessions = scope.Sessions;
-
-                    int newlyDucked = 0;
-                    for (int i = 0; i < sessions.Count; i++)
+                    try
                     {
-                        try
+                        var session = sessions[i];
+                        var processId = (int)session.GetProcessID;
+
+                        if (processId == currentProcessId || processId == 0) continue;
+                        if (excludeWebView2 && webViewPids.Contains(processId)) continue;
+
+                        var currentVolume = session.SimpleAudioVolume.Volume;
+                        // Skip sessions already at 0 — most likely they're sessions we ducked in a
+                        // prior generation and the PID got recycled; treating their 0 as "original"
+                        // would silence the app forever.
+                        if (currentVolume <= 0.001f) continue;
+
+                        lock (_lockObj)
                         {
-                            var session = sessions[i];
-                            var processId = (int)session.GetProcessID;
-
-                            if (processId == currentProcessId || processId == 0) continue;
-                            if (excludeWebView2 && _webView2Pids.Contains(processId)) continue;
-                            if (_originalVolumes.ContainsKey(processId)) continue; // already ducked
-
-                            var currentVolume = session.SimpleAudioVolume.Volume;
-                            // Skip sessions already at 0 — most likely they're sessions we ducked in a
-                            // prior generation and the PID got recycled; treating their 0 as "original"
-                            // would silence the app forever.
-                            if (currentVolume <= 0.001f) continue;
-
+                            if (!_isDucked) return;                                 // unducked mid-sweep
+                            if (_originalVolumes.ContainsKey(processId)) continue;  // already ducked
                             _originalVolumes[processId] = currentVolume;
-                            _processNames[processId] = TryGetProcessName(processId);
-
-                            var newVolume = currentVolume * (1.0f - _duckAmount);
-                            session.SimpleAudioVolume.Volume = Math.Max(0.0f, newVolume);
-                            newlyDucked++;
                         }
-                        catch { /* session may have ended */ }
-                    }
+                        var name = TryGetProcessName(processId);
+                        lock (_lockObj) { _processNames[processId] = name; }
 
-                    if (newlyDucked > 0)
-                    {
-                        App.Logger?.Debug("[Ducking] Rescan ducked {Count} new session(s)", newlyDucked);
-                        SaveDuckingState();
+                        var newVolume = currentVolume * (1.0f - amount);
+                        session.SimpleAudioVolume.Volume = Math.Max(0.0f, newVolume);
+                        newlyDucked++;
                     }
+                    catch { /* session may have ended */ }
                 }
-                catch (Exception ex)
-                {
-                    App.Logger?.Debug("[Ducking] Rescan failed: {Error}", ex.Message);
-                }
+            }
+
+            if (newlyDucked > 0)
+            {
+                App.Logger?.Debug("[Ducking] Rescan ducked {Count} new session(s)", newlyDucked);
+                SaveDuckingState();
             }
         }
 
@@ -1339,9 +1456,11 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private void RestoreRetryTick()
         {
+            if (_disposed) return;
+
             lock (_lockObj)
             {
-                if (_disposed || _pendingRestores.Count == 0)
+                if (_pendingRestores.Count == 0)
                 {
                     _restoreRetryTimer?.Dispose();
                     _restoreRetryTimer = null;
@@ -1361,93 +1480,204 @@ namespace ConditioningControlPanel.Services
                 }
 
                 if (_deviceEnumerator == null) return;
+            }
 
-                try
+            // Same skip-don't-queue rule as the rescan: this is a best-effort retry on a 5s
+            // cadence, and piling them up behind a slow endpoint helps nobody (#750-#753).
+            if (Volatile.Read(ref _duckWorkDepth) > 0) return;
+
+            EnqueueDuckWork("restore-retry", RestoreRetrySweep);
+        }
+
+        /// <summary>Worker-thread half of <see cref="RestoreRetryTick"/>.</summary>
+        private void RestoreRetrySweep()
+        {
+            Dictionary<int, float> pending;
+            Dictionary<int, string> names;
+            lock (_lockObj)
+            {
+                if (_disposed || _pendingRestores.Count == 0) return;
+                pending = new Dictionary<int, float>(_pendingRestores);
+                names = new Dictionary<int, string>(_processNames);
+            }
+
+            var restored = new List<int>();
+
+            using (var scope = CollectRenderSessions())
+            {
+                var sessions = scope.Sessions;
+
+                // Build PID-by-name index so we can match a stored PID to a new PID for the same app
+                var nameToPid = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < sessions.Count; i++)
                 {
-                    using var scope = CollectRenderSessions();
-                    var sessions = scope.Sessions;
-                    var restored = new List<int>();
+                    try
+                    {
+                        var pid = (int)sessions[i].GetProcessID;
+                        if (pid == 0) continue;
+                        var name = TryGetProcessName(pid);
+                        if (!string.IsNullOrEmpty(name) && !nameToPid.ContainsKey(name))
+                            nameToPid[name] = pid;
+                    }
+                    catch { }
+                }
 
-                    // Build PID-by-name index so we can match a stored PID to a new PID for the same app
-                    var nameToPid = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                foreach (var kv in pending)
+                {
+                    var storedPid = kv.Key;
+                    var originalVolume = kv.Value;
+                    int? targetPid = null;
+
+                    // Try direct PID match first
                     for (int i = 0; i < sessions.Count; i++)
                     {
                         try
                         {
-                            var pid = (int)sessions[i].GetProcessID;
-                            if (pid == 0) continue;
-                            var name = TryGetProcessName(pid);
-                            if (!string.IsNullOrEmpty(name) && !nameToPid.ContainsKey(name))
-                                nameToPid[name] = pid;
+                            if ((int)sessions[i].GetProcessID == storedPid) { targetPid = storedPid; break; }
                         }
                         catch { }
                     }
 
-                    foreach (var kv in _pendingRestores)
+                    // Fallback: process-name match (handles app-restart with new PID)
+                    if (targetPid == null && names.TryGetValue(storedPid, out var name)
+                        && !string.IsNullOrEmpty(name) && nameToPid.TryGetValue(name, out var freshPid))
                     {
-                        var storedPid = kv.Key;
-                        var originalVolume = kv.Value;
-                        int? targetPid = null;
+                        targetPid = freshPid;
+                    }
 
-                        // Try direct PID match first
-                        for (int i = 0; i < sessions.Count; i++)
+                    if (targetPid == null) continue;
+
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
+                        try
                         {
-                            try
+                            var session = sessions[i];
+                            if ((int)session.GetProcessID == targetPid.Value)
                             {
-                                if ((int)sessions[i].GetProcessID == storedPid) { targetPid = storedPid; break; }
+                                session.SimpleAudioVolume.Volume = originalVolume;
+                                restored.Add(storedPid);
+                                break;
                             }
-                            catch { }
                         }
-
-                        // Fallback: process-name match (handles app-restart with new PID)
-                        if (targetPid == null && _processNames.TryGetValue(storedPid, out var name)
-                            && !string.IsNullOrEmpty(name) && nameToPid.TryGetValue(name, out var freshPid))
-                        {
-                            targetPid = freshPid;
-                        }
-
-                        if (targetPid == null) continue;
-
-                        for (int i = 0; i < sessions.Count; i++)
-                        {
-                            try
-                            {
-                                var session = sessions[i];
-                                if ((int)session.GetProcessID == targetPid.Value)
-                                {
-                                    session.SimpleAudioVolume.Volume = originalVolume;
-                                    restored.Add(storedPid);
-                                    break;
-                                }
-                            }
-                            catch { }
-                        }
+                        catch { }
                     }
-
-                    if (restored.Count > 0)
-                    {
-                        foreach (var pid in restored)
-                        {
-                            _pendingRestores.Remove(pid);
-                            _processNames.Remove(pid);
-                        }
-                        App.Logger?.Information("[Ducking] Deferred-restore: recovered volume for {Count} session(s); {Remaining} still pending",
-                            restored.Count, _pendingRestores.Count);
-                    }
-
-                    if (_pendingRestores.Count == 0)
-                    {
-                        _processNames.Clear();
-                        _restoreRetryTimer?.Dispose();
-                        _restoreRetryTimer = null;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Debug("[Ducking] Restore retry tick failed: {Error}", ex.Message);
                 }
             }
+
+            int remaining;
+            lock (_lockObj)
+            {
+                foreach (var pid in restored)
+                {
+                    _pendingRestores.Remove(pid);
+                    _processNames.Remove(pid);
+                }
+
+                remaining = _pendingRestores.Count;
+                if (remaining == 0)
+                {
+                    _processNames.Clear();
+                    _restoreRetryTimer?.Dispose();
+                    _restoreRetryTimer = null;
+                }
+            }
+
+            if (restored.Count > 0)
+                App.Logger?.Information("[Ducking] Deferred-restore: recovered volume for {Count} session(s); {Remaining} still pending",
+                    restored.Count, remaining);
         }
+
+        #region Sweep worker
+
+        /// <summary>
+        /// Queue one WASAPI sweep onto the single serialized worker thread and return immediately —
+        /// this is what keeps Duck/Unduck off the UI thread's critical path (#750-#753). Items run
+        /// in submission order, so a Duck followed straight away by an Unduck still nets out right.
+        /// </summary>
+        private void EnqueueDuckWork(string name, Action work, bool trace = false)
+        {
+            if (_disposed) return;
+            EnsureDuckWorker();
+
+            Interlocked.Increment(ref _duckWorkDepth);
+            _duckWorkIdle.Reset();
+            try
+            {
+                _duckWork.Add(() =>
+                {
+                    var sw = Stopwatch.StartNew();
+                    try { work(); }
+                    catch (Exception ex) { App.Logger?.Debug("[Ducking] {Op} sweep failed: {Error}", name, ex.Message); }
+                    finally
+                    {
+                        var ms = sw.ElapsedMilliseconds;
+                        // A sweep this slow IS the freeze the reporters saw — it just no longer
+                        // happens on their dispatcher. Naming it in the video trace makes the next
+                        // report a straight read instead of another blind spot.
+                        if (trace || ms >= SlowSweepWarnMs)
+                            VideoDiag.Log("DUCK", $"{name} applied after {ms}ms");
+                        if (ms >= SlowSweepWarnMs)
+                            App.Logger?.Warning("[Ducking] {Op} sweep took {Ms}ms — a render endpoint on this machine is answering slowly", name, ms);
+                        if (Interlocked.Decrement(ref _duckWorkDepth) <= 0) _duckWorkIdle.Set();
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                // Collection completed (shutdown) — undo the depth bump so the exit flush can finish.
+                if (Interlocked.Decrement(ref _duckWorkDepth) <= 0) _duckWorkIdle.Set();
+                App.Logger?.Debug("[Ducking] could not queue {Op}: {Error}", name, ex.Message);
+            }
+        }
+
+        private void EnsureDuckWorker()
+        {
+            if (Interlocked.Exchange(ref _duckWorkerStarted, 1) == 1) return;
+            _duckWorker = new Thread(DuckWorkerLoop)
+            {
+                IsBackground = true,
+                Name = "AudioDuckWorker",
+                Priority = ThreadPriority.BelowNormal,
+            };
+            _duckWorker.Start();
+        }
+
+        private void DuckWorkerLoop()
+        {
+            // Created here on purpose — see the _sweepEnumerator field comment. A COM apartment
+            // mismatch would send every sweep back through the dispatcher, defeating the whole point.
+            try { _sweepEnumerator = new MMDeviceEnumerator(); }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("[Ducking] sweep worker could not create its own device enumerator: {Error}", ex.Message);
+            }
+
+            try
+            {
+                foreach (var item in _duckWork.GetConsumingEnumerable())
+                {
+                    try { item(); } catch { }
+                }
+            }
+            catch { /* collection completed / disposed */ }
+
+            try { _sweepEnumerator?.Dispose(); } catch { }
+            _sweepEnumerator = null;
+        }
+
+        /// <summary>
+        /// Block until every queued sweep has finished, or <paramref name="timeoutMs"/> elapses.
+        /// Dispose-only: app exit must not leave other apps pinned at the ducked volume, but a
+        /// machine with a wedged endpoint must not hold the exit open either — ducking_recovery.json
+        /// is still on disk in that case and the next launch restores from it.
+        /// </summary>
+        private bool FlushDuckWork(int timeoutMs)
+        {
+            try { return _duckWorkIdle.Wait(timeoutMs); }
+            catch { return false; }
+        }
+
+        #endregion
 
         #endregion
 
@@ -1456,19 +1686,32 @@ namespace ConditioningControlPanel.Services
         public void Dispose()
         {
             if (_disposed) return;
-            _disposed = true;
 
-            // Restore audio levels — force unduck regardless of ref count
-            if (_isDucked)
-            {
-                ForceUnduck();
-            }
+            // Restore audio levels — force unduck regardless of ref count. This runs BEFORE
+            // _disposed goes up: the sweeps bail out when it is set, and an exit that skipped the
+            // restore would leave every other app on the machine pinned at the ducked volume until
+            // the crash-recovery file is picked up on the NEXT launch.
+            bool wasDucked;
+            lock (_lockObj) { wasDucked = _isDucked; }
+            if (wasDucked) ForceUnduck();
+
+            var flushed = FlushDuckWork(WorkerFlushTimeoutMs);
+            if (!flushed)
+                App.Logger?.Warning("[Ducking] exit flush timed out after {Ms}ms — a sweep is still in flight; ducking_recovery.json will restore on the next launch",
+                    WorkerFlushTimeoutMs);
+
+            _disposed = true;
 
             StopSound();
             _duckWatchdog?.Dispose();
             _duckRescanTimer?.Dispose();
             _restoreRetryTimer?.Dispose();
-            _deviceEnumerator?.Dispose();
+            try { _duckWork.CompleteAdding(); } catch { }
+
+            // Only release the enumerators once we know no sweep is mid-COM-call on one. Yanking
+            // them out from under a wedged worker turns a clean exit into a native crash; process
+            // teardown reclaims them in the timed-out case.
+            if (flushed) _deviceEnumerator?.Dispose();
         }
 
         #endregion

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -118,6 +118,14 @@ public static class UiHangWatchdog
                         _hangLogged = true;
                         App.Logger?.Error("[WATCHDOG] UI thread unresponsive for {Sec:F0}s{Phase} — likely render-thread deadlock",
                             silence / 1000.0, started ? "" : " (never pumped — wedged during startup)");
+                        // Mirror into the video trace. These lines only ever went to the ROLLING
+                        // Serilog file, which a post-freeze relaunch scrolls straight out of the
+                        // 100-line tail a bug report attaches — the exact evidence loss VideoDiag
+                        // exists to prevent (#750-#753). Log() is a no-op until VideoDiag.Start ran.
+                        VideoDiag.Log("WATCHDOG", string.Format(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            "UI thread unresponsive for {0:F0}s{1}",
+                            silence / 1000.0, started ? "" : " (never pumped - wedged during startup)"));
                     }
                     if (!_dumpWritten)
                     {
@@ -129,6 +137,7 @@ public static class UiHangWatchdog
                 {
                     _hangLogged = false;
                     App.Logger?.Warning("[WATCHDOG] UI thread recovered");
+                    VideoDiag.Log("WATCHDOG", "UI thread recovered");
                 }
             }
             catch { }
@@ -271,6 +280,7 @@ public static class UiHangWatchdog
                         && File.Exists(path) && new FileInfo(path).Length > 100_000)
                     {
                         App.Logger?.Error("[WATCHDOG] hang dump written (external) after {Sec:F0}s of silence: {Path}", silenceMs / 1000.0, path);
+                        VideoDiag.Log("WATCHDOG", "hang dump written (external): " + path);
                         return;
                     }
                     // Do NOT Kill() a dumper that is mid-write: MiniDumpWriteDump suspends the
@@ -290,13 +300,20 @@ public static class UiHangWatchdog
             bool ok = MiniDumpWriteDump(proc.Handle, (uint)proc.Id, fs.SafeFileHandle, CompactDumpType,
                                         IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
             if (ok)
+            {
                 App.Logger?.Error("[WATCHDOG] hang dump written after {Sec:F0}s of silence: {Path}", silenceMs / 1000.0, path);
+                VideoDiag.Log("WATCHDOG", "hang dump written (in-proc): " + path);
+            }
             else
+            {
                 App.Logger?.Error("[WATCHDOG] MiniDumpWriteDump failed (error {Err})", Marshal.GetLastWin32Error());
+                VideoDiag.Log("WATCHDOG", "MiniDumpWriteDump failed (error " + Marshal.GetLastWin32Error() + ")");
+            }
         }
         catch (Exception ex)
         {
             App.Logger?.Error("[WATCHDOG] hang dump failed: {E}", ex.Message);
+            VideoDiag.Log("WATCHDOG", "hang dump failed: " + ex.Message);
         }
     }
 

--- a/ConditioningControlPanel/Services/Video/VideoDiag.cs
+++ b/ConditioningControlPanel/Services/Video/VideoDiag.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Windows.Threading;
@@ -100,6 +102,8 @@ namespace ConditioningControlPanel.Services
                 Priority = ThreadPriority.BelowNormal,
             };
             beat.Start();
+
+            InstallDispatcherHooks(dispatcher);
 
             Log("SESSION", $"---- app start, v{UpdateService.AppVersion}, pid {Environment.ProcessId} ----");
         }
@@ -260,6 +264,181 @@ namespace ConditioningControlPanel.Services
                 }
                 catch { }
             }
+        }
+
+        // ------------------------------------------------------------------------------------
+        // SLOW DISPATCHER OPERATION TRACER (#750-#753)
+        //
+        // The heartbeat proves the UI thread wedges ~8-9s AFTER PlayVideo's prologue has already
+        // returned — i.e. the blocker is NOT in the video show path at all, it is some other
+        // callback that the dispatcher runs while the 1.3s delay timer is pending. This hook names
+        // it: every DispatcherOperation is timed between OperationStarted and OperationCompleted,
+        // and anything that occupies the UI thread for half a second or more logs one line naming
+        // the delegate that did it.
+        //
+        // CONTRACT: hooks run ON the wedging thread, so they must be trivially cheap and must never
+        // throw (an exception out of a Dispatcher hook takes the app down — the exact failure we are
+        // chasing). Everything here is try/caught, does dictionary work only, and the log call is
+        // enqueue-only. Output is throttled so a storm of slow ops cannot flood the trace.
+        // ------------------------------------------------------------------------------------
+
+        private const long SlowOpMs = 500;         // report anything that holds the UI thread this long
+        private const int MaxSlowLinesPerMinute = 20;
+        private const int MaxTrackedOps = 512;     // hard cap; a leaked entry must never grow unbounded
+
+        private static readonly object _opLock = new();
+        private static readonly Dictionary<DispatcherOperation, long> _opStart = new();
+        private static int _slowLinesThisWindow;
+        private static long _slowWindowStartTicks;
+        private static int _slowSuppressed;
+        private static FieldInfo? _opMethodField;
+        private static FieldInfo? _timerTickField;
+        private static bool _methodFieldProbed;
+        private static bool _tickFieldProbed;
+
+        private static void InstallDispatcherHooks(Dispatcher dispatcher)
+        {
+            try
+            {
+                var hooks = dispatcher.Hooks;
+                hooks.OperationStarted += OnOperationStarted;
+                hooks.OperationCompleted += OnOperationFinished;
+                hooks.OperationAborted += OnOperationFinished;
+            }
+            catch { /* diagnostics must never take the app down */ }
+        }
+
+        private static void OnOperationStarted(object? sender, DispatcherHookEventArgs e)
+        {
+            try
+            {
+                lock (_opLock)
+                {
+                    // A completed/aborted op always removes itself; this cap only guards against an
+                    // op that somehow never finishes (shutdown races) pinning memory forever.
+                    if (_opStart.Count >= MaxTrackedOps) _opStart.Clear();
+                    _opStart[e.Operation] = Stopwatch.GetTimestamp();
+                }
+            }
+            catch { }
+        }
+
+        private static void OnOperationFinished(object? sender, DispatcherHookEventArgs e)
+        {
+            try
+            {
+                long started;
+                lock (_opLock)
+                {
+                    if (!_opStart.TryGetValue(e.Operation, out started)) return;
+                    _opStart.Remove(e.Operation);
+                }
+
+                long ms = (Stopwatch.GetTimestamp() - started) * 1000 / Stopwatch.Frequency;
+                if (ms < SlowOpMs) return;
+                if (!AllowSlowLine()) return;
+
+                Log("DISPATCH", $"slow op {ms}ms method={DescribeOperation(e.Operation)}");
+            }
+            catch { }
+        }
+
+        /// <summary>Rolling one-minute budget so a storm of slow ops can't drown the trace.</summary>
+        private static bool AllowSlowLine()
+        {
+            long now = DateTime.UtcNow.Ticks;
+            if (now - _slowWindowStartTicks > TimeSpan.TicksPerMinute)
+            {
+                int suppressed = _slowSuppressed;
+                _slowWindowStartTicks = now;
+                _slowLinesThisWindow = 0;
+                _slowSuppressed = 0;
+                if (suppressed > 0) Log("DISPATCH", $"({suppressed} further slow op line(s) suppressed by the rate limit)");
+            }
+            if (_slowLinesThisWindow >= MaxSlowLinesPerMinute) { _slowSuppressed++; return false; }
+            _slowLinesThisWindow++;
+            return true;
+        }
+
+        /// <summary>
+        /// Best-effort name of whatever the operation was running. The callback lives in a private
+        /// field of DispatcherOperation, so this is reflection — probed once, and every failure mode
+        /// degrades to "(unknown)" rather than throwing on the UI thread.
+        /// </summary>
+        private static string DescribeOperation(DispatcherOperation op)
+        {
+            try
+            {
+                if (!_methodFieldProbed)
+                {
+                    _methodFieldProbed = true;
+                    _opMethodField = typeof(DispatcherOperation)
+                        .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                        .FirstOrDefaultCompat(f => f.Name == "_method")
+                        ?? typeof(DispatcherOperation)
+                            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                            .FirstOrDefaultCompat(f => typeof(Delegate).IsAssignableFrom(f.FieldType));
+                }
+
+                var d = _opMethodField?.GetValue(op) as Delegate;
+                string name = d == null ? "(unknown)" : Describe(d, allowTimerDrill: true);
+                return $"{name} prio={op.Priority}";
+            }
+            catch { return "(unknown)"; }
+        }
+
+        private static string Describe(Delegate d, bool allowTimerDrill)
+        {
+            try
+            {
+                var m = d.Method;
+                var declaring = m.DeclaringType;
+                // A lambda's declaring type is a compiler-generated closure nested in the real owner;
+                // walk out to the owner so the line reads "FlashService.<Start>b__7_1", not "<>c".
+                string owner = (declaring?.Name?.StartsWith("<") == true
+                    ? declaring.DeclaringType?.Name
+                    : declaring?.Name) ?? "?";
+                string name = owner + "." + m.Name;
+
+                // DispatcherTimer posts DispatcherTimer.FireTick, which names nothing. Drill through
+                // to the Tick subscriber — that is the callback actually eating the UI thread.
+                if (allowTimerDrill && d.Target is DispatcherTimer timer)
+                {
+                    var sub = DescribeTimerTick(timer);
+                    if (!string.IsNullOrEmpty(sub)) name += " -> " + sub;
+                }
+                return name;
+            }
+            catch { return "(unknown)"; }
+        }
+
+        private static string? DescribeTimerTick(DispatcherTimer timer)
+        {
+            try
+            {
+                if (!_tickFieldProbed)
+                {
+                    _tickFieldProbed = true;
+                    _timerTickField = typeof(DispatcherTimer)
+                        .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                        .FirstOrDefaultCompat(f => f.Name == "Tick" || f.Name == "_tick");
+                }
+                if (_timerTickField?.GetValue(timer) is not Delegate tick) return null;
+                var list = tick.GetInvocationList();
+                if (list.Length == 0) return null;
+                return Describe(list[0], allowTimerDrill: false);
+            }
+            catch { return null; }
+        }
+    }
+
+    internal static class VideoDiagReflectionExtensions
+    {
+        /// <summary>Local FirstOrDefault so VideoDiag needs no LINQ import in its hot hook path.</summary>
+        internal static FieldInfo? FirstOrDefaultCompat(this FieldInfo[] fields, Func<FieldInfo, bool> match)
+        {
+            foreach (var f in fields) if (match(f)) return f;
+            return null;
         }
     }
 }

--- a/ConditioningControlPanel/Services/Video/VideoMetadataCache.cs
+++ b/ConditioningControlPanel/Services/Video/VideoMetadataCache.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using LibVLCSharp.Shared;
 using Newtonsoft.Json;
@@ -21,7 +22,30 @@ namespace ConditioningControlPanel.Services
     {
         private static string CacheFilePath => Path.Combine(App.UserDataPath, "video_metadata.json");
 
+        private const int ParseTimeoutMs = 5000;
+        /// <summary>
+        /// Delay between a parse finishing and releasing its Media. LibVLC raises the
+        /// parsed event from its own worker thread and can resume us inline on it while
+        /// still inside that media's event manager — releasing there frees the critical
+        /// section under the sender, which is the native 0xC0000005 behind #750-#753.
+        /// </summary>
+        private const int DisposeGraceMs = 1500;
+        private const int ReaperPeriodMs = 1000;
+        private const int SaveDebounceMs = 3000;
+        /// <summary>How many grace extensions a media gets before we leak it instead of freeing a live one.</summary>
+        private const int MaxDisposeDeferrals = 20;
+
         private readonly ConcurrentDictionary<string, double> _byKey = new();
+        /// <summary>Keys LibVLC couldn't give us a duration for. In-memory only, so a restart retries.</summary>
+        private readonly ConcurrentDictionary<string, byte> _unparseable = new();
+        private readonly ConcurrentDictionary<string, byte> _inFlight = new();
+        private readonly SemaphoreSlim _parseGate = new(1, 1);
+        private readonly ConcurrentQueue<CondemnedMedia> _condemned = new();
+        private readonly object _reaperLock = new();
+        private readonly object _saveTimerLock = new();
+        private Timer? _reaper;
+        private Timer? _saveTimer;
+        private int _reaping;
         private readonly LibVLC _libVlc;
         private readonly object _saveLock = new();
         private bool _dirty;
@@ -30,6 +54,19 @@ namespace ConditioningControlPanel.Services
         {
             _libVlc = libVlc;
             Load();
+        }
+
+        private sealed class CondemnedMedia
+        {
+            public CondemnedMedia(Media media, DateTime notBeforeUtc)
+            {
+                Media = media;
+                NotBeforeUtc = notBeforeUtc;
+            }
+
+            public Media Media { get; }
+            public DateTime NotBeforeUtc { get; set; }
+            public int Deferrals { get; set; }
         }
 
         /// <summary>
@@ -45,32 +82,213 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// Fetches the duration, parsing via LibVLC if not cached. Returns
-        /// null on parse failure. Safe to call repeatedly — only the first
-        /// call per path actually parses.
+        /// null on parse failure, and also when a parse for this path is already
+        /// queued — callers treat that exactly like a cache miss. Parses are
+        /// serialized, so this can take a while; nothing waits on the result.
         /// </summary>
         public async Task<double?> GetOrComputeDurationAsync(string path)
         {
             var key = ComputeKey(path);
             if (key == null) return null;
             if (_byKey.TryGetValue(key, out var cached)) return cached;
+            if (_unparseable.ContainsKey(key)) return null;
+            // A refill fires one of these per uncached video (24+ on a cold cache) and
+            // does it again on the next refill. Collapse repeats so the queue behind the
+            // gate can't grow past one entry per distinct video.
+            if (!_inFlight.TryAdd(key, 0)) return null;
 
             try
             {
-                using var media = new Media(_libVlc, path, FromType.FromPath);
-                var result = await media.Parse(MediaParseOptions.ParseLocal, timeout: 5000);
-                if (result == MediaParsedStatus.Done && media.Duration > 0)
+                // One parse at a time: every concurrent preparse is another live media
+                // whose event manager we might free out from under it (#750-#753), for
+                // metadata that only affects the *next* refill.
+                await _parseGate.WaitAsync().ConfigureAwait(false);
+                try
                 {
-                    var seconds = media.Duration / 1000.0;
-                    _byKey[key] = seconds;
-                    _dirty = true;
-                    return seconds;
+                    if (_byKey.TryGetValue(key, out cached)) return cached;
+                    return await ParseDurationAsync(path, key).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _parseGate.Release();
                 }
             }
             catch (Exception ex)
             {
                 App.Logger?.Debug("VideoMetadataCache: parse failed for {Path}: {Error}", path, ex.Message);
+                return null;
+            }
+            finally
+            {
+                _inFlight.TryRemove(key, out _);
+                ReapCondemned();
+            }
+        }
+
+        private async Task<double?> ParseDurationAsync(string path, string key)
+        {
+            Media? media = null;
+            try
+            {
+                media = new Media(_libVlc, path, FromType.FromPath);
+                var result = await media.Parse(MediaParseOptions.ParseLocal, timeout: ParseTimeoutMs)
+                    .ConfigureAwait(false);
+
+                // LibVLCSharp completes the parse task from the LibVLC event thread and can
+                // resume us inline on it. Get off that thread before touching the media
+                // again — see DisposeGraceMs.
+                await Task.Yield();
+
+                if (result == MediaParsedStatus.Done && media.Duration > 0)
+                {
+                    var seconds = media.Duration / 1000.0;
+                    _byKey[key] = seconds;
+                    _dirty = true;
+                    ScheduleSave();
+                    return seconds;
+                }
+                _unparseable[key] = 0;
+            }
+            catch (Exception ex)
+            {
+                _unparseable[key] = 0;
+                App.Logger?.Debug("VideoMetadataCache: parse failed for {Path}: {Error}", path, ex.Message);
+            }
+            finally
+            {
+                if (media != null) Condemn(media);
             }
             return null;
+        }
+
+        /// <summary>
+        /// Hands a finished-with media to the reaper instead of disposing it here. Never
+        /// dispose a Media on the heels of its own parse: the preparser may still be
+        /// inside its event manager, and the release frees that memory under it.
+        /// </summary>
+        private void Condemn(Media media)
+        {
+            try
+            {
+                var status = media.ParsedStatus;
+                // Anything short of a finished parse may still be running - ask it to stop.
+                // ParseStop is asynchronous too; the grace below is what actually waits.
+                if (status != MediaParsedStatus.Done && status != MediaParsedStatus.Failed)
+                    media.ParseStop();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("VideoMetadataCache: ParseStop failed: {Error}", ex.Message);
+            }
+
+            _condemned.Enqueue(new CondemnedMedia(media, DateTime.UtcNow.AddMilliseconds(DisposeGraceMs)));
+            EnsureReaper();
+        }
+
+        /// <summary>
+        /// Disposes condemned media whose grace has elapsed and whose parse has settled.
+        /// Anything still unsettled gets another grace period, and after
+        /// <see cref="MaxDisposeDeferrals"/> of those we drop the reference without
+        /// disposing — a leaked native media is survivable, freeing a live one is not.
+        /// (LibVLCSharp's Media has no finalizer, so dropping it really does leak-not-free.)
+        /// </summary>
+        private void ReapCondemned()
+        {
+            if (_condemned.IsEmpty) return;
+            if (Interlocked.CompareExchange(ref _reaping, 1, 0) != 0) return;
+            try
+            {
+                var now = DateTime.UtcNow;
+                var carry = new List<CondemnedMedia>();
+                var pass = _condemned.Count;
+                for (var i = 0; i < pass && _condemned.TryDequeue(out var item); i++)
+                {
+                    if (item.NotBeforeUtc > now)
+                    {
+                        carry.Add(item);
+                        continue;
+                    }
+                    if (!IsParseSettled(item.Media))
+                    {
+                        if (++item.Deferrals >= MaxDisposeDeferrals)
+                        {
+                            App.Logger?.Debug("VideoMetadataCache: leaking a media whose parse never settled");
+                            continue;
+                        }
+                        item.NotBeforeUtc = now.AddMilliseconds(DisposeGraceMs);
+                        carry.Add(item);
+                        continue;
+                    }
+                    try { item.Media.Dispose(); }
+                    catch (Exception ex) { App.Logger?.Debug("VideoMetadataCache: media dispose failed: {Error}", ex.Message); }
+                }
+                foreach (var c in carry) _condemned.Enqueue(c);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _reaping, 0);
+            }
+
+            if (_condemned.IsEmpty)
+            {
+                lock (_reaperLock)
+                {
+                    if (_condemned.IsEmpty)
+                    {
+                        _reaper?.Dispose();
+                        _reaper = null;
+                    }
+                }
+            }
+        }
+
+        /// <summary>True once LibVLC has reported a terminal parse status for this media.</summary>
+        private static bool IsParseSettled(Media media)
+        {
+            try
+            {
+                var status = media.ParsedStatus;
+                return status == MediaParsedStatus.Done
+                    || status == MediaParsedStatus.Failed
+                    || status == MediaParsedStatus.Timeout
+                    || status == MediaParsedStatus.Skipped;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void EnsureReaper()
+        {
+            lock (_reaperLock)
+            {
+                _reaper ??= new Timer(_ =>
+                {
+                    try { ReapCondemned(); }
+                    catch (Exception ex) { App.Logger?.Debug("VideoMetadataCache: reaper failed: {Error}", ex.Message); }
+                }, null, ReaperPeriodMs, ReaperPeriodMs);
+            }
+        }
+
+        /// <summary>Debounced write-behind so a warmed cache actually survives to the next launch.</summary>
+        private void ScheduleSave()
+        {
+            lock (_saveTimerLock)
+            {
+                if (_saveTimer == null)
+                {
+                    _saveTimer = new Timer(_ =>
+                    {
+                        try { Save(); }
+                        catch (Exception ex) { App.Logger?.Debug("VideoMetadataCache: deferred save failed: {Error}", ex.Message); }
+                    }, null, SaveDebounceMs, Timeout.Infinite);
+                }
+                else
+                {
+                    _saveTimer.Change(SaveDebounceMs, Timeout.Infinite);
+                }
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -113,6 +113,7 @@ namespace ConditioningControlPanel.Services
         private DispatcherTimer? _heartbeatTimer;
         private long _uiHeartbeatTicks;
         private volatile bool _wedgeRescueFired;
+        private volatile bool _preRollStallLogged; // one pre-roll stall line per armed watchdog
         // Fire only after a long, unambiguous stall — this targets the multi-minute lockouts, never a
         // UI thread that's merely busy for a beat. The legitimate ~4s teardown pump-wait keeps the
         // heartbeat ticking (it pumps Background-priority work), so it won't trip this.
@@ -131,6 +132,15 @@ namespace ConditioningControlPanel.Services
 
         private bool _isRunning;
         private bool _videoPlaying;
+        // True only once a real player/window exists on screen. _videoPlaying goes true ~2.6s
+        // EARLIER — at the top of PlayVideo, before the Discord/flash/duck prologue and the 1.3s
+        // announce delay — so it cannot be used to answer "is playback actually live?". The wedge
+        // watchdog used to ask exactly that of _videoPlaying and treated a pre-roll stall as a
+        // wedged playback, whose rescue rebuilds LibVLC on a background thread while the UI thread
+        // is on its way into EnsureLibVLCInitialized: a _libVLCLock race that killed the process
+        // natively with an empty crash.log (#750-#753). Set in StartVideoPlayback, cleared by every
+        // teardown path.
+        private volatile bool _playbackStarted;
         private bool _triggerInProgress; // Guards the 800ms freeze delay window in TriggerVideo
         private bool _strictActive;
         // True across the strict retry GAP: from the moment a strict run's attention check fails
@@ -1318,6 +1328,7 @@ namespace ConditioningControlPanel.Services
             _maxLenCapTimer?.Stop();
             _maxLenCapTimer = null;
             _videoPlaying = false;
+            _playbackStarted = false;
             _triggerInProgress = false;
             _strictActive = false;
             CancelPendingRetry();
@@ -1670,6 +1681,7 @@ namespace ConditioningControlPanel.Services
             if (!isVoutRetry) _voutRetryUsed = false;
 
             _videoPlaying = true;
+            _playbackStarted = false; // nothing is on screen yet — we are entering pre-roll
             _strictActive = strict;
             // A video is on screen again, so whatever gap we were covering is over. Cleared HERE,
             // after the two flags above are already set, so a reader on another thread never sees a
@@ -1682,6 +1694,8 @@ namespace ConditioningControlPanel.Services
 
             // Arm the off-thread wedge watchdog NOW, before any window is created — the freeze often
             // strikes mid window-creation of this video, before the safety timers get a chance to arm.
+            // During pre-roll it can only OBSERVE (a stall diag line); the destructive rescue is
+            // gated on _playbackStarted and re-armed from StartVideoPlayback. See WedgeWatchdogTick.
             StartWedgeWatchdog();
 
             // Update Discord presence
@@ -1854,6 +1868,17 @@ namespace ConditioningControlPanel.Services
                         Cleanup();
                     }
                 });
+
+                // Playback is REAL from here: a window (and, on the LibVLC path, a registered media
+                // player) exists. Only now may the wedge watchdog do its destructive retire/rescue.
+                // Re-arm it so the pre-roll's stall — which is exactly what the reporters hit while
+                // Duck() enumerated their audio endpoints — doesn't count toward the wedge threshold
+                // and immediately trip a rescue against a perfectly healthy playback (#750-#753).
+                if (_windows.Count > 0)
+                {
+                    _playbackStarted = true;
+                    StartWedgeWatchdog();
+                }
 
                 VideoDiag.Log("VIDEO", $"show complete - {_windows.Count} window(s) on screen");
                 VideoStarted?.Invoke(this, EventArgs.Empty);
@@ -4019,6 +4044,7 @@ namespace ConditioningControlPanel.Services
         private void StartWedgeWatchdog()
         {
             _wedgeRescueFired = false;
+            _preRollStallLogged = false;
             System.Threading.Interlocked.Exchange(ref _uiHeartbeatTicks, DateTime.UtcNow.Ticks);
 
             // UI-thread heartbeat: proves the dispatcher is still draining. Background priority so a
@@ -4050,6 +4076,10 @@ namespace ConditioningControlPanel.Services
         /// heart-beating for <see cref="WedgeStallMs"/>, the dispatcher is wedged (frozen final frame,
         /// topmost window holding the screen). Break it off-thread and queue a teardown so the app
         /// recovers without a hard shutdown. Fires at most once per playback.
+        ///
+        /// PRE-ROLL is observe-only: see <see cref="_playbackStarted"/>. Retiring LibVLC while the
+        /// UI thread is still walking PlayVideo's prologue towards EnsureLibVLCInitialized races the
+        /// background rebuild on _libVLCLock and takes the process down natively (#750-#753).
         /// </summary>
         private void WedgeWatchdogTick()
         {
@@ -4060,6 +4090,22 @@ namespace ConditioningControlPanel.Services
                 var last = System.Threading.Interlocked.Read(ref _uiHeartbeatTicks);
                 var stallMs = (DateTime.UtcNow.Ticks - last) / TimeSpan.TicksPerMillisecond;
                 if (stallMs < WedgeStallMs) return;
+
+                bool live = _playbackStarted;
+                if (!live) lock (_mediaPlayersLock) { live = _mediaPlayers.Count > 0; }
+                if (!live)
+                {
+                    // The UI thread IS stalled, but there is nothing on screen to rescue yet.
+                    // Record it (once) and let the next tick reconsider — whatever the prologue is
+                    // blocked on will either finish, or the app will die where the trace points.
+                    if (!_preRollStallLogged)
+                    {
+                        _preRollStallLogged = true;
+                        App.Logger?.Warning("VideoService: UI thread stalled {StallMs}ms during video PRE-ROLL — no rescue (nothing on screen yet)", stallMs);
+                        VideoDiag.Log("WEDGE", $"UI thread stalled {stallMs}ms during PRE-ROLL - observing only, no LibVLC retire");
+                    }
+                    return;
+                }
 
                 _wedgeRescueFired = true;
                 App.Logger?.Error(
@@ -4202,6 +4248,7 @@ namespace ConditioningControlPanel.Services
                 // Closing veto (SetupStrictHandlers) can never block the window teardown
                 // below, even if a caller forgot to clear it.
                 _videoPlaying = false;
+                _playbackStarted = false;
                 // Invalidate any in-flight watchdog continuation (see _teardownGeneration).
                 System.Threading.Interlocked.Increment(ref _teardownGeneration);
             }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1103,6 +1103,11 @@ namespace ConditioningControlPanel.Services
             // PlayVideo, LibVLC window creation) is UI-affine and must stay there.
             Task.Run(() =>
             {
+                // Bracketed because this step is invisible from the outside and can take seconds
+                // (content-pack decrypt, full-library refill). A trace that shows SELECT: begin and
+                // never an end means the trigger died here, not in playback (#750-#753).
+                var selectSw = System.Diagnostics.Stopwatch.StartNew();
+                VideoDiag.Log("SELECT", "begin (off-thread)");
                 string? selected = null;
                 try
                 {
@@ -1112,6 +1117,7 @@ namespace ConditioningControlPanel.Services
                 {
                     App.Logger?.Error(ex, "VideoService: GetNextVideo failed");
                 }
+                VideoDiag.Log("SELECT", $"end after {selectSw.ElapsedMilliseconds}ms clip={(selected == null ? "(none)" : Path.GetFileName(selected))}");
 
                 DispatcherHelper.RunOnUI(() =>
                 {
@@ -1692,20 +1698,30 @@ namespace ConditioningControlPanel.Services
             _hits = _total = 0;
             _spawnTimes.Clear();
 
+            // Everything from here to the delay timer's tick used to be a diag blind spot: the trace
+            // jumped straight from "BEGIN" to "libvlc-init begin" ~2.6s later, so a report whose
+            // freeze began inside this prologue told us nothing about WHICH step ate the dispatcher.
+            // One breadcrumb per step, each carrying the elapsed prologue time (#750-#753).
+            var prologueSw = System.Diagnostics.Stopwatch.StartNew();
+
             // Arm the off-thread wedge watchdog NOW, before any window is created — the freeze often
             // strikes mid window-creation of this video, before the safety timers get a chance to arm.
             // During pre-roll it can only OBSERVE (a stall diag line); the destructive rescue is
             // gated on _playbackStarted and re-armed from StartVideoPlayback. See WedgeWatchdogTick.
             StartWedgeWatchdog();
+            VideoDiag.Log("VIDEO", $"prologue: wedge watchdog armed +{prologueSw.ElapsedMilliseconds}ms");
 
             // Update Discord presence
             App.DiscordRpc?.SetVideoActivity();
+            VideoDiag.Log("VIDEO", $"prologue: SetVideoActivity +{prologueSw.ElapsedMilliseconds}ms");
 
             // Fire pre-announcement event 1.3s before video starts
             VideoAboutToStart?.Invoke(this, EventArgs.Empty);
+            VideoDiag.Log("VIDEO", $"prologue: VideoAboutToStart handlers +{prologueSw.ElapsedMilliseconds}ms");
 
             // Stop flashes during video
             App.Flash?.Stop();
+            VideoDiag.Log("VIDEO", $"prologue: Flash.Stop +{prologueSw.ElapsedMilliseconds}ms");
 
             // Duck other apps. Record that we took a duck ref so CloseAll releases exactly one
             // matching Unduck on teardown — otherwise a retry/troll "watch again" loop ducks again
@@ -1714,6 +1730,9 @@ namespace ConditioningControlPanel.Services
             {
                 App.Audio?.Duck(App.Settings.Current.DuckingLevel);
                 _didDuck = true;
+                // Duck() only queues now — the sweep's own "DUCK: duck applied after Nms" line
+                // (AudioService) is what says how long the WASAPI walk actually took.
+                VideoDiag.Log("VIDEO", $"prologue: Duck requested +{prologueSw.ElapsedMilliseconds}ms");
             }
 
             // Delay video start by 1.3 seconds to allow avatar to announce
@@ -1722,10 +1741,12 @@ namespace ConditioningControlPanel.Services
             delayTimer.Tick += (s, e) =>
             {
                 delayTimer.Stop();
+                VideoDiag.Log("VIDEO", $"prologue: delay timer ticked +{prologueSw.ElapsedMilliseconds}ms - starting playback");
                 App.Logger?.Debug("VideoService: Delay complete, calling StartVideoPlayback");
                 StartVideoPlayback(path, strict);
             };
             delayTimer.Start();
+            VideoDiag.Log("VIDEO", $"prologue: 1.3s delay timer scheduled +{prologueSw.ElapsedMilliseconds}ms");
         }
 
         private void StartVideoPlayback(string path, bool strict)

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1753,10 +1753,17 @@ namespace ConditioningControlPanel.Services
         {
             App.Logger?.Information("VideoService: StartVideoPlayback called for {File}", Path.GetFileName(path));
 
+            // Every step from here to the first frame is bracketed (#750-#753): the reporters' crash
+            // lands somewhere in this window with an empty crash.log, so the LAST breadcrumb in the
+            // trace is the only thing that says which native call the process died inside.
+            var showSw = System.Diagnostics.Stopwatch.StartNew();
+            VideoDiag.Log("VIDEO", "StartVideoPlayback entry");
+
             // Safety check: ensure app is still running
             if (Application.Current == null)
             {
                 App.Logger?.Warning("VideoService: Application.Current is null, aborting playback");
+                VideoDiag.Log("VIDEO", "StartVideoPlayback ABORT - Application.Current is null");
                 return;
             }
 
@@ -1773,6 +1780,7 @@ namespace ConditioningControlPanel.Services
                 // that slipped past selection. Wall-clock from playback start; a few seconds of LibVLC
                 // startup latency before frames roll is negligible against a minutes-long cap.
                 StartMaxLengthCapTimer();
+                VideoDiag.Log("VIDEO", $"safety + max-length timers armed +{showSw.ElapsedMilliseconds}ms");
 
                 // Ensure LibVLC is initialized (deferred from startup for faster launch).
                 // #616-#623 NOTE: this call runs ON THE UI THREAD and takes _libVLCLock, which a
@@ -1788,11 +1796,13 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Information("VideoService: LibVLC initialized = {Initialized}, LibVLC instance = {HasInstance}",
                     _libVLCInitialized, _libVLC != null);
 
+                VideoDiag.Log("VIDEO", $"show block begin (RunOnUISync) +{showSw.ElapsedMilliseconds}ms");
                 DispatcherHelper.RunOnUISync(() =>
                 {
                     try
                     {
                         var allScreens = App.GetAllScreensCached().ToList();
+                        VideoDiag.Log("VIDEO", $"screens enumerated ({allScreens.Count}) +{showSw.ElapsedMilliseconds}ms");
                         if (allScreens.Count == 0)
                         {
                             App.Logger?.Error("VideoService: No screens available - cannot play video");
@@ -1873,14 +1883,20 @@ namespace ConditioningControlPanel.Services
                         // never triggers a z-order raise. Focus-preserving, so ESC/panic still work.
                         foreach (var w in _windows) PreventClickRaise(w);
 
+                        VideoDiag.Log("VIDEO", $"z-order guards applied +{showSw.ElapsedMilliseconds}ms");
+
                         // Ambient bubble game: pause + clear so it doesn't fight the video for
                         // clicks / z-order (no-op during a chaos run, which isn't "running").
                         // A chaos run keeps its bubbles + HUD alive and lifts them back above the
                         // video itself — see ChaosModeService's VideoStarted handler.
                         App.Bubbles?.PauseAndClear();
+                        VideoDiag.Log("VIDEO", $"bubbles paused +{showSw.ElapsedMilliseconds}ms");
 
                         if (App.Settings.Current.AttentionChecksEnabled)
+                        {
                             SetupAttention();
+                            VideoDiag.Log("VIDEO", $"attention checks armed +{showSw.ElapsedMilliseconds}ms");
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1901,7 +1917,7 @@ namespace ConditioningControlPanel.Services
                     StartWedgeWatchdog();
                 }
 
-                VideoDiag.Log("VIDEO", $"show complete - {_windows.Count} window(s) on screen");
+                VideoDiag.Log("VIDEO", $"show complete +{showSw.ElapsedMilliseconds}ms - {_windows.Count} window(s) on screen");
                 VideoStarted?.Invoke(this, EventArgs.Empty);
                 _ = App.Haptics?.StartVideoBackgroundVibeAsync();
                 App.Logger?.Information("Playing: {File}", Path.GetFileName(path));
@@ -1927,9 +1943,16 @@ namespace ConditioningControlPanel.Services
             Window? win = null;
             LibVLCSharp.Shared.MediaPlayer? mediaPlayer = null;
 
+            // Sub-step breadcrumbs for the single longest UI-thread block in the show path. The
+            // window-create bracket alone only says "it died in here"; these say WHICH native call
+            // (DPI probe, surface build, LibVLC player ctor, Show(), Play()) it died inside.
+            var winSw = System.Diagnostics.Stopwatch.StartNew();
+            string tag = withAudio ? "primary" : "secondary";
+
             try
             {
                 var dpiScale = BubbleCountWindow.GetDpiForScreen(screen);
+                VideoDiag.Log("VIDEO", $"win[{tag}]: dpi probed +{winSw.ElapsedMilliseconds}ms");
                 win = new Window
                 {
                     WindowStyle = WindowStyle.None,
@@ -1957,6 +1980,7 @@ namespace ConditioningControlPanel.Services
                 // play, unlike a pre-parse of the container), and the blurred fill auto-hides for a
                 // clip that already matches the screen — so a landscape video pays no blur cost.
                 bool useBlur = App.Settings?.Current?.VideoBlurredBackgroundEnabled == true;
+                VideoDiag.Log("VIDEO", $"win[{tag}]: shell created (blur={useBlur}) +{winSw.ElapsedMilliseconds}ms");
 
                 // Create the video surface: either the blurred-background composite or a VideoView.
                 VideoView? videoView = null;
@@ -1978,9 +2002,11 @@ namespace ConditioningControlPanel.Services
                         Background = Brushes.Black
                     };
                 }
+                VideoDiag.Log("VIDEO", $"win[{tag}]: surface built +{winSw.ElapsedMilliseconds}ms");
 
                 // Create media player for this video.
                 mediaPlayer = new LibVLCSharp.Shared.MediaPlayer(_libVLC!);
+                VideoDiag.Log("VIDEO", $"win[{tag}]: MediaPlayer ctor +{winSw.ElapsedMilliseconds}ms");
                 // Mandatory-video windows default to SOFTWARE decoding. On Windows 11 (build 26200)
                 // and some Win10 machines the LibVLC hardware (DXVA/D3D11) path intermittently fails
                 // to present a frame — the window stays white and MediaEnded never fires, wedging
@@ -2189,9 +2215,12 @@ namespace ConditioningControlPanel.Services
             // Pin to the monitor's true physical bounds so a secondary monitor with different DPI
             // scaling gets the full screen instead of a part-width window (see ForceFullScreenBounds).
             ForceFullScreenBounds(win, screen);
+            VideoDiag.Log("VIDEO", $"win[{tag}]: Show() begin +{winSw.ElapsedMilliseconds}ms");
             win.Show();
+            VideoDiag.Log("VIDEO", $"win[{tag}]: Show() end +{winSw.ElapsedMilliseconds}ms");
             if (withAudio) win.Activate();
             DisableChildWindowInput(win);
+            VideoDiag.Log("VIDEO", $"win[{tag}]: activated +{winSw.ElapsedMilliseconds}ms");
 
             // Attach media player to the surface and start playback. The blurred path wires LibVLC
             // memory callbacks (SetVideoFormat + SetVideoCallbacks) instead of a VideoView; it must
@@ -2200,11 +2229,13 @@ namespace ConditioningControlPanel.Services
                 blurSurface!.Attach(mediaPlayer);
             else
                 videoView!.MediaPlayer = mediaPlayer;
+            VideoDiag.Log("VIDEO", $"win[{tag}]: surface attached +{winSw.ElapsedMilliseconds}ms");
 
             // Create media - use file path directly for better compatibility
             // Media is disposed after Play() — LibVLC internally ref-counts, so this is safe
             // (DualMonitorVideoService already uses this pattern with 'using var media')
             using var media = new Media(_libVLC!, path, FromType.FromPath);
+            VideoDiag.Log("VIDEO", $"win[{tag}]: Media ctor +{winSw.ElapsedMilliseconds}ms");
             // Secondaries skip audio decoding entirely. Setting Mute=true after Play() opened
             // a second WASAPI session on the same MMDevice; Windows collapsed both into one
             // per-app mixer slider and the result was doubled/desynced or zero-volume audio.
@@ -2254,7 +2285,9 @@ namespace ConditioningControlPanel.Services
             }
 
             // Play the media
+            VideoDiag.Log("VIDEO", $"win[{tag}]: Play() issued +{winSw.ElapsedMilliseconds}ms");
             mediaPlayer.Play(media);
+            VideoDiag.Log("VIDEO", $"win[{tag}]: Play() returned +{winSw.ElapsedMilliseconds}ms");
 
             // Configure audio AFTER Play() - LibVLC sometimes ignores settings before playback.
             // Don't call SetAudioTrack here: Play() is async and tracks aren't enumerated yet,


### PR DESCRIPTION
## Summary

Fixes the v6.6.1 crash cluster (ccp-bugs #750/#751/#752/#753, dup: #753=#752): the app died natively (empty crash.log) ~0-10s after a mandatory video trigger.

**Root cause (procdump, 3 identical dumps):** native AV 0xC0000005 on a LibVLC worker thread - a use-after-free on a Media object. VideoMetadataCache disposed each Media the instant Parse's await returned (including inline ON the LibVLC event thread via ConfigureAwait(false), and on timeouts while the preparser still held its event manager). The queue refill fired parses for every uncached video at once (24 observed), and the cache never persisted (Save had no callers), so the swarm re-ran on every refill.

## Changes

- fix(video) 45d170e2: Media never disposed mid-parse - Task.Yield off the VLC event thread, ParseStop + status-gated deferred reaper (leak-until-safe fallback), parses serialized (1 at a time), cache finally persists (debounced Save), in-memory negative cache
- fix(audio) b00034e2: Duck/Unduck WASAPI sweeps moved to a serialized worker (own MMDeviceEnumerator - the STA one marshals back to the dispatcher); _lockObj never held across COM; rescan skips cycles instead of queueing
- fix(video) 97172ca2: wedge rescue no longer retires LibVLC during pre-roll (gated on actual playback)
- feat(diag) 3bd43193 + cfbd98f4: video-diag breadcrumbs through the formerly blind pre-roll/prologue, SELECT + per-window step tracing, slow-dispatcher-op tracer, WATCHDOG lines mirrored into video-diag.log
- fix(discord) d30fa1ff: achievement-sharing opt-in now offered on first-time login; share toggles persist immediately (ccp-bugs #749)

## Verification

- Automated A/B play-test on the reporter recipe (flash 100/min + bubbles + video, cold cache, duration filter): baseline 5/5 process deaths on trigger 1; after fix **8/8 triggers survived**, all 24 parses completed, video_metadata.json written in 4.1s, warm restart re-parsed nothing
- Duck round-trip measured via WASAPI session volume: 1.000 -> 0.730 -> 1.000 across all rounds incl. 3 natural video ends
- Crash recovery (ducking_recovery.json) verified across real crashes
- Known separate issue observed once: pre-existing black-screen self-heal path (#616 family) fired and recovered - not introduced here, needs its own ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6E95zZ1HTW5bZ1fcF1bna