### PR TITLE
fix(goon): give TURN-mediated pairs a real ICE budget so cellular duels keep the bulk lane

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/core/contracts.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/contracts.js
@@ -87,7 +87,50 @@ export const GoonConsts = Object.freeze({
   MinScheduleBufferMs: 1000,
   ClockPingRounds: 10,
   ClockResyncIntervalMs: 30000,
+  /**
+   * THE BASE ICE BUDGET, spent from the moment negotiation STARTS. This is the
+   * number for a STUN-only room: with no relay credentials in hand there is no
+   * candidate left to wait for once host and srflx pairs have failed, so failing
+   * fast to the ws relay is strictly better than making the player watch a
+   * spinner. See IceRelayGraceMs for what happens when TURN IS in play.
+   */
   IceTimeoutMs: 10000,
+  /**
+   * THE TURN EXTENSION (2026-08-05, the cellular play-test). Added to
+   * IceTimeoutMs whenever the room actually handed us TURN credentials, because
+   * 10 s is not a budget a relayed pair on a carrier link can meet:
+   *
+   *   * a dead STUN/TURN url does not fail fast — libwebrtc runs its full STUN
+   *     retransmit ladder (~9.5 s) before it reports 701. The desktop's own log
+   *     from that evening shows THREE of those (metered's stun urls + UDP TURN
+   *     allocate) finishing at roughly the same moment gathering completed —
+   *     the ENTIRE base budget went on gathering, before one check ran;
+   *   * the candidate that actually works for a phone behind carrier-grade NAT
+   *     is TURN over TCP/TLS 443, which is the LAST one gathered (TCP connect +
+   *     TLS handshake + Allocate, all over a link with 100-300 ms RTT);
+   *   * every candidate then crosses the /v2/goon/signal MAILBOX, polled every
+   *     2 s, so each side's relay candidate reaches the other up to a poll
+   *     cycle plus an HTTP round trip late.
+   *
+   * Ten seconds killed a connection that was still legitimately in progress,
+   * and because the fallback is TERMINAL (no upgrade path; see net/session.js)
+   * that one impatient deadline turned the whole media-transfer feature off for
+   * the rest of the match — `supportsBulk` is P2P-only by design.
+   *
+   * Waiting longer costs nothing when the link is genuinely broken: the
+   * pc.connectionState === 'failed' edge is the real backstop and fires as soon
+   * as the browser has exhausted its checks, well inside this budget.
+   */
+  IceRelayGraceMs: 15000,
+  /**
+   * THE ONE-SHOT PROGRESS EXTENSION. Granted at most once, when the budget above
+   * runs out while the browser says checks are still in flight
+   * (iceConnectionState checking/connected/completed — see iceChecksInFlight).
+   * 'connected' without an open data channel is the DTLS+SCTP handshake still
+   * running over a relay, which is precisely the case where giving up would be
+   * absurd: the pair already won.
+   */
+  IceProgressGraceMs: 8000,
   /**
    * GUEST ONLY: how long a joined guest waits for the host's first offer before
    * giving up on P2P (webrtcTransport.waitForChannel). A guest that has redeemed

--- a/ConditioningControlPanel/Resources/web/goon/net/session.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/session.js
@@ -23,6 +23,23 @@
 // first currentMatch instance. The rebuild window is safe: ICE can only fail in Lobby, before the
 // hello/consent exchange has happened.
 //
+// THE FALLBACK IS ONE-WAY, AND THAT IS A DELIBERATE NON-FEATURE (investigated 2026-08-05).
+// It looks tempting to keep the peer connection alive through the downgrade and "upgrade back"
+// when a TURN pair finally completes — the match already survives one rebuild, why not two. It
+// does not work, for two reasons that are not about effort:
+//   1. A TRANSPORT SWITCH IS BILATERAL. The downgrade is safe only because BOTH peers independently
+//      reach the same verdict about the same room and meet again on the mailbox. An upgrade would
+//      be decided by whichever side's channel opened first, and the moment it switched it would be
+//      talking into a pipe the other side is not listening to — a duel with zero frames crossing,
+//      strictly worse than a relayed one. Making it safe needs a handshake ON the relay ("I have
+//      P2P, switch at N"), i.e. a new protocol frame, a new phase, and its own play-test.
+//   2. THE REBUILD WINDOW HAS CLOSED BY THEN. adoptLobby() only accepts a match in Idle, and it is
+//      only safe at all because nothing has been said yet. A late upgrade lands after hello and
+//      quite possibly after consent, and a fresh match object knows none of it.
+// So the fix for "cellular duels lose their media lane" lives one layer down, in how patient the
+// ICE budget is BEFORE _fallBackToRelay is ever reached — see GoonConsts.IceRelayGraceMs and
+// webrtcTransport.iceBudgetMs. Anyone revisiting the upgrade idea starts at point 1, not here.
+//
 // This facade does NOT gate on entitlement — the server enforces the tier-2 HOST bar at
 // /v2/goon/invite (403 no_host_access) and nothing at all at /join, which is free for everyone,
 // account or not. UI may pre-gate for niceness (title.js dims Host on caps.canHost), never here.
@@ -54,6 +71,29 @@ function invoke(target, names, ...args) {
     if (target && typeof target[n] === 'function') return target[n](...args);
   }
   throw new Error(`match object exposes none of: ${names.join(', ')}`);
+}
+
+/**
+ * Why did P2P give up? Two answers only, because only two matter when reading a play-test log:
+ *   deadline — a stopwatch of OURS fired. The browser may well still have been making progress,
+ *              so a recurring `deadline` is a signal the budget is wrong (webrtcTransport
+ *              iceBudgetMs / GoonConsts.IceRelayGraceMs), not that the network is hopeless.
+ *   failed   — the browser, the peer or the SDP said no. Nothing to tune; the link is unusable.
+ * Anything unrecognised reads `other` rather than being guessed at.
+ */
+function classifyFallback(lastError) {
+  switch (lastError) {
+    case 'ice_timeout':
+    case 'no_offer':
+      return 'deadline';
+    case 'ice_failed':
+    case 'sdp_rejected':
+    case 'peer_setup_failed':
+    case 'webrtc_unavailable':
+      return 'failed';
+    default:
+      return 'other';
+  }
 }
 
 function emit(listeners, arg, logger, what) {
@@ -268,7 +308,20 @@ export class GoonSession {
 
     const code = webrtc.code;
     const token = webrtc.token;
-    this._info(`P2P failed (${webrtc.lastError || '?'}), adopting room ${code} over relay`);
+    /**
+     * THE FALLBACK BREADCRUMB (2026-08-05). A warn, not an info, because info dies before the C#
+     * log and the phone's ?debug=1 overlay — and this is the single most consequential line in a
+     * duel's life: past it `supportsBulk` is false FOREVER (the ws mailbox is the one transport
+     * media may never ride), so every artifact the player queues for the rest of the match fires
+     * untagged. When a cellular play-test comes back saying "no transfers again", this line is
+     * what says whether we ran out of patience or the link genuinely died.
+     *
+     * `deadline` = a stopwatch fired while the browser may still have been working
+     * (ice_timeout / no_offer). `failed` = the browser or the SDP said no. See
+     * GoonConsts.IceRelayGraceMs for what the deadline is worth now.
+     */
+    this._warn(`relay fallback (${classifyFallback(webrtc.lastError)}: ${webrtc.lastError || '?'})`
+      + ` — adopting room ${code} over the server mailbox; bulk media lane is OFF for this match`);
 
     // Old match FIRST (it unsubscribes the dying transport; dispose sends nothing), then the
     // transport. The shared signaling client stays — the relay needs it.

--- a/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
+++ b/ConditioningControlPanel/Resources/web/goon/net/webrtcTransport.js
@@ -22,9 +22,17 @@
 //                 tick; what the two channels share is the association's congestion window, which
 //                 is what mediaChannel's backpressure pump manages.
 //
-// ICE: public STUN only, no TURN by design. A NAT pair that can't be punched gives up after
-// GoonConsts.IceTimeoutMs, sets `iceFailed`, and the caller opens a relay transport on the SAME
-// room — `code`/`token` deliberately survive the failure so session.js can adopt it.
+// ICE: three public STUN providers, ALWAYS, plus whatever turn/turns entries the ROOM handed us
+// (net/signaling.js iceServers — server-minted, short-lived; the provider's own stun urls are
+// dropped, see turnOnlyIceServers). A pair that cannot be formed gives up after `iceBudgetMs` —
+// GoonConsts.IceTimeoutMs alone when there is no relay to wait for, plus IceRelayGraceMs when
+// there is, plus one IceProgressGraceMs if checks are still in flight at that point — sets
+// `iceFailed`, and the caller opens a relay transport on the SAME room: `code`/`token`
+// deliberately survive the failure so session.js can adopt it.
+//
+// A TURN-mediated pair is STILL P2P as far as this file and `supportsBulk` are concerned: it ends
+// in ConnectedP2P over a real data channel. The thing media must never ride is the ws/HTTP mailbox
+// in net/relayTransport.js, which is a different object entirely.
 //
 // NODE-IMPORT-SAFE: nothing at module scope touches RTCPeerConnection. It is constructed only
 // inside the negotiation path, guarded — a page without WebRTC fails with lastError
@@ -43,6 +51,80 @@ export const STUN_URLS = Object.freeze([
   'stun:stun1.l.google.com:19302',
   'stun:stun.cloudflare.com:3478',
 ]);
+
+/**
+ * Does this entry carry at least one turn/turns url? The room's server-minted
+ * list is the only source of relay candidates; the built-in STUN list never is.
+ */
+export function entryHasTurn(entry) {
+  if (!entry) return false;
+  const urls = Array.isArray(entry.urls) ? entry.urls : [entry.urls];
+  return urls.some((u) => /^turns?:/i.test(String(u || '')));
+}
+
+/**
+ * THE ROOM'S ENTRIES, TURN URLS ONLY (2026-08-05).
+ *
+ * metered's credentials endpoint answers with `stun:` urls alongside its turn
+ * ones, and on the cellular play-test every single one of them 701'd:
+ *   stun:global.relay.metered.ca:80 / :443, stun:stun.relay.metered.ca:80 —
+ *   "STUN binding request timed out".
+ * A dead STUN url is not free. libwebrtc runs the full binding retransmit
+ * ladder (~9.5 s) before it gives up, and iceGatheringState stays 'gathering'
+ * the whole time, so three dead urls are three parallel legs holding the
+ * gathering phase open for most of the ICE budget — for candidates we do not
+ * need, because STUN_URLS above already covers srflx with three public
+ * providers and a TURN allocation yields its own srflx on the way through.
+ *
+ * So: keep every entry that can produce a RELAY candidate, and inside it keep
+ * only the turn/turns urls. Entries with no turn url at all are dropped whole.
+ * A server that hands out nothing but stun therefore contributes nothing, which
+ * is exactly right — that is the STUN-only case the built-in list already is.
+ */
+export function turnOnlyIceServers(entries) {
+  if (!Array.isArray(entries)) return [];
+  const out = [];
+  for (const e of entries) {
+    if (!entryHasTurn(e)) continue;
+    const urls = (Array.isArray(e.urls) ? e.urls : [e.urls])
+      .filter((u) => /^turns?:/i.test(String(u || '')));
+    if (!urls.length) continue;
+    const kept = { urls };
+    if (e.username !== undefined) kept.username = e.username;
+    if (e.credential !== undefined) kept.credential = e.credential;
+    out.push(kept);
+  }
+  return out;
+}
+
+/**
+ * How long the ICE attempt gets, from the moment negotiation starts.
+ * See GoonConsts.IceRelayGraceMs for the whole argument; the short version is
+ * that a relayed pair on a carrier link cannot be judged in ten seconds, and a
+ * STUN-only room has nothing to wait for.
+ */
+export function iceBudgetMs(turnConfigured) {
+  return GoonConsts.IceTimeoutMs + (turnConfigured ? GoonConsts.IceRelayGraceMs : 0);
+}
+
+/**
+ * Is the browser still DOING something, as of `iceConnectionState`? Gate for the
+ * one-shot IceProgressGraceMs extension.
+ *
+ *   checking   — pairs are being probed right now.
+ *   connected  — a pair WON; the only thing left is DTLS + SCTP, which over a
+ *                relay is another couple of round trips. Giving up here would
+ *                throw away a working link.
+ *   completed  — same, with gathering finished too.
+ *
+ * 'new' means nothing has started (no extension: something is wrong upstream),
+ * 'disconnected' means a pair died, and 'failed'/'closed' are terminal — the
+ * transport already folds on those via pc.onconnectionstatechange.
+ */
+export function iceChecksInFlight(iceConnectionState) {
+  const s = String(iceConnectionState || '');
+  return s === 'checking' || s === 'connected' || s === 'completed';
+}
 
 const CHANNEL_LABEL = 'goon';
 
@@ -106,6 +188,24 @@ export class GoonWebRtcTransport extends GoonTransportBase {
     this._token = null;
     this._iceFailed = false;
     this._peerDisplayName = null;
+
+    /**
+     * Did the ROOM hand us TURN credentials? Decided once, in _startPeer, off
+     * the entries the signaling client recorded — and it is what buys the
+     * attempt GoonConsts.IceRelayGraceMs on top of the base budget. Deliberately
+     * "were relay credentials in play", not "did we gather a relay candidate":
+     * the relay candidate is exactly the one that arrives LATE, so making the
+     * extension depend on having already seen it would arm the longer budget
+     * only after the short one had already killed the attempt.
+     */
+    this._turnConfigured = false;
+    /**
+     * Diagnostics only (the fallback breadcrumb + the grace warn): did either
+     * side ever produce a `typ relay` candidate? Nothing branches on it.
+     */
+    this._sawLocalRelay = false;
+    this._sawRemoteRelay = false;
+    this._pairLogged = false;         // one-shot guard for the selected-pair breadcrumb
   }
 
   /** Invite code for this room. Survives an ICE failure so the relay can adopt it. */
@@ -158,14 +258,23 @@ export class GoonWebRtcTransport extends GoonTransportBase {
   }
 
   /**
-   * Resolves when the data channel is open, or when ICE gives up (GoonConsts.IceTimeoutMs after
-   * negotiation STARTS), or — guest only — when no offer ever arrives (GoonConsts.NoOfferTimeoutMs
-   * after the join). False means "fall back to relay" — check `iceFailed` to tell that apart from
-   * a signaling failure.
+   * Resolves when the data channel is open, or when ICE gives up (iceBudgetMs after negotiation
+   * STARTS, plus at most one IceProgressGraceMs extension), or — guest only — when no offer ever
+   * arrives (GoonConsts.NoOfferTimeoutMs after the join). False means "fall back to relay" — check
+   * `iceFailed` to tell that apart from a signaling failure.
+   *
+   * THE BUDGET IS NOT A CONSTANT ANY MORE (2026-08-05). A STUN-only room still fails at
+   * GoonConsts.IceTimeoutMs; a room carrying TURN credentials gets IceRelayGraceMs on top, and one
+   * further IceProgressGraceMs if the browser is demonstrably still checking when that runs out.
+   * The whole argument lives on GoonConsts.IceRelayGraceMs — in one line: the flat 10 s deadline
+   * was killing cellular duels that were still mid-handshake, and because the relay fallback is
+   * terminal that silently disabled media transfer for the rest of the match.
    */
   async waitForChannel() {
-    let deadline = Date.now() + GoonConsts.IceTimeoutMs;
+    let budgetMs = GoonConsts.IceTimeoutMs;
+    let deadline = Date.now() + budgetMs;
     let negotiationSeen = false;
+    let graceUsed = false;
     // GUEST ONLY: a joined guest is OWED an offer — it redeemed the code, the host learns
     // `peer_joined` on its next poll and offers immediately. If none arrives inside
     // NoOfferTimeoutMs the host side is dead or unreachable, and without this budget the
@@ -183,7 +292,12 @@ export class GoonWebRtcTransport extends GoonTransportBase {
       // human to type the code must not eat into it.
       if (!negotiationSeen && this._negotiationStarted) {
         negotiationSeen = true;
-        deadline = Date.now() + GoonConsts.IceTimeoutMs;
+        budgetMs = iceBudgetMs(this._turnConfigured);
+        deadline = Date.now() + budgetMs;
+        // WARN, like the other ICE diagnostics in this file: this is the line that tells the next
+        // play-test which budget the attempt actually ran on, which is the difference between
+        // "TURN was never in play" and "TURN was in play and still lost".
+        this._warn(`ice budget ${budgetMs}ms (turn creds ${this._turnConfigured ? 'present' : 'ABSENT'})`);
       }
 
       if (!negotiationSeen && Date.now() > noOfferDeadline) {
@@ -199,9 +313,27 @@ export class GoonWebRtcTransport extends GoonTransportBase {
       }
 
       if (negotiationSeen && Date.now() > deadline) {
+        const iceState = (this._pc && this._pc.iceConnectionState) || 'none';
+
+        // THE ONE-SHOT EXTENSION. Only when the browser says checks are still running: a pair that
+        // is mid-probe, or one that already won and is only waiting on DTLS+SCTP over a relay, is
+        // not a link to throw away over a stopwatch. Once, never twice — a second extension would
+        // be an unbounded wait dressed as a budget.
+        if (!graceUsed && iceChecksInFlight(iceState)) {
+          graceUsed = true;
+          deadline = Date.now() + GoonConsts.IceProgressGraceMs;
+          this._warn(`ice budget ${budgetMs}ms elapsed but checks are still in flight`
+            + ` (iceConnectionState=${iceState}, relay candidates local=${this._sawLocalRelay} remote=${this._sawRemoteRelay})`
+            + ` — one grace extension of ${GoonConsts.IceProgressGraceMs}ms`);
+          await this._sleep(100);
+          continue;
+        }
+
         this._iceFailed = true;
         this._setLastError('ice_timeout');
-        this._warn(`ICE did not complete in ${GoonConsts.IceTimeoutMs}ms — relay fallback`);
+        this._warn(`ICE did not complete in ${budgetMs + (graceUsed ? GoonConsts.IceProgressGraceMs : 0)}ms`
+          + ` (iceConnectionState=${iceState}, turn creds ${this._turnConfigured ? 'present' : 'ABSENT'},`
+          + ` relay candidates local=${this._sawLocalRelay} remote=${this._sawRemoteRelay}) — relay fallback`);
         this._setState(GoonTransportState.Disconnected, 'ice_timeout');
         return false;
       }
@@ -344,6 +476,10 @@ export class GoonWebRtcTransport extends GoonTransportBase {
 
   async _tryAddCandidate(cand) {
     try {
+      // Diagnostics only: the SDP candidate line carries its type as `typ relay`. Knowing whether
+      // the PEER ever managed a TURN allocation is half of any "why did this pair not form"
+      // question, and the phone side never ships us a log of its own.
+      if (cand && / typ relay\b/.test(String(cand.candidate || ''))) this._sawRemoteRelay = true;
       if (this._pc) await this._pc.addIceCandidate(cand);
     } catch (e) {
       // One unusable candidate is normal (IPv6-only, a stale srflx); the pair still works.
@@ -376,18 +512,21 @@ export class GoonWebRtcTransport extends GoonTransportBase {
        * actually meet: without a relay candidate those two networks never
        * complete ICE, every duel lands on the HTTP-mailbox fallback, and the
        * media transfer (P2P-only by design) never gets a channel to run on. */
-      const iceServers = STUN_URLS.map((urls) => ({ urls }))
-        .concat(Array.isArray(this._signaling?.iceServers) ? this._signaling.iceServers : []);
+      /* TURN URLS ONLY out of the room's list — see turnOnlyIceServers for why the provider's
+       * own `stun:` entries are dropped rather than merged (they are three more dead legs
+       * holding iceGatheringState open for most of the budget, on a network where they 701). */
+      const roomTurn = turnOnlyIceServers(this._signaling?.iceServers);
+      const iceServers = STUN_URLS.map((urls) => ({ urls })).concat(roomTurn);
+      /* THE BUDGET SWITCH, decided here and read by waitForChannel: relay credentials in hand
+       * means this attempt is allowed to take as long as a relayed cellular pair actually takes. */
+      this._turnConfigured = roomTurn.length > 0;
       /* DIAGNOSTIC WARNS, deliberately (2026-08-05): info lines die before the
        * C# log and the phone's ?debug=1 overlay, and this exact spot is where
        * three play-test evenings' worth of "still relayed" questions get their
        * answer — did the room carry TURN entries at all, did the browser take
        * them, and what did gathering actually produce. */
-      const turnEntries = iceServers.filter((s) => {
-        const u = Array.isArray(s.urls) ? s.urls : [s.urls];
-        return u.some((x) => /^turns?:/i.test(String(x)));
-      }).length;
-      this._warn(`ice config: ${iceServers.length} entr(ies), ${turnEntries} carrying turn urls`);
+      this._warn(`ice config: ${iceServers.length} entr(ies), ${roomTurn.length} carrying turn urls`
+        + ` (room list ${(this._signaling?.iceServers || []).length} raw, stun-only entries dropped)`);
       const pc = new RTCPeerConnection({ iceServers });
       this._pc = pc;
       const iceTally = { host: 0, srflx: 0, relay: 0, prflx: 0 };
@@ -424,6 +563,7 @@ export class GoonWebRtcTransport extends GoonTransportBase {
         if (!e || !e.candidate || this.isDisposed) return;
         const t = String(e.candidate.type || '');
         if (t in iceTally) iceTally[t]++;
+        if (t === 'relay') this._sawLocalRelay = true;
         try { this._enqueueSignal('ice', JSON.stringify(e.candidate.toJSON())); }
         catch (err) { this._info(`Failed to queue local candidate: ${(err && err.message) || err}`); }
       };
@@ -648,6 +788,63 @@ export class GoonWebRtcTransport extends GoonTransportBase {
     // _setState kicks off the clock sync (autoClockSync) — GoonTransportBase.BeginClockSync.
     this._setState(GoonTransportState.ConnectedP2P, 'data channel open');
     this._flushResumeBuffer();
+    // Fire-and-forget: getStats is async and nothing may wait on a diagnostic. The .catch is not
+    // decoration — an unhandled rejection out of a LOG LINE would be a genuinely stupid way to
+    // take down a connection that just succeeded.
+    try { const p = this._logSelectedPair(); if (p && p.catch) p.catch(() => {}); }
+    catch (_e) { /* diagnostics never bite */ }
+  }
+
+  /**
+   * THE BREADCRUMB THAT ANSWERS "how did this duel actually connect" (2026-08-05). One warn, once
+   * per transport, naming the nominated pair's candidate types — host/srflx/relay/prflx on each
+   * side. `relay/…` is the receipt that TURN did its job; `srflx/srflx` on a cellular guest means
+   * the phone punched through and the whole TURN apparatus was never needed.
+   *
+   * It is a warn because info lines do not survive the trip to the C# log or the ?debug=1 overlay,
+   * and this line is the entire point of the next cellular play-test.
+   *
+   * BOTH STAT SHAPES. Chromium hangs the pair off `transport.selectedCandidatePairId`; Safari (the
+   * iPhone side, and the one we most need to hear from) marks the pair itself with `selected`.
+   * Neither is guaranteed, so the whole thing degrades to silence rather than throwing.
+   */
+  async _logSelectedPair() {
+    if (this._pairLogged) return;
+    const pc = this._pc;
+    if (!pc || typeof pc.getStats !== 'function') return;
+    this._pairLogged = true;
+    try {
+      const stats = await pc.getStats();
+      if (!stats || typeof stats.forEach !== 'function') return;
+
+      const byId = new Map();
+      stats.forEach((r) => { if (r && r.id) byId.set(r.id, r); });
+
+      let pair = null;
+      stats.forEach((r) => {
+        if (!r) return;
+        if (r.type === 'transport' && r.selectedCandidatePairId && byId.has(r.selectedCandidatePairId)) {
+          pair = byId.get(r.selectedCandidatePairId);
+        }
+      });
+      if (!pair) {
+        stats.forEach((r) => {
+          if (pair || !r || r.type !== 'candidate-pair') return;
+          if (r.selected === true || (r.nominated === true && r.state === 'succeeded')) pair = r;
+        });
+      }
+      if (!pair) { this._warn('p2p link up — the browser named no selected candidate pair'); return; }
+
+      const local = byId.get(pair.localCandidateId);
+      const remote = byId.get(pair.remoteCandidateId);
+      const lt = (local && local.candidateType) || '?';
+      const rt = (remote && remote.candidateType) || '?';
+      const proto = (local && (local.relayProtocol || local.protocol)) || '?';
+      this._warn(`p2p link up via ${lt}/${rt} over ${proto}`
+        + ` (turn creds ${this._turnConfigured ? 'present' : 'ABSENT'})`);
+    } catch (e) {
+      this._info(`selected-pair stats unavailable: ${(e && e.message) || e}`);
+    }
   }
 
   // ------------------------------------------------------------------ reconnect / resume

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -14,7 +14,9 @@ import { GoonFakeSignalingServer, shadowGuestUid, isShadowUid } from '../net/fak
 import { createLoopbackPair, loopbackOptions, loopbackPresets } from '../net/loopbackTransport.js';
 import { GoonRelayTransport } from '../net/relayTransport.js';
 import { GoonSession } from '../net/session.js';
-import { GoonWebRtcTransport } from '../net/webrtcTransport.js';
+import {
+  GoonWebRtcTransport, STUN_URLS, entryHasTurn, turnOnlyIceServers, iceBudgetMs, iceChecksInFlight,
+} from '../net/webrtcTransport.js';
 import { GoonTransportState, GoonConsts, makeEmote, makeTick } from '../core/contracts.js';
 
 let failures = 0;
@@ -1282,6 +1284,122 @@ async function testIceServers() {
     'a server that never heard of ice_servers leaves the client with []');
 }
 
+/* ================================================================ 14b. THE CELLULAR ICE BUDGET
+ *
+ * The 2026-08-05 play-test: iPhone on 5G joins cclabs.app/goon-beta, desktop WPF host on a home
+ * LAN. The duel never reached ConnectedP2P, fell back to the ws mailbox, and because `supportsBulk`
+ * is P2P-only every artifact after that fired untagged — the media-transfer feature silently died
+ * for the whole match. The desktop's own log said the interesting part: it gathered FOUR relay
+ * candidates, while three metered `stun:` urls and the UDP TURN allocate all 701'd on the full
+ * ~9.5 s STUN retransmit ladder. The flat 10 s GoonConsts.IceTimeoutMs was spent on GATHERING; the
+ * TURN-over-TLS pair that a carrier-NAT'd phone actually needs never got a chance to be checked.
+ *
+ * Everything below pins the two halves of the remedy: a budget that knows whether a relay is even
+ * in play, and an ice server list that does not pay for candidates it does not need. The wall-clock
+ * behaviour itself needs a browser (and a phone on cellular) — these are the pure pieces
+ * waitForChannel is built out of, plus source pins that it really uses them.
+ * ==============================================================================*/
+async function testIceBudget() {
+  // --- the budget arithmetic ----------------------------------------------------
+  ok(iceBudgetMs(false) === GoonConsts.IceTimeoutMs,
+    'a STUN-only room keeps the old fail-fast budget — with no relay to wait for, waiting is only a spinner');
+  ok(iceBudgetMs(true) === GoonConsts.IceTimeoutMs + GoonConsts.IceRelayGraceMs,
+    'a room carrying TURN creds gets the relay grace on top', String(iceBudgetMs(true)));
+  ok(iceBudgetMs(true) > 20000,
+    'and the relayed budget clears 20s — gathering alone burned ~10s on the cellular play-test',
+    String(iceBudgetMs(true)));
+  ok(Number.isFinite(GoonConsts.IceProgressGraceMs) && GoonConsts.IceProgressGraceMs > 0,
+    'there is a one-shot progress extension on top of that');
+  // A runaway upper bound is a player staring at a spinner. The hard-fail edge
+  // (pc.connectionState === 'failed') is the real backstop; this is only the "nothing at all is
+  // happening" one, and it must stay inside what a person will sit through.
+  ok(iceBudgetMs(true) + GoonConsts.IceProgressGraceMs <= 40000,
+    'the absolute worst case stays under 40s', String(iceBudgetMs(true) + GoonConsts.IceProgressGraceMs));
+
+  // --- what counts as "still working" -------------------------------------------
+  ok(iceChecksInFlight('checking'), 'checking = pairs are being probed right now, extend');
+  ok(iceChecksInFlight('connected'), 'connected = a pair WON and only DTLS/SCTP is left, extend');
+  ok(iceChecksInFlight('completed'), 'completed = same, with gathering done, extend');
+  ok(!iceChecksInFlight('new'), 'new = nothing started, no extension');
+  ok(!iceChecksInFlight('failed') && !iceChecksInFlight('closed'), 'terminal states never extend');
+  ok(!iceChecksInFlight('disconnected'), 'disconnected = a pair died, no extension');
+  ok(!iceChecksInFlight(undefined) && !iceChecksInFlight(null) && !iceChecksInFlight(''),
+    'a missing state never extends (no pc = nothing in flight)');
+
+  // --- the room list, turn urls only --------------------------------------------
+  ok(entryHasTurn({ urls: 'turn:a.example:443' }) && entryHasTurn({ urls: ['stun:b', 'turns:c:443'] }),
+    'entryHasTurn spots turn and turns, single or list');
+  ok(!entryHasTurn({ urls: 'stun:b.example' }) && !entryHasTurn(null),
+    'a stun-only entry (and junk) carries no turn');
+
+  const metered = turnOnlyIceServers([
+    { urls: 'stun:stun.relay.metered.ca:80' },
+    { urls: ['stun:global.relay.metered.ca:80', 'turn:global.relay.metered.ca:80'], username: 'u', credential: 'c' },
+    { urls: 'turns:global.relay.metered.ca:443?transport=tcp', username: 'u', credential: 'c' },
+  ]);
+  ok(metered.length === 2, 'the stun-only entry is dropped whole', JSON.stringify(metered));
+  ok(metered[0].urls.length === 1 && metered[0].urls[0] === 'turn:global.relay.metered.ca:80',
+    'and the stun url is stripped OUT of a mixed entry — a dead stun leg holds gathering open for ~9.5s');
+  ok(metered[0].username === 'u' && metered[0].credential === 'c', 'credentials ride along untouched');
+  ok(turnOnlyIceServers(null).length === 0 && turnOnlyIceServers([]).length === 0,
+    'no room list (old server, TURN unconfigured) -> [], i.e. exactly the STUN-only behaviour');
+  ok(turnOnlyIceServers([{ urls: ['stun:a', 'stun:b'] }]).length === 0,
+    'a server that hands out nothing but stun contributes nothing');
+  ok(STUN_URLS.length === 3, 'the built-in public STUN list still covers srflx on its own');
+
+  // --- the transport really wires all of it -------------------------------------
+  {
+    const src = readSource('../net/webrtcTransport.js');
+    ok(/this\._turnConfigured = roomTurn\.length > 0/.test(src),
+      'the budget switch is set from the ROOM list, not from a candidate we have already gathered');
+    ok(/budgetMs = iceBudgetMs\(this\._turnConfigured\)/.test(src),
+      'waitForChannel arms the budget off iceBudgetMs when negotiation starts');
+    ok(/turnOnlyIceServers\(this\._signaling\?\.iceServers\)/.test(src),
+      'the room list goes through turnOnlyIceServers before it reaches RTCPeerConnection');
+    const wait = src.slice(src.indexOf('async waitForChannel'), src.indexOf('signaling pump'));
+    ok(/!graceUsed && iceChecksInFlight\(iceState\)/.test(wait),
+      'the progress extension is gated on iceChecksInFlight');
+    ok((wait.match(/graceUsed = true/g) || []).length === 1 && /graceUsed = false/.test(src),
+      'it is ONE-SHOT — a second extension would be an unbounded wait dressed as a budget');
+    ok(/GoonTransportState\.ConnectedP2P\b/.test(src.slice(src.indexOf('get supportsBulk'), src.indexOf('get supportsBulk') + 220)),
+      'supportsBulk is STILL P2P-only — a TURN pair qualifies because it ends in ConnectedP2P, the mailbox never does');
+  }
+
+  // --- the two breadcrumbs the next cellular play-test reads ---------------------
+  {
+    const src = readSource('../net/webrtcTransport.js');
+    ok(/_logSelectedPair\(\)/.test(src) && /p2p link up via \$\{lt\}\/\$\{rt\}/.test(src),
+      'a connected transport warns which candidate pair actually won (host/srflx/relay)');
+    ok(/this\._pairLogged/.test(src), 'and it says so exactly once per transport');
+    ok(/selectedCandidatePairId/.test(src) && /r\.selected === true/.test(src),
+      'both stat shapes are read — Chromium hangs it off transport, Safari marks the pair');
+    ok(/this\._warn\(`p2p link up/.test(src),
+      'it is a WARN: info lines never reach the C# log or the ?debug=1 overlay');
+
+    const ses = readSource('../net/session.js');
+    ok(/function classifyFallback/.test(ses), 'session.js classifies WHY the fallback fired');
+    ok(/this\._warn\(`relay fallback \(\$\{classifyFallback\(webrtc\.lastError\)\}/.test(ses),
+      'and warns it once, on the way down to the mailbox');
+    ok(/bulk media lane is OFF for this match/.test(ses),
+      'the line spells out the consequence — this is the moment media transfer dies');
+    ok(!/this\._info\(`P2P failed/.test(ses), 'the old info-level line is gone, not duplicated');
+  }
+
+  // --- the invariant the no-offer budget lives under ----------------------------
+  // NoOfferTimeoutMs guards a DIFFERENT window (before negotiation starts) and the two are mutually
+  // exclusive in waitForChannel, so the relayed budget overtaking it is fine. What must stay true
+  // is the original point: a slow poll cycle must not eat a live host.
+  ok(GoonConsts.NoOfferTimeoutMs > GoonConsts.IceTimeoutMs,
+    'the no-offer budget still clears the BASE ice budget');
+  {
+    const src = readSource('../net/webrtcTransport.js');
+    const wait = src.slice(src.indexOf('async waitForChannel'), src.indexOf('signaling pump'));
+    ok(/if \(!negotiationSeen && Date\.now\(\) > noOfferDeadline\)/.test(wait)
+      && /if \(negotiationSeen && Date\.now\(\) > deadline\)/.test(wait),
+      'the two budgets stay mutually exclusive on negotiationSeen');
+  }
+}
+
 /* ============================================================ 14. net/codecs.js
  *
  * THE FAIL-OPEN CONTRACT IS THE TEST. Everything below is one question asked six ways: can this
@@ -1379,6 +1497,7 @@ async function testCodecs() {
 const main = async () => {
   await testSignaling();
   await testIceServers();
+  await testIceBudget();
   await testLoopback();
   await testRelayTransport();
   await testSessionFallback();


### PR DESCRIPTION
## The bug

Play-tested 2026-08-05: iPhone 13 Pro Max on 5G joining `cclabs.app/goon-beta`, desktop WPF host on a home LAN. The duel's WebRTC transport never reached `ConnectedP2P` and fell back to the server websocket relay. Because `supportsBulk` is P2P-only by design, that silently killed the **entire media-transfer feature** for the rest of the match:

```
[GG queue] payload kind N fired untagged - no bulk lane on this link (relay fallback)
```

~5 artifacts landed before the fallback completed; the rest of the match starved. On WiFi it all works.

## Root cause

`GoonConsts.IceTimeoutMs` was a flat **10 s** from the moment negotiation started. On a carrier link that budget is gone before a single connectivity check runs.

The desktop's own log from that evening says it plainly:

```
ice candidate error 701: STUN binding request timed out. (stun:global.relay.metered.ca:80 / :443, stun:stun.relay.metered.ca:80)
ice candidate error 701: TURN allocate request timed out. (turn:global.relay.metered.ca:80?transport=udp / :443?transport=udp)
ice gathering complete: host=4 srflx=1 relay=4 prflx=0
```

- A dead STUN/TURN url does **not** fail fast: libwebrtc runs its full binding retransmit ladder (~9.5 s) before it reports 701, and `iceGatheringState` stays `gathering` the whole time. Three metered `stun:` urls plus the UDP TURN allocate = four parallel dead legs holding gathering open for essentially the whole base budget.
- The candidate that actually works for a phone behind carrier-grade NAT is **TURN over TCP/TLS 443** - the *last* one gathered (TCP connect + TLS handshake + Allocate, over a 100-300 ms RTT link).
- Every candidate then crosses the `/v2/goon/signal` mailbox, short-polled every 2 s, so each side's relay candidate reaches the other up to a poll cycle plus an HTTP round trip late.

So the stopwatch was killing a handshake that was still legitimately in progress - and the fallback is **terminal** (no upgrade path), which is why one impatient deadline disabled a whole feature.

**Ruled out during the investigation:** stale TURN creds (the server mints them with a 4 h expiry behind a 30 min cache - worst case a client holds 3.5 h of relay), and the guest not getting creds at all (`/v2/goon/join` returns `ice_servers` on every path, including rejoin and self-duel, and `_noteIceServers` records them off both `/invite` and `/join`). The C# `GoonWebRtcTransport` is dev-panel-only and never read `ice_servers`, so its 10 s constant is still correct and is left alone.

## The fix

**`core/contracts.js`**
- `IceTimeoutMs` keeps its 10 s meaning, now explicitly documented as *the STUN-only budget*: with no relay credentials there is no candidate left to wait for, so failing fast beats a spinner.
- **`IceRelayGraceMs: 15000`** - added on top whenever the room actually handed us TURN credentials.
- **`IceProgressGraceMs: 8000`** - a one-shot extension, granted only when the browser says checks are still in flight at the deadline.

Worst case 33 s, and only in the "nothing at all is happening" case. The real backstop for a genuinely broken link is unchanged: `pc.connectionState === 'failed'` fires as soon as the browser has exhausted its checks, well inside this budget.

**`net/webrtcTransport.js`**
- `iceBudgetMs(turnConfigured)`, `iceChecksInFlight(state)` and `turnOnlyIceServers(entries)` exported as pure helpers and wired into `waitForChannel`.
- The budget switch is armed off the **room list**, not off a relay candidate we have already gathered - the relay candidate is exactly the one that arrives late, so gating on it would arm the longer budget only after the short one had already killed the attempt.
- `iceChecksInFlight` extends on `checking` / `connected` / `completed`. `connected` without an open data channel is DTLS+SCTP still handshaking over a relay: the pair already won, giving up there would be absurd.
- The provider's own `stun:` urls are stripped out of the room list before it reaches `RTCPeerConnection`. `STUN_URLS` already covers srflx with three public providers, and a TURN allocation yields its own srflx on the way through - those three entries bought nothing and cost most of the budget.

**Two breadcrumbs**, both `logger.warn` so they survive the trip to the C# log and the phone's `?debug=1` overlay:
- On connect: the nominated candidate pair's types, e.g. `p2p link up via relay/srflx over tcp (turn creds present)`. Reads both stat shapes - Chromium hangs it off `transport.selectedCandidatePairId`, Safari marks the pair with `selected` - and degrades to silence rather than throwing.
- On fallback: `relay fallback (deadline: ice_timeout) - ... bulk media lane is OFF for this match`. `deadline` vs `failed` vs `other`, so the next log says whether we ran out of patience or the link actually died.

Plus richer context on the existing ICE warns (which budget was armed, `iceConnectionState` at give-up, whether either side ever produced a `typ relay` candidate).

## No late upgrade back to P2P

Investigated and deliberately **not** done; the reasoning is written into the `net/session.js` header so nobody re-derives it:

1. **A transport switch is bilateral.** The downgrade is safe only because both peers independently reach the same verdict about the same room and meet again on the mailbox. An upgrade would be decided by whichever side's channel opened first, and the moment it switched it would be talking into a pipe the other side is not listening to - a duel with zero frames crossing, strictly worse than a relayed one. Doing it safely needs a handshake *on* the relay (I have P2P, switch at N): a new protocol frame, a new phase, its own play-test.
2. **The rebuild window has closed by then.** `adoptLobby()` only accepts a match in `Idle`, and it is only safe at all because nothing has been said yet. A late upgrade lands after hello and quite possibly after consent, and a fresh match object knows none of it.

## Invariants held

- `supportsBulk` unchanged and still P2P-only. A TURN pair qualifies because it ends in `ConnectedP2P`; the mailbox never does. Bulk media still never rides the server relay.
- `exec/` imports nothing from `net/` or `ui/`.
- `GOON_BUILD` not bumped.
- No server changes. `ccp-server/proxy/goon-routes.js` was read only, and nothing was deployed.

## Tests

`test/selftest-net.js` gains section 14b: the budget arithmetic, the `iceChecksInFlight` table, `turnOnlyIceServers` against the exact metered list from the play-test, a worst-case ceiling, source pins that `waitForChannel` really uses all of it and that the one-shot stays one-shot, pins for both breadcrumbs, and a note reframing the existing `NoOfferTimeoutMs > IceTimeoutMs` invariant (the two budgets guard different, mutually exclusive windows).

`PASS - 334 checks` (was 298). Every other goon suite re-run and green; `selftest-avafx.js` has its 12 pre-existing failures, unrelated.

## What still needs a real cellular play-test

Everything about the wall clock. Node has no `RTCPeerConnection`, so the pure pieces are unit-tested and the timing is not. On the next phone-on-5G duel, the C# log should now answer three questions on its own:

- `ice budget 25000ms (turn creds present)` - the extension armed.
- `p2p link up via relay/... over tcp` - it connected, and over TURN. Transfers should then work exactly as they do on WiFi.
- If it still falls back: `relay fallback (deadline: ice_timeout)` plus the give-up line's `iceConnectionState=` and `relay candidates local=/remote=`. `deadline` with `remote=false` means the *phone* never got a TURN allocation (a client/provider problem, not a budget one); `deadline` with `remote=true` and `iceConnectionState=checking` means 33 s still is not enough; `failed` means the budget was never the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
