### PR TITLE
feat(ui): tier livery - persistent gold (T1) / diamond (T2) borders

### DIFF
--- a/ConditioningControlPanel/Resources/Theme/Brushes.xaml
+++ b/ConditioningControlPanel/Resources/Theme/Brushes.xaml
@@ -129,4 +129,40 @@
          XAML anchors read {DynamicResource AccentGradientBrush}; everything else stays on PinkBrush. -->
     <SolidColorBrush x:Key="AccentGradientBrush" Color="{DynamicResource PinkColor}"/>
 
+    <!-- ==================================================================
+         TIER LIVERY - the persistent "this is paid content" trim, worn by a
+         tiered feature's chrome (Studio rack row, Play cards, rail chips)
+         whether or not the account has the tier. Distinct from the lockband
+         vocabulary (RailLock*/PlayLock*, local to their views), which is the
+         PRICE TAG a locked account sees on top of this; the livery never
+         hides, so a patron still sees which features are the premium ones.
+
+         Deliberately CONSTANT across mods, like the lockbands: a tier mark is
+         commerce, not decor, so it does not take colour from the mod chain.
+         Literal gradient stops on purpose - a Theme dictionary referencing a
+         fresh cross-dictionary StaticResource is the BAML EndOfStream trap
+         (see Velvet-Kit round 2). Base tones match the established tier
+         colours: gold #F0C24B = Tier 1, and Tier 2 wears DIAMOND (ice-white
+         cyan) - the violet flask stays on the lockband glyphs only. -->
+    <LinearGradientBrush x:Key="Tier1GoldBorderBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#F2D98C" Offset="0"/>
+        <GradientStop Color="#C9963B" Offset="0.5"/>
+        <GradientStop Color="#8C6218" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier1GoldHoverBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FFE9A9" Offset="0"/>
+        <GradientStop Color="#F0C24B" Offset="0.5"/>
+        <GradientStop Color="#C9963B" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier2DiamondBorderBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#EAFBFF" Offset="0"/>
+        <GradientStop Color="#8FD4EF" Offset="0.5"/>
+        <GradientStop Color="#4C93C4" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="Tier2DiamondHoverBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FFFFFF" Offset="0"/>
+        <GradientStop Color="#BFEFFF" Offset="0.5"/>
+        <GradientStop Color="#7FC4E8" Offset="1"/>
+    </LinearGradientBrush>
+
 </ResourceDictionary>

--- a/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/PlayTabView.xaml
@@ -91,6 +91,28 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
+            <!-- Tier livery variants: a tiered card wears its tier's metal PERMANENTLY -
+                 gold = Tier 1, diamond = Tier 2 (Resources\Theme\Brushes.xaml) - so the
+                 wall reads free/T1/T2 at a glance even for an account that owns everything
+                 (the lockbands below only exist while locked). Own hover triggers, because
+                 a derived style's trigger outranks the base one: hover brightens the metal
+                 instead of falling back to the mod accent. -->
+            <Style x:Key="PlayCardT1" TargetType="Border" BasedOn="{StaticResource PlayCard}">
+                <Setter Property="BorderBrush" Value="{DynamicResource Tier1GoldBorderBrush}"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="BorderBrush" Value="{DynamicResource Tier1GoldHoverBrush}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style x:Key="PlayCardT2" TargetType="Border" BasedOn="{StaticResource PlayCard}">
+                <Setter Property="BorderBrush" Value="{DynamicResource Tier2DiamondBorderBrush}"/>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="BorderBrush" Value="{DynamicResource Tier2DiamondHoverBrush}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
             <!-- The art plate every card header sits in. ONE height (138) for the whole wall now
                  that the wall is uniform - the old page ran 132 in three zones and 138 in one,
                  which read as a mistake in a row that mixed them. The negative margin cancels
@@ -272,7 +294,9 @@
                      It is the one hard-coded palette on this page, and it is still the floor the
                      artwork lays on: if features/dtrh.png ever fails to decode, the hero degrades
                      to exactly the gradient it shipped with rather than to a black hole. -->
-                <Border CornerRadius="16" BorderThickness="1" BorderBrush="{DynamicResource PanelAccentBrush}"
+                <!-- Diamond frame = Tier 2 livery (Brushes.xaml), same trim as the two Eyes
+                     cards, so the wall's most expensive door wears its price openly. -->
+                <Border CornerRadius="16" BorderThickness="1" BorderBrush="{DynamicResource Tier2DiamondBorderBrush}"
                         Margin="9,0,9,18" ClipToBounds="True" MinHeight="200">
                     <Border.Background>
                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
@@ -555,7 +579,7 @@
                         </Border>
                     </Grid>
                     <Grid x:Name="SlotRemoteControl" x:FieldModifier="internal">
-                        <Border Style="{StaticResource PlayCard}">
+                        <Border Style="{StaticResource PlayCardT1}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -670,7 +694,7 @@
                              (Opacity 1.0 / 0.62 + the "start tracking" band) off the tracker-state
                              event. Tracker dimming and the tier band are two independent states and
                              they stack: an unentitled account with the camera off sees both. -->
-                        <Border x:Name="PlayGazeCard" x:FieldModifier="internal" Style="{StaticResource PlayCard}">
+                        <Border x:Name="PlayGazeCard" x:FieldModifier="internal" Style="{StaticResource PlayCardT2}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -743,7 +767,7 @@
                     <!-- Focus Gaze is a separate card from the Gaze Minigame (separate handler,
                          separate art, separate needs-tracker band). It is NOT part of SlotGaze. -->
                     <Grid x:Name="SlotFocusGaze" x:FieldModifier="internal">
-                        <Border x:Name="PlayFocusCard" x:FieldModifier="internal" Style="{StaticResource PlayCard}">
+                        <Border x:Name="PlayFocusCard" x:FieldModifier="internal" Style="{StaticResource PlayCardT2}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -823,7 +847,7 @@
                          its own camera. Adding it to that method would be a behaviour change in
                          MainWindow.LabTab.cs, which this relayout does not touch. -->
                     <Grid x:Name="SlotBlinkTrainer" x:FieldModifier="internal">
-                        <Border Style="{StaticResource PlayCard}">
+                        <Border Style="{StaticResource PlayCardT1}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -990,7 +1014,7 @@
                          ShowTab intercepts into OpenFypFeed (the shared, gated launch path).
                          Never call FypHostService.Launch() from here. -->
                     <Grid x:Name="SlotFyp" x:FieldModifier="internal">
-                        <Border Style="{StaticResource PlayCard}">
+                        <Border Style="{StaticResource PlayCardT1}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -1046,7 +1070,7 @@
                          App.Lockdown.Activate stay on that page; nothing here re-implements them.
                          The lockdown pulse is that page's, and Phase 6 does not touch it. -->
                     <Grid x:Name="SlotLockdown" x:FieldModifier="internal">
-                        <Border Style="{StaticResource PlayCard}">
+                        <Border Style="{StaticResource PlayCardT1}">
                             <Grid>
                                 <Grid>
                                     <Grid.RowDefinitions>

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -279,11 +279,18 @@
                     <Setter Property="Margin" Value="0,0,0,4"/>
                     <Setter Property="Height" Value="42"/>
                     <Setter Property="Background" Value="{DynamicResource AccentTintedBgBrush}"/>
+                    <!-- Routed through the Button's own BorderBrush (was a literal
+                         GlassBorderBrush on cb) so a chip can override it: the Tier 1
+                         chips wear the gold tier livery (Brushes.xaml) permanently,
+                         while ChipGradedIntake - a weekly pass, not a tier - keeps this
+                         glass default. Hover still wins: the triggers below set cb
+                         directly, and a template trigger outranks a TemplateBinding. -->
+                    <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="Button">
                                 <Border x:Name="cb" Background="{TemplateBinding Background}"
-                                        BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1"
+                                        BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
                                         CornerRadius="9" RenderOptions.BitmapScalingMode="HighQuality">
                                     <!-- CornerRadius 8 = the chip's 9 minus the 1px border, so the
                                          overlays follow the inner curve instead of squaring it off. -->
@@ -428,6 +435,7 @@
                     <TextBlock Text="PREMIUM" FontSize="9" FontWeight="Bold" Foreground="{DynamicResource SecondaryBrush}"
                                TextAlignment="Center" Margin="0,0,0,6"/>
                     <Button x:Name="ChipTakeover" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtTakeover}"
                             Click="ChipTakeover_Click" ToolTip="Takeover — the companion triggers effects on her own · left-click opens it, right-click turns it on">
                         <Grid>
@@ -443,6 +451,7 @@
                         </Grid>
                     </Button>
                     <Button x:Name="ChipAwareness" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtAwareness}"
                             Click="ChipAwareness_Click" ToolTip="Awareness — reacts to what's on your screen · left-click opens it, right-click turns it on">
                         <Grid>
@@ -457,6 +466,7 @@
                         </Grid>
                     </Button>
                     <Button x:Name="ChipHaptics" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtHaptics}"
                             Click="ChipHaptics_Click" ToolTip="Haptics — connect a toy · left-click opens it, right-click turns it on">
                         <Grid>
@@ -492,6 +502,7 @@
                         </Grid>
                     </Button>
                     <Button x:Name="ChipVoice" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtVoice}"
                             Click="ChipVoice_Click" ToolTip="She's Listening — voice control (&quot;Hey Bambi&quot;) and the mic · left-click opens it, right-click turns it on">
                         <Grid>
@@ -515,6 +526,7 @@
                          premium gate — the chip itself never blocks, exactly like its siblings.
                          No state dot for the same reason Intake has none. -->
                     <Button x:Name="ChipFyp" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtFyp}"
                             Click="ChipFyp_Click" ToolTip="For You — an endless feed cut from your own library · left- or right-click opens it">
                         <Grid>
@@ -537,7 +549,7 @@
                          cost this card in height. -->
                     <Border x:Name="CardLockdown" x:FieldModifier="internal"
                             Margin="0,0,0,4" Background="{StaticResource ArtLockdown}"
-                            BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" CornerRadius="9"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}" BorderThickness="1" CornerRadius="9"
                             RenderOptions.BitmapScalingMode="HighQuality"
                             ToolTip="Lockdown — locks you in for the set time (panic key disabled)">
                         <Grid>
@@ -578,7 +590,7 @@
                          full-bleed treatment as Lockdown. -->
                     <Border x:Name="CardBlink" x:FieldModifier="internal"
                             Margin="0,0,0,4" Background="{StaticResource ArtBlink}"
-                            BorderBrush="{DynamicResource GlassBorderBrush}" BorderThickness="1" CornerRadius="9"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}" BorderThickness="1" CornerRadius="9"
                             RenderOptions.BitmapScalingMode="HighQuality"
                             ToolTip="Blink Trainer — webcam blink-gated visuals">
                         <Grid>
@@ -615,6 +627,7 @@
                     </Border>
                     <!-- Remote — opens a flyout to compose + start a remote session -->
                     <Button x:Name="ChipRemote" x:FieldModifier="internal" Style="{StaticResource PremiumChipStyle}"
+                            BorderBrush="{DynamicResource Tier1GoldBorderBrush}"
                             Background="{StaticResource ArtRemote}"
                             Click="ChipRemote_Click" ToolTip="Remote Control — let someone drive your session">
                         <Grid>

--- a/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml
@@ -71,12 +71,23 @@
             <Setter Property="Focusable" Value="True"/>
             <Setter Property="Margin" Value="0,1"/>
             <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <!-- Null, not the RadioButton default: TierRim below paints whatever sits in
+                 BorderBrush, and only BuildRack's tiered rows put a brush there (gold =
+                 Tier 1, diamond = Tier 2 — the tier livery, Resources\Theme\Brushes.xaml).
+                 Free rows stay rimless. -->
+            <Setter Property="BorderBrush" Value="{x:Null}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="RadioButton">
                         <Grid Background="Transparent" Height="30">
                             <Border x:Name="RowFill" CornerRadius="8" Opacity="0"
                                     Background="{DynamicResource TransparentPink20Brush}"/>
+                            <!-- The tier rim. A stroke, never a fill, and hit-test invisible so
+                                 it is pure livery: selection (RowFill/RowBar) and hover keep
+                                 their existing grammar underneath it. -->
+                            <Border x:Name="TierRim" CornerRadius="8" BorderThickness="1"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    IsHitTestVisible="False"/>
                             <Border x:Name="RowBar" Width="3" CornerRadius="2" Margin="0,5"
                                     HorizontalAlignment="Left" Visibility="Collapsed"
                                     Background="{DynamicResource PinkBrush}"/>

--- a/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/StudioTabView.xaml.cs
@@ -105,6 +105,17 @@ namespace ConditioningControlPanel.Views.Tabs
             /// header must hide rather than double up (Haptics).</summary>
             public bool OwnHeader;
 
+            /// <summary>
+            /// The tier this module is SOLD at: 0 = free, 1 = premium, 2 = Lab. Presentation
+            /// only — the row wears the tier livery (gold/diamond, Resources\Theme\Brushes.xaml)
+            /// permanently, whoever is looking; the refusal still belongs to the panel's own
+            /// premium gate and <see cref="Services.TierGate"/>. Hand-maintained, like
+            /// <see cref="BarkFeature"/>: there is no per-module verdict to derive it from
+            /// without asking PatreonService a question ("is this ALLOWED?") that answers a
+            /// different question than "what does it COST?".
+            /// </summary>
+            public int Tier;
+
             // Built by BuildRack.
             public RadioButton? Row;
             public TextBlock? Label;
@@ -260,7 +271,10 @@ namespace ConditioningControlPanel.Views.Tabs
                 // its enable lives on the nested Haptics settings object. Flip the page's own
                 // master box so MainWindow.ChkHapticsEnabled_Changed runs - including the
                 // premium gate that reverts the box for a free account.
-                toggle: () => FlipMasterCheckBox(PanelHaptics?.ChkHapticsEnabled));
+                toggle: () => FlipMasterCheckBox(PanelHaptics?.ChkHapticsEnabled),
+                // The rack's one paid module (the premium gate above is the enforcement this
+                // livery advertises). Same bar as the rail chip's RailLockBand: Tier 1.
+                tier: 1);
 
             _layout.Add("st4_studio_group_timing");
             // Both fire the popup's single "SchedulerRamp" key so the existing rules keep firing.
@@ -280,7 +294,7 @@ namespace ConditioningControlPanel.Views.Tabs
 
             void Add(string key, string glyph, string english, string locKey, UIElement? host,
                      UserControl? panel, string? bark, Func<bool?>? dot, bool ownHeader = false,
-                     Action? toggle = null)
+                     Action? toggle = null, int tier = 0)
             {
                 var entry = new StudioRackEntry
                 {
@@ -293,6 +307,7 @@ namespace ConditioningControlPanel.Views.Tabs
                     BarkFeature = bark,
                     Dot = dot,
                     OwnHeader = ownHeader,
+                    Tier = tier,
                     // Default: route the rack key straight into the dashboard's own quick-toggle.
                     // Derived rather than hand-listed per row so adding a wall tile for a module
                     // (or a module for a wall tile) cannot leave the rack behind.
@@ -385,6 +400,16 @@ namespace ConditioningControlPanel.Views.Tabs
                         VerticalAlignment = VerticalAlignment.Center,
                     },
                 };
+                // Tier livery on the chip: the metal on the chip's own frame plus a tinted
+                // well behind the glyph, so the mark survives even where the row rim is
+                // faint. Presentation only — see StudioRackEntry.Tier.
+                if (e.Tier > 0)
+                {
+                    iconChip.BorderBrush = TierLiveryBrush(e.Tier);
+                    iconChip.Background = new SolidColorBrush(e.Tier >= 2
+                        ? Color.FromRgb(0x1E, 0x33, 0x40)    // deep ice under diamond
+                        : Color.FromRgb(0x3D, 0x33, 0x1E));  // dark amber under gold
+                }
                 Grid.SetColumn(iconChip, 0);
                 grid.Children.Add(iconChip);
 
@@ -415,6 +440,9 @@ namespace ConditioningControlPanel.Views.Tabs
                     Tag = e.Key,
                     Content = grid,
                 };
+                // BorderBrush is the template's TierRim (RackEntryStyle nulls it for free
+                // rows), so a tiered row wears a permanent gold/diamond outline.
+                if (e.Tier > 0) e.Row.BorderBrush = TierLiveryBrush(e.Tier);
                 e.Row.Click += RackEntry_Click;
                 // Right-click = quick-toggle, the same second gesture the dashboard tiles carry.
                 // On the ROW, not on the dot: the dot is 7px, and the gesture belongs to the
@@ -601,9 +629,32 @@ namespace ConditioningControlPanel.Views.Tabs
             if (target == null) return;
 
             if (DetailHeader != null)
+            {
                 DetailHeader.Visibility = target.OwnHeader ? Visibility.Collapsed : Visibility.Visible;
+                // The header echoes the row's tier livery, so the detail pane says "this is
+                // the paid one" in the same metal the rack does. #2A2A46 = the header's own
+                // XAML literal, restored verbatim for free modules.
+                DetailHeader.BorderBrush = target.Tier > 0
+                    ? TierLiveryBrush(target.Tier)
+                    : new SolidColorBrush(Color.FromRgb(0x2A, 0x2A, 0x46));
+            }
             if (TxtDetailIcon != null) TxtDetailIcon.Text = target.Glyph;
             if (TxtDetailTitle != null) TxtDetailTitle.Text = LabelFor(target);
+        }
+
+        /// <summary>
+        /// The tier livery for a paid module's chrome: gold = Tier 1, diamond = Tier 2, from
+        /// the shared theme (Resources\Theme\Brushes.xaml) with a flat literal fallback in the
+        /// established tier tones, because a missing brush must degrade to a duller rim, never
+        /// to a throw inside row construction.
+        /// </summary>
+        private Brush TierLiveryBrush(int tier)
+        {
+            var key = tier >= 2 ? "Tier2DiamondBorderBrush" : "Tier1GoldBorderBrush";
+            return (Brush?)TryFindResource(key)
+                   ?? new SolidColorBrush(tier >= 2
+                       ? Color.FromRgb(0x8F, 0xD4, 0xEF)
+                       : Color.FromRgb(0xF0, 0xC2, 0x4B));
         }
 
         /// <summary>


### PR DESCRIPTION
## What

Tiered features now wear their tier permanently - **gold borders = Tier 1, diamond (ice-cyan) = Tier 2** - instead of only showing tier colours on lockbands, which vanish once the account has the tier (so patrons never saw any tier signal at all).

## Surfaces

- **Studio rack**: Haptics row wears a gold rim + gold icon chip; the detail header echoes the metal. Rack table gained a `Tier` column so future paid modules are one `tier:` arg away.
- **Play wall**: Remote / Blink / For You / Lockdown cards get gold borders; Gaze / Focus Gaze and the DTRH hero get diamond frames. Hover brightens the metal instead of falling back to the mod accent. Goon / Graded Intake / Loom stay plain (not tier-priced).
- **Premium rail**: the six T1 chips + Lockdown/Blink launcher cards trade glass for gold. ChipGradedIntake keeps glass (weekly pass, not a tier).
- **Theme**: 4 shared gradient brushes in `Resources/Theme/Brushes.xaml`, literal colour stops (cross-dict StaticResource BAML trap).

Presentation only - refusals stay with TierGate / the panels' premium gates. No new localization keys. Lockbands unchanged (violet flask still marks a locked T2; recolouring those to diamond is a separate owner call).

## Tests

Full suite 2810/2810 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UMfgzxkj6bS863F2TS8Gh