### PR TITLE
fix(670): Esc lockdown scope, streak zero-flash, consent link, season label

### DIFF
--- a/ConditioningControlPanel/Dialogs/WebcamConsentDialog.xaml.cs
+++ b/ConditioningControlPanel/Dialogs/WebcamConsentDialog.xaml.cs
@@ -14,7 +14,7 @@ namespace ConditioningControlPanel
     /// </summary>
     public partial class WebcamConsentDialog : Window
     {
-        private const string SourceUrl = "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/blob/main/ConditioningControlPanel/Services/WebcamTrackingService.cs";
+        private const string SourceUrl = "https://github.com/CodeBambi/Conditioning-Control-Panel---CSharp-WPF/blob/main/ConditioningControlPanel/Services/Webcam/WebcamTrackingService.cs";
 
         private enum Step { Intro = 1, Privacy = 2, Consent = 3, Calibrate = 4 }
         private Step _step = Step.Intro;

--- a/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
@@ -265,6 +265,12 @@ namespace ConditioningControlPanel
             // Clear all progression data
             ClearProgressionData();
 
+            // ClearProgressionData just zeroed streaks/XP locally. Re-arm the sync service's
+            // defaults guard so a re-login in this same app session READS the server profile
+            // before it can PUSH those zeros — otherwise the quest/login streak flashes 0
+            // until a later sync repaints it. Every logout path funnels through here.
+            App.ProfileSync?.ResetLoadedProfileState();
+
             // Update all UI
             UpdateQuickLoginUI();
             UpdateQuickPatreonUI();

--- a/ConditioningControlPanel/Services/Input/GlobalKeyboardHook.cs
+++ b/ConditioningControlPanel/Services/Input/GlobalKeyboardHook.cs
@@ -123,9 +123,14 @@ public class GlobalKeyboardHook : IDisposable
                     (vkCode == 0x09 || vkCode == 0x73 || vkCode == 0x1B))
                     suppress = true;
 
-                // Escape
-                if (vkCode == 0x1B)
-                    suppress = true;
+                // BARE Esc is deliberately NOT suppressed (#680). It used to be, which ate
+                // every plain Escape press system-wide, in every foreground app, for the whole
+                // lockdown window — closing dialogs, cancelling dropdowns, leaving fullscreen,
+                // aborting anything in any other program. Lockdown's job is to block task
+                // switching and app exit, and the modified-Esc branches below (Ctrl+Esc,
+                // Alt+Esc above, Ctrl+Shift+Esc) already cover every task-switch route Esc
+                // takes. Note this early-out sits ABOVE the KeyPressed dispatch, so suppressing
+                // bare Esc also starved CCP's own handlers of it.
 
                 // Ctrl+Shift+Esc (direct Task Manager shortcut)
                 if (vkCode == 0x1B && GetAsyncKeyState(0x11) < 0 && GetAsyncKeyState(0x10) < 0)

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -126,6 +126,19 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Forget that this session already completed a profile round-trip. Call on logout.
+        /// Logout zeroes local progression (ClearProgressionData), so without this the
+        /// defaults-push guard in SyncProfileAsync stays disarmed for the rest of the app
+        /// session and the first sync after a re-login can PUSH the zeroed streak/XP before
+        /// the READ lands — the streak then flashes 0 until a later sync repaints it.
+        /// </summary>
+        public void ResetLoadedProfileState()
+        {
+            _hasLoadedProfile = false;
+            App.Logger?.Debug("Profile sync: loaded-profile flag reset (logout) - defaults guard re-armed");
+        }
+
+        /// <summary>
         /// Send a lightweight heartbeat to keep user showing as online.
         /// Only updates last_seen timestamp, doesn't sync full profile.
         /// </summary>

--- a/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/QuestsTabView.xaml
@@ -24,9 +24,14 @@
                     <!-- Daily/Weekly Quests Panel -->
                     <StackPanel x:Name="DailyWeeklyPanel" x:FieldModifier="internal">
                         <!-- Season Title Banner -->
+                        <!-- The Text below is only ever the pre-first-paint placeholder: RefreshQuestUI
+                             overwrites it with QuestDefinitionService.SeasonTitle (server title, else the
+                             local month name). It must stay season-NEUTRAL - it used to hardcode
+                             "Airhead April", so any lost first-paint race showed a long-dead season.
+                             Mirrors the same neutral fallback LeaderboardTabView uses. -->
                         <Border Background="{DynamicResource DarkerBgBrush}" CornerRadius="12" Padding="20,14" Margin="0,0,0,18"
                                 BorderThickness="1" BorderBrush="#3D3D60">
-                            <TextBlock x:Name="TxtSeasonTitle" x:FieldModifier="internal" Text="{loc:Str label_airhead_april}"
+                            <TextBlock x:Name="TxtSeasonTitle" x:FieldModifier="internal" Text="{loc:Str section_seasons}"
                                        FontSize="28" FontWeight="ExtraBold" FontStyle="Italic"
                                        HorizontalAlignment="Center" TextAlignment="Center">
                                 <TextBlock.Foreground>


### PR DESCRIPTION
Pre-release fix batch for 6.7 (3 of 3).

- **#680**: bare-Esc no longer swallowed machine-wide during Lockdown. Trace in commit: the block sat upstream of hook dispatch (could only REMOVE input from CCP panic detection, never feed it); panic key is force-disabled during Lockdown anyway; Alt+Esc/Ctrl+Esc/Ctrl+Shift+Esc/Win/Alt+Tab/Alt+F4 branches untouched. Also un-blocks in-app Esc ladders (DtRH, FYP ghost) during Lockdown.
- **Streak flashes 0 after logout**: _hasLoadedProfile now resets in ClearAccountData (single funnel, all 7 logout paths). Real risk was zeros PUSHING to the server before the read landed on re-login.
- **Webcam consent dialog source link 404** - path updated for the Services/Webcam reorg.
- **Stale "Airhead April" design-time season label** -> section_seasons (already translated 9/9).
- Haptics loc keys: NO-OP, already landed in PR#136 (verified empirically, 9/9 coverage).
- **#644 scoped out**: webcam PERMISSION is already persistent; the recurring prompt is per-session camera START across 3 sites - skipping it means auto-starting the camera, an owner product call. Post-6.7 design written up (tri-state Ask/Always/Never + shared dialog + consent recheck).

Build 0 errors; 887/887 tests.

FLAGGED for its own ticket: 719 referenced loc keys missing in 7 of 9 languages (Blink Trainer, Local AI wizard, Remote Control, Companion/Lab) + 250 en-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGrTm1ev9kpvVDrZYsvesj
