### PR TITLE
fix(goon): startup sendable=0 race + lobby ammo hint

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -40,7 +40,7 @@ export const PROTOCOL = 1;
  * the title screen prints it under the fineprint, so ONE GLANCE at either
  * device answers the question. Format: r<round>-<yyyymmdd>[letter].
  */
-export const GOON_BUILD = 'r7-20260805a';
+export const GOON_BUILD = 'r7-20260805b';
 
 const win = (typeof window !== 'undefined') ? window : null;
 const webview = (win && win.chrome && win.chrome.webview) ? win.chrome.webview : null;

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
@@ -545,6 +545,17 @@ export function createMediaQueue({
     markConsumed,
     enabled,
 
+    /**
+     * How many local artifacts could be offered RIGHT NOW. The lobby's honesty
+     * line: every consent/connection gate can pass and the lane still starves
+     * when the library was never compressed (round-11's "sendable=0" — the last
+     * root cause of the 2026-08-05 saga), and only a number the UI can read
+     * turns that from archaeology into a sentence on the screen.
+     */
+    sendableCount() {
+      try { return eligible().length; } catch (_e) { return 0; }
+    },
+
     /** @returns {() => void} unsubscribe. {sha, kind, mime, bytes, url} for INBOUND landings. */
     onReceived(fn) {
       if (typeof fn !== 'function') return noop;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -303,10 +303,20 @@ export function mount(container, ctx) {
     else if (!match.peerSupportsTransfer) why = S.lobby.transferPeerOld;
     else if (!onP2P) why = stillDeciding ? S.lobby.transferConnecting : S.lobby.transferRelay;
 
+    /* Ammo honesty (round-11's last root cause): everything above can pass and
+     * the lane still starves when nothing local is compressed. A HINT, not a
+     * block — the box stays live (receiving works regardless) and the 1s
+     * repaint updates the line as compression fills the count. */
+    let hint = '';
+    if (!why && ctx.mediaQueue && typeof ctx.mediaQueue.sendableCount === 'function') {
+      try { if (match.localMediaTransfer && ctx.mediaQueue.sendableCount() === 0) hint = S.lobby.transferNoAmmo; }
+      catch (_e) { /* never let the hint break the paint */ }
+    }
+
     if (document.activeElement !== xferRow.input) xferRow.input.checked = !!match.localMediaTransfer;
     xferRow.input.disabled = !!why || !editable;
     xferRow.row.classList.toggle('is-disabled', !!why);
-    xferRow.sub.textContent = why || S.lobby.transferSub;
+    xferRow.sub.textContent = why || hint || S.lobby.transferSub;
     xferRow.value.textContent = match.remoteMediaTransfer
       ? S.lobby.transferTheirsOn : S.lobby.transferTheirsOff;
   }

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -141,6 +141,13 @@ export const S = Object.freeze({
      * went unseen — the peer then spent the whole match "toggle off".
      */
     transferConnecting: 'checking the connection — this unlocks if it comes up direct…',
+    /**
+     * The lane is ON but the local library has nothing compressed to offer
+     * (round-11: every gate green, sendable=0, attacks silently fell back to
+     * the receiver's own pool). Not a block — receiving still works and the
+     * count climbs live as compression runs — just the honest reason.
+     */
+    transferNoAmmo: 'nothing ready to send yet — compress your library in the media screen, or your attacks will use their media instead.',
     transferTheirsOn: 'they opted in',
     transferTheirsOff: 'they have not',
     /* --- "they are still picking their media" (the `media_prep` wire message).

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -140,6 +140,12 @@ namespace ConditioningControlPanel.Services.GoonGame
                 {
                     Transfer.TransferCacheStore.Instance.EnsureRoot();
                     Transfer.TransferCompressionService.Instance.Initialize();   // idempotent
+                    // Kick the plan refresh NOW instead of waiting for the page's cache hello:
+                    // after a cold app start the first match could reach Live with listSendable
+                    // still empty (the transfer lane then fires every payload untagged) because
+                    // nothing had asked the planner yet. RefreshAsync is one-pass-gated and
+                    // queues exempt-lane hashing (and auto-compress when enabled) off-thread.
+                    _ = Task.Run(() => Transfer.TransferCompressionService.Instance.RefreshAsync());
                 }
                 catch (Exception ex) { App.Logger?.Warning("GoonHostService: transfer cache init: {E}", ex.Message); }
 


### PR DESCRIPTION
GoonHostService.Launch kicks the compression plan refresh at window open (cold-start matches no longer reach Live with an empty listSendable); mediaQueue.sendableCount() + lobby transfer-row hint names the starved lane instead of silently falling back to the receiver pool. GOON_BUILD r7-20260805b. Selftests net/hud/flow/transfer green, C# build clean.