### PR TITLE
feat(goon): tier-2 host gate + free anonymous join (client half)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -289,6 +289,10 @@ bridge.on('init', (m) => {
     unifiedId: String(idm.unifiedId || idm.id || ''),
     displayName: String(idm.displayName || idm.name || ''),
     appVersion: String(idm.appVersion || ''),
+    /* NO ACCOUNT AT ALL — set only by bridge.standaloneInit, for a visitor who arrived on an
+     * invite link. /join then omits unified_id and plays on a server-minted guest seat. `=== true`
+     * because a host that never heard of the field must not read as anonymous. */
+    anonymous: idm.anonymous === true,
   };
   session.caps = m.caps || null;
   session.consent = m.consent || null;
@@ -1448,11 +1452,33 @@ function cancelFoldToTitle() {
   foldTimer = 0;
 }
 
+/**
+ * THE ANONYMOUS SEAT, remembered across reloads.
+ *
+ * A visitor who arrived on an invite link has no account, so /join mints them a `g_` identity and
+ * that id IS their seat: lose it and a refresh comes back as a stranger, is told the room already
+ * has two players — by its own ghost — and the invite is dead for the rest of the room's TTL.
+ * It rides in the same localStorage blob as every other standalone pref, and `save` writes the
+ * live fields too, because ensureSession() builds ONE GoonSession per page and the reclaim has to
+ * be readable by the signaling client it constructs next.
+ */
+const guestSeat = {
+  id: String(bridge.storedPrefs().guestId || ''),
+  code: String(bridge.storedPrefs().guestRoom || ''),
+  save(id, code) {
+    this.id = String(id || '');
+    this.code = String(code || '');
+    try { bridge.savePrefs({ guestId: this.id, guestRoom: this.code }); }
+    catch (_e) { /* a lost seat costs a rejoin, never the match in progress */ }
+  },
+};
+
 function ensureSession() {
   if (goonSession) return goonSession;
   goonSession = new GoonSession({
     createMatch: (transport, isHost) => buildMatch(transport, isHost),
     identity: session.identity || {},
+    guest: guestSeat,
     logger,
   });
   // THE rebuild seam. The relay fallback disposes the old match and builds a

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -218,6 +218,22 @@ export function savePrefs(partial) {
 
 function numOr(v, d) { const n = parseFloat(v); return isFinite(n) ? n : d; }
 
+/**
+ * The API base a standalone launch falls back to when neither `?server=` nor a
+ * stored pref names one. Non-empty ONLY on the public deployment (cclabs.app):
+ * an invite link is a bare `?join=CODE`, and a page that cannot find its server
+ * from that link alone is a dead end for the person it was built to welcome.
+ * Everywhere else (localhost, file://, forks) stays '' — the serverless dev
+ * playground, with its always-on transfer affordance, is keyed off "no server
+ * anywhere" and a built-in default would quietly kill it. Exported for tests.
+ */
+export function defaultServerBase() {
+  try {
+    const host = (typeof location !== 'undefined' && location.hostname) || '';
+    return /(^|\.)cclabs\.app$/i.test(host) ? 'https://codebambi-proxy.vercel.app' : '';
+  } catch (_e) { return ''; }
+}
+
 /** Build the fake `init` a standalone browser boots from. Exported for tests. */
 export function standaloneInit() {
   const q = new URLSearchParams((typeof location !== 'undefined' && location.search) || '');
@@ -263,14 +279,15 @@ export function standaloneInit() {
       // transfer-cache to talk to: the assets screen renders "compression lives in
       // the app" instead of a spinner that never resolves.
       assetCache: false,
-      // SENDING is premium-gated. Against a real server (a `?server=` launch or
-      // one remembered in prefs — the phone client) it starts OFF and boot.js
-      // adopts the server's `media_send` verdict from the /invite //join answer.
-      // Only the pure-local dev path (no server anywhere) keeps the old always-on
-      // affordance, because it is the one way to exercise the transfer without
-      // two Patreon accounts. The page reads this as `=== true`, so a real host
-      // that predates the flag still defaults it OFF.
-      mediaTransfer: !(q.get('server') || prefs.serverBase),
+      // SENDING is premium-gated. Against a real server (a `?server=` launch,
+      // one remembered in prefs, or the public deployment's built-in default)
+      // it starts OFF and boot.js adopts the server's `media_send` verdict from
+      // the /invite //join answer. Only the pure-local dev path (no server
+      // anywhere) keeps the old always-on affordance, because it is the one way
+      // to exercise the transfer without two Patreon accounts. The page reads
+      // this as `=== true`, so a real host that predates the flag still
+      // defaults it OFF.
+      mediaTransfer: !(q.get('server') || prefs.serverBase || defaultServerBase()),
     }, prefs.caps || {}),
     consent: Object.assign({
       liveDurationSec: 720,    // GoonConsts.LiveDurationSecDefault
@@ -283,7 +300,7 @@ export function standaloneInit() {
       skewMs: numOr(q.get('skew'), numOr(prefs.skewMs, 0)),
     },
     net: {
-      serverBase: q.get('server') || prefs.serverBase || '',
+      serverBase: q.get('server') || prefs.serverBase || defaultServerBase(),
       authToken: q.get('token') || prefs.authToken || '',
       viaHost: false,
     },

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -140,9 +140,19 @@ export function netInfo() {
   return { serverBase: netCfg.serverBase, viaHost: netCfg.viaHost, hasToken: !!netCfg.authToken, pending: pending.size };
 }
 
-/** POST JSON. Resolves {status, body} — status 0 means "never got an answer". */
-export function postNet(path, body) {
+/**
+ * POST JSON. Resolves {status, body} — status 0 means "never got an answer".
+ *
+ * `opts.noAuth` sends the call WITHOUT X-Auth-Token: the anonymous-guest path
+ * (net/signaling.js), whose caller has no account token and whose only authority
+ * is the room token in the body. Direct-fetch only, which is the only place it
+ * can arise — hosted, the app always has an account and the C# side attaches the
+ * header itself.
+ * @param {{noAuth?: boolean}} [opts]
+ */
+export function postNet(path, body, opts) {
   const p = String(path || '');
+  const noAuth = !!(opts && opts.noAuth);
   if (isHosted && netCfg.viaHost) {
     const id = 'n' + (++netSeq);
     return new Promise((resolve) => {
@@ -158,7 +168,7 @@ export function postNet(path, body) {
   // Direct fetch (standalone, or a host that opted out of proxying).
   const url = (netCfg.serverBase || '') + p;
   const headers = { 'Content-Type': 'application/json' };
-  if (netCfg.authToken) headers['X-Auth-Token'] = netCfg.authToken;
+  if (netCfg.authToken && !noAuth) headers['X-Auth-Token'] = netCfg.authToken;
   let f = null;
   try { f = (typeof fetch === 'function') ? fetch : null; } catch (_e) { f = null; }
   if (!f) return Promise.resolve({ status: 0, body: '' });
@@ -214,6 +224,11 @@ export function standaloneInit() {
   const prefs = readPrefs();
   const profile = q.get('profile') || prefs.profile || 'p2p';
   const name = q.get('name') || prefs.name || 'Solo';
+  /* A REAL ACCOUNT ID, or ''. `?uid=` now, or one an earlier launch adopted into prefs. The
+   * `local-…` fallback below is deliberately NOT one: it is a display convenience for the pure-dev
+   * path, the server would refuse it, and treating it as an account is what would send an
+   * invite-link visitor to a 401 instead of to a free guest seat. */
+  const account = String(q.get('uid') || prefs.unifiedId || '');
   return {
     type: 'init',
     protocol: PROTOCOL,
@@ -224,9 +239,18 @@ export function standaloneInit() {
     identity: {
       // `?uid=` lets a phone/browser identify as a real account (paired with
       // `?token=` below) — without it the page plays as a throwaway local id.
-      unifiedId: String(q.get('uid') || prefs.unifiedId || 'local-' + name),
+      unifiedId: account || ('local-' + name),
       displayName: String(name).slice(0, 32),
       appVersion: 'dev',
+      /**
+       * NO ACCOUNT AT ALL — the invite-link click from somebody who has never
+       * seen the app. `/join` then omits `unified_id` entirely and the server
+       * mints a free `g_` guest seat (net/signaling.js `anonymous`). Joining is
+       * free for everyone; only HOSTING is gated, and a guest never hosts.
+       *
+       * Hosted this field is simply absent: the C# host always has an account.
+       */
+      anonymous: !account,
     },
     caps: Object.assign({
       haptics: false,

--- a/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/fakeSignaling.js
@@ -4,10 +4,19 @@
 // one page, or two tabs sharing one of these), and — because it is executable — it pins the
 // contract the real server has to match. If the two ever disagree, one of them is a bug.
 //
-// It deliberately does NOT model auth, the weekly pass, or rate limiting: those are server policy,
-// and faking them here would only teach the client to trust a fake.
+// It deliberately does NOT model auth or rate limiting: those are server policy, and faking them
+// here would only teach the client to trust a fake. The weekly free pass is gone entirely.
 //
 // Server rules that ARE modelled, because clients depend on them:
+//   * THE HOST GATE (2026-08-04): /invite is TIER 2 ONLY and answers 403 `no_host_access` below it,
+//     while /join is FREE for everyone. Modelled — unlike auth — because "hosting is refused,
+//     joining never is" is the shape of the surface, and a fake where everyone hosts would leave
+//     the client's 403 path unexercised. `hostGate` is OFF by default so the room-lifecycle tests
+//     are not all about entitlement; `setLabAccess` fills the tier-2 set once it is on;
+//   * ANONYMOUS GUESTS: a /join with NO `unified_id` field at all is an invite-link click from
+//     somebody with no account. The server mints `g_` + 16 hex, returns it as `guest_id`, and takes
+//     it as `unified_id` on every later room-scoped call — where it behaves like any other uid,
+//     which is exactly what the seat rules below have to keep being true for;
 //   * append-only per-room list, `since` is an EXCLUSIVE cursor;
 //   * a caller never receives its own messages back (no self-echo) — but the cursor still advances
 //     PAST them, so the next poll doesn't re-walk the whole list;
@@ -41,6 +50,23 @@ const SELF_SUFFIX = '#self';
 export const shadowGuestUid = (uid) => `${uid}${SELF_SUFFIX}`;
 export const isShadowUid = (uid) => typeof uid === 'string' && uid.endsWith(SELF_SUFFIX);
 
+/**
+ * An anonymous joiner's seat identity: `g_` + 8 random bytes hex, minted by the server and handed
+ * back once, on the /join response. Real unified ids are `u_[a-z0-9]{8,24}`, so the two shapes can
+ * never be mistaken for one another even though they travel in the same field. It doubles as the
+ * seat-reclaim key — a guest has no account token — which is why it is random.
+ */
+const GUEST_ID_RE = /^g_[a-f0-9]{16}$/;
+export const isGuestUid = (uid) => typeof uid === 'string' && GUEST_ID_RE.test(uid);
+let guestCounter = 0;
+function mintGuestUid() {
+  // Deterministic-ish rather than crypto-random: this is a fake, and a test that has to name the
+  // id it expects is worth more here than entropy the client can never see.
+  const n = (++guestCounter).toString(16).padStart(4, '0');
+  const r = Math.floor(Math.random() * 0xffffffffffff).toString(16).padStart(12, '0');
+  return `g_${(n + r).slice(0, 16)}`;
+}
+
 function ok(body) { return Promise.resolve({ status: 200, body: JSON.stringify(body) }); }
 function fail(status, error) { return Promise.resolve({ status, body: JSON.stringify({ error }) }); }
 
@@ -66,8 +92,11 @@ export class GoonFakeSignalingServer {
    * @param {boolean|null} [o.mediaSend] the `media_send` verdict /invite //join answer with.
    *   null (the default) models a server that PREDATES the field and omits it entirely —
    *   the client must then leave its recorded verdict untouched.
+   * @param {boolean} [o.hostGate] enforce the tier-2 host gate on /invite (see `hostGate`)
+   * @param {string[]} [o.labAccess] uids that clear that gate (see setLabAccess)
    */
-  constructor({ ttlMs = DEFAULT_TTL_MS, now = () => Date.now(), codePrefix = 'LOOP', whitelist = [], mediaSend = null } = {}) {
+  constructor({ ttlMs = DEFAULT_TTL_MS, now = () => Date.now(), codePrefix = 'LOOP', whitelist = [],
+    mediaSend = null, hostGate = false, labAccess = [] } = {}) {
     this._rooms = new Map();
     this._ttlMs = ttlMs;
     this._now = now;
@@ -81,6 +110,16 @@ export class GoonFakeSignalingServer {
      * @type {Set<string>}
      */
     this._whitelist = new Set(Array.isArray(whitelist) ? whitelist.map(String) : []);
+    /**
+     * Enforce the tier-2 HOST gate on /invite? The real server always does
+     * (`computeEffectiveTier(user) >= 2`, whitelist folded in as permanent tier 2, 403
+     * `no_host_access` below it). Here it defaults OFF so the several dozen room-lifecycle
+     * assertions are not all about entitlement — turn it on to exercise the refusal, and fill
+     * `_labAccess` with the uids that clear it. Joining is never gated either way.
+     */
+    this.hostGate = !!hostGate;
+    /** @type {Set<string>} uids at tier 2, i.e. allowed to mint a room while `hostGate` is on. */
+    this._labAccess = new Set(Array.isArray(labAccess) ? labAccess.map(String) : []);
     /** Every request the server saw — handy in an assertion. */
     this.requests = [];
     /**
@@ -136,6 +175,27 @@ export class GoonFakeSignalingServer {
     return this;
   }
 
+  /**
+   * Test hook: grant (or revoke) TIER 2, i.e. the right to mint a room while `hostGate` is on.
+   * Distinct from `setWhitelisted` on purpose — the whitelist is a self-duel permission and folds
+   * to tier 2 upstream, but a plain tier-2 patron may host and still may not duel itself.
+   * @param {string} uid
+   * @param {boolean} [on]
+   */
+  setLabAccess(uid, on = true) {
+    const u = String(uid || '');
+    if (!u) return this;
+    if (on) this._labAccess.add(u); else this._labAccess.delete(u);
+    return this;
+  }
+
+  /** Whitelist folds to permanent tier 2, exactly as computeEffectiveTier does it server-side. */
+  _mayHost(uid) {
+    if (!this.hostGate) return true;
+    const u = String(uid || '');
+    return this._labAccess.has(u) || this._whitelist.has(u);
+  }
+
   /** Hand this to GoonSignalingClient's `post` option. */
   get post() { return (path, body) => this._handle(path, body); }
 
@@ -166,6 +226,10 @@ export class GoonFakeSignalingServer {
 
     switch (p) {
       case '/v2/goon/invite': {
+        // THE HOST GATE. Tier 2 or nothing — and note there is no anonymous branch here at all:
+        // a guest has no account to be tier 2 with, so an uid-less /invite simply fails the gate.
+        if (!this._mayHost(req.unified_id)) return fail(403, GoonSignalError.NoHostAccess);
+
         this._codeCounter++;
         const room = {
           code: `${this._codePrefix}${String(this._codeCounter).padStart(2, '0')}`,
@@ -194,10 +258,20 @@ export class GoonFakeSignalingServer {
       }
 
       case '/v2/goon/join': {
+        /* ANONYMOUS JOINER: no `unified_id` FIELD at all (not an empty one) = an invite-link click
+         * from somebody with no account. The seat identity is minted here, before anything else
+         * looks at the uid, so every rule below — self-duel, reclaim, already_joined — sees one
+         * uid shape and needs no anonymous branch of its own. Joining is free; there is
+         * deliberately no gate on this route to mirror. */
+        const anonymous = !req.unified_id;
+        const uid = anonymous ? mintGuestUid() : (typeof req.unified_id === 'string' ? req.unified_id : '');
+        // A returning guest re-presents the g_ id it was given, so "is this a guest" is a question
+        // about the id's SHAPE, not about whether we just minted it.
+        const guest = isGuestUid(uid);
+
         const room = this._live(req.code);
         // A bad code and an expired code are indistinguishable to a joiner, by design.
         if (!room) return fail(404, GoonSignalError.UnknownCode);
-        const uid = typeof req.unified_id === 'string' ? req.unified_id : '';
         // Your own room is not a full room. One account cannot hold both seats:
         // the ledger, the pair record and the peer card are all "the other uid".
         // …unless the account is WHITELISTED, which is the owner's two-device
@@ -218,7 +292,7 @@ export class GoonFakeSignalingServer {
         // otherwise be handed to the fresh peer connection as if it were live. The
         // SEQ counter deliberately keeps counting — the host's cursor is past it.
         if (rejoin) room.signals = [];
-        return ok(this._withMediaSend({
+        const body = this._withMediaSend({
           ok: true,
           rejoin,
           // Advisory: both seats are one account. Nothing in the match depends on it.
@@ -228,11 +302,21 @@ export class GoonFakeSignalingServer {
           expires_in_sec: Math.max(0, Math.round((room.expiresAt - this._now()) / 1000)),
           peer_display_name: 'host',
           peer_app_version: 'fake',
-          pass: 'premium',
+          // Joining costs nothing; `pass` survives as an advisory label for what happened
+          // to the SEAT, never for what was charged.
+          pass: rejoin ? 'rejoin' : (selfDuel ? 'self_duel' : 'free'),
           relay_allowed: true,
           // The joiner is the GUEST, so the peer whose card it learns is the host.
           peer_card_ver: this.hostCardVer,
-        }));
+        });
+        // THE SEAT IDENTITY, disclosed here and nowhere else — it is the reclaim key, and this
+        // response is the only place the guest can learn it. Present for a returning guest too,
+        // because the client is entitled to confirm the id it just presented was honoured.
+        // (Absent for account joins: JSON.stringify drops an undefined.)
+        if (guest) body.guest_id = uid;
+        // A guest has no user record, so it can never be a premium SENDER. Receiving is not gated.
+        if (guest && typeof body.media_send === 'boolean') body.media_send = false;
+        return ok(body);
       }
 
       case '/v2/goon/leave': {

--- a/ConditioningControlPanel/Resources/web/goon/net/session.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/session.js
@@ -23,8 +23,9 @@
 // first currentMatch instance. The rebuild window is safe: ICE can only fail in Lobby, before the
 // hello/consent exchange has happened.
 //
-// This facade does NOT gate on premium/pass state — the server enforces passes at /v2/goon/invite
-// (402 no_pass). UI may pre-gate for niceness, never here.
+// This facade does NOT gate on entitlement — the server enforces the tier-2 HOST bar at
+// /v2/goon/invite (403 no_host_access) and nothing at all at /join, which is free for everyone,
+// account or not. UI may pre-gate for niceness (title.js dims Host on caps.canHost), never here.
 //
 // LEAVE vs TEARDOWN: leave() is user-initiated and routes through match.cancelMatch (in Live that
 // is a Mercy). Every internal path — fallback, failure, dispose — uses dispose() only, which sends
@@ -67,25 +68,41 @@ export class GoonSession {
   /**
    * @param {object} o
    * @param {(transport:object, isHost:boolean) => object} o.createMatch REQUIRED — see the header
-   * @param {object} [o.identity] {unifiedId, displayName, appVersion} for the signaling body
+   * @param {object} [o.identity] {unifiedId, displayName, appVersion, anonymous} for the body
    * @param {object} [o.logger]
+   * @param {{id?:string, code?:string, save?:(id:string, code:string)=>void}} [o.guest]
+   *   the anonymous seat identity kept across reloads — see `this._guest`
    * @param {() => GoonSignalingClient} [o.createSignaling] test seam
    * @param {(isHost:boolean, signaling:GoonSignalingClient) => object} [o.createWebrtc] test seam
    * @param {(isHost:boolean, signaling:GoonSignalingClient) => object} [o.createRelay] test seam
    */
-  constructor({ createMatch, identity = null, logger = null, createSignaling = null,
+  constructor({ createMatch, identity = null, logger = null, guest = null, createSignaling = null,
     createWebrtc = null, createRelay = null } = {}) {
     if (typeof createMatch !== 'function') throw new Error('GoonSession: createMatch factory is required');
 
     this._createMatch = createMatch;
     this._identity = identity || {};
     this._log = logger || (typeof console !== 'undefined' ? console : null);
+    /**
+     * THE ANONYMOUS SEAT, across reloads. Read at signaling-CONSTRUCTION time rather than copied
+     * here, so a `save` that also updates `id`/`code` in place is what lets the next session on
+     * this page reclaim the seat instead of arriving as a stranger.
+     */
+    this._guest = (guest && typeof guest === 'object') ? guest : null;
 
     this._createSignaling = createSignaling || (() => new GoonSignalingClient({
       unifiedId: this._identity.unifiedId || '',
       appVersion: this._identity.appVersion || '',
       displayName: this._identity.displayName || '',
       logger: this._log,
+      /* NO ACCOUNT BEHIND THIS PAGE: /join asks the server for a seat identity rather than
+       * presenting one, and re-presents the one it holds when this is the same room again. */
+      anonymous: this._identity.anonymous === true,
+      guestId: (this._guest && this._guest.id) || '',
+      guestRoom: (this._guest && this._guest.code) || '',
+      onGuest: this._guest && typeof this._guest.save === 'function'
+        ? (id, code) => this._guest.save(id, code)
+        : null,
     }));
     this._createWebrtc = createWebrtc || ((isHost, signaling) => new GoonWebRtcTransport({
       isHost, signaling, logger: this._log, displayName: this._identity.displayName || '',

--- a/ConditioningControlPanel/Resources/web/goon/net/signaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/signaling.js
@@ -8,9 +8,14 @@
 //
 // FAILURE MODEL (unchanged from C#): every method resolves null on failure and leaves a
 // machine-readable reason in `lastError` (+ `lastErrorDetail`, `retryAfterSeconds`). Nothing here
-// throws for a server outcome — the lobby has to tell "your weekly pass is spent" (a product
+// throws for a server outcome — the lobby has to tell "hosting is a supporter perk" (a product
 // message) apart from "the endpoint 404s" (server not deployed) apart from "you're offline".
 // `lastErrorInfo` is the {kind, detail, retryAfterSeconds} triple the UI renders from.
+//
+// ENTITLEMENT (2026-08-04). HOSTING is tier 2 — /invite answers 403 no_host_access below it — and
+// JOINING is free for everyone, including people with no account at all: see `anonymous` on the
+// constructor for the server-minted `g_` seat identity that carries them. The weekly free pass
+// (402 no_pass) is gone; it is still PARSED, so an old server keeps producing a sentence.
 
 import { postNet } from '../bridge.js';
 import { GoonConsts } from '../core/contracts.js';
@@ -27,7 +32,10 @@ export const GOON_PATHS = Object.freeze({
 export const GoonSignalError = Object.freeze({
   /** The endpoint answered 404 with no room context, i.e. the server route isn't deployed. */
   NotDeployed: 'not_deployed',
+  /** Retired with the weekly free pass. Kept so an OLD server still gets a sentence, not a code. */
   NoPass: 'no_pass',
+  /** /invite refused: minting a room is a tier-2 perk. Joining stays free for everyone. */
+  NoHostAccess: 'no_host_access',
   UnknownCode: 'unknown_code',
   AlreadyJoined: 'already_joined',
   /** The code you typed is your OWN room — one account cannot sit on both seats. */
@@ -50,6 +58,14 @@ export function normalizeCode(code) {
   return String(code ?? '').trim().toUpperCase().replace(/[-\s]/g, '');
 }
 
+/**
+ * A server-minted anonymous seat identity: `g_` + 8 random bytes hex. Real unified ids are
+ * `u_[a-z0-9]{8,24}`, so the two shapes can never be confused for one another — which is the
+ * point, because this one is presented in the same `unified_id` field.
+ */
+const GUEST_ID_RE = /^g_[a-f0-9]{16}$/;
+export const isGuestId = (v) => typeof v === 'string' && GUEST_ID_RE.test(v);
+
 function sanitize(s, max) {
   const v = String(s ?? '').trim();
   if (!v) return '';
@@ -68,13 +84,36 @@ export class GoonSignalingClient {
    * @param {string} [o.appVersion]
    * @param {string} [o.displayName] default display name for createInvite/join
    * @param {object} [o.logger]
+   * @param {boolean} [o.anonymous] this page has NO account (see `this.anonymous`)
+   * @param {string} [o.guestId] a `g_` seat id kept from an earlier launch, for the rejoin
+   * @param {string} [o.guestRoom] the room code that `guestId` holds a seat in
+   * @param {(id:string, code:string) => void} [o.onGuest] sink that persists a minted seat id
    */
-  constructor({ post = null, unifiedId = '', appVersion = '', displayName = '', logger = null } = {}) {
+  constructor({ post = null, unifiedId = '', appVersion = '', displayName = '', logger = null,
+    anonymous = false, guestId = '', guestRoom = '', onGuest = null } = {}) {
     this._post = typeof post === 'function' ? post : postNet;
     this._log = logger || (typeof console !== 'undefined' ? console : null);
     this.unifiedId = String(unifiedId || '');
     this.appVersion = String(appVersion || '');
     this.displayName = String(displayName || '');
+
+    /**
+     * ANONYMOUS JOIN (2026-08-04). True when there is no account behind this page at all — an
+     * invite-link click from somebody who has never seen the app. `/join` then omits `unified_id`
+     * ENTIRELY (the field's ABSENCE is the request; an empty string is a 400) and the server mints
+     * a `g_` seat identity, hands it back as `guest_id`, and expects it as `unified_id` on every
+     * later room-scoped call. No X-Auth-Token rides along either — a guest has no account token,
+     * and the room token is the whole of its authority.
+     *
+     * Hosting is never anonymous: /invite is tier-2 gated and a guest has no account to be tier 2
+     * with. This flag only ever changes what the JOIN path sends.
+     */
+    this.anonymous = !!anonymous;
+    /** The `g_` seat identity, once /join has minted one (or one kept from an earlier launch). */
+    this.guestId = isGuestId(guestId) ? guestId : '';
+    /** The room `guestId` holds a seat in. A g_ id is only ever re-presented for ITS OWN room. */
+    this.guestRoom = normalizeCode(guestRoom);
+    this._onGuest = typeof onGuest === 'function' ? onGuest : null;
 
     /** @type {string|null} machine-readable reason for the last failure */
     this.lastError = null;
@@ -125,6 +164,27 @@ export class GoonSignalingClient {
     if (typeof fn !== 'function') return () => {};
     this._peerCardListeners.add(fn);
     return () => this._peerCardListeners.delete(fn);
+  }
+
+  /**
+   * Adopts the `guest_id` off a /join response: THE seat identity from here on.
+   *
+   * Writing it into `unifiedId` is what makes /signal, /relay and /leave work with no second
+   * branch — every one of them already sends that field. The sink persists it so a reload can
+   * re-present it and reclaim the seat instead of arriving as a stranger and being told the room
+   * is full. Ignores anything that is not the documented `g_` shape.
+   */
+  _adoptGuestId(json, code) {
+    const id = json && typeof json.guest_id === 'string' ? json.guest_id : '';
+    if (!isGuestId(id)) return null;
+    this.guestId = id;
+    this.guestRoom = code;
+    this.unifiedId = id;
+    if (this._onGuest) {
+      // A persistence sink must never be able to break a join that already succeeded.
+      try { this._onGuest(id, code); } catch (e) { this._warn(`guest-id sink threw: ${(e && e.message) || e}`); }
+    }
+    return id;
   }
 
   /** Records `media_send` off a parsed /invite or /join response. Absent = old server = no-op. */
@@ -192,15 +252,31 @@ export class GoonSignalingClient {
     };
   }
 
-  /** @returns {Promise<{token, expiresInSec, peerDisplayName, peerAppVersion, pass, relayAllowed, rejoin, selfDuel}|null>} */
+  /** @returns {Promise<{token, expiresInSec, peerDisplayName, peerAppVersion, pass, relayAllowed, rejoin, selfDuel, guestId}|null>} */
   async join(code, displayName = null) {
-    const json = await this._call(GOON_PATHS.join, {
-      unified_id: this.unifiedId,
-      code: normalizeCode(code),
+    const room = normalizeCode(code);
+    const body = {
+      code: room,
       display_name: sanitize(displayName ?? this.displayName, 32),
       app_version: this.appVersion,
       protocol_version: GoonConsts.ProtocolVersion,
-    });
+    };
+
+    /* THE UID GOES ON LAST, and for an anonymous joiner it may not go on at all — the ABSENCE of
+     * the field is what asks the server for a seat identity, so it is set rather than blanked.
+     *
+     * A reload re-presents the `g_` id it was given for THIS room and reclaims the seat
+     * (pass:"rejoin", fresh token). Any other room omits it and takes a fresh identity: a guest id
+     * lives only as long as the room it was minted for, and carrying one across rooms would make
+     * it a durable handle on a person who never signed up for one. */
+    if (!this.anonymous) {
+      body.unified_id = this.unifiedId;
+    } else if (this.guestId && this.guestRoom === room) {
+      body.unified_id = this.guestId;
+      this.unifiedId = this.guestId;
+    }
+
+    const json = await this._call(GOON_PATHS.join, body);
     if (!json) return null;
 
     const token = typeof json.token === 'string' ? json.token : '';
@@ -211,6 +287,8 @@ export class GoonSignalingClient {
 
     return {
       token,
+      /** The `g_` seat identity this client now presents as unified_id; '' for an account join. */
+      guestId: this._adoptGuestId(json, room) || '',
       expiresInSec: intOr(json.expires_in_sec, 300),
       peerDisplayName: typeof json.peer_display_name === 'string' ? json.peer_display_name : '',
       peerAppVersion: typeof json.peer_app_version === 'string' ? json.peer_app_version : '',
@@ -355,7 +433,9 @@ export class GoonSignalingClient {
 
     let res;
     try {
-      res = await this._post(path, body);
+      // A guest has no account token to send, and sending one would be a lie about who is
+      // calling. The room token in the body is the whole of its authority (see `anonymous`).
+      res = await this._post(path, body, this.anonymous ? { noAuth: true } : undefined);
     } catch (e) {
       // postNet does not reject, but an injected post might.
       this.lastError = GoonSignalError.Network;
@@ -391,10 +471,16 @@ export class GoonSignalingClient {
 
     switch (status) {
       case 401:
+        this.lastError = serverError || GoonSignalError.Unauthorized;
+        break;
       case 403:
+        // THE HOST GATE. /invite answers `no_host_access` here and it is a product message, not a
+        // fault — telling a tier-1 patron to reconnect a perfectly connected account (which is
+        // what the bare `unauthorized` fallback says) would send them chasing the wrong problem.
         this.lastError = serverError || GoonSignalError.Unauthorized;
         break;
       case 402:
+        // Retired with the weekly free pass; parsed only so an old server still gets a sentence.
         this.lastError = serverError || GoonSignalError.NoPass;
         this.lastErrorDetail = json && typeof json.next_pass_utc === 'string' ? json.next_pass_utc : null;
         break;

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
@@ -1,0 +1,501 @@
+// Self-contained sanity pass over the HOST GATE and the FREE ANONYMOUS JOIN (2026-08-04).
+//
+//   node Resources/web/goon/test/selftest-hostgate.js
+//
+// One server change, two halves of one product decision: minting a room became a TIER-2 perk
+// (403 `no_host_access`), and in exchange joining one became free for absolutely everyone —
+// including a person with no account at all, who plays on a server-minted `g_` seat identity.
+// The weekly free pass that used to sit between the two is gone.
+//
+// What is asserted, and why each one is here:
+//
+//   1. THE ABSENCE OF A FIELD IS A REQUEST. An anonymous /join must omit `unified_id` entirely,
+//      not send it empty: the server reads the missing key as "mint me one" and reads an empty
+//      string as a 400. This is the single easiest thing to break with a well-meaning `|| ''`,
+//      and the symptom — every invite link dying at the door — has no other cause that looks
+//      like it.
+//   2. THE SEAT ID IS ADOPTED, NOT MERELY RECEIVED. `guest_id` comes back once, on the /join
+//      response, and every later room-scoped call must present it as `unified_id`. A client that
+//      parsed it and kept sending its old id would connect, sit in the room, and be told the seat
+//      is somebody else's the moment anything re-checked.
+//   3. THE SEAT SURVIVES A RELOAD. A guest id is also the reclaim key (there is no account token
+//      behind it), so it is persisted and re-presented for ITS room — and only for its room,
+//      because a guest id carried between rooms would be a durable handle on somebody who never
+//      signed up for one.
+//   4. THE REFUSAL HAS A SENTENCE. 403 `no_host_access` is a product message, not a fault. It
+//      must not fold into `unauthorized` ("reconnect your account" to somebody whose account is
+//      connected fine) and must not fall through to the network sheet ("check your connection"
+//      about a server that answered instantly).
+//   5. THE MENU TELLS THE TRUTH EARLY, BUT ONLY WHERE IT CAN. Hosted, the C# host already knows
+//      the tier, so Host dims with the reason under it. Standalone, entitlement is unknowable
+//      before a round-trip, so Host stays live and the 403 sheet catches it — a page that dimmed
+//      on a guess would lock a paying supporter out of what they paid for.
+//   6. BOTH CLIENTS AGREE. The C# reference client and its fake are the written contract; if they
+//      and the JS binding disagree about the new rules, one of them is a bug.
+
+import { GoonSignalingClient, GoonSignalError, isGuestId, normalizeCode } from '../net/signaling.js';
+import { GoonFakeSignalingServer, isGuestUid } from '../net/fakeSignaling.js';
+import { GoonSession } from '../net/session.js';
+import { standaloneInit } from '../bridge.js';
+import { S } from '../ui/strings.js';
+
+const fs = await import('node:fs');
+const path = await import('node:path');
+const urlMod = await import('node:url');
+const HERE = path.dirname(urlMod.fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, '..');
+// LF-normalized: the worktree is CRLF (core.autocrlf) and every pin below is written against \n.
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8').replace(/\r\n/g, '\n');
+const readApp = (...rel) => fs.readFileSync(path.join(ROOT, '..', '..', '..', ...rel), 'utf8').replace(/\r\n/g, '\n');
+
+// ------------------------------------------------------------------ harness
+
+let failures = 0;
+let n = 0;
+function ok(cond, label, extra = '') {
+  n++;
+  if (!cond) { failures++; console.error(`  FAIL ${label} ${extra}`); }
+}
+const quiet = { info() {}, warn() {}, error() {}, debug() {}, log() {} };
+
+/** Wraps a fake server's post so a test can see EXACTLY what went on the wire, opts and all. */
+function recorder(server) {
+  const calls = [];
+  return {
+    calls,
+    post: (p, body, opts) => { calls.push({ path: p, body, opts }); return server.post(p, body); },
+    last: (suffix) => [...calls].reverse().find((c) => String(c.path).endsWith(suffix)) || null,
+  };
+}
+
+// ========================================================== 1. the error vocabulary
+
+{
+  ok(GoonSignalError.NoHostAccess === 'no_host_access', 'GoonSignalError carries no_host_access');
+  ok(GoonSignalError.NoPass === 'no_pass',
+    'and KEEPS no_pass — retired server-side, still parsed so an old server gets a sentence');
+
+  const stub = (status, body) => new GoonSignalingClient({
+    post: () => Promise.resolve({ status, body }),
+    unifiedId: 'u_someone', logger: quiet,
+  });
+
+  let c = stub(403, '{"error":"no_host_access"}');
+  ok((await c.createInvite('A')) === null, '403 fails the invite');
+  ok(c.lastError === GoonSignalError.NoHostAccess, '403 no_host_access maps to itself, NOT unauthorized');
+  ok(c.lastErrorInfo.kind === 'no_host_access', 'and reaches the UI through lastErrorInfo');
+
+  // A bare 403 is still "signed out": only the body can say it is an entitlement answer.
+  c = stub(403, '');
+  await c.createInvite('A');
+  ok(c.lastError === GoonSignalError.Unauthorized, 'a BODYLESS 403 still reads as unauthorized');
+
+  c = stub(402, '{"error":"no_pass","next_pass_utc":"2026-08-10T00:00:00Z"}');
+  await c.createInvite('A');
+  ok(c.lastError === GoonSignalError.NoPass && c.lastErrorDetail === '2026-08-10T00:00:00Z',
+    'the retired 402 still parses whole — old-server tolerance is not optional');
+}
+
+// ================================================ 2. the fake server models the gate
+
+{
+  const server = new GoonFakeSignalingServer({ hostGate: true });
+  server.setLabAccess('u_tier2');
+
+  const poor = new GoonSignalingClient({ post: server.post, unifiedId: 'u_tier1', logger: quiet });
+  ok((await poor.createInvite('Tier1')) === null, 'the fake refuses a room to a non-tier-2 uid');
+  ok(poor.lastError === GoonSignalError.NoHostAccess, 'with the real server\'s 403 no_host_access');
+  ok(server.roomCount === 0, 'and mints nothing');
+
+  const rich = new GoonSignalingClient({ post: server.post, unifiedId: 'u_tier2', logger: quiet });
+  const inv = await rich.createInvite('Tier2');
+  ok(!!inv && !!inv.code, 'tier 2 mints a room');
+  ok(inv.pass === 'premium', 'and /invite keeps the legacy `pass` shape (nothing is charged)');
+
+  // Whitelist folds to permanent tier 2, exactly as computeEffectiveTier does it server-side.
+  const wl = new GoonFakeSignalingServer({ hostGate: true, whitelist: ['u_owner'] });
+  const owner = new GoonSignalingClient({ post: wl.post, unifiedId: 'u_owner', logger: quiet });
+  ok(!!(await owner.createInvite('Owner')), 'a whitelisted uid hosts without being named tier 2');
+
+  // The default is OFF so the room-lifecycle suites are not all about entitlement.
+  const open = new GoonFakeSignalingServer();
+  const anyone = new GoonSignalingClient({ post: open.post, unifiedId: 'u_nobody', logger: quiet });
+  ok(!!(await anyone.createInvite('Nobody')), 'hostGate defaults off — the gate is opt-in for tests');
+}
+
+// ============================================ 3. JOINING IS FREE, AND MAY BE ANONYMOUS
+
+{
+  const server = new GoonFakeSignalingServer({ hostGate: true, labAccess: ['u_host'] });
+  const host = new GoonSignalingClient({ post: server.post, unifiedId: 'u_host', logger: quiet });
+  const inv = await host.createInvite('Host');
+
+  const rec = recorder(server);
+  const seats = [];
+  const guest = new GoonSignalingClient({
+    post: rec.post, logger: quiet,
+    anonymous: true,
+    onGuest: (id, code) => seats.push({ id, code }),
+  });
+  ok(guest.unifiedId === '', 'an anonymous client starts with no identity at all');
+
+  const j = await guest.join(inv.code, 'Nobody');
+  ok(!!j, 'a uid-less join is accepted — joining is free, account or not');
+
+  // --- 1. the absence of a field IS the request -------------------------------
+  const joinCall = rec.last('/join');
+  ok(!!joinCall && !('unified_id' in joinCall.body),
+    'the /join body OMITS unified_id entirely — an empty string is a 400, not a request');
+  ok(joinCall.opts && joinCall.opts.noAuth === true,
+    'and goes out with no X-Auth-Token: a guest has no account token to send');
+
+  // --- 2. the seat id is adopted, not merely received -------------------------
+  ok(isGuestId(j.guestId) && isGuestUid(j.guestId), 'the response carries a well-formed g_ seat id');
+  ok(/^g_[a-f0-9]{16}$/.test(j.guestId), 'g_ + 16 hex, byte for byte the documented shape');
+  ok(guest.unifiedId === j.guestId, 'the client ADOPTS it as its unified_id');
+  ok(guest.guestId === j.guestId && guest.guestRoom === normalizeCode(inv.code),
+    'and records which room the seat belongs to');
+  ok(j.pass === 'free', 'the advisory pass label is "free" — nothing was charged');
+  ok(seats.length === 1 && seats[0].id === j.guestId && seats[0].code === normalizeCode(inv.code),
+    'the persistence sink is handed the id AND the room');
+
+  // Every later room-scoped call must present the seat id, or the room stops believing us.
+  await guest.signal(inv.code, j.token, 'guest', 0, [{ kind: 'offer', data: '{}' }]);
+  ok(rec.last('/signal').body.unified_id === j.guestId, '/signal presents the g_ id');
+  ok(rec.last('/signal').opts.noAuth === true, '/signal still sends no auth header');
+  await guest.relay(inv.code, j.token, 'guest', 0, ['{}'], 100);
+  ok(rec.last('/relay').body.unified_id === j.guestId, '/relay presents the g_ id');
+  await guest.leave(inv.code, j.token, 'guest');
+  ok(rec.last('/leave').body.unified_id === j.guestId, '/leave presents the g_ id');
+
+  // --- an ACCOUNT join is untouched by any of it ------------------------------
+  const rec2 = recorder(server);
+  const acct = new GoonSignalingClient({ post: rec2.post, unifiedId: 'u_member', logger: quiet });
+  const inv2 = await host.createInvite('Host');
+  const j2 = await acct.join(inv2.code, 'Member');
+  ok(!!j2 && rec2.last('/join').body.unified_id === 'u_member', 'an account join still sends its uid');
+  ok(rec2.last('/join').opts === undefined, 'and still sends its auth header');
+  ok(j2.guestId === '' && acct.unifiedId === 'u_member', 'and is handed no guest_id to adopt');
+}
+
+// =================================================== 4. THE SEAT SURVIVES A RELOAD
+
+{
+  const server = new GoonFakeSignalingServer();
+  const host = new GoonSignalingClient({ post: server.post, unifiedId: 'u_host', logger: quiet });
+  const inv = await host.createInvite('Host');
+
+  const first = new GoonSignalingClient({ post: server.post, logger: quiet, anonymous: true });
+  const j1 = await first.join(inv.code);
+  ok(!!j1 && !!j1.guestId, 'a guest takes the seat');
+
+  // THE RELOAD. A brand new client, constructed from what was persisted.
+  const rec = recorder(server);
+  const reloaded = new GoonSignalingClient({
+    post: rec.post, logger: quiet, anonymous: true,
+    guestId: j1.guestId, guestRoom: inv.code,
+  });
+  const j2 = await reloaded.join(inv.code);
+  ok(!!j2, 'the reload gets back in — not "that room already has two players", by its own ghost');
+  ok(rec.last('/join').body.unified_id === j1.guestId, 'by RE-PRESENTING the stored g_ id');
+  ok(j2.rejoin === true && j2.pass === 'rejoin', 'the server reports a reclaim, not a fresh claim');
+  ok(j2.guestId === j1.guestId, 'the seat id is confirmed back, so the client can trust what it kept');
+  ok(j2.token !== j1.token, 'with a fresh room token');
+
+  // …but ONLY for its own room. A guest id carried between rooms would be a durable handle on
+  // somebody who never signed up for one.
+  const other = await host.createInvite('Host2');
+  const rec2 = recorder(server);
+  const elsewhere = new GoonSignalingClient({
+    post: rec2.post, logger: quiet, anonymous: true,
+    guestId: j1.guestId, guestRoom: inv.code,
+  });
+  const j3 = await elsewhere.join(other.code);
+  ok(!!j3 && !('unified_id' in rec2.last('/join').body),
+    'a DIFFERENT room omits the stored id and takes a fresh identity');
+  ok(j3.guestId && j3.guestId !== j1.guestId, 'which the server duly mints');
+
+  // A malformed stored id is not an identity — it must never reach the wire.
+  const rec3 = recorder(server);
+  const junk = new GoonSignalingClient({
+    post: rec3.post, logger: quiet, anonymous: true,
+    guestId: 'u_pretending', guestRoom: inv.code,
+  });
+  ok(junk.guestId === '', 'a non-g_ stored id is discarded at construction');
+  await junk.join(await host.createInvite('H3').then((i) => i.code));
+  ok(!('unified_id' in rec3.last('/join').body), 'and never gets presented');
+}
+
+// ================================================= 5. the session wires the two together
+
+{
+  const noop = () => ({ dispose() {}, cancelMatch() {} });
+  const saved = [];
+  const seat = { id: '', code: '', save(id, code) { this.id = id; this.code = code; saved.push([id, code]); } };
+  const s = new GoonSession({
+    createMatch: noop,
+    identity: { unifiedId: 'local-Solo', displayName: 'Solo', appVersion: 'dev', anonymous: true },
+    guest: seat,
+    logger: quiet,
+  });
+  const sig = s._createSignaling();
+  ok(sig.anonymous === true, 'GoonSession passes identity.anonymous down to the signaling client');
+  ok(typeof sig._onGuest === 'function', 'and wires the persistence sink');
+  sig._adoptGuestId({ guest_id: 'g_0123456789abcdef' }, 'ABC123');
+  ok(seat.id === 'g_0123456789abcdef' && seat.code === 'ABC123',
+    'a minted seat is written back into the live store, so the NEXT client reclaims it');
+
+  // An account page must not accidentally go anonymous.
+  const s2 = new GoonSession({
+    createMatch: noop,
+    identity: { unifiedId: 'u_member', displayName: 'M', appVersion: 'dev' },
+    logger: quiet,
+  });
+  ok(s2._createSignaling().anonymous === false, 'no `anonymous` on the identity = an account page');
+}
+
+// ============================================ 6. bridge: who counts as having an account
+
+{
+  const before = standaloneInit();
+  ok(before.identity.anonymous === true,
+    'a bare standalone launch is ANONYMOUS — a `local-…` fallback id is not an account');
+  ok(/^local-/.test(before.identity.unifiedId), 'and still carries the throwaway local id for display');
+
+  globalThis.location = { search: '?uid=u_realaccount&name=Phone' };
+  try {
+    const withUid = standaloneInit();
+    ok(withUid.identity.anonymous === false, '?uid= is a real account — not anonymous');
+    ok(withUid.identity.unifiedId === 'u_realaccount', 'and is used verbatim');
+  } finally { delete globalThis.location; }
+
+  const src = read('bridge.js');
+  ok(/const account = String\(q\.get\('uid'\) \|\| prefs\.unifiedId \|\| ''\);/.test(src),
+    'a uid adopted into prefs by an earlier launch counts as an account too');
+  ok(/if \(netCfg\.authToken && !noAuth\) headers\['X-Auth-Token'\]/.test(src),
+    'postNet honours noAuth on the direct-fetch path');
+}
+
+// ===================================================== 7. the sheet, and the retired copy
+
+{
+  ok(!!S.sheets.noHostAccess && typeof S.sheets.noHostAccess.line === 'string',
+    'there is a no_host_access sheet, and its line is a plain string (no pass date to interpolate)');
+  ok(/supporter perk/i.test(S.sheets.noHostAccess.headline + ' ' + S.sheets.noHostAccess.line),
+    'it names the perk');
+  ok(/free/i.test(S.sheets.noHostAccess.line),
+    'and says what is still free, rather than stopping at "no"');
+  ok(S.sheets.noPass === undefined, 'the weekly-pass copy is retired — the server never sends it');
+  ok(typeof S.title.hostNoLab === 'string' && S.title.hostNoLab === S.title.hostNoLab.toLowerCase(),
+    'the menu note is lowercase, same voice as lobby.transferNoPremium');
+
+  const sheets = read('ui/sheets.js');
+  ok(/case 'no_host_access':\s*\n\s*case 'no_pass':/.test(sheets),
+    'showSignalError maps BOTH the new refusal and the retired one to that sheet');
+}
+
+// ============================================== 8. the title menu, actually mounted
+
+function installDom() {
+  function makeNode(tagName) {
+    const kids = [];
+    const map = new Map();
+    const classes = new Set();
+    const attrs = new Map();
+    const node = {
+      tagName: String(tagName || 'div').toUpperCase(),
+      nodeType: 1,
+      children: kids,
+      childNodes: kids,
+      parentNode: null,
+      isConnected: true,
+      hidden: false,
+      style: { setProperty() {}, removeProperty() {} },
+      dataset: {},
+      value: '',
+      disabled: false,
+      textContent: '',
+      title: '',
+      get className() { return Array.from(classes).join(' '); },
+      set className(v) { classes.clear(); String(v || '').split(/\s+/).filter(Boolean).forEach((c) => classes.add(c)); },
+      classList: {
+        add: (...c) => c.forEach((x) => classes.add(x)),
+        remove: (...c) => c.forEach((x) => classes.delete(x)),
+        toggle: (c, on) => (on ? classes.add(c) : classes.delete(c)),
+        contains: (c) => classes.has(c),
+      },
+      appendChild(child) { if (child) { child.parentNode = node; kids.push(child); } return child; },
+      append(...c) { c.forEach((x) => node.appendChild(x)); },
+      prepend(child) { if (child) { child.parentNode = node; kids.unshift(child); } return child; },
+      removeChild(child) { const i = kids.indexOf(child); if (i >= 0) kids.splice(i, 1); return child; },
+      remove() { if (node.parentNode) node.parentNode.removeChild(node); node.parentNode = null; node.isConnected = false; },
+      replaceChildren(...c) { kids.length = 0; c.forEach((x) => node.appendChild(x)); },
+      contains(other) {
+        if (other === node) return true;
+        for (const k of kids) if (k && typeof k.contains === 'function' && k.contains(other)) return true;
+        return false;
+      },
+      setAttribute(k, v) { attrs.set(k, String(v)); if (k === 'class') node.className = String(v); },
+      getAttribute(k) { return attrs.has(k) ? attrs.get(k) : null; },
+      removeAttribute(k) { attrs.delete(k); },
+      hasAttribute(k) { return attrs.has(k); },
+      addEventListener(type, fn) { if (!map.has(type)) map.set(type, new Set()); map.get(type).add(fn); },
+      removeEventListener(type, fn) { const s = map.get(type); if (s) s.delete(fn); },
+      dispatchEvent(evt) {
+        const s = map.get(evt && evt.type);
+        if (s) for (const fn of Array.from(s)) { try { fn(evt); } catch (_e) { /* ignore */ } }
+        return true;
+      },
+      click() { node.dispatchEvent({ type: 'click', preventDefault() {}, target: node }); },
+      focus() {}, blur() {},
+      _classes: classes,
+    };
+    return node;
+  }
+  const doc = makeNode('#document');
+  doc.documentElement = makeNode('html');
+  doc.body = makeNode('body');
+  doc.activeElement = null;
+  doc.createElement = (tag) => makeNode(tag);
+  doc.createElementNS = (_ns, tag) => makeNode(tag);
+  doc.createTextNode = (t) => { const x = makeNode('#text'); x.textContent = String(t); return x; };
+  doc.getElementById = () => null;
+  globalThis.document = doc;
+  globalThis.window = makeNode('window');
+  return { doc, makeNode };
+}
+const dom = installDom();
+
+// Imported AFTER the DOM exists — a screen module touches document at mount, not at import,
+// but the router it pulls in is the one thing that must find a document to build nodes with.
+const title = await import('../ui/screens/title.js');
+
+function findAll(root, className) {
+  const out = [];
+  (function walk(node) {
+    if (!node) return;
+    if (node._classes && node._classes.has(className)) out.push(node);
+    for (const kid of node.children || []) walk(kid);
+  })(root);
+  return out;
+}
+
+/** Mount the title screen against a session shape and hand back the Host menu item. */
+function mountTitle(sessionShape) {
+  const container = dom.makeNode('div');
+  const clicks = [];
+  const handle = title.mount(container, {
+    session: sessionShape,
+    actions: {
+      goHost: () => clicks.push('host'), goJoin: () => clicks.push('join'),
+      goPractice: () => clicks.push('practice'), goAssets: () => {}, goVoice: () => {},
+      quit: () => {},
+    },
+    logger: quiet,
+  });
+  const items = findAll(container, 'gg-menu-item');
+  return { handle, container, clicks, items, host: items[0] || null };
+}
+
+{
+  // HOSTED + refused: visible, dimmed, and carrying the reason.
+  const m = mountTitle({ hosted: true, caps: { canHost: false } });
+  ok(!!m.host, 'the Host item is still RENDERED when hosting is refused — a missing row reads as broken');
+  ok(m.host.disabled === true, 'but disabled');
+  ok(m.host._classes.has('is-disabled'), 'and dimmed with the lobby-row class');
+  ok(m.host.getAttribute('aria-disabled') === 'true', 'and announced as disabled');
+  const note = findAll(m.host, 'gg-menu-note')[0];
+  ok(!!note && note.textContent === S.title.hostNoLab, 'with the supporter-perk note under it');
+  ok(!m.host._classes.has('gg-btn--primary'), 'and it is not still the primary call to action');
+  m.host.click();
+  ok(m.clicks.length === 0, 'clicking it routes nowhere — the guard is in the handler, not just the CSS');
+  m.handle.unmount();
+}
+
+{
+  // HOSTED + allowed: untouched.
+  const m = mountTitle({ hosted: true, caps: { canHost: true } });
+  ok(m.host.disabled !== true && !m.host._classes.has('is-disabled'), 'canHost true leaves Host alone');
+  m.host.click();
+  ok(m.clicks[0] === 'host', 'and it routes');
+  ok(findAll(m.host, 'gg-menu-note').length === 0, 'with no note to explain a gate that is not there');
+  m.handle.unmount();
+}
+
+{
+  // HOSTED by a host that predates the flag: absent is not false.
+  const m = mountTitle({ hosted: true, caps: { video: true } });
+  ok(m.host.disabled !== true, 'a missing canHost does NOT lock Host — `=== false` on purpose');
+  m.handle.unmount();
+  const m2 = mountTitle({ hosted: true, caps: null });
+  ok(m2.host.disabled !== true, 'and neither does a caps-less init frame');
+  m2.handle.unmount();
+}
+
+{
+  // STANDALONE: entitlement is unknowable before a round-trip, so never guess.
+  const m = mountTitle({ hosted: false, caps: { canHost: false } });
+  ok(m.host.disabled !== true,
+    'standalone leaves Host live even against canHost:false — the 403 sheet is the fallback');
+  m.host.click();
+  ok(m.clicks[0] === 'host', 'and it still routes, so a supporter is never locked out on a guess');
+  m.handle.unmount();
+}
+
+// ==================================================== 9. the C# half says the same thing
+
+{
+  const patreon = readApp('Services', 'Account', 'PatreonService.cs');
+  ok(/public bool HasLabAccess =>/.test(patreon), 'PatreonService exposes HasLabAccess');
+  ok(/HasLabAccess =>[\s\S]{0,200}CurrentTier >= PatreonTier\.Level2/.test(patreon),
+    'and it is TIER 2, not the tier-1 bar HasPremiumAccess uses');
+  ok(/HasLabAccess =>[\s\S]{0,300}IsWhitelisted/.test(patreon), 'with the whitelist folded in');
+  ok(/HasLabAccess =>[\s\S]{0,300}SubscribeStar/.test(patreon),
+    'and SubscribeStar OR\'d in, the way the server folds substar_tier');
+  ok(/computeEffectiveTier\(user\) &gt;= 2/.test(patreon),
+    'documented against the server comparison it mirrors');
+  ok(!/HasLabAccess =>[\s\S]{0,300}HasCachedPremiumAccess/.test(patreon),
+    'and NOT off the 2-week grace cache, which caches a tier-1 entitlement');
+
+  const hostSvc = readApp('Services', 'GoonGame', 'GoonHostService.cs');
+  ok(/canHost = HostingAllowed\(\),/.test(hostSvc), 'the init frame carries caps.canHost');
+  ok(/mediaTransfer = TransferAllowed\(\),\s*\n\s*canHost = HostingAllowed\(\),/.test(hostSvc),
+    'right beside the transfer verdict it is a rung above');
+  ok(/HostingAllowed\(\)\s*\n?\s*\{[\s\S]{0,160}App\.Patreon\?\.HasLabAccess == true;[\s\S]{0,80}catch \{ return false; \}/.test(hostSvc),
+    'computed from HasLabAccess, defaulting false in the same try/catch style as TransferAllowed');
+
+  const cs = readApp('Services', 'GoonGame', 'GoonSignalingClient.cs');
+  ok(/ErrorNoHostAccess = "no_host_access"/.test(cs), 'the C# client knows no_host_access');
+  ok(/case 403:\s*\n(\s*\/\/.*\n)*\s*LastError = serverError \?\? ErrorUnauthorized;/.test(cs),
+    '403 triage is its own arm, so the body can name the entitlement answer');
+  ok(/no_host_access/.test(cs.slice(0, cs.indexOf('POST /v2/goon/signal'))),
+    'and the header contract documents the tier-2 invite rule');
+  ok(/JOINING IS FREE/.test(cs), 'and that joining is free for everyone');
+  ok(/guest_id/.test(cs), 'and the anonymous-guest flow, even though C# never takes it');
+  ok(/no_pass is retired|Retired 2026-08-04|Retired: the server no longer charges/.test(cs),
+    'with the weekly pass marked retired rather than silently deleted');
+
+  // The C# fake is the executable half of that contract.
+  ok(/public bool HostGate \{ get; set; \}/.test(cs), 'GoonFakeSignalingServer models the host gate');
+  ok(/if \(HostGate && !_labAccess\.Contains[\s\S]{0,140}ErrorNoHostAccess\)/.test(cs),
+    'refusing /invite below tier 2 with 403 no_host_access');
+  ok(/\["pass"\] = "free"/.test(cs), 'and never charging for a join');
+  ok(/DOCUMENTED GAP/.test(cs), 'with the un-ported seat-identity model called out rather than implied');
+}
+
+// ============================================================ 10. the protocol doc
+
+{
+  const doc = readApp('docs', 'GOON_GAME_PROTOCOL.md');
+  ok(/no_host_access/.test(doc), 'GOON_GAME_PROTOCOL.md documents the 403');
+  ok(/guest_id/.test(doc), 'and the anonymous guest identity');
+  ok(/`g_`|g_<|`g_\+/.test(doc), 'and names the g_ shape');
+  ok(/"free"\s*\|\s*"rejoin"\s*\|\s*"self_duel"|free.*rejoin.*self_duel/.test(doc),
+    'and the new pass vocabulary');
+  ok(/canHost/.test(doc), 'and the caps.canHost the host answers with');
+}
+
+console.log(failures === 0
+  ? `selftest-hostgate: ${n}/${n} checks passed`
+  : `selftest-hostgate: ${n - failures}/${n} checks passed\n${failures} FAILURE(S)`);
+process.exitCode = failures === 0 ? 0 : 1;

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -1220,8 +1220,10 @@ async function testBetaGates() {
   // --- a) the page halves, pinned at source level -------------------------------
   {
     const bridge = readSource('../bridge.js');
-    ok(/mediaTransfer:\s*!\(q\.get\('server'\)\s*\|\|\s*prefs\.serverBase\)/.test(bridge),
-      'standaloneInit only self-grants sending when NO server is in play (the pure-local dev path)');
+    ok(/mediaTransfer:\s*!\(q\.get\('server'\)\s*\|\|\s*prefs\.serverBase\s*\|\|\s*defaultServerBase\(\)\)/.test(bridge),
+      'standaloneInit only self-grants sending when NO server is in play (query, prefs, or the public-deploy default)');
+    ok(/\(\^\|\\\.\)cclabs\\\.app\$/.test(bridge),
+      'defaultServerBase is pinned to the public deployment host, so dev origins keep the serverless playground');
     const boot = readSource('../boot.js');
     ok(/typeof goonSession\.signaling\.mediaSend === 'boolean'/.test(boot)
       && /!session\.hosted/.test(boot.slice(boot.indexOf('mediaSend') - 600, boot.indexOf('mediaSend') + 600)),

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/host.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/host.js
@@ -3,9 +3,13 @@
  *
  * The whole screen is one promise's lifetime: actions.hostStart() resolves with
  * a code or a machine-readable failure, and every failure has a SENTENCE (see
- * ui/sheets.js showSignalError) rather than a status number. "no_pass" in
+ * ui/sheets.js showSignalError) rather than a status number. "no_host_access" in
  * particular is a product message, not an error — the player has not done
- * anything wrong, their free match is simply spent.
+ * anything wrong, hosting is simply a tier-2 perk and they are not tier 2. It is
+ * also the one refusal that still reaches this screen with title.js's gate in
+ * place: STANDALONE cannot know the answer before asking, and a tier that lapsed
+ * since launch would walk past a hosted check too. (The retired 402 "no_pass"
+ * lands on the same sheet, for an old server in front of a new client.)
  *
  * The five-minute expiry is a CLIENT-SIDE countdown against the server's own
  * TTL. It is deliberately advisory: when it runs out we say so and offer a new

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
@@ -54,7 +54,31 @@ export function mount(container, ctx) {
     return b;
   };
 
-  item(S.title.host, () => actions.goHost(), { variant: standalone ? '' : 'primary' });
+  /* THE HOST GATE (2026-08-04). Hosting is a tier-2 perk — the server refuses below it with 403
+   * no_host_access — and the C# host answers the same question locally in `caps.canHost`, so
+   * HOSTED we can say so on the menu instead of routing the player to a screen whose entire
+   * content is a refusal. The item stays VISIBLE and dims: a missing menu row reads as a broken
+   * build, and a perk nobody can see is a perk nobody buys.
+   *
+   * STANDALONE it stays enabled. Out here entitlement is unknowable until a server has answered
+   * (the same reason the status ribbon below still renders no premium state), and a page that
+   * dimmed Host on a guess would lock a paying supporter out of the thing they paid for. The 403
+   * sheet is the fallback and it says the same sentence.
+   *
+   * `=== false` on purpose, exactly how the page reads every other cap: a host that predates the
+   * flag leaves Host alone rather than locking it. */
+  const hostLocked = !standalone && (session.caps || {}).canHost === false;
+  const hostItem = item(S.title.host, () => { if (!hostLocked) actions.goHost(); }, {
+    variant: hostLocked ? '' : (standalone ? '' : 'primary'),
+    note: hostLocked ? S.title.hostNoLab : '',
+  });
+  if (hostLocked) {
+    // The lobby's transfer-row pattern: disable the control and put the WHY directly under it.
+    // `disabled` carries the dimming too (.gg-btn:disabled) and keeps it out of the tab order.
+    hostItem.disabled = true;
+    hostItem.classList.add('is-disabled');
+    hostItem.setAttribute('aria-disabled', 'true');
+  }
   item(S.title.join, () => actions.goJoin());
   item(S.title.practice, () => actions.goPractice(), {
     variant: standalone ? 'primary' : '',

--- a/ConditioningControlPanel/Resources/web/goon/ui/sheets.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/sheets.js
@@ -123,8 +123,16 @@ export function createSheets({ root = null, audio = null, logger = null } = {}) 
     ];
 
     switch (kind) {
+      // The host gate, and the weekly pass it replaced. `no_pass` is retired server-side and is
+      // kept here only so an OLD server in front of a new client still produces a product message
+      // instead of falling through to "check your connection" about a server that answered fine.
+      case 'no_host_access':
       case 'no_pass':
-        return open({ icon: S.sheets.noPass.icon, headline: S.sheets.noPass.headline, line: S.sheets.noPass.line(detail) });
+        return open({
+          icon: S.sheets.noHostAccess.icon,
+          headline: S.sheets.noHostAccess.headline,
+          line: S.sheets.noHostAccess.line,
+        });
       case 'not_deployed':
         return open({ icon: S.sheets.notDeployed.icon, headline: S.sheets.notDeployed.headline, line: S.sheets.notDeployed.line });
       case 'rate_limited':

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -35,6 +35,9 @@ export const S = Object.freeze({
   title: {
     kicker: '1v1 · endurance duel · first to break loses',
     host: 'Host a match',
+    // The dimmed-Host note. Same voice as lobby.transferNoPremium — lowercase, an explanation
+    // rather than a pitch, and it names the thing that is still free instead of stopping at "no".
+    hostNoLab: 'hosting is a supporter perk — joining a room is always free.',
     join: 'Join with a code',
     practice: 'Practice',
     practiceNote: 'solo · scripted opponent',
@@ -692,10 +695,14 @@ export const S = Object.freeze({
 
   /* --------------------------------------------------------------- sheets */
   sheets: {
-    noPass: {
+    /* THE HOST GATE. Not a fault and not a wall: joining is free forever, so the sentence has to
+       leave the player somewhere to go rather than only closing a door. It also answers the
+       retired 402 `no_pass` — an old server's "your free match is spent" is the same conversation
+       with worse information, and this is the only copy left for either. */
+    noHostAccess: {
       icon: '✦',
-      headline: 'Your free match is spent',
-      line: (when) => 'Your next free match unlocks ' + (when || 'next week') + '.',
+      headline: 'Hosting is a supporter perk',
+      line: "Opening a room is for Tier 2 supporters. Joining someone else's is always free — ask them for a code.",
     },
     notDeployed: {
       icon: '⏳',

--- a/ConditioningControlPanel/Services/Account/PatreonService.cs
+++ b/ConditioningControlPanel/Services/Account/PatreonService.cs
@@ -131,6 +131,28 @@ namespace ConditioningControlPanel.Services
         public bool HasPremiumAccess => CurrentTier >= PatreonTier.Level1 || IsWhitelisted || (App.Settings?.Current?.HasCachedPremiumAccess == true)
             || (App.SubscribeStar?.HasPremiumAccess == true);
 
+        /// <summary>
+        /// Whether the user has Lab access: Tier 2+ OR whitelisted.
+        ///
+        /// THIS IS THE GOON GAME **HOST** BAR, and it mirrors the server exactly:
+        /// <c>/v2/goon/invite</c> answers 403 <c>no_host_access</c> below
+        /// <c>computeEffectiveTier(user) &gt;= 2</c>. Joining a duel is free for everyone;
+        /// minting the room is the tier-2 perk. <see cref="HasPremiumAccess"/> is deliberately
+        /// NOT the right gate here — in this codebase "premium" means tier 1.
+        ///
+        /// Whitelist folds to permanent tier 2 on both sides (<see cref="SetWhitelistStatus"/>
+        /// raises CurrentTier to Level2, computeEffectiveTier does the same server-side), so the
+        /// OR is belt-and-braces rather than a second rule. SubscribeStar is OR'd in the same way
+        /// the server folds <c>substar_tier</c>. The 2-week grace cache is NOT: it caches a
+        /// tier-1 entitlement and would let a lapsed patron host.
+        ///
+        /// Advisory only — the server refuses on its own, and this exists so the UI can say so
+        /// before the round-trip instead of after it.
+        /// </summary>
+        public bool HasLabAccess => CurrentTier >= PatreonTier.Level2 || IsWhitelisted
+            || (App.SubscribeStar?.CurrentTier ?? PatreonTier.None) >= PatreonTier.Level2
+            || (App.SubscribeStar?.IsWhitelisted == true);
+
         public PatreonService()
         {
             _tokenStorage = new SecureTokenStorage();

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -330,6 +330,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         camera = false,           // no webcam bridge into the page in v1
                         video = true,
                         mediaTransfer = TransferAllowed(),
+                        canHost = HostingAllowed(),
                     },
                     consent = new
                     {
@@ -835,6 +836,21 @@ namespace ConditioningControlPanel.Services.GoonGame
         private static bool TransferAllowed()
         {
             try { return App.Patreon?.HasPremiumAccess == true; }
+            catch { return false; }
+        }
+
+        /// <summary>May the page MINT a room? TIER 2 ONLY.
+        ///
+        /// A rung above <see cref="TransferAllowed"/>, and a different question: sending media is
+        /// tier 1, hosting a duel is tier 2. The server enforces it at <c>/v2/goon/invite</c>
+        /// (403 <c>no_host_access</c> below <c>computeEffectiveTier &gt;= 2</c>) and this is the
+        /// same verdict computed locally, so the title screen can dim Host instead of routing the
+        /// player to a screen whose only content is a refusal. JOINING is free for everyone and is
+        /// never gated here. The page reads this with <c>=== true</c>, so a host that predates the
+        /// flag leaves Host enabled and falls back to the server's answer.</summary>
+        private static bool HostingAllowed()
+        {
+            try { return App.Patreon?.HasLabAccess == true; }
             catch { return false; }
         }
 

--- a/ConditioningControlPanel/Services/GoonGame/GoonSignalingClient.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonSignalingClient.cs
@@ -25,27 +25,43 @@ namespace ConditioningControlPanel.Services.GoonGame
     // { error, cap, count, retry_after_seconds } shape the client already knows how to read.
     //
     // ---------------------------------------------------------------------------- POST /v2/goon/invite
-    // Host mints a match. Server checks premium OR burns the weekly free pass (server decides,
-    // never the client) and stores the room under a short crockford32 code with a ~5 min TTL.
+    // Host mints a match. HOSTING IS A TIER-2 PERK (2026-08-04): the server refuses anything below
+    // computeEffectiveTier(user) >= 2, into which the whitelist folds as permanent tier 2. The
+    // launch model — tier>=1 free play plus a weekly free pass for tier 0 — is GONE, along with
+    // the 402 that carried it; joining costs nothing now, so there is no pass left to charge.
+    // The room is stored under a short crockford32 code with a ~5 min TTL.
     //   req  { "unified_id":"u_...", "display_name":"Bambi", "app_version":"6.6.3",
     //          "protocol_version":1, "prefer_relay":false }
     //   200  { "ok":true, "code":"7QK4RM", "token":"<host room token>", "role":"host",
-    //          "expires_in_sec":300, "pass":"premium"|"weekly_free", "relay_allowed":true }
-    //   402  { "error":"no_pass", "next_pass_utc":"2026-08-10T00:00:00Z" }   weekly pass spent
+    //          "expires_in_sec":300, "pass":"premium", "relay_allowed":true }
+    //          `pass` is legacy-shaped: a tier-2 host was always "premium" in the old vocabulary.
+    //   403  { "error":"no_host_access" }      not tier 2 — hosting is a supporter perk
     //   401  { "error":"unauthorized" }
     //   429  { "error":"rate_limited", "cap":"user"|"ip", "count":N, "retry_after_seconds":N }
+    //   (402 no_pass is retired. Still PARSED — an old server in front of a new client must keep
+    //    producing a sentence rather than a status number — but never sent.)
     //
     // ------------------------------------------------------------------------------ POST /v2/goon/join
-    // Guest redeems the code. Same pass check. Server marks the room joined so the host's next
-    // /signal poll sees peer_joined.
+    // Guest redeems the code. FREE FOR EVERYONE — no tier check at all. Server marks the room
+    // joined so the host's next /signal poll sees peer_joined.
     //   req  { "unified_id":"u_...", "code":"7QK4RM", "display_name":"Circe",
     //          "app_version":"6.6.3", "protocol_version":1 }
     //   200  { "ok":true, "token":"<guest room token>", "role":"guest", "expires_in_sec":300,
-    //          "peer_display_name":"Bambi", "peer_app_version":"6.6.3", "pass":"premium",
-    //          "relay_allowed":true }
+    //          "peer_display_name":"Bambi", "peer_app_version":"6.6.3",
+    //          "pass":"free"|"rejoin"|"self_duel", "relay_allowed":true }
+    //          `pass` is now an ADVISORY LABEL for what happened, not what was charged.
     //   404  { "error":"unknown_code" }        bad/expired code
     //   409  { "error":"already_joined" }      someone else took the seat
-    //   402/401/429 as above
+    //   401/429 as above
+    //
+    //   ANONYMOUS GUESTS (web client only). A /join body with NO unified_id field at all is an
+    //   invite-link click from someone with no account: the server mints a `g_` + 16 hex guest
+    //   identity, returns it as `guest_id`, and the client must present THAT as unified_id on
+    //   every later room-scoped call (/signal, /relay, /leave, /ledger, /report, /blocked,
+    //   /peercard) with no X-Auth-Token at all. media_send is always false for a guest. THIS
+    //   CLIENT NEVER TAKES THAT PATH — the desktop app always has an account — and it is
+    //   documented here because this header is the contract, not because C# implements it. The
+    //   web binding (Resources/web/goon/net/signaling.js) is where it lives.
     //
     // ---------------------------------------------------------------------------- POST /v2/goon/signal
     // The SDP/ICE mailbox. ONE call both posts and drains, so a ~2 s short-poll costs one request.
@@ -97,7 +113,8 @@ namespace ConditioningControlPanel.Services.GoonGame
         public string Code { get; set; } = "";
         public string Token { get; set; } = "";
         public int ExpiresInSec { get; set; }
-        /// <summary>"premium" | "weekly_free" — what the server charged for this match.</summary>
+        /// <summary>Always "premium" — legacy-shaped, and nothing is charged. Reaching a 200 at
+        /// all IS the entitlement answer now (tier 2 or 403 no_host_access).</summary>
         public string Pass { get; set; } = "";
         public bool RelayAllowed { get; set; } = true;
     }
@@ -109,6 +126,8 @@ namespace ConditioningControlPanel.Services.GoonGame
         public int ExpiresInSec { get; set; }
         public string PeerDisplayName { get; set; } = "";
         public string PeerAppVersion { get; set; } = "";
+        /// <summary>"free" | "rejoin" | "self_duel" — advisory label for what happened to the
+        /// seat. Joining is free, so it never describes a charge.</summary>
         public string Pass { get; set; } = "";
         public bool RelayAllowed { get; set; } = true;
     }
@@ -159,7 +178,12 @@ namespace ConditioningControlPanel.Services.GoonGame
 
         /// <summary>LastError when the endpoint answered 404 with no room context, i.e. Phase F isn't deployed.</summary>
         public const string ErrorNotDeployed = "not_deployed";
+        /// <summary>Retired 2026-08-04 (the weekly free pass is gone). Kept so an OLD server in
+        /// front of a new client still produces a sentence instead of a status number.</summary>
         public const string ErrorNoPass = "no_pass";
+        /// <summary>/invite refused: hosting is tier 2 and this account is not. A product
+        /// message, not a fault — see the header. Joining stays free.</summary>
+        public const string ErrorNoHostAccess = "no_host_access";
         public const string ErrorUnknownCode = "unknown_code";
         public const string ErrorAlreadyJoined = "already_joined";
         public const string ErrorExpired = "expired";
@@ -400,10 +424,16 @@ namespace ConditioningControlPanel.Services.GoonGame
             switch ((int)status)
             {
                 case 401:
+                    LastError = serverError ?? ErrorUnauthorized;
+                    break;
                 case 403:
+                    // The host gate. A bare 403 is still "signed out" — but /invite's refusal is
+                    // an entitlement answer ("no_host_access"), and folding it into unauthorized
+                    // would tell a tier-1 patron to reconnect an account that is connected fine.
                     LastError = serverError ?? ErrorUnauthorized;
                     break;
                 case 402:
+                    // Retired: the server no longer charges for anything. Parsed for tolerance.
                     LastError = serverError ?? ErrorNoPass;
                     LastErrorDetail = json?["next_pass_utc"]?.Value<string>();
                     break;
@@ -477,8 +507,17 @@ namespace ConditioningControlPanel.Services.GoonGame
     /// pins the contract Phase F has to match. If the server and this class ever disagree, one of
     /// them is a bug.
     ///
-    /// It deliberately does NOT model auth, the weekly pass, or rate limiting: those are server
-    /// policy, and faking them here would only teach the client to trust a fake.
+    /// It deliberately does NOT model auth or rate limiting: those are server policy, and faking
+    /// them here would only teach the client to trust a fake. The HOST GATE is the one entitlement
+    /// rule it does model (<see cref="HostGate"/>, off by default) — not as auth, but because
+    /// "hosting is refused, joining is not" is the shape of the surface, and a fake that let
+    /// everybody host would never exercise the client's 403 path.
+    ///
+    /// DOCUMENTED GAP: the seat model here is still a bare <c>Joined</c> flag. Seat identity,
+    /// same-uid reclaim, /leave and self-duel — all live on the real server and in the web fake
+    /// (<c>Resources/web/goon/net/fakeSignaling.js</c>) — are deliberately NOT ported. Nothing
+    /// breaks (the desktop app is the HOST in the owner's setup and the additions are
+    /// backward-compatible), but do not trust this class for a rejoin or self-duel case.
     /// </summary>
     public sealed class GoonFakeSignalingServer
     {
@@ -495,8 +534,26 @@ namespace ConditioningControlPanel.Services.GoonGame
         }
 
         private readonly Dictionary<string, Room> _rooms = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _labAccess = new(StringComparer.Ordinal);
         private readonly object _gate = new();
         private int _codeCounter;
+
+        /// <summary>Enforce the tier-2 host gate on /invite? OFF by default, so the transport
+        /// tests that just need a room are not all about entitlement. Turn it on and only uids
+        /// passed to <see cref="SetLabAccess"/> may mint one; everyone else gets the real
+        /// server's 403 <c>no_host_access</c>. Joining is never gated either way.</summary>
+        public bool HostGate { get; set; }
+
+        /// <summary>Test hook: grant (or revoke) tier-2 hosting for a uid. Stands in for the
+        /// server's user record — the fake models WHO may, never HOW it is proven.</summary>
+        public void SetLabAccess(string unifiedId, bool on = true)
+        {
+            if (string.IsNullOrEmpty(unifiedId)) return;
+            lock (_gate)
+            {
+                if (on) _labAccess.Add(unifiedId); else _labAccess.Remove(unifiedId);
+            }
+        }
 
         /// <summary>Hand this to <see cref="GoonSignalingClient"/>'s constructor.</summary>
         public GoonHttpPost Post => PostAsync;
@@ -512,6 +569,11 @@ namespace ConditioningControlPanel.Services.GoonGame
                 {
                     case "/v2/goon/invite":
                     {
+                        // HOST GATE: tier 2 or nothing. The real server compares
+                        // computeEffectiveTier(user) >= 2 and answers 403 no_host_access below it.
+                        if (HostGate && !_labAccess.Contains(req["unified_id"]?.Value<string>() ?? ""))
+                            return Fail(HttpStatusCode.Forbidden, GoonSignalingClient.ErrorNoHostAccess);
+
                         var room = new Room
                         {
                             Code = "LOOP" + (++_codeCounter).ToString("D2"),
@@ -539,6 +601,8 @@ namespace ConditioningControlPanel.Services.GoonGame
                         if (room.Joined)
                             return Fail(HttpStatusCode.Conflict, GoonSignalingClient.ErrorAlreadyJoined);
                         room.Joined = true;
+                        // JOINING IS FREE — no gate, nothing charged. `pass` survives as an
+                        // advisory label; this fake's bare seat model only ever produces "free".
                         return Ok(new JObject
                         {
                             ["ok"] = true,
@@ -547,7 +611,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                             ["expires_in_sec"] = 300,
                             ["peer_display_name"] = "host",
                             ["peer_app_version"] = UpdateService.AppVersion,
-                            ["pass"] = "premium",
+                            ["pass"] = "free",
                             ["relay_allowed"] = true,
                         });
                     }

--- a/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
+++ b/ConditioningControlPanel/docs/GOON_GAME_PROTOCOL.md
@@ -42,10 +42,20 @@ Base: `https://codebambi-proxy.vercel.app`, all POST, auth = `X-Auth-Token` head
 429 body `{error:"rate_limited", cap, count, retry_after_seconds}`. Full field-level spec
 with all error cases lives at the top of `GoonSignalingClient.cs` — summary:
 
+**Entitlement (2026-08-04).** Exactly one route is gated: **hosting is tier 2**
+(`computeEffectiveTier(user) >= 2`, into which the whitelist folds as permanent tier 2), and
+`/invite` answers **403 `no_host_access`** below it. **Joining is free for everyone** — no tier
+check at all, and no account required (see *Anonymous guests* below). The launch model (tier ≥ 1
+free play plus a weekly free pass for tier 0) and its **402 `no_pass`** are **retired**; clients
+still parse `no_pass` so an old server keeps producing a sentence, but nothing sends it. The
+in-app host answers the same question locally as `caps.canHost` on its `init` frame, so the
+desktop title screen can dim Host before the round-trip; a standalone web page cannot know the
+answer before asking and leaves Host live, relying on the 403.
+
 | Endpoint | Purpose | Key semantics |
 |---|---|---|
-| `/v2/goon/invite` | host mints room | server checks premium OR burns weekly free pass (`pass:"premium"\|"weekly_free"`; 402 `no_pass` + `next_pass_utc`); crockford32 code, ~5 min TTL; answers `media_send` — the caller's premium SEND verdict for media transfer (tier≥1). The standalone web client defaults sending OFF against a real server and adopts this answer; the C# host computes the same verdict locally, so to it the field is advisory |
-| `/v2/goon/join` | guest redeems code | 404 `unknown_code`; 409 `already_joined` (a DIFFERENT uid holds the seat) or `self_join` (the code is your own room — one account cannot hold both seats); the SAME uid **reclaims** its seat instead of being refused: fresh token, `rejoin:true`, no second pass burned, stale SDP dropped; **whitelisted** accounts are the one exception to `self_join` and get a **self-duel** instead (`self_duel:true`, `pass:"self_duel"`) — see below; returns peer display name/version + the caller's own `media_send` verdict (see `/invite`) |
+| `/v2/goon/invite` | host mints room | **TIER 2 ONLY** — 403 `no_host_access` below it; crockford32 code, ~5 min TTL; `pass:"premium"` is legacy-shaped and charges nothing (reaching a 200 at all IS the entitlement answer); answers `media_send` — the caller's premium SEND verdict for media transfer (tier≥1, a rung BELOW the host bar). The standalone web client defaults sending OFF against a real server and adopts this answer; the C# host computes the same verdict locally, so to it the field is advisory |
+| `/v2/goon/join` | guest redeems code | **FREE — no tier check, and no account required**; 404 `unknown_code`; 409 `already_joined` (a DIFFERENT uid holds the seat) or `self_join` (the code is your own room — one account cannot hold both seats); the SAME uid **reclaims** its seat instead of being refused: fresh token, `rejoin:true`, stale SDP dropped; **whitelisted** accounts are the one exception to `self_join` and get a **self-duel** instead (`self_duel:true`) — see below; `pass` survives as an ADVISORY LABEL only, one of `"free" \| "rejoin" \| "self_duel"`; a body with **no `unified_id` field at all** mints an anonymous guest and answers `guest_id` (see below); returns peer display name/version + the caller's own `media_send` verdict (see `/invite`; always `false` for a guest) |
 | `/v2/goon/leave` | release the seat | best-effort, fire-and-forget, `{code, token, role}`; a guest hands the seat back and the ROOM stays up, a host folds the room outright; 409 `match_started` once the ledger has a row (releasing the seat invalidates the token that row is written with). Optional by design — the room TTL is still the backstop, and a client treats any failure as "never mind" |
 | `/v2/goon/signal` | SDP/ICE mailbox | post-and-drain in ONE call, ~2 s short-poll, setup only; `data` is opaque (browser-identical `toJSON()` blobs — JS does `JSON.parse` straight into `setRemoteDescription`/`addIceCandidate`); append-only list, exclusive `since` cursor, callers never receive their own messages |
 | `/v2/goon/relay` | fallback transport | same shape; `data` = whole GoonMessage frame; `wait_ms` long-poll hint; own rate budget (~1 call/2 s per player, match-length TTL), 16 KB/frame, 128-frame ring; server MUST NOT inspect or persist `data` |
@@ -53,6 +63,34 @@ with all error cases lives at the top of `GoonSignalingClient.cs` — summary:
 
 A bare 404 (no error body) on any route = "server not deployed" → clients show a
 warming-up message, never "bad code".
+
+### Anonymous guests (free join, 2026-08-04)
+
+Joining does not require an account. A `/join` body with **no `unified_id` field at all** — not an
+empty one, which is a 400 — is an invite-link click from somebody who has never seen the app. The
+server mints them a guest identity, **`g_` + 8 random bytes hex** (`^g_[a-f0-9]{16}$`), and returns
+it as **`guest_id`** on that one response.
+
+The client MUST then present that value as `unified_id` on **every** subsequent room-scoped call —
+`/signal`, `/relay`, `/leave`, `/ledger`, `/report`, `/blocked`, `/peercard` — alongside the room
+`token` it also received. **No `X-Auth-Token` header** goes with any of them: a guest has no
+account token, and the per-seat room token is the whole of its authority (the uid check is the
+secondary lock, exactly as it is for accounts).
+
+- Unified ids are `u_[a-z0-9]{8,24}`, so a `g_` id can never collide with — or be spelled by — a
+  real account, even though it travels in the same field.
+- The `g_` id **doubles as the seat-reclaim key**, which is why it is random and disclosed only
+  once. A guest that reloads re-presents its stored id with the **same room code** and reclaims its
+  seat through the normal rejoin path (`pass:"rejoin"`, fresh token). Clients persist it with the
+  room code and re-present it **only for that room** — carrying one across rooms would turn a
+  throwaway seat into a durable handle on somebody who never signed up for one.
+- A guest has **no user record**: `media_send` is always `false` for it, `/peercard` shares
+  nothing, and the ledger writes no `goon:ledger:g_*` history.
+- Guests never host: `/invite` is tier-2 gated and has no anonymous branch.
+
+Implemented on the server and in the **web** client (`net/signaling.js` `anonymous`, persisted
+through `bridge.savePrefs`). The C# client never takes this path — the desktop app always has an
+account — and documents it without implementing it.
 
 ### Self-duel (whitelist only, 2026-08-04)
 
@@ -82,8 +120,8 @@ by — a real caller, and every uid-keyed structure keeps seeing two identities:
 - a self-duel guest **reclaims the shadow seat** on rejoin (never a second shadow), and
   `/leave` frees it like any other seat.
 
-A self-duel costs no pass at all (`pass:"self_duel"`): the account already paid at
-`/invite`, and whitelist is permanent tier 2 anyway.
+A self-duel is labelled `pass:"self_duel"`. Nothing is charged for it, or for any join — whitelist
+is permanent tier 2 and the account already cleared the only gate there is, at `/invite`.
 
 > **Seat identity, `/leave` and self-duel (2026-08-04)** are implemented on the server
 > and in the **web** client (`Resources/web/goon/net/`). The C# client
@@ -93,13 +131,17 @@ A self-duel costs no pass at all (`pass:"self_duel"`): the account already paid 
 > `self_duel`. None of it is a break — the additions are backward-compatible and the
 > desktop app is the HOST in the owner's setup, which needs no client-side change —
 > but the C# fake no longer models everything the real server does, so port it before
-> trusting it for a rejoin or self-duel case.
+> trusting it for a rejoin or self-duel case. The **host gate** and **free join** (v1.5)
+> ARE ported to both: the C# client maps 403 `no_host_access` and its fake refuses a
+> non-tier-2 `/invite` (`HostGate` + `SetLabAccess`, off by default) and charges nothing
+> for a join. **Anonymous guests are web-only** by design — the desktop app always has an
+> account and can never take that path.
 
 ## 3. Transport
 - Primary: WebRTC **data channel**, ordered + reliable, one channel, no media tracks.
   ICE via public STUN (Google, Cloudflare). No TURN.
 - ICE not complete within **10 s** → fall back to relay **adopting the same room**
-  (same code + token; the invite/pass is never double-charged).
+  (same code + token; the room is never re-minted and `/join` is never re-issued).
 - Disconnect grace: **5 s** reconnect-with-resume before the wobbly/abandon flow.
 - Known WebRTC portability note: some stacks surface the answering side's channel already
   open (`ondatachannel` fires with `readyState == "open"`); open-handling MUST be
@@ -317,3 +359,14 @@ Everything here is additive: a client without it interoperates unchanged.
   invite-link format (§6, client-side only — no server change, no new endpoint).
   Web client only; the C# client neither sends nor reads `media_prep` and, per §1,
   ignores the frame as an unknown `t`.
+- v1.5 (2026-08-04, host gate + free join): §2 **hosting is tier 2** — `/invite` answers
+  403 `no_host_access` below `computeEffectiveTier >= 2` — and **joining is free for
+  everyone**, including people with no account, who play on a server-minted `g_` guest
+  seat (`guest_id` on the `/join` response, presented as `unified_id` on every later
+  room-scoped call, no `X-Auth-Token`). The weekly free pass and its 402 `no_pass` are
+  retired; clients keep parsing `no_pass` for old-server tolerance. `pass` on `/join`
+  becomes the advisory label `"free" | "rejoin" | "self_duel"`. New host→page `init`
+  cap `caps.canHost` (§2) lets the desktop title screen dim Host before the round-trip;
+  it is NOT a peer-negotiated hello cap and never crosses the wire between players.
+  No wire-version change: every addition is a new response field or a new refusal on an
+  existing route, and §1's unknown-field rules already cover both.


### PR DESCRIPTION
Client mirror of the server gating rework (CCP-Server f6c6188, already live in prod).

- New `PatreonService.HasLabAccess` = tier >= 2 OR whitelist (incl. SubscribeStar tier surface); deliberately excludes the cached-premium grace flag. This is the goon HOST bar, matching server `computeEffectiveTier >= 2`.
- `caps.canHost` into the goon page init; hosted title screen locks the Host item with supporter-perk copy when false. Standalone leaves Host live (entitlement unknowable pre-round-trip).
- Both clients map the new `403 no_host_access`; the legacy `402 no_pass` UI now points at the same supporter sheet for old-server tolerance.
- Standalone anonymous join: `/join` omits `unified_id`, adopts the returned `guest_id` for all room-scoped calls, persists it for seat-reclaim on reload.
- Fake servers (JS + C#) mirror the new contract (opt-in `hostGate`, default OFF so existing lifecycle tests stay entitlement-free); protocol doc v1.5.
- Tests: new selftest-hostgate 95/95; all existing suites unchanged green (avafx 12 fails are pre-existing on main). dotnet build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DDEHEykXLQLzBZFw9Qv7h