### PR TITLE
feat(fyp): For You feed - desktop port with ghost mode, eye control, audio glow

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1839,6 +1839,11 @@ namespace ConditioningControlPanel
             else if (e.Args.Contains("--dtrh"))
                 Services.Chaos.DtrhHostService.Launch();
 
+            // For You feed, dev shortcut: `--fyp` opens the feed window immediately,
+            // bypassing the Lab card and the premium gate (dev machines only).
+            if (e.Args.Contains("--fyp"))
+                Services.Fyp.FypHostService.Launch();
+
             // Arm the offline mic features (wake word / push-to-talk) at startup if the user left them
             // on. They're decoupled from Takeover ("She's Listening" owns them), so they no longer wait
             // for Takeover to start. No-op unless consent is given and the speech engine is available.

--- a/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
@@ -227,6 +227,30 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Lab → For You hero card. Opens the TikTok-style feed window (WebView2). Premium:
+        /// the Lab smokescreen already gates the tab, but the entitlement is re-checked here
+        /// so a stale/visible card can't launch without it.
+        /// </summary>
+        internal void BtnStartFyp_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (App.Patreon?.HasPremiumAccess != true)
+                {
+                    ShowAppInfoPopup();
+                    return;
+                }
+                Services.Fyp.FypHostService.Launch();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BtnStartFyp_Click failed");
+                MessageBox.Show("Couldn't open the For You feed:\n\n" + ex.Message, "For You",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        /// <summary>
         /// Quick Start: launch a Chaos run with the saved settings, bypassing the modal hub.
         /// Mirrors what BEGIN CHAOS does after SaveToSettings (StartRun reads ChaosRunConfig.FromSettings),
         /// just without the dialog.

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -783,11 +783,20 @@ namespace ConditioningControlPanel
             // Reactivates on its own once the game window closes (IsActive flips false).
             if (Services.Chaos.DtrhHostService.IsActive) { VideoDiag.Log("PANIC", "handed off to the DtRH web game window"); return; }
 
-            // For You feed: panic simply closes the feed window — it's a viewer, not a game,
-            // so there's no pause ladder to hand off to. The press is consumed (no fall-through
-            // into the "not running" exit branch).
+            // For You feed: a two-rung ladder. Press 1 hands the window back its clicks if it is
+            // parked click-through (otherwise the user is staring at a semi-transparent pane they
+            // cannot grab — nothing on it is clickable, including its own close button), press 2
+            // closes the feed. The press is consumed either way (no fall-through into the "not
+            // running" exit branch). The panic key reaches us regardless of focus: it rides the
+            // WH_KEYBOARD_LL hook in OnGlobalKeyPressed, not a window-level handler.
             if (Services.Fyp.FypHostService.IsActive)
             {
+                if (Services.Fyp.FypHostService.IsClickThrough)
+                {
+                    VideoDiag.Log("PANIC", "For You feed: click-through disabled (press again to close)");
+                    Services.Fyp.FypHostService.DisableClickThrough();
+                    return;
+                }
                 VideoDiag.Log("PANIC", "closing the For You feed window");
                 Services.Fyp.FypHostService.Close();
                 return;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -783,18 +783,25 @@ namespace ConditioningControlPanel
             // Reactivates on its own once the game window closes (IsActive flips false).
             if (Services.Chaos.DtrhHostService.IsActive) { VideoDiag.Log("PANIC", "handed off to the DtRH web game window"); return; }
 
-            // For You feed: a two-rung ladder. Press 1 hands the window back its clicks if it is
-            // parked click-through (otherwise the user is staring at a semi-transparent pane they
-            // cannot grab — nothing on it is clickable, including its own close button), press 2
+            // For You feed: a two-rung ladder. Press 1 drops ghost mode if the feed is parked as a
+            // see-through mirror (otherwise the user is staring at a translucent pane they cannot
+            // grab — the mouse passes straight through it, its own close button included), press 2
             // closes the feed. The press is consumed either way (no fall-through into the "not
             // running" exit branch). The panic key reaches us regardless of focus: it rides the
             // WH_KEYBOARD_LL hook in OnGlobalKeyPressed, not a window-level handler.
             if (Services.Fyp.FypHostService.IsActive)
             {
-                if (Services.Fyp.FypHostService.IsClickThrough)
+                if (Services.Fyp.FypHostService.IsGhosted)
                 {
-                    VideoDiag.Log("PANIC", "For You feed: click-through disabled (press again to close)");
-                    Services.Fyp.FypHostService.DisableClickThrough();
+                    VideoDiag.Log("PANIC", "For You feed: ghost mode dropped (press again to close)");
+                    Services.Fyp.FypHostService.ExitGhost();
+                    return;
+                }
+                if (Services.Fyp.FypHostService.RecentlyUnghosted)
+                {
+                    // The reflexive double-tap right after rung 1 — swallow it instead of
+                    // taking the whole feed down (play-tested: one Esc-Esc closed everything).
+                    VideoDiag.Log("PANIC", "For You feed: press ignored (just un-ghosted)");
                     return;
                 }
                 VideoDiag.Log("PANIC", "closing the For You feed window");

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -783,6 +783,16 @@ namespace ConditioningControlPanel
             // Reactivates on its own once the game window closes (IsActive flips false).
             if (Services.Chaos.DtrhHostService.IsActive) { VideoDiag.Log("PANIC", "handed off to the DtRH web game window"); return; }
 
+            // For You feed: panic simply closes the feed window — it's a viewer, not a game,
+            // so there's no pause ladder to hand off to. The press is consumed (no fall-through
+            // into the "not running" exit branch).
+            if (Services.Fyp.FypHostService.IsActive)
+            {
+                VideoDiag.Log("PANIC", "closing the For You feed window");
+                Services.Fyp.FypHostService.Close();
+                return;
+            }
+
             // #735 "grace pause": while a mandatory video is really on screen, the FIRST panic press
             // pauses it behind a small Paused/Resume card instead of stopping the engine — the user
             // may be pausing because someone walked in, and a bark, an achievement track and a whole

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2769,6 +2769,58 @@ namespace ConditioningControlPanel.Models
         }
         #endregion
 
+        #region For You Feed (premium, WebView2)
+        private string _fypLayout = "duo";
+        /// <summary>Feed page layout: "duo" (landscape stacks two-up), "trio" (three-up) or
+        /// "random" (irregular mosaic quilt). Mirrors the mobile reel's setting.</summary>
+        public string FypLayout
+        {
+            get => _fypLayout;
+            set { _fypLayout = value is "duo" or "trio" or "random" ? value : "duo"; OnPropertyChanged(); }
+        }
+
+        private bool _fypIncludeGifs = true;
+        /// <summary>Mix animated GIFs from the images library into the feed.</summary>
+        public bool FypIncludeGifs
+        {
+            get => _fypIncludeGifs;
+            set { _fypIncludeGifs = value; OnPropertyChanged(); }
+        }
+
+        private bool _fypMosaicAutoChange = true;
+        /// <summary>Mosaic layout re-composes itself on a timer (off = holds until swiped).</summary>
+        public bool FypMosaicAutoChange
+        {
+            get => _fypMosaicAutoChange;
+            set { _fypMosaicAutoChange = value; OnPropertyChanged(); }
+        }
+
+        private int _fypMosaicChangeSec = 10;
+        /// <summary>Seconds between mosaic re-compositions. Floored at 3 - every morph
+        /// mounts/releases up to 4 media elements, so a faster cadence churns decoders.</summary>
+        public int FypMosaicChangeSec
+        {
+            get => _fypMosaicChangeSec;
+            set { _fypMosaicChangeSec = Math.Clamp(value, 3, 60); OnPropertyChanged(); }
+        }
+
+        private bool _fypAutoAdvance = false;
+        /// <summary>Scroll to the next page when a clip's window ends (off = loop forever).</summary>
+        public bool FypAutoAdvance
+        {
+            get => _fypAutoAdvance;
+            set { _fypAutoAdvance = value; OnPropertyChanged(); }
+        }
+
+        private bool _fypMuted = false;
+        /// <summary>Feed audio muted.</summary>
+        public bool FypMuted
+        {
+            get => _fypMuted;
+            set { _fypMuted = value; OnPropertyChanged(); }
+        }
+        #endregion
+
         #region Lock Card (Unlocks Lv.35)
         private bool _lockCardEnabled = false;
         public bool LockCardEnabled

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2821,14 +2821,14 @@ namespace ConditioningControlPanel.Models
         }
 
         private double _fypWindowOpacity = 1.0;
-        /// <summary>Whole-window alpha for the feed (0.30-1.0), so it can be parked semi-transparent
-        /// over the desktop. Applied natively (WS_EX_LAYERED + LWA_ALPHA) because WPF's
-        /// Window.Opacity does not reach the WebView2 child HWND. Floored at 0.30 - any lower and
-        /// the window is invisible enough that the user cannot find it to close it.</summary>
+        /// <summary>Ghost-mode translucency for the feed (0.01-1.0) - the DWM thumbnail opacity of
+        /// the see-through mirror, never the real window's alpha (the WebView2 window must never be
+        /// layered; see FypGhostOverlay). May go near-invisible: recovery is a single Esc/panic
+        /// press, which restores the fully opaque real window regardless of this value.</summary>
         public double FypWindowOpacity
         {
             get => _fypWindowOpacity;
-            set { _fypWindowOpacity = Math.Clamp(value, 0.30, 1.0); OnPropertyChanged(); }
+            set { _fypWindowOpacity = Math.Clamp(value, 0.01, 1.0); OnPropertyChanged(); }
         }
 
         private bool _fypAudioGlow = true;

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2819,6 +2819,44 @@ namespace ConditioningControlPanel.Models
             get => _fypMuted;
             set { _fypMuted = value; OnPropertyChanged(); }
         }
+
+        private double _fypWindowOpacity = 1.0;
+        /// <summary>Whole-window alpha for the feed (0.30-1.0), so it can be parked semi-transparent
+        /// over the desktop. Applied natively (WS_EX_LAYERED + LWA_ALPHA) because WPF's
+        /// Window.Opacity does not reach the WebView2 child HWND. Floored at 0.30 - any lower and
+        /// the window is invisible enough that the user cannot find it to close it.</summary>
+        public double FypWindowOpacity
+        {
+            get => _fypWindowOpacity;
+            set { _fypWindowOpacity = Math.Clamp(value, 0.30, 1.0); OnPropertyChanged(); }
+        }
+
+        private bool _fypAudioGlow = true;
+        /// <summary>Page-side visual: the playing tile pulses with its own audio level. Persisted
+        /// here and handed to the page in the init payload; the app itself does nothing with it.</summary>
+        public bool FypAudioGlow
+        {
+            get => _fypAudioGlow;
+            set { _fypAudioGlow = value; OnPropertyChanged(); }
+        }
+
+        private bool _fypEyeControl = false;
+        /// <summary>Webcam eye control for the feed: a blink swaps one tile, holding the eyes
+        /// shut for 2s changes the whole page. Off by default - it turns the camera on.</summary>
+        public bool FypEyeControl
+        {
+            get => _fypEyeControl;
+            set { _fypEyeControl = value; OnPropertyChanged(); }
+        }
+
+        private bool _fypEyeGaze = false;
+        /// <summary>With eye control on, a blink swaps the tile the user is LOOKING at rather than
+        /// a random one. Only meaningful once gaze is calibrated; ignored otherwise.</summary>
+        public bool FypEyeGaze
+        {
+            get => _fypEyeGaze;
+            set { _fypEyeGaze = value; OnPropertyChanged(); }
+        }
         #endregion
 
         #region Lock Card (Unlocks Lv.35)

--- a/ConditioningControlPanel/Resources/web/fyp/feed.js
+++ b/ConditioningControlPanel/Resources/web/fyp/feed.js
@@ -277,6 +277,44 @@ export function createFeed(getAspect) {
     return out;
   }
 
+  /**
+   * Fresh weighted pick for one tile: orientation want, page-wide exclusion, and
+   * the outgoing cut pushed onto the tile's history stack. Shared by the 'next'
+   * direction and by 'back' when there is no history to replay.
+   */
+  function freshSwap(comp, tileIndex, hKey) {
+    const tile = comp.tiles[tileIndex];
+    const stacked = comp.layout !== 'random' && comp.tiles.length > 1;
+    let want;
+    if (stacked) want = true; // a stacked slot never falls back to portrait
+    else if (comp.layout === 'random') want = (tile.rect.w / tile.rect.h) * getAspect() >= 1;
+    else want = isLandscapeDims(tile.cut.asset.width, tile.cut.asset.height);
+    let pickPool = candidates.filter((c) => c.landscape === want);
+    if (!stacked && pickPool.length < 2) pickPool = candidates;
+    const exclude = new Set(comp.tiles.map((t) => t.cut.segId)); // no dupes on the page
+    exclude.add(tile.cut.segId);
+    const pick = weightedPick(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
+    if (!pick) return null;
+
+    let stack = history.get(hKey);
+    if (!stack) {
+      if (history.size >= HISTORY_KEYS_MAX) {
+        // evict the oldest stack (Map preserves insertion order)
+        const oldest = history.keys().next().value;
+        if (oldest != null) history.delete(oldest);
+      }
+      stack = [];
+      history.set(hKey, stack);
+    }
+    stack.push(tile.cut);
+    if (stack.length > HISTORY_MAX) stack.splice(0, stack.length - HISTORY_MAX);
+
+    remember(recent.ring, pick.segId);
+    const cut = toCut(pick);
+    comp.tiles[tileIndex] = { ...tile, cut };
+    return cut;
+  }
+
   return {
     get comps() { return comps; },
     get layout() { return layout; },
@@ -328,8 +366,11 @@ export function createFeed(getAspect) {
 
     /**
      * Swap one tile's cut. dir 'next' = fresh weighted pick, 'back' = pop the
-     * tile's history (replaying the exact same window). Returns the new Cut or
-     * null when refused (empty history / no pick) — the surface springs back.
+     * tile's history (replaying the exact same window). A 'back' with nothing
+     * left to replay (first item, or a stack of dead assets) is NOT refused: it
+     * falls through to a fresh pick, so the gesture always yields content and
+     * the caller animates it in whichever direction the user swiped. Returns
+     * null only when the pool itself can offer nothing — the surface springs back.
      */
     swapTile(compKey, tileIndex, dir) {
       const comp = comps.find((c) => c.key === compKey);
@@ -345,7 +386,7 @@ export function createFeed(getAspect) {
           const c = stack.pop();
           if (alive.has(c.asset.id)) { popped = c; break; } // skip cuts whose asset left the pool
         }
-        if (!popped) return null;
+        if (!popped) return freshSwap(comp, tileIndex, hKey); // nothing to go back to
         // Same segId/lenSec/seed => the exact same window replays; fresh surfaceKey
         // so the old surface unmounts (reporting its dwell).
         const restored = { ...popped, surfaceKey: nextSurfaceKey() };
@@ -354,36 +395,7 @@ export function createFeed(getAspect) {
         return restored;
       }
 
-      // dir === 'next'
-      const stacked = comp.layout !== 'random' && comp.tiles.length > 1;
-      let want;
-      if (stacked) want = true; // a stacked slot never falls back to portrait
-      else if (comp.layout === 'random') want = (tile.rect.w / tile.rect.h) * getAspect() >= 1;
-      else want = isLandscapeDims(tile.cut.asset.width, tile.cut.asset.height);
-      let pickPool = candidates.filter((c) => c.landscape === want);
-      if (!stacked && pickPool.length < 2) pickPool = candidates;
-      const exclude = new Set(comp.tiles.map((t) => t.cut.segId)); // no dupes on the page
-      exclude.add(tile.cut.segId);
-      const pick = weightedPick(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
-      if (!pick) return null;
-
-      let stack = history.get(hKey);
-      if (!stack) {
-        if (history.size >= HISTORY_KEYS_MAX) {
-          // evict the oldest stack (Map preserves insertion order)
-          const oldest = history.keys().next().value;
-          if (oldest != null) history.delete(oldest);
-        }
-        stack = [];
-        history.set(hKey, stack);
-      }
-      stack.push(tile.cut);
-      if (stack.length > HISTORY_MAX) stack.splice(0, stack.length - HISTORY_MAX);
-
-      remember(recent.ring, pick.segId);
-      const cut = toCut(pick);
-      comp.tiles[tileIndex] = { ...tile, cut };
-      return cut;
+      return freshSwap(comp, tileIndex, hKey);
     },
 
     /** Re-compose a random-layout page in place (fresh layout + clips). Returns

--- a/ConditioningControlPanel/Resources/web/fyp/feed.js
+++ b/ConditioningControlPanel/Resources/web/fyp/feed.js
@@ -1,0 +1,404 @@
+// Feed engine — selection, compositions and the sliding page window.
+// Port of the mobile reel's foryou.tsx selection/composition layer (no DOM here;
+// surfaces.js renders what this produces).
+//
+// Vocabulary (same as mobile):
+//   Candidate   — one addressable section of a video (or a whole GIF): the unit
+//                 selection draws from.
+//   Cut         — one media pick with its playback window: the content of a tile.
+//   Tile        — a placed cut: fractional rect + audio/advance/blur flags.
+//   Composition — one feed page: a keyed list of tiles.
+
+import {
+  segId, segmentCount, isLandscapeDims, randomClipLenSec,
+  W_BASE, W_BOOST_MAX, W_EXPLORE_BONUS, WHOLE_VIDEO_MAX_SEC,
+} from './segments.js';
+import * as stats from './stats.js';
+
+export const PAGE_SIZE = 8;
+// Feed window: appending trims the head once the list exceeds this, so an endless
+// session holds a bounded working set instead of growing forever.
+export const MAX_COMPS = 6 * PAGE_SIZE;
+const HISTORY_KEYS_MAX = 512; // hard ceiling on distinct per-tile history stacks
+const HISTORY_MAX = 20;       // per-tile swipe-back depth
+const ASSET_COOLDOWN = 2;     // don't show 3+ clips of the same video in a row
+const SAME_ASSET_PENALTY = 0.25;
+const MOSAIC_MIN_TILES = 2;
+const MOSAIC_MAX_TILES = 4;
+const RING_CAP = 128;
+
+let surfaceSeq = 0;
+const nextSurfaceKey = () => `s${surfaceSeq++}`;
+
+function weightFor(id) {
+  return W_BASE + W_BOOST_MAX * stats.segmentScore(id) + W_EXPLORE_BONUS / (1 + stats.segmentPlays(id));
+}
+
+function segCooldownFor(n) {
+  return Math.max(1, Math.min(12, Math.floor(n * 0.5)));
+}
+
+function remember(ring, id) {
+  ring.push(id);
+  if (ring.length > RING_CAP) ring.splice(0, ring.length - RING_CAP);
+}
+
+/** Expand active videos + GIFs into the flat candidate segment set. */
+function enumerateSegments(assets) {
+  const out = [];
+  for (const a of assets) {
+    const landscape = isLandscapeDims(a.width, a.height);
+    if (a.type === 'gif') {
+      // A GIF is one whole-item segment: no timeline, no grid.
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape });
+      continue;
+    }
+    const durSec = a.durationMs != null ? a.durationMs / 1000 : undefined;
+    if (durSec == null) {
+      // Cold: duration not probed yet — one placeholder segment, seed-window start.
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: false, landscape });
+    } else if (durSec <= WHOLE_VIDEO_MAX_SEC) {
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape });
+    } else {
+      const n = segmentCount(durSec);
+      for (let k = 0; k < n; k++) {
+        out.push({ asset: a, assetId: a.id, k, segId: segId(a.id, k), durKnown: true, landscape });
+      }
+    }
+  }
+  return out;
+}
+
+/** Fallback when everything is on cooldown (tiny pack): least-recently-shown. */
+function leastRecentlyUsed(candidates, ring) {
+  let best = candidates[0];
+  let bestIdx = ring.lastIndexOf(best.segId); // -1 (never shown) wins
+  for (let i = 1; i < candidates.length; i++) {
+    const idx = ring.lastIndexOf(candidates[i].segId);
+    if (idx < bestIdx) { best = candidates[i]; bestIdx = idx; }
+  }
+  return best;
+}
+
+/**
+ * One weighted-proportional pick. Weight blends an exploration floor, an
+ * optimism-under-uncertainty term and a capped retention boost; recency and the
+ * exclusion set zero candidates out. O(N); LRU fallback when all on cooldown.
+ */
+function weightedPick(pool, ring, segCooldown, exclude) {
+  if (pool.length === 0) return null;
+  const lastSeg = ring.length ? ring[ring.length - 1] : null;
+  const lastAsset = lastSeg ? lastSeg.slice(0, lastSeg.indexOf(':')) : null;
+  const recentSegs = new Set(ring.slice(-segCooldown));
+  const recentAssets = new Set(ring.slice(-ASSET_COOLDOWN).map((s) => s.slice(0, s.indexOf(':'))));
+  let total = 0;
+  const eff = pool.map((c) => {
+    let w = weightFor(c.segId);
+    if (exclude?.has(c.segId)) w = 0;
+    else if (recentSegs.has(c.segId)) w = 0;
+    else if (recentAssets.has(c.assetId)) w = 0;
+    else if (c.assetId === lastAsset) w *= SAME_ASSET_PENALTY;
+    total += w;
+    return w;
+  });
+  if (total > 0) {
+    let r = Math.random() * total;
+    let idx = 0;
+    for (; idx < pool.length - 1; idx++) {
+      r -= eff[idx];
+      if (r <= 0) break;
+    }
+    return pool[idx];
+  }
+  const usable = exclude ? pool.filter((c) => !exclude.has(c.segId)) : pool;
+  return usable.length ? leastRecentlyUsed(usable, ring) : null;
+}
+
+function toCut(pick) {
+  return {
+    surfaceKey: nextSurfaceKey(),
+    asset: pick.asset,
+    k: pick.k,
+    segId: pick.segId,
+    durKnown: pick.durKnown,
+    lenSec: randomClipLenSec(),
+    seed: Math.random(),
+  };
+}
+
+/** Equal horizontal band i of n (top-to-bottom stack rects). */
+function bandRect(i, n) {
+  return { x: 0, y: i / n, w: 1, h: 1 / n };
+}
+
+/**
+ * Partition the unit rect into n cells by recursively splitting the largest-area
+ * cell across its longer *pixel* side (soft ratio in [0.36, 0.64]). Irregular,
+ * non-symmetric quilt. `aspect` = page width/height, so cells split by real
+ * proportions, not fractions.
+ */
+function splitRects(n, aspect) {
+  const rects = [{ x: 0, y: 0, w: 1, h: 1 }];
+  while (rects.length < n) {
+    let idx = 0;
+    let bestArea = -1;
+    for (let i = 0; i < rects.length; i++) {
+      const a = rects[i].w * rects[i].h;
+      if (a > bestArea) { bestArea = a; idx = i; }
+    }
+    const r = rects[idx];
+    const ratio = 0.36 + Math.random() * 0.28;
+    const splitVertical = r.w * aspect >= r.h; // wider than tall -> left/right
+    const a = splitVertical
+      ? { x: r.x, y: r.y, w: r.w * ratio, h: r.h }
+      : { x: r.x, y: r.y, w: r.w, h: r.h * ratio };
+    const b = splitVertical
+      ? { x: r.x + r.w * ratio, y: r.y, w: r.w * (1 - ratio), h: r.h }
+      : { x: r.x, y: r.y + r.h * ratio, w: r.w, h: r.h * (1 - ratio) };
+    rects.splice(idx, 1, a, b);
+  }
+  return rects;
+}
+
+/** Landscape stack (duo/trio) or a single portrait / lone-landscape tile. */
+function buildLeadTiles(lead, rows, landscapePool, ring, segCooldown) {
+  if (!lead.landscape) {
+    return [{
+      cut: toCut(lead),
+      rect: { x: 0, y: 0, w: 1, h: 1 },
+      audio: lead.asset.type === 'video',
+      advances: true,
+      blurred: false,
+      fit: 'cover',
+    }];
+  }
+  const picks = [lead];
+  const exclude = new Set([lead.segId]);
+  for (let r = 1; r < rows; r++) {
+    const mate = weightedPick(landscapePool, ring, segCooldown, exclude);
+    if (!mate) break;
+    picks.push(mate);
+    exclude.add(mate.segId);
+    remember(ring, mate.segId);
+  }
+  const firstVideo = picks.findIndex((p) => p.asset.type === 'video');
+  const lone = picks.length === 1; // couldn't fill the stack -> letterbox
+  return picks.map((p, i) => ({
+    cut: toCut(p),
+    rect: bandRect(i, picks.length),
+    audio: i === firstVideo,
+    advances: i === 0,
+    blurred: !lone && i !== 0,
+    fit: lone ? 'contain' : 'cover',
+  }));
+}
+
+/** One irregular mosaic: orientation-matched picks into split cells. */
+function buildMosaicTiles(candidates, ring, segCooldown, aspect) {
+  const n = MOSAIC_MIN_TILES + Math.floor(Math.random() * (MOSAIC_MAX_TILES - MOSAIC_MIN_TILES + 1));
+  const rects = splitRects(n, aspect);
+  const exclude = new Set();
+  const tiles = [];
+  for (const rect of rects) {
+    const cellAspect = (rect.w / rect.h) * aspect;
+    const wantLandscape = cellAspect >= 1;
+    const oriented = candidates.filter((c) => c.landscape === wantLandscape);
+    const pool = oriented.length ? oriented : candidates;
+    // Prefer fresh + orientation-matched; widen to the full pool; only for a pack
+    // too small to fill every cell, allow a repeat rather than a black gap.
+    const pick =
+      weightedPick(pool, ring, segCooldown, exclude) ??
+      weightedPick(candidates, ring, segCooldown, exclude) ??
+      weightedPick(candidates, ring, segCooldown, null);
+    if (!pick) continue;
+    exclude.add(pick.segId);
+    remember(ring, pick.segId);
+    tiles.push({ cut: toCut(pick), rect, audio: false, advances: false, blurred: false, fit: 'cover' });
+  }
+  // Audio follows the largest video cell (mosaics have no single "top").
+  let audioIdx = -1;
+  let audioArea = -1;
+  tiles.forEach((t, i) => {
+    if (t.cut.asset.type !== 'video') return;
+    const area = t.rect.w * t.rect.h;
+    if (area > audioArea) { audioArea = area; audioIdx = i; }
+  });
+  if (audioIdx >= 0) tiles[audioIdx] = { ...tiles[audioIdx], audio: true };
+  return tiles;
+}
+
+/**
+ * The feed: owns the asset pool, candidates, recency ring, composition window,
+ * per-tile swipe history and the monotonic comp-key sequence.
+ */
+export function createFeed(getAspect) {
+  let assets = [];
+  let includeGifs = true;
+  let layout = 'duo';
+  let candidates = [];
+  let poolKey = '';
+  const recent = { ring: [] };
+  let comps = [];
+  let compSeq = 0;
+  const history = new Map(); // `${compKey}:${tileIndex}` -> Cut[]
+
+  function activePool() {
+    return assets.filter((a) => a.type === 'video' || (includeGifs && a.type === 'gif'));
+  }
+
+  function rebuildCandidates() {
+    candidates = enumerateSegments(activePool());
+  }
+
+  function computePoolKey() {
+    return activePool().map((a) => a.id).sort().join('|');
+  }
+
+  function makeCompositions(count) {
+    const out = [];
+    if (candidates.length === 0) return out;
+    const segCooldown = segCooldownFor(candidates.length);
+    const landscapePool = candidates.filter((c) => c.landscape);
+    const aspect = getAspect();
+    for (let i = 0; i < count; i++) {
+      const key = `cut-${compSeq++}`;
+      let tiles;
+      if (layout === 'random') {
+        tiles = buildMosaicTiles(candidates, recent.ring, segCooldown, aspect);
+      } else {
+        const lead = weightedPick(candidates, recent.ring, segCooldown, null);
+        if (!lead) break;
+        remember(recent.ring, lead.segId);
+        tiles = buildLeadTiles(lead, layout === 'trio' ? 3 : 2, landscapePool, recent.ring, segCooldown);
+      }
+      if (!tiles.length) break;
+      out.push({ key, layout, gen: 0, tiles });
+    }
+    return out;
+  }
+
+  return {
+    get comps() { return comps; },
+    get layout() { return layout; },
+    get candidateCount() { return candidates.length; },
+    get historySize() { return history.size; },
+
+    /** Returns true when the feed must reset to the top (pool identity or layout
+     *  changed). Duration/dimension backfills keep the feed exactly where it is. */
+    configure(nextAssets, nextIncludeGifs, nextLayout) {
+      assets = nextAssets;
+      includeGifs = nextIncludeGifs;
+      rebuildCandidates();
+      const nextKey = computePoolKey();
+      const reset = nextKey !== poolKey || nextLayout !== layout;
+      poolKey = nextKey;
+      layout = nextLayout;
+      if (reset) {
+        recent.ring = [];
+        history.clear();
+        comps = makeCompositions(PAGE_SIZE);
+        stats.pruneToAssets(new Set(assets.map((a) => a.id)));
+      }
+      return reset;
+    },
+
+    /** A playback probe filled in duration/dims: refresh candidates in place. */
+    noteAssetMeta() {
+      rebuildCandidates();
+    },
+
+    /** Append a page batch; trim the head past MAX_COMPS. Returns the number of
+     *  pages trimmed so the pager can compensate its offset in the same tick. */
+    extend() {
+      const appended = makeCompositions(PAGE_SIZE);
+      comps = comps.concat(appended);
+      let excess = comps.length - MAX_COMPS;
+      if (excess < 0) excess = 0;
+      if (excess > 0) {
+        const dead = comps.slice(0, excess);
+        comps = comps.slice(excess);
+        for (const d of dead) {
+          for (const k of history.keys()) {
+            if (k.startsWith(d.key + ':')) history.delete(k);
+          }
+        }
+      }
+      return { appended: appended.length, trimmed: excess };
+    },
+
+    /**
+     * Swap one tile's cut. dir 'next' = fresh weighted pick, 'back' = pop the
+     * tile's history (replaying the exact same window). Returns the new Cut or
+     * null when refused (empty history / no pick) — the surface springs back.
+     */
+    swapTile(compKey, tileIndex, dir) {
+      const comp = comps.find((c) => c.key === compKey);
+      const tile = comp?.tiles[tileIndex];
+      if (!comp || !tile) return null;
+      const hKey = `${compKey}:${tileIndex}`;
+
+      if (dir === 'back') {
+        const stack = history.get(hKey);
+        const alive = new Set(candidates.map((c) => c.assetId));
+        let popped = null;
+        while (stack && stack.length) {
+          const c = stack.pop();
+          if (alive.has(c.asset.id)) { popped = c; break; } // skip cuts whose asset left the pool
+        }
+        if (!popped) return null;
+        // Same segId/lenSec/seed => the exact same window replays; fresh surfaceKey
+        // so the old surface unmounts (reporting its dwell).
+        const restored = { ...popped, surfaceKey: nextSurfaceKey() };
+        remember(recent.ring, restored.segId);
+        comp.tiles[tileIndex] = { ...tile, cut: restored };
+        return restored;
+      }
+
+      // dir === 'next'
+      const stacked = comp.layout !== 'random' && comp.tiles.length > 1;
+      let want;
+      if (stacked) want = true; // a stacked slot never falls back to portrait
+      else if (comp.layout === 'random') want = (tile.rect.w / tile.rect.h) * getAspect() >= 1;
+      else want = isLandscapeDims(tile.cut.asset.width, tile.cut.asset.height);
+      let pickPool = candidates.filter((c) => c.landscape === want);
+      if (!stacked && pickPool.length < 2) pickPool = candidates;
+      const exclude = new Set(comp.tiles.map((t) => t.cut.segId)); // no dupes on the page
+      exclude.add(tile.cut.segId);
+      const pick = weightedPick(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
+      if (!pick) return null;
+
+      let stack = history.get(hKey);
+      if (!stack) {
+        if (history.size >= HISTORY_KEYS_MAX) {
+          // evict the oldest stack (Map preserves insertion order)
+          const oldest = history.keys().next().value;
+          if (oldest != null) history.delete(oldest);
+        }
+        stack = [];
+        history.set(hKey, stack);
+      }
+      stack.push(tile.cut);
+      if (stack.length > HISTORY_MAX) stack.splice(0, stack.length - HISTORY_MAX);
+
+      remember(recent.ring, pick.segId);
+      const cut = toCut(pick);
+      comp.tiles[tileIndex] = { ...tile, cut };
+      return cut;
+    },
+
+    /** Re-compose a random-layout page in place (fresh layout + clips). Returns
+     *  the new tiles, or null when the pool is empty. Drops the page's history. */
+    morph(compKey) {
+      const comp = comps.find((c) => c.key === compKey);
+      if (!comp || comp.layout !== 'random' || candidates.length === 0) return null;
+      const tiles = buildMosaicTiles(candidates, recent.ring, segCooldownFor(candidates.length), getAspect());
+      if (!tiles.length) return null;
+      for (const k of history.keys()) {
+        if (k.startsWith(compKey + ':')) history.delete(k);
+      }
+      comp.gen++;
+      comp.tiles = tiles;
+      return tiles;
+    },
+  };
+}

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -1,0 +1,314 @@
+/* For You feed — dark theme matching the app (#1A1A2E / pink #FF69B4). */
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html, body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #12121f;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  color: #fff;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+#app { position: fixed; inset: 0; }
+
+#viewport { position: absolute; inset: 0; overflow: hidden; }
+
+#track {
+  position: absolute;
+  inset: 0;
+  will-change: transform;
+}
+
+/* ---------- pages & tiles ---------- */
+
+.page {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #12121f;
+  overflow: hidden;
+}
+
+.page-inner { position: absolute; inset: 0; }
+
+.tile {
+  position: absolute;
+  overflow: hidden;
+  background: #0d0d18;
+  touch-action: none;
+}
+
+.swap-clip { position: absolute; inset: 0; overflow: hidden; }
+
+.surface {
+  position: absolute;
+  inset: 0;
+  background: #0d0d18;
+  will-change: transform;
+}
+
+.surface video,
+.surface img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+/* faint cue on non-top stack tiles so the eye knows which one to watch */
+.tile.blurred .surface video,
+.tile.blurred .surface img {
+  filter: blur(4px) brightness(0.75);
+}
+
+/* hover chevrons — the mouse affordance for the horizontal swap */
+.chev {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 34px;
+  height: 52px;
+  border: 0;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-size: 26px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 150ms ease, background 150ms ease;
+  z-index: 3;
+}
+.chev-l { left: 8px; }
+.chev-r { right: 8px; }
+.tile:hover .chev { opacity: 0.75; }
+.chev:hover { background: rgba(255, 105, 180, 0.55); opacity: 1; }
+
+/* ---------- chrome ---------- */
+
+#chrome { position: absolute; inset: 0; pointer-events: none; z-index: 10; }
+
+#top-left {
+  position: absolute;
+  top: 14px;
+  left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: auto;
+}
+
+#top-right {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  display: flex;
+  gap: 10px;
+  pointer-events: auto;
+}
+
+.round-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  border: 0;
+  background: rgba(0, 0, 0, 0.35);
+  color: #fff;
+  font-size: 17px;
+  cursor: pointer;
+  transition: background 150ms ease, opacity 150ms ease;
+}
+.round-btn:hover { background: rgba(255, 105, 180, 0.5); }
+.round-btn.small { width: 30px; height: 30px; border-radius: 15px; font-size: 13px; }
+.round-btn.off { opacity: 0.45; }
+
+#caption {
+  position: absolute;
+  left: 18px;
+  bottom: 16px;
+  max-width: 60%;
+  pointer-events: none;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
+}
+#caption-name { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#caption-folder { font-size: 12px; color: #b0b0c8; }
+
+/* ---------- options popover ---------- */
+
+.hidden { display: none !important; }
+
+#options-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 10, 20, 0.55);
+  backdrop-filter: blur(10px);
+  z-index: 20;
+}
+
+#options-card {
+  position: absolute;
+  top: 64px;
+  left: 16px;
+  width: 320px;
+  background: #1f1f36;
+  border: 1px solid rgba(255, 105, 180, 0.35);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+}
+
+.options-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.options-label { font-size: 12px; font-weight: 600; color: #b0b0c8; margin-bottom: 8px; }
+
+.layout-row { display: flex; gap: 8px; }
+
+.layout-chip {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 9px 0;
+  border-radius: 10px;
+  border: 1px solid #34345a;
+  background: transparent;
+  color: #b0b0c8;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+}
+.layout-chip .chip-icon { font-size: 18px; line-height: 1; }
+.layout-chip.selected {
+  border-color: #ff69b4;
+  background: rgba(255, 105, 180, 0.15);
+  color: #ffb3d9;
+}
+
+.options-divider { height: 1px; background: #2c2c4a; margin: 12px 0; }
+
+.option-row { display: flex; align-items: center; gap: 10px; }
+.option-text { flex: 1; }
+.option-title { font-size: 14px; font-weight: 500; }
+.option-sub { font-size: 11.5px; color: #8888a8; margin-top: 1px; }
+
+.pill-toggle {
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  border: 0;
+  background: #34345a;
+  position: relative;
+  cursor: pointer;
+  transition: background 150ms ease;
+  flex-shrink: 0;
+}
+.pill-toggle::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  background: #fff;
+  transition: left 150ms ease;
+}
+.pill-toggle.on { background: #ff69b4; }
+.pill-toggle.on::after { left: 23px; }
+
+#mosaic-slider-row { margin-top: 10px; }
+#mosaic-sec { flex: 1; accent-color: #ff69b4; }
+#mosaic-sec-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
+
+.options-footer { font-size: 11px; color: #6a6a88; margin-top: 12px; }
+
+/* ---------- attention check ---------- */
+
+#attention {
+  position: absolute;
+  width: 64px;
+  height: 64px;
+  border-radius: 32px;
+  border: 2px solid #ff69b4;
+  background: rgba(255, 105, 180, 0.25);
+  color: #fff;
+  font-size: 26px;
+  cursor: pointer;
+  z-index: 15;
+  animation: attention-pulse 0.9s ease-in-out infinite;
+}
+@keyframes attention-pulse {
+  0%, 100% { transform: scale(1); box-shadow: 0 0 0 0 rgba(255, 105, 180, 0.6); }
+  50% { transform: scale(1.12); box-shadow: 0 0 0 14px rgba(255, 105, 180, 0); }
+}
+#attention.hit { animation: attention-hit 0.4s ease-out forwards; }
+@keyframes attention-hit {
+  to { transform: scale(2.2); opacity: 0; }
+}
+
+/* ---------- empty / crash / boot ---------- */
+
+#empty, #crash {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  text-align: center;
+  padding: 40px;
+  z-index: 30;
+  background: #12121f;
+}
+#empty h1, #crash h1 { font-size: 26px; }
+#empty p, #crash p { font-size: 14px; color: #b0b0c8; line-height: 1.55; }
+.empty-emoji { font-size: 52px; }
+.empty-hint { font-size: 12px !important; color: #6a6a88 !important; }
+
+.empty-btn {
+  padding: 12px 26px;
+  border-radius: 12px;
+  border: 0;
+  background: #ff69b4;
+  color: #fff;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+}
+.empty-btn:hover { filter: brightness(1.1); }
+
+#boot {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #12121f;
+  z-index: 40;
+}
+.boot-pulse {
+  font-size: 44px;
+  color: #ff69b4;
+  animation: boot-pulse 1.1s ease-in-out infinite;
+}
+@keyframes boot-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.6; }
+  50% { transform: scale(1.25); opacity: 1; }
+}

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -254,6 +254,20 @@ html, body {
 .option-row.disabled { opacity: 0.4; pointer-events: none; }
 
 .option-status { font-size: 11.5px; color: #ffb3d9; margin-top: 8px; }
+
+.mini-btn {
+  padding: 6px 14px;
+  border-radius: 9px;
+  border: 1px solid rgba(255, 105, 180, 0.55);
+  background: rgba(255, 105, 180, 0.15);
+  color: #ffb3d9;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 150ms ease;
+}
+.mini-btn:hover { background: rgba(255, 105, 180, 0.35); color: #fff; }
 #mosaic-sec, #window-opacity { flex: 1; accent-color: #ff69b4; }
 #mosaic-sec-label, #window-opacity-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
 #window-opacity-label { width: 40px; }
@@ -268,6 +282,30 @@ body.clickthrough #chrome { pointer-events: none; }
 body.clickthrough #top-left,
 body.clickthrough #top-right,
 body.clickthrough #attention { display: none !important; }
+
+/* Notice shown when ghost mode engages, so the vanished chrome reads as a
+   mode, not a breakage. Never interactive; fades out on its own. */
+#ct-note {
+  position: absolute;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 420px;
+  padding: 18px 26px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 105, 180, 0.55);
+  background: rgba(18, 18, 31, 0.92);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.55);
+  text-align: center;
+  pointer-events: none;
+  z-index: 35;
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+#ct-note.show { opacity: 1; }
+.ct-note-title { font-size: 17px; font-weight: 700; letter-spacing: 1px; color: #ffb3d9; margin-bottom: 8px; }
+.ct-note-sub { font-size: 13px; color: #d5d5e8; line-height: 1.5; }
+.ct-note-sub b { color: #fff; }
 
 /* ---------- attention check ---------- */
 

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -68,6 +68,21 @@ html, body {
   filter: blur(4px) brightness(0.75);
 }
 
+/* audible-tile cue — an overlay (not a shadow on .tile) so it paints ABOVE the
+   video/img; purely visual, never in the way of the drag gesture */
+.audio-ring {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 105, 180, 0.65),
+    inset 0 0 22px rgba(255, 105, 180, 0.28);
+}
+.tile.audio-glow .audio-ring { opacity: 1; }
+
 /* hover chevrons — the mouse affordance for the horizontal swap */
 .chev {
   position: absolute;
@@ -231,11 +246,28 @@ html, body {
 .pill-toggle.on { background: #ff69b4; }
 .pill-toggle.on::after { left: 23px; }
 
-#mosaic-slider-row { margin-top: 10px; }
-#mosaic-sec { flex: 1; accent-color: #ff69b4; }
-#mosaic-sec-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
+#mosaic-slider-row, #opacity-row, #clickthrough-row, #eye-gaze-row { margin-top: 10px; }
+
+/* sub-option: indented under its master toggle, and inert until the master
+   (and, for gaze, a calibration) makes it meaningful */
+.option-row.sub-row { padding-left: 14px; }
+.option-row.disabled { opacity: 0.4; pointer-events: none; }
+
+.option-status { font-size: 11.5px; color: #ffb3d9; margin-top: 8px; }
+#mosaic-sec, #window-opacity { flex: 1; accent-color: #ff69b4; }
+#mosaic-sec-label, #window-opacity-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
+#window-opacity-label { width: 40px; }
 
 .options-footer { font-size: 11px; color: #6a6a88; margin-top: 12px; }
+
+/* ---------- click-through (ambient) mode ---------- */
+
+/* The window itself stops taking the mouse (host side); here we strip anything
+   that would beg to be clicked. The caption stays — it is unobtrusive. */
+body.clickthrough #chrome { pointer-events: none; }
+body.clickthrough #top-left,
+body.clickthrough #top-right,
+body.clickthrough #attention { display: none !important; }
 
 /* ---------- attention check ---------- */
 

--- a/ConditioningControlPanel/Resources/web/fyp/index.html
+++ b/ConditioningControlPanel/Resources/web/fyp/index.html
@@ -62,6 +62,45 @@
           <input id="mosaic-sec" type="range" min="3" max="60" step="1">
           <span id="mosaic-sec-label">10s</span>
         </div>
+        <div class="options-divider"></div>
+        <div class="option-row">
+          <div class="option-text">
+            <div class="option-title">Highlight audible tile</div>
+            <div class="option-sub">Soft pink ring on the clip you are hearing</div>
+          </div>
+          <button id="toggle-audio-glow" class="pill-toggle" role="switch"></button>
+        </div>
+        <div class="options-divider"></div>
+        <div class="options-label">Eye control</div>
+        <div class="option-row">
+          <div class="option-text">
+            <div class="option-title">Eye control (webcam)</div>
+            <div class="option-sub">Blink to swap a tile - hold eyes closed 2s to change the whole page.</div>
+          </div>
+          <button id="toggle-eye" class="pill-toggle" role="switch"></button>
+        </div>
+        <div class="option-row sub-row" id="eye-gaze-row">
+          <div class="option-text">
+            <div class="option-title">Gaze picks the tile</div>
+            <div class="option-sub">Blink swaps the tile you are looking at. Needs eye-tracking calibration.</div>
+          </div>
+          <button id="toggle-eye-gaze" class="pill-toggle" role="switch"></button>
+        </div>
+        <div class="option-status hidden" id="eye-status"></div>
+        <div class="options-divider"></div>
+        <div class="options-label">Window</div>
+        <div class="option-row" id="opacity-row">
+          <div class="option-text"><div class="option-title">Opacity</div></div>
+          <input id="window-opacity" type="range" min="30" max="100" step="1">
+          <span id="window-opacity-label">100%</span>
+        </div>
+        <div class="option-row" id="clickthrough-row">
+          <div class="option-text">
+            <div class="option-title">Click-through</div>
+            <div class="option-sub">Mouse passes through the window. Press the panic key once to take back control.</div>
+          </div>
+          <button id="toggle-clickthrough" class="pill-toggle" role="switch"></button>
+        </div>
         <div class="options-footer">Mosaic settings apply to the Mosaic layout.</div>
       </div>
     </div>

--- a/ConditioningControlPanel/Resources/web/fyp/index.html
+++ b/ConditioningControlPanel/Resources/web/fyp/index.html
@@ -86,23 +86,42 @@
           </div>
           <button id="toggle-eye-gaze" class="pill-toggle" role="switch"></button>
         </div>
+        <div class="option-row sub-row" id="eye-calibrate-row">
+          <div class="option-text">
+            <div class="option-sub">Follow the dots on screen to teach it where you look.</div>
+          </div>
+          <button id="btn-calibrate" class="mini-btn">Calibrate</button>
+        </div>
         <div class="option-status hidden" id="eye-status"></div>
         <div class="options-divider"></div>
         <div class="options-label">Window</div>
         <div class="option-row" id="opacity-row">
-          <div class="option-text"><div class="option-title">Opacity</div></div>
-          <input id="window-opacity" type="range" min="30" max="100" step="1">
+          <div class="option-text">
+            <div class="option-title">Ghost opacity</div>
+            <div class="option-sub">How see-through the feed is while ghost mode is on.</div>
+          </div>
+          <input id="window-opacity" type="range" min="1" max="100" step="1">
           <span id="window-opacity-label">100%</span>
         </div>
         <div class="option-row" id="clickthrough-row">
           <div class="option-text">
-            <div class="option-title">Click-through</div>
-            <div class="option-sub">Mouse passes through the window. Press the panic key once to take back control.</div>
+            <div class="option-title">Ghost mode</div>
+            <div class="option-sub">The feed becomes a see-through overlay your mouse passes through. Press Esc or the panic key once to bring it back.</div>
           </div>
           <button id="toggle-clickthrough" class="pill-toggle" role="switch"></button>
         </div>
         <div class="options-footer">Mosaic settings apply to the Mosaic layout.</div>
       </div>
+    </div>
+
+    <!-- Shown whenever ghost mode engages. Lives OUTSIDE #chrome on purpose:
+         body.clickthrough hides the chrome, but this note must survive it. It renders on the
+         REAL page, so the DWM mirror shows it for its 7 seconds too - that is the point. -->
+    <div id="ct-note">
+      <div class="ct-note-title">GHOST MODE IS ON</div>
+      <div class="ct-note-sub">The feed is now a see-through overlay - your mouse passes through it.</div>
+      <div class="ct-note-sub">Press <b>Esc</b> or tap the <b>panic key</b> once to take back control.
+        The corner buttons (<b>⚙</b> and <b>🔊</b>) stay clickable.</div>
     </div>
 
     <!-- attention check -->

--- a/ConditioningControlPanel/Resources/web/fyp/index.html
+++ b/ConditioningControlPanel/Resources/web/fyp/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>For You</title>
+  <link rel="stylesheet" href="fyp.css">
+</head>
+<body>
+  <div id="app">
+    <div id="viewport">
+      <div id="track"></div>
+    </div>
+
+    <!-- chrome -->
+    <div id="chrome">
+      <div id="top-left">
+        <button id="btn-options" class="round-btn" title="Feed options">⚙</button>
+      </div>
+      <div id="top-right">
+        <button id="btn-advance" class="round-btn" title="Auto-advance: scroll on when a clip ends">⟳</button>
+        <button id="btn-mute" class="round-btn" title="Mute">🔊</button>
+        <button id="btn-fullscreen" class="round-btn" title="Fullscreen">⛶</button>
+      </div>
+      <div id="caption">
+        <div id="caption-name"></div>
+        <div id="caption-folder"></div>
+      </div>
+    </div>
+
+    <!-- feed options popover -->
+    <div id="options-scrim" class="hidden">
+      <div id="options-card">
+        <div class="options-header">
+          <span>Feed options</span>
+          <button id="btn-options-close" class="round-btn small" title="Close">✕</button>
+        </div>
+        <div class="options-label">Layout</div>
+        <div class="layout-row">
+          <button class="layout-chip" data-layout="duo"><span class="chip-icon">▤</span>Duo</button>
+          <button class="layout-chip" data-layout="trio"><span class="chip-icon">☰</span>Trio</button>
+          <button class="layout-chip" data-layout="random"><span class="chip-icon">▦</span>Mosaic</button>
+        </div>
+        <div class="options-divider"></div>
+        <div class="option-row">
+          <div class="option-text">
+            <div class="option-title">Include GIFs</div>
+            <div class="option-sub">Mix animated GIFs into the feed</div>
+          </div>
+          <button id="toggle-gifs" class="pill-toggle" role="switch"></button>
+        </div>
+        <div class="options-divider"></div>
+        <div class="option-row">
+          <div class="option-text">
+            <div class="option-title">Auto-change mosaic</div>
+            <div class="option-sub" id="mosaic-sub">Mosaic reshuffles on a timer</div>
+          </div>
+          <button id="toggle-mosaic" class="pill-toggle" role="switch"></button>
+        </div>
+        <div class="option-row" id="mosaic-slider-row">
+          <div class="option-text"><div class="option-title">Change every</div></div>
+          <input id="mosaic-sec" type="range" min="3" max="60" step="1">
+          <span id="mosaic-sec-label">10s</span>
+        </div>
+        <div class="options-footer">Mosaic settings apply to the Mosaic layout.</div>
+      </div>
+    </div>
+
+    <!-- attention check -->
+    <button id="attention" class="hidden" title="tap!">💗</button>
+
+    <!-- empty state -->
+    <div id="empty" class="hidden">
+      <div class="empty-emoji">🎬</div>
+      <h1>For You</h1>
+      <p>An endless feed of 20-40 second clips from your own videos and GIFs.<br>
+         Add some to your assets folder to switch it on.</p>
+      <button id="btn-include-gifs" class="empty-btn hidden"></button>
+      <p class="empty-hint">Only active videos and GIFs are used - curate in the Assets tab.</p>
+    </div>
+
+    <!-- crash containment -->
+    <div id="crash" class="hidden">
+      <div class="empty-emoji">💥</div>
+      <h1>The For You feed crashed</h1>
+      <p id="crash-detail"></p>
+      <button id="btn-retry" class="empty-btn">RETRY</button>
+    </div>
+
+    <!-- boot -->
+    <div id="boot">
+      <div class="boot-pulse">♡</div>
+    </div>
+  </div>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -10,6 +10,13 @@ const CLIP_VIEWED_MIN_DWELL_MS = 5000; // below this a skim earns no XP
 const ATTENTION_MIN_GAP_MS = 120000;   // attention target every 2-4 min
 const ATTENTION_RAND_MS = 120000;
 const ATTENTION_LIFETIME_MS = 6000;
+const OPACITY_POST_MS = 100;           // throttle window-opacity posts while dragging
+const OPACITY_MIN = 0.3;
+// Eye control: one action per 600ms (a double-blink is a very common reflex), and a
+// gaze point older than this is treated as stale — the host freezes gaze while the
+// eyes are closed, so the point at blink time is always ~a moment old by design.
+const EYE_ACTION_COOLDOWN_MS = 600;
+const GAZE_STALE_MS = 1500;
 
 const $ = (id) => document.getElementById(id);
 const viewport = $('viewport');
@@ -32,6 +39,10 @@ let settings = {
   mosaicChangeSec: 10,
   autoAdvance: false,
   muted: false,
+  audioGlow: true,
+  windowOpacity: 1,
+  eyeControl: false,
+  eyeGaze: false,
 };
 let feed = null;
 const pages = new Map();      // compKey -> page object
@@ -39,6 +50,14 @@ const audioFocus = new Map(); // compKey -> tileIndex
 let activeIdx = 0;
 let booted = false;
 let attTimer = null;
+// Click-through is host state, never persisted here: it always starts OFF and
+// the host turns it back off when the user hits the panic key.
+let clickThrough = false;
+// Eye control: the host owns the camera and tells us what is actually true.
+let eyeStatus = { enabled: false, gaze: false, running: false, calibrated: false, reason: null };
+let lastGaze = null;        // { x, y, t } normalized to the client area, or null
+let lastEyeActionAt = 0;
+let pageBusyUntil = 0;      // a page slide is in flight until this timestamp
 
 const pageH = () => viewport.clientHeight || 1;
 const aspect = () => (viewport.clientWidth || 1) / pageH();
@@ -88,6 +107,7 @@ const pageCtx = {
   },
   isAutoAdvance: () => settings.autoAdvance,
   isMuted: () => settings.muted,
+  audioGlow: () => settings.audioGlow !== false,
   audioFocus: (compKey) => audioFocus.get(compKey),
   mosaicAutoChange: () => settings.mosaicAutoChange,
   mosaicChangeMs: () => settings.mosaicChangeSec * 1000,
@@ -137,6 +157,7 @@ function goTo(idx, animated = true) {
   const page = pageAt(idx);
   page?.setActive(true); // both pages live during the slide — no black gap
   applyTrack(animated);
+  if (animated) pageBusyUntil = performance.now() + PAGE_TRANSITION_MS + 60;
   if (prevPage && prevPage !== page) {
     if (animated) {
       setTimeout(() => { if (pageAt(activeIdx) !== prevPage) prevPage.setActive(false); }, PAGE_TRANSITION_MS + 40);
@@ -234,6 +255,133 @@ function updateOptionsUi() {
   $('mosaic-slider-row').classList.toggle('hidden', !settings.mosaicAutoChange);
   $('mosaic-sec').value = String(settings.mosaicChangeSec);
   $('mosaic-sec-label').textContent = `${settings.mosaicChangeSec}s`;
+  $('toggle-audio-glow').classList.toggle('on', settings.audioGlow !== false);
+  const pct = Math.round(clampOpacity(settings.windowOpacity) * 100);
+  $('window-opacity').value = String(pct);
+  $('window-opacity-label').textContent = `${pct}%`;
+  $('toggle-clickthrough').classList.toggle('on', clickThrough);
+  updateEyeUi();
+}
+
+// ---------- window opacity / click-through ----------
+
+function clampOpacity(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 1;
+  return Math.min(1, Math.max(OPACITY_MIN, Math.round(n * 100) / 100));
+}
+
+let opacityTimer = null;
+let opacityPendingAt = 0;
+let opacityPending = null;
+
+function flushOpacity() {
+  if (opacityTimer != null) { clearTimeout(opacityTimer); opacityTimer = null; }
+  if (opacityPending == null) return;
+  const v = opacityPending;
+  opacityPending = null;
+  opacityPendingAt = performance.now();
+  setting('windowOpacity', v);
+}
+
+/** Live drag feedback without spamming the host: <=1 post per OPACITY_POST_MS. */
+function queueOpacity(v) {
+  opacityPending = v;
+  if (opacityTimer != null) return;
+  const wait = OPACITY_POST_MS - (performance.now() - opacityPendingAt);
+  if (wait <= 0) flushOpacity();
+  else opacityTimer = setTimeout(flushOpacity, wait);
+}
+
+function setClickThrough(on, fromHost) {
+  clickThrough = !!on;
+  document.body.classList.toggle('clickthrough', clickThrough);
+  $('toggle-clickthrough').classList.toggle('on', clickThrough);
+  if (clickThrough) {
+    $('options-scrim').classList.add('hidden'); // nothing is clickable from here on
+    stopAttention();                            // an unclickable target is just a nag
+  } else {
+    scheduleAttention();
+  }
+  if (!fromHost) setting('clickThrough', clickThrough);
+}
+
+// ---------- eye control ----------
+//
+// The host does the sensing (blink / 2s eyes-closed / calibrated gaze) and posts
+// three message types; everything below is just "which page thing does that mean".
+// Deliberately independent of the chrome: in click-through mode the buttons are
+// gone and the window takes no mouse, and eye control is exactly what is left.
+
+function updateEyeUi() {
+  $('toggle-eye').classList.toggle('on', !!settings.eyeControl);
+  $('toggle-eye-gaze').classList.toggle('on', !!settings.eyeGaze);
+  // Gaze needs the master toggle AND a trained calibration to mean anything.
+  $('eye-gaze-row').classList.toggle('disabled', !(settings.eyeControl && eyeStatus.calibrated));
+  const line = eyeStatusText();
+  $('eye-status').textContent = line ?? '';
+  $('eye-status').classList.toggle('hidden', !line);
+}
+
+function eyeStatusText() {
+  switch (eyeStatus.reason) {
+    case 'starting': return 'Starting webcam...';
+    case 'consent': return 'Webcam permission declined - eye control is off.';
+    case 'no-camera': return 'Webcam unavailable - eye control is off.';
+    case 'error': return 'Webcam error - eye control is off.';
+    default: break;
+  }
+  if (!settings.eyeControl) return null;
+  if (!eyeStatus.running) return 'Starting webcam...';
+  if (!eyeStatus.calibrated) return 'Gaze needs calibration - blink still works.';
+  return null; // running normally: no status line at all
+}
+
+/** True when a gesture must be ignored (a dialog is up, nothing to act on, or
+ *  something is already animating). */
+function eyeBusy() {
+  if (!feed || feed.comps.length === 0 || document.hidden) return true;
+  if (!$('options-scrim').classList.contains('hidden')) return true;  // options open
+  if (!$('crash').classList.contains('hidden')) return true;
+  if (!$('empty').classList.contains('hidden')) return true;
+  const now = performance.now();
+  return now - lastEyeActionAt < EYE_ACTION_COOLDOWN_MS || now < pageBusyUntil;
+}
+
+/** Tile the user is looking at, or -1 (gaze off / uncalibrated / off-window / stale). */
+function gazeTile(page) {
+  if (!settings.eyeGaze || !eyeStatus.calibrated || !lastGaze) return -1;
+  if (performance.now() - lastGaze.t > GAZE_STALE_MS) return -1;
+  return page.tileAtPoint(lastGaze.x * window.innerWidth, lastGaze.y * window.innerHeight);
+}
+
+/** Blink: swap ONE tile (gazed-at, else random). A single-tile page has nothing
+ *  to swap within, so a blink pages on instead. */
+function onEyeBlink() {
+  if (eyeBusy()) return;
+  const page = pageAt(activeIdx);
+  if (!page) return;
+  if (page.tileCount <= 1) {
+    lastEyeActionAt = performance.now();
+    next();
+    return;
+  }
+  if (page.busy) return;
+  let idx = gazeTile(page);
+  if (idx < 0) idx = Math.floor(Math.random() * page.tileCount);
+  // Same path as the › chevron: fresh weighted pick + cross-slide. A refusal
+  // (slot mid-slide) costs nothing — leave the cooldown open for the next blink.
+  if (page.swapTileAt(idx)) lastEyeActionAt = performance.now();
+}
+
+/** Eyes held shut ~2s: change the whole page — morph the mosaic, or scroll on. */
+function onEyesClosed() {
+  if (eyeBusy()) return;
+  const page = pageAt(activeIdx);
+  if (!page) return;
+  lastEyeActionAt = performance.now();
+  if (settings.layout === 'random' && page.morphNow()) return;
+  next();
 }
 
 function updateEmptyState() {
@@ -289,6 +437,35 @@ function wireChrome() {
     setting('mosaicChangeSec', Math.max(3, Math.min(60, Number($('mosaic-sec').value) || 10)));
     updateOptionsUi();
   });
+  $('toggle-audio-glow').addEventListener('click', () => {
+    setting('audioGlow', settings.audioGlow === false);
+    updateOptionsUi();
+    pageAt(activeIdx)?.applyAudio(); // ring appears/disappears immediately
+  });
+  $('window-opacity').addEventListener('input', () => {
+    const pct = Number($('window-opacity').value) || 100;
+    $('window-opacity-label').textContent = `${pct}%`;
+    queueOpacity(clampOpacity(pct / 100));
+  });
+  $('window-opacity').addEventListener('change', () => {
+    const pct = Number($('window-opacity').value) || 100;
+    opacityPending = clampOpacity(pct / 100); // the released value always lands
+    flushOpacity();
+    updateOptionsUi();
+  });
+  $('toggle-eye').addEventListener('click', () => {
+    setting('eyeControl', !settings.eyeControl);
+    // Optimistic UI; the host's eyeStatus is authoritative and will correct this
+    // (including flipping the toggle back off if the camera refuses to start).
+    if (!settings.eyeControl) { eyeStatus = { ...eyeStatus, running: false, reason: null }; lastGaze = null; }
+    updateEyeUi();
+  });
+  $('toggle-eye-gaze').addEventListener('click', () => {
+    if (!settings.eyeControl || !eyeStatus.calibrated) return; // row is inert anyway
+    setting('eyeGaze', !settings.eyeGaze);
+    updateEyeUi();
+  });
+  $('toggle-clickthrough').addEventListener('click', () => setClickThrough(!clickThrough, false));
   $('btn-include-gifs').addEventListener('click', () => {
     setting('includeGifs', true);
     updateOptionsUi();
@@ -337,11 +514,24 @@ function wireInput() {
 
 function scheduleAttention() {
   clearTimeout(attTimer);
+  attTimer = null;
+  if (clickThrough) return; // the target could not be clicked anyway
   attTimer = setTimeout(showAttention, ATTENTION_MIN_GAP_MS + Math.random() * ATTENTION_RAND_MS);
+}
+
+/** Click-through just went on: drop the pending timer AND any live target. */
+function stopAttention() {
+  clearTimeout(attTimer);
+  attTimer = null;
+  const el = $('attention');
+  el.onclick = null;
+  el.classList.add('hidden');
+  el.classList.remove('hit');
 }
 
 function showAttention() {
   const el = $('attention');
+  if (clickThrough) return; // scheduleAttention() resumes it when control returns
   if (document.hidden || !feed || feed.comps.length === 0) { scheduleAttention(); return; }
   el.style.left = (10 + Math.random() * 80) + '%';
   el.style.top = (12 + Math.random() * 72) + '%';
@@ -365,6 +555,11 @@ function onHostMessage(data) {
     case 'init': {
       assets = Array.isArray(data.assets) ? data.assets : [];
       settings = { ...settings, ...(data.settings || {}) };
+      // Host may omit either (older builds) — both default rather than go undefined.
+      settings.audioGlow = settings.audioGlow !== false;
+      settings.windowOpacity = clampOpacity(settings.windowOpacity);
+      clickThrough = false; // never sticky across a reload
+      document.body.classList.remove('clickthrough');
       stats.init(data.stats, (s) => post({ type: 'stats-save', stats: s }));
       feed = createFeed(aspect);
       if (!booted) {
@@ -382,6 +577,38 @@ function onHostMessage(data) {
       scheduleAttention();
       break;
     }
+    case 'clickThrough':
+      // The host flips this off when the panic key gives the mouse back.
+      setClickThrough(!!data.on, true);
+      break;
+    case 'eyeStatus':
+      eyeStatus = {
+        enabled: !!data.enabled,
+        gaze: !!data.gaze,
+        running: !!data.running,
+        calibrated: !!data.calibrated,
+        reason: data.reason ?? null,
+      };
+      // The host is the source of truth for both toggles — a camera that refused
+      // to start arrives here as enabled:false and resets the master pill.
+      settings.eyeControl = eyeStatus.enabled;
+      settings.eyeGaze = eyeStatus.gaze;
+      if (!eyeStatus.enabled) lastGaze = null;
+      updateEyeUi();
+      break;
+    case 'gaze':
+      // Heavily smoothed and frozen while the eyes are shut: stamp it so a blink
+      // can tell a live fixation from a stale one.
+      lastGaze = data.inside === false
+        ? null // looking off the feed window entirely -> no tile target
+        : { x: Number(data.x) || 0, y: Number(data.y) || 0, t: performance.now() };
+      break;
+    case 'blink':
+      onEyeBlink();
+      break;
+    case 'eyesClosed':
+      onEyesClosed();
+      break;
     default:
       break;
   }

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -1,0 +1,422 @@
+// For You feed — orchestrator. Owns the bridge, settings, the vertical pager and
+// the chrome; feed.js owns selection, surfaces.js owns tiles/media.
+
+import * as stats from './stats.js';
+import { createFeed } from './feed.js';
+import { createPage } from './surfaces.js';
+
+const PAGE_TRANSITION_MS = 340;
+const CLIP_VIEWED_MIN_DWELL_MS = 5000; // below this a skim earns no XP
+const ATTENTION_MIN_GAP_MS = 120000;   // attention target every 2-4 min
+const ATTENTION_RAND_MS = 120000;
+const ATTENTION_LIFETIME_MS = 6000;
+
+const $ = (id) => document.getElementById(id);
+const viewport = $('viewport');
+const track = $('track');
+
+// ---------- bridge ----------
+
+const bridge = window.chrome?.webview;
+function post(msg) {
+  try { bridge?.postMessage(msg); } catch { /* host gone */ }
+}
+
+// ---------- state ----------
+
+let assets = [];
+let settings = {
+  layout: 'duo',
+  includeGifs: true,
+  mosaicAutoChange: true,
+  mosaicChangeSec: 10,
+  autoAdvance: false,
+  muted: false,
+};
+let feed = null;
+const pages = new Map();      // compKey -> page object
+const audioFocus = new Map(); // compKey -> tileIndex
+let activeIdx = 0;
+let booted = false;
+let attTimer = null;
+
+const pageH = () => viewport.clientHeight || 1;
+const aspect = () => (viewport.clientWidth || 1) / pageH();
+
+function setting(key, value) {
+  settings[key] = value;
+  post({ type: 'settings-changed', key, value });
+}
+
+// ---------- page context ----------
+
+const pageCtx = {
+  onAdvance(compKey) {
+    if (feed.comps[activeIdx]?.key === compKey) next();
+  },
+  onSwap(compKey, tileIndex, dir) {
+    const cut = feed.swapTile(compKey, tileIndex, dir);
+    if (cut && tileIndex === 0 && feed.comps[activeIdx]?.key === compKey) updateCaption();
+    return cut;
+  },
+  onTapAudio(compKey, tileIndex) {
+    const comp = feed.comps.find((c) => c.key === compKey);
+    if (comp?.tiles[tileIndex]?.cut.asset.type !== 'video') return;
+    audioFocus.set(compKey, tileIndex);
+    if (settings.muted) setMuted(false); // a tap means "let me hear this one"
+  },
+  onMorph(compKey) {
+    const tiles = feed.morph(compKey);
+    if (tiles) {
+      audioFocus.delete(compKey); // a stale index would point at the wrong clip
+      if (feed.comps[activeIdx]?.key === compKey) updateCaption();
+    }
+    return tiles;
+  },
+  onAssetMeta(asset, meta) {
+    post({ type: 'asset-meta', id: asset.id, ...meta });
+    // Backfill in place — improves future picks WITHOUT resetting the feed.
+    if (meta.durationMs != null) asset.durationMs = meta.durationMs;
+    if (meta.width != null) { asset.width = meta.width; asset.height = meta.height; }
+    feed.noteAssetMeta();
+  },
+  report(segIdKey, dwellMs, clipLenMs) {
+    stats.recordView(segIdKey, dwellMs, clipLenMs);
+    if (dwellMs >= CLIP_VIEWED_MIN_DWELL_MS) {
+      post({ type: 'clip-viewed', segId: segIdKey, dwellMs: Math.round(dwellMs) });
+    }
+  },
+  isAutoAdvance: () => settings.autoAdvance,
+  isMuted: () => settings.muted,
+  audioFocus: (compKey) => audioFocus.get(compKey),
+  mosaicAutoChange: () => settings.mosaicAutoChange,
+  mosaicChangeMs: () => settings.mosaicChangeSec * 1000,
+};
+
+// ---------- pager ----------
+
+function pageAt(i) {
+  const comp = feed.comps[i];
+  return comp ? pages.get(comp.key) : undefined;
+}
+
+function applyTrack(animated) {
+  track.style.transition = animated
+    ? `transform ${PAGE_TRANSITION_MS}ms cubic-bezier(0.22, 0.9, 0.36, 1)`
+    : 'none';
+  track.style.transform = `translateY(${-activeIdx * pageH()}px)`;
+}
+
+/** Reconcile page DOM with feed.comps (after configure/extend/trim). */
+function syncPages() {
+  const comps = feed.comps;
+  const keep = new Set(comps.map((c) => c.key));
+  for (const [key, page] of pages) {
+    if (!keep.has(key)) {
+      page.destroy();
+      pages.delete(key);
+      audioFocus.delete(key);
+    }
+  }
+  comps.forEach((c, i) => {
+    let page = pages.get(c.key);
+    if (!page) {
+      page = createPage(c, pageCtx);
+      pages.set(c.key, page);
+      track.appendChild(page.el);
+    }
+    page.el.style.top = (i * 100) + '%';
+  });
+}
+
+function goTo(idx, animated = true) {
+  const comps = feed.comps;
+  if (idx < 0 || idx >= comps.length || idx === activeIdx) return;
+  const prevPage = pageAt(activeIdx);
+  activeIdx = idx;
+  const page = pageAt(idx);
+  page?.setActive(true); // both pages live during the slide — no black gap
+  applyTrack(animated);
+  if (prevPage && prevPage !== page) {
+    if (animated) {
+      setTimeout(() => { if (pageAt(activeIdx) !== prevPage) prevPage.setActive(false); }, PAGE_TRANSITION_MS + 40);
+    } else {
+      prevPage.setActive(false);
+    }
+  }
+  updateCaption();
+  // Append (and possibly head-trim) OUTSIDE the slide so the compensating
+  // instant re-offset can never cancel the animation mid-flight.
+  setTimeout(maybeExtend, animated ? PAGE_TRANSITION_MS + 60 : 0);
+}
+
+const next = () => goTo(activeIdx + 1);
+const prev = () => goTo(activeIdx - 1);
+
+function maybeExtend() {
+  if (!feed || feed.comps.length === 0) return;
+  if (activeIdx < feed.comps.length - 3) return;
+  const { appended, trimmed } = feed.extend();
+  if (!appended && !trimmed) return;
+  if (trimmed) activeIdx = Math.max(0, activeIdx - trimmed);
+  syncPages();
+  applyTrack(false); // same visual position: pages shifted up + offset reduced together
+}
+
+// ---------- config / rebuild ----------
+
+function applyConfig() {
+  const reset = feed.configure(assets, settings.includeGifs, settings.layout);
+  if (reset) {
+    for (const p of pages.values()) p.destroy();
+    pages.clear();
+    audioFocus.clear();
+    activeIdx = 0;
+    syncPages();
+    applyTrack(false);
+    pageAt(0)?.setActive(true);
+    updateCaption();
+  }
+  updateEmptyState();
+}
+
+/** Crash-retry: rebuild the whole engine from the current manifest. */
+function hardReset() {
+  for (const p of pages.values()) { try { p.destroy(); } catch { /* dying anyway */ } }
+  pages.clear();
+  audioFocus.clear();
+  track.innerHTML = '';
+  activeIdx = 0;
+  feed = createFeed(aspect);
+  applyConfig();
+}
+
+// ---------- chrome ----------
+
+function updateCaption() {
+  const cap = pageAt(activeIdx)?.caption();
+  $('caption-name').textContent = cap?.filename ?? '';
+  $('caption-folder').textContent = cap?.folder ?? '';
+}
+
+function setMuted(m) {
+  settings.muted = m;
+  post({ type: 'settings-changed', key: 'muted', value: m });
+  $('btn-mute').textContent = m ? '🔇' : '🔊';
+  $('btn-mute').classList.toggle('off', m);
+  pageAt(activeIdx)?.applyAudio();
+}
+
+function setAutoAdvance(on) {
+  settings.autoAdvance = on;
+  post({ type: 'settings-changed', key: 'autoAdvance', value: on });
+  $('btn-advance').classList.toggle('off', !on);
+  $('btn-advance').title = on
+    ? 'Auto-advance ON: scrolls on when a clip ends'
+    : 'Auto-advance OFF: clips loop until you scroll';
+  pageAt(activeIdx)?.applyAutoAdvance();
+}
+
+function updateChromeForLayout() {
+  // Random mode advances itself via the morph timer — hide the toggle there.
+  $('btn-advance').classList.toggle('hidden', settings.layout === 'random');
+}
+
+function updateOptionsUi() {
+  document.querySelectorAll('.layout-chip').forEach((chip) => {
+    chip.classList.toggle('selected', chip.dataset.layout === settings.layout);
+  });
+  $('toggle-gifs').classList.toggle('on', settings.includeGifs);
+  $('toggle-mosaic').classList.toggle('on', settings.mosaicAutoChange);
+  $('mosaic-sub').textContent = settings.mosaicAutoChange
+    ? 'Mosaic reshuffles on a timer'
+    : 'Mosaic holds until you swipe';
+  $('mosaic-slider-row').classList.toggle('hidden', !settings.mosaicAutoChange);
+  $('mosaic-sec').value = String(settings.mosaicChangeSec);
+  $('mosaic-sec-label').textContent = `${settings.mosaicChangeSec}s`;
+}
+
+function updateEmptyState() {
+  const empty = feed.comps.length === 0;
+  $('empty').classList.toggle('hidden', !empty);
+  if (empty) {
+    const hiddenGifs = settings.includeGifs ? 0 : assets.filter((a) => a.type === 'gif').length;
+    const btn = $('btn-include-gifs');
+    btn.classList.toggle('hidden', hiddenGifs === 0);
+    btn.textContent = `INCLUDE ${hiddenGifs} GIF${hiddenGifs === 1 ? '' : 'S'}`;
+  }
+}
+
+function wireChrome() {
+  $('btn-mute').addEventListener('click', () => setMuted(!settings.muted));
+  $('btn-advance').addEventListener('click', () => setAutoAdvance(!settings.autoAdvance));
+  $('btn-fullscreen').addEventListener('click', () => {
+    if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
+    else document.documentElement.requestFullscreen().catch(() => {});
+  });
+  $('btn-options').addEventListener('click', () => $('options-scrim').classList.remove('hidden'));
+  $('btn-options-close').addEventListener('click', () => $('options-scrim').classList.add('hidden'));
+  $('options-scrim').addEventListener('click', (e) => {
+    if (e.target === $('options-scrim')) $('options-scrim').classList.add('hidden');
+  });
+
+  document.querySelectorAll('.layout-chip').forEach((chip) => {
+    chip.addEventListener('click', () => {
+      const layout = chip.dataset.layout;
+      if (layout === settings.layout) return;
+      setting('layout', layout);
+      updateOptionsUi();
+      updateChromeForLayout();
+      applyConfig(); // layout change resets the feed to the top (mobile behavior)
+    });
+  });
+  $('toggle-gifs').addEventListener('click', () => {
+    setting('includeGifs', !settings.includeGifs);
+    updateOptionsUi();
+    applyConfig(); // pool identity changed
+  });
+  $('toggle-mosaic').addEventListener('click', () => {
+    setting('mosaicAutoChange', !settings.mosaicAutoChange);
+    updateOptionsUi();
+    // live page picks the flag up on its next schedule pass
+    const page = pageAt(activeIdx);
+    if (page) { page.setActive(false); page.setActive(true); }
+  });
+  $('mosaic-sec').addEventListener('input', () => {
+    $('mosaic-sec-label').textContent = `${$('mosaic-sec').value}s`;
+  });
+  $('mosaic-sec').addEventListener('change', () => {
+    setting('mosaicChangeSec', Math.max(3, Math.min(60, Number($('mosaic-sec').value) || 10)));
+    updateOptionsUi();
+  });
+  $('btn-include-gifs').addEventListener('click', () => {
+    setting('includeGifs', true);
+    updateOptionsUi();
+    applyConfig();
+  });
+  $('btn-retry').addEventListener('click', () => {
+    $('crash').classList.add('hidden');
+    hardReset();
+  });
+}
+
+// ---------- input ----------
+
+function wireInput() {
+  let wheelLockUntil = 0;
+  viewport.addEventListener('wheel', (e) => {
+    const now = performance.now();
+    if (now < wheelLockUntil || Math.abs(e.deltaY) < 30) return;
+    wheelLockUntil = now + PAGE_TRANSITION_MS + 60;
+    if (e.deltaY > 0) next(); else prev();
+  }, { passive: true });
+
+  document.addEventListener('keydown', (e) => {
+    switch (e.key) {
+      case 'ArrowDown': case 'PageDown': next(); e.preventDefault(); break;
+      case 'ArrowUp': case 'PageUp': prev(); e.preventDefault(); break;
+      case 'm': case 'M': setMuted(!settings.muted); break;
+      default: break;
+    }
+  });
+
+  window.addEventListener('resize', () => applyTrack(false));
+
+  // Minimized/hidden: tear the live page down (reports dwell, frees decoders);
+  // restore on return.
+  document.addEventListener('visibilitychange', () => {
+    const page = pageAt(activeIdx);
+    if (!page) return;
+    if (document.hidden) page.setActive(false);
+    else page.setActive(true);
+  });
+  window.addEventListener('pagehide', () => stats.flush());
+}
+
+// ---------- attention check ----------
+
+function scheduleAttention() {
+  clearTimeout(attTimer);
+  attTimer = setTimeout(showAttention, ATTENTION_MIN_GAP_MS + Math.random() * ATTENTION_RAND_MS);
+}
+
+function showAttention() {
+  const el = $('attention');
+  if (document.hidden || !feed || feed.comps.length === 0) { scheduleAttention(); return; }
+  el.style.left = (10 + Math.random() * 80) + '%';
+  el.style.top = (12 + Math.random() * 72) + '%';
+  el.classList.remove('hidden', 'hit');
+  const gone = setTimeout(() => { el.classList.add('hidden'); scheduleAttention(); }, ATTENTION_LIFETIME_MS);
+  el.onclick = () => {
+    clearTimeout(gone);
+    el.onclick = null;
+    post({ type: 'attention-hit' });
+    el.classList.add('hit');
+    setTimeout(() => el.classList.add('hidden'), 400);
+    scheduleAttention();
+  };
+}
+
+// ---------- host messages ----------
+
+function onHostMessage(data) {
+  if (!data || typeof data !== 'object') return;
+  switch (data.type) {
+    case 'init': {
+      assets = Array.isArray(data.assets) ? data.assets : [];
+      settings = { ...settings, ...(data.settings || {}) };
+      stats.init(data.stats, (s) => post({ type: 'stats-save', stats: s }));
+      feed = createFeed(aspect);
+      if (!booted) {
+        booted = true;
+        wireChrome();
+        wireInput();
+      }
+      updateOptionsUi();
+      updateChromeForLayout();
+      $('btn-mute').textContent = settings.muted ? '🔇' : '🔊';
+      $('btn-mute').classList.toggle('off', settings.muted);
+      $('btn-advance').classList.toggle('off', !settings.autoAdvance);
+      applyConfig();
+      $('boot').classList.add('hidden');
+      scheduleAttention();
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+// ---------- crash containment ----------
+
+window.addEventListener('error', (e) => {
+  // The feed is the crashiest surface (media-heavy) — contain it to a retry
+  // panel instead of a dead page.
+  try {
+    $('crash-detail').textContent = String(e.message || 'unknown error');
+    $('crash').classList.remove('hidden');
+  } catch { /* truly broken */ }
+});
+
+// ---------- debug hooks (soak checks) ----------
+
+Object.defineProperty(window, '__ccpDebug', {
+  value: {
+    get compsLen() { return feed?.comps.length ?? 0; },
+    get historySize() { return feed?.historySize ?? 0; },
+    get audioFocusCount() { return audioFocus.size; },
+    get statCount() { return stats.statCount(); },
+    get activeIdx() { return activeIdx; },
+  },
+});
+
+// ---------- boot ----------
+
+if (bridge) {
+  bridge.addEventListener('message', (e) => onHostMessage(e.data));
+  post({ type: 'ready' });
+} else {
+  // Opened in a plain browser (dev): show the empty state instead of hanging.
+  $('boot').classList.add('hidden');
+  $('empty').classList.remove('hidden');
+}

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -11,7 +11,7 @@ const ATTENTION_MIN_GAP_MS = 120000;   // attention target every 2-4 min
 const ATTENTION_RAND_MS = 120000;
 const ATTENTION_LIFETIME_MS = 6000;
 const OPACITY_POST_MS = 100;           // throttle window-opacity posts while dragging
-const OPACITY_MIN = 0.3;
+const OPACITY_MIN = 0.01;
 // Eye control: one action per 600ms (a double-blink is a very common reflex), and a
 // gaze point older than this is treated as stale — the host freezes gaze while the
 // eyes are closed, so the point at blink time is always ~a moment old by design.
@@ -263,7 +263,12 @@ function updateOptionsUi() {
   updateEyeUi();
 }
 
-// ---------- window opacity / click-through ----------
+// ---------- window opacity / ghost mode ----------
+//
+// Both are HOST-side now. The slider sets the real translucency of the ghost mirror (a plain
+// window whose constant alpha the DWM thumbnail respects), so there is nothing to draw here —
+// the page only reports the value. Ghost mode itself parks the real window off-screen; the
+// page keeps calling it `clickThrough` on the wire, which is all the host listens for.
 
 function clampOpacity(v) {
   const n = Number(v);
@@ -293,14 +298,23 @@ function queueOpacity(v) {
   else opacityTimer = setTimeout(flushOpacity, wait);
 }
 
+let ctNoteTimer = null;
+
+/** Ghost mode on/off. (`clickThrough` is the wire name; the host parks the real window
+ *  off-screen behind a see-through DWM mirror.) */
 function setClickThrough(on, fromHost) {
   clickThrough = !!on;
   document.body.classList.toggle('clickthrough', clickThrough);
   $('toggle-clickthrough').classList.toggle('on', clickThrough);
+  clearTimeout(ctNoteTimer);
   if (clickThrough) {
     $('options-scrim').classList.add('hidden'); // nothing is clickable from here on
     stopAttention();                            // an unclickable target is just a nag
+    // The chrome just vanished on purpose — say so, or it reads as a breakage.
+    $('ct-note').classList.add('show');
+    ctNoteTimer = setTimeout(() => $('ct-note').classList.remove('show'), 7000);
   } else {
+    $('ct-note').classList.remove('show');
     scheduleAttention();
   }
   if (!fromHost) setting('clickThrough', clickThrough);
@@ -318,6 +332,9 @@ function updateEyeUi() {
   $('toggle-eye-gaze').classList.toggle('on', !!settings.eyeGaze);
   // Gaze needs the master toggle AND a trained calibration to mean anything.
   $('eye-gaze-row').classList.toggle('disabled', !(settings.eyeControl && eyeStatus.calibrated));
+  // Calibration only needs a running camera, i.e. the master toggle.
+  $('eye-calibrate-row').classList.toggle('disabled', !(settings.eyeControl && eyeStatus.running));
+  $('btn-calibrate').textContent = eyeStatus.calibrated ? 'Recalibrate' : 'Calibrate';
   const line = eyeStatusText();
   $('eye-status').textContent = line ?? '';
   $('eye-status').classList.toggle('hidden', !line);
@@ -445,7 +462,7 @@ function wireChrome() {
   $('window-opacity').addEventListener('input', () => {
     const pct = Number($('window-opacity').value) || 100;
     $('window-opacity-label').textContent = `${pct}%`;
-    queueOpacity(clampOpacity(pct / 100));
+    queueOpacity(clampOpacity(pct / 100)); // the host owns the visual (ghost mirror alpha)
   });
   $('window-opacity').addEventListener('change', () => {
     const pct = Number($('window-opacity').value) || 100;
@@ -466,6 +483,8 @@ function wireChrome() {
     updateEyeUi();
   });
   $('toggle-clickthrough').addEventListener('click', () => setClickThrough(!clickThrough, false));
+  // The host runs the native calibration dialog (it owns the webcam); the click just asks.
+  $('btn-calibrate').addEventListener('click', () => post({ type: 'calibrate' }));
   $('btn-include-gifs').addEventListener('click', () => {
     setting('includeGifs', true);
     updateOptionsUi();
@@ -493,6 +512,12 @@ function wireInput() {
       case 'ArrowDown': case 'PageDown': next(); e.preventDefault(); break;
       case 'ArrowUp': case 'PageUp': prev(); e.preventDefault(); break;
       case 'm': case 'M': setMuted(!settings.muted); break;
+      case 'Escape':
+        // Only meaningful while the window still holds keyboard focus (right
+        // after flipping the toggle — exactly when someone wants out). Native
+        // fullscreen-exit on Esc still happens; that's fine, both say "back off".
+        if (clickThrough) setClickThrough(false, false);
+        break;
       default: break;
     }
   });
@@ -580,6 +605,16 @@ function onHostMessage(data) {
     case 'clickThrough':
       // The host flips this off when the panic key gives the mouse back.
       setClickThrough(!!data.on, true);
+      break;
+    case 'openOptions':
+      // The ghost gear button: the host has just un-ghosted us and wants the popover up.
+      updateOptionsUi();
+      $('options-scrim').classList.remove('hidden');
+      break;
+    case 'setMuted':
+      // The ghost speaker button. setMuted echoes a settings-changed back; the host sets
+      // the same value again, which is harmless.
+      setMuted(!!data.on);
       break;
     case 'eyeStatus':
       eyeStatus = {

--- a/ConditioningControlPanel/Resources/web/fyp/segments.js
+++ b/ConditioningControlPanel/Resources/web/fyp/segments.js
@@ -1,0 +1,69 @@
+// Segment grid + weighting constants — 1:1 port of the mobile reel's lib/reelSegments.ts.
+// Contract: the *played* window must equal the *scored* segId, or retention accrues
+// against sections that were never actually on screen.
+
+/** Grid stride: one addressable segment starts every 30s of a video's timeline. */
+export const SEGMENT_STRIDE_SEC = 30;
+/** Per-cut random window length range (continuous, not integral). */
+export const CLIP_MIN_SEC = 20;
+export const CLIP_MAX_SEC = 40;
+/** Videos at most this long play whole (single segment, no grid). */
+export const WHOLE_VIDEO_MAX_SEC = CLIP_MAX_SEC + 10;
+
+/** Dwell is capped at this multiple of the clip length (loop-camping guard). */
+export const DWELL_CAP_FACTOR = 2;
+/** Dwell / (RETENTION_TARGET * clipLen) saturates the retention score at 1. */
+export const RETENTION_TARGET = 2;
+/** EWMA blend factor for the retention score. */
+export const EWMA_ALPHA = 0.3;
+/** Score assumed for a segment never seen (optimism prior). */
+export const SCORE_PRIOR = 0.5;
+/** Soft cap on distinct segment stats kept. */
+export const MAX_STAT_ENTRIES = 5000;
+
+/** Selection weight: W_BASE + W_BOOST_MAX*score + W_EXPLORE_BONUS/(1+plays).
+ *  Balanced profile — hot segments reach ~4x the floor. */
+export const W_BASE = 1;
+export const W_BOOST_MAX = 3;
+export const W_EXPLORE_BONUS = 1;
+
+/** Wider-than-tall enough to stack; excludes near-square by design. */
+export const LANDSCAPE_RATIO = 1.2;
+
+/** Asset ids are relative paths (never contain ':'), so ':' separates cleanly. */
+export function segId(assetId, k) {
+  return `${assetId}:${k}`;
+}
+
+export function assetIdOf(key) {
+  return key.slice(0, key.indexOf(':'));
+}
+
+/** How many segments a video of this duration exposes. Bucket count is sized off
+ *  CLIP_MAX (not the per-cut random length) so the set is stable across sessions. */
+export function segmentCount(durationSec) {
+  if (!Number.isFinite(durationSec) || durationSec <= 0) return 1;
+  const span = durationSec - CLIP_MAX_SEC;
+  if (span <= 0) return 1;
+  return Math.floor(span / SEGMENT_STRIDE_SEC) + 1;
+}
+
+/** Which segment a (possibly seed-derived) start offset falls into. */
+export function segmentIndexForStart(startSec) {
+  return startSec > 0 ? Math.floor(startSec / SEGMENT_STRIDE_SEC) : 0;
+}
+
+/** Grid-aligned start for segment k, clamped so the window fits the video. */
+export function startForSegment(k, durationSec, clipLenSec) {
+  return Math.min(k * SEGMENT_STRIDE_SEC, Math.max(0, durationSec - clipLenSec));
+}
+
+/** Random window length in [CLIP_MIN, CLIP_MAX) seconds. */
+export function randomClipLenSec(rng = Math.random) {
+  return CLIP_MIN_SEC + rng() * (CLIP_MAX_SEC - CLIP_MIN_SEC);
+}
+
+/** Unknown dims are treated as portrait until a probe backfills them. */
+export function isLandscapeDims(w, h) {
+  return w != null && h != null && h > 0 && w >= h * LANDSCAPE_RATIO;
+}

--- a/ConditioningControlPanel/Resources/web/fyp/stats.js
+++ b/ConditioningControlPanel/Resources/web/fyp/stats.js
@@ -1,0 +1,85 @@
+// Retention stats — port of the mobile reel's state/reelStatsStore.ts.
+// One record per segment: { plays, dwellMs, score, lastShownAt }.
+//   plays       — confidence (drives the exploration bonus decay)
+//   dwellMs     — cumulative CAPPED dwell (debug/average only)
+//   score       — EWMA retention 0..1 (the value selection consumes)
+//   lastShownAt — epoch ms; recency + LRU eviction key
+// Persistence goes through the C# bridge (fyp_stats.json): trailing-throttled so a
+// swipe storm costs one write, flushed on pagehide.
+
+import {
+  DWELL_CAP_FACTOR, RETENTION_TARGET, EWMA_ALPHA, SCORE_PRIOR, MAX_STAT_ENTRIES, assetIdOf,
+} from './segments.js';
+
+const WRITE_WINDOW_MS = 2000;
+
+let stats = Object.create(null);
+let saveTimer = null;
+let postSave = null; // set by init(); posts {type:'stats-save', stats} to C#
+
+export function init(persisted, postSaveFn) {
+  postSave = postSaveFn;
+  stats = Object.create(null);
+  if (persisted && typeof persisted === 'object') {
+    for (const [k, v] of Object.entries(persisted)) {
+      if (v && typeof v.score === 'number') stats[k] = v;
+    }
+  }
+}
+
+export function segmentScore(id) {
+  return stats[id]?.score ?? SCORE_PRIOR;
+}
+
+export function segmentPlays(id) {
+  return stats[id]?.plays ?? 0;
+}
+
+/** Record one viewing. Cap and target share the same factor, so retention
+ *  saturates at 1.0 exactly where the loop-camping cap bites. */
+export function recordView(id, dwellMs, clipLenMs) {
+  if (!(clipLenMs > 0) || !(dwellMs > 0)) return;
+  const capped = Math.min(dwellMs, DWELL_CAP_FACTOR * clipLenMs);
+  const r = Math.min(1, capped / (RETENTION_TARGET * clipLenMs));
+  const prev = stats[id];
+  const isNew = !prev;
+  stats[id] = {
+    plays: (prev?.plays ?? 0) + 1,
+    dwellMs: (prev?.dwellMs ?? 0) + capped,
+    score: prev ? (1 - EWMA_ALPHA) * prev.score + EWMA_ALPHA * r : r,
+    lastShownAt: Date.now(),
+  };
+  // Soft cap: prune only when a NEW key pushes the map over the limit.
+  if (isNew) {
+    const keys = Object.keys(stats);
+    if (keys.length > MAX_STAT_ENTRIES) {
+      keys.sort((a, b) => (stats[a].lastShownAt ?? 0) - (stats[b].lastShownAt ?? 0));
+      for (let i = 0; i < keys.length - MAX_STAT_ENTRIES; i++) delete stats[keys[i]];
+    }
+  }
+  scheduleSave();
+}
+
+/** Drop stats for assets that left the manifest (mirror of pruneAssets). */
+export function pruneToAssets(aliveAssetIds) {
+  let changed = false;
+  for (const k of Object.keys(stats)) {
+    if (!aliveAssetIds.has(assetIdOf(k))) { delete stats[k]; changed = true; }
+  }
+  if (changed) scheduleSave();
+}
+
+function scheduleSave() {
+  if (saveTimer != null) return;
+  saveTimer = setTimeout(() => { saveTimer = null; flush(); }, WRITE_WINDOW_MS);
+}
+
+/** Immediate write-through (pagehide / manual). */
+export function flush() {
+  if (saveTimer != null) { clearTimeout(saveTimer); saveTimer = null; }
+  try { postSave?.(stats); } catch { /* bridge gone — nothing to do */ }
+}
+
+export function statCount() {
+  return Object.keys(stats).length;
+}

--- a/ConditioningControlPanel/Resources/web/fyp/surfaces.js
+++ b/ConditioningControlPanel/Resources/web/fyp/surfaces.js
@@ -223,6 +223,12 @@ function createTileSlot(page, tileIndex, ctx) {
   clip.className = 'swap-clip';
   slot.appendChild(clip);
 
+  // Audible-tile cue. A shadow set on .tile itself would be painted over by the
+  // <video>/<img>, so the ring lives on its own overlay above the surface.
+  const ring = document.createElement('div');
+  ring.className = 'audio-ring';
+  slot.appendChild(ring);
+
   const chevL = document.createElement('button');
   chevL.className = 'chev chev-l';
   chevL.textContent = '‹';
@@ -329,6 +335,10 @@ function createTileSlot(page, tileIndex, ctx) {
   let lastT = 0;
   let velocity = 0;
   slot.addEventListener('pointerdown', (e) => {
+    // A press on a chevron must never start a drag: setPointerCapture below
+    // retargets the whole gesture (including the compatibility `click`) to the
+    // slot, which is exactly what used to swallow the chevron's own click.
+    if (e.target.closest?.('.chev')) return;
     if (e.button !== 0 || sliding || !surface) return;
     dragId = e.pointerId;
     dragStartX = lastX = e.clientX;
@@ -369,16 +379,39 @@ function createTileSlot(page, tileIndex, ctx) {
   slot.addEventListener('pointerup', endDrag);
   slot.addEventListener('pointercancel', (e) => { if (dragId === e.pointerId) { dragId = null; springBack(); } });
 
-  chevL.addEventListener('click', (e) => { e.stopPropagation(); if (!sliding) commit('back'); });
-  chevR.addEventListener('click', (e) => { e.stopPropagation(); if (!sliding) commit('next'); });
+  // Chevrons drive the same commit path as the drag: ‹ = history-back (what a
+  // rightward drag does), › = fresh pick (what a leftward drag does).
+  function wireChev(btn, dir) {
+    // Stop the press from reaching the slot at all (belt and braces alongside
+    // the .chev bail above) so no pointer capture is ever taken for it.
+    btn.addEventListener('pointerdown', (e) => { e.stopPropagation(); });
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (sliding || !surface) return;
+      commit(dir);
+    });
+  }
+  wireChev(chevL, 'back');
+  wireChev(chevR, 'next');
 
   return {
     el: slot,
     get tile() { return tile; },
     get surface() { return surface; },
+    get sliding() { return sliding; },
     mount,
     unmount,
     applyRect,
+    /** Eye control: the exact chevron path (same guard, same cross-slide).
+     *  Returns false when the slot could not act (mid-slide / not mounted). */
+    commitSwap(dir) {
+      if (sliding || !surface) return false;
+      commit(dir);
+      return true;
+    },
+    /** Audible-tile ring (page decides; honours the audioGlow setting + mute). */
+    setAudioGlow(on) { slot.classList.toggle('audio-glow', !!on); },
   };
 }
 
@@ -386,7 +419,8 @@ function createTileSlot(page, tileIndex, ctx) {
  * One feed page. Created for every composition in the window; only mounts live
  * media while active. ctx:
  *   { onAdvance(compKey), onSwap(compKey, i, dir), onTapAudio(compKey, i),
- *     onAssetMeta, report, isAutoAdvance(), isMuted(), audioFocus() -> index|null }
+ *     onAssetMeta, report, isAutoAdvance(), isMuted(), audioGlow() -> bool,
+ *     audioFocus() -> index|null }
  */
 export function createPage(comp, ctx) {
   const el = document.createElement('div');
@@ -398,6 +432,7 @@ export function createPage(comp, ctx) {
   let active = false;
   let slots = [];
   let morphTimer = null;
+  let morphing = false;  // a morph's fade-out is in flight
 
   function audioIndex() {
     const focus = ctx.audioFocus(comp.key);
@@ -408,7 +443,13 @@ export function createPage(comp, ctx) {
   function applyAudio() {
     const ai = audioIndex();
     const muted = ctx.isMuted();
-    slots.forEach((s, i) => s.surface?.setMuted(muted || i !== ai));
+    // Nothing is audible while muted (or when no tile carries audio at all) —
+    // in that case no tile glows either.
+    const glow = !muted && ai >= 0 && ctx.audioGlow?.() !== false;
+    slots.forEach((s, i) => {
+      s.surface?.setMuted(muted || i !== ai);
+      s.setAudioGlow(glow && i === ai);
+    });
   }
 
   function slotCtx(i) {
@@ -438,21 +479,32 @@ export function createPage(comp, ctx) {
     slots = [];
   }
 
+  /** The morph itself (fade out -> re-compose -> fade in), shared by the timer and
+   *  by the eyes-closed gesture. Returns false when it could not run. */
+  function runMorph() {
+    if (!active || morphing || comp.layout !== 'random') return false;
+    morphing = true;
+    if (morphTimer != null) { clearTimeout(morphTimer); morphTimer = null; }
+    inner.style.transition = `opacity ${MORPH_FADE_OUT_MS}ms ease-in`;
+    inner.style.opacity = '0';
+    setTimeout(() => {
+      morphing = false;
+      if (!active) { inner.style.opacity = '1'; return; }
+      const tiles = ctx.onMorph(comp.key); // feed re-composes in place
+      if (tiles) { unmountTiles(); mountTiles(); }
+      inner.style.transition = `opacity ${MORPH_FADE_IN_MS}ms ease-out`;
+      inner.style.opacity = '1';
+      scheduleMorph();
+    }, MORPH_FADE_OUT_MS);
+    return true;
+  }
+
+  // Only clears/re-arms the timer — it must NOT touch opacity, or re-arming at the
+  // tail of a morph would stomp the fade-in transition it was just given.
   function scheduleMorph() {
-    cancelMorph();
+    if (morphTimer != null) { clearTimeout(morphTimer); morphTimer = null; }
     if (!active || comp.layout !== 'random' || !ctx.mosaicAutoChange()) return;
-    morphTimer = setTimeout(() => {
-      inner.style.transition = `opacity ${MORPH_FADE_OUT_MS}ms ease-in`;
-      inner.style.opacity = '0';
-      setTimeout(() => {
-        if (!active) { inner.style.opacity = '1'; return; }
-        const tiles = ctx.onMorph(comp.key); // feed re-composes in place
-        if (tiles) { unmountTiles(); mountTiles(); }
-        inner.style.transition = `opacity ${MORPH_FADE_IN_MS}ms ease-out`;
-        inner.style.opacity = '1';
-        scheduleMorph();
-      }, MORPH_FADE_OUT_MS);
-    }, Math.max(3000, ctx.mosaicChangeMs()));
+    morphTimer = setTimeout(runMorph, Math.max(3000, ctx.mosaicChangeMs()));
   }
 
   function cancelMorph() {
@@ -466,6 +518,31 @@ export function createPage(comp, ctx) {
     key: comp.key,
     comp,
     get active() { return active; },
+
+    // ---- eye control ----
+    /** Tiles currently mounted (falls back to the model when inactive). */
+    get tileCount() { return slots.length || comp.tiles.length; },
+    /** True while a tile slide or a morph is in flight — do not act on a gesture. */
+    get busy() { return morphing || slots.some((s) => s.sliding); },
+    /**
+     * Index of the tile under a client-space point, or -1. Uses the slots' own
+     * laid-out rects, so it is right for every layout without duplicating the
+     * band/mosaic geometry: duo/trio bands and mosaic cells are both just rects.
+     */
+    tileAtPoint(cx, cy) {
+      for (let i = 0; i < slots.length; i++) {
+        const r = slots[i].el.getBoundingClientRect();
+        if (cx >= r.left && cx < r.right && cy >= r.top && cy < r.bottom) return i;
+      }
+      return -1;
+    },
+    /** Swap one tile through the exact chevron path (fresh pick + cross-slide). */
+    swapTileAt(i) {
+      return slots[i] ? slots[i].commitSwap('next') : false;
+    },
+    /** Re-compose the whole mosaic now, with the timer's fade choreography. */
+    morphNow() { return runMorph(); },
+
     setActive(on) {
       if (on === active) return;
       active = on;

--- a/ConditioningControlPanel/Resources/web/fyp/surfaces.js
+++ b/ConditioningControlPanel/Resources/web/fyp/surfaces.js
@@ -1,0 +1,492 @@
+// Tile surfaces + pages — the DOM/media layer under feed.js's data model.
+//
+// Rules carried over from mobile (they are what keeps this smooth):
+//  - Only the ACTIVE page mounts live <video>/<img> elements; a deactivated page
+//    tears its media down immediately (reporting dwell exactly once) and shows a
+//    dark placeholder. Chromium then releases the decoders.
+//  - Dwell = wall-clock while the surface is active AND playing, accumulated
+//    across stalls; reported once on teardown.
+//  - The played window must match the scored segId (grid cuts seek to their
+//    grid start; cold cuts score the section actually played).
+//  - Unmount clears src + load() so the decoder frees now, not at GC time.
+
+import { WHOLE_VIDEO_MAX_SEC, segId, segmentIndexForStart, startForSegment } from './segments.js';
+
+const SWAP_MS = 260;          // cross-slide duration on a committed swap
+const DRAG_RESISTANCE = 0.7;  // finger-follow while dragging
+const COMMIT_DIST = 64;       // px to commit a swap
+const COMMIT_VELOCITY = 0.8;  // px/ms
+const ERROR_ADVANCE_MS = 1200; // never machine-gun a broken pack
+const MORPH_FADE_OUT_MS = 220;
+const MORPH_FADE_IN_MS = 260;
+
+/**
+ * One live media surface for a cut. Returns { el, stop(), setMuted(), setAutoAdvance() }.
+ * ctx: { onEnded, onError, onAssetMeta, report(segId, dwellMs, clipLenMs), advances }
+ */
+function createVideoSurface(cut, ctx) {
+  const el = document.createElement('div');
+  el.className = 'surface';
+  const video = document.createElement('video');
+  video.src = cut.asset.url;
+  video.preload = 'auto';
+  video.playsInline = true;
+  video.disablePictureInPicture = true;
+  video.muted = true; // page audio routing unmutes the one audible tile
+  // Loop only matters at a natural end (whole-video cuts; windowed cuts are
+  // steered by timeupdate before they ever get there).
+  video.loop = !(ctx.autoAdvance && ctx.advances);
+  video.style.objectFit = cut.fit;
+  el.appendChild(video);
+
+  let cutStart = null;   // seconds; null until metadata
+  let windowLen = null;  // null = whole-video cut
+  let finished = false;
+  let autoAdvance = ctx.autoAdvance;
+  // Retention attribution (set at metadata; cold cuts score what actually played).
+  let scoreSegId = null;
+  let clipLenSec = cut.lenSec;
+  // Dwell bookkeeping.
+  let dwellAccum = 0;
+  let watchStart = null;
+  let reported = false;
+  let metaSent = false;
+  let errTimer = null;
+
+  const openDwell = () => { if (watchStart == null) watchStart = performance.now(); };
+  const closeDwell = () => {
+    if (watchStart != null) { dwellAccum += performance.now() - watchStart; watchStart = null; }
+  };
+
+  video.addEventListener('playing', openDwell);
+  video.addEventListener('waiting', closeDwell);
+  video.addEventListener('pause', () => {
+    closeDwell();
+    // There is no user-facing pause on the reel, so an unrequested pause while
+    // the surface is live is an interruption — resume it (mobile parity). The
+    // `reported` guard keeps teardown's own pause from re-kicking playback.
+    if (!reported && !finished && !document.hidden && video.error == null) {
+      video.play().catch(() => { /* teardown race */ });
+    }
+  });
+
+  video.addEventListener('loadedmetadata', () => {
+    const d = video.duration;
+    if (!Number.isFinite(d) || d <= 0) return;
+    if (cutStart == null) {
+      const len = cut.lenSec;
+      const gridClip = cut.durKnown && d > WHOLE_VIDEO_MAX_SEC;
+      // durKnown short videos play whole; cold cuts fall back to the seed window
+      // now that the duration is known.
+      const windowed = cut.durKnown ? gridClip : d > len + 10;
+      const start = gridClip
+        ? startForSegment(cut.k, d, len)
+        : windowed ? cut.seed * (d - len) : 0;
+      cutStart = start;
+      windowLen = windowed ? len : null;
+      if (start > 0) { try { video.currentTime = start; } catch { /* not seekable yet */ } }
+      scoreSegId = cut.durKnown ? cut.segId : segId(cut.asset.id, segmentIndexForStart(start));
+      clipLenSec = windowed ? len : d; // whole-video normalizes on real duration
+    }
+    // Backfill duration + dims so future sessions build the grid up front.
+    if (!metaSent && (cut.asset.durationMs == null || cut.asset.width == null)
+        && video.videoWidth > 0 && video.videoHeight > 0) {
+      metaSent = true;
+      ctx.onAssetMeta(cut.asset, {
+        durationMs: Math.round(d * 1000),
+        width: video.videoWidth,
+        height: video.videoHeight,
+      });
+    }
+  });
+
+  video.addEventListener('timeupdate', () => {
+    if (cutStart == null || windowLen == null) return;
+    if (video.currentTime >= cutStart + windowLen) {
+      if (autoAdvance && ctx.advances) advance();
+      else { try { video.currentTime = cutStart; } catch { /* ignore */ } }
+    }
+  });
+
+  video.addEventListener('ended', () => {
+    if (autoAdvance && ctx.advances) advance();
+  });
+
+  video.addEventListener('error', () => {
+    // A corrupt file never reaches timeupdate; without this an auto-advancing
+    // feed parks on a black tile forever. Delay so a broken pack pages <=1/s.
+    closeDwell();
+    if (autoAdvance && ctx.advances && errTimer == null) {
+      errTimer = setTimeout(() => { errTimer = null; advance(); }, ERROR_ADVANCE_MS);
+    }
+    ctx.onError?.(cut);
+  });
+
+  function advance() {
+    if (finished) return;
+    finished = true;
+    ctx.onEnded();
+  }
+
+  video.play().catch(() => { /* autoplay policy is disabled via browser args */ });
+
+  return {
+    el,
+    cut,
+    setMuted(m) { video.muted = m; },
+    setAutoAdvance(on) {
+      autoAdvance = on;
+      video.loop = !(on && ctx.advances);
+    },
+    /** Teardown: report dwell exactly once, then free the decoder NOW. */
+    stop() {
+      if (errTimer != null) { clearTimeout(errTimer); errTimer = null; }
+      closeDwell();
+      if (!reported) {
+        reported = true;
+        if (scoreSegId && dwellAccum > 0) ctx.report(scoreSegId, dwellAccum, clipLenSec * 1000);
+      }
+      try { video.pause(); } catch { /* ignore */ }
+      video.removeAttribute('src');
+      try { video.load(); } catch { /* ignore */ }
+      el.remove();
+    },
+  };
+}
+
+/** GIF sibling: always "playing", dwell is wall-clock, auto-advance is a timer. */
+function createGifSurface(cut, ctx) {
+  const el = document.createElement('div');
+  el.className = 'surface';
+  const img = document.createElement('img');
+  img.src = cut.asset.url;
+  img.draggable = false;
+  img.style.objectFit = cut.fit;
+  el.appendChild(img);
+
+  const start = performance.now();
+  let reported = false;
+  let finished = false;
+  let advTimer = null;
+  let metaSent = false;
+
+  img.addEventListener('load', () => {
+    if (!metaSent && cut.asset.width == null && img.naturalWidth > 0 && img.naturalHeight > 0) {
+      metaSent = true;
+      ctx.onAssetMeta(cut.asset, { width: img.naturalWidth, height: img.naturalHeight });
+    }
+  });
+
+  function arm(on) {
+    if (advTimer != null) { clearTimeout(advTimer); advTimer = null; }
+    if (on && ctx.advances) {
+      advTimer = setTimeout(() => {
+        if (finished) return;
+        finished = true;
+        ctx.onEnded();
+      }, cut.lenSec * 1000);
+    }
+  }
+  arm(ctx.autoAdvance);
+
+  return {
+    el,
+    cut,
+    setMuted() { /* GIFs are silent */ },
+    setAutoAdvance(on) { arm(on); },
+    stop() {
+      arm(false);
+      if (!reported) {
+        reported = true;
+        const dwell = performance.now() - start;
+        if (dwell > 0) ctx.report(segId(cut.asset.id, 0), dwell, cut.lenSec * 1000);
+      }
+      img.removeAttribute('src');
+      el.remove();
+    },
+  };
+}
+
+function createSurface(cut, ctx) {
+  return cut.asset.type === 'gif' ? createGifSurface(cut, ctx) : createVideoSurface(cut, ctx);
+}
+
+/**
+ * One tile slot: rect positioning, the live surface, the horizontal swap gesture
+ * (drag left = fresh pick, right = history-back) with a TikTok cross-slide, hover
+ * chevrons, click-to-focus-audio, and the stack blur cue.
+ */
+function createTileSlot(page, tileIndex, ctx) {
+  const slot = document.createElement('div');
+  slot.className = 'tile';
+  const clip = document.createElement('div');
+  clip.className = 'swap-clip';
+  slot.appendChild(clip);
+
+  const chevL = document.createElement('button');
+  chevL.className = 'chev chev-l';
+  chevL.textContent = '‹';
+  chevL.title = 'Back (replay the previous clip)';
+  const chevR = document.createElement('button');
+  chevR.className = 'chev chev-r';
+  chevR.textContent = '›';
+  chevR.title = 'Swap this tile for a fresh clip';
+  slot.append(chevL, chevR);
+
+  let surface = null;   // settled live surface (null while page inactive)
+  let sliding = false;
+  let tile = null;      // current tile model (rect/audio/blur/fit)
+  let mountGen = 0;     // bumps on mount/unmount so a mid-slide teardown can't
+                        // resurrect a surface on a dead slot (morph vs. slide race)
+
+  function applyRect(t) {
+    slot.style.left = (t.rect.x * 100) + '%';
+    slot.style.top = (t.rect.y * 100) + '%';
+    slot.style.width = (t.rect.w * 100) + '%';
+    slot.style.height = (t.rect.h * 100) + '%';
+    slot.classList.toggle('blurred', !!t.blurred);
+  }
+
+  function surfaceCtx(t) {
+    return {
+      advances: t.advances,
+      autoAdvance: ctx.isAutoAdvance(),
+      onEnded: () => ctx.onAdvance(),
+      onError: () => {},
+      onAssetMeta: ctx.onAssetMeta,
+      report: ctx.report,
+    };
+  }
+
+  function mount(t) {
+    mountGen++;
+    tile = t;
+    applyRect(t);
+    if (surface) { surface.stop(); surface = null; }
+    const s = createSurface({ ...t.cut, fit: t.fit }, surfaceCtx(t));
+    s.el.style.transform = 'translateX(0)';
+    clip.appendChild(s.el);
+    surface = s;
+    ctx.applyAudio();
+  }
+
+  function unmount() {
+    mountGen++;
+    if (surface) { surface.stop(); surface = null; }
+    tile = null;
+  }
+
+  /** Commit a swap: cross-slide old out, new in; outgoing keeps playing. */
+  function slideTo(cut, dir) {
+    const t = tile;
+    if (!t || !surface) return;
+    const gen = mountGen;
+    const w = slot.clientWidth || 1;
+    const outgoing = surface;
+    outgoing.setMuted(true); // the incoming tile carries audio from now on
+    tile = { ...t, cut };
+    const incoming = createSurface({ ...cut, fit: t.fit }, surfaceCtx(tile));
+    incoming.el.style.transition = 'none';
+    incoming.el.style.transform = `translateX(${dir === 'next' ? w : -w}px)`;
+    clip.appendChild(incoming.el);
+    sliding = true;
+    // Two frames: let the incoming's start transform land before animating.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      outgoing.el.style.transition = `transform ${SWAP_MS}ms ease-out`;
+      incoming.el.style.transition = `transform ${SWAP_MS}ms ease-out`;
+      outgoing.el.style.transform = `translateX(${dir === 'next' ? -w : w}px)`;
+      incoming.el.style.transform = 'translateX(0)';
+    }));
+    // transitionend is lossy under load — settle on a timer instead.
+    setTimeout(() => {
+      outgoing.stop(); // reports the outgoing cut's dwell
+      sliding = false;
+      if (gen !== mountGen) { incoming.stop(); return; } // slot re-mounted mid-slide
+      incoming.el.style.transition = '';
+      surface = incoming;
+      ctx.applyAudio();
+    }, SWAP_MS + 40);
+  }
+
+  function springBack() {
+    if (!surface) return;
+    surface.el.style.transition = 'transform 200ms ease-out';
+    surface.el.style.transform = 'translateX(0)';
+    setTimeout(() => { if (surface) surface.el.style.transition = ''; }, 240);
+  }
+
+  function commit(dir) {
+    const cut = ctx.onSwap(tileIndex, dir);
+    if (!cut) { springBack(); return; }
+    slideTo(cut, dir);
+  }
+
+  // Pointer drag: horizontal swap; a near-still release is a tap (audio focus).
+  let dragId = null;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let lastX = 0;
+  let lastT = 0;
+  let velocity = 0;
+  slot.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0 || sliding || !surface) return;
+    dragId = e.pointerId;
+    dragStartX = lastX = e.clientX;
+    dragStartY = e.clientY;
+    lastT = performance.now();
+    velocity = 0;
+    slot.setPointerCapture(e.pointerId);
+  });
+  slot.addEventListener('pointermove', (e) => {
+    if (dragId !== e.pointerId || !surface) return;
+    const now = performance.now();
+    const dt = now - lastT;
+    if (dt > 0) velocity = (e.clientX - lastX) / dt;
+    lastX = e.clientX;
+    lastT = now;
+    const dx = e.clientX - dragStartX;
+    if (Math.abs(dx) > 6) {
+      surface.el.style.transition = 'none';
+      surface.el.style.transform = `translateX(${dx * DRAG_RESISTANCE}px)`;
+    }
+  });
+  const endDrag = (e) => {
+    if (dragId !== e.pointerId) return;
+    dragId = null;
+    if (!surface) return;
+    surface.el.style.transition = '';
+    const dx = e.clientX - dragStartX;
+    const dy = e.clientY - dragStartY;
+    if (Math.abs(dx) > COMMIT_DIST || Math.abs(velocity) > COMMIT_VELOCITY) {
+      commit(dx < 0 || (Math.abs(dx) <= COMMIT_DIST && velocity < 0) ? 'next' : 'back');
+    } else if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
+      springBack();
+      ctx.onTapAudio(tileIndex); // a tap means "let me hear this one"
+    } else {
+      springBack();
+    }
+  };
+  slot.addEventListener('pointerup', endDrag);
+  slot.addEventListener('pointercancel', (e) => { if (dragId === e.pointerId) { dragId = null; springBack(); } });
+
+  chevL.addEventListener('click', (e) => { e.stopPropagation(); if (!sliding) commit('back'); });
+  chevR.addEventListener('click', (e) => { e.stopPropagation(); if (!sliding) commit('next'); });
+
+  return {
+    el: slot,
+    get tile() { return tile; },
+    get surface() { return surface; },
+    mount,
+    unmount,
+    applyRect,
+  };
+}
+
+/**
+ * One feed page. Created for every composition in the window; only mounts live
+ * media while active. ctx:
+ *   { onAdvance(compKey), onSwap(compKey, i, dir), onTapAudio(compKey, i),
+ *     onAssetMeta, report, isAutoAdvance(), isMuted(), audioFocus() -> index|null }
+ */
+export function createPage(comp, ctx) {
+  const el = document.createElement('div');
+  el.className = 'page';
+  const inner = document.createElement('div');
+  inner.className = 'page-inner';
+  el.appendChild(inner);
+
+  let active = false;
+  let slots = [];
+  let morphTimer = null;
+
+  function audioIndex() {
+    const focus = ctx.audioFocus(comp.key);
+    if (focus != null && comp.tiles[focus]?.cut.asset.type === 'video') return focus;
+    return comp.tiles.findIndex((t) => t.audio);
+  }
+
+  function applyAudio() {
+    const ai = audioIndex();
+    const muted = ctx.isMuted();
+    slots.forEach((s, i) => s.surface?.setMuted(muted || i !== ai));
+  }
+
+  function slotCtx(i) {
+    return {
+      isAutoAdvance: ctx.isAutoAdvance,
+      onAdvance: () => ctx.onAdvance(comp.key),
+      onSwap: (idx, dir) => ctx.onSwap(comp.key, idx, dir),
+      onTapAudio: (idx) => { ctx.onTapAudio(comp.key, idx); applyAudio(); },
+      onAssetMeta: ctx.onAssetMeta,
+      report: ctx.report,
+      applyAudio,
+    };
+  }
+
+  function mountTiles() {
+    slots = comp.tiles.map((t, i) => {
+      const slot = createTileSlot(el, i, slotCtx(i));
+      inner.appendChild(slot.el);
+      slot.mount(t);
+      return slot;
+    });
+    applyAudio();
+  }
+
+  function unmountTiles() {
+    for (const s of slots) { s.unmount(); s.el.remove(); }
+    slots = [];
+  }
+
+  function scheduleMorph() {
+    cancelMorph();
+    if (!active || comp.layout !== 'random' || !ctx.mosaicAutoChange()) return;
+    morphTimer = setTimeout(() => {
+      inner.style.transition = `opacity ${MORPH_FADE_OUT_MS}ms ease-in`;
+      inner.style.opacity = '0';
+      setTimeout(() => {
+        if (!active) { inner.style.opacity = '1'; return; }
+        const tiles = ctx.onMorph(comp.key); // feed re-composes in place
+        if (tiles) { unmountTiles(); mountTiles(); }
+        inner.style.transition = `opacity ${MORPH_FADE_IN_MS}ms ease-out`;
+        inner.style.opacity = '1';
+        scheduleMorph();
+      }, MORPH_FADE_OUT_MS);
+    }, Math.max(3000, ctx.mosaicChangeMs()));
+  }
+
+  function cancelMorph() {
+    if (morphTimer != null) { clearTimeout(morphTimer); morphTimer = null; }
+    inner.style.opacity = '1';
+    inner.style.transition = '';
+  }
+
+  return {
+    el,
+    key: comp.key,
+    comp,
+    get active() { return active; },
+    setActive(on) {
+      if (on === active) return;
+      active = on;
+      if (on) { mountTiles(); scheduleMorph(); }
+      else { cancelMorph(); unmountTiles(); }
+    },
+    applyAudio,
+    /** Auto-advance flipped while live: re-arm the surfaces. */
+    applyAutoAdvance() {
+      const on = ctx.isAutoAdvance();
+      slots.forEach((s) => s.surface?.setAutoAdvance(on && !!s.tile?.advances));
+    },
+    /** First tile's caption feeds the page chrome. */
+    caption() {
+      const t = comp.tiles[0];
+      return t ? { filename: t.cut.asset.filename, folder: t.cut.asset.folder } : null;
+    },
+    destroy() {
+      cancelMorph();
+      unmountTiles();
+      el.remove();
+    },
+  };
+}

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -1052,7 +1052,8 @@ namespace ConditioningControlPanel.Services
             // honest instead of completing and doing nothing.
             if (settings.AutonomyCanTriggerWebVideo
                 && App.BrowserMedia?.ShouldDeferNewVideo != true
-                && App.Video?.IsPlaying != true)
+                && App.Video?.IsPlaying != true
+                && !Fyp.FypHostService.IsActive)
                 candidates.Add((AutonomyActionType.WebVideo, 20));
 
             // Wallpaper shuffle - subtle desktop wallpaper change

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -142,6 +142,17 @@ public class BubbleCountService : IDisposable
             return;
         }
 
+        // For You feed open: bubble count is a video-class interaction and stands down like
+        // the mandatory video does. Drop, never queue (the feed outlives the stuck window),
+        // handing back a dequeued slot the same way the poison guard above does.
+        if (Fyp.FypHostService.IsActive)
+        {
+            App.Logger?.Information("BubbleCountService: game dropped - For You feed active");
+            if (App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.BubbleCount)
+                App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+            return;
+        }
+
         var settings = App.Settings.Current;
 
         // Check if another fullscreen interaction is active (video, lock card)

--- a/ConditioningControlPanel/Services/Companion/CompanionService.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionService.cs
@@ -22,6 +22,7 @@ namespace ConditioningControlPanel.Services
         Mantra,
         AttentionCheck,
         Chaos,
+        Fyp,
         Other
     }
 

--- a/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ConditioningControlPanel.Services.Fyp;
+
+/// <summary>
+/// Enumerates the user's active preset into the manifest the For You feed consumes over the
+/// bridge. Sibling of <see cref="Chaos.DtrhAssetManifest"/> with a richer per-entry shape:
+/// the feed's segment grid needs a stable id plus duration/dimensions where known.
+///
+/// Ids are the forward-slashed path relative to EffectiveAssetsPath — segIds are
+/// "<c>id:k</c>", so ids must never contain '<c>:</c>' (relative paths have no drive colon).
+/// Durations come from <see cref="VideoMetadataCache"/> when warm; dimensions (and durations
+/// for videos LibVLC never touched) are backfilled by the page's own probes via
+/// <see cref="FypMetaStore"/>, so the grid gets better with every session.
+/// </summary>
+internal static class FypAssetManifest
+{
+    private static readonly string[] VideoExts = { ".mp4", ".webm", ".m4v" };
+    private const long MaxGifBytes = 50L * 1024 * 1024;      // mirrors DtrhAssetManifest caps
+    private const long MaxVideoBytes = 500L * 1024 * 1024;
+    private const int MaxEntries = 5000;
+    private const int MaxWalkDepth = 8;
+
+    public sealed class Entry
+    {
+        // camelCase on the wire — the page reads these directly.
+        [Newtonsoft.Json.JsonProperty("id")] public string Id { get; init; } = "";
+        [Newtonsoft.Json.JsonProperty("url")] public string Url { get; init; } = "";
+        [Newtonsoft.Json.JsonProperty("type")] public string Type { get; init; } = "video";   // "video" | "gif"
+        [Newtonsoft.Json.JsonProperty("filename")] public string Filename { get; init; } = "";
+        [Newtonsoft.Json.JsonProperty("folder")] public string Folder { get; init; } = "";
+        [Newtonsoft.Json.JsonProperty("durationMs")] public long? DurationMs { get; set; }
+        [Newtonsoft.Json.JsonProperty("width")] public int? Width { get; set; }
+        [Newtonsoft.Json.JsonProperty("height")] public int? Height { get; set; }
+    }
+
+    /// <summary>Build the asset list for the current EffectiveAssetsPath. Never throws.</summary>
+    public static List<Entry> Build(FypMetaStore meta)
+    {
+        var entries = new List<Entry>();
+        try
+        {
+            var root = App.EffectiveAssetsPath;
+            var disabled = new HashSet<string>(
+                (App.Settings?.Current?.DisabledAssetPaths ?? new()).Select(p => p.Replace('\\', '/')),
+                StringComparer.OrdinalIgnoreCase);
+
+            Collect(Path.Combine(root, "videos"), root, isVideo: true, entries, disabled);
+            Collect(Path.Combine(root, "images"), root, isVideo: false, entries, disabled);
+
+            if (entries.Count > MaxEntries)
+            {
+                // partial Fisher-Yates, then truncate (DtrhAssetManifest precedent)
+                var rng = new Random();
+                for (int i = 0; i < MaxEntries; i++)
+                {
+                    int j = i + rng.Next(entries.Count - i);
+                    (entries[i], entries[j]) = (entries[j], entries[i]);
+                }
+                entries.RemoveRange(MaxEntries, entries.Count - MaxEntries);
+            }
+
+            // Enrich: LibVLC duration cache (videos only) + the page's own probe backfills.
+            foreach (var e in entries)
+            {
+                var m = meta.Get(e.Id);
+                if (m != null)
+                {
+                    e.DurationMs = m.DurationMs;
+                    e.Width = m.Width;
+                    e.Height = m.Height;
+                }
+                if (e.DurationMs == null && e.Type == "video")
+                {
+                    var path = Path.Combine(root, e.Id.Replace('/', Path.DirectorySeparatorChar));
+                    var sec = App.Video?.MetadataCache?.TryGetDuration(path);
+                    if (sec is > 0) e.DurationMs = (long)(sec.Value * 1000);
+                }
+            }
+
+            App.Logger?.Information("FypAssetManifest: {V} videos, {G} gifs ({D} with duration)",
+                entries.Count(e => e.Type == "video"), entries.Count(e => e.Type == "gif"),
+                entries.Count(e => e.DurationMs != null));
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("FypAssetManifest.Build failed: {E}", ex.Message);
+        }
+        return entries;
+    }
+
+    private static void Collect(string dir, string root, bool isVideo, List<Entry> entries, HashSet<string> disabled)
+    {
+        if (!Directory.Exists(dir)) return;
+        long cap = isVideo ? MaxVideoBytes : MaxGifBytes;
+        foreach (var f in Walk(dir, 0))
+        {
+            if (entries.Count >= MaxEntries * 2) return; // sample later, but bound the walk
+            var ext = Path.GetExtension(f).ToLowerInvariant();
+            if (isVideo ? !VideoExts.Contains(ext) : ext != ".gif") continue;
+            var rel = Path.GetRelativePath(root, f).Replace('\\', '/');
+            if (disabled.Count > 0 && disabled.Contains(rel)) continue;
+            long len;
+            try { len = new FileInfo(f).Length; } catch { continue; }
+            if (len <= 0 || len > cap) continue;
+            entries.Add(new Entry
+            {
+                Id = rel,
+                Url = "https://ccp.assets/" + string.Join('/', rel.Split('/').Select(Uri.EscapeDataString)),
+                Type = isVideo ? "video" : "gif",
+                Filename = Path.GetFileName(f),
+                Folder = Path.GetFileName(Path.GetDirectoryName(f)) ?? "",
+            });
+        }
+    }
+
+    private static IEnumerable<string> Walk(string dir, int depth)
+    {
+        if (depth > MaxWalkDepth) yield break;
+        IEnumerable<string> files;
+        try { files = Directory.EnumerateFiles(dir); }
+        catch { yield break; }
+        foreach (var f in files) yield return f;
+        IEnumerable<string> subs;
+        try { subs = Directory.EnumerateDirectories(dir); }
+        catch { yield break; }
+        foreach (var d in subs)
+        {
+            if (Path.GetFileName(d).StartsWith('.')) continue;
+            foreach (var f in Walk(d, depth + 1)) yield return f;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using SD = System.Drawing;
+using WF = System.Windows.Forms;
+
+namespace ConditioningControlPanel.Services.Fyp;
+
+/// <summary>
+/// The "ghost mode" mirror: a plain, empty window that shows a LIVE DWM thumbnail of the
+/// For You feed window while the real one is parked off-screen. This is the OnTopReplica
+/// technique, and it is the ONLY way this app can present a WebView2 surface as a genuinely
+/// translucent, genuinely click-through pane:
+///
+///   * SetLayeredWindowAttributes on a window that HOSTS WebView2 turns its content solid
+///     BLACK — DWM's layered redirection never sees the Chromium child processes'
+///     cross-process DirectComposition visuals. (Shipped once, reproduced live 2026-08-03.)
+///   * The blending rules were pixel-measured in isolation (2026-08-03, magenta-source /
+///     green-backdrop probe):
+///       - A thumbnail at DWM_TNP_OPACITY blends against the DESTINATION WINDOW'S OWN SURFACE,
+///         not against what is behind the window.
+///       - LWA_ALPHA multiplies the surface AND the thumbnail TOGETHER (alpha 128 halved a
+///         full-opacity thumbnail), so no constant alpha can hide the surface yet keep the
+///         mirror: alpha 1 blanks both, alpha 255 blends the mirror into opaque background.
+///       - LWA_COLORKEY removes ONLY the surface pixels from composition; the thumbnail then
+///         blends against whatever is behind the window — measured exact (0.35*src + 0.65*rear),
+///         fullscreen-sized destinations included (DWM fullscreen optimization is not a problem).
+///   * The mirror MUST be a GDI-surfaced (WinForms) window, NOT WPF: a WPF window renders its
+///     surface through D3D and LWA_COLORKEY never matches it — the key color composes as a
+///     solid sheet and the mirror degrades to "thumbnail over near-black" (observed live).
+///     The probe that measured the exact blends above ran on a WinForms window; this class is
+///     that configuration verbatim.
+///
+/// The surface is painted RGB(1,1,1) and color-keyed away (1,1,1 and not pure black, so
+/// genuinely black pixels INSIDE the mirrored feed can never match the key — verified: content
+/// blacks stay opaque), and the user's translucency rides DWM_TNP_OPACITY alone.
+///
+/// The real window keeps rendering (and playing audio, and receiving blink/gaze events) at its
+/// parking spot off the virtual desktop; this window paints the picture of it, see-through and
+/// input-transparent, covering the feed's home monitor. Nothing here ever touches the real
+/// window's frame. Chromium must be told not to throttle the parked window — see the occlusion
+/// browser flags in <see cref="FypHostService"/>, without which the mirror freezes.
+/// </summary>
+internal sealed class FypGhostOverlay
+{
+    private readonly IntPtr _sourceHwnd;
+    private readonly WF.Screen _screen;
+    private readonly MirrorForm _form;
+    private readonly Action _onGear;
+    private readonly Action _onMute;
+    private readonly Func<bool> _isMuted;
+    private GhostButton? _gearBtn;
+    private GhostButton? _muteBtn;
+    private IntPtr _thumb;
+    private double _opacity;
+    private bool _closed;
+
+    /// <param name="sourceHwnd">HWND of the real feed window (the thumbnail source). Must still
+    /// be on its home monitor when this runs — the ctor captures that monitor, so construct the
+    /// overlay BEFORE parking the window.</param>
+    /// <param name="bounds">Where the real window WAS, in DIPs (kept for the host's log).</param>
+    /// <param name="opacity">0.01..1.0; the feed's persisted window-opacity setting.</param>
+    /// <param name="onGear">Ghost gear button clicked (host un-ghosts and opens options).</param>
+    /// <param name="onMute">Ghost speaker button clicked (host flips mute).</param>
+    /// <param name="isMuted">Current mute state, for the speaker glyph.</param>
+    public FypGhostOverlay(IntPtr sourceHwnd, Rect bounds, double opacity,
+        Action onGear, Action onMute, Func<bool> isMuted)
+    {
+        _ = bounds;
+        _sourceHwnd = sourceHwnd;
+        _opacity = ClampOpacity(opacity);
+        _onGear = onGear;
+        _onMute = onMute;
+        _isMuted = isMuted;
+        _screen = WF.Screen.FromHandle(sourceHwnd);
+        _form = new MirrorForm();
+        _form.FormClosed += (_, _) => Unregister();
+    }
+
+    /// <summary>Show the mirror fullscreen on the feed's home monitor and start the live
+    /// thumbnail. The thumbnail letterboxes at the source's aspect ratio; the bars are invisible
+    /// because the color-keyed surface never composes.</summary>
+    public void Show()
+    {
+        if (_closed) return;
+        try
+        {
+            // Manual monitor-fill bounds in physical px (covers the taskbar too — fine, the
+            // mirror is click-through). Never a Maximized state change: frameworks reassert
+            // their cached styles on state transitions.
+            _form.Bounds = _screen.Bounds;
+            _form.Show();
+            ApplyColorKey();
+            EnsureThumbnail();
+            ShowButtons();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.Show: {E}", ex.Message); }
+    }
+
+    /// <summary>The two controls that stay CLICKABLE in ghost mode. They cannot live on the
+    /// mirror (its whole surface is WS_EX_TRANSPARENT by design), so each is its own tiny
+    /// topmost window without that style — small clickable islands over a click-through sea.
+    /// Positions echo the page's own chrome: gear top-left, speaker top-right.</summary>
+    private void ShowButtons()
+    {
+        try
+        {
+            if (_closed || _gearBtn != null) return;
+            var b = _screen.Bounds;
+            // Physical px, sized off the monitor's scale so they match the page's 40-DIP buttons.
+            int size = Math.Max(40, (int)Math.Round(b.Height * 0.037));
+            int pad = size / 2;
+            _gearBtn = new GhostButton("⚙", "Feed options (leaves ghost mode)",
+                new SD.Rectangle(b.X + pad, b.Y + pad, size, size), () => _onGear());
+            _muteBtn = new GhostButton(_isMuted() ? "🔇" : "🔊", "Mute / unmute",
+                new SD.Rectangle(b.Right - pad - size, b.Y + pad, size, size), () => _onMute());
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.ShowButtons: {E}", ex.Message); }
+    }
+
+    /// <summary>Re-draw the speaker glyph after the host flips mute.</summary>
+    public void RefreshMuteGlyph()
+    {
+        try { _muteBtn?.SetGlyph(_isMuted() ? "🔇" : "🔊"); }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.RefreshMuteGlyph: {E}", ex.Message); }
+    }
+
+    /// <summary>Live opacity update (the page's slider). Re-sends the thumbnail properties —
+    /// the alpha rides DWM_TNP_OPACITY, not the window (see the class comment).</summary>
+    public void SetOpacity(double v)
+    {
+        _opacity = ClampOpacity(v);
+        UpdateThumbnailBounds();
+    }
+
+    /// <summary>Drop the thumbnail and close the mirror and its buttons. Idempotent.</summary>
+    public void Close()
+    {
+        if (_closed) return;
+        _closed = true;
+        Unregister();
+        try { _gearBtn?.Close(); }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.Close gear: {E}", ex.Message); }
+        try { _muteBtn?.Close(); }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.Close mute: {E}", ex.Message); }
+        _gearBtn = null;
+        _muteBtn = null;
+        try { _form.Close(); _form.Dispose(); }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.Close: {E}", ex.Message); }
+    }
+
+    private void ApplyColorKey()
+    {
+        try
+        {
+            // Key out the RGB(1,1,1) surface — NOT LWA_ALPHA, which would multiply the
+            // thumbnail too (see the class comment). With the surface gone, the thumbnail's
+            // DWM_TNP_OPACITY blends the feed straight against the desktop behind the window.
+            SetLayeredWindowAttributes(_form.Handle, COLOR_KEY, 0, LWA_COLORKEY);
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.ApplyColorKey: {E}", ex.Message); }
+    }
+
+    private void EnsureThumbnail()
+    {
+        try
+        {
+            if (_closed || _sourceHwnd == IntPtr.Zero) return;
+            if (_thumb == IntPtr.Zero)
+            {
+                int hr = DwmRegisterThumbnail(_form.Handle, _sourceHwnd, out var thumb);
+                if (hr != 0 || thumb == IntPtr.Zero)
+                {
+                    App.Logger?.Warning("FypGhostOverlay: DwmRegisterThumbnail failed (0x{HR:X8})", hr);
+                    return;
+                }
+                _thumb = thumb;
+            }
+            UpdateThumbnailBounds();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.EnsureThumbnail: {E}", ex.Message); }
+    }
+
+    /// <summary>Point the thumbnail at our client area (physical px throughout — WinForms and
+    /// rcDestination agree, no DIP math). Letterbox: scale the source's client rect to fit,
+    /// centered; a stretched mirror would distort the moment the aspects differ.</summary>
+    private void UpdateThumbnailBounds()
+    {
+        try
+        {
+            if (_closed || _thumb == IntPtr.Zero) return;
+            int destW = Math.Max(1, _form.ClientSize.Width);
+            int destH = Math.Max(1, _form.ClientSize.Height);
+
+            int x0 = 0, y0 = 0, x1 = destW, y1 = destH;
+            if (GetClientRect(_sourceHwnd, out var src) && src.Right > 0 && src.Bottom > 0)
+            {
+                double scale = Math.Min((double)destW / src.Right, (double)destH / src.Bottom);
+                int fitW = Math.Max(1, (int)Math.Round(src.Right * scale));
+                int fitH = Math.Max(1, (int)Math.Round(src.Bottom * scale));
+                x0 = (destW - fitW) / 2; y0 = (destH - fitH) / 2;
+                x1 = x0 + fitW; y1 = y0 + fitH;
+            }
+
+            var props = new DWM_THUMBNAIL_PROPERTIES
+            {
+                dwFlags = DWM_TNP_RECTDESTINATION | DWM_TNP_VISIBLE
+                          | DWM_TNP_SOURCECLIENTAREAONLY | DWM_TNP_OPACITY,
+                rcDestination = new RECT { Left = x0, Top = y0, Right = x1, Bottom = y1 },
+                // The user's translucency — with the surface keyed away, DWM blends the
+                // thumbnail against the desktop at exactly this alpha (pixel-verified).
+                opacity = (byte)Math.Round(Math.Clamp(_opacity, OpacityMin, 1.0) * 255.0),
+                fVisible = true,
+                fSourceClientAreaOnly = true,   // clip the source's title bar / border away
+            };
+            DwmUpdateThumbnailProperties(_thumb, ref props);
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.UpdateThumbnailBounds: {E}", ex.Message); }
+    }
+
+    private void Unregister()
+    {
+        var t = _thumb;
+        _thumb = IntPtr.Zero;
+        if (t == IntPtr.Zero) return;
+        try { DwmUnregisterThumbnail(t); }
+        catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.Unregister: {E}", ex.Message); }
+    }
+
+    private const double OpacityMin = 0.01;
+    private static double ClampOpacity(double v)
+        => double.IsFinite(v) ? Math.Clamp(v, OpacityMin, 1.0) : 1.0;
+
+    /// <summary>The mirror surface. Ex-styles are baked into CreateParams so they exist from
+    /// creation — nothing is stamped behind a framework's back, nothing can reassert over them.
+    /// LAYERED = required for the colorkey. TRANSPARENT = every click, wheel and hover falls
+    /// straight through to the desktop. NOACTIVATE = never takes focus. TOOLWINDOW = no taskbar
+    /// button and no Alt-Tab entry.</summary>
+    private sealed class MirrorForm : WF.Form
+    {
+        public MirrorForm()
+        {
+            FormBorderStyle = WF.FormBorderStyle.None;
+            StartPosition = WF.FormStartPosition.Manual;
+            ShowInTaskbar = false;
+            TopMost = true;
+            Text = "For You";
+            // The color key — every surface pixel must be exactly RGB(1,1,1).
+            BackColor = SD.Color.FromArgb(1, 1, 1);
+        }
+
+        protected override bool ShowWithoutActivation => true;
+
+        protected override WF.CreateParams CreateParams
+        {
+            get
+            {
+                var cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+                return cp;
+            }
+        }
+    }
+
+    /// <summary>One round, clickable button window for ghost mode. NOACTIVATE keeps clicks from
+    /// stealing focus (mouse messages still arrive without activation); crucially it does NOT
+    /// carry WS_EX_TRANSPARENT, so unlike everything else on the ghost screen it eats its
+    /// clicks. Styled after the page's .round-btn chrome: dark disc, pink on hover.</summary>
+    private sealed class GhostButton : WF.Form
+    {
+        private readonly Action _onClick;
+        private string _glyph;
+        private bool _hover;
+
+        public GhostButton(string glyph, string tooltip, SD.Rectangle bounds, Action onClick)
+        {
+            _glyph = glyph;
+            _onClick = onClick;
+            FormBorderStyle = WF.FormBorderStyle.None;
+            StartPosition = WF.FormStartPosition.Manual;
+            ShowInTaskbar = false;
+            TopMost = true;
+            Text = "For You";
+            Cursor = WF.Cursors.Hand;
+            DoubleBuffered = true;
+            BackColor = SD.Color.FromArgb(18, 18, 31);
+            Bounds = bounds;
+            Region = new SD.Region(EllipsePath(bounds.Width, bounds.Height));
+            new WF.ToolTip().SetToolTip(this, tooltip);
+            Show();
+            // A see-through feed can sit at 1% — keep the buttons discoverable but quiet.
+            // Plain SLWA alpha is safe here: no DWM thumbnail rides this window.
+            Opacity = 0.82;
+        }
+
+        public void SetGlyph(string glyph)
+        {
+            _glyph = glyph;
+            Invalidate();
+        }
+
+        protected override bool ShowWithoutActivation => true;
+
+        protected override WF.CreateParams CreateParams
+        {
+            get
+            {
+                var cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW;
+                return cp;
+            }
+        }
+
+        protected override void OnMouseEnter(EventArgs e) { _hover = true; Invalidate(); base.OnMouseEnter(e); }
+        protected override void OnMouseLeave(EventArgs e) { _hover = false; Invalidate(); base.OnMouseLeave(e); }
+        protected override void OnMouseUp(WF.MouseEventArgs e)
+        {
+            base.OnMouseUp(e);
+            if (e.Button == WF.MouseButtons.Left)
+            {
+                try { _onClick(); }
+                catch (Exception ex) { App.Logger?.Debug("GhostButton click: {E}", ex.Message); }
+            }
+        }
+
+        protected override void OnPaint(WF.PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            var g = e.Graphics;
+            g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            using var fill = new SD.SolidBrush(_hover
+                ? SD.Color.FromArgb(255, 105, 180)
+                : SD.Color.FromArgb(31, 31, 54));
+            using var rim = new SD.Pen(SD.Color.FromArgb(255, 105, 180), 1.5f);
+            g.FillEllipse(fill, 1, 1, Width - 3, Height - 3);
+            g.DrawEllipse(rim, 1, 1, Width - 3, Height - 3);
+            using var font = new SD.Font("Segoe UI Emoji", Height * 0.38f, SD.GraphicsUnit.Pixel);
+            var sz = g.MeasureString(_glyph, font);
+            using var text = new SD.SolidBrush(SD.Color.White);
+            g.DrawString(_glyph, font, text, (Width - sz.Width) / 2f, (Height - sz.Height) / 2f);
+        }
+
+        private static System.Drawing.Drawing2D.GraphicsPath EllipsePath(int w, int h)
+        {
+            var p = new System.Drawing.Drawing2D.GraphicsPath();
+            p.AddEllipse(0, 0, w, h);
+            return p;
+        }
+    }
+
+    // ------------------------------- native -------------------------------
+
+    private const int WS_EX_TRANSPARENT = 0x00000020;
+    private const int WS_EX_TOOLWINDOW = 0x00000080;
+    private const int WS_EX_LAYERED = 0x00080000;
+    private const int WS_EX_NOACTIVATE = 0x08000000;
+    private const int LWA_COLORKEY = 0x00000001;
+    private const uint COLOR_KEY = 0x00010101;   // COLORREF for RGB(1,1,1) — must match BackColor
+
+    private const int DWM_TNP_RECTDESTINATION = 0x00000001;
+    private const int DWM_TNP_OPACITY = 0x00000004;
+    private const int DWM_TNP_VISIBLE = 0x00000008;
+    private const int DWM_TNP_SOURCECLIENTAREAONLY = 0x00000010;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DWM_THUMBNAIL_PROPERTIES
+    {
+        public int dwFlags;
+        public RECT rcDestination;
+        public RECT rcSource;
+        public byte opacity;
+        [MarshalAs(UnmanagedType.Bool)] public bool fVisible;
+        [MarshalAs(UnmanagedType.Bool)] public bool fSourceClientAreaOnly;
+    }
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmRegisterThumbnail(IntPtr dest, IntPtr src, out IntPtr thumb);
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmUnregisterThumbnail(IntPtr thumb);
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmUpdateThumbnailProperties(IntPtr thumb, ref DWM_THUMBNAIL_PROPERTIES props);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte alpha, int dwFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hWnd, out RECT rect);
+}

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Web.WebView2.Core;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Fyp;
+
+/// <summary>
+/// Hosts the For You feed (premium): a TikTok-style endless feed of random 20-40s clip
+/// windows cut from the user's active videos and GIFs, ported from the mobile reel and
+/// rendered in a WebView2 window at <c>Resources/web/fyp/index.html</c>. Modeled on
+/// <see cref="Chaos.LoomHostService"/>: one windowed <see cref="ChaosWebViewHost"/>,
+/// singleton, torn down on window close or process failure.
+///
+/// The page owns the feed algorithm and its retention stats; this class owns persistence
+/// (fyp_stats.json / fyp_meta.json), the asset manifest, settings round-trip, and XP.
+/// While <see cref="IsActive"/>, video-class features stand down (VideoService trigger,
+/// BubbleCount, Autonomy WebVideo) — flashes/subliminals/lock cards still fire over the feed.
+/// </summary>
+internal static class FypHostService
+{
+    private static ChaosWebViewHost? _host;
+    private static FypMetaStore? _meta;
+
+    // Passive-XP rate cap: the page reports honest dwell, but cap awards anyway so a
+    // misbehaving page can't fountain XP. 12 clip-views/minute is faster than the feed
+    // can actually produce distinct 20-40s slices.
+    private const int MaxClipXpPerMinute = 12;
+    private static readonly Queue<DateTime> _clipXpTimes = new();
+
+    private static string StatsFilePath => Path.Combine(App.UserDataPath, "fyp_stats.json");
+
+    /// <summary>True while the For You window is open.</summary>
+    public static bool IsActive => _host != null;
+
+    /// <summary>Open the feed window (idempotent - refocuses if already open).</summary>
+    public static void Launch()
+    {
+        if (_host != null) { _host.FocusWeb(); return; }
+        try
+        {
+            var webRoot = Path.Combine(AppContext.BaseDirectory, "Resources", "web");
+            // A missing folder makes WebView2 SKIP the mapping entirely (host rule),
+            // so make sure the assets root exists before Show().
+            try { Directory.CreateDirectory(App.EffectiveAssetsPath); }
+            catch (Exception ex) { App.Logger?.Debug("FypHost: assets dir create failed: {E}", ex.Message); }
+
+            _meta ??= new FypMetaStore();
+
+            _host = new ChaosWebViewHost(new ChaosWebViewHost.Options
+            {
+                StartUrl = "https://ccp.game/fyp/index.html",
+                PrimaryHost = "ccp.game",
+                Mappings = new List<(string, string, CoreWebView2HostResourceAccessKind)>
+                {
+                    ("ccp.game", webRoot, CoreWebView2HostResourceAccessKind.Deny),
+                    ("ccp.assets", App.EffectiveAssetsPath, CoreWebView2HostResourceAccessKind.Allow),
+                },
+                // Own browser profile; keeps DtRH/Loom state untouched.
+                UserDataFolderName = "browser_data_fyp",
+                InputEnabled = true,
+                StartFullscreen = false,
+                OwnedByMainWindow = true,
+                WindowTitle = "For You",
+                LogTag = "FypHost",
+                // An autoplaying feed: media must start without a user gesture.
+                ExtraBrowserArguments = "--autoplay-policy=no-user-gesture-required",
+                OnReady = PostInit,
+                OnMessage = OnPageMessage,
+                OnProcessFailed = _ => Close(),
+            });
+            _host.Show();
+            if (_host.Window != null)
+                _host.Window.Closed += (_, _) => Close();
+            App.Logger?.Information("FypHostService: launched");
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Error(ex, "FypHostService.Launch failed");
+            Close();
+        }
+    }
+
+    /// <summary>Tear the window down (idempotent; also the ProcessFailed and panic path).</summary>
+    public static void Close()
+    {
+        var h = _host;
+        _host = null;
+        try { _meta?.Save(); } catch { }
+        try { h?.Dispose(); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.Close: {E}", ex.Message); }
+    }
+
+    /// <summary>One init payload on page-ready: assets + settings + persisted stats.</summary>
+    private static void PostInit()
+    {
+        try
+        {
+            var s = App.Settings?.Current;
+            _meta ??= new FypMetaStore();
+            _host?.Post(new
+            {
+                type = "init",
+                assets = FypAssetManifest.Build(_meta),
+                settings = new
+                {
+                    layout = s?.FypLayout ?? "duo",
+                    includeGifs = s?.FypIncludeGifs ?? true,
+                    mosaicAutoChange = s?.FypMosaicAutoChange ?? true,
+                    mosaicChangeSec = s?.FypMosaicChangeSec ?? 10,
+                    autoAdvance = s?.FypAutoAdvance ?? false,
+                    muted = s?.FypMuted ?? false,
+                },
+                stats = LoadStats(),
+            });
+        }
+        catch (Exception ex) { App.Logger?.Warning("FypHost.PostInit failed: {E}", ex.Message); }
+    }
+
+    private static void OnPageMessage(JObject o)
+    {
+        switch ((string?)o["type"])
+        {
+            case "stats-save":
+            {
+                // The page owns the stats shape; we just persist the blob verbatim.
+                if (o["stats"] is JObject stats) SaveStats(stats);
+                break;
+            }
+            case "asset-meta":
+            {
+                _meta?.Update((string?)o["id"], (long?)o["durationMs"], (int?)o["width"], (int?)o["height"]);
+                break;
+            }
+            case "clip-viewed":
+            {
+                if (!AllowClipXp()) break;
+                try { App.Progression?.AddXP(5, XPSource.Fyp); }
+                catch (Exception ex) { App.Logger?.Debug("FypHost: clip XP failed: {E}", ex.Message); }
+                break;
+            }
+            case "attention-hit":
+            {
+                try { App.Progression?.AddXP(15, XPSource.Fyp); }
+                catch (Exception ex) { App.Logger?.Debug("FypHost: attention XP failed: {E}", ex.Message); }
+                break;
+            }
+            case "settings-changed":
+            {
+                ApplySetting((string?)o["key"], o["value"]);
+                break;
+            }
+            case "close":
+            {
+                _host?.Window?.Dispatcher.BeginInvoke(Close);
+                break;
+            }
+        }
+    }
+
+    private static bool AllowClipXp()
+    {
+        var now = DateTime.UtcNow;
+        while (_clipXpTimes.Count > 0 && (now - _clipXpTimes.Peek()).TotalSeconds > 60)
+            _clipXpTimes.Dequeue();
+        if (_clipXpTimes.Count >= MaxClipXpPerMinute) return false;
+        _clipXpTimes.Enqueue(now);
+        return true;
+    }
+
+    private static void ApplySetting(string? key, JToken? value)
+    {
+        var s = App.Settings?.Current;
+        if (s == null || key == null || value == null) return;
+        try
+        {
+            switch (key)
+            {
+                case "layout": s.FypLayout = (string?)value ?? "duo"; break;
+                case "includeGifs": s.FypIncludeGifs = (bool?)value ?? true; break;
+                case "mosaicAutoChange": s.FypMosaicAutoChange = (bool?)value ?? true; break;
+                case "mosaicChangeSec": s.FypMosaicChangeSec = (int?)value ?? 10; break;
+                case "autoAdvance": s.FypAutoAdvance = (bool?)value ?? false; break;
+                case "muted": s.FypMuted = (bool?)value ?? false; break;
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: settings-changed {Key} failed: {E}", key, ex.Message); }
+    }
+
+    private static JObject? LoadStats()
+    {
+        try
+        {
+            if (File.Exists(StatsFilePath))
+                return JObject.Parse(File.ReadAllText(StatsFilePath));
+        }
+        catch (Exception ex) { App.Logger?.Warning("FypHost: stats load failed: {E}", ex.Message); }
+        return null;
+    }
+
+    private static void SaveStats(JObject stats)
+    {
+        try
+        {
+            Directory.CreateDirectory(App.UserDataPath);
+            File.WriteAllText(StatsFilePath, stats.ToString(Newtonsoft.Json.Formatting.None));
+        }
+        catch (Exception ex) { App.Logger?.Warning("FypHost: stats save failed: {E}", ex.Message); }
+    }
+}

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -35,16 +34,23 @@ internal static class FypHostService
 
     private static string StatsFilePath => Path.Combine(App.UserDataPath, "fyp_stats.json");
 
-    // ---- desktop-parking state (see the "window mechanics" region at the bottom) ----
-    // Session-only: click-through ALWAYS starts off, so a relaunch can never come up as an
+    // ---- ghost-mode state (see the "window mechanics" region at the bottom) ----
+    // Session-only: ghost mode ALWAYS starts off, so a relaunch can never come up as an
     // un-clickable ghost the user has no way to grab.
-    private static bool _clickThrough;
-    // WS_EX_LAYERED is applied lazily and then left on (at alpha 255 when fully opaque) — flipping
-    // the bit back off re-stamps the frame for no gain.
-    private static bool _layered;
+    private static bool _ghosted;
+    private static FypGhostOverlay? _ghost;
+    private static double _ghostLeft, _ghostTop;      // the real window's parked-from position
+    private static bool _ghostWasMaximized;           // it was maximized before we normalized it
+    private static DateTime _lastGhostExitUtc = DateTime.MinValue;
 
-    /// <summary>True while the window is passing clicks through to whatever is behind it.</summary>
-    public static bool IsClickThrough => _clickThrough;
+    /// <summary>True while the feed is a see-through DWM mirror and the real window is parked
+    /// off-screen (mouse passes straight through to whatever is behind it).</summary>
+    public static bool IsGhosted => _ghosted;
+
+    /// <summary>True just after ghost mode ended. The panic ladder uses this to swallow the
+    /// reflexive double-tap: rung 1 drops the ghost, and a second press inside this window
+    /// must not immediately take the whole feed down.</summary>
+    public static bool RecentlyUnghosted => (DateTime.UtcNow - _lastGhostExitUtc).TotalMilliseconds < 1500;
 
     /// <summary>True while the For You window is open.</summary>
     public static bool IsActive => _host != null;
@@ -79,8 +85,14 @@ internal static class FypHostService
                 OwnedByMainWindow = true,
                 WindowTitle = "For You",
                 LogTag = "FypHost",
-                // An autoplaying feed: media must start without a user gesture.
-                ExtraBrowserArguments = "--autoplay-policy=no-user-gesture-required",
+                // An autoplaying feed: media must start without a user gesture. The two
+                // occlusion flags are what make GHOST MODE work: the real window is parked off
+                // the virtual desktop while the DWM mirror shows it, and Chromium would
+                // otherwise call it occluded/backgrounded, stop rendering, and freeze the
+                // mirror to a still frame.
+                ExtraBrowserArguments = "--autoplay-policy=no-user-gesture-required "
+                                        + "--disable-features=CalculateNativeWinOcclusion "
+                                        + "--disable-backgrounding-occluded-windows",
                 OnReady = PostInit,
                 OnMessage = OnPageMessage,
                 OnProcessFailed = _ => Close(),
@@ -104,12 +116,11 @@ internal static class FypHostService
         // found it. Nothing in here posts to the page, so ordering only matters for the stray
         // event that could otherwise land between here and Dispose().
         DisableEyeControl();
+        // Un-ghost BEFORE the host goes: the mirror window must not outlive its thumbnail source,
+        // and ExitGhost needs _host to put the real window back where it came from.
+        ExitGhost();
         var h = _host;
         _host = null;
-        // Session-only window state dies with the window: the next Launch() starts clickable and
-        // re-applies the persisted opacity from scratch.
-        _clickThrough = false;
-        _layered = false;
         try { _meta?.Save(); } catch { }
         try { h?.Dispose(); }
         catch (Exception ex) { App.Logger?.Debug("FypHost.Close: {E}", ex.Message); }
@@ -141,9 +152,9 @@ internal static class FypHostService
                 },
                 stats = LoadStats(),
             });
-            // Restore the parked opacity now the window is up. Click-through is deliberately NOT
-            // restored (session-only) — the page's toggle comes up off to match.
-            if ((s?.FypWindowOpacity ?? 1.0) < 1.0) ApplyWindowState();
+            // Opacity is applied host-side, but only once ghost mode engages (there is nothing to
+            // make translucent before that); ghost mode itself is deliberately NOT restored
+            // (session-only) — the page's toggle comes up off.
             // Persisted eye control re-arms the camera on every launch (with the same consent
             // gate as the toggle) — the page has already rendered its toggle "on" from the
             // payload above, and eyeStatus corrects it if the camera refuses.
@@ -185,6 +196,11 @@ internal static class FypHostService
                 ApplySetting((string?)o["key"], o["value"]);
                 break;
             }
+            case "calibrate":
+            {
+                _host?.Window?.Dispatcher.BeginInvoke(new Action(RunGazeCalibration));
+                break;
+            }
             case "close":
             {
                 _host?.Window?.Dispatcher.BeginInvoke(Close);
@@ -207,15 +223,14 @@ internal static class FypHostService
     {
         if (key == null || value == null) return;
         // Session-only and settings-free, so it is handled before the settings null-guard.
+        // ("clickThrough" is the on-the-wire key name the page has always used; host-side the
+        // feature is ghost mode. Only the user-facing strings changed.)
         if (key == "clickThrough")
         {
             try
             {
-                bool on = (bool?)value ?? false;
-                if (on == _clickThrough) return;
-                _clickThrough = on;
-                ApplyWindowState();
-                App.Logger?.Information("FypHost: click-through {State}", on ? "ON" : "off");
+                if ((bool?)value ?? false) EnterGhost();
+                else ExitGhost();
             }
             catch (Exception ex) { App.Logger?.Debug("FypHost: clickThrough failed: {E}", ex.Message); }
             return;
@@ -233,9 +248,15 @@ internal static class FypHostService
                 case "mosaicChangeSec": s.FypMosaicChangeSec = (int?)value ?? 10; break;
                 case "autoAdvance": s.FypAutoAdvance = (bool?)value ?? false; break;
                 case "muted": s.FypMuted = (bool?)value ?? false; break;
-                // The setter clamps to 0.30-1.0; read it back so the live window and the stored
-                // value can never disagree about what a rogue payload asked for.
-                case "windowOpacity": s.FypWindowOpacity = (double?)value ?? 1.0; ApplyWindowState(); break;
+                // Persist, and push straight onto the ghost mirror when one is up — the mirror
+                // is a plain window, so its constant alpha IS the opacity (see below).
+                case "windowOpacity":
+                {
+                    double v = (double?)value ?? 1.0;
+                    s.FypWindowOpacity = v;
+                    _ghost?.SetOpacity(v);
+                    break;
+                }
                 case "audioGlow": s.FypAudioGlow = (bool?)value ?? true; break;   // page-side visual: persist only
                 case "eyeControl":
                 {
@@ -278,38 +299,46 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Warning("FypHost: stats save failed: {E}", ex.Message); }
     }
 
-    // ======================= window mechanics: opacity + click-through =======================
+    // ================== window mechanics: GHOST MODE (opacity + click-through) ==================
     //
-    // The point of both is "park the feed over the desktop and keep working": a faint, unclickable
-    // pane of the feed running behind whatever the user is actually doing.
+    // The point is "park the feed over the desktop and keep working": a faint, unclickable pane of
+    // the feed running behind whatever the user is actually doing.
     //
-    // OPACITY — WPF's Window.Opacity is useless here. It is a composition-tree property, and the
-    // WebView2 surface is a CHILD HWND that DWM composites separately (the classic airspace
-    // problem): the WPF chrome would fade and the video would stay solid. AllowsTransparency=true
-    // is worse still — that is the per-pixel UpdateLayeredWindow path, in which a WebView2 child
-    // does not paint at all (see the class comment on ChaosWebViewHost). The one technique that
-    // does work is the OTHER layered-window mode: WS_EX_LAYERED + SetLayeredWindowAttributes with
-    // LWA_ALPHA, which since Windows 8 makes DWM apply a constant alpha to the whole window
-    // hierarchy, child HWNDs included, with no bearing on how anything paints.
+    // THE MECHANISM IS A DWM LIVE-THUMBNAIL MIRROR (the OnTopReplica technique), not a style dance
+    // on the feed window. Ghosting moves the REAL WebView2 window fully off the virtual desktop
+    // (shown, never minimized — a minimized source freezes the thumbnail) and shows a
+    // FypGhostOverlay at its former rectangle: an empty WPF window carrying a live DWM thumbnail
+    // of the real one. Audio keeps playing, blink/gaze keep driving the real page, and the mirror
+    // simply shows the result — see-through and input-transparent for real.
     //
-    // CLICK-THROUGH — WS_EX_TRANSPARENT on the top-level window (which also requires WS_EX_LAYERED
-    // to actually pass input through, not merely skip hit-testing). That alone is not enough here:
-    // WebView2 parents its own child HWNDs (Chrome_WidgetWin_*, "Intermediate D3D Window") under
-    // ours, and a child still answers WM_NCHITTEST for its own rectangle — which is exactly the
-    // rectangle the video fills. So the flag is stamped on every descendant too, and cleared off
-    // every descendant when click-through goes away.
+    // Why not just style the feed window (this was shipped once and reproduced live 2026-08-03):
+    //   - WPF Window.Opacity: composition-tree property; the WebView2 child HWND ignores it.
+    //   - AllowsTransparency=true: per-pixel UpdateLayeredWindow path; WebView2 does not paint at
+    //     all (see the class comment on ChaosWebViewHost).
+    //   - WS_EX_LAYERED + SetLayeredWindowAttributes(LWA_ALPHA): the moment the constant-alpha
+    //     path ENGAGES, the WebView2 content goes solid BLACK and stays black — DWM's layered
+    //     redirection never sees the Chromium child processes' cross-process DirectComposition
+    //     visuals ("clicking the opacity brings up a black screen").
+    //   - WS_EX_TRANSPARENT alone gave real click-through, but paired with a page-side dim overlay
+    //     it only ever made the feed DARKER — you still could not see the desktop behind it.
+    // NOTHING may ever call SetLayeredWindowAttributes on the FEED window. On the MIRROR window
+    // SLWA is used with LWA_COLORKEY only — pixel-measured on this machine: LWA_ALPHA multiplies
+    // the DWM thumbnail together with the surface (no alpha value works), while a color-keyed
+    // surface drops out of composition and lets DWM_TNP_OPACITY blend the mirror against the
+    // desktop. See FypGhostOverlay for the styles, the DWM structs and the DPI math.
 
-    /// <summary>Push the current opacity/click-through state onto the live window. Safe to call
-    /// from any thread and before the window exists (then it is simply a no-op).</summary>
-    private static void ApplyWindowState()
+    /// <summary>Park the real feed window off-screen and put the see-through DWM mirror in its
+    /// place. Idempotent; no-op before the window exists.</summary>
+    private static void EnterGhost()
     {
+        if (_ghosted) return;
         var win = _host?.Window;
         if (win == null) return;
         if (!win.Dispatcher.CheckAccess())
         {
             // WebView2 raises WebMessageReceived on the thread that created it, so ApplySetting is
             // already on the UI thread in practice - this is belt and braces, not a hot path.
-            try { win.Dispatcher.BeginInvoke(new Action(ApplyWindowState)); } catch { }
+            try { win.Dispatcher.BeginInvoke(new Action(EnterGhost)); } catch { }
             return;
         }
         try
@@ -317,55 +346,109 @@ internal static class FypHostService
             var hwnd = new WindowInteropHelper(win).Handle;
             if (hwnd == IntPtr.Zero) return;
 
-            double opacity = Math.Clamp(App.Settings?.Current?.FypWindowOpacity ?? 1.0, 0.30, 1.0);
-            // Never touch the frame of a window that has only ever been fully opaque and clickable:
-            // the layered path is opt-in, so an untouched feed stays exactly as it was before.
-            if (!_layered && opacity >= 1.0 && !_clickThrough) return;
+            // A maximized window has no meaningful Left/Top to mirror or restore, so normalize
+            // first (remembering to put it back) and read the restored rect.
+            _ghostWasMaximized = win.WindowState == WindowState.Maximized;
+            if (win.WindowState != WindowState.Normal) win.WindowState = WindowState.Normal;
 
-            long ex = GetWindowLongPtr(hwnd, GWL_EXSTYLE).ToInt64();
-            long want = ex | WS_EX_LAYERED;
-            if (_clickThrough) want |= WS_EX_TRANSPARENT;
-            else want &= ~WS_EX_TRANSPARENT;
-            if (want != ex) SetWindowLongPtr(hwnd, GWL_EXSTYLE, new IntPtr(want));
-            _layered = true;
+            _ghostLeft = win.Left;
+            _ghostTop = win.Top;
+            double w = win.ActualWidth > 0 ? win.ActualWidth : win.Width;
+            double h = win.ActualHeight > 0 ? win.ActualHeight : win.Height;
+            if (!(w > 0) || !(h > 0))
+            {
+                // Nothing to mirror yet, and nothing has moved — put the state back and bail.
+                if (_ghostWasMaximized) win.WindowState = WindowState.Maximized;
+                _ghostWasMaximized = false;
+                return;
+            }
+            var bounds = new Rect(_ghostLeft, _ghostTop, w, h);
 
-            SetLayeredWindowAttributes(hwnd, 0, (byte)Math.Round(opacity * 255.0), LWA_ALPHA);
-            ApplyChildClickThrough(hwnd, _clickThrough);
+            // From here on ExitGhost is the only correct way out, so arm it BEFORE the window
+            // moves: a throw below must never leave the real window parked off-screen.
+            _ghosted = true;
+
+            // The overlay ctor captures the feed's home monitor from its HWND, so it must run
+            // BEFORE the park moves the window off every monitor.
+            _ghost = new FypGhostOverlay(hwnd, bounds, App.Settings?.Current?.FypWindowOpacity ?? 1.0,
+                onGear: GhostGearClicked, onMute: GhostMuteClicked,
+                isMuted: () => App.Settings?.Current?.FypMuted ?? false);
+
+            // Park it past the right edge of every monitor. Still SHOWN (DWM keeps compositing it,
+            // so the thumbnail stays live); the browser flags keep Chromium from throttling it.
+            win.Left = SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth + 200;
+
+            _ghost.Show();
+            App.Logger?.Information(
+                "FypHostService: ghost mode ON (mirror at {L}x{T} {W}x{H}, real window parked at {Park})",
+                (int)bounds.X, (int)bounds.Y, (int)bounds.Width, (int)bounds.Height, (int)win.Left);
         }
-        catch (Exception ex) { App.Logger?.Debug("FypHost.ApplyWindowState: {E}", ex.Message); }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("FypHost.EnterGhost failed: {E}", ex.Message);
+            ExitGhost();   // never leave the real window parked off-screen with no mirror
+        }
     }
 
-    /// <summary>Stamp (or strip) WS_EX_TRANSPARENT on every descendant HWND of the host window.
-    /// WebView2's own child windows hit-test independently of ours.</summary>
-    private static void ApplyChildClickThrough(IntPtr parent, bool on)
-    {
-        try { EnumChildWindows(parent, _childStyler, on ? new IntPtr(1) : IntPtr.Zero); }
-        catch (Exception ex) { App.Logger?.Debug("FypHost.ApplyChildClickThrough: {E}", ex.Message); }
-    }
-
-    // Held in a static field so the GC cannot collect the delegate under the native callback.
-    private static readonly EnumWindowsProc _childStyler = (child, lParam) =>
+    /// <summary>The ghost gear button: give the window back and open the options popover in one
+    /// click, so tweaking settings from ghost mode is one step instead of Esc-then-gear.</summary>
+    private static void GhostGearClicked()
     {
         try
         {
-            long ex = GetWindowLongPtr(child, GWL_EXSTYLE).ToInt64();
-            long want = lParam != IntPtr.Zero ? (ex | WS_EX_TRANSPARENT) : (ex & ~WS_EX_TRANSPARENT);
-            if (want != ex) SetWindowLongPtr(child, GWL_EXSTYLE, new IntPtr(want));
+            ExitGhost();
+            _host?.Window?.Activate();
+            _host?.Post(new { type = "openOptions" });
         }
-        catch { }
-        return true;   // keep enumerating
-    };
+        catch (Exception ex) { App.Logger?.Debug("FypHost: ghost gear failed: {E}", ex.Message); }
+    }
 
-    /// <summary>Give the window back its clicks and tell the page to un-check its toggle.
-    /// The panic ladder's first rung; also safe to call when click-through is already off.</summary>
-    public static void DisableClickThrough()
+    /// <summary>The ghost speaker button: flip mute WITHOUT leaving ghost mode — the parked
+    /// window keeps playing audio, so this is the one control worth reaching in ghost.</summary>
+    private static void GhostMuteClicked()
     {
-        if (!_clickThrough) return;
-        _clickThrough = false;
-        ApplyWindowState();
+        try
+        {
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            s.FypMuted = !s.FypMuted;
+            _host?.Post(new { type = "setMuted", on = s.FypMuted });
+            _ghost?.RefreshMuteGlyph();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: ghost mute failed: {E}", ex.Message); }
+    }
+
+    /// <summary>Close the mirror, bring the real window back to where it was, and tell the page to
+    /// un-check its toggle. The panic ladder's first rung; idempotent and safe when off.</summary>
+    public static void ExitGhost()
+    {
+        if (!_ghosted) return;
+        var win = _host?.Window;
+        if (win != null && !win.Dispatcher.CheckAccess())
+        {
+            try { win.Dispatcher.BeginInvoke(new Action(ExitGhost)); } catch { }
+            return;
+        }
+        _ghosted = false;
+        var g = _ghost;
+        _ghost = null;
+        try { g?.Close(); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost close: {E}", ex.Message); }
+        try
+        {
+            if (win != null)
+            {
+                win.Left = _ghostLeft;
+                win.Top = _ghostTop;
+                if (_ghostWasMaximized) win.WindowState = WindowState.Maximized;
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost restore: {E}", ex.Message); }
+        _ghostWasMaximized = false;
+        _lastGhostExitUtc = DateTime.UtcNow;
         try { _host?.Post(new { type = "clickThrough", on = false }); }
-        catch (Exception ex) { App.Logger?.Debug("FypHost.DisableClickThrough post: {E}", ex.Message); }
-        App.Logger?.Information("FypHostService: click-through disabled");
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost post: {E}", ex.Message); }
+        App.Logger?.Information("FypHostService: ghost mode off");
     }
 
     // ============================= webcam eye control =============================
@@ -538,6 +621,27 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Debug("FypHost: eyeStatus post: {E}", ex.Message); }
     }
 
+    /// <summary>The page's Calibrate button: run the native gaze-calibration dialog over the
+    /// feed, then re-wire gaze and tell the page the new state. UI thread only.</summary>
+    private static void RunGazeCalibration()
+    {
+        try
+        {
+            if (WebcamCalibrationWindow.IsShowing) return;
+            if (App.Webcam?.IsRunning != true)
+            {
+                // The page disables the button without a running camera; this is belt and braces.
+                PostEyeStatus(null);
+                return;
+            }
+            ExitGhost();   // a parked window cannot host a modal dot dance
+            WebcamCalibrationWindow.ShowDialogWithRecalibrate(_host?.Window);
+            SyncGazeSubscription();
+            PostEyeStatus(null);
+        }
+        catch (Exception ex) { App.Logger?.Warning("FypHost: gaze calibration failed: {E}", ex.Message); }
+    }
+
     // All three handlers already arrive on the UI thread (the service Dispatch()es every event),
     // which is also the thread that owns the WebView2 — Post() is safe from here.
     private static void OnEyeBlink()
@@ -603,19 +707,4 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Debug("FypHost: gaze post: {E}", ex.Message); }
     }
 
-    private const int GWL_EXSTYLE = -20;
-    private const long WS_EX_LAYERED = 0x00080000L;
-    private const long WS_EX_TRANSPARENT = 0x00000020L;
-    private const uint LWA_ALPHA = 0x2;
-
-    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
-
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-    [DllImport("user32.dll", SetLastError = true)]
-    private static extern bool SetLayeredWindowAttributes(IntPtr hWnd, uint crKey, byte bAlpha, uint dwFlags);
-    [DllImport("user32.dll")]
-    private static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
 }

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json.Linq;
 
@@ -30,6 +34,17 @@ internal static class FypHostService
     private static readonly Queue<DateTime> _clipXpTimes = new();
 
     private static string StatsFilePath => Path.Combine(App.UserDataPath, "fyp_stats.json");
+
+    // ---- desktop-parking state (see the "window mechanics" region at the bottom) ----
+    // Session-only: click-through ALWAYS starts off, so a relaunch can never come up as an
+    // un-clickable ghost the user has no way to grab.
+    private static bool _clickThrough;
+    // WS_EX_LAYERED is applied lazily and then left on (at alpha 255 when fully opaque) — flipping
+    // the bit back off re-stamps the frame for no gain.
+    private static bool _layered;
+
+    /// <summary>True while the window is passing clicks through to whatever is behind it.</summary>
+    public static bool IsClickThrough => _clickThrough;
 
     /// <summary>True while the For You window is open.</summary>
     public static bool IsActive => _host != null;
@@ -85,8 +100,16 @@ internal static class FypHostService
     /// <summary>Tear the window down (idempotent; also the ProcessFailed and panic path).</summary>
     public static void Close()
     {
+        // Before _host goes: drop the webcam subscriptions and put the camera back the way we
+        // found it. Nothing in here posts to the page, so ordering only matters for the stray
+        // event that could otherwise land between here and Dispose().
+        DisableEyeControl();
         var h = _host;
         _host = null;
+        // Session-only window state dies with the window: the next Launch() starts clickable and
+        // re-applies the persisted opacity from scratch.
+        _clickThrough = false;
+        _layered = false;
         try { _meta?.Save(); } catch { }
         try { h?.Dispose(); }
         catch (Exception ex) { App.Logger?.Debug("FypHost.Close: {E}", ex.Message); }
@@ -111,9 +134,20 @@ internal static class FypHostService
                     mosaicChangeSec = s?.FypMosaicChangeSec ?? 10,
                     autoAdvance = s?.FypAutoAdvance ?? false,
                     muted = s?.FypMuted ?? false,
+                    windowOpacity = s?.FypWindowOpacity ?? 1.0,
+                    audioGlow = s?.FypAudioGlow ?? true,
+                    eyeControl = s?.FypEyeControl ?? false,
+                    eyeGaze = s?.FypEyeGaze ?? false,
                 },
                 stats = LoadStats(),
             });
+            // Restore the parked opacity now the window is up. Click-through is deliberately NOT
+            // restored (session-only) — the page's toggle comes up off to match.
+            if ((s?.FypWindowOpacity ?? 1.0) < 1.0) ApplyWindowState();
+            // Persisted eye control re-arms the camera on every launch (with the same consent
+            // gate as the toggle) — the page has already rendered its toggle "on" from the
+            // payload above, and eyeStatus corrects it if the camera refuses.
+            if (s?.FypEyeControl == true) EnableEyeControl();
         }
         catch (Exception ex) { App.Logger?.Warning("FypHost.PostInit failed: {E}", ex.Message); }
     }
@@ -171,8 +205,24 @@ internal static class FypHostService
 
     private static void ApplySetting(string? key, JToken? value)
     {
+        if (key == null || value == null) return;
+        // Session-only and settings-free, so it is handled before the settings null-guard.
+        if (key == "clickThrough")
+        {
+            try
+            {
+                bool on = (bool?)value ?? false;
+                if (on == _clickThrough) return;
+                _clickThrough = on;
+                ApplyWindowState();
+                App.Logger?.Information("FypHost: click-through {State}", on ? "ON" : "off");
+            }
+            catch (Exception ex) { App.Logger?.Debug("FypHost: clickThrough failed: {E}", ex.Message); }
+            return;
+        }
+
         var s = App.Settings?.Current;
-        if (s == null || key == null || value == null) return;
+        if (s == null) return;
         try
         {
             switch (key)
@@ -183,6 +233,25 @@ internal static class FypHostService
                 case "mosaicChangeSec": s.FypMosaicChangeSec = (int?)value ?? 10; break;
                 case "autoAdvance": s.FypAutoAdvance = (bool?)value ?? false; break;
                 case "muted": s.FypMuted = (bool?)value ?? false; break;
+                // The setter clamps to 0.30-1.0; read it back so the live window and the stored
+                // value can never disagree about what a rogue payload asked for.
+                case "windowOpacity": s.FypWindowOpacity = (double?)value ?? 1.0; ApplyWindowState(); break;
+                case "audioGlow": s.FypAudioGlow = (bool?)value ?? true; break;   // page-side visual: persist only
+                case "eyeControl":
+                {
+                    bool on = (bool?)value ?? false;
+                    s.FypEyeControl = on;
+                    if (on) EnableEyeControl();
+                    else { DisableEyeControl(); PostEyeStatus(null); }
+                    break;
+                }
+                case "eyeGaze":
+                {
+                    s.FypEyeGaze = (bool?)value ?? false;
+                    SyncGazeSubscription();
+                    PostEyeStatus(null);
+                    break;
+                }
             }
         }
         catch (Exception ex) { App.Logger?.Debug("FypHost: settings-changed {Key} failed: {E}", key, ex.Message); }
@@ -208,4 +277,345 @@ internal static class FypHostService
         }
         catch (Exception ex) { App.Logger?.Warning("FypHost: stats save failed: {E}", ex.Message); }
     }
+
+    // ======================= window mechanics: opacity + click-through =======================
+    //
+    // The point of both is "park the feed over the desktop and keep working": a faint, unclickable
+    // pane of the feed running behind whatever the user is actually doing.
+    //
+    // OPACITY — WPF's Window.Opacity is useless here. It is a composition-tree property, and the
+    // WebView2 surface is a CHILD HWND that DWM composites separately (the classic airspace
+    // problem): the WPF chrome would fade and the video would stay solid. AllowsTransparency=true
+    // is worse still — that is the per-pixel UpdateLayeredWindow path, in which a WebView2 child
+    // does not paint at all (see the class comment on ChaosWebViewHost). The one technique that
+    // does work is the OTHER layered-window mode: WS_EX_LAYERED + SetLayeredWindowAttributes with
+    // LWA_ALPHA, which since Windows 8 makes DWM apply a constant alpha to the whole window
+    // hierarchy, child HWNDs included, with no bearing on how anything paints.
+    //
+    // CLICK-THROUGH — WS_EX_TRANSPARENT on the top-level window (which also requires WS_EX_LAYERED
+    // to actually pass input through, not merely skip hit-testing). That alone is not enough here:
+    // WebView2 parents its own child HWNDs (Chrome_WidgetWin_*, "Intermediate D3D Window") under
+    // ours, and a child still answers WM_NCHITTEST for its own rectangle — which is exactly the
+    // rectangle the video fills. So the flag is stamped on every descendant too, and cleared off
+    // every descendant when click-through goes away.
+
+    /// <summary>Push the current opacity/click-through state onto the live window. Safe to call
+    /// from any thread and before the window exists (then it is simply a no-op).</summary>
+    private static void ApplyWindowState()
+    {
+        var win = _host?.Window;
+        if (win == null) return;
+        if (!win.Dispatcher.CheckAccess())
+        {
+            // WebView2 raises WebMessageReceived on the thread that created it, so ApplySetting is
+            // already on the UI thread in practice - this is belt and braces, not a hot path.
+            try { win.Dispatcher.BeginInvoke(new Action(ApplyWindowState)); } catch { }
+            return;
+        }
+        try
+        {
+            var hwnd = new WindowInteropHelper(win).Handle;
+            if (hwnd == IntPtr.Zero) return;
+
+            double opacity = Math.Clamp(App.Settings?.Current?.FypWindowOpacity ?? 1.0, 0.30, 1.0);
+            // Never touch the frame of a window that has only ever been fully opaque and clickable:
+            // the layered path is opt-in, so an untouched feed stays exactly as it was before.
+            if (!_layered && opacity >= 1.0 && !_clickThrough) return;
+
+            long ex = GetWindowLongPtr(hwnd, GWL_EXSTYLE).ToInt64();
+            long want = ex | WS_EX_LAYERED;
+            if (_clickThrough) want |= WS_EX_TRANSPARENT;
+            else want &= ~WS_EX_TRANSPARENT;
+            if (want != ex) SetWindowLongPtr(hwnd, GWL_EXSTYLE, new IntPtr(want));
+            _layered = true;
+
+            SetLayeredWindowAttributes(hwnd, 0, (byte)Math.Round(opacity * 255.0), LWA_ALPHA);
+            ApplyChildClickThrough(hwnd, _clickThrough);
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ApplyWindowState: {E}", ex.Message); }
+    }
+
+    /// <summary>Stamp (or strip) WS_EX_TRANSPARENT on every descendant HWND of the host window.
+    /// WebView2's own child windows hit-test independently of ours.</summary>
+    private static void ApplyChildClickThrough(IntPtr parent, bool on)
+    {
+        try { EnumChildWindows(parent, _childStyler, on ? new IntPtr(1) : IntPtr.Zero); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ApplyChildClickThrough: {E}", ex.Message); }
+    }
+
+    // Held in a static field so the GC cannot collect the delegate under the native callback.
+    private static readonly EnumWindowsProc _childStyler = (child, lParam) =>
+    {
+        try
+        {
+            long ex = GetWindowLongPtr(child, GWL_EXSTYLE).ToInt64();
+            long want = lParam != IntPtr.Zero ? (ex | WS_EX_TRANSPARENT) : (ex & ~WS_EX_TRANSPARENT);
+            if (want != ex) SetWindowLongPtr(child, GWL_EXSTYLE, new IntPtr(want));
+        }
+        catch { }
+        return true;   // keep enumerating
+    };
+
+    /// <summary>Give the window back its clicks and tell the page to un-check its toggle.
+    /// The panic ladder's first rung; also safe to call when click-through is already off.</summary>
+    public static void DisableClickThrough()
+    {
+        if (!_clickThrough) return;
+        _clickThrough = false;
+        ApplyWindowState();
+        try { _host?.Post(new { type = "clickThrough", on = false }); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.DisableClickThrough post: {E}", ex.Message); }
+        App.Logger?.Information("FypHostService: click-through disabled");
+    }
+
+    // ============================= webcam eye control =============================
+    //
+    // Blink = swap one tile on the active page (the tile being LOOKED at when gaze mode is on
+    // and calibrated, otherwise a random one). Eyes held shut for 2s = change the whole page.
+    // The gestures themselves live in the page (main.js); this end owns the camera lifecycle,
+    // the coordinate transform and the status protocol.
+    //
+    // Lifecycle rules, copied from the Deeper player's pre-play prompt:
+    //   * consent is gated on WebcamTrackingService.IsConsentCurrent() and re-prompted through
+    //     the same WebcamConsentDialog every other call site uses;
+    //   * Start() is NEVER called on the UI thread (it opens the camera and builds three ONNX
+    //     sessions synchronously) — always await StartAsync();
+    //   * we only stop the camera we started ourselves: a webcam that was already tracking for
+    //     the Lab / Deeper / blink trainer is left running when the feed closes.
+
+    private static bool _eyeSubscribed;      // OnBlink + OnEyesClosedLong attached
+    private static bool _gazeSubscribed;     // OnGazeMove attached (needs eyeGaze + calibration)
+    private static bool _fypStartedWebcam;   // WE turned the camera on -> WE turn it off
+    private static bool _eyeEnabling;        // an enable sequence is in flight (re-entrancy guard)
+    private static DateTime _lastGazePostAt = DateTime.MinValue;
+
+    // OnGazeMove fires per processed frame (~30Hz). The page only needs to know which TILE is
+    // being looked at, so coalesce to 10Hz and spare the WebView2 message pump.
+    private const int GazePostIntervalMs = 100;
+
+    /// <summary>Consent → camera → subscriptions, reporting each step to the page. Fire and
+    /// forget: OnPageMessage must never block on a camera open.</summary>
+    private static async void EnableEyeControl()
+    {
+        if (_eyeEnabling) return;
+        _eyeEnabling = true;
+        try
+        {
+            // Hop off the WebView2 message callback (and off OnReady) before anything
+            // modal or long-running: a consent dialog pumped from inside a web-message
+            // handler re-enters the browser's own message loop.
+            await System.Threading.Tasks.Task.Yield();
+
+            var svc = App.Webcam;
+            if (svc == null) { FailEyeControl("no-camera"); return; }
+
+            if (!WebcamTrackingService.IsConsentCurrent())
+            {
+                var dlg = new WebcamConsentDialog();
+                var owner = _host?.Window;
+                if (owner != null && owner.IsLoaded) dlg.Owner = owner;
+                var ok = dlg.ShowDialog();
+                if (ok != true || !dlg.ConsentGiven) { FailEyeControl("consent"); return; }
+            }
+
+            if (!svc.IsRunning)
+            {
+                PostEyeStatus("starting");   // the global loading splash rides OnStartupProgress
+                // NEVER Start() on the UI thread: it opens the camera and builds three ONNX
+                // sessions synchronously and can block for tens of seconds.
+                bool started = await svc.StartAsync();
+                if (!started)
+                {
+                    FailEyeControl(svc.State == WebcamTrackingState.Error ? "error" : "no-camera");
+                    return;
+                }
+                _fypStartedWebcam = true;
+            }
+
+            // The window may have closed, or the user may have flipped the toggle back off,
+            // while the camera was opening. Undo rather than leave an orphan camera running.
+            if (_host == null || App.Settings?.Current?.FypEyeControl != true)
+            {
+                DisableEyeControl();
+                return;
+            }
+
+            svc.OnBlink += OnEyeBlink;
+            svc.OnEyesClosedLong += OnEyeClosedLong;
+            _eyeSubscribed = true;
+            SyncGazeSubscription();
+            PostEyeStatus(null);
+            App.Logger?.Information("FypHost: eye control ON (gaze {Gaze})",
+                _gazeSubscribed ? "on" : "off");
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("FypHost: eye control enable failed: {E}", ex.Message);
+            FailEyeControl("error");
+        }
+        finally { _eyeEnabling = false; }
+    }
+
+    /// <summary>Enable failed: flip the persisted setting back off, tear down whatever got
+    /// half-built, and tell the page why so its toggle resets with a reason.</summary>
+    private static void FailEyeControl(string reason)
+    {
+        try { if (App.Settings?.Current is { } s) s.FypEyeControl = false; } catch { }
+        DisableEyeControl();
+        PostEyeStatus(reason);
+    }
+
+    /// <summary>Unsubscribe everything and hand the camera back. Safe to call repeatedly and
+    /// when nothing was ever enabled.</summary>
+    private static void DisableEyeControl()
+    {
+        var svc = App.Webcam;
+        try
+        {
+            if (svc != null)
+            {
+                if (_eyeSubscribed)
+                {
+                    svc.OnBlink -= OnEyeBlink;
+                    svc.OnEyesClosedLong -= OnEyeClosedLong;
+                }
+                if (_gazeSubscribed) svc.OnGazeMove -= OnEyeGaze;
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: eye unsubscribe: {E}", ex.Message); }
+        _eyeSubscribed = false;
+        _gazeSubscribed = false;
+
+        try
+        {
+            if (_fypStartedWebcam && svc?.IsRunning == true) svc.Stop();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: webcam stop: {E}", ex.Message); }
+        _fypStartedWebcam = false;
+    }
+
+    /// <summary>Gaze costs a message every 100ms, so it is only wired when it can actually
+    /// resolve a tile: eye control on, gaze mode on, AND a calibration loaded (uncalibrated,
+    /// OnGazeMove never fires at all — the page falls back to a random tile).</summary>
+    private static void SyncGazeSubscription()
+    {
+        var svc = App.Webcam;
+        var s = App.Settings?.Current;
+        bool want = _eyeSubscribed
+                    && svc != null
+                    && s?.FypEyeControl == true
+                    && s.FypEyeGaze
+                    && svc.Calibration != null;
+        if (want == _gazeSubscribed) return;
+        try
+        {
+            if (svc == null) { _gazeSubscribed = false; return; }
+            if (want) svc.OnGazeMove += OnEyeGaze;
+            else svc.OnGazeMove -= OnEyeGaze;
+            _gazeSubscribed = want;
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: gaze subscribe: {E}", ex.Message); }
+    }
+
+    /// <summary>Whatever just happened, tell the page what is actually true so its toggles and
+    /// status line render reality. reason ∈ null|"consent"|"starting"|"no-camera"|"error".</summary>
+    private static void PostEyeStatus(string? reason)
+    {
+        try
+        {
+            var s = App.Settings?.Current;
+            var svc = App.Webcam;
+            _host?.Post(new
+            {
+                type = "eyeStatus",
+                enabled = s?.FypEyeControl ?? false,
+                gaze = s?.FypEyeGaze ?? false,
+                running = svc?.IsRunning == true,
+                calibrated = svc?.Calibration != null,
+                reason,
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: eyeStatus post: {E}", ex.Message); }
+    }
+
+    // All three handlers already arrive on the UI thread (the service Dispatch()es every event),
+    // which is also the thread that owns the WebView2 — Post() is safe from here.
+    private static void OnEyeBlink()
+    {
+        try { _host?.Post(new { type = "blink" }); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: blink post: {E}", ex.Message); }
+    }
+
+    private static void OnEyeClosedLong()
+    {
+        try { _host?.Post(new { type = "eyesClosed" }); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: eyesClosed post: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// Gaze point → normalized WebView client coordinates.
+    ///
+    /// OnGazeMove emits DIPs local to the CALIBRATED monitor's top-left, at THAT monitor's DPI
+    /// (the calibration window was borderless-maximized on it). So: back to physical desktop
+    /// pixels through the calibration's own DpiScale/origin, then into the WebView's client
+    /// space through the WebView's own DPI — the two can differ on a mixed-DPI desktop, which
+    /// is exactly why the conversion cannot be skipped in either direction.
+    ///
+    /// The page gets 0..1 plus an <c>inside</c> flag: the point is clamped so it is always a
+    /// usable number, and the flag lets the page ignore gaze that is off the window entirely
+    /// instead of pinning it to an edge tile.
+    /// </summary>
+    private static void OnEyeGaze(Point p)
+    {
+        try
+        {
+            var now = DateTime.UtcNow;
+            if ((now - _lastGazePostAt).TotalMilliseconds < GazePostIntervalMs) return;
+
+            var web = _host?.WebView;
+            if (web == null || !web.IsLoaded || web.ActualWidth <= 0 || web.ActualHeight <= 0) return;
+
+            var bounds = App.Webcam?.Calibration?.MonitorBounds;
+            double calDpi = bounds is { DpiScale: > 0.25 and < 8.0 } ? bounds.DpiScale : 1.0;
+            double originX = bounds?.DeviceName != null ? bounds.X : 0;
+            double originY = bounds?.DeviceName != null ? bounds.Y : 0;
+            double physX = p.X * calDpi + originX;
+            double physY = p.Y * calDpi + originY;
+
+            var dpi = VisualTreeHelper.GetDpi(web);
+            double sx = dpi.DpiScaleX <= 0 ? 1.0 : dpi.DpiScaleX;
+            double sy = dpi.DpiScaleY <= 0 ? 1.0 : dpi.DpiScaleY;
+            var webOriginPx = web.PointToScreen(new Point(0, 0));   // physical px
+
+            double nx = ((physX - webOriginPx.X) / sx) / web.ActualWidth;
+            double ny = ((physY - webOriginPx.Y) / sy) / web.ActualHeight;
+            bool inside = nx >= 0 && nx <= 1 && ny >= 0 && ny <= 1;
+
+            _lastGazePostAt = now;
+            _host?.Post(new
+            {
+                type = "gaze",
+                x = Math.Clamp(nx, 0, 1),
+                y = Math.Clamp(ny, 0, 1),
+                inside,
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: gaze post: {E}", ex.Message); }
+    }
+
+    private const int GWL_EXSTYLE = -20;
+    private const long WS_EX_LAYERED = 0x00080000L;
+    private const long WS_EX_TRANSPARENT = 0x00000020L;
+    private const uint LWA_ALPHA = 0x2;
+
+    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetLayeredWindowAttributes(IntPtr hWnd, uint crKey, byte bAlpha, uint dwFlags);
+    [DllImport("user32.dll")]
+    private static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
 }

--- a/ConditioningControlPanel/Services/Fyp/FypMetaStore.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypMetaStore.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Fyp;
+
+/// <summary>
+/// Per-asset media metadata the feed page probed at playback time (duration + pixel
+/// dimensions), persisted to <c>fyp_meta.json</c> so the next launch can build the full
+/// segment grid and know orientation up front. Keyed by manifest id (relative path).
+/// Purely additive quality data — losing the file just means the page re-probes.
+/// </summary>
+internal sealed class FypMetaStore
+{
+    private static string FilePath => Path.Combine(App.UserDataPath, "fyp_meta.json");
+    private const int MaxEntries = 10000;
+
+    public sealed class Meta
+    {
+        public long? DurationMs { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+    }
+
+    private readonly Dictionary<string, Meta> _byId;
+    private readonly object _lock = new();
+    private bool _dirty;
+
+    public FypMetaStore()
+    {
+        _byId = Load();
+    }
+
+    public Meta? Get(string id)
+    {
+        lock (_lock) return _byId.TryGetValue(id, out var m) ? m : null;
+    }
+
+    /// <summary>Merge a page probe. Idempotent; junk values are ignored.</summary>
+    public void Update(string? id, long? durationMs, int? width, int? height)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        lock (_lock)
+        {
+            if (!_byId.TryGetValue(id, out var m))
+            {
+                if (_byId.Count >= MaxEntries) return;
+                m = new Meta();
+                _byId[id] = m;
+            }
+            if (durationMs is > 0 && m.DurationMs != durationMs) { m.DurationMs = durationMs; _dirty = true; }
+            if (width is > 0 && height is > 0 && (m.Width != width || m.Height != height))
+            {
+                m.Width = width;
+                m.Height = height;
+                _dirty = true;
+            }
+        }
+    }
+
+    public void Save()
+    {
+        lock (_lock)
+        {
+            if (!_dirty) return;
+            try
+            {
+                Directory.CreateDirectory(App.UserDataPath);
+                File.WriteAllText(FilePath, JsonConvert.SerializeObject(_byId));
+                _dirty = false;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("FypMetaStore: save failed: {E}", ex.Message);
+            }
+        }
+    }
+
+    private static Dictionary<string, Meta> Load()
+    {
+        try
+        {
+            if (File.Exists(FilePath))
+                return JsonConvert.DeserializeObject<Dictionary<string, Meta>>(File.ReadAllText(FilePath)) ?? new();
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("FypMetaStore: load failed: {E}", ex.Message);
+        }
+        return new();
+    }
+}

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1484,6 +1484,21 @@ namespace ConditioningControlPanel.Services
                 return;
             }
 
+            // For You feed open: the feed IS the video experience — a mandatory video over it
+            // would fight the feed's own players for audio and attention. Drop outright (never
+            // queue: the feed can stay open far longer than the queue's stuck window), releasing
+            // a dequeued claim the same way the cascade guard above does.
+            if (Fyp.FypHostService.IsActive)
+            {
+                App.Logger?.Information("VideoService: TriggerVideo dropped - For You feed active");
+                if (!_videoPlaying &&
+                    App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.Video)
+                {
+                    App.InteractionQueue.Complete(InteractionQueueService.InteractionType.Video);
+                }
+                return;
+            }
+
             // Check if another fullscreen interaction is active (bubble count, lock card)
             // If so, queue this video for later
             // Note: If CurrentInteraction is already Video, the queue dequeued us — proceed normally

--- a/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
+++ b/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs
@@ -187,6 +187,10 @@ namespace ConditioningControlPanel.Services
         private const int MaxBlinkClosedMs = 1500;           // longer than this is a stare/squint, not a blink
         private const int BlinkCooldownMs = 500;             // gap required between consecutive blink fires
         private const int BlinkDiagLogIntervalMs = 3000;     // log EAR baseline + blink count every ~3s
+        // Deliberate "hold your eyes shut" gesture. Sits ABOVE MaxBlinkClosedMs on purpose:
+        // a closure long enough to fire OnEyesClosedLong can never also be reported as a
+        // blink, so the two gestures are mutually exclusive by construction.
+        private const int EyesClosedLongMs = 2000;
 
         // EAR is computed against the IRIS MODEL's 71-point eye contour, NOT
         // FaceMesh's eyelid landmarks. FaceMesh's landmarks barely move during
@@ -398,6 +402,17 @@ namespace ConditioningControlPanel.Services
         }
 
         public event Action? OnBlink;
+
+        /// <summary>
+        /// Fired once per closure when the eyes have been continuously closed for
+        /// <see cref="EyesClosedLongMs"/> (2s) — a deliberate "hold it shut" gesture
+        /// rather than a blink. Fires WHILE still closed (not on reopen), so the
+        /// gesture feels immediate. <see cref="OnBlink"/> can never fire for the same
+        /// closure: that path requires closedMs &lt;= MaxBlinkClosedMs (1500ms).
+        /// Marshalled to the UI dispatcher like every other event here.
+        /// </summary>
+        public event Action? OnEyesClosedLong;
+
         public event Action<System.Windows.Point>? OnLongStare;
         public event Action? OnMouthOpen;
         public event Action? OnTongueOut;
@@ -499,6 +514,7 @@ namespace ConditioningControlPanel.Services
         private double _earBaseline;                             // rolling 90-frame max of avg EAR
         private bool _eyesClosed;                                // hysteresis state for both eyes (single)
         private DateTime? _eyesClosedAt;                         // start of current closed window
+        private bool _eyesClosedLongFired;                       // OnEyesClosedLong already fired for THIS closure
         private double _minEarThisClosure;                       // tracks deepest closure during current closed window
         private double _windowMinEar = double.MaxValue;          // min EAR seen since last diag log (for tuning)
         private double _windowMaxEar = double.MinValue;          // max EAR seen since last diag log
@@ -1517,6 +1533,7 @@ namespace ConditioningControlPanel.Services
             _earBaseline = 0;
             _eyesClosed = false;
             _eyesClosedAt = null;
+            _eyesClosedLongFired = false;
             _minEarThisClosure = double.MaxValue;
             _windowMinEar = double.MaxValue;
             _windowMaxEar = double.MinValue;
@@ -1933,6 +1950,7 @@ namespace ConditioningControlPanel.Services
             _pitchSmoothBuffer.Clear();
             _eyesClosed = false;
             _eyesClosedAt = null;
+            _eyesClosedLongFired = false;
             _mouthOpen = false;
             _mouthOpenedAt = null;
             _marSmoothBuffer.Clear();   // drop stale MAR so the median doesn't blip on face re-acquire
@@ -2590,10 +2608,19 @@ namespace ConditioningControlPanel.Services
             {
                 _eyesClosedAt = now;
                 _minEarThisClosure = avgEar;       // start tracking minimum
+                _eyesClosedLongFired = false;
             }
             else if (nowClosed)
             {
                 if (avgEar < _minEarThisClosure) _minEarThisClosure = avgEar;
+                // Still closed: the 2s "hold" gesture fires here, once per closure,
+                // without waiting for the eyes to reopen.
+                if (!_eyesClosedLongFired && _eyesClosedAt.HasValue
+                    && (now - _eyesClosedAt.Value).TotalMilliseconds >= EyesClosedLongMs)
+                {
+                    _eyesClosedLongFired = true;
+                    Dispatch(() => OnEyesClosedLong?.Invoke());
+                }
             }
             else if (!nowClosed && _eyesClosed && _eyesClosedAt.HasValue)
             {
@@ -2617,11 +2644,13 @@ namespace ConditioningControlPanel.Services
                     closedMs, _earBaseline, _minEarThisClosure, _minEarThisClosure / _earBaseline);
                 _eyesClosedAt = null;
                 _minEarThisClosure = double.MaxValue;
+                _eyesClosedLongFired = false;
             }
             else if (!nowClosed)
             {
                 _eyesClosedAt = null;
                 _minEarThisClosure = double.MaxValue;
+                _eyesClosedLongFired = false;
             }
 
             _eyesClosed = nowClosed;

--- a/ConditioningControlPanel/Views/Tabs/LabTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/LabTabView.xaml
@@ -156,6 +156,61 @@
 
                 <!-- HOW TO PLAY moved to the Rabbit Hole main menu (📖 HOW TO PLAY button → card tutorial overlay). -->
 
+                <!-- ===================== HERO: FOR YOU FEED ===================== -->
+                <!-- Literal English text on purpose: matches the DtRH hero card above (Lab hero
+                     cards are not localized). Premium is enforced in the click handler; the
+                     whole tab already sits behind LabSmokescreen. -->
+                <Border CornerRadius="16" BorderThickness="1" BorderBrush="{DynamicResource PanelAccentBrush}"
+                        Margin="9,0,9,18" ClipToBounds="True" MinHeight="110">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                            <GradientStop Color="#FF12142A" Offset="0"/>
+                            <GradientStop Color="#FF1A1230" Offset="0.55"/>
+                            <GradientStop Color="#FF301040" Offset="1"/>
+                        </LinearGradientBrush>
+                    </Border.Background>
+                    <Grid Margin="24,20,24,20">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- left: title + blurb -->
+                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                <TextBlock Text="📱 FOR YOU" Foreground="White" FontSize="24" FontWeight="Bold">
+                                    <TextBlock.Effect>
+                                        <DropShadowEffect Color="{DynamicResource FxGlowColor}" BlurRadius="22" ShadowDepth="0" Opacity="0.7"/>
+                                    </TextBlock.Effect>
+                                </TextBlock>
+                                <Border Background="{DynamicResource TransparentPink20Brush}" BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1"
+                                        CornerRadius="6" Padding="7,2" Margin="12,2,0,0" VerticalAlignment="Center">
+                                    <TextBlock Text="NEW" Foreground="{DynamicResource PinkBrush}" FontFamily="Consolas" FontWeight="Bold" FontSize="10"/>
+                                </Border>
+                            </StackPanel>
+                            <TextBlock Text="an endless feed cut from your own library. random 20-40 second slices, stacked and quilted into duos, trios and shifting mosaics. it learns what you linger on. keep scrolling."
+                                       Foreground="{DynamicResource TextMutedBrush}" FontSize="13" TextWrapping="Wrap" MaxWidth="520" HorizontalAlignment="Left"/>
+                        </StackPanel>
+
+                        <!-- right: launch -->
+                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="24,0,0,0">
+                            <Button x:Name="BtnStartFyp" Content="▶ START SCROLLING" Cursor="Hand" ToolTip="just one more."
+                                    Background="{DynamicResource PinkBrush}" Foreground="White" FontWeight="Bold" FontSize="16"
+                                    BorderThickness="0" Padding="30,14" HorizontalAlignment="Right"
+                                    Click="BtnStartFyp_Click">
+                                <Button.Effect>
+                                    <DropShadowEffect Color="{DynamicResource FxGlowColor}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                                </Button.Effect>
+                                <Button.Resources>
+                                    <Style TargetType="Border">
+                                        <Setter Property="CornerRadius" Value="14"/>
+                                    </Style>
+                                </Button.Resources>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
                 <!-- ===================== ZONE: MIND ===================== -->
                 <Grid Margin="2,4,2,8">
                     <Grid.ColumnDefinitions>

--- a/ConditioningControlPanel/Views/Tabs/LabTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/LabTabView.xaml.cs
@@ -67,6 +67,11 @@ namespace ConditioningControlPanel.Views.Tabs
             if (Window.GetWindow(this) is MainWindow mw)
                 mw.BtnStartChaos_Click(sender, e);
         }
+        private void BtnStartFyp_Click(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.BtnStartFyp_Click(sender, e);
+        }
         // BtnStartQuiz / BtnStartIntake / BtnTestPopQuiz moved to GradedIntakeTabView
         // when the Graded Intake graduated to its own Exclusives page.
         private void BtnStartBureau_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What

The mobile TikTok-style **For You** reel, ported to desktop as a WebView2 page (Lab card, premium-gated, `--fyp` dev arg), across three commits:

1. **b743be12** - the core port: Duo/Trio/Mosaic layouts, retention-weighted clip selection (1:1 mobile algorithm), per-tile swipe/history, morph timer, XP + attention checks, feature suppression while active.
2. **9297121b** - live-test batch: window opacity + click-through groundwork, chevron click fix, back-swipe on first item brings a fresh pick, webcam eye control (blink = swap tile, gazed tile when calibrated; eyes closed 2s = new page), audible-tile highlight ring + toggle.
3. **1d7479a4** - **ghost mode done right**: genuinely see-through, genuinely click-through.

## Ghost mode (the interesting part)

Toggling Ghost mode parks the real feed window off-screen (still rendering + playing audio; Chromium occlusion throttling disabled via browser flags) and covers its monitor with a live **DWM thumbnail mirror** - the OnTopReplica technique.

The translucency recipe was pixel-measured with an isolated probe because every intuitive approach fails:

- `SetLayeredWindowAttributes` on the WebView2 window itself: content goes solid black (DWM never sees Chromium's cross-process DirectComposition visuals).
- A DWM thumbnail at `DWM_TNP_OPACITY` blends against the destination window's **own surface**, not what is behind it.
- `LWA_ALPHA` on the mirror multiplies surface **and** thumbnail together - no alpha value works.
- The working combination: mirror surface painted RGB(1,1,1), keyed out with `LWA_COLORKEY` (thumbnail then blends straight against the desktop at exactly its TNP opacity), on a **WinForms** window - WPF's D3D surface never matches the colorkey.

Full findings are documented in `FypGhostOverlay`'s class comment.

UX around it: ghost opacity slider down to 1%; clickable corner buttons while ghosted (gear = un-ghost + open options, speaker = mute in place); gaze-calibration button in options; panic/Esc ladder (exit ghost -> close feed) with a double-tap grace.

## Testing

- Live play-tested end to end on this machine (windowed + ghost, opacity range, click-through onto apps behind, Esc ladder, corner buttons, calibration flow).
- DWM blending verified by pixel sampling in an isolated probe before wiring into the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)