### PR TITLE
fix(goon): the voice mic nobody could see - lobby opt-in, emote-adjacent slot, gate breadcrumb

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -511,6 +511,7 @@ let currentMatch = null;
 let currentTransport = null;
 let currentSd = null;        // {presenter, inputs, dispose} from ui/sd
 let voice = null;            // ui/voice/voiceService.js — MATCH-SCOPED, see attachMatch
+let micGateSaid = false;     // the mic breadcrumb is once per match — see reportMicGate
 let hudHandle = null;
 let mercyHandle = null;
 let phaseUnsubs = [];
@@ -991,6 +992,8 @@ function attachMatch(match, transport) {
   currentMatch = match;
   currentTransport = transport || (goonSession ? goonSession.transport : null);
   escMercied = false;
+  // A new match is a new answer to "is there a mic on the desk". See reportMicGate.
+  micGateSaid = false;
 
   // EVERY match starts with the player's picks in the deck, proven rather than
   // assumed. `onItems` is the reactive path and it is the one that normally does
@@ -1357,6 +1360,57 @@ function detachMatch() {
   paintProbe();
 }
 
+/* ----------------------------------------------------------------------------
+ * THE MIC BREADCRUMB — one warn, once per match, when the duel goes live with no
+ * mic on the desk.
+ *
+ * THE BUG THIS EXISTS FOR (owner, 2026-08-05): "I cannot see the mic button."
+ * Three play-tests, three setups (iPhone Safari, iPhone Safari incognito, a
+ * desktop pair), never once visible — and the page said absolutely nothing in
+ * any of the three, because a hidden mic is the CORRECT rendering of five ANDed
+ * booleans and none of them is written down anywhere a play-test can read. Every
+ * one of those three was the same first gate (their own seat had never opted
+ * in), and finding that out took a code read rather than a log line.
+ *
+ * WARN, not info, and that is deliberate: warn is the level that reaches the C#
+ * log through bridge.log AND the phone's ?debug=1 overlay. This is the exact
+ * pattern (and the exact reasoning) as net/mediaQueue.js `whyNoTags` — the
+ * untagged-payload breadcrumb that ended the same kind of three-round hunt on
+ * the media lane a day earlier.
+ *
+ * ONCE. A match that reaches Live, then SuddenDeath, then a relay REBUILD would
+ * otherwise say it three times for one fact; `micGateSaid` is cleared in
+ * attachMatch, so a genuinely new match gets a genuinely new line.
+ */
+function reportMicGate() {
+  if (micGateSaid) return;
+  micGateSaid = true;
+  const mic = hudHandle && hudHandle.parts ? hudHandle.parts.mic : null;
+  try {
+    if (!voice) { logger.warn('voice mic hidden: no voice service (createVoiceService failed at attach)'); return; }
+    // The two facts the SERVICE cannot see for itself: the desk's zen bit and
+    // whether this host has a microphone API at all. Both are read defensively —
+    // a handle-shaped stub (no service = a no-op mic) answers neither.
+    let hudHidden = false;
+    let micSupported;
+    try { if (mic && typeof mic.shown === 'function' && typeof mic.available === 'function') hudHidden = mic.available() && !mic.shown(); }
+    catch (_e) { /* leave it false */ }
+    try { if (mic && mic.recorder && typeof mic.recorder.supported === 'function') micSupported = !!mic.recorder.supported(); }
+    catch (_e) { /* leave it undefined — the gate is then not reported */ }
+
+    const why = typeof voice.whyUnavailable === 'function'
+      ? voice.whyUnavailable({ hudHidden, micSupported })
+      : (voice.available() ? '' : 'unknown (this build has no whyUnavailable)');
+    // Shown and working: say nothing. A quiet log is the good outcome.
+    if (!why && mic && typeof mic.shown === 'function' && mic.shown()) return;
+    if (!why) { logger.warn('voice mic hidden: the service says live but the desk has no strip (mount failure?)'); return; }
+    logger.warn('voice mic hidden: ' + why);
+  } catch (e) {
+    // A diagnostic that can break a match is worse than no diagnostic.
+    logger.warn('voice mic gate check threw: ' + ((e && e.message) || e));
+  }
+}
+
 function mountHudNow() {
   if (hudHandle || !mountHud || !currentMatch) return;
   try {
@@ -1491,6 +1545,9 @@ function onPhase(phase) {
       router.hide();
       mountHudNow();
       mountMercyNow();
+      // AFTER the HUD, because the answer is partly about the strip that was
+      // just (not) put on the desk. See reportMicGate.
+      reportMicGate();
       try { discord?.setRpState?.('live'); } catch (_e) { /* presence is never load-bearing */ }
       break;
 

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4865,14 +4865,26 @@ const audioMod = await import('../ui/audio.js');
     const micHost20 = findOne(frame20, 'gg-voice-host');
     const chipHost20 = findOne(frame20, 'gg-voice-chiphost');
     ok(!!micHost20 && !!chipHost20, 'mountHud gives the mic and the chip a slot each');
-    ok(micHost20.parentNode === col20 && chipHost20.parentNode === col20,
-      'both are FLOW children of the opponent column — no coordinates, so no keep-out to miss');
+    /* THE MIC MOVED TO THE ARSENAL DRAWER (2026-08-05). It lived under the
+     * receipts in the opponent column, which is where nobody looked: the owner
+     * hunted for it "right under the Emote icon" across three play-tests. The
+     * emote tile is the last item on the RIGHT rail, so the slot is now the last
+     * child of `.gg-arsenal-panel`, immediately after the two rails. Still FLOW,
+     * still no coordinates, still no keep-out band to miss. */
+    const panel20 = findOne(frame20, 'gg-arsenal-panel');
+    ok(!!panel20 && micHost20.parentNode === panel20,
+      'the mic slot is a FLOW child of the arsenal panel — under the tiles, where the emote icon is');
+    const pkids = panel20.children;
+    ok(pkids.indexOf(micHost20) === pkids.length - 1 &&
+       pkids.indexOf(micHost20) > pkids.indexOf(findOne(panel20, 'gg-arsenal-rails')),
+      'and it is the LAST thing in the drawer, directly under the rails whose last right-hand tile is the emote');
+    ok(chipHost20.parentNode === col20,
+      'the CHIP stays in the opponent column — it is about THEIR voice, not a control');
     const kids = col20.children;
     ok(kids.indexOf(chipHost20) === kids.indexOf(findOne(col20, 'gg-mon-host')) + 1,
       'the chip sits directly under their bezel');
-    ok(kids.indexOf(micHost20) === kids.length - 1 &&
-       kids.indexOf(micHost20) > kids.indexOf(findOne(col20, 'gg-receipts')),
-      'and the mic last in the column, below the receipts (the rail moved into the arsenal drawer in batch 7)');
+    ok(kids.indexOf(micHost20) < 0,
+      'and the mic is no longer in that column at all');
     ok(!!findOne(frame20, 'gg-voice-btn'), 'the button is built');
     ok(micHost20.hidden === true, 'and hidden until the feature is live');
     ok(!!hud20.parts.mic && typeof hud20.parts.mic.isRecording === 'function',
@@ -4948,9 +4960,22 @@ const audioMod = await import('../ui/audio.js');
     ok(/\.gg-voice-host\s*\{[^}]*position:\s*relative/.test(bare20),
       'the slot is the containing block...');
     ok(/\.gg-voice\s*\{[^}]*position:\s*absolute/.test(bare20) && /\.gg-voice\s*\{[^}]*right:\s*0/.test(bare20),
-      '...and the strip is anchored to its right edge, so a recording grows LEFTWARDS and nothing on the desk moves');
+      '...and the strip is anchored to an edge of it, so a recording grows sideways and nothing on the desk moves');
     ok(!/position:\s*fixed/.test(bare20) && !/z-index/.test(bare20),
       'nothing here is fixed and nothing claims a z-index — MERCY owns z60 and this tier does not go near it');
+
+    /* THE DRAWER VARIANT (2026-08-05). The slot moved under the emote tile, and
+     * the arsenal is the LEFT gutter — a strip still growing leftwards out of it
+     * would be off the screen inside two words. It flips to left-anchored, and
+     * the button flips back to the outside edge WITHOUT the DOM order changing
+     * (micHud must never re-append a node: that releases pointer capture). */
+    ok(/\.gg-arsenal-panel\s+\.gg-voice\s*\{[^}]*left:\s*0/.test(bare20)
+      && /\.gg-arsenal-panel\s+\.gg-voice\s*\{[^}]*right:\s*auto/.test(bare20),
+      'in the arsenal drawer the strip is anchored LEFT and grows rightwards, away from the screen edge');
+    ok(/\.gg-arsenal-panel\s+\.gg-voice\s*\{[^}]*flex-direction:\s*row-reverse/.test(bare20),
+      '...with the button back on the outside edge by paint order, never by re-appending a captured node');
+    ok(css20.indexOf('.gg-arsenal-panel .gg-voice {') > css20.indexOf('.gg-voice:not(.gg-plate)'),
+      'and written after the idle padding reset it has to beat');
 
     ok(/\.gg-hud-frame\s+\.gg-voice,[\s\S]{0,120}pointer-events:\s*none/.test(bare20),
       'pointer-events: none at 0,2,0 — .gg-plate would otherwise turn the strip back on over the stage');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
@@ -64,6 +64,11 @@ function installDom() {
         toggle: (c, on) => (on ? classes.add(c) : classes.delete(c)),
         contains: (c) => classes.has(c),
       },
+      // ui/screens/lobby.js repaints its eyebrow through `lastChild` — a real
+      // Node property the trimmed stub never needed until the lobby was mounted
+      // here (section 9).
+      get firstChild() { return kids[0] || null; },
+      get lastChild() { return kids[kids.length - 1] || null; },
       appendChild(child) { if (child) { child.parentNode = node; kids.push(child); } return child; },
       append(...c) { c.forEach((x) => node.appendChild(x)); },
       prepend(child) { if (child) { child.parentNode = node; kids.unshift(child); } return child; },
@@ -106,7 +111,7 @@ function installDom() {
   doc.body = makeNode('body');
   doc.activeElement = null;
   const byId = new Map();
-  for (const id of ['gg-modal', 'gg-drawer', 'gg-toasts', 'scr-voice', 'scr-title']) {
+  for (const id of ['gg-modal', 'gg-drawer', 'gg-toasts', 'scr-voice', 'scr-title', 'scr-lobby']) {
     const n = makeNode('div');
     n.id = id;
     n.hidden = true;
@@ -186,6 +191,8 @@ import { VN_MAX_NOTES, VN_MAX_BYTES } from '../ui/voice/voiceService.js';
 import { createPrefs, PREF_DEFAULTS } from '../ui/prefs.js';
 import { mountEmotes, setVoiceProvider, fireVoiceForEmote, EMOTE_ICONS } from '../ui/emotes.js';
 import * as voiceScreen from '../ui/screens/voice.js';
+import * as lobbyScreen from '../ui/screens/lobby.js';
+import { GoonMatchPhase, GoonTransportState } from '../core/contracts.js';
 import { S } from '../ui/strings.js';
 import { SCREEN_IDS } from '../ui/router.js';
 
@@ -912,6 +919,217 @@ function mountSheet(provider) {
   ok(!/gg-grad/.test(voiceBlock), 'and no RULE in the voice block touches .gg-grad');
   ok(/animation-play-state: running/.test(voiceBlock),
     'the recording pulse re-declares `running`, so the effect armor cannot freeze the live-mic tell');
+}
+
+/* =================================== 9. THE LOBBY ROW — the door that was missing
+ *
+ * THE BUG THIS SECTION EXISTS FOR (owner, 2026-08-05): the mic was hunted for
+ * across three setups — iPhone Safari, iPhone Safari incognito, and a
+ * desktop-to-desktop match — and never appeared once. Not one of those was a
+ * wire, layout or CSS failure: `prefs.voiceNotesEnabled` had never been true on
+ * that seat, because until today the ONLY switch was on a title-menu screen a
+ * player has no reason to visit before a duel, and the lobby merely REPORTED a
+ * decision nobody had ever been offered.
+ *
+ * Four properties, and the last two are the ones a well-meaning refactor breaks:
+ *
+ *   1. THE ROW EXISTS AND IT IS A REAL CHECKBOX, on the screen you sign terms on.
+ *   2. THE ACK GATE CAME WITH IT. Inert until `voiceAckSeen`; the ROW opens the
+ *      same S.voice.ack sheet; cancel writes nothing. A second door to the gate,
+ *      never a way around it.
+ *   3. TICKING IT TAKES EFFECT FOR *THIS* MATCH, WITH NO RELOAD. It writes the
+ *      pref AND calls match.setLocalVoiceNotes — because ui/prefs.js caches in
+ *      memory and boot.js only re-seeds the declaration at attachMatch, so a
+ *      pref-only write would land on the NEXT page load. (That is exactly the
+ *      trap the raw-localStorage play-test hit.)
+ *   4. THE PREF IS WRITTEN EVEN WHEN THE ENGINE REFUSES THE DECLARATION. Outside
+ *      Lobby/Consent core/match.js says no; the standing answer must survive it
+ *      or the player's choice is silently discarded.
+ */
+{
+  function fakeLobbyMatch(o = {}) {
+    const subs = { consent: new Set(), opp: new Set(), phase: new Set(), fail: new Set() };
+    const declared = [];
+    const m = {
+      declared,
+      isHost: true,
+      phase: o.phase === undefined ? GoonMatchPhase.Consent : o.phase,
+      localDisplayName: 'you',
+      localAppVersion: '1.0',
+      remoteHello: { display_name: 'them' },
+      opponent: { displayName: 'them', appVersion: '1.0', attentionMode: 1 },
+      remoteMediaPrep: false,
+      consentSheet: { live_duration_sec: 720, toy_cap: 0.7, payload_min_gap_ms: 30000 },
+      localConsentConfirmed: false,
+      remoteConsentConfirmed: false,
+      localMediaTransfer: false,
+      remoteMediaTransfer: false,
+      peerSupportsTransfer: false,
+      localVoiceNotes: !!o.localVoiceNotes,
+      remoteVoiceNotes: !!o.remoteVoiceNotes,
+      peerSupportsVoice: o.peerSupportsVoice !== false,
+      setMediaTransfer() { return true; },
+      /** The engine's real rule: Lobby/Consent only. Everything else refuses. */
+      setLocalVoiceNotes(on) {
+        declared.push(!!on);
+        if (m.phase !== GoonMatchPhase.Lobby && m.phase !== GoonMatchPhase.Consent) return false;
+        m.localVoiceNotes = !!on;
+        for (const fn of Array.from(subs.consent)) fn();
+        return true;
+      },
+      proposeConsent() {}, confirmConsent() {}, withdrawConsent() {},
+      onConsentChanged(fn) { subs.consent.add(fn); return () => subs.consent.delete(fn); },
+      onOpponentStateChanged(fn) { subs.opp.add(fn); return () => subs.opp.delete(fn); },
+      onPhaseChanged(fn) { subs.phase.add(fn); return () => subs.phase.delete(fn); },
+      onLobbyFailed(fn) { subs.fail.add(fn); return () => subs.fail.delete(fn); },
+      _subs: subs,
+    };
+    return m;
+  }
+
+  function mountLobby({ prefs, sheets, match }) {
+    const container = dom.byId.get('scr-lobby');
+    container.replaceChildren();
+    const handle = lobbyScreen.mount(container, {
+      actions: { goTitle() {}, leave() {} },
+      audio: null, prefs, sheets, discord: null, logger: quiet,
+      session: { caps: {} },
+      getMatch: () => match,
+      getTransport: () => ({ state: GoonTransportState.ConnectedP2P, onStateChanged() { return () => {}; } }),
+    });
+    return { container, handle };
+  }
+
+  // ---- 1 + 2: the row, and the gate that came with it ----------------------
+  {
+    const prefs = createPrefs();
+    const sheets = fakeSheets('go');
+    const match = fakeLobbyMatch();
+    const { container, handle } = mountLobby({ prefs, sheets, match });
+
+    const row = findOne(container, 'gg-voice-lobbyrow');
+    ok(!!row, 'THE DOOR: the lobby carries a voice-note row, on the screen the terms are signed on');
+    const input = findTag(row, 'input')[0];
+    ok(!!input && input.getAttribute('type') === 'checkbox', 'and it is a real checkbox, not a sentence');
+    ok(input.disabled === true, 'THE GATE CAME WITH IT: inert until the acknowledgment has been read');
+    ok(row._classes.has('is-disabled'), 'and the row says so');
+    const sub = findOne(container, 'gg-voice-lobbyline');
+    ok(sub && sub.textContent === S.voice.lobbyLocked, 'the sub-line says what to press, from strings');
+
+    // The belt-and-braces path: a host that ignores `disabled` still cannot
+    // switch a microphone on without both paragraphs having been on screen.
+    input.checked = true;
+    input.dispatchEvent({ type: 'change', target: input });
+    ok(input.checked === false, 'a change on the un-acked row is REVERTED on the spot');
+    ok(prefs.get('voiceNotesEnabled') === false, 'and writes nothing before the modal is answered');
+    ok(sheets.calls.length === 1, 'it opens the acknowledgment sheet instead');
+    const ack = sheets.calls[0];
+    ok(ack.headline === S.voice.ack.headline && ack.line === S.voice.ack.line,
+      'the SAME sheet ui/screens/voice.js opens — one gate, two doors');
+    await sleep(5);
+    ok(prefs.get('voiceAckSeen') === true, '"I understand" records the acknowledgment');
+    ok(prefs.get('voiceNotesEnabled') === true, 'and switches on the thing the player reached for');
+    ok(match.localVoiceNotes === true,
+      'NO RELOAD: the declaration is on THIS match, not waiting for the next attachMatch');
+
+    handle.unmount();
+  }
+
+  // ---- cancel changes nothing ----------------------------------------------
+  {
+    const prefs = createPrefs();
+    const sheets = fakeSheets('cancel');
+    const match = fakeLobbyMatch();
+    const { container, handle } = mountLobby({ prefs, sheets, match });
+    click(findOne(container, 'gg-voice-lobbyrow'));
+    await sleep(5);
+    ok(sheets.calls.length === 1, 'clicking the ROW opens the sheet (the disabled input cannot)');
+    ok(prefs.get('voiceAckSeen') === false && prefs.get('voiceNotesEnabled') === false,
+      'and cancelling records nothing at all');
+    ok(match.declared.length === 0, 'nothing was declared to the opponent either');
+    handle.unmount();
+  }
+
+  // ---- 3: an acked player, both halves, both ways ---------------------------
+  {
+    const prefs = createPrefs();
+    prefs.set('voiceAckSeen', true);
+    const match = fakeLobbyMatch();
+    const { container, handle } = mountLobby({ prefs, sheets: fakeSheets(), match });
+
+    const row = findOne(container, 'gg-voice-lobbyrow');
+    const input = findTag(row, 'input')[0];
+    ok(input.disabled === false, 'an acked player gets a live row on mount');
+    ok(input.checked === false, 'unticked, because the pref is off');
+
+    input.checked = true;
+    input.dispatchEvent({ type: 'change', target: input });
+    ok(prefs.get('voiceNotesEnabled') === true, 'ticking writes the standing answer');
+    ok(match.declared[match.declared.length - 1] === true && match.localVoiceNotes === true,
+      'AND declares it to the opponent on this match — that is the no-reload half');
+
+    input.checked = false;
+    input.dispatchEvent({ type: 'change', target: input });
+    ok(prefs.get('voiceNotesEnabled') === false && match.localVoiceNotes === false,
+      'unticking does both again');
+    handle.unmount();
+  }
+
+  // ---- 4: the engine refusing must not lose the player's answer -------------
+  {
+    const prefs = createPrefs();
+    prefs.set('voiceAckSeen', true);
+    const match = fakeLobbyMatch({ phase: GoonMatchPhase.Draft });
+    const { container, handle } = mountLobby({ prefs, sheets: fakeSheets(), match });
+    const input = findTag(findOne(container, 'gg-voice-lobbyrow'), 'input')[0];
+    ok(input.disabled === true, 'past Consent the row is not editable (the engine would refuse anyway)');
+    // ...and if it is driven anyway (a host that ignores `disabled`), the pref
+    // still records the answer for the next attachMatch rather than dropping it.
+    input.checked = true;
+    input.dispatchEvent({ type: 'change', target: input });
+    ok(prefs.get('voiceNotesEnabled') === true,
+      'a refused declaration still leaves the STANDING answer written — boot re-seeds from it');
+    ok(match.localVoiceNotes === false, 'while the engine kept its own rule and declared nothing');
+    handle.unmount();
+  }
+
+  // ---- the four status sentences, unchanged, now as the row's sub-line ------
+  {
+    const cases = [
+      [{ localVoiceNotes: true, remoteVoiceNotes: true }, S.voice.lobbyBoth, 'both on'],
+      [{ localVoiceNotes: true, remoteVoiceNotes: true, peerSupportsVoice: false }, S.voice.lobbyPeerOld, 'their build cannot'],
+      [{ localVoiceNotes: true }, S.voice.lobbyYours, 'only mine'],
+      [{ remoteVoiceNotes: true }, S.voice.lobbyTheirs, 'only theirs'],
+      [{}, S.voice.lobbySub, 'neither: the row explains itself instead of saying nothing'],
+    ];
+    for (const [state, want, why] of cases) {
+      const prefs = createPrefs();
+      prefs.set('voiceAckSeen', true);
+      const match = fakeLobbyMatch(state);
+      const { container, handle } = mountLobby({ prefs, sheets: fakeSheets(), match });
+      const sub = findOne(container, 'gg-voice-lobbyline');
+      ok(sub && sub.textContent === want, 'the sub-line — ' + why, sub && sub.textContent);
+      const value = findOne(findOne(container, 'gg-voice-lobbyrow'), 'gg-row-value');
+      ok(value && value.textContent === (state.remoteVoiceNotes ? S.voice.lobbyTheirsOn : S.voice.lobbyTheirsOff),
+        'and the chip carries THEIR half, like the transfer row above it');
+      handle.unmount();
+    }
+  }
+
+  // ---- source pins ----------------------------------------------------------
+  {
+    const src = stripComments(read('ui/screens/lobby.js'));
+    ok(/prefs\?\.set\?\.\('voiceNotesEnabled'/.test(src) && /match\.setLocalVoiceNotes\(want\)/.test(src),
+      'setVoiceEnabled writes BOTH halves — the local receive gate and the wire declaration');
+    ok(src.indexOf("prefs?.set?.('voiceNotesEnabled'") < src.indexOf('match.setLocalVoiceNotes(want)'),
+      'and the pref FIRST, so a consent frame can never announce a mic the local gate would refuse');
+    ok(/S\.voice\.ack\.headline/.test(src) && /S\.voice\.ack\.lineTwo/.test(src),
+      'the ack copy is S.voice.ack, the same deck the voice screen reads — never a second wording');
+    for (const key of Array.from(src.matchAll(/S\.voice\.([a-zA-Z0-9_]+)/g), (m) => m[1])) {
+      if (key === 'ack') continue;
+      ok(S.voice[key] !== undefined, 'the lobby reads a string that exists: S.voice.' + key);
+    }
+  }
 }
 
 console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
@@ -1053,5 +1053,236 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
   guest.dispose();
 }
 
+// ============================ 10. THE VISIBILITY CHAIN, AND WHY IT SAYS NOTHING
+//
+// THE ROUND THIS SECTION EXISTS FOR (owner, 2026-08-05). The mic was play-tested
+// three times — iPhone Safari, iPhone Safari incognito, a desktop-to-desktop
+// match — and never appeared once. Every gate above is individually pinned and
+// every one of them passed; what was NOT pinned was the whole chain end to end
+// from the boot ordering, and what did not exist at all was any way to find out
+// which gate had said no. Both are fixed here.
+//
+//   10a  whyUnavailable() names the FIRST failing gate, in available()'s own
+//        order — the net/mediaQueue.js whyNoTags() pattern.
+//   10b  two REAL engines, seeded the way boot.js seeds them (at Idle, inside
+//        attachMatch, BEFORE createInvite/join moves the phase), driven through
+//        a real handshake with nothing hand-set. This is the test that would
+//        have caught the Lobby-only setter bug of 2026-08-05 on its own.
+//   10c  the same, through the RELAY-REBUILD ordering (adoptLobby runs BEFORE
+//        the re-attach in net/session.js, so the seed lands in Lobby, not Idle)
+//        and through a rejoin onto a brand new engine pair.
+//   10d  the breadcrumb is wired, at warn, once per match.
+{
+  // ---- 10a. the ladder -----------------------------------------------------
+  {
+    const prefs = fakePrefs({ voiceNotesEnabled: false });
+    const m = fakeMatch({ agreed: false, phaseOpen: false });
+    // The stub answers the three flags the reporter reads individually.
+    m.peerSupportsVoice = false;
+    m.localVoiceNotes = false;
+    m.remoteVoiceNotes = false;
+    const svc = createVoiceService({ match: m, audio: fakeAudio(), prefs, logger: quiet });
+
+    ok(/local pref off/.test(svc.whyUnavailable()), 'gate 1: our own opt-in, named first', svc.whyUnavailable());
+    prefs.set('voiceNotesEnabled', true);
+    ok(/our declaration never rode/.test(svc.whyUnavailable()),
+      'gate 2: the pref is on but the declaration never went out — OUR bug, and it says so',
+      svc.whyUnavailable());
+    m.localVoiceNotes = true;
+    ok(/caps\.voice/.test(svc.whyUnavailable()), 'gate 3: their BUILD, named as a build problem', svc.whyUnavailable());
+    m.peerSupportsVoice = true;
+    ok(/peer never declared/.test(svc.whyUnavailable()), 'gate 4: their side is switched off', svc.whyUnavailable());
+    m.remoteVoiceNotes = true;
+    ok(/phase is closed/.test(svc.whyUnavailable()), 'gate 5: the phase', svc.whyUnavailable());
+    m.setPhaseOpen(true);
+    ok(svc.whyUnavailable({ micSupported: false }).indexOf('getUserMedia') >= 0,
+      'gate 6: a host with no microphone API at all — reported, never a silent dead button');
+    ok(/zen-hidden/.test(svc.whyUnavailable({ hudHidden: true })), 'gate 7: the desk chrome is off');
+    ok(svc.whyUnavailable({ micSupported: true, hudHidden: false }) === '',
+      'and with all seven answered it says NOTHING — a quiet log is the good outcome');
+    // The two host facts are OPTIONAL: this module never touches navigator.
+    ok(svc.whyUnavailable() === '', 'a caller that cannot answer them does not get them reported');
+    svc.dispose();
+    ok(/disposed/.test(svc.whyUnavailable()), 'and a dead service says that rather than blaming the player');
+  }
+
+  // ---- 10b/10c. two real engines, seeded in boot.js's own order -------------
+  /**
+   * A serialize/parse transport pair with the two lobby-entry verbs, so the
+   * WHOLE handshake runs: hello, caps, the host's proposal, the guest's confirm.
+   * Nothing about voice is hand-set anywhere below.
+   */
+  function realPair() {
+    const mk = (getPeer) => {
+      const msgSubs = new Set();
+      const stSubs = new Set();
+      // DISCONNECTED UNTIL _fireState, unlike section 9's pair. adoptLobby()
+      // sends the hello immediately if the transport is ALREADY up, and the
+      // rebuild case below needs the window between "in the lobby" and
+      // "connected" — that window is exactly where boot.js's re-attach seeds.
+      const t = {
+        state: 0,
+        send(msg) {
+          const back = parse(serialize(msg), { logger: quiet });
+          if (back) { const p = getPeer(); if (p) p._deliver(back); }
+          return Promise.resolve(true);
+        },
+        onMessageReceived(fn) { msgSubs.add(fn); return () => msgSubs.delete(fn); },
+        onStateChanged(fn) { stSubs.add(fn); return () => stSubs.delete(fn); },
+        createInviteAsync() { return Promise.resolve('AAAAAA'); },
+        joinAsync() { return Promise.resolve(true); },
+        _deliver(m) { for (const fn of Array.from(msgSubs)) fn(m); },
+        _fireState() { t.state = 3; for (const fn of Array.from(stSubs)) fn(3); },
+      };
+      return t;
+    };
+    const th = mk(() => tg);
+    const tg = mk(() => th);
+    const caps = () => localCaps({ voice: VOICE_CAP_VERSION, transfer: true });
+    return {
+      th,
+      tg,
+      host: new GoonMatchService(th, true, { logger: quiet, tag: 'GG:vh2', caps: caps() }),
+      guest: new GoonMatchService(tg, false, { logger: quiet, tag: 'GG:vg2', caps: caps() }),
+    };
+  }
+
+  /** boot.js attachMatch, reduced to the one line this section is about. */
+  const seedLikeBoot = (m, on) => (on ? m.setLocalVoiceNotes(true) : true);
+
+  {
+    const { host, guest, th, tg } = realPair();
+    // THE ORDER IS THE TEST. attachMatch runs while the engine is still Idle —
+    // net/session.js raises onCurrentMatchChanged from _beginSession, before
+    // createInviteAsync/joinAsync has moved the phase. A setter that refused
+    // Idle (as it did until 2026-08-05) ate this call on BOTH seats and the
+    // declaration never rode a single consent frame.
+    ok(host.phase === GoonMatchPhase.Idle && guest.phase === GoonMatchPhase.Idle, 'both seats start Idle');
+    ok(seedLikeBoot(host, true) === true && seedLikeBoot(guest, true) === true,
+      'the boot seed is ACCEPTED in Idle — a refusal here is the silent killer of the whole feature');
+
+    await host.createInviteAsync();
+    await guest.joinAsync('AAAAAA');
+    th._fireState();
+    tg._fireState();
+    await tick();
+
+    ok(host.peerSupportsVoice === true && guest.peerSupportsVoice === true,
+      'the hello carried caps.voice both ways');
+    ok(host.localVoiceNotes === true && guest.localVoiceNotes === true,
+      'and both declarations survived into the lobby');
+
+    host.confirmConsent();
+    guest.confirmConsent();
+    await tick();
+
+    ok(host.voiceNotesAgreed === true && guest.voiceNotesAgreed === true,
+      'BOTH ENGINES AGREE, from nothing but the two prefs and a real handshake');
+
+    // ...and the service on top of it answers the same, once the phase opens.
+    const svcH = createVoiceService({ match: host, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet });
+    ok(svcH.available() === false && /phase is closed/.test(svcH.whyUnavailable()),
+      'the mic is still off in the draft, and says which gate that is');
+    host._phase = GoonMatchPhase.Live;
+    ok(svcH.available() === true && svcH.whyUnavailable() === '',
+      'and it comes on at Live with nothing left to explain');
+    svcH.dispose();
+    host.dispose();
+    guest.dispose();
+  }
+
+  {
+    // ONE SEAT OPTED IN is not enough, and the OTHER seat's log has to say whose
+    // side that is — this is the owner's desktop-to-desktop case exactly.
+    const { host, guest, th, tg } = realPair();
+    seedLikeBoot(host, true);
+    seedLikeBoot(guest, false);
+    await host.createInviteAsync();
+    await guest.joinAsync('AAAAAA');
+    th._fireState(); tg._fireState();
+    await tick();
+    host.confirmConsent();
+    guest.confirmConsent();
+    await tick();
+    host._phase = GoonMatchPhase.Live;
+    guest._phase = GoonMatchPhase.Live;
+
+    const svcH = createVoiceService({ match: host, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet });
+    const svcG = createVoiceService({ match: guest, audio: fakeAudio(), prefs: fakePrefs({ voiceNotesEnabled: false }), logger: quiet });
+    ok(svcH.available() === false && /peer never declared/.test(svcH.whyUnavailable()),
+      'the opted-in seat is told THEIR side is off', svcH.whyUnavailable());
+    ok(svcG.available() === false && /local pref off/.test(svcG.whyUnavailable()),
+      'and the other seat is told it is its own', svcG.whyUnavailable());
+    svcH.dispose(); svcG.dispose(); host.dispose(); guest.dispose();
+  }
+
+  {
+    // THE RELAY-REBUILD ORDERING. net/session.js `_fallBackToRelay` calls
+    // adoptLobby() and only THEN raises onCurrentMatchChanged, so boot.js's
+    // seed lands with the engine already in Lobby — a different branch of
+    // setLocalVoiceNotes, on a brand new GoonMatchService whose declaration
+    // starts false. The declaration has to survive the rebuild.
+    const { host, guest, th, tg } = realPair();
+    ok(host.adoptLobby() === true && guest.adoptLobby() === true, 'the rebuild adopts the room first');
+    ok(host.phase === GoonMatchPhase.Lobby, '...so the re-attach seeds into Lobby, not Idle');
+    ok(seedLikeBoot(host, true) === true && seedLikeBoot(guest, true) === true,
+      'and the seed is accepted there too');
+    th._fireState(); tg._fireState();
+    await tick();
+    host.confirmConsent();
+    guest.confirmConsent();
+    await tick();
+    ok(host.voiceNotesAgreed === true && guest.voiceNotesAgreed === true,
+      'THE DECLARATION SURVIVES THE REBUILD — both sides agree over the relay-adopted room');
+    host.dispose(); guest.dispose();
+  }
+
+  {
+    // A REJOIN is a whole new pair of engines with a whole new pair of default
+    // (false) declarations. Nothing carries over but the prefs, which is exactly
+    // why boot.js re-seeds on EVERY attach rather than only on the first.
+    for (let round = 0; round < 2; round++) {
+      const { host, guest, th, tg } = realPair();
+      ok(host.localVoiceNotes === false, 'round ' + round + ': a fresh engine declares nothing by itself');
+      seedLikeBoot(host, true);
+      seedLikeBoot(guest, true);
+      await host.createInviteAsync();
+      await guest.joinAsync('AAAAAA');
+      th._fireState(); tg._fireState();
+      await tick();
+      host.confirmConsent();
+      guest.confirmConsent();
+      await tick();
+      ok(host.voiceNotesAgreed === true && guest.voiceNotesAgreed === true,
+        'round ' + round + ': and the re-seed puts it back');
+      host.dispose(); guest.dispose();
+    }
+  }
+
+  // ---- 10d. the breadcrumb is actually wired -------------------------------
+  {
+    const fs10 = await import('node:fs');
+    const url10 = await import('node:url');
+    const readSrc = (rel) => fs10.readFileSync(url10.fileURLToPath(new URL(rel, import.meta.url)), 'utf8').replace(/\r\n/g, '\n');
+    const boot = readSrc('../boot.js');
+    const bare = boot.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+    ok(/function reportMicGate\(\)/.test(bare), 'boot.js carries the mic breadcrumb');
+    ok(/logger\.warn\('voice mic hidden: '/.test(bare),
+      'at WARN — the level that reaches the C# log through bridge.log and the phone ?debug=1 overlay');
+    ok(/reportMicGate\(\);/.test(bare.split('case GoonMatchPhase.Live:')[1] || ''),
+      'fired on the Live arm, where a player would first look for the button');
+    ok(bare.indexOf('mountHudNow();') < bare.indexOf('reportMicGate();'),
+      '...after the HUD, because the answer is partly about the strip that was just not mounted');
+    ok(/micGateSaid = false;/.test(bare) && /if \(micGateSaid\) return;/.test(bare),
+      'and ONCE per match — a rebuild re-arms it, SuddenDeath does not repeat it');
+
+    const svcSrc = readSrc('../ui/voice/voiceService.js');
+    ok(/whyUnavailable,/.test(svcSrc), 'the service exposes the reporter on its handle');
+    ok(!/navigator/.test(svcSrc.replace(/\/\*[\s\S]*?\*\//g, '')),
+      'and STILL touches no navigator — the host facts are passed in, so this module stays node-import-safe');
+  }
+}
+
 console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
 process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -2457,20 +2457,30 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
  * VOICE NOTES — the held mic and the incoming chip (ui/voice/micHud.js).
  *
  * PLACEMENT IS FLOW, NOT COORDINATES, and that is the whole safety argument.
- * Both slots are ordinary children of `.gg-rightcol` (ui/hud.js builds them
- * around the receipts), so the browser keeps them inside the monitor column at
- * every viewport. They cannot reach MERCY's bottom-centre gutter, the closeness
- * dial, either rail, the announcer ribbon or the bezel itself, because none of
- * them is positioned against the frame — unlike the emote sheet and the
- * portrait rails, there is no band here to measure and nothing to re-measure
- * when the phone pass moves one. Sudden death takes them away with the rest of
- * the body (.gg-hud-frame.is-sd .gg-hud-body), for free.
+ * Both slots are ordinary flow children — the MIC is the last child of
+ * `.gg-arsenal-panel`, directly under the two rails whose last right-hand tile
+ * is the emote (2026-08-05: the owner looked for it "right under the Emote
+ * icon" three play-tests running, and holding a mic is a thing you DO, so it
+ * belongs with the other things you do); the CHIP stays in `.gg-rightcol` under
+ * their bezel, because it is about THEIR voice. Neither can reach MERCY's
+ * bottom-centre gutter, the closeness dial, the announcer ribbon or the bezel
+ * itself, because neither is positioned against the frame — unlike the emote
+ * sheet and the portrait rails, there is no band here to measure and nothing to
+ * re-measure when the phone pass moves one. Sudden death takes them away with
+ * the rest of the body (.gg-hud-frame.is-sd .gg-hud-body), for free.
  *
- * THE STRIP GROWS INSIDE ITS OWN SLOT. `.gg-voice-host` is a fixed 48px row and
- * the strip is absolutely placed against it, anchored right — so a recording
- * expands LEFTWARDS over the (pointer-transparent) well and NOTHING on the desk
- * moves while a button is being held. A layout shift under a live pointer
- * capture is how a hold gets dropped half way through a sentence.
+ * THE STRIP GROWS INSIDE ITS OWN SLOT, AND IT GROWS AWAY FROM ITS EDGE OF THE
+ * SCREEN. `.gg-voice-host` is a fixed 48px row and the strip is absolutely
+ * placed against it, so a recording expands over the (pointer-transparent) well
+ * and NOTHING on the desk moves while a button is being held — a layout shift
+ * under a live pointer capture is how a hold gets dropped half way through a
+ * sentence. The DIRECTION follows the slot's home: the arsenal drawer is on the
+ * LEFT of the desk, so the strip is anchored left and grows RIGHTWARDS, with
+ * the button first in the reading order via `row-reverse` (the DOM order is
+ * meta-then-button and micHud must never re-append a node — see its header — so
+ * this is a paint-order flip, not a re-parent). The right-anchored variant is
+ * kept below for `.gg-rightcol`, which is where the chip lives and where a
+ * future slot would land.
  *
  * POINTER-EVENTS — THE 0,2,0 TRAP, for the third time in this file. `.gg-hud-
  * frame .gg-plate { pointer-events: auto }` near the top is specificity 0,2,0,
@@ -2519,6 +2529,29 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
 }
 /* idle: no plate, no box — just the round button, exactly like the gear */
 .gg-voice:not(.gg-plate) { background: none; border: 0; backdrop-filter: none; padding-left: 0; }
+
+/* ---- THE ARSENAL-DRAWER VARIANT: anchored LEFT, growing RIGHT --------------
+ * Same nodes, same classes, same machine — only the edge it is pinned to and
+ * the direction the strip unfolds. The drawer sits on the left gutter, so a
+ * strip that grew leftwards out of it would run off the screen inside two
+ * words. `row-reverse` puts the button back on the outside edge (nearest the
+ * finger, where a 48px target belongs) without touching the DOM order micHud
+ * relies on. The host is width:100% of a two-tile-wide panel, so the strip is
+ * allowed to overhang it — the panel is pointer-transparent (sidebar rule 1)
+ * and only `.gg-voice-btn` re-opts in, so nothing under the overhang is ever
+ * swallowed. */
+.gg-arsenal-panel > .gg-voice-host { margin-top: 0.15rem; }
+.gg-arsenal-panel .gg-voice {
+  right: auto;
+  left: 0;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  padding: 0 0.85rem 0 0;
+}
+.gg-arsenal-panel .gg-voice:not(.gg-plate) { padding-right: 0; }
+/* …and the hint, which is a flow child of the host rather than of the strip:
+   it reads from the same edge the strip now grows from. */
+.gg-arsenal-panel .gg-voice-hint { right: auto; left: 0; text-align: left; }
 
 /* THE 0,2,0 OPT-OUT (see the header) + the one re-opt-in. */
 .gg-hud-frame .gg-voice,

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -572,6 +572,36 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   const leftRail = add(railBox, el('div', 'gg-rail gg-rail--left'));
   const rightRail = add(railBox, el('div', 'gg-rail gg-rail--right'));
 
+  /* ---- THE MIC SLOT — under the emote tile, which is where it was looked for
+   *
+   * IT LIVED IN THE OPPONENT'S COLUMN UNTIL 2026-08-05, under their receipts.
+   * The reasoning was placement safety (a flow child of a column cannot land on
+   * MERCY's gutter or the dial), and it was correct and beside the point: the
+   * owner play-tested this three times across three devices and looked for the
+   * mic "right under the Emote icon" every time, because holding a mic is a
+   * thing you DO — it belongs with the other things you do, not with the readout
+   * of what is being done to you. The emote tile is the last item on the right
+   * rail (ui/arsenal.js ARSENAL_ITEMS), so a full-width row immediately after
+   * the rails is literally underneath it.
+   *
+   * IT IS STILL FLOW, NOT COORDINATES. Last child of `.gg-arsenal-panel`, so the
+   * browser keeps it inside the drawer at every viewport, including the
+   * short-viewport pass where the rails turn ninety degrees. Nothing here is
+   * positioned against the frame and there is no keep-out band to miss.
+   *
+   * WHAT IT COSTS, honestly: the drawer is SHUT by default on a phone
+   * (resolveArsenalOpen), so the mic is behind the handle there — exactly like
+   * every other control a player throws. That is the trade, and it is the same
+   * one the eight tiles already make.
+   *
+   * WHAT IT DOES NOT COST: the strip still cannot eat the stage. The panel is
+   * pointer-events:none at 0,2,0 (rule 1 up in the sidebar block) and ui/hud.css
+   * re-opts ONLY `.gg-voice-btn` back in, later in the file, at the same weight.
+   *
+   * The CHIP stays in their column, under their bezel — it is about THEIR voice
+   * and it belongs as close to their face as this file can put it. */
+  const voiceHost = add(sidePanel, el('div', 'gg-voice-host'));
+
   /* ---- THE HANDLE — the one node that never hides -------------------------
    * Last in the DOM so it sits on the panel's INNER edge (the side facing the
    * field) in both states, which is where a thumb reaches for it and where it
@@ -589,30 +619,28 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   const rightCol = add(body, el('div', 'gg-rightcol'));
   const oppAvaBox = add(rightCol, el('div', 'gg-ava-minibox gg-ava-minibox--opp'));
   const monHost = add(rightCol, el('div', 'gg-mon-host'));
-  /* THEIR VOICE, IN THEIR COLUMN (ui/voice/micHud.js).
+  /* THEIR VOICE, IN THEIR COLUMN (ui/voice/micHud.js) — the CHIP half.
    *
-   * Two slots, both FLOW children of the monitor column, and that is the whole
-   * of the placement decision: the browser lays them out, so neither can land on
-   * MERCY's bottom-centre gutter, the closeness dial, either rail, the announcer
-   * ribbon or the monitor itself at ANY viewport — including the portrait pass,
-   * where this column moves to the top of the body (order: -1). Nothing here is
+   * A FLOW child of the monitor column, and that is the whole of the placement
+   * decision: the browser lays it out, so it cannot land on MERCY's
+   * bottom-centre gutter, the closeness dial, either rail, the announcer ribbon
+   * or the monitor itself at ANY viewport — including the portrait pass, where
+   * this column moves to the top of the body (order: -1). Nothing here is
    * absolutely placed against the frame, so there is no band to keep clear of
    * and nothing to re-measure when the phone rules move one.
    *
-   *   chip slot  directly under the bezel: the speaking indicator for a note
-   *              THEY sent, as close to their face as this file can put it
-   *              without reaching into ui/opponent.js.
-   *   mic slot   under the receipts, above their rail: the button you hold.
-   *              Its recording strip grows LEFTWARDS out of the button, inside
-   *              the slot, so holding it never moves anything on the desk.
+   * Directly under the bezel: the speaking indicator for a note THEY sent, as
+   * close to their face as this file can put it without reaching into
+   * ui/opponent.js. The MIC that sends yours moved to the arsenal drawer, under
+   * the emote tile (see THE MIC SLOT above) — the two halves of this feature
+   * point in opposite directions and now sit accordingly.
    *
-   * Both collapse to nothing when the feature is not live (hidden host, not an
+   * It collapses to nothing when the feature is not live (hidden host, not an
    * emptied one — see micHud's header on why it must not rebuild its nodes). */
   const voiceChipHost = add(rightCol, el('div', 'gg-voice-chiphost'));
   const receiptsHost = add(rightCol, el('div', 'gg-receipts'));
   const coolHost = add(rightCol, el('div', 'gg-cool'));
   if (coolHost) coolHost.hidden = true;
-  const voiceHost = add(rightCol, el('div', 'gg-voice-host'));
 
   /* ---- THE COLLAPSE BIT --------------------------------------------------
    * One class on one node; every hide, every slide and every layout consequence

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -1454,8 +1454,16 @@ html[data-gg-motion="reduced"] .gg-vs-splash * { transition: none !important; }
    quieter, because it is the consequence rather than the description. */
 .gg-voice-ack-2 { margin-top: 0.5rem; opacity: 0.92; }
 
-/* The lobby's read-only status line. */
-.gg-voice-lobbyline { text-align: center; }
+/* The lobby's voice-note ROW and the status line under it (2026-08-05 — it used
+   to be a lone centred sentence with no control to belong to, which is why the
+   centring is gone). The row is a plain .gg-row--check; the only extra is the
+   cursor, and it is there because the ROW is clickable while the acknowledgment
+   is unread — see ui/screens/lobby.js on why a disabled input has to have
+   something that answers a click. `is-on` is the one state worth a colour:
+   "both of you are switched on" is the answer the row exists to give. */
+.gg-voice-lobbyrow { cursor: pointer; }
+.gg-voice-lobbyrow.is-disabled { opacity: 0.75; }
+.gg-voice-lobbyrow.is-disabled .gg-row-label { color: var(--gg-text-2); }
 .gg-voice-lobbyline.is-on { color: var(--gg-violet); }
 
 /* ---------------------------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -127,22 +127,45 @@ export function mount(container, ctx) {
   const gapRow = mkSlider(S.lobby.gap, { min: GAP_MIN_SEC, max: GAP_MAX_SEC, step: 5 });
   const xferRow = mkCheck(S.lobby.transfer);
 
-  /* THE VOICE-NOTE LINE — READ ONLY, and deliberately not a row.
+  /* THE VOICE-NOTE ROW (2026-08-05) — a real toggle now, not a status line.
    *
-   * There is no toggle for it here and there must not be: turning voice notes on
-   * is an acknowledgment (your real voice goes to them, theirs can come back),
-   * and that gate lives on one screen — ui/screens/voice.js, off the title menu.
-   * A second entry point without the modal would be a way to switch a mic on
-   * without ever reading what it does.
+   * IT WAS READ-ONLY UNTIL TODAY, and that was the whole bug. The reasoning was
+   * sound and the consequence was not: turning voice notes on is an
+   * acknowledgment (your real voice goes to them, theirs can come back), so the
+   * switch was put on ONE screen — ui/screens/voice.js, off the title menu —
+   * and the lobby only reported what somebody had already decided somewhere
+   * else. Nobody ever decided it. The owner play-tested the mic three times
+   * across three setups and never saw it once, because their own seat's
+   * `voiceNotesEnabled` had never been true and nothing on the road into a duel
+   * asked. A consent gate that nobody can find is not protecting anyone.
    *
-   * So this is a STATUS SENTENCE about a decision made elsewhere: whose side has
-   * it on, or that their build is too old to speak the family at all. It renders
-   * nothing at all when neither side has opted in, because a line that says
-   * "off" on a screen full of terms reads as a term. */
-  const voiceLine = el('p', { class: 'gg-row-sub gg-voice-lobbyline', text: '', hidden: true });
+   * So the toggle is here as well, and the gate came WITH it: the checkbox is
+   * `disabled` until `voiceAckSeen`, and a click on the ROW (which is not
+   * disabled) opens the very same acknowledgment sheet ui/screens/voice.js
+   * opens, from the same S.voice.ack copy. There is still exactly ONE way to
+   * switch this on for the first time and it still goes through both
+   * paragraphs. This is a second door to the same gate, not a way around it.
+   *
+   * IT WRITES BOTH HALVES, AND THAT ORDER MATTERS FOR *THIS* MATCH:
+   *   prefs.voiceNotesEnabled   the standing answer, and the one the RECEIVE
+   *                             path reads (ui/voice/voiceService.js drops an
+   *                             inbound note unread without it) — set first, so
+   *                             a consent frame can never announce a mic the
+   *                             local gate would still refuse.
+   *   match.setLocalVoiceNotes  the declaration the OPPONENT gets told, on the
+   *                             consent frame, immediately. Without this call a
+   *                             tick here would only take effect on the NEXT
+   *                             attachMatch, i.e. after a page reload — which
+   *                             is exactly the trap the raw-localStorage
+   *                             play-test hit (ui/prefs.js caches in memory).
+   * The engine clears both signatures and re-sends the sheet, so the lamp
+   * ripple this screen already paints is the whole visible half. */
+  const voiceRow = mkCheck(S.voice.toggle);
+  voiceRow.row.classList.add('gg-voice-lobbyrow');
+  voiceRow.sub.classList.add('gg-voice-lobbyline');
 
   const sheetBox = el('div', { class: 'gg-consent' }, [
-    durRow.row, toyRow.row, gapRow.row, xferRow.row, xferRow.sub, voiceLine,
+    durRow.row, toyRow.row, gapRow.row, xferRow.row, xferRow.sub, voiceRow.row, voiceRow.sub,
   ]);
 
   /* ---------------------------------------------------------- confirm UI */
@@ -322,21 +345,108 @@ export function mount(container, ctx) {
   }
 
   /**
-   * The voice-note status line. Four states, in the order that answers the
-   * question a player is actually asking ("can they hear me?"):
-   * both on, the peer's build cannot, only mine, only theirs. Silent otherwise.
+   * The voice-note row. The CHECKBOX is our own opt-in; the chip is theirs; the
+   * sub-line is the old four-state status sentence, in the order that answers
+   * the question a player is actually asking ("can they hear me?"): both on,
+   * the peer's build cannot, only mine, only theirs.
+   *
+   * UNLIKE THE TRANSFER ROW ABOVE, IT IS NEVER DISABLED FOR A PEER REASON. The
+   * peer's build being too old is said in the sub-line and nowhere else: this
+   * switch is also the RECEIVE gate and the standing answer for every future
+   * duel, so greying it out on account of the person you happen to be facing
+   * would hide a decision that is not about them. The only thing that disables
+   * it is the acknowledgment (below) and the phase.
    */
   function paintVoice() {
     const mine = !!match.localVoiceNotes;
     const theirs = !!match.remoteVoiceNotes;
-    let text = '';
-    if (mine && theirs && match.peerSupportsVoice) text = S.voice.lobbyBoth;
-    else if ((mine || theirs) && !match.peerSupportsVoice) text = S.voice.lobbyPeerOld;
-    else if (mine) text = S.voice.lobbyYours;
-    else if (theirs) text = S.voice.lobbyTheirs;
-    voiceLine.textContent = text;
-    voiceLine.hidden = !text;
-    voiceLine.classList.toggle('is-on', text === S.voice.lobbyBoth);
+    const acked = !!(prefs && prefs.get && prefs.get('voiceAckSeen'));
+    const editable = match.phase === GoonMatchPhase.Consent || match.phase === GoonMatchPhase.Lobby;
+
+    let status = '';
+    if (mine && theirs && match.peerSupportsVoice) status = S.voice.lobbyBoth;
+    else if ((mine || theirs) && !match.peerSupportsVoice) status = S.voice.lobbyPeerOld;
+    else if (mine) status = S.voice.lobbyYours;
+    else if (theirs) status = S.voice.lobbyTheirs;
+
+    if (document.activeElement !== voiceRow.input) voiceRow.input.checked = mine;
+    voiceRow.input.disabled = !acked || !editable;
+    voiceRow.row.classList.toggle('is-disabled', !acked);
+    // The status sentence when there is one, the explanation when there is not,
+    // and "read this first" ahead of both — a locked switch always says why.
+    voiceRow.sub.textContent = !acked ? S.voice.lobbyLocked : (status || S.voice.lobbySub);
+    voiceRow.sub.classList.toggle('is-on', status === S.voice.lobbyBoth);
+    voiceRow.value.textContent = theirs ? S.voice.lobbyTheirsOn : S.voice.lobbyTheirsOff;
+  }
+
+  /**
+   * The acknowledgment sheet, byte for byte the one ui/screens/voice.js opens —
+   * same icon, same two paragraphs, same two actions. It is duplicated as a
+   * CALL rather than shared as a module because ui/sheets.js takes one `line`
+   * and this consent needs two, and the injection that adds the second one is
+   * six lines of DOM either screen can do for itself; what must never diverge
+   * is the COPY, and the copy is S.voice.ack in both.
+   *
+   * Cancel changes nothing at all. "I understand" is the switch: the player got
+   * here by reaching for it, and making them press the same thing twice for one
+   * decision is how a safety gate turns into an annoyance people learn to click
+   * through.
+   */
+  async function openVoiceAck() {
+    if (!sheets || typeof sheets.open !== 'function') return;
+    const promise = sheets.open({
+      icon: S.voice.ack.icon,
+      headline: S.voice.ack.headline,
+      line: S.voice.ack.line,
+      actions: [
+        { id: 'cancel', label: S.voice.ack.cancel, variant: 'ghost' },
+        { id: 'go', label: S.voice.ack.go, variant: 'primary' },
+      ],
+    });
+    injectAckSecondLine();
+    let answer = null;
+    try { answer = await promise; } catch (e) { ledger._err('voice ack', e); }
+    if (ledger.isDisposed) return;
+    if (answer !== 'go') { paintVoice(); return; }
+    prefs?.set?.('voiceAckSeen', true);
+    setVoiceEnabled(true);
+  }
+
+  /** The second paragraph, appended to the sheet that has just been built. See
+   *  ui/screens/voice.js injectSecondLine — same seam, same merge fallback,
+   *  because the line that says they may HEAR you is never the one that goes
+   *  missing. */
+  function injectAckSecondLine() {
+    let line = null;
+    try {
+      const modal = typeof document !== 'undefined' && document ? document.getElementById('gg-modal') : null;
+      line = modal && modal.querySelector ? modal.querySelector('.gg-sheet-line') : null;
+      if (!line) return;
+      const p = el('p', { class: 'gg-sheet-line gg-voice-ack-2', text: S.voice.ack.lineTwo });
+      if (line.parentNode && typeof line.parentNode.insertBefore === 'function') {
+        line.parentNode.insertBefore(p, line.nextSibling);
+        return;
+      }
+    } catch (e) { ledger._err('voice ack line', e); }
+    try { if (line) line.textContent = S.voice.ack.line + ' ' + S.voice.ack.lineTwo; }
+    catch (_e) { /* no DOM at all */ }
+  }
+
+  /**
+   * Both halves, in the one order that is safe (see the row's block above):
+   * the local gate first, then the declaration the opponent reads.
+   *
+   * The engine REFUSES the declaration outside Lobby/Consent, which is the
+   * whole reason the pref is written unconditionally — a refusal there must
+   * still leave the standing answer recorded for the next attachMatch rather
+   * than silently discarding what the player just asked for.
+   */
+  function setVoiceEnabled(on) {
+    const want = !!on;
+    prefs?.set?.('voiceNotesEnabled', want);
+    try { match.setLocalVoiceNotes(want); } catch (e) { ledger._err('setLocalVoiceNotes', e); }
+    paintVoice();
+    paintConfirm();
   }
 
   function paintAll() { paintIdentity(); paintConnection(); paintSheet(); paintConfirm(); paintTransfer(); paintVoice(); }
@@ -381,6 +491,27 @@ export function mount(container, ctx) {
     prefs?.set?.('mediaTransferEnabled', !!xferRow.input.checked);
     paintTransfer();
     paintConfirm();
+  });
+
+  /* THE VOICE ROW'S TWO AFFORDANCES, for the one reason ui/screens/voice.js
+   * gives: "a disabled control that does nothing when you click it is the
+   * single most reported bug in this codebase's history", so the ROW answers
+   * when the INPUT cannot. */
+  ledger.listen(voiceRow.input, 'change', () => {
+    if (!(prefs && prefs.get && prefs.get('voiceAckSeen'))) {
+      // Belt and braces — a disabled input should never fire this, but a host
+      // that ignores `disabled` must not be able to switch a microphone on
+      // without the two paragraphs having been on screen.
+      voiceRow.input.checked = false;
+      void openVoiceAck();
+      return;
+    }
+    setVoiceEnabled(!!voiceRow.input.checked);
+  });
+  ledger.listen(voiceRow.row, 'click', (e) => {
+    if (prefs && prefs.get && prefs.get('voiceAckSeen')) return;   // the input handles itself
+    if (e && e.target === voiceRow.input) return;                  // a disabled input's click
+    void openVoiceAck();
   });
 
   /**
@@ -437,6 +568,16 @@ export function mount(container, ctx) {
     ledger.sub(match.onMediaPrepChanged(() => paintIdentity()));
   }
   ledger.sub(match.onPhaseChanged(() => { paintAll(); }));
+  /* The pref is the truth and this screen is one of its readers — ui/screens/
+   * voice.js and the options drawer's Reset can both move it out from under us,
+   * and a checkbox that disagrees with the thing it controls is worse than no
+   * checkbox. (voiceAckSeen too: reading the modal anywhere unlocks it here.) */
+  if (prefs && typeof prefs.subscribe === 'function') {
+    ledger.sub(prefs.subscribe((key) => {
+      if (ledger.isDisposed) return;
+      if (key === 'voiceNotesEnabled' || key === 'voiceAckSeen') paintVoice();
+    }));
+  }
   ledger.sub(match.onLobbyFailed((reason) => {
     sheets?.open?.({
       icon: S.sheets.lobbyFailed.icon,

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -527,11 +527,26 @@ export const S = Object.freeze({
     /** ...and the emote-attached variant, anchored on the bubble instead. */
     incomingWithEmote: 'they said something',
 
-    /* --- the lobby line (read-only; the toggle lives in the screen only) --- */
+    /* --- the lobby ROW (2026-08-05) ---------------------------------------
+     * This used to be a read-only sentence, and the ONLY switch lived on a
+     * title-menu screen a player has no reason to visit before a duel. The
+     * owner then failed to find the mic three times running with the feature
+     * working exactly as written — because their own side had never been
+     * switched on, and nothing on the road into a match ever offered to. The
+     * toggle is here too now, behind the SAME acknowledgment gate (rule 1: the
+     * sentence that mentions HEARING them is never skippable), and the old
+     * status sentence stays as the sub-line under it. */
     lobbyBoth: 'voice notes on for this match',
     lobbyYours: 'you have voice notes on — they have not',
     lobbyTheirs: 'they have voice notes on — you have not',
     lobbyPeerOld: 'their app is too old for voice notes',
+    /** The row's own explanation, when there is no status to report yet. */
+    lobbySub: 'hold the mic under your items to send ten seconds of your voice. you both have to switch it on.',
+    /** Before the acknowledgment has been read. Says what to press, not "no". */
+    lobbyLocked: 'tap this row to read what it does first.',
+    /** The right-hand chip, exactly like the transfer row's pair. */
+    lobbyTheirsOn: 'they opted in',
+    lobbyTheirsOff: 'they have not',
 
     /* --- the refusals ----------------------------------------------------- */
     /** getUserMedia said no. NOT an error tone: it is a perfectly good answer. */

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -1,14 +1,23 @@
 /* ============================================================================
  * ui/voice/micHud.js — the held mic, and the chip that says they answered.
  *
- * Two small things, mounted from ui/hud.js into two slots of the opponent
- * column, because both of them are about the person on the other side:
+ * Two small things, mounted from ui/hud.js into two slots that point in opposite
+ * directions, because one of them is a CONTROL and the other is a READOUT:
  *
- *   THE MIC        a 48px button under their monitor. Press and hold; the strip
- *                  grows LEFTWARDS out of the button with a pulsing dot, the
- *                  elapsed seconds and "slide left to cancel". Release sends.
- *   THE CHIP       a speaking indicator directly under their bezel while one of
- *                  THEIR notes is playing, so a voice never arrives from nowhere.
+ *   THE MIC        a 48px button in the arsenal drawer, directly under the tiles
+ *                  — the emote is the last one on the right rail, and this is
+ *                  the thing a player reaches for next. (It sat under the
+ *                  opponent's monitor until 2026-08-05, where three play-tests
+ *                  running never found it: the owner looked "right under the
+ *                  Emote icon" every time, because holding a mic is a thing you
+ *                  DO.) Press and hold; the strip grows out of the button with a
+ *                  pulsing dot, the elapsed seconds and "slide left to cancel".
+ *                  Release sends. Which WAY it grows is a stylesheet fact — the
+ *                  drawer is the left gutter, so ui/hud.css anchors the strip
+ *                  left there and flips the paint order; nothing in this file
+ *                  knows or cares.
+ *   THE CHIP       a speaking indicator directly under THEIR bezel while one of
+ *                  their notes is playing, so a voice never arrives from nowhere.
  *
  * ────────────────────────────────────────────────────────────── the gesture ──
  *
@@ -188,7 +197,7 @@ export function sendReasonLine(reason, waitSec = 1) {
 
 /**
  * @param {object}   o
- * @param {Element}  o.host        the mic's slot in the opponent column (.gg-voice-host)
+ * @param {Element}  o.host        the mic's slot in the arsenal drawer (.gg-voice-host)
  * @param {Element}  [o.chipHost]  the incoming chip's slot, under their bezel
  * @param {object}   [o.voice]     ui/voice/voiceService.js handle. null = no mic, ever
  * @param {object}   [o.audio]     {sfx(id)}

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
@@ -287,6 +287,57 @@ export function createVoiceService({
     try { return !!match.voiceNotesAgreed && !!match.voicePhaseOpen; } catch (_e) { return false; }
   }
 
+  /**
+   * WHY is there no mic on the desk? One short phrase naming the FIRST failing
+   * gate, in the SAME ORDER available() applies them — the net/mediaQueue.js
+   * `whyNoTags()` pattern, and it exists for exactly the same reason that one
+   * does.
+   *
+   * THE BUG THIS EXISTS FOR (owner, 2026-08-05): the mic was play-tested three
+   * times across three setups — iPhone Safari, iPhone Safari incognito, and a
+   * desktop pair — and never once appeared. Every one of those was the FIRST
+   * gate below (their own opt-in had never been switched on, because until
+   * today the only switch was on a title-menu screen nobody visits before a
+   * duel), and the page said nothing at all about it in any of the three. Five
+   * ANDed booleans with no readout is a feature that can only be debugged by
+   * archaeology.
+   *
+   * `''` MEANS THE MIC IS LIVE. Everything else is a sentence to put in a warn.
+   * `micSupported` is passed in rather than sniffed here because this module is
+   * node-import-safe by charter and never touches `navigator`; a caller that
+   * does not know simply omits it and that gate is not reported.
+   *
+   * @param {object} [o]
+   * @param {boolean} [o.micSupported]  ui/voice/recorder.js `supported()`
+   * @param {boolean} [o.hudHidden]     the desk's zen bit (ui/hud.js)
+   * @returns {string} '' when live, else the first failing gate
+   */
+  function whyUnavailable(o = {}) {
+    if (disposed) return 'the voice service is disposed';
+    if (!match) return 'no match';
+    if (!localEnabled()) return 'local pref off (voice notes are not switched on for this seat)';
+    let peerBuild = false;
+    let mine = false;
+    let theirs = false;
+    let phase = false;
+    try {
+      peerBuild = !!match.peerSupportsVoice;
+      mine = !!match.localVoiceNotes;
+      theirs = !!match.remoteVoiceNotes;
+      phase = !!match.voicePhaseOpen;
+    } catch (_e) { return 'the match refused to answer'; }
+    // Our own declaration BEFORE theirs: with the pref on and this false, the
+    // seed at attachMatch was refused (a phase window) and that is our bug, not
+    // the peer's — a different sentence entirely from "they said no".
+    if (!mine) return 'our declaration never rode a consent frame (the seed was refused)';
+    if (!peerBuild) return 'the peer\'s build does not advertise caps.voice (stale page?)';
+    if (!theirs) return 'the peer never declared voice_notes (their side is switched off)';
+    if (!phase) return 'the phase is closed to voice (not Countdown/Live/SuddenDeath)';
+    if (o.micSupported === false) return 'no getUserMedia / MediaRecorder on this host';
+    if (o.hudHidden === true) return 'zen-hidden (the desk chrome is toggled off)';
+    return '';
+  }
+
   function emitState() {
     const next = available();
     if (next === lastAvailable) return;
@@ -587,6 +638,8 @@ export function createVoiceService({
 
   return {
     available,
+    /** '' when the mic is live, else the FIRST failing gate. See the block above. */
+    whyUnavailable,
     sendBlob,
     sendNote,
 


### PR DESCRIPTION
## The complaint

Owner, r11 play-test, 2026-08-05: they cannot see the mic button to record a live voice note during a match, and expect it "right under the Emote icon". Three setups, three misses — iPhone Safari, iPhone Safari incognito, and a desktop-to-desktop match. The feature shipped in #117 and has never once been seen working.

Nothing on the wire was broken. The full chain was traced end to end and proven with node-run tests.

## Root causes

**1. There was no way to opt in anywhere near a duel.** `ui/screens/lobby.js` carried a READ-ONLY status sentence ("you have voice notes on — they have not"), and the *only* switch lived on the title-menu **Send voice notes** screen behind an acknowledgment modal. Voice needs BOTH seats to declare it, so the owner's seat failed gate one — `prefs.voiceNotesEnabled` — in all three sightings. A consent gate nobody can find is not protecting anyone.

**2. The page never said why.** Five ANDed booleans (local pref, our declaration, their build's `caps.voice`, their declaration, the phase) with no readout anywhere. A hidden mic is the *correct* rendering of all five, so every round of this was diagnosed by archaeology.

**3. Placement.** The slot was a flow child of the opponent's monitor column, under the receipts. The owner looked under the emote tile every time — holding a mic is a thing you **do**, so it belongs with the other things you do.

## What changed

- **`ui/screens/lobby.js`** — a real voice-notes checkbox row, behind the **same** `S.voice.ack` sheet the library screen opens (one gate, two doors; cancel writes nothing). It writes both halves *in order*: `prefs.voiceNotesEnabled` first (the receive gate, which drops an inbound note unread without it), then `match.setLocalVoiceNotes` — so a tick takes effect for **that** match with no page reload. The pref is written even when the engine refuses the declaration outside Lobby/Consent, so a refusal never discards the player's answer. The old four-state status sentence survives as the row's sub-line; their half is the right-hand chip, like the transfer row above it.
- **`ui/voice/voiceService.js`** — `whyUnavailable({micSupported, hudHidden})`, the `net/mediaQueue.js` `whyNoTags()` pattern: `''` when live, else one phrase naming the FIRST failing gate in `available()`'s own order. Still touches no `navigator` — the two host facts are passed in, so the module stays node-import-safe.
- **`boot.js`** — `reportMicGate()`, one `logger.warn('voice mic hidden: …')` on the Live arm, after the HUD mounts, **once per match** (`micGateSaid`, cleared in `attachMatch`). Warn is the level that reaches the C# log through `bridge.log` and the phone's `?debug=1` overlay.
- **`ui/hud.js` + `ui/hud.css`** — the mic slot moved to the last child of `.gg-arsenal-panel`, immediately under the two rails whose last right-hand tile is the emote. Still flow, no coordinates, no keep-out band to miss. The drawer is the left gutter, so the strip is anchored **left** there and grows rightwards, with the button flipped back to the outside edge by `row-reverse` — a paint-order flip, never a re-append (which would release the live pointer capture). The panel is `pointer-events:none` at 0,2,0 and only `.gg-voice-btn` re-opts in, so the overhang can never eat a click meant for the stage. The incoming chip stays under their bezel: it is a readout about *their* voice, not a control.
- **`ui/strings.js` / `ui/screens.css`** — the row's copy and its styling.

## Verified against the code, not assumed

- The wire itself is sound: `caps.voice` is advertised, `voice_notes` rides every consent frame either side authors, `_seedDeclaration` accepts the Idle seed (the 2026-08-05 fix), the declaration survives the relay-fallback match REBUILD and a seat rejoin. All four are now pinned by two real `GoonMatchService` instances driven through a real handshake with nothing hand-set.
- The `.gg-voice` / `.gg-voicelib` collision has **not** regressed — `selftest-voice-ui` still proves no `gg-voice*` class is styled by both stylesheets.

## Tests

- `selftest-voice.js` §10: the gate ladder (seven rungs, in order), the boot-order handshake, the relay-rebuild ordering (`adoptLobby` before the re-attach), a rejoin, and source pins on the breadcrumb. **Deleting the Idle seed from `core/match.js` fails 8 of them** — that is the regression that would otherwise only ever be found by play-test.
- `selftest-voice-ui.js` §9: the lobby row mounted against the DOM stub — the ack gate, the belt-and-braces revert, cancel, both halves written in the right order, the refused-declaration case, and the five sub-line states.
- `selftest-hud.js`: placement pins follow the slot.
- Whole suite green; only `selftest-avafx.js`'s 12 pre-existing failures remain.

## Needs a live play-test

1. Two seats, both tick the new **Voice notes** row in the lobby (first tick opens the ack sheet). The mic should appear in the arsenal drawer under the emote tile the moment the countdown starts — with no reload on either side.
2. Hold it: strip grows rightwards out of the button, slide left to cancel, release to send.
3. **Known trade-off:** the arsenal drawer is SHUT by default on a phone, so the mic is behind the handle there — like every other control you throw. If the owner wants it visible with the drawer shut, that is a follow-up (the handle is the only node that never hides).
4. With one seat opted out, the log should now carry exactly one `voice mic hidden: the peer never declared voice_notes (their side is switched off)` on the opted-in seat and `local pref off` on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
