### PR TITLE
feat(ui): make the mod manager entry point discoverable - accent capsule + MOD MANAGER caption

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -1170,6 +1170,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Interaktion, Lösen, Größenänderung, Entwicklungsstufen und Animationen",
   "label_text_4": "🔧",
   "label_modding_guide": "Modding-Anleitung",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Öffnet den Mod-Creator mit einer Schritt-für-Schritt-Anleitung durch jeden Tab",
   "label_pro_tips": "💡 Profi-Tipps",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -2110,6 +2110,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Interacting, detaching, resizing, evolution stages, and animations",
   "label_text_4": "🔧",
   "label_modding_guide": "Modding Guide",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Opens the Mod Creator with a step-by-step walkthrough of every tab",
   "label_pro_tips": "💡 Pro Tips",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -1169,6 +1169,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Interacción, desanclaje, redimensión, etapas de evolución y animaciones",
   "label_text_4": "🔧",
   "label_modding_guide": "Guía de Modding",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Abre el Creador de Mods con un recorrido paso a paso de cada pestaña",
   "label_pro_tips": "💡 Consejos Pro",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -1170,6 +1170,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Interaction, détachement, redimensionnement, stades d'évolution, et animations",
   "label_text_4": "🔧",
   "label_modding_guide": "Guide de Modding",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Ouvre le Créateur de Mods avec un guide pas à pas de chaque onglet",
   "label_pro_tips": "💡 Astuces Pro",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -1169,6 +1169,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "操作、分離、リサイズ、進化段階、アニメーション",
   "label_text_4": "🔧",
   "label_modding_guide": "Modガイド",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Modクリエイターを開き、各タブのステップバイステップガイドを表示",
   "label_pro_tips": "💡 ヒント",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -1169,6 +1169,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "상호작용, 분리, 크기 조절, 진화 단계, 애니메이션",
   "label_text_4": "🔧",
   "label_modding_guide": "모딩 가이드",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "모든 탭을 단계별로 안내하는 모드 크리에이터를 열어요",
   "label_pro_tips": "💡 프로 팁",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -1169,6 +1169,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Interação, desancorar, redimensionar, estágios de evolução e animações",
   "label_text_4": "🔧",
   "label_modding_guide": "Guia de Modding",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Abre o Criador de Mods com um passo a passo de cada aba",
   "label_pro_tips": "💡 Dicas Profissionais",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -1169,6 +1169,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "Взаимодействие, отсоединение, изменение размера, стадии эволюции и анимации",
   "label_text_4": "🔧",
   "label_modding_guide": "Руководство по моддингу",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "Открывает конструктор модов с пошаговым руководством по каждой вкладке",
   "label_pro_tips": "💡 Полезные советы",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -1869,6 +1869,7 @@
   "label_interacting_detaching_resizing_evolution_stag": "交互、分离、调整大小、进化阶段和动画",
   "label_text_4": "🔧",
   "label_modding_guide": "模组指南",
+  "label_mod_manager": "MOD MANAGER",
   "label_opens_the_mod_creator_with_a_step_by_step_wal": "打开模组创建器并提供每个标签页的逐步指导",
   "label_pro_tips": "💡 专业技巧",
   "label_assets_images": " assets/images",

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -265,12 +265,40 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                        <!-- Accent capsule, not a bare glyph: the old 22px muted gear was the
+                             single most-asked "where is it?" control in the app. Gear + caption
+                             live inside the template so one hit area covers both.
+                             Height 28 is free vertical room - the Row 1 tab buttons in column 1
+                             are already Height 32, so this cannot grow the header row.
+                             LineHeight/BlockLineHeight pins each line so the 28px never clips. -->
                         <Button x:Name="BtnManageMods" Click="BtnManageMods_Click"
                                 ToolTip="{loc:Str tooltip_manage_mods}"
-                                Margin="4,0,0,0" Width="22" Height="22"
+                                Margin="5,0,0,0" Height="28" VerticalAlignment="Center"
                                 Background="Transparent" BorderThickness="0" Cursor="Hand">
-                            <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="11"
-                                       Foreground="{DynamicResource TextMutedBrush}"/>
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Border x:Name="capsule" CornerRadius="4" Padding="7,1"
+                                            Background="{DynamicResource TransparentPink20Brush}"
+                                            BorderBrush="{DynamicResource PinkBrush}" BorderThickness="1">
+                                        <StackPanel VerticalAlignment="Center">
+                                            <TextBlock Text="&#xE713;" FontFamily="Segoe MDL2 Assets" FontSize="12"
+                                                       Foreground="{DynamicResource PinkBrush}"
+                                                       HorizontalAlignment="Center"
+                                                       LineHeight="15" LineStackingStrategy="BlockLineHeight"/>
+                                            <TextBlock Text="{loc:Str label_mod_manager}" FontSize="8" FontWeight="Bold"
+                                                       Foreground="{DynamicResource PinkBrush}"
+                                                       HorizontalAlignment="Center"
+                                                       LineHeight="9" LineStackingStrategy="BlockLineHeight"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="capsule" Property="Background"
+                                                    Value="{DynamicResource TransparentPink40Brush}"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Button.Template>
                         </Button>
                     </StackPanel>
                     <TextBlock x:Name="TxtPlayerTitle" Text="{loc:Str label_basic_subject}" Foreground="{DynamicResource PinkBrush}"


### PR DESCRIPTION
## What

Users ask "where is the mod manager?" every day — the entry point was a 22×22 transparent muted gear glyph next to the mod selector, visually indistinguishable from decoration.

## Change

`BtnManageMods` (MainWindow.xaml) rebuilt as a pink accent capsule: bordered, tinted background, larger gear, and a bold **MOD MANAGER** caption underneath. Gear + caption live inside one button template so a single hit area covers both, with a hover tint.

- Uses mod-aware brushes (`PinkBrush` / `TransparentPink20Brush`) so the capsule follows the active mod's accent instead of hardcoded pink.
- Height 28 with `BlockLineHeight`-pinned line boxes — deterministic, cannot clip; the header row is already 32px tall (tab buttons), so the row does not grow.
- New loc key `label_mod_manager` ("MOD MANAGER") in all 9 language files, strict-JSON verified.

## Notes

- Column 0 widens by ~57px from the caption. Plenty of slack at default window size; the header's pre-existing tightness at `MinWidth=1062` with long player titles is unchanged in kind, slightly worse in degree — raising MinWidth is the real fix if tab clipping ever shows up.
- Build: 0 errors. Hover state + optical alignment still deserve a quick play-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EBFWx6sBE9B2W6iDAn2ue
