### PR TITLE
fix: post-6.6.2 triage batch - video wedge cluster, haptics gate, browser desync, settings races (#760-#767)

### DIFF
--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
@@ -1198,6 +1198,11 @@ namespace ConditioningControlPanel
                 }
                 else
                 {
+                    // The embedded browser never issued the navigation, so release the session we
+                    // just claimed above — otherwise the app keeps treating a video that is not
+                    // playing here as an active web-media session.
+                    App.BrowserMedia?.OnMediaStopped("embedded-browser-unavailable");
+
                     // Fallback: open in external browser (HTTPS only for safety)
                     if (Uri.TryCreate(url, UriKind.Absolute, out var fallbackUri) && fallbackUri.Scheme == "https")
                     {

--- a/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
@@ -1232,14 +1232,20 @@ namespace ConditioningControlPanel
         /// but the media services hold their own caches/queues that only refill lazily —
         /// without this the mandatory video keeps playing from a stale full-pool queue
         /// (count says "1 active" while playback ignores the toggle until restart).
-        /// FlashService clears its 60s file-listing cache; Video/BubbleCount just empty
-        /// their queues (cheap, O(1)) and refill from the current selection on next use.
+        /// FlashService clears its 60s file-listing cache AND its live selection pools;
+        /// Video/BubbleCount just empty their queues (cheap, O(1)) and refill from the
+        /// current selection on next use.
+        /// DisabledAssetPaths is a HashSet mutated in place, so no PropertyChanged fires and
+        /// nothing autosaves — without the explicit save the toggle is lost on restart unless
+        /// the user also presses "Save Selection". Settings.Save() is debounced (500ms), so a
+        /// rapid run of checkbox clicks still costs one disk write.
         /// </summary>
         private void InvalidateAssetPoolsAfterSelectionChange()
         {
             App.Flash?.ClearFileCache();
             App.Video?.ReloadAssets();
             App.BubbleCount?.ReloadAssets();
+            App.Settings.Save();
         }
 
         internal void BtnSelectAllAssets_Click(object sender, RoutedEventArgs e)

--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -32,10 +32,26 @@ namespace ConditioningControlPanel
     {
         #region Browser
 
+        // True only while InitializeBrowserAsync is between its first await and completion.
+        // Re-entering there would tear down the browser it is still building.
+        private bool _browserInitializing;
+
+        // True between "CreateBrowserAsync handed back a control" and BrowserReady/BrowserInitFailed,
+        // i.e. while CoreWebView2 is still coming up in WebView_Loaded. During that window the
+        // browser legitimately fails the readiness check without being wedged — tearing it down
+        // there would kill an initialization that is still in flight.
+        private bool _browserCorePending;
+
         private async System.Threading.Tasks.Task InitializeBrowserAsync(string? overrideStartUrl = null)
         {
-            if (_browserInitialized) return;
+            if (_browserInitialized || _browserInitializing) return;
 
+            // A browser whose CoreWebView2 never came up leaves the flag cleared but the dead
+            // control still parented (embedded container or pop-out). Drop it before building a
+            // replacement, otherwise two WebView2s stack up and the visible one is the dead one.
+            if (_browser != null) TearDownBrowserForReinit("stale browser before re-init");
+
+            _browserInitializing = true;
             try
             {
                 SettingsTab.TxtBrowserStatus.Text = Loc.Get("label_loading");
@@ -65,6 +81,7 @@ namespace ConditioningControlPanel
                 {
                     Dispatcher.Invoke(() =>
                     {
+                        _browserCorePending = false;
                         SettingsTab.TxtBrowserStatus.Text = Loc.Get("label_connected_2");
                         SettingsTab.TxtBrowserStatus.Foreground = new SolidColorBrush(Color.FromRgb(0, 230, 118)); // Green
 
@@ -87,6 +104,10 @@ namespace ConditioningControlPanel
                             App.DeeperBrowserDiscovery?.Attach(_browser.WebView);
                             if (App.DeeperBrowserDiscovery != null)
                             {
+                                // The service outlives the BrowserService, so a re-init would
+                                // stack a second copy of these handlers on the same instance.
+                                App.DeeperBrowserDiscovery.Bound -= OnDeeperBrowserBound;
+                                App.DeeperBrowserDiscovery.Unbound -= OnDeeperBrowserUnbound;
                                 App.DeeperBrowserDiscovery.Bound += OnDeeperBrowserBound;
                                 App.DeeperBrowserDiscovery.Unbound += OnDeeperBrowserUnbound;
                             }
@@ -154,10 +175,29 @@ namespace ConditioningControlPanel
                         catch (Exception ex) { App.Logger?.Debug("Browser teardown after ProcessFailed: {Error}", ex.Message); }
                         _browser = null;
                         _browserInitialized = false;
+                        _browserCorePending = false;
                         SettingsTab.BrowserLoadingText.Visibility = Visibility.Visible;
                         SettingsTab.BrowserLoadingText.Text = "Browser crashed - click a site to restart";
                         SettingsTab.TxtBrowserStatus.Text = "Disconnected";
                         SettingsTab.TxtBrowserStatus.Foreground = new SolidColorBrush(Color.FromRgb(230, 80, 80));
+                    });
+                };
+
+                // CoreWebView2 never came up. _browserInitialized is set the moment
+                // CreateBrowserAsync hands back the control — i.e. before this can fire — so
+                // without clearing it here the flag latches true over a dead browser and every
+                // later Navigate is silently dropped for the process lifetime (#760).
+                _browser.BrowserInitFailed += (s, reason) =>
+                {
+                    Dispatcher.Invoke(() =>
+                    {
+                        App.Logger?.Warning("Browser init failed ({Reason}) - marking browser not ready", reason);
+                        _browserInitialized = false;
+                        _browserCorePending = false;
+                        SettingsTab.BrowserLoadingText.Visibility = Visibility.Visible;
+                        SettingsTab.BrowserLoadingText.Text = "Browser failed to start - click a site to retry";
+                        SettingsTab.TxtBrowserStatus.Text = Loc.Get("label_error_2");
+                        SettingsTab.TxtBrowserStatus.Foreground = new SolidColorBrush(Color.FromRgb(255, 107, 107));
                     });
                 };
 
@@ -177,6 +217,7 @@ namespace ConditioningControlPanel
                     SettingsTab.BrowserLoadingText.Visibility = Visibility.Collapsed;
                     SettingsTab.BrowserContainer.Children.Add(webView);
                     _browserInitialized = true;
+                    _browserCorePending = true;   // cleared by BrowserReady / BrowserInitFailed
                     SyncBrowserMuteIcon();
 
                     // Note: WebMessageReceived handler is attached in BrowserReady event
@@ -225,11 +266,73 @@ namespace ConditioningControlPanel
                 SettingsTab.TxtBrowserStatus.Foreground = new SolidColorBrush(Color.FromRgb(255, 107, 107));
                 MessageBox.Show(errorMsg, Loc.Get("title_browser_error"), MessageBoxButton.OK, MessageBoxImage.Error);
             }
+            finally
+            {
+                _browserInitializing = false;
+            }
         }
 
         internal async void BrowserLoadingText_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             await InitializeBrowserAsync();
+        }
+
+        /// <summary>
+        /// Drops a browser that can no longer navigate (CoreWebView2 never came up, or died)
+        /// so the next lazy-init builds a fresh one. Mirrors the BrowserProcessFailed teardown.
+        /// </summary>
+        private void TearDownBrowserForReinit(string reason)
+        {
+            App.Logger?.Warning("Tearing down browser for re-init: {Reason}", reason);
+
+            var dead = _browser;
+            var deadView = _browser?.WebView;
+
+            // Clear the fields FIRST: closing the pop-out below runs its Closed handler, which
+            // re-parents _browser.WebView back into the embedded container if it still sees one.
+            _browser = null;
+            _browserInitialized = false;
+            _browserCorePending = false;
+
+            try
+            {
+                if (deadView != null && SettingsTab.BrowserContainer.Children.Contains(deadView))
+                    SettingsTab.BrowserContainer.Children.Remove(deadView);
+
+                if (_browserPopoutWindow != null)
+                {
+                    _browserPopoutWindow.Content = null;
+                    _browserPopoutWindow.Close();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("Browser teardown before re-init: {Error}", ex.Message); }
+
+            try { (dead as IDisposable)?.Dispose(); } catch { }
+        }
+
+        /// <summary>
+        /// Brings whichever surface actually hosts the WebView to the front. When the browser is
+        /// popped out, activating MainWindow buries the pop-out the page loads into behind it,
+        /// which looks exactly like "the link did nothing" (#760).
+        /// </summary>
+        private void FocusBrowserSurface()
+        {
+            if (_browserPopoutWindow != null)
+            {
+                try
+                {
+                    if (_browserPopoutWindow.WindowState == WindowState.Minimized)
+                        _browserPopoutWindow.WindowState = WindowState.Normal;
+                    _browserPopoutWindow.Activate();
+                    _browserPopoutWindow.Focus();
+                }
+                catch (Exception ex) { App.Logger?.Debug("Failed to focus browser pop-out: {Error}", ex.Message); }
+                return;
+            }
+
+            ShowTab("settings");
+            Activate();
+            Focus();
         }
 
         private async System.Threading.Tasks.Task InitAndNavigateAsync(string url, bool autoPlayFullscreen)
@@ -240,7 +343,13 @@ namespace ConditioningControlPanel
             // WebView_Loaded (which runs after we'd return), so the request never reached
             // CoreWebView2 and the start-URL load (BambiCloud) stuck.
             await InitializeBrowserAsync(url);
-            if (!_browserInitialized || _browser == null) return;
+            if (!_browserInitialized || _browser == null)
+            {
+                // Init failed, and the synchronous caller already returned true — nothing else
+                // will retry, so hand the link to the system browser rather than eat it (#760).
+                OpenUrlExternallyAfterBrowserFailure(url);
+                return;
+            }
 
             // Sync the radio button to the URL we just initialized to so the toggle UI
             // matches the page. Suppress the toggle handler's homepage navigation since
@@ -284,10 +393,50 @@ namespace ConditioningControlPanel
                 _browser.NavigationCompleted += OnNavCompleted;
             }
 
-            // Show the Settings tab and bring the window forward
-            ShowTab("settings");
-            Activate();
-            Focus();
+            // Bring the surface hosting the browser forward (embedded tab or pop-out window)
+            FocusBrowserSurface();
+        }
+
+        /// <summary>
+        /// Defers a navigation until an in-flight CoreWebView2 bring-up finishes. Bounded: a
+        /// bring-up that never completes falls through to the external browser rather than
+        /// swallowing the click. Continuations resume on the dispatcher (UI thread).
+        /// </summary>
+        private async System.Threading.Tasks.Task NavigateWhenBrowserReadyAsync(string url, bool autoPlayFullscreen)
+        {
+            // Surface the browser while it finishes coming up, exactly as the ready path does —
+            // otherwise the click looks ignored for as long as the bring-up takes.
+            FocusBrowserSurface();
+
+            for (int i = 0; i < 60 && _browserCorePending; i++)
+                await Task.Delay(250);
+
+            if (_browser?.IsInitialized == true && _browser.WebView?.CoreWebView2 != null)
+            {
+                NavigateToUrlInBrowser(url, autoPlayFullscreen);
+                return;
+            }
+
+            App.Logger?.Warning("Browser never finished initializing - opening externally: {Url}", url);
+            OpenUrlExternallyAfterBrowserFailure(url);
+        }
+
+        /// <summary>
+        /// Last-resort escape hatch when the embedded browser cannot be brought up: open the
+        /// link in the system browser (HTTPS only) so the click isn't silently swallowed.
+        /// </summary>
+        private void OpenUrlExternallyAfterBrowserFailure(string url)
+        {
+            try
+            {
+                if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps) return;
+                App.Logger?.Warning("Embedded browser init failed, opening externally: {Url}", url);
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Failed to open URL externally: {Url}", url);
+            }
         }
 
         internal async void BrowserSiteToggle_Changed(object sender, RoutedEventArgs e)
@@ -359,9 +508,31 @@ namespace ConditioningControlPanel
                 return false;
             }
 
-            // Lazy-load browser if not yet initialized
-            if (!_browserInitialized)
+            // Lazy-load browser if it isn't REALLY ready. _browserInitialized only means
+            // CreateBrowserAsync handed back a control — it is set before CoreWebView2 exists, so
+            // it stays true over a browser whose init failed and every Navigate is then dropped in
+            // silence for the process lifetime (#760). Consult the service's own state too and
+            // re-init on mismatch so a wedged browser self-heals on the next click.
+            var browserReady = _browserInitialized && _browser != null
+                && _browser.IsInitialized && _browser.WebView?.CoreWebView2 != null;
+
+            if (!browserReady)
             {
+                if (_browserInitialized && _browserCorePending && _browser != null)
+                {
+                    // Not wedged - CoreWebView2 is simply still coming up (_browserInitialized is
+                    // set the moment CreateBrowserAsync returns, BrowserReady only fires once
+                    // WebView_Loaded finishes). Re-initializing here would tear down an init that
+                    // is still in flight, so wait it out and navigate when it lands.
+                    _ = NavigateWhenBrowserReadyAsync(url, autoPlayFullscreen);
+                    return true;
+                }
+                if (_browserInitialized)
+                {
+                    App.Logger?.Warning("Browser flagged ready but is not usable (service init={Init}, core={HasCore}) - re-initializing for {Url}",
+                        _browser?.IsInitialized == true, _browser?.WebView?.CoreWebView2 != null, url);
+                    _browserInitialized = false; // let InitializeBrowserAsync tear down and rebuild
+                }
                 _ = InitAndNavigateAsync(url, autoPlayFullscreen);
                 return true; // Navigation will happen after init completes
             }
@@ -374,10 +545,8 @@ namespace ConditioningControlPanel
 
             try
             {
-                // Bring window to focus and show the Settings tab (where the browser is)
-                ShowTab("settings");
-                Activate();
-                Focus();
+                // Bring the surface hosting the browser forward (embedded tab or pop-out window)
+                FocusBrowserSurface();
 
                 var lowerUrl = url.ToLowerInvariant();
 
@@ -407,6 +576,7 @@ namespace ConditioningControlPanel
                 // If auto-play fullscreen requested, set up handler for when navigation completes.
                 // BambiCloud playlists are audio (no <video> element, no fullscreen) — they need a
                 // different injection that clicks the playlist's main play button.
+                EventHandler<Microsoft.Web.WebView2.Core.CoreWebView2NavigationCompletedEventArgs>? navCompletedHandler = null;
                 if (autoPlayFullscreen && _browser.WebView?.CoreWebView2 != null)
                 {
                     var isBambiCloudPlaylist = lowerUrl.Contains("bambicloud.com/playlist/");
@@ -424,11 +594,25 @@ namespace ConditioningControlPanel
                         }
                     }
 
-                    _browser.WebView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+                    navCompletedHandler = OnNavigationCompleted;
+                    _browser.WebView.CoreWebView2.NavigationCompleted += navCompletedHandler;
+                }
+                else if (autoPlayFullscreen)
+                {
+                    App.Logger?.Warning("Auto-play/fullscreen requested but CoreWebView2 is null - takeover skipped: {Url}", url);
                 }
 
-                // Navigate
-                _browser.Navigate(url);
+                // Navigate. A dropped Navigate must surface as failure: reporting success here is
+                // what skipped the caller's external-browser fallback and made the click look
+                // like it did nothing at all (#760).
+                if (!_browser.Navigate(url))
+                {
+                    if (navCompletedHandler != null && _browser.WebView?.CoreWebView2 != null)
+                        _browser.WebView.CoreWebView2.NavigationCompleted -= navCompletedHandler;
+
+                    App.Logger?.Warning("Speech link navigation dropped by browser service: {Url}", url);
+                    return false;
+                }
 
                 App.Logger?.Information("Speech link navigated to: {Url} (Site: {Site}, AutoPlay: {AutoPlay})",
                     url, lowerUrl.Contains("bambicloud") ? "BambiCloud" : "HypnoTube", autoPlayFullscreen);
@@ -2412,7 +2596,13 @@ namespace ConditioningControlPanel
             // leaving it stranded.
             App.BrowserMedia?.ReplaceSession(
                 Services.Browser.BrowserMediaService.MediaOwner.Remote, takeover: true);
-            NavigateToUrlInBrowser(url, autoPlayFullscreen: true);
+            if (!NavigateToUrlInBrowser(url, autoPlayFullscreen: true))
+            {
+                // Nothing is playing here, so don't leave the claim standing until the heartbeat
+                // retires it — panic/session-end would otherwise act on a video that never loaded.
+                _remoteBrowserVideoActive = false;
+                App.BrowserMedia?.OnMediaStopped("remote-browser-unavailable");
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Browser/BrowserService.cs
+++ b/ConditioningControlPanel/Services/Browser/BrowserService.cs
@@ -85,6 +85,10 @@ namespace ConditioningControlPanel.Services
         public event EventHandler<string>? TitleChanged;
         public event EventHandler<bool>? FullscreenChanged;
         public event EventHandler<CoreWebView2ProcessFailedEventArgs>? BrowserProcessFailed;
+        /// <summary>CoreWebView2 never came up (EnsureCoreWebView2Async threw or returned a null
+        /// core). Consumers holding their own "browser is ready" flag must clear it here, or the
+        /// browser stays wedged for the process lifetime with every Navigate silently dropped.</summary>
+        public event EventHandler<string>? BrowserInitFailed;
         /// <summary>Web messages posted from a subframe (iframe-hosted players). The top-level
         /// CoreWebView2.WebMessageReceived never sees these, so consumers must handle both.</summary>
         public event EventHandler<CoreWebView2WebMessageReceivedEventArgs>? FrameWebMessageReceived;
@@ -212,6 +216,7 @@ namespace ConditioningControlPanel.Services
                 if (_webView.CoreWebView2 == null)
                 {
                     App.Logger?.Error("CoreWebView2 is null after EnsureCoreWebView2Async");
+                    RaiseInitFailed("CoreWebView2 null after EnsureCoreWebView2Async");
                     return;
                 }
 
@@ -484,7 +489,18 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Error("Failed to initialize CoreWebView2: {Type} - {Error}", ex.GetType().Name, ex.Message);
+                // This catch also covers BrowserReady?.Invoke above, which runs consumer code
+                // AFTER _isInitialized is already true. A handler throwing there must not tear a
+                // working browser down, so only a genuine bring-up failure clears readiness.
+                if (!_isInitialized) RaiseInitFailed($"{ex.GetType().Name}: {ex.Message}");
             }
+        }
+
+        private void RaiseInitFailed(string reason)
+        {
+            _isInitialized = false;
+            try { BrowserInitFailed?.Invoke(this, reason); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserInitFailed handler threw: {Error}", ex.Message); }
         }
 
         /// <summary>
@@ -1168,11 +1184,18 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Navigate to a URL (only HTTPS allowed for security)
+        /// Navigate to a URL (only HTTPS allowed for security).
+        /// Returns true only when the request actually reached CoreWebView2 — callers use this
+        /// to decide whether to fall back instead of reporting a navigation that never happened.
         /// </summary>
-        public void Navigate(string url)
+        public bool Navigate(string url)
         {
-            if (_disposed || !_isInitialized || _webView?.CoreWebView2 == null) return;
+            if (_disposed || !_isInitialized || _webView?.CoreWebView2 == null)
+            {
+                App.Logger?.Warning("Navigate dropped - browser not ready (disposed={Disposed}, init={Init}, core={HasCore}): {Url}",
+                    _disposed, _isInitialized, _webView?.CoreWebView2 != null, url);
+                return false;
+            }
 
             try
             {
@@ -1187,7 +1210,7 @@ namespace ConditioningControlPanel.Services
                     lowerUrl.StartsWith("vbscript:"))
                 {
                     App.Logger?.Warning("Blocked potentially dangerous URL scheme: {Url}", url);
-                    return;
+                    return false;
                 }
 
                 // Force HTTPS for security
@@ -1209,15 +1232,17 @@ namespace ConditioningControlPanel.Services
                     (uri.Scheme != Uri.UriSchemeHttps))
                 {
                     App.Logger?.Warning("Invalid URL rejected: {Url}", url);
-                    return;
+                    return false;
                 }
 
                 _webView.CoreWebView2.Navigate(url);
                 App.Logger?.Debug("Navigating to: {Url}", url);
+                return true;
             }
             catch (Exception ex)
             {
                 App.Logger?.Error("Navigation failed: {Error}", ex.Message);
+                return false;
             }
         }
 

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -124,6 +124,24 @@ public class BubbleCountService : IDisposable
         if (!forceTest && (!_isRunning || _isBusy)) return;
         if (_isBusy) return; // Still prevent double-triggering
 
+        // A video teardown whose native Stop() never returned leaves a LibVLC thread stuck in this
+        // process forever. #766 is exactly that: poisoning at 22:05, a bubble-count video built on
+        // the wreckage at 22:18, and a dispatcher that never drained again. Skip this turn rather
+        // than stand another player up on it - the shared instance is being rebuilt inside the same
+        // window, and the scheduler brings the next game around anyway.
+        var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+        if (poisonMs > 0)
+        {
+            App.Logger?.Warning("BubbleCountService: skipping game - a wedged native Stop() poisoned the shared LibVLC ({Sec:F0}s of cooldown left)",
+                poisonMs / 1000.0);
+            VideoDiag.Log("BUBBLE", $"game skipped - native poison cooldown, {poisonMs}ms remaining");
+            // If the interaction queue dequeued us into this call, hand the slot back or nothing
+            // else runs until stuck detection fires.
+            if (App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.BubbleCount)
+                App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+            return;
+        }
+
         var settings = App.Settings.Current;
 
         // Check if another fullscreen interaction is active (video, lock card)
@@ -299,6 +317,21 @@ public class BubbleCountService : IDisposable
         // auto-completing BubbleCount during the retry gap, which would let queued
         // interactions (e.g. Video) start while the retry game plays.
         App.InteractionQueue?.ExtendTimeout(300);
+
+        // Same post-poisoning hold-off as TriggerGame. End the game outright rather than let the
+        // strict retry loop bounce off the cooldown every couple of seconds for a minute.
+        var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+        if (poisonMs > 0)
+        {
+            App.Logger?.Warning("BubbleCountService: retry abandoned - shared LibVLC poisoned ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
+            VideoDiag.Log("BUBBLE", $"retry abandoned - native poison cooldown, {poisonMs}ms remaining");
+            _retryCount = 0;
+            _isBusy = false;
+            App.Bubbles?.Resume();
+            App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+            GameFailed?.Invoke(this, EventArgs.Empty);
+            return;
+        }
 
         try
         {

--- a/ConditioningControlPanel/Services/Deeper/IActionDispatcher.cs
+++ b/ConditioningControlPanel/Services/Deeper/IActionDispatcher.cs
@@ -191,6 +191,11 @@ namespace ConditioningControlPanel.Services.Deeper
         // Per-EffectId live voice-prompt sessions so band Stop can tear down the right one.
         private readonly Dictionary<string, SpeakPromptSession> _speakBands = new();
         private readonly object _bandGate = new();
+        // Config-state haptic skips (no service / disabled / disconnected) repeat once per
+        // timeline entry, and the default config - haptics on, Mock provider, nothing
+        // connected - hits one on every entry. Log each distinct reason once per bind at
+        // Information so a silent drop still leaves a line (#764), then drop to Debug.
+        private readonly HashSet<string> _loggedHapticSkips = new();
 
         private sealed class BandHapticState
         {
@@ -513,6 +518,16 @@ namespace ConditioningControlPanel.Services.Deeper
             }
         }
 
+        private void LogHapticSkip(string reason)
+        {
+            bool first;
+            lock (_bandGate) first = _loggedHapticSkips.Add(reason);
+            if (first)
+                App.Logger?.Information("Deeper haptic send skipped: {Reason}", reason);
+            else
+                App.Logger?.Debug("Deeper haptic send skipped: {Reason}", reason);
+        }
+
         private async Task DispatchHaptic(TriggerHapticAction haptic)
         {
             try
@@ -524,7 +539,12 @@ namespace ConditioningControlPanel.Services.Deeper
                     {
                         lock (_bandGate) _hapticBandState.Remove(haptic.EffectId!);
                     }
-                    if (App.Haptics != null) await App.Haptics.StopAsync();
+                    if (App.Haptics == null)
+                    {
+                        LogHapticSkip("haptic service unavailable (phase=Stop)");
+                        return;
+                    }
+                    await App.Haptics.StopAsync();
                     return;
                 }
 
@@ -541,14 +561,36 @@ namespace ConditioningControlPanel.Services.Deeper
 
                 if (keyframes == null)
                 {
-                    App.Logger?.Debug("Deeper haptic: skipped — no pattern (name='{Name}', custom={Count})",
+                    App.Logger?.Information("Deeper haptic send skipped: no pattern (name='{Name}', custom={Count})",
                         haptic.PatternName, haptic.CustomPattern?.Count ?? 0);
                     return;
                 }
 
                 var samples = StockHapticPatterns.Sample(keyframes, haptic.Intensity, haptic.DurationMs);
+                if (samples.Length == 0)
+                {
+                    App.Logger?.Information("Deeper haptic send skipped: empty samples (name='{Name}', duration={Duration}ms)",
+                        haptic.PatternName, haptic.DurationMs);
+                    return;
+                }
 
-                if (App.Haptics == null) return;
+                if (App.Haptics == null)
+                {
+                    LogHapticSkip("haptic service unavailable");
+                    return;
+                }
+
+                if (!App.Haptics.Settings.Enabled)
+                {
+                    LogHapticSkip("haptics disabled in settings");
+                    return;
+                }
+
+                if (!App.Haptics.IsConnected)
+                {
+                    LogHapticSkip($"no provider connected ({App.Haptics.Settings.Provider})");
+                    return;
+                }
 
                 // Restart: send Vibrate:0 first to clear LovenseProvider's 1-second
                 // same-level debounce — without this, a same-level re-issue after a

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -2149,7 +2149,8 @@ namespace ConditioningControlPanel.Services
                     CleanupTempPackFiles();
                 }
 
-                // Refresh image lists if empty (first call or after cache clear)
+                // Refresh image lists if empty (first call, or after ClearFileCache/LoadAssets
+                // emptied the pools so a selection change takes effect on this draw)
                 if (_imageList.Count == 0 && _packImageList.Count == 0)
                 {
                     RefreshImageLists();
@@ -2496,13 +2497,25 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Clear the file list cache (called when assets are reloaded or selection changes)
+        /// Clear the file list cache (called when assets are reloaded or selection changes).
+        /// Also empties the live selection pools: they are drawn from by random index and never
+        /// drained, so clearing only the 60s listing cache left every flash still picking from
+        /// the pre-toggle paths until the next LoadAssets().
         /// </summary>
         public void ClearFileCache()
         {
-            lock (_cacheLock)
+            // Lock order: _lockObj BEFORE _cacheLock, matching
+            // GetNextImages -> RefreshImageLists -> GetMediaFiles. The reverse order deadlocks.
+            lock (_lockObj)
             {
-                _fileListCache.Clear();
+                _imageList.Clear();  // forces RefreshImageLists() on the next draw
+                _packImageList.Clear();
+                _soundQueue = new Queue<string>();
+
+                lock (_cacheLock)
+                {
+                    _fileListCache.Clear();
+                }
             }
         }
 

--- a/ConditioningControlPanel/Services/Haptics/HapticService.cs
+++ b/ConditioningControlPanel/Services/Haptics/HapticService.cs
@@ -467,7 +467,10 @@ namespace ConditioningControlPanel.Services
         /// <param name="totalDurationMs">Total duration for the pattern</param>
         public async Task SetSyncPatternAsync(float[] intensities, int totalDurationMs)
         {
-            if (!Settings.Enabled || !Settings.AudioSync.Enabled)
+            // Deliberately not gated on Settings.AudioSync.Enabled: the only callers are Deeper
+            // (runtime dispatcher + editor preview), while the audio-sync feature uses
+            // SetSyncIntensityAsync. That default-OFF toggle would drop every Deeper haptic.
+            if (!Settings.Enabled)
                 return;
 
             if (_activeProvider == null || !_activeProvider.IsConnected)
@@ -480,9 +483,9 @@ namespace ConditioningControlPanel.Services
             var levels = new int[intensities.Length];
             for (int i = 0; i < intensities.Length; i++)
             {
-                var clamped = Math.Clamp(intensities[i],
-                    (float)Settings.AudioSync.MinIntensity,
-                    (float)Settings.AudioSync.MaxIntensity);
+                // Authored Deeper intensities are used as-is - the audio-sync min/max sliders tune a
+                // different feature and would distort the pattern.
+                var clamped = Math.Clamp(intensities[i], 0f, 1f);
                 levels[i] = Haptics.LovenseProvider.IntensityToLevel(clamped);
             }
 

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -143,9 +143,10 @@ namespace ConditioningControlPanel.Services
             return roll * maxFirst;
         }
 
-        /// <summary>Decision for what to do when <see cref="ShowLockCard"/> finds a lock card already
-        /// visible (#676). Pure so the defer-and-replay policy — including the one-re-defer cap that stops
-        /// a close/hide race from bouncing forever — is unit-testable without any WPF windows.</summary>
+        /// <summary>Decision for what to do when <see cref="ShowLockCard"/> finds another fullscreen
+        /// interaction already visible — a lock card (#676) or a pop quiz (#763). Pure so the
+        /// defer-and-replay policy — including the one-re-defer cap that stops a close/hide race from
+        /// bouncing forever — is unit-testable without any WPF windows.</summary>
         internal enum BlockedCardAction
         {
             /// <summary>No card open; show this one now.</summary>
@@ -162,6 +163,9 @@ namespace ConditioningControlPanel.Services
         /// <summary>#676: AI cards can arrive faster than the user types one out. Rather than silently
         /// dropping a request that lands while a card is open, defer-and-replay it through the interaction
         /// queue — but cap at a single re-defer so a rare close/hide race can't loop.</summary>
+        /// <param name="cardAlreadyOpen">Any blocking fullscreen interaction is on screen: another lock
+        /// card, or (#763) a pop quiz — both are ownerless HWND_TOPMOST covers and must never share the
+        /// screen.</param>
         internal static BlockedCardAction ResolveBlockedCardAction(bool cardAlreadyOpen, bool isDeferredReplay, bool hasInteractionQueue)
         {
             if (!cardAlreadyOpen) return BlockedCardAction.Proceed;
@@ -178,9 +182,14 @@ namespace ConditioningControlPanel.Services
                 // Gate on the visible set (IsAnyOpen), NOT Application.Current.Windows: since 6.2.10 the
                 // window is keep-alive pooled (dismiss => Hide(), not Close()), so a hidden pooled instance
                 // lingers in Application.Current.Windows forever and would block every card after the first.
-                var blockedAction = ResolveBlockedCardAction(LockCardWindow.IsAnyOpen(), isDeferredReplay, App.InteractionQueue != null);
+                // #763: a visible pop quiz blocks us just as hard — the interaction queue is meant to keep
+                // the two apart, but it released the slot with a card still up and both covers stacked.
+                var cardOpen = LockCardWindow.IsAnyOpen();
+                var quizOpen = PopQuizWindow.IsAnyOpen();
+                var blockedAction = ResolveBlockedCardAction(cardOpen || quizOpen, isDeferredReplay, App.InteractionQueue != null);
                 if (blockedAction != BlockedCardAction.Proceed)
                 {
+                    var blocker = cardOpen ? "a lock card" : "a pop quiz";
                     // Short, log-safe snippet of the requested phrase for diagnostics.
                     var phraseSnippet = string.IsNullOrEmpty(customPhrase)
                         ? "(default/random)"
@@ -194,12 +203,12 @@ namespace ConditioningControlPanel.Services
                             // as the active LockCard, so re-enqueuing would hold the slot with nothing on
                             // screen until the 5-min stuck backstop, and could bounce indefinitely. Give up
                             // after this single re-defer and release the slot so the queue keeps moving.
-                            App.Logger?.Warning("LockCardService: Deferred lock card still blocked on replay (a card is open). Dropping after one re-defer. Phrase: {Phrase}", phraseSnippet);
+                            App.Logger?.Warning("LockCardService: Deferred lock card still blocked on replay ({Blocker} is open). Dropping after one re-defer. Phrase: {Phrase}", blocker, phraseSnippet);
                             App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.LockCard);
                             break;
 
                         case BlockedCardAction.Defer:
-                            App.Logger?.Warning("LockCardService: A lock card is already open. Deferring this one to the interaction queue. Phrase: {Phrase}", phraseSnippet);
+                            App.Logger?.Warning("LockCardService: {Blocker} is already open. Deferring this lock card to the interaction queue. Phrase: {Phrase}", blocker, phraseSnippet);
                             App.InteractionQueue?.TryStart(
                                 InteractionQueueService.InteractionType.LockCard,
                                 () => ShowLockCard(customPhrase, customRepeats, customStrict, isTest, isDeferredReplay: true),
@@ -207,7 +216,7 @@ namespace ConditioningControlPanel.Services
                             break;
 
                         case BlockedCardAction.DropNoQueue:
-                            App.Logger?.Warning("LockCardService: A lock card is already open and no interaction queue is available to defer to. Dropping. Phrase: {Phrase}", phraseSnippet);
+                            App.Logger?.Warning("LockCardService: {Blocker} is already open and no interaction queue is available to defer to. Dropping. Phrase: {Phrase}", blocker, phraseSnippet);
                             break;
                     }
                     return;

--- a/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/PopQuizService.cs
@@ -175,7 +175,7 @@ namespace ConditioningControlPanel.Services
             ShowPopQuiz();
         }
 
-        public void ShowPopQuiz(bool isTest = false)
+        public void ShowPopQuiz(bool isTest = false, bool isDeferredReplay = false)
         {
             DispatcherHelper.RunOnUISync(() =>
             {
@@ -183,6 +183,36 @@ namespace ConditioningControlPanel.Services
                 if (Application.Current.Windows.OfType<PopQuizWindow>().Any())
                 {
                     App.Logger?.Debug("PopQuizService: A pop quiz is already open. Skipping.");
+                    return;
+                }
+
+                // #763: cross-check the OTHER fullscreen interaction directly, not just the queue. Both
+                // this window and a lock card are ownerless HWND_TOPMOST covers, so if the interaction
+                // slot is ever released with a card still up (the 5-minute stuck backstop used to do
+                // exactly that) they render stacked on each other. Defer through the queue instead,
+                // capped at one re-defer like LockCardService's policy so a close race can't bounce.
+                if (LockCardWindow.IsAnyOpen())
+                {
+                    if (isDeferredReplay)
+                    {
+                        App.Logger?.Warning("PopQuizService: Deferred pop quiz still blocked by an open lock card on replay. Dropping after one re-defer.");
+                        // Slot-guarded: this replay is dispatched asynchronously, so a panic/ForceReset
+                        // and a fresh claim can land in between - an unconditional Complete would clear
+                        // whatever is current instead (the #462 class).
+                        App.InteractionQueue?.CompleteIfCurrent(InteractionQueueService.InteractionType.PopQuiz);
+                    }
+                    else if (App.InteractionQueue != null)
+                    {
+                        App.Logger?.Warning("PopQuizService: A lock card is on screen. Deferring this pop quiz to the interaction queue.");
+                        App.InteractionQueue.TryStart(
+                            InteractionQueueService.InteractionType.PopQuiz,
+                            () => ShowPopQuiz(isTest, isDeferredReplay: true),
+                            queue: true);
+                    }
+                    else
+                    {
+                        App.Logger?.Warning("PopQuizService: A lock card is on screen and no interaction queue is available to defer to. Dropping.");
+                    }
                     return;
                 }
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -454,6 +454,98 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// One-shot guard for settings recovered from a rolling daily backup
+        /// (<see cref="SettingsService.RestoredFromBackup"/>). Such a backup restores progression
+        /// WHOLESALE and can be up to three calendar days old, so it may carry a previous season's
+        /// level, XP and skill tree. Uploading that state makes the rollback permanent — the
+        /// server takes the higher level, and every down-merge here is max/union, so it can never
+        /// self-correct (#761). This does a READ-ONLY V2 profile fetch (GET, no upload) first and:
+        ///
+        /// - server season is NEWER than the restored one while local still sits above it: the
+        ///   restore reverted across a rollover, and <c>level_reset</c> is one-shot server-side
+        ///   (the pre-corruption client already consumed it), so nothing else will ever apply it —
+        ///   adopt the server's post-rollover level/XP and drop the mechanical skills the backup
+        ///   resurrected, exactly like the <c>level_reset</c> branch in <see cref="SyncProfileAsync"/>;
+        /// - server is simply ahead: adopt it via the take-higher apply;
+        /// - otherwise keep local (the server is genuinely behind) and let the push proceed.
+        ///
+        /// Returns false ONLY when the server profile could not be read — the caller then skips
+        /// the whole sync rather than risk uploading stale progression, and retries next tick.
+        /// </summary>
+        private async Task<bool> ReconcileRestoredProfileAsync(string unifiedId)
+        {
+            var settings = App.Settings?.Current;
+            if (settings == null) return false;
+
+            try
+            {
+                var v2Auth = new V2AuthService();
+                var user = await v2Auth.GetUserProfileAsync(unifiedId);
+                if (user == null)
+                {
+                    App.Logger?.Warning("Restore reconcile: read-only profile fetch returned nothing for {Id}", unifiedId);
+                    return false;
+                }
+
+                var localTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
+                var serverTotalXp = (double)user.Xp;
+
+                // Compare against the key the BACKUP carried, not the live one: a login or the
+                // #293 boot heal can have advanced settings.CurrentSeason since the restore, which
+                // would hide the rollover the restored level/XP still belong to.
+                var restoredSeason = App.Settings?.RestoredSeason ?? settings.CurrentSeason;
+                var seasonAdvanced = Services.SeasonRecapService.ShouldAdoptServerSeason(user.CurrentSeason, restoredSeason);
+
+                if (seasonAdvanced && localTotalXp > serverTotalXp)
+                {
+                    App.Logger?.Warning("Restore reconcile: restored settings belong to season {Old} but the server is on {New} — the backup reverted a rollover. Adopting the server profile: Level {LL} ({LX} XP) -> Level {SL} ({SX} XP).",
+                        string.IsNullOrEmpty(restoredSeason) ? "(none)" : restoredSeason,
+                        user.CurrentSeason, settings.PlayerLevel, (int)localTotalXp, user.Level, user.Xp);
+
+                    settings.PlayerLevel = user.Level;
+                    settings.PlayerXP = App.Progression?.GetCurrentLevelXP(user.Level, serverTotalXp) ?? 0;
+                    settings.HighestLevelEver = user.HighestLevelEver;
+                    settings.CurrentSeason = user.CurrentSeason;
+
+                    // Same policy as the level_reset branch: the POINT BALANCE is never reset,
+                    // only the tree — keep permanent nodes, drop the mechanical ones the backup
+                    // brought back. (The profile projection carries no unlocked_skills list, so
+                    // there is nothing to union in here; the next sync response re-adds anything
+                    // the server still holds.)
+                    settings.UnlockedSkills = (settings.UnlockedSkills ?? new List<string>())
+                        .Where(id => Models.SkillDefinition.PermanentIds.Contains(id)).ToList();
+                    App.SkillTree?.OnSeasonReset();
+
+                    settings.SeasonResetPending = true;
+                    NudgeSeasonRecap();
+                }
+                else if (serverTotalXp > localTotalXp)
+                {
+                    App.Logger?.Warning("Restore reconcile: server is ahead of the restored backup (Level {SL}, {SX} XP vs local Level {LL}, {LX} XP) — adopting the server profile.",
+                        user.Level, user.Xp, settings.PlayerLevel, (int)localTotalXp);
+                    v2Auth.ApplyUserDataToSettings(user); // take-higher; saves internally
+                }
+                else
+                {
+                    App.Logger?.Information("Restore reconcile: server (Level {SL}, {SX} XP, season {SS}) is not ahead of the restored local profile (Level {LL}, {LX} XP, season {LS}) — keeping local.",
+                        user.Level, user.Xp, user.CurrentSeason, settings.PlayerLevel, (int)localTotalXp, settings.CurrentSeason);
+                }
+
+                // Flush before dropping the guard. The branches above save through the 500ms
+                // debounce, so a crash inside that window would leave the PRE-reconcile level on
+                // disk with the marker already gone — and the next run would push it for real.
+                App.Settings?.SaveImmediate();
+                App.Settings?.ClearRestoredFromBackupFlag();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Restore reconcile failed — leaving the guard armed and skipping this sync");
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Sync local progression to cloud.
         /// Called after sessions and periodically.
         /// </summary>
@@ -520,10 +612,27 @@ namespace ConditioningControlPanel.Services
                     return false;
                 }
 
+                // This session's settings came out of a rolling daily backup, so the level/XP/skills
+                // below may be up to three days stale and can predate a season rollover. Reconcile
+                // against the server BEFORE the push: the sync POST is the first server contact of
+                // a run, and once a stale-but-higher profile is up there every down-merge rule is
+                // max/union, so nothing can ever bring it back down again (#761).
+                if (App.Settings?.RestoredFromBackup == true)
+                {
+                    var restoredUnifiedId = settings.UnifiedId;
+                    if (!string.IsNullOrEmpty(restoredUnifiedId) &&
+                        !await ReconcileRestoredProfileAsync(restoredUnifiedId!))
+                    {
+                        App.Logger?.Warning("Sync blocked — settings were restored from a local backup and the server profile could not be read to reconcile them. Retrying on the next sync.");
+                        return false;
+                    }
+                }
+
                 // Get achievement stats for additional tracking
                 var achievementProgress = achievements?.Progress;
 
-                // Calculate total accumulated XP (sum of all levels + current progress)
+                // Calculate total accumulated XP (sum of all levels + current progress).
+                // Read AFTER the restore reconcile above, which can rewrite level/XP.
                 var totalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
 
                 // Guard: if local data looks like fresh defaults (Level 1, near-zero XP) and we
@@ -2519,6 +2628,16 @@ namespace ConditioningControlPanel.Services
 
             var unifiedId = App.Settings?.Current?.UnifiedId;
             if (string.IsNullOrEmpty(unifiedId)) return false;
+
+            // Settings recovered from a rolling daily backup can be up to three days stale. An
+            // automatic upload here would overwrite the cloud copy — the one snapshot that still
+            // holds the pre-corruption state — before the sync reconcile has run (#761). A forced
+            // (user-initiated) backup still goes through; that is an explicit choice.
+            if (!force && App.Settings?.RestoredFromBackup == true)
+            {
+                App.Logger?.Debug("Settings cloud backup skipped — local settings came from a daily backup and have not been reconciled yet");
+                return false;
+            }
 
             // Debounce: skip if backed up recently (unless forced)
             // Uses Interlocked for thread safety — multiple async paths can call this concurrently

--- a/ConditioningControlPanel/Services/Settings/SettingsService.cs
+++ b/ConditioningControlPanel/Services/Settings/SettingsService.cs
@@ -18,6 +18,20 @@ namespace ConditioningControlPanel.Services
         private volatile bool _savePending;
         private volatile bool _suppressCloudBackupPending;
 
+        // Serializes the rotate+write half of SaveImmediate. Without it two overlapping saves
+        // (debounce timer thread + a direct UI-thread call) could File.Move each other's
+        // half-written temp over settings.json (#761). Never taken while _timerLock is held,
+        // and never held across the UI-thread serialize hop — both would deadlock the shutdown
+        // path, where SaveImmediate runs ON the UI thread.
+        private readonly object _saveLock = new();
+        private readonly object _timerLock = new();
+        private long _saveSequence;
+        private long _lastWrittenSaveSequence;
+
+        // Bounded wait for the UI-thread re-serialize retry; a busy (or wedged) UI thread must
+        // never stall the save path indefinitely.
+        private static readonly TimeSpan SerializeMarshalTimeout = TimeSpan.FromSeconds(2);
+
         public AppSettings Current { get; private set; }
 
         /// <summary>
@@ -48,6 +62,32 @@ namespace ConditioningControlPanel.Services
         public string? LastCorruptBackupPath { get; private set; }
 
         /// <summary>
+        /// True when <see cref="Current"/> came out of a rolling daily backup rather than
+        /// settings.json (see <see cref="TryLoadFromDailyBackup"/>). A backup can be up to three
+        /// calendar days old and restores progression WHOLESALE, so the level/XP/skills in memory
+        /// may predate a season rollover — <c>ProfileSyncService</c> reconciles against the server
+        /// before pushing anything, otherwise the rollback becomes permanent (#761).
+        /// Survives a restart via a marker file next to settings.json; cleared by
+        /// <see cref="ClearRestoredFromBackupFlag"/> once the reconcile has run.
+        /// </summary>
+        public bool RestoredFromBackup { get; private set; }
+
+        /// <summary>UTC time of the restore recorded by <see cref="RestoredFromBackup"/>.</summary>
+        public DateTime? RestoredFromBackupUtc { get; private set; }
+
+        /// <summary>Path of the daily backup <see cref="Current"/> was restored from, if any.</summary>
+        public string? RestoredBackupPath { get; private set; }
+
+        /// <summary>
+        /// The season key the restored backup carried, captured at restore time. The reconcile
+        /// must compare the SERVER key against this and not against the live
+        /// <c>CurrentSeason</c>: a login (V2AuthService.ApplyUserDataToSettings) or the #293 boot
+        /// heal can advance the live key first, which would hide the rollover the restored
+        /// level/XP actually belong to (#761).
+        /// </summary>
+        public string? RestoredSeason { get; private set; }
+
+        /// <summary>
         /// Preset IDs that need a re-install pass after services are wired up. Populated by
         /// <see cref="MergeBuiltInAwarenessPresets"/> when an installed preset's <c>Version</c>
         /// is bumped — we can't call <c>App.KeywordPresets.InstallPreset</c> from inside
@@ -65,6 +105,11 @@ namespace ConditioningControlPanel.Services
             MigrateSettingsFromOldLocation();
 
             Current = Load();
+
+            // A restore from an earlier run that never reached the reconcile (app closed, or
+            // offline the whole session) still needs the sync guard — the flag lives in memory,
+            // the marker on disk.
+            if (!RestoredFromBackup) TryReadRestoreMarker();
         }
 
         /// <summary>
@@ -97,19 +142,12 @@ namespace ConditioningControlPanel.Services
         {
             try
             {
-                // Recover from interrupted atomic write: if temp file exists but main doesn't,
-                // the app crashed after writing temp but before the rename completed
-                var tempPath = _settingsPath + ".tmp";
-                if (File.Exists(tempPath) && !File.Exists(_settingsPath))
-                {
-                    App.Logger?.Information("Recovering settings from interrupted save (temp file)");
-                    File.Move(tempPath, _settingsPath);
-                }
-                else if (File.Exists(tempPath))
-                {
-                    // Main file exists and temp is stale — clean it up
-                    try { File.Delete(tempPath); } catch { }
-                }
+                // Recover from an interrupted atomic write: if a temp file exists but the main
+                // one doesn't, the app died after the write but before the rename. Saves use a
+                // per-write temp name now, so glob (the legacy fixed settings.json.tmp matches too)
+                // and only adopt a candidate that still parses — a truncated temp must never be
+                // promoted to settings.json.
+                RecoverAndCleanTempFiles();
 
                 if (File.Exists(_settingsPath))
                 {
@@ -228,6 +266,53 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Promotes the newest still-parseable <c>settings.json*.tmp</c> left behind by an
+        /// interrupted save when settings.json itself is gone, then deletes every leftover temp.
+        /// </summary>
+        private void RecoverAndCleanTempFiles()
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(_settingsPath);
+                if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir)) return;
+
+                var temps = Directory.GetFiles(dir, Path.GetFileName(_settingsPath) + "*.tmp");
+                if (temps.Length == 0) return;
+
+                if (!File.Exists(_settingsPath))
+                {
+                    foreach (var candidate in temps.OrderByDescending(File.GetLastWriteTimeUtc))
+                    {
+                        try
+                        {
+                            // Well-formedness check only — per-member tolerance is the loader's job.
+                            JObject.Parse(File.ReadAllText(candidate));
+                        }
+                        catch
+                        {
+                            App.Logger?.Warning("Discarding partial settings temp file {Temp}", candidate);
+                            continue;
+                        }
+
+                        App.Logger?.Information("Recovering settings from interrupted save ({Temp})", candidate);
+                        File.Move(candidate, _settingsPath);
+                        break;
+                    }
+                }
+
+                foreach (var leftover in temps)
+                {
+                    if (!File.Exists(leftover)) continue;
+                    try { File.Delete(leftover); } catch { }
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("Settings temp-file recovery failed: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Tries settings.bak-1.json .. settings.bak-3.json (newest first) after the main
         /// file failed to parse. Returns the first backup that deserializes, with the same
         /// post-load migrations the normal path applies, or null if none work.
@@ -256,6 +341,14 @@ namespace ConditioningControlPanel.Services
                     settings.MigrateEnableUnifiedOverlayHost();
                     settings.MigrateEnableCompositorOffThreadPresent();
 
+                    // Record the restore: the backup restores progression wholesale, so sync must
+                    // reconcile with the server before pushing any of it back up (#761).
+                    RestoredFromBackup = true;
+                    RestoredFromBackupUtc = DateTime.UtcNow;
+                    RestoredBackupPath = bakPath;
+                    RestoredSeason = settings.CurrentSeason;
+                    WriteRestoreMarker();
+
                     App.Logger?.Warning("Settings RESTORED from daily backup {Backup} (main file was unparseable)", bakPath);
                     return settings;
                 }
@@ -265,6 +358,64 @@ namespace ConditioningControlPanel.Services
                 }
             }
             return null;
+        }
+
+        private string RestoreMarkerPath => _settingsPath + ".restored";
+
+        private void WriteRestoreMarker()
+        {
+            try
+            {
+                // utc|backup path|season key as restored. '|' cannot occur in a Windows path.
+                File.WriteAllText(RestoreMarkerPath,
+                    $"{RestoredFromBackupUtc:o}|{RestoredBackupPath}|{RestoredSeason}");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Could not write settings restore marker: {Error}", ex.Message);
+            }
+        }
+
+        private void TryReadRestoreMarker()
+        {
+            try
+            {
+                if (!File.Exists(RestoreMarkerPath)) return;
+
+                var parts = File.ReadAllText(RestoreMarkerPath).Split('|');
+                RestoredFromBackup = true;
+                RestoredFromBackupUtc = DateTime.TryParse(parts[0],
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind, out var stamp)
+                    ? stamp
+                    : (DateTime?)null;
+                RestoredBackupPath = parts.Length > 1 ? parts[1] : null;
+                RestoredSeason = parts.Length > 2 && !string.IsNullOrWhiteSpace(parts[2]) ? parts[2] : null;
+
+                App.Logger?.Warning("Settings were restored from daily backup {Backup} (season {Season}) on a previous run and have not been reconciled with the cloud profile yet",
+                    RestoredBackupPath, RestoredSeason);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Could not read settings restore marker: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Called by <c>ProfileSyncService</c> once the restored profile has been reconciled
+        /// against the server, so the one-shot guard doesn't re-run on every later sync (#761).
+        /// </summary>
+        public void ClearRestoredFromBackupFlag()
+        {
+            RestoredFromBackup = false;
+            try
+            {
+                if (File.Exists(RestoreMarkerPath)) File.Delete(RestoreMarkerPath);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Could not clear settings restore marker: {Error}", ex.Message);
+            }
         }
 
         /// <summary>
@@ -510,17 +661,20 @@ namespace ConditioningControlPanel.Services
             if (suppressCloudBackup)
                 _suppressCloudBackupPending = true;
 
-            _saveDebounceTimer?.Dispose();
-            _saveDebounceTimer = new System.Threading.Timer(_ =>
+            lock (_timerLock)
             {
-                if (_savePending)
+                _saveDebounceTimer?.Dispose();
+                _saveDebounceTimer = new System.Threading.Timer(_ =>
                 {
-                    _savePending = false;
-                    var suppress = _suppressCloudBackupPending;
-                    _suppressCloudBackupPending = false;
-                    SaveImmediate(suppress);
-                }
-            }, null, 500, Timeout.Infinite);
+                    if (_savePending)
+                    {
+                        _savePending = false;
+                        var suppress = _suppressCloudBackupPending;
+                        _suppressCloudBackupPending = false;
+                        SaveImmediate(suppress);
+                    }
+                }, null, 500, Timeout.Infinite);
+            }
         }
 
         /// <summary>
@@ -532,8 +686,11 @@ namespace ConditioningControlPanel.Services
             // Cancel any pending debounce — we're flushing now
             _savePending = false;
             _suppressCloudBackupPending = false;
-            _saveDebounceTimer?.Dispose();
-            _saveDebounceTimer = null;
+            lock (_timerLock)
+            {
+                _saveDebounceTimer?.Dispose();
+                _saveDebounceTimer = null;
+            }
 
             try
             {
@@ -543,20 +700,52 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("Settings.Save: ActivePackIds BEFORE serialize: [{Ids}]",
                     string.Join(", ", Current.ActivePackIds ?? new List<string>()));
 
-                // Snapshot the previous good file into the rolling daily backups before the
-                // first overwrite of the day. The atomic write below protects against a crash
-                // MID-write, but not against the file being destroyed by something else
-                // entirely (support: preset wiped by a PC crash) — this gives Load() and the
-                // user up to 3 previous days to fall back on.
-                RotateDailyBackupBeforeWrite();
+                // Serialized OUTSIDE _saveLock: the snapshot can hop to the UI thread, and holding
+                // the write lock across that hop deadlocks against a UI-thread SaveImmediate.
+                // The sequence number keeps an older snapshot from landing after a newer one.
+                var sequence = Interlocked.Increment(ref _saveSequence);
+                var json = SerializeCurrentSnapshot();
 
-                var json = JsonConvert.SerializeObject(Current, Formatting.Indented);
+                lock (_saveLock)
+                {
+                    if (sequence < Interlocked.Read(ref _lastWrittenSaveSequence))
+                    {
+                        App.Logger?.Debug("Settings save #{Sequence} dropped — a newer snapshot already reached disk", sequence);
+                        return;
+                    }
 
-                // Atomic write: write to temp file then replace, so a crash mid-write
-                // can't corrupt the settings file (prevents save state reversion bug)
-                var tempPath = _settingsPath + ".tmp";
-                File.WriteAllText(tempPath, json);
-                File.Move(tempPath, _settingsPath, overwrite: true);
+                    // Snapshot the previous good file into the rolling daily backups before the
+                    // first overwrite of the day. The atomic write below protects against a crash
+                    // MID-write, but not against the file being destroyed by something else
+                    // entirely (support: preset wiped by a PC crash) — this gives Load() and the
+                    // user up to 3 previous days to fall back on.
+                    RotateDailyBackupBeforeWrite();
+
+                    // Atomic write: write to a per-write temp file then replace, so neither a
+                    // crash mid-write nor a concurrent save can publish a half-written file
+                    // (a shared temp name let two saves rename each other's partial write over
+                    // settings.json — #761). Flush(true) commits the bytes to the device before
+                    // the rename makes them the live settings.
+                    var tempPath = _settingsPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                    try
+                    {
+                        using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                        using (var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(false)))
+                        {
+                            writer.Write(json);
+                            writer.Flush();
+                            stream.Flush(true);
+                        }
+                        File.Move(tempPath, _settingsPath, overwrite: true);
+                    }
+                    catch
+                    {
+                        try { if (File.Exists(tempPath)) File.Delete(tempPath); } catch { }
+                        throw;
+                    }
+
+                    Interlocked.Exchange(ref _lastWrittenSaveSequence, sequence);
+                }
 
                 App.Logger?.Debug("Settings saved to {Path} (Triggers: {TriggerCount}, ActivePacks: {PackCount})",
                     _settingsPath, Current.CustomTriggers?.Count ?? 0, Current.ActivePackIds?.Count ?? 0);
@@ -587,6 +776,45 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "Could not save settings");
+            }
+        }
+
+        /// <summary>
+        /// Serializes <see cref="Current"/> for the on-disk write. The pools/phrase lists are
+        /// edited on the UI thread, so a debounced background save can hit one mid-edit while
+        /// the user pastes a long list — <c>List&lt;T&gt;</c> enumeration throws on structural
+        /// modification, which used to be swallowed and the save silently skipped (#761).
+        /// Serializing on the UI thread unconditionally would put the whole settings graph on
+        /// the UI thread twice a second during play (Save fires constantly), so the throw is
+        /// caught and only the RETRY hops to the UI thread, where no edit can be in flight.
+        /// </summary>
+        private string SerializeCurrentSnapshot()
+        {
+            try
+            {
+                return JsonConvert.SerializeObject(Current, Formatting.Indented);
+            }
+            catch (Exception ex)
+            {
+                var dispatcher = System.Windows.Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted || dispatcher.CheckAccess())
+                    throw;
+
+                App.Logger?.Debug("Settings serialize raced a UI-thread edit ({Error}) — retrying on the UI thread", ex.Message);
+
+                var op = dispatcher.InvokeAsync(() => JsonConvert.SerializeObject(Current, Formatting.Indented));
+                // Observe a faulted op even if the wait below times out, otherwise it resurfaces
+                // through TaskScheduler.UnobservedTaskException with no useful context.
+                op.Task.ContinueWith(t => { _ = t.Exception; }, TaskContinuationOptions.OnlyOnFaulted);
+
+                if (op.Task.Wait(SerializeMarshalTimeout))
+                    return op.Task.Result;
+
+                // Bounded: a busy (or wedged) UI thread must never stall the save path. Drop this
+                // save rather than write a snapshot we could not take cleanly — the next one wins.
+                op.Abort();
+                App.Logger?.Warning("Settings serialize could not reach the UI thread in time — skipping this save");
+                throw;
             }
         }
 

--- a/ConditioningControlPanel/Services/UI/InteractionQueueService.cs
+++ b/ConditioningControlPanel/Services/UI/InteractionQueueService.cs
@@ -28,9 +28,23 @@ public class InteractionQueueService
     private readonly object _lock = new();
     private DispatcherTimer? _stuckDetectionTimer;
     private DateTime _interactionStartTime;
+    // Bumped on every claim of the slot, so a teardown path can tell "the claim I tripped on" from
+    // "a new claim of the same type that the teardown itself dequeued".
+    private long _claimId;
 
     // Default max time before auto-recovery when duration is unknown (5 minutes)
     private const int DefaultMaxInteractionMinutes = 5;
+
+    // User-paced interactions (lock cards, pop quizzes) have no duration of their own — the 5-minute
+    // backstop is a video-shaped timeout applied to a typing/speaking-shaped interaction. While their
+    // window is still on screen the tick renews instead of recovering, up to a hard ceiling after which
+    // the UI is force-closed BEFORE the slot is released (#763).
+    private const int UserPacedRenewMinutes = 5;
+    private const int UserPacedMaxInteractionMinutes = 30;
+    // Last-ditch cap on holding the slot for a window that reports itself open but won't go away:
+    // an un-closable overlay is bad, a permanently wedged queue (no further interactions all session)
+    // is worse.
+    private const int HeldSlotAbandonMinutes = 60;
 
     /// <summary>
     /// Currently active interaction type, or null if none
@@ -76,6 +90,7 @@ public class InteractionQueueService
             {
                 CurrentInteraction = type;
                 _interactionStartTime = DateTime.Now;
+                _claimId++;
                 StartStuckDetectionTimer();
                 App.Logger?.Information("InteractionQueue: Starting {Type}", type);
                 triggerAction();
@@ -140,6 +155,22 @@ public class InteractionQueueService
         }
     }
 
+    /// <summary>
+    /// Release the slot only if it is still the exact claim identified by <paramref name="claimId"/>.
+    /// A type-only check is not enough on the stuck-recovery path: the force-cleanup it runs may already
+    /// have released the slot AND dequeued a new interaction of the same type, whose window has not been
+    /// created yet (the trigger is dispatched asynchronously) — a type-only release would drop that fresh
+    /// claim on the floor.
+    /// </summary>
+    private void CompleteIfClaim(InteractionType type, long claimId)
+    {
+        lock (_lock)
+        {
+            if (CurrentInteraction != type || _claimId != claimId) return;
+            CompleteLocked(type);
+        }
+    }
+
     /// <summary>Completion logic; caller MUST hold <see cref="_lock"/>.</summary>
     private void CompleteLocked(InteractionType type)
     {
@@ -171,6 +202,7 @@ public class InteractionQueueService
                 var next = _queue.Dequeue();
                 CurrentInteraction = next.Type;
                 _interactionStartTime = DateTime.Now;
+                _claimId++;
                 StartStuckDetectionTimer();
                 App.Logger?.Information("InteractionQueue: Starting queued {Type} (remaining: {Count})",
                     next.Type, _queue.Count);
@@ -311,11 +343,55 @@ public class InteractionQueueService
         }
     }
 
+    /// <summary>Interactions paced by the user rather than by content: they end when a human types,
+    /// speaks or clicks, so elapsed time alone says nothing about whether they are stuck.</summary>
+    private static bool IsUserPaced(InteractionType type)
+        => type is InteractionType.LockCard or InteractionType.PopQuiz;
+
+    /// <summary>Test seam: how the queue asks whether an interaction's fullscreen UI is still on screen.
+    /// Overridable so headless tests can drive the stuck-timer paths without realizing WPF windows
+    /// (the default path needs a real visible-window set).</summary>
+    internal static Func<InteractionType, bool> UiStillOnScreenProbe = DefaultUiStillOnScreen;
+
+    private static bool DefaultUiStillOnScreen(InteractionType type)
+    {
+        try
+        {
+            return type switch
+            {
+                InteractionType.LockCard => LockCardWindow.IsAnyOpen(),
+                InteractionType.PopQuiz => PopQuizWindow.IsAnyOpen(),
+                _ => false
+            };
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Re-arm the stuck timer for a claim that turned out not to be stuck. Claim-guarded so a
+    /// slot that changed hands while we were tearing down keeps its own (already armed) timer.</summary>
+    private void RenewStuckTimeout(InteractionType type, long claimId, TimeSpan interval)
+    {
+        lock (_lock)
+        {
+            if (CurrentInteraction != type || _claimId != claimId) return;
+            StartStuckDetectionTimer(interval);
+        }
+    }
+
     private void OnStuckDetectionTimerTick(object? sender, EventArgs e)
     {
-        _stuckDetectionTimer?.Stop();
+        // Stop the timer that actually fired, not whatever the field points at now: if the slot changed
+        // hands between this timer firing and the handler running, the field is already the NEW claim's
+        // timer, and stopping it would leave that claim with no stuck detection at all (the renew and
+        // "not stuck anymore" paths below return without re-arming it).
+        ((sender as DispatcherTimer) ?? _stuckDetectionTimer)?.Stop();
 
         InteractionType stuckType;
+        long claimId;
+        TimeSpan activeDuration;
         lock (_lock)
         {
             if (!CurrentInteraction.HasValue)
@@ -324,10 +400,25 @@ public class InteractionQueueService
             }
 
             stuckType = CurrentInteraction.Value;
-            var activeDuration = DateTime.Now - _interactionStartTime;
-            App.Logger?.Warning("InteractionQueue: STUCK INTERACTION DETECTED! {Type} has been active for {Duration:F1} minutes. Auto-recovering...",
-                stuckType, activeDuration.TotalMinutes);
+            claimId = _claimId;
+            activeDuration = DateTime.Now - _interactionStartTime;
         }
+
+        // A lock card or pop quiz that is still on screen is waiting on a human, not stuck — nobody
+        // calls ExtendTimeout for them, so the 5-minute default used to "recover" a perfectly healthy
+        // card. Renew instead, up to the hard ceiling; someone who walked away still gets the screen
+        // cleared, just never while their card is up (#763).
+        if (IsUserPaced(stuckType) && activeDuration.TotalMinutes < UserPacedMaxInteractionMinutes
+            && UiStillOnScreenProbe(stuckType))
+        {
+            App.Logger?.Debug("InteractionQueue: {Type} still on screen after {Duration:F1} min - user-paced, renewing stuck timeout",
+                stuckType, activeDuration.TotalMinutes);
+            RenewStuckTimeout(stuckType, claimId, TimeSpan.FromMinutes(UserPacedRenewMinutes));
+            return;
+        }
+
+        App.Logger?.Warning("InteractionQueue: STUCK INTERACTION DETECTED! {Type} has been active for {Duration:F1} minutes. Auto-recovering...",
+            stuckType, activeDuration.TotalMinutes);
 
         // Tear down OUTSIDE the lock, then release. Ordering matters twice over:
         // - Not under _lock: the cleanups call back into CompleteIfCurrent; running them
@@ -351,6 +442,12 @@ public class InteractionQueueService
                 case InteractionType.BubbleCount:
                     App.BubbleCount?.ForceCleanup();
                     break;
+                case InteractionType.LockCard:
+                    LockCardWindow.ForceCloseAll();          // releases the slot itself when it is ours
+                    break;
+                case InteractionType.PopQuiz:
+                    PopQuizWindow.ForceCloseAll();           // OnClosed releases the slot
+                    break;
                 case InteractionType.WebVideo:
                     App.BrowserMedia?.ForceEndCore("queue-stuck-recovery"); // sync teardown, then releases
                     break;
@@ -362,9 +459,22 @@ public class InteractionQueueService
         }
         finally
         {
-            // Backstop: if the cleanup path didn't release the slot itself (or threw),
-            // free it now that no teardown is running. Idempotent and type-guarded.
-            CompleteIfCurrent(stuckType);
+            // The slot is the ONLY thing keeping two fullscreen HWND_TOPMOST overlays apart, so it must
+            // never be released while its window is still up — releasing under a live lock card is how a
+            // card and a pop quiz ended up stacked (#763). If teardown could not clear the UI, keep
+            // holding the claim and re-arm instead of handing the screen to the next interaction.
+            if (UiStillOnScreenProbe(stuckType) && activeDuration.TotalMinutes < HeldSlotAbandonMinutes)
+            {
+                App.Logger?.Warning("InteractionQueue: {Type} UI still on screen after force-cleanup - holding the slot instead of releasing it under a live overlay",
+                    stuckType);
+                RenewStuckTimeout(stuckType, claimId, TimeSpan.FromMinutes(DefaultMaxInteractionMinutes));
+            }
+            else
+            {
+                // Backstop: if the cleanup path didn't release the slot itself (or threw),
+                // free it now that no teardown is running. Idempotent and claim-guarded.
+                CompleteIfClaim(stuckType, claimId);
+            }
         }
     }
 }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -2915,6 +2915,12 @@ namespace ConditioningControlPanel.Services
             private volatile bool _hasRendered;
             private bool _hooked;
             private bool _disposed;
+            private bool _bufferReleased;
+
+            /// <summary>The player whose vmem callbacks feed this surface (set in Attach). CloseAll
+            /// uses it to pair the surface with the player's Stop() task, which owns the moment the
+            /// native frame buffer becomes safe to free.</summary>
+            public LibVLCSharp.Shared.MediaPlayer? Player { get; private set; }
 
             // #687: managed staging copy of the newest decoded frame. The UI thread copies the native
             // buffer into this UNDER _bufferLock and then RELEASES the lock before it goes anywhere
@@ -3013,6 +3019,7 @@ namespace ConditioningControlPanel.Services
             /// created lazily inside the format callback once the decoder reports the real size.</summary>
             public void Attach(LibVLCSharp.Shared.MediaPlayer player)
             {
+                Player = player;
                 _formatCb = FormatCallback;
                 _cleanupCb = CleanupCallback;
                 _lockCb = LockCallback;
@@ -3370,61 +3377,64 @@ namespace ConditioningControlPanel.Services
                 if (_disposed) return;
                 _disposed = true;
 
-                // Invalidate the buffer first so LockCallback hands LibVLC nothing, and stop blitting.
-                _bufferValid = false;
+                // Stop compositing only. The NATIVE frame buffer is deliberately NOT freed or
+                // invalidated here: LibVLC's vmem lock callback must always be handed a real plane
+                // pointer — writing null planes sends the decoder's next memcpy into address zero
+                // (0xC0000005 in msvcrt, reproduced 2026-08-02 under CCP_FAULT_WEDGE_STOP) — and on
+                // the blur path CloseAll no longer waits for Stop(), so a decoder that is still
+                // rendering is the EXPECTED case when this runs. The buffer keeps absorbing frames
+                // nobody reads until ReleaseBufferAfter(...) frees it once this surface's player has
+                // actually finished stopping; a Stop() that never completes leaks it (a few MB) by
+                // design — the same trade the player quarantine makes.
                 _frameReady = false;
                 Unhook();
 
-                // #616-#623/#766: this lock is taken on the UI THREAD during CloseAll and contends with
-                // LibVLC's native FormatCallback/LockCallback, which hold the same lock. It used to
-                // wait forever, so a decoder thread parked inside a callback wedged the dispatcher
-                // right here — and CloseAll no longer waits for Stop() on the blur path, so a LIVE
-                // wedged decoder is now the expected case rather than the rare one. Bounded like the
-                // per-frame blit (which uses an 8ms TryEnter budget).
-                //
-                // On failure we deliberately LEAK the HGlobal frame buffer: a native callback that
-                // still holds the lock may be mid-write into it, and freeing memory under a live
-                // decoder is a use-after-free. _bufferValid is already false above, so LockCallback
-                // hands LibVLC nothing from here on; the leak is one frame buffer (a few MB) per
-                // wedge, which is the same trade the player quarantine already makes.
-                IntPtr buf = IntPtr.Zero;
+                // Bounded like the per-frame blit (8ms TryEnter budget): this runs on the UI thread
+                // and contends with native FormatCallback/LockCallback. The bitmap is managed-only;
+                // if the lock can't be had, the GC gets it anyway once the rebuild posts drain.
                 long lockStart = Environment.TickCount64;
                 bool got = Monitor.TryEnter(_bufferLock, 250);
                 if (got)
                 {
-                    try
-                    {
-                        buf = _frameBuffer;
-                        _frameBuffer = IntPtr.Zero;
-                        _bitmap = null;
-                    }
+                    try { _bitmap = null; }
                     finally { Monitor.Exit(_bufferLock); }
                 }
                 long waited = Environment.TickCount64 - lockStart;
-                if (!got)
-                {
-                    App.Logger?.Warning("VideoService: blur surface {Tag} disposed while a native callback still held its buffer lock - leaking the frame buffer deliberately", _tag);
-                    Diag($"surface disposed - _bufferLock STILL held by a live native callback after {waited}ms; leaking the frame buffer (never free memory a wedged decoder may write into)");
-                }
-                else
-                {
-                    Diag(waited >= 100
-                        ? $"surface disposed - waited {waited}ms for _bufferLock (native callback contention)"
-                        : "surface disposed");
-                }
+                Diag(got
+                    ? (waited >= 100
+                        ? $"surface disposed - waited {waited}ms for _bufferLock (native callback contention); buffer held for the decoder"
+                        : "surface disposed (buffer held until the player's Stop() completes)")
+                    : $"surface disposed - _bufferLock still held by a native callback after {waited}ms; buffer held for the decoder");
+            }
 
-                // Free the native buffer only after a delay, so any frame still in flight on a
-                // LibVLC thread can't write into freed memory. On the blur path CloseAll no longer
-                // waits for Stop(), so this delay is now a real guard rather than belt-and-suspenders:
-                // _bufferValid is false, so LockCallback hands out nothing new, and the delay covers
-                // the one frame that may already hold the pointer.
+            /// <summary>
+            /// Free the native frame buffer once <paramref name="stopTask"/> — this surface's
+            /// player's Stop() — has completed, i.e. once LibVLC guarantees no vmem callback can
+            /// still hand the buffer to a decoder thread. A stop that never completes (the wedge
+            /// this whole path exists for) never frees it: leaked deliberately.
+            /// </summary>
+            public void ReleaseBufferAfter(Task stopTask)
+            {
+                if (stopTask.IsCompleted) { FreeBufferOnce(); return; }
+                stopTask.ContinueWith(_ => FreeBufferOnce(), TaskScheduler.Default);
+            }
+
+            private void FreeBufferOnce()
+            {
+                IntPtr buf;
+                lock (_bufferLock)
+                {
+                    if (_bufferReleased) return;
+                    _bufferReleased = true;
+                    buf = _frameBuffer;
+                    _frameBuffer = IntPtr.Zero;
+                    _bufferValid = false;
+                    _bitmap = null;
+                }
                 if (buf != IntPtr.Zero)
                 {
-                    Task.Run(async () =>
-                    {
-                        await Task.Delay(500);
-                        try { Marshal.FreeHGlobal(buf); } catch { /* ignore */ }
-                    });
+                    try { Marshal.FreeHGlobal(buf); } catch { /* ignore */ }
+                    Diag("frame buffer freed (player Stop() completed)");
                 }
             }
         }
@@ -5080,14 +5090,22 @@ namespace ConditioningControlPanel.Services
                 // The escape hatch's handles die with the windows (see RunWedgeEscapeHatch).
                 lock (_videoWindowHandlesLock) { _videoWindowHandles.Clear(); }
 
-                // Tear down any blurred-background memory-render surfaces: invalidate the frame
-                // buffer + unhook the render tick now (the players above are already stopped), then
-                // free the native buffer after a delay so an in-flight frame can't touch freed memory.
+                // Tear down any blurred-background memory-render surfaces: stop compositing now, but
+                // free each native frame buffer only after ITS player's Stop() task has completed —
+                // on the vmem path nothing above waited for the stops, so the decoder may still be
+                // handing frames to the surface right here, and both freeing the buffer and nulling
+                // the plane pointer under a live decoder are native AVs (the latter reproduced
+                // 2026-08-02 under CCP_FAULT_WEDGE_STOP: msvcrt memcpy into address zero).
                 if (_blurSurfaces.Count > 0)
                 {
                     foreach (var s in _blurSurfaces.ToList())
                     {
-                        try { s.Dispose(); }
+                        try
+                        {
+                            s.Dispose();
+                            var pair = stopPairs.FirstOrDefault(p => ReferenceEquals(p.player, s.Player));
+                            s.ReleaseBufferAfter(pair.task ?? Task.CompletedTask);
+                        }
                         catch (Exception ex) { App.Logger?.Debug("CloseAll: blur surface dispose failed - {Error}", ex.Message); }
                     }
                     _blurSurfaces.Clear();

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -112,7 +112,15 @@ namespace ConditioningControlPanel.Services
         private System.Threading.Timer? _wedgeWatchdog;
         private DispatcherTimer? _heartbeatTimer;
         private long _uiHeartbeatTicks;
-        private volatile bool _wedgeRescueFired;
+        // Highest rescue rung already run for this playback (0 = none). Replaces the old one-shot
+        // _wedgeRescueFired: in #767 the single rescue called player.Stop() INLINE on this timer
+        // thread, the call never returned, and that was the end of the story - dispatcher dead at
+        // 30s, 60s, forever. The ladder below keeps escalating, and every rung is bounded.
+        private volatile int _wedgeRescueRung;
+        // Set the first time a stall past WedgeStallMs is observed and left set for the rest of the
+        // playback. Read by the strict Closing veto so Alt+F4 works once the app is demonstrably
+        // wedged (#765) - a lock the user cannot escape is only defensible while the app responds.
+        private volatile bool _wedgeStallSeen;
         private volatile bool _preRollStallLogged; // one pre-roll stall line per armed watchdog
         // Fire only after a long, unambiguous stall — this targets the multi-minute lockouts, never a
         // UI thread that's merely busy for a beat. The legitimate ~4s teardown pump-wait keeps the
@@ -123,6 +131,36 @@ namespace ConditioningControlPanel.Services
         // callbacks is already pathological (the pump-wait keeps beating), so the rescue now engages
         // while the user is still watching the frozen frame rather than after they gave up.
         private const int WedgeStallMs = 8000;
+        // Escalating rescue ladder, measured from the START of the stall (#765/#766/#767):
+        //   rung 1 (8s)  - stop every native player OFF this thread. Non-destructive.
+        //   rung 2 (18s) - the wedge outlived the stops: retire the shared LibVLC instance.
+        //   rung 3 (28s) - give the user their machine back (see RunWedgeEscapeHatch).
+        // Rung 3 costs two Win32 calls and touches zero native VLC state, so it is the only rung
+        // allowed during pre-roll and during teardown.
+        private const int WedgeRescueRung2Ms = 18000;
+        private const int WedgeRescueRung3Ms = 28000;
+        // Bounded budget for one rung's off-thread Stop() batch. A player that outlives it is wedged
+        // for good and must not hold up the remaining players or the later rungs.
+        private const int WedgeStopBudgetMs = 3000;
+        // HWNDs of the live video windows, cached at creation (PreventClickRaise already resolves the
+        // HwndSource) so the escape-hatch rung can reach them from a threadpool thread. Window handles
+        // are process-wide and the Win32 calls the hatch makes need neither the dispatcher nor LibVLC,
+        // which is the whole point: they still work when the UI thread never drains again (#765).
+        private readonly List<IntPtr> _videoWindowHandles = new();
+        private readonly object _videoWindowHandlesLock = new();
+        // How long the async disposal task waits (OFF the dispatcher) for a straggling Stop() before
+        // it treats the player as wedged and quarantines it. Only a real wedge should ever spend a
+        // retire from the per-session budget.
+        private const int StopStragglerGraceMs = 4000;
+
+#if DEBUG
+        // Fault injection for the wedge cluster (#765/#766/#767). Set CCP_FAULT_WEDGE_STOP=1 and the
+        // first player's Stop() in CloseAll never completes - the exact native state the reports land
+        // in - so the teardown, rescue-ladder and escape-hatch behaviour can be play-tested without
+        // waiting for the intermittent aout stall to reproduce. DEBUG-only, read once per process.
+        private static readonly bool FaultInjectWedgeStop =
+            Environment.GetEnvironmentVariable("CCP_FAULT_WEDGE_STOP") == "1";
+#endif
 
         // Watch-time crediting for stats/quests (#447). _lastWatchPositionMs tracks the current video's
         // latest playback position (LibVLC TimeChanged); _creditedWatchSeconds is a watermark of what's
@@ -221,6 +259,10 @@ namespace ConditioningControlPanel.Services
         // down in CloseAll — invalidates the frame buffer + unhooks the render tick, then frees the
         // native buffer after a delay so an in-flight LibVLC frame can't touch freed memory.
         private readonly List<BlurVmemSurface> _blurSurfaces = new();
+        // One frame-liveness watchdog per live blur surface (see StartBlurFrameWatchdog). Threadpool
+        // timers, not DispatcherTimers, so they still fire while the UI thread is wedged.
+        private readonly List<System.Threading.Timer> _blurFrameWatchTimers = new();
+        private readonly object _blurFrameWatchLock = new();
 
         // Primary-monitor refs for the Deeper enhancement engine. Set when the
         // audio-bearing video window is created, cleared in CloseAll. Reading
@@ -624,6 +666,11 @@ namespace ConditioningControlPanel.Services
             // the "one bad teardown, then every video is a white screen" spiral (#559, and the
             // suspected shape of #616/#617/#621/#622/#623). Count it in the trace.
             VideoDiag.Log("QUARANTINE", $"{nativeObj.GetType().Name} rooted ({reason}) - {count} object(s) now quarantined");
+            // Every caller of this method quarantines a player whose Stop() never came back, so this
+            // is the one choke point where "the process now holds a permanently stuck native thread"
+            // becomes true — including on the vmem path, where CloseAll no longer waits on the
+            // dispatcher and therefore never logs the "Stop() WEDGED" line itself.
+            RecordNativePoisoning($"{nativeObj.GetType().Name} quarantined: {reason}");
         }
 
         /// <summary>
@@ -699,6 +746,327 @@ namespace ConditioningControlPanel.Services
             });
             return true;
         }
+
+        #region Managed lease (shared LibVLC for consumers outside the mandatory-video pipeline)
+
+        // Bubble count plays fullscreen topmost video on the SAME shared LibVLC as the mandatory
+        // pipeline, and until now it did so by copying the static SharedLibVLC into a field of its
+        // own — outside _libVLCLock, and well before the player was actually built (#766). A retire
+        // landing in that gap builds a MediaPlayer on an instance that is already quarantined, and
+        // nothing in this class knew those players existed: no wedge rescue, no quarantine, no
+        // trace. The lease closes both halves — the player is built on a locked-in instance, and it
+        // joins the rescue paths below.
+        //
+        // Leases are tracked SEPARATELY from _mediaPlayers on purpose: CloseAll owns everything in
+        // _mediaPlayers and disposes it, and disposing a bubble-count player out from under its live
+        // VideoView is the multi-monitor detach crash. They join the rescue/quarantine paths, which
+        // is what "managed" has to mean here — not shared ownership.
+        private readonly List<(LibVLCSharp.Shared.MediaPlayer Player, LibVLC Owner)> _managedLeases = new();
+        private readonly object _managedLock = new();
+
+        /// <summary>
+        /// Build a MediaPlayer on the CURRENT shared LibVLC and register it so it participates in
+        /// the wedge-rescue and quarantine machinery. Construction happens under _libVLCLock, so
+        /// the instance cannot be retired out from under the player mid-build.
+        /// </summary>
+        /// <param name="ownerTag">Short owner name for the trace, e.g. "bubble-count[primary]".</param>
+        /// <param name="owner">
+        /// The instance the player was built on. Create the caller's <c>Media</c> from THIS
+        /// reference rather than re-reading <see cref="SharedLibVLC"/>: a retire between the two
+        /// would otherwise hand a fresh instance's Media to a retired instance's player. A retired
+        /// instance is quarantined, never disposed, so this reference stays valid for the life of
+        /// the player.
+        /// </param>
+        public LibVLCSharp.Shared.MediaPlayer? CreateManagedPlayer(string ownerTag, out LibVLC? owner)
+        {
+            owner = null;
+            try
+            {
+                EnsureLibVLCInitialized();
+
+                LibVLCSharp.Shared.MediaPlayer player;
+                LibVLC instance;
+                lock (_libVLCLock)
+                {
+                    // Taking this lock can block behind a background rebuild's native `new LibVLC(...)`
+                    // (see RetireSharedLibVLC). That wait is the point: the alternative is the race
+                    // that built bubble-count players on retired instances.
+                    if (_libVLC == null)
+                    {
+                        VideoDiag.Log("LEASE", $"{ownerTag}: no shared LibVLC instance - player NOT created");
+                        return null;
+                    }
+                    instance = _libVLC;
+                    player = new LibVLCSharp.Shared.MediaPlayer(instance);
+                }
+
+                owner = instance;
+                lock (_managedLock) { _managedLeases.Add((player, instance)); }
+                VideoDiag.Log("LEASE", $"{ownerTag}: managed player created");
+                return player;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "VideoService: CreateManagedPlayer failed for {Owner}", ownerTag);
+                VideoDiag.Log("LEASE", $"{ownerTag}: managed player creation THREW: {ex.Message}");
+                owner = null;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Hand a leased player back. <paramref name="stopTask"/> is the task that called Stop() on
+        /// it: a task that never completes means the player is WEDGED, and a wedged player must be
+        /// quarantined (rooted forever) rather than disposed — disposing one is exactly what poisons
+        /// the shared instance for every later video (#559). Everything here runs off the
+        /// dispatcher; the caller may return immediately.
+        /// </summary>
+        public void ReleaseManagedPlayer(LibVLCSharp.Shared.MediaPlayer? player, Task? stopTask, string ownerTag)
+        {
+            if (player == null) return;
+
+            LibVLC? owner = null;
+            lock (_managedLock)
+            {
+                int i = _managedLeases.FindIndex(e => ReferenceEquals(e.Player, player));
+                if (i >= 0)
+                {
+                    owner = _managedLeases[i].Owner;
+                    _managedLeases.RemoveAt(i);
+                }
+            }
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    if (stopTask != null && !stopTask.IsCompleted)
+                    {
+                        VideoDiag.Log("LEASE", $"{ownerTag}: Stop() still running - waiting {StopStragglerGraceMs}ms off-thread before deciding");
+                        await Task.WhenAny(stopTask, Task.Delay(StopStragglerGraceMs));
+                    }
+                    // Same settle delay the mandatory teardown uses: let an in-flight EndReached or
+                    // render callback finish before the native object goes anywhere.
+                    await Task.Delay(750);
+
+                    if (stopTask != null && !stopTask.IsCompleted)
+                    {
+                        QuarantineNative(player, $"{ownerTag}: Stop() never completed");
+                        RetireSharedLibVLC(owner, $"a wedged {ownerTag} player was quarantined");
+                        return;
+                    }
+
+                    player.Dispose();
+                    VideoDiag.Log("LEASE", $"{ownerTag}: managed player disposed");
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("VideoService: ReleaseManagedPlayer({Owner}) failed - {Error}", ownerTag, ex.Message);
+                }
+            });
+        }
+
+        // ---- post-poisoning cooldown (#766) ----
+        // A Stop() that never returns leaves a native LibVLC thread stuck in this process for good.
+        // #766 is that state recorded at 22:05, a bubble-count video built on top of the wreckage at
+        // 22:18, and a dispatcher that never drained again. After a poisoning the shared instance is
+        // retired and rebuilt; consumers that can simply skip a turn should wait that out rather
+        // than immediately stand up another player.
+        private const int NativePoisonCooldownMs = 60000;
+        private static long _nativePoisonTicks;
+
+        /// <summary>
+        /// Milliseconds left of the post-poisoning cooldown, 0 when clear. Optional consumers
+        /// (bubble count) skip a turn while it is non-zero. The mandatory pipeline never checks it:
+        /// its own retire/quarantine already covers the case, and skipping a mandatory video would
+        /// be a functional regression.
+        /// </summary>
+        public static long NativePoisonCooldownRemainingMs
+        {
+            get
+            {
+                var at = Interlocked.Read(ref _nativePoisonTicks);
+                if (at == 0) return 0;
+                var elapsed = (DateTime.UtcNow.Ticks - at) / TimeSpan.TicksPerMillisecond;
+                return elapsed >= NativePoisonCooldownMs ? 0 : NativePoisonCooldownMs - elapsed;
+            }
+        }
+
+        /// <summary>Arm the cooldown. Called wherever a native Stop() is established as wedged.</summary>
+        private static void RecordNativePoisoning(string reason)
+        {
+            Interlocked.Exchange(ref _nativePoisonTicks, DateTime.UtcNow.Ticks);
+            App.Logger?.Warning(
+                "VideoService: native poisoning recorded ({Reason}) - holding new shared-LibVLC players off for {Sec}s",
+                reason, NativePoisonCooldownMs / 1000);
+            VideoDiag.Log("POISON", $"{reason} - {NativePoisonCooldownMs}ms cooldown armed for new shared-LibVLC players");
+        }
+
+        // ---- wedge protection for leased playback ----
+        // The mandatory watchdog is armed by StartVideoPlayback and gated on its own playback state,
+        // so bubble count was completely unguarded (#766): its only guard was a DispatcherTimer,
+        // i.e. dead the instant the UI thread it is meant to watch stops pumping. This is the same
+        // ladder, driven off VideoDiag's process-wide UI heartbeat instead of a private one, and
+        // without the mandatory rung 2 — retiring the shared instance mid-game rescues nothing and
+        // spends one of the four per-session retires.
+        private System.Threading.Timer? _managedWedgeWatchdog;
+        private volatile int _managedRescueRung;
+        private volatile string _managedLabel = "";
+        private readonly List<IntPtr> _managedWindowHandles = new();
+
+        /// <summary>
+        /// Arm the wedge ladder around a leased playback. Call BEFORE the first native call (the
+        /// #766 wedge is inside the MediaPlayer/HwndHost/Play sequence itself), and disarm when the
+        /// windows are gone. Independent of the mandatory watchdog, so arming this does not disturb
+        /// a video that is somehow still playing.
+        /// </summary>
+        public void ArmManagedWedgeWatchdog(string label)
+        {
+            _managedLabel = label;
+            _managedRescueRung = 0;
+            // Always called BEFORE the run's windows exist, so anything still cached here belongs to
+            // a previous run that never disarmed (its teardown threw). Those handles are dead, and
+            // acting on them would make the escape hatch's trace line lie about what it released.
+            lock (_managedLock) { _managedWindowHandles.Clear(); }
+            try { _managedWedgeWatchdog?.Dispose(); } catch { }
+            _managedWedgeWatchdog = new System.Threading.Timer(_ => ManagedWedgeTick(), null, 3000, 3000);
+            VideoDiag.Log("WEDGE", $"{label}: managed wedge watchdog armed");
+        }
+
+        /// <summary>Disarm the leased-playback ladder and forget its window handles.</summary>
+        public void DisarmManagedWedgeWatchdog()
+        {
+            // Teardown paths call this unconditionally (the panic key closes bubble count whether or
+            // not a game was running), so stay silent when there was nothing armed rather than write
+            // a WEDGE line naming a run that ended long ago.
+            bool wasArmed = _managedWedgeWatchdog != null;
+            try { _managedWedgeWatchdog?.Dispose(); } catch { }
+            _managedWedgeWatchdog = null;
+            lock (_managedLock) { _managedWindowHandles.Clear(); }
+            if (wasArmed) VideoDiag.Log("WEDGE", $"{_managedLabel}: managed wedge watchdog disarmed");
+        }
+
+        /// <summary>
+        /// Cache a leased window's HWND for the escape-hatch rung. Call from SourceInitialized:
+        /// once the UI thread wedges nothing can resolve a Window to its handle any more (#765).
+        /// </summary>
+        public void RegisterManagedWindow(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero) return;
+            lock (_managedLock)
+            {
+                if (!_managedWindowHandles.Contains(hwnd)) _managedWindowHandles.Add(hwnd);
+            }
+        }
+
+        private void ManagedWedgeTick()
+        {
+            try
+            {
+                if (_managedWedgeWatchdog == null) return;
+
+                // VideoDiag's heartbeat is process-wide and always running, so this ladder needs no
+                // DispatcherTimer of its own — one less thing that dies with the thread it watches.
+                long stallMs = VideoDiag.UiStallMs;
+                if (stallMs < WedgeStallMs) return;
+
+                if (_managedRescueRung < 1)
+                {
+                    _managedRescueRung = 1;
+                    App.Logger?.Error("VideoService: UI thread wedged {StallMs}ms during {Label} playback — off-thread rescue",
+                        stallMs, _managedLabel);
+                    VideoDiag.Log("WEDGE", $"{_managedLabel}: UI THREAD WEDGED {stallMs}ms - rung 1: off-thread player Stop()");
+                    StopManagedPlayersOffThread();
+                    return;
+                }
+
+                if (_managedRescueRung < 3 && stallMs >= WedgeRescueRung3Ms)
+                {
+                    _managedRescueRung = 3;
+                    RunManagedEscapeHatch(stallMs);
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ManagedWedgeTick error: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Rung 1 for leased playback: stop every leased player, each on its OWN task, with a
+        /// bounded batch wait. A hung player must cost only its own task — never the watchdog
+        /// thread, and never the later rung (the inline Stop() is what ended the rescue in #767).
+        /// </summary>
+        private void StopManagedPlayersOffThread()
+        {
+            List<LibVLCSharp.Shared.MediaPlayer> players;
+            lock (_managedLock) { players = _managedLeases.Select(e => e.Player).ToList(); }
+            VideoDiag.Log("WEDGE", $"{_managedLabel}: stopping {players.Count} leased player(s) off-thread");
+            if (players.Count == 0) return;
+
+            var tasks = new Task[players.Count];
+            for (int i = 0; i < players.Count; i++)
+            {
+                var index = i;
+                var player = players[i];
+                tasks[i] = Task.Run(() =>
+                {
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    try
+                    {
+                        player.Stop();
+                        VideoDiag.Log("WEDGE", $"{_managedLabel}: player[{index}].Stop returned after {sw.ElapsedMilliseconds}ms");
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("Managed wedge rescue: player.Stop failed - {Error}", ex.Message);
+                        VideoDiag.Log("WEDGE", $"{_managedLabel}: player[{index}].Stop threw after {sw.ElapsedMilliseconds}ms: {ex.Message}");
+                    }
+                });
+            }
+
+            if (!Task.WaitAll(tasks, WedgeStopBudgetMs))
+                VideoDiag.Log("WEDGE", $"{_managedLabel}: at least one leased Stop() is STILL running after {WedgeStopBudgetMs}ms - leaving it to the quarantine path");
+        }
+
+        /// <summary>
+        /// Rung 3 for leased playback — the same escape hatch the mandatory windows get (see
+        /// <see cref="RunWedgeEscapeHatch"/>). Bubble-count windows are fullscreen, topmost and (in
+        /// strict mode) refuse Esc, so a wedged dispatcher leaves the user with no way to reach the
+        /// desktop or Task Manager. Two Win32 calls against our own cached HWNDs: no dispatcher, no
+        /// LibVLC, no managed window state, so it still works when the UI thread never drains again.
+        /// </summary>
+        private void RunManagedEscapeHatch(long stallMs)
+        {
+            IntPtr[] handles;
+            lock (_managedLock) { handles = _managedWindowHandles.ToArray(); }
+            VideoDiag.Log("WEDGE", $"{_managedLabel}: rung 3 ESCAPE HATCH (stalled {stallMs}ms) - dropping {handles.Length} window(s) out of the topmost band and hiding them");
+            App.Logger?.Error("VideoService: UI thread wedged {StallMs}ms during {Label} — releasing {Count} topmost window(s) so the desktop and Task Manager are reachable",
+                stallMs, _managedLabel, handles.Length);
+            if (handles.Length == 0) return;
+
+            // Own task: a cross-thread window call can itself block on the hung owner thread, and
+            // that must never take the watchdog's timer thread with it.
+            Task.Run(() =>
+            {
+                foreach (var hwnd in handles)
+                {
+                    try
+                    {
+                        SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
+                        ShowWindow(hwnd, SW_HIDE);
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("Managed escape hatch: window release failed - {Error}", ex.Message);
+                    }
+                }
+                VideoDiag.Log("WEDGE", $"{_managedLabel}: rung 3 ESCAPE HATCH: window release calls issued");
+            });
+        }
+
+        #endregion
 
         /// <summary>
         /// Refresh the videos path based on current settings.
@@ -1695,6 +2063,10 @@ namespace ConditioningControlPanel.Services
             CancelPendingRetry();
             _retryPath = path;
             _startTime = DateTime.Now;
+            // Fresh clip ⇒ fresh length. _duration was only ever ASSIGNED (LengthChanged / MediaOpened)
+            // and never cleared, so a clip that died before LengthChanged inherited the previous
+            // clip's length and was credited with it on the skip path (#767).
+            _duration = 0;
             _hits = _total = 0;
             _spawnTimes.Clear();
 
@@ -1988,7 +2360,9 @@ namespace ConditioningControlPanel.Services
                 if (useBlur)
                 {
                     double screenAspect = (double)screen.Bounds.Width / Math.Max(1, screen.Bounds.Height);
-                    blurSurface = new BlurVmemSurface(screenAspect);
+                    // Every BLUR: line carries the surface tag so a report says WHICH screen died
+                    // instead of leaving it to be inferred from thread counts (#767).
+                    blurSurface = new BlurVmemSurface(screenAspect, $"{tag} {screen.DeviceName}");
                     _blurSurfaces.Add(blurSurface);
                     App.Logger?.Information("VideoService: blurred-background path armed for {File} on {Screen} (screenAspect={AR:0.000})",
                         Path.GetFileName(path), screen.DeviceName, screenAspect);
@@ -2039,8 +2413,15 @@ namespace ConditioningControlPanel.Services
                     catch (Exception ex) { App.Logger?.Debug("PrimaryPlaybackTimeMsChanged handler error: {Error}", ex.Message); }
                 };
 
+                // Handlers are never unsubscribed and a wedged player is quarantined rather than
+                // disposed, so a LATE event can still arrive from a player whose video is long gone.
+                // Same generation guard the watchdog continuations use (see _teardownGeneration): a
+                // stale LengthChanged must not overwrite the current clip's duration or re-arm the
+                // safety timer against a video that already ended.
+                var lengthGen = _teardownGeneration;
                 mediaPlayer.LengthChanged += (s, e) =>
                 {
+                    if (lengthGen != _teardownGeneration) return;
                     _duration = e.Length / 1000.0; // Convert ms to seconds
                     App.Logger?.Information("VideoService: LibVLC LengthChanged fired, duration={Duration}s", _duration);
 
@@ -2089,7 +2470,11 @@ namespace ConditioningControlPanel.Services
                         var dispatcher = Application.Current?.Dispatcher;
                         if (dispatcher != null && !dispatcher.HasShutdownStarted)
                         {
-                            dispatcher.BeginInvoke(() => StartSafetyTimer(_duration));
+                            dispatcher.BeginInvoke(() =>
+                            {
+                                if (lengthGen != _teardownGeneration) return; // a teardown beat us to the UI thread
+                                StartSafetyTimer(_duration);
+                            });
                         }
                         else
                         {
@@ -2303,18 +2688,23 @@ namespace ConditioningControlPanel.Services
                 // that is the line to read when a report says "video plays but has no sound".
                 App.Logger?.Information("LibVLC audio requested: Volume={Vol}, Mute={Mute} (pre-aout - see the [VIDEO] aout line for what actually happened)",
                     mediaPlayer.Volume, mediaPlayer.Mute);
-
-                // Arm the vout watchdog on the primary player: if no video output exists within the
-                // grace window the screen is white regardless of decode state (#557-#560/#574) —
-                // self-heal by retiring the shared instance and retrying once (see VoutWatchdogFire).
-                // The blurred path renders through memory callbacks (no vout HWND, so none of the
-                // DXVA present failures the vout watchdog targets), so it uses a simpler frame-arrival
-                // watchdog instead: no frame within the grace window ⇒ skip to the next video.
-                if (useBlur)
-                    StartBlurFrameWatchdog(blurSurface!);
-                else
-                    StartVoutWatchdog(mediaPlayer, path, strict);
             }
+
+            // Arm the vout watchdog on the primary player: if no video output exists within the
+            // grace window the screen is white regardless of decode state (#557-#560/#574) —
+            // self-heal by retiring the shared instance and retrying once (see VoutWatchdogFire).
+            // The blurred path renders through memory callbacks (no vout HWND, so none of the
+            // DXVA present failures the vout watchdog targets), so it uses a simpler frame-arrival
+            // watchdog instead: no frame within the grace window ⇒ skip to the next video.
+            //
+            // The frame watchdog is armed for EVERY blurred surface, not just the audio-bearing one:
+            // it used to live inside the `withAudio` block, so a stalled SECONDARY was invisible and
+            // a healthy secondary could not rescue a stalled primary (#767). The vout watchdog stays
+            // primary-only — its heal retires and replays the whole video.
+            if (useBlur)
+                StartBlurFrameWatchdog(blurSurface!, $"{tag} {screen.DeviceName}");
+            else if (withAudio)
+                StartVoutWatchdog(mediaPlayer, path, strict);
 
                 App.Logger?.Debug("LibVLC video window on: {Screen} (audio: {Audio}, vol: {Vol}, mute: {Mute})",
                     screen.DeviceName, withAudio, mediaPlayer.Volume, mediaPlayer.Mute);
@@ -2434,27 +2824,56 @@ namespace ConditioningControlPanel.Services
         /// video rather than sit on a black screen. Cheaper counterpart to StartVoutWatchdog, which
         /// targets the VideoView/DXVA white-screen the memory path can't hit.
         /// </summary>
-        private void StartBlurFrameWatchdog(BlurVmemSurface surface)
+        private void StartBlurFrameWatchdog(BlurVmemSurface surface, string surfaceTag)
         {
             var gen = _teardownGeneration;
-            // DIAGNOSTIC NOTE (#616/#617/#621/#622/#623): unlike StartVoutWatchdog (a threadpool
-            // timer) this guard is a DispatcherTimer, so it is dead weight in exactly the scenario
-            // the reports describe — a wedged UI thread. The blurred-background path is the DEFAULT
-            // in 6.5.0, which means the default render path's only frame-liveness guard cannot fire
-            // during a freeze. Logged, not changed: replacing it is a behaviour change, not
-            // instrumentation. See the write-up.
-            VideoDiag.Log("BLUR", $"frame watchdog armed (DispatcherTimer, {VoutGraceMs}ms) - cannot fire if the UI thread wedges");
-            var timer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(VoutGraceMs) };
-            timer.Tick += (s, e) =>
+            // This used to be a DispatcherTimer, and its own comment admitted the flaw: the blurred
+            // path is the DEFAULT render path, and its only frame-liveness guard could not fire in
+            // exactly the scenario it exists for — a wedged UI thread (#616-#623/#766). It is now a
+            // threadpool timer like StartVoutWatchdog, so the verdict lands in the trace even during
+            // a freeze; only the teardown it decides on is marshalled back to the dispatcher.
+            VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog armed (threadpool timer, {VoutGraceMs}ms)");
+            var timer = new System.Threading.Timer(_ =>
             {
-                timer.Stop();
-                if (!_videoPlaying || gen != _teardownGeneration) return; // torn down / superseded
-                if (surface.HasRendered) { VideoDiag.Log("BLUR", "frame watchdog: frames are arriving, all good"); return; }
-                App.Logger?.Warning("VideoService: blurred-background video produced no frame within {Ms}ms — skipping to next", VoutGraceMs);
-                VideoDiag.Log("BLUR", $"NO FRAME within {VoutGraceMs}ms - black-screen state confirmed, skipping to next video");
-                try { OnEnded(); } catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog OnEnded threw: {E}", ex.Message); }
-            };
-            timer.Start();
+                try
+                {
+                    if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return; // torn down / superseded
+                    if (surface.HasRendered) { VideoDiag.Log("BLUR", $"[{surfaceTag}] frame watchdog: frames are arriving, all good"); return; }
+                    App.Logger?.Warning("VideoService: blurred-background video produced no frame within {Ms}ms on {Surface} — skipping to next",
+                        VoutGraceMs, surfaceTag);
+                    VideoDiag.Log("BLUR", $"[{surfaceTag}] NO FRAME within {VoutGraceMs}ms - black-screen state confirmed, skipping to next video");
+
+                    var dispatcher = Application.Current?.Dispatcher;
+                    if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                    dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        if (!_videoPlaying || _isCleaningUp || gen != _teardownGeneration) return;
+                        // Nothing was ever on screen for this surface: the natural-end path must NOT
+                        // seed the watch position to the full clip length (#767).
+                        try { EndCurrentVideo(noFrameRendered: true); }
+                        catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog OnEnded threw: {E}", ex.Message); }
+                    }));
+                }
+                catch (Exception ex) { App.Logger?.Debug("StartBlurFrameWatchdog tick error: {E}", ex.Message); }
+            }, null, VoutGraceMs, System.Threading.Timeout.Infinite);
+
+            lock (_blurFrameWatchLock) { _blurFrameWatchTimers.Add(timer); }
+        }
+
+        /// <summary>Disarm every blur frame watchdog armed for the current playback. Called from the
+        /// CloseAll finally, next to StopVoutWatchdog.</summary>
+        private void StopBlurFrameWatchdogs()
+        {
+            List<System.Threading.Timer> timers;
+            lock (_blurFrameWatchLock)
+            {
+                timers = _blurFrameWatchTimers.ToList();
+                _blurFrameWatchTimers.Clear();
+            }
+            foreach (var t in timers)
+            {
+                try { t.Dispose(); } catch { }
+            }
         }
 
         /// <summary>
@@ -2477,6 +2896,9 @@ namespace ConditioningControlPanel.Services
             private const int BgSnapshotDivisor = 8;
 
             private readonly double _screenAspect;
+            // "primary \\.\DISPLAY1" — stamped on every BLUR line so a dual-monitor report says which
+            // surface stalled instead of leaving it to be inferred from decoder thread counts (#767).
+            private readonly string _tag;
             private readonly object _bufferLock = new();
             private readonly System.Windows.Shapes.Rectangle _background;
             private readonly ImageBrush _bgBrush;
@@ -2527,9 +2949,14 @@ namespace ConditioningControlPanel.Services
             /// <summary>True once at least one frame has been blitted to the surface.</summary>
             public bool HasRendered => _hasRendered;
 
-            public BlurVmemSurface(double screenAspect)
+            /// <summary>Tagged BLUR trace line for this surface. Enqueue-only, safe from the UI
+            /// thread and from LibVLC's native callback threads alike.</summary>
+            private void Diag(string message) => VideoDiag.Log("BLUR", $"[{_tag}] {message}");
+
+            public BlurVmemSurface(double screenAspect, string tag)
             {
                 _screenAspect = screenAspect > 0 ? screenAspect : (16.0 / 9.0);
+                _tag = string.IsNullOrEmpty(tag) ? "?" : tag;
 
                 // Blurred fill: same frame scaled to cover the whole screen (cropping the excess),
                 // heavily blurred. Hidden until the format callback decides bars are actually needed.
@@ -2640,7 +3067,7 @@ namespace ConditioningControlPanel.Services
                 // blurFill=true arms the fullscreen Gaussian; in 6.5.0 it ran every frame over the LIVE
                 // per-frame bitmap and that was the freeze (#616-#623/#632/#636/#687). It now runs over
                 // a small frozen snapshot instead, but the trace still records when it is armed.
-                VideoDiag.Log("BLUR", $"format cb - video {vw}x{vh}, buffer {bw}x{bh}, blurFill={needsBlur}");
+                Diag($"format cb - video {vw}x{vh}, buffer {bw}x{bh}, blurFill={needsBlur}");
 
                 var disp = Application.Current?.Dispatcher;
                 if (disp != null && !disp.HasShutdownStarted)
@@ -2670,7 +3097,7 @@ namespace ConditioningControlPanel.Services
                 {
                     if (!IsRebuildCurrent(gen, Volatile.Read(ref _formatGeneration)))
                     {
-                        VideoDiag.Log("BLUR", $"stale bitmap rebuild dropped ({bw}x{bh}, gen {gen} superseded)");
+                        Diag($"stale bitmap rebuild dropped ({bw}x{bh}, gen {gen} superseded)");
                         return;
                     }
 
@@ -2683,7 +3110,7 @@ namespace ConditioningControlPanel.Services
                     }
                     if (!applied)
                     {
-                        VideoDiag.Log("BLUR", $"stale bitmap rebuild dropped at swap ({bw}x{bh}, gen {gen} superseded)");
+                        Diag($"stale bitmap rebuild dropped at swap ({bw}x{bh}, gen {gen} superseded)");
                         return;
                     }
 
@@ -2793,7 +3220,7 @@ namespace ConditioningControlPanel.Services
                     if (_staging.Length < bytes)
                     {
                         _staging = new byte[bytes];
-                        VideoDiag.Log("BLUR", $"staging buffer grown to {bytes / 1024}KB for {w}x{h}");
+                        Diag($"staging buffer grown to {bytes / 1024}KB for {w}x{h}");
                     }
                     Marshal.Copy(_frameBuffer, _staging, 0, bytes);
                     staging = _staging;
@@ -2830,9 +3257,9 @@ namespace ConditioningControlPanel.Services
                     }
                     long blitMs = Environment.TickCount64 - lockStart;
                     if (blitMs >= 250)
-                        VideoDiag.Log("BLUR", $"UI-thread frame blit took {blitMs}ms (WriteableBitmap.Lock contended with the render thread)");
+                        Diag($"UI-thread frame blit took {blitMs}ms (WriteableBitmap.Lock contended with the render thread)");
                     if (!_hasRendered)
-                        VideoDiag.Log("BLUR", $"first frame blitted ({w}x{h})");
+                        Diag($"first frame blitted ({w}x{h})");
                     _hasRendered = true;
 
                     RefreshBackgroundSnapshot(staging, w, h);
@@ -2870,11 +3297,11 @@ namespace ConditioningControlPanel.Services
                     if (_snapBuf.Length < need)
                     {
                         _snapBuf = new byte[need];
-                        VideoDiag.Log("BLUR", $"blur-fill snapshot source is {sw}x{sh} (1/{BgSnapshotDivisor} of {w}x{h}, every {BgSnapshotEveryNFrames} frames)");
+                        Diag($"blur-fill snapshot source is {sw}x{sh} (1/{BgSnapshotDivisor} of {w}x{h}, every {BgSnapshotEveryNFrames} frames)");
                     }
                     else if (sw != _snapW || sh != _snapH)
                     {
-                        VideoDiag.Log("BLUR", $"blur-fill snapshot resized to {sw}x{sh} (from {w}x{h})");
+                        Diag($"blur-fill snapshot resized to {sw}x{sh} (from {w}x{h})");
                     }
                     _snapW = sw;
                     _snapH = sh;
@@ -2948,27 +3375,49 @@ namespace ConditioningControlPanel.Services
                 _frameReady = false;
                 Unhook();
 
-                // #616-#623: this `lock` is taken on the UI THREAD during CloseAll and contends with
-                // LibVLC's native FormatCallback/LockCallback, which hold the same lock. Unlike the
-                // per-frame blit (which uses TryEnter with an 8ms budget) this one waits forever, so
-                // a decoder thread stuck inside a callback wedges the dispatcher here. Bracketed so
-                // the trace shows whether teardown died on this exact lock.
-                IntPtr buf;
+                // #616-#623/#766: this lock is taken on the UI THREAD during CloseAll and contends with
+                // LibVLC's native FormatCallback/LockCallback, which hold the same lock. It used to
+                // wait forever, so a decoder thread parked inside a callback wedged the dispatcher
+                // right here — and CloseAll no longer waits for Stop() on the blur path, so a LIVE
+                // wedged decoder is now the expected case rather than the rare one. Bounded like the
+                // per-frame blit (which uses an 8ms TryEnter budget).
+                //
+                // On failure we deliberately LEAK the HGlobal frame buffer: a native callback that
+                // still holds the lock may be mid-write into it, and freeing memory under a live
+                // decoder is a use-after-free. _bufferValid is already false above, so LockCallback
+                // hands LibVLC nothing from here on; the leak is one frame buffer (a few MB) per
+                // wedge, which is the same trade the player quarantine already makes.
+                IntPtr buf = IntPtr.Zero;
                 long lockStart = Environment.TickCount64;
-                lock (_bufferLock)
+                bool got = Monitor.TryEnter(_bufferLock, 250);
+                if (got)
                 {
-                    buf = _frameBuffer;
-                    _frameBuffer = IntPtr.Zero;
-                    _bitmap = null;
+                    try
+                    {
+                        buf = _frameBuffer;
+                        _frameBuffer = IntPtr.Zero;
+                        _bitmap = null;
+                    }
+                    finally { Monitor.Exit(_bufferLock); }
                 }
                 long waited = Environment.TickCount64 - lockStart;
-                VideoDiag.Log("BLUR", waited >= 100
-                    ? $"surface disposed - waited {waited}ms for _bufferLock (native callback contention)"
-                    : "surface disposed");
+                if (!got)
+                {
+                    App.Logger?.Warning("VideoService: blur surface {Tag} disposed while a native callback still held its buffer lock - leaking the frame buffer deliberately", _tag);
+                    Diag($"surface disposed - _bufferLock STILL held by a live native callback after {waited}ms; leaking the frame buffer (never free memory a wedged decoder may write into)");
+                }
+                else
+                {
+                    Diag(waited >= 100
+                        ? $"surface disposed - waited {waited}ms for _bufferLock (native callback contention)"
+                        : "surface disposed");
+                }
 
                 // Free the native buffer only after a delay, so any frame still in flight on a
-                // LibVLC thread can't write into freed memory. The player is already stopped by
-                // CloseAll before this runs, so this is belt-and-suspenders.
+                // LibVLC thread can't write into freed memory. On the blur path CloseAll no longer
+                // waits for Stop(), so this delay is now a real guard rather than belt-and-suspenders:
+                // _bufferValid is false, so LockCallback hands out nothing new, and the delay covers
+                // the one frame that may already hold the pointer.
                 if (buf != IntPtr.Zero)
                 {
                     Task.Run(async () =>
@@ -3168,7 +3617,12 @@ namespace ConditioningControlPanel.Services
                 // is never vetoed — otherwise a strict window whose _videoPlaying was
                 // left true becomes permanently un-closable and renders solid black
                 // (the "video ended, black window won't close" report).
-                win.Closing += (s, e) => { if (_videoPlaying && !_isCleaningUp) e.Cancel = true; };
+                //
+                // The veto also stands down once the wedge watchdog has recorded a stall past
+                // WedgeStallMs: a strict lock is only defensible while the app is actually
+                // responding, and #765 is a user staring at a frozen fullscreen frame that refuses
+                // Alt+F4 with no way to reach Task Manager behind it.
+                win.Closing += (s, e) => { if (_videoPlaying && !_isCleaningUp && !_wedgeStallSeen) e.Cancel = true; };
                 win.PreviewKeyDown += (s, e) =>
                 {
                     // In strict mode, block panic key, Alt+F4, and system keys
@@ -3459,10 +3913,22 @@ namespace ConditioningControlPanel.Services
 
         #region Video End / Penalty / Mercy
 
-        private void OnEnded()
+        /// <summary>
+        /// The video reached its end (LibVLC EndReached / MediaElement MediaEnded / no screens).
+        /// Deliberately parameterless and NOT overloaded: the LibVLC handlers hand this method GROUP
+        /// to Dispatcher.BeginInvoke, which only binds while the group has exactly one candidate.
+        /// </summary>
+        private void OnEnded() => EndCurrentVideo(noFrameRendered: false);
+
+        /// <param name="noFrameRendered">
+        /// True only for the blur frame watchdog's black-screen skip: the surface never produced a
+        /// single frame, so the natural-end "credit the whole clip" seed below must be skipped.
+        /// Without this a 9-second black screen was credited as 357.8s watched (#767).
+        /// </param>
+        private void EndCurrentVideo(bool noFrameRendered)
         {
-            App.Logger?.Information("VideoService: OnEnded() called, _videoPlaying={Playing}, _windows={WinCount}, _isCleaningUp={Cleaning}",
-                _videoPlaying, _windows.Count, _isCleaningUp);
+            App.Logger?.Information("VideoService: OnEnded() called, _videoPlaying={Playing}, _windows={WinCount}, _isCleaningUp={Cleaning}, noFrame={NoFrame}",
+                _videoPlaying, _windows.Count, _isCleaningUp, noFrameRendered);
 
             // Skip if cleanup is already in progress (e.g., from panic key)
             if (_isCleaningUp)
@@ -3593,7 +4059,10 @@ namespace ConditioningControlPanel.Services
             // fails credit what was watched too — #447). The WPF MediaElement fallback path has no
             // TimeChanged position, so on a natural end seed the watched position to the full duration to
             // preserve the old "credit full length" behavior; the LibVLC path is already at ~duration here.
-            if (_lastWatchPositionMs <= 0 && _duration > 0)
+            // NOT on the no-frame skip: nothing was ever on screen, so the honest credit is zero.
+            if (noFrameRendered)
+                VideoDiag.Log("VIDEO", "no frame ever rendered - crediting 0s watched (skipping the full-duration seed)");
+            else if (_lastWatchPositionMs <= 0 && _duration > 0)
                 _lastWatchPositionMs = _duration * 1000.0;
 
             Cleanup();
@@ -4097,7 +4566,8 @@ namespace ConditioningControlPanel.Services
 
         private void StartWedgeWatchdog()
         {
-            _wedgeRescueFired = false;
+            _wedgeRescueRung = 0;
+            _wedgeStallSeen = false;
             _preRollStallLogged = false;
             System.Threading.Interlocked.Exchange(ref _uiHeartbeatTicks, DateTime.UtcNow.Ticks);
 
@@ -4126,110 +4596,215 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Runs on a threadpool thread every ~3s. If a video is playing but the UI thread stopped
-        /// heart-beating for <see cref="WedgeStallMs"/>, the dispatcher is wedged (frozen final frame,
-        /// topmost window holding the screen). Break it off-thread and queue a teardown so the app
-        /// recovers without a hard shutdown. Fires at most once per playback.
+        /// Runs on a threadpool thread every ~3s. If the UI thread stopped heart-beating for
+        /// <see cref="WedgeStallMs"/> while a video is playing (or being torn down), the dispatcher is
+        /// wedged — frozen final frame, topmost fullscreen window holding the whole screen. Escalates
+        /// through the rescue ladder described on <see cref="WedgeRescueRung2Ms"/> until either the
+        /// dispatcher drains again or the user has their machine back.
         ///
-        /// PRE-ROLL is observe-only: see <see cref="_playbackStarted"/>. Retiring LibVLC while the
-        /// UI thread is still walking PlayVideo's prologue towards EnsureLibVLCInitialized races the
-        /// background rebuild on _libVLCLock and takes the process down natively (#750-#753).
+        /// PRE-ROLL and TEARDOWN are restricted to the escape hatch: see <see cref="_playbackStarted"/>.
+        /// Retiring LibVLC while the UI thread is still walking PlayVideo's prologue towards
+        /// EnsureLibVLCInitialized races the background rebuild on _libVLCLock and takes the process
+        /// down natively (#750-#753), and during a teardown the players are already being stopped.
         /// </summary>
         private void WedgeWatchdogTick()
         {
             try
             {
-                if (!_videoPlaying || _wedgeRescueFired) return;
+                // #766/#767: stay armed through CloseAll. _videoPlaying is cleared at the TOP of the
+                // teardown, so gating on it alone made the app's longest predictable UI-thread block
+                // structurally invisible to the guard that exists to catch exactly that.
+                bool cleaning = _isCleaningUp;
+                if (!_videoPlaying && !cleaning) return;
+                if (_wedgeRescueRung >= 3) return; // ladder exhausted - nothing left to try
 
                 var last = System.Threading.Interlocked.Read(ref _uiHeartbeatTicks);
                 var stallMs = (DateTime.UtcNow.Ticks - last) / TimeSpan.TicksPerMillisecond;
                 if (stallMs < WedgeStallMs) return;
 
+                // Remembered for the rest of the playback: once the app has demonstrably wedged, the
+                // strict Closing veto stands down so Alt+F4 works (#765).
+                _wedgeStallSeen = true;
+
                 bool live = _playbackStarted;
                 if (!live) lock (_mediaPlayersLock) { live = _mediaPlayers.Count > 0; }
-                if (!live)
+
+                if (!live || cleaning)
                 {
-                    // The UI thread IS stalled, but there is nothing on screen to rescue yet.
-                    // Record it (once) and let the next tick reconsider — whatever the prologue is
-                    // blocked on will either finish, or the app will die where the trace points.
+                    // Nothing safe to rescue: either nothing is on screen yet (pre-roll) or teardown
+                    // already owns the players. Record it once, and still give the user an exit — the
+                    // escape hatch is two Win32 calls against our own windows and touches zero native
+                    // VLC state, so it cannot reproduce #750-#753.
                     if (!_preRollStallLogged)
                     {
                         _preRollStallLogged = true;
-                        App.Logger?.Warning("VideoService: UI thread stalled {StallMs}ms during video PRE-ROLL — no rescue (nothing on screen yet)", stallMs);
-                        VideoDiag.Log("WEDGE", $"UI thread stalled {stallMs}ms during PRE-ROLL - observing only, no LibVLC retire");
+                        var phase = cleaning ? "TEARDOWN" : "PRE-ROLL";
+                        App.Logger?.Warning("VideoService: UI thread stalled {StallMs}ms during video {Phase} — escape hatch only, no LibVLC rescue", stallMs, phase);
+                        VideoDiag.Log("WEDGE", $"UI thread stalled {stallMs}ms during {phase} - escape hatch only, no LibVLC retire");
                     }
+                    if (stallMs >= WedgeRescueRung3Ms)
+                        RunWedgeEscapeHatch(stallMs, cleaning ? "teardown" : "pre-roll");
                     return;
                 }
 
-                _wedgeRescueFired = true;
-                App.Logger?.Error(
-                    "VideoService: UI thread wedged {StallMs}ms during video playback — off-thread rescue (freeze/lockout guard)",
-                    stallMs);
-                // This is THE line the five v6.5.0 reports need (#616/#617/#621/#622/#623): it dates
-                // the freeze to the second and proves the rescue ran. Everything below is logged
-                // step by step because the rescue itself can be what hangs (a native Stop() that
-                // never returns), and we currently cannot tell those two cases apart.
-                VideoDiag.Log("WEDGE", $"UI THREAD WEDGED {stallMs}ms during playback - starting off-thread rescue");
-
-                // Stop native players off-thread. LibVLC Stop() is thread-safe (CloseAll already calls
-                // it from Task.Run) and can unblock a stuck decode/render that's holding the UI thread.
-                // Harmless when the list is empty (e.g. the wedge is mid window-recreate before the new
-                // player is registered — the posted teardown below still recovers it once unblocked).
-                List<LibVLCSharp.Shared.MediaPlayer> players;
-                lock (_mediaPlayersLock) { players = _mediaPlayers.ToList(); }
-                VideoDiag.Log("WEDGE", $"stopping {players.Count} native player(s) off-thread");
-                for (int i = 0; i < players.Count; i++)
+                if (_wedgeRescueRung < 1)
                 {
-                    var sw = System.Diagnostics.Stopwatch.StartNew();
-                    try
-                    {
-                        players[i].Stop();
-                        VideoDiag.Log("WEDGE", $"player[{i}].Stop returned after {sw.ElapsedMilliseconds}ms");
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Debug("Wedge rescue: player.Stop failed - {Error}", ex.Message);
-                        VideoDiag.Log("WEDGE", $"player[{i}].Stop threw after {sw.ElapsedMilliseconds}ms: {ex.Message}");
-                    }
+                    _wedgeRescueRung = 1;
+                    App.Logger?.Error(
+                        "VideoService: UI thread wedged {StallMs}ms during video playback — off-thread rescue (freeze/lockout guard)",
+                        stallMs);
+                    // This is THE line the freeze reports need (#616-#623, #765-#767): it dates the
+                    // freeze to the second and proves the rescue ran. Every rung is logged because the
+                    // rescue itself can be what hangs (a native Stop() that never returns), and the
+                    // trace is the only way to tell those two cases apart.
+                    VideoDiag.Log("WEDGE", $"UI THREAD WEDGED {stallMs}ms during playback - rung 1: off-thread player Stop()");
+                    WedgeStopPlayersOffThread();
+                    PostWedgeTeardown();
+                    return;
                 }
 
-                // A wedge mid-playback means the shared instance's native state is suspect - the #559
-                // pattern is precisely "one wedge, then every later video white-screens". Retire it so
-                // the next video starts on a clean instance (the retired one is rooted, never disposed).
-                RetireSharedLibVLC(_libVLC, "UI-thread wedge rescue during playback");
-
-                // Queue a real teardown + reschedule for the instant the dispatcher drains again, so a
-                // multi-minute lockout collapses to a brief stutter instead of stranding the frozen
-                // frame until the user kills the app or the next scheduled video jolts it loose.
-                // Generation-guarded: if some other teardown already ran by then (e.g. the vout heal
-                // tore down and started its retry video), this must not kill the newcomer.
-                var gen = _teardownGeneration;
-                try
+                if (_wedgeRescueRung < 2 && stallMs >= WedgeRescueRung2Ms)
                 {
-                    var dispatcher = Application.Current?.Dispatcher;
-                    if (dispatcher != null && !dispatcher.HasShutdownStarted)
-                    {
-                        VideoDiag.Log("WEDGE", "posting rescue teardown to the dispatcher");
-                        dispatcher.BeginInvoke(new Action(() =>
-                        {
-                            // If this line never appears in a report's trace, the dispatcher NEVER
-                            // drained again — i.e. the rescue's off-thread Stop() did not break the
-                            // wedge and only a process kill / hard reset could end it.
-                            VideoDiag.Log("WEDGE", $"rescue teardown running (dispatcher drained again after {VideoDiag.UiStallMs}ms)");
-                            if (_teardownGeneration != gen) return;
-                            try { ForceCleanup(); }
-                            catch (Exception ex) { App.Logger?.Warning(ex, "Wedge rescue: ForceCleanup threw"); }
-                            if (_isRunning) ScheduleNext();
-                            VideoDiag.Log("WEDGE", "rescue teardown complete");
-                        }));
-                    }
+                    // Rung 1 did not break it. A wedge that survives a Stop() means the shared
+                    // instance's native state is suspect - the #559 pattern is precisely "one wedge,
+                    // then every later video white-screens". Retire it so the next video starts on a
+                    // clean instance (the retired one is rooted, never disposed).
+                    _wedgeRescueRung = 2;
+                    VideoDiag.Log("WEDGE", $"still wedged after {stallMs}ms - rung 2: retiring the shared LibVLC instance");
+                    RetireSharedLibVLC(_libVLC, "UI-thread wedge rescue during playback");
+                    PostWedgeTeardown();
+                    return;
                 }
-                catch (Exception ex) { App.Logger?.Debug("Wedge rescue: dispatch failed - {Error}", ex.Message); }
+
+                if (stallMs >= WedgeRescueRung3Ms)
+                    RunWedgeEscapeHatch(stallMs, "playback");
             }
             catch (Exception ex)
             {
                 App.Logger?.Debug("WedgeWatchdogTick error: {Error}", ex.Message);
             }
+        }
+
+        /// <summary>
+        /// Rung 1: stop every native player, each on its OWN task, with a bounded batch wait. Runs on
+        /// the watchdog's threadpool thread.
+        ///
+        /// The old rescue called <c>players[i].Stop()</c> inline on this thread. In #767 the very
+        /// first call never returned, so the second player was never stopped, the retire never ran,
+        /// and no later rescue was possible — the app was frozen for good. A hung player must cost
+        /// only its own task.
+        /// </summary>
+        private void WedgeStopPlayersOffThread()
+        {
+            List<LibVLCSharp.Shared.MediaPlayer> players;
+            lock (_mediaPlayersLock) { players = _mediaPlayers.ToList(); }
+            // Leased players (bubble count) run on the SAME shared instance, so a wedge that the
+            // mandatory players cannot explain may well be theirs. Stopping everything native is
+            // the whole point of this rung.
+            lock (_managedLock) { players.AddRange(_managedLeases.Select(e => e.Player)); }
+            VideoDiag.Log("WEDGE", $"stopping {players.Count} native player(s) off-thread");
+            if (players.Count == 0) return;
+
+            var tasks = new Task[players.Count];
+            for (int i = 0; i < players.Count; i++)
+            {
+                var index = i;
+                var player = players[i];
+                tasks[i] = Task.Run(() =>
+                {
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    try
+                    {
+                        player.Stop();
+                        VideoDiag.Log("WEDGE", $"player[{index}].Stop returned after {sw.ElapsedMilliseconds}ms");
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("Wedge rescue: player.Stop failed - {Error}", ex.Message);
+                        VideoDiag.Log("WEDGE", $"player[{index}].Stop threw after {sw.ElapsedMilliseconds}ms: {ex.Message}");
+                    }
+                });
+            }
+
+            if (!Task.WaitAll(tasks, WedgeStopBudgetMs))
+                VideoDiag.Log("WEDGE", $"rung 1: at least one player Stop() is STILL running after {WedgeStopBudgetMs}ms - leaving it to the quarantine path and moving on");
+        }
+
+        /// <summary>
+        /// Queue a real teardown + reschedule for the instant the dispatcher drains again, so a
+        /// multi-minute lockout collapses to a brief stutter instead of stranding the frozen frame
+        /// until the user kills the app. Generation-guarded: if some other teardown already ran by
+        /// then (e.g. the vout heal tore down and started its retry video), this must not kill the
+        /// newcomer. Safe to call from more than one rung — the first one to land bumps the
+        /// generation and the rest bail.
+        /// </summary>
+        private void PostWedgeTeardown()
+        {
+            var gen = _teardownGeneration;
+            try
+            {
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                VideoDiag.Log("WEDGE", "posting rescue teardown to the dispatcher");
+                dispatcher.BeginInvoke(new Action(() =>
+                {
+                    // If this line never appears in a report's trace, the dispatcher NEVER drained
+                    // again — i.e. that rung did not break the wedge and the ladder had to escalate.
+                    VideoDiag.Log("WEDGE", $"rescue teardown running (dispatcher drained again after {VideoDiag.UiStallMs}ms)");
+                    if (_teardownGeneration != gen) return;
+                    try { ForceCleanup(); }
+                    catch (Exception ex) { App.Logger?.Warning(ex, "Wedge rescue: ForceCleanup threw"); }
+                    if (_isRunning) ScheduleNext();
+                    VideoDiag.Log("WEDGE", "rescue teardown complete");
+                }));
+            }
+            catch (Exception ex) { App.Logger?.Debug("Wedge rescue: dispatch failed - {Error}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Rung 3, the escape hatch — and the fix that actually closes #765 ("app frozen, and because
+        /// the video window is always-on-top I can't even reach Task Manager to kill it").
+        ///
+        /// Every video window is Topmost at full physical bounds over the taskbar, WS_EX_NOACTIVATE +
+        /// MA_NOACTIVATE, and in strict mode its Closing is vetoed — so a wedged dispatcher leaves the
+        /// user with no way out but a hard reset. This drops those windows out of the topmost band and
+        /// hides them using nothing but our own cached HWNDs: no dispatcher, no LibVLC, no managed
+        /// window state. It therefore works when the UI thread never drains again, and it is safe even
+        /// during pre-roll because it touches zero native VLC state (it cannot reproduce #750-#753).
+        /// Runs on its own task: cross-thread window calls can themselves block on the hung owner
+        /// thread, and that must never take the watchdog's timer thread with them.
+        /// </summary>
+        private void RunWedgeEscapeHatch(long stallMs, string phase)
+        {
+            if (_wedgeRescueRung >= 3) return;
+            _wedgeRescueRung = 3;
+
+            IntPtr[] handles;
+            lock (_videoWindowHandlesLock) { handles = _videoWindowHandles.ToArray(); }
+            VideoDiag.Log("WEDGE", $"rung 3 ESCAPE HATCH ({phase}, stalled {stallMs}ms): dropping {handles.Length} fullscreen window(s) out of the topmost band and hiding them");
+            App.Logger?.Error("VideoService: UI thread wedged {StallMs}ms during {Phase} — releasing {Count} topmost video window(s) so the desktop and Task Manager are reachable",
+                stallMs, phase, handles.Length);
+            if (handles.Length == 0) return;
+
+            Task.Run(() =>
+            {
+                foreach (var hwnd in handles)
+                {
+                    try
+                    {
+                        // SWP_ASYNCWINDOWPOS: the owning thread is by definition not pumping, so the
+                        // request must be posted rather than sent - otherwise this call joins the wedge.
+                        SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0,
+                            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
+                        ShowWindow(hwnd, SW_HIDE);
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("Wedge escape hatch: window release failed - {Error}", ex.Message);
+                    }
+                }
+                VideoDiag.Log("WEDGE", "rung 3 ESCAPE HATCH: window release calls issued");
+            });
         }
 
         #endregion
@@ -4348,10 +4923,22 @@ namespace ConditioningControlPanel.Services
                 // Stop all players in parallel with timeout to prevent one hanging player from blocking
                 // others. Keep the player↔task pairing: a player whose Stop() never completes is WEDGED
                 // and must be quarantined at disposal time, not disposed (see _nativeQuarantine).
-                var stopPairs = playersCopy.Select(player => (player, task: Task.Run(() =>
+                var stopPairs = playersCopy.Select((player, index) => (player, task: Task.Run(() =>
                 {
                     try
                     {
+#if DEBUG
+                        // Fault injection (CCP_FAULT_WEDGE_STOP=1): make the first player's Stop()
+                        // never return, which is exactly the native state #765-#767 land in. Lets the
+                        // teardown/rescue/escape-hatch changes be play-tested without reproducing the
+                        // intermittent aout stall. The thread is burned for the life of the process -
+                        // acceptable for a DEBUG-only switch, and it mirrors the real failure.
+                        if (index == 0 && FaultInjectWedgeStop)
+                        {
+                            VideoDiag.Log("CLOSE", "FAULT INJECTION (CCP_FAULT_WEDGE_STOP): player[0] Stop() will never complete");
+                            Thread.Sleep(System.Threading.Timeout.Infinite);
+                        }
+#endif
                         player.Stop();
                     }
                     catch (Exception ex)
@@ -4363,7 +4950,24 @@ namespace ConditioningControlPanel.Services
                 // can never condemn a FRESH instance that a vout-retry has since built.
                 var owningLibVLC = _libVLC;
 
-                if (stopPairs.Count > 0)
+                // The waits below exist for ONE reason: detaching a VideoView/HwndHost from a player
+                // that is still presenting is the historic multi-monitor crash (see the detach comment
+                // further down). The blurred-background path has no HwndHost at all — LibVLC renders
+                // into a memory buffer that WPF composites — so when every window on screen is a blur
+                // surface there is nothing to protect, and no reason to spend up to ~4.9s of DISPATCHER
+                // time waiting for a Stop() that may never return (#766/#767: measured 4936ms/4978ms,
+                // during which the panic key is silently dropped by Windows). Close immediately and let
+                // the async continuation at the bottom of this method quarantine the wedged player
+                // off-thread, exactly as it already does today.
+                bool vmemOnly = _blurSurfaces.Count > 0 && _blurSurfaces.Count == _windows.Count;
+
+                if (stopPairs.Count > 0 && vmemOnly)
+                {
+                    VideoDiag.Log("CLOSE",
+                        $"vmem/blur path ({_blurSurfaces.Count} surface(s), no HwndHost) - skipping the 500ms + 4s Stop() waits, " +
+                        $"{stopPairs.Count} stop task(s) handed to the async quarantine path");
+                }
+                else if (stopPairs.Count > 0)
                 {
                     var stopTasks = stopPairs.Select(p => p.task).ToArray();
 
@@ -4391,6 +4995,7 @@ namespace ConditioningControlPanel.Services
                             // owning instance NOW so the very next video (which may start within seconds)
                             // gets a clean one instead of inheriting the corrupted native state (#559).
                             RetireSharedLibVLC(owningLibVLC, "player Stop() wedged past extended wait");
+                            RecordNativePoisoning("player Stop() wedged past the extended wait");
                         }
                         else
                         {
@@ -4403,7 +5008,9 @@ namespace ConditioningControlPanel.Services
                 // CRITICAL: Wait a bit after stopping players to let LibVLC finish any pending operations
                 // This prevents crashes when detaching VideoView while LibVLC is still processing
                 // Use message-pump-aware wait to prevent deadlock (LibVLC threads may need UI thread)
-                if (playersCopy.Count > 0)
+                // Skipped on the vmem path for the same reason as the waits above: no VideoView is
+                // detached below, so there is nothing this settle time protects.
+                if (playersCopy.Count > 0 && !vmemOnly)
                 {
                     WaitWithMessagePump(300);
                 }
@@ -4438,7 +5045,7 @@ namespace ConditioningControlPanel.Services
 
                 // Another small delay after detaching before closing windows
                 // Use message-pump-aware wait to prevent deadlock with LibVLC
-                if (windowsCopy.Count > 0)
+                if (windowsCopy.Count > 0 && !vmemOnly)
                 {
                     WaitWithMessagePump(100);
                 }
@@ -4470,6 +5077,8 @@ namespace ConditioningControlPanel.Services
                     }
                 }
                 _windows.Clear();
+                // The escape hatch's handles die with the windows (see RunWedgeEscapeHatch).
+                lock (_videoWindowHandlesLock) { _videoWindowHandles.Clear(); }
 
                 // Tear down any blurred-background memory-render surfaces: invalidate the frame
                 // buffer + unhook the render tick now (the players above are already stopped), then
@@ -4524,6 +5133,18 @@ namespace ConditioningControlPanel.Services
                             // Wait for any pending EndReached events to complete their Task.Run dispatch
                             await Task.Delay(1000);
 
+                            // On the vmem path nothing waited for these Stop() calls on the dispatcher,
+                            // so this is the ONLY budget a merely-slow (not wedged) Stop gets before it
+                            // is quarantined — and a quarantine also retires the shared instance, which
+                            // burns one of the four per-session retires. Give the stragglers the same
+                            // total grace the UI thread used to give them, just off-thread.
+                            var pending = stopPairs.Where(p => !p.task.IsCompleted).Select(p => p.task).ToArray();
+                            if (pending.Length > 0)
+                            {
+                                VideoDiag.Log("CLOSE", $"{pending.Length} player Stop() task(s) still running - waiting {StopStragglerGraceMs}ms off-thread before quarantining");
+                                await Task.WhenAny(Task.WhenAll(pending), Task.Delay(StopStragglerGraceMs));
+                            }
+
                             foreach (var (player, task) in stopPairs)
                             {
                                 if (!task.IsCompleted)
@@ -4550,9 +5171,14 @@ namespace ConditioningControlPanel.Services
             }
             finally
             {
-                // Video is torn down — the wedge and vout watchdogs have nothing left to guard.
+                // Video is torn down — the wedge, vout and blur-frame watchdogs have nothing left to
+                // guard. The wedge watchdog is stopped LAST-but-here on purpose: it stays armed for
+                // the whole of the teardown above (WedgeWatchdogTick gates on _videoPlaying ||
+                // _isCleaningUp), because that teardown is the app's longest predictable UI block and
+                // used to be the one window the guard could not see (#766/#767).
                 StopWedgeWatchdog();
                 StopVoutWatchdog();
+                StopBlurFrameWatchdogs();
 
                 // Release the audio-duck ref taken in PlayVideo, exactly once per teardown. Balancing
                 // it here (not only in Cleanup) covers the paths that tear down WITHOUT Cleanup — the
@@ -4887,10 +5513,21 @@ namespace ConditioningControlPanel.Services
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 
+        // Used only by the wedge escape hatch (RunWedgeEscapeHatch) — both calls are cross-thread
+        // safe and need neither the dispatcher nor LibVLC, which is why they still work on a window
+        // whose owning UI thread has stopped pumping.
+        [DllImport("user32.dll")]
+        private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
         private const int GWL_EXSTYLE = -20;
         private const int WS_EX_NOACTIVATE = 0x08000000;
         private const uint SWP_NOZORDER = 0x0004;
         private const uint SWP_NOACTIVATE = 0x0010;
+        private const uint SWP_NOMOVE = 0x0002;
+        private const uint SWP_NOSIZE = 0x0001;
+        private const uint SWP_ASYNCWINDOWPOS = 0x4000;
+        private static readonly IntPtr HWND_NOTOPMOST = new IntPtr(-2);
+        private const int SW_HIDE = 0;
         private const int WM_MOUSEACTIVATE = 0x0021;
         private const int MA_NOACTIVATE = 3;
 
@@ -4980,6 +5617,12 @@ namespace ConditioningControlPanel.Services
                     {
                         var hwnd = new WindowInteropHelper(win).Handle;
                         if (hwnd == IntPtr.Zero) return;
+                        // Cache the handle for the wedge escape hatch while we have it: once the UI
+                        // thread wedges, nothing can resolve a Window to its HWND any more (#765).
+                        lock (_videoWindowHandlesLock)
+                        {
+                            if (!_videoWindowHandles.Contains(hwnd)) _videoWindowHandles.Add(hwnd);
+                        }
                         HwndSource.FromHwnd(hwnd)?.AddHook(NoClickRaiseHook);
                     }
                     catch (Exception ex)

--- a/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
@@ -59,8 +59,21 @@ namespace ConditioningControlPanel
         private static List<BubbleCountWindow> _allWindows = new();
         private static int _sharedBubbleCount = 0;
         private static int _sharedTargetCount = 0;
-        private static LibVLC? _libVLC;
         private static List<LibVLCSharp.Shared.MediaPlayer> _allMediaPlayers = new();
+
+        /// <summary>Owner tag used for every VideoService lease + trace line from this window.</summary>
+        private const string LeaseTag = "bubble-count";
+        /// <summary>Bounded, pumped budget for the player Stop() batch during teardown. This path
+        /// hosts a VideoView (HwndHost), so detaching before the players are stopped is the historic
+        /// multi-monitor crash - but the wait must never be unbounded on the dispatcher (#766).
+        /// Sized to VideoService.CloseAll's own VideoView budget (500ms + a 4s pumped extension):
+        /// a shorter one would start detaching from players that are merely SLOW to stop, and the
+        /// wait pumps, so it costs nothing while Stop() is healthy and does not itself look like a
+        /// UI stall to the wedge watchdog.</summary>
+        private const int StopWaitMs = 4000;
+        /// <summary>Fallback duration when the metadata cache has never seen this video. LibVLC's
+        /// LengthChanged corrects it within a second of Play() - see AdoptRealDuration.</summary>
+        private const double FallbackDurationSeconds = 30;
 
         /// <summary>Duration of the last played video in seconds (shared for XP scaling)</summary>
         internal static double LastVideoDurationSeconds { get; private set; } = 30;
@@ -109,6 +122,10 @@ namespace ConditioningControlPanel
                 var hwnd = new System.Windows.Interop.WindowInteropHelper(this).Handle;
                 var exStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
                 SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
+                // Cache the handle for VideoService's wedge escape hatch while we still can: these
+                // windows are fullscreen + topmost, and once the UI thread wedges nothing can
+                // resolve a Window to its HWND any more (#765/#766).
+                App.Video?.RegisterManagedWindow(hwnd);
             };
 
             // Reclaim focus when stolen by other windows (only primary needs focus)
@@ -138,43 +155,28 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// Get shared LibVLC from VideoService (avoid double initialization)
-        /// Always get fresh reference to avoid stale cached values
+        /// Make sure the shared LibVLC instance exists before the game windows are built.
+        /// Deliberately caches NOTHING: the player is built through
+        /// <see cref="VideoService.CreateManagedPlayer"/> under _libVLCLock at the moment it is
+        /// needed. The old code copied SharedLibVLC into a static field here and consumed it in
+        /// OnLoaded, so a retire landing in that gap built the player on an already-quarantined
+        /// instance (#766).
         /// </summary>
-        private static void EnsureLibVLCInitialized()
+        private static bool EnsureLibVLCReady()
         {
-            // Always get fresh reference from VideoService
-            _libVLC = VideoService.SharedLibVLC;
-            App.Logger?.Information("BubbleCountWindow: Got LibVLC from VideoService: {IsNull}", _libVLC == null ? "null" : "valid");
+            if (VideoService.SharedLibVLC != null) return true;
 
-            if (_libVLC == null)
+            App.Logger?.Information("BubbleCountWindow: LibVLC not ready, triggering initialization...");
+            App.Video?.PreloadLibVLC();
+
+            if (VideoService.WaitForLibVLC(5000) && VideoService.SharedLibVLC != null)
             {
-                App.Logger?.Information("BubbleCountWindow: LibVLC not ready, triggering initialization...");
-
-                // Try to trigger initialization via App.Video (should have been done at startup)
-                App.Video?.PreloadLibVLC();
-
-                // Wait for initialization to complete (up to 5 seconds)
-                App.Logger?.Information("BubbleCountWindow: Waiting for LibVLC initialization...");
-                if (VideoService.WaitForLibVLC(5000))
-                {
-                    _libVLC = VideoService.SharedLibVLC;
-                    App.Logger?.Information("BubbleCountWindow: LibVLC became available after wait");
-                }
-                else
-                {
-                    App.Logger?.Error("BubbleCountWindow: Timed out waiting for LibVLC");
-                }
+                App.Logger?.Information("BubbleCountWindow: LibVLC became available after wait");
+                return true;
             }
 
-            if (_libVLC != null)
-            {
-                App.Logger?.Information("BubbleCountWindow: Using shared LibVLC (version {Version})", _libVLC.Version);
-            }
-            else
-            {
-                App.Logger?.Error("BubbleCountWindow: LibVLC not available from VideoService");
-            }
+            App.Logger?.Error("BubbleCountWindow: LibVLC not available from VideoService");
+            return false;
         }
 
         /// <summary>
@@ -188,17 +190,60 @@ namespace ConditioningControlPanel
             {
                 _isCleaningUp = false;
             }
+            var orphanWindows = _allWindows.ToList();
+            var orphanPlayers = _allMediaPlayers.ToList();
             _allWindows.Clear();
             _allMediaPlayers.Clear();
             _sharedBubbleCount = 0;
             _sharedTargetCount = 0;
 
-            // Ensure LibVLC is ready
-            EnsureLibVLCInitialized();
+            VideoDiag.Log("BUBBLE", $"BEGIN {Path.GetFileName(videoPath)} (difficulty={difficulty}, strict={strictMode})");
 
-            if (_libVLC == null)
+            // Players are LEASED from VideoService now, so dropping the references here would strand
+            // them in its lease registry for the life of the process and every later wedge rescue
+            // would try to stop players nobody owns. Only reachable when a previous game threw
+            // partway through its show/teardown; normally both lists are already empty. Same order
+            // as CloseAllWindows - stop, detach, close, release - because releasing a player still
+            // attached to a live VideoView is the multi-monitor detach crash.
+            if (orphanPlayers.Count > 0 || orphanWindows.Count > 0)
+            {
+                VideoDiag.Log("BUBBLE", $"leftovers from a previous game: {orphanWindows.Count} window(s), {orphanPlayers.Count} player(s) - clearing before starting");
+                var orphanStops = StopPlayersBounded(orphanPlayers, 500, "ORPHAN");
+                foreach (var window in orphanWindows)
+                {
+                    try
+                    {
+                        if (window._videoView != null) window._videoView.MediaPlayer = null;
+                        window._safetyTimer?.Stop();
+                        window._bubbleSpawnTimer?.Stop();
+                        window.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("BubbleCountWindow: Error closing orphaned window - {Error}", ex.Message);
+                    }
+                }
+                ReleaseStoppedPlayers(orphanStops);
+            }
+
+            // A wedged native Stop() leaves a LibVLC thread stuck in this process forever, and #766
+            // is precisely "poisoning at 22:05, bubble-count video at 22:18, dispatcher dead". Don't
+            // stand a fresh player up on the wreckage - the caller treats this like any other
+            // can't-show and the next scheduled game gets a clean instance.
+            var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+            if (poisonMs > 0)
+            {
+                App.Logger?.Warning("BubbleCountWindow: shared LibVLC poisoned by a wedged Stop() - not starting ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
+                VideoDiag.Log("BUBBLE", $"ABORT - native poison cooldown, {poisonMs}ms remaining");
+                onComplete?.Invoke(false);
+                return;
+            }
+
+            // Ensure LibVLC is ready
+            if (!EnsureLibVLCReady())
             {
                 App.Logger?.Error("BubbleCountWindow: LibVLC not available, cannot show game");
+                VideoDiag.Log("BUBBLE", "ABORT - no shared LibVLC instance");
                 onComplete?.Invoke(false);
                 return;
             }
@@ -221,6 +266,12 @@ namespace ConditioningControlPanel
             App.Logger?.Information("BubbleCountWindow: Creating windows on {Count} screens, video={Video}",
                 screens.Length, videoPath);
 
+            // Armed BEFORE the first window exists: the #766 wedge is inside the native start-up
+            // sequence itself (MediaPlayer ctor / HwndHost attach / Play), which all runs on the UI
+            // thread from OnLoaded. Disarmed by CloseAllWindows / ForceCloseAll.
+            App.Video?.ArmManagedWedgeWatchdog(LeaseTag);
+
+            var showSw = System.Diagnostics.Stopwatch.StartNew();
             try
             {
                 // Create primary window with audio
@@ -232,6 +283,7 @@ namespace ConditioningControlPanel
                 primaryWindow.WindowState = WindowState.Maximized;
                 ForceTopmost(primaryWindow);
                 App.Logger?.Information("BubbleCountWindow: Primary window shown and maximized");
+                VideoDiag.Log("BUBBLE", $"primary window shown +{showSw.ElapsedMilliseconds}ms");
 
                 // Create secondary windows (muted)
                 foreach (var screen in screens.Where(s => s != primary))
@@ -241,15 +293,19 @@ namespace ConditioningControlPanel
                     secondaryWindow.Show();
                     secondaryWindow.WindowState = WindowState.Maximized;
                     ForceTopmost(secondaryWindow);
+                    VideoDiag.Log("BUBBLE", $"secondary window shown on {screen.DeviceName} +{showSw.ElapsedMilliseconds}ms");
                 }
 
                 // Activate primary last so it has focus for keyboard input
                 primaryWindow.Activate();
                 App.Logger?.Information("BubbleCountWindow: All windows created and shown successfully");
+                VideoDiag.Log("BUBBLE", $"show complete - {screens.Length} window(s) on screen +{showSw.ElapsedMilliseconds}ms");
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "BubbleCountWindow: Failed to create/show windows");
+                VideoDiag.Log("BUBBLE", $"show THREW +{showSw.ElapsedMilliseconds}ms: {ex.Message}");
+                App.Video?.DisarmManagedWedgeWatchdog();
                 onComplete?.Invoke(false);
             }
         }
@@ -284,28 +340,16 @@ namespace ConditioningControlPanel
             {
                 App.Logger?.Information("BubbleCountWindow.ForceCloseAll: Closing {Count} windows, {Players} players",
                     _allWindows.Count, _allMediaPlayers.Count);
+                VideoDiag.Log("BUBBLE", $"FORCE CLOSE begin - {_allWindows.Count} window(s), {_allMediaPlayers.Count} player(s)");
 
                 // Stop all media players FIRST (like VideoService)
                 var playersCopy = _allMediaPlayers.ToList();
                 _allMediaPlayers.Clear();
 
-                foreach (var player in playersCopy)
-                {
-                    try
-                    {
-                        player.Stop();
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Debug("BubbleCountWindow: Error stopping player - {Error}", ex.Message);
-                    }
-                }
-
-                // Wait for LibVLC to stop rendering (pump messages to avoid deadlock)
-                if (playersCopy.Count > 0)
-                {
-                    WaitWithMessagePump(100);
-                }
+                // Panic path: a shorter budget than the normal close. The user has already asked for
+                // the screen back, so a straggler goes to the quarantine path rather than holding
+                // the dispatcher any longer.
+                var stopPairs = StopPlayersBounded(playersCopy, 500, "FORCE CLOSE");
 
                 // Detach VideoViews from players
                 var windowsCopy = _allWindows.ToList();
@@ -346,30 +390,22 @@ namespace ConditioningControlPanel
                     }
                 }
 
-                // Dispose players asynchronously after windows closed
-                if (playersCopy.Count > 0)
-                {
-                    Task.Run(async () =>
-                    {
-                        await Task.Delay(750);
-                        foreach (var player in playersCopy)
-                        {
-                            try
-                            {
-                                player.Dispose();
-                            }
-                            catch (Exception ex)
-                            {
-                                App.Logger?.Debug("BubbleCountWindow: Error disposing player - {Error}", ex.Message);
-                            }
-                        }
-                    });
-                }
+                // Hand the players back: VideoService disposes the ones that stopped and quarantines
+                // (never disposes) any whose Stop() never returned.
+                ReleaseStoppedPlayers(stopPairs);
+
+                // Disarmed here, not at the top: the teardown above (stop batch, VideoView detach,
+                // window close) is the other place this path can wedge, so it stays guarded to the
+                // end - the same reasoning that keeps VideoService's watchdog armed through CloseAll.
+                // It must still happen BEFORE the callbacks below, which can start the next game and
+                // arm a fresh watchdog.
+                App.Video?.DisarmManagedWedgeWatchdog();
 
                 // Reset the service busy state
                 App.BubbleCount?.ResetBusyState();
 
                 App.Logger?.Information("BubbleCountWindow.ForceCloseAll: Complete");
+                VideoDiag.Log("BUBBLE", "FORCE CLOSE complete");
             }
             finally
             {
@@ -389,22 +425,21 @@ namespace ConditioningControlPanel
         {
             App.Logger?.Information("BubbleCountWindow.OnLoaded: Starting (primary={IsPrimary}, video={Video})", _isPrimary, _videoPath);
 
+            // Every step below is a native or HwndHost call on the UI THREAD, and until now not one
+            // of them left a trace line - which is why #766's freeze arrived as a silent hang. The
+            // +ms stamps mirror VideoService's win[tag] lines: the last one written names the call
+            // the dispatcher died inside.
+            var tag = _isPrimary ? "primary" : "secondary";
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            VideoDiag.Log("BUBBLE", $"win[{tag}]: OnLoaded begin on {_screen.DeviceName}");
+
             try
             {
                 // Verify video file exists
                 if (!File.Exists(_videoPath))
                 {
                     App.Logger?.Error("BubbleCountWindow.OnLoaded: Video file not found: {Path}", _videoPath);
-                    if (_isPrimary)
-                    {
-                        CloseAllWindows(false);
-                    }
-                    return;
-                }
-
-                if (_libVLC == null)
-                {
-                    App.Logger?.Error("BubbleCountWindow.OnLoaded: LibVLC is null!");
+                    VideoDiag.Log("BUBBLE", $"win[{tag}]: ABORT - video file not found");
                     if (_isPrimary)
                     {
                         CloseAllWindows(false);
@@ -420,19 +455,46 @@ namespace ConditioningControlPanel
                     VerticalAlignment = VerticalAlignment.Stretch,
                     Background = Brushes.Black
                 };
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: VideoView built +{sw.ElapsedMilliseconds}ms");
 
-                _mediaPlayer = new LibVLCSharp.Shared.MediaPlayer(_libVLC);
+                // The player is built by VideoService under _libVLCLock, registered for wedge
+                // rescue/quarantine, and hands back the exact instance it was built on. The Media
+                // below MUST come from that same reference and not from a fresh read of
+                // SharedLibVLC - a retire in between would mix instances (#766).
+                LibVLC? libVlcOwner = null;
+                var video = App.Video;
+                if (video != null) _mediaPlayer = video.CreateManagedPlayer($"{LeaseTag}[{tag}]", out libVlcOwner);
+                if (_mediaPlayer == null || libVlcOwner == null)
+                {
+                    App.Logger?.Error("BubbleCountWindow.OnLoaded: could not lease a MediaPlayer from VideoService");
+                    VideoDiag.Log("BUBBLE", $"win[{tag}]: ABORT - no managed player +{sw.ElapsedMilliseconds}ms");
+                    if (_isPrimary)
+                    {
+                        CloseAllWindows(false);
+                    }
+                    return;
+                }
                 _allMediaPlayers.Add(_mediaPlayer);
-                if (_isPrimary) App.Audio?.ApplyPreferredDevice(_mediaPlayer);
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: MediaPlayer leased +{sw.ElapsedMilliseconds}ms");
+
+                // NOTE: the user's chosen output device is applied from the Playing handler below,
+                // NOT here. LibVLC has no audio output until playback starts, so a call at
+                // construction time enumerated an empty device list, matched nothing and silently
+                // no-op'd - bubble-count audio has been ignoring the user's output device ever
+                // since (the same #707/#708 defect VideoService already fixed).
 
                 // Add VideoView to container
                 VideoContainer.Children.Add(_videoView);
 
                 if (_isPrimary)
                 {
-                    // Get video duration
-                    _videoDurationSeconds = GetVideoDuration(_videoPath);
+                    // Duration comes from the shared metadata cache; a miss falls back and LibVLC's
+                    // LengthChanged corrects everything a moment later (AdoptRealDuration). The old
+                    // synchronous MediaFoundationReader open ran on the UI thread, on a file that
+                    // may be a decrypted pack temp on a slow disk.
+                    _videoDurationSeconds = ResolveVideoDurationSeconds(_videoPath);
                     LastVideoDurationSeconds = _videoDurationSeconds;
+                    VideoDiag.Log("BUBBLE", $"win[{tag}]: duration={_videoDurationSeconds:F1}s +{sw.ElapsedMilliseconds}ms");
 
                     // Calculate target bubbles
                     CalculateTargetBubbles();
@@ -443,6 +505,9 @@ namespace ConditioningControlPanel
                     {
                         var duration = args.Length / 1000.0;
                         App.Logger?.Debug("BubbleCountWindow: LengthChanged - duration={Duration}s", duration);
+                        var dispatcher = Application.Current?.Dispatcher;
+                        if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                        dispatcher.BeginInvoke(new Action(() => AdoptRealDuration(duration)));
                     };
 
                     _mediaPlayer.EndReached += OnMediaEndReached;
@@ -461,6 +526,35 @@ namespace ConditioningControlPanel
                     _mediaPlayer.Mute = false;
                     var volume = (int)((App.Settings.Current.MasterVolume / 100.0) * 100);
                     _mediaPlayer.Volume = Math.Clamp(volume, 0, 100);
+
+                    // Everything that needs a LIVE audio output hangs off Playing, subscribed BEFORE
+                    // Play(): a fast start can raise Playing inside the Play() call itself.
+                    var player = _mediaPlayer;
+                    int audioRouted = 0; // Playing can fire again after a restart - route once
+                    player.Playing += (s, args) =>
+                    {
+                        VideoDiag.Log("BUBBLE", "PLAYING (aout is live)");
+                        if (Interlocked.Exchange(ref audioRouted, 1) != 0) return;
+                        // Anything heavier than a property set goes off the LibVLC event thread.
+                        Task.Run(() =>
+                        {
+                            try
+                            {
+                                // Same staleness guard RouteAndProbeAudio uses: teardown may have
+                                // taken ownership of this player between Playing and this task, and
+                                // it stops/releases (and eventually disposes) it off-thread.
+                                if (_isCleaningUp || _videoEnded) return;
+                                bool applied = App.Audio?.ApplyPreferredDevice(player) ?? false;
+                                var routing = App.Audio?.DescribeLibVlcAudioRouting(player) ?? "audio service unavailable";
+                                App.Logger?.Information("[VIDEO] aout live for bubble count: deviceApplied={Applied} {Routing}", applied, routing);
+                                VideoDiag.Log("AOUT", $"bubble-count deviceApplied={applied} {routing}");
+                            }
+                            catch (Exception ex)
+                            {
+                                App.Logger?.Debug("BubbleCountWindow: audio route/probe failed: {Error}", ex.Message);
+                            }
+                        });
+                    };
                 }
                 else
                 {
@@ -471,16 +565,23 @@ namespace ConditioningControlPanel
                 // Attach player to view and start playback
                 App.Logger?.Information("BubbleCountWindow.OnLoaded: Attaching MediaPlayer to VideoView...");
                 _videoView.MediaPlayer = _mediaPlayer;
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: VideoView attached +{sw.ElapsedMilliseconds}ms");
 
                 App.Logger?.Information("BubbleCountWindow.OnLoaded: Creating Media for path: {Path}", _videoPath);
-                var media = new Media(_libVLC, _videoPath, FromType.FromPath);
+                // Disposed once Play() has returned: libvlc_media_player_set_media retains the media
+                // synchronously, so this releases OUR reference and nothing else. It was leaked
+                // outright before - one native media per game window, forever.
+                using var media = new Media(libVlcOwner, _videoPath, FromType.FromPath);
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: Media ctor +{sw.ElapsedMilliseconds}ms");
                 // Secondaries skip audio decoding entirely. Setting Mute=true after Play() opened
                 // a second WASAPI session on the same MMDevice; Windows collapsed both into one
                 // per-app mixer slider and the result was doubled/desynced or zero-volume audio.
                 if (!_isPrimary) media.AddOption(":no-audio");
 
                 App.Logger?.Information("BubbleCountWindow.OnLoaded: Calling Play()...");
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: Play() issued +{sw.ElapsedMilliseconds}ms");
                 var playResult = _mediaPlayer.Play(media);
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: Play() returned {playResult} +{sw.ElapsedMilliseconds}ms");
 
                 if (!playResult)
                 {
@@ -493,6 +594,7 @@ namespace ConditioningControlPanel
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "Failed to initialize bubble count game");
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: OnLoaded THREW +{sw.ElapsedMilliseconds}ms: {ex.Message}");
                 if (_isPrimary)
                 {
                     CloseAllWindows(false);
@@ -500,10 +602,67 @@ namespace ConditioningControlPanel
             }
         }
 
+        /// <summary>
+        /// Duration for the game clock: metadata-cache hit, else a fallback that LibVLC's
+        /// LengthChanged replaces within a second. A miss also queues the background parse so the
+        /// next game on this file is a straight hit.
+        /// </summary>
+        private static double ResolveVideoDurationSeconds(string path)
+        {
+            try
+            {
+                var cache = App.Video?.MetadataCache;
+                var cached = cache?.TryGetDuration(path);
+                if (cached is > 0) return cached.Value;
+                if (cache != null) _ = cache.GetOrComputeDurationAsync(path);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BubbleCountWindow: duration lookup failed - {Error}", ex.Message);
+            }
+            return FallbackDurationSeconds;
+        }
+
+        /// <summary>
+        /// Adopt the real clip length once LibVLC reports it (UI thread). Re-derives the bubble
+        /// target, re-spaces the spawn timer and re-arms both the safety timer and the interaction
+        /// queue's stuck-detection window - without this last one a long video started on the
+        /// fallback duration would be force-cleaned up mid-game.
+        /// </summary>
+        private void AdoptRealDuration(double seconds)
+        {
+            if (!_isPrimary || seconds <= 0 || _videoEnded || _isCleaningUp) return;
+            if (Math.Abs(seconds - _videoDurationSeconds) < 1.0) return;
+
+            _videoDurationSeconds = seconds;
+            LastVideoDurationSeconds = seconds;
+
+            CalculateTargetBubbles();
+            _sharedTargetCount = _targetBubbleCount;
+            foreach (var window in _allWindows.ToList())
+            {
+                window._targetBubbleCount = _targetBubbleCount;
+            }
+
+            if (_bubbleSpawnTimer != null)
+            {
+                var intervalMs = (_videoDurationSeconds * 1000) / Math.Max(1, _targetBubbleCount);
+                _bubbleSpawnTimer.Interval = TimeSpan.FromMilliseconds(intervalMs * 0.7);
+            }
+
+            StartSafetyTimer(seconds);
+            App.InteractionQueue?.ExtendTimeout(seconds + 120);
+
+            App.Logger?.Information("BubbleCountWindow: adopted real duration {Duration:F1}s (target now {Target} bubbles)",
+                seconds, _targetBubbleCount);
+            VideoDiag.Log("BUBBLE", $"duration adopted from LibVLC: {seconds:F1}s, target={_targetBubbleCount}");
+        }
+
         private void OnMediaEndReached(object? sender, EventArgs e)
         {
             // CRITICAL: Detach from LibVLC thread immediately (same pattern as VideoService)
             App.Logger?.Information("BubbleCountWindow: EndReached fired, _isCleaningUp={Cleaning}", _isCleaningUp);
+            VideoDiag.Log("BUBBLE", $"EndReached (cleaningUp={_isCleaningUp})");
 
             Task.Run(() =>
             {
@@ -540,6 +699,7 @@ namespace ConditioningControlPanel
         private void OnMediaError(object? sender, EventArgs e)
         {
             App.Logger?.Error("BubbleCountWindow: Media playback error");
+            VideoDiag.Log("BUBBLE", "EncounteredError - ending the game");
 
             Task.Run(() =>
             {
@@ -603,19 +763,6 @@ namespace ConditioningControlPanel
             catch (Exception ex)
             {
                 App.Logger?.Warning("Failed to load bubble image: {Error}", ex.Message);
-            }
-        }
-
-        private double GetVideoDuration(string path)
-        {
-            try
-            {
-                using var reader = new MediaFoundationReader(path);
-                return reader.TotalTime.TotalSeconds;
-            }
-            catch
-            {
-                return 30;
             }
         }
 
@@ -882,16 +1029,13 @@ namespace ConditioningControlPanel
 
             try
             {
+                VideoDiag.Log("BUBBLE", $"CLOSE begin (success={success}) - {_allWindows.Count} window(s), {_allMediaPlayers.Count} player(s)");
+
                 // Stop all players first
                 var playersCopy = _allMediaPlayers.ToList();
                 _allMediaPlayers.Clear();
 
-                foreach (var player in playersCopy)
-                {
-                    try { player.Stop(); } catch { }
-                }
-
-                if (playersCopy.Count > 0) WaitWithMessagePump(100);
+                var stopPairs = StopPlayersBounded(playersCopy, StopWaitMs, "CLOSE");
 
                 // Detach VideoViews
                 var windowsCopy = _allWindows.ToList();
@@ -920,18 +1064,14 @@ namespace ConditioningControlPanel
                     catch { }
                 }
 
-                // Dispose players async
-                if (playersCopy.Count > 0)
-                {
-                    Task.Run(async () =>
-                    {
-                        await Task.Delay(750);
-                        foreach (var player in playersCopy)
-                        {
-                            try { player.Dispose(); } catch { }
-                        }
-                    });
-                }
+                // Hand the players back: disposed if they stopped, quarantined if they wedged.
+                ReleaseStoppedPlayers(stopPairs);
+                VideoDiag.Log("BUBBLE", "CLOSE complete");
+
+                // Disarmed here, not at the top: the teardown above is itself a place this path can
+                // wedge, so it stays guarded to the end - but it must happen BEFORE the completion
+                // callback, which on the strict-retry path eventually arms a fresh watchdog.
+                App.Video?.DisarmManagedWedgeWatchdog();
 
                 // Invoke completion callback
                 _onComplete?.Invoke(success);
@@ -961,6 +1101,73 @@ namespace ConditioningControlPanel
             _allWindows.Remove(this);
 
             base.OnClosed(e);
+        }
+
+        /// <summary>
+        /// Stop every player OFF the dispatcher and wait a bounded, pumping interval for the batch.
+        /// Returns the player↔task pairs so a Stop() that never came back can be quarantined instead
+        /// of disposed (see <see cref="ReleaseStoppedPlayers"/>).
+        ///
+        /// The wait itself cannot go away: this path hosts a VideoView, and detaching an HwndHost
+        /// from a player that is still presenting is the historic multi-monitor crash. What did have
+        /// to go is the old inline <c>player.Stop()</c> on the UI thread — a single wedged player
+        /// froze the whole app there, with no trace at all (#766).
+        /// </summary>
+        private static List<(LibVLCSharp.Shared.MediaPlayer Player, Task StopTask)> StopPlayersBounded(
+            List<LibVLCSharp.Shared.MediaPlayer> players, int budgetMs, string phase)
+        {
+            var pairs = players.Select(p => (Player: p, StopTask: Task.Run(() =>
+            {
+                try { p.Stop(); }
+                catch (Exception ex) { App.Logger?.Debug("BubbleCountWindow: Error stopping player - {Error}", ex.Message); }
+            }))).ToList();
+
+            if (pairs.Count == 0) return pairs;
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            bool settled = WaitForTasksWithMessagePump(pairs.Select(p => p.StopTask).ToArray(), budgetMs);
+            VideoDiag.Log("BUBBLE", settled
+                ? $"{phase}: {pairs.Count} player Stop() settled after {sw.ElapsedMilliseconds}ms"
+                : $"{phase}: player Stop() WEDGED past the {sw.ElapsedMilliseconds}ms bounded wait - detaching anyway (poisoning signature)");
+            return pairs;
+        }
+
+        /// <summary>
+        /// Give the leased players back to VideoService, which disposes the ones that stopped and
+        /// roots the ones that did not. Never dispose a wedged player here: that is what poisons the
+        /// shared LibVLC instance for every later video (#559).
+        /// </summary>
+        private static void ReleaseStoppedPlayers(List<(LibVLCSharp.Shared.MediaPlayer Player, Task StopTask)> pairs)
+        {
+            foreach (var (player, stopTask) in pairs)
+            {
+                App.Video?.ReleaseManagedPlayer(player, stopTask, LeaseTag);
+            }
+        }
+
+        /// <summary>
+        /// Pumps WPF messages until every task has completed or the budget expires. Returns true
+        /// only if they all completed.
+        /// </summary>
+        private static bool WaitForTasksWithMessagePump(Task[] tasks, int milliseconds)
+        {
+            var endTime = DateTime.UtcNow.AddMilliseconds(milliseconds);
+            while (DateTime.UtcNow < endTime)
+            {
+                if (tasks.All(t => t.IsCompleted)) return true;
+                try
+                {
+                    Application.Current?.Dispatcher?.Invoke(
+                        DispatcherPriority.Background,
+                        new Action(() => { }));
+                }
+                catch
+                {
+                    return false;
+                }
+                Thread.Sleep(10);
+            }
+            return tasks.All(t => t.IsCompleted);
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Windows/PopQuizWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/PopQuizWindow.xaml.cs
@@ -251,6 +251,24 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Whether a pop quiz is actually on screen right now. Gates on the visible set rather than the
+        /// <see cref="IsOpen"/> flag: that flag is raised in the constructor and only lowered in
+        /// OnClosed, so a quiz that failed between construction and Show() would leave it stuck true
+        /// and block every later interaction.
+        /// </summary>
+        public static bool IsAnyOpen()
+        {
+            try
+            {
+                return Application.Current?.Windows.OfType<PopQuizWindow>().Any(w => w.IsVisible) == true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Force close all pop quiz windows (used by panic button)
         /// </summary>
         public static void ForceCloseAll()


### PR DESCRIPTION
Fixes for all 8 v6.6.2 bug reports (#760-#767 in ccp-bugs), triaged 2026-08-02. The video "crashes" on 6.6.2 are NOT a regression of the 45d170e2 hotfix - they are the pre-existing #616-family wedge (audio-bearing primary LibVLC player fails to start output on the blur/SW-decode path and its Stop() never returns), now fixed at the mitigation layer.

## Video wedge cluster (#765, #766, #767)
- CloseAll no longer blocks the dispatcher on the blur/vmem path (measured 68-92ms of UI-thread time vs ~5,000ms before); wedged stops hand off to the async quarantine continuation
- One-shot wedge rescue replaced by an escalating off-thread ladder (8s stop -> 18s retire -> 28s escape hatch); watchdog stays armed through teardown
- Off-thread topmost-drop escape hatch (SetWindowPos/ShowWindow, no dispatcher, no LibVLC) frees the desktop from a frozen fullscreen video; Closing veto relaxed after a recorded stall
- Black-screen skips credit 0 watch time; _duration reset per video; LengthChanged guarded against late events from quarantined players
- Blur frame watchdog armed per surface on a threading timer, surface-tagged diag lines
- BubbleCountWindow: managed LibVLC lease (no stale static instance), Media leak fixed, audio device applied on Playing, async duration via VideoMetadataCache, VideoDiag instrumentation, wedge watchdog + escape hatch coverage, 60s post-poisoning cooldown
- DEBUG-only fault injection (CCP_FAULT_WEDGE_STOP=1) makes one player's Stop() never return so the teardown/rescue path is testable on demand

## Other fixes
- **#764**: Deeper haptics were silently dropped unless the unrelated, default-OFF Video Haptic Sync toggle was on - gate deleted (verified: SetSyncPatternAsync has exactly two callers, both Deeper); skip-reason logging added to the dispatcher
- **#760**: WebView2 readiness desync wedged the browser for the process lifetime while logging false success - real-state gate, self-heal on next click, honest Navigate result so the external-browser fallback fires, pop-out brought to front instead of buried
- **#761**: settings saves are now atomic + serialized (per-write unique tmp, fsync, save lock); profile sync no longer re-uploads a backup-restored rollback over a materially-ahead server profile
- **#762**: unchecking asset folders now purges the live flash selection pools (ClearFileCache cleared only the file-list cache; the pools were load-once-per-process)
- **#763**: stuck-interaction recovery closes LockCard/PopQuiz before releasing the exclusivity slot; user-paced interactions renew while their window is alive; cross-type stacking guards in both services

## Verification
Built green (0 errors, no new warnings vs baseline). Live play-test on the real app (dual monitor, blur path, SW decode - the #767 recipe):
- Fault-injected wedge, 3 full cycles: fast teardown, quarantine-not-dispose, POISON cooldown armed, LibVLC retired + rebuilt in 1ms, next video plays, process alive throughout
- #762: baseline 6/9 flash images from the target folder; after live uncheck, 0 of 120
- #763: test lock card survived the 5-minute stuck tick by 6+ minutes with zero STUCK warnings, clean slot release on dismissal
- #760: browser init + NavigationCompleted observed end-to-end
- Watch credit exact (19.654s for a 20s-capped video)

The play-test also caught a real AV in the first RC-2 implementation (vmem buffer freed / plane pointer nulled under a live decoder -> msvcrt memcpy into address zero) - fixed in the second commit by keeping the buffer alive until that player's Stop() completes.

Not exercised (code-reviewed only): the escape-hatch rungs under a genuine dispatcher stall, #764 at runtime, the bubble-count game itself, #761's corruption race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QT53QtmGUTtV3CJDpr9UHy