### PR TITLE
fix(goon): zen closes the held mic, and the last 3s of a voice note count down

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4330,16 +4330,22 @@ const audioMod = await import('../ui/audio.js');
       _sends: sends,
     };
   }
-  function fakeRec() {
-    const st = { starts: 0, stops: 0, cancels: 0, recording: false, disposed: false, capSubs: new Set() };
+  /**
+   * `elapsed` and `cap` are MUTABLE on the returned `st` so the countdown block
+   * below can walk the clock towards the ceiling without waiting ten real
+   * seconds — the strip reads both off the recorder every repaint, which is the
+   * whole reason it may not keep a second copy of the cap.
+   */
+  function fakeRec({ elapsed = 900, cap = 10000 } = {}) {
+    const st = { starts: 0, stops: 0, cancels: 0, recording: false, disposed: false, capSubs: new Set(), elapsed, cap };
     const api = {
       start() { st.starts++; st.recording = true; return Promise.resolve({ ok: true, reason: 'recording' }); },
       stop() { st.stops++; st.recording = false; return Promise.resolve({ ok: true, reason: 'stopped', blob: { size: 64 }, durMs: 900 }); },
       cancel() { st.cancels++; st.recording = false; return Promise.resolve({ ok: false, reason: 'cancelled' }); },
       state() { return st.recording ? 'recording' : 'idle'; },
       isRecording() { return st.recording; },
-      elapsedMs() { return 900; },
-      maxMs() { return 10000; },
+      elapsedMs() { return st.elapsed; },
+      maxMs() { return st.cap; },
       mimeType() { return ''; },
       onCapped(fn) { st.capSubs.add(fn); return () => st.capSubs.delete(fn); },
       dispose() { st.disposed = true; st.recording = false; },
@@ -4350,11 +4356,11 @@ const audioMod = await import('../ui/audio.js');
     type, pointerId: id, clientX: x, clientY: 0, preventDefault() {},
   });
   /** One mounted mic with its fakes, live and idle. */
-  function mountMic() {
+  function mountMic(recOpts) {
     const host = document.createElement('div');
     const chipHost = document.createElement('div');
     const v = fakeVoice();
-    const r = fakeRec();
+    const r = fakeRec(recOpts);
     const mic = micMod.mountMicHud({ host, chipHost, voice: v, recorder: r.api });
     return { host, chipHost, v, r, mic, btn: mic.parts.button };
   }
@@ -4464,6 +4470,114 @@ const audioMod = await import('../ui/audio.js');
     m.mic.unmount();
   }
 
+  /* --- 20c-bis. ZEN TAKES THE MIC, IN JS AND NOT ONLY IN CSS ---------------
+   * The stylesheet's `.gg-hud--zen .gg-voice-host { display:none }` is asserted
+   * in 20f, and on its own it is NOT ENOUGH: pointer capture bypasses hit
+   * testing, so hiding the slot under a live hold would leave a recording (and
+   * the OS microphone light) running with nothing on screen to say so. The bit
+   * is pushed into the handle, and it composes with availability rather than
+   * replacing it. */
+  {
+    const m = mountMic();
+    ok(typeof m.mic.setHudHidden === 'function', 'the mic takes the desk\'s hidden bit');
+    m.v._set(true);
+    ok(m.host.hidden === false && m.mic.shown() === true, 'live and shown, to start');
+    m.mic.setHudHidden(true);
+    ok(m.host.hidden === true, 'ZEN HIDES THE BUTTON — at the host, not only in the stylesheet');
+    ok(m.mic.shown() === false, 'and shown() says so');
+    ok(m.mic.available() === true, '...while available() still reports the FEATURE, which zen did not change');
+    m.mic.setHudHidden(true);
+    ok(m.host.hidden === true, 'pushing the same bit twice is a no-op');
+    m.mic.setHudHidden(false);
+    ok(m.host.hidden === false, 'un-zen gives it back');
+
+    // The two bits AND. Whichever one is false, the mic is gone.
+    m.mic.setHudHidden(true);
+    m.v._set(false);
+    m.mic.setHudHidden(false);
+    ok(m.host.hidden === true, 'leaving zen does NOT resurrect a mic the feature itself has taken away');
+    m.v._set(true);
+    ok(m.host.hidden === false, 'and both being true is the only state that shows it');
+    m.mic.unmount();
+  }
+
+  {
+    // zen DURING a hold: the recording dies with the surface it was drawn on
+    const m = mountMic();
+    m.v._set(true);
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ok(m.mic.isRecording() === true, 'a hold is running');
+    m.mic.setHudHidden(true);
+    await sleep(20);
+    ok(m.r.st.cancels === 1, 'hiding the HUD mid-hold CANCELS the recording — never a mic behind a hidden strip');
+    ok(m.v._sends.length === 0, 'and nothing is sent: the player was hiding the UI, not finishing a note');
+    ok(m.mic.isRecording() === false, 'the gesture is over');
+    ok(m.host.hidden === true, 'and the slot is gone');
+    m.mic.unmount();
+  }
+
+  /* --- 20c-ter. THE LAST THREE SECONDS ARE A COUNTDOWN ---------------------
+   * Elapsed for the first seven ("3.4s / 10s"), remaining for the last three
+   * ("2s left") — the question changes, so the number does. Both readings come
+   * off the RECORDER's own cap, which is why this fake can shrink it. */
+  {
+    const m = mountMic({ elapsed: 0, cap: 10000 });
+    m.v._set(true);
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    const timeEl = m.mic.parts.timeEl;
+
+    m.r.st.elapsed = 4200;
+    await sleep(150);
+    ok(timeEl.textContent === S20.voice.recordTimer(4200, 10000),
+      'mid-note the strip reads elapsed / cap', timeEl.textContent);
+    ok(!hasClass(m.mic.parts.strip, 'is-ending'), 'and is not warning about anything yet');
+
+    m.r.st.elapsed = 10000 - micMod.MIC_COUNTDOWN_MS + 1;
+    await sleep(150);
+    ok(hasClass(m.mic.parts.strip, 'is-ending'),
+      'crossing MIC_COUNTDOWN_MS turns the strip hot');
+    ok(timeEl.textContent === S20.voice.recordCountdown(3),
+      'and the number becomes a countdown, from strings.js', timeEl.textContent);
+
+    m.r.st.elapsed = 9200;
+    await sleep(150);
+    ok(timeEl.textContent === S20.voice.recordCountdown(1),
+      'the last whole second is "1s left", never "0s left" for a whole second', timeEl.textContent);
+
+    // ...and the warning belongs to ONE note: it may not be inherited.
+    ptr(m.btn, 'pointerup', 200);
+    await sleep(30);
+    ok(!hasClass(m.mic.parts.strip, 'is-ending'), 'sending clears it');
+    // "sent" holds the strip for MIC_FLASH_MS and onDown only fires from idle —
+    // the second hold has to wait for the fold, exactly as a player's would.
+    await sleep(micMod.MIC_FLASH_MS + 120);
+    m.r.st.elapsed = 0;
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ok(!hasClass(m.mic.parts.strip, 'is-ending') &&
+       m.mic.parts.timeEl.textContent === S20.voice.recordTimer(0, 10000),
+      'so the NEXT hold starts on the elapsed reading, not the last one\'s hot number',
+      m.mic.parts.timeEl.textContent);
+    m.mic.unmount();
+  }
+
+  {
+    // a shrunken cap counts down from ITSELF — there is no second copy of 10s
+    const m = mountMic({ elapsed: 0, cap: 4000 });
+    m.v._set(true);
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    m.r.st.elapsed = 2500;
+    await sleep(150);
+    ok(hasClass(m.mic.parts.strip, 'is-ending') &&
+       m.mic.parts.timeEl.textContent === S20.voice.recordCountdown(2),
+      'the countdown is read off rec.maxMs(), not VN_MAX_MS',
+      m.mic.parts.timeEl.textContent);
+    m.mic.unmount();
+  }
+
   {
     // their note arriving
     const m = mountMic();
@@ -4528,10 +4642,42 @@ const audioMod = await import('../ui/audio.js');
       'exposed on parts, like every other sub-mount');
     voice20._set(true);
     ok(micHost20.hidden === false, 'the desk shows it on the availability edge');
+
+    /* THE ZEN TOGGLE REALLY REACHES IT. Clicking the button the player clicks,
+     * not calling the setter: the wiring between setZen and the mic handle is
+     * the thing under test, and it has a hoisting order to get wrong. */
+    hud20.parts.zen.button.dispatchEvent({ type: 'click' });
+    ok(hud20.parts.zen.on === true, 'the zen button toggles the desk');
+    ok(micHost20.hidden === true, 'and the mic goes with the rest of the chrome');
+    hud20.parts.zen.button.dispatchEvent({ type: 'click' });
+    ok(hud20.parts.zen.on === false && micHost20.hidden === false,
+      'the toggle is its own undo for the mic too');
+    ok(hud20.parts.mic.shown() === true, 'and the handle agrees it is back');
+
     hud20.unmount();
     ok(dom.byId.get('gg-hud').children.length === 0, 'and it comes down with the desk');
     ok(match20._subs.released === match20._subs.taken, 'with no subscription left behind',
       `${match20._subs.released}/${match20._subs.taken}`);
+  }
+  {
+    /* A REMEMBERED ZEN, which is the ordering trap: the pref is read before the
+     * mic is mounted, so the bit has to be REPLAYED into the handle. Without it
+     * a returning player's first zen press would SHOW the mic instead of hiding
+     * it, and the second would hide it — the toggle inverted for one match. */
+    const match20z = makeFakeMatch();
+    const voice20z = fakeVoice();
+    const hud20z = hudMod.mountHud({
+      match: match20z, audio: { sfx() {} }, voice: voice20z,
+      prefs: { get: (k) => k === 'hudZen', set() {} },
+    });
+    const micHost20z = findOne(dom.byId.get('gg-hud'), 'gg-voice-host');
+    voice20z._set(true);
+    ok(micHost20z.hidden === true,
+      'a zen remembered from the last match hides the mic at mount, not after the first click');
+    hud20z.parts.zen.button.dispatchEvent({ type: 'click' });
+    ok(hud20z.parts.zen.on === false && micHost20z.hidden === false,
+      'and the FIRST press is the one that brings it back');
+    hud20z.unmount();
   }
   {
     // no service (a build with the feature off, or a construction failure)
@@ -4592,6 +4738,15 @@ const audioMod = await import('../ui/audio.js');
 
     ok(/gg-hud--zen\s+\.gg-voice-host/.test(bare20) && /gg-hud--zen\s+\.gg-voice-chiphost/.test(bare20),
       'zen takes both slots away by name, like the dial and the effect chips');
+    // ...and the JS half of the same fact, which is the one that closes the mic.
+    const hudSrc20 = await fs20.readFile(url20.fileURLToPath(new URL('../ui/hud.js', import.meta.url)), 'utf8');
+    ok(/setHudHidden\(zenOn\)/.test(hudSrc20.replace(/\/\*[\s\S]*?\*\//g, '')),
+      'ui/hud.js pushes the zen bit into the mic — CSS cannot end a captured hold');
+
+    ok(/\.gg-voice\.is-ending\s+\.gg-voice-time/.test(bare20),
+      'the last three seconds have a colour as well as a word');
+    ok(css20.indexOf('.gg-voice.is-cancel .gg-voice-time') > css20.indexOf('.gg-voice.is-ending .gg-voice-time'),
+      '...and the cancel state is written later, so a note about to be dropped is not also "running out"');
     ok(/prefers-reduced-motion[\s\S]*gg-voice-dot[\s\S]*animation:\s*none/.test(bare20),
       'motion off stops the pulse without taking the state away');
     ok(/\.gg-voice-btn\s*\{[^}]*width:\s*48px[\s\S]{0,40}height:\s*48px/.test(bare20),

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
@@ -801,7 +801,7 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
     for (const k of flat) if (typeof V[k] !== 'string' || V[k] === '') missing += k + ' ';
     ok(missing === '', 'every flat string wave 2 needs is present', missing);
 
-    const fns = ['noteName', 'noteLength', 'recordTimer', 'full', 'linkedTo', 'linkMoved', 'tooSoon'];
+    const fns = ['noteName', 'noteLength', 'recordTimer', 'recordCountdown', 'full', 'linkedTo', 'linkMoved', 'tooSoon'];
     let notFn = '';
     for (const k of fns) if (typeof V[k] !== 'function') notFn += k + ' ';
     ok(notFn === '', 'and every interpolator is a FUNCTION, so this module stays import-safe', notFn);
@@ -809,6 +809,18 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
     ok(V.full(VN_MAX_NOTES).includes(String(VN_MAX_NOTES)),
       'the "library is full" line carries the real ceiling', V.full(VN_MAX_NOTES));
     ok(V.recordTimer(4200, VN_MAX_MS).includes('4.2'), 'the record timer reads in seconds', V.recordTimer(4200, VN_MAX_MS));
+    /* TWO READINGS OF ONE CLOCK, and they have to be tellable apart at a glance:
+     * the library screen and the first seven seconds of a hold say how much has
+     * been said; the last three say how much is LEFT (ui/voice/micHud.js
+     * MIC_COUNTDOWN_MS). A countdown that still looked like a fraction would be
+     * a warning nobody notices. */
+    ok(V.recordCountdown(2).includes('2') && !V.recordCountdown(2).includes('/'),
+      'the countdown is a bare remaining number, not a fraction to subtract', V.recordCountdown(2));
+    ok(V.recordCountdown(2) !== V.recordTimer(8000, VN_MAX_MS),
+      'and never renders as the elapsed line for the same instant',
+      V.recordCountdown(2) + ' | ' + V.recordTimer(8000, VN_MAX_MS));
+    ok(V.recordCountdown(-1) === V.recordCountdown(0),
+      'a clock that overshot the cap still says something sane', V.recordCountdown(-1));
 
     // THE ACK GATE. Two paragraphs, and the second one is the one that is easy to
     // leave out: this switch is also a consent to HEAR them.

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -2426,7 +2426,11 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
  * parking them at heat costs no information.
  *
  * ZEN takes both away by name, like the dial and the effect chips: it exists to
- * hand the stage back, and a mic you are not holding is chrome.
+ * hand the stage back, and a mic you are not holding is chrome. THE RULE BELOW
+ * IS HALF THE FEATURE — ui/hud.js also pushes the bit into micHud
+ * (`setHudHidden`), because pointer capture bypasses hit testing and a
+ * `display:none` over a live hold would otherwise leave a recording running with
+ * no strip on screen. The stylesheet hides it; the module closes the microphone.
  * ======================================================================== */
 .gg-voice-host {
   position: relative;
@@ -2509,6 +2513,15 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   color: var(--gg-text-1);
   white-space: nowrap;
 }
+/* THE LAST THREE SECONDS. The words already changed ("2s left" — ui/strings.js
+   voice.recordCountdown); this is the colour half of the same fact, and it is a
+   COLOUR and not an animation on purpose: the strip carries state classes and
+   the section's animation budget is spent on the dot (see the header). Cancel
+   wins over ending — a note that is about to be thrown away has nothing left to
+   be running out of. */
+.gg-voice.is-ending .gg-voice-time { color: var(--gg-hot); }
+.gg-voice.is-cancel .gg-voice-time { color: var(--gg-text-4); }
+
 .gg-voice-slide {
   font-size: 0.62rem; letter-spacing: 0.08em;
   color: var(--gg-text-4);

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -29,7 +29,8 @@
  * score multiplier, the closeness dial, MERCY — is hidden by ui/hud.css off
  * .gg-hud--zen and html[data-gg-zen]. The monitor, the arsenal and the heat
  * gauge that feeds it stay: they are what the duel is played on. See the
- * toggle's own block below for why hiding MERCY is safe.
+ * toggle's own block below for why hiding MERCY is safe — and why the voice mic
+ * is the one thing zen has to hide in JS as well as in CSS.
  *
  * ANIMATION BUDGET. Chrome animations go through fx.play(): at most two run at
  * once and anything that waited more than 600 ms is dropped rather than played
@@ -381,6 +382,18 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   let zenOn = false;
   if (zenBtn) zenBtn.type = 'button';
 
+  /* THE MIC IS THE ONE THING ZEN CANNOT HIDE WITH CSS ALONE. Everything else on
+   * this toggle is chrome that stops being painted; the mic can be HELD, and a
+   * captured pointer bypasses hit testing — `display:none` would take the strip
+   * away and leave the recording (and the OS microphone light) running behind
+   * it. So the bit is pushed into ui/voice/micHud.js as well, which cancels a
+   * live hold on the same path the feature going away takes.
+   *
+   * Declared here and assigned after the mount ~300 lines down, because setZen
+   * is hoisted but the mic is not: null is the whole of the startup case, and
+   * the remembered preference is replayed into the handle the moment it exists. */
+  let micRef = null;
+
   function paintZen() {
     const label = zenOn ? S.hud.zenShow : S.hud.zenHide;
     text(zenBtn, zenOn ? S.hud.zenShowGlyph : S.hud.zenHideGlyph);
@@ -406,6 +419,7 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
     if (next === zenOn) return;
     zenOn = next;
     paintZen();
+    try { micRef?.setHudHidden(zenOn); } catch (_e) { /* a no-op handle has no bit */ }
     // Persisting is a nicety, not the state: the bit above is already true.
     if (remember && prefs && typeof prefs.set === 'function') {
       try { prefs.set('hudZen', zenOn); } catch (_e) { /* no store, no problem */ }
@@ -714,6 +728,12 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
    * the desk subscribes to the answer instead of re-deriving any of it. With no
    * service at all this is a no-op handle and no DOM. */
   const mic = mountMicHud({ host: voiceHost, chipHost: voiceChipHost, voice, audio, onLog });
+  /* Zen is restored from prefs BEFORE this mount, so the handle is told the bit
+   * it was not there to hear. setZen's own early-return means it would never be
+   * re-sent, and a remembered zen with a visible mic under it is the one state
+   * that would make the toggle look broken on the first click. */
+  micRef = mic;
+  try { mic.setHudHidden(zenOn); } catch (_e) { /* a no-op handle has no bit */ }
 
   led.add(() => { try { mic.unmount(); } catch (_e) { /* gone */ } });
   led.add(() => { try { announcer.unmount(); } catch (_e) { /* gone */ } });

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -486,6 +486,10 @@ export const S = Object.freeze({
     holdHint: 'hold the mic to record',
     /** While held. The gesture out is a slide, and it has to be said, not guessed. */
     slideToCancel: 'slide left to cancel',
+    /** The last three seconds (micHud.MIC_COUNTDOWN_MS). The question stops being
+       "how much have I said" and becomes "how long have I got", so the number
+       does too — a countdown, not a fraction to subtract mid-sentence. */
+    recordCountdown: (sec) => Math.max(0, sec) + 's left',
     /** The three outcomes, in the order a player meets them. */
     sending: 'sending…',
     sent: 'sent',

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -17,8 +17,18 @@
  *        └──(>=250ms held)──> RECORDING ──┬── pointerup ─────────> stop + send
  *                                         ├── slid left >80px ───> cancel
  *                                         ├── 10.0s cap ─────────> stop + send
+ *                                         ├── the HUD hiding ────> cancel
  *                                         └── pointercancel /
  *                                             lostpointercapture > cancel
+ *
+ * THE LAST THREE SECONDS ARE A COUNTDOWN, NOT A FRACTION. For the first seven
+ * the strip reads "3.4s / 10s", which answers "how much have I said". Inside
+ * MIC_COUNTDOWN_MS it becomes "2s left" and the number turns hot — because the
+ * question has changed to "how long have I got", and a player mid-sentence
+ * should not have to subtract two numbers to find out. The cap itself is
+ * unchanged and still lives in ui/voice/recorder.js; this is only how it is
+ * SAID, and it is read off `rec.maxMs()` so a shrunken test recorder counts down
+ * from its own cap rather than from a second copy of ten seconds.
  *
  * WHY THE RECORDER STARTS ON pointerdown AND NOT AT THE 250ms MARK. The hold
  * threshold decides whether a note EXISTS, not when the microphone opens: a
@@ -59,6 +69,17 @@
  *   `pointerType` the way the pinch gesture is — desktop is a mouse and this is
  *   a desktop app first.
  *
+ *   A HIDDEN HUD IS A CLOSED MICROPHONE. ui/hud.css already takes both voice
+ *   slots away by name under zen, but CSS alone is not enough: pointer capture
+ *   BYPASSES HIT TESTING, so a `display:none` (or the `pointer-events:none` that
+ *   sudden death lays over the body) does not end a hold that is already
+ *   captured. Left to the stylesheet, tapping zen with a second finger while the
+ *   first one holds the mic would leave a recording running with the OS mic
+ *   indicator lit and no strip anywhere on screen to say so — exactly the hot mic
+ *   recorder.js rule 1 forbids. ui/hud.js therefore PUSHES the bit in via
+ *   `setHudHidden()`, and it ends a live gesture on the same cancel path the
+ *   feature going away takes. See applyPresence().
+ *
  * Node-import-safe: no DOM at import time, only inside mountMicHud().
  * ==========================================================================*/
 
@@ -74,6 +95,13 @@ export const MIC_CANCEL_PX = 80;
 export const MIC_ARM_PX = 40;
 /** How long "sent" / "cancelled" stays on the strip before it folds away. */
 export const MIC_FLASH_MS = 1200;
+/**
+ * How close to the cap the elapsed timer turns into a countdown. Three seconds
+ * is two beats of warning at the pace people actually talk — long enough to
+ * finish a short clause, short enough that the strip is not nagging for a third
+ * of every note.
+ */
+export const MIC_COUNTDOWN_MS = 3000;
 /** The hint caption's dwell (a tap, a refusal). Long enough to read once. */
 export const MIC_HINT_MS = 2200;
 /** Timer repaint cadence while recording. 10 fps is smooth for one decimal. */
@@ -167,7 +195,8 @@ export function sendReasonLine(reason, waitSec = 1) {
  * @param {object}   [o.recorder]  TEST SEAM — a pre-built recorder (see recorder.js)
  * @param {Function} [o.now]       TEST SEAM — the clock the hold/slide read
  * @param {Function} [o.onLog]
- * @returns {{unmount:Function, isRecording:Function, available:Function, parts:object}}
+ * @returns {{unmount:Function, isRecording:Function, available:Function,
+ *            shown:Function, setHudHidden:Function, parts:object}}
  */
 export function mountMicHud({
   host, chipHost = null, voice = null, audio = null,
@@ -190,6 +219,9 @@ export function mountMicHud({
       unmount() { led.run(); },
       isRecording() { return false; },
       available() { return false; },
+      /** Nothing to hide, but the desk pushes the bit unconditionally. */
+      setHudHidden() {},
+      shown() { return false; },
       parts: {},
     };
   }
@@ -255,8 +287,10 @@ export function mountMicHud({
   let hintTimer = 0;
   let chipTimer = 0;
   let willCancel = false;
+  let ending = false;            // inside MIC_COUNTDOWN_MS of the cap
   let lastSentAt = -Infinity;
   let live = false;              // the availability bit, from voice.onStateChanged
+  let hudHidden = false;         // the zen bit, pushed in by ui/hud.js
   let unmounted = false;
 
   function log(entry) {
@@ -279,6 +313,7 @@ export function mountMicHud({
     attr(strip, 'data-gg-voice', phase);
     cls(strip, 'is-rec', phase === 'rec');
     cls(strip, 'is-cancel', phase === 'rec' && willCancel);
+    cls(strip, 'is-ending', phase === 'rec' && ending);
     // .gg-plate ONLY while the strip is a strip: idle, it is a bare round
     // button and a plate behind it would be a box around a circle. goon.css's
     // html[data-gg-fx="hot"] rule hardens it for free while it is on.
@@ -291,13 +326,42 @@ export function mountMicHud({
     text(slideEl, S.voice.slideToCancel);
   }
 
+  /**
+   * The cap THIS recorder enforces. Asked every time rather than cached: the
+   * handle can be injected (the suite shrinks it to hundreds of milliseconds so
+   * it can wait a cap out), and VN_MAX_MS is only the fallback for a recorder
+   * old enough not to answer.
+   */
+  function capMs() {
+    try {
+      const m = typeof rec.maxMs === 'function' ? Number(rec.maxMs()) : 0;
+      if (m > 0) return m;
+    } catch (_e) { /* fall through */ }
+    return VN_MAX_MS;
+  }
+
   function paintTimer() {
     if (phase !== 'rec') return;
-    text(timeEl, S.voice.recordTimer(rec.elapsedMs(), VN_MAX_MS));
+    const max = capMs();
+    const elapsed = rec.elapsedMs();
+    const left = Math.max(0, max - elapsed);
+    /* THE HANDOVER. Two readings of the same clock — "how much have I said" and
+     * "how long have I got" — and the strip only ever shows the one the player
+     * is asking. The class change is the colour half and rides the same repaint,
+     * so the words and the red never disagree by a tick. */
+    const nextEnding = left <= MIC_COUNTDOWN_MS;
+    if (nextEnding !== ending) { ending = nextEnding; paintPhase(); }
+    // ceil, so the last whole second is spoken as "1s left" rather than "0s
+    // left" for its entire duration.
+    text(timeEl, ending ? S.voice.recordCountdown(Math.ceil(left / 1000)) : S.voice.recordTimer(elapsed, max));
   }
 
   function setPhase(next) {
     phase = next;
+    // The countdown belongs to ONE recording. Leaving 'rec' for any reason —
+    // sent, cancelled, taken away — puts the strip back on the elapsed reading
+    // before the next hold can inherit a hot number from the last one.
+    if (next !== 'rec') ending = false;
     paintPhase();
     if (next === 'rec') paintTimer();
   }
@@ -496,23 +560,57 @@ export function mountMicHud({
   /* --------------------------------------------------------- availability -- */
 
   /**
-   * The mic is not disabled when voice is off — it is NOT THERE. A greyed-out
+   * THE ONE PRESENCE RULE. Two independent bits decide whether the mic is on the
+   * desk at all, and NEITHER of them may leave a gesture running:
+   *
+   *   live       ui/voice/voiceService.js's five-fact predicate — both consents,
+   *              the peer's build, the phase, your own opt-in.
+   *   hudHidden  the desk's zen toggle, pushed in by ui/hud.js.
+   *
+   * The mic is not DISABLED when either is false — it is NOT THERE. A greyed-out
    * button would be a standing invitation to a feature the other player has not
    * agreed to, and there is nothing useful to say on it (S.voice.notActive is
    * the lobby's job, once, where the toggle is).
    *
-   * The host is hidden rather than emptied: rebuilding these nodes is what would
-   * release a live pointer capture (see the header).
+   * The host is HIDDEN rather than emptied: rebuilding these nodes is what would
+   * release a live pointer capture (see the header). And it is `hidden` on the
+   * host rather than a class, both times — the stylesheet's zen rule already
+   * hides the slot, but only the attribute survives a stylesheet that has not
+   * loaded, and only the JS below closes the microphone. A recording that
+   * outlives its own strip is the failure mode this function exists to make
+   * impossible.
+   *
+   * @param {'lost'|'zen'} why  what to log the abandoned recording as
    */
+  function applyPresence(why) {
+    const shown = live && !hudHidden;
+    host.hidden = !shown;
+    cls(host, 'is-live', shown);
+    // A caption that outlived its slot: the hint is a child of the host, so it
+    // goes dark with it, but it must not come BACK when zen does.
+    if (!shown && hint) hint.hidden = true;
+    // Going away mid-hold: the gesture dies with the surface it was drawn on,
+    // and the recorder is cancelled rather than left holding the microphone.
+    if (!shown && (phase === 'rec' || phase === 'hold')) finishGesture(why || 'lost');
+  }
+
   function setLive(on) {
     const next = !!on;
     if (next === live) return;
     live = next;
-    host.hidden = !live;
-    cls(host, 'is-live', live);
-    // Going away mid-hold: the gesture dies with the feature, and the recorder
-    // is cancelled rather than left holding the microphone open.
-    if (!live && (phase === 'rec' || phase === 'hold')) finishGesture('lost');
+    applyPresence('lost');
+  }
+
+  /**
+   * The desk hiding (zen) or showing its chrome. Idempotent, so ui/hud.js can
+   * push the remembered preference at mount time without knowing whether it
+   * differs from the default.
+   */
+  function setHudHidden(on) {
+    const next = !!on;
+    if (next === hudHidden) return;
+    hudHidden = next;
+    applyPresence('zen');
   }
   host.hidden = true;
   try { setLive(voice.available()); } catch (_e) { setLive(false); }
@@ -557,6 +655,10 @@ export function mountMicHud({
     /** The phase name, for a driver that wants more than a boolean. */
     phase() { return phase; },
     available() { return live; },
+    /** Is it actually on the desk? available() AND the HUD not hidden. */
+    shown() { return live && !hudHidden; },
+    /** ui/hud.js's zen toggle, pushed in. See applyPresence(). */
+    setHudHidden,
     /** The recorder, so the library screen could share one if it ever wants to. */
     recorder: rec,
 


### PR DESCRIPTION
## What this is

The task was "add a hold-to-record voice-note button to the in-match HUD, WhatsApp style". **That button already exists on `main`** — `ui/voice/micHud.js`, shipped in PR #117. It is already the full gesture:

| asked for | already on main |
|---|---|
| press-and-hold to record | `pointerdown` opens the mic immediately; the strip expands at the 250 ms mark (`MIC_HOLD_MS`), so a tap never flashes one and a fast talker never loses their first syllable |
| slide to cancel | slide left, arms at 40 px (`MIC_ARM_PX`), cancels at 80 px (`MIC_CANCEL_PX`), with `S.voice.slideToCancel` standing on the strip the whole time |
| release to send | `rec.stop()` → `voiceService.sendBlob(blob, {durMs})` — the same send path the library screen uses |
| hidden with the HUD toggle | `.gg-hud--zen .gg-voice-host { display:none }` |
| gated like the voice feature | mounted always, `host.hidden` off `voiceService.available()`'s five-fact predicate; absent, never greyed out; `S.voice.micDenied` / `micMissing` on a refusal |
| shared pipeline | one `createVoiceRecorder` (`ui/voice/recorder.js`), shared with `ui/screens/voice.js` |
| pointer capture, 48 px, no surface fights | `setPointerCapture`, `touch-action:none`, and the 0,2,0 `pointer-events` opt-out/opt-in pair that answers `.gg-hud-frame .gg-plate` |

So this PR is **not** a re-implementation. It is the two gaps that audit turned up.

## 1. Zen hid the mic in CSS only — which cannot end a held recording

`display:none` is enough for chrome that merely stops being painted. It is not enough for a control that can be **held**: pointer capture *bypasses hit testing*, so hiding the slot mid-hold leaves the recording running, the OS microphone indicator lit, and no strip anywhere on screen to say so. On a phone that is one thumb on the mic and a second finger on the toggle — and it is exactly the hot mic `recorder.js` rule 1 forbids. (The same applies to the `pointer-events:none` sudden death lays over `.gg-hud-body`.)

`ui/hud.js` now **pushes the bit** into the handle (`mic.setHudHidden(zenOn)`), and micHud composes it with availability in one place:

```
applyPresence()  →  shown = live && !hudHidden
                    host.hidden = !shown
                    !shown && holding  →  finishGesture('zen')   // cancel, mic closed
```

Either bit false and the mic is gone *and* a live gesture dies down the path the feature going away already took. The remembered `hudZen` pref is replayed into the handle at mount — it is read before the mic exists, and without the replay a returning player's **first** zen press would *show* the mic instead of hiding it.

## 2. The 10 s cap was never counted down

The strip read `3.4s / 10s` for all ten seconds — an answer to *how much have I said*, when in the last stretch the question is *how long have I got*. Inside `MIC_COUNTDOWN_MS` (3 s) it now reads `2s left` (`S.voice.recordCountdown`) and the number goes hot via `.gg-voice.is-ending`.

A **colour, not an animation**: the section's animation budget belongs to `.gg-voice-dot` / `.gg-voice-bar`, and the suite enforces that. The cap itself is untouched and still lives in `recorder.js` — the countdown reads `rec.maxMs()`, so there is no second copy of ten seconds anywhere and a shrunken test recorder counts down from its own ceiling.

## Selftests

`selftest-hud.js` **1529/1529** (was 1498) — new blocks for: the two presence bits ANDing, zen mid-hold cancelling with nothing sent, the remembered-zen ordering trap driven through the real button, the countdown handover (and that it is not inherited by the next hold), a shrunken cap counting down from itself, and the CSS/JS pair.
`selftest-voice.js` **191** (was 188) — the new copy line, pinned as a countdown and not a fraction.
`voice-ui` 216, `flow` 218, `exec` 959, `core` 242, `net` 269, `assets` 427, `report` 213 — all green. (`selftest-avafx.js`'s 12 pre-existing failures untouched.)

`bridge.js` untouched. Nothing outside `Resources/web/goon`.

## Needs a real-device play-test

- **Two fingers on a phone**: hold the mic, tap ⊟ with the other hand. Expect: strip vanishes, nothing sent, and the OS mic indicator goes out immediately.
- The countdown at real speed — whether 3 s reads as helpful or as nagging, and whether `2s left` is legible at 0.68 rem on a 375 pt screen next to "slide left to cancel".
- A genuine 10 s cap while still holding: the auto-send path runs from `0s left`.
- WebView2 (desktop, mouse) and mobile Safari both, since the mime chain differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
