### PR TITLE
draft(sync): XP watermark (last-agreed) + read-before-write (#865, #879)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Login.cs
@@ -222,6 +222,13 @@ namespace ConditioningControlPanel
                 s.CurrentSeason = null;
                 s.PatreonTier = 0;
 
+                // This is the ONLY deliberate "yes, really zero me" surface in the app (logout,
+                // account switch, account deletion), so it is the one place allowed to void the
+                // server-confirmed XP watermark. Everything above just zeroed local progression;
+                // leaving the watermark standing would make the sync service refuse to push the
+                // new account's numbers as a regression of the old account's. (#865)
+                Services.ProfileSyncService.ClearXpWatermark(s, "explicit progression clear (logout / account switch)");
+
                 App.Settings.Save();
             }
 

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5060,6 +5060,47 @@ namespace ConditioningControlPanel.Models
             set { _highestLevelEver = Math.Max(0, value); OnPropertyChanged(); }
         }
 
+        #region Server-confirmed XP watermark (#865 regression guard)
+
+        // The highest CUMULATIVE XP the server itself has ever told us this account holds, and the
+        // season + account that figure belongs to. Written only from a server response — never from
+        // a local calculation — so it is a record of what the server agreed to, not of what this
+        // machine believes. ProfileSyncService uses it to refuse two things:
+        //   * SENDING a sync whose XP is below the watermark (a wiped local file must not talk the
+        //     server down to its own emptiness), and
+        //   * ADOPTING a response that zeroes a profile the server previously confirmed, unless the
+        //     user explicitly reset (logout/account switch) or the season legitimately rolled.
+        //
+        // Season-scoped because a season rollover lowers seasonal XP by design; an unscoped
+        // watermark would fight the rollover forever. Account-scoped because two accounts on one
+        // machine have nothing to say about each other.
+
+        private double _lastConfirmedServerXp = 0;
+        /// <summary>Highest cumulative XP the server has confirmed for <see cref="LastConfirmedServerXpAccount"/> during <see cref="LastConfirmedServerXpSeason"/>. 0 = no confirmation yet.</summary>
+        public double LastConfirmedServerXp
+        {
+            get => _lastConfirmedServerXp;
+            set { _lastConfirmedServerXp = Math.Max(0, value); OnPropertyChanged(); }
+        }
+
+        private string? _lastConfirmedServerXpAccount = null;
+        /// <summary>UnifiedId the watermark belongs to. A mismatch voids it (account switch).</summary>
+        public string? LastConfirmedServerXpAccount
+        {
+            get => _lastConfirmedServerXpAccount;
+            set { _lastConfirmedServerXpAccount = value; OnPropertyChanged(); }
+        }
+
+        private string? _lastConfirmedServerXpSeason = null;
+        /// <summary>Season key the watermark belongs to. A mismatch voids it (season rollover legitimately lowers XP).</summary>
+        public string? LastConfirmedServerXpSeason
+        {
+            get => _lastConfirmedServerXpSeason;
+            set { _lastConfirmedServerXpSeason = value; OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Season Recap (local-only, per-device)
 
         // The Season Recap Card surfaces a snapshot of the just-ended season at rollover.

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -93,12 +93,18 @@ namespace ConditioningControlPanel.Services
         /// purpose - an unscoped watermark would fight the rollover every launch, forever. Account
         /// scope matters because two accounts sharing a machine have nothing to say about each
         /// other's totals.
+        ///
+        /// V2 identities only. A legacy user has neither a unified_id nor a season key, so their
+        /// scope would be the pair ("", "") - which never changes, is therefore never voided by a
+        /// rollover, and is SHARED by every legacy account on the machine. See
+        /// <see cref="RecordAgreedServerXp"/> for why arming them was dropped rather than fixed.
         /// </summary>
         public static double ActiveXpWatermark(Models.AppSettings settings)
         {
             if (settings.LastConfirmedServerXp <= 0) return 0;
 
             var account = settings.UnifiedId ?? string.Empty;
+            if (account.Length == 0) return 0;   // legacy/V1 identity - out of scope entirely
             if (!string.Equals(settings.LastConfirmedServerXpAccount ?? string.Empty, account, StringComparison.Ordinal))
                 return 0;
 
@@ -110,58 +116,65 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Record what the server just told us it holds. Only ever called with a figure that came
-        /// out of a server response, never with a local calculation - the whole value of the
-        /// watermark is that it is the server's own word, so a corrupt local file cannot raise it.
-        /// Monotonic within an (account, season) pair; re-scoped rather than merged when either
-        /// changes.
+        /// Record the total this client and the server now AGREE on, for this (account, season).
+        ///
+        /// The watermark models the LAST AGREED figure, not "the highest the server ever said".
+        /// That distinction is the entire fix. The first draft only ever let the number rise, while
+        /// the send-guard enforced it as "the lowest the client may send" - two different things
+        /// wearing one field. So the moment a client legitimately adopted a LOWER server figure -
+        /// an anti-cheat correction, which is exactly what the clamp branch in
+        /// <see cref="SyncProfileAsync"/> does - the watermark stayed at the old high and every
+        /// subsequent sync failed the send-guard against it. Not just the XP: the guard sits before
+        /// the POST, so achievements, quests and cosmetics stopped going up too, "Cloud sync issue"
+        /// latched in the title bar, and because the watermark is persisted it survived restarts.
+        /// A guard that latches like that is worse than the regression it was written for.
+        ///
+        /// Setting it downward on agreement makes it self-healing: adopt, agree, carry on. It still
+        /// cannot be moved by a local calculation - every caller passes a figure that came out of a
+        /// server response - so a corrupted settings file still cannot talk it down.
+        ///
+        /// Agreement is decided here, once, rather than at each call site: we agree when this
+        /// client is NOT holding more than the server just reported. When it IS holding more it has
+        /// deliberately kept local (the clamp's defend branch, take-higher keeping a higher local),
+        /// which is a disagreement, and the previously agreed figure stands.
         /// </summary>
-        public static void RecordServerConfirmedXp(Models.AppSettings settings, double serverTotalXp)
+        /// <param name="serverTotalXp">Cumulative XP as the server just reported it.</param>
+        /// <param name="clientTotalXp">Cumulative XP this client holds AFTER reconciling.</param>
+        public static void RecordAgreedServerXp(Models.AppSettings settings, double serverTotalXp, double clientTotalXp, string site)
         {
             if (serverTotalXp < MeaningfulProgressXp) return;   // nothing worth defending
 
-            var account = settings.UnifiedId ?? string.Empty;
-            var season = settings.CurrentSeason ?? string.Empty;
-            var inScope = ActiveXpWatermark(settings) > 0;
-
-            if (!inScope)
+            // V1/legacy users get no watermark at all - see ActiveXpWatermark. Arming one for them
+            // would create an ("", "") scope with no rollover escape: their seasonal reset has no
+            // season key to notice, so the send-guard would block their pushes with nothing but a
+            // manual logout to clear it.
+            if (string.IsNullOrEmpty(settings.UnifiedId))
             {
-                settings.LastConfirmedServerXpAccount = account;
-                settings.LastConfirmedServerXpSeason = season;
-                settings.LastConfirmedServerXp = serverTotalXp;
-                App.Logger?.Debug("[XP watermark] set to {Xp} for account {Account} season {Season}", (int)serverTotalXp, account, season);
+                App.Logger?.Debug("[XP watermark] {Site}: not arming — legacy identity has no account/season scope", site);
                 return;
             }
 
-            if (serverTotalXp > settings.LastConfirmedServerXp)
+            if (clientTotalXp > serverTotalXp + 0.01)
             {
-                settings.LastConfirmedServerXp = serverTotalXp;
-                App.Logger?.Debug("[XP watermark] raised to {Xp}", (int)serverTotalXp);
+                App.Logger?.Debug("[XP watermark] {Site}: not recording {Sx} — this client kept a higher local total ({Cx}), so there is no agreement to record",
+                    site, (int)serverTotalXp, (int)clientTotalXp);
+                return;
             }
-        }
 
-        /// <summary>
-        /// Should we REFUSE to adopt a server profile because it would zero one the server itself
-        /// previously confirmed? Returns true (= refuse, and log loudly) only when all of:
-        /// a watermark is in scope for this account and season, and the incoming profile is empty
-        /// by <see cref="ServerProfileLooksUninitialized"/>.
-        ///
-        /// The escapes are deliberate and are all "the user, or an admin acting for them, asked for
-        /// this": a season rollover voids the watermark before the reset is applied (see the season
-        /// adopt in <see cref="SyncProfileAsync"/>), and logout/account-switch voids it in
-        /// MainWindow.ClearProgressionData. What is left is the case with no explanation at all -
-        /// the server handing back an empty record for an account it told us minutes ago was
-        /// Level 47 - and that is never something to write to disk.
-        /// </summary>
-        public static bool RefuseToZeroAConfirmedProfile(Models.AppSettings settings, int serverLevel, double serverTotalXp, string site)
-        {
-            var watermark = ActiveXpWatermark(settings);
-            if (watermark <= 0) return false;
-            if (!ServerProfileLooksUninitialized(serverLevel, serverTotalXp)) return false;
+            var account = settings.UnifiedId!;
+            var season = settings.CurrentSeason ?? string.Empty;
+            var previous = ActiveXpWatermark(settings);
 
-            App.Logger?.Error("[XP watermark] {Site} REFUSED — the server returned an empty profile (Level {SL}, {SX} XP) for an account it confirmed at {Watermark} XP this same season, and nothing has reset it. Keeping local (Level {LL}). If this is a real reset, it will arrive with a season rollover or the user can log out.",
-                site, serverLevel, (int)serverTotalXp, (int)watermark, settings.PlayerLevel);
-            return true;
+            settings.LastConfirmedServerXpAccount = account;
+            settings.LastConfirmedServerXpSeason = season;
+            settings.LastConfirmedServerXp = serverTotalXp;
+
+            if (previous > 0 && serverTotalXp < previous)
+                App.Logger?.Information("[XP watermark] {Site}: LOWERED {Old} -> {New} — this client adopted the server's figure, so that is what both sides now agree on. The send-guard follows it down.",
+                    site, (int)previous, (int)serverTotalXp);
+            else
+                App.Logger?.Debug("[XP watermark] {Site}: set to {Xp} for account {Account} season {Season}",
+                    site, (int)serverTotalXp, account, season);
         }
 
         /// <summary>
@@ -500,7 +513,12 @@ namespace ConditioningControlPanel.Services
                     // thought was true, which is precisely the wrong order when the local file is
                     // the thing that might be wrong (#865). Fetch the server's own copy first and
                     // adopt it (take-higher, so this can never LOWER a legitimate local), then push.
-                    await ReadServerProfileBeforePushAsync(unifiedId!);
+                    if (!await ReadServerProfileBeforePushAsync(unifiedId!) &&
+                        ShouldSkipPushAfterFailedRead(App.Settings?.Current))
+                    {
+                        App.Logger?.Warning("Load blocked — the server profile could not be read AND this local profile looks emptied with no watermark to defend the push. Not asserting it upward; retrying on the next sync.");
+                        return false;
+                    }
 
                     App.Logger?.Information("V2 user — pushing local state after the server read");
                     var v2Success = await SyncProfileAsync();
@@ -671,16 +689,67 @@ namespace ConditioningControlPanel.Services
         /// several down-merge paths on this side then reconcile TOWARD whatever came back.
         ///
         /// This does the GET first (<see cref="V2AuthService.GetUserProfileAsync"/>, no body, no
-        /// upload — it cannot change anything server-side) and adopts the result through the same
-        /// take-higher <see cref="V2AuthService.ApplyUserDataToSettings"/> the login path uses, so
-        /// it can raise a stale local profile but never lower a legitimate one. The push that
-        /// follows then starts from reconciled state.
+        /// upload — it cannot change anything server-side) and adopts the result take-higher, so it
+        /// can raise a stale local profile but never lower a legitimate one. The push that follows
+        /// then starts from reconciled state.
         ///
-        /// Deliberately NOT fatal: a failed read logs and returns false, and the caller pushes
-        /// anyway. Blocking the sync on an unreadable server would strand a user with a flaky
-        /// connection at zero cloud contact; the watermark guard in <see cref="SyncProfileAsync"/>
-        /// is what protects the push itself.
+        /// The adopt is written out here rather than reusing
+        /// <see cref="V2AuthService.ApplyUserDataToSettings"/>, which is a LOGIN-path routine and
+        /// unconditionally rewrites UnifiedId, UserDisplayName, IsSeason0Og, CurrentSeason,
+        /// HighestLevelEver, HasLinkedDiscord, HasLinkedPatreon and PatreonTier — and extends the
+        /// cached-premium window. Correct exactly once, at sign-in, against the login response.
+        /// Wrong on a path that runs on EVERY launch against a different, narrower projection:
+        /// - <c>display_name</c> is privacy-filtered by the server (nulled when it still equals the
+        ///   Patreon patron name), so this would blank UserDisplayName every launch for those users;
+        /// - the int fields on the DTO are non-nullable, so anything a future projection stops
+        ///   sending silently deserializes to 0 — HighestLevelEver=0 would manufacture a fresh #879
+        ///   and a missing unified_id would sign the user out;
+        /// - none of it is progression, which is the only thing this path has any business
+        ///   reconciling before a push.
+        ///
+        /// So: level/XP take-higher and the season key, nothing else. Identity, link state and tier
+        /// stay whatever sign-in and the sync response made them. (Verified against ccp-server
+        /// <c>proxy/server.js</c> GET /v2/user/profile: it does currently carry unified_id,
+        /// display_name, level, xp, current_season, highest_level_ever, is_season0_og, patreon_tier
+        /// and raw discord_id/patreon_id — but "currently carries" is not a contract this path
+        /// should be betting a user's identity on once per launch.)
+        ///
+        /// Deliberately NOT fatal in general: a failed read logs and returns false, and the caller
+        /// pushes anyway rather than stranding a flaky connection at zero cloud contact. The one
+        /// exception is the highest-risk shape — see the caller in <see cref="LoadProfileAsync"/>
+        /// and <see cref="ShouldSkipPushAfterFailedRead"/>.
         /// </summary>
+        /// <summary>
+        /// The read-before-write GET failed. Should we abort the push too, or push anyway? (#865, B-5)
+        ///
+        /// Push-anyway is the general policy and stays that way: a user on a flaky connection must
+        /// not be locked out of cloud sync entirely, and the send-guard already refuses any push
+        /// below the last agreed total. But that guard needs an ARMED watermark, and there is one
+        /// launch where it has none — the first launch after upgrading into this code. That is also
+        /// the single highest-risk launch: read failed, so we know nothing about the server, and if
+        /// the local file is the emptied one, pushing it is exactly the #865 overwrite the
+        /// read-before-write was added to prevent.
+        ///
+        /// So the abort is narrowed to that intersection: no watermark in scope AND local looks
+        /// like defaults. It matches <see cref="ReconcileRestoredProfileAsync"/>'s policy for the
+        /// same reason — an unverifiable local profile is not something to assert upward — and it
+        /// costs nothing, because a profile at Level 1 with under 100 XP has nothing to sync that
+        /// the next successful round-trip will not carry.
+        ///
+        /// Note this is a strictly wider net than the existing <c>!_hasLoadedProfile</c> defaults
+        /// guard inside <see cref="SyncProfileAsync"/>: that one disarms itself for the rest of the
+        /// session after any successful round-trip, whereas an emptied file with a failed read is
+        /// dangerous on every attempt.
+        /// </summary>
+        private static bool ShouldSkipPushAfterFailedRead(Models.AppSettings? settings)
+        {
+            if (settings == null) return false;
+            if (ActiveXpWatermark(settings) > 0) return false;   // the send-guard can defend the push
+
+            var localTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
+            return settings.PlayerLevel <= 1 && localTotalXp < MeaningfulProgressXp;
+        }
+
         private async Task<bool> ReadServerProfileBeforePushAsync(string unifiedId)
         {
             var settings = App.Settings?.Current;
@@ -700,29 +769,48 @@ namespace ConditioningControlPanel.Services
                 var preLevelXp = settings.PlayerXP;
                 var localTotalXp = App.Progression?.GetTotalXP(preLevel, preLevelXp) ?? preLevelXp;
 
-                // ApplyUserDataToSettings writes CurrentSeason unconditionally, which is fine on the
-                // login path it was written for but not here, where it runs every launch: a server
-                // that answers with a stale key would walk the season backwards and re-arm the
-                // recap. Adopt the key only when SeasonRecapService agrees it advanced; otherwise
-                // put ours back.
+                // The season key is the one non-progression field this path DOES touch, and only
+                // forward: a server answering with a stale key would otherwise walk the season
+                // backwards and re-arm the recap every launch.
                 var keepSeason = settings.CurrentSeason;
                 var seasonAdvances = Services.SeasonRecapService.ShouldAdoptServerSeason(user.CurrentSeason, keepSeason);
 
-                v2Auth.ApplyUserDataToSettings(user);   // take-higher on level/XP; saves internally
-
-                if (!seasonAdvances && !string.Equals(settings.CurrentSeason, keepSeason, StringComparison.Ordinal))
+                // Take-higher on level/XP, and nothing else — see the summary above for why this
+                // no longer routes through V2AuthService.ApplyUserDataToSettings.
+                var serverTotalXp = (double)user.Xp;
+                if (user.Level > 0 && serverTotalXp >= localTotalXp)
                 {
-                    settings.CurrentSeason = keepSeason;
+                    settings.PlayerLevel = user.Level;
+                    settings.PlayerXP = App.Progression?.GetCurrentLevelXP(user.Level, serverTotalXp) ?? 0;
                 }
-                else if (seasonAdvances)
+
+                if (seasonAdvances)
                 {
                     App.Logger?.Information("Read-before-write: season key advanced {Old} -> {New}",
                         string.IsNullOrEmpty(keepSeason) ? "(none)" : keepSeason, user.CurrentSeason);
+                    settings.CurrentSeason = user.CurrentSeason;
                     ClearXpWatermark(settings, "season rollover (read-before-write)");
                     NudgeSeasonRecap();
                 }
 
-                RecordServerConfirmedXp(settings, user.Xp);
+                // B-7: only record the watermark when the server's season is the one it will later
+                // be CHECKED under. When the server answers with an OLDER key we keep ours (above),
+                // so filing the server's total against our key would scope a foreign season's total
+                // to this one — and the send-guard would then measure this season's XP against last
+                // season's total.
+                var scopedSeason = settings.CurrentSeason ?? string.Empty;
+                if (string.Equals(user.CurrentSeason ?? string.Empty, scopedSeason, StringComparison.Ordinal))
+                {
+                    var clientTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
+                    RecordAgreedServerXp(settings, serverTotalXp, clientTotalXp, "read-before-write");
+                }
+                else
+                {
+                    App.Logger?.Debug("Read-before-write: server season {SS} is not the scope we sync under ({LS}) — not recording a watermark",
+                        string.IsNullOrEmpty(user.CurrentSeason) ? "(none)" : user.CurrentSeason,
+                        string.IsNullOrEmpty(scopedSeason) ? "(none)" : scopedSeason);
+                }
+
                 App.Settings?.Save();
 
                 var adopted = settings.PlayerLevel != preLevel || Math.Abs(settings.PlayerXP - preLevelXp) > 0.01;
@@ -1033,17 +1121,24 @@ namespace ConditioningControlPanel.Services
                 // local looks like a FRESH install and we have not loaded yet. It says nothing
                 // about a local file that lost half its progress, or about the second sync of a
                 // session after a bad adopt — both of which would happily push a lower number and
-                // ask the server to agree. The watermark is the server's own last word on this
-                // account this season, so a payload below it cannot be right: refuse to send and
-                // say so loudly rather than talking the server down to a local mistake. Voided
-                // automatically on account switch and season rollover, so legitimate resets are
-                // untouched.
+                // ask the server to agree. The watermark is the last total the two sides AGREED
+                // on, so a payload below it cannot be right: refuse to send and say so loudly
+                // rather than talking the server down to a local mistake.
+                //
+                // "Last agreed", not "highest ever seen", is what makes this survivable. Every
+                // legitimate way for the number to fall moves the watermark with it: a season
+                // rollover and an admin level_reset clear it outright, an account switch puts it
+                // out of scope, and any adopt of a lower server figure re-records at that figure
+                // (RecordAgreedServerXp). So the guard can only ever block the one case it is for
+                // — a local total that fell with no server-side explanation — and it cannot latch,
+                // which matters because this check sits in front of the whole payload, not just
+                // the XP field.
                 var watermark = ActiveXpWatermark(settings);
                 if (watermark > 0 && totalXp < watermark)
                 {
-                    App.Logger?.Error("[XP watermark] Sync REFUSED — would push {Xp} XP, below the {Watermark} XP the server last confirmed for this account this season (Level {Level}). This local profile has LOST progress; not asking the server to match it. Fix the local file or reset the account deliberately.",
+                    App.Logger?.Error("[XP watermark] Sync REFUSED — would push {Xp} XP, below the {Watermark} XP this client and the server last agreed on for this account this season (Level {Level}). This local profile has LOST progress; not asking the server to match it. Fix the local file or reset the account deliberately.",
                         (int)totalXp, (int)watermark, settings.PlayerLevel);
-                    LastSyncError = "Sync refused: local XP is below the last server-confirmed total";
+                    LastSyncError = "Sync refused: local XP is below the last server-agreed total";
                     return false;
                 }
 
@@ -1426,10 +1521,37 @@ namespace ConditioningControlPanel.Services
                             NudgeSeasonRecap();
                         }
 
-                        // Handle level_reset — server admin reset all levels, force client to accept
-                        if (v2Result?.LevelReset == true && v2Result.User != null &&
-                            !RefuseToZeroAConfirmedProfile(settings, v2Result.User.Level, v2Result.User.Xp, "level_reset"))
+                        // Handle level_reset — server admin reset all levels, force client to accept.
+                        //
+                        // This condition used to also call !RefuseToZeroAConfirmedProfile(...), a
+                        // side-effecting check inlined into the `if`. Two things went wrong with
+                        // that. First, a mid-season admin reset IS a zeroing of a confirmed profile
+                        // — that is what an admin reset is — so the guard refused it, and refused
+                        // it permanently, because level_reset is one-shot: the server never sends it
+                        // again. Second, a refusal did not stop there; it fell through into the
+                        // `else if` clamp chain below, where the same zeroed row reads as
+                        // "uninitialized", local is kept, and the next push writes the pre-reset
+                        // profile back over the admin's work.
+                        //
+                        // An explicit level_reset is the server EXPLAINING the zeroing, which is
+                        // precisely what the watermark guard exists to distinguish from an
+                        // unexplained one. So it is adopted unconditionally and the watermark is
+                        // cleared to match (#865, B-2). No spoof guard is kept: forging this flag
+                        // means forging an authenticated sync response, and anyone who can do that
+                        // can set `xp` to whatever they like in the same body — the guard bought
+                        // nothing and cost a permanent, silent divergence from the server.
+                        //
+                        // What is left in this condition is a flag test and a null check — nothing
+                        // that can DECIDE anything. Any future guard belongs in an explicit
+                        // if/else INSIDE the branch, where a refusal stays a refusal instead of
+                        // falling through into the clamp chain below.
+                        if (v2Result?.LevelReset == true && v2Result.User != null)
                         {
+                            // A reset is a licensed fall: the previously agreed total no longer
+                            // describes this account. Clear before adopting so the send-guard does
+                            // not block the very push that carries the reset upward.
+                            ClearXpWatermark(settings, "admin level_reset");
+
                             var serverLevel = v2Result.User.Level;
                             var serverXp = v2Result.User.Xp;
                             var serverLevelXp = App.Progression?.GetCurrentLevelXP(serverLevel, serverXp) ?? 0;
@@ -1531,13 +1653,23 @@ namespace ConditioningControlPanel.Services
                             }
                         }
 
-                        // Last, once the season key and any reset above have settled: remember what
-                        // the server said it holds. This response is the server's own account of
-                        // this account, which is exactly what the watermark is for — a figure a
-                        // corrupted local file cannot manufacture. (#865)
+                        // Last, once the season key and every adopt above have settled: record what
+                        // the two sides now agree this account holds. The response is the server's
+                        // own account of it, which is what makes the watermark worth anything — a
+                        // corrupted local file cannot manufacture the figure. (#865)
+                        //
+                        // Passing the client's POST-reconcile total is what makes this "last
+                        // agreed" rather than "highest ever": where a branch above adopted the
+                        // server's number the two match and the watermark follows it, DOWN as well
+                        // as up (the anti-cheat clamp is the case that matters — the old monotonic
+                        // rule latched there and blocked every later sync). Where a branch above
+                        // deliberately KEPT a higher local — the clamp's defend branch — the totals
+                        // differ, RecordAgreedServerXp sees the disagreement and leaves the
+                        // previously agreed figure standing.
                         if (v2Result?.User != null)
                         {
-                            RecordServerConfirmedXp(settings, v2Result.User.Xp);
+                            var agreedClientXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
+                            RecordAgreedServerXp(settings, v2Result.User.Xp, agreedClientXp, "V2 sync");
                             App.Settings?.Save();
                         }
                     }
@@ -1784,10 +1916,6 @@ namespace ConditioningControlPanel.Services
             var localTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
             var cloudTotalXp = (double)cloudProfile.Xp;
 
-            // The cloud just told us what it holds — that is a server-confirmed figure, so it sets
-            // the XP watermark for this account/season the same way a V2 sync response does (#865).
-            RecordServerConfirmedXp(settings, cloudTotalXp);
-
             // Cloud is authoritative on startup. Allow a small grace delta for unsynced
             // progress from a crash, but reject suspiciously large local values (file edits).
             const double MAX_STARTUP_DELTA = 50000; // Max XP above cloud we trust from local
@@ -1821,8 +1949,8 @@ namespace ConditioningControlPanel.Services
                 // carries, because a row emptied to Level 1 / 150 XP would otherwise sail past the
                 // 100 XP floor and reset a Level 40 local every launch anyway. See
                 // ServerProfileTooEmptyToClampTo.
-                // (The watermark guard adds nothing here: RefuseToZeroAConfirmedProfile fires on a
-                // strict subset of what this predicate already covers, so V1 is defended either way.)
+                // (The watermark adds nothing here anyway: it is a V2-only mechanism, and this
+                // predicate already covers every empty-row shape it would have caught.)
                 bool looksUninitialized =
                     ServerProfileTooEmptyToClampTo(cloudProfile.Level);
 
@@ -1863,6 +1991,19 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("Local and cloud progress are equal: Level {Level}, Total XP {XP}",
                     settings.PlayerLevel, (int)localTotalXp);
             }
+
+            // The cloud just told us what it holds. Record it as the agreed figure — AFTER the
+            // branches above, so the client total passed in is the post-merge one and
+            // RecordAgreedServerXp can tell an adopt from a "kept local" (#865).
+            //
+            // B-4: this arms nothing for an actual V1/legacy user. They have no unified_id and no
+            // season key, so their scope would be ("", "") — never invalidated by a rollover,
+            // shared with every other legacy account on the machine, and with no escape but a
+            // manual logout if the send-guard ever caught them. RecordAgreedServerXp refuses them
+            // outright. The call stays because this method is also the V1 FALLBACK for a V2
+            // identity, and that user does have a scope worth arming.
+            var mergedClientTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
+            RecordAgreedServerXp(settings, cloudTotalXp, mergedClientTotalXp, "V1 merge");
 
             // Merge achievements
             if (cloudProfile.Achievements != null && achievements?.Progress != null)

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -83,6 +83,106 @@ namespace ConditioningControlPanel.Services
         public static bool ServerProfileTooEmptyToClampTo(int serverLevel)
             => serverLevel <= 1;
 
+        #region Server-confirmed XP watermark (#865 regression guard)
+
+        /// <summary>
+        /// The watermark that currently applies, or 0 when none does.
+        ///
+        /// A stored watermark only counts when it belongs to BOTH the account we are syncing and
+        /// the season we are in. Season scope matters because a rollover lowers seasonal XP on
+        /// purpose - an unscoped watermark would fight the rollover every launch, forever. Account
+        /// scope matters because two accounts sharing a machine have nothing to say about each
+        /// other's totals.
+        /// </summary>
+        public static double ActiveXpWatermark(Models.AppSettings settings)
+        {
+            if (settings.LastConfirmedServerXp <= 0) return 0;
+
+            var account = settings.UnifiedId ?? string.Empty;
+            if (!string.Equals(settings.LastConfirmedServerXpAccount ?? string.Empty, account, StringComparison.Ordinal))
+                return 0;
+
+            var season = settings.CurrentSeason ?? string.Empty;
+            if (!string.Equals(settings.LastConfirmedServerXpSeason ?? string.Empty, season, StringComparison.Ordinal))
+                return 0;
+
+            return settings.LastConfirmedServerXp;
+        }
+
+        /// <summary>
+        /// Record what the server just told us it holds. Only ever called with a figure that came
+        /// out of a server response, never with a local calculation - the whole value of the
+        /// watermark is that it is the server's own word, so a corrupt local file cannot raise it.
+        /// Monotonic within an (account, season) pair; re-scoped rather than merged when either
+        /// changes.
+        /// </summary>
+        public static void RecordServerConfirmedXp(Models.AppSettings settings, double serverTotalXp)
+        {
+            if (serverTotalXp < MeaningfulProgressXp) return;   // nothing worth defending
+
+            var account = settings.UnifiedId ?? string.Empty;
+            var season = settings.CurrentSeason ?? string.Empty;
+            var inScope = ActiveXpWatermark(settings) > 0;
+
+            if (!inScope)
+            {
+                settings.LastConfirmedServerXpAccount = account;
+                settings.LastConfirmedServerXpSeason = season;
+                settings.LastConfirmedServerXp = serverTotalXp;
+                App.Logger?.Debug("[XP watermark] set to {Xp} for account {Account} season {Season}", (int)serverTotalXp, account, season);
+                return;
+            }
+
+            if (serverTotalXp > settings.LastConfirmedServerXp)
+            {
+                settings.LastConfirmedServerXp = serverTotalXp;
+                App.Logger?.Debug("[XP watermark] raised to {Xp}", (int)serverTotalXp);
+            }
+        }
+
+        /// <summary>
+        /// Should we REFUSE to adopt a server profile because it would zero one the server itself
+        /// previously confirmed? Returns true (= refuse, and log loudly) only when all of:
+        /// a watermark is in scope for this account and season, and the incoming profile is empty
+        /// by <see cref="ServerProfileLooksUninitialized"/>.
+        ///
+        /// The escapes are deliberate and are all "the user, or an admin acting for them, asked for
+        /// this": a season rollover voids the watermark before the reset is applied (see the season
+        /// adopt in <see cref="SyncProfileAsync"/>), and logout/account-switch voids it in
+        /// MainWindow.ClearProgressionData. What is left is the case with no explanation at all -
+        /// the server handing back an empty record for an account it told us minutes ago was
+        /// Level 47 - and that is never something to write to disk.
+        /// </summary>
+        public static bool RefuseToZeroAConfirmedProfile(Models.AppSettings settings, int serverLevel, double serverTotalXp, string site)
+        {
+            var watermark = ActiveXpWatermark(settings);
+            if (watermark <= 0) return false;
+            if (!ServerProfileLooksUninitialized(serverLevel, serverTotalXp)) return false;
+
+            App.Logger?.Error("[XP watermark] {Site} REFUSED — the server returned an empty profile (Level {SL}, {SX} XP) for an account it confirmed at {Watermark} XP this same season, and nothing has reset it. Keeping local (Level {LL}). If this is a real reset, it will arrive with a season rollover or the user can log out.",
+                site, serverLevel, (int)serverTotalXp, (int)watermark, settings.PlayerLevel);
+            return true;
+        }
+
+        /// <summary>
+        /// Void the watermark. Called when the account's XP is legitimately allowed to fall: a
+        /// season rollover or an explicit logout/account switch (MainWindow.ClearProgressionData).
+        /// Without this the guard would block the very resets it is supposed to let through.
+        /// </summary>
+        public static void ClearXpWatermark(Models.AppSettings? settings, string reason)
+        {
+            if (settings == null) return;
+            if (settings.LastConfirmedServerXp <= 0 && settings.LastConfirmedServerXpAccount == null) return;
+
+            App.Logger?.Information("[XP watermark] cleared ({Reason}) - was {Xp} for season {Season}",
+                reason, (int)settings.LastConfirmedServerXp, settings.LastConfirmedServerXpSeason ?? "(none)");
+            settings.LastConfirmedServerXp = 0;
+            settings.LastConfirmedServerXpAccount = null;
+            settings.LastConfirmedServerXpSeason = null;
+        }
+
+        #endregion
+
         private readonly HttpClient _httpClient;
         private DispatcherTimer? _heartbeatTimer;
         private bool _disposed;
@@ -831,6 +931,24 @@ namespace ConditioningControlPanel.Services
                     return false;
                 }
 
+                // XP regression guard (#865). The defaults-guard above only covers the case where
+                // local looks like a FRESH install and we have not loaded yet. It says nothing
+                // about a local file that lost half its progress, or about the second sync of a
+                // session after a bad adopt — both of which would happily push a lower number and
+                // ask the server to agree. The watermark is the server's own last word on this
+                // account this season, so a payload below it cannot be right: refuse to send and
+                // say so loudly rather than talking the server down to a local mistake. Voided
+                // automatically on account switch and season rollover, so legitimate resets are
+                // untouched.
+                var watermark = ActiveXpWatermark(settings);
+                if (watermark > 0 && totalXp < watermark)
+                {
+                    App.Logger?.Error("[XP watermark] Sync REFUSED — would push {Xp} XP, below the {Watermark} XP the server last confirmed for this account this season (Level {Level}). This local profile has LOST progress; not asking the server to match it. Fix the local file or reset the account deliberately.",
+                        (int)totalXp, (int)watermark, settings.PlayerLevel);
+                    LastSyncError = "Sync refused: local XP is below the last server-confirmed total";
+                    return false;
+                }
+
                 App.Logger?.Information("Syncing profile - Level: {Level}, TotalXP: {Xp}, VideoMinutes: {VideoMin:F1}, LockCards: {LockCards}",
                     settings.PlayerLevel,
                     (int)totalXp,
@@ -1196,6 +1314,11 @@ namespace ConditioningControlPanel.Services
                             App.Logger?.Information("V2 Sync: season key advanced {Old} -> {New} (server-authoritative)",
                                 string.IsNullOrEmpty(settings.CurrentSeason) ? "(none)" : settings.CurrentSeason, serverSeason);
                             settings.CurrentSeason = serverSeason;
+
+                            // A rollover is the one moment seasonal XP is SUPPOSED to fall, so the
+                            // previous season's watermark stops applying here — before the
+                            // level_reset handler below, which is the thing that does the falling.
+                            ClearXpWatermark(settings, "season rollover");
                             App.Settings?.Save();
 
                             // Nudge the recap on the key change itself, not only on level_reset.
@@ -1206,7 +1329,8 @@ namespace ConditioningControlPanel.Services
                         }
 
                         // Handle level_reset — server admin reset all levels, force client to accept
-                        if (v2Result?.LevelReset == true && v2Result.User != null)
+                        if (v2Result?.LevelReset == true && v2Result.User != null &&
+                            !RefuseToZeroAConfirmedProfile(settings, v2Result.User.Level, v2Result.User.Xp, "level_reset"))
                         {
                             var serverLevel = v2Result.User.Level;
                             var serverXp = v2Result.User.Xp;
@@ -1307,6 +1431,16 @@ namespace ConditioningControlPanel.Services
                                     App.Settings?.Save();
                                 }
                             }
+                        }
+
+                        // Last, once the season key and any reset above have settled: remember what
+                        // the server said it holds. This response is the server's own account of
+                        // this account, which is exactly what the watermark is for — a figure a
+                        // corrupted local file cannot manufacture. (#865)
+                        if (v2Result?.User != null)
+                        {
+                            RecordServerConfirmedXp(settings, v2Result.User.Xp);
+                            App.Settings?.Save();
                         }
                     }
                     catch (Exception parseEx)
@@ -1552,6 +1686,10 @@ namespace ConditioningControlPanel.Services
             var localTotalXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
             var cloudTotalXp = (double)cloudProfile.Xp;
 
+            // The cloud just told us what it holds — that is a server-confirmed figure, so it sets
+            // the XP watermark for this account/season the same way a V2 sync response does (#865).
+            RecordServerConfirmedXp(settings, cloudTotalXp);
+
             // Cloud is authoritative on startup. Allow a small grace delta for unsynced
             // progress from a crash, but reject suspiciously large local values (file edits).
             const double MAX_STARTUP_DELTA = 50000; // Max XP above cloud we trust from local
@@ -1585,6 +1723,8 @@ namespace ConditioningControlPanel.Services
                 // carries, because a row emptied to Level 1 / 150 XP would otherwise sail past the
                 // 100 XP floor and reset a Level 40 local every launch anyway. See
                 // ServerProfileTooEmptyToClampTo.
+                // (The watermark guard adds nothing here: RefuseToZeroAConfirmedProfile fires on a
+                // strict subset of what this predicate already covers, so V1 is defended either way.)
                 bool looksUninitialized =
                     ServerProfileTooEmptyToClampTo(cloudProfile.Level);
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -494,7 +494,15 @@ namespace ConditioningControlPanel.Services
                 var unifiedId = App.Settings?.Current?.UnifiedId;
                 if (!string.IsNullOrEmpty(unifiedId))
                 {
-                    App.Logger?.Information("V2 user — loading profile via V2 sync path");
+                    // READ BEFORE WRITE. SyncProfileAsync is a POST: it uploads local state and
+                    // only then reads the merged result back out of the response. That made LOAD a
+                    // write — the first thing a machine did on launch was tell the server what it
+                    // thought was true, which is precisely the wrong order when the local file is
+                    // the thing that might be wrong (#865). Fetch the server's own copy first and
+                    // adopt it (take-higher, so this can never LOWER a legitimate local), then push.
+                    await ReadServerProfileBeforePushAsync(unifiedId!);
+
+                    App.Logger?.Information("V2 user — pushing local state after the server read");
                     var v2Success = await SyncProfileAsync();
                     if (v2Success)
                     {
@@ -651,6 +659,96 @@ namespace ConditioningControlPanel.Services
         /// for any failure of the V2 sync — it no-ops when local already has progress or the
         /// server record is itself empty.
         /// </summary>
+        /// <summary>
+        /// READ-BEFORE-WRITE for the V2 load path (#865).
+        ///
+        /// <see cref="LoadProfileAsync"/> used to "load" a V2 profile by calling
+        /// <see cref="SyncProfileAsync"/>, which is a POST: local state went UP first and the
+        /// server's answer was only read out of the response afterwards. So the opening move of
+        /// every launch was an assertion, made by the party least entitled to make it — a settings
+        /// file that a crashed update, a half-restored backup or a corrupt write may have emptied.
+        /// The server's take-higher merge absorbs most of that, but "most" is not a guarantee, and
+        /// several down-merge paths on this side then reconcile TOWARD whatever came back.
+        ///
+        /// This does the GET first (<see cref="V2AuthService.GetUserProfileAsync"/>, no body, no
+        /// upload — it cannot change anything server-side) and adopts the result through the same
+        /// take-higher <see cref="V2AuthService.ApplyUserDataToSettings"/> the login path uses, so
+        /// it can raise a stale local profile but never lower a legitimate one. The push that
+        /// follows then starts from reconciled state.
+        ///
+        /// Deliberately NOT fatal: a failed read logs and returns false, and the caller pushes
+        /// anyway. Blocking the sync on an unreadable server would strand a user with a flaky
+        /// connection at zero cloud contact; the watermark guard in <see cref="SyncProfileAsync"/>
+        /// is what protects the push itself.
+        /// </summary>
+        private async Task<bool> ReadServerProfileBeforePushAsync(string unifiedId)
+        {
+            var settings = App.Settings?.Current;
+            if (settings == null || string.IsNullOrEmpty(unifiedId)) return false;
+
+            try
+            {
+                var v2Auth = new V2AuthService();
+                var user = await v2Auth.GetUserProfileAsync(unifiedId);
+                if (user == null)
+                {
+                    App.Logger?.Warning("Read-before-write: server profile could not be read for {Id} — pushing local state unreconciled (the XP watermark still guards it).", unifiedId);
+                    return false;
+                }
+
+                var preLevel = settings.PlayerLevel;
+                var preLevelXp = settings.PlayerXP;
+                var localTotalXp = App.Progression?.GetTotalXP(preLevel, preLevelXp) ?? preLevelXp;
+
+                // ApplyUserDataToSettings writes CurrentSeason unconditionally, which is fine on the
+                // login path it was written for but not here, where it runs every launch: a server
+                // that answers with a stale key would walk the season backwards and re-arm the
+                // recap. Adopt the key only when SeasonRecapService agrees it advanced; otherwise
+                // put ours back.
+                var keepSeason = settings.CurrentSeason;
+                var seasonAdvances = Services.SeasonRecapService.ShouldAdoptServerSeason(user.CurrentSeason, keepSeason);
+
+                v2Auth.ApplyUserDataToSettings(user);   // take-higher on level/XP; saves internally
+
+                if (!seasonAdvances && !string.Equals(settings.CurrentSeason, keepSeason, StringComparison.Ordinal))
+                {
+                    settings.CurrentSeason = keepSeason;
+                }
+                else if (seasonAdvances)
+                {
+                    App.Logger?.Information("Read-before-write: season key advanced {Old} -> {New}",
+                        string.IsNullOrEmpty(keepSeason) ? "(none)" : keepSeason, user.CurrentSeason);
+                    ClearXpWatermark(settings, "season rollover (read-before-write)");
+                    NudgeSeasonRecap();
+                }
+
+                RecordServerConfirmedXp(settings, user.Xp);
+                App.Settings?.Save();
+
+                var adopted = settings.PlayerLevel != preLevel || Math.Abs(settings.PlayerXP - preLevelXp) > 0.01;
+                if (adopted)
+                {
+                    App.Logger?.Information("Read-before-write: adopted the server profile BEFORE pushing — Level {LL} ({LX} XP) -> Level {SL} ({SX} XP).",
+                        preLevel, (int)localTotalXp, settings.PlayerLevel, user.Xp);
+                    // The header is written imperatively; without this it shows the pre-adopt
+                    // numbers until something else happens to repaint it (#879).
+                    RaiseProfileLoadedIfProgressionChanged(settings, preLevel, preLevelXp, "read-before-write");
+                }
+                else
+                {
+                    App.Logger?.Debug("Read-before-write: server profile (Level {SL}, {SX} XP) is not ahead of local (Level {LL}, {LX} XP) — nothing to adopt.",
+                        user.Level, user.Xp, preLevel, (int)localTotalXp);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Read-before-write: server profile read failed — pushing local state unreconciled");
+                return false;
+            }
+        }
+
         private async Task<bool> TryHealDefaultsFromServerAsync(string unifiedId)
         {
             var settings = App.Settings?.Current;

--- a/Tests/ConditioningControlPanel.Tests/ProfileSyncXpWatermarkTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProfileSyncXpWatermarkTests.cs
@@ -7,35 +7,45 @@ namespace ConditioningControlPanel.Tests;
 /// <summary>
 /// #865 - the XP regression watermark (DRAFT, pending owner review).
 ///
-/// The watermark is the highest cumulative XP the SERVER itself has confirmed for an account, and
-/// it is written only from a server response - never from a local calculation. That is the whole
-/// point: a settings file emptied by a crashed update cannot raise it, so it survives as evidence
-/// of what the account really held. ProfileSyncService then refuses to push a total below it, and
-/// refuses to adopt a response that zeroes a profile the watermark says was real.
+/// The watermark is the last cumulative total this CLIENT and the SERVER agreed on for an account
+/// in a season. ProfileSyncService refuses to push a total below it, on the grounds that a local
+/// file which fell below a figure both sides accepted has lost progress rather than learnt
+/// something. It is only ever written from a server response, never from a local calculation, so a
+/// settings file emptied by a crashed update cannot move it.
 ///
-/// It is scoped to (account, season) because both of those legitimately lower XP: a season
-/// rollover resets seasonal progress by design, and a different account's totals are unrelated.
-/// Most of these tests are about that scoping, because a watermark that outlives its scope blocks
-/// the very resets it must let through - a worse failure than the bug it fixes.
+/// "Last AGREED", not "highest ever reported", is the load-bearing part and the reason this file
+/// was rewritten. The first draft only let the number rise while the send-guard enforced it as the
+/// floor for outgoing pushes - two different meanings in one field. The moment a client
+/// legitimately adopted a LOWER server figure (an anti-cheat clamp, which the sync path does on
+/// purpose) the watermark stayed at the old high and every later sync failed against it. And
+/// because the send-guard sits in front of the POST, that blocked the whole payload - achievements,
+/// quests, cosmetics - pinned "Cloud sync issue" in the title bar, and survived restarts. A latched
+/// guard is worse than the regression it was written for, so agreement now moves the number in both
+/// directions and the guard self-heals.
+///
+/// The scoping tests carry the same weight for the same reason: a watermark that outlives its
+/// (account, season) scope blocks the resets it must let through.
 /// </summary>
 public class ProfileSyncXpWatermarkTests
 {
     private const string Account = "acct-1";
     private const string Season = "2026-08";
 
-    private static AppSettings Confirmed(double xp, string account = Account, string season = Season)
+    /// <summary>Arm the watermark by agreeing with the server at <paramref name="xp"/>.</summary>
+    private static AppSettings Agreed(double xp, string account = Account, string season = Season)
     {
         var s = new AppSettings { UnifiedId = account, CurrentSeason = season };
-        ProfileSyncService.RecordServerConfirmedXp(s, xp);
+        // clientTotalXp == serverTotalXp: the client adopted, so the two agree.
+        ProfileSyncService.RecordAgreedServerXp(s, xp, xp, "test");
         return s;
     }
 
     // ---- recording ------------------------------------------------------------------------
 
     [Fact]
-    public void AServerConfirmationArmsTheWatermarkInTheCurrentScope()
+    public void AgreeingWithTheServerArmsTheWatermarkInTheCurrentScope()
     {
-        var s = Confirmed(250_000);
+        var s = Agreed(250_000);
 
         Assert.Equal(250_000, ProfileSyncService.ActiveXpWatermark(s));
         Assert.Equal(Account, s.LastConfirmedServerXpAccount);
@@ -43,17 +53,30 @@ public class ProfileSyncXpWatermarkTests
     }
 
     [Fact]
-    public void TheWatermarkOnlyEverRisesWithinAScope()
+    public void AgreementMovesTheWatermarkDownAsWellAsUp()
     {
-        var s = Confirmed(250_000);
+        // THE fix. The old rule refused to lower the figure, so an adopted anti-cheat correction
+        // left a floor the client could never reach again.
+        var s = Agreed(250_000);
 
-        // A later response reporting less (mid-season server hiccup, partial read) must not talk
-        // the high-water mark down - that would let the regression it guards against back in.
-        ProfileSyncService.RecordServerConfirmedXp(s, 10_000);
-        Assert.Equal(250_000, ProfileSyncService.ActiveXpWatermark(s));
+        ProfileSyncService.RecordAgreedServerXp(s, 120_000, 120_000, "clamp adopt");
+        Assert.Equal(120_000, ProfileSyncService.ActiveXpWatermark(s));
 
-        ProfileSyncService.RecordServerConfirmedXp(s, 400_000);
+        ProfileSyncService.RecordAgreedServerXp(s, 400_000, 400_000, "server ahead");
         Assert.Equal(400_000, ProfileSyncService.ActiveXpWatermark(s));
+    }
+
+    [Fact]
+    public void KeepingAHigherLocalIsNotAgreementAndLeavesTheWatermarkAlone()
+    {
+        // The clamp's DEFEND branch and take-higher both end with the client holding more than the
+        // server reported. That is a disagreement: the previously agreed figure still stands, and
+        // an emptied server row cannot disarm the guard by being read.
+        var s = Agreed(250_000);
+
+        ProfileSyncService.RecordAgreedServerXp(s, 150, clientTotalXp: 250_000, "defended");
+
+        Assert.Equal(250_000, ProfileSyncService.ActiveXpWatermark(s));
     }
 
     [Fact]
@@ -63,7 +86,7 @@ public class ProfileSyncXpWatermarkTests
         // brand-new account's first sync would only create false positives.
         var s = new AppSettings { UnifiedId = Account, CurrentSeason = Season };
 
-        ProfileSyncService.RecordServerConfirmedXp(s, ProfileSyncService.MeaningfulProgressXp - 1);
+        ProfileSyncService.RecordAgreedServerXp(s, ProfileSyncService.MeaningfulProgressXp - 1, 0, "test");
 
         Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
     }
@@ -72,7 +95,7 @@ public class ProfileSyncXpWatermarkTests
     public void AFreshInstallCarriesNoWatermark()
     {
         // Every existing install upgrades into this state, so the guard starts disarmed and only
-        // arms once a server response has actually confirmed something.
+        // arms once a server response has actually been agreed with.
         var s = new AppSettings();
 
         Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
@@ -80,12 +103,42 @@ public class ProfileSyncXpWatermarkTests
         Assert.Null(s.LastConfirmedServerXpSeason);
     }
 
+    // ---- the send-guard scenario this all exists for ---------------------------------------
+
+    [Fact]
+    public void ADownwardAdoptLeavesTheNextPushAbleToSend()
+    {
+        // End-to-end shape of the bug, in the terms the send-guard checks:
+        // agree at 250k -> the server clamps us to 120k and we adopt -> the next sync wants to
+        // push 120k. Under the old monotonic rule the watermark was still 250k and that push (and
+        // every push after it, forever, carrying the entire payload) was refused.
+        var s = Agreed(250_000);
+
+        ProfileSyncService.RecordAgreedServerXp(s, 120_000, 120_000, "anti-cheat clamp");
+
+        var wouldPush = 120_000d;
+        var watermark = ProfileSyncService.ActiveXpWatermark(s);
+        Assert.False(watermark > 0 && wouldPush < watermark);
+    }
+
+    [Fact]
+    public void ALocalProfileThatLostProgressIsStillRefused()
+    {
+        // The guard must still do its job: nothing agreed the total down, the local file simply
+        // fell. That push stays blocked.
+        var s = Agreed(250_000);
+
+        var wouldPush = 4_000d;
+        var watermark = ProfileSyncService.ActiveXpWatermark(s);
+        Assert.True(watermark > 0 && wouldPush < watermark);
+    }
+
     // ---- scoping --------------------------------------------------------------------------
 
     [Fact]
     public void ASeasonRolloverPutsTheWatermarkOutOfScope()
     {
-        var s = Confirmed(250_000);
+        var s = Agreed(250_000);
 
         s.CurrentSeason = "2026-09";
 
@@ -97,7 +150,7 @@ public class ProfileSyncXpWatermarkTests
     [Fact]
     public void AnAccountSwitchPutsTheWatermarkOutOfScope()
     {
-        var s = Confirmed(250_000);
+        var s = Agreed(250_000);
 
         s.UnifiedId = "acct-2";
 
@@ -107,15 +160,60 @@ public class ProfileSyncXpWatermarkTests
     [Fact]
     public void ReArmingAfterARolloverStartsFromTheNewSeasonsFigure()
     {
-        var s = Confirmed(250_000);
+        var s = Agreed(250_000);
         s.CurrentSeason = "2026-09";
 
         // Post-rollover the server reports a small seasonal total. It re-scopes rather than
         // merging, so last season's 250k cannot leak forward and block this season.
-        ProfileSyncService.RecordServerConfirmedXp(s, 3_000);
+        ProfileSyncService.RecordAgreedServerXp(s, 3_000, 3_000, "test");
 
         Assert.Equal(3_000, ProfileSyncService.ActiveXpWatermark(s));
         Assert.Equal("2026-09", s.LastConfirmedServerXpSeason);
+    }
+
+    // ---- V1 / legacy identities (B-4) -------------------------------------------------------
+
+    [Fact]
+    public void ALegacyUserWithNoUnifiedIdIsNeverArmed()
+    {
+        // A V1 user has neither a unified_id nor a season key, so their scope would be the pair
+        // ("", ""): never invalidated by a rollover, and shared with every other legacy account on
+        // the machine. Refuse to arm rather than hand them a guard with no escape hatch.
+        var s = new AppSettings { UnifiedId = null, CurrentSeason = null };
+
+        ProfileSyncService.RecordAgreedServerXp(s, 250_000, 250_000, "V1 merge");
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Equal(0, s.LastConfirmedServerXp);
+    }
+
+    [Fact]
+    public void ALegacySeasonalResetIsNeverBlocked()
+    {
+        // The scenario B-4 is about: a legacy user's season resets, their total drops, and there
+        // is no season key for the scoping to notice. With no watermark ever armed, the send-guard
+        // has nothing to refuse and the reset syncs normally.
+        var s = new AppSettings { UnifiedId = string.Empty, CurrentSeason = string.Empty };
+        ProfileSyncService.RecordAgreedServerXp(s, 250_000, 250_000, "V1 merge");
+
+        // ...season rolls over server-side; local total falls to a fresh seasonal figure.
+        var wouldPush = 500d;
+        var watermark = ProfileSyncService.ActiveXpWatermark(s);
+
+        Assert.Equal(0, watermark);
+        Assert.False(watermark > 0 && wouldPush < watermark);
+    }
+
+    [Fact]
+    public void AStoredWatermarkIsIgnoredOnceTheIdentityIsLegacy()
+    {
+        // Defensive: covers settings persisted by an earlier build of this draft, which did arm
+        // ("", "") scopes. Losing the unified_id must not leave a live guard behind.
+        var s = Agreed(250_000);
+
+        s.UnifiedId = null;
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
     }
 
     // ---- clearing -------------------------------------------------------------------------
@@ -123,7 +221,7 @@ public class ProfileSyncXpWatermarkTests
     [Fact]
     public void ClearingVoidsAllThreeFields()
     {
-        var s = Confirmed(250_000);
+        var s = Agreed(250_000);
 
         ProfileSyncService.ClearXpWatermark(s, "test");
 
@@ -137,52 +235,46 @@ public class ProfileSyncXpWatermarkTests
     public void ClearingIsSafeOnANullSettingsObject()
         => ProfileSyncService.ClearXpWatermark(null, "test");   // must not throw
 
-    // ---- the adopt-side refusal -----------------------------------------------------------
+    // ---- the mid-season admin reset (B-2) ---------------------------------------------------
 
     [Fact]
-    public void AnEmptyServerProfileIsRefusedWhileTheWatermarkStands()
+    public void AMidSeasonAdminResetClearsTheWatermarkAndThePushGoesThrough()
     {
-        var s = Confirmed(250_000);
+        // The case that had no test and no working path. An admin sends level_reset mid-season:
+        // same season key, so the rollover escape does NOT fire, and the reset zeroes a profile
+        // the watermark says was Level 47.
+        //
+        // The old code asked RefuseToZeroAConfirmedProfile inside the `if`, which refused - and
+        // refused permanently, because level_reset is one-shot from the server. Worse, the refusal
+        // fell through into the clamp chain, where the zeroed row reads as uninitialized, local was
+        // kept, and the next push wrote the pre-reset profile back over the admin's work.
+        //
+        // An explicit level_reset is the server EXPLAINING the zeroing, so the sync path now clears
+        // the watermark and adopts. Modelled here as the two operations that branch performs.
+        var s = Agreed(250_000);
         s.PlayerLevel = 47;
 
-        // The account was Level 47 minutes ago by the server's own account of it, and nothing has
-        // reset it. An empty record now is a server-side misread, not a reset.
-        Assert.True(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+        ProfileSyncService.ClearXpWatermark(s, "admin level_reset");
+        s.PlayerLevel = 1;
+        s.PlayerXP = 0;
+
+        // Nothing left to block the push that carries the reset upward.
+        var watermark = ProfileSyncService.ActiveXpWatermark(s);
+        Assert.Equal(0, watermark);
+        Assert.False(watermark > 0 && 0d < watermark);
     }
 
     [Fact]
-    public void ARealServerProfileIsNeverRefused()
+    public void ReArmingAfterAnAdminResetStartsFromTheResetFigure()
     {
-        var s = Confirmed(250_000);
+        // And the guard comes back as soon as there is something to defend again, in the SAME
+        // season - the reset did not cost the account its protection for the rest of the month.
+        var s = Agreed(250_000);
+        ProfileSyncService.ClearXpWatermark(s, "admin level_reset");
 
-        // Lower but real (an anti-cheat clamp, another device) still gets through - the guard is
-        // about ZEROING a confirmed profile, not about defending every downward move.
-        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 30, serverTotalXp: 120_000, "test"));
-    }
+        ProfileSyncService.RecordAgreedServerXp(s, 8_000, 8_000, "V2 sync");
 
-    [Fact]
-    public void ASeasonRolloverIsAllowedToZeroTheProfile()
-    {
-        var s = Confirmed(250_000);
-        s.CurrentSeason = "2026-09";   // the sync path adopts the key before applying level_reset
-
-        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
-    }
-
-    [Fact]
-    public void AnExplicitClearIsAllowedToZeroTheProfile()
-    {
-        var s = Confirmed(250_000);
-        ProfileSyncService.ClearXpWatermark(s, "logout");
-
-        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
-    }
-
-    [Fact]
-    public void WithNoWatermarkNothingIsEverRefused()
-    {
-        var s = new AppSettings { UnifiedId = Account, CurrentSeason = Season };
-
-        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+        Assert.Equal(8_000, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Equal(Season, s.LastConfirmedServerXpSeason);
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/ProfileSyncXpWatermarkTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProfileSyncXpWatermarkTests.cs
@@ -1,0 +1,188 @@
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #865 - the XP regression watermark (DRAFT, pending owner review).
+///
+/// The watermark is the highest cumulative XP the SERVER itself has confirmed for an account, and
+/// it is written only from a server response - never from a local calculation. That is the whole
+/// point: a settings file emptied by a crashed update cannot raise it, so it survives as evidence
+/// of what the account really held. ProfileSyncService then refuses to push a total below it, and
+/// refuses to adopt a response that zeroes a profile the watermark says was real.
+///
+/// It is scoped to (account, season) because both of those legitimately lower XP: a season
+/// rollover resets seasonal progress by design, and a different account's totals are unrelated.
+/// Most of these tests are about that scoping, because a watermark that outlives its scope blocks
+/// the very resets it must let through - a worse failure than the bug it fixes.
+/// </summary>
+public class ProfileSyncXpWatermarkTests
+{
+    private const string Account = "acct-1";
+    private const string Season = "2026-08";
+
+    private static AppSettings Confirmed(double xp, string account = Account, string season = Season)
+    {
+        var s = new AppSettings { UnifiedId = account, CurrentSeason = season };
+        ProfileSyncService.RecordServerConfirmedXp(s, xp);
+        return s;
+    }
+
+    // ---- recording ------------------------------------------------------------------------
+
+    [Fact]
+    public void AServerConfirmationArmsTheWatermarkInTheCurrentScope()
+    {
+        var s = Confirmed(250_000);
+
+        Assert.Equal(250_000, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Equal(Account, s.LastConfirmedServerXpAccount);
+        Assert.Equal(Season, s.LastConfirmedServerXpSeason);
+    }
+
+    [Fact]
+    public void TheWatermarkOnlyEverRisesWithinAScope()
+    {
+        var s = Confirmed(250_000);
+
+        // A later response reporting less (mid-season server hiccup, partial read) must not talk
+        // the high-water mark down - that would let the regression it guards against back in.
+        ProfileSyncService.RecordServerConfirmedXp(s, 10_000);
+        Assert.Equal(250_000, ProfileSyncService.ActiveXpWatermark(s));
+
+        ProfileSyncService.RecordServerConfirmedXp(s, 400_000);
+        Assert.Equal(400_000, ProfileSyncService.ActiveXpWatermark(s));
+    }
+
+    [Fact]
+    public void ATrivialConfirmationNeverArmsTheGuard()
+    {
+        // Below the meaningful-progress floor there is nothing worth defending, and arming on a
+        // brand-new account's first sync would only create false positives.
+        var s = new AppSettings { UnifiedId = Account, CurrentSeason = Season };
+
+        ProfileSyncService.RecordServerConfirmedXp(s, ProfileSyncService.MeaningfulProgressXp - 1);
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+    }
+
+    [Fact]
+    public void AFreshInstallCarriesNoWatermark()
+    {
+        // Every existing install upgrades into this state, so the guard starts disarmed and only
+        // arms once a server response has actually confirmed something.
+        var s = new AppSettings();
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Null(s.LastConfirmedServerXpAccount);
+        Assert.Null(s.LastConfirmedServerXpSeason);
+    }
+
+    // ---- scoping --------------------------------------------------------------------------
+
+    [Fact]
+    public void ASeasonRolloverPutsTheWatermarkOutOfScope()
+    {
+        var s = Confirmed(250_000);
+
+        s.CurrentSeason = "2026-09";
+
+        // Seasonal XP is SUPPOSED to fall here. An in-scope watermark would refuse the rollover
+        // forever, which is worse than the regression it exists to catch.
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+    }
+
+    [Fact]
+    public void AnAccountSwitchPutsTheWatermarkOutOfScope()
+    {
+        var s = Confirmed(250_000);
+
+        s.UnifiedId = "acct-2";
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+    }
+
+    [Fact]
+    public void ReArmingAfterARolloverStartsFromTheNewSeasonsFigure()
+    {
+        var s = Confirmed(250_000);
+        s.CurrentSeason = "2026-09";
+
+        // Post-rollover the server reports a small seasonal total. It re-scopes rather than
+        // merging, so last season's 250k cannot leak forward and block this season.
+        ProfileSyncService.RecordServerConfirmedXp(s, 3_000);
+
+        Assert.Equal(3_000, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Equal("2026-09", s.LastConfirmedServerXpSeason);
+    }
+
+    // ---- clearing -------------------------------------------------------------------------
+
+    [Fact]
+    public void ClearingVoidsAllThreeFields()
+    {
+        var s = Confirmed(250_000);
+
+        ProfileSyncService.ClearXpWatermark(s, "test");
+
+        Assert.Equal(0, ProfileSyncService.ActiveXpWatermark(s));
+        Assert.Equal(0, s.LastConfirmedServerXp);
+        Assert.Null(s.LastConfirmedServerXpAccount);
+        Assert.Null(s.LastConfirmedServerXpSeason);
+    }
+
+    [Fact]
+    public void ClearingIsSafeOnANullSettingsObject()
+        => ProfileSyncService.ClearXpWatermark(null, "test");   // must not throw
+
+    // ---- the adopt-side refusal -----------------------------------------------------------
+
+    [Fact]
+    public void AnEmptyServerProfileIsRefusedWhileTheWatermarkStands()
+    {
+        var s = Confirmed(250_000);
+        s.PlayerLevel = 47;
+
+        // The account was Level 47 minutes ago by the server's own account of it, and nothing has
+        // reset it. An empty record now is a server-side misread, not a reset.
+        Assert.True(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+    }
+
+    [Fact]
+    public void ARealServerProfileIsNeverRefused()
+    {
+        var s = Confirmed(250_000);
+
+        // Lower but real (an anti-cheat clamp, another device) still gets through - the guard is
+        // about ZEROING a confirmed profile, not about defending every downward move.
+        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 30, serverTotalXp: 120_000, "test"));
+    }
+
+    [Fact]
+    public void ASeasonRolloverIsAllowedToZeroTheProfile()
+    {
+        var s = Confirmed(250_000);
+        s.CurrentSeason = "2026-09";   // the sync path adopts the key before applying level_reset
+
+        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+    }
+
+    [Fact]
+    public void AnExplicitClearIsAllowedToZeroTheProfile()
+    {
+        var s = Confirmed(250_000);
+        ProfileSyncService.ClearXpWatermark(s, "logout");
+
+        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+    }
+
+    [Fact]
+    public void WithNoWatermarkNothingIsEverRefused()
+    {
+        var s = new AppSettings { UnifiedId = Account, CurrentSeason = Season };
+
+        Assert.False(ProfileSyncService.RefuseToZeroAConfirmedProfile(s, serverLevel: 1, serverTotalXp: 0, "test"));
+    }
+}


### PR DESCRIPTION
DRAFT - stacked on #185, needs owner review before merge.

The write-protection half of the #865/#879 work:

- Read-before-write: launch sync GETs /v2/user/profile first and adopts through a NARROW take-higher (level/XP/season only - verified the projection in ccp-server; the old broad adopt was blanking privacy-nulled display_name every launch, see server-side note below)
- XP watermark = the last total this client and the server AGREED on, scoped (account, season), set downward as well as upward on any adopt - so a legitimate server correction can never wedge sync (the earlier monotonic design could). Sends below the watermark are refused; season rollover and explicit clears release it; V1/legacy accounts never arm it
- level_reset is adopted unconditionally (an authenticated reset is an explained zeroing; the refusal path is deleted)
- GET failure: push-anyway EXCEPT when no watermark is armed and local looks like defaults (the first-launch-after-upgrade hole)

Build 0 errors, tests 2447/2447 (+12 watermark/edge tests incl. mid-season admin reset and downward-adopt-then-sync).

Server-side finding while verifying the projection: proxy/server.js nulls display_name for users without display_name_set_at - any client path that blindly adopts it will blank the name. Worth a server-side look independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)