### PR TITLE
fix(ai): Train 0 hotfixes - moderation parity, CCBill ack clone, awareness duration/cooldown, AI-METER telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ConditioningControlPanel/docs/surveys/
 
 # Internal planning/docs (not for PRs)
 ConditioningControlPanel/docs/internal/
+planning/
 
 # Stray PowerShell PNG outputs that landed at the wrong path
 # (System.Drawing.Drawing2D.* etc., from failed Add-Type scratch scripts).

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.ChatInput.cs
@@ -243,7 +243,10 @@ namespace ConditioningControlPanel
                         // Show quick thinking indicator
                         if (!_isGiggling) Giggle("Hmm...");
 
-                        var aiReaction = await App.Ai.GetAwarenessReactionAsync(detectedName, category.ToString(), serviceName, pageTitle);
+                        // Double-click can land long after the user settled on this window, so
+                        // the real dwell time is the interesting signal here.
+                        var aiReaction = await App.Ai.GetAwarenessReactionAsync(detectedName, category.ToString(), serviceName, pageTitle,
+                            awareness?.CurrentActivityDuration);
                         if (!string.IsNullOrEmpty(aiReaction))
                         {
                             reaction = aiReaction;

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -29,13 +29,16 @@ namespace ConditioningControlPanel
         private readonly DateTime _startupTime = DateTime.Now; // Track startup to prevent race conditions
 
         /// <summary>
-        /// True while an awareness / still-on LLM call is in flight. The reaction cooldown is
-        /// marked on DELIVERY now, not before the call, so it no longer doubles as the
-        /// re-entrancy guard it used to be — without this a burst of window switches would
-        /// fire overlapping requests against the same daily budget. Only ever touched on the
-        /// dispatcher thread (both handlers marshal first), so no locking needed.
+        /// True while an awareness (resp. still-on) LLM call is in flight. The reaction
+        /// cooldown is marked on DELIVERY now, not before the call, so it no longer doubles as
+        /// the re-entrancy guard it used to be — without these a burst of window switches would
+        /// fire overlapping requests against the same daily budget. One flag per handler: a
+        /// slow awareness call must not swallow a still-on milestone (the milestone index
+        /// advances whether or not we deliver). Only ever touched on the dispatcher thread
+        /// (both handlers marshal first), so no locking needed.
         /// </summary>
-        private bool _awarenessAiInFlight;
+        private bool _activityAiInFlight;
+        private bool _stillOnAiInFlight;
 
         /// <summary>
         /// Handle activity change from WindowAwarenessService
@@ -69,7 +72,7 @@ namespace ConditioningControlPanel
                     return;
 
                 // Don't stack requests while one is still running (see field doc).
-                if (_awarenessAiInFlight)
+                if (_activityAiInFlight)
                     return;
 
                 // Always use the currently focused window's full context
@@ -83,7 +86,7 @@ namespace ConditioningControlPanel
 
                 if (App.Settings?.Current?.AiChatEnabled == true && App.Ai?.IsAvailable == true)
                 {
-                    _awarenessAiInFlight = true;
+                    _activityAiInFlight = true;
                     try
                     {
                         // Pass full context from currently focused window. The duration is
@@ -103,7 +106,7 @@ namespace ConditioningControlPanel
                     }
                     finally
                     {
-                        _awarenessAiInFlight = false;
+                        _activityAiInFlight = false;
                     }
                 }
 
@@ -112,8 +115,15 @@ namespace ConditioningControlPanel
                 if (Application.Current?.Dispatcher?.HasShutdownStarted ?? true)
                     return;
 
-                // Use preset if AI didn't work
-                reaction ??= GetPhraseForCategory(e.Category, displayName);
+                // Use preset if AI didn't work. Whitespace counts as "didn't work": the local
+                // provider returns empty text for an effects-only JSON reply, and bailing
+                // before MarkReaction would leave the cooldown unburned — every window switch
+                // would then fire a fresh LLM call.
+                if (string.IsNullOrWhiteSpace(reaction))
+                {
+                    reaction = GetPhraseForCategory(e.Category, displayName);
+                    isAiResponse = false;
+                }
 
                 if (string.IsNullOrWhiteSpace(reaction))
                     return;
@@ -174,7 +184,7 @@ namespace ConditioningControlPanel
                     return;
 
                 // Don't stack requests while one is still running (see field doc).
-                if (_awarenessAiInFlight)
+                if (_stillOnAiInFlight)
                     return;
 
                 // Get duration from the awareness service
@@ -192,7 +202,7 @@ namespace ConditioningControlPanel
 
                 if (App.Settings?.Current?.AiChatEnabled == true && App.Ai?.IsAvailable == true)
                 {
-                    _awarenessAiInFlight = true;
+                    _stillOnAiInFlight = true;
                     try
                     {
                         // Use the selected display name based on 50/50 choice
@@ -209,7 +219,7 @@ namespace ConditioningControlPanel
                     }
                     finally
                     {
-                        _awarenessAiInFlight = false;
+                        _stillOnAiInFlight = false;
                     }
                 }
 
@@ -218,9 +228,11 @@ namespace ConditioningControlPanel
                 if (Application.Current?.Dispatcher?.HasShutdownStarted ?? true)
                     return;
 
-                // Use preset if AI didn't work - include time in the fallback
-                if (reaction == null)
+                // Use preset if AI didn't work - include time in the fallback. Whitespace
+                // counts as "didn't work" for the same cooldown reason as OnActivityChanged.
+                if (string.IsNullOrWhiteSpace(reaction))
                 {
+                    isAiResponse = false;
                     var minutes = (int)duration.TotalMinutes;
                     var timeText = minutes < 1 ? "a bit" : $"{minutes} min";
                     reaction = $"Still on {displayName}? {timeText} already~ Do your nails instead!";

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -75,8 +75,11 @@ namespace ConditioningControlPanel
                 {
                     try
                     {
-                        // Pass full context from currently focused window
-                        reaction = await App.Ai.GetAwarenessReactionAsync(displayName, e.Category.ToString(), e.ServiceName, pageTitle);
+                        // Pass full context from currently focused window. The duration is
+                        // near zero on a fresh switch — that's truthful, and beats the
+                        // hardcoded "0m" the providers used to send on every path.
+                        reaction = await App.Ai.GetAwarenessReactionAsync(displayName, e.Category.ToString(), e.ServiceName, pageTitle,
+                            App.WindowAwareness?.CurrentActivityDuration);
                         if (reaction != null)
                         {
                             // No truncation - scrollable speech bubble handles long text

--- a/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
+++ b/ConditioningControlPanel/AvatarTube/AvatarTubeWindow.Reactions.cs
@@ -29,6 +29,15 @@ namespace ConditioningControlPanel
         private readonly DateTime _startupTime = DateTime.Now; // Track startup to prevent race conditions
 
         /// <summary>
+        /// True while an awareness / still-on LLM call is in flight. The reaction cooldown is
+        /// marked on DELIVERY now, not before the call, so it no longer doubles as the
+        /// re-entrancy guard it used to be — without this a burst of window switches would
+        /// fire overlapping requests against the same daily budget. Only ever touched on the
+        /// dispatcher thread (both handlers marshal first), so no locking needed.
+        /// </summary>
+        private bool _awarenessAiInFlight;
+
+        /// <summary>
         /// Handle activity change from WindowAwarenessService
         /// </summary>
         private async void OnActivityChanged(object? sender, ActivityChangedEventArgs e)
@@ -59,8 +68,9 @@ namespace ConditioningControlPanel
                 if (!App.WindowAwareness?.CanReact() ?? true)
                     return;
 
-                // Mark that we're reacting (resets cooldown timer)
-                App.WindowAwareness?.MarkReaction();
+                // Don't stack requests while one is still running (see field doc).
+                if (_awarenessAiInFlight)
+                    return;
 
                 // Always use the currently focused window's full context
                 // Use service name as primary, with page title for additional context
@@ -73,6 +83,7 @@ namespace ConditioningControlPanel
 
                 if (App.Settings?.Current?.AiChatEnabled == true && App.Ai?.IsAvailable == true)
                 {
+                    _awarenessAiInFlight = true;
                     try
                     {
                         // Pass full context from currently focused window. The duration is
@@ -90,6 +101,10 @@ namespace ConditioningControlPanel
                     {
                         App.Logger?.Warning(ex, "Failed to get AI awareness reaction");
                     }
+                    finally
+                    {
+                        _awarenessAiInFlight = false;
+                    }
                 }
 
                 // The await above may have spanned an app shutdown — re-check
@@ -99,6 +114,15 @@ namespace ConditioningControlPanel
 
                 // Use preset if AI didn't work
                 reaction ??= GetPhraseForCategory(e.Category, displayName);
+
+                if (string.IsNullOrWhiteSpace(reaction))
+                    return;
+
+                // Mark that we're reacting (resets cooldown timer). Deliberately AFTER the
+                // reaction is in hand: this used to run before the LLM call, so a failed,
+                // moderated or empty reaction still burned the whole cooldown window and the
+                // user got silence instead of the preset phrase they were owed.
+                App.WindowAwareness?.MarkReaction();
 
                 // AI responses get priority and double bounce, presets queue normally
                 if (isAiResponse)
@@ -149,8 +173,9 @@ namespace ConditioningControlPanel
                 if (!App.WindowAwareness?.CanStillOnReact() ?? true)
                     return;
 
-                // Mark that we're reacting (resets cooldown timer)
-                App.WindowAwareness?.MarkStillOnReaction();
+                // Don't stack requests while one is still running (see field doc).
+                if (_awarenessAiInFlight)
+                    return;
 
                 // Get duration from the awareness service
                 var duration = App.WindowAwareness?.CurrentActivityDuration ?? TimeSpan.Zero;
@@ -167,6 +192,7 @@ namespace ConditioningControlPanel
 
                 if (App.Settings?.Current?.AiChatEnabled == true && App.Ai?.IsAvailable == true)
                 {
+                    _awarenessAiInFlight = true;
                     try
                     {
                         // Use the selected display name based on 50/50 choice
@@ -180,6 +206,10 @@ namespace ConditioningControlPanel
                     catch (Exception ex)
                     {
                         App.Logger?.Warning(ex, "Failed to get AI still-on reaction");
+                    }
+                    finally
+                    {
+                        _awarenessAiInFlight = false;
                     }
                 }
 
@@ -195,6 +225,13 @@ namespace ConditioningControlPanel
                     var timeText = minutes < 1 ? "a bit" : $"{minutes} min";
                     reaction = $"Still on {displayName}? {timeText} already~ Do your nails instead!";
                 }
+
+                if (string.IsNullOrWhiteSpace(reaction))
+                    return;
+
+                // Mark that we're reacting (resets cooldown timer) — AFTER the reaction is in
+                // hand, for the same reason as OnActivityChanged above.
+                App.WindowAwareness?.MarkStillOnReaction();
 
                 // AI responses get priority
                 if (isAiResponse)

--- a/ConditioningControlPanel/Models/CompanionPromptSettings.cs
+++ b/ConditioningControlPanel/Models/CompanionPromptSettings.cs
@@ -417,7 +417,16 @@ FREQUENCY RULE:
                 KnowledgeBase = KnowledgeBase,
                 ContextReactions = ContextReactions,
                 OutputRules = OutputRules,
-                CustomDomains = new Dictionary<string, string>(CustomDomains)
+                CustomDomains = new Dictionary<string, string>(CustomDomains),
+                // The CCBill acknowledgement audit trail must survive a clone. Callers
+                // (PersonalityService.MigrateFromLegacy, CommunityPrompt) copy settings and
+                // write the clone back, so dropping these silently re-prompted the user and
+                // erased the recorded ack timestamp/locale.
+                ExplicitContentAcknowledged = ExplicitContentAcknowledged,
+                ExplicitAcknowledgedVersion = ExplicitAcknowledgedVersion,
+                ExplicitAcknowledgedAt = ExplicitAcknowledgedAt,
+                ExplicitAcknowledgedLocale = ExplicitAcknowledgedLocale,
+                PromptEditorDisclaimerAcknowledged = PromptEditorDisclaimerAcknowledged
             };
         }
     }

--- a/ConditioningControlPanel/Services/AIService/AiMeter.cs
+++ b/ConditioningControlPanel/Services/AIService/AiMeter.cs
@@ -1,0 +1,50 @@
+namespace ConditioningControlPanel.Services.AIService
+{
+    /// <summary>
+    /// One Serilog line per LLM request, greppable by the literal prefix <c>[AI-METER]</c>.
+    /// Log-only: nothing here changes behaviour, and the emitting call sites must never pass
+    /// message content, window/tab titles or user text — counts and enums only.
+    ///
+    /// Token figures are deliberately approximate (chars / 4). They exist to size the pipeline
+    /// (how many requests, how much prompt, how long), not to reconcile a provider's bill.
+    ///
+    /// Lives in one place so the four emitters (cloud, local, openai_compat, quiz) can't drift
+    /// on field names — a meter you have to grep four ways is not a meter.
+    /// </summary>
+    internal static class AiMeter
+    {
+        public const string ProviderCloud = "cloud";
+        public const string ProviderLocal = "local";
+        public const string ProviderOpenAiCompatible = "openai_compat";
+        public const string ProviderQuiz = "quiz";
+
+        public const string PurposeChat = "chat";
+        public const string PurposeAwareness = "awareness";
+        public const string PurposeStillOn = "still_on";
+        public const string PurposeKeyword = "keyword";
+        public const string PurposeLockScreen = "lockscreen";
+        public const string PurposeVideoDone = "video_done";
+        public const string PurposeQuiz = "quiz";
+
+        /// <summary>A usable reply came back.</summary>
+        public const string OutcomeOk = "ok";
+        /// <summary>ModerationGuard blocked the input; no request was sent.</summary>
+        public const string OutcomeRefusedInput = "refused_input";
+        /// <summary>ModerationGuard blocked the model output; the turn was discarded.</summary>
+        public const string OutcomeRefusedOutput = "refused_output";
+        /// <summary>Transport / HTTP / parse failure.</summary>
+        public const string OutcomeError = "error";
+        /// <summary>The request succeeded but produced no usable text.</summary>
+        public const string OutcomeEmpty = "empty";
+
+        private static int ApproxTokens(int chars) => chars <= 0 ? 0 : chars / 4;
+
+        public static void Record(string provider, string purpose, int inputChars, int outputChars,
+            long elapsedMs, string outcome)
+        {
+            App.Logger?.Information(
+                "[AI-METER] provider={Provider} purpose={Purpose} in_tok~{InTokens} out_tok~{OutTokens} ms={ElapsedMs} outcome={Outcome}",
+                provider, purpose, ApproxTokens(inputChars), ApproxTokens(outputChars), elapsedMs, outcome);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/AIService/AiResponseParser.cs
+++ b/ConditioningControlPanel/Services/AIService/AiResponseParser.cs
@@ -264,6 +264,8 @@ namespace ConditioningControlPanel.Services.AIService
             return false;
         }
 
+        public string SanitizeVisibleText(string? response) => SanitizeResponse(response);
+
         private string SanitizeResponse(string? response)
         {
             if (string.IsNullOrEmpty(response))

--- a/ConditioningControlPanel/Services/AIService/AiServiceStrategy.cs
+++ b/ConditioningControlPanel/Services/AIService/AiServiceStrategy.cs
@@ -72,8 +72,8 @@ namespace ConditioningControlPanel.Services.AIService
             => Active.GetBambiReplyExAsync(userInput, isUserMessage);
 
         public Task<string?> GetAwarenessReactionAsync(string detectedName, string category,
-            string serviceName = "", string pageTitle = "")
-            => Active.GetAwarenessReactionAsync(detectedName, category, serviceName, pageTitle);
+            string serviceName = "", string pageTitle = "", TimeSpan? duration = null)
+            => Active.GetAwarenessReactionAsync(detectedName, category, serviceName, pageTitle, duration);
 
         public Task<string?> GetStillOnReactionAsync(string displayName, string category, TimeSpan duration)
             => Active.GetStillOnReactionAsync(displayName, category, duration);

--- a/ConditioningControlPanel/Services/AIService/IAiResponseParser.cs
+++ b/ConditioningControlPanel/Services/AIService/IAiResponseParser.cs
@@ -6,6 +6,17 @@ namespace ConditioningControlPanel.Services.AIService
     public interface IAiResponseParser
     {
         ParsedAiResponse Parse(string response);
+
+        /// <summary>
+        /// Strips leaked context-metadata tags (e.g. an echoed
+        /// <c>[Category: … | App: … | Title: … | Duration: …]</c>) from user-visible text.
+        /// Must run BEFORE output moderation: the echoed Title carries the user's raw
+        /// window/tab title, which must not be able to trip the guard and land a false
+        /// model-output hit in the compliance log. <see cref="Parse"/> already applies this
+        /// to <see cref="ParsedAiResponse.CleanText"/>; this entry point exists for the
+        /// no-effects path that never calls Parse.
+        /// </summary>
+        string SanitizeVisibleText(string? response);
     }
 
     public class ParsedAiResponse

--- a/ConditioningControlPanel/Services/AIService/IAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/IAiService.cs
@@ -30,8 +30,15 @@ namespace ConditioningControlPanel.Services.AIService
         /// </summary>
         Task<AiReplyResult> GetBambiReplyExAsync(string userInput, bool isUserMessage = false);
 
+        /// <summary>
+        /// <paramref name="duration"/> is how long the user has been on this activity. It is
+        /// formatted into the context tag with the same bucketing as
+        /// <see cref="GetStillOnReactionAsync"/>; null means "not known" and reads as zero.
+        /// The value used to be hardcoded to "0m" on all three providers, which lied to the
+        /// model on the double-click path where the user may have dwelled for half an hour.
+        /// </summary>
         Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "",
-            string pageTitle = "");
+            string pageTitle = "", TimeSpan? duration = null);
 
         Task<string?> GetStillOnReactionAsync(string displayName, string category, TimeSpan duration);
 

--- a/ConditioningControlPanel/Services/AIService/LocalAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/LocalAiService.cs
@@ -348,7 +348,7 @@ namespace ConditioningControlPanel.Services.AIService
             var prompt = _bambiSprite.GetSystemPrompt();
             // Mark this as a user request so a second click while busy gets a "still thinking"
             // phrase back instead of the bare fallback.
-            var result = await GetAiResponseAsync(userInput, prompt, isUser: true, returnRefusalSentinel: true);
+            var result = await GetAiResponseAsync(userInput, prompt, isUser: true, returnRefusalSentinel: true, purpose: AiMeter.PurposeChat);
 
             var refusalSource = ModerationRefusal.GetSource(result);
             if (refusalSource.HasValue)
@@ -414,7 +414,7 @@ namespace ConditioningControlPanel.Services.AIService
             else durationText = $"{(int)elapsed.TotalHours}h";
 
             var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
-            return await GetAiResponseAsync(userInput, prompt);
+            return await GetAiResponseAsync(userInput, prompt, purpose: AiMeter.PurposeAwareness);
         }
 
         public async Task<string?> GetStillOnReactionAsync(string displayName, string category, TimeSpan duration)
@@ -426,7 +426,7 @@ namespace ConditioningControlPanel.Services.AIService
             else durationText = $"{(int)duration.TotalHours}h";
 
             var userInput = $"[Category: {category} | App: {displayName} | Title: {displayName} | Duration: {durationText}]";
-            return await GetAiResponseAsync(userInput, prompt);
+            return await GetAiResponseAsync(userInput, prompt, purpose: AiMeter.PurposeStillOn);
         }
 
         public async Task<string?> GetKeywordCommentAsync(string keyword, string? promptTemplate = null)
@@ -435,7 +435,7 @@ namespace ConditioningControlPanel.Services.AIService
             var userInput = string.IsNullOrEmpty(promptTemplate)
                 ? $"You just caught the user on the word '{keyword}'. React in character, one short line."
                 : promptTemplate.Replace("{keyword}", keyword);
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeKeyword);
         }
 
         public async Task<string?> GetLockScreenReaction(string sentance, int mistakes, int amount, string? promptTemplate = null)
@@ -452,7 +452,7 @@ namespace ConditioningControlPanel.Services.AIService
                 userInput = userInput.Replace("{mistakes}", mistakes.ToString());
                 userInput = userInput.Replace("{amount}", amount.ToString());
             }
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeLockScreen);
         }
 
         public async Task<string?> GetVideoDoneReaction(string title, string? promptTemplate = null)
@@ -461,11 +461,21 @@ namespace ConditioningControlPanel.Services.AIService
             var userInput = string.IsNullOrEmpty(promptTemplate)
                 ? $"The user has just finished the mandatory video {title}. React in character, one short line."
                 : promptTemplate.Replace("{title}", title);
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeVideoDone);
         }
 
-        private async Task<string?> GetAiResponseAsync(string userInput, string systemPrompt, bool isUser = false, bool returnRefusalSentinel = false)
+        private async Task<string?> GetAiResponseAsync(string userInput, string systemPrompt, bool isUser = false, bool returnRefusalSentinel = false,
+            string purpose = AiMeter.PurposeChat)
         {
+            // [AI-METER] — log-only sizing, one line per request attempt (plus refused input,
+            // a request we deliberately didn't make). Queue-drop paths never reach Ollama and
+            // stay silent. meterInputChars is refined to the real outgoing message list below.
+            var meterStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var meterInputChars = (systemPrompt?.Length ?? 0) + (userInput?.Length ?? 0);
+            void Meter(string outcome, int outputChars = 0) =>
+                AiMeter.Record(AiMeter.ProviderLocal, purpose, meterInputChars, outputChars,
+                    meterStopwatch.ElapsedMilliseconds, outcome);
+
             // INPUT MODERATION (Layer 1 — code-side, prompt cannot bypass). Same semantics
             // as AiService cloud path: hard categories block before the HTTP call; refusal
             // sentinel surfaces only when the caller is the chat UI.
@@ -485,6 +495,7 @@ namespace ConditioningControlPanel.Services.AIService
                     if (returnRefusalSentinel)
                         App.ModerationCounter?.RecordHit(inputCheck.Category.Value, "input:local");
                     App.Logger?.Information("LocalAiService: input blocked by ModerationGuard (category={Cat})", inputCheck.Category);
+                    Meter(AiMeter.OutcomeRefusedInput);
                     return returnRefusalSentinel ? ModerationRefusal.InputSentinel : null;
                 }
                 if (inputCheck.Allow && inputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
@@ -570,6 +581,8 @@ namespace ConditioningControlPanel.Services.AIService
                 App.Logger?.Information("LocalAiService: sending to Ollama (model={Model}, effects={Effects}, isUser={IsUser}, msgs={MsgCount})",
                     model, effectsEnabled, isUser, outgoing.Count);
 
+                meterInputChars = outgoing.Sum(m => m.Content?.Length ?? 0);
+
                 var (status, body) = await SendChatAsync(model, outgoing);
 
                 if (status != 200)
@@ -578,6 +591,7 @@ namespace ConditioningControlPanel.Services.AIService
                     // Roll back the user turn so we don't poison history with an unanswered turn.
                     // (Automated reactions never appended to _messages, so there's nothing to undo.)
                     if (isUser && _messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
+                    Meter(AiMeter.OutcomeError);
                     return DescribeOllamaError(status, body, model);
                 }
 
@@ -586,6 +600,7 @@ namespace ConditioningControlPanel.Services.AIService
                 {
                     App.Logger?.Warning("LocalAiService: empty content in 200 response: {Body}", Truncate(body, 300));
                     if (isUser && _messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
+                    Meter(AiMeter.OutcomeEmpty);
                     return GetFallbackResponse();
                 }
 
@@ -637,6 +652,7 @@ namespace ConditioningControlPanel.Services.AIService
                             if (_messages.Count > 0 && _messages[^1].Role == "assistant") _messages.RemoveAt(_messages.Count - 1);
                             if (_messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
                         }
+                        Meter(AiMeter.OutcomeRefusedOutput, content.Length);
                         return returnRefusalSentinel ? ModerationRefusal.OutputSentinel : null;
                     }
                     if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
@@ -666,12 +682,15 @@ namespace ConditioningControlPanel.Services.AIService
                     foreach (var cmd in _currentCommands) App.Commands.ExecuteCommand(cmd);
                 }
 
+                Meter(string.IsNullOrWhiteSpace(parsed.CleanText) ? AiMeter.OutcomeEmpty : AiMeter.OutcomeOk, content.Length);
+
                 return parsed.CleanText;
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "LocalAiService: chat call threw (host={Host}, model={Model})", _activeHost, model);
                 if (_messages.Count > 0 && _messages[^1].Role == "user") _messages.RemoveAt(_messages.Count - 1);
+                Meter(AiMeter.OutcomeError);
                 return DescribeChatException(ex, model);
             }
             finally

--- a/ConditioningControlPanel/Services/AIService/LocalAiService.cs
+++ b/ConditioningControlPanel/Services/AIService/LocalAiService.cs
@@ -400,12 +400,20 @@ namespace ConditioningControlPanel.Services.AIService
 
         private static readonly Random _random = new();
 
-        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "")
+        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "", TimeSpan? duration = null)
         {
             var prompt = _bambiSprite.GetSystemPrompt();
             var website = string.IsNullOrEmpty(serviceName) ? detectedName : serviceName;
             var tabName = string.IsNullOrEmpty(pageTitle) ? detectedName : pageTitle;
-            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: 0m]";
+
+            // Same bucketing as the still-on path.
+            var elapsed = duration ?? TimeSpan.Zero;
+            string durationText;
+            if (elapsed.TotalMinutes < 1) durationText = $"{(int)elapsed.TotalSeconds}s";
+            else if (elapsed.TotalMinutes < 60) durationText = $"{(int)elapsed.TotalMinutes}m";
+            else durationText = $"{(int)elapsed.TotalHours}h";
+
+            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
             return await GetAiResponseAsync(userInput, prompt);
         }
 

--- a/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
+++ b/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
@@ -599,7 +599,13 @@ namespace ConditioningControlPanel.Services.AIService
             var effectsEnabled = App.Settings?.Current?.CompanionPrompt?.AllowAiToControlEffects == true;
             if (!effectsEnabled)
             {
-                if (PassesOutputModeration(content, returnRefusalSentinel, out var plainRefusal)) return content;
+                // Strip context-tag echoes BEFORE moderation, matching the cloud path's
+                // ordering (AiService.SanitizeResponse): an echoed awareness tag carries the
+                // user's raw tab title, which must not be able to trip the output guard and
+                // write a false model-output hit into the compliance log. The effects branch
+                // below gets this for free — Parse() sanitizes CleanText.
+                var visible = _parser.SanitizeVisibleText(content);
+                if (PassesOutputModeration(visible, returnRefusalSentinel, out var plainRefusal)) return visible;
                 outputBlocked = true;
                 return plainRefusal;
             }

--- a/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
+++ b/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
@@ -168,6 +168,16 @@ namespace ConditioningControlPanel.Services.AIService
             return model;
         }
 
+        /// <summary>
+        /// Model identifier recorded in moderation.log. Mirrors the "local:{model}" shape the
+        /// Ollama provider uses so the compliance record says which endpoint produced the hit.
+        /// </summary>
+        private static string ModelHint()
+        {
+            var model = GetConfiguredModel();
+            return "openai_compat:" + (string.IsNullOrWhiteSpace(model) ? "unknown" : model);
+        }
+
         private static string? GetApiKey()
         {
             var raw = Settings?.OpenAiCompatibleApiKey;
@@ -362,12 +372,48 @@ namespace ConditioningControlPanel.Services.AIService
             _dailyRequestCount++;
         }
 
-        private async Task<string?> SendChatAsync(string systemPrompt, string userInput)
+        /// <summary>
+        /// Core request path.
+        ///
+        /// Moderation: if <paramref name="returnRefusalSentinel"/> is true and the input or
+        /// output trips <see cref="App.ModerationGuard"/>, returns the appropriate
+        /// <see cref="ModerationRefusal"/> sentinel string so the chat UI can render the
+        /// refusal bubble + POLICY badge. When false (awareness, keyword, lockscreen, video
+        /// paths) a moderation hit returns null and the caller silently drops the reaction —
+        /// surfacing a refusal there would be jarring (user didn't actively prompt).
+        /// </summary>
+        private async Task<string?> SendChatAsync(string systemPrompt, string userInput, bool returnRefusalSentinel = false)
         {
             if (App.Settings?.Current?.OfflineMode == true)
             {
                 App.Logger?.Debug("OpenAiCompatibleService: Offline mode enabled, skipping AI request");
                 return null;
+            }
+
+            // INPUT MODERATION (Layer 1 — code-side, prompt cannot bypass). Runs BEFORE the
+            // HTTP request so prohibited inputs never leave the client. Same semantics as the
+            // cloud and local providers.
+            var guard = App.ModerationGuard;
+            if (guard != null)
+            {
+                var inputCheck = guard.CheckInput(userInput ?? string.Empty);
+                if (!inputCheck.Allow && inputCheck.Category.HasValue)
+                {
+                    App.ModerationLog?.Record(inputCheck.Category.Value, source: "input", modelHint: ModelHint());
+                    // Only escalate the user-facing Content Policy Notice for content the user
+                    // actually typed (interactive chat path). Background/auto reactions leave
+                    // returnRefusalSentinel false and must not pop the warning — that filtering
+                    // is "on us, not on them". Logged above for compliance either way.
+                    if (returnRefusalSentinel)
+                        App.ModerationCounter?.RecordHit(inputCheck.Category.Value, "input:openai_compat");
+                    App.Logger?.Information("OpenAiCompatibleService: input blocked by ModerationGuard (category={Cat})", inputCheck.Category);
+                    return returnRefusalSentinel ? ModerationRefusal.InputSentinel : null;
+                }
+                // ProfessionalAdvice is soft (Allow=true with Category set) — log only.
+                if (inputCheck.Allow && inputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
+                {
+                    App.ModerationLog?.Record(ProhibitedCategory.ProfessionalAdvice, source: "input", modelHint: ModelHint());
+                }
             }
 
             var apiKey = GetApiKey();
@@ -449,7 +495,7 @@ namespace ConditioningControlPanel.Services.AIService
                     }
 
                     var content = CleanTokenizerArtifacts(contentElement.GetString());
-                    return ProcessResponse(content);
+                    return ProcessResponse(content, returnRefusalSentinel);
                 }
                 catch (HttpRequestException) when (attempt == 0)
                 {
@@ -491,17 +537,54 @@ namespace ConditioningControlPanel.Services.AIService
             return messages;
         }
 
-        private string? ProcessResponse(string? content)
+        /// <summary>
+        /// OUTPUT MODERATION (Layer 1). Returns true when <paramref name="text"/> is safe to
+        /// show. On a block, <paramref name="refusal"/> carries the value the caller must
+        /// return — the sentinel on the interactive chat path, null everywhere else.
+        /// </summary>
+        private static bool PassesOutputModeration(string? text, bool returnRefusalSentinel, out string? refusal)
+        {
+            refusal = null;
+
+            var guard = App.ModerationGuard;
+            if (guard == null) return true;
+
+            var outputCheck = guard.CheckOutput(text ?? string.Empty);
+            if (!outputCheck.Allow && outputCheck.Category.HasValue)
+            {
+                App.ModerationLog?.Record(outputCheck.Category.Value, source: "output", modelHint: ModelHint());
+                // Model OUTPUT that trips the filter is never the user's doing, so it does NOT
+                // escalate the Content Policy Notice (logged above for compliance only). The
+                // warning is reserved for user-typed input.
+                App.Logger?.Information("OpenAiCompatibleService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
+                refusal = returnRefusalSentinel ? ModerationRefusal.OutputSentinel : null;
+                return false;
+            }
+            if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
+            {
+                App.ModerationLog?.Record(ProhibitedCategory.ProfessionalAdvice, source: "output", modelHint: ModelHint());
+            }
+
+            return true;
+        }
+
+        private string? ProcessResponse(string? content, bool returnRefusalSentinel)
         {
             if (string.IsNullOrWhiteSpace(content))
                 return null;
 
             var effectsEnabled = App.Settings?.Current?.CompanionPrompt?.AllowAiToControlEffects == true;
             if (!effectsEnabled)
-                return content;
+                return PassesOutputModeration(content, returnRefusalSentinel, out var plainRefusal) ? content : plainRefusal;
 
             var parsed = _parser.Parse(content);
             var commands = parsed.Commands;
+
+            // Moderate the user-visible text (JSON effects wrapper already stripped) BEFORE
+            // executing anything, as the local provider does: a blocked turn fires no effects
+            // and shows no text.
+            if (!PassesOutputModeration(parsed.CleanText, returnRefusalSentinel, out var blockedRefusal))
+                return blockedRefusal;
 
             if (commands.Count > 0)
             {
@@ -544,7 +627,21 @@ namespace ConditioningControlPanel.Services.AIService
                 return new AiReplyResult(GetFallbackResponse(), IsAiGenerated: false, Refusal: null);
 
             var prompt = _bambiSprite.GetSystemPrompt();
-            var reply = await SendChatAsync(prompt, userInput).ConfigureAwait(false);
+            // Interactive path: a moderation block must surface as a POLICY bubble, not a
+            // silent drop, so ask for the refusal sentinel here (and only here).
+            var reply = await SendChatAsync(prompt, userInput, returnRefusalSentinel: true).ConfigureAwait(false);
+
+            var refusalSource = ModerationRefusal.GetSource(reply);
+            if (refusalSource.HasValue)
+            {
+                // Category was already logged inside SendChatAsync; the sentinel string can't
+                // carry it, so we surface only the source here.
+                return new AiReplyResult(
+                    string.Empty,
+                    IsAiGenerated: false,
+                    Refusal: new ModerationRefusalInfo(Category: null, Source: refusalSource.Value));
+            }
+
             if (string.IsNullOrWhiteSpace(reply))
                 return new AiReplyResult(GetFallbackResponse(), IsAiGenerated: false, Refusal: null);
 

--- a/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
+++ b/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
@@ -648,14 +648,24 @@ namespace ConditioningControlPanel.Services.AIService
             return new AiReplyResult(reply, IsAiGenerated: true, Refusal: null);
         }
 
-        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "")
+        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "", TimeSpan? duration = null)
         {
             var prompt = _bambiSprite.GetSystemPrompt();
 
             var website = string.IsNullOrEmpty(serviceName) ? detectedName : serviceName;
             var tabName = string.IsNullOrEmpty(pageTitle) ? detectedName : pageTitle;
 
-            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: 0m]";
+            // Same bucketing as the still-on path.
+            var elapsed = duration ?? TimeSpan.Zero;
+            string durationText;
+            if (elapsed.TotalMinutes < 1)
+                durationText = $"{(int)elapsed.TotalSeconds}s";
+            else if (elapsed.TotalMinutes < 60)
+                durationText = $"{(int)elapsed.TotalMinutes}m";
+            else
+                durationText = $"{(int)elapsed.TotalHours}h";
+
+            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
 
             return await SendChatAsync(prompt, userInput).ConfigureAwait(false);
         }

--- a/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
+++ b/ConditioningControlPanel/Services/AIService/OpenAiCompatibleService.cs
@@ -382,13 +382,23 @@ namespace ConditioningControlPanel.Services.AIService
         /// paths) a moderation hit returns null and the caller silently drops the reaction —
         /// surfacing a refusal there would be jarring (user didn't actively prompt).
         /// </summary>
-        private async Task<string?> SendChatAsync(string systemPrompt, string userInput, bool returnRefusalSentinel = false)
+        private async Task<string?> SendChatAsync(string systemPrompt, string userInput, bool returnRefusalSentinel = false,
+            string purpose = AiMeter.PurposeChat)
         {
             if (App.Settings?.Current?.OfflineMode == true)
             {
                 App.Logger?.Debug("OpenAiCompatibleService: Offline mode enabled, skipping AI request");
                 return null;
             }
+
+            // [AI-METER] — log-only sizing, one line per request attempt (plus refused input,
+            // a request we deliberately didn't make). Missing-key and daily-limit bails never
+            // reach the wire and stay silent. Refined to the real message list below.
+            var meterStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var meterInputChars = (systemPrompt?.Length ?? 0) + (userInput?.Length ?? 0);
+            void Meter(string outcome, int outputChars = 0) =>
+                AiMeter.Record(AiMeter.ProviderOpenAiCompatible, purpose, meterInputChars, outputChars,
+                    meterStopwatch.ElapsedMilliseconds, outcome);
 
             // INPUT MODERATION (Layer 1 — code-side, prompt cannot bypass). Runs BEFORE the
             // HTTP request so prohibited inputs never leave the client. Same semantics as the
@@ -407,6 +417,7 @@ namespace ConditioningControlPanel.Services.AIService
                     if (returnRefusalSentinel)
                         App.ModerationCounter?.RecordHit(inputCheck.Category.Value, "input:openai_compat");
                     App.Logger?.Information("OpenAiCompatibleService: input blocked by ModerationGuard (category={Cat})", inputCheck.Category);
+                    Meter(AiMeter.OutcomeRefusedInput);
                     return returnRefusalSentinel ? ModerationRefusal.InputSentinel : null;
                 }
                 // ProfessionalAdvice is soft (Allow=true with Category set) — log only.
@@ -433,6 +444,7 @@ namespace ConditioningControlPanel.Services.AIService
 
             var model = GetConfiguredModel();
             var messages = BuildMessages(systemPrompt, userInput);
+            meterInputChars = messages.Sum(m => m.Content?.Length ?? 0);
 
             var payload = new Dictionary<string, object>
             {
@@ -476,6 +488,7 @@ namespace ConditioningControlPanel.Services.AIService
                             status,
                             endpointUri,
                             json);
+                        Meter(AiMeter.OutcomeError);
                         return null;
                     }
 
@@ -483,6 +496,7 @@ namespace ConditioningControlPanel.Services.AIService
                     if (!doc.RootElement.TryGetProperty("choices", out var choices) || choices.GetArrayLength() == 0)
                     {
                         App.Logger?.Warning("OpenAiCompatibleService: response has no choices");
+                        Meter(AiMeter.OutcomeError);
                         return null;
                     }
 
@@ -491,11 +505,16 @@ namespace ConditioningControlPanel.Services.AIService
                         !message.TryGetProperty("content", out var contentElement))
                     {
                         App.Logger?.Warning("OpenAiCompatibleService: response missing message.content");
+                        Meter(AiMeter.OutcomeError);
                         return null;
                     }
 
                     var content = CleanTokenizerArtifacts(contentElement.GetString());
-                    return ProcessResponse(content, returnRefusalSentinel);
+                    var processed = ProcessResponse(content, returnRefusalSentinel, out var outputBlocked);
+                    Meter(outputBlocked ? AiMeter.OutcomeRefusedOutput
+                            : string.IsNullOrWhiteSpace(processed) ? AiMeter.OutcomeEmpty : AiMeter.OutcomeOk,
+                        content?.Length ?? 0);
+                    return processed;
                 }
                 catch (HttpRequestException) when (attempt == 0)
                 {
@@ -508,11 +527,13 @@ namespace ConditioningControlPanel.Services.AIService
                 catch (Exception ex)
                 {
                     App.Logger?.Warning(ex, "OpenAiCompatibleService: request failed");
+                    Meter(AiMeter.OutcomeError);
                     return null;
                 }
             }
 
             App.Logger?.Warning("OpenAiCompatibleService: request failed after retry");
+            Meter(AiMeter.OutcomeError);
             return null;
         }
 
@@ -568,14 +589,20 @@ namespace ConditioningControlPanel.Services.AIService
             return true;
         }
 
-        private string? ProcessResponse(string? content, bool returnRefusalSentinel)
+        private string? ProcessResponse(string? content, bool returnRefusalSentinel, out bool outputBlocked)
         {
+            outputBlocked = false;
+
             if (string.IsNullOrWhiteSpace(content))
                 return null;
 
             var effectsEnabled = App.Settings?.Current?.CompanionPrompt?.AllowAiToControlEffects == true;
             if (!effectsEnabled)
-                return PassesOutputModeration(content, returnRefusalSentinel, out var plainRefusal) ? content : plainRefusal;
+            {
+                if (PassesOutputModeration(content, returnRefusalSentinel, out var plainRefusal)) return content;
+                outputBlocked = true;
+                return plainRefusal;
+            }
 
             var parsed = _parser.Parse(content);
             var commands = parsed.Commands;
@@ -584,7 +611,10 @@ namespace ConditioningControlPanel.Services.AIService
             // executing anything, as the local provider does: a blocked turn fires no effects
             // and shows no text.
             if (!PassesOutputModeration(parsed.CleanText, returnRefusalSentinel, out var blockedRefusal))
+            {
+                outputBlocked = true;
                 return blockedRefusal;
+            }
 
             if (commands.Count > 0)
             {
@@ -629,7 +659,7 @@ namespace ConditioningControlPanel.Services.AIService
             var prompt = _bambiSprite.GetSystemPrompt();
             // Interactive path: a moderation block must surface as a POLICY bubble, not a
             // silent drop, so ask for the refusal sentinel here (and only here).
-            var reply = await SendChatAsync(prompt, userInput, returnRefusalSentinel: true).ConfigureAwait(false);
+            var reply = await SendChatAsync(prompt, userInput, returnRefusalSentinel: true, purpose: AiMeter.PurposeChat).ConfigureAwait(false);
 
             var refusalSource = ModerationRefusal.GetSource(reply);
             if (refusalSource.HasValue)
@@ -667,7 +697,7 @@ namespace ConditioningControlPanel.Services.AIService
 
             var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
 
-            return await SendChatAsync(prompt, userInput).ConfigureAwait(false);
+            return await SendChatAsync(prompt, userInput, purpose: AiMeter.PurposeAwareness).ConfigureAwait(false);
         }
 
         public async Task<string?> GetStillOnReactionAsync(string displayName, string category, TimeSpan duration)
@@ -684,7 +714,7 @@ namespace ConditioningControlPanel.Services.AIService
 
             var userInput = $"[Category: {category} | App: {displayName} | Title: {displayName} | Duration: {durationText}]";
 
-            return await SendChatAsync(prompt, userInput).ConfigureAwait(false);
+            return await SendChatAsync(prompt, userInput, purpose: AiMeter.PurposeStillOn).ConfigureAwait(false);
         }
 
         public async Task<string?> GetKeywordCommentAsync(string keyword, string? promptTemplate = null)
@@ -694,7 +724,7 @@ namespace ConditioningControlPanel.Services.AIService
                 ? $"You just caught the user on the word '{keyword}'. React in character, one short line."
                 : promptTemplate.Replace("{keyword}", keyword);
 
-            return await SendChatAsync(systemPrompt, userInput).ConfigureAwait(false);
+            return await SendChatAsync(systemPrompt, userInput, purpose: AiMeter.PurposeKeyword).ConfigureAwait(false);
         }
 
         public async Task<string?> GetLockScreenReaction(string sentance, int mistakes, int amount, string? promptTemplate = null)
@@ -712,7 +742,7 @@ namespace ConditioningControlPanel.Services.AIService
                 userInput = userInput.Replace("{amount}", amount.ToString());
             }
 
-            return await SendChatAsync(systemPrompt, userInput).ConfigureAwait(false);
+            return await SendChatAsync(systemPrompt, userInput, purpose: AiMeter.PurposeLockScreen).ConfigureAwait(false);
         }
 
         public async Task<string?> GetVideoDoneReaction(string title, string? promptTemplate = null)
@@ -722,7 +752,7 @@ namespace ConditioningControlPanel.Services.AIService
                 ? $"The user has just finished the mandatory video {title}. React in character, one short line."
                 : promptTemplate.Replace("{title}", title);
 
-            return await SendChatAsync(systemPrompt, userInput).ConfigureAwait(false);
+            return await SendChatAsync(systemPrompt, userInput, purpose: AiMeter.PurposeVideoDone).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/ConditioningControlPanel/Services/AiService.cs
+++ b/ConditioningControlPanel/Services/AiService.cs
@@ -147,7 +147,7 @@ namespace ConditioningControlPanel.Services
         /// Used by Awareness Mode. Passes raw website and tab name for AI to interpret.
         /// Returns null if AI unavailable (caller should use preset phrase).
         /// </summary>
-        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "")
+        public async Task<string?> GetAwarenessReactionAsync(string detectedName, string category, string serviceName = "", string pageTitle = "", TimeSpan? duration = null)
         {
             // Get prompt from active personality preset
             var prompt = _bambiSprite.GetSystemPrompt();
@@ -156,9 +156,19 @@ namespace ConditioningControlPanel.Services
             var website = string.IsNullOrEmpty(serviceName) ? detectedName : serviceName;
             var tabName = string.IsNullOrEmpty(pageTitle) ? detectedName : pageTitle;
 
+            // Format duration nicely (same bucketing as the still-on path)
+            var elapsed = duration ?? TimeSpan.Zero;
+            string durationText;
+            if (elapsed.TotalMinutes < 1)
+                durationText = $"{(int)elapsed.TotalSeconds}s";
+            else if (elapsed.TotalMinutes < 60)
+                durationText = $"{(int)elapsed.TotalMinutes}m";
+            else
+                durationText = $"{(int)elapsed.TotalHours}h";
+
             // Format context with category for accurate reactions
-            // Format: [Category: X | App: Y | Title: Z | Duration: 0m]
-            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: 0m]";
+            // Format: [Category: X | App: Y | Title: Z | Duration: Nm]
+            var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
 
             return await GetAiResponseAsync(userInput, prompt);
         }

--- a/ConditioningControlPanel/Services/AiService.cs
+++ b/ConditioningControlPanel/Services/AiService.cs
@@ -123,7 +123,7 @@ namespace ConditioningControlPanel.Services
             //   • a refusal sentinel string → typed refusal result
             //   • null on any failure (HTTP error, empty content, daily-limit, etc.) → canned fallback
             //   • model text → genuine AI reply
-            var result = await GetAiResponseAsync(userInput, prompt, returnRefusalSentinel: true);
+            var result = await GetAiResponseAsync(userInput, prompt, returnRefusalSentinel: true, purpose: AiMeter.PurposeChat);
 
             var refusalSource = ModerationRefusal.GetSource(result);
             if (refusalSource.HasValue)
@@ -170,7 +170,7 @@ namespace ConditioningControlPanel.Services
             // Format: [Category: X | App: Y | Title: Z | Duration: Nm]
             var userInput = $"[Category: {category} | App: {website} | Title: {tabName} | Duration: {durationText}]";
 
-            return await GetAiResponseAsync(userInput, prompt);
+            return await GetAiResponseAsync(userInput, prompt, purpose: AiMeter.PurposeAwareness);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace ConditioningControlPanel.Services
             // Format: [Category: X | App: Y | Title: Z | Duration: Nm]
             var userInput = $"[Category: {category} | App: {displayName} | Title: {displayName} | Duration: {durationText}]";
 
-            return await GetAiResponseAsync(userInput, prompt);
+            return await GetAiResponseAsync(userInput, prompt, purpose: AiMeter.PurposeStillOn);
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace ConditioningControlPanel.Services
                 ? $"You just caught the user on the word '{keyword}'. React in character, one short line."
                 : promptTemplate.Replace("{keyword}", keyword);
 
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeKeyword);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace ConditioningControlPanel.Services
                 userInput = userInput.Replace("{amount}", amount.ToString());
             }
 
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeLockScreen);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace ConditioningControlPanel.Services
                 ? $"The user has just finished the mandatory video {title}. React in character, one short line."
                 : promptTemplate.Replace("{title}", title);
 
-            return await GetAiResponseAsync(userInput, systemPrompt);
+            return await GetAiResponseAsync(userInput, systemPrompt, purpose: AiMeter.PurposeVideoDone);
         }
 
         /// <summary>
@@ -267,7 +267,8 @@ namespace ConditioningControlPanel.Services
         /// reaction — surfacing a refusal there would be jarring (user didn't actively
         /// prompt).
         /// </summary>
-        private async Task<string?> GetAiResponseAsync(string userInput, string systemPrompt, bool returnRefusalSentinel = false)
+        private async Task<string?> GetAiResponseAsync(string userInput, string systemPrompt, bool returnRefusalSentinel = false,
+            string purpose = AiMeter.PurposeChat)
         {
             // Check offline mode first
             if (App.Settings?.Current?.OfflineMode == true)
@@ -275,6 +276,16 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("AiService: Offline mode enabled, skipping AI request");
                 return null;
             }
+
+            // [AI-METER] — log-only sizing. Emitted once per request attempt (and for a
+            // moderation-refused input, which is a request we deliberately didn't make).
+            // The paths that never reach the wire at all — offline, no access, daily limit —
+            // are not requests and stay silent.
+            var meterStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var meterInputChars = (systemPrompt?.Length ?? 0) + (userInput?.Length ?? 0);
+            void Meter(string outcome, int outputChars = 0) =>
+                AiMeter.Record(AiMeter.ProviderCloud, purpose, meterInputChars, outputChars,
+                    meterStopwatch.ElapsedMilliseconds, outcome);
 
             // INPUT MODERATION (Layer 1 — code-side, prompt cannot bypass).
             // Runs BEFORE the HTTP request so prohibited inputs never leave the client.
@@ -294,6 +305,7 @@ namespace ConditioningControlPanel.Services
                     if (returnRefusalSentinel)
                         App.ModerationCounter?.RecordHit(inputCheck.Category.Value, "input:cloud");
                     App.Logger?.Information("AiService: input blocked by ModerationGuard (category={Cat})", inputCheck.Category);
+                    Meter(AiMeter.OutcomeRefusedInput);
                     return returnRefusalSentinel ? ModerationRefusal.InputSentinel : null;
                 }
                 // ProfessionalAdvice is soft (Allow=true with Category set) — log only.
@@ -365,13 +377,13 @@ namespace ConditioningControlPanel.Services
                         App.Logger?.Debug("AiService: V2 endpoint not available, trying legacy auth");
                         response.Dispose();
                         response = await SendLegacyRequestAsync(messages);
-                        if (response == null) return null;
+                        if (response == null) { Meter(AiMeter.OutcomeError); return null; }
                     }
                 }
                 else
                 {
                     response = await SendLegacyRequestAsync(messages);
-                    if (response == null) return null;
+                    if (response == null) { Meter(AiMeter.OutcomeError); return null; }
                 }
 
                 if (!response.IsSuccessStatusCode)
@@ -379,6 +391,7 @@ namespace ConditioningControlPanel.Services
                     var errorText = await response.Content.ReadAsStringAsync();
                     App.Logger?.Warning("AiService: Proxy returned {Status}: {Error}",
                         response.StatusCode, errorText);
+                    Meter(AiMeter.OutcomeError);
                     return null;
                 }
 
@@ -387,12 +400,14 @@ namespace ConditioningControlPanel.Services
                 if (result == null || !string.IsNullOrEmpty(result.Error))
                 {
                     App.Logger?.Warning("AiService: Proxy error: {Error}", result?.Error);
+                    Meter(AiMeter.OutcomeError);
                     return null;
                 }
 
                 if (string.IsNullOrEmpty(result.Content))
                 {
                     App.Logger?.Warning("AiService: Empty response from proxy");
+                    Meter(AiMeter.OutcomeEmpty);
                     return null;
                 }
 
@@ -431,6 +446,7 @@ namespace ConditioningControlPanel.Services
                         // it does NOT escalate the Content Policy Notice (logged above for
                         // compliance only). The warning is reserved for user-typed input.
                         App.Logger?.Information("AiService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
+                        Meter(AiMeter.OutcomeRefusedOutput, result.Content!.Length);
                         return returnRefusalSentinel ? ModerationRefusal.OutputSentinel : null;
                     }
                     if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
@@ -439,21 +455,25 @@ namespace ConditioningControlPanel.Services
                     }
                 }
 
+                Meter(AiMeter.OutcomeOk, result.Content!.Length);
                 return sanitized;
             }
             catch (TaskCanceledException)
             {
                 App.Logger?.Warning("AiService: Request timed out");
+                Meter(AiMeter.OutcomeError);
                 return null;
             }
             catch (HttpRequestException ex)
             {
                 App.Logger?.Warning(ex, "AiService: Network error");
+                Meter(AiMeter.OutcomeError);
                 return null;
             }
             catch (Exception ex)
             {
                 App.Logger?.Error(ex, "AiService: Failed to get AI reply");
+                Meter(AiMeter.OutcomeError);
                 return null;
             }
         }

--- a/ConditioningControlPanel/Services/Moderation/ModerationLog.cs
+++ b/ConditioningControlPanel/Services/Moderation/ModerationLog.cs
@@ -48,8 +48,10 @@ namespace ConditioningControlPanel.Services.Moderation
         /// Records a moderation hit. <paramref name="source"/> is one of
         /// <c>input</c>, <c>output</c>, or <c>edit</c> (the latter reserved for
         /// future prompt-validator hooks). <paramref name="modelHint"/> should be
-        /// <c>cloud</c> for the proxy AI service or <c>local:&lt;modelname&gt;</c>
-        /// for the local Ollama service.
+        /// <c>cloud</c> for the proxy AI service, <c>local:&lt;modelname&gt;</c>
+        /// for the local Ollama service, or <c>openai_compat:&lt;modelname&gt;</c>
+        /// for the bring-your-own-endpoint provider (note: that model name is
+        /// user-typed free text, not a closed set).
         /// </summary>
         public void Record(ProhibitedCategory category, string source, string modelHint)
         {

--- a/ConditioningControlPanel/Services/Quiz/QuizService.cs
+++ b/ConditioningControlPanel/Services/Quiz/QuizService.cs
@@ -659,6 +659,14 @@ Do NOT include any other text before or after the question format. Just the ques
             // Trim conversation to last 30 messages + system prompt to stay under limits.
             var messagesToSend = TrimConversation();
 
+            // [AI-METER] — log-only sizing. The quiz bypasses IAiService entirely, so it has to
+            // emit its own line or a whole quiz (11-12+ requests) is invisible to the meter.
+            var meterStopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var meterInputChars = messagesToSend.Sum(m => m.Content?.Length ?? 0);
+            void Meter(string outcome, int outputChars = 0) =>
+                AIService.AiMeter.Record(AIService.AiMeter.ProviderQuiz, AIService.AiMeter.PurposeQuiz,
+                    meterInputChars, outputChars, meterStopwatch.ElapsedMilliseconds, outcome);
+
             // Route to whichever provider the user has selected for the companion. The
             // quiz used to be cloud-only, so switching to local Ollama left it stuck on
             // "AI busy / daily limit" even though chat worked (BUG-XQRK4USW5X / #334).
@@ -668,7 +676,12 @@ Do NOT include any other text before or after the question format. Just the ques
                 : await CallCloudAiAsync(messagesToSend, maxTokens);
 
             if (string.IsNullOrEmpty(content))
+            {
+                // Both transports collapse "call failed" and "empty reply" into null and log
+                // the specific cause themselves, so the meter can only report `error` here.
+                Meter(AIService.AiMeter.OutcomeError);
                 return null;
+            }
 
             // OUTPUT MODERATION (Layer 1) — applies to BOTH providers. Discard
             // AI-generated questions / result archetype text that trips the guard.
@@ -687,6 +700,7 @@ Do NOT include any other text before or after the question format. Just the ques
                     // the user-facing Content Policy Notice. The batch is still
                     // discarded fail-closed (return null) so nothing prohibited leaks.
                     App.Logger?.Information("QuizService: output blocked by ModerationGuard (category={Cat})", outputCheck.Category);
+                    Meter(AIService.AiMeter.OutcomeRefusedOutput, content.Length);
                     return OutputBlocked;
                 }
                 if (outputCheck.Allow && outputCheck.Category == ProhibitedCategory.ProfessionalAdvice)
@@ -695,6 +709,7 @@ Do NOT include any other text before or after the question format. Just the ques
                 }
             }
 
+            Meter(AIService.AiMeter.OutcomeOk, content.Length);
             return content;
         }
 

--- a/Tests/ConditioningControlPanel.Tests/CompanionPromptCloneTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionPromptCloneTests.cs
@@ -1,0 +1,53 @@
+using ConditioningControlPanel.Models;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// <see cref="CompanionPromptSettings.Clone"/> used to stop copying at CustomDomains, silently
+/// dropping the five CCBill acknowledgement fields. Callers such as
+/// PersonalityService.MigrateFromLegacy and CommunityPrompt clone settings and write the clone
+/// back, so a user who had already accepted the explicit-content gate was re-prompted and the
+/// recorded ack timestamp/locale (the audit trail) was erased. These tests pin the whole copy.
+/// </summary>
+public class CompanionPromptCloneTests
+{
+    private static CompanionPromptSettings BuildAcknowledged() => new()
+    {
+        ExplicitContentAcknowledged = true,
+        ExplicitAcknowledgedVersion = CompanionPromptSettings.ExplicitAcknowledgementVersion,
+        ExplicitAcknowledgedAt = "2026-08-05T12:34:56.7890000Z",
+        ExplicitAcknowledgedLocale = "de-DE",
+        PromptEditorDisclaimerAcknowledged = true
+    };
+
+    [Fact]
+    public void Clone_PreservesAcknowledgementAuditTrail()
+    {
+        var clone = BuildAcknowledged().Clone();
+
+        Assert.True(clone.ExplicitContentAcknowledged);
+        Assert.Equal(CompanionPromptSettings.ExplicitAcknowledgementVersion, clone.ExplicitAcknowledgedVersion);
+        Assert.Equal("2026-08-05T12:34:56.7890000Z", clone.ExplicitAcknowledgedAt);
+        Assert.Equal("de-DE", clone.ExplicitAcknowledgedLocale);
+        Assert.True(clone.PromptEditorDisclaimerAcknowledged);
+    }
+
+    [Fact]
+    public void Clone_KeepsCopyingTheEarlierFields()
+    {
+        // Regression guard: the ack fields were appended after CustomDomains, so make sure
+        // the pre-existing tail of the copy still works.
+        var source = BuildAcknowledged();
+        source.OutputRules = "SHORT. Max 15 words.";
+        source.CustomDomains["example.com"] = "Browsing";
+
+        var clone = source.Clone();
+
+        Assert.Equal("SHORT. Max 15 words.", clone.OutputRules);
+        Assert.Equal("Browsing", clone.CustomDomains["example.com"]);
+        // Deep copy: mutating the clone's dictionary must not touch the source.
+        clone.CustomDomains["other.com"] = "Gaming";
+        Assert.False(source.CustomDomains.ContainsKey("other.com"));
+    }
+}


### PR DESCRIPTION
First batch of the AI Companion rework ("Train 0"): five surgical hotfixes plus the telemetry that grounds the upcoming token-budget decisions. All client-side - no server or endpoint changes.

## What's in
1. **Moderation for the OpenAI-compatible provider** - it had zero ModerationGuard calls: switching to a BYO endpoint silently dropped both filter layers and the CCBill compliance log. Now mirrors the cloud/local semantics exactly (input+output checks, ModerationLog record, refusal sentinel only on the interactive chat path, blocked turns fire no effects and show no text). No entitlement gate added (separate decision).
2. **CompanionPromptSettings.Clone() keeps the CCBill acknowledgement audit trail** - it silently dropped all five ack fields on preset migration / community-prompt import. Plus 2 new unit tests pinning it.
3. **Real awareness durations** - the providers hardcoded `Duration: 0m` into every awareness prompt. `GetAwarenessReactionAsync` now takes the actual dwell time (the avatar double-click path is where it matters - the user may have been on the app 30+ min).
4. **Awareness cooldown burns on delivery, not on attempt** - a failed/moderated call used to eat the whole cooldown and the user got silence. New per-handler in-flight guards keep a burst of window switches from stacking LLM calls now that the cooldown no longer doubles as a re-entrancy guard.
5. **`[AI-METER]` instrumentation** - one Serilog line per LLM request (provider, purpose, ~tokens in/out, latency, outcome) across all three providers and the quiz path. Counts and enums only, never content or titles. A week of these logs replaces the planning-grade cost estimates with measured numbers for the token-budget design.
6. `.gitignore`: internal `planning/` folder.

## Review
Independent review pass ran before push; its findings are fixed in the last commit:
- openai_compat now strips context-tag echoes **before** output moderation (cloud parity) - an echoed tab title can no longer write a false model-output hit into the compliance log
- whitespace AI replies (effects-only local turns) now fall back to the preset phrase and burn the cooldown, instead of leaving `CanReact()` permanently true
- split in-flight flags so a slow awareness call can't swallow a still-on milestone

## Verification
- `dotnet build`: 0 errors
- `dotnet test`: **913 passed / 0 failed** (911 pre-existing + 2 new Clone tests)
- Play-test checklist before merge: chat + an awareness reaction on each provider (cloud, local, BYO endpoint if configured); confirm `[AI-METER]` lines appear in the log with no titles/content; confirm a moderated BYO reply shows the refusal bubble in chat and silence for background reactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue