### PR TITLE
Goon Game: toast the mic-gate reason in-match (why is there no mic this duel)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -1485,6 +1485,42 @@ function reportMicGate() {
     }
     if (!why) { logger.warn('voice mic hidden: the service says live but the desk has no strip (mount failure?)'); return; }
     logger.warn('voice mic hidden: ' + why);
+    micGateToast(deskWhy);
+  } catch (e) {
+    // A diagnostic that can break a match is worse than no diagnostic.
+    logger.warn('voice mic gate check threw: ' + ((e && e.message) || e));
+  }
+}
+
+/**
+ * THE PLAYER-FACING HALF of reportMicGate (owner, 2026-08-05, round two): the
+ * warn above ended the log archaeology, and then the owner sat in a PvP duel
+ * with the drawer open, no mic, and no way to know WHY without reading logs —
+ * the exact blindness the warn was built to end, one audience over. One toast,
+ * once per match (this runs inside reportMicGate's micGateSaid latch), and ONLY
+ * for a seat that opted in: a player who never switched voice notes on has not
+ * lost anything worth interrupting them over. Practice is exempt for the same
+ * reason the mic is off there at all — the bot never consents, and "your
+ * partner has voice off" about a bot is noise dressed as help.
+ *
+ * FACTS, NOT PROSE: the service's whyUnavailable sentences are pinned by
+ * selftest-voice, so matching on them would couple a toast to a test vector.
+ * The match object is re-read directly, in the same order available() applies
+ * its gates, and anything unreadable simply does not toast — a missing toast
+ * is a shrug, a wrong one is a lie.
+ */
+function micGateToast(deskWhy) {
+  try {
+    if (soloPair) return;
+    if (!prefs || !prefs.get || !prefs.get('voiceNotesEnabled')) return;
+    const m = currentMatch;
+    if (!m) return;
+    let msg = '';
+    if (deskWhy === 'zen') msg = S.voice.micZenToast;
+    else if (!m.linkIsP2P) msg = S.voice.micRelayToast;
+    else if (!m.peerSupportsVoice) msg = S.voice.micPeerOldToast;
+    else if (!m.remoteVoiceNotes) msg = S.voice.micPeerOffToast;
+    if (msg) toasts?.warn?.(msg);
   } catch (e) {
     // A diagnostic that can break a match is worse than no diagnostic.
     logger.warn('voice mic gate check threw: ' + ((e && e.message) || e));

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -628,6 +628,18 @@ export const S = Object.freeze({
     lobbyTheirsOn: 'they opted in',
     lobbyTheirsOff: 'they have not',
 
+    /* --- the mic-gate toasts (2026-08-05, round two) ----------------------
+     * The lobby row says all of this — and the owner still sat in a PvP duel,
+     * drawer open, hunting a mic that was correctly hidden, because nothing
+     * IN THE MATCH said so. One of these fires as a single toast at Live,
+     * once per match, only for a seat that opted in (boot.js micGateToast).
+     * Each names the reason AND whose switch it is; none of them may read as
+     * "something broke", because nothing did. */
+    micPeerOffToast: 'no mic this duel — your partner has voice notes switched off',
+    micPeerOldToast: 'no mic this duel — their app is too old for voice notes',
+    micRelayToast: 'no mic this duel — relayed connection, and voice only crosses a direct one',
+    micZenToast: 'your mic is live but hidden by zen — bring the desk chrome back to use it',
+
     /* --- the refusals ----------------------------------------------------- */
     /** getUserMedia said no. NOT an error tone: it is a perfectly good answer. */
     micDenied: 'no microphone access — the mic stays off',


### PR DESCRIPTION
## Why

Tonight's play-test, round two: the owner sat in a **PvP duel with the arsenal drawer open and no mic**, and the only witness to why was the log (`voice mic hidden: the peer never declared voice_notes`). The `reportMicGate` warn ended log archaeology for developers - this PR gives the same one-line answer to the player.

## What

One toast at Live, once per match (rides `reportMicGate`'s existing `micGateSaid` latch), with three deliberate silences:

- **Not opted in -> silent.** A player who never switched voice notes on has lost nothing worth interrupting them over.
- **Practice -> silent.** The bot never consents; "your partner has voice off" about a bot is noise dressed as help.
- **Drawer shut -> silent.** V works and auto-opens the drawer; the log line already says so.

Reasons are re-read as **facts off the match object** (`linkIsP2P`, `peerSupportsVoice`, `remoteVoiceNotes`) in `available()`'s own gate order - not matched against `whyUnavailable()` prose, which is pinned by selftest-voice.

New strings (S.voice):

| Key | Copy |
|---|---|
| `micPeerOffToast` | no mic this duel - your partner has voice notes switched off |
| `micPeerOldToast` | no mic this duel - their app is too old for voice notes |
| `micRelayToast` | no mic this duel - relayed connection, and voice only crosses a direct one |
| `micZenToast` | your mic is live but hidden by zen - bring the desk chrome back to use it |

## Tests

All suites green except the two known pre-existing issues: the intermittent selftest-exec rotation flake (fails ~half of runs on main too) and selftest-avafx (12 fails on clean main). hud 1696/1696, voice 270/270, voice-ui 269/269, flow 318/318.

## Play-test

Duel a partner with voice notes off (your opt-in ON): one toast at Live naming their switch; none in Practice; none when your own opt-in is off; zen during a voice-capable duel says the zen line instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TES3SQQkdVKQ5utaBVHX2W
