### PR TITLE
chore(goon): remove the risk-level readout from every screen

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -315,12 +315,16 @@ const recap = await import('../ui/screens/recap.js');
   ok(recap.assertStageClear(null) === 0, 'a clean stage is a no-op and needs no logger');
 }
 
-/** A match stub shaped like the two fields recap.js actually reads. */
+/** A match stub shaped like the two fields recap.js actually reads.
+ *  `scoring` is deliberately absent since 2026-08-05: the recap used to print
+ *  `scoring.riskMultiplier` in its fine print and that readout went with the
+ *  rest of the risk indicator, so a stub carrying one would be documenting a
+ *  read that no longer happens. If recap.js ever touches scoring again this
+ *  stub throws on undefined, which is the failure we want. */
 function fakeMatch(result) {
   return {
     result,
     opponent: { displayName: 'Kit' },
-    scoring: { riskMultiplier: 1.15 },
     onResultFinalized() { return () => {}; },
     onMatchEnded() { return () => {}; },
   };

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -221,6 +221,11 @@ function makeFakeMatch() {
   const scoring = {
     score: 120,
     charges: 3,
+    /* KEPT ON PURPOSE, THOUGH NO UI READS THEM ANY MORE (2026-08-05). The real
+     * GoonScoring still exposes both — they are the engine's C#-parity names
+     * for the pool bonus — so the stub keeps the shape honest, and section 2c-ii
+     * leans on them: a HUD that ignores a 1.3 sitting right there is the proof
+     * the readout is gone rather than merely blank. */
     riskMultiplier: 1.3,
     riskTier: 2,
     _charge: new Set(),
@@ -1053,6 +1058,59 @@ function makeFakeMatch() {
   ok(!!spiral && spiral.name === 'spiral' && typeof spiral.blurb === 'string' && spiral.blurb.length > 10,
     'the draft pool carries a spiral tile with copy');
   ok(!!spiral && spiral.blurb === spiral.blurb.toLowerCase(), 'element blurbs stay lowercase');
+}
+
+/* ---- 2c-ii. THE RISK READOUT IS GONE FROM EVERY SCREEN (2026-08-05) --------
+ *
+ * Batch 7 took the meters and the pips; what it left behind was the MULTIPLIER
+ * — the same engine number (`scoring.riskMultiplier`, product of the 0-7 tier)
+ * printed in three places: "×1.30 score" under the live HUD's charge pips,
+ * "you both score ×1.30" in gold in the draft footer, and "1 pt/s · score
+ * ×1.30" in the recap's fine print. The owner's verdict covered the family:
+ * not intuitive, and the heat gauge is the readout the desk actually needed.
+ * All three are deleted.
+ *
+ * THIS PINS THE ABSENCE, AT THE SOURCE, BECAUSE THAT IS WHERE IT REGRESSES.
+ * A mounted-DOM check would only catch the live HUD, and the way this comes
+ * back is somebody re-reading `riskMultiplier` in a UI file — so the assertion
+ * is that no ui/ file reads it at all. The ENGINE is deliberately not part of
+ * this: core/scoring.js and core/draft.js still compute the tier and the
+ * multiplier every second (C#-parity, and the score depends on it), they just
+ * have no reader on a player's screen any more. */
+{
+  const fsRisk = await import('node:fs/promises');
+  const urlRisk = await import('node:url');
+  const readUi = (rel) => fsRisk.readFile(urlRisk.fileURLToPath(new URL('../' + rel, import.meta.url)), 'utf8');
+
+  for (const rel of ['ui/hud.js', 'ui/screens/draft.js', 'ui/screens/recap.js', 'ui/strings.js']) {
+    const src = await readUi(rel);
+    // Comments are where the tombstones live and they are allowed to say the
+    // word; a READ of the value is what must not exist. Strip line comments and
+    // block comments before looking.
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+    ok(!/riskMultiplier|matchRiskTier|riskTierOf/.test(code),
+      `${rel} reads no risk value out of the engine`,
+      (code.match(/.*(riskMultiplier|matchRiskTier|riskTierOf).*/) || [''])[0].trim());
+  }
+
+  // and the copy that dressed it is gone with it
+  ok(!('scoreMult' in S.hud), 'strings.js has no hud.scoreMult');
+  ok(!('score' in S.draft), 'strings.js has no draft.score multiplier line');
+  ok(typeof S.recap.scoreFineprint === 'string',
+    'the recap fine print is a flat string now, not a mult => string',
+    typeof S.recap.scoreFineprint);
+  ok(!/×|multipl/i.test(S.recap.scoreFineprint),
+    'and it names no multiplier', String(S.recap.scoreFineprint));
+
+  // the live desk builds no such node
+  const matchRisk = makeFakeMatch();          // its scoring stub still carries riskMultiplier 1.3
+  const hudRisk = hudMod.mountHud({ match: matchRisk, audio: { sfx() {} } });
+  const hostRisk = dom.byId.get('gg-hud');
+  ok(findAll(hostRisk, 'gg-mult').length === 0, 'the live HUD builds no .gg-mult readout');
+  ok(findAll(hostRisk, 'gg-risk').length === 0, 'and nothing wearing the old .gg-risk name');
+  ok(findAll(hostRisk, 'gg-pips').length === 1,
+    'while the CHARGE pips — which are not risk and never were — are still there');
+  hudRisk.unmount();
 }
 
 // -------------------------------------------------------- 3. closeness + emotes
@@ -3169,10 +3227,10 @@ const audioMod = await import('../ui/audio.js');
 }
 
 /* ===========================================================================
- * 13. THE ZEN TOGGLE — one button, four panels (owner, 2026-08-04).
+ * 13. THE ZEN TOGGLE — one button, three panels (owner, 2026-08-04).
  *
- * "add a button that hides the ui": the score, the risk multiplier, the
- * closeness dial ("you're telling them") and MERCY step off together; the
+ * "add a button that hides the ui": the score, the closeness dial ("you're
+ * telling them") and MERCY step off together; the
  * opponent monitor and the arsenal stay. The whole feature is one bit, so this
  * pins the bit, both of its names, and the CSS that reads them — a toggle that
  * flips a class no stylesheet mentions is an invisible feature.
@@ -3275,11 +3333,15 @@ const audioMod = await import('../ui/audio.js');
   const zenBlocks = hudCss13.match(/[^{}]*\.gg-hud--zen[^{}]*\{[^}]*\}/g) || [];
   ok(zenBlocks.length > 0, 'hud.css reads the modifier class at all');
   const zenText = zenBlocks.join('\n');
-  // .gg-mult was .gg-risk until 2026-08-04 — same slot in the score column, same
-  // engine number, renamed with the rest of the player-facing risk system.
-  for (const sel of ['.gg-score', '.gg-mult', '.gg-dial-host']) {
+  /* .gg-mult IS NOT ON THIS LIST ANY MORE. It was .gg-risk, then .gg-mult, then
+   * nothing (2026-08-05) — the whole risk readout left the desk, so zen has one
+   * less thing to hide and hud.css must not still be naming it. Both halves are
+   * pinned: the survivors below, and the absence right after. */
+  for (const sel of ['.gg-score', '.gg-dial-host']) {
     ok(zenText.includes(sel), `zen hides ${sel}`);
   }
+  ok(!zenText.includes('.gg-mult'),
+    'and it no longer hides .gg-mult, because there is no multiplier readout left to hide');
   // The heat gauge is NOT on that list and must not be: it is the arsenal's own
   // meter, and zen keeps the arsenal.
   ok(!zenText.includes('.gg-heat'), 'and zen keeps the heat gauge, like the rails it feeds');

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -95,8 +95,8 @@
  * monitor and the arsenal. One bit (ui/hud.js HUD_ZEN_CLASS/HUD_ZEN_ATTR), every
  * hide below it, nothing in JS.
  *
- * WHAT GOES: the score + its +1 flourish, the score multiplier, your name plate,
- * the closeness dial, the closeness THEY claim, the live-effect chips and MERCY.
+ * WHAT GOES: the score + its +1 flourish, your name plate, the closeness dial,
+ * the closeness THEY claim, the live-effect chips and MERCY.
  * WHAT STAYS: the monitor, the rails, the charge pips (they are the arsenal's
  * currency, not a readout), the timer, the attention ring and the toggle itself.
  *
@@ -121,7 +121,6 @@
  * ------------------------------------------------------------------------ */
 .gg-hud-frame.gg-hud--zen .gg-score,
 .gg-hud-frame.gg-hud--zen .gg-plus1,
-.gg-hud-frame.gg-hud--zen .gg-mult,
 .gg-hud-frame.gg-hud--zen .gg-me,
 .gg-hud-frame.gg-hud--zen .gg-dial-host,
 .gg-hud-frame.gg-hud--zen .gg-mon-close,
@@ -132,7 +131,7 @@
 html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
 
 /* ---------------------------------------------------------------------------
- * TOP BAR — score · charges · ×mult | timer | attention · gear
+ * TOP BAR — score · charges | timer | attention · gear
  * ------------------------------------------------------------------------ */
 .gg-hud-top {
   display: grid;
@@ -150,9 +149,12 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
   color: #fff;
   text-shadow: 0 0 18px rgba(var(--gg-pink-rgb), 0.55), 0 2px 0 rgba(0, 0, 0, 0.45);
 }
-/* was .gg-risk ("×1.30 risk") until 2026-08-04 — same slot, same number, and no
-   longer named after a 0-7 tier the player was never shown a key for */
-.gg-mult { font-size: 0.68rem; color: var(--gg-text-4); font-variant-numeric: tabular-nums; letter-spacing: 0.06em; }
+/* THE SCORE MULTIPLIER IS GONE (2026-08-05). `.gg-risk` ("×1.30 risk") became
+   `.gg-mult` ("×1.30 score") on 2026-08-04 and was deleted outright a day later
+   with the rest of the risk indicator — a fixed number, set at the draft and
+   unmovable for the whole match, is not a readout a live desk needs. The score
+   directly above it already carries every point the multiplier bought.
+   ui/hud.js builds no such node, so do not restyle one back into being. */
 .gg-me { font-size: 0.68rem; color: var(--gg-text-3); }
 
 .gg-pips { display: flex; gap: 6px; align-items: center; }
@@ -2178,7 +2180,7 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-hud-top { grid-template-columns: minmax(0, 1fr) auto auto; gap: 0.35rem; }
   .gg-hud-top > * { min-width: 0; }
   .gg-scorebox { min-width: 0; }
-  .gg-mult, .gg-me { overflow-wrap: anywhere; }
+  .gg-me { overflow-wrap: anywhere; }
   .gg-pip { width: 13px; height: 13px; }
   .gg-pips { gap: 5px; }
   .gg-timer { min-width: 92px; padding: 0.35rem 0.6rem 0.45rem; }

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -4,7 +4,7 @@
  * Composes the live-match HUD inside #gg-hud and owns the layout grid:
  *
  *   ┌ top ────────────────────────────────────────────────────────────────┐
- *   │ score · charges · ×mult       11:47 ▮▮▯▯▯      attention  ⊟  ⚙      │
+ *   │ score · charges               11:47 ▮▮▯▯▯      attention  ⊟  ⚙      │
  *   ├ body ───────────────────────────────────────────────────────────────┤
  *   │ ┌ arsenal ──┐◂                                            [monitor] │
  *   │ │ HEAT ▰▰▱  │      (the stage well — never covered)       [receipts]│
@@ -26,10 +26,10 @@
  * everything here is edge-anchored and the centre column is pointer-transparent.
  *
  * ZEN (the ⊟ beside the gear). One bit, and everything it hides — score, the
- * score multiplier, the closeness dial, MERCY — is hidden by ui/hud.css off
- * .gg-hud--zen and html[data-gg-zen]. The monitor, the arsenal and the heat
- * gauge that feeds it stay: they are what the duel is played on. See the
- * toggle's own block below for why hiding MERCY is safe.
+ * closeness dial, MERCY — is hidden by ui/hud.css off .gg-hud--zen and
+ * html[data-gg-zen]. The monitor, the arsenal and the heat gauge that feeds it
+ * stay: they are what the duel is played on. See the toggle's own block below
+ * for why hiding MERCY is safe.
  *
  * ANIMATION BUDGET. Chrome animations go through fx.play(): at most two run at
  * once and anything that waited more than 600 ms is dropped rather than played
@@ -326,7 +326,28 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   const pipRow = add(scoreBox, el('div', 'gg-pips'));
   const pips = [];
   for (let i = 0; i < GoonConsts.ChargeCap; i++) pips.push(add(pipRow, el('i', 'gg-pip')));
-  const multEl = add(scoreBox, el('div', 'gg-mult', S.hud.scoreMult(1)));
+
+  /* NO SCORE-MULTIPLIER READOUT (owner, 2026-08-05: "the risk level indicator
+   * is not intuitive — the heat gauge already does the job").
+   *
+   * A third line used to sit here under the charge pips: `.gg-mult`, née
+   * `.gg-risk`, painting `match.scoring.riskMultiplier` as "×1.30 score". It
+   * was the LAST player-facing limb of the risk system — batch 7 took the
+   * seven-segment tier meters and the per-tile pips off the draft screen and
+   * left this one behind, renamed. Renaming it never fixed the thing that was
+   * wrong with it: a bare multiplier with no key, on a number the player agreed
+   * to once at the draft and can no longer change, that never moves for the
+   * whole match. Nothing here reads scoring.riskMultiplier any more.
+   *
+   * THE ENGINE KEEPS IT. core/scoring.js multiplies every second by it and
+   * core/draft.js still sums the tier that produces it (C#-parity names, wire
+   * and RNG vectors depend on them) — this was a UI removal, not a mechanics
+   * change. The score in the line above is the multiplier's whole visible
+   * effect, which is the part a player could ever act on.
+   *
+   * THE CHARGE PIPS ABOVE ARE NOT IT and must stay: they are what you are
+   * holding to throw, the wire validates against them, and the arsenal's cost
+   * pips are read against them. */
 
   const timerBox = add(top, el('div', 'gg-timer gg-plate'));
   const timerClock = add(timerBox, el('div', 'gg-timer-clock', '0:00'));
@@ -362,9 +383,9 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   const attSlot = add(rightTop, el('div', 'gg-att-slot'));
 
   /* ---- THE ZEN TOGGLE ---------------------------------------------------
-   * One button, always on screen, that takes the score, its multiplier,
-   * the closeness dial and the mercy button away and gives them back. What is
-   * left is what the duel is actually played on: their monitor and the arsenal.
+   * One button, always on screen, that takes the score, the closeness dial and
+   * the mercy button away and gives them back. What is left is what the duel is
+   * actually played on: their monitor and the arsenal.
    *
    * IT IS ITS OWN UNDO. The button never hides — it would be a one-way door on
    * a phone, where there is no Escape key to fall back to — and it keeps the
@@ -861,14 +882,6 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
     }
   }
 
-  function paintMult() {
-    const s = match.scoring;
-    // `riskMultiplier` is the ENGINE's frozen name for the pool's score bonus
-    // (core/scoring.js, C#-parity). Nothing player-facing says "risk" any more.
-    const mult = s && typeof s.riskMultiplier === 'number' ? s.riskMultiplier : 1;
-    text(multEl, S.hud.scoreMult(mult));
-  }
-
   /* THE HEAT GAUGE. Polled, not subscribed: heat decays on the wall clock with
    * no timer behind it (ui/drops.js keeps it lazy), so the only way the bar can
    * show a cool-down is for the painter to ask. paintAll already runs at 5 Hz
@@ -930,7 +943,7 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   }
 
   function paintAll() {
-    try { paintScore(); paintCharges(); paintTimer(); paintMult(); paintHeat(); paintArmedBadge(); }
+    try { paintScore(); paintCharges(); paintTimer(); paintHeat(); paintArmedBadge(); }
     catch (_e) { /* a paint must never take the match down */ }
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -470,10 +470,12 @@
   padding-top: 0.9rem;
   border-top: 1px solid rgba(255, 255, 255, 0.07);
 }
-/* Once a meter, a "Match risk 4 / 7" label and a multiplier; since 2026-08-04
-   just the multiplier — the only one of the three a player could act on. */
-.gg-draft-meterwrap { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
-.gg-draft-mult { font-size: 0.8rem; color: var(--gg-gold); font-variant-numeric: tabular-nums; }
+/* THE FOOTER'S RISK SLOT IS GONE (2026-08-05). It held three things once — a
+   seven-segment meter, a "Match risk 4 / 7" label and a gold "you both score
+   ×1.30" — then only the multiplier, and now nothing: the wrapper
+   (.gg-draft-meterwrap) and the label (.gg-draft-mult) are both deleted, so the
+   row is the pool blurb and the confirm button. ui/screens/draft.js builds
+   neither node; a rule for either here would be styling a ghost. */
 
 .gg-draft-theirs { display: flex; align-items: center; gap: 0.5rem; }
 .gg-slots-label { font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--gg-text-4); }

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/draft.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/draft.js
@@ -25,10 +25,12 @@
 
 import { createLedger, el, button } from '../router.js';
 import { S, ELEMENTS } from '../strings.js';
-// matchRiskTier/riskMultiplier are the ENGINE's frozen names for "how heavy is this pool" and
-// "what does that multiply the score by" (core/scoring.js, C#-parity). The screen uses only the
-// product of the two — one honest "you both score ×N" — and shows the tier itself nowhere.
-import { ALWAYS_ON_ELEMENT, matchRiskTier, riskMultiplier, sharedPool } from '../../core/draft.js';
+// NOTHING RISK-SHAPED IS IMPORTED ANY MORE (2026-08-05). This file used to pull
+// matchRiskTier + riskMultiplier out of core/draft.js purely to print their product in the
+// footer; that readout is gone, so the import is too. Both functions are alive and well in
+// the engine — core/scoring.js multiplies by them every second — they simply have no reader
+// on any screen now. Re-importing one here means a risk number is back on a player's page.
+import { ALWAYS_ON_ELEMENT, sharedPool } from '../../core/draft.js';
 
 /** One 24x24 glyph per element. Literal markup — no interpolation, ever. */
 const GLYPHS = {
@@ -122,13 +124,19 @@ export function mount(container, ctx) {
 
   /* ---------------------------------------------------------- the footer */
 
-  const multLabel = el('span', { class: 'gg-draft-mult', text: '' });
+  /* NO MULTIPLIER LABEL EITHER (2026-08-05). `.gg-draft-mult` — "you both score
+   * ×1.30", in gold, in its own `.gg-draft-meterwrap` slot — was the last node
+   * on this screen fed by the risk tier, and it followed the meters and the
+   * per-tile pips out. `poolLabel` says the same fact in the unit the screen is
+   * about: how many effects the two of you just agreed to. */
   const poolLabel = el('span', { class: 'gg-draft-pool', text: '' });
   const errLabel = el('p', { class: 'gg-draft-error', text: '', role: 'status', hidden: true });
   const confirmBtn = button(ledger, S.draft.confirm, () => confirmIn(), { variant: 'primary', audio, sfx: 'draft-lock' });
 
+  /* The footer is two children now, not three: the empty `.gg-draft-meterwrap`
+   * that held the multiplier went with it rather than staying behind as a
+   * 0-wide flex item in a space-between row. */
   const footer = el('div', { class: 'gg-draft-foot' }, [
-    el('div', { class: 'gg-draft-meterwrap' }, [multLabel]),
     el('div', { class: 'gg-draft-poolwrap' }, [
       poolLabel,
       el('span', { class: 'gg-draft-rolled', text: S.draft.rolled }),
@@ -220,10 +228,9 @@ export function mount(container, ctx) {
       t.badge.textContent = theirsOff ? S.draft.theirsOff : '';
     }
 
-    // Both players endure the same pool, so there is ONE number here and it is the one a player
-    // can act on: agree to more, score faster. (The 0-7 "match risk" tier this used to paint as
-    // three seven-segment meters is gone — it was engine bookkeeping on a player's screen.)
-    multLabel.textContent = S.draft.score(riskMultiplier(matchRiskTier(shared)));
+    // ONE number in the footer, and it is the pool itself. (The 0-7 "match risk" tier this
+    // used to paint as three seven-segment meters, and the ×N multiplier that outlived them
+    // by a day, were both engine bookkeeping on a player's screen.)
     poolLabel.textContent = S.draft.pool(shared.length);
 
     youSig.textContent = match.localDraftConfirmed ? S.draft.confirmed : '';

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
@@ -601,9 +601,12 @@ export function mount(container, ctx) {
 
     /* --- scoreline --- */
     if (result) {
-      // `riskMultiplier` is the engine's frozen name for the pool's score bonus
-      // (core/scoring.js, C#-parity). The word never reaches the page any more.
-      const mult = match?.scoring?.riskMultiplier || 1;
+      /* THE MULTIPLIER IS NOT READ HERE ANY MORE (2026-08-05). This block used
+       * to pull `match.scoring.riskMultiplier` — the engine's frozen name for
+       * the pool's score bonus — and print it in the fine print. It was the
+       * recap's copy of the live HUD's risk readout and left with it; the
+       * scoreline is the multiplier's whole effect, already added up. The
+       * engine value is untouched, it simply has no reader on any screen. */
       column.appendChild(el('section', { class: 'gg-card gg-recap-score' }, [
         el('h2', { class: 'gg-recap-h', text: S.recap.scoreline }),
         el('div', { class: 'gg-scoreline' }, [
@@ -611,7 +614,7 @@ export function mount(container, ctx) {
           el('span', { class: 'gg-scoredash', text: '·' }),
           el('span', { class: 'gg-scorenum is-them', text: String(result.remoteScore) }),
         ]),
-        el('p', { class: 'gg-recap-fine', text: S.recap.scoreFineprint(mult) }),
+        el('p', { class: 'gg-recap-fine', text: S.recap.scoreFineprint }),
         el('p', { class: 'gg-recap-fine', text: S.recap.survived(result.survivedMs) }),
       ]));
     }

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -222,11 +222,13 @@ export const S = Object.freeze({
     lock: 'Lock in',
     locked: 'locked — waiting for them',
     theirs: 'their picks',
-    /* The "match risk N/7" readout and its seven-segment meters were removed on
-     * 2026-08-04: the tier was an engine number wearing a player-facing hat, and
-     * nobody could tell you what a 4 meant. What survives is the consequence,
-     * which needs no glossary — a heavier agreement scores faster. */
-    score: (mult) => 'you both score ×' + mult.toFixed(2),
+    /* NO `score` MULTIPLIER LINE (2026-08-05). The "match risk N/7" readout and
+     * its seven-segment meters went on 2026-08-04; the multiplier they fed
+     * ("you both score ×1.30") survived one more day and then went with the
+     * rest of the risk indicator. It was the tier in disguise — the same engine
+     * number, two decimal places, still no glossary. `pool` below says the same
+     * thing in the unit the screen is actually about: how many effects you both
+     * just agreed to take. */
     unsupported: "your opponent's app can't do this",
     /* --- the agreement pass (2026-08-03 redesign) --- */
     confirm: "I'm good with this",
@@ -261,7 +263,13 @@ export const S = Object.freeze({
     abandonLine: 'Connection lost for a minute.',
     drawLine: 'You both let go at the same moment.',
     scoreline: 'scoreline',
-    scoreFineprint: (mult) => '1 pt/s · score ×' + mult.toFixed(2),
+    /* Was `'1 pt/s · score ×' + mult`, off the engine's riskMultiplier — the
+     * recap's copy of the risk readout, and it left with the other two on
+     * 2026-08-05. The BASE RATE stays because it is the one thing the scoreline
+     * above it cannot say on its own, and attention is named instead of the
+     * multiplier because attention is the only part of the formula that was
+     * ever yours to move: the pool bonus was identical for both of you. */
+    scoreFineprint: '1 pt/s, for as long as your attention holds',
     survived: (ms) => 'survived ' + mmss(ms),
     payloads: 'payload log',
     noPayloads: 'nothing crossed the wire.',
@@ -794,13 +802,13 @@ export const S = Object.freeze({
     zenHideGlyph: '⊟',
     zenShowGlyph: '⊞',
     zenShowTitle: 'show panels · escape still ends the match',
-    /**
-     * The pool's score bonus, in the top bar. It used to read "×1.30 risk" off a
-     * 0-7 "match risk tier" nobody could explain; the tiers are gone from every
-     * screen and what is left is the only part a player could ever act on —
-     * a heavier agreement scores faster.
-     */
-    scoreMult: (mult) => '×' + Number(mult || 1).toFixed(2) + ' score',
+    /* THERE IS NO `scoreMult` ANY MORE (2026-08-05). The top bar's third line
+     * read "×1.30 score" (and "×1.30 risk" before that) off the engine's
+     * riskMultiplier. It was the last player-facing piece of the risk system,
+     * and the owner's verdict on the whole family holds for it too: a number
+     * fixed at the draft, unchangeable mid-match and unexplained by anything on
+     * the desk. Deleted rather than reworded — the score above it is the same
+     * information, already counted. */
     /* ---- the heat gauge (ui/drops.js) ----
      * ONE word, because it sits over the arsenal rail and the bar is the rest of
      * the sentence. `heatValue` is the aria-valuetext: colour never travels


### PR DESCRIPTION
## What the risk indicator actually was

Hunting it turned up that **most of it was already gone**. Batch 7 (`6db81123`, "heat gauge replaces risk", merged 2026-08-04) deleted the player-facing risk system: the seven-segment **`.gg-riskmeter`/`.gg-riskseg`** bars in the draft header (they lit **gold** at high tiers - the row of little yellow pips), the per-tile **`.gg-riskpips`** dots, and the "match risk 4 / 7" label.

What batch 7 left behind was the **multiplier** those meters fed - the same engine number (`scoring.riskMultiplier`, the product of the 0-7 tier), renamed and printed in three places:

| Screen | Node | Text |
|---|---|---|
| Live HUD, top-left score column | `.gg-mult` (was `.gg-risk`) | `×1.30 score` |
| Draft footer | `.gg-draft-mult` in `.gg-draft-meterwrap`, gold | `you both score ×1.30` |
| Recap fine print | `S.recap.scoreFineprint(mult)` | `1 pt/s · score ×1.30` |

Renaming it never fixed what was wrong with it: a bare multiplier with no key, on a number you agreed to once at the draft and cannot move for the rest of the match. **All three are deleted.**

## What was left alone

* **The engine.** `core/scoring.js` multiplies every second by `riskMultiplier`; `core/draft.js` still sums the 0-7 tier behind it. Both are C#-parity names and the wire + RNG vectors depend on them. This is a UI removal, not a mechanics change - the score itself is the multiplier's whole visible effect.
* **The charge pips** (`.gg-pips`, the pink diamonds under the score). They are the arsenal's currency, the receiving side validates throws against them, and the arsenal's cost pips are read against them. They were never the risk readout.
* **The heat gauge**, obviously - it is the thing that does the job.

## Tests

New `selftest-hud` section **2c-ii** pins the absence where it regresses: no `ui/` file reads `riskMultiplier`/`matchRiskTier`/`riskTierOf` outside a comment, the strings are gone, and a mounted HUD builds no `.gg-mult` while still building the charge pips. The zen-toggle CSS check now asserts `.gg-mult` is *not* on the hide list.

```
selftest-hud       1509/1509
selftest-exec       959
selftest-flow       218
selftest-core       242
+ voice-ui / invite / report / hostgate green
```
`selftest-avafx`'s 12 failures are pre-existing on clean main.

## One thing to confirm

If the "row of little yellow diamond pips" you saw was the **draft header's gold tier meters**, they were already gone before this PR and this finishes the job. If you meant the **pink diamonds under your score in the live HUD**, those are the charge meter (how many things you are holding to throw), not risk - say the word and I will take a separate pass at them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D