### PR TITLE
fix(deeper): video enhancements run on the browser engine (#874)

### DIFF
--- a/ConditioningControlPanel/Resources/web/player/player.js
+++ b/ConditioningControlPanel/Resources/web/player/player.js
@@ -225,7 +225,12 @@
     if (!force && ms === lastTimeMs) return;
     lastTimeMs = ms;
     lastTimePostAt = now;
-    post({ type: 'time', ms: ms });
+    // Every position carries the pause state with it. A forced post travels WHILE paused
+    // (doPause, 'seeked', 'ended'), so the host must never infer "a time message means the
+    // clip is playing" — that made IsPrimaryMediaPlaying report true one message-hop after
+    // the host paused, which broke Deeper's speak-holds. hostPaused covers a host-requested
+    // hold; fg.paused also covers a pause the page itself is sitting in. (#874)
+    post({ type: 'time', ms: ms, paused: !!(cur.hostPaused || fg.paused) });
   }
 
   // ---------- ticker: 10 Hz time + stall watchdogs + backdrop resync ----------

--- a/ConditioningControlPanel/Services/Deeper/VideoEnhancementBridge.cs
+++ b/ConditioningControlPanel/Services/Deeper/VideoEnhancementBridge.cs
@@ -70,14 +70,16 @@ namespace ConditioningControlPanel.Services.Deeper
                 }
                 if (!resolved.Found) return;
 
-                // Acceptance #6: when LibVLC is unavailable the MediaElement
-                // fallback window never sets PrimaryMediaPlayer, so the engine
-                // has no playback clock to attach to. Log loudly rather than
-                // failing silent (and don't bind a dead source).
-                if (_video.PrimaryMediaPlayer == null)
+                // Acceptance #6: the engine needs a playback clock. LibVLC exposes one via
+                // PrimaryMediaPlayer; a browser (WebView2) session feeds the SAME shared surface from
+                // the page's `time` messages, so it must bind too — requiring a native player here is
+                // what kept every mp4/webm enhancement silently dead while the browser engine was the
+                // default (#874). Only the MediaElement fallback window (LibVLC unavailable) has
+                // neither clock: log loudly rather than failing silent (and don't bind a dead source).
+                if (_video.PrimaryMediaPlayer == null && !_video.IsBrowserSessionActive)
                 {
                     App.Logger?.Warning(
-                        "VideoEnhancementBridge: matched enhancement ({Source}) for {File} but no primary LibVLC player is active (MediaElement fallback?) — enhancement engine cannot attach.",
+                        "VideoEnhancementBridge: matched enhancement ({Source}) for {File} but no playback clock is active (MediaElement fallback?) — enhancement engine cannot attach.",
                         resolved.Source, Path.GetFileName(path));
                     return;
                 }

--- a/ConditioningControlPanel/Services/Deeper/VideoServiceTimeSource.cs
+++ b/ConditioningControlPanel/Services/Deeper/VideoServiceTimeSource.cs
@@ -7,6 +7,10 @@ namespace ConditioningControlPanel.Services.Deeper
     /// <summary>
     /// Adapts <see cref="VideoService"/>'s primary-monitor playback to the
     /// generic <see cref="IPlaybackTimeSource"/> the EnhancementEngine consumes.
+    /// Engine-agnostic (#874): everything reads VideoService's shared control
+    /// surface, which answers for BOTH the LibVLC and the browser (WebView2)
+    /// engine — time/seek/pause/play were already routed, and duration, playing
+    /// state and aspect now are too.
     ///
     /// Subscribes lazily — call <see cref="Attach"/> when starting an engine,
     /// <see cref="Detach"/> when stopping. Multiple sources can be attached to
@@ -18,9 +22,9 @@ namespace ConditioningControlPanel.Services.Deeper
         private bool _attached;
 
         // Display aspect ratio (w/h, SAR-corrected) of the playing video, cached
-        // once LibVLC reports a non-zero size. -1 = not known yet. The bridge
-        // builds a fresh time source per video, so this never goes stale across
-        // videos.
+        // once the engine reports a non-zero size (LibVLC track data, or the
+        // browser page's `meta` message). -1 = not known yet. The bridge builds
+        // a fresh time source per video, so this never goes stale across videos.
         private double _cachedAspect = -1;
 
         public event Action<double>? PlaybackTimeChanged;
@@ -79,24 +83,12 @@ namespace ConditioningControlPanel.Services.Deeper
             return ms < 0 ? 0 : ms / 1000.0;
         }
 
-        public double GetDurationSeconds()
-        {
-            try
-            {
-                var len = _video.PrimaryMediaPlayer?.Length ?? 0;
-                return len > 0 ? len / 1000.0 : 0;
-            }
-            catch { return 0; }
-        }
+        // Duration and playing-state go through VideoService's engine-agnostic surface: a browser
+        // session has no PrimaryMediaPlayer by design, and reading it here is what kept every mp4
+        // enhancement dead while the browser engine was the default (#874).
+        public double GetDurationSeconds() => _video.GetPrimaryDurationSeconds();
 
-        public bool IsPlaying
-        {
-            get
-            {
-                try { return _video.PrimaryMediaPlayer?.IsPlaying ?? false; }
-                catch { return false; }
-            }
-        }
+        public bool IsPlaying => _video.IsPrimaryMediaPlaying;
 
         public void Seek(double seconds) => _video.SeekPrimary((long)Math.Max(0, seconds * 1000));
         public void Pause() => _video.PausePrimary();
@@ -169,6 +161,16 @@ namespace ConditioningControlPanel.Services.Deeper
             if (_cachedAspect > 0) return _cachedAspect;
             try
             {
+                // Browser session: the page's `meta` message carries the frame size, and the page
+                // renders the video contain-fit over the full window — the same geometry FitContain
+                // models. 0 until meta arrives, so GetVideoRect falls back to the full rect. (#874)
+                var browserAspect = _video.BrowserVideoAspect;
+                if (browserAspect > 0)
+                {
+                    _cachedAspect = browserAspect;
+                    return _cachedAspect;
+                }
+
                 var mp = _video.PrimaryMediaPlayer;
                 if (mp == null) return 0;
 

--- a/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
+++ b/ConditioningControlPanel/Services/Video/Browser/BrowserVideoEngine.cs
@@ -185,8 +185,12 @@ namespace ConditioningControlPanel.Services.Video.Browser
         /// <summary>First real <c>playing</c> event of the clip.</summary>
         public event Action? Playing;
 
-        /// <summary>~10 Hz playback position in ms. Nothing is posted while paused or ended.</summary>
-        public event Action<long>? Time;
+        /// <summary>~10 Hz playback position in ms, plus the page's own paused flag for that position.
+        /// The steady 10 Hz stream only runs while playing, but pause / seek / end FORCE a post, so the
+        /// flag is what tells those apart — never infer "playing" from the arrival of a message (#874).
+        /// null = the page did not report it (older cached page HTML); leave the host's own pause
+        /// bookkeeping alone in that case.</summary>
+        public event Action<long, bool?>? Time;
 
         /// <summary>Natural end of the clip.</summary>
         public event Action? Ended;
@@ -580,7 +584,9 @@ namespace ConditioningControlPanel.Services.Video.Browser
                         Playing?.Invoke();
                         break;
                     case "time":
-                        Time?.Invoke((long?)o["ms"] ?? 0);
+                        // `paused` is absent on older cached page HTML — pass null through rather than
+                        // defaulting to false, which would be the blind-clear this fixed (#874).
+                        Time?.Invoke((long?)o["ms"] ?? 0, (bool?)o["paused"]);
                         break;
                     case "ended":
                         StopFirstFrameWatch();

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -33,10 +33,12 @@ namespace ConditioningControlPanel.Services
         private string? _browserPath;
         private bool _browserStrict;
         private long _browserTimeMs = -1;
-        /// <summary>Host-side pause state for the session. The page posts no messages while paused,
-        /// so IsPrimaryMediaPlaying can only answer from the PausePrimary/PlayPrimary edges (grace
-        /// pause and Deeper's SpeakPromptSession both route through those). Self-heals to false on
-        /// every `time` tick — position only flows while the page is really playing. (#874)</summary>
+        /// <summary>Pause state of the session, the answer behind IsPrimaryMediaPlaying for a browser
+        /// clip. Set on the PausePrimary/PlayPrimary edges (grace pause and Deeper's SpeakPromptSession
+        /// both route through those) and then kept honest by the `paused` field the page stamps on
+        /// EVERY `time` post. It is not inferred from a message arriving: pause, seek and the natural
+        /// end all force a post while the clip is paused, so "a time message means it is playing" is
+        /// false and reading it that way made a paused video report as playing. (#874)</summary>
         private volatile bool _browserPaused;
         /// <summary>Display aspect (w/h) from the page's `meta` message, 0 until known. Read by
         /// VideoServiceTimeSource.GetVideoAspect so Deeper gaze rules can compute the contain-fit
@@ -453,11 +455,17 @@ namespace ConditioningControlPanel.Services
             });
         }
 
-        private void OnBrowserTime(long ms)
+        private void OnBrowserTime(long ms, bool? paused)
         {
             if (!_browserActive) return;
             _browserTimeMs = ms;
-            _browserPaused = false;      // position only flows while playing — heals a missed resume edge (#874)
+            // Take the pause state FROM the message, never from its mere arrival: doPause(), the
+            // 'seeked' handler and the natural end all force a post while the clip is paused, so
+            // blind-clearing here made IsPrimaryMediaPlaying report true one message-hop after
+            // PausePrimary — exactly the window Deeper's speak-holds live in (#874). null = older
+            // cached page HTML that predates the field; leave the PausePrimary/PlayPrimary edges
+            // to answer, which is the pre-#874 behaviour minus the blind clear.
+            if (paused.HasValue) _browserPaused = paused.Value;
             _lastWatchPositionMs = ms;   // watch-time crediting (#447), same field the LibVLC path feeds
             try { PrimaryPlaybackTimeMsChanged?.Invoke(ms); }
             catch (Exception ex) { App.Logger?.Debug("PrimaryPlaybackTimeMsChanged handler error: {Error}", ex.Message); }

--- a/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.Browser.cs
@@ -33,6 +33,15 @@ namespace ConditioningControlPanel.Services
         private string? _browserPath;
         private bool _browserStrict;
         private long _browserTimeMs = -1;
+        /// <summary>Host-side pause state for the session. The page posts no messages while paused,
+        /// so IsPrimaryMediaPlaying can only answer from the PausePrimary/PlayPrimary edges (grace
+        /// pause and Deeper's SpeakPromptSession both route through those). Self-heals to false on
+        /// every `time` tick — position only flows while the page is really playing. (#874)</summary>
+        private volatile bool _browserPaused;
+        /// <summary>Display aspect (w/h) from the page's `meta` message, 0 until known. Read by
+        /// VideoServiceTimeSource.GetVideoAspect so Deeper gaze rules can compute the contain-fit
+        /// picture box for a browser session (the page renders #fg object-fit: contain). (#874)</summary>
+        private double _browserVideoAspect;
         /// <summary>Teardown generation captured when the session started - a late page message that
         /// belongs to a video the user already panicked away must not act (see _teardownGeneration).</summary>
         private int _browserGeneration;
@@ -51,6 +60,11 @@ namespace ConditioningControlPanel.Services
         /// duck sweep never lowers the app's OWN video audio (LibVLC audio is in-process and
         /// structurally un-duckable, so this is what keeps the two engines at parity).</summary>
         public bool IsBrowserSessionActive => _browserActive;
+
+        /// <summary>Aspect ratio (w/h) of the clip in the live browser session, or 0 when unknown /
+        /// no browser session. The page's video element is contain-fit over the full window, so this
+        /// plus the window rect yields the rendered picture box. (#874)</summary>
+        public double BrowserVideoAspect => _browserActive ? _browserVideoAspect : 0;
 
         private BrowserVideoEngine Browser
         {
@@ -94,6 +108,8 @@ namespace ConditioningControlPanel.Services
                 _browserPath = path;
                 _browserStrict = strict;
                 _browserTimeMs = -1;
+                _browserPaused = false;
+                _browserVideoAspect = 0;
                 _browserGeneration = _teardownGeneration;
                 _browserFallbackDone = false;
                 _browserStartedFired = false;
@@ -228,6 +244,8 @@ namespace ConditioningControlPanel.Services
 
             _browserActive = false;
             _browserTimeMs = -1;
+            _browserPaused = false;
+            _browserVideoAspect = 0;
 
             var browserWindows = engine.Windows.ToList();
             try { engine.StopSession(); }
@@ -340,6 +358,9 @@ namespace ConditioningControlPanel.Services
         private void OnBrowserMeta(long durationMs, int width, int height)
         {
             if (!BrowserEventIsCurrent()) return;
+            // Captured BEFORE the duration gate: a stream with unknown duration still knows its frame
+            // size, and Deeper's gaze rect only needs the aspect. (#874)
+            if (width > 0 && height > 0) _browserVideoAspect = (double)width / height;
             // 0 = the page cannot know the duration (some webm / fragmented mp4). Arming a
             // zero-length guillotine would kill the clip instantly; the 10-minute fallback timer
             // stays armed as the net, exactly as it does when LibVLC's LengthChanged never fires.
@@ -436,6 +457,7 @@ namespace ConditioningControlPanel.Services
         {
             if (!_browserActive) return;
             _browserTimeMs = ms;
+            _browserPaused = false;      // position only flows while playing — heals a missed resume edge (#874)
             _lastWatchPositionMs = ms;   // watch-time crediting (#447), same field the LibVLC path feeds
             try { PrimaryPlaybackTimeMsChanged?.Invoke(ms); }
             catch (Exception ex) { App.Logger?.Debug("PrimaryPlaybackTimeMsChanged handler error: {Error}", ex.Message); }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -402,9 +402,11 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Whether the primary clip is actually advancing, whichever engine owns it. The browser page
-        /// posts nothing while paused, so the browser answer is tracked on the host side: playing has
-        /// been confirmed, and neither a PausePrimary hold nor a grace pause is in force. (#874)
+        /// Whether the primary clip is actually advancing, whichever engine owns it. The browser answer
+        /// is host-side bookkeeping: playing has been confirmed, and neither a PausePrimary hold nor a
+        /// grace pause is in force. <c>_browserPaused</c> follows the PausePrimary/PlayPrimary edges and
+        /// the `paused` flag the page stamps on every `time` post (a pause/seek/end forces a post WHILE
+        /// paused, so the arrival of a position never implies playback). (#874)
         /// </summary>
         public bool IsPrimaryMediaPlaying
         {

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -383,6 +383,40 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Duration of the current primary clip in seconds, or 0 if unknown — whichever engine owns
+        /// it. A browser session reports the page's <c>meta</c> duration (0 until it arrives, and for
+        /// streams that never learn it); a LibVLC session reports the primary player's Length. (#874)
+        /// </summary>
+        public double GetPrimaryDurationSeconds()
+        {
+            try
+            {
+                if (_browserActive) return _duration > 0 ? _duration : 0;
+                var len = _primaryMediaPlayer?.Length ?? 0;
+                return len > 0 ? len / 1000.0 : 0;
+            }
+            catch { return 0; }
+        }
+
+        /// <summary>
+        /// Whether the primary clip is actually advancing, whichever engine owns it. The browser page
+        /// posts nothing while paused, so the browser answer is tracked on the host side: playing has
+        /// been confirmed, and neither a PausePrimary hold nor a grace pause is in force. (#874)
+        /// </summary>
+        public bool IsPrimaryMediaPlaying
+        {
+            get
+            {
+                try
+                {
+                    if (_browserActive) return _browserStartedFired && !_browserPaused && !_gracePaused;
+                    return _primaryMediaPlayer?.IsPlaying ?? false;
+                }
+                catch { return false; }
+            }
+        }
+
+        /// <summary>
         /// Seek the primary player to the given absolute time. No-op if no
         /// video is active or the player rejects the seek (LibVLC will silently
         /// ignore for non-seekable streams).
@@ -412,7 +446,9 @@ namespace ConditioningControlPanel.Services
         /// <summary>Pause every screen's player (kept in lockstep for multi-monitor). No-op if none.</summary>
         public void PausePrimary()
         {
-            if (_browserActive) _browser?.Pause();
+            // The pause edge is remembered because the page goes silent while paused — this flag is
+            // the only way IsPrimaryMediaPlaying can answer for a browser session. (#874)
+            if (_browserActive) { _browserPaused = true; _browser?.Pause(); }
             foreach (var p in SnapshotPlayers())
             {
                 try { p.SetPause(true); }
@@ -429,7 +465,7 @@ namespace ConditioningControlPanel.Services
             // _gracePaused BEFORE it calls this, so the legitimate resume is unaffected.
             if (_gracePaused) return;
 
-            if (_browserActive) _browser?.Resume();
+            if (_browserActive) { _browserPaused = false; _browser?.Resume(); }
             foreach (var p in SnapshotPlayers())
             {
                 try { p.SetPause(false); }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -227,6 +227,9 @@ namespace ConditioningControlPanel.Services
         // bound the safety timer switches from a duration guillotine to a progress-based stall
         // watch (see StartSafetyTimer) so real playback isn't cut "after the original time is over".
         private volatile bool _enhancementDriving;
+        // Last KNOWN primary playback position seen by the stall watch (-1 = none seen yet). An
+        // unknown reading never overwrites it, so the watch keeps measuring against the real last
+        // position instead of treating "no clock" as a fresh sample (#874).
         private long _lastSafetyTimeMs = -1;
         private DateTime _lastSafetyProgressUtc = DateTime.MinValue;
         // Recheck cadence + no-progress grace used only while an enhancement is driving.
@@ -5210,7 +5213,10 @@ namespace ConditioningControlPanel.Services
         {
             _safetyTimer?.Stop();
 
-            // Stop the fallback timer since we now have accurate duration
+            // Stop the fallback timer since we now have accurate duration. NOTE: from here on this
+            // timer IS the only guillotine — while an enhancement drives the clip the tick below
+            // becomes a stall watch, and that stall watch is the sole thing standing between a wedged
+            // renderer/decoder and a fullscreen video that never goes away. Keep it reachable (#874).
             _fallbackSafetyTimer?.Stop();
             _fallbackSafetyTimer = null;
 
@@ -5246,12 +5252,25 @@ namespace ConditioningControlPanel.Services
 
                 if (_enhancementDriving)
                 {
-                    long curMs = -1;
-                    try { curMs = _primaryMediaPlayer?.Time ?? -1; } catch { curMs = -1; }
+                    // Engine-agnostic clock (#874). Reading _primaryMediaPlayer directly made this
+                    // branch blind on the browser engine, where that player is null BY DESIGN: curMs
+                    // was permanently -1, and the old "_lastSafetyTimeMs < 0" arm below read that as
+                    // PROGRESS on every 15s pass, so the force-close could never be reached. This is
+                    // the only guillotine left by then — StartSafetyTimer nulls the 10-minute fallback
+                    // timer the moment a duration is known — so a hung WebView2 renderer (no
+                    // ProcessFailed, page watchdog dead with it) held the screen forever.
+                    long curMs;
+                    try { curMs = GetCurrentPlaybackTimeMs(); } catch { curMs = -1; }
 
                     var now = DateTime.UtcNow;
-                    bool advancing = curMs >= 0 && curMs != _lastSafetyTimeMs;
-                    if (advancing || _lastSafetyTimeMs < 0)
+                    bool clockKnown = curMs >= 0;
+                    // Only a CHANGED, known position counts as progress. An unknown clock (-1) is not
+                    // progress: it leaves the last known position and the stall clock both standing, so
+                    // a clock that never reports still reaches the force-close after the grace window
+                    // instead of resetting it forever. The first known reading seeds the baseline for
+                    // free (_lastSafetyTimeMs starts at -1, so it never equals a real position).
+                    bool advancing = clockKnown && curMs != _lastSafetyTimeMs;
+                    if (advancing)
                     {
                         _lastSafetyTimeMs = curMs;
                         _lastSafetyProgressUtc = now;
@@ -5266,11 +5285,16 @@ namespace ConditioningControlPanel.Services
                     if ((now - _lastSafetyProgressUtc).TotalSeconds < EnhancementStallGraceSeconds)
                     {
                         SetSafetyInterval(EnhancementRecheckInterval);
-                        return; // paused (e.g. speak-hold) but within grace — not a wedge
+                        // Paused (e.g. speak-hold), or the clock has not reported a position yet
+                        // (pre-roll, a seek in flight) — within grace either way, so not a wedge.
+                        return;
                     }
 
                     _safetyTimer?.Stop();
-                    App.Logger?.Warning("VideoService: Enhancement-driven video stalled ~{Grace}s with no playback progress. Forcing cleanup.", EnhancementStallGraceSeconds);
+                    App.Logger?.Warning(
+                        "VideoService: Enhancement-driven video stalled ~{Grace}s with no playback progress ({Clock}). Forcing cleanup.",
+                        EnhancementStallGraceSeconds,
+                        clockKnown ? $"held at {curMs}ms" : "playback clock never reported a position");
                     Cleanup();
                     return;
                 }

--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -389,14 +389,29 @@ namespace ConditioningControlPanel.Services
         /// Duration of the current primary clip in seconds, or 0 if unknown — whichever engine owns
         /// it. A browser session reports the page's <c>meta</c> duration (0 until it arrives, and for
         /// streams that never learn it); a LibVLC session reports the primary player's Length. (#874)
+        ///
+        /// After teardown BOTH engines are gone (CloseAll clears <c>_browserActive</c> and nulls
+        /// <c>_primaryMediaPlayer</c> before Cleanup raises <c>VideoEnded</c>), so the last known
+        /// <c>_duration</c> answers instead of 0. That ordering is load-bearing for Deeper: the
+        /// EnhancementEngine's duration-less completion fallback credits PlaybackCompleted for any run
+        /// past 60s when this returns 0, which on skip / panic / attention-fail is FALSE credit for a
+        /// video the user did not finish. <c>_duration</c> survives teardown by design — only the
+        /// PlayVideo prologue and the browser→LibVLC handoff reset it — so it is the honest answer.
         /// </summary>
         public double GetPrimaryDurationSeconds()
         {
             try
             {
-                if (_browserActive) return _duration > 0 ? _duration : 0;
-                var len = _primaryMediaPlayer?.Length ?? 0;
-                return len > 0 ? len / 1000.0 : 0;
+                // A live LibVLC player is the freshest source; a browser session has none by design.
+                if (!_browserActive)
+                {
+                    var len = _primaryMediaPlayer?.Length ?? 0;
+                    if (len > 0) return len / 1000.0;
+                }
+                // Browser session, or no live engine at all: the last duration this service was told
+                // about (page `meta` / LengthChanged / MediaOpened). Still 0 for a genuinely
+                // duration-less clip — the one case the engine's fallback completion is meant for.
+                return _duration > 0 ? _duration : 0;
             }
             catch { return 0; }
         }

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -172,9 +172,13 @@ All of the following stay in VideoService (C#-side) and must fire for browser se
 - [ ] `PausePrimary`/`PlayPrimary`/`SeekPrimary` map to messages (voice commands,
       DtRH); `GetCurrentPlaybackTimeMs` + `PrimaryPlaybackTimeMsChanged` fed from
       `time` messages (FunScript haptics + Deeper time source keep working).
-- [ ] `PrimaryMediaPlayer` stays **null** during browser sessions — Deeper's
-      enhancement bridge simply won't attach (documented Stage-1 gap; the null path
-      already exists and must not throw).
+- [x] `PrimaryMediaPlayer` stays **null** during browser sessions, but Deeper's
+      enhancement bridge attaches anyway (#874): `VideoServiceTimeSource` reads the
+      engine-agnostic surface (`GetPrimaryDurationSeconds`, `IsPrimaryMediaPlaying`,
+      `BrowserVideoAspect` from the page `meta` size), and the bridge's guard only
+      refuses when NEITHER engine has a clock (the MediaElement fallback window).
+      The original Stage-1 gap — bridge silently refusing every mp4/m4v/webm while
+      the browser engine was default — shipped 6.7.0→6.7.4 and is closed.
 - [ ] `SessionSwitch` (lock) + `PowerModeChanged` (suspend) force-clean unchanged.
 - [ ] Teardown generation guard applies to browser session continuations too.
 - [ ] `VideoMetadataCache` backfill: write duration from the page `meta` message so

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -150,6 +150,11 @@ All of the following stay in VideoService (C#-side) and must fire for browser se
 - [ ] Safety timers (all C#-side, unchanged mechanisms): duration guillotine armed
       from the page `meta` message (was `LengthChanged`); 10-min fallback timer;
       `VideoMaxDurationSeconds` hard cap; `_enhancementDriving` stall-watch semantics.
+      The stall watch must read the engine-agnostic `GetCurrentPlaybackTimeMs()` and
+      must treat an **unknown** clock as no-progress, not as progress — otherwise the
+      force-close is unreachable for a browser session and a hung renderer (no
+      `ProcessFailed`, page watchdogs dead with it) holds the screen forever, because
+      arming the duration guillotine nulls the 10-min fallback timer (#874).
 - [ ] Attention checks: `SetupAttention`, the spawn schedule, the pass/fail tally, gaze
       (`GetGazeTargets`/`GazeClick`), the toy-button alternative and `EndCurrentVideo`'s
       pass/fail/XP/troll-replay/mercy logic are all unchanged. What changed is only the RENDERING:

--- a/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
+++ b/ConditioningControlPanel/docs/BROWSER_VIDEO_ENGINE_PLAN.md
@@ -184,6 +184,9 @@ All of the following stay in VideoService (C#-side) and must fire for browser se
       refuses when NEITHER engine has a clock (the MediaElement fallback window).
       The original Stage-1 gap — bridge silently refusing every mp4/m4v/webm while
       the browser engine was default — shipped 6.7.0→6.7.4 and is closed.
+      A contract that surface carries: the page tags every `time` post with its own
+      `paused` flag, and the host reads pause state from THAT — pause/seek/end each
+      force a post *while* paused, so the arrival of a position never means "playing".
 - [ ] `SessionSwitch` (lock) + `PowerModeChanged` (suspend) force-clean unchanged.
 - [ ] Teardown generation guard applies to browser session continuations too.
 - [ ] `VideoMetadataCache` backfill: write duration from the page `meta` message so

--- a/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
@@ -293,14 +293,21 @@ block at `VideoService.cs:55–110`.
 videos drivable by the same effect engine the standalone Deeper player uses. Flow:
 
 1. On `VideoStarted` (UI thread), `BindForCurrentVideo` (`:46`): bail unless `VideoEnhanceIfPossible`;
-   `EnhancementResolver.ResolveForLocalMedia(LastVideoPath)`; if no `PrimaryMediaPlayer` (MediaElement
-   fallback) log-and-bail; load the `.ccpenh.json` into its **own** `EnhancementHostService`; build a
-   `VideoServiceTimeSource` and `Bind` it (attach/detach lambdas capture *this* source so a fast next
-   video can't stale-detach the new one).
+   `EnhancementResolver.ResolveForLocalMedia(LastVideoPath)`; if there is NO playback clock at all —
+   no `PrimaryMediaPlayer` **and** no browser session (i.e. the MediaElement fallback) — log-and-bail
+   (#874: browser sessions bind like LibVLC ones; the old `PrimaryMediaPlayer == null` bail kept every
+   browser-routed mp4/m4v/webm enhancement silently dead 6.7.0→6.7.4); load the `.ccpenh.json` into
+   its **own** `EnhancementHostService`; build a `VideoServiceTimeSource` and `Bind` it (attach/detach
+   lambdas capture *this* source so a fast next video can't stale-detach the new one).
 2. It calls `_video.SetEnhancementDriving(true)` so the safety timer switches to stall-watch mode (§6).
 3. `VideoServiceTimeSource` exposes time/seek/pause/play + `GetVideoRect` (contain-fit rect for gaze
-   rules, `:105`) + SAR-corrected aspect. It marshals LibVLC-thread `TimeChanged` to the UI thread
-   (`:47`) because the engine mutates band/fired-state from the UI tick and webcam handlers.
+   rules, `:105`) + SAR-corrected aspect. Engine-agnostic (#874): duration, playing-state and aspect
+   read `VideoService.GetPrimaryDurationSeconds` / `IsPrimaryMediaPlaying` / `BrowserVideoAspect`, so
+   the same source drives both engines (browser aspect comes from the page `meta` frame size; the page
+   renders `#fg` contain-fit full-window, the same geometry `FitContain` models). It marshals
+   LibVLC-thread `TimeChanged` to the UI thread (`:47`) because the engine mutates band/fired-state
+   from the UI tick and webcam handlers (browser `time` messages already arrive on the UI thread and
+   pass straight through the same marshal).
 4. On `VideoEnded` → `Unbind` (`:136`); clears the driving flag, unloads. **Panic/`CloseAll` does NOT
    raise `VideoEnded`**, so the panic path calls `ForceUnbind()` (`:134`) or active overlays keep
    dispatching after the video is gone (#364).

--- a/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
@@ -314,6 +314,12 @@ videos drivable by the same effect engine the standalone Deeper player uses. Flo
    LibVLC-thread `TimeChanged` to the UI thread (`:47`) because the engine mutates band/fired-state
    from the UI tick and webcam handlers (browser `time` messages already arrive on the UI thread and
    pass straight through the same marshal).
+   **Browser playing-state is never inferred from message arrival.** `doPause()`, the `seeked` handler
+   and the natural end all *force* a `time` post while the clip is paused, so the page stamps a
+   `paused` flag on every position and `OnBrowserTime` sets `_browserPaused` **from that field**
+   (absent ⇒ leave the `PausePrimary`/`PlayPrimary` edge alone; old cached page HTML). Clearing it on
+   any `time` message made a paused clip read as playing one message-hop after `PausePrimary` — which
+   is exactly the window Deeper's own speak-holds live in (#874).
 4. On `VideoEnded` → `Unbind` (`:136`); clears the driving flag, unloads. **Panic/`CloseAll` does NOT
    raise `VideoEnded`**, so the panic path calls `ForceUnbind()` (`:134`) or active overlays keep
    dispatching after the video is gone (#364).

--- a/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
@@ -260,7 +260,13 @@ block at `VideoService.cs:55–110`.
    `StartSafetyTimer(duration)` (`:3159`, duration+5s) once the real length is known. If a Deeper
    enhancement is driving (`_enhancementDriving`), it switches from a one-shot guillotine to a
    **progress-based stall watch** (rechecks every 15s, force-ends only after 90s of zero progress) so a
-   loop/hold isn't cut (#536). `StartMaxLengthCapTimer` (`:3263`) separately enforces the user's
+   loop/hold isn't cut (#536). The stall watch reads `GetCurrentPlaybackTimeMs()`, so it works on
+   **both** engines, and an **unknown** clock (`-1`) counts as *no progress*, not as progress — reading
+   `_primaryMediaPlayer.Time` directly and treating `-1` as a fresh sample made the force-close
+   unreachable on the browser engine, where that player is null by design (#874). Note that once
+   `StartSafetyTimer` runs it **nulls the fallback timer**, so for an enhancement-driven clip this stall
+   watch is the *only* remaining guillotine — a hung WebView2 renderer raises no `ProcessFailed` and its
+   page-side watchdogs die with it. `StartMaxLengthCapTimer` (`:3263`) separately enforces the user's
    `VideoMaxDurationSeconds` as a wall-clock cap (the selection filter is best-effort, #584).
 2. **Vout (video-output) watchdog** — `StartVoutWatchdog` (`:3298`), a **threadpool** timer. If no
    video output exists `VoutGraceMs` (8s) after `Play()`, the screen is white regardless of decode

--- a/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/MANDATORY_VIDEOS_PRIMER.md
@@ -323,6 +323,13 @@ videos drivable by the same effect engine the standalone Deeper player uses. Flo
 4. On `VideoEnded` → `Unbind` (`:136`); clears the driving flag, unloads. **Panic/`CloseAll` does NOT
    raise `VideoEnded`**, so the panic path calls `ForceUnbind()` (`:134`) or active overlays keep
    dispatching after the video is gone (#364).
+   **Teardown ordering vs. completion credit:** `CloseAll` clears `_browserActive` and nulls
+   `_primaryMediaPlayer` *before* `Cleanup` raises `VideoEnded`, so by the time `EnhancementEngine.Stop`
+   runs neither engine is live. `GetPrimaryDurationSeconds` therefore falls back to the last known
+   `_duration` — without it the engine's duration-less completion fallback (`EnhancementEngine.cs:454`)
+   would fire `PlaybackCompleted` for **any** run past 60s, crediting a Deeper completion on skip,
+   panic and attention-fail (#874). `_duration` survives teardown by design: only the `PlayVideo`
+   prologue and the browser→LibVLC handoff reset it.
 
 `SeekPrimary`/`PausePrimary`/`PlayPrimary` (`:254/275/285`) mirror the operation to **every** screen's
 player so a Deeper blink/rewind doesn't desync the monitors (#527).


### PR DESCRIPTION
Fixes #874: Deeper enhancements (.ccpenh.json) silently never ran on the WebView2 browser video engine because the bridge and time source only knew LibVLC.

- Engine-agnostic surface: GetPrimaryDurationSeconds / IsPrimaryMediaPlaying / BrowserVideoAspect; bridge guard now also accepts an active browser session
- Review-pass fixes: the enhancement stall-watch reads the engine-agnostic clock (a hung WebView2 renderer now force-closes at 90s instead of hanging forever); pause state is reported by the page itself instead of inferred from message arrival; no completion credit for skipped/panicked videos

Build 0 errors, tests 2411/2411.

Play-test owed: enhanced mp4 on both engines + mkv control (watch for the absent "no playback clock" warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)