### PR TITLE
feat(goon): video lane quality - gif-origin demotion + HEVC peer handshake

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -50,6 +50,7 @@ import { GoonReceiptStatus } from './core/scoring.js';
 import { GoonSession } from './net/session.js';
 import { createLoopbackPair, loopbackPresets } from './net/loopbackTransport.js';
 import { createMediaQueue } from './net/mediaQueue.js';
+import { probeDecodeCodecs } from './net/codecs.js';
 import { createBlocklist } from './net/blocklist.js';
 import { createReceivedStore } from './exec/receivedStore.js';
 
@@ -640,7 +641,19 @@ function createArtifactSource() {
          * the larder never filled, and every throw fired untagged into the
          * receiver's own pool. */
         const wireKind = mime.indexOf('video/') === 0 ? 'video' : 'image';
-        out.push({ sha, bytes, mime, kind: wireKind, exempt });
+        /* …AND THE ORIGIN IS THE SOURCE'S, WHICH IS THE OTHER HALF OF THE SAME STORY. The wire
+         * kind above deliberately forgets that this mp4 used to be a gif; the VIDEO lane wants
+         * that fact back, so it travels beside it as `origin` and demotes (never excludes) the
+         * artifact when a real clip is also available. `it.origin` is the host's own answer
+         * (GoonCacheBridge, from TransferKinds.Gif); `it.kind === 'gif'` is the same answer read
+         * off the item a host too old to send `origin` still provides; a browser-picked file
+         * carries the flag from ui/assetsStore.js's compression lane.
+         *
+         * `codec` is what the producer knows it made ("avc1" from either compressor). An exempt
+         * ORIGINAL knows nothing, which is the fail-open case: net/mediaQueue.js offers it. */
+        const origin = (it.origin === 'gif' || it.kind === 'gif') ? 'gif' : '';
+        const codec = String(it.codec || '');
+        out.push({ sha, bytes, mime, kind: wireKind, exempt, origin, codec });
       }
       return out;
     },
@@ -756,6 +769,8 @@ function registerReceived(list) {
     try {
       media.addReceived({
         sha: e.sha, kind: e.kind, mime: e.mime, url: e.url, bytes: e.bytes,
+        // '' for everything that predates the field — which reads as footage, i.e. as today.
+        origin: e.origin || '',
         acquire: () => receivedStore.view(e.sha),
       });
     } catch (_err) { /* one bad row is never the whole inbox */ }
@@ -1907,11 +1922,29 @@ function buildApp() {
   });
 
   artifacts = createArtifactSource();
+
+  /* WHAT THIS DEVICE CAN DECODE, asked ONCE and told to the peer on the xfer hello.
+   *
+   * The sender's own probe (ui/assetsStore.js probeVideoDecodable) only ever proved that the
+   * SENDER can play its clip — Safari decodes its own HEVC, adopts it, transfers it perfectly,
+   * and the Windows peer paints a silent black window for the whole slot with no error anywhere.
+   * This is the missing half: the peer's list reaches net/mediaQueue.js, which stops offering
+   * what the other side has no decoder for. A runtime that cannot be asked (and node) advertises
+   * nothing, which every peer reads as "send me anything" — the old behaviour, exactly. */
+  let decodeCodecs = null;
+  try { decodeCodecs = probeDecodeCodecs(); } catch (e) {
+    logger.warn('the decode probe threw (' + ((e && e.message) || e)
+      + ') — advertising nothing, so the peer will keep offering everything');
+    decodeCodecs = null;
+  }
+  logger.info('decodes: ' + (decodeCodecs ? decodeCodecs.join(', ') : '(could not probe)'));
+
   mediaQueue = createMediaQueue({
     artifacts,
     store: receivedStore,
     blocklist,
     logger,
+    acceptsCodecs: decodeCodecs,
     // === true, NOT !== false (the idiom brainDrain/spiral use above). Deliberate
     // inversion: sending is a new, Patreon-gated capability, so a host that
     // predates the flag must default it OFF. Receiving is never gated.

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -32,7 +32,7 @@
  * RECEIVED ARTIFACTS (P2P media transfer, spec §4.3) live in a SECOND map that
  * the deck never sees:
  *
- *   addReceived({sha,kind,mime,url,bytes,acquire?})   incremental; never the deck
+ *   addReceived({sha,kind,mime,url,bytes,origin?,acquire?})  incremental; never the deck
  *   hasReceived(sha) / dropReceived(sha) / receivedCount()
  *   acquireByTag('xfer:<sha>') -> {url, release(), provenance:'peer'} | null
  *   drawFor(kind, payload)     -> THE resolution order (tag hit, else own library)
@@ -45,6 +45,15 @@
  *   - "incremental add" is a Map write: no reshuffle, no disturbance of the
  *     8-draw echo guard.
  * ==========================================================================*/
+
+/* GIF-ORIGIN CLIPS COME LAST IN THE VIDEO LANE (2026-08-05, owner call). The desktop compresses
+ * an animated gif into an mp4, so a transferred loop arrives as `video/mp4` and is a perfectly
+ * valid VIDEO artifact — it just is not FOOTAGE, and a video attack that plays a two-second loop
+ * reads as a bug even though every layer worked. `drawReceived`/`peekReceived` therefore prefer
+ * `origin !== 'gif'` and fall back to gif-origin when that is all this match has landed. It is a
+ * PREFERENCE, never a filter: their gif still beats our own library, which is the entire point of
+ * the transfer lane. The sender applies the same rule when it picks tags (net/mediaQueue.js
+ * tagsFor); this is the half that survives a tag miss and the peer-first fallback. */
 
 const NO_ECHO = 8; // a reshuffled deck avoids repeating the last N draws
 
@@ -187,9 +196,23 @@ export function createGoonMediaPool() {
       url: rec.url,
       mime: rec.mime,
       sha,
+      /** '' or 'gif' — what the SENDER said this artifact was made from. See the header. */
+      origin: rec.origin,
       provenance: 'peer',
       acquire: () => acquirePeer(rec),
     };
+  }
+
+  /**
+   * Which received views a VIDEO draw may choose between: the real footage if this match has any,
+   * and otherwise everything (which is then all gif-origin). NEVER EMPTY when `pool` was not —
+   * that is the "preference, not filter" promise in the header, and it is why the fallback returns
+   * `pool` rather than the empty `real`. The image lane passes straight through untouched.
+   */
+  function footageFirst(pool, kind) {
+    if (kind !== 'video' || pool.length < 2) return pool;
+    const real = pool.filter((v) => v.origin !== 'gif');
+    return real.length ? real : pool;
   }
 
   /** The deck draw, hoisted so `drawFor` can reach it without a `this` binding. */
@@ -304,7 +327,7 @@ export function createGoonMediaPool() {
     /**
      * Register one artifact a duel partner sent (or one this machine already had,
      * primed from the manifest frame). Touches a Map, NEVER the deck.
-     * @param {{sha:string, kind:string, mime?:string, url:string, bytes?:number,
+     * @param {{sha:string, kind:string, mime?:string, url:string, bytes?:number, origin?:string,
      *          acquire?:() => ({url:string, release?:() => void}|null)}} a
      */
     addReceived(a) {
@@ -320,6 +343,11 @@ export function createGoonMediaPool() {
         mime: String(o.mime || ''),
         url: String(o.url || ''),
         bytes: Math.max(0, Number(o.bytes) || 0),
+        /* 'gif' or ''. ABSENT READS AS NOT-A-GIF, deliberately: a peer too old to send the field,
+         * a row primed from a previous session's inbox and every existing caller all land here,
+         * and treating an unknown origin as footage keeps them exactly as eligible as they are
+         * today. The preference only ever DEMOTES something we positively know is a loop. */
+        origin: o.origin === 'gif' ? 'gif' : '',
         acquire: typeof o.acquire === 'function' ? o.acquire : null,
       });
       return true;
@@ -378,12 +406,14 @@ export function createGoonMediaPool() {
     drawReceived(kind) {
       const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
       if (!want) return null;
-      const pool = [];
+      const all = [];
       for (const sha of received.keys()) {
         const v = viewReceived(sha, want);
-        if (v) pool.push(v);
+        if (v) all.push(v);
       }
-      if (!pool.length) return null;
+      if (!all.length) return null;
+      // Real footage if they have sent any this match; their gif loops if that is all there is.
+      const pool = footageFirst(all, want);
       let at = (Math.random() * pool.length) | 0;
       if (pool.length > 1 && pool[at].sha === lastPeerPick[want]) at = (at + 1) % pool.length;
       lastPeerPick[want] = pool[at].sha;
@@ -399,12 +429,16 @@ export function createGoonMediaPool() {
     peekReceived(kind) {
       const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
       if (!want) return null;
-      const pool = [];
+      const all = [];
       for (const sha of received.keys()) {
         const v = viewReceived(sha, want);
-        if (v) pool.push(v);
+        if (v) all.push(v);
       }
-      return pool.length ? pool[(Math.random() * pool.length) | 0] : null;
+      if (!all.length) return null;
+      // The SAME candidate set drawReceived would choose from, or the preview would advertise a
+      // gif loop the render then refuses to play.
+      const pool = footageFirst(all, want);
+      return pool[(Math.random() * pool.length) | 0];
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
@@ -209,11 +209,15 @@ export function createReceivedStore({
 
   /* ------------------------------------------------------------------ the jobs */
 
-  function newJob(sha, mime, bytes) {
+  function newJob(sha, mime, bytes, origin) {
     return {
       id: 'r' + (++seq) + '-' + sha.slice(0, 8),
       sha, mime, declared: bytes,
       kind: kindForMime(mime),
+      /* 'gif' or ''. ADVISORY, and it never touches a filename, a size or a hash — it is only
+       * ever read back by exec/media.js to keep a converted gif loop out of the VIDEO lane while
+       * real footage is available. An old peer sends none and the row reads as footage. */
+      origin: origin === 'gif' ? 'gif' : '',
       written: 0,            // bytes handed to us by the protocol (the resume offset)
       seq: 0,                // next chunk sequence number the host expects
       buf: [],               // Uint8Array pieces not yet flushed
@@ -330,8 +334,12 @@ export function createReceivedStore({
     return job ? job.written : 0;
   }
 
-  /** Open — or REOPEN, for a resume — the partial for `sha`. Idempotent by contract. */
-  function begin(sha, mime, bytes) {
+  /**
+   * Open — or REOPEN, for a resume — the partial for `sha`. Idempotent by contract.
+   * @param {{origin?:string, codec?:string}} [meta] the offer's advisory metadata. OPTIONAL in
+   *   the ReceivedStore contract, so nothing breaks when a caller (or a test stub) omits it.
+   */
+  function begin(sha, mime, bytes, meta) {
     if (disposed) return false;
     if (typeof sha !== 'string' || !SHA_RE.test(sha)) return false;
     if (!kindForMime(mime)) return false;
@@ -350,15 +358,19 @@ export function createReceivedStore({
       return false;
     }
 
-    const job = newJob(sha, mime, bytes);
+    const job = newJob(sha, mime, bytes, meta && meta.origin);
     jobs.set(sha, job);
 
     if (isHosted) {
       // Sent optimistically: `begin` is synchronous by contract, so a host refusal
       // (cap-reached, bad-format) poisons the job and surfaces at commit as the
       // same store failure the protocol would have reported here.
+      // `origin` rides along so the host can persist it: without that, a gif-origin clip
+      // received today comes back from recv_index.json tomorrow looking like footage.
       after(job, async () => {
-        const r = await ask({ type: 'goon-recv-begin', id: job.id, sha256: sha, mime, bytes });
+        const r = await ask({
+          type: 'goon-recv-begin', id: job.id, sha256: sha, mime, bytes, origin: job.origin,
+        });
         job.begun = r.ok;
         if (!r.ok) {
           job.error = r.error || 'io-failed';
@@ -422,7 +434,7 @@ export function createReceivedStore({
     // a blob: URL carries nothing, so the memory backend falls back to the mime.
     const ext = isHosted ? (extFromUrl(result.url) || extFromMime(job.mime)) : extFromMime(job.mime);
     index.set(sha, {
-      sha, ext, mime: job.mime, kind: job.kind,
+      sha, ext, mime: job.mime, kind: job.kind, origin: job.origin,
       bytes: result.bytes || job.declared,
       url: result.url || '',
     });
@@ -466,7 +478,7 @@ export function createReceivedStore({
     abort,
 
     /**
-     * Prime the index from the manifest frame's `received:[{sha,ext,mime,bytes}]`.
+     * Prime the index from the manifest frame's `received:[{sha,ext,mime,bytes,origin?}]`.
      * boot.js owns the 'manifest' handler and passes the array in — this module
      * registers no manifest listener of its own (one handler per type, always).
      * @returns {string[]} the shas now known, for the blocklist prefetch.
@@ -483,6 +495,9 @@ export function createReceivedStore({
         if (!kind) continue;
         index.set(sha, {
           sha, ext, mime, kind,
+          // Absent on rows written before the host persisted it — and absent reads as footage,
+          // which is exactly how those rows behaved before the preference existed.
+          origin: e.origin === 'gif' ? 'gif' : '',
           bytes: Math.max(0, Number(e.bytes) || 0),
           url: 'https://ccp.cache/recv/' + sha + '.' + ext,
         });
@@ -492,17 +507,17 @@ export function createReceivedStore({
       return out;
     },
 
-    /** Everything committed, as exec/media.js wants it. */
+    /** Everything committed, as exec/media.js wants it (`origin` included — addReceived reads it). */
     list() {
       return Array.from(index.values()).map((e) => ({
-        sha: e.sha, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url,
+        sha: e.sha, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url, origin: e.origin || '',
       }));
     },
 
     /** Only what landed during THIS page's life — the recap report card's shortlist. */
     thisMatch() {
       return Array.from(thisSession).map((sha) => index.get(sha)).filter(Boolean).map((e) => ({
-        sha: e.sha, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url,
+        sha: e.sha, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url, origin: e.origin || '',
       }));
     },
 

--- a/ConditioningControlPanel/Resources/web/goon/net/codecs.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/codecs.js
@@ -1,0 +1,202 @@
+// net/codecs.js — WHAT CAN THE OTHER SIDE ACTUALLY DECODE?
+//
+// THE BUG THIS EXISTS FOR, written down because the shape of it is not obvious. Until now the only
+// decode question anybody asked was asked LOCALLY: ui/assetsStore.js probeVideoDecodable loads a
+// picked clip into an off-DOM <video> and believes the answer. That answer is about THIS device.
+// Safari decodes its own HEVC happily, adopts the clip, offers it, and the transfer succeeds
+// perfectly — and the Windows peer, whose WebView2 has no HEVC decoder, mounts a <video> that
+// fires no error worth the name and paints a silent black rectangle for the whole slot. Every
+// layer reports success; the player sees nothing. That is why probeVideoDecodable's own comment
+// says "KNOWN GAP, on purpose … a peer-capability handshake is the real fix", and this is it.
+//
+// THE CONTRACT IS FAIL-OPEN, IN BOTH DIRECTIONS, AND THAT IS THE WHOLE SAFETY STORY:
+//   - a peer that sends no codec list (an old build, a build with no probe surface) is treated as
+//     "accepts everything" — byte-identical to the behaviour before this file existed;
+//   - an artifact whose codec we do not KNOW is offered, always. The compression cache knows
+//     ("avc1" — it produced the file), an exempt original does not ("orig"), and a guess would
+//     refuse good clips to prevent a black rectangle, which is the worse trade.
+// Only a KNOWN codec against a KNOWN-negative peer list is ever blocked.
+//
+// NODE-IMPORT-SAFE, same rule as net/mediaChannel.js which imports it: every runtime lookup is
+// guarded and nothing touches `document`, `window` or `MediaSource` at module scope. Under node
+// the probe answers `null` ("cannot tell"), which the fail-open rule reads as "advertise nothing",
+// which makes every peer accept everything from us. The selftests depend on that.
+
+/** The families we speak about. Anything else normalizes to '' (= unknown, fail open). */
+export const CodecFamily = Object.freeze({
+  Avc: 'avc1',    // H.264, every profile — the universal one
+  Hevc: 'hvc1',   // H.265, incl. the `hev1` box name. THE problem child (iPhone)
+  Vp9: 'vp9',
+  Av1: 'av01',
+});
+
+/**
+ * THE PROBE LIST, deliberately four entries long.
+ *
+ * Each family is asked with ONE representative type string, because the question here is "is there
+ * a decoder for this family at all", not "can you take this exact profile/level". A device with an
+ * H.264 decoder that refuses one level still shows the clip; a device with no HEVC decoder shows
+ * nothing, and that is the difference this list is drawn around.
+ *
+ *  - avc1.42E01E  Baseline 3.0. If a runtime says no to this it has no H.264 at all, which in
+ *                 practice does not happen — but it is asked rather than assumed.
+ *  - avc1.640028  High 4.0: what a phone camera and most real mp4s actually carry. A runtime that
+ *                 takes Baseline but not High is a real (embedded) thing, and either answer maps
+ *                 to the same family — we take the OR, because refusing H.264 outright would kill
+ *                 the lane for everybody.
+ *  - hvc1.1.6.L93.B0  Main L3.1. Asked in mp4, the only container HEVC arrives in here.
+ *  - vp09.00.10.08    Profile 0, 8-bit. Asked in webm AND mp4 (Safari only knows it in one).
+ *  - av01.0.04M.08    Main profile, level 3.0, 8-bit.
+ */
+export const DECODE_PROBES = Object.freeze([
+  Object.freeze({ family: CodecFamily.Avc, types: Object.freeze([
+    'video/mp4; codecs="avc1.42E01E"', 'video/mp4; codecs="avc1.640028"']) }),
+  Object.freeze({ family: CodecFamily.Hevc, types: Object.freeze([
+    'video/mp4; codecs="hvc1.1.6.L93.B0"', 'video/mp4; codecs="hev1.1.6.L93.B0"']) }),
+  Object.freeze({ family: CodecFamily.Vp9, types: Object.freeze([
+    'video/webm; codecs="vp09.00.10.08"', 'video/mp4; codecs="vp09.00.10.08"']) }),
+  Object.freeze({ family: CodecFamily.Av1, types: Object.freeze([
+    'video/mp4; codecs="av01.0.04M.08"']) }),
+]);
+
+/**
+ * One codec string (a wire token, a `codecs=` parameter value, a C# cache label) reduced to its
+ * FAMILY, or '' when we do not recognise it.
+ *
+ * Tolerant on purpose: the four things that produce these strings — the C# cache ("avc1"), the
+ * page encoder ("avc1.42E01E"), an mp4 box name ("hev1") and a mime parameter ("vp09.00.10.08") —
+ * all spell the same four families differently, and an unrecognised spelling must degrade to
+ * "unknown" (offer it) rather than to a wrong family (maybe refuse it).
+ */
+export function normalizeCodec(codec) {
+  const s = String(codec || '').trim().toLowerCase();
+  if (!s) return '';
+  if (s.startsWith('avc1') || s.startsWith('avc3') || s === 'h264' || s === 'h.264') return CodecFamily.Avc;
+  if (s.startsWith('hvc1') || s.startsWith('hev1') || s === 'h265' || s === 'h.265' || s === 'hevc') return CodecFamily.Hevc;
+  if (s.startsWith('vp09') || s === 'vp9') return CodecFamily.Vp9;
+  if (s.startsWith('av01') || s === 'av1') return CodecFamily.Av1;
+  return '';                                   // 'orig', 'webp', 'jpeg', 'vp8', anything new
+}
+
+/**
+ * The codec family named by a mime's `codecs=` parameter, or ''. This is the OTHER cheap source
+ * the design allows: a plain `video/mp4` says nothing, but `video/mp4;codecs="hvc1.1.6.L93.B0"`
+ * says everything, and it costs a string split to read.
+ */
+export function codecFromMime(mime) {
+  const m = /codecs\s*=\s*"?([^";,]+)/i.exec(String(mime || ''));
+  return m ? normalizeCodec(m[1]) : '';
+}
+
+/** The mime with any parameters stripped — `video/mp4;codecs="…"` -> `video/mp4`. */
+export function baseMime(mime) {
+  return String(mime || '').split(';')[0].trim().toLowerCase();
+}
+
+/** Cached, because the probe is asked once per hello and the answer cannot change mid-session. */
+let probed = null;
+
+/**
+ * WHAT THIS RUNTIME CAN DECODE, as a list of families — or `null` when it cannot be asked.
+ *
+ * `MediaSource.isTypeSupported` first (it is the strict one: it answers about a real decoder),
+ * `<video>.canPlayType` second (it answers "maybe"/"probably", and "maybe" is deliberately taken
+ * as YES — a hedged yes from the element is still a decoder, and the cost of a false yes is one
+ * black slot while the cost of a false no is a refused good clip).
+ *
+ * `null` vs `[]` MATTERS. `null` = "no way to ask" (node, an exotic embedder): we advertise
+ * nothing and every peer keeps offering us everything, which is today's behaviour. `[]` would be
+ * a claim that we can decode NOTHING, and a peer honouring it would stop sending video entirely.
+ * Nothing in this file ever returns `[]`: a runtime that answers "no" to every probe still gets
+ * `null`, because a runtime with no H.264 at all is far likelier to be a broken probe than a real
+ * device.
+ *
+ * @param {boolean} [force] re-probe instead of answering from the cache (tests only)
+ * @returns {string[]|null}
+ */
+export function probeDecodeCodecs(force) {
+  if (probed !== null && !force) return probed.length ? probed.slice() : null;
+
+  const out = [];
+  let asked = false;
+
+  let MS = null;
+  try {
+    const g = globalThis;
+    MS = (g && g.MediaSource && typeof g.MediaSource.isTypeSupported === 'function') ? g.MediaSource : null;
+  } catch (_e) { MS = null; }
+
+  let el = null;
+  try {
+    const d = typeof document !== 'undefined' ? document : null;
+    el = (d && typeof d.createElement === 'function') ? d.createElement('video') : null;
+    if (el && typeof el.canPlayType !== 'function') el = null;
+  } catch (_e) { el = null; }
+
+  if (MS || el) {
+    for (const probe of DECODE_PROBES) {
+      let yes = false;
+      for (const type of probe.types) {
+        try {
+          if (MS && MS.isTypeSupported(type) === true) { asked = true; yes = true; break; }
+        } catch (_e) { /* one type refusing to be asked is not an answer */ }
+        try {
+          // '' is a NO; 'maybe' and 'probably' are both a YES — see the header.
+          if (el && String(el.canPlayType(type) || '') !== '') { asked = true; yes = true; break; }
+        } catch (_e) { /* ditto */ }
+      }
+      if (yes) out.push(probe.family);
+    }
+  }
+
+  // Nothing answered yes anywhere -> we could not really ask. Say "unknown", never "none".
+  probed = asked && out.length ? out : [];
+  return probed.length ? probed.slice() : null;
+}
+
+/** Test affordance: forget the cached probe so the next call re-asks this runtime. */
+export function resetDecodeProbe() { probed = null; }
+
+/**
+ * Would a peer advertising `accepts` be able to decode an artifact encoded with `codec`?
+ *
+ * THE ONLY `false` THIS FUNCTION EVER RETURNS is "the peer sent a real list, the codec is one we
+ * recognise, and it is not on their list". Every other combination — no list, empty list, unknown
+ * codec, junk input — is `true`. Read the four early returns as the fail-open contract itself.
+ *
+ * @param {string[]|null|undefined} accepts the peer's advertised families (their hello)
+ * @param {string} codec our artifact's codec, in any spelling normalizeCodec understands
+ */
+export function peerCanDecode(accepts, codec) {
+  if (!Array.isArray(accepts) || accepts.length === 0) return true;   // old peer / no probe
+  const want = normalizeCodec(codec);
+  if (!want) return true;                                             // we do not know: offer it
+  for (const a of accepts) if (normalizeCodec(a) === want) return true;
+  return false;
+}
+
+/**
+ * Every codec family named by one hello frame, read TOLERANTLY from both places a peer may have
+ * put them, or `null` when it named none.
+ *
+ *   accepts_codecs: ['avc1','vp9']                     the field this build writes
+ *   accepts: ['video/mp4;codecs="avc1.42E01E"', …]     a peer that parameterised its mime list
+ *
+ * The second form is read because `accepts` is the OLDER field and is documented as a mime
+ * allowlist: a build that decides to carry codecs there instead is not wrong, and one regex is
+ * cheaper than an interop bug. Plain mimes in `accepts` contribute nothing and are skipped, which
+ * is exactly what an old peer sends.
+ */
+export function acceptedCodecsFromHello(hello) {
+  const h = hello || {};
+  const out = [];
+  const push = (fam) => { if (fam && out.indexOf(fam) < 0) out.push(fam); };
+  if (Array.isArray(h.accepts_codecs)) for (const c of h.accepts_codecs) push(normalizeCodec(c));
+  if (Array.isArray(h.accepts)) for (const m of h.accepts) push(codecFromMime(m));
+  return out.length ? out : null;
+}
+
+export default {
+  CodecFamily, DECODE_PROBES, normalizeCodec, codecFromMime, baseMime,
+  probeDecodeCodecs, resetDecodeProbe, peerCanDecode, acceptedCodecsFromHello,
+};

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaChannel.js
@@ -29,6 +29,18 @@
 //
 // ORDERED + RELIABLE is assumed (the channel is created that way). Ordering is what guarantees
 // `xfer_end` can never overtake the last chunk, and it deletes a whole race class for free.
+//
+// TWO OPTIONAL FIELDS RIDE THE OFFER, AND BOTH ARE TOLERANT BY CONSTRUCTION (2026-08-05):
+//   `origin`  'gif' when the artifact is a converted animated image rather than real footage.
+//             Pure downstream taste — net/mediaQueue.js and exec/media.js use it to prefer real
+//             clips in the VIDEO lane — and NOTHING here gates on it.
+//   `codec`   the artifact's codec family, when the producing side knows it ('avc1', 'hvc1', …).
+//             Checked against the peer's advertised `accepts_codecs` BY THE QUEUE before it
+//             offers; see net/codecs.js for the fail-open contract.
+// A peer that sends neither is a peer from before this change, and reads exactly as it did then:
+// absent origin = "not a gif", absent codec = "unknown, offer it".
+
+import { acceptedCodecsFromHello, normalizeCodec, peerCanDecode } from './codecs.js';
 
 /** Protocol version carried on every control frame. */
 export const XFER_PROTO = 1;
@@ -142,10 +154,13 @@ export const XferCancel = Object.freeze({
  * @property {(sha:string) => number} partialLength
  *   Bytes already durably written for an INCOMPLETE artifact, 0 when there is no partial. This is
  *   the resume offset, and it is the receiver's promise: everything below it is on disk.
- * @property {(sha:string, mime:string, bytes:number) => boolean} begin
+ * @property {(sha:string, mime:string, bytes:number, meta?:{origin?:string, codec?:string}) => boolean} begin
  *   Open — or REOPEN, for a resume — the partial for `sha`. Returns false when the store refuses
  *   (full, io, quota); the caller answers `xfer_fail:'store_full'`. Must be idempotent: a resumed
  *   transfer calls it again with the same arguments and must keep the existing partial.
+ *   `meta` is ADVISORY and OPTIONAL — the offer's `origin`/`codec`, passed so a store that
+ *   persists rows (exec/receivedStore.js) can remember them. A store that ignores the fourth
+ *   argument (every store written before 2026-08-05, and every test stub) is fully correct.
  * @property {(sha:string, offset:number, bytes:ArrayBuffer) => boolean} write
  *   Append at exactly `offset` (never a seek past the end). False means the write failed and the
  *   caller answers `xfer_fail:'io'`.
@@ -176,6 +191,8 @@ export const XferCancel = Object.freeze({
  * @property {number} [dur_ms]
  * @property {number} [w]
  * @property {number} [h]
+ * @property {'gif'} [origin] the artifact came from an animated image, not from footage
+ * @property {string} [codec] codec family/label when the producer knows it ('avc1', 'hvc1', …)
  */
 
 const noop = () => {};
@@ -264,6 +281,10 @@ function toArrayBuffer(v) {
  *   Consulted FRESH on every offer, so a player who withdraws the toggle mid-match stops taking
  *   bytes on the very next offer.
  * @param {boolean} [o.isHost] mints ODD tids when true, EVEN when false — see `_nextTid`
+ * @param {string[]|null} [o.acceptsCodecs] what THIS runtime can decode (net/codecs.js
+ *   probeDecodeCodecs). Advertised on the hello as `accepts_codecs` so the PEER can skip artifacts
+ *   we would only ever render as a black rectangle. Null/absent advertises nothing, which every
+ *   peer reads as "send me anything" — the pre-2026-08-05 behaviour, and the node default.
  * @param {string} [o.tag] log prefix
  * @param {object} [o.timeouts] TEST AFFORDANCE (the relayTransport waitMs/minGapMs precedent):
  *   {offerMs, stallMs, helloMs, maxXferMs, watchdogMs}. Production passes nothing.
@@ -279,6 +300,10 @@ export function createMediaChannel(o = {}) {
   const blocklist = o.blocklist || null;
   const acceptOffers = typeof o.acceptOffers === 'function' ? o.acceptOffers : (() => false);
   const isHost = !!o.isHost;
+  /** Normalized once: whatever boot probed, reduced to the families net/codecs.js speaks. */
+  const acceptsCodecs = Array.isArray(o.acceptsCodecs)
+    ? o.acceptsCodecs.map(normalizeCodec).filter((c, i, a) => c && a.indexOf(c) === i)
+    : null;
 
   const sendBulk = typeof o.sendBulk === 'function' ? o.sendBulk : (() => false);
   const bufferedAmount = typeof o.bulkBufferedAmount === 'function' ? o.bulkBufferedAmount : (() => 0);
@@ -328,6 +353,8 @@ export function createMediaChannel(o = {}) {
   let dormant = false;          // hello never arrived — this peer does not transfer
   let helloSeen = false;
   let peerHello = null;
+  /** The peer's decodable families, or null when they named none (= accept everything). */
+  let peerCodecs = null;
   let strays = 0;
   let strayLimitHits = 0;
   let sessionBytesIn = 0;
@@ -363,6 +390,13 @@ export function createMediaChannel(o = {}) {
     return sendBulk(json) === true;
   }
 
+  /**
+   * `accepts` stays EXACTLY what it has always been — the container allowlist — and the decode
+   * answer rides beside it in `accepts_codecs`. Overloading `accepts` with parameterised mimes
+   * would have been the smaller diff and the bigger interop risk: it is documented as a mime
+   * allowlist and a peer doing a set lookup on it would stop recognising a single entry.
+   * An OMITTED `accepts_codecs` (node, an embedder with nothing to probe) is the fail-open case.
+   */
   function sendHello() {
     sendControl({
       t: XferVerb.Hello,
@@ -372,6 +406,7 @@ export function createMediaChannel(o = {}) {
       max_session_bytes: CAP_SESSION,
       max_concurrent: CAP_IN,
       accepts: Array.from(ACCEPT_MIME),
+      accepts_codecs: acceptsCodecs && acceptsCodecs.length ? acceptsCodecs.slice() : undefined,
     });
   }
 
@@ -448,6 +483,7 @@ export function createMediaChannel(o = {}) {
 
   const emitOffered = (direction, slot) => fire(ev.offered.set, {
     direction, tid: slot.tid, sha256: slot.sha256, bytes: slot.bytes, mime: slot.mime, kind: slot.kind,
+    origin: slot.origin || '', codec: slot.codec || '',
   }, log, tag, 'offered');
 
   const emitDeclined = (direction, slot, why) => fire(ev.declined.set, {
@@ -462,8 +498,11 @@ export function createMediaChannel(o = {}) {
     direction, tid: slot.tid, sha256: slot.sha256, transferred, bytes: slot.bytes,
   }, log, tag, 'progress');
 
+  /** `origin`/`codec` ride the landing so boot can register them with exec/media.js — the
+   *  receiver's soft "prefer real footage" preference is fed from exactly here. */
   const emitLanded = (direction, slot, extra) => fire(ev.landed.set, Object.assign({
     direction, tid: slot.tid, sha256: slot.sha256, bytes: slot.bytes, kind: slot.kind, mime: slot.mime,
+    origin: slot.origin || '', codec: slot.codec || '',
     ms: Math.max(0, Date.now() - slot.startedAtMs),
   }, extra || {}), log, tag, 'landed');
 
@@ -494,10 +533,16 @@ export function createMediaChannel(o = {}) {
     const kind = source.kind === 'video' ? 'video' : 'image';
     if (familyOf(mime) !== kind) { warn(`refusing to offer ${sha.slice(0, 8)}: kind/mime disagree`); return null; }
 
+    // Taste, not a gate: 'gif' or nothing, so a peer can never be handed a free-text field to
+    // switch on. The codec is passed through as the producer spelled it — net/codecs.js is the
+    // one place that decides what a spelling means.
+    const origin = source.origin === 'gif' ? 'gif' : '';
+    const codec = String(source.codec || '');
+
     const now = Date.now();
     const slot = {
       tid: nextTid(),
-      sha256: sha, bytes, mime, kind, source,
+      sha256: sha, bytes, mime, kind, source, origin, codec,
       state: 'offered',
       offset: 0, ackedOffset: 0, endSent: false, pumping: false,
       offeredAtMs: now, startedAtMs: now, lastProgressAtMs: now,
@@ -507,6 +552,8 @@ export function createMediaChannel(o = {}) {
     sendControl({
       t: XferVerb.Offer, v: XFER_PROTO,
       tid: slot.tid, sha256: sha, bytes, mime, kind,
+      origin: origin || undefined,
+      codec: codec || undefined,
       dur_ms: Number.isFinite(source.dur_ms) ? source.dur_ms : undefined,
       w: Number.isFinite(source.w) ? source.w : undefined,
       h: Number.isFinite(source.h) ? source.h : undefined,
@@ -661,10 +708,16 @@ export function createMediaChannel(o = {}) {
     // 8. the per-match, per-direction byte budget
     if (sessionBytesIn + bytes > CAP_SESSION) { decline(tid, sha, XferDecline.Quota, msg); return; }
 
+    // The two ADVISORY fields, read the way every untrusted field here is read: `origin` is
+    // 'gif' or nothing (never the peer's free text), `codec` is a label net/codecs.js reduces to
+    // a family it recognises or to ''. Neither can refuse an offer — see the header.
+    const origin = msg.origin === 'gif' ? 'gif' : '';
+    const codec = normalizeCodec(msg.codec);
+
     // 9. accept, from whatever is already on disk
     const from = safePartialLength(sha);
     let began = false;
-    try { began = store.begin(sha, mime, bytes) !== false; } catch (e) {
+    try { began = store.begin(sha, mime, bytes, { origin, codec }) !== false; } catch (e) {
       error(`store.begin(${sha.slice(0, 8)}) threw: ${(e && e.message) || e}`);
       began = false;
     }
@@ -675,7 +728,7 @@ export function createMediaChannel(o = {}) {
 
     const now = Date.now();
     const slot = {
-      tid, sha256: sha, bytes, mime, kind,
+      tid, sha256: sha, bytes, mime, kind, origin, codec,
       received: from, ackedAt: from, paused: false,
       startedAtMs: now, lastProgressAtMs: now,
     };
@@ -821,7 +874,11 @@ export function createMediaChannel(o = {}) {
         helloSeen = true;
         dormant = false;
         clearHelloTimeout();
-        info(`peer speaks xfer proto ${msg.proto ?? msg.v}`);
+        // null = they named none, which `peerCanDecode` reads as "send me anything". Every peer
+        // built before 2026-08-05 lands here, and that is the compatibility story in one line.
+        peerCodecs = acceptedCodecsFromHello(msg);
+        info(`peer speaks xfer proto ${msg.proto ?? msg.v}`
+          + (peerCodecs ? ` and decodes ${peerCodecs.join('/')}` : ' (no decode list — assuming anything)'));
         resumePaused();
         break;
       }
@@ -945,6 +1002,10 @@ export function createMediaChannel(o = {}) {
       sendControl({
         t: XferVerb.Offer, v: XFER_PROTO,
         tid: slot.tid, sha256: slot.sha256, bytes: slot.bytes, mime: slot.mime, kind: slot.kind,
+        // Re-offered VERBATIM, metadata included: a resume that dropped `origin` would land the
+        // same artifact with a different provenance story than the first attempt would have.
+        origin: slot.origin || undefined,
+        codec: slot.codec || undefined,
       });
     }
     for (const slot of inbound.values()) {
@@ -1080,10 +1141,24 @@ export function createMediaChannel(o = {}) {
           maxSessionBytes: peerHello.max_session_bytes ?? null,
           maxConcurrent: peerHello.max_concurrent ?? null,
           accepts: Array.isArray(peerHello.accepts) ? peerHello.accepts.slice() : [],
+          /** null means "they named none" — NOT "they can decode nothing". */
+          acceptsCodecs: peerCodecs ? peerCodecs.slice() : null,
         }
         : null,
+      /** What we advertise. Null under node and anywhere the probe could not be asked. */
+      acceptsCodecs: acceptsCodecs && acceptsCodecs.length ? acceptsCodecs.slice() : null,
     };
   }
+
+  /**
+   * Could the peer decode an artifact encoded like this? Asked by net/mediaQueue.js BEFORE it
+   * offers, because a refusal is only useful while it can still stop the bytes leaving.
+   *
+   * TRUE IS THE ANSWER FOR EVERY UNCERTAINTY: no hello yet, a peer that named no codecs, a codec
+   * we do not recognise. The only false is a known codec against a peer that listed families and
+   * did not list this one — see net/codecs.js peerCanDecode.
+   */
+  function peerCanDecodeCodec(codec) { return peerCanDecode(peerCodecs, codec); }
 
   return {
     open,
@@ -1091,6 +1166,7 @@ export function createMediaChannel(o = {}) {
     send,
     cancel,
     stats,
+    peerCanDecodeCodec,
 
     /** @returns {() => void} unsubscribe. {direction,tid,sha256,bytes,mime,kind} */
     onOffered: ev.offered.on,

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
@@ -17,12 +17,28 @@
 // untagged — byte-identical to the wire before this feature existed. There is no "relay mode"
 // branch anywhere, and there must never be one.
 //
+// TWO QUALITY RULES LIVE HERE, AND NEITHER IS ALLOWED TO EMPTY THE LANE (2026-08-05):
+//
+//  1. GIF-ORIGIN CLIPS ARE A LAST RESORT IN THE VIDEO LANE, NOT AN EXCLUSION. The desktop
+//     compresses an animated gif into an mp4, so what travels is `video/mp4` — deliberately, the
+//     offer gate refuses any kind/mime disagreement — and a Video payload could therefore land a
+//     two-second loop where the owner expected footage. `tagsFor` now prefers a landed artifact
+//     whose `origin` is NOT 'gif' and falls back to one that is, because a gif of THEIRS still
+//     beats a clip of the receiver's own, which is the whole point of the lane.
+//
+//  2. AN ARTIFACT THE PEER CANNOT DECODE IS NEVER OFFERED. `eligible()` drops it with a
+//     once-per-reason warn, on exactly the saidWhy pattern below: a silent skip here would look
+//     identical to "the transfer doesn't work", which is the failure mode this file has already
+//     been debugged for three times. Fail-open throughout — unknown codec or a peer that named
+//     none means OFFER IT (net/codecs.js owns that contract).
+//
 // TWO tryFirePayload INSTANCE WRAPPERS NOW EXIST. boot.js applies the matchLog wrapper first
 // (attachMatch -> matchLog.attach), then this one, so the queue's wrapper is the OUTERMOST: a
 // payload gets its tags BEFORE the log sees it, and the log records exactly what went out. Order
 // matters for readability, not correctness — both are instance patches that die with the match.
 
 import { GoonMatchPhase, GoonPayloadKind } from '../core/contracts.js';
+import { codecFromMime, normalizeCodec } from './codecs.js';
 import {
   createMediaChannel,
   ACCEPT_MIME,
@@ -75,12 +91,15 @@ const noop = () => {};
  * @param {object} [o.blocklist] net/blocklist.js
  * @param {object} [o.logger]
  * @param {() => boolean} [o.canSend] the PREMIUM gate: session.caps.mediaTransfer === true
+ * @param {string[]|null} [o.acceptsCodecs] what THIS runtime can decode (net/codecs.js
+ *   probeDecodeCodecs, probed once by boot). Handed to the channel, which advertises it on the
+ *   hello; null advertises nothing and every peer keeps offering us everything.
  * @param {number} [o.idlePollMs] TEST AFFORDANCE
  * @param {object} [o.channelOptions] TEST AFFORDANCE — {timeouts, limits} for the channel
  */
 export function createMediaQueue({
   artifacts = null, store = null, blocklist = null, logger = null,
-  canSend = null, idlePollMs, channelOptions = null,
+  canSend = null, acceptsCodecs = null, idlePollMs, channelOptions = null,
 } = {}) {
   const info = (m) => { try { logger?.info?.('[GG queue] ' + m); } catch (_e) { /* ignore */ } };
   const warn = (m) => { try { logger?.warn?.('[GG queue] ' + m); } catch (_e) { /* ignore */ } };
@@ -151,6 +170,13 @@ export function createMediaQueue({
     return rate > 0 ? rate : EST_THROUGHPUT_BPS;
   }
 
+  /**
+   * Reasons an artifact was skipped for a codec the peer cannot decode — said ONCE per codec per
+   * match, exactly like `saidWhy` below and for the same reason: the alternative is a lane that
+   * quietly does nothing and a play-test that can only guess why.
+   */
+  const saidSkip = new Set();
+
   /** Everything from the local source we would be willing to offer RIGHT NOW. */
   function eligible() {
     let all = [];
@@ -175,7 +201,31 @@ export function createMediaQueue({
       if (bytes > (a.exempt ? MAX_EXEMPT_BYTES : MAX_ARTIFACT_BYTES)) continue;
       // …and nothing is offered that cannot plausibly land inside the match's patience.
       if ((bytes / budget) * 1000 > MAX_XFER_MS) continue;
-      out.push({ sha, bytes, mime, kind, exempt: !!a.exempt });
+
+      /* THE CODEC GATE. The artifact's codec comes off the producer (the C# cache knows it made
+       * an "avc1" mp4; the page encoder knows the same; an exempt ORIGINAL knows nothing and is
+       * the fail-open case the design accepts) or, failing that, off the mime's `codecs=`
+       * parameter. `peerCanDecodeCodec` answers true for every uncertainty, so the only thing
+       * that ever drops out here is a KNOWN codec against a peer that KNOWN-ly lacks it. */
+      const codec = String(a.codec || '') || codecFromMime(mime);
+      if (kind === 'video' && channel && typeof channel.peerCanDecodeCodec === 'function'
+        && !channel.peerCanDecodeCodec(codec)) {
+        const fam = normalizeCodec(codec);
+        if (!saidSkip.has(fam)) {
+          saidSkip.add(fam);
+          warn('skipping ' + fam + ' video artifacts — the peer\'s build does not advertise a '
+            + fam + ' decoder, and sending one would land a silent black window '
+            + '(said once per codec)');
+        }
+        continue;
+      }
+
+      out.push({
+        sha, bytes, mime, kind, exempt: !!a.exempt,
+        // 'gif' or nothing. Taste that travels: see rule 1 in the header.
+        origin: a.origin === 'gif' ? 'gif' : '',
+        codec,
+      });
     }
     return out;
   }
@@ -235,7 +285,12 @@ export function createMediaQueue({
     if (!pick) return false;
 
     seen.add(pick.sha);
-    pickInfo.set(pick.sha, { kind: pick.kind, mime: pick.mime, bytes: pick.bytes });
+    // `origin` is kept here too, because the `decline:'have'` landing (cross-session reuse) never
+    // sees the artifact again and would otherwise land it as un-flagged footage.
+    pickInfo.set(pick.sha, {
+      kind: pick.kind, mime: pick.mime, bytes: pick.bytes,
+      origin: pick.origin || '', codec: pick.codec || '',
+    });
     inFlight.set(pick.sha, { state: 'offered', attempts: attempts.get(pick.sha) || 0 });
     picks++;
 
@@ -257,6 +312,8 @@ export function createMediaQueue({
         bytes: Number(src.bytes) || pick.bytes,
         mime: src.mime || pick.mime,
         kind: pick.kind,
+        origin: pick.origin || undefined,
+        codec: pick.codec || undefined,
         read: (offset, len) => src.read(offset, len),
       });
       if (tid == null) {
@@ -328,8 +385,19 @@ export function createMediaQueue({
     if (enabled()) {
       const want = KIND_TAGS[kind] || 1;
       const mediaKind = KIND_MEDIA[kind];
-      for (const a of landed) {
-        if (a.kind !== mediaKind) continue;
+      const pool = landed.filter((a) => a.kind === mediaKind);
+
+      /* THE SOFT PREFERENCE (rule 1 in the header), and every word of "soft" is load-bearing.
+       * A Video payload takes real footage first and a converted gif loop only when footage is
+       * all that is missing — TWO PASSES over the same list, never a filter, because a filter
+       * would turn "the owner does not like gif videos" into "a gif-only library sends nothing"
+       * and hand the receiver back its own pool. The FlashBurst/image lane never asks: a gif
+       * there is exactly what a gif is supposed to be. */
+      const gifLast = mediaKind === 'video'
+        ? pool.filter((a) => a.origin !== 'gif').concat(pool.filter((a) => a.origin === 'gif'))
+        : pool;
+
+      for (const a of gifLast) {
         out.push('xfer:' + a.sha);
         if (out.length >= want) break;
       }
@@ -371,6 +439,7 @@ export function createMediaQueue({
       blocklist,
       logger,
       acceptOffers,
+      acceptsCodecs,
       isHost: !!(match && match.isHost),
       tag: (match && match.isHost) ? 'GG:xfer:host' : 'GG:xfer:guest',
     }, channelOptions || {}));
@@ -378,7 +447,10 @@ export function createMediaQueue({
     unsubs.push(channel.onLanded((e) => {
       if (e.direction === 'out') {
         inFlight.delete(e.sha256);
-        pushLanded({ sha: e.sha256, kind: e.kind, mime: e.mime, bytes: e.bytes });
+        pushLanded({
+          sha: e.sha256, kind: e.kind, mime: e.mime, bytes: e.bytes,
+          origin: e.origin || deckKindFor(e.sha256).origin || '',
+        });
         info(`sent ${e.sha256.slice(0, 8)} (${Math.round(e.bytes / 1024)} KB in ${e.ms}ms)`);
         pump();
         return;
@@ -386,7 +458,14 @@ export function createMediaQueue({
       // INBOUND: the store already committed it. Announce it so boot can register it
       // with exec/media.js — this module never imports exec/.
       for (const fn of Array.from(receivedSubs)) {
-        try { fn({ sha: e.sha256, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url || '' }); }
+        try {
+          fn({
+            sha: e.sha256, kind: e.kind, mime: e.mime, bytes: e.bytes, url: e.url || '',
+            // Straight through to exec/media.js addReceived — the receiver's own
+            // "prefer real footage" preference is fed from this field and nothing else.
+            origin: e.origin || '',
+          });
+        }
         catch (err) { warn('onReceived handler threw: ' + ((err && err.message) || err)); }
       }
     }));
@@ -398,7 +477,10 @@ export function createMediaQueue({
         // read as a failure anywhere, in the code or the logs.
         inFlight.delete(e.sha256);
         const kindOf = deckKindFor(e.sha256);
-        pushLanded({ sha: e.sha256, kind: kindOf.kind, mime: kindOf.mime, bytes: kindOf.bytes });
+        pushLanded({
+          sha: e.sha256, kind: kindOf.kind, mime: kindOf.mime, bytes: kindOf.bytes,
+          origin: kindOf.origin || '',
+        });
         info(`they already had ${e.sha256.slice(0, 8)} — reusing it`);
         pump();
         return;
@@ -421,7 +503,7 @@ export function createMediaQueue({
   }
 
   function deckKindFor(sha) {
-    return pickInfo.get(sha) || { kind: 'image', mime: '', bytes: 0 };
+    return pickInfo.get(sha) || { kind: 'image', mime: '', bytes: 0, origin: '', codec: '' };
   }
 
   function onPhase(phase) {
@@ -472,6 +554,7 @@ export function createMediaQueue({
   function detach() {
     attached = false;
     saidWhy.clear();                 // a new match earns fresh diagnostics
+    saidSkip.clear();                // …and so does the codec-skip warn (a new peer, a new answer)
     stopPoll();
     for (const off of unsubs) { try { off(); } catch (_e) { /* ignore */ } }
     unsubs = [];

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -4045,6 +4045,83 @@ async function main() {
     ok(leaked === 0, 'peekKind can never surface a received artifact', String(leaked));
   }
 
+  /* ----------------------- GIF-ORIGIN CLIPS COME LAST IN THE VIDEO LANE
+   *
+   * A desktop gif is compressed into an mp4 to travel (the wire refuses a
+   * kind/mime disagreement), so a Video payload could land a two-second loop
+   * while real footage sat in the same received map — every layer working, and
+   * the owner watching a gif. `drawReceived`/`peekReceived` prefer footage.
+   *
+   * IT IS A PREFERENCE, NOT A FILTER, and both halves are pinned below: with
+   * footage present a gif is never drawn, and with ONLY gifs the lane still
+   * draws one — because their gif still beats the receiver's own library, which
+   * is the entire reason the transfer lane exists.
+   */
+  {
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const REAL_A = SHA('7');
+    const REAL_B = SHA('8');
+    const LOOP_A = SHA('9');
+    const LOOP_B = SHA('0');
+
+    const pool = createGoonMediaPool();
+    pool.setManifest(ownManifest());
+    pool.addReceived({ sha: LOOP_A, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/loopA.mp4' });
+    pool.addReceived({ sha: LOOP_B, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/loopB.mp4' });
+    pool.addReceived({ sha: REAL_A, kind: 'video', mime: 'video/mp4', url: 'r/realA.mp4' });
+    pool.addReceived({ sha: REAL_B, kind: 'video', mime: 'video/mp4', origin: '', url: 'r/realB.mp4' });
+
+    let loops = 0;
+    for (let i = 0; i < 80; i++) {
+      const v = pool.drawReceived('video');
+      if (v && (v.sha === LOOP_A || v.sha === LOOP_B)) loops++;
+    }
+    ok(loops === 0, 'eighty video draws never hand back a gif-origin clip while real footage has landed',
+      String(loops));
+
+    let peeked = 0;
+    for (let i = 0; i < 40; i++) {
+      const v = pool.peekReceived('video');
+      if (v && (v.sha === LOOP_A || v.sha === LOOP_B)) peeked++;
+    }
+    ok(peeked === 0,
+      'and the throw PREVIEW draws from the same candidate set — or it would advertise a clip the '
+      + 'render then refuses to play', String(peeked));
+
+    // …and the demotion is only ever a demotion.
+    const gifOnly = createGoonMediaPool();
+    gifOnly.addReceived({ sha: LOOP_A, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/loopA.mp4' });
+    gifOnly.addReceived({ sha: LOOP_B, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/loopB.mp4' });
+    const fallback = gifOnly.drawReceived('video');
+    ok(!!fallback && (fallback.sha === LOOP_A || fallback.sha === LOOP_B),
+      'with ONLY gif-origin clips landed the lane still draws one — their gif beats our own library');
+    ok(!!gifOnly.peekReceived('video'), 'the preview says the same thing');
+
+    // An UNKNOWN origin (an old peer, a row primed from a previous session) is
+    // footage: absence must never demote anything.
+    const unknown = createGoonMediaPool();
+    unknown.addReceived({ sha: REAL_A, kind: 'video', mime: 'video/mp4', url: 'r/realA.mp4' });
+    unknown.addReceived({ sha: LOOP_A, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/loopA.mp4' });
+    let unknownLoops = 0;
+    for (let i = 0; i < 40; i++) if (unknown.drawReceived('video').sha === LOOP_A) unknownLoops++;
+    ok(unknownLoops === 0, 'a row with NO origin field outranks a known gif — absent reads as footage',
+      String(unknownLoops));
+
+    // The IMAGE lane has no opinion: a gif is exactly what a gif should be there.
+    const flashes = createGoonMediaPool();
+    flashes.addReceived({ sha: SHA('a'), kind: 'image', mime: 'image/gif', origin: 'gif', url: 'r/a.gif' });
+    flashes.addReceived({ sha: SHA('b'), kind: 'image', mime: 'image/png', url: 'r/b.png' });
+    const seenImg = new Set();
+    for (let i = 0; i < 60; i++) seenImg.add(flashes.drawReceived('image').sha);
+    ok(seenImg.size === 2, 'the FlashBurst lane keeps drawing both — the preference is video-only',
+      String(seenImg.size));
+
+    // A tag is an EXACT instruction and outranks taste: the sender already
+    // applied the same preference when it chose which tag to send.
+    ok(pool.drawFor('video', { tags: ['xfer:' + LOOP_A] }).sha === LOOP_A,
+      'an explicit xfer tag for a gif-origin clip still resolves to exactly that clip');
+  }
+
   // -------------------------------- addReceived does not disturb the deck
   {
     const { createGoonMediaPool } = await import('../exec/media.js');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -802,6 +802,179 @@ function mountRecap(result) {
 
     a.dispose(); b.dispose(); pair.dispose();
   }
+
+  /* ---------- 6e. THE VIDEO LANE PREFERS FOOTAGE OVER CONVERTED GIF LOOPS
+   *
+   * The desktop compresses an animated gif into an mp4 so it can travel (the
+   * offer gate refuses any kind/mime disagreement), which makes it a perfectly
+   * valid VIDEO artifact — and a video attack that plays a two-second loop
+   * while a real clip sat in the same larder reads as a bug even though every
+   * layer worked. `tagsFor` spends the footage first. It is a PREFERENCE: when
+   * the loop is all that has landed it is still sent, because their gif beats
+   * the receiver's own library.
+   */
+  {
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+
+    const GIF_VID = SHA('c');
+    const REAL_VID = SHA('d');
+    const artifacts = fakeArtifacts([
+      // The gif is offered FIRST by construction (it is first in the list and
+      // smaller), so a queue that just took `landed[0]` would send the loop.
+      { sha: GIF_VID, bytes: 8000, mime: 'video/mp4', kind: 'video', exempt: false, origin: 'gif', codec: 'avc1' },
+      { sha: REAL_VID, bytes: 40000, mime: 'video/mp4', kind: 'video', exempt: false, codec: 'avc1' },
+    ]);
+    const storeB = fakeStore();
+    const landedOrder = [];
+    const qA = createMediaQueue({
+      artifacts, store: fakeStore(), logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    const qB = createMediaQueue({
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
+    });
+    qB.onReceived((e) => landedOrder.push(e.sha));
+
+    /* THE DECK IS SHUFFLED WITH Math.random (deliberately — see the header of
+     * net/mediaQueue.js), so without pinning it this test would only catch a
+     * regression half the time. `() => 0` makes the Fisher-Yates deterministic
+     * and lands the GIF FIRST, which is precisely the arrangement a queue that
+     * just took `landed[0]` would get wrong. */
+    const realRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      qA.attach(a, pair.host);
+      qB.attach(b, pair.guest);
+      for (let i = 0; i < 120 && storeB.held.size < 2; i++) await tick(25);
+    } finally {
+      Math.random = realRandom;
+    }
+    ok(storeB.held.size === 2, '6e: both clips landed — one gif-origin, one real', String(storeB.held.size));
+    ok(landedOrder[0] === GIF_VID,
+      '6e: and the GIF landed first, so `landed[0]` is the wrong answer and the test can see it',
+      landedOrder.join(','));
+
+    const first = qA.tagsFor(GoonPayloadKind.Video);
+    ok(first.length === 1 && first[0] === 'xfer:' + REAL_VID,
+      '6e: the FIRST video tag is the real clip, even though the gif landed first', first.join(','));
+
+    // Spend it, and the loop is what is left — the fallback, not an exclusion.
+    qA.markConsumed(first);
+    const second = qA.tagsFor(GoonPayloadKind.Video);
+    ok(second.length === 1 && second[0] === 'xfer:' + GIF_VID,
+      '6e: with the footage spent the gif-origin clip IS sent — a gif of theirs beats our own pool',
+      second.join(','));
+
+    qA.detach(); qB.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* ---------- 6f. THE HEVC HANDSHAKE: never offer what they cannot decode
+   *
+   * The founding bug: ui/assetsStore.js probeVideoDecodable only ever proved
+   * the SENDER could play the clip. Safari decodes its own HEVC, adopts it,
+   * transfers it flawlessly, and the peer with no HEVC decoder paints a silent
+   * black window for the whole slot. Here the receiver advertises `avc1` only
+   * and the sender's eligibility filter drops the HEVC artifact BEFORE it is
+   * offered — with a warn, because a silent skip looks exactly like "the
+   * transfer doesn't work", which is what three rounds of this were.
+   */
+  {
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+
+    const HEVC = SHA('e');
+    const H264 = SHA('f');
+    const artifacts = fakeArtifacts([
+      { sha: HEVC, bytes: 9000, mime: 'video/mp4', kind: 'video', exempt: false, codec: 'hvc1.1.6.L93.B0' },
+      { sha: H264, bytes: 9000, mime: 'video/mp4', kind: 'video', exempt: false, codec: 'avc1' },
+    ]);
+    const warns = [];
+    const loud = { info() {}, warn: (m) => warns.push(String(m)), error() {}, log() {} };
+
+    const storeB = fakeStore();
+    const qA = createMediaQueue({
+      artifacts, store: fakeStore(), logger: loud, canSend: () => true, idlePollMs: 40,
+    });
+    // THE RECEIVER IS THE ONE WITH THE OPINION: its hello carries the list.
+    const qB = createMediaQueue({
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
+      acceptsCodecs: ['avc1'],
+    });
+    qA.attach(a, pair.host);
+    qB.attach(b, pair.guest);
+    for (let i = 0; i < 120 && storeB.held.size < 1; i++) await tick(25);
+    await tick(200);                      // …and give the queue every chance to send the other one
+
+    ok(storeB.held.has(H264), '6f: the H.264 clip transferred normally');
+    ok(!storeB.held.has(HEVC),
+      '6f: the HEVC clip was NEVER offered — the peer advertised no HEVC decoder');
+    ok(qA.tagsFor(GoonPayloadKind.Video).indexOf('xfer:' + HEVC) < 0,
+      '6f: …so it can never end up on a payload either');
+    ok(warns.some((m) => /hvc1/.test(m) && /decoder/.test(m)),
+      '6f: and the skip SAYS SO once — the warn is what reaches the C# log and the ?debug=1 overlay',
+      warns.join(' | ').slice(0, 160));
+    ok(warns.filter((m) => /does not advertise a hvc1 decoder/.test(m)).length === 1,
+      '6f: exactly once per codec per match, on the saidWhy pattern — not once per poll');
+
+    qA.detach(); qB.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* ---------- 6g. THE SAME PAIR WITH AN OLD PEER: nothing is withheld.
+   * A hello with no `accepts_codecs` (every build before 2026-08-05) must be
+   * read as "send me anything", or the handshake would silently break the lane
+   * for everybody who has not updated.
+   */
+  {
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+
+    const HEVC = SHA('e');
+    const artifacts = fakeArtifacts([
+      { sha: HEVC, bytes: 9000, mime: 'video/mp4', kind: 'video', exempt: false, codec: 'hvc1.1.6.L93.B0' },
+    ]);
+    const storeB = fakeStore();
+    const qA = createMediaQueue({
+      artifacts, store: fakeStore(), logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    const qB = createMediaQueue({           // no acceptsCodecs — the old-peer shape
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
+    });
+    qA.attach(a, pair.host);
+    qB.attach(b, pair.guest);
+    for (let i = 0; i < 120 && storeB.held.size < 1; i++) await tick(25);
+    ok(storeB.held.has(HEVC),
+      '6g: a peer that advertises no codec list still receives the HEVC clip — fail open, end to end');
+
+    qA.detach(); qB.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* ---------- 6h. BOOT WIRES BOTH ENDS. Neither feature can work if the page
+   * forgets to read the fields off the artifact source or to probe at all, and
+   * both are one line in a 2,300-line file. */
+  {
+    const boot = read('boot.js');
+    ok(/origin\s*=\s*\(it\.origin === 'gif' \|\| it\.kind === 'gif'\)/.test(boot),
+      "6h: listSendable derives `origin` from the host's own flag OR the item kind (a host too "
+      + 'old to send `origin` still classifies gifs as kind "gif")');
+    ok(/out\.push\(\{ sha, bytes, mime, kind: wireKind, exempt, origin, codec \}\)/.test(boot),
+      '6h: …and both fields ride the sendable row the queue reads');
+    ok(/probeDecodeCodecs\(\)/.test(boot) && /acceptsCodecs: decodeCodecs/.test(boot),
+      '6h: boot probes what this device decodes ONCE and hands it to the queue for the hello');
+    ok(/origin: e\.origin \|\| ''/.test(boot),
+      '6h: and a received artifact keeps its origin all the way into exec/media.js addReceived');
+  }
 }
 
 /* ===========================================================================

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -1282,6 +1282,99 @@ async function testIceServers() {
     'a server that never heard of ice_servers leaves the client with []');
 }
 
+/* ============================================================ 14. net/codecs.js
+ *
+ * THE FAIL-OPEN CONTRACT IS THE TEST. Everything below is one question asked six ways: can this
+ * module ever refuse an artifact it should not? The HEVC handshake is only allowed to block a
+ * KNOWN codec against a peer that KNOWN-ly cannot decode it; every uncertainty — no list, an empty
+ * list, an unrecognised spelling, a peer from before the feature existed — must answer "send it",
+ * because a wrongly-refused good clip is invisible to the player while a black window at least
+ * looks like a bug.
+ */
+async function testCodecs() {
+  const {
+    CodecFamily, DECODE_PROBES, normalizeCodec, codecFromMime, baseMime,
+    probeDecodeCodecs, resetDecodeProbe, peerCanDecode, acceptedCodecsFromHello,
+  } = await import('../net/codecs.js');
+
+  // --- the vocabulary: four families, many spellings
+  ok(normalizeCodec('avc1') === CodecFamily.Avc && normalizeCodec('avc1.42E01E') === CodecFamily.Avc,
+    'the C# cache label and the page encoder\'s full string are the same family');
+  ok(normalizeCodec('AVC1.640028') === CodecFamily.Avc, 'case does not matter');
+  ok(normalizeCodec('hev1.1.6.L93.B0') === CodecFamily.Hevc && normalizeCodec('hvc1') === CodecFamily.Hevc,
+    'both HEVC box names normalize to one family — hev1 and hvc1 are the same decoder');
+  ok(normalizeCodec('vp09.00.10.08') === CodecFamily.Vp9 && normalizeCodec('vp9') === CodecFamily.Vp9, 'vp9');
+  ok(normalizeCodec('av01.0.04M.08') === CodecFamily.Av1, 'av1');
+  ok(normalizeCodec('orig') === '' && normalizeCodec('') === '' && normalizeCodec(null) === ''
+    && normalizeCodec('vp8') === '' && normalizeCodec('webp') === '',
+    'an exempt original, a still and anything unrecognised are UNKNOWN — never a wrong family');
+
+  ok(codecFromMime('video/mp4;codecs="hvc1.1.6.L93.B0"') === CodecFamily.Hevc,
+    'the codecs= parameter is the other cheap source of truth');
+  ok(codecFromMime('video/mp4; codecs=avc1.42E01E') === CodecFamily.Avc, 'unquoted and spaced, too');
+  ok(codecFromMime('video/mp4') === '', 'a plain mime says nothing, and says it as UNKNOWN');
+  ok(baseMime('video/mp4;codecs="avc1"') === 'video/mp4', 'baseMime strips the parameters');
+
+  // --- the decision, which is the whole feature
+  ok(peerCanDecode(['avc1'], 'hvc1.1.6.L93.B0') === false,
+    'THE ONE FALSE: a known codec against a peer that listed families and not this one');
+  ok(peerCanDecode(['avc1', 'hvc1'], 'hev1.1.6.L93.B0') === true, 'listed (under its other name) — fine');
+  ok(peerCanDecode(null, 'hvc1') === true, 'a peer that named NO codecs accepts everything (old build)');
+  ok(peerCanDecode([], 'hvc1') === true, 'an empty list is read the same way — never as "nothing"');
+  ok(peerCanDecode(['avc1'], 'orig') === true, 'an UNKNOWN codec is offered: fail open, exactly like today');
+  ok(peerCanDecode(['avc1'], '') === true, 'and so is a missing one');
+  ok(peerCanDecode('avc1', 'hvc1') === true, 'junk where the list should be still fails OPEN');
+
+  // --- reading a peer's hello, tolerantly
+  ok(acceptedCodecsFromHello({ accepts_codecs: ['avc1', 'vp9'] }).join(',') === 'avc1,vp9',
+    'the field this build writes');
+  ok(acceptedCodecsFromHello({ accepts: ['video/mp4;codecs="avc1.42E01E"', 'image/png'] }).join(',') === 'avc1',
+    'a peer that parameterised its mime list is understood too; plain mimes contribute nothing');
+  ok(acceptedCodecsFromHello({ accepts: ['video/mp4', 'image/gif'] }) === null,
+    'TODAY\'S HELLO — a plain mime allowlist — reads as null, i.e. "they named none"');
+  ok(acceptedCodecsFromHello({}) === null && acceptedCodecsFromHello(null) === null,
+    'and so does a hello with nothing at all');
+  ok(acceptedCodecsFromHello({ accepts_codecs: ['avc1', 'AVC1', 'avc1.42E01E'] }).length === 1,
+    'the list is de-duplicated by family, not by spelling');
+
+  // --- the probe: under node there is nothing to ask, and that must read as "unknown"
+  resetDecodeProbe();
+  ok(probeDecodeCodecs() === null,
+    'node has no MediaSource and no <video>, so the probe answers null — NOT [] — and we advertise nothing');
+
+  // A fake runtime with MediaSource, to prove the probe reads a real answer.
+  const realMS = globalThis.MediaSource;
+  try {
+    globalThis.MediaSource = { isTypeSupported: (t) => /avc1|vp09/.test(String(t)) };
+    resetDecodeProbe();
+    const list = probeDecodeCodecs(true);
+    ok(Array.isArray(list) && list.indexOf('avc1') >= 0 && list.indexOf('vp9') >= 0,
+      'a runtime that supports H.264 and VP9 reports both', JSON.stringify(list));
+    ok(list.indexOf('hvc1') < 0, '…and does NOT claim the HEVC it refused');
+    ok(probeDecodeCodecs() !== null && probeDecodeCodecs().length === list.length,
+      'the answer is cached — one probe per page, not one per hello');
+  } finally {
+    if (realMS === undefined) delete globalThis.MediaSource; else globalThis.MediaSource = realMS;
+    resetDecodeProbe();
+  }
+
+  // A runtime that says no to everything is a BROKEN PROBE, not a decoder-less device.
+  try {
+    globalThis.MediaSource = { isTypeSupported: () => false };
+    resetDecodeProbe();
+    ok(probeDecodeCodecs(true) === null,
+      'a runtime that refuses every probe answers null — "we could not ask", never "we decode nothing"');
+  } finally {
+    if (realMS === undefined) delete globalThis.MediaSource; else globalThis.MediaSource = realMS;
+    resetDecodeProbe();
+  }
+
+  ok(DECODE_PROBES.length === 4, 'the probe list stays SMALL — four families, asked once each');
+  ok(readSource('../net/codecs.js').indexOf('document') > 0
+    && /typeof document !== 'undefined'/.test(readSource('../net/codecs.js')),
+    'every DOM lookup in codecs.js is guarded — net/mediaChannel.js imports it and must stay node-safe');
+}
+
 // ============================================================ run
 const main = async () => {
   await testSignaling();
@@ -1297,6 +1390,7 @@ const main = async () => {
   await testSeatRelease();
   await testSelfDuel();
   await testBetaGates();
+  await testCodecs();
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-transfer.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-transfer.js
@@ -67,6 +67,10 @@ function makeSource(bytes, o = {}) {
     bytes,
     mime: o.mime || 'image/png',
     kind: o.kind || 'image',
+    // The two ADVISORY fields (2026-08-05). Absent on almost every fixture here on purpose:
+    // an offer without them is what a peer built before this change sends.
+    origin: o.origin,
+    codec: o.codec,
     data,
     reads,
     async read(offset, len) {
@@ -94,8 +98,10 @@ function makeStore(o = {}) {
     partialLength(sha) { const p = partials.get(sha); return p ? p.length : 0; },
     knowsBlocked(sha) { return blocked.has(sha); },
 
-    begin(sha, mime, bytes) {
+    /** `meta` is the offer's optional {origin, codec}; a store may ignore it and stay correct. */
+    begin(sha, mime, bytes, meta) {
       calls.begin++;
+      store.lastMeta = meta;
       if (store.refuseBegin) return false;
       if (!partials.has(sha)) partials.set(sha, { mime, bytes, chunks: [], length: 0 });
       return true;
@@ -154,11 +160,15 @@ async function makeRig(o = {}) {
   const hostCh = createMediaChannel(Object.assign(wire(pair.host), {
     store: hostStore, isHost: true, logger: quiet, tag: 'X:host',
     acceptOffers: o.hostAccepts || (() => true),
+    // Absent by default: node cannot probe, so the DEFAULT rig is two peers that advertise no
+    // decode list at all — which is also what every build before 2026-08-05 does.
+    acceptsCodecs: o.hostCodecs,
     timeouts: o.timeouts, limits: o.limits,
   }));
   const guestCh = createMediaChannel(Object.assign(wire(pair.guest), {
     store: guestStore, isHost: false, logger: quiet, tag: 'X:guest',
     acceptOffers: o.guestAccepts || (() => true),
+    acceptsCodecs: o.guestCodecs,
     timeouts: o.timeouts, limits: o.limits,
   }));
 
@@ -839,6 +849,138 @@ async function testSenderGuards() {
   rig.dispose();
 }
 
+/* ============================================================ 14. origin + codec on the offer
+ *
+ * Two optional fields, one rule: THEY MAY NEVER CHANGE WHETHER A TRANSFER HAPPENS. `origin` is
+ * downstream taste (keep a converted gif loop out of the VIDEO lane while real footage exists) and
+ * `codec` is only ever read by the SENDER's queue before it offers. An offer carrying neither —
+ * which is every offer a peer built before 2026-08-05 sends — must behave exactly as it always has.
+ */
+async function testOfferMetadata() {
+  // --- carried end to end, and handed to the store as advisory metadata
+  {
+    const rig = await makeRig();
+    const src = makeSource(2048, { mime: 'video/mp4', kind: 'video', origin: 'gif', codec: 'avc1' });
+    rig.hostCh.send(src);
+    ok(await until(() => rig.guestStore.committed.has(src.sha256), 3000), 'the gif-origin clip landed');
+
+    const offer = rig.guestSaw.find((m) => m.t === XferVerb.Offer);
+    ok(offer && offer.origin === 'gif' && offer.codec === 'avc1', 'the offer carries origin + codec',
+      JSON.stringify(offer && { origin: offer.origin, codec: offer.codec }));
+    ok(rig.guestStore.lastMeta && rig.guestStore.lastMeta.origin === 'gif'
+      && rig.guestStore.lastMeta.codec === 'avc1',
+      'and store.begin() is handed both as its optional 4th argument');
+
+    const landedIn = rig.events.guest.find((e) => e.ev === 'landed' && e.direction === 'in');
+    ok(landedIn && landedIn.origin === 'gif',
+      "the INBOUND landing reports it, which is how boot reaches exec/media.js addReceived");
+    const landedOut = rig.events.host.find((e) => e.ev === 'landed' && e.direction === 'out');
+    ok(landedOut && landedOut.origin === 'gif', 'and so does the outbound one, for the queue\'s own larder');
+    rig.dispose();
+  }
+
+  // --- an offer with NEITHER field is an old peer, and lands identically
+  {
+    const rig = await makeRig();
+    const src = makeSource(2048, { mime: 'video/mp4', kind: 'video' });
+    rig.hostCh.send(src);
+    ok(await until(() => rig.guestStore.committed.has(src.sha256), 3000),
+      'an offer with no origin and no codec transfers exactly as before');
+    const offer = rig.guestSaw.find((m) => m.t === XferVerb.Offer);
+    ok(offer && offer.origin === undefined && offer.codec === undefined,
+      'the fields are OMITTED rather than sent empty — an old parser sees the frame it expects');
+    const landedIn = rig.events.guest.find((e) => e.ev === 'landed' && e.direction === 'in');
+    ok(landedIn && landedIn.origin === '', 'and the landing reports origin "" — which reads as footage');
+    rig.dispose();
+  }
+
+  // --- a hostile peer cannot smuggle anything through either field
+  {
+    const rig = await makeRig();
+    const sha = shaOf(9911);
+    rig.rawFromHost({
+      t: XferVerb.Offer, v: XFER_PROTO, tid: 777, sha256: sha, bytes: 32,
+      mime: 'video/mp4', kind: 'video',
+      origin: '../../etc/passwd', codec: { nope: true },
+    });
+    await sleep(20);
+    ok(rig.guestStore.lastMeta && rig.guestStore.lastMeta.origin === '',
+      'a free-text origin is normalized to "" — the field is a two-valued flag, never a string we keep');
+    ok(rig.guestStore.lastMeta && rig.guestStore.lastMeta.codec === '',
+      'and a non-string codec normalizes to unknown rather than throwing');
+    ok(rig.hostSaw.some((m) => m.t === XferVerb.Accept && m.tid === 777),
+      'the offer was still ACCEPTED — neither field is ever a gate on the receiving side');
+    rig.dispose();
+  }
+}
+
+/* ============================================================ 15. the HEVC handshake
+ *
+ * The gap this closes, in one sentence: the sender's local decode probe only ever proved the
+ * SENDER could play the clip, so Safari shipped its own HEVC to a Windows peer with no HEVC
+ * decoder and the receiver watched a silent black window for the whole slot.
+ *
+ * The channel's job is only to ADVERTISE and to ANSWER; net/mediaQueue.js is what acts on the
+ * answer (selftest-flow.js §6f drives that end).
+ */
+async function testCodecHandshake() {
+  // --- advertised on the hello, and only when we have something to say
+  {
+    const rig = await makeRig({ hostCodecs: ['avc1', 'vp9'] });
+    const hello = rig.guestSaw.find((m) => m.t === XferVerb.Hello);
+    ok(hello && Array.isArray(hello.accepts_codecs)
+      && hello.accepts_codecs.join(',') === 'avc1,vp9',
+      'the hello carries accepts_codecs beside the untouched mime allowlist',
+      JSON.stringify(hello && hello.accepts_codecs));
+    ok(hello && Array.isArray(hello.accepts) && hello.accepts.includes('video/mp4'),
+      '`accepts` still means what it always meant — the CONTAINER allowlist, unchanged');
+
+    const back = rig.hostSaw.find((m) => m.t === XferVerb.Hello);
+    ok(back && back.accepts_codecs === undefined,
+      'a side with nothing to advertise OMITS the field (node cannot probe) — no empty-list claim');
+    rig.dispose();
+  }
+
+  // --- the answer the queue asks for
+  {
+    const rig = await makeRig({ guestCodecs: ['avc1'] });
+    ok(rig.hostCh.peerCanDecodeCodec('avc1.42E01E') === true, 'a listed family is decodable');
+    ok(rig.hostCh.peerCanDecodeCodec('hvc1.1.6.L93.B0') === false,
+      'THE POINT: an HEVC artifact is refused before it is ever offered to a peer without HEVC');
+    ok(rig.hostCh.peerCanDecodeCodec('orig') === true,
+      'an artifact whose codec we do not know is offered anyway — fail open');
+    ok(rig.hostCh.peerCanDecodeCodec('') === true, '…and so is one with no codec at all');
+    ok(rig.hostCh.stats().peer.acceptsCodecs.join(',') === 'avc1',
+      'stats surfaces the peer list for the ?debug=1 overlay');
+    rig.dispose();
+  }
+
+  // --- THE COMPATIBILITY CASE: a peer that says nothing takes everything
+  {
+    const rig = await makeRig();
+    ok(rig.hostCh.stats().peer.acceptsCodecs === null,
+      'a hello with no accepts_codecs reads as null — "they named none", not "they decode none"');
+    ok(rig.hostCh.peerCanDecodeCodec('hvc1') === true
+      && rig.hostCh.peerCanDecodeCodec('av01') === true,
+      'so every codec is offerable, which is byte-identical to the behaviour before the handshake');
+    const src = makeSource(1024, { mime: 'video/mp4', kind: 'video', codec: 'hvc1' });
+    rig.hostCh.send(src);
+    ok(await until(() => rig.guestStore.committed.has(src.sha256), 3000),
+      'and an HEVC clip really does still transfer to an old peer');
+    rig.dispose();
+  }
+
+  // --- the channel ADVERTISES and ANSWERS; it never refuses on its own
+  {
+    const rig = await makeRig({ guestCodecs: ['avc1'] });
+    const src = makeSource(1024, { mime: 'video/mp4', kind: 'video', codec: 'hvc1' });
+    const tid = rig.hostCh.send(src);
+    ok(tid !== null,
+      'send() does NOT gate on the peer\'s codecs: the queue is the policy, the channel is the wire');
+    rig.dispose();
+  }
+}
+
 // ============================================================ run
 const main = async () => {
   testFraming();
@@ -854,6 +996,8 @@ const main = async () => {
   await testHelloTimeout();
   await testDeadlines();
   await testSenderGuards();
+  await testOfferMetadata();
+  await testCodecHandshake();
 
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/assetsStore.js
@@ -879,6 +879,15 @@ function normalizeItem(raw) {
     // Local (browser-picked) files live behind blob: URLs, which carry no
     // extension for boot's mimeOf() to sniff — the mime must ride the item.
     mime: typeof o.mime === 'string' ? o.mime : '',
+    /* WHAT THE SOURCE WAS, when the artifact is no longer it. An animated gif compressed into an
+     * mp4 travels as `video/mp4` (the wire refuses a kind/mime disagreement), and the VIDEO lane
+     * wants to know it is a loop rather than footage — boot.js listSendable passes this through
+     * to the offer, net/mediaQueue.js and exec/media.js demote it, nothing excludes it.
+     * '' everywhere else, including every hosted row from a build that predates the field. */
+    origin: o.origin === 'gif' ? 'gif' : '',
+    /* The artifact's codec family as its PRODUCER labelled it ("avc1"): the cheap, reliable
+     * source the HEVC handshake consults. '' means unknown, which means "offer it anyway". */
+    codec: typeof o.codec === 'string' ? o.codec : '',
     bytes: Math.max(0, Number(o.bytes) || 0),
     srcBytes: Math.max(0, Number(o.srcBytes) || 0),
     w: Math.max(0, Number(o.w) || 0),
@@ -1356,6 +1365,13 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
     landArtifact({
       name, blob: out.blob, sha, mime: outMime, bytes: outBytes, srcBytes: bytes,
       w: out.w, h: out.h, durMs: out.durMs, compressed: true, report,
+      /* THE ORIGIN, on the one road in this file that changes a file's family: an animated
+       * gif/webp came in and an mp4 came out, so the wire will call it a video and the VIDEO
+       * lane deserves to know better. `animated` is the same flag that chose the lane three
+       * lines up, so the two answers cannot drift. A still that became a WebP stays an image
+       * and is not flagged — the image lane has no opinion about gifs. */
+      origin: animated ? 'gif' : '',
+      codec: String(out.codec || ''),
     });
   }
 
@@ -1369,7 +1385,8 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
    * the source — the offer gate declines any offer whose kind and mime disagree,
    * and a GIF that became an mp4 changes family.
    */
-  function landArtifact({ name, blob, sha, mime, bytes, srcBytes, w, h, durMs, compressed, report }) {
+  function landArtifact({ name, blob, sha, mime, bytes, srcBytes, w, h, durMs, compressed,
+    origin, codec, report }) {
     const id = 'local:' + sha;
     if (localItems.has(id)) { report.dupes++; return; }
     let artUrl = '';
@@ -1379,6 +1396,10 @@ export function createAssetsStore({ bridge = defaultBridge, session = null, logg
       artUrl, sha, ext: extForMime(mime), mime,
       bytes, srcBytes: Math.max(bytes, Number(srcBytes) || 0),
       w: w || 0, h: h || 0, durMs: durMs || 0,
+      // Only the gif->mp4 road sets these; an as-is video pick knows neither and says so
+      // (unknown codec = offered anyway, which is the fail-open half of the handshake).
+      origin: origin === 'gif' ? 'gif' : '',
+      codec: String(codec || ''),
     }));
     localVersion++;
     localSrcShas.add(sha);

--- a/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/localCompress.js
@@ -539,7 +539,13 @@ export async function compressImage(src, mime, o = {}) {
 /**
  * Compress one animated GIF / animated WebP into an mp4, via lane B's worker.
  *
- * @returns {Promise<{blob:Blob, mime:'video/mp4', w:number, h:number, durMs:number, kind:'video'}>}
+ * `codec` is reported because the transfer lane's HEVC handshake needs to know what this artifact
+ * actually IS: encode/encodeWorker.js only ever asks with an `avc1.*` string (codecForSize picks
+ * the level, never the family), so H.264 is a fact here, not a guess — and a peer with any video
+ * decoder at all has that one.
+ *
+ * @returns {Promise<{blob:Blob, mime:'video/mp4', w:number, h:number, durMs:number,
+ *                    kind:'video', codec:'avc1'}>}
  */
 export async function compressGif(src, mime, o = {}) {
   const driver = o.driver || createLocalEncodeDriver({ logger: o.logger || null });
@@ -560,7 +566,7 @@ export async function compressGif(src, mime, o = {}) {
     if (typeof B !== 'function') throw new Error('no-blob');
     const blob = new B([out.art], { type: 'video/mp4' });
     if (!blob.size) throw new Error('empty-output');
-    return { blob, mime: 'video/mp4', w: out.w, h: out.h, durMs: out.durMs, kind: 'video' };
+    return { blob, mime: 'video/mp4', w: out.w, h: out.h, durMs: out.durMs, kind: 'video', codec: 'avc1' };
   } finally {
     if (owned) { try { driver.dispose(); } catch (_e) { /* ignore */ } }
   }

--- a/ConditioningControlPanel/Services/GoonGame/GoonCacheBridge.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonCacheBridge.cs
@@ -533,6 +533,23 @@ namespace ConditioningControlPanel.Services.GoonGame
                             lane = it.Lane,
                             sha = it.Sha,
                             ext = it.Ext,
+                            // WHAT THE SOURCE WAS, for the goon transfer lane. An animated
+                            // gif/webp compresses into an mp4 and therefore travels as a VIDEO
+                            // (the wire refuses a kind/mime disagreement) — the page demotes such
+                            // an artifact behind real footage when it picks what to throw, so it
+                            // has to be able to tell the two apart. Taste only: nothing gates.
+                            origin = it.Kind == TransferKinds.Gif ? "gif" : "",
+                            // …and what the artifact IS. The page checks this against the peer's
+                            // advertised decoders before offering; "" / "orig" (an exempt
+                            // original, whose codec we never probed) means "offer it anyway".
+                            //
+                            // ONLY THE FULL LIST CARRIES IT: a job that finishes mid-session
+                            // arrives as a cache-progress delta, which has no codec field, so
+                            // that row stays "" until the next relist. That is the FAIL-OPEN
+                            // case by design — an unknown codec is offered — and it costs
+                            // nothing to leave alone, because everything this lane produces is
+                            // avc1 anyway.
+                            codec = it.Codec,
                             // srcBytes is the name the assets screen reads for "what compressing
                             // this would have to chew through"; `size` is the same number kept for
                             // anything that grew up on the C# field name.

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -604,8 +604,11 @@ namespace ConditioningControlPanel.Services.GoonGame
                 {
                     case "goon-recv-begin":
                     {
+                        // `origin` is the offer's advisory "this used to be a gif" flag, passed
+                        // through so the inbox can remember it across sessions. It is normalised
+                        // inside Begin and can never make the call fail.
                         var err = store.Begin(id, (string?)o["sha256"], (string?)o["mime"],
-                            (long?)o["bytes"] ?? 0);
+                            (long?)o["bytes"] ?? 0, (string?)o["origin"]);
                         ReplyRecv(id, err == null, null, 0, err);
                         break;
                     }

--- a/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
+++ b/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
@@ -15,6 +15,17 @@ namespace ConditioningControlPanel.Services.GoonGame
         [JsonProperty("ext")] public string Ext { get; set; } = "";
         /// <summary>The mime the sender declared AND the sniffer agreed with.</summary>
         [JsonProperty("mime")] public string Mime { get; set; } = "";
+        /// <summary>
+        /// "gif" when the SENDER said this artifact was a converted animated image rather than
+        /// footage; "" otherwise, which is also what every row written before 2026-08-05 says.
+        ///
+        /// ADVISORY AND UNTRUSTED, which is why it is safe to take a peer's word for it: it never
+        /// touches a filename, a size, a hash or a mime check, and the only thing that reads it is
+        /// the page's preference for real footage in the VIDEO lane. Persisted because a returning
+        /// session primes exec/media.js from this index — without it a gif loop received yesterday
+        /// comes back today looking like a clip.
+        /// </summary>
+        [JsonProperty("origin")] public string Origin { get; set; } = "";
         [JsonProperty("bytes")] public long Bytes { get; set; }
         [JsonProperty("lastAccessUtc")] public DateTime LastAccessUtc { get; set; } = DateTime.UtcNow;
     }
@@ -121,6 +132,9 @@ namespace ConditioningControlPanel.Services.GoonGame
             public required string Mime { get; init; }
             public required long Declared { get; init; }
             public required string PartPath { get; init; }
+            /// <summary>"gif" or "". Carried from Begin to Commit so it can be indexed — see
+            /// <see cref="InboxEntry.Origin"/> for why a peer's claim is safe here.</summary>
+            public string Origin { get; init; } = "";
             /// <summary>We already hold these bytes. Chunks are ACKED AND DISCARDED and Commit is a
             /// no-op success — a peer that ignored <c>decline:'have'</c> must not get us to rewrite
             /// 24 MB we already have.</summary>
@@ -320,6 +334,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         sha = kv.Key,
                         ext = kv.Value.Ext,
                         mime = kv.Value.Mime,
+                        origin = kv.Value.Origin,
                         bytes = kv.Value.Bytes,
                     })
                     .ToList();
@@ -346,7 +361,10 @@ namespace ConditioningControlPanel.Services.GoonGame
         /// <c>from_offset = PartialLength</c>), because the commit hash is the backstop: a resume
         /// that stitched the wrong bytes together fails <c>hash-mismatch</c> and is deleted.
         /// </summary>
-        public string? Begin(string? id, string? sha, string? mime, long bytes)
+        /// <param name="origin">The offer's advisory <c>origin</c> ("gif" or anything else, which
+        /// is normalised to ""). Never validated beyond that string compare, and never used for
+        /// anything that can fail — see <see cref="InboxEntry.Origin"/>.</param>
+        public string? Begin(string? id, string? sha, string? mime, long bytes, string? origin = null)
         {
             if (string.IsNullOrEmpty(id)) return "bad-name";
             if (!IsSha(sha)) return "bad-name";
@@ -390,6 +408,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         Mime = mime,
                         Declared = bytes,
                         PartPath = part,
+                        Origin = origin == "gif" ? "gif" : "",
                         Written = already,
                     };
                     return null;
@@ -514,6 +533,7 @@ namespace ConditioningControlPanel.Services.GoonGame
                         {
                             Ext = ext,
                             Mime = s.Mime,
+                            Origin = s.Origin,
                             Bytes = len,
                             LastAccessUtc = DateTime.UtcNow,
                         };

--- a/ConditioningControlPanel/Services/Media/Transfer/TransferCompressionService.cs
+++ b/ConditioningControlPanel/Services/Media/Transfer/TransferCompressionService.cs
@@ -7,10 +7,18 @@ using System.Threading.Tasks;
 
 namespace ConditioningControlPanel.Services.Transfer
 {
-    /// <summary>A queued/running/failed item as the assets screen wants to render it.</summary>
+    /// <summary>
+    /// A queued/running/failed item as the assets screen wants to render it.
+    ///
+    /// <c>Kind</c> is the SOURCE's ("gif" for an animated gif/webp) while <c>Ext</c>/<c>Codec</c>
+    /// describe the ARTIFACT — the two disagree for exactly the case the goon transfer lane cares
+    /// about, a gif that became an mp4. <c>Codec</c> is the compressor's own label ("avc1",
+    /// "webp", "jpeg", "orig") and reaches the page so a peer with no decoder for it is never
+    /// offered the file; "" / "orig" means unknown, which the page treats as "offer it anyway".
+    /// </summary>
     internal sealed record CacheItem(
         string SrcKey, string Rel, string Kind, string State, string Lane,
-        string Sha, string Ext, long Size, long Bytes, int W, int H, int DurMs,
+        string Sha, string Ext, string Codec, long Size, long Bytes, int W, int H, int DurMs,
         string? Fail, int Percent);
 
     /// <summary>One coalescable progress tick.</summary>
@@ -370,7 +378,7 @@ namespace ConditioningControlPanel.Services.Transfer
             foreach (var (key, e) in _store.Snapshot())
             {
                 seen.Add(key);
-                items.Add(new CacheItem(key, e.Rel, e.Kind, e.State, e.Lane, e.Sha, e.Ext,
+                items.Add(new CacheItem(key, e.Rel, e.Kind, e.State, e.Lane, e.Sha, e.Ext, e.Codec,
                     e.Size, e.Bytes, e.W, e.H, e.DurMs, e.Fail, 100));
             }
             lock (_lock)
@@ -383,7 +391,8 @@ namespace ConditioningControlPanel.Services.Transfer
                     if (_running.TryGetValue(j.SrcKey, out var r)) { pct = (int)r.Percent; state = "running"; }
                     else if (_pageOut.TryGetValue(j.SrcKey, out var d)) { pct = (int)d.Percent; state = "running"; }
                     else if (_queue.Any(q => q.SrcKey == j.SrcKey)) state = "queued";
-                    items.Add(new CacheItem(j.SrcKey, j.Rel, j.Kind, state, j.Lane, "", "",
+                    // Still outstanding: there is no artifact yet, so no ext and no codec.
+                    items.Add(new CacheItem(j.SrcKey, j.Rel, j.Kind, state, j.Lane, "", "", "",
                         j.Size, 0, j.SrcW, j.SrcH, j.DurMs, null, pct));
                 }
             }


### PR DESCRIPTION
Two fixes in the Goon Game P2P transfer lane. Both are **soft** and **fail-open**: nothing new can empty the lane, and every uncertainty resolves to "send it".

## 1. Gif-origin clips no longer dominate the VIDEO lane

The desktop compresses an animated gif into an mp4 so it can travel, and the wire kind therefore has to be `video` (the offer gate refuses any kind/mime disagreement - that gate is untouched). The result the owner disliked: a Video attack landing a two-second loop while real footage sat in the same larder.

An `origin` field now rides the whole pipeline:

`TransferCacheEntry.Kind == gif` -> `cache-list {origin}` -> `boot.js listSendable` -> `xfer_offer {origin}` -> `receivedStore` (persisted host-side in `recv_index.json`) -> `media.addReceived`

and both ends prefer real footage:

- **sender** - `mediaQueue.tagsFor(Video)` spends a non-gif artifact first, and falls back to a gif-origin one when that is all that has landed (their gif still beats the receiver's own pool - the whole point of the lane);
- **receiver** - `exec/media.js` `drawReceived('video')` / `peekReceived('video')` draw from the footage subset when there is one, and from everything when there is not.

An explicit `xfer:` tag still resolves exactly, and the FlashBurst/image lane is untouched - a gif there is what a gif is for.

## 2. HEVC peer-capability handshake

The known gap documented in `probeVideoDecodable`: the local probe only ever proved the **sender** could decode its clip. Safari decodes its own HEVC, adopts it, transfers it flawlessly, and a peer with no HEVC decoder paints a silent black window for the whole slot with no error anywhere.

- new **`net/codecs.js`** - the codec vocabulary (`avc1` / `hvc1` / `vp9` / `av01`, four families, one representative type each) plus a guarded, cached `probeDecodeCodecs()` over `MediaSource.isTypeSupported` and `<video>.canPlayType`;
- boot probes once and the channel advertises the answer on the xfer hello as **`accepts_codecs`** - beside `accepts`, which keeps meaning exactly what it always meant (the container allowlist);
- `mediaQueue.eligible()` drops a video artifact the peer cannot decode **before offering it**, with a once-per-codec warn on the existing `whyNoTags`/`saidWhy` pattern (the warn is what reaches the C# log and the `?debug=1` overlay);
- codec knowledge is taken from the existing pipeline - the C# cache's own `Codec` label ("avc1" for anything it transcoded), the page encoder's (`avc1` by construction), or a mime `codecs=` parameter. **Unknown means offer it.**

## Degradation against old peers

| situation | behaviour |
|---|---|
| offer with no `origin` | reads as footage - as eligible as it is today |
| hello with no `accepts_codecs` | reads as "they named none" -> send them anything |
| artifact with unknown/absent codec (every exempt original) | offered, exactly as today |
| runtime that cannot be probed (node, an exotic embedder) | advertises nothing, so peers keep offering us everything |
| received row primed from a session before this build | no `origin` -> footage |
| a store that ignores `begin`'s new optional 4th argument | fully correct |

The only thing this can ever block is a **known** codec against a peer that **known-ly** lacks it.

## Tests

`selftest-transfer` 199, `selftest-net` 298, `selftest-exec` 966, `selftest-flow` 232 - all green, plus assets/core/encode/hud/report/voice/hostgate/invite unaffected. New checks: the queue-level gif preference (with `Math.random` pinned so the gif lands FIRST and a regression cannot hide), the codec gate end to end over a real loopback pair, the old-peer fail-open twin, offer-metadata round trip, hostile input through both new fields, the whole `net/codecs.js` contract, and the pool preference in both directions. Both features were verified to FAIL their new checks when the logic is reverted.

`dotnet build`: 0 errors.

## Needs a live two-device play-test

- a real phone <-> desktop duel: the decode probe only ever runs in a browser, so the advertised list (and Safari's answer for `hvc1`) has never been seen outside a stub;
- a real HEVC clip from an iPhone camera roll offered to a Windows peer - it should now be skipped with the warn instead of landing black;
- a gif-heavy desktop library plus at least one real clip: the first video attack should be the clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
