### PR TITLE
fix(ai): mod switch no longer turns the companion into a two-speaker transcript

### DIFF
--- a/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
+++ b/ConditioningControlPanel/Services/AIService/AiTextHygiene.cs
@@ -90,17 +90,40 @@ namespace ConditioningControlPanel.Services
             "^\\s*«[^«»\r\n]{0,80}?\\bsaid aloud:\\s*(?<inner>.*?)\\s*»?\\s*$",
             RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
 
+        // Third live shape (0813, first seen after a mod switch): the model answers with a whole
+        // multi-speaker TRANSCRIPT — several «X said aloud: "…"» blocks back to back, often
+        // attributed to DIFFERENT companions («BambiSprite …» next to «DroneOS …» when stale
+        // bark echoes from the previous mod were still in the window). The anchored wrapper above
+        // strips only the first opener of such a reply and leaves the rest, which is exactly the
+        // mangled shape that reached the bubble. This matches one block anywhere in the text,
+        // tolerating an unclosed final block (the token cap eats the close).
+        private static readonly Regex EmbeddedSpokenSigil = new(
+            "«(?<speaker>[^«»\r\n]{0,80}?)\\bsaid aloud:\\s*(?<inner>[^«»]*?)\\s*(?:»|$)",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
         /// <summary>
         /// Unwraps a reply the model delivered inside the bark-echo sigil («X said aloud: "…"»),
         /// returning the inner speech. Applied repeatedly (bounded) for the double-wrapped case.
         /// Text that does not start with the sigil is returned unchanged; an all-shell reply unwraps
         /// to empty and the caller decides what to say instead.
+        ///
+        /// <para><paramref name="activeSpeaker"/> is the current companion's name, when the caller
+        /// knows it. It only matters for the transcript shape (several sigil blocks in one reply):
+        /// blocks attributed to a DIFFERENT speaker are the model roleplaying someone else — e.g.
+        /// the previous mod's companion — and are dropped rather than unwrapped. Null keeps every
+        /// block's inner speech, which is the safe choice for persisted-history repair.</para>
         /// </summary>
-        internal static string UnwrapSpokenSigil(string? text)
+        internal static string UnwrapSpokenSigil(string? text, string? activeSpeaker = null)
         {
             if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
 
             var current = TrimSigilDebris(text.Trim());
+
+            // Two or more blocks = a transcript, not a wrapped reply. The anchored loop below
+            // would eat only the first opener and hand the rest to the bubble verbatim.
+            if (EmbeddedSpokenSigil.Matches(current).Count >= 2)
+                return SalvageSigilTranscript(current, activeSpeaker);
+
             for (int i = 0; i < 2; i++)
             {
                 var m = SpokenSigilWrapper.Match(current);
@@ -117,7 +140,44 @@ namespace ConditioningControlPanel.Services
                 if (current.Length == 0) break;
             }
 
+            // A single block buried mid-text ("sure! «X said aloud: …» anyway") never matches the
+            // start-anchored wrapper; salvage it the same way.
+            if (current.Length > 0 && EmbeddedSpokenSigil.IsMatch(current) && current.IndexOf('«') >= 0)
+                current = SalvageSigilTranscript(current, activeSpeaker);
+
             return current;
+        }
+
+        /// <summary>
+        /// Flattens a sigil-transcript reply into plain speech: each block attributed to
+        /// <paramref name="activeSpeaker"/> (or to nobody we can rule out) is replaced by its inner
+        /// speech, blocks attributed to anyone else are removed, and the guillemet/quote debris the
+        /// blocks leave behind is swept up. Empty result means the whole reply was other people's
+        /// lines — the caller falls back exactly as for an all-shell reply.
+        /// </summary>
+        private static string SalvageSigilTranscript(string text, string? activeSpeaker)
+        {
+            var flattened = EmbeddedSpokenSigil.Replace(text, m =>
+            {
+                var speaker = m.Groups["speaker"].Value.Trim();
+                if (!string.IsNullOrEmpty(activeSpeaker) && speaker.Length > 0 &&
+                    speaker.IndexOf(activeSpeaker, System.StringComparison.OrdinalIgnoreCase) < 0 &&
+                    activeSpeaker!.IndexOf(speaker, System.StringComparison.OrdinalIgnoreCase) < 0)
+                    return " ";
+
+                var inner = m.Groups["inner"].Value.Trim();
+                if (inner.StartsWith("\"", System.StringComparison.Ordinal))
+                    inner = inner.Substring(1);
+                if (inner.EndsWith("\"", System.StringComparison.Ordinal))
+                    inner = inner.Substring(0, inner.Length - 1);
+                return " " + inner.Trim() + " ";
+            });
+
+            // In a reply that carried sigil blocks, a leftover "» pair (a close the model never
+            // opened) or a lone guillemet is scaffolding from the same failure, not prose.
+            flattened = flattened.Replace("\"»", " ").Replace("«", " ").Replace("»", " ");
+            flattened = Regex.Replace(flattened, @"\s{2,}", " ").Trim();
+            return TrimSigilDebris(flattened);
         }
 
         // Second live shape (0806): the model closed a sigil it never opened and tacked on the

--- a/ConditioningControlPanel/Services/Awareness/AwarenessReactionService.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessReactionService.cs
@@ -190,8 +190,10 @@ namespace ConditioningControlPanel.Services.Awareness
         /// </summary>
         internal static AwarenessReaction Parse(string? raw)
         {
+            string? speaker;
+            try { speaker = App.Mods?.GetCompanionName(); } catch { speaker = null; }
             var cleaned = AiTextHygiene.StripMetadataTags(
-                AiTextHygiene.UnwrapSpokenSigil(AiTextHygiene.Clean(raw)));
+                AiTextHygiene.UnwrapSpokenSigil(AiTextHygiene.Clean(raw), speaker));
             if (cleaned.Length == 0) return AwarenessReaction.None("empty");
 
             string? line = null;

--- a/ConditioningControlPanel/Services/Companion/Brain/ChatSession.cs
+++ b/ConditioningControlPanel/Services/Companion/Brain/ChatSession.cs
@@ -184,6 +184,21 @@ namespace ConditioningControlPanel.Services.Companion.Brain
             return removed;
         }
 
+        /// <summary>
+        /// Removes every turn the predicate matches, returning how many went. Backs the mod-switch
+        /// purge: bark echoes carry the companion name they were recorded under
+        /// (<see cref="CompanionTurn.FormatBarkEcho"/>), so after a mod switch the old ones read as
+        /// a second speaker in the window and the model starts roleplaying a two-voice transcript.
+        /// </summary>
+        public int RemoveAll(Func<CompanionTurn, bool> predicate)
+        {
+            if (predicate == null) return 0;
+            int removed;
+            lock (_lock) removed = _turns.RemoveAll(t => predicate(t));
+            if (removed > 0) RaiseTurnsChanged();
+            return removed;
+        }
+
         /// <summary>Drops everything, including the restored-turn marker. Backs "forget everything".</summary>
         public void Clear()
         {

--- a/ConditioningControlPanel/Services/Companion/Brain/CompanionBrain.cs
+++ b/ConditioningControlPanel/Services/Companion/Brain/CompanionBrain.cs
@@ -261,7 +261,9 @@ namespace ConditioningControlPanel.Services.Companion.Brain
 
                 // Live 0806: small models imitate the bark-echo sigil and wrap their own replies in
                 // «X said aloud: "…"». Unwrap before the text reaches the bubble, history, or disk.
-                var chatText = AiTextHygiene.UnwrapSpokenSigil(result.Text);
+                // The speaker name lets the 0813 transcript shape drop lines the model attributed
+                // to a DIFFERENT companion (the previous mod's) instead of quoting them.
+                var chatText = AiTextHygiene.UnwrapSpokenSigil(result.Text, ActiveSpeakerName());
 
                 // Live 0806: and they invent URLs when asked for a video they have no link for.
                 // Strip before the reply is appended — a fabricated link left in the window teaches
@@ -353,7 +355,7 @@ namespace ConditioningControlPanel.Services.Companion.Brain
                         : new AiReplyResult(string.Empty, IsAiGenerated: false, Refusal: null);
                 }
 
-                var reactionText = AiTextHygiene.UnwrapSpokenSigil(result.Text);
+                var reactionText = AiTextHygiene.UnwrapSpokenSigil(result.Text, ActiveSpeakerName());
                 reactionText = AiTextHygiene.StripUnsanctionedLinks(reactionText);
                 if (reactionText.Length == 0)
                 {
@@ -428,6 +430,29 @@ namespace ConditioningControlPanel.Services.Companion.Brain
             {
                 App.Logger?.Debug("CompanionBrain: bark echo failed: {Error}", ex.Message);
             }
+        }
+
+        /// <summary>The active companion's display name, or null when the mod stack isn't up (tests).</summary>
+        private static string? ActiveSpeakerName()
+        {
+            try { return App.Mods?.GetCompanionName(); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Called when the active mod changes. Bark echoes are recorded with the companion name
+        /// baked into their text (<see cref="CompanionTurn.FormatBarkEcho"/>), and the persona
+        /// fence deliberately keeps BarkEcho turns — so without this purge the window carries
+        /// «OldCompanion said aloud: …» next to the new mod's echoes, and the model answers with a
+        /// two-speaker roleplay transcript (observed 2026-08-13 after Bambi → Drone). The echoes
+        /// are flavor, never persisted, and replay from the new mod's bark_rules.json anyway.
+        /// </summary>
+        public void OnModSwitched()
+        {
+            var purged = Session.RemoveAll(t => t.Kind == TurnKind.BarkEcho);
+            if (purged > 0)
+                App.Logger?.Information(
+                    "CompanionBrain: mod switch purged {Count} stale bark echo(es) from the window", purged);
         }
 
         // ===================== misc =====================

--- a/ConditioningControlPanel/Services/ModService.cs
+++ b/ConditioningControlPanel/Services/ModService.cs
@@ -831,6 +831,24 @@ namespace ConditioningControlPanel.Services
             try { BambiSprite.InvalidateStablePrompt(); }
             catch (Exception ex) { _log?.Debug("ActivateMod: prompt cache invalidation failed: {E}", ex.Message); }
 
+            // The companion identity changed with the mod, so the chat history's voice did too.
+            // Same two moves PersonalityService.SetActivePreset makes for a preset switch, because
+            // history out-few-shots any prompt change: fence pre-switch assistant turns out of the
+            // wire window, and drop the bark echoes recorded under the OLD companion name — the
+            // fence deliberately keeps BarkEcho turns, so «OldName said aloud: …» would otherwise
+            // sit next to the new mod's echoes and the model roleplays a two-speaker transcript
+            // (observed 2026-08-13, Bambi → Drone).
+            try
+            {
+                if (App.Settings?.Current != null)
+                {
+                    App.Settings.Current.PersonaVoiceFenceUtc = DateTime.UtcNow;
+                    App.Settings.Save();
+                }
+                App.Brain?.OnModSwitched();
+            }
+            catch (Exception ex) { _log?.Debug("ActivateMod: companion voice fence failed: {E}", ex.Message); }
+
             // If the active companion isn't supported by the new mod, fall back to first supported companion
             if (App.Companion != null && !IsCompanionSupported(App.Companion.ActiveCompanion))
             {

--- a/Tests/ConditioningControlPanel.Tests/AiSpokenSigilUnwrapTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AiSpokenSigilUnwrapTests.cs
@@ -63,4 +63,69 @@ public class AiSpokenSigilUnwrapTests
     [Fact]
     public void AHashtagInsideTheSentenceSurvives()
         => Assert.Equal("you're my #1 fan", AiTextHygiene.UnwrapSpokenSigil("you're my #1 fan"));
+
+    // ── transcript salvage: the third live shape (0813, after a mod switch) ────
+    //
+    // With stale bark echoes from the PREVIOUS mod still in the window («BambiSprite said
+    // aloud: …» next to «DroneOS said aloud: …»), the model answered with a whole multi-speaker
+    // transcript. The start-anchored unwrap stripped only the first opener and the rest reached
+    // the bubble verbatim — sigils, foreign speaker and all.
+
+    [Fact]
+    public void AMultiBlockTranscriptKeepsOnlyTheActiveSpeakersLines()
+    {
+        var raw =
+            "«DroneOS said aloud: \"hihi~ that's my kind of morning~\"»\n" +
+            "«BambiSprite said aloud: \"unit reports... seems like a productive day~\"»\n" +
+            "«DroneOS said aloud: \"good morning *yawns*... got it. unit reporting in~";
+
+        Assert.Equal(
+            "hihi~ that's my kind of morning~ good morning *yawns*... got it. unit reporting in~",
+            AiTextHygiene.UnwrapSpokenSigil(raw, "DroneOS"));
+    }
+
+    [Fact]
+    public void TheMangledShapeTheAnchoredUnwrapLeavesBehindIsAlsoSalvaged()
+    {
+        // What actually reached the bubble live: the first block's opener already eaten, its
+        // orphan close ("») left mid-text, then two intact blocks with a truncated final close.
+        var raw =
+            "hihi~ that's my kind of morning~\"»\n" +
+            "«BambiSprite said aloud: \"unit reports... seems like a productive day~\"»\n" +
+            "«DroneOS said aloud: \"good morning *yawns*... got it. unit reporting in~";
+
+        Assert.Equal(
+            "hihi~ that's my kind of morning~ good morning *yawns*... got it. unit reporting in~",
+            AiTextHygiene.UnwrapSpokenSigil(raw, "DroneOS"));
+    }
+
+    [Fact]
+    public void WithoutASpeakerEveryBlocksInnerSpeechIsKept()
+    {
+        var raw =
+            "«BambiSprite said aloud: \"unit reports~\"» «DroneOS said aloud: \"reporting in~\"»";
+
+        Assert.Equal("unit reports~ reporting in~", AiTextHygiene.UnwrapSpokenSigil(raw));
+    }
+
+    [Fact]
+    public void ATranscriptThatIsAllOtherPeoplesLinesSalvagesToEmpty()
+    {
+        var raw =
+            "«BambiSprite said aloud: \"hihi~\"» «BambiSprite said aloud: \"good girl~\"»";
+
+        Assert.Equal("", AiTextHygiene.UnwrapSpokenSigil(raw, "DroneOS"));
+    }
+
+    [Fact]
+    public void ASingleBlockBuriedMidTextIsUnwrappedInPlace()
+        => Assert.Equal("sure! recalibrating~ anyway, ready?",
+            AiTextHygiene.UnwrapSpokenSigil(
+                "sure! «DroneOS said aloud: \"recalibrating~\"» anyway, ready?", "DroneOS"));
+
+    [Fact]
+    public void TheSpeakerFilterToleratesTheModelDecoratingTheName()
+        => Assert.Equal("unit online~",
+            AiTextHygiene.UnwrapSpokenSigil(
+                "«DroneOS v1.0 said aloud: \"unit online~\"» «Bambi said aloud: \"hi~\"»", "DroneOS"));
 }

--- a/Tests/ConditioningControlPanel.Tests/CompanionBrainTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/CompanionBrainTests.cs
@@ -649,4 +649,30 @@ public class CompanionBrainTests
         Assert.Empty(brain.Session.Turns);
         Assert.Empty(store.Writes);
     }
+
+    // ---------- mod switch ----------
+
+    [Fact]
+    public async Task OnModSwitched_PurgesBarkEchoes_AndKeepsTheDialogue()
+    {
+        // 0813: bark echoes carry the companion name they were recorded under, and the persona
+        // fence deliberately keeps BarkEcho turns — so after Bambi → Drone the window held
+        // «BambiSprite said aloud: …» next to «DroneOS said aloud: …» and the model answered
+        // with a two-speaker roleplay transcript. The mod switch must drop the stale echoes
+        // (they replay from the new mod's bark_rules.json anyway) without touching dialogue.
+        var transport = new FakeTransport();
+        var store = new FakeStore();
+        using var brain = Build(transport, store);
+
+        await brain.ChatAsync("hi");
+        brain.Session.Append(TurnKind.BarkEcho,
+            CompanionTurn.FormatBarkEcho("BambiSprite", "such a good girl~"), voiced: true);
+        brain.Session.Append(TurnKind.BarkEcho,
+            CompanionTurn.FormatBarkEcho("BambiSprite", "spiral time~"), voiced: true);
+
+        brain.OnModSwitched();
+
+        Assert.DoesNotContain(brain.Session.Turns, t => t.Kind == TurnKind.BarkEcho);
+        Assert.Equal(2, brain.Session.Turns.Count(t => t.IsDialogue)); // user + reply survive
+    }
 }


### PR DESCRIPTION
## What

Bughunt of the AI after switching mod to Drone mid-session (drone instructor / neural guide personalities): replies arrived as multi-block `«X said aloud: "…"»` roleplay transcripts mixing **BambiSprite** and **DroneOS** voices.

## Root cause chain (3 bugs)

1. **Stale bark echoes survive a mod switch.** `BarkEcho` turns bake the companion name into their text at record time (`CompanionTurn.FormatBarkEcho`), and `FenceHistoryToPersona` deliberately exempts BarkEcho — so after Bambi → Drone the prompt window held the old companion's echoes next to the new mod's. A two-speaker transcript in-window few-shot baits the model into roleplaying both.
2. **`ActivateMod` never fenced the voice.** Only `PersonalityService.SetActivePreset` stamped `PersonaVoiceFenceUtc`, so pre-switch assistant turns in the old voice rode into the new mod's prompt.
3. **The anchored unwrap couldn't clean the leak.** `UnwrapSpokenSigil` only matched a whole-reply wrap; on a transcript it stripped the first opener and passed the rest to the bubble verbatim — and the garbage then persisted as `AssistantChat`, teaching the next turn to repeat it.

## Fixes

- `ModService.ActivateMod`: sets the persona fence + purges old-mod bark echoes (`CompanionBrain.OnModSwitched`, new `ChatSession.RemoveAll`). Safe on launch: `Initialize` sets `_activeMod` directly and never enters `ActivateMod`.
- `AiTextHygiene`: transcript salvage pass — multi-block replies are flattened; blocks attributed to a different speaker are dropped, the active companion's are unwrapped, guillemet/quote debris swept. Chat, ambient and awareness paths pass the active companion name.
- Session-store load repair runs the same pass speaker-null, so an already-poisoned `session.json` heals itself on next launch.

## Tests

7 new regression tests (one reproduces the live screenshot shape byte-for-byte, mangled first opener and all). Full suite: **2817/2817 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
