### PR TITLE
One Descent silent patch: install-date recording + {petname}/{collective} vocab plumbing

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1398,6 +1398,12 @@ namespace ConditioningControlPanel
                 Logger?.Warning(ex, "Settings migration failed (non-fatal, defaults apply)");
             }
 
+            // One Descent: stamp this install's age once, from whatever on-disk evidence still
+            // exists. Silent — nothing in the UI reads it. Must run after Settings so it can read
+            // and persist the field, and early enough that the first profile sync of the session
+            // (which is what ships it) already has it.
+            EnsureInstallDateRecorded();
+
             // Migrate assets from old location (install dir) to new location (user data) in background.
             // MUST run after Settings is initialized: the migration both READS the "already migrated"
             // guard and WRITES the completion flag, and if Settings.Current is still null (as it was
@@ -3767,6 +3773,117 @@ Application State:
             }
 
             return migratedCount;
+        }
+
+        /// <summary>
+        /// Earliest install date this client will ever report. Mirrors the server's
+        /// INSTALL_DATE_FLOOR (ccp-server proxy/descent.js): anything older is a broken clock or a
+        /// file-system artefact, not a real install, and the server drops it silently.
+        /// </summary>
+        private static readonly DateTime InstallDateFloorUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// One Descent (PLAN.md Phase A): record this install's age ONCE, from the oldest on-disk
+        /// evidence still available. Silent — no UI reads <see cref="AppSettings.InstallDate"/>; the
+        /// only consumer is the <c>install_date</c> field on the v2 profile-sync payload, which the
+        /// server stores as <c>legacy_install_date</c> (also once) as fallback data for the Year One
+        /// anchor.
+        ///
+        /// Written once and only once, because every source of evidence decays: log files rotate,
+        /// installers rewrite the program folder, and settings.json is recreated by the corrupt-file
+        /// recovery path. A value re-derived a year from now would look NEWER than the truth, so the
+        /// first stamp — taken while the evidence is freshest — is the one that stands.
+        ///
+        /// Never throws and never blocks startup: every probe is individually guarded and the whole
+        /// thing falls back to today.
+        /// </summary>
+        private static void EnsureInstallDateRecorded()
+        {
+            try
+            {
+                var settings = Settings?.Current;
+                if (settings == null) return;
+                if (!string.IsNullOrWhiteSpace(settings.InstallDate)) return;
+
+                var resolved = ResolveInstallDateUtc();
+                settings.InstallDate = resolved.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
+                Settings?.Save();
+                Logger?.Information("[Descent] Recorded install date {Date} (one-shot, from on-disk evidence)", settings.InstallDate);
+            }
+            catch (Exception ex)
+            {
+                // Deliberately Debug, not Warning: this is inert fallback data. A user whose
+                // install date never gets recorded loses nothing they can see.
+                Logger?.Debug(ex, "[Descent] Install-date recording failed (non-fatal, field stays unset)");
+            }
+        }
+
+        /// <summary>
+        /// Best evidence of true install age, as the EARLIEST of, in order of trustworthiness
+        /// (they are all compared, not short-circuited — the oldest wins):
+        /// <list type="number">
+        /// <item>settings.json CreationTimeUtc — written on the first launch that ever saved settings;</item>
+        /// <item>the executable directory's CreationTimeUtc — written by the installer, but an
+        /// in-place upgrade or a move/copy of the install folder resets it, so it can read NEWER
+        /// than the truth;</item>
+        /// <item>the oldest file in the logs folder — survives reinstalls that keep user data, but
+        /// Serilog's retention window eventually eats the early ones.</item>
+        /// </list>
+        /// Falls back to today when nothing is readable, then clamps into
+        /// [<see cref="InstallDateFloorUtc"/>, today] — a future date (bad clock) would be rejected
+        /// by the server anyway, and a pre-2020 one is an artefact.
+        /// </summary>
+        private static DateTime ResolveInstallDateUtc()
+        {
+            var today = DateTime.UtcNow.Date;
+            DateTime? earliest = null;
+
+            void Consider(DateTime? candidate)
+            {
+                if (candidate is not DateTime c) return;
+                // A missing file reports 1601-01-01 rather than throwing; the floor check below
+                // would catch it, but rejecting it here keeps "earliest" honest.
+                if (c < InstallDateFloorUtc) return;
+                if (earliest == null || c < earliest) earliest = c;
+            }
+
+            // 1. settings.json
+            try
+            {
+                var settingsPath = Path.Combine(UserDataPath, "settings.json");
+                if (File.Exists(settingsPath))
+                    Consider(File.GetCreationTimeUtc(settingsPath));
+            }
+            catch (Exception ex) { Logger?.Debug(ex, "[Descent] settings.json install-date probe failed"); }
+
+            // 2. Executable directory
+            try
+            {
+                var exeDir = AppDomain.CurrentDomain.BaseDirectory;
+                if (!string.IsNullOrEmpty(exeDir) && Directory.Exists(exeDir))
+                    Consider(Directory.GetCreationTimeUtc(exeDir));
+            }
+            catch (Exception ex) { Logger?.Debug(ex, "[Descent] exe-dir install-date probe failed"); }
+
+            // 3. Oldest file in the logs folder
+            try
+            {
+                var logDir = Path.Combine(UserDataPath, "logs");
+                if (Directory.Exists(logDir))
+                {
+                    foreach (var file in Directory.EnumerateFiles(logDir))
+                    {
+                        try { Consider(File.GetCreationTimeUtc(file)); }
+                        catch { /* one unreadable log file must not lose the other candidates */ }
+                    }
+                }
+            }
+            catch (Exception ex) { Logger?.Debug(ex, "[Descent] logs install-date probe failed"); }
+
+            var result = (earliest ?? DateTime.UtcNow).Date;
+            if (result < InstallDateFloorUtc) result = InstallDateFloorUtc.Date;
+            if (result > today) result = today;
+            return result;
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Localization/LocalizationManager.cs
+++ b/ConditioningControlPanel/Localization/LocalizationManager.cs
@@ -126,6 +126,12 @@ namespace ConditioningControlPanel.Localization
 
         /// <summary>
         /// Get a localized string by key. Falls back to English, then to the key itself.
+        ///
+        /// Descent vocabulary tokens (<c>{petname}</c>, <c>{collective}</c>) are substituted on the
+        /// way out - see <see cref="VocabTokens"/>. That happens AFTER the English fallback on
+        /// purpose: a key that only exists in en.json must still come back with the active mod's
+        /// words in it, not with raw tokens. No shipped string contains a token yet, so today this
+        /// costs one character scan per lookup.
         /// </summary>
         public string Get(string key)
         {
@@ -133,10 +139,10 @@ namespace ConditioningControlPanel.Localization
                 return string.Empty;
 
             if (_strings.TryGetValue(key, out var value))
-                return value;
+                return VocabTokens.Apply(value);
 
             if (_fallbackStrings.TryGetValue(key, out var fallback))
-                return fallback;
+                return VocabTokens.Apply(fallback);
 
             // Return key as-is so untranslated strings are visible during development
             return key;

--- a/ConditioningControlPanel/Localization/VocabTokens.cs
+++ b/ConditioningControlPanel/Localization/VocabTokens.cs
@@ -26,19 +26,17 @@ namespace ConditioningControlPanel.Localization
         public const string CollectiveToken = "{collective}";
 
         // ---------------------------------------------------------------------------------
-        // VANILLA DEFAULTS — the two lines to edit when the name is decided.
-        //
-        // OPEN DECISION (planning/one-descent/DECISIONS.md, 2026-08-10): the vanilla petname is
-        // still awaiting the owner's sign-off; "dreamer"/"dreamers" is the working candidate, not
-        // the final word. Nothing else in the codebase hard-codes either value — changing these two
-        // consts changes every unmodded surface — so this is the single config point.
+        // VANILLA DEFAULTS — owner-locked 2026-08-12: "sweetie"/"sweeties"
+        // (planning/one-descent/DECISIONS.md). Nothing else in the codebase hard-codes either
+        // value — changing these two consts changes every unmodded surface — so this stays the
+        // single config point.
         // ---------------------------------------------------------------------------------
 
-        /// <summary>Vanilla (no mod override) value for <c>{petname}</c>. PENDING OWNER SIGN-OFF.</summary>
-        public const string VanillaPetName = "dreamer";
+        /// <summary>Vanilla (no mod override) value for <c>{petname}</c>.</summary>
+        public const string VanillaPetName = "sweetie";
 
-        /// <summary>Vanilla (no mod override) value for <c>{collective}</c>. PENDING OWNER SIGN-OFF.</summary>
-        public const string VanillaCollective = "dreamers";
+        /// <summary>Vanilla (no mod override) value for <c>{collective}</c>.</summary>
+        public const string VanillaCollective = "sweeties";
 
         /// <summary>
         /// Resolved values for one manifest, cached so the substitution pass does not re-walk the

--- a/ConditioningControlPanel/Localization/VocabTokens.cs
+++ b/ConditioningControlPanel/Localization/VocabTokens.cs
@@ -1,0 +1,124 @@
+using System;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel.Localization
+{
+    /// <summary>
+    /// Descent vocabulary tokens (master doc §1B): localized strings may write <c>{petname}</c> and
+    /// <c>{collective}</c> instead of hard-coding a mod's word for the user, and this class swaps in
+    /// whatever the ACTIVE mod calls them — one English sentence, nine languages, every mod.
+    ///
+    /// The pass runs inside <see cref="LocalizationManager.Get"/>, after the key lookup and after the
+    /// English fallback, so a string that only exists in en.json gets its tokens resolved too.
+    ///
+    /// INERT AS SHIPPED: no language file contains either token yet (this patch does not touch the
+    /// nine JSON files), and no built-in mod sets an override, so every call is a single
+    /// <c>IndexOf('{')</c> that misses. The plumbing lands first so the strings that need it can be
+    /// written without a second round of code.
+    ///
+    /// Matching is exact and case-sensitive — <c>{petname}</c>, not <c>{PetName}</c> or
+    /// <c>{ petname }</c> — because these tokens travel through translator hands and a fuzzy matcher
+    /// would silently "fix" typos into strings nobody reviewed.
+    /// </summary>
+    public static class VocabTokens
+    {
+        public const string PetNameToken = "{petname}";
+        public const string CollectiveToken = "{collective}";
+
+        // ---------------------------------------------------------------------------------
+        // VANILLA DEFAULTS — the two lines to edit when the name is decided.
+        //
+        // OPEN DECISION (planning/one-descent/DECISIONS.md, 2026-08-10): the vanilla petname is
+        // still awaiting the owner's sign-off; "dreamer"/"dreamers" is the working candidate, not
+        // the final word. Nothing else in the codebase hard-codes either value — changing these two
+        // consts changes every unmodded surface — so this is the single config point.
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>Vanilla (no mod override) value for <c>{petname}</c>. PENDING OWNER SIGN-OFF.</summary>
+        public const string VanillaPetName = "dreamer";
+
+        /// <summary>Vanilla (no mod override) value for <c>{collective}</c>. PENDING OWNER SIGN-OFF.</summary>
+        public const string VanillaCollective = "dreamers";
+
+        /// <summary>
+        /// Resolved values for one manifest, cached so the substitution pass does not re-walk the
+        /// mod chain on every binding read. Immutable + swapped as a whole reference, so a reader on
+        /// another thread sees either the old pair or the new pair, never a half-updated one.
+        /// </summary>
+        private sealed class Resolved
+        {
+            public ModManifest? Source;
+            public string PetName = VanillaPetName;
+            public string Collective = VanillaCollective;
+        }
+
+        private static Resolved _cache = new();
+
+        /// <summary>The active mod's word for one user, or the vanilla default.</summary>
+        public static string PetName => Current().PetName;
+
+        /// <summary>The active mod's word for the user base, or the vanilla default.</summary>
+        public static string Collective => Current().Collective;
+
+        /// <summary>
+        /// Replace every vocabulary token in <paramref name="text"/>. Returns the input unchanged
+        /// when there is nothing to do — which is the overwhelmingly common case, so the check is a
+        /// single character scan before anything else happens.
+        /// </summary>
+        public static string Apply(string? text)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
+            if (text.IndexOf('{') < 0) return text;
+
+            var hasPet = text.Contains(PetNameToken, StringComparison.Ordinal);
+            var hasCollective = text.Contains(CollectiveToken, StringComparison.Ordinal);
+            if (!hasPet && !hasCollective) return text;
+
+            var resolved = Current();
+            var result = text;
+            if (hasPet) result = result.Replace(PetNameToken, resolved.PetName, StringComparison.Ordinal);
+            if (hasCollective) result = result.Replace(CollectiveToken, resolved.Collective, StringComparison.Ordinal);
+            return result;
+        }
+
+        /// <summary>
+        /// Drop the cached pair. Only needed when a manifest is mutated IN PLACE (the mod creator
+        /// editing the active mod) — a normal mod switch installs a new manifest object, which the
+        /// reference check below notices on its own.
+        /// </summary>
+        public static void Invalidate() => _cache = new Resolved { Source = null };
+
+        private static Resolved Current()
+        {
+            ModManifest? manifest = null;
+            try
+            {
+                manifest = App.Mods?.ActiveMod?.Manifest;
+            }
+            catch
+            {
+                // Startup ordering: localization initializes BEFORE the mod system, so the very
+                // first reads land here with no ModService at all. Vanilla defaults are the right
+                // answer then, and a throwing mod layer must never take a UI string with it.
+            }
+
+            var cached = _cache;
+            if (ReferenceEquals(cached.Source, manifest)) return cached;
+
+            var fresh = new Resolved { Source = manifest };
+            try
+            {
+                fresh.PetName = App.Mods?.GetPetNameOverride() ?? VanillaPetName;
+                fresh.Collective = App.Mods?.GetCollectiveOverride() ?? VanillaCollective;
+            }
+            catch
+            {
+                fresh.PetName = VanillaPetName;
+                fresh.Collective = VanillaCollective;
+            }
+
+            _cache = fresh;
+            return fresh;
+        }
+    }
+}

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -6254,6 +6254,33 @@ namespace ConditioningControlPanel.Models
 
         #endregion
 
+        #region One Descent
+
+        private string? _installDate = null;
+        /// <summary>
+        /// Best available evidence of when this install first appeared on this machine, as a UTC
+        /// <c>yyyy-MM-dd</c> string. Written ONCE by <c>App.EnsureInstallDateRecorded</c> on the
+        /// first launch that finds it absent (see that method for the evidence ordering) and never
+        /// touched again — a re-derived value would drift downward as old files are cleaned up.
+        ///
+        /// Sent to the server as <c>install_date</c> on POST /v2/user/sync, where it lands in
+        /// <c>legacy_install_date</c> (also stored once). This is LEGACY FALLBACK DATA ONLY: the
+        /// Descent's Year One anchor is the migration-ceremony date for veterans and account
+        /// creation for new users (DECISIONS.md 2026-08-10). Nothing in the UI reads it.
+        ///
+        /// Null on installs that predate this field only until their next launch. Never blank —
+        /// the recorder falls back to today rather than writing an empty string, so
+        /// "null" reliably means "not recorded yet".
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string? InstallDate
+        {
+            get => _installDate;
+            set { _installDate = value; OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Migrations
 
         /// <summary>

--- a/ConditioningControlPanel/Models/ModManifest.cs
+++ b/ConditioningControlPanel/Models/ModManifest.cs
@@ -179,6 +179,30 @@ namespace ConditioningControlPanel.Models
         /// </summary>
         [JsonProperty("rankSubject")]
         public string? RankSubject { get; set; }
+
+        /// <summary>
+        /// Descent vocabulary: what this mod calls ONE user inside narrative copy — the value that
+        /// replaces the <c>{petname}</c> token in localized strings (see
+        /// <see cref="Localization.VocabTokens"/>). Unset on every built-in mod today, which means
+        /// every token resolves to the vanilla default.
+        ///
+        /// Deliberately NOT the same field as <see cref="UserTerm"/>: UserTerm is a UI label
+        /// ("Bambi", "Subject", "Unit") that appears title-cased in buttons and headings, while
+        /// petName is written into running prose and wants the mod's in-fiction lowercase address.
+        /// A mod that wants them identical just sets both.
+        /// </summary>
+        [JsonProperty("petName")]
+        public string? PetName { get; set; }
+
+        /// <summary>
+        /// Descent vocabulary: what this mod calls the user base as a group — the value that
+        /// replaces the <c>{collective}</c> token (plural of <see cref="PetName"/> in practice, but
+        /// free-form: a mod may prefer a group noun over a plural). Unset falls back to the vanilla
+        /// default; there is no automatic pluralization of <see cref="PetName"/>, because guessing
+        /// plurals across nine localized languages is a worse failure than a default.
+        /// </summary>
+        [JsonProperty("collective")]
+        public string? Collective { get; set; }
     }
 
     public class ModTriggers

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -609,6 +609,10 @@ namespace ConditioningControlPanel.Services
                 if (manifest.Identity.TakeoverLabel?.Length > 200) manifest.Identity.TakeoverLabel = manifest.Identity.TakeoverLabel[..200];
                 if (manifest.Identity.Affirmation?.Length > 200) manifest.Identity.Affirmation = manifest.Identity.Affirmation[..200];
                 if (manifest.Identity.RankSubject?.Length > 200) manifest.Identity.RankSubject = manifest.Identity.RankSubject[..200];
+                // Descent vocabulary. Capped shorter than the rest on purpose: these are substituted
+                // INTO sentences, so a 200-char "pet name" would blow out every layout it lands in.
+                if (manifest.Identity.PetName?.Length > 40) manifest.Identity.PetName = manifest.Identity.PetName[..40];
+                if (manifest.Identity.Collective?.Length > 40) manifest.Identity.Collective = manifest.Identity.Collective[..40];
             }
             if (manifest.Messages != null)
             {
@@ -987,6 +991,23 @@ namespace ConditioningControlPanel.Services
             if (!string.IsNullOrEmpty(rank)) return rank;
             return GetUserTerm();
         }
+
+        // ---- Descent vocabulary ({petname} / {collective}) ----
+        // These deliberately return NULL rather than a default, and deliberately do NOT walk the
+        // ActiveMod → BaseMod chain the other accessors use. The base mod (CCP Default) carries
+        // UserTerm "Subject", which is a UI label, not the vanilla narrative pet name — routing
+        // through it would silently make "Subject" the vanilla answer and bury the real default.
+        // The one owner of the default is Localization.VocabTokens; null here means "this mod has
+        // no opinion, use the vanilla word".
+
+        /// <summary>Active mod's <c>{petname}</c> override, or null when it sets none.</summary>
+        public string? GetPetNameOverride() => NullIfBlank(_activeMod.Manifest.Identity?.PetName);
+
+        /// <summary>Active mod's <c>{collective}</c> override, or null when it sets none.</summary>
+        public string? GetCollectiveOverride() => NullIfBlank(_activeMod.Manifest.Identity?.Collective);
+
+        private static string? NullIfBlank(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
         // Pool defaults
         public Dictionary<string, bool> GetDefaultSubliminalPool() =>

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1202,6 +1202,13 @@ namespace ConditioningControlPanel.Services
                         // local loadout is empty and unconfirmed - see BuildCosmeticsPayload, an
                         // all-empty object means "unequip everything" to the server.
                         cosmetics = BuildCosmeticsPayload(settings),
+                        // One Descent (PLAN.md Phase A): best on-disk evidence of this install's
+                        // age, stamped once at startup (App.EnsureInstallDateRecorded). The server
+                        // stores it once as legacy_install_date and silently drops anything it
+                        // cannot parse, so a null here — every sync before the field was ever
+                        // recorded — is a no-op, not an error. Fallback data for the Year One
+                        // anchor only; nothing reads it back.
+                        install_date = string.IsNullOrWhiteSpace(settings.InstallDate) ? null : settings.InstallDate,
                         // Send false to clear server-side reset flags only when acknowledging
                         reset_weekly_quest = false,
                         reset_daily_quest = false,

--- a/Tests/ConditioningControlPanel.Tests/VocabTokensTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/VocabTokensTests.cs
@@ -1,0 +1,74 @@
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Descent vocabulary plumbing ({petname} / {collective}).
+///
+/// These run with no ModService alive, which is exactly the vanilla case: no active mod means no
+/// override, so both tokens must resolve to the defaults in <see cref="VocabTokens"/>. The pass is
+/// inert as shipped (no language file uses a token yet), so the thing worth pinning is that it
+/// stays inert for everything that ISN'T a token — a substitution pass that "helpfully" matched
+/// {0}, {Petname} or { petname } would corrupt strings across nine languages.
+/// </summary>
+public class VocabTokensTests
+{
+    [Fact]
+    public void VanillaPetName_ReplacesToken()
+        => Assert.Equal($"good {VocabTokens.VanillaPetName}", VocabTokens.Apply("good {petname}"));
+
+    [Fact]
+    public void VanillaCollective_ReplacesToken()
+        => Assert.Equal($"all {VocabTokens.VanillaCollective}", VocabTokens.Apply("all {collective}"));
+
+    [Fact]
+    public void BothTokens_AndRepeats_AllReplaced()
+    {
+        var result = VocabTokens.Apply("{petname}, {petname}, and every {collective}");
+        Assert.Equal(
+            $"{VocabTokens.VanillaPetName}, {VocabTokens.VanillaPetName}, and every {VocabTokens.VanillaCollective}",
+            result);
+    }
+
+    [Theory]
+    [InlineData("Start Flashes")]                 // the overwhelmingly common case: no braces at all
+    [InlineData("You reached level {0}!")]        // string.Format placeholder must survive untouched
+    [InlineData("{PetName}")]                     // case-sensitive on purpose
+    [InlineData("{ petname }")]                   // exact braces on purpose
+    [InlineData("{petnames}")]
+    [InlineData("petname")]
+    public void NonTokens_PassThroughUnchanged(string input)
+        => Assert.Equal(input, VocabTokens.Apply(input));
+
+    [Fact]
+    public void NullAndEmpty_AreSafe()
+    {
+        Assert.Equal(string.Empty, VocabTokens.Apply(null));
+        Assert.Equal(string.Empty, VocabTokens.Apply(string.Empty));
+    }
+
+    [Fact]
+    public void ManifestCarriesTheOverrideFields()
+    {
+        // The wire shape a mod author writes. Nothing reads these yet beyond
+        // ModService.GetPetNameOverride/GetCollectiveOverride, so the deserialization contract is
+        // the part worth locking down.
+        const string json = """
+        { "petName": "bambi", "collective": "bambis" }
+        """;
+        var identity = JsonConvert.DeserializeObject<ModIdentity>(json)!;
+        Assert.Equal("bambi", identity.PetName);
+        Assert.Equal("bambis", identity.Collective);
+    }
+
+    [Fact]
+    public void ManifestWithoutTheFields_LeavesThemNull()
+    {
+        var identity = JsonConvert.DeserializeObject<ModIdentity>("""{ "userTerm": "Subject" }""")!;
+        Assert.Null(identity.PetName);
+        Assert.Null(identity.Collective);
+    }
+}


### PR DESCRIPTION
Desktop half of the August silent patch (One Descent program - tracker: planning/one-descent/). Zero user-visible change.

- **InstallDate**: recorded once on startup from the earliest of settings.json / install dir / oldest log creation time (2020 floor, today clamp, never re-derived), sent as install_date on the v2 sync payload (server receiving half already on ccp-server feat/one-descent-groundwork; null = no-op).
- **Vocab tokens**: {petname}/{collective} substitution in LocalizationManager.Get() (sole choke point, covers indexer/GetF/markup extension, applied to fallback hits too, runs before string.Format). Resolved from the active mod manifest's new optional Identity.petName/collective fields, else vanilla consts "dreamer"/"dreamers" (marked OPEN pending owner sign-off - single edit point). Inert: no language files touched, no built-in mod sets overrides.
- 12 new xunit tests (VocabTokensTests) all green; dotnet build 0 errors.

Build note: worktree path exceeded MAX_PATH (LongPathsEnabled=0) - built + tested via robocopy to a short path; see PR discussion/tracker for the trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkvtMhCL38SGQKdno3j4uH