### PR TITLE
feat(goon): invite the standalone joiner to discover CCP from the recap

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-report.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-report.js
@@ -185,6 +185,11 @@ ok(typeof report.buildReportBody === 'function', 'ui/report.js exports buildRepo
 ok(typeof recap.mount === 'function', 'ui/screens/recap.js still exports mount');
 ok(typeof recap.assertStageClear === 'function', 'ui/screens/recap.js still exports assertStageClear');
 ok(typeof recap.reportCandidates === 'function', 'ui/screens/recap.js exports reportCandidates');
+ok(typeof recap.EXPLORE_URL === 'string' && /^https:\/\/cclabs\.app\//.test(recap.EXPLORE_URL),
+  'ui/screens/recap.js exports EXPLORE_URL and it is an https cclabs.app link', recap.EXPLORE_URL);
+// The site is static hosting with clean URLs OFF: /explore is a 404 and only
+// /explore.html answers. Dropping the extension would ship a dead CTA.
+ok(recap.EXPLORE_URL.endsWith('.html'), 'and it keeps the .html — /explore alone is a 404', recap.EXPLORE_URL);
 ok(typeof videos.peerRenderLog === 'function', 'exec/videos.js exports peerRenderLog');
 ok(typeof videos.resetPeerRenderLog === 'function', 'exec/videos.js exports resetPeerRenderLog');
 ok(typeof videos.notePeerFlag === 'function', 'exec/videos.js exports notePeerFlag');
@@ -760,6 +765,49 @@ const fakeStore = (landed, held) => ({
 }
 
 /* ===========================================================================
+ * 7.5 THE STANDALONE CTA — the only piece of marketing on the end card, and
+ *     the only external link the page has. It is aimed at the phone joiner who
+ *     followed an invite link and has never seen the app the payloads came out
+ *     of; hosted, it is absent rather than quiet.
+ * ========================================================================= */
+{
+  // goodSession carries no `hosted` flag — that IS standalone (title.js reads
+  // the same one).
+  const box = new StubEl('section');
+  const h = recap.mount(box, fakeCtx(fakeStore([], []), []));
+  const cta = box.findAll('gg-recap-cta');
+  ok(cta.length === 1, 'standalone -> the recap offers the app');
+  const link = cta[0].findTag('a')[0] || null;
+  ok(!!link && link.getAttribute('href') === recap.EXPLORE_URL,
+    'the CTA is a real link to the explore page', link ? String(link.getAttribute('href')) : 'no <a>');
+  ok(!!link && link.getAttribute('target') === '_blank' && link.getAttribute('rel') === 'noopener',
+    'opened in a new tab, with no window.opener handle back into the duel');
+  ok(!!link && link.textContent === S.recap.ctaLink, 'labelled from strings');
+  ok(cta[0].hasText(S.recap.ctaTitle) && cta[0].hasText(S.recap.ctaLead),
+    'and the copy is in ui/strings.js, not inline in the screen');
+
+  // Below the way out, like everything else this screen appends.
+  const kids = box.childNodes[0].childNodes.map((c) => c.className);
+  ok(kids.findIndex((c) => c.includes('gg-recap-actions'))
+    < kids.findIndex((c) => c.includes('gg-recap-cta')),
+    'and it sits BELOW "Back to menu" — nothing this screen adds may bury the exit');
+  h.unmount();
+}
+
+{
+  // HOSTED (WebView2): the player is already inside the Conditioning Control
+  // Panel, so the card would be selling them the desk they are sitting at.
+  const box = new StubEl('section');
+  const ctx = fakeCtx(fakeStore([], []), []);
+  ctx.session = Object.assign({}, goodSession, { hosted: true });
+  const h = recap.mount(box, ctx);
+  ok(box.findAll('gg-recap-cta').length === 0, 'hosted -> no CTA at all');
+  ok(box.findTag('a').length === 0, 'and the hosted recap grows no external link anywhere');
+  ok(box.findAll('gg-recap-hero').length === 1, 'while the rest of the recap paints as it always did');
+  h.unmount();
+}
+
+/* ===========================================================================
  * 8. THE WIRING — pinned as source, because these three lines are the whole
  *    reason the card has data to read.
  * ========================================================================= */
@@ -839,7 +887,10 @@ const fakeStore = (landed, held) => ({
   ok(!!rule && /right:\s*8px/.test(rule[0]) && /left:\s*auto/.test(rule[0]),
     'and moves it to the opposite corner from the ✕');
   for (const cls of ['gg-recap-report', 'gg-report-thumb', 'gg-report-reason', 'gg-report-note',
-    'gg-report-actions', 'gg-report-status']) {
+    'gg-report-actions', 'gg-report-status',
+    // the standalone CTA — an <a> wearing .gg-btn needs both of these or it
+    // renders as underlined inline text in the middle of the card
+    'gg-recap-cta', 'gg-recap-cta-lead', 'gg-recap-cta-link']) {
     ok(css.includes('.' + cls), 'ui/screens.css styles .' + cls);
   }
 }

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -626,6 +626,14 @@
 .gg-title-chip-name { color: var(--gg-gold); font-weight: 800; font-size: 0.9rem; letter-spacing: 0.04em; }
 .gg-title-chip-why { color: var(--gg-text-3); font-size: 0.76rem; }
 
+/* --- "what was throwing all that at you" — STANDALONE ONLY, and recap.js is
+   what decides that (session.hosted); there is no CSS gate for it. Centred like
+   the hero, and the call to action is a real <a> wearing .gg-btn, so it needs
+   the two things a <button> already has: block layout and no underline. */
+.gg-recap-cta { text-align: center; }
+.gg-recap-cta-lead { margin: 0 0 0.9rem; color: var(--gg-text-2); font-size: 0.85rem; line-height: 1.55; }
+.gg-recap-cta-link, .gg-recap-cta-link:hover { display: inline-block; text-decoration: none; }
+
 /* ---------------------------------------------------------------------------
  * REPORTING WHAT THEY SENT (spec §7.5) — the recap card, plus the ONE override
  * the in-match flag button needs.

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
@@ -30,6 +30,13 @@ const STONE_WALL_ENDURED = 4;
 /** How many artifacts the report shortlist ever shows. Flagged ones come first. */
 export const MAX_REPORT_ITEMS = 6;
 
+/**
+ * Where the standalone CTA points. `.html` is NOT decoration: the site is
+ * plain static hosting with clean URLs OFF, so /explore is a 404 and
+ * /explore.html is the page every link on cclabs.app itself uses.
+ */
+export const EXPLORE_URL = 'https://cclabs.app/explore.html';
+
 /** One retry on a failed submit, then the card stops offering false hope. */
 export const REPORT_MAX_RETRIES = 1;
 
@@ -510,6 +517,48 @@ export function mount(container, ctx) {
     return row;
   }
 
+  /* ------------------------------------------------------------- the CTA
+   * "what was throwing all that at you" — the one piece of marketing on this
+   * page, and it is aimed at exactly one person: the STANDALONE joiner who
+   * followed an invite link, endured a duel on their phone and has never seen
+   * the app the payloads came out of. `session.hosted` is the same flag
+   * title.js reads to decide which menu item is primary.
+   *
+   * HOSTED IT IS ABSENT, not merely quiet: inside WebView2 the player is
+   * already in the Conditioning Control Panel, so the card would be selling
+   * them the desk they are sitting at — and a target=_blank in the host opens
+   * nothing useful anyway.
+   *
+   * It is appended BELOW the actions on purpose. The rule the report card
+   * follows applies here twice over: nothing this screen adds may sit between
+   * the player and "Back to menu".
+   *
+   * A plain <a>, not a button — a real link is middle-clickable, copyable and
+   * needs no host round-trip. `rel="noopener"` because target=_blank without
+   * it hands the new tab a window.opener back into this page.
+   */
+  const standalone = !(session && session.hosted);
+
+  function ctaCard() {
+    if (!standalone) return null;
+    const link = el('a', {
+      class: 'gg-btn gg-btn--primary gg-recap-cta-link',
+      href: EXPLORE_URL,
+      target: '_blank',
+      rel: 'noopener',
+      text: S.recap.ctaLink,
+    });
+    ledger.listen(link, 'click', () => {
+      try { audio?.sfx?.('ui-select'); } catch (_e) { /* stub bus */ }
+    });
+    return el('section', { class: 'gg-card gg-recap-cta' }, [
+      el('h2', { class: 'gg-recap-h', text: S.recap.ctaTitle }),
+      el('p', { class: 'gg-recap-cta-lead', text: S.recap.ctaLead }),
+      link,
+      el('p', { class: 'gg-recap-fine', text: S.recap.ctaFine }),
+    ]);
+  }
+
   /* --------------------------------------------------------------- paint */
 
   function paint() {
@@ -623,6 +672,16 @@ export function mount(container, ctx) {
     rematch.appendChild(el('span', { class: 'gg-menu-note', text: S.recap.rematchSoon }));
     const back = button(ledger, S.recap.back, () => actions.leave('recap'), { variant: 'primary', audio, sfx: 'ui-back' });
     column.appendChild(el('div', { class: 'gg-recap-actions' }, [rematch, back]));
+
+    /* --- discover the app (standalone only, and last) --- */
+    try {
+      const cta = ctaCard();
+      if (cta) column.appendChild(cta);
+    } catch (e) {
+      // An ad must never be the reason a player cannot leave the end card.
+      try { ctx?.logger?.warn?.('recap: cta failed to build: ' + ((e && e.message) || e)); }
+      catch (_e2) { /* logger is optional */ }
+    }
   }
 
   if (match) {

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -260,6 +260,15 @@ export const S = Object.freeze({
     reportPick: 'pick the one you mean',
     reportFlagged: 'flagged during the match',
     reportPrivacy: "a moderator gets the file's fingerprint, a small thumbnail and your note. they never get your name, and the other player is never told.",
+
+    /* --- the "so what WAS that" card. STANDALONE ONLY: it is written for the
+       phone joiner who arrived from an invite link, endured a match and has
+       never seen the app the payloads came out of. Hosted, the player is
+       already inside it and the card would be selling them their own desk. --- */
+    ctaTitle: 'what was throwing all that at you',
+    ctaLead: 'the flashes, the subliminals, the lock cards — all of it comes out of the Conditioning Control Panel, a desktop app that runs the whole thing for you, opponent or no opponent.',
+    ctaLink: 'See what it does',
+    ctaFine: 'opens cclabs.app in a new tab.',
   },
 
   /** Locally computed cosmetics. Nothing here reaches the server. */


### PR DESCRIPTION
Standalone-only end-card CTA linking to cclabs.app/explore.html after a match. Hosted (WebView2) recap unchanged. Selftest-report pins included.

Stranded-branch sweep 2026-08-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)