### PR TITLE
feat(fyp): endless online feed via Scrolller (client-fetched niche channels)

### DIFF
--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -2999,6 +2999,51 @@ namespace ConditioningControlPanel.Models
             get => _fypEyeGaze;
             set { _fypEyeGaze = value; OnPropertyChanged(); }
         }
+
+        private string _fypSource = "library";
+        /// <summary>Where feed content comes from: "library" (local assets only), "online"
+        /// (Scrolller streaming only) or "mixed" (both, blended by FypOnlineRatio). The online
+        /// path fetches straight from the user's device — see planning/fyp-online/DESIGN.md.</summary>
+        public string FypSource
+        {
+            get => _fypSource;
+            set { _fypSource = value is "library" or "online" or "mixed" ? value : "library"; OnPropertyChanged(); }
+        }
+
+        private int _fypOnlineRatio = 30;
+        /// <summary>In "mixed" mode, the share of feed picks that come from the online pool (%).</summary>
+        public int FypOnlineRatio
+        {
+            get => _fypOnlineRatio;
+            set { _fypOnlineRatio = Math.Clamp(value, 5, 95); OnPropertyChanged(); }
+        }
+
+        private List<string> _fypOnlineNiches = new() { "hypno" };
+        /// <summary>Selected online niche ids (see FypOnlineCoordinator.Catalog).</summary>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public List<string> FypOnlineNiches
+        {
+            get => _fypOnlineNiches;
+            set { _fypOnlineNiches = value ?? new List<string>(); OnPropertyChanged(); }
+        }
+
+        private List<string> _fypOnlineCustomSubs = new();
+        /// <summary>User-added subreddit names for the online feed (bare names, no "r/").</summary>
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public List<string> FypOnlineCustomSubs
+        {
+            get => _fypOnlineCustomSubs;
+            set { _fypOnlineCustomSubs = value ?? new List<string>(); OnPropertyChanged(); }
+        }
+
+        private bool _fypOnlineConsented = false;
+        /// <summary>The one-time online-content consent card was accepted. Until then the
+        /// source setting cannot leave "library".</summary>
+        public bool FypOnlineConsented
+        {
+            get => _fypOnlineConsented;
+            set { _fypOnlineConsented = value; OnPropertyChanged(); }
+        }
         #endregion
 
         #region Lock Card (Unlocks Lv.35)

--- a/ConditioningControlPanel/Resources/web/fyp/feed.js
+++ b/ConditioningControlPanel/Resources/web/fyp/feed.js
@@ -30,6 +30,13 @@ const RING_CAP = 128;
 let surfaceSeq = 0;
 const nextSurfaceKey = () => `s${surfaceSeq++}`;
 
+// Mixed-source share: the probability that any given pick draws from the ONLINE
+// candidate bucket instead of the local one (0 = library only, 1 = online only).
+// Applied at pick time — not by rationing the pool — because local videos expand
+// into many segments while online clips are one each, so pool-entry ratios would
+// not match what the user actually sees. Module-level: one feed per page.
+let mixRemoteShare = 0;
+
 function weightFor(id) {
   return W_BASE + W_BOOST_MAX * stats.segmentScore(id) + W_EXPLORE_BONUS / (1 + stats.segmentPlays(id));
 }
@@ -48,21 +55,22 @@ function enumerateSegments(assets) {
   const out = [];
   for (const a of assets) {
     const landscape = isLandscapeDims(a.width, a.height);
+    const remote = a.origin === 'online';
     if (a.type === 'gif') {
       // A GIF is one whole-item segment: no timeline, no grid.
-      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape });
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape, remote });
       continue;
     }
     const durSec = a.durationMs != null ? a.durationMs / 1000 : undefined;
     if (durSec == null) {
       // Cold: duration not probed yet — one placeholder segment, seed-window start.
-      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: false, landscape });
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: false, landscape, remote });
     } else if (durSec <= WHOLE_VIDEO_MAX_SEC) {
-      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape });
+      out.push({ asset: a, assetId: a.id, k: 0, segId: segId(a.id, 0), durKnown: true, landscape, remote });
     } else {
       const n = segmentCount(durSec);
       for (let k = 0; k < n; k++) {
-        out.push({ asset: a, assetId: a.id, k, segId: segId(a.id, k), durKnown: true, landscape });
+        out.push({ asset: a, assetId: a.id, k, segId: segId(a.id, k), durKnown: true, landscape, remote });
       }
     }
   }
@@ -112,6 +120,24 @@ function weightedPick(pool, ring, segCooldown, exclude) {
   }
   const usable = exclude ? pool.filter((c) => !exclude.has(c.segId)) : pool;
   return usable.length ? leastRecentlyUsed(usable, ring) : null;
+}
+
+/**
+ * A weighted pick that honours the source mix: roll which bucket (online/local)
+ * this pick should come from, try there first, and fall back to the whole pool
+ * so a starved bucket (online buffer still loading, tiny library) never blanks
+ * a tile. Every fresh-pick site routes through here.
+ */
+function pickWithMix(pool, ring, segCooldown, exclude) {
+  if (mixRemoteShare > 0 && mixRemoteShare < 1) {
+    const wantRemote = Math.random() < mixRemoteShare;
+    const bucket = pool.filter((c) => c.remote === wantRemote);
+    if (bucket.length) {
+      const pick = weightedPick(bucket, ring, segCooldown, exclude);
+      if (pick) return pick;
+    }
+  }
+  return weightedPick(pool, ring, segCooldown, exclude);
 }
 
 function toCut(pick) {
@@ -175,7 +201,7 @@ function buildLeadTiles(lead, rows, landscapePool, ring, segCooldown) {
   const picks = [lead];
   const exclude = new Set([lead.segId]);
   for (let r = 1; r < rows; r++) {
-    const mate = weightedPick(landscapePool, ring, segCooldown, exclude);
+    const mate = pickWithMix(landscapePool, ring, segCooldown, exclude);
     if (!mate) break;
     picks.push(mate);
     exclude.add(mate.segId);
@@ -207,7 +233,7 @@ function buildMosaicTiles(candidates, ring, segCooldown, aspect) {
     // Prefer fresh + orientation-matched; widen to the full pool; only for a pack
     // too small to fill every cell, allow a repeat rather than a black gap.
     const pick =
-      weightedPick(pool, ring, segCooldown, exclude) ??
+      pickWithMix(pool, ring, segCooldown, exclude) ??
       weightedPick(candidates, ring, segCooldown, exclude) ??
       weightedPick(candidates, ring, segCooldown, null);
     if (!pick) continue;
@@ -266,7 +292,7 @@ export function createFeed(getAspect) {
       if (layout === 'random') {
         tiles = buildMosaicTiles(candidates, recent.ring, segCooldown, aspect);
       } else {
-        const lead = weightedPick(candidates, recent.ring, segCooldown, null);
+        const lead = pickWithMix(candidates, recent.ring, segCooldown, null);
         if (!lead) break;
         remember(recent.ring, lead.segId);
         tiles = buildLeadTiles(lead, layout === 'trio' ? 3 : 2, landscapePool, recent.ring, segCooldown);
@@ -293,7 +319,7 @@ export function createFeed(getAspect) {
     if (!stacked && pickPool.length < 2) pickPool = candidates;
     const exclude = new Set(comp.tiles.map((t) => t.cut.segId)); // no dupes on the page
     exclude.add(tile.cut.segId);
-    const pick = weightedPick(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
+    const pick = pickWithMix(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
     if (!pick) return null;
 
     let stack = history.get(hKey);
@@ -322,10 +348,12 @@ export function createFeed(getAspect) {
     get historySize() { return history.size; },
 
     /** Returns true when the feed must reset to the top (pool identity or layout
-     *  changed). Duration/dimension backfills keep the feed exactly where it is. */
-    configure(nextAssets, nextIncludeGifs, nextLayout) {
+     *  changed). Duration/dimension backfills keep the feed exactly where it is —
+     *  and so does a remoteShare change (it only biases future picks). */
+    configure(nextAssets, nextIncludeGifs, nextLayout, nextRemoteShare = 0) {
       assets = nextAssets;
       includeGifs = nextIncludeGifs;
+      mixRemoteShare = Math.max(0, Math.min(1, Number(nextRemoteShare) || 0));
       rebuildCandidates();
       const nextKey = computePoolKey();
       const reset = nextKey !== poolKey || nextLayout !== layout;
@@ -335,9 +363,32 @@ export function createFeed(getAspect) {
         recent.ring = [];
         history.clear();
         comps = makeCompositions(PAGE_SIZE);
-        stats.pruneToAssets(new Set(assets.map((a) => a.id)));
+        // Online ids churn every session and never enter stats (see main.js report),
+        // so pruning against LOCAL ids only keeps library stats intact in online mode.
+        stats.pruneToAssets(new Set(assets.filter((a) => a.origin !== 'online').map((a) => a.id)));
       }
       return reset;
+    },
+
+    /**
+     * Grow the pool WITHOUT resetting — the online path's whole point. configure()
+     * yanks the feed to the top whenever the pool identity changes, which would be
+     * catastrophic mid-scroll every time a remote batch lands; append extends the
+     * pool in place and updates the identity key so the next configure() (layout
+     * toggle etc.) doesn't read the growth as a brand-new pool. If the feed was
+     * empty (online mode waiting on its first batch), the first pages are built
+     * here; the caller mounts them.
+     */
+    append(newAssets) {
+      if (!Array.isArray(newAssets) || newAssets.length === 0) return 0;
+      const known = new Set(assets.map((a) => a.id));
+      const fresh = newAssets.filter((a) => a && a.id && !known.has(a.id));
+      if (fresh.length === 0) return 0;
+      assets = assets.concat(fresh);
+      rebuildCandidates();
+      poolKey = computePoolKey();
+      if (comps.length === 0) comps = makeCompositions(PAGE_SIZE);
+      return fresh.length;
     },
 
     /** A playback probe filled in duration/dims: refresh candidates in place. */

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -357,6 +357,11 @@ html, body {
 
 #mosaic-slider-row, #opacity-row, #clickthrough-row, #eye-gaze-row { margin-top: 10px; }
 
+/* The opacity row's title+description were being crushed to one word per line by the
+   slider (both flex:1 in a 288px card). Wrap instead: text on its own line, slider under. */
+#opacity-row { flex-wrap: wrap; }
+#opacity-row .option-text { flex-basis: 100%; }
+
 /* sub-option: indented under its master toggle, and inert until the master
    (and, for gaze, a calibration) makes it meaningful */
 .option-row.sub-row { padding-left: 14px; }

--- a/ConditioningControlPanel/Resources/web/fyp/fyp.css
+++ b/ConditioningControlPanel/Resources/web/fyp/fyp.css
@@ -193,6 +193,9 @@ html, body {
   border-radius: 14px;
   padding: 16px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+  /* the source + niches sections outgrew the fixed card */
+  max-height: calc(100vh - 84px);
+  overflow-y: auto;
 }
 
 .options-header {
@@ -231,6 +234,96 @@ html, body {
 }
 
 .options-divider { height: 1px; background: #2c2c4a; margin: 12px 0; }
+
+/* ---------- online source (Scrolller) ---------- */
+
+.source-chip {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 9px 0;
+  border-radius: 10px;
+  border: 1px solid #34345a;
+  background: transparent;
+  color: #b0b0c8;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+}
+.source-chip .chip-icon { font-size: 18px; line-height: 1; }
+.source-chip.selected {
+  border-color: #ff69b4;
+  background: rgba(255, 105, 180, 0.15);
+  color: #ffb3d9;
+}
+
+#online-ratio-row { margin-top: 10px; }
+#online-ratio { flex: 1; accent-color: #ff69b4; }
+#online-ratio-label { font-size: 12px; color: #b0b0c8; width: 34px; text-align: right; }
+
+.online-label { margin-top: 12px; }
+
+#niche-chips, #custom-sub-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+#custom-sub-chips { margin-top: 6px; }
+#custom-sub-chips:empty { display: none; }
+
+.niche-chip {
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid #34345a;
+  background: transparent;
+  color: #b0b0c8;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, color 150ms ease;
+}
+.niche-chip.selected {
+  border-color: #ff69b4;
+  background: rgba(255, 105, 180, 0.15);
+  color: #ffb3d9;
+}
+.niche-chip.custom { border-style: dashed; }
+.niche-chip.custom .chip-x { margin-left: 6px; opacity: 0.7; }
+
+#custom-sub-row { margin-top: 8px; }
+#custom-sub-input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  border-radius: 9px;
+  border: 1px solid #34345a;
+  background: rgba(0, 0, 0, 0.25);
+  color: #eee;
+  font-size: 12px;
+  outline: none;
+}
+#custom-sub-input:focus { border-color: rgba(255, 105, 180, 0.55); }
+
+/* ---------- online consent card ---------- */
+
+#consent-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 40;                    /* over the options popover (20) */
+  background: rgba(10, 10, 20, 0.72);
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#consent-card {
+  width: min(440px, calc(100vw - 48px));
+  background: #1f1f36;
+  border: 1px solid rgba(255, 105, 180, 0.35);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+}
+#consent-card h1 { font-size: 20px; margin: 0 0 12px; }
+#consent-card p { font-size: 13px; color: #c8c8de; line-height: 1.55; margin: 0 0 10px; }
+.consent-btns { display: flex; align-items: center; gap: 12px; margin-top: 16px; }
 
 .option-row { display: flex; align-items: center; gap: 10px; }
 .option-text { flex: 1; }

--- a/ConditioningControlPanel/Resources/web/fyp/index.html
+++ b/ConditioningControlPanel/Resources/web/fyp/index.html
@@ -35,6 +35,28 @@
           <span>Feed options</span>
           <button id="btn-options-close" class="round-btn small" title="Close">✕</button>
         </div>
+        <div class="options-label">Content source</div>
+        <div class="layout-row">
+          <button class="source-chip" data-source="library"><span class="chip-icon">💾</span>Library</button>
+          <button class="source-chip" data-source="mixed"><span class="chip-icon">🔀</span>Mixed</button>
+          <button class="source-chip" data-source="online"><span class="chip-icon">🌐</span>Online</button>
+        </div>
+        <div class="option-row hidden" id="online-ratio-row">
+          <div class="option-text"><div class="option-title">Online share</div></div>
+          <input id="online-ratio" type="range" min="5" max="95" step="5">
+          <span id="online-ratio-label">30%</span>
+        </div>
+        <div id="online-config" class="hidden">
+          <div class="options-label online-label">Niches</div>
+          <div id="niche-chips"></div>
+          <div class="option-row" id="custom-sub-row">
+            <input id="custom-sub-input" type="text" placeholder="Add a subreddit (r/…)" spellcheck="false" autocomplete="off">
+            <button id="btn-add-sub" class="mini-btn">Add</button>
+          </div>
+          <div id="custom-sub-chips"></div>
+          <div class="option-status hidden" id="online-status"></div>
+        </div>
+        <div class="options-divider"></div>
         <div class="options-label">Layout</div>
         <div class="layout-row">
           <button class="layout-chip" data-layout="duo"><span class="chip-icon">▤</span>Duo</button>
@@ -127,14 +149,31 @@
     <!-- attention check -->
     <button id="attention" class="hidden" title="tap!">💗</button>
 
+    <!-- one-time online-content consent. Blocks the source switch, not the app: declining
+         simply stays on Library. Acceptance persists (FypOnlineConsented) via the bridge. -->
+    <div id="consent-scrim" class="hidden">
+      <div id="consent-card">
+        <h1>🌐 Online Feed</h1>
+        <p>This streams <b>adult content from the internet</b>, via Scrolller - a public
+           Reddit media browser. It comes from public communities and is
+           <b>not curated by CC Labs</b>: anything those communities post can appear.</p>
+        <p>Your device fetches it directly. Nothing is uploaded anywhere, and nothing is
+           saved into your library.</p>
+        <div class="consent-btns">
+          <button id="btn-consent-accept" class="empty-btn">TURN IT ON</button>
+          <button id="btn-consent-cancel" class="mini-btn">Not now</button>
+        </div>
+      </div>
+    </div>
+
     <!-- empty state -->
     <div id="empty" class="hidden">
-      <div class="empty-emoji">🎬</div>
+      <div class="empty-emoji" id="empty-emoji">🎬</div>
       <h1>For You</h1>
-      <p>An endless feed of 20-40 second clips from your own videos and GIFs.<br>
+      <p id="empty-copy">An endless feed of 20-40 second clips from your own videos and GIFs.<br>
          Add some to your assets folder to switch it on.</p>
       <button id="btn-include-gifs" class="empty-btn hidden"></button>
-      <p class="empty-hint">Only active videos and GIFs are used - curate in the Assets tab.</p>
+      <p class="empty-hint" id="empty-hint">Only active videos and GIFs are used - curate in the Assets tab.</p>
     </div>
 
     <!-- crash containment -->

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -32,7 +32,7 @@ function post(msg) {
 
 // ---------- state ----------
 
-let assets = [];
+let assets = [];            // local library manifest (init payload)
 let settings = {
   layout: 'duo',
   includeGifs: true,
@@ -44,7 +44,20 @@ let settings = {
   windowOpacity: 1,
   eyeControl: false,
   eyeGaze: false,
+  source: 'library',        // 'library' | 'mixed' | 'online'
+  onlineRatio: 30,          // mixed mode: % of picks that come from the online pool
+  onlineConsented: false,   // one-time online-content consent accepted
 };
+// ---- online source state (Scrolller via the host) ----
+let remoteAssets = [];      // appended online entries, session-scoped
+let onlineCatalog = [];     // [{id,label,subs,selected}] from init
+let customSubs = [];        // user-added subreddit names
+let onlineOk = true;        // last online-status verdict
+let remoteReqInFlight = false;
+let lastRemoteReqAt = 0;
+let remoteDryUntil = 0;     // backoff after an ok-but-empty batch (channels drained)
+const seenRemote = new Set();  // remote asset ids that already played (buffer freshness)
+let pendingSource = null;   // source waiting on the consent card
 let feed = null;
 const pages = new Map();      // compKey -> page object
 const audioFocus = new Map(); // compKey -> tileIndex
@@ -71,6 +84,75 @@ const aspect = () => (viewport.clientWidth || 1) / pageH();
 function setting(key, value) {
   settings[key] = value;
   post({ type: 'settings-changed', key, value });
+}
+
+// ---------- online source plumbing ----------
+//
+// The host fetches (straight from the user's machine to Scrolller — never through CC
+// Labs servers); this side only manages the buffer: ask when low, append what arrives,
+// prune when the niche selection changes. Remote ids look like
+// "scrolller/<subreddit>/<postId>" — the middle segment is the channel.
+
+const REMOTE_LOWWATER = 60;         // ask for more when fewer unseen than this
+const REMOTE_CAP = 1500;            // stop growing the session pool past this
+const REMOTE_REQ_TIMEOUT_MS = 20000; // a request with no reply may be retried after this
+const REMOTE_DRY_BACKOFF_MS = 30000; // all channels came back empty: breathe
+
+const sourceUsesRemote = () => settings.source !== 'library';
+const isRemoteId = (id) => typeof id === 'string' && id.startsWith('scrolller/');
+
+function remoteShare() {
+  if (settings.source === 'online') return 1;
+  if (settings.source === 'mixed') return Math.min(0.95, Math.max(0.05, (Number(settings.onlineRatio) || 30) / 100));
+  return 0;
+}
+
+function effectiveAssets() {
+  if (settings.source === 'online') return remoteAssets.slice();
+  if (settings.source === 'mixed') return assets.concat(remoteAssets);
+  return assets;
+}
+
+function requestRemote() {
+  const now = performance.now();
+  if (remoteReqInFlight && now - lastRemoteReqAt < REMOTE_REQ_TIMEOUT_MS) return;
+  remoteReqInFlight = true;
+  lastRemoteReqAt = now;
+  post({ type: 'need-remote' });
+}
+
+/** Keep the online buffer stocked: below the low-water mark in either total size or
+ *  unseen clips → ask the host for a batch. Self-clocking — every append/status reply
+ *  and every remote clip teardown calls back in here. */
+function ensureRemoteBuffer() {
+  if (!started || !sourceUsesRemote() || !settings.onlineConsented) return;
+  if (remoteAssets.length >= REMOTE_CAP) return;
+  if (performance.now() < remoteDryUntil) return;
+  const unseen = remoteAssets.length - seenRemote.size;
+  if (remoteAssets.length < REMOTE_LOWWATER || unseen < REMOTE_LOWWATER) requestRemote();
+}
+
+/** Channels currently in play, lowercased (mirror of the host's ActiveChannels). */
+function activeChannelSet() {
+  const set = new Set();
+  for (const n of onlineCatalog) {
+    if (n.selected) for (const s of n.subs || []) set.add(String(s).toLowerCase());
+  }
+  for (const c of customSubs) set.add(String(c).toLowerCase());
+  if (set.size === 0) {
+    for (const s of onlineCatalog[0]?.subs || []) set.add(String(s).toLowerCase());
+  }
+  return set;
+}
+
+/** Niche selection changed: clips from deselected channels leave the pool now (the
+ *  user just said "not that"), which resets the feed via the pool-identity check. */
+function pruneRemoteToChannels() {
+  const chans = activeChannelSet();
+  const before = remoteAssets.length;
+  remoteAssets = remoteAssets.filter((a) => chans.has((a.id.split('/')[1] || '').toLowerCase()));
+  if (started && sourceUsesRemote() && remoteAssets.length !== before) applyConfig();
+  ensureRemoteBuffer();
 }
 
 // ---------- page context ----------
@@ -113,7 +195,14 @@ const pageCtx = {
     post({ type: 'media-error', id: asset.id, code: detail?.code ?? 0, message: detail?.message || '' });
   },
   report(segIdKey, dwellMs, clipLenMs) {
-    stats.recordView(segIdKey, dwellMs, clipLenMs);
+    if (isRemoteId(segIdKey)) {
+      // One-shot clips never enter the per-segment stats (useless there and the ids
+      // churn forever); taste is learned per channel HOST-side from clip-viewed.
+      seenRemote.add(segIdKey.slice(0, segIdKey.lastIndexOf(':')));
+      ensureRemoteBuffer();
+    } else {
+      stats.recordView(segIdKey, dwellMs, clipLenMs);
+    }
     if (dwellMs >= CLIP_VIEWED_MIN_DWELL_MS) {
       post({ type: 'clip-viewed', segId: segIdKey, dwellMs: Math.round(dwellMs) });
     }
@@ -189,6 +278,7 @@ const prev = () => goTo(activeIdx - 1);
 
 function maybeExtend() {
   if (!feed || feed.comps.length === 0) return;
+  ensureRemoteBuffer(); // scroll progress is the natural "will need more soon" signal
   if (activeIdx < feed.comps.length - 3) return;
   const { appended, trimmed } = feed.extend();
   if (!appended && !trimmed) return;
@@ -200,7 +290,7 @@ function maybeExtend() {
 // ---------- config / rebuild ----------
 
 function applyConfig() {
-  const reset = feed.configure(assets, settings.includeGifs, settings.layout);
+  const reset = feed.configure(effectiveAssets(), settings.includeGifs, settings.layout, remoteShare());
   if (reset) {
     for (const p of pages.values()) p.destroy();
     pages.clear();
@@ -273,7 +363,107 @@ function updateOptionsUi() {
   $('window-opacity').value = String(pct);
   $('window-opacity-label').textContent = `${pct}%`;
   $('toggle-clickthrough').classList.toggle('on', clickThrough);
+  updateOnlineUi();
   updateEyeUi();
+}
+
+// ---------- online source UI ----------
+
+function updateOnlineUi() {
+  document.querySelectorAll('.source-chip').forEach((chip) => {
+    chip.classList.toggle('selected', chip.dataset.source === settings.source);
+  });
+  $('online-ratio-row').classList.toggle('hidden', settings.source !== 'mixed');
+  $('online-ratio').value = String(settings.onlineRatio);
+  $('online-ratio-label').textContent = `${settings.onlineRatio}%`;
+  $('online-config').classList.toggle('hidden', !sourceUsesRemote());
+
+  // Niche chips are rebuilt in place — the catalog is tiny.
+  const nicheBox = $('niche-chips');
+  nicheBox.innerHTML = '';
+  for (const n of onlineCatalog) {
+    const chip = document.createElement('button');
+    chip.className = 'niche-chip' + (n.selected ? ' selected' : '');
+    chip.textContent = n.label;
+    chip.addEventListener('click', () => {
+      n.selected = !n.selected;
+      setting('onlineNiches', onlineCatalog.filter((x) => x.selected).map((x) => x.id));
+      updateOnlineUi();
+      pruneRemoteToChannels();
+    });
+    nicheBox.appendChild(chip);
+  }
+
+  const customBox = $('custom-sub-chips');
+  customBox.innerHTML = '';
+  for (const sub of customSubs) {
+    const chip = document.createElement('button');
+    chip.className = 'niche-chip custom selected';
+    chip.title = 'Remove';
+    chip.innerHTML = `r/${sub}<span class="chip-x">✕</span>`;
+    chip.addEventListener('click', () => {
+      customSubs = customSubs.filter((s) => s !== sub);
+      setting('onlineCustomSubs', customSubs.slice());
+      updateOnlineUi();
+      pruneRemoteToChannels();
+    });
+    customBox.appendChild(chip);
+  }
+
+  const status = $('online-status');
+  if (!sourceUsesRemote()) {
+    status.classList.add('hidden');
+  } else if (!onlineOk) {
+    status.textContent = 'Online feed unreachable - retrying as you scroll.';
+    status.classList.remove('hidden');
+  } else if (remoteAssets.length > 0) {
+    status.textContent = `${remoteAssets.length} online clips this session`;
+    status.classList.remove('hidden');
+  } else {
+    status.classList.add('hidden');
+  }
+}
+
+/** "r/Name", full urls, stray punctuation → bare subreddit name (mirror of the host). */
+function sanitizeSub(raw) {
+  let s = String(raw || '').trim();
+  const idx = s.toLowerCase().lastIndexOf('/r/');
+  if (idx >= 0) s = s.slice(idx + 3);
+  else if (s.toLowerCase().startsWith('r/')) s = s.slice(2);
+  s = (s.match(/^[A-Za-z0-9_]+/) || [''])[0];
+  return s.length >= 2 && s.length <= 40 ? s : null;
+}
+
+function addCustomSub() {
+  const input = $('custom-sub-input');
+  const clean = sanitizeSub(input.value);
+  if (!clean) { input.value = ''; return; }
+  if (!customSubs.some((s) => s.toLowerCase() === clean.toLowerCase()) && customSubs.length < 20) {
+    customSubs.push(clean);
+    setting('onlineCustomSubs', customSubs.slice());
+  }
+  input.value = '';
+  updateOnlineUi();
+  ensureRemoteBuffer();
+}
+
+/** Source chip pressed: consent-gate the first step away from the library. */
+function requestSourceChange(src) {
+  if (src === settings.source) return;
+  if (src !== 'library' && !settings.onlineConsented) {
+    pendingSource = src;
+    $('consent-scrim').classList.remove('hidden');
+    return;
+  }
+  applySource(src);
+}
+
+function applySource(src) {
+  setting('source', src);
+  updateOnlineUi();
+  if (started) applyConfig();
+  updateEmptyState();
+  ensureRemoteBuffer();
 }
 
 // ---------- window opacity / ghost mode ----------
@@ -417,12 +607,28 @@ function onEyesClosed() {
 function updateEmptyState() {
   const empty = feed.comps.length === 0;
   $('empty').classList.toggle('hidden', !empty);
-  if (empty) {
-    const hiddenGifs = settings.includeGifs ? 0 : assets.filter((a) => a.type === 'gif').length;
-    const btn = $('btn-include-gifs');
-    btn.classList.toggle('hidden', hiddenGifs === 0);
-    btn.textContent = `INCLUDE ${hiddenGifs} GIF${hiddenGifs === 1 ? '' : 'S'}`;
+  if (!empty) return;
+  const gifBtn = $('btn-include-gifs');
+  if (sourceUsesRemote()) {
+    // Online/mixed with nothing yet: this is a loading (or offline) state, not
+    // a "your library is empty" state.
+    gifBtn.classList.add('hidden');
+    $('empty-hint').classList.add('hidden');
+    if (!onlineOk) {
+      $('empty-emoji').textContent = '📡';
+      $('empty-copy').innerHTML = "Couldn't reach the online feed.<br>Check your connection - it retries as you scroll.";
+    } else {
+      $('empty-emoji').textContent = '🌐';
+      $('empty-copy').textContent = 'Tuning in to the online feed…';
+    }
+    return;
   }
+  $('empty-emoji').textContent = '🎬';
+  $('empty-copy').innerHTML = 'An endless feed of 20-40 second clips from your own videos and GIFs.<br>Add some to your assets folder to switch it on.';
+  $('empty-hint').classList.remove('hidden');
+  const hiddenGifs = settings.includeGifs ? 0 : assets.filter((a) => a.type === 'gif').length;
+  gifBtn.classList.toggle('hidden', hiddenGifs === 0);
+  gifBtn.textContent = `INCLUDE ${hiddenGifs} GIF${hiddenGifs === 1 ? '' : 'S'}`;
 }
 
 // ---------- intro gate ----------
@@ -454,6 +660,7 @@ function startFeed() {
     if (!feed) return; // init never landed (host died) — nothing to build
     applyConfig();
     scheduleAttention();
+    ensureRemoteBuffer();   // online/mixed: start filling before the user hits the end
   }, INTRO_EXIT_MS);
 }
 
@@ -485,6 +692,35 @@ function wireChrome() {
       updateChromeForLayout();
       applyConfig(); // layout change resets the feed to the top (mobile behavior)
     });
+  });
+  document.querySelectorAll('.source-chip').forEach((chip) => {
+    chip.addEventListener('click', () => requestSourceChange(chip.dataset.source));
+  });
+  $('online-ratio').addEventListener('input', () => {
+    $('online-ratio-label').textContent = `${$('online-ratio').value}%`;
+  });
+  $('online-ratio').addEventListener('change', () => {
+    setting('onlineRatio', Math.max(5, Math.min(95, Number($('online-ratio').value) || 30)));
+    updateOnlineUi();
+    if (started) applyConfig(); // same pool → no reset; just re-biases future picks
+  });
+  $('btn-add-sub').addEventListener('click', addCustomSub);
+  $('custom-sub-input').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); addCustomSub(); }
+    e.stopPropagation(); // typing must never page the feed (arrow keys etc.)
+  });
+  $('btn-consent-accept').addEventListener('click', () => {
+    settings.onlineConsented = true;
+    post({ type: 'settings-changed', key: 'onlineConsented', value: true });
+    $('consent-scrim').classList.add('hidden');
+    const src = pendingSource || 'mixed';
+    pendingSource = null;
+    applySource(src);
+  });
+  $('btn-consent-cancel').addEventListener('click', () => {
+    pendingSource = null;
+    $('consent-scrim').classList.add('hidden');
+    updateOnlineUi(); // chips snap back to the real (library) source
   });
   $('toggle-gifs').addEventListener('click', () => {
     setting('includeGifs', !settings.includeGifs);
@@ -637,6 +873,10 @@ function onHostMessage(data) {
       // Host may omit either (older builds) — both default rather than go undefined.
       settings.audioGlow = settings.audioGlow !== false;
       settings.windowOpacity = clampOpacity(settings.windowOpacity);
+      onlineCatalog = Array.isArray(data.online?.niches) ? data.online.niches : [];
+      customSubs = Array.isArray(data.online?.customSubs) ? data.online.customSubs.slice() : [];
+      // Consent is the source of truth for whether a non-library source can stand.
+      if (!settings.onlineConsented && settings.source !== 'library') settings.source = 'library';
       clickThrough = false; // never sticky across a reload
       document.body.classList.remove('clickthrough');
       stats.init(data.stats, (s) => post({ type: 'stats-save', stats: s }));
@@ -677,6 +917,43 @@ function onHostMessage(data) {
       // the same value again, which is harmless.
       setMuted(!!data.on);
       break;
+    case 'assets-append': {
+      // A batch of online entries from the host. Dedupe, grow the pool in place
+      // (feed.append never resets), and if the feed was empty-waiting (online mode
+      // booting), mount the first pages that append just built.
+      remoteReqInFlight = false;
+      const list = Array.isArray(data.assets) ? data.assets : [];
+      const known = new Set(remoteAssets.map((a) => a.id));
+      const fresh = list.filter((a) => a && a.id && !known.has(a.id));
+      remoteAssets.push(...fresh);
+      if (started && feed && sourceUsesRemote() && fresh.length) {
+        const wasEmpty = feed.comps.length === 0;
+        feed.append(fresh);
+        if (wasEmpty && feed.comps.length > 0) {
+          activeIdx = 0;
+          syncPages();
+          applyTrack(false);
+          pageAt(0)?.setActive(true);
+          updateCaption();
+        }
+        updateEmptyState();
+      }
+      updateOnlineUi();
+      ensureRemoteBuffer();
+      break;
+    }
+    case 'online-status': {
+      // Arrives after every batch attempt, success or not — this is what clears the
+      // in-flight latch, flips the offline notice, and paces the dry-channel backoff.
+      remoteReqInFlight = false;
+      onlineOk = !!data.ok;
+      if (data.ok && !(data.added > 0)) remoteDryUntil = performance.now() + REMOTE_DRY_BACKOFF_MS;
+      if (!data.ok) remoteDryUntil = performance.now() + REMOTE_DRY_BACKOFF_MS;
+      updateEmptyState();
+      updateOnlineUi();
+      if (data.ok && data.added > 0) ensureRemoteBuffer();
+      break;
+    }
     case 'eyeStatus':
       eyeStatus = {
         enabled: !!data.enabled,
@@ -730,6 +1007,9 @@ Object.defineProperty(window, '__ccpDebug', {
     get audioFocusCount() { return audioFocus.size; },
     get statCount() { return stats.statCount(); },
     get activeIdx() { return activeIdx; },
+    get remoteCount() { return remoteAssets.length; },
+    get remoteSeen() { return seenRemote.size; },
+    get source() { return settings.source; },
   },
 });
 

--- a/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypAssetManifest.cs
@@ -35,6 +35,10 @@ internal static class FypAssetManifest
         [Newtonsoft.Json.JsonProperty("durationMs")] public long? DurationMs { get; set; }
         [Newtonsoft.Json.JsonProperty("width")] public int? Width { get; set; }
         [Newtonsoft.Json.JsonProperty("height")] public int? Height { get; set; }
+        /// <summary>"online" for remote entries (Scrolller et al.); absent for library files.
+        /// The page uses it for the source-mix pick and to keep remote ids out of stats.</summary>
+        [Newtonsoft.Json.JsonProperty("origin", NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string? Origin { get; init; }
     }
 
     /// <summary>Build the asset list for the current EffectiveAssetsPath. Never throws.</summary>

--- a/ConditioningControlPanel/Services/Fyp/FypHostService.cs
+++ b/ConditioningControlPanel/Services/Fyp/FypHostService.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Linq;
 using Microsoft.Web.WebView2.Core;
 using Newtonsoft.Json.Linq;
+using ConditioningControlPanel.Services.Fyp.Online;
 
 namespace ConditioningControlPanel.Services.Fyp;
 
@@ -127,6 +129,7 @@ internal static class FypHostService
         var h = _host;
         _host = null;
         try { _meta?.Save(); } catch { }
+        try { FypOnlineCoordinator.Save(); } catch { }
         try { h?.Dispose(); }
         catch (Exception ex) { App.Logger?.Debug("FypHost.Close: {E}", ex.Message); }
     }
@@ -154,6 +157,22 @@ internal static class FypHostService
                     audioGlow = s?.FypAudioGlow ?? true,
                     eyeControl = s?.FypEyeControl ?? false,
                     eyeGaze = s?.FypEyeGaze ?? false,
+                    source = s?.FypSource ?? "library",
+                    onlineRatio = s?.FypOnlineRatio ?? 30,
+                    onlineConsented = s?.FypOnlineConsented ?? false,
+                },
+                // The niche catalog rides along so the page can render chips (and knows
+                // each niche's subreddits — deselecting one prunes its clips client-side).
+                online = new
+                {
+                    niches = FypOnlineCoordinator.Catalog.Select(n => new
+                    {
+                        id = n.Id,
+                        label = n.Label,
+                        subs = n.Subs,
+                        selected = s?.FypOnlineNiches?.Contains(n.Id) ?? false,
+                    }),
+                    customSubs = s?.FypOnlineCustomSubs ?? new List<string>(),
                 },
                 stats = LoadStats(),
             });
@@ -180,7 +199,10 @@ internal static class FypHostService
             }
             case "asset-meta":
             {
-                _meta?.Update((string?)o["id"], (long?)o["durationMs"], (int?)o["width"], (int?)o["height"]);
+                // Remote pools churn forever — never let their probes grow fyp_meta.json.
+                var id = (string?)o["id"];
+                if (!IsRemoteId(id))
+                    _meta?.Update(id, (long?)o["durationMs"], (int?)o["width"], (int?)o["height"]);
                 break;
             }
             case "media-error":
@@ -189,16 +211,31 @@ internal static class FypHostService
                 // (#562) was undiagnosable with the page swallowing errors client-side.
                 // MediaError codes: 2 = network/fetch, 3 = decode failed, 4 = format not
                 // supported (HEVC in Chromium reads as 3 or 4; LibVLC plays the same file).
+                var id = (string?)o["id"];
                 App.Logger?.Warning("[FYP] media-error for {Id}: code={Code} {Message}",
-                    (string?)o["id"], (int?)o["code"] ?? 0, (string?)o["message"] ?? "");
-                _meta?.RecordFailure((string?)o["id"]);
+                    id, (int?)o["code"] ?? 0, (string?)o["message"] ?? "");
+                // Fail-strikes are for library files (a remote entry is one-shot anyway;
+                // the page's own error swap already pages past it).
+                if (!IsRemoteId(id)) _meta?.RecordFailure(id);
                 break;
             }
             case "clip-viewed":
             {
+                // Remote clips feed the channel-taste EWMA before the XP cap gets a say.
+                var segId = (string?)o["segId"];
+                if (IsRemoteId(segId))
+                {
+                    try { FypOnlineCoordinator.RecordDwell(segId!, (long?)o["dwellMs"] ?? 0); }
+                    catch (Exception ex) { App.Logger?.Debug("FypHost: dwell record failed: {E}", ex.Message); }
+                }
                 if (!AllowClipXp()) break;
                 try { App.Progression?.AddXP(5, XPSource.Fyp); }
                 catch (Exception ex) { App.Logger?.Debug("FypHost: clip XP failed: {E}", ex.Message); }
+                break;
+            }
+            case "need-remote":
+            {
+                ServeRemoteBatch();
                 break;
             }
             case "attention-hit":
@@ -289,9 +326,94 @@ internal static class FypHostService
                     PostEyeStatus(null);
                     break;
                 }
+                case "source":
+                {
+                    var src = (string?)value ?? "library";
+                    // The page shows the consent card before ever posting a non-library
+                    // source; belt and braces here so a stale page can't skip it.
+                    if (src != "library" && s.FypOnlineConsented != true) src = "library";
+                    s.FypSource = src;
+                    break;
+                }
+                case "onlineRatio": s.FypOnlineRatio = (int?)value ?? 30; break;
+                case "onlineConsented":
+                {
+                    // One-way: the page only ever sends true (accepting the card).
+                    if ((bool?)value == true && !s.FypOnlineConsented)
+                    {
+                        s.FypOnlineConsented = true;
+                        App.Logger?.Information("FypHost: online-content consent accepted");
+                    }
+                    break;
+                }
+                case "onlineNiches":
+                {
+                    if (value is JArray arr)
+                    {
+                        var known = new HashSet<string>(FypOnlineCoordinator.Catalog.Select(n => n.Id));
+                        s.FypOnlineNiches = arr.Select(t => (string?)t)
+                            .Where(id => id != null && known.Contains(id)).Select(id => id!)
+                            .Distinct().ToList();
+                        FypOnlineCoordinator.ResetChannels();
+                    }
+                    break;
+                }
+                case "onlineCustomSubs":
+                {
+                    if (value is JArray arr)
+                    {
+                        s.FypOnlineCustomSubs = arr.Select(t => FypOnlineCoordinator.SanitizeSub((string?)t))
+                            .Where(x => x != null).Select(x => x!)
+                            .Distinct(StringComparer.OrdinalIgnoreCase).Take(20).ToList();
+                        FypOnlineCoordinator.ResetChannels();
+                    }
+                    break;
+                }
             }
         }
         catch (Exception ex) { App.Logger?.Debug("FypHost: settings-changed {Key} failed: {E}", key, ex.Message); }
+    }
+
+    // ============================= online feed (Scrolller) =============================
+    //
+    // The page asks for content ({type:'need-remote'}) whenever its remote buffer runs
+    // low; one batch (~a page from one channel) comes back as {type:'assets-append'}.
+    // Fetches run on the thread pool and the reply hops back to the UI thread — the
+    // WebView2 Post is thread-affine. Single-flight: a second need-remote while one is
+    // in the air is dropped (the page re-asks after every append until it is satisfied).
+    //
+    // BRIGHT LINE: these fetches go straight from this machine to scrolller's API/CDN.
+    // Nothing here may ever involve CC Labs servers — see planning/fyp-online/DESIGN.md.
+
+    private static int _remoteFetchInFlight;   // 0/1 via Interlocked
+
+    private static bool IsRemoteId(string? id) =>
+        id != null && id.StartsWith("scrolller/", StringComparison.Ordinal);
+
+    private static async void ServeRemoteBatch()
+    {
+        var s = App.Settings?.Current;
+        if (s == null || s.FypSource == "library" || !s.FypOnlineConsented) return;
+        if (System.Threading.Interlocked.CompareExchange(ref _remoteFetchInFlight, 1, 0) != 0) return;
+        try
+        {
+            var (entries, error) = await FypOnlineCoordinator
+                .FetchBatchAsync(System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+            var win = _host?.Window;
+            if (win == null) return;   // feed closed while fetching
+            await win.Dispatcher.InvokeAsync(() =>
+            {
+                if (_host == null) return;
+                if (entries.Count > 0)
+                    _host.Post(new { type = "assets-append", assets = entries });
+                // Status goes out either way so the page can clear its loading state or
+                // show "offline" instead of an eternal spinner.
+                _host.Post(new { type = "online-status", ok = error == null, error, added = entries.Count });
+            });
+        }
+        catch (Exception ex) { App.Logger?.Warning("FypHost: remote batch failed: {E}", ex.Message); }
+        finally { System.Threading.Interlocked.Exchange(ref _remoteFetchInFlight, 0); }
     }
 
     private static JObject? LoadStats()

--- a/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Fyp.Online;
+
+/// <summary>
+/// Owns the online side of the For You feed: which channels (subreddits) are in play,
+/// which one the next batch comes from, and what the user's dwell says about each.
+///
+/// Niches are just named bundles of subreddit slugs — scrolller's taxonomy IS the niche
+/// taxonomy, so there is no server-side curation pipeline. The starter catalog below was
+/// existence-checked against the live API on 2026-08-10; a channel that stops resolving
+/// simply retires itself for the session, so a stale entry costs one wasted request, not
+/// a broken feed.
+///
+/// Learning happens here, not in the page: the page's per-segment EWMA is useless for
+/// clips seen exactly once, so dwell aggregates per CHANNEL (fyp_online.json) and biases
+/// which channel the next fetch draws from. That is the whole "For You" algorithm for
+/// online content.
+/// </summary>
+internal static class FypOnlineCoordinator
+{
+    public sealed record Niche(string Id, string Label, string[] Subs);
+
+    /// <summary>Starter catalog. Subs verified live 2026-08-10 (existence + item counts);
+    /// unresolvable ones fail soft. Order is display order in the options popover.</summary>
+    public static readonly Niche[] Catalog =
+    {
+        new("hypno",    "Hypno",    new[] { "EroticHypnosis", "sissyhypno" }),
+        new("bimbo",    "Bimbo",    new[] { "bimbo", "bimbofication" }),
+        new("sissy",    "Sissy",    new[] { "Sissies", "sissyhypno" }),
+        new("hentai",   "Hentai",   new[] { "hentai", "rule34" }),
+        new("censored", "Censored", new[] { "censoredporn" }),
+        new("bbc",      "BBC",      new[] { "BBCSluts" }),
+        new("goon",     "Goon",     new[] { "GOONED" }),
+        new("amateur",  "Amateur",  new[] { "RealGirls", "TittyDrop" }),
+    };
+
+    private const int MaxCustomSubs = 20;
+    private const int MaxChannelTriesPerBatch = 3;
+    private const double EwmaAlpha = 0.2;
+    private const double EwmaCapMs = 30000;      // one clip watched ~30s is a maxed signal
+    private const int ExploreViews = 3;          // channels with fewer views get a bonus
+
+    private static readonly object Lock = new();
+    private static readonly IFeedSource Source = new ScrolllerSource();
+    private static Dictionary<string, FeedChannelState> _channels = new(StringComparer.OrdinalIgnoreCase);
+    private static Dictionary<string, (double EwmaMs, int Views)> _dwell = new(StringComparer.OrdinalIgnoreCase);
+    private static bool _dwellLoaded;
+    private static readonly Random Rng = new();
+
+    private static string StorePath => Path.Combine(App.UserDataPath, "fyp_online.json");
+
+    /// <summary>Channel names currently in play (selected niches ∪ custom subs; the first
+    /// catalog niche when nothing is selected, so "Online" can never mean "nothing").</summary>
+    public static List<string> ActiveChannels()
+    {
+        var s = App.Settings?.Current;
+        var selected = new HashSet<string>(s?.FypOnlineNiches ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+        var subs = new List<string>();
+        foreach (var n in Catalog)
+            if (selected.Contains(n.Id))
+                subs.AddRange(n.Subs);
+        foreach (var c in s?.FypOnlineCustomSubs ?? new List<string>())
+        {
+            var clean = SanitizeSub(c);
+            if (clean != null) subs.Add(clean);
+        }
+        var distinct = subs.Distinct(StringComparer.OrdinalIgnoreCase).Take(64).ToList();
+        if (distinct.Count == 0) distinct.AddRange(Catalog[0].Subs);
+        return distinct;
+    }
+
+    /// <summary>"r/Name", urls and stray punctuation → bare subreddit name, or null.</summary>
+    public static string? SanitizeSub(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        var s = raw.Trim();
+        int idx = s.LastIndexOf("/r/", StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0) s = s[(idx + 3)..];
+        else if (s.StartsWith("r/", StringComparison.OrdinalIgnoreCase)) s = s[2..];
+        s = new string(s.TakeWhile(ch => char.IsLetterOrDigit(ch) || ch == '_').ToArray());
+        return s.Length is >= 2 and <= 40 ? s : null;
+    }
+
+    /// <summary>Niche selection / custom subs changed: drop rotation state (iterators,
+    /// dead flags) but keep the learned dwell — taste survives a channel reshuffle.</summary>
+    public static void ResetChannels()
+    {
+        lock (Lock) _channels.Clear();
+    }
+
+    /// <summary>Session teardown: persist the dwell EWMAs.</summary>
+    public static void Save()
+    {
+        lock (Lock)
+        {
+            if (!_dwellLoaded) return;
+            try
+            {
+                var o = new JObject();
+                foreach (var (k, v) in _dwell)
+                    o[k] = new JObject { ["ewmaMs"] = Math.Round(v.EwmaMs), ["views"] = v.Views };
+                Directory.CreateDirectory(App.UserDataPath);
+                File.WriteAllText(StorePath, new JObject { ["channels"] = o }.ToString(Newtonsoft.Json.Formatting.None));
+            }
+            catch (Exception ex) { App.Logger?.Debug("FypOnline: dwell save failed: {E}", ex.Message); }
+        }
+    }
+
+    /// <summary>A remote clip was watched ≥5s: fold its dwell into the channel EWMA.
+    /// segId shape "scrolller/&lt;sub&gt;/&lt;post&gt;:k".</summary>
+    public static void RecordDwell(string segId, long dwellMs)
+    {
+        var parts = segId.Split('/');
+        if (parts.Length < 3) return;
+        var sub = parts[1];
+        double capped = Math.Min(dwellMs, EwmaCapMs);
+        lock (Lock)
+        {
+            EnsureDwellLoaded();
+            _dwell.TryGetValue(sub, out var cur);
+            double ewma = cur.Views == 0 ? capped : EwmaAlpha * capped + (1 - EwmaAlpha) * cur.EwmaMs;
+            _dwell[sub] = (ewma, cur.Views + 1);
+        }
+    }
+
+    /// <summary>
+    /// Fetch the next batch of entries from the rotation. Returns (entries, error): a
+    /// null error with zero entries means "nothing new right now" (all channels dry),
+    /// a non-null error means the API itself is unreachable. Runs off the UI thread.
+    /// </summary>
+    public static async Task<(List<FypAssetManifest.Entry> Entries, string? Error)> FetchBatchAsync(CancellationToken ct)
+    {
+        List<FeedChannelState> order;
+        lock (Lock)
+        {
+            EnsureDwellLoaded();
+            var active = ActiveChannels();
+            // Rebuild the state map to the active set (keeps live iterators for kept subs).
+            var next = new Dictionary<string, FeedChannelState>(StringComparer.OrdinalIgnoreCase);
+            foreach (var name in active)
+                next[name] = _channels.TryGetValue(name, out var st) ? st : new FeedChannelState { Name = name };
+            _channels = next;
+            order = PickOrder(active);
+        }
+
+        bool sawTransportFailure = false;
+        foreach (var channel in order.Take(MaxChannelTriesPerBatch))
+        {
+            if (channel.Dead || channel.Failures >= 3) continue;
+            var page = await Source.FetchPageAsync(channel, ct).ConfigureAwait(false);
+            if (page == null) { channel.Failures++; sawTransportFailure = true; continue; }
+            channel.Failures = 0;
+            // A drained iterator restarts from the top: RANDOM sort deals different pages
+            // and the page's cooldown machinery absorbs the occasional repeat.
+            channel.Iterator = page.NextIterator;
+            if (page.Entries.Count > 0)
+            {
+                App.Logger?.Information("[FYP online] +{N} entries from r/{Sub}", page.Entries.Count, channel.Name);
+                return (page.Entries, null);
+            }
+        }
+        return (new List<FypAssetManifest.Entry>(), sawTransportFailure ? "offline" : null);
+    }
+
+    /// <summary>Channels sorted by a weighted-random draw over dwell taste: a channel the
+    /// user lingers on reaches ~4x the base weight; barely-explored ones get a bonus.</summary>
+    private static List<FeedChannelState> PickOrder(List<string> active)
+    {
+        var scored = new List<(FeedChannelState St, double Key)>();
+        foreach (var name in active)
+        {
+            var st = _channels[name];
+            _dwell.TryGetValue(name, out var d);
+            double w = 1 + 3 * Math.Min(1, d.EwmaMs / EwmaCapMs) + (d.Views < ExploreViews ? 1 : 0);
+            // Exponential-race sampling: sorting by -log(u)/w draws without replacement
+            // proportionally to weight, giving a full fallback order in one pass.
+            double u = 1 - Rng.NextDouble();
+            scored.Add((st, -Math.Log(u) / w));
+        }
+        return scored.OrderBy(x => x.Key).Select(x => x.St).ToList();
+    }
+
+    private static void EnsureDwellLoaded()
+    {
+        if (_dwellLoaded) return;
+        _dwellLoaded = true;
+        try
+        {
+            if (!File.Exists(StorePath)) return;
+            var o = JObject.Parse(File.ReadAllText(StorePath));
+            if (o["channels"] is JObject ch)
+                foreach (var p in ch.Properties())
+                    _dwell[p.Name] = ((double?)p.Value["ewmaMs"] ?? 0, (int?)p.Value["views"] ?? 0);
+        }
+        catch (Exception ex) { App.Logger?.Debug("FypOnline: dwell load failed: {E}", ex.Message); }
+    }
+}

--- a/ConditioningControlPanel/Services/Fyp/Online/IFeedSource.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/IFeedSource.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConditioningControlPanel.Services.Fyp.Online;
+
+/// <summary>
+/// One remote content rail for the For You feed. Scrolller is the first implementation;
+/// the abstraction exists because any single upstream can rot, get acquired or start
+/// charging — the feed must never have exactly one. The local library is the degenerate
+/// source (the init manifest built by <see cref="FypAssetManifest"/>) and deliberately
+/// does not flow through this interface: it is synchronous, complete and reset-free.
+///
+/// THE BRIGHT LINE (owner decision, 2026-08-10): implementations run ON THE USER'S
+/// DEVICE and fetch straight from the provider. Nothing here may ever route media
+/// through CC Labs infrastructure — no proxying, no caching, no re-serving. See
+/// planning/fyp-online/DESIGN.md.
+/// </summary>
+internal interface IFeedSource
+{
+    /// <summary>Stable id, also the entry-id prefix (e.g. "scrolller").</summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Fetch the next page for one channel (for Scrolller a channel is a subreddit).
+    /// Returns null on hard failure; an empty page with a null iterator means the
+    /// channel is exhausted for this rotation.
+    /// </summary>
+    Task<FeedPage?> FetchPageAsync(FeedChannelState channel, CancellationToken ct);
+}
+
+/// <summary>One fetched page of feed entries plus the cursor to continue from.</summary>
+internal sealed class FeedPage
+{
+    public List<FypAssetManifest.Entry> Entries { get; init; } = new();
+    public string? NextIterator { get; init; }
+}
+
+/// <summary>
+/// Mutable per-channel rotation state owned by <see cref="FypOnlineCoordinator"/>.
+/// </summary>
+internal sealed class FeedChannelState
+{
+    /// <summary>Channel key — the subreddit name, no "r/" prefix.</summary>
+    public string Name = "";
+
+    /// <summary>Pagination cursor; null = start (RANDOM sort makes restarts harmless).</summary>
+    public string? Iterator;
+
+    /// <summary>Alternates VIDEO/GIF so gif-heavy communities still fill the feed
+    /// (scrolller serves "GIFs" as silent webm/mp4 — video tiles to us either way).</summary>
+    public bool NextFilterIsGif;
+
+    /// <summary>A filter that returned zero usable items twice stops being asked for.</summary>
+    public bool VideoFilterDead;
+    public bool GifFilterDead;
+    public int EmptyVideoPages;
+    public int EmptyGifPages;
+
+    /// <summary>Consecutive hard failures; the channel is skipped after 3 (reset on success).</summary>
+    public int Failures;
+
+    /// <summary>The subreddit didn't resolve at all — never ask again this session.</summary>
+    public bool Dead;
+}

--- a/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/ScrolllerSource.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Fyp.Online;
+
+/// <summary>
+/// Scrolller (scrolller.com) as a For You feed source: a Reddit media aggregator with an
+/// unofficial GraphQL API. Everything here was live-verified 2026-08-10:
+///
+///   * Endpoint is <c>POST https://api.scrolller.com/admin</c> with a JSON body of
+///     <c>{query, variables, authorization:null}</c> (the /api/v2/graphql path serves the
+///     website shell now; gallery-dl's extractor is the reference client).
+///   * <c>SubredditQuery</c> alone both resolves a subreddit AND paginates its media via
+///     <c>children.iterator</c> — the separate children query's input schema has drifted,
+///     so we never use it. <c>sortBy: RANDOM</c> + iterator gives non-overlapping pages.
+///   * <c>mediaSources</c> mixes real video (webm/mp4), a <c>_thumb</c> webm and webp/jpg
+///     stills; the pick is "largest non-thumb webm/mp4". CDN hotlinks with no Referer
+///     (HTTP 206, range OK) and webm is Chromium-native, so entries play as-is.
+///
+/// Runs entirely on the user's device (see <see cref="IFeedSource"/>'s bright line) and
+/// mirrors gallery-dl's politeness: one request per second, modest page sizes.
+/// </summary>
+internal sealed class ScrolllerSource : IFeedSource
+{
+    public string Id => "scrolller";
+
+    private const string Endpoint = "https://api.scrolller.com/admin";
+    private const int PageLimit = 30;
+    private const int MaxSourceWidth = 1920;          // don't stream 4K into a feed tile
+    private static readonly TimeSpan MinRequestGap = TimeSpan.FromSeconds(1.1);
+
+    // Field subset of the reference SubredditQuery — GraphQL lets us ask for less.
+    private const string SubredditQuery = @"
+query SubredditQuery($url: String!, $iterator: String, $sortBy: GallerySortBy, $filter: GalleryFilter, $limit: Int!) {
+    getSubreddit(data: {url: $url, iterator: $iterator, filter: $filter, limit: $limit, sortBy: $sortBy}) {
+        id url title isNsfw videoCount
+        children {
+            iterator
+            items { id title subredditTitle hasAudio mediaSources { url width height isOptimized } }
+        }
+    }
+}";
+
+    private static readonly HttpClient Http = CreateClient();
+    private static readonly SemaphoreSlim RequestGate = new(1, 1);
+    private static DateTime _lastRequestUtc = DateTime.MinValue;
+
+    private static HttpClient CreateClient()
+    {
+        var c = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+        c.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36");
+        c.DefaultRequestHeaders.TryAddWithoutValidation("Origin", "https://scrolller.com");
+        c.DefaultRequestHeaders.TryAddWithoutValidation("Referer", "https://scrolller.com/");
+        return c;
+    }
+
+    public async Task<FeedPage?> FetchPageAsync(FeedChannelState channel, CancellationToken ct)
+    {
+        // Filter rotation: VIDEO and GIF alternate so gif-heavy subreddits still produce
+        // (scrolller GIFs are silent webm — video entries to the feed). A filter that
+        // comes back empty twice is retired for the channel.
+        string filter;
+        if (channel.VideoFilterDead && channel.GifFilterDead) return new FeedPage();
+        if (channel.VideoFilterDead) filter = "GIF";
+        else if (channel.GifFilterDead) filter = "VIDEO";
+        else filter = channel.NextFilterIsGif ? "GIF" : "VIDEO";
+        channel.NextFilterIsGif = !channel.NextFilterIsGif;
+
+        var variables = new JObject
+        {
+            ["url"] = "/r/" + channel.Name,
+            ["iterator"] = channel.Iterator != null ? channel.Iterator : JValue.CreateNull(),
+            ["sortBy"] = "RANDOM",
+            ["filter"] = filter,
+            ["limit"] = PageLimit,
+        };
+
+        var data = await RequestGraphQlAsync(SubredditQuery, variables, ct).ConfigureAwait(false);
+        if (data == null) return null;
+
+        var sub = data["getSubreddit"];
+        if (sub == null || sub.Type == JTokenType.Null)
+        {
+            // The subreddit doesn't exist on scrolller (or was removed): not an error,
+            // a dead channel. Caller retires it for the session.
+            channel.Dead = true;
+            App.Logger?.Information("[FYP online] r/{Sub} does not resolve on scrolller — channel retired", channel.Name);
+            return new FeedPage();
+        }
+
+        var items = sub["children"]?["items"] as JArray;
+        var iterator = (string?)sub["children"]?["iterator"];
+        var entries = new List<FypAssetManifest.Entry>();
+        if (items != null)
+        {
+            foreach (var item in items)
+            {
+                var e = MapItem(item, channel.Name);
+                if (e != null) entries.Add(e);
+            }
+        }
+
+        if (entries.Count == 0)
+        {
+            if (filter == "GIF" && ++channel.EmptyGifPages >= 2) channel.GifFilterDead = true;
+            if (filter == "VIDEO" && ++channel.EmptyVideoPages >= 2) channel.VideoFilterDead = true;
+        }
+
+        return new FeedPage { Entries = entries, NextIterator = iterator };
+    }
+
+    /// <summary>One scrolller post → one feed entry, or null when it has no playable
+    /// video source. Id shape "scrolller/&lt;sub&gt;/&lt;postId&gt;" — path-style on purpose:
+    /// segIds are "id:k", so ids must never contain ':', and the middle segment is what
+    /// lets clip-viewed reports attribute dwell back to the channel.</summary>
+    private static FypAssetManifest.Entry? MapItem(JToken item, string sub)
+    {
+        var sources = item["mediaSources"] as JArray;
+        if (sources == null || sources.Count == 0) return null;
+
+        JToken? best = null;
+        int bestWidth = -1;
+        foreach (var s in sources)
+        {
+            var url = (string?)s["url"];
+            if (string.IsNullOrEmpty(url)) continue;
+            bool isVideo = url.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+                        || url.EndsWith(".webm", StringComparison.OrdinalIgnoreCase);
+            if (!isVideo || url.Contains("_thumb", StringComparison.OrdinalIgnoreCase)) continue;
+            int w = (int?)s["width"] ?? 0;
+            // Prefer the largest rendition under the cap; a source over the cap only
+            // wins when nothing smaller exists.
+            bool better = best == null
+                || (w <= MaxSourceWidth && (bestWidth > MaxSourceWidth || w > bestWidth))
+                || (w > MaxSourceWidth && bestWidth > MaxSourceWidth && w < bestWidth);
+            if (better) { best = s; bestWidth = w; }
+        }
+        if (best == null) return null;
+
+        long postId = (long?)item["id"] ?? 0;
+        if (postId <= 0) return null;
+
+        var title = ((string?)item["title"] ?? "").Trim();
+        if (title.Length > 90) title = title[..87] + "...";
+
+        return new FypAssetManifest.Entry
+        {
+            Id = $"scrolller/{sub}/{postId}",
+            Url = (string?)best["url"] ?? "",
+            Type = "video",              // scrolller "GIFs" arrive as silent webm/mp4
+            Filename = title.Length > 0 ? title : $"r/{sub}",
+            Folder = "r/" + sub,
+            Width = (int?)best["width"],
+            Height = (int?)best["height"],
+            Origin = "online",
+        };
+    }
+
+    /// <summary>POST one GraphQL operation, globally throttled to ~1 req/s. Returns the
+    /// "data" object, or null on transport/HTTP/GraphQL-error failure (logged).</summary>
+    private static async Task<JObject?> RequestGraphQlAsync(string query, JObject variables, CancellationToken ct)
+    {
+        await RequestGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var wait = MinRequestGap - (DateTime.UtcNow - _lastRequestUtc);
+            if (wait > TimeSpan.Zero) await Task.Delay(wait, ct).ConfigureAwait(false);
+            _lastRequestUtc = DateTime.UtcNow;
+
+            var body = new JObject
+            {
+                ["query"] = query,
+                ["variables"] = variables,
+                ["authorization"] = JValue.CreateNull(),
+            };
+            using var content = new StringContent(body.ToString(Newtonsoft.Json.Formatting.None),
+                Encoding.UTF8, "application/json");
+            using var resp = await Http.PostAsync(Endpoint, content, ct).ConfigureAwait(false);
+            var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                App.Logger?.Warning("[FYP online] scrolller API HTTP {Code}: {Body}",
+                    (int)resp.StatusCode, text.Length > 200 ? text[..200] : text);
+                return null;
+            }
+            var parsed = JObject.Parse(text);
+            if (parsed["errors"] is JArray { Count: > 0 } errors)
+            {
+                App.Logger?.Warning("[FYP online] scrolller GraphQL error: {E}",
+                    (string?)errors[0]?["message"] ?? "unknown");
+                return null;
+            }
+            return parsed["data"] as JObject;
+        }
+        catch (OperationCanceledException) { return null; }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("[FYP online] scrolller request failed: {E}", ex.Message);
+            return null;
+        }
+        finally { RequestGate.Release(); }
+    }
+}


### PR DESCRIPTION
## What

The For You feed gains an **Online source**: endless clips streamed from Scrolller (public Reddit media browser), pickable by niche (Hypno, Bimbo, Sissy, Hentai, Censored, BBC, Goon, Amateur) plus user-added subreddits. Three modes: **Library / Mixed (ratio slider) / Online**.

This kills the content-acquisition friction (Discord hunting, pack installs): open feed, it's full.

## The bright line

**The client fetches. We never proxy.** Every API/CDN request goes straight from the user's device to Scrolller. No CC Labs server ever proxies, caches, or re-serves online media - that keeps the payment-processor surface clean, makes their per-IP rate limit per-user, and keeps us legally a client. Review any change to this feature against that rule (full rationale in `planning/fyp-online/DESIGN.md`, gitignored).

## How

- **`ScrolllerSource`** - GraphQL client for `api.scrolller.com/admin` (live-verified 2026-08-10: `SubredditQuery` resolves + paginates via iterator with `sortBy: RANDOM`; children-query variant has schema-drifted and is not used). Picks the largest non-`_thumb` webm/mp4 rendition ≤1080p; VIDEO/GIF filter rotation (scrolller GIFs are silent webm). ~1 req/s politeness, 30/page.
- **`FypOnlineCoordinator`** - niches → subreddit channels, weighted channel rotation biased by per-channel dwell EWMA (`fyp_online.json`). That's the online "For You" algorithm: per-segment stats are useless for one-shot clips, so taste is learned per channel.
- **Bridge**: page posts `need-remote` when its buffer runs low; host replies `assets-append` + `online-status`. Single-flight, dry-channel backoff, offline falls back to library with a status note - never a dead feed.
- **`feed.js append()`** - grows the pool **without** the `configure()` reset (which would yank the user to the top on every batch), and updates the pool-identity key so later layout/gif toggles don't misread growth as a new pool. Mixed-mode ratio is applied **at pick time**, not by pool rationing (local videos expand into many segments; pool ratios would lie). Headless-tested: measured share 0.50 at a 0.5 setting, append is reset-free, dedupe works, empty-boot builds pages.
- **Consent**: one-time card before the source can leave Library ("adult content from the internet, not curated by CC Labs, fetched by your device"). Host enforces it too (a stale page can't skip it).
- **Hygiene**: `scrolller/` ids never enter `fyp_meta.json` (probe backfill or fail strikes) or the page's per-segment stats; remote pool is session-scoped and capped at 1500 entries.

## Verified

- Live API spike: subreddit resolve, NSFW children, iterator pagination (zero overlap), 13 starter subreddits existence-checked, CDN hotlink with no Referer (HTTP 206, webm).
- `dotnet build` clean (0 errors).
- `feed.js` functional test (node, headless): configure/mix/append/dedupe/poolKey/empty-boot/swapTile all pass.
- Owed: in-app play-test (consent card → niche pick → scroll, mixed ratio feel, offline behavior).

## Deferred by design

Save-to-library ("heart") is **parked until CCBill is fully live** - it pipes third-party media into CCP's own surfaces (Tier-3-adjacent). RedGifs as provider #2 slots into `IFeedSource` when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aZ2c2Tqx7ELKbwh8BPGJZ