### PR TITLE
fix(packs): play-test findings - full-install probe, picker wait, sandbox hook

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -149,11 +149,26 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// User data folder path in LocalAppData - persists across updates
+        /// User data folder path in LocalAppData - persists across updates.
+        /// CCP_USERDATA_DIR redirects the whole tree (settings, logs, content, mods) so test
+        /// harnesses can run against a sandbox instead of the real profile; same env-hook
+        /// pattern as the CCP_STRESS_* knobs.
         /// </summary>
-        public static string UserDataPath { get; } = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel");
+        public static string UserDataPath { get; } = ResolveUserDataPath();
+
+        private static string ResolveUserDataPath()
+        {
+            try
+            {
+                var overrideDir = Environment.GetEnvironmentVariable("CCP_USERDATA_DIR");
+                if (!string.IsNullOrWhiteSpace(overrideDir) && Path.IsPathRooted(overrideDir))
+                    return overrideDir;
+            }
+            catch { }
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "ConditioningControlPanel");
+        }
 
         /// <summary>
         /// User assets folder path - for user-added content that persists across updates

--- a/ConditioningControlPanel/Chaos/ChaosTunnelService.cs
+++ b/ConditioningControlPanel/Chaos/ChaosTunnelService.cs
@@ -215,9 +215,7 @@ internal static class ChaosTunnelService
         _initStarted = true;
         try
         {
-            var userDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel", "browser_data_chaos_tunnel");
+            var userDataFolder = Path.Combine(App.UserDataPath, "browser_data_chaos_tunnel");
             Directory.CreateDirectory(userDataFolder);
 
             // --disable-direct-composition-video-overlays: keep the WebGL swapchain composited

--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -473,9 +473,7 @@ internal sealed class ChaosWebViewHost : IDisposable
         _initStarted = true;
         try
         {
-            var userDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel", _opts.UserDataFolderName);
+            var userDataFolder = Path.Combine(App.UserDataPath, _opts.UserDataFolderName);
             Directory.CreateDirectory(userDataFolder);
 
             // --disable-direct-composition-video-overlays: keep the WebGL swapchain composited

--- a/ConditioningControlPanel/Localization/LocalizationManager.cs
+++ b/ConditioningControlPanel/Localization/LocalizationManager.cs
@@ -170,9 +170,7 @@ namespace ConditioningControlPanel.Localization
             // Fallback: try user data directory (for user-added translations)
             if (!File.Exists(filePath))
             {
-                var userDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "ConditioningControlPanel", "Languages", $"{languageCode}.json");
+                var userDir = Path.Combine(App.UserDataPath, "Languages", $"{languageCode}.json");
                 if (File.Exists(userDir))
                     filePath = userDir;
             }

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -505,8 +505,12 @@ namespace ConditioningControlPanel
 
                         // Same waiting idiom as the first-launch branch, plus IsStartupDialogShowing:
                         // What's New is modal and posts itself onto the dispatcher, so it can still be
-                        // pending when this runs.
-                        for (int i = 0; i < 60 && (App.IsUpdateDialogActive || IsStartupDialogShowing); i++)
+                        // pending when this runs. Every modular upgrader ARRIVES with a What's New to
+                        // read, so wait out minutes of reading, not seconds - at 30s a user still on
+                        // the patch notes silently lost the picker until the next launch (play-test
+                        // scenario C caught exactly that). Past 5 min we still defer to next launch,
+                        // which ModPickerShown=false keeps armed.
+                        for (int i = 0; i < 600 && (App.IsUpdateDialogActive || IsStartupDialogShowing); i++)
                         {
                             await Task.Delay(500);
                         }

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -455,8 +455,7 @@ namespace ConditioningControlPanel.Services
 
         // Crash recovery file for ducking state
         private static readonly string DuckingRecoveryFile = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel", "ducking_recovery.json");
+            App.UserDataPath, "ducking_recovery.json");
 
         #endregion
 

--- a/ConditioningControlPanel/Services/Auth/DiscordTokenStorage.cs
+++ b/ConditioningControlPanel/Services/Auth/DiscordTokenStorage.cs
@@ -18,8 +18,7 @@ namespace ConditioningControlPanel.Services
 
         public DiscordTokenStorage()
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            var storageDir = Path.Combine(appData, "ConditioningControlPanel");
+            var storageDir = App.UserDataPath;
 
             // Ensure directory exists
             if (!Directory.Exists(storageDir))

--- a/ConditioningControlPanel/Services/Auth/SecureApiKeyStore.cs
+++ b/ConditioningControlPanel/Services/Auth/SecureApiKeyStore.cs
@@ -13,8 +13,7 @@ namespace ConditioningControlPanel.Services
     {
         private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("ConditioningControlPanel_ApiKey_v1");
         private static readonly string StoragePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "api_key.dat");
 
         private static string? _cached;

--- a/ConditioningControlPanel/Services/Auth/SecureAuthTokenStore.cs
+++ b/ConditioningControlPanel/Services/Auth/SecureAuthTokenStore.cs
@@ -13,8 +13,7 @@ namespace ConditioningControlPanel.Services
     {
         private static readonly byte[] Entropy = Encoding.UTF8.GetBytes("ConditioningControlPanel_AuthToken_v1");
         private static readonly string StoragePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "auth_token.dat");
 
         private static string? _cached;

--- a/ConditioningControlPanel/Services/Auth/SecureTokenStorage.cs
+++ b/ConditioningControlPanel/Services/Auth/SecureTokenStorage.cs
@@ -30,8 +30,7 @@ namespace ConditioningControlPanel.Services
             _label = char.ToUpperInvariant(prefix[0]) + prefix.Substring(1); // "patreon" -> "Patreon"
             _entropy = Encoding.UTF8.GetBytes($"ConditioningControlPanel_{_label}_v1");
 
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            var storageDir = Path.Combine(appData, "ConditioningControlPanel");
+            var storageDir = App.UserDataPath;
 
             // Ensure directory exists
             if (!Directory.Exists(storageDir))

--- a/ConditioningControlPanel/Services/Browser/BrowserService.cs
+++ b/ConditioningControlPanel/Services/Browser/BrowserService.cs
@@ -122,8 +122,7 @@ namespace ConditioningControlPanel.Services
         {
             // Store browser data in AppData (not install folder) to avoid lock issues during updates/uninstall
             _userDataFolder = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel",
+                App.UserDataPath,
                 "browser_data"
             );
             Directory.CreateDirectory(_userDataFolder);

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -224,14 +224,35 @@ namespace ConditioningControlPanel.Services
             return null;
         }
 
+        /// <summary>
+        /// A genuine full/legacy install bundles the whole baseline voice set (118 files this
+        /// cycle), so demand a count no hand-curated collection plausibly reaches. "Any file at
+        /// all" is NOT a full install: the modular sweep deletes bundled audio by exact name and
+        /// deliberately leaves USER-dropped files behind, so one custom mp3 (or a stray .txt)
+        /// must not flip an upgrader to FullInstall and silently disable pack downloads forever
+        /// (play-test scenario G caught exactly that).
+        /// </summary>
+        private const int FullInstallAudioThreshold = 25;
+
         private static bool DetectFullInstall()
         {
             try
             {
                 var probe = Path.Combine(AppContext.BaseDirectory, LegacyAudioProbe);
                 if (!Directory.Exists(probe)) return false;
-                // An empty leftover folder is not a full install — Inno leaves dirs behind.
-                return Directory.EnumerateFiles(probe, "*", SearchOption.AllDirectories).Any();
+                var audioCount = 0;
+                foreach (var f in Directory.EnumerateFiles(probe, "*", SearchOption.AllDirectories))
+                {
+                    var ext = Path.GetExtension(f);
+                    if (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase) ||
+                        ext.Equals(".wav", StringComparison.OrdinalIgnoreCase) ||
+                        ext.Equals(".ogg", StringComparison.OrdinalIgnoreCase) ||
+                        ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (++audioCount >= FullInstallAudioThreshold) return true;
+                    }
+                }
+                return false;
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Program/ProgramService.cs
+++ b/ConditioningControlPanel/Services/Program/ProgramService.cs
@@ -93,8 +93,7 @@ public class ProgramService : IDisposable
     public ProgramService()
     {
         _statePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "programs.json");
 
         State = LoadState();

--- a/ConditioningControlPanel/Services/Progression/IntakePunchCardService.cs
+++ b/ConditioningControlPanel/Services/Progression/IntakePunchCardService.cs
@@ -87,8 +87,7 @@ public class IntakePunchCardService : IDisposable
     public IntakePunchCardService(string? statePathOverride = null)
     {
         _statePath = statePathOverride ?? Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "intake_punchcard.json");
 
         State = LoadState();

--- a/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestDefinitionService.cs
@@ -86,9 +86,7 @@ public class QuestDefinitionService : IDisposable
         _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd($"ConditioningControlPanel/{UpdateService.AppVersion}");
 
         // Set up cache directories
-        var appDataPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel");
+        var appDataPath = App.UserDataPath;
         _cacheDir = appDataPath;
         _imageCacheDir = Path.Combine(appDataPath, "quest-images");
         _cacheFilePath = Path.Combine(_cacheDir, CacheFileName);

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -72,8 +72,7 @@ public class QuestService : IDisposable
     public QuestService()
     {
         _progressPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "quests.json");
 
         Progress = LoadProgress();

--- a/ConditioningControlPanel/Services/RoadmapService.cs
+++ b/ConditioningControlPanel/Services/RoadmapService.cs
@@ -47,13 +47,11 @@ public class RoadmapService : IDisposable
     public RoadmapService()
     {
         _progressPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "roadmap.json");
 
         _diaryFolderPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel",
+            App.UserDataPath,
             "roadmap_diary");
 
         Progress = LoadProgress();

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -260,9 +260,7 @@ public static class UiHangWatchdog
         // MiniDumpWithPrivateReadWriteMemory and wrote 1-2GB with ALL threads suspended,
         // freezing the app for 30s..minutes (or forever when the write itself wedged).
         // Both paths now write the COMPACT stream set only.
-        string dir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "ConditioningControlPanel", "logs");
+        string dir = Path.Combine(App.UserDataPath, "logs");
         string path = Path.Combine(dir, $"hang_{DateTime.Now:yyyyMMdd_HHmmss}.dmp");
         try
         {
@@ -364,9 +362,7 @@ public static class UiHangWatchdog
     {
         try
         {
-            string dir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel", "logs");
+            string dir = Path.Combine(App.UserDataPath, "logs");
             var dumps = new DirectoryInfo(dir).GetFiles("hang_*.dmp")
                 .OrderByDescending(f => f.LastWriteTimeUtc).Skip(2);
             foreach (var f in dumps)

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -226,8 +226,7 @@ Season: Airhead August";
 
         private static string GetSkipFilePath()
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            return Path.Combine(appData, "ConditioningControlPanel", "update_skip.txt");
+            return Path.Combine(App.UserDataPath, "update_skip.txt");
         }
 
         private static string? GetSkippedUpdateVersion()
@@ -534,8 +533,7 @@ Season: Airhead August";
                 : (Process.GetCurrentProcess().MainModule?.FileName ?? "");
 
             var logPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel", "logs", "update-helper.log");
+                App.UserDataPath, "logs", "update-helper.log");
 
             var helperPath = WriteUpdateHelperScript(installerPath, installPath, pid, appExe, logPath);
 
@@ -657,8 +655,7 @@ Season: Airhead August";
 
                 // Also clean up Velopack install location if different
                 var velopackPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "ConditioningControlPanel",
+                    App.UserDataPath,
                     "current",
                     "browser_data");
 

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -452,8 +452,7 @@ namespace ConditioningControlPanel.Views.Deeper
                 // hostile page (or HT phishing redirect) read the user's
                 // signed-in HT cookies via document.cookie / authenticated fetch.
                 var userDataFolder = System.IO.Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "ConditioningControlPanel",
+                    App.UserDataPath,
                     "browser_data_deeper_editor");
                 System.IO.Directory.CreateDirectory(userDataFolder);
 

--- a/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/EnhancementPlayerWindow.xaml.cs
@@ -1189,8 +1189,7 @@ namespace ConditioningControlPanel.Views.Deeper
             // let a hostile page read the user's signed-in HT cookies via
             // document.cookie / authenticated fetch.
             var userDataFolder = System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ConditioningControlPanel",
+                App.UserDataPath,
                 "browser_data_deeper_player");
             System.IO.Directory.CreateDirectory(userDataFolder);
             // --autoplay-policy=no-user-gesture-required: Chromium otherwise


### PR DESCRIPTION
Follow-up to #103, from running the plan-8 play-test matrix against a sandboxed data dir.

## Fixes
1. **DetectFullInstall**: any file under `flashes_audio` counted as a full install, so one user-dropped custom mp3 disabled pack downloads forever for exactly the users the exact-name `[InstallDelete]` list protects. Now requires 25+ audio-extension files (a genuine full install bundles 118).
2. **Upgrader picker wait**: gave up after 30s of `IsStartupDialogShowing`, but every modular upgrader lands on a What's New dialog - reading it for >30s silently deferred the picker to the next launch. Now waits up to 5 minutes.
3. **`CCP_USERDATA_DIR` sandbox hook** + routed all 17 hand-built `LocalApplicationData` paths through `App.UserDataPath` (token stores, browser_data dirs, quests/programs/roadmap state, hang dumps, update helper). Without this a sandboxed test run still read the real DPAPI tokens and wrote real state.

## Play-test verdicts (all CONFIRMED)
- Fresh install skip-all: picker shows once, baseline auto-fetch, no crash
- Picker download: audio-base + mod-bambi, 1,469 files, stamps, self-closing picker
- Upgrader: picker pre-ticks active mod after What's New (verified past the old 30s window); baseline + active-mod pack converge even on skip
- Kill mid-download: ranged resume from byte 179,109,888, sha256 verified
- Corrupt full-size partial: sha256 mismatch logged, clean refetch, ccpmod extract + live adoption
- Offline first run: graceful, retries next launch; online relaunch recovers
- Staged 6.6.3 upgrade sim: 8,429/8,429 swept, user files + all manifests survive, app boots modular

🤖 Generated with [Claude Code](https://claude.com/claude-code)