### PR TITLE
In-window attention targets, grace pause mid-target, engine-stop slot release

### DIFF
--- a/ConditioningControlPanel/Resources/web/player/index.html
+++ b/ConditioningControlPanel/Resources/web/player/index.html
@@ -17,6 +17,11 @@
     <video id="bg" muted playsinline preload="auto" disablepictureinpicture></video>
     <video id="fg" playsinline preload="auto" disablepictureinpicture></video>
   </div>
+  <!-- Attention-check targets (attentionShow / attentionHide). The only
+       hit-testable thing on the page: the layer itself passes presses through,
+       each target takes its own and reports attentionClick INSTEAD of the
+       generic click. C# still owns the text, the styling and the schedule. -->
+  <div id="attn"></div>
   <script src="player.js"></script>
 </body>
 </html>

--- a/ConditioningControlPanel/Resources/web/player/player.css
+++ b/ConditioningControlPanel/Resources/web/player/player.css
@@ -59,3 +59,87 @@ body.hide-cursor * {
 }
 
 body.has-bg #bg { display: block; }
+
+/* ---- attention-check targets ----
+   The predecessor was one topmost Win32 window per target, moved with a
+   SetWindowPos every 16ms — that per-frame window move is what the owner saw as
+   stutter. Here the bounce is a transform and the fade is an opacity
+   transition, so both stay on the compositor and never trigger layout.
+   The numbers below mirror AttentionTargetVisual (7.5px outline, 20/10 padding,
+   20px radius, 3px border, 150x60 minimum) so the two renderings match. */
+
+#attn {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  overflow: hidden;
+  /* Only the targets take presses; everything else falls through to the
+     window-level handler that reports a generic click. */
+  pointer-events: none;
+}
+
+.attn {
+  position: absolute;
+  left: 0;
+  top: 0;
+  min-width: 150px;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  cursor: pointer;
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  will-change: transform, opacity;
+  transition: opacity 0.3s linear;
+}
+
+/* Clicked, waiting for the host's attentionHide: still visible, no longer
+   clickable — a second press must not report a second hit. */
+.attn.attn-hit { pointer-events: none; }
+
+/* Grace pause (#735): frozen in place under the host's Resume card. The motion
+   loop is stopped in JS; this is what stops the clicks. */
+body.attn-paused .attn { pointer-events: none; }
+
+.attn.gone { opacity: 0; pointer-events: none; }
+
+.attn-box {
+  position: relative;
+  padding: 10px 20px;
+  border-radius: 20px;
+  border: 0 solid transparent;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.6);
+}
+
+/* Floating-text mode: the outlined glyphs and nothing else. */
+.attn-floating .attn-box {
+  padding: 0;
+  border-radius: 0;
+  border-width: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.attn-text { position: relative; display: block; }
+
+.attn-text span {
+  display: block;
+  white-space: pre-line;   /* C# already split the trigger into lines */
+  text-align: center;
+  font-weight: 700;
+  line-height: 0.95;
+}
+
+/* Stroke underneath, fill on top: the same two-pass outline the WPF target
+   draws with a stroked and a filled copy of the glyph geometry. The stroked
+   copy is out of flow so the filled one alone defines the box size. */
+.attn-text .out {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  color: transparent;
+  -webkit-text-stroke: 7.5px #000;
+}

--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -55,6 +55,7 @@
 
   const bg = document.getElementById('bg');
   const fg = document.getElementById('fg');
+  const attnLayer = document.getElementById('attn');
 
   // Belt-and-braces alongside the HTML attributes: the element is born muted and
   // silent, and the host's volume only lands once a load says so.
@@ -105,6 +106,7 @@
   /** Free both decoders NOW. Safe to call at any time, including with no session. */
   function teardown() {
     cur = null; // first, so the pause/error churn below reaches no handler
+    clearAttention(); // targets belong to the clip that is going away
     stopTicker();
     lastTimeMs = -1;
     lastTimePostAt = 0;
@@ -380,9 +382,203 @@
     log('blur backdrop failed to decode - falling back to black');
   });
 
+  // ---------- attention-check targets ----------
+
+  // C# owns everything that decides an attention check: the trigger text (mod
+  // pool + localization stay C#-side), the styling, when a target appears, when
+  // it expires and what a hit is worth. The page owns only the paint and the
+  // bounce — as transform/opacity on a promoted layer, which is the whole point
+  // of moving them in here from their own topmost windows.
+  //
+  // Live from attentionShow until attentionHide; a click reports attentionClick
+  // and then WAITS for the host to hide it, so C#'s _targets list stays the one
+  // authority on which checks are outstanding (it also gates the grace pause).
+
+  const attn = new Map();
+  let attnRaf = 0;
+  let attnLastTs = 0;
+  let attnLastReport = 0;
+  let attnPaused = false;
+
+  function attnPump() {
+    if (!attnRaf && !attnPaused && attn.size) attnRaf = requestAnimationFrame(attnFrame);
+  }
+
+  function attnFrame(ts) {
+    attnRaf = 0;
+    // A pause that landed while this frame was already queued must still win.
+    if (attnPaused || !attn.size) { attnLastTs = 0; return; }
+
+    // A dropped frame (or a page the compositor parked) must nudge the target,
+    // not teleport it across the screen.
+    const dt = attnLastTs ? Math.min(0.25, Math.max(0, (ts - attnLastTs) / 1000)) : 1 / 60;
+    attnLastTs = ts;
+    const report = ts - attnLastReport >= TICK_MS;
+    if (report) attnLastReport = ts;
+    const vw = window.innerWidth || 1;
+    const vh = window.innerHeight || 1;
+
+    attn.forEach((t) => {
+      t.x += t.vx * dt;
+      t.y += t.vy * dt;
+      if (t.x < t.minX) { t.x = t.minX; t.vx = Math.abs(t.vx); }
+      if (t.x + t.w > t.maxX) { t.x = t.maxX - t.w; t.vx = -Math.abs(t.vx); }
+      if (t.y < t.minY) { t.y = t.minY; t.vy = Math.abs(t.vy); }
+      if (t.y + t.h > t.maxY) { t.y = t.maxY - t.h; t.vy = -Math.abs(t.vy); }
+      t.el.style.transform = 'translate3d(' + t.x + 'px,' + t.y + 'px,0)';
+      // Gaze hit-testing runs C#-side against DIP bounds, and nothing else
+      // consumes these — so they are only posted when the host asked for them.
+      if (report && t.report && !t.hit) {
+        post({
+          type: 'attentionMove',
+          id: t.id,
+          xPct: t.x / vw,
+          yPct: t.y / vh,
+          wPct: t.w / vw,
+          hPct: t.h / vh,
+        });
+      }
+    });
+
+    attnPump();
+  }
+
+  function attentionShow(d) {
+    const id = d && d.id != null ? String(d.id) : '';
+    if (!id || !attnLayer) return;
+    attentionHide({ id: id }); // a repeated id replaces, never stacks
+
+    const label = typeof d.text === 'string' ? d.text : '';
+    const size = Number(d.size) > 0 ? Number(d.size) : 40;
+
+    const el = document.createElement('div');
+    el.className = 'attn' + (d.floating ? ' attn-floating' : '');
+    el.dataset.id = id;
+
+    const box = document.createElement('div');
+    box.className = 'attn-box';
+    if (!d.floating) {
+      // LinearGradientBrush(color1, color2, 90) is top-to-bottom in WPF.
+      box.style.background = 'linear-gradient(180deg,' + (d.color1 || '#FF1493') + ',' + (d.color2 || '#FF69B4') + ')';
+      if (d.showBorder) {
+        box.style.borderWidth = '3px';
+        box.style.borderColor = d.borderColor || '#FF1493';
+      }
+    }
+
+    const text = document.createElement('div');
+    text.className = 'attn-text';
+    text.style.fontSize = size + 'px';
+    text.style.fontFamily = '"' + String(d.font || 'Segoe UI') + '","Segoe UI",Arial,sans-serif';
+
+    const out = document.createElement('span');
+    out.className = 'out';
+    out.textContent = label;      // textContent, never innerHTML: the trigger is user data
+    const fill = document.createElement('span');
+    fill.className = 'fill';
+    fill.textContent = label;
+    fill.style.color = d.textColor || '#FF1493';
+
+    text.appendChild(out);
+    text.appendChild(fill);
+    box.appendChild(text);
+    el.appendChild(box);
+    attnLayer.appendChild(el);
+
+    // Only the page can know how big the target measured, so it resolves the
+    // host's 0..1 spawn position against its own bounds.
+    const r = el.getBoundingClientRect();
+    const w = r.width || 150;
+    const h = r.height || 60;
+    const vw = window.innerWidth || w;
+    const vh = window.innerHeight || h;
+    const minX = Math.min(150, vw * 0.08);
+    const minY = Math.min(100, vh * 0.08);
+    const maxX = Math.max(minX + w, vw - minX);
+    const maxY = Math.max(minY + h, vh - minY);
+    const px = Number.isFinite(d.xPct) ? Math.min(1, Math.max(0, d.xPct)) : Math.random();
+    const py = Number.isFinite(d.yPct) ? Math.min(1, Math.max(0, d.yPct)) : Math.random();
+
+    const t = {
+      id: id,
+      el: el,
+      w: w,
+      h: h,
+      minX: minX,
+      minY: minY,
+      maxX: maxX,
+      maxY: maxY,
+      x: minX + px * Math.max(0, (maxX - w) - minX),
+      y: minY + py * Math.max(0, (maxY - h) - minY),
+      vx: Number.isFinite(d.vx) ? d.vx : 130,
+      vy: Number.isFinite(d.vy) ? d.vy : 130,
+      report: !!d.reportMotion,
+      hit: false,
+    };
+    el.style.transform = 'translate3d(' + t.x + 'px,' + t.y + 'px,0)';
+    attn.set(id, t);
+    attnPump();
+  }
+
+  function attentionHide(d) {
+    const id = d && d.id != null ? String(d.id) : '';
+    const t = attn.get(id);
+    if (!t) return;
+    attn.delete(id);
+    if (!attn.size) attnLastTs = 0;
+    const el = t.el;
+    if (d && d.fade) {
+      el.classList.add('gone');
+      // The CSS transition owns the fade; this only reaps the node afterwards.
+      setTimeout(() => { if (el.parentNode) el.parentNode.removeChild(el); }, 400);
+      return;
+    }
+    if (el.parentNode) el.parentNode.removeChild(el);
+  }
+
+  function attentionHit(t) {
+    if (!t || t.hit) return;
+    t.hit = true;
+    t.el.classList.add('attn-hit');
+    // C# runs the whole hit pipeline (pop sound, XP, clearing this spawn's
+    // mirrors on the other monitors) and answers with attentionHide.
+    post({ type: 'attentionClick', id: t.id });
+  }
+
+  /**
+   * Grace pause (#735): the targets freeze with the video. Same host-paused
+   * state the media watchdogs use, so the two can never disagree — the bounce
+   * stops, presses stop registering, and the targets stay on screen under the
+   * host's Resume card. The lifespan countdown is C#-side and freezes there.
+   */
+  function attentionSetPaused(paused) {
+    attnPaused = !!paused;
+    document.body.classList.toggle('attn-paused', attnPaused);
+    if (attnPaused) {
+      if (attnRaf) { cancelAnimationFrame(attnRaf); attnRaf = 0; }
+      attnLastTs = 0; // resume must step one frame, not the whole pause
+      return;
+    }
+    attnPump();
+  }
+
+  function clearAttention() {
+    attn.forEach((t) => { if (t.el.parentNode) t.el.parentNode.removeChild(t.el); });
+    attn.clear();
+    if (attnRaf) { cancelAnimationFrame(attnRaf); attnRaf = 0; }
+    attnLastTs = 0;
+    // A session torn down while paused must not leave the next clip's targets
+    // unclickable - the resume that would have cleared it is never coming.
+    attnPaused = false;
+    document.body.classList.remove('attn-paused');
+  }
+
   // ---------- inbound protocol ----------
 
   function doPause() {
+    // Attention targets freeze even with no live load: the host can hold the
+    // session at any point and a target must never drift on under the card.
+    attentionSetPaused(true);
     if (!cur) return;
     cur.hostPaused = true;
     try { fg.pause(); } catch (e) { /* ignore */ }
@@ -391,6 +587,7 @@
   }
 
   function doResume() {
+    attentionSetPaused(false);
     if (!cur || cur.errored || cur.ended) return;
     cur.hostPaused = false;
     // The watchdog clocks restart from here, or a 60s grace pause would look
@@ -449,6 +646,12 @@
       case 'seek':
         doSeek(data.ms);
         break;
+      case 'attentionShow':
+        attentionShow(data);
+        break;
+      case 'attentionHide':
+        attentionHide(data);
+        break;
       default:
         break;
     }
@@ -456,10 +659,24 @@
 
   // ---------- input ----------
 
-  // Any press anywhere: the host brings its attention-check / floating-text
+  // Any press anywhere: the host brings whatever it still has in its own
   // windows back to the front (window-level PreviewMouseDown is unreliable over
   // a WebView2 child HWND, so this message is the only signal C# gets).
-  window.addEventListener('pointerdown', () => post({ type: 'click' }), true);
+  //
+  // A press ON an attention target is EXCLUSIVELY that target's: it must never
+  // also read as a generic surface click, or every hit would additionally
+  // trigger the host's z-order lift. Capture phase, so no other listener can
+  // reorder this.
+  window.addEventListener('pointerdown', (e) => {
+    const node = e.target && e.target.closest ? e.target.closest('.attn') : null;
+    if (node) {
+      e.preventDefault();
+      e.stopPropagation();
+      attentionHit(attn.get(node.dataset.id));
+      return;
+    }
+    post({ type: 'click' });
+  }, true);
 
   // The page is a surface, not a document.
   window.addEventListener('contextmenu', (e) => e.preventDefault());
@@ -514,6 +731,7 @@
       get durationMs() { return Number.isFinite(fg.duration) ? Math.round(fg.duration * 1000) : 0; },
       get blur() { return !!(cur && cur.blur); },
       get unrequestedPauses() { return cur ? cur.unrequestedPauses : 0; },
+      get attentionCount() { return attn.size; },
       get errored() { return !!(cur && cur.errored); },
     },
   });

--- a/ConditioningControlPanel/Services/Tracking/GazeFocusService.cs
+++ b/ConditioningControlPanel/Services/Tracking/GazeFocusService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Threading;
@@ -70,7 +70,7 @@ public class GazeFocusService : IDisposable
     // Mutually exclusive — only one target is being dwelt on at a time.
     private Bubble? _currentBubble;
     private FlashWindow? _currentFlash;
-    private FloatingText? _currentFloating;
+    private IAttentionTarget? _currentFloating;
 
     // Throttle clock for stare-linger boosts. Reset to MinValue whenever the
     // dwell target changes (or no target is held) so the first boost on
@@ -371,7 +371,7 @@ public class GazeFocusService : IDisposable
                 SetCursorLock(fr);
                 AdvanceFlashDwell(fw);
             }
-            else if (hit.Value.Floating is FloatingText ft)
+            else if (hit.Value.Floating is IAttentionTarget ft)
             {
                 SetCursorLock(ft.GetGazeBounds());
                 AdvanceFloatingTextDwell(ft);
@@ -423,7 +423,7 @@ public class GazeFocusService : IDisposable
     {
         Bubble? bestBubble = null;
         FlashWindow? bestFlash = null;
-        FloatingText? bestFloating = null;
+        IAttentionTarget? bestFloating = null;
         double bestScore = ScoreThreshold;
 
         // Defensive multi-monitor clamp at the gaze read: drop targets that
@@ -564,7 +564,7 @@ public class GazeFocusService : IDisposable
 
     private readonly struct GazeHit
     {
-        public GazeHit(Bubble? bubble, FlashWindow? flash, FloatingText? floating)
+        public GazeHit(Bubble? bubble, FlashWindow? flash, IAttentionTarget? floating)
         {
             Bubble = bubble;
             Flash = flash;
@@ -572,7 +572,7 @@ public class GazeFocusService : IDisposable
         }
         public Bubble? Bubble { get; }
         public FlashWindow? Flash { get; }
-        public FloatingText? Floating { get; }
+        public IAttentionTarget? Floating { get; }
     }
 
     private void AdvanceBubbleDwell(Bubble b)
@@ -654,7 +654,7 @@ public class GazeFocusService : IDisposable
         }
     }
 
-    private void AdvanceFloatingTextDwell(FloatingText ft)
+    private void AdvanceFloatingTextDwell(IAttentionTarget ft)
     {
         if (!ReferenceEquals(_currentFloating, ft))
         {

--- a/ConditioningControlPanel/Services/Video/AttentionTargets.cs
+++ b/ConditioningControlPanel/Services/Video/AttentionTargets.cs
@@ -1,0 +1,644 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using ConditioningControlPanel.Services.Video.Browser;
+using Screen = System.Windows.Forms.Screen;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// One live attention-check target, whatever it happens to be made of. VideoService's
+    /// <c>_targets</c> list is the authority on which checks are outstanding - it drives the
+    /// pass/fail tally AND <c>EvaluateGraceRequest(attentionTargetLive:)</c>, which refuses a grace
+    /// pause while a target is up - so every representation must add/remove itself through exactly
+    /// the same bookkeeping. A target counts as live from spawn until click, timeout or teardown.
+    ///
+    /// Three implementations, chosen per SCREEN at spawn time (see VideoService.CreateAttentionTarget):
+    ///   * <see cref="BrowserAttentionTarget"/> - a DOM element inside the browser-engine player page.
+    ///   * <see cref="InWindowAttentionTarget"/> - a WPF element inside a LibVLC video window, which
+    ///     only works on the vmem/blurred-background path (a VideoView is an HwndHost and airspace
+    ///     would hide anything WPF puts over it).
+    ///   * <see cref="FloatingText"/> - the original separate topmost window, still the only option
+    ///     over a VideoView surface, over the MediaElement fallback, and on a monitor that has no
+    ///     video window at all (3+ monitors without FillAllMonitorsWithVideo).
+    /// </summary>
+    internal interface IAttentionTarget
+    {
+        /// <summary>Idempotent "the user got this one": pop sound, onHit callback, fade. Shared by the
+        /// mouse click, the gaze dwell and the toy-button path.</summary>
+        void Hit();
+
+        /// <summary>Remove immediately, no fade, no callback. Idempotent.</summary>
+        void Destroy();
+
+        /// <summary>Freeze / unfreeze for a grace pause (#735): motion stops and clicks stop
+        /// registering, but the target stays on screen and keeps its place in <c>_targets</c>. The
+        /// expiry countdown is frozen by VideoService's shared clock, not here.</summary>
+        void SetPaused(bool paused);
+
+        /// <summary>Re-assert z-order after something raised itself over the target. Only the
+        /// separate-window representation has anything to do here.</summary>
+        void BringToFront();
+
+        /// <summary>Current bounds in WPF DIPs for gaze hit-testing, or <see cref="Rect.Empty"/> when
+        /// the target is dead or its position is unknown. Matches the coordinate space
+        /// WebcamTrackingService.OnGazeMove emits.</summary>
+        Rect GetGazeBounds();
+    }
+
+    /// <summary>
+    /// One spawn's pending timeout. Due at an <c>_startTime</c>-relative second rather than a
+    /// wall-clock deadline, which is what lets a grace pause hold it: ResumeFromGrace slides
+    /// <c>_startTime</c> forward by the paused duration, so the target gets back exactly the
+    /// lifespan it had left instead of expiring behind the Resume card.
+    /// </summary>
+    internal sealed class AttentionSpawnExpiry
+    {
+        public double DueElapsed { get; init; }
+        /// <summary>Every monitor's copy of this spawn - they live and die together.</summary>
+        public List<IAttentionTarget> Targets { get; init; } = new();
+        /// <summary>Drops the spawn's toy-button subscription. Idempotent.</summary>
+        public Action? Unhook { get; init; }
+    }
+
+    /// <summary>Attention-target styling read from settings, resolved once per spawn so the three
+    /// representations cannot drift apart.</summary>
+    internal readonly struct AttentionStyle
+    {
+        public Color Color1 { get; init; }
+        public Color Color2 { get; init; }
+        public Color TextColor { get; init; }
+        public Color BorderColor { get; init; }
+        /// <summary>No background, no border, no padding - just the outlined glyphs.</summary>
+        public bool Floating { get; init; }
+        public bool ShowBorder { get; init; }
+        public string Font { get; init; }
+    }
+
+    /// <summary>
+    /// The look of an attention target, in one place. The WPF builders below and the CSS in
+    /// <c>Resources/web/player/player.css</c> are the two renderings of it; the numbers here
+    /// (7.5px outline, 20/10 padding, 20px corner radius, 3px border, 150x60 minimum) are mirrored
+    /// there deliberately.
+    /// </summary>
+    internal static class AttentionTargetVisual
+    {
+        /// <summary>2mm at 96 DPI.</summary>
+        internal const double OutlineThickness = 7.5;
+        internal const double MinWidth = 150;
+        internal const double MinHeight = 60;
+
+        /// <summary>DIPs per second. The old per-window bounce moved 3.0 DIP per 16 ms tick; keeping
+        /// the speed identical is what makes the in-window and DOM targets feel like the same game.</summary>
+        internal const double SpeedPerSecond = 187.5;
+
+        /// <summary>Fraction of the play area kept clear on each edge, capped in DIPs.</summary>
+        internal static double MarginFor(double extent, double cap) => Math.Min(cap, extent * 0.08);
+
+        internal static AttentionStyle ReadStyle()
+        {
+            var settings = App.Settings?.Current;
+            Color c1, c2, text, border;
+            try
+            {
+                c1 = (Color)ColorConverter.ConvertFromString(settings!.AttentionColor1);
+                c2 = (Color)ColorConverter.ConvertFromString(settings.AttentionColor2);
+                text = (Color)ColorConverter.ConvertFromString(settings.AttentionTextColor);
+                border = (Color)ColorConverter.ConvertFromString(settings.AttentionBorderColor);
+            }
+            catch
+            {
+                // Fallback to bright fluo pink if colors invalid
+                c1 = Color.FromRgb(255, 20, 147);   // DeepPink
+                c2 = Color.FromRgb(255, 105, 180);  // HotPink
+                text = Color.FromRgb(255, 20, 147);
+                border = Color.FromRgb(255, 20, 147);
+            }
+            return new AttentionStyle
+            {
+                Color1 = c1,
+                Color2 = c2,
+                TextColor = text,
+                BorderColor = border,
+                Floating = settings?.AttentionFloatingText == true,
+                ShowBorder = settings?.AttentionShowBorder == true,
+                Font = string.IsNullOrWhiteSpace(settings?.AttentionFont) ? "Segoe UI" : settings!.AttentionFont,
+            };
+        }
+
+        /// <summary>"#RRGGBB" for the page protocol.</summary>
+        internal static string ToCss(Color c) => $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+
+        /// <summary>
+        /// The target's WPF content: an invisible-but-hit-testable zone under a (optionally
+        /// gradient-filled) border holding black-outlined text. <paramref name="width"/> /
+        /// <paramref name="height"/> come back as the size the caller must give it - the text is
+        /// measured as geometry, so the caller cannot work it out on its own.
+        /// </summary>
+        internal static FrameworkElement Build(string text, int size, in AttentionStyle style,
+            out double width, out double height)
+        {
+            var border = new Border
+            {
+                Background = style.Floating
+                    ? Brushes.Transparent
+                    : new LinearGradientBrush(style.Color1, style.Color2, 90),
+                CornerRadius = style.Floating ? new CornerRadius(0) : new CornerRadius(20),
+                BorderBrush = (style.ShowBorder && !style.Floating)
+                    ? new SolidColorBrush(style.BorderColor)
+                    : Brushes.Transparent,
+                BorderThickness = (style.ShowBorder && !style.Floating)
+                    ? new Thickness(3)
+                    : new Thickness(0),
+                Padding = style.Floating ? new Thickness(0) : new Thickness(20, 10, 20, 10),
+                Effect = style.Floating ? null : new System.Windows.Media.Effects.DropShadowEffect
+                {
+                    Color = Colors.Black,
+                    BlurRadius = 15,
+                    ShadowDepth = 5,
+                    Opacity = 0.6
+                },
+                Cursor = Cursors.Hand
+            };
+
+            // Outlined text via geometry - a crisp black stroke behind the fill, which no WPF text
+            // decoration gives you.
+            var fontFamily = new FontFamily($"{style.Font}, Segoe UI, Arial");
+            var typeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+
+            var formattedText = new FormattedText(
+                text,
+                System.Globalization.CultureInfo.CurrentCulture,
+                System.Windows.FlowDirection.LeftToRight,
+                typeface,
+                size,
+                Brushes.White, // Placeholder, the geometry below carries the real paint
+                PixelsPerDip());
+            formattedText.TextAlignment = TextAlignment.Center;
+            formattedText.LineHeight = size * 0.95;
+
+            var textGeometry = formattedText.BuildGeometry(new System.Windows.Point(0, 0));
+
+            // Offset the geometry so the stroke cannot be clipped by the container.
+            var bounds = textGeometry.Bounds;
+            var transformedGeometry = textGeometry.Clone();
+            transformedGeometry.Transform = new TranslateTransform(
+                -bounds.X + OutlineThickness, -bounds.Y + OutlineThickness);
+
+            var outlinePath = new System.Windows.Shapes.Path
+            {
+                Data = transformedGeometry,
+                Stroke = Brushes.Black,
+                StrokeThickness = OutlineThickness,
+                StrokeLineJoin = PenLineJoin.Round,
+                Fill = Brushes.Transparent
+            };
+            var fillPath = new System.Windows.Shapes.Path
+            {
+                Data = transformedGeometry,
+                Fill = new SolidColorBrush(style.TextColor),
+                Stroke = Brushes.Transparent
+            };
+
+            var textContainer = new Grid
+            {
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            textContainer.Children.Add(outlinePath);
+            textContainer.Children.Add(fillPath);
+            border.Child = textContainer;
+
+            width = Math.Max(bounds.Width + OutlineThickness * 2 + 60, MinWidth);
+            height = Math.Max(bounds.Height + OutlineThickness * 2 + 40, MinHeight);
+
+            // The hit zone makes the transparent pixels (the inside of an "O", the gap between two
+            // words) count as clicks, which is the whole target's worth of hit area the user aims at.
+            var container = new Grid();
+            container.Children.Add(new System.Windows.Shapes.Rectangle
+            {
+                Fill = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)),
+                IsHitTestVisible = true
+            });
+            container.Children.Add(border);
+            return container;
+        }
+
+        private static double PixelsPerDip()
+        {
+            try
+            {
+                if (Application.Current?.MainWindow is Visual v) return VisualTreeHelper.GetDpi(v).PixelsPerDip;
+            }
+            catch { /* no main window yet - 1.0 is the right guess */ }
+            return 1.0;
+        }
+
+        /// <summary>
+        /// Formats trigger text for display:
+        /// - 2 words: stack vertically (one per line)
+        /// - 4+ words: 2 lines with words split evenly
+        /// - 1 word or 3 words: keep as-is
+        /// </summary>
+        internal static string FormatTriggerText(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return text;
+
+            var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (words.Length == 2)
+            {
+                // 2 words: stack vertically
+                return $"{words[0]}\n{words[1]}";
+            }
+            else if (words.Length >= 4)
+            {
+                // 4+ words: split into 2 lines
+                int mid = words.Length / 2;
+                var line1 = string.Join(" ", words.Take(mid));
+                var line2 = string.Join(" ", words.Skip(mid));
+                return $"{line1}\n{line2}";
+            }
+
+            // 1 or 3 words: keep as-is
+            return text;
+        }
+
+        internal static void PlayPopSound()
+        {
+            try
+            {
+                var soundsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds", "bubbles");
+                var popFiles = new[] { "Pop.mp3", "Pop2.mp3", "Pop3.mp3" };
+                var chosenPop = popFiles[Random.Shared.Next(popFiles.Length)];
+                var popPath = Path.Combine(soundsPath, chosenPop);
+
+                if (File.Exists(popPath))
+                {
+                    // Apply master volume to attention target pop sound
+                    var masterVolume = App.Settings?.Current?.MasterVolume ?? 100;
+                    App.Audio?.PlayOneShot(popPath, 0.6f * (masterVolume / 100f), "target-pop");
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Failed to start pop sound: {Error}", ex.Message);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The in-window attention plane for ONE LibVLC video window: a transparent Canvas sitting above
+    /// the video surface and the click overlay in the window's root Grid.
+    ///
+    /// Only ever created on the vmem/blurred-background render path. The VideoView path is an
+    /// HwndHost, and airspace means a native child window paints OVER every WPF element in the same
+    /// window - a target added there would be invisible and unclickable.
+    ///
+    /// Hit-testing is done by hand from the window's PreviewMouseDown rather than by the routed
+    /// event system: that handler tunnels from the window and swallows the click (it exists to stop
+    /// the video raising itself), so it has to offer the press to this layer first or nothing inside
+    /// the window could ever be clicked.
+    /// </summary>
+    internal sealed class InWindowAttentionLayer : Canvas
+    {
+        private readonly List<InWindowAttentionTarget> _live = new();
+
+        public InWindowAttentionLayer(Window window, Screen screen)
+        {
+            Window = window;
+            Screen = screen;
+            Background = null;
+            ClipToBounds = true;
+            IsHitTestVisible = false;   // hit-testing is manual - see TryHit
+        }
+
+        public Window Window { get; }
+        public Screen Screen { get; }
+
+        public bool IsOn(Screen screen)
+            => screen != null && string.Equals(Screen.DeviceName, screen.DeviceName, StringComparison.Ordinal);
+
+        internal void Attach(InWindowAttentionTarget target, UIElement root)
+        {
+            Children.Add(root);
+            _live.Add(target);
+        }
+
+        internal void Detach(InWindowAttentionTarget target, UIElement root)
+        {
+            Children.Remove(root);
+            _live.Remove(target);
+        }
+
+        /// <summary>Topmost-first: the newest target wins an overlap, same as the old stack of
+        /// topmost windows did.</summary>
+        public bool TryHit(System.Windows.Point p)
+        {
+            for (int i = _live.Count - 1; i >= 0; i--)
+            {
+                var t = _live[i];
+                if (!t.Contains(p)) continue;
+                t.Hit();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// An attention target rendered INSIDE a LibVLC video window (vmem path only).
+    ///
+    /// The separate-window predecessor moved itself with a 16 ms DispatcherTimer driving
+    /// <c>Window.Left/Top</c> - one SetWindowPos per frame per target per monitor, which is what made
+    /// the bounce visibly stutter. This one only writes a <see cref="TranslateTransform"/> from
+    /// CompositionTarget.Rendering, so the motion is frame-synced and costs no layout pass at all.
+    /// </summary>
+    internal sealed class InWindowAttentionTarget : IAttentionTarget
+    {
+        private readonly InWindowAttentionLayer _layer;
+        private readonly FrameworkElement _root;
+        private readonly TranslateTransform _move = new();
+        private readonly Action _onHit;
+
+        private readonly double _w, _h;
+        private double _x, _y, _vx, _vy;
+        private double _minX, _minY, _maxX, _maxY;
+        private TimeSpan _lastRender = TimeSpan.MinValue;
+        private bool _rendering;
+        private bool _dead;
+        private bool _clicked;
+        private bool _paused;
+
+        public InWindowAttentionTarget(InWindowAttentionLayer layer, string text, int size,
+            in AttentionStyle style, Action onHit)
+        {
+            _layer = layer;
+            _onHit = onHit;
+            size = Math.Max(40, size);
+
+            _root = AttentionTargetVisual.Build(AttentionTargetVisual.FormatTriggerText(text), size, style,
+                out _w, out _h);
+            _root.Width = _w;
+            _root.Height = _h;
+            _root.RenderTransform = _move;
+
+            // The window is already shown at full screen bounds when a target spawns, so the layer
+            // has a real size; the window fallback covers a spawn that races the first layout pass.
+            double areaW = _layer.ActualWidth > 0 ? _layer.ActualWidth : _layer.Window.ActualWidth;
+            double areaH = _layer.ActualHeight > 0 ? _layer.ActualHeight : _layer.Window.ActualHeight;
+            if (areaW <= 0) areaW = _w * 3;
+            if (areaH <= 0) areaH = _h * 3;
+
+            var marginX = AttentionTargetVisual.MarginFor(areaW, 150);
+            var marginY = AttentionTargetVisual.MarginFor(areaH, 100);
+            _minX = marginX;
+            _minY = marginY;
+            _maxX = Math.Max(_minX + _w, areaW - marginX);
+            _maxY = Math.Max(_minY + _h, areaH - marginY);
+
+            _x = _minX + Random.Shared.NextDouble() * Math.Max(0, (_maxX - _w) - _minX);
+            _y = _minY + Random.Shared.NextDouble() * Math.Max(0, (_maxY - _h) - _minY);
+            _x = Math.Clamp(_x, _minX, Math.Max(_minX, _maxX - _w));
+            _y = Math.Clamp(_y, _minY, Math.Max(_minY, _maxY - _h));
+            _move.X = _x;
+            _move.Y = _y;
+
+            var angle = Random.Shared.NextDouble() * Math.PI * 2;
+            _vx = Math.Cos(angle) * AttentionTargetVisual.SpeedPerSecond;
+            _vy = Math.Sin(angle) * AttentionTargetVisual.SpeedPerSecond;
+
+            _layer.Attach(this, _root);
+            CompositionTarget.Rendering += OnRendering;
+            _rendering = true;
+        }
+
+        /// <summary>Layer-relative bounds, for the manual hit test in <see cref="InWindowAttentionLayer"/>.
+        /// A paused target is not clickable - the Resume card owns the screen.</summary>
+        public bool Contains(System.Windows.Point p)
+            => !_dead && !_clicked && !_paused && p.X >= _x && p.X <= _x + _w && p.Y >= _y && p.Y <= _y + _h;
+
+        public void SetPaused(bool paused)
+        {
+            if (_dead || _clicked || _paused == paused) return;
+            _paused = paused;
+            if (paused) { StopRendering(); return; }
+            // MinValue rather than "now": the first frame after the pause must step by one frame's
+            // worth, not by the whole 60s the pause could have lasted.
+            _lastRender = TimeSpan.MinValue;
+            if (!_rendering)
+            {
+                CompositionTarget.Rendering += OnRendering;
+                _rendering = true;
+            }
+        }
+
+        private void OnRendering(object? sender, EventArgs e)
+        {
+            if (_dead) return;
+            try
+            {
+                // Rendering can fire more than once for the same frame; RenderingTime is the only
+                // reliable clock here (a stopwatch would double-step on those repeats).
+                var now = (e as RenderingEventArgs)?.RenderingTime ?? TimeSpan.Zero;
+                if (now == _lastRender) return;
+                double dt = _lastRender == TimeSpan.MinValue ? 1.0 / 60.0 : (now - _lastRender).TotalSeconds;
+                _lastRender = now;
+                if (dt <= 0 || dt > 0.25) dt = 1.0 / 60.0;   // a dropped/stalled frame must not teleport it
+
+                _x += _vx * dt;
+                _y += _vy * dt;
+                if (_x < _minX) { _x = _minX; _vx = Math.Abs(_vx); }
+                if (_x + _w > _maxX) { _x = _maxX - _w; _vx = -Math.Abs(_vx); }
+                if (_y < _minY) { _y = _minY; _vy = Math.Abs(_vy); }
+                if (_y + _h > _maxY) { _y = _maxY - _h; _vy = -Math.Abs(_vy); }
+                _move.X = _x;
+                _move.Y = _y;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("InWindowAttentionTarget: motion tick failed: {Error}", ex.Message);
+                StopRendering();
+            }
+        }
+
+        private void StopRendering()
+        {
+            if (!_rendering) return;
+            _rendering = false;
+            CompositionTarget.Rendering -= OnRendering;
+        }
+
+        public void Hit()
+        {
+            // _paused: a gaze dwell or a toy-button press must not score while the video is held
+            // behind the Resume card either.
+            if (_clicked || _dead || _paused) return;
+            _clicked = true;
+            App.Logger?.Information("ATTENTION: Target clicked");
+            AttentionTargetVisual.PlayPopSound();
+            try { _onHit?.Invoke(); }
+            catch (Exception ex) { App.Logger?.Debug("InWindowAttentionTarget.Hit: onHit callback threw: {Error}", ex.Message); }
+            FadeOut();
+        }
+
+        private void FadeOut()
+        {
+            StopRendering();
+            try
+            {
+                var fade = new DoubleAnimation(1.0, 0.0, TimeSpan.FromMilliseconds(300));
+                fade.Completed += (_, _) => Destroy();
+                _root.BeginAnimation(UIElement.OpacityProperty, fade);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("InWindowAttentionTarget: fade failed: {Error}", ex.Message);
+                Destroy();
+            }
+        }
+
+        public void Destroy()
+        {
+            if (_dead) return;
+            _dead = true;
+            StopRendering();
+            try { _layer.Detach(this, _root); }
+            catch (Exception ex) { App.Logger?.Debug("InWindowAttentionTarget: detach failed: {Error}", ex.Message); }
+        }
+
+        /// <summary>Nothing to do: the target IS the top layer of the video window it lives in.</summary>
+        public void BringToFront() { }
+
+        public Rect GetGazeBounds()
+        {
+            if (_dead) return Rect.Empty;
+            try { return new Rect(_layer.Window.Left + _x, _layer.Window.Top + _y, _w, _h); }
+            catch { return Rect.Empty; }
+        }
+    }
+
+    /// <summary>
+    /// An attention target rendered as a DOM element inside the browser engine's player page.
+    ///
+    /// C# still owns everything that matters - the text (localization and the mod trigger pool stay
+    /// C#-side), the style, the spawn/expire schedule, the hit bookkeeping - and the page owns only
+    /// the paint and the bounce, which it runs on transform/opacity so the compositor carries it.
+    ///
+    /// The target is live from the <c>attentionShow</c> post until click, timeout or teardown, and
+    /// the owning VideoService adds/removes it from <c>_targets</c> on exactly the same beats as
+    /// every other representation.
+    /// </summary>
+    internal sealed class BrowserAttentionTarget : IAttentionTarget
+    {
+        private static int _seq;
+
+        private readonly BrowserVideoWindow _window;
+        private readonly Action _onHit;
+        private readonly bool _reportMotion;
+        private Rect _bounds = Rect.Empty;
+        private bool _dead;
+        private bool _clicked;
+        private bool _paused;
+
+        public string Id { get; }
+
+        public BrowserAttentionTarget(BrowserVideoWindow window, string text, int size,
+            in AttentionStyle style, Action onHit)
+        {
+            _window = window;
+            _onHit = onHit;
+            Id = "at" + System.Threading.Interlocked.Increment(ref _seq).ToString(System.Globalization.CultureInfo.InvariantCulture);
+            size = Math.Max(40, size);
+
+            // Only worth the 10 Hz motion reports when something actually consumes the bounds.
+            _reportMotion = App.Settings?.Current?.VideoGazeClickEnabled == true;
+
+            var angle = Random.Shared.NextDouble() * Math.PI * 2;
+
+            // Queued until the page's `ready` handshake, so posting before the CoreWebView2 exists
+            // is safe - a target spawned during a cold browser start still lands.
+            _window.Post(new
+            {
+                type = "attentionShow",
+                id = Id,
+                text = AttentionTargetVisual.FormatTriggerText(text),
+                size,
+                font = style.Font,
+                color1 = AttentionTargetVisual.ToCss(style.Color1),
+                color2 = AttentionTargetVisual.ToCss(style.Color2),
+                textColor = AttentionTargetVisual.ToCss(style.TextColor),
+                borderColor = AttentionTargetVisual.ToCss(style.BorderColor),
+                floating = style.Floating,
+                showBorder = style.ShowBorder,
+                // Fractions of the free spawn range, not of the viewport: the page is the only side
+                // that knows how big the element measured, so it resolves them against its own bounds.
+                xPct = Random.Shared.NextDouble(),
+                yPct = Random.Shared.NextDouble(),
+                vx = Math.Cos(angle) * AttentionTargetVisual.SpeedPerSecond,
+                vy = Math.Sin(angle) * AttentionTargetVisual.SpeedPerSecond,
+                reportMotion = _reportMotion,
+            });
+        }
+
+        /// <summary>Position report from the page, in viewport fractions. Gaze is the only consumer,
+        /// so this is a plain field write - no event, nothing re-entrant.</summary>
+        internal void UpdateBounds(double xPct, double yPct, double wPct, double hPct)
+        {
+            if (_dead) return;
+            try
+            {
+                // The window covers the monitor exactly, so viewport fractions map straight onto its
+                // DIP rectangle - the same space FloatingText reported and GazeFocusService expects.
+                double w = _window.Width, h = _window.Height;
+                if (w <= 0 || h <= 0) return;
+                _bounds = new Rect(_window.Left + xPct * w, _window.Top + yPct * h, wPct * w, hPct * h);
+            }
+            catch { _bounds = Rect.Empty; }
+        }
+
+        /// <summary>
+        /// No message of its own: the page freezes and unfreezes its targets from the SAME
+        /// <c>pause</c>/<c>resume</c> the grace pause already sends to hold the video, so the two can
+        /// never disagree. The flag here is only the second lock on a click that raced the pause.
+        /// </summary>
+        public void SetPaused(bool paused) => _paused = paused;
+
+        public void Hit()
+        {
+            if (_clicked || _dead || _paused) return;
+            _clicked = true;
+            App.Logger?.Information("ATTENTION: Target clicked");
+            AttentionTargetVisual.PlayPopSound();
+            try { _onHit?.Invoke(); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserAttentionTarget.Hit: onHit callback threw: {Error}", ex.Message); }
+            // The page fades it out and drops it; from here on it is gone as far as C# is concerned.
+            Post(new { type = "attentionHide", id = Id, fade = true });
+            _dead = true;
+        }
+
+        public void Destroy()
+        {
+            if (_dead) return;
+            _dead = true;
+            Post(new { type = "attentionHide", id = Id, fade = false });
+        }
+
+        /// <summary>Nothing to do: the element is inside the video surface it would be raised over.</summary>
+        public void BringToFront() { }
+
+        public Rect GetGazeBounds() => _dead ? Rect.Empty : _bounds;
+
+        private void Post(object msg)
+        {
+            try { _window.Post(msg); }
+            catch (Exception ex) { App.Logger?.Debug("BrowserAttentionTarget: post failed: {Error}", ex.Message); }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -163,6 +163,18 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>The audio-bearing window, or null when no session is live.</summary>
         public Window? PrimaryWindow => _primary;
 
+        /// <summary>The session window covering <paramref name="screen"/>, or null when this monitor
+        /// has none (secondaries are capped on high monitor counts, #389). The attention-check
+        /// spawner asks per screen and falls back to a floating window when the answer is null, which
+        /// is what keeps multi-monitor placement identical to the LibVLC path.</summary>
+        public BrowserVideoWindow? WindowForScreen(Screen screen)
+        {
+            if (screen == null) return null;
+            foreach (var w in _windows)
+                if (string.Equals(w.Screen.DeviceName, screen.DeviceName, StringComparison.Ordinal)) return w;
+            return null;
+        }
+
         // ---- events (all raised on the UI thread, from the WebView2 message callback) ----
 
         /// <summary>durationMs (0 = unknowable), width, height. Can fire MORE THAN ONCE per clip:
@@ -191,6 +203,14 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>key, alt, ctrl, shift - every non-repeat keydown the page saw. Keyboard over a
         /// focused WebView2 goes to Chromium, so this is how strict-mode/ESC decisions still reach C#.</summary>
         public event Action<string, bool, bool, bool>? KeyPressed;
+
+        /// <summary>An attention-check target was pressed (target id). Never accompanied by
+        /// <see cref="Clicked"/> for the same press - the page routes one or the other.</summary>
+        public event Action<string>? AttentionClicked;
+
+        /// <summary>Target id + its viewport-fraction rectangle, ~10 Hz while the target bounces and
+        /// only when the show message asked for it (gaze click enabled). Pure position bookkeeping.</summary>
+        public event Action<string, double, double, double, double>? AttentionMoved;
 
         // ===================== environment =====================
 
@@ -517,6 +537,23 @@ namespace ConditioningControlPanel.Services.Video.Browser
             try
             {
                 var type = (string?)o["type"];
+
+                // Attention-check traffic is window-scoped, not session-scoped: with dual monitors
+                // every screen carries its OWN target and the user may click any of them, so these
+                // two must be handled before the primary-only gate below or a secondary's target
+                // could never be hit. Each message names the target, so nothing doubles up.
+                switch (type)
+                {
+                    case "attentionClick":
+                        AttentionClicked?.Invoke((string?)o["id"] ?? "");
+                        return;
+                    case "attentionMove":
+                        AttentionMoved?.Invoke((string?)o["id"] ?? "",
+                            (double?)o["xPct"] ?? 0, (double?)o["yPct"] ?? 0,
+                            (double?)o["wPct"] ?? 0, (double?)o["hPct"] ?? 0);
+                        return;
+                }
+
                 // Only the audio-bearing window drives the session, exactly like the LibVLC primary
                 // player - a secondary's events would double every callback.
                 if (!win.IsPrimary)

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoWindow.cs
@@ -34,6 +34,10 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>True for the audio-bearing window (one per session). Secondaries load muted.</summary>
         public bool IsPrimary { get; }
 
+        /// <summary>The monitor this window covers. Used to place attention-check targets on the
+        /// right page (they are DOM elements inside these windows, one per screen).</summary>
+        public Screen Screen => _screen;
+
         /// <summary>True once the page has completed its handshake and the queue has been flushed.</summary>
         public bool IsReady => _surface.IsReady;
 

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -67,6 +67,8 @@ namespace ConditioningControlPanel.Services
                     engine.Failed += OnBrowserFailed;
                     engine.Clicked += OnBrowserClicked;
                     engine.KeyPressed += OnBrowserKey;
+                    engine.AttentionClicked += OnBrowserAttentionClicked;
+                    engine.AttentionMoved += OnBrowserAttentionMoved;
                 }
                 return engine;
             }
@@ -303,6 +305,7 @@ namespace ConditioningControlPanel.Services
                 foreach (var t in _targets.ToList()) t.Destroy();
                 _targets.Clear();
             }
+            _spawnExpiries.Clear();
             _hits = _total = _spawned = 0;
             _spawnTimes.Clear();
             _duration = 0;
@@ -461,6 +464,58 @@ namespace ConditioningControlPanel.Services
             // Window-level PreviewMouseDown never fires over a WebView2 child HWND, so this message
             // is what keeps the attention targets clickable on top of the video.
             BringTargetsToFront();
+        }
+
+        /// <summary>
+        /// The user pressed an attention-check target rendered inside the page. The page reports this
+        /// INSTEAD of the generic <c>click</c>, so <see cref="BringTargetsToFront"/> deliberately does
+        /// not run for it - there is nothing to lift, the target lives in the surface it would be
+        /// lifted over.
+        /// </summary>
+        private void OnBrowserAttentionClicked(string id)
+        {
+            if (!_browserActive || string.IsNullOrEmpty(id)) return;
+            // Hit() plays the pop sound, runs the spawn's onHit (XP, hit tally, clearing the mirror
+            // targets on the other monitors) and posts the fade - all of which shows windows and
+            // raises app events, so none of it may happen inside the page's message callback.
+            PostAfterPageMessage(() =>
+            {
+                if (!BrowserEventIsCurrent()) return;
+                IAttentionTarget? hit = null;
+                lock (_targets)
+                {
+                    foreach (var t in _targets)
+                    {
+                        if (t is BrowserAttentionTarget b && string.Equals(b.Id, id, StringComparison.Ordinal))
+                        {
+                            hit = b;
+                            break;
+                        }
+                    }
+                }
+                hit?.Hit();
+            });
+        }
+
+        /// <summary>
+        /// Position report for a live DOM target, consumed only by Focus Gaze hit-testing. Applied
+        /// inline on purpose: it is a field write on one object, raises nothing and shows nothing, so
+        /// a dispatcher hop per report at 10 Hz per target would be pure overhead.
+        /// </summary>
+        private void OnBrowserAttentionMoved(string id, double xPct, double yPct, double wPct, double hPct)
+        {
+            if (!_browserActive || string.IsNullOrEmpty(id)) return;
+            lock (_targets)
+            {
+                foreach (var t in _targets)
+                {
+                    if (t is BrowserAttentionTarget b && string.Equals(b.Id, id, StringComparison.Ordinal))
+                    {
+                        b.UpdateBounds(xPct, yPct, wPct, hPct);
+                        return;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,6 +19,7 @@ using LibVLCSharp.Shared;
 using LibVLCSharp.WPF;
 using ConditioningControlPanel.Helpers;
 using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Services.Video.Browser;
 using Application = System.Windows.Application;
 using Screen = System.Windows.Forms.Screen;
 
@@ -42,7 +43,16 @@ namespace ConditioningControlPanel.Services
         private Queue<string> _videoQueue = new();  // Performance: Changed to Queue for O(1) dequeue
         private Queue<(string PackId, PackFileEntry File)> _packVideoQueue = new();  // Queue for pack videos
         private readonly List<Window> _windows = new();
-        private readonly List<FloatingText> _targets = new();
+        private readonly List<IAttentionTarget> _targets = new();
+        /// <summary>In-window attention planes, one per LibVLC video window that can host WPF content
+        /// (the vmem/blurred-background path only - a VideoView's airspace would hide them). Lives and
+        /// dies with <see cref="_windows"/>; a screen with no entry here falls back to a FloatingText
+        /// window, which is what keeps multi-monitor spawn placement identical.</summary>
+        private readonly List<InWindowAttentionLayer> _attentionLayers = new();
+        /// <summary>One entry per spawn still waiting to time out, due at an <c>_startTime</c>-relative
+        /// second so a grace pause freezes the countdown with everything else. UI thread only (spawn
+        /// tick + teardown).</summary>
+        private readonly List<AttentionSpawnExpiry> _spawnExpiries = new();
         private readonly List<string> _tempPackFiles = new();  // Track temp files for cleanup
 
         private DispatcherTimer? _scheduler;
@@ -529,10 +539,10 @@ namespace ConditioningControlPanel.Services
         /// to Focus Gaze dwells. Returns empty when VideoGazeClickEnabled is
         /// off. Caller iterates in reverse for topmost-first selection.
         /// </summary>
-        internal IReadOnlyList<FloatingText> GetGazeTargets()
+        internal IReadOnlyList<IAttentionTarget> GetGazeTargets()
         {
             if (App.Settings?.Current?.VideoGazeClickEnabled != true)
-                return Array.Empty<FloatingText>();
+                return Array.Empty<IAttentionTarget>();
             lock (_targets)
             {
                 return _targets.ToArray();
@@ -545,7 +555,7 @@ namespace ConditioningControlPanel.Services
         /// fade). Safe to call against a target that's already been hit or
         /// destroyed.
         /// </summary>
-        internal void GazeClick(FloatingText target)
+        internal void GazeClick(IAttentionTarget target)
         {
             if (target == null) return;
             target.Hit();
@@ -2701,6 +2711,19 @@ namespace ConditioningControlPanel.Services
             };
             grid.Children.Add(clickOverlay);
 
+            // Attention plane, above everything else in this window. ONLY on the vmem path: the
+            // composite is pure WPF content, so an element over it composites normally, whereas a
+            // VideoView is an HwndHost whose native child paints over every WPF sibling (airspace) -
+            // a target added there would be invisible AND unclickable, so that path keeps the
+            // separate topmost windows (see CreateAttentionTarget).
+            InWindowAttentionLayer? attentionLayer = null;
+            if (useBlur)
+            {
+                attentionLayer = new InWindowAttentionLayer(win, screen);
+                grid.Children.Add(attentionLayer);
+                _attentionLayers.Add(attentionLayer);
+            }
+
             win.Content = grid;
 
             SetupStrictHandlers(win, strict);
@@ -2708,6 +2731,16 @@ namespace ConditioningControlPanel.Services
             // Also handle at window level for any clicks that get through
             win.PreviewMouseDown += (s, e) =>
             {
+                // PreviewMouseDown TUNNELS from the window down, so this handler runs before any
+                // child sees the press - and it swallows every one of them. The attention plane
+                // therefore has to be offered the click here, by hand, or an in-window target could
+                // never be clicked at all.
+                if (attentionLayer != null && e.ChangedButton == MouseButton.Left &&
+                    attentionLayer.TryHit(e.GetPosition(attentionLayer)))
+                {
+                    e.Handled = true;
+                    return;
+                }
                 // Don't let the video window activate - keeps targets on top
                 e.Handled = true;
                 BringTargetsToFront();
@@ -4196,6 +4229,98 @@ namespace ConditioningControlPanel.Services
                 _spawnTimes.RemoveAt(0);
                 SpawnTarget();
             }
+            ExpireDueSpawns(elapsed);
+        }
+
+        /// <summary>
+        /// Retires every spawn whose lifespan has run out, in the SAME <c>_startTime</c>-relative
+        /// clock the spawn schedule uses.
+        ///
+        /// This used to be a <c>Task.Delay(lifespan)</c> per spawn, which is wall-clock and cannot be
+        /// held: a grace pause taken with a target on screen would expire it behind the Resume card
+        /// and hand the user a failed check for pausing. Reading the same clock the spawner reads
+        /// makes the countdown freeze for free — ResumeFromGrace shifts <c>_startTime</c> forward by
+        /// the paused duration, so a target comes back with exactly the time it had left.
+        ///
+        /// Runs from the spawn tick, which is already gated by <see cref="ShouldSpawnTick"/>, so
+        /// nothing here can fire while the pause is on.
+        /// </summary>
+        private void ExpireDueSpawns(double elapsed)
+        {
+            for (int i = _spawnExpiries.Count - 1; i >= 0; i--)
+            {
+                var spawn = _spawnExpiries[i];
+                if (elapsed < spawn.DueElapsed) continue;
+                _spawnExpiries.RemoveAt(i);
+                try { spawn.Unhook?.Invoke(); }
+                catch (Exception ex) { App.Logger?.Debug("Error unhooking toy input on expiry: {Error}", ex.Message); }
+                try
+                {
+                    lock (_targets)
+                    {
+                        foreach (var target in spawn.Targets)
+                        {
+                            // Absent = already clicked (or torn down); only a target still on the
+                            // books may be destroyed, and only once.
+                            if (_targets.Remove(target)) target.Destroy();
+                        }
+                    }
+                }
+                catch (Exception ex) { App.Logger?.Warning("Error expiring targets: {Error}", ex.Message); }
+            }
+        }
+
+        /// <summary>
+        /// Freezes / unfreezes every live target for a grace pause (#735): motion stops, clicks stop
+        /// registering, and the target stays on screen under the Resume card rather than vanishing.
+        /// The expiry countdown is handled by the shared clock, not here (see
+        /// <see cref="ExpireDueSpawns"/>).
+        /// </summary>
+        private void SetAttentionPaused(bool paused)
+        {
+            List<IAttentionTarget> snapshot;
+            lock (_targets) { snapshot = _targets.ToList(); }
+            foreach (var t in snapshot)
+            {
+                try { t.SetPaused(paused); }
+                catch (Exception ex) { App.Logger?.Debug("Attention target pause toggle failed: {Error}", ex.Message); }
+            }
+        }
+
+        /// <summary>
+        /// Builds one target for one screen, in the cheapest representation that screen can actually
+        /// show. Decided PER SCREEN and per spawn, never cached: a session can have a video window on
+        /// the primary only (3+ monitors without FillAllMonitorsWithVideo) while the schedule still
+        /// wants a target on every screen, and that screen must keep getting the separate window it
+        /// has always had.
+        ///
+        /// Order matters: browser session first (its page owns the whole screen), then the in-window
+        /// WPF plane (vmem/blurred-background LibVLC windows only), then the original topmost window
+        /// - which is still the ONLY thing that can appear over a VideoView's airspace or over the
+        /// MediaElement fallback.
+        /// </summary>
+        private IAttentionTarget CreateAttentionTarget(string text, Screen screen, int size,
+            in AttentionStyle style, Action onHit)
+        {
+            try
+            {
+                if (_browserActive)
+                {
+                    var win = _browser?.WindowForScreen(screen);
+                    if (win != null) return new BrowserAttentionTarget(win, text, size, style, onHit);
+                }
+                else
+                {
+                    var layer = _attentionLayers.FirstOrDefault(l => l.IsOn(screen));
+                    if (layer != null) return new InWindowAttentionTarget(layer, text, size, style, onHit);
+                }
+            }
+            catch (Exception ex)
+            {
+                // An in-window/DOM target that could not be built must not cost the user the check.
+                App.Logger?.Warning("ATTENTION: in-window target build failed ({Error}) - using a floating window", ex.Message);
+            }
+            return new FloatingText(text, screen, size, onHit);
         }
 
         private void SpawnTarget()
@@ -4218,7 +4343,8 @@ namespace ConditioningControlPanel.Services
 
                 // When dual monitor is enabled, spawn targets on ALL screens simultaneously
                 // User only needs to click ONE target to get the hit - all targets from this spawn clear together
-                var spawnedTargets = new List<FloatingText>();
+                var spawnedTargets = new List<IAttentionTarget>();
+                var style = AttentionTargetVisual.ReadStyle();
                 bool hitRegistered = false; // Prevent double-counting hits from the same spawn
 
                 // PHASE F — "squeeze your toy" attention checks. A toy button press satisfies the
@@ -4241,8 +4367,8 @@ namespace ConditioningControlPanel.Services
                 {
                     if (screen == null) continue;
 
-                    FloatingText? target = null;
-                    target = new FloatingText(text, screen, settings.AttentionSize, () =>
+                    IAttentionTarget? target = null;
+                    target = CreateAttentionTarget(text, screen, settings.AttentionSize, style, () =>
                     {
                         // Only count as a hit once per spawn (user clicked any target from this batch)
                         if (hitRegistered) return;
@@ -4270,7 +4396,7 @@ namespace ConditioningControlPanel.Services
                         }
 
                         // Get remaining targets for bringing to front
-                        List<FloatingText> remainingTargets;
+                        List<IAttentionTarget> remainingTargets;
                         lock (_targets)
                         {
                             remainingTargets = _targets.ToList();
@@ -4325,7 +4451,7 @@ namespace ConditioningControlPanel.Services
                         try
                         {
                             if (hitRegistered) return;
-                            FloatingText? live = null;
+                            IAttentionTarget? live = null;
                             lock (_targets)
                             {
                                 foreach (var t in spawnedTargets)
@@ -4348,39 +4474,14 @@ namespace ConditioningControlPanel.Services
                     catch { toyHandler = null; }
                 }
 
-                // Auto-expire all targets from this spawn together
-                var lifespan = settings.AttentionLifespan * 1000;
-                Task.Delay(lifespan).ContinueWith(_ =>
+                // Auto-expire all targets from this spawn together. Booked against the spawner's own
+                // clock (_startTime-relative seconds) rather than a wall-clock Task.Delay, so a grace
+                // pause holds the countdown instead of burning it behind the Resume card (#735).
+                _spawnExpiries.Add(new AttentionSpawnExpiry
                 {
-                    try
-                    {
-                        DispatcherHelper.RunOnUI(() =>
-                        {
-                            try
-                            {
-                                UnhookToyInput();
-                                lock (_targets)
-                                {
-                                    foreach (var target in spawnedTargets)
-                                    {
-                                        if (_targets.Contains(target))
-                                        {
-                                            _targets.Remove(target);
-                                            target.Destroy();
-                                        }
-                                    }
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                App.Logger?.Warning("Error expiring targets: {Error}", ex.Message);
-                            }
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        App.Logger?.Debug("Target auto-expire task failed (app may be shutting down): {Error}", ex.Message);
-                    }
+                    DueElapsed = (DateTime.Now - _startTime).TotalSeconds + settings.AttentionLifespan,
+                    Targets = spawnedTargets,
+                    Unhook = UnhookToyInput,
                 });
             }
             catch (Exception ex)
@@ -4681,8 +4782,8 @@ namespace ConditioningControlPanel.Services
             Pause,
             /// <summary>Same physical keystroke as a pause we just performed — swallow it, change nothing.</summary>
             ConsumedDedup,
-            /// <summary>Not pausable (no video / already paused / budget spent / attention target live)
-            /// — the press is today's normal panic press.</summary>
+            /// <summary>Not pausable (no video / already paused / budget spent) — the press is
+            /// today's normal panic press.</summary>
             FallThrough
         }
 
@@ -4699,13 +4800,17 @@ namespace ConditioningControlPanel.Services
         /// purpose: when the video window does NOT have focus only the global handler fires, and a
         /// one-shot flag would then swallow the user's genuine SECOND press. 200ms is far below a
         /// human rapid double-tap and far above the dispatcher latency between the two handlers.
+        ///
+        /// A live "CLICK ME" target used to REFUSE the pause (it would have broken the mini-game's
+        /// timing). It no longer does: the targets now pause with the video — motion frozen, clicks
+        /// off, expiry clock stopped — and come back with their remaining time intact, so there is
+        /// nothing left for a live target to protect.
         /// </summary>
         internal static GraceDecision EvaluateGraceRequest(
             bool videoPlaying,
             bool cleaningUp,
             bool alreadyPaused,
             bool consumed,
-            bool attentionTargetLive,
             double msSinceLastGraceAction,
             int dedupMs = GraceDedupMs)
         {
@@ -4713,10 +4818,6 @@ namespace ConditioningControlPanel.Services
             if (!videoPlaying || cleaningUp) return GraceDecision.FallThrough;
             if (alreadyPaused) return GraceDecision.FallThrough;   // press 2 = today's normal panic
             if (consumed) return GraceDecision.FallThrough;        // one grace pause per video run
-            // Pausing while a "CLICK ME" target is live would break the mini-game's timing, and a
-            // panic press must NEVER be silently swallowed — so refuse the pause and let the press
-            // do what it has always done.
-            if (attentionTargetLive) return GraceDecision.FallThrough;
             return GraceDecision.Pause;
         }
 
@@ -4758,6 +4859,9 @@ namespace ConditioningControlPanel.Services
                     ? double.MaxValue
                     : (nowUtc - _lastGracePauseActionUtc).TotalMilliseconds;
 
+                // State only, no longer a veto: a live target pauses with the video (see
+                // SetAttentionPaused). Still logged, because "was a check on screen?" is the first
+                // question asked of any grace-pause report.
                 bool targetLive;
                 lock (_targets) { targetLive = _targets.Count > 0; }
 
@@ -4769,7 +4873,6 @@ namespace ConditioningControlPanel.Services
                     cleaningUp: _isCleaningUp,
                     alreadyPaused: _gracePaused,
                     consumed: _gracePauseConsumed,
-                    attentionTargetLive: targetLive,
                     msSinceLastGraceAction: sinceMs);
 
                 switch (decision)
@@ -4804,6 +4907,12 @@ namespace ConditioningControlPanel.Services
             _lastGracePauseActionUtc = nowUtc;
 
             PausePrimary();
+
+            // The attention mini-game pauses WITH the video: motion frozen, clicks off. Its expiry
+            // clock stops on its own — the deadlines are held against _startTime, which
+            // ResumeFromGrace shifts forward by the whole pause — so nobody loses a check to a
+            // countdown that ran behind the Resume card.
+            SetAttentionPaused(true);
 
             // Freeze the wall-clock guards for the duration of the pause (see TimerArm).
             PauseGuardTimers(nowUtc);
@@ -4841,12 +4950,18 @@ namespace ConditioningControlPanel.Services
             StopGraceCountdown();
             CloseGraceOverlays();
 
-            // _startTime is the attention spawner's wall clock (CheckSpawnTargets compares
-            // DateTime.Now - _startTime against the scheduled spawn times) and is the ONLY read of
-            // that field in this file — watch-time credit is position-based (FinalizeWatchCredit
-            // reads _lastWatchPositionMs). Shift it forward by the pause so the targets keep landing
-            // at their intended positions in the CLIP rather than all at once on resume.
+            // _startTime is the attention mini-game's whole clock: CheckSpawnTargets compares
+            // DateTime.Now - _startTime against both the scheduled spawn times AND each live spawn's
+            // expiry deadline. Watch-time credit is position-based and does not read it
+            // (FinalizeWatchCredit reads _lastWatchPositionMs). Shifting it forward by the pause
+            // therefore does two jobs at once: targets keep landing at their intended positions in
+            // the CLIP, and a target that was on screen when the pause began gets back exactly the
+            // lifespan it had left.
             _startTime += pausedFor;
+
+            // Motion and clicks come back with it. Ordered after the _startTime shift so no expiry
+            // tick can see the old (now stale) clock.
+            SetAttentionPaused(false);
 
             // The enhancement stall watch measures "seconds since playback last advanced" against a
             // 90s grace. The pause itself contributed up to 60 of those seconds, so restart its clock
@@ -5823,6 +5938,7 @@ namespace ConditioningControlPanel.Services
                     foreach (var t in _targets.ToList()) t.Destroy();
                     _targets.Clear();
                 }
+                _spawnExpiries.Clear();
 
                 App.Logger?.Debug("CloseAll: Closing {Count} video windows, {MsgCount} message windows",
                     _windows.Count, _messageWindows.Count);
@@ -6002,6 +6118,9 @@ namespace ConditioningControlPanel.Services
                     }
                 }
                 _windows.Clear();
+                // The attention planes are children of those windows; the targets themselves were
+                // already destroyed above, so this only drops the empty hosts.
+                _attentionLayers.Clear();
                 // The escape hatch's handles die with the windows (see RunWedgeEscapeHatch).
                 lock (_videoWindowHandlesLock) { _videoWindowHandles.Clear(); }
 
@@ -6646,9 +6765,15 @@ namespace ConditioningControlPanel.Services
     }
 
     /// <summary>
-    /// Bouncing text target - customizable via settings
+    /// Bouncing text target in its own topmost window - customizable via settings.
+    ///
+    /// The original (and still the only) representation that can sit over a surface WPF cannot draw
+    /// into: the LibVLC VideoView airspace, the MediaElement fallback, and a monitor that has no
+    /// video window at all. Everywhere else the target is now an element inside the video window
+    /// itself (<see cref="InWindowAttentionTarget"/> / <see cref="BrowserAttentionTarget"/>), which
+    /// is what removed the per-frame SetWindowPos stutter this class is stuck with.
     /// </summary>
-    internal class FloatingText
+    internal class FloatingText : IAttentionTarget
     {
         // Win32 for reliable z-order management and tool window style
         [DllImport("user32.dll", SetLastError = true)]
@@ -6683,6 +6808,7 @@ namespace ConditioningControlPanel.Services
         // share identical bookkeeping (idempotency, sound, callback, fade).
         private readonly Action _onHit;
         private bool _clicked;
+        private bool _paused;
 
         public FloatingText(string text, Screen screen, int size, Action onHit)
         {
@@ -6692,7 +6818,7 @@ namespace ConditioningControlPanel.Services
                 size = Math.Max(40, size);
 
                 // Format multi-word triggers: 2 words = 2 lines, 4+ words = 2 lines with 2 on each
-                text = FormatTriggerText(text);
+                text = AttentionTargetVisual.FormatTriggerText(text);
 
                 // Get DPI scale factor (Screen uses physical pixels, WPF uses DIPs)
                 double dpiScale = 1.0;
@@ -6718,139 +6844,18 @@ namespace ConditioningControlPanel.Services
                 double areaHeight = area.Height / dpiScale;
 
                 // Margins scale with screen size to handle different resolutions
-                var marginX = Math.Min(150, areaWidth * 0.08);
-                var marginY = Math.Min(100, areaHeight * 0.08);
+                var marginX = AttentionTargetVisual.MarginFor(areaWidth, 150);
+                var marginY = AttentionTargetVisual.MarginFor(areaHeight, 100);
                 _minX = areaX + marginX;
                 _minY = areaY + marginY;
                 _maxX = areaX + areaWidth - marginX;
                 _maxY = areaY + areaHeight - marginY;
 
-                // Load style settings
-                var settings = App.Settings.Current;
-                Color color1, color2, textColor, borderColor;
-                try
-                {
-                    color1 = (Color)ColorConverter.ConvertFromString(settings.AttentionColor1);
-                    color2 = (Color)ColorConverter.ConvertFromString(settings.AttentionColor2);
-                    textColor = (Color)ColorConverter.ConvertFromString(settings.AttentionTextColor);
-                    borderColor = (Color)ColorConverter.ConvertFromString(settings.AttentionBorderColor);
-                }
-                catch
-                {
-                    // Fallback to bright fluo pink if colors invalid
-                    color1 = Color.FromRgb(255, 20, 147); // DeepPink
-                    color2 = Color.FromRgb(255, 105, 180); // HotPink
-                    textColor = Color.FromRgb(255, 20, 147); // DeepPink
-                    borderColor = Color.FromRgb(255, 20, 147);
-                }
-
-                // Check if floating text mode (no background)
-                var isFloating = settings.AttentionFloatingText;
-
-                // Create container with customizable styling
-                var border = new Border
-                {
-                    Background = isFloating
-                        ? Brushes.Transparent
-                        : new LinearGradientBrush(color1, color2, 90),
-                    CornerRadius = isFloating ? new CornerRadius(0) : new CornerRadius(20),
-                    BorderBrush = (settings.AttentionShowBorder && !isFloating)
-                        ? new SolidColorBrush(borderColor)
-                        : Brushes.Transparent,
-                    BorderThickness = (settings.AttentionShowBorder && !isFloating)
-                        ? new Thickness(3)
-                        : new Thickness(0),
-                    Padding = isFloating ? new Thickness(0) : new Thickness(20, 10, 20, 10),
-                    Effect = isFloating ? null : new System.Windows.Media.Effects.DropShadowEffect
-                    {
-                        Color = Colors.Black,
-                        BlurRadius = 15,
-                        ShadowDepth = 5,
-                        Opacity = 0.6
-                    },
-                    Cursor = System.Windows.Input.Cursors.Hand
-                };
-
-                // Create outlined text using geometry for crisp 2mm black outline
-                var fontFamily = new FontFamily($"{settings.AttentionFont}, Segoe UI, Arial");
-                var typeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
-
-                // Create FormattedText to generate geometry
-                var formattedText = new FormattedText(
-                    text,
-                    System.Globalization.CultureInfo.CurrentCulture,
-                    System.Windows.FlowDirection.LeftToRight,
-                    typeface,
-                    size,
-                    Brushes.White, // Placeholder, we'll use geometry
-                    VisualTreeHelper.GetDpi(Application.Current.MainWindow).PixelsPerDip);
-                formattedText.TextAlignment = TextAlignment.Center;
-                formattedText.LineHeight = size * 0.95;
-
-                // Get text geometry for outline
-                var textGeometry = formattedText.BuildGeometry(new System.Windows.Point(0, 0));
-
-                // 2mm ≈ 7.5 pixels at 96 DPI
-                const double outlineThickness = 7.5;
-
-                // Get the actual bounds of the geometry and offset to ensure nothing is clipped
-                var bounds = textGeometry.Bounds;
-                double offsetX = -bounds.X + outlineThickness;
-                double offsetY = -bounds.Y + outlineThickness;
-
-                // Apply transform to offset the geometry so it starts within the container
-                var transformedGeometry = textGeometry.Clone();
-                transformedGeometry.Transform = new TranslateTransform(offsetX, offsetY);
-
-                // Create path for outline (black stroke)
-                var outlinePath = new System.Windows.Shapes.Path
-                {
-                    Data = transformedGeometry,
-                    Stroke = Brushes.Black,
-                    StrokeThickness = outlineThickness,
-                    StrokeLineJoin = PenLineJoin.Round,
-                    Fill = Brushes.Transparent
-                };
-
-                // Create path for fill (text color)
-                var fillPath = new System.Windows.Shapes.Path
-                {
-                    Data = transformedGeometry,
-                    Fill = new SolidColorBrush(textColor),
-                    Stroke = Brushes.Transparent
-                };
-
-                // Stack outline behind fill in a Grid
-                var textContainer = new Grid
-                {
-                    HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center
-                };
-                textContainer.Children.Add(outlinePath);
-                textContainer.Children.Add(fillPath);
-
-                border.Child = textContainer;
-
-                // Measure the text to get proper sizing (use actual geometry bounds + outline thickness)
-                double w = bounds.Width + outlineThickness * 2 + 60;  // Add padding + outline
-                double h = bounds.Height + outlineThickness * 2 + 40;
-
-                // Ensure minimum size
-                w = Math.Max(w, 150);
-                h = Math.Max(h, 60);
-
-                // Create a container grid with an invisible hit zone
-                // This ensures clicks register even on transparent pixels (inside "O", etc.)
-                var container = new Grid();
-
-                // Invisible hit zone rectangle - nearly transparent but still hit-testable
-                var hitZone = new System.Windows.Shapes.Rectangle
-                {
-                    Fill = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0)), // Almost invisible but hit-testable
-                    IsHitTestVisible = true
-                };
-                container.Children.Add(hitZone);
-                container.Children.Add(border);
+                // Appearance (colours, floating mode, outlined text, hit zone) is shared with the
+                // in-window and DOM representations so the three cannot drift apart; only the
+                // measured size comes back, because the caller needs it for the window and the bounce.
+                var style = AttentionTargetVisual.ReadStyle();
+                var container = AttentionTargetVisual.Build(text, size, style, out double w, out double h);
 
                 _win = new Window
                 {
@@ -6969,28 +6974,6 @@ namespace ConditioningControlPanel.Services
             }
         }
 
-        private void PlayPopSound()
-        {
-            try
-            {
-                var soundsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "sounds", "bubbles");
-                var popFiles = new[] { "Pop.mp3", "Pop2.mp3", "Pop3.mp3" };
-                var chosenPop = popFiles[Random.Shared.Next(popFiles.Length)];
-                var popPath = Path.Combine(soundsPath, chosenPop);
-
-                if (File.Exists(popPath))
-                {
-                    // Apply master volume to attention target pop sound
-                    var masterVolume = App.Settings?.Current?.MasterVolume ?? 100;
-                    App.Audio?.PlayOneShot(popPath, 0.6f * (masterVolume / 100f), "target-pop");
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Debug("Failed to start pop sound: {Error}", ex.Message);
-            }
-        }
-
         private void FadeOut()
         {
             App.Logger?.Debug("FloatingText.FadeOut() starting");
@@ -7026,13 +7009,32 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void Hit()
         {
-            if (_clicked || _dead) return;
+            // _paused: nothing scores while the video is held behind the grace-pause Resume card,
+            // whichever route got here (mouse, gaze dwell, toy button).
+            if (_clicked || _dead || _paused) return;
             _clicked = true;
             App.Logger?.Information("ATTENTION: Target clicked");
-            PlayPopSound();
+            AttentionTargetVisual.PlayPopSound();
             try { _onHit?.Invoke(); }
             catch (Exception ex) { App.Logger?.Debug("FloatingText.Hit: onHit callback threw: {Error}", ex.Message); }
             FadeOut();
+        }
+
+        /// <summary>
+        /// Grace pause (#735): stop the bounce (which also stops the topmost re-assert) and refuse
+        /// clicks, but leave the window on screen. The lifespan countdown is frozen by VideoService's
+        /// shared clock, so the target comes back with the time it had left.
+        /// </summary>
+        public void SetPaused(bool paused)
+        {
+            if (_dead || _clicked || _paused == paused) return;
+            _paused = paused;
+            try
+            {
+                if (paused) _timer.Stop();
+                else _timer.Start();
+            }
+            catch (Exception ex) { App.Logger?.Debug("FloatingText.SetPaused failed: {Error}", ex.Message); }
         }
 
         /// <summary>
@@ -7072,36 +7074,6 @@ namespace ConditioningControlPanel.Services
             {
                 App.Logger?.Error("ATTENTION: BringToFront failed: {Error}", ex.Message);
             }
-        }
-
-        /// <summary>
-        /// Formats trigger text for display:
-        /// - 2 words: stack vertically (one per line)
-        /// - 4+ words: 2 lines with words split evenly
-        /// - 1 word or 3 words: keep as-is
-        /// </summary>
-        private static string FormatTriggerText(string text)
-        {
-            if (string.IsNullOrWhiteSpace(text)) return text;
-
-            var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-            if (words.Length == 2)
-            {
-                // 2 words: stack vertically
-                return $"{words[0]}\n{words[1]}";
-            }
-            else if (words.Length >= 4)
-            {
-                // 4+ words: split into 2 lines
-                int mid = words.Length / 2;
-                var line1 = string.Join(" ", words.Take(mid));
-                var line2 = string.Join(" ", words.Skip(mid));
-                return $"{line1}\n{line2}";
-            }
-
-            // 1 or 3 words: keep as-is
-            return text;
         }
     }
 }

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -89,6 +89,8 @@ C# → page:
 | `stop` | — | decoder hygiene: `pause()` → `removeAttribute('src')` → `load()` |
 | `setVolume` | `volume`, `muted?` | master × video volume; the optional `muted` folds external mute in. Secondaries are always sent `volume: 0, muted: true` |
 | `seek` | `ms` | future Deeper use; implement anyway (trivial) |
+| `attentionShow` | `id, text, size, font, color1, color2, textColor, borderColor, floating, showBorder, xPct, yPct, vx, vy, reportMotion` | one attention-check target. C# owns the text (mod trigger pool + localization stay C#-side, already line-split) and the whole style; `xPct/yPct` are 0-1 *of the free spawn range* — only the page knows how big the element measured — and `vx/vy` are CSS px per second. `reportMotion` asks for `attentionMove` and is only set when gaze-click is on |
+| `attentionHide` | `id, fade` | `fade:true` = the user got it (300ms opacity fade, then the node is reaped); `false` = timeout / teardown, gone now |
 
 page → C#:
 | msg | fields | notes |
@@ -99,7 +101,9 @@ page → C#:
 | `time` | `ms` | ~10 Hz from `timeupdate`; drives `PrimaryPlaybackTimeMsChanged` |
 | `ended` | — | natural end |
 | `error` | `code, message` | media error OR unrequested stall the page can't recover |
-| `click` | — | any pointer-down on the surface |
+| `click` | — | any pointer-down on the surface that was NOT on an attention target |
+| `attentionClick` | `id` | the user pressed a target. Reported INSTEAD of `click` (a hit must not also trigger the host's z-order lift). The target then waits for `attentionHide` — C# stays the only authority on which checks are outstanding |
+| `attentionMove` | `id, xPct, yPct, wPct, hPct` | ~10 Hz viewport-fraction rectangle of a bouncing target, only when `reportMotion` was set. Gaze hit-testing is the sole consumer; C# maps it back to DIPs against the window |
 | `key` | `key, alt, ctrl, shift` | every non-repeat keydown the page saw (DOM `event.key`). Keyboard over a focused WebView2 goes to Chromium, so this is the ONLY route ESC / panic keys have back to C#; the page `preventDefault`s the dangerous ones and C# owns the policy |
 | `log` | `msg` | host built-in page logging |
 
@@ -146,11 +150,14 @@ All of the following stay in VideoService (C#-side) and must fire for browser se
 - [ ] Safety timers (all C#-side, unchanged mechanisms): duration guillotine armed
       from the page `meta` message (was `LengthChanged`); 10-min fallback timer;
       `VideoMaxDurationSeconds` hard cap; `_enhancementDriving` stall-watch semantics.
-- [ ] Attention checks: `SetupAttention` + `FloatingText` windows are ALREADY separate
-      topmost Win32 windows — reuse UNCHANGED over the browser windows. Wire the page
-      `click` message to `BringTargetsToFront()`. Gaze (`GetGazeTargets`/`GazeClick`)
-      and toy-button input paths unchanged. `EndCurrentVideo` pass/fail/XP/troll
-      replay/mercy logic unchanged.
+- [ ] Attention checks: `SetupAttention`, the spawn schedule, the pass/fail tally, gaze
+      (`GetGazeTargets`/`GazeClick`), the toy-button alternative and `EndCurrentVideo`'s
+      pass/fail/XP/troll-replay/mercy logic are all unchanged. What changed is only the RENDERING:
+      `_targets` holds `IAttentionTarget`, and each spawn picks a representation PER SCREEN - a DOM
+      element in the player page (browser session), a WPF element inside the video window (LibVLC
+      vmem/blur path), or the original `FloatingText` topmost window (VideoView airspace, the
+      MediaElement fallback, or a monitor with no video window at all). The page `click` message
+      still drives `BringTargetsToFront()` for the windows that are still separate.
 - [ ] Strict mode: `Closing` veto + panic/Alt-F4/system-key swallowing on
       `BrowserVideoWindow` (mirror `SetupStrictHandlers`); non-strict ESC ⇒ Cleanup.
       NOTE: keyboard events over a focused WebView2 go to Chromium — also suppress
@@ -224,6 +231,10 @@ Simplest implementation: reuse `BrowserVideoEngine`'s environment + a
 - `setSinkId` per-element audio-device routing (parity with `ApplyPreferredDevice`).
 - Duck-exclusion granularity per user-data-folder/PID.
 - Optional ffmpeg transcode tool for non-browser-safe libraries.
-- DOM-based attention targets (delete FloatingText interop).
+- ~~DOM-based attention targets~~ — done on this branch (§3 `attentionShow`/`attentionHide`),
+  alongside a WPF in-window target for the LibVLC vmem path. `FloatingText` cannot be deleted
+  yet: it is still the only representation that works over a `VideoView`'s airspace, over the
+  MediaElement fallback, and on a monitor that has no video window. It goes when the last
+  `VideoView` does.
 - Migrate small LibVLC consumers (mini-player, help video, gaze minigame, editor
   preview, inline loop); then delete the watchdog museum + `BlurVmemSurface`.

--- a/Tests/ConditioningControlPanel.Tests/VideoGracePauseTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/VideoGracePauseTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using ConditioningControlPanel.Services;
 using Xunit;
 using static ConditioningControlPanel.Services.VideoService;
@@ -25,7 +25,7 @@ public class VideoGracePauseTests
     public void PlayingVideo_FirstPress_Pauses()
     {
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: false,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: double.MaxValue);
+            consumed: false, msSinceLastGraceAction: double.MaxValue);
         Assert.Equal(GraceDecision.Pause, d);
     }
 
@@ -33,7 +33,7 @@ public class VideoGracePauseTests
     public void NoVideoPlaying_FallsThroughToNormalPanic()
     {
         var d = EvaluateGraceRequest(videoPlaying: false, cleaningUp: false, alreadyPaused: false,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: double.MaxValue);
+            consumed: false, msSinceLastGraceAction: double.MaxValue);
         Assert.Equal(GraceDecision.FallThrough, d);
     }
 
@@ -43,7 +43,7 @@ public class VideoGracePauseTests
         // A video already being torn down has nothing to pause, and swallowing the press would
         // strand the user staring at a dying fullscreen.
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: true, alreadyPaused: false,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: double.MaxValue);
+            consumed: false, msSinceLastGraceAction: double.MaxValue);
         Assert.Equal(GraceDecision.FallThrough, d);
     }
 
@@ -51,18 +51,20 @@ public class VideoGracePauseTests
     public void AlreadyPaused_SecondPress_IsTodaysNormalPanicPress()
     {
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: true,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: 5000);
+            consumed: false, msSinceLastGraceAction: 5000);
         Assert.Equal(GraceDecision.FallThrough, d);
     }
 
     [Fact]
-    public void LiveAttentionTarget_RefusesThePause()
+    public void LiveAttentionTarget_StillPauses()
     {
-        // Pausing mid-"CLICK ME" would break the mini-game timing. The press must still DO something,
-        // so it falls through rather than being swallowed.
+        // A live "CLICK ME" used to REFUSE the pause to protect the mini-game's timing. It no longer
+        // does: the targets freeze with the video (motion, clicks and their expiry countdown all
+        // stop) and come back with the time they had left, so there is nothing left to protect. The
+        // decision does not take the flag at all any more - this pins the behaviour change.
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: false,
-            consumed: false, attentionTargetLive: true, msSinceLastGraceAction: double.MaxValue);
-        Assert.Equal(GraceDecision.FallThrough, d);
+            consumed: false, msSinceLastGraceAction: double.MaxValue);
+        Assert.Equal(GraceDecision.Pause, d);
     }
 
     // ---- 1b. the 200ms double-fire dedup ----
@@ -74,7 +76,7 @@ public class VideoGracePauseTests
         // already paused. Note alreadyPaused is TRUE by then — without the dedup this exact call
         // would return FallThrough and stop the engine.
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: true,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: 12);
+            consumed: false, msSinceLastGraceAction: 12);
         Assert.Equal(GraceDecision.ConsumedDedup, d);
     }
 
@@ -84,7 +86,7 @@ public class VideoGracePauseTests
     public void InsideDedupBoundary_IsConsumed(double sinceMs)
     {
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: true,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: sinceMs);
+            consumed: false, msSinceLastGraceAction: sinceMs);
         Assert.Equal(GraceDecision.ConsumedDedup, d);
     }
 
@@ -96,7 +98,7 @@ public class VideoGracePauseTests
     {
         Assert.Equal(GraceDedupMs, 200);
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: true,
-            consumed: false, attentionTargetLive: false, msSinceLastGraceAction: sinceMs);
+            consumed: false, msSinceLastGraceAction: sinceMs);
         Assert.Equal(GraceDecision.FallThrough, d);
     }
 
@@ -107,7 +109,7 @@ public class VideoGracePauseTests
         // already be gone (a racing natural end). The duplicate must STILL be swallowed — resurrecting
         // it as a normal panic press would stop the engine off one keystroke.
         var d = EvaluateGraceRequest(videoPlaying: false, cleaningUp: true, alreadyPaused: false,
-            consumed: true, attentionTargetLive: false, msSinceLastGraceAction: 30);
+            consumed: true, msSinceLastGraceAction: 30);
         Assert.Equal(GraceDecision.ConsumedDedup, d);
     }
 
@@ -117,7 +119,7 @@ public class VideoGracePauseTests
     public void ConsumedGrace_FallsThroughForTheRestOfTheRun()
     {
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: false,
-            consumed: true, attentionTargetLive: false, msSinceLastGraceAction: double.MaxValue);
+            consumed: true, msSinceLastGraceAction: double.MaxValue);
         Assert.Equal(GraceDecision.FallThrough, d);
     }
 
@@ -129,7 +131,7 @@ public class VideoGracePauseTests
         var consumed = true;
         consumed = false;   // what PlayVideo does
         var d = EvaluateGraceRequest(videoPlaying: true, cleaningUp: false, alreadyPaused: false,
-            consumed: consumed, attentionTargetLive: false, msSinceLastGraceAction: double.MaxValue);
+            consumed: consumed, msSinceLastGraceAction: double.MaxValue);
         Assert.Equal(GraceDecision.Pause, d);
     }
 


### PR DESCRIPTION
Follow-ups to #106, built on owner direction this morning.

## Engine-stop InteractionQueue slot leak (the smoke-test blocker)
`VideoService.Stop()` (dashboard stop / remote stop / feature toggle) tore the video down but never released the "Video" queue slot - every queued interaction sat blocked for the 5-minute stuck window. Proven from the 0804 smoke logs (BubbleCount queued 04:54:47, never started). Panic was already clean (`ForceReset`). Fix: guarded `CompleteIfCurrent(Video)` after `CloseAll`, plus a dequeued BubbleCount trigger landing in a stopped service now hands its fresh claim straight back.

## In-window attention targets (owner: the floating windows were "not smooth at all")
Targets render inside the video windows instead of separate topmost windows:
- **Browser engine**: DOM element in the player page, compositor-driven bounce. New protocol: `attentionShow`/`attentionHide` (C# to page), `attentionClick` (reported INSTEAD of `click`) and `attentionMove` (10Hz, only when gaze-click is on) (page to C#).
- **LibVLC vmem/blur path**: WPF element on a Canvas plane inside the video window, `TranslateTransform` driven from `CompositionTarget.Rendering` - no more one-SetWindowPos-per-frame-per-target stutter.
- **`FloatingText` kept** for the `VideoView` airspace (non-blur mode), the MediaElement fallback, and monitors with no video window. Representation picked per screen per spawn; shared look lives in `AttentionTargetVisual` and is mirrored in `player.css`.

## Grace pause now works mid-target (owner decision)
The `attentionTargetLive` veto is gone from `EvaluateGraceRequest`: pausing freezes the targets with the video (motion stopped, mouse/gaze/toy hits refused) and the expiry countdown moved off wall-clock `Task.Delay` onto the `_startTime`-relative clock that `ResumeFromGrace` already shifts - a target comes back with exactly the lifespan it had left. Tests updated (`LiveAttentionTarget_StillPauses`); suite 887 green.

Spawn schedule, pass/fail tally, XP, troll replay, mercy, toy-button alternative, gaze dwell and strict mode are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DDEHEykXLQLzBZFw9Qv7h
