### PR TITLE
Hybrid browser video engine: out-of-process WebView2 playback for mandatory videos + BubbleCount

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1428,6 +1428,20 @@ namespace ConditioningControlPanel
             Video = new VideoService();
             Video.PreloadLibVLC(); // Pre-load LibVLC in background for faster first video
 
+            // Same idea for the hybrid browser engine: building the shared WebView2 environment can
+            // take seconds on a cold start, and a first video that pays for it spends that time
+            // against its own first-frame watchdog. Warm it here instead. Only when the feature is
+            // on - a user who never routes a video to the browser must not spawn a process for it.
+            try
+            {
+                if (Settings?.Current?.BrowserVideoEngineEnabled == true)
+                    Services.Video.Browser.BrowserVideoEngine.WarmUp();
+            }
+            catch (Exception ex)
+            {
+                Logger?.Debug("BrowserVideo warm-up skipped: {Error}", ex.Message);
+            }
+
             // Session media log - must be after Flash and Video so it can subscribe to their events.
             SessionLog = new SessionLogService();
 

--- a/ConditioningControlPanel/Features/SystemFeatureControl.xaml
+++ b/ConditioningControlPanel/Features/SystemFeatureControl.xaml
@@ -76,6 +76,21 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock Text="{loc:Str setting_browser_video_engine}" Foreground="White" FontSize="13" FontWeight="SemiBold"/>
+                        <TextBlock Text="{loc:Str tooltip_browser_video_engine}"
+                                   Foreground="{DynamicResource TextMutedBrush}" FontSize="11"
+                                   TextWrapping="Wrap" Margin="0,2,0,0"/>
+                    </StackPanel>
+                    <CheckBox Grid.Column="1" x:Name="ChkBrowserVideoEngine"
+                              Style="{StaticResource ToggleStyle}" VerticalAlignment="Center"
+                              Checked="ChkBrowserVideoEngine_Changed" Unchecked="ChkBrowserVideoEngine_Changed"/>
+                </Grid>
+                <Grid Margin="0,4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
                         <TextBlock Text="{loc:Str setting_win_start}" Foreground="White" FontSize="13" FontWeight="SemiBold"/>
                         <TextBlock Text="{loc:Str tooltip_launch_automatically_when_windows_starts}"
                                    Foreground="{DynamicResource TextMutedBrush}" FontSize="11"

--- a/ConditioningControlPanel/Features/SystemFeatureControl.xaml.cs
+++ b/ConditioningControlPanel/Features/SystemFeatureControl.xaml.cs
@@ -47,6 +47,7 @@ namespace ConditioningControlPanel.Features
                 ChkFillAllMon.IsChecked = s.FillAllMonitorsWithVideo;
                 ChkVideoGpuDecode.IsChecked = s.VideoForceHardwareDecoding;
                 ChkVideoBlurBg.IsChecked = s.VideoBlurredBackgroundEnabled;
+                ChkBrowserVideoEngine.IsChecked = s.BrowserVideoEngineEnabled;
                 ChkWinStart.IsChecked = Services.StartupManager.IsRegistered();
                 ChkVidLaunch.IsChecked = s.ForceVideoOnLaunch;
                 ChkAutoRun.IsChecked = s.AutoStartEngine;
@@ -75,6 +76,7 @@ namespace ConditioningControlPanel.Features
                 e.PropertyName == nameof(Models.AppSettings.FillAllMonitorsWithVideo) ||
                 e.PropertyName == nameof(Models.AppSettings.VideoForceHardwareDecoding) ||
                 e.PropertyName == nameof(Models.AppSettings.VideoBlurredBackgroundEnabled) ||
+                e.PropertyName == nameof(Models.AppSettings.BrowserVideoEngineEnabled) ||
                 e.PropertyName == nameof(Models.AppSettings.ForceVideoOnLaunch) ||
                 e.PropertyName == nameof(Models.AppSettings.AutoStartEngine) ||
                 e.PropertyName == nameof(Models.AppSettings.StartMinimized) ||
@@ -126,6 +128,16 @@ namespace ConditioningControlPanel.Features
             s.VideoBlurredBackgroundEnabled = ChkVideoBlurBg.IsChecked ?? true;
             App.Settings?.Save();
             App.Logger?.Information("Blurred video background set to {Enabled} (System popup)", s.VideoBlurredBackgroundEnabled);
+        }
+
+        private void ChkBrowserVideoEngine_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            s.BrowserVideoEngineEnabled = ChkBrowserVideoEngine.IsChecked ?? false;
+            App.Settings?.Save();
+            App.Logger?.Information("Browser video engine set to {Enabled} (System popup)", s.BrowserVideoEngineEnabled);
         }
 
         private void ChkVidLaunch_Changed(object sender, RoutedEventArgs e)

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "Dateien-Ordner öffnen (Bilder, Videos, Sounds)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "Inhalte auf allen verbundenen Monitoren anzeigen (2, 3 oder mehr)",
   "setting_multi_mon": "Multi Mon",
+  "setting_browser_video_engine": "Browser-Video-Engine (Beta)",
+  "tooltip_browser_video_engine": "Pflicht-Videos über den integrierten Browser statt über den klassischen Player abspielen - deutlich stabiler. Dateien, die der Browser nicht dekodieren kann, wechseln automatisch zurück zum klassischen Player. Erfordert die WebView2-Runtime (auf Windows 11 und auf Windows 10 mit Edge bereits vorinstalliert).",
   "tooltip_launch_automatically_when_windows_starts": "Automatisch starten, wenn Windows startet",
   "setting_win_start": "Win Start",
   "tooltip_play_a_mandatory_video_when_app_opens": "Ein Pflicht-Video beim Öffnen der App abspielen",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -1063,6 +1063,8 @@
   "setting_multi_mon": "Multi Mon",
   "setting_fill_all_monitors_video": "Fill all monitors with video",
   "tooltip_fill_all_monitors_video": "On 3+ monitors, give every screen its own video (heavier). Off by default on 3+ monitors to avoid lag; 1–2 monitor setups always fill.",
+  "setting_browser_video_engine": "Browser video engine (beta)",
+  "tooltip_browser_video_engine": "Play mandatory videos through the built-in browser instead of the classic player - much better stability. Files the browser can't decode automatically fall back to the classic player. Requires the WebView2 runtime (preinstalled on Windows 11, and on Windows 10 with Edge).",
   "tooltip_launch_automatically_when_windows_starts": "Launch automatically when Windows starts",
   "setting_win_start": "Win Start",
   "tooltip_play_a_mandatory_video_when_app_opens": "Play a mandatory video when app opens",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "Abrir carpeta de recursos (imágenes, videos, sonidos)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "Mostrar contenido en todos los monitores conectados (2, 3 o más)",
   "setting_multi_mon": "Multi Mon",
+  "setting_browser_video_engine": "Motor de video del navegador (beta)",
+  "tooltip_browser_video_engine": "Reproducir los videos obligatorios con el navegador integrado en lugar del reproductor clásico: mucha más estabilidad. Los archivos que el navegador no puede decodificar vuelven automáticamente al reproductor clásico. Requiere el runtime de WebView2 (ya instalado en Windows 11 y en Windows 10 con Edge).",
   "tooltip_launch_automatically_when_windows_starts": "Iniciar automáticamente cuando Windows arranca",
   "setting_win_start": "Inicio Win",
   "tooltip_play_a_mandatory_video_when_app_opens": "Reproducir un video obligatorio al abrir la app",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "Ouvrir le dossier de ressources (images, vidéos, sons)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "Afficher le contenu sur tous les moniteurs connectés (2, 3, ou plus)",
   "setting_multi_mon": "Multi Mon",
+  "setting_browser_video_engine": "Moteur vidéo du navigateur (bêta)",
+  "tooltip_browser_video_engine": "Lire les vidéos obligatoires via le navigateur intégré plutôt qu'avec le lecteur classique : bien plus stable. Les fichiers que le navigateur ne peut pas décoder repassent automatiquement au lecteur classique. Nécessite le runtime WebView2 (déjà installé sur Windows 11 et sur Windows 10 avec Edge).",
   "tooltip_launch_automatically_when_windows_starts": "Lancer automatiquement au démarrage de Windows",
   "setting_win_start": "Dém. Win",
   "tooltip_play_a_mandatory_video_when_app_opens": "Lancer une vidéo obligatoire à l'ouverture de l'appli",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "アセットフォルダを開く（画像、動画、音声）",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "接続されたすべてのモニターにコンテンツを表示（2台、3台以上）",
   "setting_multi_mon": "マルチモニター",
+  "setting_browser_video_engine": "ブラウザ動画エンジン（ベータ）",
+  "tooltip_browser_video_engine": "強制動画を従来のプレーヤーではなく内蔵ブラウザで再生します。安定性が大きく向上します。ブラウザがデコードできないファイルは自動的に従来のプレーヤーに切り替わります。WebView2ランタイムが必要です（Windows 11、およびEdgeが入ったWindows 10にはプリインストール済み）。",
   "tooltip_launch_automatically_when_windows_starts": "Windows起動時に自動で起動",
   "setting_win_start": "自動起動",
   "tooltip_play_a_mandatory_video_when_app_opens": "アプリ起動時に強制動画を再生",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "에셋 폴더 열기 (이미지, 영상, 사운드)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "연결된 모든 모니터에 콘텐츠 표시 (2개, 3개 이상)",
   "setting_multi_mon": "멀티 모니터",
+  "setting_browser_video_engine": "브라우저 비디오 엔진 (베타)",
+  "tooltip_browser_video_engine": "필수 영상을 기존 플레이어 대신 내장 브라우저로 재생합니다. 안정성이 훨씬 좋아집니다. 브라우저가 디코딩할 수 없는 파일은 자동으로 기존 플레이어로 전환됩니다. WebView2 런타임이 필요합니다 (Windows 11, 그리고 Edge가 설치된 Windows 10에는 기본 설치되어 있습니다).",
   "tooltip_launch_automatically_when_windows_starts": "Windows 시작 시 자동 실행",
   "setting_win_start": "시작 시 실행",
   "tooltip_play_a_mandatory_video_when_app_opens": "앱 실행 시 필수 영상 재생",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "Abrir pasta de recursos (imagens, vídeos, sons)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "Exibir conteúdo em todos os monitores conectados (2, 3 ou mais)",
   "setting_multi_mon": "Multi Mon",
+  "setting_browser_video_engine": "Motor de vídeo do navegador (beta)",
+  "tooltip_browser_video_engine": "Reproduzir os vídeos obrigatórios pelo navegador integrado em vez do player clássico: bem mais estável. Arquivos que o navegador não consegue decodificar voltam automaticamente para o player clássico. Requer o runtime do WebView2 (já instalado no Windows 11 e no Windows 10 com o Edge).",
   "tooltip_launch_automatically_when_windows_starts": "Iniciar automaticamente quando o Windows iniciar",
   "setting_win_start": "Início Win",
   "tooltip_play_a_mandatory_video_when_app_opens": "Reproduzir um vídeo obrigatório quando o app abrir",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -291,6 +291,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "Открыть папку ассетов (изображения, видео, звуки)",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "Использовать все мониторы для показа контента (два, три и более).",
   "setting_multi_mon": "Мульти мон.",
+  "setting_browser_video_engine": "Браузерный видеодвижок (бета)",
+  "tooltip_browser_video_engine": "Воспроизводить обязательные видео через встроенный браузер вместо классического плеера - гораздо стабильнее. Файлы, которые браузер не может декодировать, автоматически переключаются на классический плеер. Требуется среда выполнения WebView2 (уже установлена в Windows 11 и в Windows 10 с Edge).",
   "tooltip_launch_automatically_when_windows_starts": "Запускать автоматически при старте Windows",
   "setting_win_start": "Автозапуск",
   "tooltip_play_a_mandatory_video_when_app_opens": "Воспроизвести обязательное видео при открытии приложения",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -882,6 +882,8 @@
   "tooltip_open_assets_folder_images_videos_sounds": "打开资源文件夹（图片、视频、声音）",
   "tooltip_show_content_on_all_connected_monitors_2_3_or": "在所有已连接的显示器上显示内容（2个、3个或更多）",
   "setting_multi_mon": "多显示器",
+  "setting_browser_video_engine": "浏览器视频引擎（测试版）",
+  "tooltip_browser_video_engine": "使用内置浏览器代替传统播放器播放强制视频，稳定性大幅提升。浏览器无法解码的文件会自动回退到传统播放器。需要 WebView2 运行时（Windows 11 以及装有 Edge 的 Windows 10 已预装）。",
   "tooltip_launch_automatically_when_windows_starts": "Windows 启动时自动运行",
   "setting_win_start": "开机启动",
   "tooltip_play_a_mandatory_video_when_app_opens": "应用打开时播放强制视频",

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -1748,6 +1748,21 @@ namespace ConditioningControlPanel.Models
             set { _videoBlurredBackgroundEnabled = value; OnPropertyChanged(); }
         }
 
+        private bool _browserVideoEngineEnabled;
+        /// <summary>
+        /// BETA opt-in: play mandatory videos in out-of-process WebView2 windows (the player page at
+        /// Resources/web/player) instead of in-process LibVLC. LibVLC stays the automatic fallback
+        /// for anything the browser cannot decode, so turning this on never removes a playback path —
+        /// it only changes which one is tried first. See docs/BROWSER_VIDEO_ENGINE_PLAN.md.
+        /// Default OFF.
+        /// </summary>
+        [JsonProperty]
+        public bool BrowserVideoEngineEnabled
+        {
+            get => _browserVideoEngineEnabled;
+            set { _browserVideoEngineEnabled = value; OnPropertyChanged(); }
+        }
+
         private bool _restrictGazeContentToCalibratedScreen = true;
         /// <summary>
         /// When enabled (and a webcam calibration exists), all gaze-reactive

--- a/ConditioningControlPanel/Resources/web/player/index.html
+++ b/ConditioningControlPanel/Resources/web/player/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Player</title>
+  <link rel="stylesheet" href="player.css">
+</head>
+<body>
+  <!-- Mandatory-video surface for the hybrid Browser Video Engine.
+       The host window is already OS-level fullscreen borderless, so this page
+       NEVER calls requestFullscreen (plan trap #6) and draws no chrome at all.
+
+       #bg only decodes while blurBackground is on (body.has-bg); the rest of the
+       time its src is torn down so we are not paying for two decoders. -->
+  <div id="stage">
+    <video id="bg" muted playsinline preload="auto" disablepictureinpicture></video>
+    <video id="fg" playsinline preload="auto" disablepictureinpicture></video>
+  </div>
+  <script src="player.js"></script>
+</body>
+</html>

--- a/ConditioningControlPanel/Resources/web/player/player.css
+++ b/ConditioningControlPanel/Resources/web/player/player.css
@@ -1,4 +1,4 @@
-/* Mandatory-video player surface — pure black, no chrome, no cursor.
+/* Mandatory-video player surface — pure black, no chrome.
    Nothing here may introduce a scrollbar or a hit-testable control: the page is
    a passive surface and every interaction is reported to the host instead. */
 
@@ -13,8 +13,13 @@ html, body {
   font-family: "Segoe UI", system-ui, sans-serif;
   user-select: none;
   -webkit-user-select: none;
-  /* The video window is a "watch this" surface — a floating arrow over it is
-     both a distraction and a hint that there is something to click. */
+}
+
+/* Opt-IN only (load message: hideCursor). The mandatory-video windows do not hide
+   the pointer — neither does the LibVLC path they must be indistinguishable from —
+   and BubbleCount is mouse-driven, so an invisible pointer there is unplayable. */
+body.hide-cursor,
+body.hide-cursor * {
   cursor: none;
 }
 

--- a/ConditioningControlPanel/Resources/web/player/player.css
+++ b/ConditioningControlPanel/Resources/web/player/player.css
@@ -1,0 +1,56 @@
+/* Mandatory-video player surface — pure black, no chrome, no cursor.
+   Nothing here may introduce a scrollbar or a hit-testable control: the page is
+   a passive surface and every interaction is reported to the host instead. */
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html, body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+  color: #fff;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  user-select: none;
+  -webkit-user-select: none;
+  /* The video window is a "watch this" surface — a floating arrow over it is
+     both a distraction and a hint that there is something to click. */
+  cursor: none;
+}
+
+#stage {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  overflow: hidden;
+}
+
+#bg, #fg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  /* Pointer events land on the document (see the window-level pointerdown in
+     player.js) rather than on the media element's own default handling. */
+  pointer-events: none;
+  -webkit-user-drag: none;
+}
+
+/* Foreground: never crop the actual content. */
+#fg {
+  object-fit: contain;
+  z-index: 1;
+}
+
+/* Blurred fill behind a letterboxed clip. scale(1.1) hides the transparent
+   edge bleed that a 40px blur pulls in from outside the frame. */
+#bg {
+  object-fit: cover;
+  filter: blur(40px) brightness(0.7);
+  transform: scale(1.1);
+  z-index: 0;
+  display: none;
+}
+
+body.has-bg #bg { display: block; }

--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -143,6 +143,11 @@
     if (typeof d.volume === 'number') volume = clamp01(d.volume);
     if (typeof d.muted === 'boolean') muted = d.muted;
 
+    // Opt-in, default off: the host decides, because the pointer has to stay
+    // visible wherever the surface is mouse-driven (BubbleCount) or wherever the
+    // LibVLC path it replaces would have shown one (mandatory video).
+    document.body.classList.toggle('hide-cursor', !!d.hideCursor);
+
     const now = performance.now();
     cur = {
       url: url,
@@ -273,19 +278,24 @@
 
   // ---------- foreground media events ----------
 
+  // Every listener below also stands down once the load has errored: the host is
+  // already tearing the session down or replaying the file through LibVLC, and a
+  // late meta/time post would land on a run that no longer owns them (it polluted
+  // _lastWatchPositionMs during a fallback).
+
   fg.addEventListener('loadedmetadata', () => {
-    if (!cur) return;
+    if (!cur || cur.errored) return;
     applyStart();
     postMeta();
   });
 
   fg.addEventListener('durationchange', () => {
-    if (!cur) return;
+    if (!cur || cur.errored) return;
     postMeta();
   });
 
   fg.addEventListener('canplay', () => {
-    if (!cur) return;
+    if (!cur || cur.errored) return;
     applyStart(); // loadedmetadata may have been too early to seek
   });
 
@@ -298,12 +308,12 @@
   });
 
   fg.addEventListener('timeupdate', () => {
-    if (!cur || cur.ended || cur.hostPaused) return;
+    if (!cur || cur.errored || cur.ended || cur.hostPaused) return;
     postTime(false);
   });
 
   fg.addEventListener('seeked', () => {
-    if (!cur) return;
+    if (!cur || cur.errored) return;
     cur.lastProgressAt = performance.now();
     postTime(true);
   });
@@ -312,6 +322,11 @@
     if (!cur || cur.ended || cur.errored) return;
     cur.ended = true;
     postTime(true);
+    // Nothing is supposed to move after the end, and the host keeps the surface
+    // alive through its own result/teardown flow (BubbleCount's result screen runs
+    // for as long as the user takes) — so stop the 10 Hz ticker rather than let it
+    // spin for the whole of it.
+    stopTicker();
     try { bg.pause(); } catch (e) { /* ignore */ }
     post({ type: 'ended' });
   });
@@ -396,6 +411,7 @@
     try { fg.currentTime = sec; } catch (e) { log('seek rejected: ' + e); return; }
     if (cur.blur) { try { bg.currentTime = sec; } catch (e) { /* backdrop only */ } }
     cur.ended = false; // seeking back out of the end re-arms normal reporting
+    if (ticker == null) startTicker(); // ...including the ticker the end stopped
     cur.lastProgressAt = performance.now();
     // Seeking out of a finished clip leaves the element paused; without this the
     // stall watchdog would then "catch" a video nobody asked to stop.

--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -1,0 +1,513 @@
+// Mandatory-video player page for the hybrid Browser Video Engine (plan §3).
+//
+// The page is deliberately dumb: C# stays the director (scheduling, XP, safety
+// timers, attention checks) and this file is only a remote-controlled <video>
+// that reports what the element does. It queues nothing — it posts {type:'ready'}
+// once and the host holds its outbound messages until then.
+//
+// Decoder discipline is lifted from Resources/web/fyp/surfaces.js (do not import
+// it — the player is standalone):
+//   - teardown is pause() -> removeAttribute('src') -> load(), so Chromium frees
+//     the decoder now instead of at GC time, and it runs before EVERY new load,
+//   - an unrequested pause is an interruption, not a user action,
+//   - a media error never throws; it is reported and the session ends.
+
+(function () {
+  'use strict';
+
+  // ---------- tunables ----------
+
+  const TICK_MS = 100;          // time posts (~10 Hz) + watchdog sampling
+  const STALL_MS = 10000;       // live but no forward progress this long => error
+  const NO_PLAYING_MS = 10000;  // never reached 'playing' this long => error
+  const BG_DRIFT_S = 2;         // blur backdrop resync threshold
+  const BG_RESYNC_GAP_MS = 4000;
+  const BG_PLAY_RETRIES = 3;    // then give up on the backdrop (never on the clip)
+
+  // Error codes 1-4 are MediaError.code verbatim (a real decode/network failure
+  // => the file belongs in BrowserUnsafeVideoCache). 100+ are ours; only 100/101
+  // mean "this file misbehaved", 102/103 are session-level.
+  const ERR_STALLED = 100;
+  const ERR_NO_PLAYING = 101;
+  const ERR_PAUSE_LOOP = 102;
+  const ERR_BAD_LOAD = 103;
+
+  const MEDIA_ERR_NAME = {
+    1: 'aborted',
+    2: 'network',
+    3: 'decode',
+    4: 'src-not-supported',
+  };
+
+  // ---------- bridge ----------
+
+  const bridge = window.chrome && window.chrome.webview ? window.chrome.webview : null;
+
+  function post(msg) {
+    try { if (bridge) bridge.postMessage(msg); } catch (e) { /* host gone */ }
+  }
+
+  function log(msg) {
+    post({ type: 'log', msg: String(msg) });
+  }
+
+  // ---------- elements ----------
+
+  const bg = document.getElementById('bg');
+  const fg = document.getElementById('fg');
+
+  // Belt-and-braces alongside the HTML attributes: the element is born muted and
+  // silent, and the host's volume only lands once a load says so.
+  fg.muted = true;
+  fg.volume = 0;
+  bg.muted = true;
+  bg.volume = 0;
+
+  // ---------- state ----------
+
+  // Volume survives between loads so a setVolume that arrives with no session
+  // (or a load that omits the field) still means something.
+  let volume = 1;
+  let muted = false;
+
+  // The live load, or null. Every media listener no-ops when this is null, which
+  // is what makes teardown's own pause()/load() churn invisible.
+  let cur = null;
+  let ticker = null;
+  let lastTimeMs = -1;
+  let lastTimePostAt = 0;
+
+  const clamp01 = (n) => (Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 1);
+
+  function applyVolume() {
+    try {
+      fg.volume = clamp01(volume);
+      fg.muted = !!muted;
+    } catch (e) { /* out-of-range guard already applied */ }
+    bg.muted = true; // the backdrop is NEVER audible, whatever the session says
+    bg.volume = 0;
+  }
+
+  function playEl(el, tag) {
+    const p = el.play();
+    if (p && typeof p.catch === 'function') {
+      p.catch((err) => {
+        // --autoplay-policy=no-user-gesture-required makes this legal, so a
+        // rejection here is a real problem — but not a fatal one on its own: the
+        // no-playing watchdog is the thing that decides.
+        log(tag + ' play() rejected: ' + (err && err.message ? err.message : err));
+      });
+    }
+  }
+
+  // ---------- teardown ----------
+
+  /** Free both decoders NOW. Safe to call at any time, including with no session. */
+  function teardown() {
+    cur = null; // first, so the pause/error churn below reaches no handler
+    stopTicker();
+    lastTimeMs = -1;
+    lastTimePostAt = 0;
+    document.body.classList.remove('has-bg');
+    [fg, bg].forEach((el) => {
+      try { el.pause(); } catch (e) { /* ignore */ }
+      el.removeAttribute('src');
+      try { el.load(); } catch (e) { /* ignore */ }
+    });
+  }
+
+  // ---------- error reporting ----------
+
+  /** Report once per load and stop the clip. C# owns what happens next. */
+  function fail(code, message) {
+    if (!cur || cur.errored) return;
+    cur.errored = true;
+    stopTicker();
+    try { fg.pause(); } catch (e) { /* ignore */ }
+    try { bg.pause(); } catch (e) { /* ignore */ }
+    post({ type: 'error', code: code, message: String(message) });
+  }
+
+  // ---------- load ----------
+
+  function startLoad(d) {
+    teardown();
+
+    const url = typeof d.url === 'string' ? d.url : '';
+    if (!url) {
+      // No session exists yet, so fail() would no-op — report directly.
+      post({ type: 'error', code: ERR_BAD_LOAD, message: 'load message carried no url' });
+      return;
+    }
+
+    if (typeof d.volume === 'number') volume = clamp01(d.volume);
+    if (typeof d.muted === 'boolean') muted = d.muted;
+
+    const now = performance.now();
+    cur = {
+      url: url,
+      blur: !!d.blurBackground,
+      startAtMs: Number.isFinite(d.startAtMs) && d.startAtMs > 0 ? d.startAtMs : 0,
+      startedAt: now,
+      lastProgressAt: now,
+      lastPos: -1,
+      playingSent: false,
+      ended: false,
+      errored: false,
+      hostPaused: false,
+      unrequestedPauses: 0,
+      startApplied: false,
+      bgPlayFails: 0,
+      bgResyncAt: 0,
+      lastDurationMs: -1,
+    };
+
+    document.body.classList.toggle('has-bg', cur.blur);
+    applyVolume();
+
+    // Backdrop first so it is never the thing that delays the real clip.
+    if (cur.blur) {
+      bg.src = url;
+      playEl(bg, 'bg');
+    }
+    fg.src = url;
+    playEl(fg, 'fg');
+
+    startTicker();
+  }
+
+  /** startAtMs, applied as soon as the element will accept a seek. */
+  function applyStart() {
+    if (!cur || cur.startApplied || cur.startAtMs <= 0) return;
+    const sec = cur.startAtMs / 1000;
+    const d = fg.duration;
+    if (Number.isFinite(d) && d > 0 && sec >= d) { cur.startApplied = true; return; }
+    try {
+      fg.currentTime = sec;
+      if (cur.blur) { try { bg.currentTime = sec; } catch (e) { /* backdrop only */ } }
+      cur.startApplied = true;
+    } catch (e) {
+      // Not seekable yet — 'canplay' retries.
+    }
+  }
+
+  // ---------- outbound: meta / time ----------
+
+  function postMeta() {
+    if (!cur) return;
+    const d = fg.duration;
+    // Some webm/fragmented mp4 report Infinity at loadedmetadata and settle on a
+    // real number at durationchange, so meta can be posted more than once per
+    // load — the last one wins. durationMs is 0 when the duration is unknowable.
+    const durationMs = Number.isFinite(d) && d > 0 ? Math.round(d * 1000) : 0;
+    if (durationMs === cur.lastDurationMs) return;
+    cur.lastDurationMs = durationMs;
+    post({
+      type: 'meta',
+      durationMs: durationMs,
+      width: fg.videoWidth || 0,
+      height: fg.videoHeight || 0,
+    });
+  }
+
+  function postTime(force) {
+    if (!cur) return;
+    const now = performance.now();
+    if (!force && now - lastTimePostAt < TICK_MS - 10) return;
+    const ms = Math.round((fg.currentTime || 0) * 1000);
+    if (!force && ms === lastTimeMs) return;
+    lastTimeMs = ms;
+    lastTimePostAt = now;
+    post({ type: 'time', ms: ms });
+  }
+
+  // ---------- ticker: 10 Hz time + stall watchdogs + backdrop resync ----------
+
+  function startTicker() {
+    stopTicker();
+    ticker = setInterval(tick, TICK_MS);
+  }
+
+  function stopTicker() {
+    if (ticker != null) { clearInterval(ticker); ticker = null; }
+  }
+
+  function tick() {
+    if (!cur || cur.errored) return;
+
+    const now = performance.now();
+    const pos = fg.currentTime || 0;
+    if (pos !== cur.lastPos) {
+      cur.lastPos = pos;
+      cur.lastProgressAt = now;
+    }
+
+    if (!cur.ended && !cur.hostPaused) postTime(false);
+
+    // Watchdogs are suspended while the host holds a grace pause, and after a
+    // natural end (nothing is supposed to move then).
+    if (cur.ended || cur.hostPaused) return;
+
+    if (!cur.playingSent) {
+      if (now - cur.startedAt > NO_PLAYING_MS) {
+        fail(ERR_NO_PLAYING, 'no playing event within ' + NO_PLAYING_MS + 'ms of load');
+      }
+      return;
+    }
+
+    if (now - cur.lastProgressAt > STALL_MS) {
+      fail(ERR_STALLED, 'playback made no progress for ' + STALL_MS + 'ms');
+      return;
+    }
+
+    // Two elements decoding the same file drift apart; the backdrop is blurred
+    // so small drift is invisible, but a couple of seconds means it is showing a
+    // different scene. Nudge it, rarely.
+    if (cur.blur && !bg.error && Number.isFinite(bg.duration)
+        && now - cur.bgResyncAt > BG_RESYNC_GAP_MS
+        && Math.abs((bg.currentTime || 0) - pos) > BG_DRIFT_S) {
+      cur.bgResyncAt = now;
+      try { bg.currentTime = pos; } catch (e) { /* backdrop only */ }
+    }
+  }
+
+  // ---------- foreground media events ----------
+
+  fg.addEventListener('loadedmetadata', () => {
+    if (!cur) return;
+    applyStart();
+    postMeta();
+  });
+
+  fg.addEventListener('durationchange', () => {
+    if (!cur) return;
+    postMeta();
+  });
+
+  fg.addEventListener('canplay', () => {
+    if (!cur) return;
+    applyStart(); // loadedmetadata may have been too early to seek
+  });
+
+  fg.addEventListener('playing', () => {
+    if (!cur || cur.errored) return;
+    cur.lastProgressAt = performance.now();
+    if (cur.playingSent) return;
+    cur.playingSent = true;
+    post({ type: 'playing' });
+  });
+
+  fg.addEventListener('timeupdate', () => {
+    if (!cur || cur.ended || cur.hostPaused) return;
+    postTime(false);
+  });
+
+  fg.addEventListener('seeked', () => {
+    if (!cur) return;
+    cur.lastProgressAt = performance.now();
+    postTime(true);
+  });
+
+  fg.addEventListener('ended', () => {
+    if (!cur || cur.ended || cur.errored) return;
+    cur.ended = true;
+    postTime(true);
+    try { bg.pause(); } catch (e) { /* ignore */ }
+    post({ type: 'ended' });
+  });
+
+  fg.addEventListener('error', () => {
+    if (!cur) return;
+    const err = fg.error;
+    const code = err && err.code ? err.code : 0;
+    const name = MEDIA_ERR_NAME[code] || 'unknown';
+    const detail = err && err.message ? ' - ' + err.message : '';
+    fail(code || ERR_BAD_LOAD, 'media error (' + name + ')' + detail);
+  });
+
+  // Anti-pause. There is no user-facing pause on a mandatory video, so a pause we
+  // did not ask for is an interruption: resume it once, and if it happens again
+  // in the same load report an error rather than fighting the browser forever.
+  fg.addEventListener('pause', () => {
+    if (!cur || cur.errored || cur.ended || cur.hostPaused) return;
+    if (fg.ended || fg.error) return; // 'ended'/'error' own those transitions
+    // A natural end fires 'pause' BEFORE 'ended' (spec order), so fg.ended is the
+    // primary guard; this is the belt for a browser that sets the flag late.
+    const dur = fg.duration;
+    if (Number.isFinite(dur) && dur > 0 && (fg.currentTime || 0) >= dur - 0.5) return;
+    cur.unrequestedPauses++;
+    if (cur.unrequestedPauses === 1) {
+      log('unrequested pause - resuming');
+      playEl(fg, 'fg');
+      if (cur.blur) playEl(bg, 'bg');
+      return;
+    }
+    fail(ERR_PAUSE_LOOP, 'playback paused ' + cur.unrequestedPauses + ' times without a request');
+  });
+
+  // ---------- backdrop media events (never fatal) ----------
+
+  bg.addEventListener('pause', () => {
+    if (!cur || !cur.blur || cur.errored || cur.ended || cur.hostPaused) return;
+    if (bg.ended || bg.error) return;
+    if (cur.bgPlayFails >= BG_PLAY_RETRIES) return;
+    cur.bgPlayFails++;
+    playEl(bg, 'bg');
+  });
+
+  bg.addEventListener('error', () => {
+    // A backdrop that will not decode is a cosmetic loss; the clip plays on black.
+    if (!cur || !cur.blur) return;
+    cur.blur = false;
+    document.body.classList.remove('has-bg');
+    bg.removeAttribute('src');
+    try { bg.load(); } catch (e) { /* ignore */ }
+    log('blur backdrop failed to decode - falling back to black');
+  });
+
+  // ---------- inbound protocol ----------
+
+  function doPause() {
+    if (!cur) return;
+    cur.hostPaused = true;
+    try { fg.pause(); } catch (e) { /* ignore */ }
+    try { bg.pause(); } catch (e) { /* ignore */ }
+    postTime(true);
+  }
+
+  function doResume() {
+    if (!cur || cur.errored || cur.ended) return;
+    cur.hostPaused = false;
+    // The watchdog clocks restart from here, or a 60s grace pause would look
+    // like a 60s stall the moment we resume.
+    cur.lastProgressAt = performance.now();
+    if (!cur.playingSent) cur.startedAt = performance.now();
+    playEl(fg, 'fg');
+    if (cur.blur) playEl(bg, 'bg');
+  }
+
+  function doSeek(ms) {
+    if (!cur || cur.errored) return;
+    const n = Number(ms);
+    if (!Number.isFinite(n)) return;
+    let sec = Math.max(0, n / 1000);
+    const d = fg.duration;
+    if (Number.isFinite(d) && d > 0) sec = Math.min(sec, Math.max(0, d - 0.05));
+    try { fg.currentTime = sec; } catch (e) { log('seek rejected: ' + e); return; }
+    if (cur.blur) { try { bg.currentTime = sec; } catch (e) { /* backdrop only */ } }
+    cur.ended = false; // seeking back out of the end re-arms normal reporting
+    cur.lastProgressAt = performance.now();
+    // Seeking out of a finished clip leaves the element paused; without this the
+    // stall watchdog would then "catch" a video nobody asked to stop.
+    if (!cur.hostPaused && fg.paused) {
+      playEl(fg, 'fg');
+      if (cur.blur) playEl(bg, 'bg');
+    }
+    postTime(true);
+  }
+
+  function onHostMessage(data) {
+    // Tolerate PostWebMessageAsString as well as PostWebMessageAsJson.
+    if (typeof data === 'string') {
+      try { data = JSON.parse(data); } catch (e) { return; }
+    }
+    if (!data || typeof data !== 'object') return;
+    switch (data.type) {
+      case 'load':
+        startLoad(data);
+        break;
+      case 'pause':
+        doPause();
+        break;
+      case 'resume':
+        doResume();
+        break;
+      case 'stop':
+        teardown();
+        break;
+      case 'setVolume':
+        if (typeof data.volume === 'number') volume = clamp01(data.volume);
+        if (typeof data.muted === 'boolean') muted = data.muted; // optional extra
+        applyVolume();
+        break;
+      case 'seek':
+        doSeek(data.ms);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // ---------- input ----------
+
+  // Any press anywhere: the host brings its attention-check / floating-text
+  // windows back to the front (window-level PreviewMouseDown is unreliable over
+  // a WebView2 child HWND, so this message is the only signal C# gets).
+  window.addEventListener('pointerdown', () => post({ type: 'click' }), true);
+
+  // The page is a surface, not a document.
+  window.addEventListener('contextmenu', (e) => e.preventDefault());
+  window.addEventListener('selectstart', (e) => e.preventDefault());
+  window.addEventListener('dragstart', (e) => e.preventDefault());
+
+  // Keys over a focused WebView2 go to Chromium, not to the WPF window, so the
+  // page must never let Chromium act on the ones strict mode cares about. C#
+  // decides policy from the {type:'key'} report; we just neutralise them here.
+  window.addEventListener('keydown', (e) => {
+    const k = e.key;
+    const system = e.altKey || e.metaKey;
+    const reload = k === 'F5' || (e.ctrlKey && (k === 'r' || k === 'R'));
+    if (k === 'Escape' || k === 'F4' || k === 'F11' || system || reload || e.ctrlKey) {
+      // Ctrl combos are swallowed wholesale: there is no text input on this page,
+      // and Ctrl+R/W/N/P would each kill or hijack the session. (C# should also
+      // set AreBrowserAcceleratorKeysEnabled = false; this is the second lock.)
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    if (e.repeat) return; // holding a key must not flood the bridge
+    post({
+      type: 'key',
+      key: k,
+      alt: !!e.altKey,
+      ctrl: !!e.ctrlKey,
+      shift: !!e.shiftKey,
+    });
+  }, true);
+
+  // ---------- containment ----------
+
+  window.addEventListener('error', (e) => {
+    // Reported as a log, NOT as a playback error: a script fault does not stop
+    // the element, and C#'s duration guillotine / fallback timer still ends the
+    // session. Turning it into 'error' would trigger a needless LibVLC replay of
+    // a video the user is currently watching.
+    log('page script error: ' + (e && e.message ? e.message : 'unknown'));
+  });
+
+  // Never call requestFullscreen (plan trap #6) — the host window is already
+  // OS-level fullscreen and document.exitFullscreen is unreliable in WebView2.
+
+  // ---------- debug hook (soak checks) ----------
+
+  Object.defineProperty(window, '__ccpPlayerDebug', {
+    value: {
+      get live() { return cur != null; },
+      get url() { return cur ? cur.url : null; },
+      get playing() { return !!(cur && cur.playingSent && !fg.paused); },
+      get positionMs() { return Math.round((fg.currentTime || 0) * 1000); },
+      get durationMs() { return Number.isFinite(fg.duration) ? Math.round(fg.duration * 1000) : 0; },
+      get blur() { return !!(cur && cur.blur); },
+      get unrequestedPauses() { return cur ? cur.unrequestedPauses : 0; },
+      get errored() { return !!(cur && cur.errored); },
+    },
+  });
+
+  // ---------- boot ----------
+
+  if (bridge) {
+    bridge.addEventListener('message', (e) => onHostMessage(e.data));
+    post({ type: 'ready' });
+  }
+  // Opened in a plain browser (dev): nothing to do — the page stays black until
+  // a host sends a load.
+})();

--- a/ConditioningControlPanel/Services/AudioService.cs
+++ b/ConditioningControlPanel/Services/AudioService.cs
@@ -950,7 +950,13 @@ namespace ConditioningControlPanel.Services
         private void ApplyDuckSweep(float amount, int strength)
         {
             var currentProcessId = Environment.ProcessId;
-            var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
+            // The setting is about BambiCloud's audio. The OR is about parity: while a browser video
+            // session is on screen the app's OWN video audio comes out of a WebView2 process, so
+            // ducking it would mean the mandatory video ducks itself. LibVLC audio is in-process and
+            // the sweep structurally cannot touch it (it skips our PID), so without this the two
+            // engines would sound different for the same clip.
+            var excludeWebView2 = (App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true)
+                                  || App.Video?.IsBrowserSessionActive == true;
             var webViewPids = excludeWebView2 ? RefreshWebView2Pids() : new HashSet<int>();
 
             int ducked = 0;
@@ -1415,7 +1421,10 @@ namespace ConditioningControlPanel.Services
             }
 
             var currentProcessId = Environment.ProcessId;
-            var excludeWebView2 = App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true;
+            // Same exclusion rule as ApplyDuckSweep - a browser video session that comes up DURING
+            // an open duck window must not be caught by the rescan either.
+            var excludeWebView2 = (App.Settings?.Current?.ExcludeBambiCloudFromDucking ?? true)
+                                  || App.Video?.IsBrowserSessionActive == true;
             var webViewPids = excludeWebView2 ? RefreshWebView2Pids() : new HashSet<int>();
 
             int newlyDucked = 0;

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -121,7 +121,16 @@ public class BubbleCountService : IDisposable
     public void TriggerGame(bool forceTest = false)
     {
         // Allow forced test even when engine not running
-        if (!forceTest && (!_isRunning || _isBusy)) return;
+        if (!forceTest && (!_isRunning || _isBusy))
+        {
+            // A queued game can be dequeued AFTER the engine stopped (a stop mid-video now
+            // releases the Video slot, which dispatches us). Hand the fresh claim back or it
+            // blocks every interaction for the 5-minute stuck window. _isBusy claims stay: a
+            // live game owns its slot and completes through the window teardown funnel.
+            if (!_isBusy && App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.BubbleCount)
+                App.InteractionQueue.Complete(InteractionQueueService.InteractionType.BubbleCount);
+            return;
+        }
         if (_isBusy) return; // Still prevent double-triggering
 
         // The post-poisoning hold-off (#766: poisoning at 22:05, a bubble-count video built on the

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -129,7 +129,14 @@ public class BubbleCountService : IDisposable
         // the wreckage at 22:18, and a dispatcher that never drained again. Skip this turn rather
         // than stand another player up on it - the shared instance is being rebuilt inside the same
         // window, and the scheduler brings the next game around anyway.
-        var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+        //
+        // Browser engine on: the clip may well play out-of-process, where there is no shared LibVLC
+        // instance to have been poisoned - and the file is not chosen yet, so the routing decision
+        // cannot be made here. Defer to BubbleCountWindow.ShowOnAllMonitors, which knows the path
+        // and re-checks this exact cooldown before it leases anything native.
+        var poisonMs = Video.Browser.BrowserVideoGate.IsEngineUsable()
+            ? 0
+            : VideoService.NativePoisonCooldownRemainingMs;
         if (poisonMs > 0)
         {
             App.Logger?.Warning("BubbleCountService: skipping game - a wedged native Stop() poisoned the shared LibVLC ({Sec:F0}s of cooldown left)",
@@ -329,9 +336,11 @@ public class BubbleCountService : IDisposable
         // interactions (e.g. Video) start while the retry game plays.
         App.InteractionQueue?.ExtendTimeout(300);
 
-        // Same post-poisoning hold-off as TriggerGame. End the game outright rather than let the
-        // strict retry loop bounce off the cooldown every couple of seconds for a minute.
-        var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+        // Same post-poisoning hold-off as TriggerGame, and the same browser-engine caveat: with the
+        // browser engine usable the retry video may never touch LibVLC, so the window decides.
+        var poisonMs = Video.Browser.BrowserVideoGate.IsEngineUsable()
+            ? 0
+            : VideoService.NativePoisonCooldownRemainingMs;
         if (poisonMs > 0)
         {
             App.Logger?.Warning("BubbleCountService: retry abandoned - shared LibVLC poisoned ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -124,34 +124,15 @@ public class BubbleCountService : IDisposable
         if (!forceTest && (!_isRunning || _isBusy)) return;
         if (_isBusy) return; // Still prevent double-triggering
 
-        // A video teardown whose native Stop() never returned leaves a LibVLC thread stuck in this
-        // process forever. #766 is exactly that: poisoning at 22:05, a bubble-count video built on
-        // the wreckage at 22:18, and a dispatcher that never drained again. Skip this turn rather
-        // than stand another player up on it - the shared instance is being rebuilt inside the same
-        // window, and the scheduler brings the next game around anyway.
-        //
-        // Browser engine on: the clip may well play out-of-process, where there is no shared LibVLC
-        // instance to have been poisoned - and the file is not chosen yet, so the routing decision
-        // cannot be made here. Defer to BubbleCountWindow.ShowOnAllMonitors, which knows the path
-        // and re-checks this exact cooldown before it leases anything native.
-        var poisonMs = Video.Browser.BrowserVideoGate.IsEngineUsable()
-            ? 0
-            : VideoService.NativePoisonCooldownRemainingMs;
-        if (poisonMs > 0)
-        {
-            App.Logger?.Warning("BubbleCountService: skipping game - a wedged native Stop() poisoned the shared LibVLC ({Sec:F0}s of cooldown left)",
-                poisonMs / 1000.0);
-            VideoDiag.Log("BUBBLE", $"game skipped - native poison cooldown, {poisonMs}ms remaining");
-            // If the interaction queue dequeued us into this call, hand the slot back or nothing
-            // else runs until stuck detection fires.
-            if (App.InteractionQueue?.CurrentInteraction == InteractionQueueService.InteractionType.BubbleCount)
-                App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
-            return;
-        }
+        // The post-poisoning hold-off (#766: poisoning at 22:05, a bubble-count video built on the
+        // wreckage at 22:18, a dispatcher that never drained again) is evaluated AFTER the video is
+        // picked - see the skip inside the continuation below. It has to be: with the browser engine
+        // on, whether this game touches the shared LibVLC instance at all depends on the FILE, and
+        // no file has been chosen yet.
 
         // For You feed open: bubble count is a video-class interaction and stands down like
         // the mandatory video does. Drop, never queue (the feed outlives the stuck window),
-        // handing back a dequeued slot the same way the poison guard above does.
+        // handing a dequeued slot straight back.
         if (Fyp.FypHostService.IsActive)
         {
             App.Logger?.Information("BubbleCountService: game dropped - For You feed active");
@@ -216,15 +197,44 @@ public class BubbleCountService : IDisposable
                         App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
                         return;
                     }
-                    
+
+                    // Now the file is known, so the routing decision can be made - and only a clip
+                    // that will actually use LibVLC cares about the poisoned shared instance. Skip
+                    // the game OUTRIGHT (the original pre-branch behaviour): the scheduler brings
+                    // the next one around on a rebuilt instance, and letting the window abort
+                    // instead would land in the completion callback as a FAILED count, which in
+                    // strict mode starts the WRONG! WATCH AGAIN retry bounce for the whole cooldown.
+                    var poisonMs = Video.Browser.BrowserVideoGate.ShouldUseBrowser(videoPath)
+                        ? 0
+                        : VideoService.NativePoisonCooldownRemainingMs;
+                    if (poisonMs > 0)
+                    {
+                        App.Logger?.Warning("BubbleCountService: skipping game - a wedged native Stop() poisoned the shared LibVLC ({Sec:F0}s of cooldown left)",
+                            poisonMs / 1000.0);
+                        VideoDiag.Log("BUBBLE", $"game skipped - native poison cooldown, {poisonMs}ms remaining");
+                        _isBusy = false;
+                        App.Bubbles?.Resume();
+                        App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+                        return;
+                    }
+
                     // Determine difficulty settings
                     var difficulty = (Difficulty)settings.BubbleCountDifficulty;
 
                     // Track game started
                     App.Achievements?.TrackBubbleCountGameStarted();
 
-                    // Show the game on all monitors
-                    BubbleCountWindow.ShowOnAllMonitors(videoPath, difficulty, settings.BubbleCountStrictLock, OnGameComplete);
+                    // Show the game on all monitors. The skip callback is the window's backstop for
+                    // a cooldown that started in the last few milliseconds - same clean end as
+                    // above, never a lost game.
+                    BubbleCountWindow.ShowOnAllMonitors(videoPath, difficulty, settings.BubbleCountStrictLock, OnGameComplete,
+                        onSkipped: () =>
+                        {
+                            App.Logger?.Warning("BubbleCountService: game skipped by the window (native poison cooldown)");
+                            _isBusy = false;
+                            App.Bubbles?.Resume();
+                            App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+                        });
 
                     // Extend the stuck detection timeout to cover full video + counting phase
                     var videoDuration = BubbleCountWindow.LastVideoDurationSeconds;
@@ -336,22 +346,8 @@ public class BubbleCountService : IDisposable
         // interactions (e.g. Video) start while the retry game plays.
         App.InteractionQueue?.ExtendTimeout(300);
 
-        // Same post-poisoning hold-off as TriggerGame, and the same browser-engine caveat: with the
-        // browser engine usable the retry video may never touch LibVLC, so the window decides.
-        var poisonMs = Video.Browser.BrowserVideoGate.IsEngineUsable()
-            ? 0
-            : VideoService.NativePoisonCooldownRemainingMs;
-        if (poisonMs > 0)
-        {
-            App.Logger?.Warning("BubbleCountService: retry abandoned - shared LibVLC poisoned ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
-            VideoDiag.Log("BUBBLE", $"retry abandoned - native poison cooldown, {poisonMs}ms remaining");
-            _retryCount = 0;
-            _isBusy = false;
-            App.Bubbles?.Resume();
-            App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
-            GameFailed?.Invoke(this, EventArgs.Empty);
-            return;
-        }
+        // The post-poisoning hold-off is evaluated after selection here too (see TriggerGame): with
+        // the browser engine on, whether the retry clip touches LibVLC at all depends on the file.
 
         try
         {
@@ -368,11 +364,39 @@ public class BubbleCountService : IDisposable
                 return;
             }
 
+            // End the retry loop outright rather than let it bounce off the cooldown every couple
+            // of seconds for a minute. Verbatim the original resolution (mercy: the game ends, the
+            // slot is handed back, GameFailed fires once), just taken with the file in hand.
+            var poisonMs = Video.Browser.BrowserVideoGate.ShouldUseBrowser(videoPath)
+                ? 0
+                : VideoService.NativePoisonCooldownRemainingMs;
+            if (poisonMs > 0)
+            {
+                App.Logger?.Warning("BubbleCountService: retry abandoned - shared LibVLC poisoned ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
+                VideoDiag.Log("BUBBLE", $"retry abandoned - native poison cooldown, {poisonMs}ms remaining");
+                _retryCount = 0;
+                _isBusy = false;
+                App.Bubbles?.Resume();
+                App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+                GameFailed?.Invoke(this, EventArgs.Empty);
+                return;
+            }
+
             var difficulty = (Difficulty)settings.BubbleCountDifficulty;
 
             App.Achievements?.TrackBubbleCountGameStarted();
 
-            BubbleCountWindow.ShowOnAllMonitors(videoPath, difficulty, true, OnGameComplete);
+            BubbleCountWindow.ShowOnAllMonitors(videoPath, difficulty, true, OnGameComplete,
+                onSkipped: () =>
+                {
+                    // Backstop skip: same mercy end as the cooldown branch above, never a loss.
+                    App.Logger?.Warning("BubbleCountService: retry skipped by the window (native poison cooldown)");
+                    _retryCount = 0;
+                    _isBusy = false;
+                    App.Bubbles?.Resume();
+                    App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
+                    GameFailed?.Invoke(this, EventArgs.Empty);
+                });
         }
         catch (Exception ex)
         {
@@ -511,6 +535,11 @@ public class BubbleCountService : IDisposable
                 if (!string.IsNullOrEmpty(tempPath))
                 {
                     _tempPackFiles.Add(tempPath);
+                    // Same reason as VideoService.GetNextVideo: the decrypt path is a fresh GUID on
+                    // every play, so the browser engine's unsafe cache needs the pack entry's own
+                    // identity or a clip it has already failed on costs a full fallback each game.
+                    Video.Browser.BrowserUnsafeVideoCache.RegisterStableKey(
+                        tempPath, $"pack:{packVideo.PackId}|{packVideo.File.OriginalName}");
                     App.Logger?.Debug("BubbleCountService: Using pack video from '{Pack}': {File}",
                         packVideo.PackId, packVideo.File.OriginalName);
                     return tempPath;

--- a/ConditioningControlPanel/Services/BubbleCountService.cs
+++ b/ConditioningControlPanel/Services/BubbleCountService.cs
@@ -236,9 +236,13 @@ public class BubbleCountService : IDisposable
                             App.InteractionQueue?.Complete(InteractionQueueService.InteractionType.BubbleCount);
                         });
 
-                    // Extend the stuck detection timeout to cover full video + counting phase
+                    // Extend the stuck detection timeout to cover full video + counting phase.
+                    // Typed: onSkipped above can resolve synchronously inside ShowOnAllMonitors,
+                    // and its Complete() dispatches the next queued interaction before control
+                    // returns here - a type-blind extension would stretch that unrelated
+                    // interaction's stuck-recovery window with a stale duration.
                     var videoDuration = BubbleCountWindow.LastVideoDurationSeconds;
-                    App.InteractionQueue?.ExtendTimeout(videoDuration + 120);
+                    App.InteractionQueue?.ExtendTimeout(videoDuration + 120, InteractionQueueService.InteractionType.BubbleCount);
                 }
                 catch (Exception ex)
                 {

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserUnsafeVideoCache.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserUnsafeVideoCache.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Newtonsoft.Json;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>
+    /// The set of video files the browser engine has proven it cannot play. A file lands here when
+    /// the player page reports a media error for it, or never reports <c>playing</c> within the
+    /// no-playing window; from then on <see cref="BrowserVideoGate"/> routes it to LibVLC forever,
+    /// so the user never pays the fallback cost twice for the same clip.
+    ///
+    /// NOT populated by <c>ProcessFailed</c>: a dead browser process says nothing about the file.
+    ///
+    /// Keyed by full path + file size so a re-encode of the same filename gets a fresh chance.
+    /// Persisted to <c>%LOCALAPPDATA%\ConditioningControlPanel\browser_unsafe_videos.json</c>;
+    /// a corrupt or unreadable file degrades to an empty cache rather than blocking playback.
+    /// </summary>
+    internal static class BrowserUnsafeVideoCache
+    {
+        /// <summary>Bound the file. Oldest entries are dropped wholesale once it is hit - the
+        /// cost of forgetting is one extra fallback, which is cheaper than an unbounded file.</summary>
+        private const int MaxEntries = 2000;
+        private const int SaveDebounceMs = 3000;
+
+        private static readonly object _lock = new();
+        private static readonly HashSet<string> _keys = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly List<string> _order = new();   // insertion order, for the cap
+        private static bool _loaded;
+        private static Timer? _saveTimer;
+
+        private static string FilePath => Path.Combine(App.UserDataPath, "browser_unsafe_videos.json");
+
+        /// <summary>True when this exact file has already failed in the browser engine.</summary>
+        public static bool Contains(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            var key = KeyFor(path);
+            if (key == null) return false;
+            lock (_lock)
+            {
+                EnsureLoaded();
+                return _keys.Contains(key);
+            }
+        }
+
+        /// <summary>Record a file as browser-undecodable. Idempotent; never throws.</summary>
+        public static void Add(string? path, string reason)
+        {
+            if (string.IsNullOrEmpty(path)) return;
+            var key = KeyFor(path);
+            if (key == null) return;
+            lock (_lock)
+            {
+                EnsureLoaded();
+                if (!_keys.Add(key)) return;
+                _order.Add(key);
+                while (_order.Count > MaxEntries)
+                {
+                    _keys.Remove(_order[0]);
+                    _order.RemoveAt(0);
+                }
+                ScheduleSave();
+            }
+            App.Logger?.Information("BrowserVideo: {File} marked browser-unsafe ({Reason}) - it will use LibVLC from now on",
+                Path.GetFileName(path), reason);
+        }
+
+        private static string? KeyFor(string path)
+        {
+            try
+            {
+                var full = Path.GetFullPath(path);
+                long size = 0;
+                try { size = new FileInfo(full).Length; }
+                catch { /* missing/locked: key on the path alone */ }
+                return full + "|" + size;
+            }
+            catch { return null; }
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (_loaded) return;
+            _loaded = true;
+            try
+            {
+                if (!File.Exists(FilePath)) return;
+                var list = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(FilePath));
+                if (list == null) return;
+                foreach (var k in list)
+                {
+                    if (string.IsNullOrEmpty(k)) continue;
+                    if (_keys.Add(k)) _order.Add(k);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Corrupt file = empty cache. Everything simply gets one more browser attempt.
+                _keys.Clear();
+                _order.Clear();
+                App.Logger?.Warning("BrowserVideo: unsafe-video cache load failed ({E}) - starting empty", ex.Message);
+            }
+        }
+
+        private static void ScheduleSave()
+        {
+            _saveTimer ??= new Timer(_ => Save(), null, Timeout.Infinite, Timeout.Infinite);
+            try { _saveTimer.Change(SaveDebounceMs, Timeout.Infinite); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo: unsafe-cache save schedule failed: {E}", ex.Message); }
+        }
+
+        private static void Save()
+        {
+            try
+            {
+                string json;
+                lock (_lock) { json = JsonConvert.SerializeObject(_order); }
+                Directory.CreateDirectory(App.UserDataPath);
+                File.WriteAllText(FilePath, json);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("BrowserVideo: unsafe-video cache save failed: {E}", ex.Message);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserUnsafeVideoCache.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserUnsafeVideoCache.cs
@@ -14,7 +14,13 @@ namespace ConditioningControlPanel.Services.Video.Browser
     ///
     /// NOT populated by <c>ProcessFailed</c>: a dead browser process says nothing about the file.
     ///
-    /// Keyed by full path + file size so a re-encode of the same filename gets a fresh chance.
+    /// Keyed by a STABLE identity + file size so a re-encode of the same filename gets a fresh
+    /// chance. For a loose file on disk the identity is its full path; a content-pack clip is
+    /// AES-decrypted to a fresh <c>ccp_temp_&lt;GUID&gt;</c> path on EVERY play
+    /// (<c>ContentPackService.GetPackFileTempPath</c>), so keying one on its path would never match
+    /// again and every play would pay the full fallback. The selection sites register the pack's
+    /// canonical identity for the temp path they just created (see <see cref="RegisterStableKey"/>).
+    ///
     /// Persisted to <c>%LOCALAPPDATA%\ConditioningControlPanel\browser_unsafe_videos.json</c>;
     /// a corrupt or unreadable file degrades to an empty cache rather than blocking playback.
     /// </summary>
@@ -25,19 +31,67 @@ namespace ConditioningControlPanel.Services.Video.Browser
         private const int MaxEntries = 2000;
         private const int SaveDebounceMs = 3000;
 
+        /// <summary>Temp paths outlive nothing but the app session, so this map is in-memory only
+        /// and bounded like everything else here.</summary>
+        private const int MaxStableKeys = 512;
+
         private static readonly object _lock = new();
         private static readonly HashSet<string> _keys = new(StringComparer.OrdinalIgnoreCase);
         private static readonly List<string> _order = new();   // insertion order, for the cap
         private static bool _loaded;
         private static Timer? _saveTimer;
 
+        // path (usually a ccp_temp_<GUID> decrypt) -> stable identity of the underlying content.
+        private static readonly Dictionary<string, string> _stableKeys = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly List<string> _stableOrder = new();
+
         private static string FilePath => Path.Combine(App.UserDataPath, "browser_unsafe_videos.json");
 
+        /// <summary>
+        /// Give a path a content identity that survives the path itself. Called where a content-pack
+        /// entry is decrypted to a temp file - the caller is the only code that knows which pack
+        /// entry the GUID path came from. Never throws.
+        /// </summary>
+        public static void RegisterStableKey(string? path, string? stableKey)
+        {
+            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(stableKey)) return;
+            try
+            {
+                var full = Path.GetFullPath(path);
+                lock (_lock)
+                {
+                    if (_stableKeys.ContainsKey(full)) return;
+                    _stableKeys[full] = stableKey!;
+                    _stableOrder.Add(full);
+                    while (_stableOrder.Count > MaxStableKeys)
+                    {
+                        _stableKeys.Remove(_stableOrder[0]);
+                        _stableOrder.RemoveAt(0);
+                    }
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo: stable-key register failed: {E}", ex.Message); }
+        }
+
+        /// <summary>The registered identity for a path, or null when it is just a file on disk.</summary>
+        public static string? ResolveStableKey(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+            try
+            {
+                var full = Path.GetFullPath(path);
+                lock (_lock) { return _stableKeys.TryGetValue(full, out var k) ? k : null; }
+            }
+            catch { return null; }
+        }
+
         /// <summary>True when this exact file has already failed in the browser engine.</summary>
-        public static bool Contains(string? path)
+        /// <param name="stableKey">Content identity to key on instead of the path. Null resolves it
+        /// from the registry, so pack temp files key on their pack entry rather than their GUID.</param>
+        public static bool Contains(string? path, string? stableKey = null)
         {
             if (string.IsNullOrEmpty(path)) return false;
-            var key = KeyFor(path);
+            var key = KeyFor(path, stableKey);
             if (key == null) return false;
             lock (_lock)
             {
@@ -47,10 +101,10 @@ namespace ConditioningControlPanel.Services.Video.Browser
         }
 
         /// <summary>Record a file as browser-undecodable. Idempotent; never throws.</summary>
-        public static void Add(string? path, string reason)
+        public static void Add(string? path, string reason, string? stableKey = null)
         {
             if (string.IsNullOrEmpty(path)) return;
-            var key = KeyFor(path);
+            var key = KeyFor(path, stableKey);
             if (key == null) return;
             lock (_lock)
             {
@@ -68,15 +122,19 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 Path.GetFileName(path), reason);
         }
 
-        private static string? KeyFor(string path)
+        private static string? KeyFor(string path, string? stableKey)
         {
             try
             {
                 var full = Path.GetFullPath(path);
+                // A registered identity beats the path: the decrypted size is still a perfectly good
+                // second component (the same pack entry always decrypts to the same byte count, and a
+                // re-encode changes it), so the "fresh chance after a re-encode" rule survives.
+                var identity = stableKey ?? ResolveStableKey(full) ?? full;
                 long size = 0;
                 try { size = new FileInfo(full).Length; }
-                catch { /* missing/locked: key on the path alone */ }
-                return full + "|" + size;
+                catch { /* missing/locked: key on the identity alone */ }
+                return identity + "|" + size;
             }
             catch { return null; }
         }

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -160,6 +160,37 @@ namespace ConditioningControlPanel.Services.Video.Browser
 
         private static Task<CoreWebView2Environment?> EnvironmentAsync() => _envTask ??= CreateEnvironmentAsync();
 
+        /// <summary>
+        /// The ONE shared WebView2 environment, for hosts that own their own surfaces instead of a
+        /// session here (BubbleCountWindow puts a <see cref="BrowserVideoSurface"/> inside the game
+        /// window so its HUD, strict lock and ESC handling keep working). Null once it has proven
+        /// unbuildable - the caller must then use LibVLC. Never throws.
+        /// </summary>
+        public static Task<CoreWebView2Environment?> SharedEnvironmentAsync() => EnvironmentAsync();
+
+        /// <summary>Virtual-host mappings for a foreign surface, with the folders created first (a
+        /// missing folder makes WebView2 skip the mapping silently).</summary>
+        public static IReadOnlyList<(string, string, CoreWebView2HostResourceAccessKind)> SharedMappings()
+            => BuildMappings();
+
+        /// <summary>Where a foreign surface must navigate, and the only host it may navigate to.</summary>
+        public static string PlayerStartUrl => StartUrl;
+
+        public static string PlayerHost => GameHost;
+
+        /// <summary>
+        /// A host driving its own surface reports a dead browser process here, so the two-strikes
+        /// stand-down is shared app-wide: a flapping renderer must not turn every video in every
+        /// feature into a fallback. Never blames the file (plan §4).
+        /// </summary>
+        public static void ReportProcessFailure(CoreWebView2ProcessFailedKind kind)
+        {
+            _processFailures++;
+            if (_processFailures >= MaxProcessFailures)
+                App.Logger?.Warning("BrowserVideo: {Count} WebView2 process failures this session ({Kind}) - engine standing down, everything routes to LibVLC",
+                    _processFailures, kind);
+        }
+
         private static async Task<CoreWebView2Environment?> CreateEnvironmentAsync()
         {
             try

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -1,0 +1,573 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.Web.WebView2.Core;
+using Newtonsoft.Json.Linq;
+using Screen = System.Windows.Forms.Screen;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>What the host wants played, and how the host wants its windows dressed.</summary>
+    internal sealed class BrowserVideoRequest
+    {
+        /// <summary>Absolute path of the clip. Must resolve to a mapped virtual host - see
+        /// <see cref="BrowserVideoEngine.BuildPageUrl"/>.</summary>
+        public required string Path { get; init; }
+
+        /// <summary>The audio-bearing monitor.</summary>
+        public required Screen PrimaryScreen { get; init; }
+
+        /// <summary>Extra monitors to fill (already filtered by the caller's monitor-count cap, #389).
+        /// These load muted.</summary>
+        public IReadOnlyList<Screen> SecondaryScreens { get; init; } = Array.Empty<Screen>();
+
+        /// <summary>Master x video volume, 0..1. External mute folds in through <see cref="Muted"/>.</summary>
+        public double Volume { get; init; } = 1.0;
+
+        public bool Muted { get; init; }
+
+        /// <summary>Blurred-background (TikTok fill) composite instead of black bars. Page-side.</summary>
+        public bool BlurBackground { get; init; }
+
+        /// <summary>Start position for the chaos random-segment mode. 0 = from the top.</summary>
+        public long StartAtMs { get; init; }
+
+        /// <summary>Runs on each window after construction and BEFORE Show() - the host's hook for
+        /// strict handlers and anything that must be wired before the HWND is realized.</summary>
+        public Action<Window, Screen, bool>? ConfigureBeforeShow { get; init; }
+
+        /// <summary>Runs on each window right after Show() - z-order guards and the like.</summary>
+        public Action<Window, Screen, bool>? ConfigureAfterShow { get; init; }
+
+        /// <summary>True while the host is deliberately holding playback (grace pause). The
+        /// first-frame watchdog must not count that time, or a pause taken before the first frame
+        /// would fake a decode failure and force a pointless LibVLC fallback.</summary>
+        public Func<bool>? IsHostPaused { get; init; }
+    }
+
+    /// <summary>
+    /// Out-of-process video playback for mandatory videos: one WebView2 per monitor running the
+    /// player page (<c>Resources/web/player/index.html</c>), driven over the JSON bridge in
+    /// docs/BROWSER_VIDEO_ENGINE_PLAN.md §3.
+    ///
+    /// Why it exists: LibVLC renders IN-PROCESS and can wedge the WPF dispatcher (the whole
+    /// quarantine/retire/wedge-ladder museum in VideoService exists to survive that). WebView2 media
+    /// is out-of-process - a dead renderer is a <c>ProcessFailed</c> event, not a frozen desktop.
+    ///
+    /// This class owns ONLY the surfaces and the bridge. Scheduling, selection, XP, attention checks,
+    /// ducking, safety timers, strict mode and every event consumers see stay in VideoService, which
+    /// is what makes a browser session indistinguishable from a LibVLC one.
+    ///
+    /// It NEVER throws to callers: every failure is a logged event plus <see cref="Failed"/>, which
+    /// the host answers by replaying the same file through LibVLC.
+    /// </summary>
+    internal sealed class BrowserVideoEngine
+    {
+        // ---- virtual hosts (folders are created before mapping: a missing folder makes WebView2
+        // silently SKIP the mapping, which surfaces much later as a 404 on the video) ----
+        private const string GameHost = "ccp.game";
+        private const string AssetsHost = "ccp.assets";
+        private const string PacksHost = "ccp.packs";
+        private const string StartUrl = "https://" + GameHost + "/player/index.html";
+
+        /// <summary>How long a session may go without a <c>playing</c> report before it is treated as
+        /// undecodable. The page runs the same clock and reports error 101; whichever lands first
+        /// wins and the host's fallback is idempotent.</summary>
+        private const int NoPlayingTimeoutMs = 10000;
+        private const int WatchTickMs = 500;
+
+        /// <summary>Two dead browser processes in one app session and the engine stands down for
+        /// good - a flapping renderer must not turn every video into a fallback.</summary>
+        private const int MaxProcessFailures = 2;
+
+        private static BrowserVideoEngine? _instance;
+        private static Task<CoreWebView2Environment?>? _envTask;
+        private static int _processFailures;
+        private static bool _environmentDead;
+
+        /// <summary>Process-wide singleton. Touching it starts the shared environment build, so the
+        /// first video finds <see cref="IsAvailable"/> already settled.</summary>
+        public static BrowserVideoEngine Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new BrowserVideoEngine();
+                    _ = EnvironmentAsync();   // fire-and-forget warm-up
+                }
+                return _instance;
+            }
+        }
+
+        private readonly List<BrowserVideoWindow> _windows = new();
+        private BrowserVideoWindow? _primary;
+        private DispatcherTimer? _firstFrameWatch;
+        private DateTime _firstFrameDeadlineUtc;
+        private Func<bool>? _isHostPaused;
+        private bool _playingSeen;
+        private bool _failedRaised;
+        private int _sessionId;
+
+        private BrowserVideoEngine() { }
+
+        /// <summary>False once the WebView2 environment has proven unbuildable (runtime missing) or
+        /// the browser process has died twice this app session. Every video then routes to LibVLC.</summary>
+        public bool IsAvailable => !_environmentDead && _processFailures < MaxProcessFailures;
+
+        /// <summary>True between <see cref="StartSession"/> and <see cref="StopSession"/>.</summary>
+        public bool IsSessionActive => _windows.Count > 0;
+
+        /// <summary>The windows of the live session, for the host to add to its own teardown list.</summary>
+        public IReadOnlyList<Window> Windows => _windows;
+
+        /// <summary>The audio-bearing window, or null when no session is live.</summary>
+        public Window? PrimaryWindow => _primary;
+
+        // ---- events (all raised on the UI thread, from the WebView2 message callback) ----
+
+        /// <summary>durationMs (0 = unknowable), width, height. Can fire MORE THAN ONCE per clip:
+        /// webm / fragmented mp4 report Infinity at loadedmetadata and settle at durationchange.
+        /// Last one wins.</summary>
+        public event Action<long, int, int>? Meta;
+
+        /// <summary>First real <c>playing</c> event of the clip.</summary>
+        public event Action? Playing;
+
+        /// <summary>~10 Hz playback position in ms. Nothing is posted while paused or ended.</summary>
+        public event Action<long>? Time;
+
+        /// <summary>Natural end of the clip.</summary>
+        public event Action? Ended;
+
+        /// <summary>reason, blameFile. blameFile=true means the FILE is undecodable (media error or
+        /// first-frame timeout) and belongs in <see cref="BrowserUnsafeVideoCache"/>; false means the
+        /// session/environment failed and the file deserves another chance later.</summary>
+        public event Action<string, bool>? Failed;
+
+        /// <summary>Any pointer-down on the surface. Window-level PreviewMouseDown is unreliable over
+        /// a WebView2 child HWND, so this message is the only signal the host gets.</summary>
+        public event Action? Clicked;
+
+        /// <summary>key, alt, ctrl, shift - every non-repeat keydown the page saw. Keyboard over a
+        /// focused WebView2 goes to Chromium, so this is how strict-mode/ESC decisions still reach C#.</summary>
+        public event Action<string, bool, bool, bool>? KeyPressed;
+
+        // ===================== environment =====================
+
+        private static Task<CoreWebView2Environment?> EnvironmentAsync() => _envTask ??= CreateEnvironmentAsync();
+
+        private static async Task<CoreWebView2Environment?> CreateEnvironmentAsync()
+        {
+            try
+            {
+                var userDataFolder = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "ConditioningControlPanel", "browser_data_video");
+                Directory.CreateDirectory(userDataFolder);
+
+                // --autoplay-policy: the page must start without a user gesture.
+                // --disable-direct-composition-video-overlays: MPO scans video out on its own plane;
+                //   on some GPUs that means black video or video ABOVE topmost overlays (#449/#439).
+                // The two occlusion flags: a mandatory video window is covered by attention targets,
+                //   subliminals and grace cards - Chromium would call the page occluded and stop
+                //   rendering it.
+                var args = "--autoplay-policy=no-user-gesture-required "
+                         + "--disable-direct-composition-video-overlays "
+                         + "--disable-features=CalculateNativeWinOcclusion "
+                         + "--disable-backgrounding-occluded-windows";
+                var options = new CoreWebView2EnvironmentOptions { AdditionalBrowserArguments = args };
+                var env = await CoreWebView2Environment
+                    .CreateAsync(browserExecutableFolder: null, userDataFolder: userDataFolder, options: options)
+                    .ConfigureAwait(true);
+                App.Logger?.Information("BrowserVideo: WebView2 environment ready ({Folder})", userDataFolder);
+                return env;
+            }
+            catch (Exception ex)
+            {
+                // Almost always "the WebView2 runtime is not installed". One clear line, then every
+                // video routes to LibVLC for the rest of the session.
+                _environmentDead = true;
+                App.Logger?.Warning("BrowserVideo: WebView2 environment unavailable ({E}) - browser video engine disabled for this session", ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Virtual-host URL for a clip on disk, or null when the file lives outside every mapped
+        /// root (in which case the caller must use LibVLC). Percent-escaped per path segment.
+        /// The pack root is checked FIRST: content-pack clips are AES-decrypted into
+        /// <c>App.GetMediaTempPath()</c>, which normally sits inside the assets folder.
+        /// </summary>
+        public static string? BuildPageUrl(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return null;
+            try
+            {
+                var full = Path.GetFullPath(path);
+                var packRoot = PackTempRoot();
+                if (TryRelative(full, packRoot, out var packRel))
+                    return "https://" + PacksHost + "/" + EscapeSegments(packRel);
+                if (TryRelative(full, App.EffectiveAssetsPath, out var assetRel))
+                    return "https://" + AssetsHost + "/" + EscapeSegments(assetRel);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrowserVideo: URL build failed for {Path}: {E}", path, ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>The content-pack decrypt directory, resolved from the same helper
+        /// <c>ContentPackService.GetPackFileTempPath</c> writes into - never hardcoded.</summary>
+        private static string PackTempRoot()
+        {
+            try { return App.GetMediaTempPath(); }
+            catch { return string.Empty; }
+        }
+
+        private static bool TryRelative(string full, string? root, out string relative)
+        {
+            relative = string.Empty;
+            if (string.IsNullOrEmpty(root)) return false;
+            try
+            {
+                var rootFull = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (!full.StartsWith(rootFull + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                    return false;
+                relative = full.Substring(rootFull.Length + 1).Replace('\\', '/');
+                return relative.Length > 0;
+            }
+            catch { return false; }
+        }
+
+        private static string EscapeSegments(string relative)
+            => string.Join('/', Array.ConvertAll(relative.Split('/'), Uri.EscapeDataString));
+
+        private static IReadOnlyList<(string, string, CoreWebView2HostResourceAccessKind)> BuildMappings()
+        {
+            var webRoot = Path.Combine(AppContext.BaseDirectory, "Resources", "web");
+            var assets = App.EffectiveAssetsPath;
+            var packs = PackTempRoot();
+            // Create BEFORE mapping - a missing folder makes WebView2 skip the mapping silently.
+            foreach (var dir in new[] { assets, packs })
+            {
+                if (string.IsNullOrEmpty(dir)) continue;
+                try { Directory.CreateDirectory(dir); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: mapping dir create failed ({Dir}): {E}", dir, ex.Message); }
+            }
+            return new List<(string, string, CoreWebView2HostResourceAccessKind)>
+            {
+                (GameHost, webRoot, CoreWebView2HostResourceAccessKind.Deny),
+                (AssetsHost, assets, CoreWebView2HostResourceAccessKind.Allow),
+                (PacksHost, packs, CoreWebView2HostResourceAccessKind.Allow),
+            };
+        }
+
+        // ===================== session =====================
+
+        /// <summary>
+        /// Bring the windows up and start the clip. Returns false when nothing could be created (the
+        /// caller must then use LibVLC); a failure that only surfaces later comes back through
+        /// <see cref="Failed"/>. Never throws. UI thread only.
+        /// </summary>
+        public bool StartSession(BrowserVideoRequest req)
+        {
+            if (!IsAvailable) return false;
+            var url = BuildPageUrl(req.Path);
+            if (url == null) return false;
+
+            StopSession();   // a previous session must never outlive its video
+
+            var session = ++_sessionId;
+            _playingSeen = false;
+            _failedRaised = false;
+            _isHostPaused = req.IsHostPaused;
+
+            try
+            {
+                _primary = CreateWindow(req, req.PrimaryScreen, primary: true, url);
+                if (_primary == null) return false;
+                _windows.Add(_primary);
+
+                foreach (var scr in req.SecondaryScreens)
+                {
+                    var w = CreateWindow(req, scr, primary: false, url);
+                    if (w != null) _windows.Add(w);
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BrowserVideo: session start failed");
+                StopSession();
+                return false;
+            }
+
+            _ = InitWindowsAsync(session);
+            ArmFirstFrameWatch();
+
+            App.Logger?.Information("BrowserVideo: session {Id} up on {Count} screen(s) - {File} (blur={Blur}, vol={Vol:0.00}, muted={Muted})",
+                session, _windows.Count, Path.GetFileName(req.Path), req.BlurBackground, req.Volume, req.Muted);
+            return true;
+        }
+
+        private BrowserVideoWindow? CreateWindow(BrowserVideoRequest req, Screen screen, bool primary, string url)
+        {
+            BrowserVideoWindow? win = null;
+            try
+            {
+                win = new BrowserVideoWindow(screen, primary);
+                win.Message += OnWindowMessage;
+                win.ProcessFailed += OnWindowProcessFailed;
+                win.Ready += OnWindowReady;
+
+                // Queued until the page's ready handshake, so it is safe to post before the
+                // CoreWebView2 even exists.
+                win.Post(new
+                {
+                    type = "load",
+                    url,
+                    volume = primary ? Math.Clamp(req.Volume, 0, 1) : 0.0,
+                    muted = primary ? req.Muted : true,   // secondaries never carry audio
+                    blurBackground = req.BlurBackground,
+                    startAtMs = req.StartAtMs,
+                });
+
+                try { req.ConfigureBeforeShow?.Invoke(win, screen, primary); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: ConfigureBeforeShow threw: {E}", ex.Message); }
+
+                win.Show();
+                // Focus BEFORE the host stamps WS_EX_NOACTIVATE: the page needs keyboard focus for
+                // its {type:'key'} reports, and after the style lands the window can never take it.
+                if (primary) win.FocusWeb();
+
+                try { req.ConfigureAfterShow?.Invoke(win, screen, primary); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: ConfigureAfterShow threw: {E}", ex.Message); }
+
+                return win;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BrowserVideo: failed to create window on {Screen}", screen.DeviceName);
+                try { win?.Close(); } catch { }
+                return null;
+            }
+        }
+
+        private async Task InitWindowsAsync(int session)
+        {
+            var env = await EnvironmentAsync().ConfigureAwait(true);
+            if (session != _sessionId) return;   // the session ended while the environment was building
+            if (env == null)
+            {
+                RaiseFailed("WebView2 environment unavailable", blameFile: false);
+                return;
+            }
+
+            var mappings = BuildMappings();
+            foreach (var w in _windows.ToArray())
+            {
+                if (session != _sessionId) return;
+                // EnsureCoreWebView2Async only works once the control is in the visual tree, which
+                // is why this runs after Show().
+                await w.InitAsync(env, mappings, StartUrl, GameHost).ConfigureAwait(true);
+            }
+            // The control had no CoreWebView2 to focus when the window was shown, so re-assert it
+            // now that one exists - otherwise the page never receives a keydown.
+            if (session == _sessionId) _primary?.FocusWeb();
+        }
+
+        /// <summary>Tear the session down. Idempotent, never throws, raises nothing.</summary>
+        public void StopSession()
+        {
+            _sessionId++;   // invalidates every in-flight continuation and late page message
+            StopFirstFrameWatch();
+            _isHostPaused = null;
+
+            var windows = _windows.ToArray();
+            _windows.Clear();
+            _primary = null;
+            foreach (var w in windows)
+            {
+                try
+                {
+                    w.Message -= OnWindowMessage;
+                    w.ProcessFailed -= OnWindowProcessFailed;
+                    w.Ready -= OnWindowReady;
+                    // Decoder hygiene: pause -> drop src -> load(). Queued messages are dropped with
+                    // the window, so this is best-effort and the Close below is what really frees it.
+                    if (w.IsReady) w.Post(new { type = "stop" });
+                    w.Close();
+                }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: window close failed: {E}", ex.Message); }
+            }
+        }
+
+        // ---- host controls ----
+
+        public void Pause() => Broadcast(new { type = "pause" });
+
+        public void Resume() => Broadcast(new { type = "resume" });
+
+        /// <summary>Master x video volume as 0..1, with external mute folded in.</summary>
+        public void SetVolume(double volume, bool muted)
+        {
+            var v = Math.Clamp(volume, 0, 1);
+            foreach (var w in _windows.ToArray())
+            {
+                // Secondaries stay silent for the whole session (one WASAPI session per clip).
+                try { w.Post(new { type = "setVolume", volume = w.IsPrimary ? v : 0.0, muted = w.IsPrimary ? muted : true }); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: setVolume post failed: {E}", ex.Message); }
+            }
+        }
+
+        /// <summary>Seek every screen so multi-monitor mirrors stay in lockstep (#527).</summary>
+        public void Seek(long ms) => Broadcast(new { type = "seek", ms = Math.Max(0, ms) });
+
+        private void Broadcast(object msg)
+        {
+            foreach (var w in _windows.ToArray())
+            {
+                try { w.Post(msg); }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: post failed: {E}", ex.Message); }
+            }
+        }
+
+        // ---- page messages ----
+
+        private void OnWindowMessage(BrowserVideoWindow win, JObject o)
+        {
+            try
+            {
+                var type = (string?)o["type"];
+                // Only the audio-bearing window drives the session, exactly like the LibVLC primary
+                // player - a secondary's events would double every callback.
+                if (!win.IsPrimary)
+                {
+                    if (type == "error")
+                        App.Logger?.Warning("BrowserVideo[secondary]: page error {Code} {Msg} (ignored - primary owns the session)",
+                            (int?)o["code"], (string?)o["message"]);
+                    return;
+                }
+
+                switch (type)
+                {
+                    case "meta":
+                    {
+                        long durationMs = (long?)o["durationMs"] ?? 0;
+                        int w = (int?)o["width"] ?? 0;
+                        int h = (int?)o["height"] ?? 0;
+                        Meta?.Invoke(durationMs, w, h);
+                        break;
+                    }
+                    case "playing":
+                        _playingSeen = true;
+                        StopFirstFrameWatch();
+                        Playing?.Invoke();
+                        break;
+                    case "time":
+                        Time?.Invoke((long?)o["ms"] ?? 0);
+                        break;
+                    case "ended":
+                        StopFirstFrameWatch();
+                        Ended?.Invoke();
+                        break;
+                    case "error":
+                    {
+                        int code = (int?)o["code"] ?? 0;
+                        var msg = (string?)o["message"] ?? "";
+                        App.Logger?.Warning("BrowserVideo: page error {Code}: {Msg}", code, msg);
+                        RaiseFailed($"page error {code}: {msg}", blameFile: BlamesFile(code));
+                        break;
+                    }
+                    case "click":
+                        Clicked?.Invoke();
+                        break;
+                    case "key":
+                        KeyPressed?.Invoke((string?)o["key"] ?? "",
+                            (bool?)o["alt"] ?? false, (bool?)o["ctrl"] ?? false, (bool?)o["shift"] ?? false);
+                        break;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo: message dispatch failed: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Which page error codes mean "this FILE is undecodable" and belong in the unsafe cache.
+        /// 1-4 are MediaError.code verbatim, 100 is a >10s stall after playing and 101 is no first
+        /// frame within the window - all properties of the file. 102 (second unrequested pause) and
+        /// 103 (malformed load message) are session-level and must not condemn the clip.
+        /// </summary>
+        private static bool BlamesFile(int code) => (code >= 1 && code <= 4) || code == 100 || code == 101;
+
+        /// <summary>
+        /// The page handshake landed, so the queued <c>load</c> only reaches the element NOW. Restart
+        /// the first-frame clock from here: a cold WebView2 start (runtime spin-up + navigation) can
+        /// eat several of the ten seconds and would otherwise fake a decode failure on a healthy file.
+        /// </summary>
+        private void OnWindowReady(BrowserVideoWindow win)
+        {
+            if (!win.IsPrimary || _playingSeen) return;
+            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
+        }
+
+        private void OnWindowProcessFailed(BrowserVideoWindow win, CoreWebView2ProcessFailedKind kind)
+        {
+            _processFailures++;
+            if (_processFailures >= MaxProcessFailures)
+                App.Logger?.Warning("BrowserVideo: {Count} WebView2 process failures this session - engine standing down, everything routes to LibVLC",
+                    _processFailures);
+            // Never blames the file: a dead renderer is an environment failure (plan §4).
+            RaiseFailed("WebView2 process failed: " + kind, blameFile: false);
+        }
+
+        // ---- first-frame watchdog ----
+
+        private void ArmFirstFrameWatch()
+        {
+            StopFirstFrameWatch();
+            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
+            _firstFrameWatch = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(WatchTickMs) };
+            _firstFrameWatch.Tick += (_, _) =>
+            {
+                try
+                {
+                    if (_playingSeen || _windows.Count == 0) { StopFirstFrameWatch(); return; }
+                    // A grace pause holds playback on purpose, and the page suspends its own clock
+                    // for the same reason - slide the deadline instead of failing a healthy clip.
+                    if (_isHostPaused?.Invoke() == true)
+                    {
+                        _firstFrameDeadlineUtc = _firstFrameDeadlineUtc.AddMilliseconds(WatchTickMs);
+                        return;
+                    }
+                    if (DateTime.UtcNow < _firstFrameDeadlineUtc) return;
+                    StopFirstFrameWatch();
+                    RaiseFailed($"no playback within {NoPlayingTimeoutMs / 1000}s", blameFile: true);
+                }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: first-frame watch tick failed: {E}", ex.Message); }
+            };
+            _firstFrameWatch.Start();
+        }
+
+        private void StopFirstFrameWatch()
+        {
+            try { _firstFrameWatch?.Stop(); } catch { }
+            _firstFrameWatch = null;
+        }
+
+        /// <summary>One failure per session reaches the host; the page's own 10s report and this
+        /// engine's watchdog can both fire for the same stall.</summary>
+        private void RaiseFailed(string reason, bool blameFile)
+        {
+            if (_failedRaised) return;
+            _failedRaised = true;
+            StopFirstFrameWatch();
+            try { Failed?.Invoke(reason, blameFile); }
+            catch (Exception ex) { App.Logger?.Warning("BrowserVideo: Failed handler threw: {E}", ex.Message); }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -32,6 +32,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>Blurred-background (TikTok fill) composite instead of black bars. Page-side.</summary>
         public bool BlurBackground { get; init; }
 
+        /// <summary>Hide the mouse pointer over the surface. Default FALSE, which is what the LibVLC
+        /// video windows do - a surface that eats the cursor while the rest of the app still has one
+        /// reads as a frozen machine, and mouse-driven hosts (BubbleCount) need it visible.</summary>
+        public bool HideCursor { get; init; }
+
         /// <summary>Start position for the chaos random-segment mode. 0 = from the top.</summary>
         public long StartAtMs { get; init; }
 
@@ -73,33 +78,64 @@ namespace ConditioningControlPanel.Services.Video.Browser
         private const string PacksHost = "ccp.packs";
         private const string StartUrl = "https://" + GameHost + "/player/index.html";
 
-        /// <summary>How long a session may go without a <c>playing</c> report before it is treated as
-        /// undecodable. The page runs the same clock and reports error 101; whichever lands first
-        /// wins and the host's fallback is idempotent.</summary>
+        /// <summary>How long a session may go without a <c>playing</c> report ONCE THE PAGE IS UP.
+        /// The page runs the same clock from its own load and reports error 101; whichever lands
+        /// first wins and the host's fallback is idempotent.</summary>
         private const int NoPlayingTimeoutMs = 10000;
+
+        /// <summary>Budget from session start to the page's <c>ready</c> handshake. A cold WebView2
+        /// (environment build, browser process spawn, navigation) can eat well over ten seconds on a
+        /// slow disk, and NONE of that is the clip's fault - charging it to the clip is how a healthy
+        /// file ends up looking undecodable. The clock restarts at <c>ready</c>.</summary>
+        private const int PreReadyTimeoutMs = 20000;
         private const int WatchTickMs = 500;
 
         /// <summary>Two dead browser processes in one app session and the engine stands down for
         /// good - a flapping renderer must not turn every video into a fallback.</summary>
         private const int MaxProcessFailures = 2;
 
-        private static BrowserVideoEngine? _instance;
+        private static readonly Lazy<BrowserVideoEngine> _instance =
+            new(() => new BrowserVideoEngine(), System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
         private static Task<CoreWebView2Environment?>? _envTask;
+        private static readonly object _envLock = new();
         private static int _processFailures;
         private static bool _environmentDead;
 
-        /// <summary>Process-wide singleton. Touching it starts the shared environment build, so the
-        /// first video finds <see cref="IsAvailable"/> already settled.</summary>
+        /// <summary>
+        /// Process-wide singleton, built exactly once however many threads race for it (the gate is
+        /// consulted from selection code that does not always run on the UI thread).
+        ///
+        /// Touching it also KICKS OFF the shared environment build - it does not wait for it. A
+        /// first video that arrives before the build finishes still sees <see cref="IsAvailable"/>
+        /// true (it only turns false once a build has actually FAILED) and its session waits on the
+        /// same task in <see cref="InitWindowsAsync"/>. App startup warms this so the first video
+        /// does not pay for <c>CreateEnvironmentAsync</c>.
+        /// </summary>
         public static BrowserVideoEngine Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    _instance = new BrowserVideoEngine();
-                    _ = EnvironmentAsync();   // fire-and-forget warm-up
-                }
-                return _instance;
+                var engine = _instance.Value;
+                _ = EnvironmentAsync();   // fire-and-forget warm-up
+                return engine;
+            }
+        }
+
+        /// <summary>
+        /// Startup warm-up: build the singleton and begin the WebView2 environment creation now, so
+        /// the first mandatory video is not the thing that pays for a cold browser start (and does
+        /// not spend that time against its own first-frame budget). Fire-and-forget, never throws.
+        /// </summary>
+        public static void WarmUp()
+        {
+            try
+            {
+                _ = Instance;
+                App.Logger?.Debug("BrowserVideo: warm-up started (environment building in the background)");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrowserVideo: warm-up failed ({E}) - the first video will build the environment", ex.Message);
             }
         }
 
@@ -158,7 +194,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
 
         // ===================== environment =====================
 
-        private static Task<CoreWebView2Environment?> EnvironmentAsync() => _envTask ??= CreateEnvironmentAsync();
+        private static Task<CoreWebView2Environment?> EnvironmentAsync()
+        {
+            // Locked for the same reason Instance is Lazy: two threads racing here would each start
+            // a CoreWebView2Environment.CreateAsync against the same user-data folder.
+            lock (_envLock) { return _envTask ??= CreateEnvironmentAsync(); }
+        }
 
         /// <summary>
         /// The ONE shared WebView2 environment, for hosts that own their own surfaces instead of a
@@ -365,6 +406,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     volume = primary ? Math.Clamp(req.Volume, 0, 1) : 0.0,
                     muted = primary ? req.Muted : true,   // secondaries never carry audio
                     blurBackground = req.BlurBackground,
+                    hideCursor = req.HideCursor,
                     startAtMs = req.StartAtMs,
                 });
 
@@ -536,18 +578,37 @@ namespace ConditioningControlPanel.Services.Video.Browser
         private static bool BlamesFile(int code) => (code >= 1 && code <= 4) || code == 100 || code == 101;
 
         /// <summary>
-        /// The page handshake landed, so the queued <c>load</c> only reaches the element NOW. Restart
-        /// the first-frame clock from here: a cold WebView2 start (runtime spin-up + navigation) can
-        /// eat several of the ten seconds and would otherwise fake a decode failure on a healthy file.
+        /// The page handshake landed, so the queued <c>load</c> only reaches the element NOW - which
+        /// means everything before this point was environment start-up, not the clip failing to
+        /// decode. Restart the first-frame clock from here UNCONDITIONALLY (the pre-ready budget is
+        /// generous precisely so this always gets to run) and give the file its own full window.
         /// </summary>
         private void OnWindowReady(BrowserVideoWindow win)
         {
-            if (!win.IsPrimary || _playingSeen) return;
+            if (!win.IsPrimary || _playingSeen || _firstFrameWatch == null) return;
             _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
         }
 
         private void OnWindowProcessFailed(BrowserVideoWindow win, CoreWebView2ProcessFailedKind kind)
         {
+            // ONE dead browser process fires this on EVERY window sharing it, so a dual-monitor
+            // session used to spend both strikes of the stand-down budget on a single crash. Only
+            // the primary's handler counts - and only the primary's failure ends the session.
+            if (!win.IsPrimary)
+            {
+                App.Logger?.Warning("BrowserVideo[secondary]: WebView2 process failed ({Kind}) - dropping that mirror, the primary keeps playing", kind);
+                try
+                {
+                    win.Message -= OnWindowMessage;
+                    win.ProcessFailed -= OnWindowProcessFailed;
+                    win.Ready -= OnWindowReady;
+                    _windows.Remove(win);
+                    win.Close();
+                }
+                catch (Exception ex) { App.Logger?.Debug("BrowserVideo: secondary close after ProcessFailed failed: {E}", ex.Message); }
+                return;
+            }
+
             _processFailures++;
             if (_processFailures >= MaxProcessFailures)
                 App.Logger?.Warning("BrowserVideo: {Count} WebView2 process failures this session - engine standing down, everything routes to LibVLC",
@@ -561,7 +622,9 @@ namespace ConditioningControlPanel.Services.Video.Browser
         private void ArmFirstFrameWatch()
         {
             StopFirstFrameWatch();
-            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(NoPlayingTimeoutMs);
+            // Pre-ready budget: everything up to the page handshake is environment cost, not the
+            // clip's. OnWindowReady restarts the clock with the real (shorter) first-frame budget.
+            _firstFrameDeadlineUtc = DateTime.UtcNow.AddMilliseconds(PreReadyTimeoutMs);
             _firstFrameWatch = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(WatchTickMs) };
             _firstFrameWatch.Tick += (_, _) =>
             {
@@ -577,7 +640,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
                     }
                     if (DateTime.UtcNow < _firstFrameDeadlineUtc) return;
                     StopFirstFrameWatch();
-                    RaiseFailed($"no playback within {NoPlayingTimeoutMs / 1000}s", blameFile: true);
+                    // blameFile is ALWAYS false here. This timer cannot tell "undecodable clip" from
+                    // "the page never ran / the browser is still starting", and condemning a file to
+                    // LibVLC forever on that guess is the worse error. The page's OWN error 101 -
+                    // which is raised by a page that demonstrably loaded and then got no frame - is
+                    // the legitimate file-blame path (BlamesFile), and it still is.
+                    RaiseFailed("no playback before the first-frame deadline", blameFile: false);
                 }
                 catch (Exception ex) { App.Logger?.Debug("BrowserVideo: first-frame watch tick failed: {E}", ex.Message); }
             };

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
@@ -27,32 +27,21 @@ namespace ConditioningControlPanel.Services.Video.Browser
             catch { return false; }
         }
 
-        /// <summary>
-        /// True when the browser engine is switched on and healthy - i.e. a video whose path is not
-        /// chosen yet MIGHT play out-of-process. Only for callers that have to decide something
-        /// BEFORE selection (BubbleCountService's poison-cooldown skip); the per-file answer is
-        /// <see cref="ShouldUseBrowser"/>, and the host re-checks it once the file is known.
-        /// </summary>
-        public static bool IsEngineUsable()
-        {
-            try
-            {
-                if (App.Settings?.Current?.BrowserVideoEngineEnabled != true) return false;
-                return BrowserVideoEngine.Instance.IsAvailable;
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Debug("BrowserVideoGate.IsEngineUsable threw ({E}) - assuming LibVLC", ex.Message);
-                return false;
-            }
-        }
+        // There is deliberately NO "might a video use the browser?" helper here. Its only caller was
+        // BubbleCountService's poison-cooldown skip, and answering it before a file is chosen is
+        // what made that skip wrong: the routing decision is per-FILE. Both cooldown checks now run
+        // after selection and call ShouldUseBrowser with the real path.
 
         /// <summary>
         /// True when the mandatory-video pipeline should hand this clip to
         /// <see cref="BrowserVideoEngine"/> instead of LibVLC. Never throws - any doubt routes to
         /// LibVLC, which is the shipped path.
         /// </summary>
-        public static bool ShouldUseBrowser(string? path)
+        /// <param name="stableKey">Optional content identity for the unsafe-cache lookup. Null
+        /// resolves it from <see cref="BrowserUnsafeVideoCache.ResolveStableKey"/>, which is what
+        /// keeps a content-pack clip recognisable across its per-play <c>ccp_temp_&lt;GUID&gt;</c>
+        /// decrypt path.</param>
+        public static bool ShouldUseBrowser(string? path, string? stableKey = null)
         {
             try
             {
@@ -65,7 +54,7 @@ namespace ConditioningControlPanel.Services.Video.Browser
                 // A file the page cannot serve (outside every mapped virtual host) would 404 and
                 // cost a pointless fallback, so it is decided here rather than at runtime.
                 if (BrowserVideoEngine.BuildPageUrl(path) == null) return false;
-                if (BrowserUnsafeVideoCache.Contains(path)) return false;
+                if (BrowserUnsafeVideoCache.Contains(path, stableKey)) return false;
                 return true;
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>
+    /// The one place that answers "should THIS file play in the browser engine?". Everything the
+    /// hybrid routing decision depends on lives here so VideoService's branch stays a single call
+    /// and the LibVLC path keeps its exact shape for every file the browser can't take.
+    /// </summary>
+    internal static class BrowserVideoGate
+    {
+        /// <summary>
+        /// Containers Chromium decodes on a stock Windows install. Deliberately narrow: .mkv/.avi/
+        /// .wmv/.mov are LibVLC's, and a browser attempt on them would only ever cost a fallback.
+        /// </summary>
+        private static readonly string[] BrowserExtensions = { ".mp4", ".m4v", ".webm" };
+
+        public static bool IsBrowserExtension(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            try
+            {
+                var ext = Path.GetExtension(path).ToLowerInvariant();
+                return Array.IndexOf(BrowserExtensions, ext) >= 0;
+            }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// True when the mandatory-video pipeline should hand this clip to
+        /// <see cref="BrowserVideoEngine"/> instead of LibVLC. Never throws - any doubt routes to
+        /// LibVLC, which is the shipped path.
+        /// </summary>
+        public static bool ShouldUseBrowser(string? path)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(path)) return false;
+                if (App.Settings?.Current?.BrowserVideoEngineEnabled != true) return false;
+                if (!IsBrowserExtension(path)) return false;
+                // Touching Instance also kicks off the shared environment build on first use, so a
+                // later video finds IsAvailable already settled.
+                if (!BrowserVideoEngine.Instance.IsAvailable) return false;
+                // A file the page cannot serve (outside every mapped virtual host) would 404 and
+                // cost a pointless fallback, so it is decided here rather than at runtime.
+                if (BrowserVideoEngine.BuildPageUrl(path) == null) return false;
+                if (BrowserUnsafeVideoCache.Contains(path)) return false;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrowserVideoGate.ShouldUseBrowser threw ({E}) - routing to LibVLC", ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoGate.cs
@@ -28,6 +28,26 @@ namespace ConditioningControlPanel.Services.Video.Browser
         }
 
         /// <summary>
+        /// True when the browser engine is switched on and healthy - i.e. a video whose path is not
+        /// chosen yet MIGHT play out-of-process. Only for callers that have to decide something
+        /// BEFORE selection (BubbleCountService's poison-cooldown skip); the per-file answer is
+        /// <see cref="ShouldUseBrowser"/>, and the host re-checks it once the file is known.
+        /// </summary>
+        public static bool IsEngineUsable()
+        {
+            try
+            {
+                if (App.Settings?.Current?.BrowserVideoEngineEnabled != true) return false;
+                return BrowserVideoEngine.Instance.IsAvailable;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrowserVideoGate.IsEngineUsable threw ({E}) - assuming LibVLC", ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
         /// True when the mandatory-video pipeline should hand this clip to
         /// <see cref="BrowserVideoEngine"/> instead of LibVLC. Never throws - any doubt routes to
         /// LibVLC, which is the shipped path.

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoSurface.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>
+    /// A WebView2 running the player page (<c>https://ccp.game/player/index.html</c>) plus the JSON
+    /// bridge from docs/BROWSER_VIDEO_ENGINE_PLAN.md §3, as a plain WPF element that any host can
+    /// drop into its own visual tree.
+    ///
+    /// Two hosts use it:
+    ///   * <see cref="BrowserVideoWindow"/> - one per monitor, owned by <see cref="BrowserVideoEngine"/>,
+    ///     for mandatory videos (Stage 1).
+    ///   * <c>BubbleCountWindow</c> - inside the game window itself, so the counting HUD, the strict
+    ///     lock and the ESC handling keep working exactly as they do over a VideoView (Stage 2).
+    ///
+    /// HARD RULE (plan §8): the hosting window must keep <c>AllowsTransparency = false</c> and
+    /// nothing may ever call <c>SetLayeredWindowAttributes</c> on it - a WebView2 does not paint at
+    /// all inside a layered window, and the constant-alpha path turns the content solid black.
+    ///
+    /// Outbound JSON is QUEUED until the page posts <c>ready</c>, exactly like
+    /// <see cref="ChaosWebViewHost"/>; the page itself queues nothing.
+    /// </summary>
+    internal sealed class BrowserVideoSurface : Grid
+    {
+        private readonly string _tag;
+        private readonly List<string> _pending = new();   // JSON held until the page says 'ready'
+        private WebView2? _web;
+        private string _navHost = "ccp.game";
+        private bool _initStarted;
+        private bool _disposed;
+
+        /// <summary>True once the page has completed its handshake and the queue has been flushed.</summary>
+        public bool IsReady { get; private set; }
+
+        /// <summary>Every page message except the built-in <c>ready</c>/<c>log</c> handling.</summary>
+        public event Action<BrowserVideoSurface, JObject>? Message;
+
+        /// <summary>The browser or renderer process died. Hosts treat this as a session failure
+        /// (never as the file's fault - see the plan §4).</summary>
+        public event Action<BrowserVideoSurface, CoreWebView2ProcessFailedKind>? ProcessFailed;
+
+        /// <summary>Raised on the UI thread once the page posts <c>ready</c>.</summary>
+        public event Action<BrowserVideoSurface>? Ready;
+
+        public BrowserVideoSurface(string tag)
+        {
+            _tag = tag;
+            Background = Brushes.Black;
+            _web = new WebView2
+            {
+                DefaultBackgroundColor = System.Drawing.Color.Black,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+            };
+            Children.Add(_web);
+        }
+
+        /// <summary>
+        /// Build the CoreWebView2 and navigate. MUST be called once the surface is in the visual tree
+        /// of a shown window - EnsureCoreWebView2Async does nothing before that.
+        /// </summary>
+        public async Task InitAsync(
+            CoreWebView2Environment env,
+            IReadOnlyList<(string Host, string Folder, CoreWebView2HostResourceAccessKind Access)> mappings,
+            string startUrl,
+            string primaryHost)
+        {
+            if (_initStarted || _web == null || _disposed) return;
+            _initStarted = true;
+            try
+            {
+                await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
+                if (_disposed || _web?.CoreWebView2 == null)
+                {
+                    if (!_disposed) App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 core null after Ensure", _tag);
+                    return;
+                }
+
+                var core = _web.CoreWebView2;
+                var s = core.Settings;
+                s.AreDevToolsEnabled = false;
+                s.AreDefaultContextMenusEnabled = false;
+                s.IsStatusBarEnabled = false;
+                // Second lock on F5/Ctrl+R/F11 etc; the page preventDefaults them too.
+                s.AreBrowserAcceleratorKeysEnabled = false;
+                s.IsZoomControlEnabled = false;
+                s.IsBuiltInErrorPageEnabled = false;
+                s.IsWebMessageEnabled = true;
+
+                foreach (var (host, folder, access) in mappings)
+                {
+                    // A mapping whose folder does not exist is SILENTLY SKIPPED by WebView2, which
+                    // shows up much later as a 404 on the video. The engine creates them first.
+                    if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+                    {
+                        App.Logger?.Warning("BrowserVideo[{Tag}]: virtual host {Host} folder missing: {Folder}",
+                            _tag, host, folder);
+                        continue;
+                    }
+                    core.SetVirtualHostNameToFolderMapping(host, folder, access);
+                }
+
+                core.NavigationStarting += OnNavigationStarting;
+                core.WebMessageReceived += OnWebMessageReceived;
+                core.ProcessFailed += OnCoreProcessFailed;
+                _navHost = primaryHost;
+
+                core.Navigate(startUrl);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("BrowserVideo[{Tag}]: InitAsync failed: {E}", _tag, ex.Message);
+            }
+        }
+
+        /// <summary>Give the page keyboard focus so its keydown handler (and therefore the
+        /// <c>{type:'key'}</c> bridge) actually runs. Best-effort; never throws.</summary>
+        public void FocusWeb()
+        {
+            try { _web?.Focus(); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].FocusWeb: {E}", _tag, ex.Message); }
+        }
+
+        /// <summary>Post a message to the page; queued until the page's <c>ready</c> handshake.</summary>
+        public void Post(object msg)
+        {
+            try
+            {
+                var json = Newtonsoft.Json.JsonConvert.SerializeObject(msg);
+                if (IsReady && _web?.CoreWebView2 != null)
+                    _web.CoreWebView2.PostWebMessageAsJson(json);
+                else
+                    _pending.Add(json);
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].Post: {E}", _tag, ex.Message); }
+        }
+
+        private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            // Only ever our local page (defence in depth - the page never navigates).
+            if (string.IsNullOrEmpty(e.Uri) ||
+                !e.Uri.StartsWith("https://" + _navHost + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void OnCoreProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        {
+            App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 process failed ({Kind})", _tag, e.ProcessFailedKind);
+            try { ProcessFailed?.Invoke(this, e.ProcessFailedKind); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: ProcessFailed handler threw: {E}", _tag, ex.Message); }
+        }
+
+        private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            // NOTHING in here may block or go modal: this runs inside the browser's message loop.
+            try
+            {
+                var json = e.WebMessageAsJson;
+                if (string.IsNullOrEmpty(json)) return;
+                var o = JObject.Parse(json);
+                switch ((string?)o["type"])
+                {
+                    case "ready":
+                        IsReady = true;
+                        FlushPending();
+                        try { Ready?.Invoke(this); }
+                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: Ready handler threw: {E}", _tag, ex.Message); }
+                        break;
+                    case "log":
+                        // Information, not Debug: the global logger floor is Information and page
+                        // logs are the only devtools-less window into the player page.
+                        App.Logger?.Information("BrowserVideo[{Tag}][page]: {Msg}", _tag, (string?)o["msg"]);
+                        break;
+                    default:
+                        try { Message?.Invoke(this, o); }
+                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: message handler threw: {E}", _tag, ex.Message); }
+                        break;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].OnWebMessageReceived: {E}", _tag, ex.Message); }
+        }
+
+        private void FlushPending()
+        {
+            if (_web?.CoreWebView2 == null) return;
+            foreach (var json in _pending)
+            {
+                try { _web.CoreWebView2.PostWebMessageAsJson(json); } catch { }
+            }
+            _pending.Clear();
+        }
+
+        /// <summary>Unhook + dispose the WebView2. Idempotent; the host calls it from its own close
+        /// path (closing the window alone would leave the browser process alive).</summary>
+        public void DisposeWeb()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                if (_web?.CoreWebView2 != null)
+                {
+                    _web.CoreWebView2.NavigationStarting -= OnNavigationStarting;
+                    _web.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
+                    _web.CoreWebView2.ProcessFailed -= OnCoreProcessFailed;
+                }
+            }
+            catch { }
+            try { _web?.Dispose(); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: WebView2 dispose failed: {E}", _tag, ex.Message); }
+            _web = null;
+            IsReady = false;
+            _pending.Clear();
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+using Newtonsoft.Json.Linq;
+using Screen = System.Windows.Forms.Screen;
+
+namespace ConditioningControlPanel.Services.Video.Browser
+{
+    /// <summary>
+    /// One fullscreen, borderless, topmost, OPAQUE window per monitor hosting the player page
+    /// (<c>https://ccp.game/player/index.html</c>) in a WebView2. The mandatory-video surface for the
+    /// browser engine; the LibVLC equivalent is <c>VideoService.CreateLibVLCVideoWindow</c>.
+    ///
+    /// HARD RULES (see docs/BROWSER_VIDEO_ENGINE_PLAN.md §8):
+    ///   * <c>AllowsTransparency</c> stays FALSE - a WebView2 does not paint at all inside a layered
+    ///     window.
+    ///   * NOTHING may ever call <c>SetLayeredWindowAttributes</c> on this window - the constant-alpha
+    ///     path turns the Chromium content solid black (reproduced live on the FYP feed, 2026-08-03).
+    ///
+    /// Message bridge: outbound JSON is QUEUED until the page posts <c>ready</c>, exactly like
+    /// <see cref="ChaosWebViewHost"/>; the page itself queues nothing.
+    /// </summary>
+    internal sealed class BrowserVideoWindow : Window
+    {
+        private readonly Screen _screen;
+        private readonly string _tag;
+        private readonly List<string> _pending = new();   // JSON held until the page says 'ready'
+        private WebView2? _web;
+        private bool _initStarted;
+        private bool _disposed;
+
+        /// <summary>True for the audio-bearing window (one per session). Secondaries load muted.</summary>
+        public bool IsPrimary { get; }
+
+        /// <summary>True once the page has completed its handshake and the queue has been flushed.</summary>
+        public bool IsReady { get; private set; }
+
+        /// <summary>Every page message except the built-in <c>ready</c>/<c>log</c> handling.</summary>
+        public event Action<BrowserVideoWindow, JObject>? Message;
+
+        /// <summary>The browser or renderer process died. The engine treats this as a session failure
+        /// (never as the file's fault - see the plan §4).</summary>
+        public event Action<BrowserVideoWindow, CoreWebView2ProcessFailedKind>? ProcessFailed;
+
+        /// <summary>Raised on the UI thread once the page posts <c>ready</c>.</summary>
+        public event Action<BrowserVideoWindow>? Ready;
+
+        public BrowserVideoWindow(Screen screen, bool primary)
+        {
+            _screen = screen;
+            IsPrimary = primary;
+            _tag = primary ? "primary" : "secondary";
+
+            var dpiScale = BubbleCountWindow.GetDpiForScreen(screen);
+
+            AllowsTransparency = false;   // WebView2 never paints in a layered window - see class comment
+            WindowStyle = WindowStyle.None;
+            ResizeMode = ResizeMode.NoResize;
+            ShowInTaskbar = false;
+            // The audio-bearing window takes focus ONCE at show (same as the LibVLC primary), which
+            // is what lets the page see keydown at all - keyboard over a focused WebView2 goes to
+            // Chromium, so the page's {type:'key'} reports are the only route ESC/panic have back to
+            // C#. The host stamps WS_EX_NOACTIVATE straight after, so the window can never RE-raise
+            // itself over the attention targets / chaos layer afterwards.
+            ShowActivated = primary;
+            Topmost = true;
+            Background = Brushes.Black;
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            // Full screen bounds up front (no start-small-then-maximize white frame, #368). The DIP
+            // math below is only correct on the creation monitor; PinToScreen fixes mixed DPI.
+            Left = screen.Bounds.X / dpiScale;
+            Top = screen.Bounds.Y / dpiScale;
+            Width = screen.Bounds.Width / dpiScale;
+            Height = screen.Bounds.Height / dpiScale;
+
+            _web = new WebView2
+            {
+                DefaultBackgroundColor = System.Drawing.Color.Black,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+            };
+            var grid = new Grid { Background = Brushes.Black };
+            grid.Children.Add(_web);
+            Content = grid;
+
+            PinToScreen();
+        }
+
+        /// <summary>
+        /// Pins the window to the monitor's true PHYSICAL bounds. Mirrors
+        /// <c>VideoService.ForceFullScreenBounds</c>: the app is PerMonitorV2-aware, so DIP bounds set
+        /// before the HWND exists are realized in the CREATION monitor's DPI and a secondary monitor
+        /// at a different scale gets a part-width window. SetWindowPos works in real pixels. Applied
+        /// twice because WM_DPICHANGED can resize the window back after the move.
+        /// </summary>
+        private void PinToScreen()
+        {
+            void Apply()
+            {
+                try
+                {
+                    var hwnd = new WindowInteropHelper(this).Handle;
+                    if (hwnd == IntPtr.Zero) return;
+                    var b = _screen.Bounds;
+                    SetWindowPos(hwnd, IntPtr.Zero, b.X, b.Y, b.Width, b.Height, SWP_NOZORDER | SWP_NOACTIVATE);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("BrowserVideoWindow.PinToScreen failed: {E}", ex.Message);
+                }
+            }
+
+            SourceInitialized += (_, _) => Apply();
+            Loaded += (_, _) => Apply();
+        }
+
+        /// <summary>
+        /// Build the CoreWebView2 and navigate. MUST be called after <see cref="Window.Show"/> -
+        /// EnsureCoreWebView2Async only works once the control is in the visual tree.
+        /// </summary>
+        public async Task InitAsync(
+            CoreWebView2Environment env,
+            IReadOnlyList<(string Host, string Folder, CoreWebView2HostResourceAccessKind Access)> mappings,
+            string startUrl,
+            string primaryHost)
+        {
+            if (_initStarted || _web == null || _disposed) return;
+            _initStarted = true;
+            try
+            {
+                await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
+                if (_disposed || _web?.CoreWebView2 == null)
+                {
+                    if (!_disposed) App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 core null after Ensure", _tag);
+                    return;
+                }
+
+                var core = _web.CoreWebView2;
+                var s = core.Settings;
+                s.AreDevToolsEnabled = false;
+                s.AreDefaultContextMenusEnabled = false;
+                s.IsStatusBarEnabled = false;
+                // Second lock on F5/Ctrl+R/F11 etc; the page preventDefaults them too.
+                s.AreBrowserAcceleratorKeysEnabled = false;
+                s.IsZoomControlEnabled = false;
+                s.IsBuiltInErrorPageEnabled = false;
+                s.IsWebMessageEnabled = true;
+
+                foreach (var (host, folder, access) in mappings)
+                {
+                    // A mapping whose folder does not exist is SILENTLY SKIPPED by WebView2, which
+                    // shows up much later as a 404 on the video. The engine creates them first.
+                    if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
+                    {
+                        App.Logger?.Warning("BrowserVideo[{Tag}]: virtual host {Host} folder missing: {Folder}",
+                            _tag, host, folder);
+                        continue;
+                    }
+                    core.SetVirtualHostNameToFolderMapping(host, folder, access);
+                }
+
+                core.NavigationStarting += OnNavigationStarting;
+                core.WebMessageReceived += OnWebMessageReceived;
+                core.ProcessFailed += OnCoreProcessFailed;
+                _navHost = primaryHost;
+
+                core.Navigate(startUrl);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("BrowserVideo[{Tag}]: InitAsync failed: {E}", _tag, ex.Message);
+            }
+        }
+
+        private string _navHost = "ccp.game";
+
+        /// <summary>Give the page keyboard focus so its keydown handler (and therefore the
+        /// <c>{type:'key'}</c> bridge) actually runs. Best-effort; never throws.</summary>
+        public void FocusWeb()
+        {
+            try
+            {
+                Activate();
+                _web?.Focus();
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].FocusWeb: {E}", _tag, ex.Message); }
+        }
+
+        /// <summary>Post a message to the page; queued until the page's <c>ready</c> handshake.</summary>
+        public void Post(object msg)
+        {
+            try
+            {
+                var json = Newtonsoft.Json.JsonConvert.SerializeObject(msg);
+                if (IsReady && _web?.CoreWebView2 != null)
+                    _web.CoreWebView2.PostWebMessageAsJson(json);
+                else
+                    _pending.Add(json);
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].Post: {E}", _tag, ex.Message); }
+        }
+
+        private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            // Only ever our local page (defence in depth - the page never navigates).
+            if (string.IsNullOrEmpty(e.Uri) ||
+                !e.Uri.StartsWith("https://" + _navHost + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void OnCoreProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        {
+            App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 process failed ({Kind})", _tag, e.ProcessFailedKind);
+            try { ProcessFailed?.Invoke(this, e.ProcessFailedKind); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: ProcessFailed handler threw: {E}", _tag, ex.Message); }
+        }
+
+        private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            // NOTHING in here may block or go modal: this runs inside the browser's message loop.
+            try
+            {
+                var json = e.WebMessageAsJson;
+                if (string.IsNullOrEmpty(json)) return;
+                var o = JObject.Parse(json);
+                switch ((string?)o["type"])
+                {
+                    case "ready":
+                        IsReady = true;
+                        FlushPending();
+                        try { Ready?.Invoke(this); }
+                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: Ready handler threw: {E}", _tag, ex.Message); }
+                        break;
+                    case "log":
+                        // Information, not Debug: the global logger floor is Information and page
+                        // logs are the only devtools-less window into the player page.
+                        App.Logger?.Information("BrowserVideo[{Tag}][page]: {Msg}", _tag, (string?)o["msg"]);
+                        break;
+                    default:
+                        try { Message?.Invoke(this, o); }
+                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: message handler threw: {E}", _tag, ex.Message); }
+                        break;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].OnWebMessageReceived: {E}", _tag, ex.Message); }
+        }
+
+        private void FlushPending()
+        {
+            if (_web?.CoreWebView2 == null) return;
+            foreach (var json in _pending)
+            {
+                try { _web.CoreWebView2.PostWebMessageAsJson(json); } catch { }
+            }
+            _pending.Clear();
+        }
+
+        /// <summary>Unhook + dispose the WebView2. Runs on Close() too, so the shared teardown funnel
+        /// (VideoService.CloseAll closes every window in its list) is enough to end a session cleanly.</summary>
+        protected override void OnClosed(EventArgs e)
+        {
+            DisposeWeb();
+            base.OnClosed(e);
+        }
+
+        private void DisposeWeb()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                if (_web?.CoreWebView2 != null)
+                {
+                    _web.CoreWebView2.NavigationStarting -= OnNavigationStarting;
+                    _web.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
+                    _web.CoreWebView2.ProcessFailed -= OnCoreProcessFailed;
+                }
+            }
+            catch { }
+            try { _web?.Dispose(); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: WebView2 dispose failed: {E}", _tag, ex.Message); }
+            _web = null;
+            IsReady = false;
+            _pending.Clear();
+        }
+
+        private const uint SWP_NOZORDER = 0x0004;
+        private const uint SWP_NOACTIVATE = 0x0010;
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
 using Microsoft.Web.WebView2.Core;
-using Microsoft.Web.WebView2.Wpf;
 using Newtonsoft.Json.Linq;
 using Screen = System.Windows.Forms.Screen;
 
@@ -24,23 +21,21 @@ namespace ConditioningControlPanel.Services.Video.Browser
     ///   * NOTHING may ever call <c>SetLayeredWindowAttributes</c> on this window - the constant-alpha
     ///     path turns the Chromium content solid black (reproduced live on the FYP feed, 2026-08-03).
     ///
-    /// Message bridge: outbound JSON is QUEUED until the page posts <c>ready</c>, exactly like
-    /// <see cref="ChaosWebViewHost"/>; the page itself queues nothing.
+    /// Everything WebView2-shaped (the control, the bridge, the outbound queue) lives in
+    /// <see cref="BrowserVideoSurface"/>, which BubbleCount hosts inside its own game window; this
+    /// class is only the fullscreen chrome around one.
     /// </summary>
     internal sealed class BrowserVideoWindow : Window
     {
         private readonly Screen _screen;
         private readonly string _tag;
-        private readonly List<string> _pending = new();   // JSON held until the page says 'ready'
-        private WebView2? _web;
-        private bool _initStarted;
-        private bool _disposed;
+        private readonly BrowserVideoSurface _surface;
 
         /// <summary>True for the audio-bearing window (one per session). Secondaries load muted.</summary>
         public bool IsPrimary { get; }
 
         /// <summary>True once the page has completed its handshake and the queue has been flushed.</summary>
-        public bool IsReady { get; private set; }
+        public bool IsReady => _surface.IsReady;
 
         /// <summary>Every page message except the built-in <c>ready</c>/<c>log</c> handling.</summary>
         public event Action<BrowserVideoWindow, JObject>? Message;
@@ -80,15 +75,11 @@ namespace ConditioningControlPanel.Services.Video.Browser
             Width = screen.Bounds.Width / dpiScale;
             Height = screen.Bounds.Height / dpiScale;
 
-            _web = new WebView2
-            {
-                DefaultBackgroundColor = System.Drawing.Color.Black,
-                HorizontalAlignment = HorizontalAlignment.Stretch,
-                VerticalAlignment = VerticalAlignment.Stretch,
-            };
-            var grid = new Grid { Background = Brushes.Black };
-            grid.Children.Add(_web);
-            Content = grid;
+            _surface = new BrowserVideoSurface(_tag);
+            _surface.Message += (_, o) => Message?.Invoke(this, o);
+            _surface.ProcessFailed += (_, kind) => ProcessFailed?.Invoke(this, kind);
+            _surface.Ready += _ => Ready?.Invoke(this);
+            Content = _surface;
 
             PinToScreen();
         }
@@ -125,172 +116,31 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// Build the CoreWebView2 and navigate. MUST be called after <see cref="Window.Show"/> -
         /// EnsureCoreWebView2Async only works once the control is in the visual tree.
         /// </summary>
-        public async Task InitAsync(
+        public Task InitAsync(
             CoreWebView2Environment env,
             IReadOnlyList<(string Host, string Folder, CoreWebView2HostResourceAccessKind Access)> mappings,
             string startUrl,
             string primaryHost)
-        {
-            if (_initStarted || _web == null || _disposed) return;
-            _initStarted = true;
-            try
-            {
-                await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
-                if (_disposed || _web?.CoreWebView2 == null)
-                {
-                    if (!_disposed) App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 core null after Ensure", _tag);
-                    return;
-                }
-
-                var core = _web.CoreWebView2;
-                var s = core.Settings;
-                s.AreDevToolsEnabled = false;
-                s.AreDefaultContextMenusEnabled = false;
-                s.IsStatusBarEnabled = false;
-                // Second lock on F5/Ctrl+R/F11 etc; the page preventDefaults them too.
-                s.AreBrowserAcceleratorKeysEnabled = false;
-                s.IsZoomControlEnabled = false;
-                s.IsBuiltInErrorPageEnabled = false;
-                s.IsWebMessageEnabled = true;
-
-                foreach (var (host, folder, access) in mappings)
-                {
-                    // A mapping whose folder does not exist is SILENTLY SKIPPED by WebView2, which
-                    // shows up much later as a 404 on the video. The engine creates them first.
-                    if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder))
-                    {
-                        App.Logger?.Warning("BrowserVideo[{Tag}]: virtual host {Host} folder missing: {Folder}",
-                            _tag, host, folder);
-                        continue;
-                    }
-                    core.SetVirtualHostNameToFolderMapping(host, folder, access);
-                }
-
-                core.NavigationStarting += OnNavigationStarting;
-                core.WebMessageReceived += OnWebMessageReceived;
-                core.ProcessFailed += OnCoreProcessFailed;
-                _navHost = primaryHost;
-
-                core.Navigate(startUrl);
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning("BrowserVideo[{Tag}]: InitAsync failed: {E}", _tag, ex.Message);
-            }
-        }
-
-        private string _navHost = "ccp.game";
+            => _surface.InitAsync(env, mappings, startUrl, primaryHost);
 
         /// <summary>Give the page keyboard focus so its keydown handler (and therefore the
         /// <c>{type:'key'}</c> bridge) actually runs. Best-effort; never throws.</summary>
         public void FocusWeb()
         {
-            try
-            {
-                Activate();
-                _web?.Focus();
-            }
+            try { Activate(); }
             catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].FocusWeb: {E}", _tag, ex.Message); }
+            _surface.FocusWeb();
         }
 
         /// <summary>Post a message to the page; queued until the page's <c>ready</c> handshake.</summary>
-        public void Post(object msg)
-        {
-            try
-            {
-                var json = Newtonsoft.Json.JsonConvert.SerializeObject(msg);
-                if (IsReady && _web?.CoreWebView2 != null)
-                    _web.CoreWebView2.PostWebMessageAsJson(json);
-                else
-                    _pending.Add(json);
-            }
-            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].Post: {E}", _tag, ex.Message); }
-        }
-
-        private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
-        {
-            // Only ever our local page (defence in depth - the page never navigates).
-            if (string.IsNullOrEmpty(e.Uri) ||
-                !e.Uri.StartsWith("https://" + _navHost + "/", StringComparison.OrdinalIgnoreCase))
-            {
-                e.Cancel = true;
-            }
-        }
-
-        private void OnCoreProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
-        {
-            App.Logger?.Warning("BrowserVideo[{Tag}]: WebView2 process failed ({Kind})", _tag, e.ProcessFailedKind);
-            try { ProcessFailed?.Invoke(this, e.ProcessFailedKind); }
-            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: ProcessFailed handler threw: {E}", _tag, ex.Message); }
-        }
-
-        private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
-        {
-            // NOTHING in here may block or go modal: this runs inside the browser's message loop.
-            try
-            {
-                var json = e.WebMessageAsJson;
-                if (string.IsNullOrEmpty(json)) return;
-                var o = JObject.Parse(json);
-                switch ((string?)o["type"])
-                {
-                    case "ready":
-                        IsReady = true;
-                        FlushPending();
-                        try { Ready?.Invoke(this); }
-                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: Ready handler threw: {E}", _tag, ex.Message); }
-                        break;
-                    case "log":
-                        // Information, not Debug: the global logger floor is Information and page
-                        // logs are the only devtools-less window into the player page.
-                        App.Logger?.Information("BrowserVideo[{Tag}][page]: {Msg}", _tag, (string?)o["msg"]);
-                        break;
-                    default:
-                        try { Message?.Invoke(this, o); }
-                        catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: message handler threw: {E}", _tag, ex.Message); }
-                        break;
-                }
-            }
-            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}].OnWebMessageReceived: {E}", _tag, ex.Message); }
-        }
-
-        private void FlushPending()
-        {
-            if (_web?.CoreWebView2 == null) return;
-            foreach (var json in _pending)
-            {
-                try { _web.CoreWebView2.PostWebMessageAsJson(json); } catch { }
-            }
-            _pending.Clear();
-        }
+        public void Post(object msg) => _surface.Post(msg);
 
         /// <summary>Unhook + dispose the WebView2. Runs on Close() too, so the shared teardown funnel
         /// (VideoService.CloseAll closes every window in its list) is enough to end a session cleanly.</summary>
         protected override void OnClosed(EventArgs e)
         {
-            DisposeWeb();
+            _surface.DisposeWeb();
             base.OnClosed(e);
-        }
-
-        private void DisposeWeb()
-        {
-            if (_disposed) return;
-            _disposed = true;
-            try
-            {
-                if (_web?.CoreWebView2 != null)
-                {
-                    _web.CoreWebView2.NavigationStarting -= OnNavigationStarting;
-                    _web.CoreWebView2.WebMessageReceived -= OnWebMessageReceived;
-                    _web.CoreWebView2.ProcessFailed -= OnCoreProcessFailed;
-                }
-            }
-            catch { }
-            try { _web?.Dispose(); }
-            catch (Exception ex) { App.Logger?.Debug("BrowserVideo[{Tag}]: WebView2 dispose failed: {E}", _tag, ex.Message); }
-            _web = null;
-            IsReady = false;
-            _pending.Clear();
         }
 
         private const uint SWP_NOZORDER = 0x0004;

--- a/ConditioningControlPanel/Services/Video/VideoMetadataCache.cs
+++ b/ConditioningControlPanel/Services/Video/VideoMetadataCache.cs
@@ -125,6 +125,28 @@ namespace ConditioningControlPanel.Services
             }
         }
 
+        /// <summary>
+        /// Record a duration learned WITHOUT a LibVLC parse — the browser video engine's page
+        /// <c>meta</c> message. Every browser session therefore warms the selection-time duration
+        /// filter for free. Ignores non-positive durations (the page reports 0 for "unknowable")
+        /// and never throws.
+        /// </summary>
+        public void StoreDuration(string path, double seconds)
+        {
+            if (seconds <= 0) return;
+            try
+            {
+                var key = ComputeKey(path);
+                if (key == null) return;
+                if (_byKey.TryGetValue(key, out var existing) && Math.Abs(existing - seconds) < 0.5) return;
+                _byKey[key] = seconds;
+                _unparseable.TryRemove(key, out _);
+                _dirty = true;
+                ScheduleSave();
+            }
+            catch (Exception ex) { App.Logger?.Debug("VideoMetadataCache: StoreDuration failed for {Path}: {Error}", path, ex.Message); }
+        }
+
         private async Task<double?> ParseDurationAsync(string path, string key)
         {
             Media? media = null;

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -42,6 +42,15 @@ namespace ConditioningControlPanel.Services
         /// <summary>VideoStarted fires on the page's first real <c>playing</c>, not at window-show:
         /// a session that never reaches a frame falls back to LibVLC, which fires it instead.</summary>
         private bool _browserStartedFired;
+        /// <summary>The chaos random-segment jump is ONE seek per session. <c>meta</c> can arrive
+        /// twice (Infinity at loadedmetadata, the real value at durationchange) and a second seek
+        /// would yank the user back mid-clip.</summary>
+        private bool _browserSegmentSeeked;
+
+        /// <summary>True while a browser video session owns the screen. Read by AudioService so the
+        /// duck sweep never lowers the app's OWN video audio (LibVLC audio is in-process and
+        /// structurally un-duckable, so this is what keeps the two engines at parity).</summary>
+        public bool IsBrowserSessionActive => _browserActive;
 
         private BrowserVideoEngine Browser
         {
@@ -86,6 +95,7 @@ namespace ConditioningControlPanel.Services
                 _browserGeneration = _teardownGeneration;
                 _browserFallbackDone = false;
                 _browserStartedFired = false;
+                _browserSegmentSeeked = false;
 
                 // Chaos random-segment mode: the LibVLC path seeks from LengthChanged, but the page
                 // takes a start offset directly. The fraction needs the duration, which only arrives
@@ -98,6 +108,10 @@ namespace ConditioningControlPanel.Services
                     Volume = GetEffectiveVolume() / 100.0,
                     Muted = GetEffectiveVolume() <= 0,
                     BlurBackground = App.Settings?.Current?.VideoBlurredBackgroundEnabled == true,
+                    // Parity with the LibVLC video windows, which do NOT hide the pointer: a video
+                    // that swallows the cursor while the rest of the app still shows one reads as a
+                    // frozen machine, and attention targets are clicked over this surface.
+                    HideCursor = false,
                     IsHostPaused = () => _gracePaused,
                     ConfigureBeforeShow = (win, _, _) =>
                     {
@@ -109,10 +123,13 @@ namespace ConditioningControlPanel.Services
                     },
                     ConfigureAfterShow = (win, _, _) =>
                     {
-                        // Non-activating so the WebView2 never takes focus away from the app's own
-                        // key handling, and so a click on the video can't raise it over the
-                        // attention targets / chaos layer. Both need a realized HWND.
-                        MakeNonActivating(win);
+                        // EXACT parity with the LibVLC path (StartVideoPlayback): WS_EX_NOACTIVATE is
+                        // stamped ONLY during a chaos run, where the game layer must keep z-order.
+                        // Outside chaos the always-on PreventClickRaise is what stops a click from
+                        // raising the video, and the window keeps focus - which the WebView2 needs,
+                        // because ESC / panic keys only reach C# through the page's {type:'key'}
+                        // reports and a page that never gets a keydown reports nothing.
+                        if (App.Chaos?.IsRunning == true) MakeNonActivating(win);
                         PreventClickRaise(win);
                     },
                 };
@@ -136,6 +153,14 @@ namespace ConditioningControlPanel.Services
                 // something. NO wedge watchdog - nothing native can wedge the dispatcher here.
                 _playbackStarted = true;
 
+                // PlayVideo's prologue armed the wedge ladder before routing was decided, and
+                // _playbackStarted = true above would unlock its DESTRUCTIVE rungs (off-thread
+                // player Stop, RetireSharedLibVLC, the _wedgeStallSeen veto stand-down) for a
+                // session that owns no native player at all. Disarm it here; a UI stall during a
+                // browser video must trigger nothing. FallbackToLibVlc re-arms it before it hands
+                // the clip to LibVLC, and WedgeWatchdogTick also no-ops while _browserActive.
+                StopWedgeWatchdog();
+
                 App.Bubbles?.PauseAndClear();
                 if (App.Settings.Current.AttentionChecksEnabled) SetupAttention();
 
@@ -145,8 +170,40 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "VideoService: browser session start threw - falling back to LibVLC");
-                try { StopBrowserSession(); } catch { }
+                // NOT a bare StopBrowserSession(): _videoPlaying is still true here, so the strict
+                // Closing veto would refuse to close the windows this throw is trying to clean up
+                // and strand fullscreen surfaces on screen forever. Same clear/restore dance as the
+                // runtime fallback, strict bridge included.
+                try { StopBrowserSessionForHandoff(); } catch { }
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// Close the browser surfaces while the run CONTINUES (start-path throw, runtime fallback) -
+        /// i.e. everywhere the windows must go but <see cref="_videoPlaying"/> must stay true for the
+        /// LibVLC attempt that follows.
+        ///
+        /// Two things have to be true at once for that: the strict Closing veto
+        /// (<c>SetupStrictHandlers</c>) refuses a close while <c>_videoPlaying</c> is set and no
+        /// teardown is running, so the flag is cleared across the close; and
+        /// <see cref="IsStrictActive"/> is <c>(_videoPlaying &amp;&amp; _strictActive) || _strictRetryPending</c>,
+        /// so clearing it would make a strict session look non-strict for the duration - exactly the
+        /// gap <see cref="_strictRetryPending"/> exists to bridge for ShowMessage. Bridge it the same way.
+        /// </summary>
+        private void StopBrowserSessionForHandoff()
+        {
+            var wasPlaying = _videoPlaying;
+            var wasRetryPending = _strictRetryPending;
+            bool bridgeStrict = wasPlaying && _strictActive;
+
+            if (bridgeStrict) _strictRetryPending = true;
+            _videoPlaying = false;
+            try { StopBrowserSession(); }
+            finally
+            {
+                _videoPlaying = wasPlaying;
+                if (bridgeStrict) _strictRetryPending = wasRetryPending;
             }
         }
 
@@ -177,10 +234,15 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// The runtime half of the hybrid contract (plan §4): the page could not play this file, so
-        /// replay it through LibVLC exactly once, silently. No VideoEnded is raised - as far as every
-        /// consumer is concerned this is still the same video run, and the duck ref taken in
-        /// PlayVideo is deliberately kept so CloseAll still balances it exactly once.
+        /// The runtime half of the hybrid contract (plan §4): the page could not play this file.
+        ///
+        /// PRE-START failures only (error 101 before the first frame, ProcessFailed, environment
+        /// failure, a throw on the start path) replay the clip through LibVLC exactly once, silently.
+        /// No VideoEnded is raised - as far as every consumer is concerned this is still the same
+        /// video run, and the duck ref taken in PlayVideo is deliberately kept so CloseAll still
+        /// balances it exactly once.
+        ///
+        /// A failure AFTER playback genuinely started is NOT replayed: see the branch below.
         /// </summary>
         private void FallbackToLibVlc(string reason)
         {
@@ -189,16 +251,30 @@ namespace ConditioningControlPanel.Services
 
             var path = _browserPath;
             var strict = _browserStrict;
+
+            // ---- mid-clip failure: end the run, never replay it ----
+            // VideoStarted has already gone out to seven subscribers; a replay would fire it a
+            // second time and make the user rewatch the whole clip from 0 for a stall at the end.
+            // The engine has already marked the file browser-unsafe when it blamed the file, so the
+            // NEXT play of it routes to LibVLC anyway. Mirrors BubbleCountWindow's startedOnce
+            // branch: end through the same funnel a natural end uses, so it is one VideoEnded and
+            // EndCurrentVideo's normal attention pass/fail handling.
+            if (_browserStartedFired)
+            {
+                App.Logger?.Warning("VideoService: browser playback failed MID-CLIP for {File} ({Reason}) - ending the video instead of replaying it",
+                    Path.GetFileName(path ?? "(none)"), reason);
+                VideoDiag.Log("VIDEO", $"browser MID-CLIP FAILURE ({reason}) - ending {Path.GetFileName(path ?? "?")} through the normal end funnel");
+                OnEnded();
+                return;
+            }
+
             App.Logger?.Warning("VideoService: browser playback failed for {File} ({Reason}) - replaying via LibVLC",
                 Path.GetFileName(path ?? "(none)"), reason);
             VideoDiag.Log("VIDEO", $"browser FALLBACK ({reason}) - replaying {Path.GetFileName(path ?? "?")} via LibVLC");
 
-            // The strict Closing veto refuses a close while _videoPlaying is true and no teardown is
-            // running, which would strand the browser windows on screen. Same trick ShowMessage uses.
-            var wasPlaying = _videoPlaying;
-            _videoPlaying = false;
-            try { StopBrowserSession(); }
-            finally { _videoPlaying = wasPlaying; }
+            // Drops the surfaces without letting the strict Closing veto strand them, and without
+            // letting IsStrictActive blink false across the handoff.
+            StopBrowserSessionForHandoff();
 
             if (string.IsNullOrEmpty(path) || _isCleaningUp) { Cleanup(); return; }
 
@@ -217,6 +293,14 @@ namespace ConditioningControlPanel.Services
             _lastWatchPositionMs = 0;
             _creditedWatchSeconds = 0;
             _startTime = DateTime.Now;
+
+            // Handing the clip to LibVLC means the wedge ladder matters again, and it is disarmed
+            // (StartBrowserVideoPlayback stopped it). Re-arm it in the pre-roll state PlayVideo's
+            // prologue uses - observation only - so the LibVLC window creation that follows, which
+            // is where the historic freeze strikes, is guarded again. StartVideoPlayback re-arms it
+            // for real once its windows are up.
+            _playbackStarted = false;
+            StartWedgeWatchdog();
 
             StartVideoPlayback(path, strict, forceLibVlc: true);
         }
@@ -265,7 +349,11 @@ namespace ConditioningControlPanel.Services
             // play, with no LibVLC parse (and no preparse crash surface, #750-#753).
             try
             {
-                if (!string.IsNullOrEmpty(_browserPath)) MetadataCache?.StoreDuration(_browserPath!, _duration);
+                // NOT for content-pack clips: those live at a fresh ccp_temp_<GUID> path per play, so
+                // every backfill would add a key that can never be hit again and video_metadata.json
+                // would grow without bound.
+                if (!string.IsNullOrEmpty(_browserPath) && !IsMediaTempPath(_browserPath))
+                    MetadataCache?.StoreDuration(_browserPath!, _duration);
             }
             catch (Exception ex) { App.Logger?.Debug("VideoService: browser duration backfill failed - {Error}", ex.Message); }
 
@@ -274,11 +362,14 @@ namespace ConditioningControlPanel.Services
             try
             {
                 long segMs = (long)(_segmentSec * 1000);
-                if (SegmentArmed && durationMs > segMs)
+                // One seek per session: meta arrives twice for webm / fragmented mp4 and a second
+                // jump would drag the user back to the segment start mid-clip.
+                if (!_browserSegmentSeeked && SegmentArmed && durationMs > segMs)
                 {
                     long startMs = (long)((durationMs - segMs) * _segmentFraction);
                     if (startMs > 500)
                     {
+                        _browserSegmentSeeked = true;
                         Browser.Seek(startMs);
                         App.Logger?.Information("VideoService: browser random segment - seeking to {Start}s of {Len}s",
                             startMs / 1000, durationMs / 1000);
@@ -288,17 +379,46 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex) { App.Logger?.Debug("VideoService: browser random-segment seek - {Error}", ex.Message); }
         }
 
+        /// <summary>True for a content-pack clip's per-play decrypt path (App.GetMediaTempPath()).
+        /// Those paths are GUIDs that never come back, so nothing may be cached against them.</summary>
+        private static bool IsMediaTempPath(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            try
+            {
+                var root = App.GetMediaTempPath();
+                if (string.IsNullOrEmpty(root)) return false;
+                var rootFull = Path.GetFullPath(root)
+                    .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return Path.GetFullPath(path).StartsWith(rootFull + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch { return false; }
+        }
+
         private void OnBrowserPlaying()
         {
             if (!BrowserEventIsCurrent() || _browserStartedFired) return;
+            // The internal flags are set SYNCHRONOUSLY: the mid-clip-failure branch in
+            // FallbackToLibVlc keys off _browserStartedFired, and it must be true from the instant
+            // the page says it is playing, whether or not the hop below has landed yet.
             _browserStartedFired = true;
 
             VideoDiag.Log("VIDEO", "browser playback confirmed (page reported playing)");
-            VideoStarted?.Invoke(this, EventArgs.Empty);
-            _ = App.Haptics?.StartVideoBackgroundVibeAsync();
-            try { App.Haptics?.FunScript?.OnVideoStarted(_browserPath ?? ""); }
-            catch (Exception ex) { App.Logger?.Debug("FunScript start hook failed: {Error}", ex.Message); }
             App.Logger?.Information("Playing: {File} (browser engine)", Path.GetFileName(_browserPath ?? ""));
+
+            // The RAISE is deferred. This runs inside WebView2's WebMessageReceived callback, and
+            // VideoStarted has seven subscribers (barks, chaos, bouncing text, session log, ...)
+            // that show windows and start their own work - all of it would run nested inside the
+            // browser's message loop. Same discipline as the LibVLC handlers.
+            PostAfterPageMessage(() =>
+            {
+                if (!BrowserEventIsCurrent()) return;
+                VideoStarted?.Invoke(this, EventArgs.Empty);
+                _ = App.Haptics?.StartVideoBackgroundVibeAsync();
+                try { App.Haptics?.FunScript?.OnVideoStarted(_browserPath ?? ""); }
+                catch (Exception ex) { App.Logger?.Debug("FunScript start hook failed: {Error}", ex.Message); }
+            });
         }
 
         private void OnBrowserTime(long ms)
@@ -343,6 +463,18 @@ namespace ConditioningControlPanel.Services
         private void OnBrowserKey(string key, bool alt, bool ctrl, bool shift)
         {
             if (!BrowserEventIsCurrent()) return;
+            // EVERY branch below either shows WPF windows (the grace-pause overlays) or tears the
+            // session down, and this arrives inside WebView2's message callback - so the whole
+            // policy is evaluated one dispatcher hop later, with the liveness re-checked there.
+            // Two rapid ESCs therefore queue two hops, and the second finds the session already
+            // gone rather than running Cleanup a second time (which would re-fire VideoEnded and
+            // release an InteractionQueue slot it no longer owns).
+            PostAfterPageMessage(() => HandleBrowserKey(key));
+        }
+
+        private void HandleBrowserKey(string key)
+        {
+            if (!BrowserEventIsCurrent()) return;
             try
             {
                 var settings = App.Settings?.Current;
@@ -373,7 +505,10 @@ namespace ConditioningControlPanel.Services
                         return;
                     }
                     VideoDiag.Log("PANIC", "ESC received by the browser video page - dismissing via Cleanup");
-                    PostAfterPageMessage(Cleanup);   // teardown must not run inside the page's callback
+                    // Already off the page's callback (see OnBrowserKey), but still guarded: a
+                    // second ESC that raced in behind this one must not run the teardown twice.
+                    if (_browserActive && BrowserEventIsCurrent() && _videoPlaying && !_isCleaningUp)
+                        Cleanup();
                     return;
                 }
 
@@ -385,23 +520,60 @@ namespace ConditioningControlPanel.Services
                         return;
                     }
                     VideoDiag.Log("PANIC", $"panic key '{key}' received by the browser page - ForceCleanup");
-                    PostAfterPageMessage(() => ForceCleanup());
+                    if (_browserActive && BrowserEventIsCurrent() && _videoPlaying && !_isCleaningUp)
+                        ForceCleanup();
                 }
             }
             catch (Exception ex) { App.Logger?.Debug("VideoService: browser key handling failed - {Error}", ex.Message); }
         }
 
         /// <summary>
-        /// The page reports DOM key names ("Escape", "F8", "a", " "); the setting stores a WPF
-        /// <see cref="System.Windows.Input.Key"/> name ("Escape", "F8", "A", "Space"). Function keys,
-        /// Escape and letters line up case-insensitively once Space is translated, which covers every
-        /// panic key a user can actually bind through the settings picker.
+        /// The page reports DOM key values ("Escape", "F8", "a", " ", "7", "."); the setting stores a
+        /// WPF <see cref="System.Windows.Input.Key"/> name ("Escape", "F8", "A", "Space", "D7",
+        /// "OemPeriod"). Function keys, Escape and letters line up case-insensitively; everything
+        /// else needs translating, or a user whose panic key is a digit gets nothing from a focused
+        /// WebView2. The low-level keyboard hook remains the primary route - this is the page's.
         /// </summary>
         private static bool MatchesPanicKey(string pageKey, string? panicKey)
         {
             if (string.IsNullOrEmpty(pageKey) || string.IsNullOrEmpty(panicKey)) return false;
-            var normalized = pageKey == " " ? "Space" : pageKey;
+            var normalized = TranslateDomKey(pageKey);
             return string.Equals(normalized, panicKey, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>DOM <c>KeyboardEvent.key</c> -> WPF <see cref="System.Windows.Input.Key"/> name.
+        /// Anything with no special mapping passes through unchanged (F1-F24, Escape, Home, End,
+        /// Insert, Delete, PageUp/PageDown and letters all already agree case-insensitively).</summary>
+        private static string TranslateDomKey(string pageKey)
+        {
+            // Digits are "0".."9" in the DOM and D0..D9 in WPF (the numpad ones report the same
+            // values without event.location, which the bridge does not carry - the LL hook covers
+            // a numpad binding).
+            if (pageKey.Length == 1 && pageKey[0] >= '0' && pageKey[0] <= '9') return "D" + pageKey;
+
+            return pageKey switch
+            {
+                " " => "Space",
+                "Backspace" => "Back",
+                "Tab" => "Tab",
+                "Enter" => "Return",
+                "ArrowUp" => "Up",
+                "ArrowDown" => "Down",
+                "ArrowLeft" => "Left",
+                "ArrowRight" => "Right",
+                "," => "OemComma",
+                "." => "OemPeriod",
+                "-" => "OemMinus",
+                "=" => "OemPlus",
+                ";" => "OemSemicolon",
+                "'" => "OemQuotes",
+                "[" => "OemOpenBrackets",
+                "]" => "OemCloseBrackets",
+                "\\" => "OemBackslash",
+                "/" => "OemQuestion",
+                "`" => "OemTilde",
+                _ => pageKey,
+            };
         }
     }
 }

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using ConditioningControlPanel.Services.Video.Browser;
+using Screen = System.Windows.Forms.Screen;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The browser half of the hybrid video engine (docs/BROWSER_VIDEO_ENGINE_PLAN.md).
+    ///
+    /// VideoService stays the director for BOTH engines: scheduling, selection, XP, troll replay,
+    /// mercy, events, ducking, safety timers, attention checks, strict mode and grace pause all live
+    /// in the main file and are shared verbatim. Everything in here is the thin adapter that makes a
+    /// WebView2 session look exactly like a LibVLC one to those consumers.
+    ///
+    /// Deliberately NOT armed for a browser session: the vout watchdog, the wedge ladder, the native
+    /// quarantine/retire machinery and the poison cooldown. There is no in-process decoder to wedge,
+    /// so a browser session must never spend one of the four per-session LibVLC retires or be gated
+    /// by <see cref="NativePoisonCooldownRemainingMs"/>.
+    /// </summary>
+    public partial class VideoService
+    {
+        private BrowserVideoEngine? _browser;
+        private bool _browserWired;
+
+        /// <summary>True between a browser session's first window and its teardown. Read by the
+        /// shared control surface (pause/play/seek/volume/time) to route to the page.</summary>
+        private volatile bool _browserActive;
+
+        private string? _browserPath;
+        private bool _browserStrict;
+        private long _browserTimeMs = -1;
+        /// <summary>Teardown generation captured when the session started - a late page message that
+        /// belongs to a video the user already panicked away must not act (see _teardownGeneration).</summary>
+        private int _browserGeneration;
+        /// <summary>At most ONE LibVLC replay per browser trigger. The page reports its own 10s
+        /// no-playing failure AND this side runs the same clock, so both can fire for one stall.</summary>
+        private bool _browserFallbackDone;
+        /// <summary>VideoStarted fires on the page's first real <c>playing</c>, not at window-show:
+        /// a session that never reaches a frame falls back to LibVLC, which fires it instead.</summary>
+        private bool _browserStartedFired;
+
+        private BrowserVideoEngine Browser
+        {
+            get
+            {
+                var engine = _browser ??= BrowserVideoEngine.Instance;
+                if (!_browserWired)
+                {
+                    _browserWired = true;
+                    engine.Meta += OnBrowserMeta;
+                    engine.Playing += OnBrowserPlaying;
+                    engine.Time += OnBrowserTime;
+                    engine.Ended += OnBrowserEnded;
+                    engine.Failed += OnBrowserFailed;
+                    engine.Clicked += OnBrowserClicked;
+                    engine.KeyPressed += OnBrowserKey;
+                }
+                return engine;
+            }
+        }
+
+        // ===================== start =====================
+
+        /// <summary>
+        /// Runs a mandatory video through the browser engine. Returns false when nothing could be
+        /// brought up, in which case the caller falls straight through to the LibVLC path with
+        /// nothing to undo. Must be called on the UI thread, from StartVideoPlayback only.
+        /// </summary>
+        private bool StartBrowserVideoPlayback(string path, bool strict)
+        {
+            try
+            {
+                var screens = App.GetAllScreensCached().ToList();
+                if (screens.Count == 0) return false;   // LibVLC path owns the no-screens end
+                var primary = screens.FirstOrDefault(s => s.Primary) ?? screens[0];
+                var secondaries = screens.Where(s => !s.Primary).ToList();
+                if (!ShouldFillSecondaryMonitors(screens.Count)) secondaries.Clear();
+
+                _browserPath = path;
+                _browserStrict = strict;
+                _browserTimeMs = -1;
+                _browserGeneration = _teardownGeneration;
+                _browserFallbackDone = false;
+                _browserStartedFired = false;
+
+                // Chaos random-segment mode: the LibVLC path seeks from LengthChanged, but the page
+                // takes a start offset directly. The fraction needs the duration, which only arrives
+                // with `meta`, so the real jump happens there - this covers nothing yet on purpose.
+                var req = new BrowserVideoRequest
+                {
+                    Path = path,
+                    PrimaryScreen = primary,
+                    SecondaryScreens = secondaries,
+                    Volume = GetEffectiveVolume() / 100.0,
+                    Muted = GetEffectiveVolume() <= 0,
+                    BlurBackground = App.Settings?.Current?.VideoBlurredBackgroundEnabled == true,
+                    IsHostPaused = () => _gracePaused,
+                    ConfigureBeforeShow = (win, _, _) =>
+                    {
+                        // Same strict contract as a LibVLC window: Closing veto + key swallowing.
+                        // The page ALSO preventDefaults those keys and reports them back as
+                        // {type:'key'} (see OnBrowserKey) because a focused WebView2 eats keyboard
+                        // input before WPF ever sees it.
+                        SetupStrictHandlers(win, strict);
+                    },
+                    ConfigureAfterShow = (win, _, _) =>
+                    {
+                        // Non-activating so the WebView2 never takes focus away from the app's own
+                        // key handling, and so a click on the video can't raise it over the
+                        // attention targets / chaos layer. Both need a realized HWND.
+                        MakeNonActivating(win);
+                        PreventClickRaise(win);
+                    },
+                };
+
+                if (!Browser.StartSession(req))
+                {
+                    VideoDiag.Log("VIDEO", "browser session could not start - using LibVLC");
+                    return false;
+                }
+
+                _browserActive = true;
+                foreach (var w in Browser.Windows) _windows.Add(w);
+                _primaryVideoWindow = Browser.PrimaryWindow;
+
+                // Same two guards the LibVLC path arms before the first frame: a 10-minute backstop
+                // in case `meta` never arrives, and the user's hard max-length cap (#584).
+                StartFallbackSafetyTimer();
+                StartMaxLengthCapTimer();
+
+                // A window is on screen: grace pause becomes available, the strict veto means
+                // something. NO wedge watchdog - nothing native can wedge the dispatcher here.
+                _playbackStarted = true;
+
+                App.Bubbles?.PauseAndClear();
+                if (App.Settings.Current.AttentionChecksEnabled) SetupAttention();
+
+                VideoDiag.Log("VIDEO", $"browser session on screen ({_windows.Count} window(s)) - {Path.GetFileName(path)}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "VideoService: browser session start threw - falling back to LibVLC");
+                try { StopBrowserSession(); } catch { }
+                return false;
+            }
+        }
+
+        // ===================== teardown =====================
+
+        /// <summary>
+        /// Closes the browser surfaces and drops them from the shared window list. Called from
+        /// CloseAll (the single teardown funnel for every path: natural end, panic, safety timeout,
+        /// attention retry, session lock, suspend) and from the LibVLC fallback. Idempotent.
+        /// </summary>
+        private void StopBrowserSession()
+        {
+            var engine = _browser;
+            if (engine == null || (!_browserActive && !engine.IsSessionActive)) return;
+
+            _browserActive = false;
+            _browserTimeMs = -1;
+
+            var browserWindows = engine.Windows.ToList();
+            try { engine.StopSession(); }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: browser StopSession failed - {Error}", ex.Message); }
+
+            foreach (var w in browserWindows)
+            {
+                _windows.Remove(w);
+                if (ReferenceEquals(_primaryVideoWindow, w)) _primaryVideoWindow = null;
+            }
+        }
+
+        /// <summary>
+        /// The runtime half of the hybrid contract (plan §4): the page could not play this file, so
+        /// replay it through LibVLC exactly once, silently. No VideoEnded is raised - as far as every
+        /// consumer is concerned this is still the same video run, and the duck ref taken in
+        /// PlayVideo is deliberately kept so CloseAll still balances it exactly once.
+        /// </summary>
+        private void FallbackToLibVlc(string reason)
+        {
+            if (_browserFallbackDone) return;
+            _browserFallbackDone = true;
+
+            var path = _browserPath;
+            var strict = _browserStrict;
+            App.Logger?.Warning("VideoService: browser playback failed for {File} ({Reason}) - replaying via LibVLC",
+                Path.GetFileName(path ?? "(none)"), reason);
+            VideoDiag.Log("VIDEO", $"browser FALLBACK ({reason}) - replaying {Path.GetFileName(path ?? "?")} via LibVLC");
+
+            // The strict Closing veto refuses a close while _videoPlaying is true and no teardown is
+            // running, which would strand the browser windows on screen. Same trick ShowMessage uses.
+            var wasPlaying = _videoPlaying;
+            _videoPlaying = false;
+            try { StopBrowserSession(); }
+            finally { _videoPlaying = wasPlaying; }
+
+            if (string.IsNullOrEmpty(path) || _isCleaningUp) { Cleanup(); return; }
+
+            // Reset everything the failed attempt consumed so the LibVLC run starts clean. The
+            // attention schedule is rebuilt by StartVideoPlayback's own SetupAttention call.
+            try { _safetyTimer?.Stop(); } catch { }
+            try { _attentionTimer?.Stop(); } catch { }
+            lock (_targets)
+            {
+                foreach (var t in _targets.ToList()) t.Destroy();
+                _targets.Clear();
+            }
+            _hits = _total = _spawned = 0;
+            _spawnTimes.Clear();
+            _duration = 0;
+            _lastWatchPositionMs = 0;
+            _creditedWatchSeconds = 0;
+            _startTime = DateTime.Now;
+
+            StartVideoPlayback(path, strict, forceLibVlc: true);
+        }
+
+        // ===================== page events =====================
+
+        /// <summary>True when a page message still belongs to the live run.</summary>
+        private bool BrowserEventIsCurrent()
+            => _browserActive && !_isCleaningUp && _browserGeneration == _teardownGeneration;
+
+        /// <summary>
+        /// Queue work for AFTER the current page message returns. Page events arrive inside the
+        /// WebView2 message callback, and anything heavy done there (closing the very windows that
+        /// raised it, CloseAll's pumped waits, building LibVLC windows) re-enters the browser's own
+        /// message loop. Same discipline as the LibVLC handlers, which never do teardown inline on
+        /// the LibVLC event thread. Normal priority — DispatcherPriority.Loaded is starved here.
+        /// </summary>
+        private static void PostAfterPageMessage(Action action)
+        {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+            try { dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, action); }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: browser continuation dispatch failed - {Error}", ex.Message); }
+        }
+
+        private void OnBrowserMeta(long durationMs, int width, int height)
+        {
+            if (!BrowserEventIsCurrent()) return;
+            // 0 = the page cannot know the duration (some webm / fragmented mp4). Arming a
+            // zero-length guillotine would kill the clip instantly; the 10-minute fallback timer
+            // stays armed as the net, exactly as it does when LibVLC's LengthChanged never fires.
+            if (durationMs <= 0)
+            {
+                App.Logger?.Debug("VideoService: browser meta with unknown duration ({W}x{H}) - keeping the fallback timer", width, height);
+                return;
+            }
+
+            _duration = durationMs / 1000.0;
+            App.Logger?.Information("VideoService: browser meta - duration={Duration}s ({W}x{H})", _duration, width, height);
+
+            // meta can arrive more than once (Infinity at loadedmetadata, real value at
+            // durationchange) - last one wins, so the guillotine is simply re-armed.
+            StartSafetyTimer(_duration);
+
+            // Free duration metadata: the selection-time min/max filter improves with every browser
+            // play, with no LibVLC parse (and no preparse crash surface, #750-#753).
+            try
+            {
+                if (!string.IsNullOrEmpty(_browserPath)) MetadataCache?.StoreDuration(_browserPath!, _duration);
+            }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: browser duration backfill failed - {Error}", ex.Message); }
+
+            // Chaos random segment: same shared fraction as the LibVLC path, applied as a seek now
+            // that the length is known (the page holds every screen in lockstep).
+            try
+            {
+                long segMs = (long)(_segmentSec * 1000);
+                if (SegmentArmed && durationMs > segMs)
+                {
+                    long startMs = (long)((durationMs - segMs) * _segmentFraction);
+                    if (startMs > 500)
+                    {
+                        Browser.Seek(startMs);
+                        App.Logger?.Information("VideoService: browser random segment - seeking to {Start}s of {Len}s",
+                            startMs / 1000, durationMs / 1000);
+                    }
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: browser random-segment seek - {Error}", ex.Message); }
+        }
+
+        private void OnBrowserPlaying()
+        {
+            if (!BrowserEventIsCurrent() || _browserStartedFired) return;
+            _browserStartedFired = true;
+
+            VideoDiag.Log("VIDEO", "browser playback confirmed (page reported playing)");
+            VideoStarted?.Invoke(this, EventArgs.Empty);
+            _ = App.Haptics?.StartVideoBackgroundVibeAsync();
+            try { App.Haptics?.FunScript?.OnVideoStarted(_browserPath ?? ""); }
+            catch (Exception ex) { App.Logger?.Debug("FunScript start hook failed: {Error}", ex.Message); }
+            App.Logger?.Information("Playing: {File} (browser engine)", Path.GetFileName(_browserPath ?? ""));
+        }
+
+        private void OnBrowserTime(long ms)
+        {
+            if (!_browserActive) return;
+            _browserTimeMs = ms;
+            _lastWatchPositionMs = ms;   // watch-time crediting (#447), same field the LibVLC path feeds
+            try { PrimaryPlaybackTimeMsChanged?.Invoke(ms); }
+            catch (Exception ex) { App.Logger?.Debug("PrimaryPlaybackTimeMsChanged handler error: {Error}", ex.Message); }
+        }
+
+        private void OnBrowserEnded()
+        {
+            if (!BrowserEventIsCurrent()) return;
+            // Straight into the shared end-of-video pipeline: attention pass/fail, XP, troll replay,
+            // mercy, watch credit, ScheduleNext — but off the page's message callback first.
+            PostAfterPageMessage(() => { if (BrowserEventIsCurrent()) OnEnded(); });
+        }
+
+        private void OnBrowserFailed(string reason, bool blameFile)
+        {
+            if (!_browserActive) return;
+            // Marked immediately (cheap, and the routing decision must not depend on the hop landing).
+            if (blameFile && !string.IsNullOrEmpty(_browserPath))
+                BrowserUnsafeVideoCache.Add(_browserPath, reason);
+            PostAfterPageMessage(() => { if (_browserActive) FallbackToLibVlc(reason); });
+        }
+
+        private void OnBrowserClicked()
+        {
+            if (!_browserActive) return;
+            // Window-level PreviewMouseDown never fires over a WebView2 child HWND, so this message
+            // is what keeps the attention targets clickable on top of the video.
+            BringTargetsToFront();
+        }
+
+        /// <summary>
+        /// Keyboard policy for a browser session. Mirrors <c>SetupStrictHandlers</c>: the page
+        /// preventDefaults the dangerous keys and reports them here, because a focused WebView2 sends
+        /// keystrokes to Chromium rather than to the WPF window.
+        /// </summary>
+        private void OnBrowserKey(string key, bool alt, bool ctrl, bool shift)
+        {
+            if (!BrowserEventIsCurrent()) return;
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null) return;
+                bool isEscape = string.Equals(key, "Escape", StringComparison.OrdinalIgnoreCase);
+
+                if (_browserStrict)
+                {
+                    // Strict: Escape may PAUSE, never escape - and only under the same conditions the
+                    // strict window handler allows (never during lockdown, never when Escape IS the
+                    // panic key, which the global hook owns). Everything else is swallowed.
+                    if (isEscape &&
+                        App.Lockdown?.IsActive != true &&
+                        settings.PanicKeyEnabled &&
+                        !string.Equals(settings.PanicKey, "Escape", StringComparison.Ordinal))
+                    {
+                        if (TryGracePauseFromPanic())
+                            VideoDiag.Log("PANIC", "strict browser window: ESC consumed as video grace pause");
+                    }
+                    return;
+                }
+
+                if (isEscape)
+                {
+                    if (TryGracePauseFromPanic())
+                    {
+                        VideoDiag.Log("PANIC", "ESC consumed as video grace pause (browser window)");
+                        return;
+                    }
+                    VideoDiag.Log("PANIC", "ESC received by the browser video page - dismissing via Cleanup");
+                    PostAfterPageMessage(Cleanup);   // teardown must not run inside the page's callback
+                    return;
+                }
+
+                if (settings.PanicKeyEnabled && MatchesPanicKey(key, settings.PanicKey))
+                {
+                    if (TryGracePauseFromPanic())
+                    {
+                        VideoDiag.Log("PANIC", $"panic key '{key}' consumed by the browser page as a grace pause");
+                        return;
+                    }
+                    VideoDiag.Log("PANIC", $"panic key '{key}' received by the browser page - ForceCleanup");
+                    PostAfterPageMessage(() => ForceCleanup());
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("VideoService: browser key handling failed - {Error}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The page reports DOM key names ("Escape", "F8", "a", " "); the setting stores a WPF
+        /// <see cref="System.Windows.Input.Key"/> name ("Escape", "F8", "A", "Space"). Function keys,
+        /// Escape and letters line up case-insensitively once Space is translated, which covers every
+        /// panic key a user can actually bind through the settings picker.
+        /// </summary>
+        private static bool MatchesPanicKey(string pageKey, string? panicKey)
+        {
+            if (string.IsNullOrEmpty(pageKey) || string.IsNullOrEmpty(panicKey)) return false;
+            var normalized = pageKey == " " ? "Space" : pageKey;
+            return string.Equals(normalized, panicKey, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -175,6 +175,11 @@ namespace ConditioningControlPanel.Services
                 // and strand fullscreen surfaces on screen forever. Same clear/restore dance as the
                 // runtime fallback, strict bridge included.
                 try { StopBrowserSessionForHandoff(); } catch { }
+                // The disarm above already ran if the throw came after it; the LibVLC attempt this
+                // false return triggers must not build its windows unguarded (that window creation
+                // is where the historic freeze strikes). Pre-roll re-arm, same as FallbackToLibVlc.
+                _playbackStarted = false;
+                StartWedgeWatchdog();
                 return false;
             }
         }
@@ -272,9 +277,20 @@ namespace ConditioningControlPanel.Services
                 Path.GetFileName(path ?? "(none)"), reason);
             VideoDiag.Log("VIDEO", $"browser FALLBACK ({reason}) - replaying {Path.GetFileName(path ?? "?")} via LibVLC");
 
+            // Handing the clip back to LibVLC means the wedge ladder matters again. Re-arm it in
+            // the pre-roll observation state BEFORE the handoff below - closing WebView2 HWNDs is
+            // an out-of-process round trip that can itself stall, and StartVideoPlayback re-arms
+            // for real once its windows are up. WedgeWatchdogTick still no-ops until
+            // StopBrowserSession clears _browserActive, so this cannot fire early.
+            _playbackStarted = false;
+            StartWedgeWatchdog();
+
             // Drops the surfaces without letting the strict Closing veto strand them, and without
-            // letting IsStrictActive blink false across the handoff.
-            StopBrowserSessionForHandoff();
+            // letting IsStrictActive blink false across the handoff. Guarded like the start-path
+            // twin: a throw here would escape into the dispatcher continuation with
+            // _browserFallbackDone already latched, so nothing would ever retry.
+            try { StopBrowserSessionForHandoff(); }
+            catch (Exception ex) { App.Logger?.Error(ex, "VideoService: browser handoff teardown threw during fallback"); }
 
             if (string.IsNullOrEmpty(path) || _isCleaningUp) { Cleanup(); return; }
 
@@ -293,14 +309,6 @@ namespace ConditioningControlPanel.Services
             _lastWatchPositionMs = 0;
             _creditedWatchSeconds = 0;
             _startTime = DateTime.Now;
-
-            // Handing the clip to LibVLC means the wedge ladder matters again, and it is disarmed
-            // (StartBrowserVideoPlayback stopped it). Re-arm it in the pre-roll state PlayVideo's
-            // prologue uses - observation only - so the LibVLC window creation that follows, which
-            // is where the historic freeze strikes, is guarded again. StartVideoPlayback re-arms it
-            // for real once its windows are up.
-            _playbackStarted = false;
-            StartWedgeWatchdog();
 
             StartVideoPlayback(path, strict, forceLibVlc: true);
         }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -5511,6 +5511,16 @@ namespace ConditioningControlPanel.Services
         {
             try
             {
+                // A browser session has NOTHING for this ladder to rescue: the decoder is in another
+                // process, no MediaPlayer is leased and no LibVLC instance is involved. Every rung
+                // would be pure collateral damage (an off-thread Stop() of players belonging to
+                // nobody, retiring a healthy shared instance, and flipping _wedgeStallSeen, which
+                // stands the strict Closing veto down for the rest of the video). A UI stall during
+                // a browser video must trigger nothing. StartBrowserVideoPlayback also disarms the
+                // watchdog outright; this is the belt to that brace, and it covers the window
+                // between the routing decision and the disarm.
+                if (_browserActive) return;
+
                 // #766/#767: stay armed through CloseAll. _videoPlaying is cleared at the TOP of the
                 // teardown, so gating on it alone made the app's longest predictable UI-thread block
                 // structurally invisible to the guard that exists to catch exactly that.
@@ -6240,6 +6250,12 @@ namespace ConditioningControlPanel.Services
                 if (!string.IsNullOrEmpty(tempPath))
                 {
                     _tempPackFiles.Add(tempPath);  // Track for cleanup
+                    // Every play decrypts to a NEW ccp_temp_<GUID> path, so the browser engine's
+                    // unsafe cache would never recognise a pack clip it has already failed on and
+                    // the user would pay the fallback wait again and again. Give the temp path the
+                    // pack entry's identity - the one thing about it that is stable.
+                    Video.Browser.BrowserUnsafeVideoCache.RegisterStableKey(
+                        tempPath, $"pack:{packVideo.PackId}|{packVideo.File.OriginalName}");
                     App.Logger?.Debug("Using pack video: {Name} from pack {PackId}", packVideo.File.OriginalName, packVideo.PackId);
                     return tempPath;
                 }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1380,6 +1380,13 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("VideoService.Stop: LibVLCSharp.WPF not loaded, skipping CloseAll");
             }
 
+            // Stop() is the one teardown funnel that never released the queue slot: a video cut
+            // off by an engine/feature/remote stop kept "Video" claimed for the full 5-minute
+            // stuck window, blocking every queued interaction (smoke test 2026-08-04). Placed
+            // after CloseAll so the slot is never released under a still-open video window;
+            // CompleteIfCurrent never clears a claim that isn't ours.
+            App.InteractionQueue?.CompleteIfCurrent(InteractionQueueService.InteractionType.Video);
+
             App.Logger?.Information("VideoService stopped");
         }
 

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -33,7 +33,10 @@ namespace ConditioningControlPanel.Services
         public bool EndedNaturally { get; set; }
     }
 
-    public class VideoService : IDisposable
+    // partial: the browser-engine adapter lives in VideoService.Browser.cs (the hybrid video
+    // engine). Everything else — scheduling, selection, safety timers, attention, strict mode —
+    // stays here and is shared by both engines.
+    public partial class VideoService : IDisposable
     {
         private readonly Random _random = new();
         private Queue<string> _videoQueue = new();  // Performance: Changed to Queue for O(1) dequeue
@@ -363,7 +366,9 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public long GetCurrentPlaybackTimeMs()
         {
-            try { return _primaryMediaPlayer?.Time ?? -1; }
+            // Browser session: PrimaryMediaPlayer is null by design, and the position comes from the
+            // page's ~10Hz `time` messages instead (FunScript haptics + Deeper's time source).
+            try { return _browserActive ? _browserTimeMs : (_primaryMediaPlayer?.Time ?? -1); }
             catch { return -1; }
         }
 
@@ -379,6 +384,8 @@ namespace ConditioningControlPanel.Services
             // keeps playing, so the two screens desync (#527). Only the primary raises events, but
             // all players must track the same position.
             var target = Math.Max(0, ms);
+            // Browser session: the page seeks every screen in lockstep for the same reason.
+            if (_browserActive) _browser?.Seek(target);
             foreach (var p in SnapshotPlayers())
             {
                 try
@@ -395,6 +402,7 @@ namespace ConditioningControlPanel.Services
         /// <summary>Pause every screen's player (kept in lockstep for multi-monitor). No-op if none.</summary>
         public void PausePrimary()
         {
+            if (_browserActive) _browser?.Pause();
             foreach (var p in SnapshotPlayers())
             {
                 try { p.SetPause(true); }
@@ -411,6 +419,7 @@ namespace ConditioningControlPanel.Services
             // _gracePaused BEFORE it calls this, so the legitimate resume is unaffected.
             if (_gracePaused) return;
 
+            if (_browserActive) _browser?.Resume();
             foreach (var p in SnapshotPlayers())
             {
                 try { p.SetPause(false); }
@@ -1249,6 +1258,10 @@ namespace ConditioningControlPanel.Services
         private void UpdatePlayingVideosVolume()
         {
             var effectiveVolume = GetEffectiveVolume();
+
+            // Browser session: one message carries master x video volume AND the external mute
+            // (GetEffectiveVolume already folds the mute in, so both halves agree).
+            if (_browserActive) _browser?.SetVolume(effectiveVolume / 100.0, effectiveVolume <= 0);
 
             // Update LibVLC media players (thread-safe snapshot)
             List<LibVLCSharp.Shared.MediaPlayer> playersCopy;
@@ -2204,8 +2217,19 @@ namespace ConditioningControlPanel.Services
             VideoDiag.Log("VIDEO", $"prologue: 1.3s delay timer scheduled +{prologueSw.ElapsedMilliseconds}ms");
         }
 
-        private void StartVideoPlayback(string path, bool strict)
+        /// <param name="forceLibVlc">Set only by the browser engine's runtime fallback: the page
+        /// already failed on this file, so the routing branch below must not send it back.</param>
+        private void StartVideoPlayback(string path, bool strict, bool forceLibVlc = false)
         {
+            // ---- hybrid routing (docs/BROWSER_VIDEO_ENGINE_PLAN.md §4) ----
+            // The ONLY change to this path. When the browser engine takes the clip it satisfies the
+            // whole parity checklist itself (see VideoService.Browser.cs) and returns; otherwise
+            // everything below runs exactly as it always has.
+            if (!forceLibVlc && Video.Browser.BrowserVideoGate.ShouldUseBrowser(path))
+            {
+                if (StartBrowserVideoPlayback(path, strict)) return;
+            }
+
             App.Logger?.Information("VideoService: StartVideoPlayback called for {File}", Path.GetFileName(path));
 
             // Every step from here to the first frame is bracketed (#750-#753): the reporters' crash
@@ -5766,6 +5790,9 @@ namespace ConditioningControlPanel.Services
             try
             {
                 _attentionTimer?.Stop();
+                // A browser session's WebView2 windows go with the video: this is the single funnel
+                // every teardown path reaches, so the engine can never outlive the run it belongs to.
+                StopBrowserSession();
                 _segmentArmedAtUtc = DateTime.MinValue;   // random-segment mode is one-shot per video
                 // #735: the video is going away, so the grace-pause card must go with it — every
                 // teardown (panic press 2, engine stop, OS lock/suspend, wedge watchdog, natural end)

--- a/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
@@ -213,9 +213,30 @@ namespace ConditioningControlPanel
         /// <summary>
         /// Show bubble count game on all monitors using LibVLC
         /// </summary>
+        /// <param name="onSkipped">Optional "the game never happened" resolution, used by the
+        /// poison-cooldown backstop below. A skip is NOT a loss: routing it through
+        /// <paramref name="onComplete"/> with false would read as a failed count and, in strict
+        /// mode, start the WRONG! WATCH AGAIN retry loop for a game the user never saw. When null,
+        /// a skip falls back to the completion callback (old behaviour).</param>
         public static void ShowOnAllMonitors(string videoPath, BubbleCountService.Difficulty difficulty,
-            bool strictMode, Action<bool> onComplete)
+            bool strictMode, Action<bool> onComplete, Action? onSkipped = null)
         {
+            // The completion callback must reach the service EXACTLY once. Every window shares this
+            // delegate and CloseAllWindows invokes it, which can happen INSIDE the Show() below
+            // (Loaded runs synchronously there, and a browser/LibVLC start failure closes the game
+            // from it) - so the catch at the bottom would otherwise deliver a second, contradictory
+            // completion for a game that already ended.
+            int completionDelivered = 0;
+            Action<bool> complete = ok =>
+            {
+                if (System.Threading.Interlocked.Exchange(ref completionDelivered, 1) != 0)
+                {
+                    App.Logger?.Debug("BubbleCountWindow: completion already delivered - ignoring a second one (success={Success})", ok);
+                    return;
+                }
+                onComplete?.Invoke(ok);
+            };
+
             // Reset shared state
             lock (_cleanupLock)
             {
@@ -269,15 +290,24 @@ namespace ConditioningControlPanel
 
             // A wedged native Stop() leaves a LibVLC thread stuck in this process forever, and #766
             // is precisely "poisoning at 22:05, bubble-count video at 22:18, dispatcher dead". Don't
-            // stand a fresh player up on the wreckage - the caller treats this like any other
-            // can't-show and the next scheduled game gets a clean instance. Browser mode never
-            // touches the shared instance, so the cooldown has nothing to protect there.
+            // stand a fresh player up on the wreckage. Browser mode never touches the shared
+            // instance, so the cooldown has nothing to protect there.
+            //
+            // BACKSTOP ONLY: BubbleCountService now evaluates this same cooldown after it has picked
+            // the file (it is the only place that can, because the routing decision needs the path),
+            // so reaching it here means the cooldown began in the milliseconds since. Resolved as a
+            // SKIP, never as a lost game - see onSkipped.
             var poisonMs = useBrowser ? 0 : VideoService.NativePoisonCooldownRemainingMs;
             if (poisonMs > 0)
             {
                 App.Logger?.Warning("BubbleCountWindow: shared LibVLC poisoned by a wedged Stop() - not starting ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
-                VideoDiag.Log("BUBBLE", $"ABORT - native poison cooldown, {poisonMs}ms remaining");
-                onComplete?.Invoke(false);
+                VideoDiag.Log("BUBBLE", $"SKIP - native poison cooldown, {poisonMs}ms remaining");
+                if (onSkipped != null)
+                {
+                    System.Threading.Interlocked.Exchange(ref completionDelivered, 1);
+                    onSkipped();
+                }
+                else complete(false);
                 return;
             }
 
@@ -287,7 +317,7 @@ namespace ConditioningControlPanel
             {
                 App.Logger?.Error("BubbleCountWindow: LibVLC not available, cannot show game");
                 VideoDiag.Log("BUBBLE", "ABORT - no shared LibVLC instance");
-                onComplete?.Invoke(false);
+                complete(false);
                 return;
             }
 
@@ -300,7 +330,7 @@ namespace ConditioningControlPanel
             if (screens.Length == 0 || screens[0] == null)
             {
                 App.Logger?.Error("BubbleCountWindow: No screens available");
-                onComplete?.Invoke(false);
+                complete(false);
                 return;
             }
 
@@ -321,7 +351,7 @@ namespace ConditioningControlPanel
             {
                 // Create primary window with audio
                 App.Logger?.Information("BubbleCountWindow: Creating primary window...");
-                var primaryWindow = new BubbleCountWindow(videoPath, difficulty, strictMode, onComplete, primary, true);
+                var primaryWindow = new BubbleCountWindow(videoPath, difficulty, strictMode, complete, primary, true);
 
                 App.Logger?.Information("BubbleCountWindow: Showing primary window...");
                 primaryWindow.Show();
@@ -334,7 +364,7 @@ namespace ConditioningControlPanel
                 foreach (var screen in screens.Where(s => s != primary))
                 {
                     App.Logger?.Information("BubbleCountWindow: Creating secondary window on {Screen}...", screen.DeviceName);
-                    var secondaryWindow = new BubbleCountWindow(videoPath, difficulty, strictMode, onComplete, screen, false);
+                    var secondaryWindow = new BubbleCountWindow(videoPath, difficulty, strictMode, complete, screen, false);
                     secondaryWindow.Show();
                     secondaryWindow.WindowState = WindowState.Maximized;
                     ForceTopmost(secondaryWindow);
@@ -351,7 +381,8 @@ namespace ConditioningControlPanel
                 App.Logger?.Error(ex, "BubbleCountWindow: Failed to create/show windows");
                 VideoDiag.Log("BUBBLE", $"show THREW +{showSw.ElapsedMilliseconds}ms: {ex.Message}");
                 App.Video?.DisarmManagedWedgeWatchdog();
-                onComplete?.Invoke(false);
+                // No-op when the windows already delivered one from inside Show().
+                complete(false);
             }
         }
 
@@ -820,6 +851,9 @@ namespace ConditioningControlPanel
                 // Black bars, not the TikTok fill: the bubble-count surface has always letterboxed
                 // (a plain VideoView), and the count bubbles are positioned over the whole screen.
                 blurBackground = false,
+                // The whole game is "click the bubbles": an invisible pointer would make it
+                // unplayable, so the page's cursor hiding stays off here.
+                hideCursor = false,
                 startAtMs = 0,
             });
 
@@ -970,6 +1004,16 @@ namespace ConditioningControlPanel
         {
             // Counted app-wide so a flapping renderer stands the engine down for everyone rather
             // than costing every feature a fallback. Never blames the file (plan §4).
+            //
+            // ONLY from the primary: one dead browser process raises this on every window sharing
+            // it, so on a dual-monitor game a single crash used to spend BOTH strikes of the
+            // two-strikes stand-down at once. (The secondaries can't end the game either -
+            // OnBrowserFailure is primary-only - so they just go black behind the count.)
+            if (!_isPrimary)
+            {
+                App.Logger?.Warning("BubbleCountWindow[secondary]: WebView2 process failed ({Kind}) - mirror lost, the game continues", kind);
+                return;
+            }
             BrowserVideoEngine.ReportProcessFailure(kind);
             OnBrowserFailure("WebView2 process failed: " + kind, blameFile: false);
         }

--- a/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/BubbleCountWindow.xaml.cs
@@ -13,7 +13,10 @@ using System.Windows.Threading;
 using NAudio.Wave;
 using LibVLCSharp.Shared;
 using LibVLCSharp.WPF;
+using Microsoft.Web.WebView2.Core;
+using Newtonsoft.Json.Linq;
 using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Video.Browser;
 using ConditioningControlPanel.Localization;
 using Screen = System.Windows.Forms.Screen;
 
@@ -31,6 +34,10 @@ namespace ConditioningControlPanel
         private readonly Action<bool> _onComplete;
         private readonly Screen _screen;
         private readonly bool _isPrimary;
+        /// <summary>This game plays out-of-process in a WebView2 instead of a leased LibVLC player.
+        /// Nothing else about the game changes: bubbles, counting, difficulty, the result window,
+        /// the strict lock and the XP flow are shared verbatim.</summary>
+        private readonly bool _useBrowser;
 
         private readonly Random _random = new();
         private readonly List<CountBubble> _activeBubbles = new();
@@ -53,6 +60,13 @@ namespace ConditioningControlPanel
         private LibVLCSharp.Shared.MediaPlayer? _mediaPlayer;
         private VideoView? _videoView;
 
+        // Browser engine (docs/BROWSER_VIDEO_ENGINE_PLAN.md §6) - instance fields per window.
+        // Mutually exclusive with the LibVLC fields above: a game is one engine or the other.
+        private BrowserVideoSurface? _browserSurface;
+        private DispatcherTimer? _browserFirstFrameTimer;
+        private bool _browserPlayingSeen;
+        private bool _browserFailed;
+
         // Multi-monitor support - static shared state
         private static readonly object _cleanupLock = new();
         private static bool _isCleaningUp = false;
@@ -60,6 +74,14 @@ namespace ConditioningControlPanel
         private static int _sharedBubbleCount = 0;
         private static int _sharedTargetCount = 0;
         private static List<LibVLCSharp.Shared.MediaPlayer> _allMediaPlayers = new();
+
+        /// <summary>
+        /// Routing decision for the game being started, taken ONCE in <see cref="ShowOnAllMonitors"/>
+        /// and copied into every window's <c>_useBrowser</c> as it is constructed. A static handover
+        /// rather than a constructor argument so the public signature (used by BubbleCountService and
+        /// the test/remote paths) does not change.
+        /// </summary>
+        private static bool _nextGameUsesBrowser;
 
         /// <summary>Owner tag used for every VideoService lease + trace line from this window.</summary>
         private const string LeaseTag = "bubble-count";
@@ -74,6 +96,12 @@ namespace ConditioningControlPanel
         /// <summary>Fallback duration when the metadata cache has never seen this video. LibVLC's
         /// LengthChanged corrects it within a second of Play() - see AdoptRealDuration.</summary>
         private const double FallbackDurationSeconds = 30;
+        /// <summary>Browser mode only: how long the game waits for the page's first <c>playing</c>
+        /// report. The page runs its OWN 10s no-playing clock and reports error 101, so this only
+        /// covers the case where the page never got far enough to run it at all (WebView2 never
+        /// initialised, navigation blocked) - which would otherwise sit on black until the safety
+        /// timer. Generous, because a cold WebView2 start can eat several seconds by itself.</summary>
+        private const int BrowserFirstFrameTimeoutMs = 20000;
 
         /// <summary>Duration of the last played video in seconds (shared for XP scaling)</summary>
         internal static double LastVideoDurationSeconds { get; private set; } = 30;
@@ -90,6 +118,7 @@ namespace ConditioningControlPanel
             _onComplete = onComplete;
             _screen = screen ?? Screen.PrimaryScreen!;
             _isPrimary = isPrimary;
+            _useBrowser = _nextGameUsesBrowser;
 
             // Set difficulty display
             TxtDifficulty.Text = $" ({difficulty})";
@@ -124,8 +153,10 @@ namespace ConditioningControlPanel
                 SetWindowLong(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TOOLWINDOW);
                 // Cache the handle for VideoService's wedge escape hatch while we still can: these
                 // windows are fullscreen + topmost, and once the UI thread wedges nothing can
-                // resolve a Window to its HWND any more (#765/#766).
-                App.Video?.RegisterManagedWindow(hwnd);
+                // resolve a Window to its HWND any more (#765/#766). Browser mode has no in-process
+                // decoder to wedge the dispatcher, and its watchdog is never armed, so the escape
+                // hatch has nothing to escape from.
+                if (!_useBrowser) App.Video?.RegisterManagedWindow(hwnd);
             };
 
             // Reclaim focus when stolen by other windows (only primary needs focus)
@@ -226,11 +257,22 @@ namespace ConditioningControlPanel
                 ReleaseStoppedPlayers(orphanStops);
             }
 
+            // Routing for THIS game (plan §6), decided once and shared by every window. A session
+            // already live on the engine would mean a mandatory video is on screen right now: the
+            // InteractionQueue's single slot is supposed to make that impossible, so treat it as
+            // doubt and take the shipped LibVLC path rather than stealing the video's surfaces.
+            var useBrowser = BrowserVideoGate.ShouldUseBrowser(videoPath)
+                             && !BrowserVideoEngine.Instance.IsSessionActive;
+            _nextGameUsesBrowser = useBrowser;
+            if (useBrowser)
+                VideoDiag.Log("BUBBLE", $"browser engine selected for {Path.GetFileName(videoPath)} - no LibVLC lease, no wedge watchdog");
+
             // A wedged native Stop() leaves a LibVLC thread stuck in this process forever, and #766
             // is precisely "poisoning at 22:05, bubble-count video at 22:18, dispatcher dead". Don't
             // stand a fresh player up on the wreckage - the caller treats this like any other
-            // can't-show and the next scheduled game gets a clean instance.
-            var poisonMs = VideoService.NativePoisonCooldownRemainingMs;
+            // can't-show and the next scheduled game gets a clean instance. Browser mode never
+            // touches the shared instance, so the cooldown has nothing to protect there.
+            var poisonMs = useBrowser ? 0 : VideoService.NativePoisonCooldownRemainingMs;
             if (poisonMs > 0)
             {
                 App.Logger?.Warning("BubbleCountWindow: shared LibVLC poisoned by a wedged Stop() - not starting ({Sec:F0}s of cooldown left)", poisonMs / 1000.0);
@@ -239,8 +281,9 @@ namespace ConditioningControlPanel
                 return;
             }
 
-            // Ensure LibVLC is ready
-            if (!EnsureLibVLCReady())
+            // Ensure LibVLC is ready (browser mode never leases a player, so it must not block on -
+            // or trigger - the shared instance's initialization)
+            if (!useBrowser && !EnsureLibVLCReady())
             {
                 App.Logger?.Error("BubbleCountWindow: LibVLC not available, cannot show game");
                 VideoDiag.Log("BUBBLE", "ABORT - no shared LibVLC instance");
@@ -268,8 +311,10 @@ namespace ConditioningControlPanel
 
             // Armed BEFORE the first window exists: the #766 wedge is inside the native start-up
             // sequence itself (MediaPlayer ctor / HwndHost attach / Play), which all runs on the UI
-            // thread from OnLoaded. Disarmed by CloseAllWindows / ForceCloseAll.
-            App.Video?.ArmManagedWedgeWatchdog(LeaseTag);
+            // thread from OnLoaded. Disarmed by CloseAllWindows / ForceCloseAll. NOT armed in
+            // browser mode - WebView2 media is out-of-process, so there is nothing native on this
+            // thread that can wedge the dispatcher.
+            if (!useBrowser) App.Video?.ArmManagedWedgeWatchdog(LeaseTag);
 
             var showSw = System.Diagnostics.Stopwatch.StartNew();
             try
@@ -444,6 +489,15 @@ namespace ConditioningControlPanel
                     {
                         CloseAllWindows(false);
                     }
+                    return;
+                }
+
+                // Browser mode owns the whole start-up sequence: no VideoView, no lease, no Media,
+                // no Play(). Everything AFTER playback start (bubbles, counting, result window,
+                // strict lock, XP) is the shared code below and in CloseAllWindows.
+                if (_useBrowser)
+                {
+                    StartBrowserPlayback(tag, sw);
                     return;
                 }
 
@@ -723,6 +777,311 @@ namespace ConditioningControlPanel
             });
         }
 
+        #region Browser engine (plan §6)
+
+        /// <summary>
+        /// Browser-mode start-up for this window: a <see cref="BrowserVideoSurface"/> inside the
+        /// game window's own VideoContainer, in place of the leased LibVLC player + VideoView. The
+        /// surface goes INSIDE this window rather than into a separate BrowserVideoWindow so the
+        /// counting HUD, the strict indicator and the ESC hint keep drawing over the video, and so
+        /// ShowOnAllMonitors' one-window-per-screen shape is unchanged.
+        ///
+        /// The page's <c>meta</c> message replaces LibVLC's LengthChanged (both land in
+        /// <see cref="AdoptRealDuration"/>) and its <c>ended</c> message replaces EndReached.
+        /// </summary>
+        private void StartBrowserPlayback(string tag, System.Diagnostics.Stopwatch sw)
+        {
+            var url = BrowserVideoEngine.BuildPageUrl(_videoPath);
+            if (url == null)
+            {
+                // ShouldUseBrowser already proved the file maps to a virtual host, so this is a race
+                // (the assets folder moved between selection and here). Nothing is on screen yet.
+                App.Logger?.Warning("BubbleCountWindow: no virtual-host URL for {Path} - abandoning the game", _videoPath);
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: ABORT - browser URL build failed +{sw.ElapsedMilliseconds}ms");
+                if (_isPrimary) CloseAllWindows(false);
+                return;
+            }
+
+            _browserSurface = new BrowserVideoSurface($"{LeaseTag}[{tag}]");
+            _browserSurface.Message += OnBrowserMessage;
+            _browserSurface.ProcessFailed += OnBrowserProcessFailed;
+            VideoContainer.Children.Add(_browserSurface);
+            VideoDiag.Log("BUBBLE", $"win[{tag}]: browser surface built +{sw.ElapsedMilliseconds}ms");
+
+            // Same audio contract as the LibVLC path: the primary carries the game's volume and
+            // every secondary is silent, so there is exactly one WASAPI session per clip.
+            var volume = _isPrimary ? Math.Clamp(App.Settings.Current.MasterVolume / 100.0, 0, 1) : 0.0;
+            _browserSurface.Post(new
+            {
+                type = "load",
+                url,
+                volume,
+                muted = !_isPrimary || volume <= 0,
+                // Black bars, not the TikTok fill: the bubble-count surface has always letterboxed
+                // (a plain VideoView), and the count bubbles are positioned over the whole screen.
+                blurBackground = false,
+                startAtMs = 0,
+            });
+
+            if (_isPrimary)
+            {
+                // Identical to the LibVLC path: cache hit, else the 30s fallback, corrected the
+                // moment the page reports its real duration.
+                _videoDurationSeconds = ResolveVideoDurationSeconds(_videoPath);
+                LastVideoDurationSeconds = _videoDurationSeconds;
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: duration={_videoDurationSeconds:F1}s (awaiting page meta) +{sw.ElapsedMilliseconds}ms");
+
+                CalculateTargetBubbles();
+                _sharedTargetCount = _targetBubbleCount;
+
+                StartSafetyTimer(_videoDurationSeconds);
+                StartBubbleSpawning();
+                ArmBrowserFirstFrameWatch();
+
+                App.Logger?.Information("BubbleCount game started (browser engine) - Target: {Target} bubbles, Duration: {Duration}s, Difficulty: {Diff}",
+                    _targetBubbleCount, _videoDurationSeconds, _difficulty);
+            }
+            else
+            {
+                _targetBubbleCount = _sharedTargetCount;
+            }
+
+            // EnsureCoreWebView2Async only works once the control is in the visual tree, which it
+            // now is (this runs from the window's Loaded handler).
+            _ = InitBrowserSurfaceAsync(tag);
+        }
+
+        /// <summary>Attach the shared WebView2 environment and navigate to the player page. The
+        /// environment is the engine's - one per process, whoever asks for it first builds it.</summary>
+        private async Task InitBrowserSurfaceAsync(string tag)
+        {
+            var surface = _browserSurface;
+            if (surface == null) return;
+            try
+            {
+                var env = await BrowserVideoEngine.SharedEnvironmentAsync();
+                if (!ReferenceEquals(surface, _browserSurface) || _isCleaningUp) return;
+                if (env == null)
+                {
+                    // WebView2 runtime missing. The gate consults IsAvailable, so this only happens
+                    // when the very first environment build of the session fails right here.
+                    OnBrowserFailure("WebView2 environment unavailable", blameFile: false);
+                    return;
+                }
+
+                await surface.InitAsync(env, BrowserVideoEngine.SharedMappings(),
+                    BrowserVideoEngine.PlayerStartUrl, BrowserVideoEngine.PlayerHost);
+                VideoDiag.Log("BUBBLE", $"win[{tag}]: browser surface navigated");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "BubbleCountWindow: browser surface init failed");
+                OnBrowserFailure("surface init failed: " + ex.Message, blameFile: false);
+            }
+        }
+
+        /// <summary>
+        /// Page messages (plan §3). Runs on the UI thread INSIDE the WebView2 message callback, so
+        /// nothing here may tear down the surface that raised it - every heavy continuation is
+        /// posted back through <see cref="PostAfterPageMessage"/>.
+        /// </summary>
+        private void OnBrowserMessage(BrowserVideoSurface surface, JObject o)
+        {
+            try
+            {
+                var type = (string?)o["type"];
+
+                // Only the primary drives the game, exactly like the LibVLC primary player: a
+                // secondary's events would end the game twice.
+                if (!_isPrimary)
+                {
+                    if (type == "error")
+                        App.Logger?.Warning("BubbleCountWindow[secondary]: page error {Code} {Msg} (ignored - primary owns the game)",
+                            (int?)o["code"], (string?)o["message"]);
+                    return;
+                }
+
+                switch (type)
+                {
+                    case "meta":
+                    {
+                        // Replaces LengthChanged. Can arrive more than once (Infinity at
+                        // loadedmetadata, the real value at durationchange) - last one wins, and
+                        // AdoptRealDuration already ignores a repeat of what it has. 0 = the page
+                        // cannot know the duration, so the metadata-cache value (or the 30s
+                        // fallback) stands, just as it does when LengthChanged never fires.
+                        long durationMs = (long?)o["durationMs"] ?? 0;
+                        if (durationMs > 0) AdoptRealDuration(durationMs / 1000.0);
+                        else App.Logger?.Debug("BubbleCountWindow: browser meta with unknown duration - keeping {Duration:F1}s", _videoDurationSeconds);
+                        break;
+                    }
+                    case "playing":
+                        _browserPlayingSeen = true;
+                        StopBrowserFirstFrameWatch();
+                        VideoDiag.Log("BUBBLE", "browser PLAYING (page reported the first frame)");
+                        break;
+                    case "ended":
+                        // Same completion path as EndReached.
+                        PostAfterPageMessage(() =>
+                        {
+                            if (!_isCleaningUp && _isPrimary) OnVideoEnded();
+                        });
+                        break;
+                    case "error":
+                    {
+                        int code = (int?)o["code"] ?? 0;
+                        var msg = (string?)o["message"] ?? "";
+                        OnBrowserFailure($"page error {code}: {msg}", blameFile: BrowserErrorBlamesFile(code));
+                        break;
+                    }
+                    case "key":
+                        OnBrowserKey((string?)o["key"] ?? "");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BubbleCountWindow: browser message dispatch failed - {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Which page error codes mean "this FILE is undecodable" and belong in the unsafe cache.
+        /// 1-4 are MediaError.code verbatim, 100 is a &gt;10s stall after playing and 101 is no first
+        /// frame within the page's own window. 102/103 are session-level and must not condemn the
+        /// clip. Mirrors BrowserVideoEngine.BlamesFile.
+        /// </summary>
+        private static bool BrowserErrorBlamesFile(int code) => (code >= 1 && code <= 4) || code == 100 || code == 101;
+
+        /// <summary>
+        /// Keys over a focused WebView2 go to Chromium, not to this window, so the page reports them
+        /// back here. Same policy as <see cref="OnKeyDown"/>: ESC skips the game unless the strict
+        /// lock is on (the page has already preventDefaulted it either way).
+        /// </summary>
+        private void OnBrowserKey(string key)
+        {
+            if (!string.Equals(key, "Escape", StringComparison.OrdinalIgnoreCase)) return;
+            if (_strictMode || _gameCompleted || _isCleaningUp) return;
+            _gameCompleted = true;
+            PostAfterPageMessage(() => CloseAllWindows(false));
+        }
+
+        private void OnBrowserProcessFailed(BrowserVideoSurface surface, CoreWebView2ProcessFailedKind kind)
+        {
+            // Counted app-wide so a flapping renderer stands the engine down for everyone rather
+            // than costing every feature a fallback. Never blames the file (plan §4).
+            BrowserVideoEngine.ReportProcessFailure(kind);
+            OnBrowserFailure("WebView2 process failed: " + kind, blameFile: false);
+        }
+
+        /// <summary>
+        /// The page could not play this clip.
+        ///
+        /// Stage 2 deliberately does NOT re-run the same file through LibVLC mid-game the way
+        /// VideoService does: the surfaces here are per-window and the game clock, bubble schedule
+        /// and target count are already running off the failed attempt, so a swap would have to
+        /// rebuild every window's playback from inside a page callback. Instead the file is marked
+        /// browser-unsafe - the very next game that draws it takes the LibVLC path - and this game
+        /// ends through the flow it already has for a video that would not play.
+        /// </summary>
+        private void OnBrowserFailure(string reason, bool blameFile)
+        {
+            if (!_isPrimary || _browserFailed || _isCleaningUp || _videoEnded) return;
+            _browserFailed = true;
+            StopBrowserFirstFrameWatch();
+
+            App.Logger?.Warning("BubbleCountWindow: browser playback failed for {File} ({Reason})",
+                Path.GetFileName(_videoPath), reason);
+            VideoDiag.Log("BUBBLE", $"browser FAILED ({reason}) blameFile={blameFile}");
+            if (blameFile) BrowserUnsafeVideoCache.Add(_videoPath, reason);
+
+            var startedOnce = _browserPlayingSeen;
+            PostAfterPageMessage(() =>
+            {
+                if (_isCleaningUp || _videoEnded) return;
+                if (startedOnce)
+                {
+                    // Mid-clip failure: the user has already watched and counted most of it, so end
+                    // the video exactly as EncounteredError does on the LibVLC path.
+                    OnVideoEnded();
+                }
+                else
+                {
+                    // Never showed a frame. Asking for a bubble count would be a guaranteed fail, so
+                    // this is a can't-show: the existing completion flow retries (strict) or ends
+                    // the game (non-strict), and a retry draws a NEW video that skips this file.
+                    _gameCompleted = true;
+                    CloseAllWindows(false);
+                }
+            });
+        }
+
+        private void ArmBrowserFirstFrameWatch()
+        {
+            StopBrowserFirstFrameWatch();
+            _browserFirstFrameTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(BrowserFirstFrameTimeoutMs)
+            };
+            _browserFirstFrameTimer.Tick += (s, e) =>
+            {
+                StopBrowserFirstFrameWatch();
+                if (_browserPlayingSeen || _videoEnded || _isCleaningUp) return;
+                // blameFile stays false: the page's own 101 report is what condemns a file it could
+                // actually load. Getting here means the PAGE never ran, which is environmental.
+                OnBrowserFailure($"no playback within {BrowserFirstFrameTimeoutMs / 1000}s", blameFile: false);
+            };
+            _browserFirstFrameTimer.Start();
+        }
+
+        private void StopBrowserFirstFrameWatch()
+        {
+            try { _browserFirstFrameTimer?.Stop(); } catch { }
+            _browserFirstFrameTimer = null;
+        }
+
+        /// <summary>
+        /// Queue work for AFTER the current page message returns. Page events arrive inside the
+        /// WebView2 message callback, and anything heavy done there (closing the very surface that
+        /// raised it, CloseAllWindows' pumped waits) re-enters the browser's own message loop - the
+        /// same discipline the LibVLC handlers use with Task.Run. Normal priority:
+        /// DispatcherPriority.Loaded is starved in this app.
+        /// </summary>
+        private static void PostAfterPageMessage(Action action)
+        {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+            try { dispatcher.BeginInvoke(DispatcherPriority.Normal, action); }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BubbleCountWindow: browser continuation dispatch failed - {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>Unhook, stop the clip and dispose the WebView2. Called from OnClosed, which every
+        /// teardown path (normal close, panic force-close, orphan sweep) funnels through.</summary>
+        private void DisposeBrowserSurface()
+        {
+            StopBrowserFirstFrameWatch();
+            var surface = _browserSurface;
+            if (surface == null) return;
+            _browserSurface = null;
+            try
+            {
+                surface.Message -= OnBrowserMessage;
+                surface.ProcessFailed -= OnBrowserProcessFailed;
+                // Decoder hygiene: pause -> drop src -> load(), so Chromium frees the decoder now.
+                if (surface.IsReady) surface.Post(new { type = "stop" });
+                surface.DisposeWeb();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BubbleCountWindow: browser surface teardown failed - {Error}", ex.Message);
+            }
+        }
+
+        #endregion
+
         private void CalculateTargetBubbles()
         {
             double baseRate = _difficulty switch
@@ -947,6 +1306,10 @@ namespace ConditioningControlPanel
             {
                 window._videoEnded = true;
                 window._bubbleSpawnTimer?.Stop();
+                window.StopBrowserFirstFrameWatch();
+                // The game windows are only HIDDEN for the result screen, so a clip that is still
+                // running (safety-timer end, mid-clip failure) would keep playing behind it.
+                try { window._browserSurface?.Post(new { type = "pause" }); } catch { }
             }
 
             // Clear remaining bubbles on all windows (bubbles are separate windows now).
@@ -1076,6 +1439,8 @@ namespace ConditioningControlPanel
             _bubbleSpawnTimer?.Stop();
             _bubbleAnimTimer?.Stop();
             _bubbleAnimTimer = null;
+            // Browser mode: closing the window alone would leave the browser process alive.
+            DisposeBrowserSurface();
 
             foreach (var bubble in _activeBubbles)
             {

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -84,10 +84,10 @@ Queue outbound messages until the page posts `ready` (ChaosWebViewHost pattern).
 C# → page:
 | msg | fields | notes |
 |---|---|---|
-| `load` | `url, volume (0-1), muted, blurBackground (bool), startAtMs?` | begins playback immediately |
+| `load` | `url, volume (0-1), muted, blurBackground (bool), hideCursor (bool), startAtMs?` | begins playback immediately. `hideCursor` defaults to **false** — the LibVLC video windows do not hide the pointer either, and BubbleCount is mouse-driven |
 | `pause` / `resume` | — | grace pause / DtRH / voice commands |
 | `stop` | — | decoder hygiene: `pause()` → `removeAttribute('src')` → `load()` |
-| `setVolume` | `volume` | master × video volume, external-mute folds in C#-side |
+| `setVolume` | `volume`, `muted?` | master × video volume; the optional `muted` folds external mute in. Secondaries are always sent `volume: 0, muted: true` |
 | `seek` | `ms` | future Deeper use; implement anyway (trivial) |
 
 page → C#:
@@ -100,13 +100,15 @@ page → C#:
 | `ended` | — | natural end |
 | `error` | `code, message` | media error OR unrequested stall the page can't recover |
 | `click` | — | any pointer-down on the surface |
+| `key` | `key, alt, ctrl, shift` | every non-repeat keydown the page saw (DOM `event.key`). Keyboard over a focused WebView2 goes to Chromium, so this is the ONLY route ESC / panic keys have back to C#; the page `preventDefault`s the dangerous ones and C# owns the policy |
 | `log` | `msg` | host built-in page logging |
 
 Page behaviour (from `surfaces.js` discipline):
 - `<video>` born muted then volume applied via message (autoplay flag makes `play()`
   legal anyway, but belt-and-suspenders).
 - `playsInline`, `disablePictureInPicture`, `preload='auto'`, no controls,
-  context-menu suppressed, text selection suppressed, cursor hidden over the surface.
+  context-menu suppressed, text selection suppressed. Cursor hiding is opt-in per load
+  (`hideCursor`), NOT unconditional — see the `load` row above.
 - Anti-pause: an unrequested `pause` while a session is live ⇒ resume once, then
   report `error` if it re-pauses (don't fight forever).
 - Blur background: when `blurBackground`, render TWO elements from the same src —

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -1,0 +1,227 @@
+# Browser Video Engine (hybrid) — Implementation Plan
+
+Branch: `feat/browser-video-engine` (worktree `C:\Projects\ccp-wt-browservideo`).
+Owner decision (2026-08-04): **hybrid** — browser-first playback, existing LibVLC path
+stays as fallback for files the browser cannot decode. No caller-facing API changes.
+
+## 1. Why
+
+Roughly 2,000 lines of `Services/Video/VideoService.cs` exist solely to survive LibVLC:
+native quarantine (#559), retire circuit breaker (#557-#560/#574), 3-rung wedge ladder
+(#529/#532/#765/#766/#767), vout self-heal (#600), poison cooldown (#766), `VideoDiag`.
+Procdump (v6.6.2, #750-#753) proved a native use-after-free inside LibVLC's event
+manager. LibVLC renders in-process and can wedge the WPF dispatcher; WebView2 media is
+out-of-process — a dead renderer is a `ProcessFailed` event, not a frozen PC.
+
+## 2. Architecture
+
+```
+VideoService (unchanged public contract, stays the director:
+  scheduling, selection, XP, troll replay, mercy, events, ducking, safety timers)
+    └─ after file selection, route:
+         BrowserVideoGate.ShouldUseBrowser(path)  ── yes ──> BrowserVideoEngine
+                                                └── no ───> existing LibVLC path (untouched)
+```
+
+New files (all under `Services/Video/Browser/`):
+- **`BrowserVideoEngine.cs`** — process-wide singleton owned by VideoService (or App).
+  Creates ONE shared `CoreWebView2Environment` (user-data folder
+  `%LOCALAPPDATA%\ConditioningControlPanel\browser_data_video`), owns the per-monitor
+  window set for the active session, exposes `StartSession(BrowserVideoRequest)` /
+  `StopSession()` and events back to VideoService. If environment creation throws
+  (WebView2 runtime missing), mark `IsAvailable=false` for the whole session and log
+  one clear Warning — every video then routes to LibVLC. Never throw to callers.
+- **`BrowserVideoWindow`** (WPF window class) — one per monitor, borderless, sized to
+  full **physical** bounds of its `Screen` (mirror `ForceFullScreenBounds` logic in
+  VideoService for mixed-DPI; use `BubbleCountWindow.GetDpiForScreen`). Topmost.
+  `AllowsTransparency = false` — HARD RULE, WebView2 never paints in layered windows.
+  NOTHING may ever call `SetLayeredWindowAttributes` on these windows.
+- **`BrowserVideoGate.cs`** — `ShouldUseBrowser(path)`:
+  `App.Settings.Current.BrowserVideoEngineEnabled && engine.IsAvailable
+   && ext ∈ {.mp4, .m4v, .webm} && !UnsafeCache.Contains(path)`.
+- **`BrowserUnsafeVideoCache.cs`** — persisted JSON (`App.UserDataPath\browser_unsafe_videos.json`),
+  key = full path + file size. A file lands here when the page reports `error` for it
+  or never reports `playing` within 10 s; from then on it routes to LibVLC forever.
+  Cap entries (say 2,000), save debounced, load lazily. Corrupt file ⇒ empty cache.
+
+Web page: **`Resources/web/player/index.html` + `player.js` + `player.css`**.
+Served as `https://ccp.game/player/index.html`. Copy the decoder discipline from
+`Resources/web/fyp/surfaces.js` (do NOT import fyp files; the player is standalone).
+
+### Host windows / WebView2 setup
+Reuse the `ChaosWebViewHost` *patterns*, not necessarily the class (it is hardcoded to
+the primary screen and carries FYP-specific z-order glue). If extending it, the change
+must be purely additive (optional explicit-bounds option); forking a lean host window
+is acceptable and probably simpler. Requirements per window:
+- Browser args: `--autoplay-policy=no-user-gesture-required
+  --disable-direct-composition-video-overlays
+  --disable-features=CalculateNativeWinOcclusion
+  --disable-backgrounding-occluded-windows`
+  (MPO black-screen #449/#439; occlusion throttling freezes covered/parked pages).
+- Virtual host mappings (create directories BEFORE mapping — a missing folder makes
+  WebView2 silently skip the mapping, see `FypHostService.cs:65-68`):
+  - `ccp.game`  → `AppContext.BaseDirectory\Resources\web` (`Deny`)
+  - `ccp.assets` → `App.EffectiveAssetsPath` (`Allow`)
+  - `ccp.packs` → the content-pack temp-decrypt directory (`Allow`) — pack videos are
+    AES-decrypted to a temp path per play (`GetPackFileTempPath`); the page can only
+    reach them if that directory is mapped. Resolve the actual temp root from the
+    existing pack code; do not hardcode.
+- URL building: percent-escape per segment exactly like `FypAssetManifest.cs:112`.
+- `NavigationStarting` lockdown to `https://ccp.game/`.
+- `CoreWebView2.ProcessFailed` ⇒ treat as playback error: end session, fall back
+  (§4). Also guards the "zombie control" state (`BrowserService.cs:232-238`).
+- `EnsureCoreWebView2Async` only after the control is in the visual tree.
+- Multi-monitor: one window per `Screen`, honouring `ShouldFillSecondaryMonitors`
+  (high monitor-count cap, #389). Primary window carries audio; secondaries load with
+  `muted: true`. Windows share the single environment.
+- Input: window-level `PreviewMouseDown` is unreliable over a WebView2 child HWND —
+  the page posts `{type:'click'}` instead (§3) and C# calls `BringTargetsToFront()`.
+
+## 3. C# ⇄ page protocol (JSON via PostWebMessageAsJson / WebMessageReceived)
+
+Queue outbound messages until the page posts `ready` (ChaosWebViewHost pattern).
+
+C# → page:
+| msg | fields | notes |
+|---|---|---|
+| `load` | `url, volume (0-1), muted, blurBackground (bool), startAtMs?` | begins playback immediately |
+| `pause` / `resume` | — | grace pause / DtRH / voice commands |
+| `stop` | — | decoder hygiene: `pause()` → `removeAttribute('src')` → `load()` |
+| `setVolume` | `volume` | master × video volume, external-mute folds in C#-side |
+| `seek` | `ms` | future Deeper use; implement anyway (trivial) |
+
+page → C#:
+| msg | fields | notes |
+|---|---|---|
+| `ready` | — | host built-in |
+| `meta` | `durationMs, width, height` | on `loadedmetadata`; feeds safety timer + `VideoMetadataCache` backfill |
+| `playing` | — | first real `playing` event; arms the C#-side "started" state |
+| `time` | `ms` | ~10 Hz from `timeupdate`; drives `PrimaryPlaybackTimeMsChanged` |
+| `ended` | — | natural end |
+| `error` | `code, message` | media error OR unrequested stall the page can't recover |
+| `click` | — | any pointer-down on the surface |
+| `log` | `msg` | host built-in page logging |
+
+Page behaviour (from `surfaces.js` discipline):
+- `<video>` born muted then volume applied via message (autoplay flag makes `play()`
+  legal anyway, but belt-and-suspenders).
+- `playsInline`, `disablePictureInPicture`, `preload='auto'`, no controls,
+  context-menu suppressed, text selection suppressed, cursor hidden over the surface.
+- Anti-pause: an unrequested `pause` while a session is live ⇒ resume once, then
+  report `error` if it re-pauses (don't fight forever).
+- Blur background: when `blurBackground`, render TWO elements from the same src —
+  a background `<video>` with `object-fit: cover; filter: blur(40px) brightness(.7);
+  transform: scale(1.1)` (blur edge bleed) and the foreground `object-fit: contain`.
+  Background is always `muted`. When off: black background, contain only.
+  This replaces the entire `BlurVmemSurface` vmem path for browser sessions.
+- Media `error` event or `stalled`>10s ⇒ post `error`, never throw.
+
+## 4. Hybrid routing + runtime fallback
+
+1. Selection (existing off-thread logic, #732) produces a path.
+2. `ShouldUseBrowser(path)`? → browser session; else LibVLC path exactly as today.
+3. Runtime failure fallback (once per video): if the page posts `error`, or posts no
+   `playing` within **10 s** of `load`, or `ProcessFailed` fires:
+   - mark path in `BrowserUnsafeVideoCache` (only for media errors / playing-timeout,
+     NOT for `ProcessFailed` — that's an environment failure, not the file's fault),
+   - tear down the browser session **without** raising VideoEnded,
+   - replay the SAME file through the LibVLC path (guard flag so this happens at most
+     once per trigger; if LibVLC then also fails, normal existing error flow applies).
+4. `ProcessFailed` twice in one app session ⇒ `IsAvailable=false` for the rest of the
+   session (stop flapping).
+
+## 5. VideoService integration — parity checklist
+
+The browser session must be indistinguishable from a LibVLC session to every consumer.
+All of the following stay in VideoService (C#-side) and must fire for browser sessions:
+
+- [ ] `VideoAboutToStart` / `VideoStarted` / `VideoEnded` events; `LastVideoPath`,
+      `LastVideoTitle`, `IsPlaying`, `_videoPlaying` flag lifecycle.
+- [ ] Ducking: `App.Audio.Duck(level)` at start with `_didDuck`; exactly one `Unduck`
+      in the teardown path (`CloseAll` finally parity, #526). NOTE: WebView2 PIDs are
+      excluded from the duck sweep by default (`ExcludeBambiCloudFromDucking`), which
+      is what we want — the video's own audio survives the duck.
+- [ ] Safety timers (all C#-side, unchanged mechanisms): duration guillotine armed
+      from the page `meta` message (was `LengthChanged`); 10-min fallback timer;
+      `VideoMaxDurationSeconds` hard cap; `_enhancementDriving` stall-watch semantics.
+- [ ] Attention checks: `SetupAttention` + `FloatingText` windows are ALREADY separate
+      topmost Win32 windows — reuse UNCHANGED over the browser windows. Wire the page
+      `click` message to `BringTargetsToFront()`. Gaze (`GetGazeTargets`/`GazeClick`)
+      and toy-button input paths unchanged. `EndCurrentVideo` pass/fail/XP/troll
+      replay/mercy logic unchanged.
+- [ ] Strict mode: `Closing` veto + panic/Alt-F4/system-key swallowing on
+      `BrowserVideoWindow` (mirror `SetupStrictHandlers`); non-strict ESC ⇒ Cleanup.
+      NOTE: keyboard events over a focused WebView2 go to Chromium — also suppress
+      in-page (`keydown` preventDefault for Escape/F4/system keys) and make the
+      windows non-activating like the LibVLC ones (`MakeNonActivating`) so the WPF
+      handlers keep working app-side.
+- [ ] Grace pause (#735): `TryGracePauseFromPanic` sends `pause`/`resume`;
+      `GracePauseOverlayWindow` reuse unchanged; TimerArm capture/re-arm unchanged;
+      60 s auto-resume.
+- [ ] `SetExternalMute` (DtRH dive) and volume updates ⇒ `setVolume` messages via
+      `GetEffectiveVolume()`.
+- [ ] `PausePrimary`/`PlayPrimary`/`SeekPrimary` map to messages (voice commands,
+      DtRH); `GetCurrentPlaybackTimeMs` + `PrimaryPlaybackTimeMsChanged` fed from
+      `time` messages (FunScript haptics + Deeper time source keep working).
+- [ ] `PrimaryMediaPlayer` stays **null** during browser sessions — Deeper's
+      enhancement bridge simply won't attach (documented Stage-1 gap; the null path
+      already exists and must not throw).
+- [ ] `SessionSwitch` (lock) + `PowerModeChanged` (suspend) force-clean unchanged.
+- [ ] Teardown generation guard applies to browser session continuations too.
+- [ ] `VideoMetadataCache` backfill: write duration from the page `meta` message so
+      the duration filter improves over time without LibVLC parses.
+- [ ] Wedge/vout/quarantine/poison machinery: **not armed** for browser sessions
+      (nothing native to wedge). `NativePoisonCooldownRemainingMs` must NOT gate
+      browser playback.
+- [ ] FYP exclusivity gates (`FypHostService` active ⇒ video features off) unchanged.
+
+## 6. Stage 2 — BubbleCount
+
+`BubbleCountService` (scheduling/XP/mercy) untouched. `BubbleCountWindow` gets a
+browser-mode surface: when `BrowserVideoGate.ShouldUseBrowser(path)`, host a WebView2
+playing the same player page instead of leasing a LibVLC player. Bubble overlay
+windows, count logic, result window, duration resolution (`meta` message replaces
+`AdoptRealDuration`'s `LengthChanged`) unchanged. Poison-cooldown skip
+(`BubbleCountService.cs:132/:334`, `BubbleCountWindow:233`) only applies when the
+session would use LibVLC. Managed wedge watchdog not armed in browser mode.
+Simplest implementation: reuse `BrowserVideoEngine`'s environment + a
+`BrowserVideoWindow` variant (or the same class with an options struct).
+
+## 7. Settings + localization
+
+- `AppSettings.BrowserVideoEngineEnabled` — bool, `[JsonProperty]`, default **false**
+  (beta opt-in). Toggle UI next to the existing video settings (near the blurred-
+  background toggle), labelled as beta.
+- Loc keys in ALL 9 `Localization/Languages/*.json`. STRICT JSON: escaped `\n` only,
+  never literal newlines; don't touch line endings (files are LF in git, CRLF in
+  worktree via autocrlf — normal).
+
+## 8. Traps (read before coding)
+
+1. WebView2 + `AllowsTransparency=true` ⇒ nothing paints. `LWA_ALPHA` ⇒ solid black.
+2. MPO: without `--disable-direct-composition-video-overlays` some GPUs scan out
+   black video / video above topmost overlays.
+3. Occlusion: without the two occlusion flags Chromium stops rendering covered
+   windows.
+4. Missing mapped folder ⇒ mapping silently skipped. `Directory.CreateDirectory` first.
+5. Never block inside `WebMessageReceived` (`await Task.Yield()` before anything
+   modal) — re-enters the browser message loop.
+6. `document.exitFullscreen` unreliable — we never use HTML fullscreen; windows are
+   OS-level fullscreen borderless. Don't call `requestFullscreen` in the page.
+7. Duplicate WPF resource keys crash at launch and tests don't catch it.
+8. `--no-build` runs a stale dll; always full `dotnet build`.
+9. `DispatcherPriority.Loaded` is starved in this app — use `Normal`.
+10. Don't put converters in local Grid.Resources (DataTemplate lookup fails).
+11. LibVLC path stays byte-for-byte untouched except the routing branch — the
+    fallback must keep working exactly as shipped.
+12. The FYP ghost/DWM-mirror machinery is NOT needed here — mandatory video windows
+    are opaque fullscreen. Do not touch `FypGhostOverlay`.
+
+## 9. Later stages (not this branch)
+
+- `setSinkId` per-element audio-device routing (parity with `ApplyPreferredDevice`).
+- Duck-exclusion granularity per user-data-folder/PID.
+- Optional ffmpeg transcode tool for non-browser-safe libraries.
+- DOM-based attention targets (delete FloatingText interop).
+- Migrate small LibVLC consumers (mini-player, help video, gaze minigame, editor
+  preview, inline loop); then delete the watchdog museum + `BlurVmemSurface`.


### PR DESCRIPTION
## Why

About half of our bug volume is hangs/freezes, and the worst of them live in the LibVLC video path: the v6.6.2 procdump proved a native use-after-free inside LibVLC's event manager, and ~2,000 lines of VideoService exist solely to survive LibVLC (wedge ladder, quarantine, retire circuit breaker, vout self-heal, poison cooldown). LibVLC renders in-process and can take the WPF dispatcher down with it. WebView2 media is out-of-process - a dead renderer is a ProcessFailed event, not a frozen PC.

## What

**Hybrid, opt-in (beta):** new setting `BrowserVideoEngineEnabled` (default OFF - flag-off is a reviewed, proven no-op). When ON, browser-safe files (.mp4/.m4v/.webm) play through per-monitor WebView2 windows driving a new web player page; everything else - and any file the browser fails on - automatically uses the classic LibVLC path. A persisted unsafe-file cache (stable keys, pack-aware) makes each failure a one-time cost.

- `Services/Video/Browser/` - engine (shared environment, per-monitor windows, JSON bridge), gate, unsafe cache, reusable `BrowserVideoSurface`
- `Resources/web/player/` - hardened HTML5 surface (decoder hygiene, anti-pause, stall watchdog, CSS blurred-background replacing the 725-line vmem blur path for browser sessions)
- `VideoService` keeps its entire public contract - all 15+ callers (sessions, autonomy/takeover, effect bubbles, remote, voice) unchanged. Full parity: events, ducking, safety timers, attention checks (FloatingText reused), strict mode, grace pause, time source for FunScript/Deeper
- BubbleCount hosts a browser surface inside its own windows (HUD/count/mercy flow untouched)
- None of the native watchdog machinery arms for browser sessions; poison cooldown only gates LibVLC-bound games

## Verification

- 3-lens adversarial review (concurrency/lifecycle, protocol conformance, integration regressions) -> 20 adjudicated fixes, then an independent verification pass on the strict/teardown fix cluster -> 3 residual low-severity fixes. Flag-off no-op was explicitly proven by the integration reviewer.
- Unattended smoke test on this machine (dual monitor): browser mandatory video CONFIRMED end-to-end (WebView2 process tree up/down cleanly, ESC teardown, app responsive); hybrid routing proven per-file (a .mov fell through to LibVLC mid-session while .mp4s used the browser); flag-off regression test clean (same clip, classic path); no crash.log, zero ERR/FTL lines.

## Known gaps / follow-ups (documented in docs/BROWSER_VIDEO_ENGINE_PLAN.md)

- Deeper enhancement bridge doesn't attach in browser sessions (PrimaryMediaPlayer stays null by design; time source works)
- Per-element audio device routing (setSinkId) and finer duck-exclusion granularity are Stage 3
- .m4v MIME risk is self-healing (a failing .m4v routes to LibVLC forever via the unsafe cache)
- Browser BubbleCount not exercised e2e: blocked by a PRE-EXISTING InteractionQueue slot leak on ESC-ended videos (reproduces identically with the flag off; self-heals via stuck-recovery timeout) - separate ticket recommended
- One smoke anomaly to re-test deliberately: ESC ended the browser video while LibVLC grace-paused - discriminator was a live attention target, not an engine flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DDEHEykXLQLzBZFw9Qv7h