### PR TITLE
Goon Game: partner media is ephemeral - wiped at match end, page boot, window close, and app start

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -352,10 +352,13 @@ bridge.on('init', (m) => {
 bridge.on('manifest', (m) => {
   gotManifest = true;
   session.manifest = media.setManifest(m);
-  // WHAT A PARTNER SENT US IN AN EARLIER SESSION rides this same frame (spec §6.4)
-  // rather than a new boot milestone — settle() already gates on gotManifest, so the
-  // received set is primed before any screen mounts, which is what lets the very
-  // first offer of a match answer `decline:'have'` instead of re-transferring 20 MB.
+  // EPHEMERAL INBOX (owner decision, 2026-08-05): a partner's media never survives
+  // the match — the page purges at teardownEverything and the host wipes at page
+  // boot, so `received` is empty in production. The priming path is kept because
+  // the manifest frame still carries the field (shape compatibility, and the
+  // standalone/test harness feeds rows through it), not because anything should
+  // arrive here. If this ever logs a nonzero count on a fresh page, a purge seam
+  // regressed — that is the bug that put past partners' media into Practice.
   session.received = Array.isArray(m.received) ? m.received : [];
   primeReceived(session.received);
   bridge.log('manifest: ' + session.manifest.images + ' images, ' + session.manifest.videos + ' videos'
@@ -800,6 +803,32 @@ function primeReceived(list) {
     registerReceived(receivedStore.list());
   } catch (e) {
     logger.warn('priming the received inbox failed: ' + ((e && e.message) || e));
+  }
+}
+
+/**
+ * THE EPHEMERAL-INBOX SEAM (owner decision, 2026-08-05): nothing a partner sent
+ * survives the match. Dropping goes through the SAME two ledgers priming filled —
+ * exec/media.js (so a Practice peer-run's drawReceived can never see a dead row)
+ * and the received store (whose drop() also deletes the host's disk file) — in
+ * that order, so no window exists where media can hand out a view the store has
+ * already destroyed. Called from teardownEverything, which every road out of a
+ * match funnels through and a relay REBUILD never touches; the recap always
+ * mounts BEFORE its match is torn down, so its report card keeps its plates.
+ */
+function purgeReceived(why) {
+  if (!receivedStore) return;
+  try {
+    const rows = receivedStore.list();
+    if (!rows.length) return;
+    for (const e of rows) {
+      try { media.dropReceived(e.sha); } catch (_e) { /* one bad row never stops the sweep */ }
+      try { receivedStore.drop(e.sha); } catch (_e) { /* ignore */ }
+    }
+    session.received = [];
+    logger.info('received inbox purged (' + why + '): ' + rows.length + ' artifact(s)');
+  } catch (e) {
+    logger.warn('purging the received inbox failed: ' + ((e && e.message) || e));
   }
 }
 
@@ -1785,6 +1814,9 @@ async function teardownEverything() {
   }
   try { layers.stopAll(); } catch (_e) { /* ignore */ }
   try { executor?.stopAll?.(); } catch (_e) { /* ignore */ }
+  // LAST, after the executor is stopped: nothing can be mid-draw on a view the
+  // drop is about to destroy. See purgeReceived for why this seam is the one.
+  purgeReceived('teardown');
 }
 
 const actions = {

--- a/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/flashes.js
@@ -1094,8 +1094,10 @@ export function createFlashes({ layers, media, audio, logger } = {}) {
         // relayed connection.
         tags: xferTags(payload),
         // PEER run: after `tags` is spent, showOne keeps drawing from the
-        // received store instead of the local library (null in solo, where
-        // nothing was ever received — the fallback is unchanged there).
+        // received store instead of the local library. Empty in solo BY THE
+        // PURGE SEAMS, not by accident: boot.js purges the inbox at every
+        // teardown and the host wipes it at page boot, so Practice's scripted
+        // peer can never replay what a past partner sent (the 2026-08-05 scare).
         peer: true,
       };
       // Tell the ambient renderers (spiral bed, drain wash) a squall is on:

--- a/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/receivedStore.js
@@ -10,7 +10,11 @@
 //     Services/GoonGame/TransferInboxStore.cs -> transfer-cache/recv/<sha>.<ext>, served back as
 //     https://ccp.cache/recv/... A 24 MB blob: URL in a <video> forces the whole artifact into
 //     renderer memory and breaks seeking; a virtual-host URL streams exactly like the existing
-//     ccp.assets path, release() stays the no-op it already is, and cross-session persistence is free.
+//     ccp.assets path, and release() stays the no-op it already is. THE INBOX IS EPHEMERAL
+//     (owner decision, 2026-08-05): boot.js purges every committed artifact at teardownEverything
+//     and the host wipes recv/ at app start, page boot and window close — a partner's media never
+//     outlives the match it arrived in. decline:'have' therefore only dedupes WITHIN a match; a
+//     rematch re-transfers, and that cost is the accepted price of the privacy guarantee.
 //
 //   STANDALONE (a plain browser)  an in-memory Blob map capped at MEM_STORE_BYTES with a REAL
 //     refcount: at zero the object URL is revoked, and the next view() mints a fresh one off the

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -360,10 +360,12 @@ namespace ConditioningControlPanel.Services.GoonGame
                 // builder verbatim (asset-tree deselection, size caps, sampling) — one enumerator
                 // for every web core.
                 var m = DtrhAssetManifest.Build();
-                // `received` rides the EXISTING manifest frame rather than a new boot milestone:
-                // boot.js already gates settle() on gotManifest, so the received-artifact set is
-                // primed before any screen mounts - which is what lets the very first offer of a
-                // match answer decline:'have' instead of re-transferring (spec 6.4).
+                // EPHEMERAL INBOX (owner decision, 2026-08-05): a fresh page means any committed
+                // artifact is a leftover from a session the page-side purge never saw (window
+                // closed from the recap, a reload). Wipe BEFORE listing, so the manifest's
+                // `received` rows - kept for frame-shape compatibility - are always empty and the
+                // page never re-primes a past partner's media into the pool (the Practice leak).
+                TransferInboxStore.Instance.PurgeCommittedSafe("page boot");
                 var received = SafeReceivedList();
                 _host?.Post(new
                 {
@@ -376,11 +378,9 @@ namespace ConditioningControlPanel.Services.GoonGame
                 });
 
                 // The compression cache's own feed. Attached AFTER the manifest so the page has its
-                // pool before the first cache-state lands, and pruned here because "page ready" is
-                // one of exactly two moments when nothing can be mid-transfer.
+                // pool before the first cache-state lands. (The inbox needs no prune here anymore -
+                // the ephemeral wipe above already emptied it.)
                 GoonCacheBridge.Attach(_host);
-                try { TransferInboxStore.Instance.PruneSafe(); }
-                catch (Exception ex) { App.Logger?.Debug("GoonHostService: inbox prune: {E}", ex.Message); }
 
                 // ...and tell the page which window it is actually painted in. Its affordances read
                 // the echoed state, never the requested one.
@@ -1619,7 +1619,10 @@ namespace ConditioningControlPanel.Services.GoonGame
                 // mid-match would otherwise leave the queue paused for the rest of the app session.
                 try { GoonCacheBridge.Detach(); } catch { }
                 try { Transfer.TransferCompressionService.Instance.ResumeAfterMatch(); } catch { }
-                try { TransferInboxStore.Instance.PruneSafe(); } catch { }
+                // Ephemeral inbox: the window is the session, and the session is over. A file the
+                // renderer still holds open just fails the delete - the page-boot wipe and the
+                // startup sweep are the backstops for whatever this one cannot take.
+                try { TransferInboxStore.Instance.PurgeCommittedSafe("window closed"); } catch { }
                 // Last word to the page before the window goes: a live match should get a chance
                 // to post its own abandon rather than just vanishing from the opponent's side.
                 try { _host?.Post(new { type = "end-run", reason = "dispose" }); } catch { }

--- a/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
+++ b/ConditioningControlPanel/Services/GoonGame/TransferInboxStore.cs
@@ -21,9 +21,9 @@ namespace ConditioningControlPanel.Services.GoonGame
         ///
         /// ADVISORY AND UNTRUSTED, which is why it is safe to take a peer's word for it: it never
         /// touches a filename, a size, a hash or a mime check, and the only thing that reads it is
-        /// the page's preference for real footage in the VIDEO lane. Persisted because a returning
-        /// session primes exec/media.js from this index — without it a gif loop received yesterday
-        /// comes back today looking like a clip.
+        /// the page's preference for real footage in the VIDEO lane. Still indexed so a mid-match
+        /// page reload keeps the distinction; the inbox itself no longer survives the session
+        /// (ephemeral policy — see the class doc).
         /// </summary>
         [JsonProperty("origin")] public string Origin { get; set; } = "";
         [JsonProperty("bytes")] public long Bytes { get; set; }
@@ -58,6 +58,15 @@ namespace ConditioningControlPanel.Services.GoonGame
     ///
     /// Thread-safety: every public method takes the instance lock. Commit hashes up to 24 MB, so
     /// callers should run it off the UI thread (the bridge does).
+    ///
+    /// THE INBOX IS EPHEMERAL (owner decision, 2026-08-05): a partner's media must never outlive
+    /// the match it arrived in. The page purges per-artifact at its teardown seam; this class
+    /// backstops every path the page cannot see by wiping ALL committed artifacts at the startup
+    /// sweep (a crash), at page boot (<see cref="PurgeCommittedSafe"/> from OnPageReady — a window
+    /// reopened within one app run), and at window close (DisposeAll). Before this policy the
+    /// inbox persisted for cross-session <c>decline:'have'</c> dedupe — and boot.js primed it into
+    /// the media pool, which let Practice's scripted peer replay past partners' media. Dedupe is
+    /// now within-match only; a rematch re-transfers. Do not "optimize" persistence back in.
     /// </summary>
     internal sealed class TransferInboxStore
     {
@@ -194,58 +203,15 @@ namespace ConditioningControlPanel.Services.GoonGame
         }
 
         /// <summary>
-        /// Startup sweep, caller holds the lock. Cheap paranoia against a tampered folder:
-        ///   - a file in recv/ whose NAME is not a sha (or whose magic disagrees with its extension)
-        ///     is deleted — it cannot have come from this code path;
-        ///   - an index row with no file is dropped;
-        ///   - a file with no index row is ADOPTED (an index write lost to a crash is recoverable —
-        ///     the bytes are the artifact and the name is already the verified hash);
-        ///   - every <c>recv-*.part</c> from a previous run is deleted. Resume survives a page
-        ///     RELOAD (the session dict is process-lived) but deliberately NOT an app restart:
-        ///     a half-file whose sender is long gone is pure cost.
+        /// Startup sweep, caller holds the lock. Under the ephemeral policy (class doc) anything in
+        /// recv/ at startup is a leftover from an unclean exit — the page's teardown purge and the
+        /// window-close purge already ran on every clean path — so the sweep deletes ALL of it, the
+        /// index with it, and every <c>recv-*.part</c> from a previous run. Resume across an app
+        /// restart was never supported; now the committed files do not cross a restart either.
         /// </summary>
         private void SweepLocked()
         {
-            var onDisk = new Dictionary<string, (string Ext, long Bytes)>(StringComparer.Ordinal);
-            try
-            {
-                Directory.CreateDirectory(RecvDir);
-                foreach (var f in Directory.EnumerateFiles(RecvDir))
-                {
-                    var sha = Path.GetFileNameWithoutExtension(f);
-                    var ext = Path.GetExtension(f).TrimStart('.').ToLowerInvariant();
-                    if (!ShaRe.IsMatch(sha)) { TryDelete(f, "bad name"); continue; }
-                    var fmt = SniffFile(f);
-                    if (fmt == null || !FormatToExt.TryGetValue(fmt, out var wantExt) || wantExt != ext)
-                    {
-                        TryDelete(f, "magic mismatch");
-                        continue;
-                    }
-                    try { onDisk[sha] = (ext, new FileInfo(f).Length); } catch { }
-                }
-            }
-            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Sweep(recv): {E}", ex.Message); }
-
-            foreach (var sha in _index.Entries.Keys.ToList())
-                if (!onDisk.ContainsKey(sha)) _index.Entries.Remove(sha);
-
-            foreach (var (sha, info) in onDisk)
-            {
-                if (_index.Entries.TryGetValue(sha, out var e))
-                {
-                    e.Ext = info.Ext;
-                    e.Bytes = info.Bytes;
-                    continue;
-                }
-                _index.Entries[sha] = new InboxEntry
-                {
-                    Ext = info.Ext,
-                    Mime = MimeForExt(info.Ext),
-                    Bytes = info.Bytes,
-                    LastAccessUtc = DateTime.UtcNow,
-                };
-            }
-            RecountLocked();
+            PurgeCommittedLocked("startup sweep");
 
             try
             {
@@ -256,6 +222,44 @@ namespace ConditioningControlPanel.Services.GoonGame
             catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Sweep(tmp): {E}", ex.Message); }
 
             SaveLocked();
+        }
+
+        /// <summary>
+        /// Delete every committed artifact and its index row. Caller holds the lock. Never touches
+        /// TmpDir partials — a live session's .part is the one thing a purge may not race.
+        /// </summary>
+        private void PurgeCommittedLocked(string why)
+        {
+            var n = 0;
+            try
+            {
+                Directory.CreateDirectory(RecvDir);
+                foreach (var f in Directory.EnumerateFiles(RecvDir)) { TryDelete(f, why); n++; }
+            }
+            catch (Exception ex) { App.Logger?.Debug("TransferInboxStore.Purge(recv): {E}", ex.Message); }
+            _index.Entries.Clear();
+            RecountLocked();
+            if (n > 0)
+                App.Logger?.Information("TransferInboxStore: purged {N} received artifact(s) ({Why})", n, why);
+        }
+
+        /// <summary>
+        /// The ephemeral-inbox wipe (class doc). Callable ONLY from moments when nothing can be
+        /// mid-match — page boot (OnPageReady) and window close (DisposeAll) — because it deletes
+        /// files the page may otherwise still be rendering. Never throws.
+        /// </summary>
+        public void PurgeCommittedSafe(string why)
+        {
+            try
+            {
+                EnsureLoaded();
+                lock (_lock)
+                {
+                    PurgeCommittedLocked(why);
+                    SaveLocked();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Warning("TransferInboxStore.PurgeCommittedSafe: {E}", ex.Message); }
         }
 
         private static void TryDelete(string path, string why)
@@ -590,7 +594,8 @@ namespace ConditioningControlPanel.Services.GoonGame
             return true;
         }
 
-        /// <summary>Mark an artifact used so the LRU keeps it. Called when the page renders one.</summary>
+        /// <summary>Refresh an artifact's last-access stamp. (The LRU prune that read it is gone -
+        /// ephemeral policy - but the stamp is still honest bookkeeping for the index row.)</summary>
         public void Touch(string? sha)
         {
             if (!IsSha(sha)) return;
@@ -598,54 +603,13 @@ namespace ConditioningControlPanel.Services.GoonGame
                 if (_index.Entries.TryGetValue(sha!, out var e)) e.LastAccessUtc = DateTime.UtcNow;
         }
 
-        // ---- LRU ------------------------------------------------------------------
+        // (The LRU prune that lived here died with cross-session persistence: the ephemeral wipes
+        //  at startup, page boot and window close are the only artifact-deletion entry points now,
+        //  and CapBytes is enforced at Begin. LastAccessUtc stays on the index rows — a mid-match
+        //  page reload still reads them.)
 
-        /// <summary>
-        /// Prune to <see cref="CapBytes"/>, least-recently-accessed first. THE ONLY PRUNE ENTRY
-        /// POINT, and the host calls it at exactly two moments — page ready and end-run — because
-        /// pruning between <see cref="Begin"/> and the end of a match could delete the artifact a
-        /// floating window is playing from. A live write session vetoes the whole pass.
-        /// </summary>
-        public void PruneSafe()
-        {
-            EnsureLoaded();
-            var doomed = new List<(string Sha, string Ext, long Bytes)>();
-            lock (_lock)
-            {
-                SweepStaleSessionsLocked();
-                if (_sessions.Count > 0)
-                {
-                    App.Logger?.Debug("TransferInboxStore: prune skipped ({N} writes in flight)", _sessions.Count);
-                    return;
-                }
-                long left = _usedBytes;
-                if (left <= CapBytes) return;
-                foreach (var kv in _index.Entries.OrderBy(x => x.Value.LastAccessUtc).ToList())
-                {
-                    if (left <= CapBytes) break;
-                    doomed.Add((kv.Key, kv.Value.Ext, kv.Value.Bytes));
-                    _index.Entries.Remove(kv.Key);
-                    left -= kv.Value.Bytes;
-                }
-                RecountLocked();
-                SaveLocked();
-            }
-            foreach (var (sha, ext, _) in doomed)
-            {
-                try
-                {
-                    var p = Path.Combine(RecvDir, sha + "." + ext);
-                    if (File.Exists(p)) File.Delete(p);
-                }
-                catch { }
-            }
-            if (doomed.Count > 0)
-                App.Logger?.Information("TransferInboxStore: pruned {N} received artifacts ({MB:F1} MB)",
-                    doomed.Count, doomed.Sum(d => d.Bytes) / 1048576.0);
-        }
-
-        /// <summary>Drop write sessions the page stopped feeding, so one dead transfer can't veto
-        /// every future prune. Caller holds the lock.</summary>
+        /// <summary>Drop write sessions the page stopped feeding, so one dead transfer can't hold
+        /// its .part (and its cap bytes) forever. Caller holds the lock.</summary>
         private void SweepStaleSessionsLocked()
         {
             if (_sessions.Count == 0) return;


### PR DESCRIPTION
## The scare

During the 2026-08-05 pre-release, Practice mode replayed media that past duel partners had sent. Root cause: the received-media inbox (`transfer-cache/recv/`) persisted across sessions for `decline:'have'` dedupe, boot primed it into the live media pool on every page load, and Practice's scripted opponent fires real peer-tagged runs - which prefer `drawReceived()`. The code comment claiming solo "never received anything" was true when written and silently broke when persistence landed.

## The policy (owner decision)

A partner's media must never outlive the match it arrived in. Privacy beats bandwidth: within-match dedupe is unchanged, a rematch re-transfers.

## The seams

| Boundary | Mechanism |
|---|---|
| Every road out of a match | `purgeReceived()` at the end of `teardownEverything` (boot.js) - relay rebuilds never call it; the recap mounts before teardown so its report card keeps its plates |
| Page boot (window reopened same app run, reload) | `TransferInboxStore.PurgeCommittedSafe("page boot")` before the manifest is built - `received` rows are now always empty (kept for frame-shape compat) |
| Window close | `PurgeCommittedSafe("window closed")` in `DisposeAll` |
| App start (crash backstop) | startup sweep now deletes ALL committed artifacts + stale partials |

The LRU prune (`PruneSafe`) died with persistence - `CapBytes` is still enforced at `Begin`. Phone/standalone was already ephemeral (in-memory blob store).

## Tests

13/14 suites green (assets 427, core 242, encode 190, exec 1054, flow 318, hostgate 97, hud 1696, invite 199, net 350, report 213, transfer 199, voice-ui 269, voice 270). `selftest-avafx` fails 12 checks **on clean main too** - pre-existing, unrelated.

## Play-test

- Duel, receive media, finish to recap: recap plates render; leave to title; enter Practice: **no partner media**, log shows `received inbox purged (teardown)`
- Duel, close the goon window from the recap, reopen: log shows the page-boot purge; Practice clean
- Kill the app mid-match, relaunch: startup sweep logs the wipe; `transfer-cache/recv/` empty
- Mid-match sanity: transfers still land and render during a live duel; rematch re-transfers (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TES3SQQkdVKQ5utaBVHX2W
