### PR TITLE
fix(remote): controller connect/expiry no longer kills the subject's session (#878)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -1235,6 +1235,9 @@ namespace ConditioningControlPanel
         private void OnSessionCompleted(object? sender, SessionCompletedEventArgs e)
         {
             App.IsSessionRunning = false;
+            // Release the controller-owned-run marker (MainWindow.RemoteControl.cs). Hygiene only —
+            // IsSessionRemoteStarted already reads false once the engine stops.
+            _remoteStartedSession = null;
             Dispatcher.Invoke(() =>
             {
                 // Award XP. The completion dialog is shown from OnSessionLogReady,
@@ -1465,6 +1468,8 @@ namespace ConditioningControlPanel
         private void OnSessionStopped(object? sender, EventArgs e)
         {
             App.IsSessionRunning = false;
+            // See OnSessionCompleted — drop the reference to the controller-started run.
+            _remoteStartedSession = null;
 
             // Captured BEFORE the dispatcher work: SessionEngine nulls _currentSession at the end
             // of StopSession, and ProgramService clears its expected id when SessionCompleted

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -104,10 +104,19 @@ namespace ConditioningControlPanel
                 UpdateDirectoryListingStatus();
                 _ = RunOptInChainAsync();
 
-                // Listen for controller connection changes
+                // Listen for controller connection changes. The -= before every += is not
+                // decoration: any enable path that reaches here without StopRemoteControl having
+                // run (e.g. the service ended the session itself and OnRemoteSessionEnded merely
+                // unticked the box) would otherwise stack a second copy of every handler on the
+                // multicast list, one more per cycle. Removing a delegate that isn't subscribed
+                // is a documented no-op, so this is idempotent and kills the whole bug class.
+                App.RemoteControl.ControllerConnectedChanged -= OnRemoteControllerChanged;
                 App.RemoteControl.ControllerConnectedChanged += OnRemoteControllerChanged;
+                App.RemoteControl.ControllerIdleChanged -= OnRemoteControllerIdleChanged;
                 App.RemoteControl.ControllerIdleChanged += OnRemoteControllerIdleChanged;
+                App.RemoteControl.CommandReceived -= OnRemoteCommandReceived;
                 App.RemoteControl.CommandReceived += OnRemoteCommandReceived;
+                App.RemoteControl.SessionEnded -= OnRemoteSessionEnded;
                 App.RemoteControl.SessionEnded += OnRemoteSessionEnded;
 
                 // Wire up session callbacks for remote status
@@ -908,6 +917,19 @@ namespace ConditioningControlPanel
             {
                 HideRemoteControlOverlay();
                 UpdateStartButtonForRemoteControl(false);
+                // Unticking under _isLoading deliberately suppresses ChkRemoteControlEnabled_Changed
+                // (it early-returns on _isLoading), so StopRemoteControl never runs on this path and
+                // used to leave all four handlers attached — a fresh set stacked on top on the next
+                // enable, once per expiry cycle. Detach them here so the steady state is clean.
+                // Unsubscribing from inside SessionEnded's own invocation is safe: the runtime
+                // iterates a snapshot of the invocation list.
+                if (App.RemoteControl != null)
+                {
+                    App.RemoteControl.ControllerConnectedChanged -= OnRemoteControllerChanged;
+                    App.RemoteControl.ControllerIdleChanged -= OnRemoteControllerIdleChanged;
+                    App.RemoteControl.CommandReceived -= OnRemoteCommandReceived;
+                    App.RemoteControl.SessionEnded -= OnRemoteSessionEnded;
+                }
                 _isLoading = true;
                 RemoteControlTab.ChkRemoteControlEnabled.IsChecked = false;
                 _isLoading = false;

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -183,8 +183,11 @@ namespace ConditioningControlPanel
                 if (!ShowRemoteControlWaiver(newTier))
                     return;
 
-                // Unsubscribe before stopping so OnRemoteSessionEnded doesn't collapse the panel
+                // Unsubscribe before stopping so OnRemoteSessionEnded doesn't collapse the panel.
+                // ControllerIdleChanged has to come off too or the re-subscribe below stacks a
+                // second copy on the multicast list every time the tier is changed.
                 App.RemoteControl.ControllerConnectedChanged -= OnRemoteControllerChanged;
+                App.RemoteControl.ControllerIdleChanged -= OnRemoteControllerIdleChanged;
                 App.RemoteControl.CommandReceived -= OnRemoteCommandReceived;
                 App.RemoteControl.SessionEnded -= OnRemoteSessionEnded;
 
@@ -815,6 +818,9 @@ namespace ConditioningControlPanel
             if (App.RemoteControl != null)
             {
                 App.RemoteControl.ControllerConnectedChanged -= OnRemoteControllerChanged;
+                // Was never detached, so every enable/disable cycle left another live copy
+                // subscribed to the service and firing into this (now torn-down) tab UI.
+                App.RemoteControl.ControllerIdleChanged -= OnRemoteControllerIdleChanged;
                 App.RemoteControl.CommandReceived -= OnRemoteCommandReceived;
                 App.RemoteControl.SessionEnded -= OnRemoteSessionEnded;
                 await App.RemoteControl.StopSessionAsync();
@@ -863,17 +869,15 @@ namespace ConditioningControlPanel
 
                 if (connected)
                 {
-                    // Only stop the local session on the FIRST controller of this remote
-                    // session. On a takeover (controller A leaves, B joins), connected
-                    // briefly transitions true→false→true; without this guard, B's connect
-                    // would re-stop a session that A or the sub had running, even when
-                    // B hasn't sent any command yet (bug report #166).
-                    if (!_remoteSessionHasTakenLocal)
-                    {
-                        _remoteSessionHasTakenLocal = true;
-                        try { _sessionEngine?.StopSession(completed: false); } catch { }
-                    }
-
+                    // A controller joining must NOT kill the subject's scripted session
+                    // (#878). It used to call _sessionEngine.StopSession(completed: false)
+                    // here, which threw away the session's elapsed time and its bonus XP
+                    // the instant somebody connected — and the 120 s idle auto-disconnect
+                    // meant an idle controller could do it again on every reconnect.
+                    // The controller sees live session progress in the status push and has
+                    // explicit verbs (pause_session / stop_session / start_session /
+                    // trigger_panic) when it genuinely wants the floor. See the matching
+                    // comment in RemoteControlService's connect path.
                     ShowRemoteControlOverlay();
                     NotifyRemoteControllerJoined();
                 }
@@ -883,11 +887,6 @@ namespace ConditioningControlPanel
                 }
             });
         }
-
-        // Set true once the first controller of the active remote-control session has
-        // claimed control. Reset when the remote session ends so a future remote session
-        // re-applies the take-over-local-session step on its first controller.
-        private bool _remoteSessionHasTakenLocal;
 
         private void OnRemoteControllerIdleChanged(object? sender, EventArgs e)
         {
@@ -907,7 +906,6 @@ namespace ConditioningControlPanel
         {
             Dispatcher.Invoke(() =>
             {
-                _remoteSessionHasTakenLocal = false;
                 HideRemoteControlOverlay();
                 UpdateStartButtonForRemoteControl(false);
                 _isLoading = true;

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -1272,6 +1272,29 @@ namespace ConditioningControlPanel
             _isLoading = false;
         }
 
+        // The exact Session instance a remote controller started via `start_session`.
+        // Held by reference (never by id) so IsSessionRemoteStarted describes THIS run and
+        // not "some session with the same id" — every start site builds a fresh object.
+        private Models.Session? _remoteStartedSession;
+
+        /// <summary>
+        /// True only while the session the engine is running right now is the one a remote
+        /// controller started. False for a session the subject started locally (Sessions tab,
+        /// Programs tab, dashboard), and false when nothing is running.
+        /// <para>
+        /// #878 followup: RemoteControlService.StopAllRemoteEffects consults this before tearing
+        /// the subject's session down, so a remote session that merely *expires* (server 404,
+        /// 3× 401, or the subject unticking Remote Control) can no longer abandon a local run
+        /// and forfeit its bonus XP. The self-clearing reference comparison means no start/stop
+        /// path has to remember to reset a latch — the previous latch (#878's
+        /// _remoteSessionHasTakenLocal) leaked for exactly that reason.
+        /// </para>
+        /// </summary>
+        internal bool IsSessionRemoteStarted =>
+            _remoteStartedSession != null
+            && _sessionEngine?.IsRunning == true
+            && ReferenceEquals(_sessionEngine.CurrentSession, _remoteStartedSession);
+
         // Methods called by RemoteControlService for session commands
         internal async void StartSessionFromRemote(Models.Session session)
         {
@@ -1314,6 +1337,9 @@ namespace ConditioningControlPanel
                 }
 
                 App.IsSessionRunning = true;
+                // Mark the run as controller-owned BEFORE the await: the teardown that consults
+                // IsSessionRemoteStarted can fire from the poll timer at any point after this.
+                _remoteStartedSession = session;
                 await _sessionEngine.StartSessionAsync(session);
                 App.Logger?.Information("[RemoteControl] Session engine started successfully for: {Name}", session.Name);
             }

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -300,6 +300,16 @@ namespace ConditioningControlPanel.Services
             if (App.Overlay != null)
                 App.Overlay.BypassLevelCheck = false;
 
+            // EnsureOverlayRunning() starts OverlayService on controller connect even when the
+            // subject has no engine of their own running. Nothing used to stop it again, so the
+            // service stayed IsRunning with a live 500 ms DispatcherTimer for the rest of the
+            // process, reacting to settings toggles with no engine behind them. Hand it back
+            // only when the subject isn't running an engine — if they are, the overlay belongs
+            // to them now and StopEngine will deal with it.
+            // (On the UI thread — Stop() disposes a DispatcherTimer and closes overlay windows.)
+            if (MainWindowRef?.IsEngineRunning != true)
+                DispatcherHelper.RunOnUISync(() => App.Overlay?.Stop());
+
             if (ControllerConnected)
             {
                 ControllerConnected = false;

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -291,8 +291,10 @@ namespace ConditioningControlPanel.Services
             Tier = null;
             ControllerIdle = false;
 
-            // Stop all effects that were triggered by the remote controller
-            DispatcherHelper.RunOnUISync(() => StopAllRemoteEffects());
+            // Stop all effects that were triggered by the remote controller. force:false — the
+            // remote session ending is not a controller verb, so a session the SUBJECT started
+            // is left alone (#878 followup).
+            DispatcherHelper.RunOnUISync(() => StopAllRemoteEffects(force: false));
 
             // Reset overlay level bypass when remote session ends
             if (App.Overlay != null)
@@ -764,11 +766,24 @@ namespace ConditioningControlPanel.Services
             return services;
         }
 
-        private void StopAllRemoteEffects()
+        /// <summary>
+        /// Tears down everything a controller could have started.
+        /// </summary>
+        /// <param name="force">
+        /// True only for <c>trigger_panic</c> — an explicit controller verb that means "stop
+        /// EVERYTHING", so it takes the subject's session down no matter who started it.
+        /// False for the CleanupSession path, where the remote session merely ended (server-side
+        /// expiry, 3× 401, or the subject unticking Remote Control). None of those is a
+        /// controller verb, so a session the subject started locally must survive them (#878
+        /// followup) — otherwise a 60-minute local run with Remote Control merely armed got
+        /// stopped, TrackSessionAbandoned'd and its bonus XP forfeited the moment the server
+        /// expired the unused remote session.
+        /// </param>
+        private void StopAllRemoteEffects(bool force)
         {
             try
             {
-                App.Logger?.Information("[RemoteControl] Stopping all remote effects");
+                App.Logger?.Information("[RemoteControl] Stopping all remote effects (force={Force})", force);
 
                 App.KillAllAudio();
 
@@ -832,8 +847,18 @@ namespace ConditioningControlPanel.Services
                 }
                 App.Overlay?.RefreshOverlays();
 
-                // Stop session engine and main engine if running
-                MainWindowRef?.StopSessionFromRemote();
+                // Stop session engine and main engine — but ONLY when the controller owns the
+                // run (it issued start_session) or this is a panic. A session the subject
+                // started for themselves is not the remote session's to end: see the `force`
+                // parameter docs above.
+                if (force || MainWindowRef?.IsSessionRemoteStarted == true)
+                {
+                    MainWindowRef?.StopSessionFromRemote();
+                }
+                else if (MainWindowRef?.IsEngineRunning == true)
+                {
+                    App.Logger?.Information("[RemoteControl] Leaving the subject's own session/engine running — the controller did not start it");
+                }
 
                 // Sync checkbox state and bring window to front
                 if (MainWindowRef != null)
@@ -1257,7 +1282,9 @@ namespace ConditioningControlPanel.Services
                             break;
 
                         case "trigger_panic":
-                            StopAllRemoteEffects();
+                            // Explicit "stop everything" verb — the one path that is allowed to
+                            // end a session the subject started for themselves.
+                            StopAllRemoteEffects(force: true);
                             break;
 
                         default:

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -283,7 +283,6 @@ namespace ConditioningControlPanel.Services
             _controllerAutoDisconnected = false;
             _lastStatusPushUtc = DateTime.MinValue;
             _statusBackoffUntil = DateTime.MinValue;
-            _engineStoppedForController = false;
             _lastOptInTags = null;
             _lastOptInStatus = null;
             IsActive = false;
@@ -333,10 +332,6 @@ namespace ConditioningControlPanel.Services
         // call would immediately bounce off the debounce gate.
         public bool IsWithinDebounceWindow =>
             (DateTime.UtcNow - _lastEmoteSentUtc).TotalMilliseconds < EmoteDebounceMs;
-        // Set true after the first controller of the active remote session caused the
-        // local engine to stop. Prevents a takeover (A leaves, B joins) from re-stopping
-        // an engine the second controller would otherwise inherit. Cleared in CleanupSession.
-        private bool _engineStoppedForController;
 
         private async Task PollForCommandsAsync()
         {
@@ -464,16 +459,18 @@ namespace ConditioningControlPanel.Services
                     ControllerConnected = connected;
                     if (connected)
                     {
-                        // Only stop the engine on the FIRST controller of this remote
-                        // session. Takeovers (controller A leaves, B joins) trigger this
-                        // branch again as a false→true transition; without the guard we'd
-                        // re-stop a session/engine that the previous controller or sub had
-                        // running, even when B sent no command (#166).
-                        if (MainWindowRef?.IsEngineRunning == true && !_engineStoppedForController)
-                        {
-                            _engineStoppedForController = true;
-                            MainWindowRef.StopEngine();
-                        }
+                        // A controller connecting does NOT tear the subject's own run down
+                        // (#878). Earlier builds stopped the local engine here so the
+                        // controller inherited a clean slate; that killed whatever the sub
+                        // had running and — because the 120 s idle auto-disconnect below
+                        // produces a genuine false→true→false→true cycle — re-ran the
+                        // teardown every couple of minutes for an idle controller.
+                        // Nothing in the dispatch table needs the engine down: every verb
+                        // calls its target service's entry point directly and works fine
+                        // alongside a running engine. "Taking over" is therefore an
+                        // explicit command (start_session, which stops any running session
+                        // itself; pause_session; stop_session; trigger_panic), never an
+                        // implicit side effect of connecting.
 
                         // Ensure overlay service is ready for remote commands
                         EnsureOverlayRunning();
@@ -854,47 +851,22 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Lighter cleanup for controller disconnect — stops remote-triggered effects
-        /// but preserves the user's engine and autonomy state.
-        /// </summary>
-        /// <summary>
         /// Runs when the controller disconnects (explicit or idle timeout). With the
-        /// opt-in "stop effects on disconnect" setting we tear remote effects down;
-        /// otherwise (the default continuity mode) we restore the local engine that
-        /// was force-stopped when the controller took over, so the sub's flashing /
-        /// autonomy(takeover) / haptics resume instead of staying dead (#294).
+        /// opt-in "stop effects on disconnect" setting we tear remote-triggered effects
+        /// down; otherwise (the default continuity mode) we leave everything exactly as
+        /// the controller left it.
+        /// <para>
+        /// Nothing is *restored* here any more. #294's "the sub is left dead after the
+        /// controller leaves" could only happen because the connect path force-stopped the
+        /// local engine; since #878 it never does, so there is no stopped engine to bring
+        /// back. Re-starting one here would also be actively wrong on the 120 s idle
+        /// timeout, which fires while the subject is simply sitting still.
+        /// </para>
         /// </summary>
         private void HandleControllerDisconnectCleanup()
         {
             if (App.Settings?.Current?.StopEffectsOnRemoteDisconnect == true)
                 StopRemoteTriggeredEffects();
-            else
-                RestoreEngineAfterControllerLeftIfNeeded();
-        }
-
-        /// <summary>
-        /// Restart the local engine iff WE stopped it when the controller took over
-        /// (<see cref="_engineStoppedForController"/>). Clearing the flag means a
-        /// later controller reconnect will correctly re-take-over the now-running
-        /// engine. Runs on the poll/UI thread, same context the connect path uses to
-        /// call StopEngine.
-        /// </summary>
-        private void RestoreEngineAfterControllerLeftIfNeeded()
-        {
-            if (!_engineStoppedForController) return;
-            _engineStoppedForController = false;
-            try
-            {
-                if (MainWindowRef != null && MainWindowRef.IsEngineRunning != true)
-                {
-                    App.Logger?.Information("[RemoteControl] Controller left — restoring the engine that was stopped on takeover (#294)");
-                    MainWindowRef.StartEngine();
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning(ex, "[RemoteControl] Failed to restore engine after controller left");
-            }
         }
 
         private void StopRemoteTriggeredEffects()

--- a/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
@@ -73,9 +73,15 @@ There is no direct peer connection. Three parties talk through the proxy:
   `DispatcherTimer` (`:151`). Raises `SessionStarted` (`:159`). Returns the session code (or `null` on
   failure).
 - **`StopSessionAsync`** (`:253`): POSTs `/v2/remote/stop` (best-effort) then `CleanupSession`.
-- **`CleanupSession`** (`:275`): stops the timer, resets all flags, **runs `StopAllRemoteEffects` on
-  the UI thread** (`:296`), clears `App.Overlay.BypassLevelCheck`, fires `ControllerConnectedChanged`
-  (if it was connected) + `SessionEnded`.
+- **`CleanupSession`** (`:275`): stops the timer, resets all flags, **runs
+  `StopAllRemoteEffects(force: false)` on the UI thread** (`:296`), clears
+  `App.Overlay.BypassLevelCheck`, **stops `App.Overlay` when the subject has no engine running**,
+  fires `ControllerConnectedChanged` (if it was connected) + `SessionEnded`.
+  - `force: false` is load-bearing. `CleanupSession` is reached by *expiry* — poll `404`, 3× `401`,
+    or the subject unticking Remote Control — none of which is a controller verb, so the subject's
+    own session must survive it. See §4c.
+  - The overlay stop is the counterpart to `EnsureOverlayRunning`: the connect path can start
+    `OverlayService` with no engine behind it, and nothing else would ever stop it.
 - **`Dispose`** (`:303`): stops the timer, disposes the `HttpClient`. Called first in `App` shutdown so
   no new effects queue during teardown.
 
@@ -179,18 +185,38 @@ string over the network and calls into another service. There is no per-command 
 | `enable_strict_lock` / `disable_strict_lock` | `Settings.StrictLockEnabled` (`:1244`/`:1252`) | |
 | `disable_panic` / `enable_panic` | `Settings.PanicKeyEnabled` (`:1260`/`:1268`) | Controller can disable the subject's ESC panic key. |
 | `trigger_wallpaper` / `stop_wallpaper` | `App.Wallpaper.Activate()/Shuffle()` / `.Deactivate()` (`:1276`/`:1283`) | |
-| `trigger_panic` | `StopAllRemoteEffects()` (`:1287`) | The "stop everything" verb (see §4c). |
+| `trigger_panic` | `StopAllRemoteEffects(force: true)` (`:1287`) | The "stop everything" verb — the **only** caller that passes `force` (see §4c). |
 | _unknown_ | logged as warning (`:1291`) | Silently ignored otherwise. |
 
-### 4c. Panic / stop-all fan-out (`StopAllRemoteEffects`, `:770`)
-Called by `trigger_panic` and by `CleanupSession`. Kills audio, cancels + re-arms Autonomy (careful
-dance to keep the toggle honest, `:787`), stops Haptics, Video (LibVLC **and** the WebView2 HypnoTube
-path via `StopBrowserVideoFromRemote`, `:807`), Flash, Subliminal, Bubbles, BouncingText, BubbleCount,
-MindWipe, BrainDrain, LockCard, Wallpaper; **resets `App.InteractionQueue` before** force-closing
-LockCard/BubbleCount windows (`:822`, ordering matters — #462); turns off overlays; stops the session
-engine (`StopSessionFromRemote`); restores the window from tray + shows the avatar. `StopRemoteTriggeredEffects`
-(`:900`) is the **lighter** variant used on controller disconnect when
+### 4c. Panic / stop-all fan-out (`StopAllRemoteEffects(bool force)`, `:770`)
+Called by `trigger_panic` (`force: true`) and by `CleanupSession` (`force: false`). Kills audio,
+cancels + re-arms Autonomy (careful dance to keep the toggle honest, `:787`), stops Haptics, Video
+(LibVLC **and** the WebView2 HypnoTube path via `StopBrowserVideoFromRemote`, `:807`), Flash,
+Subliminal, Bubbles, BouncingText, BubbleCount, MindWipe, BrainDrain, LockCard, Wallpaper; **resets
+`App.InteractionQueue` before** force-closing LockCard/BubbleCount windows (`:822`, ordering matters
+— #462); turns off overlays; restores the window from tray + shows the avatar.
+`StopRemoteTriggeredEffects` (`:900`) is the **lighter** variant used on controller disconnect when
 `StopEffectsOnRemoteDisconnect` is set.
+
+**The session/engine stop is conditional.** `StopSessionFromRemote()` runs only when
+`force || MainWindowRef.IsSessionRemoteStarted`:
+
+| Path | `force` | Session was started by | Session stopped? |
+|---|---|---|---|
+| `trigger_panic` | `true` | anyone (or nothing running) | **yes** — panic means stop everything |
+| expiry / 401×3 / untick (`CleanupSession`) | `false` | the **controller** (`start_session`) | **yes** |
+| expiry / 401×3 / untick (`CleanupSession`) | `false` | the **subject** (Sessions tab, Programs tab, dashboard) | **no** |
+| expiry / 401×3 / untick (`CleanupSession`) | `false` | nothing running | no-op |
+
+Everything else in the fan-out is unconditional in both modes. The narrow exemption exists because a
+subject who armed Remote Control mid-run and was never connected to used to lose the run — and its
+bonus XP, via `TrackSessionAbandoned` — the moment the server expired the idle remote session.
+
+`IsSessionRemoteStarted` (`MainWindow.RemoteControl.cs`) is **not a latch**: it reference-compares
+`_remoteStartedSession` (the exact `Session` instance handed to `StartSessionFromRemote`) against
+`_sessionEngine.CurrentSession`, so it self-clears when the engine stops or runs anything else. Keep
+it that way — the one-shot latches this replaced (`_remoteSessionHasTakenLocal`) leaked precisely
+because some path forgot to reset them (§10.7).
 
 ### 4d. Subsystem touchpoints beyond the dispatch table
 - **SessionEngine**: three callbacks wired by `WireRemoteSessionCallbacks` (`MainWindow.RemoteControl.cs:989`)
@@ -202,13 +228,18 @@ engine (`StopSessionFromRemote`); restores the window from tray + shows the avat
   running session's elapsed time + bonus XP and re-fired on every 120 s-idle → reconnect cycle.
   Taking the floor is now always an **explicit command**: `start_session` (which stops any running
   session itself, `MainWindow.RemoteControl.cs:1285`), `pause_session`, `stop_session`,
-  `trigger_panic`. Consequently `_engineStoppedForController`, `_remoteSessionHasTakenLocal` and
+  `trigger_panic`. The **end** of the remote session is likewise not a takeover — see the §4c truth
+  table; only a controller-started run goes down with it.
+  Consequently `_engineStoppedForController`, `_remoteSessionHasTakenLocal` and
   `RestoreEngineAfterControllerLeftIfNeeded` (#294's restore) are **gone** — with nothing
   force-stopping the engine there is nothing to restore, and restoring on the idle timeout would
   restart an engine the subject deliberately left off. `HandleControllerDisconnectCleanup` now only
   runs the opt-in `StopRemoteTriggeredEffects` branch.
-- **Overlay**: `EnsureOverlayRunning` (`:953`) sets `App.Overlay.BypassLevelCheck = true` so remote
-  pink/spiral work regardless of the subject's level; cleared on session end.
+- **Overlay**: `EnsureOverlayRunning` (`:953`) starts `OverlayService` if needed and sets
+  `App.Overlay.BypassLevelCheck = true` so remote pink/spiral work regardless of the subject's level.
+  `CleanupSession` clears the bypass **and stops the service again** unless the subject's own engine
+  is running (`MainWindow.IsEngineRunning`) — the connect path can start it with no engine behind it,
+  and a service left running holds a 500 ms `DispatcherTimer` for the process lifetime.
 - **Progression / quests**: only the quest hook (§4a). **No XP is awarded for remote commands
   themselves.**
 - **GamificationBridge**: subscribes to the service's `SessionStarted` event
@@ -341,7 +372,7 @@ A public opt-in matchmaking directory bolted onto Remote Control ("SP5 layer 3")
    **only the server decides which commands to enqueue for a given tier.** Trusting the tier for
    safety requires trusting the proxy.
 3. **`trigger_panic` (remote) does NOT call `TriggerPanicFromRemote`.** The remote panic verb runs
-   `StopAllRemoteEffects()` (`:1287`). `MainWindow.TriggerPanicFromRemote` (`:1381`) — despite the name
+   `StopAllRemoteEffects(force: true)` (`:1287`). `MainWindow.TriggerPanicFromRemote` (`:1381`) — despite the name
    — is actually invoked by the **local voice** panic command (`AutonomyService.VoiceCommands.cs:133`),
    not by any remote command. Misleading name; don't assume the remote path goes through it.
 4. **`MinimizeToTrayForRemote` (`:1439`) appears unused.** No caller found in the C# sources — likely
@@ -359,7 +390,9 @@ A public opt-in matchmaking directory bolted onto Remote Control ("SP5 layer 3")
    (the restore helper cleared one, so the next reconnect re-stopped the engine; `StopRemoteControl`
    unsubscribes `SessionEnded` before stopping, so the other never got cleared at all). **#878** cut
    the knot by removing the teardown instead of guarding it. Anything you add to the connect path
-   must be idempotent and non-destructive.
+   must be idempotent and non-destructive. The same rule now covers the **session-end** path: it is
+   reached by expiry and by the subject unticking the box, so it may only tear down what the
+   controller owns (§4c).
 8. **Controller-supplied text and URLs cross a trust boundary.** `trigger_custom_subliminal` puts
    arbitrary controller text on the subject's screens (capped/stripped inside `FlashSubliminalCustom`).
    `play_hypnotube` is the **only** command that hard-validates its input (`HtUrlHelper.IsEligibleHtUrl`,
@@ -371,6 +404,14 @@ A public opt-in matchmaking directory bolted onto Remote Control ("SP5 layer 3")
 10. **`CleanupSession` runs `StopAllRemoteEffects` on the UI thread synchronously** (`:296`,
     `RunOnUISync`). If you add expensive teardown, keep it UI-thread-safe and fast, or the session-stop
     click will hitch.
+11. **`OnRemoteSessionEnded` unticks the box under `_isLoading`, so `StopRemoteControl` never runs on
+    that path.** The untick is deliberate (`ChkRemoteControlEnabled_Changed` early-returns on
+    `_isLoading`, `:37`), but `StopRemoteControl` was the only place the four service handlers
+    (`ControllerConnectedChanged`, `ControllerIdleChanged`, `CommandReceived`, `SessionEnded`) were
+    detached — so every service-initiated end left them attached and the next enable stacked another
+    full set, one more per expiry cycle. Both ends are now defended: the subscription site does `-=`
+    before every `+=`, and `OnRemoteSessionEnded` detaches all four. **If you add a fifth event, wire
+    it into both places.**
 
 ---
 

--- a/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
+++ b/ConditioningControlPanel/docs/primers/REMOTE_CONTROL_PRIMER.md
@@ -88,10 +88,10 @@ The heartbeat. Guards against re-entrance (`_pollInProgress`, `:344`), POSTs `{u
   (`:379`). Otherwise increment `_consecutivePollFailures` and log.
 - **Recovery** (`:400`): on the first success after a backoff, restores the 5 s interval.
 - **Controller connection** (`:435`): reads `controller_connected` / `controller_idle` from the
-  response. On the **first** controller connect of the session, if the local engine is running it
-  **stops the engine** (`_engineStoppedForController` guard prevents a takeover re-stop, `:472`) and
-  ensures the overlay service is running (`EnsureOverlayRunning`, `:479`). On disconnect it runs
-  `HandleControllerDisconnectCleanup` (`:486`) and re-publishes the directory entry.
+  response. On connect it **only** ensures the overlay service is running (`EnsureOverlayRunning`).
+  It does **not** touch the local engine or the scripted session — that implicit teardown was removed
+  in **#878** (see §4d). On disconnect it runs `HandleControllerDisconnectCleanup` and re-publishes
+  the directory entry.
 - **Idle auto-disconnect** (`:506`): after `IdleAutoDisconnectSeconds` = **120 s** idle (`:322`), the
   client force-treats the controller as disconnected.
 - **Command execution** (`:534`): each element of the `commands` JArray → `ExecuteCommand(action,
@@ -196,10 +196,17 @@ engine (`StopSessionFromRemote`); restores the window from tray + shows the avat
 - **SessionEngine**: three callbacks wired by `WireRemoteSessionCallbacks` (`MainWindow.RemoteControl.cs:989`)
   — `GetAvailableSessionsCallback`, `GetSessionProgressCallback`, `FindSessionByIdCallback` — feed the
   controller the subject's session list + live progress via the status push.
-- **Engine takeover**: first controller connect **stops the running engine/session** both in the
-  service (`:472`) and in `OnRemoteControllerChanged` (`MainWindow.RemoteControl.cs:871`); on
-  controller-left the engine is optionally **restored** (`RestoreEngineAfterControllerLeftIfNeeded`,
-  `:882`, #294) unless `StopEffectsOnRemoteDisconnect`.
+- **Engine takeover — there isn't one (since #878).** A controller connecting leaves the subject's
+  engine *and* scripted session running; both the service connect path and
+  `OnRemoteControllerChanged` (`MainWindow.RemoteControl.cs`) used to stop them, which threw away a
+  running session's elapsed time + bonus XP and re-fired on every 120 s-idle → reconnect cycle.
+  Taking the floor is now always an **explicit command**: `start_session` (which stops any running
+  session itself, `MainWindow.RemoteControl.cs:1285`), `pause_session`, `stop_session`,
+  `trigger_panic`. Consequently `_engineStoppedForController`, `_remoteSessionHasTakenLocal` and
+  `RestoreEngineAfterControllerLeftIfNeeded` (#294's restore) are **gone** — with nothing
+  force-stopping the engine there is nothing to restore, and restoring on the idle timeout would
+  restart an engine the subject deliberately left off. `HandleControllerDisconnectCleanup` now only
+  runs the opt-in `StopRemoteTriggeredEffects` branch.
 - **Overlay**: `EnsureOverlayRunning` (`:953`) sets `App.Overlay.BypassLevelCheck = true` so remote
   pink/spiral work regardless of the subject's level; cleared on session end.
 - **Progression / quests**: only the quest hook (§4a). **No XP is awarded for remote commands
@@ -345,10 +352,14 @@ A public opt-in matchmaking directory bolted onto Remote Control ("SP5 layer 3")
 6. **PIN is intentionally in the URL hash fragment**, not a query param, so it stays out of server logs
    and Referer headers (`:1151` comment). It is also sent plaintext in the directory opt-in body — by
    design (same PIN already on-screen, `:172` comment). Keep both properties if you touch pairing.
-7. **The engine-takeover has a false→true→true trap.** A controller takeover (A leaves, B joins)
-   re-fires the connect transition; `_engineStoppedForController` (`:339`) and
-   `_remoteSessionHasTakenLocal` (`MainWindow.RemoteControl.cs:890`) guard against re-stopping a
-   session the previous controller had running (#166). Preserve these guards.
+7. **The connect transition fires more than once per remote session — never put teardown behind it.**
+   A takeover (A leaves, B joins) *and* every 120 s-idle auto-disconnect → reconnect cycle re-fire
+   `ControllerConnectedChanged` as false→true. #166 tried to survive that with one-shot latches
+   (`_engineStoppedForController`, `_remoteSessionHasTakenLocal`); the latches themselves then leaked
+   (the restore helper cleared one, so the next reconnect re-stopped the engine; `StopRemoteControl`
+   unsubscribes `SessionEnded` before stopping, so the other never got cleared at all). **#878** cut
+   the knot by removing the teardown instead of guarding it. Anything you add to the connect path
+   must be idempotent and non-destructive.
 8. **Controller-supplied text and URLs cross a trust boundary.** `trigger_custom_subliminal` puts
    arbitrary controller text on the subject's screens (capped/stripped inside `FlashSubliminalCustom`).
    `play_hypnotube` is the **only** command that hard-validates its input (`HtUrlHelper.IsEligibleHtUrl`,


### PR DESCRIPTION
Fixes #878: connecting a remote controller tore down the subject's running session (twice), and the 120s idle-reconnect cycle re-fired it.

- Connect leaves the local session running (controller has explicit pause/stop/start verbs; start_session already replaces)
- Review-pass: remote-session END (server 404/401 expiry, untick) now only stops a session the controller actually started - detected by reference-comparing the Session instance, so nothing can leak; trigger_panic still force-stops everything
- Handler stacking fixed both ways (defensive detach before subscribe + full detach on session end); orphaned OverlayService stopped when no engine is running

Build 0 errors, tests 2411/2411. REMOTE_CONTROL_PRIMER updated with the new truth table.

Owner call surfaced (unchanged behavior): BtnStart stays disabled while a controller is connected, so the subject's escape is ESC panic / Remote tab Stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)