### PR TITLE
fix(goon): brain drain shows the ATTACKER media, and overlay payloads instant-swap

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/exec/brainDrain.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/brainDrain.js
@@ -30,11 +30,47 @@
  * (exec/loadGovernor.js) — a burst is the worst possible moment to hand the
  * compositor a fresh fullscreen decode. The full tier calls neither.
  *
+ * WHOSE PICTURE IS IN THE WASH (2026-08-05, owner play-testing r12: "check IF we
+ * actually send our gifs as the braindrain — right now it seems like we are using
+ * the local assets of the receiver"). He was right, and the audit answer is worth
+ * writing down because nothing was broken: a BrainDrain payload is NOT in
+ * net/mediaQueue.js's XFER_KINDS, so it has never carried an `xfer:` tag, and this
+ * file only ever asked `media.drawKind('image')` — the receiver's own deck. Every
+ * layer worked; the veil simply never asked for their file.
+ *
+ * So the wash now climbs the SAME peer-first ladder exec/flashes.js has run since
+ * PR #126, and for the same reason ("the attacks are a transfer, every time"):
+ *
+ *   1. an exact artifact named by an `xfer:` tag  (media.drawFor)
+ *   2. anything else the opponent has landed this match, on the received store's
+ *      least-recently-shown rotation           (media.drawReceived)
+ *   3. and only then the receiver's own library (media.drawKind / drawStillImage)
+ *
+ * RUNG 2 IS THE ONE THAT ACTUALLY FIXES THE REPORT, and it is why this is an exec/
+ * change and not a net/ one. A drain runs 45s and re-picks every 7-11s, so it wants
+ * four to six pictures; one tag could only ever have paid for the first. Adding
+ * BrainDrain to XFER_KINDS would make rung 1 reachable and is a reasonable follow-up,
+ * but it is not the fix — the rotation is, and it needs no tags at all.
+ *
+ * THE LADDER IS PAYLOAD-ONLY. An ELEMENT cue (the ramp's own bed) has no attacker,
+ * so it stays on rung 3 forever — which is also the invariant media.js's header
+ * promises: draw()/drawKind() may never surface a peer file, and their media appears
+ * exactly where their payload asked for it and nowhere else.
+ *
+ * THE LITE TIER STILL GETS ITS PREFERENCE, on whichever rung answered: `preferStill`
+ * narrows the peer rotation the same way drawStillImage narrows the deck. A
+ * preference, never a filter — an all-gif opponent still washes their gif, because
+ * a phone frame is worth less than the owner's whole point about the transfer lane.
+ *
+ * ONE PAYLOAD AT A TIME, AND THE NEW ONE WINS INSTANTLY (2026-08-05, owner: "we just
+ * instantly swap whats active for whatever's next immediately, should be easier on
+ * the performances"). See renderPayload.
+ *
  * Uniform renderer shape — see the banner in exec/flashes.js.
  * ==========================================================================*/
 
 import { perfLite } from './perfTier.js';
-import { drawStillImage } from './media.js';
+import { drawStillImage, XFER_TAG_PREFIX } from './media.js';
 import { governorBusy } from './loadGovernor.js';
 
 const WASH_MIN_MS = 7000;    // how long one washed image holds before a re-pick
@@ -52,6 +88,20 @@ const reducedMotion = () => {
   try { return typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches; }
   catch (_e) { return false; }
 };
+
+/**
+ * The `xfer:` tags one payload carries, as a spendable list (empty for every payload
+ * that has none, which today is every BrainDrain — see the banner). Mirrored locally
+ * rather than imported from exec/flashes.js or net/: exec/ modules do not reach into
+ * net/, and one four-line reader is cheaper than a dependency between two renderers.
+ */
+export function xferTags(payload) {
+  const raw = (payload && Array.isArray(payload.tags)) ? payload.tags : null;
+  if (!raw) return [];
+  const out = [];
+  for (const t of raw) if (typeof t === 'string' && t.startsWith(XFER_TAG_PREFIX)) out.push(t);
+  return out;
+}
 
 /** Cue intensity -> the veil dial. The band is DtRH's scaleD(0.35, 0.62, strength). */
 export function drainTuning(intensity, calm) {
@@ -72,6 +122,17 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
   let washTimer = 0;             // the slow re-pick
   let elementIntensity = null;   // null = element not running
   let payloadIntensity = null;   // null = no payload running
+  /**
+   * THE ONE payload run that owns the veil right now, or null. Two jobs, and it is
+   * the same object for both because they are the same fact:
+   *   · it is the ANSWER to "is this veil an attack?" — repickWash climbs the
+   *     peer-first ladder only while a run holds it, so an element bed cannot see
+   *     peer media (media.js's header invariant);
+   *   · it is the SWAP TOKEN — see renderPayload. A run only puts the dial down if
+   *     it still owns it, so a run that has been swapped out settles into thin air
+   *     instead of tearing down its successor's veil.
+   */
+  let payloadRun = null;
 
   const layer = () => (layers && typeof layers.get === 'function' ? layers.get('drain') : null);
 
@@ -80,13 +141,39 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
     washHandle = null;
   }
 
-  /** Wash one image from the player's pool over the veil (no pool = plain dim). */
+  /**
+   * Wash one image over the veil (no pool at all = plain dim).
+   *
+   * WHOSE image is the whole point — see the banner. While a PAYLOAD owns the veil
+   * this is the attacker's picture if they have landed one: exact tag, then their
+   * received store, then ours. An element bed skips straight to ours.
+   *
+   * The shape of the three rungs is copied deliberately from exec/flashes.js
+   * showOne() (the `wantPeer && provenance !== 'peer'` re-draw included), because two
+   * peer-first ladders that read differently are two ladders that drift apart.
+   */
   function repickWash() {
     if (!veilEl || !media || typeof media.drawKind !== 'function') return;
+    const run = payloadRun;
+    const wantPeer = !!run;
     // LITE: prefer a still — a fullscreen animated wash is the one per-frame
     // cost this veil has left on a phone (see the banner). Full tier: the
-    // exact draw it has always made.
-    const entry = perfLite() ? drawStillImage(media) : media.drawKind('image');
+    // exact draw it has always made. The preference now rides BOTH sources.
+    const lite = perfLite();
+
+    // 1. the exact artifact this payload named, one tag spent per re-pick (a 45s
+    //    drain re-picks four to six times; flashes.js spends its tags the same way).
+    const drawWith = (run && run.tags.length) ? { tags: [run.tags.shift()] } : null;
+    let entry = (drawWith && typeof media.drawFor === 'function')
+      ? media.drawFor('image', drawWith)
+      : null;
+    // 2. …else anything else they have landed this match. drawFor falls THROUGH to
+    //    the local deck on a tag miss, so a non-peer answer here is a miss, not a hit.
+    if (wantPeer && (!entry || entry.provenance !== 'peer') && typeof media.drawReceived === 'function') {
+      entry = media.drawReceived('image', lite ? { preferStill: true } : undefined) || entry;
+    }
+    // 3. …and only now the receiver's own library — the last resort, not the default.
+    if (!entry) entry = lite ? drawStillImage(media) : media.drawKind('image');
     if (!entry) return;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     if (!handle || !handle.url) return;
@@ -170,13 +257,45 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
       apply();
     },
 
-    /** The once-per-match heavy: ride the veil up for duration_ms, then release. */
+    /**
+     * The once-per-match heavy: ride the veil up for duration_ms, then release.
+     *
+     * INSTANT SWAP, NEVER A BACKLOG (2026-08-05, owner: "we just instantly swap whats
+     * active for whatever's next immediately, should be easier on the performances").
+     *
+     * WHAT IT USED TO DO, and why it looked like a queue. `payloadIntensity` is ONE
+     * scalar and each call closed over its OWN endTimer, so two overlapping drains
+     * shared a dial and kept two clocks: the second one's intensity stamped over the
+     * first, then the FIRST one's timer expired and put the dial down — killing the
+     * veil while the second payload still had thirty seconds of its own duration to
+     * run, whose only remaining effect was a late second settle. A backlog of dead
+     * durations, exactly as reported, and on a phone it is also a second fullscreen
+     * decode inside the frame budget of the first.
+     *
+     * WHAT IT DOES NOW. `payloadRun` is a one-slot register. The arriving run takes
+     * ownership BEFORE the outgoing one is settled, so:
+     *   · the outgoing run's settle sees it no longer owns the dial, skips the
+     *     teardown entirely, clears its OWN endTimer and reports `endured=false` —
+     *     receipt `completed`, no charge, no refund, which is the semantic
+     *     exec/executor.js already uses for "it ran and you did not take all of it";
+     *   · the veil node, its wash timer and its backdrop-filter pane are NEVER torn
+     *     down and re-created, so there is no blank frame and no second pane — the
+     *     swap is one opacity write plus one repickWash();
+     *   · the dead run's remaining duration dies with its timer. It cannot re-trigger.
+     *
+     * ELEMENT CUES ARE UNTOUCHED. The element and the payload still hold separate
+     * dials and apply() still takes the louder — a swap between payloads cannot pull
+     * the veil out from under a running ramp bed.
+     */
     renderPayload(payload, done) {
       const p = payload || {};
       const runMs = Math.max(1000, (p.duration_ms | 0) || 45000);
-      payloadIntensity = Math.max(0.55, clamp01(p.intensity !== undefined ? p.intensity : 0.8));
-      apply();
-      repickWash();
+
+      const run = {
+        tags: xferTags(p),
+        intensity: Math.max(0.55, clamp01(p.intensity !== undefined ? p.intensity : 0.8)),
+        settle: null,
+      };
 
       let finished = false;
       let endTimer = 0;
@@ -184,10 +303,27 @@ export function createBrainDrain({ layers, media, audio, logger } = {}) {
         if (finished) return;
         finished = true;
         try { clearTimeout(endTimer); } catch (_e) { /* ignore */ }
-        payloadIntensity = null;
-        apply();
+        // ONLY the owner may put the dial down. A run that was swapped out has
+        // already handed the veil to its successor and must not tear it down.
+        if (payloadRun === run) {
+          payloadRun = null;
+          payloadIntensity = null;
+          apply();
+        }
         if (typeof done === 'function') { try { done(endured); } catch (e) { warn(`done() threw: ${e && e.message}`); } }
       };
+      run.settle = settle;
+
+      // The swap itself. Ownership moves first, THEN the outgoing run is settled —
+      // reversing those two lines is what would flash a blank frame.
+      const prev = payloadRun;
+      payloadRun = run;
+      if (prev) { try { prev.settle(false); } catch (e) { warn(`swap settle threw: ${e && e.message}`); } }
+
+      payloadIntensity = run.intensity;
+      apply();
+      repickWash();
+
       endTimer = soon(() => settle(true), runMs);
       return () => settle(false);
     },

--- a/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/bubbles.js
@@ -588,21 +588,41 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
     }
   }
 
-  /** An image handle from the player's own pool (null when the pool has none).
+  /** An image handle for a pop effect (null when there is nothing to draw).
+   *
    *  LITE prefers a STILL (media.js drawStillImage — a preference, never a
    *  filter): a pop's flick and the drain hold both fire at the busiest moment
    *  a phone has, and an animated GIF is a decode loop where a still is a
-   *  texture. Full tier: the exact draw it has always made. */
-  function drawImage() {
+   *  texture. Full tier: the exact draw it has always made.
+   *
+   *  WHOSE IMAGE (2026-08-05, the same audit that fixed exec/brainDrain.js's wash).
+   *  A bubble the OPPONENT'S SWARM minted is their attack, so the flash or the drain
+   *  wash it bursts into should be THEIR picture when they have landed one — the
+   *  peer-first ladder, minus rung 1: a BubbleSwarm carries no `xfer:` tags and there
+   *  is no per-bubble slot to spend one on anyway. Their received store, then ours.
+   *
+   *  A FIELD BUBBLE STAYS ENTIRELY OURS, and that asymmetry is the point: the ambient
+   *  field is the player's own bed, not an attack, so it may never surface a peer file
+   *  (media.js's header invariant — their media appears exactly where their payload
+   *  asked for it and nowhere else). `fromPayload` is the only gate.
+   *
+   *  @param {boolean} [peer] this pop belongs to a bubble an inbound swarm minted
+   */
+  function drawImage(peer) {
     if (!media || typeof media.drawKind !== 'function') return null;
-    const entry = perfLite() ? drawStillImage(media) : media.drawKind('image');
+    const lite = perfLite();
+    let entry = null;
+    if (peer && typeof media.drawReceived === 'function') {
+      entry = media.drawReceived('image', lite ? { preferStill: true } : undefined);
+    }
+    if (!entry) entry = lite ? drawStillImage(media) : media.drawKind('image');
     if (!entry) return null;
     const handle = (typeof media.acquire === 'function') ? media.acquire(entry) : null;
     return (handle && handle.url) ? handle : null;
   }
 
   /** The scattered flash a popped flash-bubble throws (payloadFx.flash, bounded). */
-  function popFlash(strength) {
+  function popFlash(strength, peer) {
     pruneFlashes();
     const host = layer();
     if (!host || typeof document === 'undefined') return;
@@ -610,7 +630,7 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
     const dur = scale(900, 1600, strength);
     for (let i = 0; i < amount; i++) {
       if (popFlashes.size >= MAX_POP_FLASH) break;
-      const handle = drawImage();
+      const handle = drawImage(peer);
       if (!handle) break;
       const img = document.createElement('img');
       img.className = 'gg-flash';
@@ -641,10 +661,10 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
   }
 
   /** The drain wash: dim + blur-behind with a faint image over it (showBraindrain). */
-  function popDrain(strength) {
+  function popDrain(strength, peer) {
     const h = holdOn('drain', 'gg-drain', scaleD(0.35, 0.62, strength), scale(1500, 4500, strength));
     if (!h) return h;
-    const handle = drawImage();
+    const handle = drawImage(peer);
     if (handle) {
       releaseHold(h);
       h.handle = handle;
@@ -653,11 +673,24 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
     return h;
   }
 
-  /** What a popped bubble of each kind throws. Bounded, and never a new layer. */
-  function popFx(kind, strength) {
+  /**
+   * What a popped bubble of each kind throws. Bounded, and never a new layer.
+   *
+   * INSTANT SWAP IS ALREADY THE RULE HERE, and it is worth naming so nobody
+   * "fixes" it: every wash below rides holdOn(), whose `gen` counter means a
+   * fresh pop clears the previous hideTimer, re-raises the SAME pane and leaves
+   * the old removal callback to bail out on a stale generation. Two pops of the
+   * same kind can never stack two panes or queue two durations — the second one
+   * takes the pane over on the spot. (The paying-per-frame kinds — spiral, pink,
+   * drain — each own their own pane and are allowed to COMPOSE across kinds,
+   * which is a layer question, not a queue question.)
+   *
+   * @param {boolean} [peer] the bubble was minted by an inbound swarm — see drawImage
+   */
+  function popFx(kind, strength, peer) {
     switch (kind) {
       case 'flash':
-        popFlash(strength);
+        popFlash(strength, peer);
         break;
       case 'spiral': {
         const h = holdOn('spiral', 'gg-spiral', scaleD(0.25, 0.70, strength), scale(1500, 4500, strength));
@@ -673,12 +706,12 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
         holdOn('pink', 'gg-pink', scaleD(0.25, 0.70, strength), scale(1500, 4500, strength));
         break;
       case 'braindrain':
-        popDrain(strength);
+        popDrain(strength, peer);
         break;
       case 'glitch': {
         // RGB-split shudder OVER the drain wash — DtRH's showGlitch, hard-capped
         // so a fat bubble can never strobe forever.
-        const h = popDrain(strength);
+        const h = popDrain(strength, peer);
         if (!h) break;
         h.el.classList.add('is-glitching');
         const ms = Math.min(4000, scale(1200, 3000, strength));
@@ -742,7 +775,10 @@ export function createBubbles({ layers, media, audio, logger } = {}) {
     announcePop(rec, x, y);
     // Bubble size IS the strength dial in the Fall; same here.
     const strength = Math.round(clamp01((rec.size - BUB_MIN_PX) / (BUB_MAX_PX - BUB_MIN_PX)) * 100);
-    try { popFx(rec.kind, strength); } catch (e) { warn(`popFx ${rec.kind} threw: ${e && e.message}`); }
+    // `fromPayload` rides along: a bubble the opponent's swarm minted bursts into
+    // THEIR media when they have landed some (drawImage), a field bubble into ours.
+    try { popFx(rec.kind, strength, rec.fromPayload); }
+    catch (e) { warn(`popFx ${rec.kind} threw: ${e && e.message}`); }
     rec.bubble.addEventListener('animationend', () => recycle(rec), { once: true });
     soon(() => recycle(rec), 600);
   }

--- a/ConditioningControlPanel/Resources/web/goon/exec/media.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/media.js
@@ -294,6 +294,26 @@ export function createGoonMediaPool() {
     return real.length ? real : pool;
   }
 
+  /**
+   * The LITE tier's version of footageFirst, for the image lane: stills ahead of animated
+   * artifacts, and NEVER a filter — see the drawStillImage banner above for why one more
+   * fullscreen decode loop is the thing a phone cannot afford, and the header's
+   * "preference, never a filter" promise for why an all-GIF peer pool still gets its GIF.
+   *
+   * IT IS DELIBERATELY A SET NARROWING, NOT A REDRAW LOOP. drawStillImage retries the deck
+   * because the deck is a consuming shuffle and a retry costs nothing but an echo-guard slot;
+   * the peer pool is a ROTATION whose whole job is fairness, so retrying here would burn
+   * rotation stamps on artifacts nobody was shown and quietly re-introduce the "always the
+   * same gif" run this rotation exists to kill. Narrowing the candidate set and rotating once
+   * keeps the ledger honest: the stills rotate among themselves, and the moment a still lands
+   * the gifs stop being drawn rather than being drawn and discarded.
+   */
+  function stillFirst(pool, kind) {
+    if (kind !== 'image' || pool.length < 2) return pool;
+    const stills = pool.filter((v) => !isAnimatedMedia(v));
+    return stills.length ? stills : pool;
+  }
+
   /** Every received view of that kind the blocklist still allows. Shared by draw and peek. */
   function receivedViews(kind) {
     const all = [];
@@ -534,14 +554,25 @@ export function createGoonMediaPool() {
      * this file for why random-with-an-echo-guard was the thing the owner was
      * seeing as "always the same gif". Least-recently-shown wins; the pick is
      * stamped so it goes to the back of the queue.
+     *
+     * @param {string} kind 'image' | 'video'
+     * @param {{preferStill?:boolean}} [opts] LITE-TIER ONLY, and only the image lane reads it:
+     *   a fullscreen wash (exec/brainDrain.js, a bubble's drain hold) would rather have a
+     *   texture than a decode loop. A PREFERENCE — an all-animated peer pool still hands one
+     *   back, because their gif beats our own library and that is the entire point of the
+     *   transfer lane. Omitted everywhere else, so every existing caller is byte-identical.
      */
-    drawReceived(kind) {
+    drawReceived(kind, opts) {
       const want = kind === 'video' ? 'video' : (kind === 'image' ? 'image' : '');
       if (!want) return null;
       const all = receivedViews(want);
       if (!all.length) return null;
       // Real footage if they have sent any this match; their gif loops if that is all there is.
-      const chosen = rotate(footageFirst(all, want));
+      let pool = footageFirst(all, want);
+      // …and, when the caller is paying per frame for it, a still ahead of an animation.
+      // Applied AFTER footageFirst so neither preference can empty what the other left.
+      if (opts && opts.preferStill) pool = stillFirst(pool, want);
+      const chosen = rotate(pool);
       peerShownAt.set(chosen.sha, ++peerDrawSeq);
       return chosen;
     },

--- a/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/spiral.js
@@ -205,6 +205,15 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
   let paneEl = null;
   let elementIntensity = null;    // null = element not running
   let payloadIntensity = null;    // null = no payload running
+  /**
+   * THE ONE payload run holding the pane, or null — the swap token. See
+   * renderPayload for the whole argument; the short version is that a second
+   * spiral arriving mid-run used to share this file's single `payloadIntensity`
+   * while keeping its own end timer, so the FIRST timer to expire took the pane
+   * down and left the second run's duration as a dead backlog. A run may only put
+   * the dial down while it still owns it.
+   */
+  let payloadRun = null;
 
   // THE SPIRAL CURRENTLY ON THE PANE — one roll from the session pool, driving
   // BOTH beds: `.params` is what the shader weaves, `.image()` is the baked
@@ -745,10 +754,55 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       sfx('spiral-out');
     },
 
-    /** Spiral payload: ride the pane up for duration_ms, then hand it back. */
+    /**
+     * Spiral payload: ride the pane up for duration_ms, then hand it back.
+     *
+     * INSTANT SWAP, NEVER A BACKLOG (2026-08-05, owner: "we just instantly swap whats
+     * active for whatever's next immediately, should be easier on the performances").
+     * The full argument lives in exec/brainDrain.js renderPayload — this pane has the
+     * identical one-scalar/two-clocks shape and therefore had the identical bug — but
+     * the SPIRAL has a second, sharper reason to swap rather than stack:
+     *
+     * ONE PANE, ONE WEAVE, ONE BAKE. A teardown-then-restart between two overlapping
+     * spirals would detach the woven canvas, drop the shader context, mount a fresh
+     * pane and queue a fresh raster bake, all inside the incoming cue's own fade —
+     * which is the exact double-bake shape PR #137 already had to chase off an iPhone
+     * once. Keeping the pane and letting `repick()` roll a new spiral onto it is one
+     * bake and no context churn, and it is also the nicer picture: the spiral changes
+     * without the screen blinking.
+     *
+     * `mintedPane` still does its job unchanged. On a swap the pane already exists, so
+     * apply() mints nothing, so the repick below is the one and only roll of this cue.
+     */
     renderPayload(payload, done) {
       const p = payload || {};
       const runMs = Math.max(1000, (p.duration_ms | 0) || 12000);
+
+      const run = { settle: null };
+
+      let finished = false;
+      let endTimer = 0;
+      const settle = (endured) => {
+        if (finished) return;
+        finished = true;
+        try { clearTimeout(endTimer); } catch (_e) { /* ignore */ }
+        // Only the owner may put the dial down; a swapped-out run settles into
+        // thin air rather than tearing down its successor's pane.
+        if (payloadRun === run) {
+          payloadRun = null;
+          payloadIntensity = null;
+          apply();
+        }
+        if (typeof done === 'function') { try { done(endured); } catch (e) { warn(`done() threw: ${e && e.message}`); } }
+      };
+      run.settle = settle;
+
+      // Ownership moves BEFORE the outgoing run is settled — reversing these two
+      // lines is what would tear the pane down and blink.
+      const prev = payloadRun;
+      payloadRun = run;
+      if (prev) { try { prev.settle(false); } catch (e) { warn(`swap settle threw: ${e && e.message}`); } }
+
       payloadIntensity = Math.max(0.5, clamp01(p.intensity !== undefined ? p.intensity : 0.75));
       apply();
       // ONE ROLL PER CUE. apply() -> ensurePane() already repicks for a pane it
@@ -762,16 +816,6 @@ export function createSpiral({ layers, media, audio, logger } = {}) {
       // change.
       if (!mintedPane) repick();
 
-      let finished = false;
-      let endTimer = 0;
-      const settle = (endured) => {
-        if (finished) return;
-        finished = true;
-        try { clearTimeout(endTimer); } catch (_e) { /* ignore */ }
-        payloadIntensity = null;
-        apply();
-        if (typeof done === 'function') { try { done(endured); } catch (e) { warn(`done() threw: ${e && e.message}`); } }
-      };
       endTimer = soon(() => settle(true), runMs);
       return () => settle(false);
     },

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -4581,6 +4581,226 @@ async function main() {
     for (const id of LAYER_IDS) byId.get(id).replaceChildren();
   }
 
+  /* ------- brain drain: the veil washes THEIR picture, not the receiver's own
+   *
+   * 2026-08-05, owner play-testing r12: "check IF we actually send our gifs as the
+   * braindrain — right now it seems like we are using the local assets of the
+   * receiver". He was right, and nothing was broken: a BrainDrain payload is not in
+   * net/mediaQueue.js's XFER_KINDS, so it never carries an `xfer:` tag, and
+   * exec/brainDrain.js only ever asked media.drawKind('image').
+   *
+   * The load-bearing rung is therefore the SECOND one — the received store's
+   * rotation, which needs no tags at all. These pin all three plus the invariant
+   * that keeps the ladder honest: an ELEMENT bed is not an attack and may never
+   * surface a peer file.
+   */
+  {
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    const drainHost = byId.get('gg-fx-drain');
+    const { createGoonMediaPool } = await import('../exec/media.js');
+    const BD = await import('../exec/brainDrain.js');
+
+    // The wash arrives as --gg-drain-img: url("…"), never as background-image (an
+    // inline background-image would drop fx.css's dim + desaturate layers — the B&W bug).
+    const washUrl = () => {
+      const veil = drainHost.findAll('gg-drain')[0];
+      const raw = veil ? String(veil.style.getPropertyValue('--gg-drain-img') || '') : '';
+      const m = /url\("([^"]*)"\)/.exec(raw);
+      return m ? m[1] : '';
+    };
+
+    const junkTags = { tags: ['xfer:' + SHA_IMG, 'lol:no', 42, null] };
+    ok(BD.xferTags(junkTags).length === 1,
+      'brainDrain.xferTags keeps only the xfer: namespace and never throws on junk',
+      JSON.stringify(BD.xferTags(junkTags)));
+    ok(BD.xferTags({}).length === 0 && BD.xferTags(null).length === 0,
+      'a payload with no tags is an empty spend list, not a crash');
+
+    // ---- 1. a peer payload draws from the received store, with NO tags at all
+    {
+      const pool = createGoonMediaPool();
+      pool.setManifest(ownManifest());
+      pool.addReceived({ sha: SHA('e'), kind: 'image', mime: 'image/gif', url: 'https://ccp.cache/recv/d0.gif' });
+      pool.addReceived({ sha: SHA('f'), kind: 'image', mime: 'image/png', url: 'https://ccp.cache/recv/d1.png' });
+
+      const ex = createExecutor({ media: pool, layers, logger: quiet, toyBridge: null });
+      ex.attach(fakeMatch());
+      const R = ex.rendererFor(GoonElement.BrainDrain);
+
+      const cancel = R.renderPayload({ id: 'pD1', duration_ms: 40000, intensity: 0.8 }, () => {});
+      await sleep(60);
+      ok(washUrl().startsWith('https://ccp.cache/recv/'),
+        'an UNTAGGED brain drain washes an artifact the opponent transferred this match — '
+        + 'the rung that actually answers the owner report, because a drain never carries tags',
+        washUrl());
+      ok(drainHost.findAll('gg-drain').length === 1,
+        'and it is still exactly one veil pane', String(drainHost.findAll('gg-drain').length));
+      cancel();
+      ex.stopAll();
+      ex.detach();
+      await sleep(60);
+      for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    }
+
+    // ---- 2. an exact xfer: tag outranks the rotation. Rung 1 is built, not
+    //         aspirational — the day BrainDrain joins XFER_KINDS it just works.
+    {
+      const pool = createGoonMediaPool();
+      pool.setManifest(ownManifest());
+      pool.addReceived({ sha: SHA('e'), kind: 'image', mime: 'image/png', url: 'https://ccp.cache/recv/d0.png' });
+      pool.addReceived({ sha: SHA_IMG, kind: 'image', mime: 'image/webp', url: 'https://ccp.cache/recv/exact.webp' });
+
+      const ex = createExecutor({ media: pool, layers, logger: quiet, toyBridge: null });
+      ex.attach(fakeMatch());
+      const R = ex.rendererFor(GoonElement.BrainDrain);
+      const cancel = R.renderPayload({
+        id: 'pD2', duration_ms: 40000, intensity: 0.8, tags: ['xfer:' + SHA_IMG],
+      }, () => {});
+      await sleep(60);
+      ok(washUrl() === 'https://ccp.cache/recv/exact.webp',
+        'a tagged brain drain washes the EXACT artifact the tag names, ahead of the rotation',
+        washUrl());
+      cancel();
+      ex.stopAll();
+      ex.detach();
+      await sleep(60);
+      for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    }
+
+    // ---- 3. an EMPTY received store falls back to the receiver's own library —
+    //         byte-identical to the behaviour before this feature existed
+    {
+      const pool = createGoonMediaPool();
+      pool.setManifest(ownManifest());
+
+      const ex = createExecutor({ media: pool, layers, logger: quiet, toyBridge: null });
+      ex.attach(fakeMatch());
+      const R = ex.rendererFor(GoonElement.BrainDrain);
+      const cancel = R.renderPayload({ id: 'pD3', duration_ms: 40000, intensity: 0.8 }, () => {});
+      await sleep(60);
+      ok(washUrl().startsWith('https://ccp.assets/'),
+        'a peer drain with nothing landed still washes the receiver own library — the '
+        + 'transfer lane degrades to today behaviour, it never blanks the veil', washUrl());
+      cancel();
+      ex.stopAll();
+      ex.detach();
+      await sleep(60);
+      for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    }
+
+    // ---- 4. THE INVARIANT: an element bed is not an attack. Even with a full
+    //         received store, the ramp's own drain stays on the local library.
+    {
+      const pool = createGoonMediaPool();
+      pool.setManifest(ownManifest());
+      pool.addReceived({ sha: SHA('e'), kind: 'image', mime: 'image/png', url: 'https://ccp.cache/recv/d0.png' });
+      pool.addReceived({ sha: SHA('f'), kind: 'image', mime: 'image/png', url: 'https://ccp.cache/recv/d1.png' });
+
+      const ex = createExecutor({ media: pool, layers, logger: quiet, toyBridge: null });
+      const m = fakeMatch();
+      ex.attach(m);
+      m.emitStart({ element: GoonElement.BrainDrain, intensity: 1, durationMs: 0, elapsedMs: 0 });
+      await sleep(60);
+      ok(washUrl().startsWith('https://ccp.assets/'),
+        'the ELEMENT drain never surfaces a peer file — their media appears exactly where '
+        + 'their payload asked for it and nowhere else (exec/media.js header invariant)', washUrl());
+      ex.stopAll();
+      ex.detach();
+      await sleep(60);
+      for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    }
+  }
+
+  /* --------- overlay payloads INSTANT-SWAP, they never queue up behind each other
+   *
+   * 2026-08-05, owner: "we just instantly swap whats active for whatever's next
+   * immediately, should be easier on the performances".
+   *
+   * WHAT THE BUG WAS. Both overlay renderers held ONE `payloadIntensity` scalar and
+   * gave each renderPayload call its OWN end timer. Two overlapping payloads
+   * therefore shared a dial and kept two clocks: the second stamped its intensity
+   * over the first, and then the FIRST one's timer expired and put the dial down —
+   * killing the overlay while the second still had most of its duration left, whose
+   * only remaining effect was a late second settle. A backlog of dead durations, and
+   * on a phone also a second fullscreen decode inside the first one's frame budget.
+   *
+   * WHAT IS PINNED, per overlay type:
+   *   1. the outgoing payload settles IMMEDIATELY, endured=false (receipt
+   *      `completed`, no charge, no refund — executor.js's existing interrupt
+   *      semantic, reused rather than invented);
+   *   2. the pane is NOT torn down and re-created — the SAME node throughout, so
+   *      there is no blank frame and no second backdrop-filter pane;
+   *   3. the dead run's remaining duration cannot re-trigger and never settles twice;
+   *   4. the survivor still settles normally through the ordinary door.
+   *
+   * ACROSS types nothing changes, deliberately: spiral, drain and the bubbles' pink
+   * hold each own a DIFFERENT layer (exec/layers.js) and are designed to compose.
+   * The owner's complaint was about a QUEUE, not about layering.
+   */
+  {
+    for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    const { createGoonMediaPool } = await import('../exec/media.js');
+
+    for (const [label, kind, hostId, cls] of [
+      ['brain drain', GoonPayloadKind.BrainDrain, 'gg-fx-drain', 'gg-drain'],
+      ['spiral', GoonPayloadKind.Spiral, 'gg-fx-spiral', 'gg-spiral'],
+    ]) {
+      const host = byId.get(hostId);
+      host.replaceChildren();
+      const pool = createGoonMediaPool();
+      pool.setManifest(ownManifest());
+
+      const ex = createExecutor({ media: pool, layers, logger: quiet, toyBridge: null });
+      const m = fakeMatch();
+      ex.attach(m);
+
+      // Through the EXECUTOR, not the renderer, so the receipt path is the shipped
+      // one: a swap has to produce a real closing receipt or the sender waits forever.
+      m.emitPayload({ payload: { id: 'sw1', kind, duration_ms: 60000, intensity: 0.6 } });
+      await sleep(40);
+      const firstNode = host.findAll(cls)[0];
+      ok(!!firstNode, `${label}: the first payload raised a pane`);
+      ok(m.receipts.length === 0, `${label}: and nothing has been receipted yet`,
+        JSON.stringify(m.receipts));
+
+      m.emitPayload({ payload: { id: 'sw2', kind, duration_ms: 60000, intensity: 0.9 } });
+      await sleep(40);
+
+      ok(m.receipts.length === 1 && m.receipts[0].id === 'sw1' && m.receipts[0].endured === false,
+        `${label}: the incoming payload settles the active one IMMEDIATELY, endured=false — `
+        + 'receipt completed, no charge, and the sender is never left waiting',
+        JSON.stringify(m.receipts));
+      ok(ex.activeCount() === 1,
+        `${label}: exactly one payload runs afterwards — the backlog is gone, not queued`,
+        String(ex.activeCount()));
+
+      const panes = host.findAll(cls);
+      ok(panes.length === 1, `${label}: still exactly ONE pane after the swap`, String(panes.length));
+      ok(panes[0] === firstNode,
+        `${label}: and it is the SAME node — the swap re-dials the running pane instead of `
+        + 'tearing it down and re-creating it, which is what would flash a blank frame');
+
+      // The dead run must not come back: its timer is cleared, and even if a host
+      // fired it anyway it no longer owns the dial. Well past its own teardown delay.
+      await sleep(150);
+      ok(m.receipts.length === 1,
+        `${label}: the swapped-out payload never settles twice and its remaining duration `
+        + 'cannot re-trigger', JSON.stringify(m.receipts));
+      ok(host.findAll(cls).length === 1,
+        `${label}: and the survivor pane is still up long after the dead run would have swept`,
+        String(host.findAll(cls).length));
+
+      ex.stopAll();
+      ok(m.receipts.length === 2 && m.receipts[1].id === 'sw2',
+        `${label}: the survivor still settles through the normal door afterwards`,
+        JSON.stringify(m.receipts));
+      ok(ex.activeCount() === 0, `${label}: registry empty`, String(ex.activeCount()));
+      ex.detach();
+      await sleep(60);
+      for (const id of LAYER_IDS) byId.get(id).replaceChildren();
+    }
+  }
+
   /* ------------------------------------------------- the received store, hosted
    *
    * The disk backend talks to TransferInboxStore through five verbs that ALL reply


### PR DESCRIPTION
Two owner reports from the r12 play-test, both landing in the payload executors (`exec/`). No `core/`, `ui/hud.js` or arsenal files touched, and `GOON_BUILD` is not bumped.

## 1. The brain drain showed the receiver's own assets

> "another agent should check IF we actually send our gifs as the braindrain - right now it seems like we are using the local assets of the receiver."

He was right, and **nothing was broken**. A `BrainDrain` payload is not in `net/mediaQueue.js`'s `XFER_KINDS`, so it has never carried an `xfer:` tag, and `exec/brainDrain.js` only ever asked `media.drawKind('image')` - the receiver's own deck. Every transfer layer worked; the veil simply never asked for their file.

The wash now climbs the same peer-first ladder `exec/flashes.js` has run since PR #126:

1. exact artifact via `media.drawFor` (an `xfer:` tag)
2. anything else they have landed this match, on the received store's least-recently-shown rotation (`media.drawReceived`)
3. the receiver's own library, last resort

**Rung 2 is the fix**, and it is why this is an `exec/` change and not a `net/` one: a drain runs 45s and re-picks every 7-11s, so it wants four to six pictures - one tag could only ever pay for the first. Adding `BrainDrain` to `XFER_KINDS` would make rung 1 reachable and is a reasonable follow-up, but it is not the fix. Rung 1 is built and tested regardless, so that day needs no work here.

The ladder is **payload-only**. An element cue (the ramp's own bed) has no attacker and stays on rung 3 forever, which keeps `media.js`'s header invariant intact: `draw()`/`drawKind()` may never surface a peer file.

Same treatment for a bubble an inbound swarm minted - `rec.fromPayload` now rides into `popFx`, so their swarm's bubbles burst into their picture while the ambient field stays entirely ours.

`media.drawReceived(kind, opts)` takes an optional `{preferStill}` so the lite tier keeps its no-fullscreen-decode-loop preference on the peer rung too. A preference, never a filter - an all-gif opponent still washes their gif. It **narrows the candidate set** rather than retrying, so it cannot burn rotation stamps and re-introduce the "always the same gif" run the rotation exists to kill.

## 2. Overlay payloads queued up behind each other

> "we just instantly swap whats active for whatever's next immediately, should be easier on the performances"

`brainDrain` and `spiral` each held ONE `payloadIntensity` scalar and gave every `renderPayload` call its OWN end timer. Two overlapping payloads therefore shared a dial and kept two clocks: the second stamped its intensity over the first, then the **first** one's timer expired and put the dial down - killing the overlay while the second still had most of its duration left, whose only remaining effect was a late second settle. A backlog of dead durations, and on a phone also a second fullscreen decode inside the first one's frame budget.

Both now keep a one-slot `payloadRun` register. The arriving run takes ownership **before** the outgoing one is settled, so:

- the outgoing run's settle sees it no longer owns the dial, skips the teardown, clears its own timer and reports `endured=false` - receipt `completed`, no charge, **no refund**, which is the interrupt semantic `executor.js` already uses;
- the pane, its wash timer and its backdrop-filter surface are never torn down and re-created, so **no blank frame** and no second pane - the swap is one opacity write plus one re-pick;
- the spiral gets **one** `repick()` instead of the PR #137 double bake, with no canvas detach or shader-context churn;
- the dead run's remaining duration dies with its timer and cannot re-trigger.

**Across types nothing changes, deliberately.** Spiral, drain and the bubbles' pink hold each own a *different* layer (`exec/layers.js`) and are designed to compose. The complaint was about a QUEUE, not about layering. The bubbles' holds already instant-swapped via their `gen` counter - now documented so nobody "fixes" it.

## Audit table

| Executor | Shows media? | Source before | Now | Scheduling before | Now |
|---|---|---|---|---|---|
| `brainDrain.js` (payload) | fullscreen wash | **local only** (the bug) | peer-first ladder | 1 scalar + N timers -> clobber | **instant swap** |
| `brainDrain.js` (element) | fullscreen wash | local | local (invariant) | n/a | n/a |
| `spiral.js` | generative/baked spiral, no user media | n/a | **N/A** | 1 scalar + N timers -> clobber | **instant swap** |
| `bubbles.js` pop flash/drain, swarm-minted | flash + wash | local only | peer-first (rung 2/3) | `gen` counter | already instant-swap (documented) |
| `bubbles.js` pop, field-minted | flash + wash | local | local (invariant) | `gen` counter | unchanged |
| `bubbles.js` `pinkfilter` | pure CSS tint, no media | n/a | **N/A** | `gen` counter | already instant-swap |
| `flashes.js` | scattered images | peer-first (PR #126) | unchanged | density capped by `MAX_LIVE` | unchanged (not an overlay) |
| `videos.js` | floating windows | peer-first | unchanged | pooled, capped | unchanged (not an overlay) |
| `subliminals.js` | text only | n/a | **N/A** | - | - |
| `bouncingText.js` | text only | n/a | **N/A** | - | - |
| `lockCards.js` | text/typing | n/a | **N/A** | - | - |
| `toys.js` | haptics | n/a | **N/A** | - | - |

## Tests

`test/selftest-exec.js` **1027 -> 1054 checks**, all green:

- peer drain with **no tags** draws from the received store (the rung that answers the report)
- a tagged drain takes the **exact** artifact ahead of the rotation
- an **empty** received store falls back to the local library - the lane degrades to today's behaviour, it never blanks the veil
- the **element** drain never surfaces a peer file (the invariant)
- `xferTags` junk tolerance
- per overlay type: the incoming payload settles the active one immediately with `endured=false`, `activeCount()` stays 1, **one pane and the SAME node** across the swap, no double settle, the dead duration cannot re-trigger, and the survivor still settles normally

Every other goon suite unchanged. `selftest-avafx` keeps its 12 pre-existing failures (not from this branch).

## Needs a live play-test

- **The drain actually shows their gif** on a real duel once artifacts have landed (headless pins the draw, not the pixels).
- **Swap feel**: throw two drains / two spirals back to back and confirm the overlay changes without a blink.
- **Mobile perf**: whether the swap measurably helps the burst lag the owner suspected. The stacking it removes is real, but it was never the only candidate.
- **Lite-tier still preference on the peer rung**: an all-gif opponent should still get their gif (preference, not filter).

Optional follow-up, not done here: adding `BrainDrain` to `net/mediaQueue.js`'s `XFER_KINDS` so rung 1 is reachable. It would consume a landed artifact tag in competition with `FlashBurst`, and the rotation already covers the case, so it is a deliberate non-change.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
