### PR TITLE
fix(670): asset deselection scope + voice-spiral quest credit

### DIFF
--- a/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosFlashOverlay.cs
@@ -220,14 +220,23 @@ public sealed class ChaosFlashOverlay : Window
 
     /// <summary>Pick one random image from the SAME enabled pool the flashes draw on (disk +
     /// content packs, honoring the asset manager's disabled set) — see FlashService.GetChaosImagePaths.
-    /// Falls back to the raw folder listing only if the flash service isn't up yet. Returns null if
-    /// nothing is enabled. One image = at most one pack decrypt, so it's cheap on the UI thread.</summary>
+    /// Falls back to the raw folder listing ONLY when the flash service isn't up at all. Returns null if
+    /// nothing is enabled. One image = at most one pack decrypt, so it's cheap on the UI thread.
+    ///
+    /// #762/#798/#619: the fallback used to trigger on an EMPTY result, which cannot tell "service not
+    /// initialized" from "the user unchecked everything" — so deselecting all assets made the wash fall
+    /// back to the RAW folder and flash exactly the content the user had just turned off. An empty
+    /// enabled pool means show nothing, so gate on the service reference instead.</summary>
     private static string? PickImage()
     {
         try
         {
-            var picks = App.Flash?.GetChaosImagePaths(1);
-            if (picks != null && picks.Count > 0) return picks[0];
+            var flash = App.Flash;
+            if (flash != null)
+            {
+                var picks = flash.GetChaosImagePaths(1);
+                return picks != null && picks.Count > 0 ? picks[0] : null;
+            }
             // Fallback (Flash service not initialized): raw folder pool.
             var files = ChaosImagePool.GetFiles();
             if (files.Count == 0) return null;

--- a/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
+++ b/ConditioningControlPanel/Chaos/ChaosGifCascadeOverlay.cs
@@ -62,8 +62,11 @@ public sealed class ChaosGifCascadeOverlay : Window
                 List<string> files;
                 try
                 {
-                    files = flash?.GetChaosImagePaths(batch) ?? new List<string>();
-                    if (files.Count == 0) files = PickFiles();   // fallback: raw folder pool if Flash isn't up
+                    // #762/#798/#619: the raw-folder fallback is for a MISSING flash service only. Keying it
+                    // off an empty result meant "user unchecked every folder" looked identical to "service not
+                    // up", so deselecting everything rained the raw folder — precisely the content the user
+                    // just turned off. An empty enabled pool is a legitimate "rain nothing".
+                    files = flash != null ? flash.GetChaosImagePaths(batch) : PickFiles();
                 }
                 catch { files = new List<string>(); }
                 Application.Current?.Dispatcher.BeginInvoke(new Action(() =>

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -209,6 +209,17 @@ public class OverlayService : IDisposable
     public bool IsRunning => _isRunning;
 
     /// <summary>
+    /// Is the spiral / pink tint ACTUALLY on screen right now, no matter who put it there — the
+    /// persistent setting, a dashboard trigger bubble, a Deeper band, or a voice command
+    /// (ShowOverlaySustained). Progress tracking gates on these so screen time earned through the
+    /// ad-hoc paths counts (#719: "turn on spiral" by voice never sets settings.SpiralEnabled, so
+    /// the setting-only gate credited nothing while the spiral spun in the user's face).
+    /// UI thread only — same affinity as the window lists / compositor layers they read.
+    /// </summary>
+    public bool IsSpiralVisible => SpiralShowing;
+    public bool IsPinkFilterVisible => PinkShowing;
+
+    /// <summary>
     /// When true, overlay level checks are bypassed (e.g. for remote control commands).
     /// </summary>
     public bool BypassLevelCheck { get; set; }

--- a/ConditioningControlPanel/Services/Progression/AchievementService.cs
+++ b/ConditioningControlPanel/Services/Progression/AchievementService.cs
@@ -206,6 +206,23 @@ public class AchievementService : IDisposable
     }
 
     /// <summary>
+    /// Does an overlay effect (pink filter / spiral) count as active for progress + quest time?
+    /// True when the persistent feature is on during an overlay run — the original rule, kept
+    /// verbatim so existing sessions credit identically — OR when the effect is genuinely ON SCREEN
+    /// through one of the ad-hoc paths that never touch the setting: ShowOverlaySustained (voice
+    /// "turn on spiral" / "go pink", Deeper enhancement bands) and ShowOverlayTimed (dashboard
+    /// trigger bubbles).
+    ///
+    /// #719: the voice command shows a sustained overlay and deliberately does NOT flip
+    /// settings.SpiralEnabled (that setting is the user's saved preference — it drives the settings
+    /// UI checkbox, survives restarts, and is what the 500ms reconciler tears the overlay down
+    /// against). Crediting the visible state here fixes the quest without letting a transient voice
+    /// command rewrite persisted preferences.
+    /// </summary>
+    internal static bool IsOverlayEffectActive(bool featureEnabled, bool overlayRunning, bool effectVisible)
+        => (featureEnabled && overlayRunning) || effectVisible;
+
+    /// <summary>
     /// Track time-based progress (called every second)
     /// </summary>
     private void TrackTimeBasedProgress(object? sender, EventArgs e)
@@ -221,9 +238,12 @@ public class AchievementService : IDisposable
             App.SkillTree?.AddConditioningTime(1.0 / 60.0);
         }
 
-        // Track Pink Filter time - only when overlay is actually running
-        var isPinkFilterActive = settings.PinkFilterEnabled &&
-                                 App.Overlay?.IsRunning == true;
+        // Track Pink Filter time - the persistent feature during a run, OR the tint actually on
+        // screen through an ad-hoc path (voice command / Deeper band / trigger bubble). See
+        // IsOverlayEffectActive.
+        var isPinkFilterActive = IsOverlayEffectActive(settings.PinkFilterEnabled,
+                                                       App.Overlay?.IsRunning == true,
+                                                       App.Overlay?.IsPinkFilterVisible == true);
         if (isPinkFilterActive)
         {
             var elapsed = (now - _lastPinkFilterCheck).TotalMinutes;
@@ -249,9 +269,11 @@ public class AchievementService : IDisposable
             _lastPinkFilterCheck = now;
         }
 
-        // Track Spiral time - only when overlay is actually running
-        var isSpiralActive = settings.SpiralEnabled &&
-                             App.Overlay?.IsRunning == true;
+        // Track Spiral time - the persistent feature during a run, OR the spiral actually on screen
+        // through an ad-hoc path (voice "turn on spiral" / Deeper band / trigger bubble).
+        var isSpiralActive = IsOverlayEffectActive(settings.SpiralEnabled,
+                                                   App.Overlay?.IsRunning == true,
+                                                   App.Overlay?.IsSpiralVisible == true);
         if (isSpiralActive)
         {
             var elapsed = (now - _lastSpiralCheck).TotalMinutes;

--- a/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
+++ b/ConditioningControlPanel/Services/Quiz/IntakeHostService.cs
@@ -721,23 +721,53 @@ namespace ConditioningControlPanel.Services.Quiz
             catch { return string.Empty; }
         }
 
+        /// <summary>
+        /// Deselected-asset lookup set, built from <c>AppSettings.DisabledAssetPaths</c> (the blacklist
+        /// the Assets tree writes: paths relative to EffectiveAssetsPath). Normalized exactly like
+        /// <c>FlashService.GetMediaFiles</c> — separator-agnostic and case-insensitive — so the same
+        /// uncheck that hides an image from the flashes hides it from the intake page too.
+        /// </summary>
+        internal static HashSet<string> BuildDisabledAssetSet(IEnumerable<string>? disabledPaths) => new(
+            (disabledPaths ?? Enumerable.Empty<string>()).Select(p => (p ?? "").Replace('\\', '/')),
+            StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>True when <paramref name="fullPath"/> is still enabled for the user's preset.
+        /// Empty set = nothing deselected = everything active (identical to the pre-fix behavior).</summary>
+        internal static bool IsAssetActive(HashSet<string> disabled, string root, string fullPath)
+        {
+            if (disabled.Count == 0) return true;
+            string rel;
+            try { rel = Path.GetRelativePath(root, fullPath).Replace('\\', '/'); }
+            catch { return true; }   // unrelatable path: never silently drop content over a path quirk
+            return !disabled.Contains(rel);
+        }
+
         /// <summary>MediaManifest (contracts.js): a small random sample of the user's flash images,
         /// split gifs/stills, as ccp.assets URLs. Null on any failure — the page's effect layer
-        /// falls back to its particle stand-ins.</summary>
+        /// falls back to its particle stand-ins.
+        ///
+        /// #762/#798/#619: this walk used to list the images folder RAW, so anything the user
+        /// unchecked in the Assets tree still rode the manifest and showed up in the intake page's
+        /// effect layer / captcha grid. It now applies the same DisabledAssetPaths filter the flash
+        /// pool uses; users with nothing deselected see exactly what they saw before.</summary>
         private static object? BuildMediaManifest()
         {
             try
             {
                 var gifs = new List<string>();
                 var stills = new List<string>();
-                var imagesRoot = Path.Combine(App.EffectiveAssetsPath, "images");
+                var assetsRoot = App.EffectiveAssetsPath;
+                var imagesRoot = Path.Combine(assetsRoot, "images");
+                var disabled = BuildDisabledAssetSet(App.Settings?.Current?.DisabledAssetPaths);
                 if (Directory.Exists(imagesRoot))
                 {
                     foreach (var file in Directory.EnumerateFiles(imagesRoot, "*", SearchOption.AllDirectories))
                     {
                         var ext = Path.GetExtension(file).ToLowerInvariant();
+                        if (ext != ".gif" && ext is not (".png" or ".jpg" or ".jpeg" or ".webp")) continue;
+                        if (!IsAssetActive(disabled, assetsRoot, file)) continue;   // unchecked in the Assets tree
                         if (ext == ".gif") gifs.Add(file);
-                        else if (ext is ".png" or ".jpg" or ".jpeg" or ".webp") stills.Add(file);
+                        else stills.Add(file);
                     }
                 }
 

--- a/Tests/ConditioningControlPanel.Tests/AssetDeselectionScopeTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AssetDeselectionScopeTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using ConditioningControlPanel.Services.Quiz;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #762/#798/#619: surfaces outside the flash pool used to walk the assets folder RAW, so images
+/// the user had unchecked in the Assets tree still showed up (here: the Graded Intake page's media
+/// manifest). The filter must match FlashService.GetMediaFiles' normalization exactly — the saved
+/// blacklist entry can differ from the runtime relative path by separator and by case — and must
+/// stay a pure pass-through when nothing is deselected.
+/// </summary>
+public class AssetDeselectionScopeTests
+{
+    private const string Root = @"C:\assets";
+
+    [Fact]
+    public void NothingDeselected_EverythingStaysActive()
+    {
+        var disabled = IntakeHostService.BuildDisabledAssetSet(null);
+        Assert.True(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\a.gif"));
+
+        disabled = IntakeHostService.BuildDisabledAssetSet(new List<string>());
+        Assert.True(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\a.gif"));
+    }
+
+    [Fact]
+    public void DeselectedFile_IsExcluded()
+    {
+        var disabled = IntakeHostService.BuildDisabledAssetSet(new[] { "images/nope.gif" });
+        Assert.False(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\nope.gif"));
+        Assert.True(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\yes.gif"));
+    }
+
+    [Fact]
+    public void BackslashSavedEntry_StillMatches()
+    {
+        // The Assets tree has written both separator styles over the years.
+        var disabled = IntakeHostService.BuildDisabledAssetSet(new[] { @"images\sub\nope.png" });
+        Assert.False(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\sub\nope.png"));
+    }
+
+    [Fact]
+    public void CaseDiffers_StillMatches()
+    {
+        // Windows is case-insensitive at the filesystem level; a case-sensitive lookup let the
+        // unchecked image slip through.
+        var disabled = IntakeHostService.BuildDisabledAssetSet(new[] { "Images/NOPE.gif" });
+        Assert.False(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\nope.gif"));
+    }
+
+    [Fact]
+    public void UnrelatedFolderEntry_DoesNotOverMatch()
+    {
+        var disabled = IntakeHostService.BuildDisabledAssetSet(new[] { "videos/clip.mp4" });
+        Assert.True(IntakeHostService.IsAssetActive(disabled, Root, @"C:\assets\images\clip.mp4"));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/OverlayQuestCreditTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/OverlayQuestCreditTests.cs
@@ -1,0 +1,52 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #719: "turn on spiral" by voice shows a SUSTAINED overlay (OverlayService.ShowOverlaySustained)
+/// and never sets settings.SpiralEnabled, but the progress tracker credited time only while the
+/// persistent setting was on — so the spiral spun and the quest stayed at zero. The gate now also
+/// accepts "the effect is actually on screen", which covers voice commands, Deeper bands and
+/// dashboard trigger bubbles without a transient command rewriting persisted preferences.
+/// </summary>
+public class OverlayQuestCreditTests
+{
+    [Fact]
+    public void PersistentFeatureDuringARun_StillCredits()
+    {
+        Assert.True(AchievementService.IsOverlayEffectActive(
+            featureEnabled: true, overlayRunning: true, effectVisible: true));
+        // Setting on, run active, but the overlay itself no-oped (e.g. no spiral asset): unchanged
+        // from the original rule so existing sessions credit exactly as before.
+        Assert.True(AchievementService.IsOverlayEffectActive(
+            featureEnabled: true, overlayRunning: true, effectVisible: false));
+    }
+
+    [Fact]
+    public void SettingOnButNoOverlayRun_DoesNotCredit()
+    {
+        Assert.False(AchievementService.IsOverlayEffectActive(
+            featureEnabled: true, overlayRunning: false, effectVisible: false));
+    }
+
+    [Fact]
+    public void VoiceSustainedOverlay_CreditsWithoutTheSetting()
+    {
+        // The bug: setting off (voice never flips it), yet the spiral is on screen.
+        Assert.True(AchievementService.IsOverlayEffectActive(
+            featureEnabled: false, overlayRunning: true, effectVisible: true));
+        // ...and it counts even outside an overlay run, because the user is still looking at it.
+        Assert.True(AchievementService.IsOverlayEffectActive(
+            featureEnabled: false, overlayRunning: false, effectVisible: true));
+    }
+
+    [Fact]
+    public void NothingOn_NeverCredits()
+    {
+        Assert.False(AchievementService.IsOverlayEffectActive(
+            featureEnabled: false, overlayRunning: true, effectVisible: false));
+        Assert.False(AchievementService.IsOverlayEffectActive(
+            featureEnabled: false, overlayRunning: false, effectVisible: false));
+    }
+}


### PR DESCRIPTION
Pre-release fix batch for 6.7 (1 of 3).

- **#762/#798/#619**: chaos overlays (flash wash + gif cascade) fell back to a RAW unfiltered folder pool exactly when the user had unchecked everything; fallback now gates on the Flash service genuinely being unavailable. Graded Intake now applies DisabledAssetPaths inside its media walk (same normalization as the flash pool). No-deselection behavior is unchanged by construction.
- **#719**: quest tracker now credits spiral/pink time when the overlay effect is actually visible (voice commands, Deeper bands, dashboard bubbles) instead of only when the persistent setting is on. Voice commands do NOT flip the saved setting (remote-control commands keep their flip-the-setting contract).

Build 0 errors; 896/896 tests (9 new: AssetDeselectionScopeTests + OverlayQuestCreditTests).
Play-test note: chaos fallback has no headless seam - uncheck all image folders, trigger a glitch wash + cascade, expect nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGrTm1ev9kpvVDrZYsvesj