### PR TITLE
perf(goon): mobile pass 2 - animated-gif budget, tempo-only lite bursts, cross-effect load governor

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/exec/brainDrain.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/brainDrain.js
@@ -19,8 +19,23 @@
  * the running one and puts it back afterwards — and the element and the payload
  * share it through a small dial stack.
  *
+ * THE LITE TIER'S SHARE (2026-08-05, second mobile pass). PR #129 already took
+ * the backdrop-filter away on phones (fx.css); what was LEFT per-frame here was
+ * the WASH ITSELF whenever the pool dealt an animated GIF — a fullscreen,
+ * cover-sized animation repainting behind a two-layer blend stack for 7-11s at
+ * a time, which on an iPhone is a spiral-sized cost hiding in a "static" veil.
+ * So on lite the wash PREFERS A STILL (media.js drawStillImage — a preference,
+ * never a filter: an all-GIF library still gets its GIF), and the slow re-pick
+ * holds its current image while the load governor says a payload squall is on
+ * (exec/loadGovernor.js) — a burst is the worst possible moment to hand the
+ * compositor a fresh fullscreen decode. The full tier calls neither.
+ *
  * Uniform renderer shape — see the banner in exec/flashes.js.
  * ==========================================================================*/
+
+import { perfLite } from './perfTier.js';
+import { drawStillImage } from './media.js';
+import { governorBusy } from './loadGovernor.js';
 
 const WASH_MIN_MS = 7000;    // how long one washed image holds before a re-pick
 const WASH_MAX_MS = 11000;
@@ -68,7 +83,10 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
   /** Wash one image from the player's pool over the veil (no pool = plain dim). */
   function repickWash() {
     if (!veilEl || !media || typeof media.drawKind !== 'function') return;
-    const entry = media.drawKind('image');
+    // LITE: prefer a still — a fullscreen animated wash is the one per-frame
+    // cost this veil has left on a phone (see the banner). Full tier: the
+    // exact draw it has always made.
+    const entry = perfLite() ? drawStillImage(media) : media.drawKind('image');
     if (!entry) return;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     if (!handle || !handle.url) return;
@@ -85,7 +103,12 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
     try { clearTimeout(washTimer); } catch (_e) { /* ignore */ }
     washTimer = soon(() => {
       if (!veilEl) return;
-      repickWash();
+      // A lite-tier payload squall holds the CURRENT wash: skipping one slow
+      // re-pick is invisible (the image was going to sit for 7-11s anyway),
+      // and a fresh fullscreen decode mid-burst is not. governorBusy() is
+      // false everywhere but a lite tier inside a hold, so the full tier's
+      // cadence is untouched. The next tick re-picks as normal.
+      if (!governorBusy()) repickWash();
       scheduleWash();
     }, Math.round(rand(WASH_MIN_MS, WASH_MAX_MS)));
   }

--- a/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
@@ -68,6 +68,8 @@
 // spirals this match has been showing, because it is one of them.
 import { pickSpiralImage } from './spiralGen.js';
 import { perfLite } from './perfTier.js';
+// The lite tier's still-preferred image draw — see drawImage() below.
+import { drawStillImage } from './media.js';
 
 export const MAX_LIVE = 26;   // hard ceiling on bubble nodes, swarm included
 /* The LITE ceiling (exec/perfTier.js — phones). Bites in refresh(), on top of
@@ -586,10 +588,14 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
     }
   }
 
-  /** An image handle from the player's own pool (null when the pool has none). */
+  /** An image handle from the player's own pool (null when the pool has none).
+   *  LITE prefers a STILL (media.js drawStillImage — a preference, never a
+   *  filter): a pop's flick and the drain hold both fire at the busiest moment
+   *  a phone has, and an animated GIF is a decode loop where a still is a
+   *  texture. Full tier: the exact draw it has always made. */
   function drawImage() {
     if (!media || typeof media.drawKind !== 'function') return null;
-    const entry = media.drawKind('image');
+    const entry = perfLite() ? drawStillImage(media) : media.drawKind('image');
     if (!entry) return null;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     return (handle && handle.url) ? handle : null;

--- a/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
@@ -92,6 +92,8 @@ import {
   viewportCap, pxToVmin, safeInsets,
 } from './pinch.js';
 import { perfLite } from './perfTier.js';
+import { isAnimatedMedia } from './media.js';
+import { governorHold } from './loadGovernor.js';
 
 export const MAX_LIVE = 20;          // concurrent <img> nodes, hydra children included
 /* The LITE tier's cap (exec/perfTier.js — phones). Half the field: each flash is
@@ -100,6 +102,25 @@ export const MAX_LIVE = 20;          // concurrent <img> nodes, hydra children i
  * build, so the options toggle reaches a burst already in flight — a tightened
  * cap simply stops admitting nodes and the live ones age out on their own. */
 export const MAX_LIVE_LITE = 10;
+/* THE ANIMATION BUDGET (lite only — 2026-08-05, second mobile pass). The node
+ * cap above treats a static JPEG and an animated GIF as the same spend, and
+ * they are not even close: an <img> playing a GIF is a CPU decode loop that
+ * runs for the flash's whole life, and a burst of peer media is USUALLY GIFs —
+ * ten at once is exactly the "everything overloads" moment the owner
+ * play-tested. So on lite at most this many flashes may be PLAYING an animated
+ * file at once (isAnimatedMedia decides what counts, generously). Overflow
+ * flashes still land — frozen on their first frame via a one-frame canvas bake
+ * (`animation-play-state` cannot pause a GIF; only not-being-a-GIF can) — so a
+ * burst keeps its density while paying for three decode loops, not ten. A host
+ * that cannot bake (no Image, no 2d context) SKIPS the overflow flash instead:
+ * a skipped beat is the cap's own precedent, and rendering the animation
+ * anyway would be the budget lying. */
+export const ANIM_LIVE_LITE = 3;
+/* The frozen frame's longest side, in backing pixels. A flash tops out at
+ * ~44vmin (<=430px CSS on any phone this tier targets), so 512 is already
+ * oversampled — decoding a 4K GIF's first frame into a 4K canvas would spend
+ * the very memory the freeze is here to save. */
+export const FROZEN_MAX_PX = 512;
 export const HYDRA_CHILDREN = 2;     // what one click hatches (clamped to the cap)
 export const BASE_HOLD_MS = 5000;    // on-screen time a flash is centred on
 const HOLD_SPREAD_MS = 400;          // ± this across the intensity range (4600..5400)
@@ -110,6 +131,17 @@ const HATCH_MS = [70, 210];          // children hatch staggered, never on one f
  * MIRRORS net/mediaChannel.js XFER_TAGS_MAX and is kept local on purpose — exec/
  * never imports net/, so the render tier stays independent of the wire tier. */
 export const XFER_TAGS_MAX = 3;
+
+/* BURST DENSITY, PER TIER (renderPayload). The full tier's burst halves the
+ * beat gap AND adds a flash per beat — density by tempo and by node count at
+ * once. On LITE only the tempo survives: the gap tightens less (0.72 vs 0.5)
+ * and the per-beat count stays the bed's own, because on a phone every extra
+ * node is another decode landing inside the squall's own frames. The burst
+ * still reads as a burst — beats arrive ~40% faster than the bed's — but the
+ * standing population climbs at roughly half the full-tier rate, which is the
+ * churn the play-test was drowning in. */
+export const BURST_GAP_SCALE = 0.5;
+export const BURST_GAP_SCALE_LITE = 0.72;
 
 /** The `xfer:` tags off a payload, cleaned and capped. [] for every other payload. */
 function xferTags(payload) {
@@ -729,6 +761,62 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
     try { rec.node.style.setProperty('--gg-flash-size', `${next.toFixed(1)}vmin`); } catch (_e) { /* ignore */ }
   }
 
+  /* =========================================================================
+   * THE ANIMATION BUDGET's moving parts (lite only — see ANIM_LIVE_LITE).
+   * ======================================================================= */
+
+  /** Live flashes currently PLAYING an animated file. Counted off the live
+   *  set, not tracked as a counter, so a node the layer tore out from under us
+   *  (prune) can never leave a phantom charge against the budget. */
+  function countAnimPlaying() {
+    let k = 0;
+    for (const rec of live) { if (rec.animPlaying) k++; }
+    return k;
+  }
+
+  /** A canvas ready to wear frame 0, or null when this host cannot freeze one
+   *  (no 2d context, no Image constructor) — the caller then SKIPS the flash. */
+  function frozenCanvas() {
+    if (typeof Image !== 'function') return null;
+    let cv = null;
+    try { cv = document.createElement('canvas'); } catch (_e) { return null; }
+    if (!cv || typeof cv.getContext !== 'function') return null;
+    let ctx = null;
+    try { ctx = cv.getContext('2d'); } catch (_e) { return null; }
+    if (!ctx || typeof ctx.drawImage !== 'function') return null;
+    return cv;
+  }
+
+  /**
+   * Decode ONE frame of `url` into the canvas. The probe <img> never enters
+   * the DOM, so the browser decodes the first frame for the draw and nothing
+   * ever asks it to advance — that asymmetry is the entire saving. Drawing a
+   * cross-origin frame TAINTS the canvas, which is fine: nothing here reads
+   * pixels back, it only shows them. Every failure lands on rec.kill(), the
+   * same road a dud <img> src takes (a skipped flash, never a throw).
+   */
+  function paintFrameZero(cv, url, rec) {
+    let probe = null;
+    try { probe = new Image(); } catch (_e) { rec.kill(); return; }
+    probe.onload = () => {
+      if (rec.popped || !cv.isConnected) return;   // it died while decoding
+      const w = (probe.naturalWidth | 0) || (probe.width | 0);
+      const h = (probe.naturalHeight | 0) || (probe.height | 0);
+      if (!w || !h) { rec.kill(); return; }
+      const k = Math.min(1, FROZEN_MAX_PX / Math.max(w, h));
+      try {
+        cv.width = Math.max(1, Math.round(w * k));
+        cv.height = Math.max(1, Math.round(h * k));
+        cv.getContext('2d').drawImage(probe, 0, 0, cv.width, cv.height);
+      } catch (_e) { rec.kill(); return; }
+      // Let the decoder drop the animation it was holding for the probe.
+      try { probe.src = ''; } catch (_e) { /* ignore */ }
+    };
+    probe.onerror = () => rec.kill();
+    try { probe.decoding = 'async'; } catch (_e) { /* ignore */ }
+    try { probe.src = url; } catch (_e) { rec.kill(); }
+  }
+
   /** Where a flash lands. `near` (a parent's vw/vh) makes it a hydra child:
    *  pushed radially off the parent so the split reads as a split, then boxed
    *  back into the scatter area so nothing hatches off-screen. */
@@ -783,12 +871,29 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
     const sizeVmin = (opts && num(opts.size, 0) > 0) ? opts.size : BASE_SIZE_VMIN;
     const rot = (Math.random() * 16 - 8).toFixed(1);
 
-    const img = document.createElement('img');
+    // THE ANIMATION BUDGET (lite only — see ANIM_LIVE_LITE at the top). The
+    // sniff runs only under lite, so the full tier does not even classify:
+    // its spawn path is byte-identical to the pre-budget one. Over budget, the
+    // flash lands FROZEN (a frame-0 canvas instead of an <img>); a host that
+    // cannot freeze skips it, which is what the cap already does when full.
+    const animated = perfLite() && isAnimatedMedia(entry);
+    const mustFreeze = animated && countAnimPlaying() >= ANIM_LIVE_LITE;
+
+    let img;
+    if (mustFreeze) {
+      img = frozenCanvas();
+      if (!img) {
+        try { if (handle.release) handle.release(); } catch (_e) { /* ignore */ }
+        return;                                    // a skipped beat, never a flood
+      }
+    } else {
+      img = document.createElement('img');
+      img.decoding = 'async';
+      img.alt = '';
+    }
     // --hydra is the pointer opt-in (fx.css). bubbles.js's pop flashes are plain
     // .gg-flash on purpose and stay click-through.
     img.className = gen > 0 ? 'gg-flash gg-flash--hydra gg-flash--hatch' : 'gg-flash gg-flash--hydra';
-    img.decoding = 'async';
-    img.alt = '';
     img.style.setProperty('--gg-flash-dur', `${tune.holdMs}ms`);
     img.style.setProperty('--gg-flash-op', String(tune.opacity));
     // scatter across the window like the WPF floating flashes (never dead-centre)
@@ -811,6 +916,9 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
       held: false, fly: null,                 // in hand / gliding on a fling
       bornAt: nowMs(), holdMs: tune.holdMs, remainMs: tune.holdMs,
       safety: 0, expTimer: 0,
+      // Charged against ANIM_LIVE_LITE while this rec is live. A frozen flash
+      // is animated MEDIA but not an animated NODE, so it charges nothing.
+      animPlaying: animated && !mustFreeze,
     };
     live.add(rec);
 
@@ -833,11 +941,18 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
     // Fires for whichever animation is running — the timed fade, or the pop-out
     // that replaces it on a click.
     img.addEventListener('animationend', kill, { once: true });
-    img.onerror = kill;                       // a dud entry is a skipped beat, never a throw
     // The press: a click (hydra, on pointerUP) or a grab, decided by the slop.
     img.addEventListener('pointerdown', (e) => onPointerDown(rec, e));
-    img.src = handle.url;
-    host.appendChild(img);
+    if (mustFreeze) {
+      // The canvas cannot error and carries no src; the PROBE inside
+      // paintFrameZero owns both, and its failures land on the same kill.
+      host.appendChild(img);
+      paintFrameZero(img, handle.url, rec);
+    } else {
+      img.onerror = kill;                     // a dud entry is a skipped beat, never a throw
+      img.src = handle.url;
+      host.appendChild(img);
+    }
     // Safety net: a throttled/hidden tab (and prefers-reduced-motion, which has no
     // animation at all) may never deliver animationend, and a leaked node is a
     // leak for the rest of the match. The FIRST grab cancels this and hands the
@@ -983,11 +1098,17 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
         // nothing was ever received — the fallback is unchanged there).
         peer: true,
       };
+      // Tell the ambient renderers (spiral bed, drain wash) a squall is on:
+      // on lite they volunteer frames for its duration. Held unconditionally,
+      // read behind perfLite() — see exec/loadGovernor.js for why both.
+      const releaseGovernor = governorHold(runMs);
+
       let finished = false;
       const settle = (endured) => {
         if (finished) return;
         finished = true;
         run.alive = false;
+        try { releaseGovernor(); } catch (_e) { /* ignore */ }
         try { clearTimeout(run.timer); } catch (_e) { /* ignore */ }
         try { clearTimeout(run.endTimer); } catch (_e) { /* ignore */ }
         if (typeof done === 'function') { try { done(endured); } catch (e) { warn(`done() threw: ${e && e.message}`); } }
@@ -996,8 +1117,14 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
       const burstLoop = () => {
         if (!run.alive) return;
         const tune = flashTuning(run.intensity, calm);
-        tune.gapMs = Math.round(tune.gapMs * 0.5);
-        tune.count = Math.min(3, tune.count + 1);
+        // Tier split — see BURST_GAP_SCALE/_LITE: on lite the burst is a burst
+        // by TEMPO only. Read per beat, so the mid-match toggle bites.
+        if (perfLite()) {
+          tune.gapMs = Math.round(tune.gapMs * BURST_GAP_SCALE_LITE);
+        } else {
+          tune.gapMs = Math.round(tune.gapMs * BURST_GAP_SCALE);
+          tune.count = Math.min(3, tune.count + 1);
+        }
         beat(tune, run);
         run.timer = soon(burstLoop, rand(tune.gapMs * 0.7, tune.gapMs * 1.3));
       };

--- a/ConditioningControlPanel/Resources/web/goon/exec/fx.css
+++ b/ConditioningControlPanel/Resources/web/goon/exec/fx.css
@@ -963,3 +963,24 @@ html[data-gg-perf="lite"] .gg-vwin-inner {
 html[data-gg-perf="lite"] .gg-vwin-inner::after {
   box-shadow: inset 0 0 14px rgba(var(--gg-pink-rgb), 0.3);
 }
+
+/* PASS 2 (2026-08-05) — the per-frame FILTER loops the first pass left behind.
+ *
+ * · the GLITCH SHUDDER. ggDrainGlitch hue-rotates and saturates a FULLSCREEN
+ *   pane 12.5 times a second for up to 4s — a repeated whole-screen filter
+ *   raster, which is backdrop-filter's little sibling and lands at the same
+ *   moment the pop economy is already busy. The lite tier swaps the NAME to a
+ *   transform-only twin (the longhand outranks the shorthand's name at this
+ *   specificity), so the shudder keeps its exact timing, steps and hard cap —
+ *   it just shakes without recolouring. The full-tier keyframes are untouched.
+ * · the BOUNCE HIT pop. Each wall hit animates brightness + a drop-shadow on
+ *   a text node — an offscreen filter pass per bounce, forever, for a garnish.
+ *   The word still travels (the rAF loop is not an animation); only the flash
+ *   on impact goes. */
+html[data-gg-perf="lite"] .gg-drain.is-glitching { animation-name: ggDrainGlitchLite; }
+@keyframes ggDrainGlitchLite {
+  0%   { transform: translate(0, 0); }
+  50%  { transform: translate(-1.2%, 0); }
+  100% { transform: translate(1.2%, 0); }
+}
+html[data-gg-perf="lite"] .gg-bounce-word.is-hit { animation: none; }

--- a/ConditioningControlPanel/Resources/web/goon/exec/loadGovernor.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/loadGovernor.js
@@ -1,0 +1,91 @@
+/* ============================================================================
+ * exec/loadGovernor.js — THE CROSS-EFFECT LOAD GOVERNOR (lite tier only).
+ *
+ * WHY THIS EXISTS (2026-08-05, second mobile pass). PR #129's tier cut every
+ * renderer's own budget, and the iPhone still buried itself at one specific
+ * moment: a FLASH BURST landing on top of a running spiral bed and drain veil.
+ * Each renderer was inside its own budget; the SUM was not — ten animated
+ * images decoding, a WebGL pane filling the screen at 30fps and a fullscreen
+ * blend stack all repainting in the same frames. One thing at full quality
+ * beats three things at 5fps, so while a burst is on screen the AMBIENT
+ * renderers volunteer a further step down, and take it back the moment the
+ * squall passes.
+ *
+ * THE SHAPE: a hold. The renderer that is about to spend the frames (the
+ * flash burst today; anything payload-shaped tomorrow) declares "I am the loud
+ * one for the next N ms" via governorHold(ms) and gets back a release. The
+ * ambient renderers ask one boolean, governorBusy(), from inside loops they
+ * already run — nobody subscribes to anything, nobody imports anybody's
+ * renderer, and a governor that nobody consults costs nothing.
+ *
+ * SELF-RESTORING BY CONSTRUCTION, twice over, because a degradation that can
+ * stick is worse than the lag it prevents:
+ *   · every hold carries a DEADLINE (capped at GOVERNOR_HOLD_MAX_MS) and a
+ *     hold past its deadline reads as idle even if its release was lost to a
+ *     thrown callback — the worst possible leak costs ten seconds of coarser
+ *     spiral, not a match of it;
+ *   · the release is idempotent, so the settle/cancel double-call every
+ *     payload path can produce never underflows the count.
+ *
+ * FULL TIER IS EXEMPT AT THE READ, NOT THE WRITE. governorBusy() answers
+ * false unless the lite tier is in force RIGHT NOW (read lazily, same as every
+ * other tier dial), so a desktop's burst writes a timestamp nobody looks at
+ * and the full-tier picture stays byte-identical. Holding unconditionally
+ * keeps the caller free of tier logic — and means a mid-burst toggle to lite
+ * degrades the ambience immediately, which is exactly when it is wanted.
+ *
+ * Import-safe under node: no DOM at import, no timers at all — the deadline
+ * is compared, never scheduled.
+ * ==========================================================================*/
+
+import { perfLite } from './perfTier.js';
+
+/** The longest any single hold may claim. A burst is 3-8s by contract
+ *  (exec/flashes.js renderPayload clamps it); anything asking for more is
+ *  getting the cap, because "temporarily" is the entire deal here. */
+export const GOVERNOR_HOLD_MAX_MS = 10000;
+
+let holders = 0;     // live (un-released) holds
+let deadline = 0;    // latest expiry among them, in nowMs() time
+
+const nowMs = () => {
+  try { if (typeof performance === 'object' && performance && typeof performance.now === 'function') return performance.now(); }
+  catch (_e) { /* fall through */ }
+  return Date.now();
+};
+
+/**
+ * Declare a burst of load for the next `ms` (clamped to the cap).
+ * @returns {() => void} release — idempotent; call it when the burst settles.
+ */
+export function governorHold(ms) {
+  const dur = Math.max(0, Math.min(GOVERNOR_HOLD_MAX_MS, ms | 0));
+  holders++;
+  deadline = Math.max(deadline, nowMs() + dur);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    holders = Math.max(0, holders - 1);
+    if (holders === 0) deadline = 0;
+  };
+}
+
+/**
+ * Should an ambient renderer step down RIGHT NOW? True only when (a) at least
+ * one hold is live, (b) its deadline has not passed, and (c) the lite tier is
+ * in force — a full-tier machine renders everything at once on purpose.
+ */
+export function governorBusy() {
+  if (holders === 0) return false;
+  if (nowMs() >= deadline) {
+    // A hold that outlived its own deadline is a leak (a release lost to a
+    // throw); heal it here rather than letting it gate the spiral forever.
+    holders = 0;
+    deadline = 0;
+    return false;
+  }
+  return perfLite();
+}
+
+export default governorBusy;

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -60,6 +60,59 @@ const NO_ECHO = 8; // a reshuffled deck avoids repeating the last N draws
 /** The one namespace `tags` carries for this feature. `tags` stays open for others. */
 export const XFER_TAG_PREFIX = 'xfer:';
 
+/* ---------------------------------------------------------------------------
+ * ANIMATED-OR-STILL, the classification the LITE tier budgets on (2026-08-05,
+ * second mobile pass). Ten static PNGs are ten textures; ten animated GIFs are
+ * ten CPU decode loops that never stop, and on an iPhone the difference IS the
+ * flash-burst lag. The sniff is deliberately GENEROUS — mime first (peer
+ * artifacts always carry one), then the extension of the name (a local pick
+ * keeps its filename even when its blob: URL has none), then of the URL (the
+ * host manifest's virtual-host paths). webp/apng may be still in truth, but a
+ * false positive costs one frame-0 freeze of an image that was not moving
+ * anyway — invisible — while a false negative is an unbudgeted animation, so
+ * ambiguity votes ANIMATED. Pure, exported for exec/flashes.js and the drain
+ * washes; the FULL tier never calls it.
+ * ------------------------------------------------------------------------- */
+const ANIMATED_MIME_RE = /^image\/(gif|webp|apng)\b/i;
+const ANIMATED_EXT_RE = /\.(gif|webp|apng)(?:[?#]|$)/i;
+
+/** Does this entry LOOK like an animated image? (see the banner above) */
+export function isAnimatedMedia(entry) {
+  if (!entry || typeof entry !== 'object') return false;
+  try {
+    if (ANIMATED_MIME_RE.test(String(entry.mime || ''))) return true;
+    if (ANIMATED_EXT_RE.test(String(entry.name || ''))) return true;
+    if (ANIMATED_EXT_RE.test(String(entry.url || ''))) return true;
+  } catch (_e) { return false; }
+  return false;
+}
+
+/** Redraws spent hunting a still before settling for what the deck holds. */
+export const STILL_DRAW_TRIES = 4;
+
+/**
+ * An image draw that PREFERS a still — the lite tier's version of "one more
+ * fullscreen animation is the last thing this phone needs". A PREFERENCE,
+ * never a filter (the footageFirst promise, again): an all-GIF library still
+ * gets its GIF, because a drain veil with no wash is a missing feature and a
+ * budget is not allowed to become one. Each retry is a real deck draw, so the
+ * echo guard keeps doing its job; STILL_DRAW_TRIES bounds the churn on a
+ * library that is mostly loops.
+ *
+ * Takes the POOL as an argument (not `this`) so any renderer holding an
+ * injected media object can call it without widening the pool interface.
+ */
+export function drawStillImage(pool) {
+  if (!pool || typeof pool.drawKind !== 'function') return null;
+  let entry = pool.drawKind('image');
+  for (let tries = 1; tries < STILL_DRAW_TRIES && entry && isAnimatedMedia(entry); tries++) {
+    const next = pool.drawKind('image');
+    if (!next) break;
+    entry = next;
+  }
+  return entry;
+}
+
 const SHA_RE = /^[0-9a-f]{64}$/;
 
 export function createGoonMediaPool() {

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
@@ -72,6 +72,7 @@
 import { createSpiralField, loopMsFor } from './spiralField.js';
 import { beginSpiralSession, nextSpiral } from './spiralGen.js';
 import { perfLite } from './perfTier.js';
+import { governorBusy } from './loadGovernor.js';
 
 /* --- THE SHADER KILL SWITCH. The pref is ui/prefs.js's (`shaderSpirals`,
    default TRUE); it reaches this tier as a ROOT ATTRIBUTE, because exec/ does not
@@ -101,6 +102,12 @@ export const MAX_BACKING_PX = 3840 * 2160;
    bed already spinning. ----------------------------------------------------- */
 export const LITE_MAX_DPR = 1;
 export const LITE_FRAME_MS = 33;   // ~30fps draw cadence on the lite tier
+/* …and the deeper step the bed volunteers WHILE A BURST IS ON (2026-08-05,
+   exec/loadGovernor.js): ~15fps for the squall's few seconds, because the
+   burst's decodes and the shader's fill land in the same frames and the phase
+   maths already makes a skipped draw cost pixels, never tempo. Self-restoring
+   by the governor's own deadline; the full tier never consults it. */
+export const LITE_BURST_FRAME_MS = 67;
 
 /* --- THE IN-LOOP WATCHDOG. Checked once per HEALTH_CHECK_MS, never per frame:
    gl.getError()/isContextLost() can force a sync round-trip to the driver, which
@@ -402,8 +409,10 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       // THE LITE THROTTLE. The PHASE above advanced by real elapsed time on
       // every callback, so skipping a draw skips pixels, never tempo — a
       // 30fps bed and a 120fps bed show the same rotation at the same second.
+      // While the load governor says a payload squall is on, the bed steps
+      // down further still (LITE_BURST_FRAME_MS) and climbs back by itself.
       // Full tier: no gate at all, byte-identical to the pre-tier loop.
-      if (!perfLite() || (now - lastDraw) >= LITE_FRAME_MS) {
+      if (!perfLite() || (now - lastDraw) >= (governorBusy() ? LITE_BURST_FRAME_MS : LITE_FRAME_MS)) {
         lastDraw = now;
         draw();
       }

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -4705,6 +4705,147 @@ async function main() {
     documentElement.removeAttribute(PT.PERF_ATTR);
   }
 
+  /* --------- SUSTAINED MOBILE LOAD, PASS 2 (2026-08-05)
+   * The tier's caps counted NODES; the second play-test showed the real cost is
+   * what a node DOES per frame — an animated GIF is a decode loop where a PNG
+   * is a texture, and a flash burst of peer GIFs buried the phone the caps had
+   * just saved. What is pinned here: the ANIMATION BUDGET (ANIM_LIVE_LITE and
+   * the sniff it trusts), the still-preferred draw the washes lean on, the
+   * lite burst's tempo-not-count dials, and the cross-effect load governor
+   * (lite-gated, deadline-expiring, self-healing).
+   * ------------------------------------------------------------------------ */
+  {
+    const PT = await import('../exec/perfTier.js');
+    const F = await import('../exec/flashes.js');
+    const SP = await import('../exec/spiral.js');
+    const M = await import('../exec/media.js');
+    const G = await import('../exec/loadGovernor.js');
+
+    // ---- the new dials, pinned
+    ok(F.ANIM_LIVE_LITE === 3 && F.ANIM_LIVE_LITE < F.MAX_LIVE_LITE,
+      'the animation budget is 3 concurrent PLAYING gifs, strictly inside the lite node cap',
+      `${F.ANIM_LIVE_LITE}/${F.MAX_LIVE_LITE}`);
+    ok(F.BURST_GAP_SCALE === 0.5 && F.BURST_GAP_SCALE_LITE === 0.72,
+      'the burst dials are the shipped pair (full halves the gap, lite tightens it to 0.72)',
+      `${F.BURST_GAP_SCALE}/${F.BURST_GAP_SCALE_LITE}`);
+    ok(F.BURST_GAP_SCALE_LITE > F.BURST_GAP_SCALE,
+      'and the lite burst is strictly SLOWER-spawning than the full one — density by tempo, not node count');
+    ok(SP.LITE_BURST_FRAME_MS > SP.LITE_FRAME_MS,
+      'the spiral steps down further while a burst is on than it does at lite idle',
+      `${SP.LITE_BURST_FRAME_MS} vs ${SP.LITE_FRAME_MS}`);
+    ok(G.GOVERNOR_HOLD_MAX_MS >= 8000,
+      'the governor cap covers the longest burst (8s) — a hold can never expire under its own payload',
+      String(G.GOVERNOR_HOLD_MAX_MS));
+
+    // ---- the animated-media sniff, pure. Generous by design: ambiguity votes
+    // ANIMATED, because freezing a still is invisible and playing a GIF is not.
+    ok(M.isAnimatedMedia({ mime: 'image/gif' }) === true, 'gif by mime is animated (peer artifacts always carry one)');
+    ok(M.isAnimatedMedia({ name: 'loop.WEBP', url: 'blob:x' }) === true,
+      'webp by NAME extension is animated — a local pick keeps its filename when its blob: URL has none');
+    ok(M.isAnimatedMedia({ url: 'https://ccp.assets/images/a.gif?v=1' }) === true,
+      'gif by URL extension is animated, query string and all (the host manifest path)');
+    ok(M.isAnimatedMedia({ mime: 'image/png', name: 'still.png', url: 'https://ccp.assets/images/still.png' }) === false,
+      'png/jpeg stay still — the budget must never charge a texture');
+    ok(M.isAnimatedMedia(null) === false && M.isAnimatedMedia({}) === false,
+      'null and fieldless entries read still: an unreadable signal must never spend the budget');
+
+    // ---- drawStillImage: a preference, never a filter
+    {
+      const deal = (seq) => {
+        let at = 0;
+        return { drawKind: () => ({ kind: 'image', name: seq[Math.min(at, seq.length - 1)], url: 'blob:' + (at++) }) };
+      };
+      const mixed = deal(['a.gif', 'b.gif', 'c.png', 'd.gif']);
+      const still = M.drawStillImage(mixed);
+      ok(still && still.name === 'c.png',
+        'drawStillImage redraws past the loops and settles on the still', still && still.name);
+      const loops = deal(['a.gif', 'b.gif', 'c.gif', 'd.gif', 'e.gif']);
+      const gif = M.drawStillImage(loops);
+      ok(!!gif && /\.gif$/.test(gif.name),
+        'an all-GIF library still gets its GIF — the preference is not allowed to become a missing wash',
+        gif && gif.name);
+      ok(M.drawStillImage(null) === null && M.drawStillImage({}) === null,
+        'and a poolless caller gets null, exactly like drawKind would');
+    }
+
+    // ---- the load governor: lite-gated at the READ, expiring, self-healing
+    ok(G.governorBusy() === false, 'the governor is idle until somebody holds it');
+    const rel = G.governorHold(5000);
+    ok(G.governorBusy() === false,
+      'a hold on the FULL tier is inert — the desktop renders everything at once on purpose');
+    documentElement.setAttribute(PT.PERF_ATTR, PT.PERF_LITE);
+    ok(G.governorBusy() === true, 'the same hold reads busy the moment the lite tier is in force');
+    rel();
+    ok(G.governorBusy() === false, 'released = idle again');
+    rel();
+    ok(G.governorBusy() === false, 'and the release is idempotent (settle + cancel double-call is normal)');
+    const rel2 = G.governorHold(30);
+    ok(G.governorBusy() === true, 'a short hold is live…');
+    await sleep(60);
+    ok(G.governorBusy() === false,
+      '…and reads idle past its own deadline even if never released — the degradation cannot stick');
+    rel2();
+
+    // ---- BEHAVIOUR: an all-animated pool on lite caps at the budget. The stub
+    // has no Image and its canvases have no 2d context, so the freeze path
+    // reports "cannot freeze" and over-budget spawns are SKIPPED — the
+    // budget-respecting fallback, and the one this harness can observe.
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    const flashHost = byId.get('gg-fx-flash');
+    const gifMedia = {
+      drawKind: (kind) => ({ kind, name: `${kind}-1.gif`, url: `https://ccp.assets/${kind}/1.gif` }),
+      acquire: (e) => (e ? { url: e.url, release() {} } : null),
+      hasMedia: () => true,
+    };
+    const liveShots = () => flashHost.findAll('gg-flash').filter((el) => !el._cls.has('is-popped'));
+    const fl = F.createFlashes({ layers, media: gifMedia, logger: quiet });
+    fl.start({ intensity: 1 });
+    await sleep(1400);                       // two beats' worth of spawn attempts at i=1
+    ok(liveShots().length > 0 && liveShots().length <= F.ANIM_LIVE_LITE,
+      'a lite bed drawing only GIFs never exceeds the animation budget', String(liveShots().length));
+    fl.stop();
+    // The hydra spends the same budget: hammer the splits and it still holds.
+    for (let round = 0; round < 4; round++) {
+      for (const el of liveShots()) tap(el);
+      await sleep(280);
+    }
+    ok(liveShots().length <= F.ANIM_LIVE_LITE,
+      'and the hydra cannot split past it either', String(liveShots().length));
+
+    // ---- while a STILL pool on lite still fills to the full lite node cap —
+    // the budget bites animated media only, never the field.
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    const fl2 = F.createFlashes({ layers, media: fakeMedia(), logger: quiet });
+    fl2.start({ intensity: 1 });
+    await sleep(320);
+    fl2.stop();
+    for (let round = 0; round < 6 && liveShots().length < F.MAX_LIVE_LITE; round++) {
+      for (const el of liveShots()) tap(el);
+      await sleep(280);
+    }
+    await sleep(300);
+    ok(liveShots().length === F.MAX_LIVE_LITE,
+      'a still-image pool on lite fills to MAX_LIVE_LITE — the animation budget charged nothing',
+      String(liveShots().length));
+    documentElement.removeAttribute(PT.PERF_ATTR);
+
+    // ---- the lite CSS half of pass 2 (fx.css)
+    {
+      const fs = await import('node:fs/promises');
+      const url = await import('node:url');
+      const raw = await fs.readFile(url.fileURLToPath(new URL('../exec/fx.css', import.meta.url)), 'utf8');
+      const css = raw.replace(/\/\*[\s\S]*?\*\//g, '');
+      ok(/html\[data-gg-perf="lite"\]\s*\.gg-drain\.is-glitching\s*\{\s*animation-name:\s*ggDrainGlitchLite/.test(css),
+        'lite swaps the glitch shudder onto its transform-only twin');
+      const liteBody = /@keyframes\s+ggDrainGlitchLite([\s\S]*?)(?=@keyframes|html\[|$)/.exec(css);
+      ok(!!liteBody && !/filter/.test(liteBody[1]),
+        'and the twin animates NO filter — the fullscreen recolour raster is the whole cost being shed',
+        liteBody ? liteBody[1].trim().slice(0, 60) : '(missing)');
+      ok(/html\[data-gg-perf="lite"\]\s*\.gg-bounce-word\.is-hit\s*\{\s*animation:\s*none/.test(css),
+        'lite drops the bounce-word hit flash (a filter pass per wall hit, for a garnish)');
+    }
+  }
+
   console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
   process.exit(failures === 0 ? 0 : 1);
 }


### PR DESCRIPTION
## Why

PR #129's lite tier cut every renderer's **node** budget, and the owner's iPhone 13 Pro Max (r8-20260805a) still lagged - worst when a **flash burst** landed: everything overloads, spirals freeze for seconds, brain drain suspected too, much worse in iOS Low Power Mode. The caps counted nodes; the cost is what a node **does per frame**. A static PNG is a texture; an animated GIF in an `<img>` is a CPU decode loop that never stops - and a burst of peer media is usually GIFs. Ten of them inside the lite cap **was** the lag.

**Full tier (desktop) is byte-identical**: every new dial reads behind `perfLite()` (lazily, so the mid-match toggle bites), or behind a governor whose read answers false off-lite.

## Sustained-load culprits, ranked

1. **Concurrent animated GIF decode loops** during a burst (up to 10 at once under the lite node cap, most of them the peer's transferred GIFs).
2. **Burst spawn churn**: the burst halves the beat gap *and* bumps count - every spawn is a fresh decode landing inside the squall's own frames.
3. **Sum-of-budgets**: burst + 30fps WebGL spiral fill + fullscreen drain blend stack all in the same frames - each within its own budget, the total not.
4. **Fullscreen animated drain wash**: when the pool dealt a GIF, the veil became a cover-sized animation repainting behind a two-layer blend for 7-11s (the drain's one remaining per-frame cost after #129 removed its backdrop-filter).
5. **Leftover fullscreen filter animations**: the glitch shudder hue-rotates the whole pane 12.5x/s; the bounce-word hit pop runs a filter pass per wall bounce.

## What changed (lite dials, old -> new)

| Dial | Full | Lite (old) | Lite (new) |
|---|---|---|---|
| Concurrent **playing** animated flashes | uncapped (node cap 20) | node cap 10, animation uncapped | **`ANIM_LIVE_LITE = 3`**; overflow renders **frozen** (frame-0 canvas, `FROZEN_MAX_PX = 512`), or is skipped where a host can't bake |
| Burst beat gap | x0.5 | x0.5 | **x0.72** (`BURST_GAP_SCALE_LITE`) |
| Burst per-beat count | +1 (max 3) | +1 (max 3) | **no bump** - a burst is a burst by tempo, not node count |
| Spiral draw cadence during a burst | every rAF | 33ms (~30fps) | **67ms (~15fps)** while `governorBusy()` (`LITE_BURST_FRAME_MS`), self-restoring |
| Drain wash re-pick during a burst | 7-11s | 7-11s | **held** while `governorBusy()` (skips one tick, next re-picks) |
| Drain/pop wash media | any image | any image | **still-preferred** (`drawStillImage`, up to 4 redraws; an all-GIF library still gets its GIF - preference, never filter) |
| Glitch shudder | hue-rotate+translate | same | **transform-only twin keyframes** (`ggDrainGlitchLite`), same timing/steps/cap |
| Bounce-word hit pop | brightness+drop-shadow | same | **off** (word still travels) |

## The animation budget design

- `exec/media.js isAnimatedMedia(entry)` - generous sniff: mime first (peer artifacts always carry one), then name extension (local picks keep filenames when blob: URLs have none), then URL extension. gif/webp/apng all count: a false positive freezes a still (visually a no-op), a false negative is an unbudgeted decode loop.
- Charged per live rec (`rec.animPlaying`), counted off the live set so pruned nodes can't leave phantom charges; the hydra spends the same budget.
- Overflow freeze: `animation-play-state` can't pause a GIF, so an **off-DOM probe `Image`** decodes exactly one frame into a `<canvas>` that wears the same classes, keyframes, drag/pinch/hydra handlers and kill paths as the `<img>` it replaces. Cross-origin taint is fine - nothing reads pixels back. Hosts that can't bake skip the flash (the cap's own skipped-beat precedent).

## The load governor (`exec/loadGovernor.js`, new)

The burst takes `governorHold(runMs)` and releases on settle; spiral/drain ask one boolean from loops they already run. Self-restoring twice over: idempotent release **and** a deadline (cap 10s) past which a leaked hold reads idle - the degradation cannot stick. Lite-gated at the **read**, so a desktop burst writes a timestamp nobody consults. `exec/` fences hold: the governor imports only `perfTier`, and no renderer imports another renderer.

## Low Power Mode

No cheap reliable detection exists, so the frame logic is delta-time-robust instead - verified rather than changed: spiral phase advances by real elapsed time (skipped draws cost pixels, never tempo), flashes' fling stepper clamps real dt to 0.5-3 frames, bouncingText clamps dt at 100ms, and the 33/67ms gates pass ~30fps rAF frames whole.

## Deliberately left to the sibling (`fix/goon-spiral-stutter`)

Spiral **startup** stutter - first-frame warm-up, shader compile, bake-on-cue freeze at payload start. This pass touches only sustained load; the one overlap is the `step()` gate line, a one-line merge either way.

## Tests

- `selftest-exec`: **1007 checks**, new pass-2 block pins the dials, the sniff decision table, still-preference, governor lite-gating/expiry/idempotence, and behaviour: an all-GIF pool on lite caps at the budget (hydra hammering included) while a still pool fills to `MAX_LIVE_LITE` untouched.
- `selftest-hud` 1540, `selftest-flow` 232, plus core/net/transfer/assets/encode/report/invite/hostgate/voice/voice-ui - all green (avafx's 12 pre-existing failures excepted).
- (One unrelated pre-existing flake noted in the bubbles gutter block - random spawn positions - passed on re-run, untouched here.)

## Real-device verification (iPhone 13 Pro Max, cclabs.app/goon-beta)

1. Options drawer -> confirm resolved tier shows **lite** (or force it).
2. Duel vs a desktop with a GIF-heavy library; have it throw a **flash burst** onto a running spiral + brain drain bed. Expect: at most ~3 flashes visibly animating (the rest hold their first frame), spiral turns coarser but **never freezes seconds**, and it smooths back within ~10s of the squall ending.
3. Repeat in **Low Power Mode** - degraded but no multi-second stalls.
4. Pop a glitch bubble on lite: the drain still shakes, no colour strobing.
5. Flip Lite graphics OFF mid-match on a desktop-class phone: full burst behaviour returns next beat (and vice versa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
