### PR TITLE
fix(goon): enforce the draft agreement on inbound payloads, and stop a peer from ending your match

### DIFF
--- a/ConditioningControlPanel/Resources/web/goon/core/contracts.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/contracts.js
@@ -268,6 +268,32 @@ export function costOf(kind) {
   return c === undefined ? Infinity : c;
 }
 
+/**
+ * Which ELEMENT a payload kind lands as. Frozen, because both sides of it are frozen wire codes.
+ *
+ * IT LIVES HERE, not in exec/executor.js where it used to be the only copy, because the AGREEMENT
+ * GATE reads it (core/match.js _handleInboundPayload) and core/ must stay node-import-safe —
+ * importing the executor would drag the whole renderer tree, and the DOM with it, into the engine.
+ * exec/executor.js re-exports this object so the renderer fan-out and the gate can never disagree
+ * about what a kind turns into; ui/announcer.js keeps a hand-written mirror for its own copy deck.
+ *
+ * A kind with NO entry (a newer peer's kind 8) maps to undefined, which the gate reads as "not a
+ * draft-toggleable element" and lets through to the checks that do know about it. The unknown-kind
+ * guard is costOf's job, above, and it runs first.
+ *
+ * MIRROR: GoonConsts.ElementFor(GoonPayloadKind) in Services/GoonGame/GoonContracts.cs.
+ */
+export const PAYLOAD_ELEMENT = Object.freeze({
+  [GoonPayloadKind.FlashBurst]: GoonElement.Flashes,
+  [GoonPayloadKind.SubliminalStorm]: GoonElement.Subliminals,
+  [GoonPayloadKind.BubbleSwarm]: GoonElement.Bubbles,
+  [GoonPayloadKind.Video]: GoonElement.Videos,
+  [GoonPayloadKind.LockCard]: GoonElement.LockCards,
+  [GoonPayloadKind.ToyPattern]: GoonElement.ToyPatterns,
+  [GoonPayloadKind.BrainDrain]: GoonElement.BrainDrain,
+  [GoonPayloadKind.Spiral]: GoonElement.Spiral,
+});
+
 // ------------------------------------------------------------------ factories
 
 /**

--- a/ConditioningControlPanel/Resources/web/goon/core/match.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/match.js
@@ -17,8 +17,10 @@
 //  * Mercy is available in EVERY phase and always ends the match locally, even if the wire is
 //    dead. Pre-Live it degrades to a clean cancel that never reaches the ledger.
 //  * No payload kind can touch panic/lockdown/tray/session state — no such message exists.
-//  * The RECEIVER enforces admission: burst/gap rate limit, one heavy per match, schedule-buffer
-//    clamp and text cap — regardless of what the wire claims.
+//  * The RECEIVER enforces admission: THE DRAFT AGREEMENT (an element this seat switched off is
+//    not throwable AT this seat, 2026-08-06 — the sheet governs the throwables, not just the
+//    ramp), burst/gap rate limit, one heavy per match, schedule-buffer clamp and text cap —
+//    regardless of what the wire claims.
 //    THE CHARGE CHECK IS NOT ON THAT LIST ANY MORE (owner, 2026-08-05: "we should remove the
 //    requirement entirely"). The receiver used to hold a sender to the charge count on their last
 //    state tick and reject anything dearer. Nothing gates on a balance now, on either side, so a
@@ -63,7 +65,7 @@
 
 import {
   GoonAttentionMode, GoonElement, GoonEndReason, GoonMatchPhase, GoonPayloadKind, GoonTransportState,
-  GoonConsts, clampWindowCount, costOf, enumName, isClockMessage,
+  GoonConsts, PAYLOAD_ELEMENT, clampWindowCount, costOf, enumName, isClockMessage,
   makeConsent, makeDraft, makeEmote, makeHello, makeMatchStart, makeMediaPrep, makeMercy,
   makePayloadReceipt, makeResult, makeTick, makePayload, makeVoice, peerSpeaksVoice, VOICE_SUBS,
 } from './contracts.js';
@@ -86,6 +88,10 @@ const DRAW_WINDOW_MS = 1500;
 const PAYLOAD_SCHEDULE_BUFFER_MS = 1500;   // >= GoonConsts.MinScheduleBufferMs
 const NO_CAM_CHECK_INTERVAL_MS = 90000;
 const MAX_PAYLOAD_DURATION_MS = 180000;
+/* Ceiling on a score the PEER reports for its own half. Deliberately far above anything reachable
+   — the per-second rate tops out near 3 (risk x attention), so even a 24-hour sitting lands around
+   265k — because this is a sanity clamp on an untrusted number, not a balance rule. */
+const MAX_REPORTED_SCORE = 1000000;
 
 /** Freshness of the opponent's state ticks. */
 export const GoonConnectionHealth = Object.freeze({ Fresh: 0, Wobbly: 1, Dead: 2 });
@@ -146,6 +152,21 @@ export class GoonMatchResult {
 // ------------------------------------------------------------------ small helpers
 
 function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+/**
+ * A score off the wire, made storable. The peer's half of the scoreboard is THEIRS to report (each
+ * side is authoritative for its own half) and was taken verbatim until 2026-08-06 — so `"guest
+ * score: NaN"`, a negative, or 1e308 went straight onto the recap and into the ledger row.
+ * Anything that is not a finite number reads 0, exactly as an absent field does.
+ *
+ * MIRROR: GoonMatchService.ClampReportedScore(int) — which only needs the range half, the wire
+ * type having already been enforced by the C# DTO.
+ */
+function clampReportedScore(v) {
+  const n = typeof v === 'number' ? v : (typeof v === 'string' ? Number(v) : NaN);
+  if (!Number.isFinite(n)) return 0;
+  return clamp(Math.trunc(n), 0, MAX_REPORTED_SCORE);
+}
 
 /** C# Math.Round(double) is banker's rounding. */
 function roundHalfToEven(x) {
@@ -1568,6 +1589,29 @@ export class GoonMatchService {
       this._rejectPayload(payload, GoonReceiptStatus.RejectedFiltered, 'kind not in our advertised caps');
       return;
     }
+    /* THE AGREEMENT, ON THE THROWABLES (2026-08-06). Until this check existed the draft governed
+       ONE thing — buildRamp's self-inflicted schedule — and nothing else. The agreement screen
+       says "everything is on. switch off what you will not take — you both get whatever is left"
+       (ui/strings.js), and yet switching Videos off and signing left an opponent free to open a
+       video on your monitor, because the only element-shaped test down here was the STATIC caps
+       list built once in boot.js. A promise the receiver made to itself was being kept by nobody.
+       `_localAllowed` is OUR OWN sheet, deliberately, not sharedPool(): the intersection is what
+       the RAMP is rolled from, and a receiver is the authority on what it will take regardless of
+       what the sender left switched on at their end.
+       THE ALWAYS-ON EXEMPTION IS LOAD-BEARING. `_localAllowed` is defaultAllowed(pool), which is
+       normalizeAllowed()'d — it can never contain Bubbles (the always-on baseline, never toggled,
+       never rolled) and never contains an element outside the caps intersection. Testing every
+       kind against it would therefore reject BubbleSwarm outright: kind 2 is not throwable from
+       our own arsenal any more, but it is a frozen wire code an older or third-party client may
+       still send and exec/bubbles.js still renders it. So enforcement is scoped to elements that
+       ACTUALLY HAD A TOGGLE — the same set `_localAllowed` was seeded from. */
+    const inboundElement = PAYLOAD_ELEMENT[payload.kind];
+    if (inboundElement !== undefined && this._isDraftToggleable(inboundElement)
+      && !this._localAllowed.includes(inboundElement)) {
+      this._rejectPayload(payload, GoonReceiptStatus.RejectedFiltered,
+        `${enumName(GoonElement, inboundElement)} is switched off on our agreement sheet`);
+      return;
+    }
     if (payload.kind === GoonPayloadKind.BrainDrain && this._remoteHeavyUsed) {
       this._rejectPayload(payload, GoonReceiptStatus.RejectedFiltered, 'heavy already used');
       return;
@@ -1612,6 +1656,21 @@ export class GoonMatchService {
 
     this._ev.payloadAccepted.emit({ payload, fireAtLocalMs },
       (e) => this._error(`payloadAccepted handler threw: ${(e && e.stack) || e}`));
+  }
+
+  /**
+   * Was this element ever on the agreement screen for THIS pairing?
+   *
+   * The answer has to be derived exactly the way `_localAllowed` was seeded (`_tryEnterDraft`:
+   * defaultAllowed(this._availableDraftPool)), or the gate above starts disagreeing with the
+   * sheet the player actually signed: defaultAllowed() drops the always-on element, drops
+   * anything outside PoolV1, and falls back to the whole pool when the caps intersection is
+   * empty — three behaviours a hand-rolled `PoolV1.includes(e)` would each get wrong.
+   *
+   * MIRROR: GoonMatchService.IsDraftToggleable(GoonElement).
+   */
+  _isDraftToggleable(element) {
+    return defaultAllowed(this._availableDraftPool).includes(element);
   }
 
   _rejectPayload(payload, status, reason) {
@@ -1859,20 +1918,57 @@ export class GoonMatchService {
     this._ev.matchEnded.emit(result, (e) => this._error(`matchEnded handler threw: ${(e && e.stack) || e}`));
   }
 
+  /**
+   * Their `result`. TWO GATES BEFORE THE ADOPT BRANCH (2026-08-06), because that branch used to be
+   * a remote kill switch: it ran on `!this._ended` with no phase test and a hard-coded
+   * countsForLedger=true, so a frame sent five seconds into Live — `{"t":"result","end_reason":1,
+   * "winner_is_host":<not me>}` — ended the victim's match on the spot and wrote them a loss.
+   *
+   *   1. THE PHASE. A result is meaningless before a match exists; anything outside
+   *      Live/SuddenDeath/Recap is logged and dropped. (Recap is in the list because that is where
+   *      the countersign handshake lives, and because a PRE-LIVE peer mercy puts us in Recap
+   *      through _handleRemoteMercy before their result frame lands behind it on the same ordered
+   *      channel.)
+   *   2. WHO IT SAYS LOST. The branch is NOT dead code and must not be turned into
+   *      `if (this._ended)`: it is how PEER MERCY is honoured — they tap out, they end, they send
+   *      a result in which THEY are the loser, and we adopt it. What no honest client can produce
+   *      is a result declaring US the loser while OUR side is still running: our own loss is only
+   *      ever resolved locally (mercy, the abandon watchdog, sudden death). So we adopt a
+   *      concession or a draw, and refuse a claimed local loss — the match simply carries on, and
+   *      if the peer then drops, _checkOpponentFreshness records the abandon it always did.
+   *      Sudden death is DETACHED today (no runner is assigned in boot.js / soloDriver.js), so
+   *      there is no legitimate path at all for the peer to resolve our loss; the rule is written
+   *      so it still reads correctly if the round ladder comes back.
+   *
+   * MIRROR: GoonMatchService.HandleRemoteResult — same two gates, same score clamp.
+   */
   _handleRemoteResult(remote) {
+    if (this._phase !== GoonMatchPhase.Live && this._phase !== GoonMatchPhase.SuddenDeath
+      && this._phase !== GoonMatchPhase.Recap) {
+      this._warn(`ignoring a result frame in phase ${this._phase} - no match to end`);
+      return;
+    }
+
     if (!this._ended) {
-      // Their end signal reached us before ours fired (lost mercy, or a sudden-death exit resolved
-      // on their side first). Adopt their outcome.
+      // Their end signal reached us before ours fired (their mercy, or a sudden-death exit
+      // resolved on their side first).
       const localLost = remote.winner_is_host !== null && remote.winner_is_host !== undefined
         && remote.winner_is_host !== this._isHost;
-      this._endMatch(remote.end_reason, localLost, true);
+      if (localLost) {
+        this._warn('REFUSED a result that declares us the loser while our side is still running - '
+          + 'not ending, not recording');
+        return;
+      }
+      this._endMatch(remote.end_reason, false, true);
     }
     const result = this._result;
     if (!result) return;
 
-    // Each side's own score is authoritative for its own half.
-    if (this._isHost) result.guestScore = remote.guest_score;
-    else result.hostScore = remote.host_score;
+    // Each side's own score is authoritative for its own half — and it is still THEIR NUMBER off
+    // an untrusted wire, so it is clamped to something a match can actually produce before it is
+    // stored, shown on the recap, or handed to the ledger.
+    if (this._isHost) result.guestScore = clampReportedScore(remote.guest_score);
+    else result.hostScore = clampReportedScore(remote.host_score);
 
     if (remote.agree) {
       result.agreed = true;

--- a/ConditioningControlPanel/Resources/web/goon/core/suddenDeath.js
+++ b/ConditioningControlPanel/Resources/web/goon/core/suddenDeath.js
@@ -69,8 +69,8 @@ import {
 } from './contracts.js';
 import { GoonRng, combineSeeds, newSeedContribution } from './rng.js';
 import {
-  GoonRoundConsts, GoonRoundVerdict, createEmitter, deferred, delay, isAbortError, nullRoundInputs,
-  nullRoundPresenter, present, signalAsync, waitUntilMatchMs,
+  GoonRoundConsts, GoonRoundVerdict, INT_MAX, createEmitter, deferred, delay, isAbortError,
+  nullRoundInputs, nullRoundPresenter, present, signalAsync, waitUntilMatchMs,
 } from './rounds/model.js';
 import * as quickDraw from './rounds/quickDraw.js';
 import * as staringContest from './rounds/staringContest.js';
@@ -143,8 +143,70 @@ const verdictHigher = (mine, theirs) =>
   mine > theirs ? GoonRoundVerdict.Win : mine < theirs ? GoonRoundVerdict.Loss : GoonRoundVerdict.Draw;
 
 /**
+ * The peer's round_result, made safe to judge (2026-08-06).
+ *
+ * GoonRoundJudge.decide compares THEIR numbers against OURS with `<` and `>` and nothing else — it
+ * has no opinion about sign, type or plausibility, and it should not grow one, because it must stay
+ * a pure antisymmetric function of two results. So the untrusted half is cleaned up HERE, on
+ * ingest, before it is judged, shown or emitted: a peer that reports `reaction_ms: -5` would
+ * otherwise beat every human alive, and `elapsed_ms: -1` wins a quick draw the same way.
+ *
+ * `suspect` is RECOMPUTED rather than read. It is self-reported (rounds/reactionDuel.js sets it on
+ * its own measurement), it gates nothing, and a cheat would simply send false — so the flag that
+ * reaches the recap is now OUR verdict on THEIR claimed number, which is the only version of it
+ * that means anything.
+ *
+ * Sudden death is DETACHED today (no runner is assigned in boot.js / soloDriver.js), so this is
+ * hardening for the day the ladder comes back rather than a live hole. Kept deliberately small.
+ *
+ * MIRROR: GoonSuddenDeathRunner.SanitizePeerResult in Services/GoonGame/GoonSuddenDeath.cs.
+ *
+ * @param {number} kind GoonRoundKind the round was actually run as
+ * @param {object} peer raw round_result off the wire
+ * @returns {object} a fresh round_result — the input is never mutated
+ */
+export function sanitizePeerRoundResult(kind, peer) {
+  if (!peer) return peer;
+
+  const int = (v, lo, hi) => {
+    const n = typeof v === 'number' ? v : (typeof v === 'string' ? Number(v) : NaN);
+    if (!Number.isFinite(n)) return lo;
+    const t = Math.trunc(n);
+    return t < lo ? lo : t > hi ? hi : t;
+  };
+
+  // Per-kind range for `progress`, which is a different quantity in every round (see the
+  // RoundResultMsg doc comment): attention percent, bubbles popped, mistakes typed, false-start
+  // flag. Anything unknown falls back to the non-negative-integer floor.
+  const progressMax = kind === GoonRoundKind.StaringContest ? 100
+    : kind === GoonRoundKind.BubbleRace ? GoonRoundConsts.BubbleMaxCount
+      : kind === GoonRoundKind.ReactionDuel ? 1
+        : INT_MAX;
+
+  // spec.maxResponseMs IS this constant (rounds/reactionDuel.js buildSpec), and the runner does
+  // not hold the spec — the round owns it and returns only the measurement.
+  const reactionRaw = peer.reaction_ms;
+  const reactionMs = (reactionRaw === null || reactionRaw === undefined)
+    ? null : int(reactionRaw, 0, GoonRoundConsts.ReactionMaxResponseMs);
+
+  return makeRoundResult({
+    v: peer.v,
+    round_no: int(peer.round_no, 0, INT_MAX),
+    completed: peer.completed === true,
+    elapsed_ms: int(peer.elapsed_ms, 0, INT_MAX),
+    reaction_ms: reactionMs,
+    suspect: reactionMs !== null && reactionMs < GoonConsts.SuspectReactionMs,
+    progress: int(peer.progress, 0, progressMax),
+  });
+}
+
+/**
  * Pure round judgement. Called with the same two results on both machines (arguments swapped), so
  * it MUST be antisymmetric: decide(k, a, b) === Win exactly when decide(k, b, a) === Loss.
+ *
+ * IT TRUSTS ITS ARGUMENTS. Peer results are cleaned by sanitizePeerRoundResult() on ingest, above;
+ * do not add clamping in here, or the two calls (one per machine, arguments swapped) stop being
+ * the same function.
  */
 export const GoonRoundJudge = Object.freeze({
   decide(kind, mine, theirs) {
@@ -380,12 +442,15 @@ export class GoonSuddenDeathRunner {
 
         await this._send(ctx, local, token);
 
-        const peer = await this._results.wait(roundNo, GoonRoundConsts.PeerResultTimeoutMs, token);
-        if (peer == null) {
+        const raw = await this._results.wait(roundNo, GoonRoundConsts.PeerResultTimeoutMs, token);
+        if (raw == null) {
           this._warn(`sudden death: no peer result for round ${roundNo} within ${GoonRoundConsts.PeerResultTimeoutMs}ms`);
           this._raiseAborted('peer_result_timeout');
           return;
         }
+        // Clean on INGEST, once, so everything downstream — judge, verdict UI, outcome event —
+        // sees the same sane numbers. `raw` is not used again past this line on purpose.
+        const peer = sanitizePeerRoundResult(kind, raw);
 
         const verdict = GoonRoundJudge.decide(kind, local, peer);
         this._netScore += verdict === GoonRoundVerdict.Win ? 1 : verdict === GoonRoundVerdict.Loss ? -1 : 0;

--- a/ConditioningControlPanel/Resources/web/goon/exec/executor.js
+++ b/ConditioningControlPanel/Resources/web/goon/exec/executor.js
@@ -46,7 +46,7 @@
  * flips html[data-gg-fx] idle -> warm -> hot and hardens the HUD plates.
  * ==========================================================================*/
 
-import { GoonElement, GoonPayloadKind, enumName } from '../core/contracts.js';
+import { GoonElement, GoonPayloadKind, PAYLOAD_ELEMENT, enumName } from '../core/contracts.js';
 import { localMonotonicMs } from '../core/clock.js';
 
 import * as defaultLayers from './layers.js';
@@ -62,17 +62,11 @@ import { createBrainDrain } from './brainDrain.js';
 import { createBouncingText } from './bouncingText.js';
 import { createSpiral } from './spiral.js';
 
-/** Which element renders a given payload kind. Frozen: the wire codes are frozen. */
-export const PAYLOAD_ELEMENT = Object.freeze({
-  [GoonPayloadKind.FlashBurst]: GoonElement.Flashes,
-  [GoonPayloadKind.SubliminalStorm]: GoonElement.Subliminals,
-  [GoonPayloadKind.BubbleSwarm]: GoonElement.Bubbles,
-  [GoonPayloadKind.Video]: GoonElement.Videos,
-  [GoonPayloadKind.LockCard]: GoonElement.LockCards,
-  [GoonPayloadKind.ToyPattern]: GoonElement.ToyPatterns,
-  [GoonPayloadKind.BrainDrain]: GoonElement.BrainDrain,
-  [GoonPayloadKind.Spiral]: GoonElement.Spiral,
-});
+/* Which element renders a given payload kind. THE TABLE MOVED to core/contracts.js on 2026-08-06
+   and is re-exported here unchanged, because core/match.js's agreement gate now reads it too and
+   core/ may not import exec/ (node-import-safe: no DOM at import). Same object, one truth — a
+   renderer that runs a kind and a gate that admits it can no longer disagree about the element. */
+export { PAYLOAD_ELEMENT };
 
 const MAX_SCHEDULE_LEAD_MS = 190000;   // > MAX_PAYLOAD_DURATION_MS; a sane wire guard
 

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-core.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-core.js
@@ -3,7 +3,12 @@
 
 import { GoonRng, combineSeeds, saltSeed, seedFromAny, seedToString } from '../core/rng.js';
 import { serialize, serializeForSend, parse, wireByteLength, MAX_WIRE_BYTES } from '../core/wire.js';
-import { makeMatchStart, makePayload, makeTick, makeRound, costOf, GoonElement, GoonPayloadKind, GoonConsts } from '../core/contracts.js';
+import {
+  makeMatchStart, makePayload, makeTick, makeRound, costOf, GoonElement, GoonPayloadKind,
+  GoonRoundKind, GoonConsts, PAYLOAD_ELEMENT,
+} from '../core/contracts.js';
+import { sanitizePeerRoundResult } from '../core/suddenDeath.js';
+import { GoonRoundConsts, INT_MAX } from '../core/rounds/model.js';
 import {
   ALWAYS_ON_ELEMENT, GoonCueAction, MAX_MATCH_RISK_TIER, MIN_ALLOWED_ELEMENTS, PoolV1, TogglePool,
   buildRamp, defaultAllowed, isValidAllowed, isValidSharedPool, matchRiskTier, normalizeAllowed,
@@ -194,6 +199,66 @@ const quiet = { info() {}, warn() {}, error() {}, log() {} };
   ok(isValidSharedPool([GoonElement.Spiral, GoonElement.Videos]).ok, 'a two-element one is fine');
   ok(isValidAllowed([]).error === isValidAllowed([]).error.toLowerCase(),
     'engine refusals stay lowercase', isValidAllowed([]).error);
+}
+
+// ------------------------------------- payload -> element, the table the agreement gate reads
+// It moved out of exec/executor.js on 2026-08-06 because core/match.js's agreement gate needs it
+// and core/ may not import exec/. Both sides of every entry are FROZEN wire codes; a renumber or a
+// re-point has to fail here rather than at the far end of a duel.
+{
+  ok(PAYLOAD_ELEMENT[GoonPayloadKind.Video] === GoonElement.Videos, 'Video -> Videos');
+  ok(PAYLOAD_ELEMENT[GoonPayloadKind.BubbleSwarm] === GoonElement.Bubbles, 'BubbleSwarm -> Bubbles');
+  ok(PAYLOAD_ELEMENT[GoonPayloadKind.Spiral] === GoonElement.Spiral, 'Spiral -> Spiral');
+  ok(PAYLOAD_ELEMENT[GoonPayloadKind.BrainDrain] === GoonElement.BrainDrain, 'BrainDrain -> BrainDrain');
+  const kinds = Object.values(GoonPayloadKind);
+  ok(kinds.every((k) => PAYLOAD_ELEMENT[k] !== undefined), 'every payload kind maps to an element',
+    String(kinds.length));
+  ok(PAYLOAD_ELEMENT[99] === undefined,
+    'and a kind we have never heard of maps to nothing — the gate reads that as "not toggleable"');
+  // (that exec/executor.js re-exports this very object is checked in selftest-exec.js, which
+  // already owns the renderer graph — importing it here would drag exec/ into a core-only suite)
+}
+
+// -------------------------- sudden death: the peer's round result is cleaned on INGEST (0806)
+// GoonRoundJudge.decide compares their numbers to ours with < and > and nothing else, so a peer
+// reporting reaction_ms:-5 would beat every human alive. The ladder is DETACHED today; this is the
+// clamp that has to be in place when it comes back.
+{
+  const raw = {
+    round_no: 3, completed: true, elapsed_ms: -1, reaction_ms: -5, suspect: false, progress: 4000,
+  };
+  const duel = sanitizePeerRoundResult(GoonRoundKind.ReactionDuel, raw);
+  ok(duel.elapsed_ms === 0, 'a negative elapsed_ms clamps to 0', String(duel.elapsed_ms));
+  ok(duel.reaction_ms === 0, 'and a negative reaction_ms with it', String(duel.reaction_ms));
+  ok(duel.progress === 1, "the duel's progress is a false-start flag, so it clamps to 0..1",
+    String(duel.progress));
+  ok(duel.suspect === true,
+    'suspect is RECOMPUTED from their claimed number, not read off their flag (they sent false)');
+  ok(raw.elapsed_ms === -1, 'and the frame we were handed is never mutated', String(raw.elapsed_ms));
+
+  const slow = sanitizePeerRoundResult(GoonRoundKind.ReactionDuel,
+    { round_no: 1, completed: true, elapsed_ms: 5000, reaction_ms: 900000, suspect: true });
+  ok(slow.reaction_ms === GoonRoundConsts.ReactionMaxResponseMs,
+    'a reaction beyond the response window clamps to it', String(slow.reaction_ms));
+  ok(slow.suspect === false, 'and a slow one is not suspect however they badged it');
+
+  const race = sanitizePeerRoundResult(GoonRoundKind.BubbleRace,
+    { round_no: 2, completed: 'yes', elapsed_ms: 1e30, progress: 1e9 });
+  ok(race.completed === false, "completed is `=== true`, so a truthy string is not a claim to have won");
+  ok(race.progress === GoonRoundConsts.BubbleMaxCount, 'bubbles popped cannot exceed the biggest race',
+    String(race.progress));
+  ok(Number.isInteger(race.elapsed_ms) && race.elapsed_ms === INT_MAX,
+    'elapsed_ms stays inside the int field the C# side reads it into', String(race.elapsed_ms));
+
+  const staring = sanitizePeerRoundResult(GoonRoundKind.StaringContest,
+    { round_no: 1, completed: true, elapsed_ms: 20000, progress: 5000 });
+  ok(staring.progress === 100, 'average attention is a percent, so it clamps to 100', String(staring.progress));
+
+  const junk = sanitizePeerRoundResult(GoonRoundKind.QuickDrawLockCard,
+    { round_no: NaN, completed: true, elapsed_ms: 'fast', reaction_ms: undefined, progress: null });
+  ok(junk.elapsed_ms === 0 && junk.round_no === 0 && junk.progress === 0,
+    'anything that is not a finite number reads as the floor, exactly as an absent field does');
+  ok(junk.reaction_ms === null, 'and an absent reaction stays absent rather than becoming 0');
 }
 
 // ------------------------------------------------------ the rolled ramp + always-on bubbles

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-exec.js
@@ -382,6 +382,14 @@ async function main() {
     let mapped = 0;
     for (const k of kinds) if (PAYLOAD_ELEMENT[k] !== undefined) mapped++;
     ok(mapped === kinds.length, 'every payload kind maps to an element', `${mapped}/${kinds.length}`);
+
+    // The table MOVED to core/contracts.js on 2026-08-06 (core/match.js's agreement gate reads it,
+    // and core/ may not import exec/). This file's export is now a re-export, and it has to stay
+    // the SAME OBJECT: a copy is how the renderer that runs a kind and the gate that admits it
+    // start disagreeing about which element it is.
+    const core = await import('../core/contracts.js');
+    ok(core.PAYLOAD_ELEMENT === PAYLOAD_ELEMENT,
+      'exec/executor.js re-exports core/contracts.js PAYLOAD_ELEMENT — one table, not a copy');
   }
 
   // ------------------------------------------------------- detach settles a run

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-flow.js
@@ -2099,5 +2099,167 @@ function mountRecap(result) {
     'and armDrop knows nothing about practice: the mode lives in boot, the slot logic does not');
 }
 
+/* ==========================================================================
+ * 6. THE AGREEMENT GATES THE THROWABLES (2026-08-06)
+ *
+ * The draft screen promises "everything is on. switch off what you will not
+ * take — you both get whatever is left". Until this gate existed it governed
+ * exactly ONE thing: buildRamp's self-inflicted schedule. The inbound payload
+ * gate tested the STATIC entitlement list built once in boot.js and never the
+ * sheet, so switching Videos off, signing, and then being thrown a video opened
+ * one on your monitor anyway.
+ *
+ * Two halves, and the second is the one that is easy to get wrong: the gate
+ * reads OUR OWN allowed set (a receiver is the authority over its own screen),
+ * and it applies only to elements that ACTUALLY HAD A TOGGLE. Bubbles is the
+ * always-on baseline and is in nobody's allowed set, so gating naively on
+ * membership would reject BubbleSwarm — a frozen wire code this client still
+ * renders for any peer that still throws one.
+ * ==========================================================================*/
+{
+  const { GoonElement, GoonPayloadKind, makePayload } = await import('../core/contracts.js');
+  const { GoonReceiptStatus } = await import('../core/scoring.js');
+  const { PoolV1, defaultAllowed } = await import('../core/draft.js');
+
+  /** A seat parked in Live with the sheet we hand it. Nothing else reaches the gate. */
+  function liveSeat(allowed) {
+    const pair = createLoopbackPair(loopbackOptions({ latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, logger: quiet }));
+    const m = new GoonMatchService(pair.guest, false, { logger: quiet, tag: 'GG:gate' });
+    m._availableDraftPool = PoolV1.slice();
+    m._localAllowed = (allowed || defaultAllowed(PoolV1)).slice();
+    m._remoteAllowed = defaultAllowed(PoolV1);
+    m._phase = GoonMatchPhase.Live;
+    const seen = { accepted: [], rejected: [] };
+    m.onPayloadAccepted((e) => seen.accepted.push(e.payload));
+    m.onPayloadRejected((r) => seen.rejected.push(r));
+    return { m, pair, seen };
+  }
+  const lands = (seat, kind) => {
+    seat.m._handleInboundPayload(makePayload({ id: 'in1', kind, duration_ms: 5000 }));
+    return { ok: seat.seen.accepted.length === 1, receipt: seat.seen.rejected[0] || null };
+  };
+  const close = (seat) => { seat.m.dispose(); seat.pair.dispose(); };
+
+  // ---- the sheet says no
+  const noVideo = liveSeat(defaultAllowed(PoolV1).filter((e) => e !== GoonElement.Videos));
+  const videoIn = lands(noVideo, GoonPayloadKind.Video);
+  ok(videoIn.ok === false,
+    'THE FIX: a payload whose element the receiver switched off on the agreement sheet never lands');
+  ok(!!videoIn.receipt && videoIn.receipt.status === GoonReceiptStatus.RejectedFiltered,
+    'and the thrower gets an honest rejected_filtered receipt, not silence',
+    videoIn.receipt ? String(videoIn.receipt.status) : 'none');
+  close(noVideo);
+
+  // ---- …and it is that element only: the rest of the sheet still works
+  const stillOn = liveSeat(defaultAllowed(PoolV1).filter((e) => e !== GoonElement.Videos));
+  ok(lands(stillOn, GoonPayloadKind.FlashBurst).ok === true,
+    'an element that is still switched ON is admitted exactly as before');
+  close(stillOn);
+
+  // ---- the always-on baseline is exempt
+  const bubbles = liveSeat(null);
+  ok(!defaultAllowed(PoolV1).includes(GoonElement.Bubbles),
+    'Bubbles is in NO allowed set — it is the always-on baseline, never toggled, never rolled');
+  ok(lands(bubbles, GoonPayloadKind.BubbleSwarm).ok === true,
+    'so BubbleSwarm must still land: gating it on the sheet would reject a kind we happily render');
+  close(bubbles);
+
+  // ---- the receiver's sheet, not the intersection: their toggle cannot open ours
+  const theirsOnly = liveSeat(defaultAllowed(PoolV1).filter((e) => e !== GoonElement.LockCards));
+  theirsOnly.m._remoteAllowed = defaultAllowed(PoolV1);      // they left everything on
+  ok(lands(theirsOnly, GoonPayloadKind.LockCard).ok === false,
+    'the gate reads OUR sheet: a sender who left it on cannot put it back on our screen');
+  close(theirsOnly);
+
+  // ---- and the C# engine says the same thing in the same place
+  const csGate = read('../../../Services/GoonGame/GoonMatchService.cs');
+  ok(/ElementFor\(payload\.Kind\)/.test(csGate) && /IsDraftToggleable\(/.test(csGate)
+    && /_localAllowed\.Contains\(/.test(csGate),
+    'GoonMatchService.HandleInboundPayload carries the same gate — the two engines stay in step');
+}
+
+/* ==========================================================================
+ * 7. A PEER CANNOT END YOUR MATCH AND RECORD YOU THE LOSER (2026-08-06)
+ *
+ * _handleRemoteResult's adopt branch ran on `!this._ended` with no phase test
+ * and countsForLedger hard-coded true, so a frame sent five seconds into Live —
+ * `{"t":"result","end_reason":1,"winner_is_host":<not me>}` — ended the
+ * victim's match instantly and wrote them a loss. It was a grief-stop too: end
+ * anybody's match, any time.
+ *
+ * The branch is NOT dead code, which is why the fix is a rule and not a
+ * deletion: PEER MERCY arrives exactly this way — they tap out, they end, and
+ * they send a result in which THEY are the loser, which we must adopt.
+ * ==========================================================================*/
+{
+  const { makeResult } = await import('../core/contracts.js');
+
+  function liveSeat() {
+    const pair = createLoopbackPair(loopbackOptions({ latencyMs: 0, jitterMs: 0, guestClockSkewMs: 0, logger: quiet }));
+    const m = new GoonMatchService(pair.guest, false, { logger: quiet, tag: 'GG:result' });
+    m._phase = GoonMatchPhase.Live;
+    return { m, pair };
+  }
+  const close = (seat) => { seat.m.dispose(); seat.pair.dispose(); };
+
+  // ---- 7a. the attack: mid-Live, "you lost"
+  const victim = liveSeat();
+  victim.m._handleRemoteResult(makeResult({
+    end_reason: GoonEndReason.SuddenDeathLoss,
+    winner_is_host: !victim.m.isHost,          // they claim the win, i.e. WE lost
+    host_score: 9, guest_score: 2,
+  }));
+  ok(victim.m.phase === GoonMatchPhase.Live,
+    'THE FIX: a peer claiming we lost while our side is still running does not end the match',
+    String(victim.m.phase));
+  ok(victim.m.result === null, 'and nothing is written — no loss, no ledger row');
+  close(victim);
+
+  // ---- 7b. …while the legitimate case it sits on top of still works
+  const mercied = liveSeat();
+  mercied.m._handleRemoteResult(makeResult({
+    end_reason: GoonEndReason.Mercy,
+    winner_is_host: mercied.m.isHost,          // they concede: WE are the winner
+    host_score: 3, guest_score: 40,
+  }));
+  ok(mercied.m.phase === GoonMatchPhase.Recap, 'PEER MERCY IS STILL ADOPTED — they tapped out, we end',
+    String(mercied.m.phase));
+  ok(!!mercied.m.result && mercied.m.result.endReason === GoonEndReason.Mercy,
+    'as a mercy', String(mercied.m.result && mercied.m.result.endReason));
+  ok(!!mercied.m.result && mercied.m.result.localWon === true, 'with the concession recorded our way');
+  close(mercied);
+
+  // ---- 7c. a result before there is a match to end
+  const early = liveSeat();
+  early.m._phase = GoonMatchPhase.Draft;
+  early.m._handleRemoteResult(makeResult({ end_reason: GoonEndReason.Mercy, winner_is_host: early.m.isHost }));
+  ok(early.m.phase === GoonMatchPhase.Draft && early.m.result === null,
+    'a result frame outside Live/SuddenDeath/Recap is logged and ignored', String(early.m.phase));
+  close(early);
+
+  // ---- 7d. the adopted scores are their claim, clamped
+  const scored = liveSeat();                    // guest seat: the HOST half is theirs to report
+  scored.m._handleRemoteResult(makeResult({
+    end_reason: GoonEndReason.Mercy, winner_is_host: scored.m.isHost, host_score: -50, guest_score: 7,
+  }));
+  ok(!!scored.m.result && scored.m.result.hostScore === 0,
+    'a negative score off the wire clamps to 0', String(scored.m.result && scored.m.result.hostScore));
+  scored.m._handleRemoteResult(makeResult({
+    end_reason: GoonEndReason.Mercy, winner_is_host: scored.m.isHost, host_score: 1e12, guest_score: 7,
+  }));
+  ok(!!scored.m.result && scored.m.result.hostScore === 1000000,
+    'and an absurd one clamps to the ceiling instead of landing on the recap',
+    String(scored.m.result && scored.m.result.hostScore));
+  close(scored);
+
+  // ---- and the C# mirror carries both gates
+  const csResult = read('../../../Services/GoonGame/GoonMatchService.cs');
+  ok(/GoonMatchPhase\.Live or GoonMatchPhase\.SuddenDeath or GoonMatchPhase\.Recap/.test(csResult),
+    'GoonMatchService.HandleRemoteResult has the same phase gate');
+  ok(/REFUSED a result that declares us the loser/.test(csResult),
+    'and the same refusal of a peer-claimed local loss');
+  ok(/ClampReportedScore\(remote\.(Guest|Host)Score\)/.test(csResult), 'and the same score clamp');
+}
+
 console.log(failures === 0 ? `PASS — ${n} checks` : `FAILED — ${failures}/${n} checks`);
 process.exit(failures === 0 ? 0 : 1);

--- a/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
+++ b/ConditioningControlPanel/Resources/web/goon/test/selftest-hud.js
@@ -537,6 +537,44 @@ function makeFakeMatch() {
   ars.unmount();
 }
 
+/* --- 2b-ii-b. …and so does the AGREEMENT (2026-08-06) ---------------------
+ * peerCanTake() used to ask one question — can their client RUN the kind? The
+ * engine now rejects an inbound payload whose element the RECEIVER switched off
+ * on the draft sheet (core/match.js _handleInboundPayload), so a tile that only
+ * consulted the caps was offering a throw that was guaranteed to bounce off the
+ * far side with a rejected_filtered receipt. "they can't receive this" is
+ * exactly the right words for it; it just has to be said before the throw.  */
+{
+  const match = makeFakeMatch();
+  // Caps say yes to everything. The sheet is where Videos died.
+  match.sharedElementPool = [
+    GoonElement.Flashes, GoonElement.Subliminals, GoonElement.LockCards,
+    GoonElement.ToyPatterns, GoonElement.BrainDrain, GoonElement.Spiral,
+  ];
+  const ars = arsenalMod.mountArsenal({
+    leftHost: document.createElement('div'),
+    rightHost: document.createElement('div'),
+    receiptsHost: document.createElement('div'),
+    match,
+  });
+  ars.armDrop('video');
+  ars.armDrop('flash');
+  ok(ars.stateOf('video') === 'filtered',
+    'a kind whose ELEMENT is off the agreed pool reads filtered even with the stack in hand',
+    String(ars.stateOf('video')));
+  ok(ars.stateOf('flash') === 'ready', 'while an agreed one is ready as ever', String(ars.stateOf('flash')));
+  ok(ars.droppable().every((c) => c.id !== 'video'), 'and it is not worth dropping either');
+
+  // A pool we cannot see yet (pre-draft, or a match object that never grew the getter) must filter
+  // NOTHING — an affordance that goes dark because the engine has not spoken yet is a worse lie
+  // than the one being fixed.
+  match.sharedElementPool = [];
+  match._emit('phase', GoonMatchPhase.Live);          // the repaint the engine would have caused
+  ok(ars.stateOf('video') === 'ready', 'an empty/absent pool filters nothing at all',
+    String(ars.stateOf('video')));
+  ars.unmount();
+}
+
 /* --- 2b-iii. ui/drops.js: the HEAT economy ---------------------------------
  * The flat "12% per unit of worth" coin flip was replaced on 2026-08-04 by a
  * heat gauge: pops bank heat, the chance ramps with the fill, a landed drop

--- a/ConditioningControlPanel/Resources/web/goon/ui/announcer.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/announcer.js
@@ -43,7 +43,7 @@
  * Node-import-safe: no DOM at import, only inside mountAnnouncer().
  * ==========================================================================*/
 
-import { GoonElement, GoonMatchPhase, GoonPayloadKind } from '../core/contracts.js';
+import { GoonElement, GoonMatchPhase, PAYLOAD_ELEMENT } from '../core/contracts.js';
 import { GoonCueAction } from '../core/draft.js';
 import { localMonotonicMs } from '../core/clock.js';
 import { S } from './strings.js';
@@ -75,17 +75,13 @@ export const ANNOUNCE_LEAD_BEATS_DEDUPE = ANNOUNCE_LEAD_MS > ANNOUNCE_DEDUPE_MS;
 /** Never announced. Bubbles are the always-on baseline — see the header. */
 export const ANNOUNCE_SKIP_ELEMENTS = Object.freeze([GoonElement.Bubbles]);
 
-/** exec/executor.js PAYLOAD_ELEMENT, mirrored as a literal so ui/ never imports exec/. */
-export const PAYLOAD_ANNOUNCE_ELEMENT = Object.freeze({
-  [GoonPayloadKind.FlashBurst]: GoonElement.Flashes,
-  [GoonPayloadKind.SubliminalStorm]: GoonElement.Subliminals,
-  [GoonPayloadKind.BubbleSwarm]: GoonElement.Bubbles,
-  [GoonPayloadKind.Video]: GoonElement.Videos,
-  [GoonPayloadKind.LockCard]: GoonElement.LockCards,
-  [GoonPayloadKind.ToyPattern]: GoonElement.ToyPatterns,
-  [GoonPayloadKind.BrainDrain]: GoonElement.BrainDrain,
-  [GoonPayloadKind.Spiral]: GoonElement.Spiral,
-});
+/**
+ * Which element a payload announces as. This WAS a hand-written mirror of exec/executor.js's
+ * table, because ui/ never imports exec/; since 2026-08-06 the table lives in core/contracts.js
+ * (core/match.js's agreement gate reads it too), so the mirror is gone and this is an alias onto
+ * the one table. The name stays — it is what the suite and mountAnnouncer already say.
+ */
+export const PAYLOAD_ANNOUNCE_ELEMENT = PAYLOAD_ELEMENT;
 
 /** The little mark in front of the words. Same vocabulary as ui/hud.js's rail chips. */
 export const ANNOUNCE_GLYPH = Object.freeze({

--- a/ConditioningControlPanel/Resources/web/goon/ui/arsenal.js
+++ b/ConditioningControlPanel/Resources/web/goon/ui/arsenal.js
@@ -10,7 +10,8 @@
  *   ready      full colour + a ×N stack badge; the rarest one you hold glows
  *   cooling    conic sweep + the shared "next payload in {n}s" readout
  *   used       brain drain only, once per match: struck through
- *   filtered   hatched, "they can't receive this" (kind outside the peer caps)
+ *   filtered   hatched, "they can't receive this" (kind outside the peer caps, OR an element one
+ *              of you switched off on the agreement sheet — the engine rejects those on arrival)
  *   hidden     the kind is outside OUR OWN caps — the slot never renders
  *
  * THERE IS NO "TOO POOR" STATE, AND NO COST PIPS (owner, 2026-08-05: "we still
@@ -44,7 +45,8 @@
  * Node-import-safe: no DOM at import, only inside mountArsenal().
  * ==========================================================================*/
 
-import { GoonConsts, GoonMatchPhase, GoonPayloadKind, costOf } from '../core/contracts.js';
+import { GoonConsts, GoonMatchPhase, GoonPayloadKind, PAYLOAD_ELEMENT, costOf } from '../core/contracts.js';
+import { ALWAYS_ON_ELEMENT } from '../core/draft.js';
 import { GoonPayloadRateLimiter, GoonReceiptStatus } from '../core/scoring.js';
 import { localMonotonicMs } from '../core/clock.js';
 import { dressGhost } from './throwPreview.js';
@@ -319,9 +321,37 @@ export function mountArsenal({
      engine and still rides the state tick; this file no longer has an opinion
      about it, and re-adding a reader here would be re-adding the gate. */
 
+  /**
+   * Will this land on their monitor at all? TWO questions, not one (2026-08-06):
+   *
+   *   1. CAPS — can their client run the kind? (Static, settled at hello.)
+   *   2. THE AGREEMENT — is the element still in the shared pool, or did one of you switch it off
+   *      on the draft sheet? The engine now REJECTS an inbound payload whose element the receiver
+   *      switched off (core/match.js _handleInboundPayload), so a tile that only consulted the
+   *      caps was offering a throw that was guaranteed to bounce. "filtered / they can't receive
+   *      this" is exactly the right word for it, and the affordance should say so before the
+   *      throw, not after the receipt.
+   *
+   * The shared pool is used here rather than their sheet alone because this is a SENDER-side
+   * courtesy: if either of you switched it off it is not part of this match. The receiver's own
+   * sheet remains the authority over there, which is where it belongs.
+   *
+   * BUBBLES ARE EXEMPT for the reason they are exempt in the engine: the always-on baseline is
+   * never in an allowed set, so testing it against the pool would filter a kind the receiver
+   * happily renders. (No bubble tile exists today — see ARSENAL_ITEMS — so this is the rule being
+   * written where it belongs rather than a live case.) A pool we cannot see yet (pre-draft, or a
+   * fake match in a test) filters nothing.
+   */
   function peerCanTake(kind) {
     const list = match && match.availablePayloadKinds;
-    return !Array.isArray(list) || list.includes(kind);
+    if (Array.isArray(list) && !list.includes(kind)) return false;
+
+    const element = PAYLOAD_ELEMENT[kind];
+    if (element === undefined || element === ALWAYS_ON_ELEMENT) return true;
+
+    const pool = match && match.sharedElementPool;
+    if (!Array.isArray(pool) || pool.length === 0) return true;
+    return pool.includes(element);
   }
 
   function isLive() {

--- a/ConditioningControlPanel/Services/GoonGame/GoonContracts.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonContracts.cs
@@ -145,6 +145,26 @@ namespace ConditioningControlPanel.Services.GoonGame
             GoonPayloadKind.Spiral => 2,
             _ => int.MaxValue,
         };
+
+        /// <summary>
+        /// Which ELEMENT a payload kind lands as. Both sides of the mapping are frozen wire codes.
+        /// Null = a kind we have no element for (a newer peer's kind 8): the agreement gate reads
+        /// that as "not a draft-toggleable element" and leaves it to the checks that do know about
+        /// it — CostOf, above, is the unknown-kind guard and runs first.
+        /// MIRROR: PAYLOAD_ELEMENT in Resources/web/goon/core/contracts.js.
+        /// </summary>
+        public static GoonElement? ElementFor(GoonPayloadKind kind) => kind switch
+        {
+            GoonPayloadKind.FlashBurst => GoonElement.Flashes,
+            GoonPayloadKind.SubliminalStorm => GoonElement.Subliminals,
+            GoonPayloadKind.BubbleSwarm => GoonElement.Bubbles,
+            GoonPayloadKind.Video => GoonElement.Videos,
+            GoonPayloadKind.LockCard => GoonElement.LockCards,
+            GoonPayloadKind.ToyPattern => GoonElement.ToyPatterns,
+            GoonPayloadKind.BrainDrain => GoonElement.BrainDrain,
+            GoonPayloadKind.Spiral => GoonElement.Spiral,
+            _ => null,
+        };
     }
 
     // -------------------------------------------------------------- transport

--- a/ConditioningControlPanel/Services/GoonGame/GoonMatchService.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonMatchService.cs
@@ -33,9 +33,11 @@ using System.Windows.Threading;
 //  * Nothing in this file reads or writes PanicKeyEnabled / StrictLockEnabled or
 //    any lockdown/tray verb. GG's payload set (GoonPayloadKind) excludes them by
 //    construction — there is no code path to a banned verb.
-//  * The RECEIVER enforces the economy: burst/gap rate limit, charge cost against
-//    the opponent's last self-reported meter, one heavy per match, schedule buffer
-//    clamp and text cap — regardless of what the wire claims.
+//  * The RECEIVER enforces the economy: THE DRAFT AGREEMENT (an element this seat
+//    switched off is not throwable AT this seat, 2026-08-06 — the sheet governs the
+//    throwables, not just the ramp), burst/gap rate limit, charge cost against the
+//    opponent's last self-reported meter, one heavy per match, schedule buffer clamp
+//    and text cap — regardless of what the wire claims.
 // ============================================================================
 
 namespace ConditioningControlPanel.Services.GoonGame
@@ -50,6 +52,10 @@ namespace ConditioningControlPanel.Services.GoonGame
         private const int PayloadScheduleBufferMs = 1500;   // >= GoonConsts.MinScheduleBufferMs
         private const int NoCamCheckIntervalMs = 90000;     // interaction-check cadence (no-cam)
         private const int MaxPayloadDurationMs = 180000;
+        // Ceiling on a score the PEER reports for its own half. Deliberately far above anything
+        // reachable — the per-second rate tops out near 3 — because it is a sanity clamp on an
+        // untrusted number, not a balance rule. MIRROR: MAX_REPORTED_SCORE in core/match.js.
+        private const int MaxReportedScore = 1000000;
         private const int EmoteTextMaxChars = 60;
         private const int EmoteIconMaxChars = 8;
 
@@ -1105,6 +1111,29 @@ namespace ConditioningControlPanel.Services.GoonGame
                 RejectPayload(payload, GoonReceiptStatus.RejectedFiltered, "kind not in our advertised caps");
                 return;
             }
+            /* THE AGREEMENT, ON THE THROWABLES (2026-08-06). Until this check existed the draft
+               governed ONE thing — BuildRamp's self-inflicted schedule — and nothing else. The
+               agreement screen promises "everything is on. switch off what you will not take", and
+               yet switching Videos off and signing left the opponent free to open a video on this
+               seat, because the only element-shaped test down here was the STATIC caps list.
+               _localAllowed is OUR OWN sheet, deliberately, not SharedPool(): the intersection is
+               what the RAMP is rolled from, and a receiver is the authority on what it will take
+               regardless of what the sender left switched on at their end.
+               THE ALWAYS-ON EXEMPTION IS LOAD-BEARING: _localAllowed is DefaultAllowed(pool), i.e.
+               normalized, so it can never contain Bubbles (the always-on baseline, never toggled)
+               — testing every kind against it would reject BubbleSwarm outright, and kind 2 is a
+               frozen wire code an older or third-party client may still send and this client still
+               renders. Enforcement is therefore scoped to elements that ACTUALLY HAD A TOGGLE.
+               MIRROR: core/match.js _handleInboundPayload — narrowing one side and not the other
+               is how the two engines drift. */
+            var inboundElement = GoonConsts.ElementFor(payload.Kind);
+            if (inboundElement.HasValue && IsDraftToggleable(inboundElement.Value)
+                && !_localAllowed.Contains(inboundElement.Value))
+            {
+                RejectPayload(payload, GoonReceiptStatus.RejectedFiltered,
+                    $"{inboundElement.Value} is switched off on our agreement sheet");
+                return;
+            }
             if (payload.Kind == GoonPayloadKind.BrainDrain && _remoteHeavyUsed)
             {
                 RejectPayload(payload, GoonReceiptStatus.RejectedFiltered, "heavy already used");
@@ -1155,6 +1184,26 @@ namespace ConditioningControlPanel.Services.GoonGame
             try { handler(this, new GoonInboundPayloadEventArgs { Payload = payload, FireAtLocalMs = fireAtLocal }); }
             catch (Exception ex) { App.Logger?.Error(ex, "[GG] PayloadAccepted handler threw"); }
         }
+
+        /// <summary>
+        /// Was this element ever on the agreement screen for THIS pairing? Derived exactly the way
+        /// <c>_localAllowed</c> is seeded (TryEnterDraft: <c>GoonDraft.DefaultAllowed(AvailableDraftPool)</c>),
+        /// or the gate starts disagreeing with the sheet the player signed: DefaultAllowed drops the
+        /// always-on element, drops anything outside PoolV1, and falls back to the whole pool when the
+        /// caps intersection is empty — three behaviours a hand-rolled PoolV1.Contains would each get
+        /// wrong. MIRROR: core/match.js _isDraftToggleable.
+        /// </summary>
+        private bool IsDraftToggleable(GoonElement element)
+            => GoonDraft.DefaultAllowed(AvailableDraftPool).Contains(element);
+
+        /// <summary>
+        /// A score off the wire, made storable. The peer's half of the scoreboard is theirs to report
+        /// (each side is authoritative for its own half) and was taken verbatim until 2026-08-06 — so
+        /// a negative or an absurd number went straight onto the recap and into the ledger row. The
+        /// JSON layer already guarantees an int here; this is the RANGE half of the JS clamp.
+        /// MIRROR: clampReportedScore() in core/match.js.
+        /// </summary>
+        private static int ClampReportedScore(int score) => Math.Clamp(score, 0, MaxReportedScore);
 
         private void RejectPayload(PayloadMsg payload, string status, string reason)
         {
@@ -1383,21 +1432,56 @@ namespace ConditioningControlPanel.Services.GoonGame
             catch (Exception ex) { App.Logger?.Error(ex, "[GG] MatchEnded handler threw"); }
         }
 
+        /// <summary>
+        /// Their ResultMsg. TWO GATES BEFORE THE ADOPT BRANCH (2026-08-06), because that branch used
+        /// to be a remote kill switch: it ran on <c>!_ended</c> with no phase test and a hard-coded
+        /// countsForLedger=true, so a frame sent five seconds into Live ended the victim's match on
+        /// the spot and wrote them a loss.
+        /// <para>
+        /// 1. THE PHASE. A result is meaningless before a match exists; anything outside
+        /// Live/SuddenDeath/Recap is logged and dropped. Recap is in the list because that is where
+        /// the countersign handshake lives, and because a PRE-LIVE peer mercy puts us in Recap through
+        /// HandleRemoteMercy before their result frame lands behind it on the same ordered channel.
+        /// </para><para>
+        /// 2. WHO IT SAYS LOST. The branch is NOT dead code and must not become <c>if (_ended)</c>: it
+        /// is how PEER MERCY is honoured — they tap out, they end, they send a result in which THEY
+        /// are the loser, and we adopt it. What no honest client can produce is a result declaring US
+        /// the loser while OUR side is still running: our own loss is only ever resolved locally
+        /// (mercy, the abandon watchdog, sudden death). So we adopt a concession or a draw, and refuse
+        /// a claimed local loss — the match carries on, and if the peer then drops,
+        /// CheckOpponentFreshness records the abandon it always did.
+        /// </para>
+        /// MIRROR: core/match.js _handleRemoteResult — same two gates, same score clamp.
+        /// </summary>
         private void HandleRemoteResult(ResultMsg remote)
         {
+            if (Phase is not (GoonMatchPhase.Live or GoonMatchPhase.SuddenDeath or GoonMatchPhase.Recap))
+            {
+                App.Logger?.Warning("[GG] ignoring a result frame in phase {Phase} - no match to end", Phase);
+                return;
+            }
+
             if (!_ended)
             {
-                // Their end signal reached us before ours fired (lost MercyMsg, or a
-                // sudden-death exit resolved on their side first). Adopt their outcome.
+                // Their end signal reached us before ours fired (their mercy, or a sudden-death
+                // exit resolved on their side first).
                 bool localLost = remote.WinnerIsHost.HasValue && remote.WinnerIsHost.Value != IsHost;
-                EndMatch(remote.EndReason, localLost, countsForLedger: true);
+                if (localLost)
+                {
+                    App.Logger?.Warning("[GG] REFUSED a result that declares us the loser while our side "
+                        + "is still running - not ending, not recording");
+                    return;
+                }
+                EndMatch(remote.EndReason, localLost: false, countsForLedger: true);
             }
             var result = Result;
             if (result == null) return;
 
-            // Each side's own score is authoritative for its own half.
-            if (IsHost) result.GuestScore = remote.GuestScore;
-            else result.HostScore = remote.HostScore;
+            // Each side's own score is authoritative for its own half — and it is still THEIR
+            // number off an untrusted wire, so it is clamped to something a match can actually
+            // produce before it is stored, shown on the recap, or handed to the ledger.
+            if (IsHost) result.GuestScore = ClampReportedScore(remote.GuestScore);
+            else result.HostScore = ClampReportedScore(remote.HostScore);
 
             if (remote.Agree)
             {

--- a/ConditioningControlPanel/Services/GoonGame/GoonSuddenDeath.cs
+++ b/ConditioningControlPanel/Services/GoonGame/GoonSuddenDeath.cs
@@ -158,13 +158,16 @@ namespace ConditioningControlPanel.Services.GoonGame
 
                     await SendAsync(ctx, local, token).ConfigureAwait(false);
 
-                    var peer = await _results.WaitAsync(roundNo, GoonRoundConsts.PeerResultTimeoutMs, token).ConfigureAwait(false);
-                    if (peer == null)
+                    var raw = await _results.WaitAsync(roundNo, GoonRoundConsts.PeerResultTimeoutMs, token).ConfigureAwait(false);
+                    if (raw == null)
                     {
                         App.Logger?.Warning("[GG] sudden death: no peer result for round {Round} within {Ms}ms", roundNo, GoonRoundConsts.PeerResultTimeoutMs);
                         RaiseAborted("peer_result_timeout");
                         return;
                     }
+                    // Clean on INGEST, once, so everything downstream — judge, verdict UI, outcome
+                    // event — sees the same sane numbers. `raw` is not used again past this line.
+                    var peer = SanitizePeerResult(kind, raw);
 
                     var verdict = GoonRoundJudge.Decide(kind, local, peer);
                     NetScore += verdict switch
@@ -267,6 +270,53 @@ namespace ConditioningControlPanel.Services.GoonGame
                     try { _cts?.Cancel(); } catch (ObjectDisposedException) { }
                     break;
             }
+        }
+
+        /// <summary>
+        /// The peer's RoundResultMsg, made safe to judge (2026-08-06).
+        /// <para>
+        /// GoonRoundJudge.Decide compares THEIR numbers against OURS with &lt; and &gt; and nothing
+        /// else — it has no opinion about sign or plausibility, and it must not grow one, because it
+        /// has to stay a pure antisymmetric function of two results. So the untrusted half is cleaned
+        /// up HERE, on ingest, before it is judged, shown or emitted: a peer reporting ReactionMs = -5
+        /// would otherwise beat every human alive, and ElapsedMs = -1 wins a quick draw the same way.
+        /// </para><para>
+        /// Suspect is RECOMPUTED rather than read: it is self-reported, it gates nothing, and a cheat
+        /// would simply send false — so the flag that reaches the recap is OUR verdict on THEIR
+        /// claimed number, which is the only version of it that means anything.
+        /// </para>
+        /// MIRROR: sanitizePeerRoundResult() in Resources/web/goon/core/suddenDeath.js.
+        /// </summary>
+        internal static RoundResultMsg SanitizePeerResult(GoonRoundKind kind, RoundResultMsg peer)
+        {
+            if (peer == null) return peer!;
+
+            // Per-kind range for Progress, which is a different quantity in every round (see the
+            // RoundResultMsg doc comment): attention percent, bubbles popped, mistakes typed,
+            // false-start flag. Anything unknown falls back to the non-negative-integer floor.
+            int progressMax = kind switch
+            {
+                GoonRoundKind.StaringContest => 100,
+                GoonRoundKind.BubbleRace => GoonRoundConsts.BubbleMaxCount,
+                GoonRoundKind.ReactionDuel => 1,
+                _ => int.MaxValue,
+            };
+
+            // ReactionDuelSpec.MaxResponseMs IS this constant, and the runner does not hold the spec
+            // — the round owns it and returns only the measurement.
+            int? reactionMs = peer.ReactionMs.HasValue
+                ? Math.Clamp(peer.ReactionMs.Value, 0, GoonRoundConsts.ReactionMaxResponseMs)
+                : null;
+
+            return new RoundResultMsg
+            {
+                RoundNo = Math.Max(0, peer.RoundNo),
+                Completed = peer.Completed,
+                ElapsedMs = Math.Max(0, peer.ElapsedMs),
+                ReactionMs = reactionMs,
+                Suspect = reactionMs.HasValue && reactionMs.Value < GoonConsts.SuspectReactionMs,
+                Progress = Math.Clamp(peer.Progress, 0, progressMax),
+            };
         }
 
         // -------------------------------------------------------- scheduling
@@ -605,6 +655,11 @@ namespace ConditioningControlPanel.Services.GoonGame
     /// <summary>
     /// Pure round judgement. Called with the same two results on both machines (arguments swapped),
     /// so it MUST be antisymmetric: Decide(k, a, b) == Win exactly when Decide(k, b, a) == Loss.
+    /// <para>
+    /// IT TRUSTS ITS ARGUMENTS. Peer results are cleaned by GoonSuddenDeathRunner.SanitizePeerResult
+    /// on ingest; do not add clamping in here, or the two calls (one per machine, arguments swapped)
+    /// stop being the same function.
+    /// </para>
     /// </summary>
     public static class GoonRoundJudge
     {


### PR DESCRIPTION
Two fixes from the 2026-08-06 security review, both in the duel's trust boundary between peers.

## 1. The draft agreement now actually gates what arrives

This is the consent promise of the feature and it was not wired to the receive path. `_handleInboundPayload` checked the *static* capability list, never the agreed sheet - so switching an element off in the draft did not stop it from arriving.

The gate is now the receiver's **own** sheet (`_localAllowed`), not the capability intersection, plus `_isDraftToggleable(el)`. That helper choice is load-bearing: using the raw pool would reject `BubbleSwarm` (kind 2, frozen wire code, still rendered). `PAYLOAD_ELEMENT` moved from `exec/executor.js` to `core/contracts.js` so `core/` stays node-import-safe; the announcer's hand-mirror now aliases it instead of redeclaring.

Mirrored on the C# side in `GoonMatchService` / `GoonContracts` so the host enforces the same sheet.

## 2. Result frames are phase-gated and clamped

A `result` frame was accepted in any phase with `countsForLedger` hardcoded true, which let a peer write a recorded loss. Now:

- accepted only in Live / Sudden Death / **Recap** - Recap is required, a pre-live peer mercy lands there first
- while `!_ended`, only **non-loss** results are adopted (that branch is how peer mercy is honoured - do not simplify it to `if (_ended)`)
- scores clamped; sudden-death peer round results sanitized and `suspect` recomputed locally instead of trusted

## Tests

`selftest-core` 261, `selftest-flow` 336, `selftest-hud` 1704, `selftest-exec` 1071; `dotnet build` 0 errors.

## Owner checklist

- [ ] Duel play-test with a real peer: turn an element **off** in the draft and confirm the tile never arrives and never renders.
- [ ] Confirm mercy still works from both sides, including a peer conceding before the match goes live.
- [ ] Ships in the next desktop release (the web half of the duel is unaffected by this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue