### PR TITLE
feat(goon): peer-first payload rendering (burst keeps using received media)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -40,7 +40,7 @@ export const PROTOCOL = 1;
  * the title screen prints it under the fineprint, so ONE GLANCE at either
  * device answers the question. Format: r<round>-<yyyymmdd>[letter].
  */
-export const GOON_BUILD = 'r6-20260805';
+export const GOON_BUILD = 'r7-20260805';
 
 const win = (typeof window !== 'undefined') ? window : null;
 const webview = (win && win.chrome && win.chrome.webview) ? win.chrome.webview : null;

--- a/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
@@ -750,11 +750,19 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
     if (live.size >= MAX_LIVE) return;
     if (!media || typeof media.drawKind !== 'function') return;
 
-    // media.js kinds are image|video; GIFs ride as images.
+    // media.js kinds are image|video; GIFs ride as images. A PEER run spends
+    // its exact xfer: tags first, then keeps drawing from whatever else the
+    // opponent has transferred this match (media.drawReceived) — the local
+    // library is the last resort, not the rest of the burst.
     const drawWith = takeTag(run);
-    const entry = (typeof media.drawFor === 'function')
+    const wantPeer = !!(run && run.peer);
+    let entry = (drawWith && typeof media.drawFor === 'function')
       ? media.drawFor('image', drawWith)
-      : media.drawKind('image');
+      : null;
+    if (wantPeer && (!entry || entry.provenance !== 'peer') && typeof media.drawReceived === 'function') {
+      entry = media.drawReceived('image') || entry;
+    }
+    if (!entry) entry = media.drawKind('image');
     if (!entry) return;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     if (!handle || !handle.url) return;
@@ -787,6 +795,7 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
 
     const rec = {
       node: img, handle, x: pos.x, y: pos.y, gen, tune, popped: false, kill: null,
+      peer: wantPeer,                         // hydra children keep drawing peer media
       rot,                                    // tilt, re-applied by every paint()
       dx: 0, dy: 0,                           // drag/fling offset in px off the anchor
       sizeVmin, baseSizeVmin: sizeVmin,       // current vs. born size (the wheel clamp)
@@ -883,7 +892,10 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
       // A live sustained run re-tunes the children to the CURRENT intensity;
       // otherwise they inherit whatever tune spawned their parent.
       const tune = sustained ? flashTuning(sustained.intensity, calm) : rec.tune;
-      soon(() => showOne(tune, opts), HATCH_MS[k] != null ? HATCH_MS[k] : 70 + k * 140);
+      // A child of a peer flash is still the opponent's moment: pass a tagless
+      // peer run so it draws received media too (takeTag on it answers null).
+      const kidRun = rec.peer ? { peer: true } : undefined;
+      soon(() => showOne(tune, opts, kidRun), HATCH_MS[k] != null ? HATCH_MS[k] : 70 + k * 140);
     }
   }
 
@@ -956,6 +968,10 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
         // tags, which is every payload before this feature and every payload on a
         // relayed connection.
         tags: xferTags(payload),
+        // PEER run: after `tags` is spent, showOne keeps drawing from the
+        // received store instead of the local library (null in solo, where
+        // nothing was ever received — the fallback is unchanged there).
+        peer: true,
       };
       let finished = false;
       const settle = (endured) => {

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -70,6 +70,9 @@ export function createGoonMediaPool() {
    */
   const received = new Map();
 
+  /** Last sha drawReceived handed out per kind, so a 2-3 file pool doesn't strobe. */
+  const lastPeerPick = { image: '', video: '' };
+
   /** Injected (never imported): {knows(sha), isBlocked(sha)} from net/blocklist.js. */
   let blocklist = null;
 
@@ -357,6 +360,34 @@ export function createGoonMediaPool() {
         }
       }
       return drawKindInner(kind);                                          // <- today's line
+    },
+
+    /**
+     * A random received (peer) artifact of that kind, or null. This is how a
+     * PAYLOAD keeps rendering the sender's files after its few `xfer:` tags are
+     * spent (2026-08-05 play-test: one desktop gif and then local-only reads as
+     * "the transfer doesn't work"): everything the opponent has transferred this
+     * match is fair game, and the pool only grows as the queue keeps landing.
+     *
+     * The header's invariant survives because ONLY payload render paths call
+     * this — draw()/drawKind() still never surface a peer file, so their media
+     * still appears exactly where a payload of theirs asked for it. Blocklist
+     * and kind agreement ride on viewReceived; with any choice at all the same
+     * sha is never handed out twice in a row.
+     */
+    drawReceived(kind) {
+      const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
+      if (!want) return null;
+      const pool = [];
+      for (const sha of received.keys()) {
+        const v = viewReceived(sha, want);
+        if (v) pool.push(v);
+      }
+      if (!pool.length) return null;
+      let at = (Math.random() * pool.length) | 0;
+      if (pool.length > 1 && pool[at].sha === lastPeerPick[want]) at = (at + 1) % pool.length;
+      lastPeerPick[want] = pool[at].sha;
+      return pool[at];
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/goon/exec/videos.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/videos.js
@@ -1401,9 +1401,16 @@ export function createVideos({ layers, media, audio, logger, onWindowCountChange
     if (mayEvict === false && wins.length >= MAX_WINDOWS) return null;
     if (!media || typeof media.drawKind !== 'function') return null;
 
-    const entry = (typeof media.drawFor === 'function')
+    let entry = (typeof media.drawFor === 'function')
       ? media.drawFor('video', payload || null)
       : media.drawKind('video');
+    // A PAYLOAD window whose tag missed (not landed yet, blocklisted) or that
+    // carried no tag at all still prefers any clip the opponent already
+    // transferred this match over our own library — same peer-first rule as
+    // exec/flashes.js. Element runs and spawnLocal pass no payload: untouched.
+    if (payload && (!entry || entry.provenance !== 'peer') && typeof media.drawReceived === 'function') {
+      entry = media.drawReceived('video') || entry;
+    }
     if (!entry) return null;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     if (!handle || !handle.url) return null;

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -4286,18 +4286,21 @@ async function main() {
     await sleep(GHOST_WAIT);
     for (const id of LAYER_IDS) byId.get(id).replaceChildren();
 
-    // An untagged payload is byte-for-byte the old behaviour.
+    // An untagged payload is still PEER-FIRST (2026-08-05: "the attacks are a
+    // transfer, every time"): any clip the opponent already transferred this
+    // match beats the receiver's own library. Only an empty received store
+    // reads as the old behaviour — covered by the drawFor suite above.
     R.renderPayload({ id: 'pT2', duration_ms: 40000, intensity: 0.5 }, () => {});
     const plainVid = liveWins(host)[0].findAll('gg-vwin-vid')[0];
-    ok(plainVid.src.startsWith('https://ccp.assets/'),
-      'an untagged Video payload draws from the receiver\'s library exactly as before', plainVid.src);
+    ok(plainVid.src === 'https://ccp.cache/recv/b.mp4',
+      'an untagged Video payload still prefers a clip the opponent transferred this match', plainVid.src);
     ex.stopAll();
     ex.detach();
     await sleep(GHOST_WAIT);
     for (const id of LAYER_IDS) byId.get(id).replaceChildren();
   }
 
-  // ------------------------------- flashes: up to XFER_TAGS_MAX, each spent once
+  // ------------- flashes: exact tags first, then the received store, own last
   {
     for (const id of LAYER_IDS) byId.get(id).replaceChildren();
     const host = byId.get('gg-fx-flash');
@@ -4318,7 +4321,10 @@ async function main() {
     ex.attach(fakeMatch());
     const R = ex.rendererFor(GoonElement.Flashes);
 
-    // FOUR tags offered; the cap is three, and each of those is spent exactly once.
+    // FOUR tags offered; the cap is three EXACT spends, and past them the burst
+    // keeps drawing the sender's files from the received store — the receiver's
+    // own library is the last resort, not the rest of the squall (2026-08-05
+    // play-test: "one desktop gif then local-only" read as a broken transfer).
     const cancel = R.renderPayload({
       id: 'pF1', duration_ms: 4000, intensity: 0.8,
       tags: tagShas.map((s) => 'xfer:' + s),
@@ -4327,16 +4333,16 @@ async function main() {
     const srcs = host.findAll('gg-flash').map((el) => el.src || '');
     const peer = srcs.filter((s) => s.startsWith('https://ccp.cache/recv/'));
     const own = srcs.filter((s) => s.startsWith('https://ccp.assets/'));
-    ok(peer.length === 3,
-      'a burst shows at most XFER_TAGS_MAX of the sender\'s images — the rest is the receiver\'s '
-      + 'own library, which is what keeps a 30-flash squall from costing 30 transfers',
+    ok(peer.length > 3,
+      'the burst stays on the SENDER\'s images past the three exact tag spends — '
+      + 'the received store feeds the rest of the squall',
       `${peer.length} peer / ${own.length} own`);
-    ok(new Set(peer).size === peer.length,
-      'and each landed artifact is spent ONCE — a repeated file reads as a bug, not as emphasis',
-      peer.join(','));
-    ok(!peer.includes('https://ccp.cache/recv/t3.png'),
-      'the fourth tag was never used: the cap is a cap, not a suggestion');
-    ok(own.length > 0, 'the burst kept going on our own images after the tags ran out', String(own.length));
+    for (const i of [0, 1, 2]) {
+      ok(peer.includes('https://ccp.cache/recv/t' + i + '.png'),
+        `exact tag ${i} was spent on its own flash before the random received draws`, peer.join(','));
+    }
+    ok(own.length === 0,
+      'the receiver\'s own library never shows while received artifacts exist', String(own.length));
     cancel();
     ex.stopAll();
     ex.detach();


### PR DESCRIPTION
Round-13 play-test verdict: the transfer works, but only the FIRST flash of a burst showed the sender's file. A burst carries max 3 exact xfer tags; every later flash fell back to the receiver's own library by design. Now: exact tags first, then random draws from everything the opponent has transferred this match (received store), own library only as last resort. Applies to FlashBurst (incl. hydra children) and Video payloads. draw()/drawKind() untouched - peer media still only ever appears where a payload asked. Selftests: exec 959 pass (assertions updated), transfer/flow/hud/net/report green; avafx 12 fails pre-existing on clean HEAD. GOON_BUILD r7-20260805.