### PR TITLE
fix(goon): the opponent monitor is actually draggable now

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -5015,8 +5015,13 @@ const audioMod = await import('../ui/audio.js');
     return { get: (k) => v[k], set: (k, x) => { v[k] = x; return true; }, _v: v };
   };
   const PID = 4200;
-  const ptr = (node, type, x, y) => {
+  /** `target` is a fifth argument on purpose: an event WITHOUT one is a press
+   *  dispatched straight AT a node, i.e. the suite naming the surface it means
+   *  rather than a hit test. One with a target is the browser's version, and it
+   *  is what the docked grab surface is decided by. */
+  const ptr = (node, type, x, y, target) => {
     const e = { type, button: 0, pointerId: PID, clientX: x, clientY: y, preventDefault() {}, stopPropagation() {} };
+    if (target) e.target = target;
     if (node && node.dispatchEvent) node.dispatchEvent(e);
     return e;
   };
@@ -5043,6 +5048,44 @@ const audioMod = await import('../ui/audio.js');
     ptr(mon.root, 'pointermove', 153, 152);           // 3.6px — inside the slop
     ptr(mon.root, 'pointerup', 153, 152);
     ok(mon.isLoose() === false, 'a sub-slop press does nothing at all — it is not a drag and it is not a click');
+
+    /* THE GRIP. The whole feature shipped unreachable: `#gg-hud > .gg-hud-frame`
+     * is pointer-events:none so the bubble field can be played through the desk,
+     * pointer-events INHERITS, and .gg-mon was not on the allowlist that opts
+     * things back in — so no press ever arrived, so it could never detach, so
+     * the `.is-mon-loose > .gg-mon { pointer-events: auto }` rule that would
+     * have unlocked it never applied. These pins are the closed loop, opened. */
+    ok(!!mon.grip, 'the monitor exposes a GRIP — the strip a docked card can actually be touched by');
+    ok(hasClass(mon.grip, O.MON_GRIP_CLASS) && hasClass(mon.grip, 'gg-mon-head'),
+      'and it IS the head row, not a bar bolted on above it', mon.grip.className);
+    ok(findAll(mon.root, 'gg-mon-grip-dots').length === 1,
+      'with the six-dot handle in it — nobody drags a thing that does not look draggable');
+    ok(!!mon.grip.getAttribute('title'),
+      '…and a tooltip, because not one of the three gestures is discoverable on its own');
+
+    // a press that came through any OTHER part of the card is not a drag: the
+    // card is transparent so a bubble under it is still poppable, and JS says so
+    // too rather than trusting one line of CSS to hold that line forever
+    ptr(mon.root, 'pointerdown', 150, 150, mon.projection);
+    ptr(mon.root, 'pointermove', 400, 300);
+    ptr(mon.root, 'pointerup', 400, 300);
+    ok(mon.isLoose() === false,
+      'a press that came through the projection rect is NOT a drag — the docked card is field, not handle');
+
+    // …and one through the grip is
+    ptr(mon.grip, 'pointerdown', 150, 150, mon.grip);
+    ptr(mon.grip, 'pointermove', 400, 300, mon.grip);
+    ok(mon.isLoose() === true, 'a drag from the grip takes it off the shelf');
+    ptr(mon.grip, 'pointerup', 400, 300, mon.grip);
+    ok(store._v.monitorX === 350, 'and lands where the grip was dragged to', String(store._v.monitorX));
+
+    // once it is LOOSE the whole card is a handle again — by then it is a window
+    // the player parked, not a row in the column (exec/fx.css's .gg-vwin, same)
+    ptr(mon.root, 'pointerdown', 400, 300, mon.projection);
+    ptr(mon.root, 'pointermove', 600, 400);
+    ok(mon.loosePlacement().x === 550,
+      'and a loose monitor is grabbable anywhere on it, projection rect included', JSON.stringify(mon.loosePlacement()));
+    ptr(mon.root, 'pointerup', 600, 400);
 
     mon.unmount();
   }
@@ -5150,6 +5193,35 @@ const audioMod = await import('../ui/audio.js');
     const before = mon.root.style[O.MON_WIDTH_VAR];
     wheel(mon.root, 0);
     ok(mon.root.style[O.MON_WIDTH_VAR] === before, 'a wheel event with no delta changes nothing');
+
+    /* ONE NOTCH IS ONE STEP. The grip listens and so does the root, and in a
+     * browser the second of those sees the SAME event a moment later, bubbled.
+     * Stepping twice per notch is a resize that runs away under the hand. */
+    for (let i = 0; i < 20; i++) wheel(mon.root, 100);   // back off the ceiling
+    const scale0 = mon.loosePlacement().scale;
+    const one = { type: 'wheel', deltaY: -100, preventDefault() {}, stopPropagation() {} };
+    mon.grip.dispatchEvent(one);
+    mon.root.dispatchEvent(one);
+    ok(Math.abs(mon.loosePlacement().scale - scale0 * O.MON_WHEEL_STEP) < 1e-9,
+      'one wheel event seen by BOTH the grip and the root is still one notch',
+      `${scale0} -> ${mon.loosePlacement().scale}`);
+
+    mon.unmount();
+  }
+
+  /* ---- D2. the wheel can be REACHED on a docked monitor ----------------- */
+  {
+    // The resize died of the same cause the drag did: while docked, the grip is
+    // the only thing on the card a wheel event can possibly land on.
+    const match = makeFakeMatch();
+    const host = document.createElement('div');
+    const mon = O.mountOpponent({ host, match, prefs: prefsOf() });
+    await sleep(50);
+
+    mon.grip.dispatchEvent({ type: 'wheel', deltaY: -100, preventDefault() {}, stopPropagation() {} });
+    ok(mon.isLoose() === true, 'a wheel over the GRIP of a docked monitor detaches and resizes it');
+    ok(mon.root.style[O.MON_WIDTH_VAR] === Math.round(200 * O.MON_WHEEL_STEP) + 'px',
+      'by exactly one notch', String(mon.root.style[O.MON_WIDTH_VAR]));
 
     mon.unmount();
   }
@@ -5285,6 +5357,26 @@ const audioMod = await import('../ui/audio.js');
     ok(/user-select:\s*none/.test(monBlocks), "and the mouse's half of the same claim");
     ok(/cursor:\s*grab/.test(monBlocks), 'and it looks grabbable');
     ok(/\.gg-mon\.is-grabbed\s*\{[^}]*cursor:\s*grabbing/.test(css), 'and held while it is held');
+
+    /* THE ONE THAT WOULD HAVE CAUGHT IT. Everything above was true on the day
+     * the monitor shipped undraggable: the drag was not broken, it was
+     * UNREACHABLE. pointer-events inherits, the desk is none so the bubble field
+     * can be played through it, and only the allowlist near the top of hud.css
+     * opts anything back in. */
+    ok(/#gg-hud\s*>\s*\.gg-hud-frame\s*\{[^}]*pointer-events:\s*none/.test(css),
+      'the desk is transparent to the pointer — the rule every gesture on it has to be let out of');
+    const gripAllow = /\.gg-hud-frame\s+\.gg-mon-grip[^{]*\{([^}]*)\}/.exec(css);
+    ok(!!gripAllow && /pointer-events:\s*auto/.test(gripAllow[1]),
+      'and the grip is on the allowlist that lets it out — without this line the drag, the wheel and the reset are all dead');
+    ok(!/\.gg-hud-frame\s+\.gg-mon\s*[,{]/.test(css),
+      'the CARD deliberately is not: it sits over the stage, and a card that took clicks would eat every bubble pop under it');
+
+    const gripBlock = blockOf('.gg-mon-grip');
+    ok(/touch-action:\s*none/.test(gripBlock),
+      "the grip claims the finger too, or the first 6px of a phone drag is a page pan", gripBlock);
+    ok(/cursor:\s*grab/.test(gripBlock), 'and it looks like what it is');
+    ok(/\.gg-mon\.is-grabbed\s+\.gg-mon-grip\s*\{[^}]*cursor:\s*grabbing/.test(css),
+      'and like a held one while it is held');
 
     ok(/\.gg-mon-host\.is-mon-loose\s*\{[^}]*pointer-events:\s*none/.test(css),
       'the placeholder it leaves behind is an empty box that stops taking clicks');

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -72,11 +72,17 @@
 .gg-hud-top,
 .gg-hud-body,
 .gg-hud-bottom { min-width: 0; }
+/* THE ALLOWLIST. `pointer-events` is INHERITED, so the `none` above reaches
+   every descendant of the frame and this is the complete list of things on the
+   desk a pointer can touch. A control that is not on it is invisible to the
+   mouse no matter what its own JS listens for — which is exactly how the
+   opponent monitor shipped undraggable (see .gg-mon-grip below). */
 .gg-hud-frame button,
 .gg-hud-frame .gg-plate,
 .gg-hud-frame .gg-item,
 .gg-hud-frame .gg-dial,
 .gg-hud-frame .gg-emotes,
+.gg-hud-frame .gg-mon-grip,
 .gg-hud-frame .gg-att-token { pointer-events: auto; }
 
 /* Sudden death contracts the desk: rails, monitor and dial step aside. */
@@ -915,6 +921,58 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   animation: none;
 }
 .gg-mon.is-grabbed { cursor: grabbing; }
+
+/* 5. THE GRIP — and the bug it exists to fix (owner, 2026-08-04 round 2: "the
+ *    opponent monitor cannot be moved").
+ *
+ *    Rule 1 above says the grab surface is the whole card. It was not, and it
+ *    could not be: `#gg-hud > .gg-hud-frame { pointer-events: none }` at the top
+ *    of this file makes the entire desk transparent so the bubble field can be
+ *    played through it, `pointer-events` inherits, and .gg-mon was not on the
+ *    allowlist that opts things back in. No pointerdown ever reached the
+ *    monitor, so it could never detach — and `.gg-mon-host.is-mon-loose >
+ *    .gg-mon { pointer-events: auto }` below, the rule that would have made it
+ *    grabbable, only applies AFTER a detach that could not happen. The drag, the
+ *    wheel and the double-tap reset were all dead behind one inherited keyword.
+ *
+ *    Putting .gg-mon on the allowlist would have fixed the drag and broken the
+ *    game: the monitor sits over the top-right of the stage, bubbles drift under
+ *    it, and a card that takes clicks eats every pop in that corner (the arsenal
+ *    learned this the same way — see IT MAY NOT EAT THE FIELD). So the CARD stays
+ *    transparent and the HEAD ROW becomes a titlebar. It is ~20px of a 280px
+ *    card, it contains nothing interactive, and it is the whole cost.
+ *
+ *    Once the monitor is LOOSE the card takes pointers anyway (the is-mon-loose
+ *    rule below) and the grip stops being the only way in — by then it is a
+ *    floating window the player parked on purpose, and exec/fx.css's .gg-vwin is
+ *    grabbable all over for the same reason. */
+.gg-mon-grip {
+  cursor: grab;
+  touch-action: none;              /* a finger's first 6px is ours, not a page pan */
+  min-height: 20px;
+  padding: 2px 0;
+  /* VERTICAL ONLY. A negative inline margin would make the titlebar wider than
+     the card it sits on, and this column is the right-hand EDGE of the desk —
+     4px of overflow there is 4px off the screen on a phone. */
+  margin: -2px 0;
+  border-radius: 7px;
+  transition: background .18s ease;
+}
+.gg-mon-grip:hover { background: rgba(var(--gg-pink-rgb), 0.1); }
+.gg-mon.is-grabbed .gg-mon-grip { cursor: grabbing; }
+/* the affordance: six dots, the universal "this is a handle". Flex-frozen so it
+   never gives the name row its width back under pressure. */
+.gg-mon-grip-dots {
+  flex: 0 0 auto;
+  width: 9px; height: 13px;
+  background-image: radial-gradient(circle, rgba(var(--gg-pink-rgb), 0.85) 1px, transparent 1.3px);
+  background-size: 4.5px 4.5px;
+  background-position: center;
+  opacity: 0.5;
+  transition: opacity .18s ease;
+}
+.gg-mon-grip:hover .gg-mon-grip-dots,
+.gg-mon.is-loose .gg-mon-grip-dots { opacity: 1; }
 /* THE HOLE IT LEFT. ui/opponent.js writes a measured `min-height` on this host
    so the receipts under it do not jump up the frame the monitor detaches. The
    placeholder is an empty box over the desk, so it stops taking clicks — and the
@@ -2087,6 +2145,13 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   /* the head row of a 190px monitor: the name gives way, the score and the
      charge pips never do */
   .gg-mon-name { max-width: 100%; }
+  /* …and the grip, which is that same row, has to survive the squeeze AND be a
+     finger target: 26px is the whole drag surface on a phone, where there is no
+     wheel and no hover to find it with. The dots narrow rather than leave —
+     they are the only thing that says the row can be dragged at all. */
+  .gg-mon-head { gap: 0.3rem; }
+  .gg-mon-grip { min-height: 26px; }
+  .gg-mon-grip-dots { width: 7px; background-size: 3.5px 4.5px; }
   .gg-mon-att-label { font-size: 0.6rem; }
   /* a receipt is right-aligned in a 190px column, so a long one has to wrap
      rather than reach back across the stage */

--- a/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
@@ -216,6 +216,35 @@ const MAX_WINDOW_MS = 180000;
  *   · desktop-only, deliberately. A phone has no wheel and this is not worth a
  *     pinch: the drag alone already works there through pointer events.
  *
+ * THE GRIP, AND WHY IT HAD TO EXIST (owner, 2026-08-04 round 2: "the opponent
+ * monitor cannot be moved"). The first cut of this listened on .gg-mon itself,
+ * and NO POINTERDOWN EVER ARRIVED. #gg-hud > .gg-hud-frame is `pointer-events:
+ * none` (hud.css) so the desk chrome does not swallow the clicks the bubble
+ * field is played with, and every hittable thing on it is named in one small
+ * allowlist — `button`, .gg-plate, .gg-item, .gg-dial, .gg-emotes,
+ * .gg-att-token. .gg-mon was not on it. The one rule that WOULD have made the
+ * monitor hittable, `.gg-mon-host.is-mon-loose > .gg-mon`, only applies once it
+ * has detached — and it could never detach, because detaching needs the press
+ * that pointer-events:none was eating. A closed loop, and the tests could not
+ * see it: they dispatch straight at the node, where no CSS exists.
+ *
+ * The fix is NOT "make the whole card hittable". That is the law this desk is
+ * built on (hud.css, THE ARSENAL SIDEBAR rule 1: it may not eat the field) —
+ * the monitor sits over the top-right of the stage and bubbles drift under it,
+ * so a card that took clicks would silently swallow pops in that corner. So the
+ * card keeps its transparency and the HEAD ROW becomes a titlebar: one small
+ * strip, `pointer-events: auto`, with a visible grip. Everything else follows
+ * from that —
+ *   · DOCKED, the grip is the only way in (and the only thing the wheel can
+ *     find, which is why the resize was dead too);
+ *   · LOOSE, the whole card is grabbable, because a floating window the player
+ *     has deliberately parked is a window, not desk chrome — that is the
+ *     existing .gg-mon-host.is-mon-loose rule and exec/fx.css's .gg-vwin doing
+ *     the same thing;
+ *   · the CAPTURE TARGET is whichever of the two the press came through, never
+ *     blindly the root: capturing on a pointer-events:none element is exactly
+ *     the kind of thing that works in one engine and not the next.
+ *
  * AND THE ONE THING THE GIFS DID NOT HAVE TO SOLVE: the monitor is a ROW IN A
  * COLUMN. A floating window is born detached; this starts life in the HUD's
  * right-hand column and only leaves it when the player asks. See DETACH-ON-
@@ -246,6 +275,9 @@ export const MON_WIDTH_VAR = '--gg-mon-loose-w';
 /** On .gg-mon while it is detached; on .gg-mon while it is in hand. */
 export const MON_LOOSE_CLASS = 'is-loose';
 export const MON_GRABBED_CLASS = 'is-grabbed';
+/** The titlebar. Rides the head row, and is the ONE part of a docked monitor
+ *  hud.css lets the pointer reach — see THE GRIP above. */
+export const MON_GRIP_CLASS = 'gg-mon-grip';
 /** On the HOST element ui/hud.js hands us, while it is holding the column open. */
 export const MON_HOST_LOOSE_CLASS = 'is-mon-loose';
 
@@ -404,14 +436,23 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
   if (!root || !host) {
     return {
       unmount() { led.run(); },
-      root: null, dropTarget: null,
+      root: null, dropTarget: null, grip: null,
       showEmote() {}, markEmoteFired() { return false; },
       isLoose() { return false; }, loosePlacement() { return null; }, redock() { return false; },
     };
   }
 
-  // ---- head: name · connection dot · their score · charge pips ------------
-  const head = add(root, el('div', 'gg-mon-head'));
+  // ---- head: grip · connection dot · name · their score · charge pips -----
+  // The head row is ALSO the titlebar (MON_GRIP_CLASS, see THE GRIP above): on a
+  // docked monitor it is the only strip hud.css lets the pointer reach, so it is
+  // where the drag and the wheel both have to start. Nothing in it is
+  // interactive — a dot, two words and five pips — which is exactly why it is
+  // safe to claim the whole row rather than a corner of it.
+  const head = add(root, el('div', 'gg-mon-head ' + MON_GRIP_CLASS));
+  if (head && head.setAttribute) head.setAttribute('title', S.monitor.dragHint);
+  // …and the affordance, first in the row: nobody drags a thing that does not
+  // look draggable, which is half of why this went unnoticed for a whole batch.
+  add(head, el('i', 'gg-mon-grip-dots'));
   const dot = add(head, el('i', 'gg-mon-dot'));
   const nameEl = add(head, el('span', 'gg-mon-name', 'opponent'));
   const scoreEl = add(head, el('span', 'gg-mon-score', '0'));
@@ -1136,6 +1177,8 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
   let grab = null;
   /** Sub-slop taps: two inside MON_RESET_TAP_MS re-dock. */
   let lastTapAt = -Infinity;
+  /** The last wheel event OBJECT, so one notch seen twice is still one notch. */
+  let lastWheelEvent = null;
 
   const winRef = (typeof window !== 'undefined' && window) ? window : null;
   const vpW = () => { const v = winRef ? Number(winRef.innerWidth) : 0; return v > 0 ? v : 1280; };
@@ -1243,18 +1286,39 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
 
   /* ------------------------------------------------------------- the press */
 
+  /**
+   * The move/up/cancel listeners go on BOTH the surface the press came through
+   * and the root, and that is not belt-and-braces — it is the only arrangement
+   * that is correct in a browser AND legible to a test. In a browser the grip is
+   * a CHILD of the root, so a captured event fires the grip's handler and then
+   * bubbles into the root's; the handlers are idempotent by construction (a move
+   * recomputes the same absolute position from the same anchor, and the second
+   * endGrab finds no grab and returns), so the duplicate costs nothing. In the
+   * node suite, where nothing bubbles, it means a press dispatched at either
+   * node is a press either way.
+   */
+  function grabNodes(g) {
+    const out = [root];
+    if (g && g.surface && g.surface !== root) out.push(g.surface);
+    return out;
+  }
+
   function forgetGrab() {
     if (!grab) return;
     const g = grab;
     grab = null;
     try { clearTimeout(g.watchdog); } catch (_e) { /* gone */ }
-    if (typeof root.removeEventListener === 'function') {
+    for (const n of grabNodes(g)) {
+      if (!n || typeof n.removeEventListener !== 'function') continue;
       try {
-        root.removeEventListener('pointermove', onMonMove);
-        root.removeEventListener('pointerup', onMonUp);
-        root.removeEventListener('pointercancel', onMonCancel);
-        root.removeEventListener('lostpointercapture', onMonCancel);
+        n.removeEventListener('pointermove', onMonMove);
+        n.removeEventListener('pointerup', onMonUp);
+        n.removeEventListener('pointercancel', onMonCancel);
+        n.removeEventListener('lostpointercapture', onMonCancel);
       } catch (_e) { /* stub DOM */ }
+    }
+    if (g.surface && typeof g.surface.releasePointerCapture === 'function' && g.pointerId != null) {
+      try { g.surface.releasePointerCapture(g.pointerId); } catch (_e) { /* never had it */ }
     }
   }
 
@@ -1281,30 +1345,58 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     if (why === 'up') persistLoose();
   }
 
-  function onMonDown(e) {
+  /**
+   * WHERE A DRAG IS ALLOWED TO START. Docked, only the grip: the rest of the
+   * card is transparent to the bubble field behind it and must stay a place
+   * where a pop lands, not a place where the monitor moves. Loose, anywhere on
+   * it — by then it is a floating window the player put there on purpose.
+   *
+   * An event with NO target is one dispatched straight at a node (the node
+   * suite, a driver): there is nothing to test, and the caller has already said
+   * which node it means by choosing it.
+   */
+  function fromGrip(e) {
+    if (loose) return true;
+    const t = e && e.target;
+    if (!t || !head || typeof head.contains !== 'function') return true;
+    try { return head.contains(t); } catch (_e) { return true; }
+  }
+
+  function onMonDown(e, surface) {
     // A right press is not a drag, and swallowing it here is how a browser gets
     // talked out of its own context menu — which this element does not want to
     // be in the business of suppressing.
     if (e && e.button != null && e.button !== 0) return;
+    const pid = (e && e.pointerId != null) ? e.pointerId : null;
+    // The SAME press, seen twice: the grip's handler ran and the event then
+    // bubbled into the root's. One press is one grab, and the first one wins —
+    // it is the one holding the capture.
+    if (grab && grab.pointerId === pid) return;
     if (grab) endGrab('restart');
     const x = ptX(e), y = ptY(e);
     grab = {
-      pointerId: (e && e.pointerId != null) ? e.pointerId : null,
+      pointerId: pid,
+      surface: surface || root,
       x0: x, y0: y, baseX: 0, baseY: 0, moved: false, watchdog: 0,
     };
-    if (typeof root.addEventListener === 'function') {
+    for (const n of grabNodes(grab)) {
+      if (!n || typeof n.addEventListener !== 'function') continue;
       try {
-        root.addEventListener('pointermove', onMonMove);
-        root.addEventListener('pointerup', onMonUp);
-        root.addEventListener('pointercancel', onMonCancel);
-        root.addEventListener('lostpointercapture', onMonCancel);
+        n.addEventListener('pointermove', onMonMove);
+        n.addEventListener('pointerup', onMonUp);
+        n.addEventListener('pointercancel', onMonCancel);
+        n.addEventListener('lostpointercapture', onMonCancel);
       } catch (_e) { /* stub DOM */ }
     }
     if (typeof setTimeout === 'function') {
       grab.watchdog = setTimeout(() => { if (grab) endGrab('watchdog'); }, MON_HOLD_WATCHDOG_MS);
     }
+    // Capture on the element the press actually came through — the grip while
+    // docked, since the root is pointer-events:none there and an engine is
+    // within its rights to route nothing to it.
     try {
-      if (typeof root.setPointerCapture === 'function' && e && e.pointerId != null) root.setPointerCapture(e.pointerId);
+      const cap = grab.surface;
+      if (cap && typeof cap.setPointerCapture === 'function' && pid != null) cap.setPointerCapture(pid);
     } catch (_e) { /* capture is a nicety; the node listeners still work without it */ }
   }
 
@@ -1355,6 +1447,11 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
    * reflow the whole right-hand side of the desk.
    */
   function onMonWheel(e) {
+    // One notch is one step: the grip's handler and the root's both see the
+    // same event once it bubbles, and two steps per notch is a resize that
+    // runs away under the hand.
+    if (e && e === lastWheelEvent) return;
+    lastWheelEvent = e;
     const dy = Number(e && e.deltaY) || 0;
     if (!dy) return;
     if (e && typeof e.preventDefault === 'function') e.preventDefault();   // the page never scrolls
@@ -1369,9 +1466,16 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     persistLoose();
   }
 
-  led.listen(root, 'pointerdown', onMonDown);
+  /* THE TWO WAYS IN. The grip is the one a DOCKED monitor can actually be
+   * reached through (hud.css hands it `pointer-events: auto` and hands the card
+   * nothing); the root is the one a LOOSE monitor is grabbed anywhere by, and it
+   * is guarded so it can never quietly become a second docked grab surface if
+   * somebody widens the CSS later. Both land in the same handler. */
+  led.listen(head, 'pointerdown', (e) => onMonDown(e, head));
+  led.listen(root, 'pointerdown', (e) => { if (fromGrip(e)) onMonDown(e, root); });
   // passive:false or the preventDefault above is ignored and the page scrolls.
-  led.listen(root, 'wheel', onMonWheel, { passive: false });
+  led.listen(head, 'wheel', onMonWheel, { passive: false });
+  led.listen(root, 'wheel', (e) => { if (fromGrip(e)) onMonWheel(e); }, { passive: false });
   // The viewport changed under a parked monitor: same two rules, re-applied. The
   // width is re-DERIVED from the scale rather than kept in px, so a monitor at
   // 1.5x is 1.5x of the new --gg-mon-w and not a stale pixel count.
@@ -1409,6 +1513,8 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     dropTarget: frame,
     /** The projection rect — exposed so a play-test driver can find the minis. */
     projection: proj,
+    /** The titlebar: the only part of a DOCKED monitor a pointer can reach. */
+    grip: head,
     /** Detached from the HUD column? selftest-hud and the play-test driver pin these. */
     isLoose: () => !!loose,
     loosePlacement: () => (loose ? { x: loose.x, y: loose.y, scale: loose.scale } : null),

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -808,6 +808,9 @@ export const S = Object.freeze({
     dropHint: 'drop it here',
     /** The green checkmark on their projection: they took the whole payload. */
     passed: 'they held it',
+    /** The titlebar's tooltip. All three gestures, because not one of them is
+     *  discoverable and the grip dots only ever promise the first. */
+    dragHint: 'drag to move · wheel to resize · double-tap to put it back',
   },
 
   /* ---------------------------------------------- the announcer ribbon (ui/announcer.js)


### PR DESCRIPTION
The batch-7 drag code existed but was unreachable: the HUD frame is pointer-transparent (so bubbles stay poppable through it) and the monitor was never on the pointer-events allowlist. The head row is now a grip titlebar (drag from grip while docked, anywhere while loose, wheel resize, double-tap redock), the play field stays poppable underneath, and position/scale persist via the existing prefs. selftest-hud 1382 green (+17 pins); build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAgZYfCffPA4vHvWDVAxQ