### PR TITLE
fix(goon): incoming-throw preview learns the received rung

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -40,7 +40,7 @@ export const PROTOCOL = 1;
  * the title screen prints it under the fineprint, so ONE GLANCE at either
  * device answers the question. Format: r<round>-<yyyymmdd>[letter].
  */
-export const GOON_BUILD = 'r7-20260805';
+export const GOON_BUILD = 'r7-20260805a';
 
 const win = (typeof window !== 'undefined') ? window : null;
 const webview = (win && win.chrome && win.chrome.webview) ? win.chrome.webview : null;

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -389,6 +389,23 @@ export function createGoonMediaPool() {
       lastPeerPick[want] = pool[at].sha;
       return pool[at];
     },
+
+    /**
+     * drawReceived without the echo-guard write: ui/throwPreview.js's rung for
+     * "the render will draw SOME received artifact" (representative, not exact
+     * — same contract as peekKind, and mutating lastPeerPick from a preview
+     * would let the preview change what it is previewing).
+     */
+    peekReceived(kind) {
+      const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
+      if (!want) return null;
+      const pool = [];
+      for (const sha of received.keys()) {
+        const v = viewReceived(sha, want);
+        if (v) pool.push(v);
+      }
+      return pool.length ? pool[(Math.random() * pool.length) | 0] : null;
+    },
   };
 }
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/throwPreview.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/throwPreview.js
@@ -310,6 +310,25 @@ function fromTags(mediaKind, payload) {
   return null;
 }
 
+/**
+ * The peer-first middle rung (mirrors exec/media.js drawFor + drawReceived):
+ * an untagged payload — or one whose tag has not landed — still renders from
+ * the received store when anything of that kind has landed, so the preview
+ * must guess PEER before it guesses own-library. Representative, not exact:
+ * peekReceived never touches the render's echo guard.
+ */
+function fromReceived(mediaKind) {
+  if (!pool || typeof pool.peekReceived !== 'function') return null;
+  let entry = null;
+  try { entry = pool.peekReceived(mediaKind); } catch (_e) { entry = null; }
+  if (!entry) return null;
+  let h = null;
+  if (typeof entry.acquire === 'function') { try { h = entry.acquire(); } catch (_e) { h = null; } }
+  const url = (h && h.url) || entry.url;
+  if (!url) { releaseHandle(h); return null; }
+  return { url: String(url), release: () => releaseHandle(h), provenance: 'peer', exact: false };
+}
+
 /** The representative half: our own deck, PEEKED — see the header. */
 function fromOwnPool(mediaKind) {
   if (!pool || typeof pool.peekKind !== 'function') return null;
@@ -337,7 +356,11 @@ function fromOwnPool(mediaKind) {
 export function resolvePreview(kind, payload) {
   const mediaKind = PREVIEW_MEDIA_KIND[kind];
   if (!mediaKind) return null;
-  const hit = fromTags(mediaKind, payload) || fromOwnPool(mediaKind);
+  // The received rung is INBOUND-only (payload present): an outbound preview
+  // shows what WE are about to send, and that draw is always our own library.
+  const hit = fromTags(mediaKind, payload)
+    || (payload ? fromReceived(mediaKind) : null)
+    || fromOwnPool(mediaKind);
   return hit ? Object.assign({ mediaKind }, hit) : null;
 }
 


### PR DESCRIPTION
With peer-first rendering (#126) the receiver draws from the received store when the exact tag misses or is absent, but the incoming-throw thumbnail still guessed from the local library - the owner saw their own video as the thumb while the landing clip was the sender's. Preview resolution now mirrors the render: exact tag, then received store (inbound only - outbound previews still show what WE send), then own-library peek. peekReceived is echo-guard-free so a preview can never change what it previews. Selftests: exec 959, hud 1498, flow 218, transfer 176, report 213 all green. GOON_BUILD r7-20260805a.