### PR TITLE
fix(goon): stop the spiral freezing for a second when it lands

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
@@ -34,9 +34,22 @@
  *      fx.css keyframe at the variant's own solved revolution time. The
  *      fallback is never removed and never degraded; it is what a machine
  *      without a GPU still gets.
- * The pane always carries the baked background-image either way, so path 2 is
- * one property removal away at any moment — and because both paths draw the
- * same roll, a mid-match context loss now changes the RENDERER, not the picture.
+ * Path 2 is one property removal away at any moment, and because both paths
+ * draw the same roll, a mid-match context loss changes the RENDERER, not the
+ * picture.
+ *
+ * THE STILL IS PAINTED WHEN THE PANE LANDS ON RASTER, NOT BEFORE (2026-08-05).
+ * The pane used to carry the baked background-image ALWAYS, woven or not, on
+ * the theory that a bed which already holds its own fallback cannot be caught
+ * out by a context loss. What that actually bought, on a phone, was a ~1600-fill
+ * canvas bake plus a PNG encode plus a multi-megabyte data-URL decode — for a
+ * picture sitting underneath an OPAQUE canvas where no player can ever see it —
+ * landing on the main thread inside the cue's own first frames, which is
+ * precisely the stutter the owner reported (a spiral that mounts and then holds
+ * still for a second or two). Now: the bake is WARMED at build during idle time
+ * (exec/spiralGen.js#warmSpiralStills), the woven pane skips painting it, and
+ * unweave() — the one door every fallback goes through — paints it on the way
+ * down. The guarantee is unchanged and the cost moved off the cue.
  *
  * THE FREEZE DEFENCE (2026-08-04). This pane is the only GPU context the duel
  * owns, and it went in hours before a session froze VISUALLY while its JS kept
@@ -70,7 +83,9 @@
  * ==========================================================================*/
 
 import { createSpiralField, loopMsFor } from './spiralField.js';
-import { beginSpiralSession, nextSpiral } from './spiralGen.js';
+import {
+  beginSpiralSession, nextSpiral, warmSharedSpirals, RASTER_PX, LITE_RASTER_PX,
+} from './spiralGen.js';
 import { perfLite } from './perfTier.js';
 
 /* --- THE SHADER KILL SWITCH. The pref is ui/prefs.js's (`shaderSpirals`,
@@ -101,6 +116,25 @@ export const MAX_BACKING_PX = 3840 * 2160;
    bed already spinning. ----------------------------------------------------- */
 export const LITE_MAX_DPR = 1;
 export const LITE_FRAME_MS = 33;   // ~30fps draw cadence on the lite tier
+
+/**
+ * Is this frame owed a DRAW? Pure, so the startup edge is pinnable in node.
+ *
+ * The phase advances on every callback either way (see step()), so a skipped
+ * frame skips pixels and never tempo. Two rules:
+ *   · the full tier never skips — byte-identical to the pre-tier loop;
+ *   · a lastDraw of 0 is "this weave has not drawn a LOOP frame yet" and always
+ *     draws. weave() zeroes it for exactly this reason: rAF timestamps are a
+ *     page-lifetime clock shared with the pane that just died, so a bed that
+ *     mounts within 33ms of the last one's final frame would otherwise open by
+ *     SKIPPING — a fresh spiral's first visible act being a dropped frame is
+ *     the one moment a throttle must not be silently right.
+ */
+export function dueForDraw(now, lastDraw, lite) {
+  if (!lite) return true;
+  if (!(lastDraw > 0)) return true;
+  return (now - lastDraw) >= LITE_FRAME_MS;
+}
 
 /* --- THE IN-LOOP WATCHDOG. Checked once per HEALTH_CHECK_MS, never per frame:
    gl.getError()/isContextLost() can force a sync round-trip to the driver, which
@@ -143,7 +177,21 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   // duel page (boot.js builds one executor), so this is the session boundary —
   // and it is the shared pool, so exec/bubbles.js's popped-spiral flick throws
   // a spiral this match has actually been showing.
-  try { beginSpiralSession(); } catch (_e) { /* the pool builds lazily on first ask anyway */ }
+  //
+  // …AND WARM THEIR STILLS FROM HERE TOO. boot.js#buildApp builds the executor
+  // BEFORE the first screen, so this fires with the whole title/lobby/countdown
+  // stretch of idle time still ahead of it — every bake is cached long before a
+  // cue, or a popped spiral bubble (exec/bubbles.js#popFx -> pickSpiralImage),
+  // can ask for one on the main thread. The lite tier bakes SMALLER (see
+  // LITE_RASTER_PX): the still is the fallback bed there and the live bed it
+  // falls back FROM is already only LITE_MAX_DPR deep. The tier is read once,
+  // here, because a pool's bake size is fixed when it is built — a player who
+  // flips the perf toggle mid-match moves the shader and the caps, not the five
+  // pictures already in hand.
+  try {
+    beginSpiralSession({ size: perfLite() ? LITE_RASTER_PX : RASTER_PX });
+    warmSharedSpirals();
+  } catch (_e) { /* the pool builds lazily on first ask anyway */ }
 
   let paneEl = null;
   let elementIntensity = null;    // null = element not running
@@ -153,6 +201,13 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   // BOTH beds: `.params` is what the shader weaves, `.image()` is the baked
   // still underneath it, `.revSec` is the spin the CSS keyframe runs at.
   let variant = null;
+  // The variant whose still is actually IN the pane's background-image. Null
+  // while the pane is woven and has never needed one — see paintStill().
+  let stillOn = null;
+  // ensurePane() MINTED the pane on this call (rather than finding one already
+  // up). Read one line later by start()/renderPayload(), which must not roll a
+  // second variant on top of the one the new pane just rolled for itself.
+  let mintedPane = false;
 
   // --- the woven path's state (all null on the raster fallback) -------------
   let canvasEl = null;
@@ -209,6 +264,8 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     if (paneEl && paneEl.isConnected) return true;
     const host = layer();
     if (!host || typeof document === 'undefined') return false;
+    mintedPane = true;
+    stillOn = null;                 // a brand-new node carries no picture yet
     paneEl = document.createElement('div');
     // .gg-deco so the heat armor can park the spin when the stack goes hot.
     // (The woven path cancels the keyframe and parks itself — see step().)
@@ -285,6 +342,7 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     phase = Math.random();      // never start every match on the same frame
     lastTs = 0;
     lastCheck = 0;
+    lastDraw = 0;               // this weave has not drawn a LOOP frame — see dueForDraw()
     // THE FIRST FRAME GOES IN BEFORE THE APPEND. The context is `alpha: false`,
     // so an un-drawn canvas is OPAQUE BLACK: appending it and drawing afterwards
     // blinks the bed out for a frame. It matters most on the re-upgrade after a
@@ -383,7 +441,15 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
     rafId = 0;
     if (!field || !paneEl) return;
     const now = typeof ts === 'number' ? ts : 0;
-    if (now - lastCheck >= HEALTH_CHECK_MS) {
+    // SEED, DON'T POLL, ON THE FIRST FRAME OF A WEAVE. lastCheck starts at 0 and
+    // an rAF timestamp is a page-lifetime clock, so the very first callback used
+    // to satisfy `now - 0 >= 1000` and run the driver poll — a synchronous
+    // round-trip to the GPU, in the busiest millisecond of the pane's life, when
+    // the only thing it can possibly report is a context created moments ago.
+    // (It also re-seeds after a visibilitychange, which zeroes lastCheck for the
+    // same reason the stall check does.)
+    if (!lastCheck) lastCheck = now;
+    else if (now - lastCheck >= HEALTH_CHECK_MS) {
       lastCheck = now;
       const ill = healthCheck(now);
       if (ill) {
@@ -403,7 +469,7 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       // every callback, so skipping a draw skips pixels, never tempo — a
       // 30fps bed and a 120fps bed show the same rotation at the same second.
       // Full tier: no gate at all, byte-identical to the pre-tier loop.
-      if (!perfLite() || (now - lastDraw) >= LITE_FRAME_MS) {
+      if (dueForDraw(now, lastDraw, perfLite())) {
         lastDraw = now;
         draw();
       }
@@ -460,6 +526,15 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
    * PROPERTIES (repick), precisely so this shorthand clear cannot eat them.
    */
   function unweave() {
+    // PAINT THE STILL FIRST, WHILE THE DEAD CANVAS IS STILL COVERING THE PANE.
+    // This is the moment the fallback stops being insurance and becomes the
+    // bed, and it is the ONE door every fallback comes through (a lost context,
+    // a polled stall, the kill switch, a render that threw). Doing it here
+    // instead of on every repick is what keeps the bake off the cue — and doing
+    // it BEFORE detachWoven() drops the canvas is what keeps the swap from
+    // showing a frame of empty pane. It is normally free: the pool warmed this
+    // picture during idle time long before anything went wrong.
+    paintStill(variant);
     detachWoven()();
     // Hand the raster treatments back exactly as fx.css declares them.
     if (paneEl && paneEl.style) {
@@ -511,22 +586,46 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   }
 
   /**
-   * Advance to the next spiral in the session's rotation, and put it on BOTH
-   * beds at once: the shader takes its parameters, the pane's background-image
-   * takes the baked still of the same roll. Doing both every time is what keeps
-   * the fallback underneath from ever being stale — or, now, from ever being a
-   * different picture — if the context dies mid-match.
+   * Put `v`'s baked still into the pane's background-image — the raster bed's
+   * whole picture, and the woven bed's parachute.
+   *
+   * IDEMPOTENT ON THE VARIANT, because it is called from two directions (the
+   * deferred bake on a raster pane, and unweave() on the way down from a woven
+   * one) and repainting a picture the pane already carries would re-decode a
+   * multi-megabyte data URL for no change at all.
    *
    * An UNBAKEABLE variant (no canvas, no 2D context, a toDataURL the host
-   * refuses) returns '' and the pane simply keeps whatever it had. Writing
+   * refuses) answers '' and the pane simply keeps whatever it had. Writing
    * `url('')` instead would blank a bed that was working a moment ago.
+   */
+  function paintStill(v) {
+    if (!paneEl || !paneEl.style || !v || stillOn === v) return;
+    try {
+      const img = v.image();       // warmed at build; cached after the first ask
+      if (!img) return;
+      paneEl.style.setProperty('background-image', `url("${img}")`);
+      stillOn = v;
+    } catch (_e) { /* the bed keeps whatever it had */ }
+  }
+
+  /**
+   * Advance to the next spiral in the session's rotation, and put it on the
+   * shader — and, when the pane is (or lands) on the raster bed, put the baked
+   * still of the SAME roll underneath it. One roll drives both, which is what
+   * keeps the fallback from ever being a different picture if the context dies
+   * mid-match.
    *
-   * THE BAKE IS DEFERRED ONE TICK, and that is not a micro-optimisation. A
-   * first bake is ~1600 canvas path fills plus a PNG encode — tens of
-   * milliseconds, ON THE MAIN THREAD, and repick() is called from the middle of
-   * a cue landing. The pane fades in over 450-900ms, so an image that arrives
-   * on the next tick arrives invisibly; a bed that ate the cue's own frame
-   * would be felt. Cached after the first ask, so a repeat variant is free.
+   * THE WOVEN PANE DOES NOT PAINT ONE AT ALL (2026-08-05, the phone stutter).
+   * The bake used to be DEFERRED ONE TICK on the theory that a bed fading in
+   * over 450-900ms would swallow it. It does not: one tick lands the work in
+   * the pane's FIRST FRAMES, the rAF loop queues behind it, and a ~1600-fill
+   * bake plus a PNG encode plus a multi-megabyte data-URL decode is a second
+   * of a spiral that is on screen and not turning. And on the woven path the
+   * whole thing is invisible anyway — the canvas over it is `alpha: false`.
+   * So: the tick's callback bails if the weave took, unweave() paints on the
+   * way back down to raster, and a pane that never wove (no WebGL, shaders off,
+   * a defence already fired) paints exactly as before, one tick later. The
+   * picture itself is normally already warm — see the createSpiral() banner.
    */
   function repick() {
     if (!paneEl || !paneEl.style) return;
@@ -545,10 +644,11 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       // A pane that has been torn down (or replaced) in the meantime must not
       // be painted into — its node lingers 900ms on the way out by design.
       if (paneEl !== el || !el.style) return;
-      try {
-        const img = v.image();
-        if (img) el.style.setProperty('background-image', `url("${img}")`);
-      } catch (_e) { /* the bed keeps whatever it had */ }
+      // The weave (ensurePane's, one line after its repick) took: the still
+      // would be baked, decoded and uploaded for a layer nobody can see. It is
+      // owed, not skipped — unweave() paints it the instant the pane needs it.
+      if (field) return;
+      paintStill(v);
     }, 0);
     if (field) {
       params = variant.params;
@@ -596,6 +696,10 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       : Math.max(payloadIntensity === null ? 0 : payloadIntensity, elementIntensity === null ? 0 : elementIntensity);
 
     if (want === null) { teardown(); return; }
+    // Cleared BEFORE the call, set by ensurePane only when it actually mints:
+    // start()/renderPayload() read it one line after apply() returns, and a
+    // stale true from the pane before this one would cost that cue its repick.
+    mintedPane = false;
     if (!ensurePane()) return;
 
     const tune = spiralTuning(want, calm);
@@ -611,7 +715,11 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       const fresh = elementIntensity === null;
       elementIntensity = clamp01(cue && cue.intensity);
       apply();
-      if (fresh) { repick(); sfx('spiral-in'); }   // a new bed gets a new spiral; a re-tune keeps its own
+      // A new bed gets a new spiral; a re-tune keeps its own. But a pane
+      // ensurePane() JUST MINTED has ALREADY rolled one (and woven it) — see
+      // the note in renderPayload; rolling again here would be the second roll
+      // of the same cue.
+      if (fresh) { if (!mintedPane) repick(); sfx('spiral-in'); }
     },
 
     setIntensity(v) {
@@ -632,7 +740,16 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       const runMs = Math.max(1000, (p.duration_ms | 0) || 12000);
       payloadIntensity = Math.max(0.5, clamp01(p.intensity !== undefined ? p.intensity : 0.75));
       apply();
-      repick();
+      // ONE ROLL PER CUE. apply() -> ensurePane() already repicks for a pane it
+      // MINTED, and that roll is the one weave() wove a first frame of; rolling
+      // again here threw that frame away, swapped the shader's params on the
+      // spot, and — before the still moved off this path — queued a SECOND
+      // 1280px raster bake behind the first, both landing on the main thread
+      // inside the cue's own fade. That double bake is the freeze the owner
+      // play-tested on an iPhone. A bed that was ALREADY UP still repicks: a
+      // payload landing on a running spiral is exactly when the picture should
+      // change.
+      if (!mintedPane) repick();
 
       let finished = false;
       let endTimer = 0;

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiralGen.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiralGen.js
@@ -28,6 +28,18 @@
  *   · the raster bake (below) is the expensive half, and a fixed set of five
  *     can be baked lazily and cached instead of re-encoded per cue.
  *
+ * …AND WARMED, NOT BAKED ON A CUE (2026-08-05). "Lazily" above used to mean
+ * "on the main thread, in the middle of the cue that needs it", and on an
+ * iPhone that is a VISIBLE FREEZE: a 1280px bake is ~1600 antialiased path
+ * fills plus a PNG encode of a 6.5MB backing store, and the owner's play-test
+ * found a spiral that mounted and then sat perfectly still for a second or two
+ * before it started turning. warmSpiralStills() walks the pool during IDLE time
+ * instead — it is armed from exec/spiral.js at executor build, which on this
+ * page is app build, so the whole title/lobby/countdown stretch is available
+ * and every bake is already cached long before a cue can ask for one. The
+ * laziness is still there underneath (a host that never idles still bakes on
+ * first ask); what changed is that nothing normal ever reaches it.
+ *
  * EVERY VARIANT IS BOTH BEDS AT ONCE. `params` drives exec/spiralField.js's
  * WebGL field; `image()` bakes the SAME parameters to a still PNG for the
  * no-WebGL raster path and for the bubble-pop flick. That is new: the shader
@@ -102,6 +114,22 @@ export const SESSION_SIZE = 5;
  * Going higher is not free: the PNG data URL is held in an inline style.
  */
 export const RASTER_PX = 1280;
+
+/**
+ * …and what the LITE tier bakes at (exec/perfTier.js — phones).
+ *
+ * BOTH HALVES OF THE COST ARE QUADRATIC IN THIS NUMBER: the wedge fills cover
+ * area, and the PNG encode chews the whole backing store (1280² RGBA is 6.5MB,
+ * 640² is 1.6MB). Quartering it is the difference between a bake a phone can
+ * absorb in an idle slice and one it cannot.
+ *
+ * AND IT COSTS THE LITE TIER NOTHING VISIBLE, because the still is the FALLBACK
+ * bed there and the fallback's competition is a shader that already draws at
+ * LITE_MAX_DPR = 1 — a 428pt-wide iPhone weaves at 428 backing pixels, so a
+ * 640px bake is MORE detail than the live path on the same device, under a
+ * screen blend at <=0.70 with a 1.1px blur over it.
+ */
+export const LITE_RASTER_PX = 640;
 
 /* ---------------------------------------------------------------------------
  * ROLLING ONE
@@ -368,17 +396,30 @@ export function drawSpiralRaster(ctx, size, params, phase = 0) {
  * ONE scratch canvas for every bake in the page. A 1280-square backing store is
  * ~6.5MB; minting a fresh one per variant would hold five of them alive for as
  * long as the session, for no reason — the PNG is the only thing worth keeping.
+ *
+ * NOTHING IS CACHED UNTIL A REAL 2D CONTEXT COMES BACK. The canvas and its
+ * context are taken together and remembered together, because a host that
+ * answers getContext('2d') with null (a WebView under memory pressure, a
+ * locked-down embedder, a self-test fake that only serves WebGL) would
+ * otherwise have its dud canvas remembered as THE scratch canvas for the life
+ * of the page — and every bake after the condition cleared would still fail
+ * against it. Refusing to cache a failure is what makes the next ask a retry.
+ *
+ * @returns {{cv: object, ctx: object, size: number}|null}
  */
 let scratch = null;
-function scratchCanvas(size) {
-  if (scratch && scratch.width === size) return scratch;
+function scratchTarget(size) {
+  if (scratch && scratch.size === size) return scratch;
   if (typeof document === 'undefined' || typeof document.createElement !== 'function') return null;
   let cv = null;
   try { cv = document.createElement('canvas'); } catch (_e) { return null; }
   if (!cv || typeof cv.getContext !== 'function') return null;
   try { cv.width = size; cv.height = size; } catch (_e) { return null; }
-  scratch = cv;
-  return cv;
+  let ctx = null;
+  try { ctx = cv.getContext('2d'); } catch (_e) { return null; }
+  if (!ctx) return null;
+  scratch = { cv, ctx, size };
+  return scratch;
 }
 
 /**
@@ -388,12 +429,10 @@ function scratchCanvas(size) {
  * alone, and a pane with no picture is invisible rather than wrong.
  */
 export function bakeSpiralImage(params, size = RASTER_PX) {
-  const cv = scratchCanvas(size);
-  if (!cv) return '';
-  let ctx = null;
-  try { ctx = cv.getContext('2d'); } catch (_e) { return ''; }
-  if (!ctx) return '';
-  if (!drawSpiralRaster(ctx, size, params, 0)) return '';
+  const target = scratchTarget(size);
+  if (!target) return '';
+  const cv = target.cv;
+  if (!drawSpiralRaster(target.ctx, size, params, 0)) return '';
   if (typeof cv.toDataURL !== 'function') return '';
   try {
     const url = cv.toDataURL('image/png');
@@ -438,12 +477,17 @@ export function createSpiralSession(opts = {}) {
         if (baked === null) baked = bakeSpiralImage(rolled.params, size);
         return baked;
       },
+      /** Has this variant's still been baked yet? ('' counts — a host that
+       *  cannot bake has ANSWERED, and asking it again would answer the same.)
+       *  warmSpiralStills' progress, and the self-test's pin on it. */
+      isBaked: () => baked !== null,
     });
   }
 
   let order = shuffled(variants.map((_v, i) => i), r);
   let at = 0;
   let last = -1;
+  let picks = 0;
 
   function next() {
     if (at >= order.length) {
@@ -453,6 +497,7 @@ export function createSpiralSession(opts = {}) {
       at = 0;
     }
     last = order[at++];
+    picks++;
     return variants[last];
   }
 
@@ -463,7 +508,89 @@ export function createSpiralSession(opts = {}) {
     next,
     /** Any variant, no rotation state touched — the bubble-pop flick's pick. */
     any: () => variants[Math.min(variants.length - 1, (r() * variants.length) | 0)],
+    /** How many variants have a resolved bake — warmSpiralStills' progress. */
+    bakedCount: () => variants.reduce((n2, v) => n2 + (v.isBaked() ? 1 : 0), 0),
+    /** How many times next() has handed one out. This is a COUNTER, not
+     *  bookkeeping the rotation needs: exec/spiral.js used to roll TWICE for one
+     *  fresh pane (ensurePane repicks, then the cue repicked again on top), and
+     *  test/selftest-exec.js pins that it now rolls once. A repick is not free
+     *  — it is a variant swap, a redraw and, before the warm, a raster bake. */
+    picked: () => picks,
   };
+}
+
+/* ---------------------------------------------------------------------------
+ * THE WARM — every bake, off the hot path.
+ *
+ * THE BUG THIS EXISTS FOR (iPhone 13 Pro Max, r8-20260805): a spiral payload
+ * mounted its pane and then FROZE for a second or two before it started
+ * turning. Nothing was loading and nothing was awaiting — the main thread was
+ * baking, inside the cue, with the pane's own rAF loop queued behind it.
+ * exec/spiral.js scheduled that bake one tick after the cue landed (see the
+ * repick() banner there), which moves it out of the cue's call stack and into
+ * the cue's first FRAMES, which is worse: the pane is already on screen and
+ * visibly not moving.
+ *
+ * So the pool warms itself instead, ONE VARIANT PER IDLE SLICE. One per slice
+ * matters as much as the idleness does: five bakes back to back is one long
+ * task however idle the moment was, and a long task during a countdown is the
+ * countdown skipping.
+ *
+ * `requestIdleCallback` WITH A TIMEOUT, and a plain timer under it. The timeout
+ * is because a page that never goes idle would otherwise never warm at all, and
+ * a still that arrives late is still ahead of the cue that needs it. The
+ * fallback is not decoration either: WebKit was the last engine to ship
+ * requestIdleCallback, so "the phone in the bug report" is exactly the host most
+ * likely to be missing it. (node has neither, and every bake there is a no-op ''
+ * anyway.) `schedule` is injectable so the self-test can drive the walk step by
+ * step instead of racing timers.
+ * ------------------------------------------------------------------------ */
+
+/** How long an idle callback may be starved before it runs anyway. */
+export const WARM_IDLE_TIMEOUT_MS = 3000;
+/** Spacing on the no-requestIdleCallback fallback path. */
+export const WARM_GAP_MS = 150;
+
+function defaultWarmSchedule(fn) {
+  try {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(fn, { timeout: WARM_IDLE_TIMEOUT_MS });
+      return;
+    }
+  } catch (_e) { /* fall through to the timer */ }
+  try {
+    const t = setTimeout(fn, WARM_GAP_MS);
+    // unref'd: a warm walking its five must never be the reason node's loop
+    // (the self-tests') stays open.
+    if (t && typeof t.unref === 'function') t.unref();
+  } catch (_e) { /* a host with no timers simply never warms — every bake stays lazy */ }
+}
+
+/**
+ * Bake a pool's stills during idle time. Returns a CANCEL — a session that has
+ * been replaced must stop warming, or a page that opens two duels pays for the
+ * dead pool's pictures.
+ *
+ * @param {{session?: object, schedule?: (fn: () => void) => void}} [opts]
+ * @returns {() => void} cancel
+ */
+export function warmSpiralStills(opts = {}) {
+  const sess = (opts && opts.session) || spiralSession();
+  const schedule = (opts && typeof opts.schedule === 'function') ? opts.schedule : defaultWarmSchedule;
+  const list = sess.all();
+  let stopped = false;
+  let i = 0;
+  const stepOne = () => {
+    if (stopped || i >= list.length) return;
+    const v = list[i++];
+    // image() caches, including the '' a host that cannot bake answers with, so
+    // a second pass over an already-warm pool is free and a warm that overlaps
+    // a fallback's own ask cannot double-bake.
+    try { v.image(); } catch (_e) { /* an unbakeable variant is still a warmed one */ }
+    if (i < list.length) schedule(stepOne);
+  };
+  schedule(stepOne);
+  return () => { stopped = true; };
 }
 
 /* --- THE SHARED SESSION. exec/spiral.js (the bed) and exec/bubbles.js (the
@@ -472,6 +599,7 @@ export function createSpiralSession(opts = {}) {
    sweep costs nothing, and re-rolled by beginSpiralSession() when a new duel
    builds its executor. ----------------------------------------------------- */
 let session = null;
+let cancelWarm = null;
 
 /** The session pool, built on first ask. */
 export function spiralSession() {
@@ -479,10 +607,24 @@ export function spiralSession() {
   return session;
 }
 
-/** Roll a fresh set for a new match. Called once, from createSpiral(). */
+/**
+ * Roll a fresh set for a new match. Called once, from createSpiral().
+ *
+ * Any warm still walking the OLD pool is cancelled here: those five stills are
+ * about to be unreachable, and paying for a picture nobody can ask for again is
+ * exactly the main-thread time this whole path was built to stop spending.
+ */
 export function beginSpiralSession(opts) {
+  if (cancelWarm) { try { cancelWarm(); } catch (_e) { /* ignore */ } cancelWarm = null; }
   session = createSpiralSession(opts || {});
   return session;
+}
+
+/** Arm the idle warm for the shared pool. exec/spiral.js calls this at build. */
+export function warmSharedSpirals(opts) {
+  if (cancelWarm) { try { cancelWarm(); } catch (_e) { /* ignore */ } }
+  cancelWarm = warmSpiralStills(Object.assign({ session: spiralSession() }, opts || {}));
+  return cancelWarm;
 }
 
 /** The next spiral in the session's rotation. */

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -621,6 +621,44 @@ async function main() {
     ok(strays === 0, 'nextSpiral() only ever draws from the shared session', String(strays));
     ok(spiralGen.pickSpiralImage() === '',
       'and pickSpiralImage() (exec/bubbles.js‘s flick) goes through the same pool');
+
+    /* --- THE IDLE WARM (2026-08-05, the iPhone spiral stutter).
+     *
+     * The pool's stills used to be baked BY THE CUE THAT NEEDED ONE — ~1600
+     * path fills plus a PNG encode, on the main thread, one tick after a spiral
+     * landed, which on a phone is a bed that mounts and then holds still for a
+     * second or two. warmSpiralStills walks the pool during idle time instead.
+     * `schedule` is injected here so the walk is driven step by step: what is
+     * pinned is that NOTHING bakes synchronously and that a slice bakes exactly
+     * ONE variant (five in a row is one long task however idle the moment was).
+     * On this host every bake resolves to the '' it can only answer — which is
+     * the point of isBaked(): the pool tracks that it ASKED. ----------------- */
+    const warmPool = spiralGen.createSpiralSession({ rng: seeded(11) });
+    ok(warmPool.bakedCount() === 0, 'a fresh pool has baked nothing at all — every still starts lazy',
+      String(warmPool.bakedCount()));
+    const slices = [];
+    const stopWarm = spiralGen.warmSpiralStills({ session: warmPool, schedule: (fn) => slices.push(fn) });
+    ok(slices.length === 1 && warmPool.bakedCount() === 0,
+      'warmSpiralStills bakes NOTHING on the caller‘s stack — it queues one slice and returns',
+      `${slices.length} queued / ${warmPool.bakedCount()} baked`);
+    slices.shift()();
+    ok(warmPool.bakedCount() === 1, 'and one slice bakes exactly ONE variant, never the whole pool',
+      String(warmPool.bakedCount()));
+    let spins2 = 0;
+    while (slices.length && spins2++ < 50) slices.shift()();
+    ok(warmPool.bakedCount() === warmPool.count && slices.length === 0,
+      'the walk finishes the pool and then stops asking for slices',
+      `${warmPool.bakedCount()}/${warmPool.count}, ${slices.length} queued`);
+    stopWarm();
+    // CANCEL IS NOT DECORATION: beginSpiralSession() calls it, and a warm that
+    // kept walking a replaced pool would pay for five pictures nobody can ask
+    // for again — on the phone this whole path exists to spare.
+    const dropped = spiralGen.createSpiralSession({ rng: seeded(12) });
+    const dropQ = [];
+    spiralGen.warmSpiralStills({ session: dropped, schedule: (fn) => dropQ.push(fn) })();
+    while (dropQ.length && spins2++ < 50) dropQ.shift()();
+    ok(dropped.bakedCount() === 0, 'a cancelled warm bakes nothing, even if its slice still runs',
+      String(dropped.bakedCount()));
   }
 
   // ------------------------------------------------------------ spiral renders
@@ -629,12 +667,25 @@ async function main() {
     const ex = createExecutor({ media: fakeMedia(), layers, logger: quiet, toyBridge: null });
     const m = fakeMatch();
     ex.attach(m);
+    // The pool THIS executor rolled (createSpiral -> beginSpiralSession). Its
+    // pick counter is how the one-roll-per-cue rule below is pinned.
+    const pool = spiralGen.spiralSession();
+    const picksAtAttach = pool.picked();
 
     m.emitPayload({
       payload: payloadOf({ id: 'pSp', kind: GoonPayloadKind.Spiral, duration_ms: 1000, intensity: 0.9 }),
       fireAtLocalMs: localMonotonicMs(),
     });
     await sleep(120);
+    /* ONE ROLL PER CUE (2026-08-05, the iPhone spiral stutter). A payload on a
+     * FRESH pane used to roll twice — ensurePane() repicks for the pane it
+     * mints, then renderPayload repicked again on top — which threw away the
+     * frame the weave had just drawn and, before the still moved off the woven
+     * path, queued a SECOND 1280px raster bake behind the first, both landing on
+     * the main thread inside the cue's own fade. */
+    ok(pool.picked() - picksAtAttach === 1,
+      'a spiral payload on a fresh pane rolls ONE variant, not two',
+      String(pool.picked() - picksAtAttach));
     const panes = byId.get('gg-fx-spiral').findAll('gg-spiral');
     ok(panes.length === 1, 'spiral payload mounts exactly one pane', String(panes.length));
     // NO background-image on this host: the stub has no 2D canvas, so the bake
@@ -658,6 +709,12 @@ async function main() {
     m.emitStart({ element: GoonElement.Spiral, intensity: 0.4, durationMs: 0, elapsedMs: 0 });
     ok(byId.get('gg-fx-spiral').findAll('gg-spiral').length === 1,
       'element + payload share one pane', String(byId.get('gg-fx-spiral').findAll('gg-spiral').length));
+    // …and the skip above is ONLY for a pane that just rolled its own. A cue
+    // landing on a bed that was already up is exactly when the picture should
+    // change, so it still repicks.
+    ok(pool.picked() - picksAtAttach === 2,
+      'a cue on a bed that was ALREADY UP does roll a new spiral',
+      String(pool.picked() - picksAtAttach));
 
     await sleep(1100);
     ok(m.receipts.length === 1 && m.receipts[0].endured === true,
@@ -4673,6 +4730,27 @@ async function main() {
     ok(SP.LITE_MAX_DPR < SP.MAX_DPR && SP.LITE_FRAME_MS >= 30,
       'the spiral halves both of its dials: CSS-pixel backing and a ~30fps draw cadence',
       `${SP.LITE_MAX_DPR}/${SP.LITE_FRAME_MS}`);
+    // The RASTER bake is a third lite dial (2026-08-05): both halves of its cost
+    // are quadratic in the edge, and on a phone the still it bakes is the
+    // fallback for a live bed that already only draws at LITE_MAX_DPR.
+    ok(spiralGen.LITE_RASTER_PX < spiralGen.RASTER_PX,
+      'and it bakes its fallback still smaller on lite than on full',
+      `${spiralGen.LITE_RASTER_PX}/${spiralGen.RASTER_PX}`);
+
+    /* ---- THE LITE DRAW THROTTLE'S STARTUP EDGE (dueForDraw).
+     * rAF timestamps are a PAGE-lifetime clock shared with the pane that just
+     * died, so "have 33ms passed since the last draw" is the wrong question for
+     * the first frame of a new weave: a bed mounting inside 33ms of the last
+     * one's final frame would open by SKIPPING. weave() zeroes lastDraw and 0
+     * always draws. */
+    ok(SP.dueForDraw(1000, 0, false) === true && SP.dueForDraw(1000, 999, false) === true,
+      'the full tier never skips a draw — the throttle is lite-only, and desktop is byte-identical');
+    ok(SP.dueForDraw(1000, 0, true) === true,
+      'a lite bed ALWAYS draws the first loop frame of a weave, whatever the clock says');
+    ok(SP.dueForDraw(1000, 999, true) === false,
+      'a draw one millisecond ago is skipped — which is exactly why lastDraw is zeroed per weave');
+    ok(SP.dueForDraw(1000, 1000 - SP.LITE_FRAME_MS, true) === true,
+      `and the gate opens again at LITE_FRAME_MS (${SP.LITE_FRAME_MS}ms)`);
 
     // ---- the decision table, pure
     ok(PT.detectPerfTier({ coarse: false, viewportMinPx: 400, deviceMemoryGb: 2 }) === PT.PERF_FULL,


### PR DESCRIPTION
## The bug

Owner play-test, iPhone 13 Pro Max, build r8-20260805: **a spiral payload fires, the spiral appears, and then it is stuck for a second or two before it starts animating normally.**

## Root cause (measured, not inferred)

Nothing is loading and nothing is awaiting. The main thread is **baking**.

I ran the renderer on a throwaway harness that provides *both* a fake GPU and a fake 2D context — a combination no existing self-test block has — and counted `toDataURL` calls. One spiral payload landing on a fresh pane, pre-fix:

```
after payload: woven? true
  bg while woven: "url(data:image/png;base64,HARNESS)"
  encodes while woven: 2        <- two full 1280px bakes, inside the cue
```

Each of those is ~1600 antialiased canvas path fills plus a PNG encode of a 6.5MB backing store (`exec/spiralGen.js:314 drawSpiralRaster`, `:390 bakeSpiralImage`), on the main thread, one `setTimeout(0)` after the cue landed — i.e. squarely inside the pane's first frames, with its own `requestAnimationFrame` loop queued behind them. The pane is on screen, the CSS fade runs on the compositor, and the canvas holds frame 0. That is the freeze, exactly as described.

Two of them, because a fresh pane rolled **twice**:

- `exec/spiral.js:208 ensurePane()` calls `repick()` for the pane it mints (and `weave()` draws that variant's first frame);
- `exec/spiral.js:636 renderPayload()` (and `start()`) then called `repick()` again on top — a second variant, a second bake, and the weave's first frame thrown away.

And on the woven path **every one of those bakes is invisible**: the WebGL context is `alpha: false`, so the canvas sitting over the pane is opaque. The picture was being encoded, decoded and uploaded for a layer no player can see.

Provenance: a **PR #122 regression**. Before the generator, `repick()` was `background-image: url(<bundled sp*.gif>)` (`7ec15786:exec/spiral.js:497`) and cost nothing, so the double call was harmless. PR #129's lite tier reduced the shader cost and never touched this.

## The fix

| | |
|---|---|
| **One roll per cue** | A pane `ensurePane()` just minted keeps the variant it already rolled and wove. A bed that was **already up** still repicks — that is the case the second call was ever for. |
| **The still is painted when the pane lands on raster, not before** | The deferred bake bails if the weave took; `unweave()` — the one door every fallback comes through (lost context, polled stall, kill switch, a render that threw) — paints it on the way down, *before* the dead canvas is dropped. The guarantee is unchanged; only the timing moved. |
| **Warmed at build** | `spiralGen.warmSpiralStills()` walks the pool **one variant per `requestIdleCallback` slice** (timer fallback — WebKit shipped rIC last, so the phone in the bug report is the host most likely to lack it). Armed from `createSpiral`, which `boot.js#buildApp` runs *before the first screen*, so the whole title/lobby/countdown stretch is available. This also fixes `exec/bubbles.js:661`, where a popped spiral bubble baked on the main thread mid-pop. |
| **`LITE_RASTER_PX = 640`** | Both halves of a bake are quadratic in the edge. On a phone the still is the fallback for a bed already drawing at `LITE_MAX_DPR = 1` (428 backing pixels on a 13 Pro Max), so 640 is *more* detail than the live path, at a quarter of the cost. |
| **The lite throttle's startup edge** | Closed rather than found: rAF timestamps are a page-lifetime clock, so a bed mounting within 33ms of the previous pane's last frame would open by *skipping*. `weave()` zeroes `lastDraw`, and the new pure `dueForDraw()` always draws frame 0. The first frame of a weave no longer runs the once-a-second driver poll either (a synchronous GPU round-trip in the busiest millisecond of the pane's life). |
| **Scratch-canvas hardening** | `spiralGen` cached its scratch canvas *before* checking that a 2D context came back, so a host that answers `getContext('2d')` with null had its dud canvas remembered for the life of the page. Canvas and context are now taken and cached together. |

Post-fix, same harness, same cue:

```
after payload: picked 1 (was 0-indexed 2 rolls)   woven? true
  bg while woven: ""            <- nothing baked, nothing decoded
  encodes while woven: 0
after context loss: encodes 1   <- the parachute, baked on the way down
after idle:        baked 5 of 5 <- the warm, off every hot path
```

## What was ruled out

- **A frame-timing bug in the lite 30fps step.** There isn't one: the phase advances by real elapsed time and `lastDraw` starts at 0, which passes the gate. The only edge (a stale `lastDraw` inherited across panes) can cost at most one 33ms frame — hardened anyway, above.
- **An `await`/idle deferral leaving the node mounted but static.** The payload path is entirely synchronous; the only deferrals are `setTimeout(…, 0)` (the bake — the culprit) and `setTimeout(…, 16)` (the `is-on` class).
- **Lazy pool generation.** `beginSpiralSession()` only rolls parameters — five `rollSpiral` calls, each solving 15 candidates through `revolutionSecFor`. Microseconds, and it happens at app build, not on a cue.
- **Shader compile / context creation per pane** (the pane is torn down between payloads, so each one builds a fresh context and program). Real, but ~50-150ms against the ~1s of baking, and killing it means holding a GPU context across the whole match or stealing a canvas mid-fade. Left alone deliberately; worth revisiting only if the phone still hitches.

## Desktop safety

Untouched by construction: `dueForDraw` is unconditional on the full tier, the bake size is unchanged there, and both tiers draw the same roll at the same solved revolution. The spiral's look and tempo do not change once running.

## Tests

`node test/selftest-exec.js` — **993 checks green** (+12 new): the one-roll rule pinned through a new pick counter on the pool, the warm's step-by-step walk and its cancel, `dueForDraw`'s full table including the startup edge, and the lite bake size. Every other goon suite re-run and unchanged; `selftest-avafx` keeps its 12 pre-existing failures.

## How to verify on a real phone

1. Open `cclabs.app/goon-beta` on the iPhone, join or host a duel, and confirm the options drawer shows the perf mode on **auto/lite**.
2. Take a spiral payload. It should start turning **on the frame it appears** — no held first frame.
3. Fire several in a row (the pool is five variants, so pre-fix the freeze recurred until each had been baked once); every one should come up moving.
4. Pop a **spiral bubble**: the pink wash it throws used to bake a still on the spot. Same test — no hitch.
5. Regression check on the fallback: switch **shader spirals off** in the options drawer mid-match. The bed must keep spinning as a still image (CSS keyframe, same 10-18s revolution), not go blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
