### PR TITLE
feat(goon): remove the charge requirement entirely

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -1884,32 +1884,37 @@ function logDeck(why) {
  * earned by popping bubbles (ui/drops.js), and on a fresh match nothing is
  * earned yet. In a DUEL that ramp is the game. In PRACTICE it is a wall in front
  * of the one question practice exists to answer — "does my library work?" — so
- * practice hands over the two slots that draw from the library, plus the charges
- * to spend them, and lets the player find out in the first ten seconds.
+ * practice hands over the two slots that draw from the library and lets the
+ * player find out in the first ten seconds.
+ *
+ * IT USED TO HAND OVER CHARGES TOO (`match.creditCharges(charges,
+ * 'practice-seed')`), because an armed slot with an empty meter would have fired
+ * into a rejection: the receiver validated the sender's wallet. The owner deleted
+ * that requirement on 2026-08-05, so the seed is now exactly the two stacks and
+ * nothing else — there is no second truth left to keep in step.
  *
  * DUEL GATING IS UNTOUCHED: this is reached from startSolo's own phase
- * subscription and from nowhere else, and it goes through the public seams
- * ui/drops.js already uses (creditCharges then armDrop), so the wire truth and
- * the local truth cannot disagree.
+ * subscription and from nowhere else, and it goes through the same public seam
+ * ui/drops.js uses (armDrop).
  * -------------------------------------------------------------------------- */
 const PRACTICE_SEED = Object.freeze([
-  Object.freeze({ id: 'flash', cost: 1 }),    // images, the cheap one
+  // `cost` is not spent — it is the drop-rarity weight these two carry elsewhere,
+  // kept here so the pair reads the same as an ARSENAL_ITEMS row.
+  Object.freeze({ id: 'flash', cost: 1 }),    // images, the common one
   Object.freeze({ id: 'video', cost: 2 }),    // a clip, in a floating window
 ]);
 
-function seedPracticeArsenal(match) {
+function seedPracticeArsenal() {
   const arsenal = hudHandle && hudHandle.parts && hudHandle.parts.arsenal;
   if (!arsenal || typeof arsenal.armDrop !== 'function') return;
-  let charges = 0;
   let armed = 0;
   for (const seed of PRACTICE_SEED) {
     // `silent` — the drop flourish is a reward animation and this is a gift, not
     // a reward. It would also fire before the HUD has finished its entrance.
-    if (arsenal.armDrop(seed.id, { count: 1, silent: true })) { armed++; charges += seed.cost; }
+    if (arsenal.armDrop(seed.id, { count: 1, silent: true })) armed++;
   }
   if (!armed) return;
-  try { match.creditCharges(charges, 'practice-seed'); } catch (_e) { /* the slot still lights */ }
-  logger.info('practice: seeded ' + armed + ' arsenal slot(s) and ' + charges + ' charge(s)');
+  logger.info('practice: seeded ' + armed + ' arsenal slot(s)');
 }
 
 /* ----------------------------------------------------------------------------
@@ -1942,7 +1947,7 @@ async function startSolo() {
    * it runs after boot's own phase handler, i.e. after mountHudNow() has built
    * the arsenal it seeds. On phaseUnsubs so it dies with the match. */
   phaseUnsubs.push(local.onPhaseChanged((p) => {
-    if (p === GoonMatchPhase.Live) seedPracticeArsenal(local);
+    if (p === GoonMatchPhase.Live) seedPracticeArsenal();
   }));
   /* PRACTICE HAS A FACE TOO — a tile, a name and dm:false (contract §6). It is
    * set AFTER attachMatch, which clears the peer, and it is the only way the

--- a/ConditioningControlPanel/Resources/web/goon/core/contracts.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/contracts.js
@@ -248,6 +248,20 @@ const COSTS = Object.freeze({
 /**
  * Charge cost per payload kind. Unknown kind -> Infinity, mirroring C#'s int.MaxValue
  * default: a cost nothing can afford, i.e. the payload is rejected rather than free.
+ *
+ * WHAT A COST STILL MEANS (owner, 2026-08-05: the charge REQUIREMENT is gone). Nothing is paid
+ * for any more — neither core/match.js nor ui/arsenal.js checks a balance before a throw. TWO
+ * consumers survive, and both are about SHAPE rather than payment:
+ *
+ *   1. THE UNKNOWN-KIND GUARD. `Infinity` is still how both ends say "that is not a payload kind
+ *      I know", which is the check that stops a malformed or future frame being scheduled. That
+ *      guard is why costOf() is still called on the hot path at all.
+ *   2. THE DROP RARITY CURVE. ui/drops.js weights each arsenal candidate at 1/cost^COST_BIAS, so
+ *      a cost now reads as a RARITY: flash (1) rains, brain drain (3) is a treat. Moving a number
+ *      here retunes how often that item DROPS, and nothing else.
+ *
+ * Keep the table in step with the C# side regardless: it is parity, and the wire still carries
+ * the meter these numbers were once priced against.
  */
 export function costOf(kind) {
   const c = COSTS[kind];

--- a/ConditioningControlPanel/Resources/web/goon/core/match.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/match.js
@@ -3,9 +3,8 @@
 //   Idle -> Lobby -> Consent -> Draft -> Countdown -> Live -> SuddenDeath -> Recap -> Idle
 //
 // Owns a transport (injected), the SHARED endurance ramp rolled from the draft agreement (the
-// intersection of both players' allowed sets) and the combined match seed, the scoring/charge
-// economy, the mercy and abandon flows, the receiver-side payload gate and the two-way result
-// handshake.
+// intersection of both players' allowed sets) and the combined match seed, the scoring meters,
+// the mercy and abandon flows, the receiver-side payload gate and the two-way result handshake.
 //
 // DRAFT (2026-08-03 redesign): both players toggle what they ALLOW, the pool is the intersection,
 // any toggle clears BOTH signatures, and the ramp both sides run is one seeded roll over that
@@ -18,9 +17,14 @@
 //  * Mercy is available in EVERY phase and always ends the match locally, even if the wire is
 //    dead. Pre-Live it degrades to a clean cancel that never reaches the ledger.
 //  * No payload kind can touch panic/lockdown/tray/session state — no such message exists.
-//  * The RECEIVER enforces the economy: burst/gap rate limit, charge cost against the opponent's
-//    last self-reported meter, one heavy per match, schedule-buffer clamp and text cap —
-//    regardless of what the wire claims.
+//  * The RECEIVER enforces admission: burst/gap rate limit, one heavy per match, schedule-buffer
+//    clamp and text cap — regardless of what the wire claims.
+//    THE CHARGE CHECK IS NOT ON THAT LIST ANY MORE (owner, 2026-08-05: "we should remove the
+//    requirement entirely"). The receiver used to hold a sender to the charge count on their last
+//    state tick and reject anything dearer. Nothing gates on a balance now, on either side, so a
+//    throw costs nothing and the RATE LIMIT is the whole of the pacing. `tick.charges` still rides
+//    every frame (frozen field, C# parity) and this class still tracks the opponent's copy of it —
+//    it is reported state, not a permission.
 //
 // ---------------------------------------------------------------------------------------------
 // TRANSPORT SURFACE CONSUMED (duck-typed; net/ owns the implementations). Mechanical camelCase of
@@ -211,6 +215,11 @@ export class GoonMatchService {
     this._liveWatchStoppedLocalMs = null;
     this._inboundLimiter = new GoonPayloadRateLimiter();
     this._outboundLimiter = new GoonPayloadRateLimiter();
+    /* id -> the kind's cost. It was the REFUND LEDGER: a rejected receipt looked its payload up
+       here and handed the charges back. Nothing refunds since 2026-08-05 (charges buy nothing),
+       so what survives is the MEMBERSHIP test — "this id is one of ours, still unreceipted" —
+       which is what guards the once-per-match heavy restore in _handleReceipt. The cost is kept
+       as the value because it is free to keep and it is what the entry has always meant. */
     this._outboundCosts = new Map();
     this._activeElements = new Set();
     // The agreement: two allowed sets, two signatures, one intersection.
@@ -270,7 +279,12 @@ export class GoonMatchService {
     this._localHeavyUsed = false;
     this._localHeavyPayloadId = null;
     this._remoteHeavyUsed = false;
-    this._opponentChargesKnown = 0;
+    /* `_opponentChargesKnown` used to live here: the ceiling the receiver held a sender to,
+       refreshed off every state tick and decremented by each admitted payload's cost. It had
+       exactly one reader — the charge gate in _handleInboundPayload — and the owner removed that
+       gate on 2026-08-05, so the ledger went with it rather than sitting here accruing a number
+       nobody consults. `this._opponent.charges` still mirrors what they report; that is the
+       reported state, and it never gated anything on its own. */
 
     this._localMercyMatchMs = null;
     this._remoteMercyMatchMs = null;
@@ -911,9 +925,16 @@ export class GoonMatchService {
   // ---------------------------------------------------------- payloads
 
   /**
-   * Fires an offensive payload at the opponent. Sender-side mirror of the receiver's gate
-   * (charges, rate limit, one heavy per match) so a well-behaved client is never rejected; the
+   * Fires an offensive payload at the opponent. Sender-side mirror of the receiver's gate (rate
+   * limit, one heavy per match, the agreed pool) so a well-behaved client is never rejected; the
    * receiver re-checks everything anyway. C# out-error -> {ok, error, id}.
+   *
+   * A THROW IS FREE (owner, 2026-08-05). Two lines used to sit in the middle of this method: a
+   * `charges < cost` pre-check that produced "needs N charge(s)", and the trySpend() that actually
+   * debited the meter. Both are gone, and the receiver's matching check went with them. What is
+   * left is the pacing the owner kept: ONE payload per GoonConsts.PayloadMinGapMs with a burst of
+   * PayloadBurst, enforced by _outboundLimiter here and _inboundLimiter over there. If you are
+   * about to add a "but only if…" to this method, that is the requirement that was just deleted.
    */
   msUntilNextPayloadMs() {
     return this._outboundLimiter.msUntilNextToken(localMonotonicMs());
@@ -931,9 +952,10 @@ export class GoonMatchService {
       return { ok: false, error: `opponent's client cannot run ${request.kind}`, id: null };
     }
 
-    let cost = costOf(request.kind);
+    // costOf is still the UNKNOWN-KIND guard (Infinity for a kind we have no entry for). It is
+    // no longer a price: nothing is checked against the meter and nothing is debited.
+    const cost = costOf(request.kind);
     if (cost <= 0 || !Number.isFinite(cost)) return { ok: false, error: 'unknown payload', id: null };
-    if (this._scoring.charges < cost) return { ok: false, error: `needs ${cost} charge(s)`, id: null };
 
     const nowLocal = localMonotonicMs();
     if (!this._outboundLimiter.tryAdmit(nowLocal)) {
@@ -944,9 +966,6 @@ export class GoonMatchService {
         id: null,
       };
     }
-    const spend = this._scoring.trySpend(request.kind);
-    if (!spend.ok) return { ok: false, error: `needs ${spend.cost} charge(s)`, id: null };
-    cost = spend.cost;
 
     const id = `p${++this._payloadSeq}${this._isHost ? 'h' : 'g'}`;
     const msg = makePayload({
@@ -967,16 +986,24 @@ export class GoonMatchService {
     }
     this._outboundCosts.set(id, cost);
     this._send(msg);
-    this._info(`payload out ${id} ${request.kind} cost ${cost}`);
+    this._info(`payload out ${id} ${request.kind}`);
     return { ok: true, error: '', id };
   }
 
   /**
-   * Credits charges earned outside the payload/round economy (the bubble economy is the first
-   * consumer). Integer count >= 1; the total is clamped to GoonConsts.ChargeCap exactly like every
-   * other earning, and the next state tick reports the new meter. No-ops outside the Live phase.
+   * Credits charges earned outside the payload/round economy. Integer count >= 1; the total is
+   * clamped to GoonConsts.ChargeCap exactly like every other earning, and the next state tick
+   * reports the new meter. No-ops outside the Live phase.
    *
-   * MIRROR: GoonMatchService.CreditCharges(int, string).
+   * NO PRODUCTION CALLER SINCE 2026-08-05. ui/drops.js, ui/soloDriver.js and boot.js all called
+   * this before arming an item, for ONE reason: the receiver validated the sender's wallet, so an
+   * armed sticker with no charge behind it would have fired into a rejection. That validation is
+   * gone, so crediting a meter nobody reads was ceremony — the calls came out and the seam stayed.
+   *
+   * It stays because it is C# parity (GoonMatchService.CreditCharges(int, string)) and because
+   * test/vectors-engine.js pins its contract: Live-only, integer >= 1, clamped at the cap. If a
+   * future feature wants a visible meter again, credit it here — but give it a READER first, and
+   * do not make it a permission to throw.
    *
    * @returns {boolean} true when at least the request was accepted (credited, cap permitting)
    */
@@ -995,7 +1022,12 @@ export class GoonMatchService {
 
   /**
    * The executor calls this when an accepted inbound payload finishes.
-   * endured = the receiver took it all the way -> +1 charge.
+   *
+   * `endured` = the receiver took it all the way, which is the difference between the `survived`
+   * and `completed` receipt statuses — the thrower's log says "endured" and the arsenal plays
+   * gg-endured off it. It still ticks the local charge meter (parity with GoonScoring.cs), but
+   * that is now bookkeeping: since 2026-08-05 nothing anywhere spends a charge, so riding out a
+   * payload buys the receiver no ammunition. The RECEIPT is the whole of what it earns.
    */
   notifyInboundPayloadFinished(payloadId, endured) {
     if (!payloadId) return;
@@ -1443,9 +1475,11 @@ export class GoonMatchService {
     this._opponent.lastTickLocalMs = localMonotonicMs();
     this._opponent.hasSeenTick = true;
 
-    // The opponent's self-reported meter is the ceiling we hold them to when their next payload
-    // lands (C# assigns unconditionally — a lower claim tightens the ceiling immediately).
-    this._opponentChargesKnown = this._opponent.charges;
+    /* Their meter is now PURELY REPORTED STATE. It used to be copied into `_opponentChargesKnown`
+       as the ceiling their next payload was held to; the gate went on 2026-08-05 and the ledger
+       with it. The field itself stays parsed, clamped and mirrored because it is a frozen tick
+       field a C# host still sends — a reader that wants to draw it can, and nothing decides
+       anything with it. */
 
     if (this._opponent.health !== GoonConnectionHealth.Fresh) {
       this._opponent.health = GoonConnectionHealth.Fresh;
@@ -1484,14 +1518,15 @@ export class GoonMatchService {
       this._rejectPayload(payload, GoonReceiptStatus.RejectedRate, 'rate limit');
       return;
     }
-    if (this._opponentChargesKnown < cost) {
-      // Economy violation. No dedicated receipt status exists in v1, so it rides rejected_rate.
-      this._rejectPayload(payload, GoonReceiptStatus.RejectedRate,
-        `charge economy: claimed ${this._opponentChargesKnown} < cost ${cost}`);
-      return;
-    }
-
-    this._opponentChargesKnown -= cost;
+    /* THE CHARGE GATE STOOD HERE and it is gone on purpose (owner, 2026-08-05: "we should remove
+       the requirement entirely"). It held the sender to the count on their last state tick —
+       `claimed N < cost M` -> rejected_rate — and decremented a local ledger by every admitted
+       cost. With throws free on the sending side, an inbound payload backed by an empty meter is
+       CORRECT BEHAVIOUR, not an economy violation, and keeping the check would have made every
+       throw from an updated peer bounce off the first receiver to read its wallet.
+       Both seats run the same deployed build in this beta, so there is no mixed-version window to
+       cover. Everything that actually protects this seat is still above and below: the phase, our
+       own advertised caps, the once-per-match heavy, the rate limit, and the clamps. */
     if (payload.kind === GoonPayloadKind.BrainDrain) this._remoteHeavyUsed = true;
 
     // Defensive normalisation. exec/ still owns full receiver-side resolution (tags -> own
@@ -1529,15 +1564,16 @@ export class GoonMatchService {
   _handleReceipt(receipt) {
     const status = typeof receipt.status === 'string' ? receipt.status : '';
     if (receipt.id && status.toLowerCase().startsWith('rejected') && this._outboundCosts.has(receipt.id)) {
-      const cost = this._outboundCosts.get(receipt.id);
       this._outboundCosts.delete(receipt.id);
-      this._scoring.refund(cost);
-      // A rejected heavy was never delivered — give the once-per-match slot back.
+      /* NO REFUND ANY MORE. Nothing was spent to send it (2026-08-05), so handing charges back
+         here would MINT them: a peer that rejected everything would have filled the sender's
+         meter. The once-per-match heavy is the only thing a rejection still restores, and that
+         one matters more than ever — it is now the single scarce item in the deck. */
       if (this._localHeavyPayloadId === receipt.id) {
         this._localHeavyPayloadId = null;
         this._localHeavyUsed = false;
       }
-      this._info(`payload ${receipt.id} rejected (${status}) - ${cost} charge(s) refunded`);
+      this._info(`payload ${receipt.id} rejected (${status})`);
     } else if (receipt.id && (status === GoonReceiptStatus.Completed || status === GoonReceiptStatus.Survived)) {
       this._outboundCosts.delete(receipt.id);
     }

--- a/ConditioningControlPanel/Resources/web/goon/core/scoring.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/scoring.js
@@ -1,5 +1,20 @@
-// Score ticks, the charge economy, and the receiver-side payload rate limiter —
+// Score ticks, the charge meter, and the receiver-side payload rate limiter —
 // port of Services/GoonGame/GoonScoring.cs (GoonScoring + GoonPayloadRateLimiter).
+//
+// CHARGES NO LONGER BUY ANYTHING (owner, 2026-08-05: "we still have the charge
+// system in (you need 3 to do X etc), we should remove the requirement entirely
+// (and the Need 1/2/3 under the throwables)"). Every counter below is still
+// here, still named after GoonScoring.cs and still carried on the state tick —
+// core/match.js simply stopped asking it for permission. THE PACING IS THE
+// COOLDOWN NOW: GoonPayloadRateLimiter at the foot of this file (one payload per
+// PayloadMinGapMs, burst PayloadBurst) is the whole of it, on both sides.
+//
+// So `charges` is a number that accrues and is reported, and nothing reads it to
+// make a decision. It stays because it is WIRE STATE (tick.charges is a frozen
+// field a C# host and every older peer already send and parse) and because
+// GoonScoring.cs still has all of it — deleting the meter here would fork the
+// parity port for a field the protocol keeps sending either way. Do not build a
+// new gate on it; the owner removed the last one on purpose.
 //
 // Formula: 1 pt/s x (1 + DraftRiskStep x riskTier) x attention multiplier.
 //   Cam   : rolling attention % -> AttentionMultMin .. AttentionMultMax
@@ -163,6 +178,12 @@ export class GoonScoring {
   /**
    * Spends the cost of a payload kind. C# `TrySpend(kind, out cost)` -> {ok, cost}; on failure
    * `cost` is what the kind REQUIRES, which is what the caller puts in its error string.
+   *
+   * NO PRODUCTION CALLER SINCE 2026-08-05. core/match.js ran this inside tryFirePayload and handed
+   * the failure straight back to the arsenal as "needs N charge(s)". Firing is free now (see the
+   * header), so nothing spends and — critically — nothing refunds either: the two are a matched
+   * pair, and re-adding one without the other mints charges out of a rejected receipt. Kept
+   * because GoonScoring.cs still has TrySpend/Refund and this file is its port.
    */
   trySpend(kind) {
     const cost = costOf(kind);
@@ -175,7 +196,8 @@ export class GoonScoring {
     return { ok: true, cost };
   }
 
-  /** Refund after a receiver-side rejection (rate/filter). Never exceeds the cap. */
+  /** Refund after a receiver-side rejection (rate/filter). Never exceeds the cap.
+   *  Dormant with trySpend — see the note there before wiring either back up. */
   refund(cost) {
     if (!(cost > 0)) return;
     this._chargesSpent = Math.max(0, this._chargesSpent - cost);

--- a/ConditioningControlPanel/Resources/web/goon/index.html
+++ b/ConditioningControlPanel/Resources/web/goon/index.html
@@ -72,10 +72,10 @@
         <div id="gg-fx-vwin"></div>
     </div>
 
-    <!-- z40 — in-match HUD (clock, charges, score, opponent plate). -->
+    <!-- z40 — in-match HUD (clock, score, heat gauge, opponent plate). -->
     <div id="gg-hud" hidden></div>
 
-    <!-- z50 — transient toasts (payload landed, peer wobbly, charge earned). -->
+    <!-- z50 — transient toasts (payload landed, peer wobbly, item dropped). -->
     <div id="gg-toasts" aria-live="polite"></div>
 
     <!-- z60 — MERCY. Its own layer on purpose: never dimmed, filtered or

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -645,14 +645,16 @@ function mountRecap(result) {
       'the bytes that landed are the bytes that were sent, start and end',
       `${got.length} vs ${sent.length}`);
 
-    // --- the payload. Live phase + charges are forced: this section is about the
-    // wrapper and the tag, not about the charge economy (selftest-core owns that).
+    // --- the payload. The Live phase is forced: this section is about the wrapper
+    // and the tag, not about the phase machine.
+    //
+    // TWO LINES USED TO SIT HERE, `a._scoring._charges = 9` and
+    // `b._opponentChargesKnown = 9`, because we skip Live entirely and the inbound
+    // gate would otherwise refuse A's shot on the charge economy. That gate went on
+    // 2026-08-05 with the charge requirement, so a payload fired off an empty meter
+    // is simply admitted now — which is the point of this whole change.
     a._phase = GoonMatchPhase.Live;
     b._phase = GoonMatchPhase.Live;
-    a._scoring._charges = 9;
-    // B only knows what A's state frames told it, and we skipped Live entirely — so
-    // hand it the same number by hand or the inbound gate refuses on the economy.
-    b._opponentChargesKnown = 9;
 
     const kind = received[0].kind === 'video' ? GoonPayloadKind.Video : GoonPayloadKind.FlashBurst;
     const tags = qA.tagsFor(kind);
@@ -710,10 +712,9 @@ function mountRecap(result) {
     ok(q.enabled() === false, 'the queue is dormant even though everything else agreed');
     ok(q.tagsFor(GoonPayloadKind.Video).length === 0, 'so tagsFor returns []');
 
+    // (No charge priming: neither seat has a balance to be short of since 2026-08-05.)
     a._phase = GoonMatchPhase.Live;
     b._phase = GoonMatchPhase.Live;
-    a._scoring._charges = 9;
-    b._opponentChargesKnown = 9;
     let inbound = null;
     b.onPayloadAccepted((e) => { inbound = e && e.payload; });
     const res = a.tryFirePayload({ kind: GoonPayloadKind.Video, durationMs: 5000, intensity: 0.5 });
@@ -1871,21 +1872,26 @@ function mountRecap(result) {
  * throws BACK. An inbound payload resolves against the RECEIVER's library
  * (exec/media.js drawFor -> drawKind), so the bot's flash burst is drawn from the
  * player's own uploads — that is the loop, and it used to wait on the bot's
- * economy (PAYLOAD_TRY_MS, a 35% skip, and charges it has not earned yet).
+ * economy (PAYLOAD_TRY_MS, a 35% skip, and charges it had not earned yet).
  *
  * Two fixes, both practice-only:
  *   · the bot opens with a scheduled salvo of the two MEDIA-CARRYING kinds;
  *   · boot seeds the practice arsenal, so the slots that draw from the library
  *     are not locked behind a bubble-drop grind.
  *
- * THE REGRESSION THIS BLOCK EXISTS FOR: the receiver validates the SENDER's
- * charges off the last state TICK, not off the payload frame, so crediting and
- * firing in the same turn is rejected with "claimed 0 < cost 1". The first cut
- * did exactly that and the salvo never landed.
+ * THE REGRESSION THIS BLOCK EXISTED FOR, and what replaced it. The receiver used
+ * to validate the SENDER's charges off the last state TICK rather than off the
+ * payload frame, so crediting and firing in the same turn came back as "claimed
+ * 0 < cost 1" — the first cut of the salvo did exactly that and never landed.
+ * That gate went on 2026-08-05 with the entire charge requirement, so the lead is
+ * no longer funding anything. IT STILL HAS A JOB: it reserves the shot
+ * (`salvoArmed`) so the ordinary cadence cannot take the RATE-LIMIT TOKEN the
+ * scheduled shot needs — the same silent-failure shape, on the one constraint
+ * that is left. Hence SALVO_RESERVE_LEAD_MS, and hence the same assertions.
  * ==========================================================================*/
 {
   const wait = (ms) => new Promise((r) => setTimeout(r, ms));
-  const { createSoloDriver, SALVO, SALVO_CREDIT_LEAD_MS } = await import('../ui/soloDriver.js');
+  const { createSoloDriver, SALVO, SALVO_RESERVE_LEAD_MS } = await import('../ui/soloDriver.js');
   const { GoonConsts, GoonPayloadKind, costOf } = await import('../core/contracts.js');
 
   // ---- the shape of the salvo
@@ -1895,17 +1901,20 @@ function mountRecap(result) {
     'and it is the two MEDIA-CARRYING kinds — the ones that draw off the deck', JSON.stringify(salvoKinds));
   ok(SALVO[0].atMs <= 10000, 'the first shot lands in the first ten seconds, not after a grind',
     String(SALVO[0].atMs));
-  ok(SALVO_CREDIT_LEAD_MS > GoonConsts.TickIntervalMs,
-    'the charges are credited more than one state tick ahead of the shot — the receiver reads the '
-    + 'wallet off the tick, so credit-and-fire in one turn is rejected',
-    SALVO_CREDIT_LEAD_MS + 'ms vs ' + GoonConsts.TickIntervalMs + 'ms');
-  ok(SALVO.every((s) => s.atMs - SALVO_CREDIT_LEAD_MS >= 0),
-    'every shot has room for its own credit lead');
+  ok(SALVO_RESERVE_LEAD_MS > GoonConsts.TickIntervalMs,
+    'a salvo shot is reserved more than one state tick ahead of firing — comfortably longer than '
+    + 'any single cadence turn, so nothing can slip in and take its rate-limit token',
+    SALVO_RESERVE_LEAD_MS + 'ms vs ' + GoonConsts.TickIntervalMs + 'ms');
+  ok(SALVO.every((s) => s.atMs - SALVO_RESERVE_LEAD_MS >= 0),
+    'every shot has room for its own reserve lead');
   const soloSrc = stripComments(read('ui/soloDriver.js'));
   ok(/if \(salvoArmed > 0\) return;/.test(soloSrc),
-    'and the ordinary cadence cannot spend a salvo shot\'s charges out from under it');
-  ok(/match\.creditCharges\(cost - have, 'practice-salvo'\)/.test(soloSrc),
-    'the charges go through the engine, so the wire truth stays the truth (no back door)');
+    'and the ordinary cadence stands down while a shot is reserved');
+  ok(!/creditCharges/.test(soloSrc),
+    'THE BOT FUNDS NOTHING. The practice-salvo creditCharges call went with the charge '
+    + 'requirement (2026-08-05): a throw is free, so there is no wallet to top up first');
+  ok(!/costOf/.test(soloSrc),
+    'and its affordability filter went too — the bot throws whatever the agreement allows');
   ok(/match\.tryFirePayload\(\{/.test(soloSrc),
     'and the shot goes through the same public API a human uses — every engine gate still applies');
 
@@ -1952,16 +1961,19 @@ function mountRecap(result) {
 
   // ---- boot seeds the practice arsenal, and ONLY the practice arsenal
   const bootSeed = stripComments(read('boot.js'));
-  ok(/function seedPracticeArsenal\(match\)/.test(bootSeed), 'boot.js has seedPracticeArsenal()');
-  ok(/const PRACTICE_SEED = Object\.freeze\(\[[\s\S]{0,300}?id: 'flash'[\s\S]{0,200}?id: 'video'/.test(bootSeed),
+  ok(/function seedPracticeArsenal\(\)/.test(bootSeed), 'boot.js has seedPracticeArsenal()');
+  ok(/const PRACTICE_SEED = Object\.freeze\(\[[\s\S]{0,400}?id: 'flash'[\s\S]{0,200}?id: 'video'/.test(bootSeed),
     'and it seeds the two slots that draw from the library (flash + video)');
-  ok(/arsenal\.armDrop\(seed\.id, \{ count: 1, silent: true \}\)/.test(bootSeed)
-    && /match\.creditCharges\(charges, 'practice-seed'\)/.test(bootSeed),
-    'through the same two public seams ui/drops.js uses — armDrop, and the charges that back it');
+  ok(/arsenal\.armDrop\(seed\.id, \{ count: 1, silent: true \}\)/.test(bootSeed),
+    'through the same public seam ui/drops.js uses — armDrop');
+  ok(!/creditCharges/.test(bootSeed),
+    'and NOTHING ELSE. The practice-seed charge credit went with the charge requirement '
+    + '(2026-08-05), so the two stacks are the whole gift and there is no second truth to keep '
+    + 'in step with them');
   const seedCalls = (bootSeed.match(/seedPracticeArsenal\(/g) || []).length;
   ok(seedCalls === 2, 'seedPracticeArsenal is defined once and called once', String(seedCalls));
-  ok(/async function startSolo\(\)[\s\S]*?seedPracticeArsenal\(local\)/.test(bootSeed)
-    || /seedPracticeArsenal\(local\)[\s\S]*?async function startSolo\(\)/.test(bootSeed),
+  ok(/async function startSolo\(\)[\s\S]*?seedPracticeArsenal\(\)/.test(bootSeed)
+    || /seedPracticeArsenal\(\)[\s\S]*?async function startSolo\(\)/.test(bootSeed),
     'and that one call is wired from startSolo — practice only, duel gating untouched');
   const arsenalSrc = stripComments(read('ui/arsenal.js'));
   const armDropAt = arsenalSrc.indexOf('function armDrop');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -604,6 +604,13 @@ function makeFakeMatch() {
     droppable: () => [{ id: 'flash', kind: GoonPayloadKind.FlashBurst, cost: 1, armed: 0 }],
     armDrop: (id) => { armedIds.push(id); return true; },
   };
+  /* THE ROLLER PAYS FOR NOTHING (2026-08-05). It used to call
+     match.creditCharges(cost, 'bubble-drop') before arming and refuse the drop
+     ('no-charge') if the engine said no — the receiver validated the sender's
+     wallet, so an armed slot with an empty meter would have fired into a
+     rejection. The owner deleted that requirement, so the roller now talks to
+     the arsenal ALONE. `credits` survives as a TRIPWIRE: the fake engine records
+     any call and the checks below assert there were none. */
   const credits = [];
   const match = {
     phase: GoonMatchPhase.Live,
@@ -614,33 +621,32 @@ function makeFakeMatch() {
 
   const clutter = roller.onPop({ kind: 'normal', worth: bub.POP_WORTH_PAYLOAD, payload: true });
   ok(clutter.dropped === false && clutter.reason === 'clutter', 'a payload-minted pop is skipped entirely');
-  ok(credits.length === 0, 'and never credits a charge');
 
   const hit = roller.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT, x: 10, y: 10 });
   ok(hit.dropped === true && hit.id === 'flash', 'a winning roll arms an item', JSON.stringify(hit));
-  ok(credits.length === 1 && credits[0].n === 1 && credits[0].reason === 'bubble-drop',
-    'and credits the charge the item will cost, on the engine seam', JSON.stringify(credits));
+  ok(credits.length === 0,
+    'and pays NOTHING for it — a drop is a grant now, not a purchase', JSON.stringify(credits));
   ok(armedIds.length === 1, 'exactly one arm per drop');
 
-  // the engine refusing (wrong phase, capped, whatever) must block the arm
+  // an engine that refuses every credit changes nothing, because we never ask
   const noCredit = createDropRoller({
     match: { phase: GoonMatchPhase.Live, creditCharges: () => false },
     arsenal: fakeArsenal,
     random: () => 0,
   });
   const blocked = noCredit.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT });
-  ok(blocked.dropped === false && blocked.reason === 'no-charge',
-    'creditCharges() saying no blocks the arm', JSON.stringify(blocked));
-  ok(armedIds.length === 1, 'and nothing was armed behind its back', String(armedIds.length));
+  ok(blocked.dropped === true && blocked.reason === 'drop',
+    'an engine that refuses every charge can no longer block a drop', JSON.stringify(blocked));
+  ok(armedIds.length === 2, 'and the arsenal armed it', String(armedIds.length));
 
-  // outside Live nothing rolls at all
+  // outside Live nothing rolls at all — THE phase check, and now the only gate
   const idle = createDropRoller({ match: { phase: GoonMatchPhase.Draft }, arsenal: fakeArsenal, random: () => 0 });
   ok(idle.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT }).reason === 'phase', 'no drops outside a live match');
 
   // a missing seam (older engine) must not break the loop
   const noSeam = createDropRoller({ match: { phase: GoonMatchPhase.Live }, arsenal: fakeArsenal, random: () => 0 });
   ok(noSeam.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT }).dropped === true,
-    'the roller still works against an engine without creditCharges');
+    'the roller still works against an engine with no charge seam at all');
 
   // a miss is a miss
   const missed = createDropRoller({ match, arsenal: fakeArsenal, random: () => 0.99 });
@@ -699,9 +705,16 @@ function makeFakeMatch() {
     ok(spender.heat < hotBefore, 'a drop spends heat back down', `${hotBefore} -> ${spender.heat}`);
     ok(spender.heat >= 0, 'never below empty', String(spender.heat));
 
+    /* A DROP THE PLAYER NEVER GOT MUST NOT SPEND THE GAUGE. The refusal used to
+       be the engine saying no to the charge; since 2026-08-05 there is no charge
+       to be refused, so the remaining way to win a roll and get nothing is a
+       FULL ARSENAL — armDrop() answering false. Same invariant, real cause. */
+    const fullArsenal = {
+      droppable: () => [{ id: 'flash', kind: GoonPayloadKind.FlashBurst, cost: 1, armed: 0 }],
+      armDrop: () => false,
+    };
     const refuser = createDropRoller({
-      match: { phase: GoonMatchPhase.Live, creditCharges: () => false },
-      arsenal: fakeArsenal, random: scripted, now: clock,
+      match, arsenal: fullArsenal, random: scripted, now: clock,
     });
     for (let i = 0; i < 2; i++) refuser.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT });
     const heldBefore = refuser.heat;
@@ -709,7 +722,7 @@ function makeFakeMatch() {
     win = true;
     const refused = refuser.onPop({ kind: 'flash', worth: bub.POP_WORTH_EFFECT });
     win = false;
-    ok(refused.reason === 'no-charge', 'the engine refuses the drop', JSON.stringify(refused));
+    ok(refused.reason === 'refused', 'the arsenal refuses the drop', JSON.stringify(refused));
     ok(refuser.heat > heldBefore,
       'and a drop the player never got does NOT spend the gauge', `${heldBefore} -> ${refuser.heat}`);
 
@@ -1113,48 +1126,47 @@ function makeFakeMatch() {
   hudRisk.unmount();
 }
 
-/* ---- 2c-iii. AND THE CHARGE PIPS WENT TOO (2026-08-05, second pass) --------
+/* ---- 2c-iii. AND THEN THE WHOLE CHARGE READOUT WENT (2026-08-05, third pass)
  *
- * The first pass argued the charge pips were not the risk indicator and kept
- * them: they are what you hold to throw, core/wire.js validates throws against
- * them and the arsenal pays its costs out of them, so they carried real state.
- * The owner saw them in play anyway — "the little yellow squares that we were
- * supposed to have removed" — and that settles it: the objection was to the
- * SHAPE, and a row of rotated squares under the score is not distinguishable,
- * at arm's length on a phone, from the row of rotated squares that had just
- * come off the draft tiles.
+ * THE THREE PASSES, because the last one is not a styling decision:
+ *   1. the risk pips came off the draft tiles;
+ *   2. the CHARGE pips came off the HUD ("the little yellow squares that we were
+ *      supposed to have removed"), replaced by a word count: `.gg-charges`
+ *      ("3 / 5 charges") under your score and `.gg-mon-charges` in their monitor
+ *      titlebar. That pass kept the DATA on the argument that it was real — the
+ *      wire validated throws against it and the arsenal paid its costs from it;
+ *   3. the owner then removed the REQUIREMENT itself: "we still have the charge
+ *      system in (you need 3 to do X etc), we should remove the requirement
+ *      entirely (and the Need 1/2/3 under the throwables)". That retired the
+ *      argument holding the readout up, so the readout went.
  *
- * So the data stayed and the diamond went, in BOTH places it was drawn: yours
- * under the score (`.gg-pips`) and theirs in the monitor titlebar
- * (`.gg-mon-pips`, the `.gg-pip--sm` variant). Leaving the second would have
- * kept the complained-about shape on screen two inches from where it was
- * deleted, and kept the CSS alive to grow a third user.
+ * WHAT CHARGES FEED, audited before deleting rather than assumed: the score is
+ * seconds x riskMultiplier x attentionMultiplier and never touches them; nothing
+ * in the client reads chargesEarned/chargesSpent; the drop economy is paced by
+ * HEAT and picks by cost-as-RARITY; enduring a payload still banks one, to
+ * nothing. The answer is NOTHING — and a readout of nothing is worse than no
+ * readout, because "1 / 3 charges" beside a tile you CAN throw says you cannot.
  *
- * WHAT THIS SECTION PINS, in order: the words are there and say the number; the
- * cap is still readable on YOUR line; the gain juice (sfx + "+1" chip) survived
- * the pips it used to be attached to; a SPEND is silent; and no `.gg-pip` node
- * or rule exists anywhere on the desk. The last one is the regression guard —
- * this comes back as somebody adding "just a little indicator". */
+ * WHAT THIS SECTION PINS, in order: no charge string survives in strings.js; the
+ * mounted desk builds no `.gg-charges`, no `.gg-mon-charges` and no `.gg-pip` of
+ * any kind; a charge gain is now SILENT and mints no chip; the arsenal tiles
+ * carry no cost pips and never enter the "poor" state; and neither the JS nor
+ * the CSS has a live reference left. The source-level checks are the regression
+ * guard — this comes back as somebody adding "just a little indicator". */
 {
   const fsChg = await import('node:fs/promises');
   const urlChg = await import('node:url');
   const readUi = (rel) => fsChg.readFile(urlChg.fileURLToPath(new URL('../' + rel, import.meta.url)), 'utf8');
 
   // ---- the strings themselves -------------------------------------------
-  ok(typeof S.hud.charges === 'function', 'strings.js carries hud.charges(n, cap)');
-  ok(typeof S.monitor.charges === 'function', 'and monitor.charges(n) for theirs');
-  ok(/\bcharges\b/.test(S.hud.charges(3, 5)), 'your line says the WORD charge, not a shape',
-    S.hud.charges(3, 5));
-  ok(S.hud.charges(3, 5).includes('3') && S.hud.charges(3, 5).includes('5'),
-    'and carries both the held count and the cap — the pips said the cap by being five',
-    S.hud.charges(3, 5));
-  ok(S.monitor.charges(1) === '1 charge' && S.monitor.charges(0) === '0 charges'
-    && S.monitor.charges(4) === '4 charges',
-    'their count pluralises, and never prints "1 charges" beside a live name',
-    [S.monitor.charges(1), S.monitor.charges(0), S.monitor.charges(4)].join(' | '));
-  ok(!/\//.test(S.monitor.charges(2)),
-    'their line omits the cap — their ceiling is not a number you can spend against',
-    S.monitor.charges(2));
+  ok(!('charges' in S.hud), 'strings.js has no hud.charges — the "3 / 5 charges" line is gone');
+  ok(!('charges' in S.monitor), 'and no monitor.charges for theirs either');
+  ok(!('charge' in S.toasts), 'and the never-called "+1 charge" toast went with them');
+  ok(!/charge/i.test(S.recap.chipEnduredNote),
+    'the recap endured chip stops promising them a charge', String(S.recap.chipEnduredNote));
+  ok(S.how.bullets.length === 6 && !S.how.bullets.some((b) => /charge/i.test(b)),
+    'and "how it works" is still six bullets, none of which teaches an economy that is gone',
+    S.how.bullets.filter((b) => /charge/i.test(b)).join(' | '));
 
   // ---- the mounted desk --------------------------------------------------
   const matchChg = makeFakeMatch();                 // scoring.charges starts at 3
@@ -1165,75 +1177,75 @@ function makeFakeMatch() {
   ok(findAll(hostChg, 'gg-pip').length === 0, 'the mounted HUD contains no .gg-pip node at all');
   ok(findAll(hostChg, 'gg-pips').length === 0, 'nor the row that held them');
   ok(findAll(hostChg, 'gg-mon-pips').length === 0, 'nor the monitor titlebar copy of it');
+  ok(findAll(hostChg, 'gg-charges').length === 0,
+    'and no .gg-charges line — the count that replaced the pips outlived them by one pass');
+  ok(findAll(hostChg, 'gg-mon-charges').length === 0, 'nor .gg-mon-charges in their titlebar');
+  ok(findAll(hostChg, 'gg-score').length > 0,
+    'the SCORE is still there — this took the meter, not the scorebox');
 
-  const chargeLine = findOne(hostChg, 'gg-charges');
-  ok(!!chargeLine, 'the scorebox carries one .gg-charges line instead');
-  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(3, GoonConsts.ChargeCap),
-    'painted from the engine on the very first paint, cap and all',
-    String(chargeLine && chargeLine.textContent));
-
-  const monLine = findOne(hostChg, 'gg-mon-charges');
-  ok(!!monLine, 'and their titlebar carries .gg-mon-charges');
-  ok(String(monLine && monLine.textContent).indexOf(S.monitor.charges(2)) >= 0,
-    'showing the count off match.opponent.charges (2 in the stub)',
-    String(monLine && monLine.textContent));
-
-  // ---- a GAIN: the number moves, and the juice the pips wore survives -----
+  // ---- a GAIN is now completely silent -----------------------------------
   audioChg.ids.length = 0;
   matchChg.scoring.charges = 4;
   await sleep(260);                                  // paintAll polls at 200ms
-  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(4, GoonConsts.ChargeCap),
-    'a gain repaints the line', String(chargeLine && chargeLine.textContent));
-  ok(audioChg.ids.includes('gg-charge'),
-    'and still plays gg-charge — the cue was never the pip, it was the charge',
-    audioChg.ids.join(','));
-  ok(findAll(hostChg, 'gg-plus1').length === 1,
-    'and still throws the floating "+1" chip, which is now the WHOLE flourish');
-
-  // ---- a SPEND: the number moves back, in silence ------------------------
-  await sleep(950);                                  // let the chip retire itself
-  ok(findAll(hostChg, 'gg-plus1').length === 0, 'the chip removes itself after its 900ms');
-  audioChg.ids.length = 0;
-  matchChg.scoring.charges = 1;
-  await sleep(260);
-  ok(String(chargeLine && chargeLine.textContent) === S.hud.charges(1, GoonConsts.ChargeCap),
-    'spending three on an item repaints the line down',
-    String(chargeLine && chargeLine.textContent));
-  ok(!audioChg.ids.includes('gg-charge'), 'and is silent — you only hear the ones you earn',
-    audioChg.ids.join(','));
-  ok(findAll(hostChg, 'gg-plus1').length === 0, 'with no "+1" on the way down');
-
-  // ---- an unchanged poll must not rewrite anything -----------------------
-  audioChg.ids.length = 0;
-  await sleep(260);
   ok(!audioChg.ids.includes('gg-charge'),
-    'and a poll that finds the same number does nothing at all — the memo still holds');
+    'banking a charge plays nothing — the cue had one caller and it went with the readout',
+    audioChg.ids.join(','));
+  ok(findAll(hostChg, 'gg-plus1').length === 0,
+    'and mints no floating "+1" chip: there is no number on screen for it to be about');
+  ok(findAll(hostChg, 'gg-charges').length === 0, 'and still no line, however the meter moves');
 
   hudChg.unmount();
-  ok(findAll(hostChg, 'gg-charges').length === 0, 'and unmount takes the line with it');
+
+  // ---- the arsenal: no price under a sticker, and no "need N" ------------
+  const matchArs = makeFakeMatch();
+  matchArs.scoring.charges = 0;                      // as broke as it is possible to be
+  const leftArs = document.createElement('div');
+  const rightArs = document.createElement('div');
+  const ars = arsenalMod.mountArsenal({ leftHost: leftArs, rightHost: rightArs, match: matchArs });
+  ok(findAll(leftArs, 'gg-cost-pip').length === 0 && findAll(rightArs, 'gg-cost-pip').length === 0,
+    'no tile carries a cost pip');
+  ok(findAll(leftArs, 'gg-item-cost').length === 0 && findAll(rightArs, 'gg-item-cost').length === 0,
+    'nor the row that held them');
+  // The heavy costs 3 and the player holds 0: the old code painted "need 3" and refused.
+  ars.armDrop('braindrain');
+  ok(ars.stateOf('braindrain') === 'ready',
+    'a 3-cost item on an EMPTY meter reads ready, not "need 3"', String(ars.stateOf('braindrain')));
+  const broke = ars.fire('braindrain');
+  ok(broke && broke.ok === true,
+    'and it FIRES — the owner request in one assertion', JSON.stringify(broke));
+  ars.unmount();
 
   // ---- the source, because that is where it regrows ----------------------
   const strip = (src) => src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
   for (const rel of ['ui/hud.js', 'ui/opponent.js']) {
     const code = strip(await readUi(rel));
-    ok(!/gg-pip/.test(code), `${rel} builds no gg-pip node (comments may name the dead class)`,
+    ok(!/gg-pip/.test(code), rel + ' builds no gg-pip node (comments may name the dead class)',
       (code.match(/.*gg-pip.*/) || [''])[0].trim());
+    ok(!/charges/.test(code), rel + ' reads no charge count out of the engine',
+      (code.match(/.*charges.*/) || [''])[0].trim());
   }
+  const arsCode = strip(await readUi('ui/arsenal.js'));
+  ok(!/scoring\.charges|gg-cost-pip|is-poor/.test(arsCode),
+    'ui/arsenal.js prices nothing and reads no balance',
+    (arsCode.match(/.*(scoring\.charges|gg-cost-pip|is-poor).*/) || [''])[0].trim());
 
-  /* The CSS half. Comments are allowed to name the class — the tombstone at the
-   * top of the score block does, on purpose — so this strips them first and then
-   * looks for a live SELECTOR. `.gg-cost-pip` is deliberately not caught by the
-   * word boundary: it is the arsenal's round amber cost dot, a different thing
-   * that was never part of the complaint, and it stays. */
+  /* The CSS half. Comments are allowed to name the class — the tombstones do, on
+   * purpose — so this strips them first and then looks for a live SELECTOR. */
   const cssChg = (await readUi('ui/hud.css')).replace(/\/\*[\s\S]*?\*\//g, '');
   ok(!/(^|[\s,{}])\.gg-pips?\b/.test(cssChg), 'hud.css has no live .gg-pip / .gg-pips rule',
     (cssChg.match(/.*\.gg-pips?\b.*/) || [''])[0].trim());
   ok(!/\.gg-pip--sm\b/.test(cssChg), 'and the small variant went with its one caller');
   ok(!/@keyframes\s+ggPipPop/.test(cssChg), 'and the pop keyframe has no pip left to bounce');
-  ok(/\.gg-cost-pip\s*\{/.test(cssChg),
-    'while the arsenal cost dots — round, amber, welded to their tile — are untouched');
-  ok(/\.gg-charges\s*\{/.test(cssChg) && /\.gg-mon-charges\s*\{/.test(cssChg),
-    'and both text readouts are styled');
+  ok(!/\.gg-cost-pip\b/.test(cssChg),
+    'the arsenal cost dots are gone too — the owner named them directly ("the Need 1/2/3 under '
+    + 'the throwables")', (cssChg.match(/.*\.gg-cost-pip\b.*/) || [''])[0].trim());
+  ok(!/\.gg-charges\b/.test(cssChg) && !/\.gg-mon-charges\b/.test(cssChg),
+    'and neither text readout is styled any more',
+    (cssChg.match(/.*\.gg-(mon-)?charges\b.*/) || [''])[0].trim());
+  ok(!/\.gg-plus1\b/.test(cssChg), 'nor the +1 chip that flourished them',
+    (cssChg.match(/.*\.gg-plus1\b.*/) || [''])[0].trim());
+  ok(/@keyframes\s+ggFloatUp/.test(cssChg),
+    'but ggFloatUp SURVIVES — two other rules still animate on it');
 }
 
 // -------------------------------------------------------- 3. closeness + emotes
@@ -2698,8 +2710,9 @@ const audioMod = await import('../ui/audio.js');
     'the prism and the effect bubbles have their own');
 
   ok(/sfx\('gg-drop'\)/.test(dropsSrc), 'ui/drops.js cues an armed drop');
-  ok((dropsSrc.match(/sfx\('gg-drop-dud'\)/g) || []).length === 2,
-    'and BOTH fizzle paths (no charge / arsenal full) cue the dud');
+  ok((dropsSrc.match(/sfx\('gg-drop-dud'\)/g) || []).length === 1,
+    'and the ONE fizzle path left (the arsenal already full) cues the dud — the other was '
+    + '"no charge", deleted 2026-08-05 with the requirement itself');
   ok(!/reason: 'miss'[^\n]*sfx\(/.test(dropsSrc),
     'a missed roll stays silent — most rolls miss');
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/arsenal.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/arsenal.js
@@ -3,26 +3,35 @@
  * gesture that turns an item into a payload aimed at the opponent's monitor.
  *
  * One tile per payload kind (plus the emote sheet opener). A tile is a BARE ITEM
- * IMAGE — a sticker cutout sitting on the desk, no plate, no border, no fill —
- * with its cost in tiny diamonds under it. It always says what state it is in
- * with a WORD, never colour alone:
+ * IMAGE — a sticker cutout sitting on the desk, no plate, no border, no fill.
+ * It always says what state it is in with a WORD, never colour alone:
  *
  *   locked     greyed sticker + "?" — you have not DROPPED one yet (see below)
- *   ready      full colour + a ×N stack badge; the priciest affordable one glows
- *   too poor   45% + amber pips; tap -> shake + "costs {n} — you have {m}"
+ *   ready      full colour + a ×N stack badge; the rarest one you hold glows
  *   cooling    conic sweep + the shared "next payload in {n}s" readout
  *   used       brain drain only, once per match: struck through
  *   filtered   hatched, "they can't receive this" (kind outside the peer caps)
  *   hidden     the kind is outside OUR OWN caps — the slot never renders
  *
- * THE DROP ECONOMY (2026-08-03 owner redesign). Items are NOT simply "affordable
- * or not" any more. Every slot starts LOCKED and lights up only when a popped
- * bubble drops it: exec/bubbles.js dispatches `gg-bubble-pop`, ui/drops.js rolls
- * it, and a hit calls armDrop(id) here. Firing consumes ONE stack; at zero the
- * slot goes back to locked. Charges remain the WIRE truth (the receiver still
- * validates "sender charges >= cost"), so ui/drops.js credits the charge before
- * it arms — charges beyond your armed stacks are just headroom, and a charge
- * earned by SURVIVING a payload never arms anything on its own.
+ * THERE IS NO "TOO POOR" STATE, AND NO COST PIPS (owner, 2026-08-05: "we still
+ * have the charge system in (you need 3 to do X etc), we should remove the
+ * requirement entirely (and the Need 1/2/3 under the throwables)"). A sixth
+ * state used to sit in that list — 45% opacity, a row of amber pips under the
+ * sticker, the word "need 3", and a tap that shook the tile and said "costs 3 —
+ * you have 1". It is gone at every layer: the tile paints no price, the fire
+ * path checks no balance, and the engine underneath stopped validating one on
+ * both sides of the wire (core/match.js). IF YOU ARE HOLDING IT, YOU CAN THROW
+ * IT — the only things that can still say no are the cooldown, the once-per-
+ * match heavy, and the peer's own caps.
+ *
+ * THE DROP ECONOMY IS WHAT SURVIVED, and it is now the whole economy. Every slot
+ * starts LOCKED and lights up only when a popped bubble drops it: exec/bubbles.js
+ * dispatches `gg-bubble-pop`, ui/drops.js rolls it against the heat gauge, and a
+ * hit calls armDrop(id) here. Firing consumes ONE stack; at zero the slot goes
+ * back to locked. So an item is EARNED, never bought, and the tile's ×N badge is
+ * the only inventory number left on the desk. `cost` survives on the record for
+ * exactly one reason — ui/drops.js weights the drop roll by 1/cost^1.6, which
+ * makes an expensive kind a RARE one — see droppable() at the foot of this file.
  *
  * The emote slot is social, costs nothing, and is therefore never locked and
  * never dropped (see needsArming()).
@@ -46,7 +55,8 @@ import { S } from './strings.js';
  * items go on the end and never renumber a finger that already knows the deck.
  * `durationMs` is the payload length we request; the engine clamps to
  * 1000..180000 so every one of these lands unchanged. `cost` is documentation
- * and a fallback only: costOf() is authority whenever it knows the kind.
+ * and a fallback only: costOf() is authority whenever it knows the kind. Since
+ * 2026-08-05 a cost is a RARITY WEIGHT, not a price — nothing is ever paid.
  *
  * THERE IS NO BUBBLE THROWABLE (owner, 2026-08-04). BubbleSwarm used to sit here
  * as a 1-charge sticker, from before bubbles became the ALWAYS-ON baseline field
@@ -77,8 +87,9 @@ const PAYLOAD_ITEMS = ARSENAL_ITEMS.filter((i) => i.kind !== null);
  *
  * A free slot (the emote sheet: no kind, no cost) never locks and never drops —
  * chatting at someone is social, not economy. The rule is written against the
- * COST rather than against the id, so the day emote grows a price it joins the
- * drop pool with everything else and nothing here needs editing.
+ * COST rather than against the id, so the day emote grows a cost it joins the
+ * drop pool with everything else and nothing here needs editing. (A cost is a
+ * drop WEIGHT now, not a price; zero still means "outside the drop pool".)
  *
  * @param {object} item ARSENAL_ITEMS entry
  * @param {number} cost resolved cost (costOf is authority; see buildTile)
@@ -191,7 +202,10 @@ function receiptWord(status) {
   switch (status) {
     case GoonReceiptStatus.Accepted: return { word: 'landed', tone: 'ok' };
     case GoonReceiptStatus.Completed: return { word: 'landed', tone: 'ok' };
-    case GoonReceiptStatus.Survived: return { word: 'endured', tone: 'gold', note: '+1 charge for them' };
+    // 'endured' carried the note "+1 charge for them" until 2026-08-05. It was
+    // true and it is not any more — enduring buys them nothing, because nothing
+    // is bought. The word is the whole story: they rode it out.
+    case GoonReceiptStatus.Survived: return { word: 'endured', tone: 'gold', note: 'they rode it out' };
     case GoonReceiptStatus.RejectedRate: return { word: 'too soon', tone: 'warn' };
     case GoonReceiptStatus.RejectedFiltered: return { word: 'blocked', tone: 'warn' };
     default: return { word: String(status || 'sent'), tone: 'dim' };
@@ -244,8 +258,8 @@ export function mountArsenal({
   function buildTile(item, host) {
     if (!host) return null;
     // costOf is authority; the item's own `cost` only covers a kind the shared
-    // contract has not landed yet (it returns Infinity for those, which would
-    // otherwise pin the tile at "too poor" forever).
+    // contract has not landed yet (it returns Infinity for those, and an
+    // Infinity weight would take that item out of the drop roll entirely).
     const known = item.kind === null ? 0 : costOf(item.kind);
     const cost = item.kind === null ? 0 : (Number.isFinite(known) ? known : (item.cost | 0));
     // NO PLATE: the item art IS the button. Chrome would fight the sticker cutouts.
@@ -267,9 +281,12 @@ export function mountArsenal({
     const fallbackArt = add(root, el('i', 'gg-item-fallback'));
     if (fallbackArt) fallbackArt.setAttribute && fallbackArt.setAttribute('aria-hidden', 'true');
     const nameEl = add(root, el('span', 'gg-item-name', item.label));
-    const pipRow = add(root, el('span', 'gg-item-cost'));
-    const costPips = [];
-    for (let i = 0; i < cost; i++) costPips.push(add(pipRow, el('i', 'gg-cost-pip')));
+    /* NO PRICE ROW. `.gg-item-cost` held one round amber `.gg-cost-pip` per
+       charge the item cost, and paint() lit them all when you could not afford
+       it. The owner removed the requirement on 2026-08-05, so a price under a
+       sticker is a number about nothing — the tile is holding it or it is not,
+       and the ×N badge says which. Nothing is built here any more; the CSS
+       tombstone is in ui/hud.css. */
     const stateEl = add(root, el('span', 'gg-item-state'));
     const sweep = add(root, el('i', 'gg-item-sweep'));
     // The economy chrome: a "?" while the slot is locked, a ×N badge once it is
@@ -283,7 +300,7 @@ export function mountArsenal({
 
     add(host, root);
     const rec = {
-      item, cost, root, img, fallbackArt, nameEl, pipRow, costPips, stateEl, sweep,
+      item, cost, root, img, fallbackArt, nameEl, stateEl, sweep,
       lockEl, stackEl, tip,
       state: 'ready', tipTimer: 0,
       needsArm: needsArming(item, cost),
@@ -296,10 +313,11 @@ export function mountArsenal({
 
   // ------------------------------------------------------------- state pass
 
-  function charges() {
-    const s = match && match.scoring;
-    return s ? (s.charges | 0) : 0;
-  }
+  /* `charges()` used to live here — `match.scoring.charges | 0`, read by paint()
+     for the "too poor" state, by the glow picker and by the refusal message.
+     Deleted with the requirement (2026-08-05). The meter still exists in the
+     engine and still rides the state tick; this file no longer has an opinion
+     about it, and re-adding a reader here would be re-adding the gate. */
 
   function peerCanTake(kind) {
     const list = match && match.availablePayloadKinds;
@@ -318,18 +336,20 @@ export function mountArsenal({
   }
 
   function paint() {
-    const have = charges();
     const coolMs = cool.msLeft();
     const cooling = coolMs > 0;
 
-    // The priciest ARMED + affordable tile earns the glow — "you could spend
-    // this". A locked tile never glows: there is nothing there to spend yet.
+    // The RAREST thing you are holding earns the glow — "this is the good one,
+    // and it is available". It used to read "the priciest one you can currently
+    // afford", which is the same tile whenever you could afford anything; with
+    // affordability gone the highest cost is simply the rarest drop, and that is
+    // the tile worth pointing at. A locked tile never glows: you do not have it.
     let glowId = null;
     let glowCost = -1;
     for (const rec of tiles.values()) {
       if (rec.item.kind === null) continue;
       if (rec.needsArm && rec.armed <= 0) continue;
-      if (rec.cost <= have && rec.cost > glowCost && peerCanTake(rec.item.kind)) { glowCost = rec.cost; glowId = rec.item.id; }
+      if (rec.cost > glowCost && peerCanTake(rec.item.kind)) { glowCost = rec.cost; glowId = rec.item.id; }
     }
 
     for (const rec of tiles.values()) {
@@ -346,13 +366,14 @@ export function mountArsenal({
       if (isSpent(rec)) { state = 'used'; word = 'used'; }
       else if (!peerCanTake(item.kind)) { state = 'filtered'; word = "they can't receive this"; }
       else if (rec.armed <= 0) { state = 'locked'; word = S.arsenal.locked; }
-      else if (rec.cost > have) { state = 'poor'; word = 'need ' + rec.cost; }
       else if (cooling) { state = 'cooling'; word = 'cooling'; }
+      /* `else if (rec.cost > have) { state = 'poor'; word = 'need ' + rec.cost; }`
+         was the "Need 1/2/3" the owner named. Removed 2026-08-05: an item you are
+         holding is an item you can throw. */
 
       setState(rec, state, word);
       paintStack(rec);
       cls(rec.root, 'is-glow', state === 'ready' && item.id === glowId);
-      for (const pip of rec.costPips) cls(pip, 'is-short', state === 'poor');
       if (rec.sweep && rec.sweep.style) {
         const pct = cooling ? Math.max(0, Math.min(100, 100 - (coolMs / GoonConsts.PayloadMinGapMs) * 100)) : 100;
         rec.sweep.style.setProperty && rec.sweep.style.setProperty('--gg-sweep', pct.toFixed(1) + '%');
@@ -368,7 +389,8 @@ export function mountArsenal({
 
   function setState(rec, state, word) {
     if (rec.state !== state) {
-      for (const s of ['ready', 'poor', 'cooling', 'used', 'filtered', 'locked']) cls(rec.root, 'is-' + s, s === state);
+      // ('poor' left this list on 2026-08-05 with the charge requirement.)
+      for (const s of ['ready', 'cooling', 'used', 'filtered', 'locked']) cls(rec.root, 'is-' + s, s === state);
       rec.state = state;
     }
     text(rec.stateEl, word);
@@ -424,7 +446,8 @@ export function mountArsenal({
     // LOCKED outranks every other refusal: nothing else about the tile matters
     // until a bubble has dropped one.
     if (rec.needsArm && rec.armed <= 0) { refuse(rec, S.arsenal.lockedTip); return { ok: false, error: 'locked', id: null }; }
-    if (rec.state === 'poor') { refuse(rec, 'costs ' + rec.cost + ' — you have ' + charges()); return { ok: false, error: 'charges', id: null }; }
+    /* The affordability refusal stood next — shake + "costs 3 — you have 1" +
+       {error:'charges'}. Gone 2026-08-05: there is no balance to be short of. */
     if (rec.state === 'filtered') { refuse(rec, "they can't receive this"); return { ok: false, error: 'filtered', id: null }; }
     if (rec.state === 'used') { refuse(rec, 'one brain drain a match'); return { ok: false, error: 'used', id: null }; }
     if (rec.state === 'cooling') { refuse(rec, 'next payload in ' + Math.ceil(cool.msLeft() / 1000) + 's'); return { ok: false, error: 'cooling', id: null }; }
@@ -493,6 +516,9 @@ export function mountArsenal({
    * caps are dropped here, and a spent heavy is dropped here too — arming an
    * item that can never be fired is a dead drop.
    *
+   * `cost` rides along because it is the roller's RARITY WEIGHT (1/cost^1.6):
+   * it is the last consumer of the number now that nothing is bought with it.
+   *
    * @returns {Array<{id:string, kind:number, cost:number, armed:number}>}
    */
   function droppable() {
@@ -507,9 +533,10 @@ export function mountArsenal({
   }
 
   /**
-   * Arm one (or `count`) of an item. THE only way a slot leaves `locked`.
-   * ui/drops.js calls this AFTER match.creditCharges() said yes, so the wire
-   * truth (charges) and the local truth (stacks) can never disagree.
+   * Arm one (or `count`) of an item. THE only way a slot leaves `locked`, and
+   * since 2026-08-05 the only inventory there is: ui/drops.js used to credit a
+   * charge first so the receiver would believe the shot, and there is nothing
+   * left to believe — the stack IS the truth.
    *
    * @param {string} id ARSENAL_ITEMS id
    * @param {{count?:number, from?:{x:number,y:number}|null, silent?:boolean}} [o]
@@ -530,7 +557,7 @@ export function mountArsenal({
     return rec ? (rec.armed | 0) : 0;
   }
 
-  /** Current tile state word ('locked' | 'ready' | 'poor' | ...), for tests/HUD. */
+  /** Current tile state word ('locked' | 'ready' | 'cooling' | ...), for tests/HUD. */
   function stateOf(id) {
     const rec = tiles.get(id);
     return rec ? rec.state : null;
@@ -765,10 +792,12 @@ export function mountArsenal({
   }
   sub('onPayloadReceiptReceived', onReceipt);
   sub('onPhaseChanged', () => paint());
-  if (match && match.scoring && typeof match.scoring.onChargesChanged === 'function') {
-    const off = match.scoring.onChargesChanged(() => paint());
-    led.add(typeof off === 'function' ? off : null);
-  }
+  /* THE CHARGE SUBSCRIPTION IS GONE (2026-08-05). `match.scoring.onChargesChanged(paint)` sat
+     here so a tile could leave "too poor" the instant a charge landed. No tile state depends on
+     the meter any more, so the repaint it bought is the repaint the 250 ms poll below already
+     does — and a live subscription to a number this file no longer reads is exactly the sort of
+     thing that gets re-wired into a gate by accident. The engine's seam stays; we just do not
+     listen. */
   led.interval(250, () => { try { paint(); } catch (_e) { /* never break the HUD */ } });
   paint();
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/audio.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/audio.js
@@ -35,7 +35,7 @@
  * TWO CUE BUSES, because "sfx" was one slider over two different jobs. `ui` is
  * the chrome you drive — menu ticks, the code cells, the lamps — and `game` is
  * everything that happens to you inside a match: the draft, the countdown,
- * charges, drops, payloads, bubbles, the recap. A player who wants the match
+ * drops, payloads, bubbles, the recap. A player who wants the match
  * loud and the menus quiet (or the reverse, on a phone at 2am) could not say so
  * with one number. Every SFX_REGISTRY entry declares which one it is on.
  *
@@ -184,9 +184,12 @@ export const SFX_REGISTRY = Object.freeze({
   'gg-tick':        gameCue({ files: [L('verify-tick-1.mp3'), L('verify-tick-2.mp3')], gain: 0.26 }),
   'gg-go':          gameCue({ files: [L('verify-resolve-1.mp3')],  gain: 0.50 }),
 
-  /* ---- the economy -------------------------------------------------- game - */
-  'gg-charge':      gameCue({ files: [L('chime-1.mp3')],           gain: 0.30 }),
-  'charge-earned':  gameCue({ files: [L('chime-1.mp3')],           gain: 0.30 }),
+  /* ---- the economy -------------------------------------------------- game -
+     `gg-charge` and its older alias `charge-earned` (both chime-1.mp3 at 0.30)
+     headed this block: the ding for banking a charge. Removed 2026-08-05 when
+     the owner deleted the charge requirement — ui/hud.js was the only caller and
+     its whole charge readout went with it. The loop keeps its payoff ding one
+     line down, which is the one players are actually listening for. */
   /** A bubble dropped an item and the slot lit up. The payoff cue of the loop. */
   'gg-drop':        gameCue({ files: [L('slip_dling.mp3')],        gain: 0.42 }),
   /** ...and the same roll refused because the arsenal is already full. A dud. */

--- a/ConditioningControlPanel/Resources/web/goon/ui/drops.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/drops.js
@@ -6,8 +6,8 @@
  *   exec/bubbles.js   dispatches `gg-bubble-pop` {kind, worth, payload, size}
  *   ui/hud.js         hears it and hands the detail to this roller
  *   THIS FILE         adds heat, rolls the chance the heat bought, picks a
- *                     payload kind, credits the charge, arms the slot, and
- *                     spends a chunk of the heat back
+ *                     payload kind, arms the slot, and spends a chunk of the
+ *                     heat back
  *   ui/arsenal.js     lights the sticker up and counts the stack
  *   ui/hud.js         paints the gauge off `roller.heat`
  *
@@ -34,15 +34,27 @@
  * how often you actually get something. Retune the shape freely; move that
  * ratio only when you mean to move the economy.
  *
- * WHY THE CHARGE STILL MATTERS. Charges are the WIRE truth: the receiving side
- * validates "sender charges >= cost" and rejects anything it does not believe,
- * so an armed sticker with no charge behind it would fire into a rejection. A
- * drop therefore credits `match.creditCharges(cost, 'bubble-drop')` FIRST and
- * only arms if the engine said yes (it refuses outside Live and clamps at the
- * cap). Charges earned the old way — by SURVIVING what they sent you — still
- * accrue, they just do not arm anything: they are headroom, not inventory.
- * A roll the engine or a full arsenal refuses does NOT spend heat: the player
- * got nothing, so the gauge keeps what it earned.
+ * THE CHARGE NO LONGER MATTERS (owner, 2026-08-05: "we should remove the
+ * requirement entirely"). A drop used to call `match.creditCharges(cost,
+ * 'bubble-drop')` FIRST and arm only if the engine said yes, for one reason: the
+ * RECEIVER validated "sender charges >= cost" and would have bounced a shot
+ * fired off an empty meter. With that validation deleted on both sides of the
+ * wire, the credit was a payment into an account nobody audits — so the call is
+ * gone and this roller talks to the arsenal alone. THE DROP IS THE WHOLE GRANT.
+ *
+ * (Worth being precise about what that gate ever was: `creditCharges` returns
+ * true for any integer >= 1 while the phase is Live and silently discards
+ * overflow at the cap, so it never once refused a drop for want of charges. It
+ * refused for being outside Live — which is the `isLive()` check in onPop, six
+ * lines above where the credit used to sit. The economy was a phase check in a
+ * costume, and the honest version of it is the one that is left.)
+ *
+ * A roll a full arsenal refuses does NOT spend heat: the player got nothing, so
+ * the gauge keeps what it earned.
+ *
+ * WHAT A COST IS NOW: purely a RARITY WEIGHT. weightOf() below prices the pick
+ * at 1/cost^COST_BIAS, so brain drain (3) is rare and a flash (1) is common.
+ * That is the only surviving consumer of the number in the whole client.
  *
  * RANDOMNESS. Plain Math.random on purpose. This is client-local economy, it
  * crosses no wire and it is not part of the deterministic engine RNG (core/rng
@@ -155,7 +167,7 @@ export function pickDrop(candidates, roll) {
 
 /**
  * @param {object}   o
- * @param {object}   o.match      GoonMatchService (creditCharges + phase)
+ * @param {object}   o.match      GoonMatchService (read for `phase` and nothing else)
  * @param {object}   o.arsenal    mountArsenal handle (droppable/armDrop)
  * @param {object}   [o.audio]
  * @param {Function} [o.onLog]
@@ -196,9 +208,10 @@ export function createDropRoller({ match, arsenal, audio = null, onLog = null, r
 
   /** The roll has exactly two audible outcomes: a slot lit up ('gg-drop', the
    *  payoff ding of the whole loop) or the roll WON and could not be taken —
-   *  no charge, or the arsenal already full ('gg-drop-dud', a small nothing).
-   *  A miss stays silent: most rolls miss, and a sound for "nothing happened"
-   *  would be the loudest thing in the match. */
+   *  the arsenal was already full of that item ('gg-drop-dud', a small nothing;
+   *  "no charge" was the other way to get here until 2026-08-05). A miss stays
+   *  silent: most rolls miss, and a sound for "nothing happened" would be the
+   *  loudest thing in the match. */
   const sfx = (id) => {
     try { if (audio && typeof audio.sfx === 'function') audio.sfx(id); } catch (_e) { /* stub */ }
   };
@@ -208,16 +221,10 @@ export function createDropRoller({ match, arsenal, audio = null, onLog = null, r
     return p === GoonMatchPhase.Live || p === GoonMatchPhase.SuddenDeath;
   }
 
-  /**
-   * Credit the charge the item will cost to fire. Returns true when the arsenal
-   * may arm. Until core/match.js publishes the seam this degrades to "yes" so
-   * the loop is playable today; the moment it lands, the engine is authority.
-   */
-  function credit(cost) {
-    if (!match || typeof match.creditCharges !== 'function') return true;
-    try { return match.creditCharges(cost | 0, 'bubble-drop') === true; }
-    catch (_e) { return false; }
-  }
+  /* `credit(cost)` stood here: one call to match.creditCharges() whose boolean
+     decided whether the slot was allowed to arm. See the header — the charge it
+     paid buys nothing since 2026-08-05, and the only thing it ever actually
+     enforced is the isLive() check that is already in onPop. */
 
   /**
    * One pop. Safe to call with anything: a malformed detail is a no-op.
@@ -243,7 +250,6 @@ export function createDropRoller({ match, arsenal, audio = null, onLog = null, r
 
     const pick = pickDrop(arsenal.droppable(), rnd());
     if (!pick) return { dropped: false, id: null, reason: 'no-candidate', heat: hot };
-    if (!credit(pick.cost)) { stats.refused++; sfx('gg-drop-dud'); return { dropped: false, id: null, reason: 'no-charge', heat: hot }; }
 
     const from = (typeof d.x === 'number' && typeof d.y === 'number') ? { x: d.x, y: d.y } : null;
     const armed = arsenal.armDrop(pick.id, { count: DROP_TUNING.STACK_PER_DROP, from });

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -99,10 +99,12 @@
  * monitor and the arsenal. One bit (ui/hud.js HUD_ZEN_CLASS/HUD_ZEN_ATTR), every
  * hide below it, nothing in JS.
  *
- * WHAT GOES: the score + its +1 flourish, your name plate, the closeness dial,
- * the closeness THEY claim, the live-effect chips and MERCY.
- * WHAT STAYS: the monitor, the rails, the charge count (it is the arsenal's
- * currency, not a readout), the timer, the attention ring and the toggle itself.
+ * WHAT GOES: the score, your name plate, the closeness dial, the closeness THEY
+ * claim, the live-effect chips and MERCY.
+ * WHAT STAYS: the monitor, the rails, the timer, the attention ring and the
+ * toggle itself. (The charge count used to be on the STAYS list, as "the
+ * arsenal's currency, not a readout". There is no currency and no count since
+ * 2026-08-05 — see the tombstone at the top bar.)
  *
  * THE TWO ADDED 2026-08-04 (owner: "we need space to see the animations"):
  *   .gg-mon-close   the "they claim / warm" panel. It is the opponent's half of
@@ -123,8 +125,9 @@
  * the layer is restored by the same button that took it away, and Escape
  * concedes throughout (boot.js's ladder calls declareMercy() directly).
  * ------------------------------------------------------------------------ */
+/* (`.gg-hud--zen .gg-plus1` was the second line of this list. The chip it hid
+   was deleted on 2026-08-05 with the charge readout it belonged to.) */
 .gg-hud-frame.gg-hud--zen .gg-score,
-.gg-hud-frame.gg-hud--zen .gg-plus1,
 .gg-hud-frame.gg-hud--zen .gg-me,
 .gg-hud-frame.gg-hud--zen .gg-dial-host,
 .gg-hud-frame.gg-hud--zen .gg-mon-close,
@@ -161,37 +164,25 @@ html[data-gg-zen="on"] #gg-mercy .gg-mercy-wrap { display: none; }
    ui/hud.js builds no such node, so do not restyle one back into being. */
 .gg-me { font-size: 0.68rem; color: var(--gg-text-3); }
 
-/* THE CHARGE PIPS ARE GONE (2026-08-05). `.gg-pips` / `.gg-pip` / `.gg-pip--sm`
-   and @keyframes ggPipPop drew five 16px squares rotated 45° — outline for the
-   cap, filled pink for what you held — under the score here and, at 12px, in the
+/* THE CHARGE READOUT IS GONE, IN TWO STEPS ON THE SAME DAY (2026-08-05).
+   STEP ONE took the SHAPE: `.gg-pips` / `.gg-pip` / `.gg-pip--sm` and
+   @keyframes ggPipPop drew five 16px squares rotated 45° — outline for the cap,
+   filled pink for what you held — under the score here and, at 12px, in the
    opponent monitor's titlebar. The owner asked twice for "the little yellow
-   squares" to go: the risk pips went in the first pass and these read as the
-   same indicator to anyone not holding the source, which is everyone.
-   ui/hud.js and ui/opponent.js now print the count in words instead (.gg-charges
-   and .gg-mon-charges below), so THE DIAMOND IS NOT A SHAPE THIS UI USES ANY
-   MORE. Do not reintroduce one for a count — a rotated square in this app has a
-   history, and the next person to see it will read it as the risk meter.
-   (The arsenal's `.gg-cost-pip` is a different thing and stays: round, amber,
-   welded to the tile whose price it is, and never part of this complaint.) */
-.gg-charges {
-  font-size: 0.68rem;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.02em;
-  color: var(--gg-text-2);
-}
-/* The charge-gain flourish, and the WHOLE flourish since the pips went — it used
-   to land at top:1.4rem, on the pip row, where covering an outline for 900ms
-   cost nothing. That row is a SENTENCE now and a chip parked on top of it is a
-   readout you cannot read, so the chip moved up beside the score instead: 3.2rem
-   clears five tabular digits at 1.35rem bold, and it floats away from the count
-   rather than across it. */
-.gg-plus1 {
-  position: absolute; left: 3.2rem; top: 0.15rem;
-  font-size: 0.8rem; font-weight: 700; color: var(--gg-pink);
-  text-shadow: 0 0 12px rgba(var(--gg-pink-rgb), 0.7);
-  animation: ggFloatUp .9s ease-out forwards;
-  pointer-events: none;
-}
+   squares" to go. THE DIAMOND IS NOT A SHAPE THIS UI USES ANY MORE: do not
+   reintroduce one for a count, because a rotated square in this app has a
+   history and the next person to see it will read it as the risk meter.
+   STEP TWO took the DATA. `.gg-charges` ("3 / 5 charges") and, in the monitor
+   titlebar, `.gg-mon-charges` replaced the pips in the morning and were deleted
+   the same evening, when the owner removed the charge REQUIREMENT itself. A
+   charge now gates nothing, so both were counting something that decides
+   nothing — the audit is in ui/hud.js's top-bar note. Neither file builds the
+   node; there is nothing left on this desk for these rules to style.
+   `.gg-plus1` (position:absolute, floated up beside the score) went with them:
+   it was the +1 flourish for a charge gain and had no other producer. NOTE
+   @keyframes ggFloatUp SURVIVES — two other rules in this file animate on it.
+   The arsenal's amber `.gg-cost-pip` price dots went in the same pass; their
+   tombstone is down at the item rail. */
 @keyframes ggFloatUp {
   from { opacity: 1; transform: translateY(0); }
   to { opacity: 0; transform: translateY(-22px); }
@@ -562,13 +553,13 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
 }
 
 .gg-item-name { font-size: 0.6rem; letter-spacing: 0.04em; color: var(--gg-text-2); text-align: center; }
-.gg-item-cost { display: flex; gap: 3px; }
-.gg-cost-pip {
-  width: 7px; height: 7px; transform: rotate(45deg); border-radius: 2px;
-  background: var(--gg-pink);
-  box-shadow: 0 0 6px rgba(var(--gg-pink-rgb), 0.5);
-}
-.gg-cost-pip.is-short { background: var(--gg-amber); box-shadow: 0 0 6px rgba(255, 180, 84, 0.5); }
+/* THE PRICE ROW IS GONE (2026-08-05). `.gg-item-cost` was a flex row of one
+   `.gg-cost-pip` per charge the item cost — 7px, pink, and amber (`.is-short`)
+   on a tile you could not afford. The owner named it directly: "remove the
+   requirement entirely (and the Need 1/2/3 under the throwables)". Nothing is
+   priced any more, so a price under a sticker would be a number about nothing.
+   ui/arsenal.js builds neither node. A tile now says only what it IS and what
+   state it is in, and its inventory is the ×N stack badge. */
 .gg-item-state { font-size: 0.55rem; color: var(--gg-text-4); text-align: center; min-height: 0.7em; line-height: 1.1; }
 
 /* reach states — a glow on the alpha, never an outline box */
@@ -590,11 +581,13 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.55)) drop-shadow(0 0 16px rgba(var(--gg-pink-rgb), 0.95)) brightness(1.08);
 }
 
-/* out-of-reach states — desaturate + dim, on top of the word */
-.gg-item.is-poor,
+/* out-of-reach states — desaturate + dim, on top of the word.
+   `.gg-item.is-poor` (too few charges) headed this list until 2026-08-05: the
+   state does not exist any more, because holding an item is the whole of being
+   able to throw it. The three that are left are all real refusals — spent
+   heavy, kind the peer cannot receive, cooldown. */
 .gg-item.is-used,
 .gg-item.is-filtered { opacity: 0.5; }
-.gg-item.is-poor .gg-item-img, .gg-item.is-poor .gg-item-fallback,
 .gg-item.is-used .gg-item-img, .gg-item.is-used .gg-item-fallback,
 .gg-item.is-filtered .gg-item-img, .gg-item.is-filtered .gg-item-fallback,
 .gg-item.is-cooling .gg-item-img, .gg-item.is-cooling .gg-item-fallback {
@@ -1004,15 +997,13 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
 .gg-mon-dot.is-gone { background: #6d6d78; box-shadow: none; }
 /* `min-width: 0` is what lets the ellipsis actually happen: without it a
    nowrap name is a flex item that refuses to be narrower than its own text, and
-   it pushes the score and the charge count off the end of the head row. */
+   it pushes the score off the end of the head row. */
 .gg-mon-name { color: var(--gg-text-1); font-weight: 600; max-width: 9rem; min-width: 0; flex: 0 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gg-mon-score { margin-left: auto; padding-left: 0.3rem; font-variant-numeric: tabular-nums; color: var(--gg-text-2); flex: 0 0 auto; }
-/* Their charges, in words since 2026-08-05 (this was `.gg-mon-pips`, five 12px
-   diamonds — see the tombstone up at .gg-charges). `white-space: nowrap` because
-   this is the LAST item in the narrowest row in the layout: the name has the
-   ellipsis budget and this must never be the thing that wraps the titlebar into
-   two lines, which would move the grip out from under a finger mid-drag. */
-.gg-mon-charges { flex: 0 0 auto; white-space: nowrap; font-variant-numeric: tabular-nums; color: var(--gg-text-3); }
+/* `.gg-mon-charges` stood here — their charge count, in words for one morning
+   and as `.gg-mon-pips` (five 12px diamonds) before that. Deleted the same
+   evening with the requirement itself; the score above is now the last item in
+   this row. See the tombstone up at the top bar. */
 
 /* THE MONITOR FRAME, AND THE FOUR NUMBERS EVERYTHING INSIDE IT IS MEASURED FROM.
  *
@@ -2232,12 +2223,9 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-hud-top > * { min-width: 0; }
   .gg-scorebox { min-width: 0; }
   .gg-me { overflow-wrap: anywhere; }
-  /* The charge line is a SENTENCE now, not a 104px row of diamonds (2026-08-05),
-     which is part of why the score column can be the compressible track: text
-     wraps where a flex row of fixed-size pips could only overflow. Both counts
-     shrink a notch on a phone and neither goes below legible. */
-  .gg-charges { font-size: 0.64rem; }
-  .gg-mon-charges { font-size: 0.64rem; }
+  /* (`.gg-charges` and `.gg-mon-charges` each dropped to 0.64rem here. Both
+     readouts were deleted on 2026-08-05 — the score column is simply narrower
+     than the measurements above assume now, which is slack, not a problem.) */
   .gg-timer { min-width: 92px; padding: 0.35rem 0.6rem 0.45rem; }
   .gg-hud-topright { gap: 0.35rem; }
   .gg-att { gap: 0.4rem; padding: 0.3rem 0.45rem; }
@@ -2312,7 +2300,7 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-item-img, .gg-item-fallback { width: 92%; max-width: 42px; }
   .gg-item-name { font-size: 0.5rem; letter-spacing: 0.01em; line-height: 1.15; }
   .gg-item-state { font-size: 0.5rem; min-height: 0; line-height: 1.15; }
-  .gg-cost-pip { width: 5px; height: 5px; }
+  /* (`.gg-cost-pip` shrank to 5px here; the price row was deleted 2026-08-05.) */
   .gg-item-lock { font-size: 0.95rem; }
   /* "locked" was a full text line under five of the nine tiles. On a phone the
      lock is the "?" badge and the full desaturation instead — but the WORD is
@@ -2410,10 +2398,10 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   .gg-sd-track.is-close .gg-sd-notch.is-end,
   .gg-timer.is-urgent .gg-timer-clock { animation: none !important; }
   /* `.gg-pip.is-pop` used to head this list — the charge pips' 1.55x scale
-     bounce. It went with the pips themselves on 2026-08-05, and the flourish
-     that replaced nothing (the `.gg-plus1` chip) is unchanged: it was never in
-     this block, because a chip that floats 22px and deletes itself is the
-     feedback, not decoration on top of it. */
+     bounce. It went with the pips themselves on 2026-08-05, and the `.gg-plus1`
+     chip that briefly replaced it went the same evening with the whole charge
+     readout. Neither was ever listed in this block: a chip that floats 22px and
+     deletes itself is the feedback, not decoration on top of it. */
   .gg-item.is-shake, .gg-sd-card.is-slip { animation: none !important; }
   /* the drawer still ARRIVES and the handle still lights — they just stop
      moving. Neither animation has a fill-mode, so removing it lands both nodes

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -4,7 +4,7 @@
  * Composes the live-match HUD inside #gg-hud and owns the layout grid:
  *
  *   ┌ top ────────────────────────────────────────────────────────────────┐
- *   │ score · charges               11:47 ▮▮▯▯▯      attention  ⊟  ⚙      │
+ *   │ score                         11:47 ▮▮▯▯▯      attention  ⊟  ⚙      │
  *   ├ body ───────────────────────────────────────────────────────────────┤
  *   │ ┌ arsenal ──┐◂                                            [monitor] │
  *   │ │ HEAT ▰▰▱  │      (the stage well — never covered)       [receipts]│
@@ -324,7 +324,6 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
 
   const scoreBox = add(top, el('div', 'gg-scorebox'));
   const scoreEl = add(scoreBox, el('div', 'gg-score', '0'));
-  const chargeEl = add(scoreBox, el('div', 'gg-charges', S.hud.charges(0, GoonConsts.ChargeCap)));
 
   /* NO SCORE-MULTIPLIER READOUT (owner, 2026-08-05: "the risk level indicator
    * is not intuitive — the heat gauge already does the job").
@@ -344,29 +343,35 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
    * change. The score in the line above is the multiplier's whole visible
    * effect, which is the part a player could ever act on.
    *
-   * AND THE CHARGE PIPS WENT TOO (owner, 2026-08-05, second pass: "the little
-   * yellow squares that we were supposed to have removed"). The first pass kept
-   * them on the argument that they are NOT the risk indicator — they are what
-   * you are holding to throw, the wire validates throws against them and the
-   * arsenal pays its costs out of them, so they were real and load-bearing in a
-   * way the multiplier never was. That argument was about the DATA and the
-   * owner's complaint was about the SHAPE. A row of five rotated squares under
-   * the score is indistinguishable, on a phone, from the row of rotated squares
-   * that had just been taken off the draft tiles: the player cannot tell "your
-   * ammunition" from "the risk meter you asked me to delete" by looking, and
-   * being right about the difference does not help them at arm's length.
+   * AND THE CHARGE READOUT IS GONE AS WELL (owner, 2026-08-05, third pass: "we
+   * still have the charge system in (you need 3 to do X etc), we should remove
+   * the requirement entirely"). This is the end of a three-step demolition and
+   * the steps matter, because the last one is not a styling decision:
    *
-   * So the DATA stays and the SHAPE goes: one small line, "3 / 5 charges", in
-   * words. It is strictly more legible than the pips ever were — it survives a
-   * squint, it reads aloud, it does not depend on a fill colour, and it says the
-   * cap out loud instead of asking you to count outlines to find it. There is no
-   * diamond left anywhere in this HUD; the only pips on the desk now are the
-   * arsenal's amber `.gg-cost-pip` cost dots, which are round, attached to the
-   * tile whose price they are, and were never part of this complaint.
+   *   1. the charge PIPS came out (same day, second pass) and were replaced by
+   *      `.gg-charges`, one line reading "3 / 5 charges". The DATA was kept on
+   *      the argument that it was real: the wire validated throws against it and
+   *      the arsenal paid its costs out of it.
+   *   2. the owner then removed the REQUIREMENT itself. Nothing validates a
+   *      throw against the meter any more (core/match.js, both directions) and
+   *      no tile is priced (ui/arsenal.js).
+   *   3. which retired the argument that kept the line alive. So the line went.
    *
-   * THE GAIN JUICE SURVIVES INTACT — sfx('gg-charge') and the floating "+1"
-   * chip both still fire in paintCharges(). Only the per-pip pop animation died
-   * with the pips, because there is no longer a pip to pop. */
+   * WHAT CHARGES FEED, checked before deleting rather than assumed: the score is
+   * seconds x riskMultiplier x attentionMultiplier and never touches them; the
+   * recap reads `snapshot().score`, not `chargesEarned`/`chargesSpent` (nothing
+   * in the client reads either); the drop economy is paced by HEAT and picks by
+   * COST-AS-RARITY, and its old `creditCharges` gate could never actually refuse
+   * for want of charges; and enduring a payload still credits one, to nothing.
+   * The honest answer is NOTHING, and a number that feeds nothing is worse than
+   * no number — a player who reads "1 / 3 charges" beside a tile they can throw
+   * has been told they are short of something. The engine's meter is untouched
+   * and still rides `tick.charges`; this desk simply has no opinion on it.
+   *
+   * THE "+1" CHIP AND sfx('gg-charge') WENT WITH IT. They were the gain flourish
+   * for this readout and nothing else. The reward loop the player actually plays
+   * is unchanged and lives one row down: pop -> heat gauge climbs -> 'gg-drop'
+   * dings -> a sticker lights up with "+1 flash" and a ×N badge. */
 
   const timerBox = add(top, el('div', 'gg-timer gg-plate'));
   const timerClock = add(timerBox, el('div', 'gg-timer-clock', '0:00'));
@@ -883,7 +888,6 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   let targetScore = 0;
   let lerpFrom = 0;
   let lerpAt = 0;
-  let lastCharges = -1;
   let lastTickSecond = -1;
 
   function durationMs() {
@@ -906,30 +910,12 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
     text(scoreEl, String(shownScore));
   }
 
-  /* THE CHARGE COUNT. Memoised on `lastCharges` exactly as the pip row was, for
-   * the same two reasons: the 5 Hz poll would otherwise rewrite an unchanged
-   * string twenty times a second, and the "+1" flourish has to fire ONCE on the
-   * edge rather than on every tick that finds the number high.
-   *
-   * `lastCharges >= 0` is the mount guard: the very first paint moves 0 -> N and
-   * is not a gain the player did anything to earn, so it must not bang the sfx
-   * on the way into a match that resumed with charges already banked. */
-  function paintCharges() {
-    const s = match.scoring;
-    const c = s ? (s.charges | 0) : 0;
-    if (c === lastCharges) return;
-    const gained = c > lastCharges && lastCharges >= 0;
-    lastCharges = c;
-    text(chargeEl, S.hud.charges(c, GoonConsts.ChargeCap));
-    if (!gained) return;
-    sfx(audio, 'gg-charge');
-    fx.play(400, () => {
-      const chip = el('span', 'gg-plus1', '+1');
-      if (!chip) return;
-      add(scoreBox, chip);
-      setTimeout(() => { try { chip.remove(); } catch (_e) { /* gone */ } }, 900);
-    });
-  }
+  /* `paintCharges()` was here: it memoised `match.scoring.charges` on
+     `lastCharges`, wrote "3 / 5 charges" into `.gg-charges`, and on a rising
+     edge played gg-charge plus a floating "+1" chip. The whole function came out
+     on 2026-08-05 with the readout it painted — see the long note up in the top
+     bar for what charges turned out to feed (nothing) and why a dead number is
+     worse than no number. paintAll() below is one call shorter. */
 
   function paintTimer() {
     const total = durationMs();
@@ -1014,7 +1000,7 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   }
 
   function paintAll() {
-    try { paintScore(); paintCharges(); paintTimer(); paintHeat(); paintArmedBadge(); }
+    try { paintScore(); paintTimer(); paintHeat(); paintArmedBadge(); }
     catch (_e) { /* a paint must never take the match down */ }
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/opponent.js
@@ -1,8 +1,8 @@
 /* ============================================================================
  * ui/opponent.js — the streamer-cam "monitor" that IS the opponent.
  *
- * Everything the other player lets us see lands here: their name, their charge
- * meter, their attention bar, the closeness they CLAIM, their emotes, and — in a
+ * Everything the other player lets us see lands here: their name, their score,
+ * their attention bar, the closeness they CLAIM, their emotes, and — in a
  * centred PROJECTION RECT inside the bezel — a stylized miniature of their
  * screen. The miniature is DOM/CSS only: it is a caricature, never a stream, and
  * no frame of their machine ever crosses the wire.
@@ -458,20 +458,24 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     };
   }
 
-  // ---- head: grip · connection dot · name · their score · their charges ----
+  // ---- head: grip · connection dot · name · their score -------------------
   // The head row is ALSO the titlebar (MON_GRIP_CLASS, see THE GRIP above): on a
   // docked monitor it is the only strip hud.css lets the pointer reach, so it is
   // where the drag and the wheel both have to start. Nothing in it is
-  // interactive — a dot and three little readouts — which is exactly why it is
+  // interactive — a dot and two little readouts — which is exactly why it is
   // safe to claim the whole row rather than a corner of it.
   //
-  // THEIR CHARGES ARE A COUNT, NOT PIPS (2026-08-05). This row carried five
-  // `.gg-pip--sm` diamonds until the owner asked, for the second time, for "the
-  // little yellow squares" to go: the HUD's own charge row went in the same
-  // pass, and leaving these would have kept the exact shape being complained
-  // about on screen — two inches from where it was removed — while letting the
-  // dead CSS live on. See the long note in ui/hud.js for the full reasoning.
-  // Nothing about the mechanic changed; only the way it is drawn.
+  // THEIR CHARGE COUNT IS GONE (2026-08-05). It was five `.gg-pip--sm` diamonds,
+  // then briefly a `.gg-mon-charges` word count, and now nothing: the owner
+  // removed the charge REQUIREMENT that day, so their meter stopped predicting
+  // anything about what they are able to throw at you. Knowing an opponent has
+  // "2 charges" was only ever useful as a threat forecast, and there is no
+  // forecast left to make — they throw when their cooldown is up, same as you.
+  // Their tick still carries the number (`match.opponent.charges`, frozen wire
+  // field) and this titlebar simply does not draw it. The full reasoning, and
+  // the audit of what charges actually feed, is in the top-bar note in
+  // ui/hud.js. THE ROW IS ALSO THE NARROWEST STRIP IN THE LAYOUT, so anything
+  // added back here costs the name its ellipsis budget on a phone.
   const head = add(root, el('div', 'gg-mon-head ' + MON_GRIP_CLASS));
   if (head && head.setAttribute) head.setAttribute('title', S.monitor.dragHint);
   // …and the affordance, first in the row: nobody drags a thing that does not
@@ -480,7 +484,6 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
   const dot = add(head, el('i', 'gg-mon-dot'));
   const nameEl = add(head, el('span', 'gg-mon-name', 'opponent'));
   const scoreEl = add(head, el('span', 'gg-mon-score', '0'));
-  const chargeEl = add(head, el('span', 'gg-mon-charges', S.monitor.charges(0)));
 
   // ---- the screen inside the bezel ---------------------------------------
   // THE STACKING ORDER HERE IS LOAD-BEARING. assets/monitor_frame.png (935x667
@@ -727,12 +730,9 @@ export function mountOpponent({ host, match, audio = null, fx = null, prefs = nu
     const p = stalePrefix();
 
     text(nameEl, op.displayName || 'opponent');
+    // The stale prefix rides on their score and their focus. It rode on their
+    // charge count too until that readout came out (2026-08-05).
     text(scoreEl, p + String(op.score | 0));
-    // The stale prefix rides on the charge count too. It did NOT ride on the
-    // pips — a lit diamond had nowhere to put a "~" — and that was a small lie
-    // the shape forced: a frozen count is exactly as out of date as the frozen
-    // score sitting beside it, and the words have room to say so.
-    text(chargeEl, p + S.monitor.charges(op.charges | 0));
 
     const pct = Math.max(0, Math.min(100, Number(op.attentionPct) || 0));
     if (attFill && attFill.style) attFill.style.width = pct + '%';

--- a/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
@@ -25,7 +25,7 @@ export const PREF_DEFAULTS = Object.freeze({
   /**
    * THE TWO CUE SLIDERS, split out of the old single `sfxVolume`. `ui` is the
    * chrome you drive (menus, sheets, the code cells); `game` is everything the
-   * match does at you (the draft, the countdown, charges, drops, payloads,
+   * match does at you (the draft, the countdown, drops, payloads,
    * bubbles, the recap). Every entry in ui/audio.js's SFX_REGISTRY declares
    * which bus it is on, and each is a real gain node under masterBus.
    *

--- a/ConditioningControlPanel/Resources/web/goon/ui/soloDriver.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/soloDriver.js
@@ -21,7 +21,8 @@ import { createLedger } from './router.js';
 import { GoonRng } from '../core/rng.js';
 import { GoonStimulusKind, fakeRoundInputs } from '../core/rounds/model.js';
 import { GoonSuddenDeathRunner } from '../core/suddenDeath.js';
-import { GoonMatchPhase, GoonPayloadKind, GoonConsts, costOf } from '../core/contracts.js';
+// (`costOf` left this import on 2026-08-05 with the bot's affordability filter.)
+import { GoonMatchPhase, GoonPayloadKind, GoonConsts } from '../core/contracts.js';
 
 /** How long the bot "thinks" before signing the consent sheet. */
 const CONSENT_THINK_MS = [700, 1600];
@@ -50,12 +51,15 @@ const BUBBLE_POP_MS = [420, 900];
  * through to drawKind), so the bot's flash burst is drawn from the player's OWN
  * uploads. That is the loop that shows a phone player their library, and it used
  * to depend on the bot first earning charges the slow way: `tryPayload` waits
- * PAYLOAD_TRY_MS, skips 35% of its turns and needs `charges >= cost`, which on a
- * fresh match can be minutes of nothing.
+ * PAYLOAD_TRY_MS, skips 35% of its turns and (until 2026-08-05) also needed
+ * `charges >= cost`, which on a fresh match could be minutes of nothing.
  *
- * So the bot opens on a clock instead of on its economy. The charges are still
- * credited through the engine (`creditCharges`), so the wire truth the receiver
- * validates is the truth — this buys the bot no shot it could not have taken.
+ * So the bot opens on a clock instead of on its economy — and since the owner
+ * removed the charge requirement outright there is no economy left to open on.
+ * The salvo's `creditCharges` step went with it: the only reason it ever existed
+ * was that the RECEIVER validated the sender's wallet off the last state tick,
+ * and it does not any more. See SALVO_RESERVE_LEAD_MS for what the lead is FOR
+ * now, because the answer changed and the number did not.
  *
  * PRACTICE ONLY, structurally: createSoloDriver is constructed in exactly one
  * place (boot.js startSolo). Duel balance cannot reach this file.
@@ -68,15 +72,25 @@ export const SALVO = Object.freeze([
 ]);
 
 /**
- * How long BEFORE a salvo shot its charges are credited.
+ * How long BEFORE a salvo shot the slot is RESERVED (`salvoArmed++`).
  *
- * THE RECEIVER IS THE AUTHORITY ON THE SENDER'S WALLET, and it reads that wallet
- * off the last state tick, not off the payload frame — credit-then-fire in the
- * same turn is rejected with `charge economy: claimed 0 < cost 1`, which is
- * exactly what the first cut of this salvo did. GoonConsts.TickIntervalMs is
- * 3000, so a lead comfortably past one tick is what makes the shot land.
+ * WAS `SALVO_CREDIT_LEAD_MS`, and the rename is the whole story. The lead used
+ * to exist because THE RECEIVER WAS THE AUTHORITY ON THE SENDER'S WALLET and
+ * read that wallet off the last state tick, not off the payload frame:
+ * credit-then-fire in the same turn came back as `charge economy: claimed 0 <
+ * cost 1`, which is exactly what the first cut of this salvo did. That check was
+ * deleted on 2026-08-05 with the rest of the charge requirement, so there is no
+ * wallet to fund and no tick to beat.
+ *
+ * THE LEAD STILL EARNS ITS KEEP, on the constraint that replaced it: the RATE
+ * LIMIT. One payload per GoonConsts.PayloadMinGapMs is now the only pacing on
+ * the wire, so an ordinary-cadence shot fired a second before a scheduled salvo
+ * shot eats the token the salvo needed and the scripted moment silently does not
+ * happen. Reserving the slot early (see `salvoArmed` in tryPayload) is what
+ * stops that. A lead comfortably past one tick interval is still the right size:
+ * it is longer than any single cadence turn.
  */
-export const SALVO_CREDIT_LEAD_MS = 5000;
+export const SALVO_RESERVE_LEAD_MS = 5000;
 
 /**
  * @param {object} o
@@ -219,29 +233,32 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
     }, pick(DRAFT_THINK_MS));
   }
 
-  /** Salvo shots whose charges are credited and not yet spent (see fireSalvo). */
+  /** Salvo shots that are RESERVED and not yet fired (see fireSalvo). */
   let salvoArmed = 0;
 
   function tryPayload() {
     if (match.phase !== GoonMatchPhase.Live && match.phase !== GoonMatchPhase.SuddenDeath) return;
-    // A salvo shot's charges are already credited and SPOKEN FOR. Letting the
-    // ordinary cadence spend them would turn "the practice player sees a clip at
-    // 45s" into a coin flip.
+    // A salvo shot has the next rate-limit token SPOKEN FOR. Letting the ordinary
+    // cadence take it would turn "the practice player sees a clip at 45s" into a
+    // coin flip. (It used to be the shot's CHARGES that were spoken for; charges
+    // buy nothing since 2026-08-05, and the token is the scarce thing now.)
     if (salvoArmed > 0) return;
-    const charges = match.scoring.charges;
     // BrainDrain: once per match, and the bot must not spend it on a whim.
     // BubbleSwarm: the human has no such sticker any more (ui/arsenal.js, owner
     // 2026-08-04 — bubbles are the always-on field, so a bubble throwable bought
     // nothing) and the practice bot throws from the player's own deck. The kind
     // stays legal on the wire and stays rendered inbound; nothing local sends one.
-    const affordable = (match.availablePayloadKinds || [])
+    //
+    // `&& costOf(k) <= charges` was the third filter here, and it is gone with the
+    // charge requirement (2026-08-05): the bot throws what the agreement allows,
+    // when the clock and the rate limiter let it.
+    const throwable = (match.availablePayloadKinds || [])
       .filter((k) => k !== GoonPayloadKind.BrainDrain
-        && k !== GoonPayloadKind.BubbleSwarm
-        && costOf(k) <= charges);
-    if (affordable.length === 0) return;
+        && k !== GoonPayloadKind.BubbleSwarm);
+    if (throwable.length === 0) return;
     if (rng.nextDouble() < 0.35) return;    // it does not fire the instant it can
 
-    const kind = affordable[rng.nextInt(0, affordable.length)];
+    const kind = throwable[rng.nextInt(0, throwable.length)];
     const res = match.tryFirePayload({
       kind,
       durationMs: 20000 + rng.nextInt(0, 25000),
@@ -252,10 +269,15 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
   }
 
   /**
-   * Step one of a salvo shot: put the charges in the wallet, early enough that a
-   * state tick carries them to the receiver (SALVO_CREDIT_LEAD_MS). A kind the
-   * agreement left out never gets funded — the bot cannot send what the two of
-   * you did not allow, salvo or not.
+   * Step one of a salvo shot: RESERVE it, SALVO_RESERVE_LEAD_MS ahead, so the
+   * ordinary cadence cannot take the rate-limit token out from under it. A kind
+   * the agreement left out is never reserved — the bot cannot send what the two
+   * of you did not allow, salvo or not.
+   *
+   * This used to also credit the charges the shot would cost
+   * (`match.creditCharges(cost - have, 'practice-salvo')`), because the receiver
+   * checked the sender's wallet before admitting anything. It does not any more
+   * (2026-08-05), so the funding step is gone and only the reservation is left.
    */
   function armSalvo(spec) {
     if (ledger.isDisposed || match.phase !== GoonMatchPhase.Live) return;
@@ -263,16 +285,13 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
       log('salvo ' + spec.kind + ' skipped (not in the agreed pool)');
       return;
     }
-    const cost = costOf(spec.kind);
-    const have = (match.scoring && match.scoring.charges) | 0;
-    if (have < cost) match.creditCharges(cost - have, 'practice-salvo');
     salvoArmed++;
   }
 
   /**
    * Step two: fire, through the SAME public API tryPayload uses, so every engine
-   * gate (phase, rate limit, caps, the shared pool, the charge check) still
-   * applies. Whatever happens the shot stops being reserved.
+   * gate (phase, rate limit, caps, the shared pool) still applies. Whatever
+   * happens the shot stops being reserved.
    */
   function fireSalvo(spec) {
     if (ledger.isDisposed) return;
@@ -318,7 +337,7 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
         // predictable clock. Through the ledger, so leaving mid-match cannot land
         // a flash burst on the recap.
         for (const spec of SALVO) {
-          ledger.timer(() => armSalvo(spec), Math.max(0, spec.atMs - SALVO_CREDIT_LEAD_MS));
+          ledger.timer(() => armSalvo(spec), Math.max(0, spec.atMs - SALVO_RESERVE_LEAD_MS));
           ledger.timer(() => fireSalvo(spec), spec.atMs);
         }
         payloadTimer = ledger.interval(tryPayload, PAYLOAD_TRY_MS);
@@ -349,7 +368,8 @@ export function createSoloDriver({ match, name = 'Practice', seed = 0xB0BBn, log
     const p = ev && ev.payload;
     if (!p) return;
     // It endures everything, all the way. A bot that flinched would hide the
-    // "+1 charge for them" path from the human's recap.
+    // `survived` receipt — the "endured" chip on the human's recap — behind a
+    // `completed` one they would never see the difference in.
     const wait = Math.max(1000, (p.duration_ms | 0)) + 300;
     // A landed video "opens a window" on the bot's screen (see fake block above).
     if (p.kind === GoonPayloadKind.Video) fakeWindow(Math.min(60000, Math.max(1000, p.duration_ms | 0)));

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -54,8 +54,13 @@ export const S = Object.freeze({
     bullets: [
       'two players, one clock. you both endure your own library at the same time.',
       'you both agree what stays switched on. whatever is left, you BOTH endure — same effects, same moments.',
-      'holding still earns points; enduring what they send you earns charges.',
-      'charges buy payloads you fire at them. the receiver decides what it can run.',
+      /* These two read "…enduring what they send you earns charges." and
+         "charges buy payloads you fire at them." until 2026-08-05, when the
+         owner deleted the charge requirement. They now teach the loop that
+         actually exists: pop bubbles, get items, throw when the cooldown lets
+         you. STILL EXACTLY SIX BULLETS — do not let this become seven. */
+      'holding still earns points; popping bubbles drops the items you throw.',
+      'throw one whenever your cooldown is up. the receiver decides what it can run.',
       'mercy is always one key away. escape, any phase, no confirmation.',
       'if nobody breaks before the clock runs out, the higher score wins.',
     ],
@@ -287,7 +292,10 @@ export const S = Object.freeze({
     back: 'Back to menu',
     chipLanded: 'landed',
     chipEndured: 'endured',
-    chipEnduredNote: '+1 charge for them',
+    /* Was "+1 charge for them" — accurate until 2026-08-05, when charges stopped
+       buying anything. Riding a payload out now earns exactly the credit for
+       having ridden it out, which is what the note says. */
+    chipEnduredNote: 'they rode it out',
     chipBlocked: 'blocked',
     chipTooSoon: 'too soon',
     dirIn: 'they sent',
@@ -842,23 +850,18 @@ export const S = Object.freeze({
      * fixed at the draft, unchangeable mid-match and unexplained by anything on
      * the desk. Deleted rather than reworded — the score above it is the same
      * information, already counted. */
-    /* ---- the charge count (ui/hud.js) ----
-     * WHAT REPLACED THE PIP ROW on 2026-08-05. Five rotated squares under the
-     * score used to carry this: outlines for the cap, filled for what you hold.
-     * The owner read them as the risk pips they had just had removed ("the
-     * little yellow squares"), which is a fair reading — same shape, same
-     * neighbourhood — so the count is a sentence now.
+    /* THERE IS NO `charges` STRING ANY MORE (2026-08-05). `charges: (n, cap) =>
+     * n + " / " + cap + " charges"` lived here for a matter of hours: it was
+     * what replaced the five-diamond pip row in the morning's pass, and by the
+     * evening the owner had removed the charge REQUIREMENT it described ("we
+     * still have the charge system in (you need 3 to do X etc), we should remove
+     * the requirement entirely"). A count of a currency that buys nothing is not
+     * a readout, it is a rumour of a rule — and this one actively misinforms,
+     * because "1 / 3" beside an item you CAN throw says you cannot.
      *
-     * THE CAP IS IN THE STRING ON PURPOSE. The pips said it by being five, and
-     * a bare "3" would have quietly dropped it. It is actionable: at the cap the
-     * endurance you are grinding out stops banking, and the arsenal's costs are
-     * priced against the same ceiling. Their count (S.monitor.charges) omits it,
-     * because nothing you can do turns their ceiling into a decision.
-     *
-     * Spaces around the slash so "3 / 5" cannot be misread as a date or a score
-     * line at a glance, and the noun is always plural — "1 / 5 charge" reads
-     * like a typo, and the number this labels is the pair, not the 1. */
-    charges: (n, cap) => (n | 0) + ' / ' + (cap | 0) + ' charges',
+     * Nothing in ui/hud.js builds the line. Do not restore this key without a
+     * mechanic behind it; the engine's meter (core/scoring.js) is still there
+     * and still on the wire, and that is deliberately not the same thing. */
     /* ---- the heat gauge (ui/drops.js) ----
      * ONE word, because it sits over the arsenal rail and the bar is the rest of
      * the sentence. `heatValue` is the aria-valuetext: colour never travels
@@ -873,15 +876,13 @@ export const S = Object.freeze({
     dropHint: 'drop it here',
     /** The green checkmark on their projection: they took the whole payload. */
     passed: 'they held it',
-    /* Their charge count in the monitor's titlebar — the same 2026-08-05 removal
-     * as S.hud.charges: five little `.gg-pip--sm` diamonds sat here beside their
-     * score and were the last diamonds on the desk once the HUD's own row went.
-     * NO CAP HERE, unlike yours: their ceiling is not a number you can spend
-     * against, and the head row is the narrowest strip in the whole layout (it
-     * shares 200px with a grip, a health dot, their name and their score on a
-     * phone). Singular is spelled out because "1 charges" beside a live opponent
-     * name looks like a bug in the app rather than a count. */
-    charges: (n) => (n | 0) + ((n | 0) === 1 ? ' charge' : ' charges'),
+    /* THEIR CHARGE COUNT IS GONE TOO (2026-08-05) — `charges: (n) => n + " charge(s)"`,
+     * and five `.gg-pip--sm` diamonds before that. It followed S.hud.charges out
+     * the door and for the sharper reason: yours was at least a fact about you,
+     * while theirs was only ever a THREAT FORECAST — "they can afford the heavy"
+     * — and with the requirement removed there is no forecast to make. They
+     * throw when their cooldown is up, exactly like you do. ui/opponent.js draws
+     * no such span; the titlebar is grip · dot · name · score. */
     /** The titlebar's tooltip. All three gestures, because not one of them is
      *  discoverable and the grip dots only ever promise the first. */
     dragHint: 'drag to move · wheel to resize · double-tap to put it back',
@@ -956,7 +957,10 @@ export const S = Object.freeze({
     copyFailed: 'could not copy — select the code instead',
     peerWobbly: 'their connection is wobbling',
     peerBack: 'they are back',
-    charge: '+1 charge',
+    /* `charge: '+1 charge'` was here with no caller at all — the HUD played its
+       own inline "+1" chip instead. Removed 2026-08-05 with the rest of the
+       charge surface rather than left as a toast for a thing that no longer
+       means anything. */
     left: 'left the match',
   },
 });

--- a/ConditioningControlPanel/Resources/web/goon/ui/toasts.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/toasts.js
@@ -2,7 +2,7 @@
  * ui/toasts.js — the transient notice stack on #gg-toasts (z50).
  *
  * A toast is for something that ALREADY HAPPENED and needs no decision: a
- * charge earned, a payload landed, the peer wobbling. Anything the player must
+ * a payload landed, the peer wobbling. Anything the player must
  * answer is a sheet (ui/sheets.js), never this.
  *
  * The layer is aria-live="polite" in index.html, so a screen reader announces


### PR DESCRIPTION
## The owner's call

> "we still have the charge system in (you need 3 to do X etc), we should remove the requirement entirely (and the Need 1/2/3 under the throwables)" — 2026-08-05

**A throw is free now.** The cooldown is the whole of the pacing: one payload per `GoonConsts.PayloadMinGapMs` (30s) with a burst of `PayloadBurst`, enforced by the sender's and the receiver's limiter exactly as before. Nothing else about the deck changed — the drop economy, the once-per-match heavy, and the peer's caps are untouched.

## What charges actually fed (the evidence)

I audited this before deciding what to do with the `.gg-charges` readout PR #142 added, because the brief was explicit that a dead number is worse than none.

| Candidate consumer | Verdict |
|---|---|
| **Throw gating** (sender `tryFirePayload`, receiver `_handleInboundPayload`) | **The only real one.** Removed. |
| Arsenal `poor` state / cost pips | A projection of the above. Removed. |
| **Score** | No. `tick()` is `seconds x riskMultiplier x attentionMultiplier`; charges never appear. |
| **Recap / report** | No. `chargesEarned` / `chargesSpent` exist only inside `core/scoring.js` — grepped the tree, no reader. The recap's only mention was the string `"+1 charge for them"`. |
| **Drops** | No. `ui/drops.js` gated arming on `match.creditCharges(...) === true`, but `creditCharges` returns true for any integer >= 1 while the phase is Live and silently discards overflow at the cap — **it never once refused for want of charges.** It refused for being outside Live, which is the `isLive()` check six lines above it. The economy was a phase check in a costume. Drops are paced by **heat** and picked by **cost-as-rarity**. |
| **Endurance** | `awardPayloadEndured()` -> +1 charge -> fed the gate, and nothing else. |

So: **nothing**. Both readouts are removed rather than left displaying a number that decides nothing — and `1 / 3 charges` beside a tile you *can* throw actively says you cannot. The reasoning is written into a long WHY block at the top bar of `ui/hud.js`, with pointers from the CSS and strings tombstones.

## Removed vs kept

**Removed (gating + its UI):**

- `core/match.js` — the sender's `charges < cost` pre-check and `trySpend()`; the receiver's `charge economy: claimed N < cost M` rejection and the `_opponentChargesKnown` ledger behind it; the `refund()` on a rejected receipt (nothing was spent, so refunding would **mint** charges out of a peer that rejects everything). The rejected-heavy slot restore is preserved.
- `ui/arsenal.js` — the `poor` state, the `need N` word, the `.gg-cost-pip` price row, the affordability refusal, the `charges()` reader, and the `onChargesChanged` subscription. The glow now picks the **rarest** tile you hold rather than "the priciest you can afford" (the same tile whenever you could afford anything).
- `ui/drops.js` — the `credit()` gate and the `creditCharges` call; the `'no-charge'` outcome.
- `ui/soloDriver.js` / `boot.js` — the `practice-salvo` and `practice-seed` credits, and the bot's `costOf(k) <= charges` filter.
- `ui/hud.js` / `ui/opponent.js` — `.gg-charges`, `.gg-mon-charges`, `paintCharges()`, the `.gg-plus1` chip and the `gg-charge` / `charge-earned` cues.
- Strings: `S.hud.charges`, `S.monitor.charges`, `S.toasts.charge` (already caller-less); `S.recap.chipEnduredNote` and the arsenal receipt note now say `they rode it out`; two of the six "how it works" bullets rewritten (still exactly six).

**Kept (internal / parity):**

- The entire `GoonScoring` meter: `_charges`, `chargesEarned`, `chargesSpent`, the trickle, `awardPayloadEndured`, `awardEventWon`, `trySpend`, `refund`, `snapshot().charges`, `onChargesChanged`.
- `GoonConsts.ChargeCap` / `ChargeTrickleMs`, the `COSTS` table, `costOf()`, `creditCharges()`.
- The `tick.charges` wire field, `makeTick`, the parse path and `match.opponent.charges`.

`costOf()` keeps two live consumers, both documented in `core/contracts.js`: the **unknown-kind guard** (`Infinity`), and the **drop rarity weight** `1/cost^COST_BIAS` in `ui/drops.js` — a cost is now how *rare* an item is, not what it costs.

## Vector impact: NONE

`test/rng-vectors.json` carries no charge data at all. `vectors.js`, `vectors-engine.js` and `vectors-rounds.js` all pass **unmodified**:

```
PASS - 345 values matched across 8 seed(s), 4 derive case(s), 9 salt_seed element(s)
PASS - ramp parity: 509 cues matched ... host score 3
PASS - 32 round specs, 1744 spec fields, 5208 judge checks
```

`vectors-engine.js` pins the `creditCharges` contract (Live-only, integer >= 1, clamped at the cap) and that seam is intact — it just has no production caller now, which is stated in its doc comment.

**One rename**, called out loudly: `SALVO_CREDIT_LEAD_MS` -> `SALVO_RESERVE_LEAD_MS` in `ui/soloDriver.js`. The lead existed because the receiver read the sender's wallet off the last state tick, so credit-then-fire in one turn bounced. That is gone — but the lead still earns its keep on the constraint that replaced it: it reserves the shot so the ordinary cadence cannot eat the **rate-limit token** the scheduled salvo needs. Same silent-failure shape, new cause.

## Tests

All goon selftests green except `selftest-avafx` (12 pre-existing failures, all "the X one-shot is declared on the CHILD" — avatar FX CSS, not this change).

```
assets 427/427   core 242   encode 190/190   exec 1027   flow 310
hostgate 95/95   hud 1622/1622   invite 199/199   net 334
report 213   transfer 199   voice 225   voice-ui 262
avafx 176/188 (12 pre-existing)
```

- **`selftest-hud.js` 2c-iii** rewritten from "the charge readout is a sentence" into a removal pin: no charge string survives, no `.gg-charges` / `.gg-mon-charges` / `.gg-pip` node mounts, a charge gain is now silent and mints no chip, the arsenal builds no cost pips — and the money assertion, **a 3-cost brain drain fires off a completely empty meter**.
- The drops suite is re-pointed at the real remaining refusal (**a full arsenal**, `armDrop` returning false) for the "a drop the player never got does not spend the gauge" invariant, and `credits` is kept as a tripwire asserting the roller pays nothing.
- `selftest-flow.js` salvo/seed section rewritten; it now asserts `soloDriver.js` and `boot.js` contain **no** `creditCharges` at all.
- Two places in `selftest-flow.js` that hand-primed `_scoring._charges = 9` / `_opponentChargesKnown = 9` to get past the old gate no longer need to.

## Needs a live play-test

1. **A duel, both seats.** Throw the heavy immediately at t=0 with an empty meter — it should land, not bounce. Then confirm the 30s cooldown still visibly refuses the next throw ("next payload in Ns").
2. **The tile layout.** Each sticker lost a flex row (the price pips), so tiles are slightly shorter — worth a look on a phone at 428px and 375px, in both drawer states.
3. **The scorebox.** It is now score + your avatar mini, one line lighter. Check it does not look empty and that the mobile `minmax(0, 1fr)` track still behaves.
4. **The monitor titlebar** is grip / dot / name / score. Confirm the grip is still comfortably draggable and a long opponent name still ellipsises.
5. **Practice mode** end to end: the seeded flash + video slots, and the 6s / 45s salvo both landing (the reserve lead is the thing that keeps the 45s clip from being eaten by a cadence shot).
6. **The desk's reward loop** without the charge ding: pop -> heat climbs -> `gg-drop` -> sticker lights with "+1 flash". Confirm it still reads as rewarding now that the second chime is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D
