### PR TITLE
fix(goon): assets screen clipped at top - compress-all button unreachable

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/goon.css
+++ b/ConditioningControlPanel/Resources/web/goon/goon.css
@@ -93,10 +93,19 @@ html, body {
 .gg-screen {
   position: absolute; inset: 0;
   display: flex; flex-direction: column;
-  align-items: center; justify-content: center;
-  padding: clamp(1rem, 4vw, 3rem);
+  align-items: center;
+  /* NO justify-content:center here: on a scroll container it pushes half the
+     overflow above scrollTop:0 where no amount of scrolling can reach it (the
+     assets card lost its whole header + compress-all row this way). The edge
+     children's auto margins below center the group when it fits and collapse
+     to 0 when it overflows, so the top always stays scrollable. */
+  padding: calc(clamp(1rem, 4vw, 3rem) + env(safe-area-inset-top, 0px))
+           clamp(1rem, 4vw, 3rem)
+           calc(clamp(1rem, 4vw, 3rem) + env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
 }
+.gg-screen > :first-child { margin-top: auto; }
+.gg-screen > :last-child { margin-bottom: auto; }
 
 /* ---------------------------------------------------------------------------
  * COMPONENT KIT

--- a/ConditioningControlPanel/Resources/web/goon/ui/router.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/router.js
@@ -273,6 +273,9 @@ export function createRouter({ screens = {}, ctx = null, logger = null } = {}) {
       currentEl = section;
       section.replaceChildren();
       section.hidden = false;
+      // Sections persist across shows, and so does their scroll position — a
+      // screen taller than the viewport (assets) must not reopen mid-scroll.
+      try { section.scrollTop = 0; } catch (_e) { /* ignore */ }
       markScreen(name);
 
       const mountCtx = args ? Object.assign({}, ctx, args) : ctx;


### PR DESCRIPTION
## The bug
The Goon Game Asset Manager opened with its top cut off, and the "compress all" button appeared to be missing. The button exists (`ui/screens/assets.js:108`, first item of the toolbar) - it was clipped off-screen along with the whole card header.

## Root cause
`.gg-screen` in `goon.css` combined `justify-content: center` with `overflow-y: auto`. When the single flex child is taller than the viewport, centering distributes the overflow to BOTH ends, and the part above the start edge sits above `scrollTop: 0` - permanently unreachable by scrolling. The assets library is the tallest screen in the app (58rem card, head + 2 toolbar rows + up to 120 tiles per growth chunk), so it is where this latent bug bit first. `.gg-recap` had already worked around the same thing locally with `margin: auto`.

## The fix
- `.gg-screen` centers via auto margins on its edge children instead of `justify-content: center`: identical centering when content fits, margins collapse to 0 on overflow so the top stays scrollable. (Chose this over `justify-content: safe center`, which iOS Safari silently ignores - phones are a first-class GG client.)
- Screen padding now adds `env(safe-area-inset-top/bottom)` so notched phones do not tuck the card top under the status bar.
- `router.show()` resets `section.scrollTop` - sections persist across shows, so a tall screen must not reopen mid-scroll.

Countdown/stage screens are unaffected (absolutely positioned children, auto margins resolve to 0). No feature flags or tier gates were involved.

Note: when every asset is already compressed the button is intentionally disabled at 50% opacity with the label "everything is compressed" - that part is by design, not this bug.

## Play-test
Not play-tested in-app yet - needs the usual look at the Assets screen (windowed + phone) to confirm the header and compress-all row are visible and the screen scrolls to the very top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGrTm1ev9kpvVDrZYsvesj
