### PR TITLE
perf(goon): device-tiered lite mode for phones - fix iPhone lag and skipped frames

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -38,6 +38,10 @@ import * as layers from './exec/layers.js';
 // the only thing that resets it (see attachMatch). Import-safe: videos.js
 // touches no DOM at module scope.
 import { peerRenderLog, resetPeerRenderLog } from './exec/videos.js';
+// The device performance tier. The DETECTOR lives in exec/ (with the renderers
+// that obey it) and the PREF lives in ui/prefs.js (`perfMode`); this file is
+// where they meet, because boot imports both tiers by charter — see buildApp.
+import { applyPerfTier } from './exec/perfTier.js';
 
 import { GoonMatchService } from './core/match.js';
 import { GoonSuddenDeathRunner } from './core/suddenDeath.js';
@@ -1861,6 +1865,15 @@ async function startSolo() {
  * ==========================================================================*/
 function buildApp() {
   prefs = createPrefs(session.prefs);
+  /* STAMP THE PERFORMANCE TIER — <html data-gg-perf>, the attribute the lite
+   * CSS and every renderer cap key off. Before any renderer is built (the
+   * executor comes later in startup) so the first spawn already sees it, and
+   * re-stamped on every change of the pref so the options toggle reaches a
+   * match already running: the caps, the spiral throttle and the lite CSS all
+   * read it lazily. ui/prefs.js cannot mirror this one itself — resolving
+   * 'auto' needs the detector, which lives in exec/ (see the pref's banner). */
+  applyPerfTier(prefs.get('perfMode'));
+  prefs.subscribe((key, value) => { if (key === 'perfMode') applyPerfTier(value); });
   audio = createAudio({ prefs, logger });
   toasts = createToasts({ prefs });
   sheets = createSheets({ audio, logger });

--- a/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
@@ -67,8 +67,14 @@
 // from a bundled file and not from a fresh roll — the flick should look like the
 // spirals this match has been showing, because it is one of them.
 import { pickSpiralImage } from './spiralGen.js';
+import { perfLite } from './perfTier.js';
 
 export const MAX_LIVE = 26;   // hard ceiling on bubble nodes, swarm included
+/* The LITE ceiling (exec/perfTier.js — phones). Bites in refresh(), on top of
+ * the width-based COUNT_MIN/COUNT_MAX below: those are captured at build off
+ * innerWidth, which lies on a phone held sideways (926px "wide" on the very
+ * iPhone this tier exists for), while the tier is read fresh on every cue. */
+export const MAX_LIVE_LITE = 10;
 const MAX_POP_FLASH = 4;      // pop-driven flash images live at once (payloadFx MAX_FLASH's cousin)
 const SWARM_BONUS = 4;        // extra bubbles a BubbleSwarm payload puts on the bed
 
@@ -483,11 +489,14 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
       return;
     }
     const want = Math.max.apply(null, wants);
+    // The tier's ceiling, read fresh: on lite the whole field — swarm bonus
+    // included — is clamped, and the mid-match toggle bites on the next cue.
+    const cap = perfLite() ? MAX_LIVE_LITE : MAX_LIVE;
     tune = bubbleTuning(want, calm, COUNT_MIN, COUNT_MAX);
-    targetCount = Math.min(MAX_LIVE, tune.targetCount + (payloadRuns.size ? SWARM_BONUS : 0));
+    targetCount = Math.min(cap, tune.targetCount + (payloadRuns.size ? SWARM_BONUS : 0));
     fieldTarget = elementIntensity === null
       ? 0
-      : Math.min(MAX_LIVE, bubbleTuning(elementIntensity, calm, COUNT_MIN, COUNT_MAX).targetCount);
+      : Math.min(cap, bubbleTuning(elementIntensity, calm, COUNT_MIN, COUNT_MAX).targetCount);
     ensureTopup();
   }
 
@@ -497,7 +506,9 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
   function sparkleBurst(x, y) {
     const host = layer();
     if (!host || typeof document === 'undefined') return;
-    const n = 9;
+    // 9 shards is DtRH's number; the lite tier throws 5 — each shard is a
+    // box-shadowed node minted mid-pop, exactly when the phone is busiest.
+    const n = perfLite() ? 5 : 9;
     for (let i = 0; i < n; i++) {
       const p = document.createElement('div');
       p.className = 'gg-spark';

--- a/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
@@ -91,8 +91,15 @@ import {
   pinchEligible, pinchDistance, pinchMidpoint, pinchStarted, pinchStep,
   viewportCap, pxToVmin, safeInsets,
 } from './pinch.js';
+import { perfLite } from './perfTier.js';
 
 export const MAX_LIVE = 20;          // concurrent <img> nodes, hydra children included
+/* The LITE tier's cap (exec/perfTier.js — phones). Half the field: each flash is
+ * a ~44vmin GPU layer and twenty of them is most of what an iPhone was choking
+ * on. Read LAZILY at every spawn (liveCap in the factory), never captured at
+ * build, so the options toggle reaches a burst already in flight — a tightened
+ * cap simply stops admitting nodes and the live ones age out on their own. */
+export const MAX_LIVE_LITE = 10;
 export const HYDRA_CHILDREN = 2;     // what one click hatches (clamped to the cap)
 export const BASE_HOLD_MS = 5000;    // on-screen time a flash is centred on
 const HOLD_SPREAD_MS = 400;          // ± this across the intensity range (4600..5400)
@@ -210,6 +217,8 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
   let stepLast = 0;
 
   const layer = () => (layers && typeof layers.get === 'function' ? layers.get('flash') : null);
+  /** THE cap, resolved fresh per ask — the device tier owns the difference. */
+  const liveCap = () => (perfLite() ? MAX_LIVE_LITE : MAX_LIVE);
   const warn = (m) => { if (log && log.warn) log.warn(`[gg:flashes] ${m}`); };
   const sfx = (id) => { if (audio && typeof audio.sfx === 'function') { try { audio.sfx(id); } catch (_e) { /* ignore */ } } };
 
@@ -747,7 +756,7 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
     prune();
     const host = layer();
     if (!host || typeof document === 'undefined') return;
-    if (live.size >= MAX_LIVE) return;
+    if (live.size >= liveCap()) return;
     if (!media || typeof media.drawKind !== 'function') return;
 
     // media.js kinds are image|video; GIFs ride as images. A PEER run spends
@@ -877,8 +886,9 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
 
     // Headroom measured BEFORE the dismissal frees this one's slot: kids <= room
     // means the post-click population is at most (live.size - 1 + room) =
-    // MAX_LIVE - 1. At the cap room is 0 and the click is a plain dismissal.
-    const room = Math.max(0, MAX_LIVE - live.size);
+    // the cap - 1. At the cap room is 0 and the click is a plain dismissal.
+    // liveCap(), not MAX_LIVE: the hydra spends the same headroom the tier set.
+    const room = Math.max(0, liveCap() - live.size);
     dismiss(rec);
     sfx('flash-pop');
 

--- a/ConditioningControlPanel/Resources/web/goon/exec/fx.css
+++ b/ConditioningControlPanel/Resources/web/goon/exec/fx.css
@@ -918,3 +918,48 @@ html[data-gg-vskip="on"] .gg-vwin-x { display: flex; }
   .gg-lock, .gg-lock.is-wrong { animation: none; }
   .gg-lock.is-solved { animation: none; opacity: 0; transition: opacity 300ms ease; }
 }
+
+/* ---------------------------------------------------------------------------
+ * THE LITE TIER — html[data-gg-perf="lite"], stamped by exec/perfTier.js
+ * (boot.js applies it; ui/prefs.js `perfMode` overrides the detection). This is
+ * the CSS HALF of the phone diet: the JS half (smaller caps, the spiral's
+ * 30fps/CSS-pixel throttle) lives in the renderers. Absent attribute = every
+ * rule above exactly as written, which is what keeps the desktop byte-identical.
+ *
+ * What goes, and why it is these and not others:
+ *   · the FLASH HALO. `drop-shadow` forces every flash — up to MAX_LIVE_LITE
+ *     44vmin layers — through an offscreen filter pass and inflates its texture
+ *     by the blur radius on all four sides. iOS pays that in layer memory it
+ *     does not have. The tilt, the fade and the whole gesture set survive.
+ *   · the DRAIN'S BLUR-BEHIND. backdrop-filter re-blurs everything under a
+ *     fullscreen pane every frame anything under it moves — the single most
+ *     expensive declaration on this page, on iOS by a distance. The veil keeps
+ *     its dim/desat/wash stack and leans a little harder on the dim
+ *     (0.42 -> 0.54) so "heavy" survives losing "blurry".
+ *   · the RASTER SPIRAL'S 1.1px blur. It hides wedge seams under MAGNIFICATION;
+ *     a phone shows the 1280px bake DOWNscaled, where there is nothing to hide.
+ *   · the WINDOW GLOW stack: three box-shadows on every .gg-vwin-inner plus two
+ *     on its breathing ::after. One pink ring each says the same thing for a
+ *     fraction of the texture. The border, the dot and the exits are untouched.
+ * What deliberately STAYS: the bubble kind halos (the coloured drop-shadow IS
+ * the kind — see the sprite banner), every gameplay pointer affordance, and
+ * every exit/teardown animation (a stranded node costs more than any shadow).
+ * ------------------------------------------------------------------------ */
+html[data-gg-perf="lite"] .gg-flash { filter: none; }
+html[data-gg-perf="lite"] .gg-flash--grabbed.is-held {
+  /* The lift keeps ONE cheap cue (the held scale is in the inline transform);
+     the double drop-shadow it wore is exactly the cost this tier exists to shed. */
+  filter: none;
+}
+html[data-gg-perf="lite"] .gg-drain {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  --gg-drain-dim: 0.54;
+}
+html[data-gg-perf="lite"] .gg-spiral { filter: none; }
+html[data-gg-perf="lite"] .gg-vwin-inner {
+  box-shadow: 0 0 18px rgba(var(--gg-pink-rgb), 0.45);
+}
+html[data-gg-perf="lite"] .gg-vwin-inner::after {
+  box-shadow: inset 0 0 14px rgba(var(--gg-pink-rgb), 0.3);
+}

--- a/ConditioningControlPanel/Resources/web/goon/exec/perfTier.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/perfTier.js
@@ -1,0 +1,151 @@
+/* ============================================================================
+ * exec/perfTier.js — THE DEVICE TIER. One question, answered in one place:
+ * is this machine allowed the full effect stack, or the lite one?
+ *
+ * WHY THIS EXISTS (2026-08-05). The owner play-tested a real 1v1 on an iPhone
+ * 13 Pro Max — no power-save, nothing else running — and got lag and skipped
+ * frames during live matches. The busy screen is the same one the desktop
+ * renders effortlessly: ~20 drop-shadowed flash <img>s, a 26-bubble field, a
+ * fullscreen two-layer WebGL spiral under a screen blend, up to four decoding
+ * <video> windows, and a fullscreen backdrop-filter drain pane. A phone GPU
+ * does not get to vote on any of that unless something tells the renderers to
+ * ask for less — this module is that something.
+ *
+ * TWO TIERS, NOT A DIAL. 'full' is the page exactly as it has always been;
+ * 'lite' lowers the concurrent-node caps, halves the spiral's frame rate and
+ * resolution, and swaps the iOS-catastrophic CSS (backdrop-filter, the big
+ * per-node drop-shadows) for flat equivalents. A dial would invite per-device
+ * tuning nobody can reproduce; a tier is a fact a bug report can name.
+ *
+ * HOW THE ANSWER TRAVELS — the same road every exec-visible preference already
+ * takes (data-gg-vskip, data-gg-shader, data-gg-fx): a ROOT ATTRIBUTE,
+ * `data-gg-perf`, stamped by boot.js from applyPerfTier() and re-stamped when
+ * the pref changes. exec/ modules read it lazily through perfLite(); the lite
+ * CSS keys off `html[data-gg-perf="lite"]`. exec/ never imports ui/ and ui/
+ * never imports exec/, and this module keeps both promises: the DETECTION
+ * lives here (exec/, importable by the renderers and by boot), the PREF lives
+ * in ui/prefs.js (`perfMode`), and boot.js — which imports both tiers by
+ * charter — is the one place they meet.
+ *
+ * ABSENT MEANS FULL. The attribute only exists once boot has stamped it, and a
+ * page that never did (the node self-tests, the import sweep, a bare harness)
+ * must behave exactly as it did before this module existed. Only the exact
+ * 'lite' value switches anything down — same polarity contract as
+ * data-gg-shader, and for the same reason.
+ *
+ * THE DETECTION IS DELIBERATELY COARSE, and desktop-safe by construction: a
+ * FINE-pointer machine can never resolve lite, whatever its memory claims,
+ * because the requirement is "desktop byte-identical" and a touchscreen
+ * laptop's deviceMemory is not a reason to change a desktop's picture. On a
+ * coarse-pointer device (a phone, a small tablet) either signal — a small
+ * viewport or a low navigator.deviceMemory (Chrome-only; Safari never exposes
+ * it, which is why it is a second vote and not the first) — lands on lite.
+ * The player can overrule either answer from the options drawer.
+ *
+ * Import-safe under node: nothing here touches the DOM at import, and every
+ * runtime read is guarded.
+ * ==========================================================================*/
+
+/** The root attribute, on <html>. Written by applyPerfTier (boot.js calls it). */
+export const PERF_ATTR = 'data-gg-perf';
+export const PERF_FULL = 'full';
+export const PERF_LITE = 'lite';
+
+/**
+ * A coarse-pointer viewport at or under this (its SMALLER dimension, so
+ * rotating a phone cannot flip the tier) is a phone or a small tablet. 820
+ * clears every iPhone (428 for the 13 Pro Max) and the 768 iPads while leaving
+ * the 1024 iPad Pros — which render the full stack fine — on full.
+ */
+export const LITE_VIEWPORT_MAX_PX = 820;
+
+/** navigator.deviceMemory at or under this GB is the second vote for lite.
+ *  Chrome-only and clamped to 8 by spec; Safari simply never casts it. */
+export const LITE_DEVICE_MEMORY_GB = 4;
+
+/**
+ * The tier, from a plain env bag — PURE, so the self-test can sweep the whole
+ * decision table without a window. Missing fields vote for full: an unreadable
+ * signal must never be the thing that degrades somebody's picture.
+ *
+ * @param {{coarse?:boolean, viewportMinPx?:number, deviceMemoryGb?:number}} [env]
+ * @returns {'full'|'lite'}
+ */
+export function detectPerfTier(env) {
+  const e = env && typeof env === 'object' ? env : {};
+  if (e.coarse !== true) return PERF_FULL;   // fine pointer = desktop = full, always
+  const minPx = (typeof e.viewportMinPx === 'number' && e.viewportMinPx > 0) ? e.viewportMinPx : Infinity;
+  if (minPx <= LITE_VIEWPORT_MAX_PX) return PERF_LITE;
+  const mem = (typeof e.deviceMemoryGb === 'number' && e.deviceMemoryGb > 0) ? e.deviceMemoryGb : Infinity;
+  if (mem <= LITE_DEVICE_MEMORY_GB) return PERF_LITE;
+  return PERF_FULL;
+}
+
+/** What this host actually is, read fresh. Every probe is guarded — a stub
+ *  without matchMedia or a window simply reads as a fine-pointer desktop. */
+export function readPerfEnv() {
+  const env = { coarse: false, viewportMinPx: 0, deviceMemoryGb: 0 };
+  try { env.coarse = typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches === true; }
+  catch (_e) { env.coarse = false; }
+  try {
+    if (typeof window !== 'undefined' && window && window.innerWidth > 0 && window.innerHeight > 0) {
+      env.viewportMinPx = Math.min(window.innerWidth, window.innerHeight);
+    }
+  } catch (_e) { /* stays 0 = unknown */ }
+  try {
+    const m = (typeof navigator !== 'undefined' && navigator) ? navigator.deviceMemory : undefined;
+    if (typeof m === 'number' && m > 0) env.deviceMemoryGb = m;
+  } catch (_e) { /* stays 0 = unknown */ }
+  return env;
+}
+
+/**
+ * The pref -> the tier. 'full' and 'lite' are the player's explicit answers and
+ * win outright; EVERYTHING else — 'auto', a corrupt store, an older client's
+ * boolean, undefined — falls through to detection, so a junk pref can only ever
+ * land on "what this device deserves", never on a frozen wrong answer.
+ * Pure and total, same contract as ui/prefs.js resolveArsenalOpen.
+ *
+ * @param {string} mode the stored `perfMode` pref
+ * @param {{coarse?:boolean, viewportMinPx?:number, deviceMemoryGb?:number}} [env]
+ *        injectable for tests; app code omits it and gets the real host
+ * @returns {'full'|'lite'}
+ */
+export function resolvePerfTier(mode, env) {
+  if (mode === PERF_FULL) return PERF_FULL;
+  if (mode === PERF_LITE) return PERF_LITE;
+  return detectPerfTier(env || readPerfEnv());
+}
+
+/**
+ * Resolve and STAMP. boot.js calls this once at startup (beside the
+ * data-gg-motion write) and again whenever the `perfMode` pref changes, so a
+ * toggle flipped mid-match reaches renderers that were built at startup — the
+ * caps, the spiral throttle and the lite CSS all read the attribute lazily.
+ * @param {string} mode the stored `perfMode` pref
+ * @returns {'full'|'lite'} what was stamped (or would have been, headless)
+ */
+export function applyPerfTier(mode) {
+  const tier = resolvePerfTier(mode);
+  try {
+    if (typeof document !== 'undefined' && document && document.documentElement) {
+      document.documentElement.setAttribute(PERF_ATTR, tier);
+    }
+  } catch (_e) { /* a host without a DOM has nothing to degrade */ }
+  return tier;
+}
+
+/**
+ * Is the LITE tier in force RIGHT NOW? The renderers' one entry point — read
+ * lazily at every spawn/refresh (never cached at build, or the options toggle
+ * would be a dead switch), and absent means full: a page nobody stamped is the
+ * page exactly as it was.
+ */
+export function perfLite() {
+  try {
+    if (typeof document === 'undefined' || !document || !document.documentElement) return false;
+    return document.documentElement.getAttribute(PERF_ATTR) === PERF_LITE;
+  } catch (_e) { return false; }
+}
+
+export default perfLite;

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
@@ -71,6 +71,7 @@
 
 import { createSpiralField, loopMsFor } from './spiralField.js';
 import { beginSpiralSession, nextSpiral } from './spiralGen.js';
+import { perfLite } from './perfTier.js';
 
 /* --- THE SHADER KILL SWITCH. The pref is ui/prefs.js's (`shaderSpirals`,
    default TRUE); it reaches this tier as a ROOT ATTRIBUTE, because exec/ does not
@@ -90,6 +91,16 @@ export const SHADER_OFF = 'off';               // …anything else, or absent, i
    display in front of this game can actually show. ------------------------- */
 export const MAX_DPR = 1.5;
 export const MAX_BACKING_PX = 3840 * 2160;
+/* --- THE LITE TIER'S HALF OF BOTH DIALS (exec/perfTier.js — phones). The
+   shader is a per-pixel per-frame cost and a phone GPU pays it twice over: a
+   Retina DPR and a 120Hz ProMotion rAF. So the lite tier draws at CSS pixels
+   (a screen-blended bed at <=0.70 opacity survives that with no visible loss)
+   and at ~30fps — the phase keeps real time either way (see step()), so a
+   throttled bed turns at exactly the tempo the full one does, in coarser
+   steps. Both read LAZILY, per resize/frame, so the options toggle reaches a
+   bed already spinning. ----------------------------------------------------- */
+export const LITE_MAX_DPR = 1;
+export const LITE_FRAME_MS = 33;   // ~30fps draw cadence on the lite tier
 
 /* --- THE IN-LOOP WATCHDOG. Checked once per HEALTH_CHECK_MS, never per frame:
    gl.getError()/isContextLost() can force a sync round-trip to the driver, which
@@ -154,6 +165,7 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   let onResize = null;
   let onVisibility = null;
   let lastCheck = 0;              // in-loop watchdog: last health poll (rAF timestamp ms)
+  let lastDraw = 0;               // lite-tier draw throttle: last frame actually rendered
   // A defence fired and this pane stays on raster until it is replaced. Cleared
   // only by teardown (a new pane earns a fresh try) or by a context RESTORE
   // inside the recovery budget — never by a repick, or a machine whose driver is
@@ -220,7 +232,8 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   function backingSize() {
     const w = (paneEl && paneEl.clientWidth) || (typeof innerWidth === 'number' ? innerWidth : 0);
     const h = (paneEl && paneEl.clientHeight) || (typeof innerHeight === 'number' ? innerHeight : 0);
-    const dpr = Math.min(MAX_DPR, (typeof devicePixelRatio === 'number' && devicePixelRatio > 0) ? devicePixelRatio : 1);
+    const dpr = Math.min(perfLite() ? LITE_MAX_DPR : MAX_DPR,
+      (typeof devicePixelRatio === 'number' && devicePixelRatio > 0) ? devicePixelRatio : 1);
     let bw = Math.max(1, Math.round(w * dpr));
     let bh = Math.max(1, Math.round(h * dpr));
     const total = bw * bh;
@@ -386,7 +399,14 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     if (!parked()) {
       const loop = Math.max(1, loopMsFor(params));
       if (lastTs) phase = (phase + (now - lastTs) / loop) % 1;
-      draw();
+      // THE LITE THROTTLE. The PHASE above advanced by real elapsed time on
+      // every callback, so skipping a draw skips pixels, never tempo — a
+      // 30fps bed and a 120fps bed show the same rotation at the same second.
+      // Full tier: no gate at all, byte-identical to the pre-tier loop.
+      if (!perfLite() || (now - lastDraw) >= LITE_FRAME_MS) {
+        lastDraw = now;
+        draw();
+      }
     }
     lastTs = now;
     if (hasRaf()) rafId = requestAnimationFrame((t) => step(t, gen));
@@ -402,7 +422,7 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     const w = { cv: canvasEl, f: field, raf: rafId, lost: onLost, resize: onResize, vis: onVisibility };
     weaveGen++;                        // every queued frame for this weave is now stale
     canvasEl = null; field = null; params = null;
-    rafId = 0; lastTs = 0; lastCheck = 0; onLost = null; onResize = null; onVisibility = null;
+    rafId = 0; lastTs = 0; lastCheck = 0; lastDraw = 0; onLost = null; onResize = null; onVisibility = null;
     return () => {
       if (w.raf && typeof cancelAnimationFrame === 'function') {
         try { cancelAnimationFrame(w.raf); } catch (_e) { /* ignore */ }

--- a/ConditioningControlPanel/Resources/web/goon/exec/videos.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/videos.js
@@ -192,12 +192,20 @@ import {
   pinchEligible, pinchDistance, pinchMidpoint, pinchStarted, pinchStep,
   viewportCap, safeInsets,
 } from './pinch.js';
+import { perfLite } from './perfTier.js';
 
 const MAX_SOURCE_TRIES = 3;   // a broken entry costs one redraw, not the run
 
 /* --- the window dials. Exported because the self-test asserts against these
    numbers rather than re-typing them. ------------------------------------- */
 export const MAX_WINDOWS = 4;          // live floating windows; a 5th evicts the oldest
+/* The LITE tier's pool (exec/perfTier.js — phones). Four simultaneously
+ * DECODING <video>s is a real load on a phone's media pipeline; three is the
+ * most the small screen can even show unstacked. The receipt arithmetic is
+ * untouched by the smaller cap: an early eviction settles endured=true, which
+ * is the very receipt a 5th-window eviction (or the 60s cap) already posts —
+ * the thrown payload is never cheated, it is merely "survived" a bit sooner. */
+export const MAX_WINDOWS_LITE = 3;
 export const WINDOW_CAP_MS = 60000;    // nothing floats longer than this, ever
 export const DRAG_SLOP_PX = 6;         // <= this much travel and the press was a CLICK
 export const WHEEL_STEP = 1.08;        // size multiplier per wheel notch
@@ -638,6 +646,12 @@ export function createVideos({ layers, media, audio, logger, onWindowCountChange
 
   const stage = () => (layers && typeof layers.get === 'function' ? layers.get('stage') : null);
   const winLayer = () => (layers && typeof layers.get === 'function' ? layers.get('vwin') : null);
+  /** THE POOL CAP, tier-resolved fresh per ask (exec/perfTier.js). Lazily like
+   *  skippable() below, so the options toggle reaches the very next spawn — a
+   *  pool already OVER a tightened cap is left alone and simply drains: closing
+   *  a window the player was thrown, on a settings flip, would be the receipt
+   *  deciding itself. */
+  const winCap = () => (perfLite() ? MAX_WINDOWS_LITE : MAX_WINDOWS);
 
   /**
    * Is "skippable videos" on RIGHT NOW? Read lazily, every time, off the root
@@ -1398,7 +1412,7 @@ export function createVideos({ layers, media, audio, logger, onWindowCountChange
     if (typeof document === 'undefined') return null;
     const host = winLayer();
     if (!host) return null;
-    if (mayEvict === false && wins.length >= MAX_WINDOWS) return null;
+    if (mayEvict === false && wins.length >= winCap()) return null;
     if (!media || typeof media.drawKind !== 'function') return null;
 
     let entry = (typeof media.drawFor === 'function')
@@ -1425,7 +1439,7 @@ export function createVideos({ layers, media, audio, logger, onWindowCountChange
 
     // At the cap the OLDEST settles first — it has been watched the longest, so
     // it is endured, not interrupted. A LOCAL spawn never reaches this line.
-    while (wins.length >= MAX_WINDOWS) settleWindow(wins[0], true);
+    while (wins.length >= winCap()) settleWindow(wins[0], true);
 
     const baseW = baseWindowWidth(vpW());
     const pos = placeWindow(vpW(), vpH(), baseW, baseW * 9 / 16);
@@ -1720,8 +1734,8 @@ export function createVideos({ layers, media, audio, logger, onWindowCountChange
      */
     spawnLocal(opts) {
       const o = opts || {};
-      if (wins.length >= MAX_WINDOWS) {
-        info(`local window fizzled — ${wins.length}/${MAX_WINDOWS} up, and a self-pop never displaces one`);
+      if (wins.length >= winCap()) {
+        info(`local window fizzled — ${wins.length}/${winCap()} up, and a self-pop never displaces one`);
         return false;
       }
       const capMs = windowCapMs(o.duration_ms);

--- a/ConditioningControlPanel/Resources/web/goon/goon.css
+++ b/ConditioningControlPanel/Resources/web/goon/goon.css
@@ -70,7 +70,13 @@ html, body {
 #gg-bg      { position: fixed; inset: 0; z-index: 0;  width: 100%; height: 100%; }
 #gg-screens { position: fixed; inset: 0; z-index: 10; }
 #gg-stage   { position: fixed; inset: 0; z-index: 20; display: flex; align-items: center; justify-content: center; }
-#gg-fx      { position: fixed; inset: 0; z-index: 30; pointer-events: none; }
+/* `contain: layout paint` is an ALL-TIER win with no visible cost: the layer is
+   exactly the viewport, so paint containment clips nothing a player could ever
+   see (anything past its edge is past the screen), and it lets the engine keep
+   a squall of flash/bubble invalidations from being anybody else's problem.
+   It does NOT create a new stacking context — #gg-fx already is one (fixed +
+   z-index) — so the spiral's screen blend composes exactly as before. */
+#gg-fx      { position: fixed; inset: 0; z-index: 30; pointer-events: none; contain: layout paint; }
 #gg-hud     { position: fixed; inset: 0; z-index: 40; pointer-events: none; }
 #gg-toasts  { position: fixed; inset: 0; z-index: 50; pointer-events: none; }
 #gg-drawer  { position: fixed; inset: 0 0 0 auto; z-index: 70; width: min(24rem, 92vw); }
@@ -146,6 +152,13 @@ html, body {
    flips html[data-gg-fx]. */
 html[data-gg-fx="hot"] .gg-plate { background: rgba(10, 5, 17, 0.90); backdrop-filter: none; }
 html[data-gg-fx="hot"] { --gg-deco-play: paused; }
+/* THE LITE TIER wears the hot-plate armor ALL THE TIME (and takes the scrim's
+   blur too): backdrop-filter is the worst thing iOS Safari can be asked to
+   composite, and a phone does not get to wait for the stack to run hot before
+   it stops paying for it. html[data-gg-perf] is stamped by exec/perfTier.js
+   via boot.js; absent means full, so desktop never reaches these rules. */
+html[data-gg-perf="lite"] .gg-plate { background: rgba(10, 5, 17, 0.90); backdrop-filter: none; }
+html[data-gg-perf="lite"] .gg-scrim { backdrop-filter: none; }
 /* Decorative motion opts in by using the token; nothing functional may. */
 .gg-deco, .gg-loader-ring, .gg-eyebrow i { animation-play-state: var(--gg-deco-play); }
 

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -934,11 +934,22 @@ async function main() {
       'the pane declares no static filter — the glitch keyframes animate filter and would wipe it',
       String(drain));
     // the blur is the most expensive thing this page draws: exactly one pane,
-    // exactly one backdrop-filter (+ its -webkit- twin), and the count is pinned.
-    const bdf = (css.match(/backdrop-filter:/g) || []).length;
-    ok(bdf === 2, 'fx.css still declares backdrop-filter exactly twice (one pane, one -webkit- twin)', String(bdf));
+    // exactly one blur-behind (+ its -webkit- twin), and the count is pinned.
+    // Counted by VALUE since the lite tier (2026-08-05): `backdrop-filter: none`
+    // is the phone diet switching this very pane OFF, not a second pane, so the
+    // guard splits the declarations into "the blur" and "the offs" and pins both
+    // sides — anything that is neither is a new pane and still fails.
+    const bdfAll = css.match(/backdrop-filter:[^;}]*/g) || [];
+    const bdfBlur = bdfAll.filter((d) => /blur\(/.test(d)).length;
+    const bdfNone = bdfAll.filter((d) => /:\s*none/.test(d)).length;
+    ok(bdfBlur === 2, 'fx.css still declares ONE blur-behind (+ its -webkit- twin)', bdfAll.join(' | '));
+    ok(bdfBlur + bdfNone === bdfAll.length,
+      'and every other backdrop-filter is a `none` — the lite tier switching the same pane off, never a second pane',
+      bdfAll.join(' | '));
     ok(/\.gg-drain\s*\{[^}]*backdrop-filter:\s*blur\(7px\)/.test(css),
-      'and the one that exists is the drain blur', String(bdf));
+      'and the one that exists is the drain blur', String(bdfBlur));
+    ok(/html\[data-gg-perf="lite"\]\s*\.gg-drain\s*\{[^}]*backdrop-filter:\s*none/.test(css),
+      'the lite tier drops the drain blur-behind outright — the most expensive declaration on the page does not run on phones');
     // the shudder still rides the veil, and still recolours what is under it
     const glitchKf = /@keyframes\s+ggDrainGlitch\s*\{([\s\S]*?)\n\}/.exec(css);
     ok(!!glitchKf && /hue-rotate\(/.test(glitchKf[1]) && /saturate\(/.test(glitchKf[1]),
@@ -4557,6 +4568,62 @@ async function main() {
     ok(outOfBand.length === 0, 'and every one of them spins inside the 10-18s band', outOfBand.join(' '));
     sp.stop();
     document.createElement = realCreate;
+  }
+
+  /* --------- THE DEVICE PERFORMANCE TIER (exec/perfTier.js, 2026-08-05)
+   * The owner's iPhone dropped frames in a live duel, so the renderers grew a
+   * second, smaller set of caps behind <html data-gg-perf="lite">. What is
+   * pinned here is the DECISION TABLE and the polarity, because both are
+   * contracts other files lean on:
+   *   · a FINE pointer can never resolve lite — "desktop byte-identical" is a
+   *     requirement, not a tendency, and no memory claim may override it;
+   *   · ABSENT MEANS FULL — every check in this suite ran without the
+   *     attribute, and that is exactly the guarantee that keeps them honest;
+   *   · the explicit pref values beat detection, junk falls through to it.
+   * ------------------------------------------------------------------------ */
+  {
+    const PT = await import('../exec/perfTier.js');
+    const F = await import('../exec/flashes.js');
+    const B = await import('../exec/bubbles.js');
+    const V = await import('../exec/videos.js');
+    const SP = await import('../exec/spiral.js');
+
+    ok(F.MAX_LIVE_LITE === 10 && B.MAX_LIVE_LITE === 10 && V.MAX_WINDOWS_LITE === 3,
+      'the lite caps are the shipped dials (flashes 10, bubbles 10, windows 3)',
+      `${F.MAX_LIVE_LITE}/${B.MAX_LIVE_LITE}/${V.MAX_WINDOWS_LITE}`);
+    ok(F.MAX_LIVE_LITE < F.MAX_LIVE && B.MAX_LIVE_LITE < B.MAX_LIVE && V.MAX_WINDOWS_LITE < V.MAX_WINDOWS,
+      'and every one of them is strictly under its full-tier twin — a "lite" cap above full would be a typo, not a tier');
+    ok(SP.LITE_MAX_DPR < SP.MAX_DPR && SP.LITE_FRAME_MS >= 30,
+      'the spiral halves both of its dials: CSS-pixel backing and a ~30fps draw cadence',
+      `${SP.LITE_MAX_DPR}/${SP.LITE_FRAME_MS}`);
+
+    // ---- the decision table, pure
+    ok(PT.detectPerfTier({ coarse: false, viewportMinPx: 400, deviceMemoryGb: 2 }) === PT.PERF_FULL,
+      'a fine pointer is FULL whatever else the device claims — the desktop can never detect its way to lite');
+    ok(PT.detectPerfTier({ coarse: true, viewportMinPx: 428 }) === PT.PERF_LITE,
+      'coarse + phone-sized viewport is lite (the iPhone 13 Pro Max is 428)');
+    ok(PT.detectPerfTier({ coarse: true, viewportMinPx: 1024 }) === PT.PERF_FULL,
+      'coarse + a big tablet viewport stays full — an iPad Pro renders the full stack fine');
+    ok(PT.detectPerfTier({ coarse: true, viewportMinPx: 1024, deviceMemoryGb: 4 }) === PT.PERF_LITE,
+      'unless a low deviceMemory casts the second vote');
+    ok(PT.detectPerfTier() === PT.PERF_FULL && PT.detectPerfTier({}) === PT.PERF_FULL,
+      'and an empty/unreadable env is FULL: a missing signal must never degrade somebody’s picture');
+
+    // ---- the pref resolution: explicit beats detection, junk falls through
+    const phone = { coarse: true, viewportMinPx: 428 };
+    ok(PT.resolvePerfTier('full', phone) === PT.PERF_FULL && PT.resolvePerfTier('lite', {}) === PT.PERF_LITE,
+      'the explicit pref values overrule detection in BOTH directions');
+    ok(PT.resolvePerfTier('auto', phone) === PT.PERF_LITE && PT.resolvePerfTier(undefined, phone) === PT.PERF_LITE
+      && PT.resolvePerfTier(42, phone) === PT.PERF_LITE,
+      'auto, undefined and junk all fall through to detection — a corrupt store can only land on "what this device deserves"');
+
+    // ---- the attribute contract: absent means full, only the exact value bites
+    ok(PT.perfLite() === false, 'no stamp = full tier — which is the tier this whole suite just ran under');
+    documentElement.setAttribute(PT.PERF_ATTR, PT.PERF_LITE);
+    ok(PT.perfLite() === true, 'the stamped lite value is read live off <html>');
+    documentElement.setAttribute(PT.PERF_ATTR, 'sideways');
+    ok(PT.perfLite() === false, 'anything that is not exactly "lite" is full — same polarity contract as data-gg-shader');
+    documentElement.removeAttribute(PT.PERF_ATTR);
   }
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);

--- a/ConditioningControlPanel/Resources/web/goon/ui/options.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/options.js
@@ -173,6 +173,23 @@ export function createOptions({ prefs, audio = null, session = null, setFullscre
     body.appendChild(shaders.node);
     body.appendChild(el('p', { class: 'gg-panel-note', text: S.options.shaderSpiralsNote }));
 
+    /* LITE GRAPHICS — the device performance tier, and the third mid-match
+     * comfort knob in this run: the moment a player wants it is the moment the
+     * match is dropping frames. The toggle READS the resolved answer off
+     * <html data-gg-perf> (the pref may still be 'auto' — phones detect lite,
+     * desks full) and a touch writes the EXPLICIT tier, the same one-way door
+     * out of 'auto' the arsenal handle uses. The stamp itself is boot.js's:
+     * it subscribes to `perfMode` and re-applies exec/perfTier.js, because
+     * resolving 'auto' needs the detector and ui/ never imports exec/. */
+    const perf = toggleRow(S.options.perfLite,
+      () => {
+        try { return doc.documentElement.getAttribute('data-gg-perf') === 'lite'; }
+        catch (_e) { return false; }
+      },
+      (v) => prefs.set('perfMode', v ? 'lite' : 'full'));
+    body.appendChild(perf.node);
+    body.appendChild(el('p', { class: 'gg-panel-note', text: S.options.perfLiteNote }));
+
     /* OPPONENT AVATARS — the viewer's half of the Discord sharing feature
      * (contract §1). It is offered mid-match like the two knobs above it,
      * because it is the same kind of switch: what MY screen shows me. Turning

--- a/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
@@ -71,6 +71,24 @@ export const PREF_DEFAULTS = Object.freeze({
    */
   shaderSpirals: true,
   /**
+   * THE DEVICE PERFORMANCE TIER — 'auto' | 'full' | 'lite'. Three values for
+   * the same reason arsenalOpen has three: a boolean cannot say "I have no
+   * opinion yet", and the right default genuinely differs by device. 'auto'
+   * lets exec/perfTier.js detect (coarse pointer + small viewport, or a low
+   * navigator.deviceMemory, resolves lite; a desktop always resolves full);
+   * the two explicit values are the player overruling the detection from the
+   * options drawer, and they travel with the player like every other pref.
+   *
+   * NOT in REFLECT below, on purpose, and this is the one pref whose mirror
+   * lives elsewhere: 'auto' cannot be resolved without the detector, the
+   * detector lives in exec/ (the tier that consumes it), and ui/ never imports
+   * exec/. boot.js — which imports both by charter — stamps the RESOLVED value
+   * onto <html data-gg-perf> at startup and re-stamps it on every change of
+   * this key (it subscribes), so the attribute contract is exactly the one
+   * data-gg-vskip and data-gg-shader already honour.
+   */
+  perfMode: 'auto',
+  /**
    * Whether an opponent's shared Discord picture is shown on this machine (the
    * VS splash, the HUD mini, the recap plate). ON by default — the sharer has
    * already opted in and hiding their choice by default would make the feature

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -375,6 +375,13 @@ export const S = Object.freeze({
        that stops moving while the game carries on is the exact symptom. Names
        the fallback too, so turning it off does not feel like losing the bed. */
     shaderSpiralsNote: 'draws the spiral bed live instead of stretching a gif. turn it off if the picture ever freezes while the sound and the clock keep going — the bed falls back to the bundled spirals and nothing else changes.',
+    /* The device tier (exec/perfTier.js). The toggle shows the RESOLVED answer
+       — phones start on, desks start off, via the 'auto' pref — and touching it
+       writes an explicit choice, same one-way door as the arsenal handle. The
+       note says what it costs, because "performance mode" toggles that hide
+       their trade read as snake oil. */
+    perfLite: 'Lite graphics',
+    perfLiteNote: 'fewer flashes and bubbles on screen at once, a lighter spiral and no glass-blur — for phones and small machines that drop frames mid-match. on by itself on most phones; nothing about the match itself changes.',
     /* THE VIEWER'S OWN SWITCH, and it is not the same decision as the sharing
      * toggles in the lobby: those say what leaves this machine, this says what
      * arrives. Off, their picture is never even FETCHED (ui/discord.js), which


### PR DESCRIPTION
## Why

The owner play-tested a real 1v1 duel on an iPhone 13 Pro Max (not in power-save) and hit lag and skipped frames during live matches. The busy screen asks a phone GPU for: ~20 drop-shadowed 44vmin flash layers, a 26-bubble field, a fullscreen two-layer WebGL spiral under a screen blend (at Retina DPR, on a 120Hz ProMotion rAF), up to 4 simultaneously-decoding floating videos, and a fullscreen `backdrop-filter: blur(7px)` drain pane - the single most expensive thing iOS Safari can be asked to composite.

## What

**New: `exec/perfTier.js`** - one small module, one question: `full` or `lite`.

- Detection is desktop-safe **by construction**: a fine pointer can never resolve lite. A coarse-pointer device resolves lite via a small viewport (min dimension <= 820px) or low `navigator.deviceMemory` (<= 4GB, Chrome-only second vote).
- The answer travels as a root attribute (`<html data-gg-perf>`), same contract as `data-gg-vskip`/`data-gg-shader`. **Absent means full** - self-tests and unstamped harnesses run the page exactly as before.
- Pref override: `perfMode: 'auto' | 'full' | 'lite'` in ui/prefs.js, stamped by boot.js (which imports both tiers by charter - exec/ still never imports ui/ or net/, ui/ still never imports exec/). Options drawer grows a **Lite graphics** toggle showing the resolved tier; touching it writes an explicit choice (the `arsenalOpen` one-way-door pattern).

**Lite tier (all read lazily - the mid-match toggle bites):**

| Cost centre | full | lite |
|---|---|---|
| Flash cap (`MAX_LIVE`) | 20 | 10 |
| Bubble field ceiling | 26 | 10 (+ sparkle 9 -> 5) |
| Spiral backing store | 1.5x DPR | CSS pixels (1x) |
| Spiral draw cadence | every rAF (120 on ProMotion) | ~30fps, phase keeps real time |
| Video window pool | 4 | 3 (receipts unchanged: early eviction already settles `endured=true`) |
| Drain pane | `backdrop-filter: blur(7px)` | none, dim sheet 0.42 -> 0.54 |
| Flash halo | 26px drop-shadow per node | none |
| .gg-plate / .gg-scrim | blur-behind | hot-armor opaque / no blur |
| vwin glow | 5 box-shadows | 2 |

**All-tier win:** `#gg-fx` gets `contain: layout paint` - the layer is exactly the viewport (clips nothing visible), already a stacking context (screen blend untouched), and flash/bubble squall invalidations stop propagating.

**Deliberately unchanged:** bubble kind halos (the coloured drop-shadow IS the kind), all exit/teardown animations, subliminals/bouncingText (already composited-cheap), the wire tier (per-16KB chunk work is small; hashing is native async `crypto.subtle`), and everything the full tier draws - desktop is byte-identical.

## Tests

- `selftest-exec` grows a pinned decision table + attribute polarity block (974 checks); its fx.css backdrop-filter guard now counts by value so the lite `none` pair reads as switching the one pane off, not a second pane.
- `selftest-exec` / `selftest-hud` / `selftest-flow` green; all ten other suites green (avafx's 12 pre-existing failures excepted).
- `bridge.js` untouched.

## Needs a real-device play-test

- iPhone 13 Pro Max, live duel: confirm frames hold on the busy screen, and that the drain reading (dim, no blur) still lands.
- Confirm the Options -> Lite graphics toggle flips mid-match (caps drain over ~seconds as nodes age out; over-cap video windows drain rather than close).
- A quick desktop sanity pass that nothing looks different at full tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D