### PR TITLE
fix(goon): round 6 - phone play-test fixes (media multi-add, .mov support, relay clock, seat resume)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -409,6 +409,21 @@ function openFirstScreen() {
   let code = '';
   try { code = consumeJoinCode(typeof window !== 'undefined' ? window : null); }
   catch (_e) { code = ''; }
+  /* A LIVE GUEST SEAT SURVIVES THE PAGE THAT CLAIMED IT (2026-08-04 play-test).
+   * iOS routinely kills this page while the player is off in the photo sheet,
+   * and the reload comes back on a BARE url — consumeJoinCode stripped the
+   * ?join on the first visit, so the one person with a seat waiting for them
+   * landed on a menu with no way back but re-finding the link. If prefs hold a
+   * fresh `g_` seat, walk them straight back into the join flow: presenting
+   * the kept id is a server-side seat RECLAIM (pass:"rejoin"), and a room that
+   * died in the meantime fails on the join screen with the code prefilled and
+   * a plain sentence, not a dead end. An EXPLICIT link still wins — the player
+   * asked for THAT room. */
+  if (!code && guestSeat.id && guestSeat.code
+    && guestSeat.at && (Date.now() - guestSeat.at) < GUEST_SEAT_FRESH_MS) {
+    code = guestSeat.code;
+    bridge.log('resuming guest seat in ' + code);
+  }
   if (code) {
     bridge.log('invite link: joining ' + code);
     router.show('join', { autoCode: code });
@@ -552,7 +567,7 @@ function localCaps() {
 /** ext -> mime. The cache serves artifacts by extension; the protocol wants a mime. */
 const ARTIFACT_MIME = {
   png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
-  webp: 'image/webp', mp4: 'video/mp4', webm: 'video/webm',
+  webp: 'image/webp', mp4: 'video/mp4', webm: 'video/webm', mov: 'video/quicktime',
 };
 
 /**
@@ -1465,13 +1480,22 @@ function cancelFoldToTitle() {
 const guestSeat = {
   id: String(bridge.storedPrefs().guestId || ''),
   code: String(bridge.storedPrefs().guestRoom || ''),
+  at: Number(bridge.storedPrefs().guestAt) || 0,
   save(id, code) {
     this.id = String(id || '');
     this.code = String(code || '');
-    try { bridge.savePrefs({ guestId: this.id, guestRoom: this.code }); }
+    // The claim instant bounds the RESUME window (openFirstScreen): a seat is
+    // only worth walking back into while its room can still exist server-side.
+    this.at = this.id ? Date.now() : 0;
+    try { bridge.savePrefs({ guestId: this.id, guestRoom: this.code, guestAt: this.at }); }
     catch (_e) { /* a lost seat costs a rejoin, never the match in progress */ }
   },
+  /** The seat is spent — left on purpose, or its room is confirmed dead. */
+  clear() { this.save('', ''); },
 };
+
+/** How long a remembered guest seat is worth resuming: the room's own match TTL. */
+const GUEST_SEAT_FRESH_MS = 30 * 60 * 1000;
 
 function ensureSession() {
   if (goonSession) return goonSession;
@@ -1505,6 +1529,33 @@ function ensureSession() {
     sheets?.showSignalError?.(errorInfo(reason)).then(() => router.show('title'));
   });
   return goonSession;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE RESUME KICK — iOS's half of the connection story (2026-08-04 play-test).
+ *
+ * A phone in the OS photo sheet, a locked screen, an app switch: Safari clamps
+ * or outright freezes this page's timers, and both network loops (the P2P
+ * signal pump and the relay mailbox loop) park inside a setTimeout that never
+ * fires on schedule. Meanwhile the desktop host reads the silence as the guest
+ * being gone — the play-test host sat on "waiting for your opponent" while the
+ * guest was right there, picking photos. The loops already expose a wake seam
+ * (`nudge()`, used by their own send paths); this just pulls it the moment the
+ * page is visible again, so the first poll happens NOW and not a backoff later.
+ * Registered once, at module scope, like bridge's own listeners — the handler
+ * reads the CURRENT session through the closure, so it survives every rebuild.
+ * -------------------------------------------------------------------------- */
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  const kick = () => {
+    try { if (document.visibilityState === 'hidden') return; } catch (_e) { /* be generous */ }
+    try { goonSession?.transport?.nudge?.(); } catch (_e) { /* a kick is never load-bearing */ }
+  };
+  document.addEventListener('visibilitychange', kick);
+  if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+    window.addEventListener('pageshow', kick);   // bfcache restores skip visibilitychange
+    window.addEventListener('online', kick);     // radio came back before the timer did
+    window.addEventListener('focus', kick);
+  }
 }
 
 /** Merge the machine reason with whatever the signaling client recorded. */
@@ -1573,7 +1624,20 @@ const actions = {
     lastConnectFailed = null;
     let ok = false;
     try { ok = await s.join(inviteCode); } finally { awaitingEntry = false; }
-    if (!ok) return { ok: false, error: errorInfo(lastConnectFailed) };
+    if (!ok) {
+      const err = errorInfo(lastConnectFailed);
+      /* A DEAD ROOM SPENDS THE SEAT. Without this, the resume path
+       * (openFirstScreen) walks every fresh page load straight back into the
+       * same expired code for up to half an hour — an auto-retry loop nobody
+       * asked for, wearing an error screen. Only the seat's OWN room counts,
+       * and only verdicts that mean the room is truly gone. */
+      const kind = err && err.kind;
+      if ((kind === 'expired' || kind === 'unknown_code') && guestSeat.id
+        && String(inviteCode || '').trim().toUpperCase() === guestSeat.code) {
+        guestSeat.clear();
+      }
+      return { ok: false, error: err };
+    }
 
     /* THE FIRST-RUN MEDIA STEP, decided HERE and nowhere else — one join, one
      * answer. A duel plays the player's OWN library at them, so a joiner with an
@@ -1631,6 +1695,8 @@ const actions = {
     if (s) { try { await s.leave(); } catch (e) { logger.warn('leave threw: ' + ((e && e.message) || e)); } }
     else if (currentMatch) { try { currentMatch.cancelMatch('left'); } catch (_e) { /* ignore */ } }
     await teardownEverything();
+    // Walking out is a decision — the resume path must not walk them back in.
+    guestSeat.clear();
     cancelFoldToTitle();      // leaving is an explanation of its own
     router.show('title');
   },

--- a/ConditioningControlPanel/Resources/web/goon/core/clock.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/clock.js
@@ -46,13 +46,23 @@ export class MatchClock {
    * @param {(msg:object)=>any} [o.sendPing] outbound path; may also be supplied later via attach()
    * @param {object} [o.logger] console-shaped
    * @param {number} [o.testSkewMs] TEST ONLY: fake local skew so a loopback pair must actually converge
+   * @param {number} [o.pingTimeoutMs] how long after the burst a pong may still land and count.
+   *   The default fits a data channel. A RELAY transport must pass its own: one mailbox
+   *   round-trip is up to two long-poll holds, so a 3 s window scores every pong as
+   *   unanswered and the sync never converges (2026-08-04 play-test, "0 usable samples"
+   *   every round) — which matters, because the host refuses to propose a start on an
+   *   unsynced clock (core/match.js _tryProposeStart).
+   * @param {number} [o.pingSpacingMs] gap between pings in a burst — same story, relay passes longer.
    */
-  constructor({ isClockMaster = false, tag = 'GoonClock', sendPing = null, logger = null, testSkewMs = 0 } = {}) {
+  constructor({ isClockMaster = false, tag = 'GoonClock', sendPing = null, logger = null, testSkewMs = 0,
+    pingTimeoutMs = PING_TIMEOUT_MS, pingSpacingMs = PING_SPACING_MS } = {}) {
     this._isClockMaster = !!isClockMaster;
     this._tag = tag;
     this._send = sendPing;
     this._log = logger || (typeof console !== 'undefined' ? console : null);
     this._testSkewMs = testSkewMs | 0;
+    this._pingTimeoutMs = Math.max(100, Number(pingTimeoutMs) || PING_TIMEOUT_MS);
+    this._pingSpacingMs = Math.max(10, Number(pingSpacingMs) || PING_SPACING_MS);
 
     this._pending = new Map();      // seq -> local send ms
     this._samples = [];             // {rtt, offset}
@@ -189,11 +199,11 @@ export class MatchClock {
         continue;
       }
 
-      await delay(PING_SPACING_MS);
+      await delay(this._pingSpacingMs);
     }
 
     // Give the last few pongs a chance to land before scoring the burst.
-    const deadline = this.nowLocalMs() + PING_TIMEOUT_MS;
+    const deadline = this.nowLocalMs() + this._pingTimeoutMs;
     while (this.nowLocalMs() < deadline && !this._stopped && !this._disposed) {
       if (this._pending.size === 0) break;
       await delay(50);

--- a/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
@@ -66,13 +66,13 @@ const SHA_RE = /^[0-9a-f]{64}$/;
 /** mime -> the kind exec/media.js speaks. Anything else is not ours to store. */
 const MIME_KIND = Object.freeze({
   'image/png': 'image', 'image/jpeg': 'image', 'image/gif': 'image', 'image/webp': 'image',
-  'video/mp4': 'video', 'video/webm': 'video',
+  'video/mp4': 'video', 'video/webm': 'video', 'video/quicktime': 'video',
 });
 
 /** ext -> mime, for the manifest's `received` rows (which carry both anyway). */
 const EXT_MIME = Object.freeze({
   png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
-  webp: 'image/webp', mp4: 'video/mp4', webm: 'video/webm',
+  webp: 'image/webp', mp4: 'video/mp4', webm: 'video/webm', mov: 'video/quicktime',
 });
 
 export function kindForMime(mime) { return MIME_KIND[String(mime || '').toLowerCase()] || ''; }

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
@@ -79,9 +79,15 @@ export const XFER_TAGS_MAX = 3;
  *  that never finishes, and 50 ms of polling is cheaper than that failure mode. */
 export const PUMP_WATCHDOG_MS = 50;
 
-/** The only media types either side will carry. */
+/** The only media types either side will carry. `video/quicktime` is here for
+ *  the iPhone: EVERY camera capture is a .mov container ("Most Compatible"
+ *  included — that setting only swaps HEVC for H.264 inside the same wrapper),
+ *  so refusing the container refused the whole camera roll (2026-08-04
+ *  play-test). Whether THIS device can actually decode what is inside is a
+ *  separate question the adopter answers with a real probe (ui/assetsStore.js
+ *  probeVideoDecodable), not a string compare. */
 export const ACCEPT_MIME = Object.freeze(new Set([
-  'video/mp4', 'video/webm',
+  'video/mp4', 'video/webm', 'video/quicktime',
   'image/png', 'image/jpeg', 'image/gif', 'image/webp',
 ]));
 

--- a/ConditioningControlPanel/Resources/web/goon/net/relayTransport.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/relayTransport.js
@@ -41,7 +41,20 @@ export class GoonRelayTransport extends GoonTransportBase {
    */
   constructor({ isHost = false, signaling = null, logger = null, displayName = '',
     waitMs = RELAY_WAIT_MS, minGapMs = RELAY_MIN_GAP_MS } = {}) {
-    super({ isHost, tag: isHost ? 'GoonRelay:host' : 'GoonRelay:guest', logger });
+    super({
+      isHost, tag: isHost ? 'GoonRelay:host' : 'GoonRelay:guest', logger,
+      /* THE MAILBOX IS SLOW AND THE CLOCK MUST KNOW (2026-08-04 play-test). A
+       * ping's round trip here is up to two long-poll holds (~8 s each way at
+       * worst), so the data-channel default of a 3 s pong window scored every
+       * relay pong as unanswered — "0 usable samples" forever, and a host that
+       * never proposes a start (core/match.js _tryProposeStart hard-gates on a
+       * synced clock; the Draft tick re-polls it, so converging LATE is fine).
+       * The window covers the worst honest round trip; the extra retries cover
+       * the peer's loop simply not having reached the mailbox yet. */
+      clockPingTimeoutMs: (waitMs || RELAY_WAIT_MS) * 2 + 4000,
+      clockPingSpacingMs: 400,
+      clockSyncRetries: 5,
+    });
 
     this._ownsSignaling = !signaling;
     this._signaling = signaling || new GoonSignalingClient({ logger });
@@ -65,6 +78,15 @@ export class GoonRelayTransport extends GoonTransportBase {
 
   get code() { return this._code; }
   get token() { return this._token; }
+
+  /**
+   * Wake the loop NOW. The one caller that matters is boot's visibility watcher:
+   * a phone that spent a minute in the OS photo sheet (or a locked pocket) comes
+   * back with this loop parked deep in a backoff or a gap timer iOS refused to
+   * run — and every second it stays parked, the peer reads "gone". Idempotent
+   * and safe whenever; a loop mid-request simply ignores it.
+   */
+  nudge() { this._wake(); }
 
   /**
    * Take over a room the WebRTC transport already opened, after ICE gave up. No second /invite or

--- a/ConditioningControlPanel/Resources/web/goon/net/transportBase.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/transportBase.js
@@ -46,8 +46,16 @@ export class GoonTransportBase {
    * @param {object} [o.logger] console-shaped
    * @param {number} [o.clockTestSkewMs] TEST ONLY — fake local skew handed to the MatchClock
    * @param {boolean} [o.autoClockSync] run clock sync automatically on the first connected state
+   * @param {number} [o.clockPingTimeoutMs] pong window handed to the MatchClock — a transport
+   *   that KNOWS it is slow (the relay's mailbox cadence) must widen it or the sync never
+   *   converges and the host never proposes a start (core/clock.js has the full story)
+   * @param {number} [o.clockPingSpacingMs] ping burst spacing, same ownership
+   * @param {number} [o.clockSyncRetries] extra sync attempts after a failed first one. The
+   *   old behavior (one retry) is the default; the relay asks for more, because its early
+   *   attempts routinely race the peer's arrival on the mailbox.
    */
-  constructor({ isHost = false, tag = 'GoonTransport', logger = null, clockTestSkewMs = 0, autoClockSync = true } = {}) {
+  constructor({ isHost = false, tag = 'GoonTransport', logger = null, clockTestSkewMs = 0, autoClockSync = true,
+    clockPingTimeoutMs = 0, clockPingSpacingMs = 0, clockSyncRetries = 1 } = {}) {
     this._isHost = !!isHost;
     this._tag = tag;
     this._log = logger || (typeof console !== 'undefined' ? console : null);
@@ -56,6 +64,7 @@ export class GoonTransportBase {
     this._disposed = false;
     this._autoClockSync = autoClockSync !== false;
     this._clockSyncRunning = false;
+    this._clockSyncRetries = Math.max(0, Number(clockSyncRetries) || 0);
 
     this._messageListeners = new Set();
     this._stateListeners = new Set();
@@ -66,6 +75,8 @@ export class GoonTransportBase {
       tag,
       logger: this._log,
       testSkewMs: clockTestSkewMs,
+      ...(clockPingTimeoutMs > 0 ? { pingTimeoutMs: clockPingTimeoutMs } : {}),
+      ...(clockPingSpacingMs > 0 ? { pingSpacingMs: clockPingSpacingMs } : {}),
     });
     // The clock's pings ride the same guarded send path as everything else.
     this._clock.attach((msg) => this.send(msg));
@@ -213,20 +224,23 @@ export class GoonTransportBase {
   _setLastError(err) { this._lastError = err || null; }
 
   /**
-   * Runs the clock's ping rounds once the channel is usable. Fire-and-forget safe; one retry,
-   * same as GoonTransportBase.BeginClockSync.
+   * Runs the clock's ping rounds once the channel is usable. Fire-and-forget safe. The retry
+   * budget is the transport's (`clockSyncRetries`): one for a data channel, more for the relay
+   * — whose first attempt routinely fires before the peer's loop has even reached the mailbox,
+   * and whose sync failing forever is a match that never leaves Draft.
    */
   _beginClockSync() {
     if (this._disposed || this._clockSyncRunning) return;
     this._clockSyncRunning = true;
     (async () => {
       try {
-        const ok = await this._clock.sync();
-        if (ok) return;
-        this._warn('Initial clock sync did not converge — retrying once');
-        await new Promise((r) => setTimeout(r, 1000));
-        if (this._disposed) return;
-        await this._clock.sync();
+        if (await this._clock.sync()) return;
+        for (let i = 0; i < this._clockSyncRetries; i++) {
+          this._warn(`Initial clock sync did not converge — retry ${i + 1}/${this._clockSyncRetries}`);
+          await new Promise((r) => setTimeout(r, 2000));
+          if (this._disposed || !this.isConnected) return;
+          if (await this._clock.sync()) return;
+        }
       } catch (e) {
         this._error(`Clock sync threw: ${(e && e.message) || e}`);
       } finally {

--- a/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
@@ -117,6 +117,9 @@ export class GoonWebRtcTransport extends GoonTransportBase {
   /** Display name the server reported for the opponent (guest side, from /join). */
   get peerDisplayName() { return this._peerDisplayName; }
 
+  /** Wake the signal pump NOW — see GoonRelayTransport.nudge for who calls this and why. */
+  nudge() { this._wake(); }
+
   // ------------------------------------------------------------------ setup
 
   async createInvite() {

--- a/ConditioningControlPanel/Resources/web/goon/package.json
+++ b/ConditioningControlPanel/Resources/web/goon/package.json
@@ -1,0 +1,4 @@
+{
+  "//": "Every .js under this folder is an ES module. Without this marker Node walks up to ConditioningControlPanel/package.json (type: commonjs, puppeteer tooling) and refuses the selftest suite's imports. Browsers never read this file.",
+  "type": "module"
+}

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
@@ -364,7 +364,8 @@ async function mountVoiceScreen({ prefs, sheets, toasts, notes = null, match = n
   const store = createNoteStore({ prefs, logger: quiet, idb: null });
   const { container, handle } = await mountVoiceScreen({ prefs, sheets, toasts, notes: store });
 
-  ok(!!findOne(container, 'gg-voice'), 'the screen mounts a .gg-voice card');
+  ok(!!findOne(container, 'gg-voicelib'), 'the screen mounts a .gg-voicelib card');
+  ok(!findOne(container, 'gg-voice'), 'and NEVER wears .gg-voice — that is the HUD mic strip, absolute in the corner');
   const row = findOne(container, 'gg-voice-optin');
   ok(!!row, 'with the opt-in row');
   const input = findTag(row, 'input')[0];
@@ -880,13 +881,34 @@ function mountSheet(provider) {
     'and never touches indexedDB above the function that looks it up (node-import-safe)');
 
   const css = read('ui/screens.css');
-  ok(/\.gg-voice \{/.test(css), 'screens.css styles the screen');
+  ok(/\.gg-voicelib \{/.test(css), 'screens.css styles the screen');
   ok(/\.gg-voice-picker \{/.test(css) && /\.gg-voice-emote \{/.test(css), 'and the emote picker');
   ok(/\.gg-voice-note \{[^}]*minmax\(0, 1fr\)/.test(css), 'the note row is written minmax(0,1fr) — phone-safe');
+
+  /* THE COLLISION, and the reason this screen once rendered as a pile in the
+   * top-right corner: ui/hud.css owns `.gg-voice` / `.gg-voice-hint` for the
+   * in-duel mic strip (position:absolute; right:0), and it LOADS AFTER
+   * screens.css — so any name shared between the two files is decided by the
+   * HUD. Not "prefer not to"; the screen has no way to win. */
+  const hudCss = read('ui/hud.css');
+  const classNames = (text) => new Set(
+    Array.from(stripComments(text).matchAll(/\.(gg-voice[a-z0-9-]*)/g), (m) => m[1]),
+  );
+  const hudNames = classNames(hudCss);
+  const shared = Array.from(classNames(css)).filter((c) => hudNames.has(c));
+  ok(shared.length === 0,
+    'no gg-voice* class is styled by BOTH screens.css and hud.css (hud.css loads last and would win)',
+    shared.join(', '));
+  const screenSrc = stripComments(read('ui/screens/voice.js'));
+  for (const name of ['gg-voice', 'gg-voice-hint']) {
+    ok(!new RegExp("['\" ]" + name + "['\" ]").test(screenSrc),
+      'the screen never mounts .' + name + ' — hud.css owns it');
+  }
+
   // THE TRAP: .gg-grad + a `background:` shorthand paints the text transparent.
   // From the first RULE (not the header comment, which discusses the trap by
   // name) to the motion section that follows the block.
-  const voiceBlock = stripComments(css.slice(css.indexOf('.gg-voice {'), css.indexOf('MOTION — the player')));
+  const voiceBlock = stripComments(css.slice(css.indexOf('.gg-voicelib {'), css.indexOf('MOTION — the player')));
   ok(!/gg-grad/.test(voiceBlock), 'and no RULE in the voice block touches .gg-grad');
   ok(/animation-play-state: running/.test(voiceBlock),
     'the recording pulse re-declares `running`, so the effect armor cannot freeze the live-mic tell');

--- a/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
@@ -115,6 +115,7 @@ export const LOCAL_ZIP_MAX_ENTRIES = ZIP_MAX_ENTRIES;
 export const LOCAL_MIME_BY_EXT = Object.freeze({
   png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
   webp: 'image/webp', mp4: 'video/mp4', m4v: 'video/mp4', webm: 'video/webm',
+  mov: 'video/quicktime',
 });
 
 /**
@@ -182,6 +183,54 @@ export function localMimeOf(file) {
   const m = /\.([a-z0-9]{2,5})$/i.exec(String((file && file.name) || ''));
   const byExt = m ? (LOCAL_MIME_BY_EXT[m[1].toLowerCase()] || '') : '';
   return ACCEPT_MIME.has(byExt) ? byExt : '';
+}
+
+/** Metadata that has not arrived by now is a busy device, not a verdict. */
+export const VIDEO_PROBE_TIMEOUT_MS = 4000;
+
+/**
+ * Can THIS device actually decode this video? A real probe — load the blob into
+ * an off-DOM <video> and wait for metadata — because with `video/quicktime` on
+ * the accept list a string compare stops being an answer: the container says
+ * nothing about whether the codec inside (HEVC, mostly, on an iPhone) has a
+ * decoder here. `false` only on the element's own error/zero-size verdict;
+ * anything ambiguous (no DOM under node, createObjectURL refused, the timeout)
+ * answers `true`, because a wrongly-refused good clip is this feature's
+ * founding bug and a wrongly-adopted bad one just plays black for its slot.
+ *
+ * KNOWN GAP, on purpose: the probe is LOCAL. Safari happily decodes its own
+ * HEVC and will still ship it to a Windows peer that may not — a
+ * peer-capability handshake is the real fix and is out of scope here.
+ */
+export function probeVideoDecodable(blob) {
+  if (typeof document === 'undefined' || typeof URL === 'undefined'
+    || typeof URL.createObjectURL !== 'function') return Promise.resolve(true);
+  let url = '';
+  try { url = URL.createObjectURL(blob); } catch (_e) { return Promise.resolve(true); }
+  return new Promise((resolve) => {
+    let v = null;
+    let timer = 0;
+    let done = false;
+    const finish = (ok) => {
+      if (done) return;
+      done = true;
+      try { clearTimeout(timer); } catch (_e) { /* ignore */ }
+      // Detach before revoking, or Safari keeps the decode session alive.
+      try { if (v) { v.removeAttribute('src'); v.load(); } } catch (_e) { /* ignore */ }
+      try { URL.revokeObjectURL(url); } catch (_e) { /* ignore */ }
+      v = null;
+      resolve(ok);
+    };
+    timer = setTimeout(() => finish(true), VIDEO_PROBE_TIMEOUT_MS);
+    try {
+      v = document.createElement('video');
+      v.preload = 'metadata';
+      v.muted = true;
+      v.onloadedmetadata = () => finish((v.videoWidth | 0) > 0);
+      v.onerror = () => finish(false);
+      v.src = url;
+    } catch (_e) { finish(true); }
+  });
 }
 
 /* -------------------------------------------------------- pure helpers
@@ -1157,13 +1206,14 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    *
    * THE POLICY, in the order it is applied:
    *   1. not a mime the wire carries        -> badType
-   *   2. ≤ 8 MB                             -> EXEMPT, as-is, untouched
-   *   3. video 8..64 MB                     -> non-exempt artifact, as-is (no transcode)
-   *   4. video > 64 MB                      -> tooBigVideo (its own sentence)
-   *   5. still/animated > 80 MB source      -> tooBig (we will not decode that)
-   *   6. animated gif/awebp > 8 MB          -> mp4 artifact, via lane B's worker
-   *   7. still > 8 MB                       -> WebP (or JPEG) artifact
-   *   8. any compressed output > 64 MB      -> failed (pathological; nothing to send)
+   *   2. video this device cannot decode    -> badCodec (probeVideoDecodable)
+   *   3. ≤ 8 MB                             -> EXEMPT, as-is, untouched
+   *   4. video 8..64 MB                     -> non-exempt artifact, as-is (no transcode)
+   *   5. video > 64 MB                      -> tooBigVideo (its own sentence)
+   *   6. still/animated > 80 MB source      -> tooBig (we will not decode that)
+   *   7. animated gif/awebp > 8 MB          -> mp4 artifact, via lane B's worker
+   *   8. still > 8 MB                       -> WebP (or JPEG) artifact
+   *   9. any compressed output > 64 MB      -> failed (pathological; nothing to send)
    */
   async function adoptLocalFile(f, report) {
     if (!f || typeof f.arrayBuffer !== 'function') { report.failed++; return; }
@@ -1177,6 +1227,13 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
 
   /** The original travels untouched. This is the path that has always existed. */
   async function adoptExempt(f, mime, bytes, report) {
+    // The probe sits BEFORE the hash: refusing after paying for the sha would
+    // only make the refusal slower. Images skip it — decode failures there
+    // surface in the compressor lanes that already own them.
+    if (kindForMime(mime) === 'video' && !(await probeVideoDecodable(f))) {
+      report.badCodec++; return;
+    }
+    if (disposed) return;
     let sha = '';
     try {
       sha = await shaOfBytes(await f.arrayBuffer());
@@ -1217,6 +1274,8 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
      * COUNTED AND NAMED rather than quietly dropped. */
     if (kindForMime(mime) === 'video') {
       if (bytes > LOCAL_ARTIFACT_MAX_BYTES) { report.tooBigVideo++; return; }
+      if (!(await probeVideoDecodable(f))) { report.badCodec++; return; }
+      if (disposed) return;
       let buf = null;
       try { buf = await f.arrayBuffer(); } catch (e) {
         warn('could not read "' + name + '": ' + ((e && e.message) || e));
@@ -1417,6 +1476,11 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     report.tooBig += res.tooBig;
     report.tooBigVideo += res.tooBigVideo || 0;
     report.failed += res.failed;
+    // Entries the mime table refused are NAMED, not vanished: a zip of nothing
+    // but foreign formats used to read "no media in that zip", which renders as
+    // a broken button to the person who just watched their library go in.
+    // `ineligible`, not `skipped` — junk sidecars and nested zips stay silent.
+    report.badType += res.ineligible || 0;
     // NOT `failed`: entry 501, or the inflated-total backstop, means we TOOK THE
     // FIRST N of a real library. Rendering that as "unreadable" is the same
     // class of lie the per-file cap text was on an archive failure.
@@ -1441,13 +1505,13 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    *
    * @param {ArrayLike<File>} files
    * @returns {Promise<{added:number, compressed:number, dupes:number, tooBig:number,
-   *   tooBigVideo:number, trimmed:number, badType:number, failed:number,
-   *   zips:number, zipBad:number}>}
+   *   tooBigVideo:number, trimmed:number, badType:number, badCodec:number,
+   *   failed:number, zips:number, zipBad:number}>}
    */
   async function addLocalFiles(files) {
     const report = {
       added: 0, compressed: 0, dupes: 0, tooBig: 0, tooBigVideo: 0, trimmed: 0,
-      badType: 0, failed: 0, zips: 0, zipBad: 0,
+      badType: 0, badCodec: 0, failed: 0, zips: 0, zipBad: 0,
     };
     const list = Array.from(files || []);
     // Re-entrant adds (the player picks again while a zip is still expanding)

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -1329,8 +1329,15 @@ html[data-gg-motion="reduced"] .gg-vs-splash * { transition: none !important; }
  *     transition, so the pulse goes on its ::before dot, which is its own box.
  *   · minmax(0, 1fr) / min-width: 0 on every grid child — a long note name must
  *     wrap, never widen the row past the viewport on a phone.
+ *   · THE NAMESPACE IS SHARED WITH THE HUD, AND THE HUD WINS. ui/hud.css loads
+ *     after this file and already owns `.gg-voice` and `.gg-voice-hint` for the
+ *     in-duel mic strip — both `position: absolute; right: 0`. The card is
+ *     therefore `.gg-voicelib` and the footer caption `.gg-voice-foot-hint`;
+ *     naming either one after the HUD's classes throws the whole screen into
+ *     the top-right corner as a 22rem flex row. Check hud.css before adding a
+ *     `gg-voice-*` name here (selftest-voice-ui.js pins that no name is shared).
  * ------------------------------------------------------------------------ */
-.gg-voice { min-width: min(38rem, 96vw); max-width: min(38rem, 96vw); text-align: left; }
+.gg-voicelib { min-width: min(38rem, 96vw); max-width: min(38rem, 96vw); text-align: left; }
 .gg-voice-head { text-align: center; }
 
 .gg-voice-consent { margin-bottom: 0.9rem; }
@@ -1419,7 +1426,7 @@ html[data-gg-motion="reduced"] .gg-vs-splash * { transition: none !important; }
 }
 
 .gg-voice-foot { margin-top: 1.1rem; border-top: 1px solid rgba(255, 255, 255, 0.08); padding-top: 0.8rem; }
-.gg-voice-hint { margin: 0; font-size: 0.72rem; color: var(--gg-text-4); line-height: 1.6; }
+.gg-voice-foot-hint { margin: 0; font-size: 0.72rem; color: var(--gg-text-4); line-height: 1.6; }
 .gg-voice-foot-actions { display: flex; justify-content: center; gap: 0.6rem; margin-top: 0.9rem; }
 
 /* The second paragraph of the acknowledgment sheet (injected next to the first
@@ -1456,7 +1463,7 @@ html[data-gg-motion="reduced"] .gg-draft.is-sealed::after { display: none; }
   .gg-count-names { top: 8%; padding: 0 1rem; }
   .gg-plrow--out { flex-direction: row; text-align: left; }
   .gg-assets { min-width: 0; max-width: 96vw; }
-  .gg-voice { min-width: 0; max-width: 96vw; }
+  .gg-voicelib { min-width: 0; max-width: 96vw; }
   /* One column on a phone: the acts row drops under the name instead of
      squeezing it, and every child is min-width:0 so nothing can widen the page. */
   .gg-voice-note { grid-template-columns: minmax(0, 1fr); }

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/assets.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/assets.js
@@ -36,8 +36,8 @@ import {
 /** What the picker offers the OS file sheet — mirror of the wire's allowlist,
  * plus .zip: a phone cannot hand over a folder, so an archive is the only way
  * a player on a phone gives us a whole library (assetsStore expands it). */
-const LOCAL_ACCEPT = '.png,.jpg,.jpeg,.gif,.webp,.mp4,.m4v,.webm,.zip,'
-  + 'image/png,image/jpeg,image/gif,image/webp,video/mp4,video/webm,'
+const LOCAL_ACCEPT = '.png,.jpg,.jpeg,.gif,.webp,.mp4,.m4v,.webm,.mov,.zip,'
+  + 'image/png,image/jpeg,image/gif,image/webp,video/mp4,video/webm,video/quicktime,'
   + 'application/zip,application/x-zip-compressed';
 
 /** Hard ceiling on simultaneously playing micro-previews. */
@@ -648,6 +648,7 @@ function localMediaCard({ store, ledger, audio, actions, logger }) {
       // ARTIFACT cap in its own sentence rather than the exempt one.
       if (r.tooBigVideo) bits.push(L.skipBigVideo(r.tooBigVideo, artMaxText));
       if (r.badType) bits.push(L.skipType(r.badType));
+      if (r.badCodec) bits.push(L.skipCodec(r.badCodec));
       if (r.failed) bits.push(L.skipFailed(r.failed));
       // "Took the first 500" is not a failure and must never read as one.
       if (r.trimmed) bits.push(L.trimmed(r.trimmed, LOCAL_ZIP_MAX_ENTRIES));

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/host.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/host.js
@@ -159,6 +159,17 @@ export function mount(container, ctx) {
 
   function tickExpiry() {
     if (!code) return;
+    /* THE TTL SLIDES NOW, ON BOTH SIDES. The server re-arms the lobby's five
+     * minutes on every host poll (2026-08-04 — a host who waited six minutes
+     * for a friend watched the code die mid-wait), and the poll runs exactly
+     * as long as this page is visible and its session alive. So a VISIBLE
+     * screen slides its own countdown in step: past the halfway mark the bar
+     * is pushed back to full, and the only way it ever runs out is the page
+     * being hidden or dead — the same conditions under which the server-side
+     * room is genuinely burning down. */
+    let vis = true;
+    try { vis = typeof document === 'undefined' || document.visibilityState !== 'hidden'; } catch (_e) { /* assume visible */ }
+    if (vis && expiresAt - Date.now() < EXPIRY_MS / 2) expiresAt = Date.now() + EXPIRY_MS;
     const left = expiresAt - Date.now();
     const frac = Math.max(0, Math.min(1, left / EXPIRY_MS));
     const fill = expiryBar.firstChild;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/mediaSetup.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/mediaSetup.js
@@ -31,6 +31,15 @@
  * images plus a few clips is what makes a match feel like a match, and the copy
  * says so, but a hard gate on a stranger's first thirty seconds is how you lose
  * the player instead of the match.
+ *
+ * …AND ADDING MORE IS THE DEFAULT, not the fine print (owner play-test,
+ * 2026-08-04). A phone's photo sheet is one-shot per visit: pick from one
+ * album, confirm, back here. The first cut of this screen left "I'm set" as
+ * the only primary action after that first batch, and people took it — into a
+ * duel armed with six photos from one folder. So after anything lands the ADD
+ * button is the primary one and says "add more", the lock wears the exact
+ * count it would commit, and NOTHING advances this screen except that lock
+ * (or Leave): not a batch finishing, not the tally clearing the suggestion.
  * ==========================================================================*/
 
 import { createLedger, el, button } from '../router.js';
@@ -47,8 +56,8 @@ export const SUGGESTED_ITEMS = 20;
  * the two lists are the same list, and a divergence would mean the onboarding
  * step accepted a file the library screen would refuse.
  */
-export const LOCAL_ACCEPT = '.png,.jpg,.jpeg,.gif,.webp,.mp4,.m4v,.webm,.zip,'
-  + 'image/png,image/jpeg,image/gif,image/webp,video/mp4,video/webm,'
+export const LOCAL_ACCEPT = '.png,.jpg,.jpeg,.gif,.webp,.mp4,.m4v,.webm,.mov,.zip,'
+  + 'image/png,image/jpeg,image/gif,image/webp,video/mp4,video/webm,video/quicktime,'
   + 'application/zip,application/x-zip-compressed';
 
 /**
@@ -128,6 +137,8 @@ export function mount(container, ctx) {
   const lockBtn = button(ledger, L.lock, () => lockIn(), { variant: 'primary', audio, sfx: 'lamp-confirm' });
   lockBtn.disabled = true;
   lockBtn.title = L.lockNeed;
+  /** A batch mid-decode: the lock waits for it. Painted by the progress sub. */
+  let adding = false;
   const leaveBtn = button(ledger, L.leave, () => { void actions?.leave?.('media-setup'); },
     { variant: 'ghost', audio, sfx: 'ui-back' });
 
@@ -197,13 +208,25 @@ export function mount(container, ctx) {
     tally.textContent = n ? L.count(n) : L.countNone;
     tallyNote.textContent = n >= SUGGESTED_ITEMS ? L.enough : L.suggest(SUGGESTED_ITEMS);
 
-    // ONE item unlocks it. The suggestion above is a suggestion (see header).
-    lockBtn.disabled = n < 1;
-    lockBtn.title = n < 1 ? L.lockNeed : '';
+    /* THE ROLES SWAP once something is in (see header): adding more becomes the
+     * primary move and says so, locking becomes the explicit commitment wearing
+     * its count. Classes, not new buttons — the ledger already owns these. */
+    addBtn.textContent = n ? L.addMore : L.add;
+    lockBtn.classList.toggle('gg-btn--primary', n > 0);
+    lockBtn.textContent = n ? L.lockN(n) : L.lock;
+
+    // ONE item unlocks it. The suggestion above is a suggestion (see header) —
+    // but never mid-batch: locking in "6 picks" while a zip is still unpacking
+    // its other two hundred is a commitment nobody meant to make.
+    lockBtn.disabled = n < 1 || adding;
+    lockBtn.title = adding ? L.lockBusy : (n < 1 ? L.lockNeed : '');
   }
 
   if (store && typeof store.onLocalProgress === 'function') {
     ledger.sub(store.onLocalProgress((p) => {
+      const wasAdding = adding;
+      adding = !!(p && p.running);
+      if (adding !== wasAdding) paint();
       if (!p || !p.running) { progress.hidden = true; progress.textContent = ''; return; }
       progress.hidden = false;
       if (p.pct > 0 && p.name) progress.textContent = AL.compressing(p.name, p.pct);
@@ -231,6 +254,7 @@ export function mount(container, ctx) {
       if (r.tooBig) bits.push(AL.skipBig(r.tooBig, maxText));
       if (r.tooBigVideo) bits.push(AL.skipBigVideo(r.tooBigVideo, artMaxText));
       if (r.badType) bits.push(AL.skipType(r.badType));
+      if (r.badCodec) bits.push(AL.skipCodec(r.badCodec));
       if (r.failed) bits.push(AL.skipFailed(r.failed));
       if (r.trimmed) bits.push(AL.trimmed(r.trimmed, LOCAL_ZIP_MAX_ENTRIES));
       if (r.zipBad) bits.push(AL.zipBad(r.zipBad));

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
@@ -163,11 +163,17 @@ export function mount(container, ctx) {
   /* ---- footer ------------------------------------------------------------ */
   const backBtn = button(ledger, S.voice.back, () => { actions?.goTitle?.(); }, { variant: 'ghost', audio, sfx: 'ui-back' });
   const footer = el('div', { class: 'gg-voice-foot' }, [
-    el('p', { class: 'gg-voice-hint', text: S.voice.volumeHint }),
+    el('p', { class: 'gg-voice-foot-hint', text: S.voice.volumeHint }),
     el('div', { class: 'gg-voice-foot-actions' }, [backBtn]),
   ]);
 
-  container.appendChild(el('div', { class: 'gg-card gg-voice' }, [
+  /* THE CARD IS `gg-voicelib`, NOT `gg-voice`. ui/voice/micHud.js already owns
+   * `.gg-voice` (and `.gg-voice-hint`) for the in-duel mic strip, and ui/hud.css
+   * loads AFTER ui/screens.css — so a card wearing that name inherited
+   * `position:absolute; right:0; top:0; height:48px; display:flex` and rendered
+   * as a 22rem pile in the top-right corner of an empty page. Every other class
+   * on this screen is `gg-voice-*` and unique; these two are the HUD's. */
+  container.appendChild(el('div', { class: 'gg-card gg-voicelib' }, [
     head,
     el('div', { class: 'gg-consent gg-voice-consent' }, [optRow, optSub]),
     recRow, recNote,

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -534,14 +534,21 @@ export const S = Object.freeze({
       headline: 'add media to send',
       line: 'pick files from this device and they can travel to your opponent mid-duel, straight from you to them. nothing is uploaded anywhere.',
       add: 'add files',
-      limits: (max, vmax) => 'jpg, png, gif, webp, mp4, webm · or a zip of them · up to ' + max
+      limits: (max, vmax) => 'jpg, png, gif, webp, mp4, webm, mov · or a zip of them · up to ' + max
         + ' travels as-is, bigger photos and gifs are compressed to fit, clips up to ' + vmax,
       empty: 'nothing added yet.',
       note: 'your picks last until this page closes — add them again next visit.',
       remove: 'remove',
       skipDupe: (n) => n + ' already added',
       skipBig: (n, max) => n + ' over ' + max,
-      skipType: (n) => n + ' of an unsupported type',
+      skipType: (n) => n + ' of a format we can\'t carry (jpg, png, gif, webp, mp4, webm and mov travel)',
+      /**
+       * The container was welcome but THIS device has no decoder for what is
+       * inside — iPhone HEVC on an older browser, mostly. Distinct from
+       * skipType on purpose: "wrong format" tells the player to convert,
+       * "can't decode" tells them nothing they did is wrong.
+       */
+      skipCodec: (n) => n + (n === 1 ? ' clip' : ' clips') + ' this device can\'t decode — a re-save as mp4 usually fixes it',
       skipFailed: (n) => n + ' unreadable',
       added: (n) => n + ' added',
       /**
@@ -677,6 +684,13 @@ export const S = Object.freeze({
     discordLine: 'no stash yet? plenty of girls share their packs on the discord.',
     discordCta: 'open the discord',
     add: 'add media',
+    /**
+     * The button once SOMETHING is in: the phone's photo sheet is one-shot per
+     * visit, so "add more" is the whole answer to "…but that was only one
+     * album" (2026-08-04 play-test — the first small batch read as the end of
+     * the road and the primary button below whisked people into the room).
+     */
+    addMore: 'add more · another album, a zip…',
     /** The running tally. Reassuring at 3, congratulatory at 20 — see `enough`. */
     count: (n) => n + (n === 1 ? ' item added' : ' items added'),
     countNone: 'nothing added yet.',
@@ -686,7 +700,10 @@ export const S = Object.freeze({
     enough: 'that will do nicely.',
     remove: 'remove',
     lock: "I'm set",
+    /** The commitment, wearing its own number — nobody locks in "3 picks" thinking they added an album. */
+    lockN: (n) => "I'm set — lock in " + n + (n === 1 ? ' pick' : ' picks'),
     lockNeed: 'add at least one thing',
+    lockBusy: 'still adding…',
     /** The opponent is watching a "picking their media" line while this is up. */
     waiting: 'they know you are still picking. take your time.',
     note: 'your picks stay on this device and travel nowhere unless you switch sending on in the lobby.',

--- a/ConditioningControlPanel/Resources/web/goon/ui/zipReader.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/zipReader.js
@@ -375,7 +375,11 @@ async function readEntryBytes(blob, w, flate) {
  *   assetsStore streams; the tests read the array.
  * @returns {Promise<{ok:boolean, reason:string, entries:Array<{name:string, bytes:Uint8Array}>,
  *   tooBig:number, tooBigVideo:number, failed:number, trimmed:number, skipped:number,
- *   truncated:boolean}>}
+ *   ineligible:number, truncated:boolean}>}
+ *   `ineligible` is the slice of `skipped` that was REAL media of a format the
+ *   mime table refuses (a zip of .avi files) — junk sidecars and nested zips
+ *   stay in `skipped` alone, so the caller can name refused formats without
+ *   accusing a .DS_Store of being one.
  *   `reason` on failure is one of: 'not-a-zip' | 'unreadable' | 'zip64' | 'no-zip-lib'.
  *   `trimmed` is the count the CEILINGS left behind — a legitimate library that
  *   ran past 500 entries or the inflated total. It is deliberately not `failed`:
@@ -384,7 +388,8 @@ async function readEntryBytes(blob, w, flate) {
 export async function readZipMedia(src, o = {}) {
   const out = {
     ok: false, reason: '', entries: [], took: 0,
-    tooBig: 0, tooBigVideo: 0, failed: 0, trimmed: 0, skipped: 0, truncated: false,
+    tooBig: 0, tooBigVideo: 0, failed: 0, trimmed: 0, skipped: 0, ineligible: 0,
+    truncated: false,
   };
   const eligible = typeof o.isEligible === 'function' ? o.isEligible : () => true;
   const classify = typeof o.classify === 'function' ? o.classify : null;
@@ -425,7 +430,7 @@ export async function readZipMedia(src, o = {}) {
     const name = String(rec.name || '');
     if (isJunkEntry(name)) { out.skipped++; continue; }
     if (isZipName(name)) { out.skipped++; continue; }             // no recursion, ever
-    if (!eligible(baseName(name))) { out.skipped++; continue; }
+    if (!eligible(baseName(name))) { out.skipped++; out.ineligible++; continue; }
     if (rec.flags & 0x0001) { out.failed++; continue; }           // encrypted — unreadable, honestly
     const size = Math.max(0, Number(rec.oSize) || 0);
     if (!size) { out.tooBig++; continue; }

--- a/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
+++ b/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
@@ -80,6 +80,11 @@ namespace ConditioningControlPanel.Services.GoonGame
             ["image/webp"] = "webp",
             ["video/mp4"] = "mp4",
             ["video/webm"] = "webm",
+            // iPhone camera captures are QuickTime containers whatever the codec
+            // ("Most Compatible" only swaps HEVC for H.264 inside the same
+            // wrapper). Same ISO-BMFF sniff family as mp4 — the "qt  " brand
+            // below is what actually admits them.
+            ["video/quicktime"] = "mp4",
         };
 
         /// <summary>format id -&gt; the extension the file gets. SNIFFED, never claimed.</summary>
@@ -98,6 +103,7 @@ namespace ConditioningControlPanel.Services.GoonGame
         private static readonly HashSet<string> Mp4Brands = new(StringComparer.Ordinal)
         {
             "isom", "mp42", "avc1", "iso2", "mp41", "M4V ", "dash", "msnv", "iso4", "iso5", "iso6", "mp71",
+            "qt  ",     // QuickTime — every iPhone camera capture
         };
 
         private readonly object _lock = new();


### PR DESCRIPTION
Fixes the four breaks from tonight's desktop-host + iPhone-guest play-test:

- **Media setup multi-add**: the phone photo sheet is one-shot per visit, so the screen now loops on adding ('add more' primary, lock button carries the exact pick count, disabled mid-batch). Nothing advances the screen but the lock or Leave.
- **iPhone videos rejected**: every iPhone camera capture is a .mov/QuickTime container; the allowlist refused them before any decode logic ran. Accepted end to end now (picker, ext map, wire ACCEPT_MIME, received store, C# TransferInboxStore + 'qt  ' brand), with a real decodability probe at adoption and honest refusal copy ('format we can't carry' vs 'this device can't decode'). Zips of refused formats say so instead of 'no media in that zip'.
- **Relay clock sync never converged** ('0 usable samples' every round in the logs) which silently blocks the host from proposing a start. Clock window/spacing are now transport-owned; the relay sizes them to its long-poll cadence and retries; late convergence un-stalls Draft automatically.
- **iOS lifecycle**: visibility/pageshow/online/focus now kick both network loops immediately after Safari froze them (the 'host sat on waiting for your opponent' failure), and a killed page resumes its anonymous guest seat on the next bare-url load (server-side seat reclaim; leaving clears it; a dead room spends it).
- **Host screen countdown** slides in step with the server's new sliding empty-lobby TTL (CCP-Server `3e3db5f`).

All 9 goon selftests green (2,718 checks); `dotnet build` clean. Server half deployed separately from CCP-Server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAgZYfCffPA4vHvWDVAxQ