### PR TITLE
fix: frozen Sissy portraits, truncated-tag garbage in bubbles, and the mod picker that never picked

### DIFF
--- a/ConditioningControlPanel/Dialogs/ModPickerDialog.xaml.cs
+++ b/ConditioningControlPanel/Dialogs/ModPickerDialog.xaml.cs
@@ -177,6 +177,7 @@ namespace ConditioningControlPanel
     public partial class ModPickerDialog : Window
     {
         private readonly ObservableCollection<ModPickerCard> _cards = new();
+        private readonly string? _preselectModId;
         private bool _offline;
         private bool _downloading;
         private bool _finished;
@@ -191,6 +192,10 @@ namespace ConditioningControlPanel
         {
             InitializeComponent();
 
+            // Kept for BtnDownload_Click: a preselect means an UPGRADER restoring media for the
+            // mod they already run - never auto-switch them (queue[0] is catalogue order, so a
+            // Sissy upgrader who also ticks Bambi would get demoted onto Bambi otherwise).
+            _preselectModId = preselectModId;
             BuildCards(preselectModId);
             CardsList.ItemsSource = _cards;
 
@@ -465,10 +470,16 @@ namespace ConditioningControlPanel
             // on CCP Default after a 300 MB download. Pressing the button is the explicit choice, so
             // this is the only place the intent is ever recorded, and with several ticked the first in
             // catalogue order is the one they land on. The switch happens as soon as the content
-            // exists: right now if it is already on disk, otherwise when the pack lands - even after
-            // this dialog is gone, or in a later session.
-            PendingModActivation.Record(queue[0].ModId);
-            PendingModActivation.ApplyIfReady(PendingModActivation.Trigger.Immediate);
+            // exists - even after this dialog is gone, or in a later session. UPGRADERS (preselect
+            // set) are only re-downloading media for the mod they already run: recording would
+            // switch them to whichever ticked pack finishes first, so their intent is never recorded.
+            if (_preselectModId == null)
+            {
+                PendingModActivation.Record(queue[0].ModId);
+                // Unreachable today (installed cards are filtered out of the queue above), kept as a
+                // belt in case the queue filter ever admits an already-on-disk pack.
+                PendingModActivation.ApplyIfReady(PendingModActivation.Trigger.Immediate);
+            }
 
             _downloading = true;
             BtnDownload.IsEnabled = false;

--- a/ConditioningControlPanel/Dialogs/ModPickerDialog.xaml.cs
+++ b/ConditioningControlPanel/Dialogs/ModPickerDialog.xaml.cs
@@ -461,6 +461,15 @@ namespace ConditioningControlPanel
                 return;
             }
 
+            // Choosing a mod here MEANS choosing to run it - the picker used to leave a first-run user
+            // on CCP Default after a 300 MB download. Pressing the button is the explicit choice, so
+            // this is the only place the intent is ever recorded, and with several ticked the first in
+            // catalogue order is the one they land on. The switch happens as soon as the content
+            // exists: right now if it is already on disk, otherwise when the pack lands - even after
+            // this dialog is gone, or in a later session.
+            PendingModActivation.Record(queue[0].ModId);
+            PendingModActivation.ApplyIfReady(PendingModActivation.Trigger.Immediate);
+
             _downloading = true;
             BtnDownload.IsEnabled = false;
             BtnDownload.Opacity = 0.45;

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -1712,12 +1712,54 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// Activates the mod the user chose in the first-run picker, now that its content is on disk.
+        /// Deliberately routed through the SAME two steps as the top-bar combo (ActivateMod +
+        /// <see cref="ApplyActiveModChange"/>) rather than a parallel switching path.
+        /// Called on the UI thread by <see cref="PendingModActivation"/>; never throws back into the
+        /// pack-install callback that triggered it.
+        /// </summary>
+        internal void ActivateChosenMod(string modId, PendingModActivation.Trigger trigger)
+        {
+            try
+            {
+                if (App.Mods == null || string.IsNullOrWhiteSpace(modId)) return;
+
+                App.Mods.ActivateMod(modId);
+                if (!string.Equals(App.Mods.ActiveModId, modId, StringComparison.OrdinalIgnoreCase))
+                {
+                    // ActivateMod refuses ids it doesn't know yet (registration can trail the pack).
+                    // Keep the choice pending so the next availability signal retries it.
+                    App.Logger?.Warning("[ModPicker] {ModId} could not be activated yet - keeping the choice pending", modId);
+                    return;
+                }
+
+                ApplyActiveModChange(fromPickerChoice: true);
+                PendingModActivation.Clear("activated");
+
+                App.Logger?.Information(
+                    "[ModPicker] Auto-activated the mod chosen in the first-run picker: {ModId} (trigger: {Trigger})",
+                    modId, trigger);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[ModPicker] Failed to activate the chosen mod {ModId}", modId);
+            }
+        }
+
+        /// <summary>
         /// Centralized refresh of mod-aware UI after the active mod changes.
         /// Called by both the top-bar ComboBox and the Manage Mods dialog return path.
         /// </summary>
-        private void ApplyActiveModChange()
+        /// <param name="fromPickerChoice">
+        /// True only for <see cref="ActivateChosenMod"/>. Every other caller is a MANUAL switch, which
+        /// outranks a first-run picker choice still waiting on its download - so the pending choice is
+        /// dropped rather than yanking the user off the mod they just picked by hand.
+        /// </param>
+        private void ApplyActiveModChange(bool fromPickerChoice = false)
         {
             if (App.Mods == null) return;
+
+            if (!fromPickerChoice) PendingModActivation.Clear("the user switched mods manually");
 
             App.Settings.Current.ActiveModId = App.Mods.ActiveModId;
             App.Settings.Current.ModChosen = true;
@@ -2098,6 +2140,11 @@ namespace ConditioningControlPanel
             // Wire the in-app notification surface. Anything App.Notifications.Show()'d
             // before this point is replayed on attach.
             App.Notifications?.AttachHost(NotificationHost);
+
+            // First-run picker: activate the mod the user chose there once its pack is on disk. Armed
+            // here rather than in the ctor because the switch repaints this window's tabs, and the
+            // resume case can fire the moment it is armed (download finished while the app was shut).
+            PendingModActivation.Attach(this);
 
             // Phase 1.6: legacy calibration prompt. Pre-multi-monitor-hotfix
             // saves have MonitorBounds without DeviceName, so the runtime

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -258,6 +258,20 @@ namespace ConditioningControlPanel.Models
             set { _modPickerOfflineOffers = value; OnPropertyChanged(); }
         }
 
+        private string _pendingModActivationId = "";
+        /// <summary>
+        /// Mod the user picked in the first-run mod picker whose content was still downloading, so it
+        /// could not be activated yet (<c>Services.PendingModActivation</c>). Persisted because the
+        /// download can outlive the session that started it — a restart mid-download still ends up on
+        /// the mod the user chose. Cleared once applied, and dropped the moment the user switches mods
+        /// by hand: a manual choice outranks a queued one.
+        /// </summary>
+        public string PendingModActivationId
+        {
+            get => _pendingModActivationId;
+            set { _pendingModActivationId = value ?? ""; OnPropertyChanged(); }
+        }
+
         private string _lastSeenVersion = "";
         /// <summary>
         /// Last version the user has seen patch notes for. Used to show "What's New" after updates.

--- a/ConditioningControlPanel/Services/AIService/AiResponseParser.cs
+++ b/ConditioningControlPanel/Services/AIService/AiResponseParser.cs
@@ -269,11 +269,9 @@ namespace ConditioningControlPanel.Services.AIService
             if (string.IsNullOrEmpty(response))
                 return response ?? string.Empty;
 
-            var sanitized = Regex.Replace(response, @"\[Category:[^\]]*\]", "", RegexOptions.IgnoreCase);
-            sanitized = Regex.Replace(sanitized, @"\[[A-Za-z]+/[A-Za-z]+\]", "", RegexOptions.IgnoreCase);
-            sanitized = Regex.Replace(sanitized, @"\[(?:Category|App|Title|Duration|Context):[^\]]*\]", "", RegexOptions.IgnoreCase);
-            sanitized = Regex.Replace(sanitized, @"\s{2,}", " ");
-            sanitized = sanitized.Trim();
+            // Closed metadata tags plus the unclosed ones the 100-token response cap truncates.
+            // Shared with AiService's cloud-path sanitizer so both strip the same set.
+            var sanitized = AiTextHygiene.StripMetadataTags(response);
 
             return string.IsNullOrWhiteSpace(sanitized) ? _fallbackProvider() : sanitized;
         }

--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -30,6 +30,53 @@ namespace ConditioningControlPanel.Services
             @"</(think|thinking|reasoning|thought)>",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        // Context metadata the model echoes back instead of answering, e.g.
+        // "[Category: Media | App: VLC | Title: ... | Duration: 12m]".
+        private static readonly Regex ClosedCategoryTag = new(
+            @"\[Category:[^\]]*\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Reaction category tags like [Media/Streaming] or [Gaming/Casual].
+        private static readonly Regex ReactionCategoryTag = new(
+            @"\[[A-Za-z]+/[A-Za-z]+\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Any standalone bracket tag that looks like metadata.
+        private static readonly Regex ClosedMetadataTag = new(
+            @"\[(?:Category|App|Title|Duration|Context):[^\]]*\]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Replies are hard-capped at 100 tokens, so a fabricated tag can be cut off before its closing
+        // bracket - and every pass above needs that bracket, so the fragment rendered raw in the bubble.
+        // Two end-of-string passes, because the cap can land anywhere:
+        //   1. a known metadata keyword, whether or not the colon survived the cut;
+        private static readonly Regex UnclosedKnownTag = new(
+            @"\[(?:Category|App|Title|Duration|Context)[^\]]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        //   2. anything shaped like "[Word:" for tags we haven't seen yet - production also showed a
+        //      fabricated "[Satisf: ...". The colon is what marks the fragment as metadata rather than
+        //      prose, so stage directions ("[giggles") and citations ("[3") survive while an unknown
+        //      "[Mood: playful" does not. Matching bare keyword prefixes instead (e.g. "[Cat") would
+        //      widen this to ordinary words, which is the one failure this must not have.
+        private static readonly Regex UnclosedKeyedTag = new(
+            @"\[[A-Za-z][A-Za-z0-9 _-]*:[^\]]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Strip leaked context-metadata tags, closed or truncated, then collapse the whitespace the
+        /// removal leaves behind. An empty result means the reply was nothing but metadata - the caller
+        /// decides what to say instead.
+        /// </summary>
+        internal static string StripMetadataTags(string? text)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
+
+            var sanitized = ClosedCategoryTag.Replace(text, "");
+            sanitized = ReactionCategoryTag.Replace(sanitized, "");
+            sanitized = ClosedMetadataTag.Replace(sanitized, "");
+            sanitized = UnclosedKnownTag.Replace(sanitized, "");
+            sanitized = UnclosedKeyedTag.Replace(sanitized, "");
+
+            sanitized = Regex.Replace(sanitized, @"\s{2,}", " ");
+            return sanitized.Trim();
+        }
+
         /// <summary>
         /// Strip tokenizer artifacts and reasoning blocks. Whitespace is normalised but the text is
         /// otherwise left alone - callers layer their own product-specific sanitising on top.

--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -45,10 +45,12 @@ namespace ConditioningControlPanel.Services
 
         // Replies are hard-capped at 100 tokens, so a fabricated tag can be cut off before its closing
         // bracket - and every pass above needs that bracket, so the fragment rendered raw in the bubble.
+        // Both passes exclude newlines: truncation can only land on the LAST line, and letting [^\]]
+        // cross \n would delete everything after a mid-reply bracket in a multi-line answer.
         // Two end-of-string passes, because the cap can land anywhere:
-        //   1. a known metadata keyword, whether or not the colon survived the cut;
+        //   1. a known metadata keyword (\b so "[Apple pie" isn't eaten by "App"), colon optional;
         private static readonly Regex UnclosedKnownTag = new(
-            @"\[(?:Category|App|Title|Duration|Context)[^\]]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            @"\[(?:Category|App|Title|Duration|Context)\b[^\]\r\n]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         //   2. anything shaped like "[Word:" for tags we haven't seen yet - production also showed a
         //      fabricated "[Satisf: ...". The colon is what marks the fragment as metadata rather than
@@ -56,7 +58,7 @@ namespace ConditioningControlPanel.Services
         //      "[Mood: playful" does not. Matching bare keyword prefixes instead (e.g. "[Cat") would
         //      widen this to ordinary words, which is the one failure this must not have.
         private static readonly Regex UnclosedKeyedTag = new(
-            @"\[[A-Za-z][A-Za-z0-9 _-]*:[^\]]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            @"\[[A-Za-z][A-Za-z0-9 _-]*:[^\]\r\n]*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// Strip leaked context-metadata tags, closed or truncated, then collapse the whitespace the

--- a/ConditioningControlPanel/Services/AiService.cs
+++ b/ConditioningControlPanel/Services/AiService.cs
@@ -461,18 +461,10 @@ namespace ConditioningControlPanel.Services
             // cleanup at all, so a reasoning model's scratchpad rendered verbatim into the bubble.
             response = AiTextHygiene.Clean(response);
 
-            // Remove context metadata tags like [Category: X | App: Y | Title: Z | Duration: Nm]
-            var sanitized = Regex.Replace(response, @"\[Category:[^\]]*\]", "", RegexOptions.IgnoreCase);
-
-            // Remove reaction category tags like [Media/Streaming] or [Gaming/Casual]
-            sanitized = Regex.Replace(sanitized, @"\[[A-Za-z]+/[A-Za-z]+\]", "", RegexOptions.IgnoreCase);
-
-            // Remove any standalone square bracket tags that look like metadata
-            sanitized = Regex.Replace(sanitized, @"\[(?:Category|App|Title|Duration|Context):[^\]]*\]", "", RegexOptions.IgnoreCase);
-
-            // Clean up any resulting double spaces or leading/trailing whitespace
-            sanitized = Regex.Replace(sanitized, @"\s{2,}", " ");
-            sanitized = sanitized.Trim();
+            // Remove context metadata tags like [Category: X | App: Y | Title: Z | Duration: Nm],
+            // reaction tags like [Media/Streaming], and the truncated variants the 100-token cap
+            // produces. Shared with the parser path so both stay in step.
+            var sanitized = AiTextHygiene.StripMetadataTags(response);
 
             // If sanitization removed everything meaningful, return a fallback
             if (string.IsNullOrWhiteSpace(sanitized))

--- a/ConditioningControlPanel/Services/Companion/AvatarPortraitLoader.cs
+++ b/ConditioningControlPanel/Services/Companion/AvatarPortraitLoader.cs
@@ -157,19 +157,31 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         private static bool CountsAsPresent(AvatarPortraitManifest manifest, string baseDir, string manifestPath)
         {
-            var basePose = string.IsNullOrEmpty(manifest.DefaultEmotion) ? manifest.IdleEmotion : manifest.DefaultEmotion;
-            // Only demand the base pose if the manifest actually declares it, so a manifest whose
-            // defaultEmotion is a typo still works off its other emotions (GetBucket already falls back).
-            bool needBasePose = manifest.Emotions.ContainsKey(basePose);
-            bool haveBasePose = !needBasePose;
-            int found = 0;
+            // The floor scales down for small manifests - a creator mod declaring 3 portraits must
+            // still be able to enter portrait mode. A missing base pose is deliberately NOT a gate:
+            // GetBucket's skin-0 -> idle fallback chain resolves a pose from whatever portraits
+            // exist, which is exactly the case that chain was built for.
+            int totalDeclared = 0;
+            foreach (var skin in manifest.Skins)
+                foreach (var kv in manifest.Emotions)
+                    foreach (var p in kv.Value.Portraits)
+                        if (!string.IsNullOrEmpty(p.File)) totalDeclared++;
 
+            int floor = Math.Min(MinPortraitFiles, totalDeclared);
+            if (floor == 0)
+            {
+                App.Logger?.Information(
+                    "AvatarPortraitLoader: portrait avatar skipped for {Path} - the manifest declares no portrait files; using the animated avatar instead",
+                    manifestPath);
+                return false;
+            }
+
+            int found = 0;
             foreach (var skin in manifest.Skins)
             {
                 var skinDir = Path.Combine(baseDir, (skin.Dir ?? "").Replace('/', Path.DirectorySeparatorChar));
                 foreach (var kv in manifest.Emotions)
                 {
-                    bool isBasePose = string.Equals(kv.Key, basePose, StringComparison.OrdinalIgnoreCase);
                     foreach (var p in kv.Value.Portraits)
                     {
                         if (string.IsNullOrEmpty(p.File)) continue;
@@ -177,15 +189,14 @@ namespace ConditioningControlPanel.Services
                         // Same install-dir/content-pack split GetBucket handles.
                         if (!File.Exists(abs) && ContentLocator.Mirror(abs) == null) continue;
                         found++;
-                        if (isBasePose) haveBasePose = true;
-                        if (haveBasePose && found >= MinPortraitFiles) return true;
+                        if (found >= floor) return true;
                     }
                 }
             }
 
             App.Logger?.Information(
-                "AvatarPortraitLoader: portrait avatar skipped for {Path} - only {Count} portrait image file(s) found on disk " +
-                "(content pack missing?); using the animated avatar instead", manifestPath, found);
+                "AvatarPortraitLoader: portrait avatar skipped for {Path} - {Count} of {Declared} declared portrait image file(s) on disk " +
+                "(floor {Floor}; content pack missing?); using the animated avatar instead", manifestPath, found, totalDeclared, floor);
             return false;
         }
     }

--- a/ConditioningControlPanel/Services/Companion/AvatarPortraitLoader.cs
+++ b/ConditioningControlPanel/Services/Companion/AvatarPortraitLoader.cs
@@ -46,17 +46,44 @@ namespace ConditioningControlPanel.Services
         /// <summary>Resolve the active mod's manifest path (packaged first, then embedded). Null = no portrait system.</summary>
         public static string? ResolveManifestPath() => ActiveModManifestPath ?? EmbeddedModManifestPath;
 
-        /// <summary>True if the active mod ships a portrait manifest (cheap existence check, no parse).</summary>
-        public static bool HasManifestForActiveMod() => ResolveManifestPath() != null;
+        /// <summary>
+        /// True if the active mod ships a portrait manifest AND its portraits are actually on disk.
+        /// The manifest ships inside the app but the portrait PNGs arrive in a downloadable content
+        /// pack, so a failed/skipped pack download leaves a valid manifest with zero images — and the
+        /// avatar used to commit to portrait mode anyway, freezing on one undersized legacy pose.
+        /// The disk check is cached per manifest path: this gate is polled on every avatar-set switch.
+        /// </summary>
+        public static bool HasManifestForActiveMod()
+        {
+            var path = ResolveManifestPath();
+            return path != null && PortraitsPresent(path);
+        }
 
         /// <summary>
         /// Load + parse the active mod's manifest into an <see cref="AvatarPortraitSet"/>. Never throws —
-        /// a missing/garbled manifest returns null and the caller uses the legacy avatar path.
+        /// a missing/garbled manifest, or one whose portraits never landed, returns null and the caller
+        /// uses the legacy avatar path.
         /// </summary>
         public static AvatarPortraitSet? Load()
         {
             var path = ResolveManifestPath();
             if (path == null) return null;
+
+            var manifest = ReadManifest(path);
+            if (manifest == null) return null;
+
+            var baseDir = Path.GetDirectoryName(path) ?? "";
+            if (!PortraitsPresent(path, manifest)) return null;
+
+            App.Logger?.Information(
+                "AvatarPortraitLoader: loaded {Emotions} emotions, {Skins} skins, {Lines} lines from {Path}",
+                manifest.Emotions.Count, manifest.Skins.Count, manifest.Lines.Count, path);
+            return new AvatarPortraitSet(manifest, baseDir);
+        }
+
+        /// <summary>Read + validate a manifest file. Never throws; null = unusable.</summary>
+        private static AvatarPortraitManifest? ReadManifest(string path)
+        {
             try
             {
                 var json = File.ReadAllText(path);
@@ -67,17 +94,99 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Warning("AvatarPortraitLoader: manifest at {Path} is empty/invalid", path);
                     return null;
                 }
-                var baseDir = Path.GetDirectoryName(path) ?? "";
-                App.Logger?.Information(
-                    "AvatarPortraitLoader: loaded {Emotions} emotions, {Skins} skins, {Lines} lines from {Path}",
-                    manifest.Emotions.Count, manifest.Skins.Count, manifest.Lines.Count, path);
-                return new AvatarPortraitSet(manifest, baseDir);
+                return manifest;
             }
             catch (Exception ex)
             {
                 App.Logger?.Warning(ex, "AvatarPortraitLoader: failed to load manifest at {Path}", path);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// A half-unpacked pack is as unusable as a missing one, so require a few files rather than
+        /// exactly one — plus the default/idle pose, which is what portrait mode shows first.
+        /// </summary>
+        private const int MinPortraitFiles = 4;
+
+        // Verified-once cache. Only the last-resolved manifest is remembered because exactly one mod
+        // is active at a time; a mod switch re-verifies. Invalidated when a content pack lands.
+        private static string? _verifiedManifestPath;
+        private static bool _verifiedHasPortraits;
+        private static readonly object _verifyLock = new();
+
+        /// <summary>
+        /// Drop the cached "are the portraits on disk?" answer so a pack that lands mid-session is
+        /// picked up. The avatar re-enters portrait mode on the next mod/avatar-set switch.
+        /// </summary>
+        public static void InvalidateAvailabilityCache()
+        {
+            lock (_verifyLock) { _verifiedManifestPath = null; }
+        }
+
+        private static bool PortraitsPresent(string manifestPath, AvatarPortraitManifest? preloaded = null)
+        {
+            lock (_verifyLock)
+            {
+                if (_verifiedManifestPath == manifestPath) return _verifiedHasPortraits;
+
+                var manifest = preloaded ?? ReadManifest(manifestPath);
+                bool present;
+                try
+                {
+                    present = manifest != null &&
+                              CountsAsPresent(manifest, Path.GetDirectoryName(manifestPath) ?? "", manifestPath);
+                }
+                catch (Exception ex)
+                {
+                    // This gate is polled from paths with no try/catch of their own; an odd manifest
+                    // must degrade to the legacy avatar, not take the tube down.
+                    App.Logger?.Warning(ex, "AvatarPortraitLoader: portrait availability check failed for {Path}", manifestPath);
+                    present = false;
+                }
+
+                _verifiedManifestPath = manifestPath;
+                _verifiedHasPortraits = present;
+                return present;
+            }
+        }
+
+        /// <summary>
+        /// Stat the manifest's portraits until enough are found (early exit) — a full sweep only ever
+        /// happens on the failure path, which is also the only path that needs an exact count to log.
+        /// </summary>
+        private static bool CountsAsPresent(AvatarPortraitManifest manifest, string baseDir, string manifestPath)
+        {
+            var basePose = string.IsNullOrEmpty(manifest.DefaultEmotion) ? manifest.IdleEmotion : manifest.DefaultEmotion;
+            // Only demand the base pose if the manifest actually declares it, so a manifest whose
+            // defaultEmotion is a typo still works off its other emotions (GetBucket already falls back).
+            bool needBasePose = manifest.Emotions.ContainsKey(basePose);
+            bool haveBasePose = !needBasePose;
+            int found = 0;
+
+            foreach (var skin in manifest.Skins)
+            {
+                var skinDir = Path.Combine(baseDir, (skin.Dir ?? "").Replace('/', Path.DirectorySeparatorChar));
+                foreach (var kv in manifest.Emotions)
+                {
+                    bool isBasePose = string.Equals(kv.Key, basePose, StringComparison.OrdinalIgnoreCase);
+                    foreach (var p in kv.Value.Portraits)
+                    {
+                        if (string.IsNullOrEmpty(p.File)) continue;
+                        var abs = Path.Combine(skinDir, p.File);
+                        // Same install-dir/content-pack split GetBucket handles.
+                        if (!File.Exists(abs) && ContentLocator.Mirror(abs) == null) continue;
+                        found++;
+                        if (isBasePose) haveBasePose = true;
+                        if (haveBasePose && found >= MinPortraitFiles) return true;
+                    }
+                }
+            }
+
+            App.Logger?.Information(
+                "AvatarPortraitLoader: portrait avatar skipped for {Path} - only {Count} portrait image file(s) found on disk " +
+                "(content pack missing?); using the animated avatar instead", manifestPath, found);
+            return false;
         }
     }
 

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -2038,6 +2038,12 @@ namespace ConditioningControlPanel.Services
             try { ModResourceResolver.ClearCache(); }
             catch (Exception ex) { _log?.Debug("ModService: resolver cache clear failed: {Error}", ex.Message); }
 
+            // Before ModChanged fires: AvatarTubeWindow re-evaluates the portrait gate from that
+            // event, and the adopted package may have just delivered the portrait PNGs — a stale
+            // cached "absent" would park the avatar on the legacy poses for the whole session.
+            try { AvatarPortraitLoader.InvalidateAvailabilityCache(); }
+            catch (Exception ex) { _log?.Debug("ModService: portrait cache clear failed: {Error}", ex.Message); }
+
             // The extracted mod.json can declare a different companion set than the hardcoded
             // manifest we were running on.
             try

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -2198,6 +2198,9 @@ namespace ConditioningControlPanel.Services
         /// <summary>Raises <see cref="ModAvailabilityChanged"/>; a throwing subscriber never escapes.</summary>
         private void RaiseModAvailabilityChanged(string modOrPackId)
         {
+            // A pack landing can be the moment the avatar portraits finally exist on disk; drop the
+            // cached "no portraits" answer so the next mod/avatar-set switch can enter portrait mode.
+            AvatarPortraitLoader.InvalidateAvailabilityCache();
             try { ModAvailabilityChanged?.Invoke(this, modOrPackId); }
             catch (Exception ex) { _log?.Debug("ModAvailabilityChanged subscriber error: {Error}", ex.Message); }
         }

--- a/ConditioningControlPanel/Services/PendingModActivation.cs
+++ b/ConditioningControlPanel/Services/PendingModActivation.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// The mod a user explicitly chose in the first-run <c>ModPickerDialog</c>, held until its content
+    /// is actually on disk. The picker only ever REQUESTED the download, so a first-run user picked
+    /// (say) Bambi Sleep, waited out a few hundred MB, closed the picker — and was still on CCP
+    /// Default, which has no idle bark rules, so the companion looked broken.
+    ///
+    /// The choice is persisted (<see cref="Models.AppSettings.PendingModActivationId"/>) so a restart
+    /// mid-download still honours it, and is dropped the moment the user switches mods by hand — a
+    /// manual choice always outranks a queued one. ONLY a mod ticked in the picker is ever recorded;
+    /// nothing here infers a choice.
+    ///
+    /// Activation itself is MainWindow's ApplyActiveModChange path — the same one the top-bar combo
+    /// and the Mod Manager use. This type only decides WHEN.
+    /// </summary>
+    internal static class PendingModActivation
+    {
+        /// <summary>Which of the three timings applied the choice. Support reads this out of the log.</summary>
+        internal enum Trigger
+        {
+            /// <summary>The content was already on disk when the user chose it.</summary>
+            Immediate,
+
+            /// <summary>The pack finished installing (picker open or long since closed).</summary>
+            PackArrived,
+
+            /// <summary>The download completed while the app was closed; honoured on the next launch.</summary>
+            RestartResume
+        }
+
+        private static bool _hooked;
+
+        /// <summary>
+        /// The window that hosts the switch. Handed in by <see cref="Attach"/> rather than read from
+        /// Application.Current.MainWindow, which is the SPLASH while the main window is being created
+        /// and null whenever the app is hidden to tray.
+        /// </summary>
+        private static MainWindow? _window;
+
+        // ---- pure rules ----
+
+        /// <summary>
+        /// Worth remembering at all? Nothing to do for an empty choice or for the mod already running
+        /// (the picker's "restore what I had" preselect is the common case of the latter).
+        /// </summary>
+        internal static bool ShouldRecord(string? chosenModId, string? activeModId)
+            => !string.IsNullOrWhiteSpace(chosenModId)
+               && !string.Equals(chosenModId, activeModId, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Does an availability signal satisfy the pending choice? ModService raises
+        /// <c>ModAvailabilityChanged</c> with a mod id, falling back to the pack id when the pack maps
+        /// to no built-in mod, so both spellings have to match.
+        /// </summary>
+        internal static bool Matches(string? pendingModId, string? modOrPackId)
+        {
+            if (string.IsNullOrWhiteSpace(pendingModId) || string.IsNullOrWhiteSpace(modOrPackId))
+                return false;
+            if (string.Equals(pendingModId, modOrPackId, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            var packId = ModService.PackIdForMod(pendingModId!);
+            return !string.IsNullOrEmpty(packId)
+                   && string.Equals(packId, modOrPackId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The switch is due: there is a choice, its content has landed, and it is not already the
+        /// active mod. A pending choice that is already active is satisfied, not pending — the caller
+        /// clears it instead of switching.
+        /// </summary>
+        internal static bool ShouldActivate(string? pendingModId, string? activeModId, bool contentAvailable)
+            => contentAvailable
+               && !string.IsNullOrWhiteSpace(pendingModId)
+               && !string.Equals(pendingModId, activeModId, StringComparison.OrdinalIgnoreCase);
+
+        // ---- state ----
+
+        /// <summary>The mod waiting to be activated, or null when there is nothing pending.</summary>
+        internal static string? Pending
+        {
+            get
+            {
+                var id = App.Settings?.Current?.PendingModActivationId;
+                return string.IsNullOrWhiteSpace(id) ? null : id;
+            }
+        }
+
+        /// <summary>Remembers a mod the user chose in the picker. Saved immediately — the download can outlive this session.</summary>
+        internal static void Record(string modId)
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null) return;
+
+                if (!ShouldRecord(modId, App.Mods?.ActiveModId))
+                {
+                    Clear("the chosen mod is already the active one");
+                    return;
+                }
+
+                settings.PendingModActivationId = modId;
+                App.Settings?.Save();
+                App.Logger?.Information(
+                    "[ModPicker] {ModId} chosen - it becomes the active mod as soon as its content is on disk", modId);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[ModPicker] Could not record the chosen mod");
+            }
+        }
+
+        /// <summary>Drops the pending choice (applied, superseded by a manual switch, or moot).</summary>
+        internal static void Clear(string reason)
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null || string.IsNullOrWhiteSpace(settings.PendingModActivationId)) return;
+
+                App.Logger?.Debug("[ModPicker] Dropping the pending activation of {ModId}: {Reason}",
+                    settings.PendingModActivationId, reason);
+                settings.PendingModActivationId = "";
+                App.Settings?.Save();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[ModPicker] Could not clear the pending activation: {Error}", ex.Message);
+            }
+        }
+
+        /// <summary>Is this mod's media actually on disk? A mod with no pack ships in the box.</summary>
+        internal static bool IsContentAvailable(string modId)
+        {
+            try
+            {
+                var packId = ModService.PackIdForMod(modId);
+                if (string.IsNullOrEmpty(packId)) return true;
+
+                var svc = App.ReleaseContent;
+                if (svc == null) return false;
+                return svc.IsFullInstall || svc.IsInstalled(packId!);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[ModPicker] Availability check for {ModId} failed: {Error}", modId, ex.Message);
+                return false;
+            }
+        }
+
+        // ---- wiring ----
+
+        /// <summary>
+        /// Starts listening for the chosen mod's content arriving and honours a choice whose download
+        /// finished while the app was closed. Idempotent; called from MainWindow's Loaded handler, so
+        /// the window this ultimately repaints is guaranteed to exist.
+        /// </summary>
+        internal static void Attach(MainWindow window)
+        {
+            try
+            {
+                _window = window;
+                if (App.Mods == null) return;
+
+                if (!_hooked)
+                {
+                    _hooked = true;
+                    App.Mods.ModAvailabilityChanged += OnModAvailabilityChanged;
+                }
+
+                ApplyIfReady(Trigger.RestartResume);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[ModPicker] Could not arm the pending mod activation");
+            }
+        }
+
+        private static void OnModAvailabilityChanged(object? sender, string modOrPackId)
+        {
+            // Raised off pack installs and background extractions - never throw back into them.
+            try
+            {
+                if (!Matches(Pending, modOrPackId)) return;
+                ApplyIfReady(Trigger.PackArrived);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[ModPicker] Pending activation handler failed");
+            }
+        }
+
+        /// <summary>
+        /// Activates the pending choice once its content is on disk. Safe from any thread and at any
+        /// point in the session: it marshals, checks for shutdown, and no-ops when there is nothing
+        /// pending, no MainWindow, or the bytes have not landed yet.
+        /// </summary>
+        internal static void ApplyIfReady(Trigger trigger)
+        {
+            try
+            {
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+
+                if (!dispatcher.CheckAccess())
+                {
+                    // Normal, never Loaded: Loaded-priority work is starved in this app and silently
+                    // never runs.
+                    dispatcher.BeginInvoke(new Action(() => ApplyIfReady(trigger)), DispatcherPriority.Normal);
+                    return;
+                }
+
+                var pending = Pending;
+                if (pending == null) return;
+
+                var activeModId = App.Mods?.ActiveModId;
+                if (string.Equals(pending, activeModId, StringComparison.OrdinalIgnoreCase))
+                {
+                    Clear("it is already the active mod");
+                    return;
+                }
+
+                if (!ShouldActivate(pending, activeModId, IsContentAvailable(pending))) return;
+
+                var window = _window ?? App.MainWindowRef;
+                if (window == null) return;   // pre-window pack install: the next signal (or launch) applies it
+
+                window.ActivateChosenMod(pending, trigger);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[ModPicker] Pending activation failed");
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/PendingModActivation.cs
+++ b/ConditioningControlPanel/Services/PendingModActivation.cs
@@ -106,7 +106,9 @@ namespace ConditioningControlPanel.Services
                 }
 
                 settings.PendingModActivationId = modId;
-                App.Settings?.Save();
+                // SaveImmediate, not the 500ms-debounced Save: the user just committed to a
+                // 77-345MB download and may kill the app right after - the choice must survive.
+                App.Settings?.SaveImmediate();
                 App.Logger?.Information(
                     "[ModPicker] {ModId} chosen - it becomes the active mod as soon as its content is on disk", modId);
             }
@@ -228,7 +230,9 @@ namespace ConditioningControlPanel.Services
 
                 if (!ShouldActivate(pending, activeModId, IsContentAvailable(pending))) return;
 
-                var window = _window ?? App.MainWindowRef;
+                // Prefer the live window: _window is a static ref that survives a window
+                // re-creation, so a stale unloaded instance must lose to App.MainWindowRef.
+                var window = (_window is { IsLoaded: true }) ? _window : (App.MainWindowRef ?? _window);
                 if (window == null) return;   // pre-window pack install: the next signal (or launch) applies it
 
                 window.ActivateChosenMod(pending, trigger);

--- a/Tests/ConditioningControlPanel.Tests/AiMetadataTagStripTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiMetadataTagStripTests.cs
@@ -1,4 +1,4 @@
-using ConditioningControlPanel.Services;
+﻿using ConditioningControlPanel.Services;
 using ConditioningControlPanel.Services.AIService;
 using Xunit;
 
@@ -51,10 +51,23 @@ public class AiMetadataTagStripTests
     [InlineData("wait for it [giggles")]                    // unclosed, but no colon = prose
     [InlineData("count to [3")]
     [InlineData("the [cat is out")]                         // shares a prefix with "Category" - still prose
+    [InlineData("[Apple pie is the best")]                  // "App" needs \b - "Apple" is prose
     [InlineData("good girl~")]
     [InlineData("look at the time: 3:00 already")]
     public void LegitimateBracketsAndProseAreUntouched(string input)
         => Assert.Equal(input, AiTextHygiene.StripMetadataTags(input));
+
+    [Fact]
+    public void AMidReplyBracketInAMultiLineAnswerDoesNotEatTheRest()
+        // The blank line collapses (pre-existing whitespace pass) but every word survives -
+        // the old [^\]]* patterns crossed the newline and deleted everything after "Rule".
+        => Assert.Equal("Rule [one: stay still Now breathe deep for me, good girl",
+            AiTextHygiene.StripMetadataTags("Rule [one: stay still\n\nNow breathe deep for me, good girl"));
+
+    [Fact]
+    public void ATruncatedTagOnTheLastLineOfAMultiLineAnswerIsStillStripped()
+        => Assert.Equal("So deep now~",
+            AiTextHygiene.StripMetadataTags("So deep now~\n[Category: Gam"));
 
     // ── whitespace + all-metadata ───────────────────────────────────────────────────────────
     [Fact]

--- a/Tests/ConditioningControlPanel.Tests/AiMetadataTagStripTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiMetadataTagStripTests.cs
@@ -1,0 +1,96 @@
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.AIService;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// OpenRouter provider drift had the cloud model fabricating "[Category: ...]" style metadata in
+/// ordinary replies. Both sanitizers stripped those tags only when the closing bracket was present -
+/// but replies are hard-capped at 100 tokens, so the cap regularly cut the tag in half and the
+/// fragment ("[Satisf: ...") rendered raw in the speech bubble.
+///
+/// The strip has to stay narrow: eating a stage direction ("[giggles]") or a citation would turn a
+/// rendering bug into a content one.
+/// </summary>
+public class AiMetadataTagStripTests
+{
+    // ── closed tags: existing behavior, pinned ──────────────────────────────────────────────
+    [Theory]
+    [InlineData("[Category: Media] good girl~", "good girl~")]
+    [InlineData("good girl~ [Category: Media | App: VLC | Duration: 12m]", "good girl~")]
+    [InlineData("[Media/Streaming] enjoying the show?", "enjoying the show?")]
+    [InlineData("[App: Chrome] browsing again?", "browsing again?")]
+    [InlineData("[Title: something] hi", "hi")]
+    [InlineData("[Context: idle] hi", "hi")]
+    [InlineData("[CATEGORY: media] hi", "hi")]
+    public void ClosedMetadataTagsAreStripped(string input, string expected)
+        => Assert.Equal(expected, AiTextHygiene.StripMetadataTags(input));
+
+    // ── unclosed tags: the truncation the 100-token cap produces ────────────────────────────
+    [Theory]
+    [InlineData("good girl~ [Category: Med", "good girl~")]
+    [InlineData("good girl~ [Satisf: hig", "good girl~")]
+    [InlineData("good girl~ [App: Chro", "good girl~")]
+    [InlineData("good girl~ [Duration:", "good girl~")]
+    [InlineData("good girl~ [Category", "good girl~")]
+    [InlineData("good girl~ [Mood: playful", "good girl~")]
+    public void UnclosedMetadataTagAtEndIsStripped(string input, string expected)
+        => Assert.Equal(expected, AiTextHygiene.StripMetadataTags(input));
+
+    [Fact]
+    public void UnclosedTagAfterAClosedOneIsAlsoStripped()
+        => Assert.Equal("good girl~",
+            AiTextHygiene.StripMetadataTags("[Media/Streaming] good girl~ [Category: Gam"));
+
+    // ── things that must survive ────────────────────────────────────────────────────────────
+    [Theory]
+    [InlineData("[giggles] good girl~")]                    // closed stage direction, no colon
+    [InlineData("that's the [3] one you liked")]            // mid-sentence citation
+    [InlineData("mmm [giggles] you're doing so well [3]")]
+    [InlineData("wait for it [giggles")]                    // unclosed, but no colon = prose
+    [InlineData("count to [3")]
+    [InlineData("the [cat is out")]                         // shares a prefix with "Category" - still prose
+    [InlineData("good girl~")]
+    [InlineData("look at the time: 3:00 already")]
+    public void LegitimateBracketsAndProseAreUntouched(string input)
+        => Assert.Equal(input, AiTextHygiene.StripMetadataTags(input));
+
+    // ── whitespace + all-metadata ───────────────────────────────────────────────────────────
+    [Fact]
+    public void WhitespaceLeftByARemovedTagIsCollapsed()
+        => Assert.Equal("so good", AiTextHygiene.StripMetadataTags("so [Category: Media] good"));
+
+    [Theory]
+    [InlineData("[Category: Media]")]
+    [InlineData("[Category: Med")]
+    [InlineData("[Media/Streaming]")]
+    [InlineData("")]
+    public void AnAllMetadataReplyStripsToNothing(string input)
+        => Assert.Equal("", AiTextHygiene.StripMetadataTags(input));
+
+    // ── parser path: same strip, plus its fallback when nothing survives ────────────────────
+    [Theory]
+    [InlineData("hey cutie [Category: Med", "hey cutie")]
+    [InlineData("hey cutie [Category: Media]", "hey cutie")]
+    [InlineData("[giggles] hey cutie", "[giggles] hey cutie")]
+    public void ParserSanitizesPlainTextReplies(string reply, string expected)
+    {
+        var parser = new AiResponseParser(() => "FALLBACK");
+        Assert.Equal(expected, parser.Parse(reply).CleanText);
+    }
+
+    [Fact]
+    public void ParserFallsBackWhenTheReplyIsAllMetadata()
+    {
+        var parser = new AiResponseParser(() => "FALLBACK");
+        Assert.Equal("FALLBACK", parser.Parse("[Category: Med").CleanText);
+    }
+
+    [Fact]
+    public void ParserSanitizesTheResponseFieldOfJsonReplies()
+    {
+        var parser = new AiResponseParser(() => "FALLBACK");
+        Assert.Equal("good girl~", parser.Parse("{\"response\": \"good girl~ [Category: Media]\"}").CleanText);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/PendingModActivationTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PendingModActivationTests.cs
@@ -1,0 +1,104 @@
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The first-run picker downloaded the mod the user chose and then left them on CCP Default (no idle
+/// bark rules — the companion looks broken). The choice is now remembered until its content lands.
+/// These cover the decision rules that drive it: what is worth remembering, which availability signal
+/// satisfies it, and when the switch is actually due.
+/// </summary>
+public class PendingModActivationTests
+{
+    // ---- what is worth remembering ----
+
+    [Fact]
+    public void AChoiceOtherThanTheActiveMod_IsRecorded()
+        => Assert.True(PendingModActivation.ShouldRecord(
+            BuiltInMods.BambiSleepId, BuiltInMods.CCPDefaultId));
+
+    [Fact]
+    public void TheModAlreadyRunning_IsNotRecorded()
+        => Assert.False(PendingModActivation.ShouldRecord(
+            BuiltInMods.BambiSleepId, BuiltInMods.BambiSleepId));
+
+    [Fact]
+    public void CaseDoesNotMakeItANewChoice()
+        => Assert.False(PendingModActivation.ShouldRecord(
+            BuiltInMods.BambiSleepId.ToUpperInvariant(), BuiltInMods.BambiSleepId));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NothingChosen_IsNotRecorded(string? chosen)
+        => Assert.False(PendingModActivation.ShouldRecord(chosen, BuiltInMods.CCPDefaultId));
+
+    // ---- which availability signal satisfies it ----
+
+    [Fact]
+    public void TheModsOwnIdMatches()
+        => Assert.True(PendingModActivation.Matches(BuiltInMods.BambiSleepId, BuiltInMods.BambiSleepId));
+
+    [Fact]
+    public void ThePackIdThatCarriesItMatches()
+        => Assert.True(PendingModActivation.Matches(BuiltInMods.BambiSleepId, "mod-bambi"));
+
+    [Fact]
+    public void AnotherModsPackDoesNot()
+        => Assert.False(PendingModActivation.Matches(BuiltInMods.BambiSleepId, "mod-sissy"));
+
+    [Fact]
+    public void AnAudioPackCarriesNoModAndMatchesNothing()
+        => Assert.False(PendingModActivation.Matches(BuiltInMods.BambiSleepId, "audio-core"));
+
+    [Theory]
+    [InlineData(null, BuiltInMods.BambiSleepId)]
+    [InlineData("", BuiltInMods.BambiSleepId)]
+    [InlineData(BuiltInMods.BambiSleepId, null)]
+    [InlineData(BuiltInMods.BambiSleepId, "")]
+    public void NothingPendingOrNoSignal_NeverMatches(string? pending, string? signal)
+        => Assert.False(PendingModActivation.Matches(pending, signal));
+
+    // ---- when the switch is due ----
+
+    [Fact]
+    public void ContentOnDisk_AndNotYetActive_Switches()
+        => Assert.True(PendingModActivation.ShouldActivate(
+            BuiltInMods.BambiSleepId, BuiltInMods.CCPDefaultId, contentAvailable: true));
+
+    [Fact]
+    public void StillDownloading_Waits()
+        => Assert.False(PendingModActivation.ShouldActivate(
+            BuiltInMods.BambiSleepId, BuiltInMods.CCPDefaultId, contentAvailable: false));
+
+    [Fact]
+    public void AlreadyActive_IsSatisfiedNotSwitched()
+        => Assert.False(PendingModActivation.ShouldActivate(
+            BuiltInMods.BambiSleepId, BuiltInMods.BambiSleepId, contentAvailable: true));
+
+    [Fact]
+    public void NoPendingChoice_NeverSwitches()
+        => Assert.False(PendingModActivation.ShouldActivate(
+            null, BuiltInMods.CCPDefaultId, contentAvailable: true));
+
+    /// <summary>
+    /// The manual-switch rule, end to end: the user picks Bambi, then switches to Sissy by hand while
+    /// the pack is still coming down. The manual choice wins — MainWindow drops the pending id, so the
+    /// arriving pack has nothing left to match and cannot yank them back.
+    /// </summary>
+    [Fact]
+    public void AManualSwitchLeavesNothingForThePackToTrigger()
+    {
+        string? pending = BuiltInMods.BambiSleepId;
+
+        // ApplyActiveModChange(fromPickerChoice: false) — any manual switch clears it.
+        pending = null;
+
+        Assert.False(PendingModActivation.Matches(pending, "mod-bambi"));
+        Assert.False(PendingModActivation.ShouldActivate(
+            pending, BuiltInMods.SissyHypnoId, contentAvailable: true));
+    }
+}


### PR DESCRIPTION
Companion to #168 - the remaining client-side fixes from the v6.6.4 incident triage. Zero file overlap with #168 (verified); the two merge independently in either order.

## 1. Frozen portrait avatar (Sissy users with a missing content pack)
`avatar_manifest.json` ships with the app but the 312 portrait PNGs arrive by pack - the loader committed to portrait mode on the manifest alone, leaving one frozen, undersized pose that never reacts. Portrait mode now engages only when the images are actually on disk (floor scales down for small creator-mod manifests; a missing base pose falls to the existing GetBucket fallback chain instead of hard-failing), with cache invalidation when a pack lands mid-session.

## 2. Truncated fabricated tags rendered raw in speech bubbles
The OpenRouter endpoints fabricate `[Category: ...]`-style tags in replies; the 100-token cap can cut one off before its closing bracket, and every sanitizer regex required that bracket - so users saw raw `[Satisf: ...` fragments (visible in the incident screenshots). Both sanitizers now share one `AiTextHygiene.StripMetadataTags` (they had drifted-identical copies) with two newline-safe end-of-string passes. Review hardened: `\b` so "[Apple pie" survives, newline exclusion so a mid-reply bracket in a multi-line answer can't eat the rest.

## 3. The first-run Mod Picker never activated the chosen mod
A first-run user who picked Bambi Sleep and waited out the download was still on CCP Default - which has **zero idle bark rules**, i.e. a companion that never speaks unprompted. The choice made by pressing Download is now recorded (survives restarts via `SaveImmediate`) and applied the moment the pack's content exists: immediately, on pack arrival, or on next launch. Manual mod switches always win and clear the pending choice. Review hardened: **upgraders (picker pre-selects their current mod) are never auto-switched** - previously a Sissy upgrader who also ticked Bambi would have been demoted onto Bambi.

## Review
Independent Opus review ran pre-push; all three ship-blockers + five smaller findings fixed in the last commit. Confirmed no semantic clash with #168's stamp-dropping rollback (they're complementary). Follow-ups ticketed: tube doesn't re-enter portrait mode live when a loose-media pack lands mid-session (needs a ModAvailabilityChanged subscription), one tautological test.

## Verification
- `dotnet build`: 0 errors · `dotnet test`: **1015 passed / 0 failed** (+54 vs baseline 961)
- Play-test before merge: fresh-install flow - pick a mod in the picker, let it download, confirm the app switches to it (watch for `[ModPicker] Auto-activated` log line); upgrade flow - open picker with your current mod pre-ticked, add another, confirm you STAY on your mod; delete the Sissy portrait PNGs, relaunch, confirm animated avatar (not a frozen pose); send AI chat messages, confirm no bracket fragments in bubbles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue