### PR TITLE
fix(content): self-heal the content-pack wedge behind the silent-companion reports

### DIFF
--- a/ConditioningControlPanel/Services/Content/MergeJournal.cs
+++ b/ConditioningControlPanel/Services/Content/MergeJournal.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Record of what a content-pack merge wrote into the live content tree, so a merge that throws
+    /// part-way can be taken back out.
+    ///
+    /// Without this, a failed install left whatever it had already copied behind, and that debris is
+    /// exactly what makes a broken pack read as "present" to the on-disk floor probes — the pack is
+    /// then never re-fetched and the user stays voiceless. Deleting the destination TREE instead is
+    /// not an option: every loose-media pack merges into the shared
+    /// <c>content\Resources</c>, so a wholesale delete would take other packs' files with it. Only
+    /// what this merge created comes back out.
+    ///
+    /// Overwritten files are removed along with new ones: a half-updated file is not a file worth
+    /// keeping, and driving the pack all the way back to "clearly missing" is the whole point.
+    /// </summary>
+    internal sealed class MergeJournal
+    {
+        private readonly List<string> _files = new();
+        private readonly List<string> _directories = new();
+        private readonly List<string> _trees = new();
+
+        // A retry merges on top of the first attempt's work and re-records the same paths, so
+        // membership is deduped while the lists keep write order.
+        private readonly HashSet<string> _seen = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Destination files this merge wrote, in write order.</summary>
+        internal IReadOnlyList<string> Files => _files;
+
+        /// <summary>Destination directories this merge had to create, in creation order.</summary>
+        internal IReadOnlyList<string> Directories => _directories;
+
+        /// <summary>
+        /// Destination trees this merge created wholesale by renaming the staging folder onto a
+        /// target that did not exist. Nothing else can own them, so they come out recursively.
+        /// </summary>
+        internal IReadOnlyList<string> Trees => _trees;
+
+        internal bool IsEmpty => _files.Count == 0 && _directories.Count == 0 && _trees.Count == 0;
+
+        internal void RecordFile(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && _seen.Add("f:" + path)) _files.Add(path);
+        }
+
+        internal void RecordDirectory(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && _seen.Add("d:" + path)) _directories.Add(path);
+        }
+
+        internal void RecordTree(string path)
+        {
+            if (!string.IsNullOrEmpty(path) && _seen.Add("t:" + path)) _trees.Add(path);
+        }
+
+        /// <summary>
+        /// Deletes everything this merge wrote, best-effort, and returns how many files actually
+        /// went. Per-item IO errors are expected here (an antivirus scanner holding a freshly
+        /// written file is the usual reason the merge failed in the first place) and are swallowed
+        /// so one locked file cannot abort the rest of the cleanup.
+        /// </summary>
+        internal int Rollback()
+        {
+            var removed = 0;
+
+            foreach (var tree in _trees)
+            {
+                try
+                {
+                    if (!Directory.Exists(tree)) continue;
+                    removed += CountFilesUnder(tree);
+                    Directory.Delete(tree, true);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("MergeJournal: could not remove tree {Path}: {Error}", tree, ex.Message);
+                }
+            }
+
+            foreach (var file in _files)
+            {
+                try
+                {
+                    if (!File.Exists(file)) continue;
+                    File.Delete(file);
+                    removed++;
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("MergeJournal: could not remove {Path}: {Error}", file, ex.Message);
+                }
+            }
+
+            // Longest path first. A child path is always its parent plus a separator and a name, so
+            // length descending guarantees descendants are visited before their ancestors — which is
+            // the only order in which a parent can have become empty by the time we reach it.
+            var deepestFirst = new List<string>(_directories);
+            deepestFirst.Sort((a, b) => b.Length.CompareTo(a.Length));
+
+            foreach (var dir in deepestFirst)
+            {
+                try
+                {
+                    if (!Directory.Exists(dir)) continue;
+                    // Non-recursive on purpose: anything still in there is not ours.
+                    Directory.Delete(dir, false);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("MergeJournal: left {Path} in place: {Error}", dir, ex.Message);
+                }
+            }
+
+            return removed;
+        }
+
+        private static int CountFilesUnder(string dir)
+        {
+            try
+            {
+                var count = 0;
+                foreach (var _ in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories)) count++;
+                return count;
+            }
+            catch { return 0; }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -1143,37 +1143,106 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Extensions that count as pack-delivered media. PNG is in deliberately: the packs carry
+        /// portrait/pose art as well as voice (builtin-sissyhypno ships 312 PNGs next to its ~1,700
+        /// audio files) and a mod whose art did not survive is just as broken to the user as a
+        /// silent one. The <c>.json</c> manifests in these folders stay in the installer, so they
+        /// must never count — that is what let a stripped install read as fully stocked.
+        /// </summary>
+        private static readonly string[] MediaExtensions = { ".mp3", ".wav", ".ogg", ".m4a", ".png" };
+
+        /// <summary>
+        /// How many media files a mod's own subtree must hold before <see cref="HasModMediaOnDisk"/>
+        /// calls it present.
+        ///
+        /// "Any .mp3 at all" is what wedged v6.6.4: ONE file surviving a half-merged install
+        /// satisfied the probe forever, so the pack was never re-fetched and the user stayed
+        /// voiceless. Healthy trees are nowhere near this line — an extracted built-in mod runs 390+
+        /// media files and the loose companion audio 1,400-2,000 — so any floor between "a handful"
+        /// and "a hundred" separates clearly-present from clearly-broken. 50 is chosen at the low end
+        /// on purpose: this number decides whether to spend a user's bandwidth, and a hand-trimmed
+        /// but working install must not be dragged into a re-download.
+        /// </summary>
+        internal const int MinModMediaFiles = 50;
+
+        /// <summary>
+        /// Media files among <paramref name="paths"/>, counting no further than
+        /// <paramref name="stopAt"/> — callers only ever compare against a floor, and these
+        /// enumerations run over thousands of files during startup.
+        /// </summary>
+        internal static int CountMediaFiles(IEnumerable<string>? paths, int stopAt = int.MaxValue)
+        {
+            if (paths == null || stopAt <= 0) return 0;
+
+            var count = 0;
+            foreach (var path in paths)
+            {
+                if (string.IsNullOrEmpty(path)) continue;
+                var ext = Path.GetExtension(path);
+                if (string.IsNullOrEmpty(ext)) continue;
+
+                foreach (var known in MediaExtensions)
+                {
+                    if (!ext.Equals(known, StringComparison.OrdinalIgnoreCase)) continue;
+                    if (++count >= stopAt) return count;
+                    break;
+                }
+            }
+            return count;
+        }
+
+        /// <summary>
         /// True when a built-in mod's media is present WITHOUT its pack being stamped — the surviving
-        /// state of an in-place upgrade. Two shapes to probe, matching the two shapes the packs take:
-        /// an extracted <c>.ccpmod</c> tree (drone, locked) and loose companion audio (bambi, sissy,
-        /// locked). Any failure answers "present" so a bad probe can never trigger a download.
+        /// state of an in-place upgrade. Both shapes the packs take feed ONE count: an extracted
+        /// <c>.ccpmod</c> tree (drone, locked) and loose companion audio (bambi, sissy, locked). A
+        /// half-merged install leaves debris in either, so neither shape may vote "present" on its
+        /// structure alone — see <see cref="MinModMediaFiles"/>.
+        ///
+        /// A probe failure answers "missing": a needless re-download costs bandwidth once, a probe
+        /// that answers "present" whenever it breaks wedges the user voiceless forever.
         /// </summary>
         private static bool HasModMediaOnDisk(string modId)
         {
+            var count = 0;
             try
             {
-                // 1) Extracted .ccpmod payload — the exact probes ModService.PrepareBuiltInMod uses
-                //    (mod.json for a full package, resources\ for a resources-only one).
+                // 1) Extracted .ccpmod payload, under the root ModService.PrepareBuiltInMod fills.
                 var extractDir = Path.Combine(App.UserDataPath, "builtin_mods", modId);
-                if (File.Exists(Path.Combine(extractDir, "mod.json"))) return true;
-                if (Directory.Exists(Path.Combine(extractDir, "resources"))) return true;
+                if (Directory.Exists(extractDir))
+                    count = CountMediaFiles(SafeEnumerateFiles(extractDir), MinModMediaFiles);
 
-                // 2) Loose companion audio. Deliberately audio-only patterns: the .json manifests in
-                //    this folder STAY in the installer, so "any file here" would report a stripped
-                //    install as fully stocked. ContentLocator covers both roots.
-                var relAudio = Path.Combine("Resources", "sounds", "companion_audio", "mods", modId);
-                foreach (var pattern in new[] { "*.mp3", "*.wav" })
+                // 2) Loose companion audio. ContentLocator covers both roots.
+                if (count < MinModMediaFiles)
                 {
-                    if (ContentLocator.EnumerateFiles(relAudio, pattern, SearchOption.AllDirectories).Any())
-                        return true;
+                    var relAudio = Path.Combine("Resources", "sounds", "companion_audio", "mods", modId);
+                    count += CountMediaFiles(
+                        ContentLocator.EnumerateFiles(relAudio, "*", SearchOption.AllDirectories),
+                        MinModMediaFiles - count);
                 }
 
-                return false;
+                if (count >= MinModMediaFiles) return true;
             }
             catch (Exception ex)
             {
-                App.Logger?.Debug("ReleaseContentService: mod-media probe for {Mod} failed: {Error}", modId, ex.Message);
-                return true;
+                App.Logger?.Information(
+                    "ReleaseContentService: mod-media probe for {Mod} failed ({Error}) — treating it as missing so the pack re-fetches",
+                    modId, ex.Message);
+                return false;
+            }
+
+            App.Logger?.Information(
+                "ReleaseContentService: mod {Mod} has only {Count} media file(s) on disk (floor {Floor}) — queueing a pack re-fetch",
+                modId, count, MinModMediaFiles);
+            return false;
+        }
+
+        private static IEnumerable<string> SafeEnumerateFiles(string dir)
+        {
+            try { return Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories); }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ReleaseContentService: could not enumerate {Dir}: {Error}", dir, ex.Message);
+                return Array.Empty<string>();
             }
         }
 

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -92,6 +92,16 @@ namespace ConditioningControlPanel.Services
         private const int MaxDownloadAttempts = 10;
 
         /// <summary>
+        /// Extract+merge passes before a pack install is called lost. Two, because the usual reason a
+        /// download that arrived intact still fails to install is a real-time antivirus scanner
+        /// holding freshly written files open — which clears on its own within seconds. The rollback
+        /// only runs after the LAST attempt, so the retry keeps whatever the first pass landed.
+        /// </summary>
+        private const int MaxInstallAttempts = 2;
+
+        private static readonly TimeSpan InstallRetryDelay = TimeSpan.FromSeconds(5);
+
+        /// <summary>
         /// Bound on the (tiny) manifest GET. <see cref="HttpClient.Timeout"/> is sized for a 380 MB
         /// pack, so without this a black-holing network would leave the picker "not offline yet" for
         /// half an hour. Downloads keep the long timeout — they have their own retry ladder.
@@ -668,10 +678,6 @@ namespace ConditioningControlPanel.Services
                 // ---- install: extract to a temp sibling, then merge into content\{targetRoot} ----
                 SetState(ReleaseContentState.Installing, packId, 100);
 
-                TryDeleteDirectory(extractPath);
-                await Task.Run(() => ZipFile.ExtractToDirectory(partialPath, extractPath, overwriteFiles: true), ct)
-                    .ConfigureAwait(false);
-
                 var target = ResolveTargetDirectory(info);
                 if (target == null)
                 {
@@ -683,7 +689,42 @@ namespace ConditioningControlPanel.Services
                     return false;
                 }
 
-                await Task.Run(() => MergeDirectory(extractPath, target), ct).ConfigureAwait(false);
+                // One journal across BOTH attempts: the retry merges on top of whatever the first
+                // attempt already wrote, so only a journal that spans them can take the whole failed
+                // install back out.
+                var journal = new MergeJournal();
+
+                for (var attempt = 1; attempt <= MaxInstallAttempts; attempt++)
+                {
+                    try
+                    {
+                        TryDeleteDirectory(extractPath);
+                        await Task.Run(() => ZipFile.ExtractToDirectory(partialPath, extractPath, overwriteFiles: true), ct)
+                            .ConfigureAwait(false);
+                        await Task.Run(() => MergeDirectory(extractPath, target, journal), ct).ConfigureAwait(false);
+                        break;
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex) when (attempt < MaxInstallAttempts)
+                    {
+                        // Real-time antivirus holds freshly written files open for a beat, which is
+                        // the common way a download that arrived intact still fails to install.
+                        App.Logger?.Warning(
+                            "ReleaseContentService: install of {Pack} failed on attempt {Attempt}/{Max} ({Error}) — retrying in {Seconds}s",
+                            packId, attempt, MaxInstallAttempts, ex.Message, (int)InstallRetryDelay.TotalSeconds);
+                        await Task.Delay(InstallRetryDelay, ct).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // Out of attempts: pull this merge's files back out so the pack reads as
+                        // clearly missing next launch instead of "present" over half a payload.
+                        RollbackMerge(journal, packId);
+                        throw;
+                    }
+                }
 
                 TryDeleteDirectory(extractPath);
                 TryDeleteFile(partialPath);
@@ -921,13 +962,20 @@ namespace ConditioningControlPanel.Services
         /// <see cref="Directory.Move"/> when the target does not exist (both live under LOCALAPPDATA,
         /// so it is a same-volume rename); otherwise a recursive file-by-file overwrite so an update
         /// replaces changed files without orphaning the rest.
+        ///
+        /// Everything it writes goes into <paramref name="journal"/> so a failure part-way through
+        /// can be taken back out — see <see cref="MergeJournal"/>.
         /// </summary>
-        private static void MergeDirectory(string source, string target)
+        private static void MergeDirectory(string source, string target, MergeJournal journal)
         {
             if (!Directory.Exists(target))
             {
                 var parent = Path.GetDirectoryName(target);
-                if (!string.IsNullOrEmpty(parent)) Directory.CreateDirectory(parent);
+                if (!string.IsNullOrEmpty(parent)) CreateDirectoryTracked(parent, journal);
+
+                // Recorded BEFORE the rename: nothing else can own a tree that did not exist a
+                // moment ago, so on failure it comes out whole regardless of how far Move got.
+                journal.RecordTree(target);
                 Directory.Move(source, target);
                 return;
             }
@@ -935,7 +983,7 @@ namespace ConditioningControlPanel.Services
             foreach (var dir in Directory.GetDirectories(source, "*", SearchOption.AllDirectories))
             {
                 var rel = Path.GetRelativePath(source, dir);
-                Directory.CreateDirectory(Path.Combine(target, rel));
+                CreateDirectoryTracked(Path.Combine(target, rel), journal);
             }
 
             foreach (var file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
@@ -943,8 +991,48 @@ namespace ConditioningControlPanel.Services
                 var rel = Path.GetRelativePath(source, file);
                 var dest = Path.Combine(target, rel);
                 var destDir = Path.GetDirectoryName(dest);
-                if (!string.IsNullOrEmpty(destDir)) Directory.CreateDirectory(destDir);
+                if (!string.IsNullOrEmpty(destDir)) CreateDirectoryTracked(destDir, journal);
                 File.Copy(file, dest, overwrite: true);
+                journal.RecordFile(dest);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="Directory.CreateDirectory"/> that tells <paramref name="journal"/> about every
+        /// folder it actually had to create, so a rollback removes only the ones this merge
+        /// introduced and never a shared folder that was already there.
+        /// </summary>
+        private static void CreateDirectoryTracked(string path, MergeJournal journal)
+        {
+            if (string.IsNullOrEmpty(path) || Directory.Exists(path)) return;
+
+            // The missing ancestors count too: CreateDirectory makes the whole chain in one call,
+            // and a rollback that only knew the leaf would leave the empty chain above it behind.
+            var parent = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(parent)) CreateDirectoryTracked(parent, journal);
+
+            Directory.CreateDirectory(path);
+            journal.RecordDirectory(path);
+        }
+
+        /// <summary>
+        /// Undoes a merge that threw part-way, so the pack converges back to "clearly missing" and
+        /// the next launch's floor probe re-fetches it. Never throws.
+        /// </summary>
+        private static void RollbackMerge(MergeJournal journal, string packId)
+        {
+            try
+            {
+                if (journal.IsEmpty) return;
+
+                var removed = journal.Rollback();
+                App.Logger?.Warning(
+                    "ReleaseContentService: rolled back the failed {Pack} install — removed {Removed} merged file(s) so the next launch re-fetches",
+                    packId, removed);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ReleaseContentService: rollback of the failed {Pack} install did not complete", packId);
             }
         }
 

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -385,12 +385,18 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>Accepts both the envelope form ({ packs: [...] }) and a bare array.</summary>
-        private static List<ContentPackInfo>? ParseManifest(string json)
+        internal static List<ContentPackInfo>? ParseManifest(string json)
         {
             if (string.IsNullOrWhiteSpace(json)) return null;
             try
             {
-                var token = JToken.Parse(json);
+                // The published manifest carries a UTF-8 BOM. ReadAsStringAsync strips it today, but
+                // JToken.Parse rejects a leading U+FEFF outright, so whether every user's content
+                // packs resolve must not hinge on how the bytes happened to be decoded.
+                var trimmed = json.TrimStart('\uFEFF', '\u200B', ' ', '\t', '\r', '\n');
+                if (trimmed.Length == 0) return null;
+
+                var token = JToken.Parse(trimmed);
                 if (token is JArray array)
                     return array.ToObject<List<ContentPackInfo>>();
 

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -102,6 +102,14 @@ namespace ConditioningControlPanel.Services
         private static readonly TimeSpan InstallRetryDelay = TimeSpan.FromSeconds(5);
 
         /// <summary>
+        /// Multiple of a pack's advertised size that must be free before an install starts: the
+        /// <c>.partial</c> zip, the extract staging tree and the merged copies all coexist on the
+        /// same drive at peak. Running out mid-merge is the other half of the wedge story — it is
+        /// what leaves a part-copied payload behind.
+        /// </summary>
+        private const int InstallFreeSpaceFactor = 3;
+
+        /// <summary>
         /// Bound on the (tiny) manifest GET. <see cref="HttpClient.Timeout"/> is sized for a 380 MB
         /// pack, so without this a black-holing network would leave the picker "not offline yet" for
         /// half an hour. Downloads keep the long timeout — they have their own retry ladder.
@@ -633,6 +641,12 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Information("ReleaseContentService: offline mode — pack {Pack} download skipped", packId);
                 return false;
             }
+            if (!HasRoomForPack(info))
+            {
+                // Fail here, not 380 MB in: a merge that runs out of disk is precisely the failure
+                // that strands a half-copied payload in the live content tree.
+                return false;
+            }
 
             var baseUrl = _resolvedBaseUrl ?? BaseUrl;
             var url = baseUrl + Uri.EscapeDataString(info.File);
@@ -1095,6 +1109,55 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "ReleaseContentService: could not persist install stamp for {Pack}", info.Id);
+            }
+        }
+
+        /// <summary>
+        /// Peak bytes an install of this size occupies on the content drive — see
+        /// <see cref="InstallFreeSpaceFactor"/>. Zero for a manifest entry with no size, which the
+        /// caller reads as "cannot judge, proceed".
+        /// </summary>
+        internal static long RequiredFreeBytes(long sizeBytes)
+        {
+            if (sizeBytes <= 0) return 0;
+            // A tampered manifest must not overflow this into a negative "plenty of room".
+            if (sizeBytes > long.MaxValue / InstallFreeSpaceFactor) return long.MaxValue;
+            return sizeBytes * InstallFreeSpaceFactor;
+        }
+
+        /// <summary>False only when the drive demonstrably cannot hold the install.</summary>
+        internal static bool HasEnoughFreeSpace(long sizeBytes, long availableBytes)
+            => availableBytes >= RequiredFreeBytes(sizeBytes);
+
+        /// <summary>
+        /// Free-space gate for a pack install. A probe that cannot answer (unknown size, network
+        /// path, drive not ready) says yes — a wrong "no space" would lock a user out of content
+        /// they have the disk for, which is worse than the disk error it was trying to pre-empt.
+        /// </summary>
+        private static bool HasRoomForPack(ContentPackInfo info)
+        {
+            try
+            {
+                if (info.SizeBytes <= 0) return true;
+
+                var driveRoot = Path.GetPathRoot(Path.GetFullPath(ContentRoot));
+                if (string.IsNullOrEmpty(driveRoot)) return true;
+
+                var drive = new DriveInfo(driveRoot);
+                if (!drive.IsReady) return true;
+
+                var available = drive.AvailableFreeSpace;
+                if (HasEnoughFreeSpace(info.SizeBytes, available)) return true;
+
+                App.Logger?.Error(
+                    "ReleaseContentService: not enough free space for pack {Pack} on {Drive} — needs {Required} bytes ({Factor}x its {Size}-byte zip for partial + extract + merged copies), {Available} available",
+                    info.Id, drive.Name, RequiredFreeBytes(info.SizeBytes), InstallFreeSpaceFactor, info.SizeBytes, available);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ReleaseContentService: free-space probe for {Pack} failed: {Error}", info.Id, ex.Message);
+                return true;
             }
         }
 

--- a/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
+++ b/ConditioningControlPanel/Services/Content/ReleaseContentService.cs
@@ -993,10 +993,11 @@ namespace ConditioningControlPanel.Services
                 var parent = Path.GetDirectoryName(target);
                 if (!string.IsNullOrEmpty(parent)) CreateDirectoryTracked(parent, journal);
 
-                // Recorded BEFORE the rename: nothing else can own a tree that did not exist a
-                // moment ago, so on failure it comes out whole regardless of how far Move got.
-                journal.RecordTree(target);
                 Directory.Move(source, target);
+                // Recorded AFTER the rename: a failed same-volume rename leaves nothing at the
+                // target to undo, while recording first would let a concurrent pack populate
+                // the tree in the retry window and lose its files to the recursive rollback.
+                journal.RecordTree(target);
                 return;
             }
 
@@ -1046,6 +1047,12 @@ namespace ConditioningControlPanel.Services
                 if (journal.IsEmpty) return;
 
                 var removed = journal.Rollback();
+                // A failed UPDATE can roll back files the merge overwrote — i.e. a previously
+                // WORKING install. The old stamp would then keep IsInstalled answering true
+                // (and HasInstalledPayload sees a shared content root other packs populated),
+                // hiding the gutted pack from ResolveMissingActiveModPack's media probe. Drop
+                // the stamp so the rolled-back state reads as what it is: not installed.
+                DropInstallStamp(packId);
                 App.Logger?.Warning(
                     "ReleaseContentService: rolled back the failed {Pack} install — removed {Removed} merged file(s) so the next launch re-fetches",
                     packId, removed);
@@ -1053,6 +1060,46 @@ namespace ConditioningControlPanel.Services
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "ReleaseContentService: rollback of the failed {Pack} install did not complete", packId);
+            }
+        }
+
+        /// <summary>
+        /// Removes a pack's install stamp after a rollback. Same UI-thread marshalling contract
+        /// as <see cref="RecordInstalled"/> (plain Dictionary + UI-thread Save assumption).
+        /// On dispatcher shutdown the stamp survives — acceptable: rollback already removed the
+        /// files, so the next launch's media probe still triggers the re-fetch for the active
+        /// mod, and the Mod Manager path re-verifies via NeedsUpdate.
+        /// </summary>
+        private static void DropInstallStamp(string packId)
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null) return;
+
+                void Apply()
+                {
+                    try
+                    {
+                        if (settings.InstalledContentPacks.Remove(packId))
+                            App.Settings?.Save();
+                    }
+                    catch (Exception ex)
+                    {
+                        App.Logger?.Warning(ex, "ReleaseContentService: could not drop install stamp for {Pack}", packId);
+                    }
+                }
+
+                var dispatcher = System.Windows.Application.Current?.Dispatcher;
+                if (dispatcher == null) { Apply(); return; }
+                if (dispatcher.HasShutdownStarted) return;
+
+                if (dispatcher.CheckAccess()) Apply();
+                else dispatcher.Invoke(Apply);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ReleaseContentService: could not drop install stamp for {Pack}", packId);
             }
         }
 
@@ -1350,10 +1397,11 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>
         /// True when a built-in mod's media is present WITHOUT its pack being stamped — the surviving
-        /// state of an in-place upgrade. Both shapes the packs take feed ONE count: an extracted
-        /// <c>.ccpmod</c> tree (drone, locked) and loose companion audio (bambi, sissy, locked). A
-        /// half-merged install leaves debris in either, so neither shape may vote "present" on its
-        /// structure alone — see <see cref="MinModMediaFiles"/>.
+        /// state of an in-place upgrade. The packs take two shapes — an extracted <c>.ccpmod</c> tree
+        /// (drone, locked) and loose companion audio (bambi, sissy, locked) — and each shape must
+        /// clear <see cref="MinModMediaFiles"/> ON ITS OWN: summing them would let two half-merged
+        /// debris trees vote "present" together (healthy installs clear the floor 7-40× in whichever
+        /// shape they actually ship).
         ///
         /// A probe failure answers "missing": a needless re-download costs bandwidth once, a probe
         /// that answers "present" whenever it breaks wedges the user voiceless forever.
@@ -1366,18 +1414,19 @@ namespace ConditioningControlPanel.Services
                 // 1) Extracted .ccpmod payload, under the root ModService.PrepareBuiltInMod fills.
                 var extractDir = Path.Combine(App.UserDataPath, "builtin_mods", modId);
                 if (Directory.Exists(extractDir))
-                    count = CountMediaFiles(SafeEnumerateFiles(extractDir), MinModMediaFiles);
-
-                // 2) Loose companion audio. ContentLocator covers both roots.
-                if (count < MinModMediaFiles)
                 {
-                    var relAudio = Path.Combine("Resources", "sounds", "companion_audio", "mods", modId);
-                    count += CountMediaFiles(
-                        ContentLocator.EnumerateFiles(relAudio, "*", SearchOption.AllDirectories),
-                        MinModMediaFiles - count);
+                    count = CountMediaFiles(SafeEnumerateFiles(extractDir), MinModMediaFiles);
+                    if (count >= MinModMediaFiles) return true;
                 }
 
-                if (count >= MinModMediaFiles) return true;
+                // 2) Loose companion audio. ContentLocator covers both roots.
+                var relAudio = Path.Combine("Resources", "sounds", "companion_audio", "mods", modId);
+                var audioCount = CountMediaFiles(
+                    ContentLocator.EnumerateFiles(relAudio, "*", SearchOption.AllDirectories),
+                    MinModMediaFiles);
+                if (audioCount >= MinModMediaFiles) return true;
+
+                count = Math.Max(count, audioCount);   // for the log line below
             }
             catch (Exception ex)
             {

--- a/Tests/ConditioningControlPanel.Tests/ContentFreeSpaceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ContentFreeSpaceTests.cs
@@ -1,0 +1,46 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// A merge that runs the drive out of space part-way is one of the two root causes behind the
+/// failed pack installs that stranded v6.6.4 users — and the one that leaves half a payload behind.
+/// These pin the arithmetic of the gate that now refuses the install before the download starts.
+/// </summary>
+public class ContentFreeSpaceTests
+{
+    [Fact]
+    public void ThePackIsBudgetedThreeTimesOver()
+    {
+        // .partial zip + extract staging + merged copies all coexist at peak.
+        Assert.Equal(300, ReleaseContentService.RequiredFreeBytes(100));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void AnUnsizedManifestEntryIsNotJudged(long sizeBytes)
+    {
+        // No size to reason about means no grounds to block: proceed and let the IO speak.
+        Assert.Equal(0, ReleaseContentService.RequiredFreeBytes(sizeBytes));
+        Assert.True(ReleaseContentService.HasEnoughFreeSpace(sizeBytes, 0));
+    }
+
+    [Theory]
+    [InlineData(100L, 299L, false)]
+    [InlineData(100L, 300L, true)]   // exactly enough is enough
+    [InlineData(100L, 301L, true)]
+    [InlineData(380L * 1024 * 1024, 1024L * 1024 * 1024, false)]  // a 380 MB pack needs 1.14 GB
+    [InlineData(380L * 1024 * 1024, 4L * 1024 * 1024 * 1024, true)]
+    public void SpaceIsCheckedAgainstThePeak(long sizeBytes, long available, bool expected)
+        => Assert.Equal(expected, ReleaseContentService.HasEnoughFreeSpace(sizeBytes, available));
+
+    [Fact]
+    public void AnAbsurdManifestSizeSaturatesInsteadOfWrappingNegative()
+    {
+        // A tampered/garbled size must not overflow into "plenty of room".
+        Assert.Equal(long.MaxValue, ReleaseContentService.RequiredFreeBytes(long.MaxValue));
+        Assert.False(ReleaseContentService.HasEnoughFreeSpace(long.MaxValue, long.MaxValue - 1));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/ContentManifestParseTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ContentManifestParseTests.cs
@@ -1,0 +1,51 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// content-manifest.json decides whether ANY pack is reachable, so nothing incidental about the
+/// bytes may sink it. The live file is served with a UTF-8 BOM and JToken.Parse rejects a leading
+/// U+FEFF outright; today's ReadAsStringAsync strips it, but that must not be the only thing
+/// standing between a user and their voice lines.
+/// </summary>
+public class ContentManifestParseTests
+{
+    private const string EnvelopeJson =
+        "{\"schemaVersion\":1,\"cycle\":\"v6.6.0\",\"packs\":[" +
+        "{\"id\":\"audio-base\",\"file\":\"audio-base.zip\",\"sizeBytes\":123,\"contentVersion\":2}]}";
+
+    private const string ArrayJson =
+        "[{\"id\":\"mod-bambi\",\"file\":\"mod-bambi.zip\",\"sizeBytes\":456}]";
+
+    [Fact]
+    public void EnvelopeFormParses()
+    {
+        var packs = ReleaseContentService.ParseManifest(EnvelopeJson);
+        Assert.NotNull(packs);
+        Assert.Equal("audio-base", Assert.Single(packs!).Id);
+    }
+
+    [Fact]
+    public void BareArrayFormParses()
+        => Assert.Equal("mod-bambi", Assert.Single(ReleaseContentService.ParseManifest(ArrayJson)!).Id);
+
+    [Theory]
+    [InlineData("\uFEFF")]        // the live manifest is served with a UTF-8 BOM
+    [InlineData("\uFEFF\r\n  ")]
+    [InlineData("  \t\r\n")]
+    [InlineData("\u200B")]
+    public void ALeadingBomOrWhitespaceNeverDecidesWhetherPacksResolve(string prefix)
+    {
+        Assert.Equal("audio-base", Assert.Single(ReleaseContentService.ParseManifest(prefix + EnvelopeJson)!).Id);
+        Assert.Equal("mod-bambi", Assert.Single(ReleaseContentService.ParseManifest(prefix + ArrayJson)!).Id);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\uFEFF")]
+    [InlineData("not json at all")]
+    public void JunkParsesToNullRatherThanThrowing(string json)
+        => Assert.Null(ReleaseContentService.ParseManifest(json));
+}

--- a/Tests/ConditioningControlPanel.Tests/ContentMediaFloorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ContentMediaFloorTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// v6.6.4's installer deletes the bundled media and the packs bring it back, so the "has this mod
+/// got its media?" probe decides whether a user gets their voice back. The old answer was
+/// ".Any() over *.mp3", which ONE file surviving a half-merged install satisfied forever. These
+/// pin the counting floor that replaced it.
+/// </summary>
+public class ContentMediaFloorTests
+{
+    private static IEnumerable<string> Media(int count, string ext = ".mp3")
+        => Enumerable.Range(0, count).Select(i => $@"C:\content\Resources\sounds\clip{i}{ext}");
+
+    // ---- what counts ----
+
+    [Theory]
+    [InlineData(".mp3")]
+    [InlineData(".wav")]
+    [InlineData(".ogg")]
+    [InlineData(".m4a")]
+    [InlineData(".png")]   // portraits break the mod just as visibly as silence does
+    [InlineData(".PNG")]   // NTFS is case-insensitive; the probe must be too
+    public void MediaExtensionsCount(string ext)
+        => Assert.Equal(3, ReleaseContentService.CountMediaFiles(Media(3, ext)));
+
+    [Theory]
+    [InlineData(".json")]  // bark_rules.json / mantras.json STAY in the installer — never payload
+    [InlineData(".txt")]
+    [InlineData(".dll")]
+    [InlineData("")]
+    public void NonMediaDoesNot(string ext)
+        => Assert.Equal(0, ReleaseContentService.CountMediaFiles(Media(3, ext)));
+
+    [Fact]
+    public void NullAndEmptyEntriesAreSkippedRatherThanThrowing()
+        => Assert.Equal(1, ReleaseContentService.CountMediaFiles(
+            new string[] { null!, "", "   ", @"C:\a\voice.mp3" }));
+
+    [Fact]
+    public void NullSequenceCountsZero()
+        => Assert.Equal(0, ReleaseContentService.CountMediaFiles(null));
+
+    // ---- the floor itself ----
+
+    [Fact]
+    public void OneSurvivingFileIsNotAnInstall()
+    {
+        // The exact v6.6.4 wedge: partial debris must read as missing so the pack re-fetches.
+        Assert.True(ReleaseContentService.CountMediaFiles(Media(1)) < ReleaseContentService.MinModMediaFiles);
+        Assert.True(ReleaseContentService.CountMediaFiles(Media(12)) < ReleaseContentService.MinModMediaFiles);
+    }
+
+    [Fact]
+    public void AHealthyTreeClearsTheFloorWithRoomToSpare()
+    {
+        // Real trees: 390+ files extracted per built-in mod, 1,400-2,000 loose companion audio.
+        Assert.True(ReleaseContentService.CountMediaFiles(Media(390), ReleaseContentService.MinModMediaFiles)
+                    >= ReleaseContentService.MinModMediaFiles);
+        Assert.True(ReleaseContentService.MinModMediaFiles < 390);
+    }
+
+    // ---- the short-circuit ----
+
+    [Fact]
+    public void CountingStopsAtTheFloor()
+        => Assert.Equal(ReleaseContentService.MinModMediaFiles,
+            ReleaseContentService.CountMediaFiles(Media(5000), ReleaseContentService.MinModMediaFiles));
+
+    [Fact]
+    public void ShortCircuitNeverInflatesAnUnderCount()
+    {
+        // The log line quotes this number to support, so a capped count must still be EXACT
+        // whenever it lands below the cap — which is the only case that gets logged.
+        for (var n = 0; n < ReleaseContentService.MinModMediaFiles; n++)
+            Assert.Equal(n, ReleaseContentService.CountMediaFiles(Media(n), ReleaseContentService.MinModMediaFiles));
+    }
+
+    [Fact]
+    public void NonPositiveStopAtCountsNothing()
+    {
+        // The two-shape probe passes `floor - count` as the remaining budget; a zero budget must
+        // not walk thousands of paths for an answer it already has.
+        Assert.Equal(0, ReleaseContentService.CountMediaFiles(Media(100), 0));
+        Assert.Equal(0, ReleaseContentService.CountMediaFiles(Media(100), -1));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/ContentMergeRollbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ContentMergeRollbackTests.cs
@@ -183,8 +183,8 @@ public class ContentMergeRollbackTests
     [Fact]
     public void RollbackIsIdempotent()
     {
-        // The generic install catch can reach the cleanup twice; a second pass must be a no-op
-        // rather than an exception out of a path that is already handling a failure.
+        // RollbackMerge runs once today, but rollback executes inside a path that is already
+        // handling a failure — a second pass must stay a harmless no-op, never a new throw.
         var root = NewTempDir();
         try
         {

--- a/Tests/ConditioningControlPanel.Tests/ContentMergeRollbackTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ContentMergeRollbackTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// A pack merge that threw part-way used to leave whatever it had already copied in the live
+/// content tree — the debris that makes a broken pack read as "present" and wedges it out of ever
+/// being re-fetched. These pin the journal that takes it back out, and above all the constraint
+/// that makes the whole thing delicate: every loose-media pack merges into the SHARED
+/// content\Resources, so a rollback must never remove a file it did not write.
+/// </summary>
+public class ContentMergeRollbackTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ccp-665-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string Touch(string dir, string relPath, string content = "x")
+    {
+        var full = Path.Combine(dir, relPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    // ---- bookkeeping ----
+
+    [Fact]
+    public void AFreshJournalHasNothingToUndo()
+        => Assert.True(new MergeJournal().IsEmpty);
+
+    [Fact]
+    public void RecordingKeepsWriteOrderAndDropsRepeats()
+    {
+        // The retry pass re-merges over the first attempt's work and re-records the same paths.
+        var journal = new MergeJournal();
+        journal.RecordFile(@"C:\c\a.mp3");
+        journal.RecordFile(@"C:\c\b.mp3");
+        journal.RecordFile(@"C:\c\a.mp3");
+        journal.RecordFile(@"C:\C\A.MP3");   // NTFS is case-insensitive
+
+        Assert.Equal(new[] { @"C:\c\a.mp3", @"C:\c\b.mp3" }, journal.Files.ToArray());
+    }
+
+    [Fact]
+    public void FilesDirectoriesAndTreesAreTrackedApart()
+    {
+        var journal = new MergeJournal();
+        journal.RecordFile(@"C:\c\a.mp3");
+        journal.RecordDirectory(@"C:\c\sub");
+        journal.RecordTree(@"C:\c\whole");
+
+        Assert.False(journal.IsEmpty);
+        Assert.Single(journal.Files);
+        Assert.Single(journal.Directories);
+        Assert.Single(journal.Trees);
+    }
+
+    [Fact]
+    public void EmptyPathsAreIgnored()
+    {
+        var journal = new MergeJournal();
+        journal.RecordFile("");
+        journal.RecordDirectory("");
+        journal.RecordTree(null!);
+
+        Assert.True(journal.IsEmpty);
+    }
+
+    // ---- the undo ----
+
+    [Fact]
+    public void RollbackRemovesExactlyTheFilesTheMergeWrote()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var stranger = Touch(root, @"Resources\sounds\another-packs-file.mp3");
+            var mine = Touch(root, @"Resources\sounds\mine.mp3");
+
+            var journal = new MergeJournal();
+            journal.RecordFile(mine);
+
+            Assert.Equal(1, journal.Rollback());
+            Assert.False(File.Exists(mine));
+            Assert.True(File.Exists(stranger), "rollback took a file that belonged to another pack");
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void RollbackRemovesOnlyTheDirectoriesItCreated_AndOnlyOnceEmpty()
+    {
+        var root = NewTempDir();
+        try
+        {
+            // Shared: predates the merge and keeps a stranger's file. Mine: created by the merge.
+            var shared = Path.Combine(root, "Resources");
+            var stranger = Touch(root, @"Resources\another.mp3");
+            var mineDir = Path.Combine(shared, "mods", "builtin-bambisleep");
+            var mine = Touch(root, @"Resources\mods\builtin-bambisleep\voice.mp3");
+
+            var journal = new MergeJournal();
+            journal.RecordDirectory(Path.Combine(shared, "mods"));
+            journal.RecordDirectory(mineDir);
+            journal.RecordFile(mine);
+
+            journal.Rollback();
+
+            Assert.False(Directory.Exists(mineDir));
+            Assert.False(Directory.Exists(Path.Combine(shared, "mods")), "the empty parent chain was left behind");
+            Assert.True(Directory.Exists(shared), "rollback removed a directory it did not create");
+            Assert.True(File.Exists(stranger));
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void ADirectoryThatStillHoldsSomeoneElsesFileSurvives()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var dir = Path.Combine(root, "Resources", "sounds");
+            var mine = Touch(root, @"Resources\sounds\mine.mp3");
+            var stranger = Touch(root, @"Resources\sounds\theirs.mp3");
+
+            var journal = new MergeJournal();
+            journal.RecordDirectory(dir);
+            journal.RecordFile(mine);
+
+            journal.Rollback();
+
+            Assert.True(Directory.Exists(dir));
+            Assert.True(File.Exists(stranger));
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void ATreeCreatedWholesaleComesOutWholesale()
+    {
+        // The rename fast path: the target did not exist, so nothing in it belongs to anyone else.
+        var root = NewTempDir();
+        try
+        {
+            var tree = Path.Combine(root, "packs");
+            Touch(root, @"packs\a.ccpmod");
+            Touch(root, @"packs\nested\b.mp3");
+
+            var journal = new MergeJournal();
+            journal.RecordTree(tree);
+
+            Assert.Equal(2, journal.Rollback());
+            Assert.False(Directory.Exists(tree));
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void AlreadyGoneEntriesAreNotCountedAndDoNotThrow()
+    {
+        var root = NewTempDir();
+        try
+        {
+            var journal = new MergeJournal();
+            journal.RecordFile(Path.Combine(root, "never-written.mp3"));
+            journal.RecordDirectory(Path.Combine(root, "never-made"));
+            journal.RecordTree(Path.Combine(root, "never-moved"));
+
+            Assert.Equal(0, journal.Rollback());
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void RollbackIsIdempotent()
+    {
+        // The generic install catch can reach the cleanup twice; a second pass must be a no-op
+        // rather than an exception out of a path that is already handling a failure.
+        var root = NewTempDir();
+        try
+        {
+            var mine = Touch(root, @"Resources\mine.mp3");
+            var journal = new MergeJournal();
+            journal.RecordFile(mine);
+
+            Assert.Equal(1, journal.Rollback());
+            Assert.Equal(0, journal.Rollback());
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+
+    [Fact]
+    public void DeepChainsUnwindChildBeforeParent()
+    {
+        // Directories are recorded parents-first; the undo has to walk them the other way or the
+        // parent is still non-empty when it is tried.
+        var root = NewTempDir();
+        try
+        {
+            var journal = new MergeJournal();
+            var path = root;
+            foreach (var segment in new[] { "a", "b", "c", "d" })
+            {
+                path = Path.Combine(path, segment);
+                Directory.CreateDirectory(path);
+                journal.RecordDirectory(path);
+            }
+            var leaf = Touch(root, @"a\b\c\d\voice.mp3");
+            journal.RecordFile(leaf);
+
+            journal.Rollback();
+
+            Assert.False(Directory.Exists(Path.Combine(root, "a")));
+            Assert.True(Directory.Exists(root));
+        }
+        finally { try { Directory.Delete(root, true); } catch { } }
+    }
+}


### PR DESCRIPTION
Emergency fix set for the v6.6.4 content-pack incident (#823 and the Discord "AI is lobotomized" wave - the silent-companion half; the gibberish half was the OpenRouter Parasail endpoint, already fixed server-side).

## Root cause recap
The 6.6.4 installer deletes 8,429 bundled media files (that's the 1,597→637MB diet) and `ReleaseContentService` re-downloads them as packs. But:
- `HasModMediaOnDisk` was a `.Any()` probe: **one leftover file from a failed merge read as "media present" forever**, permanently blocking the re-fetch (and its catch returned *true* = "don't download")
- failed merges left debris in the shared content root with no rollback
- no disk-space guard existed anywhere (mod-sissy peaks at ~1GB during install)
- extraction/merge sat outside the retry ladder, so one AV file-lock killed the install for the whole launch

## Fixes
1. **Count-based media floor** (`MinModMediaFiles = 50`, includes .png for portraits) applied to both pack shapes - each shape must clear the floor on its own; exception → "missing" (re-fetch); one log line with the exact count for support
2. **MergeJournal rollback** - a failed install removes exactly the files it wrote (shared `content\Resources` root is never swept), and **drops the install stamp** so a failed update can't hide a gutted pack behind `IsInstalled`
3. **Disk-space precheck** (3× pack size, fails open on probe errors) + **extract/merge retry** (2 attempts, 5s apart) for AV lock storms
4. **BOM-tolerant manifest parsing** (the live manifest ships a UTF-8 BOM; one encoding change away from a silent global outage)

## Review
Independent Opus review ran before push; its three findings (stamp-drop on rollback, tree-record ordering on the Move fast path, per-shape floor) are fixed in the last commit. Follow-ups ticketed rather than crammed in: `HasInstalledPayload` cross-pack false positive, cancelled-mid-merge debris, `.gif/.webp` in the media extension list, redirected-LOCALAPPDATA disk probe, distinct "disk full" error state.

## Verification
- `dotnet build`: 0 errors · `dotnet test`: **1008 passed / 0 failed** (+47 new)
- User-side workaround already circulating (Mod Manager → mod → Download) remains valid and is unaffected
- Play-test before merge: upgrade a 6.6.3 install, kill the app mid-download, relaunch → it must re-fetch and complete; then delete half a mod's audio files, relaunch → re-fetch queued (watch for the new `queueing a pack re-fetch` log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue