### PR TITLE
fix(fyp): ghost mode survives Show Desktop + mirror covers the whole monitor

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
+++ b/ConditioningControlPanel/Chaos/ChaosWebViewHost.cs
@@ -339,11 +339,30 @@ internal sealed class ChaosWebViewHost : IDisposable
     private void RefreshNativeOwner()
     {
         if (!_glueAttached) return;
+        if (_glueSuspended) { ApplyNativeOwner(false); return; }
         bool ownerDown = _glueOwner == null || _glueOwner.WindowState == WindowState.Minimized;
         ApplyNativeOwner(!ownerDown);
         // Main is minimized: nothing can bury us, so the link buys nothing and the cascade would
         // only take us down with it. Make sure we survived it.
         if (ownerDown) EnsureNativeVisible();
+    }
+
+    private bool _glueSuspended;
+
+    /// <summary>Sever the owner link for as long as the caller needs the window to be immune to
+    /// the OWNER's window-state changes, then re-apply it. Built for the For You ghost mode:
+    /// while the feed window is parked off the virtual desktop, the link buys nothing (z-order
+    /// is meaningless off-screen) and is the one path Show Desktop / Win+D still reaches the
+    /// parked window through - minimizing the OWNER makes USER32 hide its owned windows, a
+    /// hidden source stops being composed, and the DWM mirror freezes on its last frame.
+    /// While suspended, main's StateChanged keeps firing RefreshNativeOwner - the guard there
+    /// keeps the link severed until resume.</summary>
+    public void SuspendMainWindowGlue(bool suspend)
+    {
+        _glueSuspended = suspend;
+        if (!_glueAttached) return;
+        if (suspend) ApplyNativeOwner(false);
+        else RefreshNativeOwner();
     }
 
     private void ApplyNativeOwner(bool owned)

--- a/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
@@ -133,6 +133,17 @@ internal sealed class FypGhostOverlay
         UpdateThumbnailBounds();
     }
 
+    /// <summary>Drop the registration and register a fresh thumbnail on the same source. The
+    /// host calls this after healing a minimize of the parked window (Show Desktop reaches it
+    /// too): DWM freezes a minimized source's thumbnail on its last frame and does not reliably
+    /// resume the OLD registration once the window is restored off-screen.</summary>
+    public void RefreshThumbnail()
+    {
+        if (_closed) return;
+        Unregister();
+        EnsureThumbnail();
+    }
+
     /// <summary>Drop the thumbnail and close the mirror and its buttons. Idempotent.</summary>
     public void Close()
     {

--- a/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypGhostOverlay.cs
@@ -193,8 +193,13 @@ internal sealed class FypGhostOverlay
     }
 
     /// <summary>Point the thumbnail at our client area (physical px throughout — WinForms and
-    /// rcDestination agree, no DIP math). Letterbox: scale the source's client rect to fit,
-    /// centered; a stretched mirror would distort the moment the aspects differ.</summary>
+    /// rcDestination agree, no DIP math). COVER, not letterbox: the destination is always the
+    /// whole monitor, and an aspect mismatch is resolved by cropping the SOURCE symmetrically
+    /// (rcSource) instead of shrinking the picture. Letterboxing left a bare band across the
+    /// top of the ghost whenever the source's client was even slightly wider-aspect than the
+    /// monitor — and it always is: SetWindowPos clamps a bordered window to the max track size,
+    /// so "client == monitor" cannot be guaranteed. A few cropped rows are invisible; a bare
+    /// desktop stripe is not.</summary>
     private void UpdateThumbnailBounds()
     {
         try
@@ -203,27 +208,37 @@ internal sealed class FypGhostOverlay
             int destW = Math.Max(1, _form.ClientSize.Width);
             int destH = Math.Max(1, _form.ClientSize.Height);
 
-            int x0 = 0, y0 = 0, x1 = destW, y1 = destH;
-            if (GetClientRect(_sourceHwnd, out var src) && src.Right > 0 && src.Bottom > 0)
-            {
-                double scale = Math.Min((double)destW / src.Right, (double)destH / src.Bottom);
-                int fitW = Math.Max(1, (int)Math.Round(src.Right * scale));
-                int fitH = Math.Max(1, (int)Math.Round(src.Bottom * scale));
-                x0 = (destW - fitW) / 2; y0 = (destH - fitH) / 2;
-                x1 = x0 + fitW; y1 = y0 + fitH;
-            }
-
             var props = new DWM_THUMBNAIL_PROPERTIES
             {
                 dwFlags = DWM_TNP_RECTDESTINATION | DWM_TNP_VISIBLE
                           | DWM_TNP_SOURCECLIENTAREAONLY | DWM_TNP_OPACITY,
-                rcDestination = new RECT { Left = x0, Top = y0, Right = x1, Bottom = y1 },
+                rcDestination = new RECT { Left = 0, Top = 0, Right = destW, Bottom = destH },
                 // The user's translucency — with the surface keyed away, DWM blends the
                 // thumbnail against the desktop at exactly this alpha (pixel-verified).
                 opacity = (byte)Math.Round(Math.Clamp(_opacity, OpacityMin, 1.0) * 255.0),
                 fVisible = true,
                 fSourceClientAreaOnly = true,   // clip the source's title bar / border away
             };
+
+            if (GetClientRect(_sourceHwnd, out var src) && src.Right > 0 && src.Bottom > 0)
+            {
+                double destAspect = (double)destW / destH;
+                double srcAspect = (double)src.Right / src.Bottom;
+                int sx0 = 0, sy0 = 0, sx1 = src.Right, sy1 = src.Bottom;
+                if (srcAspect > destAspect)
+                {
+                    int w = Math.Max(1, (int)Math.Round(src.Bottom * destAspect));
+                    sx0 = (src.Right - w) / 2; sx1 = sx0 + w;
+                }
+                else if (srcAspect < destAspect)
+                {
+                    int h = Math.Max(1, (int)Math.Round(src.Right / destAspect));
+                    sy0 = (src.Bottom - h) / 2; sy1 = sy0 + h;
+                }
+                props.dwFlags |= DWM_TNP_RECTSOURCE;
+                props.rcSource = new RECT { Left = sx0, Top = sy0, Right = sx1, Bottom = sy1 };
+            }
+
             DwmUpdateThumbnailProperties(_thumb, ref props);
         }
         catch (Exception ex) { App.Logger?.Debug("FypGhostOverlay.UpdateThumbnailBounds: {E}", ex.Message); }
@@ -369,6 +384,7 @@ internal sealed class FypGhostOverlay
     private const uint COLOR_KEY = 0x00010101;   // COLORREF for RGB(1,1,1) — must match BackColor
 
     private const int DWM_TNP_RECTDESTINATION = 0x00000001;
+    private const int DWM_TNP_RECTSOURCE = 0x00000002;
     private const int DWM_TNP_OPACITY = 0x00000004;
     private const int DWM_TNP_VISIBLE = 0x00000008;
     private const int DWM_TNP_SOURCECLIENTAREAONLY = 0x00000010;

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -403,23 +403,32 @@ internal static class FypHostService
             SetWindowPos(hwnd, IntPtr.Zero, _parkX, _parkY, _parkW, _parkH,
                 SWP_NOZORDER | SWP_NOACTIVATE);
 
-            // Show Desktop / Win+D minimizes every restorable top-level window — the parked
-            // source included — and a minimized source stops being composed: the mirror freezes
-            // on its last frame, and the minimize scrambles the window's saved restore rect so
-            // every LATER ghost cycle comes up frozen too (play-tested 2026-08-04). Two layers:
-            // veto SC_MINIMIZE while ghosted (the window is off-screen, minimizing it means
-            // nothing), and if a minimize lands anyway (raw ShowWindow skips WM_SYSCOMMAND),
-            // heal it — restore, re-park, re-register the thumbnail.
+            // Sever the MainWindow owner link for the duration. Off-screen, the z-order glue
+            // buys nothing — and it is the one path Show Desktop / Win+D still reaches the
+            // parked window through: minimizing the OWNER makes USER32 hide its owned windows,
+            // a hidden source stops being composed (WindowState/IsIconic never change, so no
+            // state event fires), and the mirror freezes on its last frame. A probe of this
+            // exact park + mirror + browser-flags configuration WITHOUT an owner link sailed
+            // through Show Desktop live (2026-08-04).
+            _host?.SuspendMainWindowGlue(true);
+
+            // Show Desktop / Win+D also minimizes every restorable top-level window — the
+            // parked source included. Veto SC_MINIMIZE while ghosted (the window is off-screen,
+            // minimizing it means nothing), veto the owner-cascade hide, and if a minimize or a
+            // hide lands anyway, heal it — restore, re-park, re-register the thumbnail.
             _ghostHookSource = HwndSource.FromHwnd(hwnd);
             _ghostHook = GhostWndProc;
             _ghostHookSource?.AddHook(_ghostHook);
             _ghostStateGuard = OnGhostWindowStateChanged;
             win.StateChanged += _ghostStateGuard;
+            StartGhostDiagnostics(hwnd);
 
             _ghost.Show();
+            GetWindowRect(hwnd, out var applied);
             App.Logger?.Information(
-                "FypHostService: ghost mode ON (mirror on {Mon}, real window parked at {X}x{Y} {W}x{H}px)",
-                scr, _parkX, _parkY, _parkW, _parkH);
+                "FypHostService: ghost mode ON (mirror on {Mon}, park requested {X}x{Y} {W}x{H}px, applied {AW}x{AH}px)",
+                scr, _parkX, _parkY, _parkW, _parkH,
+                applied.Right - applied.Left, applied.Bottom - applied.Top);
         }
         catch (Exception ex)
         {
@@ -474,6 +483,7 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost close: {E}", ex.Message); }
         try
         {
+            StopGhostDiagnostics();
             if (win != null && _ghostStateGuard != null) win.StateChanged -= _ghostStateGuard;
             _ghostStateGuard = null;
             if (_ghostHookSource != null && _ghostHook != null) _ghostHookSource.RemoveHook(_ghostHook);
@@ -499,6 +509,9 @@ internal static class FypHostService
             }
         }
         catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost restore: {E}", ex.Message); }
+        // Window is back on-screen: give it its owner link (and its z-order slot) back.
+        try { _host?.SuspendMainWindowGlue(false); }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost glue resume: {E}", ex.Message); }
         _ghostWasMaximized = false;
         _lastGhostExitUtc = DateTime.UtcNow;
         try { _host?.Post(new { type = "clickThrough", on = false }); }
@@ -506,14 +519,56 @@ internal static class FypHostService
         App.Logger?.Information("FypHostService: ghost mode off");
     }
 
-    /// <summary>While ghosted, refuse SC_MINIMIZE on the parked window (Show Desktop, Win+D,
-    /// Win+M all arrive here). A minimized source freezes the DWM mirror; off the virtual
-    /// desktop there is nothing a minimize could mean anyway. Never swallows when not ghosted.</summary>
+    /// <summary>While ghosted, refuse everything that would stop the parked window from being
+    /// composed (a source DWM stops composing = a mirror frozen on its last frame):
+    /// SC_MINIMIZE (Show Desktop, Win+D, Win+M), and any native HIDE — the owner-minimize
+    /// cascade hides owned windows entirely inside USER32, so neither WindowState nor IsIconic
+    /// ever changes and only this message ever tells us. Vetoing is primary; a hide that lands
+    /// through a path DefWindowProc never sees is healed right after. Never swallows anything
+    /// when not ghosted.</summary>
     private static IntPtr GhostWndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
     {
-        if (_ghosted && msg == WM_SYSCOMMAND && ((long)wParam & 0xFFF0) == SC_MINIMIZE)
+        if (!_ghosted) return IntPtr.Zero;
+        if (msg == WM_SYSCOMMAND && ((long)wParam & 0xFFF0) == SC_MINIMIZE)
+        {
+            App.Logger?.Information("FypHostService: ghost vetoed SC_MINIMIZE");
             handled = true;
+        }
+        else if (msg == WM_SHOWWINDOW && wParam == IntPtr.Zero)
+        {
+            long why = (long)lParam;
+            App.Logger?.Information("FypHostService: ghost saw WM_SHOWWINDOW hide (lParam={Why})", why);
+            if (why != 0)
+            {
+                // A cascade hide (SW_PARENTCLOSING et al.): DefWindowProc is what would hide
+                // us — refuse it, and re-check visibility once the storm passes.
+                handled = true;
+            }
+            try { _host?.Window?.Dispatcher.BeginInvoke(new Action(HealGhostVisibility)); } catch { }
+        }
         return IntPtr.Zero;
+    }
+
+    /// <summary>If the parked window ended up natively hidden while ghosted (WPF still believes
+    /// it is Visible — the hide happened inside USER32), show it again without activation and
+    /// re-register the thumbnail so the mirror comes back live.</summary>
+    private static void HealGhostVisibility()
+    {
+        try
+        {
+            if (!_ghosted) return;
+            var win = _host?.Window;
+            if (win == null) return;
+            var hwnd = new WindowInteropHelper(win).Handle;
+            if (hwnd == IntPtr.Zero) return;
+            if (!IsWindowVisible(hwnd))
+            {
+                ShowWindow(hwnd, SW_SHOWNA);
+                App.Logger?.Information("FypHostService: parked window was natively hidden — re-shown");
+            }
+            _ghost?.RefreshThumbnail();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost: ghost visibility heal failed: {E}", ex.Message); }
     }
 
     /// <summary>The belt to the veto's braces: a minimize that reached the parked window some
@@ -545,10 +600,53 @@ internal static class FypHostService
         }));
     }
 
+    // While ghosted, log the parked window's real native state every few seconds. This is the
+    // instrumentation that turns the next "it froze" report into a diagnosis instead of a
+    // guess: visible/iconic/cloaked and the applied rect, straight from USER32/DWM — the exact
+    // three ways a window can silently stop being composed.
+    private static System.Windows.Threading.DispatcherTimer? _ghostDiagTimer;
+
+    private static void StartGhostDiagnostics(IntPtr hwnd)
+    {
+        try
+        {
+            StopGhostDiagnostics();
+            _ghostDiagTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(5),
+            };
+            _ghostDiagTimer.Tick += (_, _) =>
+            {
+                try
+                {
+                    if (!_ghosted) { StopGhostDiagnostics(); return; }
+                    DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, out int cloaked, sizeof(int));
+                    GetWindowRect(hwnd, out var r);
+                    App.Logger?.Information(
+                        "FypGhost diag: visible={Vis} iconic={Icon} cloaked={Cloak} rect=({X},{Y} {W}x{H})",
+                        IsWindowVisible(hwnd), IsIconic(hwnd), cloaked,
+                        r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top);
+                }
+                catch (Exception ex) { App.Logger?.Debug("FypGhost diag failed: {E}", ex.Message); }
+            };
+            _ghostDiagTimer.Start();
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.StartGhostDiagnostics: {E}", ex.Message); }
+    }
+
+    private static void StopGhostDiagnostics()
+    {
+        try { _ghostDiagTimer?.Stop(); } catch { }
+        _ghostDiagTimer = null;
+    }
+
     // ------------------------------- native (ghost mode) -------------------------------
 
     private const int WM_SYSCOMMAND = 0x0112;
+    private const int WM_SHOWWINDOW = 0x0018;
     private const int SC_MINIMIZE = 0xF020;
+    private const int SW_SHOWNA = 8;
+    private const int DWMWA_CLOAKED = 14;
     private const uint SWP_NOZORDER = 0x0004;
     private const uint SWP_NOACTIVATE = 0x0010;
 
@@ -567,6 +665,18 @@ internal static class FypHostService
     [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
     private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
         int x, int y, int cx, int cy, uint flags);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool IsWindowVisible(IntPtr hWnd);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [System.Runtime.InteropServices.DllImport("dwmapi.dll")]
+    private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attr, out int value, int size);
 
     // ============================= webcam eye control =============================
     //

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -39,9 +39,14 @@ internal static class FypHostService
     // un-clickable ghost the user has no way to grab.
     private static bool _ghosted;
     private static FypGhostOverlay? _ghost;
-    private static double _ghostLeft, _ghostTop;      // the real window's parked-from position
+    private static double _ghostLeft, _ghostTop;      // the real window's parked-from position (DIPs, log/fallback)
     private static bool _ghostWasMaximized;           // it was maximized before we normalized it
     private static DateTime _lastGhostExitUtc = DateTime.MinValue;
+    private static int _restoreX, _restoreY, _restoreW, _restoreH;   // pre-park window rect (physical px)
+    private static int _parkX, _parkY, _parkW, _parkH;               // parked window rect (physical px)
+    private static EventHandler? _ghostStateGuard;    // heals a minimize of the parked window
+    private static HwndSource? _ghostHookSource;      // carries the SC_MINIMIZE veto while ghosted
+    private static HwndSourceHook? _ghostHook;        // strong ref: AddHook holds only weakly
 
     /// <summary>True while the feed is a see-through DWM mirror and the real window is parked
     /// off-screen (mouse passes straight through to whatever is behind it).</summary>
@@ -374,14 +379,47 @@ internal static class FypHostService
                 onGear: GhostGearClicked, onMute: GhostMuteClicked,
                 isMuted: () => App.Settings?.Current?.FypMuted ?? false);
 
-            // Park it past the right edge of every monitor. Still SHOWN (DWM keeps compositing it,
-            // so the thumbnail stays live); the browser flags keep Chromium from throttling it.
-            win.Left = SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth + 200;
+            // Park it past the right edge of every monitor, RESIZED so the client area is
+            // exactly the home monitor. The mirror letterboxes at the source's aspect, and a
+            // windowed source (screen-wide but short of the taskbar) is wider-aspect than the
+            // monitor — that letterbox was the bare band across the top of the ghost (its twin
+            // sat invisibly over the taskbar). Sized 1:1 there is nothing to letterbox.
+            // One native call, physical px end to end: atomic (no flash of a monitor-sized
+            // window at the old spot) and an exact round-trip for ExitGhost regardless of what
+            // DPI the parking spot resolves to. Still SHOWN (DWM keeps compositing it, so the
+            // thumbnail stays live); the browser flags keep Chromium from throttling it.
+            GetWindowRect(hwnd, out var wr);
+            GetClientRect(hwnd, out var cr);
+            _restoreX = wr.Left; _restoreY = wr.Top;
+            _restoreW = wr.Right - wr.Left; _restoreH = wr.Bottom - wr.Top;
+            int chromeW = _restoreW - cr.Right;    // window minus client: borders + title bar
+            int chromeH = _restoreH - cr.Bottom;
+            var scr = System.Windows.Forms.Screen.FromHandle(hwnd).Bounds;
+            var vs = System.Windows.Forms.SystemInformation.VirtualScreen;
+            _parkX = vs.Right + 200;
+            _parkY = scr.Y;
+            _parkW = scr.Width + Math.Max(0, chromeW);
+            _parkH = scr.Height + Math.Max(0, chromeH);
+            SetWindowPos(hwnd, IntPtr.Zero, _parkX, _parkY, _parkW, _parkH,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+
+            // Show Desktop / Win+D minimizes every restorable top-level window — the parked
+            // source included — and a minimized source stops being composed: the mirror freezes
+            // on its last frame, and the minimize scrambles the window's saved restore rect so
+            // every LATER ghost cycle comes up frozen too (play-tested 2026-08-04). Two layers:
+            // veto SC_MINIMIZE while ghosted (the window is off-screen, minimizing it means
+            // nothing), and if a minimize lands anyway (raw ShowWindow skips WM_SYSCOMMAND),
+            // heal it — restore, re-park, re-register the thumbnail.
+            _ghostHookSource = HwndSource.FromHwnd(hwnd);
+            _ghostHook = GhostWndProc;
+            _ghostHookSource?.AddHook(_ghostHook);
+            _ghostStateGuard = OnGhostWindowStateChanged;
+            win.StateChanged += _ghostStateGuard;
 
             _ghost.Show();
             App.Logger?.Information(
-                "FypHostService: ghost mode ON (mirror at {L}x{T} {W}x{H}, real window parked at {Park})",
-                (int)bounds.X, (int)bounds.Y, (int)bounds.Width, (int)bounds.Height, (int)win.Left);
+                "FypHostService: ghost mode ON (mirror on {Mon}, real window parked at {X}x{Y} {W}x{H}px)",
+                scr, _parkX, _parkY, _parkW, _parkH);
         }
         catch (Exception ex)
         {
@@ -436,10 +474,27 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost close: {E}", ex.Message); }
         try
         {
+            if (win != null && _ghostStateGuard != null) win.StateChanged -= _ghostStateGuard;
+            _ghostStateGuard = null;
+            if (_ghostHookSource != null && _ghostHook != null) _ghostHookSource.RemoveHook(_ghostHook);
+            _ghostHookSource = null;
+            _ghostHook = null;
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost unhook: {E}", ex.Message); }
+        try
+        {
             if (win != null)
             {
-                win.Left = _ghostLeft;
-                win.Top = _ghostTop;
+                // A minimize can still have slipped through (the veto arms mid-Show-Desktop, a
+                // race loses): un-minimize FIRST or the rect restore below lands on a window
+                // nobody can see. Windows' own restore rect may be the parked spot by now —
+                // the native SetWindowPos right after puts the real geometry back regardless.
+                if (win.WindowState == WindowState.Minimized) win.WindowState = WindowState.Normal;
+                var hwnd = new WindowInteropHelper(win).Handle;
+                if (hwnd != IntPtr.Zero && _restoreW > 0 && _restoreH > 0)
+                    SetWindowPos(hwnd, IntPtr.Zero, _restoreX, _restoreY, _restoreW, _restoreH,
+                        SWP_NOZORDER | SWP_NOACTIVATE);
+                else { win.Left = _ghostLeft; win.Top = _ghostTop; }
                 if (_ghostWasMaximized) win.WindowState = WindowState.Maximized;
             }
         }
@@ -450,6 +505,68 @@ internal static class FypHostService
         catch (Exception ex) { App.Logger?.Debug("FypHost.ExitGhost post: {E}", ex.Message); }
         App.Logger?.Information("FypHostService: ghost mode off");
     }
+
+    /// <summary>While ghosted, refuse SC_MINIMIZE on the parked window (Show Desktop, Win+D,
+    /// Win+M all arrive here). A minimized source freezes the DWM mirror; off the virtual
+    /// desktop there is nothing a minimize could mean anyway. Never swallows when not ghosted.</summary>
+    private static IntPtr GhostWndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (_ghosted && msg == WM_SYSCOMMAND && ((long)wParam & 0xFFF0) == SC_MINIMIZE)
+            handled = true;
+        return IntPtr.Zero;
+    }
+
+    /// <summary>The belt to the veto's braces: a minimize that reached the parked window some
+    /// other way is healed after the fact — back to Normal, back to the parking spot (restore-
+    /// from-minimize goes to Windows' saved rect, which can be anywhere by now), and a FRESH
+    /// thumbnail registration, because DWM does not reliably resume the old one.</summary>
+    private static void OnGhostWindowStateChanged(object? sender, EventArgs e)
+    {
+        if (!_ghosted) return;
+        var win = _host?.Window;
+        if (win == null || win.WindowState != WindowState.Minimized) return;
+        // Deferred: this event is raised off the window's own WM_SIZE — let it finish first.
+        win.Dispatcher.BeginInvoke(new Action(() =>
+        {
+            try
+            {
+                if (!_ghosted) return;
+                var w = _host?.Window;
+                if (w == null || w.WindowState != WindowState.Minimized) return;
+                w.WindowState = WindowState.Normal;
+                var hwnd = new WindowInteropHelper(w).Handle;
+                if (hwnd != IntPtr.Zero)
+                    SetWindowPos(hwnd, IntPtr.Zero, _parkX, _parkY, _parkW, _parkH,
+                        SWP_NOZORDER | SWP_NOACTIVATE);
+                _ghost?.RefreshThumbnail();
+                App.Logger?.Information("FypHostService: parked window was minimized (Show Desktop?) — healed");
+            }
+            catch (Exception ex) { App.Logger?.Debug("FypHost: ghost minimize heal failed: {E}", ex.Message); }
+        }));
+    }
+
+    // ------------------------------- native (ghost mode) -------------------------------
+
+    private const int WM_SYSCOMMAND = 0x0112;
+    private const int SC_MINIMIZE = 0xF020;
+    private const uint SWP_NOZORDER = 0x0004;
+    private const uint SWP_NOACTIVATE = 0x0010;
+
+    [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll")]
+    private static extern bool GetClientRect(IntPtr hWnd, out RECT rect);
+
+    [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+    private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
+        int x, int y, int cx, int cy, uint flags);
 
     // ============================= webcam eye control =============================
     //


### PR DESCRIPTION
## Play-test bugs (2026-08-04)

### 1. Show Desktop froze ghost mode (and it stayed frozen until a full feature restart)
The taskbar Show Desktop button / Win+D minimizes every restorable top-level window - **including the real feed window parked off the virtual desktop**. A minimized source stops being composed by DWM, so the mirror froze on its last frame. The minimize also overwrote the window's saved restore rect with parked/scrambled geometry, which is why Esc recovered the real window fine but every ghost re-entry came up frozen.

**Fix - two layers while ghosted:**
- An `HwndSource` hook vetoes `SC_MINIMIZE` on the parked window (Show Desktop, Win+D, Win+M, taskbar all route through it; minimizing an off-screen window means nothing anyway).
- If a minimize lands some other way, a `StateChanged` heal restores to Normal, natively re-parks, and **re-registers the DWM thumbnail** (DWM does not reliably resume the old registration).
- `ExitGhost` now un-minimizes first and restores the exact pre-park window rect via native `SetWindowPos` (physical px round-trip), so rung 1 of the panic ladder always brings the real window back.

### 2. Bare band across the top of the ghost (worked around by fullscreening first)
The mirror letterboxes at the source aspect. A windowed feed (screen-wide, but short of the taskbar) is *wider*-aspect than the monitor, producing equal bands top and bottom - the bottom one hid over the taskbar, the top one showed as the missing strip. The park now happens in one atomic `SetWindowPos` that also resizes the window so its **client area is exactly the home monitor**: nothing to letterbox, edge-to-edge coverage, 1:1 pixels. Original size restored on exit.

## Play-test checklist
- [ ] Open feed windowed (NOT fullscreen) -> ghost -> covers the whole screen, no top band
- [ ] In ghost, click Show Desktop -> ghost keeps playing (or heals within a beat)
- [ ] Esc -> feed returns at its old position/size; re-enter ghost -> still live
- [ ] Maximized feed -> ghost -> Esc -> comes back maximized
- [ ] Gear / speaker ghost buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)