### PR TITLE
fix(goon): remove the last diamonds from the HUD and de-yellow the closeness dial

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -1064,7 +1064,7 @@ function makeFakeMatch() {
  *
  * Batch 7 took the meters and the pips; what it left behind was the MULTIPLIER
  * — the same engine number (`scoring.riskMultiplier`, product of the 0-7 tier)
- * printed in three places: "×1.30 score" under the live HUD's charge pips,
+ * printed in three places: "×1.30 score" under the live HUD's charge row,
  * "you both score ×1.30" in gold in the draft footer, and "1 pt/s · score
  * ×1.30" in the recap's fine print. The owner's verdict covered the family:
  * not intuitive, and the heat gauge is the readout the desk actually needed.
@@ -1108,9 +1108,132 @@ function makeFakeMatch() {
   const hostRisk = dom.byId.get('gg-hud');
   ok(findAll(hostRisk, 'gg-mult').length === 0, 'the live HUD builds no .gg-mult readout');
   ok(findAll(hostRisk, 'gg-risk').length === 0, 'and nothing wearing the old .gg-risk name');
-  ok(findAll(hostRisk, 'gg-pips').length === 1,
-    'while the CHARGE pips — which are not risk and never were — are still there');
+  ok(findAll(hostRisk, 'gg-pips').length === 0,
+    'and the charge PIP ROW went with it in the second pass (see 2c-iii)');
   hudRisk.unmount();
+}
+
+/* ---- 2c-iii. AND THE CHARGE PIPS WENT TOO (2026-08-05, second pass) --------
+ *
+ * The first pass argued the charge pips were not the risk indicator and kept
+ * them: they are what you hold to throw, core/wire.js validates throws against
+ * them and the arsenal pays its costs out of them, so they carried real state.
+ * The owner saw them in play anyway — "the little yellow squares that we were
+ * supposed to have removed" — and that settles it: the objection was to the
+ * SHAPE, and a row of rotated squares under the score is not distinguishable,
+ * at arm's length on a phone, from the row of rotated squares that had just
+ * come off the draft tiles.
+ *
+ * So the data stayed and the diamond went, in BOTH places it was drawn: yours
+ * under the score (`.gg-pips`) and theirs in the monitor titlebar
+ * (`.gg-mon-pips`, the `.gg-pip--sm` variant). Leaving the second would have
+ * kept the complained-about shape on screen two inches from where it was
+ * deleted, and kept the CSS alive to grow a third user.
+ *
+ * WHAT THIS SECTION PINS, in order: the words are there and say the number; the
+ * cap is still readable on YOUR line; the gain juice (sfx + "+1" chip) survived
+ * the pips it used to be attached to; a SPEND is silent; and no `.gg-pip` node
+ * or rule exists anywhere on the desk. The last one is the regression guard —
+ * this comes back as somebody adding "just a little indicator". */
+{
+  const fsChg = await import('node:fs/promises');
+  const urlChg = await import('node:url');
+  const readUi = (rel) => fsChg.readFile(urlChg.fileURLToPath(new URL('../' + rel, import.meta.url)), 'utf8');
+
+  // ---- the strings themselves -------------------------------------------
+  ok(typeof S.hud.charges === 'function', 'strings.js carries hud.charges(n, cap)');
+  ok(typeof S.monitor.charges === 'function', 'and monitor.charges(n) for theirs');
+  ok(/\bcharges\b/.test(S.hud.charges(3, 5)), 'your line says the WORD charge, not a shape',
+    S.hud.charges(3, 5));
+  ok(S.hud.charges(3, 5).includes('3') && S.hud.charges(3, 5).includes('5'),
+    'and carries both the held count and the cap — the pips said the cap by being five',
+    S.hud.charges(3, 5));
+  ok(S.monitor.charges(1) === '1 charge' && S.monitor.charges(0) === '0 charges'
+    && S.monitor.charges(4) === '4 charges',
+    'their count pluralises, and never prints "1 charges" beside a live name',
+    [S.monitor.charges(1), S.monitor.charges(0), S.monitor.charges(4)].join(' | '));
+  ok(!/\//.test(S.monitor.charges(2)),
+    'their line omits the cap — their ceiling is not a number you can spend against',
+    S.monitor.charges(2));
+
+  // ---- the mounted desk --------------------------------------------------
+  const matchChg = makeFakeMatch();                 // scoring.charges starts at 3
+  const audioChg = { ids: [], sfx(id) { audioChg.ids.push(id); } };
+  const hudChg = hudMod.mountHud({ match: matchChg, audio: audioChg });
+  const hostChg = dom.byId.get('gg-hud');
+
+  ok(findAll(hostChg, 'gg-pip').length === 0, 'the mounted HUD contains no .gg-pip node at all');
+  ok(findAll(hostChg, 'gg-pips').length === 0, 'nor the row that held them');
+  ok(findAll(hostChg, 'gg-mon-pips').length === 0, 'nor the monitor titlebar copy of it');
+
+  const chargeLine = findOne(hostChg, 'gg-charges');
+  ok(!!chargeLine, 'the scorebox carries one .gg-charges line instead');
+  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(3, GoonConsts.ChargeCap),
+    'painted from the engine on the very first paint, cap and all',
+    String(chargeLine && chargeLine.textContent));
+
+  const monLine = findOne(hostChg, 'gg-mon-charges');
+  ok(!!monLine, 'and their titlebar carries .gg-mon-charges');
+  ok(String(monLine && monLine.textContent).indexOf(S.monitor.charges(2)) >= 0,
+    'showing the count off match.opponent.charges (2 in the stub)',
+    String(monLine && monLine.textContent));
+
+  // ---- a GAIN: the number moves, and the juice the pips wore survives -----
+  audioChg.ids.length = 0;
+  matchChg.scoring.charges = 4;
+  await sleep(260);                                  // paintAll polls at 200ms
+  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(4, GoonConsts.ChargeCap),
+    'a gain repaints the line', String(chargeLine && chargeLine.textContent));
+  ok(audioChg.ids.includes('gg-charge'),
+    'and still plays gg-charge — the cue was never the pip, it was the charge',
+    audioChg.ids.join(','));
+  ok(findAll(hostChg, 'gg-plus1').length === 1,
+    'and still throws the floating "+1" chip, which is now the WHOLE flourish');
+
+  // ---- a SPEND: the number moves back, in silence ------------------------
+  await sleep(950);                                  // let the chip retire itself
+  ok(findAll(hostChg, 'gg-plus1').length === 0, 'the chip removes itself after its 900ms');
+  audioChg.ids.length = 0;
+  matchChg.scoring.charges = 1;
+  await sleep(260);
+  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(1, GoonConsts.ChargeCap),
+    'spending three on an item repaints the line down',
+    String(chargeLine && chargeLine.textContent));
+  ok(!audioChg.ids.includes('gg-charge'), 'and is silent — you only hear the ones you earn',
+    audioChg.ids.join(','));
+  ok(findAll(hostChg, 'gg-plus1').length === 0, 'with no "+1" on the way down');
+
+  // ---- an unchanged poll must not rewrite anything -----------------------
+  audioChg.ids.length = 0;
+  await sleep(260);
+  ok(!audioChg.ids.includes('gg-charge'),
+    'and a poll that finds the same number does nothing at all — the memo still holds');
+
+  hudChg.unmount();
+  ok(findAll(hostChg, 'gg-charges').length === 0, 'and unmount takes the line with it');
+
+  // ---- the source, because that is where it regrows ----------------------
+  const strip = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+  for (const rel of ['ui/hud.js', 'ui/opponent.js']) {
+    const code = strip(await readUi(rel));
+    ok(!/gg-pip/.test(code), `${rel} builds no gg-pip node (comments may name the dead class)`,
+      (code.match(/.*gg-pip.*/) || [''])[0].trim());
+  }
+
+  /* The CSS half. Comments are allowed to name the class — the tombstone at the
+   * top of the score block does, on purpose — so this strips them first and then
+   * looks for a live SELECTOR. `.gg-cost-pip` is deliberately not caught by the
+   * word boundary: it is the arsenal's round amber cost dot, a different thing
+   * that was never part of the complaint, and it stays. */
+  const cssChg = (await readUi('ui/hud.css')).replace(/\/\*[\s\S]*?\*\//g, '');
+  ok(!/(^|[\s,{}])\.gg-pips?\b/.test(cssChg), 'hud.css has no live .gg-pip / .gg-pips rule',
+    (cssChg.match(/.*\.gg-pips?\b.*/) || [''])[0].trim());
+  ok(!/\.gg-pip--sm\b/.test(cssChg), 'and the small variant went with its one caller');
+  ok(!/@keyframes\s+ggPipPop/.test(cssChg), 'and the pop keyframe has no pip left to bounce');
+  ok(/\.gg-cost-pip\s*\{/.test(cssChg),
+    'while the arsenal cost dots — round, amber, welded to their tile — are untouched');
+  ok(/\.gg-charges\s*\{/.test(cssChg) && /\.gg-mon-charges\s*\{/.test(cssChg),
+    'and both text readouts are styled');
 }
 
 // -------------------------------------------------------- 3. closeness + emotes
@@ -3378,6 +3501,58 @@ const audioMod = await import('../ui/audio.js');
   ok(dialMin < 15, 'the closeness dial is narrower than the 15rem it shipped at', String(dialMin));
   ok(/\.gg-dial-stop\s*\{[^}]*min-height:\s*48px/.test(hudCss13),
     'but its four stops keep their 48px touch target — the plate shrank, the targets did not');
+
+  /* ---- THE DIAL HAS NO YELLOW (owner, 2026-08-05) -----------------------
+   * Second half of the same "little yellow squares" complaint that took the
+   * charge pips: at `close`, every lit bar on this row turned --gg-gold, and in
+   * a mid-match screenshot four short gold blocks under the score read as
+   * exactly the indicator the owner had already had removed twice.
+   *
+   * PINNED AS A HUE BAN OVER THE WHOLE DIAL, not as one selector, because that
+   * is how it comes back — a `.is-warm` or a hover state picking gold up again
+   * because the rest of the app uses it freely. Gold is still legal EVERYWHERE
+   * ELSE on the desk and the last two checks say so out loud: this was a
+   * targeted restyle, and a blanket find-and-replace across hud.css would be a
+   * different (and wrong) change. Intensity carries the ramp instead, which is
+   * only legal because every stop is a word and the head stop is taller. */
+  {
+    const rules = [];
+    const reDial = /([^{}]+)\{([^{}]*)\}/g;
+    let mDial;
+    while ((mDial = reDial.exec(hudCss13.replace(/\/\*[\s\S]*?\*\//g, '')))) {
+      if (/\.gg-dial/.test(mDial[1])) rules.push(mDial[1].trim() + ' {' + mDial[2] + '}');
+    }
+    ok(rules.length >= 6, 'the dial still has its rules to check', String(rules.length));
+    for (const rule of rules) {
+      ok(!/--gg-gold|ffd45e|255,\s*212,\s*94/i.test(rule),
+        'no gold anywhere on the closeness dial', rule.slice(0, 120));
+      ok(!/--gg-amber|ffb454/i.test(rule),
+        'and no amber either — the neighbouring warm hue is the same mistake', rule.slice(0, 120));
+    }
+    ok(/--gg-pink-deep:\s*#[0-9a-f]{6}/i.test(hudCss13),
+      'the middle rung has a named colour of its own');
+    ok(/\.gg-dial\[data-gg-close="2"\][^{}]*\{[^}]*--gg-pink-deep/.test(hudCss13),
+      'and `close` uses it — one step along the pink ramp, not a hue change');
+    ok(/\.gg-dial\[data-gg-close="3"\][^{}]*\{[^}]*--gg-hot/.test(hudCss13),
+      'while `edge` still tops the ramp out at --gg-hot');
+    /* The two top rungs each carry a glow, and the higher one is the bigger
+     * blur: with the hue break gone that spread IS the ramp, so a future edit
+     * that flattens them back to the same number has quietly merged `close`
+     * into `edge` for anyone reading the bars rather than the words. */
+    const blurAt = (close) => {
+      const rule = (hudCss13.match(new RegExp('\\.gg-dial\\[data-gg-close="' + close + '"\\][^{}]*\\{[^}]*\\}')) || [''])[0];
+      return { rule, px: Number((rule.match(/box-shadow:\s*0 0 (\d+)px/) || [])[1] || 0) };
+    };
+    const glowClose = blurAt('2');
+    const glowEdge = blurAt('3');
+    ok(glowClose.px > 0, 'close carries its own glow — intensity is what separates the rungs now', glowClose.rule);
+    ok(glowEdge.px > glowClose.px, 'and edge glows harder than close', `${glowClose.px} -> ${glowEdge.px}`);
+    // …and the three places gold still belongs are untouched.
+    ok(/\.gg-timer\.is-urgent\s+\.gg-timer-fill\s*\{[^}]*--gg-gold/.test(hudCss13),
+      'the timer still goes gold when it is running out');
+    ok(/\.gg-receipt\.is-gold[^{}]*\{[^}]*--gg-gold/.test(hudCss13),
+      'and a flagged receipt is still gold — only the dial was asked to change');
+  }
 }
 
 /* ===========================================================================
@@ -3465,7 +3640,7 @@ const audioMod = await import('../ui/audio.js');
   ok(/max-width:\s*var\(--gg-mon-w\)/.test(ruleFor(css16, '.gg-mon')),
     'the monitor is capped by --gg-mon-w rather than hard-sized to it');
   ok(/\.gg-mon-name\s*\{[^}]*min-width:\s*0/.test(css16),
-    'and their name may ellipsise instead of shoving the score and pips off the end');
+    'and their name may ellipsise instead of shoving the score and the charge count off the end');
   const monW = num(phone, /--gg-mon-w:\s*min\([^,]+,\s*(\d+)px\)/, 999);
   ok(monW <= 200, 'on a phone the monitor is at most 200px wide — it was half off-screen at 220', String(monW));
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -23,6 +23,10 @@
   --gg-mon-w: clamp(210px, 22vw, 280px);
   --gg-amber: #ffb454;
   --gg-hot: #ff1493;
+  /* The middle rung of the closeness dial — one real step along the pink ramp
+     between --gg-pink (#ff69b4) and --gg-hot (#ff1493), not a hue change. It
+     exists because that rung used to be --gg-gold; see THE DIAL HAS NO YELLOW. */
+  --gg-pink-deep: #ff479f;
   /* the ONLY green in the HUD: "they passed it", nothing else. */
   --gg-green: #5ef2a0;
   --gg-green-rgb: 94, 242, 160;
@@ -46,7 +50,7 @@
    * items — it is allowed to grow past the container. `.gg-hud-top` below is
    * `1fr auto 1fr` where `1fr` means `minmax(auto, 1fr)`, so each side track has
    * a min-content floor it can never go under, and `.gg-timer` adds an explicit
-   * `min-width`. On a 428px phone those floors (charge pips + timer + the
+   * `min-width`. On a 428px phone those floors (the score column + timer + the
    * attention plate and two 48px buttons) added up to ~442px, the implicit
    * column took that as its base size, and EVERY row inherited it — which is
    * how the opponent monitor, the "they claim" panel, the receipts and the
@@ -97,7 +101,7 @@
  *
  * WHAT GOES: the score + its +1 flourish, your name plate, the closeness dial,
  * the closeness THEY claim, the live-effect chips and MERCY.
- * WHAT STAYS: the monitor, the rails, the charge pips (they are the arsenal's
+ * WHAT STAYS: the monitor, the rails, the charge count (it is the arsenal's
  * currency, not a readout), the timer, the attention ring and the toggle itself.
  *
  * THE TWO ADDED 2026-08-04 (owner: "we need space to see the animations"):
@@ -157,25 +161,32 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
    ui/hud.js builds no such node, so do not restyle one back into being. */
 .gg-me { font-size: 0.68rem; color: var(--gg-text-3); }
 
-.gg-pips { display: flex; gap: 6px; align-items: center; }
-.gg-pip {
-  width: 16px; height: 16px;
-  transform: rotate(45deg);
-  border: 1px solid rgba(var(--gg-pink-rgb), 0.55);
-  border-radius: 3px;
-  background: transparent;
-  transition: background .18s ease, box-shadow .18s ease, transform .18s ease;
+/* THE CHARGE PIPS ARE GONE (2026-08-05). `.gg-pips` / `.gg-pip` / `.gg-pip--sm`
+   and @keyframes ggPipPop drew five 16px squares rotated 45° — outline for the
+   cap, filled pink for what you held — under the score here and, at 12px, in the
+   opponent monitor's titlebar. The owner asked twice for "the little yellow
+   squares" to go: the risk pips went in the first pass and these read as the
+   same indicator to anyone not holding the source, which is everyone.
+   ui/hud.js and ui/opponent.js now print the count in words instead (.gg-charges
+   and .gg-mon-charges below), so THE DIAMOND IS NOT A SHAPE THIS UI USES ANY
+   MORE. Do not reintroduce one for a count — a rotated square in this app has a
+   history, and the next person to see it will read it as the risk meter.
+   (The arsenal's `.gg-cost-pip` is a different thing and stays: round, amber,
+   welded to the tile whose price it is, and never part of this complaint.) */
+.gg-charges {
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--gg-text-2);
 }
-.gg-pip.is-on { background: var(--gg-pink); box-shadow: 0 0 12px rgba(var(--gg-pink-rgb), 0.75); }
-.gg-pip.is-pop { animation: ggPipPop .4s ease-out 1; }
-.gg-pip--sm { width: 12px; height: 12px; }
-@keyframes ggPipPop {
-  0% { transform: rotate(45deg) scale(1); }
-  40% { transform: rotate(45deg) scale(1.55); }
-  100% { transform: rotate(45deg) scale(1); }
-}
+/* The charge-gain flourish, and the WHOLE flourish since the pips went — it used
+   to land at top:1.4rem, on the pip row, where covering an outline for 900ms
+   cost nothing. That row is a SENTENCE now and a chip parked on top of it is a
+   readout you cannot read, so the chip moved up beside the score instead: 3.2rem
+   clears five tabular digits at 1.35rem bold, and it floats away from the count
+   rather than across it. */
 .gg-plus1 {
-  position: absolute; left: 2.4rem; top: 1.4rem;
+  position: absolute; left: 3.2rem; top: 0.15rem;
   font-size: 0.8rem; font-weight: 700; color: var(--gg-pink);
   text-shadow: 0 0 12px rgba(var(--gg-pink-rgb), 0.7);
   animation: ggFloatUp .9s ease-out forwards;
@@ -993,10 +1004,15 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
 .gg-mon-dot.is-gone { background: #6d6d78; box-shadow: none; }
 /* `min-width: 0` is what lets the ellipsis actually happen: without it a
    nowrap name is a flex item that refuses to be narrower than its own text, and
-   it pushes the score and the charge pips off the end of the head row. */
+   it pushes the score and the charge count off the end of the head row. */
 .gg-mon-name { color: var(--gg-text-1); font-weight: 600; max-width: 9rem; min-width: 0; flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gg-mon-score { margin-left: auto; padding-left: 0.3rem; font-variant-numeric: tabular-nums; color: var(--gg-text-2); flex: 0 0 auto; }
-.gg-mon-pips { display: flex; gap: 4px; flex: 0 0 auto; }
+/* Their charges, in words since 2026-08-05 (this was `.gg-mon-pips`, five 12px
+   diamonds — see the tombstone up at .gg-charges). `white-space: nowrap` because
+   this is the LAST item in the narrowest row in the layout: the name has the
+   ellipsis budget and this must never be the thing that wraps the titlebar into
+   two lines, which would move the grip out from under a finger mid-drag. */
+.gg-mon-charges { flex: 0 0 auto; white-space: nowrap; font-variant-numeric: tabular-nums; color: var(--gg-text-3); }
 
 /* THE MONITOR FRAME, AND THE FOUR NUMBERS EVERYTHING INSIDE IT IS MEASURED FROM.
  *
@@ -1816,10 +1832,44 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   font-size: 0.62rem;
   padding: 0;
 }
-.gg-dial-bar { width: 100%; height: 10px; border-radius: 3px; background: rgba(255, 255, 255, 0.12); transition: background .25s ease, height .25s ease; }
+/* THE DIAL HAS NO YELLOW (owner, 2026-08-05). At `close` the four lit bars used
+   to turn `--gg-gold`, and in a mid-match screenshot that row of short gold
+   blocks was the SECOND thing the owner pointed at as "the little yellow
+   squares" — the same complaint that took the risk pips and then the charge
+   pips off this HUD. Every other gold on this desk means a specific thing that
+   is about to bite — the timer running out, a flagged receipt, the last notch
+   of the sudden-death track — and none of them is "you are enjoying yourself",
+   so the dial had no business borrowing the hue: a warning colour spliced into
+   the middle of an otherwise monotone pink ramp is exactly what made a
+   self-report row read as an alarm.
+
+   THE RAMP IS PINK ALL THE WAY UP NOW, and it still has four distinguishable
+   rungs, by INTENSITY rather than hue:
+
+     none   the track's own white 12% — nothing claimed yet
+     0 / 1  flat --gg-pink, no glow      (steady, warm)
+     2      --gg-pink-deep + a soft glow (close)
+     3      --gg-hot + a hard glow       (edge)
+
+   COLOUR IS STILL NOT THE ONLY CHANNEL, which is what makes an intensity ramp
+   legal here: ui/closeness.js prints a WORD under every bar ("steady / warm /
+   close / edge") and marks the chosen one `.is-head`, which is 16px tall against
+   10px and brightens its label. Someone who cannot separate #ff479f from
+   #ff69b4 still reads the dial off the words and the tall bar, exactly as
+   before — the hue was never carrying the meaning, only the alarm.
+
+   This is a restyle and nothing else — the stops, the 48px targets, the
+   350ms write cooldown and the data-gg-close contract are all untouched. */
+.gg-dial-bar { width: 100%; height: 10px; border-radius: 3px; background: rgba(255, 255, 255, 0.12); transition: background .25s ease, box-shadow .25s ease, height .25s ease; }
 .gg-dial-stop.is-on .gg-dial-bar { background: var(--gg-pink); }
-.gg-dial[data-gg-close="2"] .gg-dial-stop.is-on .gg-dial-bar { background: var(--gg-gold); }
-.gg-dial[data-gg-close="3"] .gg-dial-stop.is-on .gg-dial-bar { background: var(--gg-hot); }
+.gg-dial[data-gg-close="2"] .gg-dial-stop.is-on .gg-dial-bar {
+  background: var(--gg-pink-deep);
+  box-shadow: 0 0 9px rgba(var(--gg-pink-rgb), 0.6);
+}
+.gg-dial[data-gg-close="3"] .gg-dial-stop.is-on .gg-dial-bar {
+  background: var(--gg-hot);
+  box-shadow: 0 0 15px rgba(var(--gg-pink-rgb), 0.95);
+}
 .gg-dial-stop.is-head { color: var(--gg-text); }
 .gg-dial-stop.is-head .gg-dial-bar { height: 16px; }
 .gg-dial-fine { font-size: 0.54rem; line-height: 1.2; color: var(--gg-text-4); }
@@ -1927,7 +1977,7 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   display: flex; flex-direction: column; align-items: center;
   gap: 0.5rem;
   /* clears the HUD top bar: the desk contracts on sudden death but the score,
-     charge pips and timer plate stay, and the ladder must not land on them. */
+     charge count and timer plate stay, and the ladder must not land on them. */
   padding-top: clamp(4.6rem, 11vh, 6.4rem);
   pointer-events: none;
 }
@@ -2170,8 +2220,9 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
 
   /* ---- top bar: it must not be able to overflow ------------------------
    * `1fr auto 1fr` gives both side tracks a min-content floor, and those floors
-   * (pips + timer min-width + the attention plate and two 48px buttons) came to
-   * ~442px on a 428px phone — 34px more than the frame has. The score column is
+   * (the score column + timer min-width + the attention plate and two 48px
+   * buttons) came to ~442px on a 428px phone — 34px more than the frame has.
+   * The score column is
    * the only compressible one of the three (its text can wrap or ellipsise), so
    * it is the one that gets minmax(0, …) and the other two are content-sized.
    * The pieces below are also just plain smaller, so the row FITS rather than
@@ -2181,8 +2232,12 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-hud-top > * { min-width: 0; }
   .gg-scorebox { min-width: 0; }
   .gg-me { overflow-wrap: anywhere; }
-  .gg-pip { width: 13px; height: 13px; }
-  .gg-pips { gap: 5px; }
+  /* The charge line is a SENTENCE now, not a 104px row of diamonds (2026-08-05),
+     which is part of why the score column can be the compressible track: text
+     wraps where a flex row of fixed-size pips could only overflow. Both counts
+     shrink a notch on a phone and neither goes below legible. */
+  .gg-charges { font-size: 0.64rem; }
+  .gg-mon-charges { font-size: 0.64rem; }
   .gg-timer { min-width: 92px; padding: 0.35rem 0.6rem 0.45rem; }
   .gg-hud-topright { gap: 0.35rem; }
   .gg-att { gap: 0.4rem; padding: 0.3rem 0.45rem; }
@@ -2197,7 +2252,7 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-rightcol { width: 100%; align-items: flex-end; order: -1; }
   .gg-well { display: none; }
   /* the head row of a 190px monitor: the name gives way, the score and the
-     charge pips never do */
+     charge count never do */
   .gg-mon-name { max-width: 100%; }
   /* …and the grip, which is that same row, has to survive the squeeze AND be a
      finger target: 26px is the whole drag surface on a phone, where there is no
@@ -2354,7 +2409,12 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-mon-close.is-edge,
   .gg-sd-track.is-close .gg-sd-notch.is-end,
   .gg-timer.is-urgent .gg-timer-clock { animation: none !important; }
-  .gg-pip.is-pop, .gg-item.is-shake, .gg-sd-card.is-slip { animation: none !important; }
+  /* `.gg-pip.is-pop` used to head this list — the charge pips' 1.55x scale
+     bounce. It went with the pips themselves on 2026-08-05, and the flourish
+     that replaced nothing (the `.gg-plus1` chip) is unchanged: it was never in
+     this block, because a chip that floats 22px and deletes itself is the
+     feedback, not decoration on top of it. */
+  .gg-item.is-shake, .gg-sd-card.is-slip { animation: none !important; }
   /* the drawer still ARRIVES and the handle still lights — they just stop
      moving. Neither animation has a fill-mode, so removing it lands both nodes
      on their finished state rather than on the off-screen keyframe. */

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -324,14 +324,12 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
 
   const scoreBox = add(top, el('div', 'gg-scorebox'));
   const scoreEl = add(scoreBox, el('div', 'gg-score', '0'));
-  const pipRow = add(scoreBox, el('div', 'gg-pips'));
-  const pips = [];
-  for (let i = 0; i < GoonConsts.ChargeCap; i++) pips.push(add(pipRow, el('i', 'gg-pip')));
+  const chargeEl = add(scoreBox, el('div', 'gg-charges', S.hud.charges(0, GoonConsts.ChargeCap)));
 
   /* NO SCORE-MULTIPLIER READOUT (owner, 2026-08-05: "the risk level indicator
    * is not intuitive — the heat gauge already does the job").
    *
-   * A third line used to sit here under the charge pips: `.gg-mult`, née
+   * A third line used to sit here under the charge readout: `.gg-mult`, née
    * `.gg-risk`, painting `match.scoring.riskMultiplier` as "×1.30 score". It
    * was the LAST player-facing limb of the risk system — batch 7 took the
    * seven-segment tier meters and the per-tile pips off the draft screen and
@@ -346,9 +344,29 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
    * change. The score in the line above is the multiplier's whole visible
    * effect, which is the part a player could ever act on.
    *
-   * THE CHARGE PIPS ABOVE ARE NOT IT and must stay: they are what you are
-   * holding to throw, the wire validates against them, and the arsenal's cost
-   * pips are read against them. */
+   * AND THE CHARGE PIPS WENT TOO (owner, 2026-08-05, second pass: "the little
+   * yellow squares that we were supposed to have removed"). The first pass kept
+   * them on the argument that they are NOT the risk indicator — they are what
+   * you are holding to throw, the wire validates throws against them and the
+   * arsenal pays its costs out of them, so they were real and load-bearing in a
+   * way the multiplier never was. That argument was about the DATA and the
+   * owner's complaint was about the SHAPE. A row of five rotated squares under
+   * the score is indistinguishable, on a phone, from the row of rotated squares
+   * that had just been taken off the draft tiles: the player cannot tell "your
+   * ammunition" from "the risk meter you asked me to delete" by looking, and
+   * being right about the difference does not help them at arm's length.
+   *
+   * So the DATA stays and the SHAPE goes: one small line, "3 / 5 charges", in
+   * words. It is strictly more legible than the pips ever were — it survives a
+   * squint, it reads aloud, it does not depend on a fill colour, and it says the
+   * cap out loud instead of asking you to count outlines to find it. There is no
+   * diamond left anywhere in this HUD; the only pips on the desk now are the
+   * arsenal's amber `.gg-cost-pip` cost dots, which are round, attached to the
+   * tile whose price they are, and were never part of this complaint.
+   *
+   * THE GAIN JUICE SURVIVES INTACT — sfx('gg-charge') and the floating "+1"
+   * chip both still fire in paintCharges(). Only the per-pip pop animation died
+   * with the pips, because there is no longer a pip to pop. */
 
   const timerBox = add(top, el('div', 'gg-timer gg-plate'));
   const timerClock = add(timerBox, el('div', 'gg-timer-clock', '0:00'));
@@ -860,19 +878,24 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
     text(scoreEl, String(shownScore));
   }
 
+  /* THE CHARGE COUNT. Memoised on `lastCharges` exactly as the pip row was, for
+   * the same two reasons: the 5 Hz poll would otherwise rewrite an unchanged
+   * string twenty times a second, and the "+1" flourish has to fire ONCE on the
+   * edge rather than on every tick that finds the number high.
+   *
+   * `lastCharges >= 0` is the mount guard: the very first paint moves 0 -> N and
+   * is not a gain the player did anything to earn, so it must not bang the sfx
+   * on the way into a match that resumed with charges already banked. */
   function paintCharges() {
     const s = match.scoring;
     const c = s ? (s.charges | 0) : 0;
     if (c === lastCharges) return;
     const gained = c > lastCharges && lastCharges >= 0;
     lastCharges = c;
-    for (let i = 0; i < pips.length; i++) cls(pips[i], 'is-on', i < c);
+    text(chargeEl, S.hud.charges(c, GoonConsts.ChargeCap));
     if (!gained) return;
     sfx(audio, 'gg-charge');
-    const pip = pips[Math.max(0, c - 1)];
     fx.play(400, () => {
-      cls(pip, 'is-pop', true);
-      setTimeout(() => cls(pip, 'is-pop', false), 400);
       const chip = el('span', 'gg-plus1', '+1');
       if (!chip) return;
       add(scoreBox, chip);

--- a/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
@@ -458,12 +458,20 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     };
   }
 
-  // ---- head: grip · connection dot · name · their score · charge pips -----
+  // ---- head: grip · connection dot · name · their score · their charges ----
   // The head row is ALSO the titlebar (MON_GRIP_CLASS, see THE GRIP above): on a
   // docked monitor it is the only strip hud.css lets the pointer reach, so it is
   // where the drag and the wheel both have to start. Nothing in it is
-  // interactive — a dot, two words and five pips — which is exactly why it is
+  // interactive — a dot and three little readouts — which is exactly why it is
   // safe to claim the whole row rather than a corner of it.
+  //
+  // THEIR CHARGES ARE A COUNT, NOT PIPS (2026-08-05). This row carried five
+  // `.gg-pip--sm` diamonds until the owner asked, for the second time, for "the
+  // little yellow squares" to go: the HUD's own charge row went in the same
+  // pass, and leaving these would have kept the exact shape being complained
+  // about on screen — two inches from where it was removed — while letting the
+  // dead CSS live on. See the long note in ui/hud.js for the full reasoning.
+  // Nothing about the mechanic changed; only the way it is drawn.
   const head = add(root, el('div', 'gg-mon-head ' + MON_GRIP_CLASS));
   if (head && head.setAttribute) head.setAttribute('title', S.monitor.dragHint);
   // …and the affordance, first in the row: nobody drags a thing that does not
@@ -472,9 +480,7 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
   const dot = add(head, el('i', 'gg-mon-dot'));
   const nameEl = add(head, el('span', 'gg-mon-name', 'opponent'));
   const scoreEl = add(head, el('span', 'gg-mon-score', '0'));
-  const pipRow = add(head, el('span', 'gg-mon-pips'));
-  const pips = [];
-  for (let i = 0; i < GoonConsts.ChargeCap; i++) pips.push(add(pipRow, el('i', 'gg-pip gg-pip--sm')));
+  const chargeEl = add(head, el('span', 'gg-mon-charges', S.monitor.charges(0)));
 
   // ---- the screen inside the bezel ---------------------------------------
   // THE STACKING ORDER HERE IS LOAD-BEARING. assets/monitor_frame.png (935x667
@@ -722,7 +728,11 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
 
     text(nameEl, op.displayName || 'opponent');
     text(scoreEl, p + String(op.score | 0));
-    for (let i = 0; i < pips.length; i++) cls(pips[i], 'is-on', i < (op.charges | 0));
+    // The stale prefix rides on the charge count too. It did NOT ride on the
+    // pips — a lit diamond had nowhere to put a "~" — and that was a small lie
+    // the shape forced: a frozen count is exactly as out of date as the frozen
+    // score sitting beside it, and the words have room to say so.
+    text(chargeEl, p + S.monitor.charges(op.charges | 0));
 
     const pct = Math.max(0, Math.min(100, Number(op.attentionPct) || 0));
     if (attFill && attFill.style) attFill.style.width = pct + '%';

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -413,10 +413,14 @@
 .gg-elem-why { display: none; font-size: 0.66rem; color: var(--gg-text-4); line-height: 1.4; }
 
 /* The per-tile RISK PIPS (.gg-riskpips — three dots of the 0-3 tier) went the
-   same way on 2026-08-04. The warning they carried still applies to whatever
-   lands here next: do NOT name a draft-screen class .gg-pips — ui/hud.css owns
-   that for the charge meter and loads AFTER this file. Two owners, one name,
-   silent bug. */
+   same way on 2026-08-04, and on 2026-08-05 the HUD's own `.gg-pips` charge row
+   followed them (owner: the two shapes were indistinguishable in play). SO THE
+   NAME IS FREE NOW — and the warning it carried outlives it, because the reason
+   was never that one class: ui/hud.css loads AFTER this file, so ANY name the
+   two sheets share is silently the HUD's, and a draft-screen rule that looks
+   correct here will lose on the draft screen. Prefix draft classes `.gg-elem-`
+   the way everything above this comment does, `.gg-pips` included if it ever
+   comes back. */
 
 .gg-elem-badge {
   position: absolute;

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -827,6 +827,23 @@ export const S = Object.freeze({
      * fixed at the draft, unchangeable mid-match and unexplained by anything on
      * the desk. Deleted rather than reworded — the score above it is the same
      * information, already counted. */
+    /* ---- the charge count (ui/hud.js) ----
+     * WHAT REPLACED THE PIP ROW on 2026-08-05. Five rotated squares under the
+     * score used to carry this: outlines for the cap, filled for what you hold.
+     * The owner read them as the risk pips they had just had removed ("the
+     * little yellow squares"), which is a fair reading — same shape, same
+     * neighbourhood — so the count is a sentence now.
+     *
+     * THE CAP IS IN THE STRING ON PURPOSE. The pips said it by being five, and
+     * a bare "3" would have quietly dropped it. It is actionable: at the cap the
+     * endurance you are grinding out stops banking, and the arsenal's costs are
+     * priced against the same ceiling. Their count (S.monitor.charges) omits it,
+     * because nothing you can do turns their ceiling into a decision.
+     *
+     * Spaces around the slash so "3 / 5" cannot be misread as a date or a score
+     * line at a glance, and the noun is always plural — "1 / 5 charge" reads
+     * like a typo, and the number this labels is the pair, not the 1. */
+    charges: (n, cap) => (n | 0) + ' / ' + (cap | 0) + ' charges',
     /* ---- the heat gauge (ui/drops.js) ----
      * ONE word, because it sits over the arsenal rail and the bar is the rest of
      * the sentence. `heatValue` is the aria-valuetext: colour never travels
@@ -841,6 +858,15 @@ export const S = Object.freeze({
     dropHint: 'drop it here',
     /** The green checkmark on their projection: they took the whole payload. */
     passed: 'they held it',
+    /* Their charge count in the monitor's titlebar — the same 2026-08-05 removal
+     * as S.hud.charges: five little `.gg-pip--sm` diamonds sat here beside their
+     * score and were the last diamonds on the desk once the HUD's own row went.
+     * NO CAP HERE, unlike yours: their ceiling is not a number you can spend
+     * against, and the head row is the narrowest strip in the whole layout (it
+     * shares 200px with a grip, a health dot, their name and their score on a
+     * phone). Singular is spelled out because "1 charges" beside a live opponent
+     * name looks like a bug in the app rather than a count. */
+    charges: (n) => (n | 0) + ((n | 0) === 1 ? ' charge' : ' charges'),
     /** The titlebar's tooltip. All three gestures, because not one of them is
      *  discoverable and the grip dots only ever promise the first. */
     dragHint: 'drag to move · wheel to resize · double-tap to put it back',


### PR DESCRIPTION
Owner, 2026-08-05, second pass on "the little yellow squares that we were supposed to have removed". After the risk pips and the score multiplier came off, two things were still drawing that shape.

## 1. The charge pips are gone (text count instead)

Five 16px rotated squares under the score (`.gg-pips` / `.gg-pip`) and five more at 12px in the opponent monitor titlebar (`.gg-mon-pips`, the `.gg-pip--sm` variant).

The previous pass deliberately kept them, on the argument that they are **not** the risk meter: they are your throwable ammunition, `core/wire.js` validates throws against them, and the arsenal pays its costs out of them. That argument was about the **data**; the owner's complaint was about the **shape** — at arm's length on a phone, a row of rotated squares under the score is the row of rotated squares that had just come off the draft tiles.

So the data stayed and the diamond went:

| where | was | is |
|---|---|---|
| your scorebox | 5 diamonds | `3 / 5 charges` (`.gg-charges`) |
| their titlebar | 5 small diamonds | `2 charges` (`.gg-mon-charges`) |

- Your line keeps the **cap**, which the pips said by being five and a bare number would have dropped silently — at the cap your endurance stops banking, and arsenal costs are priced against it.
- Their line drops the cap (you cannot spend against their ceiling) and **picks up the stale `~` prefix** that already rides their score — a lit diamond had nowhere to put one.
- **The gain juice survives whole**: `sfx('gg-charge')` and the floating `+1` chip both still fire. Only the per-pip pop animation died, because there is no pip to pop. The chip moved from `top:1.4rem` (on the old pip row) up beside the score, so it no longer parks on top of a line you now have to read.

**Both** draw sites went. Leaving the monitor's copy would have kept the complained-about shape on screen two inches from where it was deleted, and kept `.gg-pip` alive to grow a third user.

**Not touched:** the arsenal's `.gg-cost-pip` cost dots — round, amber, welded to the tile whose price they are, never part of this complaint.

## 2. The closeness dial has no yellow

The `you're telling them` row (steady / warm / close / edge) turned every lit bar `--gg-gold` at `close`. In the mid-match screenshot that is four short gold blocks, and it is the second thing the owner pointed at.

The ramp is pink all the way up now, four distinguishable rungs by **intensity** rather than hue:

```
none    the track's own white 12%
0 / 1   flat --gg-pink, no glow             (steady, warm)
2       --gg-pink-deep #ff479f + soft glow  (close)
3       --gg-hot + hard glow                (edge)
```

Colour was never the only channel here and still is not: every stop prints its word under the bar and the chosen one is `.is-head`, 16px tall against 10px with a brighter label.

Restyle only — stops, 48px touch targets, the 350ms write cooldown and the `data-gg-close` contract are untouched. Gold stays everywhere it belongs: timer urgency, flagged receipts, the sudden-death end notch, the draft screen.

## Housekeeping

- CSS deleted: `.gg-pips`, `.gg-pip`, `.gg-pip--sm`, `@keyframes ggPipPop`, plus their mobile and `prefers-reduced-motion` entries.
- Every stale "charge pips" comment across `hud.css` updated to say "charge count".
- The `screens.css` warning about naming a draft class `.gg-pips` is **kept and rewritten**: the name is free now, but `hud.css` still loads after that file, so the hazard it described outlives the class it named.
- New strings `S.hud.charges(n, cap)` and `S.monitor.charges(n)`, both with the usual WHY block.
- `GOON_BUILD` not bumped — the driver session handles stamps.

## Tests

`test/selftest-hud.js` grows a **2c-iii** section pinning:
- the words are there and carry the number (and the cap, on yours);
- first paint, gain repaint + `gg-charge` sfx + `+1` chip, chip self-retirement, a **silent spend**, a memoised no-op poll, and unmount;
- **no `.gg-pip` node** anywhere in the mounted HUD, and no `gg-pip` in `hud.js` / `opponent.js` source once comments are stripped;
- no live `.gg-pip*` selector or `ggPipPop` keyframe in `hud.css`, while `.gg-cost-pip` is asserted **present**.

…and a **hue ban over every `.gg-dial` rule** (no `--gg-gold`, no `--gg-amber`, in any of them), the glow ordering `close < edge`, and two counter-checks that the timer and receipt golds are still there — so a blanket find-and-replace across `hud.css` fails this suite.

`selftest-hud: 1617/1617`. All 14 goon selftests green except `selftest-avafx`'s 12 pre-existing failures, unchanged from `origin/main` (verified against the baseline before touching anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
