### PR TITLE
feat(goon): visible incoming-throw fx for every payload kind

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4901,6 +4901,154 @@ const audioMod = await import('../ui/audio.js');
     await sleep(THROW_MS + 140);
   }
 
+  /* --- EVERY KIND, AND EVERY KIND AS ITSELF (owner, 2026-08-05: "flashes and
+   * videos show the little incoming throw, the other kinds do not").
+   *
+   * markInbound was never kind-gated and these checks say so out loud. What the
+   * other six kinds lacked was anything to SHOW: their only pixels were a
+   * ~650 KB item cutout whose fetch began when the projectile did, so what flew
+   * was an empty box. The glyph is the fix — text, frame one, no network — and
+   * the warm is the other half: the fetch now starts at ACCEPT, inside the lead
+   * the engine already reserved. */
+  {
+    const announcerMod = await import('../ui/announcer.js');
+    const kinds = Object.keys(GoonPayloadKind).map((k) => GoonPayloadKind[k]);
+    ok(kinds.length === 8, 'the wire has eight payload kinds', String(kinds.length));
+
+    // The mark table is COMPLETE. A ninth wire code must fail HERE, in the
+    // suite, and not as an invisible projectile in somebody's duel.
+    for (const kind of kinds) {
+      const m = previewMod.THROW_MARK[kind];
+      ok(!!m && typeof m.glyph === 'string' && m.glyph.length > 0,
+        `payload kind ${kind} has a glyph of its own`);
+      ok(!!m && /^\d{1,3}, \d{1,3}, \d{1,3}$/.test(String(m && m.tint)),
+        `…and an rgb triple for its tint`, String(m && m.tint));
+    }
+    // …and the glyphs are the vocabulary the ribbon and the rail chips already
+    // speak, not a fourth private alphabet. (Bubbles is never announced, so the
+    // ribbon has no glyph to compare against for BubbleSwarm.)
+    for (const kind of kinds) {
+      const element = announcerMod.PAYLOAD_ANNOUNCE_ELEMENT[kind];
+      const want = announcerMod.ANNOUNCE_GLYPH[element];
+      if (!want) continue;
+      ok(previewMod.markFor(kind).glyph === want,
+        `kind ${kind} flies under the same glyph the announcer names it with`,
+        previewMod.markFor(kind).glyph + ' vs ' + want);
+    }
+    ok(previewMod.markFor(9999) === previewMod.DEFAULT_THROW_MARK,
+      'a kind from a newer peer still throws something you can see');
+
+    const match = makeFakeMatch();
+    const host = document.createElement('div');
+    const mon = opponentMod.mountOpponent({ host, match });
+
+    const hitsBefore = findAll(document.body, 'gg-throw-hit').length;
+    for (const kind of kinds) {
+      ok(mon.markInbound({ kind, waitMs: 0 }) === true, `kind ${kind} is thrown at us`);
+      const flies = findAll(document.body, 'gg-throw');
+      const fly = flies[flies.length - 1];
+      ok(!!fly, `kind ${kind} put a projectile on the page`);
+      const mark = fly && findOne(fly, 'gg-throw-mark');
+      ok(!!mark && mark.textContent === previewMod.markFor(kind).glyph,
+        `…carrying its own glyph, which needs no network to be visible (kind ${kind})`,
+        mark ? mark.textContent : 'none');
+      ok(!!fly && String(fly.style['--gg-throw-tint'] || '') === previewMod.markFor(kind).tint,
+        `…and its own tint, which themes the flare, the glow and the splash (kind ${kind})`,
+        fly ? String(fly.style['--gg-throw-tint']) : 'none');
+      ok(!!fly && fly.getAttribute('data-gg-kind') === String(kind),
+        `…and says which kind it is (kind ${kind})`);
+      const art = fly && findOne(fly, 'gg-throw-art');
+      ok(!!art && /item_[a-z]+\.png/.test(String(art.style['--gg-throw-sticker'] || '')),
+        `…with the cutout queued behind it (kind ${kind})`);
+      ok(!hasClass(fly, 'is-art'),
+        `…but NOT revealed, because it has not decoded — that hole was the bug (kind ${kind})`);
+    }
+    ok(hasClass(mon.root, 'is-throwing') && String(mon.root.style['--gg-throw-tint'] || '')
+      === previewMod.markFor(kinds[kinds.length - 1]).tint,
+      'their monitor flares in the colour of the thing it just threw');
+
+    await sleep(THROW_MIN_MS + 160);
+    const hits = findAll(document.body, 'gg-throw-hit');
+    ok(hits.length - hitsBefore === kinds.length,
+      'all eight land — the impact cue is not a two-kind feature either',
+      String(hits.length - hitsBefore));
+    const firstHit = hits[hitsBefore];
+    ok(!!firstHit && String(firstHit.style['--gg-throw-tint'] || '') === previewMod.markFor(kinds[0]).tint,
+      'and the splash wears the same colour the projectile did');
+
+    // THE WORD: the two payloads that ARE text arrive with their text.
+    ok(previewMod.throwWord(GoonPayloadKind.Video, { text: 'nope' }) === '',
+      'a kind whose payload is not text never grows a caption');
+    ok(previewMod.throwWord(GoonPayloadKind.LockCard, { text: '  good   girls\ndrift  ' }) === 'good girls drift',
+      'the caption is collapsed remote text, never a line break in a pill');
+    const longWord = previewMod.throwWord(GoonPayloadKind.SubliminalStorm, { text: 'z'.repeat(120) });
+    ok(longWord.length === previewMod.THROW_WORD_MAX && /…$/.test(longWord),
+      'a wall of text is clamped to a glance', String(longWord.length));
+    ok(previewMod.throwWord(GoonPayloadKind.LockCard, null) === ''
+      && previewMod.throwWord(GoonPayloadKind.LockCard, { text: String.fromCharCode(7, 0) }) === '',
+      'and control characters alone are not a caption');
+    {
+      mon.markInbound({ kind: GoonPayloadKind.LockCard, waitMs: 0, payload: { text: 'say it out loud' } });
+      const flies = findAll(document.body, 'gg-throw');
+      const fly = flies[flies.length - 1];
+      const word = fly && findOne(fly, 'gg-throw-word');
+      ok(!!word && word.textContent === 'say it out loud',
+        'a lock card flies with the phrase it is about to demand', word ? word.textContent : 'none');
+      ok(!!word && word.parentNode && word.parentNode._classes.has('gg-throw-arc'),
+        '…on the ARC, never on the art: the art tumbles and a spinning phrase cannot be read');
+      ok(hasClass(fly, 'is-word'), '…and the item steadies so it can be');
+    }
+
+    /* THE WARM. The cutout's fetch starts when the payload is ACCEPTED, which is
+     * a second and a half before the projectile exists — otherwise a 650 KB PNG
+     * has to arrive inside a 380 ms flight, and it does not. */
+    {
+      previewMod.resetStickerWarm();
+      const made = [];
+      globalThis.Image = class FakeImage {
+        constructor() { this.complete = false; this.src = ''; made.push(this); }
+        addEventListener(type, fn) { if (type === 'load') this._load = fn; }
+      };
+      ok(previewMod.warmSticker(GoonPayloadKind.Spiral) === false,
+        'a cutout nobody has fetched yet is not ready');
+      ok(made.length === 1 && /item_spiral\.png/.test(String(made[0].src || '')),
+        'and asking for it started exactly one fetch', String(made.length));
+      ok(previewMod.warmSticker(GoonPayloadKind.Spiral) === false && made.length === 1,
+        'asking twice does not fetch twice — one HTTP cache, one page');
+
+      let revealed = 0;
+      previewMod.warmSticker(GoonPayloadKind.Spiral, () => { revealed++; });
+      ok(revealed === 0, 'nothing is revealed while it is still in the air');
+      made[0]._load();
+      ok(revealed === 1 && previewMod.stickerWarm(GoonPayloadKind.Spiral) === true,
+        'the DECODE is what reveals it, exactly like .gg-throw-live is-ready');
+      let again = 0;
+      previewMod.warmSticker(GoonPayloadKind.Spiral, () => { again++; });
+      ok(again === 1, 'and from then on it is instant');
+
+      mon.markInbound({ kind: GoonPayloadKind.Spiral, waitMs: 0 });
+      const flies = findAll(document.body, 'gg-throw');
+      ok(hasClass(flies[flies.length - 1], 'is-art'),
+        'a warm cutout steps in front of the glyph on frame one');
+
+      // …and the accept itself is what warms it: a payload eight seconds out
+      // launches nothing yet, but the fetch is already running.
+      const before = made.length;
+      mon.markInbound({ kind: GoonPayloadKind.BrainDrain, waitMs: 8000 });
+      ok(made.length === before + 1,
+        'ACCEPT starts the fetch — the lead the engine reserved pays for it, not the flight');
+      ok(findAll(document.body, 'gg-throw').length === flies.length,
+        '…while the flight itself is still correctly parked inside that lead');
+
+      delete globalThis.Image;
+      previewMod.resetStickerWarm();
+    }
+
+    mon.unmount();
+    ok(match._subs.released === match._subs.taken, 'and none of it leaks a subscription');
+    await sleep(THROW_MS + 140);
+  }
+
   // --- the CSS half: one animation per node, the heat exemption, reduced motion
   {
     const fs = await import('node:fs/promises');
@@ -4921,6 +5069,26 @@ const audioMod = await import('../ui/audio.js');
     }
     ok(/\.gg-throw-live[^{]*\{[^}]*transition:\s*opacity/.test(css),
       'the live preview fades in on a TRANSITION — an animation there would take the spin\'s slot');
+
+    // THE MARK rides on the same rule, for the same reason.
+    ok(/transition:\s*opacity/.test(blockOf('.gg-throw-mark')) && !/animation:/.test(blockOf('.gg-throw-mark')),
+      'the per-kind glyph fades on a transition and takes no animation slot of its own');
+    ok(/\.gg-throw\.is-art\s+\.gg-throw-mark[\s\S]{0,80}opacity:\s*0/.test(css),
+      'and it only steps aside once the cutout has really DECODED (is-art), never on a timer');
+    ok(!/animation:/.test(blockOf('.gg-throw-word')), 'the caption takes no slot either');
+    ok(/white-space:\s*nowrap/.test(blockOf('.gg-throw-word'))
+      && /text-overflow:\s*ellipsis/.test(blockOf('.gg-throw-word')),
+      'a long phrase is one clipped line, never a paragraph flying across the screen');
+    ok(/\.gg-throw\.is-word\s+\.gg-throw-art[^{]*\{[^}]*ggThrowSwell/.test(css),
+      'and a payload carrying words stops tumbling so they can be read');
+
+    // one tint, every surface of the same event
+    for (const sel of ['.gg-mon-throw', '.gg-throw-art', '.gg-throw-mark', '.gg-throw-word', '.gg-throw-hit']) {
+      ok(/rgba?\(var\(--gg-throw-tint/.test(blockOf(sel)),
+        `${sel} is coloured by the thrown kind's tint`);
+      ok(/--gg-throw-tint,\s*var\(--gg-pink-rgb\)/.test(blockOf(sel)),
+        `…and falls back to the brand pink when nobody set one (${sel})`);
+    }
 
     // THE MONITOR IS INFORMATION: a throw flourish must survive the heat park.
     ok(/--gg-deco-play:\s*running/.test(blockOf('.gg-mon-throw')),

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -1458,6 +1458,9 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
  * carries Y (with a lob keyframe partway through, which is the entire arc), and
  * .gg-throw-art carries the spin. The splash is a fourth node for the same
  * reason, and the monitor's flare is a fifth on the monitor itself.
+ * The two nodes added by THE MARK (.gg-throw-mark, .gg-throw-word) take no slot
+ * at all: they fade on a TRANSITION, which is the only way to decorate a node
+ * whose animation belongs to somebody else.
  *
  * NOTHING HERE IS REMOVED ON animationend. A parked animation (data-gg-fx="hot"),
  * a reduced-motion override or a re-parented node all swallow that event; every
@@ -1482,11 +1485,13 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   border-radius: 8px;
   pointer-events: none;
   opacity: 0;
+  /* --gg-throw-tint is written on .gg-mon by ui/opponent.js flareMonitor(), so
+     the flare wears the colour of whatever they just threw. Pink until then. */
   background: radial-gradient(72% 58% at 50% 40%,
-    rgba(var(--gg-pink-rgb), 0.42) 0%,
-    rgba(var(--gg-pink-rgb), 0.12) 56%,
+    rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.42) 0%,
+    rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.12) 56%,
     rgba(0, 0, 0, 0) 78%);
-  box-shadow: inset 0 0 26px rgba(var(--gg-pink-rgb), 0.5);
+  box-shadow: inset 0 0 26px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.5);
 }
 .gg-mon.is-throwing .gg-mon-throw {
   opacity: 1;
@@ -1520,23 +1525,25 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   animation: ggThrowY var(--gg-throw-ms, 760ms) cubic-bezier(.35, .1, .5, 1) 1 forwards;
   animation-play-state: var(--gg-deco-play);
 }
-/* The STICKER IS THE FLOOR: it is this node's background, painted from frame
-   one, and a live preview (if there is one) fades in over it. A clip that is
-   slow, broken or simply not applicable therefore degrades to the item art with
-   no timer and no branch — see ui/throwPreview.js. */
+/* The item cutout, revealed by `is-art` once it has DECODED — see the mark
+   below for why it cannot be trusted to be the floor on its own. A live preview
+   (if there is one) then fades in over it. */
 .gg-throw-art {
   position: absolute; inset: 0;
   background-image: var(--gg-throw-sticker, none);
   background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
-  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.7)) drop-shadow(0 0 18px rgba(var(--gg-pink-rgb), 0.55));
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.7))
+          drop-shadow(0 0 18px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.55));
   animation: ggThrowSpin var(--gg-throw-ms, 760ms) ease-out 1 forwards;
   animation-play-state: var(--gg-deco-play);
 }
-/* A live clip does not tumble — you are meant to be able to READ it on the way
-   in. Mutually exclusive with the rule above (one shorthand, one winner). */
-.gg-throw.is-live .gg-throw-art {
+/* Neither a live clip nor a phrase tumbles — you are meant to be able to READ
+   what is coming. Mutually exclusive with the rule above (one shorthand, one
+   winner), which is also why both states share the one keyframe. */
+.gg-throw.is-live .gg-throw-art,
+.gg-throw.is-word .gg-throw-art {
   animation: ggThrowSwell var(--gg-throw-ms, 760ms) ease-out 1 forwards;
 }
 .gg-throw-live {
@@ -1544,11 +1551,55 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   width: 88%; height: 88%;
   object-fit: cover;
   border-radius: 10px;
-  box-shadow: 0 0 0 2px rgba(var(--gg-pink-rgb), 0.75), inset 0 0 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 0 2px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.75), inset 0 0 20px rgba(0, 0, 0, 0.5);
   opacity: 0;                       /* the first decoded frame lifts this */
   transition: opacity .18s ease;    /* a transition, not an animation: no slot taken */
 }
 .gg-throw-live.is-ready { opacity: 1; }
+
+/* THE MARK — the floor UNDER the sticker, and the reason every kind now reads.
+   The item cutouts are ~650 KB each and their fetch used to start when the
+   projectile did, so the six kinds with no live preview routinely flew as an
+   empty box: nothing on screen, i.e. "the throw did not fire". This glyph is
+   text — it is on screen in frame one, for every kind, with no network in the
+   path — and it steps aside the moment something better has actually decoded.
+   Colour comes from the kind's tint, written inline by ui/opponent.js. */
+.gg-throw-mark {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-style: normal;
+  font-size: calc(var(--gg-throw-size, 128px) * 0.52);
+  line-height: 1;
+  color: rgb(var(--gg-throw-tint, var(--gg-pink-rgb)));
+  text-shadow: 0 0 12px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.85),
+               0 2px 10px rgba(0, 0, 0, 0.8);
+  opacity: 1;
+  transition: opacity .18s ease;    /* a transition — the art's one animation slot is taken */
+}
+.gg-throw.is-art .gg-throw-mark,
+.gg-throw.is-live .gg-throw-mark { opacity: 0; }
+
+/* THEIR WORDS, for the two payloads that ARE text (LockCard, SubliminalStorm).
+   A child of the ARC and never of the art: the art tumbles. Remote text, always
+   written with textContent — ui/opponent.js's TRUST rule. */
+.gg-throw-word {
+  position: absolute;
+  left: 50%; top: 94%;
+  transform: translateX(-50%);
+  max-width: 15rem;
+  padding: 3px 10px;
+  border-radius: var(--gg-radius-pill, 999px);
+  font-size: .74rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--gg-text, #fff);
+  background: rgba(12, 6, 20, 0.86);
+  border: 1px solid rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.8);
+  box-shadow: 0 0 14px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.4);
+  pointer-events: none;
+}
 @keyframes ggThrowX {
   from { transform: translateX(0); }
   to { transform: translateX(var(--gg-throw-dx, 0px)); }
@@ -1578,7 +1629,8 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   margin: -11px 0 0 -11px;
   border-radius: 50%;
   pointer-events: none;
-  box-shadow: 0 0 0 2px rgba(var(--gg-pink-rgb), 0.9), 0 0 34px rgba(var(--gg-pink-rgb), 0.75);
+  box-shadow: 0 0 0 2px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.9),
+              0 0 34px rgba(var(--gg-throw-tint, var(--gg-pink-rgb)), 0.75);
   animation: ggThrowHit .42s cubic-bezier(.2, .8, .3, 1) 1 forwards;
   animation-play-state: var(--gg-deco-play);
 }

--- a/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
@@ -49,7 +49,7 @@ import { GoonConnectionHealth } from '../core/match.js';
 import { GoonConsts, GoonElement, GoonMatchPhase, GoonPayloadKind, enumName } from '../core/contracts.js';
 import { GoonReceiptStatus } from '../core/scoring.js';
 import { S } from './strings.js';
-import { createPreview, stickerUrl } from './throwPreview.js';
+import { createPreview, stickerUrl, markFor, throwWord, warmSticker } from './throwPreview.js';
 
 /** Closeness 0-3 -> the word that always rides with the colour. */
 export const CLOSENESS_WORDS = Object.freeze(['steady', 'warm', 'close', 'edge']);
@@ -175,6 +175,22 @@ const VWIN_MAX_MINIS = 4;
  * will throw — with the item sticker painted underneath it until the first frame
  * decodes, and left showing for the kinds that have no content (see
  * ui/throwPreview.js for which are which, and how exact the picture is).
+ *
+ * EVERY KIND, AND EVERY KIND AS ITSELF (2026-08-05). markInbound was never
+ * kind-gated — ui/hud.js hands it every accepted payload and it has always
+ * launched one projectile per kind — but for the six kinds with no live preview
+ * the ONLY pixels were the item cutout, a ~650 KB PNG whose fetch began when the
+ * projectile did and regularly landed after it. What flew was an empty box, and
+ * an empty box reads as "nothing was thrown", which is how it was reported. So
+ * each projectile now carries, in order of precedence:
+ *     the KIND'S GLYPH (text, frame one, no network)  <- the real floor
+ *     its STICKER, revealed only once it has decoded — and WARMED at accept, so
+ *       the engine's own schedule lead pays for the fetch, never the flight
+ *     its LIVE PREVIEW, media kinds only, exactly as before
+ *   + a per-kind TINT on the sender's flare, the projectile and the splash
+ *   + THEIR WORDS under it for the two payloads that are text (LockCard,
+ *     SubliminalStorm) — textContent only, see TRUST above.
+ * None of that touches the schedule: the same one timer, the same two constants.
  * ------------------------------------------------------------------------- */
 
 /** The flight, when the schedule lead can pay for it in full. */
@@ -951,8 +967,15 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     return { x: w / 2, y: h * THROW_TARGET_Y };
   }
 
-  /** Their monitor lights up: THEY did this, and it is about to arrive. */
-  function flareMonitor() {
+  /**
+   * Their monitor lights up: THEY did this, and it is about to arrive — in the
+   * colour of the thing they threw, so the flare and the projectile that leaves
+   * it are visibly the same event.
+   */
+  function flareMonitor(tint) {
+    if (tint && root.style && typeof root.style.setProperty === 'function') {
+      try { root.style.setProperty('--gg-throw-tint', tint); } catch (_e) { /* stub DOM */ }
+    }
     cls(root, 'is-throwing', true);
     try { clearTimeout(flareTimer); } catch (_e) { /* gone */ }
     if (typeof setTimeout === 'function') {
@@ -975,7 +998,8 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
    * shorthand, so a second live rule on the same element silently cancels the
    * first. The outer travels in X (linear), the middle travels in Y (with a lob
    * partway through — that is the arc), the art spins and swells. The splash at
-   * the far end is a FOURTH node for the same reason.
+   * the far end is a FOURTH node for the same reason. Everything the mark adds
+   * below rides a TRANSITION, never an animation, for exactly that reason.
    */
   function launch(kind, payload, flightMs) {
     const d = doc();
@@ -990,12 +1014,36 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     const art = add(arc, el('i', 'gg-throw-art'));
     if (!arc || !art) return null;
 
-    // The sticker is the FLOOR: painted as the art node's background from the
-    // first frame, so a preview that is slow, broken or simply not applicable
-    // degrades to it with no timer and no branch.
+    // The kind's own colour, on the projectile and (via the rec) on the splash.
+    const mark = markFor(kind);
+    if (fly.style && typeof fly.style.setProperty === 'function') {
+      fly.style.setProperty('--gg-throw-tint', mark.tint);
+    }
+    try { if (typeof fly.setAttribute === 'function') fly.setAttribute('data-gg-kind', String(kind)); }
+    catch (_e) { /* stub DOM */ }
+
+    // THE GLYPH is the real floor — text, painted on frame one, no fetch, no
+    // decode, no way to fail. Everything below is allowed to be late.
+    add(art, el('i', 'gg-throw-mark', mark.glyph));
+
+    // The sticker sits over the glyph, but ONLY once it has actually decoded:
+    // a background-image that has not arrived yet is not a floor, it is a hole,
+    // and that hole is the whole bug this pass fixes. `is-art` is the same
+    // first-decoded-frame gate .gg-throw-live's `is-ready` already uses, and
+    // the fetch itself was started back at accept (markInbound).
     const sticker = stickerUrl(kind);
     if (sticker && art.style && typeof art.style.setProperty === 'function') {
       art.style.setProperty('--gg-throw-sticker', 'url(' + sticker + ')');
+    }
+    warmSticker(kind, () => cls(fly, 'is-art', true));
+
+    // THEIR WORDS, for the two kinds whose payload IS text. On the ARC, not the
+    // art: the art tumbles, and a spinning phrase cannot be read. `is-word`
+    // steadies the item for the same reason `is-live` does.
+    const word = throwWord(kind, payload);
+    if (word) {
+      add(arc, el('span', 'gg-throw-word', word));
+      cls(fly, 'is-word', true);
     }
 
     // …and the live preview of what is actually about to play, when there is
@@ -1023,11 +1071,11 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
       }
     }
     add(d.body, fly);
-    return { node: fly, destroy: preview ? preview.destroy : null, timers: [], to };
+    return { node: fly, destroy: preview ? preview.destroy : null, timers: [], to, tint: mark.tint };
   }
 
   /** The splash where it lands. Removed on a timer — animationend is not a promise. */
-  function splash(to) {
+  function splash(to, tint) {
     const d = doc();
     if (!d || !d.body || !to) return;
     const hit = el('i', 'gg-throw-hit');
@@ -1035,13 +1083,15 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     if (hit.style) {
       hit.style.left = Math.round(to.x) + 'px';
       hit.style.top = Math.round(to.y) + 'px';
+      // The impact is the same event as the flight and wears the same colour.
+      if (tint && typeof hit.style.setProperty === 'function') hit.style.setProperty('--gg-throw-tint', tint);
     }
     add(d.body, hit);
     laterOnce(THROW_HIT_MS + 80, () => { try { hit.remove(); } catch (_e) { /* gone */ } });
   }
 
   function throwAtUs(kind, payload, flightMs) {
-    flareMonitor();
+    flareMonitor(markFor(kind).tint);
     // Reduced motion: the highlight IS the feedback. Nothing travels, and the
     // `payload-in` cue still lands on the beat it always did.
     if (isCalm()) return;
@@ -1053,8 +1103,9 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     // animation, a reduced-motion override or a re-parent can all swallow.
     rec.timers.push(laterOnce(flightMs, () => {
       const at = rec.to;
+      const tint = rec.tint;
       dropFlight(rec);
-      splash(at);
+      splash(at, tint);
     }));
   }
 
@@ -1068,6 +1119,11 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
    */
   function markInbound({ kind = null, waitMs = 0, payload = null } = {}) {
     if (kind === null || kind === undefined) return false;
+    // Start the cutout's fetch NOW, at accept — the earliest moment we know a
+    // throw is coming. The engine's schedule lead (a second and a half) is dead
+    // time we already own, and spending it here is what stops a 650 KB PNG from
+    // having to arrive inside a 380 ms flight. Once per kind per page.
+    warmSticker(kind);
     const wait = Math.max(0, Math.min(MAX_THROW_LEAD_MS, Number(waitMs) || 0));
     // Fit the flight inside the lead; never push the impact past it by more than
     // the shortest readable throw.

--- a/ConditioningControlPanel/Resources/web/goon/ui/throwPreview.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/throwPreview.js
@@ -9,6 +9,11 @@
  * media at all. Everything else keeps its sticker, which is why the sticker map
  * lives here too: it is the FLOOR, never a failure state.
  *
+ * …and UNDER that floor, for every kind alike, is THE MARK (2026-08-04): a
+ * glyph, a tint, and — for the two payloads that ARE text — their own words.
+ * See THE MARK below for why a sticker on its own left six of the eight kinds
+ * looking like nothing had been thrown at all.
+ *
  * ---------------------------------------------------------------------------
  * WHICH CLIP, AND HOW SURE WE ARE (read this before "fixing" a wrong preview)
  *
@@ -91,6 +96,167 @@ export const STICKER_FOR_PAYLOAD = Object.freeze({
 
 /** Where the cutouts live, relative to index.html (same base as ui/arsenal.js). */
 export const ITEM_ART_BASE = './assets/items/';
+
+/* ---------------------------------------------------------------------------
+ * THE MARK — every kind reads as ITSELF in the air (2026-08-04).
+ *
+ * "when an effect arrives from the opponent, flashes and videos show the little
+ *  incoming throw — the other kinds do not." (owner)
+ *
+ * The throw was never kind-gated: ui/hud.js hands EVERY accepted payload to
+ * ui/opponent.js markInbound and one projectile is launched per kind. What was
+ * missing is that only the four media-backed kinds in PREVIEW_MEDIA_KIND had
+ * anything to SHOW. The other four flew as `--gg-throw-sticker` alone — a
+ * ~650 KB item cutout whose fetch STARTS when the projectile is built, which
+ * routinely loses the race against a 380-760 ms flight (the whole flight is
+ * shorter than a cold PNG on a phone). A projectile whose only pixel source has
+ * not decoded yet is an empty box, and an empty box is indistinguishable from
+ * "the throw never fired" — which is exactly how it was reported.
+ *
+ * So every kind now carries three layers, in this order of precedence:
+ *   1. its GLYPH   — text, painted on frame one, no network, cannot fail;
+ *   2. its STICKER — revealed only once the PNG has actually decoded, and
+ *      warmed at ACCEPT time (warmSticker) so the lead the engine already
+ *      reserved pays for the fetch instead of the flight paying for it;
+ *   3. its LIVE PREVIEW — media kinds only, exactly as before.
+ * …plus a TINT, so the four kinds that share the sticker-only path still read
+ * apart at a glance: it themes the sender's flare, the projectile's glow and
+ * the landing splash.
+ *
+ * THE GLYPHS ARE A COPY, deliberately, of the vocabulary ui/hud.js's rail chips
+ * and ui/announcer.js's ribbon already use — the same reason STICKER_FOR_PAYLOAD
+ * is a copy of the arsenal's `img` column: this module is reached FROM the
+ * arsenal and must not drag the HUD tier in behind it. The self-test pins the
+ * copy against ui/announcer.js's ANNOUNCE_GLYPH so the two cannot drift.
+ *
+ * THE TINTS are goon.css's own hues (pink, violet, gold, green) plus two
+ * near-palette neighbours for the kinds that would otherwise collide. They are
+ * glow colours only: nothing here is ever the sole carrier of a meaning.
+ * ------------------------------------------------------------------------- */
+export const THROW_MARK = Object.freeze({
+  [GoonPayloadKind.FlashBurst]: Object.freeze({ glyph: '✦', tint: '255, 105, 180' }),   // --gg-pink-rgb
+  [GoonPayloadKind.SubliminalStorm]: Object.freeze({ glyph: '≋', tint: '236, 220, 255' }),
+  [GoonPayloadKind.BubbleSwarm]: Object.freeze({ glyph: '○', tint: '150, 226, 255' }),
+  [GoonPayloadKind.Video]: Object.freeze({ glyph: '▶', tint: '179, 136, 255' }),        // --gg-violet-rgb
+  [GoonPayloadKind.LockCard]: Object.freeze({ glyph: '▢', tint: '255, 212, 94' }),      // --gg-gold
+  [GoonPayloadKind.ToyPattern]: Object.freeze({ glyph: '∿', tint: '94, 242, 160' }),    // --gg-green-rgb
+  [GoonPayloadKind.BrainDrain]: Object.freeze({ glyph: '◍', tint: '138, 92, 246' }),
+  [GoonPayloadKind.Spiral]: Object.freeze({ glyph: '◎', tint: '255, 168, 214' }),
+});
+
+/**
+ * A kind we have never heard of (a newer peer's ninth code) still throws, and
+ * still throws something you can SEE. Unknown is never invisible.
+ */
+export const DEFAULT_THROW_MARK = Object.freeze({ glyph: '◆', tint: '255, 105, 180' });
+
+/** @param {number} kind GoonPayloadKind @returns {{glyph:string, tint:string}} */
+export function markFor(kind) {
+  return THROW_MARK[kind] || DEFAULT_THROW_MARK;
+}
+
+/**
+ * THE WORD — the two kinds whose payload IS text fly with it written under them.
+ *
+ * `payload.text` is the phrase a LockCard will make you type and the line a
+ * SubliminalStorm will chant (exec/lockCards.js, exec/subliminals.js both read
+ * it). Showing it in flight is the same promise the clip half makes — "this is
+ * what is about to play" — kept for two kinds no clip can cover.
+ *
+ * REMOTE TEXT. The engine sanitized it once and the renderer sanitizes it again
+ * on its way to the DOM; this is a third, narrower pass (control characters out,
+ * whitespace collapsed, hard length cap) and the caller writes the result with
+ * textContent, never markup — ui/opponent.js's TRUST rule, unchanged.
+ */
+export const WORD_KINDS = Object.freeze([GoonPayloadKind.SubliminalStorm, GoonPayloadKind.LockCard]);
+
+/** Longer than this and it stops being a glance. */
+export const THROW_WORD_MAX = 28;
+
+/**
+ * @param {number} kind      GoonPayloadKind
+ * @param {object} [payload] the wire payload
+ * @returns {string} the words to show, or '' for every kind that has none
+ */
+export function throwWord(kind, payload) {
+  if (WORD_KINDS.indexOf(kind) < 0) return '';
+  const raw = (payload && typeof payload.text === 'string') ? payload.text : '';
+  if (!raw) return '';
+  let clean = '';
+  for (const ch of raw) {
+    const c = ch.charCodeAt(0);
+    clean += (c < 0x20 || (c >= 0x7f && c <= 0x9f)) ? ' ' : ch;
+  }
+  clean = clean.replace(/\s+/g, ' ').trim();
+  if (!clean) return '';
+  return clean.length > THROW_WORD_MAX ? (clean.slice(0, THROW_WORD_MAX - 1) + '…') : clean;
+}
+
+// ------------------------------------------------------- warming the sticker
+
+/**
+ * url -> {done, waiters[]}. Module-level for the same reason `pool` is: the
+ * page has one HTTP cache and one set of nine cutouts, and a per-mount map
+ * would re-fetch them every match.
+ */
+const warmed = new Map();
+
+/** A stuck decode must not grow an unbounded callback list. */
+const WARM_WAITERS_MAX = 32;
+
+/**
+ * Start the item cutout's fetch and tell me when it can actually be shown.
+ *
+ * Called TWICE per throw, on purpose: once by markInbound the instant the
+ * engine admits the payload (which is ~1-1.5 s before the projectile exists —
+ * the schedule lead pays for the fetch), and once by the launch itself to learn
+ * whether the art is ready yet. The second call is free; the fetch is one.
+ *
+ * @param   {number}   kind      GoonPayloadKind
+ * @param   {Function} [onReady] run once the art has decoded (immediately if it
+ *                               already has). Never run if it errors — the
+ *                               glyph simply stays, which is the point of it.
+ * @returns {boolean} whether the art is decoded RIGHT NOW
+ */
+export function warmSticker(kind, onReady = null) {
+  const url = stickerUrl(kind);
+  if (!url) return false;
+  let rec = warmed.get(url);
+  if (!rec) {
+    const Img = (typeof Image === 'function') ? Image : null;
+    if (!Img) return false;                       // node / no DOM: nothing to warm
+    let img = null;
+    try { img = new Img(); } catch (_e) { img = null; }
+    if (!img) return false;
+    rec = { done: false, waiters: [] };
+    warmed.set(url, rec);
+    const settle = () => {
+      if (rec.done) return;
+      rec.done = true;
+      const list = rec.waiters.splice(0, rec.waiters.length);
+      for (const fn of list) { try { fn(); } catch (_e) { /* never break a throw */ } }
+    };
+    try { img.decoding = 'async'; } catch (_e) { /* stub */ }
+    try { if (typeof img.addEventListener === 'function') img.addEventListener('load', settle); } catch (_e) { /* stub */ }
+    try { img.src = url; } catch (_e) { /* stub */ }
+    try { if (img.complete) settle(); } catch (_e) { /* stub */ }
+  }
+  if (rec.done) {
+    if (typeof onReady === 'function') { try { onReady(); } catch (_e) { /* ignore */ } }
+    return true;
+  }
+  if (typeof onReady === 'function' && rec.waiters.length < WARM_WAITERS_MAX) rec.waiters.push(onReady);
+  return false;
+}
+
+/** Read-only, for a driver or a test. */
+export function stickerWarm(kind) {
+  const rec = warmed.get(stickerUrl(kind));
+  return !!(rec && rec.done);
+}
+
+/** Test seam: forget every warmed cutout. The page never calls this. */
+export function resetStickerWarm() { warmed.clear(); }
 
 /** A ghost nobody ever removed must still give its refcount back. */
 const GHOST_MAX_MS = 120000;
@@ -319,4 +485,7 @@ export function dressGhost(node, kind) {
   return live;
 }
 
-export default { createPreview, resolvePreview, dressGhost, setPreviewMedia, stickerUrl };
+export default {
+  createPreview, resolvePreview, dressGhost, setPreviewMedia, stickerUrl,
+  markFor, throwWord, warmSticker, stickerWarm,
+};


### PR DESCRIPTION
The fling was wired for all kinds but only flashes/videos ever showed anything: the other kinds' only projectile art was a ~650KB PNG fetched at launch, gone before it decoded. Now: instant per-kind glyph floor, sticker warmed at payload-accept (~1.5s of lead), per-kind tint on flare/projectile/splash, and lock-card/subliminal text flying under the projectile. Timing/protocol untouched; zen + reduced-motion behavior preserved. selftest-hud 1481 green (+101); build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAgZYfCffPA4vHvWDVAxQ