### PR TITLE
feat(goon): transfer variety (sender + receiver) and a ?debug=1 perf readout

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -194,6 +194,15 @@ const el = (id) => (hasDom() ? document.getElementById(id) : null);
 let debugOverlay = null;
 let debugArming = false;
 const debugPrelog = [];
+/**
+ * ui/perfProbe.js, armed only alongside the overlay. It is the 2026-08-05
+ * play-test's instrument: the phone reports lag, code-reading has run out of
+ * road, and the next session has to come back with fps + frame-gap + long-task
+ * numbers instead of an adjective. Its warn lines go through `logger.warn`
+ * BELOW — one call that reaches the C# log, the console and the overlay's ring
+ * at once — and its one-line readout goes to the overlay's status row.
+ */
+let perfProbe = null;
 
 function teeDebug(level, m) {
   if (debugOverlay) { debugOverlay.push(level, m); return; }
@@ -242,9 +251,34 @@ function initDebugOverlay() {
         debugOverlay.push('warn', 'debug on — ' + (bridge.isHosted ? 'hosted' : 'standalone')
           + ' protocol v' + bridge.PROTOCOL);
         for (const [lvl, m] of debugPrelog.splice(0)) debugOverlay.push(lvl, m);
+        initPerfProbe();
       })
       .catch(() => { debugArming = false; });
   } catch (_e) { debugArming = false; }
+}
+
+/**
+ * The perf readout. A SECOND dynamic import, nested inside the branch that has
+ * already decided debug is on, so a shipped page never fetches it and a page
+ * whose probe module is missing still gets its overlay — same "optional wave"
+ * shape as loadSiblings, for the same reason.
+ */
+function initPerfProbe() {
+  if (perfProbe || !debugOverlay) return;
+  try {
+    import('./ui/perfProbe.js')
+      .then((mod) => {
+        if (!mod || typeof mod.createPerfProbe !== 'function' || !debugOverlay) return;
+        perfProbe = mod.createPerfProbe({
+          setStatus: (t) => { try { debugOverlay.setStatus(t); } catch (_e) { /* ignore */ } },
+          // logger.warn, NOT overlay.push: warn is the sink that reaches the C# host
+          // log as well, and a phone-only number nobody can collect is not telemetry.
+          onWarn: (m) => logger.warn(m),
+        });
+        perfProbe.start();
+      })
+      .catch(() => { /* no readout, no harm — the overlay still logs */ });
+  } catch (_e) { /* ditto */ }
 }
 
 /* ----------------------------------------------------------------------------
@@ -2344,6 +2378,9 @@ if (typeof window !== 'undefined') {
       get received() { return receivedStore; },
       get blocklist() { return blocklist; },
       get mediaQueue() { return mediaQueue; },
+      // null unless ?debug=1 armed it. `.sample()` is the fps/gap/long-task
+      // snapshot the C# play-test driver can read without a screenshot.
+      get perf() { return perfProbe; },
       get discord() { return discord; },
       get stubs() { return stubs.slice(); },
       actions,

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -55,6 +55,26 @@
  * the transfer lane. The sender applies the same rule when it picks tags (net/mediaQueue.js
  * tagsFor); this is the half that survives a tag miss and the peer-first fallback. */
 
+/* THE PEER POOL ROTATES, IT DOES NOT SHUFFLE (2026-08-05, phone play-test r9: "seems like I am
+ * receiving always the same gif").
+ *
+ * `drawReceived` used to pick uniformly at random with a one-item echo guard. On the pool this
+ * lane actually has — two or three artifacts for the first minute of a match — uniform random is
+ * a machine for producing runs: with three files and only the immediate repeat blocked, the SAME
+ * file comes back every other draw about half the time, and a burst that spends thirty draws in
+ * eight seconds shows the owner one gif over and over. That is not a transfer bug; it is what
+ * random looks like at n=3, which is exactly why it survived three rounds of code-reading.
+ *
+ * So the draw is now a ROTATION: least-recently-shown first, ties broken at random, and the pick
+ * stamped with a monotonic counter. A pool of three cycles A-B-C; a pool of ten walks all ten
+ * before it repeats one; a pool of one still draws that one, forever, because there is nothing
+ * else and a rotation is not allowed to invent variety it does not have.
+ *
+ * WHAT IT DELIBERATELY IS NOT: it is not the deck (`recent`/`reshuffle`) above. The deck indexes
+ * `entries` and is re-dealt whenever a manifest or a local library lands; the peer pool is a Map
+ * that only ever grows during a match and must survive both of those. One counter Map is the
+ * whole mechanism, and `dropReceived` prunes it so a blocklist sweep cannot leave a ghost row. */
+
 const NO_ECHO = 8; // a reshuffled deck avoids repeating the last N draws
 
 /** The one namespace `tags` carries for this feature. `tags` stays open for others. */
@@ -132,8 +152,14 @@ export function createGoonMediaPool() {
    */
   const received = new Map();
 
-  /** Last sha drawReceived handed out per kind, so a 2-3 file pool doesn't strobe. */
-  const lastPeerPick = { image: '', video: '' };
+  /**
+   * sha -> the draw counter at which drawReceived last handed it out. A sha that is absent has
+   * NEVER been shown and therefore sorts ahead of everything that has (see peerRank). One shared
+   * ledger across both kinds: a sha only ever belongs to one of them, so splitting it would buy
+   * nothing but a second Map to keep pruned.
+   */
+  const peerShownAt = new Map();
+  let peerDrawSeq = 0;
 
   /** Injected (never imported): {knows(sha), isBlocked(sha)} from net/blocklist.js. */
   let blocklist = null;
@@ -266,6 +292,49 @@ export function createGoonMediaPool() {
     if (kind !== 'video' || pool.length < 2) return pool;
     const real = pool.filter((v) => v.origin !== 'gif');
     return real.length ? real : pool;
+  }
+
+  /** Every received view of that kind the blocklist still allows. Shared by draw and peek. */
+  function receivedViews(kind) {
+    const all = [];
+    for (const sha of received.keys()) {
+      const v = viewReceived(sha, kind);
+      if (v) all.push(v);
+    }
+    return all;
+  }
+
+  /** How long ago this artifact was shown. -1 = never, which is the front of every queue. */
+  function peerRank(v) {
+    const at = peerShownAt.get(v.sha);
+    return at === undefined ? -1 : at;
+  }
+
+  /**
+   * The rotation: the least-recently-shown candidate, TIES BROKEN AT RANDOM.
+   *
+   * The tie-break is not decoration. Every artifact starts at rank -1, so on a fresh pool the
+   * whole set ties and a deterministic answer would walk the received Map's INSERTION ORDER —
+   * i.e. the order the wire happened to land things in, identically on every match, which is a
+   * different way of being predictable. Random among equals keeps the first cycle a surprise and
+   * the later ones fair.
+   *
+   * @param {Array} pool candidates, non-empty
+   * @returns {object} the chosen view — the caller decides whether to stamp it
+   */
+  function rotate(pool) {
+    let best = -2;
+    let ties = 0;
+    let chosen = pool[0];
+    for (const v of pool) {
+      const r = peerRank(v);
+      if (r < best || best === -2) { best = r; ties = 1; chosen = v; continue; }
+      if (r !== best) continue;
+      // Reservoir sampling over the tied set: one pass, no array, uniform among equals.
+      ties++;
+      if (((Math.random() * ties) | 0) === 0) chosen = v;
+    }
+    return chosen;
   }
 
   /** The deck draw, hoisted so `drawFor` can reach it without a `this` binding. */
@@ -410,7 +479,13 @@ export function createGoonMediaPool() {
     hasReceived(sha) { return typeof sha === 'string' && received.has(sha); },
 
     /** Blocklist sweep / eviction / user delete. Does not touch the file. */
-    dropReceived(sha) { return typeof sha === 'string' && received.delete(sha); },
+    dropReceived(sha) {
+      if (typeof sha !== 'string') return false;
+      // The rotation ledger is pruned with it, or a re-received artifact would come back
+      // carrying its old position at the BACK of the queue and skip its turn.
+      peerShownAt.delete(sha);
+      return received.delete(sha);
+    },
 
     receivedCount() { return received.size; },
 
@@ -453,45 +528,42 @@ export function createGoonMediaPool() {
      * The header's invariant survives because ONLY payload render paths call
      * this — draw()/drawKind() still never surface a peer file, so their media
      * still appears exactly where a payload of theirs asked for it. Blocklist
-     * and kind agreement ride on viewReceived; with any choice at all the same
-     * sha is never handed out twice in a row.
+     * and kind agreement ride on viewReceived.
+     *
+     * THE PICK IS A ROTATION, NOT A SHUFFLE — see the second banner at the top of
+     * this file for why random-with-an-echo-guard was the thing the owner was
+     * seeing as "always the same gif". Least-recently-shown wins; the pick is
+     * stamped so it goes to the back of the queue.
      */
     drawReceived(kind) {
       const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
       if (!want) return null;
-      const all = [];
-      for (const sha of received.keys()) {
-        const v = viewReceived(sha, want);
-        if (v) all.push(v);
-      }
+      const all = receivedViews(want);
       if (!all.length) return null;
       // Real footage if they have sent any this match; their gif loops if that is all there is.
-      const pool = footageFirst(all, want);
-      let at = (Math.random() * pool.length) | 0;
-      if (pool.length > 1 && pool[at].sha === lastPeerPick[want]) at = (at + 1) % pool.length;
-      lastPeerPick[want] = pool[at].sha;
-      return pool[at];
+      const chosen = rotate(footageFirst(all, want));
+      peerShownAt.set(chosen.sha, ++peerDrawSeq);
+      return chosen;
     },
 
     /**
-     * drawReceived without the echo-guard write: ui/throwPreview.js's rung for
+     * drawReceived without the rotation write: ui/throwPreview.js's rung for
      * "the render will draw SOME received artifact" (representative, not exact
-     * — same contract as peekKind, and mutating lastPeerPick from a preview
+     * — same contract as peekKind, and stamping the rotation from a preview
      * would let the preview change what it is previewing).
+     *
+     * It reads the SAME rotation, so on a settled pool the preview and the render
+     * usually agree on the next artifact — which is more than the old random pick
+     * could ever promise, and costs nothing.
      */
     peekReceived(kind) {
       const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
       if (!want) return null;
-      const all = [];
-      for (const sha of received.keys()) {
-        const v = viewReceived(sha, want);
-        if (v) all.push(v);
-      }
+      const all = receivedViews(want);
       if (!all.length) return null;
       // The SAME candidate set drawReceived would choose from, or the preview would advertise a
       // gif loop the render then refuses to play.
-      const pool = footageFirst(all, want);
-      return pool[(Math.random() * pool.length) | 0];
+      return rotate(footageFirst(all, want));
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/mediaQueue.js
@@ -32,6 +32,35 @@
 //     been debugged for three times. Fail-open throughout — unknown codec or a peer that named
 //     none means OFFER IT (net/codecs.js owns that contract).
 //
+// AND A THIRD RULE, THE VARIETY ONE (2026-08-05, phone play-test r9): "SEEMS LIKE I AM RECEIVING
+// ALWAYS THE SAME GIF". Every gate above passed and every layer worked; the receiver's pool was
+// simply TOO SMALL AND TOO LOPSIDED for the first minute of the match, so the two animated images
+// that happened to land first were the two images every early burst had to choose between. Three
+// changes, all of them about the SHAPE of the pool rather than its existence:
+//
+//  3a. DEPTH IS EARNED BY SIZE, not fixed at four. `targetDepth()` keeps roughly QUEUE_AHEAD_MS of
+//      WIRE TIME landed ahead of the match instead of a flat count, so a library of 400 KB stills
+//      primes ten deep during the untimed draft while a library of 40 MB clips still primes four.
+//      The wire budget is unchanged — `eligible()` still refuses anything that cannot land inside
+//      MAX_XFER_MS at the measured rate — this only decides how many of the affordable ones we
+//      bother to keep ahead. LANDED_MAX (12) is deliberately above QUEUE_DEPTH_MAX (10) so the
+//      ring can never truncate the working set it was told to build.
+//
+//  3b. THE PUMP BALANCES KINDS AND FAVOURS DISTINCTNESS. The draw was a straight `deck.pop()`, so
+//      four consecutive videos was as likely as any other hand and the FlashBurst lane could sit
+//      empty for a minute. `nextPick` now scans the top PICK_SCAN entries of the (still shuffled,
+//      still Math.random) deck and prefers the kind the receiver's pool is SHORT of, then an
+//      `origin` that differs from the last pick — a soft score, never a filter, so a single-kind
+//      or all-gif library behaves exactly as it did. Ties keep the topmost card, which is what
+//      keeps the shuffle in charge of everything the score does not care about.
+//
+//  3c. TAGS REMEMBER WHAT THE PEER HAS ALREADY BEEN SHOWN. `markConsumed` was a pure delete; it
+//      now also writes a small `shown` ledger (sha -> {kind, seq}), and `tagsFor` fills a burst's
+//      spare slots from it least-recently-shown-first when the landed pool is short. THE LEDGER
+//      CAN ONLY TOP UP, NEVER OPEN: a tag set that found nothing fresh still comes back EMPTY, so
+//      "one landing, one drop" and the untagged diagnostic below both survive intact, and the
+//      receiver's own rotation (exec/media.js drawReceived) stays the answer for "nothing new".
+//
 // TWO tryFirePayload INSTANCE WRAPPERS NOW EXIST. boot.js applies the matchLog wrapper first
 // (attachMatch -> matchLog.attach), then this one, so the queue's wrapper is the OUTERMOST: a
 // payload gets its tags BEFORE the log sees it, and the log records exactly what went out. Order
@@ -49,12 +78,40 @@ import {
   XferDecline,
 } from './mediaChannel.js';
 
-/** Landed-or-in-flight artifacts we try to keep ahead of the match. */
+/**
+ * Landed-or-in-flight artifacts we try to keep ahead of the match — THE FLOOR, not the answer.
+ * `targetDepth()` raises it toward QUEUE_DEPTH_MAX when the library is cheap enough to go deeper
+ * (rule 3a in the header); it is never lowered, because four ahead is the depth the whole feature
+ * was tuned at and a slow link deserves the same patience it always had.
+ */
 export const QUEUE_DEPTH = 4;
+/**
+ * …and the ceiling. Held BELOW LANDED_MAX on purpose: the moment the target depth could exceed
+ * the landed ring, the pump would spend the wire on artifacts the ring then silently dropped.
+ */
+export const QUEUE_DEPTH_MAX = 10;
+/**
+ * How much WIRE TIME the queue tries to keep landed ahead of the match, which is the honest unit:
+ * "four artifacts" means half a minute of small stills and six minutes of long clips. 45 s is the
+ * draft's own dead time plus a margin — enough that a still-image library is primed several deep
+ * before the first payload fires, which is precisely the minute the owner saw repeats in.
+ */
+export const QUEUE_AHEAD_MS = 45000;
+/**
+ * How many cards off the top of the shuffled deck `nextPick` may score before it settles. Small
+ * on purpose: a window this size is enough to find a card of the hungrier kind in any mixed
+ * library, and short enough that the SHUFFLE — not the score — still decides most hands.
+ */
+export const PICK_SCAN = 12;
 /** The idle poll only bothers when fewer than this many have landed. */
 export const QUEUE_MIN = 2;
 /** How many landed artifacts are tracked per match, so a 12-minute run cannot grow unbounded. */
 export const LANDED_MAX = 12;
+/**
+ * Rows in the "already shown them this" ledger (rule 3c). Bounded for the same reason LANDED_MAX
+ * is; at 64 a twelve-minute match has never truncated anything a burst would have asked for.
+ */
+export const SHOWN_MAX = 64;
 /** Ported from exec/media.js: a reshuffled deck must not repeat the last N picks. */
 export const NO_ECHO = 8;
 /** Cheap wedge insurance while the match is running. */
@@ -132,6 +189,19 @@ export function createMediaQueue({
   /** The shuffled deck over eligible artifacts, drawn from the end. */
   let deck = [];
   const recent = [];
+  /**
+   * The `origin` of the last card taken ('' or 'gif'), so `nextPick` can lean away from four
+   * converted loops in a row. A ONE-CARD memory is all this needs: `seen` already guarantees the
+   * same FILE never goes twice, so the only repetition left to break up is of a KIND of thing.
+   */
+  let lastOrigin = '';
+  /**
+   * sha -> {kind, seq} for every artifact a fired payload has already pointed the peer at.
+   * `seq` is a monotonic counter, so "least recently shown" is a number comparison and nothing
+   * here has to know what time it is. Written ONLY by markConsumed (rule 3c).
+   */
+  const shown = new Map();
+  let showSeq = 0;
 
   const receivedSubs = new Set();
   let picks = 0;
@@ -245,6 +315,88 @@ export function createMediaQueue({
     }
   }
 
+  /* --------------------------------------------------------- depth + kind balance (rule 3) */
+
+  /**
+   * How deep to keep the queue RIGHT NOW, in artifacts. Wire time is the unit (see QUEUE_AHEAD_MS)
+   * and the MEAN artifact is the estimator — coarse on purpose, because the only decision it feeds
+   * is "a few more or not", and a median would cost a sort on every pump for an answer that
+   * differs by one.
+   *
+   * `estBps()` is the SAME budget `eligible()` filters against, so depth and admission can never
+   * disagree: nothing in the pool has already been refused for being too slow to land.
+   *
+   * @param {Array} [pool] the eligible set, when the caller already has one
+   */
+  function targetDepth(pool) {
+    let p = pool;
+    if (!Array.isArray(p)) { try { p = eligible(); } catch (_e) { return QUEUE_DEPTH; } }
+    if (!p.length) return QUEUE_DEPTH;
+    let sum = 0;
+    for (const a of p) sum += a.bytes;
+    const msEach = ((sum / p.length) / estBps()) * 1000;
+    if (!(msEach > 0)) return QUEUE_DEPTH;                 // NaN/0 -> the floor, never a huge depth
+    const n = Math.floor(QUEUE_AHEAD_MS / msEach);
+    return Math.max(QUEUE_DEPTH, Math.min(QUEUE_DEPTH_MAX, n));
+  }
+
+  /** How many of each media kind are landed or in flight right now. */
+  function kindCounts() {
+    let image = 0;
+    let video = 0;
+    for (const a of landed) { if (a.kind === 'video') video++; else image++; }
+    for (const sha of inFlight.keys()) {
+      const meta = pickInfo.get(sha);
+      if (!meta) continue;
+      if (meta.kind === 'video') video++; else image++;
+    }
+    return { image, video };
+  }
+
+  /**
+   * The kind the receiver's pool is SHORT of, or '' for "no opinion".
+   *
+   * '' is the answer whenever the preference could do harm rather than good: a pool that already
+   * holds the same number of each, and — the important one — a library that only HAS one kind,
+   * where wanting the other would just mean scoring every card identically. Both cases fall
+   * straight back to the shuffle.
+   */
+  function hungriestKind(pool) {
+    let hasImage = false;
+    let hasVideo = false;
+    for (const a of pool) {
+      if (a.kind === 'video') hasVideo = true; else hasImage = true;
+      if (hasImage && hasVideo) break;
+    }
+    if (!hasImage || !hasVideo) return '';
+    const c = kindCounts();
+    if (c.image === c.video) return '';
+    return c.image < c.video ? 'image' : 'video';
+  }
+
+  /**
+   * Which card of the deck to take: the best-scoring one in the top PICK_SCAN, index into `deck`.
+   *
+   * THE SCORE IS SOFT, TWICE OVER, and that is the whole design. Wanting the hungrier kind is
+   * worth 2 and a fresh `origin` is worth 1, so kind balance outranks distinctness but neither can
+   * EXCLUDE anything: on a library where no card scores, the topmost card of a shuffled deck wins,
+   * which is byte-identical to the `deck.pop()` this replaced. Ties go to the topmost for the same
+   * reason (the comparison is strict `>` while scanning downward from the top).
+   */
+  function pickIndex(want) {
+    let best = deck.length - 1;
+    let bestScore = -1;
+    const from = Math.max(0, deck.length - PICK_SCAN);
+    for (let i = deck.length - 1; i >= from; i--) {
+      const e = deck[i];
+      let score = 0;
+      if (want && e.kind === want) score += 2;
+      if ((e.origin || '') !== lastOrigin) score += 1;
+      if (score > bestScore) { bestScore = score; best = i; }
+    }
+    return best;
+  }
+
   /** The next artifact worth offering, or null. */
   function nextPick() {
     const pool = eligible();
@@ -252,8 +404,10 @@ export function createMediaQueue({
     const live = new Set(pool.map((e) => e.sha));
     deck = deck.filter((e) => live.has(e.sha) && !seen.has(e.sha) && !neverOffer.has(e.sha));
     if (!deck.length) reshuffle(pool);
-    const pick = deck.pop() || null;
+    if (!deck.length) return null;
+    const [pick] = deck.splice(pickIndex(hungriestKind(pool)), 1);
     if (!pick) return null;
+    lastOrigin = pick.origin || '';
     recent.push(pick.sha);
     if (recent.length > NO_ECHO) recent.shift();
     return pick;
@@ -263,18 +417,30 @@ export function createMediaQueue({
 
   function inFlightCount() { return inFlight.size; }
 
-  /** Fill to QUEUE_DEPTH. Event-driven: channel open, xfer_done, decline:'have', consumption. */
+  /**
+   * Fill to `targetDepth()`. Event-driven: channel open, xfer_done, decline:'have', consumption.
+   *
+   * The loop still terminates after ONE offer in practice — `offerNext` refuses while anything is
+   * in flight (MAX_CONCURRENT_OUT is 1 and lives on the channel, because two artifacts sharing one
+   * bulk lane is not throughput, it is interleaving) — so depth buys LANDINGS OVER TIME, not
+   * parallelism: each landing re-enters here and takes the next card.
+   */
   function pump() {
     if (!attached || !enabled()) return;
+    const depth = targetDepth();
     let guard = 0;
-    while (landed.length + inFlightCount() < QUEUE_DEPTH && guard++ < QUEUE_DEPTH) {
+    while (landed.length + inFlightCount() < depth && guard++ < QUEUE_DEPTH_MAX) {
       if (!offerNext()) break;
     }
   }
 
-  /** The 5 s idle poll's cheaper cousin — only bothers when the larder is actually low. */
+  /**
+   * The 5 s idle poll's cheaper cousin — only bothers when the larder is actually low. "Low"
+   * scales with the target: a two-artifact floor was the right hunger line at depth four and is
+   * plain wrong at depth ten, where three landed out of ten wanted is a starving queue.
+   */
   function pumpIfHungry() {
-    if (landed.length < QUEUE_MIN) pump();
+    if (landed.length < Math.max(QUEUE_MIN, targetDepth() >> 1)) pump();
   }
 
   /** @returns {boolean} true when an offer went out (or is being opened). */
@@ -401,6 +567,28 @@ export function createMediaQueue({
         out.push('xfer:' + a.sha);
         if (out.length >= want) break;
       }
+
+      /* THE LEDGER TOP-UP (rule 3c). A FlashBurst asks for three and the landed pool routinely
+       * holds one, so two of its three exact slots used to go out empty. Those slots are now
+       * filled from `shown`, LEAST-RECENTLY-SHOWN FIRST, with artifacts this peer demonstrably
+       * already holds (they landed, and a fired payload pointed at them).
+       *
+       * `out.length` GATES IT, and that guard is the load-bearing part: with nothing fresh at all
+       * the answer stays [], which keeps "one landing, one drop" true, keeps the untagged
+       * diagnostic below firing, and leaves "nothing new has landed" to the receiver's own
+       * rotation — exec/media.js drawReceived already spends the rest of every peer burst there
+       * and rotates least-recently-SHOWN, so a stale pin would only make that answer worse. */
+      if (out.length && out.length < want) {
+        const repeats = [];
+        for (const [sha, meta] of shown) {
+          if (meta.kind === mediaKind && out.indexOf('xfer:' + sha) < 0) repeats.push([sha, meta.seq]);
+        }
+        repeats.sort((x, y) => x[1] - y[1]);
+        for (const [sha] of repeats) {
+          out.push('xfer:' + sha);
+          if (out.length >= want) break;
+        }
+      }
     }
     if (!out.length) {
       const why = whyNoTags();
@@ -412,6 +600,26 @@ export function createMediaQueue({
     return out;
   }
 
+  /**
+   * Note that a fired payload has pointed the peer at this artifact. The ledger's ONLY writer —
+   * `tagsFor` deliberately does not touch it, so a tag set built for a payload that then failed
+   * its charge check cannot age the record of something the peer never actually saw.
+   */
+  function noteShown(sha, kind) {
+    const meta = shown.get(sha);
+    if (meta) { meta.seq = ++showSeq; return; }
+    shown.set(sha, { kind: kind === 'video' ? 'video' : 'image', seq: ++showSeq });
+    /* Over the cap we drop the MOST recently shown row, not the oldest: a row's whole value here
+     * is as a repeat candidate, and the least-recently-shown rows are the good ones. */
+    while (shown.size > SHOWN_MAX) {
+      let worstSha = '';
+      let worstSeq = -1;
+      for (const [s, m] of shown) if (m.seq > worstSeq) { worstSeq = m.seq; worstSha = s; }
+      if (!worstSha) break;
+      shown.delete(worstSha);
+    }
+  }
+
   /** A payload went out carrying these tags — those artifacts are spent. */
   function markConsumed(tags) {
     if (!Array.isArray(tags) || !tags.length) return;
@@ -420,6 +628,12 @@ export function createMediaQueue({
       if (typeof t === 'string' && t.startsWith('xfer:')) spent.add(t.slice(5));
     }
     if (!spent.size) return;
+    // The ledger is written BEFORE the filter, while `landed` still knows each artifact's kind.
+    // `pickInfo` is the backstop for a deliberate repeat (already gone from `landed`).
+    for (const sha of spent) {
+      const from = landed.find((a) => a.sha === sha) || pickInfo.get(sha) || null;
+      noteShown(sha, from ? from.kind : 'image');
+    }
     const before = landed.length;
     landed = landed.filter((a) => !spent.has(a.sha));
     consumed += before - landed.length;
@@ -573,6 +787,10 @@ export function createMediaQueue({
     neverOffer.clear();
     seen.clear();
     recent.length = 0;
+    // A new match has shown the new peer nothing, and owes the old one's taste nothing either.
+    shown.clear();
+    showSeq = 0;
+    lastOrigin = '';
     match = null;
     transport = null;
   }
@@ -659,6 +877,10 @@ export function createMediaQueue({
         picks,
         consumed,
         deck: deck.length,
+        // The variety dials, so a play-test can read the pool's SHAPE and not just its size.
+        depth: targetDepth(),
+        kinds: kindCounts(),
+        shown: shown.size,
         estBps: estBps(),
         channel: channel ? channel.stats() : null,
       };

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -4192,6 +4192,90 @@ async function main() {
       'an explicit xfer tag for a gif-origin clip still resolves to exactly that clip');
   }
 
+  /* ------------------------- THE PEER POOL ROTATES, IT DOES NOT SHUFFLE
+   *
+   * 2026-08-05, phone play-test r9: "seems like I am receiving always the same
+   * gif". The draw was uniform random with a one-item echo guard, which at the
+   * pool size this lane actually has — two or three files for the first minute —
+   * is a machine for producing runs. A burst spends thirty draws in eight
+   * seconds; at n=3 with only the immediate repeat blocked, one file comes back
+   * every other draw about half the time.
+   *
+   * The fix is a rotation: least-recently-shown first, ties broken at random.
+   * The pins below are the three claims that makes.
+   */
+  {
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const A = SHA('1');
+    const B = SHA('2');
+    const C = SHA('3');
+
+    const three = createGoonMediaPool();
+    three.addReceived({ sha: A, kind: 'image', mime: 'image/gif', url: 'r/a.gif' });
+    three.addReceived({ sha: B, kind: 'image', mime: 'image/png', url: 'r/b.png' });
+    three.addReceived({ sha: C, kind: 'image', mime: 'image/webp', url: 'r/c.webp' });
+
+    // --- 1. EVERY WINDOW OF THREE HOLDS ALL THREE. This is the claim uniform
+    //     random cannot make at any pool size, and the one the owner was seeing
+    //     violated. Thirty draws, checked as ten complete cycles.
+    const seq = [];
+    for (let i = 0; i < 30; i++) seq.push(three.drawReceived('image').sha);
+    let brokenCycles = 0;
+    for (let i = 0; i < 30; i += 3) {
+      if (new Set(seq.slice(i, i + 3)).size !== 3) brokenCycles++;
+    }
+    ok(brokenCycles === 0,
+      'thirty draws over a three-file pool are ten complete cycles — no file repeats until every '
+      + 'other one has had its turn', String(brokenCycles));
+    let backToBack = 0;
+    for (let i = 1; i < seq.length; i++) if (seq[i] === seq[i - 1]) backToBack++;
+    ok(backToBack === 0, 'and nothing is ever handed out twice in a row', String(backToBack));
+
+    // --- 2. IT CANNOT INVENT VARIETY IT DOES NOT HAVE. One file is one file.
+    const one = createGoonMediaPool();
+    one.addReceived({ sha: A, kind: 'image', mime: 'image/gif', url: 'r/a.gif' });
+    let same = 0;
+    for (let i = 0; i < 10; i++) if (one.drawReceived('image').sha === A) same++;
+    ok(same === 10, 'a pool of ONE still draws it every time — a rotation is not a filter',
+      String(same));
+
+    // --- 3. THE PREVIEW READS THE ROTATION WITHOUT SPENDING IT. Same contract as
+    //     peekKind: a preview that mutated the queue would change what it previews.
+    //     (The pool is settled here — every rank is distinct — so the answer is
+    //     unambiguous; on a fresh pool every candidate ties and the tie-break is
+    //     deliberately random.)
+    const nextUp = three.peekReceived('image').sha;
+    ok(three.peekReceived('image').sha === nextUp,
+      'peekReceived is stable on a settled pool — it reads the rotation, it does not turn it');
+    ok(three.drawReceived('image').sha === nextUp,
+      'and the render then draws exactly what the preview advertised', nextUp.slice(0, 8));
+    ok(three.peekReceived('image').sha !== nextUp,
+      'after the draw the rotation has moved on — the preview is not a cached answer');
+
+    // --- 4. dropReceived PRUNES THE LEDGER. A re-received artifact must come back
+    //     at the FRONT of the queue, not carrying the position it had when it left.
+    const drops = createGoonMediaPool();
+    drops.addReceived({ sha: A, kind: 'image', mime: 'image/png', url: 'r/a.png' });
+    drops.addReceived({ sha: B, kind: 'image', mime: 'image/png', url: 'r/b.png' });
+    drops.drawReceived('image');
+    drops.drawReceived('image');                    // both stamped, A first
+    drops.dropReceived(A);
+    drops.addReceived({ sha: A, kind: 'image', mime: 'image/png', url: 'r/a.png' });
+    ok(drops.drawReceived('image').sha === A,
+      'a dropped-and-re-received artifact is NEVER-SHOWN again, so it goes straight to the front');
+
+    // --- 5. THE FOOTAGE PREFERENCE STILL OUTRANKS THE ROTATION. A gif-origin clip
+    //     whose turn it is does not get to jump a real clip that has never been shown.
+    const vids = createGoonMediaPool();
+    vids.addReceived({ sha: A, kind: 'video', mime: 'video/mp4', origin: 'gif', url: 'r/a.mp4' });
+    vids.addReceived({ sha: B, kind: 'video', mime: 'video/mp4', url: 'r/b.mp4' });
+    let loopDraws = 0;
+    for (let i = 0; i < 20; i++) if (vids.drawReceived('video').sha === A) loopDraws++;
+    ok(loopDraws === 0,
+      'the rotation runs INSIDE footageFirst — a converted loop never takes a real clip\'s turn',
+      String(loopDraws));
+  }
+
   // -------------------------------- addReceived does not disturb the deck
   {
     const { createGoonMediaPool } = await import('../exec/media.js');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -979,6 +979,143 @@ function mountRecap(result) {
     ok(/origin: e\.origin \|\| ''/.test(boot),
       '6h: and a received artifact keeps its origin all the way into exec/media.js addReceived');
   }
+
+  /* ---------- 6i. TRANSFER VARIETY, THE SENDER'S HALF (2026-08-05, play-test r9)
+   *
+   * "Seems like I am receiving always the same gif." Every gate passed; the pool
+   * was simply too small and too lopsided for the first minute. Three rules, all
+   * pinned here — see rule 3 in net/mediaQueue.js's header.
+   */
+  {
+    const { QUEUE_DEPTH, QUEUE_DEPTH_MAX, EST_THROUGHPUT_BPS, QUEUE_AHEAD_MS } =
+      await import('../net/mediaQueue.js');
+
+    // --- 3a. DEPTH IS EARNED BY SIZE. Pure: no transport, no match — `targetDepth`
+    //     only needs the eligible set and the throughput estimate, and with no
+    //     channel attached that estimate is exactly EST_THROUGHPUT_BPS.
+    const depthOf = (bytes, n = 4) => {
+      const list = [];
+      for (let i = 0; i < n; i++) {
+        list.push({ sha: SHA(String(i)), bytes, mime: 'image/png', kind: 'image', exempt: false });
+      }
+      return createMediaQueue({
+        artifacts: { listSendable: () => list, open: () => null },
+        store: fakeStore(), logger: quiet, canSend: () => false,
+      }).stats().depth;
+    };
+    const msFor = (bytes) => (bytes / EST_THROUGHPUT_BPS) * 1000;
+    ok(depthOf(200000) === QUEUE_DEPTH_MAX,
+      '6i: a library of small stills primes to the CEILING — the pool the phone was starved of',
+      String(depthOf(200000)));
+    ok(depthOf(4000000) === Math.floor(QUEUE_AHEAD_MS / msFor(4000000)),
+      '6i: a mid-sized library lands in between — the unit is WIRE TIME, not a file count',
+      String(depthOf(4000000)));
+    ok(depthOf(8000000) === QUEUE_DEPTH,
+      '6i: and a library of big clips keeps the old depth — the wire budget is never widened',
+      String(depthOf(8000000)));
+    ok(depthOf(0, 0) === QUEUE_DEPTH, '6i: an empty library answers the floor, never NaN');
+    ok(QUEUE_DEPTH_MAX < 12,
+      '6i: the ceiling stays BELOW LANDED_MAX, or the pump would spend the wire on artifacts '
+      + 'the landed ring then dropped', String(QUEUE_DEPTH_MAX));
+
+    // --- 3b. THE PUMP BALANCES KINDS. Five images and three videos: the first card
+    //     is a tie and the shuffle takes it, but the SECOND is drawn against a pool
+    //     that is now one-sided, so the two kinds cannot both be missing at t+1.
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+    const mixed = [];
+    for (let i = 0; i < 5; i++) {
+      mixed.push({ sha: SHA('a' + i), bytes: 6000, mime: 'image/png', kind: 'image', exempt: false });
+    }
+    for (let i = 0; i < 3; i++) {
+      mixed.push({ sha: SHA('b' + i), bytes: 6000, mime: 'video/mp4', kind: 'video', exempt: false, codec: 'avc1' });
+    }
+    const storeB = fakeStore();
+    const order = [];
+    const qA = createMediaQueue({
+      artifacts: fakeArtifacts(mixed), store: fakeStore(), logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    const qB = createMediaQueue({
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
+    });
+    qB.onReceived((e) => order.push(e.kind));
+
+    /* Math.random pinned, exactly as 6e does it: the deck is shuffled with it on
+     * purpose, and an unpinned test would only catch this regression sometimes. */
+    const realRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      qA.attach(a, pair.host);
+      qB.attach(b, pair.guest);
+      for (let i = 0; i < 160 && order.length < 4; i++) await tick(25);
+    } finally {
+      Math.random = realRandom;
+    }
+    ok(order.length >= 4, '6i: the queue primed several deep during the draft', order.join(','));
+    ok(order[0] !== order[1],
+      '6i: the FIRST TWO landings are one of each kind — the receiver has an image lane and a '
+      + 'video lane before the first payload fires', order.join(','));
+    ok(order.slice(0, 4).filter((k) => k === 'image').length >= 1
+      && order.slice(0, 4).filter((k) => k === 'video').length >= 1,
+      '6i: …and the balance holds through the first four', order.join(','));
+    qA.detach(); qB.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* ---------- 6j. THE SHOWN LEDGER (rule 3c): a burst's spare tag slots are filled
+   * with artifacts the peer already has, least-recently-shown first — but ONLY as a
+   * top-up. With nothing fresh at all the answer is still [], because that is what
+   * keeps "one landing, one drop" true and keeps the untagged diagnostic firing.
+   */
+  {
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+
+    const four = [];
+    for (let i = 0; i < 4; i++) {
+      four.push({ sha: SHA(String(i)), bytes: 5000, mime: 'image/png', kind: 'image', exempt: false });
+    }
+    const storeB = fakeStore();
+    const qA = createMediaQueue({
+      artifacts: fakeArtifacts(four), store: fakeStore(), logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    const qB = createMediaQueue({
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
+    });
+    qA.attach(a, pair.host);
+    qB.attach(b, pair.guest);
+    for (let i = 0; i < 200 && storeB.held.size < 4; i++) await tick(25);
+    ok(storeB.held.size === 4, '6j: all four stills landed (depth 10 for a library this small)',
+      String(storeB.held.size));
+
+    const t1 = qA.tagsFor(GoonPayloadKind.FlashBurst);
+    ok(t1.length === 3, '6j: a FlashBurst takes XFER_TAGS_MAX fresh artifacts', String(t1.length));
+    qA.markConsumed(t1);
+    ok(qA.stats().shown === 3, '6j: and consumption writes all three into the shown ledger',
+      String(qA.stats().shown));
+
+    const t2 = qA.tagsFor(GoonPayloadKind.FlashBurst);
+    ok(t2.length === 3, '6j: the next burst still gets three slots — one fresh, two topped up',
+      String(t2.length));
+    ok(t1.indexOf(t2[0]) < 0,
+      '6j: the FRESH artifact goes first — a never-seen file always outranks a repeat', t2[0]);
+    ok(t2[1] === t1[0] && t2[2] === t1[1],
+      '6j: and the repeats are the LEAST recently shown two, in that order', t2.join(','));
+
+    qA.markConsumed(t2);
+    ok(qA.tagsFor(GoonPayloadKind.FlashBurst).length === 0,
+      '6j: with nothing fresh left the answer is EMPTY, not a stale pin — "one landing, one drop" '
+      + 'survives, and the receiver\'s own rotation takes it from here');
+
+    qA.detach(); qB.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
 }
 
 /* ===========================================================================
@@ -1187,6 +1324,23 @@ function mountRecap(result) {
   panel.node.dispatchEvent({ type: 'click' });
   ok(panel.collapsed() === false, 'and back');
 
+  /* the PERF STATUS ROW (ui/perfProbe.js writes it twice a second). It is
+   * rewritten in place and must never reach the ring — a readout that pushed a
+   * line would flush the last fifty warnings out in twenty-five seconds, which
+   * is the one thing this overlay exists to prevent. */
+  const ringBefore = panel.lines().length;
+  panel.setStatus('58fps · worst 34ms · lt 0 · fx:idle');
+  ok(panel.status() === '58fps · worst 34ms · lt 0 · fx:idle', 'setStatus round-trips', panel.status());
+  ok(panel.lines().length === ringBefore,
+    'and it does NOT touch the ring — the readout can never flush a warning out');
+  panel.setStatus('19fps');
+  ok(panel.status() === '19fps', 'it is rewritten in place, not appended', panel.status());
+  panel.setStatus('');
+  ok(panel.status() === '', 'and an empty status clears it (the probe does this on stop)');
+  let statusThrew = false;
+  try { panel.setStatus(null); panel.setStatus(undefined); } catch (_e) { statusThrew = true; }
+  ok(!statusThrew, 'setStatus can never throw — it sits on a timer inside a debug session');
+
   // the two seams a logger never sees
   const fakeWin = (() => {
     const map = new Map();
@@ -1233,6 +1387,215 @@ function mountRecap(result) {
   const bridgeSrc = read('bridge.js');
   ok(/keep\.debug = /.test(bridgeSrc), 'bridge persists the flag next to server/token/uid/name');
   ok(/export function storedPrefs\(\)/.test(bridgeSrc), 'and exposes the stored blob for the pre-init decision');
+}
+
+/* ============================================================================
+ * 7b. THE PERF PROBE (ui/perfProbe.js) — the play-test's stopwatch.
+ *
+ * Added for the 2026-08-05 phone report: the owner says it lags, three rounds of
+ * code-reading have produced three theories and no evidence, and the device has
+ * no devtools. The next session has to come back with numbers.
+ *
+ * What must hold, or it is worse than not having it:
+ *   · ?debug=1 ONLY — the module is not even fetched otherwise, so the shipped
+ *     page's behaviour is byte-identical;
+ *   · it names WHICH detector fired. Safari has no `longtask` entry type, and a
+ *     probe that silently observed nothing on the one device it was built for
+ *     would be worse than none at all — so the rAF gap becomes the detector and
+ *     the readout says so;
+ *   · it never allocates per frame. A perf tool that makes garbage sixty times a
+ *     second is arguing against its own numbers.
+ * ==========================================================================*/
+{
+  const probeMod = await import('../ui/perfProbe.js');
+  const {
+    createPerfProbe, formatPerfLine, formatLoadContext, readLoadContext,
+    PERF_LONGTASK_WARN_MS, PERF_PAINT_MS, PERF_BUCKET_MS,
+  } = probeMod;
+
+  // ---- the two pure formatters (no DOM, no window — this is why they are pure)
+  ok(formatLoadContext({ heat: 'hot', flash: 14, vwin: 2, spiral: 1, drain: 1, gov: true, lite: true })
+    === 'fx:hot fl:14 vw:2 sp dr gov lite',
+    'the load context names the burst, the windows, the spiral, the veil, the governor and the tier',
+    formatLoadContext({ heat: 'hot', flash: 14, vwin: 2, spiral: 1, drain: 1, gov: true, lite: true }));
+  ok(formatLoadContext({ heat: 'idle' }) === 'fx:idle',
+    'and an idle page is ONE token — zero counts are omitted or the line does not fit on a phone',
+    formatLoadContext({ heat: 'idle' }));
+  ok(formatLoadContext(null) === 'fx:idle', 'a missing bag reads as idle, never as a throw');
+
+  ok(formatPerfLine({ fps: 59.6, worstMs: 18.2, hits: 0, longestMs: 0, observed: true, ctx: 'fx:idle' })
+    === '60fps · worst 18ms · lt 0 · fx:idle',
+    'a healthy page is one short line',
+    formatPerfLine({ fps: 59.6, worstMs: 18.2, hits: 0, longestMs: 0, observed: true, ctx: 'fx:idle' }));
+  const sick = formatPerfLine({ fps: 19.4, worstMs: 412.7, hits: 4, longestMs: 380.2, observed: true, ctx: 'fx:hot fl:14' });
+  ok(sick === '19fps · worst 413ms · lt 4/380ms · fx:hot fl:14',
+    'and a sick one carries the fps, the worst gap, the tally and the load that caused it', sick);
+  const safari = formatPerfLine({ fps: 19, worstMs: 412, hits: 4, longestMs: 412, observed: false, ctx: 'fx:hot' });
+  ok(/lt~ 4/.test(safari),
+    'WITHOUT the longtask API the tally is written `lt~` — the tilde is the whole caveat, and it '
+    + 'stops anyone comparing a Safari number to a Chromium one by accident', safari);
+
+  ok(typeof readLoadContext() === 'object' && readLoadContext().heat === 'idle',
+    'readLoadContext answers off a page with no DOM at all rather than throwing');
+  ok(readLoadContext() === readLoadContext(),
+    'and it refills ONE shared bag — a fresh object twice a second is the only garbage this '
+    + 'module could produce');
+
+  // ---- the loop, over a hand-cranked window
+  const mkWin = () => {
+    let clock = 0;
+    let pending = null;
+    let rafCalls = 0;
+    const seen = new Set();
+    return {
+      now: () => clock,
+      rafCalls: () => rafCalls,
+      distinctCallbacks: () => seen.size,
+      /** Advance the clock by `ms` and deliver one frame. */
+      step(ms) { clock += ms; const fn = pending; pending = null; if (fn) fn(clock); },
+      win: {
+        performance: { now: () => clock },
+        requestAnimationFrame(fn) { rafCalls++; seen.add(fn); pending = fn; return rafCalls; },
+        cancelAnimationFrame() { pending = null; },
+        // NO PerformanceObserver — this is the Safari/iOS shape on purpose.
+      },
+    };
+  };
+
+  {
+    const h = mkWin();
+    const warns = [];
+    let status = '';
+    const probe = createPerfProbe({
+      win: h.win,
+      setStatus: (t) => { status = t; },
+      onWarn: (m) => warns.push(m),
+      context: () => ({ heat: 'hot', flash: 12, vwin: 1, gov: true, lite: true }),
+      warnMs: 100, paintMs: 0, cooldownMs: 0,
+    });
+    ok(probe.start() === true, 'the probe starts');
+    for (let i = 0; i < 20; i++) h.step(16);          // ~320ms of healthy frames
+    ok(Math.round(probe.sample().fps) === 63,
+      'twenty 16ms frames read as ~63fps', String(Math.round(probe.sample().fps)));
+    ok(warns.length === 0, 'and a healthy page says nothing at all', warns.join(' | '));
+    ok(/63fps · worst 16ms · lt~ 0 · fx:hot fl:12 vw:1 gov lite/.test(status),
+      'the readout is one line and it carries the load context', status);
+
+    h.step(400);                                       // …and then the hitch
+    ok(probe.sample().worstMs === 400, 'the worst gap is captured exactly',
+      String(probe.sample().worstMs));
+    ok(warns.length === 1, 'one warn, not one per frame', String(warns.length));
+    ok(/^perf: frame stall 400ms/.test(warns[0]),
+      'WITHOUT the longtask API a 400ms gap IS the long task, and the line says which detector '
+      + 'saw it', warns[0]);
+    ok(/fx:hot fl:12 vw:1 gov lite/.test(warns[0]),
+      'and it names what was on screen when it happened — the whole point of the exercise',
+      warns[0]);
+    ok(/\|.*fps worst 400ms/.test(warns[0]), 'plus the running numbers, so one line is enough',
+      warns[0]);
+    ok(probe.sample().hits === 1 && probe.sample().observed === false,
+      'the stall is tallied and flagged as gap-derived');
+
+    // ONE function object, handed back to rAF every frame. An inline arrow here
+    // would be sixty closures a second in the loop that measures the page.
+    ok(h.distinctCallbacks() === 1,
+      'the frame callback is a single hoisted function, not a per-frame closure',
+      String(h.distinctCallbacks()));
+
+    probe.stop();
+    ok(probe.running() === false && status === '',
+      'stop unsubscribes and clears the readout');
+    const before = h.rafCalls();
+    h.step(16);
+    ok(h.rafCalls() === before, 'and a stopped probe never re-arms itself', String(h.rafCalls()));
+  }
+
+  // ---- the cooldown: a page genuinely on fire may not flood the C# log
+  {
+    const h = mkWin();
+    const warns = [];
+    const probe = createPerfProbe({
+      win: h.win, onWarn: (m) => warns.push(m), context: () => ({ heat: 'hot' }),
+      warnMs: 50, paintMs: 100000, cooldownMs: 1000,
+    });
+    probe.start();
+    h.step(16);
+    for (let i = 0; i < 4; i++) h.step(200);          // four stalls inside one cooldown
+    ok(warns.length === 1, 'four stalls inside one cooldown produce ONE line, not four',
+      String(warns.length));
+    h.step(2000);
+    ok(warns.length === 2 && /\(\+\d+ more/.test(warns[1]),
+      'and the next line that gets through REPORTS the ones the cooldown ate — the rate limit '
+      + 'costs a timestamp, not a fact', warns[1]);
+    probe.stop();
+  }
+
+  // ---- with a longtask observer, the rAF detector stands down (or every hitch
+  //      would be counted twice and every number on the line would be inflated)
+  {
+    const h = mkWin();
+    const warns = [];
+    let cb = null;
+    h.win.PerformanceObserver = function PO(fn) { cb = fn; };
+    h.win.PerformanceObserver.supportedEntryTypes = ['longtask', 'paint'];
+    h.win.PerformanceObserver.prototype.observe = function () {};
+    h.win.PerformanceObserver.prototype.disconnect = function () {};
+    const probe = createPerfProbe({
+      win: h.win, onWarn: (m) => warns.push(m), context: () => ({ heat: 'warm' }),
+      warnMs: 100, paintMs: 100000, cooldownMs: 0,
+    });
+    probe.start();
+    ok(probe.sample().observed === true, 'the observer took, so the readout drops the tilde');
+    h.step(16);
+    h.step(500);                                       // a huge gap the observer already saw
+    ok(probe.sample().hits === 0,
+      'the rAF detector does NOT double-count it — the observer owns the tally here',
+      String(probe.sample().hits));
+    cb({ getEntries: () => [{ duration: 312 }] });
+    ok(probe.sample().hits === 1 && Math.round(probe.sample().longestMs) === 312,
+      'and a real longtask entry is what counts', JSON.stringify(probe.sample().hits));
+    ok(/^perf: long task 312ms/.test(warns[0]), 'named as a long task, not a stall', warns[0]);
+    probe.stop();
+  }
+
+  // ---- no rAF at all (node, the import sweep) -> an inert handle, never a throw
+  const headless = createPerfProbe({ win: null });
+  ok(headless.start() === false && headless.running() === false && headless.sample() === null,
+    'no requestAnimationFrame -> every method is a no-op, exactly like the overlay handle');
+  headless.stop();
+
+  ok(PERF_LONGTASK_WARN_MS === 250 && PERF_PAINT_MS === 500 && PERF_BUCKET_MS === 2500,
+    'the dials: warn over 250ms, repaint at most 2x/s, two 2.5s buckets = the ~5s window');
+
+  // ---- and boot wires it BEHIND the debug flag and nowhere else
+  const bootSrc = read('boot.js');
+  ok(/import\('\.\/ui\/perfProbe\.js'\)/.test(bootSrc),
+    'the probe is a dynamic import, so a page that never asks for debug never fetches it');
+  ok(/function initPerfProbe\(\)/.test(bootSrc)
+    && bootSrc.indexOf('initPerfProbe();') > bootSrc.indexOf("import('./ui/debugOverlay.js')"),
+    'and it is armed INSIDE the branch that already decided the overlay was wanted — one gate, '
+    + 'not two that can disagree');
+  ok(/onWarn: \(m\) => logger\.warn\(m\)/.test(bootSrc),
+    'its warns go through logger.warn — the ONE sink that reaches the C# host log, the console '
+    + 'and the overlay ring at once');
+  ok(/setStatus: \(t\) =>/.test(bootSrc), 'and the readout goes to the overlay status row');
+
+  // ---- the fence: ui/ may import exec/, but never the other way round
+  const probeSrc = read('ui/perfProbe.js');
+  ok(!/from '\.\.\/net\//.test(probeSrc),
+    'ui/perfProbe.js imports nothing from net/ — it reads the render tier, not the wire');
+  ok(/from '\.\.\/exec\/loadGovernor\.js'/.test(probeSrc)
+    && /from '\.\.\/exec\/layers\.js'/.test(probeSrc)
+    && /from '\.\.\/exec\/perfTier\.js'/.test(probeSrc),
+    'it reads the governor, the layer registry and the device tier — three cheap READERS, no '
+    + 'renderer, no subscription');
+  const execFiles = fs.readdirSync(path.join(HERE, '..', 'exec'));
+  let leaked = '';
+  for (const f of execFiles) {
+    if (!f.endsWith('.js')) continue;
+    if (/perfProbe/.test(read('exec/' + f))) leaked += f + ' ';
+  }
+  ok(leaked === '', 'and nothing in exec/ knows the probe exists — the fence held', leaked);
 }
 
 /* ============================================================================

--- a/ConditioningControlPanel/Resources/web/goon/ui/debugOverlay.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/debugOverlay.js
@@ -37,6 +37,10 @@ export const OVERLAY_Z = 2147483000;
 
 const ON = /^(1|true|on|yes)$/i;
 
+/** The perf status row's look, minus its display: — setStatus rewrites the whole string. */
+const STATUS_CSS = 'padding:2px 8px;color:#9ff5d0;background:rgba(0,0,0,.25);'
+  + 'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;';
+
 /** Is the flag on in a raw querystring? `?debug=1`, `?debug` and `?debug=true` all count. */
 export function debugInSearch(search) {
   const s = String(search || '');
@@ -89,7 +93,8 @@ export function describe(v) {
  * @param {number} [o.max] ring size
  * @param {() => number} [o.now] injectable clock
  * @returns {{push:(level:string,msg:any)=>void, lines:()=>string[], collapsed:()=>boolean,
- *            toggle:()=>void, node:object|null, dispose:()=>void}}
+ *            toggle:()=>void, setStatus:(text:string)=>void, status:()=>string,
+ *            node:object|null, dispose:()=>void}}
  */
 export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Date.now() } = {}) {
   const d = doc || (typeof document !== 'undefined' ? document : null);
@@ -97,13 +102,15 @@ export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Da
   let root = null;
   let body = null;
   let badge = null;
+  let statusRow = null;
+  let statusText = '';
   let collapsed = false;
   let disposed = false;
   const cap = Math.max(1, max | 0);
 
   const noop = {
     push() {}, lines() { return []; }, collapsed() { return false; },
-    toggle() {}, node: null, dispose() {},
+    toggle() {}, setStatus() {}, status() { return ''; }, node: null, dispose() {},
   };
   if (!d || !d.body || typeof d.createElement !== 'function') return noop;
 
@@ -125,6 +132,20 @@ export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Da
       + 'cursor:pointer;touch-action:manipulation;');
     badge.textContent = 'debug 0';
 
+    /* THE STATUS LINE — one row, rewritten in place, never appended to the ring.
+     * ui/perfProbe.js repaints it twice a second; if it went through push() it
+     * would flush the last fifty warn lines out of the ring in twenty-five
+     * seconds, which would destroy the thing this overlay exists for.
+     *
+     * It sits ABOVE the scrolling body and OUTSIDE the collapse, on purpose: one
+     * folded 16px badge plus a live fps line is a readout you can play a match
+     * under, which is the only condition the numbers are worth anything in. It
+     * is created empty and hidden, so a page with no probe — every page before
+     * this one — shows exactly what it always showed. */
+    statusRow = d.createElement('div');
+    statusRow.id = 'gg-debug-perf';
+    style(statusRow, STATUS_CSS + 'display:none;');
+
     body = d.createElement('div');
     body.id = 'gg-debug-body';
     // 30vh, and the badge is the TOP row so one tap folds it to a 16px bar: a
@@ -133,6 +154,7 @@ export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Da
     style(body, 'max-height:30vh;overflow:auto;padding:4px 8px 6px;white-space:pre-wrap;word-break:break-word;');
 
     root.appendChild(badge);
+    root.appendChild(statusRow);
     root.appendChild(body);
     // TAP ANYWHERE ON THE STRIP, not just a hit-box: a 10px close button on a
     // phone is a control that does not exist.
@@ -171,6 +193,22 @@ export function createDebugOverlay({ doc = null, max = MAX_LINES, now = () => Da
       } catch (_e) { /* a log line can never be the thing that breaks the page */ }
     },
     lines() { return ring.map((e) => e.at + ' ' + e.level + ' ' + e.msg); },
+
+    /**
+     * The perf readout, rewritten in place. NEVER throws and never allocates a
+     * node — the probe calls this on a timer and the overlay is not allowed to
+     * become the thing that costs frames on the machine it is measuring.
+     */
+    setStatus(text) {
+      if (disposed) return;
+      statusText = String(text == null ? '' : text).slice(0, 200);
+      try {
+        statusRow.textContent = statusText;
+        style(statusRow, STATUS_CSS + 'display:' + (statusText ? 'block' : 'none') + ';');
+      } catch (_e) { /* stub DOM */ }
+    },
+    status() { return statusText; },
+
     collapsed() { return collapsed; },
     toggle() {
       collapsed = !collapsed;

--- a/ConditioningControlPanel/Resources/web/goon/ui/perfProbe.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/perfProbe.js
@@ -1,0 +1,399 @@
+/* ============================================================================
+ * ui/perfProbe.js — THE PLAY-TEST'S STOPWATCH.
+ *
+ * WHY THIS EXISTS (2026-08-05, phone play-test r9). The owner reports lag on an
+ * iPhone 13 Pro Max and three rounds of code-reading have produced three
+ * plausible culprits and no evidence. PR #129's perf tier and #130's load
+ * governor were both authored from a READING of the render paths; neither can be
+ * confirmed or refuted by another reading. The next play-test has to come back
+ * with numbers, and the phone has no devtools, no console and — standalone — not
+ * even the C# log the desktop writes to. So the page measures itself.
+ *
+ * WHAT IT MEASURES, and why exactly these three:
+ *
+ *   · ROLLING FPS. The headline. "It lagged" and "it ran at 19fps for the whole
+ *     Live phase" are different bug reports.
+ *   · WORST FRAME GAP IN THE LAST ~5s. Mean fps hides the failure mode that
+ *     actually reads as lag: 58fps with one 400ms hitch per burst feels far
+ *     worse than a steady 40, and averages erase it completely.
+ *   · LONG TASKS. The only signal that says WHO: a 300ms task is main-thread
+ *     JavaScript or layout, never the GPU, which points at the renderers rather
+ *     than at the compositor.
+ *
+ * SAFARI HAS NO longtask ENTRY TYPE, and that is not a footnote — it is the
+ * target device. A PerformanceObserver that silently observes nothing would have
+ * shipped a telemetry feature that reports zero long tasks on the one machine
+ * the feature exists for. So when the entry type is unavailable the rAF loop
+ * itself becomes the detector: a frame gap over the same threshold IS a long
+ * task seen from the other side (the main thread was busy and did not paint),
+ * and the readout says which of the two it is measuring rather than pretending
+ * they are the same number.
+ *
+ * COST. Nothing here is imported unless `?debug=1` asked for it (boot.js loads
+ * the module dynamically inside the branch that already decided to build the
+ * overlay), so the shipped page pays ONE dynamic import that never happens.
+ * Inside the loop the rules are strict:
+ *   · the rAF callback is a NAMED HOISTED FUNCTION passed by reference — no
+ *     closure, no bound method, no arrow allocated per frame;
+ *   · per frame it does arithmetic on `let` numbers and nothing else — no
+ *     objects, no arrays, no strings, no Date;
+ *   · the readout is rebuilt at most PERF_PAINT_MS apart (2x/s) and the load
+ *     context is read into ONE REUSED bag, so even the slow path allocates a
+ *     handful of strings a second rather than sixty.
+ *
+ * THE FRAME BUDGET IS TWO BUCKETS, NOT A RING BUFFER. "Worst gap in the last 5
+ * seconds" wants a sliding window; a sliding window wants an array of samples;
+ * an array of samples is an allocation per frame. Two half-windows of
+ * PERF_BUCKET_MS each — the one filling now and the one before it — give a
+ * window that slides between 2.5s and 5s of history using four numbers and no
+ * memory at all. The imprecision is in the window LENGTH, never in the maximum
+ * it reports, which is the number anyone actually reads.
+ *
+ * FENCES. This file lives in ui/ and imports from exec/ — which is the legal
+ * direction (exec/ never imports ui/ or net/, and that is the fence that
+ * matters). It imports only the three cheap READERS: the load governor, the
+ * layer registry and the device tier. It never imports a renderer, never
+ * subscribes to anything, and never writes.
+ *
+ * Import-safe under node: no DOM, no window, no timers at module scope.
+ * ==========================================================================*/
+
+import { governorBusy } from '../exec/loadGovernor.js';
+import { get as layerNode, fxHeat } from '../exec/layers.js';
+import { perfLite } from '../exec/perfTier.js';
+
+/** A task/stall at or over this many ms earns a warn-level line. */
+export const PERF_LONGTASK_WARN_MS = 250;
+/** The readout is rebuilt no more often than this — "throttled, <= 2x/s". */
+export const PERF_PAINT_MS = 500;
+/** Half of the worst-gap window. Two of these are what "the last 5s" means here. */
+export const PERF_BUCKET_MS = 2500;
+/**
+ * The floor between two warn lines. A page that is genuinely on fire can fire a
+ * long task every frame, and sixty warns a second would flood the 400-char C#
+ * log line for line until the useful ones scrolled out — the exact failure the
+ * logger's header warns about. Suppressed hits are COUNTED and reported on the
+ * next line that gets through, so the rate limit costs a timestamp, not a fact.
+ */
+export const PERF_WARN_COOLDOWN_MS = 1000;
+
+/* ------------------------------------------------------------------ formatting (pure) */
+
+/**
+ * The load context as one short token list. PURE — the caller reads the world,
+ * this only names it — so the self-test can pin every token without a DOM.
+ *
+ * Zero counts are OMITTED. The line has to fit on a phone in 10px monospace next
+ * to the fps, and `fl:0 vw:0 bb:0 sb:0 bo:0` is five tokens of "nothing is
+ * happening" crowding out the one that says what is.
+ *
+ * @param {object} b the bag readLoadContext fills
+ * @returns {string} e.g. `fx:hot fl:14 vw:2 sp dr gov lite`
+ */
+export function formatLoadContext(b) {
+  const g = b && typeof b === 'object' ? b : {};
+  let s = 'fx:' + (g.heat || 'idle');
+  if (g.flash > 0) s += ' fl:' + g.flash;      // flashes on screen — a burst, or the bed
+  if (g.vwin > 0) s += ' vw:' + g.vwin;        // floating video windows open
+  if (g.bubbles > 0) s += ' bb:' + g.bubbles;
+  if (g.sub > 0) s += ' sb:' + g.sub;
+  if (g.bounce > 0) s += ' bo:' + g.bounce;
+  if (g.spiral > 0) s += ' sp';                // the spiral bed is woven
+  if (g.drain > 0) s += ' dr';                 // the drain veil is up
+  if (g.stage > 0) s += ' st';                 // centre stage is occupied (ramp video, lock card)
+  if (g.gov) s += ' gov';                      // a payload squall holds the governor (lite only)
+  if (g.lite) s += ' lite';
+  return s;
+}
+
+/**
+ * The one-line readout. PURE, for the same reason as above.
+ *
+ * `worst` is the gap; `lt` is the long-task tally. When the browser has no
+ * longtask entry type the tally is written `lt~` — the tilde is the whole
+ * caveat, and it means "counted from frame gaps, not from the API", so nobody
+ * compares a Safari number to a Chromium one without noticing.
+ *
+ * @param {{fps:number, worstMs:number, hits:number, longestMs:number,
+ *          observed:boolean, ctx:string}} s
+ */
+export function formatPerfLine(s) {
+  const v = s && typeof s === 'object' ? s : {};
+  const fps = Math.max(0, Math.round(v.fps || 0));
+  const worst = Math.max(0, Math.round(v.worstMs || 0));
+  const hits = Math.max(0, v.hits | 0);
+  const longest = Math.max(0, Math.round(v.longestMs || 0));
+  let line = fps + 'fps · worst ' + worst + 'ms';
+  line += ' · ' + (v.observed ? 'lt ' : 'lt~ ') + hits;
+  if (hits > 0) line += '/' + longest + 'ms';
+  return line + ' · ' + (v.ctx || '');
+}
+
+/* --------------------------------------------------------------- reading the world */
+
+/**
+ * The bag, allocated ONCE and refilled in place. The probe reads it twice a
+ * second and again on every warn; a fresh object each time would be the only
+ * garbage this module produces, and a perf tool that makes garbage is arguing
+ * against itself.
+ */
+const bag = {
+  heat: 'idle', flash: 0, vwin: 0, bubbles: 0, sub: 0, bounce: 0,
+  spiral: 0, drain: 0, stage: 0, gov: false, lite: false,
+};
+
+/** childElementCount of one fx layer, or 0 for "no DOM / no layer / it threw". */
+function countIn(name) {
+  try {
+    const el = layerNode(name);
+    return el && typeof el.childElementCount === 'number' ? el.childElementCount : 0;
+  } catch (_e) { return 0; }
+}
+
+/**
+ * Refill `bag` from the cheapest readers the page has. Every one of them is a
+ * cached element reference or a single attribute read — exec/layers.js memoizes
+ * its lookups and exec/perfTier.js reads one attribute off <html> — so this is
+ * a couple of microseconds, twice a second.
+ *
+ * NOTHING IS SUBSCRIBED TO and nothing is imported that could run code: the
+ * probe must be able to observe a wedged page, which rules out asking a
+ * renderer how it is doing.
+ *
+ * @returns {object} the shared bag (never a copy — do not retain it)
+ */
+export function readLoadContext() {
+  try { bag.heat = fxHeat(); } catch (_e) { bag.heat = 'idle'; }
+  bag.flash = countIn('flash');
+  bag.vwin = countIn('vwin');
+  bag.bubbles = countIn('bubbles');
+  bag.sub = countIn('sub');
+  bag.bounce = countIn('bounce');
+  bag.spiral = countIn('spiral');
+  bag.drain = countIn('drain');
+  bag.stage = countIn('stage');
+  try { bag.gov = governorBusy() === true; } catch (_e) { bag.gov = false; }
+  try { bag.lite = perfLite() === true; } catch (_e) { bag.lite = false; }
+  return bag;
+}
+
+/* --------------------------------------------------------------------- the probe */
+
+/**
+ * Build the probe. Returns a handle whose every method is a no-op when there is
+ * no rAF to hang off (node, a stub harness), so the caller never branches.
+ *
+ * @param {object} [o]
+ * @param {(text:string) => void} [o.setStatus] where the one-line readout goes
+ *        (ui/debugOverlay.js setStatus)
+ * @param {(msg:string) => void} [o.onWarn] warn-level sink — boot passes
+ *        logger.warn, which is the ONE call that reaches the C# host log AND
+ *        (via the logger's tee) the overlay's ring at the same time
+ * @param {object} [o.win] injectable window, for the self-test
+ * @param {() => object} [o.context] injectable load-context reader
+ * @param {number} [o.warnMs] TEST AFFORDANCE
+ * @param {number} [o.paintMs] TEST AFFORDANCE
+ * @param {number} [o.cooldownMs] TEST AFFORDANCE
+ */
+export function createPerfProbe({
+  setStatus = null, onWarn = null, win = null, context = null,
+  warnMs, paintMs, cooldownMs,
+} = {}) {
+  const w = win || (typeof window !== 'undefined' ? window : null);
+  const dead = { start() { return false; }, stop() {}, sample() { return null; }, running() { return false; } };
+  if (!w || typeof w.requestAnimationFrame !== 'function') return dead;
+
+  const WARN_MS = Number.isFinite(warnMs) ? warnMs : PERF_LONGTASK_WARN_MS;
+  const PAINT_MS = Number.isFinite(paintMs) ? paintMs : PERF_PAINT_MS;
+  const COOL_MS = Number.isFinite(cooldownMs) ? cooldownMs : PERF_WARN_COOLDOWN_MS;
+  const readCtx = typeof context === 'function' ? context : readLoadContext;
+  const emit = typeof onWarn === 'function' ? onWarn : null;
+  const paintTo = typeof setStatus === 'function' ? setStatus : null;
+
+  /* Every one of these is a plain number the frame callback mutates in place.
+   * cur* is the bucket filling now; prev* is the one before it. */
+  let running = false;
+  let rafId = 0;
+  let last = 0;              // timestamp of the previous frame
+  let bucketAt = 0;          // when the current bucket opened
+  let curFrames = 0;
+  let curSpan = 0;
+  let curWorst = 0;
+  let prevFrames = 0;
+  let prevSpan = 0;
+  let prevWorst = 0;
+  let paintedAt = 0;
+
+  let hits = 0;              // long tasks (or, unobserved, stalls) this session
+  let longest = 0;           // the worst one, ms
+  /* Last warn emitted, in loop time. It starts a long way in the PAST, not at
+   * zero: performance.now() is zero at page load, so `0` would mean "we already
+   * warned at boot" and would swallow the first hitch of every session — which
+   * on this page is the one during the very first burst. */
+  let warnedAt = -1e9;
+  let suppressed = 0;        // warns the cooldown ate since then
+  let observed = false;      // did PerformanceObserver('longtask') actually take?
+  let obs = null;
+
+  /** Now, in the same clock the rAF timestamp uses (so the two are comparable). */
+  function nowMs() {
+    try {
+      if (w.performance && typeof w.performance.now === 'function') return w.performance.now();
+    } catch (_e) { /* fall through */ }
+    return Date.now();
+  }
+
+  /** Rolling fps over both buckets. Falls back to the current one alone at t<2.5s. */
+  function fpsNow() {
+    const span = curSpan + prevSpan;
+    const frames = curFrames + prevFrames;
+    return span > 0 ? (frames * 1000) / span : 0;
+  }
+
+  /** The worst gap either half-window saw — "the last ~5 seconds". */
+  function worstNow() { return curWorst > prevWorst ? curWorst : prevWorst; }
+
+  /**
+   * One warn line, rate-limited. `kind` names WHICH detector fired, because the
+   * two have different blind spots and a reader has to be able to tell them
+   * apart six weeks later in a log file.
+   */
+  function warnLoad(kind, ms, at) {
+    if (!emit) return;
+    if (at - warnedAt < COOL_MS) { suppressed++; return; }
+    const extra = suppressed ? ' (+' + suppressed + ' more in the last ' + COOL_MS + 'ms)' : '';
+    warnedAt = at;
+    suppressed = 0;
+    try {
+      emit('perf: ' + kind + ' ' + Math.round(ms) + 'ms' + extra
+        + ' — ' + formatLoadContext(readCtx())
+        + ' | ' + Math.round(fpsNow()) + 'fps worst ' + Math.round(worstNow()) + 'ms');
+    } catch (_e) { /* a telemetry line can never be the thing that breaks the page */ }
+  }
+
+  /** Rebuild the readout. Only ever called from the throttled branch. */
+  function paint() {
+    if (!paintTo) return;
+    try {
+      paintTo(formatPerfLine({
+        fps: fpsNow(),
+        worstMs: worstNow(),
+        hits,
+        longestMs: longest,
+        observed,
+        ctx: formatLoadContext(readCtx()),
+      }));
+    } catch (_e) { /* ditto */ }
+  }
+
+  /**
+   * THE FRAME CALLBACK. Named and hoisted so `w.requestAnimationFrame(frame)`
+   * hands over the SAME function object every frame — an inline arrow here would
+   * be one closure allocation per frame, sixty a second, forever, which is the
+   * kind of thing this file exists to catch.
+   */
+  function frame(t) {
+    if (!running) return;
+    const now = typeof t === 'number' ? t : nowMs();
+    if (last > 0) {
+      const dt = now - last;
+      curFrames++;
+      curSpan += dt;
+      if (dt > curWorst) curWorst = dt;
+      /* THE SAFARI PATH. With no longtask API a gap this size is the only
+       * evidence a long task leaves, so it is counted as one — and the readout's
+       * `lt~` says that is what happened. When the API IS live this branch stays
+       * shut, because the observer already counted the same event and counting
+       * it twice would inflate every number on the line. */
+      if (!observed && dt >= WARN_MS) {
+        hits++;
+        if (dt > longest) longest = dt;
+        warnLoad('frame stall', dt, now);
+      }
+    }
+    last = now;
+
+    if (now - bucketAt >= PERF_BUCKET_MS) {
+      prevFrames = curFrames; prevSpan = curSpan; prevWorst = curWorst;
+      curFrames = 0; curSpan = 0; curWorst = 0;
+      bucketAt = now;
+    }
+    if (now - paintedAt >= PAINT_MS) { paintedAt = now; paint(); }
+
+    rafId = w.requestAnimationFrame(frame);
+  }
+
+  /** The observer callback — also hoisted, also passed by reference. */
+  function onLongTasks(list) {
+    let entries = null;
+    try { entries = list && typeof list.getEntries === 'function' ? list.getEntries() : null; }
+    catch (_e) { return; }
+    if (!entries) return;
+    for (let i = 0; i < entries.length; i++) {
+      const ms = Number(entries[i] && entries[i].duration) || 0;
+      hits++;
+      if (ms > longest) longest = ms;
+      if (ms >= WARN_MS) warnLoad('long task', ms, nowMs());
+    }
+  }
+
+  /**
+   * Wire the observer, or leave `observed` false so the rAF path takes over.
+   * `buffered:true` picks up the long tasks that fired during boot, which is
+   * exactly the window a debug session most wants and the one it can never
+   * otherwise see (the probe starts after the page has already done its worst).
+   */
+  function armObserver() {
+    try {
+      const PO = w.PerformanceObserver;
+      if (typeof PO !== 'function') return;
+      const types = PO.supportedEntryTypes;
+      if (Array.isArray(types) && types.indexOf('longtask') < 0) return;
+      obs = new PO(onLongTasks);
+      obs.observe({ type: 'longtask', buffered: true });
+      observed = true;
+    } catch (_e) {
+      // Safari, and any browser that names the type but refuses the observe.
+      obs = null;
+      observed = false;
+    }
+  }
+
+  return {
+    start() {
+      if (running) return true;
+      running = true;
+      last = 0;
+      bucketAt = nowMs();
+      paintedAt = bucketAt;
+      armObserver();
+      rafId = w.requestAnimationFrame(frame);
+      return true;
+    },
+
+    stop() {
+      running = false;
+      try { if (rafId && typeof w.cancelAnimationFrame === 'function') w.cancelAnimationFrame(rafId); }
+      catch (_e) { /* ignore */ }
+      rafId = 0;
+      try { if (obs) obs.disconnect(); } catch (_e) { /* ignore */ }
+      obs = null;
+      if (paintTo) { try { paintTo(''); } catch (_e) { /* ignore */ } }
+    },
+
+    running() { return running; },
+
+    /** The numbers, for a test or a report card. Allocates — never called per frame. */
+    sample() {
+      return {
+        fps: fpsNow(), worstMs: worstNow(), hits, longestMs: longest,
+        observed, suppressed, line: formatPerfLine({
+          fps: fpsNow(), worstMs: worstNow(), hits, longestMs: longest,
+          observed, ctx: formatLoadContext(readCtx()),
+        }),
+      };
+    },
+  };
+}
+
+export default createPerfProbe;


### PR DESCRIPTION
Two scoped features from the owner's live phone play-test (iPhone 13 Pro Max, build r9-20260805).

## 1. Transfer variety — "seems like I am receiving always the same gif"

Every gate passed and every layer worked. The receiver's pool was simply **too small and too lopsided for the first minute**, and at n=3 a uniform random draw with a one-item echo guard is a machine for producing runs — which is exactly why three rounds of code-reading found nothing.

### Sender half — `net/mediaQueue.js` (rule 3 in the file header)

| | before | after |
|---|---|---|
| **depth** | flat `QUEUE_DEPTH = 4` | `targetDepth()` keeps ~`QUEUE_AHEAD_MS` (45s) of **wire time** landed ahead: 10 for a library of 200 KB stills, 5 at 4 MB, 4 at 8 MB. The `eligible()` wire budget is untouched — this only decides how many of the already-affordable ones to keep ahead. `QUEUE_DEPTH_MAX` (10) stays below `LANDED_MAX` (12) so the ring can never truncate the working set. |
| **the draw** | `deck.pop()` | `nextPick` scores the top `PICK_SCAN` (12) cards of the still-shuffled, still-`Math.random` deck: **+2** for the kind the pool is short of, **+1** for an `origin` unlike the last pick, ties to the topmost. |
| **tags** | landed pool only, short sets went out partly empty | `markConsumed` writes a bounded `shown` ledger (sha to {kind, seq}); `tagsFor` fills a burst's spare slots from it least-recently-shown first. |

Both scores are **soft, never filters**: a single-kind library, an all-gif library and an empty one all behave byte-identically to before. `MAX_CONCURRENT_OUT` is deliberately left at 1 (it lives on the channel — two artifacts sharing one bulk lane is interleaving, not throughput), so depth buys **landings over time**, not parallelism.

The ledger **can only top up, never open**: a tag set that found nothing fresh still comes back `[]`, so "one landing, one drop" and the untagged diagnostic warn both survive intact, and "nothing new has landed" stays the receiver's rotation's job.

### Receiver half — `exec/media.js`

`drawReceived`/`peekReceived` now **rotate** (least-recently-shown first, ties broken at random) instead of drawing at random with a 1-item echo guard. A pool of three cycles A-B-C; a pool of ten walks all ten before repeating; a pool of one still draws it, because a rotation is not allowed to invent variety it does not have. The random tie-break matters: every artifact starts unshown, so a deterministic answer would walk the received Map's *insertion order* — a different way of being predictable.

`footageFirst` still outranks the rotation (a converted gif loop never takes a real clip's turn), and `dropReceived` prunes the ledger so a re-received artifact comes back at the front.

## 2. Perf telemetry in the `?debug=1` overlay

Code-reading has hit diminishing returns on the phone lag; the next play-test has to produce data, and the device has no devtools and — standalone — no C# log either.

New `ui/perfProbe.js`, dynamically imported **inside** the branch that already decided to build the overlay, so a shipped page pays one import that never happens.

**The readout** (one line, new status row above the log ring, repainted at most 2x/s):

```
19fps · worst 413ms · lt 4/380ms · fx:hot fl:14 vw:2 sp dr gov lite
```

- `19fps` — rolling, over two 2.5s buckets
- `worst 413ms` — worst frame gap in the last ~5s (two half-windows, four numbers, **no allocation**)
- `lt 4/380ms` — long tasks this session / the longest. Written **`lt~`** when the browser has no `longtask` entry type
- the rest is the live load: fx heat, flash / vwin / bubble / sub / bounce counts, `sp` spiral woven, `dr` drain up, `st` stage occupied, `gov` a payload squall holds the load governor, `lite` the perf tier. Zero counts are omitted.

**The warn line**, at `logger.warn` — the one sink that reaches the C# host log, the console and the overlay ring at once — whenever a task or stall passes 250 ms:

```
perf: long task 312ms (+3 more in the last 1000ms) — fx:hot fl:14 vw:2 sp dr gov lite | 19fps worst 340ms
```

**Safari has no `longtask` entry type** — and Safari is the target device. A `PerformanceObserver` that silently observed nothing would have shipped telemetry that reports zero long tasks on the one machine it exists for, so when the type is unavailable the rAF loop becomes the detector (a >250 ms frame gap *is* a long task seen from the other side) and the line says `frame stall` / `lt~` rather than pretending they are the same number. When the observer *is* live the rAF detector stands down, or every hitch would be counted twice.

The warn is rate-limited to one per second with the suppressed count carried onto the next line — sixty warns a second would flood the 400-char C# log until the useful lines scrolled out.

`window.__gg.perf.sample()` exposes the numbers for the C# play-test driver.

## Constraints held
- `exec/` imports neither `net/` nor `ui/`; the probe lives in `ui/` and imports only three cheap **readers** from `exec/` (governor, layer registry, device tier) — pinned by a test that sweeps `exec/` for any mention of it.
- **Full/desktop behaviour is identical when `?debug` is absent** — the module is never fetched.
- `bridge.js` untouched.

## Tests
`selftest-transfer`, `selftest-net`, `selftest-exec`, `selftest-hud`, `selftest-flow` green, plus every other suite. New pins:
- **flow 6i** — depth-by-size (ceiling / mid / floor / empty), and the first two landings are one of each kind, `Math.random` pinned so the regression cannot hide half the time
- **flow 6j** — the shown ledger: fresh-first, LRU repeats in order, and `[]` when nothing fresh is left
- **exec** — thirty draws over three files are ten complete cycles, nothing back-to-back, a pool of one still draws, peek reads the rotation without spending it, `dropReceived` prunes, footage still outranks
- **flow 7/7b** — the status row never touches the ring; the probe's formatters, the gap detector, the cooldown, the observer stand-down, the inert headless handle, the single hoisted rAF callback, boot's wiring and the module fence

`selftest-avafx`'s 12 pre-existing failures are untouched.

## Found but not fixed
- `exec/flashes.js` sets `peer: true` on every FlashBurst run, so a burst already spends its untagged slots on `drawReceived` — which makes the sender's ledger top-up belt-and-braces rather than the main lever. It is kept because the tag is *exact* and shows the sender's intent in the match log.
- The probe cannot distinguish "a burst is on" from "the sustained bed is dense"; `fl:N` + `gov` is the closest cheap proxy. A real burst flag would need a new global.
- `MAX_CONCURRENT_OUT = 1` is untouched; if the play-test shows the pool still growing too slowly, that is the next lever and it belongs to `net/mediaChannel.js`.
- Not play-tested on a device — that is the point of the telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
