### PR TITLE
fix(companion): title the awareness deny-list so it reads as hidden, not visible

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -3741,6 +3741,7 @@
   "companion_awareness_add_deny": "+ App hinzufügen…",
   "companion_awareness_allow_per_app": "pro App erlauben…",
   "companion_awareness_deny_banking": "Banking ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ Apps vor ihr verstecken kommt mit Train 2",
   "companion_awareness_deny_email": "E-Mail ✓",
   "companion_awareness_deny_passwords": "Passwort-Manager ✓",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -4301,6 +4301,7 @@
   "companion_awareness_add_deny": "+ add app…",
   "companion_awareness_allow_per_app": "allow per app…",
   "companion_awareness_deny_banking": "banking ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ hiding apps from her arrives with Train 2",
   "companion_awareness_deny_email": "email ✓",
   "companion_awareness_deny_passwords": "password managers ✓",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -3732,6 +3732,7 @@
   "companion_awareness_add_deny": "+ añadir app…",
   "companion_awareness_allow_per_app": "permitir por app…",
   "companion_awareness_deny_banking": "banca ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ esconderle apps llega con Train 2",
   "companion_awareness_deny_email": "correo ✓",
   "companion_awareness_deny_passwords": "gestores de contraseñas ✓",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -3741,6 +3741,7 @@
   "companion_awareness_add_deny": "+ ajouter une app…",
   "companion_awareness_allow_per_app": "autoriser par app…",
   "companion_awareness_deny_banking": "banque ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ lui cacher des apps arrive avec Train 2",
   "companion_awareness_deny_email": "e-mail ✓",
   "companion_awareness_deny_passwords": "gestionnaires de mots de passe ✓",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -3732,6 +3732,7 @@
   "companion_awareness_add_deny": "+ アプリを追加…",
   "companion_awareness_allow_per_app": "アプリごとに許可…",
   "companion_awareness_deny_banking": "銀行 ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ アプリを隠す機能はTrain 2から",
   "companion_awareness_deny_email": "メール ✓",
   "companion_awareness_deny_passwords": "パスワード管理 ✓",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -3739,6 +3739,7 @@
   "companion_awareness_add_deny": "+ 앱 추가…",
   "companion_awareness_allow_per_app": "앱별로 허용…",
   "companion_awareness_deny_banking": "뱅킹 ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ 앱 숨기기는 Train 2에서 시작돼요",
   "companion_awareness_deny_email": "이메일 ✓",
   "companion_awareness_deny_passwords": "비밀번호 관리자 ✓",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -3740,6 +3740,7 @@
   "companion_awareness_add_deny": "+ adicionar app…",
   "companion_awareness_allow_per_app": "permitir por app…",
   "companion_awareness_deny_banking": "bancos ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ esconder apps dela chega com o Train 2",
   "companion_awareness_deny_email": "e-mail ✓",
   "companion_awareness_deny_passwords": "gerenciadores de senha ✓",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -3739,6 +3739,7 @@
   "companion_awareness_add_deny": "+ добавить приложение…",
   "companion_awareness_allow_per_app": "разрешить по приложениям…",
   "companion_awareness_deny_banking": "банки ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ прятать от неё приложения можно будет с Train 2",
   "companion_awareness_deny_email": "почта ✓",
   "companion_awareness_deny_passwords": "менеджеры паролей ✓",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -4199,6 +4199,7 @@
   "companion_awareness_add_deny": "+ 添加应用…",
   "companion_awareness_allow_per_app": "按应用允许…",
   "companion_awareness_deny_banking": "银行 ✓",
+  "companion_awareness_deny_head": "always hidden from her — no reaction, no counter, nothing sent:",
   "companion_awareness_deny_dormant": "+ 对她隐藏应用将随 Train 2 到来",
   "companion_awareness_deny_email": "邮箱 ✓",
   "companion_awareness_deny_passwords": "密码管理器 ✓",

--- a/ConditioningControlPanel/Views/Controls/Companion/AwarenessPrivacyView.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/AwarenessPrivacyView.xaml
@@ -301,7 +301,12 @@
                 <Rectangle Style="{StaticResource CmpDashedOutlineStyle}"/>
             </Grid>
 
-            <!-- ========== deny list ========== -->
+            <!-- ========== deny list ==========
+                 The heading is load-bearing: without it these chips sit under a card titled
+                 "What she can see" and read as the ONLY things she can see — the exact
+                 opposite of what they are. -->
+            <TextBlock Text="{loc:Str companion_awareness_deny_head}"
+                       Style="{StaticResource CmpFaintTextStyle}" Margin="2,0,0,4"/>
             <ItemsControl ItemsSource="{Binding DenyList}" ItemTemplate="{StaticResource CmpDenyChipTemplate}"
                           Margin="0,0,0,4">
                 <ItemsControl.ItemsPanel>


### PR DESCRIPTION
## What

Mort's urgent optics report (Discord, screenshot): in the **What she can see** panel, the deny chips (`password managers ✓ / banking ✓ / email ✓`) had no heading — under a card titled "What she can see" they read as the *only things she CAN see*, when they are the apps that are always invisible to her. The explanation only appeared after clicking `+ add app…`.

## Fix

- New heading line directly above the chips, same faint style as the other list labels:
  > always hidden from her — no reaction, no counter, nothing sent:
- Loc key `companion_awareness_deny_head` added to all 9 language files (English text; fallback covers translation later). Strict-JSON verified, 1-line diff each, EOL preserved.

## Verify

- `dotnet build` green (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue
