### PR TITLE
feat(goon): procedurally generated spirals (Loom port, no baked assets)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
@@ -63,7 +63,10 @@
  * Uniform renderer shape — see the banner in exec/flashes.js.
  * ==========================================================================*/
 
-import { pickSpiralUrl } from './spiral.js';
+// A popped spiral bubble flicks a still. It comes from the SESSION POOL, not
+// from a bundled file and not from a fresh roll — the flick should look like the
+// spirals this match has been showing, because it is one of them.
+import { pickSpiralImage } from './spiralGen.js';
 
 export const MAX_LIVE = 26;   // hard ceiling on bubble nodes, swarm included
 const MAX_POP_FLASH = 4;      // pop-driven flash images live at once (payloadFx MAX_FLASH's cousin)
@@ -641,7 +644,12 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
         break;
       case 'spiral': {
         const h = holdOn('spiral', 'gg-spiral', scaleD(0.25, 0.70, strength), scale(1500, 4500, strength));
-        if (h) { try { h.el.style.setProperty('background-image', `url('${pickSpiralUrl()}')`); } catch (_e) { /* ignore */ } }
+        if (h) {
+          // '' means the host could not bake one; the wash still reads without a
+          // picture, and `url('')` would be worse than nothing.
+          try { const img = pickSpiralImage(); if (img) h.el.style.setProperty('background-image', `url("${img}")`); }
+          catch (_e) { /* ignore */ }
+        }
         break;
       }
       case 'pinkfilter':

--- a/ConditioningControlPanel/Resources/web/goon/exec/fx.css
+++ b/ConditioningControlPanel/Resources/web/goon/exec/fx.css
@@ -339,21 +339,33 @@ body:has(#gg-stage > *) .gg-flash--hydra { pointer-events: none; cursor: default
  * Overscanned so the rotation never bares a corner. The renderer swaps only the
  * background-image; this rule owns cover/blend/spin.
  *
- * THE GRAIN. The bundled pool is 360-640px dithered 256-colour GIFs, and `cover`
- * on a 1080p+ window blows a 360px source up 3-5x: the dither pattern stops
- * reading as shading and starts reading as GRAIN crawling over the whole screen.
- * A constant 1.1px blur softens the dither below the resolution of the eye while
- * leaving the spiral's own edges (which are huge at that scale) perfectly legible.
- * It is safe to sit in `filter` because NOTHING animates filter on this pane —
- * ggSpiralSpin is transform-only and the fade is opacity-only. Do not add a
- * filter keyframe here without moving this blur onto a wrapper.
- * (The other half of the fix is in exec/spiral.js: sp7.gif, the 360x360 worst
- * offender, is out of SPIRAL_POOL. The file stays on disk — DtRH owns it.)
+ * NO BUNDLED IMAGE (2026-08-04). This rule used to name a DtRH file as its
+ * default background. It names none now: every spiral goon shows is GENERATED at
+ * run time by exec/spiralGen.js, and the pane's background-image is a baked PNG
+ * data URL written inline by exec/spiral.js. A pane with no picture is invisible,
+ * which is the right answer on a host that cannot bake one.
+ *
+ * THE BLUR, WHICH STILL EARNS ITS PLACE. It went in to hide the dither in a
+ * 360px 256-colour GIF magnified 3-5x. There is no dither any more — but there
+ * is still magnification (the bake is 1280px square, `cover` plus `scale: 1.6`
+ * puts it near 2.4x on a 1080p window), and the bake draws its arms as filled
+ * annular wedge strips whose radial seams are exactly what a sub-pixel blur is
+ * for. It is safe to sit in `filter` because NOTHING animates filter on this
+ * pane — ggSpiralSpin is transform-only and the fade is opacity-only. Do not add
+ * a filter keyframe here without moving this blur onto a wrapper.
+ *
+ * SPIN RATE AND DIRECTION ARE CUSTOM PROPERTIES, and that is load-bearing. Each
+ * generated variant is solved onto its own 10-18s revolution, which exec/spiral.js
+ * writes here so the raster bed turns at the rate — and the way — the shader bed
+ * would. They cannot be plain animation-duration/-direction longhands: the woven
+ * path cancels this keyframe with an inline `animation` SHORTHAND and clears it
+ * again with '' on the way back, and a shorthand clear takes every longhand it
+ * owns with it.
  * ------------------------------------------------------------------------ */
 .gg-spiral {
   position: absolute;
   inset: 0;
-  background: url('/dtrh/assets/bubbles/effects/spiral.png') center / cover no-repeat;
+  background: center / cover no-repeat;
   mix-blend-mode: screen;
   transform-origin: 50% 50%;
   scale: 1.6;
@@ -361,7 +373,7 @@ body:has(#gg-stage > *) .gg-flash--hydra { pointer-events: none; cursor: default
   filter: blur(1.1px);
   will-change: opacity, transform;
   transition: opacity var(--gg-spiral-fade, 450ms) ease;
-  animation: ggSpiralSpin 14s linear infinite;
+  animation: ggSpiralSpin var(--gg-spiral-spin, 14s) linear infinite var(--gg-spiral-dir, normal);
   animation-play-state: var(--gg-deco-play, running);
 }
 .gg-spiral.is-on { opacity: var(--gg-spiral-op, 0.4); }

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
@@ -11,20 +11,32 @@
  * stack (whoever wants it louder wins); a payload landing on a running bed does
  * not add a second spinning cover pass.
  *
- * TWO WAYS TO FILL THAT PANE, AND THE GOOD ONE IS PREFERRED.
- *   1. WOVEN (default). exec/spiralField.js renders the Loom's own spiral field
- *      live in WebGL at the window's real pixel ratio — no magnification, no
- *      palette, no dither. The pane gets a <canvas> child and its CSS
- *      magnification/softening (`scale: 1.6`, `filter: blur(1.1px)`) and its
- *      spin keyframe are all cancelled INLINE, because a live renderer needs
- *      none of them: the shader oversizes to the corners itself and does its own
- *      rotation. See that module's banner for why the rasters were grainy.
+ * NOTHING HERE IS BAKED ANY MORE (2026-08-04). The bed used to draw from six
+ * bundled DtRH files (/dtrh/assets/bubbles/effects/spirals/sp*.gif|webp) and,
+ * on the shader path, from six hand-authored presets. Both are gone. Every
+ * spiral is now ROLLED at run time by exec/spiralGen.js — the Loom's "surprise
+ * me" generator, ported and re-tuned — which pre-generates a SESSION'S WORTH
+ * (five) at executor build and rotates through them, never the same one twice
+ * running. NO CENTERPIECE: the Loom's dot/cross overlays are excluded at the
+ * schema level, not filtered out. The DtRH files stay on disk; DtRH owns them
+ * and still draws them. Goon simply stopped pointing at them.
+ *
+ * TWO WAYS TO FILL THAT PANE, AND THEY NOW SHOW THE SAME SPIRAL.
+ *   1. WOVEN (default). exec/spiralField.js renders the variant's parameters
+ *      live in WebGL at the window's real pixel ratio. The pane gets a <canvas>
+ *      child and its CSS magnification/softening (`scale: 1.6`,
+ *      `filter: blur(1.1px)`) and its spin keyframe are all cancelled INLINE,
+ *      because a live renderer needs none of them: the shader oversizes to the
+ *      corners itself and does its own rotation.
  *   2. RASTER (fallback). No WebGL, no canvas, or a lost context -> the pane
- *      keeps the bundled sp*.gif pool exactly as it always worked, blur and
- *      overscan included. The fallback is never removed and never degraded; it
- *      is what a machine without a GPU still gets.
- * The pane always carries a pool background-image either way, so path 2 is one
- * property removal away at any moment.
+ *      falls back to a still PNG of THE SAME VARIANT, baked on a 2D canvas by
+ *      spiralGen (a port of the Loom's own no-WebGL renderer) and spun by the
+ *      fx.css keyframe at the variant's own solved revolution time. The
+ *      fallback is never removed and never degraded; it is what a machine
+ *      without a GPU still gets.
+ * The pane always carries the baked background-image either way, so path 2 is
+ * one property removal away at any moment — and because both paths draw the
+ * same roll, a mid-match context loss now changes the RENDERER, not the picture.
  *
  * THE FREEZE DEFENCE (2026-08-04). This pane is the only GPU context the duel
  * owns, and it went in hours before a session froze VISUALLY while its JS kept
@@ -49,37 +61,16 @@
  * armor has parked decoration: not painting is CORRECT in both, and a watchdog
  * that fires on correct behaviour gets switched off by the people it protects.
  *
- * ASSETS: the pool is the DtRH bundle under /dtrh/assets/bubbles/effects/spirals/
- * (same ccp.game origin — Resources/web is the host root, so /dtrh/... resolves
- * from /goon/). Deliberately NOT imported from dtrh/engine/loomSpirals.js: that
- * module pulls DtRH settings/Loom storage in with it. The pick is three lines.
- * exec/spiralField.js obeys the same rule — it is a COPY of the Loom's shader,
- * not an import, and it never touches the player's saved-spiral library.
+ * NO CROSS-IMPORT: nothing here reaches into dtrh/. dtrh/engine/loomSpirals.js
+ * would pull DtRH settings and the player's saved-spiral storage in with it, and
+ * goon must never read the player's Loom library. exec/spiralField.js and
+ * exec/spiralGen.js are COPIES of the Loom's renderer and its dice, not imports.
  *
  * Uniform renderer shape — see the banner in exec/flashes.js.
  * ==========================================================================*/
 
-import { createSpiralField, pickSpiralParams, loopMsFor } from './spiralField.js';
-
-/**
- * The bundled spiral pool — the FALLBACK bed (DtRH ships these; goon reads them
- * off the same host) and the source for the bubble-pop flick, which is a brief
- * transient where magnification never gets the chance to read as grain.
- *
- * sp7.gif IS DELIBERATELY NOT IN HERE. Measured, these are 360x360..720x720 with
- * palettes as thin as 8 and 16 colours, and a fullscreen cover plus
- * `.gg-spiral { scale: 1.6 }` magnifies them 4.3x (sp2/sp4) to 8.5x (sp7) — so
- * sp7 is the worst case by a wide margin. The rest are softened enough by
- * `.gg-spiral { filter: blur(1.1px) }` in fx.css, which is why that blur must
- * STAY for this path even though the woven path cancels it. The FILE stays on
- * disk — DtRH owns it and still uses it.
- */
-export const SPIRAL_DIR = '/dtrh/assets/bubbles/effects/spirals/';
-export const SPIRAL_POOL = Object.freeze([
-  'sp1.gif', 'sp2.webp', 'sp3.gif', 'sp4.webp', 'sp5.gif', 'sp6.gif',
-]);
-/** The one still that ships outside the pool — the floor if the pool is ever empty. */
-export const SPIRAL_FALLBACK = '/dtrh/assets/bubbles/effects/spiral.png';
+import { createSpiralField, loopMsFor } from './spiralField.js';
+import { beginSpiralSession, nextSpiral } from './spiralGen.js';
 
 /* --- THE SHADER KILL SWITCH. The pref is ui/prefs.js's (`shaderSpirals`,
    default TRUE); it reaches this tier as a ROOT ATTRIBUTE, because exec/ does not
@@ -110,12 +101,6 @@ export const RAF_STALL_MS = 4000;
 /** Context losses this pane will re-upgrade through before it stays on raster. */
 export const MAX_CONTEXT_RECOVERIES = 2;
 
-/** A random spiral URL. Shared with exec/bubbles.js (a popped spiral bubble flicks one). */
-export function pickSpiralUrl() {
-  if (!SPIRAL_POOL.length) return SPIRAL_FALLBACK;
-  return SPIRAL_DIR + SPIRAL_POOL[(Math.random() * SPIRAL_POOL.length) | 0];
-}
-
 const clamp01 = (n) => (typeof n === 'number' && n === n ? (n < 0 ? 0 : n > 1 ? 1 : n) : 0);
 const lerp = (a, b, t) => a + (b - a) * clamp01(t);
 const soon = (fn, ms) => {
@@ -143,9 +128,20 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   const sfx = (id) => { try { if (audio && typeof audio.sfx === 'function') audio.sfx(id); } catch (_e) { /* stub */ } };
   const calm = reducedMotion();
 
+  // ROLL THE MATCH'S SPIRALS, ONCE, HERE. createSpiral runs exactly once per
+  // duel page (boot.js builds one executor), so this is the session boundary —
+  // and it is the shared pool, so exec/bubbles.js's popped-spiral flick throws
+  // a spiral this match has actually been showing.
+  try { beginSpiralSession(); } catch (_e) { /* the pool builds lazily on first ask anyway */ }
+
   let paneEl = null;
   let elementIntensity = null;    // null = element not running
   let payloadIntensity = null;    // null = no payload running
+
+  // THE SPIRAL CURRENTLY ON THE PANE — one roll from the session pool, driving
+  // BOTH beds: `.params` is what the shader weaves, `.image()` is the baked
+  // still underneath it, `.revSec` is the spin the CSS keyframe runs at.
+  let variant = null;
 
   // --- the woven path's state (all null on the raster fallback) -------------
   let canvasEl = null;
@@ -266,7 +262,11 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     const f = createSpiralField(cv);
     if (!f) { canvasEl = null; return; }
     field = f;
-    params = pickSpiralParams();
+    // The pane's OWN roll, not a fresh one: the still already underneath this
+    // canvas has to be the same spiral, or the swap between the two paths would
+    // be a visible cut instead of a change of renderer.
+    if (!variant) variant = nextSpiral();
+    params = variant.params;
     const gen = ++weaveGen;
 
     phase = Math.random();      // never start every match on the same frame
@@ -432,9 +432,12 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
    * REMOVING THE THREE INLINE PROPERTIES IS THE WHOLE SWAP, and it has to remove
    * ALL THREE: fx.css's `.gg-spiral` carries `scale: 1.6`, `filter: blur(1.1px)`
    * and the spin keyframe as one treatment for one bed. Leaving `filter: none`
-   * behind would hand the player a magnified, unblurred, unspun raster — the
-   * dither this pane exists to hide, at 4-8x, held still. Setting each property
-   * to '' (not to its CSS value) is what lets the stylesheet answer again.
+   * behind would hand the player a magnified, unsoftened, UNSPUN still — the
+   * baked PNG's wedge edges at 2.4x, held perfectly still, which is the one way
+   * to make a generated spiral look worse than the GIFs it replaced. Setting
+   * each property to '' (not to its CSS value) is what lets the stylesheet
+   * answer again — and note the spin's rate and direction ride CUSTOM
+   * PROPERTIES (repick), precisely so this shorthand clear cannot eat them.
    */
   function unweave() {
     detachWoven()();
@@ -488,16 +491,47 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   }
 
   /**
-   * Draw a different spiral. BOTH beds are repicked every time: the woven one
-   * takes a new preset, and the raster background-image is refreshed too so the
-   * fallback underneath is never stale if the context dies mid-match.
+   * Advance to the next spiral in the session's rotation, and put it on BOTH
+   * beds at once: the shader takes its parameters, the pane's background-image
+   * takes the baked still of the same roll. Doing both every time is what keeps
+   * the fallback underneath from ever being stale — or, now, from ever being a
+   * different picture — if the context dies mid-match.
+   *
+   * An UNBAKEABLE variant (no canvas, no 2D context, a toDataURL the host
+   * refuses) returns '' and the pane simply keeps whatever it had. Writing
+   * `url('')` instead would blank a bed that was working a moment ago.
+   *
+   * THE BAKE IS DEFERRED ONE TICK, and that is not a micro-optimisation. A
+   * first bake is ~1600 canvas path fills plus a PNG encode — tens of
+   * milliseconds, ON THE MAIN THREAD, and repick() is called from the middle of
+   * a cue landing. The pane fades in over 450-900ms, so an image that arrives
+   * on the next tick arrives invisibly; a bed that ate the cue's own frame
+   * would be felt. Cached after the first ask, so a repeat variant is free.
    */
   function repick() {
     if (!paneEl || !paneEl.style) return;
-    try { paneEl.style.setProperty('background-image', `url('${pickSpiralUrl()}')`); }
-    catch (_e) { /* a host without inline style support just keeps the CSS default */ }
+    variant = nextSpiral();
+    try {
+      // Both beds turn at the roll's own solved revolution time. These are
+      // CUSTOM PROPERTIES on purpose: unweave() clears the `animation`
+      // shorthand to hand the pane back to fx.css, and a shorthand clear would
+      // take plain animation-duration/-direction longhands with it.
+      paneEl.style.setProperty('--gg-spiral-spin', `${variant.revSec.toFixed(2)}s`);
+      paneEl.style.setProperty('--gg-spiral-dir', variant.params.layer.direction === -1 ? 'reverse' : 'normal');
+    } catch (_e) { /* a host without inline style support just keeps the CSS default */ }
+    const el = paneEl;
+    const v = variant;
+    soon(() => {
+      // A pane that has been torn down (or replaced) in the meantime must not
+      // be painted into — its node lingers 900ms on the way out by design.
+      if (paneEl !== el || !el.style) return;
+      try {
+        const img = v.image();
+        if (img) el.style.setProperty('background-image', `url("${img}")`);
+      } catch (_e) { /* the bed keeps whatever it had */ }
+    }, 0);
     if (field) {
-      params = pickSpiralParams();
+      params = variant.params;
       draw();
       return;
     }

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiralField.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiralField.js
@@ -26,19 +26,24 @@
  * NO CROSS-IMPORT, BY CONSTRUCTION. Nothing here reaches into dtrh/. The Loom's
  * consumer module (dtrh/engine/loomSpirals.js) drags DtRH settings + the Loom's
  * saved-spiral storage in with it; goon is offline-by-construction and must
- * never read the player's Loom library. The presets below are authored HERE, in
- * goon's palette, and are the whole content surface.
+ * never read the player's Loom library.
  *
- * PRESETS AND THEIR SPIN. Rotation is seamless by construction: a layer moves
- * exactly one symmetry span per loop, so revolution time is
+ * PARAMS ARE ROLLED, NOT AUTHORED (2026-08-04). This module is the RENDERER and
+ * nothing else — exec/spiralGen.js generates a session's worth of randomized
+ * parameter sets and hands them here. The Loom's centerpiece (dot/star/cross/x)
+ * is excluded at the schema level below: there is no field for one.
+ *
+ * SPIN. Rotation is seamless by construction: a layer moves exactly one symmetry
+ * span per loop, so revolution time is
  *   revMs = loopMs * arms / (arms % colors === 0 ? colors : arms) / speedMul
- * Every preset below is tuned into a 10-18s revolution — the band the CSS
- * `ggSpiralSpin 14s` keyframe used to sit in, so the bed feels unchanged.
+ * (that is revolutionSecFor, below). spiralGen solves every roll into a 10-18s
+ * revolution — the band the CSS `ggSpiralSpin 14s` keyframe sits in, so a bed
+ * that drops from the shader to the raster path does not change tempo.
  *
- * The raster pool is NOT deleted: exec/spiral.js still falls back to it when
- * WebGL is unavailable or the context is lost, and exec/bubbles.js still flicks
- * a bundled still on a popped spiral bubble. This module is the upgrade path,
- * not a replacement for the floor.
+ * The raster path is NOT deleted, it is GENERATED TOO: exec/spiralGen.js bakes
+ * the same parameters to a still PNG with a 2D-canvas port of the Loom's own
+ * fallback renderer. So a lost context now swaps the RENDERER and keeps the
+ * picture, where it used to swap in an unrelated bundled GIF.
  * ==========================================================================*/
 
 /* ---------------------------------------------------------------------------
@@ -129,74 +134,27 @@ function layerRotationRad(layer, phase) {
   return layer.direction * phase * symmetrySpanRad(layer) * layer.speedMul;
 }
 
-/** Seconds per full revolution — the number every preset below is tuned on. */
+/** Seconds per full revolution — the number every roll is solved onto. */
 export function revolutionSecFor(q) {
   const p = normalizeSpiralParams(q);
   return (loopMsFor(p) / (symmetrySpanRad(p.layer) / TWO_PI) / p.layer.speedMul) / 1000;
 }
 
 /* ---------------------------------------------------------------------------
- * THE POOL — six woven spirals in goon's palette, one per retired raster.
+ * WHERE THE PARAMS COME FROM: exec/spiralGen.js.
  *
- * DUTY IS THE COVERAGE DIAL, AND IT IS TUNED LOW ON PURPOSE. This is a BED: it
- * screen-blends over live gameplay at up to 0.70, so it has to read as a spiral
- * without painting over the match. The rasters it replaces were thin bright
- * arms on a mostly-black field; `duty` (the lit fraction of each arm band) is
- * what reproduces that, and every preset sits at 0.26-0.34 rather than the
- * Loom's 0.5 default. Raise the ARM COUNT, not the duty, to make one busier.
- *
- * Comments carry the tuned revolution time (see the banner's revMs formula).
+ * This module used to carry a table of six hand-authored presets. It does not
+ * any more — the owner asked for the Loom's OTHER half, the 🎲 roll, so the
+ * whole content surface is now generated per session in spiralGen.js and this
+ * module is purely the renderer. What that module has to respect is written
+ * down there; the two rules it inherited from the retired table are worth
+ * repeating because they are properties of the MATH above, not of taste:
+ *   · a multi-thread layer needs `arms % colors.length === 0`, or there is no
+ *     sub-2PI symmetry, the loop must cover a whole turn, and the bed spins
+ *     arms/colors times too fast;
+ *   · `duty` is the coverage dial and belongs near 0.3 for a bed, not at the
+ *     Loom's 0.5 default — raise the ARM COUNT to make a spiral busier.
  * ------------------------------------------------------------------------ */
-export const SPIRAL_PRESETS = Object.freeze([
-  // silk — the classic: four soft pink arms opening to the rim. 14.4s/rev.
-  {
-    speed: 1, glow: 0.3,
-    layer: { arms: 4, turns: 2.25, duty: 0.3, style: 'log', direction: 1, colors: ['#ff69b4'] },
-    bg: { kind: 'radial', color: '#0a0410', outer: '#04010a' },
-  },
-  // ribbon — five swelling bands, a slow breath under them. 18s/rev.
-  {
-    speed: 1, glow: 0.2, pulse: { amp: 0.06, cycles: 1 },
-    layer: { arms: 5, turns: 1.75, duty: 0.28, style: 'ribbon', direction: -1, colors: ['#e56cc0'] },
-    bg: { kind: 'solid', color: '#080312' },
-  },
-  // twin — pink/violet candy stripe with a counter-rotating cyan weave. 10.8s/rev.
-  {
-    speed: 1, glow: 0.28,
-    layer: { arms: 6, turns: 2.5, duty: 0.28, style: 'log', direction: 1, colors: ['#ff69b4', '#8a5cff'] },
-    layer2: { enabled: true, arms: 3, turns: 1.5, duty: 0.2, style: 'arch', direction: -1, colors: ['#00e5ff'], speedMul: 1 },
-    bg: { kind: 'radial', color: '#0a0412', outer: '#030108' },
-  },
-  // golden — constant-pitch growth, gradient-blended, faintly liquid. 10.8s/rev.
-  // 6 arms, not 3: an ODD arm count with 2 threads has no sub-2PI symmetry, so
-  // the loop has to cover a whole turn and the bed spins 3x too fast (3.6s).
-  // Keep `arms % colors.length === 0` on every multi-thread preset.
-  {
-    speed: 1, glow: 0.4, wobble: { amp: 0.09, freq: 3, cycles: 1 },
-    layer: { arms: 6, turns: 3, duty: 0.3, style: 'golden', direction: 1, colors: ['#ff69b4', '#8a5cff'], bandMode: 'gradient' },
-    bg: { kind: 'solid', color: '#070310' },
-  },
-  // tunnel — rings riding the radius, sheared into a helix. Rushes inward. 14.4s/rev.
-  {
-    speed: 1, glow: 0.22,
-    layer: { arms: 8, turns: 2, duty: 0.26, style: 'tunnel', direction: -1, colors: ['#8a5cff', '#ff69b4'] },
-    bg: { kind: 'radial', color: '#0a0414', outer: '#020106' },
-  },
-  // petal — a rose sheared into blades; the softest of the six. 14.4s/rev.
-  // 8 arms at speed 3, not 5 at speed 1: petals are WIDE, so a low arm count
-  // reads as a pinwheel rather than a spiral, and 8 arms at speed 1 would crawl
-  // round in 28.8s. This pairing lands back on the same 14.4s as silk.
-  {
-    speed: 3, glow: 0.45, pulse: { amp: 0.08, cycles: 1 },
-    layer: { arms: 8, turns: 3, duty: 0.34, style: 'petal', direction: 1, colors: ['#ff8fd0'] },
-    bg: { kind: 'solid', color: '#060210' },
-  },
-].map(normalizeSpiralParams));
-
-/** A random woven spiral. The procedural twin of exec/spiral.js#pickSpiralUrl. */
-export function pickSpiralParams() {
-  return SPIRAL_PRESETS[(Math.random() * SPIRAL_PRESETS.length) | 0];
-}
 
 /* ---------------------------------------------------------------------------
  * THE SHADER — copied from the Loom's field (dtrh/shared/loomField.js) so the
@@ -377,7 +335,7 @@ export const CONTEXT_LOST_WEBGL = 0x9242;
 /**
  * The field renderer on a canvas. Returns null on ANY host that cannot run it
  * — no canvas element, no getContext, no WebGL, a shader that will not compile
- * — because exec/spiral.js's raster pool is a perfectly good floor and a thrown
+ * — because exec/spiral.js's baked raster bed is a perfectly good floor and a thrown
  * error inside a renderer would take the whole effect tier down with it.
  *
  * @returns {{render(q:object, phase:number):void, lost():boolean, dispose():void, gl:object}|null}
@@ -491,7 +449,7 @@ export function createSpiralField(canvas) {
     }
   }
 
-  /** Hand the GPU its memory back; the pane goes home to the raster pool. */
+  /** Hand the GPU its memory back; the pane goes home to the raster bake. */
   function dispose() {
     if (dead) return;
     dead = true;

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiralGen.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiralGen.js
@@ -1,0 +1,494 @@
+/* ============================================================================
+ * exec/spiralGen.js — THE SPIRAL FOUNDRY. Every spiral this duel shows is woven
+ * here, at run time, out of nothing.
+ *
+ * WHY THIS EXISTS. The bed used to draw from a BAKED POOL: six DtRH GIF/WebP
+ * files under /dtrh/assets/bubbles/effects/spirals/, plus a hand-authored table
+ * of six presets for the shader path. Both were fixed content — the same six
+ * spirals, forever, in every match, on every machine. The owner asked for the
+ * Loom's trick instead: the Loom has a 🎲 "surprise me" that rolls a whole
+ * spiral out of a parameter space (dtrh/shared/loomField.js#randomParams2), and
+ * that is what this module is, ported into goon's tree and re-tuned for a
+ * screen-blended fullscreen BED rather than a framed GIF the player is staring
+ * straight at.
+ *
+ * WHAT WAS DELIBERATELY LEFT BEHIND: the Loom's CENTERPIECE (the dot / star /
+ * cross / x it can stamp over the middle at 25%). Excluded by the owner, and
+ * excluded here BY CONSTRUCTION rather than by a `if (kind !== 'dot')` — the
+ * param schema this module rolls into (spiralField.js#normalizeSpiralParams)
+ * has no centerpiece field at all, and the raster renderer below draws no
+ * centre mark. There is nowhere for one to come from. Same for `hueCycles`: a
+ * hue sweep on a screen blend reads as a colour strobe.
+ *
+ * PRE-GENERATED, NOT PER-FIRE. A session rolls SESSION_SIZE variants ONCE and
+ * then rotates through them (shuffled, never the same one twice in a row). Two
+ * reasons, and neither is performance theatre:
+ *   · a match gets a SET it can recognise — five spirals that come back is a
+ *     texture, a fresh spiral every three seconds is noise;
+ *   · the raster bake (below) is the expensive half, and a fixed set of five
+ *     can be baked lazily and cached instead of re-encoded per cue.
+ *
+ * EVERY VARIANT IS BOTH BEDS AT ONCE. `params` drives exec/spiralField.js's
+ * WebGL field; `image()` bakes the SAME parameters to a still PNG for the
+ * no-WebGL raster path and for the bubble-pop flick. That is new: the shader
+ * bed and the fallback bed used to show unrelated spirals, so a context loss
+ * mid-match visibly swapped the picture. Now it swaps the renderer only.
+ *
+ * DETERMINISM. Every roll takes an injectable `rng` (default Math.random) so
+ * test/selftest-exec.js can drive the whole space from a seeded generator.
+ * App code passes nothing and gets Math.random, which is correct here — a
+ * spiral has no wire contract and no peer to agree with.
+ * ==========================================================================*/
+
+import { normalizeSpiralParams, revolutionSecFor } from './spiralField.js';
+
+/* ---------------------------------------------------------------------------
+ * THE BOUNDS. The Loom's randomParams2 rolls for a GIF the player will stare
+ * at head-on; this bed screen-blends over live gameplay at up to 0.70 opacity.
+ * Three of its dials are therefore pulled in hard, and the rest are the Loom's:
+ *   · DUTY (the lit fraction of an arm band) — the Loom rolls 0.30..0.70, this
+ *     rolls 0.24..0.36. Coverage is what turns a spiral into a curtain. Raise
+ *     the ARM COUNT to make one busier, never the duty.
+ *   · PALETTE — goon's five, not the Loom's eight. Its acid green / amber /
+ *     orange are lovely on black and muddy over a pink HUD.
+ *   · REVOLUTION TIME — pinned to 10..18s (see solveSpin) rather than left to
+ *     fall out of the speed roll. That is the band the retired CSS keyframe
+ *     `ggSpiralSpin 14s` sat in, and it is slow enough to read as a pull.
+ * ------------------------------------------------------------------------ */
+
+/** Goon's swatches. The Loom's LOOM_SWATCHES minus everything warm. */
+export const SPIRAL_PALETTE = Object.freeze([
+  '#ff69b4',   // hot pink — the house colour
+  '#e56cc0',   // dusty rose
+  '#ff8fd0',   // pale pink
+  '#8a5cff',   // violet
+  '#00e5ff',   // cyan (the counter-thread; sparing, it is the loudest of the five)
+]);
+
+/** Near-black field colours. The bed is screen-blended, so these read as clear. */
+const BG_INNER = Object.freeze(['#0a0410', '#080312', '#070310', '#060210', '#0a0414']);
+const BG_OUTER = Object.freeze(['#04010a', '#030108', '#020106']);
+
+const STYLES = Object.freeze(['log', 'arch', 'ribbon', 'golden', 'tunnel', 'petal']);
+
+/**
+ * Arm-count band per style, and they are NOT interchangeable. Petals are WIDE
+ * (a rose lobe, not a line) so a low count reads as a pinwheel; tunnel bands
+ * ride the radius so a low count reads as three fat rings. The rest are arms in
+ * the ordinary sense and 3..8 is the whole useful range — past 8 a screen blend
+ * turns them into a haze.
+ */
+const ARM_BAND = Object.freeze({
+  log: [3, 8], arch: [3, 8], ribbon: [3, 7], golden: [4, 8], tunnel: [5, 10], petal: [6, 10],
+});
+
+/** The spin band every variant is solved into, in seconds per revolution. */
+export const REV_SEC_MIN = 10;
+export const REV_SEC_MAX = 18;
+
+/** Variants a session pre-generates. The owner asked for 4-5; five it is. */
+export const SESSION_SIZE = 5;
+
+/**
+ * Bake resolution for the raster fallback, in pixels square.
+ *
+ * THE MAGNIFICATION MATH, because this number is the whole quality argument.
+ * The pane covers the window and fx.css then multiplies it by `scale: 1.6`
+ * (rotation overscan — a square at `cover` leaves the viewport corners bare at
+ * 45°). On a 1920-wide window that is 3072 effective pixels. At 1280 the bake
+ * is magnified 2.4x, against 4.3x-8.5x for the 360..720px GIFs this replaces —
+ * and unlike them it is a smooth two-tone wedge fill with no palette and no
+ * dither, so what magnification costs is softness, not crawling grain.
+ * Going higher is not free: the PNG data URL is held in an inline style.
+ */
+export const RASTER_PX = 1280;
+
+/* ---------------------------------------------------------------------------
+ * ROLLING ONE
+ * ------------------------------------------------------------------------ */
+
+const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+const snap = (v, step) => Math.round(v / step) * step;
+/** A defended rng: a host (or a test) that hands back junk must not poison a roll. */
+const rngOf = (rng) => {
+  const f = typeof rng === 'function' ? rng : Math.random;
+  return () => {
+    const v = f();
+    return typeof v === 'number' && v >= 0 && v < 1 ? v : 0;
+  };
+};
+const pickFrom = (arr, r) => arr[Math.min(arr.length - 1, (r() * arr.length) | 0)];
+const between = (lo, hi, r) => lo + r() * (hi - lo);
+const intBetween = (lo, hi, r) => lo + Math.min(hi - lo, (r() * (hi - lo + 1)) | 0);
+
+/** Fisher-Yates on a copy — the Loom's `threads()`, minus its sort-comparator shuffle. */
+function shuffled(arr, r) {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = (r() * (i + 1)) | 0;
+    const t = a[i]; a[i] = a[j]; a[j] = t;
+  }
+  return a;
+}
+
+/**
+ * Arm counts a layer with `threads` colours may take, in `style`'s band. TWO
+ * constraints, and both are arithmetic rather than taste — see the revolution
+ * formula in spiralField.js's banner:
+ *
+ *   revSec = loopMs(speed) * arms / (arms % threads === 0 ? threads : arms)
+ *            / speedMul / 1000
+ *
+ *   1. arms % threads === 0. Otherwise there is NO sub-2PI symmetry: the loop
+ *      has to cover a whole turn and the bed spins arms/threads times too fast.
+ *      (This is the trap the retired `golden` preset was written around: 3 arms
+ *      with 2 threads came out at 3.6s instead of 10.8s.)
+ *   2. arms >= MIN_ARMS_PER_THREAD * threads. `loopMs` tops out at 3600ms
+ *      (speed 1), so the SLOWEST revolution any combination can reach is
+ *      3.6s * arms/threads. At a ratio of 3 that is 10.8s — just inside
+ *      REV_SEC_MIN, which is what lets solveSpin() promise the band instead of
+ *      hoping for it. A ratio of 1 (say 3 arms, 3 threads) caps out at 3.6s and
+ *      would give the bed a spin nobody can look at.
+ *
+ * May return [] — a style's band simply has no legal count for that many
+ * threads (3 threads need 9+ arms, which only tunnel and petal reach). The
+ * caller picks the thread count from what the style can actually carry.
+ */
+const MIN_ARMS_PER_THREAD = 3;
+function armChoices(style, threads) {
+  const [lo, hi] = ARM_BAND[style] || [3, 8];
+  const out = [];
+  for (let a = Math.max(lo, MIN_ARMS_PER_THREAD * threads); a <= hi; a++) {
+    if (a % threads === 0) out.push(a);
+  }
+  return out;
+}
+
+/** Thread counts `style` can carry at all, cheapest question first. */
+function threadChoices(style) {
+  return [1, 2, 3].filter((n) => armChoices(style, n).length > 0);
+}
+
+/**
+ * Pick the (speed, speedMul) pair that puts one revolution closest to
+ * `targetSec`. Fifteen combinations, each evaluated with the FIELD'S OWN
+ * formula, so the answer is right by construction rather than right by comment.
+ *
+ * This is what replaces the hand-tuning every retired preset carried ("8 arms
+ * at speed 3, not 5 at speed 1, because petals are wide and 8 arms at speed 1
+ * would crawl round in 28.8s"). A generator cannot hand-tune, so it solves.
+ *
+ * IN-BAND CANDIDATES WIN OUTRIGHT, even when an out-of-band one sits nearer the
+ * target: the target is a preference, [REV_SEC_MIN, REV_SEC_MAX] is the actual
+ * requirement. Without this a 5-armed roll asked for 10.0s would take 9.0s
+ * (0.9 off) over 12.6s (2.6 off) and quietly leave the band. armChoices'
+ * constraint 2 is what guarantees the in-band set is never empty.
+ */
+function solveSpin(base, targetSec) {
+  let best = null;
+  let nearest = null;
+  for (let speed = 1; speed <= 5; speed++) {
+    for (let speedMul = 1; speedMul <= 3; speedMul++) {
+      const q = Object.assign({}, base, {
+        speed,
+        layer: Object.assign({}, base.layer, { speedMul }),
+      });
+      const revSec = revolutionSecFor(q);
+      const cand = { speed, speedMul, revSec, err: Math.abs(revSec - targetSec) };
+      if (!nearest || cand.err < nearest.err) nearest = cand;
+      if (revSec < REV_SEC_MIN || revSec > REV_SEC_MAX) continue;
+      if (!best || cand.err < best.err) best = cand;
+    }
+  }
+  return best || nearest || { speed: 1, speedMul: 1, revSec: 0, err: Infinity };
+}
+
+/**
+ * Roll one spiral. Returns NORMALIZED schema-v2 params (spiralField's own
+ * shape) plus the solved revolution time, which the raster bed uses as its CSS
+ * spin duration so both paths turn at the same rate.
+ *
+ * @param {() => number} [rng] injectable for tests; app code wants Math.random
+ * @returns {{params: object, revSec: number}}
+ */
+export function rollSpiral(rng) {
+  const r = rngOf(rng);
+
+  const style = pickFrom(STYLES, r);
+  // 1 thread most of the time: two colours on a screen blend is a candy stripe,
+  // three is a rainbow. The Loom rolls 1-3 evenly; a bed cannot afford that.
+  // Weighted 6/3/1, then intersected with what this style's arm band can carry
+  // (see armChoices) — the weights are a preference, the arithmetic is not.
+  const legal = threadChoices(style);
+  const bag = [];
+  for (const n of legal) for (let i = 0; i < (n === 1 ? 6 : n === 2 ? 3 : 1); i++) bag.push(n);
+  const threadCount = bag.length ? pickFrom(bag, r) : 1;
+  const palette = shuffled(SPIRAL_PALETTE, r);
+  const colors = palette.slice(0, threadCount);
+  const choices = armChoices(style, threadCount);
+  const arms = choices.length ? pickFrom(choices, r) : MIN_ARMS_PER_THREAD * threadCount;
+  const direction = r() < 0.5 ? 1 : -1;
+
+  const base = {
+    speed: 1,
+    glow: +between(0.18, 0.45, r).toFixed(3),
+    layer: {
+      arms,
+      turns: clamp(snap(between(1.5, 3.25, r), 0.25), 0.5, 6),
+      duty: +clamp(snap(between(0.24, 0.36, r), 0.02), 0.2, 0.8).toFixed(3),
+      style,
+      direction,
+      colors,
+      // Gradient blending only makes sense with something to blend BETWEEN.
+      bandMode: threadCount > 1 && r() < 0.3 ? 'gradient' : 'hard',
+      speedMul: 1,
+    },
+    bg: { kind: r() < 0.5 ? 'radial' : 'solid', color: pickFrom(BG_INNER, r), outer: pickFrom(BG_OUTER, r) },
+  };
+
+  // A counter-rotating second weave, sometimes. Always the OPPOSITE direction
+  // (the Loom does this too) — two layers turning the same way just look thick.
+  if (r() < 0.35) {
+    base.layer2 = {
+      enabled: true,
+      arms: intBetween(2, 6, r),
+      turns: clamp(snap(between(0.75, 2, r), 0.25), 0.5, 6),
+      duty: +between(0.16, 0.26, r).toFixed(3),
+      style: pickFrom(['arch', 'log', 'ribbon'], r),
+      direction: -direction,
+      colors: [palette[palette.length - 1]],   // the thread layer 1 did NOT take
+      speedMul: 1,
+    };
+  }
+  if (r() < 0.35) base.pulse = { amp: +between(0.05, 0.1, r).toFixed(3), cycles: 1 };
+  if (r() < 0.3) base.wobble = { amp: +between(0.06, 0.14, r).toFixed(3), freq: intBetween(2, 4, r), cycles: 1 };
+
+  const spin = solveSpin(base, between(REV_SEC_MIN, REV_SEC_MAX, r));
+  base.speed = spin.speed;
+  base.layer.speedMul = spin.speedMul;
+
+  return { params: normalizeSpiralParams(base), revSec: spin.revSec };
+}
+
+/* ---------------------------------------------------------------------------
+ * THE RASTER BAKE — the no-WebGL floor, drawn instead of downloaded.
+ *
+ * This is the Loom's OWN 2D fallback renderer (dtrh/shared/loomSpiral.js
+ * #drawSpiral, reached through its projectToV1) copied across and taught the
+ * two things a v2 param set has that v1 did not: a radial background, and up to
+ * three threads instead of two. Arms are filled annular wedge strips — cheap,
+ * alias-friendly at any size, and no stroke-width tuning.
+ *
+ * IT DRAWS ONE FRAME, NOT AN ANIMATION. The pane's spin is the CSS keyframe
+ * rotating the whole still, which is exactly what the retired GIFs' own frames
+ * were doing and costs the compositor a transform instead of a decode. Nothing
+ * in the field is rotationally asymmetric per-frame except the arms themselves,
+ * so a rotating still and a re-rendered frame are the same picture.
+ * ------------------------------------------------------------------------ */
+
+/** v2's six styles down to the three radius easings the 2D path knows. */
+const V1_STYLE = Object.freeze({
+  log: 'log', arch: 'arch', ribbon: 'ribbon', golden: 'log', tunnel: 'arch', petal: 'ribbon',
+});
+
+function radiusAt(style, t) {
+  if (style === 'log') return Math.pow(t, 1.75);      // tight centre, opening rim
+  if (style === 'arch') return t;                     // archimedean — even bands
+  return t * t * (3 - 2 * t);                         // ribbon — smoothstep swell
+}
+
+/**
+ * Draw one still frame of `params` into a 2D context, `size` px square.
+ *
+ * Every ctx call that a minimal/stub context may not implement is guarded: this
+ * runs on whatever WebView2 hands us and, in the self-test, on a recording
+ * fake. A bake that cannot draw returns false and the caller keeps its old
+ * image rather than showing a black square.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {number} size square edge in pixels
+ * @param {object} params NORMALIZED params (rollSpiral's `.params`)
+ * @param {number} [phase] 0..1 inside the loop; a still bakes at 0
+ * @returns {boolean}
+ */
+export function drawSpiralRaster(ctx, size, params, phase = 0) {
+  if (!ctx || typeof ctx.fillRect !== 'function' || typeof ctx.arc !== 'function') return false;
+  const q = normalizeSpiralParams(params);
+  const L = q.layer;
+  const c = size / 2;
+  const maxR = c * 1.45;                        // overdraw the corners: no dead edges
+  const arms = Math.max(1, L.arms);
+  const armSpan = (Math.PI * 2) / arms;
+  const litSpan = armSpan * L.duty;
+  const twist = L.turns * Math.PI * 2;          // how far a band shears over the radius
+  const rot = L.direction * phase * armSpan;
+  const style = V1_STYLE[L.style] || 'log';
+  // Radial resolution — how many annular strips the shear is approximated by.
+  // The Loom uses size/6 unbounded, because it is baking a file the player will
+  // stare at. This bakes at RASTER_PX and 160 strips x 10 arms is already 1600
+  // path fills; past that the extra strips are finer than the 1.1px blur
+  // .gg-spiral puts over them, so they cost time and change nothing.
+  const rings = clamp(Math.round(size / 6), 48, 160);
+
+  try {
+    let bg = q.bg.color;
+    if (q.bg.kind === 'radial' && typeof ctx.createRadialGradient === 'function') {
+      const g = ctx.createRadialGradient(c, c, 0, c, c, maxR);
+      g.addColorStop(0, q.bg.color);
+      g.addColorStop(1, q.bg.outer);
+      bg = g;
+    }
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, size, size);
+  } catch (_e) { return false; }
+
+  try {
+    for (let ring = 0; ring < rings; ring++) {
+      const t0 = ring / rings, t1 = (ring + 1) / rings;
+      const r0 = radiusAt(style, t0) * maxR;
+      const r1 = radiusAt(style, t1) * maxR + 0.75;   // slight overlap: no moiré seams
+      if (r1 <= 0.5) continue;
+      const shear = twist * ((t0 + t1) / 2);
+      for (let arm = 0; arm < arms; arm++) {
+        const a0 = rot + arm * armSpan + shear;
+        ctx.fillStyle = L.colors[arm % L.colors.length];
+        ctx.beginPath();
+        ctx.arc(c, c, r1, a0, a0 + litSpan, false);
+        if (r0 > 0.5) ctx.arc(c, c, r0, a0 + litSpan, a0, true);
+        else if (typeof ctx.lineTo === 'function') ctx.lineTo(c, c);
+        ctx.closePath();
+        ctx.fill();
+      }
+    }
+  } catch (_e) { return false; }
+  return true;
+}
+
+/**
+ * ONE scratch canvas for every bake in the page. A 1280-square backing store is
+ * ~6.5MB; minting a fresh one per variant would hold five of them alive for as
+ * long as the session, for no reason — the PNG is the only thing worth keeping.
+ */
+let scratch = null;
+function scratchCanvas(size) {
+  if (scratch && scratch.width === size) return scratch;
+  if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
+  let cv = null;
+  try { cv = document.createElement('canvas'); } catch (_e) { return null; }
+  if (!cv || typeof cv.getContext !== 'function') return null;
+  try { cv.width = size; cv.height = size; } catch (_e) { return null; }
+  scratch = cv;
+  return cv;
+}
+
+/**
+ * Bake `params` to a PNG data URL, or '' on any host that cannot draw one (no
+ * document, no canvas, no 2D context, a toDataURL the host refuses). '' is a
+ * first-class answer: exec/spiral.js simply leaves the pane's background-image
+ * alone, and a pane with no picture is invisible rather than wrong.
+ */
+export function bakeSpiralImage(params, size = RASTER_PX) {
+  const cv = scratchCanvas(size);
+  if (!cv) return '';
+  let ctx = null;
+  try { ctx = cv.getContext('2d'); } catch (_e) { return ''; }
+  if (!ctx) return '';
+  if (!drawSpiralRaster(ctx, size, params, 0)) return '';
+  if (typeof cv.toDataURL !== 'function') return '';
+  try {
+    const url = cv.toDataURL('image/png');
+    return typeof url === 'string' && url.indexOf('data:image') === 0 ? url : '';
+  } catch (_e) { return ''; }   // a tainted or oversized canvas throws; the bed survives it
+}
+
+/* ---------------------------------------------------------------------------
+ * THE SESSION POOL
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Pre-generate a session's spirals and hand back a rotator.
+ *
+ * ROTATION, NOT RE-ROLLING. `next()` walks a shuffled order and reshuffles at
+ * the end of each pass, refusing to open the new pass with the variant that
+ * closed the old one — with five entries a plain re-shuffle would repeat back
+ * to back roughly one pass in five, and a bed that "changes" into the same
+ * spiral reads as a bug.
+ *
+ * `image()` bakes LAZILY and caches. A match that never drops to the raster
+ * path (the normal case — the shader bed is on by default) pays nothing.
+ *
+ * @param {{rng?: () => number, count?: number, size?: number}} [opts]
+ */
+export function createSpiralSession(opts = {}) {
+  const r = rngOf(opts.rng);
+  const count = Math.max(1, (opts.count | 0) || SESSION_SIZE);
+  const size = Math.max(64, (opts.size | 0) || RASTER_PX);
+
+  const variants = [];
+  for (let i = 0; i < count; i++) {
+    const rolled = rollSpiral(r);
+    let baked = null;
+    variants.push({
+      params: rolled.params,
+      revSec: rolled.revSec,
+      /** The PNG data URL for this variant, baked on first ask. '' if unbakeable.
+       *  Closes over its own params rather than reading `this`, so a caller that
+       *  pulls the method off the variant still gets the right picture. */
+      image: () => {
+        if (baked === null) baked = bakeSpiralImage(rolled.params, size);
+        return baked;
+      },
+    });
+  }
+
+  let order = shuffled(variants.map((_v, i) => i), r);
+  let at = 0;
+  let last = -1;
+
+  function next() {
+    if (at >= order.length) {
+      order = shuffled(order, r);
+      // Never open a pass with the variant that closed the last one.
+      if (order.length > 1 && order[0] === last) { const t = order[0]; order[0] = order[1]; order[1] = t; }
+      at = 0;
+    }
+    last = order[at++];
+    return variants[last];
+  }
+
+  return {
+    size,
+    count: variants.length,
+    all: () => variants.slice(),
+    next,
+    /** Any variant, no rotation state touched — the bubble-pop flick's pick. */
+    any: () => variants[Math.min(variants.length - 1, (r() * variants.length) | 0)],
+  };
+}
+
+/* --- THE SHARED SESSION. exec/spiral.js (the bed) and exec/bubbles.js (the
+   pop flick) must draw from the SAME five, or a popped spiral bubble would
+   throw a spiral the match has never shown. Built lazily so a module-import
+   sweep costs nothing, and re-rolled by beginSpiralSession() when a new duel
+   builds its executor. ----------------------------------------------------- */
+let session = null;
+
+/** The session pool, built on first ask. */
+export function spiralSession() {
+  if (!session) session = createSpiralSession();
+  return session;
+}
+
+/** Roll a fresh set for a new match. Called once, from createSpiral(). */
+export function beginSpiralSession(opts) {
+  session = createSpiralSession(opts || {});
+  return session;
+}
+
+/** The next spiral in the session's rotation. */
+export function nextSpiral() { return spiralSession().next(); }
+
+/** A baked still from the session, for exec/bubbles.js's popped-spiral flick. */
+export function pickSpiralImage() { return spiralSession().any().image(); }
+
+export default createSpiralSession;

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -164,7 +164,8 @@ globalThis.window = { innerWidth: 1280, innerHeight: 720 };
 const { createExecutor, PAYLOAD_ELEMENT } = await import('../exec/executor.js');
 const { createLockCardView } = await import('../exec/lockCards.js');
 const layers = await import('../exec/layers.js');
-const { pickSpiralUrl, SPIRAL_POOL } = await import('../exec/spiral.js');
+const spiralGen = await import('../exec/spiralGen.js');
+const spiralField = await import('../exec/spiralField.js');
 const { GoonElement, GoonPayloadKind } = await import('../core/contracts.js');
 const { localMonotonicMs } = await import('../core/clock.js');
 
@@ -455,23 +456,171 @@ async function main() {
     ok(PAYLOAD_ELEMENT[GoonPayloadKind.Spiral] === GoonElement.Spiral,
       'GoonPayloadKind.Spiral routes to GoonElement.Spiral', String(PAYLOAD_ELEMENT[GoonPayloadKind.Spiral]));
 
-    // The pool is the DtRH bundle, read off the same ccp.game origin — MINUS
-    // sp7.gif. Every entry is a dithered 256-colour file blown up to COVER the
-    // window, and at 360x360 sp7's dither read as crawling grain rather than
-    // shading (owner-approved cull, 2026-08-03). The FILE stays on disk: DtRH
-    // owns it and still draws it.
-    ok(SPIRAL_POOL.length === 6, 'the bundled spiral pool has 6 entries', String(SPIRAL_POOL.length));
-    ok(!SPIRAL_POOL.includes('sp7.gif'), 'sp7.gif is culled from the pool (the worst grain offender)',
-      SPIRAL_POOL.join(','));
-    let poolHits = 0;
-    let sp7 = 0;
-    for (let i = 0; i < 200; i++) {
-      const u = pickSpiralUrl();
-      if (u.startsWith('/dtrh/assets/bubbles/effects/spirals/') && SPIRAL_POOL.some((f) => u.endsWith(f))) poolHits++;
-      if (u.endsWith('sp7.gif')) sp7++;
+    // NOTHING BUNDLED. The pool of six DtRH sp*.gif files this bed used to draw
+    // from is gone from goon (the FILES stay on disk — DtRH owns them and still
+    // draws them). Nothing under exec/ may name that directory again.
+    // COMMENTS ARE STRIPPED FIRST, the way the fx.css pins below do it: the
+    // banners in both modules quote the retired path verbatim (that is the
+    // history worth keeping), and a regression pin a comment can turn red is
+    // not a pin.
+    {
+      const fs = await import('node:fs/promises');
+      const url = await import('node:url');
+      const read = async (rel) => (await fs.readFile(url.fileURLToPath(new URL(rel, import.meta.url)), 'utf8'))
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      for (const name of ['spiral.js', 'bubbles.js']) {
+        const src = await read(`../exec/${name}`);
+        ok(!/\/dtrh\/assets\/bubbles\/effects\/spiral/.test(src),
+          `exec/${name} names no bundled spiral asset — every spiral is generated`,
+          (/[^\n]*\/dtrh\/assets\/bubbles\/effects\/spiral[^\n]*/.exec(src) || [''])[0]);
+      }
+      const fxSrc = await read('../exec/fx.css');
+      ok(!/\.gg-spiral\s*\{[^}]*url\(/.test(fxSrc),
+        'fx.css .gg-spiral declares NO background image — the renderer writes a baked one',
+        (/\.gg-spiral\s*\{[^}]*\}/.exec(fxSrc) || [''])[0]);
+      // The spin rate/direction MUST ride custom properties: the woven path
+      // cancels this keyframe with an inline `animation` shorthand and clears it
+      // with '' again, and a shorthand clear eats every longhand it owns.
+      ok(/animation:\s*ggSpiralSpin\s+var\(--gg-spiral-spin[^)]*\)[^;]*var\(--gg-spiral-dir/.test(fxSrc),
+        '.gg-spiral takes its spin rate AND direction from custom properties',
+        (/animation:\s*ggSpiralSpin[^;]*/.exec(fxSrc) || [''])[0]);
     }
-    ok(poolHits === 200, 'every picked spiral url is a bundled DtRH spiral', String(poolHits));
-    ok(sp7 === 0, 'and 200 picks never drew the culled one', String(sp7));
+  }
+
+  /* ------------------------------------------------- the spiral generator
+   * exec/spiralGen.js — the Loom's 🎲 roll, ported. Driven here through its
+   * INJECTABLE rng, which is the only reason a random content surface is
+   * testable at all: app code passes nothing and gets Math.random.
+   * ------------------------------------------------------------------- */
+  {
+    /** A seeded rng (mulberry32) — same seed, same spiral, every run. */
+    const seeded = (seed) => () => {
+      seed = (seed + 0x6D2B79F5) | 0;
+      let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+
+    // --- deterministic under an injected rng
+    const a = spiralGen.rollSpiral(seeded(1234));
+    const b = spiralGen.rollSpiral(seeded(1234));
+    ok(JSON.stringify(a.params) === JSON.stringify(b.params),
+      'the same seed rolls the same spiral — the generator is rng-injectable, not clock-driven');
+    ok(JSON.stringify(spiralGen.rollSpiral(seeded(99)).params) !== JSON.stringify(a.params),
+      'and a different seed rolls a different one');
+
+    // --- the whole space, swept. 4000 rolls off the real rng.
+    let revOut = 0;
+    let symBreak = 0;
+    let dutyOut = 0;
+    let offPalette = 0;
+    let centrepiece = 0;
+    let hue = 0;
+    const stylesSeen = new Set();
+    const armsSeen = new Set();
+    let mostRecent = null;
+    for (let i = 0; i < 4000; i++) {
+      const roll = spiralGen.rollSpiral();
+      const L = roll.params.layer;
+      mostRecent = roll;
+      stylesSeen.add(L.style);
+      armsSeen.add(L.arms);
+      if (roll.revSec < spiralGen.REV_SEC_MIN - 1e-6 || roll.revSec > spiralGen.REV_SEC_MAX + 1e-6) revOut++;
+      // The symmetry rule: a multi-thread layer whose arm count is not a
+      // multiple of its thread count has no sub-2PI symmetry and spins
+      // arms/threads times too fast. See armChoices in exec/spiralGen.js.
+      if (L.arms % L.colors.length !== 0) symBreak++;
+      if (L.duty < 0.23 || L.duty > 0.37) dutyOut++;
+      for (const c of L.colors) if (!spiralGen.SPIRAL_PALETTE.includes(c)) offPalette++;
+      // THE OWNER'S EXPLICIT EXCLUSION: the Loom can stamp a dot/star/cross/x
+      // over the middle at 25%. Goon must never. It is excluded by CONSTRUCTION
+      // (the schema has no field) rather than filtered, so this check is a pin
+      // on the schema, not on a branch.
+      if ('centerpiece' in roll.params || 'centrepiece' in roll.params) centrepiece++;
+      if (roll.params.hueCycles !== 0) hue++;
+    }
+    ok(revOut === 0,
+      `every roll is solved into the ${spiralGen.REV_SEC_MIN}-${spiralGen.REV_SEC_MAX}s revolution band`,
+      String(revOut));
+    ok(symBreak === 0, 'no roll breaks the arms % threads === 0 symmetry rule', String(symBreak));
+    ok(dutyOut === 0, 'duty stays in the BED band (~0.24-0.36), not the Loom‘s 0.3-0.7', String(dutyOut));
+    ok(offPalette === 0, 'every thread is one of goon‘s five swatches', String(offPalette));
+    ok(centrepiece === 0, 'NO roll can carry a centerpiece — the dot/cross overlays are excluded', String(centrepiece));
+    ok(hue === 0, 'and hueCycles stays pinned off (a hue sweep on a screen blend is a strobe)', String(hue));
+    ok(stylesSeen.size === 6, '4000 rolls reach all six weave styles', Array.from(stylesSeen).join(','));
+    ok(armsSeen.size >= 5, 'and a spread of arm counts', Array.from(armsSeen).sort((x, y) => x - y).join(','));
+
+    // --- the solved revolution really is the field's own number
+    ok(Math.abs(spiralField.revolutionSecFor(mostRecent.params) - mostRecent.revSec) < 1e-9,
+      'the revSec a roll reports is the FIELD‘s formula, not the generator‘s opinion',
+      `${spiralField.revolutionSecFor(mostRecent.params)} vs ${mostRecent.revSec}`);
+
+    // --- junk rng: a host that hands back garbage must not poison a roll
+    const junk = spiralGen.rollSpiral(() => NaN);
+    ok(junk.params.layer.arms >= 1 && junk.revSec > 0,
+      'an rng that returns NaN still produces a valid spiral', JSON.stringify(junk.params.layer));
+
+    // --- the 2D raster bake, on a recording fake context
+    const calls = { fillRect: 0, arc: 0, fill: 0, gradients: 0 };
+    const fakeCtx = {
+      fillStyle: null,
+      fillRect() { calls.fillRect++; },
+      beginPath() {}, closePath() {}, lineTo() {},
+      arc() { calls.arc++; },
+      fill() { calls.fill++; },
+      createRadialGradient() { calls.gradients++; return { addColorStop() {} }; },
+    };
+    const rolled = spiralGen.rollSpiral(seeded(7));
+    ok(spiralGen.drawSpiralRaster(fakeCtx, 512, rolled.params, 0) === true,
+      'drawSpiralRaster draws the still the no-WebGL bed shows');
+    ok(calls.fillRect === 1, 'exactly one background fill', String(calls.fillRect));
+    ok(calls.fill > 100 && calls.arc > 100, 'and the arms are annular wedge strips, not one path',
+      `${calls.fill} fills / ${calls.arc} arcs`);
+    ok(spiralGen.drawSpiralRaster({}, 512, rolled.params) === false,
+      'a context that cannot draw is refused rather than thrown over');
+    // The stub DOM has no canvas 2D context at all, which is exactly the host
+    // that must get '' instead of a broken `url('')`.
+    ok(spiralGen.bakeSpiralImage(rolled.params, 64) === '',
+      'a host with no 2D canvas bakes to the empty string, not to junk',
+      spiralGen.bakeSpiralImage(rolled.params, 64));
+
+    // --- the session pool: pre-generated, and rotated rather than re-rolled
+    const sess = spiralGen.createSpiralSession({ rng: seeded(42) });
+    ok(sess.count === spiralGen.SESSION_SIZE, `a session pre-generates ${spiralGen.SESSION_SIZE} variants`,
+      String(sess.count));
+    ok(sess.all().length === spiralGen.SESSION_SIZE && sess.all() !== sess.all(),
+      'all() hands back a copy, so a caller cannot edit the session‘s pool');
+    const identities = new Set(sess.all().map((v) => JSON.stringify(v.params)));
+    ok(identities.size >= 4, 'and the five it rolled are (near enough) all different',
+      String(identities.size));
+    const seen = new Map();
+    let repeats = 0;
+    let prev = null;
+    for (let i = 0; i < 200; i++) {
+      const v = sess.next();
+      if (v === prev) repeats++;
+      prev = v;
+      seen.set(v, (seen.get(v) || 0) + 1);
+    }
+    ok(repeats === 0, 'next() never hands out the same variant twice running', String(repeats));
+    ok(seen.size === spiralGen.SESSION_SIZE, '200 picks rotate through every variant', String(seen.size));
+    const counts = Array.from(seen.values());
+    ok(Math.max(...counts) - Math.min(...counts) <= 1,
+      'and the rotation is even — a shuffled walk, not a re-roll', counts.join(','));
+    ok(sess.all().every((v) => v.image() === '' && v.image() === v.image()),
+      'image() caches (here: caches the empty string this host can only bake)');
+
+    // --- the shared session, which is what makes a popped spiral bubble throw a
+    //     spiral THIS MATCH has been showing rather than a seventh one
+    const shared = spiralGen.beginSpiralSession({ rng: seeded(5) });
+    ok(spiralGen.spiralSession() === shared, 'beginSpiralSession installs the shared pool');
+    const fromShared = new Set(shared.all());
+    let strays = 0;
+    for (let i = 0; i < 50; i++) if (!fromShared.has(spiralGen.nextSpiral())) strays++;
+    ok(strays === 0, 'nextSpiral() only ever draws from the shared session', String(strays));
+    ok(spiralGen.pickSpiralImage() === '',
+      'and pickSpiralImage() (exec/bubbles.js‘s flick) goes through the same pool');
   }
 
   // ------------------------------------------------------------ spiral renders
@@ -488,8 +637,20 @@ async function main() {
     await sleep(120);
     const panes = byId.get('gg-fx-spiral').findAll('gg-spiral');
     ok(panes.length === 1, 'spiral payload mounts exactly one pane', String(panes.length));
-    ok(String(panes[0].style.getPropertyValue('background-image')).includes('/dtrh/assets/bubbles/effects/spirals/'),
-      'the pane draws a bundled DtRH spiral', panes[0].style.getPropertyValue('background-image'));
+    // NO background-image on this host: the stub has no 2D canvas, so the bake
+    // returns '' and the renderer must leave the property alone rather than
+    // write `url('')` and blank a bed that was working. What it DOES write, on
+    // every host, is the roll's own spin — which is the pin that a variant
+    // actually reached the pane.
+    ok(!String(panes[0].style.getPropertyValue('background-image')).trim(),
+      'a host that cannot bake a still gets no background-image, not url(\'\')',
+      panes[0].style.getPropertyValue('background-image'));
+    const spin = parseFloat(panes[0].style.getPropertyValue('--gg-spiral-spin'));
+    ok(spin >= 10 && spin <= 18, 'the pane spins at the generated variant‘s own 10-18s revolution',
+      panes[0].style.getPropertyValue('--gg-spiral-spin'));
+    ok(/^(normal|reverse)$/.test(panes[0].style.getPropertyValue('--gg-spiral-dir')),
+      'and turns the way that variant was rolled to turn',
+      panes[0].style.getPropertyValue('--gg-spiral-dir'));
     const op = parseFloat(panes[0].style.getPropertyValue('--gg-spiral-op'));
     ok(op >= 0.25 && op <= 0.7, 'spiral opacity stays inside the 0.25..0.70 band', String(op));
 
@@ -3287,7 +3448,15 @@ async function main() {
       const el = realCreate(tag);
       if (String(tag).toLowerCase() === 'canvas') {
         el.width = 0; el.height = 0;
-        el.getContext = () => { contexts++; lastGl = fakeGl(el); return lastGl; };
+        // THE FAKE IS A GPU, NOT A CANVAS. '2d' is answered with null on
+        // purpose: exec/spiralGen.js's raster bake asks for a 2D context on its
+        // own scratch canvas, and handing it this object would both count a
+        // context this block never asked for and move `lastGl` off the weave
+        // that the loss tests below are about to kill.
+        el.getContext = (type) => {
+          if (String(type) === '2d') return null;
+          contexts++; lastGl = fakeGl(el); return lastGl;
+        };
       }
       return el;
     };
@@ -3326,8 +3495,17 @@ async function main() {
       ok(inlineOf('filter') === '' && inlineOf('scale') === '' && inlineOf('animation') === '',
         'shaders off: no inline overrides, so fx.css paints its blur(1.1px) + overscan + spin',
         `filter="${inlineOf('filter')}" scale="${inlineOf('scale')}"`);
-      ok(String(inlineOf('background-image')).includes('/dtrh/assets/bubbles/effects/spirals/'),
-        'shaders off: and a bundled spiral is what is actually on screen', inlineOf('background-image'));
+      // The variant reached the pane: its solved revolution and its rolled
+      // direction are on it. (The baked PNG is not — this fake GPU refuses a 2D
+      // context, which is exactly the "cannot bake" host, and the renderer must
+      // leave background-image alone rather than write url('').)
+      const spin = parseFloat(inlineOf('--gg-spiral-spin'));
+      ok(spin >= 10 && spin <= 18,
+        'shaders off: a GENERATED variant is on the pane, spinning at its own solved rate',
+        inlineOf('--gg-spiral-spin'));
+      ok(!String(inlineOf('background-image')).trim(),
+        'shaders off: and a host that cannot bake a still writes no background-image at all',
+        inlineOf('background-image'));
       sp.stop();
     }
 
@@ -3381,8 +3559,15 @@ async function main() {
       ok(inlineOf('scale') === '' && inlineOf('filter') === '' && inlineOf('animation') === '',
         'ALL THREE inline cancels are handed back — a leftover filter:none would be a magnified, UNBLURRED, still raster',
         `scale="${inlineOf('scale')}" filter="${inlineOf('filter')}" animation="${inlineOf('animation')}"`);
-      ok(String(inlineOf('background-image')).includes('/dtrh/assets/bubbles/effects/spirals/'),
-        'with the pool image already underneath it — the swap is one property removal', inlineOf('background-image'));
+      // The still underneath is the SAME roll the shader was weaving, so the
+      // swap is a change of renderer, not of picture. It cannot be asserted by
+      // its pixels here (this fake GPU refuses a 2D context, so nothing baked);
+      // what IS asserted is that the pane kept the variant's spin, which is
+      // what the CSS keyframe now needs to turn that still at the right rate.
+      const spin = parseFloat(inlineOf('--gg-spiral-spin'));
+      ok(spin >= 10 && spin <= 18,
+        'and the surviving pane keeps the variant‘s own revolution for the CSS spin to use',
+        inlineOf('--gg-spiral-spin'));
       ok(cv.width === 1 && cv.height === 1,
         'the dead canvas is shrunk to 1x1: an antenna for the restore, not a retained backing store',
         `${cv.width}x${cv.height}`);
@@ -4297,6 +4482,75 @@ async function main() {
       ok(typeof v.release === 'function', 'release() exists and is the no-op the disk backend wants');
       store.dispose();
     }
+  }
+
+  /* =========================================================================
+   * THE SPIRAL BED ON A HOST THAT CAN ACTUALLY BAKE.
+   *
+   * Every spiral check above ran on the bare stub, which has no 2D context —
+   * the "cannot bake" host, where the renderer must write no background-image
+   * at all. This block gives it one and pins the other half: a real pane gets
+   * a GENERATED still, as a data URL, and it lands ONE TICK LATE on purpose
+   * (~1600 path fills plus a PNG encode is not something to do inside the frame
+   * a cue lands on).
+   *
+   * IT RUNS LAST, AND THAT IS DELIBERATE. exec/spiralGen.js caches one scratch
+   * canvas per size for the life of the page; handing it a working 2D context
+   * earlier would leave every later block able to bake, and the freeze-defence
+   * block above depends on being the machine that cannot.
+   * ======================================================================= */
+  {
+    const SP = await import('../exec/spiral.js');
+    const realCreate = document.createElement;
+    let encodes = 0;
+    document.createElement = (tag) => {
+      const el = realCreate(tag);
+      if (String(tag).toLowerCase() === 'canvas') {
+        el.width = 0; el.height = 0;
+        el.getContext = (type) => (String(type) === '2d' ? {
+          fillStyle: null,
+          fillRect() {}, beginPath() {}, closePath() {}, lineTo() {}, arc() {}, fill() {},
+          createRadialGradient: () => ({ addColorStop() {} }),
+        } : null);
+        el.toDataURL = () => { encodes++; return 'data:image/png;base64,SPIRAL'; };
+      }
+      return el;
+    };
+
+    const spiralLayer = byId.get('gg-fx-spiral');
+    spiralLayer.replaceChildren();
+    const sp = SP.createSpiral({ layers, media: fakeMedia(), audio: { sfx() {} }, logger: quiet });
+    sp.start({ element: GoonElement.Spiral, intensity: 0.5, durationMs: 0, elapsedMs: 0 });
+    const pane = spiralLayer.findAll('gg-spiral')[0] || null;
+    ok(!!pane, 'the bed mounts on a bakeable host too');
+    const bgAtOnce = pane ? pane.style.getPropertyValue('background-image') : '(no pane)';
+    ok(!String(bgAtOnce).trim(),
+      'the bake does NOT happen inside the cue‘s own frame — the pane fades in over 450ms, the encode can wait a tick',
+      bgAtOnce);
+    await sleep(30);
+    const bg = pane ? pane.style.getPropertyValue('background-image') : '(no pane)';
+    ok(/^url\("data:image\/png;base64,/.test(String(bg)),
+      'a tick later the pane is wearing a GENERATED still — no file, no network, no bundled asset', String(bg));
+    ok(encodes >= 1, 'and it came from a real canvas encode', String(encodes));
+
+    // Rotation: a second cue must swap in a DIFFERENT variant, and the pane's
+    // spin must follow it (each roll carries its own solved revolution).
+    const firstSpin = pane.style.getPropertyValue('--gg-spiral-spin');
+    let spins = new Set([firstSpin]);
+    for (let i = 0; i < 8; i++) {
+      sp.stop();
+      sp.start({ element: GoonElement.Spiral, intensity: 0.5, durationMs: 0, elapsedMs: 0 });
+      const p = spiralLayer.findAll('gg-spiral').slice(-1)[0];
+      if (p) spins.add(p.style.getPropertyValue('--gg-spiral-spin'));
+    }
+    ok(spins.size > 1, 'consecutive cues rotate through the session‘s variants, they do not re-show one',
+      Array.from(spins).join(' '));
+    // One check, not one per spin: the set's size is a roll of the dice and a
+    // suite whose CHECK COUNT moves between runs is a suite nobody can diff.
+    const outOfBand = Array.from(spins).filter((s) => !(parseFloat(s) >= 10 && parseFloat(s) <= 18));
+    ok(outOfBand.length === 0, 'and every one of them spins inside the 10-18s band', outOfBand.join(' '));
+    sp.stop();
+    document.createElement = realCreate;
   }
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);

--- a/ConditioningControlPanel/Resources/web/goon/ui/options.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/options.js
@@ -162,8 +162,9 @@ export function createOptions({ prefs, audio = null, session = null, setFullscre
     /* SHADER SPIRALS — the freeze escape hatch, and it is offered mid-match for
      * the same reason skippable videos is: the moment a player wants it is the
      * moment the picture has stopped moving. Default ON (it is the good bed);
-     * off, exec/spiral.js drops to the bundled spiral pool within a second and
-     * stays there for the life of the pane. Same chain as the toggle above —
+     * off, exec/spiral.js drops to a baked still of the same generated spiral
+     * within a second and stays there for the life of the pane. Same chain as
+     * the toggle above —
      * prefs writes <html data-gg-shader> and exec/ reads it there, because exec/
      * never imports ui/. */
     const shaders = toggleRow(S.options.shaderSpirals,

--- a/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
@@ -62,8 +62,9 @@ export const PREF_DEFAULTS = Object.freeze({
   skippableVideos: false,
   /**
    * The spiral bed is drawn live on the GPU (exec/spiralField.js). ON by default
-   * — it is the good path, and the raster pool it falls back to is a magnified,
-   * dithered GIF. This exists as an ESCAPE HATCH: on 2026-08-04 a session froze
+   * — it is the good path; off, the pane shows a still PNG of the SAME generated
+   * spiral (baked by exec/spiralGen.js), spun by a CSS keyframe. This exists as an
+   * ESCAPE HATCH: on 2026-08-04 a session froze
    * visually while its script kept running (a compositor/GPU stall, no crash),
    * and the shader pane is the only GPU context the duel owns. Off, exec/spiral.js
    * takes the raster path from the start and drops any live weave within a second.
@@ -359,7 +360,8 @@ const MEDIA_SPEC = {
 const REFLECT = Object.freeze({
   /** exec/videos.js reads this to decide whether a window's ✕ is real. */
   skippableVideos: { attr: 'data-gg-vskip', on: 'on', off: 'off' },
-  /** exec/spiral.js reads this to decide whether the bed is a shader or a GIF.
+  /** exec/spiral.js reads this to decide whether the bed is a live shader or a
+   *  spun still of the same generated spiral.
    *  Note the polarity: absent means ON there (a page with no prefs store still
    *  gets the good path), so it is the OFF value that carries the meaning. */
   shaderSpirals: { attr: 'data-gg-shader', on: 'on', off: 'off' },


### PR DESCRIPTION
Replaces the goon Spiral bed's six baked gifs + six hand-authored WebGL presets with a ported Loom generator (`exec/spiralGen.js`): 5 randomized variants pre-generated per duel, rotated with no back-to-back repeats, no dot/cross centerpieces by construction. DtRH's own copies of the assets are untouched (it still uses them). selftest-exec 958 green; all suites pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAgZYfCffPA4vHvWDVAxQ