### PR TITLE
feat(goon): transfer lane names why a payload fired untagged

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -631,7 +631,16 @@ function createArtifactSource() {
         if (!bytes) continue;
         urls.set(sha, url);
         mimes.set(sha, mime);
-        out.push({ sha, bytes, mime, kind: it.kind === 'video' ? 'video' : 'image', exempt });
+        /* THE WIRE KIND IS THE ARTIFACT'S, NOT THE SOURCE'S (2026-08-05). A gif
+         * compresses into an mp4 artifact: the ITEM stays kind 'image' (that is
+         * what it is in the deck), but what actually TRAVELS is video/mp4 — and
+         * the channel's offer gate refuses any offer whose kind and mime
+         * families disagree. In a gif-heavy library that refused nearly every
+         * artifact ("refusing to offer …: kind/mime disagree", over and over),
+         * the larder never filled, and every throw fired untagged into the
+         * receiver's own pool. */
+        const wireKind = mime.indexOf('video/') === 0 ? 'video' : 'image';
+        out.push({ sha, bytes, mime, kind: wireKind, exempt });
       }
       return out;
     },

--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -995,6 +995,16 @@ function attachMatch(match, transport) {
   try {
     if (prefs.get('voiceNotesEnabled')) match.setLocalVoiceNotes(true);
   } catch (e) { logger.warn('setLocalVoiceNotes threw: ' + ((e && e.message) || e)); }
+  /* SENDING DEFAULTS ON (owner call, 2026-08-05). Sending is free for every
+   * seat now and "my attacks carry MY media" is the product, so the standing
+   * answer is yes unless this player has explicitly unticked the lobby box
+   * before (prefs 'mediaTransferEnabled' === false — the checkbox writes it).
+   * Same seam as the voice seeding above, for the same rebuild reason; the
+   * engine still refuses the call outside Lobby/Consent, and the peer still
+   * has to be opted in too before a single byte moves. */
+  try {
+    if (prefs.get('mediaTransferEnabled') !== false) match.setMediaTransfer(true);
+  } catch (e) { logger.warn('setMediaTransfer threw: ' + ((e && e.message) || e)); }
   /* KEEP THE SCREEN ON for the duration. A phone that dims and locks mid-Live is
    * an unintended mercy; the lock is match-scoped (start here, stop in
    * detachMatch) so an idle title screen never holds one. Unsupported = no-op. */

--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -993,17 +993,28 @@ function attachMatch(match, transport) {
    * remount to notice. core/match.js refuses the call outside Lobby/Consent, so
    * a mid-match re-attach is a no-op rather than a signature-clearing surprise. */
   try {
-    if (prefs.get('voiceNotesEnabled')) match.setLocalVoiceNotes(true);
+    if (prefs.get('voiceNotesEnabled') && !match.setLocalVoiceNotes(true)) {
+      // The engine refused the seed. That was the SILENT killer of the whole
+      // transfer lane until 2026-08-05 (attachMatch runs while the match is
+      // still Idle; the setter used to be Lobby/Consent-only), so a refusal is
+      // never allowed to be quiet again.
+      logger.warn('voice-note seed REFUSED by the engine (phase ' + match.phase + ') — declaration will not ride the consent frames');
+    }
   } catch (e) { logger.warn('setLocalVoiceNotes threw: ' + ((e && e.message) || e)); }
   /* SENDING DEFAULTS ON (owner call, 2026-08-05). Sending is free for every
    * seat now and "my attacks carry MY media" is the product, so the standing
    * answer is yes unless this player has explicitly unticked the lobby box
    * before (prefs 'mediaTransferEnabled' === false — the checkbox writes it).
    * Same seam as the voice seeding above, for the same rebuild reason; the
-   * engine still refuses the call outside Lobby/Consent, and the peer still
-   * has to be opted in too before a single byte moves. */
+   * engine accepts the seed in Idle too (core/match.js _seedDeclaration —
+   * attachMatch runs BEFORE createInvite/join flips the phase, and the old
+   * Lobby/Consent-only gate ate this exact call on every fresh P2P match),
+   * still refuses it mid-match, and the peer still has to be opted in too
+   * before a single byte moves. */
   try {
-    if (prefs.get('mediaTransferEnabled') !== false) match.setMediaTransfer(true);
+    if (prefs.get('mediaTransferEnabled') !== false && !match.setMediaTransfer(true)) {
+      logger.warn('media-transfer seed REFUSED by the engine (phase ' + match.phase + ') — attacks will fall back to the receiver\'s local pool');
+    }
   } catch (e) { logger.warn('setMediaTransfer threw: ' + ((e && e.message) || e)); }
   /* KEEP THE SCREEN ON for the duration. A phone that dims and locks mid-Live is
    * an unintended mercy; the lock is match-scoped (start here, stop in
@@ -2257,7 +2268,10 @@ if (hasDom()) {
   startHeartbeat();
   armDeadline();
   bridge.announceReady();
-  bridge.log('boot: ready posted, waiting for init + manifest');
+  // The build stamp is the FIRST diagnostic of every cross-device session:
+  // "which build is that phone actually running" must be answerable from the
+  // C# log / ?debug=1 overlay alone (see GOON_BUILD in bridge.js).
+  bridge.log('boot: ready posted, build ' + bridge.GOON_BUILD + ' (' + (bridge.isHosted ? 'hosted' : 'standalone') + '), waiting for init + manifest');
 }
 
 /* Handy for the play-test driver and for anything that needs the shell's guts

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -29,6 +29,19 @@
 
 export const PROTOCOL = 1;
 
+/**
+ * THE BUILD STAMP — bump it in every PR that touches this folder.
+ *
+ * Two devices, one robocopy mirror, and iOS Safari's cache made "which build is
+ * that phone actually running?" an unanswerable question for three play-tests
+ * in a row (the 2026-08-05 transfer hunt spent its first sessions on exactly
+ * that). The stamp closes the hole from both ends: boot.js logs it through
+ * bridge.log (so the C# app log and the ?debug=1 overlay both carry it) and
+ * the title screen prints it under the fineprint, so ONE GLANCE at either
+ * device answers the question. Format: r<round>-<yyyymmdd>[letter].
+ */
+export const GOON_BUILD = 'r6-20260805';
+
 const win = (typeof window !== 'undefined') ? window : null;
 const webview = (win && win.chrome && win.chrome.webview) ? win.chrome.webview : null;
 

--- a/ConditioningControlPanel/Resources/web/goon/core/match.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/match.js
@@ -604,9 +604,10 @@ export class GoonMatchService {
    * The re-sent sheet carries the new declaration; the peer's `_handleConsent` reads it back out
    * and the two sides converge without the fingerprint ever changing.
    *
-   * @returns {boolean} true when the toggle was taken (Lobby/Consent only).
+   * @returns {boolean} true when the toggle was taken (Idle/Lobby/Consent only).
    */
   setMediaTransfer(on) {
+    if (this._phase === GoonMatchPhase.Idle) return this._seedDeclaration('media', on);
     if (this._phase !== GoonMatchPhase.Lobby && this._phase !== GoonMatchPhase.Consent) return false;
 
     this._localMediaTransfer = !!on;
@@ -631,9 +632,10 @@ export class GoonMatchService {
    * It is NOT the whole gate either: the peer's build has to speak the family (`caps.voice`) and
    * the phase has to be open. `voiceNotesAgreed` ANDs the consents; the service ANDs the rest.
    *
-   * @returns {boolean} true when the toggle was taken (Lobby/Consent only).
+   * @returns {boolean} true when the toggle was taken (Idle/Lobby/Consent only).
    */
   setLocalVoiceNotes(on) {
+    if (this._phase === GoonMatchPhase.Idle) return this._seedDeclaration('voice', on);
     if (this._phase !== GoonMatchPhase.Lobby && this._phase !== GoonMatchPhase.Consent) return false;
 
     this._localVoiceNotes = !!on;
@@ -641,6 +643,42 @@ export class GoonMatchService {
     this._remoteConsentConfirmed = false;
     this._consentSheet = cloneSheet(this._consentSheet, false, this._localMediaTransfer, this._localVoiceNotes);
     this._send(this._consentSheet);
+    this._ev.consentChanged.emit(undefined, (e) => this._warn(`consentChanged handler threw: ${e && e.message}`));
+    return true;
+  }
+
+  /**
+   * IDLE-PHASE SEEDING, the shared tail of both setters above.
+   *
+   * THE BUG THIS EXISTS FOR (proven in test/selftest-transfer.js "boot seeding
+   * order", 2026-08-05): boot.js seeds the standing declarations inside
+   * attachMatch, and net/session.js raises onCurrentMatchChanged from
+   * _beginSession — BEFORE createInviteAsync/joinAsync has moved the phase off
+   * Idle. The old Lobby/Consent-only gate silently refused that call on BOTH
+   * seats of every fresh P2P match, the declaration never rode a single consent
+   * frame, and the peer read "their lobby send toggle is off" no matter what
+   * the player had opted into. (Only the relay-rebuild path dodged it, because
+   * adoptLobby() runs before the re-attach there.)
+   *
+   * Idle is the SAFE phase to record a standing answer: no peer, no signatures
+   * to clear, nothing on the wire to desync. So this records the flag and
+   * re-signs the local sheet — and deliberately does NOT send (there is no
+   * open channel to send on) and does NOT touch the confirmations (both are
+   * already false). Every consent frame authored later (proposeConsent,
+   * confirmConsent, the counter-proposal adopt) reads the flags fresh, so the
+   * declaration rides out with the first real frame exactly as if the player
+   * had ticked the box in the lobby.
+   *
+   * Mid-match phases still refuse in the callers, unchanged: a re-attach during
+   * Live must never become a signature-clearing surprise.
+   *
+   * JS-ONLY ADDITION: the C# GoonMatchService seeds its declarations after its
+   * own lobby entry and never hits this window.
+   */
+  _seedDeclaration(which, on) {
+    if (which === 'media') this._localMediaTransfer = !!on;
+    else this._localVoiceNotes = !!on;
+    this._consentSheet = cloneSheet(this._consentSheet, false, this._localMediaTransfer, this._localVoiceNotes);
     this._ev.consentChanged.emit(undefined, (e) => this._warn(`consentChanged handler threw: ${e && e.message}`));
     return true;
   }

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
@@ -291,20 +291,55 @@ export function createMediaQueue({
   /* -------------------------------------------------------------------- the tags */
 
   /**
+   * WHY is a media-kind payload about to fire untagged? One short sentence naming
+   * the FIRST failing gate, for the diagnostic below. The order mirrors enabled().
+   */
+  function whyNoTags() {
+    if (!sendGate()) return 'this side\'s send capability is off (caps.mediaTransfer)';
+    if (!match || !match.peerSupportsTransfer) return 'the peer\'s build does not advertise transfer (stale page?)';
+    if (!match.localMediaTransfer) return 'our lobby send toggle is off';
+    if (!match.remoteMediaTransfer) return 'their lobby send toggle is off';
+    if (!transport || !transport.supportsBulk) return 'no bulk lane on this link (relay fallback)';
+    if (!channel || !channel.helloSeen) return 'the peer never said xfer_hello';
+    let sendable = -1;
+    try { sendable = eligible().length + seen.size; } catch (_e) { /* leave -1 */ }
+    return 'no artifact landed yet (sendable=' + sendable + ', in flight=' + inFlightCount()
+      + ', landed=' + landed.length + ', consumed=' + consumed + ')';
+  }
+
+  /** Reasons already said this match — the diagnostic prints each ONCE, not per throw. */
+  const saidWhy = new Set();
+
+  /**
    * The tags for one payload, or [] when nothing has landed / the feature is off.
    * `[]` IS THE NORMAL PATH: the payload then fires exactly as it does today, and a drop can
    * never block on a transfer.
+   *
+   * THE WARN IS THE PLAY-TEST'S EYES (2026-08-05). "It defaults to local media" reached the
+   * owner three times with three different root causes upstream of here (relay link, the
+   * un-advertised transfer cap, a stale phone page) and every round was diagnosed by
+   * archaeology. A media-kind payload leaving untagged now SAYS WHY, once per distinct
+   * reason per match — warn level, because that is what reaches the C# log and the phone's
+   * ?debug=1 overlay.
    */
   function tagsFor(kind) {
-    if (!enabled()) return [];
     if (!XFER_KINDS.has(kind)) return [];
-    const want = KIND_TAGS[kind] || 1;
-    const mediaKind = KIND_MEDIA[kind];
     const out = [];
-    for (const a of landed) {
-      if (a.kind !== mediaKind) continue;
-      out.push('xfer:' + a.sha);
-      if (out.length >= want) break;
+    if (enabled()) {
+      const want = KIND_TAGS[kind] || 1;
+      const mediaKind = KIND_MEDIA[kind];
+      for (const a of landed) {
+        if (a.kind !== mediaKind) continue;
+        out.push('xfer:' + a.sha);
+        if (out.length >= want) break;
+      }
+    }
+    if (!out.length) {
+      const why = whyNoTags();
+      if (!saidWhy.has(why)) {
+        saidWhy.add(why);
+        warn('payload kind ' + kind + ' fired untagged — ' + why + ' (said once per reason)');
+      }
     }
     return out;
   }
@@ -436,6 +471,7 @@ export function createMediaQueue({
   /** Unbind everything. A NAMED function, so `attach` never depends on a `this` binding. */
   function detach() {
     attached = false;
+    saidWhy.clear();                 // a new match earns fresh diagnostics
     stopPoll();
     for (const off of unsubs) { try { off(); } catch (_e) { /* ignore */ } }
     unsubs = [];
@@ -485,7 +521,10 @@ export function createMediaQueue({
       origFire = match.tryFirePayload.bind(match);
       wrappedFire = (req) => {
         let out = req;
-        if (req && XFER_KINDS.has(req.kind) && !req.tags && enabled()) {
+        // No enabled() pre-check here: tagsFor answers [] when the lane is off
+        // AND says why (once per reason) — the pre-check was hiding exactly the
+        // failures the 2026-08-05 play-tests needed named.
+        if (req && XFER_KINDS.has(req.kind) && !req.tags) {
           const tags = tagsFor(req.kind);                  // [] when nothing has landed
           if (tags.length) out = Object.assign({}, req, { tags });
         }

--- a/ConditioningControlPanel/Resources/web/goon/net/signaling.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/signaling.js
@@ -235,7 +235,14 @@ export class GoonSignalingClient {
 
   /** Records `ice_servers` off a parsed /invite or /join response. Absent = old server = no-op. */
   _noteIceServers(json) {
-    if (json && Array.isArray(json.ice_servers)) this.iceServers = sanitizeIceServers(json.ice_servers);
+    if (json && Array.isArray(json.ice_servers)) {
+      this.iceServers = sanitizeIceServers(json.ice_servers);
+      // WARN, not info (2026-08-05 diagnostics): this is the receipt that the
+      // room actually carried TURN entries — 0 here means the SERVER minted
+      // nothing (key/provider trouble), before any browser gathering runs.
+      this._warn(`room carried ${this.iceServers.length} ice server entr(ies)`
+        + (this.iceServers.length !== json.ice_servers.length ? ` (${json.ice_servers.length} raw, rest dropped by sanitize)` : ''));
+    }
     return this.iceServers;
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
@@ -378,8 +378,29 @@ export class GoonWebRtcTransport extends GoonTransportBase {
        * media transfer (P2P-only by design) never gets a channel to run on. */
       const iceServers = STUN_URLS.map((urls) => ({ urls }))
         .concat(Array.isArray(this._signaling?.iceServers) ? this._signaling.iceServers : []);
+      /* DIAGNOSTIC WARNS, deliberately (2026-08-05): info lines die before the
+       * C# log and the phone's ?debug=1 overlay, and this exact spot is where
+       * three play-test evenings' worth of "still relayed" questions get their
+       * answer — did the room carry TURN entries at all, did the browser take
+       * them, and what did gathering actually produce. */
+      const turnEntries = iceServers.filter((s) => {
+        const u = Array.isArray(s.urls) ? s.urls : [s.urls];
+        return u.some((x) => /^turns?:/i.test(String(x)));
+      }).length;
+      this._warn(`ice config: ${iceServers.length} entr(ies), ${turnEntries} carrying turn urls`);
       const pc = new RTCPeerConnection({ iceServers });
       this._pc = pc;
+      const iceTally = { host: 0, srflx: 0, relay: 0, prflx: 0 };
+      pc.onicecandidateerror = (e) => {
+        // 701 = unreachable/DNS (often noise when one of several urls is slow);
+        // 401/403 from a TURN url = credentials refused — THE line to look for.
+        this._warn(`ice candidate error ${e && e.errorCode}: ${(e && e.errorText) || ''} (${(e && e.url) || '?'})`);
+      };
+      pc.onicegatheringstatechange = () => {
+        if (pc.iceGatheringState === 'complete') {
+          this._warn(`ice gathering complete: host=${iceTally.host} srflx=${iceTally.srflx} relay=${iceTally.relay} prflx=${iceTally.prflx}`);
+        }
+      };
 
       // SYMMETRIC AND IMMEDIATE, on both roles, before any offer/answer work. A negotiated channel
       // is out-of-band by definition, so both sides must create it themselves and neither will see
@@ -401,6 +422,8 @@ export class GoonWebRtcTransport extends GoonTransportBase {
       pc.onicecandidate = (e) => {
         // Trickle: every candidate goes out the moment it is gathered.
         if (!e || !e.candidate || this.isDisposed) return;
+        const t = String(e.candidate.type || '');
+        if (t in iceTally) iceTally[t]++;
         try { this._enqueueSignal('ice', JSON.stringify(e.candidate.toJSON())); }
         catch (err) { this._info(`Failed to queue local candidate: ${(err && err.message) || err}`); }
       };

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -722,6 +722,86 @@ function mountRecap(result) {
     q.detach();
     a.dispose(); b.dispose(); pair.dispose();
   }
+
+  // ------------------- 6c. BOOT'S SEEDING ORDER — the 2026-08-05 field bug
+  // boot.js seeds the standing declarations inside attachMatch, and
+  // net/session.js raises onCurrentMatchChanged from _beginSession — BEFORE
+  // createInvite/join has moved the phase off Idle. Until 2026-08-05 the
+  // setters were Lobby/Consent-only and SILENTLY refused that call on both
+  // seats of every fresh P2P match: the opt-in never rode a consent frame and
+  // every attack fell back to the receiver's local pool, while this suite
+  // stayed green because every test seeded AFTER adoptLobby(). This section
+  // seeds in boot's order and would have caught it.
+  {
+    const caps = localCaps({ transfer: true });
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const a = new GoonMatchService(pair.host, true, { logger: quiet, caps, displayName: 'A', tag: 'GG:A6c' });
+    const b = new GoonMatchService(pair.guest, false, { logger: quiet, caps, displayName: 'B', tag: 'GG:B6c' });
+
+    // attachMatch runs NOW — the phase is still Idle on both seats.
+    ok(a.phase === GoonMatchPhase.Idle && b.phase === GoonMatchPhase.Idle,
+      '6c: both matches are Idle when boot would seed them', `${a.phase}/${b.phase}`);
+    ok(a.setMediaTransfer(true) === true, '6c: the Idle-phase media seed is TAKEN, not silently refused');
+    ok(b.setMediaTransfer(true) === true, '6c: ...on the guest seat too');
+    ok(a.setLocalVoiceNotes(true) === true, '6c: and the voice-note twin takes the Idle seed the same way');
+
+    // ...then createInvite/join flips the phase and the lobby walk happens.
+    a.adoptLobby(); b.adoptLobby();
+    await pair.connect();
+    await tick(60);
+    a.proposeConsent(600, 0, 30000);
+    await tick(40);
+    a.confirmConsent();
+    b.confirmConsent();
+    await tick(60);
+
+    ok(a.phase === GoonMatchPhase.Draft && b.phase === GoonMatchPhase.Draft,
+      '6c: the pair consented and drafted with no extra frames', `${a.phase}/${b.phase}`);
+    ok(a.localMediaTransfer === true && a.remoteMediaTransfer === true,
+      '6c: the host reads BOTH opt-ins true', `${a.localMediaTransfer}/${a.remoteMediaTransfer}`);
+    ok(b.localMediaTransfer === true && b.remoteMediaTransfer === true,
+      '6c: and so does the guest', `${b.localMediaTransfer}/${b.remoteMediaTransfer}`);
+    ok(a.mediaTransferAgreed === true && b.mediaTransferAgreed === true,
+      '6c: mediaTransferAgreed on both seats — the queue\'s consent legs pass');
+    ok(b.remoteVoiceNotes === true, '6c: the guest heard the host\'s voice declaration too');
+
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  // ---------- 6d. the asymmetric seat: one side never opts in (stale page)
+  // The exact field verdict from the 08-05 hunt: the desktop's tracer said
+  // "their lobby send toggle is off". A peer that never seeds (an old cached
+  // build, or a player who unticked the box) must gate BOTH directions, and
+  // the opted-in side's remoteMediaTransfer is the leg that says why.
+  {
+    const caps = localCaps({ transfer: true });
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const a = new GoonMatchService(pair.host, true, { logger: quiet, caps, displayName: 'A', tag: 'GG:A6d' });
+    const b = new GoonMatchService(pair.guest, false, { logger: quiet, caps, displayName: 'B', tag: 'GG:B6d' });
+    ok(a.setMediaTransfer(true) === true, '6d: host opted in at Idle');
+    // The guest NEVER calls setMediaTransfer — the stale-page seat.
+    a.adoptLobby(); b.adoptLobby();
+    await pair.connect();
+    await tick(60);
+    a.proposeConsent(600, 0, 30000);
+    await tick(40);
+    a.confirmConsent();
+    b.confirmConsent();
+    await tick(60);
+
+    ok(a.localMediaTransfer === true && a.remoteMediaTransfer === false,
+      '6d: the host reads local ON, remote OFF — mediaQueue names "their lobby send toggle is off"');
+    ok(b.localMediaTransfer === false && b.remoteMediaTransfer === true,
+      '6d: the guest reads the mirror image');
+    ok(a.mediaTransferAgreed === false && b.mediaTransferAgreed === false,
+      '6d: nobody transfers until BOTH declare — one stale seat gates both directions');
+
+    a.dispose(); b.dispose(); pair.dispose();
+  }
 }
 
 /* ===========================================================================

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -122,6 +122,20 @@
   line-height: 1.6;
 }
 
+/* The build stamp (ui/screens/title.js, bridge.js GOON_BUILD): the quiet
+ * "which build is this device on" answer for cross-device play-tests. Even
+ * more muted than the fineprint on purpose — readable when you look for it,
+ * invisible when you do not. */
+.gg-title-buildstamp {
+  margin: 0.5rem auto 0;
+  color: var(--gg-text-4);
+  opacity: 0.65;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-align: center;
+  user-select: text;
+}
+
 .gg-how-list {
   margin: 0.4rem 0 0;
   padding-left: 1.1rem;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -289,12 +289,19 @@ export function mount(container, ctx) {
     const caps = (ctx.session && ctx.session.caps) || {};
     const t = getTransport ? getTransport() : null;
     const onP2P = !!(t && t.state === GoonTransportState.ConnectedP2P);
+    /* Only a transport that has SETTLED somewhere else gets the terminal
+     * "relayed" sentence. During Signaling/ConnectingP2P the honest answer is
+     * "still deciding" — showing the verdict early is how the 2026-08-05
+     * play-test phone confirmed consent with the box greyed and spent the
+     * whole match reading "their toggle is off" on the other screen. */
+    const stillDeciding = !!(t && (t.state === GoonTransportState.Signaling
+      || t.state === GoonTransportState.ConnectingP2P));
     const editable = match.phase === GoonMatchPhase.Consent || match.phase === GoonMatchPhase.Lobby;
 
     let why = '';
     if (caps.mediaTransfer !== true) why = S.lobby.transferNoPremium;
     else if (!match.peerSupportsTransfer) why = S.lobby.transferPeerOld;
-    else if (!onP2P) why = S.lobby.transferRelay;
+    else if (!onP2P) why = stillDeciding ? S.lobby.transferConnecting : S.lobby.transferRelay;
 
     if (document.activeElement !== xferRow.input) xferRow.input.checked = !!match.localMediaTransfer;
     xferRow.input.disabled = !!why || !editable;
@@ -359,6 +366,9 @@ export function mount(container, ctx) {
   // already paints on a clear is the whole visible half.
   ledger.listen(xferRow.input, 'change', () => {
     match.setMediaTransfer(!!xferRow.input.checked);
+    // The STANDING answer, not just this match's: boot seeds the next lobby
+    // from it (default ON since 2026-08-05; an untick here is the opt-out).
+    prefs?.set?.('mediaTransferEnabled', !!xferRow.input.checked);
     paintTransfer();
     paintConfirm();
   });

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
@@ -14,6 +14,7 @@
 import { createLedger, el, button } from '../router.js';
 import { S } from '../strings.js';
 import { formatBytes } from '../assetsStore.js';
+import { GOON_BUILD } from '../../bridge.js';
 
 export function mount(container, ctx) {
   const ledger = createLedger();
@@ -119,6 +120,12 @@ export function mount(container, ctx) {
   }
 
   card.appendChild(el('p', { class: 'gg-title-fineprint', text: S.title.fineprint }));
+
+  /* THE BUILD STAMP (bridge.js GOON_BUILD). One muted line so a play-tester can
+   * tell at a glance whether a device — the iPhone especially, whose Safari
+   * cache outlives deploys — is running the build that was just shipped. It is
+   * a diagnostic, not branding: it must never grow, animate, or move up. */
+  card.appendChild(el('p', { class: 'gg-title-buildstamp', text: 'build ' + GOON_BUILD }));
 
   // NOTE: #gg-boot-ok is owned by boot.js and lives on <body> — it has to stay
   // readable on every screen, not just this one, or the play-test driver loses

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -134,6 +134,13 @@ export const S = Object.freeze({
     transferNoPremium: 'sending is a supporter perk — you can still receive theirs.',
     transferPeerOld: 'their app is too old for this — nothing crosses either way.',
     transferRelay: 'only on a direct connection. this one is relayed.',
+    /**
+     * ICE is still deciding (2026-08-05). The old code showed transferRelay
+     * during the 10-20s negotiation window, players read the terminal verdict,
+     * confirmed consent without the box, and the un-grey a few seconds later
+     * went unseen — the peer then spent the whole match "toggle off".
+     */
+    transferConnecting: 'checking the connection — this unlocks if it comes up direct…',
     transferTheirsOn: 'they opted in',
     transferTheirsOff: 'they have not',
     /* --- "they are still picking their media" (the `media_prep` wire message).


### PR DESCRIPTION
Diagnostic warn (once per reason per match) naming the first failing transfer gate — reaches the desktop Serilog and the phone ?debug=1 overlay. All suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaAgZYfCffPA4vHvWDVAxQ