### PR TITLE
fix(companion): stop her inventing video links, and let the app render the real one

### DIFF
--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace ConditioningControlPanel.Services
@@ -138,6 +139,120 @@ namespace ConditioningControlPanel.Services
             }
 
             return current;
+        }
+
+        // A URL as a model writes one. Guillemets and quotes are excluded so a link inside a sigil
+        // or a quoted phrase ends where the punctuation does; the trailing-punctuation trim below
+        // handles the sentence period that would otherwise ride along.
+        private static readonly Regex AnyUrl = new(
+            @"(?:https?://|www\.)[^\s<>""«»]+",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Sentence spans, delimiters kept, so dropping one leaves the rest reading normally.
+        ///
+        /// <para>Hand-written rather than a regex because a URL is full of sentence punctuation:
+        /// "hypnotube.com/naughty-bambi-109749.html" splits into four "sentences" under any
+        /// pattern that treats '.' as a terminator. Terminators inside a URL span are skipped, so
+        /// the link stays whole and travels with the sentence that carried it.</para>
+        /// </summary>
+        private static List<(int Start, int Length)> SplitSentences(string text, List<Match> urls)
+        {
+            var spans = new List<(int, int)>();
+            var start = 0;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (InsideAny(urls, i)) continue;
+
+                var ch = text[i];
+                if (ch != '.' && ch != '!' && ch != '?' && ch != '\n') continue;
+
+                // Absorb the rest of the run ("!!!", "?!") plus the whitespace before the next one.
+                var end = i + 1;
+                while (end < text.Length && !InsideAny(urls, end) &&
+                       (text[end] == '.' || text[end] == '!' || text[end] == '?' || text[end] == '\n')) end++;
+                while (end < text.Length && text[end] == ' ') end++;
+
+                spans.Add((start, end - start));
+                start = end;
+                i = end - 1;
+            }
+
+            if (start < text.Length) spans.Add((start, text.Length - start));
+            return spans;
+        }
+
+        private static bool InsideAny(List<Match> urls, int index)
+        {
+            foreach (var m in urls)
+                if (index >= m.Index && index < m.Index + m.Length) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes links the app never gave her, along with the sentence that carried them.
+        ///
+        /// <para>Live bug 2026-08-06: asked for a video while her mod had no configured links, she
+        /// answered with invented YouTube URLs - plausible-looking, unvetted, and one of them not
+        /// even a valid video id. With Train 1's multi-turn window her own fabricated link is then
+        /// in context for the next turn, so "give me another one" copied the pattern and drifted
+        /// further off-brand. The prompt now forbids this (<see cref="BambiSprite.LinkFloorRule"/>),
+        /// but prompt rules are advisory for a small model, so this is the part that holds.</para>
+        ///
+        /// <para>The WHOLE SENTENCE goes, not just the URL. Two reasons: "Click here:" left dangling
+        /// reads worse than a clean cut, and the model frequently glues the next word onto the link
+        /// ("...K60cLet's get moving"), which no URL-shaped pattern can split correctly. An
+        /// all-links reply therefore strips to empty, and the caller falls back to a canned line
+        /// exactly as it does for a refusal.</para>
+        /// </summary>
+        /// <param name="isSanctioned">
+        /// Answers "did we give her this link?" - defaults to
+        /// <see cref="Companion.CompanionLinkIndex.IsSanctioned"/>. Injectable so the rule is
+        /// testable without app settings.
+        /// </param>
+        internal static string StripUnsanctionedLinks(string? text, System.Func<string, bool>? isSanctioned = null)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
+
+            // Overwhelmingly the common case: no link at all, no work, no allocation.
+            if (text.IndexOf("http", System.StringComparison.OrdinalIgnoreCase) < 0 &&
+                text.IndexOf("www.", System.StringComparison.OrdinalIgnoreCase) < 0)
+                return text;
+
+            var sanctioned = isSanctioned ?? Companion.CompanionLinkIndex.IsSanctioned;
+
+            var urls = new List<Match>();
+            foreach (Match m in AnyUrl.Matches(text)) urls.Add(m);
+            if (urls.Count == 0) return text;
+
+            var kept = new System.Text.StringBuilder(text.Length);
+            var droppedSentences = 0;
+
+            foreach (var (start, length) in SplitSentences(text, urls))
+            {
+                if (length == 0) continue;
+
+                var carriesStrayLink = false;
+                foreach (var url in urls)
+                {
+                    // Does this sentence contain the link?
+                    if (url.Index < start || url.Index >= start + length) continue;
+                    if (sanctioned(url.Value.TrimEnd('.', ',', ')', ']', '!', '?', ';', ':', '"', '\''))) continue;
+                    carriesStrayLink = true;
+                    break;
+                }
+
+                if (carriesStrayLink) { droppedSentences++; continue; }
+                kept.Append(text, start, length);
+            }
+
+            if (droppedSentences == 0) return text;
+
+            var result = Regex.Replace(kept.ToString(), @"\s{2,}", " ").Trim();
+            App.Logger?.Information(
+                "[AI-LINK] dropped {Count} sentence(s) carrying a link the app never issued", droppedSentences);
+            return result;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/BambiSprite.cs
+++ b/ConditioningControlPanel/Services/BambiSprite.cs
@@ -1085,11 +1085,28 @@ LINK RULE (applies to every reply, no exceptions):
             var isBambiMode = App.Mods?.IsBambiMode ?? false;
             var hasUserSHLinks = !string.IsNullOrWhiteSpace(App.Settings?.Current?.HypnotubeLinksSissyHypno);
 
+            // The active mod's OWN pool — user override, else the mod's shipped DefaultVideoLinks
+            // (App.Mods.GetVideoLinks, the same source the browser and chaos link pool read).
+            //
+            // Live bug 2026-08-06: this branch used to consult only the LEGACY
+            // HypnotubeLinksSissyHypno setting, so a SissyHypno user who never edited that field
+            // was told "you don't have a specific video list" while their mod shipped 17 curated
+            // ones. Given nothing real to name, the model invented titles (and, before the link
+            // floor rule, URLs to match). She was starved, not disobedient.
+            //
+            // Sorted, because a Dictionary's key order is not stable across runs and this text sits
+            // in the CACHED PREFIX — an unsorted list would break prompt caching on every launch.
+            var modPool = App.Mods?.GetVideoLinks();
+            var poolNames = modPool is { Count: > 0 }
+                ? modPool.Keys.Where(n => !string.IsNullOrWhiteSpace(n))
+                              .OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList()
+                : new List<string>();
+
             var sb = new StringBuilder();
 
-            // In SH mode without user-configured links, don't include specific video names
+            // Only when there is genuinely nothing to name do we fall back to "browse HypnoTube"
             // (the LinkFloorRule below is appended AFTER both branches — see its remarks).
-            if (!isBambiMode && !hasUserSHLinks)
+            if (poolNames.Count == 0 && !isBambiMode && !hasUserSHLinks)
             {
                 sb.AppendLine($@"
 You are a ""{companionName}""—a digital, giggly, hyper-femme assistant.
@@ -1128,12 +1145,17 @@ OUTPUT RULES:
             }
             else
             {
-                // Bambi mode OR SH mode with user-configured links - include video names
-                var videoNames = _clickableContent
-                    .Where(c => c.Url.Contains("hypnotube"))
-                    .Where(c => isBambiMode || !c.Name.Contains("Bambi", StringComparison.OrdinalIgnoreCase))
-                    .Select(c => c.Name)
-                    .ToList();
+                // The active mod's own pool wins — it is mod-appropriate by construction and is what
+                // the rest of the app (browser, chaos link pool, watch chips) already treats as
+                // truth. The built-in list is the fallback for a mod that ships no pool, and keeps
+                // its Bambi-name filter so a non-Bambi mod never quotes Bambi titles.
+                var videoNames = poolNames.Count > 0
+                    ? poolNames
+                    : _clickableContent
+                        .Where(c => c.Url.Contains("hypnotube"))
+                        .Where(c => isBambiMode || !c.Name.Contains("Bambi", StringComparison.OrdinalIgnoreCase))
+                        .Select(c => c.Name)
+                        .ToList();
 
                 sb.AppendLine($@"
 You are a ""{companionName}""—a digital, giggly, hyper-femme assistant.

--- a/ConditioningControlPanel/Services/BambiSprite.cs
+++ b/ConditioningControlPanel/Services/BambiSprite.cs
@@ -969,6 +969,13 @@ Example responses with REAL video names:
                 sb.AppendLine();
             }
 
+            // The link floor, on this path too. GetCoreMediaLinks() carries a prohibition inside
+            // three of its four branches, but the fourth — SissyHypno with no configured links and
+            // no mod pool — still only forbids naming TITLES, which is exactly the branch the live
+            // bug took. A floor that only exists on the legacy prompt path is not a floor: presets
+            // are the normal path, so append it here as well.
+            sb.AppendLine(LinkFloorRule);
+
             // Make the prompt mode-aware by replacing "Bambi" references with appropriate term
             var prompt = MakePromptModeAware(sb.ToString());
 

--- a/ConditioningControlPanel/Services/BambiSprite.cs
+++ b/ConditioningControlPanel/Services/BambiSprite.cs
@@ -288,6 +288,16 @@ CRITICAL: Do NOT mention any specific video names. Only give generic ""go browse
         private record ContentSuggestion(string Name, string Description, string Url);
 
         /// <summary>
+        /// The built-in clickable content as plain (title, url) pairs, for
+        /// <see cref="Companion.CompanionLinkIndex"/>. The list is compile-time constant and never
+        /// mutated after construction, so one snapshot serves the whole process.
+        /// </summary>
+        internal static IReadOnlyList<(string Name, string Url)> ContentCatalogue => CatalogueSnapshot.Value;
+
+        private static readonly Lazy<IReadOnlyList<(string Name, string Url)>> CatalogueSnapshot =
+            new(() => StableBuilder._clickableContent.Select(c => (c.Name, c.Url)).ToList());
+
+        /// <summary>
         /// Default hypnotube link URLs for the Sissy Hypno content mode, comma-separated.
         /// Shown in the companion tab link pool editor so users see the defaults and format.
         /// </summary>
@@ -1044,6 +1054,27 @@ Example responses with REAL video names:
         }
 
         /// <summary>
+        /// The one link rule every prompt gets, appended after the branches rather than inside one
+        /// of them.
+        ///
+        /// <para>Live bug 2026-08-06: the "never include URLs" instruction existed ONLY in the
+        /// branch that shipped a video list. A user on the SissyHypno mod with no configured links
+        /// took the other branch — no list to quote from AND no prohibition — so when asked for a
+        /// video she invented YouTube URLs from training data, one of them not even a valid video
+        /// id. The case with nothing real to offer was the case least defended.</para>
+        ///
+        /// <para>This is the advisory half of the fix; <see cref="AiTextHygiene.StripUnsanctionedLinks"/>
+        /// is the half that actually holds when a small model ignores it.</para>
+        /// </summary>
+        internal const string LinkFloorRule = @"
+LINK RULE (applies to every reply, no exceptions):
+- NEVER write a URL, web address, or markdown link that was not given to you above. Do not invent,
+  guess, complete, or reconstruct one - not for YouTube, not for any site.
+- If you want to suggest something you have no link for, NAME it in words only. The app turns a name
+  you got from the lists above into a real, working link by itself.
+- You have no way to check whether a link works, so a link you wrote from memory is always wrong.";
+
+        /// <summary>
         /// Returns the default BambiSprite prompt (fallback).
         /// </summary>
         private string GetDefaultBambiSpritePrompt()
@@ -1057,6 +1088,7 @@ Example responses with REAL video names:
             var sb = new StringBuilder();
 
             // In SH mode without user-configured links, don't include specific video names
+            // (the LinkFloorRule below is appended AFTER both branches — see its remarks).
             if (!isBambiMode && !hasUserSHLinks)
             {
                 sb.AppendLine($@"
@@ -1151,6 +1183,8 @@ OUTPUT RULES:
                     sb.AppendLine(link.ToPromptText());
                 }
             }
+
+            sb.AppendLine(LinkFloorRule);
 
             var defaultPrompt = sb.ToString();
             return App.Mods?.MakeModAware(defaultPrompt) ?? defaultPrompt;

--- a/ConditioningControlPanel/Services/Companion/Brain/CompanionBrain.cs
+++ b/ConditioningControlPanel/Services/Companion/Brain/CompanionBrain.cs
@@ -234,9 +234,16 @@ namespace ConditioningControlPanel.Services.Companion.Brain
                 // Live 0806: small models imitate the bark-echo sigil and wrap their own replies in
                 // «X said aloud: "…"». Unwrap before the text reaches the bubble, history, or disk.
                 var chatText = AiTextHygiene.UnwrapSpokenSigil(result.Text);
+
+                // Live 0806: and they invent URLs when asked for a video they have no link for.
+                // Strip before the reply is appended — a fabricated link left in the window teaches
+                // the next turn to write another one.
+                chatText = AiTextHygiene.StripUnsanctionedLinks(chatText);
+
                 if (chatText.Length == 0)
                 {
-                    // The reply was nothing but sigil shell. Same treatment as a canned fallback.
+                    // Nothing but sigil shell, or nothing but invented links. Either way there is no
+                    // reply left to show: same treatment as a canned fallback.
                     Session.Remove(userTurn);
                     return new AiReplyResult(GetFallbackPhrase(), IsAiGenerated: false, Refusal: null);
                 }
@@ -313,6 +320,7 @@ namespace ConditioningControlPanel.Services.Companion.Brain
                 }
 
                 var reactionText = AiTextHygiene.UnwrapSpokenSigil(result.Text);
+                reactionText = AiTextHygiene.StripUnsanctionedLinks(reactionText);
                 if (reactionText.Length == 0)
                 {
                     Session.Remove(eventTurn);

--- a/ConditioningControlPanel/Services/Companion/Brain/CompanionSessionStore.cs
+++ b/ConditioningControlPanel/Services/Companion/Brain/CompanionSessionStore.cs
@@ -175,11 +175,15 @@ namespace ConditioningControlPanel.Services.Companion.Brain
                 if (!Enum.TryParse<TurnKind>(t.Kind, ignoreCase: true, out var kind)) continue;
                 if (kind is not (TurnKind.UserChat or TurnKind.AssistantChat)) continue;
 
-                // Replies persisted before the 0806 sigil fix carry «... said aloud: "..."» shells;
-                // heal them on the way in so old files stop re-teaching the model the pattern.
-                var text = kind == TurnKind.AssistantChat
-                    ? Services.AiTextHygiene.UnwrapSpokenSigil(t.Text)
-                    : t.Text;
+                // Replies persisted before the 0806 fixes carry «... said aloud: "..."» shells and
+                // invented URLs; heal both on the way in so an old file stops re-teaching the model
+                // the patterns. A turn that was nothing but shell, or nothing but links, is dropped.
+                var text = t.Text;
+                if (kind == TurnKind.AssistantChat)
+                {
+                    text = Services.AiTextHygiene.UnwrapSpokenSigil(text);
+                    text = Services.AiTextHygiene.StripUnsanctionedLinks(text);
+                }
                 if (text.Length == 0) continue;
 
                 result.Add(CompanionTurn.Create(kind, text, t.Mood,

--- a/ConditioningControlPanel/Services/Companion/CompanionLinkIndex.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionLinkIndex.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConditioningControlPanel.Services.Companion
+{
+    /// <summary>
+    /// The catalogue of links the app itself can stand behind: the built-in clickable content plus
+    /// whatever the user put in their global knowledge base.
+    ///
+    /// <para>Two jobs, both born from the same live bug (2026-08-06). Asked "any video to train
+    /// on?" while the active mod had no configured links, the model invented YouTube URLs out of
+    /// training data — plausible-looking, unvetted, and in one case not even a valid video id. The
+    /// prompt's ban on links only existed in the branch that HAD links to offer, so the one case
+    /// with nothing real to say was also the one case under no prohibition.</para>
+    ///
+    /// <list type="number">
+    ///   <item><see cref="IsSanctioned"/> answers "did we give her this link?" for
+    ///   <see cref="AiTextHygiene.StripUnsanctionedLinks"/> — prompt rules are advisory for a small
+    ///   model, so the hygiene pass is the part that actually holds.</item>
+    ///   <item><see cref="FindMentionedTitle"/> turns a title she NAMED into a link the app owns, so
+    ///   the chat can offer a real, working affordance instead of her guessing at a URL.</item>
+    /// </list>
+    ///
+    /// <para>Rebuilt on demand from a settings fingerprint: the knowledge base is user-editable at
+    /// runtime, and a stale index would either strip a link the user just added or offer one they
+    /// just deleted.</para>
+    /// </summary>
+    internal static class CompanionLinkIndex
+    {
+        /// <summary>A title short enough to appear inside ordinary prose by accident is not a
+        /// reliable mention. "Overload" (8) is a real catalogue entry; matching it inside "sensory
+        /// overload" would attach a video to a sentence that never suggested one.</summary>
+        internal const int MinimumTitleLength = 10;
+
+        private static readonly object Gate = new();
+        private static string? _fingerprint;
+        private static Entry[] _entries = Array.Empty<Entry>();
+        private static HashSet<string> _urls = new(StringComparer.OrdinalIgnoreCase);
+
+        internal readonly record struct Entry(string Title, string Url);
+
+        /// <summary>Diagnostics + tests: how many times the index was actually rebuilt.</summary>
+        internal static int BuildCount { get; private set; }
+
+        /// <summary>
+        /// True when <paramref name="url"/> is one the app handed her. Compared without the
+        /// trailing punctuation a sentence tends to leave on a URL, and ignoring case because a
+        /// model rarely echoes a link back byte-exact.
+        /// </summary>
+        internal static bool IsSanctioned(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return false;
+            EnsureCurrent();
+            lock (Gate) return _urls.Contains(Trim(url));
+        }
+
+        /// <summary>
+        /// Finds the catalogue title mentioned in <paramref name="text"/>, longest first so
+        /// "Bambi TikTok - In Beat" wins over a shorter title contained inside it. Returns null when
+        /// nothing is named — the common case, and it must stay cheap.
+        /// </summary>
+        internal static Entry? FindMentionedTitle(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return null;
+            EnsureCurrent();
+
+            Entry[] entries;
+            lock (Gate) entries = _entries;
+
+            foreach (var entry in entries)          // pre-sorted longest-first
+            {
+                var at = text.IndexOf(entry.Title, StringComparison.OrdinalIgnoreCase);
+                if (at >= 0 && IsWholeMention(text, at, entry.Title.Length)) return entry;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The match must not be the middle of a longer word. Quotes, brackets and ordinary
+        /// punctuation around a title are normal ("Watch <i>"Naughty Bambi"</i> for me~"), so only
+        /// letters and digits on the boundary disqualify it.
+        /// </summary>
+        private static bool IsWholeMention(string text, int start, int length)
+        {
+            if (start > 0 && char.IsLetterOrDigit(text[start - 1])) return false;
+            var end = start + length;
+            return end >= text.Length || !char.IsLetterOrDigit(text[end]);
+        }
+
+        private static string Trim(string url) => url.Trim().TrimEnd('.', ',', ')', ']', '!', '?', ';', ':', '"', '\'');
+
+        private static void EnsureCurrent()
+        {
+            var fingerprint = Fingerprint();
+            lock (Gate)
+            {
+                if (_fingerprint == fingerprint) return;
+                Rebuild(fingerprint);
+            }
+        }
+
+        private static void Rebuild(string fingerprint)
+        {
+            var entries = new List<Entry>();
+            var urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                foreach (var (title, url) in BambiSprite.ContentCatalogue)
+                    Add(entries, urls, title, url);
+
+                var kb = App.Settings?.Current?.GlobalKnowledgeBaseLinks;
+                if (kb != null)
+                    foreach (var link in kb)
+                        Add(entries, urls, link?.Title, link?.Url);
+            }
+            catch (Exception ex)
+            {
+                // A half-built index would silently sanction fewer links than it should, and the
+                // caller strips whatever is not sanctioned — so fail to the empty index (strip
+                // everything) rather than to a partial one, and say why.
+                App.Logger?.Warning(ex, "CompanionLinkIndex: failed to build the sanctioned-link index");
+                entries.Clear();
+                urls.Clear();
+            }
+
+            entries.Sort((a, b) => b.Title.Length.CompareTo(a.Title.Length));
+            _entries = entries.ToArray();
+            _urls = urls;
+            _fingerprint = fingerprint;
+            BuildCount++;
+        }
+
+        private static void Add(List<Entry> entries, HashSet<string> urls, string? title, string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return;
+            urls.Add(Trim(url));
+
+            if (string.IsNullOrWhiteSpace(title) || title.Trim().Length < MinimumTitleLength) return;
+            entries.Add(new Entry(title.Trim(), url.Trim()));
+        }
+
+        /// <summary>
+        /// Cheap stand-in for "did the catalogue change": the built-in list is compile-time constant,
+        /// so only the knowledge base can move underneath us.
+        /// </summary>
+        private static string Fingerprint()
+        {
+            var kb = App.Settings?.Current?.GlobalKnowledgeBaseLinks;
+            if (kb == null || kb.Count == 0) return "kb:0";
+
+            var sb = new System.Text.StringBuilder("kb:").Append(kb.Count);
+            foreach (var link in kb) sb.Append('|').Append(link?.Url).Append('#').Append(link?.Title);
+            return sb.ToString();
+        }
+
+        /// <summary>Tests only: forget the cached index so the next call rebuilds.</summary>
+        internal static void ResetForTests()
+        {
+            lock (Gate)
+            {
+                _fingerprint = null;
+                _entries = Array.Empty<Entry>();
+                _urls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Companion/CompanionLinkIndex.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionLinkIndex.cs
@@ -107,6 +107,15 @@ namespace ConditioningControlPanel.Services.Companion
 
             try
             {
+                // The ACTIVE MOD'S POOL FIRST — user override, else the mod's shipped
+                // DefaultVideoLinks. This is what she is actually told to name, so it is the set
+                // that most needs a working chip; omitting it would also strip her own pool's URLs
+                // as "unsanctioned" if she ever echoed one.
+                var pool = App.Mods?.GetVideoLinks();
+                if (pool != null)
+                    foreach (var kvp in pool)
+                        Add(entries, urls, kvp.Key, kvp.Value);
+
                 foreach (var (title, url) in BambiSprite.ContentCatalogue)
                     Add(entries, urls, title, url);
 
@@ -142,16 +151,23 @@ namespace ConditioningControlPanel.Services.Companion
         }
 
         /// <summary>
-        /// Cheap stand-in for "did the catalogue change": the built-in list is compile-time constant,
-        /// so only the knowledge base can move underneath us.
+        /// Cheap stand-in for "did the catalogue change". The built-in list is compile-time
+        /// constant; the two things that move are the knowledge base and the active mod's pool —
+        /// and a mod switch replaces the whole pool, so the mod id has to be in here or a switch
+        /// would keep sanctioning the previous mod's links.
         /// </summary>
         private static string Fingerprint()
         {
-            var kb = App.Settings?.Current?.GlobalKnowledgeBaseLinks;
-            if (kb == null || kb.Count == 0) return "kb:0";
+            var sb = new System.Text.StringBuilder("mod:").Append(App.Mods?.ActiveModId ?? "none");
 
-            var sb = new System.Text.StringBuilder("kb:").Append(kb.Count);
-            foreach (var link in kb) sb.Append('|').Append(link?.Url).Append('#').Append(link?.Title);
+            var pool = App.Mods?.GetVideoLinks();
+            sb.Append("|pool:").Append(pool?.Count ?? 0);
+
+            var kb = App.Settings?.Current?.GlobalKnowledgeBaseLinks;
+            sb.Append("|kb:").Append(kb?.Count ?? 0);
+            if (kb != null)
+                foreach (var link in kb) sb.Append('|').Append(link?.Url).Append('#').Append(link?.Title);
+
             return sb.ToString();
         }
 

--- a/ConditioningControlPanel/Views/Controls/Companion/ChatThresholdView.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/ChatThresholdView.xaml
@@ -59,8 +59,18 @@
                       ToolTip="{Binding Timestamp}">
                     <Border x:Name="Bubble" Style="{StaticResource CmpBubbleHerStyle}"
                             HorizontalAlignment="Stretch">
-                        <TextBlock x:Name="BubbleText" Text="{Binding Text}"
-                                   Style="{StaticResource CmpBubbleTextStyle}"/>
+                        <StackPanel>
+                            <TextBlock x:Name="BubbleText" Text="{Binding Text}"
+                                       Style="{StaticResource CmpBubbleTextStyle}"/>
+
+                            <!-- She names a title; the app owns the link. Collapsed unless the
+                                 title she named resolves to something we can actually open, so an
+                                 ordinary line keeps exactly the layout it had. -->
+                            <Button x:Name="WatchChip" Style="{StaticResource CmpWatchChipStyle}"
+                                    Command="{Binding OpenLinkCommand}"
+                                    Content="{Binding LinkTitle}"
+                                    Visibility="{Binding LinkTitle, Converter={StaticResource CmpHasContentToVis}}"/>
+                        </StackPanel>
                     </Border>
 
                     <!-- her signature rail. The CSS is a faint outline PLUS a solid 3px pink

--- a/ConditioningControlPanel/Views/Controls/Companion/CompanionItemVms.cs
+++ b/ConditioningControlPanel/Views/Controls/Companion/CompanionItemVms.cs
@@ -29,6 +29,19 @@ namespace ConditioningControlPanel.Views.Controls.Companion
 
         /// <summary>Relative time for the tooltip ("2h ago"). Optional.</summary>
         string? Timestamp { get; }
+
+        /// <summary>
+        /// Title of a video she NAMED that the app has a real link for, or null. Drives the watch
+        /// chip under the bubble.
+        ///
+        /// <para>She is forbidden from writing URLs (she has no way to check one, and on 2026-08-06
+        /// she was caught inventing them). Naming a title is the half she can do honestly; resolving
+        /// that name to a working link is the half the app can do honestly.</para>
+        /// </summary>
+        string? LinkTitle { get; }
+
+        /// <summary>Opens <see cref="LinkTitle"/>'s link. Null when there is nothing to open.</summary>
+        ICommand? OpenLinkCommand { get; }
     }
 
     /// <summary>One card on the Z3 fact wall.</summary>
@@ -186,18 +199,23 @@ namespace ConditioningControlPanel.Views.Controls.Companion
     {
         public CompanionChatBubble() { Text = string.Empty; }
 
-        public CompanionChatBubble(CompanionBubbleKind kind, string text, bool isAi = false, string? timestamp = null)
+        public CompanionChatBubble(CompanionBubbleKind kind, string text, bool isAi = false, string? timestamp = null,
+            string? linkTitle = null, ICommand? openLink = null)
         {
             Kind = kind;
             Text = text;
             IsAiGenerated = isAi;
             Timestamp = timestamp;
+            LinkTitle = linkTitle;
+            OpenLinkCommand = openLink;
         }
 
         public CompanionBubbleKind Kind { get; init; }
         public string Text { get; init; }
         public bool IsAiGenerated { get; init; }
         public string? Timestamp { get; init; }
+        public string? LinkTitle { get; init; }
+        public ICommand? OpenLinkCommand { get; init; }
     }
 
     public sealed class CompanionMemoryFact : CompanionObservable, IMemoryFactVm

--- a/ConditioningControlPanel/Views/Controls/Companion/Runtime/ChatThresholdRuntimeVm.cs
+++ b/ConditioningControlPanel/Views/Controls/Companion/Runtime/ChatThresholdRuntimeVm.cs
@@ -257,6 +257,15 @@ namespace ConditioningControlPanel.Views.Controls.Companion.Runtime
             var bubbles = new List<IChatBubbleVm>(picked.Count);
             foreach (var turn in picked)
             {
+                var text = turn.Kind == TurnKind.BarkEcho ? UnwrapEcho(turn.Text) : turn.Text;
+
+                // She names titles; the app owns links (see IChatBubbleVm.LinkTitle). Only her own
+                // lines get a chip — a title inside the USER's message is them talking, not a
+                // suggestion, and a bark is a recording that never had a link to begin with.
+                var link = turn.Kind == TurnKind.AssistantChat
+                    ? Services.Companion.CompanionLinkIndex.FindMentionedTitle(text)
+                    : null;
+
                 bubbles.Add(new CompanionChatBubble(
                     kind: turn.Kind switch
                     {
@@ -264,10 +273,12 @@ namespace ConditioningControlPanel.Views.Controls.Companion.Runtime
                         TurnKind.BarkEcho => CompanionBubbleKind.Echo,
                         _ => CompanionBubbleKind.Her
                     },
-                    text: turn.Kind == TurnKind.BarkEcho ? UnwrapEcho(turn.Text) : turn.Text,
+                    text: text,
                     // Only an AssistantChat turn is a genuine completion — see the class remarks.
                     isAi: turn.Kind == TurnKind.AssistantChat,
-                    timestamp: RelativeTime(turn.Utc)));
+                    timestamp: RelativeTime(turn.Utc),
+                    linkTitle: link?.Title,
+                    openLink: link is { } hit ? CompanionLinkLauncher.CommandFor(hit.Url) : null));
             }
             return bubbles;
         }

--- a/ConditioningControlPanel/Views/Controls/Companion/Runtime/CompanionLinkLauncher.cs
+++ b/ConditioningControlPanel/Views/Controls/Companion/Runtime/CompanionLinkLauncher.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using ConditioningControlPanel.Services.Browser;
+
+namespace ConditioningControlPanel.Views.Controls.Companion.Runtime
+{
+    /// <summary>
+    /// Opens a link the app itself issued, from a chat bubble's watch chip.
+    ///
+    /// <para>Deliberately the same sequence the speech bubble already uses
+    /// (<c>AvatarTubeWindow.Speech.cs</c> <c>SpeechBubbleHyperlink_RequestNavigate</c>): refuse while
+    /// a remote controller is attached, hand the media session over explicitly, prefer the embedded
+    /// browser, and fall back to the system browser for HTTPS only. Two ways to open the same kind
+    /// of link would be two sets of rules about remote control and media ownership, and one of them
+    /// would drift.</para>
+    /// </summary>
+    internal static class CompanionLinkLauncher
+    {
+        internal static ICommand CommandFor(string url) => new RelayCommand(() => Open(url));
+
+        internal static void Open(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return;
+
+            try
+            {
+                // A controller driving the session must not have the browser navigated out from
+                // under it mid-playback.
+                if (App.RemoteControl?.ControllerConnected == true)
+                {
+                    App.Logger?.Debug("Companion watch chip blocked - remote controller is connected");
+                    return;
+                }
+
+                if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+                {
+                    App.Logger?.Warning("Companion watch chip refused a non-http(s) link");
+                    return;
+                }
+
+                var mainWindow = Application.Current?.Windows.OfType<MainWindow>().FirstOrDefault();
+
+                // The user clicked it themselves, so never refuse — but take the session over
+                // explicitly instead of navigating out from under a previous claim.
+                App.BrowserMedia?.ReplaceSession(BrowserMediaService.MediaOwner.AvatarLink, takeover: true);
+
+                if (mainWindow?.NavigateToUrlInBrowser(url, autoPlayFullscreen: true) == true)
+                {
+                    App.Logger?.Information("Companion watch chip routed to the embedded browser");
+                    return;
+                }
+
+                // The embedded browser never issued the navigation, so release the session we just
+                // claimed — otherwise the app keeps treating a video that is not playing here as an
+                // active web-media session.
+                App.BrowserMedia?.OnMediaStopped("embedded-browser-unavailable");
+
+                if (uri.Scheme == Uri.UriSchemeHttps)
+                {
+                    App.Logger?.Warning("Embedded browser unavailable, opening the watch chip externally");
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "Companion watch chip failed to open its link");
+            }
+        }
+
+        private sealed class RelayCommand : ICommand
+        {
+            private readonly Action _run;
+            internal RelayCommand(Action run) => _run = run;
+
+            public event EventHandler? CanExecuteChanged { add { } remove { } }
+            public bool CanExecute(object? parameter) => true;
+            public void Execute(object? parameter) => _run();
+        }
+    }
+}

--- a/ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/Themes/CompanionTheme.xaml
@@ -922,6 +922,40 @@
         <Setter Property="Foreground" Value="{StaticResource CmpFaintBrush}"/>
     </Style>
 
+    <!-- .watchchip — sits under her line when she NAMED something the app has a real link for.
+         Quiet by design: it is an offer, not a call to action, and it must never compete with the
+         zone's own CTA. The play glyph is the whole affordance; the label is her wording. -->
+    <Style x:Key="CmpWatchChipStyle" TargetType="Button">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="Margin" Value="0,7,0,0"/>
+        <Setter Property="Padding" Value="9,4"/>
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource CmpPinkBrush}"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Chip" CornerRadius="9" Padding="{TemplateBinding Padding}"
+                            Background="#26FF69B4" BorderBrush="#59FF69B4" BorderThickness="1">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="▶" FontSize="9" VerticalAlignment="Center"
+                                       Margin="0,0,5,0" Foreground="{TemplateBinding Foreground}"/>
+                            <TextBlock Text="{TemplateBinding Content}" TextTrimming="CharacterEllipsis"
+                                       MaxWidth="240" VerticalAlignment="Center"
+                                       Foreground="{TemplateBinding Foreground}"/>
+                        </StackPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Chip" Property="Background" Value="#3DFF69B4"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- .aibadge — the pink AI badge. INVARIANT: this rides IsAiGenerated only. It must never
          appear on a bark, a canned line, or a BarkEcho. -->
     <Style x:Key="CmpAiBadgeStyle" TargetType="Border">

--- a/Tests/ConditioningControlPanel.Tests/AiInventedLinkStripTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiInventedLinkStripTests.cs
@@ -1,0 +1,125 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Live play-test 2026-08-06: asked "any video to train on?" on a mod with no configured links, she
+/// answered with invented YouTube URLs — plausible-looking, unvetted, and one of them not even a
+/// valid video id ("9d7WKQwz7qCcM" is 13 chars; a YouTube id is 11). With Train 1's multi-turn
+/// window her own fabricated link then sat in context, so "give me another one" copied the pattern
+/// and drifted further off-brand.
+///
+/// <para>The rule: a link the app issued survives; a link she wrote from memory takes its whole
+/// sentence with it. Sentence-level because "Click here:" left dangling reads worse than a clean
+/// cut, and because she frequently glues the next word onto the URL.</para>
+/// </summary>
+public class AiInventedLinkStripTests
+{
+    // Stands in for the real catalogue; "did we give her this link?" and nothing more.
+    private static bool OnlyOurs(string url) =>
+        url == "https://hypnotube.com/video/naughty-bambi-109749.html";
+
+    [Fact]
+    public void AnInventedLinkTakesItsSentenceWithIt()
+    {
+        var reply = "Of course! How about \"Bambi TikTok Mix\"? It's a fun one! " +
+                    "Click here: https://youtu.be/9d7WKQwz7qCcM Let's get you hypnotized. 💕";
+
+        var cleaned = AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs);
+
+        Assert.DoesNotContain("youtu.be", cleaned);
+        Assert.DoesNotContain("Click here", cleaned);
+        Assert.Contains("Bambi TikTok Mix", cleaned);   // the naming survives; only the link goes
+        Assert.Contains("💕", cleaned);
+    }
+
+    [Fact]
+    public void AGluedFollowingWordGoesWithTheSentenceRatherThanBeingHalfEaten()
+    {
+        // The exact second live shape: no space between the URL and "Let's". No URL-shaped pattern
+        // can split that correctly, which is precisely why the whole sentence is dropped.
+        var reply = "Sure! It's got catchy tunes. Click here: https://youtu.be/6VwZJ7UfK60cLet's " +
+                    "get moving and grooving together! 💃";
+
+        var cleaned = AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs);
+
+        // Trailing decoration after the terminator is its own fragment and carries no link, so it
+        // survives — keeping a stray emoji beats eating a sentence we had no reason to drop.
+        Assert.Equal("Sure! It's got catchy tunes. 💃", cleaned);
+        Assert.DoesNotContain("grooving", cleaned);     // the glued remainder left with its sentence
+        Assert.DoesNotContain("youtu.be", cleaned);
+    }
+
+    [Fact]
+    public void ALinkTheAppIssuedIsLeftAlone()
+    {
+        var reply = "Watch https://hypnotube.com/video/naughty-bambi-109749.html for me~";
+        Assert.Equal(reply, AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs));
+    }
+
+    [Fact]
+    public void OurLinkSurvivesEvenWithTheSentencePeriodStuckToIt()
+    {
+        var reply = "Go watch https://hypnotube.com/video/naughty-bambi-109749.html. You'll love it.";
+        Assert.Equal(reply, AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs));
+    }
+
+    [Fact]
+    public void OneStraySentenceDoesNotTakeTheGoodOneWithIt()
+    {
+        var reply = "Try https://hypnotube.com/video/naughty-bambi-109749.html first. " +
+                    "Or this one: https://youtu.be/aaaaaaaaaaa instead!";
+
+        var cleaned = AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs);
+
+        Assert.Contains("hypnotube.com", cleaned);
+        Assert.DoesNotContain("youtu.be", cleaned);
+    }
+
+    [Fact]
+    public void AReplyThatWasNothingButAnInventedLinkStripsToEmpty()
+    {
+        // The caller treats empty as "no reply" and falls back to a canned line, exactly as it does
+        // for an all-sigil reply.
+        Assert.Equal("", AiTextHygiene.StripUnsanctionedLinks("https://youtu.be/9d7WKQwz7qCcM", OnlyOurs));
+    }
+
+    [Theory]
+    [InlineData("good girl~ no links here at all")]
+    [InlineData("")]
+    [InlineData("I love the http protocol joke")]      // contains "http" but no URL
+    public void OrdinaryRepliesPassThroughUntouched(string reply)
+        => Assert.Equal(reply, AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs));
+
+    [Fact]
+    public void ASchemelessAddressIsStillALink()
+    {
+        var reply = "Check it out. Go to www.youtube.com/watch?v=abcdefghijk now!";
+        var cleaned = AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs);
+
+        Assert.Equal("Check it out.", cleaned);
+    }
+
+    [Fact]
+    public void TheStripSurvivesAMultiLineReply()
+    {
+        var reply = "First line is fine.\nhttps://youtu.be/aaaaaaaaaaa\nThird line is fine too.";
+        var cleaned = AiTextHygiene.StripUnsanctionedLinks(reply, OnlyOurs);
+
+        Assert.Contains("First line is fine.", cleaned);
+        Assert.Contains("Third line is fine too.", cleaned);
+        Assert.DoesNotContain("youtu.be", cleaned);
+    }
+
+    [Fact]
+    public void TheLinkFloorRuleIsPartOfEveryPromptNotOneBranch()
+    {
+        // The bug was structural: the "never write a URL" rule lived only in the branch that shipped
+        // a video list, so the mod with nothing real to offer was the one under no prohibition.
+        var rule = ConditioningControlPanel.Services.BambiSprite.LinkFloorRule;
+
+        Assert.Contains("NEVER write a URL", rule);
+        Assert.Contains("NAME it in words only", rule);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/AiInventedLinkStripTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiInventedLinkStripTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services;
 using Xunit;
 
@@ -121,5 +123,31 @@ public class AiInventedLinkStripTests
 
         Assert.Contains("NEVER write a URL", rule);
         Assert.Contains("NAME it in words only", rule);
+    }
+
+    [Fact]
+    public void ThePresetPathCarriesTheFloorToo_NotJustTheLegacyPrompt()
+    {
+        // The rule above was appended in GetDefaultBambiSpritePrompt only, and that is the FALLBACK.
+        // A user with an active personality preset — the normal case — goes through
+        // BuildPromptFromPreset, whose media block forbids URLs in three of its four branches. The
+        // fourth is SissyHypno with no configured links and no mod pool: it forbids naming TITLES
+        // and says nothing about URLs, and it is the branch the live bug actually took. A floor
+        // present on only one of two prompt paths is not a floor.
+        var preset = new PersonalityPreset
+        {
+            Id = "test-preset",
+            Name = "Test",
+            PromptSettings = new CompanionPromptSettings { Personality = "You are a test persona." }
+        };
+
+        var build = typeof(BambiSprite).GetMethod(
+            "BuildPromptFromPreset", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(build);
+
+        var prompt = (string)build!.Invoke(new BambiSprite(), new object[] { preset })!;
+
+        Assert.Contains("NEVER write a URL", prompt);
+        Assert.Contains("NAME it in words only", prompt);
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/CompanionLinkIndexTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionLinkIndexTests.cs
@@ -1,0 +1,87 @@
+using ConditioningControlPanel.Services.Companion;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// She names a title; the app owns the link (2026-08-06 fix). These pin the half that turns her
+/// wording into something clickable — the half that must never attach a video to a sentence that
+/// never suggested one.
+/// </summary>
+[Collection("CompanionLinkIndex")]
+public class CompanionLinkIndexTests
+{
+    public CompanionLinkIndexTests() => CompanionLinkIndex.ResetForTests();
+
+    [Fact]
+    public void ATitleSheNamedResolvesToTheAppsOwnLink()
+    {
+        var hit = CompanionLinkIndex.FindMentionedTitle("How about Bambi's Naughty TikTok Collection tonight?~");
+
+        Assert.NotNull(hit);
+        Assert.Equal("Bambi's Naughty TikTok Collection", hit!.Value.Title);
+        Assert.StartsWith("https://hypnotube.com/", hit.Value.Url);
+    }
+
+    [Fact]
+    public void QuotesAndPunctuationAroundTheTitleAreNormal()
+    {
+        var hit = CompanionLinkIndex.FindMentionedTitle("Watch \"Bambi's Naughty TikTok Collection\", good girl.");
+        Assert.NotNull(hit);
+    }
+
+    [Fact]
+    public void TheMatchIsCaseInsensitive()
+        => Assert.NotNull(CompanionLinkIndex.FindMentionedTitle("go watch bambi's naughty tiktok collection~"));
+
+    [Fact]
+    public void AShortTitleIsNotMatchedInsideOrdinaryProse()
+    {
+        // "Overload" is a real catalogue entry, but a title that short appears in normal sentences
+        // by accident — attaching a video to "sensory overload" would be the model looking broken.
+        Assert.Null(CompanionLinkIndex.FindMentionedTitle("that was sensory overload, wasn't it?"));
+    }
+
+    [Fact]
+    public void ATitleGluedInsideALongerWordIsNotAMention()
+        => Assert.Null(CompanionLinkIndex.FindMentionedTitle("xxBambi's Naughty TikTok Collectionxx"));
+
+    [Fact]
+    public void NothingNamedMeansNoChip()
+    {
+        Assert.Null(CompanionLinkIndex.FindMentionedTitle("hi cutie, how was your day?"));
+        Assert.Null(CompanionLinkIndex.FindMentionedTitle(""));
+        Assert.Null(CompanionLinkIndex.FindMentionedTitle(null));
+    }
+
+    [Fact]
+    public void TheAppsOwnLinksAreSanctionedAndAnythingElseIsNot()
+    {
+        var hit = CompanionLinkIndex.FindMentionedTitle("Bambi's Naughty TikTok Collection");
+        Assert.NotNull(hit);
+
+        Assert.True(CompanionLinkIndex.IsSanctioned(hit!.Value.Url));
+        Assert.False(CompanionLinkIndex.IsSanctioned("https://youtu.be/9d7WKQwz7qCcM"));
+        Assert.False(CompanionLinkIndex.IsSanctioned(""));
+        Assert.False(CompanionLinkIndex.IsSanctioned(null));
+    }
+
+    [Fact]
+    public void TrailingSentencePunctuationDoesNotUnsanctionOurOwnLink()
+    {
+        var hit = CompanionLinkIndex.FindMentionedTitle("Bambi's Naughty TikTok Collection");
+        Assert.True(CompanionLinkIndex.IsSanctioned(hit!.Value.Url + "."));
+        Assert.True(CompanionLinkIndex.IsSanctioned(hit.Value.Url + "!"));
+    }
+
+    [Fact]
+    public void TheIndexIsBuiltOnceAndReusedUntilTheCatalogueMoves()
+    {
+        CompanionLinkIndex.FindMentionedTitle("warm the cache");
+        var after = CompanionLinkIndex.BuildCount;
+
+        for (int i = 0; i < 5; i++) CompanionLinkIndex.FindMentionedTitle("nothing named here");
+
+        Assert.Equal(after, CompanionLinkIndex.BuildCount);
+    }
+}


### PR DESCRIPTION
Found in the play-test of #172/#173. Asked *"any video to train on?"*, she replied with fabricated YouTube URLs — one of them not even a valid video id (13 characters; YouTube ids are 11). Clicking them landed on unrelated, unvetted videos. The app's real catalogue is HypnoTube; nothing in it is a YouTube link.

## Root cause

Structural, not model noise. The `NEVER include URLs` instruction lived **only in the prompt branch that had a video list to quote from** (`BambiSprite.cs:1126`). A user on the SissyHypno mod with no configured links takes the *other* branch, which has no list **and** no prohibition — so the one case with nothing real to offer was the one case least defended.

Train 1 then amplified it. With multi-turn history her own fabricated link sits in the window, so "give me another one" copied the pattern and drifted further off-brand (a TikTok dance compilation, not hypno at all). Same self-priming shape as the sigil-imitation bug fixed in #172.

## The fix, in three parts

**1. `LinkFloorRule` is appended after both branches**, so every prompt carries it. It also states the honest division of labour: she names things in words, the app turns a name into a working link.

**2. `AiTextHygiene.StripUnsanctionedLinks`** removes links the app never issued, along with the sentence carrying them. Prompt rules are advisory for a model this small, so this is the part that actually holds. Sentence-level for two reasons: `Click here:` left dangling reads worse than a clean cut, and she glues the following word onto the URL (`…K60cLet's get moving`), which no URL-shaped pattern can split correctly. Wired into both brain paths **and the session loader**, so conversations already on disk stop re-teaching the pattern.

Sentence splitting is hand-written rather than a regex: a URL is full of periods, and any `[.!?]` pattern cuts `hypnotube.com/naughty-bambi-109749.html` into four "sentences". That was a real bug caught by the tests.

**3. `CompanionLinkIndex`** resolves a title she *named* to a link the app owns — built-in catalogue plus the user's knowledge base — and the bubble offers it as a quiet watch chip. Opening reuses the speech bubble's existing sequence (remote-control check, media-session handover, embedded browser, HTTPS-only external fallback) instead of growing a second set of rules for the same kind of link.

Fails closed throughout: if the index can't be built, nothing is sanctioned and every link is stripped.

## Tests

1778 green, 21 new — including both live replies verbatim, the glued-word case, our own links surviving with sentence punctuation attached, and the short-title guard (`Overload` must not match "sensory overload").

## Owner checklist

- [ ] Ask her for a video on a mod with no configured links — she should name something without a URL.
- [ ] When she names a catalogue title, the watch chip appears and opens in the embedded browser.
- [ ] Your existing conversation heals on load: the two bad replies lose their link sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue