### PR TITLE
feat(goon): free seats can send their media - fix the verdict race and the standalone default

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -585,9 +585,10 @@ function localCaps() {
    * `transfer` (its sibling in core/caps.js) is advertised on EXACTLY the same
    * terms: this build ships net/mediaChannel.js and will parse offers, full
    * stop. It says nothing about consent (the sheet's `media_transfer` term),
-   * nothing about premium (session.caps.mediaTransfer gates SENDING only —
-   * receiving is deliberately free), and nothing about the link (the lobby row
-   * checks supportsBulk separately). Until 2026-08-04 NOBODY set this flag —
+   * nothing about entitlement (session.caps.mediaTransfer gates SENDING only,
+   * and as of 2026-08-05 that is free for every seat anyway — receiving never
+   * was), and nothing about the link (the lobby row checks supportsBulk
+   * separately). Until 2026-08-04 NOBODY set this flag —
    * caps.js documented that boot advertises it and boot never did — so every
    * hello said `transfer:false`, both lobbies greyed the checkbox out with
    * "their build doesn't transfer", and the entire media lane was unreachable
@@ -605,9 +606,9 @@ function localCaps() {
 /* ============================================================================
  * P2P MEDIA TRANSFER — the three singletons and the one adapter.
  *
- * The queue SENDS (premium-gated, session.caps.mediaTransfer), the store RECEIVES
- * (never gated — a free player seeing a supporter's media is the whole product),
- * and the blocklist is the render-time safety gate. All three are built in
+ * The queue SENDS (session.caps.mediaTransfer — free for every seat since
+ * 2026-08-05; the paid perk is HOSTING), the store RECEIVES (never gated at all,
+ * in any era), and the blocklist is the render-time safety gate. All three are built in
  * buildApp() and the queue is attached/detached with the match, so the relay
  * rebuild re-binds it over the new transport and it simply goes dormant.
  * ==========================================================================*/
@@ -980,6 +981,47 @@ function buildMatch(transport, isHost, { withSuddenDeathUi = true, displayName =
   return match;
 }
 
+/**
+ * THE SERVER'S SEND VERDICT -> session.caps.mediaTransfer. Standalone only.
+ *
+ * Sending is free for every seat now (bridge.js defaults the cap ON, and the C#
+ * host's TransferAllowed() answers true), so this is no longer how a seat EARNS
+ * the capability — it is how the server can still TAKE IT BACK. /invite and
+ * /join answer `media_send`; net/signaling.js records it; this folds it in. A
+ * `false` from a future policy turns sending off with no client release, and a
+ * `null` (a server that predates the field) deliberately changes nothing.
+ *
+ * WHY THIS IS A FUNCTION AND NOT A LINE IN attachMatch — it has to run TWICE,
+ * on two different roads, and running it only in attachMatch is exactly the bug
+ * that made a verdict-driven gate unusable:
+ *
+ *   FIRST CONNECT.  GoonSession._beginSession() constructs a BRAND NEW signaling
+ *     client (mediaSend === null), builds the match, and raises
+ *     currentMatchChanged — i.e. calls attachMatch — and only THEN awaits
+ *     createInvite/join, which is the round trip that learns the verdict. Read
+ *     at attach time the answer is therefore ALWAYS null. Under the old
+ *     default-OFF cap that left every standalone seat unable to send for the
+ *     whole match, however loudly the server said yes. hostStart/joinStart call
+ *     this again after their await, which is the only moment the answer exists.
+ *
+ *   RELAY REBUILD.  _fallBackToRelay disposes the match and raises
+ *     currentMatchChanged over a new transport, KEEPING the signaling client. The
+ *     call in attachMatch catches that road, where the verdict is long since in.
+ *
+ * Idempotent by construction (it assigns a value, it does not toggle one), so
+ * calling it on both roads and twice on one of them costs nothing. Hosted pages
+ * are skipped outright: the C# init frame is authoritative there and there is no
+ * signaling client on this side to ask.
+ */
+function adoptServerSendVerdict() {
+  if (session.hosted) return;
+  const verdict = goonSession && goonSession.signaling ? goonSession.signaling.mediaSend : null;
+  if (typeof verdict !== 'boolean') return;
+  if (session.caps && session.caps.mediaTransfer === verdict) return;   // no churn, no log spam
+  session.caps = Object.assign({}, session.caps, { mediaTransfer: verdict });
+  logger.info('server send verdict adopted: caps.mediaTransfer = ' + verdict);
+}
+
 /* ----------------------------------------------------------------------------
  * ATTACH / DETACH — the rebuild-safe graph. Everything that observes a match is
  * bound HERE and nowhere else, so "the match was replaced" is one function call
@@ -1003,18 +1045,11 @@ function attachMatch(match, transport) {
   // leaves the host's manifest half of the deck exactly where it was.
   syncLocalDeck(true);
 
-  /* THE PREMIUM SEND GATE, standalone half. The server answered /invite //join
-   * with `media_send` (tier>=1, the same bar the C# host applies to its own init
-   * frame) and the signaling client recorded it. Folding it in HERE — the one
-   * seam every connect path crosses before the lobby renders — means a phone
-   * client can no longer grant itself sending by editing a querystring: the caps
-   * default is OFF against a real server and only the server turns it on. Hosted
-   * stays untouched (the init frame is authoritative), and null (an old server
-   * that never answered the question) changes nothing by design. */
-  if (!session.hosted && goonSession && goonSession.signaling
-      && typeof goonSession.signaling.mediaSend === 'boolean') {
-    session.caps = Object.assign({}, session.caps, { mediaTransfer: goonSession.signaling.mediaSend });
-  }
+  // The server's send verdict, for the REBUILD road into a match (the relay
+  // fallback raises currentMatchChanged again with the room already redeemed, so
+  // by here the verdict is known). The FIRST road is handled at the call sites —
+  // see adoptServerSendVerdict for why one call here can never be enough.
+  adoptServerSendVerdict();
 
   try { executor?.attach?.(match); } catch (e) { logger.error('executor.attach threw: ' + ((e && e.stack) || e)); }
   try { matchLog.attach(match); } catch (e) { logger.error('matchLog.attach threw: ' + ((e && e.stack) || e)); }
@@ -1760,6 +1795,10 @@ const actions = {
     lastConnectFailed = null;
     let code = null;
     try { code = await s.host(); } finally { awaitingEntry = false; }
+    // /invite has answered, so `media_send` finally EXISTS. attachMatch already
+    // ran (inside the await, before the POST) and read null — see
+    // adoptServerSendVerdict. This is the first moment there is a verdict to fold.
+    adoptServerSendVerdict();
     if (code) return { ok: true, code };
     return { ok: false, error: errorInfo(lastConnectFailed) };
   },
@@ -1772,6 +1811,10 @@ const actions = {
     lastConnectFailed = null;
     let ok = false;
     try { ok = await s.join(inviteCode); } finally { awaitingEntry = false; }
+    // The guest's half of the same fold — and the one that actually mattered to a
+    // FREE seat, which is the seat that reaches a duel down this road. See
+    // adoptServerSendVerdict: attachMatch ran before /join was ever posted.
+    adoptServerSendVerdict();
     if (!ok) {
       const err = errorInfo(lastConnectFailed);
       /* A DEAD ROOM SPENDS THE SEAT. Without this, the resume path
@@ -2049,9 +2092,12 @@ function buildApp() {
     blocklist,
     logger,
     acceptsCodecs: decodeCodecs,
-    // === true, NOT !== false (the idiom brainDrain/spiral use above). Deliberate
-    // inversion: sending is a new, Patreon-gated capability, so a host that
-    // predates the flag must default it OFF. Receiving is never gated.
+    // === true, NOT !== false (the idiom brainDrain/spiral use above). Kept
+    // strict even though the capability is free now: a host that predates the
+    // flag entirely says nothing, and "said nothing" must not read as consent to
+    // start a lane. Every host that DOES speak the flag sets it true (C#
+    // TransferAllowed, bridge.js standalone default), so the strictness only
+    // ever catches a genuinely ancient frame. Receiving is never gated.
     canSend: () => !!(session.caps && session.caps.mediaTransfer === true),
   });
   mediaQueue.onReceived((a) => {

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -292,15 +292,27 @@ export function standaloneInit() {
       // transfer-cache to talk to: the assets screen renders "compression lives in
       // the app" instead of a spinner that never resolves.
       assetCache: false,
-      // SENDING is premium-gated. Against a real server (a `?server=` launch,
-      // one remembered in prefs, or the public deployment's built-in default)
-      // it starts OFF and boot.js adopts the server's `media_send` verdict from
-      // the /invite //join answer. Only the pure-local dev path (no server
-      // anywhere) keeps the old always-on affordance, because it is the one way
-      // to exercise the transfer without two Patreon accounts. The page reads
-      // this as `=== true`, so a real host that predates the flag still
-      // defaults it OFF.
-      mediaTransfer: !(q.get('server') || prefs.serverBase || defaultServerBase()),
+      /* SENDING IS FREE FOR EVERY SEAT (owner call, 2026-08-05). This WAS a
+       * premium default — OFF against any real server, ON only on the pure-local
+       * dev path — and boot.js flipped it on once the server's `media_send`
+       * verdict landed. That defaulting is what a free guest experienced as
+       * "my attacks throw blanks": the paid perk is HOSTING (caps.canHost, the
+       * server's tier-2 bar at /v2/goon/invite) and once a room exists BOTH
+       * players sending their own media is the whole shape of a duel.
+       *
+       * It stays TRUE here and the server's verdict stays the AUTHORITY: boot.js
+       * still folds `media_send` in (adoptServerSendVerdict), so a server that
+       * answers false turns sending off again with no client release, and a
+       * server that predates the field (null) leaves this default alone. The
+       * inversion matters — defaulting ON and letting the server veto is a very
+       * different failure mode from defaulting OFF and hoping a verdict arrives
+       * in time, and the second one is the bug this replaced.
+       *
+       * NOT an enforcement point either way: media is P2P, so this gate is
+       * advisory UX (the lobby row's explanation, the queue's send arm). The
+       * REAL gates are the two lobby consent toggles, which are untouched.
+       */
+      mediaTransfer: true,
     }, prefs.caps || {}),
     consent: Object.assign({
       liveDurationSec: 720,    // GoonConsts.LiveDurationSecDefault

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -612,8 +612,10 @@ function mountRecap(result) {
     const qA = createMediaQueue({
       artifacts, store: storeA, logger: quiet, canSend: () => true, idlePollMs: 40,
     });
-    // B sends nothing (no artifacts, no premium) and receives everything — which is
-    // the asymmetry the product is built on: only SENDING is gated.
+    // B sends nothing (no artifacts, and canSend forced off) and receives everything.
+    // The forced-off gate is a TEST FIXTURE, not a tier: since 2026-08-05 no real
+    // seat is refused the capability (see 6a-free). It stays here because the
+    // receive path must keep working while the send path is shut, whatever shut it.
     const qB = createMediaQueue({
       artifacts: { listSendable: () => [], open: () => null },
       store: storeB, logger: quiet, canSend: () => false, idlePollMs: 40,
@@ -626,7 +628,7 @@ function mountRecap(result) {
 
     qA.attach(a, pair.host);
     qB.attach(b, pair.guest);
-    ok(qB.enabled() === false, 'B cannot send: canSend() is the premium gate and it said no');
+    ok(qB.enabled() === false, 'B cannot send: canSend() is the capability gate and it said no');
 
     // The queue primes at Draft; the hello round trip and the idle poll are what make
     // it start, so give it a moment rather than assuming one turn.
@@ -684,6 +686,98 @@ function mountRecap(result) {
     qB.detach();
     ok(typeof a.tryFirePayload === 'function', 'detach left a callable tryFirePayload behind');
     a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* ---------------- 6a-free. THE FREE SEAT SENDS (owner call, 2026-08-05) ------
+   * Everything above drives `canSend` from a hand-written arrow. This one drives
+   * it from the SHAPE A FREE SEAT ACTUALLY HOLDS — bridge.js's standaloneInit
+   * caps, minus every paid marker — through the same predicate boot.js installs
+   * (`caps.mediaTransfer === true`). If someone re-introduces a tier default in
+   * bridge.js, this fails on the object rather than on a source regex.
+   *
+   * The two verdicts are asserted TOGETHER on the same caps object because the
+   * whole decision is that they diverge: sending free, hosting not.
+   * -------------------------------------------------------------------------- */
+  {
+    // A guest that arrived on an invite link: no account, no tier, no host right.
+    const freeSeatCaps = {
+      platform: 'web', video: true, camera: false, assetCache: false,
+      mediaTransfer: true,     // bridge.js standaloneInit — free for every seat
+      canHost: false,          // …and the server's tier-2 bar, unmoved
+    };
+    // boot.js's canSend closure, verbatim in shape.
+    const canSend = () => !!(freeSeatCaps && freeSeatCaps.mediaTransfer === true);
+    ok(canSend() === true, 'a free seat CAN send: caps.mediaTransfer is true with no account behind it');
+    ok(freeSeatCaps.canHost !== true, 'and still cannot host — the perk did not move');
+
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const { a, b } = await consentedPair(pair);
+    const artifacts = fakeArtifacts([
+      { sha: SHA_IMG, bytes: 40000, mime: 'image/png', kind: 'image', exempt: false },
+    ]);
+    const storeB = fakeStore();
+    // The FREE seat is the sender here — the exact inversion of 6a, where the
+    // gated side was the one holding nothing.
+    const qFree = createMediaQueue({ artifacts, store: fakeStore(), logger: quiet, canSend, idlePollMs: 40 });
+    const qPeer = createMediaQueue({
+      artifacts: { listSendable: () => [], open: () => null },
+      store: storeB, logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    qFree.attach(a, pair.host);
+    qPeer.attach(b, pair.guest);
+
+    // The hello is a round trip, so the ladder is only complete a few turns in —
+    // same wait 6a uses, and the same reason.
+    for (let i = 0; i < 80 && storeB.held.size < 1; i++) await tick(25);
+    ok(qFree.enabled() === true,
+      'and the whole sendGate ladder passes for it — capability, both consents, peer support, bulk, hello');
+    ok(storeB.held.size >= 1, "the free seat's media actually crossed the wire", String(storeB.held.size));
+
+    qFree.detach(); qPeer.detach();
+    a.dispose(); b.dispose(); pair.dispose();
+  }
+
+  /* -------- 6a-consent. A FREE CAPABILITY IS NOT A FREE PASS --------------------
+   * The half of 6a-free that matters most for review: give the free seat the
+   * capability and take away the OTHER side's lobby tick, and the lane stays
+   * shut — with the queue naming consent, not entitlement, as the reason. The
+   * pair is built the 6d way (declarations set at Idle, one side silent) because
+   * the setter refuses past Consent and a withdrawal mid-Draft is a no-op.
+   * -------------------------------------------------------------------------- */
+  {
+    const caps = localCaps({ transfer: true });
+    const pair = createLoopbackPair(loopbackOptions({
+      latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
+    }));
+    const a = new GoonMatchService(pair.host, true, { logger: quiet, caps, displayName: 'Free', tag: 'GG:AFREE' });
+    const b = new GoonMatchService(pair.guest, false, { logger: quiet, caps, displayName: 'Peer', tag: 'GG:BFREE' });
+    ok(a.setMediaTransfer(true) === true, 'the free seat ticks its own lobby box');
+    // The peer never does.
+    a.adoptLobby(); b.adoptLobby();
+    await pair.connect();
+    await tick(60);
+    a.proposeConsent(600, 0, 30000);
+    await tick(40);
+    a.confirmConsent(); b.confirmConsent();
+    await tick(60);
+
+    const q = createMediaQueue({
+      artifacts: fakeArtifacts([{ sha: SHA_IMG, bytes: 40000, mime: 'image/png', kind: 'image', exempt: false }]),
+      store: fakeStore(), logger: quiet, canSend: () => true, idlePollMs: 40,
+    });
+    q.attach(a, pair.host);
+    await tick(60);
+    ok(q.enabled() === false,
+      'the capability is granted and the lane is STILL shut — one consent short');
+    const why = q.tagsFor(GoonPayloadKind.FlashBurst);
+    ok(Array.isArray(why) && why.length === 0,
+      'so a media payload fires untagged, exactly as it does for a gated seat');
+    ok(a.mediaTransferAgreed === false,
+      'and the engine agrees: free to send is not the same as cleared to send');
+
+    q.detach(); a.dispose(); b.dispose(); pair.dispose();
   }
 
   // ------------------------------- 6b. the relay case: dormant, with no special case

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
@@ -287,7 +287,14 @@ function recorder(server) {
     'and says what is still free, rather than stopping at "no"');
   ok(S.sheets.noPass === undefined, 'the weekly-pass copy is retired — the server never sends it');
   ok(typeof S.title.hostNoLab === 'string' && S.title.hostNoLab === S.title.hostNoLab.toLowerCase(),
-    'the menu note is lowercase, same voice as lobby.transferNoPremium');
+    'the menu note is lowercase, same voice as lobby.transferOff');
+  /* HOSTING IS THE LAST PAID THING IN THE DUEL (2026-08-05). The lobby's
+   * send-side copy used to make the same pitch; it does not any more, and this
+   * pins that so a future edit cannot quietly re-sell a free capability. */
+  ok(S.lobby.transferNoPremium === undefined,
+    'the old "sending is a supporter perk" key is gone, not merely reworded');
+  ok(typeof S.lobby.transferOff === 'string' && !/supporter|perk|premium/i.test(S.lobby.transferOff),
+    'and its replacement explains the dark row without selling anything');
 
   const sheets = read('ui/sheets.js');
   ok(/case 'no_host_access':\s*\n\s*case 'no_pass':/.test(sheets),

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -1185,12 +1185,15 @@ async function testSelfDuel() {
 /* ================================================================================
  * 12. BETA GATES (pre-ship follow-ups, 2026-08-04)
  *
- *   a) THE PREMIUM SEND VERDICT. The standalone page used to grant itself
- *      caps.mediaTransfer=true unconditionally (the dev affordance). Now the
- *      server answers /invite and /join with `media_send` (tier>=1 — the same
- *      bar the C# host applies), the signaling client records it, boot.js folds
- *      it into session.caps for the standalone page, and bridge.js only keeps
- *      the always-on default when there is NO server in play at all.
+ *   a) THE SEND VERDICT. Was "the PREMIUM send verdict": the server answered
+ *      /invite and /join with `media_send` (tier>=1), the standalone cap
+ *      defaulted OFF against any real server, and boot.js flipped it on when the
+ *      verdict landed. Owner call 2026-08-05 made SENDING FREE FOR EVERY SEAT —
+ *      the paid perk is hosting alone — so the default inverted to ON and the
+ *      verdict became a VETO the server can still exercise (`media_send:false`)
+ *      rather than the grant that turns the lane on. Both directions are pinned
+ *      below, along with the free-seat fixture: a guest with no account at all
+ *      may send, and hosting is still refused to it.
  *   b) THE OWED OFFER. A guest that redeemed a code is owed the host's offer
  *      within a poll round trip; a dead host used to leave it on "joining…"
  *      forever because the ICE budget never started. NoOfferTimeoutMs now feeds
@@ -1219,17 +1222,134 @@ async function testBetaGates() {
       '/join carries the verdict and the client records true (premium)');
   }
 
+  /* --- a) THE FREE-SEAT FIXTURE (2026-08-05) -----------------------------------
+   * The owner's decision in one runnable shape: the seat with the LEAST standing
+   * this protocol has — an anonymous invite-link click, no account, no tier, a
+   * server-minted `g_` id — may SEND its media, and still may not HOST. The two
+   * halves are asserted against the same server instance on purpose: one gate
+   * moving must not drag the other with it.
+   * -------------------------------------------------------------------------- */
+  {
+    // Prod's answer as of 2026-08-04: media_send true unconditionally, host gate on.
+    const prod = new GoonFakeSignalingServer({ mediaSend: true, hostGate: true });
+    prod.setLabAccess('u_lab', true);
+
+    const labHost = new GoonSignalingClient({ post: prod.post, unifiedId: 'u_lab', logger: quiet });
+    const room = await labHost.createInvite('Lab');
+    ok(!!room && labHost.mediaSend === true, 'the tier-2 host mints a room and may send');
+
+    // `anonymous: true` is the whole free seat — /join omits unified_id and the
+    // server hands back the `g_` identity it minted (see net/signaling.js).
+    const freeSeat = new GoonSignalingClient({ post: prod.post, anonymous: true, logger: quiet });
+    const joined = await freeSeat.join(room.code, 'Nobody');
+    ok(!!joined, 'an anonymous invite-link click gets a seat with no account at all');
+    ok(/^g_[a-f0-9]{16}$/.test(freeSeat.guestId), 'and a server-minted guest identity');
+    ok(joined.mediaSend === true && freeSeat.mediaSend === true,
+      'AND THE SERVER SAYS IT MAY SEND — the free seat is a full participant in the media lane');
+
+    // The other half, unmoved: the same seat cannot mint a room of its own.
+    const wouldHost = new GoonSignalingClient({
+      post: prod.post, unifiedId: freeSeat.guestId, logger: quiet,
+    });
+    const refused = await wouldHost.createInvite('Nobody');
+    ok(refused === null && wouldHost.lastError === GoonSignalError.NoHostAccess,
+      'while HOSTING stays tier 2 — free to send, not free to host');
+
+    // And the veto still works, so the field is a live policy hook rather than
+    // decoration: a server that answers false is obeyed.
+    prod.setMediaSend(false);
+    prod.setLabAccess('u_lab2', true);          // clears the host gate; the veto is the subject here
+    const vetoed = new GoonSignalingClient({ post: prod.post, unifiedId: 'u_lab2', logger: quiet });
+    await vetoed.createInvite('Vetoed');
+    ok(vetoed.mediaSend === false,
+      'a server that answers media_send:false is still obeyed — the grant can be taken back');
+  }
+
   // --- a) the page halves, pinned at source level -------------------------------
   {
     const bridge = readSource('../bridge.js');
-    ok(/mediaTransfer:\s*!\(q\.get\('server'\)\s*\|\|\s*prefs\.serverBase\s*\|\|\s*defaultServerBase\(\)\)/.test(bridge),
-      'standaloneInit only self-grants sending when NO server is in play (query, prefs, or the public-deploy default)');
+    /* THE INVERSION, pinned. Was `!(q.get('server') || prefs.serverBase ||
+     * defaultServerBase())` — sending self-granted ONLY with no server in play.
+     * A free seat always has a server in play, so that expression was the client
+     * half of "my attacks throw blanks". */
+    ok(/mediaTransfer:\s*true,/.test(bridge),
+      'standaloneInit grants sending to every seat — the capability is free, hosting is the perk');
+    ok(!/mediaTransfer:\s*!\(q\.get\('server'\)/.test(bridge),
+      'and the old server-presence default is gone, not commented out beside it');
     ok(/\(\^\|\\\.\)cclabs\\\.app\$/.test(bridge),
       'defaultServerBase is pinned to the public deployment host, so dev origins keep the serverless playground');
+
     const boot = readSource('../boot.js');
-    ok(/typeof goonSession\.signaling\.mediaSend === 'boolean'/.test(boot)
-      && /!session\.hosted/.test(boot.slice(boot.indexOf('mediaSend') - 600, boot.indexOf('mediaSend') + 600)),
-      'boot.js folds the server verdict into session.caps — standalone only, hosted init stays authoritative');
+    ok(/function adoptServerSendVerdict\(\)/.test(boot),
+      'boot.js folds the server verdict through one named function');
+    const fold = boot.slice(boot.indexOf('function adoptServerSendVerdict()'));
+    ok(/if \(session\.hosted\) return;/.test(fold.slice(0, 400)),
+      'standalone only — the hosted init frame stays authoritative');
+    ok(/typeof verdict !== 'boolean'/.test(fold.slice(0, 600)),
+      'and a server that predates the field (null) changes nothing');
+    /* THE ORDERING, pinned at source. One call is not enough — see the runtime
+     * proof below for WHY — so all three sites have to survive a refactor. */
+    ok((boot.match(/adoptServerSendVerdict\(\);/g) || []).length >= 3,
+      'and it is called on every road into a match: attach, hostStart, joinStart');
+    ok(/await s\.host\(\);[\s\S]{0,400}?adoptServerSendVerdict\(\);/.test(boot),
+      'hostStart folds AFTER /invite answers');
+    ok(/await s\.join\(inviteCode\);[\s\S]{0,400}?adoptServerSendVerdict\(\);/.test(boot),
+      'joinStart folds AFTER /join answers');
+  }
+
+  /* --- a) WHY THE POST-AWAIT FOLD EXISTS, proven rather than asserted ----------
+   * GoonSession._beginSession constructs the signaling client, builds the match
+   * and raises currentMatchChanged — boot's attachMatch seam — and only THEN
+   * awaits createInvite/join, which is the round trip that learns `media_send`.
+   * So the verdict read at attach time is ALWAYS null on a first connect. Under
+   * the old default-OFF cap that left a free seat unable to send for the whole
+   * match no matter how loudly the server agreed. This models boot's fold with
+   * the same predicate and shows the two readings disagree.
+   * -------------------------------------------------------------------------- */
+  {
+    let mediaSend = null;                       // the signaling client's field
+    const signaling = { get mediaSend() { return mediaSend; }, dispose() {} };
+
+    class Leg {
+      constructor(isHost) { this.isHost = isHost; this.code = null; this.token = null; }
+      // The POST is what learns the verdict — exactly like the real client's
+      // _noteMediaSend, and deliberately not a line earlier.
+      async createInvite() { mediaSend = true; this.code = 'ROOM01'; this.token = 't'; return this.code; }
+      async join(c) { mediaSend = true; this.code = c; this.token = 't'; return true; }
+      async waitForChannel() { await sleep(5); return true; }
+      async close() {} dispose() {}
+    }
+    class Match {
+      constructor(t) { this.transport = t; }
+      createInvite() { return this.transport.createInvite(); }
+      join(c) { return this.transport.join(c); }
+      adoptLobby() { return true; }
+      cancelMatch() {} dispose() {}
+    }
+
+    // boot.js's fold, in miniature: same `typeof === 'boolean'` predicate.
+    const caps = { mediaTransfer: true };
+    const adopt = () => { if (typeof signaling.mediaSend === 'boolean') caps.mediaTransfer = signaling.mediaSend; };
+
+    const atAttach = [];
+    const session = new GoonSession({
+      logger: quiet,
+      createMatch: (t) => new Match(t),
+      createSignaling: () => signaling,
+      createWebrtc: (isHost) => new Leg(isHost),
+      createRelay: (isHost) => new Leg(isHost),
+    });
+    session.onCurrentMatchChanged((m) => { if (m) atAttach.push(signaling.mediaSend); });
+
+    const code = await session.host();
+    ok(code === 'ROOM01', 'the stub session mints a room');
+    ok(atAttach.length === 1 && atAttach[0] === null,
+      'THE RACE: at the attachMatch seam the verdict does not exist yet — it reads null');
+    ok(signaling.mediaSend === true,
+      'and only after the await does the server verdict exist at all');
+    adopt();
+    ok(caps.mediaTransfer === true, 'so the post-await fold is the one that can ever see it');
+    await session.dispose();
   }
 
   // --- b) the owed offer, transport half (needs a browser to run for real) ------

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -304,9 +304,16 @@ export function mount(container, ctx) {
   /**
    * The transfer row. THREE separate reasons it can be off, and each one gets its
    * own line, because "greyed out with no explanation" is the thing players report
-   * as a bug: not a supporter (send-side only — receiving is never gated), the
-   * peer's build does not speak the protocol, or the link is relayed (media never
-   * touches the server, so a relay physically cannot carry it).
+   * as a bug: the send capability is off for this seat, the peer's build does not
+   * speak the protocol, or the link is relayed (media never touches the server,
+   * so a relay physically cannot carry it).
+   *
+   * THE FIRST REASON USED TO BE "not a supporter" AND IS NOT ANY MORE (owner call
+   * 2026-08-05). Sending is free for every seat — the paid perk is hosting — so
+   * caps.mediaTransfer is true on every current host and this arm is now reserved
+   * for a server that vetoes sending (`media_send:false`) or a frame too old to
+   * carry the flag. Kept as an arm rather than deleted so the row can never go
+   * dark in silence; see S.lobby.transferOff.
    */
   function paintTransfer() {
     const caps = (ctx.session && ctx.session.caps) || {};
@@ -322,7 +329,7 @@ export function mount(container, ctx) {
     const editable = match.phase === GoonMatchPhase.Consent || match.phase === GoonMatchPhase.Lobby;
 
     let why = '';
-    if (caps.mediaTransfer !== true) why = S.lobby.transferNoPremium;
+    if (caps.mediaTransfer !== true) why = S.lobby.transferOff;
     else if (!match.peerSupportsTransfer) why = S.lobby.transferPeerOld;
     else if (!onP2P) why = stillDeciding ? S.lobby.transferConnecting : S.lobby.transferRelay;
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -35,7 +35,8 @@ export const S = Object.freeze({
   title: {
     kicker: '1v1 · endurance duel · first to break loses',
     host: 'Host a match',
-    // The dimmed-Host note. Same voice as lobby.transferNoPremium — lowercase, an explanation
+    // The dimmed-Host note, and since 2026-08-05 the ONLY "this costs money"
+    // sentence in the duel — sending stopped being one. Lowercase, an explanation
     // rather than a pitch, and it names the thing that is still free instead of stopping at "no".
     hostNoLab: 'hosting is a supporter perk — joining a room is always free.',
     join: 'Join with a code',
@@ -130,8 +131,20 @@ export const S = Object.freeze({
        willing to send, and the chip says what THEY answered. --- */
     transfer: 'Send them your own media',
     transferSub: 'a few of your images and clips go straight to them, machine to machine. never through a server.',
-    // Lowercase "supporter perk" on purpose: an explanation, not a pitch.
-    transferNoPremium: 'sending is a supporter perk — you can still receive theirs.',
+    /**
+     * NO LONGER A PITCH, because it is no longer a perk (owner call 2026-08-05):
+     * sending is free for every seat and the only thing money buys is HOSTING
+     * (title.hostNoLab, above). Renamed off `transferNoPremium` so the key stops
+     * lying about why the row is dark.
+     *
+     * Deliberately still HERE rather than deleted. caps.mediaTransfer can be
+     * false in exactly two ways now — a server that answers `media_send:false`
+     * (the policy hook the field was kept alive for), or a host frame so old it
+     * never carried the flag — and a greyed row with no sentence under it is the
+     * precise bug report this string family exists to prevent. Vague on purpose:
+     * naming a cause we cannot tell apart would be a guess.
+     */
+    transferOff: 'sending is switched off for this seat — you can still receive theirs.',
     transferPeerOld: 'their app is too old for this — nothing crosses either way.',
     transferRelay: 'only on a direct connection. this one is relayed.',
     /**


### PR DESCRIPTION
## What the owner asked for

Media **sending** becomes free for every seat. **Hosting stays a tier-2 perk and is untouched.** Joining stays free/anonymous. Both lobby consent ticks are still required before a single byte moves.

## The caps chain, as found

| Link | Where | State on `main` before this PR |
|---|---|---|
| Server mint (`/invite`) | `ccp-server` `proxy/goon-routes.js:680` | `media_send: true` — already unconditional (`5357a8c`, 2026-08-04) |
| Server mint (`/join`) | `proxy/goon-routes.js:850` | `media_send: true` — already unconditional |
| TURN mint | `fetchIceServers()`, both routes | already handed to **both** seats, no tier check |
| Wire | `net/signaling.js` `_noteMediaSend` | records `true` / `false` / `null` (old server) |
| C# host caps | `Services/GoonGame/GoonHostService.cs` `TransferAllowed()` | already `return true` (`d64f57c2`) |
| Standalone caps | `bridge.js` `standaloneInit` | **OFF whenever a server was in play** |
| Fold | `boot.js` `attachMatch` | **read the verdict too early — always `null`** |
| Send gate | `net/mediaQueue.js` `sendGate()` / `whyNoTags()` | `caps.mediaTransfer === true` |
| Lobby copy | `ui/screens/lobby.js` `paintTransfer` | said *sending is a supporter perk* |

So both entitlement values were already `true` — and a free guest still could not send. The client was refusing for two reasons that had nothing to do with tier.

## What actually broke it

**1. The default.** `bridge.js` granted `caps.mediaTransfer` only when *no* server was in play (the pure-local dev path). A real seat always has a server in play, so it started OFF and waited to be rescued by the server verdict.

**2. The race, which is why the rescue never arrived.** `GoonSession._beginSession()` constructs the signaling client, builds the match and raises `currentMatchChanged` — i.e. runs `boot.js attachMatch` — and only **then** awaits `createInvite`/`join`, which is the round trip that learns `media_send`. The fold lived in `attachMatch` alone, so on every first connect it read `null` and the cap kept its default for the whole match. Only the relay rebuild (which reuses an already-redeemed signaling client) ever saw a real verdict.

## The change

- **`bridge.js`** — `mediaTransfer: true`. The capability is free; the server verdict becomes a **veto** rather than the grant. Defaulting ON and letting the server say no is a very different failure mode from defaulting OFF and hoping a verdict lands in time.
- **`boot.js`** — the fold is now `adoptServerSendVerdict()`, called on all three roads: `attachMatch` (relay rebuild), and `hostStart`/`joinStart` **after** their awaits. `false` still turns sending off with no client release; `null` (pre-field server) still changes nothing; hosted pages are skipped (the C# init frame stays authoritative).
- **`ui/strings.js` + `ui/screens/lobby.js`** — `lobby.transferNoPremium` → `lobby.transferOff`, reworded. The arm is kept (not deleted) so the row can never grey out in silence, but it no longer sells a free capability.
- **Server** — no functional change was needed. The companion branch `feat/goon-free-sender` on `CC-Labs-llc/CCP-Server` documents the entitlement map at the top of `goon-routes.js` so nobody re-derives `media_send` from a tier.

Nothing in `core/`, `ui/hud.js` or the arsenal UI was touched (concurrent charge-gating work). `GOON_BUILD` deliberately not bumped.

## Consent is untouched

Free access to the *capability* bypasses nothing. `sendGate()` is one rung of six, and `6a-consent` in the flow suite proves it: grant the capability, leave one lobby tick off, and the lane stays shut with the queue naming consent as the reason.

## Cost consideration (owner has accepted this)

Transfers are P2P and the usual artifact never touches our server. But a link that cannot hole-punch — carrier-grade NAT, i.e. most cellular — falls back to the **metered.ca TURN relay**, and relayed media is bandwidth we pay for. Those credentials already went to both seats with no tier check, so **free seats can now generate relay bandwidth**. Accepted for now. If it ever needs capping, the cap belongs on the TURN mint (room-scoped, already the choke point) and **not** back on `media_send`, which would return us to the blank-attack bug.

## Voice notes — reported, not changed

**Voice notes have no tier gate anywhere, and no free-seat gap.** Checked end to end:

- `proxy/goon-routes.js` has **no** voice field at all — nothing is minted, so nothing can be withheld.
- `core/contracts.js` `caps.voice` is a protocol **revision integer**, not an entitlement — "this build can parse `t:'voice'`".
- `ui/voice/voiceService.js` `whyUnavailable()` has six rungs and **none** reads `session.caps`: local pref, our declaration, the peer's build, their declaration, the phase, and the mic.
- Voice rides the ordinary match frames, **not** the bulk media channel, so it never depended on `supportsBulk` or on `caps.mediaTransfer`.

The old "caps.transfer gap" note appears to be stale: voice is already free for every seat. **No voice change is in this PR.**

## Tests

`selftest-net` — the free-seat fixture: an anonymous `g_` seat (no account, no tier) is told it may send, **the same server still refuses it a room** (`no_host_access`), and a `media_send:false` veto is still obeyed. Plus source pins for the inverted default and all three fold sites, and a runtime proof that the attach-time read is `null`.

`selftest-flow` — `6a-free` drives `canSend` off a real free-seat caps object (not an arrow), the whole `sendGate` ladder passes and its media crosses the wire; `6a-consent` shows the lane shut one tick short.

`selftest-hostgate` — pins that the supporter pitch is gone from the transfer row and that hosting is now the only paid sentence in the duel.

```
assets  427/427   core  242   encode  190/190   flow  316   hostgate  97/97
hud  1622/1622    invite  199/199   net  350   report  213   transfer  199
voice  225        voice-ui  262   exec  1054
avafx  12 FAIL (pre-existing)
```

**`selftest-avafx`** fails its known 12 on a clean `origin/main` worktree taken before any edit here. Not from this branch.

**`selftest-exec` is FLAKY on `main`, not broken by this branch.** The check *"a tagged brain drain washes the EXACT artifact the tag names, ahead of the rotation"* fails intermittently - about 2 runs in 10, and it failed on the clean pre-edit baseline too. It came in with `4e38c97b` (PR #153), the commit immediately before this branch point, and it is timing-dependent: the assertion sleeps 60ms then reads the wash URL, so under load the rotation beats the tag and it reads `recv/d0.png` instead of `recv/exact.webp`. Worth its own fix; nothing to do with caps.

## Manual verification for the driver

1. Deploy the server (see below), then host from a tier-2 account and join from a phone on **cellular** with no CCP account, via a `?join=` link.
2. Both seats tick the lobby transfer box. Confirm the guest's row is **live** and no longer says *supporter perk*.
3. Guest throws a media payload — the desktop should render the guest's own image/clip, not fall back to its local pool.
4. With `?debug=1` on the guest, confirm the log line `server send verdict adopted: caps.mediaTransfer = true` and that `whyNoTags` never reports *this side's send capability is off*.
5. Confirm Host is still dimmed for the free account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U83oyVuKtjBJy2DQLuKW2D

