### PR TITLE
feat(progression): apply server-minted web XP claims on sync (Phase B desktop)

### DIFF
--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5181,6 +5181,25 @@ namespace ConditioningControlPanel.Models
 
         #endregion
 
+        #region Web XP claim (claim-on-sync handshake)
+
+        private string? _lastWebXpClaimId = null;
+        /// <summary>
+        /// Id of the last web-XP claim this client APPLIED to the local ledger. The server mints XP
+        /// for verified web activity into a pending bucket and offers it back on /v2/user/sync as
+        /// {id, amount}; this field is both the "already paid" marker and the ack we echo up on every
+        /// subsequent sync so the server can settle. Persisted before the XP is added, never after —
+        /// see the handshake comment in ProfileSyncService. Null until the first claim ever lands.
+        /// </summary>
+        [JsonProperty]
+        public string? LastWebXpClaimId
+        {
+            get => _lastWebXpClaimId;
+            set { _lastWebXpClaimId = value; OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Season Recap (local-only, per-device)
 
         // The Season Recap Card surfaces a snapshot of the just-ended season at rollover.

--- a/ConditioningControlPanel/Services/Progression/ProgressionService.cs
+++ b/ConditioningControlPanel/Services/Progression/ProgressionService.cs
@@ -76,8 +76,62 @@ namespace ConditioningControlPanel.Services
 
             // Track for quests (only for "earn X XP" type quests)
             App.Quests?.TrackXPEarned((int)amount);
-            
+
             // Check for level up
+            SpendXPOnLevels(settings, inOfflineMode);
+
+            XPChanged?.Invoke(this, settings.PlayerXP);
+        }
+
+        /// <summary>
+        /// Awards XP that the server already decided the exact size of - currently only the web XP
+        /// claim settled through /v2/user/sync (see ProfileSyncService's claim handshake).
+        ///
+        /// Deliberately NOT AddXP: the amount is the server's, so it takes no skill-tree multiplier,
+        /// no idle suppression, no companion routing and no quest credit - doubling it here would let
+        /// a web action out-earn the same action in the app. What it DOES share is the level-up loop,
+        /// so a claim that pushes the player over the line gets the full level-up experience
+        /// (celebration, haptics, level achievements, skill points, leaderboard sync).
+        /// </summary>
+        /// <param name="amount">Exact XP to add, as minted by the server.</param>
+        public void AddClaimedXP(double amount)
+        {
+            if (amount <= 0) return;
+
+            // Same gate as AddXP: logged in, or offline mode with a local username
+            var isOfflineMode = App.Settings?.Current?.OfflineMode == true;
+            var hasOfflineUsername = !string.IsNullOrWhiteSpace(App.Settings?.Current?.OfflineUsername);
+
+            if (!App.IsLoggedIn && !(isOfflineMode && hasOfflineUsername))
+            {
+                App.Logger?.Debug("Web XP claim not applied - user not logged in and not in offline mode");
+                return;
+            }
+
+            var inOfflineMode = isOfflineMode && hasOfflineUsername;
+            var settings = App.Settings?.Current;
+            if (settings == null) return;
+
+            var previousXP = settings.PlayerXP;
+            settings.PlayerXP += amount;
+
+            // Track total XP earned (for stats)
+            App.Achievements?.TrackXPEarned(amount);
+
+            App.Logger?.Information("Web XP claim applied: +{Amount} (was {Prev}, now {Now})", amount, previousXP, settings.PlayerXP);
+
+            SpendXPOnLevels(settings, inOfflineMode);
+
+            XPChanged?.Invoke(this, settings.PlayerXP);
+        }
+
+        /// <summary>
+        /// Drains banked XP into levels for as long as the player can afford the next one, running
+        /// the full level-up experience for each level gained. Shared by AddXP and AddClaimedXP so
+        /// the two ways XP can arrive can never drift apart.
+        /// </summary>
+        private void SpendXPOnLevels(Models.AppSettings settings, bool inOfflineMode)
+        {
             var xpNeeded = GetXPForLevel(settings.PlayerLevel);
             while (settings.PlayerXP >= xpNeeded)
             {
@@ -123,8 +177,6 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Debug("Offline mode: Skipped cloud sync for level up to {Level}", settings.PlayerLevel);
                 }
             }
-            
-            XPChanged?.Invoke(this, settings.PlayerXP);
         }
 
         public double GetXPForLevel(int level)

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -1202,6 +1202,12 @@ namespace ConditioningControlPanel.Services
                         // local loadout is empty and unconfirmed - see BuildCosmeticsPayload, an
                         // all-empty object means "unequip everything" to the server.
                         cosmetics = BuildCosmeticsPayload(settings),
+                        // Web XP claim ack: the id of the claim this client last APPLIED. Sent on
+                        // every sync, not just the one after a claim - the server settles the pending
+                        // bucket when it sees its own id come back, and ignores stale/unknown ones.
+                        // Null until the first claim ever lands, which is a perfectly good "nothing
+                        // applied yet" to the server.
+                        web_xp_claim_ack = settings.LastWebXpClaimId,
                         // Send false to clear server-side reset flags only when acknowledging
                         reset_weekly_quest = false,
                         reset_daily_quest = false,
@@ -1321,6 +1327,38 @@ namespace ConditioningControlPanel.Services
                         // Trainer Card cosmetics: fill-if-empty only, so a fresh machine inherits
                         // the look and an established one is never undressed by a stale echo.
                         if (AdoptCloudCosmetics(v2Result?.Cosmetics)) App.Settings?.Save();
+
+                        // WEB XP CLAIM. The server mints XP for verified web activity into a pending
+                        // bucket; it never touches the ledger the client authors (xp/level). It hands
+                        // that bucket over one claim at a time - {id, amount} on this response - and
+                        // THIS is the only door web XP walks through into real progression, so it
+                        // gets the normal level-up experience on the way in.
+                        //
+                        // The handshake is deliberately lopsided. We persist the id BEFORE adding the
+                        // XP, and we ack that id on every sync from then on. A crash in the gap costs
+                        // the player one claim; the other order would pay it twice on the next launch,
+                        // and under-paying once is the failure we can live with. The server re-offers
+                        // an unacked claim indefinitely, so nothing is lost by skipping a round -
+                        // which is exactly why level_reset skips: a season-reset response is about to
+                        // overwrite level and XP wholesale, and XP applied into that is XP thrown away.
+                        //
+                        // The whole block is a no-op when `web_xp` is absent (server flag off).
+                        var webXpClaim = v2Result?.WebXp?.Claim;
+                        if (webXpClaim != null &&
+                            !string.IsNullOrEmpty(webXpClaim.Id) &&
+                            webXpClaim.Amount > 0 &&
+                            webXpClaim.Id != settings.LastWebXpClaimId &&
+                            v2Result?.LevelReset != true)
+                        {
+                            App.Logger?.Information("V2 Sync: Web XP claim {ClaimId} — applying +{Amount} XP (pending {Pending}, lifetime {Total})",
+                                webXpClaim.Id, webXpClaim.Amount, v2Result?.WebXp?.Pending ?? 0, v2Result?.WebXp?.Total ?? 0);
+
+                            // Order is load-bearing — see above.
+                            settings.LastWebXpClaimId = webXpClaim.Id;
+                            App.Settings?.Save();
+
+                            App.Progression?.AddClaimedXP(webXpClaim.Amount);
+                        }
 
                         // Prestige: adopt the server's lifetime_points_spent when ahead (other
                         // device / migration backfill). Monotonic — never lowered.
@@ -3840,8 +3878,41 @@ namespace ConditioningControlPanel.Services
             [JsonProperty("companion_progress")]
             public Dictionary<string, Models.CompanionProgress>? CompanionProgress { get; set; }
 
+            /// <summary>
+            /// Web XP the server has minted for verified web activity, plus at most one claim to
+            /// hand over. Absent entirely while the server-side flag is off — nullable for exactly
+            /// that reason, and the claim handler treats absence as "nothing to do".
+            /// </summary>
+            [JsonProperty("web_xp")]
+            public V2WebXp? WebXp { get; set; }
+
             [JsonProperty("user")]
             public V2SyncUser? User { get; set; }
+        }
+
+        private class V2WebXp
+        {
+            /// <summary>XP minted but not yet handed to this client.</summary>
+            [JsonProperty("pending")]
+            public int Pending { get; set; }
+
+            /// <summary>Lifetime web XP for this account (informational — never applied directly).</summary>
+            [JsonProperty("total")]
+            public long Total { get; set; }
+
+            /// <summary>The one claim on offer, or null when there is nothing to settle.</summary>
+            [JsonProperty("claim")]
+            public V2WebXpClaim? Claim { get; set; }
+        }
+
+        private class V2WebXpClaim
+        {
+            /// <summary>Idempotency key — persisted locally once applied and echoed back as the ack.</summary>
+            [JsonProperty("id")]
+            public string? Id { get; set; }
+
+            [JsonProperty("amount")]
+            public int Amount { get; set; }
         }
 
         private class V2SyncUser


### PR DESCRIPTION
Desktop half of Web XP Phase B (server half: CCP-Server feat/web-xp-claim). The server mints XP for verified web activity into a pending bucket and offers it back on /v2/user/sync as `web_xp.claim = {id, amount}`; this PR makes the desktop apply that claim to the local ledger - the one and only door web XP walks through into real progression - and ack the id so the server settles.

- `AppSettings.LastWebXpClaimId` - persisted "already applied" marker, echoed up as `web_xp_claim_ack` on every sync.
- `ProgressionService.AddClaimedXP(amount)` - exact server-decided amount: no skill multiplier, no idle suppression, no companion/quest routing, but the FULL level-up loop (celebration, haptics, level achievements, skill points, milestone webhook, leaderboard sync). The loop is extracted into a shared `SpendXPOnLevels` so AddXP and AddClaimedXP can never drift; AddXP's observable behavior is unchanged.
- ProfileSyncService applies a claim only when id is fresh, amount > 0, and no level_reset handshake is in flight (the server re-offers indefinitely, so skipping a round loses nothing). Order is load-bearing: the id is persisted and saved BEFORE the XP is added - a crash in the gap under-pays one claim; the reverse order could double-pay forever.
- Absent `web_xp` field (server flag off) is a complete no-op; old servers and old clients interoperate cleanly in both directions.

Build clean, 0 new warnings. Test suite 2660/2660, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTZUrGYbe6QspHLTynxzXU
