### PR TITLE
Goon Game web client: phone play-test rounds 2-4 (join flow, zips, compression, 64MB caps, mobile HUD, practice salvo, self-duel)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -585,10 +585,17 @@ function createArtifactSource() {
 let syncedLocalVersion = -1;
 let loggedLocalDeck = -1;
 
-function syncLocalDeck() {
+/**
+ * @param {boolean} [force] re-feed the pool even when `localVersion` has not
+ *   moved. The version guard is an optimisation against hosted `cache-list`
+ *   churn, and it is the ONE thing that can turn a missed `onItems` emit into a
+ *   permanently empty deck — so every road INTO a match (attachMatch, startSolo)
+ *   forces one, which costs one array map and closes the hole for good.
+ */
+function syncLocalDeck(force) {
   if (!assets) return;
   const v = Number(assets.localVersion) || 0;
-  if (v === syncedLocalVersion) return;      // a hosted cache-list, not a pick
+  if (v === syncedLocalVersion && !force) return;   // a hosted cache-list, not a pick
   syncedLocalVersion = v;
   try {
     const list = localPlayableEntries(assets.localItems);
@@ -597,6 +604,15 @@ function syncLocalDeck() {
       loggedLocalDeck = list.length;
       logger.info('local library: ' + list.length + ' playable item(s) — pool now '
         + c.images + ' images, ' + c.videos + ' videos');
+    }
+    // THE ONE CASE WORTH A WARN, and it has to be a warn: `logger.info` does not
+    // reach the ?debug=1 overlay (see teeDebug — only warn/error do), so on a
+    // phone an info line is a line nobody can read. Picks that produce no
+    // playable entry means the store adopted rows with no URL or no kind, which
+    // looks exactly like "my uploads do nothing" and is otherwise invisible.
+    if (!list.length && (assets.localCount | 0) > 0) {
+      logger.warn('local library: ' + assets.localCount + ' pick(s) but NOTHING playable — '
+        + 'no url/kind survived adoption, so every effect will draw from an empty deck');
     }
   } catch (e) {
     logger.warn('could not fold the local library into the media pool: ' + ((e && e.message) || e));
@@ -807,6 +823,14 @@ function attachMatch(match, transport) {
   currentMatch = match;
   currentTransport = transport || (goonSession ? goonSession.transport : null);
   escMercied = false;
+
+  // EVERY match starts with the player's picks in the deck, proven rather than
+  // assumed. `onItems` is the reactive path and it is the one that normally does
+  // this; forcing it here is the belt to its braces, because "the effects ran and
+  // the screen stayed blank" is the failure mode with no symptom of its own.
+  // Hosted this is a no-op: there are no local picks, and setLocalLibrary([])
+  // leaves the host's manifest half of the deck exactly where it was.
+  syncLocalDeck(true);
 
   try { executor?.attach?.(match); } catch (e) { logger.error('executor.attach threw: ' + ((e && e.stack) || e)); }
   try { matchLog.attach(match); } catch (e) { logger.error('matchLog.attach threw: ' + ((e && e.stack) || e)); }
@@ -1345,6 +1369,68 @@ const actions = {
   },
 };
 
+/**
+ * ONE LINE THAT SAYS WHAT THE DECK IS, and it is a WARN on purpose.
+ *
+ * `logger.info` goes to console.info and to the C# tunnel — neither of which
+ * exists on a phone running this page standalone. Only warn/error reach the
+ * ?debug=1 overlay (see teeDebug above), which is the only console an owner with
+ * an iPhone has. Two blind round-trips on "practice fires no assets" were spent
+ * guessing at exactly this number; do not demote it to info.
+ *
+ * It separates the three things that were indistinguishable from a screenshot:
+ * what the HOST's preset gave us, what the PLAYER picked in this browser, and
+ * how much of what they picked was actually playable.
+ */
+function logDeck(why) {
+  try {
+    const c = media.counts();
+    const local = media.localCount();
+    const host = Math.max(0, (c.images + c.videos) - local);
+    const picked = assets ? (assets.localCount | 0) : 0;
+    logger.warn(why + ' deck: ' + host + ' host + ' + local + ' local'
+      + ' (' + c.images + ' img / ' + c.videos + ' vid)'
+      + ' from ' + picked + ' pick(s), ' + media.receivedCount() + ' received');
+  } catch (_e) { /* a diagnostic can never be the thing that breaks practice */ }
+}
+
+/* ----------------------------------------------------------------------------
+ * THE PRACTICE SEED — the media-carrying slots start ARMED, in practice only.
+ *
+ * Owner report, 2026-08-04: "from mobile it's not triggering any asset even if I
+ * uploaded them and went to practice", with every arsenal chip reading `locked`.
+ * That reading was correct and the economy was working as designed: a slot is
+ * earned by popping bubbles (ui/drops.js), and on a fresh match nothing is
+ * earned yet. In a DUEL that ramp is the game. In PRACTICE it is a wall in front
+ * of the one question practice exists to answer — "does my library work?" — so
+ * practice hands over the two slots that draw from the library, plus the charges
+ * to spend them, and lets the player find out in the first ten seconds.
+ *
+ * DUEL GATING IS UNTOUCHED: this is reached from startSolo's own phase
+ * subscription and from nowhere else, and it goes through the public seams
+ * ui/drops.js already uses (creditCharges then armDrop), so the wire truth and
+ * the local truth cannot disagree.
+ * -------------------------------------------------------------------------- */
+const PRACTICE_SEED = Object.freeze([
+  Object.freeze({ id: 'flash', cost: 1 }),    // images, the cheap one
+  Object.freeze({ id: 'video', cost: 2 }),    // a clip, in a floating window
+]);
+
+function seedPracticeArsenal(match) {
+  const arsenal = hudHandle && hudHandle.parts && hudHandle.parts.arsenal;
+  if (!arsenal || typeof arsenal.armDrop !== 'function') return;
+  let charges = 0;
+  let armed = 0;
+  for (const seed of PRACTICE_SEED) {
+    // `silent` — the drop flourish is a reward animation and this is a gift, not
+    // a reward. It would also fire before the HUD has finished its entrance.
+    if (arsenal.armDrop(seed.id, { count: 1, silent: true })) { armed++; charges += seed.cost; }
+  }
+  if (!armed) return;
+  try { match.creditCharges(charges, 'practice-seed'); } catch (_e) { /* the slot still lights */ }
+  logger.info('practice: seeded ' + armed + ' arsenal slot(s) and ' + charges + ' charge(s)');
+}
+
 /* ----------------------------------------------------------------------------
  * PRACTICE — a loopback pair and a scripted opponent (ui/soloDriver.js).
  *
@@ -1371,6 +1457,12 @@ async function startSolo() {
   soloDriver = createSoloDriver({ match: soloOpponent, logger });
 
   attachMatch(local, soloPair.host);
+  /* THE PRACTICE SEED — see seedPracticeArsenal. Registered AFTER attachMatch so
+   * it runs after boot's own phase handler, i.e. after mountHudNow() has built
+   * the arsenal it seeds. On phaseUnsubs so it dies with the match. */
+  phaseUnsubs.push(local.onPhaseChanged((p) => {
+    if (p === GoonMatchPhase.Live) seedPracticeArsenal(local);
+  }));
   /* PRACTICE HAS A FACE TOO — a tile, a name and dm:false (contract §6). It is
    * set AFTER attachMatch, which clears the peer, and it is the only way the
    * splash, the HUD minis and the recap plates are exercisable with no server
@@ -1381,6 +1473,7 @@ async function startSolo() {
   soloDriver.start();
 
   logger.info('practice: loopback "' + profile + '" latency ' + opts.latencyMs + 'ms skew ' + opts.guestClockSkewMs + 'ms');
+  logDeck('practice');
   try {
     const ok = await soloPair.connect();
     if (!ok) logger.warn('practice: clock sync did not converge');

--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -161,12 +161,69 @@ const el = (id) => (hasDom() ? document.getElementById(id) : null);
  * payload, every phase) and the C# log is 400 chars per line — flooding it
  * would push the useful lines out.
  * -------------------------------------------------------------------------- */
+/**
+ * THE THIRD SINK (ui/debugOverlay.js, `?debug=1` only). warn/error already go to
+ * the console and down the C# tunnel; neither of those exists on a phone running
+ * this page standalone, which is where the failures nobody can read happen. The
+ * tee is null until the overlay lands, and `debugPrelog` holds what was said
+ * before that — losing the sibling-load warnings, the first thing to go wrong in
+ * a broken boot, would defeat the point.
+ */
+let debugOverlay = null;
+let debugArming = false;
+const debugPrelog = [];
+
+function teeDebug(level, m) {
+  if (debugOverlay) { debugOverlay.push(level, m); return; }
+  if (debugArming && debugPrelog.length < 50) debugPrelog.push([level, m]);
+}
+
 const logger = {
   debug: (m) => { try { console.debug('[gg]', m); } catch (_e) { /* ignore */ } },
   info: (m) => { try { console.info('[gg]', m); } catch (_e) { /* ignore */ } },
-  warn: (m) => { try { console.warn('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('warn: ' + m); },
-  error: (m) => { try { console.error('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('error: ' + m); },
+  warn: (m) => { try { console.warn('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('warn: ' + m); teeDebug('warn', m); },
+  error: (m) => { try { console.error('[gg]', m); } catch (_e) { /* ignore */ } bridge.log('error: ' + m); teeDebug('error', m); },
 };
+
+/**
+ * Cheap pre-check, so the module is not even FETCHED unless somebody asked for
+ * it — hosted especially, where a debug strip must never appear because a
+ * browser tab once had one. The module owns the authoritative answer
+ * (debugRequested); this only decides whether to go and ask it.
+ */
+function wantsDebugHint() {
+  try {
+    const s = (typeof location !== 'undefined' && location.search) || '';
+    if (/[?&]debug\b/.test(s)) return true;
+    if (bridge.isHosted) return false;          // standalone remembers, hosted never does
+    const p = bridge.storedPrefs();
+    return !!(p && p.debug);
+  } catch (_e) { return false; }
+}
+
+/** Loaded dynamically and optionally, exactly like the sibling waves. */
+function initDebugOverlay() {
+  if (!hasDom() || !wantsDebugHint()) return;
+  debugArming = true;
+  try {
+    import('./ui/debugOverlay.js')
+      .then((mod) => {
+        if (!mod || typeof mod.createDebugOverlay !== 'function') return;
+        const want = mod.debugRequested({
+          search: (typeof location !== 'undefined' && location.search) || '',
+          prefs: bridge.storedPrefs(),
+          hosted: bridge.isHosted,
+        });
+        if (!want) { debugArming = false; debugPrelog.length = 0; return; }
+        debugOverlay = mod.createDebugOverlay({});
+        mod.captureGlobalErrors(debugOverlay);
+        debugOverlay.push('warn', 'debug on — ' + (bridge.isHosted ? 'hosted' : 'standalone')
+          + ' protocol v' + bridge.PROTOCOL);
+        for (const [lvl, m] of debugPrelog.splice(0)) debugOverlay.push(lvl, m);
+      })
+      .catch(() => { debugArming = false; });
+  } catch (_e) { debugArming = false; }
+}
 
 /* ----------------------------------------------------------------------------
  * SIBLING WAVES — loaded dynamically so a wave that has not merged yet is a
@@ -1092,6 +1149,47 @@ function onPhase(phase) {
  * ACTIONS — everything a screen is allowed to DO. Screens never touch
  * GoonSession, the transports or the match factory directly.
  * -------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------
+ * FOLDING TO THE TITLE — deferred by one macrotask, and that is the whole fix.
+ *
+ * THE BUG THIS EXISTS FOR (owner's phone test, 2026-08-04): "when i accept the
+ * invite briefly shows the page of the setup before game then bounces me back to
+ * homepage." Every internal teardown inside net/session.js — a signaling pump
+ * that gave up, a relay that never answered, a P2P attempt that failed in a way
+ * nothing flagged for fallback — raises onCurrentMatchChanged(null), and this
+ * file used to answer that with a bare `router.show('title')`. That is a SILENT
+ * eviction: the lobby vanishes and nothing anywhere tells the player a single
+ * thing about why. The explanation always exists (GoonSession raises
+ * connectFailed immediately afterwards, and the entry screens render their own
+ * errors) — it just arrived AFTER the screen was already gone.
+ *
+ * So the jump waits one turn of the event loop. The paths that own an
+ * explanation (onConnectFailed above, actions.leave, the exit handshake) cancel
+ * it and route the player themselves; a teardown nobody claims still lands on
+ * the title, exactly as before, one tick later and with a line in the log.
+ * -------------------------------------------------------------------------- */
+let foldTimer = 0;
+
+function foldToTitle() {
+  cancelFoldToTitle();
+  const go = () => {
+    foldTimer = 0;
+    // A session that came back (a relay rebuild lands a new match on the very
+    // next tick) has nothing to fold, and neither does a screen that already
+    // moved on under its own power.
+    if (currentMatch || soloPair || !router) return;
+    logger.warn('session folded with no explanation — returning to the title');
+    router.show('title');
+  };
+  try { foldTimer = setTimeout(go, 0); } catch (_e) { go(); }
+}
+
+function cancelFoldToTitle() {
+  if (!foldTimer) return;
+  try { clearTimeout(foldTimer); } catch (_e) { /* ignore */ }
+  foldTimer = 0;
+}
+
 function ensureSession() {
   if (goonSession) return goonSession;
   goonSession = new GoonSession({
@@ -1108,12 +1206,17 @@ function ensureSession() {
       attachMatch(match, goonSession.transport);
     } else {
       detachMatch();
-      if (!soloPair) router.show('title');
+      if (!soloPair) foldToTitle();
     }
   });
   goonSession.onConnectFailed((reason) => {
     lastConnectFailed = reason;
     logger.warn('connect failed: ' + reason);
+    // THE FOLD IS SPOKEN FOR. GoonSession tears the match down and THEN raises
+    // this, so without the cancel the deferred jump would land first and the
+    // sheet would open over a title screen — telling the player "we could not
+    // connect" about a screen they were already yanked off.
+    cancelFoldToTitle();
     if (awaitingEntry) return;      // the entry screen renders it
     sheets?.showSignalError?.(errorInfo(reason)).then(() => router.show('title'));
   });
@@ -1201,6 +1304,7 @@ const actions = {
     if (s) { try { await s.leave(); } catch (e) { logger.warn('leave threw: ' + ((e && e.message) || e)); } }
     else if (currentMatch) { try { currentMatch.cancelMatch('left'); } catch (_e) { /* ignore */ } }
     await teardownEverything();
+    cancelFoldToTitle();      // leaving is an explanation of its own
     router.show('title');
   },
 };
@@ -1461,6 +1565,7 @@ function requestExit(why) {
 function finishExit(why) {
   try { clearTimeout(exitTimer); } catch (_e) { /* ignore */ }
   exiting = true;
+  cancelFoldToTitle();      // the page is leaving; there is no title to fold to
   // BEFORE teardownEverything, which is async: the page may be seconds from
   // gone and `rp-state off` is the frame the host needs to clear (or restore)
   // the presence. teardownEverything posts it again and the second one is a
@@ -1628,6 +1733,9 @@ function startHeartbeat() {
  * skipped, so every module stays provably side-effect free.
  * -------------------------------------------------------------------------- */
 if (hasDom()) {
+  // FIRST, before anything can go wrong: the strip is only useful if it is
+  // already listening when the boot it is meant to explain fails.
+  initDebugOverlay();
   try {
     window.addEventListener('keydown', onKeyDown);
     window.addEventListener('keyup', onKeyUp);

--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -58,7 +58,7 @@ import { createToasts } from './ui/toasts.js';
 import { createSheets } from './ui/sheets.js';
 import { createOptions } from './ui/options.js';
 import { createSoloDriver } from './ui/soloDriver.js';
-import { createAssetsStore } from './ui/assetsStore.js';
+import { createAssetsStore, localPlayableEntries } from './ui/assetsStore.js';
 import { createDiscord, confirmOpenDm } from './ui/discord.js';
 import { emitAva, mountVsSplash } from './ui/avatar.js';
 import { S } from './ui/strings.js';
@@ -565,6 +565,42 @@ function createArtifactSource() {
       };
     },
   };
+}
+
+/* ----------------------------------------------------------------------------
+ * THE LOCAL LIBRARY IS A PLAYABLE LIBRARY.
+ *
+ * Standalone there is no host and bridge.js synthesizes an EMPTY manifest, so
+ * exec/media.js's deck starts (and used to stay) empty: the files a player picks
+ * on the assets screen only ever reached the SEND path (listSendable above).
+ * A practice session on a phone therefore fired every flash, bubble and video
+ * against nothing — the effects ran, the screen stayed blank. This is the other
+ * half: the picks go into the deck too, so the player's OWN effects — in
+ * practice AND in a duel — draw from the library they just loaded.
+ *
+ * Hosted this is inert (the picker only exists when there is no host cache, and
+ * an empty list sets an empty local half) — the host's manifest still owns the
+ * deck, exactly as before.
+ * -------------------------------------------------------------------------- */
+let syncedLocalVersion = -1;
+let loggedLocalDeck = -1;
+
+function syncLocalDeck() {
+  if (!assets) return;
+  const v = Number(assets.localVersion) || 0;
+  if (v === syncedLocalVersion) return;      // a hosted cache-list, not a pick
+  syncedLocalVersion = v;
+  try {
+    const list = localPlayableEntries(assets.localItems);
+    const c = media.setLocalLibrary(list);
+    if (list.length !== loggedLocalDeck) {
+      loggedLocalDeck = list.length;
+      logger.info('local library: ' + list.length + ' playable item(s) — pool now '
+        + c.images + ' images, ' + c.videos + ' videos');
+    }
+  } catch (e) {
+    logger.warn('could not fold the local library into the media pool: ' + ((e && e.message) || e));
+  }
 }
 
 /**
@@ -1369,6 +1405,11 @@ function buildApp() {
   // cache-* handler (bridge.on throws on a duplicate and the assets screen
   // mounts many times per session).
   assets = createAssetsStore({ session, logger });
+  // Every pick the player adopts (and every one they remove) re-feeds the media
+  // deck — see syncLocalDeck above. `onItems` is the store's one change signal;
+  // the version guard is what keeps a hosted cache-list out of the pool.
+  assets.onItems(() => syncLocalDeck());
+  syncLocalDeck();
 
   /* --- DISCORD. Built once, like the store above and for the same reason: it
    * registers the `discord` and `peer-card` handlers and bridge.on throws on a

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -190,6 +190,13 @@ function readPrefs() {
   } catch (_e) { return {}; }
 }
 
+/**
+ * The stored standalone blob, for anything that has to decide something BEFORE
+ * the `init` frame is built (ui/debugOverlay.js asks whether the debug strip was
+ * turned on in an earlier launch). Always an object; `{}` hosted or unreadable.
+ */
+export function storedPrefs() { return isHosted ? {} : readPrefs(); }
+
 /** Persist standalone prefs (so a reload keeps your picks). No-op hosted. */
 export function savePrefs(partial) {
   if (isHosted) return;
@@ -272,6 +279,10 @@ if (!isHosted && typeof document !== 'undefined') {
         if (q.get('token')) keep.authToken = q.get('token');
         if (q.get('uid')) keep.unifiedId = q.get('uid');
         if (q.get('name')) keep.name = q.get('name');
+        // `?debug=1` sticks: a phone that reloads (or was pinned to the home
+        // screen without the query) keeps the one surface that can explain what
+        // just happened. `?debug=0` is how it comes back off.
+        if (q.has('debug')) keep.debug = /^(1|true|on|yes)$/i.test(q.get('debug') || '1');
         if (Object.keys(keep).length) savePrefs(keep);
       } catch (_e) { /* prefs are a convenience, never load-bearing */ }
       dispatch(standaloneInit());

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -14,9 +14,20 @@
  * swap stays a one-file change.
  *
  *   setManifest({images,videos,skipped,truncated})
+ *   setLocalLibrary([{kind,name,url}])                 (see below)
  *   draw() / drawKind('image'|'video') -> {kind, name, url, acquire} | null
  *   acquire(entry) -> {url, release(), provenance}
  *   counts() -> {images, videos, skipped, truncated}   hasMedia() -> bool
+ *
+ * THE LOCAL LIBRARY (standalone). In a plain browser there is no host and
+ * therefore no manifest frame worth the name — bridge.js synthesizes an EMPTY
+ * one — so the only library a phone has is what the player picked on the assets
+ * screen (ui/assetsStore.js `localItems`). Those picks used to reach the SEND
+ * path only, which meant a practice session on a phone drew from an empty deck
+ * and every effect fired with no media. `setLocalLibrary` is the other half:
+ * the deck is `hostEntries + localEntries`, and the two are set INDEPENDENTLY —
+ * a late manifest cannot wipe the player's picks and a new pick cannot wipe the
+ * host's preset. Both re-deal; neither touches `received`.
  *
  * RECEIVED ARTIFACTS (P2P media transfer, spec §4.3) live in a SECOND map that
  * the deck never sees:
@@ -43,7 +54,9 @@ export const XFER_TAG_PREFIX = 'xfer:';
 const SHA_RE = /^[0-9a-f]{64}$/;
 
 export function createGoonMediaPool() {
-  let entries = [];   // { kind: 'image'|'video', name, url }
+  let hostEntries = [];   // the host's manifest — the user's active preset
+  let localEntries = [];  // standalone: files the player picked in this browser
+  let entries = [];       // hostEntries + localEntries — what the deck indexes
   let skipped = 0;    // reported by the host (browser-undecodable formats etc.)
   let truncated = false;
   let deck = [];      // shuffled indices into entries, drawn from the end
@@ -65,6 +78,24 @@ export function createGoonMediaPool() {
     for (const e of entries) (e.kind === 'image' ? images++ : videos++);
     return { images, videos, skipped, truncated };
   };
+
+  /**
+   * The deck's view of the two sources, re-dealt. Called by BOTH setters, which
+   * is what makes them independent: whichever moved, the other survives.
+   */
+  function rebuildEntries() {
+    entries = localEntries.length ? hostEntries.concat(localEntries) : hostEntries.slice();
+    deck = [];          // re-deal with the new entries in the mix
+    recent.length = 0;
+  }
+
+  /** One {kind,name,url} normalized, or null when it is not something to draw. */
+  function toEntry(e) {
+    if (!e || !e.url) return null;
+    const kind = e.kind === 'video' ? 'video' : (e.kind === 'image' ? 'image' : '');
+    if (!kind) return null;
+    return { kind, name: String(e.name || ''), url: String(e.url) };
+  }
 
   function reshuffle() {
     deck = entries.map((_, i) => i);
@@ -173,18 +204,41 @@ export function createGoonMediaPool() {
     /** Swap in a manifest: {images:[{name,url}], videos:[...], skipped, truncated}. */
     setManifest(m) {
       const src = m || {};
-      entries = [];
-      for (const e of (src.images || [])) if (e && e.url) entries.push({ kind: 'image', name: e.name || '', url: e.url });
-      for (const e of (src.videos || [])) if (e && e.url) entries.push({ kind: 'video', name: e.name || '', url: e.url });
+      hostEntries = [];
+      for (const e of (src.images || [])) { const v = toEntry({ kind: 'image', name: e && e.name, url: e && e.url }); if (v) hostEntries.push(v); }
+      for (const e of (src.videos || [])) { const v = toEntry({ kind: 'video', name: e && e.name, url: e && e.url }); if (v) hostEntries.push(v); }
       skipped = src.skipped | 0;
       truncated = !!src.truncated;
-      deck = [];          // re-deal with the new entries in the mix
-      recent.length = 0;
+      rebuildEntries();
       // NOTE: `received` is deliberately NOT touched. The deck reset is about the
       // user's own preset changing; what a duel partner sent is keyed by hash and
       // has nothing to do with it (spec §4.3, trap register #5/#7).
+      // NOTE 2: `localEntries` is not touched either — a manifest frame that lands
+      // after the player has picked files (a host that re-scans its preset, or the
+      // synthesized standalone frame arriving late) must not empty their library.
       return counts();
     },
+
+    /**
+     * Swap in the LOCAL library — the whole list, every time, because that is
+     * what ui/assetsStore.js can hand over cheaply and a diff would only buy a
+     * reshuffle we do not mind paying for. Entries are `{kind,name,url}` with
+     * `kind` ALREADY DECIDED by the store (a blob: URL has no extension to sniff,
+     * so re-deriving it here would classify every pick as an image).
+     *
+     * URLs are the store's to own: acquire() hands them out with a no-op
+     * release(), so nothing here ever revokes a blob the assets screen is still
+     * rendering a thumbnail from.
+     */
+    setLocalLibrary(list) {
+      localEntries = [];
+      for (const e of (list || [])) { const v = toEntry(e); if (v) localEntries.push(v); }
+      rebuildEntries();
+      return counts();
+    },
+
+    /** How many of the deck's entries came from the player's own picks. */
+    localCount: () => localEntries.length,
 
     hasMedia: () => entries.length > 0,
     counts,

--- a/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
@@ -41,8 +41,11 @@
 
 import * as defaultBridge from '../bridge.js';
 
-/** The in-memory backend's whole budget. Nothing persists; this is the ceiling per session. */
-export const MEM_STORE_BYTES = 64 * 1024 * 1024;
+/** The in-memory backend's whole budget. Nothing persists; this is the ceiling per
+ * session. Sized to hold a few artifacts at the 64 MB wire cap — a phone browser
+ * is the only runtime that lives on this backend, so it stays deliberately
+ * smaller than MAX_SESSION_BYTES and old entries are evicted refcount-first. */
+export const MEM_STORE_BYTES = 192 * 1024 * 1024;
 
 /**
  * Binary bytes per bridge chunk. 262 144 -> 349 528 base64 chars, inside the host's

--- a/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
@@ -12,6 +12,13 @@
 //   * a caller never receives its own messages back (no self-echo) — but the cursor still advances
 //     PAST them, so the next poll doesn't re-walk the whole list;
 //   * /join marks the room joined, which is what the host's next /signal sees as peer_joined;
+//   * SEAT IDENTITY: the seat belongs to a uid. The same uid rejoining RECLAIMS it (fresh token,
+//     stale SDP dropped), a different uid is refused `already_joined`, and the host's own uid is
+//     refused `self_join`. This is not auth — it is the rule that decides whether a client can get
+//     back into the room it just fell out of, and a fake that got it wrong would teach the client
+//     that a ghost seat is normal;
+//   * /leave hands the seat back (guest) or folds the room (host), so a fold is testable without
+//     waiting out a TTL;
 //   * room TTL (the C# fake has no clock; this one does, so an "expired" path is testable).
 //
 // Long-poll: the fake answers instantly and the caller's cadence timer paces it, same as C#.
@@ -111,6 +118,9 @@ export class GoonFakeSignalingServer {
           code: `${this._codePrefix}${String(this._codeCounter).padStart(2, '0')}`,
           hostToken: newToken(),
           guestToken: newToken(),
+          hostUid: typeof req.unified_id === 'string' ? req.unified_id : '',
+          guestUid: null,
+          guestEpoch: 0,
           joined: false,
           signals: [],          // {seq, kind, data, from}
           relay: [],            // {seq, from, data}
@@ -134,10 +144,23 @@ export class GoonFakeSignalingServer {
         const room = this._live(req.code);
         // A bad code and an expired code are indistinguishable to a joiner, by design.
         if (!room) return fail(404, GoonSignalError.UnknownCode);
-        if (room.joined) return fail(409, GoonSignalError.AlreadyJoined);
+        const uid = typeof req.unified_id === 'string' ? req.unified_id : '';
+        // Your own room is not a full room. One account cannot hold both seats:
+        // the ledger, the pair record and the peer card are all "the other uid".
+        if (uid && uid === room.hostUid) return fail(409, GoonSignalError.SelfJoin);
+        const rejoin = room.joined && !!uid && room.guestUid === uid;
+        if (room.joined && !rejoin) return fail(409, GoonSignalError.AlreadyJoined);
         room.joined = true;
+        room.guestUid = uid;
+        room.guestEpoch++;
+        room.guestToken = newToken();     // every claim gets a fresh token
+        // A reclaimed seat starts on a clean mailbox: the dead attempt's SDP would
+        // otherwise be handed to the fresh peer connection as if it were live. The
+        // SEQ counter deliberately keeps counting — the host's cursor is past it.
+        if (rejoin) room.signals = [];
         return ok({
           ok: true,
+          rejoin,
           token: room.guestToken,
           role: 'guest',
           expires_in_sec: Math.max(0, Math.round((room.expiresAt - this._now()) / 1000)),
@@ -148,6 +171,28 @@ export class GoonFakeSignalingServer {
           // The joiner is the GUEST, so the peer whose card it learns is the host.
           peer_card_ver: this.hostCardVer,
         });
+      }
+
+      case '/v2/goon/leave': {
+        const room = this._live(req.code);
+        if (!room) return fail(404, GoonSignalError.Expired);
+        const role = typeof req.role === 'string' ? req.role : 'guest';
+        const token = typeof req.token === 'string' ? req.token : '';
+        if (token !== (role === 'host' ? room.hostToken : room.guestToken)) {
+          return fail(401, GoonSignalError.Unauthorized);
+        }
+        if (role === 'host') {
+          // The code dies with the person holding it.
+          this._rooms.delete(room.code);
+          return ok({ ok: true, folded: true });
+        }
+        // The seat goes back on the market; the ROOM stays up, so the same player
+        // can retry (or anyone else can join) without a second code and a second
+        // burned pass. This is the anti-ghost half of the 2026-08-04 fix.
+        room.joined = false;
+        room.guestUid = null;
+        room.signals = [];
+        return ok({ ok: true, folded: false });
       }
 
       case '/v2/goon/signal': {

--- a/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
@@ -17,6 +17,11 @@
 //     refused `self_join`. This is not auth — it is the rule that decides whether a client can get
 //     back into the room it just fell out of, and a fake that got it wrong would teach the client
 //     that a ghost seat is normal;
+//   * SELF-DUEL: a WHITELISTED uid is the one exception to `self_join` — it may hold both seats, and
+//     its guest seat is stored under the shadow id `<uid>#self`. Modelled because it is seat
+//     identity, and because a fake that refused it would make the owner's two-device play-test
+//     (one account, PC hosts, phone joins) look like a client bug. `whitelist`/`setWhitelisted`
+//     stand in for the server's user record — the fake models WHO may, never HOW it is proven;
 //   * /leave hands the seat back (guest) or folds the room (host), so a fold is testable without
 //     waiting out a TTL;
 //   * room TTL (the C# fake has no clock; this one does, so an "expired" path is testable).
@@ -26,6 +31,15 @@
 import { GoonSignalError } from './signaling.js';
 
 const DEFAULT_TTL_MS = 300000;   // ~5 min, the documented room TTL
+
+/**
+ * A self-duel's guest seat id. Unified ids are `u_[a-z0-9]{8,24}` server-side, so the '#' can never
+ * collide with — or be mistaken for — a real account, which is the whole point: every uid-keyed
+ * thing the real server writes (pair record, ledger, report attribution) then sees two identities.
+ */
+const SELF_SUFFIX = '#self';
+export const shadowGuestUid = (uid) => `${uid}${SELF_SUFFIX}`;
+export const isShadowUid = (uid) => typeof uid === 'string' && uid.endsWith(SELF_SUFFIX);
 
 function ok(body) { return Promise.resolve({ status: 200, body: JSON.stringify(body) }); }
 function fail(status, error) { return Promise.resolve({ status, body: JSON.stringify({ error }) }); }
@@ -48,13 +62,22 @@ export class GoonFakeSignalingServer {
    * @param {number} [o.ttlMs] room lifetime
    * @param {() => number} [o.now] injectable clock (ms) — tests expire rooms without waiting
    * @param {string} [o.codePrefix]
+   * @param {string[]} [o.whitelist] uids allowed to self-duel (see setWhitelisted)
    */
-  constructor({ ttlMs = DEFAULT_TTL_MS, now = () => Date.now(), codePrefix = 'LOOP' } = {}) {
+  constructor({ ttlMs = DEFAULT_TTL_MS, now = () => Date.now(), codePrefix = 'LOOP', whitelist = [] } = {}) {
     this._rooms = new Map();
     this._ttlMs = ttlMs;
     this._now = now;
     this._codePrefix = codePrefix;
     this._codeCounter = 0;
+    /**
+     * Uids that may hold BOTH seats of their own room. The real server reads this off the user
+     * record (`patreon_is_whitelisted` / `substar_is_whitelisted` — whitelist, NOT tier: a paying
+     * tier-2 patron is refused, because a self-duel is a ledger/self-report surface and only the
+     * hand-maintained list is trusted with it). Here it is just a set a test can fill.
+     * @type {Set<string>}
+     */
+    this._whitelist = new Set(Array.isArray(whitelist) ? whitelist.map(String) : []);
     /** Every request the server saw — handy in an assertion. */
     this.requests = [];
     /**
@@ -81,6 +104,18 @@ export class GoonFakeSignalingServer {
     const v = (typeof ver === 'string' && ver) ? ver : null;
     if (role === 'guest') this.guestCardVer = v; else this.hostCardVer = v;
     return v;
+  }
+
+  /**
+   * Test hook: mark a uid privileged (or not), i.e. allowed to self-duel.
+   * @param {string} uid
+   * @param {boolean} [on]
+   */
+  setWhitelisted(uid, on = true) {
+    const u = String(uid || '');
+    if (!u) return this;
+    if (on) this._whitelist.add(u); else this._whitelist.delete(u);
+    return this;
   }
 
   /** Hand this to GoonSignalingClient's `post` option. */
@@ -147,11 +182,18 @@ export class GoonFakeSignalingServer {
         const uid = typeof req.unified_id === 'string' ? req.unified_id : '';
         // Your own room is not a full room. One account cannot hold both seats:
         // the ledger, the pair record and the peer card are all "the other uid".
-        if (uid && uid === room.hostUid) return fail(409, GoonSignalError.SelfJoin);
-        const rejoin = room.joined && !!uid && room.guestUid === uid;
+        // …unless the account is WHITELISTED, which is the owner's two-device
+        // play-test. Then it takes the SHADOW seat, so those three stay pointed at
+        // two distinct identities and the exception costs the guard nothing.
+        const selfDuel = !!uid && uid === room.hostUid;
+        if (selfDuel && !this._whitelist.has(uid)) return fail(409, GoonSignalError.SelfJoin);
+        // Which seat this caller is entitled to reclaim. A self-duel guest must match
+        // the SHADOW seat, or every rejoin would re-enter the fresh-claim path.
+        const seatUid = selfDuel ? shadowGuestUid(uid) : uid;
+        const rejoin = room.joined && !!uid && room.guestUid === seatUid;
         if (room.joined && !rejoin) return fail(409, GoonSignalError.AlreadyJoined);
         room.joined = true;
-        room.guestUid = uid;
+        room.guestUid = seatUid;
         room.guestEpoch++;
         room.guestToken = newToken();     // every claim gets a fresh token
         // A reclaimed seat starts on a clean mailbox: the dead attempt's SDP would
@@ -161,6 +203,8 @@ export class GoonFakeSignalingServer {
         return ok({
           ok: true,
           rejoin,
+          // Advisory: both seats are one account. Nothing in the match depends on it.
+          self_duel: selfDuel,
           token: room.guestToken,
           role: 'guest',
           expires_in_sec: Math.max(0, Math.round((room.expiresAt - this._now()) / 1000)),

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
@@ -45,8 +45,10 @@ export const BULK_LOW_WATER = 1 << 18;     // 256 KiB
 /** Receiver acks at most this often, by bytes received. */
 export const ACK_EVERY_BYTES = 1 << 18;    // 256 KiB
 
-/** Per artifact, both directions. */
-export const MAX_ARTIFACT_BYTES = 24 * 1024 * 1024;
+/** Per artifact, both directions. (Owner raised 24→64 MB 2026-08-04: real clips
+ * routinely land 25..50 MB and the transfer already self-regulates via the
+ * MAX_XFER_MS throughput budget, so the rail was the only thing refusing them.) */
+export const MAX_ARTIFACT_BYTES = 64 * 1024 * 1024;
 /**
  * Tighter cap for un-transcoded originals. An exempt original is by definition un-optimised (no
  * 720p ceiling, no re-encode), and 20 MB of that is ~40 s of dead time on a mediocre link.
@@ -54,8 +56,8 @@ export const MAX_ARTIFACT_BYTES = 24 * 1024 * 1024;
  * exempt original from a compressed artifact and does not try.
  */
 export const MAX_EXEMPT_BYTES = 8 * 1024 * 1024;
-/** Per match, per direction. */
-export const MAX_SESSION_BYTES = 192 * 1024 * 1024;
+/** Per match, per direction. Scaled with the artifact cap (~8 big items). */
+export const MAX_SESSION_BYTES = 512 * 1024 * 1024;
 
 export const MAX_CONCURRENT_IN = 1;
 export const MAX_CONCURRENT_OUT = 1;

--- a/ConditioningControlPanel/Resources/web/goon/net/session.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/session.js
@@ -29,6 +29,19 @@
 // LEAVE vs TEARDOWN: leave() is user-initiated and routes through match.cancelMatch (in Live that
 // is a Mercy). Every internal path — fallback, failure, dispose — uses dispose() only, which sends
 // nothing. Getting that backwards would turn a transport hiccup into a forfeit.
+//
+// THE SEAT IS HANDED BACK (2026-08-04). Every teardown of a room that never connected fires a
+// best-effort /v2/goon/leave (_releaseRoom). Without it, a guest whose handshake died left its uid
+// sitting in the room's guest slot for the whole 30-minute TTL, and the retry it obviously makes
+// next was answered with "that room already has two players" — by its own ghost. The server also
+// reclaims a same-uid seat on /join now, so the two fixes cover each other: the goodbye can be
+// lost (offline, closed tab, old server) and the rejoin still works.
+//
+// ONE /join PER USER ACTION: the entry points refuse to start while `currentMatch` is set
+// (_beginSession returns null), the relay fallback re-uses the room via adoptRoom instead of
+// re-joining, and the join screen holds a `busy` latch across the await. There is no path that
+// issues two concurrent redemptions for one tap, and that is load-bearing — the second one would
+// be answered by the first one's seat.
 
 import { GoonSignalingClient } from './signaling.js';
 import { GoonWebRtcTransport } from './webrtcTransport.js';
@@ -85,6 +98,12 @@ export class GoonSession {
     this._transport = null;
     this._cancelled = false;
     this._disposed = false;
+    /**
+     * Did any transport in this session ever hand us an open channel? It gates the
+     * goodbye in _teardown: a room that never connected can safely be handed back,
+     * a room that DID is a live match whose room token the ledger still needs.
+     */
+    this._everConnected = false;
 
     /** The live match, or null when idle. REPLACED on relay fallback. */
     this.currentMatch = null;
@@ -185,6 +204,7 @@ export class GoonSession {
     if (this.currentMatch) return null;
 
     this._cancelled = false;
+    this._everConnected = false;   // per ATTEMPT, not per session object
     this._signaling = this._createSignaling();
     const webrtc = this._createWebrtc(isHost, this._signaling);
     this._transport = webrtc;
@@ -206,6 +226,7 @@ export class GoonSession {
     (async () => {
       try {
         const ok = await webrtc.waitForChannel();
+        if (ok) this._noteConnected(webrtc);
         if (ok || this._cancelled || this._disposed) return;
 
         if (!webrtc.iceFailed || !webrtc.code || !webrtc.token) {
@@ -252,6 +273,7 @@ export class GoonSession {
     this._raiseMatchChanged();
 
     const ok = await relay.waitForChannel();
+    if (ok) this._noteConnected(relay);
     if (!ok && !this._cancelled && !this._disposed) {
       const reason = relay.lastError || 'relay_failed';
       await this._teardown();
@@ -269,6 +291,14 @@ export class GoonSession {
     this._signaling = null;
     this._cancelled = true;
 
+    // THE GOODBYE. Hand the seat back before anything is disposed, so the room we
+    // are abandoning does not sit there as a GHOST for the rest of its TTL —
+    // which is what turns "join again" into "that room already has two players"
+    // (owner play-test, 2026-08-04). Strictly best-effort: not awaited, never
+    // throws, and skipped entirely once a channel came up, because past that
+    // point the room token belongs to a live match and the ledger still needs it.
+    this._releaseRoom(transport, signaling);
+
     if (match) {
       try { match.dispose(); }
       catch (e) { this._warn(`match dispose threw: ${(e && e.message) || e}`); }
@@ -281,6 +311,37 @@ export class GoonSession {
     if (signaling) { try { signaling.dispose(); } catch (_e) { /* already gone */ } }
 
     this._raiseMatchChanged();
+  }
+
+  /**
+   * A transport reported an open channel. Ignored unless it is still THE transport
+   * of THIS attempt: a watchdog for a torn-down leg resolving late must not mark
+   * the next attempt's room as connected — that would silently stop the goodbye.
+   */
+  _noteConnected(transport) {
+    if (this._cancelled || this._disposed) return;
+    if (this._transport !== transport) return;
+    this._everConnected = true;
+  }
+
+  /**
+   * Fire-and-forget /v2/goon/leave for a room that never connected. Deliberately
+   * NOT awaited: a teardown must complete at the same speed whether the server
+   * answers, 404s (route not deployed) or never replies at all.
+   */
+  _releaseRoom(transport, signaling) {
+    if (this._everConnected) return;
+    if (!signaling || typeof signaling.leave !== 'function') return;
+    const code = transport && transport.code;
+    const token = transport && transport.token;
+    if (!code || !token) return;    // never got a room; there is nothing to hand back
+    const role = transport.isHost ? 'host' : 'guest';
+    try {
+      const p = signaling.leave(code, token, role);
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    } catch (e) {
+      this._warn(`leave threw: ${(e && e.message) || e}`);
+    }
   }
 
   // ------------------------------------------------------------------ events

--- a/ConditioningControlPanel/Resources/web/goon/net/signaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/signaling.js
@@ -172,7 +172,7 @@ export class GoonSignalingClient {
     };
   }
 
-  /** @returns {Promise<{token, expiresInSec, peerDisplayName, peerAppVersion, pass, relayAllowed}|null>} */
+  /** @returns {Promise<{token, expiresInSec, peerDisplayName, peerAppVersion, pass, relayAllowed, rejoin, selfDuel}|null>} */
   async join(code, displayName = null) {
     const json = await this._call(GOON_PATHS.join, {
       unified_id: this.unifiedId,
@@ -200,6 +200,15 @@ export class GoonSignalingClient {
       peerCardVer: this._notePeerCard(json),
       /** True when the server handed back a seat this uid already held. */
       rejoin: json.rejoin === true,
+      /**
+       * True when this account is sitting in BOTH seats — the whitelist-only
+       * self-duel affordance (one account, two devices, the owner's play-test).
+       * Advisory only: the server put the guest seat under a shadow identity, so
+       * nothing about the match, the transports or the recap differs. Surfaced
+       * because a client that cannot SAY "you are duelling yourself" would leave
+       * the tester guessing which device is which.
+       */
+      selfDuel: json.self_duel === true,
     };
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/net/signaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/signaling.js
@@ -18,6 +18,7 @@ import { GoonConsts } from '../core/contracts.js';
 export const GOON_PATHS = Object.freeze({
   invite: '/v2/goon/invite',
   join: '/v2/goon/join',
+  leave: '/v2/goon/leave',
   signal: '/v2/goon/signal',
   relay: '/v2/goon/relay',
 });
@@ -29,6 +30,8 @@ export const GoonSignalError = Object.freeze({
   NoPass: 'no_pass',
   UnknownCode: 'unknown_code',
   AlreadyJoined: 'already_joined',
+  /** The code you typed is your OWN room — one account cannot sit on both seats. */
+  SelfJoin: 'self_join',
   Expired: 'expired',
   Unauthorized: 'unauthorized',
   RateLimited: 'rate_limited',
@@ -195,7 +198,39 @@ export class GoonSignalingClient {
       relayAllowed: json.relay_allowed === undefined ? true : !!json.relay_allowed,
       /** §3: the guest learns the host's card version on the join response. */
       peerCardVer: this._notePeerCard(json),
+      /** True when the server handed back a seat this uid already held. */
+      rejoin: json.rejoin === true,
     };
+  }
+
+  /**
+   * Best-effort seat release. A guest hands its seat back so a retry is not met
+   * by its own GHOST ("that room already has two players" for the rest of the
+   * room TTL); a host folds the lobby it is walking away from.
+   *
+   * FIRE-AND-FORGET BY CONTRACT. It resolves true/false and never throws, the
+   * caller must not await it on a teardown path, and the server treats it as
+   * advisory — the room TTL was always the real backstop and still is. It is
+   * also refused (409 match_started) once the match has reached the ledger,
+   * because releasing the seat invalidates the very token the result row needs;
+   * callers must only send it for a room that never connected.
+   * @returns {Promise<boolean>} true if the server acknowledged the release
+   */
+  async leave(code, token, role) {
+    // A goodbye must never overwrite the diagnosis the lobby is about to render:
+    // this runs on teardown paths that are ALREADY holding the reason they folded
+    // (`ice_timeout`, `already_joined`, …) in exactly these three fields.
+    const prev = { e: this.lastError, d: this.lastErrorDetail, r: this.retryAfterSeconds };
+    const json = await this._call(GOON_PATHS.leave, {
+      unified_id: this.unifiedId,
+      code: normalizeCode(code),
+      token: token || '',
+      role,
+    });
+    this.lastError = prev.e;
+    this.lastErrorDetail = prev.d;
+    this.retryAfterSeconds = prev.r;
+    return !!json;
   }
 
   /**

--- a/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
@@ -402,7 +402,15 @@ export class GoonWebRtcTransport extends GoonTransportBase {
         try {
           await pc.setRemoteDescription(remoteOffer);
         } catch (e) {
+          // SAME REMEDY AS webrtc_unavailable ABOVE, and for the same reason: the
+          // room is live and the pass is burned, so this has to be flagged for
+          // the relay or session.js reads it as a signaling-level failure and
+          // FOLDS THE LOBBY — which is a guest being evicted to the title screen
+          // with nothing said, the 2026-08-04 phone report. An offer this browser
+          // will not take is precisely a case a relay carries fine: the SDP never
+          // has to be understood by anything but the two peers' own stacks.
           this._warn(`setRemoteDescription(offer) rejected: ${(e && e.message) || e}`);
+          this._iceFailed = true;
           this._setLastError('sdp_rejected');
           this._setState(GoonTransportState.Disconnected, 'sdp_rejected');
           return;

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
@@ -890,7 +890,7 @@ function fakeSheets() {
  * AS-IS.
  *
  * The wire has two rails, not one: MAX_EXEMPT_BYTES (8 MB) for an untouched
- * original and MAX_ARTIFACT_BYTES (24 MB) for a compressed product. Everything
+ * original and MAX_ARTIFACT_BYTES (64 MB) for a compressed product. Everything
  * over the first used to be skipped, which meant a 1 GB zip of real photos
  * adopted nothing and said "over 8 MB" — a limit invented by the picker, not by
  * the protocol.
@@ -949,7 +949,7 @@ function fakeSheets() {
     && classifyLocalSize('image/png', 90 * MB) === 'too-big'
     && classifyLocalSize('video/mp4', 2 * MB) === 'take'
     && classifyLocalSize('video/mp4', 20 * MB) === 'take'
-    && classifyLocalSize('video/mp4', 30 * MB) === 'too-big-video'
+    && classifyLocalSize('video/mp4', 70 * MB) === 'too-big-video'
     && classifyLocalSize('image/gif', 0) === 'too-big',
     'classifyLocalSize routes by family AND size: a still is compressible to the decode cap, a clip only to '
     + 'the artifact cap, and past that it is its own answer');
@@ -990,7 +990,7 @@ function fakeSheets() {
     store.dispose();
   }
 
-  /* --- 8..24 MB of video rides as-is; past that it is said out loud ------- */
+  /* --- 8..64 MB of video rides as-is; past that it is said out loud ------- */
   {
     const stub = makeStub();
     const b = fakeBridge({ hosted: false });
@@ -1010,7 +1010,7 @@ function fakeSheets() {
     ok(!!it && it.artUrl !== '', 'behind artUrl, like every other artifact');
     ok(stub.calls.image.length === 0 && stub.calls.gif.length === 0, 'and the compressor was never asked');
 
-    const big = await store.addLocalFiles([realFile('feature.mp4', fill(30 * MB, 6), 'video/mp4')]);
+    const big = await store.addLocalFiles([realFile('feature.mp4', fill(70 * MB, 6), 'video/mp4')]);
     ok(big.tooBigVideo === 1 && big.added === 0 && big.tooBig === 0 && big.failed === 0,
       'a 30 MB clip lands in tooBigVideo — its OWN counter, because "too big to send" and "over the 8 MB '
       + 'as-is limit" are different sentences and only one of them is true here', JSON.stringify(big));
@@ -1100,7 +1100,7 @@ function fakeSheets() {
       'every adopted kind agrees with its mime — mediaChannel.familyOf is the rule and it declines the pair '
       + 'when they disagree, so an item that fails this is un-sendable and invisible about it');
     ok(locals.every((x) => x.bytes > 0 && x.bytes <= LOCAL_ARTIFACT_MAX_BYTES),
-      'and nothing adopted is past the 24 MB rail the transfer queue enforces');
+      'and nothing adopted is past the 64 MB rail the transfer queue enforces');
     ok(locals.every((x) => (x.state === 'exempt' ? x.bytes <= LOCAL_MAX_BYTES : x.state === 'ready' && !!x.artUrl)),
       'exempt items are the small ones; everything else is ready + artUrl, which is what listSendable reads');
     store.dispose();
@@ -1112,13 +1112,13 @@ function fakeSheets() {
     // 25 MB of "compressed" output: past the wire cap, so there is nothing to
     // adopt. Adopting it anyway would put a row on the screen that can never be
     // offered, which is a worse lie than "that one did not work".
-    const fat = makeStub({ imageOut: new Uint8Array(25 * MB) });
+    const fat = makeStub({ imageOut: new Uint8Array(65 * MB) });
     const b = fakeBridge({ hosted: false });
     const store = createAssetsStore({ bridge: b, logger: null, compressor: fat });
     await sleep(5);
     const r = await store.addLocalFiles([realFile('vast.png', fill(20 * MB, 4), 'image/png')]);
     ok(r.failed === 1 && r.added === 0 && r.compressed === 0,
-      'an output past the 24 MB artifact cap is counted failed, never adopted', JSON.stringify(r));
+      'an output past the 64 MB artifact cap is counted failed, never adopted', JSON.stringify(r));
     store.dispose();
 
     const cross = makeStub({ throwOnImage: true });
@@ -1341,8 +1341,8 @@ function fakeSheets() {
     for (const k of ['adding', 'addingOne', 'compressing', 'compressed', 'skipBigVideo', 'trimmed', 'sizeShrunk']) {
       ok(S.assets.local[k] !== undefined, 'S.assets.local.' + k + ' exists');
     }
-    ok(/24 MB/.test(S.assets.local.skipBigVideo(2, formatBytes(LOCAL_ARTIFACT_MAX_BYTES))),
-      'the video refusal quotes the 24 MB rail, not the 8 MB one',
+    ok(/64 MB/.test(S.assets.local.skipBigVideo(2, formatBytes(LOCAL_ARTIFACT_MAX_BYTES))),
+      'the video refusal quotes the 64 MB rail, not the 8 MB one',
       S.assets.local.skipBigVideo(2, formatBytes(LOCAL_ARTIFACT_MAX_BYTES)));
   }
 }
@@ -1352,8 +1352,8 @@ function fakeSheets() {
   const src = await read('../ui/screens/assets.js');
   ok(/const LOCAL_ACCEPT[\s\S]{0,300}\.zip/.test(src), 'the device picker offers .zip to the OS file sheet');
   ok(/application\/zip/.test(src), 'by mime as well as by extension (android hands over one or the other)');
-  ok(/zip/.test(S.assets.local.limits('8 MB', '24 MB')), 'and the limits line says so out loud',
-    S.assets.local.limits('8 MB', '24 MB'));
+  ok(/zip/.test(S.assets.local.limits('8 MB', '64 MB')), 'and the limits line says so out loud',
+    S.assets.local.limits('8 MB', '64 MB'));
   ok(typeof S.assets.local.zipNone === 'string',
     'S.assets.local.zipNone exists — an archive holding nothing sendable must still answer');
   ok(typeof S.assets.local.zipBad === 'function'

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
@@ -188,11 +188,13 @@ const routerMod = await import('../ui/router.js');
 const stringsMod = await import('../ui/strings.js');
 const sheetsMod = await import('../ui/sheets.js');
 const zipMod = await import('../ui/zipReader.js');
+const compressMod = await import('../ui/localCompress.js');
 
 const {
   createAssetsStore, probeEncode, clampCapBytes, capGb, formatBytes, formatUsage,
-  etaMinutes, matchesFilter, normalizeState, pendingInputBytes,
+  etaMinutes, matchesFilter, normalizeState, pendingInputBytes, classifyLocalSize,
   CAP_MIN_BYTES, CAP_MAX_BYTES, CAP_DEFAULT_BYTES, MAX_COMPRESS_IDS, FILTERS, GB,
+  LOCAL_MAX_BYTES, LOCAL_ARTIFACT_MAX_BYTES, LOCAL_DECODE_MAX_BYTES, LOCAL_ZIP_MAX_ENTRIES,
 } = storeMod;
 const { S } = stringsMod;
 
@@ -592,10 +594,12 @@ function fakeSheets() {
     file('b.mp4', 2000, 'video/mp4'),
     file('typed-by-ext.GIF', 500, ''),                    // empty type — the extension decides
     file('evil.exe', 100, 'application/x-msdownload'),    // wire would refuse: rejected here
-    file('huge.png', 9 * 1024 * 1024, 'image/png'),       // over the exempt cap
+    // Past the DECODE cap, so it is refused without a compressor being asked —
+    // and without 90 MB being allocated: the gate is on `size`, before the read.
+    file('monster.png', 90 * 1024 * 1024, 'image/png'),
   ]);
   ok(r1.added === 3, 'three files adopted', JSON.stringify(r1));
-  ok(r1.badType === 1 && r1.tooBig === 1, 'the exe and the 9MB file were refused');
+  ok(r1.badType === 1 && r1.tooBig === 1, 'the exe and the 90MB source were refused');
   const locals = store.items.filter((it) => it.id.indexOf('local:') === 0);
   ok(locals.length === 3, 'they surface through store.items');
   ok(locals.every((it) => it.state === 'exempt' && /^[0-9a-f]{64}$/.test(it.sha)), 'as exempt items with a real sha');
@@ -635,6 +639,18 @@ function fakeSheets() {
   };
   const enc = new TextEncoder();
 
+  /**
+   * Per entry, optionally:
+   *   localExtra   — bytes in the LOCAL header's extra field that the central
+   *                  record does NOT mirror. Real writers pad these two
+   *                  differently all the time (zip64 placeholders, unix
+   *                  timestamps, alignment), and a reader that computes the
+   *                  data offset from the central copy lands inside the data.
+   *   declaredSize — the originalSize written into both headers, regardless of
+   *                  how many bytes are really there. Lets a 100 MB claim be
+   *                  tested without 100 MB of anything.
+   *   method       — the compression method id written into both headers.
+   */
   function storedZip(entries) {
     const locals = [];
     const central = [];
@@ -643,18 +659,23 @@ function fakeSheets() {
       const name = enc.encode(e.name);
       const data = e.bytes || new Uint8Array(0);
       const crc = crc32(data);
-      const lh = new Uint8Array(30 + name.length);
+      const lex = e.localExtra || new Uint8Array(0);
+      const oSize = (e.declaredSize === undefined) ? data.length : e.declaredSize;
+      const method = (e.method === undefined) ? 0 : e.method;
+      const lh = new Uint8Array(30 + name.length + lex.length);
       const lv = new DataView(lh.buffer);
       lv.setUint32(0, 0x04034b50, true); lv.setUint16(4, 20, true);
+      lv.setUint16(8, method, true);
       lv.setUint32(14, crc, true);
-      lv.setUint32(18, data.length, true); lv.setUint32(22, data.length, true);
-      lv.setUint16(26, name.length, true);
-      lh.set(name, 30);
+      lv.setUint32(18, data.length, true); lv.setUint32(22, oSize, true);
+      lv.setUint16(26, name.length, true); lv.setUint16(28, lex.length, true);
+      lh.set(name, 30); lh.set(lex, 30 + name.length);
       const ch = new Uint8Array(46 + name.length);
       const cv = new DataView(ch.buffer);
       cv.setUint32(0, 0x02014b50, true); cv.setUint16(4, 20, true); cv.setUint16(6, 20, true);
+      cv.setUint16(10, method, true);
       cv.setUint32(16, crc, true);
-      cv.setUint32(20, data.length, true); cv.setUint32(24, data.length, true);
+      cv.setUint32(20, data.length, true); cv.setUint32(24, oSize, true);
       cv.setUint16(28, name.length, true); cv.setUint32(42, offset, true);
       ch.set(name, 46);
       locals.push(lh, data); central.push(ch);
@@ -677,10 +698,12 @@ function fakeSheets() {
     for (let i = 0; i < n; i++) u[i] = (i * 7 + seed) % 251;
     return u;
   };
-  const asFile = (name, bytes, type) => ({
-    name, type: type || '', size: bytes.length,
-    arrayBuffer: () => Promise.resolve(bytes.slice().buffer),
-  });
+  /**
+   * A REAL File, because the reader now takes the pick itself and slices it.
+   * Node has had File (with Blob.slice().arrayBuffer()) since 20, so the same
+   * object the browser hands over is the object under test here.
+   */
+  const asFile = (name, bytes, type) => new File([bytes], name, { type: type || '' });
   const zipOf = (name, entries) => asFile(name, storedZip(entries), 'application/zip');
 
   const b = fakeBridge({ hosted: false });
@@ -695,13 +718,15 @@ function fakeSheets() {
     { name: '__MACOSX/._a.png', bytes: fill(32, 4) },                   // resource fork
     { name: '.hidden.png', bytes: fill(48, 5) },                        // dotfile
     { name: 'inner.zip', bytes: storedZip([{ name: 'c.png', bytes: fill(100, 6) }]) },
-    { name: 'huge.png', bytes: fill(9 * 1024 * 1024, 7) },              // over the exempt cap
+    // 90 MB DECLARED, ten bytes present: past the decode cap, so the directory
+    // pass refuses it and the bytes are never touched.
+    { name: 'monster.png', bytes: fill(10, 7), declaredSize: 90 * 1024 * 1024 },
   ]);
 
   const r1 = await store.addLocalFiles([library]);
   ok(r1.zips === 1, 'the picked archive was EXPANDED, not adopted', JSON.stringify(r1));
   ok(r1.added === 2, 'both eligible entries came out of it', JSON.stringify(r1));
-  ok(r1.tooBig === 1, 'and the 9 MB entry hit the very same exempt cap a hand-picked file would');
+  ok(r1.tooBig === 1, 'and the 90 MB entry hit the very same decode cap a hand-picked file would');
   const locals = store.items.filter((it) => it.id.indexOf('local:') === 0);
   ok(locals.length === 2, 'they surface through store.items like any other pick');
   ok(locals.every((it) => it.state === 'exempt' && /^[0-9a-f]{64}$/.test(it.sha)),
@@ -725,8 +750,9 @@ function fakeSheets() {
 
   const junk = fill(64, 13);
   const r4 = await store.addLocalFiles([asFile('broken.zip', junk, 'application/zip')]);
-  ok(r4.failed === 1 && r4.added === 0 && r4.zips === 0,
-    'a corrupt archive is ONE failed pick — it never throws and never empties the screen', JSON.stringify(r4));
+  ok(r4.zipBad === 1 && r4.added === 0 && r4.zips === 0 && r4.tooBig === 0,
+    'a corrupt archive is ONE zipBad — it never throws, never empties the screen, and NEVER lands in tooBig '
+    + '(the per-file 8 MB line on an archive failure is the whole bug this path had)', JSON.stringify(r4));
 
   const r5 = await store.addLocalFiles([
     zipOf('more.zip', [{ name: 'd.webp', bytes: fill(700, 8) }]),
@@ -744,18 +770,109 @@ function fakeSheets() {
     'and it lands at its ORIGINAL size, not its packed one');
 
   // The ceilings, driven straight — the store passes only the per-entry cap.
-  const four = storedZip([1, 2, 3, 4].map((i) => ({ name: 'p' + i + '.png', bytes: fill(500, 20 + i) })));
+  const four = asFile('four.zip',
+    storedZip([1, 2, 3, 4].map((i) => ({ name: 'p' + i + '.png', bytes: fill(500, 20 + i) }))),
+    'application/zip');
   const cut = await zipMod.readZipMedia(four, { maxEntries: 2 });
-  ok(cut.ok && cut.entries.length === 2 && cut.truncated === true && cut.failed === 2,
-    'the entry ceiling truncates and counts the rest as failed', JSON.stringify({ n: cut.entries.length, f: cut.failed }));
+  ok(cut.ok && cut.entries.length === 2 && cut.truncated === true && cut.trimmed === 2 && cut.failed === 0,
+    'the entry ceiling truncates and counts the rest as TRIMMED, never as failed — "took the first N" of a '
+    + 'real library is not the same news as "unreadable"',
+    JSON.stringify({ n: cut.entries.length, trimmed: cut.trimmed, failed: cut.failed }));
   const bomb = await zipMod.readZipMedia(four, { maxTotalBytes: 900 });
   ok(bomb.ok && bomb.entries.length === 1 && bomb.truncated === true,
     'and the zip-bomb guard stops on the DECLARED size, before a byte is inflated',
     JSON.stringify({ n: bomb.entries.length }));
-  const garbage = await zipMod.readZipMedia(junk);
+  const garbage = await zipMod.readZipMedia(asFile('junk.zip', junk, 'application/zip'));
   ok(garbage.ok === false && garbage.entries.length === 0,
     'readZipMedia answers ok:false for garbage instead of throwing', garbage.reason);
-  ok((await zipMod.readZipMedia(new Uint8Array(4))).ok === false, 'a buffer too short to hold an EOCD is refused early');
+  ok((await zipMod.readZipMedia(asFile('tiny.zip', new Uint8Array(4), ''))).ok === false,
+    'a file too short to hold an EOCD is refused early');
+
+  /* --- the local header's extra field is NOT the central one ---------------
+   * The classic offset bug: compute the data start from the central record's
+   * extraLen and every byte read is shifted. STORED entries make it silent —
+   * the slice is still the right LENGTH — so this compares the bytes. */
+  {
+    const want = fill(600, 41);
+    const skew = asFile('skew.zip', storedZip([
+      { name: 'front-padded.png', bytes: want, localExtra: fill(37, 99) },
+      { name: 'plain.png', bytes: fill(240, 42) },
+    ]), 'application/zip');
+    const r = await zipMod.readZipMedia(skew);
+    const got = r.entries.find((e) => e.name === 'front-padded.png');
+    ok(r.ok && !!got && got.bytes.length === want.length && got.bytes.every((b, i) => b === want[i]),
+      'an entry whose LOCAL extra field is longer than its central record still reads byte-exact '
+      + '— the data offset comes from the local header, never the directory',
+      JSON.stringify({ ok: r.ok, n: r.entries.length, failed: r.failed }));
+    ok(r.entries.length === 2 && r.failed === 0, 'and the entry after it is still found', JSON.stringify(r.failed));
+  }
+
+  /* --- a fat DECLARED size is refused without being touched --------------- */
+  {
+    // 100 MB claimed, ten bytes of junk present, method 8. Anything that tried
+    // to inflate this would count `failed`; the ceiling must catch it first,
+    // from the directory alone.
+    const liar = asFile('liar.zip', storedZip([
+      { name: 'whopper.png', bytes: fill(10, 3), declaredSize: 100 * 1024 * 1024, method: 8 },
+      { name: 'ok.png', bytes: fill(120, 4) },
+    ]), 'application/zip');
+    const r = await zipMod.readZipMedia(liar, { maxEntryBytes: 8 * 1024 * 1024 });
+    ok(r.ok && r.tooBig === 1 && r.failed === 0 && r.entries.length === 1,
+      'an entry declaring more than the per-entry cap is counted tooBig from the DIRECTORY — '
+      + 'never sliced, never inflated (a bogus deflate stream would have failed loudly)',
+      JSON.stringify({ tooBig: r.tooBig, failed: r.failed, n: r.entries.length }));
+  }
+
+  /* --- a corrupt EOCD is an archive-level answer, not an exception -------- */
+  {
+    const good = storedZip([{ name: 'x.png', bytes: fill(300, 51) }]);
+    const noSig = good.slice();
+    noSig[noSig.length - 22] ^= 0xFF;                       // murder the EOCD signature
+    const a = await zipMod.readZipMedia(asFile('nosig.zip', noSig, 'application/zip'));
+    ok(a.ok === false && a.reason === 'not-a-zip' && a.entries.length === 0,
+      'an EOCD with a broken signature answers ok:false, and says which kind of broken', a.reason);
+
+    const badOff = good.slice();
+    new DataView(badOff.buffer).setUint32(badOff.length - 22 + 16, 0x7FFFFFF0, true);  // cd offset past EOF
+    const b2 = await zipMod.readZipMedia(asFile('badoff.zip', badOff, 'application/zip'));
+    ok(b2.ok === false && b2.reason === 'unreadable' && b2.entries.length === 0,
+      'and an EOCD pointing its central directory past the end of the file does too', b2.reason);
+
+    const r5b = await store.addLocalFiles([asFile('nosig2.zip', noSig, 'application/zip')]);
+    ok(r5b.zipBad === 1 && r5b.tooBig === 0 && r5b.failed === 0,
+      'the store reports that as zipBad — the ONE counter the 8 MB copy never reads', JSON.stringify(r5b));
+  }
+
+  /* --- the memory profile, measured -------------------------------------
+   * The whole point of the rework: a big archive must cost its tail, its
+   * directory and one entry — never its size. This wraps a real File in a
+   * counter and checks the bytes actually pulled. */
+  {
+    const big = storedZip([1, 2, 3, 4, 5, 6].map((i) => ({ name: 'm' + i + '.png', bytes: fill(64 * 1024, i) })));
+    const real = asFile('big.zip', big, 'application/zip');
+    let sliced = 0;
+    let wholeReads = 0;
+    const watched = {
+      name: real.name, type: real.type, size: real.size,
+      slice(a, b) { sliced += (b - a); return real.slice(a, b); },
+      arrayBuffer() { wholeReads++; return real.arrayBuffer(); },
+    };
+    const r = await zipMod.readZipMedia(watched, { isEligible: (n) => n === 'm3.png' });
+    ok(r.ok && r.entries.length === 1, 'a selective read still finds its one entry', JSON.stringify(r.entries.length));
+    ok(wholeReads === 0, 'and NOTHING on the path called arrayBuffer() on the archive itself');
+    ok(sliced < real.size / 2,
+      'the bytes actually pulled are a fraction of the archive — tail + directory + one entry',
+      sliced + ' of ' + real.size);
+
+    // ...and the caller can refuse to let the extracted bytes pile up at all.
+    const seen = [];
+    const streamed = await zipMod.readZipMedia(real, { onEntry: (e) => { seen.push(e.name); } });
+    ok(streamed.ok && streamed.took === 6 && seen.length === 6 && streamed.entries.length === 0,
+      'onEntry streams each entry out and the result array stays EMPTY — 500 photos are never in the heap together',
+      JSON.stringify({ took: streamed.took, held: streamed.entries.length }));
+    ok(/onEntry/.test(await read('../ui/assetsStore.js')),
+      'and the store is what uses it: entries are adopted one at a time, not collected first');
+  }
   ok(zipMod.isZipFile({ name: 'x.ZIP', type: '' }) === true
     && zipMod.isZipFile({ name: 'x', type: 'application/x-zip-compressed' }) === true
     && zipMod.isZipFile({ name: 'x.png', type: 'image/png' }) === false,
@@ -768,14 +885,485 @@ function fakeSheets() {
   ok(store.localCount === 0, 'dispose clears everything the archives added, too');
 }
 
+/* ===========================================================================
+ * THE ADOPTION POLICY — what standalone does with media that is TOO BIG TO SEND
+ * AS-IS.
+ *
+ * The wire has two rails, not one: MAX_EXEMPT_BYTES (8 MB) for an untouched
+ * original and MAX_ARTIFACT_BYTES (24 MB) for a compressed product. Everything
+ * over the first used to be skipped, which meant a 1 GB zip of real photos
+ * adopted nothing and said "over 8 MB" — a limit invented by the picker, not by
+ * the protocol.
+ *
+ * The compressor is INJECTED here. There is no canvas, no createImageBitmap and
+ * no WebCodecs under node, so what these checks pin is the POLICY — which lane a
+ * file is routed to, which counter it lands in, what identity it ends up with —
+ * and never the pixels. The real lanes are exercised in a browser.
+ * ======================================================================== */
+{
+  const MB = 1024 * 1024;
+  const hexOf = (buf) => Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');
+  const sha256 = async (u8) => hexOf(await crypto.subtle.digest('SHA-256', u8));
+  const fill = (n, seed) => {
+    const u = new Uint8Array(n);
+    for (let i = 0; i < n; i++) u[i] = (i * 31 + seed) % 251;
+    return u;
+  };
+  const realFile = (name, bytes, type) => new File([bytes], name, { type: type || '' });
+
+  /**
+   * The stub. It records what it was handed and answers with bytes of a size
+   * the test chose, so "did the policy pick the still lane or the animated one"
+   * and "whose bytes became the wire identity" are both directly observable.
+   */
+  function makeStub(o = {}) {
+    const calls = { image: [], gif: [] };
+    const imgOut = o.imageOut || fill(600 * 1024, 7);
+    const gifOut = o.gifOut || fill(900 * 1024, 9);
+    return {
+      calls, imgOut, gifOut,
+      compressImage(src, mime) {
+        calls.image.push({ mime, bytes: src.byteLength });
+        if (o.throwOnImage) return Promise.reject(new Error('stub-refused'));
+        return Promise.resolve({
+          blob: new Blob([imgOut], { type: 'image/webp' }), mime: 'image/webp', w: 1920, h: 1080, kind: 'image',
+        });
+      },
+      compressGif(src, mime) {
+        calls.gif.push({ mime, bytes: src.byteLength });
+        return Promise.resolve({
+          blob: new Blob([gifOut], { type: 'video/mp4' }), mime: 'video/mp4', w: 720, h: 720, durMs: 3200, kind: 'video',
+        });
+      },
+    };
+  }
+
+  const chan = await import('../net/mediaChannel.js');
+  ok(LOCAL_MAX_BYTES === chan.MAX_EXEMPT_BYTES && LOCAL_ARTIFACT_MAX_BYTES === chan.MAX_ARTIFACT_BYTES,
+    'the two local rails ARE the wire\'s two rails, imported — a copy of 8/24 would drift the day either moves',
+    LOCAL_MAX_BYTES + ' / ' + LOCAL_ARTIFACT_MAX_BYTES);
+
+  /* --- the routing table, as a pure function ----------------------------- */
+  ok(classifyLocalSize('image/png', 1000) === 'take'
+    && classifyLocalSize('image/png', 12 * MB) === 'take'
+    && classifyLocalSize('image/png', 90 * MB) === 'too-big'
+    && classifyLocalSize('video/mp4', 2 * MB) === 'take'
+    && classifyLocalSize('video/mp4', 20 * MB) === 'take'
+    && classifyLocalSize('video/mp4', 30 * MB) === 'too-big-video'
+    && classifyLocalSize('image/gif', 0) === 'too-big',
+    'classifyLocalSize routes by family AND size: a still is compressible to the decode cap, a clip only to '
+    + 'the artifact cap, and past that it is its own answer');
+
+  /* --- a 12 MB still becomes an artifact, identified by the OUTPUT bytes -- */
+  {
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+
+    const png = fill(12 * MB, 3);
+    const r = await store.addLocalFiles([realFile('holiday.png', png, 'image/png')]);
+    ok(r.added === 1 && r.compressed === 1 && r.tooBig === 0 && r.failed === 0,
+      'a 12 MB png is COMPRESSED and adopted, not refused — the whole bug, in one line', JSON.stringify(r));
+    ok(stub.calls.image.length === 1 && stub.calls.gif.length === 0,
+      'it went down the still lane', JSON.stringify(stub.calls.image));
+    ok(stub.calls.image[0].bytes === 12 * MB, 'with the SOURCE bytes, whole', String(stub.calls.image[0].bytes));
+
+    const it = store.items.find((x) => x.name === 'holiday.png');
+    ok(!!it && it.state === 'ready', 'it lands as a READY artifact, not as exempt — exempt means "sent as-is", '
+      + 'and this is not the file the player picked', it && it.state);
+    ok(!!it && it.bytes === stub.imgOut.length && it.srcBytes === 12 * MB,
+      'bytes is what TRAVELS and srcBytes what it came from', it && (it.bytes + '/' + it.srcBytes));
+    ok(!!it && it.sha === await sha256(stub.imgOut),
+      'and the sha is the sha of the COMPRESSED bytes — the artifact is the thing with the wire identity, '
+      + 'and the receiver re-hashes exactly these');
+    ok(!!it && it.mime === 'image/webp' && it.kind === 'image',
+      'the mime is the OUTPUT mime and the kind agrees with it (mediaChannel declines any offer where they do not)',
+      it && (it.mime + '/' + it.kind));
+    ok(!!it && it.artUrl !== '' && it.srcUrl === '',
+      'the bytes hang off artUrl, which is where boot.js listSendable() looks for a non-exempt item');
+
+    // Picking it again must not pay for the compression a second time.
+    const again = await store.addLocalFiles([realFile('holiday-copy.png', png, 'image/png')]);
+    ok(again.dupes === 1 && again.added === 0 && stub.calls.image.length === 1,
+      'the SOURCE sha is remembered, so the same photo is never compressed twice', JSON.stringify(again));
+    store.dispose();
+  }
+
+  /* --- 8..24 MB of video rides as-is; past that it is said out loud ------- */
+  {
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+
+    const clip = fill(20 * MB, 5);
+    const r = await store.addLocalFiles([realFile('clip.mp4', clip, 'video/mp4')]);
+    ok(r.added === 1 && r.compressed === 0 && r.tooBigVideo === 0,
+      'a 20 MB mp4 is adopted AS-IS — there is no browser transcode and it does not need one', JSON.stringify(r));
+    const it = store.items.find((x) => x.name === 'clip.mp4');
+    ok(!!it && it.state === 'ready' && it.kind === 'video' && it.mime === 'video/mp4',
+      'as a non-exempt READY artifact (exempt is capped at 8 MB — this would never be offered)',
+      it && (it.state + '/' + it.kind));
+    ok(!!it && it.bytes === 20 * MB && it.sha === await sha256(clip),
+      'carrying its OWN bytes and its own sha — nothing was re-encoded');
+    ok(!!it && it.artUrl !== '', 'behind artUrl, like every other artifact');
+    ok(stub.calls.image.length === 0 && stub.calls.gif.length === 0, 'and the compressor was never asked');
+
+    const big = await store.addLocalFiles([realFile('feature.mp4', fill(30 * MB, 6), 'video/mp4')]);
+    ok(big.tooBigVideo === 1 && big.added === 0 && big.tooBig === 0 && big.failed === 0,
+      'a 30 MB clip lands in tooBigVideo — its OWN counter, because "too big to send" and "over the 8 MB '
+      + 'as-is limit" are different sentences and only one of them is true here', JSON.stringify(big));
+    store.dispose();
+  }
+
+  /* --- animated vs still, decided by the BYTES ---------------------------- */
+  {
+    // A minimal but structurally real GIF: header, no global colour table, then
+    // graphic-control-extension + image-descriptor pairs, then the trailer.
+    const gifOf = (frames) => {
+      const out = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 2, 0, 2, 0, 0x00, 0, 0];
+      for (let i = 0; i < frames; i++) {
+        out.push(0x21, 0xF9, 0x04, 0x00, 0x0A, 0x00, 0x00, 0x00);        // GCE + sub-block terminator
+        out.push(0x2C, 0, 0, 0, 0, 2, 0, 2, 0, 0x00);                    // image descriptor
+        out.push(0x02, 0x01, 0x00, 0x00);                                // LZW size + one sub-block
+      }
+      out.push(0x3B);
+      return new Uint8Array(out);
+    };
+    ok(compressMod.gifFrameCount(gifOf(1), 2) === 1 && compressMod.gifFrameCount(gifOf(3), 2) === 2,
+      'gifFrameCount walks the block structure and stops at the limit',
+      compressMod.gifFrameCount(gifOf(1), 2) + '/' + compressMod.gifFrameCount(gifOf(3), 2));
+    ok(compressMod.gifFrameCount(new Uint8Array([1, 2, 3]), 2) === -1,
+      'and answers -1 rather than guessing when the walk hits something it does not know');
+    ok(compressMod.sniffAnimated(gifOf(4), 'image/gif') === 'animated'
+      && compressMod.sniffAnimated(gifOf(1), 'image/gif') === 'still',
+      'so a one-frame GIF takes the STILL lane and a four-frame one does not');
+
+    const webpHead = (flags, fourcc) => {
+      const u = new Uint8Array(24);
+      u.set([0x52, 0x49, 0x46, 0x46], 0);                                 // RIFF
+      u.set([0x57, 0x45, 0x42, 0x50], 8);                                 // WEBP
+      u.set(fourcc, 12);
+      u[20] = flags;
+      return u;
+    };
+    ok(compressMod.webpIsAnimated(webpHead(0x02, [0x56, 0x50, 0x38, 0x58])) === 'animated'
+      && compressMod.webpIsAnimated(webpHead(0x00, [0x56, 0x50, 0x38, 0x58])) === 'still'
+      && compressMod.webpIsAnimated(webpHead(0x00, [0x56, 0x50, 0x38, 0x20])) === 'still',
+      'and an animated WebP is read from the VP8X flag byte — a plain VP8 chunk is one frame by construction');
+
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+
+    // A 9 MB animated gif: over the exempt cap, so it must be encoded.
+    const anim = new Uint8Array(9 * MB);
+    anim.set(gifOf(6), 0);
+    const r = await store.addLocalFiles([realFile('loop.gif', anim, 'image/gif')]);
+    ok(r.added === 1 && r.compressed === 1 && stub.calls.gif.length === 1 && stub.calls.image.length === 0,
+      'a 9 MB ANIMATED gif goes to the animated lane — lane B\'s own worker, not the canvas',
+      JSON.stringify({ r, gif: stub.calls.gif.length, img: stub.calls.image.length }));
+    const it = store.items.find((x) => x.name === 'loop.gif');
+    ok(!!it && it.mime === 'video/mp4' && it.kind === 'video',
+      'and it changes FAMILY on the way: the artifact is an mp4, so the kind must say video or the offer gate '
+      + 'declines it as bad_mime', it && (it.mime + '/' + it.kind));
+    ok(!!it && it.ext === 'mp4' && it.durMs === 3200, 'the extension and duration come off the encode, not the source');
+
+    // ...and a still one of the same size does not.
+    const still = new Uint8Array(9 * MB);
+    still.set(gifOf(1), 0);
+    const r2 = await store.addLocalFiles([realFile('static.gif', still, 'image/gif')]);
+    ok(r2.added === 1 && stub.calls.image.length === 1 && stub.calls.gif.length === 1,
+      'a single-frame gif of the same size takes the STILL lane — an mp4 of one frame is nobody\'s idea of a photo',
+      JSON.stringify({ img: stub.calls.image.length, gif: stub.calls.gif.length }));
+    store.dispose();
+  }
+
+  /* --- every adopted local item satisfies the offer gate's own rules ------ */
+  {
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+    await store.addLocalFiles([
+      realFile('small.png', fill(2000, 1), 'image/png'),
+      realFile('mid.mp4', fill(12 * MB, 2), 'video/mp4'),
+      realFile('big.jpg', fill(30 * MB, 3), 'image/jpeg'),
+    ]);
+    const locals = store.items.filter((x) => String(x.id).indexOf('local:') === 0);
+    ok(locals.length === 3, 'three picks, three adoption roads, three items', String(locals.length));
+    const family = (m) => (String(m).indexOf('video/') === 0 ? 'video' : 'image');
+    ok(locals.every((x) => chan.ACCEPT_MIME.has(x.mime)), 'every adopted mime is one the wire carries');
+    ok(locals.every((x) => family(x.mime) === x.kind),
+      'every adopted kind agrees with its mime — mediaChannel.familyOf is the rule and it declines the pair '
+      + 'when they disagree, so an item that fails this is un-sendable and invisible about it');
+    ok(locals.every((x) => x.bytes > 0 && x.bytes <= LOCAL_ARTIFACT_MAX_BYTES),
+      'and nothing adopted is past the 24 MB rail the transfer queue enforces');
+    ok(locals.every((x) => (x.state === 'exempt' ? x.bytes <= LOCAL_MAX_BYTES : x.state === 'ready' && !!x.artUrl)),
+      'exempt items are the small ones; everything else is ready + artUrl, which is what listSendable reads');
+    store.dispose();
+  }
+
+  /* --- a pathological output, and a compressor that refuses --------------- */
+  {
+    const stub = makeStub({ imageOut: fill(1024, 2) });
+    // 25 MB of "compressed" output: past the wire cap, so there is nothing to
+    // adopt. Adopting it anyway would put a row on the screen that can never be
+    // offered, which is a worse lie than "that one did not work".
+    const fat = makeStub({ imageOut: new Uint8Array(25 * MB) });
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: fat });
+    await sleep(5);
+    const r = await store.addLocalFiles([realFile('vast.png', fill(20 * MB, 4), 'image/png')]);
+    ok(r.failed === 1 && r.added === 0 && r.compressed === 0,
+      'an output past the 24 MB artifact cap is counted failed, never adopted', JSON.stringify(r));
+    store.dispose();
+
+    const cross = makeStub({ throwOnImage: true });
+    const b2 = fakeBridge({ hosted: false });
+    const store2 = createAssetsStore({ bridge: b2, logger: null, compressor: cross });
+    await sleep(5);
+    const src = fill(11 * MB, 8);
+    const r2 = await store2.addLocalFiles([realFile('bad.png', src, 'image/png')]);
+    ok(r2.failed === 1 && r2.added === 0, 'a compressor that throws is one failed file, not a dead picker',
+      JSON.stringify(r2));
+    const r3 = await store2.addLocalFiles([realFile('bad-again.png', src, 'image/png')]);
+    ok(r3.dupes === 1 && cross.calls.image.length === 1,
+      'and the same bytes are not put through it again — a refusal is remembered for the session too');
+    store2.dispose();
+    ok(stub.imgOut.length === 1024, 'the unused stub is untouched');   // keeps the linter honest
+  }
+
+  /* --- the zip ceilings trim a real library, and SAY so ------------------- */
+  {
+    const enc = new TextEncoder();
+    const CRC = (() => {
+      const t = new Uint32Array(256);
+      for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+        t[i] = c >>> 0;
+      }
+      return t;
+    })();
+    const crc32 = (u8) => {
+      let c = 0xFFFFFFFF;
+      for (let i = 0; i < u8.length; i++) c = CRC[(c ^ u8[i]) & 0xFF] ^ (c >>> 8);
+      return (c ^ 0xFFFFFFFF) >>> 0;
+    };
+    function storedZip(entries) {
+      const locals = [];
+      const central = [];
+      let offset = 0;
+      for (const e of entries) {
+        const name = enc.encode(e.name);
+        const data = e.bytes || new Uint8Array(0);
+        const crc = crc32(data);
+        const oSize = (e.declaredSize === undefined) ? data.length : e.declaredSize;
+        const lh = new Uint8Array(30 + name.length);
+        const lv = new DataView(lh.buffer);
+        lv.setUint32(0, 0x04034b50, true); lv.setUint16(4, 20, true);
+        lv.setUint32(14, crc, true);
+        lv.setUint32(18, data.length, true); lv.setUint32(22, oSize, true);
+        lv.setUint16(26, name.length, true);
+        lh.set(name, 30);
+        const ch = new Uint8Array(46 + name.length);
+        const cv = new DataView(ch.buffer);
+        cv.setUint32(0, 0x02014b50, true); cv.setUint16(4, 20, true); cv.setUint16(6, 20, true);
+        cv.setUint32(16, crc, true);
+        cv.setUint32(20, data.length, true); cv.setUint32(24, oSize, true);
+        cv.setUint16(28, name.length, true); cv.setUint32(42, offset, true);
+        ch.set(name, 46);
+        locals.push(lh, data); central.push(ch);
+        offset += lh.length + data.length;
+      }
+      const cdSize = central.reduce((a, c) => a + c.length, 0);
+      const eocd = new Uint8Array(22);
+      const ev = new DataView(eocd.buffer);
+      ev.setUint32(0, 0x06054b50, true);
+      ev.setUint16(8, entries.length & 0xFFFF, true); ev.setUint16(10, entries.length & 0xFFFF, true);
+      ev.setUint32(12, cdSize, true); ev.setUint32(16, offset, true);
+      const all = locals.concat(central, [eocd]);
+      const out = new Uint8Array(all.reduce((a, c) => a + c.length, 0));
+      let p = 0;
+      for (const c of all) { out.set(c, p); p += c.length; }
+      return out;
+    }
+
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+
+    // Byte-unique per entry: `fill` repeats every 251 seeds, and 500 photos that
+    // dedup down to 251 would make this measure the wrong ceiling entirely.
+    const uniq = (i) => { const u = fill(40, i % 251); new DataView(u.buffer).setUint32(0, i, true); return u; };
+    const many = [];
+    for (let i = 0; i < LOCAL_ZIP_MAX_ENTRIES + 3; i++) many.push({ name: 'p' + i + '.png', bytes: uniq(i) });
+    const huge = new File([storedZip(many)], 'library.zip', { type: 'application/zip' });
+    const r = await store.addLocalFiles([huge]);
+    ok(r.added === LOCAL_ZIP_MAX_ENTRIES && r.trimmed === 3,
+      'a zip past the entry ceiling adopts the first ' + LOCAL_ZIP_MAX_ENTRIES + ' and TRIMS the rest',
+      JSON.stringify({ added: r.added, trimmed: r.trimmed, failed: r.failed }));
+    ok(r.failed === 0 && r.zipBad === 0 && r.tooBig === 0,
+      'and none of that is failed, zipBad or tooBig — the archive was fine, the ceiling is ours to admit to',
+      JSON.stringify(r));
+    ok(typeof S.assets.local.trimmed === 'function'
+      && !/unreadable|couldn't|broken/i.test(S.assets.local.trimmed(3, LOCAL_ZIP_MAX_ENTRIES)),
+      'and the string says what happened without calling a good library broken',
+      S.assets.local.trimmed(3, LOCAL_ZIP_MAX_ENTRIES));
+    store.dispose();
+  }
+
+  /* --- the progress seam: a long add is not a silent one ------------------ */
+  {
+    const stub = makeStub();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null, compressor: stub });
+    await sleep(5);
+    const seen = [];
+    const off = store.onLocalProgress((p) => seen.push({ running: p.running, done: p.done, total: p.total }));
+    ok(seen.length === 1 && seen[0].running === false,
+      'onLocalProgress answers immediately — a subscriber never waits for the first pick');
+    await store.addLocalFiles([
+      realFile('one.png', fill(1000, 1), 'image/png'),
+      realFile('two.png', fill(1000, 2), 'image/png'),
+      realFile('three.png', fill(1000, 3), 'image/png'),
+    ]);
+    ok(seen.some((p) => p.running && p.total === 3), 'it reports the denominator up front', JSON.stringify(seen[1]));
+    ok(seen.some((p) => p.running && p.done === 2), 'and counts up as each pick lands');
+    const last = seen[seen.length - 1];
+    ok(last.running === false && last.done === 3 && last.total === 3,
+      'and finishes at done === total with running false, so the line can hide itself',
+      JSON.stringify(last));
+    off();
+    store.dispose();
+  }
+
+  /* --- the LOCAL encode driver: lane B's worker, without lane B's protocol -
+   * The hosted driver answers a host `encode-request` and base64-chunks the
+   * result back over the bridge. This one is called directly and hands the
+   * bytes to its caller — same worker, same messages, no bridge in sight, which
+   * is exactly why the hosted path cannot regress from any of it. */
+  {
+    function fakeWorker() {
+      const w = {
+        posted: [], killed: false, onmessage: null, onerror: null,
+        postMessage(m, transfer) { w.posted.push({ m, transfer }); },
+        terminate() { w.killed = true; },
+        reply(m) { if (w.onmessage) w.onmessage({ data: m }); },
+      };
+      return w;
+    }
+
+    let made = null;
+    const driver = compressMod.createLocalEncodeDriver({ workerFactory: () => (made = fakeWorker()) });
+    const src = new Uint8Array(64).fill(9).buffer;
+    const pcts = [];
+    const p = driver.encode(src, 'image/gif', { maxBox: 720 }, (pct) => pcts.push(pct));
+    await sleep(2);
+    ok(!!made && made.posted.length === 1 && made.posted[0].m.kind === 'encode',
+      'the local driver posts an `encode` to the same worker lane B uses');
+    ok(made.posted[0].transfer && made.posted[0].transfer[0] === src,
+      'with the source bytes TRANSFERRED, not copied — a 40 MB gif is not cloned onto the worker heap');
+    ok(made.posted[0].m.cfg.maxBox === 720, 'and the caller\'s config, verbatim');
+    ok(!/jobId/.test(JSON.stringify(made.posted[0].m)) === false && String(made.posted[0].m.jobId).length > 0,
+      'the job carries its own id, minted here — the host never hears about it');
+
+    const id = made.posted[0].m.jobId;
+    made.reply({ kind: 'progress', jobId: id, pct: 42 });
+    made.reply({ kind: 'done', jobId: id, art: new Uint8Array(96).fill(1).buffer, w: 480, h: 270, durMs: 1500 });
+    const out = await p;
+    ok(pcts.length === 1 && pcts[0] === 42, 'progress is forwarded to the caller, not to a bridge', JSON.stringify(pcts));
+    ok(out && out.art.byteLength === 96 && out.w === 480 && out.durMs === 1500,
+      'and the finished mp4 comes back as BYTES — there is no cache to put it in');
+
+    const p2 = driver.encode(new Uint8Array(8).buffer, 'image/webp', {}, null);
+    await sleep(2);
+    const id2 = made.posted[1].m.jobId;
+    ok(made.posted[1].m.mime === 'image/webp', 'an animated WebP asks the decoder for image/webp, not gif');
+    made.reply({ kind: 'fail', jobId: id2, reason: 'unsupported' });
+    let threw = '';
+    try { await p2; } catch (e) { threw = String(e.message || e); }
+    ok(threw === 'unsupported', 'a worker failure rejects with the worker\'s own reason', threw);
+    driver.dispose();
+    ok(made.killed === true, 'and dispose terminates the worker — an encoder thread must not outlive the store');
+
+    // The blob wrapper, end to end, through the same seam the store calls.
+    const w2 = fakeWorker();
+    const d2 = compressMod.createLocalEncodeDriver({ workerFactory: () => w2 });
+    const gifP = compressMod.compressGif(new Uint8Array(32).buffer, 'image/gif', { driver: d2 });
+    await sleep(2);
+    w2.reply({ kind: 'done', jobId: w2.posted[0].m.jobId, art: new Uint8Array(64).fill(2).buffer, w: 300, h: 300, durMs: 900 });
+    const gifOut = await gifP;
+    ok(w2.posted[0].m.cfg.wantPrev === false,
+      'compressGif asks for NO micro-preview: the preview is a hosted concept (a second cache-put stream on the '
+      + 'bridge) and standalone has nowhere to put one');
+    ok(gifOut.mime === 'video/mp4' && gifOut.kind === 'video' && gifOut.blob.size === 64,
+      'compressGif answers with an mp4 Blob and the VIDEO kind — the store copies both onto the item, and the '
+      + 'offer gate declines any pair that disagrees', gifOut.mime + '/' + gifOut.kind);
+    d2.dispose();
+
+    ok(compressMod.fitDown(4000, 3000, 1920).w === 1920 && compressMod.fitDown(4000, 3000, 1920).h === 1440,
+      'fitDown scales the long edge to the box and keeps the ratio',
+      JSON.stringify(compressMod.fitDown(4000, 3000, 1920)));
+    ok(compressMod.fitDown(800, 600, 1920).scaled === false && compressMod.fitDown(800, 600, 1920).w === 800,
+      'and never scales a small image UP');
+    ok(compressMod.canEncodeAnimated() === false,
+      'canEncodeAnimated is a SYNCHRONOUS call-time probe — node has no WebCodecs and says so without '
+      + 'building a worker or transferring a 40 MB buffer into it first');
+    const real = compressMod.createLocalCompressor();
+    let refused = '';
+    try { await real.compressGif(new Uint8Array(8).buffer, 'image/gif'); } catch (e) { refused = String(e.message || e); }
+    ok(refused === 'no-encoder',
+      'so the real compressor refuses the animated lane honestly here — which is exactly what a Safari without '
+      + 'WebCodecs gets, and the store counts it as one failed file');
+    real.dispose();
+
+    ok(compressMod.extForMime('video/mp4') === 'mp4' && compressMod.extForMime('image/webp') === 'webp'
+      && compressMod.extForMime('image/jpeg') === 'jpg' && compressMod.extForMime('application/zip') === '',
+      'and the artifact extension comes from the OUTPUT mime');
+  }
+
+  /* --- the card says all of it ------------------------------------------- */
+  {
+    const src = await read('../ui/screens/assets.js');
+    ok(/r\.compressed[\s\S]{0,120}L\.compressed/.test(src), 'the summary line reports what was compressed');
+    ok(/r\.tooBigVideo[\s\S]{0,160}L\.skipBigVideo/.test(src),
+      'and gives an un-sendable video its own sentence, with the ARTIFACT cap in it');
+    ok(/r\.trimmed[\s\S]{0,120}L\.trimmed/.test(src), 'and admits to a trimmed library');
+    ok(/onLocalProgress/.test(src) && /ledger\.sub\(store\.onLocalProgress/.test(src),
+      'the progress line is a LEDGER subscription — an add that outlives the screen must not write to a dead node');
+    ok(/role: 'status'[\s\S]{0,200}gg-local-progress|gg-local-progress[\s\S]{0,200}role: 'status'/.test(src),
+      'and it is a role=status, so a screen reader hears the wait too');
+    for (const k of ['adding', 'addingOne', 'compressing', 'compressed', 'skipBigVideo', 'trimmed', 'sizeShrunk']) {
+      ok(S.assets.local[k] !== undefined, 'S.assets.local.' + k + ' exists');
+    }
+    ok(/24 MB/.test(S.assets.local.skipBigVideo(2, formatBytes(LOCAL_ARTIFACT_MAX_BYTES))),
+      'the video refusal quotes the 24 MB rail, not the 8 MB one',
+      S.assets.local.skipBigVideo(2, formatBytes(LOCAL_ARTIFACT_MAX_BYTES)));
+  }
+}
+
 {
   // --- the picker and the copy both admit that zips are allowed ----------
   const src = await read('../ui/screens/assets.js');
   ok(/const LOCAL_ACCEPT[\s\S]{0,300}\.zip/.test(src), 'the device picker offers .zip to the OS file sheet');
   ok(/application\/zip/.test(src), 'by mime as well as by extension (android hands over one or the other)');
-  ok(/zip/.test(S.assets.local.limits('8 MB')), 'and the limits line says so out loud', S.assets.local.limits('8 MB'));
+  ok(/zip/.test(S.assets.local.limits('8 MB', '24 MB')), 'and the limits line says so out loud',
+    S.assets.local.limits('8 MB', '24 MB'));
   ok(typeof S.assets.local.zipNone === 'string',
     'S.assets.local.zipNone exists — an archive holding nothing sendable must still answer');
+  ok(typeof S.assets.local.zipBad === 'function'
+    && !/\bMB\b/.test(S.assets.local.zipBad(1) + S.assets.local.zipBad(3)),
+    'S.assets.local.zipBad speaks about the ARCHIVE and never quotes a per-file size',
+    S.assets.local.zipBad(1) + ' / ' + S.assets.local.zipBad(3));
+  ok(/r\.zipBad[\s\S]{0,80}L\.zipBad/.test(src),
+    'and the summary line renders it on its own, instead of folding an archive failure into skipBig');
+  ok(!/LOCAL_ZIP_MAX_BYTES|too big to open/.test(await read('../ui/assetsStore.js')),
+    'the archive-SIZE refusal is gone entirely — a 1 GB library is the use case, not an edge case');
 }
 
 {

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
@@ -1746,17 +1746,149 @@ function fakeSheets() {
     store.dispose();
   }
 
+  /* --- THE OWNER'S SEQUENCE, END TO END ----------------------------------
+   * Round 3 pinned the PARTS. This walks the exact road the report describes,
+   * in order, through boot's real seam (onItems -> syncLocalDeck -> the pool),
+   * because both round-3 halves passed and the phone still came back empty:
+   *
+   *   standalone init (empty manifest)  ->  assets screen  ->  add files
+   *   ->  BACK (no dispose, no re-dispatch)  ->  start practice
+   *
+   * Every step asserts the deck, so whichever one ever loses the library says so
+   * by name instead of arriving as "practice fires nothing".
+   * ---------------------------------------------------------------------- */
+  {
+    const fill3 = (nb, seed) => {
+      const u = new Uint8Array(nb);
+      for (let i = 0; i < nb; i++) u[i] = (i * 13 + seed) % 253;
+      return u;
+    };
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const pool = createGoonMediaPool();
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null });
+    await sleep(5);
+
+    // boot's seam, verbatim (boot.js syncLocalDeck + the onItems subscription).
+    let syncedLocalVersion = -1;
+    let syncs = 0;
+    const syncLocalDeck = (force) => {
+      const v = Number(store.localVersion) || 0;
+      if (v === syncedLocalVersion && !force) return;
+      syncedLocalVersion = v;
+      syncs++;
+      pool.setLocalLibrary(localPlayableEntries(store.localItems));
+    };
+    store.onItems(() => syncLocalDeck());
+
+    // 1. standalone init: bridge.js synthesizes ONE empty manifest frame.
+    pool.setManifest({ images: [], videos: [], skipped: 0, truncated: false });
+    syncLocalDeck();
+    ok(pool.hasMedia() === false, '1. standalone starts with an empty deck (the synthesized manifest)');
+
+    // 2. the assets screen: the player adds a zip's worth of files.
+    const r2 = await store.addLocalFiles([
+      new File([fill3(4000, 1)], 'a.png', { type: 'image/png' }),
+      new File([fill3(4200, 2)], 'b.jpg', { type: 'image/jpeg' }),
+      new File([fill3(4400, 3)], 'c.gif', { type: 'image/gif' }),
+      new File([fill3(9000, 4)], 'd.mp4', { type: 'video/mp4' }),
+    ]);
+    ok(r2.added === 4, '2. four picks adopted on the assets screen', JSON.stringify(r2));
+    ok(pool.counts().images === 3 && pool.counts().videos === 1,
+      '   and boot\'s onItems seam already folded them into the deck — no extra step, no screen to visit',
+      pool.counts().images + 'i/' + pool.counts().videos + 'v');
+
+    // 3. BACK to the title. Nothing on that road may dispose the store or revoke
+    //    a URL — teardownEverything() deliberately does not touch `assets`.
+    const urlsBefore = store.localDeck().map((e) => e.url).join(',');
+    ok(store.localItems.length === 4 && store.localDeck().length === 4,
+      '3. leaving the assets screen keeps every pick (the store outlives the screen)');
+
+    // 4. a LATE manifest frame — a host re-scan, or the synthesized one arriving
+    //    twice — must not empty the player's half. This is the round-3 contract.
+    pool.setManifest({ images: [], videos: [], skipped: 0, truncated: false });
+    ok(pool.localCount() === 4 && pool.counts().images === 3,
+      '4. a second manifest frame resets the HOST half and leaves the local half alone',
+      pool.localCount() + ' local');
+
+    // 5. practice starts: attachMatch forces a re-feed even though localVersion
+    //    has not moved. It has to be a no-op that still proves the deck.
+    const syncsBefore = syncs;
+    syncLocalDeck();          // the guard swallows this one
+    ok(syncs === syncsBefore, '5. the version guard swallows a redundant sync…');
+    syncLocalDeck(true);      // …and the forced one at attachMatch does not
+    ok(syncs === syncsBefore + 1 && pool.localCount() === 4,
+      '   …while the forced re-feed at match start always re-proves it', String(pool.localCount()));
+    ok(store.localDeck().map((e) => e.url).join(',') === urlsBefore,
+      '   with the SAME object URLs — nothing on this road revoked a blob the deck is holding');
+
+    // 6. what the effects actually ask for. The media-carrying renderers call
+    //    drawKind('image') (flashes, brain drain, bubble pop-flashes) and
+    //    drawKind('video') (the floating windows); both must answer.
+    const img = pool.drawKind('image');
+    const vid = pool.drawKind('video');
+    ok(img && img.url.indexOf('blob:') === 0 && img.kind === 'image',
+      '6. drawKind("image") — what flashes/brainDrain/bubbles ask for — hands back a pick',
+      img ? img.url.slice(0, 12) : 'NULL');
+    ok(vid && vid.url.indexOf('blob:') === 0 && vid.kind === 'video',
+      '   and drawKind("video") — what the floating windows ask for — does too',
+      vid ? vid.url.slice(0, 12) : 'NULL');
+    const h = pool.acquire(img);
+    ok(h && h.url === img.url && h.provenance === 'local',
+      '   and acquire() gives the renderer a usable handle on it');
+
+    // 7. KIND PARITY. Every kind the store can emit has to be a kind an effect
+    //    asks for — a third string here (a 'gif' lane, say) would fill the deck
+    //    with entries nothing ever matches, which looks exactly like an empty one.
+    const kinds = new Set(store.localDeck().map((e) => e.kind));
+    ok(Array.from(kinds).every((k) => k === 'image' || k === 'video'),
+      '7. localPlayableEntries only ever emits image|video — the two kinds drawKind is called with',
+      Array.from(kinds).join(','));
+    const execKinds = new Set();
+    for (const rel of ['../exec/flashes.js', '../exec/videos.js', '../exec/bubbles.js', '../exec/brainDrain.js']) {
+      const src = await read(rel);
+      for (const m of src.matchAll(/draw(?:Kind|For)\(\s*'([a-z]+)'/g)) execKinds.add(m[1]);
+    }
+    ok(execKinds.size === 2 && execKinds.has('image') && execKinds.has('video'),
+      '   and exec/ asks for exactly those two and nothing else', Array.from(execKinds).join(','));
+
+    store.dispose();
+  }
+
   /* --- boot really wires it ---------------------------------------------- */
   {
     const bootSrc = await read('../boot.js');
     ok(/import \{ createAssetsStore, localPlayableEntries \} from '\.\/ui\/assetsStore\.js'/.test(bootSrc),
       'boot.js imports the mapper from the store (one definition of "playable", not two)');
-    ok(/function syncLocalDeck\(\)/.test(bootSrc), 'boot.js has syncLocalDeck()');
+    ok(/function syncLocalDeck\(force\)/.test(bootSrc), 'boot.js has syncLocalDeck(force)');
     ok(/media\.setLocalLibrary\(/.test(bootSrc), 'which feeds exec/media.js the local half of the deck');
     ok(/assets\.onItems\(\(\) => syncLocalDeck\(\)\)/.test(bootSrc),
       'and is re-run on every store change, so a pick made mid-session lands in the deck');
-    ok(/if \(v === syncedLocalVersion\) return;/.test(bootSrc),
-      'guarded on localVersion, so a hosted cache-list never re-deals the pool');
+    ok(/if \(v === syncedLocalVersion && !force\) return;/.test(bootSrc),
+      'guarded on localVersion, so a hosted cache-list never re-deals the pool…');
+    /* ROUND 4 (2026-08-04). The reactive path above shipped, and the owner STILL
+     * reported no assets in practice from a phone with no way to see why. The
+     * version guard is the one thing that can turn a missed `onItems` emit into a
+     * permanently empty deck, so every road into a match forces a re-feed past
+     * it: the guard is an optimisation, never a gate on correctness. */
+    ok(/syncLocalDeck\(true\);/.test(bootSrc),
+      '…and a FORCED re-feed exists, so a missed emit cannot strand the deck empty');
+    ok(/function attachMatch\(match, transport\) \{[\s\S]{0,1600}?syncLocalDeck\(true\);/.test(bootSrc),
+      'attachMatch — the one funnel every match goes through — forces it');
+    ok(/logDeck\('practice'\);/.test(bootSrc), 'and startSolo logs the deck it is about to play with');
+    /* THE LINE THAT ENDS THE BLIND ROUND-TRIPS. `logger.info` reaches console.info
+     * and the C# tunnel; a phone standalone has NEITHER, and ui/debugOverlay.js —
+     * the only console that phone has — is fed by teeDebug from warn/error ONLY.
+     * A deck diagnostic at info is a deck diagnostic nobody can screenshot. */
+    ok(/function logDeck\(why\) \{[\s\S]{0,900}?logger\.warn\(why \+ ' deck: '/.test(bootSrc),
+      'logDeck speaks at WARN, because only warn/error reach the ?debug=1 overlay');
+    ok(/warn: \(m\) => \{[^\n]*teeDebug\('warn', m\)/.test(bootSrc)
+      && !/info: \(m\) => \{[^\n]*teeDebug/.test(bootSrc),
+      'and that is still true of the logger it goes through — info is NOT teed');
+    ok(/' host \+ ' \+ local \+ ' local'/.test(bootSrc) && /' pick\(s\), '/.test(bootSrc),
+      'the line separates host entries, local entries and raw picks — the three a screenshot could not tell apart');
+    ok(/NOTHING playable/.test(bootSrc),
+      'and picks that produced no playable entry get their own warn, the one silent failure left on this path');
     const mediaSrc = await read('../exec/media.js');
     ok(/setLocalLibrary\(list\)/.test(mediaSrc) && /let localEntries = \[\]/.test(mediaSrc),
       'exec/media.js keeps the local half as its own list…');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-assets.js
@@ -1633,6 +1633,138 @@ function fakeSheets() {
   store.dispose();
 }
 
+/* ==========================================================================
+ * THE LOCAL LIBRARY IS A PLAYABLE LIBRARY (the phone bug, 2026-08-04).
+ *
+ * A player loaded a zip on a phone, saw the assets in the manager, backed out,
+ * started a practice session — and every effect fired with no media. The picks
+ * had only ever been wired into the SEND path (boot.js listSendable); the
+ * PLAYBACK deck (exec/media.js `entries`) is fed by the host `manifest` frame,
+ * which bridge.js synthesizes EMPTY standalone. These pin the join: the store
+ * can hand its picks over as deck entries, and boot really asks it to.
+ * ======================================================================== */
+{
+  const { localPlayableEntries } = storeMod;
+  ok(typeof localPlayableEntries === 'function', 'assetsStore exports localPlayableEntries()');
+
+  /* --- the pure mapping -------------------------------------------------- */
+  const mapped = localPlayableEntries([
+    // An EXEMPT original IS the file: its bytes are behind srcUrl.
+    { id: 'local:1', name: 'pic.png', kind: 'image', state: 'exempt', srcUrl: 'blob:x/1', artUrl: '', mime: 'image/png' },
+    // A compressed pick has no srcUrl at all — the artifact is the thing.
+    { id: 'local:2', name: 'holiday.webp', kind: 'image', state: 'ready', srcUrl: '', artUrl: 'blob:x/2', mime: 'image/webp' },
+    { id: 'local:3', name: 'clip.mp4', kind: 'video', state: 'ready', srcUrl: '', artUrl: 'blob:x/3', mime: 'video/mp4' },
+    // Nothing to play: skipped rather than pushed as an entry that can only 404.
+    { id: 'local:4', name: 'urlless.png', kind: 'image', state: 'exempt', srcUrl: '', artUrl: '', mime: 'image/png' },
+    null,
+  ]);
+  ok(mapped.length === 3, 'three of five rows are playable — a URL-less row and a null are dropped',
+    String(mapped.length));
+  ok(mapped[0].url === 'blob:x/1' && mapped[1].url === 'blob:x/2',
+    'an exempt pick plays from srcUrl and a compressed one from artUrl — the same rule listSendable uses',
+    mapped.map((e) => e.url).join(','));
+  ok(mapped[2].kind === 'video' && mapped[1].kind === 'image',
+    'the KIND is taken from the item, never re-derived: a blob: URL has no extension to sniff',
+    mapped.map((e) => e.kind).join(','));
+  ok(mapped.every((e) => typeof e.name === 'string' && typeof e.url === 'string' && e.kind),
+    'and every entry is the {kind,name,url} shape exec/media.js setLocalLibrary takes');
+
+  // A row that somehow lost its kind still classifies by mime rather than
+  // vanishing — the deck would rather have it as an image than not at all.
+  const byMime = localPlayableEntries([
+    { id: 'local:5', name: 'a', kind: '', state: 'exempt', srcUrl: 'blob:x/5', mime: 'video/mp4' },
+    { id: 'local:6', name: 'b', kind: '', state: 'exempt', srcUrl: 'blob:x/6', mime: 'image/gif' },
+    { id: 'local:7', name: 'c', kind: '', state: 'exempt', srcUrl: 'blob:x/7', mime: '' },
+  ]);
+  ok(byMime.length === 2 && byMime[0].kind === 'video' && byMime[1].kind === 'image',
+    'a kindless row falls back to its mime family, and a row with neither is dropped',
+    byMime.map((e) => e.kind).join(','));
+
+  /* --- the store really hands its picks over ----------------------------- */
+  {
+    const fill2 = (nb, seed) => {
+      const u = new Uint8Array(nb);
+      for (let i = 0; i < nb; i++) u[i] = (i * 17 + seed) % 251;
+      return u;
+    };
+    const b = fakeBridge({ hosted: false });
+    const store = createAssetsStore({ bridge: b, logger: null });
+    await sleep(5);
+
+    ok(store.localVersion === 0 && store.localDeck().length === 0,
+      'a fresh standalone store has an empty local deck (this is the state the phone was stuck in)');
+
+    const r = await store.addLocalFiles([
+      new File([fill2(4000, 1)], 'zip-pic-a.png', { type: 'image/png' }),
+      new File([fill2(5000, 2)], 'zip-pic-b.jpg', { type: 'image/jpeg' }),
+      new File([fill2(6000, 3)], 'zip-clip.mp4', { type: 'video/mp4' }),
+    ]);
+    ok(r.added === 3, 'three picks adopted', JSON.stringify(r));
+    const v1 = store.localVersion;
+    ok(v1 === 3, 'localVersion counted every one of them', String(v1));
+
+    const deck = store.localDeck();
+    ok(deck.length === 3, 'and localDeck() hands all three to the media pool', String(deck.length));
+    ok(deck.filter((e) => e.kind === 'video').length === 1 && deck.filter((e) => e.kind === 'image').length === 2,
+      'with the kinds the adoption road decided, not the URL', deck.map((e) => e.kind).join(','));
+    ok(deck.every((e) => e.url.indexOf('blob:') === 0), 'behind the store\'s own object URLs',
+      deck.map((e) => e.url.slice(0, 12)).join(','));
+    ok(store.localItems.length === 3 && store.localItems !== store.localItems,
+      'store.localItems is a snapshot array, not the live map');
+
+    // THE OTHER HALF OF THE JOIN: the real pool takes them and draws them.
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const pool = createGoonMediaPool();
+    pool.setManifest({ images: [], videos: [], skipped: 0, truncated: false });   // what bridge.js synthesizes
+    ok(pool.hasMedia() === false, 'the standalone pool starts empty, exactly as the player found it');
+    const counts = pool.setLocalLibrary(store.localDeck());
+    ok(counts.images === 2 && counts.videos === 1,
+      'and setLocalLibrary(store.localDeck()) fills it — a solo session now has something to draw',
+      counts.images + 'i/' + counts.videos + 'v');
+    const drawn = pool.drawKind('image');
+    ok(drawn && drawn.url.indexOf('blob:') === 0, 'the deck really hands back one of the picked files',
+      drawn ? drawn.url.slice(0, 12) : 'null');
+
+    // Removing a pick moves the version, so boot re-feeds the deck.
+    const gone = store.localItems.find((it) => it.name === 'zip-clip.mp4');
+    ok(store.removeLocal(gone.id) === true && store.localVersion === v1 + 1,
+      'removeLocal bumps localVersion too — the deck must lose it as well');
+    ok(pool.setLocalLibrary(store.localDeck()).videos === 0, 'and re-feeding drops the clip from the pool');
+    store.dispose();
+  }
+
+  /* --- a HOSTED cache-list must NOT move the local version --------------- */
+  {
+    const b = fakeBridge();
+    const store = createAssetsStore({ bridge: b, session: { caps: {} }, logger: null, autoHello: false });
+    const before = store.localVersion;
+    b.fire({ type: 'cache-list', seq: 0, last: true, items: [mkItem(1, { state: 'ready' }), mkItem(2, { state: 'ready' })] });
+    ok(store.items.length === 2, 'the hosted list landed');
+    ok(store.localVersion === before && store.localDeck().length === 0,
+      'but localVersion did not move and the local deck stays empty — the host manifest owns the hosted deck, '
+      + 'and boot\'s version guard is what keeps a cache-list from re-dealing the pool');
+    store.dispose();
+  }
+
+  /* --- boot really wires it ---------------------------------------------- */
+  {
+    const bootSrc = await read('../boot.js');
+    ok(/import \{ createAssetsStore, localPlayableEntries \} from '\.\/ui\/assetsStore\.js'/.test(bootSrc),
+      'boot.js imports the mapper from the store (one definition of "playable", not two)');
+    ok(/function syncLocalDeck\(\)/.test(bootSrc), 'boot.js has syncLocalDeck()');
+    ok(/media\.setLocalLibrary\(/.test(bootSrc), 'which feeds exec/media.js the local half of the deck');
+    ok(/assets\.onItems\(\(\) => syncLocalDeck\(\)\)/.test(bootSrc),
+      'and is re-run on every store change, so a pick made mid-session lands in the deck');
+    ok(/if \(v === syncedLocalVersion\) return;/.test(bootSrc),
+      'guarded on localVersion, so a hosted cache-list never re-deals the pool');
+    const mediaSrc = await read('../exec/media.js');
+    ok(/setLocalLibrary\(list\)/.test(mediaSrc) && /let localEntries = \[\]/.test(mediaSrc),
+      'exec/media.js keeps the local half as its own list…');
+    ok(/`localEntries` is not touched/.test(mediaSrc),
+      '…and says out loud that setManifest must not wipe it');
+  }
+}
+
 await sleep(60);
 console.log(`\nselftest-assets: ${n - failures}/${n} checks passed`);
 if (failures > 0) {

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -3480,6 +3480,115 @@ async function main() {
       'the tag still resolves after a preset change, even though there is no local video at all');
   }
 
+  /* -------------------------------------------------------------------------
+   * THE LOCAL LIBRARY — standalone playback (the phone bug, 2026-08-04).
+   *
+   * In a browser there is no host: bridge.js synthesizes an EMPTY manifest, and
+   * the files the player picks on the assets screen used to reach the SEND path
+   * only. So the deck stayed empty and a practice session fired every effect
+   * against nothing. setLocalLibrary is the other half of the deck, and these
+   * checks pin BOTH directions of the independence that makes it safe.
+   * ---------------------------------------------------------------------- */
+  {
+    const { createGoonMediaPool } = await import('../exec/media.js');
+
+    // 1. The bug, reproduced: standalone boots on an empty manifest.
+    const pool = createGoonMediaPool();
+    pool.setManifest({ images: [], videos: [], skipped: 0, truncated: false });
+    ok(pool.hasMedia() === false && pool.drawKind('image') === null,
+      'standalone starts on the empty synthesized manifest — an empty deck (this WAS the bug)');
+
+    // 2. The picks land, kind-first. Blob URLs carry NO extension, so the kind
+    //    the store decided is the only thing that can classify them.
+    const locals = [
+      { kind: 'image', name: 'pic-0.jpg', url: 'blob:http://localhost/aaa' },
+      { kind: 'image', name: 'pic-1.png', url: 'blob:http://localhost/bbb' },
+      { kind: 'image', name: 'pic-2.gif', url: 'blob:http://localhost/ccc' },
+      { kind: 'video', name: 'clip-0.mp4', url: 'blob:http://localhost/ddd' },
+      { kind: 'video', name: 'clip-1.mp4', url: 'blob:http://localhost/eee' },
+    ];
+    const c = pool.setLocalLibrary(locals);
+    ok(c.images === 3 && c.videos === 2, 'setLocalLibrary puts the picks in the deck',
+      c.images + 'i/' + c.videos + 'v');
+    ok(pool.hasMedia() === true && pool.localCount() === 5,
+      'the pool has media now — a solo session draws from the player\'s own picks');
+
+    const img = pool.drawKind('image');
+    const vid = pool.drawKind('video');
+    const vidUrls = new Set(['blob:http://localhost/ddd', 'blob:http://localhost/eee']);
+    ok(img && img.url.startsWith('blob:') && img.kind === 'image' && img.provenance === 'local',
+      'drawKind("image") hands back one of the picked stills, as local provenance',
+      img ? img.url : 'null');
+    ok(vid && vidUrls.has(vid.url), 'and drawKind("video") one of the picked clips', vid ? vid.url : 'null');
+    ok(pool.acquire(img).url === img.url, 'acquire hands the blob URL straight through…');
+    ok(typeof pool.acquire(img).release === 'function',
+      '…with a no-op release: the assets store owns those object URLs, not the pool');
+
+    // 3. Kinds never cross. A video pick must never render as a flash.
+    let crossed = 0;
+    for (let i = 0; i < 120; i++) {
+      const d = pool.drawKind('image');
+      if (!d || vidUrls.has(d.url)) crossed++;
+    }
+    ok(crossed === 0, 'one hundred and twenty image draws never surfaced a video pick', String(crossed));
+
+    // 4. Junk is skipped, never pushed as an entry that can only fail to load.
+    const c2 = pool.setLocalLibrary(locals.concat([
+      null,
+      { kind: 'image', name: 'no-url' },
+      { kind: 'audio', name: 'wrong-kind.mp3', url: 'blob:http://localhost/fff' },
+    ]));
+    ok(c2.images === 3 && c2.videos === 2, 'a null, a URL-less row and an unknown kind are all dropped',
+      c2.images + 'i/' + c2.videos + 'v');
+
+    // 5. Removing every pick empties the local half — and only that half.
+    ok(pool.setLocalLibrary([]).images === 0 && pool.localCount() === 0,
+      'clearing the library clears the deck when there is no host manifest behind it');
+  }
+
+  // ------------------- the two halves of the deck are INDEPENDENT (hosted safety)
+  {
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const pool = createGoonMediaPool();
+    const hosted = pool.setManifest(ownManifest());
+    ok(hosted.images === 6 && hosted.videos === 4, 'the hosted manifest flow is untouched',
+      hosted.images + 'i/' + hosted.videos + 'v');
+
+    // Hosted, nobody ever picks a file — an empty local half changes nothing.
+    const still = pool.setLocalLibrary([]);
+    ok(still.images === 6 && still.videos === 4,
+      'an empty local library leaves the host\'s preset exactly as it was',
+      still.images + 'i/' + still.videos + 'v');
+    let offPreset = 0;
+    for (let i = 0; i < 60; i++) {
+      const d = pool.draw();
+      if (!d || !d.url.startsWith('https://ccp.assets/')) offPreset++;
+    }
+    ok(offPreset === 0, 'and sixty draws all come off the host manifest', String(offPreset));
+
+    // Defensive: if both ever coexist, they ADD — neither setter clobbers the other.
+    const both = pool.setLocalLibrary([{ kind: 'image', name: 'p.jpg', url: 'blob:x/1' }]);
+    ok(both.images === 7 && both.videos === 4, 'a pick alongside a host manifest adds to the deck',
+      both.images + 'i/' + both.videos + 'v');
+    const relisted = pool.setManifest({ images: [{ name: 'only', url: 'https://ccp.assets/only' }], videos: [] });
+    ok(relisted.images === 2 && relisted.videos === 0,
+      'a NEW manifest re-deals the host half and KEEPS the player\'s picks (2 = 1 host + 1 local)',
+      relisted.images + 'i/' + relisted.videos + 'v');
+    ok(pool.localCount() === 1, 'the local half really survived the manifest reset', String(pool.localCount()));
+
+    // …and the received map is none of setLocalLibrary's business either.
+    pool.addReceived({ sha: SHA_VID, kind: 'video', mime: 'video/mp4', url: 'https://ccp.cache/recv/b.mp4' });
+    pool.setLocalLibrary([{ kind: 'image', name: 'q.jpg', url: 'blob:x/2' }]);
+    ok(pool.hasReceived(SHA_VID) === true,
+      'setLocalLibrary re-deals the DECK and leaves the received map alone, exactly like setManifest');
+    let peerFromDeck = 0;
+    for (let i = 0; i < 120; i++) {
+      const d = pool.draw();
+      if (d && d.provenance !== 'local') peerFromDeck++;
+    }
+    ok(peerFromDeck === 0, 'and a local pick still cannot make the deck surface a peer artifact', String(peerFromDeck));
+  }
+
   // ------------------------------------ videos: the payload path, and only it
   {
     for (const id of LAYER_IDS) byId.get(id).replaceChildren();

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -3546,6 +3546,65 @@ async function main() {
       'clearing the library clears the deck when there is no host manifest behind it');
   }
 
+  /* -------------------------------------------------------------------------
+   * …AND THE RENDERERS ACTUALLY PUT IT ON SCREEN (round 4, 2026-08-04).
+   *
+   * The block above proves the DECK. The owner's SECOND report — same phone,
+   * same practice session, still "not triggering any asset" — is about the next
+   * seam along: the element ramp starts Flashes at t=0 and the renderer draws off
+   * that deck, so "the pool holds 3 images" and "the player sees an image" are
+   * two different claims and only the first was ever pinned. This drives the real
+   * renderer over the real pool and reads the URLs back off the layer.
+   * ---------------------------------------------------------------------- */
+  {
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const pool = createGoonMediaPool();
+    pool.setManifest({ images: [], videos: [], skipped: 0, truncated: false });   // standalone
+    const picks = [
+      { kind: 'image', name: 'a.png', url: 'blob:phone/a' },
+      { kind: 'image', name: 'b.jpg', url: 'blob:phone/b' },
+      { kind: 'video', name: 'c.mp4', url: 'blob:phone/c' },
+    ];
+
+    const ex = createExecutor({ media: pool, layers, logger: quiet });
+    const m = fakeMatch();
+    ex.attach(m);
+
+    // The ramp's FIRST cue, fired against an EMPTY deck: nothing to draw, and
+    // that is the state the phone was stuck in. It must not throw and must not
+    // LATCH — the bed keeps beating, so the next beat picks the library up.
+    m.emitStart({ element: GoonElement.Flashes, intensity: 0.9, durationMs: 60000, elapsedMs: 0 });
+    await sleep(150);
+    const flashHost = byId.get('gg-fx-flash');
+    ok(flashHost.findAll('gg-flash').length === 0,
+      'an empty deck renders nothing and throws nothing — the effect ran, the screen stayed blank (the report)');
+
+    // The player's picks arrive mid-run: they came back from the assets screen.
+    pool.setLocalLibrary(picks);
+    await sleep(2600);
+    const shown = flashHost.findAll('gg-flash').map((el) => el.src);
+    ok(shown.length > 0, 'once the library lands the SAME running bed starts drawing — no restart needed',
+      String(shown.length));
+    ok(shown.length > 0 && shown.every((u) => u === 'blob:phone/a' || u === 'blob:phone/b'),
+      'and every flash on the layer is one of the player\'s own picks', shown.slice(0, 4).join(','));
+    ok(shown.indexOf('blob:phone/c') < 0,
+      'never the clip: a video pick can never be rendered as a flash');
+    m.emitStop({ element: GoonElement.Flashes });
+
+    // The floating windows are the OTHER media-carrying renderer, asking for the
+    // other kind. spawnLocal is the popped-bubble path, i.e. the one a practice
+    // player reaches with no arsenal slot unlocked at all.
+    const vids = ex.rendererFor(GoonElement.Videos);
+    ok(vids.spawnLocal({ duration_ms: 4000, intensity: 0.5 }) === true,
+      'and the video renderer spawns a local window off the same library');
+    ok(byId.get('gg-fx-vwin').findAll('gg-vwin').length === 1, 'one window on the layer');
+
+    ex.stopAll();
+    ex.detach();
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+  }
+
   // ------------------- the two halves of the deck are INDEPENDENT (hosted safety)
   {
     const { createGoonMediaPool } = await import('../exec/media.js');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -863,5 +863,120 @@ function mountRecap(result) {
     'discord-open-dm carries WHICH and nothing else');
 }
 
+/* ============================================================================
+ * 7. THE DEBUG OVERLAY (ui/debugOverlay.js) — the console a phone does not have.
+ *
+ * Added for the 2026-08-04 phone report: a guest was evicted from the lobby back
+ * to the title and there was nowhere ON THE DEVICE for the reason to be written.
+ * Hosted, warn/error tunnel to the C# log; standalone they went to a console
+ * nobody can open.
+ *
+ * What must hold, or it is worse than not having it:
+ *   · it never renders unless asked (and hosted, never implicitly);
+ *   · push() cannot throw — it sits inside logger.warn/error;
+ *   · the ring is bounded, so a warning storm cannot eat the page;
+ *   · it is ONE node on <body> with pointer-events on itself: no gameplay.
+ * ==========================================================================*/
+{
+  const overlay = await import('../ui/debugOverlay.js');
+  const { debugRequested, debugInSearch, createDebugOverlay, captureGlobalErrors, MAX_LINES } = overlay;
+
+  // ---- the gate
+  ok(debugInSearch('?debug=1') && debugInSearch('?a=b&debug=true') && debugInSearch('?debug'),
+    '?debug=1 / =true / bare all count');
+  ok(!debugInSearch('?debug=0') && !debugInSearch('?solo=0') && !debugInSearch(''),
+    '?debug=0 and an unrelated query do not');
+  ok(debugRequested({ search: '?debug=1', hosted: true }) === true,
+    'hosted CAN be asked explicitly on the querystring');
+  ok(debugRequested({ search: '', prefs: { debug: true }, hosted: true }) === false,
+    'but a hosted session never inherits a stored flag — a WebView2 duel keeps its chrome');
+  ok(debugRequested({ search: '', prefs: { debug: true }, hosted: false }) === true,
+    'standalone remembers it, so a reload (or a home-screen pin) keeps the strip');
+  ok(debugRequested({ search: '', prefs: { debug: false }, hosted: false }) === false,
+    'and ?debug=0 writes the flag back off');
+  ok(debugRequested({}) === false, 'nothing asked for it -> nothing');
+
+  // ---- the strip itself, over the stub DOM
+  const panel = createDebugOverlay({ doc: dom.doc, max: 4, now: () => 0 });
+  ok(!!panel.node && panel.node.id === 'gg-debug', 'it mounts exactly one node');
+  ok(dom.doc.body.childNodes.indexOf(panel.node) >= 0, 'appended to <body>, not into a screen');
+  const css = String(panel.node.getAttribute('style') || '');
+  ok(/position:fixed/.test(css) && /z-index:2147483000/.test(css),
+    'fixed and above every layer the page owns (#gg-modal is z70)', css.slice(0, 60));
+  ok(/pointer-events:auto/.test(css), 'it takes taps on itself only — nothing else is touched');
+
+  panel.push('warn', 'one');
+  panel.push('error', new Error('two'));
+  ok(panel.lines().length === 2, 'lines land', String(panel.lines().length));
+  ok(/warn one/.test(panel.lines()[0]), 'with the level in the line', panel.lines()[0]);
+  ok(/error two/.test(panel.lines()[1]), 'an Error is flattened to its message', panel.lines()[1]);
+  for (let i = 0; i < 20; i++) panel.push('warn', 'flood ' + i);
+  ok(panel.lines().length === 4, 'the ring is bounded — a storm cannot eat the page', String(panel.lines().length));
+  ok(/flood 19/.test(panel.lines()[3]), 'and it keeps the NEWEST lines', panel.lines()[3]);
+
+  // push() is inside logger.warn: it may never be the thing that throws.
+  let threw = false;
+  try {
+    const circular = {}; circular.self = circular;
+    panel.push('warn', circular);
+    panel.push(null, undefined);
+  } catch (_e) { threw = true; }
+  ok(!threw, 'push() survives a circular object and a null level');
+
+  // tap-to-collapse: one gesture, the whole strip is the target
+  ok(panel.collapsed() === false, 'it starts open — an empty badge explains nothing');
+  panel.node.dispatchEvent({ type: 'click' });
+  ok(panel.collapsed() === true, 'tapping anywhere on it collapses it');
+  panel.node.dispatchEvent({ type: 'click' });
+  ok(panel.collapsed() === false, 'and back');
+
+  // the two seams a logger never sees
+  const fakeWin = (() => {
+    const map = new Map();
+    return {
+      addEventListener(t, f) { if (!map.has(t)) map.set(t, new Set()); map.get(t).add(f); },
+      removeEventListener(t, f) { const s = map.get(t); if (s) s.delete(f); },
+      fire(t, e) { for (const f of Array.from(map.get(t) || [])) f(e); },
+      count(t) { return (map.get(t) || new Set()).size; },
+    };
+  })();
+  const off = captureGlobalErrors(panel, fakeWin);
+  fakeWin.fire('error', { message: 'boom', filename: 'https://x/goon/ui/lobby.js', lineno: 12 });
+  fakeWin.fire('unhandledrejection', { reason: new Error('nope') });
+  ok(/boom @ lobby\.js:12/.test(panel.lines().join('\n')), 'window.onerror is captured with a location',
+    panel.lines().join(' | '));
+  ok(/promise: nope/.test(panel.lines().join('\n')), 'so is an unhandled rejection');
+  off();
+  ok(fakeWin.count('error') === 0 && fakeWin.count('unhandledrejection') === 0, 'and it unsubscribes cleanly');
+
+  panel.dispose();
+  ok(dom.doc.body.childNodes.indexOf(panel.node) < 0, 'dispose removes the node');
+  panel.push('warn', 'after dispose');
+  ok(panel.lines().length === 4, 'and a disposed strip stops collecting', String(panel.lines().length));
+
+  // no usable DOM (the node import sweep) -> a handle whose every method is a no-op
+  const headless = createDebugOverlay({ doc: {} });
+  ok(headless.node === null && headless.lines().length === 0, 'no document -> an inert handle, never a throw');
+  headless.push('warn', 'x'); headless.toggle(); headless.dispose();
+
+  ok(MAX_LINES === 50, 'the default ring is the last 50 lines', String(MAX_LINES));
+
+  // ---- and that boot.js actually wires it, behind the flag and nowhere else
+  const boot = read('boot.js');
+  ok(/teeDebug\('warn', m\)/.test(boot) && /teeDebug\('error', m\)/.test(boot),
+    'boot tees warn AND error into the strip (info/debug stay out — the engine is chatty)');
+  ok(!/teeDebug\('info'/.test(boot), 'and info is NOT teed');
+  ok(/function wantsDebugHint\(\)/.test(boot), 'the module is not even imported unless something asked for it');
+  ok(/if \(bridge\.isHosted\) return false;/.test(boot),
+    'hosted never picks the flag up from stored prefs');
+  ok(/import\('\.\/ui\/debugOverlay\.js'\)/.test(boot),
+    'it is loaded dynamically, like the sibling waves — a missing file is not a white page');
+  ok(boot.indexOf('initDebugOverlay();') < boot.indexOf("window.addEventListener('keydown'"),
+    'and it is armed FIRST, so it is listening before the boot it explains can fail');
+  const bridgeSrc = read('bridge.js');
+  ok(/keep\.debug = /.test(bridgeSrc), 'bridge persists the flag next to server/token/uid/name');
+  ok(/export function storedPrefs\(\)/.test(bridgeSrc), 'and exposes the stored blob for the pre-init decision');
+}
+
 console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
 process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -978,5 +978,118 @@ function mountRecap(result) {
   ok(/export function storedPrefs\(\)/.test(bridgeSrc), 'and exposes the stored blob for the pre-init decision');
 }
 
+/* ============================================================================
+ * 8. PRACTICE SHOWS YOU YOUR OWN LIBRARY (the phone bug, round 4, 2026-08-04).
+ *
+ * Owner report, twice: "from mobile it's not triggering any asset even if I
+ * uploaded them and went to practice", with every arsenal chip reading `locked`.
+ *
+ * THE SHAPE OF IT. In a duel your arsenal shot lands on THEIR screen. In practice
+ * the opponent is ui/soloDriver.js, which has no exec/ renderer at all — so a
+ * payload the practice player fires is a payload nobody ever sees, and the only
+ * media that reaches their own screen is the element ramp plus whatever the bot
+ * throws BACK. An inbound payload resolves against the RECEIVER's library
+ * (exec/media.js drawFor -> drawKind), so the bot's flash burst is drawn from the
+ * player's own uploads — that is the loop, and it used to wait on the bot's
+ * economy (PAYLOAD_TRY_MS, a 35% skip, and charges it has not earned yet).
+ *
+ * Two fixes, both practice-only:
+ *   · the bot opens with a scheduled salvo of the two MEDIA-CARRYING kinds;
+ *   · boot seeds the practice arsenal, so the slots that draw from the library
+ *     are not locked behind a bubble-drop grind.
+ *
+ * THE REGRESSION THIS BLOCK EXISTS FOR: the receiver validates the SENDER's
+ * charges off the last state TICK, not off the payload frame, so crediting and
+ * firing in the same turn is rejected with "claimed 0 < cost 1". The first cut
+ * did exactly that and the salvo never landed.
+ * ==========================================================================*/
+{
+  const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+  const { createSoloDriver, SALVO, SALVO_CREDIT_LEAD_MS } = await import('../ui/soloDriver.js');
+  const { GoonConsts, GoonPayloadKind, costOf } = await import('../core/contracts.js');
+
+  // ---- the shape of the salvo
+  ok(Array.isArray(SALVO) && SALVO.length >= 2, 'the practice bot has an opening salvo', String(SALVO.length));
+  const salvoKinds = SALVO.map((s) => s.kind);
+  ok(salvoKinds.includes(GoonPayloadKind.FlashBurst) && salvoKinds.includes(GoonPayloadKind.Video),
+    'and it is the two MEDIA-CARRYING kinds — the ones that draw off the deck', JSON.stringify(salvoKinds));
+  ok(SALVO[0].atMs <= 10000, 'the first shot lands in the first ten seconds, not after a grind',
+    String(SALVO[0].atMs));
+  ok(SALVO_CREDIT_LEAD_MS > GoonConsts.TickIntervalMs,
+    'the charges are credited more than one state tick ahead of the shot — the receiver reads the '
+    + 'wallet off the tick, so credit-and-fire in one turn is rejected',
+    SALVO_CREDIT_LEAD_MS + 'ms vs ' + GoonConsts.TickIntervalMs + 'ms');
+  ok(SALVO.every((s) => s.atMs - SALVO_CREDIT_LEAD_MS >= 0),
+    'every shot has room for its own credit lead');
+  const soloSrc = stripComments(read('ui/soloDriver.js'));
+  ok(/if \(salvoArmed > 0\) return;/.test(soloSrc),
+    'and the ordinary cadence cannot spend a salvo shot\'s charges out from under it');
+  ok(/match\.creditCharges\(cost - have, 'practice-salvo'\)/.test(soloSrc),
+    'the charges go through the engine, so the wire truth stays the truth (no back door)');
+  ok(/match\.tryFirePayload\(\{/.test(soloSrc),
+    'and the shot goes through the same public API a human uses — every engine gate still applies');
+
+  // ---- the real thing: two engines, a real loopback, the real driver
+  const pair = createLoopbackPair(loopbackOptions({
+    latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, logger: quiet,
+  }));
+  const me = new GoonMatchService(pair.host, true, { logger: quiet, displayName: 'Me', tag: 'GG:me' });
+  const bot = new GoonMatchService(pair.guest, false, { logger: quiet, displayName: 'Practice', tag: 'GG:bot' });
+  const driver = createSoloDriver({ match: bot, logger: quiet });
+
+  const inbound = [];
+  me.onPayloadAccepted((e) => inbound.push(e.payload));
+
+  me.adoptLobby();
+  bot.adoptLobby();
+  driver.start();
+  await pair.connect();
+  await wait(80);
+  me.proposeConsent(60, 0, 30000);
+  await wait(60);
+  me.confirmConsent();
+  await wait(400);
+  for (let i = 0; i < 40 && me.phase === GoonMatchPhase.Draft; i++) { me.confirmDraft(); await wait(120); }
+  ok(me.phase === GoonMatchPhase.Countdown || me.phase === GoonMatchPhase.Live,
+    'practice reaches the countdown with the bot signed', String(me.phase));
+
+  // Countdown + the first salvo's own clock, plus slack for the schedule buffer.
+  const deadline = Date.now() + SALVO[0].atMs + 12000;
+  while (Date.now() < deadline && inbound.length === 0) await wait(200);
+
+  ok(inbound.length > 0,
+    'THE FIX: the practice player receives the bot\'s opening payload — the thing that puts their own '
+    + 'library on their own screen', String(inbound.length));
+  ok(inbound.length > 0 && inbound[0].kind === SALVO[0].kind,
+    'and it is the flash burst, i.e. the images', inbound.length ? String(inbound[0].kind) : 'none');
+  ok(inbound.length > 0 && costOf(inbound[0].kind) > 0,
+    'a real, costed payload — not a special case the renderer has to know about');
+
+  driver.stop();
+  me.dispose();
+  bot.dispose();
+  pair.dispose();
+
+  // ---- boot seeds the practice arsenal, and ONLY the practice arsenal
+  const bootSeed = stripComments(read('boot.js'));
+  ok(/function seedPracticeArsenal\(match\)/.test(bootSeed), 'boot.js has seedPracticeArsenal()');
+  ok(/const PRACTICE_SEED = Object\.freeze\(\[[\s\S]{0,300}?id: 'flash'[\s\S]{0,200}?id: 'video'/.test(bootSeed),
+    'and it seeds the two slots that draw from the library (flash + video)');
+  ok(/arsenal\.armDrop\(seed\.id, \{ count: 1, silent: true \}\)/.test(bootSeed)
+    && /match\.creditCharges\(charges, 'practice-seed'\)/.test(bootSeed),
+    'through the same two public seams ui/drops.js uses — armDrop, and the charges that back it');
+  const seedCalls = (bootSeed.match(/seedPracticeArsenal\(/g) || []).length;
+  ok(seedCalls === 2, 'seedPracticeArsenal is defined once and called once', String(seedCalls));
+  ok(/async function startSolo\(\)[\s\S]*?seedPracticeArsenal\(local\)/.test(bootSeed)
+    || /seedPracticeArsenal\(local\)[\s\S]*?async function startSolo\(\)/.test(bootSeed),
+    'and that one call is wired from startSolo — practice only, duel gating untouched');
+  const arsenalSrc = stripComments(read('ui/arsenal.js'));
+  const armDropAt = arsenalSrc.indexOf('function armDrop');
+  ok(/function armDrop\(id, \{ count = DROP_STACK/.test(arsenalSrc),
+    'ui/arsenal.js still owns armDrop — nothing reached past it to poke a tile');
+  ok(armDropAt > 0 && !/practice|solo/i.test(arsenalSrc.slice(armDropAt, armDropAt + 600)),
+    'and armDrop knows nothing about practice: the mode lives in boot, the slot logic does not');
+}
+
 console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
 process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -2896,6 +2896,171 @@ const audioMod = await import('../ui/audio.js');
     'but its four stops keep their 48px touch target — the plate shrank, the targets did not');
 }
 
+/* ===========================================================================
+ * 16. THE PHONE PASS (owner, 2026-08-04, with two screenshots).
+ *
+ * "this mess is waaaaay too cluttered, we need space to see the animations and
+ * effects." Two separate faults, and this section pins the fix for each so a
+ * later tidy cannot quietly reintroduce either:
+ *
+ *   A. THE RIGHT EDGE. `.gg-hud-frame` is a grid with ONE implicit column, and
+ *      an `auto` track takes the largest min-content contribution among its
+ *      items as its base size — it may exceed the container. `.gg-hud-top` is
+ *      `1fr auto 1fr` (each `1fr` is `minmax(auto, 1fr)`, i.e. floored at
+ *      min-content) plus a `min-width` on the timer, so on a 428pt phone the
+ *      row's floor came to ~442px against a 408px content box. The whole
+ *      column took that width, so EVERY row did, and the monitor, the "they
+ *      claim" panel, the receipt strip and the closeness dial were all laid out
+ *      ~34px past the right edge of the screen. `minmax(0, 1fr)` is the fix.
+ *
+ *   B. THE BOTTOM THIRD. Two tall arsenal rows, the dial UNDER them in the
+ *      flow (so it landed on top of them), the effect chips in a third corner,
+ *      and a MERCY button the portrait rule had quietly inflated back to 20rem.
+ *
+ * Everything below is asserted off the stylesheet: these are layout facts with
+ * no JS to observe them, and a HUD whose CSS says nothing is an invisible bug.
+ * ======================================================================== */
+{
+  const fs16 = await import('node:fs/promises');
+  const url16 = await import('node:url');
+  // Comments come out FIRST and stay out: this tier's comments carry both
+  // braces and commas (they quote selectors at each other), and either one
+  // derails a brace-counting or a selector-list parse.
+  const css16 = (await fs16.readFile(url16.fileURLToPath(new URL('../ui/hud.css', import.meta.url)), 'utf8'))
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+
+  /** Pull one balanced `@media …{ … }` body out of the sheet by a marker inside it. */
+  function mediaBlock(src, marker) {
+    let at = 0;
+    for (;;) {
+      const open = src.indexOf('@media', at);
+      if (open < 0) return '';
+      const brace = src.indexOf('{', open);
+      if (brace < 0) return '';
+      let depth = 0;
+      let i = brace;
+      for (; i < src.length; i++) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}') { depth--; if (depth === 0) break; }
+      }
+      const body = src.slice(brace + 1, i);
+      if (body.includes(marker)) return body;
+      at = i + 1;
+    }
+  }
+  /** The declarations of every rule whose selector list contains EXACTLY `sel`.
+   *  Exact, not substring: `.gg-hud-frame` must not pick up the
+   *  `#gg-hud > .gg-hud-frame` pointer-events opt-out that sits above it. */
+  function ruleFor(src, sel) {
+    const out = [];
+    const re = /([^{}]+)\{([^{}]*)\}/g;
+    let m;
+    while ((m = re.exec(src))) {
+      const list = m[1].split(',').map((s) => s.replace(/\/\*[\s\S]*?\*\//g, '').trim());
+      if (list.includes(sel)) out.push(m[2]);
+    }
+    return out.join(';');
+  }
+  const num = (s, re, dflt) => { const m = String(s).match(re); return m ? Number(m[1]) : dflt; };
+
+  const phone = mediaBlock(css16, '--gg-mon-w');
+  ok(phone.length > 0, 'hud.css still carries the portrait/narrow block');
+
+  /* ---- A. the right edge ------------------------------------------------ */
+  const frame16 = ruleFor(css16, '.gg-hud-frame');
+  ok(/grid-template-columns:\s*minmax\(\s*0\s*,\s*1fr\s*\)/.test(frame16),
+    'the frame pins its one column to minmax(0, 1fr) — an auto track floors at min-content and takes every row off the right edge with it',
+    frame16);
+  ok(/min-width:\s*0/.test(ruleFor(css16, '.gg-hud-bottom')) || /\.gg-hud-top[^{}]*,[\s\S]{0,120}\.gg-hud-bottom\s*\{[^}]*min-width:\s*0/.test(css16),
+    'and the three rows may be narrower than their own contents want to be');
+  for (const side of ['left', 'right', 'bottom']) {
+    ok(new RegExp('padding-' + side + ':[^;]*env\\(safe-area-inset-' + side).test(frame16),
+      `the frame respects safe-area-inset-${side}`);
+  }
+  // the monitor column: capped, never a hard width that can outgrow its host
+  ok(/max-width:\s*var\(--gg-mon-w\)/.test(ruleFor(css16, '.gg-mon')),
+    'the monitor is capped by --gg-mon-w rather than hard-sized to it');
+  ok(/\.gg-mon-name\s*\{[^}]*min-width:\s*0/.test(css16),
+    'and their name may ellipsise instead of shoving the score and pips off the end');
+  const monW = num(phone, /--gg-mon-w:\s*min\([^,]+,\s*(\d+)px\)/, 999);
+  ok(monW <= 200, 'on a phone the monitor is at most 200px wide — it was half off-screen at 220', String(monW));
+
+  /* ---- B. the bottom third ---------------------------------------------- */
+  const item16 = num(phone, /--gg-item:\s*(\d+)px/, 0);
+  ok(item16 >= 48, 'an arsenal tile keeps a 48px finger even after the compression pass', String(item16));
+  ok(/\.gg-item-state\s*\{[^}]*min-height:\s*0/.test(phone),
+    'the state line stops reserving a row when it has nothing to say');
+  const lockedState = ruleFor(phone, '.gg-item.is-locked .gg-item-state');
+  ok(/clip-path:\s*inset\(50%\)/.test(lockedState) && !/display:\s*none/.test(lockedState),
+    'and "locked" leaves the LAYOUT, not the DOM — colour never travels alone in this tier',
+    lockedState);
+
+  const railRight = ruleFor(phone, '.gg-rail--right');
+  const railLeft = ruleFor(phone, '.gg-rail--left');
+  const deck16 = ruleFor(phone, '.gg-hud-bottom');
+  const bRight = num(railRight, /bottom:\s*([\d.]+)rem/, 0);
+  const bLeft = num(railLeft, /bottom:\s*([\d.]+)rem/, 0);
+  const deckPad = num(deck16, /padding-bottom:\s*([\d.]+)rem/, 0);
+  ok(bRight >= deckPad, 'the lower arsenal band starts at or above the deck floor', `${bRight} vs ${deckPad}`);
+  ok(bLeft >= bRight + 3.5, 'and the upper band clears the lower one by a whole tile', `${bLeft} vs ${bRight}`);
+  ok(/right:\s*auto/.test(railRight) && /max-width:\s*calc\(100% - [\d.]+rem\)/.test(railRight),
+    'the lower band comes in from the LEFT and is capped, so it shares its row with the dial instead of being buried under it',
+    railRight);
+  const dialW = num(ruleFor(phone, '.gg-dial'), /width:\s*min\([^,]+,\s*([\d.]+)rem\)/, 99);
+  const railCap = num(railRight, /max-width:\s*calc\(100% - ([\d.]+)rem\)/, 0);
+  ok(railCap >= dialW + 1, 'and the cap leaves the dial its own width plus daylight', `${railCap} vs ${dialW}`);
+  ok(/flex-direction:\s*row/.test(deck16),
+    'the deck is one row on a phone — the dial stacked under the chips is what pushed it onto the rails');
+
+  // the live-effect chips move out of the bottom-left corner entirely…
+  const fxrail16 = ruleFor(phone, '.gg-fxrail');
+  ok(/position:\s*absolute/.test(fxrail16) && /top:\s*[\d.]+rem/.test(fxrail16),
+    'the effect chips leave the mercy strip for the top-left, under the score column', fxrail16);
+  // …but stay INSIDE the deck in the DOM, which is how .is-sd and zen still reach them
+  {
+    const match16 = makeFakeMatch();
+    const hud16 = hudMod.mountHud({ match: match16, audio: { sfx() {} } });
+    const host16 = dom.byId.get('gg-hud');
+    const rail16 = findOne(host16, 'gg-fxrail');
+    ok(!!rail16 && hasClass(rail16.parentNode, 'gg-hud-bottom'),
+      'the chip rail is still a child of the bottom deck — .is-sd and zen both reach it through the parent');
+    hud16.unmount();
+  }
+
+  // MERCY: the portrait rule used to INFLATE it back to 20rem on a 428pt phone
+  const mercy16 = ruleFor(phone, '.gg-mercy-btn');
+  const mercyRem = num(mercy16, /width:\s*min\([^,]+,\s*([\d.]+)rem\)/, 99);
+  const mercyH16 = num(mercy16, /height:\s*(\d+)px/, 0);
+  ok(mercyRem <= 15, 'the phone MERCY is no wider than 15rem — the old rule blew it back up to 20', String(mercyRem));
+  ok(mercyH16 >= 48 && mercyH16 <= 56, 'and it is still a finger tall', String(mercyH16));
+  ok(!/animation/.test(mercy16), 'and the isolation contract is untouched — no motion is added to it here');
+
+  /* ---- the top bar cannot overflow either -------------------------------- */
+  const top16 = ruleFor(phone, '.gg-hud-top');
+  ok(/grid-template-columns:\s*minmax\(\s*0\s*,\s*1fr\s*\)\s+auto\s+auto/.test(top16),
+    'on a phone only the score column is compressible; the timer and the attention/zen/gear cluster are content-sized',
+    top16);
+  ok(num(ruleFor(phone, '.gg-timer'), /min-width:\s*(\d+)px/, 999) <= 104,
+    'and the timer gives back part of its desktop min-width');
+  ok(/\.gg-zen\s*\{[^}]*width:\s*48px/.test(css16) && !/\.gg-zen\s*\{[^}]*width/.test(phone),
+    'the zen toggle is never one of the things that shrinks — it is the only way back');
+
+  /* ---- zen, extended (owner: hide the claim panel and the chips too) ------ */
+  const zenText16 = (css16.match(/[^{}]*\.gg-hud--zen[^{}]*\{[^}]*\}/g) || []).join('\n');
+  for (const sel of ['.gg-mon-close', '.gg-fxrail']) {
+    ok(zenText16.includes(sel), `zen also hides ${sel}`);
+  }
+  ok(!/\.gg-hud--zen[^{}]*\.gg-mon-close[^{}]*\{[^}]*(opacity|filter|transform|animation)/.test(css16),
+    'and it hides them with display only, like everything else the toggle takes away');
+  // the claim panel and the dial are the two halves of one readout: never split
+  ok(zenText16.includes('.gg-dial-host') && zenText16.includes('.gg-mon-close'),
+    'both halves of the closeness readout leave together — hiding one and keeping the other reads as a bug');
+  // what still must survive zen on a phone: the rails drop, they do not vanish
+  const zenRail = ruleFor(phone, '.gg-hud-frame.gg-hud--zen .gg-rail--left');
+  ok(/bottom:\s*[\d.]+rem/.test(zenRail) && !/display:\s*none/.test(zenRail),
+    'zen moves the arsenal down into the freed space rather than taking it away', zenRail);
+}
+
 await sleep(60);
 console.log(`\nselftest-hud: ${n - failures}/${n} checks passed`);
 if (failures > 0) {

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -2751,6 +2751,151 @@ const audioMod = await import('../ui/audio.js');
   dmDc.dispose();
 }
 
+/* ===========================================================================
+ * 13. THE ZEN TOGGLE — one button, four panels (owner, 2026-08-04).
+ *
+ * "add a button that hides the ui": the score, the risk multiplier, the
+ * closeness dial ("you're telling them") and MERCY step off together; the
+ * opponent monitor and the arsenal stay. The whole feature is one bit, so this
+ * pins the bit, both of its names, and the CSS that reads them — a toggle that
+ * flips a class no stylesheet mentions is an invisible feature.
+ * ======================================================================== */
+{
+  const { S: S13 } = await import('../ui/strings.js');
+  const prefsMod13 = await import('../ui/prefs.js');
+
+  ok(typeof hudMod.HUD_ZEN_CLASS === 'string' && hudMod.HUD_ZEN_CLASS.length > 0,
+    'ui/hud.js exports the zen class name');
+  ok(typeof hudMod.HUD_ZEN_ATTR === 'string' && hudMod.HUD_ZEN_ATTR.length > 0,
+    'ui/hud.js exports the <html> attribute MERCY is hidden from');
+
+  // every user-facing word goes through ui/strings.js
+  ok(!!(S13.hud && S13.hud.zenHide && S13.hud.zenShow),
+    'strings.js carries both labels for the toggle');
+  ok(!!(S13.hud.zenHideGlyph && S13.hud.zenShowGlyph && S13.hud.zenHideGlyph !== S13.hud.zenShowGlyph),
+    'and two DIFFERENT glyphs — the state is never only a colour');
+  ok(/escape/i.test(String(S13.hud.zenShowTitle || '')),
+    'the hidden state says out loud that escape still ends the match');
+
+  const match13 = makeFakeMatch();
+  const store13 = { hudZen: false };
+  const prefs13 = { get: (k) => store13[k], set: (k, v) => { store13[k] = v; } };
+  const hud13 = hudMod.mountHud({ match: match13, audio: { sfx() {} }, prefs: prefs13 });
+  const hudHost13 = dom.byId.get('gg-hud');
+  const root13 = findOne(hudHost13, 'gg-hud-frame');
+  const zen13 = findOne(hudHost13, 'gg-zen');
+  const html13 = dom.doc.documentElement;
+
+  ok(!!zen13, 'the live HUD carries exactly one zen toggle');
+  ok(findAll(hudHost13, 'gg-zen').length === 1, 'exactly one',
+    String(findAll(hudHost13, 'gg-zen').length));
+  ok(zen13 && zen13.tagName === 'BUTTON', 'it is a real button');
+  ok(zen13 && zen13.getAttribute('aria-pressed') === 'false', 'unpressed to start');
+  ok(zen13 && zen13.getAttribute('aria-label') === S13.hud.zenHide,
+    'labelled from strings.js', zen13 && String(zen13.getAttribute('aria-label')));
+  ok(!hasClass(root13, hudMod.HUD_ZEN_CLASS), 'the desk starts whole');
+  ok(html13.getAttribute(hudMod.HUD_ZEN_ATTR) === null, 'and MERCY starts visible');
+
+  zen13.dispatchEvent({ type: 'click' });
+  ok(hasClass(root13, hudMod.HUD_ZEN_CLASS), 'one press puts the modifier on the frame');
+  ok(html13.getAttribute(hudMod.HUD_ZEN_ATTR) === 'on',
+    'and mirrors the same bit onto <html>, which is the only way to reach #gg-mercy');
+  ok(zen13.getAttribute('aria-pressed') === 'true', 'aria-pressed follows');
+  ok(zen13.getAttribute('aria-label') === S13.hud.zenShow, 'and so does the label');
+  ok(zen13.textContent === S13.hud.zenShowGlyph, 'the glyph flips to the way back');
+  ok(store13.hudZen === true, 'the pick is remembered');
+  ok(hudHost13.children.length > 0 && !!findOne(hudHost13, 'gg-mon-host'),
+    'the monitor and the rest of the desk are untouched — CSS does the hiding, not JS');
+
+  zen13.dispatchEvent({ type: 'click' });
+  ok(!hasClass(root13, hudMod.HUD_ZEN_CLASS), 'a second press gives everything back');
+  ok(html13.getAttribute(hudMod.HUD_ZEN_ATTR) === null, 'including MERCY');
+  ok(zen13.getAttribute('aria-pressed') === 'false', 'and the button says so');
+  ok(store13.hudZen === false, 'the pref follows it back');
+
+  // the handle a play-test driver uses instead of synthesising a click
+  hud13.parts.zen.set(true);
+  ok(hud13.parts.zen.on === true && hasClass(root13, hudMod.HUD_ZEN_CLASS),
+    'parts.zen drives the same one bit');
+
+  /* THE UNWIND. The class dies with the node; the attribute does not, and a
+   * leftover one would hide the mercy button of the NEXT match with no button
+   * left on screen to bring it back. */
+  hud13.unmount();
+  ok(html13.getAttribute(hudMod.HUD_ZEN_ATTR) === null,
+    'unmount clears the <html> bit — a stale one would hide the next match\'s MERCY');
+  ok(match13._subs.released === match13._subs.taken,
+    'and the toggle leaks no subscriptions', `${match13._subs.released}/${match13._subs.taken}`);
+
+  // remembered across mounts
+  const match13b = makeFakeMatch();
+  const hud13b = hudMod.mountHud({ match: match13b, audio: { sfx() {} }, prefs: { get: () => true, set() {} } });
+  const root13b = findOne(dom.byId.get('gg-hud'), 'gg-hud-frame');
+  ok(hasClass(root13b, hudMod.HUD_ZEN_CLASS) && html13.getAttribute(hudMod.HUD_ZEN_ATTR) === 'on',
+    'a remembered zen is applied at mount, not on the first click');
+  hud13b.unmount();
+  ok(html13.getAttribute(hudMod.HUD_ZEN_ATTR) === null, 'and unwound the same way');
+
+  ok(prefsMod13.PREF_DEFAULTS.hudZen === false,
+    'the pref exists and defaults OFF — a desk you cannot read your score in is a choice',
+    String(prefsMod13.PREF_DEFAULTS.hudZen));
+
+  // a HUD with no pref store at all must still toggle
+  const match13c = makeFakeMatch();
+  const hud13c = hudMod.mountHud({ match: match13c, audio: { sfx() {} } });
+  const zen13c = findOne(dom.byId.get('gg-hud'), 'gg-zen');
+  zen13c.dispatchEvent({ type: 'click' });
+  ok(hasClass(findOne(dom.byId.get('gg-hud'), 'gg-hud-frame'), hudMod.HUD_ZEN_CLASS),
+    'the toggle works with no prefs object — persistence is a nicety, not the state');
+  hud13c.unmount();
+
+  /* ---- the CSS half ----------------------------------------------------- */
+  const fs13 = await import('node:fs/promises');
+  const url13 = await import('node:url');
+  const hudCss13 = await fs13.readFile(url13.fileURLToPath(new URL('../ui/hud.css', import.meta.url)), 'utf8');
+  const goonCss13 = await fs13.readFile(url13.fileURLToPath(new URL('../goon.css', import.meta.url)), 'utf8');
+
+  const zenBlocks = hudCss13.match(/[^{}]*\.gg-hud--zen[^{}]*\{[^}]*\}/g) || [];
+  ok(zenBlocks.length > 0, 'hud.css reads the modifier class at all');
+  const zenText = zenBlocks.join('\n');
+  for (const sel of ['.gg-score', '.gg-risk', '.gg-dial-host']) {
+    ok(zenText.includes(sel), `zen hides ${sel}`);
+  }
+  ok(/\.gg-hud--zen[^{}]*\{[^}]*display:\s*none/.test(zenText),
+    'and it hides them with display, so the layout closes up instead of leaving holes');
+
+  // what must SURVIVE the toggle: their monitor and the effects you can send
+  for (const sel of ['.gg-mon-host', '.gg-rail', '.gg-item', '.gg-zen']) {
+    ok(!new RegExp('\\.gg-hud--zen[^{}]*' + sel.replace('.', '\\.') + '[^{}]*\\{[^}]*display:\\s*none').test(hudCss13),
+      `zen never hides ${sel}`);
+  }
+
+  ok(/html\[data-gg-zen="on"\]\s*#gg-mercy[^{]*\{[^}]*display:\s*none/.test(hudCss13),
+    'MERCY is reached from <html>, because it is not a descendant of the HUD');
+  const mercyZen = (hudCss13.match(/html\[data-gg-zen="on"\][^{]*\{[^}]*\}/g) || []).join('\n');
+  ok(!/opacity|filter|transform|animation/.test(mercyZen),
+    'and only display: the isolation contract in goon.css is not being dimmed, filtered or moved');
+  ok(/filter:\s*none\s*!important/.test(goonCss13) && /opacity:\s*1\s*!important/.test(goonCss13),
+    'goon.css still owns the mercy isolation block, untouched');
+
+  // the button is the only way back on a phone: hit area, and no parked animation
+  const zenBtnBlock = (hudCss13.match(/\.gg-zen\s*\{[^}]*\}/g) || [])[0] || '';
+  ok(/width:\s*48px/.test(zenBtnBlock) && /height:\s*48px/.test(zenBtnBlock),
+    'the toggle keeps a 48px hit area', zenBtnBlock);
+  ok(!/animation/.test(zenBtnBlock),
+    'and no animation — it would need pinning against the --gg-deco-play park');
+
+  /* ---- the size pass (independent of the toggle) ------------------------- */
+  const mercyBlock = (hudCss13.match(/\.gg-mercy-btn\s*\{[^}]*\}/g) || [])[0] || '';
+  const mercyH = Number((mercyBlock.match(/height:\s*(\d+)px/) || [])[1] || 0);
+  ok(mercyH >= 48 && mercyH <= 64, 'MERCY is smaller than it was, and still a finger tall', String(mercyH));
+  const dialBlock = (hudCss13.match(/\.gg-dial\s*\{[^}]*\}/g) || [])[0] || '';
+  const dialMin = Number((dialBlock.match(/min-width:\s*([\d.]+)rem/) || [])[1] || 99);
+  ok(dialMin < 15, 'the closeness dial is narrower than the 15rem it shipped at', String(dialMin));
+  ok(/\.gg-dial-stop\s*\{[^}]*min-height:\s*48px/.test(hudCss13),
+    'but its four stops keep their 48px touch target — the plate shrank, the targets did not');
+}
+
 await sleep(60);
 console.log(`\nselftest-hud: ${n - failures}/${n} checks passed`);
 if (failures > 0) {

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -57,8 +57,23 @@ async function testSignaling() {
   ok(joined.token !== invite.token, 'guest gets its own room token');
   ok(joined.peerDisplayName === 'host', 'join reports the peer display name');
 
-  const dup = await guest.join(invite.code, 'Circe');
-  ok(dup === null && guest.lastError === GoonSignalError.AlreadyJoined, 'second join -> already_joined', String(guest.lastError));
+  /* --- THE SEAT BELONGS TO A UID (ghost-slot fix, 2026-08-04) ------------------
+   * The owner's phone was told "that room already has two players" by its OWN
+   * earlier attempt. Three outcomes have to stay separable here, because the
+   * lobby renders three different sentences from them. */
+  const stranger = new GoonSignalingClient({ post: fake.post, unifiedId: 'u_third', appVersion: 'test', logger: quiet });
+  const taken = await stranger.join(invite.code, 'Stranger');
+  ok(taken === null && stranger.lastError === GoonSignalError.AlreadyJoined,
+    'a DIFFERENT uid on an occupied room -> already_joined', String(stranger.lastError));
+
+  const selfJoin = await host.join(invite.code, 'Bambi');
+  ok(selfJoin === null && host.lastError === GoonSignalError.SelfJoin,
+    'the host redeeming its own code -> self_join, not "full"', String(host.lastError));
+
+  const again = await guest.join(invite.code, 'Circe');
+  ok(!!again && again.rejoin === true, 'the SAME uid reclaims its seat instead of being refused');
+  ok(!!again && again.token && again.token !== joined.token, 'a reclaimed seat gets a fresh room token');
+  const reclaimedToken = again.token;
 
   // --- post-and-drain round trip ------------------------------------------------
   const h1 = await host.signal(invite.code, invite.token, 'host', 0, [{ kind: 'offer', data: 'OFFER' }]);
@@ -66,7 +81,7 @@ async function testSignaling() {
   ok(h1 && h1.cursor === 1, 'cursor advances PAST our own message', String(h1 && h1.cursor));
   ok(h1 && h1.peerJoined === true, 'peer_joined true after the guest redeemed');
 
-  const g1 = await guest.signal(invite.code, joined.token, 'guest', 0, [{ kind: 'answer', data: 'ANSWER' }]);
+  const g1 = await guest.signal(invite.code, reclaimedToken, 'guest', 0, [{ kind: 'answer', data: 'ANSWER' }]);
   ok(g1 && g1.messages.length === 1 && g1.messages[0].kind === 'offer', 'guest drains the offer');
   ok(g1 && g1.messages[0].from === 'host' && g1.messages[0].seq === 1, 'drained message carries seq + from');
   ok(g1 && g1.cursor === 2, 'guest cursor covers its own answer too', String(g1 && g1.cursor));
@@ -79,7 +94,7 @@ async function testSignaling() {
   // --- relay mailbox is a separate ring -----------------------------------------
   const r1 = await host.relay(invite.code, invite.token, 'host', 0, ['{"t":"tick"}'], 10);
   ok(r1 && r1.frames.length === 0 && r1.cursor === 1, 'relay: no self-echo, cursor advances');
-  const r2 = await guest.relay(invite.code, joined.token, 'guest', 0, [], 10);
+  const r2 = await guest.relay(invite.code, reclaimedToken, 'guest', 0, [], 10);
   ok(r2 && r2.frames.length === 1 && r2.frames[0] === '{"t":"tick"}', 'relay: peer drains the frame');
   ok(r2 && r2.peerOnline === true, 'relay reports peer_online');
 
@@ -909,6 +924,169 @@ async function testGuestFold() {
   }
 }
 
+/* ================================================================================
+ * 10. THE GHOST SEAT (owner play-test, 2026-08-04)
+ *
+ * The phone was refused with "that room already has two players" by a room whose
+ * second player WAS the phone: an earlier attempt had registered the seat and then
+ * folded without telling anyone, and nothing but the 30-minute room TTL could
+ * clear it. Two independent halves fix it, and both are pinned here because either
+ * one alone still leaves a hole:
+ *
+ *   a) the SERVER reclaims a seat for the uid that already holds it, so the retry
+ *      works even when the goodbye never arrives (closed tab, dead network, a
+ *      server that predates /leave);
+ *   b) the CLIENT hands the seat back on any teardown of a room that never
+ *      connected, so the ghost does not exist in the first place — and does NOT
+ *      hand it back once a channel came up, because past that point the room token
+ *      is what the ledger writes with.
+ * ==============================================================================*/
+async function testSeatRelease() {
+  // --- a) the fake server's seat semantics, end to end -------------------------
+  {
+    const fake = new GoonFakeSignalingServer();
+    const host = new GoonSignalingClient({ post: fake.post, unifiedId: 'u_h', logger: quiet });
+    const phone = new GoonSignalingClient({ post: fake.post, unifiedId: 'u_p', logger: quiet });
+    const other = new GoonSignalingClient({ post: fake.post, unifiedId: 'u_o', logger: quiet });
+
+    const inv = await host.createInvite('Host');
+    const first = await phone.join(inv.code, 'Phone');
+    ok(!!first && first.rejoin === false, 'a first join is not a rejoin');
+
+    // The bounce: the phone hands the seat back on its way out.
+    ok(await phone.leave(inv.code, first.token, 'guest') === true, 'guest /leave is acknowledged');
+    ok(fake.room(inv.code) && fake.room(inv.code).joined === false, 'the seat is free again');
+
+    const back = await phone.join(inv.code, 'Phone');
+    ok(!!back && back.rejoin === false, 'a released seat is a clean join, not a reclaim');
+    ok(fake.room(inv.code).guestUid === 'u_p', 'and the room knows whose seat it is');
+
+    // …and the belt-and-braces half: even WITHOUT the goodbye, the same uid gets in.
+    const reclaim = await phone.join(inv.code, 'Phone');
+    ok(!!reclaim && reclaim.rejoin === true, 'a ghost seat is reclaimed by its own uid');
+    ok(fake.room(inv.code).guestEpoch === 3, 'each claim is a new seat epoch', String(fake.room(inv.code).guestEpoch));
+
+    ok(await other.join(inv.code, 'Other') === null && other.lastError === GoonSignalError.AlreadyJoined,
+      'a genuinely occupied room still refuses a stranger — the message was only a lie about the OWNER');
+
+    // The host walking away takes the code with it.
+    ok(await host.leave(inv.code, inv.token, 'host') === true, 'host /leave is acknowledged');
+    ok(fake.room(inv.code) === null, 'a host fold deletes the room');
+    ok(await phone.join(inv.code, 'Phone') === null && phone.lastError === GoonSignalError.UnknownCode,
+      'and the folded code is gone for everyone');
+  }
+
+  // --- b) leave() never disturbs the error the lobby is about to render ---------
+  {
+    const c = new GoonSignalingClient({ post: () => Promise.resolve({ status: 500, body: '' }), logger: quiet });
+    c.lastError = GoonSignalError.AlreadyJoined;
+    c.lastErrorDetail = 'keep-me';
+    await c.leave('ABC123', 'tok', 'guest');
+    ok(c.lastError === GoonSignalError.AlreadyJoined && c.lastErrorDetail === 'keep-me',
+      'a failed goodbye does not overwrite lastError');
+  }
+
+  // --- c) which teardowns send it ----------------------------------------------
+  const leaves = [];
+  const sig = () => ({
+    dispose() {},
+    leave: (code, token, role) => { leaves.push({ code, token, role }); return Promise.resolve(true); },
+  });
+  class Leg {
+    constructor(isHost, outcome) {
+      this.isHost = isHost; this._outcome = outcome;
+      this.code = null; this.token = null; this.iceFailed = false; this.lastError = null;
+    }
+    async createInvite() { this.code = 'ROOM99'; this.token = 'tok-host'; return this.code; }
+    async join(c) { this.code = c; this.token = 'tok-guest'; return true; }
+    async waitForChannel() {
+      await sleep(5);
+      if (this._outcome === 'connected') return true;
+      this.iceFailed = false;                    // signaling-level: no relay, straight fold
+      this.lastError = 'signaling_failed';
+      return false;
+    }
+    async close() {}
+    dispose() {}
+  }
+  const mk = (outcome) => new GoonSession({
+    logger: quiet,
+    createMatch: (t, isHost) => ({
+      transport: t, isHost,
+      createInvite: () => t.createInvite(), join: (c) => t.join(c),
+      adoptLobby: () => true, cancelMatch: () => {}, dispose: () => {},
+    }),
+    createSignaling: sig,
+    createWebrtc: (isHost) => new Leg(isHost, outcome),
+    createRelay: (isHost) => new Leg(isHost, outcome),
+  });
+
+  {
+    const s = mk('fold');
+    await s.join('ABC123');
+    ok(await until(() => leaves.length === 1, 3000), 'a guest fold hands the seat back');
+    ok(leaves[0] && leaves[0].role === 'guest' && leaves[0].code === 'ABC123' && leaves[0].token === 'tok-guest',
+      'with the room it actually held', JSON.stringify(leaves[0]));
+  }
+  {
+    leaves.length = 0;
+    const s = mk('fold');
+    await s.host();
+    await s.leave();
+    ok(leaves.length === 1 && leaves[0].role === 'host', 'a host that never connected folds its lobby',
+      JSON.stringify(leaves));
+  }
+  {
+    leaves.length = 0;
+    const s = mk('connected');
+    await s.join('ABC123');
+    await sleep(40);
+    await s.leave();
+    ok(leaves.length === 0,
+      'a room that CONNECTED is never released — the ledger still needs that token', JSON.stringify(leaves));
+  }
+  {
+    leaves.length = 0;
+    const s = mk('fold');
+    await s.dispose();
+    ok(leaves.length === 0, 'a session that never got a room has nothing to hand back');
+  }
+  {
+    // …and the flag is per ATTEMPT. A session object outlives one match here, so a
+    // sticky "we connected once" would silently disable the goodbye for every room
+    // after the first — the exact ghost, one match later.
+    leaves.length = 0;
+    let leg = 0;
+    const s = new GoonSession({
+      logger: quiet,
+      createMatch: (t, isHost) => ({
+        transport: t, isHost, join: (c) => t.join(c),
+        adoptLobby: () => true, cancelMatch: () => {}, dispose: () => {},
+      }),
+      createSignaling: sig,
+      createWebrtc: () => new Leg(false, ++leg === 1 ? 'connected' : 'fold'),
+      createRelay: () => new Leg(false, 'fold'),
+    });
+    await s.join('AAA111');
+    await sleep(40);
+    await s.leave();
+    ok(leaves.length === 0, 'the connected attempt still sends nothing');
+    await s.join('BBB222');
+    ok(await until(() => leaves.length === 1 && leaves[0].code === 'BBB222', 3000),
+      'a LATER attempt on the same session still hands its seat back', JSON.stringify(leaves));
+  }
+
+  // --- d) the server half, pinned by source (it lives in another repo) ----------
+  {
+    const src = readSource('../net/session.js');
+    ok(/_releaseRoom\(transport, signaling\);/.test(src) && src.indexOf('_releaseRoom(transport, signaling);') < src.indexOf('signaling.dispose()'),
+      'the goodbye is issued BEFORE the signaling client is disposed');
+    const sess = src.slice(src.indexOf('_releaseRoom(transport, signaling) {'));
+    ok(/if \(this\._everConnected\) return;/.test(sess.slice(0, 400)),
+      'and it is gated on never having connected');
+  }
+}
+
 // ============================================================ run
 const main = async () => {
   await testSignaling();
@@ -920,6 +1098,7 @@ const main = async () => {
   await testBlocklist();
   await testPeerCardVer();
   await testGuestFold();
+  await testSeatRelease();
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -10,7 +10,7 @@
 import fs from 'node:fs';
 
 import { GoonSignalingClient, GoonSignalError, normalizeCode } from '../net/signaling.js';
-import { GoonFakeSignalingServer } from '../net/fakeSignaling.js';
+import { GoonFakeSignalingServer, shadowGuestUid, isShadowUid } from '../net/fakeSignaling.js';
 import { createLoopbackPair, loopbackOptions, loopbackPresets } from '../net/loopbackTransport.js';
 import { GoonRelayTransport } from '../net/relayTransport.js';
 import { GoonSession } from '../net/session.js';
@@ -1087,6 +1087,99 @@ async function testSeatRelease() {
   }
 }
 
+/* ================================================================================
+ * 11. SELF-DUEL — one whitelisted account in both seats
+ *
+ * The owner play-tests GG with ONE account on two devices: the PC app hosts, the
+ * phone opens the standalone web build through a link that carries the same
+ * `?uid=`, so §10's `self_join` guard — correct for everyone else — refused the
+ * entire e2e run. Whitelisted accounts may therefore hold both seats, with the
+ * guest seat under the SHADOW id `<uid>#self`.
+ *
+ * The shadow is the whole safety argument, and it is a SERVER-side one (single
+ * ledger row, a self-report that names nobody, an intact room-by-uid lookup).
+ * What is pinned HERE is the half the client can be wrong about: the fake server
+ * models the same rule, and nothing in the client stack cares that the two seats
+ * are one account — no uid comparison, no ledger de-dup, no peercard assumption.
+ * ==============================================================================*/
+async function testSelfDuel() {
+  const OWNER = 'u_owner', OUTSIDER = 'u_outsider';
+  const SHADOW = shadowGuestUid(OWNER);
+  ok(isShadowUid(SHADOW) && !isShadowUid(OWNER) && SHADOW === `${OWNER}#self`,
+    'the shadow id is the uid plus a suffix a real unified_id can never contain');
+
+  // --- a non-whitelisted account is refused exactly as before -------------------
+  {
+    const fake = new GoonFakeSignalingServer();
+    const plain = new GoonSignalingClient({ post: fake.post, unifiedId: OWNER, logger: quiet });
+    const inv = await plain.createInvite('Owner');
+    const self = await plain.join(inv.code, 'Owner');
+    ok(self === null && plain.lastError === GoonSignalError.SelfJoin,
+      'without the whitelist the host still gets self_join', String(plain.lastError));
+    ok(fake.room(inv.code).joined === false, 'and the refusal did not take the seat');
+  }
+
+  // --- the affordance ----------------------------------------------------------
+  const fake = new GoonFakeSignalingServer();
+  fake.setWhitelisted(OWNER);
+  const pc = new GoonSignalingClient({ post: fake.post, unifiedId: OWNER, logger: quiet });
+  const phone = new GoonSignalingClient({ post: fake.post, unifiedId: OWNER, logger: quiet });
+  const other = new GoonSignalingClient({ post: fake.post, unifiedId: OUTSIDER, logger: quiet });
+
+  const inv = await pc.createInvite('Owner PC');
+  const seat = await phone.join(inv.code, 'Owner Phone');
+  ok(!!seat && !!seat.token, 'a whitelisted account may redeem its own code');
+  ok(seat.selfDuel === true && seat.rejoin === false, 'and the response says so', JSON.stringify(seat));
+  ok(fake.room(inv.code).guestUid === SHADOW,
+    'the guest seat is the SHADOW id, never the real uid', String(fake.room(inv.code).guestUid));
+  ok(fake.room(inv.code).hostUid === OWNER, 'the host seat is untouched');
+
+  // The two seats are still two peers as far as every mailbox is concerned.
+  const h = await pc.signal(inv.code, inv.token, 'host', 0, [{ kind: 'offer', data: 'OFFER' }]);
+  ok(h && h.messages.length === 0 && h.peerJoined === true, 'the host sees a joined peer and no self-echo');
+  const g = await phone.signal(inv.code, seat.token, 'guest', 0, [{ kind: 'answer', data: 'ANSWER' }]);
+  ok(g && g.messages.length === 1 && g.messages[0].data === 'OFFER', 'the shadow seat drains the offer');
+  const h2 = await pc.signal(inv.code, inv.token, 'host', h.cursor, []);
+  ok(h2 && h2.messages.length === 1 && h2.messages[0].data === 'ANSWER', 'and the host drains the answer back');
+  const r = await pc.relay(inv.code, inv.token, 'host', 0, ['{"t":"tick"}'], 10);
+  const r2 = await phone.relay(inv.code, seat.token, 'guest', 0, [], 10);
+  ok(r && r2 && r2.frames.length === 1 && r2.peerOnline === true, 'the relay ring works across the two seats');
+
+  // --- reclaim lands on the shadow, never on a second shadow -------------------
+  const back = await phone.join(inv.code, 'Owner Phone');
+  ok(!!back && back.rejoin === true && back.selfDuel === true, 'the self-duel guest reclaims its own seat');
+  ok(fake.room(inv.code).guestUid === SHADOW, 'still ONE shadow deep (never <uid>#self#self)',
+    String(fake.room(inv.code).guestUid));
+  ok(fake.room(inv.code).guestEpoch === 2, 'the reclaim is a new seat epoch', String(fake.room(inv.code).guestEpoch));
+  ok(back.token !== seat.token, 'and it gets a fresh room token');
+
+  // --- /leave frees the shadow seat -------------------------------------------
+  ok(await phone.leave(inv.code, back.token, 'guest') === true, 'the shadow seat can be handed back');
+  ok(fake.room(inv.code).joined === false && fake.room(inv.code).guestUid === null, 'the seat is free again');
+  const again = await phone.join(inv.code, 'Owner Phone');
+  ok(!!again && again.selfDuel === true && again.rejoin === false, 'and the owner walks straight back in');
+  ok(fake.room(inv.code).guestUid === SHADOW, 'on the same shadow id');
+
+  // --- the guard it is an exception to still holds -----------------------------
+  ok(await other.join(inv.code, 'Outsider') === null && other.lastError === GoonSignalError.AlreadyJoined,
+    'a stranger is still refused an occupied room');
+  const inv2 = await pc.createInvite('Owner PC');
+  ok((await other.join(inv2.code, 'Outsider')) !== null, 'a real second player joins a whitelisted host normally');
+  ok(fake.room(inv2.code).guestUid === OUTSIDER, 'and takes the seat under its OWN uid');
+  const late = await phone.join(inv2.code, 'Owner Phone');
+  ok(late === null && phone.lastError === GoonSignalError.AlreadyJoined,
+    'a whitelisted host cannot self-duel into an occupied room', String(phone.lastError));
+
+  // --- nothing in the client stack compares the two identities -----------------
+  // If any of these ever grow a uid comparison, a self-duel becomes a silent
+  // "you are your own opponent" bug rather than a working test rig.
+  for (const rel of ['../net/session.js', '../net/webrtcTransport.js', '../net/relayTransport.js',
+    '../net/transportBase.js', '../core/match.js']) {
+    ok(!/unified_?[Ii]d\s*[=!]==?/.test(readSource(rel)), `${rel} never compares unified ids`);
+  }
+  ok(/self_duel/.test(readSource('../net/signaling.js')), 'the client reads the self_duel flag off /join');
+}
+
 // ============================================================ run
 const main = async () => {
   await testSignaling();
@@ -1099,6 +1192,7 @@ const main = async () => {
   await testPeerCardVer();
   await testGuestFold();
   await testSeatRelease();
+  await testSelfDuel();
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -7,6 +7,8 @@
 // kept thin over the shared base: everything asserted below lives in transportBase/signaling/
 // session, and the browser leg is a play-test item.
 
+import fs from 'node:fs';
+
 import { GoonSignalingClient, GoonSignalError, normalizeCode } from '../net/signaling.js';
 import { GoonFakeSignalingServer } from '../net/fakeSignaling.js';
 import { createLoopbackPair, loopbackOptions, loopbackPresets } from '../net/loopbackTransport.js';
@@ -23,6 +25,9 @@ function ok(cond, label, extra = '') {
 }
 const quiet = { info() {}, warn() {}, error() {}, log() {} };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// LF-normalized: the worktree is CRLF (core.autocrlf) and every source pin below
+// is written against \n.
+const readSource = (rel) => fs.readFileSync(new URL(rel, import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 async function until(fn, ms = 4000, step = 25) {
   const deadline = Date.now() + ms;
@@ -763,6 +768,147 @@ async function testPeerCardVer() {
   guestSig.dispose(); hostSig2.dispose(); guestSig2.dispose();
 }
 
+/* ==================================================================================
+ * 9. THE GUEST BOUNCE — "briefly shows the page of the setup before game then
+ *    bounces me back to homepage" (owner's phone test, 2026-08-04).
+ *
+ * The phone runs this page STANDALONE and joins a match the PC app hosts. The
+ * join lands, the lobby paints, and a moment later the player is on the title
+ * with nothing said. There is exactly one mechanism in the page that can do that
+ * SILENTLY: GoonSession tears the match down internally, boot.js hears
+ * onCurrentMatchChanged(null) and jumps to the title — while the EXPLANATION
+ * (onConnectFailed) is still one turn behind it.
+ *
+ * Three things are pinned here:
+ *   a) a guest that connects raises neither of the two events that can evict it;
+ *   b) every internal fold raises connectFailed in the SAME macrotask turn as the
+ *      teardown, which is what makes boot's deferred jump correct rather than
+ *      lucky (a setTimeout(0) armed when the match goes null still runs after);
+ *   c) a P2P attempt that died in a way the BROWSER owns — an SDP the phone's
+ *      stack refuses — is flagged for the RELAY, not folded. The room is live and
+ *      the weekly pass is burned; folding it is the eviction above.
+ * ================================================================================*/
+async function testGuestFold() {
+  /** A guest transport shaped like GoonWebRtcTransport, with the outcome dialled in. */
+  class GuestLeg {
+    constructor(outcome) {
+      this.isHost = false;
+      this.code = null; this.token = null;
+      this.iceFailed = false; this.lastError = null;
+      this.closed = false; this.disposed = false;
+      this._outcome = outcome;
+    }
+    async join(code) { this.code = code; this.token = 'tok-guest'; return true; }
+    async waitForChannel() {
+      await sleep(10);
+      if (this._outcome === 'connected') return true;
+      // 'sdp_rejected' is the fixed shape: a browser-level refusal that still
+      // leaves a live room behind, so it flags for fallback like ice_timeout.
+      this.iceFailed = this._outcome !== 'signaling';
+      this.lastError = this._outcome === 'signaling' ? 'signaling_failed' : 'sdp_rejected';
+      return false;
+    }
+    async close() { this.closed = true; }
+    dispose() { this.disposed = true; }
+  }
+  class RelayLeg {
+    constructor() { this.adopted = null; this.lastError = null; }
+    adoptRoom(code, token) { this.adopted = { code, token }; }
+    async waitForChannel() { return true; }
+    async close() { /* nothing to close */ }
+    dispose() { /* nothing to drop */ }
+  }
+  class FoldMatch {
+    constructor(transport, isHost) {
+      this.transport = transport; this.isHost = isHost;
+      this.adoptedLobby = false; this.disposed = false;
+    }
+    join(c) { return this.transport.join(c); }
+    adoptLobby() { this.adoptedLobby = true; return true; }
+    cancelMatch() { /* the user path, not exercised here */ }
+    dispose() { this.disposed = true; }
+  }
+  const build = (outcome) => {
+    const legs = []; const relays = []; const events = [];
+    const s = new GoonSession({
+      logger: quiet,
+      createMatch: (t, isHost) => new FoldMatch(t, isHost),
+      createSignaling: () => ({ dispose() {} }),
+      createWebrtc: () => { const l = new GuestLeg(outcome); legs.push(l); return l; },
+      createRelay: () => { const r = new RelayLeg(); relays.push(r); return r; },
+    });
+    s.onCurrentMatchChanged((m) => events.push(m ? 'match' : 'null'));
+    s.onConnectFailed((r) => events.push('failed:' + r));
+    return { s, legs, relays, events };
+  };
+
+  // --- a) the healthy guest: nothing that can evict it ever fires ----------------
+  {
+    const g = build('connected');
+    ok(await g.s.join('ABC123') === true, 'a guest that connects reports a successful join');
+    await sleep(120);
+    ok(g.events.join(',') === 'match', 'no teardown and no connectFailed on a healthy join', g.events.join(','));
+    ok(g.s.currentMatch !== null, 'the match is still live — the lobby has something to render');
+    await g.s.leave();
+  }
+
+  // --- b) the ordering boot.js's deferred fold depends on -----------------------
+  {
+    const g = build('signaling');
+    let foldRanAt = -1;
+    g.s.onCurrentMatchChanged((m) => {
+      if (m) return;
+      setTimeout(() => { foldRanAt = g.events.length; }, 0);
+    });
+    await g.s.join('ABC123');
+    ok(await until(() => foldRanAt >= 0, 3000), 'the deferred fold ran');
+    ok(g.events.join(',') === 'match,null,failed:signaling_failed',
+      'an internal fold raises teardown THEN connectFailed', g.events.join(','));
+    ok(foldRanAt === 3, 'and both land before a setTimeout(0) armed at teardown', String(foldRanAt));
+    ok(g.relays.length === 0, 'a signaling-level failure still refuses to try a relay');
+  }
+
+  // --- c) an SDP the phone refused is a relay case, not an eviction -------------
+  {
+    const g = build('sdp_rejected');
+    await g.s.join('ABC123');
+    ok(await until(() => g.relays.length === 1 && !!g.relays[0].adopted, 3000),
+      'a transport that flags iceFailed adopts the SAME room over the relay');
+    ok(g.relays[0].adopted.code === 'ABC123', 'the code the player already typed is reused',
+      String(g.relays[0].adopted && g.relays[0].adopted.code));
+    ok(g.events.indexOf('null') < 0, 'and the guest is never torn down — no bounce to the title',
+      g.events.join(','));
+    ok(g.s.currentMatch !== null && g.s.currentMatch.adoptedLobby === true,
+      'the rebuilt match adopts the lobby instead of re-joining');
+    await g.s.leave();
+  }
+
+  // --- and the transport half of (c), which needs a browser to run for real -----
+  {
+    const src = readSource('../net/webrtcTransport.js');
+    const i = src.indexOf('setRemoteDescription(offer) rejected');
+    ok(i > 0, 'webrtcTransport still handles a rejected inbound offer');
+    const arm = src.slice(i, i + 400);
+    ok(/_iceFailed\s*=\s*true/.test(arm),
+      'a guest whose stack refuses the offer flags iceFailed — session.js relays it instead of folding');
+    ok(/_setState\(GoonTransportState\.Disconnected, 'sdp_rejected'\)/.test(arm),
+      'and it still surfaces promptly rather than burning the ICE budget');
+  }
+
+  // --- the boot.js half: the jump is deferred and cancellable -------------------
+  {
+    const boot = readSource('../boot.js');
+    ok(/function foldToTitle\(\)/.test(boot) && /function cancelFoldToTitle\(\)/.test(boot),
+      'boot.js routes the silent teardown through foldToTitle/cancelFoldToTitle');
+    ok(/if \(!soloPair\) foldToTitle\(\);/.test(boot),
+      'onCurrentMatchChanged(null) no longer calls router.show(\'title\') directly');
+    const cf = boot.indexOf('onConnectFailed((reason)');
+    ok(cf > 0 && /cancelFoldToTitle\(\);/.test(boot.slice(cf, cf + 900)),
+      'the connect-failure sheet cancels the fold so it opens over the screen it is about');
+    ok(/setTimeout\(go, 0\)/.test(boot), 'and the fold really is deferred by a macrotask');
+  }
+}
+
 // ============================================================ run
 const main = async () => {
   await testSignaling();
@@ -773,6 +919,7 @@ const main = async () => {
   await testVwinTick();
   await testBlocklist();
   await testPeerCardVer();
+  await testGuestFold();
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
@@ -73,7 +73,7 @@ export const NEEDS_STATES = Object.freeze(['pending', 'queued', 'working']);
  *   ≤ MAX_EXEMPT_BYTES (8 MB)    sent AS-IS, on the exempt path. Never
  *                                recompressed: it already fits, and re-encoding
  *                                something that fits only loses quality.
- *   ≤ MAX_ARTIFACT_BYTES (24 MB) the ceiling for a NON-exempt artifact — what
+ *   ≤ MAX_ARTIFACT_BYTES (64 MB) the ceiling for a NON-exempt artifact — what
  *                                the transfer queue allows once an item is a
  *                                compressed product rather than an original.
  *
@@ -313,7 +313,7 @@ export async function probeEncode() {
 
 /** GoonCacheBridge.MaxPutB64Chars — base64 CHARACTERS, not bytes. */
 export const PUT_MAX_B64_CHARS = 4 * 1024 * 1024;
-/** GoonCacheBridge.MaxPutParts. 16 x 3 MB is far past the 24 MiB wire cap. */
+/** GoonCacheBridge.MaxPutParts. 16 x 3 MB = 48 MB — plenty for lane B's ~2 MB mp4s (raw sends never ride this put path). */
 export const PUT_MAX_PARTS = 16;
 /** Bytes per part: base64 is 4 chars per 3 bytes, and parts must not straddle. */
 export const PUT_PART_BYTES = Math.floor(PUT_MAX_B64_CHARS / 4) * 3;
@@ -1117,12 +1117,12 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    * THE POLICY, in the order it is applied:
    *   1. not a mime the wire carries        -> badType
    *   2. ≤ 8 MB                             -> EXEMPT, as-is, untouched
-   *   3. video 8..24 MB                     -> non-exempt artifact, as-is (no transcode)
-   *   4. video > 24 MB                      -> tooBigVideo (its own sentence)
+   *   3. video 8..64 MB                     -> non-exempt artifact, as-is (no transcode)
+   *   4. video > 64 MB                      -> tooBigVideo (its own sentence)
    *   5. still/animated > 80 MB source      -> tooBig (we will not decode that)
    *   6. animated gif/awebp > 8 MB          -> mp4 artifact, via lane B's worker
    *   7. still > 8 MB                       -> WebP (or JPEG) artifact
-   *   8. any compressed output > 24 MB      -> failed (pathological; nothing to send)
+   *   8. any compressed output > 64 MB      -> failed (pathological; nothing to send)
    */
   async function adoptLocalFile(f, report) {
     if (!f || typeof f.arrayBuffer !== 'function') { report.failed++; return; }
@@ -1162,7 +1162,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
   /**
    * Everything over the exempt cap. What lands is a NON-EXEMPT ARTIFACT: state
    * 'ready' with an `artUrl`, which is exactly the shape boot.js listSendable()
-   * offers under the 24 MB rail (`bytes <= MAX_ARTIFACT_BYTES`), and exactly the
+   * offers under the 64 MB rail (`bytes <= MAX_ARTIFACT_BYTES`), and exactly the
    * shape the host's own compressed items have.
    */
   async function adoptOversize(f, mime, bytes, report) {
@@ -1170,7 +1170,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
 
     /* --- video: as-is up to the artifact cap, and honest above it ----------
      * A browser cannot re-encode an mp4 without decoding every frame through
-     * WebCodecs, at a cost we cannot promise on a phone. So an 8..24 MB clip
+     * WebCodecs, at a cost we cannot promise on a phone. So an 8..64 MB clip
      * rides the wire as the artifact it already is, and anything bigger is
      * COUNTED AND NAMED rather than quietly dropped. */
     if (kindForMime(mime) === 'video') {
@@ -1235,7 +1235,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
       report.failed++; return;
     }
     const outBytes = Number(out.blob.size) || 0;
-    // The 24 MB rail is the transfer queue's, and an artifact past it is simply
+    // The 64 MB rail is the transfer queue's, and an artifact past it is simply
     // un-offerable — adopting it would put an item on the screen that can never
     // be sent, which is worse than saying it did not work.
     if (outBytes > LOCAL_ARTIFACT_MAX_BYTES) {
@@ -1264,7 +1264,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    * `state: 'ready'` + `artUrl` is not decoration: listSendable() reads `artUrl`
    * for anything that is not exempt, and `bytes` must be the ARTIFACT's length
    * because that is the number the receiver's offer gate checks against its own
-   * 24 MB cap. `kind` is derived from the OUTPUT mime, never carried over from
+   * 64 MB cap. `kind` is derived from the OUTPUT mime, never carried over from
    * the source — the offer gate declines any offer whose kind and mime disagree,
    * and a GIF that became an mp4 changes family.
    */

--- a/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
@@ -138,6 +138,43 @@ export function classifyLocalSize(mime, bytes) {
   return size <= LOCAL_DECODE_MAX_BYTES ? 'take' : 'too-big';
 }
 
+/**
+ * The local library as exec/media.js DECK ENTRIES — `{kind, name, url}`.
+ *
+ * Standalone this is the player's whole library, and it is the ONLY thing the
+ * media pool can draw from: bridge.js synthesizes an empty `manifest` frame out
+ * here, so without this the practice session fires every effect against an empty
+ * deck (which is exactly what it did). Pure, exported and driven by the selftest
+ * because it is the join between two tiers that must not learn about each other.
+ *
+ *   - `kind` is TAKEN, not re-derived. A pick lives behind a blob: URL with no
+ *     extension to sniff; the store decided image/video from the mime at
+ *     adoption time (kindForMime) and that answer is the right one. The mime is
+ *     only a fallback for a row that somehow carries none.
+ *   - the URL follows the same rule the send path uses: an EXEMPT original IS
+ *     the file (srcUrl), a compressed pick's bytes are the artifact (artUrl).
+ *   - a row with no URL at all (node, where there is no createObjectURL) is
+ *     skipped rather than pushed as an entry that can only fail to load.
+ */
+export function localPlayableEntries(items) {
+  const out = [];
+  for (const it of items || []) {
+    if (!it) continue;
+    const url = normalizeState(it.state) === 'exempt'
+      ? (it.srcUrl || it.artUrl || '')
+      : (it.artUrl || it.srcUrl || '');
+    if (!url) continue;
+    let kind = it.kind === 'video' ? 'video' : (it.kind === 'image' ? 'image' : '');
+    if (!kind && it.mime) kind = kindOfMime(it.mime);
+    if (!kind) continue;
+    out.push({ kind, name: String(it.name || ''), url: String(url) });
+  }
+  return out;
+}
+
+/** The mime family the wire insists a `kind` agrees with (mediaChannel familyOf). */
+function kindOfMime(mime) { return String(mime || '').indexOf('video/') === 0 ? 'video' : 'image'; }
+
 /** The wire mime for a picked file, or '' when the wire would refuse it. */
 export function localMimeOf(file) {
   const typed = String((file && file.type) || '').toLowerCase();
@@ -827,6 +864,10 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    * purpose: every hosted `cache-list` commit REPLACES `items` wholesale, and
    * local picks must survive that. Merged into `itemsArr` by rebuildArr(). */
   const localItems = new Map();
+  /** Bumped on every MEMBERSHIP change of `localItems`. boot.js re-feeds the
+   * media deck off this, so a hosted `cache-list` (which fires the same
+   * `onItems` subscribers) cannot make it re-deal the pool for nothing. */
+  let localVersion = 0;
   let itemsArr = [];
   let listLoaded = false;
   let listRequested = false;
@@ -1087,7 +1128,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
   }
 
   /** The mime family the wire insists a `kind` agrees with (mediaChannel familyOf). */
-  const kindForMime = (mime) => (String(mime || '').indexOf('video/') === 0 ? 'video' : 'image');
+  const kindForMime = kindOfMime;
 
   /**
    * Source shas already adopted (or already refused) this session. The OUTPUT of
@@ -1154,6 +1195,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
       state: 'exempt', srcUrl, sha, ext: m ? m[1].toLowerCase() : '', mime,
       bytes, srcBytes: bytes,
     }));
+    localVersion++;
     localSrcShas.add(sha);
     report.added++;
     noteItemLanded();
@@ -1279,6 +1321,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
       bytes, srcBytes: Math.max(bytes, Number(srcBytes) || 0),
       w: w || 0, h: h || 0, durMs: durMs || 0,
     }));
+    localVersion++;
     localSrcShas.add(sha);
     report.added++;
     if (compressed) report.compressed++;
@@ -1446,6 +1489,7 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     const it = localItems.get(String(id));
     if (!it) return false;
     localItems.delete(String(id));
+    localVersion++;
     // A compressed pick's bytes live behind `artUrl`, not `srcUrl` — revoking
     // only the latter leaks the whole artifact for the life of the page.
     revokeLocal(it);
@@ -1536,6 +1580,19 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
 
     /** Files the player picked in the browser (standalone's whole library). */
     get localCount() { return localItems.size; },
+
+    /** Those files, as an array. A snapshot — mutating it changes nothing. */
+    get localItems() { return Array.from(localItems.values()); },
+
+    /**
+     * Bumped whenever a local item is added or removed, and NEVER by a hosted
+     * `cache-list`. boot.js watches it so the media deck is only re-dealt when
+     * the player's own library actually moved (see localPlayableEntries above).
+     */
+    get localVersion() { return localVersion; },
+
+    /** The local library as exec/media.js deck entries. Convenience over the pure fn. */
+    localDeck() { return localPlayableEntries(Array.from(localItems.values())); },
 
     /**
      * ADOPTION PROGRESS — fires immediately with the current value, then on

--- a/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
@@ -12,7 +12,12 @@
  *      `hello` that carries it;
  *   4. a STANDALONE answer. In a plain browser there is no host and therefore no
  *      cache, and the screen must say so immediately — a spinner that can never
- *      resolve is the worst of the three possible outcomes.
+ *      resolve is the worst of the three possible outcomes;
+ *   5. the STANDALONE LIBRARY itself — files the player picks (or a zip of
+ *      them), adopted here and sent straight from this page. Anything over the
+ *      wire's exempt cap is COMPRESSED IN THE PAGE (ui/localCompress.js) into an
+ *      artifact that fits, exactly as the C# app would have; see the adoption
+ *      policy on adoptLocalFile.
  *
  * NOTHING here touches the DOM, and nothing throws at import: the module is
  * imported by the node selftests with a fake bridge injected.
@@ -28,8 +33,9 @@
 
 import * as defaultBridge from '../bridge.js';
 import { decodeFilmstrip, closeFilmstrip, mimeForKind, fitBox } from '../encode/gifDecode.js';
-import { ACCEPT_MIME, MAX_EXEMPT_BYTES } from '../net/mediaChannel.js';
-import { isZipFile, readZipMedia, ZIP_MAX_TOTAL_BYTES } from './zipReader.js';
+import { ACCEPT_MIME, MAX_ARTIFACT_BYTES, MAX_EXEMPT_BYTES } from '../net/mediaChannel.js';
+import { isZipFile, readZipMedia, ZIP_MAX_ENTRIES, ZIP_MAX_TOTAL_BYTES } from './zipReader.js';
+import { createLocalCompressor, extForMime, sniffAnimated, MAX_DECODE_BYTES } from './localCompress.js';
 
 /* ----------------------------------------------------------------- units */
 
@@ -59,28 +65,78 @@ export const FILTERS = Object.freeze(['all', 'needs', 'ready', 'failed', 'exempt
 export const NEEDS_STATES = Object.freeze(['pending', 'queued', 'working']);
 
 /* ------------------------------------------------------- local (browser) files
- * Standalone has no host library, so the page can adopt files the player picks
- * by hand. They ride the EXEMPT path: sent as-is, so they obey the exempt cap
- * and the wire's mime allowlist — both imported from mediaChannel so this can
- * never drift from what the receiver's offer gate will actually accept.
+ * Standalone has no host library, so the page adopts what the player picks. The
+ * caps below are the wire's own (imported from mediaChannel, so they can never
+ * drift from what the receiver's offer gate will actually accept) and there are
+ * TWO of them, which is the whole shape of this tier:
+ *
+ *   ≤ MAX_EXEMPT_BYTES (8 MB)    sent AS-IS, on the exempt path. Never
+ *                                recompressed: it already fits, and re-encoding
+ *                                something that fits only loses quality.
+ *   ≤ MAX_ARTIFACT_BYTES (24 MB) the ceiling for a NON-exempt artifact — what
+ *                                the transfer queue allows once an item is a
+ *                                compressed product rather than an original.
+ *
+ * Everything between those two, and everything above the second, used to be
+ * "too big" and was skipped. That was wrong: a 1 GB zip of photos is the USE
+ * CASE, and the page can put a 12 MB photo through a canvas the same way the C#
+ * app puts it through its still lane. See ui/localCompress.js.
  * ------------------------------------------------------------------------- */
 
 export const LOCAL_MAX_BYTES = MAX_EXEMPT_BYTES;
+
+/** The wire ceiling for a COMPRESSED (non-exempt) artifact. */
+export const LOCAL_ARTIFACT_MAX_BYTES = MAX_ARTIFACT_BYTES;
+
+/**
+ * The biggest SOURCE we will decode. A decode costs width*height*4 bytes of
+ * RGBA no matter what the file weighs, so this is a phone-memory guard, not a
+ * wire limit — past it a still is counted `tooBig` rather than attempted.
+ */
+export const LOCAL_DECODE_MAX_BYTES = MAX_DECODE_BYTES;
 
 /**
  * A .zip is a pick too: phones cannot hand over a folder, so an archive is the
  * only way a player on a phone gives us a library. It is expanded INLINE by
  * ui/zipReader.js and every eligible entry walks the same adoption road as a
  * hand-picked file — same mime gate, same per-file cap, same sha, same dedup.
- * The archive is read into memory whole, so past this size we do not try.
+ *
+ * THIS IS NOT AN ARCHIVE-SIZE LIMIT. There is none: zipReader reads a zip by
+ * Blob range and never holds more than one entry, so a 1 GB library costs a
+ * directory plus one photo. This is the ceiling on the INFLATED total taken out
+ * of one archive — the zip-bomb guard, checked against declared sizes.
  */
-export const LOCAL_ZIP_MAX_BYTES = ZIP_MAX_TOTAL_BYTES;
+export const LOCAL_ZIP_MAX_INFLATED_BYTES = ZIP_MAX_TOTAL_BYTES;
+
+/** Entries taken from one archive before the rest is `trimmed` (and said so). */
+export const LOCAL_ZIP_MAX_ENTRIES = ZIP_MAX_ENTRIES;
 
 /** Phones love to hand over files with an empty `type`; the extension decides. */
 export const LOCAL_MIME_BY_EXT = Object.freeze({
   png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
   webp: 'image/webp', mp4: 'video/mp4', m4v: 'video/mp4', webm: 'video/webm',
 });
+
+/**
+ * Which road a file of this mime and this size takes, judged on SIZE ALONE.
+ *
+ * Exported and pure because it is applied in TWO places that must not disagree:
+ * adoptLocalFile (on the real bytes) and the zip reader's directory pass (on the
+ * declared size, before anything is inflated).
+ *
+ * @returns {'take'|'too-big'|'too-big-video'} 'take' means "the store has a road
+ *   for this" — exempt, as-is artifact, or compressed artifact; which one is
+ *   adoptLocalFile's business.
+ */
+export function classifyLocalSize(mime, bytes) {
+  const size = Math.max(0, Number(bytes) || 0);
+  if (!size) return 'too-big';
+  if (size <= LOCAL_MAX_BYTES) return 'take';
+  if (String(mime || '').indexOf('video/') === 0) {
+    return size <= LOCAL_ARTIFACT_MAX_BYTES ? 'take' : 'too-big-video';
+  }
+  return size <= LOCAL_DECODE_MAX_BYTES ? 'take' : 'too-big';
+}
 
 /** The wire mime for a picked file, or '' when the wire would refuse it. */
 export function localMimeOf(file) {
@@ -755,9 +811,15 @@ function normalizeItem(raw) {
  * @param {boolean} [o.autoEncoder] build the lane-B driver when the probe says
  *   this runtime can encode (default true). Off, the seam stays empty and the
  *   host's encode-requests are dropped with one log line, exactly as before.
+ * @param {{compressImage:Function, compressGif:Function}} [o.compressor] the
+ *   standalone compression lanes. Injectable so the node selftest can drive the
+ *   ADOPTION POLICY (which lane, which counter, which sha) with a stub — there
+ *   is no canvas, no createImageBitmap and no WebCodecs under node, so the real
+ *   one is only ever exercised in a browser. Default: ui/localCompress.js,
+ *   built lazily on the first file that actually needs it.
  */
 export function createAssetsStore({ bridge = defaultBridge, session = null, logger = null,
-  autoHello = true, autoEncoder = true } = {}) {
+  autoHello = true, autoEncoder = true, compressor: injectedCompressor = null } = {}) {
   const state = blankState();
   /** id -> item */
   const items = new Map();
@@ -963,20 +1025,120 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
 
   const hex = (buf) => Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');
 
+  /* --------------------------------------------------- the adoption progress
+   * Adding used to be instant, because adopting meant hashing. It is not any
+   * more: a zip of 200 photos is 200 decodes and 200 encodes, and a card that
+   * says nothing for four minutes reads as a broken button. This is the seam
+   * the standalone card watches — one object, mutated in place, emitted on
+   * every step. `total` grows when a zip's plan lands (an archive counts as one
+   * pick until we know how many entries survived pass 1).
+   * ---------------------------------------------------------------------- */
+
+  const localProgress = { running: false, done: 0, total: 0, name: '', pct: 0 };
+  const localProgressSubs = new Set();
+
+  function emitLocalProgress() {
+    for (const fn of Array.from(localProgressSubs)) {
+      try { fn(localProgress); } catch (e) { warn('local-progress subscriber threw: ' + ((e && e.message) || e)); }
+    }
+  }
+
+  /** One pick (or one zip entry) is finished, whatever the verdict. */
+  function noteStep(name) {
+    localProgress.done += 1;
+    localProgress.name = String(name || '');
+    localProgress.pct = 0;
+    emitLocalProgress();
+  }
+
+  /** A long compression is talking. Only the percentage moves. */
+  function noteWorking(name, pct) {
+    if (!localProgress.running) return;
+    localProgress.name = String(name || '');
+    localProgress.pct = Math.min(100, Math.max(0, Math.round(Number(pct) || 0)));
+    emitLocalProgress();
+  }
+
+  /* Items are emitted AS THEY LAND, so a long zip fills the list instead of
+   * appearing all at once at the end — but coalesced, because a 500-entry
+   * archive that repainted the list 500 times would spend longer in layout than
+   * in the encoder. The final emit in addLocalFiles is unconditional, so the
+   * last few always land. */
+  const LOCAL_EMIT_MS = 200;
+  let lastLocalEmit = 0;
+  function noteItemLanded() {
+    const now = Date.now();
+    if (now - lastLocalEmit < LOCAL_EMIT_MS) return;
+    lastLocalEmit = now;
+    rebuildArr();
+    emitItems();
+  }
+
+  /** Every object URL one local item owns, released. */
+  function revokeLocal(it) {
+    for (const u of [it && it.srcUrl, it && it.artUrl]) {
+      try { if (u) URL.revokeObjectURL(u); } catch (_e) { /* ignore */ }
+    }
+  }
+
+  /** sha-256 of a File/Blob's bytes, or '' when it could not be read. */
+  async function shaOfBytes(buf) {
+    return hex(await crypto.subtle.digest('SHA-256', buf));
+  }
+
+  /** The mime family the wire insists a `kind` agrees with (mediaChannel familyOf). */
+  const kindForMime = (mime) => (String(mime || '').indexOf('video/') === 0 ? 'video' : 'image');
+
+  /**
+   * Source shas already adopted (or already refused) this session. The OUTPUT of
+   * a compression is what carries the wire identity, so dedup on the output sha
+   * alone would still re-compress the same 40 MB photo every time the player
+   * picked the same zip — minutes of a phone's CPU to arrive back at a dupe.
+   */
+  const localSrcShas = new Set();
+
+  /** The compressor. Injectable — the node selftest drives the POLICY with a stub. */
+  let compressor = injectedCompressor;
+  function ensureCompressor() {
+    if (!compressor) {
+      try { compressor = createLocalCompressor({ logger }); } catch (e) {
+        warn('no local compressor: ' + ((e && e.message) || e));
+        compressor = null;
+      }
+    }
+    return compressor;
+  }
+
   /**
    * ONE file (picked by hand, or lifted out of a zip) down the ONE adoption
    * road. Every counter the summary line reads is written here, so a zip entry
    * and a hand-picked file can never be judged by two different rules.
+   *
+   * THE POLICY, in the order it is applied:
+   *   1. not a mime the wire carries        -> badType
+   *   2. ≤ 8 MB                             -> EXEMPT, as-is, untouched
+   *   3. video 8..24 MB                     -> non-exempt artifact, as-is (no transcode)
+   *   4. video > 24 MB                      -> tooBigVideo (its own sentence)
+   *   5. still/animated > 80 MB source      -> tooBig (we will not decode that)
+   *   6. animated gif/awebp > 8 MB          -> mp4 artifact, via lane B's worker
+   *   7. still > 8 MB                       -> WebP (or JPEG) artifact
+   *   8. any compressed output > 24 MB      -> failed (pathological; nothing to send)
    */
   async function adoptLocalFile(f, report) {
     if (!f || typeof f.arrayBuffer !== 'function') { report.failed++; return; }
     const mime = localMimeOf(f);
     if (!mime) { report.badType++; return; }
     const bytes = Math.max(0, Number(f.size) || 0);
-    if (!bytes || bytes > LOCAL_MAX_BYTES) { report.tooBig++; return; }
+    if (!bytes) { report.tooBig++; return; }
+    if (bytes <= LOCAL_MAX_BYTES) return await adoptExempt(f, mime, bytes, report);
+    return await adoptOversize(f, mime, bytes, report);
+  }
+
+  /** The original travels untouched. This is the path that has always existed. */
+  async function adoptExempt(f, mime, bytes, report) {
     let sha = '';
     try {
-      sha = hex(await crypto.subtle.digest('SHA-256', await f.arrayBuffer()));
+      sha = await shaOfBytes(await f.arrayBuffer());
     } catch (e) {
       warn('could not hash "' + String(f.name || '?') + '": ' + ((e && e.message) || e));
       report.failed++; return;
@@ -988,11 +1150,139 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     try { srcUrl = URL.createObjectURL(f); } catch (_e) { /* node selftest — no object URLs */ }
     const m = /\.([a-z0-9]{2,5})$/i.exec(String(f.name || ''));
     localItems.set(id, normalizeItem({
-      id, name: String(f.name || sha.slice(0, 8)), kind: mime.startsWith('video/') ? 'video' : 'image',
+      id, name: String(f.name || sha.slice(0, 8)), kind: kindForMime(mime),
       state: 'exempt', srcUrl, sha, ext: m ? m[1].toLowerCase() : '', mime,
       bytes, srcBytes: bytes,
     }));
+    localSrcShas.add(sha);
     report.added++;
+    noteItemLanded();
+  }
+
+  /**
+   * Everything over the exempt cap. What lands is a NON-EXEMPT ARTIFACT: state
+   * 'ready' with an `artUrl`, which is exactly the shape boot.js listSendable()
+   * offers under the 24 MB rail (`bytes <= MAX_ARTIFACT_BYTES`), and exactly the
+   * shape the host's own compressed items have.
+   */
+  async function adoptOversize(f, mime, bytes, report) {
+    const name = String(f.name || 'file');
+
+    /* --- video: as-is up to the artifact cap, and honest above it ----------
+     * A browser cannot re-encode an mp4 without decoding every frame through
+     * WebCodecs, at a cost we cannot promise on a phone. So an 8..24 MB clip
+     * rides the wire as the artifact it already is, and anything bigger is
+     * COUNTED AND NAMED rather than quietly dropped. */
+    if (kindForMime(mime) === 'video') {
+      if (bytes > LOCAL_ARTIFACT_MAX_BYTES) { report.tooBigVideo++; return; }
+      let buf = null;
+      try { buf = await f.arrayBuffer(); } catch (e) {
+        warn('could not read "' + name + '": ' + ((e && e.message) || e));
+        report.failed++; return;
+      }
+      let sha = '';
+      try { sha = await shaOfBytes(buf); } catch (_e) { report.failed++; return; }
+      if (disposed) return;
+      landArtifact({ name, blob: f, sha, mime, bytes, srcBytes: bytes, report });
+      return;
+    }
+
+    if (bytes > LOCAL_DECODE_MAX_BYTES) { report.tooBig++; return; }
+
+    let buf = null;
+    try { buf = await f.arrayBuffer(); } catch (e) {
+      warn('could not read "' + name + '": ' + ((e && e.message) || e));
+      report.failed++; return;
+    }
+    if (disposed) return;
+
+    // The SOURCE sha, so picking the same archive twice does not pay for the
+    // same compression twice. The wire identity is still the OUTPUT's sha.
+    let srcSha = '';
+    try { srcSha = await shaOfBytes(buf); } catch (_e) { srcSha = ''; }
+    if (disposed) return;
+    if (srcSha && localSrcShas.has(srcSha)) { report.dupes++; return; }
+
+    const comp = ensureCompressor();
+    if (!comp) { report.failed++; return; }
+
+    // GIF and WebP are both "maybe animated", and the answer decides the lane:
+    // an animated file put through the still lane loses every frame but one.
+    // 'unknown' is read as animated on purpose — a one-frame mp4 costs bytes, a
+    // one-frame GIF costs the file.
+    const animated = mime === 'image/gif' || mime === 'image/webp'
+      ? sniffAnimated(new Uint8Array(buf), mime) !== 'still'
+      : false;
+
+    let out = null;
+    try {
+      out = animated
+        ? await comp.compressGif(buf, mime, { onProgress: (pct) => noteWorking(name, pct) })
+        : await comp.compressImage(buf, mime, {});
+    } catch (e) {
+      warn('could not compress "' + name + '" (' + mime + ', ' + formatBytes(bytes) + '): '
+        + ((e && e.message) || e));
+      if (srcSha) localSrcShas.add(srcSha);          // do not try it again this session
+      report.failed++;
+      return;
+    }
+    if (disposed) return;
+    if (!out || !out.blob || !(Number(out.blob.size) > 0)) { report.failed++; return; }
+
+    const outMime = String(out.mime || out.blob.type || '');
+    if (!ACCEPT_MIME.has(outMime)) {
+      warn('compressor produced "' + outMime + '" for "' + name + '", which the wire will not carry');
+      report.failed++; return;
+    }
+    const outBytes = Number(out.blob.size) || 0;
+    // The 24 MB rail is the transfer queue's, and an artifact past it is simply
+    // un-offerable — adopting it would put an item on the screen that can never
+    // be sent, which is worse than saying it did not work.
+    if (outBytes > LOCAL_ARTIFACT_MAX_BYTES) {
+      warn('"' + name + '" compressed to ' + formatBytes(outBytes) + ', past the '
+        + formatBytes(LOCAL_ARTIFACT_MAX_BYTES) + ' wire cap');
+      if (srcSha) localSrcShas.add(srcSha);
+      report.failed++; return;
+    }
+
+    let sha = '';
+    try { sha = await shaOfBytes(await out.blob.arrayBuffer()); } catch (e) {
+      warn('could not hash the compressed "' + name + '": ' + ((e && e.message) || e));
+      report.failed++; return;
+    }
+    if (disposed) return;
+    if (srcSha) localSrcShas.add(srcSha);
+    landArtifact({
+      name, blob: out.blob, sha, mime: outMime, bytes: outBytes, srcBytes: bytes,
+      w: out.w, h: out.h, durMs: out.durMs, compressed: true, report,
+    });
+  }
+
+  /**
+   * Commit one non-exempt artifact.
+   *
+   * `state: 'ready'` + `artUrl` is not decoration: listSendable() reads `artUrl`
+   * for anything that is not exempt, and `bytes` must be the ARTIFACT's length
+   * because that is the number the receiver's offer gate checks against its own
+   * 24 MB cap. `kind` is derived from the OUTPUT mime, never carried over from
+   * the source — the offer gate declines any offer whose kind and mime disagree,
+   * and a GIF that became an mp4 changes family.
+   */
+  function landArtifact({ name, blob, sha, mime, bytes, srcBytes, w, h, durMs, compressed, report }) {
+    const id = 'local:' + sha;
+    if (localItems.has(id)) { report.dupes++; return; }
+    let artUrl = '';
+    try { artUrl = URL.createObjectURL(blob); } catch (_e) { /* node selftest — no object URLs */ }
+    localItems.set(id, normalizeItem({
+      id, name, kind: kindForMime(mime), state: 'ready',
+      artUrl, sha, ext: extForMime(mime), mime,
+      bytes, srcBytes: Math.max(bytes, Number(srcBytes) || 0),
+      w: w || 0, h: h || 0, durMs: durMs || 0,
+    }));
+    localSrcShas.add(sha);
+    report.added++;
+    if (compressed) report.compressed++;
+    noteItemLanded();
   }
 
   /**
@@ -1017,62 +1307,138 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
   }
 
   /**
-   * Expand one picked archive. Everything the reader refuses lands in the same
-   * counters a hand-picked refusal would (an entry over the exempt cap is
-   * `tooBig`, a bomb-guard truncation and a corrupt archive are `failed`), so
-   * the summary line needs no zip-shaped vocabulary to stay honest.
+   * Expand one picked archive.
+   *
+   * THE FILE ITSELF GOES TO THE READER, never its bytes: readZipMedia slices
+   * the ranges it needs, so nothing on this path ever calls arrayBuffer() on a
+   * multi-gigabyte pick. (addLocalFiles routes on isZipFile BEFORE
+   * adoptLocalFile, which is the only other place a pick gets read whole — it
+   * hashes what it adopts.)
+   *
+   * PER-ENTRY refusals land in the same counters a hand-picked refusal would
+   * (an entry over the exempt cap is `tooBig`, a bomb-guard truncation is
+   * `failed`). An ARCHIVE-level failure gets its own counter and its own line,
+   * because rendering it as `tooBig` is exactly how a 1 GB library once got
+   * told "1 over 8 MB".
    */
   async function expandLocalZip(file, report) {
-    if (!file || typeof file.arrayBuffer !== 'function') { report.failed++; return; }
-    const size = Math.max(0, Number(file.size) || 0);
-    if (size > LOCAL_ZIP_MAX_BYTES) {
-      warn('zip "' + String(file.name || '?') + '" is ' + formatBytes(size) + ' — too big to open');
-      report.tooBig++; return;
-    }
+    if (!file || typeof file.slice !== 'function') { report.zipBad++; noteStep(file && file.name); return; }
     let res = null;
+    let planned = 0;
     try {
-      res = await readZipMedia(await file.arrayBuffer(), {
+      res = await readZipMedia(file, {
         // The mime table stays owned by this module: what the picker accepts,
         // what the zip adopts and what the wire allows are ONE decision.
         isEligible: (name) => !!localMimeOf({ name, type: '' }),
-        maxEntryBytes: LOCAL_MAX_BYTES,
+        // ...and so is the SIZE policy. This mirrors adoptLocalFile exactly,
+        // from the DECLARED size in the directory, so an entry the store could
+        // never use is never sliced, never inflated and never decoded — and the
+        // two refusals stay distinguishable ("compressible" vs "un-sendable").
+        classify: (name, size) => classifyLocalSize(localMimeOf({ name, type: '' }), size),
+        maxEntryBytes: LOCAL_DECODE_MAX_BYTES,
+        onPlan: (n) => {
+          planned = Math.max(0, Number(n) || 0);
+          // The archive counted as ONE pick until now; it is really `planned`.
+          localProgress.total += Math.max(0, planned - 1);
+          emitLocalProgress();
+        },
+        // STREAMED, not collected: each entry is adopted (hashed, compressed if
+        // it must be, turned into a blob URL) and dropped before the next is
+        // inflated, so an archive of five hundred photos never has five hundred
+        // photos in the heap at once.
+        onEntry: async (e) => {
+          if (disposed) return;
+          const emime = localMimeOf({ name: e.name, type: '' });
+          noteWorking(e.name, 0);
+          await adoptLocalFile(fileFromBytes(e.name, e.bytes, emime), report);
+          noteStep(e.name);
+        },
       });
     } catch (e) {
       warn('zip "' + String(file.name || '?') + '" threw: ' + ((e && e.message) || e));
       res = null;
     }
-    if (!res || !res.ok) { report.failed++; return; }
+    if (!res || !res.ok) {
+      warn('zip "' + String(file.name || '?') + '" (' + formatBytes(file.size) + ') could not be opened: '
+        + String((res && res.reason) || 'threw'));
+      // The plan's entries never happened; give the denominator back, then take
+      // the archive's own one step.
+      if (planned > 1) localProgress.total -= (planned - 1);
+      report.zipBad++;
+      noteStep(file.name);
+      return;
+    }
+    // An archive that planned nothing still consumed a pick's worth of the bar.
+    if (planned <= 0) noteStep(file.name);
     report.zips++;
     report.tooBig += res.tooBig;
+    report.tooBigVideo += res.tooBigVideo || 0;
     report.failed += res.failed;
-    info('zip "' + String(file.name || '?') + '": ' + res.entries.length + ' media entr(ies), '
-      + res.skipped + ' skipped' + (res.truncated ? ' (truncated — the archive is past the ceilings)' : ''));
-    for (const e of res.entries) {
-      if (disposed) return;
-      await adoptLocalFile(fileFromBytes(e.name, e.bytes, localMimeOf({ name: e.name, type: '' })), report);
-    }
+    // NOT `failed`: entry 501, or the inflated-total backstop, means we TOOK THE
+    // FIRST N of a real library. Rendering that as "unreadable" is the same
+    // class of lie the per-file cap text was on an archive failure.
+    report.trimmed += res.trimmed || 0;
+    info('zip "' + String(file.name || '?') + '" (' + formatBytes(file.size) + '): ' + res.took
+      + ' media entr(ies), ' + res.skipped + ' skipped'
+      + (res.truncated ? ' (trimmed — the archive is past the ceilings)' : ''));
   }
 
   /**
-   * Adopt player-picked files as sendable EXEMPT items. The sha-256 computed
-   * here is only the OFFER identity — the receiving host re-hashes what actually
+   * Adopt player-picked files as sendable items. The sha-256 computed here is
+   * only the OFFER identity — the receiving host re-hashes what actually
    * arrives, so lying about it buys nothing but a declined transfer.
    * Session-only: blob URLs do not survive a reload, and neither do these.
    *
    * A picked .zip is EXPANDED, not adopted: its eligible media becomes items,
    * one entry at a time, and the archive itself never becomes a sendable thing.
    *
+   * SERIAL, deliberately. Compression is CPU, not IO: two encodes racing on a
+   * phone finish later than the same two in a row and make the page unusable in
+   * between. Progress is surfaced through `onLocalProgress` as each one lands.
+   *
    * @param {ArrayLike<File>} files
-   * @returns {Promise<{added:number, dupes:number, tooBig:number, badType:number, failed:number, zips:number}>}
+   * @returns {Promise<{added:number, compressed:number, dupes:number, tooBig:number,
+   *   tooBigVideo:number, trimmed:number, badType:number, failed:number,
+   *   zips:number, zipBad:number}>}
    */
   async function addLocalFiles(files) {
-    const report = { added: 0, dupes: 0, tooBig: 0, badType: 0, failed: 0, zips: 0 };
-    for (const f of Array.from(files || [])) {
-      if (disposed) break;
-      if (isZipFile(f)) { await expandLocalZip(f, report); continue; }
-      await adoptLocalFile(f, report);
+    const report = {
+      added: 0, compressed: 0, dupes: 0, tooBig: 0, tooBigVideo: 0, trimmed: 0,
+      badType: 0, failed: 0, zips: 0, zipBad: 0,
+    };
+    const list = Array.from(files || []);
+    // Re-entrant adds (the player picks again while a zip is still expanding)
+    // extend the same run rather than resetting the denominator under it.
+    localProgress.total = (localProgress.running ? localProgress.total : 0) + list.length;
+    if (!localProgress.running) { localProgress.running = true; localProgress.done = 0; }
+    localProgress.name = '';
+    localProgress.pct = 0;
+    emitLocalProgress();
+    try {
+      for (const f of list) {
+        if (disposed) break;
+        if (isZipFile(f)) {
+          // A zip's step accounting is its OWN: it counted as one pick until its
+          // plan landed, and after that its entries are the steps. Stepping here
+          // as well would push `done` past `total` on every archive.
+          noteWorking(String(f.name || ''), 0);
+          await expandLocalZip(f, report);
+          continue;
+        }
+        noteWorking(String(f.name || ''), 0);
+        await adoptLocalFile(f, report);
+        noteStep(String(f.name || ''));
+      }
+    } finally {
+      localProgress.running = false;
+      localProgress.name = '';
+      localProgress.pct = 0;
+      emitLocalProgress();
     }
-    if (report.added) { rebuildArr(); emitItems(); }
+    // Unconditional: the coalescer may be holding the last few items back, and
+    // "added 40" with 37 rows on screen is a bug report.
+    rebuildArr();
+    emitItems();
     return report;
   }
 
@@ -1080,7 +1446,9 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     const it = localItems.get(String(id));
     if (!it) return false;
     localItems.delete(String(id));
-    try { if (it.srcUrl) URL.revokeObjectURL(it.srcUrl); } catch (_e) { /* ignore */ }
+    // A compressed pick's bytes live behind `artUrl`, not `srcUrl` — revoking
+    // only the latter leaks the whole artifact for the life of the page.
+    revokeLocal(it);
     rebuildArr();
     emitItems();
     return true;
@@ -1169,6 +1537,22 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     /** Files the player picked in the browser (standalone's whole library). */
     get localCount() { return localItems.size; },
 
+    /**
+     * ADOPTION PROGRESS — fires immediately with the current value, then on
+     * every step of an `addLocalFiles` run. `{running, done, total, name, pct}`,
+     * where `pct` is only meaningful during a compression. Read it, never mutate
+     * it (the same contract as `state`).
+     */
+    onLocalProgress(fn) {
+      if (typeof fn !== 'function') return () => {};
+      localProgressSubs.add(fn);
+      try { fn(localProgress); } catch (e) { warn('local-progress subscriber threw: ' + ((e && e.message) || e)); }
+      return () => localProgressSubs.delete(fn);
+    },
+
+    /** Live adoption progress. Same object every time — do not keep a copy. */
+    get localProgress() { return localProgress; },
+
     requestList, compressAll, compress, cancel, pause, resume, deleteOne, deleteAll, setCap,
     addLocalFiles, removeLocal,
 
@@ -1186,12 +1570,18 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
       disposed = true;
       stateSubs.clear();
       itemSubs.clear();
-      for (const it of localItems.values()) {
-        try { if (it.srcUrl) URL.revokeObjectURL(it.srcUrl); } catch (_e) { /* ignore */ }
-      }
+      localProgressSubs.clear();
+      for (const it of localItems.values()) revokeLocal(it);
       localItems.clear();
+      localSrcShas.clear();
       encodeHandler = null;
       if (encoder) { try { encoder.dispose(); } catch (_e) { /* ignore */ } encoder = null; }
+      // The compressor owns a Worker when the page ever built one; a disposed
+      // store that leaves it running keeps a whole encoder thread alive.
+      if (compressor && compressor !== injectedCompressor) {
+        try { compressor.dispose?.(); } catch (_e) { /* ignore */ }
+      }
+      compressor = null;
       for (const t of OWNED_TYPES) { try { bridge.off(t); } catch (_e) { /* ignore */ } }
     },
   };

--- a/ConditioningControlPanel/Resources/web/goon/ui/debugOverlay.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/debugOverlay.js
@@ -1,0 +1,216 @@
+/* ============================================================================
+ * ui/debugOverlay.js — the console a phone does not have.
+ *
+ * WHY THIS EXISTS. The page's worst failures are SILENT: a guest joins, the
+ * lobby paints for a second, and the player is back on the title with nothing
+ * written anywhere they can read. On the desktop that is one devtools tab away;
+ * on an iPhone in a bedroom it is unfalsifiable. Hosted, `logger.warn/error`
+ * tunnel to the C# log and the answer is in `logs/crash.log` — STANDALONE there
+ * is no C# and no log, so the same lines go nowhere at all.
+ *
+ * So: a fixed, high-z, tap-to-collapse strip that mirrors the last MAX_LINES
+ * warn/error lines, plus every window.onerror and unhandledrejection. Tiny,
+ * monospace, no dependencies, no styling from goon.css (a broken stylesheet must
+ * not be able to hide the thing that explains the break).
+ *
+ * HARD RULES
+ *   1. NOTHING at module import touches document/window/localStorage — this file
+ *      is swept by the node import test like every other module.
+ *   2. It never loads unless asked: `?debug=1`. Standalone the answer is
+ *      remembered in `goon.prefs` (bridge.js persists it next to server/token),
+ *      so a reload — or a home-screen pin that dropped the query — keeps it on.
+ *      HOSTED IT IS ALWAYS EXPLICIT: a WebView2 session must never grow a debug
+ *      strip because a browser tab once had one.
+ *   3. It never touches gameplay. One <div> appended to <body>, pointer-events
+ *      on itself only, no listeners on anything it does not own, and every entry
+ *      point is wrapped — a logger tee that can throw would turn a warning into
+ *      a crash, which is the exact inversion of the point.
+ * ==========================================================================*/
+
+/** The querystring flag, and the key bridge.js parks it under in goon.prefs. */
+export const DEBUG_PARAM = 'debug';
+export const DEBUG_PREF_KEY = 'debug';
+/** Ring size. Small on purpose: the last 50 lines are the ones that explain it. */
+export const MAX_LINES = 50;
+/** Above #gg-modal (70), above the mercy button, above anything a wave adds. */
+export const OVERLAY_Z = 2147483000;
+
+const ON = /^(1|true|on|yes)$/i;
+
+/** Is the flag on in a raw querystring? `?debug=1`, `?debug` and `?debug=true` all count. */
+export function debugInSearch(search) {
+  const s = String(search || '');
+  if (!s) return false;
+  try {
+    const q = new URLSearchParams(s.charAt(0) === '?' ? s.slice(1) : s);
+    if (!q.has(DEBUG_PARAM)) return false;
+    const v = q.get(DEBUG_PARAM);
+    return v === '' || ON.test(String(v));
+  } catch (_e) { return false; }
+}
+
+/**
+ * The whole decision, as one pure function so it is testable under node.
+ * @param {object} o
+ * @param {string} [o.search] location.search
+ * @param {object} [o.prefs] the parsed goon.prefs blob (standalone only)
+ * @param {boolean} [o.hosted] inside WebView2
+ */
+export function debugRequested({ search = '', prefs = null, hosted = false } = {}) {
+  if (debugInSearch(search)) return true;
+  if (hosted) return false;                       // rule 2: hosted is explicit, always
+  const v = prefs && typeof prefs === 'object' ? prefs[DEBUG_PREF_KEY] : undefined;
+  return v === true || (typeof v === 'string' && ON.test(v));
+}
+
+function stamp(now) {
+  const d = new Date(now);
+  const p = (n, w) => String(n).padStart(w, '0');
+  return `${p(d.getHours(), 2)}:${p(d.getMinutes(), 2)}:${p(d.getSeconds(), 2)}.${p(d.getMilliseconds(), 3)}`;
+}
+
+/** Flatten anything a logger, an ErrorEvent or a rejection reason can carry. */
+export function describe(v) {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'string') return v;
+  if (v instanceof Error || (v && typeof v.message === 'string' && typeof v.stack === 'string')) {
+    return String(v.message) + (v.stack ? ' | ' + String(v.stack).split('\n').slice(1, 3).join(' <- ') : '');
+  }
+  try { return JSON.stringify(v); } catch (_e) { return String(v); }
+}
+
+/**
+ * Build the strip. Returns a handle even when there is no DOM (node, or a page
+ * that never asked for it) — every method is a no-op then, so callers never
+ * branch on whether the overlay exists.
+ *
+ * @param {object} [o]
+ * @param {Document} [o.doc] injectable for the self-test's stub DOM
+ * @param {number} [o.max] ring size
+ * @param {() => number} [o.now] injectable clock
+ * @returns {{push:(level:string,msg:any)=>void, lines:()=>string[], collapsed:()=>boolean,
+ *            toggle:()=>void, node:object|null, dispose:()=>void}}
+ */
+export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Date.now() } = {}) {
+  const d = doc || (typeof document !== 'undefined' ? document : null);
+  const ring = [];
+  let root = null;
+  let body = null;
+  let badge = null;
+  let collapsed = false;
+  let disposed = false;
+  const cap = Math.max(1, max | 0);
+
+  const noop = {
+    push() {}, lines() { return []; }, collapsed() { return false; },
+    toggle() {}, node: null, dispose() {},
+  };
+  if (!d || !d.body || typeof d.createElement !== 'function') return noop;
+
+  const style = (node, css) => { try { node.setAttribute('style', css); } catch (_e) { /* stub DOM */ } };
+
+  try {
+    root = d.createElement('div');
+    root.id = 'gg-debug';
+    style(root,
+      'position:fixed;left:0;bottom:0;z-index:' + OVERLAY_Z + ';max-width:100vw;'
+      + 'font:10px/1.35 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;'
+      + 'color:#ffd7f2;background:rgba(10,6,20,.86);border-top:1px solid rgba(255,105,180,.55);'
+      + 'pointer-events:auto;-webkit-user-select:text;user-select:text;');
+
+    badge = d.createElement('div');
+    badge.id = 'gg-debug-badge';
+    style(badge,
+      'padding:4px 8px;background:rgba(255,105,180,.22);letter-spacing:.06em;'
+      + 'cursor:pointer;touch-action:manipulation;');
+    badge.textContent = 'debug 0';
+
+    body = d.createElement('div');
+    body.id = 'gg-debug-body';
+    // 30vh, and the badge is the TOP row so one tap folds it to a 16px bar: a
+    // diagnostic strip that covers the button you have to press to reproduce the
+    // bug is a strip that prevents its own use.
+    style(body, 'max-height:30vh;overflow:auto;padding:4px 8px 6px;white-space:pre-wrap;word-break:break-word;');
+
+    root.appendChild(badge);
+    root.appendChild(body);
+    // TAP ANYWHERE ON THE STRIP, not just a hit-box: a 10px close button on a
+    // phone is a control that does not exist.
+    if (typeof root.addEventListener === 'function') root.addEventListener('click', () => api.toggle());
+    d.body.appendChild(root);
+  } catch (_e) {
+    return noop;                                  // a strip that cannot build is simply absent
+  }
+
+  function paintBadge() {
+    try { badge.textContent = 'debug ' + ring.length + (collapsed ? ' ▴' : ' ▾'); }
+    catch (_e) { /* stub DOM */ }
+  }
+
+  function paint(entry) {
+    try {
+      const row = d.createElement('div');
+      style(row, 'color:' + (entry.level === 'error' ? '#ff8a8a' : entry.level === 'warn' ? '#ffd27f' : '#c9c9ff'));
+      row.textContent = entry.at + ' ' + entry.level + ' ' + entry.msg;
+      body.appendChild(row);
+      while (body.childNodes && body.childNodes.length > cap) body.removeChild(body.childNodes[0]);
+      if (typeof body.scrollHeight === 'number') body.scrollTop = body.scrollHeight;
+    } catch (_e) { /* stub DOM */ }
+    paintBadge();
+  }
+
+  const api = {
+    /** One line. NEVER throws — this sits inside logger.warn/error. */
+    push(level, msg) {
+      if (disposed) return;
+      try {
+        const entry = { at: stamp(now()), level: String(level || 'log'), msg: describe(msg).slice(0, 400) };
+        ring.push(entry);
+        while (ring.length > cap) ring.shift();
+        paint(entry);
+      } catch (_e) { /* a log line can never be the thing that breaks the page */ }
+    },
+    lines() { return ring.map((e) => e.at + ' ' + e.level + ' ' + e.msg); },
+    collapsed() { return collapsed; },
+    toggle() {
+      collapsed = !collapsed;
+      try { body.hidden = collapsed; } catch (_e) { /* stub DOM */ }
+      paintBadge();
+    },
+    get node() { return root; },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      try { root.remove(); } catch (_e) { /* already gone */ }
+    },
+  };
+
+  paintBadge();
+  return api;
+}
+
+/**
+ * Catch what never reaches a logger: a throw out of an event handler and a
+ * promise nobody awaited. boot.js already forwards both to bridge.log, which is
+ * a C# tunnel that goes nowhere standalone — this is the same two seams, ending
+ * somewhere a phone can actually read.
+ * @returns {() => void} unsubscribe
+ */
+export function captureGlobalErrors(overlay, win = (typeof window !== 'undefined' ? window : null)) {
+  if (!overlay || !win || typeof win.addEventListener !== 'function') return () => {};
+  const onError = (e) => {
+    const where = e && e.filename ? ' @ ' + String(e.filename).split('/').pop() + ':' + e.lineno : '';
+    overlay.push('error', ((e && e.message) || 'script error') + where);
+  };
+  const onReject = (e) => overlay.push('error', 'promise: ' + describe(e && e.reason));
+  try {
+    win.addEventListener('error', onError);
+    win.addEventListener('unhandledrejection', onReject);
+  } catch (_e) { return () => {}; }
+  return () => {
+    try { win.removeEventListener('error', onError); } catch (_e) { /* ignore */ }
+    try { win.removeEventListener('unhandledrejection', onReject); } catch (_e) { /* ignore */ }
+  };
+}
+
+export default { createDebugOverlay, captureGlobalErrors, debugRequested, debugInSearch };

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -58,6 +58,32 @@
 .gg-hud-frame.is-over { opacity: 0.35; pointer-events: none; }
 
 /* ---------------------------------------------------------------------------
+ * ZEN — the desk cleared down to the two things the duel is played on: their
+ * monitor and the arsenal. One bit (ui/hud.js HUD_ZEN_CLASS/HUD_ZEN_ATTR), every
+ * hide below it, nothing in JS.
+ *
+ * WHAT GOES: the score + its +1 flourish, the risk multiplier, your name plate,
+ * the closeness dial and MERCY. WHAT STAYS: the monitor, the rails, the charge
+ * pips (they are the arsenal's currency, not a readout), the timer, the
+ * attention ring and the toggle itself.
+ *
+ * MERCY IS NOT A DESCENDANT. #gg-mercy is its own fixed layer in goon.css, so
+ * the same bit is mirrored onto <html> and reached from there. This does not
+ * touch the isolation block: nothing is dimmed, filtered, scaled or animated,
+ * the layer is restored by the same button that took it away, and Escape
+ * concedes throughout (boot.js's ladder calls declareMercy() directly).
+ * ------------------------------------------------------------------------ */
+.gg-hud-frame.gg-hud--zen .gg-score,
+.gg-hud-frame.gg-hud--zen .gg-plus1,
+.gg-hud-frame.gg-hud--zen .gg-risk,
+.gg-hud-frame.gg-hud--zen .gg-me,
+.gg-hud-frame.gg-hud--zen .gg-dial-host { display: none; }
+/* the bottom deck reclaims MERCY's keep-out — there is nothing parked below it */
+.gg-hud-frame.gg-hud--zen .gg-hud-bottom { padding-bottom: 0; }
+
+html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
+
+/* ---------------------------------------------------------------------------
  * TOP BAR — score · charges · risk | timer | attention · gear
  * ------------------------------------------------------------------------ */
 .gg-hud-top {
@@ -128,6 +154,24 @@
   cursor: pointer;
 }
 .gg-gear:hover { color: #fff; border-color: var(--gg-pink); }
+
+/* The zen toggle, beside the gear and built to the same 48px hit area — it is
+   the ONLY way back once the panels are away, so it is never the thing that
+   shrinks. No animation of any kind: it would need pinning against the
+   --gg-deco-play park, and a control that must be findable at heat does not
+   move anyway. */
+.gg-zen {
+  width: 48px; height: 48px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 1.05rem; line-height: 1; color: var(--gg-text-2);
+  background: var(--gg-plate-bg);
+  border: var(--gg-plate-border);
+  border-radius: 50%;
+  cursor: pointer;
+}
+.gg-zen:hover { color: #fff; border-color: var(--gg-pink); }
+/* pressed = the desk is cleared; the glyph flips as well, colour is never alone */
+.gg-zen[aria-pressed="true"] { color: var(--gg-pink); border-color: rgba(var(--gg-pink-rgb), 0.7); }
 
 /* ---------------------------------------------------------------------------
  * ATTENTION — the ring, the dot history, the token, the missed-check banner
@@ -1011,10 +1055,14 @@
 }
 .gg-fxchip.is-incoming .gg-fxchip-bar { background: rgba(var(--gg-violet-rgb), 0.7); }
 
+/* SIZE (owner, 2026-08-04: "both are too big, especially on mobile"). The dial
+   lost a third of its width and most of its padding; it did NOT lose its touch
+   targets — the four stops keep their 48px, which is what the tier rule is
+   about, and the plate simply stopped padding them out. */
 .gg-dial-host { display: flex; justify-content: flex-end; }
-.gg-dial { min-width: 15rem; padding: 0.5rem 0.7rem 0.6rem; }
-.gg-dial-label { font-size: 0.62rem; letter-spacing: 0.16em; color: var(--gg-text-4); }
-.gg-dial-stops { display: flex; gap: 4px; margin: 0.35rem 0 0.3rem; }
+.gg-dial { min-width: 10.5rem; max-width: 14rem; padding: 0.3rem 0.5rem 0.35rem; }
+.gg-dial-label { font-size: 0.56rem; letter-spacing: 0.14em; color: var(--gg-text-4); }
+.gg-dial-stops { display: flex; gap: 4px; margin: 0.25rem 0 0.2rem; }
 .gg-dial-stop {
   flex: 1 1 0;
   min-height: 48px;
@@ -1030,7 +1078,7 @@
 .gg-dial[data-gg-close="3"] .gg-dial-stop.is-on .gg-dial-bar { background: var(--gg-hot); }
 .gg-dial-stop.is-head { color: var(--gg-text); }
 .gg-dial-stop.is-head .gg-dial-bar { height: 16px; }
-.gg-dial-fine { font-size: 0.6rem; color: var(--gg-text-4); }
+.gg-dial-fine { font-size: 0.54rem; line-height: 1.2; color: var(--gg-text-4); }
 
 /* ---------------------------------------------------------------------------
  * EMOTE SHEET
@@ -1071,12 +1119,16 @@
  * MERCY CHROME — the button itself is styled in goon.css (DO NOT TOUCH block).
  * Everything here is around it, and never on top of it.
  * ------------------------------------------------------------------------ */
-.gg-mercy-wrap { display: flex; flex-direction: column; align-items: center; gap: 0.3rem; }
+.gg-mercy-wrap { display: flex; flex-direction: column; align-items: center; gap: 0.25rem; }
+/* SIZE (owner, 2026-08-04: the button was eating the bottom of a phone). It is
+   smaller, not weaker: still the widest single control on the desk, still well
+   past a 48px finger in both axes, still the only uppercase word on the page,
+   and every line of the isolation contract in goon.css is untouched. */
 .gg-mercy-btn {
   position: relative;
-  width: min(420px, 60vw);
-  height: 72px;
-  font-size: 1rem;
+  width: min(300px, 46vw);
+  height: 56px;
+  font-size: 0.86rem;
 }
 .gg-mercy-btn.is-arming { pointer-events: none; opacity: 1; }
 .gg-mercy-arm {
@@ -1087,7 +1139,7 @@
   animation: ggArm 700ms linear forwards;
 }
 @keyframes ggArm { to { clip-path: inset(0 0 0 0); } }
-.gg-mercy-fine { font-size: 0.64rem; letter-spacing: 0.1em; color: var(--gg-text-4); }
+.gg-mercy-fine { font-size: 0.58rem; letter-spacing: 0.08em; color: var(--gg-text-4); }
 
 /* NOT children of #gg-mercy: that layer carries `transform: translateX(-50%)`,
    which makes it the containing block for any fixed-position descendant — a
@@ -1369,15 +1421,28 @@
   /* both rails share the strip: left half scrolls in from the left, right from the right */
   .gg-rail--left { bottom: 12.6rem; }
 
-  .gg-hud-bottom { flex-direction: column; align-items: stretch; gap: 0.4rem; padding-bottom: 5.6rem; }
+  /* keeps clearing the mercy strip, which is now 60px + its fineprint tall */
+  .gg-hud-bottom { flex-direction: column; align-items: stretch; gap: 0.4rem; padding-bottom: 5rem; }
   .gg-fxrail { max-width: none; }
-  .gg-dial-host { justify-content: stretch; }
-  .gg-dial { min-width: 0; width: 100%; }
+  /* the dial no longer spans the phone: it sits in the right corner at a size a
+     thumb still hits, and the rail beside it gets the rest of the row back */
+  .gg-dial-host { justify-content: flex-end; }
+  .gg-dial { min-width: 0; width: min(100%, 17rem); max-width: none; }
 
   .gg-emotes { right: 0.6rem; left: 0.6rem; width: auto; bottom: 18rem; }
 
-  .gg-mercy-btn { width: calc(100vw - 1.6rem); height: 84px; }
+  .gg-mercy-btn { width: min(calc(100vw - 1.6rem), 20rem); height: 60px; }
   .gg-sd-react { width: 92vw; height: 40vh; }
+
+  /* ZEN on a phone: the dial and the mercy strip are gone, so the two arsenal
+     rails drop into the space they were clearing instead of leaving a hole.
+     They stop 5.2rem up rather than at the floor — the effect chips still stack
+     upward from the bottom of the deck and they were never the thing being
+     hidden. The rails are absolutely placed, so this is the only way they can
+     follow the reflow at all. */
+  .gg-hud-frame.gg-hud--zen .gg-rail,
+  .gg-hud-frame.gg-hud--zen .gg-rail--right { bottom: 5.2rem; }
+  .gg-hud-frame.gg-hud--zen .gg-rail--left { bottom: 10.6rem; }
 }
 
 /* ---------------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -39,12 +39,39 @@
   position: absolute;
   inset: 0;
   display: grid;
+  /* THE ONE COLUMN, AND WHY IT IS PINNED TO ZERO.
+   *
+   * A grid with no `grid-template-columns` gets ONE implicit `auto` column, and
+   * an auto track's base size is the largest MIN-CONTENT contribution among its
+   * items — it is allowed to grow past the container. `.gg-hud-top` below is
+   * `1fr auto 1fr` where `1fr` means `minmax(auto, 1fr)`, so each side track has
+   * a min-content floor it can never go under, and `.gg-timer` adds an explicit
+   * `min-width`. On a 428px phone those floors (charge pips + timer + the
+   * attention plate and two 48px buttons) added up to ~442px, the implicit
+   * column took that as its base size, and EVERY row inherited it — which is
+   * how the opponent monitor, the "they claim" panel, the receipts and the
+   * closeness dial all ended up ~34px past the right edge of the screen while
+   * the absolutely-placed rails (which measure the frame's padding box) stayed
+   * put. (owner, 2026-08-04: "waaaaay too cluttered".)
+   *
+   * minmax(0, 1fr) removes the floor: the column is exactly the frame's content
+   * box at every viewport, so a row that cannot fit overflows ON ITS OWN and
+   * can never drag the other two rows off screen with it. Desktop has room to
+   * spare, so nothing there changes. */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto 1fr auto;
   gap: var(--gg-hud-gap);
   padding: clamp(0.6rem, 1.6vw, 1.4rem);
+  padding-left: calc(clamp(0.6rem, 1.6vw, 1.4rem) + env(safe-area-inset-left, 0px));
+  padding-right: calc(clamp(0.6rem, 1.6vw, 1.4rem) + env(safe-area-inset-right, 0px));
   padding-bottom: calc(clamp(0.6rem, 1.6vw, 1.4rem) + env(safe-area-inset-bottom, 0px));
   font-family: var(--gg-font);
 }
+/* the second half of the same guarantee: a row may not refuse to be narrower
+   than its own contents want to be */
+.gg-hud-top,
+.gg-hud-body,
+.gg-hud-bottom { min-width: 0; }
 .gg-hud-frame button,
 .gg-hud-frame .gg-plate,
 .gg-hud-frame .gg-item,
@@ -63,9 +90,22 @@
  * hide below it, nothing in JS.
  *
  * WHAT GOES: the score + its +1 flourish, the risk multiplier, your name plate,
- * the closeness dial and MERCY. WHAT STAYS: the monitor, the rails, the charge
- * pips (they are the arsenal's currency, not a readout), the timer, the
- * attention ring and the toggle itself.
+ * the closeness dial, the closeness THEY claim, the live-effect chips and MERCY.
+ * WHAT STAYS: the monitor, the rails, the charge pips (they are the arsenal's
+ * currency, not a readout), the timer, the attention ring and the toggle itself.
+ *
+ * THE TWO ADDED 2026-08-04 (owner: "we need space to see the animations"):
+ *   .gg-mon-close   the "they claim / warm" panel. It is the opponent's half of
+ *                   the closeness readout, and zen already takes YOUR half away
+ *                   with .gg-dial-host — keeping one and hiding the other read
+ *                   as a bug on a phone. Both halves now leave together.
+ *   .gg-fxrail      the "bubbles / subliminals" chips. They narrate effects the
+ *                   player is ALREADY WATCHING happen, which is the one thing
+ *                   zen exists to stop covering up.
+ * The arsenal is deliberately NOT on this list — including the emote tile. It
+ * is what the duel is played on, the suite pins that zen never hides .gg-item
+ * or .gg-rail, and a tile whose sheet was hidden underneath it would be a
+ * control that silently does nothing.
  *
  * MERCY IS NOT A DESCENDANT. #gg-mercy is its own fixed layer in goon.css, so
  * the same bit is mirrored onto <html> and reached from there. This does not
@@ -77,7 +117,9 @@
 .gg-hud-frame.gg-hud--zen .gg-plus1,
 .gg-hud-frame.gg-hud--zen .gg-risk,
 .gg-hud-frame.gg-hud--zen .gg-me,
-.gg-hud-frame.gg-hud--zen .gg-dial-host { display: none; }
+.gg-hud-frame.gg-hud--zen .gg-dial-host,
+.gg-hud-frame.gg-hud--zen .gg-mon-close,
+.gg-hud-frame.gg-hud--zen .gg-fxrail { display: none; }
 /* the bottom deck reclaims MERCY's keep-out — there is nothing parked below it */
 .gg-hud-frame.gg-hud--zen .gg-hud-bottom { padding-bottom: 0; }
 
@@ -261,7 +303,15 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
 .gg-well { pointer-events: none; }
 
 .gg-rail { display: flex; flex-direction: column; gap: 0.55rem; }
-.gg-rightcol { display: flex; flex-direction: column; align-items: flex-end; gap: 0.45rem; width: var(--gg-mon-w); }
+/* max-width, not width, on every box between the grid cell and the bezel: the
+   monitor column is the right-hand edge of the desk, so anything it cannot fit
+   inside leaves the screen rather than wrapping. */
+.gg-rightcol {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 0.45rem;
+  width: var(--gg-mon-w);
+  max-width: 100%;
+  min-width: 0;
+}
 
 /* ---------------------------------------------------------------------------
  * ARSENAL — CHROMELESS. The item art IS the button: the PNGs are transparent
@@ -525,16 +575,18 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
 /* ---------------------------------------------------------------------------
  * OPPONENT MONITOR
  * ------------------------------------------------------------------------ */
-.gg-mon-host { width: 100%; display: flex; justify-content: flex-end; }
+.gg-mon-host { width: 100%; min-width: 0; display: flex; justify-content: flex-end; }
 .gg-mon {
-  width: var(--gg-mon-w);
+  width: 100%;
+  max-width: var(--gg-mon-w);
+  min-width: 0;
   display: flex; flex-direction: column; gap: 0.3rem;
   transition: opacity .3s ease;
 }
 .gg-mon.is-wobbly { opacity: 0.7; }
 .gg-mon.is-gone { opacity: 0.4; }
 
-.gg-mon-head { display: flex; align-items: center; gap: 0.4rem; font-size: 0.72rem; }
+.gg-mon-head { display: flex; align-items: center; gap: 0.4rem; font-size: 0.72rem; min-width: 0; }
 .gg-mon-dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--gg-pink);
@@ -542,9 +594,12 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
 }
 .gg-mon-dot.is-wobbly { background: var(--gg-amber); box-shadow: 0 0 10px rgba(255, 180, 84, 0.7); }
 .gg-mon-dot.is-gone { background: #6d6d78; box-shadow: none; }
-.gg-mon-name { color: var(--gg-text-1); font-weight: 600; max-width: 9rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gg-mon-score { margin-left: auto; font-variant-numeric: tabular-nums; color: var(--gg-text-2); }
-.gg-mon-pips { display: flex; gap: 4px; }
+/* `min-width: 0` is what lets the ellipsis actually happen: without it a
+   nowrap name is a flex item that refuses to be narrower than its own text, and
+   it pushes the score and the charge pips off the end of the head row. */
+.gg-mon-name { color: var(--gg-text-1); font-weight: 600; max-width: 9rem; min-width: 0; flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gg-mon-score { margin-left: auto; padding-left: 0.3rem; font-variant-numeric: tabular-nums; color: var(--gg-text-2); flex: 0 0 auto; }
+.gg-mon-pips { display: flex; gap: 4px; flex: 0 0 auto; }
 
 .gg-mon-frame {
   position: relative;
@@ -1394,55 +1449,167 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
   animation: ggFloatUp .7s ease-out forwards;
 }
 
-/* ---------------------------------------------------------------------------
- * PORTRAIT / NARROW — the rails become one horizontal strip above the mercy
- * zone, the monitor shrinks to the top-right, the dial spans the width.
- * ------------------------------------------------------------------------ */
+/* ===========================================================================
+ * PORTRAIT / NARROW — the phone pass (owner, 2026-08-04: "this mess is waaaaay
+ * too cluttered, we need space to see the animations and effects").
+ *
+ * THE BUDGET, from the floor up, on a 428pt phone. Everything below is written
+ * against these five bands and nothing may be added without taking a band away:
+ *
+ *   0.0 - 5.5rem   MERCY (its own fixed layer) + its fineprint
+ *   6.0 - 11.2rem  BAND A: the right rail (left-anchored) | the closeness dial
+ *                  (right-anchored). Side by side, NOT stacked — the dial used
+ *                  to sit in the flow underneath both rails and landed on top
+ *                  of them, which is the overlap in the owner's screenshot.
+ *  11.6 - 15.2rem  BAND B: the left rail, full width.
+ *   7.2rem (top)   the live-effect chips, moved OUT of the bottom deck to under
+ *                  the score column: they are a status readout, and they were
+ *                  the third thing competing for the bottom-left corner.
+ *   everything else  is #gg-stage, which is the entire point of the screen.
+ *
+ * WHAT IS NOT NEGOTIABLE HERE: every tile, every dial stop and both round
+ * buttons keep a >= 48px hit area. The tiles got SHORTER (the icon and the
+ * words shrank, the "locked" line stopped taking a row of its own), never
+ * narrower than a finger.
+ * ======================================================================== */
 @media (orientation: portrait), (max-width: 720px) {
-  :root { --gg-mon-w: min(46vw, 220px); --gg-item: 62px; }
+  :root { --gg-mon-w: min(42vw, 190px); --gg-item: 48px; }
 
-  .gg-hud-body { grid-template-columns: 1fr; grid-template-rows: auto 1fr; align-items: start; }
+  /* ---- top bar: it must not be able to overflow ------------------------
+   * `1fr auto 1fr` gives both side tracks a min-content floor, and those floors
+   * (pips + timer min-width + the attention plate and two 48px buttons) came to
+   * ~442px on a 428px phone — 34px more than the frame has. The score column is
+   * the only compressible one of the three (its text can wrap or ellipsise), so
+   * it is the one that gets minmax(0, …) and the other two are content-sized.
+   * The pieces below are also just plain smaller, so the row FITS rather than
+   * merely failing quietly: ~49 + 92 + ~200 + gaps ≈ 356px at 428, and it still
+   * fits a 375px phone. */
+  .gg-hud-top { grid-template-columns: minmax(0, 1fr) auto auto; gap: 0.35rem; }
+  .gg-hud-top > * { min-width: 0; }
+  .gg-scorebox { min-width: 0; }
+  .gg-risk, .gg-me { overflow-wrap: anywhere; }
+  .gg-pip { width: 13px; height: 13px; }
+  .gg-pips { gap: 5px; }
+  .gg-timer { min-width: 92px; padding: 0.35rem 0.6rem 0.45rem; }
+  .gg-hud-topright { gap: 0.35rem; }
+  .gg-att { gap: 0.4rem; padding: 0.3rem 0.45rem; }
+  .gg-att-ring { width: 34px; height: 34px; }
+  .gg-att-ring::after { inset: 3px; }
+  .gg-att-label { font-size: 0.62rem; }
+  .gg-att-dot { width: 6px; height: 6px; }
+  .gg-att-dots { gap: 3px; }
+
+  /* ---- body: the monitor column, and nothing else ---------------------- */
+  .gg-hud-body { grid-template-columns: minmax(0, 1fr); grid-template-rows: auto 1fr; align-items: start; }
   .gg-rightcol { width: 100%; align-items: flex-end; order: -1; }
   .gg-well { display: none; }
+  /* the head row of a 190px monitor: the name gives way, the score and the
+     charge pips never do */
+  .gg-mon-name { max-width: 100%; }
+  .gg-mon-att-label { font-size: 0.6rem; }
+  /* a receipt is right-aligned in a 190px column, so a long one has to wrap
+     rather than reach back across the stage */
+  .gg-receipt { max-width: 100%; flex-wrap: wrap; font-size: 0.6rem; }
 
+  /* ---- the arsenal: shorter tiles, two tight bands ---------------------- */
   .gg-rail {
     position: absolute;
-    left: 0; right: 0;
-    bottom: 7.2rem;
+    left: calc(0.4rem + env(safe-area-inset-left, 0px));
+    right: calc(0.4rem + env(safe-area-inset-right, 0px));
+    bottom: 11.6rem;
     flex-direction: row;
-    gap: 0.4rem;
-    padding: 0 0.6rem;
+    align-items: flex-start;      /* the art lines up; only the words hang */
+    gap: 0.3rem;
+    padding: 0;
     overflow-x: auto;
     overscroll-behavior-x: contain;
     scrollbar-width: none;
   }
   .gg-rail::-webkit-scrollbar { display: none; }
-  .gg-rail--right { bottom: 7.2rem; justify-content: flex-end; }
-  /* both rails share the strip: left half scrolls in from the left, right from the right */
-  .gg-rail--left { bottom: 12.6rem; }
+  /* BAND A shares its row with the dial, so the right rail comes in from the
+     LEFT and stops at half the width — the two can never reach each other. */
+  .gg-rail--right {
+    bottom: 6rem;
+    right: auto;
+    /* 13rem is the dial's own 11.5rem plus the frame's right padding and a
+       finger's worth of daylight. Four tiles need 206px and this hands them
+       220px on a 428pt phone; a narrower phone scrolls the rail instead of
+       letting it walk into the dial. */
+    max-width: calc(100% - 13rem);
+    justify-content: flex-start;
+  }
+  .gg-rail--left { bottom: 11.6rem; }
 
-  /* keeps clearing the mercy strip, which is now 60px + its fineprint tall */
-  .gg-hud-bottom { flex-direction: column; align-items: stretch; gap: 0.4rem; padding-bottom: 5rem; }
-  .gg-fxrail { max-width: none; }
-  /* the dial no longer spans the phone: it sits in the right corner at a size a
-     thumb still hits, and the rail beside it gets the rest of the row back */
-  .gg-dial-host { justify-content: flex-end; }
-  .gg-dial { min-width: 0; width: min(100%, 17rem); max-width: none; }
+  /* A tile is 48px wide and about 62px tall instead of ~90: the art is smaller,
+     the words are smaller, and the state line no longer reserves a row when it
+     has nothing to say. */
+  .gg-item { padding: 0 0 0.1rem; gap: 0; }
+  .gg-item-img, .gg-item-fallback { width: 92%; max-width: 42px; }
+  .gg-item-name { font-size: 0.5rem; letter-spacing: 0.01em; line-height: 1.15; }
+  .gg-item-state { font-size: 0.5rem; min-height: 0; line-height: 1.15; }
+  .gg-cost-pip { width: 5px; height: 5px; }
+  .gg-item-lock { font-size: 0.95rem; }
+  /* "locked" was a full text line under five of the nine tiles. On a phone the
+     lock is the "?" badge and the full desaturation instead — but the WORD is
+     still in the DOM and still read out, because the tier rule is that colour
+     never travels alone. This is the sr-only recipe from goon.css, applied by
+     state rather than by class so ui/arsenal.js needs no change. */
+  .gg-item.is-locked .gg-item-state {
+    position: absolute;
+    width: 1px; height: 1px;
+    margin: -1px; padding: 0; border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
 
-  .gg-emotes { right: 0.6rem; left: 0.6rem; width: auto; bottom: 18rem; }
+  /* ---- the bottom deck: the dial alone, in BAND A ----------------------- */
+  /* padding-bottom clears MERCY, measured not guessed: 1.4rem off the floor +
+     a 50px button + a 0.25rem gap + an 11px fineprint = 5.46rem, so 6rem. */
+  .gg-hud-bottom { flex-direction: row; align-items: flex-end; justify-content: flex-end; gap: 0.4rem; padding-bottom: 6rem; }
+  .gg-dial-host { justify-content: flex-end; flex: 0 0 auto; }
+  .gg-dial { min-width: 0; width: min(46vw, 11.5rem); max-width: none; padding: 0.28rem 0.4rem 0.32rem; }
+  .gg-dial-label { font-size: 0.54rem; }
+  .gg-dial-stops { gap: 3px; margin: 0.2rem 0 0.15rem; }
+  .gg-dial-stop { font-size: 0.56rem; }
+  .gg-dial-fine { font-size: 0.5rem; }
 
-  .gg-mercy-btn { width: min(calc(100vw - 1.6rem), 20rem); height: 60px; }
+  /* THE LIVE-EFFECT CHIPS LEAVE THE BOTTOM. They narrate what is already
+     playing on the stage, so they belong beside the score and not in the third
+     corner of the mercy strip. Absolutely placed against the frame like the
+     rails: clear of the announcer ribbon (which stops around 5.5rem) above and
+     of the monitor column (which starts past 55% width) to the right. They stay
+     a DESCENDANT of .gg-hud-bottom, so `.is-sd` still takes them away with the
+     rest of the deck and zen still hides them by name. */
+  .gg-fxrail {
+    position: absolute;
+    left: calc(0.4rem + env(safe-area-inset-left, 0px));
+    top: 7.2rem;
+    bottom: auto;
+    max-width: 48vw;
+    align-items: flex-start;
+  }
+  .gg-fxchip { font-size: 0.62rem; padding: 0.18rem 0.5rem; max-width: 100%; }
+  .gg-fxchip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .gg-emotes { right: 0.6rem; left: 0.6rem; width: auto; bottom: 16.5rem; }
+
+  /* SIZE, again (owner, 2026-08-04: it is STILL too big on this phone). The old
+     portrait rule was the bug — `min(100vw - 1.6rem, 20rem)` INFLATED the
+     button back to 320px on a 428pt screen, undoing the base rule's
+     `min(300px, 46vw)`. It now shrinks on a phone like it says it does, and it
+     is still the widest control on the desk by a mile. */
+  .gg-mercy-btn { width: min(52vw, 14rem); height: 50px; font-size: 0.8rem; }
   .gg-sd-react { width: 92vw; height: 40vh; }
 
-  /* ZEN on a phone: the dial and the mercy strip are gone, so the two arsenal
-     rails drop into the space they were clearing instead of leaving a hole.
-     They stop 5.2rem up rather than at the floor — the effect chips still stack
-     upward from the bottom of the deck and they were never the thing being
-     hidden. The rails are absolutely placed, so this is the only way they can
-     follow the reflow at all. */
+  /* ZEN on a phone: the dial, the effect chips and the mercy strip are gone, so
+     both arsenal bands drop to the floor instead of leaving a hole where the
+     deck used to be. That is ~11rem of stage handed back — which is the whole
+     point of the toggle. The rails are absolutely placed, so this is the only
+     way they can follow the reflow at all. */
   .gg-hud-frame.gg-hud--zen .gg-rail,
-  .gg-hud-frame.gg-hud--zen .gg-rail--right { bottom: 5.2rem; }
-  .gg-hud-frame.gg-hud--zen .gg-rail--left { bottom: 10.6rem; }
+  .gg-hud-frame.gg-hud--zen .gg-rail--right { bottom: 1.6rem; }
+  .gg-hud-frame.gg-hud--zen .gg-rail--left { bottom: 7.2rem; }
 }
 
 /* ---------------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -4,7 +4,7 @@
  * Composes the live-match HUD inside #gg-hud and owns the layout grid:
  *
  *   ┌ top ────────────────────────────────────────────────────────────────┐
- *   │ score · charges · risk        11:47 ▮▮▯▯▯        attention   ⚙      │
+ *   │ score · charges · risk        11:47 ▮▮▯▯▯      attention  ⊟  ⚙      │
  *   ├ body ───────────────────────────────────────────────────────────────┤
  *   │ [rail]              (the stage well — never covered)      [monitor] │
  *   │  4 items                                                  [receipts]│
@@ -15,6 +15,11 @@
  *
  * THE MIDDLE IS SACRED. The HUD frames #gg-stage, it never lands on top of it:
  * everything here is edge-anchored and the centre column is pointer-transparent.
+ *
+ * ZEN (the ⊟ beside the gear). One bit, and everything it hides — score, risk,
+ * the closeness dial, MERCY — is hidden by ui/hud.css off .gg-hud--zen and
+ * html[data-gg-zen]. The monitor and the arsenal stay: they are what the duel is
+ * played on. See the toggle's own block below for why hiding MERCY is safe.
  *
  * ANIMATION BUDGET. Chrome animations go through fx.play(): at most two run at
  * once and anything that waited more than 600 ms is dropped rather than played
@@ -47,6 +52,21 @@ export const BUBBLE_POP_EVENT = 'gg-bubble-pop';
  * holds an id — the detail carries a NAME and nothing else.
  */
 export const DISCORD_DM_EVENT = 'gg-discord-dm';
+
+/**
+ * THE ZEN BIT — one class on the frame, one attribute on <html>.
+ *
+ * "add a button that hides the ui" (owner, 2026-08-04). Everything the toggle
+ * takes away is hidden by ui/hud.css off these two names and nothing else, so
+ * the whole feature is one boolean: no per-element `hidden` flags to keep in
+ * sync and nothing to leave behind if a paint throws.
+ *
+ * The attribute exists because MERCY is NOT inside the HUD: #gg-mercy is its own
+ * fixed layer (z60, goon.css) and no descendant selector from .gg-hud-frame can
+ * reach it. Exported so the suite pins the same two strings the CSS does.
+ */
+export const HUD_ZEN_CLASS = 'gg-hud--zen';
+export const HUD_ZEN_ATTR = 'data-gg-zen';
 
 /** Own-draft element cues -> the chip that shows them on the bottom-left rail. */
 const ELEMENT_META = Object.freeze({
@@ -296,6 +316,73 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
 
   const rightTop = add(top, el('div', 'gg-hud-topright'));
   const attSlot = add(rightTop, el('div', 'gg-att-slot'));
+
+  /* ---- THE ZEN TOGGLE ---------------------------------------------------
+   * One button, always on screen, that takes the score, the risk multiplier,
+   * the closeness dial and the mercy button away and gives them back. What is
+   * left is what the duel is actually played on: their monitor and the arsenal.
+   *
+   * IT IS ITS OWN UNDO. The button never hides — it would be a one-way door on
+   * a phone, where there is no Escape key to fall back to — and it keeps the
+   * gear's 48px hit area for the same reason.
+   *
+   * HIDING MERCY IS A PREFERENCE, NOT A CHANGE TO THE SAFETY CONTRACT. Escape
+   * concedes through boot.js's ladder, which calls match.declareMercy() itself
+   * and has never touched this button (ui/mercy.js's own pointerdown handler is
+   * a second, independent path). Nothing here reads or focuses the button
+   * either, so a hidden mercy is a mercy that still works — and the title says
+   * so out loud while it is away.
+   */
+  const zenBtn = add(rightTop, el('button', 'gg-zen'));
+  let zenOn = false;
+  if (zenBtn) zenBtn.type = 'button';
+
+  function paintZen() {
+    const label = zenOn ? S.hud.zenShow : S.hud.zenHide;
+    text(zenBtn, zenOn ? S.hud.zenShowGlyph : S.hud.zenHideGlyph);
+    if (zenBtn && zenBtn.setAttribute) {
+      try {
+        zenBtn.setAttribute('aria-pressed', zenOn ? 'true' : 'false');
+        zenBtn.setAttribute('aria-label', label);
+        zenBtn.title = zenOn ? S.hud.zenShowTitle : label;
+      } catch (_e) { /* stub DOM */ }
+    }
+    cls(root, HUD_ZEN_CLASS, zenOn);
+    try {
+      const de = d && d.documentElement;
+      if (de && typeof de.setAttribute === 'function') {
+        if (zenOn) de.setAttribute(HUD_ZEN_ATTR, 'on');
+        else de.removeAttribute(HUD_ZEN_ATTR);
+      }
+    } catch (_e) { /* no <html>: the frame class still does the HUD half */ }
+  }
+
+  function setZen(on, remember) {
+    const next = !!on;
+    if (next === zenOn) return;
+    zenOn = next;
+    paintZen();
+    // Persisting is a nicety, not the state: the bit above is already true.
+    if (remember && prefs && typeof prefs.set === 'function') {
+      try { prefs.set('hudZen', zenOn); } catch (_e) { /* no store, no problem */ }
+    }
+  }
+
+  // Remembered across matches when there is a store to remember it in.
+  if (prefs && typeof prefs.get === 'function') {
+    try { if (prefs.get('hudZen')) zenOn = true; } catch (_e) { /* ignore */ }
+  }
+  paintZen();
+  led.listen(zenBtn, 'click', () => { sfx(audio, 'ui-select'); setZen(!zenOn, true); });
+  // The <html> attribute outlives this node, so it is unwound by hand: a stray
+  // data-gg-zen would hide the mercy button of the NEXT match.
+  led.add(() => {
+    try {
+      const de = d && d.documentElement;
+      if (de && typeof de.removeAttribute === 'function') de.removeAttribute(HUD_ZEN_ATTR);
+    } catch (_e) { /* gone */ }
+  });
+
   const gear = add(rightTop, el('button', 'gg-gear', '⚙'));
   if (gear) {
     gear.type = 'button';
@@ -673,7 +760,11 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
 
   return {
     /** Exposed so H (or a play-test driver) can poke the desk without re-deriving it. */
-    parts: { root, arsenal, opponent, dial, attention, emotes, announcer, fx, drops },
+    parts: {
+      root, arsenal, opponent, dial, attention, emotes, announcer, fx, drops,
+      /** The zen toggle, for a driver that wants the state without the click. */
+      zen: { button: zenBtn, set: (on) => setZen(on, true), get on() { return zenOn; } },
+    },
     unmount() {
       fx.stop();
       for (const rec of Array.from(chips.values())) dropChipRec(rec);

--- a/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
@@ -9,7 +9,7 @@
  * which is not a limit — it is a missing feature.
  *
  * The wire's actual ceiling for a NON-exempt artifact is MAX_ARTIFACT_BYTES
- * (24 MB). So the page can adopt big media the same way the C# app does: by
+ * (64 MB). So the page can adopt big media the same way the C# app does: by
  * compressing it into an artifact that fits. This module is the two lanes.
  *
  *   IMAGE  decode -> downscale to ≤1920 long edge -> WebP q0.80.
@@ -27,7 +27,7 @@
  *          directly and hands the bytes back to its caller. The worker itself is
  *          shared and untouched, so lane B cannot regress from anything here.
  *
- * WHAT IS NOT HERE, ON PURPOSE: video transcoding. An mp4/webm over 24 MB is
+ * WHAT IS NOT HERE, ON PURPOSE: video transcoding. An mp4/webm over 64 MB is
  * counted and said out loud, because a browser-side H.264 -> H.264 transcode
  * means decoding every frame through WebCodecs at real cost for a result we
  * cannot promise, and "the video is too big to send" is a better answer than a

--- a/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
@@ -1,0 +1,611 @@
+/* ============================================================================
+ * ui/localCompress.js — the STANDALONE page's own compression lanes.
+ *
+ * In the app, compression happens in C# (TransferCompressionService) and the
+ * page only drives lane B for animated GIF/WebP. In a plain browser there is no
+ * host at all, and until now that meant the picker adopted only files that were
+ * already small enough to send as-is (≤ MAX_EXEMPT_BYTES, 8 MB). A player who
+ * handed over a 1 GB zip of real photos got told everything in it was "too big",
+ * which is not a limit — it is a missing feature.
+ *
+ * The wire's actual ceiling for a NON-exempt artifact is MAX_ARTIFACT_BYTES
+ * (24 MB). So the page can adopt big media the same way the C# app does: by
+ * compressing it into an artifact that fits. This module is the two lanes.
+ *
+ *   IMAGE  decode -> downscale to ≤1920 long edge -> WebP q0.80.
+ *          WebP is the goal, not the promise: a runtime that cannot encode it
+ *          (Safari before 14, and anything else whose canvas quietly answers
+ *          PNG) is DETECTED BY THE BLOB IT PRODUCED, never by a user-agent
+ *          sniff, and we re-encode as JPEG q0.82. Both mimes are in the wire's
+ *          ACCEPT_MIME, so either answer is sendable.
+ *
+ *   ANIMATED  the SAME machinery lane B already uses: encode/gifDecode.js takes
+ *          the file apart into a filmstrip and encode/encodeWorker.js muxes an
+ *          H.264 mp4. What is different here is only the PLUMBING — the hosted
+ *          driver in assetsStore.js answers a host `encode-request` and posts
+ *          the result back over the bridge in base64 parts; this one is called
+ *          directly and hands the bytes back to its caller. The worker itself is
+ *          shared and untouched, so lane B cannot regress from anything here.
+ *
+ * WHAT IS NOT HERE, ON PURPOSE: video transcoding. An mp4/webm over 24 MB is
+ * counted and said out loud, because a browser-side H.264 -> H.264 transcode
+ * means decoding every frame through WebCodecs at real cost for a result we
+ * cannot promise, and "the video is too big to send" is a better answer than a
+ * phone that heats up for four minutes and then fails anyway.
+ *
+ * NODE-IMPORT-SAFE, and that is load-bearing: not one browser global is touched
+ * at module scope, there are no static imports of the encode tier (its worker is
+ * reached lazily), and every capability is probed AT CALL TIME. The selftests
+ * import this file under node — where there is no canvas, no createImageBitmap
+ * and no WebCodecs — and only the pure helpers run.
+ * ==========================================================================*/
+
+/** Long-edge ceiling for a compressed still. 1920 is the duel's own display box. */
+export const IMAGE_MAX_EDGE = 1920;
+/** WebP quality. 0.80 is the knee: past it the file grows faster than the image improves. */
+export const IMAGE_WEBP_QUALITY = 0.80;
+/** JPEG quality for the fallback. Slightly higher — JPEG needs it to match. */
+export const IMAGE_JPEG_QUALITY = 0.82;
+
+/**
+ * Hard ceiling on what we will DECODE. Not a wire limit: a decode allocates
+ * width*height*4 bytes of RGBA whatever the file weighs, and a 500 MB TIFF on a
+ * phone is a tab crash, not a slow adopt. Anything past this is counted, not tried.
+ */
+export const MAX_DECODE_BYTES = 80 * 1024 * 1024;
+
+/** Long-edge ceiling for an animated artifact — lane B's own default. */
+export const ANIM_MAX_BOX = 720;
+/** Bitrate ceiling for an animated artifact (encodeWorker clamps to the same). */
+export const ANIM_BITRATE = 1_800_000;
+/** Frame-rate ceiling for an animated artifact. */
+export const ANIM_MAX_FPS = 30;
+/** A single local encode that has said nothing for this long is abandoned. */
+export const ANIM_TIMEOUT_MS = 180000;
+
+/**
+ * An <img> decode that has neither loaded nor errored in this long is given up
+ * on. Adoption is a SERIAL loop: one file whose load event never arrives (a
+ * truncated jpeg on some runtimes, a stub environment) would wedge the whole
+ * queue and leave the picker disabled forever, with no error anywhere.
+ */
+export const IMAGE_DECODE_TIMEOUT_MS = 30000;
+
+/* ------------------------------------------------------------ pure helpers */
+
+/** Whatever we were handed, as a Uint8Array view (never a copy when avoidable). */
+function asU8(src) {
+  if (src instanceof Uint8Array) return src;
+  if (src instanceof ArrayBuffer) return new Uint8Array(src);
+  if (src && typeof src === 'object' && src.buffer instanceof ArrayBuffer
+      && typeof src.byteOffset === 'number' && typeof src.byteLength === 'number') {
+    return new Uint8Array(src.buffer, src.byteOffset, src.byteLength);
+  }
+  return new Uint8Array(0);
+}
+
+/**
+ * Fit w×h inside a square of `maxEdge`, never scaling UP.
+ *
+ * Stills do not care about even dimensions (there is no 4:2:0 chroma), so this
+ * is deliberately NOT gifDecode's fitBox — it keeps the aspect ratio exactly and
+ * floors to whole pixels, minimum 1.
+ */
+export function fitDown(w, h, maxEdge = IMAGE_MAX_EDGE) {
+  const w0 = Math.max(1, Math.floor(Number(w) || 0));
+  const h0 = Math.max(1, Math.floor(Number(h) || 0));
+  const box = Math.max(1, Math.floor(Number(maxEdge) || IMAGE_MAX_EDGE));
+  const scale = Math.min(1, box / Math.max(w0, h0));
+  return {
+    w: Math.max(1, Math.round(w0 * scale)),
+    h: Math.max(1, Math.round(h0 * scale)),
+    scaled: scale < 1,
+  };
+}
+
+/**
+ * How many image descriptors are in a GIF, up to `limit`.
+ *
+ * A pure walk of the block structure — header, optional global colour table,
+ * then extensions (label + length-prefixed sub-blocks) and image descriptors
+ * (9 bytes + optional local colour table + LZW data). Nothing is decoded; we
+ * only need to know whether there is more than one frame.
+ *
+ * @returns {number} frames found (capped at `limit`), or -1 if the walk hit
+ *   something it did not understand — which is an answer of "do not guess".
+ */
+export function gifFrameCount(bytes, limit = 2) {
+  const u8 = asU8(bytes);
+  const cap = Math.max(1, Math.floor(Number(limit) || 2));
+  if (u8.length < 13) return -1;
+  if (!(u8[0] === 0x47 && u8[1] === 0x49 && u8[2] === 0x46)) return -1;   // 'GIF'
+
+  const skipBlocks = (at) => {
+    let p = at;
+    while (p < u8.length) {
+      const len = u8[p];
+      if (len === 0) return p + 1;
+      p += 1 + len;
+    }
+    return -1;                                        // ran off the end mid-stream
+  };
+
+  let p = 13;
+  const packed = u8[10];
+  if (packed & 0x80) p += 3 * (1 << ((packed & 7) + 1));   // global colour table
+
+  let frames = 0;
+  while (p < u8.length) {
+    const b = u8[p];
+    if (b === 0x3B) break;                            // trailer
+    if (b === 0x21) {                                 // extension: 0x21, label, sub-blocks
+      p = skipBlocks(p + 2);
+      if (p < 0) return -1;
+      continue;
+    }
+    if (b === 0x2C) {                                 // image descriptor
+      frames++;
+      if (frames >= cap) return frames;
+      p += 10;                                        // 0x2C + left/top/w/h + packed
+      if (p > u8.length) return -1;
+      const lf = u8[p - 1];
+      if (lf & 0x80) p += 3 * (1 << ((lf & 7) + 1));  // local colour table
+      p += 1;                                         // LZW minimum code size
+      p = skipBlocks(p);
+      if (p < 0) return -1;
+      continue;
+    }
+    return -1;                                        // not a structure we know
+  }
+  return frames;
+}
+
+/** Is this WebP animated? Read from the VP8X chunk's flag byte, nowhere else. */
+export function webpIsAnimated(bytes) {
+  const u8 = asU8(bytes);
+  if (u8.length < 21) return 'unknown';
+  if (!(u8[0] === 0x52 && u8[1] === 0x49 && u8[2] === 0x46 && u8[3] === 0x46)) return 'unknown';   // RIFF
+  if (!(u8[8] === 0x57 && u8[9] === 0x45 && u8[10] === 0x42 && u8[11] === 0x50)) return 'unknown'; // WEBP
+  // 'VP8X' is the only container that can be animated. Plain 'VP8 ' / 'VP8L' is one frame.
+  if (u8[12] === 0x56 && u8[13] === 0x50 && u8[14] === 0x38 && u8[15] === 0x58) {
+    return (u8[20] & 0x02) ? 'animated' : 'still';
+  }
+  return 'still';
+}
+
+/**
+ * Which lane a file belongs in, from its BYTES rather than its extension.
+ *
+ * 'unknown' means the sniff could not tell, and the caller must treat it as
+ * animated: sending a one-frame mp4 for a still costs a few kilobytes, while
+ * sending frame 1 of a 400-frame GIF loses the whole point of the file.
+ *
+ * @returns {'animated'|'still'|'unknown'}
+ */
+export function sniffAnimated(bytes, mime) {
+  const m = String(mime || '').toLowerCase();
+  const u8 = asU8(bytes);
+  if (m === 'image/gif' || (u8[0] === 0x47 && u8[1] === 0x49 && u8[2] === 0x46)) {
+    const n = gifFrameCount(u8, 2);
+    if (n < 0) return 'unknown';
+    return n > 1 ? 'animated' : 'still';
+  }
+  if (m === 'image/webp' || (u8[8] === 0x57 && u8[9] === 0x45 && u8[10] === 0x42 && u8[11] === 0x50)) {
+    return webpIsAnimated(u8);
+  }
+  return 'still';
+}
+
+/**
+ * Can this runtime encode an animated file at all?
+ *
+ * The cheap, SYNCHRONOUS half of probeEncode — asked at call time, before a
+ * Worker is constructed and before a 40 MB buffer is transferred into it, so a
+ * runtime without WebCodecs fails in a microsecond rather than after paying for
+ * both. The full async probe (codec strings, hardware hint) is the HOST's
+ * question and lives in assetsStore.probeEncode; this one only needs to know
+ * whether the three constructors exist.
+ *
+ * NOTE the deliberate absence of a MediaRecorder fallback here. The hosted lane
+ * has one because the host has already committed to the job; standalone would
+ * rather say "that gif is too big to send" instantly than spend thirty seconds
+ * of a phone's main thread painting frames in real time for a maybe.
+ */
+export function canEncodeAnimated() {
+  return typeof globalThis.VideoEncoder === 'function'
+    && typeof globalThis.VideoFrame === 'function'
+    && typeof globalThis.ImageDecoder === 'function';
+}
+
+/** The file extension a compressed artifact should carry. */
+export function extForMime(mime) {
+  switch (String(mime || '').toLowerCase()) {
+    case 'video/mp4': return 'mp4';
+    case 'video/webm': return 'webm';
+    case 'image/webp': return 'webp';
+    case 'image/jpeg': return 'jpg';
+    case 'image/png': return 'png';
+    case 'image/gif': return 'gif';
+    default: return '';
+  }
+}
+
+/* ------------------------------------------------------- runtime plumbing */
+
+/** Bytes out of a File/Blob/ArrayBuffer/Uint8Array, as an ArrayBuffer. */
+async function toArrayBuffer(src) {
+  if (src instanceof ArrayBuffer) return src;
+  if (src && typeof src.arrayBuffer === 'function') return await src.arrayBuffer();
+  const u8 = asU8(src);
+  return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength);
+}
+
+/** A Blob view of the source, for the decoders that want one. */
+async function toBlob(src, mime) {
+  const type = String(mime || '');
+  if (src && typeof src.arrayBuffer === 'function' && typeof src.size === 'number') {
+    // Already a File/Blob. Keep it: createImageBitmap(File) skips a copy.
+    if (!type || String(src.type || '') === type) return src;
+  }
+  const B = globalThis.Blob;
+  if (typeof B !== 'function') return null;
+  const buf = await toArrayBuffer(src);
+  return new B([buf], { type });
+}
+
+/** OffscreenCanvas when it exists, a real <canvas> when it does not, null in node. */
+function makeCanvas(w, h) {
+  const OC = globalThis.OffscreenCanvas;
+  if (typeof OC === 'function') {
+    try {
+      const c = new OC(w, h);
+      if (c && typeof c.getContext === 'function') return c;
+    } catch (_e) { /* fall through to the DOM canvas */ }
+  }
+  const doc = globalThis.document;
+  if (doc && typeof doc.createElement === 'function') {
+    try {
+      const c = doc.createElement('canvas');
+      if (c && typeof c.getContext === 'function') { c.width = w; c.height = h; return c; }
+    } catch (_e) { /* no DOM canvas either */ }
+  }
+  return null;
+}
+
+/** One blob out of a canvas, whichever of the two APIs this runtime has. */
+async function canvasToBlob(canvas, type, quality) {
+  if (typeof canvas.convertToBlob === 'function') {
+    try { return await canvas.convertToBlob({ type, quality }); } catch (_e) { return null; }
+  }
+  if (typeof canvas.toBlob === 'function') {
+    return await new Promise((res) => {
+      let settled = false;
+      const fin = (b) => { if (!settled) { settled = true; res(b || null); } };
+      try { canvas.toBlob(fin, type, quality); } catch (_e) { fin(null); }
+      // A canvas that refuses the type outright can drop the callback entirely.
+      setTimeout(() => fin(null), 15000);
+    });
+  }
+  return null;
+}
+
+/**
+ * Decode one still into something drawable.
+ *
+ * EXIF ORIENTATION IS HANDLED THE CHEAP WAY: `imageOrientation:'from-image'`.
+ * Without it a phone photo taken in portrait draws sideways, and the only other
+ * fix is parsing the EXIF block by hand. Runtimes that reject the option get a
+ * plain createImageBitmap, then an <img> — which applies orientation itself,
+ * since `image-orientation: from-image` has been the CSS default for years.
+ */
+async function decodeStill(blob) {
+  const CIB = globalThis.createImageBitmap;
+  if (typeof CIB === 'function') {
+    try {
+      const bm = await CIB(blob, { imageOrientation: 'from-image' });
+      return { image: bm, w: bm.width, h: bm.height, close: () => { try { bm.close(); } catch (_e) { /* ignore */ } } };
+    } catch (_e) { /* the option is not universal — try without it */ }
+    try {
+      const bm = await CIB(blob);
+      return { image: bm, w: bm.width, h: bm.height, close: () => { try { bm.close(); } catch (_e) { /* ignore */ } } };
+    } catch (_e) { /* fall through to <img> */ }
+  }
+
+  const doc = globalThis.document;
+  const U = globalThis.URL;
+  if (!doc || typeof doc.createElement !== 'function' || !U || typeof U.createObjectURL !== 'function') {
+    throw new Error('no-image-decoder');
+  }
+  const url = U.createObjectURL(blob);
+  try {
+    const img = await new Promise((res, rej) => {
+      let settled = false;
+      const el = doc.createElement('img');
+      const fin = (fn, arg) => { if (!settled) { settled = true; fn(arg); } };
+      el.onload = () => fin(res, el);
+      el.onerror = () => fin(rej, new Error('decode-failed'));
+      el.decoding = 'sync';
+      // See IMAGE_DECODE_TIMEOUT_MS: a load event that never comes must not be
+      // able to stop the adoption loop.
+      try {
+        const t = setTimeout(() => fin(rej, new Error('decode-timeout')), IMAGE_DECODE_TIMEOUT_MS);
+        if (t && typeof t.unref === 'function') t.unref();
+      } catch (_e) { /* no timers — the events are all we have */ }
+      el.src = url;
+    });
+    const w = img.naturalWidth || img.width || 0;
+    const h = img.naturalHeight || img.height || 0;
+    if (!w || !h) throw new Error('decode-failed');
+    return { image: img, w, h, close: () => { try { U.revokeObjectURL(url); } catch (_e) { /* ignore */ } } };
+  } catch (e) {
+    try { U.revokeObjectURL(url); } catch (_e) { /* ignore */ }
+    throw e;
+  }
+}
+
+/* ============================================================================
+ * THE ANIMATED LANE — the same worker lane B drives, without the bridge.
+ *
+ * The hosted driver (createEncodeDriver in ui/assetsStore.js) exists to answer a
+ * host `encode-request`: fetch by URL, encode, base64-chunk the result into
+ * `cache-put` frames, heartbeat so the service's 3-minute stale timer never
+ * fires. NONE of that applies to a file the player just picked in a browser —
+ * there is no host, no job id the host knows about and no cache to put into.
+ *
+ * So this driver is the same worker with the protocol stripped to what it is:
+ * post bytes, get an mp4. It never touches `bridge`, so the two drivers cannot
+ * contend for anything, and a worker failure here falls back to running the very
+ * same `runEncodeJob` on the main thread rather than to a different encoder.
+ * ==========================================================================*/
+
+export function createLocalEncodeDriver({ workerFactory = null, logger = null } = {}) {
+  let worker = null;
+  let workerDead = false;
+  let seq = 0;
+  let disposed = false;
+  /** jobId -> {resolve, reject, onProgress, timer} */
+  const jobs = new Map();
+
+  const warn = (m) => { try { logger?.warn?.('[GG local-encode] ' + m); } catch (_e) { /* ignore */ } };
+
+  function settle(id, fn, arg) {
+    const j = jobs.get(id);
+    if (!j) return;
+    jobs.delete(id);
+    if (j.timer) { try { clearTimeout(j.timer); } catch (_e) { /* ignore */ } }
+    try { fn(j, arg); } catch (_e) { /* a settled promise cannot be settled twice */ }
+  }
+
+  function onMessage(m) {
+    if (!m || disposed) return;
+    const id = String(m.jobId || '');
+    const j = jobs.get(id);
+    if (!j) return;
+    if (m.kind === 'progress') {
+      j.touched = Date.now();
+      try { j.onProgress?.(Number(m.pct) || 0); } catch (_e) { /* a reporter never fails a job */ }
+      return;
+    }
+    if (m.kind === 'fail') { settle(id, (job, why) => job.reject(new Error(why)), String(m.reason || 'encode-failed')); return; }
+    if (m.kind === 'done') {
+      settle(id, (job, out) => job.resolve(out), {
+        art: m.art, w: Number(m.w) || 0, h: Number(m.h) || 0, durMs: Number(m.durMs) || 0,
+      });
+    }
+  }
+
+  function ensureWorker() {
+    if (worker || workerDead) return worker;
+    try {
+      if (typeof workerFactory === 'function') worker = workerFactory();
+      else if (typeof Worker === 'function') {
+        // RELATIVE, for the same reason the hosted driver's is: the app serves
+        // Resources/web (so this is /goon/encode/...) and the headless harness
+        // serves goon/ as the root (so it is /encode/...). An absolute path
+        // resolves in exactly one of the two.
+        worker = new Worker(new URL('../encode/encodeWorker.js', import.meta.url), { type: 'module' });
+      }
+    } catch (e) {
+      warn('worker construction failed: ' + ((e && e.message) || e));
+      worker = null;
+    }
+    if (!worker) { workerDead = true; return null; }
+    try {
+      worker.onmessage = (e) => onMessage(e && e.data);
+      worker.onerror = (e) => {
+        warn('worker error: ' + ((e && e.message) || e));
+        // A worker that threw is not trusted for the next job either; every job
+        // waiting on it is failed rather than left hanging on a dead port.
+        try { worker.terminate(); } catch (_e) { /* ignore */ }
+        worker = null;
+        workerDead = true;
+        for (const id of Array.from(jobs.keys())) settle(id, (job) => job.reject(new Error('worker-error')));
+      };
+    } catch (_e) { /* a stub worker without the setters is fine */ }
+    return worker;
+  }
+
+  /**
+   * Encode one animated file into an mp4.
+   *
+   * @param {ArrayBuffer} buf  TRANSFERRED to the worker — do not read it after.
+   * @returns {Promise<{art:ArrayBuffer, w:number, h:number, durMs:number}>}
+   */
+  async function encode(buf, mime, cfg = {}, onProgress = null) {
+    if (disposed) throw new Error('disposed');
+    const w = ensureWorker();
+    if (!w) return await encodeOnMainThread(buf, mime, cfg, onProgress);
+
+    seq += 1;
+    const id = 'local-' + seq;
+    const job = { onProgress, touched: Date.now(), resolve: null, reject: null, timer: null };
+    const p = new Promise((res, rej) => { job.resolve = res; job.reject = rej; });
+    jobs.set(id, job);
+    try {
+      job.timer = setTimeout(() => settle(id, (jj) => jj.reject(new Error('encode-timeout'))), ANIM_TIMEOUT_MS);
+      if (job.timer && typeof job.timer.unref === 'function') job.timer.unref();
+    } catch (_e) { /* no timers is not fatal */ }
+
+    try {
+      w.postMessage({ kind: 'encode', jobId: id, buf, mime, cfg }, [buf]);
+    } catch (e) {
+      settle(id, (jj) => jj.reject(new Error('post-failed')));
+      warn('postMessage failed: ' + ((e && e.message) || e));
+      throw new Error('post-failed');
+    }
+    return await p;
+  }
+
+  /**
+   * No Worker (or it died): run the identical job here. Slower and it blocks the
+   * page, but "this browser cannot send GIFs" is a much worse answer, and the
+   * import is dynamic so a runtime that never needs it never pays for the muxer.
+   */
+  async function encodeOnMainThread(buf, mime, cfg, onProgress) {
+    let mod = null;
+    try { mod = await import('../encode/encodeWorker.js'); } catch (e) {
+      warn('encode module unavailable: ' + ((e && e.message) || e));
+      throw new Error('no-encoder');
+    }
+    if (!mod || typeof mod.runEncodeJob !== 'function') throw new Error('no-encoder');
+    const out = await mod.runEncodeJob(buf, mime, cfg, {
+      onProgress: (pct) => { try { onProgress?.(pct); } catch (_e) { /* ignore */ } },
+      shouldStop: () => disposed,
+    });
+    return { art: out.art, w: out.w, h: out.h, durMs: out.durMs };
+  }
+
+  return {
+    encode,
+    get busy() { return jobs.size > 0; },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const id of Array.from(jobs.keys())) settle(id, (job) => job.reject(new Error('disposed')));
+      if (worker) { try { worker.terminate(); } catch (_e) { /* ignore */ } worker = null; }
+    },
+  };
+}
+
+/* --------------------------------------------------------------- the lanes */
+
+/**
+ * Compress one still into a ≤1920-edge WebP (or JPEG where WebP is refused).
+ *
+ * @param {File|Blob|ArrayBuffer|Uint8Array} src
+ * @param {string} mime  the SOURCE mime — only used to build a Blob when needed
+ * @param {object} [o]   {maxEdge, quality, jpegQuality}
+ * @returns {Promise<{blob:Blob, mime:string, w:number, h:number, kind:'image'}>}
+ */
+export async function compressImage(src, mime, o = {}) {
+  const maxEdge = Math.max(16, Math.floor(Number(o.maxEdge) || IMAGE_MAX_EDGE));
+  const q = Math.min(1, Math.max(0.1, Number(o.quality) || IMAGE_WEBP_QUALITY));
+  const jq = Math.min(1, Math.max(0.1, Number(o.jpegQuality) || IMAGE_JPEG_QUALITY));
+
+  const blob = await toBlob(src, mime);
+  if (!blob) throw new Error('no-blob');
+  const dec = await decodeStill(blob);
+  try {
+    const fit = fitDown(dec.w, dec.h, maxEdge);
+    const canvas = makeCanvas(fit.w, fit.h);
+    if (!canvas) throw new Error('no-canvas');
+    // OffscreenCanvas takes its size at construction; a DOM canvas needs it set.
+    try { canvas.width = fit.w; canvas.height = fit.h; } catch (_e) { /* read-only on some stubs */ }
+    const ctx = canvas.getContext('2d');
+    if (!ctx || typeof ctx.drawImage !== 'function') throw new Error('no-2d-context');
+    ctx.drawImage(dec.image, 0, 0, fit.w, fit.h);
+
+    // WEBP IS ASKED FOR, NEVER ASSUMED. Safari's canvas answers a PNG for an
+    // unsupported type instead of failing, so the produced blob's own type is
+    // the only trustworthy signal — and a PNG of a photo is bigger than the
+    // source we were trying to shrink.
+    let out = await canvasToBlob(canvas, 'image/webp', q);
+    let type = String((out && out.type) || '').toLowerCase();
+    if (!out || type.indexOf('image/webp') !== 0) {
+      const jpg = await canvasToBlob(canvas, 'image/jpeg', jq);
+      if (jpg && jpg.size > 0) { out = jpg; type = String(jpg.type || 'image/jpeg').toLowerCase(); }
+    }
+    if (!out || !out.size) throw new Error('encode-failed');
+
+    const outMime = type.indexOf('image/webp') === 0 ? 'image/webp'
+      : type.indexOf('image/png') === 0 ? 'image/png'
+        : 'image/jpeg';
+    return { blob: out, mime: outMime, w: fit.w, h: fit.h, kind: 'image' };
+  } finally {
+    dec.close();
+  }
+}
+
+/**
+ * Compress one animated GIF / animated WebP into an mp4, via lane B's worker.
+ *
+ * @returns {Promise<{blob:Blob, mime:'video/mp4', w:number, h:number, durMs:number, kind:'video'}>}
+ */
+export async function compressGif(src, mime, o = {}) {
+  const driver = o.driver || createLocalEncodeDriver({ logger: o.logger || null });
+  const owned = !o.driver;
+  const type = String(mime || '').toLowerCase() === 'image/webp' ? 'image/webp' : 'image/gif';
+  const cfg = {
+    maxBox: Math.max(64, Number(o.maxBox) || ANIM_MAX_BOX),
+    bitrate: Math.max(100000, Number(o.bitrate) || ANIM_BITRATE),
+    maxFps: Math.max(1, Number(o.maxFps) || ANIM_MAX_FPS),
+    // The micro-preview is a HOSTED concept (a second part stream on the cache
+    // bridge). Standalone has nowhere to put one, so it is not encoded at all.
+    wantPrev: false,
+  };
+  try {
+    const buf = await toArrayBuffer(src);
+    const out = await driver.encode(buf, type, cfg, o.onProgress || null);
+    const B = globalThis.Blob;
+    if (typeof B !== 'function') throw new Error('no-blob');
+    const blob = new B([out.art], { type: 'video/mp4' });
+    if (!blob.size) throw new Error('empty-output');
+    return { blob, mime: 'video/mp4', w: out.w, h: out.h, durMs: out.durMs, kind: 'video' };
+  } finally {
+    if (owned) { try { driver.dispose(); } catch (_e) { /* ignore */ } }
+  }
+}
+
+/**
+ * The compressor the store adopts through.
+ *
+ * A FACTORY, not a module-level singleton, because the whole point of the seam
+ * is that the node selftest hands the store a stub with the same two methods and
+ * drives the POLICY without a canvas, a decoder or a Worker in sight. The real
+ * one is exercised in the browser only.
+ *
+ * @param {object} [o] {logger, workerFactory}
+ * @returns {{compressImage:Function, compressGif:Function, dispose:Function}}
+ */
+export function createLocalCompressor(o = {}) {
+  let driver = null;
+  let disposed = false;
+
+  function ensureDriver() {
+    if (!driver && !disposed) {
+      driver = createLocalEncodeDriver({ workerFactory: o.workerFactory || null, logger: o.logger || null });
+    }
+    return driver;
+  }
+
+  return {
+    compressImage(src, mime, opts = {}) {
+      return compressImage(src, mime, opts);
+    },
+    compressGif(src, mime, opts = {}) {
+      // Probed HERE, not inside compressGif: the primitive is also the seam a
+      // test drives with an injected driver, and a global-sniffing guard inside
+      // it would make that untestable. This is the production entry point, and
+      // it is the one that must not build a worker it cannot use.
+      if (!canEncodeAnimated()) return Promise.reject(new Error('no-encoder'));
+      return compressGif(src, mime, Object.assign({ logger: o.logger || null }, opts, { driver: ensureDriver() }));
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (driver) { try { driver.dispose(); } catch (_e) { /* ignore */ } driver = null; }
+    },
+  };
+}
+
+export default createLocalCompressor;

--- a/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
@@ -53,6 +53,17 @@ export const PREF_DEFAULTS = Object.freeze({
    * the same request, and a pref that only hid the pixels would be a lie.
    */
   showOpponentAvatars: true,
+  /**
+   * The HUD's zen toggle (ui/hud.js): score, risk, the closeness dial and the
+   * mercy button hidden, leaving the opponent monitor and the arsenal. OFF by
+   * default — a duel you cannot read your own score in is a choice, never a
+   * starting position — and remembered only so a player who wants the quiet
+   * desk does not have to ask for it every match. It is NOT mirrored onto
+   * <html> from here: ui/hud.js owns that bit for as long as a HUD is mounted,
+   * and a stale attribute would hide the mercy button with no button to bring
+   * it back.
+   */
+  hudZen: false,
   /** Last consent terms this player proposed — pre-filled next lobby. */
   matchLengthSec: 720,
   payloadGapSec: 30,

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/assets.js
@@ -28,7 +28,8 @@
 import { createLedger, el, button } from '../router.js';
 import { S } from '../strings.js';
 import {
-  CONFIRM_ETA_MS, CONFIRM_INPUT_BYTES, FILTERS, GB, LOCAL_MAX_BYTES, NEEDS_STATES,
+  CONFIRM_ETA_MS, CONFIRM_INPUT_BYTES, FILTERS, GB, LOCAL_ARTIFACT_MAX_BYTES, LOCAL_MAX_BYTES,
+  LOCAL_ZIP_MAX_ENTRIES, NEEDS_STATES,
   capGb, etaMinutes, formatBytes, formatUsage, matchesFilter, normalizeState, pendingInputBytes,
 } from '../assetsStore.js';
 
@@ -606,25 +607,54 @@ function unavailableCard(onBack, ledger, audio) {
 function localMediaCard({ store, ledger, audio, actions, logger }) {
   const L = S.assets.local;
   const maxText = formatBytes(LOCAL_MAX_BYTES);
+  const artMaxText = formatBytes(LOCAL_ARTIFACT_MAX_BYTES);
 
   const input = el('input', { type: 'file', class: 'gg-sr-only', multiple: true, accept: LOCAL_ACCEPT, 'aria-hidden': 'true', tabindex: '-1' });
   const addBtn = button(ledger, L.add, () => { try { input.click(); } catch (_e) { /* ignore */ } }, { variant: 'primary', audio });
   const status = el('p', { class: 'gg-assets-eta', text: '', role: 'status', hidden: true });
+  /* A SECOND status line, and not the same one as the summary: the summary is
+   * the answer and this is the wait. Folding them together means the last run's
+   * result is what the player stares at while the next one runs. */
+  const progress = el('p', { class: 'gg-assets-eta gg-local-progress', text: '', role: 'status', hidden: true });
   const list = el('div', { class: 'gg-local-list', role: 'list' });
+
+  /* Adding a big zip is minutes of decoding and encoding now, so the card says
+   * so while it happens. Through the ledger, like every other subscription. */
+  if (typeof store.onLocalProgress === 'function') ledger.sub(store.onLocalProgress((p) => {
+    if (!p || !p.running) { progress.hidden = true; progress.textContent = ''; return; }
+    progress.hidden = false;
+    if (p.pct > 0 && p.name) progress.textContent = L.compressing(p.name, p.pct);
+    else if (p.total > 1) progress.textContent = L.adding(Math.min(p.done + 1, p.total), p.total);
+    else progress.textContent = p.name ? L.addingOne(p.name) : L.adding(p.done, Math.max(1, p.total));
+  }));
 
   ledger.listen(input, 'change', () => {
     const files = input.files;
     if (!files || !files.length) return;
     addBtn.disabled = true;
+    status.hidden = true;
     store.addLocalFiles(files).then((r) => {
       addBtn.disabled = false;
       try { input.value = ''; } catch (_e) { /* ignore */ }
       const bits = [];
       if (r.added) bits.push(L.added(r.added));
+      // Worth its own clause: the whole point of the compression lanes is that
+      // files which used to be refused are now sendable, and the player should
+      // be told that is what happened to them.
+      if (r.compressed) bits.push(L.compressed(r.compressed));
       if (r.dupes) bits.push(L.skipDupe(r.dupes));
       if (r.tooBig) bits.push(L.skipBig(r.tooBig, maxText));
+      // Video is the one family the page cannot re-encode, so it gets the
+      // ARTIFACT cap in its own sentence rather than the exempt one.
+      if (r.tooBigVideo) bits.push(L.skipBigVideo(r.tooBigVideo, artMaxText));
       if (r.badType) bits.push(L.skipType(r.badType));
       if (r.failed) bits.push(L.skipFailed(r.failed));
+      // "Took the first 500" is not a failure and must never read as one.
+      if (r.trimmed) bits.push(L.trimmed(r.trimmed, LOCAL_ZIP_MAX_ENTRIES));
+      // An archive we could not OPEN is its own sentence. It must never be
+      // folded into skipBig: the per-file cap text on an archive failure is how
+      // a 1 GB library got reported as "1 over 8 MB".
+      if (r.zipBad) bits.push(L.zipBad(r.zipBad));
       // An archive that opened and held nothing sendable would otherwise say
       // nothing at all, which reads as "the button is broken".
       if (!bits.length && r.zips) bits.push(L.zipNone);
@@ -639,15 +669,25 @@ function localMediaCard({ store, ledger, audio, actions, logger }) {
 
   function row(it) {
     const thumb = el('div', { class: 'gg-local-thumb' });
-    if (it.srcUrl && it.kind === 'image') {
-      thumb.appendChild(el('img', { src: it.srcUrl, alt: '', decoding: 'async', loading: 'lazy' }));
+    // A COMPRESSED pick has no srcUrl — its bytes are the artifact, behind
+    // artUrl. Reading only srcUrl here is how a compressed photo renders as the
+    // word "image" next to a perfectly good thumbnail.
+    const previewUrl = it.srcUrl || it.artUrl || '';
+    if (previewUrl && it.kind === 'image') {
+      thumb.appendChild(el('img', { src: previewUrl, alt: '', decoding: 'async', loading: 'lazy' }));
     } else {
       thumb.appendChild(el('span', { class: 'gg-local-thumb-kind', text: it.kind === 'video' ? 'video' : 'image' }));
     }
     const name = el('span', { class: 'gg-local-name' });
     name.textContent = String(it.name || '');          // user data — text, always
     name.title = String(it.name || '');
-    const size = el('span', { class: 'gg-local-size', text: formatBytes(it.bytes) });
+    // What it weighs ON THE WIRE, and what it weighed before — a compressed pick
+    // showing only its new size looks like the picker lied about the file.
+    const shrunk = it.srcBytes > it.bytes;
+    const size = el('span', {
+      class: 'gg-local-size',
+      text: shrunk ? L.sizeShrunk(formatBytes(it.srcBytes), formatBytes(it.bytes)) : formatBytes(it.bytes),
+    });
     const rm = el('button', { type: 'button', class: 'gg-asset-act', text: L.remove });
     ledger.listen(rm, 'click', () => {
       try { audio?.sfx?.('ui-back'); } catch (_e) { /* stub bus */ }
@@ -673,7 +713,8 @@ function localMediaCard({ store, ledger, audio, actions, logger }) {
     el('h2', { class: 'gg-assets-standalone-head', text: L.headline }),
     el('p', { class: 'gg-lead', text: L.line }),
     el('div', { class: 'gg-assets-tools-row gg-local-tools' }, [addBtn, input]),
-    el('p', { class: 'gg-assets-note', text: L.limits(maxText) }),
+    el('p', { class: 'gg-assets-note', text: L.limits(maxText, artMaxText) }),
+    progress,
     status,
     list,
     el('p', { class: 'gg-assets-note', text: L.note }),

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/join.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/join.js
@@ -111,6 +111,7 @@ export function mount(container, ctx) {
     switch (kind) {
       case 'unknown_code': return S.join.errUnknown;
       case 'already_joined': return S.join.errFull;
+      case 'self_join': return S.join.errSelf;
       case 'expired': return S.join.errExpired;
       default: return null;
     }

--- a/ConditioningControlPanel/Resources/web/goon/ui/sheets.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/sheets.js
@@ -135,6 +135,13 @@ export function createSheets({ root = null, audio = null, logger = null } = {}) 
         });
       case 'unauthorized':
         return open({ icon: S.sheets.unauthorized.icon, headline: S.sheets.unauthorized.headline, line: S.sheets.unauthorized.line });
+      // The join SCREEN renders these two inline; they only reach a sheet from a
+      // path with no red line to put them on. Either way they must not fall through
+      // to the network sheet — the room answered fine, it just said no.
+      case 'already_joined':
+        return open({ icon: S.sheets.seatTaken.icon, headline: S.sheets.seatTaken.headline, line: S.sheets.seatTaken.line });
+      case 'self_join':
+        return open({ icon: S.sheets.selfJoin.icon, headline: S.sheets.selfJoin.headline, line: S.sheets.selfJoin.line });
       case 'ice_timeout':
       case 'relay_failed':
       case 'signaling_failed':

--- a/ConditioningControlPanel/Resources/web/goon/ui/soloDriver.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/soloDriver.js
@@ -36,6 +36,48 @@ const LOCKCARD_MS = [4200, 6800];
 /** Gap between bubble pops. */
 const BUBBLE_POP_MS = [420, 900];
 
+/* ----------------------------------------------------------------------------
+ * THE OPENING SALVO — practice only, and it exists because of one owner report:
+ * "from mobile it's not triggering any asset even if I uploaded them and went to
+ * practice" (2026-08-04).
+ *
+ * THE SHAPE OF THAT BUG. In a duel your arsenal shot lands on THEIR screen. In
+ * practice the opponent is this script, which has no exec/ renderer at all (see
+ * the fake-window block below), so a payload the player fires is a payload
+ * nobody ever sees. The only media that reaches the practice player's own screen
+ * is (a) the element ramp and (b) what the bot throws BACK — and an inbound
+ * payload resolves against the RECEIVER's library (exec/media.js drawFor falls
+ * through to drawKind), so the bot's flash burst is drawn from the player's OWN
+ * uploads. That is the loop that shows a phone player their library, and it used
+ * to depend on the bot first earning charges the slow way: `tryPayload` waits
+ * PAYLOAD_TRY_MS, skips 35% of its turns and needs `charges >= cost`, which on a
+ * fresh match can be minutes of nothing.
+ *
+ * So the bot opens on a clock instead of on its economy. The charges are still
+ * credited through the engine (`creditCharges`), so the wire truth the receiver
+ * validates is the truth — this buys the bot no shot it could not have taken.
+ *
+ * PRACTICE ONLY, structurally: createSoloDriver is constructed in exactly one
+ * place (boot.js startSolo). Duel balance cannot reach this file.
+ * ------------------------------------------------------------------------- */
+export const SALVO = Object.freeze([
+  // Images, almost immediately: the whole point is "I can see my own pictures".
+  Object.freeze({ atMs: 6000, kind: GoonPayloadKind.FlashBurst, durationMs: 6000, intensity: 0.7 }),
+  // …and a clip, past the engine's 30s payload gap, into a floating window.
+  Object.freeze({ atMs: 45000, kind: GoonPayloadKind.Video, durationMs: 45000, intensity: 0.6 }),
+]);
+
+/**
+ * How long BEFORE a salvo shot its charges are credited.
+ *
+ * THE RECEIVER IS THE AUTHORITY ON THE SENDER'S WALLET, and it reads that wallet
+ * off the last state tick, not off the payload frame — credit-then-fire in the
+ * same turn is rejected with `charge economy: claimed 0 < cost 1`, which is
+ * exactly what the first cut of this salvo did. GoonConsts.TickIntervalMs is
+ * 3000, so a lead comfortably past one tick is what makes the shot land.
+ */
+export const SALVO_CREDIT_LEAD_MS = 5000;
+
 /**
  * @param {object} o
  * @param {object} o.match the GUEST match (its transport is the loopback peer)
@@ -177,8 +219,15 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
     }, pick(DRAFT_THINK_MS));
   }
 
+  /** Salvo shots whose charges are credited and not yet spent (see fireSalvo). */
+  let salvoArmed = 0;
+
   function tryPayload() {
     if (match.phase !== GoonMatchPhase.Live && match.phase !== GoonMatchPhase.SuddenDeath) return;
+    // A salvo shot's charges are already credited and SPOKEN FOR. Letting the
+    // ordinary cadence spend them would turn "the practice player sees a clip at
+    // 45s" into a coin flip.
+    if (salvoArmed > 0) return;
     const charges = match.scoring.charges;
     const affordable = (match.availablePayloadKinds || [])
       .filter((k) => k !== GoonPayloadKind.BrainDrain && costOf(k) <= charges);
@@ -193,6 +242,43 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
       text: null,
     });
     log('payload ' + kind + (res.ok ? ' sent' : ' refused: ' + res.error));
+  }
+
+  /**
+   * Step one of a salvo shot: put the charges in the wallet, early enough that a
+   * state tick carries them to the receiver (SALVO_CREDIT_LEAD_MS). A kind the
+   * agreement left out never gets funded — the bot cannot send what the two of
+   * you did not allow, salvo or not.
+   */
+  function armSalvo(spec) {
+    if (ledger.isDisposed || match.phase !== GoonMatchPhase.Live) return;
+    if (!(match.availablePayloadKinds || []).includes(spec.kind)) {
+      log('salvo ' + spec.kind + ' skipped (not in the agreed pool)');
+      return;
+    }
+    const cost = costOf(spec.kind);
+    const have = (match.scoring && match.scoring.charges) | 0;
+    if (have < cost) match.creditCharges(cost - have, 'practice-salvo');
+    salvoArmed++;
+  }
+
+  /**
+   * Step two: fire, through the SAME public API tryPayload uses, so every engine
+   * gate (phase, rate limit, caps, the shared pool, the charge check) still
+   * applies. Whatever happens the shot stops being reserved.
+   */
+  function fireSalvo(spec) {
+    if (ledger.isDisposed) return;
+    if (salvoArmed > 0) salvoArmed--;
+    if (match.phase !== GoonMatchPhase.Live) return;
+    if (!(match.availablePayloadKinds || []).includes(spec.kind)) return;
+    const res = match.tryFirePayload({
+      kind: spec.kind,
+      durationMs: spec.durationMs,
+      intensity: spec.intensity,
+      text: null,
+    });
+    log('salvo ' + spec.kind + (res.ok ? ' sent' : ' refused: ' + res.error));
   }
 
   /* ------------------------------------------------ fake floating windows */
@@ -220,6 +306,14 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
       case GoonMatchPhase.Draft: doDraft(); break;
       case GoonMatchPhase.Live:
         match.setCloseness(1);
+        // The salvo BEFORE the economy timer: it is the only thing that puts the
+        // practice player's own library on the practice player's own screen on a
+        // predictable clock. Through the ledger, so leaving mid-match cannot land
+        // a flash burst on the recap.
+        for (const spec of SALVO) {
+          ledger.timer(() => armSalvo(spec), Math.max(0, spec.atMs - SALVO_CREDIT_LEAD_MS));
+          ledger.timer(() => fireSalvo(spec), spec.atMs);
+        }
         payloadTimer = ledger.interval(tryPayload, PAYLOAD_TRY_MS);
         ledger.interval(() => {
           if (match.phase !== GoonMatchPhase.Live) return;

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -354,7 +354,8 @@ export const S = Object.freeze({
       headline: 'add media to send',
       line: 'pick files from this device and they can travel to your opponent mid-duel, straight from you to them. nothing is uploaded anywhere.',
       add: 'add files',
-      limits: (max) => 'up to ' + max + ' each · jpg, png, gif, webp, mp4, webm · or a zip of them',
+      limits: (max, vmax) => 'jpg, png, gif, webp, mp4, webm · or a zip of them · up to ' + max
+        + ' travels as-is, bigger photos and gifs are compressed to fit, clips up to ' + vmax,
       empty: 'nothing added yet.',
       note: 'your picks last until this page closes — add them again next visit.',
       remove: 'remove',
@@ -363,8 +364,41 @@ export const S = Object.freeze({
       skipType: (n) => n + ' of an unsupported type',
       skipFailed: (n) => n + ' unreadable',
       added: (n) => n + ' added',
+      /**
+       * Adding is no longer instant — a zip of two hundred photos is two hundred
+       * decodes and two hundred encodes. This line is the whole difference
+       * between "working" and "the button is broken"; it lives on a role=status.
+       */
+      adding: (done, total) => 'adding ' + done + ' / ' + total + '…',
+      addingOne: (name) => 'adding ' + name + '…',
+      /** Mid-compression, when the encoder is actually reporting a percentage. */
+      compressing: (name, pct) => 'compressing ' + name + '… ' + pct + '%',
+      /** The good news in the summary: these were too big, and now they are not. */
+      compressed: (n) => n + ' compressed to fit',
+      /**
+       * A clip past the wire's artifact cap. Its OWN sentence, carrying the
+       * VIDEO number: a browser cannot transcode video, so this is the one
+       * refusal the player can act on (trim it, or send a gif instead).
+       */
+      skipBigVideo: (n, max) => n + (n === 1 ? ' video' : ' videos') + ' too big to send (' + max + ' max)',
+      /**
+       * The ceilings trimmed a REAL library. Never "unreadable", never a
+       * per-file size: what happened is that we took the first N of something
+       * legitimate, and the player is owed exactly that sentence.
+       */
+      trimmed: (n, max) => n + ' more left out — one zip adds its first ' + max + ' files',
+      /** A compressed row: what it weighed, and what actually travels. */
+      sizeShrunk: (from, to) => from + ' → ' + to,
       /** A zip opened fine and held nothing we can send — say so, never stay silent. */
       zipNone: 'no media in that zip',
+      /**
+       * The ARCHIVE itself could not be opened (corrupt, truncated, a format we
+       * cannot walk). Its own line on purpose: the size of a zip is no longer a
+       * reason to refuse one, and reporting an archive failure with the
+       * per-file cap text is what told a player with a 1 GB library that it was
+       * "1 over 8 MB".
+       */
+      zipBad: (n) => (n === 1 ? "couldn't open that zip" : n + " zips couldn't be opened"),
     },
 
     statReady: (n) => n + ' ready',

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -81,6 +81,9 @@ export const S = Object.freeze({
     back: 'Back',
     errUnknown: 'No room with that code. Check the last character?',
     errFull: 'That room already has two players.',
+    // NOT "full": the other seat is yours. Sending a player off to re-read a code
+    // they typed correctly is the worst thing this screen can do.
+    errSelf: 'That is your own room — the other player has to be on a different account.',
     errExpired: 'That code expired. Ask for a fresh one.',
     errShort: 'six characters, please.',
   },
@@ -505,6 +508,19 @@ export const S = Object.freeze({
       headline: 'Could not connect',
       line: 'Neither a direct nor a relayed link came up. Try again.',
     },
+    // A seat problem is never a connection problem, and the fall-through sheet
+    // ("could not reach the server") would tell the player to check their wifi
+    // about a room that answered perfectly.
+    seatTaken: {
+      icon: '👥',
+      headline: 'That room is taken',
+      line: 'Someone else is already in there. Ask for a fresh code.',
+    },
+    selfJoin: {
+      icon: '🪞',
+      headline: 'That is your own room',
+      line: 'You are the host of that code. The other player has to be on a different account.',
+    },
     lobbyFailed: {
       icon: '⚙',
       headline: 'This pairing will not work',
@@ -513,6 +529,25 @@ export const S = Object.freeze({
     ok: 'OK',
     cancel: 'Cancel',
     retry: 'Try again',
+  },
+
+  /* ------------------------------------------------------ the desk's chrome
+   * The zen toggle (ui/hud.js): ONE button that clears the desk down to the
+   * opponent monitor and the arsenal — the score, the risk multiplier, the
+   * closeness dial and the mercy button all step off together.
+   *
+   * A glyph, because it sits in the top-right corner beside the gear where a
+   * word would not fit, so the label travels in aria-label + title instead and
+   * the pressed state travels in aria-pressed. The "escape still ends the
+   * match" half is not decoration: while the panels are away it is the only
+   * place that says so. */
+  hud: {
+    zenHide: 'hide panels',
+    zenShow: 'show panels',
+    /** ⊟ collapse / ⊞ expand — a box that loses and regains its contents. */
+    zenHideGlyph: '⊟',
+    zenShowGlyph: '⊞',
+    zenShowTitle: 'show panels · escape still ends the match',
   },
 
   /* ------------------------------------------------- the opponent monitor */

--- a/ConditioningControlPanel/Resources/web/goon/ui/zipReader.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/zipReader.js
@@ -6,37 +6,79 @@
  * addLocalFiles() detects a zip and asks here for the media inside it, then
  * adopts each entry down the EXACT same road a hand-picked file takes.
  *
- * THE APPROACH IS BORROWED, ON PURPOSE. cclabs-site's sissy-fall minigame has
- * shipped this shape for a while (js/sissy-fall/media.js -> addZip): walk the
- * central directory with a filter that inflates NOTHING, decide from the entry
- * names and their declared sizes what is worth having, and only then inflate
- * the survivors one at a time. Same vendored library (vendor/fflate, MIT),
- * same two-pass walk, same reason: a 2 GB archive must never be inflated whole
- * into a tab's heap to find out it held one gif.
+ * THE ARCHIVE IS NEVER READ WHOLE. This module reads a zip the way a browser
+ * reads a REMOTE zip — by range — except the ranges are Blob.slice() calls on
+ * the picked File. Four kinds of read, and nothing else:
+ *
+ *   1. the TAIL (≤64 KB + 22 B) to find the End Of Central Directory record;
+ *   2. the CENTRAL DIRECTORY range the EOCD points at — names, methods and
+ *      declared sizes for every entry, which is all the filtering needs;
+ *   3. per surviving entry, its 30-byte LOCAL FILE HEADER, to learn where its
+ *      data actually starts;
+ *   4. per surviving entry, exactly its compressed bytes.
+ *
+ * A 1 GB library zip therefore costs a tail, a directory, and one entry at a
+ * time — never 1 GB of a phone's heap. This replaces an earlier shape that read
+ * the whole archive into an ArrayBuffer and refused anything over 512 MB; that
+ * refusal was reported as `tooBig`, which the summary line renders with the
+ * PER-FILE cap text, so a player with a 1 GB library was told "1 over 8 MB".
+ * A big library is the USE CASE. There is no archive-size ceiling here at all.
  *
  * THINGS THAT ARE NOT DECORATION
  *   1. NOTHING HERE THROWS AT IMPORT, and fflate is loaded LAZILY, by dynamic
- *      import, the first time a player actually picks a zip. A static import
- *      would put 90 KB in front of every page load for a feature most sessions
- *      never touch — and an import that throws in WebView2 is a silent infinite
- *      loader, which is this project's worst failure mode.
+ *      import, and only when a surviving entry is actually DEFLATED. A static
+ *      import would put 90 KB in front of every page load for a feature most
+ *      sessions never touch — and an import that throws in WebView2 is a silent
+ *      infinite loader, which is this project's worst failure mode.
  *   2. THE CEILINGS ARE THE FEATURE. A zip is attacker-shaped input even when
  *      the attacker is just a curious player: MAX_ENTRIES caps the count,
  *      MAX_TOTAL_BYTES caps the inflated total (the zip-bomb guard, checked
  *      against the DECLARED size before a single byte is inflated), and the
- *      per-entry cap is the caller's exempt ceiling.
- *   3. NO RECURSION. A zip inside the zip is skipped, not opened. There is no
+ *      per-entry verdict is the CALLER'S (`classify`) — the store now has a road
+ *      for a 12 MB photo (compress it) that it does not have for a 30 MB clip
+ *      (nothing a browser can do), and those two refusals are different
+ *      sentences. What is gone is only the ceiling on the COMPRESSED archive,
+ *      which no longer costs us anything.
+ *      A ceiling that trims a LEGITIMATE library reports `trimmed`, never
+ *      `failed`: "took the first 500" and "unreadable" are not the same news.
+ *   3. THE LOCAL HEADER IS RE-READ ON PURPOSE. A local header's extra field is
+ *      routinely a different length from the same entry's central-directory
+ *      record (zip64 placeholders, unix timestamps, alignment padding). Taking
+ *      the central copy lands the read a few bytes inside the data — the
+ *      classic offset bug, and it corrupts silently.
+ *   4. NO RECURSION. A zip inside the zip is skipped, not opened. There is no
  *      depth counter to get wrong because there is no depth.
- *   4. A corrupt archive is an ANSWER (`ok:false`), never an exception: the
- *      caller counts it as one failed pick and the player keeps their screen.
+ *   5. A corrupt archive is an ANSWER (`ok:false` + a `reason`), never an
+ *      exception, and the caller must never render it as a per-file refusal.
+ *
+ * WHAT IS NOT CHECKED, AND WHY: entry CRCs. A truncated or scrambled deflate
+ * stream makes inflate throw, and every entry's inflated length is compared to
+ * its declared size, which catches the rest. CRC-32 over half a gigabyte on a
+ * mid-range phone is seconds of main-thread work to re-confirm what two cheaper
+ * checks already said.
  * ==========================================================================*/
 
 /** At most this many entries are taken from one archive. */
 export const ZIP_MAX_ENTRIES = 500;
-/** Inflated bytes per archive, total. Past this the rest is dropped as failed. */
-export const ZIP_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+/**
+ * Inflated bytes per archive, total — the heap-spike backstop, NOT a library
+ * ceiling. Entries are streamed one at a time (see `onEntry`), so this bound is
+ * about how much work one pick may plan, and 1 GB is a real photo library. Past
+ * it the remainder is `trimmed` — TAKEN THE FIRST N, never "unreadable".
+ */
+export const ZIP_MAX_TOTAL_BYTES = 1024 * 1024 * 1024;
+/** The tail we slice hunting the EOCD: the 22-byte record + a max-length comment. */
+export const ZIP_EOCD_SCAN_BYTES = 22 + 0xFFFF;
+/** Sanity ceiling on the central-directory slice itself (~1M entries' worth). */
+export const ZIP_MAX_CENTRAL_BYTES = 64 * 1024 * 1024;
 /** Yield to the event loop every this many inflated entries, so the UI paints. */
 const YIELD_EVERY = 8;
+
+const SIG_EOCD = 0x06054b50;      // end of central directory
+const SIG_EOCD64 = 0x06064b50;    // zip64 end of central directory record
+const SIG_LOC64 = 0x07064b50;     // zip64 end of central directory locator
+const SIG_CEN = 0x02014b50;       // central directory file header
+const SIG_LOC = 0x04034b50;       // local file header
 
 /** Is this name (or File) a zip? Used both to route picks and to refuse nesting. */
 export function isZipName(name) {
@@ -74,6 +116,10 @@ export function baseName(name) {
  * Loaded once, on first use, and REMEMBERED as a promise so two zips picked in
  * the same breath do not fetch it twice. A failure to load is cached as null,
  * not retried forever: the runtime that cannot import it will not learn to.
+ *
+ * Only `inflateSync` is wanted now (RAW deflate — no zlib or gzip wrapper),
+ * because this module does its own walking. An archive whose surviving entries
+ * are all STORED never touches this at all.
  * ------------------------------------------------------------------------ */
 
 let flatePromise = null;
@@ -81,7 +127,7 @@ let flatePromise = null;
 async function loadFlate() {
   if (!flatePromise) {
     flatePromise = import('../vendor/fflate/fflate.module.js')
-      .then((m) => (m && typeof m.unzipSync === 'function' ? m : null))
+      .then((m) => (m && typeof m.inflateSync === 'function' ? m : null))
       .catch(() => null);
   }
   return flatePromise;
@@ -90,79 +136,346 @@ async function loadFlate() {
 /** Test seam: forget the cached module (and any cached failure). */
 export function _resetZipLib() { flatePromise = null; }
 
+/* ------------------------------------------------------------ byte plumbing */
+
 /**
- * Pull the eligible media out of one zip.
+ * Everything this module reads goes through here, so "how much of the archive
+ * did we actually touch" is one function's worth of answer.
+ */
+async function sliceU8(blob, start, end) {
+  const size = blob.size;
+  const a = Math.max(0, Math.min(size, Math.floor(Number(start) || 0)));
+  const b = Math.max(a, Math.min(size, Math.floor(Number(end) || 0)));
+  if (b <= a) return new Uint8Array(0);
+  const ab = await blob.slice(a, b).arrayBuffer();
+  return new Uint8Array(ab);
+}
+
+/**
+ * A 64-bit little-endian field, as a Number. Zip64 sizes past 2^53 would go
+ * lossy here, but every one of them is orders of magnitude past the ceilings
+ * that reject the entry anyway — and reading it as two u32s keeps BigInt (and
+ * its older-WebView2 gaps) off this path entirely.
+ */
+function u64(dv, off) {
+  return dv.getUint32(off + 4, true) * 4294967296 + dv.getUint32(off, true);
+}
+
+/** Blob-like in, Blob-like out. Bytes are wrapped rather than refused. */
+function toBlob(src) {
+  if (!src) return null;
+  if (typeof src.slice === 'function' && typeof src.arrayBuffer === 'function'
+      && typeof src.size === 'number') {
+    return src;
+  }
+  // A legacy caller handing over raw bytes still works: wrap them so there is
+  // exactly ONE reading path below.
+  try {
+    const u8 = src instanceof Uint8Array ? src : new Uint8Array(src);
+    if (typeof Blob === 'function') return new Blob([u8]);
+  } catch (_e) { /* not bytes either */ }
+  return null;
+}
+
+/** Entry names are UTF-8 in every archive a phone will produce. */
+function makeDecoder() {
+  try {
+    if (typeof TextDecoder === 'function') {
+      const td = new TextDecoder('utf-8');
+      return (u8) => td.decode(u8);
+    }
+  } catch (_e) { /* fall through */ }
+  return (u8) => {
+    let s = '';
+    for (let i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i]);
+    return s;
+  };
+}
+
+function yieldTick() {
+  return new Promise((res) => { try { setTimeout(res, 0); } catch (_e) { res(); } });
+}
+
+/* ------------------------------------------------------------------- EOCD */
+
+/**
+ * Find the End Of Central Directory record by slicing ONLY the tail.
+ *
+ * The signature is scanned for backwards, and a candidate is only trusted when
+ * its declared comment length lands the record exactly at the end of the file —
+ * without that, a .png inside the archive that happens to contain the four
+ * signature bytes can win the scan.
+ *
+ * @returns {Promise<{entries:number, cdSize:number, cdOff:number}|{err:string}>}
+ */
+async function findEocd(blob) {
+  const size = blob.size;
+  if (size < 22) return { err: 'not-a-zip' };
+  const tailLen = Math.min(size, ZIP_EOCD_SCAN_BYTES);
+  const base = size - tailLen;
+  const tail = await sliceU8(blob, base, size);
+  if (tail.length < 22) return { err: 'not-a-zip' };
+  const dv = new DataView(tail.buffer, tail.byteOffset, tail.byteLength);
+
+  let at = -1;
+  let loose = -1;
+  for (let i = tail.length - 22; i >= 0; i--) {
+    if (dv.getUint32(i, true) !== SIG_EOCD) continue;
+    if (i + 22 + dv.getUint16(i + 20, true) === tail.length) { at = i; break; }
+    if (loose < 0) loose = i;
+  }
+  if (at < 0) at = loose;
+  if (at < 0) return { err: 'not-a-zip' };
+
+  const entries = dv.getUint16(at + 10, true);
+  const cdSize = dv.getUint32(at + 12, true);
+  const cdOff = dv.getUint32(at + 16, true);
+  const needs64 = entries === 0xFFFF || cdSize === 0xFFFFFFFF || cdOff === 0xFFFFFFFF;
+  if (!needs64) return { entries, cdSize, cdOff };
+
+  /* ZIP64. The locator is the 20 bytes immediately before the EOCD and points
+   * at the real record. Anything unexpected on this leg is reported as 'zip64'
+   * rather than guessed at: a misparsed directory reads as a corrupt archive. */
+  const eocdAbs = base + at;
+  if (eocdAbs < 20) return { err: 'zip64' };
+  const loc = await sliceU8(blob, eocdAbs - 20, eocdAbs);
+  if (loc.length < 20) return { err: 'zip64' };
+  const lv = new DataView(loc.buffer, loc.byteOffset, loc.byteLength);
+  if (lv.getUint32(0, true) !== SIG_LOC64) return { err: 'zip64' };
+  const recAt = u64(lv, 8);
+  if (!(recAt >= 0) || recAt + 56 > size) return { err: 'zip64' };
+  const rec = await sliceU8(blob, recAt, recAt + 56);
+  if (rec.length < 56) return { err: 'zip64' };
+  const rv = new DataView(rec.buffer, rec.byteOffset, rec.byteLength);
+  if (rv.getUint32(0, true) !== SIG_EOCD64) return { err: 'zip64' };
+  return { entries: u64(rv, 32), cdSize: u64(rv, 40), cdOff: u64(rv, 48) };
+}
+
+/* -------------------------------------------------------- central directory */
+
+/**
+ * The zip64 extended-information extra field (id 0x0001) carries ONLY the
+ * fields whose base record was written as all-ones, in a fixed order. Reading
+ * it positionally is the entire trick.
+ */
+function applyZip64Extra(cd, from, extraLen, rec) {
+  const end = Math.min(cd.length, from + extraLen);
+  let p = from;
+  const dv = new DataView(cd.buffer, cd.byteOffset, cd.byteLength);
+  while (p + 4 <= end) {
+    const id = dv.getUint16(p, true);
+    const len = dv.getUint16(p + 2, true);
+    const body = p + 4;
+    if (body + len > end) break;
+    if (id === 0x0001) {
+      let q = body;
+      if (rec.oSize === 0xFFFFFFFF && q + 8 <= body + len) { rec.oSize = u64(dv, q); q += 8; }
+      if (rec.cSize === 0xFFFFFFFF && q + 8 <= body + len) { rec.cSize = u64(dv, q); q += 8; }
+      if (rec.lho === 0xFFFFFFFF && q + 8 <= body + len) { rec.lho = u64(dv, q); q += 8; }
+      return;
+    }
+    p = body + len;
+  }
+}
+
+/**
+ * Slice the central directory and turn it into records. Nothing is decompressed
+ * and no entry data is touched: this is the pass that decides what is worth
+ * reading at all.
+ */
+async function readCentral(blob, cdOff, cdSize) {
+  if (!(cdSize > 0) || !(cdOff >= 0) || cdOff + cdSize > blob.size) return { err: 'unreadable' };
+  if (cdSize > ZIP_MAX_CENTRAL_BYTES) return { err: 'unreadable' };
+  const cd = await sliceU8(blob, cdOff, cdOff + cdSize);
+  if (cd.length < 46) return { err: 'unreadable' };
+  const dv = new DataView(cd.buffer, cd.byteOffset, cd.byteLength);
+  const dec = makeDecoder();
+  const recs = [];
+  let p = 0;
+  while (p + 46 <= cd.length) {
+    if (dv.getUint32(p, true) !== SIG_CEN) break;
+    const nameLen = dv.getUint16(p + 28, true);
+    const extraLen = dv.getUint16(p + 30, true);
+    const cmtLen = dv.getUint16(p + 32, true);
+    const nameEnd = p + 46 + nameLen;
+    if (nameEnd > cd.length) break;
+    const rec = {
+      name: dec(cd.subarray(p + 46, nameEnd)),
+      flags: dv.getUint16(p + 8, true),
+      method: dv.getUint16(p + 10, true),
+      cSize: dv.getUint32(p + 20, true),
+      oSize: dv.getUint32(p + 24, true),
+      lho: dv.getUint32(p + 42, true),
+    };
+    if (rec.oSize === 0xFFFFFFFF || rec.cSize === 0xFFFFFFFF || rec.lho === 0xFFFFFFFF) {
+      applyZip64Extra(cd, nameEnd, extraLen, rec);
+    }
+    recs.push(rec);
+    p = nameEnd + extraLen + cmtLen;
+  }
+  return { recs };
+}
+
+/* ------------------------------------------------------------- entry bytes */
+
+/**
+ * Read ONE entry: its local header (for the real data offset), then exactly its
+ * compressed bytes, then stored-or-inflated. Returns null for every way an
+ * entry can be unreadable — the caller counts one `failed`, never a dead
+ * archive.
+ */
+async function readEntryBytes(blob, w, flate) {
+  const head = await sliceU8(blob, w.lho, w.lho + 30);
+  if (head.length < 30) return null;
+  const hv = new DataView(head.buffer, head.byteOffset, head.byteLength);
+  if (hv.getUint32(0, true) !== SIG_LOC) return null;
+  // THE LOCAL EXTRA FIELD IS ITS OWN LENGTH. See note 3 in the header: taking
+  // the central record's extraLen here is the classic silent-corruption bug.
+  const dataAt = w.lho + 30 + hv.getUint16(26, true) + hv.getUint16(28, true);
+  if (dataAt + w.cSize > blob.size) return null;
+
+  const comp = await sliceU8(blob, dataAt, dataAt + w.cSize);
+  if (comp.length !== w.cSize) return null;
+
+  if (w.method === 0) return comp.length === w.oSize ? comp : null;
+  if (w.method !== 8) return null;                       // bzip2/lzma/xz — not ours to read
+  if (!flate) return null;
+  const inf = flate.inflateSync(comp);
+  // The declared size is the contract. A stream that inflates to a different
+  // length is either lying or damaged, and either way it is not adoptable.
+  return (inf && inf.length === w.oSize) ? inf : null;
+}
+
+/**
+ * Pull the eligible media out of one zip, reading only the ranges it needs.
  *
  * The caller owns what "eligible" means — assetsStore passes its own mime
  * table, so the picker, the wire's allowlist and this filter can never drift
  * apart into "the zip adopted a file the offer gate then refused".
  *
- * @param {ArrayBuffer|Uint8Array} buf   the whole archive
+ * @param {Blob|File|ArrayBuffer|Uint8Array} src  the archive; a File is the point
  * @param {object} [o]
  * @param {(name:string)=>boolean} [o.isEligible]  name -> keep it? (default: keep all non-junk)
- * @param {number} [o.maxEntryBytes]     per-entry ceiling; bigger entries count as tooBig
+ * @param {(name:string, size:number)=>('take'|'too-big'|'too-big-video')} [o.classify]
+ *   THE PER-ENTRY SIZE POLICY, owned by the caller. A single `maxEntryBytes`
+ *   cannot express what the store actually does now — a still up to the decode
+ *   cap is compressible, a video past the wire's artifact cap is not sendable at
+ *   all, and those two refusals are DIFFERENT SENTENCES to the player. Without
+ *   it, `maxEntryBytes` alone decides, exactly as before.
+ * @param {number} [o.maxEntryBytes]     hard backstop; bigger entries count as tooBig
  * @param {number} [o.maxEntries]        default ZIP_MAX_ENTRIES
- * @param {number} [o.maxTotalBytes]     default ZIP_MAX_TOTAL_BYTES
+ * @param {number} [o.maxTotalBytes]     default ZIP_MAX_TOTAL_BYTES (INFLATED bytes)
+ * @param {(planned:number)=>any} [o.onPlan]  how many entries survived pass 1, called
+ *   BEFORE the first one is inflated. The standalone card needs it to say
+ *   "adding 37 / 214" instead of counting up to a total nobody knows.
+ * @param {(e:{name:string,bytes:Uint8Array})=>any} [o.onEntry]  hand each entry over as
+ *   it comes out (awaited) INSTEAD of collecting it. Without this the result
+ *   array holds every extracted entry at once — bounded by maxTotalBytes, but
+ *   that bound is a gigabyte, which is not a thing to hold on a phone.
+ *   assetsStore streams; the tests read the array.
  * @returns {Promise<{ok:boolean, reason:string, entries:Array<{name:string, bytes:Uint8Array}>,
- *   tooBig:number, failed:number, skipped:number, truncated:boolean}>}
+ *   tooBig:number, tooBigVideo:number, failed:number, trimmed:number, skipped:number,
+ *   truncated:boolean}>}
+ *   `reason` on failure is one of: 'not-a-zip' | 'unreadable' | 'zip64' | 'no-zip-lib'.
+ *   `trimmed` is the count the CEILINGS left behind — a legitimate library that
+ *   ran past 500 entries or the inflated total. It is deliberately not `failed`:
+ *   "took the first 500" and "unreadable" are not the same news.
  */
-export async function readZipMedia(buf, o = {}) {
-  const out = { ok: false, reason: '', entries: [], tooBig: 0, failed: 0, skipped: 0, truncated: false };
+export async function readZipMedia(src, o = {}) {
+  const out = {
+    ok: false, reason: '', entries: [], took: 0,
+    tooBig: 0, tooBigVideo: 0, failed: 0, trimmed: 0, skipped: 0, truncated: false,
+  };
   const eligible = typeof o.isEligible === 'function' ? o.isEligible : () => true;
+  const classify = typeof o.classify === 'function' ? o.classify : null;
+  const onEntry = typeof o.onEntry === 'function' ? o.onEntry : null;
+  const onPlan = typeof o.onPlan === 'function' ? o.onPlan : null;
   const maxEntry = Math.max(1, Number(o.maxEntryBytes) || Infinity);
   const maxEntries = Math.max(1, Math.floor(Number(o.maxEntries) || ZIP_MAX_ENTRIES));
   const maxTotal = Math.max(1, Number(o.maxTotalBytes) || ZIP_MAX_TOTAL_BYTES);
 
-  let data = null;
-  try {
-    data = buf instanceof Uint8Array ? buf : new Uint8Array(buf || 0);
-  } catch (_e) { data = null; }
-  if (!data || data.length < 22) { out.reason = 'not-a-zip'; return out; }   // shorter than an EOCD
+  const blob = toBlob(src);
+  if (!blob || blob.size < 22) { out.reason = 'not-a-zip'; return out; }   // shorter than an EOCD
 
-  const flate = await loadFlate();
-  if (!flate) { out.reason = 'no-zip-lib'; return out; }
-
-  /* Pass 1 — walk the central directory and DECOMPRESS NOTHING. The filter
-   * returning false for every record is what makes this a cheap read: fflate
-   * hands us each header, we answer "no", and the archive is never inflated. */
-  const wanted = [];
-  let planned = 0;
+  /* Pass 0 — the tail, then the directory. Two slices, whatever the archive
+   * weighs. Every failure here is ARCHIVE-level and must be reported as such:
+   * rendering it as a per-file refusal is how a 1 GB library once got told it
+   * was "over 8 MB". */
+  let dir = null;
   try {
-    flate.unzipSync(data, {
-      filter: (f) => {
-        const name = String((f && f.name) || '');
-        if (isJunkEntry(name)) { out.skipped++; return false; }
-        if (isZipName(name)) { out.skipped++; return false; }        // no recursion, ever
-        if (!eligible(baseName(name))) { out.skipped++; return false; }
-        const size = Math.max(0, Number(f && f.originalSize) || 0);
-        if (!size || size > maxEntry) { out.tooBig++; return false; }
-        if (wanted.length >= maxEntries) { out.truncated = true; out.failed++; return false; }
-        if (planned + size > maxTotal) { out.truncated = true; out.failed++; return false; }
-        planned += size;
-        wanted.push({ name, base: baseName(name) });
-        return false;                                                 // never inflate during the walk
-      },
-    });
+    const eocd = await findEocd(blob);
+    if (eocd.err) { out.reason = eocd.err; return out; }
+    if (!eocd.entries && !eocd.cdSize) { out.ok = true; return out; }      // a genuinely empty archive
+    const central = await readCentral(blob, eocd.cdOff, eocd.cdSize);
+    if (central.err) { out.reason = central.err; return out; }
+    if (!central.recs.length) { out.reason = 'unreadable'; return out; }
+    dir = central.recs;
   } catch (_e) {
-    // A header we cannot read at all. Whatever was collected before the throw
-    // is still honest, so keep going only if there IS something.
-    if (!wanted.length) { out.reason = 'unreadable'; return out; }
+    out.reason = 'unreadable';
+    return out;
   }
 
-  /* Pass 2 — inflate the survivors one at a time, yielding periodically so the
-   * standalone card can repaint between a hundred photos. One entry that will
-   * not inflate is one failed count, not a dead archive. */
+  /* Pass 1 — decide from names and DECLARED sizes alone. Nothing is read, and
+   * nothing is decompressed: this is what makes a 1 GB archive holding one gif
+   * cost one gif. */
+  const wanted = [];
+  let planned = 0;
+  let needFlate = false;
+  for (const rec of dir) {
+    const name = String(rec.name || '');
+    if (isJunkEntry(name)) { out.skipped++; continue; }
+    if (isZipName(name)) { out.skipped++; continue; }             // no recursion, ever
+    if (!eligible(baseName(name))) { out.skipped++; continue; }
+    if (rec.flags & 0x0001) { out.failed++; continue; }           // encrypted — unreadable, honestly
+    const size = Math.max(0, Number(rec.oSize) || 0);
+    if (!size) { out.tooBig++; continue; }
+    // THE POLICY RUNS FIRST, the backstop second: a 90 MB video must be counted
+    // as "too big to send", not as "over the decode cap" — the player is told
+    // two different true things and only one of them is actionable.
+    const verdict = classify ? String(classify(baseName(name), size) || 'take') : (size > maxEntry ? 'too-big' : 'take');
+    if (verdict === 'too-big-video') { out.tooBigVideo++; continue; }
+    if (verdict !== 'take' || size > maxEntry) { out.tooBig++; continue; }
+    // Compressed bytes are what we actually slice, so they get their own bound:
+    // deflate cannot inflate a stream materially larger than its output, and a
+    // record claiming otherwise is malformed.
+    if (!(rec.cSize >= 0) || rec.cSize > size + 65536) { out.failed++; continue; }
+    if (wanted.length >= maxEntries) { out.truncated = true; out.trimmed++; continue; }
+    if (planned + size > maxTotal) { out.truncated = true; out.trimmed++; continue; }
+    planned += size;
+    if (rec.method === 8) needFlate = true;
+    wanted.push({
+      name, base: baseName(name),
+      method: rec.method, cSize: rec.cSize, oSize: size, lho: rec.lho,
+    });
+  }
+
+  /* The plan is the only honest denominator for a progress line, and it is known
+   * BEFORE any inflating happens — pass 1 read nothing but the directory. */
+  if (onPlan) { try { onPlan(wanted.length); } catch (_e) { /* a reporter never fails a read */ } }
+
+  /* fflate is asked for ONLY here, and only if something survived that is
+   * actually deflated. A STORED-only archive never pays the 90 KB. */
+  let flate = null;
+  if (needFlate) {
+    flate = await loadFlate();
+    if (!flate) { out.reason = 'no-zip-lib'; return out; }
+  }
+
+  /* Pass 2 — one entry at a time: its local header, its compressed bytes, its
+   * inflate. Peak memory is ONE ENTRY, not one archive — provided the caller
+   * takes each one via onEntry rather than letting the array grow. Yields
+   * periodically so the standalone card can repaint between a hundred photos. */
   for (let i = 0; i < wanted.length; i++) {
     const w = wanted[i];
     try {
-      const bag = flate.unzipSync(data, { filter: (f) => f && f.name === w.name });
-      const bytes = bag ? bag[w.name] : null;
-      if (bytes && bytes.length) out.entries.push({ name: w.base, bytes });
-      else out.failed++;
+      const bytes = await readEntryBytes(blob, w, flate);
+      if (bytes && bytes.length) {
+        out.took++;
+        if (onEntry) await onEntry({ name: w.base, bytes });
+        else out.entries.push({ name: w.base, bytes });
+      } else out.failed++;
     } catch (_e) { out.failed++; }
-    if ((i % YIELD_EVERY) === YIELD_EVERY - 1) {
-      await new Promise((res) => { try { setTimeout(res, 0); } catch (_e) { res(); } });
-    }
+    if ((i % YIELD_EVERY) === YIELD_EVERY - 1) await yieldTick();
   }
 
   out.ok = true;

--- a/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
+++ b/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
@@ -45,13 +45,22 @@ with all error cases lives at the top of `GoonSignalingClient.cs` — summary:
 | Endpoint | Purpose | Key semantics |
 |---|---|---|
 | `/v2/goon/invite` | host mints room | server checks premium OR burns weekly free pass (`pass:"premium"\|"weekly_free"`; 402 `no_pass` + `next_pass_utc`); crockford32 code, ~5 min TTL |
-| `/v2/goon/join` | guest redeems code | 404 `unknown_code`, 409 `already_joined`; returns peer display name/version |
+| `/v2/goon/join` | guest redeems code | 404 `unknown_code`; 409 `already_joined` (a DIFFERENT uid holds the seat) or `self_join` (the code is your own room — one account cannot hold both seats); the SAME uid **reclaims** its seat instead of being refused: fresh token, `rejoin:true`, no second pass burned, stale SDP dropped; returns peer display name/version |
+| `/v2/goon/leave` | release the seat | best-effort, fire-and-forget, `{code, token, role}`; a guest hands the seat back and the ROOM stays up, a host folds the room outright; 409 `match_started` once the ledger has a row (releasing the seat invalidates the token that row is written with). Optional by design — the room TTL is still the backstop, and a client treats any failure as "never mind" |
 | `/v2/goon/signal` | SDP/ICE mailbox | post-and-drain in ONE call, ~2 s short-poll, setup only; `data` is opaque (browser-identical `toJSON()` blobs — JS does `JSON.parse` straight into `setRemoteDescription`/`addIceCandidate`); append-only list, exclusive `since` cursor, callers never receive their own messages |
 | `/v2/goon/relay` | fallback transport | same shape; `data` = whole GoonMessage frame; `wait_ms` long-poll hint; own rate budget (~1 call/2 s per player, match-length TTL), 16 KB/frame, 128-frame ring; server MUST NOT inspect or persist `data` |
 | `/v2/goon/ledger` | end-of-match write | both clients post their signed result; server stores the pair under both unified_ids, flags mismatches as disputed; private to the two players |
 
 A bare 404 (no error body) on any route = "server not deployed" → clients show a
 warming-up message, never "bad code".
+
+> **Seat identity / `/leave` (2026-08-04)** are implemented on the server and in the
+> **web** client (`Resources/web/goon/net/`). The C# client
+> (`Services/GoonGame/GoonSignalingClient.cs` and its `GoonFakeSignalingServer`) has
+> not been taught either yet: it never sends `/leave`, and its fake server still
+> models the seat as a bare `joined` flag. Neither is a break — the additions are
+> backward-compatible — but the C# fake no longer models everything the real server
+> does, so port it before trusting it for a rejoin case.
 
 ## 3. Transport
 - Primary: WebRTC **data channel**, ordered + reliable, one channel, no media tracks.

--- a/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
+++ b/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
@@ -45,7 +45,7 @@ with all error cases lives at the top of `GoonSignalingClient.cs` — summary:
 | Endpoint | Purpose | Key semantics |
 |---|---|---|
 | `/v2/goon/invite` | host mints room | server checks premium OR burns weekly free pass (`pass:"premium"\|"weekly_free"`; 402 `no_pass` + `next_pass_utc`); crockford32 code, ~5 min TTL |
-| `/v2/goon/join` | guest redeems code | 404 `unknown_code`; 409 `already_joined` (a DIFFERENT uid holds the seat) or `self_join` (the code is your own room — one account cannot hold both seats); the SAME uid **reclaims** its seat instead of being refused: fresh token, `rejoin:true`, no second pass burned, stale SDP dropped; returns peer display name/version |
+| `/v2/goon/join` | guest redeems code | 404 `unknown_code`; 409 `already_joined` (a DIFFERENT uid holds the seat) or `self_join` (the code is your own room — one account cannot hold both seats); the SAME uid **reclaims** its seat instead of being refused: fresh token, `rejoin:true`, no second pass burned, stale SDP dropped; **whitelisted** accounts are the one exception to `self_join` and get a **self-duel** instead (`self_duel:true`, `pass:"self_duel"`) — see below; returns peer display name/version |
 | `/v2/goon/leave` | release the seat | best-effort, fire-and-forget, `{code, token, role}`; a guest hands the seat back and the ROOM stays up, a host folds the room outright; 409 `match_started` once the ledger has a row (releasing the seat invalidates the token that row is written with). Optional by design — the room TTL is still the backstop, and a client treats any failure as "never mind" |
 | `/v2/goon/signal` | SDP/ICE mailbox | post-and-drain in ONE call, ~2 s short-poll, setup only; `data` is opaque (browser-identical `toJSON()` blobs — JS does `JSON.parse` straight into `setRemoteDescription`/`addIceCandidate`); append-only list, exclusive `since` cursor, callers never receive their own messages |
 | `/v2/goon/relay` | fallback transport | same shape; `data` = whole GoonMessage frame; `wait_ms` long-poll hint; own rate budget (~1 call/2 s per player, match-length TTL), 16 KB/frame, 128-frame ring; server MUST NOT inspect or persist `data` |
@@ -54,13 +54,46 @@ with all error cases lives at the top of `GoonSignalingClient.cs` — summary:
 A bare 404 (no error body) on any route = "server not deployed" → clients show a
 warming-up message, never "bad code".
 
-> **Seat identity / `/leave` (2026-08-04)** are implemented on the server and in the
-> **web** client (`Resources/web/goon/net/`). The C# client
+### Self-duel (whitelist only, 2026-08-04)
+
+One account may hold **both** seats of its own room, but only if it is **whitelisted**
+(`patreon_is_whitelisted` / `substar_is_whitelisted` on the user record — the same
+fields `computeEffectiveTier` folds into its permanent-tier-2 override). It is a
+testing affordance: the owner play-tests with one account on two devices (the desktop
+app hosts, the phone joins the standalone web build through a link that passes the
+same `uid`), and `self_join` otherwise refuses the whole run. **Tier is deliberately
+not enough** — a paying tier-2 patron is still refused, because a self-duel would
+otherwise be a ledger-farming and self-report surface.
+
+Everyone else's `self_join` 409 is unchanged, byte for byte.
+
+The guest seat of a self-duel is stored under a **shadow identity**, `<uid>#self`.
+Unified ids are `u_[a-z0-9]{8,24}`, so a shadow can never collide with — or be spelled
+by — a real caller, and every uid-keyed structure keeps seeing two identities:
+
+- `goon:pair:<code>` records `guest_uid: "<uid>#self"`, so a self-report accuses an
+  account that does not exist instead of the reporter;
+- the ledger **skips** shadow seats entirely — one recap row per match, under the real
+  uid, never two;
+- `goon:lookup:<uid>` stays the host's room-by-uid mapping; the shadow writes none;
+- `/peercard` for a shadow peer answers `not_shared` (`user:<uid>#self` cannot exist);
+- room auth resolves the shadow back to its base uid, so the device holding the seat
+  authenticates as the real account on `/signal`, `/relay`, `/ledger` and `/leave`;
+- a self-duel guest **reclaims the shadow seat** on rejoin (never a second shadow), and
+  `/leave` frees it like any other seat.
+
+A self-duel costs no pass at all (`pass:"self_duel"`): the account already paid at
+`/invite`, and whitelist is permanent tier 2 anyway.
+
+> **Seat identity, `/leave` and self-duel (2026-08-04)** are implemented on the server
+> and in the **web** client (`Resources/web/goon/net/`). The C# client
 > (`Services/GoonGame/GoonSignalingClient.cs` and its `GoonFakeSignalingServer`) has
-> not been taught either yet: it never sends `/leave`, and its fake server still
-> models the seat as a bare `joined` flag. Neither is a break — the additions are
-> backward-compatible — but the C# fake no longer models everything the real server
-> does, so port it before trusting it for a rejoin case.
+> not been taught any of the three: it never sends `/leave`, its fake server still
+> models the seat as a bare `joined` flag, and it neither knows a shadow id nor reads
+> `self_duel`. None of it is a break — the additions are backward-compatible and the
+> desktop app is the HOST in the owner's setup, which needs no client-side change —
+> but the C# fake no longer models everything the real server does, so port it before
+> trusting it for a rejoin or self-duel case.
 
 ## 3. Transport
 - Primary: WebRTC **data channel**, ordered + reliable, one channel, no media tracks.
@@ -238,3 +271,6 @@ Everything here is additive: a client without it interoperates unchanged.
   data channel); `caps.transfer` + `consent.media_transfer` (append-only, absent = false);
   `payload.tags` `xfer:` namespace for Video/FlashBurst; §11 exception carved for
   hash-named, receiver-verified transferred content.
+- v1.2 (2026-08-04): §2 seat identity (`self_join`, same-uid reclaim), `/v2/goon/leave`,
+  and the whitelist-only **self-duel** on a `<uid>#self` shadow seat. Server + web client
+  only; the C# client and its fake server are unported (see the note in §2).

--- a/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
+++ b/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
@@ -199,7 +199,7 @@ Everything here is additive: a client without it interoperates unchanged.
   `xfer_cancel {tid, why: peer_gone|match_over|superseded|timeout|user|stray}`.
 - **Receiver offer gate, in order, before any byte flows**: feature off → mime/kind allowlist
   (`video/mp4`, `video/webm`, `image/png`, `image/jpeg`, `image/gif`, `image/webp`) → sha
-  shape → size (24 MiB artifact / 8 MiB un-transcoded original; 192 MiB per match per
+  shape → size (64 MiB artifact / 8 MiB un-transcoded original; 512 MiB per match per
   direction) → locally-known blocklist → already-have (`decline:'have'` — the cross-session
   reuse SUCCESS path) → concurrency (1 in / 1 out) → session quota → accept.
 - **Integrity is receiver-side**: the offered sha256 is a claim. The receiver hashes the


### PR DESCRIPTION
Play-tested live PC-host + iPhone-guest across four rounds; all issues found were fixed and re-verified on device. Server counterparts (seat identity, /leave, self-duel shadow seat) are already deployed from CCP-Server 772a6b2; the web client is live on cclabs.app/goon-beta (site 7390543).

## Round 2 - join bounce + big zips + browser compression (f66e238)
- Join no longer silently bounces to title: deferred cancellable fold + honest error sheets; guest sdp_rejected adopts relay instead of folding
- Zip import reworked to Blob-range reads (EOCD tail -> central directory -> per-entry slice, ZIP64): a 1GB zip peaks ~16MB memory
- Browser compression lanes (ui/localCompress.js): >8MB stills -> <=1920 WebP (JPEG fallback, sniffed), animated gif/awebp -> mp4 via the lane-B worker, big videos ride as non-exempt artifacts
- ?debug=1 log overlay for phone diagnosis

## Caps raise (c46a0030)
- MAX_ARTIFACT_BYTES 24 -> 64MB, MAX_SESSION_BYTES 192 -> 512MB, receive store 64 -> 192MB

## Round 3 (904ca305)
- Standalone picker items now feed local playback (solo + own duel effects), not just the send path: media deck split into host/local halves
- Seat identity: distinct self_join error; same-uid rejoin reclaims the seat; client releases the seat via new /leave on pre-connect teardown
- HUD zen toggle: one button hides mercy/dial/score/risk chrome; mercy + closeness dial shrunk

## Round 4 (8ad7bd41)
- Mobile clipping root-caused to a single grid bug (implicit auto column sized to widest row min-content) - fixed with minmax(0,1fr) + safe-area insets; bottom rebuilt into non-overlapping bands; zen hides more (~11rem of stage back)
- Practice opening salvo: bot fires a flash burst (~6s) and video (~45s) drawn from the player's uploads, with practice-only arsenal seeding - duel economy untouched
- Self-duel (whitelist-only) client plumbing + protocol doc v1.2

## Verification
- All 10 selftest suites green: assets 425 / avafx 188 / core 188 / encode 190 / exec 831 / flow 205 / hud 786 / net 252 / report 199 / transfer 176
- Server redis-stub harness 155/155
- dotnet build 0 errors; owner device play-test passed (zip import, practice with uploads, same-account phone join, mobile layout, zen toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5JFXRCWPJUQxcnChhYiPP