### PR TITLE
chore(goon): r12 build stamp

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -40,7 +40,7 @@ export const PROTOCOL = 1;
  * the title screen prints it under the fineprint, so ONE GLANCE at either
  * device answers the question. Format: r<round>-<yyyymmdd>[letter].
  */
-export const GOON_BUILD = 'r11-20260805';
+export const GOON_BUILD = 'r12-20260805';
 
 const win = (typeof window !== 'undefined') ? window : null;
 const webview = (win && win.chrome && win.chrome.webview) ? win.chrome.webview : null;


### PR DESCRIPTION
Stamp-only bump to r12-20260805 covering PR #149 (footage preload) and PR #150 (lobby voice opt-in + mic under emote tile + hidden-mic breadcrumb).