### PR TITLE
feat(descent): phase-1 dark ship — spiral rail host + the four S-items

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -495,6 +495,14 @@ namespace ConditioningControlPanel
         /// reads it renders nothing at all when it is absent.
         /// </summary>
         public static Services.Descent.DescentService? Descent { get; private set; }
+
+        /// <summary>
+        /// LIVE EVENTS — the world event switchboard (themed bubble skin, accent
+        /// override, capped XP boost). Constructed dark and never armed in this
+        /// build: nothing calls Apply(), so every consumer falls through to the
+        /// behaviour it had before the seam existed. See LiveEventService.
+        /// </summary>
+        public static Services.Events.LiveEventService? LiveEvent { get; private set; }
         public static LeaderboardService Leaderboard { get; private set; } = null!;
         public static HapticService Haptics { get; private set; } = null!;
         public static AudioSyncService? AudioSync { get; private set; }
@@ -1547,6 +1555,12 @@ namespace ConditioningControlPanel
             // Initialize localization (must be after settings, before UI)
             LocalizationManager.Instance.Initialize(Settings?.Current?.Language ?? "en");
 
+            // The world-event switchboard, constructed DARK and never armed in this build.
+            // It goes up before ModService because the mod palette + resource chains both
+            // consult it on their very first resolve; constructed-but-empty is the state
+            // they are written against, and a null App.LiveEvent resolves identically.
+            LiveEvent = new Services.Events.LiveEventService();
+
             // Initialize mod system (must be after settings, before services that use content config)
             Mods = new ModService();
             Mods.Initialize(Settings?.Current?.ActiveModId);
@@ -1566,6 +1580,26 @@ namespace ConditioningControlPanel
             {
                 void Recolor()
                 {
+                    Services.RecapTheme.ApplyForActiveMod();
+                    Services.FxTheme.ApplyForActiveMod();
+                    foreach (Window w in Current.Windows)
+                        Services.WindowChromeHelper.ApplyDarkTitleBar(w);
+                }
+                if (Current?.Dispatcher?.CheckAccess() == true) Recolor();
+                else Current?.Dispatcher?.Invoke(Recolor);
+            };
+
+            // An event starting or ending is the same repaint as a mod switch — the accent
+            // chain and the sprite chain both changed answer — with one addition: the
+            // resource cache is keyed on the event skin id, so stale entries must go or
+            // the old bubble would outlive the event. NEVER FIRES IN THIS BUILD; nothing
+            // calls LiveEventService.Apply/Clear. It is wired now so the day it does, the
+            // repaint is already correct instead of being discovered live.
+            LiveEvent.EventChanged += (_, __) =>
+            {
+                void Recolor()
+                {
+                    Services.ModResourceResolver.ClearCache();
                     Services.RecapTheme.ApplyForActiveMod();
                     Services.FxTheme.ApplyForActiveMod();
                     foreach (Window w in Current.Windows)

--- a/ConditioningControlPanel/Controls/SpiralEmbedView.cs
+++ b/ConditioningControlPanel/Controls/SpiralEmbedView.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Descent;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Controls
+{
+    /// <summary>
+    /// THE SPIRAL EMBED — the WebView2 window onto cclabs-web's `/embed/spiral` canvas
+    /// (CONTRACTS-0812-FINISH §9). One canvas, three hosts: this is the desktop one.
+    ///
+    /// THE POINT OF THE EMBED, and the reason it is not just "a page in a webview":
+    /// the route renders ONLY the canvas and makes NO authenticated request of its own.
+    /// It has no session, no token and no cookie worth having. Every number it draws is
+    /// handed to it by this class over postMessage. That is law §0.1 made structural —
+    /// the desktop's X-Auth-Token never enters a browser, because the browser is never
+    /// in a position to need one.
+    ///
+    /// PROTOCOL (§9, exact):
+    ///   host → page   { type: 'spiral:state', devotion_days, stage, relapse_multiplier?,
+    ///                   vat_fill_pct?, lit_station_ids?, reduced_motion?, perf_tier? }
+    ///   page → host   { type: 'spiral:ready' }
+    /// State posted before 'spiral:ready' is QUEUED, not dropped — the canvas's boot and
+    /// the descent block's arrival race every launch, and whichever wins, the last state
+    /// posted is the state drawn. Note the handshake is 'spiral:ready', NOT the bare
+    /// 'ready' the DtRH/Goon bridge uses, so this cannot reuse ChaosWebViewHost's pipe.
+    ///
+    /// FAILS SOFT, ALWAYS (§9). Missing WebView2 runtime, a dead browser process, a 404
+    /// on a route that has not deployed yet — every one of them ends the same way: this
+    /// view stays empty and reports failure to its host, which draws the static stage
+    /// badge instead. The Spiral is the hook; it is never a dependency of playing.
+    ///
+    /// AIRSPACE — READ BEFORE MOVING THIS ANYWHERE NEW. A WebView2 is a native child
+    /// HWND: it does not clip to rounded corners, does not fade with an opacity
+    /// animation, does not scroll inside a ScrollViewer and cannot be drawn over. Every
+    /// other WebView2 in this app is either its own window or a plain rectangular slab
+    /// in a static tab. See VatGlassCanvas's header for why the vat is Skia instead, and
+    /// SpiralRailHost for the mitigation this one ships with.
+    /// </summary>
+    public sealed class SpiralEmbedView : Grid
+    {
+        /// <summary>Origin of the embed. Navigation is locked to it; nothing else may load.</summary>
+        public const string EmbedHost = "app.cclabs.app";
+
+        private const string EmbedPath = "/embed/spiral";
+
+        /// <summary>Shared browser profile for both modes — one warm cache, one cookie jar (empty).</summary>
+        private const string UserDataFolderName = "browser_data_spiral";
+
+        private readonly string _mode;
+        private readonly List<string> _pending = new();
+        private WebView2? _web;
+        private bool _initStarted;
+        private bool _disposed;
+
+        /// <summary>True once the canvas has posted 'spiral:ready'.</summary>
+        public bool IsReady { get; private set; }
+
+        /// <summary>
+        /// Raised (UI thread) when this view has given up: no runtime, no core, a dead
+        /// process, or a navigation failure. Hosts draw their fallback on this.
+        /// </summary>
+        public event EventHandler<string>? Failed;
+
+        /// <summary>Raised (UI thread) on 'spiral:ready'.</summary>
+        public event EventHandler? Ready;
+
+        /// <param name="mode">"mini" (the 80px rail miniature) or "map" (the expanded surface).</param>
+        public SpiralEmbedView(string mode)
+        {
+            _mode = mode == "map" ? "map" : "mini";
+            // Opaque, and matching the rail's own sink so a slow first paint reads as a
+            // dark panel rather than a white flash. There is no transparent WebView2.
+            Background = new SolidColorBrush(Color.FromRgb(0x1C, 0x1C, 0x36));
+        }
+
+        /// <summary>The full embed URL for this view's mode.</summary>
+        public string Url => BuildUrl(_mode);
+
+        /// <summary>
+        /// Pure URL builder, split out so the route can be asserted without an STA thread
+        /// and a live WebView2. Anything that is not "map" is "mini" — the mode reaches a
+        /// query string, so it is normalised here rather than trusted.
+        /// </summary>
+        internal static string BuildUrl(string mode)
+            => $"https://{EmbedHost}{EmbedPath}?mode={(mode == "map" ? "map" : "mini")}";
+
+        // ============================== lifecycle ==============================
+
+        /// <summary>
+        /// Create the browser and navigate. Safe to call more than once; only the first
+        /// does anything. Returns immediately — everything else happens on the
+        /// continuation, and every failure path ends at <see cref="Failed"/>.
+        /// </summary>
+        public void Start()
+        {
+            if (_initStarted || _disposed) return;
+            _initStarted = true;
+            _ = InitAsync();
+        }
+
+        private async Task InitAsync()
+        {
+            try
+            {
+                // PROBE BEFORE BUILDING. BrowserService is the only other place that calls
+                // this, and it is worth the one call here: an install with no WebView2
+                // runtime should fall back to the badge without ever constructing a
+                // control, creating a user-data folder, or logging an exception trace.
+                string? version = null;
+                try { version = CoreWebView2Environment.GetAvailableBrowserVersionString(); }
+                catch (Exception ex)
+                {
+                    Fail("WebView2 runtime not installed: " + ex.Message);
+                    return;
+                }
+                if (string.IsNullOrEmpty(version)) { Fail("WebView2 runtime not installed"); return; }
+
+                _web = new WebView2
+                {
+                    DefaultBackgroundColor = System.Drawing.Color.FromArgb(0x1C, 0x1C, 0x36),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                    VerticalAlignment = VerticalAlignment.Stretch,
+                };
+                Children.Add(_web);
+
+                var userDataFolder = Path.Combine(App.UserDataPath, UserDataFolderName);
+                Directory.CreateDirectory(userDataFolder);
+
+                // Same anti-MPO / anti-occlusion pair every other host in the app uses: the
+                // canvas animates on rAF, and Chromium's occlusion tracker will happily
+                // decide a rail-docked view is covered and throttle the spin to nothing.
+                var options = new CoreWebView2EnvironmentOptions
+                {
+                    AdditionalBrowserArguments =
+                        "--disable-direct-composition-video-overlays " +
+                        "--disable-features=CalculateNativeWinOcclusion " +
+                        "--disable-backgrounding-occluded-windows",
+                };
+
+                var env = await CoreWebView2Environment
+                    .CreateAsync(browserExecutableFolder: null, userDataFolder: userDataFolder, options: options)
+                    .ConfigureAwait(true);
+                if (_disposed) return;
+
+                await _web.EnsureCoreWebView2Async(env).ConfigureAwait(true);
+                if (_disposed) return;
+
+                var core = _web.CoreWebView2;
+                if (core == null) { Fail("WebView2 core was null after Ensure"); return; }
+
+                var s = core.Settings;
+                s.AreDevToolsEnabled = false;
+                s.AreDefaultContextMenusEnabled = false;
+                s.IsStatusBarEnabled = false;
+                s.AreBrowserAcceleratorKeysEnabled = false;
+                s.IsZoomControlEnabled = false;
+                s.IsBuiltInErrorPageEnabled = false;
+                s.IsWebMessageEnabled = true;
+
+                core.NavigationStarting += OnNavigationStarting;
+                core.NavigationCompleted += OnNavigationCompleted;
+                core.WebMessageReceived += OnWebMessageReceived;
+                core.ProcessFailed += OnProcessFailed;
+
+                core.Navigate(Url);
+            }
+            catch (Exception ex)
+            {
+                Fail(ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// LOCKED TO THE EMBED ORIGIN. The canvas is a pure renderer with no links, so a
+        /// navigation anywhere else is either a mistake or something wearing the app's
+        /// chrome. Cancel it; there is no in-app browser to hand it off to.
+        /// </summary>
+        private void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.Uri) ||
+                !e.Uri.StartsWith("https://" + EmbedHost + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                e.Cancel = true;
+            }
+        }
+
+        /// <summary>
+        /// A failed navigation is the expected state until the embed route deploys, and
+        /// it must land on the badge rather than on a blank rectangle. IsBuiltInErrorPage
+        /// is off, so without this the user would see the background colour and nothing else.
+        /// </summary>
+        private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess) Fail("navigation failed: " + e.WebErrorStatus);
+        }
+
+        private void OnProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        {
+            // No auto-recovery, matching every other host in the app: a browser that died
+            // once on a decorative surface gets the badge, not a retry loop.
+            Fail("browser process failed: " + e.ProcessFailedKind);
+        }
+
+        // ============================== the bridge ==============================
+
+        /// <summary>
+        /// Post a §9 state message. Queued until the canvas says 'spiral:ready', and only
+        /// the LAST queued state survives — an intermediate reading nobody drew is not
+        /// worth replaying, and re-posting a burst of them on ready would animate the dot
+        /// through a history the user never watched.
+        /// </summary>
+        public void PostState(DescentBlock? block)
+        {
+            if (_disposed) return;
+            try
+            {
+                var json = JsonConvert.SerializeObject(BuildState(block));
+                if (IsReady && _web?.CoreWebView2 != null)
+                {
+                    _web.CoreWebView2.PostWebMessageAsJson(json);
+                }
+                else
+                {
+                    _pending.Clear();
+                    _pending.Add(json);
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Spiral] PostState: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// The §9 payload, built from the block the server already sent us and from the
+        /// two host-owned signals the canvas cannot know: how much motion this user
+        /// allows, and how much GPU the app currently has to spare.
+        ///
+        /// `lit_station_ids` is DELIBERATELY ABSENT. The station registry lives in
+        /// cclabs-web (lib/descent/stations.ts); desktop has no copy and must not invent
+        /// one — a client-authored list of lit stations is a client deciding what it has
+        /// earned. The canvas treats the field as optional and lights nothing without it.
+        /// </summary>
+        private static object BuildState(DescentBlock? block)
+        {
+            return new
+            {
+                type = "spiral:state",
+                devotion_days = block?.DevotionDays ?? 0,
+                stage = block?.Stage?.N ?? 0,
+                relapse_multiplier = block?.Relapse?.Multiplier ?? 1.0,
+                vat_fill_pct = block?.Vat?.FillPct ?? 0.0,
+                reduced_motion = MotionFx.Level != Models.MotionLevel.Full,
+                perf_tier = PerfTier(),
+            };
+        }
+
+        /// <summary>
+        /// Map the app's own tier onto §9's three-value scale. Quality is the tier the
+        /// app considers "indistinguishable from unoptimised", so it is 'high'; the two
+        /// escalations are the ones that mean the machine is already busy.
+        /// </summary>
+        private static string PerfTier() => PerformanceProfile.CurrentTier switch
+        {
+            Models.PerformanceTier.Performance => "low",
+            Models.PerformanceTier.Balanced => "mid",
+            _ => "high",
+        };
+
+        private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            // Runs on the browser's message loop — nothing here may block or go modal.
+            try
+            {
+                var json = e.WebMessageAsJson;
+                if (string.IsNullOrEmpty(json)) return;
+                var o = JObject.Parse(json);
+                if ((string?)o["type"] != "spiral:ready") return;
+
+                IsReady = true;
+                foreach (var queued in _pending)
+                {
+                    try { _web?.CoreWebView2?.PostWebMessageAsJson(queued); } catch { /* page gone */ }
+                }
+                _pending.Clear();
+                Ready?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Spiral] OnWebMessageReceived: {E}", ex.Message);
+            }
+        }
+
+        // ============================== teardown ==============================
+
+        private void Fail(string reason)
+        {
+            App.Logger?.Information("[Spiral] embed unavailable ({Mode}): {Reason} - falling back", _mode, reason);
+            Dispose();
+            try { Failed?.Invoke(this, reason); }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] Failed handler threw: {E}", ex.Message); }
+        }
+
+        /// <summary>Tear the browser down and empty the view. Idempotent.</summary>
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            IsReady = false;
+            _pending.Clear();
+            try
+            {
+                if (_web != null)
+                {
+                    var core = _web.CoreWebView2;
+                    if (core != null)
+                    {
+                        core.NavigationStarting -= OnNavigationStarting;
+                        core.NavigationCompleted -= OnNavigationCompleted;
+                        core.WebMessageReceived -= OnWebMessageReceived;
+                        core.ProcessFailed -= OnProcessFailed;
+                    }
+                    Children.Remove(_web);
+                    _web.Dispose();
+                    _web = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Spiral] dispose: {E}", ex.Message);
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Controls/SpiralRailHost.cs
+++ b/ConditioningControlPanel/Controls/SpiralRailHost.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using ConditioningControlPanel.Services.Descent;
+
+namespace ConditioningControlPanel.Controls
+{
+    /// <summary>
+    /// THE SPIRAL RAIL — the 80px miniature docked in the nav rail (CONTRACTS §9),
+    /// with the static stage badge it falls back to.
+    ///
+    /// TWO LAYERS, ONE ALWAYS PRESENT:
+    ///   • the BADGE — a plain WPF Border/TextBlock pair showing the stage numeral. It
+    ///     is composited like everything else on the rail, costs nothing, and is what a
+    ///     machine with no WebView2 runtime sees. §9's rule is "never an empty hole",
+    ///     and the badge is how that is kept.
+    ///   • the EMBED — <see cref="SpiralEmbedView"/> at ?mode=mini, created lazily and
+    ///     only when the flag is on. It sits ON TOP of the badge and hides it once the
+    ///     canvas is ready; any failure disposes it and the badge is simply uncovered.
+    ///
+    /// DARK BY DEFAULT. AppSettings.DescentSpiralRailEnabled is false and has no editor,
+    /// so in a shipped build <see cref="Arm"/> returns before it touches anything and
+    /// this control stays Collapsed — zero pixels, zero HWNDs, zero requests. The embed
+    /// route does not exist yet either; when it 404s, the fallback path above is the one
+    /// that runs, which is exactly the path this had to prove anyway.
+    ///
+    /// THE AIRSPACE MITIGATION, AND THE OPEN QUESTION BEHIND IT. DECISIONS.md
+    /// (2026-08-10) amended the "one web canvas" law with "rail MINI = native WPF
+    /// Canvas/Path — a rail-docked WebView2 HWND would sit over every tab transition";
+    /// CONTRACTS-0812-FINISH §9 and Master Doc v2.1 §9 (both newer, both frozen) say the
+    /// mini IS the shared canvas hosted via WebView2. This class implements the contract
+    /// and mitigates the amendment's objection: the embed is shown ONLY while the rail is
+    /// wide enough to hold it and is torn down whenever the rail collapses or the control
+    /// leaves the screen (<see cref="OnSizeChanged"/> / <see cref="OnIsVisibleChanged"/>),
+    /// so a native HWND never sits in the middle of the flyout's width animation. It is a
+    /// mitigation, not a proof — whether the mini stays WebView2 or reverts to native WPF
+    /// is an owner/coordinator call, and nothing downstream of this file depends on which
+    /// way it goes.
+    /// </summary>
+    public sealed class SpiralRailHost : Grid
+    {
+        /// <summary>Below this width the embed is not shown — see the airspace note above.</summary>
+        private const double MinEmbedWidth = 72;
+
+        private readonly Border _badge;
+        private readonly TextBlock _badgeText;
+        private SpiralEmbedView? _embed;
+        private bool _wired;
+        private bool _embedGaveUp;
+
+        public SpiralRailHost()
+        {
+            Height = 80;
+            Margin = new Thickness(0, 6, 0, 2);
+            Cursor = Cursors.Hand;
+            // The rail is dark and nothing here has a flag on: stay out of the layout
+            // entirely until Arm() says otherwise, so an un-armed build measures as if
+            // this control were not in the tree.
+            Visibility = Visibility.Collapsed;
+
+            _badgeText = new TextBlock
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                FontSize = 15,
+                FontWeight = FontWeights.SemiBold,
+                Foreground = new SolidColorBrush(Color.FromRgb(0xFF, 0x8F, 0xAF)),
+            };
+
+            _badge = new Border
+            {
+                Width = 40,
+                Height = 40,
+                CornerRadius = new CornerRadius(20),
+                BorderThickness = new Thickness(1.5),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0x69, 0xB4)),
+                Background = new SolidColorBrush(Color.FromRgb(0x25, 0x25, 0x42)),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Child = _badgeText,
+            };
+            Children.Add(_badge);
+
+            MouseLeftButtonUp += (_, _) => OpenMap();
+            SizeChanged += OnSizeChanged;
+            IsVisibleChanged += OnIsVisibleChanged;
+            // SELF-WIRING. The host window adds this control and nothing else: no init
+            // call in MainWindow, no line in the startup sequence, no partial to keep in
+            // step. A Collapsed element still raises Loaded, so the flag-off case reaches
+            // Arm(), returns immediately and never touches DescentService.
+            Loaded += (_, _) => Wire();
+        }
+
+        /// <summary>The flag. False in every shipped build; there is deliberately no editor for it.</summary>
+        public static bool FlagEnabled => App.Settings?.Current?.DescentSpiralRailEnabled == true;
+
+        // ============================== lifecycle ==============================
+
+        /// <summary>
+        /// Light the rail up, if it is allowed to be lit. Three gates, all required: the
+        /// flag, an account the server has actually shipped a descent block to, and a
+        /// live DescentService. Missing any one leaves the control Collapsed.
+        ///
+        /// Called on every block change, so an account whose key lights up mid-session
+        /// gets the rail without a restart — and one whose key is withdrawn loses it.
+        /// </summary>
+        public void Arm()
+        {
+            try
+            {
+                bool allowed = FlagEnabled && App.Descent?.Current is not null;
+                if (!allowed)
+                {
+                    Visibility = Visibility.Collapsed;
+                    TeardownEmbed();
+                    return;
+                }
+
+                Visibility = Visibility.Visible;
+                ApplyBlock(App.Descent?.Current);
+                EvaluateEmbed();
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] Arm: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Subscribe to the descent block. Idempotent; call once from the host window.
+        /// The rail feeds off the SAME service the Trainer Card's vat does and issues no
+        /// request of its own — one reader, one cadence, one 10s floor.
+        /// </summary>
+        public void Wire()
+        {
+            if (_wired) return;
+            _wired = true;
+            try
+            {
+                if (App.Descent != null) App.Descent.BlockChanged += (_, _) => Arm();
+                Arm();
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] Wire: {E}", ex.Message); }
+        }
+
+        // ============================== the badge ==============================
+
+        private void ApplyBlock(DescentBlock? block)
+        {
+            _badgeText.Text = StageNumeral(block?.Stage?.N ?? 0);
+            _embed?.PostState(block);
+        }
+
+        /// <summary>
+        /// Stage as a Roman numeral, which is the ONLY stage copy this control ships.
+        /// The stage NAMES (Curious … Eternal) are still an open owner decision in §14
+        /// and have no localization keys, so putting one on screen here would be the
+        /// client inventing copy that the ceremony has not agreed to yet. n = 0 is the
+        /// real pre-begin rung and reads as a dot.
+        /// </summary>
+        internal static string StageNumeral(int n) => n switch
+        {
+            1 => "I",
+            2 => "II",
+            3 => "III",
+            4 => "IV",
+            5 => "V",
+            6 => "VI",
+            7 => "VII",
+            8 => "VIII",
+            _ => n > 8 ? n.ToString(System.Globalization.CultureInfo.InvariantCulture) : "·",
+        };
+
+        // ============================== the embed ==============================
+
+        /// <summary>
+        /// Create or tear down the embed to match the space available. The width test is
+        /// the airspace mitigation: a collapsed 56px rail gets the badge, and the native
+        /// HWND only exists while there is a stable slab wide enough to hold it.
+        /// </summary>
+        private void EvaluateEmbed()
+        {
+            if (_embedGaveUp) return;                      // one failure is permanent for the session
+            if (!FlagEnabled) { TeardownEmbed(); return; }
+
+            bool room = IsVisible && ActualWidth >= MinEmbedWidth;
+            if (!room) { TeardownEmbed(); return; }
+            if (_embed != null) return;
+
+            var embed = new SpiralEmbedView("mini");
+            embed.Failed += (_, _) =>
+            {
+                // The badge is already underneath — uncovering it IS the fallback.
+                _embedGaveUp = true;
+                TeardownEmbed();
+            };
+            embed.Ready += (_, _) => _badge.Visibility = Visibility.Hidden;
+            _embed = embed;
+            Children.Add(embed);
+            embed.Start();
+            embed.PostState(App.Descent?.Current);
+        }
+
+        private void TeardownEmbed()
+        {
+            if (_embed == null) return;
+            try
+            {
+                Children.Remove(_embed);
+                _embed.Dispose();
+            }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] TeardownEmbed: {E}", ex.Message); }
+            _embed = null;
+            _badge.Visibility = Visibility.Visible;
+        }
+
+        private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (Visibility == Visibility.Visible) EvaluateEmbed();
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (IsVisible) EvaluateEmbed();
+            else TeardownEmbed();
+        }
+
+        /// <summary>
+        /// Click-to-expand: the same canvas at ?mode=map, in its own window. A window and
+        /// not an in-tab panel on purpose — the map is the one surface big enough for the
+        /// airspace problem to be unmanageable, and a separate top-level HWND has no
+        /// airspace problem at all.
+        /// </summary>
+        private void OpenMap()
+        {
+            if (!FlagEnabled) return;
+            try { SpiralMapWindow.ShowMap(); }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] OpenMap: {E}", ex.Message); }
+        }
+    }
+}

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -1800,6 +1800,7 @@
   "skill_mult_maximum_sparkle": "Maximum Sparkle",
   "skill_mult_night_shift": "Nachtschicht",
   "skill_mult_early_bird": "Frühaufsteher-Bimbo",
+  "skill_mult_event_boost": "Event-Bonus",
   "skill_mult_pink_rush_active": "PINK RUSH AKTIV!",
   "skill_lucky_flash": "Lucky Flash",
   "skill_lucky_bubble": "Lucky Bubble",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -2795,6 +2795,7 @@
   "skill_mult_maximum_sparkle": "Maximum Sparkle",
   "skill_mult_night_shift": "Night Shift",
   "skill_mult_early_bird": "Early Bird Bimbo",
+  "skill_mult_event_boost": "Event bonus",
   "skill_mult_pink_rush_active": "PINK RUSH ACTIVE!",
   "skill_lucky_flash": "Lucky Flash",
   "skill_lucky_bubble": "Lucky Bubble",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -1799,6 +1799,7 @@
   "skill_mult_maximum_sparkle": "Brillo Máximo",
   "skill_mult_night_shift": "Turno Nocturno",
   "skill_mult_early_bird": "Bimbo Madrugadora",
+  "skill_mult_event_boost": "Bonificación de evento",
   "skill_mult_pink_rush_active": "¡RUSH ROSA ACTIVO!",
   "skill_lucky_flash": "Flash de Suerte",
   "skill_lucky_bubble": "Burbuja de Suerte",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -1800,6 +1800,7 @@
   "skill_mult_maximum_sparkle": "Étincelle Maximum",
   "skill_mult_night_shift": "Équipe de Nuit",
   "skill_mult_early_bird": "Bimbo Lève-tôt",
+  "skill_mult_event_boost": "Bonus d'événement",
   "skill_mult_pink_rush_active": "RUSH ROSE ACTIF !",
   "skill_lucky_flash": "Flash Chanceux",
   "skill_lucky_bubble": "Bulle Chanceuse",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -1799,6 +1799,7 @@
   "skill_mult_maximum_sparkle": "マキシマムスパークル",
   "skill_mult_night_shift": "ナイトシフト",
   "skill_mult_early_bird": "早起きビンボ",
+  "skill_mult_event_boost": "イベントボーナス",
   "skill_mult_pink_rush_active": "ピンクラッシュ発動中！",
   "skill_lucky_flash": "ラッキーフラッシュ",
   "skill_lucky_bubble": "ラッキーバブル",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -1799,6 +1799,7 @@
   "skill_mult_maximum_sparkle": "맥시멈 스파클",
   "skill_mult_night_shift": "나이트 시프트",
   "skill_mult_early_bird": "얼리 버드 빔보",
+  "skill_mult_event_boost": "이벤트 보너스",
   "skill_mult_pink_rush_active": "핑크 러시 활성!",
   "skill_lucky_flash": "럭키 플래시",
   "skill_lucky_bubble": "럭키 버블",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -1799,6 +1799,7 @@
   "skill_mult_maximum_sparkle": "Brilho Máximo",
   "skill_mult_night_shift": "Turno Noturno",
   "skill_mult_early_bird": "Bimbo Madrugadora",
+  "skill_mult_event_boost": "Bônus de evento",
   "skill_mult_pink_rush_active": "PINK RUSH ATIVO!",
   "skill_lucky_flash": "Flash de Sorte",
   "skill_lucky_bubble": "Bolha de Sorte",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -1799,6 +1799,7 @@
   "skill_mult_maximum_sparkle": "Максимум искр",
   "skill_mult_night_shift": "Ночная смена",
   "skill_mult_early_bird": "Ранняя пташка бимбо",
+  "skill_mult_event_boost": "Бонус события",
   "skill_mult_pink_rush_active": "РОЗОВЫЙ ПРИЛИВ АКТИВЕН!",
   "skill_lucky_flash": "Счастливая вспышка",
   "skill_lucky_bubble": "Счастливый пузырёк",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -2540,6 +2540,7 @@
   "skill_mult_maximum_sparkle": "最大闪耀",
   "skill_mult_night_shift": "夜班",
   "skill_mult_early_bird": "早起宝贝",
+  "skill_mult_event_boost": "活动加成",
   "skill_mult_pink_rush_active": "粉色冲刺激活中！",
   "skill_lucky_flash": "幸运闪图",
   "skill_lucky_bubble": "幸运泡泡",

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:loc="clr-namespace:ConditioningControlPanel.Localization"
         xmlns:local="clr-namespace:ConditioningControlPanel"
         xmlns:views="clr-namespace:ConditioningControlPanel.Views.Tabs"
+        xmlns:controls="clr-namespace:ConditioningControlPanel.Controls"
         Title="Conditioning Control Panel"
         Height="943" Width="1563"
         MinHeight="620" MinWidth="1131"
@@ -752,6 +753,13 @@
                 <!-- Settings door: pinned to the bottom and visually separated. Phase 1 routes
                      it at the Dashboard; Phase 2 gives it its own view (key "appsettings"). -->
                 <StackPanel Grid.Row="1">
+                    <!-- THE SPIRAL RAIL (CONTRACTS-0812-FINISH §9). Collapsed in every shipped
+                         build: AppSettings.DescentSpiralRailEnabled is false and has no editor,
+                         and even with it set the control stays collapsed until the server ships
+                         this account a descent block. Collapsed measures as zero, so the rail's
+                         layout is identical to the build before this element existed.
+                         See Controls/SpiralRailHost.cs - especially the airspace note. -->
+                    <controls:SpiralRailHost x:Name="SpiralRail"/>
                     <Border Height="1" Background="#2A2A46" Margin="10,8,10,6"/>
                     <Button x:Name="DoorSettings" Tag="appsettings" Style="{StaticResource NavDoorButton}"
                             Click="NavDoor_Click" ToolTip="{loc:Str nav_door_settings}">

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5295,6 +5295,31 @@ namespace ConditioningControlPanel.Models
 
         #endregion
 
+        #region The Descent — Spiral rail
+
+        private bool _descentSpiralRailEnabled = false;
+        /// <summary>
+        /// Shows the Spiral Track miniature in the nav rail (CONTRACTS-0812-FINISH §9).
+        ///
+        /// FALSE IN EVERY SHIPPED BUILD, and deliberately without a settings editor: the
+        /// `/embed/spiral` route it hosts has not deployed, and a visible toggle for a
+        /// surface that cannot draw yet is worse than no toggle. Flip it by hand in
+        /// settings.json to exercise the host. When the Spiral goes public this becomes a
+        /// normal preference with a normal editor — or disappears, if the rail ends up
+        /// always-on.
+        ///
+        /// Even set true the rail stays dark unless the server has shipped this account a
+        /// descent block (SpiralRailHost.Arm), so turning it on cannot conjure a spiral
+        /// for an account outside the rollout dial.
+        /// </summary>
+        public bool DescentSpiralRailEnabled
+        {
+            get => _descentSpiralRailEnabled;
+            set { _descentSpiralRailEnabled = value; OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Web XP claim (claim-on-sync handshake)
 
         private string? _lastWebXpClaimId = null;

--- a/ConditioningControlPanel/Services/Events/LiveEventService.cs
+++ b/ConditioningControlPanel/Services/Events/LiveEventService.cs
@@ -1,0 +1,141 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Events
+{
+    // ============================================================================
+    // LIVE EVENTS — the dormant switchboard for world events (The Descent §11/§14).
+    //
+    // WHAT THIS IS: three values a world event may set, and nothing else. A skin id
+    // (themed bubbles), an accent hex (the palette shift) and an additive XP boost.
+    // Every Phase-1 "S" item consults this object FIRST and falls straight through
+    // when it is dark, which is its state in this build and every build until the
+    // server grows an `events[]` block on the quest-definitions channel (§14).
+    //
+    // WHAT THIS IS NOT: a fetcher. There is deliberately no network code, no timer,
+    // no cache and no persistence here. Nothing in the shipped app calls
+    // <see cref="Apply"/>. The wire half lands with the event engine (Phase 2); this
+    // half exists now so that the five renderers, the palette chain and the XP funnel
+    // are already reading through a seam by the time it does — the alternative is
+    // touching all of them again on the day an event has to go live.
+    //
+    // DORMANCY IS THE CONTRACT: with no event applied, <see cref="SkinId"/> and
+    // <see cref="AccentHex"/> are null and <see cref="XpBoost"/> is 0.0, so every
+    // consumer below is a provable no-op:
+    //   • BubbleSkinResolver returns the mod/default sprite exactly as before,
+    //   • ModService's FX chain resolves at its old first link,
+    //   • SkillTreeService adds +0.0 to the multiplier.
+    //
+    // SERVER-DRIVEN, NEVER CLIENT-INVENTED: when this is wired, the values arrive
+    // from the server's event block. A client that can name its own event skin is a
+    // client that can hand itself an XP boost, so nothing here is persisted to
+    // settings and nothing reconstructs an event from local state.
+    // ============================================================================
+
+    /// <summary>
+    /// The active world event's cosmetic + economy overrides. Dark in this build:
+    /// nothing calls <see cref="Apply"/>, so every property sits at its dormant
+    /// default and every consumer falls through to today's behaviour.
+    /// </summary>
+    public sealed class LiveEventService
+    {
+        /// <summary>
+        /// The hard ceiling on an event's XP boost, as an additive term on the
+        /// multiplier (0.25 = +25%). An event is a nudge, not a new economy: the
+        /// funnel already reaches ~6.3x on skills alone, and an uncapped server
+        /// number would let a typo mint a level. Clamped on the way in AND read
+        /// through <see cref="ClampXpBoost"/> on the way out.
+        /// </summary>
+        public const double MaxXpBoost = 0.25;
+
+        /// <summary>
+        /// Id of the event's bubble skin (e.g. "snowglobe"), or null for no event
+        /// skin. Resolved against the sprite pipeline's skin folders; an id with no
+        /// art on disk resolves back to the default, so a server typo costs nothing.
+        /// </summary>
+        public string? SkinId { get; private set; }
+
+        /// <summary>
+        /// The event's accent colour as "#RRGGBB", or null to leave the mod's own
+        /// palette alone. Consulted ahead of the mod's fxPalette slot, which is the
+        /// whole point — an event dresses every mod, not just the default one.
+        /// </summary>
+        public string? AccentHex { get; private set; }
+
+        /// <summary>
+        /// Additive XP multiplier term, 0.0 when no event is running. Always within
+        /// [0, <see cref="MaxXpBoost"/>].
+        /// </summary>
+        public double XpBoost { get; private set; }
+
+        /// <summary>True when any of the three overrides is actually set.</summary>
+        public bool IsActive => SkinId != null || AccentHex != null || XpBoost > 0.0;
+
+        /// <summary>
+        /// Raised after <see cref="Apply"/> or <see cref="Clear"/> so live surfaces
+        /// can repaint. No subscribers in this build — nothing fires it.
+        /// </summary>
+        public event EventHandler? EventChanged;
+
+        /// <summary>
+        /// Install an event's overrides. NOT CALLED ANYWHERE IN THIS BUILD — the
+        /// caller is the event engine, which ships later. Values are sanitised here
+        /// rather than at the call site so the wire half cannot skip it.
+        /// </summary>
+        public void Apply(string? skinId, string? accentHex, double xpBoost)
+        {
+            SkinId = NormalizeId(skinId);
+            AccentHex = NormalizeHex(accentHex);
+            XpBoost = ClampXpBoost(xpBoost);
+            EventChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>Back to dormant. Also the state this object is constructed in.</summary>
+        public void Clear()
+        {
+            SkinId = null;
+            AccentHex = null;
+            XpBoost = 0.0;
+            EventChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        // ---- pure helpers (testable without a live App) ------------------------
+
+        /// <summary>
+        /// Clamp an event boost into [0, <see cref="MaxXpBoost"/>]. NaN and negative
+        /// values collapse to 0 — a malformed event must never subtract XP.
+        /// </summary>
+        public static double ClampXpBoost(double value)
+        {
+            if (double.IsNaN(value) || value <= 0.0) return 0.0;
+            return Math.Min(value, MaxXpBoost);
+        }
+
+        /// <summary>Blank/whitespace ids are "no skin", not a skin called " ".</summary>
+        public static string? NormalizeId(string? id)
+            => string.IsNullOrWhiteSpace(id) ? null : id!.Trim();
+
+        /// <summary>
+        /// Accept ONLY a literal "#RRGGBB". Anything else is treated as unset: the
+        /// palette chain's next link is always a valid colour, so a bad event hex
+        /// degrades to the mod's own accent instead of a brush parse throw somewhere
+        /// deep in a renderer.
+        ///
+        /// SIX DIGITS, NOT EIGHT, and that is a real constraint rather than laziness:
+        /// ModService.ParseHexColor accepts 6 only and silently returns hot pink for
+        /// anything else, so an "#AARRGGBB" event accent would resolve to a correct
+        /// colour in some places and to #FF69B4 in others. One length, one answer.
+        /// </summary>
+        public static string? NormalizeHex(string? hex)
+        {
+            if (string.IsNullOrWhiteSpace(hex)) return null;
+            var trimmed = hex!.Trim();
+            if (trimmed.Length != 7) return null;
+            if (trimmed[0] != '#') return null;
+            for (int i = 1; i < trimmed.Length; i++)
+            {
+                if (!Uri.IsHexDigit(trimmed[i])) return null;
+            }
+            return trimmed.ToUpperInvariant();
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/ModResourceResolver.cs
+++ b/ConditioningControlPanel/Services/ModResourceResolver.cs
@@ -8,13 +8,50 @@ using Serilog;
 namespace ConditioningControlPanel.Services
 {
     /// <summary>
-    /// Resolves resource images with mod override support.
-    /// Checks the active mod's resources/ folder first, falls back to embedded pack:// URI.
+    /// Resolves resource images with EVENT SKIN and mod override support.
+    /// Chain: active event skin → active mod's resources/ → embedded pack:// URI.
+    ///
+    /// THE EVENT SKIN LINK (The Descent §14, "themed bubble skins") is the whole reason
+    /// this file is the right place for it: bubble.png, tube.png, tube2.png and logo.png
+    /// all already resolve through here, so ONE probe at the head of the chain lights
+    /// every bubble renderer (the ambient/Chaos field in BubbleService, its Skia
+    /// compositor twin, the Bubble Count minigame, the avatar tube's random bubble and
+    /// the Intake page's data-URI sprite) plus the tube and the logo at once. Adding a
+    /// skin id to any of those renderers individually would have been five divergent
+    /// implementations of the same lookup.
+    ///
+    /// DORMANT IN THIS BUILD: nothing arms LiveEventService, so <see cref="EventSkinId"/>
+    /// is always null, the probe is skipped entirely, and every resolve is byte-for-byte
+    /// the mod-then-embedded answer it was before. A skin id with no art on disk is also
+    /// a no-op per file — the probe is File.Exists, so an event that ships only a bubble
+    /// leaves the tube and logo exactly as the mod drew them.
     /// </summary>
     public static class ModResourceResolver
     {
         private static readonly ILogger? _log = App.Logger;
         private static readonly ConcurrentDictionary<string, ImageSource?> _cache = new();
+
+        /// <summary>Folder under UserDataPath holding downloaded event skins, one dir per skin id.</summary>
+        private const string EventSkinRoot = "event_skins";
+
+        /// <summary>The active event's skin id, or null. Null = the whole event link is skipped.</summary>
+        private static string? EventSkinId => App.LiveEvent?.SkinId;
+
+        /// <summary>
+        /// Absolute path this resource would have inside the active event skin, or null
+        /// when there is no event skin (or the id is not a safe single path segment — an
+        /// id is server-supplied, so it gets the same traversal treatment as the path).
+        /// Does NOT test existence; callers do.
+        /// </summary>
+        private static string? EventSkinPath(string resourcePath)
+        {
+            var id = EventSkinId;
+            if (string.IsNullOrEmpty(id)) return null;
+            if (id!.Contains("..") || id.Contains('/') || id.Contains('\\') || Path.IsPathRooted(id)) return null;
+
+            return Path.Combine(App.UserDataPath, EventSkinRoot, id,
+                resourcePath.Replace('/', Path.DirectorySeparatorChar));
+        }
 
         /// <summary>
         /// Resolve a resource image path. If the active mod has an override, returns
@@ -34,34 +71,30 @@ namespace ConditioningControlPanel.Services
             // Normalize path separators
             resourcePath = resourcePath.Replace('\\', '/');
 
-            // Check cache first
-            var cacheKey = $"{App.Mods?.ActiveModId}:{resourcePath}";
+            // Check cache first. THE EVENT SKIN ID IS PART OF THE KEY, not just the mod
+            // id: an event starting or ending does not change the active mod, so without
+            // it the first bubble sprite resolved would be the one every later resolve got.
+            var cacheKey = $"{EventSkinId}:{App.Mods?.ActiveModId}:{resourcePath}";
             if (_cache.TryGetValue(cacheKey, out var cached))
                 return cached;
 
             ImageSource? result = null;
 
+            // Event skin first — it outranks the mod for the duration of the event.
+            var eventPath = EventSkinPath(resourcePath);
+            if (eventPath != null && File.Exists(eventPath))
+            {
+                result = LoadFrozen(eventPath, "event skin");
+            }
+
             // Check active mod's resources folder
             var modPath = App.Mods?.ActiveMod?.InstalledPath;
-            if (modPath != null)
+            if (result == null && modPath != null)
             {
                 var overridePath = Path.Combine(modPath, "resources", resourcePath.Replace('/', Path.DirectorySeparatorChar));
                 if (File.Exists(overridePath))
                 {
-                    try
-                    {
-                        var bitmap = new BitmapImage();
-                        bitmap.BeginInit();
-                        bitmap.UriSource = new Uri(overridePath, UriKind.Absolute);
-                        bitmap.CacheOption = BitmapCacheOption.OnLoad;
-                        bitmap.EndInit();
-                        bitmap.Freeze();
-                        result = bitmap;
-                    }
-                    catch (Exception ex)
-                    {
-                        _log?.Warning(ex, "Failed to load mod resource override: {Path}", overridePath);
-                    }
+                    result = LoadFrozen(overridePath, "mod resource override");
                 }
             }
 
@@ -91,6 +124,30 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Load a file into a frozen BitmapImage, or null on any failure. Shared by the
+        /// event-skin and mod-override branches so a broken file in either degrades the
+        /// same way — one warning, then fall through to the next link in the chain.
+        /// </summary>
+        private static ImageSource? LoadFrozen(string path, string what)
+        {
+            try
+            {
+                var bitmap = new BitmapImage();
+                bitmap.BeginInit();
+                bitmap.UriSource = new Uri(path, UriKind.Absolute);
+                bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                bitmap.EndInit();
+                bitmap.Freeze();
+                return bitmap;
+            }
+            catch (Exception ex)
+            {
+                _log?.Warning(ex, "Failed to load {What}: {Path}", what, path);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Resolve a resource path to a URI string. Returns a file:// URI for mod overrides
         /// or a pack:// URI for embedded resources.
         /// </summary>
@@ -104,6 +161,15 @@ namespace ConditioningControlPanel.Services
                 return $"pack://application:,,,/Resources/{resourcePath}";
 
             resourcePath = resourcePath.Replace('\\', '/');
+
+            // Event skin first, same precedence as ResolveImage — the two must agree or a
+            // surface that asks for a URI (the Intake data-URI sprite, spiral.gif) would
+            // draw the mod's art while its neighbour draws the event's.
+            var eventPath = EventSkinPath(resourcePath);
+            if (eventPath != null && File.Exists(eventPath))
+            {
+                return new Uri(eventPath, UriKind.Absolute).AbsoluteUri;
+            }
 
             // Check active mod's resources folder
             var modPath = App.Mods?.ActiveMod?.InstalledPath;
@@ -120,14 +186,25 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Check whether the active mod has an override for a given resource.
+        /// Check whether anything above the embedded resources overrides this path — the
+        /// active event skin, or failing that the active mod.
+        ///
+        /// The event counts here deliberately. Callers use this to ask "did an author
+        /// draw this art", and the tube pair is the reason: a skin that ships tube.png
+        /// but not tube2.png must trigger the same attached-layout fallback a mod does
+        /// (ModOverridesAttachedTubeOnly), or the avatar floats outside the event's
+        /// chamber instead of the mod's.
         /// </summary>
         public static bool HasModOverride(string resourcePath)
         {
+            resourcePath = resourcePath.Replace('\\', '/');
+
+            var eventPath = EventSkinPath(resourcePath);
+            if (eventPath != null && File.Exists(eventPath)) return true;
+
             var modPath = App.Mods?.ActiveMod?.InstalledPath;
             if (modPath == null) return false;
 
-            resourcePath = resourcePath.Replace('\\', '/');
             var overridePath = Path.Combine(modPath, "resources", resourcePath.Replace('/', Path.DirectorySeparatorChar));
             return File.Exists(overridePath);
         }

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -859,9 +859,35 @@ namespace ConditioningControlPanel.Services
             return baseFallback(_baseMod.Manifest);
         }
 
+        // ---- The event override, consulted FIRST -------------------------------
+        //
+        // A world event dresses EVERY mod, which is why it sits above the mod chain
+        // rather than inside it: Snowglobe has to turn the drone's cyan cold too, and
+        // a per-mod implementation would mean shipping an event palette per mod
+        // forever. One link at the top of the chain does it once.
+        //
+        // DORMANT IN THIS BUILD. Nothing arms LiveEventService, so EventAccentHex is
+        // always null here and every getter below resolves exactly as it did before
+        // this seam existed — same string, same call count, same brushes.
+        //
+        // Deliberately NOT overridden: background/panel/surface. Those are the app's
+        // structural darks; an event tints the accents that read as "the app's
+        // colour", it does not repaint the chrome out from under the user's mod.
+
+        /// <summary>The active event's accent, or null. Already validated as #RRGGBB(AA).</summary>
+        private static string? EventAccentHex => App.LiveEvent?.AccentHex;
+
+        /// <summary>
+        /// Event first, then whatever the mod chain would have said. Split out and
+        /// pure so the precedence is testable without a live ModService or an event.
+        /// </summary>
+        internal static string ResolveEventThemeHex(string? eventHex, string modHex)
+            => string.IsNullOrWhiteSpace(eventHex) ? modHex : eventHex!;
+
         // Theme colors
         public string GetAccentColorHex() =>
-            GetStringValue(m => m.Theme?.AccentColor, m => m.Theme!.AccentColor!);
+            ResolveEventThemeHex(EventAccentHex,
+                GetStringValue(m => m.Theme?.AccentColor, m => m.Theme!.AccentColor!));
 
         public (byte R, byte G, byte B) GetAccentColorRgb()
         {
@@ -869,11 +895,20 @@ namespace ConditioningControlPanel.Services
             return ParseHexColor(hex);
         }
 
+        // The light/dark rims are DERIVED from the event accent rather than taken from
+        // the mod, because a half-applied palette is worse than none: the mod's hot-pink
+        // hover rim around an event's cold-blue button is the exact incoherence this
+        // override exists to avoid. Shade factors match the ±18% the app's own
+        // LightenColor/DarkenColor use for the same pair.
         public string GetAccentLightColorHex() =>
-            GetStringValue(m => m.Theme?.AccentLightColor, m => m.Theme!.AccentLightColor!);
+            EventAccentHex is { } ev
+                ? ShadeHex(ev, 1.18)
+                : GetStringValue(m => m.Theme?.AccentLightColor, m => m.Theme!.AccentLightColor!);
 
         public string GetAccentDarkColorHex() =>
-            GetStringValue(m => m.Theme?.AccentDarkColor, m => m.Theme!.AccentDarkColor!);
+            EventAccentHex is { } ev
+                ? ShadeHex(ev, 0.82)
+                : GetStringValue(m => m.Theme?.AccentDarkColor, m => m.Theme!.AccentDarkColor!);
 
         // Background colors
         public string GetBackgroundColorHex() =>
@@ -886,7 +921,8 @@ namespace ConditioningControlPanel.Services
             GetStringValue(m => m.Theme?.SurfaceColor, m => m.Theme?.SurfaceColor ?? "#1E1E3A");
 
         public string GetFilterColorHex() =>
-            GetStringValue(m => m.Theme?.FilterColor, m => m.Theme?.FilterColor ?? m.Theme!.AccentColor!);
+            ResolveEventThemeHex(EventAccentHex,
+                GetStringValue(m => m.Theme?.FilterColor, m => m.Theme?.FilterColor ?? m.Theme!.AccentColor!));
 
         public (byte R, byte G, byte B) GetFilterColorRgb()
         {
@@ -911,10 +947,28 @@ namespace ConditioningControlPanel.Services
             return FxDefaultHex;
         }
 
+        /// <summary>
+        /// Chain: EVENT accent → fxPalette slot → theme.filterColor → theme.accentColor
+        /// → app default. The event link is the only addition; the four behind it are
+        /// untouched, and with no event running this is the old three-link resolve.
+        /// </summary>
         private string GetFxSlotHex(Func<ModManifest, string?> slot)
         {
             var m = _activeMod.Manifest;
-            return ResolveFxSlotHex(slot(m), m.Theme?.FilterColor, m.Theme?.AccentColor);
+            return ResolveEventThemeHex(EventAccentHex,
+                ResolveFxSlotHex(slot(m), m.Theme?.FilterColor, m.Theme?.AccentColor));
+        }
+
+        /// <summary>
+        /// Scale a #RRGGBB toward white (factor &gt; 1) or black (factor &lt; 1), clamped per
+        /// channel. Same shape as MainWindow's LightenColor/DarkenColor, kept here so the
+        /// event rims can be derived without ModService reaching into the window.
+        /// </summary>
+        internal static string ShadeHex(string hex, double factor)
+        {
+            var (r, g, b) = ParseHexColor(hex);
+            static byte Scale(byte c, double f) => (byte)Math.Clamp(Math.Round(c * f), 0, 255);
+            return $"#{Scale(r, factor):X2}{Scale(g, factor):X2}{Scale(b, factor):X2}";
         }
 
         public string GetMistColorHex() => GetFxSlotHex(m => m.FxPalette?.MistColor);

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -343,7 +343,21 @@ public class QuestService : IDisposable
             .Where(q => q.Id != excludeId)
             .Where(q => IsQuestAvailableForLevel(q.Category))
             .Where(IsQuestAvailableForTier)
+            .Where(IsQuestInDateWindow)
             .ToList();
+
+        // THE WINDOW MUST NEVER STARVE THE PLAYER. If a date window emptied the pool,
+        // fall back to the undated pool rather than leaving the day questless: an event
+        // that ends at midnight UTC-somewhere must not be able to take the daily quest
+        // with it. See IsQuestInDateWindow.
+        if (availableQuests.Count == 0)
+        {
+            availableQuests = questPool
+                .Where(q => q.Id != excludeId)
+                .Where(q => IsQuestAvailableForLevel(q.Category))
+                .Where(IsQuestAvailableForTier)
+                .ToList();
+        }
 
         if (availableQuests.Count == 0) return;
 
@@ -364,7 +378,18 @@ public class QuestService : IDisposable
             .Where(q => q.Id != excludeId)
             .Where(q => IsQuestAvailableForLevel(q.Category))
             .Where(IsQuestAvailableForTier)
+            .Where(IsQuestInDateWindow)
             .ToList();
+
+        // Same starvation guard as the daily generator — see the note there.
+        if (availableQuests.Count == 0)
+        {
+            availableQuests = questPool
+                .Where(q => q.Id != excludeId)
+                .Where(q => IsQuestAvailableForLevel(q.Category))
+                .Where(IsQuestAvailableForTier)
+                .ToList();
+        }
 
         if (availableQuests.Count == 0) return;
 
@@ -393,6 +418,52 @@ public class QuestService : IDisposable
     private static bool IsQuestAvailableForTier(QuestDefinition quest)
     {
         return !quest.RequiresPremium || App.Patreon?.HasPremiumAccess == true;
+    }
+
+    /// <summary>
+    /// THE DATE WINDOW, finally read. QuestDefinitionService has parsed, cached and
+    /// refreshed `activeFrom`/`activeUntil` since the definitions channel shipped, and
+    /// nothing has ever looked at them — a seasonal quest went live the moment it was
+    /// published and stayed live forever. This predicate is that missing read, and it
+    /// doubles as the channel's kill switch: publishing a quest with an `activeUntil`
+    /// in the past retires it on the next roll without a client update.
+    ///
+    /// NO-OP BY CONSTRUCTION FOR EVERYTHING THAT SHIPS TODAY. Both fields are null on
+    /// every embedded quest (QuestDefinition's ctor never sets them) and on every quest
+    /// the live channel currently publishes, and a null/blank/unparseable bound is
+    /// treated as "no constraint". A quest can only be hidden by a bound that is both
+    /// present and a valid yyyy-MM-dd — anything else fails OPEN, because a server typo
+    /// must cost a scheduling window, never the player's daily quest.
+    ///
+    /// LOCAL DATES, DELIBERATELY. The rest of quest scheduling turns over on
+    /// DateTime.Today (QuestProgress.IsDailyExpired, GetStartOfWeek), so the window
+    /// uses the same boundary — a quest that appears at "the start of the day" must
+    /// appear at the start of the day the player's other quests reset on, not eight
+    /// hours off it. `activeUntil` is INCLUSIVE: the last day named is a day it runs.
+    /// </summary>
+    private static bool IsQuestInDateWindow(QuestDefinition quest)
+        => IsQuestInDateWindow(quest.ActiveFrom, quest.ActiveUntil, DateTime.Today);
+
+    /// <summary>Pure form of the window test, split out so it is testable without a live App.</summary>
+    internal static bool IsQuestInDateWindow(string? activeFrom, string? activeUntil, DateTime today)
+    {
+        if (TryParseQuestDate(activeFrom, out var from) && today.Date < from) return false;
+        if (TryParseQuestDate(activeUntil, out var until) && today.Date > until) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Strict yyyy-MM-dd only. The channel is hand-authored JSON, so a loose parse would
+    /// read "03/04" differently depending on the machine's culture and retire a quest on
+    /// the wrong continent. False means "no usable bound" — the caller then ignores it.
+    /// </summary>
+    private static bool TryParseQuestDate(string? value, out DateTime date)
+    {
+        date = default;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        return DateTime.TryParseExact(value.Trim(), "yyyy-MM-dd",
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out date);
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
+++ b/ConditioningControlPanel/Services/Progression/SkillTreeService.cs
@@ -6,6 +6,7 @@ using System.Windows.Threading;
 using ConditioningControlPanel.Helpers;
 using ConditioningControlPanel.Localization;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.Events;
 
 namespace ConditioningControlPanel.Services;
 
@@ -254,6 +255,14 @@ public class SkillTreeService : IDisposable
             multiplier += 0.50;
         }
 
+        // World event boost (additive, capped, and 0.0 unless an event is running).
+        // ADDITIVE ON PURPOSE: the one multiplicative term below already triples
+        // whatever it lands on, and an event that multiplied instead of added would
+        // stack with it into a number nobody costed. Capped inside LiveEventService
+        // (MaxXpBoost) so a bad server value can nudge the rate, never mint a level.
+        // Dormant in this build — nothing arms LiveEventService, so this adds +0.0.
+        multiplier += LiveEventService.ClampXpBoost(App.LiveEvent?.XpBoost ?? 0.0);
+
         // Pink Rush (active window)
         if (settings.PinkRushActive && HasSkill("pink_rush"))
         {
@@ -292,6 +301,13 @@ public class SkillTreeService : IDisposable
             breakdown.Add((Loc.Get("skill_mult_night_shift"), 0.50));
         if (HasSkill("early_bird_bimbo") && hour >= 5 && hour < 8)
             breakdown.Add((Loc.Get("skill_mult_early_bird"), 0.50));
+
+        // Kept in step with GetTotalXpMultiplier above. Omitted entirely when no event
+        // is running, which is every build until the event engine ships — an "Event +0%"
+        // row would advertise a feature that does not exist yet.
+        var eventBoost = LiveEventService.ClampXpBoost(App.LiveEvent?.XpBoost ?? 0.0);
+        if (eventBoost > 0.0)
+            breakdown.Add((Loc.Get("skill_mult_event_boost"), eventBoost));
 
         if (settings.PinkRushActive && HasSkill("pink_rush"))
             breakdown.Add((Loc.Get("skill_mult_pink_rush_active"), 2.0)); // Shows as +200% (3x total)

--- a/ConditioningControlPanel/Windows/SpiralMapWindow.cs
+++ b/ConditioningControlPanel/Windows/SpiralMapWindow.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ConditioningControlPanel.Controls;
+
+// NAMESPACE: root, NOT ConditioningControlPanel.Windows, matching all 41 other files in
+// this folder. A `ConditioningControlPanel.Windows` namespace shadows the global WinRT
+// `Windows` root inside every file in this assembly — ScreenOcrService's Windows.Graphics
+// reference stops compiling the moment one exists. Do not "tidy" this into a folder
+// namespace.
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE EXPANDED SPIRAL — the same `/embed/spiral` canvas at ?mode=map, in its own
+    /// window (CONTRACTS §9: "the 80px rail miniature and the expanded map are the same
+    /// canvas", "click-to-expand opens the map in the same surface").
+    ///
+    /// ITS OWN WINDOW, DELIBERATELY. The map is the large surface, and a large WebView2
+    /// inside a tab is the worst version of the airspace problem this app keeps running
+    /// into (VatGlassCanvas's header; SettingsTabView's browser card). A top-level HWND
+    /// has no airspace problem: nothing clips it, nothing animates over it, and closing
+    /// it takes the browser with it. It is also the shape every other hosted page in the
+    /// app already uses.
+    ///
+    /// SINGLETON, AND OPAQUE. One map at a time — a second click focuses the open one
+    /// rather than starting a second browser. AllowsTransparency stays false: a WebView2
+    /// does not paint inside a layered window, and this app has the render-thread scar
+    /// tissue to prove it.
+    ///
+    /// FAILS SOFT LIKE THE RAIL: if the embed cannot start, the window closes itself
+    /// rather than standing there as an empty rectangle. There is no map without the
+    /// canvas, and a blank window is worse than no window.
+    /// </summary>
+    public sealed class SpiralMapWindow : Window
+    {
+        private static SpiralMapWindow? _open;
+
+        private readonly SpiralEmbedView _embed;
+
+        private SpiralMapWindow()
+        {
+            Title = "The Spiral";
+            Width = 900;
+            Height = 700;
+            MinWidth = 480;
+            MinHeight = 480;
+            WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            AllowsTransparency = false;
+            Background = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x2E));
+
+            _embed = new SpiralEmbedView("map");
+            _embed.Failed += (_, _) =>
+            {
+                try { Close(); } catch { /* already going */ }
+            };
+
+            Content = new Grid { Children = { _embed } };
+
+            Loaded += (_, _) =>
+            {
+                _embed.Start();
+                _embed.PostState(App.Descent?.Current);
+            };
+
+            // The map is a view of the same block the rail draws; a sync landing while it
+            // is open should move the dot rather than wait for a reopen.
+            if (App.Descent != null) App.Descent.BlockChanged += OnBlockChanged;
+
+            Closed += (_, _) =>
+            {
+                if (App.Descent != null) App.Descent.BlockChanged -= OnBlockChanged;
+                _embed.Dispose();
+                if (ReferenceEquals(_open, this)) _open = null;
+            };
+        }
+
+        private void OnBlockChanged(object? sender, EventArgs e)
+        {
+            // DescentService already marshalled to the UI thread before raising.
+            try { _embed.PostState(App.Descent?.Current); }
+            catch (Exception ex) { App.Logger?.Debug("[Spiral] map state: {E}", ex.Message); }
+        }
+
+        /// <summary>Open the map, or focus the one already open.</summary>
+        public static void ShowMap()
+        {
+            try
+            {
+                if (_open != null)
+                {
+                    _open.Activate();
+                    return;
+                }
+
+                var w = new SpiralMapWindow();
+                var main = Application.Current?.MainWindow;
+                if (main != null && !ReferenceEquals(main, w)) w.Owner = main;
+                _open = w;
+                w.Show();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[Spiral] ShowMap: {E}", ex.Message);
+            }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/DescentPhase1DormancyTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentPhase1DormancyTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Linq;
+using ConditioningControlPanel.Controls;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Events;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE DESCENT, PHASE 1 — the five "S" items, and the one property all of them share:
+/// with no event running and no date window authored, every seam added for the Descent
+/// resolves to exactly the answer the app gave before it existed.
+///
+/// These tests are mostly about DORMANCY rather than behaviour. The behaviour half
+/// cannot ship until the server grows an events block and the embed route deploys; what
+/// can be proved today is that nothing lit up early.
+/// </summary>
+public class DescentPhase1DormancyTests
+{
+    // ============================ event XP boost (§14 row 2) ============================
+
+    [Fact]
+    public void XpBoost_IsZero_WhenNoEventRunning()
+        => Assert.Equal(0.0, LiveEventService.ClampXpBoost(new LiveEventService().XpBoost));
+
+    [Fact]
+    public void XpBoost_ClampsToTheCeiling()
+        => Assert.Equal(LiveEventService.MaxXpBoost, LiveEventService.ClampXpBoost(99.0));
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-0.5)]
+    [InlineData(double.NaN)]
+    public void XpBoost_MalformedOrNegative_CollapsesToZero(double value)
+        => Assert.Equal(0.0, LiveEventService.ClampXpBoost(value));
+
+    [Fact]
+    public void XpBoost_PassesThroughUnderTheCap()
+        => Assert.Equal(0.10, LiveEventService.ClampXpBoost(0.10));
+
+    [Fact]
+    public void Apply_ThenClear_ReturnsToDormant()
+    {
+        var svc = new LiveEventService();
+        svc.Apply("snowglobe", "#88CCFF", 5.0);
+        Assert.True(svc.IsActive);
+        Assert.Equal(LiveEventService.MaxXpBoost, svc.XpBoost);   // clamped on the way in
+
+        svc.Clear();
+        Assert.False(svc.IsActive);
+        Assert.Null(svc.SkinId);
+        Assert.Null(svc.AccentHex);
+        Assert.Equal(0.0, svc.XpBoost);
+    }
+
+    [Fact]
+    public void NewService_IsDormant()
+    {
+        var svc = new LiveEventService();
+        Assert.False(svc.IsActive);
+        Assert.Null(svc.SkinId);
+        Assert.Null(svc.AccentHex);
+        Assert.Equal(0.0, svc.XpBoost);
+    }
+
+    // ============================ event palette (§14 row 4) ============================
+
+    [Fact]
+    public void Palette_EventUnset_LeavesTheModChainExactlyAsItWas()
+        => Assert.Equal("#00FF41", ModService.ResolveEventThemeHex(null, "#00FF41"));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Palette_BlankEvent_FallsThroughLikeNull(string ev)
+        => Assert.Equal("#00FF41", ModService.ResolveEventThemeHex(ev, "#00FF41"));
+
+    [Fact]
+    public void Palette_EventSet_OutranksTheMod()
+        => Assert.Equal("#88CCFF", ModService.ResolveEventThemeHex("#88CCFF", "#00FF41"));
+
+    [Fact]
+    public void Palette_ModChain_IsUntouchedBehindTheNewLink()
+    {
+        // The pre-existing three-link chain must still answer identically; the event link
+        // sits in front of it rather than replacing any part of it.
+        Assert.Equal("#112233", ModService.ResolveFxSlotHex(null, "#112233", "#445566"));
+        Assert.Equal("#FF69B4", ModService.ResolveFxSlotHex(null, null, null));
+    }
+
+    [Theory]
+    [InlineData("#88CCFF")]          // canonical
+    [InlineData("  #88ccff  ")]      // trimmed + upper-cased
+    public void EventHex_AcceptsSixDigitRrggbb(string input)
+        => Assert.Equal("#88CCFF", LiveEventService.NormalizeHex(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("88CCFF")]           // no hash
+    [InlineData("#88CCF")]           // too short
+    [InlineData("#FF88CCFF")]        // eight digits: ModService.ParseHexColor would return hot pink
+    [InlineData("#88CCFZ")]          // not hex
+    [InlineData("rebeccapurple")]
+    public void EventHex_RejectsAnythingElse_SoThePaletteFallsThrough(string? input)
+        => Assert.Null(LiveEventService.NormalizeHex(input));
+
+    [Fact]
+    public void ShadeHex_DerivesLightAndDarkRimsFromTheEventAccent()
+    {
+        Assert.Equal("#FFFFFF", ModService.ShadeHex("#FFFFFF", 1.18));   // clamps, never wraps
+        Assert.Equal("#000000", ModService.ShadeHex("#000000", 0.82));
+        Assert.Equal("#808080", ModService.ShadeHex("#808080", 1.0));    // identity
+    }
+
+    // ============================ event bubble skin (§14 row 1) ============================
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SkinId_BlankIsNoSkin(string? id)
+        => Assert.Null(LiveEventService.NormalizeId(id));
+
+    [Fact]
+    public void SkinId_IsTrimmed()
+        => Assert.Equal("snowglobe", LiveEventService.NormalizeId("  snowglobe  "));
+
+    [Fact]
+    public void ResourceResolver_WithNoEvent_StillResolvesTheEmbeddedBubble()
+    {
+        // App.LiveEvent is null in the test host, which is the same answer as "dormant":
+        // the event probe is skipped and the mod-then-embedded chain runs unchanged.
+        Assert.NotNull(ModResourceResolver.ResolveImage("bubble.png"));
+        Assert.StartsWith("pack://", ModResourceResolver.ResolveUri("bubble.png"));
+        Assert.False(ModResourceResolver.HasModOverride("bubble.png"));
+    }
+
+    // ============================ quest date window (§14 row 3) ============================
+
+    private static readonly DateTime Today = new(2026, 8, 12);
+
+    [Fact]
+    public void Window_NoBounds_IsAlwaysActive()
+        => Assert.True(QuestService.IsQuestInDateWindow(null, null, Today));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-date")]
+    [InlineData("12/08/2026")]      // ambiguous culture format: NOT a constraint
+    [InlineData("2026-13-45")]      // out of range
+    public void Window_UnparseableBound_FailsOpen(string bound)
+    {
+        Assert.True(QuestService.IsQuestInDateWindow(bound, null, Today));
+        Assert.True(QuestService.IsQuestInDateWindow(null, bound, Today));
+    }
+
+    [Fact]
+    public void Window_BeforeActiveFrom_IsHidden()
+        => Assert.False(QuestService.IsQuestInDateWindow("2026-08-13", null, Today));
+
+    [Fact]
+    public void Window_OnActiveFrom_IsActive()
+        => Assert.True(QuestService.IsQuestInDateWindow("2026-08-12", null, Today));
+
+    [Fact]
+    public void Window_AfterActiveUntil_IsHidden()
+        => Assert.False(QuestService.IsQuestInDateWindow(null, "2026-08-11", Today));
+
+    [Fact]
+    public void Window_OnActiveUntil_IsStillActive_BoundIsInclusive()
+        => Assert.True(QuestService.IsQuestInDateWindow(null, "2026-08-12", Today));
+
+    [Fact]
+    public void Window_InsideBothBounds_IsActive()
+        => Assert.True(QuestService.IsQuestInDateWindow("2026-08-01", "2026-08-31", Today));
+
+    [Fact]
+    public void Window_InvertedBounds_HideTheQuest_RatherThanThrow()
+        => Assert.False(QuestService.IsQuestInDateWindow("2026-09-01", "2026-07-01", Today));
+
+    [Fact]
+    public void Window_IsANoOp_ForEveryQuestThatShipsInThisBuild()
+    {
+        // The whole safety claim for this item in one assertion: no embedded quest carries
+        // a window, so the new filter cannot remove any of them on any date.
+        var all = QuestDefinition.DailyQuests.Concat(QuestDefinition.WeeklyQuests).ToList();
+        Assert.NotEmpty(all);
+        Assert.All(all, q =>
+        {
+            Assert.Null(q.ActiveFrom);
+            Assert.Null(q.ActiveUntil);
+            Assert.True(QuestService.IsQuestInDateWindow(q.ActiveFrom, q.ActiveUntil, Today));
+            Assert.True(QuestService.IsQuestInDateWindow(q.ActiveFrom, q.ActiveUntil, new DateTime(2099, 1, 1)));
+        });
+    }
+
+    // ============================ spiral rail (§9) ============================
+
+    [Fact]
+    public void SpiralRail_IsOffByDefault()
+        => Assert.False(new AppSettings().DescentSpiralRailEnabled);
+
+    [Theory]
+    [InlineData(0, "·")]      // the real pre-begin rung draws a dot, never "0"
+    [InlineData(1, "I")]
+    [InlineData(7, "VII")]
+    [InlineData(8, "VIII")]
+    [InlineData(9, "9")]      // past the authored ladder: a numeral, not a wrong Roman
+    public void SpiralRail_StageBadge_NeverInventsStageCopy(int n, string expected)
+        => Assert.Equal(expected, SpiralRailHost.StageNumeral(n));
+
+    [Fact]
+    public void SpiralEmbed_UrlCarriesTheMode_AndOnlyTheEmbedOrigin()
+    {
+        Assert.Equal("https://app.cclabs.app/embed/spiral?mode=mini", SpiralEmbedView.BuildUrl("mini"));
+        Assert.Equal("https://app.cclabs.app/embed/spiral?mode=map", SpiralEmbedView.BuildUrl("map"));
+        // An unknown mode must not reach the wire as-is.
+        Assert.Equal("https://app.cclabs.app/embed/spiral?mode=mini", SpiralEmbedView.BuildUrl("nonsense"));
+    }
+}


### PR DESCRIPTION
Desktop PHASE-1 lane of the 0812 finish wave. Everything here is built and **dormant**: flag off, no event data, no date windows. Flag-off UI and behaviour are identical to `main`.

Contract: `planning/one-descent/CONTRACTS-0812-FINISH.md` §9 · design `DESIGN-SNAPSHOT-v2.1.html` §9/§14.

## ⚠️ One decision needs an owner/coordinator call

`DECISIONS.md` (2026-08-10) amended the one-canvas law:

> **Spiral amendment: rail MINI = native WPF Canvas/Path** (rail-docked WebView2 HWND would sit over every tab transition — airspace); expandable MAP stays the shared web canvas.

`CONTRACTS-0812-FINISH` §9 and Master Doc v2.1 §9 — both newer, both frozen — say the mini **is** the shared canvas hosted via WebView2. `VatGlassCanvas.cs` quotes the amendment as binding precedent.

**This PR implements the contract** (newer + explicitly my brief) and mitigates the objection: the embed is created only while the rail is wide enough to hold it and is torn down whenever the rail collapses or scrolls away, so a native HWND never sits in the middle of the nav flyout's width animation. It is a mitigation, not a proof. Nothing downstream depends on which way this goes — reverting the mini to native WPF is a change inside `SpiralRailHost`, and the map stays WebView2 either way.

## What's here

**1 · Spiral rail host (§9)** — `Controls/SpiralEmbedView.cs`, `Controls/SpiralRailHost.cs`, `Windows/SpiralMapWindow.cs`

- Hosts `https://app.cclabs.app/embed/spiral?mode=mini|map`, navigation locked to that origin.
- §9 protocol exactly: host → `{ type: 'spiral:state', devotion_days, stage, relapse_multiplier, vat_fill_pct, reduced_motion, perf_tier }`; page → `{ type: 'spiral:ready' }`. State posted before the handshake is queued (last-wins); re-posted on every `DescentService.BlockChanged`.
- `lit_station_ids` deliberately **omitted** — the station registry lives in cclabs-web and desktop must not invent a list of what it has earned.
- `perf_tier` maps `PerformanceProfile.CurrentTier` → `low|mid|high`; `reduced_motion` from `MotionFx.Level`.
- **Fails soft** (§9): no WebView2 runtime, dead process, or a 404 on the route that hasn't deployed → dispose, uncover the native stage badge underneath. Never an empty hole.
- Badge shows a Roman numeral only — stage **names** are still an open owner decision in §14, so the client ships no stage copy.
- Click-to-expand opens `?mode=map` in its own window (no airspace problem at top level).
- Self-wiring off `Loaded`; **zero lines added to `MainWindow.xaml.cs`**.

Dormant via `AppSettings.DescentSpiralRailEnabled` (default `false`, no editor — a visible toggle for a route that can't draw is worse than none), **and** it additionally requires a server descent block, so the flag alone can't conjure a spiral for an account outside the rollout dial.

**2 · Bubble skin resolver (§14 row 1)** — `Services/ModResourceResolver.cs`

One probe at the head of the existing chain (`event skin → mod → embedded`). Because `bubble.png` / `tube.png` / `logo.png` all already resolve through here, this lights **all five bubble renderers** (BubbleService, its Skia compositor twin, Bubble Count, the avatar tube bubble, the Intake data-URI sprite) plus the tube and logo at once. Cache key gains the skin id; the same probe is mirrored into `ResolveUri` and `HasModOverride` so the tube pair's attached-layout fallback stays consistent. Dormant: no skin id → probe skipped entirely.

**3 · Event palette override (§14 row 4)** — `Services/ModService.cs`

`ResolveEventThemeHex` sits in front of the mod chain for accent / filter / the four FX slots. Light+dark rims are *derived* from the event accent rather than left on the mod's, so a half-applied palette (event-blue button, mod-pink hover rim) is impossible. Event hex is validated as `#RRGGBB` only — 8-digit would silently become hot pink through `ParseHexColor`. Deliberately **not** overridden: background/panel/surface (structural darks). Dormant: null event → same string as before.

**4 · Quest date window (§14 row 3)** — `Services/Progression/QuestService.cs`

`activeFrom`/`activeUntil` have been parsed, cached and refreshed since the definitions channel shipped and **never read**. This is that read, and it doubles as the channel's kill switch. Strict `yyyy-MM-dd`; `activeUntil` inclusive; local dates to match the quest day boundary (`QuestProgress.IsDailyExpired`); **fails open** on blank/unparseable (a server typo must cost a scheduling window, never the player's daily quest); and it cannot starve the pool — an emptied filter falls back to the undated pool. Proven a no-op over the entire embedded quest set on two dates.

**5 · Event XP boost (§14 row 2)** — `Services/Progression/SkillTreeService.cs`

One additive term in the single funnel, capped at `LiveEventService.MaxXpBoost` (0.25). Additive on purpose — the Pink Rush term already `*= 3.0` on whatever it lands on. Breakdown row is omitted entirely at 0 rather than showing "Event +0%". Loc key `skill_mult_event_boost` added to all 9 language files (one line each, no line-ending churn).

**Shared** — `Services/Events/LiveEventService.cs`: the dormant switchboard for items 2/3/5. A data holder with **no network, no timer, no persistence**. Nothing calls `Apply()`. The event-flip repaint is wired in `App.xaml.cs` (clears the resource cache + re-runs the same recolor trio as a mod switch) so it's already correct the day the event engine arrives.

## Gates

| | |
|---|---|
| Build warnings | **328 → 328** (full `--no-incremental` rebuild, zero new) |
| Errors | 0 |
| `dotnet test` | **2708 / 2708** green (baseline 2660, +48 new) |
| Versions bumped | none |
| `ProfileSyncService.cs` / `ProgressionService.cs` | **untouched** (sibling ceremony lane owns them) |

New tests: `Tests/ConditioningControlPanel.Tests/DescentPhase1DormancyTests.cs` — dormancy for all five items, the palette precedence, hex validation, the full date-window matrix incl. fail-open and inverted bounds, and the no-op proof over every embedded quest.

## Notes / deviations

- **No settings editor** for `DescentSpiralRailEnabled`. `DECISIONS.md` warns that Descent AppSettings props without visible editors get flagged as orphaned by the Phase 2/8 audits — accepted deliberately: dark-ship beats the orphan convention while the route can't draw. The editor lands when the Spiral lights up.
- `SpiralMapWindow` uses the **root** namespace, not `ConditioningControlPanel.Windows` — a folder namespace there shadows the WinRT `Windows` root and breaks `ScreenOcrService`'s `Windows.Graphics` reference. Comment left in the file.
- The embed route hadn't deployed at build time, so the live-canvas path is unexercised; the **failure** path (which is what a 404 hits) is the one that runs today and is the one wired to the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTZUrGYbe6QspHLTynxzXU
