### PR TITLE
chore(release): bump to v6.6.2 - Video Hotfix

### DIFF
--- a/ConditioningControlPanel/ConditioningControlPanel.csproj
+++ b/ConditioningControlPanel/ConditioningControlPanel.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>ConditioningControlPanel</AssemblyName>
     <RootNamespace>ConditioningControlPanel</RootNamespace>
-    <Version>6.6.1</Version>
+    <Version>6.6.2</Version>
     <Company>CodeBambi</Company>
     <Product>Conditioning Control Panel</Product>
     <Description>A professional visual conditioning application with gamification features.</Description>

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "Wenn dir das Projekt gefällt, ",
   "label_consider_supporting_it": "unterstütze es gerne",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Ein besonderer Dank an Platinum Puppets für die bereitgestellten Audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -985,6 +985,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "If you love the project please ",
   "label_consider_supporting_it": "consider supporting it",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "A special thanks to Platinum Puppets for providing the audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "Si te encanta el proyecto, por favor ",
   "label_consider_supporting_it": "considera apoyarlo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un agradecimiento especial a Platinum Puppets por proporcionar los audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "Si tu aimes ce projet, ",
   "label_consider_supporting_it": "pense à le soutenir",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Un merci spécial aux Platinum Puppets pour les audios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "このプロジェクトが気に入ったら",
   "label_consider_supporting_it": "ぜひ支援をご検討ください",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Platinum Puppetsのオーディオ提供に感謝します ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "이 프로젝트가 마음에 드셨다면 ",
   "label_consider_supporting_it": "후원을 고려해 주세요",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "오디오를 제공해 주신 Platinum Puppets에게 특별히 감사드려요 ❤️",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "Se você ama o projeto, por favor ",
   "label_consider_supporting_it": "considere apoiá-lo",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Um agradecimento especial às Platinum Puppets por fornecerem os áudios ❤️",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -214,6 +214,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "Если тебе нравится проект, ",
   "label_consider_supporting_it": "поддержи его",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "Особая благодарность Platinum Puppets за предоставленные аудио ❤️",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -805,6 +805,8 @@
   "tooltip_v6_6_0_enrolled": "v6.6.0 - Enrolled 💗",
   "btn_v6_6_1_is_out": "💖 v6.6.1 IS OUT! 💖",
   "tooltip_v6_6_1_airhead_august": "v6.6.1 - Airhead August 💗",
+  "btn_v6_6_2_is_out": "💖 v6.6.2 IS OUT! 💖",
+  "tooltip_v6_6_2_video_hotfix": "v6.6.2 - Video Hotfix 💗",
   "label_if_you_love_the_project_please": "如果你喜欢这个项目，请",
   "label_consider_supporting_it": "考虑支持它",
   "label_a_special_thanks_to_platinum_puppets_for_prov": "特别感谢 Platinum Puppets 提供音频 ❤️",

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -587,8 +587,8 @@
                             </Style>
                         </ComboBox.ItemContainerStyle>
                     </ComboBox>
-                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_6_1_is_out}"
-                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_6_1_airhead_august}"
+                    <Button x:Name="BtnUpdateAvailable" Content="{loc:Str btn_v6_6_2_is_out}"
+                            Click="BtnUpdateAvailable_Click" ToolTip="{loc:Str tooltip_v6_6_2_video_hotfix}"
                             FontSize="11" FontWeight="Bold" Cursor="Hand">
                         <Button.Style>
                             <Style TargetType="Button">

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -20,29 +20,22 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Current application version - UPDATE THIS WHEN BUMPING VERSION
         /// </summary>
-        public const string AppVersion = "6.6.1";
+        public const string AppVersion = "6.6.2";
 
         /// <summary>
         /// Patch notes for the current version - UPDATE THIS WHEN BUMPING VERSION
         /// These are shown in the update dialog and can be used when GitHub release notes are unavailable.
         /// </summary>
-        public const string CurrentPatchNotes = @"v6.6.1 - Airhead August 💗
+        public const string CurrentPatchNotes = @"v6.6.2 - Video Hotfix 💗
 
 🔧 BUG FIXES
-- Program days that could never be completed are fixed. 33 tasks across all five programs asked for something their own session never delivered, and Kept Day 1 sat at 0% forever
-- Lock cards now always land inside your session. At 1 per hour the first card could be scheduled past the end of a short session, so it never arrived at all
-- Fixed a crash to desktop when the webcam failed to open and retried
-- Popping a video bubble no longer freezes the app
-- A detached companion keeps animating when you minimize the main window instead of freezing on one frame
-- The companion no longer occasionally replies with garbled text or with its own thinking notes
-- Your end-of-season recap card shows up again. The app was never told the season had rolled over, so the card silently never appeared
-
-📦 OTHER
-- Brain Drain and Brain Melt are withheld for now while we rework the effect. They are hidden from the Deeper editor pickers, and any enhancement that already uses one still plays normally - that overlay is simply skipped, nothing else about the video changes
+- Fixed the crash and freeze when a mandatory video starts. Reading a video file could take the whole app down with it, and it no longer can
+- Video length scanning is gentler now. One file at a time instead of all at once, and the result is remembered between sessions, so each video is only ever measured once
+- Audio ducking no longer runs on the UI thread. Videos start snappier and ducking can no longer freeze the app
+- Video playback now records far more detail when something goes wrong, so future reports are quicker to fix
 
 🎨 UI/UX
-- Saving a preset no longer implies your settings were not already saved
-- The Remote Control tab now tells you the pairing URL instead of leaving you to guess it
+- Discord now asks about achievement sharing after a first-time login too, and the sharing toggles save the moment you flip them
 
 Season: Airhead August";
 

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -7,7 +7,7 @@ echo ============================================
 echo.
 
 :: Configuration
-set VERSION=6.6.1
+set VERSION=6.6.2
 set PROJECT_DIR=ConditioningControlPanel
 set PUBLISH_DIR=%PROJECT_DIR%\bin\Release\net8.0-windows10.0.19041.0\win-x64\publish
 set INSTALLER_OUTPUT=installer-output

--- a/installer.iss
+++ b/installer.iss
@@ -13,7 +13,7 @@
 ; - Store install path in registry for Velopack updates
 
 #define MyAppName "Conditioning Control Panel"
-#define MyAppVersion "6.6.1"
+#define MyAppVersion "6.6.2"
 #define MyAppPublisher "CodeBambi"
 #define MyAppURL "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF"
 #define MyAppExeName "ConditioningControlPanel.exe"

--- a/notes-v6.6.2.txt
+++ b/notes-v6.6.2.txt
@@ -1,0 +1,14 @@
+v6.6.2 - Video Hotfix
+
+A critical hotfix for the crashes that hit when a mandatory video starts.
+
+BUG FIXES
+- Fixed the crash and freeze when a mandatory video starts. Reading a video file could take the whole app down with it, and it no longer can. This is the cause behind the crash reports that came in after 6.6.1.
+- Video length scanning is gentler now. Videos are measured one file at a time instead of all at once, and the result is remembered between sessions, so each video is only ever measured once.
+- Audio ducking no longer runs on the UI thread. Videos start snappier and ducking can no longer freeze the app.
+- Video playback now records far more detail when something goes wrong, so future reports are quicker to fix.
+
+UI/UX
+- Discord now asks about achievement sharing after a first-time login too, and the sharing toggles save the moment you flip them.
+
+Season: Airhead August


### PR DESCRIPTION
Version bump for the v6.6.2 hotfix (mandatory-video crash fix, ccp-bugs #750-#753 + #749).
All 7 version locations + 9 language files updated; strict-JSON parse and line endings verified; build 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6E95zZ1HTW5bZ1fcF1bna