### PR TITLE
feat(descent): migration ceremony, curve v2 and the epoch echo (ships dark)

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -495,6 +495,15 @@ namespace ConditioningControlPanel
         /// reads it renders nothing at all when it is absent.
         /// </summary>
         public static Services.Descent.DescentService? Descent { get; private set; }
+
+        /// <summary>
+        /// THE MIGRATION CEREMONY's runtime (CONTRACTS-0812 §4). Constructed on every launch and
+        /// DORMANT on every launch: the only thing that can wake it is a /v2/user/sync response
+        /// carrying <c>descent_migration.required</c>, which the server sends only with
+        /// DESCENT_MIGRATION armed. There is no client flag and no other entry point.
+        /// </summary>
+        public static Services.Descent.DescentMigrationService? DescentMigration { get; private set; }
+
         public static LeaderboardService Leaderboard { get; private set; } = null!;
         public static HapticService Haptics { get; private set; } = null!;
         public static AudioSyncService? AudioSync { get; private set; }
@@ -1876,6 +1885,9 @@ namespace ConditioningControlPanel
             // Constructing it costs nothing and issues no request: it fetches only
             // when a surface asks, and the Trainer Card is the only one that does.
             Descent = new Services.Descent.DescentService();
+            // Costs one allocation and issues nothing. See the property doc: it cannot act until
+            // a server offer arrives.
+            DescentMigration = new Services.Descent.DescentMigrationService();
             Leaderboard = new LeaderboardService();
             Haptics = new HapticService(Settings.Current.Haptics);
             AudioSync = new AudioSyncService(Haptics, Settings.Current.Haptics.AudioSync);

--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -364,6 +364,11 @@ namespace ConditioningControlPanel
             BubbleCountResultWindow.ForceCloseAll();
             QuizWindow.ForceCloseAll();
             PopQuizWindow.ForceCloseAll();
+            // The migration ceremony is fullscreen and topmost, so panic has to be able to clear
+            // it too. Closing it costs the user nothing: before the choice is taken nothing has
+            // been written and the server simply re-offers; after it, the choice is already on
+            // disk and riding the sync queue.
+            DescentCeremonyWindow.ForceCloseAll();
 
             // Stop ramp timer and reset sliders
             StopRampTimer();

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -5314,6 +5314,168 @@ namespace ConditioningControlPanel.Models
 
         #endregion
 
+        #region The Descent — migration ceremony state
+
+        // Everything in this region is written by exactly one place: the migration ceremony
+        // (Services/Descent/DescentMigrationService). It is all inert on a fresh install and on
+        // every install today — the server has to offer the ceremony before any of it moves.
+        //
+        // TWO FLAGS, TWO MEANINGS, and mixing them up is the bug this comment exists to prevent:
+        //   DescentEpoch            — "which curve is my ledger denominated in". Set at SUBMIT,
+        //                             because the ledger we send must be derived under the curve
+        //                             we claim to be on.
+        //   DescentMigrationCompleted — "the server has acknowledged my choice". Set ONLY on the
+        //                             server's completed:true ack (CONTRACTS §2.4). A crash in
+        //                             between re-offers the ceremony and loses nothing, because
+        //                             both choices are idempotent against an unchanged lifetime XP.
+
+        private int _descentEpoch = 0;
+        /// <summary>
+        /// This ACCOUNT's curve epoch. 0 = curve v1 (everybody, today). 1 = post-ceremony, curve
+        /// v2 live. Read by ProgressionService.ActiveCurveEpoch. NOT the wire constant — see
+        /// DescentEpochs.ClientEpoch, which is a property of the build and is always 1.
+        /// </summary>
+        [JsonProperty]
+        public int DescentEpoch
+        {
+            get => _descentEpoch;
+            set { _descentEpoch = value; OnPropertyChanged(); }
+        }
+
+        private bool _descentMigrationCompleted = false;
+        /// <summary>
+        /// True only once the server has answered a submit with descent_migration.completed.
+        /// The ceremony will not re-offer while this is set, and nothing else may set it.
+        /// </summary>
+        [JsonProperty]
+        public bool DescentMigrationCompleted
+        {
+            get => _descentMigrationCompleted;
+            set { _descentMigrationCompleted = value; OnPropertyChanged(); }
+        }
+
+        private string? _descentMigrationChoice = null;
+        /// <summary>"restore" or "cycle" — the acknowledged choice. Null until the ack lands.</summary>
+        [JsonProperty]
+        public string? DescentMigrationChoice
+        {
+            get => _descentMigrationChoice;
+            set { _descentMigrationChoice = value; OnPropertyChanged(); }
+        }
+
+        private string? _pendingDescentMigrationChoice = null;
+        /// <summary>
+        /// A choice the user has made and this client has applied locally, but which the server
+        /// has not acked yet. Its presence is what makes the next sync carry descent_migration,
+        /// and what stops the ceremony re-opening in front of somebody who already chose. Cleared
+        /// by the ack. A submit that never lands simply retries on every subsequent sync — the
+        /// server treats a repeat submit as a silent no-op (CONTRACTS §2.6).
+        /// </summary>
+        [JsonProperty]
+        public string? PendingDescentMigrationChoice
+        {
+            get => _pendingDescentMigrationChoice;
+            set { _pendingDescentMigrationChoice = value; OnPropertyChanged(); }
+        }
+
+        private DateTime? _descentAnchorUtc = null;
+        /// <summary>
+        /// Year One anchor: the ceremony date (§10). For veterans this is the birth of their
+        /// year, which is why the spiral starts at Day 1 for everybody — nobody's track arrives
+        /// pre-lit. Local mirror of the server's descent.anchor; the server's copy is canonical.
+        /// </summary>
+        [JsonProperty]
+        public DateTime? DescentAnchorUtc
+        {
+            get => _descentAnchorUtc;
+            set { _descentAnchorUtc = value; OnPropertyChanged(); }
+        }
+
+        private int _descentCycle = 0;
+        /// <summary>Cycles taken. 1 after choosing "Descend again". The permanent mark on the card.</summary>
+        [JsonProperty]
+        public int DescentCycle
+        {
+            get => _descentCycle;
+            set { _descentCycle = value; OnPropertyChanged(); }
+        }
+
+        private double _descentCycleXpBonus = 1.0;
+        /// <summary>
+        /// The lasting XP multiplier a Cycle grants. 1.0 = none. Written from
+        /// DescentMigration.CycleXpBonus at submit and clamped to it on read, so the persisted
+        /// figure can never exceed the blessed constant even if the file is edited by hand.
+        /// </summary>
+        [JsonProperty]
+        public double DescentCycleXpBonus
+        {
+            get => _descentCycleXpBonus;
+            set { _descentCycleXpBonus = value; OnPropertyChanged(); }
+        }
+
+        private bool _descentVeteranArchive = false;
+        /// <summary>
+        /// The keepsake marker (§6 reveal ruling): veterans are paid in an archive of every recap
+        /// card they ever earned plus a badge that says they were here before the fall — NOT in
+        /// spiral position. Set for both choices. The server grants the same marker; this is the
+        /// local mirror so the badge renders before the next profile read.
+        /// </summary>
+        [JsonProperty]
+        public bool DescentVeteranArchive
+        {
+            get => _descentVeteranArchive;
+            set { _descentVeteranArchive = value; OnPropertyChanged(); }
+        }
+
+        private int _descentPreMigrationLevel = 0;
+        /// <summary>The level the subject stood at when the ceremony opened. Keepsake copy; 0 = never migrated.</summary>
+        [JsonProperty]
+        public int DescentPreMigrationLevel
+        {
+            get => _descentPreMigrationLevel;
+            set { _descentPreMigrationLevel = value; OnPropertyChanged(); }
+        }
+
+        private double _descentPreMigrationLifetimeXp = 0;
+        /// <summary>Lifetime XP as the server reported it in the offer. Keepsake copy.</summary>
+        [JsonProperty]
+        public double DescentPreMigrationLifetimeXp
+        {
+            get => _descentPreMigrationLifetimeXp;
+            set { _descentPreMigrationLifetimeXp = value; OnPropertyChanged(); }
+        }
+
+        private List<int> _descentPendingStageCeremonies = new();
+        /// <summary>
+        /// THE DRIP (§6). "Take it all back" restores a veteran to a stage they never watched
+        /// themselves reach, so the stage ceremonies they skipped are queued here and released
+        /// ONE PER LOGIN DAY instead of firing in a single unwatchable burst — a veteran relives
+        /// the ladder across a week or two. Client-paced: no server involvement, no timer, just
+        /// this queue and <see cref="DescentLastStageDripDate"/>. Empty for a Cycle, which has no
+        /// ladder to re-walk.
+        /// </summary>
+        [JsonProperty]
+        public List<int> DescentPendingStageCeremonies
+        {
+            get => _descentPendingStageCeremonies;
+            set { _descentPendingStageCeremonies = value ?? new List<int>(); OnPropertyChanged(); }
+        }
+
+        private string? _descentLastStageDripDate = null;
+        /// <summary>
+        /// Local yyyy-MM-dd the last queued stage ceremony was released on. One per DAY, not per
+        /// launch — a user who restarts the app five times gets one, and a user who never opens
+        /// it loses nothing (the queue waits).
+        /// </summary>
+        [JsonProperty]
+        public string? DescentLastStageDripDate
+        {
+            get => _descentLastStageDripDate;
+            set { _descentLastStageDripDate = value; OnPropertyChanged(); }
+        }
+
+        #endregion
+
         #region Season Recap (local-only, per-device)
 
         // The Season Recap Card surfaces a snapshot of the just-ended season at rollover.

--- a/ConditioningControlPanel/Services/Descent/DescentCeremonyCopy.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentCeremonyCopy.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Globalization;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    /// <summary>
+    /// Every word the migration ceremony says, in one place.
+    ///
+    /// <para><b>Hardcoded English, deliberately, and it is a debt not a decision.</b> The repo
+    /// runs both conventions for one-shot surfaces (FeatureIntroPopup and ProgramsIntroPopup are
+    /// hardcoded on purpose; AwarenessConsentDialog and SeasonRecapWindow are fully localized),
+    /// and this copy is heavily interpolated with live numbers, which makes it the worst kind of
+    /// thing to hand to nine language files in a hurry. Collecting it here instead means the
+    /// localization pass is one file and one afternoon, rather than an archaeology dig through
+    /// XAML. See the PR notes.</para>
+    ///
+    /// <para><b>The tone is §6's.</b> Calm, ceremonial, no urgency, no scarcity, and — per
+    /// CONTRACTS §0.6 — not one offer, price, tier or upsell anywhere near it. This is the night
+    /// the wipe does not happen; it does not need selling.</para>
+    /// </summary>
+    public static class DescentCeremonyCopy
+    {
+        public const string Eyebrow = "THE DESCENT";
+
+        // ---- Act I: the intro -------------------------------------------------
+
+        public const string IntroHeadline = "The last season has ended.";
+
+        public const string IntroBody =
+            "Nothing was wiped. Nothing will be — this time the wipe simply doesn't happen, and it " +
+            "won't happen again.\n\n" +
+            "But the ladder underneath you has been rebuilt. The first forty levels are exactly " +
+            "where you left them; below that it gets steeper, and it keeps getting steeper all the " +
+            "way down. A level is going to mean more than it used to.\n\n" +
+            "So you get to choose how you meet it. Once.";
+
+        public const string IntroContinue = "Show me the two doors";
+
+        public static string IntroStanding(int level, double lifetimeXp, int devotionDays) =>
+            $"You stand at Level {level}  ·  {lifetimeXp.ToString("N0", CultureInfo.CurrentCulture)} lifetime XP  ·  " +
+            $"{devotionDays} {(devotionDays == 1 ? "day" : "days")} of devotion";
+
+        // ---- Act II: the two doors -------------------------------------------
+
+        public const string ChoiceHeadline = "Two doors. Both of them go down.";
+
+        public const string RestoreTitle = "Take it all back";
+        public const string RestoreKicker = "Everything you built, re-measured.";
+
+        public static string RestoreBody(int oldLevel, int newLevel) =>
+            $"Your lifetime XP is spent again on the new ladder, and it buys you Level {newLevel}.\n\n" +
+            $"The number moves because the ladder moved — not because anything was taken. Your " +
+            $"lifetime XP is untouched, your devotion is untouched, your keepsakes are untouched.\n\n" +
+            $"And the stages you already climbed come back to you one per day, so you get to watch " +
+            $"each one land instead of skipping the whole ladder in a single night.";
+
+        public static string RestoreDelta(int oldLevel, int newLevel) =>
+            oldLevel == newLevel
+                ? $"Level {oldLevel} → Level {newLevel}  (unchanged)"
+                : $"Level {oldLevel} → Level {newLevel}";
+
+        public const string CycleTitle = "Descend again";
+        public const string CycleKicker = "Cycle I. From the top.";
+
+        public static string CycleBody() =>
+            "Level 1. The whole fall again, first night to last, with everything you learned the " +
+            "first time.\n\n" +
+            "A Cycle wipes nothing but the number. Your devotion, your keepsakes, your badge, every " +
+            "day you have ever banked — all of it stays exactly where it is. What it adds is a " +
+            "permanent mark on your card that says you chose to fall twice, and a bonus on every " +
+            "point of XP you earn from here on.\n\n" +
+            "This is the dramatic one. It is for people who want the fall itself.";
+
+        public static string CycleBonusLine() =>
+            $"+{(DescentMigration.CycleXpBonus - 1.0) * 100:0.#}% XP, permanently";
+
+        public const string BothDoorsFooter =
+            "Either way: the veteran badge and your keepsake archive are yours — every recap card " +
+            "you ever earned, kept, because you were here before the fall. And either way the spiral " +
+            "starts tonight at Day 1. Nobody arrives with a track already lit. We all fall together.";
+
+        // ---- Act III: the confirm --------------------------------------------
+
+        public const string ConfirmHeadline = "This is the part that doesn't come back.";
+
+        public static string ConfirmBody(string choice) =>
+            choice == DescentMigrationChoices.Cycle
+                ? "You are choosing to descend again. Your level goes to 1 tonight and stays there " +
+                  "until you earn it back.\n\n" +
+                  "There is no undo. Not a setting, not a support ticket, not a second ceremony. " +
+                  "You get asked this once, and this is the once.\n\n" +
+                  "Take a breath first if you need one. The door will still be here."
+                : "You are choosing to take it all back. Your level is re-measured on the new ladder " +
+                  "and the stages you climbed will be handed back to you one a day.\n\n" +
+                  "There is no undo. Not a setting, not a support ticket, not a second ceremony. " +
+                  "You get asked this once, and this is the once.\n\n" +
+                  "Take a breath first if you need one. The door will still be here.";
+
+        public static string ConfirmYes(string choice) =>
+            choice == DescentMigrationChoices.Cycle ? "Yes. Take me back to Level 1." : "Yes. Give it back to me.";
+
+        public const string ConfirmBack = "Not that one";
+
+        // ---- Act IV: the close ------------------------------------------------
+
+        public const string DoneHeadline = "It's done.";
+
+        public static string DoneBody(string choice, int level) =>
+            choice == DescentMigrationChoices.Cycle
+                ? $"Cycle I. Level {level}.\n\n" +
+                  "The mark is on your card and it stays there. Everything you banked is still " +
+                  "banked. The spiral starts tonight, at Day 1 — the same Day 1 as everyone else."
+                : $"Level {level}, measured on the ladder you're actually standing on.\n\n" +
+                  "The stages you climbed will come back to you one a day. The spiral starts " +
+                  "tonight, at Day 1 — the same Day 1 as everyone else.";
+
+        public const string DoneClose = "Begin";
+
+        // ---- The escape hatch --------------------------------------------------
+
+        public const string Later = "Not tonight";
+
+        public const string LaterHint =
+            "Closing this changes nothing. The ceremony will be waiting the next time you sync.";
+
+        // ---- Companion lines (scripted; no bark rule required) -----------------
+
+        /// <summary>Spoken on open. Rule id the bark lane can adopt later: <c>descent_ceremony_open</c>.</summary>
+        public const string CompanionIntro = "Come here. Something is ending, and I want you with me for it.";
+
+        /// <summary>Spoken after the ack. Rule id: <c>descent_ceremony_done</c>.</summary>
+        public static string CompanionDone(string choice) =>
+            choice == DescentMigrationChoices.Cycle
+                ? "All the way back to the top with you. Good. I get to watch you fall all over again."
+                : "There you are. Same you, honest numbers. Let's keep going down.";
+
+        // ---- Helpers -----------------------------------------------------------
+
+        private static readonly string[] Numerals =
+            { "0", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X" };
+
+        /// <summary>Stage numerals for ceremony copy. Falls back to the digits past the ladder's end.</summary>
+        public static string RomanNumeral(int n) =>
+            n >= 0 && n < Numerals.Length ? Numerals[n] : n.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/ConditioningControlPanel/Services/Descent/DescentMigration.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentMigration.cs
@@ -1,0 +1,135 @@
+using System;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    // ============================================================================
+    // THE MIGRATION CEREMONY — wire constants, the offer, and the two choices.
+    //
+    // Spec: planning/one-descent/CONTRACTS-0812-FINISH.md §1 (epoch), §2 (handshake),
+    // §3 (curve v2), §4 (ceremony UX). Soul: DESIGN-SNAPSHOT-v2.1.html §6.
+    //
+    // THERE IS NO CLIENT FLAG, and that is the design. Every code path below is
+    // dormant until a sync response carries `descent_migration.required: true`,
+    // which the server only ever sends with DESCENT_MIGRATION armed. A build that
+    // ships today ships this whole feature dark; the owner turns it on server-side
+    // with nothing to re-release.
+    // ============================================================================
+
+    /// <summary>Epoch constants. Two of them, and they are NOT the same number twice.</summary>
+    public static class DescentEpochs
+    {
+        /// <summary>
+        /// THE BUILD'S epoch, sent as <c>descent_epoch</c> in every /v2/user/sync body
+        /// (CONTRACTS §1). It says "this client understands the Descent" — nothing about the
+        /// account. The server uses it as the resurrection guard: once a record is migrated, a
+        /// body arriving WITHOUT this number has its xp/level/total_xp_earned ignored, which is
+        /// what stops an unsynced old-curve phone from resurrecting a pre-migration level.
+        ///
+        /// <para>Unconditional on the wire by design — it is the one field CONTRACTS §1 exempts
+        /// from the flag-off-is-byte-identical rule, because it is the flag that identifies the
+        /// build.</para>
+        /// </summary>
+        public const int ClientEpoch = 1;
+
+        /// <summary>An account that has not been through the ceremony. Curve v1, no cycle mark.</summary>
+        public const int AccountLegacy = 0;
+
+        /// <summary>An account that has. Curve v2 from this point on.</summary>
+        public const int AccountDescent = 1;
+    }
+
+    /// <summary>The two doors of §6. Wire values are lowercase and exact — the server matches on them.</summary>
+    public static class DescentMigrationChoices
+    {
+        /// <summary>Option A, "Take it all back": level re-derived from lifetime XP under curve v2.</summary>
+        public const string Restore = "restore";
+
+        /// <summary>Option B, "Descend again": Cycle I, level 1, permanent mark, lasting XP bonus.</summary>
+        public const string Cycle = "cycle";
+
+        public static bool IsValid(string? choice) =>
+            choice == Restore || choice == Cycle;
+    }
+
+    /// <summary>
+    /// The server's offer, parsed off a /v2/user/sync response. Its mere existence is the whole
+    /// trigger — there is no local condition that can conjure one.
+    /// </summary>
+    public sealed class DescentMigrationOffer
+    {
+        /// <summary>Lifetime XP the SERVER holds for this account. The relevel's only input.</summary>
+        public double TotalXpEarned { get; init; }
+
+        /// <summary>Server-side devotion days, already backfilled. Display only.</summary>
+        public int DevotionDays { get; init; }
+    }
+
+    /// <summary>
+    /// The re-derived ledger a choice produces. Pure output of <see cref="DescentMigration.Resolve"/>
+    /// — computing it never touches settings, so the ceremony can PREVIEW both options side by
+    /// side before the user commits to either.
+    /// </summary>
+    public readonly record struct DescentRelevelResult(int Level, double XpIntoLevel, double LifetimeXp)
+    {
+        /// <summary>The `xp` field of the sync body: cumulative XP under curve v2 at this standing.</summary>
+        public double LedgerXp => LifetimeXp;
+    }
+
+    /// <summary>
+    /// The migration's pure arithmetic and the tunables that ride with it. Everything here is
+    /// static and side-effect free so it can be exercised without an App.
+    /// </summary>
+    public static class DescentMigration
+    {
+        /// <summary>
+        /// The Cycle XP bonus. TUNABLE AND UNBLESSED — CONTRACTS §3 records that the owner has
+        /// not signed off on 1.10, only on "there is a lasting bonus". It ships dark with the
+        /// ceremony; changing it is a one-line edit here and nowhere else.
+        /// </summary>
+        public const double CycleXpBonus = 1.10;
+
+        /// <summary>
+        /// The multiplier <see cref="ProgressionService.AddXP"/> actually applies. 1.0 for every
+        /// account that has not taken a Cycle, which today is every account in existence.
+        /// Defensive clamp on the persisted value: a hand-edited settings.json must not be able
+        /// to write itself a 50x XP tap.
+        /// </summary>
+        public static double ActiveCycleXpBonus
+        {
+            get
+            {
+                var stored = App.Settings?.Current?.DescentCycleXpBonus ?? 1.0;
+                if (double.IsNaN(stored) || stored < 1.0) return 1.0;
+                return Math.Min(stored, CycleXpBonus);
+            }
+        }
+
+        /// <summary>
+        /// What a choice does to the ledger, in one place, with no side effects.
+        ///
+        /// <para><b>Restore</b> re-derives level from the SERVER's lifetime figure under curve v2.
+        /// The server's number and not the client's on purpose: the server independently derives
+        /// the same value and clamps our claim to within one level of it (CONTRACTS §2.5), so
+        /// deriving from anything else is asking to be clamped.</para>
+        ///
+        /// <para><b>Cycle</b> is level 1, XP 0. Lifetime XP is carried through untouched —
+        /// total_xp_earned is lifetime and never decreases, not even here (§2.5), and §6 is
+        /// explicit that a Cycle "wipes nothing else".</para>
+        ///
+        /// <para>Both are IDEMPOTENT, which is what makes the crash-before-ack case survivable:
+        /// re-running either against the same server offer produces the same ledger.</para>
+        /// </summary>
+        public static DescentRelevelResult Resolve(string choice, DescentMigrationOffer offer)
+        {
+            double lifetime = offer.TotalXpEarned;
+            if (double.IsNaN(lifetime) || lifetime < 0) lifetime = 0;
+
+            if (choice == DescentMigrationChoices.Cycle)
+                return new DescentRelevelResult(1, 0, lifetime);
+
+            var (level, into) = ProgressionService.DeriveLevelFromLifetimeXp(
+                lifetime, DescentEpochs.AccountDescent);
+            return new DescentRelevelResult(level, into, lifetime);
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Descent/DescentMigrationService.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentMigrationService.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using Serilog;
+
+namespace ConditioningControlPanel.Services.Descent
+{
+    /// <summary>
+    /// THE MIGRATION CEREMONY's runtime — the one thing that knows how to turn a server offer
+    /// into a rewritten local ledger, and the only writer of the Descent settings region.
+    ///
+    /// <para><b>DORMANCY, stated once so it can be checked.</b> Nothing here runs on its own.
+    /// <see cref="OfferReceived"/> is called from exactly one place — ProfileSyncService, when a
+    /// /v2/user/sync response carries <c>descent_migration.required</c> — and the server sends
+    /// that only with DESCENT_MIGRATION armed. There is no client flag, no local heuristic, no
+    /// debug entry point and no timer. On today's server every method below is unreachable.</para>
+    ///
+    /// <para><b>Threading.</b> The offer arrives on a background sync continuation, so the window
+    /// open is marshalled to the dispatcher with the CLAUDE.md rule-6/8 guards (bail if the
+    /// dispatcher is gone or shutting down). Everything else is called from the UI thread.</para>
+    /// </summary>
+    public sealed class DescentMigrationService
+    {
+        private readonly object _gate = new();
+        private DescentMigrationOffer? _liveOffer;
+        private bool _ceremonyOpen;
+
+        /// <summary>
+        /// Raised when a queued stage ceremony comes due — one per login day, after a "Take it
+        /// all back" restored a veteran past stages they never watched themselves reach.
+        ///
+        /// <para>The desktop stage-ceremony SURFACE does not exist yet (it belongs to the stage
+        /// ladder lane, not this one). This event and the queue behind it are the contract that
+        /// lane consumes; until it lands, a drip spends itself on a companion line and a log
+        /// entry, which is the honest minimum and is still a moment rather than a silent
+        /// increment.</para>
+        /// </summary>
+        public event EventHandler<int>? StageCeremonyDue;
+
+        /// <summary>True while the ceremony window is on screen. Guards a second open.</summary>
+        public bool IsCeremonyOpen { get { lock (_gate) return _ceremonyOpen; } }
+
+        /// <summary>The offer the live ceremony is running against, or null.</summary>
+        public DescentMigrationOffer? LiveOffer { get { lock (_gate) return _liveOffer; } }
+
+        // ------------------------------------------------------------------
+        // The offer
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// The server has offered the ceremony. Open it — once — on the UI thread.
+        /// ProfileSyncService has already ruled out "already migrated" and "a choice is already
+        /// pending"; this method only has to avoid opening a second window over the first.
+        /// </summary>
+        public void OfferReceived(DescentMigrationOffer offer)
+        {
+            if (offer is null) return;
+
+            lock (_gate)
+            {
+                if (_ceremonyOpen) return;
+                _liveOffer = offer;
+            }
+
+            // CLAUDE.md async rules 6/8: a fire-and-forget hop onto a dispatcher that has begun
+            // shutting down is a crash report nobody can read.
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.HasShutdownStarted) return;
+
+            if (dispatcher.CheckAccess()) OpenCeremonyWindow();
+            else dispatcher.BeginInvoke(new Action(OpenCeremonyWindow));
+        }
+
+        private void OpenCeremonyWindow()
+        {
+            try
+            {
+                if (Application.Current?.Dispatcher?.HasShutdownStarted != false) return;
+
+                DescentMigrationOffer? offer;
+                lock (_gate)
+                {
+                    if (_ceremonyOpen) return;
+                    offer = _liveOffer;
+                    if (offer is null) return;
+                    _ceremonyOpen = true;
+                }
+
+                // Flat namespace — see the trap note at the top of DescentCeremonyWindow.xaml.cs.
+                var window = new DescentCeremonyWindow(offer);
+                window.Closed += (_, _) => { lock (_gate) _ceremonyOpen = false; };
+
+                var main = Application.Current?.MainWindow;
+                if (main != null && main.IsLoaded) window.Owner = main;
+
+                window.Show();
+                window.Activate();
+
+                Log.Information("[Descent] Migration ceremony opened.");
+            }
+            catch (Exception ex)
+            {
+                lock (_gate) _ceremonyOpen = false;
+                Log.Error(ex, "[Descent] Could not open the migration ceremony window — the server will re-offer on the next sync.");
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // The choice
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// COMMIT. Applies the chosen half of the migration locally and arms the submit that the
+        /// next sync carries. One-way, and the confirm step in front of it says so.
+        ///
+        /// <para><b>Why local-first.</b> The sync body's xp/level fields ARE the submit's ledger
+        /// (CONTRACTS §2.2) — there is no separate ledger field to fill — so the settings have to
+        /// be rewritten before the POST, not after the ack. What waits for the ack is the
+        /// "migrated" marker, and only that. See HandleDescentMigrationAck for why every ordering
+        /// of a crash here is survivable.</para>
+        /// </summary>
+        /// <returns>False if the choice was invalid or settings were unavailable.</returns>
+        public bool ApplyChoice(string choice, DescentMigrationOffer offer)
+        {
+            if (!DescentMigrationChoices.IsValid(choice)) return false;
+
+            var settings = App.Settings?.Current;
+            if (settings is null || offer is null) return false;
+
+            if (settings.DescentMigrationCompleted)
+            {
+                Log.Warning("[Descent] ApplyChoice ignored — this account is already migrated.");
+                return false;
+            }
+
+            var result = DescentMigration.Resolve(choice, offer);
+
+            // Keepsakes first, from the standing that is about to be replaced.
+            settings.DescentPreMigrationLevel = settings.PlayerLevel;
+            settings.DescentPreMigrationLifetimeXp = result.LifetimeXp;
+
+            // The ledger. PlayerXP is the progress INTO the current level, and PlayerLevel the
+            // level itself — GetTotalXP recombines them, which is what the sync body sends.
+            settings.DescentEpoch = DescentEpochs.AccountDescent;   // curve v2 is live from here
+            settings.PlayerLevel = result.Level;
+            settings.PlayerXP = result.XpIntoLevel;
+
+            // HighestLevelEver is a permanent-unlock key, not a ledger entry, and §6 is explicit
+            // that a Cycle "wipes nothing else". It is never lowered here.
+            if (settings.PlayerLevel > settings.HighestLevelEver)
+                settings.HighestLevelEver = settings.PlayerLevel;
+
+            if (choice == DescentMigrationChoices.Cycle)
+            {
+                settings.DescentCycle = Math.Max(1, settings.DescentCycle);
+                settings.DescentCycleXpBonus = DescentMigration.CycleXpBonus;
+                settings.DescentPendingStageCeremonies = new List<int>();   // no ladder to re-walk
+            }
+            else
+            {
+                settings.DescentPendingStageCeremonies = BuildStageDripQueue(offer);
+            }
+
+            // The keepsake and the anchor land for BOTH choices (§4). The anchor is the ceremony
+            // date: for veterans that is the birth of Year One, which is exactly why nobody's
+            // spiral arrives pre-lit — the track starts here, tonight, for everyone.
+            settings.DescentVeteranArchive = true;
+            settings.DescentAnchorUtc = DateTime.UtcNow;
+            settings.DescentLastStageDripDate = null;   // first drip may land the very next day
+
+            // THE WATERMARK MUST GO. It records the last total this client and the server agreed
+            // on, in PRE-migration terms; leaving it armed would have the send-guard defending a
+            // number the ceremony just deliberately retired, and it is scoped to (account,
+            // season) so a rollover will not clear it for us. The same helper the admin
+            // level_reset path uses — this is the same kind of event: a sanctioned rewrite.
+            ProfileSyncService.ClearXpWatermark(settings, "descent migration ceremony");
+
+            // LAST: arm the submit. Written after the ledger so a crash between the two leaves a
+            // rewritten-but-unsubmitted client, which the server's next offer simply re-runs to
+            // the same answer — rather than an armed submit with a stale ledger behind it.
+            settings.PendingDescentMigrationChoice = choice;
+            App.Settings?.Save();
+
+            Log.Information("[Descent] Choice '{Choice}' applied locally: Level {OldLevel} -> {NewLevel} on curve v2 (lifetime {Xp} XP). Awaiting server ack.",
+                choice, settings.DescentPreMigrationLevel, result.Level, (int)result.LifetimeXp);
+
+            // Push it now rather than waiting for the next scheduled sync. Fire-and-forget with
+            // the usual guard: a failed submit costs nothing, because the pending choice stays on
+            // disk and rides the next sync instead.
+            try
+            {
+                _ = App.ProfileSync?.SyncProfileAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Descent] Immediate submit sync could not be started: {Error}. It will ride the next sync.", ex.Message);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// THE DRIP QUEUE (§6). A restored veteran lands on a stage they never watched themselves
+        /// reach; firing every skipped stage ceremony at once would burn the whole ladder in one
+        /// unwatchable burst, so they are queued and released one per login day.
+        ///
+        /// <para>Built from the server's own ladder when one is in hand
+        /// (<see cref="DescentService.Current"/>), and from nothing at all when it is not — an
+        /// empty queue is a correct answer, and inventing a ladder client-side to fill it would
+        /// be exactly the local fabrication DescentModels forbids.</para>
+        /// </summary>
+        private static List<int> BuildStageDripQueue(DescentMigrationOffer offer)
+        {
+            var stage = App.Descent?.Current?.Stage;
+            var thresholds = stage?.Thresholds;
+
+            int reached;
+            if (thresholds is { Count: > 0 })
+                reached = thresholds.Count(t => offer.DevotionDays >= t);
+            else if (stage != null && stage.N > 0)
+                reached = stage.N;
+            else
+            {
+                Log.Information("[Descent] No stage ladder in hand at ceremony time — queueing no stage ceremonies. The restore is unaffected.");
+                return new List<int>();
+            }
+
+            var queue = Enumerable.Range(1, Math.Max(0, reached)).ToList();
+            Log.Information("[Descent] Queued {Count} stage ceremonies to drip one per login day.", queue.Count);
+            return queue;
+        }
+
+        // ------------------------------------------------------------------
+        // The drip
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// Release at most one queued stage ceremony, at most once per LOCAL DAY. Called after a
+        /// successful sync — a proven "this account is signed in and awake" moment that needs no
+        /// new lifecycle wiring. A user who restarts the app five times gets one; a user who does
+        /// not open the app at all loses nothing, because the queue simply waits.
+        /// </summary>
+        public void TickStageDrip()
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings is null) return;
+                if (!settings.DescentMigrationCompleted) return;
+
+                var queue = settings.DescentPendingStageCeremonies;
+                if (queue is null || queue.Count == 0) return;
+
+                var today = DateTime.Now.ToString("yyyy-MM-dd");
+                if (string.Equals(settings.DescentLastStageDripDate, today, StringComparison.Ordinal)) return;
+
+                var stage = queue[0];
+                settings.DescentPendingStageCeremonies = queue.Skip(1).ToList();
+                settings.DescentLastStageDripDate = today;
+                App.Settings?.Save();
+
+                Log.Information("[Descent] Stage {Stage} ceremony released ({Left} still queued).",
+                    stage, settings.DescentPendingStageCeremonies.Count);
+
+                RaiseStageCeremonyDue(stage);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Descent] Stage drip tick failed: {Error}", ex.Message);
+            }
+        }
+
+        private void RaiseStageCeremonyDue(int stage)
+        {
+            var dispatcher = Application.Current?.Dispatcher;
+            if (dispatcher is null || dispatcher.HasShutdownStarted) return;
+
+            void Fire()
+            {
+                try
+                {
+                    StageCeremonyDue?.Invoke(this, stage);
+
+                    // Until the stage-ceremony surface exists, the companion carries the moment.
+                    // playSound:false and aiGenerated:false — scripted copy, no AI badge, no
+                    // chat-suppression window.
+                    App.AvatarWindow?.GigglePriority(
+                        $"Stage {DescentCeremonyCopy.RomanNumeral(stage)}. You walked this once already. Walk it again with me.",
+                        playSound: false, aiGenerated: false);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug("[Descent] StageCeremonyDue handler threw: {Error}", ex.Message);
+                }
+            }
+
+            if (dispatcher.CheckAccess()) Fire();
+            else dispatcher.BeginInvoke(new Action(Fire));
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Progression/ProgressionService.cs
+++ b/ConditioningControlPanel/Services/Progression/ProgressionService.cs
@@ -13,8 +13,25 @@ namespace ConditioningControlPanel.Services
         public event EventHandler<int>? LevelUp;
         public event EventHandler<double>? XPChanged;
 
-        // Memoization cache for cumulative XP calculations
-        private readonly Dictionary<int, double> _cumulativeXPCache = new();
+        /// <summary>The curve every account has always been on. See <see cref="XpForLevelV1"/>.</summary>
+        public const int CurveEpochLegacy = 0;
+
+        /// <summary>The Descent recurve, live only after the migration ceremony. See <see cref="XpForLevelV2"/>.</summary>
+        public const int CurveEpochDescent = 1;
+
+        /// <summary>
+        /// Ceiling on any level a lifetime-XP figure may be derived to. Curve v2's cumulative
+        /// cost past L300 is a quarter of a billion XP, so this can only ever be hit by garbage
+        /// input — and a derive loop that trusts its input is a hang.
+        /// </summary>
+        public const int MaxDerivableLevel = 500;
+
+        // Memoization cache for cumulative XP calculations, one per curve epoch. Two caches and
+        // not one keyed pair because the curve NEVER changes mid-run for a given epoch, but it
+        // DOES change under a user's feet at the migration ceremony — a single cache would hand
+        // out v1 sums to a v2 client for the rest of the session.
+        private readonly Dictionary<int, double> _cumulativeXPCacheV1 = new();
+        private readonly Dictionary<int, double> _cumulativeXPCacheV2 = new();
 
         /// <summary>
         /// Awards XP to both the user (for feature unlocks) and the active companion (for companion leveling).
@@ -52,8 +69,12 @@ namespace ConditioningControlPanel.Services
             var settings = App.Settings.Current;
 
             // Apply skill tree XP multiplier (sparkle boost, time bonuses, pink rush, etc.)
+            // times the Cycle bonus — the lasting reward for having chosen "Descend again" at
+            // the migration ceremony. DescentCycleXpBonus is 1.0 for everybody who has not, so
+            // this is arithmetically invisible until a Cycle mark exists.
             var skillMultiplier = App.SkillTree?.GetTotalXpMultiplier() ?? 1.0;
-            var adjustedAmount = amount * skillMultiplier;
+            var cycleMultiplier = Descent.DescentMigration.ActiveCycleXpBonus;
+            var adjustedAmount = amount * skillMultiplier * cycleMultiplier;
 
             var previousXP = settings.PlayerXP;
             settings.PlayerXP += adjustedAmount;
@@ -179,18 +200,46 @@ namespace ConditioningControlPanel.Services
             }
         }
 
-        public double GetXPForLevel(int level)
-        {
-            // Progressive XP curve designed around session rewards:
-            // Easy: 400 XP, Medium: 800 XP, Hard: 1200 XP, Extreme: 2000 XP
-            //
-            // Target progression:
-            // Level 1-80: Easy (~800-2500 XP, 1-2 hard sessions per level)
-            // Level 80-100: Harder (~2500-4000 XP, 2-3 hard sessions per level)
-            // Level 100-125: Harder still (~4000-6000 XP, 3-5 hard sessions per level)
-            // Level 125-150: Even harder (~6000-10000 XP, 5-8 hard sessions per level)
-            // Level 150+: 3% compound growth per level
+        /// <summary>
+        /// Which XP curve THIS install is on right now. <see cref="CurveEpochLegacy"/> for every
+        /// account that has not been through the Descent migration ceremony — which today is all
+        /// of them, because nothing sets <c>DescentEpoch</c> until the ceremony's submit runs.
+        ///
+        /// <para>This is the per-USER epoch (AppSettings), deliberately NOT the per-BUILD wire
+        /// constant <see cref="Descent.DescentEpochs.ClientEpoch"/>. The build says "I am a client
+        /// that understands epoch 1"; this says "this account has crossed over". Conflating them
+        /// would recurve everybody the moment they installed the new version.</para>
+        /// </summary>
+        public static int ActiveCurveEpoch =>
+            App.Settings?.Current?.DescentEpoch == CurveEpochDescent ? CurveEpochDescent : CurveEpochLegacy;
 
+        /// <summary>XP to clear <paramref name="level"/> on the curve this account is currently on.</summary>
+        public double GetXPForLevel(int level) => GetXPForLevel(level, ActiveCurveEpoch);
+
+        /// <summary>
+        /// XP to clear <paramref name="level"/> on an explicitly named curve. Pure and static so
+        /// the recurve can be tested, and so the ceremony can price BOTH curves in the same breath
+        /// (it shows the user what their lifetime XP is worth under the new one).
+        /// </summary>
+        public static double GetXPForLevel(int level, int epoch) =>
+            epoch >= CurveEpochDescent ? XpForLevelV2(level) : XpForLevelV1(level);
+
+        /// <summary>
+        /// CURVE v1 — the original. Untouched, and it must stay untouched: every un-migrated
+        /// account's stored level was earned against these numbers.
+        ///
+        /// Progressive XP curve designed around session rewards:
+        /// Easy: 400 XP, Medium: 800 XP, Hard: 1200 XP, Extreme: 2000 XP
+        ///
+        /// Target progression:
+        /// Level 1-80: Easy (~800-2500 XP, 1-2 hard sessions per level)
+        /// Level 80-100: Harder (~2500-4000 XP, 2-3 hard sessions per level)
+        /// Level 100-125: Harder still (~4000-6000 XP, 3-5 hard sessions per level)
+        /// Level 125-150: Even harder (~6000-10000 XP, 5-8 hard sessions per level)
+        /// Level 150+: 3% compound growth per level
+        /// </summary>
+        public static double XpForLevelV1(int level)
+        {
             if (level <= 80)
             {
                 // Easy progression: linear growth from 800 to 2500
@@ -225,6 +274,123 @@ namespace ConditioningControlPanel.Services
                 double baseAt150 = 10000;
                 return Math.Round(baseAt150 * Math.Pow(1.03, level - 150));
             }
+        }
+
+        /// <summary>
+        /// CURVE v2 — THE RECURVE (CONTRACTS-0812 §3, master design doc §13). Canonical source:
+        /// <c>planning/descent-sim4.py</c> <c>cost_hybrid</c>. The literals below are that
+        /// function's literals; they are not re-derived here and must not be "tidied".
+        ///
+        /// <list type="bullet">
+        /// <item>L1-40 is BYTE-IDENTICAL to v1 — the honeymoon is protected on purpose, so a new
+        /// or newish subject feels nothing change.</item>
+        /// <item>L41-80 ramps to 4,200/level, L81-100 to 9,400, L101-125 to 20,400,
+        /// L126-150 to 50,400, then x1.035 compounding.</item>
+        /// </list>
+        ///
+        /// <para><b>The 1639 seam is deliberate.</b> v1's formula at L40 gives 1639.24; the sim
+        /// restarts the next segment from the flat literal 1639, a 0.24 XP discontinuity nobody
+        /// can perceive. The server implements the same literal. Matching the sim beats matching
+        /// the algebra, because the two implementations only have to agree with EACH OTHER.</para>
+        ///
+        /// <para><b>Rounding is part of the contract.</b> <see cref="MidpointRounding.AwayFromZero"/>
+        /// and not the framework default: every cost here is positive, so away-from-zero is
+        /// exactly JavaScript's <c>Math.round</c>, which is what the server rounds with. The
+        /// default (banker's, to-even) would disagree with the server on any cost landing on a
+        /// half — and a one-XP disagreement is a one-level disagreement at a boundary.</para>
+        /// </summary>
+        public static double XpForLevelV2(int level)
+        {
+            if (level <= 40)
+            {
+                // UNCHANGED from v1. Same expression, deliberately duplicated rather than
+                // delegated: v1 must remain editable-in-theory without silently moving v2.
+                return Math.Round(800 + (level - 1) * (1700.0 / 79), MidpointRounding.AwayFromZero);
+            }
+            else if (level <= 80)
+            {
+                // 1639 -> 4200 across 40 levels
+                return Math.Round(1639 + (level - 40) * ((4200.0 - 1639.0) / 40), MidpointRounding.AwayFromZero);
+            }
+            else if (level <= 100)
+            {
+                // 4200 -> 9400
+                return Math.Round(4200 + (level - 80) * 260.0, MidpointRounding.AwayFromZero);
+            }
+            else if (level <= 125)
+            {
+                // 9400 -> 20400
+                return Math.Round(9400 + (level - 100) * 440.0, MidpointRounding.AwayFromZero);
+            }
+            else if (level <= 150)
+            {
+                // 20400 -> 50400
+                return Math.Round(20400 + (level - 125) * 1200.0, MidpointRounding.AwayFromZero);
+            }
+            else
+            {
+                // 3.5% compound growth per level from 50,400
+                return Math.Round(50400 * Math.Pow(1.035, level - 150), MidpointRounding.AwayFromZero);
+            }
+        }
+
+        /// <summary>
+        /// Per-level quest XP scale factor. v1 is the runaway +4%/level the balance audit caught
+        /// (74% of a casual's year came from quest claims, and "log in, claim, quit" out-earned
+        /// playing); v2 corrects it to +1.2%/level. The 600 base is NOT here — it lives in each
+        /// quest definition's own XPReward, which is where an author can tune it.
+        /// </summary>
+        public static double QuestLevelScale(int level, int epoch) =>
+            1 + level * (epoch >= CurveEpochDescent ? 0.012 : 0.04);
+
+        /// <summary>Quest scale on the curve this account is currently on.</summary>
+        public static double QuestLevelScale(int level) => QuestLevelScale(level, ActiveCurveEpoch);
+
+        /// <summary>
+        /// Cumulative XP a subject must have earned to STAND at <paramref name="level"/> — i.e.
+        /// the sum of every level cost below it. Pure, uncached, iterative (the recursive cached
+        /// sibling is for hot UI paths; this one is for the derive loop and for tests, where a
+        /// 500-deep recursion would be a stack risk for no gain).
+        /// </summary>
+        public static double CumulativeXpToReachLevel(int level, int epoch)
+        {
+            if (level <= 1) return 0;
+            if (level > MaxDerivableLevel) level = MaxDerivableLevel;
+
+            double total = 0;
+            for (int l = 1; l < level; l++) total += GetXPForLevel(l, epoch);
+            return total;
+        }
+
+        /// <summary>
+        /// THE RELEVEL. Turns a lifetime XP total back into "what level does that buy on this
+        /// curve, and how far into it are you" — the exact arithmetic the migration ceremony's
+        /// "Take it all back" performs, and the arithmetic the server re-performs independently
+        /// before clamping the client's claim to within one level of its own answer
+        /// (CONTRACTS-0812 §2.5).
+        ///
+        /// <para>Deterministic and side-effect free: no App statics, no settings, no clock. The
+        /// same lifetime figure yields the same level every time it is asked, on any machine —
+        /// which is what makes a ceremony that crashes mid-flight safe to re-run.</para>
+        /// </summary>
+        /// <param name="lifetimeXp">Total XP ever earned. Negative and NaN are treated as zero.</param>
+        /// <param name="epoch">Curve to price it against.</param>
+        public static (int Level, double XpIntoLevel) DeriveLevelFromLifetimeXp(double lifetimeXp, int epoch)
+        {
+            if (double.IsNaN(lifetimeXp) || lifetimeXp <= 0) return (1, 0);
+
+            int level = 1;
+            double remaining = lifetimeXp;
+
+            while (level < MaxDerivableLevel)
+            {
+                double cost = GetXPForLevel(level, epoch);
+                if (cost <= 0 || remaining < cost) break;   // cost <= 0 is impossible; a guard, not a case
+                remaining -= cost;
+                level++;
+            }
+
+            return (level, Math.Max(0, remaining));
         }
 
         /// <summary>
@@ -268,15 +434,19 @@ namespace ConditioningControlPanel.Services
         {
             if (level <= 0) return 0;
 
+            // The cache is per epoch — a migrated account asking for a sum it already asked for
+            // under the old curve must not be handed the old answer.
+            var cache = ActiveCurveEpoch == CurveEpochDescent ? _cumulativeXPCacheV2 : _cumulativeXPCacheV1;
+
             // Check cache first
-            if (_cumulativeXPCache.TryGetValue(level, out double cached))
+            if (cache.TryGetValue(level, out double cached))
             {
                 return cached;
             }
 
             // Calculate: cumulative XP for previous level + XP for current level
             double cumulative = GetCumulativeXPForLevel(level - 1) + GetXPForLevel(level);
-            _cumulativeXPCache[level] = cumulative;
+            cache[level] = cumulative;
             return cumulative;
         }
 

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -921,13 +921,17 @@ public class QuestService : IDisposable
             Progress.TotalWeeklyQuestsCompleted++;
         }
 
-        // Scale XP reward based on player level (+4% per level)
+        // Scale XP reward based on player level. +4%/level pre-Descent, +1.2%/level once the
+        // account has been through the migration ceremony (CONTRACTS-0812 §3) — the coefficient
+        // moves with the XP curve, because it was the curve that made the old one a runaway.
+        // ProgressionService.QuestLevelScale reads the per-user epoch, so this is a no-op for
+        // every un-migrated account.
         var playerLevel = App.Settings?.Current?.PlayerLevel ?? 1;
         var betterQuestsMultiplier = App.SkillTree?.GetRerollBonusMultiplier() ?? 1.0;
         // Quest streak bonus: +3% per consecutive day
         var questStreak = App.Settings?.Current?.DailyQuestStreak ?? 0;
         var streakMultiplier = 1.0 + (questStreak * 0.03);
-        var scaledXP = (int)Math.Round(def.XPReward * (1 + playerLevel * 0.04) * betterQuestsMultiplier * streakMultiplier);
+        var scaledXP = (int)Math.Round(def.XPReward * ProgressionService.QuestLevelScale(playerLevel) * betterQuestsMultiplier * streakMultiplier);
 
         Progress.TotalXPFromQuests += scaledXP;
 

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -12,7 +12,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.Descent;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace ConditioningControlPanel.Services
 {
@@ -1110,7 +1112,27 @@ namespace ConditioningControlPanel.Services
                 // Guard: if local data looks like fresh defaults (Level 1, near-zero XP) and we
                 // haven't completed a round-trip load yet this session, skip sending XP/level.
                 // This prevents a settings reset (update crash, corruption) from zeroing the server.
-                if (!_hasLoadedProfile && settings.PlayerLevel <= 1 && totalXp < MeaningfulProgressXp)
+                // THE ONE SANCTIONED DOWNWARD WRITE (CONTRACTS-0812 §2.5). A migration choice the
+                // user has made but the server has not acked yet suspends BOTH XP-regression
+                // guards below for this sync — and only for this sync, because the flag is
+                // cleared by the ack. Without it the two guards do exactly what they were built
+                // to do and refuse the ceremony: "Descend again" pushes Level 1 / 0 XP, which is
+                // the defaults-guard's whole signature, and both choices push a total under the
+                // watermark this client and the server last agreed on.
+                //
+                // Suspending them is safe here precisely because this is not a local calculation
+                // that went wrong: the figure was derived from the SERVER's own total_xp_earned
+                // in response to the SERVER's own offer, and the server re-derives and clamps it
+                // on arrival. Nothing else in the app can set this flag.
+                var pendingMigrationChoice = settings.PendingDescentMigrationChoice;
+                var migrationSubmitInFlight = DescentMigrationChoices.IsValid(pendingMigrationChoice);
+                if (migrationSubmitInFlight)
+                {
+                    App.Logger?.Information("[Descent] Migration submit riding this sync (choice={Choice}, Level {Level}, XP {Xp}) — XP regression guards suspended for it.",
+                        pendingMigrationChoice, settings.PlayerLevel, (int)totalXp);
+                }
+
+                if (!migrationSubmitInFlight && !_hasLoadedProfile && settings.PlayerLevel <= 1 && totalXp < MeaningfulProgressXp)
                 {
                     App.Logger?.Warning("Sync blocked — local looks like defaults (Level {Level}, XP {Xp}) and profile not yet loaded. Waiting for LoadProfileAsync.",
                         settings.PlayerLevel, (int)totalXp);
@@ -1133,7 +1155,7 @@ namespace ConditioningControlPanel.Services
                 // — a local total that fell with no server-side explanation — and it cannot latch,
                 // which matters because this check sits in front of the whole payload, not just
                 // the XP field.
-                var watermark = ActiveXpWatermark(settings);
+                var watermark = migrationSubmitInFlight ? 0 : ActiveXpWatermark(settings);
                 if (watermark > 0 && totalXp < watermark)
                 {
                     App.Logger?.Error("[XP watermark] Sync REFUSED — would push {Xp} XP, below the {Watermark} XP this client and the server last agreed on for this account this season (Level {Level}). This local profile has LOST progress; not asking the server to match it. Fix the local file or reset the account deliberately.",
@@ -1208,6 +1230,17 @@ namespace ConditioningControlPanel.Services
                         // Null until the first claim ever lands, which is a perfectly good "nothing
                         // applied yet" to the server.
                         web_xp_claim_ack = settings.LastWebXpClaimId,
+                        // THE EPOCH ECHO (CONTRACTS-0812 §1). Unconditional, on every body, from
+                        // every build that carries this line — it identifies the CLIENT, not the
+                        // account, so it does not wait for a flag and it does not read settings.
+                        //
+                        // Server side it is the resurrection guard: once a record is migrated, a
+                        // sync body arriving without this number has its xp/level/total_xp_earned
+                        // ignored outright, which is the only thing standing between a migrated
+                        // account and an unsynced old-curve phone pushing a pre-migration level
+                        // back up through the take-higher merge. Legacy clients see no error and
+                        // no wire change; their level writes just stop landing.
+                        descent_epoch = DescentEpochs.ClientEpoch,
                         // Send false to clear server-side reset flags only when acknowledging
                         reset_weekly_quest = false,
                         reset_daily_quest = false,
@@ -1218,6 +1251,23 @@ namespace ConditioningControlPanel.Services
                     var v2Request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}/v2/user/sync");
                     AddAuthHeader(v2Request);
                     var v2Body = JsonConvert.SerializeObject(v2SyncData);
+
+                    // THE CHOICE SUBMIT (CONTRACTS-0812 §2.2), grafted on rather than declared in
+                    // the anonymous object above, because an anonymous property would serialize as
+                    // `"descent_migration": null` on the 100% of syncs that carry no choice — and
+                    // §0.4 says flag-off is BYTE-IDENTICAL wire, not "identical apart from a null".
+                    // No pending choice, no re-serialization, no new bytes.
+                    //
+                    // The re-derived ledger rides in the ORDINARY xp/level fields (already built
+                    // above from the settings the ceremony rewrote); this object carries nothing
+                    // but the choice.
+                    if (migrationSubmitInFlight)
+                    {
+                        var payload = JObject.Parse(v2Body);
+                        payload["descent_migration"] = new JObject { ["choice"] = pendingMigrationChoice };
+                        v2Body = payload.ToString(Formatting.None);
+                    }
+
                     v2Request.Content = new StringContent(v2Body, Encoding.UTF8, "application/json");
                     SignRequest(v2Request, v2Body);
 
@@ -1359,6 +1409,25 @@ namespace ConditioningControlPanel.Services
 
                             App.Progression?.AddClaimedXP(webXpClaim.Amount);
                         }
+
+                        // THE MIGRATION HANDSHAKE, both halves (CONTRACTS-0812 §2). Absent block =
+                        // nothing happens, which is the state of every account in the world until
+                        // the owner arms DESCENT_MIGRATION server-side. There is no client flag to
+                        // find and no local condition that reaches this code on its own.
+                        //
+                        // Ack FIRST, offer second, and the order matters: a submit's own response
+                        // carries the ack, and settling it before looking at `required` means a
+                        // server that (wrongly) sent both in one breath cannot re-open a ceremony
+                        // the user just finished.
+                        HandleDescentMigrationAck(settings, v2Result?.DescentMigration);
+                        HandleDescentMigrationOffer(settings, v2Result?.DescentMigration);
+
+                        // The stage-ceremony drip (§6). A successful sync is the cheapest honest
+                        // proxy for "signed in and awake today" that needs no new lifecycle
+                        // wiring, and the tick is a same-local-day no-op, so syncing forty times
+                        // still releases exactly one. Returns immediately for the ~100% of
+                        // accounts with an empty queue.
+                        App.DescentMigration?.TickStageDrip();
 
                         // Prestige: adopt the server's lifetime_points_spent when ahead (other
                         // device / migration backfill). Monotonic — never lowered.
@@ -1629,6 +1698,28 @@ namespace ConditioningControlPanel.Services
                                 (System.Windows.Application.Current?.MainWindow as ConditioningControlPanel.MainWindow)?.TryPresentSeasonRecap();
                             }));
                         }
+                        // THE CEREMONY'S LEDGER IS NOT UP FOR NEGOTIATION until the server acks it.
+                        //
+                        // This is the nastiest interaction in the whole migration. The adopt block
+                        // below exists to pull a client UP to a server that is 5k ahead — and on
+                        // the sync that submits a Cycle, the server's pre-migration record is
+                        // hundreds of thousands of XP ahead of the Level 1 ledger we just wrote.
+                        // If the server did NOT process the submit (flag off mid-flight, an older
+                        // deploy, a partial write), the adopt would cheerfully resurrect the
+                        // pre-ceremony level while the pending choice sat on disk waiting to
+                        // re-submit — a client and a server disagreeing about whether a one-way
+                        // ceremony happened.
+                        //
+                        // So: while a submit is in flight, the ONLY response allowed to move the
+                        // ledger is one carrying the ack. With the ack, the server's figures ARE
+                        // the post-migration truth (including the §2.5 ±1-level clamp on a
+                        // restore) and adopting them is exactly right. Without it, we keep what
+                        // the ceremony wrote and try again next sync.
+                        else if (migrationSubmitInFlight && v2Result?.DescentMigration?.Completed != true)
+                        {
+                            App.Logger?.Warning("[Descent] Migration submit was not acknowledged in this response — holding the ceremony's ledger (Level {Level}) and ignoring the server's pre-migration figures. Will re-submit on the next sync.",
+                                settings.PlayerLevel);
+                        }
                         // Adopt server XP after sync. Two cases:
                         // 1. Server > local: server has more (admin boost, other device). Adopt.
                         // 2. Server significantly < local: server clamped us (anti-cheat). Adopt to
@@ -1704,7 +1795,14 @@ namespace ConditioningControlPanel.Services
                         // deliberately KEPT a higher local — the clamp's defend branch — the totals
                         // differ, RecordAgreedServerXp sees the disagreement and leaves the
                         // previously agreed figure standing.
-                        if (v2Result?.User != null)
+                        //
+                        // Suppressed entirely while a migration submit is unacked, for the same
+                        // reason the adopt above is: there is no agreement to record. The server
+                        // is still quoting a pre-ceremony total and this client is deliberately
+                        // holding a lower one. Writing that down as "agreed" would arm the
+                        // send-guard at a figure the ceremony just retired.
+                        if (v2Result?.User != null &&
+                            (!migrationSubmitInFlight || v2Result.DescentMigration?.Completed == true))
                         {
                             var agreedClientXp = App.Progression?.GetTotalXP(settings.PlayerLevel, settings.PlayerXP) ?? settings.PlayerXP;
                             RecordAgreedServerXp(settings, v2Result.User.Xp, agreedClientXp, "V2 sync");
@@ -3659,6 +3757,76 @@ namespace ConditioningControlPanel.Services
 
         #endregion
 
+        #region The Descent — migration handshake (CONTRACTS-0812 §2)
+
+        /// <summary>
+        /// Settle a submit. THE ACK IS THE ONLY THING THAT MAY WRITE
+        /// <see cref="AppSettings.DescentMigrationCompleted"/> — this method is the one place that
+        /// touches it, and it is deliberately the mirror image of the web-XP claim handshake a few
+        /// hundred lines up.
+        ///
+        /// <para>The lopsidedness is the point. The client applies its half of the migration
+        /// BEFORE the submit (it has to — the ledger it sends must be denominated in the curve it
+        /// claims), and marks itself done only when the server says so. Crash in the gap and the
+        /// server is still unmigrated, so it re-offers; the pending choice is still on disk, so
+        /// the very next sync re-submits it; and the server treats a repeat submit as a silent
+        /// no-op. Nothing is lost in any ordering, because both choices are pure functions of a
+        /// lifetime XP total that never moves.</para>
+        /// </summary>
+        private static void HandleDescentMigrationAck(AppSettings settings, V2DescentMigration? block)
+        {
+            if (block?.Completed != true) return;
+            if (settings.DescentMigrationCompleted) return;   // already settled; idempotent
+
+            // Prefer the server's echo of the choice; fall back to what we submitted. They can
+            // only differ if the account migrated on another device, and the server's word wins.
+            var choice = DescentMigrationChoices.IsValid(block.Choice)
+                ? block.Choice
+                : settings.PendingDescentMigrationChoice;
+
+            settings.DescentMigrationCompleted = true;
+            settings.DescentMigrationChoice = choice;
+            settings.PendingDescentMigrationChoice = null;
+            App.Settings?.Save();
+
+            App.Logger?.Information("[Descent] Migration ACKNOWLEDGED by server (choice={Choice}). Curve v2 is now this account's curve, permanently.",
+                choice ?? "unknown");
+        }
+
+        /// <summary>
+        /// Open the ceremony when the server offers it. Every condition here is a reason NOT to:
+        /// the block has to be present, it has to say required, the account must not already be
+        /// migrated, and there must be no choice already made and waiting to land.
+        ///
+        /// <para>That last one is what stops the ceremony re-opening in front of a user who has
+        /// already chosen but whose ack has not arrived — the server will keep saying "required"
+        /// until the submit lands, and asking a one-way question twice is the one thing this
+        /// ceremony must never do.</para>
+        /// </summary>
+        private static void HandleDescentMigrationOffer(AppSettings settings, V2DescentMigration? block)
+        {
+            if (block?.Required != true) return;
+            if (settings.DescentMigrationCompleted) return;
+            if (DescentMigrationChoices.IsValid(settings.PendingDescentMigrationChoice))
+            {
+                App.Logger?.Debug("[Descent] Offer re-sent but a choice is already pending server ack — not re-opening the ceremony.");
+                return;
+            }
+
+            var offer = new DescentMigrationOffer
+            {
+                TotalXpEarned = block.TotalXpEarned ?? 0,
+                DevotionDays = block.DevotionDays ?? 0
+            };
+
+            App.Logger?.Information("[Descent] Server is offering the migration ceremony (lifetime {Xp} XP, {Days} devotion days).",
+                (int)offer.TotalXpEarned, offer.DevotionDays);
+
+            App.DescentMigration?.OfferReceived(offer);
+        }
+
+        #endregion
+
         public void Dispose()
         {
             if (_disposed) return;
@@ -3886,8 +4054,45 @@ namespace ConditioningControlPanel.Services
             [JsonProperty("web_xp")]
             public V2WebXp? WebXp { get; set; }
 
+            /// <summary>
+            /// The Descent migration handshake, offer AND ack on the same key (CONTRACTS §2).
+            /// Absent unless the server has DESCENT_MIGRATION armed, which is why it is nullable
+            /// and why every reader treats absence as "there is no ceremony".
+            /// </summary>
+            [JsonProperty("descent_migration")]
+            public V2DescentMigration? DescentMigration { get; set; }
+
             [JsonProperty("user")]
             public V2SyncUser? User { get; set; }
+        }
+
+        /// <summary>
+        /// One shape, two directions. On an ordinary sync the server may fill
+        /// <see cref="Required"/> + the two figures (the OFFER); on the response to a submit it
+        /// fills <see cref="Completed"/> + <see cref="Choice"/> (the ACK). Nullable throughout:
+        /// a missing field is never a zero, it is a server that did not speak.
+        /// </summary>
+        private class V2DescentMigration
+        {
+            /// <summary>The offer. True = this account has not migrated and the flag is on.</summary>
+            [JsonProperty("required")]
+            public bool? Required { get; set; }
+
+            /// <summary>Lifetime XP the SERVER holds — the sole input to the relevel (§2.5).</summary>
+            [JsonProperty("total_xp_earned")]
+            public double? TotalXpEarned { get; set; }
+
+            /// <summary>Server-side devotion days, already backfilled. Display only.</summary>
+            [JsonProperty("devotion_days")]
+            public int? DevotionDays { get; set; }
+
+            /// <summary>The ack. The ONLY thing that may mark this client migrated (§2.4).</summary>
+            [JsonProperty("completed")]
+            public bool? Completed { get; set; }
+
+            /// <summary>The choice the server recorded: "restore" or "cycle".</summary>
+            [JsonProperty("choice")]
+            public string? Choice { get; set; }
         }
 
         private class V2WebXp

--- a/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml
+++ b/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml
@@ -1,0 +1,287 @@
+<Window x:Class="ConditioningControlPanel.DescentCeremonyWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="The Descent"
+        WindowStyle="None"
+        WindowState="Maximized"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Topmost="True"
+        Background="#FF0A0514"
+        UseLayoutRounding="True"
+        TextOptions.TextFormattingMode="Ideal">
+
+    <!--
+      THE MIGRATION CEREMONY (CONTRACTS-0812 §4, design doc §6).
+
+      Deliberately NOT AllowsTransparency. A layered fullscreen window created while other
+      layered surfaces are animating can wedge the shared WPF render thread (see the notes on
+      ChaosUnlockCardOverlay and LockCardWindow's pool) — and this window has no need of
+      transparency at all: it is opaque by design, because "dimmed chrome" for a ceremony this
+      size means covering the chrome, not tinting it.
+
+      No offers. No prices. No tiers. No upsell. CONTRACTS §0.6, and it is not negotiable.
+    -->
+
+    <Grid>
+        <!-- Backdrop: radial base -> wash -> vignette, the MantraWindow recipe -->
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="0.5,0.42" Center="0.5,0.42" RadiusX="0.85" RadiusY="0.9">
+                    <GradientStop Color="#FF241041" Offset="0"/>
+                    <GradientStop Color="#FF1A1A2E" Offset="0.55"/>
+                    <GradientStop Color="#FF0A0514" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+        <Border x:Name="GlowLayer" Opacity="0.30">
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="0.5,0.30" Center="0.5,0.30" RadiusX="0.6" RadiusY="0.45">
+                    <GradientStop Color="{DynamicResource PinkColor}" Offset="0"/>
+                    <GradientStop Color="#00FF69B4" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+        <Border>
+            <Border.Background>
+                <RadialGradientBrush GradientOrigin="0.5,0.5" Center="0.5,0.5" RadiusX="0.75" RadiusY="0.75">
+                    <GradientStop Color="#00000000" Offset="0.45"/>
+                    <GradientStop Color="#99000000" Offset="1"/>
+                </RadialGradientBrush>
+            </Border.Background>
+        </Border>
+
+        <!-- Content -->
+        <Grid x:Name="Stage" Margin="40">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0"
+                       Text="THE DESCENT"
+                       HorizontalAlignment="Center"
+                       Margin="0,18,0,0"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       Foreground="{DynamicResource PinkBrush}"
+                       Opacity="0.85">
+                <TextBlock.RenderTransform>
+                    <TranslateTransform/>
+                </TextBlock.RenderTransform>
+            </TextBlock>
+
+            <!-- One act visible at a time; the code-behind swaps Visibility. -->
+            <Grid Grid.Row="1" x:Name="ActHost">
+
+                <!-- ACT I - the intro -->
+                <StackPanel x:Name="ActIntro"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="760">
+                    <TextBlock x:Name="IntroHeadline"
+                               FontSize="38" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="IntroStanding"
+                               Margin="0,18,0,0"
+                               FontSize="14"
+                               Foreground="{DynamicResource PinkBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"
+                               Opacity="0.9"/>
+                    <TextBlock x:Name="IntroBody"
+                               Margin="0,28,0,0"
+                               FontSize="16" LineHeight="27"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <Button x:Name="BtnIntroContinue"
+                            Margin="0,40,0,0"
+                            HorizontalAlignment="Center"
+                            Padding="30,13"
+                            FontSize="15"
+                            Style="{DynamicResource PinkButton}"
+                            Click="OnIntroContinue"/>
+                </StackPanel>
+
+                <!-- ACT II - the two doors -->
+                <Grid x:Name="ActChoice" Visibility="Collapsed">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0"
+                               x:Name="ChoiceHeadline"
+                               Margin="0,10,0,0"
+                               FontSize="28" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextAlignment="Center" TextWrapping="Wrap"/>
+
+                    <Grid Grid.Row="1" MaxWidth="1080" VerticalAlignment="Center" Margin="0,24,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="28"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Door A -->
+                        <Border Grid.Column="0"
+                                Background="#FF252542"
+                                CornerRadius="14"
+                                BorderBrush="{DynamicResource TransparentPink40Brush}"
+                                BorderThickness="1.5"
+                                Padding="30,28">
+                            <StackPanel>
+                                <TextBlock x:Name="RestoreTitle"
+                                           FontSize="24" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock x:Name="RestoreKicker"
+                                           Margin="0,6,0,0"
+                                           FontSize="13"
+                                           Foreground="{DynamicResource PinkBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Border Margin="0,18,0,0" Padding="14,10"
+                                        CornerRadius="8" Background="#FF1A1A2E">
+                                    <TextBlock x:Name="RestoreDelta"
+                                               FontSize="17" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextLightBrush}"
+                                               TextAlignment="Center" TextWrapping="Wrap"/>
+                                </Border>
+                                <TextBlock x:Name="RestoreBody"
+                                           Margin="0,18,0,0"
+                                           FontSize="14" LineHeight="23"
+                                           Foreground="{DynamicResource TextMutedBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Button x:Name="BtnChooseRestore"
+                                        Margin="0,24,0,0"
+                                        Padding="0,12"
+                                        FontSize="14"
+                                        Style="{DynamicResource PinkButton}"
+                                        Click="OnChooseRestore"/>
+                            </StackPanel>
+                        </Border>
+
+                        <!-- Door B -->
+                        <Border Grid.Column="2"
+                                Background="#FF252542"
+                                CornerRadius="14"
+                                BorderBrush="{DynamicResource TransparentPink40Brush}"
+                                BorderThickness="1.5"
+                                Padding="30,28">
+                            <StackPanel>
+                                <TextBlock x:Name="CycleTitle"
+                                           FontSize="24" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextLightBrush}"
+                                           TextWrapping="Wrap"/>
+                                <TextBlock x:Name="CycleKicker"
+                                           Margin="0,6,0,0"
+                                           FontSize="13"
+                                           Foreground="{DynamicResource PinkBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Border Margin="0,18,0,0" Padding="14,10"
+                                        CornerRadius="8" Background="#FF1A1A2E">
+                                    <TextBlock x:Name="CycleBonus"
+                                               FontSize="17" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TextLightBrush}"
+                                               TextAlignment="Center" TextWrapping="Wrap"/>
+                                </Border>
+                                <TextBlock x:Name="CycleBody"
+                                           Margin="0,18,0,0"
+                                           FontSize="14" LineHeight="23"
+                                           Foreground="{DynamicResource TextMutedBrush}"
+                                           TextWrapping="Wrap"/>
+                                <Button x:Name="BtnChooseCycle"
+                                        Margin="0,24,0,0"
+                                        Padding="0,12"
+                                        FontSize="14"
+                                        Style="{DynamicResource OutlineButton}"
+                                        Click="OnChooseCycle"/>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+
+                    <TextBlock Grid.Row="2"
+                               x:Name="BothDoorsFooter"
+                               MaxWidth="900"
+                               Margin="0,26,0,0"
+                               FontSize="13" LineHeight="21"
+                               Foreground="{DynamicResource TextDimBrush}"
+                               TextAlignment="Center" TextWrapping="Wrap"/>
+                </Grid>
+
+                <!-- ACT III - the one-way confirm -->
+                <StackPanel x:Name="ActConfirm"
+                            Visibility="Collapsed"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="640">
+                    <TextBlock x:Name="ConfirmHeadline"
+                               FontSize="30" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="ConfirmBody"
+                               Margin="0,24,0,0"
+                               FontSize="15" LineHeight="26"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,38,0,0">
+                        <Button x:Name="BtnConfirmBack"
+                                Padding="26,12" FontSize="14"
+                                Style="{DynamicResource SecondaryButton}"
+                                Click="OnConfirmBack"/>
+                        <Button x:Name="BtnConfirmYes"
+                                Margin="16,0,0,0"
+                                Padding="26,12" FontSize="14"
+                                Style="{DynamicResource PinkButton}"
+                                Click="OnConfirmYes"/>
+                    </StackPanel>
+                    <TextBlock x:Name="ConfirmError"
+                               Visibility="Collapsed"
+                               Margin="0,20,0,0"
+                               FontSize="13"
+                               Foreground="#FFFF8080"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                </StackPanel>
+
+                <!-- ACT IV - the close -->
+                <StackPanel x:Name="ActDone"
+                            Visibility="Collapsed"
+                            VerticalAlignment="Center" HorizontalAlignment="Center"
+                            MaxWidth="640">
+                    <TextBlock x:Name="DoneHeadline"
+                               FontSize="34" FontWeight="Light"
+                               Foreground="{DynamicResource TextLightBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <TextBlock x:Name="DoneBody"
+                               Margin="0,24,0,0"
+                               FontSize="16" LineHeight="27"
+                               Foreground="{DynamicResource TextMutedBrush}"
+                               TextWrapping="Wrap" TextAlignment="Center"/>
+                    <Button x:Name="BtnDoneClose"
+                            Margin="0,40,0,0"
+                            HorizontalAlignment="Center"
+                            Padding="34,13" FontSize="15"
+                            Style="{DynamicResource PinkButton}"
+                            Click="OnDoneClose"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- The escape hatch. Closing before a choice is made costs nothing. -->
+            <StackPanel Grid.Row="2" x:Name="LaterHost" HorizontalAlignment="Center" Margin="0,0,0,14">
+                <Button x:Name="BtnLater"
+                        HorizontalAlignment="Center"
+                        Background="Transparent" BorderThickness="0"
+                        Foreground="{DynamicResource TextDimBrush}"
+                        FontSize="13" Padding="10,6" Cursor="Hand"
+                        Click="OnLater"/>
+                <TextBlock x:Name="LaterHint"
+                           HorizontalAlignment="Center"
+                           FontSize="11"
+                           Foreground="{DynamicResource TextDimBrush}"
+                           Opacity="0.7"
+                           TextAlignment="Center"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</Window>

--- a/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/DescentCeremonyWindow.xaml.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media.Animation;
+using ConditioningControlPanel.Services.Descent;
+using Serilog;
+
+// NAMESPACE TRAP, and it is not a style preference. Every window under Windows/ lives in the
+// FLAT ConditioningControlPanel namespace — not one of them declares ConditioningControlPanel.Windows.
+// Declaring it here compiles for a moment and then breaks ScreenOcrService, whose
+// `Windows.Graphics.Imaging.BitmapDecoder` is resolved relative to the enclosing
+// ConditioningControlPanel namespace: the instant a ConditioningControlPanel.Windows exists, it
+// shadows the WinRT `Windows` root and the OCR service stops finding its decoder. Keep it flat.
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE MIGRATION CEREMONY (CONTRACTS-0812 §4, design doc §6). Four acts, one question, asked
+    /// once in the life of an account: intro → the two doors → a plain-language one-way confirm →
+    /// the close.
+    ///
+    /// <para><b>This window never opens on its own.</b> Its only constructor takes a
+    /// <see cref="DescentMigrationOffer"/>, and the only thing in the app that can build one is
+    /// ProfileSyncService parsing <c>descent_migration.required</c> off a sync response. No menu
+    /// item reaches it, no setting reveals it, no flag turns it on. Delete the server flag and
+    /// this file is dead code.</para>
+    ///
+    /// <para><b>No offers, ever</b> (CONTRACTS §0.6). Nothing on this surface may mention a price,
+    /// a tier, a pack or an upgrade — not on the closing act, not on a shelf, not anywhere. This
+    /// is the night the wipe does not happen.</para>
+    ///
+    /// <para><b>Escape is not handled here, on purpose.</b> Escape is the app's panic key and it
+    /// is delivered by a global low-level hook regardless of focus; swallowing it would put a
+    /// fullscreen topmost window between a user and the one key they are promised always works.
+    /// The way out of this window is the "Not tonight" button, and taking it costs nothing —
+    /// the server re-offers on the next sync.</para>
+    /// </summary>
+    public partial class DescentCeremonyWindow : Window
+    {
+        /// <summary>
+        /// Live instances, so the panic path can clear the screen. Static because panic has no
+        /// reference to hand: it is a global keystroke, not a UI interaction.
+        /// </summary>
+        private static readonly List<DescentCeremonyWindow> Live = new();
+
+        private readonly DescentMigrationOffer _offer;
+        private readonly int _restoreLevel;
+        private string? _pendingChoice;
+        private bool _committed;
+
+        public DescentCeremonyWindow(DescentMigrationOffer offer)
+        {
+            _offer = offer ?? throw new ArgumentNullException(nameof(offer));
+
+            InitializeComponent();
+
+            // Both doors are priced BEFORE the user sees either, from the same pure function the
+            // submit will use — so the number on the card is the number they get, not an estimate.
+            _restoreLevel = DescentMigration
+                .Resolve(DescentMigrationChoices.Restore, _offer).Level;
+
+            PopulateCopy();
+
+            Loaded += OnLoaded;
+            Closed += OnClosedInternal;
+
+            lock (Live) Live.Add(this);
+        }
+
+        // ------------------------------------------------------------------
+        // Copy
+        // ------------------------------------------------------------------
+
+        private void PopulateCopy()
+        {
+            var currentLevel = App.Settings?.Current?.PlayerLevel ?? 1;
+
+            IntroHeadline.Text = DescentCeremonyCopy.IntroHeadline;
+            IntroStanding.Text = DescentCeremonyCopy.IntroStanding(
+                currentLevel, _offer.TotalXpEarned, _offer.DevotionDays);
+            IntroBody.Text = DescentCeremonyCopy.IntroBody;
+            BtnIntroContinue.Content = DescentCeremonyCopy.IntroContinue;
+
+            ChoiceHeadline.Text = DescentCeremonyCopy.ChoiceHeadline;
+
+            RestoreTitle.Text = DescentCeremonyCopy.RestoreTitle;
+            RestoreKicker.Text = DescentCeremonyCopy.RestoreKicker;
+            RestoreDelta.Text = DescentCeremonyCopy.RestoreDelta(currentLevel, _restoreLevel);
+            RestoreBody.Text = DescentCeremonyCopy.RestoreBody(currentLevel, _restoreLevel);
+            BtnChooseRestore.Content = DescentCeremonyCopy.RestoreTitle;
+
+            CycleTitle.Text = DescentCeremonyCopy.CycleTitle;
+            CycleKicker.Text = DescentCeremonyCopy.CycleKicker;
+            CycleBonus.Text = DescentCeremonyCopy.CycleBonusLine();
+            CycleBody.Text = DescentCeremonyCopy.CycleBody();
+            BtnChooseCycle.Content = DescentCeremonyCopy.CycleTitle;
+
+            BothDoorsFooter.Text = DescentCeremonyCopy.BothDoorsFooter;
+
+            ConfirmHeadline.Text = DescentCeremonyCopy.ConfirmHeadline;
+            BtnConfirmBack.Content = DescentCeremonyCopy.ConfirmBack;
+
+            DoneHeadline.Text = DescentCeremonyCopy.DoneHeadline;
+            BtnDoneClose.Content = DescentCeremonyCopy.DoneClose;
+
+            BtnLater.Content = DescentCeremonyCopy.Later;
+            LaterHint.Text = DescentCeremonyCopy.LaterHint;
+        }
+
+        // ------------------------------------------------------------------
+        // Lifecycle
+        // ------------------------------------------------------------------
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                // A slow breath under the whole thing. Opacity only — no layout, no layered
+                // window, nothing the render thread can trip over.
+                var breath = new DoubleAnimation(0.22, 0.42, TimeSpan.FromSeconds(5.5))
+                {
+                    AutoReverse = true,
+                    RepeatBehavior = RepeatBehavior.Forever,
+                    EasingFunction = new SineEase { EasingMode = EasingMode.EaseInOut }
+                };
+                GlowLayer.BeginAnimation(OpacityProperty, breath);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Descent] Ceremony backdrop animation skipped: {Error}", ex.Message);
+            }
+
+            Say(DescentCeremonyCopy.CompanionIntro);
+        }
+
+        private void OnClosedInternal(object? sender, EventArgs e)
+        {
+            lock (Live) Live.Remove(this);
+
+            try { GlowLayer.BeginAnimation(OpacityProperty, null); }
+            catch (Exception ex) { Log.Debug("[Descent] Ceremony animation teardown: {Error}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Clear the ceremony off the screen for the panic path. Safe at any act: nothing here is
+        /// lost by closing, because the ceremony is only "taken" once <see cref="_committed"/> —
+        /// and once it is, the choice is already on disk and riding the sync queue.
+        /// </summary>
+        public static void ForceCloseAll()
+        {
+            List<DescentCeremonyWindow> snapshot;
+            lock (Live) snapshot = new List<DescentCeremonyWindow>(Live);
+
+            foreach (var w in snapshot)
+            {
+                try { w.Close(); }
+                catch (Exception ex) { Log.Debug("[Descent] Ceremony force-close failed: {Error}", ex.Message); }
+            }
+        }
+
+        // ------------------------------------------------------------------
+        // Acts
+        // ------------------------------------------------------------------
+
+        private void ShowAct(UIElement act)
+        {
+            ActIntro.Visibility = ReferenceEquals(act, ActIntro) ? Visibility.Visible : Visibility.Collapsed;
+            ActChoice.Visibility = ReferenceEquals(act, ActChoice) ? Visibility.Visible : Visibility.Collapsed;
+            ActConfirm.Visibility = ReferenceEquals(act, ActConfirm) ? Visibility.Visible : Visibility.Collapsed;
+            ActDone.Visibility = ReferenceEquals(act, ActDone) ? Visibility.Visible : Visibility.Collapsed;
+
+            // The way out disappears once the choice is taken — there is nothing left to defer.
+            LaterHost.Visibility = ReferenceEquals(act, ActDone) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        private void OnIntroContinue(object sender, RoutedEventArgs e) => ShowAct(ActChoice);
+
+        private void OnChooseRestore(object sender, RoutedEventArgs e) => AskToConfirm(DescentMigrationChoices.Restore);
+
+        private void OnChooseCycle(object sender, RoutedEventArgs e) => AskToConfirm(DescentMigrationChoices.Cycle);
+
+        private void AskToConfirm(string choice)
+        {
+            _pendingChoice = choice;
+            ConfirmBody.Text = DescentCeremonyCopy.ConfirmBody(choice);
+            BtnConfirmYes.Content = DescentCeremonyCopy.ConfirmYes(choice);
+            ConfirmError.Visibility = Visibility.Collapsed;
+            ShowAct(ActConfirm);
+        }
+
+        private void OnConfirmBack(object sender, RoutedEventArgs e)
+        {
+            _pendingChoice = null;
+            ShowAct(ActChoice);
+        }
+
+        private void OnConfirmYes(object sender, RoutedEventArgs e)
+        {
+            if (_committed) return;
+
+            var choice = _pendingChoice;
+            if (!DescentMigrationChoices.IsValid(choice))
+            {
+                ShowAct(ActChoice);
+                return;
+            }
+
+            // Everything irreversible happens inside ApplyChoice: the local relevel, the epoch
+            // flip, the keepsakes, and arming the submit. It returns false only for states this
+            // window should never have reached (already migrated, no settings) — in which case
+            // say so plainly rather than pretending it worked.
+            bool applied;
+            try
+            {
+                applied = App.DescentMigration?.ApplyChoice(choice!, _offer) == true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[Descent] ApplyChoice threw during the ceremony.");
+                applied = false;
+            }
+
+            if (!applied)
+            {
+                ConfirmError.Text = "That didn't take. Nothing has changed — close this and it will be offered again.";
+                ConfirmError.Visibility = Visibility.Visible;
+                return;
+            }
+
+            _committed = true;
+
+            var level = App.Settings?.Current?.PlayerLevel ?? 1;
+            DoneBody.Text = DescentCeremonyCopy.DoneBody(choice!, level);
+            ShowAct(ActDone);
+
+            Say(DescentCeremonyCopy.CompanionDone(choice!));
+        }
+
+        private void OnDoneClose(object sender, RoutedEventArgs e) => Close();
+
+        private void OnLater(object sender, RoutedEventArgs e)
+        {
+            Log.Information("[Descent] Ceremony deferred by the user — nothing written, the server will re-offer.");
+            Close();
+        }
+
+        // ------------------------------------------------------------------
+        // Companion
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        /// One scripted line, spoken by whoever the active mod's companion is.
+        /// <c>aiGenerated: false</c> keeps the AI badge off and stops the line opening a
+        /// chat-suppression window; <c>playSound: false</c> because there is no voiced clip for
+        /// these beats yet — the bark lane can add <c>descent_ceremony_open</c> /
+        /// <c>descent_ceremony_done</c> rules later and this becomes a PickVoiceLine call.
+        /// </summary>
+        private static void Say(string line)
+        {
+            try
+            {
+                App.AvatarWindow?.GigglePriority(line, playSound: false, aiGenerated: false);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("[Descent] Companion line skipped: {Error}", ex.Message);
+            }
+        }
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/DescentCurveV2Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentCurveV2Tests.cs
@@ -1,0 +1,256 @@
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Descent;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// CURVE v2 — THE RECURVE, pinned to the sim (CONTRACTS-0812 §3, planning/descent-sim4.py
+/// <c>cost_hybrid</c>).
+///
+/// These numbers are not "what the code happens to produce". They are the numbers the SERVER
+/// implements independently, and §2.5 has the server re-derive a migrating client's level and
+/// clamp the client's claim to within one level of its own answer. A one-XP drift here is a
+/// one-level disagreement at a boundary and a clamped ceremony for a real person, so the whole
+/// table is nailed down rather than spot-checked.
+///
+/// Three properties matter more than any individual figure:
+///   1. L1-40 is BYTE-IDENTICAL to v1. The honeymoon is protected on purpose; a subject who has
+///      not yet passed 40 must feel literally nothing change.
+///   2. The relevel is monotonic and idempotent — more lifetime XP never buys a lower level, and
+///      deriving twice gives the same answer. That is what makes a ceremony that crashes
+///      mid-flight safe to re-run.
+///   3. Nothing on curve v2 is reachable without an explicit epoch argument. There is no way to
+///      get a v2 number by accident.
+/// </summary>
+public class DescentCurveV2Tests
+{
+    private const int V1 = ProgressionService.CurveEpochLegacy;
+    private const int V2 = ProgressionService.CurveEpochDescent;
+
+    // ---------------------------------------------------------------- the table
+
+    /// <summary>Every segment boundary of the sim's cost_hybrid, plus a point inside each.</summary>
+    [Theory]
+    [InlineData(1, 800)]        // segment 1 (== v1)
+    [InlineData(2, 822)]
+    [InlineData(10, 994)]
+    [InlineData(25, 1316)]
+    [InlineData(40, 1639)]      // last honeymoon level
+    [InlineData(41, 1703)]      // segment 2 starts: 1639 -> 4200 over 40 levels
+    [InlineData(50, 2279)]
+    [InlineData(60, 2920)]
+    [InlineData(80, 4200)]
+    [InlineData(81, 4460)]      // segment 3: +260/level
+    [InlineData(100, 9400)]
+    [InlineData(101, 9840)]     // segment 4: +440/level
+    [InlineData(125, 20400)]
+    [InlineData(126, 21600)]    // segment 5: +1200/level
+    [InlineData(150, 50400)]
+    [InlineData(151, 52164)]    // segment 6: x1.035 compounding
+    [InlineData(175, 119108)]
+    [InlineData(200, 281480)]
+    public void XpForLevelV2_MatchesTheSim(int level, double expected)
+    {
+        Assert.Equal(expected, ProgressionService.XpForLevelV2(level));
+    }
+
+    /// <summary>
+    /// THE HONEYMOON IS PROTECTED. Levels 1-40 must cost exactly what they have always cost —
+    /// this is the single most user-visible promise the recurve makes.
+    /// </summary>
+    [Fact]
+    public void Levels1To40_AreIdenticalOnBothCurves()
+    {
+        for (int level = 1; level <= 40; level++)
+        {
+            Assert.Equal(ProgressionService.XpForLevelV1(level), ProgressionService.XpForLevelV2(level));
+        }
+    }
+
+    /// <summary>...and 41 onwards must not be, or the recurve did nothing.</summary>
+    [Fact]
+    public void Level41Onwards_IsStrictlyDearerOnV2()
+    {
+        for (int level = 41; level <= 250; level++)
+        {
+            Assert.True(ProgressionService.XpForLevelV2(level) > ProgressionService.XpForLevelV1(level),
+                $"Level {level} should cost more on curve v2");
+        }
+    }
+
+    /// <summary>A curve that ever gets cheaper as it deepens is a curve with a farming exploit in it.</summary>
+    [Fact]
+    public void BothCurves_AreMonotonicallyIncreasing()
+    {
+        for (int level = 2; level <= 300; level++)
+        {
+            Assert.True(ProgressionService.XpForLevelV2(level) >= ProgressionService.XpForLevelV2(level - 1));
+            Assert.True(ProgressionService.XpForLevelV1(level) >= ProgressionService.XpForLevelV1(level - 1));
+        }
+    }
+
+    // ------------------------------------------------------------ the dispatcher
+
+    [Fact]
+    public void GetXPForLevel_DispatchesOnEpoch()
+    {
+        Assert.Equal(ProgressionService.XpForLevelV1(100), ProgressionService.GetXPForLevel(100, V1));
+        Assert.Equal(ProgressionService.XpForLevelV2(100), ProgressionService.GetXPForLevel(100, V2));
+
+        // Anything that is not the Descent epoch is legacy. A garbage epoch must not silently
+        // recurve somebody.
+        Assert.Equal(ProgressionService.XpForLevelV1(100), ProgressionService.GetXPForLevel(100, -7));
+    }
+
+    // -------------------------------------------------------------- cumulatives
+
+    /// <summary>
+    /// Cumulative totals at the levels the ceremony's relevel actually lands on. Same source, and
+    /// the same figures the server sums to clamp with.
+    /// </summary>
+    [Theory]
+    [InlineData(10, 7976, 7976)]
+    [InlineData(25, 25140, 25140)]
+    [InlineData(40, 47147, 47147)]        // still identical
+    [InlineData(50, 64507, 66417)]        // and here the curves part
+    [InlineData(100, 193750, 296047)]
+    [InlineData(150, 515750, 1533047)]
+    [InlineData(200, 1643720, 8135340)]
+    public void CumulativeXpToReachLevel_MatchesTheSim(int level, double v1Total, double v2Total)
+    {
+        Assert.Equal(v1Total, ProgressionService.CumulativeXpToReachLevel(level, V1));
+        Assert.Equal(v2Total, ProgressionService.CumulativeXpToReachLevel(level, V2));
+    }
+
+    // ------------------------------------------------------------- the relevel
+
+    /// <summary>
+    /// THE RELEVEL, at the levels people are actually standing at. A veteran at v1 L150 comes out
+    /// of the ceremony at v2 L117 — a 33-level drop, which is exactly the number the ceremony has
+    /// to say out loud before anyone agrees to it (design doc §13: "both migration options
+    /// re-derive level explicitly, so the relevel is part of the ceremony instead of a silent
+    /// shift").
+    /// </summary>
+    [Theory]
+    [InlineData(10, 10)]
+    [InlineData(25, 25)]
+    [InlineData(40, 40)]    // honeymoon: nobody below 41 moves at all
+    [InlineData(50, 49)]
+    [InlineData(60, 57)]
+    [InlineData(75, 68)]
+    [InlineData(100, 86)]
+    [InlineData(125, 102)]
+    [InlineData(150, 117)]
+    [InlineData(175, 133)]
+    [InlineData(200, 152)]
+    public void Restore_RelevelsALegacyStandingOntoCurveV2(int legacyLevel, int expectedV2Level)
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(legacyLevel, V1);
+        var (level, _) = ProgressionService.DeriveLevelFromLifetimeXp(lifetime, V2);
+        Assert.Equal(expectedV2Level, level);
+    }
+
+    /// <summary>Derive is the exact inverse of cumulate: land ON a boundary, stand at that level with 0 into it.</summary>
+    [Fact]
+    public void DeriveLevelFromLifetimeXp_IsTheInverseOfCumulative()
+    {
+        for (int level = 1; level <= 200; level++)
+        {
+            var lifetime = ProgressionService.CumulativeXpToReachLevel(level, V2);
+            var (derived, into) = ProgressionService.DeriveLevelFromLifetimeXp(lifetime, V2);
+            Assert.Equal(level, derived);
+            Assert.Equal(0, into);
+        }
+    }
+
+    /// <summary>One XP short of a boundary is still the level below it, with the whole level banked.</summary>
+    [Fact]
+    public void DeriveLevelFromLifetimeXp_IsExactAtTheBoundaryMinusOne()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(100, V2) - 1;
+        var (level, into) = ProgressionService.DeriveLevelFromLifetimeXp(lifetime, V2);
+
+        Assert.Equal(99, level);
+        Assert.Equal(ProgressionService.XpForLevelV2(99) - 1, into);
+    }
+
+    /// <summary>More lifetime XP can never buy a lower level. Sanity that outranks any single figure.</summary>
+    [Fact]
+    public void DeriveLevelFromLifetimeXp_IsMonotonic()
+    {
+        int last = 0;
+        for (double xp = 0; xp < 3_000_000; xp += 7_919)   // prime step, so no boundary is favoured
+        {
+            var (level, _) = ProgressionService.DeriveLevelFromLifetimeXp(xp, V2);
+            Assert.True(level >= last, $"level went backwards at {xp} XP");
+            last = level;
+        }
+    }
+
+    /// <summary>Garbage in, Level 1 out — never a hang, never a negative level.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-999999)]
+    [InlineData(double.NaN)]
+    public void DeriveLevelFromLifetimeXp_FloorsAtLevelOne(double lifetime)
+    {
+        var (level, into) = ProgressionService.DeriveLevelFromLifetimeXp(lifetime, V2);
+        Assert.Equal(1, level);
+        Assert.Equal(0, into);
+    }
+
+    /// <summary>
+    /// A lifetime figure no human could earn must terminate at the cap rather than spinning. The
+    /// derive loop is the one place a corrupt server figure could hang the ceremony.
+    /// </summary>
+    [Fact]
+    public void DeriveLevelFromLifetimeXp_TerminatesAtTheCap()
+    {
+        var (level, _) = ProgressionService.DeriveLevelFromLifetimeXp(double.MaxValue, V2);
+        Assert.Equal(ProgressionService.MaxDerivableLevel, level);
+    }
+
+    // ------------------------------------------------------------ quest scaling
+
+    /// <summary>
+    /// Quest scaling moves with the curve: +4%/level before the ceremony, +1.2%/level after. The
+    /// audit that produced this number found 74% of a casual's year coming from quest claims,
+    /// with "log in, claim, quit" out-earning playing.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 1.04, 1.012)]
+    [InlineData(50, 3.0, 1.6)]
+    [InlineData(100, 5.0, 2.2)]
+    [InlineData(150, 7.0, 2.8)]
+    public void QuestLevelScale_MovesWithTheCurve(int level, double v1Scale, double v2Scale)
+    {
+        Assert.Equal(v1Scale, ProgressionService.QuestLevelScale(level, V1), 6);
+        Assert.Equal(v2Scale, ProgressionService.QuestLevelScale(level, V2), 6);
+    }
+
+    /// <summary>The §3 prose figure: a 600-XP quest at L100 pays 1,320 post-migration.</summary>
+    [Fact]
+    public void QuestBase600_PaysTheDesignDocFigure()
+    {
+        Assert.Equal(1320, 600 * ProgressionService.QuestLevelScale(100, V2), 6);
+    }
+
+    // ------------------------------------------------------ the epoch constants
+
+    /// <summary>
+    /// The build's wire epoch and the account's curve epoch are the same integer and NOT the same
+    /// idea. This pins them apart: if someone ever "simplifies" one into the other, every user of
+    /// the new build gets recurved on install instead of at their ceremony.
+    /// </summary>
+    [Fact]
+    public void EpochConstants_AreDistinctConcepts()
+    {
+        Assert.Equal(1, DescentEpochs.ClientEpoch);          // sent on every sync, always
+        Assert.Equal(0, DescentEpochs.AccountLegacy);        // where every account starts
+        Assert.Equal(1, DescentEpochs.AccountDescent);       // where the ceremony leaves it
+        Assert.Equal(DescentEpochs.AccountLegacy, ProgressionService.CurveEpochLegacy);
+        Assert.Equal(DescentEpochs.AccountDescent, ProgressionService.CurveEpochDescent);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/DescentMigrationChoiceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentMigrationChoiceTests.cs
@@ -1,0 +1,257 @@
+using ConditioningControlPanel.Services;
+using ConditioningControlPanel.Services.Descent;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE TWO DOORS, as arithmetic (CONTRACTS-0812 §2.5, design doc §6).
+///
+/// <see cref="DescentMigration.Resolve"/> is deliberately pure — no App, no settings, no clock —
+/// because the crash-before-ack ordering the handshake depends on is only safe if re-running a
+/// choice against an unchanged offer produces an unchanged answer. These tests are that claim,
+/// written down.
+/// </summary>
+public class DescentMigrationChoiceTests
+{
+    private static DescentMigrationOffer Offer(double lifetimeXp, int devotionDays = 120) =>
+        new() { TotalXpEarned = lifetimeXp, DevotionDays = devotionDays };
+
+    // ------------------------------------------------------ "Take it all back"
+
+    /// <summary>
+    /// A v1 Level 150 veteran, re-measured. The drop is real and large, which is precisely why it
+    /// happens inside a ceremony that states it rather than in a silent patch.
+    /// </summary>
+    [Fact]
+    public void Restore_RederivesLevelFromTheServersLifetimeFigure()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(150, ProgressionService.CurveEpochLegacy);
+
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, Offer(lifetime));
+
+        Assert.Equal(117, result.Level);
+        Assert.Equal(lifetime, result.LifetimeXp);
+        Assert.Equal(lifetime, result.LedgerXp);   // lifetime is what rides the wire's xp field
+    }
+
+    /// <summary>
+    /// The relevel is exact, not approximate: level plus progress-into-level must add back up to
+    /// the lifetime figure the server handed us. If it did not, the ledger we submit would
+    /// disagree with the ledger the server derives and the clamp would bite.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(799)]
+    [InlineData(47_147)]
+    [InlineData(193_750)]
+    [InlineData(515_750)]
+    [InlineData(8_135_340)]
+    public void Restore_LevelPlusProgressReconstructsLifetimeXp(double lifetime)
+    {
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, Offer(lifetime));
+
+        var floor = ProgressionService.CumulativeXpToReachLevel(result.Level, ProgressionService.CurveEpochDescent);
+        Assert.Equal(lifetime, floor + result.XpIntoLevel);
+    }
+
+    /// <summary>Nobody in the honeymoon moves. A Level 30 subject walks out a Level 30 subject.</summary>
+    [Fact]
+    public void Restore_LeavesTheHoneymoonUntouched()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(30, ProgressionService.CurveEpochLegacy);
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, Offer(lifetime));
+
+        Assert.Equal(30, result.Level);
+    }
+
+    // --------------------------------------------------------- "Descend again"
+
+    /// <summary>
+    /// Cycle is Level 1 / 0 XP — and lifetime XP survives it intact. §2.5 exempts
+    /// total_xp_earned from the one sanctioned downward write, and §6 says a Cycle "wipes nothing
+    /// else". A Cycle that ate lifetime XP would also quietly eat the user's Chapter standing.
+    /// </summary>
+    [Fact]
+    public void Cycle_IsLevelOneAndKeepsLifetimeXp()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(150, ProgressionService.CurveEpochLegacy);
+
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Cycle, Offer(lifetime));
+
+        Assert.Equal(1, result.Level);
+        Assert.Equal(0, result.XpIntoLevel);
+        Assert.Equal(lifetime, result.LifetimeXp);
+    }
+
+    // ------------------------------------------------------------- idempotence
+
+    /// <summary>
+    /// THE ORDERING GUARANTEE. Crash after applying a choice but before the server acks, and the
+    /// ceremony re-offers against the same untouched lifetime figure. Re-running must land in the
+    /// same place, or the "nothing is lost in any ordering" claim in the handshake is false.
+    /// </summary>
+    [Theory]
+    [InlineData(DescentMigrationChoices.Restore)]
+    [InlineData(DescentMigrationChoices.Cycle)]
+    public void Resolve_IsIdempotent(string choice)
+    {
+        var offer = Offer(515_750);
+
+        var first = DescentMigration.Resolve(choice, offer);
+        var second = DescentMigration.Resolve(choice, offer);
+
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>
+    /// And switching horses mid-crash is safe too: a user who applied Cycle, crashed, and picks
+    /// Restore on the re-offer still gets the level their untouched lifetime XP buys. The anchor
+    /// is the server's lifetime figure, which no client action moves.
+    /// </summary>
+    [Fact]
+    public void Resolve_ARestoreAfterAnUnackedCycleStillRestoresFully()
+    {
+        var offer = Offer(ProgressionService.CumulativeXpToReachLevel(150, ProgressionService.CurveEpochLegacy));
+
+        DescentMigration.Resolve(DescentMigrationChoices.Cycle, offer);
+        var restore = DescentMigration.Resolve(DescentMigrationChoices.Restore, offer);
+
+        Assert.Equal(117, restore.Level);
+    }
+
+    // ------------------------------------------------------------ hostile input
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    public void Resolve_TreatsImpossibleLifetimeFiguresAsZero(double lifetime)
+    {
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, Offer(lifetime));
+
+        Assert.Equal(1, result.Level);
+        Assert.Equal(0, result.LifetimeXp);
+    }
+
+    /// <summary>
+    /// Anything that is not one of the two exact wire strings must resolve as a restore, never as
+    /// a cycle. Restore is the conservative branch — it keeps the standing — so an unknown choice
+    /// falling through it cannot cost anybody a level. (The submit path rejects invalid choices
+    /// outright; this is the second line.)
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("CYCLE")]
+    [InlineData("Cycle")]
+    [InlineData("reset")]
+    public void Resolve_UnknownChoicesFallToTheConservativeBranch(string choice)
+    {
+        Assert.False(DescentMigrationChoices.IsValid(choice));
+
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(100, ProgressionService.CurveEpochLegacy);
+        var result = DescentMigration.Resolve(choice, Offer(lifetime));
+
+        Assert.Equal(86, result.Level);   // the restore answer, not level 1
+    }
+
+    [Fact]
+    public void Choices_AreExactLowercaseWireStrings()
+    {
+        Assert.Equal("restore", DescentMigrationChoices.Restore);
+        Assert.Equal("cycle", DescentMigrationChoices.Cycle);
+        Assert.True(DescentMigrationChoices.IsValid("restore"));
+        Assert.True(DescentMigrationChoices.IsValid("cycle"));
+        Assert.False(DescentMigrationChoices.IsValid(null));
+    }
+
+    // ------------------------------------------------------------- the tunable
+
+    /// <summary>
+    /// The Cycle XP bonus is UNBLESSED (CONTRACTS §3: the owner has signed off on "there is a
+    /// lasting bonus", not on 1.10). This test does not defend the number — it defends the shape:
+    /// a bonus, above 1.0, sane, and reflected verbatim in the ceremony copy so tuning the
+    /// constant tunes what the user is promised.
+    /// </summary>
+    [Fact]
+    public void CycleXpBonus_IsABonusAndTheCopyQuotesIt()
+    {
+        Assert.True(DescentMigration.CycleXpBonus > 1.0);
+        Assert.True(DescentMigration.CycleXpBonus <= 1.5);
+
+        var expectedPct = $"{(DescentMigration.CycleXpBonus - 1.0) * 100:0.#}%";
+        Assert.Contains(expectedPct, DescentCeremonyCopy.CycleBonusLine());
+    }
+
+    // ------------------------------------------------------- the ceremony's mouth
+
+    /// <summary>
+    /// CONTRACTS §0.6: no offers, no popups, no upsell anywhere near this flow. Cheap to assert,
+    /// and the failure mode it guards against — someone dropping a "go Tier 2 to keep your level"
+    /// line onto the most emotionally loaded screen in the app — is expensive.
+    /// </summary>
+    [Theory]
+    [InlineData("patreon")]
+    [InlineData("subscribe")]
+    [InlineData("upgrade")]
+    [InlineData("tier")]
+    [InlineData("$")]
+    [InlineData("purchase")]
+    [InlineData("premium")]
+    [InlineData("discount")]
+    [InlineData("limited time")]
+    public void CeremonyCopy_ContainsNoOffer(string forbidden)
+    {
+        var everything = string.Join("\n",
+            DescentCeremonyCopy.IntroHeadline,
+            DescentCeremonyCopy.IntroBody,
+            DescentCeremonyCopy.IntroContinue,
+            DescentCeremonyCopy.IntroStanding(150, 515750, 300),
+            DescentCeremonyCopy.ChoiceHeadline,
+            DescentCeremonyCopy.RestoreTitle,
+            DescentCeremonyCopy.RestoreKicker,
+            DescentCeremonyCopy.RestoreBody(150, 117),
+            DescentCeremonyCopy.RestoreDelta(150, 117),
+            DescentCeremonyCopy.CycleTitle,
+            DescentCeremonyCopy.CycleKicker,
+            DescentCeremonyCopy.CycleBody(),
+            DescentCeremonyCopy.CycleBonusLine(),
+            DescentCeremonyCopy.BothDoorsFooter,
+            DescentCeremonyCopy.ConfirmHeadline,
+            DescentCeremonyCopy.ConfirmBody(DescentMigrationChoices.Restore),
+            DescentCeremonyCopy.ConfirmBody(DescentMigrationChoices.Cycle),
+            DescentCeremonyCopy.ConfirmYes(DescentMigrationChoices.Restore),
+            DescentCeremonyCopy.ConfirmYes(DescentMigrationChoices.Cycle),
+            DescentCeremonyCopy.ConfirmBack,
+            DescentCeremonyCopy.DoneHeadline,
+            DescentCeremonyCopy.DoneBody(DescentMigrationChoices.Restore, 117),
+            DescentCeremonyCopy.DoneBody(DescentMigrationChoices.Cycle, 1),
+            DescentCeremonyCopy.DoneClose,
+            DescentCeremonyCopy.Later,
+            DescentCeremonyCopy.LaterHint,
+            DescentCeremonyCopy.CompanionIntro,
+            DescentCeremonyCopy.CompanionDone(DescentMigrationChoices.Restore),
+            DescentCeremonyCopy.CompanionDone(DescentMigrationChoices.Cycle));
+
+        Assert.DoesNotContain(forbidden, everything, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The confirm step must say the one-way part in words, not imply it (§4).</summary>
+    [Theory]
+    [InlineData(DescentMigrationChoices.Restore)]
+    [InlineData(DescentMigrationChoices.Cycle)]
+    public void ConfirmCopy_StatesThatThereIsNoUndo(string choice)
+    {
+        Assert.Contains("no undo", DescentCeremonyCopy.ConfirmBody(choice), System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "I")]
+    [InlineData(7, "VII")]
+    [InlineData(9, "IX")]
+    [InlineData(42, "42")]
+    public void RomanNumeral_CoversTheLadderAndFallsBackPastIt(int n, string expected)
+    {
+        Assert.Equal(expected, DescentCeremonyCopy.RomanNumeral(n));
+    }
+}


### PR DESCRIPTION
The desktop CEREMONY lane of the ONE DESCENT 0812 finish wave. Spec: `planning/one-descent/CONTRACTS-0812-FINISH.md` §1 (epoch), §2 (handshake), §3 (curve v2), §4 (ceremony UX). Soul: `DESIGN-SNAPSHOT-v2.1.html` §6. Curve numbers: `planning/descent-sim4.py` (`cost_hybrid`).

**Do not merge on my say-so.** No version numbers were touched — a release train runs later today.

## How the dormancy is guaranteed

There is no client flag to find, and no local condition that reaches any of this.

| Surface | Behaviour today |
|---|---|
| `DescentMigrationService.OfferReceived` | Called from exactly one place: `ProfileSyncService`, when a sync response carries `descent_migration.required`. The server sends that only with `DESCENT_MIGRATION` armed. |
| `DescentCeremonyWindow` | Its only constructor takes a `DescentMigrationOffer`, and only the parse above can build one. No menu item, no setting, no debug hook reaches it. Delete the server flag and the file is dead code. |
| Curve v2 | Gated on `AppSettings.DescentEpoch == 1`, which nothing but the ceremony's submit can write. `ActiveCurveEpoch` returns 0 for every account in existence. |
| Quest scaling | Same gate. Pre-migration the expression is `def.XPReward * (1 + level * 0.04)` exactly as before. |
| Cycle XP bonus | `DescentCycleXpBonus` defaults to 1.0 and is clamped to the blessed constant on read. Arithmetically invisible. |
| Stage drip | `TickStageDrip` returns immediately unless `DescentMigrationCompleted` is set, which only the server's ack sets. |

**One deliberate wire change**, mandated by §1 and exempted there from the byte-identical rule: `descent_epoch: 1` now rides every `/v2/user/sync` body. It identifies the *build*, not the account, so it does not wait for a flag. The choice submit (`descent_migration: { choice }`) is grafted onto the serialized body only when a choice is pending — so on the 100% of syncs that carry none, the bytes are unchanged rather than gaining a `"descent_migration": null`.

## Curve v2 spot values

L1–40 is **byte-identical** to v1 (the honeymoon is protected on purpose).

| Level | v1 | v2 | | Reach level | v1 cumulative | v2 cumulative |
|---|---|---|---|---|---|---|
| 40 | 1,639 | 1,639 | | 40 | 47,147 | 47,147 |
| 41 | 1,661 | 1,703 | | 50 | 64,507 | 66,417 |
| 80 | 2,500 | 4,200 | | 100 | 193,750 | 296,047 |
| 100 | 4,000 | 9,400 | | 150 | 515,750 | 1,533,047 |
| 125 | 6,000 | 20,400 | | 200 | 1,643,720 | 8,135,340 |
| 150 | 10,000 | 50,400 | | | | |
| 200 | 43,839 | 281,480 | | | | |

**What the relevel does to real people** (v1 standing → v2 standing at the same lifetime XP): L40→40, L50→49, L75→68, L100→86, L125→102, **L150→117**, L200→152. The ceremony states this number out loud before anyone agrees to it — which is the entire reason §0.3 lets the recurve ship here and nowhere else.

Rounding is `MidpointRounding.AwayFromZero`, not the framework default. Every cost is positive, so that is exactly JavaScript's `Math.round`. **Server lane: please match.** Banker's rounding would disagree on any cost landing on a half, and a one-XP disagreement is a one-level disagreement at a boundary.

## Two live hazards found and closed

1. **The XP guards would have refused the ceremony's own submit.** A Cycle pushes Level 1 / 0 XP — the defaults-guard's exact signature — and both choices push a total below the watermark this client and the server last agreed on. §2.5's "one sanctioned downward write" now suspends both, for that sync only, keyed on a pending choice that nothing else in the app can set. The watermark is also cleared at submit via the same helper the admin `level_reset` uses.
2. **The anti-cheat adopt would have undone the ceremony.** On a Cycle submit the server's *pre-migration* record is hundreds of thousands of XP above the ledger we just wrote; if the server did not process the submit, the "server is 5k ahead, adopt" branch would cheerfully resurrect the pre-ceremony level while the pending choice sat on disk waiting to re-submit. While a submit is in flight, only a response carrying the ack may move the ledger. `RecordAgreedServerXp` is suppressed in the same window — there is no agreement to record.

## Ordering (the load-bearing part)

Local relevel + epoch flip + keepsakes → arm the pending choice → sync → **persist "migrated" only on `completed: true`**. Crash anywhere in that and the server is still unmigrated, so it re-offers; the pending choice is still on disk, so the next sync re-submits; and a repeat submit is a server-side no-op. Safe in every ordering because both choices are pure functions of a lifetime XP total that never moves — including the nasty case where a user applies Cycle, crashes, and picks Restore on the re-offer. There is a test for that.

## Deviations / flags for the coordinator

- **"Not tonight" is an addition to the §4 flow.** A fullscreen topmost window with no exit is a hostage situation. It closes and writes nothing; the server re-offers. Escape is deliberately *not* handled — it is the app's panic key, delivered by a global hook, and swallowing it would put this window between a user and the one key they are promised always works. `ForceCloseAll` is registered on the panic path beside `LockCardWindow`/`QuizWindow`.
- **Ceremony copy is hardcoded English**, collected in one file (`DescentCeremonyCopy`) so the loc pass is one file rather than an archaeology dig. The repo runs both conventions for one-shot surfaces. This is a debt, not a decision — flagging it for an owner call.
- **The Cycle XP bonus (1.10) is unblessed**, per §3. One constant, `DescentMigration.CycleXpBonus`; the ceremony copy quotes it back, so tuning the constant tunes the promise. There is a test that the copy and the constant agree.
- **The stage-ceremony drip has state and an event but no visual surface** — the desktop stage-ceremony UI belongs to the stage-ladder lane. `StageCeremonyDue` is the contract that lane consumes; until it lands a drip spends itself on a companion line and a log entry. The queue is built from the *server's* ladder when one is in hand and is empty otherwise (no client-side fabrication, per the DescentModels tri-state law).
- **Companion lines are scripted, unvoiced.** `GigglePriority(..., aiGenerated: false)`. Rule ids reserved for the bark lane: `descent_ceremony_open`, `descent_ceremony_done`.
- **Namespace trap, worth knowing repo-wide:** no window under `Windows/` declares `ConditioningControlPanel.Windows`, and that is load-bearing — the moment that namespace exists it shadows the WinRT `Windows` root and `ScreenOcrService`'s `Windows.Graphics.Imaging.BitmapDecoder` stops resolving. Found it the hard way; there is now a comment on it.

## Gates

- `dotnet build --no-incremental`: **421 warnings, 0 errors** — identical to the origin/main baseline. Zero new warnings.
- `dotnet test`: **2750/2750 passed, 0 failed** (baseline 2660; +90 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTZUrGYbe6QspHLTynxzXU
