### PR TITLE
fix(lockcard): panic always closes cards, strict Esc only yields to a LIVE panic key (#875)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -874,8 +874,9 @@ namespace ConditioningControlPanel
                 // Stop all visual overlays (spiral, pink filter, etc.)
                 Overlay?.Stop();
 
-                // Stop lock card and pop quiz if active
-                LockCard?.Stop();
+                // Stop lock card and pop quiz if active. Kill-everything path (panic + exit), so the
+                // card on screen goes too — see LockCardService.Stop(dismissOpenCards).
+                LockCard?.Stop(dismissOpenCards: true);
                 PopQuiz?.Stop();
 
                 // Stop mantra lab audio

--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -413,6 +413,17 @@ namespace ConditioningControlPanel
         public static SkillTreeService SkillTree { get; private set; } = null!;
         public static KeywordTriggerService KeywordTriggers { get; private set; } = null!;
         public static KeywordTriggerPresetService KeywordPresets { get; private set; } = null!;
+        /// <summary>
+        /// The one WH_KEYBOARD_LL hook that carries the panic key — MainWindow owns it and registers
+        /// it here on creation (and clears it on dispose). Published so code that has to know whether
+        /// a panic escape REALLY exists can ask the hook instead of trusting
+        /// <c>PanicKeyEnabled</c>: <see cref="GlobalKeyboardHook.IsInstalled"/> is false when
+        /// SetWindowsHookEx failed, and Windows silently un-registers a low-level hook whose callback
+        /// overran LowLevelHooksTimeout with nothing to reinstall it (#616-#623). Deliberately NOT the
+        /// short-lived hooks other windows spin up for themselves (e.g. the chaos countdown) — only
+        /// this one is wired to <c>HandlePanicKeyPress</c>.
+        /// </summary>
+        public static GlobalKeyboardHook? PanicHook { get; internal set; }
         public static ScreenOcrService ScreenOcr { get; private set; } = null!;
         public static KeywordHighlightService? KeywordHighlight { get; private set; }
         public static ActivityTracker ActivityTracker { get; private set; } = null!;

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -1559,6 +1559,7 @@
   "label_good_girl_2": "✨ Braves Mädchen! ✨",
   "label_press_esc_to_close_if_allowed": "Drücke ESC zum Schließen (wenn erlaubt)",
   "label_press_esc_to_close": "Drücke ESC zum Schließen",
+  "label_strict_only_panic_key_closes": "Strikte Sperre - nur die Panik-Taste ({0}) schließt das",
   "label_input_synced_from_primary_monitor": "Eingabe vom Hauptmonitor synchronisiert",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -2514,6 +2514,7 @@
   "label_good_girl_2": "✨ Good girl! ✨",
   "label_press_esc_to_close_if_allowed": "Press ESC to close (if allowed)",
   "label_press_esc_to_close": "Press ESC to close",
+  "label_strict_only_panic_key_closes": "Strict lock - only the panic key ({0}) closes this",
   "label_input_synced_from_primary_monitor": "Input synced from primary monitor",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -1558,6 +1558,7 @@
   "label_good_girl_2": "✨ ¡Buena chica! ✨",
   "label_press_esc_to_close_if_allowed": "Presiona ESC para cerrar (si está permitido)",
   "label_press_esc_to_close": "Presiona ESC para cerrar",
+  "label_strict_only_panic_key_closes": "Bloqueo estricto - solo la tecla de pánico ({0}) cierra esto",
   "label_input_synced_from_primary_monitor": "Entrada sincronizada desde el monitor principal",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -1559,6 +1559,7 @@
   "label_good_girl_2": "✨ Bonne fille ! ✨",
   "label_press_esc_to_close_if_allowed": "Appuie sur Échap pour fermer (si autorisé)",
   "label_press_esc_to_close": "Appuie sur Échap pour fermer",
+  "label_strict_only_panic_key_closes": "Verrouillage strict - seule la touche panique ({0}) ferme ceci",
   "label_input_synced_from_primary_monitor": "Saisie synchronisée depuis le moniteur principal",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -1558,6 +1558,7 @@
   "label_good_girl_2": "✨ えらいね！ ✨",
   "label_press_esc_to_close_if_allowed": "ESCで閉じる（許可されている場合）",
   "label_press_esc_to_close": "ESCで閉じる",
+  "label_strict_only_panic_key_closes": "厳格ロック - パニックキー（{0}）でのみ閉じられます",
   "label_input_synced_from_primary_monitor": "プライマリモニターから入力を同期",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -1558,6 +1558,7 @@
   "label_good_girl_2": "✨ 착한 소녀! ✨",
   "label_press_esc_to_close_if_allowed": "ESC를 눌러 닫기 (허용된 경우)",
   "label_press_esc_to_close": "ESC를 눌러 닫기",
+  "label_strict_only_panic_key_closes": "엄격 잠금 - 패닉 키({0})로만 닫을 수 있습니다",
   "label_input_synced_from_primary_monitor": "기본 모니터에서 입력 동기화됨",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -1558,6 +1558,7 @@
   "label_good_girl_2": "✨ Boa menina! ✨",
   "label_press_esc_to_close_if_allowed": "Pressione ESC para fechar (se permitido)",
   "label_press_esc_to_close": "Pressione ESC para fechar",
+  "label_strict_only_panic_key_closes": "Bloqueio estrito - só a tecla de pânico ({0}) fecha isto",
   "label_input_synced_from_primary_monitor": "Entrada sincronizada do monitor principal",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -1558,6 +1558,7 @@
   "label_good_girl_2": "✨ Хорошая девочка! ✨",
   "label_press_esc_to_close_if_allowed": "Нажми ESC для закрытия (если разрешено)",
   "label_press_esc_to_close": "Нажми ESC для закрытия",
+  "label_strict_only_panic_key_closes": "Строгая блокировка - закрывает только клавиша паники ({0})",
   "label_input_synced_from_primary_monitor": "Ввод синхронизирован с основного монитора",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -2289,6 +2289,7 @@
   "label_good_girl_2": "✨ 乖女孩！✨",
   "label_press_esc_to_close_if_allowed": "按 ESC 关闭（如果允许）",
   "label_press_esc_to_close": "按 ESC 关闭",
+  "label_strict_only_panic_key_closes": "严格锁定 - 只有紧急停止键（{0}）可以关闭",
   "label_input_synced_from_primary_monitor": "输入从主显示器同步",
   "label_text_6": "🎮",
   "label_text_7": "⭐",

--- a/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.RemoteControl.cs
@@ -1407,7 +1407,7 @@ namespace ConditioningControlPanel
                 App.BubbleCount?.Stop();
                 App.MindWipe?.Stop();
                 App.BrainDrain?.Stop();
-                App.LockCard?.Stop();
+                App.LockCard?.Stop(dismissOpenCards: true);   // remote panic == local panic
 
                 // Turn off overlays but keep the overlay service alive
                 // so the controller can turn them back on. Clear the settings flags first so a

--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -331,7 +331,7 @@ namespace ConditioningControlPanel
             // Stop other services
             App.Subliminal.Stop();
             App.Overlay.Stop();
-            App.LockCard.Stop();
+            App.LockCard.Stop();   // scheduler only — the visible card is dropped by ForceCloseAll below
             App.BubbleCount.Stop();
             App.MindWipe.Stop();
             App.BrainDrain.Stop();

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -241,6 +241,7 @@ namespace ConditioningControlPanel
                 }
 
                 _keyboardHook?.Dispose();
+                App.PanicHook = null;   // #875: a disposed hook must not read as a live panic escape
                 _trayIcon?.Dispose();
                 _browser?.Dispose();
                 _avatarTubeWindow?.CloseSafe();

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -334,6 +334,7 @@ namespace ConditioningControlPanel
 
             // Initialize global keyboard hook (only if panic key is enabled)
             _keyboardHook = new GlobalKeyboardHook();
+            App.PanicHook = _keyboardHook;   // #875: lock cards ask this whether a panic escape really exists
             _keyboardHook.KeyPressed += OnGlobalKeyPressed;
             _keyboardHook.KeyPressedWithVkCode += (key, vkCode) => App.KeywordTriggers?.OnKeyPressed(key, vkCode);
             App.KeywordTriggers?.SetSessionActiveCallback(() => _sessionEngine?.IsRunning == true);

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -997,7 +997,7 @@ namespace ConditioningControlPanel
                 App.BubbleCount?.Stop();
                 App.MindWipe?.Stop();
                 App.BrainDrain?.Stop();
-                App.LockCard?.Stop();
+                App.LockCard?.Stop(dismissOpenCards: true);   // panic: the card on screen is the point
 
                 // Clear the settings flags so a running reconcile loop won't recreate them, then
                 // stop the windows directly — voice/Deeper start spiral & pink ad-hoc (no reconcile

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -803,6 +803,24 @@ namespace ConditioningControlPanel
         private void HandlePanicKeyPress()
         {
             VideoDiag.Log("PANIC", $"handling panic press (engineRunning={_isRunning}, uiStall={VideoDiag.UiStallMs}ms)");
+
+            // #875: an open lock card outranks every hand-off below, so it is answered FIRST. A lock
+            // card can coexist with a descent, the DtRH window or the feed — AutonomyService,
+            // RemoteControlService and MantraLockScreenCommand all show one with no guard against them
+            // — and the card is a fullscreen HWND_TOPMOST cover that steals focus from the game's own
+            // Esc ladder. With DtRH up the hand-off below returns unconditionally, so the panic key
+            // never reached StopAdHocEffects and the card had no exit at all: a permanent trap. The
+            // press is consumed here (like the video grace pause) and deliberately does NOT advance the
+            // press ladder, so it can never be the tap that exits the app.
+            // IsAnyOpen also covers a deferred show still pending; cancelling that is the right answer
+            // to panic too, and DismissAll clears both, so the next press falls through normally.
+            if (LockCardWindow.IsAnyOpen())
+            {
+                VideoDiag.Log("PANIC", "dismissing the open lock card (it outranks every hand-off)");
+                App.LockCard?.Stop(dismissOpenCards: true);
+                return;
+            }
+
             // A live Rabbit Hole descent owns the panic key: the chaos key hook pauses the
             // run (and a second press surfaces it). Without this hand-off a mid-run panic
             // fell into the "not running" branch below — where a second press EXITS the app.

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -87,6 +87,15 @@ namespace ConditioningControlPanel.Services
 
         public void Stop()
         {
+            // #875: dismiss FIRST, before the not-running early-return. A card can be on screen with
+            // the scheduler stopped — every ad-hoc surface shows one that way (voice command, the
+            // dashboard Test button, Deeper, MantraLockScreenCommand, remote trigger_lock_card). The
+            // panic key reaches an ad-hoc card only through MainWindow.StopAdHocEffects -> this Stop(),
+            // so an early-return here made panic a silent no-op and left the user staring at a card
+            // nothing could close. ForceCloseAll is idempotent (empty visible set = no-op), so paying
+            // it on every Stop() costs nothing when no card is up.
+            try { LockCardWindow.ForceCloseAll(); } catch { }
+
             if (!_isRunning) return;
             _isRunning = false;
             

--- a/ConditioningControlPanel/Services/LockCard/LockCardService.cs
+++ b/ConditioningControlPanel/Services/LockCard/LockCardService.cs
@@ -85,16 +85,31 @@ namespace ConditioningControlPanel.Services
                 perHour, firstDelay, windowMinutes is > 0 ? $"{windowMinutes.Value:F1}min" : "open-ended");
         }
 
-        public void Stop()
+        /// <summary>
+        /// Stop the scheduler. <paramref name="dismissOpenCards"/> additionally tears down a card that
+        /// is already on screen.
+        /// </summary>
+        /// <param name="dismissOpenCards">
+        /// #875: dismiss the visible card FIRST, before the not-running early-return. A card can be on
+        /// screen with the scheduler stopped — every ad-hoc surface shows one that way (voice command,
+        /// the dashboard Test button, Deeper, MantraLockScreenCommand, remote trigger_lock_card). The
+        /// panic key reaches an ad-hoc card only through MainWindow.StopAdHocEffects -> this Stop(), so
+        /// the early-return made panic a silent no-op and left the user staring at a card nothing could
+        /// close.
+        ///
+        /// It stays opt-in because most Stop() callers are not an escape at all: pausing a session,
+        /// un-ticking the lock-card feature, applying a preset. Dismissing there would walk straight
+        /// through strict mode and forfeit the XP of a card the user was mid-way through typing — a
+        /// feature toggle must never be a back door out of a lock. Only panic and genuine
+        /// kill-everything paths pass true. ForceCloseAll is idempotent, so true with no card up is a
+        /// no-op.
+        /// </param>
+        public void Stop(bool dismissOpenCards = false)
         {
-            // #875: dismiss FIRST, before the not-running early-return. A card can be on screen with
-            // the scheduler stopped — every ad-hoc surface shows one that way (voice command, the
-            // dashboard Test button, Deeper, MantraLockScreenCommand, remote trigger_lock_card). The
-            // panic key reaches an ad-hoc card only through MainWindow.StopAdHocEffects -> this Stop(),
-            // so an early-return here made panic a silent no-op and left the user staring at a card
-            // nothing could close. ForceCloseAll is idempotent (empty visible set = no-op), so paying
-            // it on every Stop() costs nothing when no card is up.
-            try { LockCardWindow.ForceCloseAll(); } catch { }
+            if (dismissOpenCards)
+            {
+                try { LockCardWindow.ForceCloseAll(); } catch { }
+            }
 
             if (!_isRunning) return;
             _isRunning = false;
@@ -339,8 +354,9 @@ namespace ConditioningControlPanel.Services
         {
             if (_isDisposed) return;
             _isDisposed = true;
-            
-            Stop();
+
+            // Teardown: nothing is left to solve the card against, so it must not outlive the service.
+            Stop(dismissOpenCards: true);
         }
     }
 }

--- a/ConditioningControlPanel/Services/RemoteControlService.cs
+++ b/ConditioningControlPanel/Services/RemoteControlService.cs
@@ -812,7 +812,8 @@ namespace ConditioningControlPanel.Services
                 App.BubbleCount?.Stop();
                 App.MindWipe?.Stop();
                 App.BrainDrain?.Stop();
-                App.LockCard?.Stop();
+                App.LockCard?.Stop();   // scheduler only — ForceCloseAll below drops the visible card,
+                                        // deliberately after the queue reset (see the note there)
                 App.Wallpaper?.Deactivate();
 
                 // Reset the queue BEFORE the ForceCloseAll calls: a lock-card Complete fired
@@ -915,7 +916,7 @@ namespace ConditioningControlPanel.Services
                 App.BubbleCount?.Stop();
                 App.MindWipe?.Stop();
                 App.BrainDrain?.Stop();
-                App.LockCard?.Stop();
+                App.LockCard?.Stop();   // scheduler only — ForceCloseAll below drops the visible card
                 App.Wallpaper?.Deactivate();
 
                 // Reset BEFORE ForceCloseAll so a lock-card Complete can't dequeue a stale

--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -433,6 +433,8 @@ namespace ConditioningControlPanel.Services
             App.Flash?.Stop();
             App.Subliminal?.Stop();
             App.Bubbles?.Stop();
+            // Scheduler only. A pause must NOT dismiss a card the user is mid-way through typing —
+            // that would walk through strict mode and forfeit the card's XP (#875).
             App.LockCard?.Stop();
             App.PopQuiz?.Stop();
             App.BubbleCount?.Stop();

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -237,7 +237,10 @@ namespace ConditioningControlPanel
         /// Every keyboard gesture that could put text into the box without typing it, or take text out
         /// of it: clipboard (Ctrl+C/V/X, Ctrl+Insert, Shift+Insert, Shift+Delete), select-all, and
         /// undo/redo. Pure so it can be unit-tested; used by both the input's preview handler and the
-        /// window-level backstop. Escape is deliberately NOT here — it is the always-available exit.
+        /// window-level backstop. Escape is deliberately NOT here: it is an exit, not a way to cheat
+        /// text into the box, so this gesture list has no say over it. Whether Esc actually closes the
+        /// card is decided once, in <c>Window_KeyDown</c> via <c>EscClosesCard</c> — a strict card with
+        /// a live panic escape swallows it, everything else honours it.
         /// </summary>
         internal static bool IsBlockedInputGesture(Key key, ModifierKeys mods)
         {
@@ -361,12 +364,7 @@ namespace ConditioningControlPanel
 
             // Handle strict mode
             TxtStrict.Text = _strictMode ? Loc.Get("label_strict") : "";
-            // #875: promise only the exit this card actually honours. A strict card with the panic key
-            // live swallows Esc, so name the panic key instead of telling the user to press a key that
-            // will do nothing; every other case (non-strict, or strict with no panic key) keeps Esc.
-            TxtEscHint.Text = EscClosesCard
-                ? Loc.Get("label_press_esc_to_close")
-                : Loc.GetF("label_strict_only_panic_key_closes", App.Settings?.Current?.PanicKey ?? "?");
+            RefreshEscHint();
 
             // Position on screen
             if (screen != null)
@@ -609,29 +607,72 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// #875: does Esc close THIS card? Non-strict cards: yes, Esc is the ordinary dismiss. Strict
-        /// cards: only when the panic key is switched off, because then Esc is the sole remaining exit
-        /// and strict mode must never become an inescapable trap (<see cref="Models.AppSettings.CheckDangerousCombinations"/>
-        /// warns about that combination rather than making it real). Settings unreadable ⇒ treat the
-        /// panic key as gone and keep Esc live: the failure mode has to fall open, not shut.
+        /// #875: is there a panic escape from this card RIGHT NOW? Not "is the panic key configured" —
+        /// the setting is only half of it. The panic key rides a WH_KEYBOARD_LL hook installed by
+        /// MainWindow, and that hook can be absent while the setting says yes: SetWindowsHookEx fails
+        /// under a hook quota or security software, and Windows silently un-registers a low-level hook
+        /// whose callback overran LowLevelHooksTimeout (~300ms) with nothing here ever reinstalling it
+        /// — the #616-#623 cluster. Lockdown already refuses to trust the setting for the same reason
+        /// (MainWindow.Lab.OnLockdownActivated checks IsInstalled after arming suppression), so the
+        /// lock card must not either: a dead hook plus a strict card gated Esc off, made the panic key
+        /// undeliverable, and left OnClosing cancelling Alt+F4 — no exit but Task Manager.
         /// </summary>
-        private bool EscClosesCard =>
-            !_strictMode || App.Settings?.Current?.PanicKeyEnabled != true;
+        private static bool PanicEscapeIsLive =>
+            App.Settings?.Current?.PanicKeyEnabled == true && App.PanicHook?.IsInstalled == true;
+
+        /// <summary>
+        /// #875: does Esc close THIS card? Non-strict cards: yes, Esc is the ordinary dismiss. Strict
+        /// cards: only while a panic escape is actually live (<see cref="PanicEscapeIsLive"/>), because
+        /// otherwise Esc is the sole remaining exit and strict mode must never become an inescapable
+        /// trap (<see cref="Models.AppSettings.CheckDangerousCombinations"/> warns about that
+        /// combination rather than making it real). Settings unreadable, or the hook gone ⇒ keep Esc
+        /// live: every failure mode here has to fall open, not shut.
+        /// </summary>
+        private bool EscClosesCard => !_strictMode || !PanicEscapeIsLive;
+
+        /// <summary>
+        /// #875: paint the bottom hint from the exit this card honours RIGHT NOW. A strict card with a
+        /// live panic escape swallows Esc, so it names the panic key rather than telling the user to
+        /// press a key that will do nothing; every other case (non-strict, no panic key, or a panic
+        /// hook that died) keeps the Esc promise. Re-run rather than snapshotted at Configure because
+        /// <see cref="EscClosesCard"/> is live — a controller can flip PanicKeyEnabled mid-card.
+        /// </summary>
+        private void RefreshEscHint()
+        {
+            if (TxtEscHint == null) return;
+            TxtEscHint.Text = EscClosesCard
+                ? Loc.Get("label_press_esc_to_close")
+                : Loc.GetF("label_strict_only_panic_key_closes", App.Settings?.Current?.PanicKey ?? "?");
+        }
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
-            // Esc closes the card unless strict mode is on AND the panic key is live to cover it
-            // (see EscClosesCard). The unconditional close that the 55f872086 file split left here
-            // voided strict mode outright: any card, however strict, died to a single Esc. Strict now
-            // means "type it out, or panic out" — and Half 1 of #875 (LockCardService.Stop force-closing
-            // above its not-running guard) is what makes that panic key work for an ad-hoc card, so the
-            // two fixes must ship together or strict cards become unescapable.
-            if (e.Key == Key.Escape && !_isCompleted && EscClosesCard)
+            // Esc closes the card unless strict mode is on AND a panic escape is genuinely live to
+            // cover it (see EscClosesCard / PanicEscapeIsLive). The unconditional close that the
+            // 55f872086 file split left here voided strict mode outright: any card, however strict,
+            // died to a single Esc. Strict now means "type it out, or panic out" — and Half 1 of #875
+            // (LockCardService.Stop force-closing above its not-running guard) is what makes that panic
+            // key work for an ad-hoc card, so the two fixes must ship together or strict cards become
+            // unescapable.
+            if (e.Key == Key.Escape && !_isCompleted)
             {
-                App.Logger?.Information("Lock Card closed via ESC (strict={Strict})", _strictMode);
-                CloseAllWindows();
+                if (EscClosesCard)
+                {
+                    App.Logger?.Information("Lock Card closed via ESC (strict={Strict})", _strictMode);
+                    CloseAllWindows();
+                }
+                else
+                {
+                    // Refused. The hint was painted at Configure but the gate is live, so the two can
+                    // disagree (a controller flipping PanicKeyEnabled, a hook Windows just dropped).
+                    // Repaint every card now that the user has told us they are looking for the exit.
+                    foreach (var w in new List<LockCardWindow>(_allWindows))
+                    {
+                        try { w.RefreshEscHint(); } catch { }
+                    }
+                }
             }
-            
+
             // Prevent Alt+F4 in strict mode
             if (_strictMode && e.Key == Key.System && e.SystemKey == Key.F4)
             {

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -1088,8 +1088,15 @@ namespace ConditioningControlPanel
         /// post-completion auto-close). Windows are hidden and returned to the keep-alive pool rather
         /// than closed, so the next card reuses a pre-realized layered window instead of realizing a
         /// fresh one on the hot path — the fix for the #494 render-thread-deadlock freeze.
+        ///
+        /// Marshalled to the UI thread (matching ShowLockCard's convention), because DismissAll touches
+        /// WPF windows: off-thread it would still clear the visible set and stand the dead-man's switch
+        /// down while every Hide() threw into a per-window catch — cards left on screen, unclosable, and
+        /// silently so. All callers were UI-thread when this was written, but LockCardService.Stop is
+        /// now the funnel for panic and can be reached from anywhere. RunOnUISync executes inline when
+        /// already on the UI thread, so the common path is unchanged.
         /// </summary>
-        public static void ForceCloseAll() => DismissAll();
+        public static void ForceCloseAll() => Helpers.DispatcherHelper.RunOnUISync(DismissAll);
 
         private static void DismissAll()
         {

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -361,8 +361,12 @@ namespace ConditioningControlPanel
 
             // Handle strict mode
             TxtStrict.Text = _strictMode ? Loc.Get("label_strict") : "";
-            // Esc always works now (even in strict mode) so always show the hint.
-            TxtEscHint.Text = Loc.Get("label_press_esc_to_close");
+            // #875: promise only the exit this card actually honours. A strict card with the panic key
+            // live swallows Esc, so name the panic key instead of telling the user to press a key that
+            // will do nothing; every other case (non-strict, or strict with no panic key) keeps Esc.
+            TxtEscHint.Text = EscClosesCard
+                ? Loc.Get("label_press_esc_to_close")
+                : Loc.GetF("label_strict_only_panic_key_closes", App.Settings?.Current?.PanicKey ?? "?");
 
             // Position on screen
             if (screen != null)
@@ -604,13 +608,25 @@ namespace ConditioningControlPanel
             if (_voiceMode) StartVoiceSolve();
         }
 
+        /// <summary>
+        /// #875: does Esc close THIS card? Non-strict cards: yes, Esc is the ordinary dismiss. Strict
+        /// cards: only when the panic key is switched off, because then Esc is the sole remaining exit
+        /// and strict mode must never become an inescapable trap (<see cref="Models.AppSettings.CheckDangerousCombinations"/>
+        /// warns about that combination rather than making it real). Settings unreadable ⇒ treat the
+        /// panic key as gone and keep Esc live: the failure mode has to fall open, not shut.
+        /// </summary>
+        private bool EscClosesCard =>
+            !_strictMode || App.Settings?.Current?.PanicKeyEnabled != true;
+
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
-            // Esc always closes the lock card, even in strict mode. Strict mode used to
-            // block Esc but that left the panic key (often "1") as the only way out —
-            // and "1" can collide with mantra characters, so the user was effectively
-            // trapped. Esc is a dedicated exit that won't ever be part of a mantra.
-            if (e.Key == Key.Escape && !_isCompleted)
+            // Esc closes the card unless strict mode is on AND the panic key is live to cover it
+            // (see EscClosesCard). The unconditional close that the 55f872086 file split left here
+            // voided strict mode outright: any card, however strict, died to a single Esc. Strict now
+            // means "type it out, or panic out" — and Half 1 of #875 (LockCardService.Stop force-closing
+            // above its not-running guard) is what makes that panic key work for an ad-hoc card, so the
+            // two fixes must ship together or strict cards become unescapable.
+            if (e.Key == Key.Escape && !_isCompleted && EscClosesCard)
             {
                 App.Logger?.Information("Lock Card closed via ESC (strict={Strict})", _strictMode);
                 CloseAllWindows();
@@ -627,7 +643,8 @@ namespace ConditioningControlPanel
             // below ever fired for the case it was written for (#734). The real block is
             // TxtInput_PreviewKeyDown; this just covers keys pressed while the input doesn't have focus
             // (voice mode, mirrors). Do NOT move the Esc branch above into a preview handler: it is the
-            // deliberate always-available exit the dead-man's switch depends on.
+            // deliberate exit the dead-man's switch depends on, and it has to stay on the bubbling
+            // handler so nothing upstream can swallow it (#875 gates WHEN it fires, never WHERE).
             if (IsBlockedInputGesture(e.Key, Keyboard.Modifiers))
             {
                 e.Handled = true;


### PR DESCRIPTION
Fixes #875: ad-hoc lock cards ignored the ESC panic path, and strict mode could trap users.

- Panic closes cards even when the service thinks it is not running (ForceCloseAll above the guard, marshalled to the UI thread)
- Strict cards swallow Esc ONLY while the panic key is enabled AND the low-level hook is actually installed - a silently dead hook (the known #616-#623 failure) falls open
- An open lock card is answered at the top of the panic ladder, before the DtRH/FYP hand-offs that used to eat the press
- Stop(dismissOpenCards) narrowed: pause/feature-toggle/preset no longer nuke a live card mid-challenge; new strict-mode hint names the actual panic key (9 loc files)

Build 0 errors, tests 2411/2411.

Behavior change to play-test: with a card up during a session, panic now takes two presses (1 clears the card, 2 stops the engine). Known product hole left as-is: LockdownService forces panic-off, so a lockdown card stays Esc-closable (= old behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)