### PR TITLE
fix: v6.6.3 stability triage - freeze cluster, audio-death leak, video aspect, gaze hydra, tint z-order

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -3406,7 +3406,10 @@ Application State:
                 try
                 {
                     Logger?.Information("Syncing profile to cloud before exit...");
-                    ProfileSync.SyncProfileAsync().Wait(TimeSpan.FromSeconds(2));
+                    // Task.Run so the await continuations land on the thread pool: ProfileSyncService
+                    // has no ConfigureAwait(false), and a bare Wait() here blocks the very dispatcher
+                    // those continuations need - the sync could never finish inside the timeout.
+                    Task.Run(() => ProfileSync.SyncProfileAsync()).Wait(TimeSpan.FromSeconds(2));
                 }
                 catch (Exception ex)
                 {

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -244,22 +244,7 @@ namespace ConditioningControlPanel
                 // Keep fallback sounds quieter (50% of master)
                 var volume = (float)Math.Pow(masterVolume, 1.5) * 0.5f;
 
-                Task.Run(() =>
-                {
-                    try
-                    {
-                        using var audioFile = new NAudio.Wave.AudioFileReader(soundPath);
-                        audioFile.Volume = volume;
-                        using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                        outputDevice.Init(audioFile);
-                        outputDevice.Play();
-                        while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                        {
-                            System.Threading.Thread.Sleep(50);
-                        }
-                    }
-                    catch { /* Ignore audio errors */ }
-                });
+                App.Audio?.PlayOneShot(soundPath, volume, "bubble-fallback");
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Speech.cs
@@ -123,9 +123,11 @@ namespace ConditioningControlPanel
 
         // Unified "spoken audio" channel — ALL companion voice (barks, event lines, idle voicelines) plays
         // through one stoppable player so a new line cuts off the previous one instead of overlapping.
+        // The device itself is owned by AudioService (see Services/Audio/AudioService.Playback.cs) —
+        // this window only holds the stop/pause handle and the generation ticket for the current line.
         private readonly object _spokenLock = new();
-        private NAudio.Wave.WaveOutEvent? _spokenPlayer;
-        private NAudio.Wave.AudioFileReader? _spokenReader;
+        private Services.AudioPlaybackHandle? _spokenHandle;
+        private object? _spokenTicket;
         private volatile bool _isSpeakingAudio = false;   // true only while a spoken clip is actually playing
 
         // ============================================================
@@ -1465,22 +1467,7 @@ namespace ConditioningControlPanel
                     var bubblesVolume = (App.Settings?.Current?.BubblesVolume ?? 50) / 100f;
                     var normalizedVolume = Math.Max(0.05f, (float)Math.Pow(bubblesVolume * masterVolume, 1.5));
 
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new NAudio.Wave.AudioFileReader(popPath);
-                            audioFile.Volume = normalizedVolume;
-                            using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-                            while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                            {
-                                System.Threading.Thread.Sleep(50);
-                            }
-                        }
-                        catch { }
-                    });
+                    App.Audio?.PlayOneShot(popPath, normalizedVolume, "avatar-bubble-pop");
                 }
             }
             catch (Exception ex)
@@ -1586,48 +1573,41 @@ namespace ConditioningControlPanel
                 if (!System.IO.File.Exists(filePath)) return;
                 StopSpokenAudio(); // cut off the previous line → no overlap
 
-                NAudio.Wave.AudioFileReader reader;
-                NAudio.Wave.WaveOutEvent player;
-                try
-                {
-                    reader = new NAudio.Wave.AudioFileReader(filePath) { Volume = volume };
-                    player = new NAudio.Wave.WaveOutEvent();
-                    player.Init(reader);
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Debug("PlaySpokenAudio: init failed - {Error}", ex.Message);
-                    return;
-                }
+                // One-shot playback is owned by AudioService: it opens/closes the device on its own
+                // worker thread (never the dispatcher), caps concurrency, disposes deterministically
+                // from BOTH PlaybackStopped and a safety timer, and refuses to spin when the endpoint
+                // is dead (#778/#779). The old inline version blocked a thread-pool thread for the
+                // whole clip and leaked the device outright whenever Init hung.
+                // The ticket identifies THIS line for the whole of its life. It is published under
+                // the lock before playback can start, so a clip that finishes (or is refused)
+                // before PlayOneShot even returns still unwinds against the right generation.
+                var ticket = new object();
+                lock (_spokenLock) { _spokenTicket = ticket; _spokenHandle = null; _isSpeakingAudio = true; }
 
-                lock (_spokenLock) { _spokenReader = reader; _spokenPlayer = player; _isSpeakingAudio = true; }
-
-                System.Threading.Tasks.Task.Run(() =>
-                {
-                    try
-                    {
-                        player.Play();
-                        // Loop until Stopped (not "while Playing") so a Pause() during a world-freeze
-                        // holds the clip mid-line instead of tearing it down; Resume() (Play) continues it.
-                        while (player.PlaybackState != NAudio.Wave.PlaybackState.Stopped)
-                            System.Threading.Thread.Sleep(40);
-                    }
-                    catch { /* ignore audio errors */ }
-                    finally
+                var handle = App.Audio?.PlayOneShot(filePath, volume, "companion-voice",
+                    onFinished: () =>
                     {
                         lock (_spokenLock)
                         {
-                            if (ReferenceEquals(_spokenPlayer, player)) // not already replaced by a newer line
-                            {
-                                _spokenPlayer = null;
-                                _spokenReader = null;
-                                _isSpeakingAudio = false; // stops the speaking wobble/mist exactly at clip end
-                            }
+                            if (!ReferenceEquals(_spokenTicket, ticket)) return; // replaced by a newer line
+                            _spokenTicket = null;
+                            _spokenHandle = null;
+                            _isSpeakingAudio = false; // stops the speaking wobble/mist exactly at clip end
                         }
-                        try { player.Dispose(); } catch { }
-                        try { reader.Dispose(); } catch { }
+                    });
+
+                lock (_spokenLock)
+                {
+                    if (!ReferenceEquals(_spokenTicket, ticket)) return; // already superseded / already finished
+                    if (handle == null)
+                    {
+                        // Refused (missing file, muted, breaker open) — don't leave the wobble stuck on.
+                        _spokenTicket = null;
+                        _isSpeakingAudio = false;
+                        return;
                     }
-                });
+                    _spokenHandle = handle;
+                }
             }
             catch (Exception ex)
             {
@@ -1635,29 +1615,29 @@ namespace ConditioningControlPanel
             }
         }
 
-        /// <summary>Stop the current spoken line immediately (its play-loop sees Stopped and disposes).</summary>
+        /// <summary>Stop the current spoken line immediately (AudioService disposes its device).</summary>
         public void StopSpokenAudio()
         {
-            NAudio.Wave.WaveOutEvent? p;
-            lock (_spokenLock) { p = _spokenPlayer; }
-            try { p?.Stop(); } catch { }
+            Services.AudioPlaybackHandle? h;
+            lock (_spokenLock) { h = _spokenHandle; }
+            try { h?.Stop(); } catch { }
         }
 
         /// <summary>Freeze the current spoken line in place (world-freeze). Holds position + the
-        /// speaking wobble; a paused clip survives the play-loop (it exits only on Stop). No-op if idle.</summary>
+        /// speaking wobble; a paused clip is not torn down (only Stop ends it). No-op if idle.</summary>
         public void PauseSpokenAudio()
         {
-            NAudio.Wave.WaveOutEvent? p;
-            lock (_spokenLock) { p = _spokenPlayer; }
-            try { if (p?.PlaybackState == NAudio.Wave.PlaybackState.Playing) p.Pause(); } catch { }
+            Services.AudioPlaybackHandle? h;
+            lock (_spokenLock) { h = _spokenHandle; }
+            try { h?.Pause(); } catch { }
         }
 
         /// <summary>Resume a line paused by <see cref="PauseSpokenAudio"/>. No-op if idle or already playing.</summary>
         public void ResumeSpokenAudio()
         {
-            NAudio.Wave.WaveOutEvent? p;
-            lock (_spokenLock) { p = _spokenPlayer; }
-            try { if (p?.PlaybackState == NAudio.Wave.PlaybackState.Paused) p.Play(); } catch { }
+            Services.AudioPlaybackHandle? h;
+            lock (_spokenLock) { h = _spokenHandle; }
+            try { h?.Resume(); } catch { }
         }
 
         /// <summary>
@@ -2122,24 +2102,10 @@ namespace ConditioningControlPanel
                 var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
                 var volume = (float)Math.Pow(masterVolume, 1.5) * 0.9f; // a touch louder — it's a once-ever moment
 
-                Task.Run(() =>
-                {
-                    try
-                    {
-                        using var audioFile = new NAudio.Wave.AudioFileReader(clipPath);
-                        audioFile.Volume = volume;
-                        using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                        outputDevice.Init(audioFile);
-                        outputDevice.Play();
-                        while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                            System.Threading.Thread.Sleep(50);
-                    }
-                    catch (Exception ex) { App.Logger?.Warning(ex, "PlayNoteClip: playback failed"); }
-                    finally
-                    {
-                        RunOnAvatar(() => _isPlayingUninterruptibleClip = false);
-                    }
-                });
+                // onFinished is guaranteed to fire exactly once — including when playback is
+                // refused outright — so the uninterruptible latch can never stick on (#778).
+                App.Audio?.PlayOneShot(clipPath, volume, "note-clip",
+                    onFinished: () => RunOnAvatar(() => _isPlayingUninterruptibleClip = false));
                 return true;
             }
             catch (Exception ex)
@@ -2220,23 +2186,7 @@ namespace ConditioningControlPanel
                     // Mute egg / silenced audio (Fork F): MasterVolume == 0 means don't attempt audio.
                     if (masterVolume <= 0f) return;
 
-                    // Use NAudio for async playback
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new NAudio.Wave.AudioFileReader(gigglePath);
-                            audioFile.Volume = volume;
-                            using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-                            while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                            {
-                                System.Threading.Thread.Sleep(50);
-                            }
-                        }
-                        catch { /* Ignore audio errors */ }
-                    });
+                    App.Audio?.PlayOneShot(gigglePath, volume, "giggle");
                 }
             }
             catch (Exception ex)
@@ -2258,23 +2208,7 @@ namespace ConditioningControlPanel
                     var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
                     var volume = (float)Math.Pow(masterVolume, 1.5);
 
-                    // Use NAudio for async playback
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new NAudio.Wave.AudioFileReader(popPath);
-                            audioFile.Volume = volume;
-                            using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-                            while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                            {
-                                System.Threading.Thread.Sleep(50);
-                            }
-                        }
-                        catch { /* Ignore audio errors */ }
-                    });
+                    App.Audio?.PlayOneShot(popPath, volume, "avatar-pop");
                 }
             }
             catch (Exception ex)
@@ -2303,22 +2237,7 @@ namespace ConditioningControlPanel
                     var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
                     var volume = (float)Math.Pow(masterVolume, 1.5);
 
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new NAudio.Wave.AudioFileReader(audioPath);
-                            audioFile.Volume = volume;
-                            using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-                            while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                            {
-                                System.Threading.Thread.Sleep(50);
-                            }
-                        }
-                        catch { /* Ignore audio errors */ }
-                    });
+                    App.Audio?.PlayOneShot(audioPath, volume, "cum-and-collapse");
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Windowing.cs
@@ -148,6 +148,7 @@ namespace ConditioningControlPanel
         private static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
 
         private const uint GW_HWNDPREV = 3;   // the window directly ABOVE hWnd in the z-order
+        private const uint GW_HWNDNEXT = 2;   // the window directly BELOW hWnd in the z-order
 
         /// <summary>
         /// Start monitoring for fullscreen applications
@@ -1069,7 +1070,11 @@ namespace ConditioningControlPanel
                             Top = wa.Bottom - Math.Max(120, ActualHeight) - margin;
                         }
                         catch { /* positioning is best-effort */ }
-                        ReassertTopmost();   // keep the freshly-parked widget above the run's overlays
+                        // Put the freshly-parked widget back in the topmost band. NOT above the
+                        // compositor host any more (#776) — the host's fullscreen effects, the pink
+                        // tint above all, now win over the companion; ReassertTopmost slots the tube
+                        // directly beneath the host, which still leaves it over the run's own chrome.
+                        ReassertTopmost();
                     }
                 }
                 else
@@ -1182,7 +1187,17 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// Reassert topmost status when detached - ensures avatar stays on top as a widget
+        /// Reassert topmost status when detached - ensures avatar stays on top as a widget.
+        ///
+        /// #776: the raise is UNCONDITIONAL (never gated on having lost WS_EX_TOPMOST) but it is no
+        /// longer always aimed at HWND_TOPMOST. The shared compositor host carries the pink filter and
+        /// re-pins itself to the front of the topmost band every 5s (OverlayService.ReassertZOrder);
+        /// this tick fired every 500ms and put the tube back on top, so the tint appeared to blink on
+        /// and off the companion. The tint wins: when a visible host covers the tube's monitor we
+        /// insert directly BELOW it instead — still topmost, still above every ordinary app window,
+        /// permanently under the tint. Runs on the tube's OWN thread (AvatarOwnThread), which is why
+        /// the host handle comes from CompositorEngine's lock-free anchor snapshot rather than from
+        /// its UI-thread-only host dictionaries.
         /// </summary>
         private void ReassertTopmost()
         {
@@ -1191,10 +1206,59 @@ namespace ConditioningControlPanel
             // Don't fight with pop quiz for topmost z-order
             if ((PopQuizWindow.IsOpen || QuizWindow.IsOpen)) return;
 
-            // Use Win32 SetWindowPos with HWND_TOPMOST to force topmost z-order
-            // This is more reliable than WPF's Topmost property across monitor/focus changes
-            SetWindowPos(_tubeHandle, HWND_TOPMOST, 0, 0, 0, 0,
+            var insertAfter = HWND_TOPMOST;
+            if (Services.OverlayService.ResolveZOrderAction(
+                    hasVideo: false, isVideoWindow: false, aboveVideo: false, needsPin: true, force: true,
+                    yieldToCompositorHost: TryGetCompositorHostAnchor(out var hostHwnd))
+                == Services.OverlayService.ZOrderAction.PinBelowCompositorHost)
+            {
+                // Already sitting directly under the host? Then the invariant holds and we skip the
+                // call entirely — this is a layered window, and poking WM_WINDOWPOSCHANGING twice a
+                // second for nothing is exactly the kind of churn that perturbs the emote crossfades.
+                if (GetWindow(hostHwnd, GW_HWNDNEXT) == _tubeHandle) return;
+                insertAfter = hostHwnd;
+            }
+
+            // Use Win32 SetWindowPos to force the z-order slot. More reliable than WPF's Topmost
+            // property across monitor/focus changes; inserting after a topmost host keeps our own
+            // WS_EX_TOPMOST set, so the tube never drops out of the widget band.
+            SetWindowPos(_tubeHandle, insertAfter, 0, 0, 0, 0,
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
+
+        /// <summary>
+        /// The compositor host window the detached tube must sit under, if any: the visible
+        /// main-surface host covering the tube's centre point (physical px, the space the anchor
+        /// snapshot is published in).
+        ///
+        /// Deliberately keyed on the HOST EXISTING, not on the tint being active — an empty host is
+        /// fully transparent and click-through, so parking below it costs nothing, whereas testing
+        /// "is the tint rendering here" would re-introduce the same flip-flop the bug is about
+        /// (PinkTintLayer.ShouldRenderOnScreen can also gate the tint off this monitor entirely,
+        /// which is exactly a monitor where no host effect can ever cover us anyway).
+        ///
+        /// A playing mandatory video is left alone: the reconciler pins the hosts BELOW it (#497),
+        /// so yielding to a host there would drag the companion under an opaque fullscreen video —
+        /// a behaviour change #776 never asked for. In that state the tube keeps its old raise.
+        /// </summary>
+        private bool TryGetCompositorHostAnchor(out IntPtr hostHwnd)
+        {
+            hostHwnd = IntPtr.Zero;
+            try
+            {
+                if (App.Compositor is not { } engine) return false;
+                if (App.Video?.IsPlaying == true) return false;
+                if (!GetWindowRect(_tubeHandle, out var r)) return false;
+
+                int cx = r.Left + (r.Right - r.Left) / 2;
+                int cy = r.Top + (r.Bottom - r.Top) / 2;
+                var handle = engine.FindHostAnchorAt(cx, cy);
+                if (handle == 0) return false;
+
+                hostHwnd = handle;
+                return true;
+            }
+            catch { return false; }   // never let a z-order hint break the tick
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Controls/InlineLoopVideo.cs
+++ b/ConditioningControlPanel/Controls/InlineLoopVideo.cs
@@ -29,9 +29,6 @@ namespace ConditioningControlPanel.Controls
     /// </summary>
     public sealed class InlineLoopVideo : IDisposable
     {
-        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory")]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
-
         private readonly string _path;
         private readonly uint _w;
         private readonly uint _h;
@@ -42,6 +39,14 @@ namespace ConditioningControlPanel.Controls
         private IntPtr _frameBuffer = IntPtr.Zero;
         private volatile bool _frameReady;
         private volatile bool _bufferValid;
+
+        /// <summary>Managed staging copy of the newest decoded frame — see <see cref="OnRendering"/>
+        /// for why the native buffer is never read while the bitmap lock is held.</summary>
+        private byte[] _staging = Array.Empty<byte>();
+
+        /// <summary>Per-frame budget for <c>WriteableBitmap.TryLock</c>; a wedged render thread must
+        /// cost a frame, not the dispatcher.</summary>
+        private static readonly Duration BlitLockBudget = new(TimeSpan.FromMilliseconds(150));
 
         private VlcMediaPlayer? _player;
         private Media? _media;
@@ -171,11 +176,30 @@ namespace ConditioningControlPanel.Controls
             _renderingHooked = false;
         }
 
+        /// <summary>
+        /// Per-frame blit, UI thread. Two strictly separated phases — the same split
+        /// <c>VideoService.BlurVmemSurface.OnRendering</c> had to make for the #632/#636/#687 freeze
+        /// cluster, which this control's ancestor code predates:
+        ///
+        ///   1. Under <c>_bufferLock</c>: native buffer -> managed staging. Nothing here blocks on
+        ///      another thread.
+        ///   2. Lock RELEASED: <c>TryLock</c> / copy / <c>AddDirtyRect</c> / <c>Unlock</c>.
+        ///
+        /// Doing step 2 while still holding <c>_bufferLock</c> is a three-thread deadlock:
+        /// <c>WriteableBitmap.Lock()</c> waits on the WPF render thread, and the LibVLC decoder
+        /// thread parks on <c>_bufferLock</c> inside <c>LockCallback</c> — with the decoder parked in
+        /// a native callback, <c>player.Stop()</c> can never return. And <c>Lock()</c> has no
+        /// timeout, so a render thread that never drops its read lock takes the dispatcher with it.
+        /// One extra memcpy per frame buys "a stalled render thread can only ever cost frames".
+        /// </summary>
         private void OnRendering(object? sender, EventArgs e)
         {
             if (!_bufferValid || !_frameReady) return;
             _frameReady = false;
 
+            int bytes = (int)(_w * _h * 4);
+
+            // ---- Phase 1: native -> managed, under the lock, no blocking calls. ----
             bool got = false;
             try
             {
@@ -183,10 +207,26 @@ namespace ConditioningControlPanel.Controls
                 if (!got) return;
                 if (!_bufferValid || _frameBuffer == IntPtr.Zero) return;
 
-                _bitmap.Lock();
+                if (_staging.Length < bytes) _staging = new byte[bytes];
+                Marshal.Copy(_frameBuffer, _staging, 0, bytes);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("InlineLoopVideo: frame snapshot error: {Error}", ex.Message);
+                return;
+            }
+            finally
+            {
+                if (got) Monitor.Exit(_bufferLock);
+            }
+
+            // ---- Phase 2: managed -> bitmap, lock released, bounded wait on the render thread. ----
+            try
+            {
+                if (!_bitmap.TryLock(BlitLockBudget)) return; // render thread is busy: drop the frame
                 try
                 {
-                    CopyMemory(_bitmap.BackBuffer, _frameBuffer, _w * _h * 4);
+                    Marshal.Copy(_staging, 0, _bitmap.BackBuffer, bytes);
                     _bitmap.AddDirtyRect(new Int32Rect(0, 0, (int)_w, (int)_h));
                 }
                 finally
@@ -197,10 +237,6 @@ namespace ConditioningControlPanel.Controls
             catch (Exception ex)
             {
                 App.Logger?.Debug("InlineLoopVideo: frame copy error: {Error}", ex.Message);
-            }
-            finally
-            {
-                if (got) Monitor.Exit(_bufferLock);
             }
         }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -170,8 +170,7 @@ namespace ConditioningControlPanel
         
         // Avatar Tube Window
         private AvatarTubeWindow? _avatarTubeWindow;
-        private WaveOutEvent? _levelUpSoundDevice;
-        private AudioFileReader? _levelUpSoundFile;
+        private Services.AudioPlaybackHandle? _levelUpSoundHandle;
         private bool _avatarWasAttachedBeforeMaximize = false;
         private bool _avatarWasAttachedBeforeBrowserFullscreen = false;
 
@@ -688,52 +687,17 @@ namespace ConditioningControlPanel
                 // Stop any previous level up sound still playing
                 StopLevelUpSound();
 
-                Task.Run(() =>
-                {
-                    try
-                    {
-                        var audioFile = new AudioFileReader(soundPath);
-                        var outputDevice = new WaveOutEvent();
-                        App.Audio?.ApplyPreferredDevice(outputDevice);
+                var masterVolume = App.Settings.Current.MasterVolume / 100f;
+                var curvedVolume = (float)Math.Pow(masterVolume, 1.5) * 0.2625f;
 
-                        var masterVolume = App.Settings.Current.MasterVolume / 100f;
-                        var curvedVolume = (float)Math.Pow(masterVolume, 1.5) * 0.2625f;
-                        audioFile.Volume = Math.Max(0.01f, curvedVolume);
+                // AudioService owns the device + its disposal (deferred past NAudio's own unwind,
+                // which is what the old "Handle is not initialized" workaround here was for), and
+                // it never opens the device on the dispatcher — #778/#779.
+                // Stop() on an already-finished handle is a no-op, so no completion bookkeeping is
+                // needed — StopLevelUpSound above already ran before this one started.
+                _levelUpSoundHandle = App.Audio?.PlayOneShot(soundPath, Math.Max(0.01f, curvedVolume), "level-up");
 
-                        outputDevice.Init(audioFile);
-                        outputDevice.PlaybackStopped += (s, e) =>
-                        {
-                            // Defer disposal — disposing inside PlaybackStopped causes
-                            // "Handle is not initialized" when NAudio's internal cleanup
-                            // races with our Dispose call.
-                            Task.Run(() =>
-                            {
-                                try
-                                {
-                                    Thread.Sleep(50); // Let NAudio finish its internal cleanup
-                                    outputDevice.Dispose();
-                                    audioFile.Dispose();
-                                    if (_levelUpSoundDevice == outputDevice)
-                                    {
-                                        _levelUpSoundDevice = null;
-                                        _levelUpSoundFile = null;
-                                    }
-                                }
-                                catch (Exception) { }
-                            });
-                        };
-
-                        _levelUpSoundDevice = outputDevice;
-                        _levelUpSoundFile = audioFile;
-                        outputDevice.Play();
-
-                        App.Logger?.Debug("Level up sound played from: {Path}", soundPath);
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Warning("Failed to play level up sound: {Error}", ex.Message);
-                    }
-                });
+                App.Logger?.Debug("Level up sound played from: {Path}", soundPath);
             }
             catch (Exception ex)
             {
@@ -745,11 +709,8 @@ namespace ConditioningControlPanel
         {
             try
             {
-                _levelUpSoundDevice?.Stop();
-                _levelUpSoundDevice?.Dispose();
-                _levelUpSoundFile?.Dispose();
-                _levelUpSoundDevice = null;
-                _levelUpSoundFile = null;
+                _levelUpSoundHandle?.Stop();
+                _levelUpSoundHandle = null;
             }
             catch { }
         }

--- a/ConditioningControlPanel/Models/AchievementProgress.cs
+++ b/ConditioningControlPanel/Models/AchievementProgress.cs
@@ -310,6 +310,55 @@ public class AchievementProgress
     }
 
     /// <summary>
+    /// Pure decision function for the midnight-rollover path: given the last banked day and the
+    /// current day, should the day-advance path run right now?
+    ///
+    /// Deliberately pure (no clock, no settings, no services) so the correctness argument is a
+    /// property of two dates rather than of wall-clock timing, which cannot be tested by waiting.
+    ///
+    /// Returns false when:
+    ///  - <paramref name="lastBankedDate"/> is default/MinValue. That is the "no local launch
+    ///    history" case which <see cref="UpdateDailyStreak"/>'s startup path owns exclusively
+    ///    (it defers to the cloud restore). The rollover path must never claim a first run.
+    ///  - the day has not advanced (<c>today == lastBanked</c>) — today is already banked, so
+    ///    running again would be the double-count we must never produce.
+    ///  - the day went BACKWARDS (<c>today &lt; lastBanked</c>) — a clock correction or a
+    ///    timezone change. Re-running the gap logic there would compute a negative gap and reset
+    ///    a healthy streak to 1, so we simply stand still and let the next real day advance it.
+    /// </summary>
+    public static bool ShouldBankDayRollover(DateTime lastBankedDate, DateTime today)
+    {
+        var last = lastBankedDate.Date;
+        if (last == default) return false;
+        return today.Date > last;
+    }
+
+    /// <summary>
+    /// Day-advance entry point for a calendar rollover that happens while the app is RUNNING
+    /// (PC left asleep, or CCP simply left open across midnight). Both cases previously lost the
+    /// day entirely because <see cref="LastLaunchDate"/> was only ever written on the startup path.
+    ///
+    /// This intentionally delegates to <see cref="UpdateDailyStreak"/> rather than reimplementing
+    /// the day-advance: that keeps Streak Shields, Oopsie Insurance, the shielded-date bookkeeping
+    /// and the Season Recap hooks on exactly one code path, and it means <see cref="LastLaunchDate"/>
+    /// still has exactly one writer. Since UpdateDailyStreak early-returns when the day is already
+    /// banked, startup and rollover can never both bank the same date.
+    ///
+    /// Returns true if a day was banked (caller is then responsible for persisting).
+    /// </summary>
+    public bool TryAdvanceDayRollover()
+    {
+        if (!ShouldBankDayRollover(LastLaunchDate, DateTime.Today)) return false;
+
+        var before = LastLaunchDate.Date;
+        UpdateDailyStreak();
+
+        // UpdateDailyStreak is the sole writer of LastLaunchDate; if it did not move, nothing was
+        // banked (defensive — with the guard above it always moves) and the caller should not save.
+        return LastLaunchDate.Date != before;
+    }
+
+    /// <summary>
     /// Called after SkillTree is initialized to award streak bonus that was deferred during startup.
     /// </summary>
     public void AwardDeferredStreakBonus()

--- a/ConditioningControlPanel/Services/Audio/AudioService.Playback.cs
+++ b/ConditioningControlPanel/Services/Audio/AudioService.Playback.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+using NAudio.Wave;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Handle to one in-flight one-shot started by <see cref="AudioService.PlayOneShot"/>.
+    /// Safe to Stop/Pause/Resume before the clip has actually opened (the request is replayed
+    /// onto the device the moment it exists) and safe to keep after it finished (no-ops).
+    /// </summary>
+    public sealed class AudioPlaybackHandle
+    {
+        private readonly object _sync = new();
+        private WaveOutEvent? _output;
+        private bool _stopRequested;
+        private bool _pauseRequested;
+        private int _finished;
+
+        /// <summary>True once the clip ended, was stopped, failed, or was force-torn-down.</summary>
+        public bool IsFinished => Volatile.Read(ref _finished) != 0;
+
+        /// <summary>Single-winner latch — everything that tears a one-shot down goes through this.</summary>
+        internal bool TryFinish() => Interlocked.Exchange(ref _finished, 1) == 0;
+
+        internal void Attach(WaveOutEvent output)
+        {
+            bool stop, pause;
+            lock (_sync) { _output = output; stop = _stopRequested; pause = _pauseRequested; }
+            // A Stop() that arrived while the clip was still queued must not be lost, or the
+            // caller's "cut off the previous line" contract silently breaks.
+            if (stop) { try { output.Stop(); } catch { } }
+            else if (pause) { try { output.Pause(); } catch { } }
+        }
+
+        internal void Detach() { lock (_sync) { _output = null; } }
+
+        public void Stop()
+        {
+            WaveOutEvent? o;
+            lock (_sync) { _stopRequested = true; o = _output; }
+            if (o != null) { try { o.Stop(); } catch { } }
+        }
+
+        public void Pause()
+        {
+            WaveOutEvent? o;
+            lock (_sync) { _pauseRequested = true; o = _output; }
+            if (o != null) { try { if (o.PlaybackState == PlaybackState.Playing) o.Pause(); } catch { } }
+        }
+
+        public void Resume()
+        {
+            WaveOutEvent? o;
+            lock (_sync) { _pauseRequested = false; o = _output; }
+            if (o != null) { try { if (o.PlaybackState == PlaybackState.Paused) o.Play(); } catch { } }
+        }
+    }
+
+    public partial class AudioService
+    {
+        #region One-shot playback (#778/#779)
+
+        // ── Why this file exists ──────────────────────────────────────────────────────────────
+        // Every short clip in the app (giggle, pop, chime, whisper, bark voice, mantra prompt,
+        // narrator cue, level-up) used to be played by its own copy of:
+        //
+        //     Task.Run(() => { using var r = new AudioFileReader(p);
+        //                      using var o = new WaveOutEvent();
+        //                      o.Init(r); o.Play();
+        //                      while (o.PlaybackState == Playing) Thread.Sleep(50); });
+        //
+        // Three separate failure modes, all of which #778/#779 hit at once:
+        //
+        //  1. TWO blocked thread-pool threads per clip. NAudio's WaveOutEvent.Play() already
+        //     queues its own PlaybackThread onto the pool for the clip's whole duration; the
+        //     Thread.Sleep loop above burns a second one. Nothing capped how many ran at once.
+        //  2. waveOutOpen (inside Init) does NOT fail fast when the Windows audio endpoint is
+        //     gone — it blocks on the audio-service RPC. So every clip fired while the endpoint
+        //     was dead parked another pair of pool threads, the pool injected ~1-2 more per
+        //     second, and each parked frame pinned a half-built WaveOutEvent + AutoResetEvent +
+        //     AudioFileReader. That is the reporter's +202 threads / +5,601 handles verbatim,
+        //     and why the app "ground to a halt and died" the moment Audio Endpoint Builder
+        //     came back and 200 blocked calls returned at once.
+        //  3. WaveOutEvent captures SynchronizationContext.Current in its CONSTRUCTOR and posts
+        //     PlaybackStopped to it. Constructed on the UI thread (the whisper/mind-wipe/level-up
+        //     paths all did), cleanup was a dispatcher post — so a busy or wedged UI thread meant
+        //     the disposal never ran at all.
+        //
+        // The replacement below: open/close serialized on one dedicated MTA thread (never the
+        // dispatcher, never the pool, and no captured SynchronizationContext), no blocking wait
+        // anywhere, a hard cap on concurrent clips, deterministic disposal from BOTH
+        // PlaybackStopped and a safety timer, and a circuit breaker so a dead endpoint makes the
+        // app go quiet instead of spinning. It recovers by itself when the endpoint comes back.
+
+        /// <summary>Consecutive failures before new playback is suppressed.</summary>
+        private const int OutputFailuresToTrip = 5;
+
+        /// <summary>How long playback stays suppressed once the breaker trips.</summary>
+        private static readonly TimeSpan OutputCooldown = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Hard ceiling on simultaneously-open one-shots. Overlapping short clips are normal
+        /// (pop + bark + whisper), a hundred of them are not — that is a dead endpoint, and
+        /// dropping the excess is what keeps the handle count flat instead of unbounded.
+        /// </summary>
+        private const int MaxConcurrentOneShots = 10;
+
+        /// <summary>Queue ceiling for the open/close worker. Only reachable if it is wedged.</summary>
+        private const int MaxQueuedPlaybackWork = 32;
+
+        /// <summary>A single open/close taking longer than this means the audio stack is hung.</summary>
+        private const int PlaybackWorkerWedgeMs = 4_000;
+
+        private int _outputFailStreak;
+        private long _outputSuppressedUntilTicks;   // DateTime.UtcNow.Ticks; 0 = healthy
+        private int _outputRecoveryLogPending;      // 1 once we've logged a trip and owe a recovery line
+
+        private int _oneShotsInFlight;
+
+        private readonly BlockingCollection<Action> _playbackWork = new();
+        private Thread? _playbackWorker;
+        private int _playbackWorkerStarted;
+        private int _playbackQueueDepth;
+        private long _playbackWorkItemStartedTicks;  // 0 = idle
+
+        private MMDeviceEnumerator? _notifyEnumerator;
+        private EndpointWatcher? _endpointWatcher;
+        private long _lastEndpointLogTicks;
+
+        /// <summary>
+        /// True while the circuit breaker is open — the audio endpoint failed repeatedly and we
+        /// are deliberately silent for a cooldown instead of hammering a dead device. Clears
+        /// itself when the cooldown expires or an endpoint change is observed.
+        /// </summary>
+        public bool IsOutputSuppressed
+        {
+            get
+            {
+                var until = Interlocked.Read(ref _outputSuppressedUntilTicks);
+                if (until == 0) return false;
+                if (DateTime.UtcNow.Ticks < until) return true;
+
+                // Cooldown expired — re-arm and let the next clip probe the device for real.
+                if (Interlocked.CompareExchange(ref _outputSuppressedUntilTicks, 0, until) == until)
+                {
+                    Interlocked.Exchange(ref _outputFailStreak, 0);
+                    InvalidateOutputDeviceCache();   // never re-use a device number resolved against a dead endpoint
+                    App.Logger?.Information("[Audio] output cooldown expired — retrying playback on a freshly resolved device");
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Play a short clip. Never blocks the caller, never blocks a thread for the clip's
+        /// duration, and always disposes its device + reader exactly once.
+        /// </summary>
+        /// <param name="path">Absolute path to the clip.</param>
+        /// <param name="volume">Final linear volume 0..1 (apply your own curve before calling).</param>
+        /// <param name="tag">Short label for diagnostics ("bark", "pop", "whisper", ...).</param>
+        /// <param name="onStarted">Invoked with the clip's duration once it is actually playing.</param>
+        /// <param name="onFinished">
+        /// Invoked exactly once, off the UI thread, when the clip ends OR when it was refused
+        /// (missing file, breaker open, cap hit) — so caller state machines always unwind.
+        /// </param>
+        /// <returns>A handle, or null when nothing will play.</returns>
+        public AudioPlaybackHandle? PlayOneShot(string path, float volume, string tag = "audio",
+                                                Action<TimeSpan>? onStarted = null, Action? onFinished = null)
+        {
+            if (_disposed) { FireFinished(onFinished); return null; }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                FireFinished(onFinished);
+                return null;
+            }
+
+            if (volume <= 0f)
+            {
+                // Muted — don't touch the audio stack at all.
+                FireFinished(onFinished);
+                return null;
+            }
+
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    App.Logger?.Debug("[Audio] {Tag}: clip not found at {Path}", tag, path);
+                    FireFinished(onFinished);
+                    return null;
+                }
+            }
+            catch { FireFinished(onFinished); return null; }
+
+            if (IsOutputSuppressed) { FireFinished(onFinished); return null; }
+
+            if (IsPlaybackWorkerWedged())
+            {
+                // The open/close thread is stuck inside the audio stack. Every further clip would
+                // just queue behind it, so refuse and treat the wedge itself as a device failure.
+                NoteOutputFailure(tag, "playback worker wedged in the audio stack");
+                FireFinished(onFinished);
+                return null;
+            }
+
+            if (Interlocked.Increment(ref _oneShotsInFlight) > MaxConcurrentOneShots)
+            {
+                Interlocked.Decrement(ref _oneShotsInFlight);
+                NoteOutputFailure(tag, $"concurrent one-shot cap ({MaxConcurrentOneShots}) reached");
+                FireFinished(onFinished);
+                return null;
+            }
+
+            var handle = new AudioPlaybackHandle();
+            var clampedVolume = Math.Clamp(volume, 0f, 1f);
+
+            if (!EnqueuePlaybackWork(() => OpenAndPlayOneShot(handle, path, clampedVolume, tag, onStarted, onFinished)))
+            {
+                Interlocked.Decrement(ref _oneShotsInFlight);
+                handle.TryFinish();
+                NoteOutputFailure(tag, "open/close queue full");
+                FireFinished(onFinished);
+                return null;
+            }
+
+            return handle;
+        }
+
+        /// <summary>
+        /// Worker-thread half of <see cref="PlayOneShot"/>. Runs on the dedicated MTA playback
+        /// thread so waveOutOpen can never block the dispatcher and WaveOutEvent captures no
+        /// SynchronizationContext (PlaybackStopped then fires on NAudio's own thread, which is
+        /// the only way cleanup stays reliable when the UI thread is busy).
+        /// </summary>
+        private void OpenAndPlayOneShot(AudioPlaybackHandle handle, string path, float volume, string tag,
+                                        Action<TimeSpan>? onStarted, Action? onFinished)
+        {
+            AudioFileReader? reader = null;
+            WaveOutEvent? output = null;
+            System.Threading.Timer? safety = null;
+
+            void Complete(bool ok, string reason)
+            {
+                if (!handle.TryFinish()) return;   // PlaybackStopped and the safety timer race — one wins
+                handle.Detach();
+                try { safety?.Dispose(); } catch { }
+                ScheduleTeardown(output, reader);
+                Interlocked.Decrement(ref _oneShotsInFlight);
+                if (ok) NoteOutputSuccess();
+                else NoteOutputFailure(tag, reason);
+                FireFinished(onFinished);
+            }
+
+            try
+            {
+                reader = new AudioFileReader(path) { Volume = volume };
+                var duration = reader.TotalTime;
+
+                output = CreateWaveOut();
+                if (output == null) throw new InvalidOperationException("no audio output device accepted waveOutOpen");
+
+                output.Init(reader);
+
+                // Created disarmed, then started right after Play() — created FIRST so a clip that
+                // ends between Play() and here can still find a timer to dispose.
+                var safetyMs = (int)Math.Clamp(reader.TotalTime.TotalMilliseconds + 5_000, 10_000, 20 * 60_000);
+                safety = new System.Threading.Timer(_ =>
+                {
+                    // A deliberately paused clip (world-freeze) is not a stuck device — give it
+                    // another window rather than tearing the line down mid-sentence.
+                    try
+                    {
+                        if (output != null && output.PlaybackState == PlaybackState.Paused)
+                        {
+                            safety?.Change(safetyMs, Timeout.Infinite);
+                            return;
+                        }
+                    }
+                    catch { }
+                    Complete(false, "playback never reported stopped");
+                }, null, Timeout.Infinite, Timeout.Infinite);
+
+                output.PlaybackStopped += (_, e) =>
+                    Complete(e?.Exception == null, e?.Exception?.Message ?? "playback stopped with an error");
+
+                handle.Attach(output);
+                output.Play();
+
+                // Safety net: if PlaybackStopped never arrives (endpoint yanked mid-clip, driver
+                // stops pumping) this is what still frees the device, the reader and the slot.
+                try { safety.Change(safetyMs, Timeout.Infinite); } catch { }
+
+                NoteOutputSuccess();
+                if (onStarted != null)
+                {
+                    try { onStarted(duration); }
+                    catch (Exception ex) { App.Logger?.Debug("[Audio] {Tag}: onStarted threw: {E}", tag, ex.Message); }
+                }
+            }
+            catch (Exception ex)
+            {
+                try { safety?.Dispose(); } catch { }
+                try { output?.Dispose(); } catch { }
+                try { reader?.Dispose(); } catch { }
+                if (handle.TryFinish())
+                {
+                    handle.Detach();
+                    Interlocked.Decrement(ref _oneShotsInFlight);
+                    NoteOutputFailure(tag, ex.Message);
+                    FireFinished(onFinished);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Free a finished clip's device + reader on the serialized worker, after a short grace
+        /// period. The grace exists because disposing straight out of PlaybackStopped races
+        /// NAudio's own unwind ("Handle is not initialized"); the worker exists because
+        /// waveOutReset/waveOutClose block exactly as hard as waveOutOpen on a dead endpoint.
+        /// </summary>
+        private void ScheduleTeardown(WaveOutEvent? output, AudioFileReader? reader)
+        {
+            if (output == null && reader == null) return;
+
+            void Teardown()
+            {
+                // teardown: true — never dropped by the queue cap, or the cap itself would leak.
+                EnqueuePlaybackWork(() =>
+                {
+                    try { output?.Stop(); } catch { }
+                    try { output?.Dispose(); } catch { }
+                    try { reader?.Dispose(); } catch { }
+                }, teardown: true);
+            }
+
+            try
+            {
+                System.Threading.Timer? t = null;
+                t = new System.Threading.Timer(_ =>
+                {
+                    try { t?.Dispose(); } catch { }
+                    Teardown();
+                }, null, 50, Timeout.Infinite);
+            }
+            catch
+            {
+                Teardown();   // timer creation failed — free it now rather than never
+            }
+        }
+
+        private static void FireFinished(Action? onFinished)
+        {
+            if (onFinished == null) return;
+            try
+            {
+                ThreadPool.UnsafeQueueUserWorkItem(_ =>
+                {
+                    try { onFinished(); }
+                    catch (Exception ex) { App.Logger?.Debug("[Audio] one-shot completion callback threw: {E}", ex.Message); }
+                }, null);
+            }
+            catch { }
+        }
+
+        #endregion
+
+        #region Circuit breaker
+
+        /// <summary>
+        /// Record a successful open/play. Resets the failure streak and, if we were suppressed,
+        /// logs the recovery once.
+        /// </summary>
+        internal void NoteOutputSuccess()
+        {
+            Interlocked.Exchange(ref _outputFailStreak, 0);
+            Interlocked.Exchange(ref _outputSuppressedUntilTicks, 0);
+            if (Interlocked.CompareExchange(ref _outputRecoveryLogPending, 0, 1) == 1)
+                App.Logger?.Information("[Audio] output recovered — playback resumed");
+        }
+
+        /// <summary>
+        /// Record a failed open/play. After <see cref="OutputFailuresToTrip"/> in a row the
+        /// breaker opens for <see cref="OutputCooldown"/>: new playback is refused (silently,
+        /// one log line) and the cached device resolution is dropped so the retry after the
+        /// cooldown re-resolves the CURRENT default endpoint instead of the dead one.
+        /// </summary>
+        internal void NoteOutputFailure(string tag, string? reason)
+        {
+            var streak = Interlocked.Increment(ref _outputFailStreak);
+            if (streak < OutputFailuresToTrip)
+            {
+                App.Logger?.Debug("[Audio] {Tag}: playback failed ({Reason}) — streak {Streak}/{Trip}",
+                    tag, reason ?? "unknown", streak, OutputFailuresToTrip);
+                return;
+            }
+
+            var until = DateTime.UtcNow.Add(OutputCooldown).Ticks;
+            var previous = Interlocked.Exchange(ref _outputSuppressedUntilTicks, until);
+
+            // Only the transition healthy -> suppressed gets a log line; a dead endpoint must
+            // never be able to fill the log the way it used to fill the thread pool.
+            if (previous == 0 || previous < DateTime.UtcNow.Ticks)
+            {
+                Interlocked.Exchange(ref _outputRecoveryLogPending, 1);
+                App.Logger?.Warning(
+                    "[Audio] output failed {Streak}x in a row (last: {Tag} — {Reason}). Suppressing playback for {Seconds}s; it will re-resolve the default device and retry. Windows audio may have restarted or the endpoint was removed.",
+                    streak, tag, reason ?? "unknown", (int)OutputCooldown.TotalSeconds);
+                InvalidateOutputDeviceCache();
+            }
+        }
+
+        #endregion
+
+        #region Playback worker + endpoint watcher
+
+        private bool IsPlaybackWorkerWedged()
+        {
+            var started = Volatile.Read(ref _playbackWorkItemStartedTicks);
+            if (started == 0) return false;
+            return DateTime.UtcNow.Ticks - started > TimeSpan.TicksPerMillisecond * PlaybackWorkerWedgeMs;
+        }
+
+        private bool EnqueuePlaybackWork(Action work, bool teardown = false)
+        {
+            if (_disposed) return false;
+            EnsurePlaybackWorker();
+
+            if (!teardown && Volatile.Read(ref _playbackQueueDepth) >= MaxQueuedPlaybackWork)
+                return false;
+
+            Interlocked.Increment(ref _playbackQueueDepth);
+            try
+            {
+                _playbackWork.Add(() =>
+                {
+                    Volatile.Write(ref _playbackWorkItemStartedTicks, DateTime.UtcNow.Ticks);
+                    try { work(); }
+                    catch (Exception ex) { App.Logger?.Debug("[Audio] playback work item failed: {E}", ex.Message); }
+                    finally
+                    {
+                        Volatile.Write(ref _playbackWorkItemStartedTicks, 0);
+                        Interlocked.Decrement(ref _playbackQueueDepth);
+                    }
+                });
+                return true;
+            }
+            catch
+            {
+                Interlocked.Decrement(ref _playbackQueueDepth);   // collection completed (shutdown)
+                return false;
+            }
+        }
+
+        private void EnsurePlaybackWorker()
+        {
+            if (Interlocked.Exchange(ref _playbackWorkerStarted, 1) == 1) return;
+            _playbackWorker = new Thread(PlaybackWorkerLoop)
+            {
+                IsBackground = true,
+                Name = "AudioPlaybackWorker",
+            };
+            _playbackWorker.Start();
+        }
+
+        private void PlaybackWorkerLoop()
+        {
+            // MTA by default, and crucially NOT the dispatcher: every WaveOutEvent minted here
+            // has SynchronizationContext.Current == null, so PlaybackStopped is raised on
+            // NAudio's playback thread and cleanup no longer depends on a live UI thread.
+            TryRegisterEndpointWatcher();
+
+            try
+            {
+                foreach (var item in _playbackWork.GetConsumingEnumerable())
+                {
+                    try { item(); } catch { }
+                }
+            }
+            catch { /* collection completed / disposed */ }
+
+            TryUnregisterEndpointWatcher();
+        }
+
+        /// <summary>
+        /// Watch for endpoint churn (default device changed, device added/removed/disabled, audio
+        /// service restarted) so a cached WaveOut device number resolved against a device that no
+        /// longer exists is dropped, and a tripped breaker re-arms immediately instead of waiting
+        /// out its cooldown. Registered from the worker thread on purpose: MTA callbacks arrive on
+        /// an RPC thread and never need the dispatcher to pump.
+        /// </summary>
+        private void TryRegisterEndpointWatcher()
+        {
+            try
+            {
+                _notifyEnumerator = new MMDeviceEnumerator();
+                _endpointWatcher = new EndpointWatcher(this);
+                _notifyEnumerator.RegisterEndpointNotificationCallback(_endpointWatcher);
+                App.Logger?.Debug("[Audio] endpoint notification watcher registered");
+            }
+            catch (Exception ex)
+            {
+                // Purely an optimisation — the cooldown path recovers on its own without it.
+                _endpointWatcher = null;
+                App.Logger?.Debug("[Audio] could not register endpoint watcher: {E}", ex.Message);
+            }
+        }
+
+        private void TryUnregisterEndpointWatcher()
+        {
+            try
+            {
+                if (_notifyEnumerator != null && _endpointWatcher != null)
+                    _notifyEnumerator.UnregisterEndpointNotificationCallback(_endpointWatcher);
+            }
+            catch { }
+            _endpointWatcher = null;
+            try { _notifyEnumerator?.Dispose(); } catch { }
+            _notifyEnumerator = null;
+        }
+
+        /// <summary>
+        /// Called from a COM callback thread — must stay cheap and must never throw or block.
+        /// </summary>
+        internal void OnEndpointChanged(string reason)
+        {
+            try
+            {
+                if (_disposed) return;
+
+                InvalidateOutputDeviceCache();
+                Interlocked.Exchange(ref _outputFailStreak, 0);
+                Interlocked.Exchange(ref _outputSuppressedUntilTicks, 0);
+
+                // Endpoint changes arrive in bursts (one per role, per flow) — log at most one
+                // line every couple of seconds.
+                var now = DateTime.UtcNow.Ticks;
+                var last = Interlocked.Read(ref _lastEndpointLogTicks);
+                if (now - last > TimeSpan.TicksPerSecond * 2 &&
+                    Interlocked.CompareExchange(ref _lastEndpointLogTicks, now, last) == last)
+                {
+                    App.Logger?.Information("[Audio] audio endpoint change ({Reason}) — device cache dropped, playback re-enabled", reason);
+                }
+            }
+            catch { }
+        }
+
+        private sealed class EndpointWatcher : IMMNotificationClient
+        {
+            private readonly AudioService _service;
+            public EndpointWatcher(AudioService service) => _service = service;
+
+            public void OnDeviceStateChanged(string deviceId, DeviceState newState) => _service.OnEndpointChanged("device state");
+            public void OnDeviceAdded(string pwstrDeviceId) => _service.OnEndpointChanged("device added");
+            public void OnDeviceRemoved(string deviceId) => _service.OnEndpointChanged("device removed");
+
+            public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+            {
+                if (flow == DataFlow.Render) _service.OnEndpointChanged("default render device");
+            }
+
+            public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key) { }
+        }
+
+        /// <summary>Stop accepting new playback work and drop the endpoint watcher. Called from Dispose.</summary>
+        private void ShutdownPlayback()
+        {
+            try { _playbackWork.CompleteAdding(); } catch { }
+            if (Volatile.Read(ref _playbackWorkerStarted) == 0) TryUnregisterEndpointWatcher();
+        }
+
+        #endregion
+    }
+}

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -17,7 +17,11 @@ namespace ConditioningControlPanel.Services
     /// Handles audio playback and system audio ducking.
     /// Ported from Python utils.py AudioDucker.
     /// </summary>
-    public class AudioService : IDisposable
+    /// <remarks>
+    /// One-shot clip playback, the output circuit breaker and the endpoint watcher live in
+    /// <c>Services/Audio/AudioService.Playback.cs</c>.
+    /// </remarks>
+    public partial class AudioService : IDisposable
     {
         #region Fields
 
@@ -155,8 +159,12 @@ namespace ConditioningControlPanel.Services
                 }
             }
 
+            // NOT permanent any more (#779): the circuit breaker clears this via
+            // InvalidateOutputDeviceCache when it trips and again when its cooldown expires, and
+            // the endpoint watcher clears it the moment a device comes back — so restarting the
+            // Windows Audio Endpoint Builder service recovers playback instead of needing a relaunch.
             _waveOutPermanentlyUnavailable = true;
-            App.Logger?.Warning("AudioService: no WaveOut device on this system would accept waveOutOpen ({Count} candidates tried). Audio playback disabled this session.", count);
+            App.Logger?.Warning("AudioService: no WaveOut device on this system would accept waveOutOpen ({Count} candidates tried). Audio playback paused until an endpoint returns.", count);
             return null;
         }
 
@@ -804,15 +812,20 @@ namespace ConditioningControlPanel.Services
 
                 _soundPlayer.Init(_soundFile);
                 _soundPlayer.Play();
-                
+                NoteOutputSuccess();
+
                 var duration = _soundFile.TotalTime.TotalSeconds;
                 App.Logger?.Debug("Playing sound: {Path}, duration: {Duration}s", Path.GetFileName(path), duration);
-                
+
                 return duration;
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning("Could not play sound {Path}: {Error}", path, ex.Message);
+                // Init/Play can throw with the fields already assigned — free them here rather than
+                // leaving an open device parked until the next PlaySound call (#778).
+                StopSound();
+                NoteOutputFailure("playsound", ex.Message);
                 return 0;
             }
         }
@@ -1703,6 +1716,7 @@ namespace ConditioningControlPanel.Services
             _disposed = true;
 
             StopSound();
+            ShutdownPlayback();
             _duckWatchdog?.Dispose();
             _duckRescanTimer?.Dispose();
             _restoreRetryTimer?.Dispose();

--- a/ConditioningControlPanel/Services/BubbleService.cs
+++ b/ConditioningControlPanel/Services/BubbleService.cs
@@ -1931,92 +1931,19 @@ public class BubbleService : IDisposable
         }
     }
 
-    // Performance: Pool of audio devices to avoid creating new ones for each sound
-    private static readonly Queue<WaveOutEvent> _audioDevicePool = new();
-    private static readonly object _audioPoolLock = new();
-    private const int MAX_POOLED_DEVICES = 4;
-
-    private WaveOutEvent GetPooledAudioDevice()
-    {
-        lock (_audioPoolLock)
-        {
-            if (_audioDevicePool.Count > 0)
-            {
-                return _audioDevicePool.Dequeue();
-            }
-        }
-        // Apply user's chosen output device on construction. Pool is drained when the
-        // setting changes (see DrainAudioDevicePool) so we never need to reapply on Get.
-        var w = new WaveOutEvent();
-        App.Audio?.ApplyPreferredDevice(w);
-        return w;
-    }
-
     /// <summary>
-    /// Disposes all pooled audio devices. Call after the user changes the output device
-    /// setting so the next pop-sound playback re-creates devices on the new endpoint
-    /// (DeviceNumber can't be changed once Init() has been called).
+    /// No-op kept for the settings hook: the WaveOutEvent pool this used to drain is gone.
+    /// Device selection is re-resolved by AudioService per clip, and its cache is invalidated
+    /// by the output-device setter and by the endpoint watcher (#778/#779).
     /// </summary>
-    public static void DrainAudioDevicePool()
-    {
-        lock (_audioPoolLock)
-        {
-            while (_audioDevicePool.Count > 0)
-            {
-                try { _audioDevicePool.Dequeue().Dispose(); } catch { }
-            }
-        }
-    }
-
-    private void ReturnAudioDevice(WaveOutEvent device)
-    {
-        lock (_audioPoolLock)
-        {
-            if (_audioDevicePool.Count < MAX_POOLED_DEVICES)
-            {
-                _audioDevicePool.Enqueue(device);
-            }
-            else
-            {
-                device.Dispose();
-            }
-        }
-    }
+    public static void DrainAudioDevicePool() { }
 
     private void PlaySoundAsync(string path, float volume)
     {
-        Task.Run(() =>
-        {
-            WaveOutEvent? outputDevice = null;
-            AudioFileReader? audioFile = null;
-            try
-            {
-                audioFile = new AudioFileReader(path);
-                audioFile.Volume = volume;
-
-                outputDevice = GetPooledAudioDevice();  // Performance: Reuse pooled device
-                outputDevice.Init(audioFile);
-                outputDevice.Play();
-
-                while (outputDevice.PlaybackState == PlaybackState.Playing)
-                {
-                    Thread.Sleep(50);
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning("Audio playback failed: {Error}", ex.Message);
-            }
-            finally
-            {
-                audioFile?.Dispose();
-                if (outputDevice != null)
-                {
-                    try { outputDevice.Stop(); } catch { }
-                    ReturnAudioDevice(outputDevice);  // Performance: Return to pool
-                }
-            }
-        });
+        // Pop sounds fire in bursts, which is exactly the pattern that used to park two
+        // thread-pool threads per bubble. AudioService owns the device, the concurrency cap
+        // and the disposal now (#778/#779).
+        App.Audio?.PlayOneShot(path, volume, "bubble-pop");
     }
 
     public void PopAllBubbles()
@@ -2075,14 +2002,8 @@ public class BubbleService : IDisposable
         // Close pooled bubble window shells (static pool holds hidden HWNDs for the process life).
         try { DispatcherHelper.RunOnUI(Bubble.DrainWindowPool); } catch { }
 
-        // Drain and dispose pooled audio devices (static pool persists across service restarts)
-        lock (_audioPoolLock)
-        {
-            while (_audioDevicePool.Count > 0)
-            {
-                try { _audioDevicePool.Dequeue().Dispose(); } catch { }
-            }
-        }
+        // Audio devices are no longer pooled here — AudioService owns every one-shot device
+        // and disposes it deterministically (#778/#779).
     }
 }
 

--- a/ConditioningControlPanel/Services/CalibrationSoundService.cs
+++ b/ConditioningControlPanel/Services/CalibrationSoundService.cs
@@ -42,34 +42,7 @@ namespace ConditioningControlPanel.Services
                     return;
                 }
 
-                Task.Run(() =>
-                {
-                    WaveOutEvent? device = null;
-                    AudioFileReader? reader = null;
-                    try
-                    {
-                        reader = new AudioFileReader(path) { Volume = curved };
-                        device = new WaveOutEvent();
-                        App.Audio?.ApplyPreferredDevice(device);
-                        device.Init(reader);
-                        device.Play();
-                        while (device.PlaybackState == PlaybackState.Playing)
-                            Thread.Sleep(50);
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Warning("CalibrationSoundService playback failed: {Error}", ex.Message);
-                    }
-                    finally
-                    {
-                        reader?.Dispose();
-                        if (device != null)
-                        {
-                            try { device.Stop(); } catch { }
-                            device.Dispose();
-                        }
-                    }
-                });
+                App.Audio?.PlayOneShot(path, curved, "calibration");
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Chaos/ChaosNarrator.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosNarrator.cs
@@ -105,7 +105,11 @@ public static class ChaosNarrator
     /// <summary>Force-stop ducking + clear state (run teardown).</summary>
     public static void Reset()
     {
-        try { Application.Current?.Dispatcher.Invoke(() => { _endTimer?.Stop(); }); } catch { }
+        // RunOnUI (BeginInvoke), not a blocking Invoke: Reset() is called from chaos teardown on
+        // arbitrary threads and nothing here needs a result. An unbounded cross-thread Invoke just
+        // pins the caller's thread for as long as the UI thread is busy - and permanently if it
+        // wedges, which is how one freeze cascades into thread-pool starvation (#779: threads +200).
+        try { ConditioningControlPanel.Helpers.DispatcherHelper.RunOnUI(() => { _endTimer?.Stop(); }); } catch { }
         Interlocked.Exchange(ref _busyUntilTicks, 0);
         EndDuck();
     }

--- a/ConditioningControlPanel/Services/Chaos/ChaosNarrator.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosNarrator.cs
@@ -185,25 +185,6 @@ public static class ChaosNarrator
     private static void PlayAsync(string path)
     {
         float vol = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
-        Task.Run(() =>
-        {
-            WaveOutEvent? outputDevice = null;
-            AudioFileReader? audioFile = null;
-            try
-            {
-                audioFile = new AudioFileReader(path) { Volume = vol };
-                outputDevice = new WaveOutEvent();
-                App.Audio?.ApplyPreferredDevice(outputDevice);
-                outputDevice.Init(audioFile);
-                outputDevice.Play();
-                while (outputDevice.PlaybackState == PlaybackState.Playing) Thread.Sleep(40);
-            }
-            catch (Exception ex) { App.Logger?.Warning("ChaosNarrator playback failed: {E}", ex.Message); }
-            finally
-            {
-                try { outputDevice?.Dispose(); } catch { }
-                try { audioFile?.Dispose(); } catch { }
-            }
-        });
+        App.Audio?.PlayOneShot(path, vol, "chaos-narrator");
     }
 }

--- a/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
+++ b/ConditioningControlPanel/Services/Chaos/ChaosSfx.cs
@@ -88,43 +88,13 @@ public static class ChaosSfx
         catch { return scale; }
     }
 
-    // Voice cap: each cue burns a Task.Run thread + its own WaveOutEvent for the clip's
-    // duration. "Fire rarely" stopped holding once chaos pops/subliminal payloads routed
-    // through here — WER dumps 27800 (0xc0000005) and 24012 (0xc0000409) both died with
-    // 6-15 threads inside this method mid audio storm. Excess cues are dropped, not
-    // queued: a one-shot SFX played late is worse than silence.
-    private const int MAX_VOICES = 6;
-    private static int _activeVoices;
-
+    // Voice cap: the local cap that used to live here is now enforced (globally, across every
+    // audio path in the app) by AudioService.PlayOneShot — which also owns the device lifetime,
+    // the failure circuit breaker and disposal. The old inline version burned a Task.Run thread
+    // PLUS NAudio's own playback thread for each cue; WER dumps 27800 (0xc0000005) and 24012
+    // (0xc0000409) both died with 6-15 threads inside this method mid audio storm.
     private static void PlayAsync(string path, float volume)
     {
-        if (Interlocked.Increment(ref _activeVoices) > MAX_VOICES)
-        {
-            Interlocked.Decrement(ref _activeVoices);
-            App.Logger?.Debug("ChaosSfx: voice cap ({Max}) reached, dropping {Path}", MAX_VOICES, path);
-            return;
-        }
-        Task.Run(() =>
-        {
-            WaveOutEvent? outputDevice = null;
-            AudioFileReader? audioFile = null;
-            try
-            {
-                audioFile = new AudioFileReader(path) { Volume = volume };
-                outputDevice = new WaveOutEvent();
-                App.Audio?.ApplyPreferredDevice(outputDevice);   // honour the user's output device
-                outputDevice.Init(audioFile);
-                outputDevice.Play();
-                while (outputDevice.PlaybackState == PlaybackState.Playing)
-                    Thread.Sleep(40);
-            }
-            catch (Exception ex) { App.Logger?.Warning("ChaosSfx playback failed: {E}", ex.Message); }
-            finally
-            {
-                try { outputDevice?.Dispose(); } catch { }
-                try { audioFile?.Dispose(); } catch { }
-                Interlocked.Decrement(ref _activeVoices);
-            }
-        });
+        App.Audio?.PlayOneShot(path, volume, "chaos-sfx");
     }
 }

--- a/ConditioningControlPanel/Services/Companion/CompanionPhraseService.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionPhraseService.cs
@@ -364,28 +364,16 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private void PlayAudioFile(string path)
         {
-            Task.Run(() =>
+            try
             {
-                try
-                {
-                    var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
-                    var volume = (float)Math.Pow(masterVolume, 1.5) * 0.7f;
-
-                    using var audioFile = new NAudio.Wave.AudioFileReader(path);
-                    audioFile.Volume = volume;
-                    using var outputDevice = new NAudio.Wave.WaveOutEvent();
-                    outputDevice.Init(audioFile);
-                    outputDevice.Play();
-                    while (outputDevice.PlaybackState == NAudio.Wave.PlaybackState.Playing)
-                    {
-                        System.Threading.Thread.Sleep(50);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Debug("Failed to play phrase audio: {Error}", ex.Message);
-                }
-            });
+                var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
+                var volume = (float)Math.Pow(masterVolume, 1.5) * 0.7f;
+                App.Audio?.PlayOneShot(path, volume, "phrase-audio");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Failed to play phrase audio: {Error}", ex.Message);
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
@@ -1,0 +1,611 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using SkiaSharp;
+
+namespace ConditioningControlPanel.Services.Compositor;
+
+/// <summary>
+/// The single-frame hand-off between a producer thread and a consumer thread: the producer parks
+/// the newest frame here (disposing any older one the consumer never got round to taking), and the
+/// consumer takes ownership of whatever is waiting. LATEST WINS - a consumer that falls behind
+/// skips frames rather than queueing them, which is the only sane policy for live screen content.
+///
+/// The invariants this exists to make testable (they are the whole #777 fix):
+///   * The consumer NEVER waits on the producer. <see cref="TryTake"/> is a bounded
+///     <see cref="Monitor.TryEnter"/> and returns null on a miss, at which point the caller simply
+///     redraws the frame it already owns.
+///   * Ownership transfers exactly once. A frame the consumer has taken is never disposed by the
+///     producer - <see cref="Publish"/> and <see cref="Clear"/> only ever touch a frame still
+///     sitting in the slot, and they null it under the same gate before disposing.
+///   * The critical section is a two-field pointer swap. Nothing allocating, native, or
+///     blocking is ever done while the gate is held.
+/// </summary>
+internal sealed class LatestFrameSlot<T> where T : class, IDisposable
+{
+    /// <summary>Internal purely so the contention test can hold the gate and prove that a blocked
+    /// slot makes the consumer skip a frame rather than wait. Production code never touches it.</summary>
+    internal readonly object Gate = new();
+    private T? _pending;
+
+    /// <summary>Producer. Parks <paramref name="frame"/> as the newest; any un-taken predecessor is
+    /// disposed OUTSIDE the gate (it is unreachable by then, so nothing can race the dispose).</summary>
+    public void Publish(T frame)
+    {
+        T? stale;
+        lock (Gate)
+        {
+            stale = _pending;
+            _pending = frame;
+        }
+        stale?.Dispose();
+    }
+
+    /// <summary>Consumer. Returns the newest un-taken frame and transfers ownership, or null if
+    /// there is nothing new OR the gate was busy for <paramref name="timeoutMs"/>. Never blocks
+    /// longer than that.</summary>
+    public T? TryTake(int timeoutMs)
+    {
+        if (!Monitor.TryEnter(Gate, timeoutMs)) return null;
+        try
+        {
+            var frame = _pending;
+            _pending = null;   // taken: the producer must not dispose it now
+            return frame;
+        }
+        finally { Monitor.Exit(Gate); }
+    }
+
+    /// <summary>Producer teardown. Drops (and disposes) an un-taken frame; a frame the consumer
+    /// already took is untouched, because it is no longer in the slot.</summary>
+    public void Clear()
+    {
+        T? pending;
+        lock (Gate)
+        {
+            pending = _pending;
+            _pending = null;
+        }
+        pending?.Dispose();
+    }
+}
+
+/// <summary>
+/// The desktop grab + blur that feeds <see cref="BrainDrainLayer"/>, on a thread of its own (#777).
+///
+/// WHY THIS EXISTS: the capture used to run in the layer's Update(), i.e. ON THE UI THREAD, ~30
+/// times a second: <c>GetDC(NULL)</c> then a full-screen <c>StretchBlt</c> off the LIVE DESKTOP,
+/// while the compositor's present thread was issuing <c>UpdateLayeredWindow</c> against windows on
+/// that same desktop. A blt against the desktop DC cannot be time-bounded - it serialises behind
+/// DWM, the GPU, and every other window's redraw - so a single stalled blt takes the dispatcher
+/// with it and the app is frozen with the audio still playing (#777: "both screens froze, audio
+/// still running, had to kill it from Task Manager"). Moving the call here means the worst a stall
+/// can now do is freeze THIS thread: the UI keeps running and the overlay simply holds its last
+/// frame until the blt returns.
+///
+/// THREADING CONTRACT
+///   * Everything native (screen DC, per-monitor memory DC + DIB section) and everything Skia that
+///     is written to (the small blur surface, the melt noise tile, the filter chain) is created,
+///     used and destroyed ON THIS THREAD. The UI thread never touches a GDI handle here, which is
+///     also what makes the GDI accounting in the [RES] diagnostics honest.
+///   * Output is handed over one immutable <see cref="SKImage"/> at a time through a per-monitor
+///     slot: this thread parks the newest frame in the slot (disposing any older un-taken one), the
+///     UI thread TAKES it under a short bounded <see cref="Monitor.TryEnter"/> and from then on owns
+///     it. On a lock miss (which effectively cannot happen - the critical section is a pointer swap)
+///     the UI thread just redraws the frame it already owns. NEITHER SIDE EVER WAITS ON THE OTHER.
+///   * Parameters flow the other way as plain volatile writes (sigma, melt amplitude, target
+///     screens); this thread reads them at the top of each tick. Nothing is ever pushed with a
+///     lock the UI thread could contend on.
+///
+/// TEARDOWN: <see cref="Shutdown"/> is fire-and-forget on purpose - the UI thread must NEVER join
+/// this thread, because joining a thread that is wedged in a desktop blt reproduces exactly the
+/// hang the class exists to prevent. The thread frees its own resources as its last act. If it is
+/// wedged forever the handles leak, which is the same trade LayeredCompositorHost.Close already
+/// makes (leak beats use-after-free, and beats a frozen app).
+///
+/// SELF-CAPTURE: unchanged from the UI-thread version and load-bearing. The blt is a plain SRCCOPY
+/// with NO <c>CAPTUREBLT</c>, so the desktop DC excludes layered windows outright - the brain-drain
+/// host (and every other compositor overlay) cannot feed back into the blur. The host window is
+/// additionally WDA_EXCLUDEFROMCAPTURE'd by the engine because the layer reports
+/// <c>ExcludeFromCapture</c>. Running on another thread changes neither: a GDI desktop DC is a
+/// process-wide object and the process is manifest-declared PerMonitorV2, so this thread sees the
+/// same virtual-desktop pixel geometry the UI thread did.
+/// </summary>
+internal sealed class BrainDrainCapturePump
+{
+    /// <summary>How long the UI thread will wait for the hand-off lock before giving up and
+    /// redrawing the frame it already has. The critical section is a two-field pointer swap, so
+    /// this budget exists only so that "never block the UI thread" is enforced, not hoped for.</summary>
+    private const int SwapTimeoutMs = 2;
+
+    /// <summary>A capture tick slower than this is the #777 shape happening (just harmlessly now).
+    /// Logged to the video-diag trace - the one place a future hang report can prove it.</summary>
+    private const int StallWarnMs = 400;
+    private static readonly TimeSpan StallLogCooldown = TimeSpan.FromSeconds(5);
+
+    /// <summary>One monitor's capture: its GDI staging surface (this thread) plus the hand-off
+    /// slot (shared). Bounds/W/H are written before the slot array is published and never mutated,
+    /// so the UI thread can read them without a lock.</summary>
+    private sealed class Slot
+    {
+        public readonly LatestFrameSlot<SKImage> Frame = new();   // the pump -> UI hand-off
+        public System.Drawing.Rectangle Bounds;   // monitor rect, virtual-desktop device px
+        public int W, H;                          // downscaled capture size
+        public IntPtr MemDc, HBitmap, Bits, OldObj;
+        public SKSurface? Surface;                // small blur target (pump thread only)
+    }
+
+    private readonly int _downscale;
+    private readonly TimeSpan _interval;
+    private readonly bool _melt;
+
+    private readonly Thread _thread;
+    private readonly AutoResetEvent _wake = new(false);
+    private volatile bool _stop;
+
+    // UI -> pump (volatile: read once at the top of each tick).
+    private volatile System.Drawing.Rectangle[] _requestedScreens;
+    private volatile float _sigma;
+    private volatile float _meltAmplitude;
+
+    // pump -> UI.
+    private volatile Slot[] _slots = Array.Empty<Slot>();
+
+    // Pump-thread-only state (the blur/melt chain, lifted verbatim from the old CapturePass).
+    private readonly SKPaint _blurPaint = new();
+    private SKImageFilter? _blurFilter;
+    private float _lastSigma = -1f;
+    private SKImage? _meltNoiseTile;
+    private float _meltTileCoverage;
+    private int _meltNoiseShort = -1;
+    private SKPaint? _meltNoisePaint;
+    private SKPaint? _meltPaint;
+    private int _errorsLogged;
+    private DateTime _lastStallLogUtc = DateTime.MinValue;
+    private DateTime _nextSlotRetryUtc = DateTime.MinValue;
+    private static readonly TimeSpan SlotRetryBackoff = TimeSpan.FromSeconds(1);
+
+    // Noise field constants - see BrainDrainLayer's field comments for the reasoning; they live
+    // here because this is where the turbulence is rasterised.
+    private const float NoiseCellFraction = 0.20f;
+    private const float NoiseCellAspect = 0.65f;
+    private const int NoiseOctaves = 2;
+    private const float NoiseSeed = 7f;
+    private const int NoiseTilePx = 256;
+    private const float NoiseCellsPerTile = 12f;
+    private const float MeltDriftPxPerSec = 6f;
+    private const float MeltSwayPx = 2.5f;
+    private const float MeltSwayRate = 0.55f;   // rad/s
+
+    public BrainDrainCapturePump(int downscale, TimeSpan interval, bool melt,
+                                 System.Drawing.Rectangle[] screens, float sigma, float meltAmplitude)
+    {
+        _downscale = Math.Max(1, downscale);
+        _interval = interval > TimeSpan.Zero ? interval : TimeSpan.FromMilliseconds(33);
+        _melt = melt;
+        _requestedScreens = screens ?? Array.Empty<System.Drawing.Rectangle>();
+        _sigma = sigma;
+        _meltAmplitude = meltAmplitude;
+
+        _thread = new Thread(Loop)
+        {
+            IsBackground = true,           // a wedged blt must never hold up process exit
+            Name = "BrainDrain-Capture",
+            Priority = ThreadPriority.BelowNormal,
+        };
+        _thread.Start();
+    }
+
+    /// <summary>Push the blur strength (and melt warp amplitude). UI thread; never blocks.</summary>
+    public void SetBlur(float sigma, float meltAmplitude)
+    {
+        _sigma = sigma;
+        _meltAmplitude = meltAmplitude;
+    }
+
+    /// <summary>Push the monitors to capture. The pump rebuilds its staging bitmaps on its own
+    /// thread at the next tick. UI thread; never blocks.</summary>
+    public void SetScreens(System.Drawing.Rectangle[] screens)
+    {
+        _requestedScreens = screens ?? Array.Empty<System.Drawing.Rectangle>();
+        // try/catch: the pump thread disposes the event on its way out, and a Set() that races
+        // a shutdown is a no-op, not an error the caller should ever see.
+        try { _wake.Set(); } catch { }
+    }
+
+    /// <summary>
+    /// UI thread. Reports whether the monitor containing (<paramref name="cx"/>,<paramref name="cy"/>)
+    /// is covered, and hands over the newest completed frame for it IF one is waiting - ownership
+    /// transfers to the caller, which must dispose it once it has a newer one. <paramref name="fresh"/>
+    /// is null when no new frame has landed since the last call (or on a lock miss), and the caller
+    /// is expected to redraw the frame it already holds. Never blocks for more than
+    /// <see cref="SwapTimeoutMs"/>.
+    /// </summary>
+    public bool TryTakeFrame(int cx, int cy, out SKImage? fresh, out System.Drawing.Rectangle bounds)
+    {
+        fresh = null;
+        bounds = default;
+        var slots = _slots;
+        foreach (var slot in slots)
+        {
+            if (!slot.Bounds.Contains(cx, cy)) continue;
+            bounds = slot.Bounds;
+            fresh = slot.Frame.TryTake(SwapTimeoutMs);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Stop capturing. Returns immediately - the pump thread frees its own GDI/Skia
+    /// resources on the way out. NEVER joined from the UI thread (see the class remarks).</summary>
+    public void Shutdown()
+    {
+        _stop = true;
+        try { _wake.Set(); } catch { }
+    }
+
+    // ------------------------------------------------------------------ pump thread from here on
+
+    private void Loop()
+    {
+        var phase = Stopwatch.StartNew();   // melt drift is wall-clock, owned by this thread
+        var tick = new Stopwatch();
+        try
+        {
+            while (!_stop)
+            {
+                tick.Restart();
+                try
+                {
+                    SyncSlots();
+                    if (!_stop) CaptureOnce((float)phase.Elapsed.TotalSeconds);
+                }
+                catch (Exception ex)
+                {
+                    if (++_errorsLogged <= 5)
+                        App.Logger?.Debug("BrainDrain capture pump failed: {Error}", ex.Message);
+                }
+
+                var remaining = _interval - tick.Elapsed;
+                _wake.WaitOne(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Error(ex, "BrainDrain capture pump died");
+        }
+        finally
+        {
+            ReleaseAll();
+            try { _wake.Dispose(); } catch { }
+        }
+    }
+
+    /// <summary>Rebuild the staging bitmaps when the UI thread has re-targeted the capture
+    /// (dual-monitor toggle, display topology drift). Pump thread.</summary>
+    private void SyncSlots()
+    {
+        var want = _requestedScreens;
+        var have = _slots;
+        if (want.Length == have.Length)
+        {
+            bool same = true;
+            for (int i = 0; i < want.Length; i++)
+                if (have[i].Bounds != want[i]) { same = false; break; }
+            if (same) return;
+        }
+
+        // Under GDI exhaustion CreateSlot returns null and the counts stay mismatched, so without
+        // a floor this would re-attempt DC/DIB creation at the capture cadence. Back off to ~1s,
+        // which is what the old UI-thread drift check happened to give us for free.
+        if (DateTime.UtcNow < _nextSlotRetryUtc) return;
+
+        ReleaseSlots(have);
+        _slots = Array.Empty<Slot>();
+        var built = new List<Slot>(want.Length);
+        foreach (var bounds in want)
+        {
+            var slot = CreateSlot(bounds);
+            if (slot != null) built.Add(slot);
+        }
+        _slots = built.ToArray();   // volatile publish: Bounds/W/H are already final
+        // Only a FAILED build arms the backoff, so a real topology change still re-targets on the
+        // very next tick.
+        _nextSlotRetryUtc = built.Count == want.Length ? DateTime.MinValue : DateTime.UtcNow + SlotRetryBackoff;
+    }
+
+    private Slot? CreateSlot(System.Drawing.Rectangle bounds)
+    {
+        int dw = Math.Max(2, (bounds.Width / _downscale) & ~1);
+        int dh = Math.Max(2, (bounds.Height / _downscale) & ~1);
+
+        var memDc = CreateCompatibleDC(IntPtr.Zero);
+        if (memDc == IntPtr.Zero) return null;
+
+        var bmi = new BITMAPINFOHEADER
+        {
+            biSize = Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = dw,
+            biHeight = -dh, // top-down so the pixel pointer reads row 0 first
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0, // BI_RGB
+        };
+        var hBitmap = CreateDIBSection(memDc, ref bmi, 0 /*DIB_RGB_COLORS*/, out var bits, IntPtr.Zero, 0);
+        if (hBitmap == IntPtr.Zero || bits == IntPtr.Zero)
+        {
+            if (hBitmap != IntPtr.Zero) DeleteObject(hBitmap);
+            DeleteDC(memDc);
+            return null;
+        }
+
+        var surface = SKSurface.Create(new SKImageInfo(dw, dh, SKColorType.Bgra8888, SKAlphaType.Premul));
+        if (surface == null)
+        {
+            DeleteObject(hBitmap);
+            DeleteDC(memDc);
+            return null;
+        }
+
+        return new Slot
+        {
+            Bounds = bounds,
+            W = dw,
+            H = dh,
+            MemDc = memDc,
+            HBitmap = hBitmap,
+            Bits = bits,
+            OldObj = SelectObject(memDc, hBitmap),
+            Surface = surface,
+        };
+    }
+
+    /// <summary>One capture tick: shrink every target monitor off the desktop DC, blur (and melt)
+    /// the small frames, publish them. Pump thread. Identical pixel work to the old UI-thread
+    /// CapturePass - only the thread it runs on changed.</summary>
+    private void CaptureOnce(float phaseSeconds)
+    {
+        var slots = _slots;
+        if (slots.Length == 0) return;
+
+        // Rebuild the blur filter only when the radius actually changed. The sigma pushed in is
+        // ALREADY source-space (see BrainDrainLayer.SetIntensity); dividing by the downscale again
+        // here is what once made every steady-state blur invisible.
+        float sigma = _sigma;
+        if (MathF.Abs(sigma - _lastSigma) > 0.01f)
+        {
+            _lastSigma = sigma;
+            _blurFilter?.Dispose();
+            _blurFilter = sigma > 0.05f ? SKImageFilter.CreateBlur(sigma, sigma) : null;
+            _blurPaint.ImageFilter = _blurFilter;
+        }
+
+        // Melt: compose displacement + blur into ONE chain. Only the cheap wrappers around the
+        // cached noise tile (the drifted image shader and the two filters that carry it) are
+        // rebuilt per tick; the turbulence raster itself is built once per capture size.
+        SKShader? drift = null;
+        SKImageFilter? noiseFilter = null, meltFilter = null;
+        float amplitude = _meltAmplitude;
+        float gutter = 0f;
+        if (_melt && amplitude > 0.05f)
+        {
+            var tile = EnsureNoiseTile(slots);
+            if (tile != null)
+            {
+                float tierScale = 4f / _downscale;
+                // Wrapped into one tile period: the pattern repeats there anyway, and it keeps the
+                // float drift from growing without bound over a long session.
+                float dx = MeltSwayPx * tierScale * MathF.Sin(phaseSeconds * MeltSwayRate);
+                float dy = (MeltDriftPxPerSec * tierScale * phaseSeconds) % _meltTileCoverage;
+                float s = _meltTileCoverage / NoiseTilePx;
+                drift = SKShader.CreateImage(tile, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+                                             SKMatrix.CreateScaleTranslation(s, s, dx, dy));
+                // Bilinear: a nearest-sampled noise tile would quantise the warp into visible blocks.
+                (_meltNoisePaint ??= new SKPaint { FilterQuality = SKFilterQuality.Low }).Shader = drift;
+                noiseFilter = SKImageFilter.CreatePaint(_meltNoisePaint);
+                if (noiseFilter != null)
+                {
+                    // input: _blurFilter (may be null at low intensity, where sigma is sub-pixel -
+                    // the warp still applies, it just warps the unblurred capture).
+                    meltFilter = SKImageFilter.CreateDisplacementMapEffect(
+                        SKColorChannel.R, SKColorChannel.G, amplitude, noiseFilter, _blurFilter);
+                    (_meltPaint ??= new SKPaint()).ImageFilter = meltFilter;
+                    // Displacement samples outside the source bleed transparent along the frame
+                    // edges. Max |offset| is amplitude/2 (the map is centred on 0.5), +2px slack
+                    // for the CTM scale below feeding back into the mapped displacement scale.
+                    gutter = amplitude * 0.5f + 2f;
+                }
+            }
+        }
+
+        try
+        {
+            // THE call this whole class exists to get off the UI thread. Plain SRCCOPY, no
+            // CAPTUREBLT: layered windows (every compositor overlay, including our own host) are
+            // excluded from a desktop DC blt, which is the self-capture guard.
+            var screenDc = GetDC(IntPtr.Zero);
+            if (screenDc == IntPtr.Zero) return;
+            long startTs = Stopwatch.GetTimestamp();
+            try
+            {
+                foreach (var slot in slots)
+                {
+                    if (_stop) return;
+                    if (slot.Surface == null) continue;
+                    SetStretchBltMode(slot.MemDc, HALFTONE);
+                    if (!StretchBlt(slot.MemDc, 0, 0, slot.W, slot.H,
+                                    screenDc, slot.Bounds.X, slot.Bounds.Y,
+                                    slot.Bounds.Width, slot.Bounds.Height, SRCCOPY))
+                        continue;
+                    GdiFlush();
+
+                    var info = new SKImageInfo(slot.W, slot.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
+                    using var raw = SKImage.FromPixels(info, slot.Bits, slot.W * 4); // zero-copy wrap; consumed below
+                    if (raw == null) continue;
+
+                    var canvas = slot.Surface.Canvas;
+                    canvas.Clear(SKColors.Transparent);
+                    if (meltFilter != null)
+                    {
+                        // Scale about the centre so the gutter falls off-frame entirely.
+                        canvas.Save();
+                        canvas.Translate(slot.W * 0.5f, slot.H * 0.5f);
+                        canvas.Scale((slot.W + 2f * gutter) / slot.W, (slot.H + 2f * gutter) / slot.H);
+                        canvas.Translate(-slot.W * 0.5f, -slot.H * 0.5f);
+                        canvas.DrawImage(raw, 0, 0, _meltPaint);
+                        canvas.Restore();
+                    }
+                    else
+                    {
+                        canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
+                    }
+                    slot.Frame.Publish(slot.Surface.Snapshot());
+                }
+            }
+            finally
+            {
+                ReleaseDC(IntPtr.Zero, screenDc);
+                ReportStall((Stopwatch.GetTimestamp() - startTs) * 1000.0 / Stopwatch.Frequency);
+            }
+        }
+        finally
+        {
+            // Drop the per-tick wrappers the same tick they were made (the carrier paints and the
+            // turbulence tile are the only melt state that survives to the next capture).
+            if (_meltPaint != null) _meltPaint.ImageFilter = null;
+            if (_meltNoisePaint != null) _meltNoisePaint.Shader = null;
+            meltFilter?.Dispose();
+            noiseFilter?.Dispose();
+            drift?.Dispose();
+        }
+    }
+
+    /// <summary>A tick that took this long on the UI thread WAS the #777 freeze. Here it is a
+    /// dropped frame, and a line the next hang report can be read against.</summary>
+    private void ReportStall(double ms)
+    {
+        if (ms < StallWarnMs) return;
+        var now = DateTime.UtcNow;
+        if (now - _lastStallLogUtc < StallLogCooldown) return;
+        _lastStallLogUtc = now;
+        VideoDiag.Log("BDRAIN", $"desktop capture blt took {ms:F0}ms on the capture thread " +
+                                "(would have wedged the UI thread before #777)");
+    }
+
+    /// <summary>Rasterises the tileable turbulence field for the melt warp, sized off the first
+    /// capture's short edge. Rebuilt only when that size changes (downscale change / monitor swap);
+    /// costs ~14ms once, versus ~24ms EVERY tick if the Perlin shader were evaluated live.</summary>
+    private SKImage? EnsureNoiseTile(Slot[] slots)
+    {
+        if (slots.Length == 0) return null;
+        int shortEdge = Math.Min(slots[0].W, slots[0].H);
+        if (_meltNoiseTile != null && _meltNoiseShort == shortEdge) return _meltNoiseTile;
+
+        _meltNoiseTile?.Dispose();
+        _meltNoiseTile = null;
+        _meltNoiseShort = shortEdge;
+        // One cell = NoiseCellFraction of the short edge, NoiseCellsPerTile cells to a tile.
+        _meltTileCoverage = Math.Max(8f, shortEdge * NoiseCellFraction) * NoiseCellsPerTile;
+        float freq = NoiseCellsPerTile / NoiseTilePx; // cycles per TILE px - Skia snaps it to tile
+        using var noise = SKShader.CreatePerlinNoiseTurbulence(
+            freq, freq * NoiseCellAspect, NoiseOctaves, NoiseSeed, new SKSizeI(NoiseTilePx, NoiseTilePx));
+        using var surface = SKSurface.Create(
+            new SKImageInfo(NoiseTilePx, NoiseTilePx, SKColorType.Bgra8888, SKAlphaType.Premul));
+        if (surface == null) return null;
+        using var paint = new SKPaint { Shader = noise };
+        surface.Canvas.Clear(SKColors.Transparent);
+        surface.Canvas.DrawRect(0, 0, NoiseTilePx, NoiseTilePx, paint);
+        _meltNoiseTile = surface.Snapshot();
+        return _meltNoiseTile;
+    }
+
+    /// <summary>Free every GDI + Skia object one slot array owns. Pump thread only. The un-taken
+    /// frame is cleared UNDER the slot's gate so a concurrent TryTakeFrame either got it (and owns
+    /// it) or sees null - never a disposed image.</summary>
+    private static void ReleaseSlots(Slot[] slots)
+    {
+        foreach (var slot in slots)
+        {
+            try
+            {
+                slot.Frame.Clear();
+
+                slot.Surface?.Dispose();
+                slot.Surface = null;
+                if (slot.MemDc != IntPtr.Zero)
+                {
+                    if (slot.OldObj != IntPtr.Zero) SelectObject(slot.MemDc, slot.OldObj);
+                    DeleteDC(slot.MemDc);
+                    slot.MemDc = IntPtr.Zero;
+                }
+                if (slot.HBitmap != IntPtr.Zero)
+                {
+                    DeleteObject(slot.HBitmap);
+                    slot.HBitmap = IntPtr.Zero;
+                }
+            }
+            catch { /* GDI cleanup best-effort */ }
+        }
+    }
+
+    private void ReleaseAll()
+    {
+        try
+        {
+            ReleaseSlots(_slots);
+            _slots = Array.Empty<Slot>();
+        }
+        catch { }
+        try
+        {
+            _blurPaint.ImageFilter = null;
+            _blurFilter?.Dispose();
+            _blurFilter = null;
+            _blurPaint.Dispose();
+            if (_meltPaint != null) { _meltPaint.ImageFilter = null; _meltPaint.Dispose(); _meltPaint = null; }
+            if (_meltNoisePaint != null) { _meltNoisePaint.Shader = null; _meltNoisePaint.Dispose(); _meltNoisePaint = null; }
+            _meltNoiseTile?.Dispose();
+            _meltNoiseTile = null;
+            _meltNoiseShort = -1;
+        }
+        catch { }
+    }
+
+    #region Win32
+
+    private const int SRCCOPY = 0x00CC0020;
+    private const int HALFTONE = 4;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BITMAPINFOHEADER
+    {
+        public int biSize;
+        public int biWidth;
+        public int biHeight;
+        public short biPlanes;
+        public short biBitCount;
+        public int biCompression;
+        public int biSizeImage;
+        public int biXPelsPerMeter;
+        public int biYPelsPerMeter;
+        public int biClrUsed;
+        public int biClrImportant;
+    }
+
+    [DllImport("user32.dll")] private static extern IntPtr GetDC(IntPtr hwnd);
+    [DllImport("user32.dll")] private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern bool DeleteDC(IntPtr hdc);
+    [DllImport("gdi32.dll")] private static extern IntPtr SelectObject(IntPtr hdc, IntPtr obj);
+    [DllImport("gdi32.dll")] private static extern bool DeleteObject(IntPtr obj);
+    [DllImport("gdi32.dll")] private static extern bool GdiFlush();
+    [DllImport("gdi32.dll")] private static extern int SetStretchBltMode(IntPtr hdc, int mode);
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFOHEADER pbmi, uint usage,
+        out IntPtr ppvBits, IntPtr hSection, uint offset);
+    [DllImport("gdi32.dll")]
+    private static extern bool StretchBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest,
+        IntPtr hdcSrc, int xSrc, int ySrc, int wSrc, int hSrc, int rop);
+
+    #endregion
+}

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using SkiaSharp;
 
 namespace ConditioningControlPanel.Services.Compositor;
@@ -16,24 +15,32 @@ namespace ConditioningControlPanel.Services.Compositor;
 /// Renders on the capture-EXCLUDED surface (self-capture guard); plain SRCCOPY StretchBlt also
 /// skips layered windows entirely, so other overlays never feed back into the blur (legacy same).
 /// OverlayService owns all intensity/ramp/pulse math and pushes values; this layer only
-/// captures and draws. All methods UI thread (engine tick + OverlayService RunOnUISync).
+/// captures and draws.
+///
+/// THREADING (#777): the capture and the blur run on <see cref="BrainDrainCapturePump"/>'s own
+/// thread, NOT here. A full-screen StretchBlt off the live desktop DC cannot be time-bounded, and
+/// running it on the dispatcher every ~33ms - concurrently with the compositor present thread's
+/// UpdateLayeredWindow against windows on that same desktop - is a frozen app waiting to happen
+/// (#777: both screens frozen, audio still running, killed from Task Manager). What is left on the
+/// UI thread is this class: Start/Stop/SetIntensity/Pulse (parameter pushes, all non-blocking) and
+/// Render, which takes the newest finished frame from the pump under a 2ms bounded lock and draws
+/// it. A stalled capture now costs a repeated frame, never the dispatcher.
 /// </summary>
 public sealed class BrainDrainLayer : BaseLayer
 {
-    private sealed class ScreenCapture
+    /// <summary>The frame the UI thread currently owns for one monitor. Ownership transfers from
+    /// the pump on a successful take, and nothing but the UI thread ever touches these images -
+    /// so there is no disposal race with the capture thread by construction.</summary>
+    private sealed class UiFrame
     {
-        public System.Drawing.Rectangle Bounds; // monitor rect, virtual-desktop device px
-        public int W, H;                        // downscaled capture size
-        public IntPtr MemDc, HBitmap, Bits, OldObj;
-        public SKSurface? Surface;              // small blur target
-        public SKImage? Blurred;                // latest blurred frame (drawn by Render)
+        public System.Drawing.Rectangle Bounds;
+        public SKImage? Image;
     }
 
-    private readonly List<ScreenCapture> _captures = new();
-    private readonly SKPaint _blurPaint = new();
+    private readonly List<UiFrame> _uiFrames = new();   // UI thread only
+    private BrainDrainCapturePump? _pump;
+
     private readonly SKPaint _drawPaint = new() { FilterQuality = SKFilterQuality.Low }; // bilinear = WPF Image default
-    private SKImageFilter? _blurFilter;
-    private float _lastSigma = -1f;
 
     private int _downscale = 4;
     private double _sourceRadius;               // WPF-BlurEffect-equivalent radius ON THE DOWNSCALED SOURCE
@@ -51,50 +58,21 @@ public sealed class BrainDrainLayer : BaseLayer
     // Melt variant ("braindrain_melt"): shares this layer and ALL of OverlayService's hold/ramp
     // state - a melt band and a plain blur band never co-exist by design.
     // Melt = the same blur PLUS a slowly-flowing Perlin displacement warp ("melting glass"),
-    // composed into ONE filter chain on the existing small-surface draw in CapturePass. It never
-    // touches Render: warping at monitor resolution on a CPU raster surface is not affordable, and
-    // the capture cadence (30fps default) is smooth enough for a drift this slow.
-    private bool _melt;
-    private float _meltTime;                    // seconds since Start, accumulated from Update's delta
+    // composed into ONE filter chain on the pump's small-surface draw. It never touches Render:
+    // warping at monitor resolution on a CPU raster surface is not affordable, and the capture
+    // cadence (30fps default) is smooth enough for a drift this slow. The warp's phase is wall
+    // clock owned by the pump thread, so the flow speed stays independent of both the engine tick
+    // rate and the capture cadence (it used to be accumulated from the engine's delta here). The
+    // melt FLAG itself now lives only on the pump - it is fixed for the lifetime of one run.
     private float _meltAmplitude;               // displacement scale, SOURCE px (see SetIntensity)
-    private SKImage? _meltNoiseTile;            // pre-rendered tileable turbulence (see EnsureNoiseTile)
-    private float _meltTileCoverage;            // surface px one tile spans
-    private int _meltNoiseShort = -1;           // short edge the cached tile was sized for
-    private SKPaint? _meltNoisePaint;           // carrier for the per-tick drifted noise shader
-    private SKPaint? _meltPaint;                // carrier for the per-tick displacement+blur chain
 
-    // Noise field. Turbulence cells are sized off the SMALL surface's short edge so the look holds
-    // across monitor sizes and performance tiers: one cell = 20% of the short edge (inside the
-    // 1/8..1/4 target), with the vertical frequency lowered so cells are ~1.5x taller than wide -
-    // that elongation is what reads as "dripping" rather than "boiling". 2 octaves; fixed seed so
-    // the pattern is reproducible run to run.
-    // Skia's RASTER Perlin shader is far too slow to evaluate per frame (2 octaves x 4 channels of
-    // scalar lattice noise per pixel measured 24ms/tick at 480x270 and 98ms at 960x540 - i.e. a
-    // whole core at the 30fps capture cadence). So the turbulence is rasterised ONCE into a small
-    // TILEABLE image and animated per tick by an image shader in Repeat mode; that is a SIMD
-    // bilinear fetch instead of noise evaluation and costs ~1.5ms at 480x270. The tile spans 12
-    // cells so its repeat period is wider than the frame - no visible tiling - and it is stored at
-    // a fixed 256px raster, upscaled bilinearly, which is lossless in practice because the smallest
-    // feature (the 2nd octave) is still ~10 tile px across.
-    private const float NoiseCellFraction = 0.20f;
-    private const float NoiseCellAspect = 0.65f; // freqY = freqX * this  =>  taller cells
-    private const int NoiseOctaves = 2;
-    private const float NoiseSeed = 7f;
-    private const int NoiseTilePx = 256;
-    private const float NoiseCellsPerTile = 12f;
-    // Drift, expressed at downscale 4 and divided by the actual downscale so the on-SCREEN flow
-    // speed is tier-independent: 6 source px/s downward (= 24 screen px/s at x4) plus a 2.5 px
-    // sinusoidal sway on a ~11s period. Melting is mostly gravity with a little wander.
-    private const float MeltDriftPxPerSec = 6f;
-    private const float MeltSwayPx = 2.5f;
-    private const float MeltSwayRate = 0.55f;    // rad/s
     private TimeSpan _captureInterval = TimeSpan.FromMilliseconds(33);
-    private TimeSpan _sinceCapture;
 
-    // Topology drift is rare; checking (and allocating target rects) every capture tick at
-    // 30-60Hz is pure waste. ~1s detection latency on a monitor change is imperceptible.
+    // Topology drift is rare; re-targeting the pump every engine tick at 60Hz is pure waste.
+    // ~1s detection latency on a monitor change is imperceptible.
     private static readonly TimeSpan DriftCheckInterval = TimeSpan.FromSeconds(1);
     private TimeSpan _sinceDriftCheck;
+    private System.Drawing.Rectangle[] _requestedScreens = Array.Empty<System.Drawing.Rectangle>();
 
     public BrainDrainLayer(CompositorEngine engine) : base(engine) { }
 
@@ -107,8 +85,8 @@ public sealed class BrainDrainLayer : BaseLayer
     /// Perlin displacement warp.</summary>
     public void Start(int intensity, bool melt = false)
     {
-        _melt = melt;
-        _meltTime = 0f;
+        StopPump();   // defensive: a re-Start must never strand a live capture thread
+
         var settings = App.Settings?.Current;
         var tier = PerformanceProfile.CurrentTier;
         _downscale = PerformanceProfile.BrainDrainDownscale(tier);
@@ -116,9 +94,11 @@ public sealed class BrainDrainLayer : BaseLayer
                            PerformanceProfile.BrainDrainFps(tier));
         _captureInterval = TimeSpan.FromMilliseconds(1000.0 / Math.Max(1, fps));
         SetIntensity(intensity);
-        RebuildCaptures(GetTargetScreens());
-        _sinceCapture = _captureInterval; // capture on the very first tick
-        _sinceDriftCheck = TimeSpan.Zero; // captures just rebuilt - no immediate drift check
+
+        _requestedScreens = GetTargetScreens();
+        _sinceDriftCheck = TimeSpan.Zero;   // just targeted - no immediate drift check
+        _pump = new BrainDrainCapturePump(_downscale, _captureInterval, melt,
+                                          _requestedScreens, Sigma, _meltAmplitude);
         SetActive(true);
     }
 
@@ -126,7 +106,6 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         SetActive(false);
         ReleaseCaptures();
-        _melt = false;
     }
 
     // Blur strength per intensity point, SOURCE px per unit. The legacy constant was 0.4 (radius
@@ -136,8 +115,14 @@ public sealed class BrainDrainLayer : BaseLayer
     // same constant - keep them identical.
     internal const double RadiusScale = 0.14;
 
+    /// <summary>Gaussian sigma handed to the pump. WPF's BlurEffect radius-to-sigma ratio is 3, and
+    /// <see cref="_sourceRadius"/> is ALREADY source-space (see <see cref="SetIntensity"/>) - a
+    /// second divide by the downscale here is what once made every steady-state blur invisible
+    /// (max intensity landed at sigma ~0.83px, 1..6 at literally zero).</summary>
+    private float Sigma => (float)(_sourceRadius / 3.0);
+
     /// <summary>Normal/ramp/restore path - a SOURCE-space radius (the pre-compositor BlurEffect
-    /// radius was applied to the downscaled bitmap; CapturePass turns it into sigma = radius/3).
+    /// radius was applied to the downscaled bitmap; the pump turns it into sigma = radius/3).
     /// Strength curve retuned subtle 2026-07-31, see <see cref="RadiusScale"/>.</summary>
     public void SetIntensity(int intensity)
     {
@@ -152,6 +137,7 @@ public sealed class BrainDrainLayer : BaseLayer
         // (Subtle retune 2026-07-31; the original 2 + i*0.12 read as "basically illegible".)
         // Clamped at the legacy 200 ceiling (amp 10) so a runaway value cannot eat the frame.
         _meltAmplitude = (float)((1.0 + Math.Clamp(intensity, 0, 200) * 0.045) * 4.0 / Math.Max(1, _downscale));
+        _pump?.SetBlur(Sigma, _meltAmplitude);
     }
 
     /// <summary>Pulse boost - a deliberate 1-second slam: full draw alpha and the boosted radius
@@ -163,6 +149,7 @@ public sealed class BrainDrainLayer : BaseLayer
     {
         _sourceRadius = boostedIntensity * RadiusScale / Math.Max(1, _downscale);
         _drawAlpha = 255;
+        _pump?.SetBlur(Sigma, _meltAmplitude);
     }
 
     /// <summary>Draw alpha for an intensity: <see cref="AlphaFloor"/> at 1, linear to
@@ -177,46 +164,84 @@ public sealed class BrainDrainLayer : BaseLayer
 
     public override void OnDeactivated() => ReleaseCaptures();
 
+    /// <summary>
+    /// UI thread, once per engine tick. All this does now is re-target the pump when the display
+    /// topology drifts - the capture itself is the pump thread's job and the melt phase is its wall
+    /// clock. Cheap enough that it can never be what a hang report is pointing at.
+    /// </summary>
     public override void Update(TimeSpan delta)
     {
-        _sinceCapture += delta;
         _sinceDriftCheck += delta;
-        // Wall-clock melt phase: accumulated every tick (not only on capture ticks) so the flow
-        // speed is independent of the capture cadence. No DateTime.Now - the engine owns the clock.
-        if (_melt) _meltTime += (float)delta.TotalSeconds;
-        if (_sinceCapture < _captureInterval) return;
-        _sinceCapture = TimeSpan.Zero;
+        if (_sinceDriftCheck < DriftCheckInterval) return;
+        _sinceDriftCheck = TimeSpan.Zero;
 
         try
         {
-            if (_sinceDriftCheck >= DriftCheckInterval)
-            {
-                _sinceDriftCheck = TimeSpan.Zero;
-                EnsureCapturesMatchScreens();
-            }
-            CapturePass();
+            var pump = _pump;
+            if (pump == null) return;
+            var screens = GetTargetScreens();
+            if (screens.Length == 0) return;   // display transition - keep capturing what we have
+            if (SameScreens(screens, _requestedScreens)) return;
+
+            _requestedScreens = screens;
+            pump.SetScreens(screens);
+            // The frames we hold describe monitors that may no longer exist (or have moved); drop
+            // them rather than keep stretching a stale grab over a new rectangle.
+            ReleaseUiFrames();
         }
         catch (Exception ex)
         {
-            App.Logger?.Debug("BrainDrainLayer capture failed: {Error}", ex.Message);
+            App.Logger?.Debug("BrainDrainLayer drift check failed: {Error}", ex.Message);
         }
     }
 
     public override void Render(SKCanvas canvas, SKRectI boundsPx, double dpiScale, TimeSpan elapsed)
     {
+        // BREADCRUMB: the ONLY brain-drain work still on the UI thread. The desktop StretchBlt this
+        // mark used to name moved to the capture thread in #777, so the mark moved with it - if a
+        // hang report's "last UI mark" is THIS, the wedge is the hand-off or the Skia draw, and NOT
+        // the screen grab. Two volatile writes; safe on a per-frame path.
+        using var _ = VideoDiag.UiScope("BrainDrainLayer.Render(take frame + draw)");
+
+        var pump = _pump;
+        if (pump == null) return;
+
         // World-space: boundsPx is this monitor's rect; draw only its own capture.
         int cx = (boundsPx.Left + boundsPx.Right) / 2, cy = (boundsPx.Top + boundsPx.Bottom) / 2;
+        if (!pump.TryTakeFrame(cx, cy, out var fresh, out var captureBounds)) return;
+
+        var frame = GetOrAddFrame(captureBounds);
+        if (fresh != null)
+        {
+            frame.Image?.Dispose();   // UI-thread-owned: the pump provably is not looking at it
+            frame.Image = fresh;
+        }
+        if (frame.Image == null) return;   // first tick(s): the pump has not produced one yet
+
         // Alpha mix: white-with-alpha modulates the image draw (RGB is ignored for DrawImage).
         // Set per frame - Render, SetIntensity and Pulse are all on the UI thread, so this can
         // never read a half-written value, and it keeps the ramp path free of paint bookkeeping.
         _drawPaint.Color = SKColors.White.WithAlpha(_drawAlpha);
-        foreach (var c in _captures)
-        {
-            if (c.Blurred == null || !c.Bounds.Contains(cx, cy)) continue;
-            canvas.DrawImage(c.Blurred,
-                new SKRect(c.Bounds.X, c.Bounds.Y, c.Bounds.Right, c.Bounds.Bottom), _drawPaint);
-            return;
-        }
+        canvas.DrawImage(frame.Image,
+            new SKRect(captureBounds.X, captureBounds.Y, captureBounds.Right, captureBounds.Bottom),
+            _drawPaint);
+    }
+
+    private UiFrame GetOrAddFrame(System.Drawing.Rectangle bounds)
+    {
+        foreach (var f in _uiFrames)
+            if (f.Bounds == bounds) return f;
+        var added = new UiFrame { Bounds = bounds };
+        _uiFrames.Add(added);
+        return added;
+    }
+
+    private static bool SameScreens(System.Drawing.Rectangle[] a, System.Drawing.Rectangle[] b)
+    {
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++)
+            if (a[i] != b[i]) return false;
+        return true;
     }
 
     private static System.Drawing.Rectangle[] GetTargetScreens()
@@ -233,280 +258,30 @@ public sealed class BrainDrainLayer : BaseLayer
         catch { return Array.Empty<System.Drawing.Rectangle>(); }
     }
 
-    /// <summary>Throttled (~1s) drift check so display topology / dual-monitor changes
-    /// mid-run re-target the captures without a restart.</summary>
-    private void EnsureCapturesMatchScreens()
-    {
-        var screens = GetTargetScreens();
-        if (screens.Length == 0) return; // display transition - keep last frames
-        if (screens.Length == _captures.Count)
-        {
-            bool same = true;
-            for (int i = 0; i < screens.Length; i++)
-                if (_captures[i].Bounds != screens[i]) { same = false; break; }
-            if (same) return;
-        }
-        RebuildCaptures(screens);
-    }
-
-    private void RebuildCaptures(System.Drawing.Rectangle[] screens)
-    {
-        ReleaseCaptures();
-        foreach (var bounds in screens)
-        {
-            var c = CreateCapture(bounds);
-            if (c != null) _captures.Add(c);
-        }
-    }
-
-    private ScreenCapture? CreateCapture(System.Drawing.Rectangle bounds)
-    {
-        int divisor = Math.Max(1, _downscale);
-        int dw = Math.Max(2, (bounds.Width / divisor) & ~1);
-        int dh = Math.Max(2, (bounds.Height / divisor) & ~1);
-
-        var memDc = CreateCompatibleDC(IntPtr.Zero);
-        if (memDc == IntPtr.Zero) return null;
-
-        var bmi = new BITMAPINFOHEADER
-        {
-            biSize = Marshal.SizeOf<BITMAPINFOHEADER>(),
-            biWidth = dw,
-            biHeight = -dh, // top-down so the pixel pointer reads row 0 first
-            biPlanes = 1,
-            biBitCount = 32,
-            biCompression = 0, // BI_RGB
-        };
-        var hBitmap = CreateDIBSection(memDc, ref bmi, 0 /*DIB_RGB_COLORS*/, out var bits, IntPtr.Zero, 0);
-        if (hBitmap == IntPtr.Zero || bits == IntPtr.Zero)
-        {
-            DeleteDC(memDc);
-            return null;
-        }
-
-        return new ScreenCapture
-        {
-            Bounds = bounds,
-            W = dw,
-            H = dh,
-            MemDc = memDc,
-            HBitmap = hBitmap,
-            Bits = bits,
-            OldObj = SelectObject(memDc, hBitmap),
-            Surface = SKSurface.Create(new SKImageInfo(dw, dh, SKColorType.Bgra8888, SKAlphaType.Premul)),
-        };
-    }
-
-    private void CapturePass()
-    {
-        if (_captures.Count == 0) return;
-
-        // Rebuild the blur filter only when the radius actually changed. _sourceRadius is ALREADY
-        // source-space (see SetIntensity) - dividing by _downscale again here is what made every
-        // steady-state blur invisible (max intensity landed at sigma ~0.83px, 1..6 at literally zero).
-        float sigma = (float)(_sourceRadius / 3.0);
-        if (Math.Abs(sigma - _lastSigma) > 0.01f)
-        {
-            _lastSigma = sigma;
-            _blurFilter?.Dispose();
-            _blurFilter = sigma > 0.05f ? SKImageFilter.CreateBlur(sigma, sigma) : null;
-            _blurPaint.ImageFilter = _blurFilter;
-        }
-
-        // Melt: compose displacement + blur into ONE chain. Only the cheap wrappers around the
-        // cached noise tile (the drifted image shader and the two filters that carry it) are
-        // rebuilt per tick; the turbulence raster itself is built once per capture size.
-        SKShader? drift = null;
-        SKImageFilter? noiseFilter = null, meltFilter = null;
-        float gutter = 0f;
-        if (_melt && _meltAmplitude > 0.05f)
-        {
-            var tile = EnsureNoiseTile();
-            if (tile != null)
-            {
-                float tierScale = 4f / Math.Max(1, _downscale);
-                // Wrapped into one tile period: the pattern repeats there anyway, and it keeps the
-                // float drift from growing without bound over a long session.
-                float dx = MeltSwayPx * tierScale * MathF.Sin(_meltTime * MeltSwayRate);
-                float dy = (MeltDriftPxPerSec * tierScale * _meltTime) % _meltTileCoverage;
-                float s = _meltTileCoverage / NoiseTilePx;
-                drift = SKShader.CreateImage(tile, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
-                                             SKMatrix.CreateScaleTranslation(s, s, dx, dy));
-                // Bilinear: a nearest-sampled noise tile would quantise the warp into visible blocks.
-                (_meltNoisePaint ??= new SKPaint { FilterQuality = SKFilterQuality.Low }).Shader = drift;
-                noiseFilter = SKImageFilter.CreatePaint(_meltNoisePaint);
-                if (noiseFilter != null)
-                {
-                    // input: _blurFilter (may be null at low intensity, where sigma is sub-pixel -
-                    // the warp still applies, it just warps the unblurred capture).
-                    meltFilter = SKImageFilter.CreateDisplacementMapEffect(
-                        SKColorChannel.R, SKColorChannel.G, _meltAmplitude, noiseFilter, _blurFilter);
-                    (_meltPaint ??= new SKPaint()).ImageFilter = meltFilter;
-                    // Displacement samples outside the source bleed transparent along the frame
-                    // edges. Max |offset| is amplitude/2 (the map is centred on 0.5), +2px slack
-                    // for the CTM scale below feeding back into the mapped displacement scale.
-                    gutter = _meltAmplitude * 0.5f + 2f;
-                }
-            }
-        }
-
-        try
-        {
-            // BREADCRUMB: a full-screen GDI StretchBlt off the DESKTOP DC, on the UI thread, at the
-            // capture cadence — the single heaviest native call the dispatcher makes while the
-            // compositor's present thread is issuing UpdateLayeredWindow against windows on that
-            // same desktop. If a hang report's "last UI mark" is this line, the wedge is here.
-            using var _ = VideoDiag.UiScope("BrainDrainLayer.CapturePass(StretchBlt from desktop DC)");
-            var screenDc = GetDC(IntPtr.Zero);
-            if (screenDc == IntPtr.Zero) return;
-            try
-            {
-                foreach (var c in _captures)
-                {
-                    if (c.Surface == null) continue;
-                    SetStretchBltMode(c.MemDc, HALFTONE);
-                    if (!StretchBlt(c.MemDc, 0, 0, c.W, c.H,
-                                    screenDc, c.Bounds.X, c.Bounds.Y, c.Bounds.Width, c.Bounds.Height, SRCCOPY))
-                        continue;
-                    GdiFlush();
-
-                    var info = new SKImageInfo(c.W, c.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
-                    using var raw = SKImage.FromPixels(info, c.Bits, c.W * 4); // zero-copy wrap; consumed synchronously below
-                    if (raw == null) continue;
-
-                    var canvas = c.Surface.Canvas;
-                    canvas.Clear(SKColors.Transparent);
-                    if (meltFilter != null)
-                    {
-                        // Scale about the centre so the gutter falls off-frame entirely.
-                        canvas.Save();
-                        canvas.Translate(c.W * 0.5f, c.H * 0.5f);
-                        canvas.Scale((c.W + 2f * gutter) / c.W, (c.H + 2f * gutter) / c.H);
-                        canvas.Translate(-c.W * 0.5f, -c.H * 0.5f);
-                        canvas.DrawImage(raw, 0, 0, _meltPaint);
-                        canvas.Restore();
-                    }
-                    else
-                    {
-                        canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
-                    }
-                    c.Blurred?.Dispose();
-                    c.Blurred = c.Surface.Snapshot();
-                }
-            }
-            finally
-            {
-                ReleaseDC(IntPtr.Zero, screenDc);
-            }
-        }
-        finally
-        {
-            // Drop the per-tick wrappers the same tick they were made (the carrier paints and the
-            // turbulence tile are the only melt state that survives to the next capture).
-            if (_meltPaint != null) _meltPaint.ImageFilter = null;
-            if (_meltNoisePaint != null) _meltNoisePaint.Shader = null;
-            meltFilter?.Dispose();
-            noiseFilter?.Dispose();
-            drift?.Dispose();
-        }
-    }
-
-    /// <summary>Rasterises the tileable turbulence field for the melt warp, sized off the first
-    /// capture's short edge. Rebuilt only when that size changes (downscale change / monitor swap);
-    /// costs ~14ms once, versus ~24ms EVERY tick if the Perlin shader were evaluated live.</summary>
-    private SKImage? EnsureNoiseTile()
-    {
-        if (_captures.Count == 0) return null;
-        int shortEdge = Math.Min(_captures[0].W, _captures[0].H);
-        if (_meltNoiseTile != null && _meltNoiseShort == shortEdge) return _meltNoiseTile;
-
-        _meltNoiseTile?.Dispose();
-        _meltNoiseTile = null;
-        _meltNoiseShort = shortEdge;
-        // One cell = NoiseCellFraction of the short edge, NoiseCellsPerTile cells to a tile.
-        _meltTileCoverage = Math.Max(8f, shortEdge * NoiseCellFraction) * NoiseCellsPerTile;
-        float freq = NoiseCellsPerTile / NoiseTilePx; // cycles per TILE px - Skia snaps it to tile
-        using var noise = SKShader.CreatePerlinNoiseTurbulence(
-            freq, freq * NoiseCellAspect, NoiseOctaves, NoiseSeed, new SKSizeI(NoiseTilePx, NoiseTilePx));
-        using var surface = SKSurface.Create(
-            new SKImageInfo(NoiseTilePx, NoiseTilePx, SKColorType.Bgra8888, SKAlphaType.Premul));
-        if (surface == null) return null;
-        using var paint = new SKPaint { Shader = noise };
-        surface.Canvas.Clear(SKColors.Transparent);
-        surface.Canvas.DrawRect(0, 0, NoiseTilePx, NoiseTilePx, paint);
-        _meltNoiseTile = surface.Snapshot();
-        return _meltNoiseTile;
-    }
-
-    private void ReleaseMelt()
-    {
-        if (_meltPaint != null) _meltPaint.ImageFilter = null;
-        if (_meltNoisePaint != null) _meltNoisePaint.Shader = null;
-        _meltPaint?.Dispose();
-        _meltPaint = null;
-        _meltNoisePaint?.Dispose();
-        _meltNoisePaint = null;
-        _meltNoiseTile?.Dispose();
-        _meltNoiseTile = null;
-        _meltNoiseShort = -1;
-    }
-
+    /// <summary>Tear the capture down. UI thread, and deliberately NON-BLOCKING: the pump thread
+    /// frees its own GDI handles and Skia surfaces as its last act, because joining a thread that
+    /// may be inside a stalled desktop blt would re-create the very freeze #777 is about.</summary>
     private void ReleaseCaptures()
     {
-        foreach (var c in _captures)
-        {
-            try
-            {
-                c.Blurred?.Dispose();
-                c.Surface?.Dispose();
-                if (c.MemDc != IntPtr.Zero)
-                {
-                    if (c.OldObj != IntPtr.Zero) SelectObject(c.MemDc, c.OldObj);
-                    DeleteDC(c.MemDc);
-                }
-                if (c.HBitmap != IntPtr.Zero) DeleteObject(c.HBitmap);
-            }
-            catch { /* GDI cleanup best-effort */ }
-        }
-        _captures.Clear();
-        ReleaseMelt();
+        StopPump();
+        ReleaseUiFrames();
+        _requestedScreens = Array.Empty<System.Drawing.Rectangle>();
     }
 
-    #region Win32
-
-    private const int SRCCOPY = 0x00CC0020;
-    private const int HALFTONE = 4;
-
-    [StructLayout(LayoutKind.Sequential)]
-    private struct BITMAPINFOHEADER
+    private void StopPump()
     {
-        public int biSize;
-        public int biWidth;
-        public int biHeight;
-        public short biPlanes;
-        public short biBitCount;
-        public int biCompression;
-        public int biSizeImage;
-        public int biXPelsPerMeter;
-        public int biYPelsPerMeter;
-        public int biClrUsed;
-        public int biClrImportant;
+        var pump = _pump;
+        _pump = null;
+        pump?.Shutdown();
     }
 
-    [DllImport("user32.dll")] private static extern IntPtr GetDC(IntPtr hwnd);
-    [DllImport("user32.dll")] private static extern int ReleaseDC(IntPtr hwnd, IntPtr hdc);
-    [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
-    [DllImport("gdi32.dll")] private static extern bool DeleteDC(IntPtr hdc);
-    [DllImport("gdi32.dll")] private static extern IntPtr SelectObject(IntPtr hdc, IntPtr obj);
-    [DllImport("gdi32.dll")] private static extern bool DeleteObject(IntPtr obj);
-    [DllImport("gdi32.dll")] private static extern bool GdiFlush();
-    [DllImport("gdi32.dll")] private static extern int SetStretchBltMode(IntPtr hdc, int mode);
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFOHEADER pbmi, uint usage,
-        out IntPtr ppvBits, IntPtr hSection, uint offset);
-    [DllImport("gdi32.dll")]
-    private static extern bool StretchBlt(IntPtr hdcDest, int xDest, int yDest, int wDest, int hDest,
-        IntPtr hdcSrc, int xSrc, int ySrc, int wSrc, int hSrc, int rop);
-
-    #endregion
+    private void ReleaseUiFrames()
+    {
+        foreach (var f in _uiFrames)
+        {
+            try { f.Image?.Dispose(); } catch { }
+            f.Image = null;
+        }
+        _uiFrames.Clear();
+    }
 }

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -352,6 +352,11 @@ public sealed class BrainDrainLayer : BaseLayer
 
         try
         {
+            // BREADCRUMB: a full-screen GDI StretchBlt off the DESKTOP DC, on the UI thread, at the
+            // capture cadence — the single heaviest native call the dispatcher makes while the
+            // compositor's present thread is issuing UpdateLayeredWindow against windows on that
+            // same desktop. If a hang report's "last UI mark" is this line, the wedge is here.
+            using var _ = VideoDiag.UiScope("BrainDrainLayer.CapturePass(StretchBlt from desktop DC)");
             var screenDc = GetDC(IntPtr.Zero);
             if (screenDc == IntPtr.Zero) return;
             try

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -326,6 +326,8 @@ public class CompositorEngine : IDisposable
         foreach (var screen in screens)
         {
             if (surface.ContainsKey(screen.DeviceName)) continue;
+            // Creating a layered host mid-run is the churn the class header warns about; name it.
+            using var _ = VideoDiag.UiScope($"Compositor.CreateHost({screen.DeviceName}{(excluded ? ",excluded" : "")})");
             if (_offThreadMode)
             {
                 surface[screen.DeviceName] = new LayeredCompositorHost(screen, excluded);
@@ -349,6 +351,11 @@ public class CompositorEngine : IDisposable
     /// (records an empty picture) and for prewarm.</summary>
     private void PresentSurface(Dictionary<string, ICompositorHost> surface, bool excluded)
     {
+        // Breadcrumb for the freeze reports: on the WPF-host path this is a full-screen UI-thread
+        // Skia raster (InvalidateSurface -> OnPaintSurface); on the off-thread path it records a
+        // picture and hands it over. Either way it is per-frame UI-thread work against a layered
+        // surface, so a hang that lands here has a name in the next report (VideoDiag.UiScope).
+        using var _ = VideoDiag.UiScope(excluded ? "Compositor.PresentSurface(excluded)" : "Compositor.PresentSurface(main)");
         IWpfLayer[]? layers = null;
         foreach (var host in surface.Values)
         {

--- a/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
+++ b/ConditioningControlPanel/Services/Compositor/CompositorEngine.cs
@@ -135,6 +135,50 @@ public class CompositorEngine : IDisposable
         return handles;
     }
 
+    /// <summary>One visible main-surface host: its native handle and the monitor rect it covers.</summary>
+    public readonly record struct HostAnchor(nint Hwnd, System.Drawing.Rectangle BoundsPx);
+
+    // Lock-free snapshot of the visible MAIN-surface hosts, republished on every show / hide /
+    // create / topology edge (all UI thread). Read from ANY thread — the avatar tube lives on its
+    // own dispatcher under AvatarOwnThread and must never touch the host dictionaries, but it does
+    // need to know where the host sits so it can park itself just BELOW the pink tint (#776).
+    private volatile HostAnchor[] _hostAnchors = Array.Empty<HostAnchor>();
+
+    /// <summary>
+    /// Handle of the visible main-surface host covering the given virtual-desktop device-px point,
+    /// or 0 when no host is up there. Safe from any thread (reads an immutable snapshot).
+    /// </summary>
+    public nint FindHostAnchorAt(int xPx, int yPx)
+    {
+        var anchors = _hostAnchors;
+        foreach (var a in anchors)
+            if (a.BoundsPx.Contains(xPx, yPx)) return a.Hwnd;
+        return 0;
+    }
+
+    /// <summary>Self-heal hook for the 5s z-order reconciler: re-derive the anchor snapshot in case
+    /// an edge was missed (e.g. a host whose hwnd was not realized yet when it was published).
+    /// UI thread only, like <see cref="GetVisibleHostHandles"/>.</summary>
+    public void RepublishHostAnchors() => PublishHostAnchors();
+
+    /// <summary>Republish <see cref="_hostAnchors"/> from the main-surface dictionary. UI thread
+    /// (reads _windows); call on every edge that shows, hides, creates or retargets a host.</summary>
+    private void PublishHostAnchors()
+    {
+        try
+        {
+            var list = new List<HostAnchor>(_windows.Count);
+            foreach (var host in _windows.Values)
+                if (host.IsVisible && host.WindowHandle != 0)
+                    list.Add(new HostAnchor(host.WindowHandle, host.ScreenBoundsPx));
+            _hostAnchors = list.ToArray();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("CompositorEngine: PublishHostAnchors failed: {Error}", ex.Message);
+        }
+    }
+
     /// <summary>
     /// Pay the one-time host costs (window creation, hwnd + ex-styles, Skia surface alloc, paint
     /// JIT) at startup instead of on the first effect trigger. Creates and shows the main-surface
@@ -150,6 +194,7 @@ public class CompositorEngine : IDisposable
             EnsureWindows(_windows, excluded: false);
             foreach (var w in _windows.Values)
                 if (!w.IsVisible) w.Show();
+            PublishHostAnchors();
             PresentSurface(_windows, excluded: false); // one (empty) frame realizes the surface + JIT
             Wake(); // ticks once, finds nothing active, parks + schedules the window hide
         }
@@ -272,14 +317,19 @@ public class CompositorEngine : IDisposable
     {
         if (!active) return;
         EnsureWindows(surface, excluded);
+        bool shownAny = false;
         foreach (var w in surface.Values)
         {
             if (!w.IsVisible)
             {
-                try { w.Show(); }
+                try { w.Show(); shownAny = true; }
                 catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Show failed"); }
             }
         }
+        // Edge only — the steady state must not allocate a snapshot every frame. A host that just
+        // showed re-asserted HWND_TOPMOST, so the avatar tube has to learn about it NOW or its next
+        // 500ms tick would jump back over the tint (#776).
+        if (shownAny && !excluded) PublishHostAnchors();
     }
 
     /// <summary>Arm the one-shot hide of all (idle, empty) host windows, WindowHideGrace from
@@ -306,6 +356,7 @@ public class CompositorEngine : IDisposable
                     catch (Exception ex) { App.Logger?.Error(ex, "CompositorEngine: host Hide failed"); }
                 }
             }
+            PublishHostAnchors();   // hosts gone: the tube may go back to the top of the topmost band
         };
         return t;
     }
@@ -443,6 +494,7 @@ public class CompositorEngine : IDisposable
             {
                 RebuildSurface(_windows);
                 RebuildSurface(_excludedWindows);
+                PublishHostAnchors();   // monitor rects moved / a host was torn down
                 Wake();
             }
             catch (Exception ex)
@@ -492,5 +544,6 @@ public class CompositorEngine : IDisposable
         }
         _windows.Clear();
         _excludedWindows.Clear();
+        _hostAnchors = Array.Empty<HostAnchor>();
     }
 }

--- a/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
+++ b/ConditioningControlPanel/Services/Compositor/LayeredCompositorHost.cs
@@ -98,9 +98,16 @@ internal sealed class LayeredCompositorHost : ICompositorHost
         _signal.Set();
     }
 
+    // Show/Hide/UpdateScreenBounds run on the UI thread and touch a WS_EX_LAYERED window that the
+    // present thread is concurrently blitting into with UpdateLayeredWindow. Layered-window state
+    // changes are the app's historical render-thread wedge, and none of these Win32 calls can be
+    // given a timeout — so they are breadcrumbed instead: a hang report whose "last UI mark" is one
+    // of these names the wedge outright (see VideoDiag.UiScope).
+
     public void Show()
     {
         if (_hwnd == IntPtr.Zero) return;
+        using var _ = VideoDiag.UiScope($"LayeredCompositorHost.Show({ScreenDeviceName})");
         var b = ScreenBoundsPx;
         SetWindowPos(_hwnd, HWND_TOPMOST, b.X, b.Y, b.Width, b.Height, SWP_NOACTIVATE);
         ShowWindow(_hwnd, SW_SHOWNA);
@@ -110,12 +117,14 @@ internal sealed class LayeredCompositorHost : ICompositorHost
     public void Hide()
     {
         if (_hwnd == IntPtr.Zero) return;
+        using var _ = VideoDiag.UiScope($"LayeredCompositorHost.Hide({ScreenDeviceName})");
         ShowWindow(_hwnd, SW_HIDE);
         IsVisible = false;
     }
 
     public void UpdateScreenBounds(System.Windows.Forms.Screen screen)
     {
+        using var _ = VideoDiag.UiScope($"LayeredCompositorHost.UpdateScreenBounds({ScreenDeviceName})");
         var b = screen.Bounds;
         ScreenBoundsPx = b;
         if (_hwnd != IntPtr.Zero && IsVisible)
@@ -125,6 +134,7 @@ internal sealed class LayeredCompositorHost : ICompositorHost
 
     public void Close()
     {
+        using var _ = VideoDiag.UiScope($"LayeredCompositorHost.Close({ScreenDeviceName})");
         _stop = true;
         _signal.Set();
         bool exited = false;

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -262,12 +262,13 @@ namespace ConditioningControlPanel.Services
         /// <summary>
         /// Programmatic equivalent of a mouse click on a flash window. Runs
         /// the same close + hydra-multiplication + haptic + FlashClicked
-        /// pipeline as MouseLeftButtonDown.
+        /// pipeline as MouseLeftButtonDown. Flagged as gaze-driven so hydra
+        /// can stop the self-sustaining chain (#784) — see OnFlashClicked.
         /// </summary>
         internal void GazePop(FlashWindow window)
         {
             if (window == null || window.IsFadingOut) return;
-            OnFlashClicked(window, App.Settings.Current);
+            OnFlashClicked(window, App.Settings.Current, fromGaze: true);
         }
 
         #endregion
@@ -1691,7 +1692,8 @@ namespace ConditioningControlPanel.Services
             if (!anyLayer) ReleaseLayerHook();
         }
 
-        private void OnFlashClicked(FlashWindow window, AppSettings settings)
+        /// <param name="fromGaze">True when a gaze dwell/blink popped this flash rather than the mouse.</param>
+        private void OnFlashClicked(FlashWindow window, AppSettings settings, bool fromGaze = false)
         {
             // Cancel only THIS window's lifetime — other windows keep living~ ✨
             try { window.LifetimeCts?.Cancel(); } catch { }
@@ -1707,7 +1709,14 @@ namespace ConditioningControlPanel.Services
 
             // Hydra mode: spawn 2 more when clicking (NO NEW AUDIO)
             // No global _cleanupInProgress check needed — each window has its own lifetime~ 🐍
-            if (settings.CorruptionMode)
+            // #784: a gaze pop is automatic — the dwell attractor snaps straight onto the fresh
+            // children and pops them ~1s later, so an unrestricted gaze→hydra chain feeds itself
+            // and flashes never stop spawning (the population cap only bounds how many are on
+            // screen at once, not the endless churn). Let gaze take the FIRST hop off an original
+            // flash (the documented "stare to pop = click, including hydra") and stop there;
+            // children of a gaze pop just dismiss. Mouse clicks are unchanged — a human hand is
+            // the throttle there.
+            if (settings.CorruptionMode && (!fromGaze || window.HydraGeneration == 0))
             {
                 var maxHydra = Math.Min(settings.HydraLimit, 20);
                 int currentCount;

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -2573,33 +2573,10 @@ namespace ConditioningControlPanel.Services
 
                 if (File.Exists(chimePath))
                 {
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new AudioFileReader(chimePath);
-                            using var outputDevice = new WaveOutEvent();
-                            App.Audio?.ApplyPreferredDevice(outputDevice);
-
-                            var masterVolume = App.Settings.Current.MasterVolume / 100f;
-                            var volume = (float)Math.Pow(masterVolume, 1.5) * 0.35f;
-                            audioFile.Volume = volume;
-
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-
-                            while (outputDevice.PlaybackState == PlaybackState.Playing)
-                            {
-                                Thread.Sleep(50);
-                            }
-
-                            App.Logger?.Information("🎉 Lucky Flash! 10x XP!");
-                        }
-                        catch (Exception ex)
-                        {
-                            App.Logger?.Debug("Failed to play lucky flash sound: {Error}", ex.Message);
-                        }
-                    });
+                    var masterVolume = App.Settings.Current.MasterVolume / 100f;
+                    var volume = (float)Math.Pow(masterVolume, 1.5) * 0.35f;
+                    App.Audio?.PlayOneShot(chimePath, volume, "lucky-flash");
+                    App.Logger?.Information("🎉 Lucky Flash! 10x XP!");
                 }
             }
             catch (Exception ex)
@@ -2761,6 +2738,7 @@ namespace ConditioningControlPanel.Services
 
                 sound.Init(audioFile);
                 sound.Play();
+                App.Audio?.NoteOutputSuccess();
 
                 // Only assign to fields after everything succeeded
                 _currentAudioFile = audioFile;
@@ -2774,6 +2752,7 @@ namespace ConditioningControlPanel.Services
                 sound?.Dispose();
                 audioFile?.Dispose();
                 App.Logger.Warning("Could not play sound {Path}: {Error}", path, ex.Message);
+                App.Audio?.NoteOutputFailure("flash-sound", ex.Message);
                 return 5.0;
             }
         }

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -2989,11 +2989,15 @@ namespace ConditioningControlPanel.Services
                 // Closing a layered window mid-run is the render-thread-deadlock trigger.
                 if (window.IsLoaded && _windowPool.Count < WINDOW_POOL_MAX)
                 {
+                    using var _uiMark = VideoDiag.UiScope("FlashService.HideFlashWindow(layered)");
                     window.Hide();
                     _windowPool.Push(window);
                 }
                 else
                 {
+                    // The pool-overflow branch: the comment above says it, so breadcrumb it — if a
+                    // hang report's "last UI mark" is this, the deadlock trigger fired for real.
+                    using var _uiMark = VideoDiag.UiScope("FlashService.CloseFlashWindow(layered, pool full)");
                     window.Close();
                 }
             }

--- a/ConditioningControlPanel/Services/KeywordTriggerService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerService.cs
@@ -1952,6 +1952,7 @@ namespace ConditioningControlPanel.Services
 
                     _triggerPlayer.Init(_triggerAudioFile);
                     _triggerPlayer.Play();
+                    App.Audio?.NoteOutputSuccess();
 
                     App.Logger?.Information("PlayTriggerAudio: playing '{Path}' curved={Curve:0.00} master={Master:0.00} thread={Thread}",
                         Path.GetFileName(path), curvedVolume, masterVolume, System.Threading.Thread.CurrentThread.ManagedThreadId);
@@ -1961,6 +1962,8 @@ namespace ConditioningControlPanel.Services
                 catch (Exception ex)
                 {
                     App.Logger?.Warning("PlayTriggerAudio: Error playing audio: {Error}", ex.Message);
+                    App.Audio?.NoteOutputFailure("keyword-trigger", ex.Message);
+                    StopTriggerAudio(); // Init/Play threw with the fields already assigned — free them now
                     return 0;
                 }
             }

--- a/ConditioningControlPanel/Services/LockCard/BrainDrainService.cs
+++ b/ConditioningControlPanel/Services/LockCard/BrainDrainService.cs
@@ -181,10 +181,12 @@ namespace ConditioningControlPanel.Services
         
         private void PlayAudio(string filePath)
         {
+            if (App.Audio?.IsOutputSuppressed == true) return; // endpoint down — stay quiet, don't spin
+
             try
             {
                 StopCurrentAudio();
-                
+
                 _audioReader = new AudioFileReader(filePath);
                 _audioReader.Volume = (float)(App.Settings.Current.MasterVolume / 100.0);
                 
@@ -202,10 +204,13 @@ namespace ConditioningControlPanel.Services
                 };
                 
                 _waveOut.Play();
+                App.Audio?.NoteOutputSuccess();
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "BrainDrain: Error playing audio file {Path}", filePath);
+                App.Audio?.NoteOutputFailure("braindrain", ex.Message);
+                StopCurrentAudio(); // Init/Play threw with the fields already assigned — free them now
             }
         }
         

--- a/ConditioningControlPanel/Services/LockCard/MindWipeService.cs
+++ b/ConditioningControlPanel/Services/LockCard/MindWipeService.cs
@@ -318,7 +318,11 @@ namespace ConditioningControlPanel.Services
         private void StartNextLoopPlayer()
         {
             if (!_isRunning || !_loopMode || string.IsNullOrEmpty(_loopFilePath)) return;
-            
+
+            // Endpoint is down — the crossfade loop would otherwise re-open a device every clip
+            // length forever, blocking the UI thread inside waveOutOpen each time (#778/#779).
+            if (App.Audio?.IsOutputSuppressed == true) return;
+
             try
             {
                 if (_usePlayerA)
@@ -362,10 +366,12 @@ namespace ConditioningControlPanel.Services
                 
                 // Alternate for next iteration
                 _usePlayerA = !_usePlayerA;
+                App.Audio?.NoteOutputSuccess();
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "MindWipe: Error starting loop player");
+                App.Audio?.NoteOutputFailure("mindwipe-loop", ex.Message);
             }
         }
         
@@ -515,11 +521,13 @@ namespace ConditioningControlPanel.Services
         
         private void PlayAudio(string filePath)
         {
+            if (App.Audio?.IsOutputSuppressed == true) return; // endpoint down — stay quiet, don't spin
+
             try
             {
                 // Stop any currently playing audio
                 StopCurrentAudio();
-                
+
                 _audioReader = new AudioFileReader(filePath);
                 _audioReader.Volume = (float)_volume;
 
@@ -538,10 +546,13 @@ namespace ConditioningControlPanel.Services
                 };
                 
                 _waveOut.Play();
+                App.Audio?.NoteOutputSuccess();
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "MindWipe: Error playing audio file {Path}", filePath);
+                App.Audio?.NoteOutputFailure("mindwipe", ex.Message);
+                StopCurrentAudio(); // Init/Play threw with the fields already assigned — free them now
             }
         }
         

--- a/ConditioningControlPanel/Services/MantraChantService.cs
+++ b/ConditioningControlPanel/Services/MantraChantService.cs
@@ -253,6 +253,16 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
+            // The output circuit breaker is open (endpoint dead / Windows audio restarting) —
+            // opening a device now would block on the audio-service RPC and re-arm the cooldown
+            // on every gap. Stay silent and come back on the next wait (#778/#779).
+            if (App.Audio?.IsOutputSuppressed == true)
+            {
+                _pending.Clear();      // don't resume half a mantra minutes later
+                ScheduleNext();
+                return;
+            }
+
             try
             {
                 DisposeOutput(); // release the previous clip before opening the next
@@ -263,11 +273,13 @@ namespace ConditioningControlPanel.Services
                 _output.Init(_reader);
                 _output.PlaybackStopped += OnPlaybackStopped;
                 _output.Play();
+                App.Audio?.NoteOutputSuccess();
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "MantraChantService.PlayNext failed for {Path} — moving on after the next wait.", path);
                 DisposeOutput();
+                App.Audio?.NoteOutputFailure("mantra-chant", ex.Message);
                 ScheduleNext(); // don't wedge the loop on one bad clip
             }
         }

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2462,8 +2462,16 @@ public class OverlayService : IDisposable
         try
         {
             if (App.Compositor is { } engine)
+            {
                 foreach (var hostHwnd in engine.GetVisibleHostHandles())
                     ReassertOne(hostHwnd, videoHwnd, aboveVideo, force, ref anyRecovered);
+                // The detached avatar tube parks itself directly BELOW the host covering its monitor
+                // so the pink tint stops flickering on and off the companion (#776). It does that on
+                // its OWN thread (AvatarOwnThread => cross-thread SetWindowPos is a deadlock source
+                // here), reading a lock-free anchor snapshot; refresh it now so a missed show/hide
+                // edge self-heals on this tick instead of persisting until the next one.
+                engine.RepublishHostAnchors();
+            }
         }
         catch (Exception ex)
         {
@@ -2475,19 +2483,29 @@ public class OverlayService : IDisposable
     /// <summary>One window's worth of ReassertZOrder. Normally: below the active video (#497), else
     /// topmost. When <paramref name="aboveVideo"/> (a live Deeper overlay band), the overlay is the
     /// enhanced video's own effect, so pin it to the top of the topmost band ABOVE the video instead.</summary>
-    /// <summary>Where a single overlay window should be pinned relative to a (possibly playing) video.</summary>
-    internal enum ZOrderAction { None, PinBelowVideo, PinTopmost }
+    /// <summary>Where a single topmost window should be pinned relative to a (possibly playing) video
+    /// and to the shared compositor host that carries the fullscreen effects.</summary>
+    internal enum ZOrderAction { None, PinBelowVideo, PinBelowCompositorHost, PinTopmost }
 
     /// <summary>
-    /// Pure z-order decision for one overlay window. Extracted from <see cref="ReassertOne"/> so the
+    /// Pure z-order decision for one topmost window. Extracted from <see cref="ReassertOne"/> so the
     /// Deeper-band-above-video rule (and the #497 below-video pin it must preserve) can be unit-tested.
     /// <paramref name="aboveVideo"/> — a live Deeper enhancement band, so the overlay IS the video's own
     /// effect and must sit above it; otherwise a co-existing video keeps overlays pinned just below it.
+    /// <paramref name="yieldToCompositorHost"/> — the caller is a self-raising topmost window that is
+    /// NOT a compositor layer and must live UNDER the host's effects. Only the detached avatar tube
+    /// passes this: it re-pinned itself to the top of the topmost band every 500ms while the host
+    /// re-pinned itself every 5s, so the pink tint flickered on and off the companion (#776). The tube
+    /// now inserts directly below the host instead — still topmost, still above ordinary app windows,
+    /// but permanently under the tint. Ordered AFTER the video rule so #497 can never be traded away.
     /// </summary>
-    internal static ZOrderAction ResolveZOrderAction(bool hasVideo, bool isVideoWindow, bool aboveVideo, bool needsPin, bool force)
+    internal static ZOrderAction ResolveZOrderAction(bool hasVideo, bool isVideoWindow, bool aboveVideo,
+        bool needsPin, bool force, bool yieldToCompositorHost = false)
     {
         if (hasVideo && !isVideoWindow && !aboveVideo)
             return ZOrderAction.PinBelowVideo;
+        if (yieldToCompositorHost)
+            return ZOrderAction.PinBelowCompositorHost;
         if (needsPin || force || aboveVideo)
             return ZOrderAction.PinTopmost;
         return ZOrderAction.None;
@@ -2515,6 +2533,11 @@ public class OverlayService : IDisposable
                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 if (needsPin) anyRecovered = true;
                 break;
+            // ZOrderAction.PinBelowCompositorHost is never produced here — the overlay windows and
+            // the hosts ARE the compositor's layers. It belongs to the detached avatar tube, which
+            // applies it itself in AvatarTubeWindow.ReassertTopmost: that window can live on its own
+            // dispatcher (AvatarOwnThread), and a cross-thread SetWindowPos sends WM_WINDOWPOSCHANGING
+            // synchronously — this app's documented deadlock source (#431/#451).
         }
     }
 

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2353,6 +2353,10 @@ public class OverlayService : IDisposable
     /// </summary>
     private void ReassertBounds()
     {
+        // Breadcrumb: this MOVES + RESIZES layered overlay windows (SetWindowPos with a size and
+        // SWP_SHOWWINDOW), which forces WPF to reallocate the layered surface and sync with the
+        // render thread - the shape behind this app's historical layered-window wedges.
+        using var _uiMark = VideoDiag.UiScope("OverlayService.ReassertBounds");
         // While a monitor/DPI change settles, both the screen cache and the HWND rects are in
         // flux — repositioning against stale geometry would fight the OS mid-storm (the same
         // reason the recreate path above defers). The post-settle kick heals any drift.
@@ -2424,6 +2428,11 @@ public class OverlayService : IDisposable
     /// </summary>
     private bool ReassertZOrder(bool force = false)
     {
+        // Breadcrumb: this sweeps SetWindowPos over every per-monitor layered overlay window AND
+        // every visible compositor host, on the UI thread, and NotifyTopWindowClosed forces a full
+        // pass after each mandatory video. Un-timeout-able Win32 - so name it for the next hang
+        // report instead (VideoDiag.UiScope).
+        using var _uiMark = VideoDiag.UiScope("OverlayService.ReassertZOrder");
         bool anyRecovered = false;
 
         // While a mandatory/session video is playing, keep the overlays in the topmost band but
@@ -2544,6 +2553,10 @@ public class OverlayService : IDisposable
     /// </summary>
     private void RecreateOverlays()
     {
+        // Breadcrumb: the ONE path that destroys and rebuilds every per-monitor layered overlay
+        // window mid-run. It fires 3s after a sustained topmost loss, which a closing fullscreen
+        // video reliably provokes - i.e. squarely inside the freeze window of #780.
+        using var _uiMark = VideoDiag.UiScope("OverlayService.RecreateOverlays");
         App.Logger?.Warning("Overlay topmost loss persisted for 3s — recreating overlay windows");
 
         var settings = App.Settings.Current;

--- a/ConditioningControlPanel/Services/Progression/AchievementService.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementService.cs
@@ -95,6 +95,14 @@ public class AchievementService : IDisposable
         
         // Track time-based achievements every second
         _trackingTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        // Midnight rollover FIRST, and as its own handler rather than a block inside
+        // TrackTimeBasedProgress: a throw in one multicast Tick handler suppresses the handlers
+        // after it, so keeping them separate stops either one from starving the other. Both are
+        // individually try/caught. This timer is the right host because it is created here in the
+        // constructor (App.OnStartup) and only stopped in Dispose, so it ticks for the whole app
+        // lifetime — including while completely idle, which is exactly the case the streak bug
+        // affects. SessionEngine's 1s tick was rejected: it only runs during an active session.
+        _trackingTimer.Tick += CheckDayRollover;
         _trackingTimer.Tick += TrackTimeBasedProgress;
         _trackingTimer.Start();
         
@@ -142,6 +150,61 @@ public class AchievementService : IDisposable
         }
     }
     
+    /// <summary>
+    /// Bank the login streak when the calendar day rolls over while the app is running.
+    ///
+    /// Before this existed, <see cref="AchievementProgress.LastLaunchDate"/> was only ever written
+    /// on the startup path, so a user who left their PC asleep, or who simply left CCP open across
+    /// midnight, silently lost the day (and eventually the whole streak).
+    ///
+    /// No double-count is possible: the decision is
+    /// <see cref="AchievementProgress.ShouldBankDayRollover"/> over the PERSISTED
+    /// <c>LastLaunchDate</c> — not over any timer-local bookkeeping — and the banking itself is the
+    /// same <c>UpdateDailyStreak</c> the startup path calls, which early-returns once the day is
+    /// banked. A restart at 00:05 therefore finds the day already stamped and does nothing.
+    /// Because the gate is re-derived from persisted state on every tick and never latched, a
+    /// transient failure here simply retries a second later instead of dropping the day.
+    /// </summary>
+    private void CheckDayRollover(object? sender, EventArgs e)
+    {
+        try
+        {
+            // AwardDeferredStreakBonus can surface XP/level-up UI, so don't run during teardown.
+            if (Application.Current?.Dispatcher == null) return;
+            if (Application.Current.Dispatcher.HasShutdownStarted) return;
+
+            // Cheap (two date truncations) and, crucially, stateless — see remarks above.
+            if (!_progress.TryAdvanceDayRollover()) return;
+
+            App.Logger?.Information(
+                "Login streak: day rolled over while running — banked {Date}, streak now {Days} day(s)",
+                _progress.LastLaunchDate.ToString("yyyy-MM-dd"), _progress.ConsecutiveDays);
+
+            // SyncCurrentStreak mutates settings.CurrentStreak/LastStreakDate WITHOUT saving, so it
+            // must run BEFORE Save (same ordering as ProfileSyncService.cs:932 and MergeCloudProfile).
+            _progress.SyncCurrentStreak();
+            App.Settings?.Save();
+
+            // Persist immediately rather than leaving it to the 30s auto-save: the whole point of
+            // this path is users who leave the app running, and a crash before the next auto-save
+            // would lose the banked day.
+            Save();
+
+            // Unlike the startup path (which runs before SkillTree exists and therefore defers the
+            // bonus to App.OnStartup), SkillTree is live by now, so pay it immediately. Guarded so
+            // that in the vanishingly unlikely case this fires mid-startup we leave PendingStreakBonus
+            // set for App.OnStartup rather than burning it for 0 XP.
+            if (App.SkillTree != null)
+            {
+                _progress.AwardDeferredStreakBonus();
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Error(ex, "Login streak: midnight rollover check failed");
+        }
+    }
+
     /// <summary>
     /// Track time-based progress (called every second)
     /// </summary>

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using NAudio.Wave;
+using ConditioningControlPanel.Helpers;
 
 namespace ConditioningControlPanel.Services
 {
@@ -222,7 +223,7 @@ namespace ConditioningControlPanel.Services
                     _ = App.Haptics?.TriggerSubliminalPatternAsync(text);
                     Task.Delay(250).ContinueWith(__ =>
                     {
-                        Application.Current?.Dispatcher?.Invoke(() => ShowSubliminalVisuals(text));
+                        DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(text));
                     });
                 });
 
@@ -289,7 +290,7 @@ namespace ConditioningControlPanel.Services
                     _ = App.Haptics?.TriggerSubliminalPatternAsync(text);
                     Task.Delay(250).ContinueWith(__ =>
                     {
-                        Application.Current?.Dispatcher?.Invoke(() => ShowSubliminalVisuals(text));
+                        DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(text));
                     });
                 });
 
@@ -336,7 +337,7 @@ namespace ConditioningControlPanel.Services
             var delay = _random.Next(1000, 2000);
             Task.Delay(delay).ContinueWith(_ =>
             {
-                Application.Current?.Dispatcher?.Invoke(() => PlayBambiReset());
+                DispatcherHelper.RunOnUI(() => PlayBambiReset());
             });
         }
 
@@ -356,7 +357,7 @@ namespace ConditioningControlPanel.Services
             var delay = _random.Next(4000, 8000);
             Task.Delay(delay).ContinueWith(_ =>
             {
-                Application.Current?.Dispatcher?.Invoke(() => PlayBambiReset());
+                DispatcherHelper.RunOnUI(() => PlayBambiReset());
             });
         }
 
@@ -379,7 +380,7 @@ namespace ConditioningControlPanel.Services
                     _ = App.Haptics?.TriggerSubliminalPatternAsync(resetText);
                     Task.Delay(250).ContinueWith(__ =>
                     {
-                        Application.Current?.Dispatcher?.Invoke(() => ShowSubliminalVisuals(resetText));
+                        DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(resetText));
                     });
                 });
             }
@@ -588,7 +589,7 @@ namespace ConditioningControlPanel.Services
                     await Task.Delay(anticipationMs);
 
                 // Now show on UI thread
-                Application.Current?.Dispatcher?.Invoke(() => ShowSubliminalVisuals(text, opacity, overrideDurationMs));
+                DispatcherHelper.RunOnUI(() => ShowSubliminalVisuals(text, opacity, overrideDurationMs));
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -62,8 +62,8 @@ namespace ConditioningControlPanel.Services
         private DateTime _modAudioFilesCacheTime;
         private string? _modAudioCacheModId;
 
-        private WaveOutEvent? _audioPlayer;
-        private AudioFileReader? _audioFile;
+        // The whisper device itself is owned by AudioService — this is only the stop handle.
+        private AudioPlaybackHandle? _audioHandle;
 
         private bool _isRunning;
         private bool _oneShotActive; // Allow one-shot display when service not running (remote control)
@@ -516,53 +516,49 @@ namespace ConditioningControlPanel.Services
             {
                 StopAudio();
 
-                _audioFile = new AudioFileReader(path);
-                _audioPlayer = new WaveOutEvent();
-                App.Audio?.ApplyPreferredDevice(_audioPlayer);
-
                 // Apply volume with curve, including master volume
                 var masterVol = App.Settings.Current.MasterVolume / 100.0f;
                 var subVol = App.Settings.Current.SubAudioVolume / 100.0f;
                 var curvedVol = (float)Math.Pow(subVol * masterVol, 1.5);
-                _audioFile.Volume = curvedVol;
-                
-                _audioPlayer.Init(_audioFile);
+
                 // Capture duck generation so stale callbacks after ForceUnduck are ignored
                 var duckGen = App.Audio?.DuckGeneration ?? -1;
-                _audioPlayer.PlaybackStopped += (s, e) =>
-                {
-                    // Unduck after playback + small delay
-                    Task.Delay(500).ContinueWith(_ =>
-                    {
-                        try { App.Audio?.Unduck(duckGen); }
-                        catch (Exception ex) { App.Logger?.Debug("Unduck failed in PlaybackStopped: {Error}", ex.Message); }
-                    });
-                };
-                _audioPlayer.Play();
-                // Tell the bark system a whisper is now audible so the companion won't talk over it.
-                App.Audio?.MarkWhisperAudio(_audioFile.TotalTime.TotalSeconds);
 
+                // Whispers are the highest-frequency clip in the app; the old inline WaveOutEvent
+                // was built on the UI thread, which meant NAudio posted PlaybackStopped back to the
+                // dispatcher — so the unduck AND the disposal both stalled whenever the UI was busy
+                // (#778/#779). AudioService now owns the device off-thread and guarantees the
+                // completion callback fires exactly once, including when playback is refused.
+                var handle = App.Audio?.PlayOneShot(path, curvedVol, "whisper",
+                    onStarted: duration =>
+                    {
+                        // Tell the bark system a whisper is now audible so the companion won't talk over it.
+                        App.Audio?.MarkWhisperAudio(duration.TotalSeconds);
+                    },
+                    onFinished: () =>
+                    {
+                        // Unduck after playback + small delay
+                        Task.Delay(500).ContinueWith(_ =>
+                        {
+                            try { App.Audio?.Unduck(duckGen); }
+                            catch (Exception ex) { App.Logger?.Debug("Unduck failed after whisper: {Error}", ex.Message); }
+                        });
+                    });
+
+                _audioHandle = handle;
                 App.Logger?.Debug("Playing subliminal audio: {Path}", Path.GetFileName(path));
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning("Could not play subliminal audio: {Error}", ex.Message);
-                App.Audio.Unduck();
+                App.Audio?.Unduck();
             }
         }
 
         private void StopAudio()
         {
-            try
-            {
-                _audioPlayer?.Stop();
-                _audioPlayer?.Dispose();
-                _audioFile?.Dispose();
-            }
-            catch { }
-            
-            _audioPlayer = null;
-            _audioFile = null;
+            try { _audioHandle?.Stop(); } catch { }
+            _audioHandle = null;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/UI/InteractionQueueService.cs
+++ b/ConditioningControlPanel/Services/UI/InteractionQueueService.cs
@@ -301,15 +301,34 @@ public class InteractionQueueService
         }
     }
 
+    // ------------------------------------------------------------------------------------
+    // LOCK/DISPATCHER INVERSION (freeze cluster #775/#777/#779/#780)
+    //
+    // Every caller of the two methods below holds _lock: TryStart (:94), CompleteLocked (:178,
+    // :206), RenewStuckTimeout (:380), ExtendTimeout (:298). They used to marshal with
+    // RunOnUISync, i.e. a BLOCKING cross-thread Dispatcher.Invoke — so a background caller held
+    // _lock while waiting on the UI thread, and any UI-thread TryStart/Complete/QueuedCount
+    // waiting on _lock deadlocked against it. (Video teardown calls Complete() on the UI thread
+    // on every single video end; haptics/OCR/remote-control paths call TryStart off-thread.)
+    // Only DispatcherHelper's 5-second SyncInvokeTimeout broke it, i.e. a 5-second whole-app
+    // freeze per occurrence, silently, with the UI work then abandoned.
+    //
+    // RunOnUI (BeginInvoke) removes the inversion outright: no result is needed here, the
+    // dispatcher preserves FIFO order at a given priority so a start-then-stop pair still lands
+    // in order, and this is a FIVE-MINUTE stuck detector — arming it a dispatcher turn later
+    // cannot matter. On the UI thread RunOnUI still runs inline, exactly as before.
+    // ------------------------------------------------------------------------------------
+
     /// <summary>
-    /// Starts a timer that auto-recovers from stuck interactions
+    /// Starts a timer that auto-recovers from stuck interactions. Safe to call under <see cref="_lock"/>:
+    /// never blocks on the UI thread (see the note above).
     /// </summary>
     private void StartStuckDetectionTimer(TimeSpan? timeout = null)
     {
         try
         {
             var interval = timeout ?? TimeSpan.FromMinutes(DefaultMaxInteractionMinutes);
-            DispatcherHelper.RunOnUISync(() =>
+            DispatcherHelper.RunOnUI(() =>
             {
                 StopStuckDetectionTimer();
 
@@ -327,11 +346,12 @@ public class InteractionQueueService
         }
     }
 
+    /// <summary>Disarms the stuck detector. Safe to call under <see cref="_lock"/> (see the note above).</summary>
     private void StopStuckDetectionTimer()
     {
         try
         {
-            DispatcherHelper.RunOnUISync(() =>
+            DispatcherHelper.RunOnUI(() =>
             {
                 _stuckDetectionTimer?.Stop();
                 _stuckDetectionTimer = null;

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -116,16 +116,21 @@ public static class UiHangWatchdog
                     if (!_hangLogged)
                     {
                         _hangLogged = true;
-                        App.Logger?.Error("[WATCHDOG] UI thread unresponsive for {Sec:F0}s{Phase} — likely render-thread deadlock",
-                            silence / 1000.0, started ? "" : " (never pumped — wedged during startup)");
+                        // VideoDiag.UiMarkDescription names the call the UI thread never returned
+                        // from (screen capture, layered-window Show/Hide/Close, bitmap lock). It is
+                        // "(idle)" when the wedge is somewhere uninstrumented, which is itself a
+                        // useful negative — see the breadcrumb contract in VideoDiag.
+                        string mark = VideoDiag.UiMarkDescription;
+                        App.Logger?.Error("[WATCHDOG] UI thread unresponsive for {Sec:F0}s{Phase} — likely render-thread deadlock; last UI mark: {Mark}",
+                            silence / 1000.0, started ? "" : " (never pumped — wedged during startup)", mark);
                         // Mirror into the video trace. These lines only ever went to the ROLLING
                         // Serilog file, which a post-freeze relaunch scrolls straight out of the
                         // 100-line tail a bug report attaches — the exact evidence loss VideoDiag
                         // exists to prevent (#750-#753). Log() is a no-op until VideoDiag.Start ran.
                         VideoDiag.Log("WATCHDOG", string.Format(
                             System.Globalization.CultureInfo.InvariantCulture,
-                            "UI thread unresponsive for {0:F0}s{1}",
-                            silence / 1000.0, started ? "" : " (never pumped - wedged during startup)"));
+                            "UI thread unresponsive for {0:F0}s{1} - last UI mark: {2}",
+                            silence / 1000.0, started ? "" : " (never pumped - wedged during startup)", mark));
                     }
                     if (!_dumpWritten)
                     {

--- a/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
+++ b/ConditioningControlPanel/Services/Video/DualMonitorVideoService.cs
@@ -36,6 +36,15 @@ namespace ConditioningControlPanel.Services
         private readonly object _bufferLock = new();
         private volatile bool _frameReady;
         private volatile bool _bufferValid;  // Guards buffer access across threads
+
+        /// <summary>Managed staging copy of the newest decoded frame. See
+        /// <see cref="OnCompositionTargetRendering"/>: the native buffer is never read while a
+        /// WriteableBitmap lock is held.</summary>
+        private byte[] _staging = Array.Empty<byte>();
+
+        /// <summary>Per-frame budget for <c>WriteableBitmap.TryLock</c>; a wedged render thread must
+        /// cost a frame, not the dispatcher.</summary>
+        private static readonly Duration BlitLockBudget = new(TimeSpan.FromMilliseconds(150));
         private bool _isPlaying;
         private bool _disposed;
         private Task? _playerDisposeTask;
@@ -49,10 +58,6 @@ namespace ConditioningControlPanel.Services
         // Win32 for window positioning
         [DllImport("user32.dll")]
         private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
-
-        // Win32 for memory copy (safe alternative to unsafe code)
-        [DllImport("kernel32.dll", EntryPoint = "RtlMoveMemory")]
-        private static extern void CopyMemory(IntPtr dest, IntPtr src, uint count);
 
         private static readonly IntPtr HWND_TOPMOST = new(-1);
         private const uint SWP_NOSIZE = 0x0001;
@@ -504,6 +509,16 @@ namespace ConditioningControlPanel.Services
 
             _frameReady = false;
 
+            int bufferSize;
+            Int32Rect dirtyRect;
+
+            // ---- Phase 1: native -> managed staging, under the lock, nothing that can block. ----
+            // The blit below MUST NOT run inside this lock: WriteableBitmap.Lock() waits on the WPF
+            // render thread while the LibVLC decoder parks on _bufferLock inside LockCallback, so a
+            // slow render thread wedges the decoder, player.Stop() never returns, and the teardown
+            // takes the dispatcher with it. That is the #632/#636/#687 freeze cluster; the mandatory
+            // pipeline's twin (VideoService.BlurVmemSurface.OnRendering) was split for it and this
+            // copy was missed. One extra memcpy per frame is the price of that guarantee.
             bool lockAcquired = false;
             try
             {
@@ -519,42 +534,48 @@ namespace ConditioningControlPanel.Services
                 if (!_bufferValid || _frameBuffer == IntPtr.Zero)
                     return;
 
-                var bufferSize = _videoWidth * _videoHeight * 4;
-                var dirtyRect = new Int32Rect(0, 0, (int)_videoWidth, (int)_videoHeight);
+                bufferSize = (int)(_videoWidth * _videoHeight * 4);
+                if (bufferSize <= 0) return;
+                dirtyRect = new Int32Rect(0, 0, (int)_videoWidth, (int)_videoHeight);
 
-                // Copy to each window's bitmap independently
-                // If one fails, others still update
-                foreach (var (_, bitmap, _) in windows)
-                {
-                    try
-                    {
-                        bitmap.Lock();
-                        try
-                        {
-                            CopyMemory(bitmap.BackBuffer, _frameBuffer, bufferSize);
-                            bitmap.AddDirtyRect(dirtyRect);
-                        }
-                        finally
-                        {
-                            bitmap.Unlock();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Debug("DualMonitorVideo: Frame copy error for one window: {Error}", ex.Message);
-                        // Continue to other windows
-                    }
-                }
+                if (_staging.Length < bufferSize) _staging = new byte[bufferSize];
+                Marshal.Copy(_frameBuffer, _staging, 0, bufferSize);
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("DualMonitorVideo: Frame copy error: {Error}", ex.Message);
+                App.Logger?.Debug("DualMonitorVideo: Frame snapshot error: {Error}", ex.Message);
+                return;
             }
             finally
             {
                 if (lockAcquired)
                 {
                     Monitor.Exit(_bufferLock);
+                }
+            }
+
+            // ---- Phase 2: staging -> each window's bitmap, lock released, bounded render wait. ----
+            foreach (var (_, bitmap, _) in windows)
+            {
+                try
+                {
+                    // TryLock, not Lock: Lock() has no timeout and a render thread that never drops
+                    // its read lock would take the dispatcher permanently. Drop the frame instead.
+                    if (!bitmap.TryLock(BlitLockBudget)) continue;
+                    try
+                    {
+                        Marshal.Copy(_staging, 0, bitmap.BackBuffer, bufferSize);
+                        bitmap.AddDirtyRect(dirtyRect);
+                    }
+                    finally
+                    {
+                        bitmap.Unlock();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("DualMonitorVideo: Frame copy error for one window: {Error}", ex.Message);
+                    // Continue to other windows
                 }
             }
         }

--- a/ConditioningControlPanel/Services/Video/VideoDiag.cs
+++ b/ConditioningControlPanel/Services/Video/VideoDiag.cs
@@ -137,6 +137,68 @@ namespace ConditioningControlPanel.Services
             catch { }
         }
 
+        // ------------------------------------------------------------------------------------
+        // UI-THREAD BREADCRUMB (#775/#777/#779/#780)
+        //
+        // Every one of those reports is the same shape: the dispatcher stops, nothing is logged,
+        // and the hang dump is the only evidence — because the UI thread died INSIDE a native
+        // call (a GDI screen capture, a layered-window Show/Hide/Close, a WriteableBitmap.Lock
+        // that waits on the render thread) rather than between two log statements. A trace line
+        // written on ENTRY would cost a disk queue push 60 times a second; a breadcrumb costs two
+        // volatile writes, and the watchdogs read it when the stall is already established. The
+        // next report then names the call the UI thread never returned from.
+        //
+        // CONTRACT: written ONLY by the UI thread (so the label and its timestamp cannot tear
+        // against each other in a way that matters), read by the heartbeat/watchdog threads.
+        // Scopes restore the previous label so nesting reads as the innermost active call.
+        // ------------------------------------------------------------------------------------
+
+        private static string _uiMark = "(idle)";
+        private static long _uiMarkTicks;
+
+        /// <summary>Stamp what the UI thread is about to do. UI thread only; never throws.</summary>
+        public static void UiMark(string label)
+        {
+            _uiMark = label;
+            Volatile.Write(ref _uiMarkTicks, DateTime.UtcNow.Ticks);
+        }
+
+        /// <summary>
+        /// <c>using var _ = VideoDiag.UiScope("Something.Risky");</c> — marks the UI thread as being
+        /// inside <paramref name="label"/> and restores the previous label on exit. Two volatile
+        /// writes per call, so it is safe on per-frame paths.
+        /// </summary>
+        public static UiMarkScope UiScope(string label) => new(label);
+
+        public readonly struct UiMarkScope : IDisposable
+        {
+            private readonly string _previous;
+            internal UiMarkScope(string label)
+            {
+                _previous = _uiMark;
+                UiMark(label);
+            }
+            public void Dispose() => UiMark(_previous);
+        }
+
+        /// <summary>"Compositor.Show (entered 41213ms ago)" — what the UI thread was last doing, for
+        /// the stall lines. Safe from any thread.</summary>
+        public static string UiMarkDescription
+        {
+            get
+            {
+                try
+                {
+                    var mark = _uiMark;
+                    var at = Volatile.Read(ref _uiMarkTicks);
+                    if (at == 0) return mark;
+                    long ageMs = (DateTime.UtcNow.Ticks - at) / TimeSpan.TicksPerMillisecond;
+                    return $"{mark} (entered {ageMs}ms ago)";
+                }
+                catch { return "(unknown)"; }
+            }
+        }
+
         /// <summary>Last <paramref name="maxLines"/> lines of the trace, for the bug report attachment.</summary>
         public static string Tail(int maxLines)
         {
@@ -257,7 +319,11 @@ namespace ConditioningControlPanel.Services
                         if (stall >= t && lastReported < t)
                         {
                             lastReported = t;
-                            Log("UI", $"dispatcher UNRESPONSIVE for {stall}ms (no posted callback has run)");
+                            // The breadcrumb is the whole point of this line now: a stall with
+                            // "last UI mark: Compositor.Present" reads completely differently from
+                            // one with "(idle)" (nothing instrumented was running - look at the
+                            // slow-op tracer instead).
+                            Log("UI", $"dispatcher UNRESPONSIVE for {stall}ms (no posted callback has run) - last UI mark: {UiMarkDescription}");
                             break;
                         }
                     }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -2996,6 +2996,15 @@ namespace ConditioningControlPanel.Services
             private bool _disposed;
             private bool _bufferReleased;
 
+            /// <summary>Per-frame budget for <c>WriteableBitmap.TryLock</c>. Long enough that an
+            /// ordinarily busy render thread still gets its frame through (a fullscreen Gaussian
+            /// pass measures in tens of ms), short enough that a WEDGED one costs a frame instead
+            /// of the dispatcher. See the call site in <see cref="OnRendering"/>.</summary>
+            private const int BlitLockBudgetMs = 150;
+            private static readonly Duration BlitLockBudget =
+                new(TimeSpan.FromMilliseconds(BlitLockBudgetMs));
+            private bool _blitLockTimeoutLogged;
+
             /// <summary>The player whose vmem callbacks feed this surface (set in Attach). CloseAll
             /// uses it to pair the surface with the player's Stop() task, which owns the moment the
             /// native frame buffer becomes safe to free.</summary>
@@ -3189,11 +3198,26 @@ namespace ConditioningControlPanel.Services
 
                     var bmp = new WriteableBitmap((int)bw, (int)bh, 96, 96, PixelFormats.Bgr32, null);
                     bool applied;
-                    lock (_bufferLock)
+                    // BOUNDED, like the per-frame blit (:TryEnter 8ms) and Dispose (:TryEnter 250ms):
+                    // this was the last plain `lock (_bufferLock)` left on the UI thread, and since
+                    // 6.6.3 CloseAll no longer waits for Stop() on this path, a decoder thread parked
+                    // in LockCallback/FormatCallback (i.e. the wedged-Stop state the quarantine path
+                    // exists for) can now still be holding this lock long after the surface's video
+                    // ended. An unbounded wait here would hand that native wedge the dispatcher.
+                    // Dropping the rebuild is safe: the geometry the decoder is producing is stale by
+                    // definition once a newer format callback lands, and OnRendering's dimension guard
+                    // skips frames until a rebuild does land.
+                    if (!Monitor.TryEnter(_bufferLock, 250))
+                    {
+                        Diag($"bitmap rebuild dropped ({bw}x{bh}, gen {gen}) - _bufferLock still held by a native callback after 250ms");
+                        return;
+                    }
+                    try
                     {
                         applied = IsRebuildCurrent(gen, _formatGeneration);
                         if (applied) _bitmap = bmp;
                     }
+                    finally { Monitor.Exit(_bufferLock); }
                     if (!applied)
                     {
                         Diag($"stale bitmap rebuild dropped at swap ({bw}x{bh}, gen {gen} superseded)");
@@ -3330,8 +3354,23 @@ namespace ConditioningControlPanel.Services
                 // blit crosses a human-visible stall, plus the very first frame. ----
                 try
                 {
+                    using var _ = VideoDiag.UiScope("BlurVmemSurface.Blit(WriteableBitmap.TryLock)");
                     long lockStart = Environment.TickCount64;
-                    bmp.Lock();
+                    // TryLock, NOT Lock: WriteableBitmap.Lock() has no timeout and waits on the WPF
+                    // RENDER thread to drop its read lock. A render thread that never drops it (the
+                    // "likely render-thread deadlock" every #775/#777/#779/#780 report ends on, and
+                    // the CWGXBitmapLockState::LockRead stack a previous hang dump caught) therefore
+                    // takes the dispatcher with it, permanently and silently. A dropped frame is
+                    // always the better trade: the decoder keeps running and the next frame retries.
+                    if (!bmp.TryLock(BlitLockBudget))
+                    {
+                        if (!_blitLockTimeoutLogged)
+                        {
+                            _blitLockTimeoutLogged = true;
+                            Diag($"frame DROPPED - WriteableBitmap.TryLock timed out after {BlitLockBudgetMs}ms (render thread is not releasing its read lock)");
+                        }
+                        return;
+                    }
                     try
                     {
                         Marshal.Copy(staging, 0, bmp.BackBuffer, bytes);

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -2679,7 +2679,48 @@ namespace ConditioningControlPanel.Services
             // memory callbacks (SetVideoFormat + SetVideoCallbacks) instead of a VideoView; it must
             // happen BEFORE Play() below, same as attaching a VideoView.
             if (useBlur)
+            {
                 blurSurface!.Attach(mediaPlayer);
+
+                // #786: the vmem format callback reports the CODED frame size with the sample aspect
+                // ratio dropped, so an anamorphic clip's buffer is the wrong SHAPE and drawing it at
+                // its own pixel aspect widened the picture until it filled the screen. The media's
+                // video track carries the SAR, but only once the ES is enumerated - which is after
+                // the first format callback. Push it in whenever it becomes available; the surface
+                // re-lays-out idempotently. Subscribed BEFORE Play() so a fast start can't outrun it.
+                var aspectTarget = blurSurface!;
+                var aspectPlayer = mediaPlayer;
+                void PushTrackAspect()
+                {
+                    try
+                    {
+                        var tracks = aspectPlayer.Media?.Tracks;
+                        if (tracks == null) return;
+                        foreach (var track in tracks)
+                        {
+                            if (track.TrackType != TrackType.Video) continue;
+                            var v = track.Data.Video;
+                            bool transposed = v.Orientation is VideoOrientation.LeftTop
+                                or VideoOrientation.LeftBottom
+                                or VideoOrientation.RightTop
+                                or VideoOrientation.RightBottom;
+                            double aspect = DisplayAspectFrom(v.Width, v.Height, v.SarNum, v.SarDen, transposed);
+                            if (aspect > 0)
+                            {
+                                aspectTarget.SetSourceAspect(aspect, $"track {v.Width}x{v.Height} sar {v.SarNum}:{v.SarDen}");
+                                return;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Debug("VideoService: video-track aspect probe failed: {Error}", ex.Message);
+                    }
+                }
+                mediaPlayer.Playing += (s, e) => PushTrackAspect();
+                mediaPlayer.ESSelected += (s, e) => PushTrackAspect();
+                mediaPlayer.Vout += (s, e) => PushTrackAspect();
+            }
             else
                 videoView!.MediaPlayer = mediaPlayer;
             VideoDiag.Log("VIDEO", $"win[{tag}]: surface attached +{winSw.ElapsedMilliseconds}ms");
@@ -2846,6 +2887,63 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// True DISPLAY aspect (w/h) of a video track: the coded frame size corrected by the sample
+        /// aspect ratio, and transposed when the track carries a 90°/270° rotation (LibVLC rotates
+        /// the vmem buffer for us via video_format_ApplyRotation, but the track still reports the
+        /// pre-rotation size). Returns 0 when the numbers can't describe a real frame.
+        ///
+        /// #786: the vmem format callback hands us the CODED size with the SAR already dropped, so
+        /// an anamorphic clip (non-square pixels) arrived as, say, 640x368 when its real display
+        /// shape is much taller — and rendering that buffer at its own pixel aspect stretched the
+        /// picture sideways until it filled the screen. Never derive the on-screen shape from the
+        /// buffer when the track can tell us the truth. Pure — unit-tested.
+        /// </summary>
+        internal static double DisplayAspectFrom(uint width, uint height, uint sarNum, uint sarDen, bool transposed)
+        {
+            if (width == 0 || height == 0) return 0;
+            double num = width * (sarNum > 0 ? sarNum : 1u);
+            double den = height * (sarDen > 0 ? sarDen : 1u);
+            if (den <= 0) return 0;
+            double aspect = num / den;
+            if (transposed) aspect = 1.0 / aspect;
+            if (double.IsNaN(aspect) || double.IsInfinity(aspect) || aspect <= 0) return 0;
+            // Sanity fence: real clips live well inside 16:1 .. 1:16. Anything outside is a garbage
+            // SAR and must fall back to the buffer aspect rather than produce a sliver of video.
+            if (aspect > 16.0 || aspect < 1.0 / 16.0) return 0;
+            return aspect;
+        }
+
+        /// <summary>
+        /// Largest rect of <paramref name="aspect"/> (w/h) that fits inside the container —
+        /// i.e. letterbox or pillarbox, never stretch. Returns (0,0) when there is nothing sane to
+        /// fit yet. Pure — unit-tested.
+        /// </summary>
+        internal static (double W, double H) FitToAspect(double containerW, double containerH, double aspect)
+        {
+            if (containerW <= 0 || containerH <= 0 || aspect <= 0 ||
+                double.IsNaN(aspect) || double.IsInfinity(aspect)) return (0, 0);
+
+            double w = containerW;
+            double h = containerW / aspect;
+            if (h > containerH)
+            {
+                h = containerH;
+                w = containerH * aspect;
+            }
+            return (w, h);
+        }
+
+        /// <summary>
+        /// Whether the blurred fill is worth paying for: bars only appear when the video's display
+        /// aspect differs from the screen's by more than the tolerance. Pure — unit-tested.
+        /// </summary>
+        internal static bool NeedsBlurFill(double videoAspect, double screenAspect)
+        {
+            if (videoAspect <= 0 || screenAspect <= 0) return false;
+            return Math.Abs(videoAspect / screenAspect - 1.0) > 0.03;
+        }
+
+        /// <summary>
         /// Byte size of one BGRA frame of the given geometry, or 0 if the geometry is absurd
         /// (overflow / zero side). A bogus format callback must make the blit SKIP the frame, never
         /// allocate or copy on a garbage length. Pure — unit-tested.
@@ -2983,6 +3081,7 @@ namespace ConditioningControlPanel.Services
             private readonly ImageBrush _bgBrush;
             private readonly Image _foreground;
             private readonly System.Windows.Shapes.Rectangle _scrim;
+            private readonly Grid _hostGrid;
 
             // Set from the video-format callback once the decoder reports the real frame size.
             private uint _w;
@@ -3020,6 +3119,21 @@ namespace ConditioningControlPanel.Services
             // #687: stamped by every FormatCallback (under _bufferLock, so it is paired with _w/_h).
             // A rebuild posted to the dispatcher applies only if its stamp is still the newest.
             private int _formatGeneration;
+
+            // #786: the two aspects that decide the on-screen shape.
+            //   _bufferAspect — what the LATEST format callback reported (coded size, SAR dropped).
+            //                   Re-stamped by every callback so a mid-stream resolution change
+            //                   re-lays-out instead of leaving a stale rect behind.
+            //   _trueAspect   — the SAR-corrected DISPLAY aspect from the media's video track, 0
+            //                   until the track is enumerated. Authoritative when known: an
+            //                   anamorphic clip's buffer aspect is simply the wrong shape.
+            // Written on the UI thread, read from the decoder thread inside FormatCallback, hence
+            // Volatile (doubles are not guaranteed atomic on 32-bit, but this process is x64 and a
+            // torn read here would only mis-log one line).
+            private double _bufferAspect;
+            private double _trueAspect;
+            private string _aspectSource = "buffer";
+            private bool _geometryLogged;
 
             // Delegates handed to native LibVLC — kept in fields so the GC can't collect them
             // while libvlc still holds the pointers (the callbacks fire for the whole playback).
@@ -3079,6 +3193,12 @@ namespace ConditioningControlPanel.Services
 
                 // Sharp centred video: same frame, aspect-fit. Margins are transparent so the
                 // blurred fill shows through where the bars would otherwise be black.
+                //
+                // #786: Stretch.Uniform here fits the BITMAP's pixel aspect, which is only the right
+                // shape when the vmem buffer happens to have square pixels. It is the safe default
+                // until the real display aspect is known; ApplyGeometry then switches this to an
+                // explicitly sized Stretch.Fill rect computed from that aspect, so an anamorphic or
+                // padded buffer can never be drawn stretched.
                 _foreground = new Image
                 {
                     Stretch = Stretch.Uniform,
@@ -3090,6 +3210,11 @@ namespace ConditioningControlPanel.Services
                 grid.Children.Add(_background);
                 grid.Children.Add(_scrim);
                 grid.Children.Add(_foreground);
+                // The window is created at full screen bounds and then re-pinned to the monitor's
+                // physical bounds (ForceFullScreenBounds), so the fit rect has to be recomputed when
+                // the host resizes — otherwise the first layout's numbers stick.
+                grid.SizeChanged += (_, __) => ApplyGeometry();
+                _hostGrid = grid;
                 Root = grid;
             }
 
@@ -3141,23 +3266,31 @@ namespace ConditioningControlPanel.Services
                     gen = ++_formatGeneration; // stamped with the geometry it belongs to
                 }
 
-                // Bars appear when the video aspect differs from the screen aspect. Only then do we
-                // pay for the blurred fill; a clip that already fills the screen shows just the sharp
-                // layer (which covers everything at Uniform == the whole screen).
-                double videoAspect = vh > 0 ? (double)vw / vh : _screenAspect;
-                bool needsBlur = Math.Abs(videoAspect / _screenAspect - 1.0) > 0.03;
+                // Bars appear when the video's DISPLAY aspect differs from the screen aspect. Only
+                // then do we pay for the blurred fill; a clip that already fills the screen shows
+                // just the sharp layer.
+                //
+                // #786: this used to read the aspect straight off the callback's dims. Those are the
+                // coded dims with the SAR dropped, and LibVLC re-reports them mid-setup (640x368 four
+                // times, then 640x386), so the decision flip-flopped AND the shape it was deciding
+                // about was not the shape the clip should have. The authoritative number is the
+                // track's SAR-corrected aspect when we have it; the buffer aspect is the fallback.
+                // Both the decision and the layout are recomputed from scratch on every callback.
+                double bufferAspect = (vw > 0 && vh > 0) ? (double)vw / vh : 0;
+                double effectiveAspect = EffectiveAspect(bufferAspect);
+                bool needsBlur = NeedsBlurFill(effectiveAspect, _screenAspect);
 
-                App.Logger?.Information("VideoService: blurred-background format cb — video {VW}x{VH}, buffer {BW}x{BH}, blurFill={Blur}",
-                    vw, vh, bw, bh, needsBlur);
+                App.Logger?.Information("VideoService: blurred-background format cb — video {VW}x{VH}, buffer {BW}x{BH}, displayAspect={AR:0.000} ({Src}), blurFill={Blur}",
+                    vw, vh, bw, bh, effectiveAspect, Volatile.Read(ref _trueAspect) > 0 ? "track" : "buffer", needsBlur);
                 // Runs on a LibVLC decoder thread — enqueue only, never touch the disk or the UI here.
                 // blurFill=true arms the fullscreen Gaussian; in 6.5.0 it ran every frame over the LIVE
                 // per-frame bitmap and that was the freeze (#616-#623/#632/#636/#687). It now runs over
                 // a small frozen snapshot instead, but the trace still records when it is armed.
-                Diag($"format cb - video {vw}x{vh}, buffer {bw}x{bh}, blurFill={needsBlur}");
+                Diag($"format cb - video {vw}x{vh}, buffer {bw}x{bh}, displayAspect={effectiveAspect:0.000}, blurFill={needsBlur}");
 
                 var disp = Application.Current?.Dispatcher;
                 if (disp != null && !disp.HasShutdownStarted)
-                    disp.BeginInvoke(new Action(() => RebuildBitmap(gen, bw, bh, needsBlur)));
+                    disp.BeginInvoke(new Action(() => RebuildBitmap(gen, bw, bh, bufferAspect)));
 
                 return 1; // one plane (RV32)
             }
@@ -3176,7 +3309,7 @@ namespace ConditioningControlPanel.Services
             /// decoder behind it. The stamp is re-checked INSIDE _bufferLock so the swap is atomic with
             /// respect to a format callback that lands while this rebuild is mid-flight.
             /// </summary>
-            private void RebuildBitmap(int gen, uint bw, uint bh, bool needsBlur)
+            private void RebuildBitmap(int gen, uint bw, uint bh, double bufferAspect)
             {
                 if (_disposed) return;
                 try
@@ -3201,20 +3334,118 @@ namespace ConditioningControlPanel.Services
                     }
 
                     _foreground.Source = bmp;
-                    _needsBlur = needsBlur;
-                    _background.Visibility = needsBlur ? Visibility.Visible : Visibility.Collapsed;
-                    _scrim.Visibility = needsBlur ? Visibility.Visible : Visibility.Collapsed;
+
+                    // #786: re-stamp the buffer aspect from THIS callback and re-derive both the blur
+                    // decision and the fit rect. Every callback lands a complete layout; nothing is
+                    // carried over from the previous geometry.
+                    if (bufferAspect > 0 && Math.Abs(Volatile.Read(ref _bufferAspect) - bufferAspect) >= 0.0005)
+                    {
+                        Volatile.Write(ref _bufferAspect, bufferAspect);
+                        _geometryLogged = false; // the reported shape moved - trace the new fit once
+                    }
+                    ApplyGeometry();
 
                     // The fill is fed by RefreshBackgroundSnapshot, NOT by this bitmap (#687). Drop the
                     // old snapshot so the next frame rebuilds it at the new geometry immediately.
                     _snapW = 0;
                     _snapH = 0;
                     _frameCounter = 0;
-                    if (!needsBlur) _bgBrush.ImageSource = null;
                 }
                 catch (Exception ex)
                 {
                     App.Logger?.Debug("BlurVmemSurface: bitmap rebuild failed: {Error}", ex.Message);
+                }
+            }
+
+            /// <summary>
+            /// The aspect the picture must actually be drawn at: the track's SAR-corrected display
+            /// aspect when it is known, else the buffer's own pixel aspect, else the screen's (so a
+            /// surface with no information yet is never sized to nonsense). Callable from any thread.
+            /// </summary>
+            private double EffectiveAspect(double bufferAspect)
+            {
+                double t = Volatile.Read(ref _trueAspect);
+                if (t > 0) return t;
+                if (bufferAspect > 0) return bufferAspect;
+                double b = Volatile.Read(ref _bufferAspect);
+                return b > 0 ? b : _screenAspect;
+            }
+
+            /// <summary>
+            /// The SAR-corrected display aspect read off the media's video track, pushed in once the
+            /// track is enumerated (it is not available when the first format callback fires). Safe
+            /// to call repeatedly and from any thread — it marshals to the UI thread and only
+            /// re-lays-out when the number actually changed.
+            /// </summary>
+            public void SetSourceAspect(double aspect, string source)
+            {
+                if (aspect <= 0 || _disposed) return;
+                var disp = Application.Current?.Dispatcher;
+                if (disp == null || disp.HasShutdownStarted) return;
+                disp.BeginInvoke(new Action(() =>
+                {
+                    if (_disposed) return;
+                    if (Math.Abs(Volatile.Read(ref _trueAspect) - aspect) < 0.0005) return;
+                    Volatile.Write(ref _trueAspect, aspect);
+                    _aspectSource = source;
+                    _geometryLogged = false; // the shape changed - say so once with the new numbers
+                    ApplyGeometry();
+                }));
+            }
+
+            /// <summary>
+            /// Size the sharp layer to the largest rect of the video's true display aspect that fits
+            /// this screen, and arm the blurred fill only when that leaves bars. UI thread only.
+            ///
+            /// #786: the sharp layer used to rely on Stretch.Uniform against the WriteableBitmap,
+            /// which fits the BUFFER's pixel aspect. LibVLC's vmem callback reports the coded frame
+            /// size with the sample-aspect-ratio already dropped, so an anamorphic clip was drawn at
+            /// the wrong shape — widened until it filled the screen. Computing the rect ourselves
+            /// from the display aspect makes the fit independent of whatever geometry the decoder
+            /// happens to report, and re-running it on every format callback, aspect update and
+            /// resize makes repeated callbacks idempotent instead of leaving a stale rect.
+            /// </summary>
+            private void ApplyGeometry()
+            {
+                if (_disposed) return;
+                try
+                {
+                    double aspect = EffectiveAspect(0);
+                    bool needsBlur = NeedsBlurFill(aspect, _screenAspect);
+
+                    _needsBlur = needsBlur;
+                    _background.Visibility = needsBlur ? Visibility.Visible : Visibility.Collapsed;
+                    _scrim.Visibility = needsBlur ? Visibility.Visible : Visibility.Collapsed;
+                    if (!needsBlur) _bgBrush.ImageSource = null;
+
+                    double cw = _hostGrid.ActualWidth;
+                    double ch = _hostGrid.ActualHeight;
+                    var (fw, fh) = FitToAspect(cw, ch, aspect);
+                    if (fw <= 0 || fh <= 0)
+                    {
+                        // No usable container size yet (first layout pass). Fall back to WPF's own
+                        // aspect-preserving fit rather than pinning a bogus rect — still never a
+                        // stretch, just possibly the buffer's aspect for a frame or two.
+                        _foreground.Stretch = Stretch.Uniform;
+                        _foreground.Width = double.NaN;
+                        _foreground.Height = double.NaN;
+                        return;
+                    }
+
+                    _foreground.Stretch = Stretch.Fill;   // exact, because the rect below IS the fit
+                    _foreground.Width = fw;
+                    _foreground.Height = fh;
+
+                    if (!_geometryLogged)
+                    {
+                        _geometryLogged = true;
+                        Diag($"fit {fw:0}x{fh:0} in {cw:0}x{ch:0} at displayAspect {aspect:0.000} " +
+                             $"({_aspectSource}; screen {_screenAspect:0.000}), blurFill={needsBlur}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("BlurVmemSurface: geometry apply failed: {Error}", ex.Message);
                 }
             }
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -6583,28 +6583,9 @@ namespace ConditioningControlPanel.Services
 
                 if (File.Exists(popPath))
                 {
-                    Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new AudioFileReader(popPath);
-                            // Apply master volume to attention target pop sound
-                            var masterVolume = App.Settings?.Current?.MasterVolume ?? 100;
-                            audioFile.Volume = 0.6f * (masterVolume / 100f);
-                            using var outputDevice = new WaveOutEvent();
-                            App.Audio?.ApplyPreferredDevice(outputDevice);
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-                            while (outputDevice.PlaybackState == PlaybackState.Playing)
-                            {
-                                Thread.Sleep(50);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            App.Logger?.Debug("Pop sound playback failed: {Error}", ex.Message);
-                        }
-                    });
+                    // Apply master volume to attention target pop sound
+                    var masterVolume = App.Settings?.Current?.MasterVolume ?? 100;
+                    App.Audio?.PlayOneShot(popPath, 0.6f * (masterVolume / 100f), "target-pop");
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
@@ -922,31 +922,16 @@ namespace ConditioningControlPanel
             var masterVolume = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
             var bubblesVolume = (App.Settings?.Current?.BubblesVolume ?? 50) / 100f;
 
-            Task.Run(() =>
+            try
             {
-                try
-                {
-                    var soundsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds", "bubbles");
-                    var popFiles = new[] { "Pop.mp3", "Pop2.mp3", "Pop3.mp3" };
-                    var popPath = Path.Combine(soundsPath, popFiles[soundIndex]);
+                var soundsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds", "bubbles");
+                var popFiles = new[] { "Pop.mp3", "Pop2.mp3", "Pop3.mp3" };
+                var popPath = Path.Combine(soundsPath, popFiles[soundIndex]);
 
-                    if (!File.Exists(popPath)) return;
-
-                    var volume = (float)Math.Pow(masterVolume * bubblesVolume, 1.5);
-
-                    using var audioFile = new AudioFileReader(popPath);
-                    audioFile.Volume = volume;
-                    using var outputDevice = new WaveOutEvent();
-                    App.Audio?.ApplyPreferredDevice(outputDevice);
-                    outputDevice.Init(audioFile);
-                    outputDevice.Play();
-                    while (outputDevice.PlaybackState == PlaybackState.Playing)
-                    {
-                        Thread.Sleep(50);
-                    }
-                }
-                catch { }
-            });
+                var volume = (float)Math.Pow(masterVolume * bubblesVolume, 1.5);
+                App.Audio?.PlayOneShot(popPath, volume, "bubblecount-pop");
+            }
+            catch { }
         }
 
         private void OnVideoEnded()

--- a/ConditioningControlPanel/Windows/PopQuizWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/PopQuizWindow.xaml.cs
@@ -202,28 +202,7 @@ namespace ConditioningControlPanel
                 var master = (App.Settings?.Current?.MasterVolume ?? 100) / 100f;
                 var volume = (float)Math.Pow(master * 0.5f, 1.5);
 
-                Task.Run(() =>
-                {
-                    WaveOutEvent? output = null;
-                    AudioFileReader? reader = null;
-                    try
-                    {
-                        reader = new AudioFileReader(path) { Volume = volume };
-                        output = new WaveOutEvent();
-                        App.Audio?.ApplyPreferredDevice(output);
-                        output.Init(reader);
-                        output.Play();
-                        while (output.PlaybackState == PlaybackState.Playing)
-                            System.Threading.Thread.Sleep(50);
-                    }
-                    catch { }
-                    finally
-                    {
-                        reader?.Dispose();
-                        try { output?.Stop(); } catch { }
-                        output?.Dispose();
-                    }
-                });
+                App.Audio?.PlayOneShot(path, volume, "popquiz-chime");
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Windows/QuizWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/QuizWindow.xaml.cs
@@ -1114,76 +1114,16 @@ namespace ConditioningControlPanel
 
         // ============ AUDIO ============
 
-        private static WaveOutEvent GetPooledDevice()
-        {
-            lock (_audioPoolLock)
-            {
-                if (_audioPool.Count > 0)
-                    return _audioPool.Dequeue();
-            }
-            // Pool is drained when user changes output device (DrainAudioDevicePool),
-            // so we only need to apply on construction.
-            var w = new WaveOutEvent();
-            App.Audio?.ApplyPreferredDevice(w);
-            return w;
-        }
-
         /// <summary>
-        /// Disposes pooled audio devices. Call after the user changes the output device
-        /// setting so the next quiz sound re-creates devices on the new endpoint.
+        /// No-op kept for the settings hook: the WaveOutEvent pool this used to drain is gone.
+        /// AudioService re-resolves the output device per clip and invalidates its own cache
+        /// on the setting change and on endpoint churn (#778/#779).
         /// </summary>
-        public static void DrainAudioDevicePool()
-        {
-            lock (_audioPoolLock)
-            {
-                while (_audioPool.Count > 0)
-                {
-                    try { _audioPool.Dequeue().Dispose(); } catch { }
-                }
-            }
-        }
-
-        private static void ReturnDevice(WaveOutEvent device)
-        {
-            lock (_audioPoolLock)
-            {
-                if (_audioPool.Count < MAX_POOLED_DEVICES)
-                    _audioPool.Enqueue(device);
-                else
-                    device.Dispose();
-            }
-        }
+        public static void DrainAudioDevicePool() { }
 
         private static void PlaySoundAsync(string path, float volume)
         {
-            Task.Run(() =>
-            {
-                WaveOutEvent? outputDevice = null;
-                AudioFileReader? audioFile = null;
-                try
-                {
-                    audioFile = new AudioFileReader(path) { Volume = volume };
-                    outputDevice = GetPooledDevice();
-                    outputDevice.Init(audioFile);
-                    outputDevice.Play();
-
-                    while (outputDevice.PlaybackState == PlaybackState.Playing)
-                        Thread.Sleep(50);
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Debug("Quiz audio playback failed: {Error}", ex.Message);
-                }
-                finally
-                {
-                    audioFile?.Dispose();
-                    if (outputDevice != null)
-                    {
-                        try { outputDevice.Stop(); } catch { }
-                        ReturnDevice(outputDevice);
-                    }
-                }
-            });
+            App.Audio?.PlayOneShot(path, volume, "quiz-sfx");
         }
 
         private static float GetVolume(float multiplier = 1f)

--- a/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.cs
@@ -139,29 +139,9 @@ namespace ConditioningControlPanel
                 var soundPath = soundPaths.FirstOrDefault(File.Exists);
                 if (soundPath != null)
                 {
-                    System.Threading.Tasks.Task.Run(() =>
-                    {
-                        try
-                        {
-                            using var audioFile = new AudioFileReader(soundPath);
-                            using var outputDevice = new WaveOutEvent();
-                            App.Audio?.ApplyPreferredDevice(outputDevice);
-
-                            var masterVolume = App.Settings.Current.MasterVolume / 100f;
-                            var curvedVolume = (float)Math.Pow(masterVolume, 1.5) * 0.35f;
-                            audioFile.Volume = Math.Max(0.01f, curvedVolume);
-
-                            outputDevice.Init(audioFile);
-                            outputDevice.Play();
-
-                            while (outputDevice.PlaybackState == PlaybackState.Playing)
-                                System.Threading.Thread.Sleep(50);
-                        }
-                        catch (Exception ex)
-                        {
-                            App.Logger?.Debug("Failed to play completion sound: {Error}", ex.Message);
-                        }
-                    });
+                    var masterVolume = App.Settings.Current.MasterVolume / 100f;
+                    var curvedVolume = (float)Math.Pow(masterVolume, 1.5) * 0.35f;
+                    App.Audio?.PlayOneShot(soundPath, Math.Max(0.01f, curvedVolume), "session-complete");
                 }
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
@@ -195,10 +195,17 @@ queued lock-card can't start on top of the retry video); they `ExtendTimeout(300
 1. **Blurred-background composite (DEFAULT in 6.5.0, `VideoBlurredBackgroundEnabled`)** — a
    `BlurVmemSurface` (`:2200`): LibVLC memory (vmem) callbacks fill a native buffer; a
    `CompositionTarget.Rendering` tick blits it into a `WriteableBitmap` shown twice — a Gaussian-blurred
-   `UniformToFill` fill behind + a sharp `Uniform` video in front — so an aspect-mismatched clip fills
+   `UniformToFill` fill behind + a sharp aspect-fit video in front — so an aspect-mismatched clip fills
    the bars with a blurred copy of itself (TikTok/Shorts look). The blur fill auto-hides when the video
-   already matches the screen aspect (`needsBlur`, `:2339`). Buffer dims come from `ComputeBufferDims`
-   (`:2148`, long side capped 1080). Frame-liveness guarded by `StartBlurFrameWatchdog` (`:2166`).
+   already matches the screen aspect (`needsBlur`). Buffer dims come from `ComputeBufferDims`
+   (long side capped 1080). Frame-liveness guarded by `StartBlurFrameWatchdog`.
+   **#786 — never size the picture off the vmem buffer.** The format callback reports the *coded*
+   frame size with the sample-aspect-ratio dropped, and LibVLC re-reports it mid-setup with different
+   numbers (640x368 x4, then 640x386). `BlurVmemSurface.ApplyGeometry` therefore computes an explicit
+   fit rect (`FitToAspect`) from the **display** aspect — `DisplayAspectFrom(track W, H, SarNum,
+   SarDen, rotated)`, pushed in from `Playing`/`ESSelected`/`Vout`, with the buffer aspect only as a
+   fallback — and re-runs on every format callback, aspect update and resize. The sharp layer is
+   `Stretch.Fill` inside that rect, so an anamorphic clip can never be drawn stretched.
 2. **Classic `VideoView` (HwndHost airspace)** — used when blur is off. A native child HWND; a
    transparent WPF click overlay sits above it to catch clicks (LibVLC's child window bypasses WPF
    events). Guarded by `StartVoutWatchdog`.

--- a/Tests/ConditioningControlPanel.Tests/BlurSurfaceFrameTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BlurSurfaceFrameTests.cs
@@ -136,4 +136,128 @@ public class BlurSurfaceFrameTests
 
         Assert.False(IsRebuildCurrent(postedGen, current));
     }
+
+    // ---- #786: display aspect vs buffer aspect ----
+
+    [Fact]
+    public void DisplayAspect_SquarePixelsIsJustWidthOverHeight()
+    {
+        Assert.Equal(16.0 / 9.0, DisplayAspectFrom(1920, 1080, 1, 1, false), 5);
+        Assert.Equal(640.0 / 368.0, DisplayAspectFrom(640, 368, 1, 1, false), 5);
+    }
+
+    [Fact]
+    public void DisplayAspect_AppliesTheSampleAspectRatio()
+    {
+        // The #786 shape: an anamorphic clip whose coded frame is nothing like its display frame.
+        // Reading the buffer's own pixel aspect (1.739) drew it far too wide.
+        Assert.Equal(0.87, DisplayAspectFrom(640, 368, 1, 2, false), 2);
+        // Classic DVD: 720x480 storage, 32:27 pixels -> 16:9 on screen.
+        Assert.Equal(16.0 / 9.0, DisplayAspectFrom(720, 480, 32, 27, false), 3);
+    }
+
+    [Fact]
+    public void DisplayAspect_ZeroSarIsTreatedAsSquare()
+    {
+        // libvlc reports 0:0 for "unspecified"; that must mean square pixels, not a divide by zero.
+        Assert.Equal(640.0 / 368.0, DisplayAspectFrom(640, 368, 0, 0, false), 5);
+    }
+
+    [Fact]
+    public void DisplayAspect_RotatedTracksAreTransposed()
+    {
+        // A 90-degree-rotated 1920x1080 phone clip presents as 1080x1920; LibVLC rotates the vmem
+        // buffer but the track still reports the pre-rotation size.
+        Assert.Equal(1080.0 / 1920.0, DisplayAspectFrom(1920, 1080, 1, 1, true), 5);
+    }
+
+    [Fact]
+    public void DisplayAspect_GarbageIsRejectedSoTheBufferAspectWins()
+    {
+        Assert.Equal(0, DisplayAspectFrom(0, 368, 1, 1, false));
+        Assert.Equal(0, DisplayAspectFrom(640, 0, 1, 1, false));
+        Assert.Equal(0, DisplayAspectFrom(640, 368, 100, 1, false));   // 174:1, not a real clip
+        Assert.Equal(0, DisplayAspectFrom(640, 368, 1, 100, false));   // 1:57
+    }
+
+    // ---- #786: the fit rect (letterbox / pillarbox, never stretch) ----
+
+    [Fact]
+    public void Fit_PillarboxesAClipNarrowerThanTheScreen()
+    {
+        var (w, h) = FitToAspect(1920, 1080, 9.0 / 16.0);
+        Assert.Equal(1080, h, 3);            // height-limited
+        Assert.Equal(607.5, w, 3);
+        Assert.Equal(9.0 / 16.0, w / h, 5);  // aspect preserved exactly
+    }
+
+    [Fact]
+    public void Fit_LetterboxesAClipWiderThanTheScreen()
+    {
+        var (w, h) = FitToAspect(1920, 1080, 2.39);
+        Assert.Equal(1920, w, 3);            // width-limited
+        Assert.Equal(1920 / 2.39, h, 3);
+        Assert.True(h < 1080);
+    }
+
+    [Fact]
+    public void Fit_NeverExceedsTheContainerAndNeverStretches()
+    {
+        foreach (var aspect in new[] { 0.5, 0.75, 1.0, 1.333, 1.739, 1.778, 2.35 })
+        {
+            var (w, h) = FitToAspect(1920, 1080, aspect);
+            Assert.True(w <= 1920.001 && h <= 1080.001);
+            Assert.Equal(aspect, w / h, 5);
+        }
+    }
+
+    [Fact]
+    public void Fit_NoContainerYetYieldsNothingRatherThanABogusRect()
+    {
+        Assert.Equal((0d, 0d), FitToAspect(0, 1080, 1.778));
+        Assert.Equal((0d, 0d), FitToAspect(1920, 0, 1.778));
+        Assert.Equal((0d, 0d), FitToAspect(1920, 1080, 0));
+        Assert.Equal((0d, 0d), FitToAspect(1920, 1080, double.NaN));
+    }
+
+    // ---- #786: the blur-fill decision is a pure function of the two aspects ----
+
+    [Fact]
+    public void BlurFill_ArmsOnlyWhenBarsWouldShow()
+    {
+        double screen = 16.0 / 9.0;
+        Assert.False(NeedsBlurFill(1.778, screen));           // exact match
+        Assert.False(NeedsBlurFill(640.0 / 368.0, screen));   // 1.739, inside the 3% tolerance
+        Assert.True(NeedsBlurFill(640.0 / 386.0, screen));    // 1.658, outside it
+        Assert.True(NeedsBlurFill(9.0 / 16.0, screen));       // vertical clip
+    }
+
+    [Fact]
+    public void BlurFill_UnknownAspectDoesNotArmTheGaussian()
+    {
+        Assert.False(NeedsBlurFill(0, 16.0 / 9.0));
+        Assert.False(NeedsBlurFill(1.778, 0));
+    }
+
+    [Fact]
+    public void RepeatedFormatCallbacks_EachOneFullyDeterminesTheLayout()
+    {
+        // The #786 trace: 640x368 four times, then 640x386 twice, for one playback. Because the fit
+        // is recomputed from the LATEST dims every time, replaying the sequence in any order lands
+        // the same rect for the same dims - no stale layout survives a callback.
+        double screen = 16.0 / 9.0;
+        var seen = new List<(double W, double H)>();
+        foreach (var (vw, vh) in new List<(double, double)> { (640, 368), (640, 368), (640, 368), (640, 368), (640, 386), (640, 386) })
+            seen.Add(FitToAspect(1920, 1080, vw / vh));
+
+        Assert.Equal(seen[0], seen[3]);   // same dims -> identical layout, idempotent
+        Assert.Equal(seen[4], seen[5]);
+        Assert.NotEqual(seen[0], seen[4]);
+
+        // And neither one is ever a stretch: both fit inside the screen at their own aspect.
+        Assert.Equal(640.0 / 368.0, seen[0].W / seen[0].H, 5);
+        Assert.Equal(640.0 / 386.0, seen[4].W / seen[4].H, 5);
+        Assert.False(NeedsBlurFill(640.0 / 368.0, screen));
+        Assert.True(NeedsBlurFill(640.0 / 386.0, screen));
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/BrainDrainFrameHandoffTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrainDrainFrameHandoffTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using ConditioningControlPanel.Services.Compositor;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #777 — the brain-drain desktop capture moved off the UI thread, and <see cref="LatestFrameSlot{T}"/>
+/// is the seam it moved across. The freeze being fixed was a full-screen StretchBlt off the live
+/// desktop DC running ON the dispatcher; the fix is only worth anything if the new hand-off cannot
+/// re-introduce a wait, a leak, or a double free. Those three properties are what is asserted here
+/// (the GDI capture itself needs a real desktop and is verified in play-test).
+/// </summary>
+public class BrainDrainFrameHandoffTests
+{
+    private sealed class Frame : IDisposable
+    {
+        public readonly int Id;
+        public int DisposeCount;
+        public bool Disposed => DisposeCount > 0;
+        public Frame(int id) => Id = id;
+        public void Dispose() => Interlocked.Increment(ref DisposeCount);
+    }
+
+    // ---- latest-wins ----
+
+    [Fact]
+    public void ConsumerGetsTheNewestFrame_AndTheSkippedOneIsFreed()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        var first = new Frame(1);
+        var second = new Frame(2);
+
+        slot.Publish(first);
+        slot.Publish(second);      // consumer never came for #1
+
+        var taken = slot.TryTake(2);
+
+        Assert.Same(second, taken);
+        Assert.True(first.Disposed);      // skipped frames are freed by the producer, not leaked
+        Assert.False(second.Disposed);
+    }
+
+    [Fact]
+    public void FallingBehindSkipsFrames_ItNeverQueuesThem()
+    {
+        // A capture thread running while the UI is busy: 50 frames produced, one consumed. Exactly
+        // one frame is live at any moment, and the other 49 are freed - if this queued instead, a
+        // 30fps full-screen capture would balloon memory during any UI stall.
+        var slot = new LatestFrameSlot<Frame>();
+        var frames = new Frame[50];
+        for (int i = 0; i < frames.Length; i++)
+        {
+            frames[i] = new Frame(i);
+            slot.Publish(frames[i]);
+        }
+
+        var taken = slot.TryTake(2);
+
+        Assert.Same(frames[^1], taken);
+        for (int i = 0; i < frames.Length - 1; i++)
+            Assert.True(frames[i].Disposed, $"frame {i} leaked");
+    }
+
+    // ---- ownership transfers exactly once ----
+
+    [Fact]
+    public void ATakenFrameIsNeverDisposedByTheProducer()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        var taken = new Frame(1);
+        slot.Publish(taken);
+        Assert.Same(taken, slot.TryTake(2));
+
+        slot.Publish(new Frame(2));   // producer moves on
+        slot.Clear();                 // ...then tears the slot down
+
+        Assert.False(taken.Disposed); // the consumer owns it; double-freeing it would be a native AV
+    }
+
+    [Fact]
+    public void NothingNewMeansNull_SoTheConsumerRedrawsWhatItHas()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        slot.Publish(new Frame(1));
+
+        Assert.NotNull(slot.TryTake(2));
+        Assert.Null(slot.TryTake(2));   // a capture cadence slower than the render tick
+        Assert.Null(slot.TryTake(2));
+    }
+
+    [Fact]
+    public void TeardownFreesAnUntakenFrame()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        var orphan = new Frame(1);
+        slot.Publish(orphan);
+
+        slot.Clear();
+
+        Assert.True(orphan.Disposed);
+        Assert.Equal(1, orphan.DisposeCount);
+        Assert.Null(slot.TryTake(2));
+    }
+
+    // ---- the consumer never waits (the whole point of #777) ----
+
+    [Fact]
+    public void AContendedSlotMakesTheConsumerSkip_NotBlock()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        var held = new Frame(1);
+        slot.Publish(held);
+
+        var holding = new ManualResetEventSlim(false);
+        var release = new ManualResetEventSlim(false);
+        var hog = Task.Run(() =>
+        {
+            lock (slot.Gate)      // stand in for a producer mid-swap
+            {
+                holding.Set();
+                release.Wait(5000);
+            }
+        });
+        Assert.True(holding.Wait(5000));
+
+        var sw = Stopwatch.StartNew();
+        var taken = slot.TryTake(2);
+        sw.Stop();
+
+        release.Set();
+        hog.Wait(5000);
+
+        Assert.Null(taken);   // skipped this frame rather than waiting on the capture thread
+        Assert.True(sw.ElapsedMilliseconds < 250,
+            $"TryTake blocked for {sw.ElapsedMilliseconds}ms on a busy slot - on the UI thread that " +
+            "is the #777 freeze coming back through the front door.");
+    }
+
+    // ---- concurrent hammering: no double free, no leak ----
+
+    [Fact]
+    public void ProducerAndConsumerRacing_LeaveEveryFrameFreedExactlyOnce()
+    {
+        var slot = new LatestFrameSlot<Frame>();
+        const int Count = 5000;
+        var produced = new Frame[Count];
+        Frame? lastTaken = null;
+
+        var producer = Task.Run(() =>
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                produced[i] = new Frame(i);
+                slot.Publish(produced[i]);
+            }
+        });
+
+        var consumer = Task.Run(() =>
+        {
+            while (!producer.IsCompleted)
+            {
+                var f = slot.TryTake(2);
+                if (f == null) continue;
+                lastTaken?.Dispose();   // the consumer frees the frame it is replacing
+                lastTaken = f;
+            }
+            var tail = slot.TryTake(2);
+            if (tail != null) { lastTaken?.Dispose(); lastTaken = tail; }
+        });
+
+        Task.WaitAll(new[] { producer, consumer }, 30000);
+        slot.Clear();
+        lastTaken?.Dispose();
+
+        foreach (var f in produced)
+        {
+            Assert.Equal(1, f.DisposeCount);   // exactly once: 0 = leak, 2 = use-after-free
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OverlayZOrderTests.cs
@@ -75,4 +75,76 @@ public class OverlayZOrderTests
         Assert.Equal(ZOrderAction.PinBelowVideo, below);
         Assert.Equal(ZOrderAction.PinTopmost, above);
     }
+
+    // ---------------------------------------------------------------------------------------
+    // #776 — the detached avatar tube yields to the pink tint.
+    //
+    // Two independent self-raising topmost windows were fighting: the tube re-pinned itself to the
+    // FRONT of the topmost band every 500ms, the compositor host (which renders the pink tint) every
+    // 5s. Last raiser won, so the tint blinked on and off the companion. The product decision is that
+    // the tint wins, so the tube resolves to PinBelowCompositorHost and inserts directly under the
+    // host instead — still topmost, still above ordinary app windows.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void TubeYieldsToCompositorHost_PinsBelowIt_NotTopmost()
+    {
+        // The tube always asks unconditionally (needsPin + force), exactly as before the fix — the
+        // yield flag, not a lost WS_EX_TOPMOST, is what redirects it.
+        var action = ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+            needsPin: true, force: true, yieldToCompositorHost: true);
+        Assert.Equal(ZOrderAction.PinBelowCompositorHost, action);
+    }
+
+    [Fact]
+    public void TubeWithNoHostOnItsMonitor_StillPinsTopmost()
+    {
+        // No visible host over the tube (hidden after the idle grace, or a monitor the compositor
+        // isn't covering): the widget keeps its original front-of-the-topmost-band raise.
+        var action = ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+            needsPin: true, force: true, yieldToCompositorHost: false);
+        Assert.Equal(ZOrderAction.PinTopmost, action);
+    }
+
+    [Fact]
+    public void YieldFlagDefaultsOff_SoOverlayWindowsAreUnaffected()
+    {
+        // Every existing caller omits the parameter; the legacy 5-arg decisions must be identical.
+        Assert.Equal(
+            ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false, needsPin: false, force: false),
+            ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false, needsPin: false, force: false, yieldToCompositorHost: false));
+        Assert.Equal(ZOrderAction.None,
+            ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false, needsPin: false, force: false));
+    }
+
+    [Fact]
+    public void VideoRuleOutranksTheYield_So497CannotBeTradedAway()
+    {
+        // A window that both co-exists with a playing video and asks to yield must still land BELOW
+        // the video: burying the mandatory video is the one outcome that is never acceptable (#497).
+        var action = ResolveZOrderAction(hasVideo: true, isVideoWindow: false, aboveVideo: false,
+            needsPin: true, force: true, yieldToCompositorHost: true);
+        Assert.Equal(ZOrderAction.PinBelowVideo, action);
+    }
+
+    [Fact]
+    public void YieldDoesNotOutrankADeeperBandAboveVideo()
+    {
+        // aboveVideo means the overlay IS the enhanced video's effect. It is a compositor layer, so it
+        // never yields; if a caller ever passed both, the band must not be demoted under the host.
+        var action = ResolveZOrderAction(hasVideo: true, isVideoWindow: false, aboveVideo: true,
+            needsPin: false, force: false, yieldToCompositorHost: false);
+        Assert.Equal(ZOrderAction.PinTopmost, action);
+    }
+
+    [Fact]
+    public void YieldIsIndependentOfNeedsPinAndForce()
+    {
+        // Whatever the tube's current WS_EX_TOPMOST state, a visible host over it means "go below".
+        foreach (var needsPin in new[] { false, true })
+            foreach (var force in new[] { false, true })
+                Assert.Equal(ZOrderAction.PinBelowCompositorHost,
+                    ResolveZOrderAction(hasVideo: false, isVideoWindow: false, aboveVideo: false,
+                        needsPin: needsPin, force: force, yieldToCompositorHost: true));
+    }
 }


### PR DESCRIPTION
Fixes from the 2026-08-03 triage of the v6.6.3 bug reports, stability-focused.

## Freeze cluster (#775 / #777 / #779 / #780)
- Kill the WriteableBitmap.Lock() vs render-thread inversion still live in DualMonitorVideoService and InlineLoopVideo (same family as the v6.6.2 BlurVmemSurface fix)
- Fix InteractionQueueService taking a blocking Dispatcher.Invoke while holding its lock (fires on every video end; was a silent 5s UI freeze capped only by the DispatcherHelper timeout)
- Bounded TryLock on all UI-thread buffer locks in the blur blit path; 7 blocking Invoke -> RunOnUI conversions on the post-video path
- New UiMark/UiScope breadcrumbs: the hang watchdog now logs the exact native call the UI thread died in, so the next freeze report identifies itself

## Audio endpoint death -> thread/handle runaway (#778 / #779)
- Replaces ~15 copies of the Task.Run + WaveOutEvent + Sleep-poll idiom with a single PlayOneShot pipeline on a dedicated MTA audio worker (waveOutOpen BLOCKS on a dead endpoint; every clip parked 2 pool threads -> +202 threads / +5,601 handles)
- Deterministic disposal (event + safety timer), 10-concurrent cap, 5-failure circuit breaker with 30s cooldown, IMMNotificationClient endpoint watcher - restarting the Windows Audio Endpoint Builder service now recovers playback instead of killing the app

## Video widens to fill the screen (#786)
- The blurred-background path derived the on-screen shape from LibVLC's coded frame size with the sample aspect ratio dropped, stretching anamorphic clips
- Now uses the SAR-corrected display aspect from the video track (rotation-aware, sane fallbacks) with the fit rect recomputed on every format callback - letterbox/pillarbox by construction, stretching is impossible

## Gaze + hydra flash runaway (#784)
- Gaze pops fed the hydra branch and the gaze attractor snapped straight onto the spawned children -> self-sustaining infinite flash loop
- Gaze pops still take the first hydra hop off an original flash; hydra children popped by gaze just dismiss. Mouse behavior unchanged

## Pink filter flicker on the detached avatar (#776)
- Root cause: z-order war - the detached tube reasserted HWND_TOPMOST every 500ms, the compositor host every 5s; last raiser wins
- Decision: avatar sits UNDER the tint. The tube now inserts directly below the compositor host via a new PinBelowCompositorHost case in the z-order reconciler (checked after PinBelowVideo so #497 cannot regress; playing video suppresses the yield)

## BrainDrain desktop capture off the UI thread
- CapturePass did a full-screen StretchBlt from GetDC(NULL) on the UI thread every 33ms; now a dedicated capture pump owns all GDI with latest-wins frame handoff (bounded 2ms TryTake, teardown never joins a wedged blt)
- Note: this was NOT the #777 wedge (the BrainDrainWithheld gate meant it never ran there) but it un-mines the path before the Brain Drain revival (PR#92) lifts the gate

## Exit profile sync
- App.OnExit's SyncProfileAsync().Wait(2s) starved its own UI-context continuations, so the exit sync always timed out silently; the awaits now run on the thread pool and the 2s budget does real work

## Also included
- ef1296f8 fix(streak): bank the login streak on midnight rollover (was already on this branch's base)

## Verification
- Build: 0 errors, warning set identical to baseline
- Tests: 887/887 pass (26 new: 13 blur aspect, 6 z-order reconciler, 7 BrainDrain frame handoff)
- Not yet play-tested; the play-test checklist is: audio endpoint stop/start mid-session, dual-monitor anamorphic mandatory video, detached tube + pink filter on multi-mon/mixed-DPI, one bubble-count session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5JFXRCWPJUQxcnChhYiPP