### PR TITLE
Goon Game: desktop voice notes (V key), mic failure recovery, honest P2P privacy copy

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -1427,9 +1427,21 @@ function reportMicGate() {
     // whether this host has a microphone API at all. Both are read defensively —
     // a handle-shaped stub (no service = a no-op mic) answers neither.
     let hudHidden = false;
+    let deskWhy = '';
     let micSupported;
-    try { if (mic && typeof mic.shown === 'function' && typeof mic.available === 'function') hudHidden = mic.available() && !mic.shown(); }
-    catch (_e) { /* leave it false */ }
+    /* WHICH piece of chrome, not just "some chrome". Zen and the arsenal drawer
+     * both take the slot away and they are undone by opposite gestures — and the
+     * drawer is the DESKTOP failure this breadcrumb existed for and could not
+     * name: an in-app seat plays with the drawer shut (every payload is on the
+     * number row) and the mic is a flow child of the panel that shutting it
+     * removes. Read defensively: a handle-shaped stub answers none of this. */
+    try { if (mic && typeof mic.hiddenBy === 'function') deskWhy = String(mic.hiddenBy() || ''); }
+    catch (_e) { /* an older handle simply cannot say */ }
+    if (deskWhy) hudHidden = deskWhy === 'zen';
+    else {
+      try { if (mic && typeof mic.shown === 'function' && typeof mic.available === 'function') hudHidden = mic.available() && !mic.shown(); }
+      catch (_e) { /* leave it false */ }
+    }
     try { if (mic && mic.recorder && typeof mic.recorder.supported === 'function') micSupported = !!mic.recorder.supported(); }
     catch (_e) { /* leave it undefined — the gate is then not reported */ }
 
@@ -1438,6 +1450,10 @@ function reportMicGate() {
       : (voice.available() ? '' : 'unknown (this build has no whyUnavailable)');
     // Shown and working: say nothing. A quiet log is the good outcome.
     if (!why && mic && typeof mic.shown === 'function' && mic.shown()) return;
+    if (!why && deskWhy === 'drawer') {
+      logger.warn('voice mic hidden: the arsenal drawer is shut and the mic is inside it — hold V to record, or open the drawer');
+      return;
+    }
     if (!why) { logger.warn('voice mic hidden: the service says live but the desk has no strip (mount failure?)'); return; }
     logger.warn('voice mic hidden: ' + why);
   } catch (e) {

--- a/ConditioningControlPanel/Resources/web/goon/core/contracts.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/contracts.js
@@ -496,8 +496,12 @@ export function makeEmote(o = {}) {
 
 /**
  * ONE VOICE NOTE, in three sub-frames (2026-08-04). APPEND-ONLY, and it rides the CONTROL lane —
- * the same channel as every message above — never `goon-media`: the bulk channel does not exist on
- * the relay fallback, and voice has to work on the worst link a duel can end up on.
+ * the same channel as every message above — never `goon-media`: the bulk channel is a second,
+ * out-of-band binary stream, and chunked base64 in an ordinary frame is what a fire-and-forget
+ * family wants. It was ALSO chosen so a note would survive the relay fallback; that reason is
+ * dead as of 2026-08-05. Voice notes are now P2P-ONLY (core/match.js `linkIsP2P` gates both the
+ * send door and the receive door): on a relayed duel these frames are neither sent nor accepted,
+ * because a recording of somebody's voice may not cross a wire we can read.
  *
  *   {t:'voice', sub:'meta',  id, bytes, durMs, emote|null, parts}   announces one note
  *   {t:'voice', sub:'chunk', id, seq, data}                         base64, capped well under 16K

--- a/ConditioningControlPanel/Resources/web/goon/core/match.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/match.js
@@ -335,12 +335,18 @@ export class GoonMatchService {
       connectionHealthChanged: makeEvent(),
       emoteReceived: makeEvent(),
       voiceFrameReceived: makeEvent(),
+      linkChanged: makeEvent(),
       mediaPrepChanged: makeEvent(),
       interactionCheckDue: makeEvent(),
       lobbyFailed: makeEvent(),
       matchEnded: makeEvent(),
       resultFinalized: makeEvent(),
     };
+
+    /* The last answer `linkIsP2P` gave, so `linkChanged` is an EDGE. Seeded from the
+     * transport as it is right now: a service built on an already-connected transport
+     * (the relay rebuild does exactly that) must not raise a change that did not happen. */
+    this._lastLinkP2P = this.linkIsP2P;
 
     const onMsg = bindFn(transport, ['onMessageReceived', 'onMessage']);
     const onState = bindFn(transport, ['onStateChanged', 'onState']);
@@ -398,6 +404,35 @@ export class GoonMatchService {
     return this._phase === GoonMatchPhase.Countdown
       || this._phase === GoonMatchPhase.Live
       || this._phase === GoonMatchPhase.SuddenDeath;
+  }
+
+  /**
+   * IS THIS LINK DIRECT? The one fact that decides whether a person's recorded voice may
+   * exist on this wire at all (owner call, 2026-08-05: voice notes are P2P-ONLY, exactly
+   * like media).
+   *
+   * ConnectedP2P is a DTLS/SCTP channel between the two machines — a TURN hop still
+   * qualifies, because TURN forwards ciphertext and never our JSON. ConnectedRelay is the
+   * `/v2/goon/relay` mailbox: our server, our TLS termination, plain base64 in a frame we
+   * could read. Voice used to ride that path on purpose (it is the CONTROL lane, and the
+   * control lane survives a fallback); it does not any more. On a relayed duel the mic is
+   * simply absent — see ui/voice/voiceService.js `available()` — and both the send door
+   * and the receive door below refuse, so an unpatched or hostile peer cannot push one
+   * through us either.
+   *
+   * NOT `transport.supportsBulk`, deliberately, even though that is the media lane's own
+   * P2P-only predicate: supportsBulk ALSO requires the out-of-band media channel to be
+   * open, and voice does not ride it. A P2P pair whose `goon-media` channel failed to
+   * construct (net/webrtcTransport.js catches that and carries on) still has a perfectly
+   * private control lane, and taking the mic off it would be a second, invisible reason
+   * for a missing button. The privacy claim is about the LINK, so the link is what is read.
+   *
+   * @returns {boolean} false for every transport that cannot answer — this fails CLOSED.
+   */
+  get linkIsP2P() {
+    try {
+      return !!this._transport && this._transport.state === GoonTransportState.ConnectedP2P;
+    } catch (_e) { return false; }
   }
 
   /** Are WE the one still picking media (`media_prep`, as last declared)? */
@@ -507,6 +542,15 @@ export class GoonMatchService {
    * ran. What core owes the service is a frame that is the right shape, from the right phase.
    */
   onVoiceFrame(fn) { return this._ev.voiceFrameReceived.on(fn); }
+  /**
+   * fn(isP2P) on the EDGE of `linkIsP2P` — the transport settling on a direct channel, or
+   * losing one. It exists for ui/voice/voiceService.js, whose availability bit (and therefore
+   * the mic on the desk) is now partly a fact about the link: without an edge to hang off, a
+   * link that changed under a live match would leave a mic on screen that can send nothing.
+   *
+   * EDGE, NOT STATE: Signaling -> ConnectingP2P raises nothing, because neither is direct.
+   */
+  onLinkChanged(fn) { return this._ev.linkChanged.on(fn); }
   /** fn(preparing) whenever the OPPONENT's `media_prep` declaration changes. */
   onMediaPrepChanged(fn) { return this._ev.mediaPrepChanged.on(fn); }
   /** No-cam only: prompt an interaction check, then call reportInteractionCheck(). */
@@ -850,6 +894,11 @@ export class GoonMatchService {
    *
    *   · not disposed, not ended, and the PHASE is Countdown/Live/SuddenDeath. A note that lands
    *     on a recap has nowhere to play and a note before the countdown is a mic hot in a lobby;
+   *   · THE LINK IS DIRECT (`linkIsP2P`, 2026-08-05). A voice note is somebody's actual voice
+   *     and it may only exist on a wire we cannot read: on the relay mailbox every frame is
+   *     plain base64 JSON through our own server, so the answer there is not "encrypt it
+   *     later", it is NOTHING LEAVES. The mic is hidden for that duel and this door is the
+   *     backstop under the hidden mic;
    *   · BOTH consents plus the peer's `caps.voice` (voiceNotesAgreed). Sending to a build that
    *     never heard of the family is not "harmless": the frame is dropped silently at the far end
    *     and this family has NO receipt, so the sender would sit there believing it landed;
@@ -867,6 +916,10 @@ export class GoonMatchService {
   sendVoiceFrame(sub, fields = {}) {
     if (this._disposed || this._ended) return false;
     if (!this.voicePhaseOpen) return false;
+    // P2P ONLY. Ahead of the consent check on purpose: the consents are about each other,
+    // this one is about US, and no agreement either side can reach makes it acceptable for
+    // a recording of a voice to cross our server.
+    if (!this.linkIsP2P) return false;
     if (!this.voiceNotesAgreed) return false;
 
     const msg = makeVoice(Object.assign({}, fields, {
@@ -1125,6 +1178,13 @@ export class GoonMatchService {
     this._info(`transport state ${state}`);
     if (state === GoonTransportState.ConnectedP2P || state === GoonTransportState.ConnectedRelay) {
       this._sendHelloOnce();
+    }
+    // THE LINK EDGE, for whoever's feature is P2P-only (voice notes, today). Raised from the
+    // getter rather than from `state` so there is exactly one definition of "direct".
+    const p2p = this.linkIsP2P;
+    if (p2p !== this._lastLinkP2P) {
+      this._lastLinkP2P = p2p;
+      this._ev.linkChanged.emit(p2p, (e) => this._warn(`linkChanged handler threw: ${e && e.message}`));
     }
   }
 
@@ -1588,12 +1648,17 @@ export class GoonMatchService {
   }
 
   /**
-   * An inbound voice frame. TWO gates and nothing else:
+   * An inbound voice frame. THREE gates and nothing else:
    *
    *   1. the PHASE. A note that arrives on the recap (or in the lobby) is dropped without being
    *      looked at — post-match frames are ignored, per the protocol, and a mic that could reach
    *      somebody after they tapped out is the one shape of this feature nobody agreed to;
-   *   2. the SUB. '' is what clampVoiceSub answers for a kind we do not know, which is how a
+   *   2. THE LINK (2026-08-05). A voice frame that came up the relay mailbox is dropped where it
+   *      lands. Our own send door refuses to put one there, so anything arriving over the server
+   *      is a peer running an older build or a modified one — and "they sent it anyway" must not
+   *      be a way to make somebody's voice pass through us. DEFENCE IN DEPTH: the promise the
+   *      copy now makes is about this wire, not about the politeness of the other end;
+   *   3. the SUB. '' is what clampVoiceSub answers for a kind we do not know, which is how a
    *      newer peer's fourth sub arrives — ignored, never routed, never an error.
    *
    * Everything else — the local opt-in, the size ceilings, the rate limit, the assembly, the
@@ -1603,6 +1668,7 @@ export class GoonMatchService {
    */
   _handleVoice(frame) {
     if (!this.voicePhaseOpen) return;
+    if (!this.linkIsP2P) return;
     if (!frame.sub || !VOICE_SUBS.includes(frame.sub)) return;
     frame.emote = frame.emote == null ? null : (sanitizeText(frame.emote, EMOTE_ICON_MAX_CHARS) || null);
     this._ev.voiceFrameReceived.emit(frame, (e) => this._warn(`voiceFrame handler threw: ${e && e.message}`));

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4836,7 +4836,12 @@ const audioMod = await import('../ui/audio.js');
   }
 
   {
-    // the feature going away under a live hold
+    /* The feature going away under a live hold — and since 2026-08-05 the commonest
+     * REAL cause of that edge is the link: voice notes are P2P-only, so a duel that
+     * degrades to the relay mailbox mid-recording drops `available()` and lands here.
+     * The service raises the edge (test/selftest-voice.js §5), and this is the half
+     * that says a running microphone dies with it rather than staying hot behind a
+     * button nobody can see. */
     const m = mountMic();
     m.v._set(true);
     ptr(m.btn, 'pointerdown', 200);
@@ -4845,6 +4850,7 @@ const audioMod = await import('../ui/audio.js');
     await sleep(20);
     ok(m.r.st.cancels === 1, 'voice going unavailable mid-hold cancels the recording');
     ok(m.host.hidden === true, 'and the mic leaves with it');
+    ok(m.v._sends.length === 0, 'and NOTHING was sent — a cancelled hold is not a note');
     m.mic.unmount();
   }
 
@@ -4993,6 +4999,16 @@ const audioMod = await import('../ui/audio.js');
     ok(micMod.sendReasonLine('unavailable') === S20.voice.notActive, 'a dead feature explains itself');
     ok(micMod.sendReasonLine('nonsense-from-the-future') === S20.voice.sendFailed,
       'and an unknown reason still says something true');
+    /* THE RELAYED LINK (2026-08-05). Voice notes are P2P-only, so 'relay' is a
+     * refusal a player cannot act on — and it must NOT borrow `notActive`, which
+     * sends them looking for a toggle that would change nothing. In practice the
+     * mic is already off the desk by then; this line is for the race where the
+     * link degrades between the release and the send. */
+    ok(micMod.sendReasonLine('relay') === S20.voice.relayOff,
+      'a relayed link gets its own sentence', micMod.sendReasonLine('relay'));
+    ok(micMod.sendReasonLine('relay') !== micMod.sendReasonLine('unavailable')
+      && micMod.sendReasonLine('relay') !== micMod.sendReasonLine('nope'),
+    '...which is neither the "switch it on" line nor the generic failure');
 
     /* TWO KINDS OF NO, AND THEY ARE NOT THE SAME SENTENCE. sendReasonLine is
      * about a NOTE that failed to cross; micReasonLine is about a MICROPHONE

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4953,7 +4953,167 @@ const audioMod = await import('../ui/audio.js');
     hud20b.unmount();
   }
 
-  /* --- 20f. the CSS half --------------------------------------------------
+  /* --- 20f. THE DRAWER, AND THE DESK'S OWN KEY ----------------------------
+   *
+   * THE DESKTOP BUG (owner, 2026-08-05, in-app seat): both players opted in,
+   * the phone's mic appeared, the desktop's never did. The mic is the last flow
+   * child of `.gg-arsenal-panel` — and a shut drawer is display:none over that
+   * whole panel (sidebar rule 3). A desktop seat plays with it shut, because
+   * every payload it throws is on the number row, so the one control in the
+   * drawer with no key of its own was simply not on the desk.
+   *
+   * Two halves, and both are pinned here: the drawer is a THIRD hiding bit that
+   * must close the microphone the way zen does, and the desk owns a push-to-talk
+   * key that drives the same gesture — asking for the drawer first, and giving
+   * it back after. */
+  {
+    const m = mountMic();
+    m.v._set(true);
+    ok(typeof m.mic.setDeskShut === 'function' && typeof m.mic.hold === 'function'
+      && typeof m.mic.hiddenBy === 'function',
+    'the mic takes the drawer bit, a driven hold, and says which chrome is on it');
+    ok(m.mic.hiddenBy() === '', 'live and on the desk: nothing is sitting on it');
+    m.mic.setDeskShut(true);
+    ok(m.host.hidden === true, 'a shut drawer takes the slot away, exactly as zen does');
+    ok(m.mic.available() === true && m.mic.shown() === false,
+      '...without pretending the FEATURE went away — the drawer is chrome, not consent');
+    ok(m.mic.hiddenBy() === 'drawer', 'and it names the drawer, not zen');
+    ok(m.mic.hold(true) === false && m.r.st.starts === 0,
+      'a hold is REFUSED while there is no strip to draw it on: no microphone opens behind a shut panel');
+    m.mic.setDeskShut(false);
+    ok(m.host.hidden === false && m.mic.hiddenBy() === '', 'and it comes back with the drawer');
+    m.mic.unmount();
+  }
+
+  {
+    // the drawer closing UNDER a live hold. The zen hole, in its second form:
+    // display:none does not end a gesture, so the bit has to be pushed.
+    const m = mountMic();
+    m.v._set(true);
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ok(m.mic.isRecording() === true, 'a hold is running');
+    m.mic.setDeskShut(true);
+    await sleep(30);
+    ok(m.r.st.cancels === 1 && m.v._sends.length === 0,
+      'shutting the drawer CANCELS it — never a hot mic behind a panel nobody can see');
+    ok(m.mic.isRecording() === false, 'and the gesture is over');
+    m.mic.unmount();
+  }
+
+  {
+    // hold(true)/hold(false) is the SAME machine the button drives.
+    const m = mountMic();
+    m.v._set(true);
+    ok(m.mic.hold(true) === true, 'the desk can begin a hold without a pointer');
+    ok(m.r.st.starts === 1, 'and the microphone opens on the same first instruction');
+    await sleep(320);
+    ok(m.mic.isRecording() === true, 'the 250ms threshold is the one threshold');
+    ok(m.mic.hold(false, 'up') === true, 'releasing ends it');
+    await sleep(30);
+    ok(m.r.st.stops === 1 && m.v._sends.length === 1, 'and the note goes out exactly once');
+    ok(m.mic.hold(false, 'up') === false, 'a release with nothing held does nothing');
+    m.mic.unmount();
+  }
+
+  {
+    // a KEYED tap names the key, not a button they may not have on screen.
+    const m = mountMic();
+    m.v._set(true);
+    m.mic.hold(true);
+    await sleep(60);
+    m.mic.hold(false, 'up');
+    await sleep(20);
+    ok(m.v._sends.length === 0 && m.r.st.cancels === 1, 'a tapped key is a tap: nothing is sent');
+    ok(m.mic.parts.hint.textContent === S20.voice.holdKeyHint,
+      'and the hint tells them to HOLD THE KEY, not to hold a mic they cannot see',
+      m.mic.parts.hint.textContent);
+    m.mic.unmount();
+  }
+
+  {
+    // the reveal handshake: asked for BEFORE the microphone opens, and given
+    // back only when the strip folds — "sending…" and "sent" need it too.
+    const host = document.createElement('div');
+    const chipHost = document.createElement('div');
+    const v = fakeVoice();
+    const r = fakeRec();
+    const seen = [];
+    let mic = null;
+    mic = micMod.mountMicHud({
+      host, chipHost, voice: v, recorder: r.api,
+      onReveal: (on) => { seen.push(on); try { mic.setDeskShut(!on); } catch (_e) { /* pre-assign */ } },
+    });
+    v._set(true);
+    mic.setDeskShut(true);
+    ok(mic.hold(true) === true, 'a desk that CAN show the slot gets its recording');
+    ok(seen[0] === true && r.st.starts === 1, 'and it was asked before the microphone opened',
+      JSON.stringify(seen));
+    await sleep(320);
+    mic.hold(false, 'up');
+    await sleep(30);
+    ok(seen.length === 1, 'the drawer is NOT snatched back on the release');
+    await sleep(micMod.MIC_FLASH_MS + 150);
+    ok(seen[seen.length - 1] === false, 'it goes back when the strip folds', JSON.stringify(seen));
+    ok(mic.shown() === false, 'and the desk is exactly how the player left it');
+    mic.unmount();
+  }
+
+  {
+    // ...and end to end through the real desk: the key, the drawer, the note.
+    const match20k = makeFakeMatch();
+    const voice20k = fakeVoice();
+    const prefs20k = { get: (k) => (k === 'arsenalOpen' ? 'shut' : undefined), set() {} };
+    const hud20k = hudMod.mountHud({
+      match: match20k, audio: { sfx() {} }, voice: voice20k, prefs: prefs20k,
+    });
+    const frame20k = dom.byId.get('gg-hud');
+    const micHost20k = findOne(frame20k, 'gg-voice-host');
+    voice20k._set(true);
+    ok(micHost20k.hidden === true,
+      'a remembered SHUT drawer starts with no mic on the desk — the desktop bug, reproduced');
+    ok(hud20k.parts.mic.hiddenBy() === 'drawer', 'and the desk knows exactly why');
+    dom.win.dispatchEvent({ type: 'keydown', key: 'v', repeat: false, preventDefault() {} });
+    ok(micHost20k.hidden === false, 'the key opens the drawer for the note it is about to record');
+    /* This desk is running the REAL ui/voice/recorder.js against a node stub
+     * with no getUserMedia, so the microphone is refused a tick later — which
+     * is the other thing worth pinning: a refusal hands the drawer straight back
+     * instead of leaving the player looking at an arsenal they did not open. The
+     * recording itself is exercised above, against the injectable recorder. */
+    await sleep(60);
+    ok(hud20k.parts.mic.isRecording() === false, 'a host with no microphone records nothing');
+    ok(micHost20k.hidden === true, 'and the drawer goes back to shut, because we only borrowed it');
+    ok(voice20k._sends.length === 0, 'with nothing whatsoever on the wire');
+
+    // A key that is not the mic's must not reach it. Escape especially: during
+    // Live that is Mercy, and a voice note may never add a rung to that ladder.
+    dom.win.dispatchEvent({ type: 'keydown', key: 'Escape', repeat: false, preventDefault() {} });
+    dom.win.dispatchEvent({ type: 'keydown', key: '1', repeat: false, preventDefault() {} });
+    await sleep(20);
+    ok(hud20k.parts.mic.isRecording() === false && micHost20k.hidden === true,
+      'Escape and the payload digits do not touch the mic');
+    // ...and focus leaving is the keyboard's lostpointercapture: a key-up
+    // delivered to another window never arrives, so a hold would otherwise
+    // strand an open microphone. It must be safe to fire with nothing held.
+    dom.win.dispatchEvent({ type: 'blur' });
+    await sleep(20);
+    ok(hud20k.parts.mic.isRecording() === false, 'and a stray blur is a no-op, not a throw');
+    hud20k.unmount();
+  }
+
+  {
+    // The binding lives on the DESK, and the module that holds the microphone
+    // still owns no keys at all (20d scans micHud.js for exactly this).
+    const fs20k = await import('node:fs/promises');
+    const url20k = await import('node:url');
+    const hudSrc20k = await fs20k.readFile(url20k.fileURLToPath(new URL('../ui/hud.js', import.meta.url)), 'utf8');
+    const bare20k = hudSrc20k.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    ok(/MIC_KEY\s*=\s*'v'/.test(bare20k), 'ui/hud.js spells the mic key ONCE, and it is v');
+    ok(/setDeskShut\(!sideOpen\)/.test(bare20k),
+      'and pushes the drawer bit into the mic the way it pushes zen');
+  }
+
+  /* --- 20g. the CSS half --------------------------------------------------
    * micHud.js only toggles classes. Placement, the click-through, the animation
    * budget and zen are all stylesheet facts, and a mic with no rules would pass
    * every check above while lying across the stage eating clicks. */

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -4564,6 +4564,147 @@ const audioMod = await import('../ui/audio.js');
     ok(f.tracks[0].stopped === true, 'dispose() mid-recording takes the microphone with it');
   }
 
+  /* --- 20b-bis. ONE FAILURE MAY NOT POISON THE NEXT PRESS ------------------
+   *
+   * THE REPORTED BUG (owner, 2026-08-05): "the mic can be triggered once, but if
+   * that first recording fails the button never resets — every press after it
+   * says that one did not record". Every check in this block is a way that used
+   * to happen, and all of them share one shape: something left the recorder OUT
+   * OF `idle` with nobody waiting on it, and `start()` answers everything that
+   * is not idle with 'busy' — which the strip rendered as a refusal, forever.
+   * ---------------------------------------------------------------------- */
+  {
+    // A microphone whose permission prompt is never ANSWERED (swiped away on
+    // iOS, where that promise then simply never settles).
+    const tracks = [{ kind: 'audio', stopped: false, stop() { this.stopped = true; } }];
+    let resolveGum = null;
+    const rec = recMod.createVoiceRecorder({
+      // A cap the block cannot reach (the disowned attempt below is waited out
+      // in real time) and a short start ceiling, so it is waited out quickly.
+      maxMs: 30_000,
+      startTimeoutMs: 150,
+      getUserMedia: () => new Promise((res) => { resolveGum = res; }),
+      recorderFactory: () => ({ start() {}, stop() { setTimeout(() => { try { this.onstop && this.onstop(); } catch (_e) { /* ignore */ } }, 0); } }),
+      isTypeSupported: () => true,
+    });
+
+    const first = rec.start();
+    await sleep(0);
+    ok(rec.state() === 'starting', 'a press with a prompt still up leaves the recorder starting');
+    // ...and the gesture goes away underneath it: a tap, or the prompt itself
+    // stealing the pointer and firing pointercancel.
+    const cancelled = await rec.cancel();
+    ok(cancelled.reason === 'cancelled', 'cancelling during the prompt answers at once, without waiting for it');
+
+    const second = rec.start();
+    await sleep(0);
+    ok(typeof resolveGum === 'function', 'the second press asked for a microphone of its own');
+    resolveGum({ getTracks: () => tracks });
+    const r2 = await second;
+    ok(r2.ok === true && r2.reason === 'recording',
+      'A PRESS AFTER A DISOWNED ONE IS A FRESH ATTEMPT — not the "busy" that used to stick for the session',
+      JSON.stringify(r2));
+    ok(rec.isRecording() === true, 'and it really is recording');
+    const r1 = await first;
+    /* AND IT ANSWERS 'cancelled', NOT A FAILURE. Its ceiling expires long after
+     * the gesture that asked for it is forgotten, and a caller that RECOVERS
+     * from failures (the mic HUD does, deliberately) would otherwise take the
+     * microphone off the recording that replaced it, half a minute later. */
+    ok(r1.ok === false && r1.reason === 'cancelled',
+      'a superseded attempt reports itself cancelled, not failed', JSON.stringify(r1));
+    ok(rec.isRecording() === true, '...and does not disturb the recording that replaced it');
+    rec.dispose();
+  }
+
+  {
+    // ...and where nothing supersedes it, the attempt gives up on its own.
+    const tracks = [{ kind: 'audio', stopped: false, stop() { this.stopped = true; } }];
+    let resolveGum = null;
+    const rec = recMod.createVoiceRecorder({
+      startTimeoutMs: 120,
+      getUserMedia: () => new Promise((res) => { resolveGum = res; }),
+      recorderFactory: () => ({ start() {}, stop() {} }),
+    });
+    const res = await rec.start();
+    ok(res.ok === false && res.reason === 'failed',
+      'a getUserMedia that never answers is written off, not waited on forever', JSON.stringify(res));
+    ok(rec.state() === 'idle', 'AND THE MACHINE IS LEFT PRESSABLE — this is the whole bug');
+    resolveGum({ getTracks: () => tracks });
+    await sleep(5);
+    ok(tracks[0].stopped === true,
+      'a stream that lands after the timeout is stopped where it arrives — rule 1 does not care that it was late');
+    rec.dispose();
+  }
+
+  {
+    // The recovery door the UI reaches for when it is refused and cannot say why.
+    const f = fakeMic();
+    await f.rec.start();
+    ok(f.rec.state() === 'recording', 'a recording is running');
+    f.rec.reset();
+    ok(f.rec.state() === 'idle', 'reset() puts it back to idle from anywhere');
+    ok(f.tracks[0].stopped === true, '...taking the microphone with it, like every other terminal path');
+    const again = await f.rec.start();
+    ok(again.ok === true, 'and the next press records rather than being told "busy"');
+    f.rec.dispose();
+  }
+
+  {
+    // THE TIMESLICE. Without it WebKit may hand over nothing at all for a short
+    // note, which arrives at the player as "that one did not record".
+    const tracks = [{ kind: 'audio', stopped: false, stop() { this.stopped = true; } }];
+    let sliceSeen = 'never started';
+    const rec = recMod.createVoiceRecorder({
+      getUserMedia: () => Promise.resolve({ getTracks: () => tracks }),
+      recorderFactory: () => ({ start(ms) { sliceSeen = ms; }, stop() {} }),
+    });
+    await rec.start();
+    ok(sliceSeen === recMod.VN_TIMESLICE_MS,
+      'MediaRecorder is started WITH a timeslice, so a note is assembled as it is spoken',
+      String(sliceSeen));
+    ok(recMod.VN_TIMESLICE_MS > 0 && recMod.VN_TIMESLICE_MS <= 1000,
+      'and it is short enough that the shortest keepable note still has a chunk in it');
+    rec.dispose();
+  }
+
+  {
+    // A recorder that dies MID-NOTE. Nobody asked it to stop, so nobody is
+    // awaiting an answer — it has to volunteer one.
+    const tracks = [{ kind: 'audio', stopped: false, stop() { this.stopped = true; } }];
+    let made = null;
+    const rec = recMod.createVoiceRecorder({
+      getUserMedia: () => Promise.resolve({ getTracks: () => tracks }),
+      recorderFactory: () => { made = { start() {}, stop() {} }; return made; },
+    });
+    await rec.start();
+    const seen = [];
+    rec.onFailed((p) => seen.push(p));
+    made.onerror({ error: new Error('the pipeline fell over') });
+    ok(seen.length === 1 && seen[0].reason === 'recorder-error',
+      'a recorder that dies mid-note SAYS so, instead of letting the strip count against nothing');
+    ok(tracks[0].stopped === true, 'and hands the microphone back on the way down');
+    ok(rec.state() === 'idle', 'and is pressable again without anybody having to ask');
+    rec.dispose();
+  }
+
+  {
+    // release() answering a stop that is still in flight. A recorder that never
+    // fires `stop` AND is reset under the caller must still settle the promise —
+    // an await that never returns is a strip stuck on "sending…".
+    const tracks = [{ kind: 'audio', stopped: false, stop() { this.stopped = true; } }];
+    const rec = recMod.createVoiceRecorder({
+      getUserMedia: () => Promise.resolve({ getTracks: () => tracks }),
+      recorderFactory: () => ({ start() {}, stop() { /* never fires onstop */ } }),
+    });
+    await rec.start();
+    const pending = rec.stop();
+    rec.reset();
+    const settled = await Promise.race([pending, sleep(50).then(() => 'NEVER SETTLED')]);
+    ok(settled !== 'NEVER SETTLED', 'a pending stop() is ANSWERED by the release under it, never dropped');
+    ok(rec.state() === 'idle', 'and the machine is idle behind it');
+    rec.dispose();
+  }
+
   /* --- 20c. the gesture --------------------------------------------------- */
   function fakeVoice() {
     const stateSubs = new Set();
@@ -4852,6 +4993,108 @@ const audioMod = await import('../ui/audio.js');
     ok(micMod.sendReasonLine('unavailable') === S20.voice.notActive, 'a dead feature explains itself');
     ok(micMod.sendReasonLine('nonsense-from-the-future') === S20.voice.sendFailed,
       'and an unknown reason still says something true');
+
+    /* TWO KINDS OF NO, AND THEY ARE NOT THE SAME SENTENCE. sendReasonLine is
+     * about a NOTE that failed to cross; micReasonLine is about a MICROPHONE
+     * that never opened. Telling somebody "that one did not record" when nothing
+     * ever started is how a mic problem gets mistaken for a recording problem. */
+    ok(typeof micMod.micReasonLine === 'function', 'ui/voice/micHud.js exports micReasonLine');
+    ok(micMod.micReasonLine('denied') === S20.voice.micDenied, 'a refused mic is a refusal, not a failure');
+    ok(micMod.micReasonLine('missing') === S20.voice.micMissing, 'no device says no device');
+    ok(micMod.micReasonLine('unsupported') === S20.voice.micMissing, '...and so does a host with no getUserMedia');
+    ok(micMod.micReasonLine('cancelled') === '', 'our own gesture ending it says NOTHING — there is nothing to report');
+    ok(micMod.micReasonLine('busy') === S20.voice.micFailed
+      && micMod.micReasonLine('failed') === S20.voice.micFailed
+      && micMod.micReasonLine('nonsense-from-the-future') === S20.voice.micFailed,
+    'and everything else blames the mic rather than the recording', micMod.micReasonLine('busy'));
+    ok(micMod.micReasonLine('failed') !== S20.voice.sendFailed,
+      'the two lines are actually DIFFERENT — this used to be one string doing both jobs');
+    ok(/try again/i.test(S20.voice.micFailed), 'and it says the thing that is now true: try again');
+  }
+
+  /* --- 20c-quater. A THROWN SEAM IS NOT A DEAD BUTTON ----------------------
+   *
+   * The other half of the reported stuck mic, on this side of the wire. Both
+   * awaits in stopAndSend are on INJECTABLE handles, and a rejection from either
+   * one used to walk out as an unhandled rejection with the strip still reading
+   * "sending…" — a phase onDown refuses. The mic was then dead for the match.
+   * ---------------------------------------------------------------------- */
+  function mountBrokenMic(broken) {
+    const host = document.createElement('div');
+    const chipHost = document.createElement('div');
+    const v = fakeVoice();
+    const st = { starts: 0, resets: 0 };
+    const api = {
+      start() { st.starts++; return Promise.resolve({ ok: true, reason: 'recording' }); },
+      stop() {
+        return broken === 'stop'
+          ? Promise.reject(new Error('the recorder fell over'))
+          : Promise.resolve({ ok: true, reason: 'stopped', blob: { size: 64 }, durMs: 900 });
+      },
+      cancel() { return Promise.resolve({ ok: false, reason: 'cancelled' }); },
+      state() { return 'idle'; },
+      isRecording() { return false; },
+      elapsedMs() { return 900; },
+      maxMs() { return 10000; },
+      mimeType() { return ''; },
+      onCapped() { return () => {}; },
+      reset() { st.resets++; },
+      dispose() {},
+    };
+    if (broken === 'send') v.sendBlob = () => Promise.reject(new Error('the wire died'));
+    const mic = micMod.mountMicHud({ host, chipHost, voice: v, recorder: api });
+    v._set(true);
+    return { mic, btn: mic.parts.button, st, v };
+  }
+
+  {
+    const m = mountBrokenMic('stop');
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ptr(m.btn, 'pointerup', 200);
+    await sleep(40);
+    ok(m.st.resets === 1, 'a stop() that REJECTS is recovered from, not left in flight');
+    ok(m.mic.parts.timeEl.textContent === S20.voice.micFailed,
+      'and the player is told the MIC failed, not that their note did',
+      m.mic.parts.timeEl.textContent);
+    ok(m.mic.phase() !== 'send', 'the strip is not left on "sending…"', m.mic.phase());
+    // ...and the very next press is a whole new recording, with no wait.
+    ptr(m.btn, 'pointerdown', 200);
+    ok(m.st.starts === 2, 'THE NEXT PRESS RECORDS — one failure does not poison the mic');
+    m.mic.unmount();
+  }
+
+  {
+    const m = mountBrokenMic('send');
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ptr(m.btn, 'pointerup', 200);
+    await sleep(40);
+    ok(m.mic.parts.timeEl.textContent === S20.voice.sendFailed,
+      'a sendBlob that REJECTS reports a failed note (the recording was fine — the wire was not)',
+      m.mic.parts.timeEl.textContent);
+    ptr(m.btn, 'pointerdown', 200);
+    ok(m.st.starts === 2, 'and the mic is pressable straight afterwards');
+    m.mic.unmount();
+  }
+
+  {
+    /* A FLASH IS NOT A LOCK. The terminal word sits on the strip for
+     * MIC_FLASH_MS, and a player who has just been told a note failed reaches
+     * STRAIGHT back for the button. A press that is ignored for over a second
+     * is indistinguishable from the stuck mic all of this is about. */
+    const m = mountMic();
+    m.v._set(true);
+    ptr(m.btn, 'pointerdown', 200);
+    await sleep(320);
+    ptr(m.btn, 'pointerup', 200);
+    await sleep(30);
+    ok(m.mic.phase() === 'flash', 'a finished note flashes its word');
+    ptr(m.btn, 'pointerdown', 200);
+    ok(m.r.st.starts === 2, 'pressing DURING the flash cuts it short and opens the mic again');
+    await sleep(320);
+    ok(m.mic.isRecording() === true, 'and that press becomes a real recording');
+    m.mic.unmount();
   }
 
   /* --- 20d. ESCAPE IS NOT TOUCHED ----------------------------------------- */

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
@@ -987,7 +987,8 @@ function mountSheet(provider) {
     return m;
   }
 
-  function mountLobby({ prefs, sheets, match }) {
+  /** `linkState` is a parameter because voice notes are P2P-only: the row says so. */
+  function mountLobby({ prefs, sheets, match, linkState = GoonTransportState.ConnectedP2P }) {
     const container = dom.byId.get('scr-lobby');
     container.replaceChildren();
     const handle = lobbyScreen.mount(container, {
@@ -995,7 +996,7 @@ function mountSheet(provider) {
       audio: null, prefs, sheets, discord: null, logger: quiet,
       session: { caps: {} },
       getMatch: () => match,
-      getTransport: () => ({ state: GoonTransportState.ConnectedP2P, onStateChanged() { return () => {}; } }),
+      getTransport: () => ({ state: linkState, onStateChanged() { return () => {}; } }),
     });
     return { container, handle };
   }
@@ -1113,6 +1114,44 @@ function mountSheet(provider) {
       ok(value && value.textContent === (state.remoteVoiceNotes ? S.voice.lobbyTheirsOn : S.voice.lobbyTheirsOff),
         'and the chip carries THEIR half, like the transfer row above it');
       handle.unmount();
+    }
+  }
+
+  /* ---- THE RELAYED LINK OUTRANKS ALL FOUR (2026-08-05) ----------------------
+   *
+   * Voice notes went P2P-only on the same day media did, so a duel that fell back
+   * to the server mailbox has no mic on either side. The row has to SAY that,
+   * ahead of every other sentence: "voice notes on for this match" over a relayed
+   * link would be a straight lie, and "they have not" would blame the opponent for
+   * a network. The checkbox stays live on purpose — it is the standing answer and
+   * the receive gate, not a per-link switch.
+   */
+  {
+    const prefs = createPrefs();
+    prefs.set('voiceAckSeen', true);
+    const match = fakeLobbyMatch({ localVoiceNotes: true, remoteVoiceNotes: true });
+    const { container, handle } = mountLobby({
+      prefs, sheets: fakeSheets(), match, linkState: GoonTransportState.ConnectedRelay,
+    });
+    const sub = findOne(container, 'gg-voice-lobbyline');
+    ok(sub && sub.textContent === S.voice.lobbyRelay,
+      'both sides opted in, but the link is relayed — the row says the link', sub && sub.textContent);
+    const input = findTag(findOne(container, 'gg-voice-lobbyrow'), 'input')[0];
+    ok(input.disabled === false,
+      'and the box stays live: it is the standing answer and the receive gate, not a per-link switch');
+    handle.unmount();
+
+    // ...and while ICE is still deciding, the verdict is NOT shown early — the exact
+    // bug the transfer row's own comment describes.
+    for (const st of [GoonTransportState.Signaling, GoonTransportState.ConnectingP2P, GoonTransportState.Disconnected]) {
+      const p2 = createPrefs();
+      p2.set('voiceAckSeen', true);
+      const m2 = fakeLobbyMatch({ localVoiceNotes: true, remoteVoiceNotes: true });
+      const r2 = mountLobby({ prefs: p2, sheets: fakeSheets(), match: m2, linkState: st });
+      const s2 = findOne(r2.container, 'gg-voice-lobbyline');
+      ok(s2 && s2.textContent === S.voice.lobbyBoth,
+        'state ' + st + ' has decided nothing, so the ordinary sentence stands', s2 && s2.textContent);
+      r2.handle.unmount();
     }
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
@@ -832,8 +832,26 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
       V.ack.headline + ' | ' + V.ack.line);
     ok(/hear/i.test(V.ack.lineTwo),
       'and the SECOND says you may hear THEM — the half a player can otherwise miss', V.ack.lineTwo);
-    ok(/server/i.test(V.ack.line) || /server/i.test(V.voice === undefined ? '' : V.lead),
-      'and somewhere on the way in it says no server is involved');
+    /* WHERE THE AUDIO GOES, PINNED HONEST (2026-08-05 privacy pass).
+     *
+     * This used to assert only that the word "server" appeared "somewhere on the
+     * way in", and the copy it was green against said "no server ever hears them"
+     * — which is false the moment ICE gives up. A voice note rides the CONTROL
+     * lane exactly so it survives a relayed link (see the voiceService.js header),
+     * and on that link every frame is plain JSON through /v2/goon/relay. So the
+     * assertions are now about CONTENT, in both directions:
+     *   · the sheet names the recipient, because that is the consent;
+     *   · the sheet and the lead both admit the relay hop; and
+     *   · neither of them may ever claim again that no server is involved. */
+    const voiceCopy = V.ack.line + ' ' + V.ack.lineTwo + ' ' + V.lead;
+    ok(/duelling|opponent|them|their/i.test(V.ack.line),
+      'the ack sheet names WHO gets the recording — that is the consent being asked for', V.ack.line);
+    ok(/relay|relayed/i.test(V.ack.line) && /relay|relayed/i.test(V.lead),
+      'and both the sheet and the screen lead admit the relayed hop through our server',
+      V.ack.line + ' | ' + V.lead);
+    ok(!/no server|never touches a server|nothing is uploaded|no server ever/i.test(voiceCopy),
+      'and NOTHING in the voice copy claims a server is never involved — it is, on the fallback path',
+      voiceCopy);
     ok(/hear|hears/i.test(V.toggleOn) && /drop/i.test(V.toggleOff),
       'the toggle hints name both directions on and the unread drop off',
       V.toggleOn + ' / ' + V.toggleOff);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
@@ -4,9 +4,16 @@
 //   node Resources/web/goon/test/selftest-voice.js
 //
 // It exists because this is the first feature on the page that carries a PERSON
-// rather than a picture, and almost all of it is refusals. Four properties are
+// rather than a picture, and almost all of it is refusals. Five properties are
 // worth more than the rest of the file put together, and every one of them is
 // pinned below against the code that would quietly undo it:
+//
+//   0. IT NEVER CROSSES OUR SERVER. Voice notes are P2P-ONLY as of 2026-08-05,
+//      exactly like media: on a relayed duel the send door refuses ('relay'),
+//      an inbound frame is dropped where it lands, the mic is not on the desk,
+//      and the copy says so without a caveat. This is the one property that
+//      cannot be restored by an apology if it is broken, so it is pinned at the
+//      engine, at the service, at the copy and in both directions.
 //
 //   1. NOTHING CROSSES WITHOUT BOTH CONSENTS. `voice_notes` is a per-side
 //      declaration on the consent frame, cloned from `media_transfer` — which
@@ -19,9 +26,11 @@
 //   3. THE CEILINGS HOLD AGAINST A LYING PEER. The declared size and the
 //      accumulated size are two different checks on purpose, and the second one
 //      is the one that catches a meta claiming 40 KB in front of 4 MB.
-//   4. A FRAME ALWAYS FITS THE LANE. Voice rides the CONTROL channel (the relay
-//      has no bulk one), which clamps at 16 KB including the JSON envelope, so
-//      the worst-case chunk frame is serialized here and measured.
+//   4. A FRAME ALWAYS FITS THE LANE. Voice rides the CONTROL channel (there is
+//      no bulk one to ride), which clamps at 16 KB including the JSON envelope,
+//      so the worst-case chunk frame is serialized here and measured. The lane
+//      is unchanged by rule 0 — what changed is that the lane is only allowed
+//      to carry a note when the lane itself is a direct P2P channel.
 //
 // Everything runs under plain node: no DOM, no mic, no AudioContext. The one
 // place a graph is needed (the playback queue) gets a fake one.
@@ -29,7 +38,7 @@
 import { serialize, parse, wireByteLength, MAX_WIRE_BYTES } from '../core/wire.js';
 import {
   makeConsent, makeVoice, makeHello, makeCaps,
-  GoonMatchPhase, VOICE_SUBS, VOICE_CAP_VERSION, clampVoiceSub, peerSpeaksVoice,
+  GoonMatchPhase, GoonTransportState, VOICE_SUBS, VOICE_CAP_VERSION, clampVoiceSub, peerSpeaksVoice,
 } from '../core/contracts.js';
 import { local as localCaps } from '../core/caps.js';
 import { GoonMatchService } from '../core/match.js';
@@ -65,27 +74,38 @@ function bytes(count, seed = 7) {
  * have to be provable with the engine's answers pinned by hand, and the real
  * engine is exercised separately in section 2.
  */
-function fakeMatch({ agreed = true, phaseOpen = true } = {}) {
+function fakeMatch({ agreed = true, phaseOpen = true, p2p = true } = {}) {
   const frames = [];
   const voiceSubs = new Set();
+  const linkSubs = new Set();
   const m = {
     frames,
     get voiceNotesAgreed() { return agreed; },
     get voicePhaseOpen() { return phaseOpen; },
+    /** The engine's P2P-only bit. `deliver` below still fires on a relayed link,
+     *  ON PURPOSE: that is the modified-peer case the service must survive. */
+    get linkIsP2P() { return p2p; },
     setAgreed(v) { agreed = v; },
     setPhaseOpen(v) { phaseOpen = v; },
+    setLink(v) {
+      const next = !!v;
+      if (next === p2p) return;
+      p2p = next;
+      for (const fn of Array.from(linkSubs)) fn(next);
+    },
     onVoiceFrame(fn) { voiceSubs.add(fn); return () => voiceSubs.delete(fn); },
     onConsentChanged() { return () => {}; },
     onPhaseChanged() { return () => {}; },
+    onLinkChanged(fn) { linkSubs.add(fn); return () => linkSubs.delete(fn); },
     /** Push a frame at the service the way core/match.js would (parsed + clamped). */
     deliver(fields) {
       const f = parse(serialize(makeVoice(fields)));
       for (const fn of Array.from(voiceSubs)) fn(f);
       return f;
     },
-    sendVoiceMeta(o) { if (!agreed || !phaseOpen) return false; frames.push({ sub: 'meta', ...o }); return true; },
-    sendVoiceChunk(id, seq, data) { if (!agreed || !phaseOpen) return false; frames.push({ sub: 'chunk', id, seq, data }); return true; },
-    sendVoiceEnd(id) { if (!agreed || !phaseOpen) return false; frames.push({ sub: 'end', id }); return true; },
+    sendVoiceMeta(o) { if (!agreed || !phaseOpen || !p2p) return false; frames.push({ sub: 'meta', ...o }); return true; },
+    sendVoiceChunk(id, seq, data) { if (!agreed || !phaseOpen || !p2p) return false; frames.push({ sub: 'chunk', id, seq, data }); return true; },
+    sendVoiceEnd(id) { if (!agreed || !phaseOpen || !p2p) return false; frames.push({ sub: 'end', id }); return true; },
   };
   return m;
 }
@@ -180,7 +200,12 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 
 // ================================================= 2. the engine's send/receive gates
 {
-  const mk = (tag) => new GoonMatchService({
+  /* `state` IS NOT DECORATION ANY MORE. Voice notes are P2P-only, so the engine reads
+   * the transport's state at both doors — a stub without one is a relayed link as far
+   * as core/match.js is concerned, and every send below would refuse. The relay-shaped
+   * stub gets its own block at the end of this section. */
+  const mk = (tag, state = GoonTransportState.ConnectedP2P) => new GoonMatchService({
+    state,
     send() { return Promise.resolve(true); },
     onMessageReceived() { return () => {}; },
     onStateChanged() { return () => {}; },
@@ -300,6 +325,63 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
     ok(m.localVoiceNotes === true, 'and cloneSheet kept OUR value, not theirs');
     ok(m.remoteVoiceNotes === false && m.voiceNotesAgreed === false,
       'their opt-out is recorded as theirs and nothing is agreed');
+    m.dispose();
+  }
+
+  // --- THE LINK GATE, at the engine, in BOTH directions -----------------------------------
+  //
+  // The whole of the P2P-only rule, at the tier that owns the wire. A relayed duel is a
+  // fully legitimate duel in every other respect — connected, agreed, mid-phase — and the
+  // ONLY thing different about it is that our server can read the frames. That is enough.
+  {
+    for (const state of [GoonTransportState.ConnectedRelay, GoonTransportState.Reconnecting,
+      GoonTransportState.Signaling, GoonTransportState.Disconnected]) {
+      const m = mk('GG:vrelay', state);
+      const sent = [];
+      m._send = (msg) => { sent.push(msg); };
+      m._phase = GoonMatchPhase.Live;
+      m._localVoiceNotes = true;
+      m._remoteVoiceNotes = true;
+      m._peerSupportsVoice = true;
+
+      ok(m.linkIsP2P === false, `state ${state} is not a direct link`);
+      ok(m.sendVoiceMeta({ id: 1, bytes: 10, durMs: 100, parts: 1 }) === false
+        && m.sendVoiceChunk(1, 0, 'AAAA') === false && m.sendVoiceEnd(1) === false,
+      `state ${state}: every voice verb refuses — consent and phase cannot buy a relayed note`);
+      ok(sent.length === 0, `state ${state}: and NOTHING reached the transport`);
+
+      // ...and the receive door, which is the half a modified peer would attack.
+      const got = [];
+      m.onVoiceFrame((f) => got.push(f));
+      m._handleVoice(parse(serialize(makeVoice({ sub: 'meta', id: 1, bytes: 9, parts: 1 }))));
+      m._handleVoice(parse(serialize(makeVoice({ sub: 'chunk', id: 1, seq: 0, data: 'AAAA' }))));
+      ok(got.length === 0, `state ${state}: an inbound voice frame off the mailbox is dropped, not delivered`);
+      m.dispose();
+    }
+
+    // The same engine, once the link comes up direct: nothing about the gate is sticky.
+    const t = {
+      state: GoonTransportState.Signaling,
+      send() { return Promise.resolve(true); },
+      onMessageReceived() { return () => {}; },
+      onStateChanged(fn) { t._fire = () => fn(t.state); return () => {}; },
+    };
+    const m = new GoonMatchService(t, true, { logger: quiet, tag: 'GG:vlink' });
+    m._phase = GoonMatchPhase.Live;
+    m._localVoiceNotes = true; m._remoteVoiceNotes = true; m._peerSupportsVoice = true;
+    const edges = [];
+    m.onLinkChanged((v) => edges.push(v));
+    ok(m.sendVoiceEnd(1) === false, 'while ICE is still deciding, no note leaves');
+    t.state = GoonTransportState.ConnectedP2P;
+    t._fire();
+    ok(edges.length === 1 && edges[0] === true,
+      'the link edge fires ONCE when it settles direct — what the mic hangs its availability on',
+      JSON.stringify(edges));
+    ok(m.sendVoiceEnd(1) === true, 'and the same engine now sends');
+    t.state = GoonTransportState.ConnectedRelay;
+    t._fire();
+    ok(edges.length === 2 && edges[1] === false, 'a link that stops being direct raises the other edge');
+    ok(m.sendVoiceEnd(1) === false, 'and the door shuts again with it');
     m.dispose();
   }
 
@@ -671,6 +753,88 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
     svc.dispose();
   }
 
+  // --- THE RELAY REFUSAL, which is the whole privacy promise ---------------------------
+  //
+  // Everything else on this page degrades on a relayed link. This does not degrade: it is
+  // ABSENT. The reason is its own word ('relay', never the catch-all 'unavailable') because
+  // ui/voice/micHud.js says a different sentence for it and because a player who reads
+  // "you both have to switch it on" would go looking for a switch that would not help.
+  {
+    const match = fakeMatch({ p2p: false });
+    const svc = createVoiceService({ match, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet, now: () => 1e6 });
+
+    const r = await svc.sendBlob(bytes(4000), { durMs: 3000 });
+    ok(!r.ok && r.reason === 'relay', 'a relayed link refuses the send with its OWN reason', JSON.stringify(r));
+    ok(match.frames.length === 0, 'and not one frame was handed to the engine — there is no fallback path');
+    ok(svc.available() === false, 'the service says the feature is not live');
+    ok(/relayed/.test(svc.whyUnavailable()) && /P2P|direct/i.test(svc.whyUnavailable()),
+      '...and says why in words a play-test log can read', svc.whyUnavailable());
+    ok(svc.stats().sendDropped === 1, 'the refusal is counted as a drop, like every other one',
+      JSON.stringify(svc.stats()));
+
+    // The store path leans on the same door rather than carrying its own copy of the rule.
+    const store = { get: async () => ({ blob: bytes(500), durMs: 2500, emote: '👀' }) };
+    const svc2 = createVoiceService({ match, audio: fakeAudio(), prefs: fakePrefs(), noteStore: store, logger: quiet, now: () => 1e6 });
+    ok((await svc2.sendNote('n1')).reason === 'relay', 'a pre-recorded note is refused on the same terms');
+    ok(match.frames.length === 0, 'still nothing on the wire');
+    svc2.dispose();
+
+    // ...and the link coming back is not sticky either way.
+    match.setLink(true);
+    const back = await svc.sendBlob(bytes(4000), { durMs: 3000 });
+    ok(back.ok, 'and a link that comes up direct sends normally', JSON.stringify(back));
+    svc.dispose();
+  }
+
+  // --- THE RECEIVE GUARD: an unpatched (or hostile) peer cannot push one through us ------
+  //
+  // core/match.js refuses to DELIVER a voice frame on a relayed link, so in the real page
+  // nothing reaches the service at all. This drives the service directly anyway — the
+  // stub's `deliver` ignores the link on purpose — because the tier that promises "never
+  // decoded, never played" is this one, and a promise that only holds while the layer
+  // below it is intact is not a promise.
+  {
+    const match = fakeMatch({ p2p: false });
+    const audio = fakeAudio();
+    const svc = createVoiceService({ match, audio, prefs: fakePrefs(), logger: quiet, now: () => 1e6 });
+
+    const b64 = bytesToVoiceB64(bytes(600));
+    match.deliver({ sub: 'meta', id: 1, bytes: 600, parts: 1, durMs: 2000 });
+    match.deliver({ sub: 'chunk', id: 1, seq: 0, data: b64 });
+    match.deliver({ sub: 'end', id: 1 });
+    await tick();
+    ok(audio.played.length === 0, 'a note that arrived over the relay is NEVER played');
+    ok(svc.stats().received === 0 && svc.stats().recvDropped === 3,
+      'every frame of it was dropped where it landed, unassembled', JSON.stringify(svc.stats()));
+
+    // The same frames on a direct link do play — this is a link gate, not a broken receiver.
+    match.setLink(true);
+    match.deliver({ sub: 'meta', id: 2, bytes: 600, parts: 1, durMs: 2000 });
+    match.deliver({ sub: 'chunk', id: 2, seq: 0, data: b64 });
+    match.deliver({ sub: 'end', id: 2 });
+    await tick();
+    ok(audio.played.length === 1, '...while the identical note on a direct link arrives normally');
+    svc.dispose();
+  }
+
+  // --- the mic presents as unavailable, and the edge that takes it off the desk ----------
+  {
+    const match = fakeMatch();
+    const svc = createVoiceService({ match, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet, now: () => 1e6 });
+    const edges = [];
+    svc.onStateChanged((v) => edges.push(v));
+    ok(svc.available() === true, 'a direct, agreed, live duel has a mic');
+
+    match.setLink(false);
+    ok(edges.length === 1 && edges[0] === false,
+      'THE LINK EDGE TAKES IT AWAY — which is what ui/voice/micHud.js cancels a live hold on',
+      JSON.stringify(edges));
+    ok(svc.available() === false, 'and the predicate agrees');
+    match.setLink(true);
+    ok(edges.length === 2 && edges[1] === true, 'and puts it back if the link ever came good');
+    svc.dispose();
+  }
+
   // --- sendNote leans on the store, and degrades without one ---------------------------
   {
     const match = fakeMatch();
@@ -794,8 +958,8 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
       'linkLabel', 'linkNone', 'linkHelp',
       'hudLabel', 'holdHint', 'slideToCancel', 'sending', 'sent', 'cancelled', 'sendFailed',
       'incoming', 'incomingWithEmote',
-      'lobbyBoth', 'lobbyYours', 'lobbyTheirs', 'lobbyPeerOld',
-      'micDenied', 'micMissing', 'notActive', 'volumeHint',
+      'lobbyBoth', 'lobbyYours', 'lobbyTheirs', 'lobbyPeerOld', 'lobbyRelay',
+      'micDenied', 'micMissing', 'notActive', 'relayOff', 'volumeHint',
     ];
     let missing = '';
     for (const k of flat) if (typeof V[k] !== 'string' || V[k] === '') missing += k + ' ';
@@ -832,26 +996,56 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
       V.ack.headline + ' | ' + V.ack.line);
     ok(/hear/i.test(V.ack.lineTwo),
       'and the SECOND says you may hear THEM — the half a player can otherwise miss', V.ack.lineTwo);
-    /* WHERE THE AUDIO GOES, PINNED HONEST (2026-08-05 privacy pass).
+    /* WHERE THE AUDIO GOES, PINNED HONEST — AND THE TRUTH IT PINS HAS CHANGED ONCE
+     * ALREADY (2026-08-05).
      *
-     * This used to assert only that the word "server" appeared "somewhere on the
-     * way in", and the copy it was green against said "no server ever hears them"
-     * — which is false the moment ICE gives up. A voice note rides the CONTROL
-     * lane exactly so it survives a relayed link (see the voiceService.js header),
-     * and on that link every frame is plain JSON through /v2/goon/relay. So the
-     * assertions are now about CONTENT, in both directions:
-     *   · the sheet names the recipient, because that is the consent;
-     *   · the sheet and the lead both admit the relay hop; and
-     *   · neither of them may ever claim again that no server is involved. */
+     * Round one asserted only that the word "server" appeared "somewhere on the way
+     * in", against copy that said "no server ever hears them" — false the moment ICE
+     * gave up, because voice rode the CONTROL lane precisely so it would survive a
+     * relayed link, and on that link every frame was plain JSON through
+     * /v2/goon/relay. Round two made the copy ADMIT that hop, and pinned the
+     * admission here.
+     *
+     * ROUND THREE IS THE OWNER'S CALL AND IT IS THE ONE THESE ASSERTIONS NOW GUARD:
+     * the hop is GONE. Voice notes are P2P-only (core/match.js `linkIsP2P` at both
+     * doors, ui/voice/voiceService.js `available()` on the mic), so the unconditional
+     * sentence is true again and the copy is allowed to say it. Which means the test
+     * has to work in the OPPOSITE direction from round two:
+     *   · the sheet still names the recipient, because that is the consent;
+     *   · the sheet and the lead both claim the DIRECT link and "never through our
+     *     servers" — and if a future edit ever puts a voice frame back on the relay,
+     *     these two lines become a lie, so §2's link-gate block is the other half of
+     *     this test and neither may be relaxed alone;
+     *   · neither may describe a note travelling THROUGH us on any path;
+     *   · and the relayed case is still SAID, as a feature that is off rather than a
+     *     hop that is disclosed. */
     const voiceCopy = V.ack.line + ' ' + V.ack.lineTwo + ' ' + V.lead;
     ok(/duelling|opponent|them|their/i.test(V.ack.line),
       'the ack sheet names WHO gets the recording — that is the consent being asked for', V.ack.line);
-    ok(/relay|relayed/i.test(V.ack.line) && /relay|relayed/i.test(V.lead),
-      'and both the sheet and the screen lead admit the relayed hop through our server',
+    ok(/direct/i.test(V.ack.line) && /direct/i.test(V.lead),
+      'both the sheet and the screen lead say the note takes the DIRECT link', V.ack.line + ' | ' + V.lead);
+    ok(/never through our server/i.test(V.ack.line) && /never through our server/i.test(V.lead),
+      'and both make the unconditional promise the P2P-only rule now backs',
       V.ack.line + ' | ' + V.lead);
-    ok(!/no server|never touches a server|nothing is uploaded|no server ever/i.test(voiceCopy),
-      'and NOTHING in the voice copy claims a server is never involved — it is, on the fallback path',
-      voiceCopy);
+    ok(!/(passes|pass|travels|routed|goes|sent) (through|via) (our|the) (server|relay)/i.test(voiceCopy)
+      && !/through our server on the way/i.test(voiceCopy),
+    'and NOTHING in the voice copy describes a note travelling through us — there is no such path any more',
+    voiceCopy);
+    ok(/relay/i.test(V.ack.line) && /(switched off|off for that duel|not there|no voice)/i.test(V.ack.line + ' ' + V.lead),
+      'the relayed case is still said out loud — as the feature being OFF, not as a hop being disclosed',
+      V.ack.line + ' | ' + V.lead);
+    ok(typeof V.lobbyRelay === 'string' && V.lobbyRelay !== ''
+      && typeof V.relayOff === 'string' && V.relayOff !== '',
+    'and it has its own two lines: one for the lobby row, one for the mic strip',
+    V.lobbyRelay + ' | ' + V.relayOff);
+    ok(/relay|direct/i.test(V.lobbyRelay) && /direct|relay/i.test(V.relayOff),
+      'both of which name the LINK rather than blaming the player', V.lobbyRelay + ' | ' + V.relayOff);
+    ok(!/error|fail|sorry|cannot|denied/i.test(V.lobbyRelay + ' ' + V.relayOff),
+      'and neither is phrased as a failure — nothing broke, the note simply has nowhere private to go',
+      V.lobbyRelay + ' | ' + V.relayOff);
+    ok(/taken back|theirs/i.test(V.ack.lineTwo),
+      'the fact that survives every rewrite: once it lands it is theirs and cannot be taken back',
+      V.ack.lineTwo);
     ok(/hear|hears/i.test(V.toggleOn) && /drop/i.test(V.toggleOff),
       'the toggle hints name both directions on and the unread drop off',
       V.toggleOn + ' / ' + V.toggleOff);
@@ -1103,21 +1297,27 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 
     ok(/local pref off/.test(svc.whyUnavailable()), 'gate 1: our own opt-in, named first', svc.whyUnavailable());
     prefs.set('voiceNotesEnabled', true);
+    // GATE 2 IS THE LINK, and it is deliberately ahead of everything about the two
+    // players: it is the only gate that is about US, and it is terminal for the match.
+    m.setLink(false);
+    ok(/relayed/.test(svc.whyUnavailable()),
+      'gate 2: a relayed link, named as the link rather than as somebody\'s toggle', svc.whyUnavailable());
+    m.setLink(true);
     ok(/our declaration never rode/.test(svc.whyUnavailable()),
-      'gate 2: the pref is on but the declaration never went out — OUR bug, and it says so',
+      'gate 3: the pref is on but the declaration never went out — OUR bug, and it says so',
       svc.whyUnavailable());
     m.localVoiceNotes = true;
-    ok(/caps\.voice/.test(svc.whyUnavailable()), 'gate 3: their BUILD, named as a build problem', svc.whyUnavailable());
+    ok(/caps\.voice/.test(svc.whyUnavailable()), 'gate 4: their BUILD, named as a build problem', svc.whyUnavailable());
     m.peerSupportsVoice = true;
-    ok(/peer never declared/.test(svc.whyUnavailable()), 'gate 4: their side is switched off', svc.whyUnavailable());
+    ok(/peer never declared/.test(svc.whyUnavailable()), 'gate 5: their side is switched off', svc.whyUnavailable());
     m.remoteVoiceNotes = true;
-    ok(/phase is closed/.test(svc.whyUnavailable()), 'gate 5: the phase', svc.whyUnavailable());
+    ok(/phase is closed/.test(svc.whyUnavailable()), 'gate 6: the phase', svc.whyUnavailable());
     m.setPhaseOpen(true);
     ok(svc.whyUnavailable({ micSupported: false }).indexOf('getUserMedia') >= 0,
-      'gate 6: a host with no microphone API at all — reported, never a silent dead button');
-    ok(/zen-hidden/.test(svc.whyUnavailable({ hudHidden: true })), 'gate 7: the desk chrome is off');
+      'gate 7: a host with no microphone API at all — reported, never a silent dead button');
+    ok(/zen-hidden/.test(svc.whyUnavailable({ hudHidden: true })), 'gate 8: the desk chrome is off');
     ok(svc.whyUnavailable({ micSupported: true, hudHidden: false }) === '',
-      'and with all seven answered it says NOTHING — a quiet log is the good outcome');
+      'and with all eight answered it says NOTHING — a quiet log is the good outcome');
     // The two host facts are OPTIONAL: this module never touches navigator.
     ok(svc.whyUnavailable() === '', 'a caller that cannot answer them does not get them reported');
     svc.dispose();

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -103,6 +103,28 @@ export const ARSENAL_NARROW_MQ = '(orientation: portrait), (max-width: 720px)';
 /** Keys 1..N, i.e. one per payload slot. ui/arsenal.js owns the binding. */
 const ARSENAL_KEY_COUNT = ARSENAL_ITEMS.filter((i) => i.kind !== null).length;
 
+/**
+ * THE MIC'S KEY — push to talk, and the desktop half of voice notes.
+ *
+ * The mic lives in the arsenal drawer, under the emote tile, because that is
+ * where a hand looks for it. A DESKTOP seat does not use that drawer: every
+ * payload is on the number row (ui/arsenal.js binds 1..7 to `window` precisely
+ * so the drawer can stay shut and the stage stay clear), and a shut drawer is
+ * `display:none` over the whole panel — mic included. So the one control in
+ * there without a key of its own was simply not on an in-app player's desk,
+ * however loudly both seats had opted in. That is the bug this constant fixes.
+ *
+ * WHY IT IS BOUND HERE AND NOT IN THE MIC. ui/voice/micHud.js has no key
+ * handler of any kind, deliberately and pinned by the suite: Escape during Live
+ * is Mercy, and the way to guarantee a voice note can never add a rung to that
+ * ladder is for the module holding the microphone to own no keys at all. The
+ * desk owns this one and drives the gesture through `mic.hold()`.
+ *
+ * WHY `v`. It is not a payload digit, not the Mercy key, not a browser
+ * accelerator on its own, and it is the first letter of the thing it does.
+ */
+const MIC_KEY = 'v';
+
 /** Is this a phone-shaped screen? Absent matchMedia (node, old hosts) = no. */
 function isNarrowViewport() {
   try {
@@ -673,6 +695,13 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
         sideTab.title = sideOpen ? label : S.arsenal.sidebarTitle;
       } catch (_e) { /* stub DOM */ }
     }
+    /* THE MIC IS INSIDE THIS DRAWER, and a shut drawer is display:none over the
+     * whole panel (sidebar rule 3 in ui/hud.css). CSS alone is not enough for
+     * the same reason it was not enough for zen: pointer capture bypasses hit
+     * testing, so shutting the drawer on a live hold would leave a microphone
+     * open behind a panel nobody can see. The bit is pushed, exactly like zen's,
+     * and micHud ends the gesture on its ordinary cancel path. */
+    try { micRef?.setDeskShut(!sideOpen); } catch (_e) { /* a no-op handle has no bit */ }
   }
 
   function setSide(on, remember) {
@@ -799,13 +828,82 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
    * your own opt-in) and ui/voice/voiceService.js is the one place that knows —
    * the desk subscribes to the answer instead of re-deriving any of it. With no
    * service at all this is a no-op handle and no DOM. */
-  const mic = mountMicHud({ host: voiceHost, chipHost: voiceChipHost, voice, audio, onLog });
+  /* WHAT THE DRAWER OWES BACK. `null` = we have not opened it for the mic;
+   * `false` = it was shut when a keyed hold asked for it, so it goes back to
+   * shut the moment the strip folds. A player who opens the drawer themselves
+   * mid-note keeps it open — the debt is only ever the one WE took on. */
+  let micDrawerRestore = null;
+  const mic = mountMicHud({
+    host: voiceHost, chipHost: voiceChipHost, voice, audio, onLog,
+    /* The key binding below can fire while the drawer this slot lives in is
+     * display:none. Rather than move a node (micHud must never re-append one:
+     * that releases pointer capture) the desk simply opens the drawer for the
+     * length of the note and puts it back. Not remembered — a hold is not a
+     * decision about where the player likes their arsenal. */
+    onReveal: (on) => {
+      if (on) {
+        micDrawerRestore = sideOpen ? null : false;
+        if (!sideOpen) setSide(true, false);
+        return;
+      }
+      const owed = micDrawerRestore;
+      micDrawerRestore = null;
+      if (owed === false) setSide(false, false);
+    },
+  });
   /* Zen is restored from prefs BEFORE this mount, so the handle is told the bit
    * it was not there to hear. setZen's own early-return means it would never be
    * re-sent, and a remembered zen with a visible mic under it is the one state
    * that would make the toggle look broken on the first click. */
   micRef = mic;
   try { mic.setHudHidden(zenOn); } catch (_e) { /* a no-op handle has no bit */ }
+  /* ...and the drawer bit, for the same reason and on the same terms: paintSide
+   * ran before this mount existed, so the starting state has to be handed over
+   * once by hand or a HUD that came up with a shut drawer would think its mic
+   * was on screen. */
+  try { mic.setDeskShut(!sideOpen); } catch (_e) { /* a no-op handle has no bit */ }
+
+  /* ---- PUSH TO TALK (see MIC_KEY at the top of this file) -----------------
+   *
+   * The desktop half of voice notes: hold V to record, release to send. It is
+   * the SAME gesture the button runs — micHud.hold() drives the one machine, so
+   * the 250ms threshold, the ten-second cap, the "sending…/sent" strip and the
+   * 4s floor are all shared rather than re-implemented for a keyboard.
+   *
+   * ESCAPE IS NOT TOUCHED HERE EITHER. This handler looks at one key and returns
+   * for every other, so Escape during Live still walks boot.js's ladder to
+   * Mercy. A held recording is released by the key that is holding it, or by the
+   * window losing focus (below), which is the keyboard's `lostpointercapture`:
+   * without it, alt-tabbing mid-hold would strand an open microphone, because a
+   * key-up delivered to another window never arrives here.
+   */
+  function micKeyMatch(e) {
+    return !!e && String(e.key || '').toLowerCase() === MIC_KEY;
+  }
+  function typingInto() {
+    const active = d && d.activeElement;
+    const tag = active && active.tagName ? String(active.tagName).toLowerCase() : '';
+    return tag === 'input' || tag === 'textarea' || !!(active && active.isContentEditable);
+  }
+  const winRef = typeof window !== 'undefined' ? window : null;
+  led.listen(winRef, 'keydown', (e) => {
+    if (!micKeyMatch(e) || e.repeat || e.ctrlKey || e.altKey || e.metaKey) return;
+    if (typingInto()) return;
+    let took = false;
+    try { took = !!micRef?.hold(true); } catch (_e) { /* never let a key break the desk */ }
+    if (took && typeof e.preventDefault === 'function') e.preventDefault();
+  });
+  led.listen(winRef, 'keyup', (e) => {
+    // NO guards on the way OUT beyond the key itself. Whatever happened in
+    // between — a modifier pressed mid-hold, focus landing in a field, the
+    // drawer moving — the microphone that was opened has to close, and it closes
+    // on the path that SENDS, because the player let go on purpose.
+    if (!micKeyMatch(e)) return;
+    try { micRef?.hold(false, 'up'); } catch (_e) { /* ignore */ }
+  });
+  led.listen(winRef, 'blur', () => {
+    try { micRef?.hold(false, 'lost'); } catch (_e) { /* ignore */ }
+  });
 
   led.add(() => { try { mic.unmount(); } catch (_e) { /* gone */ } });
   led.add(() => { try { announcer.unmount(); } catch (_e) { /* gone */ } });

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -824,8 +824,9 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   const announcer = mountAnnouncer({ host: root, match, audio, onLog });
 
   /* The mic. Mounted unconditionally and hidden by itself: whether a duel has
-   * voice in it is five facts wide (both consents, the peer's build, the phase,
-   * your own opt-in) and ui/voice/voiceService.js is the one place that knows —
+   * voice in it is six facts wide (the LINK being direct — voice notes are
+   * P2P-only, like media — both consents, the peer's build, the phase, your own
+   * opt-in) and ui/voice/voiceService.js is the one place that knows —
    * the desk subscribes to the answer instead of re-deriving any of it. With no
    * service at all this is a no-op handle and no DOM. */
   /* WHAT THE DRAWER OWES BACK. `null` = we have not opened it for the mic;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -369,15 +369,33 @@ export function mount(container, ctx) {
    * duel, so greying it out on account of the person you happen to be facing
    * would hide a decision that is not about them. The only thing that disables
    * it is the acknowledgment (below) and the phase.
+   *
+   * ...AND THAT NOW INCLUDES A RELAYED LINK (2026-08-05). Voice notes went
+   * P2P-only, exactly like media, so a relayed duel has no mic on either side —
+   * but the reason it is SAID here rather than enforced here is the same as
+   * above: the box is a standing answer, not a per-link one, and the next duel
+   * may well come up direct. The sentence takes the TOP of the status ladder
+   * because it outranks every other one: with no direct link, whose toggle is on
+   * is moot. Terminal, too — net/session.js never upgrades a relayed match back.
    */
   function paintVoice() {
     const mine = !!match.localVoiceNotes;
     const theirs = !!match.remoteVoiceNotes;
     const acked = !!(prefs && prefs.get && prefs.get('voiceAckSeen'));
     const editable = match.phase === GoonMatchPhase.Consent || match.phase === GoonMatchPhase.Lobby;
+    /* ConnectedRelay AND NOTHING ELSE — narrower than paintTransfer's read on
+     * purpose. That row treats every settled non-P2P state as relayed; here the
+     * only state that has actually decided anything is the mailbox being live.
+     * Signaling/ConnectingP2P is still deciding (showing the verdict early is the
+     * bug that row's own comment describes), and Disconnected/Closed is a link
+     * that has not happened yet — neither is a reason to tell somebody their mic
+     * is off for the match. */
+    const t = getTransport ? getTransport() : null;
+    const settledRelay = !!t && t.state === GoonTransportState.ConnectedRelay;
 
     let status = '';
-    if (mine && theirs && match.peerSupportsVoice) status = S.voice.lobbyBoth;
+    if (settledRelay) status = S.voice.lobbyRelay;
+    else if (mine && theirs && match.peerSupportsVoice) status = S.voice.lobbyBoth;
     else if ((mine || theirs) && !match.peerSupportsVoice) status = S.voice.lobbyPeerOld;
     else if (mine) status = S.voice.lobbyYours;
     else if (theirs) status = S.voice.lobbyTheirs;
@@ -601,10 +619,12 @@ export function mount(container, ctx) {
 
   const transport = getTransport ? getTransport() : null;
   if (transport && typeof transport.onStateChanged === 'function') {
-    // Relay vs direct decides whether the transfer row is even offerable.
-    ledger.sub(transport.onStateChanged(() => { paintConnection(); paintTransfer(); }));
+    // Relay vs direct decides whether the transfer row is even offerable — and,
+    // since 2026-08-05, whether there is a mic on the desk at all. Both rows read
+    // the link, so both repaint on its edge.
+    ledger.sub(transport.onStateChanged(() => { paintConnection(); paintTransfer(); paintVoice(); }));
   } else {
-    ledger.interval(() => { paintConnection(); paintTransfer(); }, 1000);   // no event seam: poll cheaply
+    ledger.interval(() => { paintConnection(); paintTransfer(); paintVoice(); }, 1000);   // no event seam: poll cheaply
   }
 
   // Seed the sheet from the player's last duel the FIRST time we reach Consent

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -346,7 +346,13 @@ export function mount(container, ctx) {
     if (document.activeElement !== xferRow.input) xferRow.input.checked = !!match.localMediaTransfer;
     xferRow.input.disabled = !!why || !editable;
     xferRow.row.classList.toggle('is-disabled', !!why);
-    xferRow.sub.textContent = why || hint || S.lobby.transferSub;
+    /* THE DISCLOSURE IS NOT OPTIONAL FURNITURE (2026-08-05 privacy pass). `hint`
+     * used to REPLACE S.lobby.transferSub, which meant a player whose library had
+     * nothing compressed yet could tick the box having read only "nothing ready to
+     * send yet" — never the sentence that says the media goes to their opponent.
+     * `why` still replaces it, and that is correct: those three arms all mean
+     * nothing can cross at all. Whenever the box is live, the sentence is there. */
+    xferRow.sub.textContent = why || (hint ? hint + ' ' + S.lobby.transferSub : S.lobby.transferSub);
     xferRow.value.textContent = match.remoteMediaTransfer
       ? S.lobby.transferTheirsOn : S.lobby.transferTheirsOff;
   }

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
@@ -301,16 +301,30 @@ export function mount(container, ctx) {
 
     let started = null;
     try { started = await rec.start(); }
-    catch (e) { logger?.info?.('[GG voice] recorder.start threw: ' + ((e && e.message) || e)); started = { ok: false, reason: 'denied' }; }
-    if (started && started.ok === false) {
+    catch (e) { logger?.info?.('[GG voice] recorder.start threw: ' + ((e && e.message) || e)); started = { ok: false, reason: 'failed' }; }
+    /* ANYTHING BUT A YES IS A NO. This used to test `started.ok === false`, which
+     * let a recorder that resolved nothing at all (undefined, a bare null) walk
+     * through as a success — and then the button said Stop over a microphone
+     * that had never opened, which can only be got out of by pressing it again.
+     * The recorder is DISPOSED on the way out either way, so a refused attempt
+     * leaves nothing behind for the next press to trip over. */
+    if (!started || started.ok !== true) {
       try { rec.dispose?.(); } catch (_e) { /* ignore */ }
-      return { ok: false, reason: String(started.reason || 'denied') };
+      return { ok: false, reason: String((started && started.reason) || 'failed') };
     }
     return { ok: true, rec };
   }
 
   async function onRecordPress() {
-    if (recorder) { await finishRecording(false); return; }
+    /* THE STOP HALF. It is wrapped because a throw out of here would leave the
+     * press unfinished and the button in whatever state it was mid-stop — and
+     * finishRecording has already cleared `recorder` by the time anything in it
+     * can throw, so repainting is all that is left to rescue. */
+    if (recorder) {
+      try { await finishRecording(false); }
+      catch (e) { ledger._err('finishRecording', e); paintRecording(); }
+      return;
+    }
     if (busy) return;
     if (!store) { toast(S.voice.micMissing, 'warn'); return; }
     if (notes.length >= VN_MAX_NOTES) { toast(S.voice.full(VN_MAX_NOTES), 'warn'); return; }
@@ -323,10 +337,18 @@ export function mount(container, ctx) {
     busy = true;
     recBtn.disabled = true;
     let opened = null;
-    try { opened = await openRecorder(); } finally { busy = false; recBtn.disabled = false; }
+    try { opened = await openRecorder(); }
+    catch (e) { ledger._err('openRecorder', e); opened = { ok: false, reason: 'failed' }; }
+    finally { busy = false; recBtn.disabled = false; paintRecording(); }
     if (ledger.isDisposed) return;
-    if (!opened.ok) {
-      toast(opened.reason === 'denied' ? S.voice.micDenied : S.voice.micMissing, 'warn');
+    if (!opened || !opened.ok) {
+      /* THREE DIFFERENT REFUSALS, THREE DIFFERENT SENTENCES. 'failed' used to
+       * borrow micMissing ("no microphone found"), which sent people looking for
+       * a hardware problem after a getUserMedia that simply never answered. */
+      const reason = (opened && opened.reason) || 'failed';
+      toast(reason === 'denied' ? S.voice.micDenied
+        : (reason === 'missing' || reason === 'unsupported') ? S.voice.micMissing
+          : S.voice.micFailed, 'warn');
       return;
     }
 
@@ -369,7 +391,9 @@ export function mount(container, ctx) {
     recorder = null;
     clearTick();
 
-    let out = { ok: false, reason: 'empty', blob: null, durMs: 0 };
+    // 'failed', not 'empty': a stop() that THREW never got as far as producing
+    // nothing, and the two have different sentences on the other side.
+    let out = { ok: false, reason: 'failed', blob: null, durMs: 0 };
     try { out = normalizeRecording(await rec.stop()); }
     catch (e) { logger?.warn?.('[GG voice] recorder.stop threw: ' + ((e && e.message) || e)); }
     await completeRecording(rec, out, capped);
@@ -380,13 +404,17 @@ export function mount(container, ctx) {
     try { rec.dispose?.(); } catch (_e) { /* ignore */ }
     if (ledger.isDisposed) return;
     paintRecording();
-    if (!out.ok) { toast(S.voice.sendFailed, 'warn'); return; }
+    // 'empty' is a recording that produced nothing; anything else means there was
+    // no recording to produce it — see S.voice.micFailed.
+    if (!out.ok) { toast(out.reason === 'empty' ? S.voice.sendFailed : S.voice.micFailed, 'warn'); return; }
 
     const durMs = out.durMs > 0 ? Math.min(VN_MAX_MS, out.durMs) : Math.min(VN_MAX_MS, Date.now() - recordStartedAt);
-    const res = await store.add(out.blob, { durMs, name: nextName() });
+    let res = null;
+    try { res = await store.add(out.blob, { durMs, name: nextName() }); }
+    catch (e) { ledger._err('notes.add', e); res = { ok: false, reason: 'failed' }; }
     if (ledger.isDisposed) return;
-    if (!res.ok) {
-      toast(res.reason === 'full' ? S.voice.full(VN_MAX_NOTES) : S.voice.sendFailed, 'warn');
+    if (!res || !res.ok) {
+      toast((res && res.reason) === 'full' ? S.voice.full(VN_MAX_NOTES) : S.voice.sendFailed, 'warn');
       return;
     }
     if (capped) { recNote.textContent = S.voice.recordCapped; recNote.hidden = false; }

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -539,6 +539,15 @@ export const S = Object.freeze({
     cancelled: 'cancelled',
     /** The recorder came back with nothing usable (a mic that produced silence). */
     sendFailed: 'that one did not record — try again',
+    /**
+     * THE MIC NEVER OPENED, which is a different sentence from the one above and
+     * used to borrow it. `sendFailed` blames the recording ("that one did not
+     * record"); this is for the case where there was no recording to blame —
+     * getUserMedia timed out, MediaRecorder would not construct, the recorder
+     * fell over mid-note. Both end in "try again" because both are recoverable,
+     * and after 2026-08-05 both actually are.
+     */
+    micFailed: 'the mic did not open — try again',
     /** The 4 s floor between sends, phrased as a wait rather than a refusal. */
     tooSoon: (sec) => 'one more in ' + sec + 's',
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -46,7 +46,14 @@ export const S = Object.freeze({
     options: 'Options',
     how: 'How it works',
     quit: 'Quit',
-    fineprint: 'Both players endure their own library. Nothing you own leaves this machine.',
+    /* THE FINEPRINT SAYS WHAT ACTUALLY CROSSES (2026-08-05 privacy pass). It read
+       "Nothing you own leaves this machine" until today, which was written before
+       media transfer and voice notes existed and has been the exact opposite of
+       the truth ever since: with sending switched on, copies of your images and
+       clips are sent to your opponent, and a voice note is your recorded voice
+       going to a stranger. Both are opt-in and both are off until you say so —
+       which is the honest version of the same reassurance, so that is what it says. */
+    fineprint: 'Both players endure their own library. Nothing you own is sent anywhere until you switch sending on — then it goes to your opponent, and nowhere else.',
   },
 
   /** The "how it works" modal — exactly six bullets, in reading order. */
@@ -135,7 +142,19 @@ export const S = Object.freeze({
     /* --- the media-transfer opt-in. Per-side: this row says what YOU are
        willing to send, and the chip says what THEY answered. --- */
     transfer: 'Send them your own media',
-    transferSub: 'a few of your images and clips go straight to them, machine to machine. never through a server.',
+    /* THE CONSENT SENTENCE FOR SHARING, and every clause in it is checked against
+       the code (2026-08-05 privacy pass):
+         · "sent to them"   — net/mediaQueue.js puts compressed copies on the wire.
+                              This is the half the old copy buried; it now leads.
+         · "encrypted"      — the bulk lane is a WebRTC data channel, so DTLS/SCTP.
+         · "never through our servers" — `supportsBulk` is P2P-ONLY (see
+                              net/mediaQueue.js:625 and paintTransfer below): on the
+                              ws-mailbox relay the row greys out and nothing crosses.
+                              A TURN hop is still this data channel and still sees
+                              nothing but ciphertext.
+         · "theirs to keep"  — exec/receivedStore.js writes it down on their side.
+                              We cannot unsend it and the copy must not imply we can. */
+    transferSub: 'a few of your images and clips are sent to your opponent — encrypted, straight to their machine, never through our servers. what lands on their side is theirs to keep.',
     /**
      * NO LONGER A PITCH, because it is no longer a perk (owner call 2026-08-05):
      * sending is free for every seat and the only thing money buys is HOSTING
@@ -447,10 +466,18 @@ export const S = Object.freeze({
    *      is two consents in one switch — your voice goes to them, and theirs can
    *      come back — and a player who only reads the button must not be able to
    *      miss the second half. That is why the ack gate exists at all.
-   *   2. NOTHING HERE PROMISES DELETION OR PRIVACY IT CANNOT KEEP. The audio is
-   *      peer-to-peer and never touches a server, so the copy says exactly that
-   *      and nothing more — no "disappears after", no "only you can hear it".
-   *      What happens on their machine is theirs, and the ack line says so.
+   *   2. NOTHING HERE PROMISES DELETION OR PRIVACY IT CANNOT KEEP — and until the
+   *      2026-08-05 privacy pass this block broke its own rule. It said "no server
+   *      ever hears them" and "there is no server in the middle", which is FALSE on
+   *      the fallback path and was false the day it was written: a voice note rides
+   *      the CONTROL lane precisely so it survives a relayed link (see the header of
+   *      ui/voice/voiceService.js and core/contracts.js makeVoice), and on that link
+   *      every frame is plain JSON through our /v2/goon/relay mailbox. There is no
+   *      application-layer encryption on that hop — TLS to us, readable by us.
+   *      So the copy now says the true thing in two clauses: direct link, straight
+   *      to them and we never see it; relayed link, it passes through our server.
+   *      Still no "disappears after" and no "only you can hear it": what happens on
+   *      their machine is theirs, and the ack line says so.
    *   3. THE OFF PATH IS NEVER SCOLDED. Cancelling a recording, refusing the mic
    *      and turning the whole thing off are all ordinary things to do, phrased
    *      as ordinary things.
@@ -464,7 +491,7 @@ export const S = Object.freeze({
 
     /* --- the screen ----------------------------------------------------- */
     eyebrow: 'voice notes',
-    lead: 'ten seconds each, straight to whoever you are duelling. nothing is uploaded and no server ever hears them.',
+    lead: 'ten seconds each, sent to whoever you are duelling. on a direct link it goes straight to them, encrypted, and we never see it — on a relayed one it passes through our server to reach them.',
     back: 'back',
 
     /* --- the acknowledgment gate (shown ONCE, before the toggle will move)
@@ -473,8 +500,8 @@ export const S = Object.freeze({
     ack: {
       icon: '🎙',
       headline: 'This records your real voice',
-      line: 'Holding the mic records you and sends the audio straight to the person you are duelling, machine to machine. There is no server in the middle and nothing is stored anywhere but on the two of you.',
-      lineTwo: 'Switching this on also means you may HEAR them: if you have both turned it on, their voice plays on your side too. Once a note has left your machine, what happens to it is on theirs.',
+      line: 'Holding the mic records your real voice and sends that recording to the person you are duelling. On a direct connection it travels straight to their machine, encrypted, and our servers never see it. If your two networks can only reach each other through our relay, the note passes through our server on the way to them.',
+      lineTwo: 'Switching this on also means you may HEAR them: if you have both turned it on, their voice plays on your side too. Once a note has reached them it is on their machine, and what happens to it there is theirs — it cannot be taken back.',
       go: 'I understand',
       cancel: 'Not now',
     },
@@ -601,7 +628,7 @@ export const S = Object.freeze({
     /** Standalone's OWN library: files picked straight off the device. */
     local: {
       headline: 'add media to send',
-      line: 'pick files from this device and they can travel to your opponent mid-duel, straight from you to them. nothing is uploaded anywhere.',
+      line: 'pick files from this device and copies of them can be sent to your opponent mid-duel, encrypted, straight from you to them. nothing is uploaded to our servers — but what reaches them is theirs to keep.',
       add: 'add files',
       limits: (max, vmax) => 'jpg, png, gif, webp, mp4, webm, mov · or a zip of them · up to ' + max
         + ' travels as-is, bigger photos and gifs are compressed to fit, clips up to ' + vmax,
@@ -737,8 +764,12 @@ export const S = Object.freeze({
    * Two rules the copy has to keep:
    *   1. the twenty-item suggestion is a SUGGESTION and must read as one. The
    *      button unlocks on the first file; nothing here may sound like a gate.
-   *   2. it says where the media STAYS. A stranger asking a first-time visitor
-   *      for their porn folder has about one sentence to be honest in. */
+   *   2. it says where the media GOES. A stranger asking a first-time visitor
+   *      for their porn folder has about one sentence to be honest in, and until
+   *      the 2026-08-05 privacy pass that sentence spent it on the wrong half
+   *      ("travel nowhere") — true only for as long as the lobby toggle stays
+   *      off, and read by everybody as a promise about the whole feature. It now
+   *      names the toggle AND what crossing it means. */
   mediaSetup: {
     eyebrow: 'before you play',
     headline: 'bring something to endure',
@@ -775,7 +806,7 @@ export const S = Object.freeze({
     lockBusy: 'still adding…',
     /** The opponent is watching a "picking their media" line while this is up. */
     waiting: 'they know you are still picking. take your time.',
-    note: 'your picks stay on this device and travel nowhere unless you switch sending on in the lobby.',
+    note: 'your picks stay on this device unless you switch sending on in the lobby — then copies of a few of them are sent to your opponent, encrypted and never through our servers, and whatever reaches them is theirs to keep.',
     leave: 'Leave',
   },
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -527,6 +527,14 @@ export const S = Object.freeze({
     hudLabel: 'voice note',
     /** A tap that was too short to be a recording. A hint, never an error. */
     holdHint: 'hold the mic to record',
+    /** THE DESK'S KEY. A desktop seat fires its whole arsenal off the number row
+       (ui/arsenal.js binds 1..7 on `window` precisely so the drawer can stay
+       shut), and the mic is the one control in that drawer with no key of its
+       own — which is how an in-app player ends up with no way to record at all.
+       ui/hud.js owns the binding; ui/voice/micHud.js still has no key handler,
+       so the Escape-is-Mercy ladder is untouched. Said on the button's tooltip,
+       and shown as the hint when the key is TAPPED rather than held. */
+    holdKeyHint: 'hold V to record',
     /** While held. The gesture out is a slide, and it has to be said, not guessed. */
     slideToCancel: 'slide left to cancel',
     /** The last three seconds (micHud.MIC_COUNTDOWN_MS). The question stops being

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -466,16 +466,21 @@ export const S = Object.freeze({
    *      is two consents in one switch — your voice goes to them, and theirs can
    *      come back — and a player who only reads the button must not be able to
    *      miss the second half. That is why the ack gate exists at all.
-   *   2. NOTHING HERE PROMISES DELETION OR PRIVACY IT CANNOT KEEP — and until the
-   *      2026-08-05 privacy pass this block broke its own rule. It said "no server
-   *      ever hears them" and "there is no server in the middle", which is FALSE on
-   *      the fallback path and was false the day it was written: a voice note rides
-   *      the CONTROL lane precisely so it survives a relayed link (see the header of
-   *      ui/voice/voiceService.js and core/contracts.js makeVoice), and on that link
-   *      every frame is plain JSON through our /v2/goon/relay mailbox. There is no
-   *      application-layer encryption on that hop — TLS to us, readable by us.
-   *      So the copy now says the true thing in two clauses: direct link, straight
-   *      to them and we never see it; relayed link, it passes through our server.
+   *   2. NOTHING HERE PROMISES DELETION OR PRIVACY IT CANNOT KEEP — and this block
+   *      has now been wrong in BOTH directions, which is why the history is kept.
+   *      It first said "no server ever hears them", which was false the moment ICE
+   *      gave up: voice rode the CONTROL lane precisely so it survived a relayed
+   *      link, and on that link every frame was plain JSON through our
+   *      /v2/goon/relay mailbox — TLS to us, readable by us. The 2026-08-05 privacy
+   *      pass made the copy admit that hop. Later the same day the owner made the
+   *      better call: don't disclose the hop, DELETE it. Voice notes are now
+   *      P2P-ONLY, exactly like media (core/match.js `linkIsP2P` gates the send
+   *      door, the receive door and the mic itself), so the unconditional sentence
+   *      is true again — straight to them over the encrypted direct link, never
+   *      through our servers — and the relayed case gets its own honest line
+   *      saying the feature is simply off for that duel. If anything ever puts a
+   *      voice frame back on the mailbox, THIS COPY BECOMES A LIE: the assertions
+   *      in test/selftest-voice.js §6 are what stop that happening quietly.
    *      Still no "disappears after" and no "only you can hear it": what happens on
    *      their machine is theirs, and the ack line says so.
    *   3. THE OFF PATH IS NEVER SCOLDED. Cancelling a recording, refusing the mic
@@ -491,7 +496,7 @@ export const S = Object.freeze({
 
     /* --- the screen ----------------------------------------------------- */
     eyebrow: 'voice notes',
-    lead: 'ten seconds each, sent to whoever you are duelling. on a direct link it goes straight to them, encrypted, and we never see it — on a relayed one it passes through our server to reach them.',
+    lead: 'ten seconds each, sent to whoever you are duelling. straight to them over your encrypted direct link, never through our servers. no direct link, no voice notes — the mic simply is not there.',
     back: 'back',
 
     /* --- the acknowledgment gate (shown ONCE, before the toggle will move)
@@ -500,7 +505,7 @@ export const S = Object.freeze({
     ack: {
       icon: '🎙',
       headline: 'This records your real voice',
-      line: 'Holding the mic records your real voice and sends that recording to the person you are duelling. On a direct connection it travels straight to their machine, encrypted, and our servers never see it. If your two networks can only reach each other through our relay, the note passes through our server on the way to them.',
+      line: 'Holding the mic records your real voice and sends that recording to the person you are duelling. It travels straight to their machine over your encrypted direct link, and never through our servers. If your two networks can only reach each other through our relay, voice notes are switched off for that duel rather than routed through us.',
       lineTwo: 'Switching this on also means you may HEAR them: if you have both turned it on, their voice plays on your side too. Once a note has reached them it is on their machine, and what happens to it there is theirs — it cannot be taken back.',
       go: 'I understand',
       cancel: 'Not now',
@@ -605,6 +610,16 @@ export const S = Object.freeze({
     lobbyYours: 'you have voice notes on — they have not',
     lobbyTheirs: 'they have voice notes on — you have not',
     lobbyPeerOld: 'their app is too old for voice notes',
+    /**
+     * THE RELAYED DUEL, said where the transfer row says its own version of it
+     * (S.lobby.transferRelay). Voice notes are P2P-only as of 2026-08-05, so a
+     * link that could not come up direct has no mic on it at all — and the one
+     * thing this line must never do is let a player think their opt-in failed.
+     * The row is not disabled: this checkbox is also the RECEIVE gate and the
+     * standing answer for the next duel, and greying it out would hide a
+     * decision that is not about this link. See lobby.js paintVoice.
+     */
+    lobbyRelay: 'this connection is relayed — voice notes only cross a direct one, so the mic is off this match.',
     /** The row's own explanation, when there is no status to report yet. */
     lobbySub: 'hold the mic under your items to send ten seconds of your voice. you both have to switch it on.',
     /** Before the acknowledgment has been read. Says what to press, not "no". */
@@ -620,6 +635,15 @@ export const S = Object.freeze({
     micMissing: 'no microphone found',
     /** The one line that explains a hidden mic button mid-match. */
     notActive: 'voice notes need both of you switched on',
+    /**
+     * ...and the OTHER reason there is no mic, which is not a switch anybody can
+     * flip. Short, because this one lands on the strip (ui/voice/micHud.js
+     * sendReasonLine) in the race where a link degrades between the release and
+     * the send. Never phrased as a failure: nothing broke, the note just has no
+     * private road to travel and we would rather send nothing than send it
+     * through ourselves.
+     */
+    relayOff: 'no direct link — voice notes stay home',
     /** Where the volume lives, from the screen that made the note. */
     volumeHint: 'their notes play at the Voice notes volume in options.',
   },

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -53,6 +53,28 @@
  * and stay in the match. A held recording is released by the pointer that is
  * holding it, or by that pointer being taken away.
  *
+ * ────────────────────────────────────── a failure is never the last failure ──
+ *
+ * ONE BAD RECORDING MAY NOT COST A PLAYER THE FEATURE. Reported 2026-08-05: the
+ * mic worked once, the first attempt failed, and every press after it answered
+ * "that one did not record" for the rest of the session. Two halves, and both
+ * are pinned in test/selftest-hud.js §20b-bis and §20c-quater:
+ *
+ *   THE RECORDER LATCHED. ui/voice/recorder.js refuses any start() that is not
+ *   from `idle`, so anything parking it in `starting` (a permission prompt
+ *   nobody answered) refused every later press. Fixed there — but this file
+ *   still calls recoverRecorder() on EVERY refusal, because a UI that cannot
+ *   explain a "no" should not be the thing that decides to live with it.
+ *
+ *   THE STRIP LATCHED. `phase` gates onDown, and both awaits in stopAndSend are
+ *   on injectable seams: a rejection used to leave the strip on 'send' with no
+ *   path back. Every await is now inside a try/catch inside a try/finally that
+ *   guarantees a pressable phase, MIC_SETTLE_MAX_MS is the timer under that, and
+ *   a press DURING a flash cuts the word short rather than being swallowed.
+ *
+ * And the copy tells the two apart: S.voice.sendFailed is a note that failed,
+ * S.voice.micFailed is a microphone that never opened. See micReasonLine.
+ *
  * ────────────────────────────────────────────────────────── the four traps ──
  *
  *   ONE ANIMATION SLOT. The pulse lives on `.gg-voice-dot` and the level bars on
@@ -113,6 +135,18 @@ export const MIC_FLASH_MS = 1200;
 export const MIC_COUNTDOWN_MS = 3000;
 /** The hint caption's dwell (a tap, a refusal). Long enough to read once. */
 export const MIC_HINT_MS = 2200;
+/**
+ * THE DEAD-MAN'S SWITCH ON THE STRIP.
+ *
+ * Everything this file awaits is documented to settle and every one of those
+ * awaits is now wrapped — but `recorder` and `voice` are both INJECTABLE seams,
+ * and a promise that never settles would leave the strip on 'send' with no way
+ * back. A mic button that is dead for the rest of the match is the exact bug
+ * this whole pass exists to make impossible, so there is a timer under it as
+ * well as a `finally`. Comfortably longer than a ten-second note plus a send,
+ * so it never fires on anything that is merely slow.
+ */
+export const MIC_SETTLE_MAX_MS = 20_000;
 /** Timer repaint cadence while recording. 10 fps is smooth for one decimal. */
 const TICK_MS = 100;
 
@@ -192,6 +226,28 @@ export function sendReasonLine(reason, waitSec = 1) {
     case 'aborted':
     case 'busy':        return S.voice.cancelled;
     default:            return S.voice.sendFailed;   // empty | too-big | unreadable | send-failed
+  }
+}
+
+/**
+ * A refusal from the RECORDER (ui/voice/recorder.js start/stop) -> the line the
+ * player sees. Separate from sendReasonLine on purpose: those reasons are about
+ * a note that failed to cross, these are about a microphone that never opened,
+ * and telling somebody "that one did not record" when nothing ever started is
+ * how a mic problem gets mistaken for a recording problem for three play-tests
+ * running. Exported so the suite pins the mapping.
+ *
+ * @param {string} reason  denied|missing|unsupported|cancelled|busy|failed|idle
+ */
+export function micReasonLine(reason) {
+  switch (reason) {
+    case 'denied':      return S.voice.micDenied;
+    case 'missing':
+    case 'unsupported': return S.voice.micMissing;
+    // The player's own gesture ended it. There is nothing to report.
+    case 'cancelled':   return '';
+    // busy | failed | idle | anything a newer recorder invents.
+    default:            return S.voice.micFailed;
   }
 }
 
@@ -295,6 +351,16 @@ export function mountMicHud({
   let flashTimer = 0;
   let hintTimer = 0;
   let chipTimer = 0;
+  let settleTimer = 0;
+  /* One number per press. rec.start() is awaited, and its answer can arrive long
+   * after the gesture that asked for it (a permission prompt is a human), so the
+   * answer carries the number it was asked under and is dropped if it is stale. */
+  let gestureSeq = 0;
+  /* An await is in flight inside stopAndSend / cancelRecording. The phase alone
+   * cannot say so — 'flash' is worn both while cancel() is being waited on and
+   * while a finished word is merely sitting on the strip — and the difference
+   * matters to onDown, which may interrupt the second but not the first. */
+  let settling = false;
   let willCancel = false;
   let ending = false;            // inside MIC_COUNTDOWN_MS of the cap
   let lastSentAt = -Infinity;
@@ -308,6 +374,64 @@ export function mountMicHud({
   }
 
   function clearTimer(id) { if (id) { try { clearTimeout(id); } catch (_e) { /* gone */ } } return 0; }
+
+  /**
+   * ONE FAILURE MAY NOT POISON THE NEXT PRESS.
+   *
+   * The recorder is asked to go back to idle whatever it thinks it is holding —
+   * a getUserMedia nobody answered, a MediaRecorder that would not construct, a
+   * note half assembled. This is the whole cure for the reported bug: before it,
+   * a first attempt that failed could leave the recorder parked in `starting` or
+   * `stopping`, and every later press was answered 'busy' and shown a refusal,
+   * for the rest of the session.
+   *
+   * `reset()` is the recorder's own door; `cancel()` is the fallback for an
+   * older/injected handle that has no such thing, and its promise is swallowed
+   * because nobody is waiting on a recovery.
+   */
+  function recoverRecorder() {
+    try {
+      if (typeof rec.reset === 'function') { rec.reset(); return; }
+      const p = rec.cancel?.();
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    } catch (_e) { /* a handle that throws at its own recovery is already gone */ }
+  }
+
+  /** rec.cancel() where nothing is waiting for the answer. Never unhandled. */
+  function safeCancel() {
+    try {
+      const p = rec.cancel?.();
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    } catch (_e) { /* ignore */ }
+  }
+
+  /** Put the strip back on the button, from anywhere. Never throws. */
+  function goIdle() {
+    holdTimer = clearTimer(holdTimer);
+    flashTimer = clearTimer(flashTimer);
+    releasePointer();
+    willCancel = false;
+    setPhase('idle');
+    text(timeEl, '');
+  }
+
+  /** See MIC_SETTLE_MAX_MS. Armed around every await, disarmed by the finally. */
+  function armSettleGuard() {
+    settleTimer = clearTimer(settleTimer);
+    try {
+      settleTimer = setTimeout(() => {
+        settleTimer = 0;
+        if (unmounted) return;
+        settling = false;
+        recoverRecorder();
+        goIdle();
+        showHint(S.voice.micFailed);
+        log({ t: 'voice-out', ok: false, reason: 'stuck' });
+      }, MIC_SETTLE_MAX_MS);
+    } catch (_e) { settleTimer = 0; }
+  }
+
+  function clearSettleGuard() { settleTimer = clearTimer(settleTimer); }
 
   function showHint(line) {
     if (!hint || !line) return;
@@ -383,11 +507,18 @@ export function mountMicHud({
     flashTimer = clearTimer(flashTimer);
     try {
       flashTimer = setTimeout(() => {
+        flashTimer = 0;
         if (unmounted) return;
         setPhase('idle');
         text(timeEl, '');
       }, MIC_FLASH_MS);
-    } catch (_e) { /* ignore */ }
+    } catch (_e) {
+      // No timer here (a host without setTimeout, a stub DOM). A word nobody can
+      // clear would be a button nobody can press: skip the dwell, keep the mic.
+      flashTimer = 0;
+      setPhase('idle');
+      text(timeEl, '');
+    }
   }
 
   /** Let go of the pointer, whatever happened to it. Never throws. */
@@ -403,45 +534,148 @@ export function mountMicHud({
 
   /* ---------------------------------------------------------------- sending */
 
+  /**
+   * Stop, and put the note on the wire.
+   *
+   * EVERY EXIT LEAVES A PRESSABLE BUTTON. Two awaits here, on two injectable
+   * seams, and before 2026-08-05 a throw from either one walked straight out of
+   * this function as an unhandled rejection with the strip still reading
+   * "sending…" — a phase onDown refuses, forever. Both are caught into a REASON
+   * now (a thrown recorder is a failed recording, which is a thing the copy deck
+   * has a sentence for), and the `finally` is the backstop for the paths a
+   * future edit adds.
+   */
   async function stopAndSend() {
+    settling = true;
+    armSettleGuard();
     setPhase('send');
     text(timeEl, S.voice.sending);
     text(slideEl, '');
-    const res = await rec.stop();
-    if (unmounted) return;
-    if (!res || !res.ok || !res.blob) {
-      // 'empty' is a mic that produced silence (a muted device, a track that
-      // never delivered a sample). It is not the player's mistake and the copy
-      // says so.
-      flash(S.voice.sendFailed);
-      log({ t: 'voice-out', ok: false, reason: (res && res.reason) || 'empty' });
-      return;
+    try {
+      let res = null;
+      let threw = '';
+      try { res = await rec.stop(); }
+      catch (e) { threw = 'stop-threw'; log({ t: 'voice-out', ok: false, reason: threw, err: (e && e.message) || String(e) }); res = null; }
+      if (unmounted) return;
+      if (!res || !res.ok || !res.blob) {
+        const reason = threw || (res && res.reason) || 'empty';
+        // ...and the recorder does not get to stay in whatever state produced
+        // that. The next press starts from scratch.
+        recoverRecorder();
+        /* WHICH SENTENCE. 'empty' is a mic that produced silence (a muted
+         * device, a track that never delivered a sample) — the recording
+         * failed, and sendFailed says exactly that. 'idle' / 'cancelled' mean
+         * there was no recording to fail: the recorder was already gone when we
+         * asked, which is a MIC failure and gets the mic's sentence. */
+        flash(reason === 'empty' ? S.voice.sendFailed : S.voice.micFailed);
+        log({ t: 'voice-out', ok: false, reason });
+        return;
+      }
+      // The two cues are AFTER the microphone is closed, never before or during:
+      // a sound played while recording is a sound that ends up in the note.
+      sfx(audio, 'ui-select');
+      let out = null;
+      try { out = await voice.sendBlob(res.blob, { durMs: res.durMs }); }
+      catch (e) { log({ t: 'voice-out', ok: false, reason: 'send-threw', err: (e && e.message) || String(e) }); out = null; }
+      if (unmounted) return;
+      const reason = (out && out.reason) || 'send-failed';
+      if (out && out.ok) lastSentAt = clock();
+      const waitSec = Math.max(1, Math.ceil((VN_SEND_MIN_GAP_MS - (clock() - lastSentAt)) / 1000));
+      flash(sendReasonLine(reason, waitSec));
+      log({ t: 'voice-out', ok: !!(out && out.ok), reason, durMs: res.durMs });
+    } finally {
+      settling = false;
+      clearSettleGuard();
+      /* THE GUARANTEE. However this exited — a resolved send, a thrown seam, an
+       * early return somebody adds next year — the strip may not be left on a
+       * phase that refuses the next press. 'flash' folds itself; anything else
+       * is put back by hand. */
+      if (!unmounted && phase !== 'flash' && phase !== 'idle') goIdle();
     }
-    // The two cues are AFTER the microphone is closed, never before or during:
-    // a sound played while recording is a sound that ends up in the note.
-    sfx(audio, 'ui-select');
-    const out = await voice.sendBlob(res.blob, { durMs: res.durMs });
-    if (unmounted) return;
-    const reason = (out && out.reason) || 'send-failed';
-    if (out && out.ok) lastSentAt = clock();
-    const waitSec = Math.max(1, Math.ceil((VN_SEND_MIN_GAP_MS - (clock() - lastSentAt)) / 1000));
-    flash(sendReasonLine(reason, waitSec));
-    log({ t: 'voice-out', ok: !!(out && out.ok), reason, durMs: res.durMs });
   }
 
   async function cancelRecording(why) {
+    settling = true;
+    armSettleGuard();
     setPhase('flash');
-    await rec.cancel();
-    if (unmounted) return;
-    sfx(audio, 'ui-back');
-    flash(S.voice.cancelled);
-    log({ t: 'voice-cancel', why: why || 'pointer' });
+    try {
+      try { await rec.cancel(); }
+      catch (e) { log({ t: 'voice-cancel', why: 'cancel-threw', err: (e && e.message) || String(e) }); recoverRecorder(); }
+      if (unmounted) return;
+      sfx(audio, 'ui-back');
+      flash(S.voice.cancelled);
+      log({ t: 'voice-cancel', why: why || 'pointer' });
+    } finally {
+      settling = false;
+      clearSettleGuard();
+      // A cancel that never reached flash() still owes the player their button.
+      if (!unmounted && phase !== 'flash' && phase !== 'idle') goIdle();
+    }
   }
 
   /* --------------------------------------------------------- the pointer -- */
 
+  /**
+   * Open the microphone for this gesture.
+   *
+   * A REFUSAL IS RECOVERED FROM, NOT JUST REPORTED. Whatever the recorder is
+   * holding onto when it says no, it is forced back to idle here — so the very
+   * next pointerdown is a fresh attempt instead of a second refusal. That one
+   * line is the reported bug: without it a first failure latched the recorder
+   * out of `idle` and every press afterwards was answered 'busy' and told "that
+   * one did not record", which was neither true nor recoverable.
+   */
+  async function startMic(mine) {
+    let res = null;
+    try { res = await rec.start(); }
+    catch (e) {
+      log({ t: 'voice-mic', ok: false, reason: 'start-threw', err: (e && e.message) || String(e) });
+      res = { ok: false, reason: 'failed' };
+    }
+    if (unmounted) return;
+    /* A LATER PRESS OWNS THE MIC NOW. An answer to a gesture that is over may
+     * not act on the one that replaced it — recovering "from" this refusal would
+     * take the microphone off a recording that is running perfectly well, and a
+     * getUserMedia ceiling means that answer can arrive half a minute late. */
+    if (mine !== gestureSeq) {
+      // ...and a stale attempt that somehow SUCCEEDED has opened a microphone no
+      // gesture owns. That is rule 1's problem, so it is given back here.
+      if (res && res.ok) recoverRecorder();
+      log({ t: 'voice-mic', ok: false, reason: 'stale', stale: true });
+      return;
+    }
+    if (res && res.ok) return;
+    const reason = (res && res.reason) || 'failed';
+    // 'cancelled' is our own gesture ending the attempt — there is nothing stuck
+    // and nothing to say. Everything else gets the machine put back.
+    if (reason !== 'cancelled') recoverRecorder();
+    /* THE ONE MOMENT A PLAYER CAN BE TOLD WHY. If the gesture has already moved
+     * on (a tap that finished, a release that is mid-send) the refusal is that
+     * path's to report, and saying it twice would be two words on one strip. */
+    if (phase === 'hold' || phase === 'rec') {
+      releasePointer();
+      holdTimer = clearTimer(holdTimer);
+      setPhase('idle');
+      showHint(micReasonLine(reason));
+    }
+    log({ t: 'voice-mic', ok: false, reason });
+  }
+
   function onDown(e) {
-    if (!live || phase !== 'idle') return;
+    if (!live || settling) return;
+    /* A FLASH IS NOT A LOCK. "sent" / "cancelled" / a refusal holds the strip for
+     * MIC_FLASH_MS, and a player who has just been told a note failed reaches
+     * straight back for the button — a mic that ignores that press is
+     * indistinguishable from the stuck one everything above exists to prevent.
+     * The word is cut short and the new hold starts from a clean idle. (The
+     * awaits behind those words are already finished; `settling` above is what
+     * guards the ones that are not.) */
+    if (phase === 'flash') {
+      flashTimer = clearTimer(flashTimer);
+      setPhase('idle');
+      text(timeEl, '');
+    }
+    if (phase !== 'idle') return;
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
     pointerId = e && e.pointerId != null ? e.pointerId : null;
     downX = e && typeof e.clientX === 'number' ? e.clientX : 0;
@@ -454,22 +688,7 @@ export function mountMicHud({
     try { if (pointerId != null) btn.setPointerCapture?.(pointerId); } catch (_e) { /* ignore */ }
 
     // The microphone opens NOW (see the header); the STRIP waits for the hold.
-    void rec.start().then((res) => {
-      if (unmounted) return;
-      if (res && res.ok) return;
-      // A refusal ends the gesture then and there, with a sentence rather than
-      // a dead button: this is the one moment a player can be told why.
-      const reason = (res && res.reason) || 'failed';
-      if (phase === 'hold' || phase === 'rec') {
-        releasePointer();
-        holdTimer = clearTimer(holdTimer);
-        setPhase('idle');
-        showHint(reason === 'denied' ? S.voice.micDenied
-          : reason === 'missing' ? S.voice.micMissing
-            : reason === 'cancelled' ? '' : S.voice.sendFailed);
-      }
-      log({ t: 'voice-mic', ok: false, reason });
-    });
+    void startMic(++gestureSeq);
 
     holdTimer = clearTimer(holdTimer);
     try {
@@ -525,16 +744,18 @@ export function mountMicHud({
     if (how === 'up' && wasRec) { void stopAndSend(); return; }
     if (how === 'up' && !wasRec) {
       // A TAP. Nothing was wanted, so nothing is kept — and the mic that opened
-      // on pointerdown closes on the same call a real cancel makes.
+      // on pointerdown closes on the same call a real cancel makes. The strip is
+      // put back FIRST: a tap is the commonest press there is, and the recorder
+      // may still be sitting on a permission prompt when it lands.
       setPhase('idle');
-      void rec.cancel();
+      safeCancel();
       if (held < MIC_HOLD_MS) showHint(S.voice.holdHint);
       log({ t: 'voice-tap', heldMs: Math.round(held) });
       return;
     }
     if (wasRec) { void cancelRecording(how); return; }
     setPhase('idle');
-    void rec.cancel();
+    safeCancel();
   }
 
   if (btn) {
@@ -554,17 +775,59 @@ export function mountMicHud({
     holdTimer = clearTimer(holdTimer);
     setPhase('send');
     text(timeEl, S.voice.sending);
-    if (!res || !res.ok || !res.blob) { flash(S.voice.sendFailed); return; }
+    if (!res || !res.ok || !res.blob) {
+      recoverRecorder();
+      flash(res && res.reason === 'empty' ? S.voice.sendFailed : S.voice.micFailed);
+      log({ t: 'voice-out', ok: false, reason: (res && res.reason) || 'empty', capped: true });
+      return;
+    }
     sfx(audio, 'ui-select');
-    void voice.sendBlob(res.blob, { durMs: res.durMs }).then((out) => {
+    void sendCapped(res);
+  }));
+
+  /**
+   * The cap's own send. Split out of the subscriber so it can be a plain
+   * try/finally like stopAndSend's — a `.then()` with no `.catch()` on the same
+   * two seams was the other way the strip could be left reading "sending…" with
+   * no path back to the button.
+   */
+  async function sendCapped(res) {
+    settling = true;
+    armSettleGuard();
+    try {
+      let out = null;
+      try { out = await voice.sendBlob(res.blob, { durMs: res.durMs }); }
+      catch (e) { log({ t: 'voice-out', ok: false, reason: 'send-threw', err: (e && e.message) || String(e) }); out = null; }
       if (unmounted) return;
       const reason = (out && out.reason) || 'send-failed';
       if (out && out.ok) lastSentAt = clock();
       const waitSec = Math.max(1, Math.ceil((VN_SEND_MIN_GAP_MS - (clock() - lastSentAt)) / 1000));
       flash(sendReasonLine(reason, waitSec));
       log({ t: 'voice-out', ok: !!(out && out.ok), reason, durMs: res.durMs, capped: true });
-    });
-  }));
+    } finally {
+      settling = false;
+      clearSettleGuard();
+      if (!unmounted && phase !== 'flash' && phase !== 'idle') goIdle();
+    }
+  }
+
+  /* THE RECORDER DYING UNDER A LIVE HOLD. A MediaRecorder can fall over mid-note
+   * (a device unplugged, a pipeline that gave up); ui/voice/recorder.js releases
+   * the microphone itself and says so here. Without this the strip would go on
+   * counting seconds against a recorder that stopped recording, and the player
+   * would only find out when they let go of a note that no longer existed. */
+  if (typeof rec.onFailed === 'function') {
+    try {
+      led.add(rec.onFailed(() => {
+        if (unmounted || settling) return;
+        if (phase !== 'rec' && phase !== 'hold') return;
+        releasePointer();
+        holdTimer = clearTimer(holdTimer);
+        flash(S.voice.micFailed);
+        log({ t: 'voice-mic', ok: false, reason: 'recorder-error' });
+      }) || (() => {}));
+    } catch (_e) { /* a recorder without the hook simply never reports one */ }
+  }
 
   /* --------------------------------------------------------- availability -- */
 
@@ -677,6 +940,8 @@ export function mountMicHud({
       flashTimer = clearTimer(flashTimer);
       hintTimer = clearTimer(hintTimer);
       chipTimer = clearTimer(chipTimer);
+      settleTimer = clearTimer(settleTimer);
+      settling = false;
       releasePointer();
       led.run();
       // The microphone NEVER outlives the desk. dispose() stops the tracks

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -78,6 +78,26 @@
  *   `pointerType` the way the pinch gesture is — desktop is a mouse and this is
  *   a desktop app first.
  *
+ *   THE DRAWER IS A THIRD WAY TO BE HIDDEN, AND IT IS THE DESKTOP ONE (fixed
+ *   2026-08-05). The mic's slot is the last flow child of `.gg-arsenal-panel`,
+ *   and that panel is `display:none` when the drawer is shut ("collapsed is
+ *   empty, not invisible" — ui/hud.css sidebar rule 3). A desktop seat fires its
+ *   whole arsenal off the number row, so it plays with the drawer shut for the
+ *   stage room — and the mic, the one control in there with no key of its own,
+ *   simply was not on the desk. That is why an in-app player could opt in on
+ *   both seats and still never see a microphone while their phone opponent saw
+ *   one the moment they tapped the handle.
+ *
+ *   Two halves, and neither of them moves a node. `setDeskShut()` is the same
+ *   pushed bit `setHudHidden()` is, so a drawer closing mid-hold ends the
+ *   recording on the ordinary cancel path instead of leaving a microphone open
+ *   behind a panel that is not rendered. `hold()` is the gesture the desk can
+ *   drive from its own key binding (ui/hud.js — this file still has NO key
+ *   handler of any kind), and it asks for the drawer through `onReveal` BEFORE
+ *   it opens the microphone, so a recording is never running without its strip
+ *   somewhere on screen. The drawer goes back to how the player left it when the
+ *   strip folds.
+ *
  *   A HIDDEN HUD IS A CLOSED MICROPHONE. ui/hud.css already takes both voice
  *   slots away by name under zen, but CSS alone is not enough: pointer capture
  *   BYPASSES HIT TESTING, so a `display:none` (or the `pointer-events:none` that
@@ -204,12 +224,16 @@ export function sendReasonLine(reason, waitSec = 1) {
  * @param {object}   [o.recorder]  TEST SEAM — a pre-built recorder (see recorder.js)
  * @param {Function} [o.now]       TEST SEAM — the clock the hold/slide read
  * @param {Function} [o.onLog]
+ * @param {Function} [o.onReveal]  fn(true|false) — "put my slot on screen / you
+ *                                 can have it back". ui/hud.js opens and re-shuts
+ *                                 the arsenal drawer with it for a keyed hold.
  * @returns {{unmount:Function, isRecording:Function, available:Function,
- *            shown:Function, setHudHidden:Function, parts:object}}
+ *            shown:Function, setHudHidden:Function, setDeskShut:Function,
+ *            hold:Function, hiddenBy:Function, parts:object}}
  */
 export function mountMicHud({
   host, chipHost = null, voice = null, audio = null,
-  recorder = null, now = nowMs, onLog = null,
+  recorder = null, now = nowMs, onLog = null, onReveal = null,
 } = {}) {
   const led = createLedger();
   const clock = typeof now === 'function' ? now : nowMs;
@@ -228,8 +252,12 @@ export function mountMicHud({
       unmount() { led.run(); },
       isRecording() { return false; },
       available() { return false; },
-      /** Nothing to hide, but the desk pushes the bit unconditionally. */
+      /** Nothing to hide, but the desk pushes both bits unconditionally. */
       setHudHidden() {},
+      setDeskShut() {},
+      /** ...and drives the gesture from its own binding, which finds nothing. */
+      hold() { return false; },
+      hiddenBy() { return 'no-service'; },
       shown() { return false; },
       parts: {},
     };
@@ -246,7 +274,9 @@ export function mountMicHud({
   if (btn) {
     btn.type = 'button';
     attr(btn, 'aria-label', S.voice.hudLabel);
-    attr(btn, 'title', S.voice.holdHint);
+    // Both affordances on the one tooltip: the hold, and the key that does the
+    // same thing for the seat that never opens this drawer with a pointer.
+    attr(btn, 'title', S.voice.holdHint + ' · ' + S.voice.holdKeyHint);
     // Chromium turns a long press into a text selection / callout otherwise, and
     // on a phone it would also try to scroll the page out from under the hold.
     try { btn.style.touchAction = 'none'; btn.style.userSelect = 'none'; } catch (_e) { /* stub */ }
@@ -300,6 +330,9 @@ export function mountMicHud({
   let lastSentAt = -Infinity;
   let live = false;              // the availability bit, from voice.onStateChanged
   let hudHidden = false;         // the zen bit, pushed in by ui/hud.js
+  let deskShut = false;          // the arsenal-drawer bit, pushed in by ui/hud.js
+  let keyed = false;             // this gesture came from the desk, not a pointer
+  let revealed = false;          // we asked the desk for its drawer and owe it back
   let unmounted = false;
 
   function log(entry) {
@@ -308,6 +341,20 @@ export function mountMicHud({
   }
 
   function clearTimer(id) { if (id) { try { clearTimeout(id); } catch (_e) { /* gone */ } } return 0; }
+
+  /**
+   * ASK THE DESK FOR THE SLOT, AND GIVE IT BACK. Edge-triggered, never load
+   * bearing: a desk that does not answer (no callback, a throw) leaves the
+   * gesture exactly as it would have been, and `hold()` below still refuses to
+   * open a microphone it cannot draw a strip for.
+   */
+  function reveal(want) {
+    const next = !!want;
+    if (next === revealed) return;
+    revealed = next;
+    if (typeof onReveal !== 'function') return;
+    try { onReveal(next); } catch (_e) { /* the drawer is a nicety, not the state */ }
+  }
 
   function showHint(line) {
     if (!hint || !line) return;
@@ -373,6 +420,11 @@ export function mountMicHud({
     if (next !== 'rec') ending = false;
     paintPhase();
     if (next === 'rec') paintTimer();
+    /* IDLE IS THE ONLY MOMENT THE DRAWER IS OWED BACK — not the release, which
+     * still has "sending…" and then "sent" to say, and both of those belong on
+     * screen. Every road out of a gesture ends here (the flash timer, a tap, a
+     * refusal), so one line covers all of them. */
+    if (next === 'idle') { keyed = false; reveal(false); }
   }
 
   /** A terminal word on the strip (sent / cancelled / a refusal), then fold. */
@@ -443,6 +495,17 @@ export function mountMicHud({
   function onDown(e) {
     if (!live || phase !== 'idle') return;
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
+    beginGesture(e);
+  }
+
+  /**
+   * THE ONE ENTRANCE. `e` is a pointer event for the button, and null for the
+   * desk's own binding — the only difference between the two is the capture and
+   * the slide, both of which need a pointer to exist at all. Everything that
+   * decides whether a note happens (the hold threshold, the cap, the send) is
+   * one machine on purpose, so a keyed hold cannot drift from a held one.
+   */
+  function beginGesture(e) {
     pointerId = e && e.pointerId != null ? e.pointerId : null;
     downX = e && typeof e.clientX === 'number' ? e.clientX : 0;
     downAt = clock();
@@ -517,6 +580,7 @@ export function mountMicHud({
    */
   function finishGesture(how) {
     const wasRec = phase === 'rec';
+    const wasKeyed = keyed;          // setPhase('idle') clears it — read it first
     const held = clock() - downAt;
     holdTimer = clearTimer(holdTimer);
     releasePointer();
@@ -528,8 +592,11 @@ export function mountMicHud({
       // on pointerdown closes on the same call a real cancel makes.
       setPhase('idle');
       void rec.cancel();
-      if (held < MIC_HOLD_MS) showHint(S.voice.holdHint);
-      log({ t: 'voice-tap', heldMs: Math.round(held) });
+      // The hint names the affordance they actually used — telling somebody who
+      // tapped a key to "hold the mic" is an instruction for a button they may
+      // not even have on screen.
+      if (held < MIC_HOLD_MS) showHint(wasKeyed ? S.voice.holdKeyHint : S.voice.holdHint);
+      log({ t: 'voice-tap', heldMs: Math.round(held), keyed: wasKeyed });
       return;
     }
     if (wasRec) { void cancelRecording(how); return; }
@@ -592,7 +659,7 @@ export function mountMicHud({
    * @param {'lost'|'zen'} why  what to log the abandoned recording as
    */
   function applyPresence(why) {
-    const shown = live && !hudHidden;
+    const shown = live && !hudHidden && !deskShut;
     host.hidden = !shown;
     cls(host, 'is-live', shown);
     // A caption that outlived its slot: the hint is a child of the host, so it
@@ -620,6 +687,66 @@ export function mountMicHud({
     if (next === hudHidden) return;
     hudHidden = next;
     applyPresence('zen');
+  }
+
+  /**
+   * THE ARSENAL DRAWER, pushed in on exactly the terms zen is (ui/hud.js
+   * paintSide). A shut drawer is `display:none` over the whole panel this slot
+   * lives in, and CSS alone has the same hole zen had: pointer capture bypasses
+   * hit testing, so shutting the drawer with a second hand while the first holds
+   * the mic would leave a recording running with the OS mic light on and no
+   * strip rendered anywhere. This ends it on the ordinary cancel path.
+   */
+  function setDeskShut(on) {
+    const next = !!on;
+    if (next === deskShut) return;
+    deskShut = next;
+    applyPresence('desk');
+  }
+
+  /**
+   * THE GESTURE, WITHOUT A POINTER — what ui/hud.js's key binding drives, and
+   * the whole of this feature's desktop parity. There is deliberately no key
+   * handling in this file (Escape during Live is Mercy and the mic may not add a
+   * rung to that ladder); the desk owns the binding and calls in here.
+   *
+   *   hold(true)          begin. Refused unless the mic is genuinely live.
+   *   hold(false)         release: send if it was a recording, hint if a tap.
+   *   hold(false,'lost')  the hand is empty (focus gone) — cancel, never send.
+   *
+   * THE DRAWER IS ASKED FOR FIRST, AND THE MICROPHONE ONLY OPENS IF IT ARRIVES.
+   * A recording whose strip is not on screen is the one state this module
+   * refuses to be in, so a desk that cannot show the slot gets no recording —
+   * `hold` answers false and the caller is free to say so.
+   *
+   * @returns {boolean} whether the call did anything
+   */
+  function hold(on, how) {
+    if (unmounted) return false;
+    if (on) {
+      if (!live || phase !== 'idle') return false;
+      reveal(true);
+      if (hudHidden || deskShut) { reveal(false); return false; }
+      keyed = true;
+      beginGesture(null);
+      return true;
+    }
+    if (phase !== 'hold' && phase !== 'rec') return false;
+    finishGesture(how === 'lost' ? 'lost' : 'up');
+    return true;
+  }
+
+  /**
+   * WHY IS THERE NO MIC ON THE DESK, for the two reasons the SERVICE cannot see
+   * (boot.js reportMicGate turns this into the one warn line a play-test reads).
+   * '' when it is on screen, or when it is the service's own five-fact gate that
+   * is closed — that half has its own sentence in ui/voice/voiceService.js.
+   */
+  function hiddenBy() {
+    if (!live) return '';
+    if (hudHidden) return 'zen';
+    if (deskShut) return 'drawer';
+    return '';
   }
   host.hidden = true;
   try { setLive(voice.available()); } catch (_e) { setLive(false); }
@@ -664,14 +791,23 @@ export function mountMicHud({
     /** The phase name, for a driver that wants more than a boolean. */
     phase() { return phase; },
     available() { return live; },
-    /** Is it actually on the desk? available() AND the HUD not hidden. */
-    shown() { return live && !hudHidden; },
+    /** Is it actually on the desk? available() AND nothing hiding the slot. */
+    shown() { return live && !hudHidden && !deskShut; },
     /** ui/hud.js's zen toggle, pushed in. See applyPresence(). */
     setHudHidden,
+    /** ...and its arsenal drawer, on the same terms. See setDeskShut(). */
+    setDeskShut,
+    /** The desk's own binding drives the gesture through here. See hold(). */
+    hold,
+    /** '' | 'zen' | 'drawer' — which piece of chrome is sitting on the mic. */
+    hiddenBy,
     /** The recorder, so the library screen could share one if it ever wants to. */
     recorder: rec,
 
     unmount() {
+      // The drawer goes back BEFORE the flag, or reveal() would be talking to a
+      // desk that is already tearing itself down with a debt still open.
+      reveal(false);
       unmounted = true;
       holdTimer = clearTimer(holdTimer);
       flashTimer = clearTimer(flashTimer);

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -235,13 +235,19 @@ function createLedger() {
  * the suite pins the mapping rather than re-deriving it, and so a reason nobody
  * anticipated still says something true instead of nothing.
  *
- * @param {string} reason  sent|unavailable|too-soon|busy|empty|too-big|unreadable|aborted|send-failed
+ * @param {string} reason  sent|relay|unavailable|too-soon|busy|empty|too-big|unreadable|aborted|send-failed
  * @param {number} [waitSec] seconds left on the 4s floor, for 'too-soon'
  */
 export function sendReasonLine(reason, waitSec = 1) {
   switch (reason) {
     case 'sent':        return S.voice.sent;
     case 'too-soon':    return S.voice.tooSoon(Math.max(1, Math.ceil(waitSec)));
+    /* THE RELAYED DUEL. Its own sentence rather than `notActive`, because it is not a
+     * switch anybody can flip: voice notes are P2P-only and this link never came up
+     * direct. In practice the mic is already gone by the time a send could answer this
+     * (the service's availability bit carries the same fact), so this is the copy for
+     * the race — a link that degraded between the release and the send. */
+    case 'relay':       return S.voice.relayOff;
     case 'unavailable': return S.voice.notActive;
     case 'aborted':
     case 'busy':        return S.voice.cancelled;
@@ -902,8 +908,9 @@ export function mountMicHud({
    * THE ONE PRESENCE RULE. Two independent bits decide whether the mic is on the
    * desk at all, and NEITHER of them may leave a gesture running:
    *
-   *   live       ui/voice/voiceService.js's five-fact predicate — both consents,
-   *              the peer's build, the phase, your own opt-in.
+   *   live       ui/voice/voiceService.js's six-fact predicate — the LINK being
+   *              direct (voice notes are P2P-only), both consents, the peer's
+   *              build, the phase, your own opt-in.
    *   hudHidden  the desk's zen toggle, pushed in by ui/hud.js.
    *
    * The mic is not DISABLED when either is false — it is NOT THERE. A greyed-out
@@ -1001,8 +1008,9 @@ export function mountMicHud({
 
   /**
    * WHY IS THERE NO MIC ON THE DESK, for the two reasons the SERVICE cannot see
+   * (the relayed link is one it CAN — whyUnavailable names it)
    * (boot.js reportMicGate turns this into the one warn line a play-test reads).
-   * '' when it is on screen, or when it is the service's own five-fact gate that
+   * '' when it is on screen, or when it is the service's own six-fact gate that
    * is closed — that half has its own sentence in ui/voice/voiceService.js.
    */
   function hiddenBy() {

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/recorder.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/recorder.js
@@ -8,7 +8,7 @@
  *   stop()    -> {ok, reason, blob, durMs, mime}   the note, measured
  *   cancel()  -> {ok:false, reason:'cancelled'}    the note, thrown away
  *
- * FOUR RULES, and each one is a promise made to somebody about their own voice:
+ * FIVE RULES, and each one is a promise made to somebody about their own voice:
  *
  *   1. NO HOT MIC. The stream is acquired when a recording STARTS and every
  *      track is stopped when it ends — stopped, cancelled, capped, errored,
@@ -26,7 +26,16 @@
  *      hands the finished blob to `onCapped` subscribers, so the HUD can
  *      auto-send and the library can auto-finish without either of them owning
  *      a second copy of the cap.
- *   4. NOTHING IS TOUCHED AT IMPORT TIME. No navigator, no window, no
+ *   4. NOTHING LATCHES. No state but `idle` may be permanent, because `start()`
+ *      answers everything that is not idle with 'busy' — so anything that can
+ *      park this machine outside `idle` with nobody waiting on it is a mic that
+ *      is dead for the rest of the session. That is not hypothetical: it is the
+ *      bug this file was rewritten for on 2026-08-05 (one unanswered permission
+ *      prompt, and every press afterwards was refused). Hence VN_START_TIMEOUT_MS
+ *      on the acquire, VN_STOP_TIMEOUT_MS on the close, the attempt token that
+ *      lets a live press supersede a disowned one, and `reset()` as the door the
+ *      UI can always reach for.
+ *   5. NOTHING IS TOUCHED AT IMPORT TIME. No navigator, no window, no
  *      MediaRecorder lookup until a call actually needs one — the self-tests
  *      import this module under plain node and drive the whole state machine
  *      through the two injectable seams (`getUserMedia`, `recorderFactory`).
@@ -36,7 +45,12 @@
  *      idle ──start()──> starting ──(stream+recorder)──> recording
  *       ▲                   │                              │
  *       │                   │ cancel() during the await    │ stop() / cancel() / cap
+ *       │                   │ getUserMedia timed out       │ recorder error
  *       └───────────────────┴──────────────────────────────┴──> stopping ──> idle
+ *
+ * ...and `reset()` is that diagram collapsed into one arrow: any state, to idle,
+ * now. Every edge into `idle` goes through `release()`, which is also the only
+ * place a pending stop() promise is answered — dropping one strands the caller.
  *
  * `stopping` exists because MediaRecorder.stop() is asynchronous: the last
  * `dataavailable` lands with (or just before) `stop`, and a blob assembled
@@ -77,6 +91,34 @@ export const VN_AUDIO_BPS = 32_000;
  * one failure mode of this file that a player would be right to be angry about.
  */
 export const VN_STOP_TIMEOUT_MS = 1_500;
+
+/**
+ * How long `starting` may last before the attempt is written off.
+ *
+ * THE STUCK MIC THIS EXISTS FOR. getUserMedia is a HUMAN waiting — a permission
+ * sheet that somebody has to read — so the ceiling is generous. But it is not
+ * infinite, because on some hosts (iOS Safari, notably) a prompt that is
+ * DISMISSED rather than answered leaves that promise pending forever, and a
+ * recorder parked in `starting` answers every later start() with 'busy'. One
+ * unanswered prompt would then be the reason the mic never worked again for the
+ * rest of the session. Thirty seconds is longer than anyone spends deciding and
+ * far shorter than "never".
+ */
+export const VN_START_TIMEOUT_MS = 30_000;
+
+/**
+ * The MediaRecorder timeslice — how often it must hand us a chunk.
+ *
+ * WHY THIS IS NOT LEFT TO THE UA. `MediaRecorder.start()` with no argument is
+ * allowed to hold the entire recording and deliver it as one `dataavailable`
+ * alongside `stop`, and WebKit does exactly that — so a short note, or one
+ * stopped before the encoder flushes, can deliver NO data event at all. That
+ * arrives at the caller as `reason:'empty'` and reads to the player as "that one
+ * did not record", on a recording they definitely made. Asking for a chunk every
+ * quarter second means there is always something assembled by the time stop()
+ * lands, whatever the platform chooses to do at the end.
+ */
+export const VN_TIMESLICE_MS = 250;
 
 /** performance.now() where it exists; Date.now() otherwise. */
 function nowMs() {
@@ -146,6 +188,10 @@ export function micErrorReason(err) {
     case 'TrackStartError':
     case 'AbortError':
       return 'failed';
+    // No getUserMedia here at all, or none that will do audio.
+    case 'NotSupportedError':
+    case 'TypeError':
+      return 'unsupported';
     default:
       return 'failed';
   }
@@ -167,15 +213,20 @@ function stopTracks(stream) {
  * @param {Function} [o.recorderFactory] (stream, opts) => MediaRecorder. TEST SEAM.
  * @param {Function} [o.isTypeSupported] (mime) => bool. TEST SEAM.
  * @param {number}   [o.maxMs]           the hard cap (defaults to VN_MAX_MS)
+ * @param {number}   [o.startTimeoutMs]  the getUserMedia ceiling (VN_START_TIMEOUT_MS)
+ * @param {number}   [o.timesliceMs]     the MediaRecorder timeslice (VN_TIMESLICE_MS)
  * @param {Function} [o.now]             the clock durMs is measured on
  * @param {object}   [o.logger]          console-shaped
  */
 export function createVoiceRecorder({
   getUserMedia = null, recorderFactory = null, isTypeSupported = null,
-  maxMs = VN_MAX_MS, now = nowMs, logger = null,
+  maxMs = VN_MAX_MS, startTimeoutMs = VN_START_TIMEOUT_MS, timesliceMs = VN_TIMESLICE_MS,
+  now = nowMs, logger = null,
 } = {}) {
   const clock = typeof now === 'function' ? now : nowMs;
   const cap = Math.max(500, Math.floor(Number(maxMs) || VN_MAX_MS));
+  const startCap = Math.max(250, Math.floor(Number(startTimeoutMs) || VN_START_TIMEOUT_MS));
+  const slice = Math.max(0, Math.floor(Number(timesliceMs) || 0));
   const warn = (m) => { try { logger?.warn?.('[GG rec] ' + m); } catch (_e) { /* ignore */ } };
 
   /** 'idle' | 'starting' | 'recording' | 'stopping' */
@@ -197,7 +248,16 @@ export function createVoiceRecorder({
   let pendingReason = 'stopped';
   let abandon = false;        // cancel() landed while getUserMedia was still awaiting
   let disposed = false;
+  /* THE ATTEMPT TOKEN. Every start() takes a number, and anything that comes
+   * back from getUserMedia checks it before touching a single shared field. It
+   * is what makes a LATE stream (one that lands after its attempt timed out, was
+   * disowned or was superseded) harmless: it is stopped where it arrives and
+   * nothing else happens. Without it, "recover from a stuck start" and "do not
+   * clobber the recording that is running now" are the same edit fighting
+   * itself. */
+  let gen = 0;
   const capSubs = new Set();
+  const failSubs = new Set();
 
   function clearCapTimer() {
     if (!capTimer) return;
@@ -212,10 +272,17 @@ export function createVoiceRecorder({
    */
   function release() {
     clearCapTimer();
-    if (stopWait) {
-      try { clearTimeout(stopWait.timer); } catch (_e) { /* ignore */ }
-      stopWait = null;
-    }
+    /* A PENDING stop() IS ANSWERED, NEVER DROPPED. This used to null `stopWait`
+     * on its way past, which left whoever was awaiting stop()/cancel() holding a
+     * promise that would never settle — and the mic HUD awaits exactly that
+     * before it puts its button back. One release on the wrong path was a strip
+     * stuck on "sending…" for the rest of the match. Releasing the microphone
+     * out from under a stop IS its answer, so it is given one.
+     * Captured BEFORE the cleanup and resolved AFTER it, so the caller wakes to
+     * a machine that is already idle. */
+    const pending = stopWait;
+    stopWait = null;
+    if (pending) { try { clearTimeout(pending.timer); } catch (_e) { /* ignore */ } }
     stopTracks(stream);
     stream = null;
     if (rec) {
@@ -225,6 +292,37 @@ export function createVoiceRecorder({
     }
     rec = null;
     state = 'idle';
+    if (pending) {
+      try { pending.resolve({ ok: false, reason: 'idle', blob: null, durMs: 0, mime }); }
+      catch (_e) { /* a caller that threw at its own resolve is not our problem */ }
+    }
+  }
+
+  /**
+   * FORCE THIS THING BACK TO PRESSABLE, from any state, at any time.
+   *
+   * Everything release() does, plus the disowning of an in-flight getUserMedia
+   * (via the attempt token) and an ask to stop a live MediaRecorder. It exists
+   * because the UI needs ONE call it can make after a refusal it cannot explain
+   * — the rule being that a single failure may never be the reason the NEXT
+   * press is refused too.
+   */
+  function reset() {
+    gen++;
+    abandon = false;
+    pendingReason = 'cancelled';
+    if (state === 'recording' || state === 'stopping') {
+      try { rec?.stop?.(); } catch (_e) { /* a recorder that will not stop still loses its tracks below */ }
+    }
+    chunks = [];
+    release();
+  }
+
+  /** The recording died on its own (not at anybody's request). */
+  function emitFailed(reason) {
+    for (const fn of Array.from(failSubs)) {
+      try { fn({ reason }); } catch (e) { warn('onFailed handler threw: ' + ((e && e.message) || e)); }
+    }
   }
 
   /** Assemble what arrived into one blob (or null where there is no Blob ctor). */
@@ -274,38 +372,102 @@ export function createVoiceRecorder({
     });
   }
 
+  /**
+   * getUserMedia, with a ceiling on how long it may hold us in `starting` — and
+   * with the late stream stopped rather than leaked. See VN_START_TIMEOUT_MS.
+   *
+   * @param {Function} gum   the acquire function
+   * @param {number}   mine  this attempt's token
+   */
+  function guardedGum(gum, mine) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let timer = 0;
+      const finish = (fn, v) => {
+        if (settled) return;
+        settled = true;
+        try { clearTimeout(timer); } catch (_e) { /* ignore */ }
+        fn(v);
+      };
+      try {
+        timer = setTimeout(() => {
+          finish(reject, Object.assign(new Error('getUserMedia never answered'), { name: 'TimeoutError' }));
+        }, startCap);
+      } catch (_e) { timer = 0; }
+      let p = null;
+      try { p = gum(); } catch (e) { finish(reject, e); return; }
+      Promise.resolve(p).then(
+        (s) => {
+          /* THE LATE STREAM. The attempt that asked for this is over — it timed
+           * out, it was superseded, or the whole recorder was disposed — so it
+           * never becomes a recording. It does not get to leave the microphone
+           * open either: rule 1 does not care that a stream arrived late. */
+          if (settled || mine !== gen || disposed) { stopTracks(s); return; }
+          finish(resolve, s);
+        },
+        (e) => { finish(reject, e); },
+      );
+    });
+  }
+
   async function start() {
     if (disposed) return { ok: false, reason: 'unsupported' };
+    /* A DISOWNED ATTEMPT IS NOT A BUSY ONE — and this is the stuck mic, in one
+     * branch. `starting` means a getUserMedia is in flight; `abandon` means the
+     * gesture that asked for it has already gone (a tap, or the permission
+     * prompt itself stealing the pointer and firing pointercancel). NOBODY is
+     * waiting on that promise, so the fresh press supersedes it rather than
+     * being told 'busy' by a recorder that is only holding a prompt nobody
+     * answered. The old attempt's stream is stopped on arrival by the token
+     * check in guardedGum. */
+    if (state === 'starting' && abandon) {
+      gen++;
+      abandon = false;
+      state = 'idle';
+    }
     if (state !== 'idle') return { ok: false, reason: 'busy' };
 
     const gum = typeof getUserMedia === 'function' ? getUserMedia : defaultGetUserMedia;
     const make = typeof recorderFactory === 'function' ? recorderFactory : defaultRecorderFactory;
     if (!gum || !make) return { ok: false, reason: 'unsupported' };
 
+    const mine = ++gen;
     state = 'starting';
     abandon = false;
     pendingReason = 'stopped';
     chunks = [];
     let s = null;
     try {
-      s = await gum();
+      s = await guardedGum(gum, mine);
     } catch (e) {
-      state = 'idle';
+      /* SUPERSEDED — and it answers 'cancelled', not a failure.
+       *
+       * A newer press already owns this machine (this attempt was disowned while
+       * its prompt was up, and only heard about it when its own ceiling
+       * expired). It must touch nothing: resetting here would take the
+       * microphone off the press that replaced it. It must not report a FAILURE
+       * either, because a caller that recovers from failures would then do the
+       * same damage a beat later — thirty seconds after a gesture nobody
+       * remembers. 'cancelled' is the truth: this attempt was called off. */
+      if (mine !== gen) return { ok: false, reason: 'cancelled' };
       const reason = micErrorReason(e);
+      abandon = false;
+      release();
       warn('getUserMedia refused (' + reason + '): ' + ((e && e.message) || e));
       return { ok: false, reason };
     }
-    if (!s) { state = 'idle'; return { ok: false, reason: 'failed' }; }
+    if (mine !== gen || disposed) { stopTracks(s); return { ok: false, reason: 'cancelled' }; }
+    if (!s) { abandon = false; release(); return { ok: false, reason: 'failed' }; }
 
     /* THE ABANDONED HOLD. A player can press and release faster than a
      * permission-primed getUserMedia resolves, and this is the branch where the
      * stream arrives after nobody wants it: it is stopped here and now, before
      * a single sample is recorded. Without this the mic would stay open until
      * the next start(), which is the whole thing rule 1 forbids. */
-    if (abandon || disposed) {
+    if (abandon) {
       stopTracks(s);
-      state = 'idle';
       abandon = false;
+      release();
       return { ok: false, reason: 'cancelled' };
     }
 
@@ -325,13 +487,27 @@ export function createVoiceRecorder({
         warn('recorder error: ' + ((e && e.error && e.error.message) || (e && e.message) || 'unknown'));
         stoppedAt = clock();
         // An errored recorder still owes us the microphone back.
-        if (stopWait) settleStop();
-        else { chunks = []; release(); }
+        if (stopWait) { settleStop(); return; }
+        chunks = [];
+        release();
+        /* ...and it owes the UI a word. Nobody asked for this stop, so nobody is
+         * awaiting an answer: without the callback the mic HUD would go on
+         * counting seconds against a recorder that is no longer recording, and
+         * only find out when the player let go. */
+        emitFailed('recorder-error');
       };
-      rec.start();
+      /* THE TIMESLICE (see VN_TIMESLICE_MS). A recorder that refuses the
+       * argument outright is started the plain way rather than not at all —
+       * it did not start, so this is not a double start. */
+      if (slice > 0) {
+        try { rec.start(slice); } catch (_e) { rec.start(); }
+      } else {
+        rec.start();
+      }
     } catch (e) {
       warn('MediaRecorder start threw: ' + ((e && e.message) || e));
       chunks = [];
+      abandon = false;
       release();
       return { ok: false, reason: 'failed' };
     }
@@ -453,12 +629,35 @@ export function createVoiceRecorder({
       return () => capSubs.delete(fn);
     },
 
+    /**
+     * fn({reason}) when the recording died WITHOUT anybody asking — a
+     * MediaRecorder error mid-note, a device pulled out. The microphone is
+     * already released by the time this fires; what is left is telling the
+     * player, which is the caller's job. -> unsub.
+     */
+    onFailed(fn) {
+      if (typeof fn !== 'function') return () => {};
+      failSubs.add(fn);
+      return () => failSubs.delete(fn);
+    },
+
+    /**
+     * Back to a pressable idle from wherever we are. The recovery door for a UI
+     * that has just been refused and does not know why — ONE failure may not be
+     * the reason the next press fails too. Safe to call in any state, including
+     * mid-recording (the note is discarded) and mid-getUserMedia (the attempt is
+     * disowned, its stream stopped on arrival).
+     */
+    reset,
+
     /** Tear down. The microphone goes with it, whatever state we were in. */
     dispose() {
       if (disposed) return;
       disposed = true;
       abandon = true;
+      gen++;                       // any getUserMedia still in flight is disowned
       capSubs.clear();
+      failSubs.clear();
       if (state === 'recording' || state === 'stopping') {
         pendingReason = 'cancelled';
         try { rec?.stop?.(); } catch (_e) { /* ignore */ }

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
@@ -10,12 +10,25 @@
  *   │ RECEIVE meta / chunk* / end -> assembled bytes -> audio.playVoiceNote() │
  *   └────────────────────────────────────────────────────────────────────────┘
  *
- * WHY THE CONTROL LANE AND NOT `goon-media`. The bulk channel does not exist on
- * the relay fallback (net/mediaQueue.js degrades to nothing there, by design) and
- * a voice note has to work on the worst link a duel can end up on. So it rides
- * the same ordered/reliable channel as every other message — which costs a 4/3
- * base64 inflation and a 16 KB per-frame ceiling, and both are paid for in the
- * chunk plan below. 256 KB of opus is about 35 frames; a tick is 400 bytes.
+ * P2P ONLY, LIKE MEDIA (owner call, 2026-08-05). A voice note is a recording of a
+ * person, and it may only exist on a wire we cannot read. So:
+ *
+ *   · a DIRECT duel (GoonTransportState.ConnectedP2P, TURN hop included — TURN
+ *     forwards ciphertext) carries voice, and our servers never see a byte of it;
+ *   · a RELAYED duel carries none. The mic is not on the desk, `sendBlob` refuses
+ *     with reason 'relay' before a microphone is even read, and an inbound frame
+ *     that came up the mailbox anyway is dropped (see onFrame). Nothing is
+ *     queued for later and nothing degrades quietly: voice is simply off.
+ *
+ * This is a REVERSAL, and the old reasoning is kept here because it reads so
+ * plausibly: voice rides the CONTROL lane (not `goon-media`) so that it would
+ * survive the relay fallback, on the theory that a feature should work on the
+ * worst link a duel can end up on. What that actually bought was a person's voice
+ * travelling through /v2/goon/relay as plain base64 JSON — TLS to us, readable by
+ * us — which is a promise no copy could honestly make. The lane is unchanged (the
+ * chunk plan below is still what makes a note fit a 16 KB control frame); what
+ * changed is that `match.linkIsP2P` now gates both doors. 256 KB of opus is about
+ * 35 frames; a tick is 400 bytes.
  *
  * IT IS THE `t:'emote'` FAMILY, NOT A PAYLOAD. No charges, no receipts, no ACKs,
  * no retries, nothing in the ledger, nothing in active_effects. A dropped frame
@@ -23,9 +36,12 @@
  * feature where somebody's voice can be OWED to them — queued, retried, delivered
  * three minutes later out of context — is a different and much worse feature.
  *
- * THE FIVE GATES, and every one of them is enforced on BOTH ends because the
+ * THE SIX GATES, and every one of them is enforced on BOTH ends because the
  * wire is untrusted and the other end is a stranger's build:
  *
+ *   0. THE LINK. `match.linkIsP2P` — see above. First, because it is the only one
+ *      that is about US rather than about the two players, and no agreement they
+ *      could reach would make a relayed voice note acceptable.
  *   1. CONSENT. Both sides declared `voice_notes` on the consent frame AND the
  *      peer's build advertises `caps.voice` (core/match.js voiceNotesAgreed).
  *   2. PHASE. Countdown, Live, SuddenDeath. Nothing before, nothing after —
@@ -273,8 +289,19 @@ export function createVoiceService({
   }
 
   /**
-   * The ONE predicate. Both consents, the peer's build, the phase, and our own
-   * opt-in — all five, ANDed, in one place, so the mic button and the send path
+   * IS THE LINK DIRECT? core/match.js owns the definition; this is the read, and it
+   * FAILS CLOSED for anything that cannot answer (a stub, an older engine). A voice
+   * note is the one payload on this page where "we could not tell, so we sent it"
+   * would be the wrong way round.
+   */
+  function linkDirect() {
+    if (!match) return false;
+    try { return !!match.linkIsP2P; } catch (_e) { return false; }
+  }
+
+  /**
+   * The ONE predicate. The link, both consents, the peer's build, the phase, and our
+   * own opt-in — all six, ANDed, in one place, so the mic button and the send path
    * can never disagree about whether this feature is live.
    *
    * Note that a SOLO match satisfies none of it in practice (the practice
@@ -284,6 +311,7 @@ export function createVoiceService({
   function available() {
     if (disposed || !match) return false;
     if (!localEnabled()) return false;
+    if (!linkDirect()) return false;
     try { return !!match.voiceNotesAgreed && !!match.voicePhaseOpen; } catch (_e) { return false; }
   }
 
@@ -316,6 +344,9 @@ export function createVoiceService({
     if (disposed) return 'the voice service is disposed';
     if (!match) return 'no match';
     if (!localEnabled()) return 'local pref off (voice notes are not switched on for this seat)';
+    // THE LINK, in available()'s own order. Terminal for the whole match: net/session.js
+    // never upgrades a relayed duel back to P2P, so this sentence means "not this duel".
+    if (!linkDirect()) return 'the link is relayed, not direct (voice notes are P2P-only — nothing crosses our server)';
     let peerBuild = false;
     let mine = false;
     let theirs = false;
@@ -363,12 +394,19 @@ export function createVoiceService({
    * @param {string} [o.emote]  the emote this note rides with, or null for a live one
    * @param {number} [o.durMs]  recorded length, for their chip. Cosmetic.
    * @returns {Promise<{ok:boolean, reason:string, id:number, parts:number}>}
-   *   reason is 'sent' | 'unavailable' | 'too-soon' | 'busy' | 'empty' | 'too-big' |
-   *   'unreadable' | 'aborted' | 'send-failed'.
+   *   reason is 'sent' | 'relay' | 'unavailable' | 'too-soon' | 'busy' | 'empty' |
+   *   'too-big' | 'unreadable' | 'aborted' | 'send-failed'.
    */
   async function sendBlob(blob, o = {}) {
     const fail = (reason) => { stats.sendDropped++; return { ok: false, reason, id: 0, parts: 0 }; };
     if (disposed) return fail('unavailable');
+    /* 'relay' IS ITS OWN REASON, and it is checked before the general predicate so it
+     * cannot be reported as the catch-all 'unavailable'. The two mean different things
+     * to a player — "you both have to switch it on" is something they can fix, "this
+     * duel came up relayed" is not — and ui/voice/micHud.js sendReasonLine has a
+     * separate sentence for it. It is also the reason a refusal here NEVER falls back
+     * to the mailbox: there is no fallback, by design. */
+    if (!linkDirect()) return fail('relay');
     if (!available()) return fail('unavailable');
 
     // ONE AT A TIME, OUT. Interleaving two transfers on one id space would need
@@ -388,8 +426,11 @@ export function createVoiceService({
     const plan = planVoiceChunks(bytes.length);
     if (!plan.ok) return fail(plan.reason);
 
-    // Re-checked AFTER the await: a match can end, or a phase turn, while a blob
-    // is being read off disk, and the gate that mattered is the one at send time.
+    // Re-checked AFTER the await: a match can end, a phase can turn, or a link can
+    // fall over, while a blob is being read off disk — and the gate that mattered is
+    // the one at send time. The link is asked for separately so a degrade mid-read is
+    // still reported as the relay refusal rather than as a generic one.
+    if (!linkDirect()) return fail('relay');
     if (!available()) return fail('unavailable');
 
     const b64 = bytesToVoiceB64(bytes);
@@ -602,6 +643,15 @@ export function createVoiceService({
   /** One inbound frame, already phase-gated and shape-clamped by core/match.js. */
   function onFrame(f) {
     if (disposed || !f) return;
+    /* THE RELAY DROP, DEFENCE IN DEPTH (2026-08-05). core/match.js `_handleVoice`
+     * already refuses to deliver a voice frame that arrived over the server mailbox,
+     * so nothing should reach here on a relayed duel — this is the second lock on the
+     * same door, for the same reason every other gate in this file is applied twice:
+     * the tier that can promise "never decoded, never queued, never played" is this
+     * one, and a promise that depends on the layer below having run is not a promise.
+     * A peer on an older build (or a modified one) can still PUT voice frames on the
+     * relay; what it cannot do is make them audible. */
+    if (!linkDirect()) { stats.recvDropped++; return; }
     try {
       if (f.sub === 'meta') onMeta(f);
       else if (f.sub === 'chunk') onChunk(f);
@@ -620,10 +670,13 @@ export function createVoiceService({
     try { unsubs.push(match.onVoiceFrame(onFrame) || (() => {})); }
     catch (e) { warn('onVoiceFrame subscribe threw: ' + ((e && e.message) || e)); }
   }
-  // The availability edge, from all three things that can move it. The mic HUD
+  // The availability edge, from all four things that can move it. The mic HUD
   // subscribes to the RESULT rather than to these, so it never has to know that
-  // "voice is live" is made of a consent frame, a phase and a checkbox.
-  for (const [name, hook] of [['onConsentChanged', 'consent'], ['onPhaseChanged', 'phase']]) {
+  // "voice is live" is made of a consent frame, a phase, a checkbox and a link.
+  // `onLinkChanged` is the newest of them and the reason the mic vanishes (ending
+  // any live recording on ui/voice/micHud.js's ordinary cancel path) the moment a
+  // duel stops being direct.
+  for (const [name, hook] of [['onConsentChanged', 'consent'], ['onPhaseChanged', 'phase'], ['onLinkChanged', 'link']]) {
     if (match && typeof match[name] === 'function') {
       try { unsubs.push(match[name](() => emitState()) || (() => {})); }
       catch (e) { warn(`${hook} subscribe threw: ` + ((e && e.message) || e)); }

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -429,9 +429,48 @@ namespace ConditioningControlPanel.Services.GoonGame
                 if (ReferenceEquals(core, _micPermissionCore)) return;  // a reload's second "ready"
                 _micPermissionCore = core;
                 core.PermissionRequested += OnPermissionRequested;
+                ClearBankedMicDenial(core);
                 App.Logger?.Debug("GoonHostService: microphone permission handler attached");
             }
             catch (Exception ex) { App.Logger?.Warning("GoonHostService.HookMicPermission: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// A HANDLER IS NOT ENOUGH ON ITS OWN, and this is the desktop-only trap under it.
+        /// WebView2 remembers permission decisions PER PROFILE (our <c>browser_data_goon</c> folder
+        /// outlives every launch), and a remembered answer is served from the profile WITHOUT
+        /// raising <c>PermissionRequested</c> at all. So one Deny — banked by the runtime's own
+        /// prompt on a build that predates <see cref="HookMicPermission"/>, or by a player who hit
+        /// Escape on it once — mutes the in-app microphone permanently, and the handler above never
+        /// runs to undo it. The page cannot tell: <c>getUserMedia</c> simply rejects, the mic HUD
+        /// shows "no microphone" and no amount of opting in changes anything.
+        ///
+        /// So the state is written explicitly, for our own virtual host and nothing else. The real
+        /// gate is still the page's double-locked opt-in (see the handler's own remarks) — this
+        /// only makes sure the question reaches it.
+        ///
+        /// Fire-and-forget and best-effort by design: it is a repair for an install that may never
+        /// have been broken, it must not delay the init frame, and an SDK/runtime that does not
+        /// support the profile API leaves us exactly where we already were.
+        /// </summary>
+        private static void ClearBankedMicDenial(CoreWebView2 core)
+        {
+            try
+            {
+                var profile = core.Profile;
+                if (profile == null) return;
+                _ = profile.SetPermissionStateAsync(
+                        CoreWebView2PermissionKind.Microphone,
+                        "https://ccp.game",
+                        CoreWebView2PermissionState.Allow)
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                            App.Logger?.Debug("GoonHostService: mic permission state write failed: {E}",
+                                t.Exception?.GetBaseException().Message);
+                    }, TaskScheduler.Default);
+            }
+            catch (Exception ex) { App.Logger?.Debug("GoonHostService.ClearBankedMicDenial: {E}", ex.Message); }
         }
 
         /// <summary>Allow the microphone; leave every other permission kind to WebView2's default.</summary>
@@ -452,6 +491,12 @@ namespace ConditioningControlPanel.Services.GoonGame
                 // sensible for it in a borderless duel window, and the in-page opt-in has already
                 // asked the same question in the player's own words.
                 e.Handled = true;
+                // ...and this answer is NOT banked in the profile. A saved decision is served
+                // straight out of browser_data_goon on every later launch without this handler ever
+                // running, which turns one bad answer into a permanently dead microphone and makes
+                // the grant depend on a file instead of on the code that owns the policy. Asked and
+                // answered every time is the only version of this we can reason about.
+                try { e.SavesInProfile = false; } catch { /* older runtime: the write is not fatal */ }
                 App.Logger?.Information("GoonHostService: microphone permission allowed (voice notes)");
             }
             catch (Exception ex) { App.Logger?.Warning("GoonHostService.OnPermissionRequested: {E}", ex.Message); }


### PR DESCRIPTION
Three goon voice-note fixes, developed on separate branches and merged here.

## 1. Desktop mic was unreachable (`fix/goon-desktop-mic`)
The desktop seat runs the same web UI in WebView2 and all voice machinery existed since PR#117 — but the mic button lives in the arsenal drawer, which desktop plays shut, and it was the only control without a hotkey.
- **Push-to-talk on `V`**: hold to record, release to send; the drawer auto-opens for the note and shuts after. Button path unchanged when the drawer is open. Wire format / 10s cap / phone interop untouched.
- WebView2 permission fix: the mic grant no longer saves into the profile (`SavesInProfile = false`), and a banked Deny is repaired on attach — previously one stored Deny muted the in-app mic forever.
- `reportMicGate()` now names the drawer instead of staying silent.

## 2. Browser mic stuck after one failure (`fix/goon-mic-stuck`)
`getUserMedia` was awaited with no ceiling; releasing the button (or dismissing the iOS prompt) during the wait parked the recorder in `starting` forever — every later press refused as `busy` and mislabeled "that one did not record".
- 30s acquire ceiling + attempt tokens (a new press supersedes a dead one).
- Every failure path (denied, cancelled, mid-note error, empty blob, send failure, hang) now resets recorder + button; 20s settle guard as backstop.
- `MediaRecorder` now started with a 250ms timeslice — WebKit could deliver zero data for short notes, making a real recording report as "didn't record".
- New accurate `micFailed` string ("the mic did not open — try again") distinct from `sendFailed`.

## 3. Privacy/consent copy was false (`fix/goon-privacy-copy`)
Copy claimed "nothing leaves your machine" / "no server ever hears them". Verified data path: media rides the P2P `goon-media` data channel and cannot cross the relay; **voice notes ride the control lane and on relay fallback pass through `/v2/goon/relay` unencrypted**.
- All 7 misleading strings rewritten: shared content is *sent to your opponent*, encrypted on a direct link, theirs to keep; voice copy admits the relay hop.
- Lobby disclosure bug: the "nothing ready to send yet" hint *replaced* the transfer disclosure, so a player could enable sending without ever seeing it — now it prepends.
- Self-test added: no voice string may ever again claim a server is uninvolved.

## Merge notes
Two conflicts in `micHud.js` (parallel helper blocks; tap path now uses `safeCancel()` + keyed-aware hint), resolved here.

## Verification
- All 14 goon self-test suites green post-merge: hud 1693/1693, voice 227, voice-ui 263, encode 190, core 242, flow 318, net 350, transfer 199, assets 427, hostgate 97, invite 199, report 213. `selftest-exec` has one rotation-dependent flaky check that fails intermittently **on untouched main as well** (verified 3 runs) — unrelated. `selftest-avafx` failures are pre-existing on main.
- `dotnet build`: 0 errors (312 pre-existing warnings).

## Left for a human
- Play-test: two seats, drawer shut (`V`) and open (button); `V` vs Q/E, 1–7, Esc, F11; dead in join-code field; confirm the real WebView2 mic opens (log: "microphone permission allowed (voice notes)").
- One phone pass with a genuinely denied iOS permission prompt (behavior inferred from code).
- Product calls: relay-mailbox retention wording, TURN/metered.ca nuance, whether voice should be P2P-only like media, and a UI glance at the longer voice ack sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGrTm1ev9kpvVDrZYsvesj