### PR TITLE
fix(nux): remove Blink Trainer 'new home' toast on fresh installs

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.TabNavigation.cs
@@ -427,36 +427,6 @@ namespace ConditioningControlPanel
         /// </summary>
         private void RefreshBlinkTrainerTab()
         {
-            // First-visit flag flip (Phase G) — suppresses the v5.9.8 flagship
-            // sticky toast on next launch. Also dismisses the toast in this
-            // session if it's currently showing (H.3): once the user finds
-            // the feature, the announcement has done its job.
-            // Isolated try/catch so a settings failure here can't keep the
-            // rest of the refresh from running.
-            try
-            {
-                if (App.Settings?.Current is { HasSeenBlinkTrainerFlagship: false } first)
-                {
-                    first.HasSeenBlinkTrainerFlagship = true;
-                    App.Settings?.Save();
-
-                    // Fade out the toast if it's still on screen, and persist
-                    // the dismissal so it can't refire even if HasSeen somehow
-                    // doesn't stick.
-                    const string flagshipKey = "blink-trainer-flagship-v5.9.8";
-                    App.Notifications?.Dismiss(flagshipKey);
-                    if (!first.DismissedNotificationKeys.Contains(flagshipKey))
-                    {
-                        first.DismissedNotificationKeys.Add(flagshipKey);
-                        App.Settings?.Save();
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning(ex, "HasSeenBlinkTrainerFlagship flag: failed to set");
-            }
-
             try
             {
                 var s = App.Settings?.Current;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2132,51 +2132,6 @@ namespace ConditioningControlPanel
                 App.Logger?.Debug("Recalibrate-suggest check failed: {Error}", ex.Message);
             }
 
-            // v5.9.8 Blink Trainer flagship sticky. Fires once for users who
-            // updated to v5.9.8 and haven't yet visited the new Exclusives →
-            // Blink Trainer page. Suppression is belt-and-suspenders:
-            //   - ShowSticky no-ops if its key is in DismissedNotificationKeys
-            //   - the if-check below short-circuits when HasSeenBlinkTrainerFlagship is true
-            //   - the action handler ALSO adds the key to DismissedNotificationKeys
-            //     in case HasSeen somehow doesn't persist.
-            try
-            {
-                const string flagshipKey = "blink-trainer-flagship-v5.9.8";
-                if (App.Settings?.Current?.HasSeenBlinkTrainerFlagship == false)
-                {
-                    App.Notifications?.ShowSticky(
-                        flagshipKey,
-                        Localization.Loc.Get("blink_trainer_flagship_toast"),
-                        Services.NotificationType.Info,
-                        actionLabel: Localization.Loc.Get("blink_trainer_flagship_toast_action"),
-                        action: () =>
-                        {
-                            try
-                            {
-                                // Belt-and-suspenders dedupe: add the key to
-                                // DismissedNotificationKeys so the toast can't
-                                // refire next launch even if HasSeen flag fails
-                                // to persist.
-                                var s = App.Settings?.Current;
-                                if (s != null && !s.DismissedNotificationKeys.Contains(flagshipKey))
-                                {
-                                    s.DismissedNotificationKeys.Add(flagshipKey);
-                                    App.Settings?.Save();
-                                }
-                                ShowTab("blinktrainer");
-                            }
-                            catch (Exception ex)
-                            {
-                                App.Logger?.Warning(ex, "Blink Trainer toast action: failed");
-                            }
-                        });
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning(ex, "Blink Trainer flagship sticky: failed");
-            }
-
             // One-time premium celebration for entitlements granted silently (cached state
             // restored in the ctor, the grace window, V2-linked accounts). The provider
             // TierChanged handlers cover the loud grant paths; this covers the quiet ones

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5777,14 +5777,6 @@ namespace ConditioningControlPanel.Models
             set { _blinkTrainerMixImages = value; OnPropertyChanged(); }
         }
 
-        // Tracks whether the user has visited the v5.9.8 Blink Trainer flagship
-        // page at least once. Used to suppress the one-time "moved to its own
-        // home" sticky toast (see Phase G). Defaults false so existing users
-        // see the toast on first launch after update; new users default to
-        // false too but the toast self-suppresses once they visit the tab.
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public bool HasSeenBlinkTrainerFlagship { get; set; }
-
         /// <summary>
         /// Set once the one-time asset migration (install-dir assets -> %APPDATA% user folder)
         /// has completed. Without this flag the migration re-copies the entire library on every


### PR DESCRIPTION
The `blink-trainer-flagship-v5.9.8` sticky toast was gated only on `HasSeenBlinkTrainerFlagship` (default false) with no upgrade check, so brand-new installs saw a migration notice for a move they never witnessed.

Removed: the trigger block in `MainWindow_Loaded`, the first-visit flag-flip in `RefreshBlinkTrainerTab` (existed only to suppress the toast), and the orphaned `AppSettings` property. Loc keys left in all 9 language files (harmless orphans; strict-JSON files untouched). Net -83 lines.

Rebased onto latest main; builds clean (0 errors, baseline warnings only).

Related, deliberately NOT in this PR (separate decisions): the static 'MOVED' chip in the Lab tab, and the Deeper/Programs tab pulses that also fire for new users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DDEHEykXLQLzBZFw9Qv7h