### PR TITLE
feat(goon): first-encounter coaching - nudges, explanations and the objective

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -62,6 +62,7 @@ import { createRouter } from './ui/router.js';
 import { createPrefs } from './ui/prefs.js';
 import { createAudio } from './ui/audio.js';
 import { createToasts } from './ui/toasts.js';
+import { createCoach, COACH } from './ui/coach.js';
 import { createSheets } from './ui/sheets.js';
 import { createOptions } from './ui/options.js';
 import { createSoloDriver } from './ui/soloDriver.js';
@@ -490,6 +491,11 @@ let audio = null;
 let toasts = null;
 let sheets = null;
 let options = null;
+/* ui/coach.js — the one-time explainers. A boot singleton rather than a per-match
+ * handle on purpose: "once ever" is a fact about the PLAYER, and a coach rebuilt
+ * on every attachMatch (the relay fallback rebuilds the whole graph) would keep
+ * its page-local ledger for a matter of seconds. */
+let coach = null;
 let router = null;
 let executor = null;
 let matchLog = null;
@@ -1499,7 +1505,7 @@ function mountHudNow() {
       // from inside the HUD. mountHud takes a destructured options object, so an
       // extra key is inert — and handing it over here means the mic lands as one
       // line in ui/hud.js rather than as a second wiring pass through this file.
-      match: currentMatch, session, audio, prefs, media, matchLog, discord, voice,
+      match: currentMatch, session, audio, prefs, media, matchLog, discord, voice, coach,
     }) || null;
   } catch (e) { logger.error('mountHud threw: ' + ((e && e.stack) || e)); hudHandle = null; }
 }
@@ -1507,6 +1513,9 @@ function mountHudNow() {
 function unmountHud() {
   if (!hudHandle) return;
   try { hudHandle.unmount?.(); } catch (e) { logger.warn('hud.unmount threw: ' + ((e && e.message) || e)); }
+  // A coached line still waiting its turn is about a match that has just ended.
+  // The marks stay; only the queue goes. See coach.clearPending.
+  try { coach?.clearPending?.(); } catch (_e) { /* a hint is never load-bearing */ }
   hudHandle = null;
   const hud = el('gg-hud');
   if (hud) { hud.replaceChildren(); hud.hidden = true; }
@@ -2006,6 +2015,18 @@ function seedPracticeArsenal() {
   }
   if (!armed) return;
   logger.info('practice: seeded ' + armed + ' arsenal slot(s)');
+  /* ...AND SAY SO. The seed is silent by design (`silent: true` above — a gift,
+   * not a reward), which solved the "nothing is happening" report and left a
+   * second one behind it: two stickers quietly light up in a drawer that is SHUT
+   * by default on a phone, and nothing anywhere says they are there or what to
+   * press. Practice is the one place coaching may be a little louder, so this is
+   * the one hint fired from outside the desk.
+   *
+   * Deferred a beat: mountHudNow() has only just run and the HUD's entrance is
+   * still animating, so a toast on this tick lands under a moving desk. */
+  setTimeout(() => {
+    try { coach?.fire?.(COACH.PRACTICE, S.coach.practice); } catch (_e) { /* never break practice */ }
+  }, 900);
 }
 
 /* ----------------------------------------------------------------------------
@@ -2078,6 +2099,10 @@ function buildApp() {
   prefs.subscribe((key, value) => { if (key === 'perfMode') applyPerfTier(value); });
   audio = createAudio({ prefs, logger });
   toasts = createToasts({ prefs });
+  /* AFTER the toasts, because that is its whole output tier, and BEFORE the
+   * options drawer, which offers its switch. Nothing coaches until a HUD is
+   * mounted — this only builds the ledger. */
+  coach = createCoach({ prefs, toasts, logger });
   sheets = createSheets({ audio, logger });
   matchLog = createMatchLog();
   // ONE store, built once, and the only thing on the page allowed to register a

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-coach.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-coach.js
@@ -379,6 +379,31 @@ function fakeStore(seed) {
     ok(new RegExp('COACH\\.' + key + '\\b').test(all), 'every id in COACH has a caller — ' + key);
   }
 
+  /* THE "IT BANKED HEAT" GATE. ui/hud.js's NO_HEAT_REASONS is a hand-copy of
+   * ui/drops.js's three early returns, because the roller publishes those words
+   * on a return value rather than as a constant. If drops.js grows a fourth
+   * no-heat exit, the coached line starts claiming a gauge filled that did not —
+   * so the copy is checked against the source that produces it. */
+  {
+    const dropsSrc = stripComments(read('ui/drops.js'));
+    const listed = /const NO_HEAT_REASONS = Object\.freeze\(\[([^\]]*)\]\)/.exec(sources['ui/hud.js']);
+    ok(!!listed, 'ui/hud.js declares NO_HEAT_REASONS');
+    const names = listed ? Array.from(listed[1].matchAll(/'([a-z-]+)'/g)).map((m) => m[1]) : [];
+    ok(names.join(',') === 'clutter,phase,no-arsenal', 'and it lists the three', names.join(','));
+    // Every one of them must be a reason drops.js can actually return BEFORE the
+    // setHeat() call — i.e. it appears above it in the source.
+    const heatAt = dropsSrc.indexOf('setHeat(current() + gain)');
+    ok(heatAt > 0, 'ui/drops.js still banks heat with setHeat(current() + gain)');
+    for (const name of names) {
+      const at = dropsSrc.indexOf("reason: '" + name + "'");
+      ok(at > 0 && at < heatAt, '"' + name + '" is still an early return, before any heat is banked');
+    }
+    // ...and the reasons AFTER it must not be on the list, or a real pop goes uncoached.
+    for (const name of ['miss', 'no-candidate', 'refused', 'drop']) {
+      ok(names.indexOf(name) < 0, '"' + name + '" is a pop that DID bank heat and still coaches');
+    }
+  }
+
   // Nothing coached may block. The module reaches for one method on one tier.
   const coachSrc = stripComments(read('ui/coach.js'));
   ok(/toasts\s*&&\s*typeof toasts\.show === 'function'/.test(coachSrc),

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-coach.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-coach.js
@@ -1,0 +1,432 @@
+// Self-contained sanity pass over the COACHING TIER — ui/coach.js, the S.coach
+// copy deck, the two prefs behind them, and the call sites that fire them.
+//
+//   node Resources/web/goon/test/selftest-coach.js
+//
+// The feature is one sentence: the first time each mechanic touches a player,
+// say one true thing about it, once, ever. Every check below defends one word of
+// that sentence.
+//
+//   1. IMPORT SWEEP. There are no devtools inside WebView2 — a module that
+//      throws at import does not error, the loader simply never settles and the
+//      player watches a spinner forever.
+//   2. THE POLICY IS PURE. shouldFire/hasSeen/withSeen decide everything and
+//      touch no store, no clock and no DOM, so the rules are testable without
+//      building a match.
+//   3. ONCE MEANS ONCE, AND THE MARK GOES DOWN AT QUEUE TIME. A hint dropped by
+//      the pacer, cleared by a teardown, or fired into a page with no toast
+//      layer is still spent. A hint refused because the feature is OFF is NOT —
+//      switching hints back on must not have silently burned the deck.
+//   4. THE PACER SPACES THEM. Firsts arrive in clumps; four toasts at once is
+//      noise. One per COACH_GAP_MS, and a queue past COACH_QUEUE_MAX drops
+//      rather than grows.
+//   5. NOTHING IS BLOCKING. The module reaches for `toasts.show` and nothing
+//      else — no sheet, no modal, no scrim. A sheet opened during Live is what
+//      froze the drop economy the last time one was, and coaching is the least
+//      important thing on the desk.
+//   6. THE COPY IS TRUE TO THE CODE. Every number in S.coach is cross-checked
+//      against the constant that produces it. This is the check that matters
+//      most: a wrong explainer is worse than no explainer, because a player
+//      plans around it. It is also the one that will fail first when somebody
+//      retunes a constant, which is the entire point.
+//   7. EVERY HINT HAS A CALL SITE AND EVERY CALL SITE HAS A HINT. An id nothing
+//      fires is dead weight; a fire() with an id the module does not own is a
+//      hint that can never be marked and would therefore repeat forever.
+//   8. THE PARALLEL-PR FENCE. S.voice and boot's reportMicGate are being edited
+//      elsewhere; this suite pins that the coaching pass did not touch either.
+
+// ------------------------------------------------------------------ harness
+
+let failures = 0;
+let n = 0;
+function ok(cond, label, extra = '') {
+  n++;
+  if (!cond) { failures++; console.error(`  FAIL ${label} ${extra}`); }
+}
+const quiet = { info() {}, warn() {}, error() {}, debug() {}, log() {} };
+const tick = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const fs = await import('node:fs');
+const path = await import('node:path');
+const urlMod = await import('node:url');
+const HERE = path.dirname(urlMod.fileURLToPath(import.meta.url));
+const ROOT = path.join(HERE, '..');
+// LF-normalized: the worktree is CRLF (core.autocrlf) and every pin below is
+// written against \n.
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8').replace(/\r\n/g, '\n');
+
+/** Strip // and block comments so "is this code or a note?" is answerable. */
+function stripComments(src) {
+  return String(src)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+// =========================================================== 1. import sweep
+
+let coachMod = null;
+let stringsMod = null;
+let prefsMod = null;
+let contractsMod = null;
+let arsenalMod = null;
+{
+  let threw = '';
+  try {
+    coachMod = await import('../ui/coach.js');
+    stringsMod = await import('../ui/strings.js');
+    prefsMod = await import('../ui/prefs.js');
+    contractsMod = await import('../core/contracts.js');
+    arsenalMod = await import('../ui/arsenal.js');
+  } catch (e) { threw = (e && e.message) || String(e); }
+  ok(!threw, 'the coaching tier imports clean under node (no DOM at import)', threw);
+}
+
+const { createCoach, COACH, COACH_IDS, COACH_GAP_MS, COACH_QUEUE_MAX, COACH_TOAST_MS,
+  COACH_PREF_ENABLED, COACH_PREF_SEEN, isCoachId, hasSeen, withSeen, shouldFire } = coachMod;
+const S = stringsMod.S;
+const { GoonConsts } = contractsMod;
+const { ARSENAL_ITEMS } = arsenalMod;
+
+// ======================================================== 2. the pure policy
+{
+  ok(COACH_IDS.length >= 8, 'there are at least eight hint ids', String(COACH_IDS.length));
+  ok(new Set(COACH_IDS).size === COACH_IDS.length, 'and no two of them collide');
+  ok(COACH_IDS.every((id) => typeof id === 'string' && id.length > 0), 'every id is a non-empty string');
+
+  ok(isCoachId(COACH.DROP) === true, 'isCoachId knows an id it owns');
+  ok(isCoachId('nope') === false && isCoachId(null) === false && isCoachId(7) === false,
+    'and refuses anything else, without throwing');
+
+  ok(hasSeen(null, COACH.POP) === false, 'hasSeen tolerates a missing map');
+  ok(hasSeen({}, COACH.POP) === false, 'and an empty one');
+  ok(hasSeen({ pop: true }, COACH.POP) === true, 'and reads a mark');
+  // A store round-trips through JSON and through prefs.coerce; an older build's
+  // 1 must not resurrect a hint somebody already read.
+  ok(hasSeen({ pop: 1 }, COACH.POP) === true, 'ANY truthy member counts as spent, not just `true`');
+
+  const base = Object.freeze({ pop: true });
+  const next = withSeen(base, COACH.DROP);
+  ok(next !== base && next.pop === true && next.drop === true,
+    'withSeen returns a NEW map carrying both marks — the caller\'s copy is never mutated');
+  ok(withSeen(base, COACH.POP) === base, 'and is a no-op (same reference) when the mark is already there');
+  ok(withSeen(base, 'not-a-hint') === base, 'a typo at a call site cannot grow the stored blob');
+  ok(Object.keys(withSeen(null, COACH.POP)).length === 1, 'withSeen tolerates a missing map too');
+
+  ok(shouldFire(COACH.POP, { enabled: true, seen: {} }) === true, 'shouldFire: fresh + on = yes');
+  ok(shouldFire(COACH.POP, { enabled: false, seen: {} }) === false, 'hints off = no');
+  ok(shouldFire(COACH.POP, { enabled: true, seen: { pop: true } }) === false, 'already spent = no');
+  ok(shouldFire('nope', { enabled: true, seen: {} }) === false, 'an unknown id = no');
+  ok(shouldFire(COACH.POP) === true, 'and with no state at all it coaches (a dev harness is not a reason to go silent)');
+}
+
+// ============================================ 3. the prefs behind the feature
+{
+  const { PREF_DEFAULTS, createPrefs } = prefsMod;
+  ok(PREF_DEFAULTS[COACH_PREF_ENABLED] === true,
+    'coachHints defaults ON — a duel with nothing explained is the bug this exists for');
+  ok(PREF_DEFAULTS[COACH_PREF_SEEN] && typeof PREF_DEFAULTS[COACH_PREF_SEEN] === 'object',
+    'coachSeen defaults to an object, so prefs.coerce takes its object branch');
+  ok(Object.keys(PREF_DEFAULTS[COACH_PREF_SEEN]).length === 0, 'and it starts empty');
+
+  const p = createPrefs();
+  p.set(COACH_PREF_SEEN, { pop: true, drop: true });
+  const back = p.get(COACH_PREF_SEEN);
+  ok(back && back.pop === true && back.drop === true, 'a seen-map round-trips through the store');
+  ok(back !== p.get(COACH_PREF_SEEN), 'and comes out as a COPY each time — an edit has to come back through set()');
+  // The failure mode the object branch exists for: String({}) is "[object Object]".
+  ok(typeof p.get(COACH_PREF_SEEN) === 'object', 'it never degrades to a nine-character string');
+  p.set(COACH_PREF_SEEN, 'garbage');
+  ok(typeof p.get(COACH_PREF_SEEN) === 'object' && Object.keys(p.get(COACH_PREF_SEEN)).length === 0,
+    'and a corrupt value lands as a fresh empty map rather than as itself');
+}
+
+/** A toast sink that records instead of painting. */
+function fakeToasts() {
+  const shown = [];
+  return {
+    shown,
+    show(text, opts) { shown.push({ text, opts: opts || {} }); return {}; },
+    good(t, o) { return this.show(t, o); },
+    warn(t, o) { return this.show(t, o); },
+    bad(t, o) { return this.show(t, o); },
+  };
+}
+
+/** The smallest prefs-shaped store the coach needs. */
+function fakeStore(seed) {
+  const values = Object.assign({ [COACH_PREF_ENABLED]: true, [COACH_PREF_SEEN]: {} }, seed || {});
+  return {
+    values,
+    get(k) { const v = values[k]; return (v && typeof v === 'object') ? Object.assign({}, v) : v; },
+    set(k, v) { values[k] = v; return true; },
+  };
+}
+
+// ================================================== 4. once ever, and the mark
+{
+  const toasts = fakeToasts();
+  const prefs = fakeStore();
+  const c = createCoach({ prefs, toasts, logger: quiet });
+
+  ok(c.fire(COACH.POP, 'pop line') === true, 'the first fire is accepted');
+  ok(c.seen(COACH.POP) === true, 'and the hint is immediately marked spent');
+  ok(prefs.values[COACH_PREF_SEEN].pop === true, 'in the STORE, not only on the page');
+  ok(c.fire(COACH.POP, 'pop line') === false, 'a second fire of the same hint is refused');
+  ok(toasts.shown.length === 1, 'and nothing is shown twice', String(toasts.shown.length));
+  ok(toasts.shown[0].text === 'pop line', 'the caller\'s finished sentence is what goes out');
+  ok(toasts.shown[0].opts.ms === COACH_TOAST_MS,
+    'coached toasts dwell longer than a status toast — they are a sentence, not a state');
+
+  ok(c.fire('not-a-hint', 'x') === false, 'an unknown id is refused rather than shown');
+  ok(c.fire(COACH.DIAL, '') === false, 'an empty sentence is refused rather than shown as a blank toast');
+  c.dispose();
+}
+
+// A hint refused because the feature is OFF must NOT be spent.
+{
+  const toasts = fakeToasts();
+  const prefs = fakeStore({ [COACH_PREF_ENABLED]: false });
+  const c = createCoach({ prefs, toasts, logger: quiet });
+  ok(c.enabled === false, 'the coach reads the switch off the store');
+  ok(c.fire(COACH.CHECK, 'check line') === false, 'with hints off, nothing fires');
+  ok(toasts.shown.length === 0, 'and nothing is shown');
+  ok(c.seen(COACH.CHECK) === false,
+    'and the hint is NOT burned — turning hints back on must not hand the player an empty deck');
+
+  prefs.values[COACH_PREF_ENABLED] = true;
+  ok(c.enabled === true, 'the switch is read LIVE, so the drawer reaches a match already running');
+  ok(c.fire(COACH.CHECK, 'check line') === true, 'and the hint is still there to spend');
+  c.dispose();
+}
+
+// No store at all (private mode, a dev harness): still once per page.
+{
+  const toasts = fakeToasts();
+  const c = createCoach({ toasts, logger: quiet });
+  ok(c.fire(COACH.EMOTE, 'a') === true && c.fire(COACH.EMOTE, 'a') === false,
+    'with no prefs store the page-local ledger still keeps "once"');
+  c.dispose();
+}
+
+// No toast layer at all: the hint is spent, not banked.
+{
+  const prefs = fakeStore();
+  const c = createCoach({ prefs, logger: quiet });
+  ok(c.fire(COACH.DIAL, 'a') === true, 'a page with no toast tier still accepts a fire');
+  ok(c.seen(COACH.DIAL) === true, 'and spends it — hints must never bank up for a later match');
+  c.dispose();
+}
+
+// ============================================================= 5. the pacer
+{
+  const toasts = fakeToasts();
+  const c = createCoach({ prefs: fakeStore(), toasts, logger: quiet });
+  c.fire(COACH.POP, 'one');
+  c.fire(COACH.DROP, 'two');
+  c.fire(COACH.FIRED, 'three');
+  ok(toasts.shown.length === 1, 'a clump of firsts shows ONE line immediately', String(toasts.shown.length));
+  ok(c.pending === 2, 'and queues the rest', String(c.pending));
+  ok(c.seen(COACH.FIRED) === true, 'every one of them is already marked, queued or not');
+  await tick(COACH_GAP_MS + 120);
+  ok(toasts.shown.length === 2, 'the second lands a gap later', String(toasts.shown.length));
+  await tick(COACH_GAP_MS + 120);
+  ok(toasts.shown.length === 3, 'and the third after that', String(toasts.shown.length));
+  ok(c.pending === 0, 'the queue drains to empty');
+  c.dispose();
+}
+
+// The queue has a ceiling, and hitting it still spends the hint.
+{
+  const toasts = fakeToasts();
+  const c = createCoach({ prefs: fakeStore(), toasts, logger: quiet });
+  const ids = COACH_IDS.slice(0, COACH_QUEUE_MAX + 3);
+  for (const id of ids) c.fire(id, 'line ' + id);
+  ok(c.pending <= COACH_QUEUE_MAX,
+    'the queue never grows past COACH_QUEUE_MAX — a line a minute late is worse than no line', String(c.pending));
+  ok(ids.every((id) => c.seen(id)), 'and every id offered is spent, shown or dropped');
+  c.dispose();
+}
+
+// A teardown clears what is queued and keeps every mark.
+{
+  const toasts = fakeToasts();
+  const prefs = fakeStore();
+  const c = createCoach({ prefs, toasts, logger: quiet });
+  c.fire(COACH.POP, 'one');
+  c.fire(COACH.DROP, 'two');
+  c.clearPending();
+  ok(c.pending === 0, 'clearPending empties the queue');
+  await tick(COACH_GAP_MS + 120);
+  ok(toasts.shown.length === 1, 'so nothing arrives over the recap of a match that already ended');
+  ok(c.seen(COACH.DROP) === true, 'and the cleared hint stays spent — it was offered');
+  c.dispose();
+}
+
+// Switching OFF drops what has not been said yet.
+{
+  const toasts = fakeToasts();
+  const prefs = fakeStore();
+  const c = createCoach({ prefs, toasts, logger: quiet });
+  c.fire(COACH.POP, 'one');
+  c.fire(COACH.DROP, 'two');
+  c.setEnabled(false);
+  ok(prefs.values[COACH_PREF_ENABLED] === false, 'setEnabled writes the pref');
+  await tick(COACH_GAP_MS + 120);
+  ok(toasts.shown.length === 1, 'and a queued line does not arrive after the switch was thrown');
+  c.dispose();
+}
+
+// dispose() is idempotent and stops the pump.
+{
+  const toasts = fakeToasts();
+  const c = createCoach({ prefs: fakeStore(), toasts, logger: quiet });
+  c.fire(COACH.POP, 'one');
+  c.fire(COACH.DROP, 'two');
+  c.dispose();
+  c.dispose();
+  ok(c.fire(COACH.CHECK, 'x') === false, 'a disposed coach accepts nothing');
+  await tick(COACH_GAP_MS + 120);
+  ok(toasts.shown.length === 1, 'and never drains after teardown', String(toasts.shown.length));
+}
+
+// ===================================================== 6. the copy IS the code
+{
+  const c = S.coach;
+  ok(c && typeof c === 'object', 'S.coach exists');
+  for (const key of ['goal', 'pop', 'fired', 'check', 'dial', 'emote', 'practice', 'hints', 'hintsNote', 'howGoal']) {
+    ok(typeof c[key] === 'string' && c[key].length > 0, 'S.coach.' + key + ' is a non-empty string');
+  }
+  ok(typeof c.drop === 'function' && typeof c.incoming === 'function',
+    'the two interpolated lines are FUNCTIONS, so strings.js stays import-safe');
+  ok(c.drop('flash', 1).indexOf('flash') >= 0 && c.drop('flash', 1).indexOf('1') >= 0,
+    'S.coach.drop names the item and its key');
+  ok(c.drop().length > 0 && c.incoming().length > 0, 'and both still read as sentences with nothing to name');
+  ok(c.incoming('flash burst').indexOf('flash burst') >= 0, 'S.coach.incoming names the family that just landed');
+
+  // --- the attention check: twelve seconds, then x0.6 for a minute ----------
+  const attSrc = read('ui/attention.js');
+  const grace = /const GRACE_MS = (\d+);/.exec(attSrc);
+  ok(grace && Number(grace[1]) === 12000,
+    'ui/attention.js GRACE_MS is still 12 s — S.coach.check says "twelve seconds"', grace ? grace[1] : 'missing');
+  ok(/twelve seconds/.test(c.check), 'and the copy says so');
+  ok(GoonConsts.NoCamFailedCheckMult === 0.6, 'the failed-check multiplier is still 0.6');
+  ok(/x0\.6/.test(c.check), 'and the copy says x0.6');
+  ok(GoonConsts.NoCamFailedCheckPenaltyMs === 60000, 'the penalty is still one minute');
+  ok(/minute/.test(c.check), 'and the copy says a minute');
+
+  // --- the cooldown: two back to back, then one every thirty seconds --------
+  ok(GoonConsts.PayloadMinGapMs === 30000, 'PayloadMinGapMs is still 30 s');
+  ok(/thirty seconds/.test(c.fired), 'and S.coach.fired says thirty seconds');
+  ok(GoonConsts.PayloadBurst === 2, 'PayloadBurst is still 2');
+  ok(/^two /.test(c.fired), 'and S.coach.fired opens with the burst');
+
+  // --- the practice seed: flash on key 1, video on key 3 -------------------
+  const bootSrc = read('boot.js');
+  const seedBlock = /const PRACTICE_SEED = Object\.freeze\(\[([\s\S]*?)\]\);/.exec(bootSrc);
+  ok(!!seedBlock, 'boot.js still has a PRACTICE_SEED table');
+  const seedIds = seedBlock ? Array.from(seedBlock[1].matchAll(/id: '([a-z]+)'/g)).map((m) => m[1]) : [];
+  ok(seedIds.join(',') === 'flash,video',
+    'practice still seeds flash + video — S.coach.practice names exactly those two', seedIds.join(','));
+  const slots = ARSENAL_ITEMS.filter((i) => i.kind !== null).map((i) => i.id);
+  ok(slots.indexOf('flash') === 0, 'flash is still key 1', String(slots.indexOf('flash') + 1));
+  ok(slots.indexOf('video') === 2, 'video is still key 3', String(slots.indexOf('video') + 1));
+  ok(/flash/.test(c.practice) && /video/.test(c.practice), 'and the copy names both');
+  ok(/keys 1 and 3/.test(c.practice), 'and quotes the two keys that actually fire them');
+
+  // --- the three things the copy may NEVER say -----------------------------
+  const allCopy = Object.keys(c)
+    .map((k) => (typeof c[k] === 'function' ? c[k]('x', 1) : c[k]))
+    .join(' | ')
+    .toLowerCase();
+  ok(!/charge/.test(allCopy),
+    'NOTHING in S.coach mentions charges — the meter still exists and still buys nothing (2026-08-05)');
+  ok(!/camera|webcam|gaze/.test(allCopy),
+    'and nothing mentions a camera — localAttentionMode is hard-wired NoCam, the Cam branch is unreachable');
+  ok(!/sudden death/.test(allCopy),
+    'and nothing promises sudden death — the runner is detached (boot.js), the phase resolves on score in one tick');
+  ok(!/damage|hurt(s)? you|costs you .*point/.test(allCopy),
+    'and no payload is described as taking points: nothing inbound touches score, multiplier, heat or cooldown');
+  ok(!/[!]/.test(allCopy), 'no exclamation marks — the announcer is the only raised voice on this page');
+}
+
+// ============================== 7. every hint has a call site, and vice versa
+{
+  const sources = {
+    'ui/hud.js': stripComments(read('ui/hud.js')),
+    'ui/attention.js': stripComments(read('ui/attention.js')),
+    'ui/closeness.js': stripComments(read('ui/closeness.js')),
+    'boot.js': stripComments(read('boot.js')),
+  };
+  const all = Object.keys(sources).map((k) => sources[k]).join('\n');
+
+  const expect = {
+    POP: 'ui/hud.js',
+    DROP: 'ui/hud.js',
+    FIRED: 'ui/hud.js',
+    INCOMING: 'ui/hud.js',
+    EMOTE: 'ui/hud.js',
+    CHECK: 'ui/attention.js',
+    DIAL: 'ui/closeness.js',
+    PRACTICE: 'boot.js',
+  };
+  for (const name of Object.keys(expect)) {
+    const file = expect[name];
+    ok(new RegExp('COACH\\.' + name + '\\b').test(sources[file]),
+      'COACH.' + name + ' is fired from ' + file);
+  }
+  // The other direction: an id nothing fires can never be spent and is dead weight.
+  for (const key of Object.keys(COACH)) {
+    ok(new RegExp('COACH\\.' + key + '\\b').test(all), 'every id in COACH has a caller — ' + key);
+  }
+
+  // Nothing coached may block. The module reaches for one method on one tier.
+  const coachSrc = stripComments(read('ui/coach.js'));
+  ok(/toasts\s*&&\s*typeof toasts\.show === 'function'/.test(coachSrc),
+    'ui/coach.js paints through ui/toasts.js and guards the handle');
+  ok(!/sheets|openNode|showSignalError|gg-modal|gg-scrim/.test(coachSrc),
+    'and never opens a sheet, a modal or a scrim — a coached line can never block a live match');
+  ok(!/document|window|createElement/.test(coachSrc),
+    'and touches no DOM at all: the toast tier owns every node');
+
+  // Every fire in the tree goes through a guarded optional call, so a null coach
+  // (a HUD built without one) is an uncoached desk and not a crash.
+  const fires = Array.from(all.matchAll(/coach[?.]*\.fire\?*\./g));
+  ok(fires.length >= 8, 'there are at least eight coached beats wired up', String(fires.length));
+  ok(!/[^?]\bcoach\.fire\(/.test(all),
+    'and every one of them is an OPTIONAL call — a desk with no coach is uncoached, never broken');
+}
+
+// ===================================================== 8. the switch, and the fence
+{
+  const optSrc = stripComments(read('ui/options.js'));
+  ok(/S\.coach\.hints\b/.test(optSrc) && /'coachHints'/.test(optSrc),
+    'the options drawer offers the hints toggle');
+  ok(/S\.coach\.hintsNote/.test(optSrc), 'with a note saying what OFF means');
+
+  const hudSrc = read('ui/hud.js');
+  ok(/S\.coach\.goal/.test(hudSrc), 'the desk carries the objective caption');
+  const cssSrc = read('ui/hud.css');
+  ok(/gg-hud--zen \.gg-coach-goal/.test(cssSrc),
+    'and zen hides it with the dial it captions — a caption for an absent readout is a bug');
+  ok(/\.gg-coach-goal[\s\S]{0,400}pointer-events: none/.test(cssSrc),
+    'the caption is pointer-transparent — it may never park a dead box over the bubble field');
+
+  const titleSrc = read('ui/screens/title.js');
+  ok(/S\.coach\.howGoal/.test(titleSrc), 'the how-it-works card leads with the goal');
+  ok(S.how.bullets.length === 6, 'and the six bullets under it are still six', String(S.how.bullets.length));
+
+  // --- the parallel-PR fence (see the header) ------------------------------
+  const strSrc = read('ui/strings.js');
+  ok(/S\.coach|coach: \{/.test(strSrc), 'S.coach lives in ui/strings.js with the rest of the deck');
+  ok(/lobbyRelay:/.test(strSrc) && /holdKeyHint:/.test(strSrc),
+    'and the S.voice block is intact — a parallel PR owns it');
+  ok(/function reportMicGate\(\)/.test(read('boot.js')), 'boot.js reportMicGate is untouched — same reason');
+}
+
+// -------------------------------------------------------------------- report
+if (failures) {
+  console.error(`\nselftest-coach: ${n - failures}/${n} checks passed`);
+  console.error(`${failures} FAILURE(S)`);
+  process.exit(1);
+}
+console.log(`selftest-coach: ${n}/${n} checks passed`);

--- a/ConditioningControlPanel/Resources/web/goon/ui/attention.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/attention.js
@@ -17,6 +17,8 @@
  * ==========================================================================*/
 
 import { GoonAttentionMode } from '../core/contracts.js';
+import { COACH } from './coach.js';
+import { S } from './strings.js';
 
 /** Mirrors match.js's private NO_CAM_CHECK_INTERVAL_MS. */
 const CHECK_INTERVAL_MS = 90000;
@@ -101,8 +103,11 @@ function viewport() {
  * @param {object}   [o.audio]
  * @param {Function} [o.getAvoid]  () => Element[] the token must not land on
  * @param {Function} [o.onLog]
+ * @param {object}   [o.coach]     ui/coach.js — the once-ever explainer for the
+ *                                 first token this player ever sees
  */
-export function mountAttention({ host, tokenHost = null, match, audio = null, getAvoid = null, onLog = null } = {}) {
+export function mountAttention({ host, tokenHost = null, match, audio = null, getAvoid = null,
+  onLog = null, coach = null } = {}) {
   const led = createLedger();
   const root = el('div', 'gg-att gg-plate');
   if (!root || !host) return { unmount() { led.run(); }, spawn() {} };
@@ -204,6 +209,14 @@ export function mountAttention({ host, tokenHost = null, match, audio = null, ge
     sfx(audio, 'gg-check');
     if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => cls(node, 'is-live', true));
     else cls(node, 'is-live', true);
+
+    /* THE FIRST TOKEN EVER, EXPLAINED — and it is coached HERE rather than off
+     * the engine's due event because this is the branch that actually put a
+     * circle on screen: spawn() early-returns for a token already up and for a
+     * seat that is not NoCam, and a hint about tapping a circle that was never
+     * drawn would be the most confusing line on the page. The copy carries
+     * GRACE_MS and the engine's failure penalty; see S.coach's rule 1. */
+    try { coach?.fire?.(COACH.CHECK, S.coach.check); } catch (_e) { /* a hint never breaks a check */ }
 
     led.listen(node, 'pointerdown', (e) => { if (e && e.preventDefault) e.preventDefault(); resolve(true); });
     tokenTimer = setTimeout(() => resolve(false), GRACE_MS);

--- a/ConditioningControlPanel/Resources/web/goon/ui/closeness.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/closeness.js
@@ -11,6 +11,9 @@
  * Node-import-safe: no DOM at import, only inside mountCloseness().
  * ==========================================================================*/
 
+import { COACH } from './coach.js';
+import { S } from './strings.js';
+
 /** 0-3 -> the word. Colour never travels alone. */
 export const CLOSENESS_STOPS = Object.freeze(['steady', 'warm', 'close', 'edge']);
 
@@ -67,9 +70,10 @@ function nowMs() {
  * @param {object}  o.match
  * @param {object}  [o.audio]
  * @param {Function} [o.onLog]
+ * @param {object}  [o.coach] ui/coach.js — the once-ever "this is a claim" line
  * @returns {{unmount:Function, set:Function, value:Function}}
  */
-export function mountCloseness({ host, match, audio = null, onLog = null } = {}) {
+export function mountCloseness({ host, match, audio = null, onLog = null, coach = null } = {}) {
   const led = createLedger();
   const root = el('div', 'gg-dial gg-plate');
   if (!root || !host) return { unmount() { led.run(); }, set() {}, value() { return null; } };
@@ -112,6 +116,13 @@ export function mountCloseness({ host, match, audio = null, onLog = null } = {})
     current = next;
     try { if (match && typeof match.setCloseness === 'function') match.setCloseness(next); } catch (_e) { /* engine said no */ }
     sfx(audio, 'gg-taunt-up');
+    /* THE FIRST MOVE, EXPLAINED. The dial's own fineprint says what they SEE
+     * ("they can only see what you say"); this says what nobody sees — there is
+     * no sensor behind it, the value is not checked anywhere, and bluffing with
+     * it is the whole point (core/match.js: "Bluffable BY DESIGN"). Fired after
+     * the cooldown and the no-op checks above, so it can only ever ride a change
+     * the player actually made. */
+    try { coach?.fire?.(COACH.DIAL, S.coach.dial); } catch (_e) { /* a hint never breaks the dial */ }
     if (typeof onLog === 'function') { try { onLog({ t: 'closeness', value: next, word: CLOSENESS_STOPS[next] }); } catch (_e) { /* ignore */ } }
     paint();
   }

--- a/ConditioningControlPanel/Resources/web/goon/ui/coach.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/coach.js
@@ -1,0 +1,316 @@
+/* ============================================================================
+ * ui/coach.js — the one-time explainers.
+ *
+ * "add some nudges and explanations — the whole game feels kinda random atm
+ * with no direction" (owner, 2026-08-05).
+ *
+ * WHAT THIS IS. A duel throws seven kinds of effect, a heat gauge, an item
+ * economy, an attention check and a self-reported dial at a stranger inside the
+ * first two minutes, and until today the page explained exactly one of them (the
+ * six bullets on the title card, which a player reads before any of it has
+ * happened and therefore cannot yet attach to anything). This module is the
+ * other half: ONE short line, fired the first time each mechanic actually
+ * touches the player, at the moment it touches them — and then never again.
+ *
+ * WHAT IT IS NOT, and every one of these is a rule rather than a preference:
+ *
+ *   · NOT A TUTORIAL. There is no sequence, no step counter and no "next".
+ *     Hints fire in whatever order the match happens to deal them, and a hint
+ *     for a mechanic a player never meets is simply never spent.
+ *   · NOT MODAL, EVER. Everything here goes out through ui/toasts.js — the
+ *     transient stack on #gg-toasts (z50), which is below MERCY (z60) by
+ *     construction and holds no interactive element. Nothing in this file can
+ *     pause the clock, cover the mercy button, eat a bubble pop or take focus.
+ *     A sheet during Live is what froze the drop economy the last time one was
+ *     opened, and coaching is the LEAST important thing on the desk.
+ *   · NOT A GAMEPLAY CHANGE. It reads state and writes prefs. It never touches
+ *     the match, the arsenal, the economy or the wire.
+ *
+ * ONCE-EVER, AND THE MARK GOES DOWN AT QUEUE TIME. `fire()` records the hint as
+ * spent before its toast has been shown, let alone dismissed. That is
+ * deliberate: a player who alt-tabs, mercies out or closes the page with a
+ * coached line still queued has already been interrupted enough, and re-offering
+ * it next launch would break the one promise the feature makes — that it goes
+ * away. The cost is a hint that can be lost to a teardown; it is a hint, and the
+ * alternative is a hint that can be shown twice.
+ *
+ * THE PACER. Firsts arrive in clumps — the first drop, the first throw and the
+ * first inbound payload can all land inside ten seconds of a lively opening —
+ * and four explainers stacked on top of each other is noise, not coaching. So
+ * fires are QUEUED and drained one per COACH_GAP_MS, and a queue that is already
+ * COACH_QUEUE_MAX deep drops the newest rather than growing: a line that would
+ * appear a minute after the thing it explains is worse than no line. Dropped
+ * that way the hint stays SPENT — see above; being shown once is the ceiling,
+ * not the guarantee.
+ *
+ * Everything above the createCoach() line is pure and total, so
+ * test/selftest-coach.js can pin the policy without a DOM, a store or a clock.
+ * Node-import-safe: no DOM at import and none anywhere in this file — the toast
+ * tier owns every node.
+ * ==========================================================================*/
+
+/** The pref that switches the whole feature off. */
+export const COACH_PREF_ENABLED = 'coachHints';
+/** The pref holding `{ [hintId]: true }` for every line already spent. */
+export const COACH_PREF_SEEN = 'coachSeen';
+
+/**
+ * Every hint id, spelled once.
+ *
+ * The VALUES are what land in the `coachSeen` map and therefore in a player's
+ * localStorage forever, so they are stable identifiers and not labels: renaming
+ * one re-shows a hint to everybody who already read it, which is the single
+ * worst thing this module can do. Add ids; do not rename them.
+ */
+export const COACH = Object.freeze({
+  /** The first bubble pop that banked heat. */
+  POP: 'pop',
+  /** The first drop that armed a slot. */
+  DROP: 'drop',
+  /** The first payload this player actually fired. */
+  FIRED: 'fired',
+  /** The first payload of THEIRS that was accepted for this screen. */
+  INCOMING: 'incoming',
+  /** The first attention token to spawn. */
+  CHECK: 'check',
+  /** The first time the player moved the closeness dial. */
+  DIAL: 'dial',
+  /** The first emote received. */
+  EMOTE: 'emote',
+  /** Practice only: the seeded arsenal, and one concrete thing to press. */
+  PRACTICE: 'practice',
+});
+
+/** The ids, as a list, in no meaningful order (there is no sequence). */
+export const COACH_IDS = Object.freeze(Object.keys(COACH).map((k) => COACH[k]));
+
+/** Minimum spacing between two coached lines. See THE PACER. */
+export const COACH_GAP_MS = 2800;
+/** How long a coached toast dwells — longer than a status toast, it is a sentence. */
+export const COACH_TOAST_MS = 6400;
+/** Queue depth past which a new fire is dropped (but still marked spent). */
+export const COACH_QUEUE_MAX = 3;
+/** The glyph every coached toast carries, so the stack reads as one voice. */
+export const COACH_ICON = '✳';
+
+/* ---------------------------------------------------------------------------
+ * THE POLICY, pure. Nothing below reads a store, a clock or a document.
+ * ------------------------------------------------------------------------ */
+
+/** Is this a hint this module knows about? Total: any input, boolean out. */
+export function isCoachId(id) {
+  return typeof id === 'string' && COACH_IDS.indexOf(id) >= 0;
+}
+
+/**
+ * Has `id` already been spent?
+ *
+ * ANY truthy member counts, not `=== true`: the map round-trips through JSON and
+ * through ui/prefs.js's `coerce`, and a store written by an older or a
+ * hand-edited build must not be able to resurrect a hint by holding a 1 where
+ * this file writes a true.
+ */
+export function hasSeen(seen, id) {
+  if (!seen || typeof seen !== 'object') return false;
+  return !!seen[id];
+}
+
+/**
+ * `seen` + `id` -> a NEW map with `id` spent. Never mutates its argument (the
+ * caller's copy came out of prefs.get, which hands out clones on purpose) and
+ * never records an id this module does not own, so a typo at a call site cannot
+ * quietly grow the stored blob.
+ */
+export function withSeen(seen, id) {
+  const base = (seen && typeof seen === 'object') ? seen : {};
+  if (!isCoachId(id) || hasSeen(base, id)) return base;
+  const out = {};
+  for (const k of Object.keys(base)) out[k] = base[k];
+  out[id] = true;
+  return out;
+}
+
+/**
+ * The whole gate, in one pure function: may `id` be shown?
+ *
+ * Order matters and is the order a reader would ask it in — is it a real hint,
+ * is the feature on, has it already been spent. `enabled` defaults to true so a
+ * caller with no store still coaches; a page with no prefs is a dev harness or a
+ * browser with storage disabled, and neither is a reason to go silent.
+ *
+ * @param {string} id
+ * @param {{enabled?:boolean, seen?:object}} [state]
+ */
+export function shouldFire(id, { enabled = true, seen = null } = {}) {
+  if (!isCoachId(id)) return false;
+  if (enabled === false) return false;
+  return !hasSeen(seen, id);
+}
+
+/* ---------------------------------------------------------------------------
+ * THE HANDLE
+ * ------------------------------------------------------------------------ */
+
+/**
+ * @param {object}   [o]
+ * @param {object}   [o.prefs]  ui/prefs.js store. Absent: hints fire, once per
+ *                              page, and nothing is remembered across a reload.
+ * @param {object}   [o.toasts] ui/toasts.js handle. Absent: every fire is a
+ *                              silent no-op that still spends the hint — a page
+ *                              with no toast layer must not bank them all up.
+ * @param {object}   [o.logger]
+ * @param {Function} [o.now]    () => ms, for the suite. Defaults to Date.now.
+ * @param {Function} [o.schedule] (fn, ms) => handle, for the suite.
+ * @param {Function} [o.cancel]   (handle) => void, for the suite.
+ */
+export function createCoach({ prefs = null, toasts = null, logger = null,
+  now = null, schedule = null, cancel = null } = {}) {
+  const clock = typeof now === 'function' ? now : () => Date.now();
+  const setLater = typeof schedule === 'function'
+    ? schedule
+    : (fn, ms) => { try { return setTimeout(fn, ms); } catch (_e) { return 0; } };
+  const clearLater = typeof cancel === 'function'
+    ? cancel
+    : (h) => { try { clearTimeout(h); } catch (_e) { /* gone */ } };
+
+  /* THE PAGE-LOCAL LEDGER. A second copy of the spent set, kept because a page
+   * with no store at all (private mode, the node harness) still owes the "once"
+   * half of "once ever" — without it a mechanic that fires twice a minute would
+   * coach twice a minute. With a store it simply agrees with it. */
+  const spentHere = Object.create(null);
+
+  const queue = [];
+  let drainAt = 0;
+  let timer = 0;
+  let disposed = false;
+
+  function readSeen() {
+    try {
+      if (prefs && typeof prefs.get === 'function') {
+        const v = prefs.get(COACH_PREF_SEEN);
+        if (v && typeof v === 'object') return v;
+      }
+    } catch (_e) { /* a corrupt store coaches rather than throws */ }
+    return null;
+  }
+
+  function readEnabled() {
+    try {
+      if (prefs && typeof prefs.get === 'function') return prefs.get(COACH_PREF_ENABLED) !== false;
+    } catch (_e) { /* fall through */ }
+    return true;
+  }
+
+  function markSpent(id) {
+    spentHere[id] = true;
+    try {
+      if (prefs && typeof prefs.set === 'function') {
+        const next = withSeen(readSeen(), id);
+        prefs.set(COACH_PREF_SEEN, next);
+      }
+    } catch (e) {
+      try { logger?.warn?.('[GG coach] could not record "' + id + '": ' + ((e && e.message) || e)); }
+      catch (_e) { /* a logger is never load-bearing */ }
+    }
+  }
+
+  function show(entry) {
+    if (!entry) return;
+    try {
+      if (toasts && typeof toasts.show === 'function') {
+        toasts.show(entry.text, { kind: 'info', icon: COACH_ICON, ms: COACH_TOAST_MS });
+      }
+    } catch (_e) { /* a coached line must never break the desk */ }
+  }
+
+  function drain() {
+    timer = 0;
+    if (disposed) return;
+    const entry = queue.shift();
+    if (!entry) return;
+    show(entry);
+    drainAt = clock() + COACH_GAP_MS;
+    if (queue.length) timer = setLater(drain, COACH_GAP_MS);
+  }
+
+  function pump() {
+    if (disposed || timer || !queue.length) return;
+    const wait = Math.max(0, drainAt - clock());
+    if (wait <= 0) { drain(); return; }
+    timer = setLater(drain, wait);
+  }
+
+  const api = {
+    /** The master switch, live — the drawer can flip it mid-match. */
+    get enabled() { return readEnabled(); },
+    /** Has this line already been spent, on this page or on this machine? */
+    seen(id) { return !!spentHere[id] || hasSeen(readSeen(), id); },
+
+    /**
+     * Offer one hint. Returns true when it was accepted (i.e. queued and marked
+     * spent), false when the gate refused it — so a caller can tell "I coached"
+     * from "already coached" without reaching into the store.
+     *
+     * Callers pass the TEXT, not a key: the copy lives in ui/strings.js S.coach
+     * and several lines are interpolators (a label, a key number) that only the
+     * call site holds the arguments for.
+     *
+     * @param {string} id   one of COACH
+     * @param {string} text the finished sentence
+     */
+    fire(id, text) {
+      if (disposed) return false;
+      if (spentHere[id]) return false;
+      if (!shouldFire(id, { enabled: readEnabled(), seen: readSeen() })) return false;
+      // SPENT FIRST, SHOWN SECOND. See the banner: a queue drop, a teardown or a
+      // missing toast layer must all leave the hint used up.
+      markSpent(id);
+      const line = String(text || '');
+      if (!line) return false;
+      if (queue.length >= COACH_QUEUE_MAX) return false;
+      queue.push({ id, text: line });
+      pump();
+      return true;
+    },
+
+    /** The options drawer's setter, so callers never spell the pref key. */
+    setEnabled(on) {
+      try { prefs?.set?.(COACH_PREF_ENABLED, !!on); } catch (_e) { /* no store, no problem */ }
+      // Switching OFF empties what has not been said yet. A hint that arrives
+      // after the toggle would read as the switch not working.
+      if (!on) queue.length = 0;
+    },
+
+    /**
+     * Drop everything still queued, keeping every mark. The desk calls this when
+     * a HUD comes down: a match is over, so a line explaining a mechanic of it
+     * arriving over the recap is a leftover, not coaching. The hints stay SPENT
+     * — they were offered, the match simply ended first, and re-offering them
+     * next duel is the "never re-show" rule broken by a technicality.
+     */
+    clearPending() {
+      queue.length = 0;
+      if (timer) { clearLater(timer); timer = 0; }
+    },
+
+    /** Test/dev hook: forget everything, on this page and in the store. */
+    reset() {
+      for (const k of Object.keys(spentHere)) delete spentHere[k];
+      queue.length = 0;
+      try { prefs?.set?.(COACH_PREF_SEEN, {}); } catch (_e) { /* ignore */ }
+    },
+
+    /** Queued-but-unsaid count. The suite reads it; nothing else should. */
+    get pending() { return queue.length; },
+
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      queue.length = 0;
+      if (timer) { clearLater(timer); timer = 0; }
+    },
+  };
+  return api;
+}
+
+export default createCoach;

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.css
@@ -1810,6 +1810,33 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
    lost a third of its width and most of its padding; it did NOT lose its touch
    targets — the four stops keep their 48px, which is what the tier rule is
    about, and the plate simply stopped padding them out. */
+/* THE DIAL'S COLUMN — the objective caption, then the dial (ui/hud.js THE
+   OBJECTIVE LINE). The bottom bar is still a two-child flex row, so the dial is
+   still hard right at every breakpoint; this only stacks a caption over it.
+   `align-items: flex-end` rather than a width, so the caption is as wide as its
+   own text wants to be and the dial keeps its own min/max. */
+.gg-dial-col { display: flex; flex-direction: column; align-items: flex-end; gap: 0.3rem; min-width: 0; }
+.gg-coach-goal {
+  max-width: min(22rem, 46vw);
+  text-align: right;
+  font-size: 0.6rem; line-height: 1.35;
+  color: var(--gg-text-4);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.75);   /* it floats over the stage, not a plate */
+  /* NOT a .gg-plate: a plate would re-enable pointer events at 0,2,0 and park a
+     dead box over the field the player is popping bubbles in. It is a caption. */
+  pointer-events: none;
+  transition: opacity .8s ease;
+}
+/* Its own exit, so nothing has to remove a node mid-match. */
+.gg-coach-goal.is-gone { opacity: 0; }
+/* Zen takes the dial; the caption over it goes at the same time, or the desk
+   keeps a line explaining a readout that is no longer on it. */
+.gg-hud-frame.gg-hud--zen .gg-coach-goal { display: none; }
+@media (orientation: portrait), (max-width: 720px) {
+  /* A phone has no room for a second sentence beside the fx chips. */
+  .gg-coach-goal { max-width: 60vw; font-size: 0.56rem; }
+}
+
 .gg-dial-host { display: flex; justify-content: flex-end; }
 .gg-dial { min-width: 10.5rem; max-width: 14rem; padding: 0.3rem 0.5rem 0.35rem; }
 .gg-dial-label { font-size: 0.56rem; letter-spacing: 0.14em; color: var(--gg-text-4); }
@@ -2320,6 +2347,10 @@ html[data-gg-fx="hot"] .gg-arsenal-panel { background: rgba(10, 5, 17, 0.9); }
   /* padding-bottom clears MERCY, measured not guessed: 1.4rem off the floor +
      a 50px button + a 0.25rem gap + an 11px fineprint = 5.46rem, so 6rem. */
   .gg-hud-bottom { flex-direction: row; align-items: flex-end; justify-content: flex-end; gap: 0.4rem; padding-bottom: 6rem; }
+  /* The dial's column takes the `flex: 0 0 auto` the host used to carry here —
+     it is the bottom deck's child now, and a stretched column would drag the
+     dial off the right edge it is pinned to. */
+  .gg-dial-col { flex: 0 0 auto; }
   .gg-dial-host { justify-content: flex-end; flex: 0 0 auto; }
   .gg-dial { min-width: 0; width: min(46vw, 11.5rem); max-width: none; padding: 0.28rem 0.4rem 0.32rem; }
   .gg-dial-label { font-size: 0.54rem; }

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -191,6 +191,22 @@ const GOAL_MAX_MATCHES = 3;
 /** How long it stays up once Live starts. Long enough to read twice. */
 const GOAL_DWELL_MS = 60000;
 
+/**
+ * ui/drops.js `onPop` verdicts where NO HEAT WAS BANKED.
+ *
+ * The roller's three early returns, in its own words: `clutter` (worth below
+ * MIN_WORTH — a bubble an opponent's BubbleSwarm minted, stamped 0), `phase`
+ * (a pop that arrived outside Live/SuddenDeath, which the recap window can
+ * still deliver before the HUD comes down) and `no-arsenal`. Every other
+ * verdict — miss, refused, no-candidate, drop — banked its gain first.
+ *
+ * It exists so the coached "popping fills your gauge" line can only ever ride a
+ * pop that actually filled it. Spelled here rather than imported because
+ * ui/drops.js publishes the strings on its return value and not as a constant;
+ * if it ever does, delete this.
+ */
+const NO_HEAT_REASONS = Object.freeze(['clutter', 'phase', 'no-arsenal']);
+
 /** Score count-up window. */
 const SCORE_LERP_MS = 250;
 /** Concurrent chrome animations, and how long a queued one may wait. */
@@ -877,13 +893,15 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
       if (res && res.dropped) emitAva('drop', 'you', res.id ? { item: res.id } : null);
       /* THE TWO COACHED BEATS OF THE ECONOMY, and they hang off the SAME two
        * facts rather than off the event, so neither can fire for a pop that
-       * banked nothing. `clutter` is a bubble an opponent's swarm minted: it is
-       * worth zero heat (exec/bubbles.js POP_WORTH_PAYLOAD), so coaching "this
-       * fills your gauge" off one would be a lie the gauge itself disproves.
+       * banked nothing. NO_HEAT_REASONS is ui/drops.js's three early returns —
+       * a swarm bubble worth zero (exec/bubbles.js POP_WORTH_PAYLOAD), a pop
+       * outside Live, and a desk with no arsenal — and coaching "this fills
+       * your gauge" off any of them would be a lie the gauge disproves in the
+       * same glance.
        *
        * `drop` names the item AND its number key, off SLOT_KEYS, which is
        * derived from the same list the keydown handler indexes. */
-      if (res && res.reason !== 'clutter') {
+      if (res && NO_HEAT_REASONS.indexOf(res.reason) < 0) {
         try { coach?.fire?.(COACH.POP, S.coach.pop); } catch (_e) { /* ignore */ }
       }
       if (res && res.dropped) {

--- a/ConditioningControlPanel/Resources/web/goon/ui/hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/hud.js
@@ -50,6 +50,7 @@ import { mountEmotes } from './emotes.js';
 import { mountAnnouncer } from './announcer.js';
 import { mountMicHud } from './voice/micHud.js';
 import { createDropRoller } from './drops.js';
+import { COACH } from './coach.js';
 import { avatarNode, emitAva } from './avatar.js';
 import { setPreviewMedia } from './throwPreview.js';
 import { resolveArsenalOpen, ARSENAL_OPEN_ON, ARSENAL_OPEN_OFF } from './prefs.js';
@@ -101,7 +102,22 @@ export const ARSENAL_OPEN_CLASS = 'is-open';
 export const ARSENAL_NARROW_MQ = '(orientation: portrait), (max-width: 720px)';
 
 /** Keys 1..N, i.e. one per payload slot. ui/arsenal.js owns the binding. */
-const ARSENAL_KEY_COUNT = ARSENAL_ITEMS.filter((i) => i.kind !== null).length;
+const PAYLOAD_SLOTS = ARSENAL_ITEMS.filter((i) => i.kind !== null);
+const ARSENAL_KEY_COUNT = PAYLOAD_SLOTS.length;
+
+/**
+ * An arsenal id -> the number key that fires it, and the word on its sticker.
+ *
+ * DERIVED, never hand-listed: it is the same filter-and-index ui/arsenal.js's
+ * keydown handler uses (PAYLOAD_ITEMS[n - 1]), so a coached line that says
+ * "press 3" can never drift from the key that actually throws the thing. A slot
+ * hidden by our own caps leaves its number DEAD rather than renumbering the
+ * others, which is exactly why the index is taken off the unfiltered list.
+ */
+const SLOT_KEYS = Object.freeze(PAYLOAD_SLOTS.reduce((map, item, i) => {
+  map[item.id] = { key: i + 1, label: item.label };
+  return map;
+}, Object.create(null)));
 
 /**
  * THE MIC'S KEY — push to talk, and the desktop half of voice notes.
@@ -165,6 +181,15 @@ const PAYLOAD_META = Object.freeze({
  * seconds-to-minutes long and it closes on the receipt either way.
  */
 const PAYLOAD_LEAD_MS = Math.max(GoonConsts.MinScheduleBufferMs, 1500);
+
+/**
+ * THE OBJECTIVE CAPTION's two limits (see THE OBJECTIVE LINE in the bottom bar).
+ * Matches, not duels won: ui/prefs.js `matchesPlayed` counts every recap, which
+ * is the number of times this player has been through the loop at all.
+ */
+const GOAL_MAX_MATCHES = 3;
+/** How long it stays up once Live starts. Long enough to read twice. */
+const GOAL_DWELL_MS = 60000;
 
 /** Score count-up window. */
 const SCORE_LERP_MS = 250;
@@ -304,10 +329,14 @@ function logTo(sink, entry) {
  * @param {object} [o.voice]    ui/voice/voiceService.js handle — the mic + the
  *                              incoming chip. null (or a build with the feature
  *                              off) simply means there is no mic on the desk.
+ * @param {object} [o.coach]    ui/coach.js handle — the one-time explainers.
+ *                              null means an uncoached desk and nothing else:
+ *                              every call below is `coach?.fire(...)` and the
+ *                              hint is the only thing that does not happen.
  * @returns {{unmount:Function}}
  */
 export function mountHud({ match, session = null, audio = null, prefs = null, media = null,
-  matchLog = null, discord = null, voice = null } = {}) {
+  matchLog = null, discord = null, voice = null, coach = null } = {}) {
   const led = createLedger();
   const fx = createFx();
   const d = doc();
@@ -744,7 +773,46 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   // ---------------------------------------------------------------- bottom
   const bottom = add(root, el('div', 'gg-hud-bottom'));
   const fxRail = add(bottom, el('div', 'gg-fxrail'));
-  const dialHost = add(bottom, el('div', 'gg-dial-host'));
+
+  /* ---- THE OBJECTIVE LINE ------------------------------------------------
+   * "the whole game feels kinda random atm with no direction" (owner,
+   * 2026-08-05). The desk tells a new player what every readout on it is DOING
+   * and never once what any of it is FOR — so one quiet caption sits over the
+   * closeness dial and says the goal out loud.
+   *
+   * IT IS A COLUMN, NOT A NEW EDGE. `.gg-dial-col` wraps the caption and the
+   * dial host that was already the bottom bar's right-hand child, so the flex
+   * row is still two children and the dial is still bottom-right at every
+   * breakpoint. Nothing is absolutely placed and no keep-out band is involved:
+   * MERCY's strip is `.gg-hud-bottom`'s own padding, below all of this.
+   *
+   * IT LEAVES ON ITS OWN, twice over. It is only built for the first
+   * GOAL_MAX_MATCHES matches (ui/prefs.js `matchesPlayed`, which the recap
+   * increments) and it fades after GOAL_DWELL_MS of Live — a permanent caption
+   * on a desk this dense is furniture, and furniture is what the eye stops
+   * reading. The hints toggle silences it like everything else.
+   * -------------------------------------------------------------------- */
+  const dialCol = add(bottom, el('div', 'gg-dial-col'));
+  const goalLine = add(dialCol, el('div', 'gg-coach-goal', S.coach.goal));
+  const dialHost = add(dialCol, el('div', 'gg-dial-host'));
+
+  function goalWanted() {
+    if (!goalLine) return false;
+    try {
+      if (coach && coach.enabled === false) return false;
+      if (!prefs || typeof prefs.get !== 'function') return true;
+      return ((prefs.get('matchesPlayed') | 0) < GOAL_MAX_MATCHES);
+    } catch (_e) { return false; }
+  }
+  if (goalLine) {
+    goalLine.hidden = !goalWanted();
+    if (!goalLine.hidden) {
+      const t = setTimeout(() => {
+        try { cls(goalLine, 'is-gone', true); } catch (_e) { /* stub DOM */ }
+      }, GOAL_DWELL_MS);
+      led.add(() => { try { clearTimeout(t); } catch (_e) { /* gone */ } });
+    }
+  }
 
   // ------------------------------------------------------------ sub-mounts
   /* The media pool reaches the THROW PREVIEW here and nowhere else. It is a
@@ -779,6 +847,11 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
       // The FX beat first and unconditionally: it is about the ACT of firing,
       // which happened whether or not the monitor can draw the flight.
       emitAva('fire', 'you', shot && shot.kind !== undefined ? { kind: shot.kind } : null);
+      /* THE COOLDOWN, ONCE, ON THE FIRST THROW. It is the next thing that will
+       * surprise this player — the second throw is free (PayloadBurst = 2) and
+       * the third is thirty seconds away — and there is nowhere on the desk that
+       * says so until a tile is already greyed out and sweeping. */
+      try { coach?.fire?.(COACH.FIRED, S.coach.fired); } catch (_e) { /* never break a throw */ }
       if (!shot || typeof opponent.markPayloadFired !== 'function') return;
       opponent.markPayloadFired({
         id: shot.id,
@@ -802,15 +875,31 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
       // it to four a second), `drop` is the rare one that armed a slot.
       emitAva('pop', 'you');
       if (res && res.dropped) emitAva('drop', 'you', res.id ? { item: res.id } : null);
+      /* THE TWO COACHED BEATS OF THE ECONOMY, and they hang off the SAME two
+       * facts rather than off the event, so neither can fire for a pop that
+       * banked nothing. `clutter` is a bubble an opponent's swarm minted: it is
+       * worth zero heat (exec/bubbles.js POP_WORTH_PAYLOAD), so coaching "this
+       * fills your gauge" off one would be a lie the gauge itself disproves.
+       *
+       * `drop` names the item AND its number key, off SLOT_KEYS, which is
+       * derived from the same list the keydown handler indexes. */
+      if (res && res.reason !== 'clutter') {
+        try { coach?.fire?.(COACH.POP, S.coach.pop); } catch (_e) { /* ignore */ }
+      }
+      if (res && res.dropped) {
+        const slot = SLOT_KEYS[res.id];
+        if (slot) { try { coach?.fire?.(COACH.DROP, S.coach.drop(slot.label, slot.key)); } catch (_e) { /* ignore */ } }
+      }
     } catch (_e) { /* a drop must never break the desk */ }
   });
 
-  const dial = mountCloseness({ host: dialHost, match, audio, onLog });
+  const dial = mountCloseness({ host: dialHost, match, audio, onLog, coach });
   const attention = mountAttention({
     host: attSlot,
     tokenHost: root,
     match,
     audio,
+    coach,
     /* `sideBox` rather than the two rails: it is the whole sidebar including the
      * handle, and it is the only one of the three whose rect is HONEST in both
      * states — a collapsed panel is display:none, so a rail measures 0x0 and an
@@ -1192,6 +1281,11 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
       // schedules ahead (PAYLOAD_LEAD_MS) and a bubble that recoiled a second
       // and a half early would read as a glitch, not a hit.
       emitAva('land', 'you', { kind: p.kind });
+      /* ...and so does the EXPLANATION, for exactly the same reason: a line
+       * saying "that is them" a second and a half before anything appears is
+       * about nothing. It rides the landing timer, naming the family off the
+       * same PAYLOAD_META the fx chip beside it uses. */
+      try { coach?.fire?.(COACH.INCOMING, S.coach.incoming(meta.label)); } catch (_e) { /* ignore */ }
     }, Math.min(wait, 30000));
     led.add(() => { try { clearTimeout(t); } catch (_e) { /* gone */ } });
     onLog({ t: 'payload-in', kind: meta.label, id: p.id });
@@ -1215,6 +1309,10 @@ export function mountHud({ match, session = null, audio = null, prefs = null, me
   // rather than on avatarFx's 2600ms fallback.
   sub('onEmoteReceived', (e) => {
     emitAva('emote', 'opp', { emote: (e && (e.text || e.icon)) || '', ms: EMOTE_MINI_MS });
+    /* A bubble appearing over a stranger's face with no warning is the one beat
+     * on this desk that reads as the game doing something TO you when it is the
+     * only thing on it that does nothing at all. The hint says both halves. */
+    try { coach?.fire?.(COACH.EMOTE, S.coach.emote); } catch (_e) { /* ignore */ }
   });
 
   // The hello carries their display name; the mini is built before it lands.

--- a/ConditioningControlPanel/Resources/web/goon/ui/options.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/options.js
@@ -201,6 +201,21 @@ export function createOptions({ prefs, audio = null, session = null, setFullscre
     body.appendChild(oppAva.node);
     body.appendChild(el('p', { class: 'gg-panel-note', text: S.options.oppAvatarsNote }));
 
+    /* COACHING HINTS — the one-time explainers (ui/coach.js), and the fourth
+     * mid-match knob for the fourth time for the same reason: the moment a
+     * player wants this off is the moment a hint has just told them something
+     * they already knew. It is read live on every fire, so flipping it here
+     * silences the very next one rather than the next match.
+     *
+     * The pref alone is the switch — no handle is threaded in. ui/coach.js reads
+     * `coachHints` off the same store on every fire, which is what keeps this
+     * drawer free of a dependency on a singleton it is built before. */
+    const hints = toggleRow(S.coach.hints,
+      () => prefs.get('coachHints'),
+      (v) => prefs.set('coachHints', v));
+    body.appendChild(hints.node);
+    body.appendChild(el('p', { class: 'gg-panel-note', text: S.coach.hintsNote }));
+
     if (session && session.hosted && setFullscreen) {
       const fs = toggleRow(S.options.fullscreen,
         () => !!session.fullscreen,

--- a/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/prefs.js
@@ -163,6 +163,30 @@ export const PREF_DEFAULTS = Object.freeze({
   /** Local-only counter; the recap's "GG" title reads it. Never sent anywhere. */
   matchesPlayed: 0,
 
+  /* ---------------------------------------------------------------- coaching
+   * THE ONE-TIME EXPLAINERS (ui/coach.js). Two keys, and they are two keys
+   * rather than one for the same reason the voice pair is:
+   *
+   *   coachHints  the master switch. ON by default — a duel with nothing
+   *     explained is the bug this feature exists for — and OFF is a standing
+   *     answer that must survive a player who then meets a mechanic for the
+   *     first time. Read on every fire, so flipping it mid-match is immediate.
+   *   coachSeen   { [hintId]: true } — which lines have already been spent.
+   *     The SECOND non-scalar pref on the page (voiceEmoteMap was the first,
+   *     and it is the reason `coerce` already has an object branch). A map
+   *     rather than a boolean-per-hint because the set of hints is owned by
+   *     ui/coach.js and grows there; a new id must not need a schema edit here,
+   *     and an id retired from the module leaves a dead key that nothing reads
+   *     rather than a default nothing sets.
+   *
+   * ONCE-EVER MEANS ONCE EVER. A hint is marked the moment it is QUEUED, not
+   * when its toast is dismissed: a match that ends (or a page that closes) with
+   * a coached line still in the queue must not re-offer it on the next launch.
+   * The whole promise of this feature is that it goes away.
+   */
+  coachHints: true,
+  coachSeen: Object.freeze({}),
+
   /* ---------------------------------------------------------------- voice notes
    * FOUR keys, and the first two are the safety pair. Both default to the answer
    * that does nothing:

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -136,6 +136,17 @@
   user-select: text;
 }
 
+/* The objective, over the six bullets (ui/screens/title.js). Brighter than the
+   list under it on purpose — it is the one line somebody who reads nothing else
+   should still come away with. */
+.gg-how-goal {
+  margin: 0.5rem 0 0;
+  color: var(--gg-text);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-align: left;
+}
+
 .gg-how-list {
   margin: 0.4rem 0 0;
   padding-left: 1.1rem;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/title.js
@@ -137,8 +137,16 @@ export function mount(container, ctx) {
     prefs?.set?.('seenHowItWorks', true);
     // Built as a sheet body rather than through sheets.open(), because six
     // bullets is a list, not a one-line notice.
+    /* THE GOAL, ABOVE THE BULLETS (2026-08-05). Six bullets described the LOOP
+     * accurately and never once said what winning is, so a first-time reader
+     * finished the card knowing how to throw a flash and not what for. It is a
+     * lead PARAGRAPH and deliberately not a seventh bullet — the list is pinned
+     * at six by its own note in ui/strings.js, and "the goal" is not a step in a
+     * sequence anyway. Same sentence the desk's own caption carries, one screen
+     * earlier (ui/hud.js THE OBJECTIVE LINE). */
     const body = el('div', { class: 'gg-how' }, [
       el('h2', { class: 'gg-sheet-headline', text: S.how.headline }),
+      el('p', { class: 'gg-how-goal', text: S.coach.howGoal }),
       el('ul', { class: 'gg-how-list' }, S.how.bullets.map((b) => el('li', { text: b }))),
     ]);
     sheets?.openNode?.(body, { label: S.how.headline, closeLabel: S.how.close });

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -1035,6 +1035,95 @@ export const S = Object.freeze({
     dropToast: (label) => (label || 'item') + ' dropped',
   },
 
+  /* ------------------------------------------------------------ the coaching
+   * THE ONE-TIME EXPLAINERS (ui/coach.js). Owner, 2026-08-05: "the whole game
+   * feels kinda random atm with no direction."
+   *
+   * Every line here fires ONCE EVER, the first time the mechanic it describes
+   * actually touches the player, and never again on any machine that has a prefs
+   * store. That is the whole reason the register is different from the rest of
+   * this file: these are not furniture the eye slides over, they are the single
+   * sentence a stranger gets about a thing that just happened to them, so each
+   * one has to name the ACT and the CONSEQUENCE and then get out of the way.
+   *
+   * THREE RULES THAT ARE CORRECTNESS, NOT STYLE, because a wrong explainer is
+   * worse than no explainer — a player will plan around it:
+   *
+   *   1. EVERY CLAUSE IS CHECKED AGAINST THE CODE. The numbers below are read
+   *      out of the modules that own them, not remembered: twelve seconds is
+   *      ui/attention.js GRACE_MS, x0.6 for a minute is GoonConsts
+   *      NoCamFailedCheckMult + NoCamFailedCheckPenaltyMs, thirty seconds and
+   *      "two back to back" are GoonConsts PayloadMinGapMs + PayloadBurst. Move
+   *      one of those constants and this copy is a lie — the checks in
+   *      test/selftest-coach.js are what stop that happening quietly.
+   *   2. NOTHING HERE MENTIONS CHARGES. The meter still exists in the engine and
+   *      still rides the wire, and since 2026-08-05 it buys exactly nothing (see
+   *      the tombstones in ui/hud.js and ui/arsenal.js). A hint that named a
+   *      currency the player cannot spend would be the most confusing sentence
+   *      on the page, which is the opposite of the job.
+   *   3. NOTHING HERE PROMISES A PAYLOAD DOES DAMAGE. Grepped before writing:
+   *      no payload touches score, multiplier, heat, cooldown or phase on the
+   *      receiving side. They are interference — they make you look away, and
+   *      looking away is what costs. `incoming` says exactly that and no more.
+   *
+   * Lowercase furniture like the rest of the deck. No exclamation marks: the
+   * announcer is the one voice on this page allowed to raise itself. */
+  coach: {
+    /* THE OBJECTIVE, and the only line here that is not a one-shot toast: it is
+       a quiet caption over the closeness dial for the first minute of the first
+       three matches (ui/hud.js). Deliberately carries NO per-second number —
+       the rate is seconds x riskMultiplier x attentionMultiplier and the two
+       multipliers were removed from this desk on purpose, so "1 pt/s" would be
+       a fourth readout of a number the owner deleted three of. "still here" is
+       the honest version: points tick for as long as you have not tapped out. */
+    goal: 'outlast them. points tick up every second you are still here — they tap out, or you are ahead when the clock runs out.',
+
+    /** The first bubble that banks heat. Says what popping is FOR. */
+    pop: 'popping bubbles fills your heat gauge. the fuller it is, the more likely the next pop drops you something to throw.',
+    /**
+     * The first slot a drop ever arms. BOTH gestures, because the drawer is shut
+     * by default on a phone (there is no number row there) and open by default
+     * on a desk (where nobody finds a drag on their own). `key` is the tile's
+     * position in ui/arsenal.js ARSENAL_ITEMS — 1..7, and it never renumbers.
+     */
+    drop: (label, key) => 'you earned a ' + (label || 'item') + '. tap it, then tap their monitor — or press '
+      + key + ', then ' + key + ' again.',
+    /** The first thing you actually throw. The cooldown, before it surprises you. */
+    fired: 'two throws back to back, then one every thirty seconds. the tiles count the wait down for you.',
+    /**
+     * The first payload of theirs that lands. The half a new player gets wrong is
+     * the middle clause: nothing on their side subtracts a point from you.
+     */
+    incoming: (label) => 'that ' + (label || 'one') + ' is them. payloads take no points off you — they are there to make you look away, or tap out.',
+    /** The first attention token. The one hint with a deadline attached. */
+    check: 'tap the circle within twelve seconds. miss it and you score at x0.6 for the next minute.',
+    /**
+     * The first time the player moves the dial. It is a CLAIM and the code says
+     * so twice (ui/closeness.js's header, core/match.js "Bluffable BY DESIGN"),
+     * so the hint says it too rather than letting anyone think it is measured.
+     */
+    dial: 'that goes on their screen and nothing checks it. tell them the truth, or do not.',
+    /** The first emote from them. Cosmetic, and the hint must not imply otherwise. */
+    emote: 'they said something at you. your own emote tile is in the items panel — it costs nothing and does nothing.',
+    /**
+     * PRACTICE COACHES HARDER, because practice is where a player is allowed to
+     * be bad at this. Names the two slots boot.js's PRACTICE_SEED actually arms
+     * (flash = key 1, video = key 3) and one concrete thing to press.
+     */
+    practice: 'you start with a flash and a video — keys 1 and 3. press 1, then 1 again, to throw the flash at them.',
+
+    /* ---- the switch (ui/options.js) ----
+     * ONE toggle for the whole feature, offered mid-match like every other knob
+     * about your own screen. The note says what OFF means precisely, because
+     * "hints" is a word that has meant "tooltips", "tutorials" and "nagging" in
+     * three different apps this week. */
+    hints: 'Coaching hints',
+    hintsNote: 'the one-line explainers that fire the first time each part of a duel happens to you. each one appears once, ever. off, none of them do.',
+
+    /** The lead line over the "how it works" bullets (ui/screens/title.js). */
+    howGoal: 'the goal: outlast them. they tap out, or you are ahead when the clock runs out.',
+  },
+
   /* --------------------------------------------------------------- toasts */
   toasts: {
     copied: 'invite line copied',


### PR DESCRIPTION
## Why

> "add some nudges and explanations — the whole game feels kinda random atm with no direction" — owner

A duel throws seven effect kinds, a heat gauge, an item economy, an attention check and a self-reported dial at a stranger inside the first two minutes, and explains exactly one of them: the six bullets on the title card, which a player reads *before* any of it has happened and therefore cannot attach to anything. This is the other half — one short, true line, fired the first time each mechanic actually touches the player, and then never again.

**Additive UI only.** No game logic, economy, timing, net protocol or `exec/` renderer is touched. Nothing here can block, pause, modal or delay a live match.

---

## What was added

### `ui/coach.js` (new)

The once-ever ledger and a pacer. Everything above `createCoach()` is pure and total (`isCoachId` / `hasSeen` / `withSeen` / `shouldFire`), so the policy is testable with no DOM, no store and no clock.

- Output is `ui/toasts.js` and **nothing else** — `#gg-toasts` is z50, below MERCY (z60), holds no interactive element and is already `aria-live="polite"`. The module touches no DOM at all.
- **A hint is marked spent at QUEUE time**, not on dismiss. A line dropped by the pacer, cleared by a teardown, or fired into a page with no toast layer is still spent — the whole promise of the feature is that it goes away.
- **The pacer**: firsts arrive in clumps (first drop, first throw and first inbound payload can all land inside ten seconds). One line per `COACH_GAP_MS` (2800), and a queue already `COACH_QUEUE_MAX` (3) deep drops the newest rather than growing — a line a minute after the thing it explains is worse than no line.
- A hint refused because **hints are OFF is *not* spent**: turning them back on must not hand the player an empty deck.

### The eight coached beats

Each fires from the branch that *actually happened*, never from the event that predicted it.

| Hint id | Trigger (exact) | Copy |
|---|---|---|
| `pop` | `ui/hud.js` — first `gg-bubble-pop` whose roller verdict is not in `NO_HEAT_REASONS` (`clutter` / `phase` / `no-arsenal`), i.e. a pop that really banked heat. An opponent's BubbleSwarm bubbles are stamped worth 0 and never coach. | *popping bubbles fills your heat gauge. the fuller it is, the more likely the next pop drops you something to throw.* |
| `drop` | `ui/hud.js` — first `drops.onPop()` returning `{dropped:true}` | *you earned a {label}. tap it, then tap their monitor — or press {key}, then {key} again.* |
| `fired` | `ui/hud.js` — arsenal `onFired`, first payload this player throws | *two throws back to back, then one every thirty seconds. the tiles count the wait down for you.* |
| `incoming` | `ui/hud.js` — first `onPayloadAccepted`, fired on the **landing timer**, not the accept (the engine schedules ~1.5 s ahead) | *that {family} is them. payloads take no points off you — they are there to make you look away, or tap out.* |
| `check` | `ui/attention.js` — inside `spawn()`, after the NoCam/duplicate early-returns, i.e. only when a circle is really on screen | *tap the circle within twelve seconds. miss it and you score at x0.6 for the next minute.* |
| `dial` | `ui/closeness.js` — inside `set()`, after the 350 ms cooldown and the no-op check, so only a change the player actually made | *that goes on their screen and nothing checks it. tell them the truth, or do not.* |
| `emote` | `ui/hud.js` — first `onEmoteReceived` | *they said something at you. your own emote tile is in the items panel — it costs nothing and does nothing.* |
| `practice` | `boot.js` `seedPracticeArsenal()`, +900 ms (the HUD entrance is still animating) | *you start with a flash and a video — keys 1 and 3. press 1, then 1 again, to throw the flash at them.* |

`S.coach.drop` derives the label and the key from `SLOT_KEYS` in `ui/hud.js`, built by the same `filter(kind !== null)` + index that `ui/arsenal.js`'s keydown handler uses — so "press 3" can never drift from the key that throws the thing.

### Direction / the objective, twice

- **`S.coach.goal`** — a quiet caption over the closeness dial: *outlast them. points tick up every second you are still here — they tap out, or you are ahead when the clock runs out.* Shown only for the first 3 matches (`matchesPlayed`) and fades after 60 s of Live. Pointer-transparent, not a `.gg-plate`, hidden by zen along with the dial it captions.
- **`S.coach.howGoal`** — a lead paragraph over the how-it-works bullets: *the goal: outlast them. they tap out, or you are ahead when the clock runs out.* Deliberately **not** a seventh bullet — the list is pinned at six by its own note in `strings.js`.

The how-it-works card itself (ghost button on the title screen, auto-opens once) **already existed** on main; this adds the objective it never stated.

### The switch

`S.coach.hints` — a **Coaching hints** toggle in the options drawer (`ui/options.js`), offered mid-match like the other own-screen knobs. Read live on every fire, so flipping it silences the very next line rather than the next match.

---

## Every new string

All under a new `S.coach` section in `ui/strings.js`. **`S.voice` is untouched** and `boot.js`'s `reportMicGate` is untouched (both pinned by the new suite) — the parallel PR owns them.

- `goal` — `outlast them. points tick up every second you are still here — they tap out, or you are ahead when the clock runs out.`
- `pop` — `popping bubbles fills your heat gauge. the fuller it is, the more likely the next pop drops you something to throw.`
- `drop(label, key)` — `you earned a {label}. tap it, then tap their monitor — or press {key}, then {key} again.`
- `fired` — `two throws back to back, then one every thirty seconds. the tiles count the wait down for you.`
- `incoming(label)` — `that {label} is them. payloads take no points off you — they are there to make you look away, or tap out.`
- `check` — `tap the circle within twelve seconds. miss it and you score at x0.6 for the next minute.`
- `dial` — `that goes on their screen and nothing checks it. tell them the truth, or do not.`
- `emote` — `they said something at you. your own emote tile is in the items panel — it costs nothing and does nothing.`
- `practice` — `you start with a flash and a video — keys 1 and 3. press 1, then 1 again, to throw the flash at them.`
- `hints` — `Coaching hints`
- `hintsNote` — `the one-line explainers that fire the first time each part of a duel happens to you. each one appears once, ever. off, none of them do.`
- `howGoal` — `the goal: outlast them. they tap out, or you are ahead when the clock runs out.`

---

## Pref keys

| Key | Default | What |
|---|---|---|
| `coachHints` | `true` | The master switch. Read live on every fire, so the drawer reaches a match already running. |
| `coachSeen` | `{}` | `{ [hintId]: true }` — which lines are spent. The second non-scalar pref on the page (`voiceEmoteMap` was the first, and it is why `coerce` already has an object branch). |

Ids are stable identifiers, not labels: renaming one re-shows a hint to everybody who already read it.

---

## Copy correctness

Every number in `S.coach` is read out of the constant that produces it, and `test/selftest-coach.js` cross-checks each one so a retune fails the suite instead of quietly making the copy a lie:

- "twelve seconds" comes from `ui/attention.js` `GRACE_MS = 12000`
- "x0.6" / "a minute" from `GoonConsts.NoCamFailedCheckMult = 0.6`, `NoCamFailedCheckPenaltyMs = 60000`
- "two ... thirty seconds" from `GoonConsts.PayloadBurst = 2`, `PayloadMinGapMs = 30000`
- "flash and a video — keys 1 and 3" from `boot.js` `PRACTICE_SEED` ids, indexed through `ARSENAL_ITEMS`

The suite also pins the three things this copy may **never** say:

1. **charges** — the meter still exists and still rides the wire, and has bought nothing since 2026-08-05. A hint naming an unspendable currency would be the most confusing sentence on the page.
2. **a camera / gaze** — `localAttentionMode` is hard-wired `NoCam`; the whole Cam branch is unreachable.
3. **sudden death** — the runner is detached in `boot.js`; the phase resolves on score in one tick.

...plus: no payload may be described as taking points (grepped — nothing inbound touches score, multiplier, heat, cooldown or phase), and no exclamation marks (the announcer is the only raised voice on this page).

---

## Tests

- **`test/selftest-coach.js` (new): 136/136** — import sweep, the pure policy, prefs round-trip and corrupt-store coercion, once-ever plus mark-at-queue-time, the OFF path not burning hints, the pacer and its ceiling, `clearPending`/`dispose`, every copy number against its constant, the three forbidden subjects, every hint having a call site *and* every call site an id, and the parallel-PR fence.
- `selftest-hud` 1700/1700 · `selftest-flow` 318 · `selftest-exec` 1054 · `selftest-voice-ui` 269 · `selftest-core` 242 · `selftest-net` 350 · `selftest-assets` 427 · `selftest-encode` 190 · `selftest-hostgate` 97 · `selftest-invite` 199 · `selftest-report` 213 · `selftest-transfer` 199 · `selftest-voice` 270 — all green.
- `selftest-avafx` fails its usual 12 checks — **pre-existing on clean main**, unrelated.
- `dotnet build`: **0 errors**, 312 warnings (the usual CA1416/CS8602 noise).

## Not play-tested

Nothing here has been in front of a real duel yet. The suite covers the policy and the copy; what it cannot cover is whether a line lands at the right *moment*, which needs one practice run and one real match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TES3SQQkdVKQ5utaBVHX2W
