### PR TITLE
feat(goon): sending media + voice notes is a supporter perk again (tier 1+)

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/boot.js
+++ b/ConditioningControlPanel/Resources/web/goon/boot.js
@@ -594,10 +594,10 @@ function localCaps() {
    * `transfer` (its sibling in core/caps.js) is advertised on EXACTLY the same
    * terms: this build ships net/mediaChannel.js and will parse offers, full
    * stop. It says nothing about consent (the sheet's `media_transfer` term),
-   * nothing about entitlement (session.caps.mediaTransfer gates SENDING only,
-   * and as of 2026-08-05 that is free for every seat anyway — receiving never
-   * was), and nothing about the link (the lobby row checks supportsBulk
-   * separately). Until 2026-08-04 NOBODY set this flag —
+   * nothing about entitlement (session.caps.mediaTransfer gates SENDING only —
+   * a tier-1+ perk again as of 2026-08-06, and voice notes ride the same cap;
+   * receiving was never gated in any era), and nothing about the link (the
+   * lobby row checks supportsBulk separately). Until 2026-08-04 NOBODY set this flag —
    * caps.js documented that boot advertises it and boot never did — so every
    * hello said `transfer:false`, both lobbies greyed the checkbox out with
    * "their build doesn't transfer", and the entire media lane was unreachable
@@ -615,8 +615,9 @@ function localCaps() {
 /* ============================================================================
  * P2P MEDIA TRANSFER — the three singletons and the one adapter.
  *
- * The queue SENDS (session.caps.mediaTransfer — free for every seat since
- * 2026-08-05; the paid perk is HOSTING), the store RECEIVES (never gated at all,
+ * The queue SENDS (session.caps.mediaTransfer — a TIER 1+ PERK again as of
+ * 2026-08-06, after one day free; voice notes ride the same cap, and hosting is
+ * still a rung above at tier 2), the store RECEIVES (never gated at all,
  * in any era), and the blocklist is the render-time safety gate. All three are built in
  * buildApp() and the queue is attached/detached with the match, so the relay
  * rebuild re-binds it over the new transport and it simply goes dormant.
@@ -1019,12 +1020,19 @@ function buildMatch(transport, isHost, { withSuddenDeathUi = true, displayName =
 /**
  * THE SERVER'S SEND VERDICT -> session.caps.mediaTransfer. Standalone only.
  *
- * Sending is free for every seat now (bridge.js defaults the cap ON, and the C#
- * host's TransferAllowed() answers true), so this is no longer how a seat EARNS
- * the capability — it is how the server can still TAKE IT BACK. /invite and
- * /join answer `media_send`; net/signaling.js records it; this folds it in. A
- * `false` from a future policy turns sending off with no client release, and a
- * `null` (a server that predates the field) deliberately changes nothing.
+ * THIS IS THE TIER GATE OUT HERE, again, as of 2026-08-06. bridge.js still
+ * defaults the cap ON and the fold below is still literally "adopt whatever the
+ * server said" — NOTHING IN THIS FUNCTION CHANGED with the re-gate — but what the
+ * server says changed: `media_send` on /invite and /join now answers
+ * computeEffectiveTier >= 1, and an anonymous `g_` guest gets false. So on a
+ * standalone page the verdict is once again what decides whether this seat may
+ * send, rather than a veto a permissive server never exercises. (Hosted pages are
+ * the C# init frame's business — TransferAllowed(), the same tier-1 bar.)
+ *
+ * The mechanics are unchanged and still matter: net/signaling.js records the
+ * answer, this folds it in, and a `null` (a server that predates the field)
+ * deliberately changes nothing. Voice notes ride the same cap from here — the
+ * `sendAllowed` thunk in attachMatch reads exactly this value.
  *
  * WHY THIS IS A FUNCTION AND NOT A LINE IN attachMatch — it has to run TWICE,
  * on two different roads, and running it only in attachMatch is exactly the bug
@@ -1112,6 +1120,19 @@ function attachMatch(match, transport) {
       // The same content gate the media lane renders through. See the consult in
       // voiceService.onEnd: local map only, fails open, never waits on the net.
       blocklist,
+      /* THE SEND PERK, SHARED WITH MEDIA (owner call, 2026-08-06). The SAME
+       * expression the media queue's `canSend` uses, deliberately written out
+       * again rather than hoisted into a shared closure: these are two lanes with
+       * two lifetimes (the queue is a buildApp singleton, this is per-match) and
+       * the day one of them needs its own answer, the divergence should be an
+       * edit rather than a discovery. One send policy today, and the C# doc on
+       * TransferAllowed() says so from the other side.
+       *
+       * A THUNK, never a snapshot: `session.caps` is REPLACED (not mutated) by
+       * adoptServerSendVerdict, and on the first-connect road that happens AFTER
+       * this service is built. Capturing the boolean here would gate every fresh
+       * standalone duel on a verdict that had not arrived yet. */
+      sendAllowed: () => !!(session.caps && session.caps.mediaTransfer === true),
       logger,
     });
   } catch (e) { logger.error('createVoiceService threw: ' + ((e && e.stack) || e)); voice = null; }
@@ -1136,9 +1157,21 @@ function attachMatch(match, transport) {
       logger.warn('voice-note seed REFUSED by the engine (phase ' + match.phase + ') — declaration will not ride the consent frames');
     }
   } catch (e) { logger.warn('setLocalVoiceNotes threw: ' + ((e && e.message) || e)); }
-  /* SENDING DEFAULTS ON (owner call, 2026-08-05). Sending is free for every
-   * seat now and "my attacks carry MY media" is the product, so the standing
-   * answer is yes unless this player has explicitly unticked the lobby box
+  /* THE LOBBY BOX DEFAULTS ON, AND STAYS THAT WAY THROUGH THE RE-GATE.
+   *
+   * This seeds CONSENT, not entitlement, and the two are different questions:
+   * this box says "I am willing to use the media lane with this person", and the
+   * lane it opens carries traffic in BOTH directions — receiving is part of it
+   * and receiving has never been gated or paid for. Entitlement is
+   * session.caps.mediaTransfer alone (a tier-1+ perk again as of 2026-08-06),
+   * checked by net/mediaQueue.js `canSend` and by the voice service's
+   * `sendAllowed`. So an ungated seat still ticks this box, still receives
+   * everything, and simply sends nothing — with the lobby row saying why
+   * (S.lobby.transferOff). Defaulting it OFF for unpaid seats would take away the
+   * free half of the feature to enforce the paid half.
+   *
+   * "My attacks carry MY media" is the product for the seats that have it, so the
+   * standing answer is yes unless this player has explicitly unticked the lobby box
    * before (prefs 'mediaTransferEnabled' === false — the checkbox writes it).
    * Same seam as the voice seeding above, for the same rebuild reason; the
    * engine accepts the seed in Idle too (core/match.js _seedDeclaration —
@@ -1523,6 +1556,13 @@ function micGateToast(deskWhy) {
     if (!m) return;
     let msg = '';
     if (deskWhy === 'zen') msg = S.voice.micZenToast;
+    /* THE PERK, ahead of the three facts about the duel and in the order
+     * voiceService.available() applies its own gates (2026-08-06). Read off
+     * `session.caps` rather than off the match, because it is the only gate here
+     * that is about the SEAT: an ungated player can meet every other condition —
+     * direct link, modern peer, both boxes ticked — and still have no mic, which
+     * without this arm is a hidden control and total silence. */
+    else if (!(session.caps && session.caps.mediaTransfer === true)) msg = S.voice.micNoPerkToast;
     else if (!m.linkIsP2P) msg = S.voice.micRelayToast;
     else if (!m.peerSupportsVoice) msg = S.voice.micPeerOldToast;
     else if (!m.remoteVoiceNotes) msg = S.voice.micPeerOffToast;
@@ -2221,12 +2261,15 @@ function buildApp() {
     blocklist,
     logger,
     acceptsCodecs: decodeCodecs,
-    // === true, NOT !== false (the idiom brainDrain/spiral use above). Kept
-    // strict even though the capability is free now: a host that predates the
-    // flag entirely says nothing, and "said nothing" must not read as consent to
-    // start a lane. Every host that DOES speak the flag sets it true (C#
-    // TransferAllowed, bridge.js standalone default), so the strictness only
-    // ever catches a genuinely ancient frame. Receiving is never gated.
+    // === true, NOT !== false (the idiom brainDrain/spiral use above). The
+    // strictness carries the whole entitlement now that sending is a TIER 1+
+    // PERK again (2026-08-06): C# TransferAllowed() answers HasPremiumAccess,
+    // the server's `media_send` verdict answers computeEffectiveTier >= 1, and
+    // adoptServerSendVerdict folds that into the standalone cap. A host that
+    // predates the flag entirely says nothing, and "said nothing" must not read
+    // as a grant. Voice notes ride this same cap through the voice service's
+    // `sendAllowed` (attachMatch). RECEIVING IS NEVER GATED, in any era — this
+    // predicate is only ever asked about the send arm.
     canSend: () => !!(session.caps && session.caps.mediaTransfer === true),
   });
   mediaQueue.onReceived((a) => {

--- a/ConditioningControlPanel/Resources/web/goon/bridge.js
+++ b/ConditioningControlPanel/Resources/web/goon/bridge.js
@@ -292,25 +292,25 @@ export function standaloneInit() {
       // transfer-cache to talk to: the assets screen renders "compression lives in
       // the app" instead of a spinner that never resolves.
       assetCache: false,
-      /* SENDING IS FREE FOR EVERY SEAT (owner call, 2026-08-05). This WAS a
-       * premium default — OFF against any real server, ON only on the pure-local
-       * dev path — and boot.js flipped it on once the server's `media_send`
-       * verdict landed. That defaulting is what a free guest experienced as
-       * "my attacks throw blanks": the paid perk is HOSTING (caps.canHost, the
-       * server's tier-2 bar at /v2/goon/invite) and once a room exists BOTH
-       * players sending their own media is the whole shape of a duel.
+      /* DEFAULT ON, SERVER DECIDES (re-gated 2026-08-06: sending — media and
+       * voice notes alike — is a tier-1+ supporter perk again, after one day
+       * free-for-every-seat). This flat TRUE is NOT the entitlement; it is the
+       * optimistic default the server's `media_send` verdict overwrites: boot.js
+       * folds it in (adoptServerSendVerdict) on /invite and /join, so a free or
+       * anonymous seat is switched off by the answer, with no client release.
+       * A server that predates the field (null) leaves this default alone.
        *
-       * It stays TRUE here and the server's verdict stays the AUTHORITY: boot.js
-       * still folds `media_send` in (adoptServerSendVerdict), so a server that
-       * answers false turns sending off again with no client release, and a
-       * server that predates the field (null) leaves this default alone. The
-       * inversion matters — defaulting ON and letting the server veto is a very
-       * different failure mode from defaulting OFF and hoping a verdict arrives
-       * in time, and the second one is the bug this replaced.
+       * WHY DEFAULT ON RATHER THAN OFF (2026-08-05's lesson, keep it): the old
+       * premium default was OFF-until-verdict, the verdict arrives AFTER
+       * attachMatch, and a free guest experienced the window as "my attacks
+       * throw blanks" — a broken feature, not a paywall. Defaulting ON and
+       * letting the server veto is the survivable failure mode, and the lobby
+       * row (S.lobby.transferOff) now names the perk when the veto lands.
        *
        * NOT an enforcement point either way: media is P2P, so this gate is
-       * advisory UX (the lobby row's explanation, the queue's send arm). The
-       * REAL gates are the two lobby consent toggles, which are untouched.
+       * advisory UX (the lobby row's explanation, the queue's send arm, the
+       * voice service's sendAllowed). The REAL gates are the two lobby consent
+       * toggles, which are untouched.
        */
       mediaTransfer: true,
     }, prefs.caps || {}),

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -690,27 +690,47 @@ function mountRecap(result) {
     a.dispose(); b.dispose(); pair.dispose();
   }
 
-  /* ---------------- 6a-free. THE FREE SEAT SENDS (owner call, 2026-08-05) ------
-   * Everything above drives `canSend` from a hand-written arrow. This one drives
-   * it from the SHAPE A FREE SEAT ACTUALLY HOLDS — bridge.js's standaloneInit
-   * caps, minus every paid marker — through the same predicate boot.js installs
-   * (`caps.mediaTransfer === true`). If someone re-introduces a tier default in
-   * bridge.js, this fails on the object rather than on a source regex.
+  /* ------------- 6a-tier. THE UNENTITLED SEAT DOES NOT SEND (re-gate 2026-08-06)
    *
-   * The two verdicts are asserted TOGETHER on the same caps object because the
-   * whole decision is that they diverge: sending free, hosting not.
+   * Everything above drives `canSend` from a hand-written arrow. This one drives
+   * it from the SHAPE A SEAT ACTUALLY HOLDS, through the same predicate boot.js
+   * installs (`caps.mediaTransfer === true`), for both answers.
+   *
+   * THE POLICY, and its whole history in four lines. Sending was tier 1+, went
+   * FREE for one day (2026-08-05, because a gated seat's attacks silently fell
+   * back to the receiver's own pool and read as a broken feature), and came back
+   * as a perk on 2026-08-06 with the copy it should have shipped with — abuse
+   * beat generosity, and the lobby row now names the perk (S.lobby.transferOff)
+   * rather than going dark in silence. The BLANK-ATTACK BEHAVIOUR IS UNCHANGED
+   * and is asserted below: an unentitled seat's payloads fire untagged and the
+   * receiver draws from its own pool. That is not a bug any more, it is the
+   * documented shape of the free tier — the fix was the sentence, not the lane.
+   *
+   * The two verdicts are asserted on the SAME caps object because the two bars
+   * are different: sending is tier 1, hosting is tier 2, and a supporter who may
+   * send still may not mint a room.
    * -------------------------------------------------------------------------- */
   {
-    // A guest that arrived on an invite link: no account, no tier, no host right.
+    // A guest that arrived on an invite link: no account, no tier, and — since the
+    // re-gate — no send. The server's `media_send` verdict answers false for an
+    // anonymous `g_` seat and boot.js folds it into the cap.
     const freeSeatCaps = {
       platform: 'web', video: true, camera: false, assetCache: false,
-      mediaTransfer: true,     // bridge.js standaloneInit — free for every seat
-      canHost: false,          // …and the server's tier-2 bar, unmoved
+      mediaTransfer: false,    // the adopted server verdict for an unentitled seat
+      canHost: false,          // …and the tier-2 bar above it, unmoved
     };
-    // boot.js's canSend closure, verbatim in shape.
+    // boot.js's canSend closure, verbatim in shape. The SAME expression now also
+    // gates voice notes (ui/voice/voiceService.js `sendAllowed`) — one send policy.
     const canSend = () => !!(freeSeatCaps && freeSeatCaps.mediaTransfer === true);
-    ok(canSend() === true, 'a free seat CAN send: caps.mediaTransfer is true with no account behind it');
-    ok(freeSeatCaps.canHost !== true, 'and still cannot host — the perk did not move');
+    ok(canSend() === false, 'an unentitled seat cannot send: caps.mediaTransfer is false');
+    ok(freeSeatCaps.canHost !== true, 'and still cannot host — two bars, not one');
+
+    // ...and the entitled shape, on the same predicate, so the gate is proved to be
+    // a gate rather than an off switch.
+    const paidSeatCaps = Object.assign({}, freeSeatCaps, { mediaTransfer: true });
+    ok(!!(paidSeatCaps && paidSeatCaps.mediaTransfer === true) === true,
+      'a tier-1+ seat may send on the very same predicate');
+    ok(paidSeatCaps.canHost !== true, 'while tier 1 still buys no room — sending is the lower bar');
 
     const pair = createLoopbackPair(loopbackOptions({
       latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, bulk: true, logger: quiet,
@@ -720,8 +740,8 @@ function mountRecap(result) {
       { sha: SHA_IMG, bytes: 40000, mime: 'image/png', kind: 'image', exempt: false },
     ]);
     const storeB = fakeStore();
-    // The FREE seat is the sender here — the exact inversion of 6a, where the
-    // gated side was the one holding nothing.
+    // The UNENTITLED seat is the sender here — everything else about it is perfect:
+    // a bulk-capable link, both consents, a modern peer and a compressed library.
     const qFree = createMediaQueue({ artifacts, store: fakeStore(), logger: quiet, canSend, idlePollMs: 40 });
     const qPeer = createMediaQueue({
       artifacts: { listSendable: () => [], open: () => null },
@@ -730,23 +750,25 @@ function mountRecap(result) {
     qFree.attach(a, pair.host);
     qPeer.attach(b, pair.guest);
 
-    // The hello is a round trip, so the ladder is only complete a few turns in —
-    // same wait 6a uses, and the same reason.
+    // The same wait 6a uses — long enough that a lane which WAS going to open has.
     for (let i = 0; i < 80 && storeB.held.size < 1; i++) await tick(25);
-    ok(qFree.enabled() === true,
-      'and the whole sendGate ladder passes for it — capability, both consents, peer support, bulk, hello');
-    ok(storeB.held.size >= 1, "the free seat's media actually crossed the wire", String(storeB.held.size));
+    ok(qFree.enabled() === false,
+      'the whole rest of the ladder passes and the lane is STILL shut — the capability is the one missing rung');
+    ok(storeB.held.size === 0, 'nothing crossed the wire', String(storeB.held.size));
+    ok(qFree.tagsFor(GoonPayloadKind.FlashBurst).length === 0,
+      'so its payloads fire UNTAGGED and the receiver draws from its own pool — the documented free-tier shape');
 
     qFree.detach(); qPeer.detach();
     a.dispose(); b.dispose(); pair.dispose();
   }
 
-  /* -------- 6a-consent. A FREE CAPABILITY IS NOT A FREE PASS --------------------
-   * The half of 6a-free that matters most for review: give the free seat the
-   * capability and take away the OTHER side's lobby tick, and the lane stays
-   * shut — with the queue naming consent, not entitlement, as the reason. The
-   * pair is built the 6d way (declarations set at Idle, one side silent) because
-   * the setter refuses past Consent and a withdrawal mid-Draft is a no-op.
+  /* -------- 6a-consent. THE CAPABILITY IS NOT A FREE PASS -----------------------
+   * The other half of 6a-tier: give the seat the capability and take away the
+   * OTHER side's lobby tick, and the lane stays shut — with the queue naming
+   * consent, not entitlement, as the reason. Entitlement and consent are two
+   * different gates and neither one substitutes for the other. The pair is built
+   * the 6d way (declarations set at Idle, one side silent) because the setter
+   * refuses past Consent and a withdrawal mid-Draft is a no-op.
    * -------------------------------------------------------------------------- */
   {
     const caps = localCaps({ transfer: true });
@@ -755,7 +777,7 @@ function mountRecap(result) {
     }));
     const a = new GoonMatchService(pair.host, true, { logger: quiet, caps, displayName: 'Free', tag: 'GG:AFREE' });
     const b = new GoonMatchService(pair.guest, false, { logger: quiet, caps, displayName: 'Peer', tag: 'GG:BFREE' });
-    ok(a.setMediaTransfer(true) === true, 'the free seat ticks its own lobby box');
+    ok(a.setMediaTransfer(true) === true, 'the entitled seat ticks its own lobby box');
     // The peer never does.
     a.adoptLobby(); b.adoptLobby();
     await pair.connect();
@@ -777,7 +799,7 @@ function mountRecap(result) {
     ok(Array.isArray(why) && why.length === 0,
       'so a media payload fires untagged, exactly as it does for a gated seat');
     ok(a.mediaTransferAgreed === false,
-      'and the engine agrees: free to send is not the same as cleared to send');
+      'and the engine agrees: entitled to send is not the same as cleared to send');
 
     q.detach(); a.dispose(); b.dispose(); pair.dispose();
   }

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hostgate.js
@@ -288,13 +288,34 @@ function recorder(server) {
   ok(S.sheets.noPass === undefined, 'the weekly-pass copy is retired — the server never sends it');
   ok(typeof S.title.hostNoLab === 'string' && S.title.hostNoLab === S.title.hostNoLab.toLowerCase(),
     'the menu note is lowercase, same voice as lobby.transferOff');
-  /* HOSTING IS THE LAST PAID THING IN THE DUEL (2026-08-05). The lobby's
-   * send-side copy used to make the same pitch; it does not any more, and this
-   * pins that so a future edit cannot quietly re-sell a free capability. */
+  /* TWO PAID THINGS AGAIN, AT TWO DIFFERENT BARS (re-gate 2026-08-06): SENDING is
+   * tier 1+ (caps.mediaTransfer / the server's media_send verdict, and voice notes
+   * ride the same cap), HOSTING is tier 2 (caps.canHost). Sending was free for one
+   * day — 2026-08-05 — and these pins flipped with it; they flip back here.
+   *
+   * WHAT IS PINNED IS THE SHAPE OF THE SENTENCE, not the existence of a pitch. The
+   * FIRST tier gate shipped SILENT: a free seat's attacks fell back to the
+   * receiver's own pool with nothing on screen, and it was read as a broken
+   * feature rather than as a paywall, which is why it was un-gated instead of
+   * explained. The row naming the perk is the condition on the gate coming back. */
   ok(S.lobby.transferNoPremium === undefined,
-    'the old "sending is a supporter perk" key is gone, not merely reworded');
-  ok(typeof S.lobby.transferOff === 'string' && !/supporter|perk|premium/i.test(S.lobby.transferOff),
-    'and its replacement explains the dark row without selling anything');
+    'the retired key stays retired — the live one is transferOff, whatever the policy is this week');
+  ok(typeof S.lobby.transferOff === 'string' && /supporter perk/i.test(S.lobby.transferOff),
+    'the transfer row NAMES the perk — a dark row with no reason is what got the first gate reverted');
+  ok(/receive theirs/i.test(S.lobby.transferOff),
+    'and names what is still free: receiving was never gated, in any era');
+  ok(S.lobby.transferOff === S.lobby.transferOff.toLowerCase(),
+    'lowercase, the same voice as title.hostNoLab');
+  /* ONE SEND POLICY, NOT TWO (owner call, same day). Voice notes ride the SAME
+   * capability, and the voice row makes the same promise in its own vocabulary. */
+  ok(typeof S.voice.lobbyNoPerk === 'string' && /supporter perk/i.test(S.voice.lobbyNoPerk),
+    'the voice row names the same perk — one send policy, said in two places');
+  ok(/hear theirs/i.test(S.voice.lobbyNoPerk), 'and its own free half: hearing them was never gated');
+  /* THE BARS ARE NOT THE SAME BAR, and the copy must not merge them: a tier-1
+   * supporter who may send is still refused a room, and this is the sentence that
+   * has to keep making sense to them. */
+  ok(/tier 2/i.test(S.sheets.noHostAccess.line) || /Tier 2/.test(S.sheets.noHostAccess.line),
+    'the host refusal still names TIER 2 — sending at tier 1 does not buy a room');
 
   const sheets = read('ui/sheets.js');
   ok(/case 'no_host_access':\s*\n\s*case 'no_pass':/.test(sheets),
@@ -470,6 +491,22 @@ function mountTitle(sessionShape) {
     'right beside the transfer verdict it is a rung above');
   ok(/HostingAllowed\(\)\s*\n?\s*\{[\s\S]{0,160}App\.Patreon\?\.HasLabAccess == true;[\s\S]{0,80}catch \{ return false; \}/.test(hostSvc),
     'computed from HasLabAccess, defaulting false in the same try/catch style as TransferAllowed');
+  /* THE OTHER BAR, AND THE PIN IT NEVER HAD (re-gate 2026-08-06). TransferAllowed()
+   * was a bare `return true` for one day and nothing in this suite noticed, because
+   * "free" is the one state a gate does not need asserting. It is tier 1+ again —
+   * HasPremiumAccess, the SAME bar the server's media_send verdict computes
+   * (computeEffectiveTier >= 1) — so the two halves of one policy cannot drift
+   * apart silently a second time. */
+  ok(/TransferAllowed\(\)\s*\n?\s*\{[\s\S]{0,160}App\.Patreon\?\.HasPremiumAccess == true;[\s\S]{0,80}catch \{ return false; \}/.test(hostSvc),
+    'the hosted send verdict is TIER 1+ (HasPremiumAccess), failing closed in the same try/catch style');
+  ok(!/TransferAllowed\(\)\s*\n?\s*\{\s*\n?\s*return true;/.test(hostSvc),
+    'and is not the free-for-every-seat `return true` it was for one day');
+  // Loose across the line wrap: the doc comment breaks mid-sentence and `///` sits
+  // between the words, so the assertion is on the phrase, not on the formatting.
+  ok(/voice notes ride this same[\s\S]{0,24}cap/i.test(hostSvc),
+    'with ONE SEND POLICY documented where the verdict is computed — voice is not a second entitlement');
+  ok(/S\.lobby\.transferOff/.test(hostSvc),
+    'and the C# doc points at the client sentence that keeps the gate legible');
 
   const cs = readApp('Services', 'GoonGame', 'GoonSignalingClient.cs');
   ok(/ErrorNoHostAccess = "no_host_access"/.test(cs), 'the C# client knows no_host_access');

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -5010,6 +5010,20 @@ const audioMod = await import('../ui/audio.js');
       && micMod.sendReasonLine('relay') !== micMod.sendReasonLine('nope'),
     '...which is neither the "switch it on" line nor the generic failure');
 
+    /* THE SEND PERK (re-gate 2026-08-06). Sending voice notes is tier 1+ and rides
+     * session.caps.mediaTransfer, the same cap media sends on. Its refusal gets its
+     * own sentence for exactly the reason 'relay' does: `notActive` points at the
+     * two consent checkboxes, and neither of them is what is in the way. Rare by
+     * construction — an unentitled seat has no mic at all — so this is the copy for
+     * the race where a server verdict lands mid-gesture. */
+    ok(micMod.sendReasonLine('not-entitled') === S20.voice.noPerkSend,
+      'an unentitled send names the perk', micMod.sendReasonLine('not-entitled'));
+    ok(/supporter perk/i.test(S20.voice.noPerkSend), 'in so many words');
+    ok(micMod.sendReasonLine('not-entitled') !== micMod.sendReasonLine('unavailable')
+      && micMod.sendReasonLine('not-entitled') !== micMod.sendReasonLine('relay')
+      && micMod.sendReasonLine('not-entitled') !== micMod.sendReasonLine('nope'),
+    '...and is its own line, not borrowed from the switch, the link or the catch-all');
+
     /* TWO KINDS OF NO, AND THEY ARE NOT THE SAME SENTENCE. sendReasonLine is
      * about a NOTE that failed to cross; micReasonLine is about a MICROPHONE
      * that never opened. Telling somebody "that one did not record" when nothing

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-net.js
@@ -1185,15 +1185,26 @@ async function testSelfDuel() {
 /* ================================================================================
  * 12. BETA GATES (pre-ship follow-ups, 2026-08-04)
  *
- *   a) THE SEND VERDICT. Was "the PREMIUM send verdict": the server answered
- *      /invite and /join with `media_send` (tier>=1), the standalone cap
- *      defaulted OFF against any real server, and boot.js flipped it on when the
- *      verdict landed. Owner call 2026-08-05 made SENDING FREE FOR EVERY SEAT —
- *      the paid perk is hosting alone — so the default inverted to ON and the
- *      verdict became a VETO the server can still exercise (`media_send:false`)
- *      rather than the grant that turns the lane on. Both directions are pinned
- *      below, along with the free-seat fixture: a guest with no account at all
- *      may send, and hosting is still refused to it.
+ *   a) THE SEND VERDICT, which has been three things in three days. Originally
+ *      the PREMIUM verdict: the server answered /invite and /join with
+ *      `media_send` (tier>=1), the standalone cap defaulted OFF against any real
+ *      server, and boot.js flipped it on when the verdict landed. Owner call
+ *      2026-08-05 made SENDING FREE FOR EVERY SEAT — the paid perk was hosting
+ *      alone — so the default inverted to ON and the verdict became a veto rather
+ *      than the grant that turns the lane on. Owner call 2026-08-06 RE-GATED it
+ *      at tier 1+ (abuse beat generosity; voice notes ride the same cap now), and
+ *      this time the page ANSWERS THE FREE SEAT IN WORDS — the first gate shipped
+ *      silent, was read as a broken feature rather than as a paywall, and that is
+ *      the only reason it was ever reverted.
+ *
+ *      THE MECHANISM DID NOT MOVE through any of that, which is what the pins
+ *      below are for: bridge.js still defaults ON, adoptServerSendVerdict still
+ *      folds in whatever the server said, and a `null` still changes nothing.
+ *      What moved is the ANSWER — `media_send` computes computeEffectiveTier >= 1
+ *      again, so an anonymous `g_` seat is told false and the fold is once more
+ *      the thing that decides a standalone seat's lane rather than a veto nobody
+ *      exercises. The free-seat fixture below asserts both halves of that: no
+ *      send, and no room, at two different bars.
  *   b) THE OWED OFFER. A guest that redeemed a code is owed the host's offer
  *      within a poll round trip; a dead host used to leave it on "joining…"
  *      forever because the ICE budget never started. NoOfferTimeoutMs now feeds
@@ -1222,58 +1233,81 @@ async function testBetaGates() {
       '/join carries the verdict and the client records true (premium)');
   }
 
-  /* --- a) THE FREE-SEAT FIXTURE (2026-08-05) -----------------------------------
+  /* --- a) THE FREE-SEAT FIXTURE (re-gated 2026-08-06) --------------------------
    * The owner's decision in one runnable shape: the seat with the LEAST standing
    * this protocol has — an anonymous invite-link click, no account, no tier, a
-   * server-minted `g_` id — may SEND its media, and still may not HOST. The two
-   * halves are asserted against the same server instance on purpose: one gate
-   * moving must not drag the other with it.
+   * server-minted `g_` id — is told it MAY NOT SEND, and may not host either. It
+   * still JOINS, still plays, still RECEIVES everything: two entitlements are
+   * refused to it and nothing else is.
+   *
+   * THE FAKE SERVER HAS ONE GLOBAL `mediaSend` SWITCH, not a tier model (see
+   * net/fakeSignaling.js, and the DOCUMENTED GAP its C# twin carries), so the
+   * per-seat verdict is modelled by setting the switch to what the real server's
+   * computeEffectiveTier would answer for the caller about to speak. That is the
+   * honest fixture available here: the tier arithmetic itself lives server-side,
+   * in another repository, and this suite has never been able to execute it.
    * -------------------------------------------------------------------------- */
   {
-    // Prod's answer as of 2026-08-04: media_send true unconditionally, host gate on.
     const prod = new GoonFakeSignalingServer({ mediaSend: true, hostGate: true });
     prod.setLabAccess('u_lab', true);
 
+    // A tier-2 supporter: over both bars, so it mints a room AND may send.
     const labHost = new GoonSignalingClient({ post: prod.post, unifiedId: 'u_lab', logger: quiet });
     const room = await labHost.createInvite('Lab');
     ok(!!room && labHost.mediaSend === true, 'the tier-2 host mints a room and may send');
 
+    // ...and now the anonymous joiner, for whom computeEffectiveTier is 0.
+    prod.setMediaSend(false);
     // `anonymous: true` is the whole free seat — /join omits unified_id and the
     // server hands back the `g_` identity it minted (see net/signaling.js).
     const freeSeat = new GoonSignalingClient({ post: prod.post, anonymous: true, logger: quiet });
     const joined = await freeSeat.join(room.code, 'Nobody');
-    ok(!!joined, 'an anonymous invite-link click gets a seat with no account at all');
+    ok(!!joined, 'an anonymous invite-link click still GETS A SEAT — joining is free and always was');
     ok(/^g_[a-f0-9]{16}$/.test(freeSeat.guestId), 'and a server-minted guest identity');
-    ok(joined.mediaSend === true && freeSeat.mediaSend === true,
-      'AND THE SERVER SAYS IT MAY SEND — the free seat is a full participant in the media lane');
+    ok(joined.mediaSend === false && freeSeat.mediaSend === false,
+      'AND IS TOLD IT MAY NOT SEND — tier 1+ again as of 2026-08-06, and the client records it');
+    /* THE HALF THE CLIENT OWES IT. This verdict is what boot.js folds into
+     * caps.mediaTransfer, and a `false` there is what the lobby row must EXPLAIN
+     * rather than merely obey — the first tier gate refused in silence and was read
+     * as a broken feature. S.lobby.transferOff / S.voice.lobbyNoPerk are pinned in
+     * selftest-hostgate.js; this is the wire fact they exist to translate. */
 
-    // The other half, unmoved: the same seat cannot mint a room of its own.
+    // The other bar, unmoved and higher: the same seat cannot mint a room of its own.
     const wouldHost = new GoonSignalingClient({
       post: prod.post, unifiedId: freeSeat.guestId, logger: quiet,
     });
     const refused = await wouldHost.createInvite('Nobody');
     ok(refused === null && wouldHost.lastError === GoonSignalError.NoHostAccess,
-      'while HOSTING stays tier 2 — free to send, not free to host');
+      'while HOSTING stays TIER 2 — the two bars are different heights, not one gate');
 
-    // And the veto still works, so the field is a live policy hook rather than
-    // decoration: a server that answers false is obeyed.
-    prod.setMediaSend(false);
-    prod.setLabAccess('u_lab2', true);          // clears the host gate; the veto is the subject here
-    const vetoed = new GoonSignalingClient({ post: prod.post, unifiedId: 'u_lab2', logger: quiet });
-    await vetoed.createInvite('Vetoed');
-    ok(vetoed.mediaSend === false,
-      'a server that answers media_send:false is still obeyed — the grant can be taken back');
+    // And a server that grants it is obeyed just as readily: the field is a live
+    // policy hook in both directions, which is what made three policy changes in
+    // three days shippable without a client release.
+    prod.setMediaSend(true);
+    prod.setLabAccess('u_lab2', true);          // clears the host gate; the verdict is the subject here
+    const granted = new GoonSignalingClient({ post: prod.post, unifiedId: 'u_lab2', logger: quiet });
+    await granted.createInvite('Granted');
+    ok(granted.mediaSend === true,
+      'a server that answers media_send:true is obeyed too — the gate can be moved from the server alone');
   }
 
   // --- a) the page halves, pinned at source level -------------------------------
   {
     const bridge = readSource('../bridge.js');
-    /* THE INVERSION, pinned. Was `!(q.get('server') || prefs.serverBase ||
-     * defaultServerBase())` — sending self-granted ONLY with no server in play.
-     * A free seat always has a server in play, so that expression was the client
-     * half of "my attacks throw blanks". */
+    /* THE INVERSION, pinned, and it SURVIVES the 2026-08-06 re-gate deliberately.
+     * Was `!(q.get('server') || prefs.serverBase || defaultServerBase())` — sending
+     * self-granted ONLY with no server in play, which for a free seat (always with a
+     * server in play) was the client half of "my attacks throw blanks".
+     *
+     * IT STAYS `true` BECAUSE THE DEFAULT IS NOT THE POLICY. The tier gate out here
+     * is the SERVER'S VERDICT (adoptServerSendVerdict, pinned below), and defaulting
+     * ON while letting the server say no is a very different failure mode from
+     * defaulting OFF and hoping a verdict arrives before the first payload: the
+     * second one is the bug this replaced, and re-gating the policy is not a reason
+     * to walk back into it. The pure-local dev path — no server at all, nothing to
+     * ask — is the only case the default is the final answer for. */
     ok(/mediaTransfer:\s*true,/.test(bridge),
-      'standaloneInit grants sending to every seat — the capability is free, hosting is the perk');
+      'standaloneInit still defaults sending ON — the SERVER VERDICT is the gate, not this line');
     ok(!/mediaTransfer:\s*!\(q\.get\('server'\)/.test(bridge),
       'and the old server-presence default is gone, not commented out beside it');
     ok(/\(\^\|\\\.\)cclabs\\\.app\$/.test(bridge),
@@ -1295,6 +1329,12 @@ async function testBetaGates() {
       'hostStart folds AFTER /invite answers');
     ok(/await s\.join\(inviteCode\);[\s\S]{0,400}?adoptServerSendVerdict\(\);/.test(boot),
       'joinStart folds AFTER /join answers');
+    /* ONE CAP, TWO LANES (re-gate 2026-08-06). Whatever this fold decides now also
+     * decides voice notes: both read `session.caps.mediaTransfer` and neither has a
+     * second entitlement of its own. Pinned here rather than only in the voice suite
+     * because THIS is the function that moves the value. */
+    ok((boot.match(/session\.caps && session\.caps\.mediaTransfer === true/g) || []).length >= 2,
+      'the adopted verdict gates BOTH the media queue and the voice service — one send policy');
   }
 
   /* --- a) WHY THE POST-AWAIT FOLD EXISTS, proven rather than asserted ----------

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-report.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-report.js
@@ -765,6 +765,78 @@ const fakeStore = (landed, held) => ({
 }
 
 /* ===========================================================================
+ * 7.25 THE EMAIL ROAD (owner ask, 2026-08-06).
+ *
+ * The card above reports ONE FILE: a fingerprint, a thumbnail and a note, filed
+ * against an artifact that landed. A great deal of what a person actually needs
+ * to report is not a file at all — being threatened, harassment across several
+ * duels, something said on a voice note — and none of it fits a picker of
+ * pictures. So the card also names a human road out, and asks for the two things
+ * that make a mail actionable: screenshots, and WHO.
+ *
+ * THE PART THAT IS EASY TO GET WRONG is WHEN it is visible. It is not a receipt.
+ * Somebody upset enough to need it must not have to file a file-report first to
+ * discover that email exists, so it is asserted on the UNTOUCHED card, and again
+ * on the collapsed one after a report has already gone.
+ * ========================================================================= */
+{
+  const box = new StubEl('section');
+  const h = recap.mount(box, fakeCtx(fakeStore([rowA], [rowA]), []));
+  const card = box.findAll('gg-recap-report')[0];
+  ok(!!card, 'the card is there to carry the line');
+  const line = card.findAll('gg-report-email')[0];
+  ok(!!line, 'the report card carries the email line BEFORE anything is picked or submitted');
+  ok(/support@cclabs\.app/.test(line.textContent), 'and it names the address', line.textContent);
+  ok(/screenshot/i.test(line.textContent), 'asks for screenshots');
+  ok(/name of the player/i.test(line.textContent), 'and for the name of the player they were with');
+  h.unmount();
+}
+
+{
+  // THE NAME, interpolated. It is the field a stranger cannot reconstruct an hour
+  // later and it is on this screen right now, so the recap fills it in.
+  const box = new StubEl('section');
+  const ctx = fakeCtx(fakeStore([rowA], [rowA]), []);
+  ctx.getMatch = () => ({
+    result: null,
+    localDisplayName: 'me',
+    opponent: { displayName: 'Kittenbot' },
+    onResultFinalized: () => () => {},
+    onMatchEnded: () => () => {},
+  });
+  const h = recap.mount(box, ctx);
+  const line = box.findAll('gg-report-email')[0];
+  ok(!!line && line.textContent.indexOf('Kittenbot') >= 0,
+    "the opponent's display name is in the line when the recap knows it", line && line.textContent);
+  ok(line.textContent === S.recap.reportEmail('Kittenbot'), 'straight from strings, never assembled in the component');
+  h.unmount();
+}
+
+{
+  // ...and a match that never learned a name gets the nameless variant rather than
+  // "the name of the player you were with (they)".
+  ok(typeof S.recap.reportEmail === 'function', 'S.recap.reportEmail is a function of the name');
+  ok(/support@cclabs\.app/.test(S.recap.reportEmail('')), 'the nameless variant still names the address');
+  ok(!/\(\)/.test(S.recap.reportEmail('')) && !/\(they\)/.test(S.recap.reportEmail('')),
+    'and carries no empty bracket where a name would have been', S.recap.reportEmail(''));
+  ok(S.recap.reportEmail('Zed').indexOf('Zed') >= 0, 'while a named one interpolates');
+  ok(S.recap.reportEmail('') === S.recap.reportEmail('').toLowerCase(),
+    'lowercase, like the rest of the card furniture');
+
+  // The collapsed card — after a report has been filed — keeps it. A filed
+  // file-report is not an answer to "he threatened me".
+  const rsrc = read('ui/screens/recap.js');
+  const cardFn = rsrc.slice(rsrc.indexOf('  function reportCard()'), rsrc.indexOf('  /* ------------------------------------------------------------- verdict'));
+  ok((cardFn.match(/emailLine\(\)/g) || []).length === 2,
+    'the line is appended on BOTH roads — the live card and the collapsed one');
+  ok(cardFn.indexOf('const emailLine') < cardFn.indexOf('reportPhase === \'done\''),
+    'built before the collapse branch returns, which is what lets it appear on both');
+  ok(/S\.recap\.reportEmail\(peerName\(\)\)/.test(cardFn), 'and the name comes from one helper, not from three call sites');
+  ok(/slice\(0, 64\)/.test(rsrc),
+    'peerName clamps: it is a peer-supplied string being read back to the player as an instruction');
+}
+
+/* ===========================================================================
  * 7.5 THE STANDALONE CTA — the only piece of marketing on the end card, and
  *     the only external link the page has. It is aimed at the phone joiner who
  *     followed an invite link and has never seen the app the payloads came out
@@ -888,6 +960,9 @@ const fakeStore = (landed, held) => ({
     'and moves it to the opposite corner from the ✕');
   for (const cls of ['gg-recap-report', 'gg-report-thumb', 'gg-report-reason', 'gg-report-note',
     'gg-report-actions', 'gg-report-status',
+    // the email road out (2026-08-06) — ruled off from the fine print it sits with,
+    // because it is the only line on the card that names a human to talk to
+    'gg-report-email',
     // the standalone CTA — an <a> wearing .gg-btn needs both of these or it
     // renders as underlined inline text in the middle of the card
     'gg-recap-cta', 'gg-recap-cta-lead', 'gg-recap-cta-link']) {

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice-ui.js
@@ -351,13 +351,23 @@ function fakeToasts() {
   return { shown, show(text, o) { shown.push({ text, kind: (o && o.kind) || 'info' }); return null; } };
 }
 
-async function mountVoiceScreen({ prefs, sheets, toasts, notes = null, match = null, audio = null }) {
+/**
+ * `caps` defaults to ENTITLED (2026-08-06) for the reason mountLobby's does: every
+ * block below is about the library, the ack gate or the recorder, and none of them
+ * should be asserting the supporter-perk line by accident. The perk case has its
+ * own block.
+ */
+async function mountVoiceScreen({
+  prefs, sheets, toasts, notes = null, match = null, audio = null,
+  caps = { mediaTransfer: true },
+}) {
   const container = dom.doc.getElementById('scr-voice');
   container.replaceChildren();
   const handle = voiceScreen.mount(container, {
     actions: { goTitle() {} },
     audio, prefs, sheets, toasts, logger: quiet,
     notes,
+    session: { caps },
     getMatch: () => match,
   });
   await sleep(5);
@@ -987,14 +997,26 @@ function mountSheet(provider) {
     return m;
   }
 
-  /** `linkState` is a parameter because voice notes are P2P-only: the row says so. */
-  function mountLobby({ prefs, sheets, match, linkState = GoonTransportState.ConnectedP2P }) {
+  /**
+   * `linkState` is a parameter because voice notes are P2P-only: the row says so.
+   *
+   * `caps` is a parameter for the same kind of reason (2026-08-06): SENDING voice
+   * notes is a tier-1+ perk riding `session.caps.mediaTransfer`, so the row has a
+   * sentence for a seat without it. The DEFAULT IS ENTITLED because every case
+   * below this one is about the consent statuses and the link — an unentitled
+   * default would make all of them assert the perk line by accident. The perk
+   * case gets its own block.
+   */
+  function mountLobby({
+    prefs, sheets, match, linkState = GoonTransportState.ConnectedP2P,
+    caps = { mediaTransfer: true },
+  }) {
     const container = dom.byId.get('scr-lobby');
     container.replaceChildren();
     const handle = lobbyScreen.mount(container, {
       actions: { goTitle() {}, leave() {} },
       audio: null, prefs, sheets, discord: null, logger: quiet,
-      session: { caps: {} },
+      session: { caps },
       getMatch: () => match,
       getTransport: () => ({ state: linkState, onStateChanged() { return () => {}; } }),
     });
@@ -1153,6 +1175,102 @@ function mountSheet(provider) {
         'state ' + st + ' has decided nothing, so the ordinary sentence stands', s2 && s2.textContent);
       r2.handle.unmount();
     }
+  }
+
+  /* ---- THE SEND PERK, IN THE ROW (re-gate 2026-08-06) -----------------------
+   *
+   * Sending voice notes is tier 1+ again and rides the SAME cap as media
+   * (session.caps.mediaTransfer). The mic is HIDDEN for a seat without it — the
+   * service folds the cap into available() — so this row is the surface that has
+   * to name the perk. This is the whole condition on the re-gate being allowed:
+   * the FIRST tier gate shipped with no copy anywhere, was read as breakage
+   * rather than as a paywall, and was reverted for it.
+   * ------------------------------------------------------------------------- */
+  {
+    const prefs = createPrefs();
+    prefs.set('voiceAckSeen', true);
+    const match = fakeLobbyMatch({ localVoiceNotes: true, remoteVoiceNotes: true });
+    const { container, handle } = mountLobby({
+      prefs, sheets: fakeSheets(), match, caps: { mediaTransfer: false },
+    });
+    const sub = findOne(container, 'gg-voice-lobbyline');
+    ok(sub && sub.textContent === S.voice.lobbyNoPerk,
+      'an unentitled seat is TOLD, in the row, instead of getting a hidden mic and silence',
+      sub && sub.textContent);
+    ok(/supporter perk/i.test(S.voice.lobbyNoPerk), 'and the sentence names the perk in so many words');
+    ok(/hear theirs/i.test(S.voice.lobbyNoPerk),
+      'AND says receiving still works — the free half must not read as taken away');
+    const input = findTag(findOne(container, 'gg-voice-lobbyrow'), 'input')[0];
+    ok(input.disabled === false,
+      'the box stays live: it is the RECEIVE gate and the standing answer, and neither is paid for');
+    handle.unmount();
+
+    // The relayed link still outranks it: with no direct link there is no voice in
+    // EITHER direction, so promising "you can still hear theirs" over it would be
+    // the one thing this copy may not do.
+    const p2 = createPrefs();
+    p2.set('voiceAckSeen', true);
+    const m2 = fakeLobbyMatch({ localVoiceNotes: true, remoteVoiceNotes: true });
+    const r2 = mountLobby({
+      prefs: p2, sheets: fakeSheets(), match: m2,
+      caps: { mediaTransfer: false }, linkState: GoonTransportState.ConnectedRelay,
+    });
+    const s2 = findOne(r2.container, 'gg-voice-lobbyline');
+    ok(s2 && s2.textContent === S.voice.lobbyRelay,
+      'relayed AND unentitled says the LINK — the bigger truth, and the only one true in both directions',
+      s2 && s2.textContent);
+    r2.handle.unmount();
+
+    // ...and an entitled seat is never sold anything it already has.
+    const p3 = createPrefs();
+    p3.set('voiceAckSeen', true);
+    const m3 = fakeLobbyMatch({ localVoiceNotes: true, remoteVoiceNotes: true });
+    const r3 = mountLobby({ prefs: p3, sheets: fakeSheets(), match: m3, caps: { mediaTransfer: true } });
+    const s3 = findOne(r3.container, 'gg-voice-lobbyline');
+    ok(s3 && s3.textContent === S.voice.lobbyBoth, 'a tier-1+ seat sees the ordinary status, no pitch');
+    r3.handle.unmount();
+  }
+
+  /* ---- THE LIBRARY SCREEN SAYS IT TOO --------------------------------------
+   * The lead on ui/screens/voice.js promises these notes are "sent to whoever you
+   * are duelling" — a sentence an unentitled seat cannot act on. The correction
+   * goes in the same eyeline, and the screen itself KEEPS WORKING: recording,
+   * playback and the emote picker are local and none of them is gated.
+   * ------------------------------------------------------------------------- */
+  {
+    // ...on the real screen, first.
+    const prefsA = createPrefs();
+    prefsA.set('voiceAckSeen', true);
+    const gated = await mountVoiceScreen({
+      prefs: prefsA, sheets: fakeSheets(), toasts: fakeToasts(), caps: { mediaTransfer: false },
+    });
+    const perk = findOne(gated.container, 'gg-voice-perk');
+    ok(!!perk && perk.textContent === S.voice.screenNoPerk,
+      'an unentitled seat gets the perk line on the library screen', perk && perk.textContent);
+    ok(findAll(gated.container, 'gg-voice-record').length === 1,
+      'and the Record button is STILL THERE — recording is local and was never the paid half');
+    gated.handle.unmount();
+
+    const prefsB = createPrefs();
+    prefsB.set('voiceAckSeen', true);
+    const paid = await mountVoiceScreen({
+      prefs: prefsB, sheets: fakeSheets(), toasts: fakeToasts(), caps: { mediaTransfer: true },
+    });
+    ok(!findOne(paid.container, 'gg-voice-perk'),
+      'and an entitled seat is not sold anything it already has');
+    paid.handle.unmount();
+
+    const vsrc = stripComments(read('ui/screens/voice.js'));
+    ok(/S\.voice\.screenNoPerk/.test(vsrc), 'the voice screen renders the perk line from strings');
+    ok(/caps\.mediaTransfer === true/.test(vsrc),
+      'off session.caps.mediaTransfer — the SAME cap media sends on, not a second entitlement');
+    ok(!/screenNoPerk[\s\S]{0,200}disabled/.test(vsrc),
+      'and nothing on that screen is disabled by it — only the crossing is paid for');
+    ok(/supporter perk/i.test(S.voice.screenNoPerk), 'the line names the perk');
+    ok(/still work/i.test(S.voice.screenNoPerk) && /hear theirs/i.test(S.voice.screenNoPerk),
+      'and says what still works, because a library that looked broken is the bug this replaced');
+    ok(S.voice.screenNoPerk === S.voice.screenNoPerk.toLowerCase(),
+      'lowercase furniture, like the rest of the screen');
   }
 
   // ---- source pins ----------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-voice.js
@@ -786,6 +786,100 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
     svc.dispose();
   }
 
+  /* --- THE SEND PERK (re-gate 2026-08-06) ---------------------------------------------
+   *
+   * Sending voice notes is tier 1+ again and rides the SAME capability as media
+   * (`session.caps.mediaTransfer`; boot.js hands it in as `sendAllowed`). Four things
+   * are asserted here and each one is a decision somebody could undo by accident:
+   *
+   *   1. CAP FALSE => NO SEND, live mic AND emote-attached, with its own reason word
+   *      ('not-entitled', never the catch-all 'unavailable' — the strip says
+   *      "supporter perk", and "you both have to switch it on" would point a paying
+   *      question at the wrong control).
+   *   2. CAP FALSE => NO MIC. available() folds it in, so an ungated seat never opens
+   *      a microphone it cannot send from. Recording somebody's voice and then telling
+   *      them it is going nowhere is a worse answer than no mic.
+   *   3. RECEIVING IS UNTOUCHED. This is the load-bearing one: the perk is the
+   *      crossing OUT. An ungated seat hears every note its opponent sends.
+   *   4. CAP TRUE => SEND, and no predicate at all => send (every other block in this
+   *      file constructs the service without one).
+   * ---------------------------------------------------------------------------------- */
+  {
+    let entitled = false;
+    const match = fakeMatch();
+    const audio = fakeAudio();
+    const store = { get: async () => ({ blob: bytes(500), durMs: 2500, emote: '👀' }) };
+    const svc = createVoiceService({
+      match, audio, prefs: fakePrefs(), noteStore: store, logger: quiet,
+      sendAllowed: () => entitled, now: () => 1e6,
+    });
+
+    // 1 + 2. the gate shut
+    const r = await svc.sendBlob(bytes(4000), { durMs: 3000 });
+    ok(!r.ok && r.reason === 'not-entitled',
+      'an unentitled seat cannot send, and the refusal has its OWN word', JSON.stringify(r));
+    ok(match.frames.length === 0, 'not one frame reached the engine');
+    ok((await svc.sendNote('n1')).reason === 'not-entitled',
+      'and the EMOTE-ATTACHED road is refused at the same door — one choke point, not two');
+    ok(match.frames.length === 0, 'still nothing on the wire');
+    ok(svc.available() === false, 'so there is no mic on the desk either, rather than one that refuses on release');
+    ok(svc.sendEntitled() === false, 'and the service will say so on its own');
+    ok(/perk|entitle/i.test(svc.whyUnavailable()),
+      'the log line names the entitlement, not a switch that cannot help', svc.whyUnavailable());
+    /* THE ORDER, and it is the legibility argument in one assertion: reported AFTER
+     * the opt-in, this sentence would send an unentitled player to a checkbox that
+     * changes nothing for them — the 2026-08-05 blindness with an extra step. */
+    const offPrefs = fakePrefs({ voiceNotesEnabled: false });
+    const bothOff = createVoiceService({
+      match, audio: fakeAudio(), prefs: offPrefs, logger: quiet,
+      sendAllowed: () => false, now: () => 1e6,
+    });
+    ok(/perk|entitle/i.test(bothOff.whyUnavailable()),
+      'with BOTH shut, the entitlement is what is reported — no switch on this page moves it',
+      bothOff.whyUnavailable());
+    bothOff.dispose();
+
+    // 3. RECEIVING IS NOT GATED BY IT.
+    const b64 = bytesToVoiceB64(bytes(600));
+    match.deliver({ sub: 'meta', id: 1, bytes: 600, parts: 1, durMs: 2000 });
+    match.deliver({ sub: 'chunk', id: 1, seq: 0, data: b64 });
+    match.deliver({ sub: 'end', id: 1 });
+    await tick();
+    await tick();
+    ok(audio.played.length === 1,
+      'THE PERK IS THE CROSSING OUT: an unentitled seat still HEARS everything they are sent',
+      String(audio.played.length));
+
+    // 4. the gate open, on the same service — it is read live, never captured, because
+    //    the server verdict can land after the service was built (boot.js runs
+    //    adoptServerSendVerdict on two roads and the first is after attachMatch).
+    entitled = true;
+    ok(svc.sendEntitled() === true && svc.available() === true, 'granting the cap brings the mic back with no rebuild');
+    const ok2 = await svc.sendBlob(bytes(4000), { durMs: 3000 });
+    ok(ok2.ok && ok2.reason === 'sent', 'and an entitled seat sends normally', JSON.stringify(ok2));
+    svc.dispose();
+
+    // NO PREDICATE = NOT GATED. Every other block in this file omits `sendAllowed`,
+    // and a closed default would have turned "we added an option" into "voice is off".
+    const m2 = fakeMatch();
+    const plain = createVoiceService({ match: m2, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet, now: () => 1e6 });
+    ok(plain.sendEntitled() === true && (await plain.sendBlob(bytes(400))).ok,
+      'a service built without an entitlement predicate is not gated by one');
+    plain.dispose();
+
+    // ...but a predicate that THROWS is a no. Once somebody is gating this build, an
+    // unreadable answer must never become a send.
+    const m3 = fakeMatch();
+    const angry = createVoiceService({
+      match: m3, audio: fakeAudio(), prefs: fakePrefs(), logger: quiet,
+      sendAllowed: () => { throw new Error('caps went away'); }, now: () => 1e6,
+    });
+    ok(angry.sendEntitled() === false, 'a throwing entitlement predicate fails CLOSED');
+    ok((await angry.sendBlob(bytes(400))).reason === 'not-entitled', 'and nothing crosses');
+    ok(m3.frames.length === 0, 'literally nothing');
+    angry.dispose();
+  }
+
   // --- THE RECEIVE GUARD: an unpatched (or hostile) peer cannot push one through us ------
   //
   // core/match.js refuses to DELIVER a voice frame on a relayed link, so in the real page
@@ -1175,6 +1269,32 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
   ok(/localCapsOf\(\{ elements, payloads, rounds, platform: 'web', voice: voiceCap, transfer: true \}\)/.test(boot),
     'boot advertises caps.voice AND caps.transfer — the only way a fire-and-forget sender ever learns the peer can hear it');
   ok(/const voiceCap = VOICE_CAP_VERSION;/.test(boot), 'from the pinned revision constant');
+
+  /* --- ONE SEND POLICY, NOT TWO (re-gate 2026-08-06) -----------------------------
+   * Voice notes ride the SAME `session.caps.mediaTransfer` media does. Pinned at the
+   * call site because the service defaults to UNGATED when no predicate is handed in
+   * (see §5) — which means a wiring line silently going missing would not fail a
+   * behaviour test anywhere, it would just quietly make the perk free again. */
+  ok(/sendAllowed: \(\) => !!\(session\.caps && session\.caps\.mediaTransfer === true\)/.test(boot),
+    'boot hands the voice service the entitlement — the SAME expression the media queue uses');
+  ok(/canSend: \(\) => !!\(session\.caps && session\.caps\.mediaTransfer === true\)/.test(boot),
+    '...which is that expression, still on the media queue, unchanged');
+  ok(/function attachMatch\([\s\S]{0,6000}?sendAllowed:/.test(boot),
+    'handed in at the per-match construction, so a relay rebuild re-reads the cap');
+  // A THUNK, never a snapshot: adoptServerSendVerdict REPLACES session.caps, and on
+  // the first-connect road it does so after this service was built.
+  ok(!/sendAllowed: session\.caps/.test(boot), 'and it is a thunk, not a captured boolean');
+
+  /* THE IN-MATCH SURFACE. The mic is HIDDEN for an unentitled seat, so without this
+   * arm a player who opted in, reached a direct duel and met both consents would get
+   * silence from every surface in the match — the exact blindness this toast family
+   * was built for, one cause later. */
+  const toast = boot.slice(boot.indexOf('function micGateToast('), boot.indexOf('function mountHudNow('));
+  ok(/S\.voice\.micNoPerkToast/.test(toast), 'the mic-gate toast has an arm for the entitlement');
+  ok(toast.indexOf('micNoPerkToast') < toast.indexOf('micRelayToast'),
+    'reported ahead of the facts about the duel, in the order available() applies its gates');
+  ok(/session\.caps && session\.caps\.mediaTransfer === true/.test(toast),
+    'read off the SEAT (session.caps), not off the match — it is the one gate here that is not about the duel');
 
   // exec/ must not have learned anything about this.
   const execFiles = fs.readdirSync(url.fileURLToPath(new URL('../exec/', import.meta.url)));

--- a/ConditioningControlPanel/Resources/web/goon/ui/emotes.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/emotes.js
@@ -39,6 +39,15 @@ const RATE_MS = 5000;
  *   pinned to this emote. Six icons in a sheet must not be able to fail because
  *   of a microphone feature.
  *
+ * ...WHICH IS ALSO HOW THE SEND PERK LANDS HERE (2026-08-06). Sending voice notes
+ * is tier 1+ now, gated at the one choke point in ui/voice/voiceService.js
+ * (`sendBlob` -> reason 'not-entitled'). Nothing in this file learned a new fact:
+ * an ungated seat's emote goes out exactly as it always did and simply does not
+ * carry its note, the rejected promise is swallowed by the same handler below,
+ * and the player is told once in the lobby (S.voice.lobbyNoPerk) rather than six
+ * times a match by a toast. NO ERROR SPAM is the requirement, and the existing
+ * fire-and-forget shape is what satisfies it.
+ *
  * IT IS A MODULE-LEVEL PROVIDER, set by boot.js, rather than a mountEmotes()
  * dependency — because this sheet is mounted by ui/hud.js, which is owned by
  * another wave and cannot be asked to thread a new dep through. An instance

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens.css
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens.css
@@ -697,6 +697,15 @@
 .gg-recap-report .gg-recap-fine { text-align: left; }
 .gg-report-lead { margin: 0 0 0.7rem; color: var(--gg-text-2); font-size: 0.82rem; line-height: 1.5; }
 .gg-report-note-line { margin: 0.6rem 0 0; color: var(--gg-text-4); font-size: 0.7rem; line-height: 1.5; }
+/* The email road out (S.recap.reportEmail, 2026-08-06). Same type as the fine
+   print it sits with, one step brighter and ruled off above: it is the last line
+   of the card and the only one that names a human being to talk to, so it must
+   not read as more small print about the form above it. */
+.gg-report-email {
+  color: var(--gg-text-3);
+  border-top: 1px solid rgba(255, 105, 180, 0.18);
+  padding-top: 0.6rem;
+}
 
 /* The shortlist. Fixed-height thumbs so a portrait clip and a wide still do not
    make the row jump; `object-fit: cover` is what keeps them the same shape. */
@@ -1370,6 +1379,16 @@ html[data-gg-motion="reduced"] .gg-vs-splash * { transition: none !important; }
  * ------------------------------------------------------------------------ */
 .gg-voicelib { min-width: min(38rem, 96vw); max-width: min(38rem, 96vw); text-align: left; }
 .gg-voice-head { text-align: center; }
+/* The supporter-perk line, under the lead it qualifies (S.voice.screenNoPerk,
+   2026-08-06). Quieter than the lead and warm rather than red: nothing is broken
+   and nothing failed — one half of this screen crosses to another person and that
+   half is paid for. Rendered only for a seat without the cap. */
+.gg-voice-perk {
+  margin-top: 0.5rem;
+  font-size: 0.82rem;
+  color: var(--gg-gold);
+  opacity: 0.92;
+}
 
 .gg-voice-consent { margin-bottom: 0.9rem; }
 /* The opt-in row is CLICKABLE EVEN WHEN THE CHECKBOX IS NOT: the ack gate

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/lobby.js
@@ -308,12 +308,16 @@ export function mount(container, ctx) {
    * speak the protocol, or the link is relayed (media never touches the server,
    * so a relay physically cannot carry it).
    *
-   * THE FIRST REASON USED TO BE "not a supporter" AND IS NOT ANY MORE (owner call
-   * 2026-08-05). Sending is free for every seat — the paid perk is hosting — so
-   * caps.mediaTransfer is true on every current host and this arm is now reserved
-   * for a server that vetoes sending (`media_send:false`) or a frame too old to
-   * carry the flag. Kept as an arm rather than deleted so the row can never go
-   * dark in silence; see S.lobby.transferOff.
+   * THE FIRST REASON IS THE TIER PERK AGAIN (owner call 2026-08-06, after one
+   * day of free-for-every-seat). caps.mediaTransfer is true for tier 1+ and false
+   * for an anonymous seat, so this arm is the one a real player actually meets —
+   * the server veto (`media_send:false`) and the too-old frame still land here
+   * too, and S.lobby.transferOff is written to be true for all three.
+   *
+   * THIS ROW IS WHY THE RE-GATE IS SHIPPABLE. The first tier gate had no copy at
+   * all: attacks silently fell back to the receiver's pool and it read as
+   * breakage, not as a paywall. An arm that names the perk, every time, is the
+   * condition on the gate coming back.
    */
   function paintTransfer() {
     const caps = (ctx.session && ctx.session.caps) || {};
@@ -392,9 +396,21 @@ export function mount(container, ctx) {
      * is off for the match. */
     const t = getTransport ? getTransport() : null;
     const settledRelay = !!t && t.state === GoonTransportState.ConnectedRelay;
+    /* THE SEND PERK, shared with the transfer row above (2026-08-06): voice notes
+     * ride the SAME session.caps.mediaTransfer. Read here rather than off the
+     * voice service because there is no service yet in the lobby half of the time
+     * (it is built per match) and because this row must answer even then. */
+    const entitled = !!(ctx.session && ctx.session.caps && ctx.session.caps.mediaTransfer === true);
 
     let status = '';
+    /* RELAY FIRST, because it is the bigger truth when both are true: a relayed
+     * duel has no voice in EITHER direction, so promising "you can still hear
+     * theirs" over it would be the one thing this copy may not do. Below it the
+     * perk line outranks the consent statuses for the reason whyUnavailable puts
+     * it first — no checkbox on this screen can move it, and sending somebody to
+     * one that cannot help them is how a paywall gets reported as a bug. */
     if (settledRelay) status = S.voice.lobbyRelay;
+    else if (!entitled) status = S.voice.lobbyNoPerk;
     else if (mine && theirs && match.peerSupportsVoice) status = S.voice.lobbyBoth;
     else if ((mine || theirs) && !match.peerSupportsVoice) status = S.voice.lobbyPeerOld;
     else if (mine) status = S.voice.lobbyYours;

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/recap.js
@@ -153,6 +153,27 @@ export function mount(container, ctx) {
   const getPeerRenders = typeof ctx.getPeerRenders === 'function' ? ctx.getPeerRenders : null;
   const mountedAt = Date.now();
 
+  /**
+   * THE OPPONENT'S DISPLAY NAME, or '' when this match never learned one.
+   *
+   * For the report card's email line (S.recap.reportEmail), which asks a player
+   * to tell support WHO they were with — the one field a mail an hour later
+   * cannot reconstruct, and the one this screen already knows. It falls back to
+   * the Discord card's name the way resultPlates() does, and to '' rather than to
+   * a placeholder: "the name of the player you were with (they)" would be worse
+   * than not naming anybody, so the string has a nameless variant instead.
+   * Trimmed and length-clamped because it is a peer-supplied string being read
+   * back to the player as an instruction.
+   */
+  function peerName() {
+    try {
+      const card = ctx.discord ? ctx.discord.peer : null;
+      const raw = (match && match.opponent && match.opponent.displayName)
+        || (card && card.name) || '';
+      return String(raw).trim().slice(0, 64);
+    } catch (_e) { return ''; }
+  }
+
   let reportPick = '';        // sha
   let reportReason = '';      // a WIRE code from REPORT_REASONS
   let reportNote = '';
@@ -267,6 +288,19 @@ export function mount(container, ctx) {
       el('h2', { class: 'gg-recap-h', text: S.recap.reportTitle }),
     ]);
 
+    /* THE EMAIL ROAD (owner ask, 2026-08-06), and it is built here — before the
+     * collapse branch below — so it appears in BOTH states. The card above files
+     * against ONE ARTIFACT; serious abuse is very often not a file at all, and a
+     * player who has just filed a picture-report may be exactly the one who still
+     * needs a human. The name is the opponent's DISPLAY NAME when the recap has
+     * one, because it is the field a stranger cannot reconstruct later and it is
+     * on this screen right now; the string has a nameless variant for a match
+     * that never learned one (an abandon before the hello). */
+    const emailLine = () => el('p', {
+      class: 'gg-report-note-line gg-report-email',
+      text: S.recap.reportEmail(peerName()),
+    });
+
     // COLLAPSED. A filed report is a closed subject: the shortlist, the picker
     // and the button all go, so the card cannot be used to file a second one by
     // accident and does not sit there looking unfinished.
@@ -275,6 +309,7 @@ export function mount(container, ctx) {
         class: 'gg-report-status is-done',
         text: reportPhase === 'deduped' ? S.report.deduped : S.report.done(reportId),
       }));
+      card.appendChild(emailLine());
       return card;
     }
 
@@ -360,6 +395,10 @@ export function mount(container, ctx) {
     }
 
     card.appendChild(el('p', { class: 'gg-report-note-line', text: S.recap.reportPrivacy }));
+    // LAST, and unconditional: it must be readable before anything is picked,
+    // before a reason is chosen and before anything is submitted. The one thing
+    // it may never be is a receipt that only exists after a successful file.
+    card.appendChild(emailLine());
     return card;
   }
 

--- a/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/screens/voice.js
@@ -112,6 +112,17 @@ export function mount(container, ctx) {
 
   const acked = () => !!(prefs && prefs.get && prefs.get('voiceAckSeen'));
   const enabled = () => !!(prefs && prefs.get && prefs.get('voiceNotesEnabled'));
+  /* THE SEND PERK (owner call, 2026-08-06). Voice notes ride the SAME capability
+   * as media — session.caps.mediaTransfer, tier 1+ — and this screen is one of
+   * the three places that says so out loud (the lobby row and the in-match toast
+   * are the others). Read off the SESSION, not off the voice service: there is no
+   * service outside a match and this is a title-menu screen.
+   *
+   * IT GATES NOTHING ON THIS SCREEN. Recording, playback, deletion and the emote
+   * picker are all local and stay live — the perk is the CROSSING, and the copy
+   * says exactly that. A library screen that quietly stopped working would be the
+   * 2026-08-05 mistake wearing this wave's clothes. */
+  const canSend = () => !!(ctx && ctx.session && ctx.session.caps && ctx.session.caps.mediaTransfer === true);
   const toast = (text, kind) => { try { toasts?.show?.(text, { kind: kind || 'info' }); } catch (_e) { /* stub */ } };
 
   /* ---- head -------------------------------------------------------------- */
@@ -119,6 +130,14 @@ export function mount(container, ctx) {
     el('div', { class: 'gg-eyebrow' }, [el('i'), el('span', { text: S.voice.eyebrow })]),
     el('p', { class: 'gg-lead', text: S.voice.lead }),
   ]);
+  /* Directly under the lead, which promised these notes are "sent to whoever you
+   * are duelling" — an unqualified sentence this seat cannot act on. The
+   * correction belongs in the same eyeline as the claim, not at the bottom of the
+   * screen. Absent entirely for an entitled seat: nothing here sells anything to
+   * somebody who already has it. */
+  if (!canSend()) {
+    head.appendChild(el('p', { class: 'gg-lead gg-voice-perk', text: S.voice.screenNoPerk }));
+  }
 
   /* ---- the opt-in --------------------------------------------------------
    * A CHECKBOX with `disabled` until the ack has been read, and a click on the

--- a/ConditioningControlPanel/Resources/web/goon/ui/strings.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/strings.js
@@ -156,19 +156,34 @@ export const S = Object.freeze({
                               We cannot unsend it and the copy must not imply we can. */
     transferSub: 'a few of your images and clips are sent to your opponent — encrypted, straight to their machine, never through our servers. what lands on their side is theirs to keep.',
     /**
-     * NO LONGER A PITCH, because it is no longer a perk (owner call 2026-08-05):
-     * sending is free for every seat and the only thing money buys is HOSTING
-     * (title.hostNoLab, above). Renamed off `transferNoPremium` so the key stops
-     * lying about why the row is dark.
+     * IT IS A PERK AGAIN (owner call 2026-08-06), and this line is the whole
+     * reason the re-gate is allowed to exist.
      *
-     * Deliberately still HERE rather than deleted. caps.mediaTransfer can be
-     * false in exactly two ways now — a server that answers `media_send:false`
-     * (the policy hook the field was kept alive for), or a host frame so old it
-     * never carried the flag — and a greyed row with no sentence under it is the
-     * precise bug report this string family exists to prevent. Vague on purpose:
-     * naming a cause we cannot tell apart would be a guess.
+     * THE HISTORY, because it is the argument. The FIRST tier gate shipped with
+     * no copy at all: a free seat's attacks silently fell back to the RECEIVER's
+     * own pool for the whole match, every gate green, nothing on screen — and it
+     * was read as a broken feature rather than as a paywall, which is why it was
+     * un-gated on 2026-08-05 rather than explained. Sending was free for exactly
+     * one day. What comes back on 2026-08-06 is the gate WITH its sentence: tier
+     * 1+ (any paid tier or whitelist) may send, an anonymous `g_` guest may not,
+     * and this row says which one this seat is instead of going quietly dark.
+     *
+     * ONE SEND POLICY, NOT TWO. Voice notes ride the SAME `caps.mediaTransfer`
+     * (S.voice.lobbyNoPerk says this in the voice row's own words), so a player
+     * never has to learn two entitlements for one idea.
+     *
+     * NAMES THE PERK, THEN NAMES WHAT IS STILL FREE — the shape title.hostNoLab
+     * uses, because "no" on its own is what got read as breakage. RECEIVING was
+     * never gated in any era and the second clause is the load-bearing half.
+     *
+     * STILL THE ONLY SENTENCE FOR THE OTHER TWO CAUSES, and it is correct for
+     * them: caps.mediaTransfer can also be false because a server answered
+     * `media_send:false` (the policy hook) or because a host frame is too old to
+     * carry the flag. The tier gate is the dominant one by orders of magnitude,
+     * and the affordance is identical in all three — sending off, receiving on —
+     * so naming the perk is the honest read of a dark row rather than a guess.
      */
-    transferOff: 'sending is switched off for this seat — you can still receive theirs.',
+    transferOff: 'sending your own media is a supporter perk — you can still receive theirs.',
     transferPeerOld: 'their app is too old for this — nothing crosses either way.',
     transferRelay: 'only on a direct connection. this one is relayed.',
     /**
@@ -342,6 +357,24 @@ export const S = Object.freeze({
     reportPick: 'pick the one you mean',
     reportFlagged: 'flagged during the match',
     reportPrivacy: "a moderator gets the file's fingerprint, a small thumbnail and your note. they never get your name, and the other player is never told.",
+    /* --- THE OTHER ROAD (owner ask, 2026-08-06). The card above reports ONE
+       FILE: a fingerprint, a thumbnail and a note, filed against an artifact. A
+       lot of what a person actually needs to report is not a file at all — being
+       threatened, being harassed across several duels, something said on a voice
+       note — and none of that fits a picker of pictures.
+       So the humans get named too, and the line asks for the two things that make
+       a mail actionable: the pictures, and WHO. The name is interpolated when the
+       recap knows it (match.opponent.displayName) because "the name of the player
+       you were with" is the single hardest field for a stranger to reconstruct an
+       hour later, and it is right there on this screen. It is a DISPLAY NAME, not
+       an id or an account — nothing here leaks an identifier the page would not
+       already have shown (see the discord block's rule 2).
+       Rendered BEFORE submitting, not as a receipt afterwards: somebody who is
+       upset enough to need this must not have to file a file-report first to
+       find out that email exists. --- */
+    reportEmail: (name) => (name
+      ? 'for anything serious, email support@cclabs.app — send screenshots of what happened and the name of the player you were with (' + name + ').'
+      : 'for anything serious, email support@cclabs.app — send screenshots of what happened and the name of the player you were with.'),
 
     /* --- the "so what WAS that" card. STANDALONE ONLY: it is written for the
        phone joiner who arrived from an invite link, endured a match and has
@@ -620,6 +653,24 @@ export const S = Object.freeze({
      * decision that is not about this link. See lobby.js paintVoice.
      */
     lobbyRelay: 'this connection is relayed — voice notes only cross a direct one, so the mic is off this match.',
+    /**
+     * THE SEND PERK, in the voice row's own words (owner call 2026-08-06). Voice
+     * notes ride the SAME capability as media (`session.caps.mediaTransfer`, C#
+     * TransferAllowed / the server's `media_send` verdict, tier 1+): one send
+     * policy, not two, so a player never has to hold two entitlements in their
+     * head for one idea.
+     *
+     * SAID HERE, IN THE LOBBY, because the mic is HIDDEN rather than greyed when
+     * this bites (ui/voice/micHud.js applyPresence — a disabled mic would be a
+     * standing invitation), and a hidden control with no sentence anywhere is
+     * precisely the failure that got the first media gate reverted. The row is
+     * NOT disabled: this checkbox is also the RECEIVE gate and the standing
+     * answer for the next duel, exactly as with lobbyRelay above.
+     *
+     * Same shape as S.lobby.transferOff and S.title.hostNoLab — name the perk,
+     * then name what is still free. Hearing them was never gated.
+     */
+    lobbyNoPerk: 'sending your own voice is a supporter perk — you can still hear theirs.',
     /** The row's own explanation, when there is no status to report yet. */
     lobbySub: 'hold the mic under your items to send ten seconds of your voice. you both have to switch it on.',
     /** Before the acknowledgment has been read. Says what to press, not "no". */
@@ -639,6 +690,11 @@ export const S = Object.freeze({
     micPeerOldToast: 'no mic this duel — their app is too old for voice notes',
     micRelayToast: 'no mic this duel — relayed connection, and voice only crosses a direct one',
     micZenToast: 'your mic is live but hidden by zen — bring the desk chrome back to use it',
+    /** ...and the entitlement, in the same one-toast family (2026-08-06). Without
+     *  this arm a seat that opted in, reached a direct duel and met both consents
+     *  would get a hidden mic and SILENCE from every surface in the match — the
+     *  one outcome this whole toast family exists to make impossible. */
+    micNoPerkToast: 'no mic this duel — sending your voice is a supporter perk',
 
     /* --- the refusals ----------------------------------------------------- */
     /** getUserMedia said no. NOT an error tone: it is a perfectly good answer. */
@@ -656,6 +712,23 @@ export const S = Object.freeze({
      * through ourselves.
      */
     relayOff: 'no direct link — voice notes stay home',
+    /**
+     * THE ENTITLEMENT REFUSAL, on the strip (ui/voice/micHud.js sendReasonLine,
+     * reason 'not-entitled'). In practice the mic is already gone by the time a
+     * send could answer this — the service folds the cap into available() — so
+     * this is the copy for the race where a server verdict lands mid-gesture.
+     * Short, because it lands on a 48px strip, and it still names the perk.
+     */
+    noPerkSend: 'sending voice is a supporter perk — nothing was sent',
+    /**
+     * THE LIBRARY SCREEN'S LINE (ui/screens/voice.js). The screen KEEPS WORKING
+     * when this shows: recording, playing back, deleting and pinning notes to
+     * emotes are all local and none of them is gated. Only the crossing is. Said
+     * as plainly as that, because "a supporter perk" over a screen that had
+     * silently stopped functioning would be the 2026-08-05 mistake with better
+     * words on it.
+     */
+    screenNoPerk: 'sending your voice to an opponent is a supporter perk. recording, keeping and pinning notes to emotes all still work, and you can still hear theirs.',
     /** Where the volume lives, from the screen that made the note. */
     volumeHint: 'their notes play at the Voice notes volume in options.',
   },

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/micHud.js
@@ -235,13 +235,19 @@ function createLedger() {
  * the suite pins the mapping rather than re-deriving it, and so a reason nobody
  * anticipated still says something true instead of nothing.
  *
- * @param {string} reason  sent|relay|unavailable|too-soon|busy|empty|too-big|unreadable|aborted|send-failed
+ * @param {string} reason  sent|not-entitled|relay|unavailable|too-soon|busy|empty|too-big|unreadable|aborted|send-failed
  * @param {number} [waitSec] seconds left on the 4s floor, for 'too-soon'
  */
 export function sendReasonLine(reason, waitSec = 1) {
   switch (reason) {
     case 'sent':        return S.voice.sent;
     case 'too-soon':    return S.voice.tooSoon(Math.max(1, Math.ceil(waitSec)));
+    /* THE PERK (2026-08-06). Its own sentence for the same reason 'relay' has one:
+     * `notActive` sends the player to the two consent checkboxes, and neither of
+     * them is the thing standing in the way. Rare by construction — the mic is not
+     * on the desk for an ungated seat at all (voiceService.available folds the cap
+     * in), so this is the copy for the race where a verdict lands mid-gesture. */
+    case 'not-entitled': return S.voice.noPerkSend;
     /* THE RELAYED DUEL. Its own sentence rather than `notActive`, because it is not a
      * switch anybody can flip: voice notes are P2P-only and this link never came up
      * direct. In practice the mic is already gone by the time a send could answer this

--- a/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/voice/voiceService.js
@@ -36,12 +36,22 @@
  * feature where somebody's voice can be OWED to them — queued, retried, delivered
  * three minutes later out of context — is a different and much worse feature.
  *
- * THE SIX GATES, and every one of them is enforced on BOTH ends because the
+ * SENDING IS A PERK; HEARING IS NOT (owner call, 2026-08-06). Voice notes ride the
+ * SAME capability as media — `session.caps.mediaTransfer`, tier 1+, computed by the
+ * C# host's TransferAllowed() and by the server's `media_send` verdict — folded in
+ * here through the `sendAllowed` predicate. One send policy, not two. It sits on the
+ * SEND SIDE ONLY: `onMeta` / `onChunk` / `onEnd` never consult it, so an ungated seat
+ * hears everything its opponent sends, exactly as before. See `sendEntitled`.
+ *
+ * THE SEVEN GATES, and every one of them is enforced on BOTH ends because the
  * wire is untrusted and the other end is a stranger's build:
  *
  *   0. THE LINK. `match.linkIsP2P` — see above. First, because it is the only one
  *      that is about US rather than about the two players, and no agreement they
  *      could reach would make a relayed voice note acceptable.
+ *   0b. THE ENTITLEMENT (`sendAllowed`). Send-side only, and reported ahead of the
+ *      switches below because it is the one gate no switch on this page can move —
+ *      see `available()` for why the ORDER is the whole legibility argument.
  *   1. CONSENT. Both sides declared `voice_notes` on the consent frame AND the
  *      peer's build advertises `caps.voice` (core/match.js voiceNotesAgreed).
  *   2. PHASE. Countdown, Live, SuddenDeath. Nothing before, nothing after —
@@ -246,12 +256,15 @@ function nowMs() {
  * @param {object}   o.prefs          ui/prefs.js handle (`voiceNotesEnabled` is the receive gate)
  * @param {object}   [o.noteStore]    ui/voice/noteStore.js (wave 2). null = live notes only
  * @param {object}   [o.blocklist]    net/blocklist.js — see the consult below
+ * @param {Function} [o.sendAllowed]  () => boolean — the ENTITLEMENT, read live.
+ *                   boot.js passes `session.caps.mediaTransfer === true`. Omitted
+ *                   means "nobody is gating this build" — see sendEntitled().
  * @param {object}   [o.logger]       console-shaped
  * @param {Function} [o.now]          TEST AFFORDANCE — the clock the rate limits read
  */
 export function createVoiceService({
   match = null, audio = null, prefs = null, noteStore = null,
-  blocklist = null, logger = null, now = nowMs,
+  blocklist = null, sendAllowed = null, logger = null, now = nowMs,
 } = {}) {
   const clock = typeof now === 'function' ? now : nowMs;
   const log = logger;
@@ -300,9 +313,37 @@ export function createVoiceService({
   }
 
   /**
-   * The ONE predicate. The link, both consents, the peer's build, the phase, and our
-   * own opt-in — all six, ANDed, in one place, so the mic button and the send path
-   * can never disagree about whether this feature is live.
+   * MAY THIS SEAT SEND AT ALL? The tier gate, read LIVE rather than captured: the
+   * server's `media_send` verdict can land after this service was built (boot.js
+   * adoptServerSendVerdict runs on two roads and the first one is after attach),
+   * so a snapshot taken in the constructor would be null on every fresh duel.
+   *
+   * NO PREDICATE MEANS NOT GATED. Every self-test in test/selftest-voice*.js
+   * constructs this service without one, and so does any caller that predates the
+   * cap; answering `false` to them would turn "we added an option" into "voice is
+   * off everywhere". The production caller ALWAYS passes one (boot.js), so the
+   * permissive default is only ever reachable where there is no entitlement model
+   * to consult — the same shape as bridge.js's pure-local dev affordance.
+   *
+   * A PREDICATE THAT THROWS IS A NO, which is the other half: once somebody IS
+   * gating this build, an unreadable answer must not become a send.
+   */
+  function sendEntitled() {
+    if (typeof sendAllowed !== 'function') return true;
+    try { return sendAllowed() === true; } catch (_e) { return false; }
+  }
+
+  /**
+   * The ONE predicate. The entitlement, the link, both consents, the peer's build,
+   * the phase, and our own opt-in — all seven, ANDed, in one place, so the mic
+   * button and the send path can never disagree about whether this feature is live.
+   *
+   * THE ENTITLEMENT IS IN HERE, AND THAT IS DELIBERATE: `available()` is what puts
+   * the mic on the desk (ui/voice/micHud.js subscribes to it), so an ungated seat
+   * simply has no mic rather than a mic that refuses on release. Recording somebody's
+   * voice and then telling them it cannot go anywhere is a worse answer than never
+   * opening the microphone. RECEIVING does not read this function at all (see onMeta
+   * / onChunk / onEnd) — an ungated seat still hears every note its opponent sends.
    *
    * Note that a SOLO match satisfies none of it in practice (the practice
    * opponent never declares `voice_notes`), which is how the mic stays off
@@ -310,6 +351,7 @@ export function createVoiceService({
    */
   function available() {
     if (disposed || !match) return false;
+    if (!sendEntitled()) return false;
     if (!localEnabled()) return false;
     if (!linkDirect()) return false;
     try { return !!match.voiceNotesAgreed && !!match.voicePhaseOpen; } catch (_e) { return false; }
@@ -343,6 +385,14 @@ export function createVoiceService({
   function whyUnavailable(o = {}) {
     if (disposed) return 'the voice service is disposed';
     if (!match) return 'no match';
+    /* THE ENTITLEMENT, AHEAD OF EVERY SWITCH, and the order is the point rather
+     * than an accident. Reported after the opt-in it would read as "switch voice
+     * notes on" to a seat for which switching it on changes nothing — sending a
+     * player to a control that cannot help them is the 2026-08-05 blindness with
+     * an extra step. This gate is terminal for the seat: no checkbox on this page
+     * moves it, and the lobby row (S.voice.lobbyNoPerk) says so where the player
+     * can act on it. */
+    if (!sendEntitled()) return 'sending is not entitled for this seat (caps.mediaTransfer is not true — tier 1+ perk)';
     if (!localEnabled()) return 'local pref off (voice notes are not switched on for this seat)';
     // THE LINK, in available()'s own order. Terminal for the whole match: net/session.js
     // never upgrades a relayed duel back to P2P, so this sentence means "not this duel".
@@ -394,12 +444,21 @@ export function createVoiceService({
    * @param {string} [o.emote]  the emote this note rides with, or null for a live one
    * @param {number} [o.durMs]  recorded length, for their chip. Cosmetic.
    * @returns {Promise<{ok:boolean, reason:string, id:number, parts:number}>}
-   *   reason is 'sent' | 'relay' | 'unavailable' | 'too-soon' | 'busy' | 'empty' |
-   *   'too-big' | 'unreadable' | 'aborted' | 'send-failed'.
+   *   reason is 'sent' | 'not-entitled' | 'relay' | 'unavailable' | 'too-soon' |
+   *   'busy' | 'empty' | 'too-big' | 'unreadable' | 'aborted' | 'send-failed'.
    */
   async function sendBlob(blob, o = {}) {
     const fail = (reason) => { stats.sendDropped++; return { ok: false, reason, id: 0, parts: 0 }; };
     if (disposed) return fail('unavailable');
+    /* THE ONE CHOKE POINT (2026-08-06). Live mic and emote-attached both arrive
+     * here — sendNote() delegates — so this single line is the whole send gate,
+     * and `available()` below already ANDs the same fact in. It is stated TWICE
+     * on purpose: this one gives the refusal its OWN reason code, so the strip
+     * can say "supporter perk" (S.voice.noPerkSend) instead of the catch-all
+     * 'unavailable' -> "you both have to switch it on", which would be a lie
+     * pointing at the wrong control. Checked before the link for the same reason
+     * whyUnavailable reports it first. */
+    if (!sendEntitled()) return fail('not-entitled');
     /* 'relay' IS ITS OWN REASON, and it is checked before the general predicate so it
      * cannot be reported as the catch-all 'unavailable'. The two mean different things
      * to a player — "you both have to switch it on" is something they can fix, "this
@@ -429,7 +488,10 @@ export function createVoiceService({
     // Re-checked AFTER the await: a match can end, a phase can turn, or a link can
     // fall over, while a blob is being read off disk — and the gate that mattered is
     // the one at send time. The link is asked for separately so a degrade mid-read is
-    // still reported as the relay refusal rather than as a generic one.
+    // still reported as the relay refusal rather than as a generic one. The
+    // entitlement is asked for separately on the same terms: a verdict that landed
+    // while the blob was being read is a perk refusal, not a generic one.
+    if (!sendEntitled()) return fail('not-entitled');
     if (!linkDirect()) return fail('relay');
     if (!available()) return fail('unavailable');
 
@@ -693,6 +755,10 @@ export function createVoiceService({
     available,
     /** '' when the mic is live, else the FIRST failing gate. See the block above. */
     whyUnavailable,
+    /** May this seat send at all (the tier perk), regardless of consents, phase or
+     *  link? Exported so a screen can explain a hidden mic without re-deriving the
+     *  cap, and so the suite can pin the gate on its own. */
+    sendEntitled,
     sendBlob,
     sendNote,
 

--- a/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonHostService.cs
@@ -879,18 +879,22 @@ namespace ConditioningControlPanel.Services.GoonGame
         /// <c>true</c> so the gate has one place to come back to if that ever changes.)</summary>
         private static bool BrainDrainAllowed() => true;
 
-        /// <summary>May the page send its OWN media to the opponent? YES — for everyone in a room.
+        /// <summary>May the page send its OWN media to the opponent? TIER 1+ (any paid tier or
+        /// whitelist), re-gated 2026-08-06.
         ///
-        /// This WAS a premium gate (tier >= 1). Owner call 2026-08-04: the supporter perk is
-        /// HOSTING (<see cref="HostingAllowed"/>, tier 2) — once a duel exists, BOTH players
-        /// sending their media is what makes the match feel like a duel, and an invited free
-        /// player throwing blanks read as broken in the very first real play-test. The server's
-        /// <c>media_send</c> verdict on /invite and /join flipped to unconditional the same day,
-        /// so the two verdicts still agree. Consent still gates it per-match (the lobby checkbox
-        /// both sides must tick), and receiving was never gated.</summary>
+        /// Sending was free-for-every-seat for one day (owner call 2026-08-04): the free model
+        /// fixed the "invited free player throws blanks" bug from the first play-test, but left
+        /// an un-gated seat able to push arbitrary media at an opponent, and abuse won over
+        /// generosity. The blank-attack lesson survives as UI instead: the lobby transfer row
+        /// names the perk (S.lobby.transferOff) rather than greying out in silence. The server's
+        /// <c>media_send</c> verdict on /invite and /join computes the same bar
+        /// (computeEffectiveTier &gt;= 1), so the two verdicts agree; voice notes ride this same
+        /// cap. Consent still gates the lane per-match (the lobby checkbox both sides must
+        /// tick), and receiving was never gated.</summary>
         private static bool TransferAllowed()
         {
-            return true;
+            try { return App.Patreon?.HasPremiumAccess == true; }
+            catch { return false; }
         }
 
         /// <summary>May the page MINT a room? TIER 2 ONLY.


### PR DESCRIPTION
## What

Re-gates Goon Game **sending** (P2P media transfer AND voice notes) to tier 1+ / whitelist, per owner call 2026-08-06 (abuse hardening). Receiving, joining, and relay stay free; hosting stays tier 2.

Server half is already on CCP-Server main (`310c647`): `media_send` answers `computeEffectiveTier >= 1` on `/invite` + `/join`, anonymous guests always false. Every deployed web/phone client obeys that verdict with no release (the policy hook kept alive for exactly this).

## Why this won't repeat the blank-attack bug

The first tier gate (pre-08-05) shipped with zero client messaging, so a free player's attacks silently fell back to the receiver's pool and read as broken. This time the gate is named everywhere it bites:

- lobby transfer row: "sending your own media is a supporter perk — you can still receive theirs."
- voice: mic HUD reason line, lobby voice row, and the Send Voice Notes screen all name the perk; recording/library/pinning still work, hearing theirs still works
- an emote fired by an ungated seat simply doesn't carry its note (no error spam)

## Also in here (owner ask)

Recap report card now tells players: for anything serious, email **support@cclabs.app** with screenshots and the name of the player they were with (opponent name filled in when known).

## Mechanics

- `TransferAllowed()` = `App.Patreon?.HasPremiumAccess == true` (tier>=1 or whitelist, Patreon + SubscribeStar) — the C# init frame verdict for hosted seats
- voice rides the **same** `caps.mediaTransfer` cap via a new `sendAllowed` predicate on `voiceService` (one send policy, not two); gate sits at the send seam, receive path untouched
- consent seed + `adoptServerSendVerdict` + bridge default-ON are behaviorally unchanged (comments brought to the re-gated truth)

## Tests

All 15 goon suites green: voice 292, voice-ui 286, hostgate 106 (new pin on the C# `TransferAllowed` body), hud 1703, report 230, net 351, flow 321, exec 1070, assets 427, transfer 199, encode 190, core 242, coach 136, invite 199 (avafx 176/188 = pre-existing baseline). `dotnet build` 0 errors. Server suite 160/160 (was 150 + 9 stale weekly-pass-era fails, harnesses modernized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)