### PR TITLE
fix(fyp): smooth swipe — neighbour previews kill the black flash, drag-to-peek paging

### DIFF
--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -6,6 +6,24 @@ import { createFeed } from './feed.js';
 import { createPage } from './surfaces.js';
 
 const PAGE_TRANSITION_MS = 340;
+// Neighbour pages this many steps from the active one stay mounted in PREVIEW
+// (media loaded + seeked, paused on the window's first frame). This is at once
+// the "never a black box" fix (a committed page resumes in place, no cold
+// mount), the peek a half-swipe reveals, and the preload of the next page
+// (preload='auto' buffers while the active clip plays). ±1 on purpose: a page
+// can hold up to 4 decoders, and local files load fast enough that ±2 buys
+// nothing but memory.
+const NEIGHBOR_PAGES = 1;
+// Live drag (ported back from the browser FYP, see FypFeed.tsx there):
+const PAGE_COMMIT_FRAC = 0.22;         // drag this fraction of the viewport commits
+const FLICK_V = 0.55;                  // px/ms release velocity that commits...
+const FLICK_MIN_PX = 20;               // ...but a twitch is not a flick
+const RUBBER = 0.35;                   // resistance where there is nothing to reveal
+// Remote entries carry a poster still; warming the image cache this many pages
+// ahead means even a swipe burst lands on a picture while the stream catches
+// up. One fetch per url per session; local files have no poster (their paused
+// preview frame plays that role) so this is online/mixed-mode work only.
+const POSTER_WARM_AHEAD = 6;
 const INTRO_EXIT_MS = 240;             // intro card is fully gone before the feed is built
 const CLIP_VIEWED_MIN_DWELL_MS = 5000; // below this a skim earns no XP
 const ATTENTION_MIN_GAP_MS = 120000;   // attention target every 2-4 min
@@ -161,6 +179,30 @@ const pageCtx = {
   onAdvance(compKey) {
     if (feed.comps[activeIdx]?.key === compKey) next();
   },
+  isPagerBusy: () => performance.now() < pageBusyUntil,
+  // Vertical drag, forwarded by whichever tile slot locked the 'y' axis. Only
+  // the active page steers the track; a stale gesture (page changed under it)
+  // is dropped rather than fought over.
+  onPageDragMove(compKey, dy) {
+    if (feed.comps[activeIdx]?.key !== compKey) return;
+    const atEdge = (activeIdx <= 0 && dy > 0) || (activeIdx >= feed.comps.length - 1 && dy < 0);
+    const eff = atEdge ? dy * RUBBER : dy;
+    track.style.transition = 'none';
+    track.style.transform = `translateY(${-activeIdx * pageH() + eff}px)`;
+  },
+  onPageDragEnd(compKey, dy, vy) {
+    if (feed.comps[activeIdx]?.key !== compKey) { applyTrack(true); return; }
+    let dir = 0;
+    if (Math.abs(vy) > FLICK_V && Math.sign(vy) === Math.sign(dy) && Math.abs(dy) > FLICK_MIN_PX) {
+      dir = dy < 0 ? 1 : -1;
+    } else if (Math.abs(dy) > pageH() * PAGE_COMMIT_FRAC) {
+      dir = dy < 0 ? 1 : -1;
+    }
+    // Commit continues the slide from wherever the pointer left the track
+    // (goTo's applyTrack animates from the current transform); a refusal
+    // (feed edge) or a short drag springs back the same way.
+    if (dir === 0 || !goTo(activeIdx + dir)) applyTrack(true);
+  },
   onSwap(compKey, tileIndex, dir) {
     const cut = feed.swapTile(compKey, tileIndex, dir);
     if (cut && tileIndex === 0 && feed.comps[activeIdx]?.key === compKey) updateCaption();
@@ -229,6 +271,43 @@ function applyTrack(animated) {
   track.style.transform = `translateY(${-activeIdx * pageH()}px)`;
 }
 
+/**
+ * Enforce the page window around activeIdx: the active page LIVE, its ±NEIGHBOR
+ * neighbours PREVIEW (mounted, paused on their first frame — the peek a
+ * half-swipe reveals, and the warm media a commit resumes with no black gap),
+ * everything else OFF. Hidden window: everything off — decoders freed, dwell
+ * reported — exactly what the old binary active flag did on minimize.
+ */
+function applyWindow() {
+  if (document.hidden) {
+    for (const p of pages.values()) p.setMode('off');
+    return;
+  }
+  feed.comps.forEach((c, i) => {
+    const page = pages.get(c.key);
+    if (!page) return;
+    const d = Math.abs(i - activeIdx);
+    page.setMode(d === 0 ? 'live' : d <= NEIGHBOR_PAGES ? 'preview' : 'off');
+  });
+  warmPosters();
+}
+
+// Poster pre-warm (online/mixed): one new Image() per url per session, well
+// past the mounted window, so a swipe burst lands on a cached still while the
+// stream spins up. Local entries have no posterUrl and skip out for free.
+const warmedPosters = new Set();
+function warmPosters() {
+  const until = Math.min(activeIdx + POSTER_WARM_AHEAD, feed.comps.length - 1);
+  for (let i = activeIdx + 1; i <= until; i++) {
+    for (const t of feed.comps[i].tiles) {
+      const u = t.cut.asset.posterUrl;
+      if (!u || warmedPosters.has(u)) continue;
+      warmedPosters.add(u);
+      new Image().src = u;
+    }
+  }
+}
+
 /** Reconcile page DOM with feed.comps (after configure/extend/trim). */
 function syncPages() {
   const comps = feed.comps;
@@ -249,28 +328,27 @@ function syncPages() {
     }
     page.el.style.top = (i * 100) + '%';
   });
+  applyWindow();
 }
 
+/** Returns true when the pager actually moved (the drag release needs the
+ *  refusal to spring back instead of committing into a wall). */
 function goTo(idx, animated = true) {
   const comps = feed.comps;
-  if (idx < 0 || idx >= comps.length || idx === activeIdx) return;
-  const prevPage = pageAt(activeIdx);
+  if (idx < 0 || idx >= comps.length || idx === activeIdx) return false;
   activeIdx = idx;
-  const page = pageAt(idx);
-  page?.setActive(true); // both pages live during the slide — no black gap
+  // The window shift does all the media work in place: incoming preview
+  // resumes (it was paused on the exact frame it shows — no black, no jump),
+  // outgoing live page freezes as a preview and keeps its frame through the
+  // slide, the far neighbour tears down (reporting its dwell).
+  applyWindow();
   applyTrack(animated);
   if (animated) pageBusyUntil = performance.now() + PAGE_TRANSITION_MS + 60;
-  if (prevPage && prevPage !== page) {
-    if (animated) {
-      setTimeout(() => { if (pageAt(activeIdx) !== prevPage) prevPage.setActive(false); }, PAGE_TRANSITION_MS + 40);
-    } else {
-      prevPage.setActive(false);
-    }
-  }
   updateCaption();
   // Append (and possibly head-trim) OUTSIDE the slide so the compensating
   // instant re-offset can never cancel the animation mid-flight.
   setTimeout(maybeExtend, animated ? PAGE_TRANSITION_MS + 60 : 0);
+  return true;
 }
 
 const next = () => goTo(activeIdx + 1);
@@ -296,9 +374,8 @@ function applyConfig() {
     pages.clear();
     audioFocus.clear();
     activeIdx = 0;
-    syncPages();
+    syncPages(); // applies the live/preview window around page 0
     applyTrack(false);
-    pageAt(0)?.setActive(true);
     updateCaption();
   }
   updateEmptyState();
@@ -732,7 +809,7 @@ function wireChrome() {
     updateOptionsUi();
     // live page picks the flag up on its next schedule pass
     const page = pageAt(activeIdx);
-    if (page) { page.setActive(false); page.setActive(true); }
+    if (page) { page.setMode('off'); page.setMode('live'); }
   });
   $('mosaic-sec').addEventListener('input', () => {
     $('mosaic-sec-label').textContent = `${$('mosaic-sec').value}s`;
@@ -814,13 +891,13 @@ function wireInput() {
 
   window.addEventListener('resize', () => applyTrack(false));
 
-  // Minimized/hidden: tear the live page down (reports dwell, frees decoders);
-  // restore on return.
+  // Minimized/hidden: tear every mounted page down (reports dwell, frees
+  // decoders — previews included); the window is restored on return. The
+  // re-snap covers a drag whose release was lost to the hide.
   document.addEventListener('visibilitychange', () => {
-    const page = pageAt(activeIdx);
-    if (!page) return;
-    if (document.hidden) page.setActive(false);
-    else page.setActive(true);
+    if (!feed) return;
+    applyWindow();
+    if (!document.hidden) applyTrack(false);
   });
   window.addEventListener('pagehide', () => stats.flush());
 }
@@ -931,9 +1008,8 @@ function onHostMessage(data) {
         feed.append(fresh);
         if (wasEmpty && feed.comps.length > 0) {
           activeIdx = 0;
-          syncPages();
+          syncPages(); // applies the live/preview window around page 0
           applyTrack(false);
-          pageAt(0)?.setActive(true);
           updateCaption();
         }
         updateEmptyState();

--- a/ConditioningControlPanel/Resources/web/fyp/surfaces.js
+++ b/ConditioningControlPanel/Resources/web/fyp/surfaces.js
@@ -1,11 +1,15 @@
 // Tile surfaces + pages — the DOM/media layer under feed.js's data model.
 //
 // Rules carried over from mobile (they are what keeps this smooth):
-//  - Only the ACTIVE page mounts live <video>/<img> elements; a deactivated page
-//    tears its media down immediately (reporting dwell exactly once) and shows a
-//    dark placeholder. Chromium then releases the decoders.
-//  - Dwell = wall-clock while the surface is active AND playing, accumulated
-//    across stalls; reported once on teardown.
+//  - Pages live in three states now (ported back from the browser FYP, which
+//    solved the black-flash-on-advance first): LIVE (playing, audible),
+//    PREVIEW (media mounted but paused on its first window frame — what a
+//    half-swipe peeks at, and what a committed page resumes from with no
+//    black gap), OFF (torn down, decoders freed). Only the active page is
+//    live; its ±1 neighbours hold preview; everything further is off.
+//  - Dwell = wall-clock while the surface is live AND playing, accumulated
+//    across stalls; reported exactly once on teardown. A preview never plays,
+//    so it banks nothing — promotion to live is when the clock starts.
 //  - The played window must match the scored segId (grid cuts seek to their
 //    grid start; cold cuts score the section actually played).
 //  - Unmount clears src + load() so the decoder frees now, not at GC time.
@@ -16,6 +20,12 @@ const SWAP_MS = 260;          // cross-slide duration on a committed swap
 const DRAG_RESISTANCE = 0.7;  // finger-follow while dragging
 const COMMIT_DIST = 64;       // px to commit a swap
 const COMMIT_VELOCITY = 0.8;  // px/ms
+// Movement below this never locks a drag axis — the release is a tap. The
+// first travel past it picks the axis: 'x' trades this tile (the drag that
+// was always here), 'y' hands the gesture to the pager so the whole track
+// follows the pointer (browser-FYP parity).
+const DRAG_LOCK_PX = 8;
+const VELOCITY_WINDOW_MS = 120; // release velocity reads the last ~120ms only
 const ERROR_ADVANCE_MS = 1200; // never machine-gun a broken pack
 const MAX_ERROR_SWAPS = 3;     // per mounted slot; then the visible fail state stays
 const MORPH_FADE_OUT_MS = 220;
@@ -32,9 +42,25 @@ function markFailed(el, cut) {
   el.appendChild(note);
 }
 
+/** Release velocity over the last ~VELOCITY_WINDOW_MS of samples, px/ms. */
+function dragVelocity(samples, k) {
+  const last = samples[samples.length - 1];
+  if (!last) return 0;
+  let first = samples[0];
+  for (const p of samples) {
+    if (last.t - p.t <= VELOCITY_WINDOW_MS) { first = p; break; }
+  }
+  const dt = last.t - first.t;
+  if (dt <= 0) return 0;
+  return (last[k] - first[k]) / dt;
+}
+
 /**
- * One live media surface for a cut. Returns { el, stop(), setMuted(), setAutoAdvance() }.
- * ctx: { onEnded, onError, onAssetMeta, report(segId, dwellMs, clipLenMs), advances }
+ * One media surface for a cut. Returns { el, stop(), setMuted(), setAutoAdvance(),
+ * setPreview(), failed }. ctx: { onEnded, onError, onAssetMeta,
+ * report(segId, dwellMs, clipLenMs), advances, preview }. Born with ctx.preview
+ * it loads + seeks but never plays: a paused element showing its window's first
+ * frame, ready to resume the instant the page goes live.
  */
 function createVideoSurface(cut, ctx) {
   const el = document.createElement('div');
@@ -49,11 +75,15 @@ function createVideoSurface(cut, ctx) {
   // steered by timeupdate before they ever get there).
   video.loop = !(ctx.autoAdvance && ctx.advances);
   video.style.objectFit = cut.fit;
+  // Remote entries carry a still; local files don't need one (the paused
+  // first frame IS the poster once metadata lands). Never black either way.
+  if (cut.asset.posterUrl) video.poster = cut.asset.posterUrl;
   el.appendChild(video);
 
   let cutStart = null;   // seconds; null until metadata
   let windowLen = null;  // null = whole-video cut
   let finished = false;
+  let previewing = !!ctx.preview;
   let autoAdvance = ctx.autoAdvance;
   // Retention attribution (set at metadata; cold cuts score what actually played).
   let scoreSegId = null;
@@ -76,8 +106,9 @@ function createVideoSurface(cut, ctx) {
     closeDwell();
     // There is no user-facing pause on the reel, so an unrequested pause while
     // the surface is live is an interruption — resume it (mobile parity). The
-    // `reported` guard keeps teardown's own pause from re-kicking playback.
-    if (!reported && !finished && !document.hidden && video.error == null) {
+    // `reported` guard keeps teardown's own pause from re-kicking playback,
+    // and `previewing` keeps a demoted page frozen on its frame.
+    if (!reported && !finished && !previewing && !document.hidden && video.error == null) {
       video.play().catch(() => { /* teardown race */ });
     }
   });
@@ -143,15 +174,31 @@ function createVideoSurface(cut, ctx) {
     ctx.onEnded();
   }
 
-  video.play().catch(() => { /* autoplay policy is disabled via browser args */ });
+  // A preview only buffers + seeks; playback (and dwell) starts on promotion.
+  if (!previewing) video.play().catch(() => { /* autoplay policy is disabled via browser args */ });
 
   return {
     el,
     cut,
+    /** A slot promoting a preview checks this to self-heal a dead file (#562). */
+    get failed() { return video.error != null; },
     setMuted(m) { video.muted = m; },
     setAutoAdvance(on) {
       autoAdvance = on;
       video.loop = !(on && ctx.advances);
+    },
+    /** live ⇄ preview without remounting: pause holds the frame (and the warm
+     *  buffer), play resumes exactly where the window left off. */
+    setPreview(on) {
+      if (on === previewing) return;
+      previewing = on;
+      if (on) {
+        closeDwell();
+        video.muted = true; // a peeked page must never talk over the live one
+        try { video.pause(); } catch { /* ignore */ }
+      } else {
+        video.play().catch(() => { /* teardown race */ });
+      }
     },
     /** Teardown: report dwell exactly once, then free the decoder NOW. */
     stop() {
@@ -169,7 +216,9 @@ function createVideoSurface(cut, ctx) {
   };
 }
 
-/** GIF sibling: always "playing", dwell is wall-clock, auto-advance is a timer. */
+/** GIF sibling: a GIF cannot pause, so preview only changes the accounting —
+ *  dwell is wall-clock while LIVE (not since mount), auto-advance is a timer
+ *  armed only while live. */
 function createGifSurface(cut, ctx) {
   const el = document.createElement('div');
   el.className = 'surface';
@@ -179,11 +228,19 @@ function createGifSurface(cut, ctx) {
   img.style.objectFit = cut.fit;
   el.appendChild(img);
 
-  const start = performance.now();
+  let previewing = !!ctx.preview;
+  let dwellAccum = 0;
+  let watchStart = previewing ? null : performance.now();
   let reported = false;
   let finished = false;
+  let failed = false;
   let advTimer = null;
   let metaSent = false;
+  let autoAdvance = ctx.autoAdvance;
+
+  const closeDwell = () => {
+    if (watchStart != null) { dwellAccum += performance.now() - watchStart; watchStart = null; }
+  };
 
   img.addEventListener('load', () => {
     if (!metaSent && cut.asset.width == null && img.naturalWidth > 0 && img.naturalHeight > 0) {
@@ -195,13 +252,14 @@ function createGifSurface(cut, ctx) {
   // GIFs had NO error listener at all — a broken image sat as the bare browser
   // glyph with nothing reported anywhere (#562).
   img.addEventListener('error', () => {
+    failed = true;
     markFailed(el, cut);
     ctx.onError?.(cut, { code: 0, message: 'image failed to load' });
   });
 
   function arm(on) {
     if (advTimer != null) { clearTimeout(advTimer); advTimer = null; }
-    if (on && ctx.advances) {
+    if (on && !previewing && ctx.advances) {
       advTimer = setTimeout(() => {
         if (finished) return;
         finished = true;
@@ -209,19 +267,26 @@ function createGifSurface(cut, ctx) {
       }, cut.lenSec * 1000);
     }
   }
-  arm(ctx.autoAdvance);
+  arm(autoAdvance);
 
   return {
     el,
     cut,
+    get failed() { return failed; },
     setMuted() { /* GIFs are silent */ },
-    setAutoAdvance(on) { arm(on); },
+    setAutoAdvance(on) { autoAdvance = on; arm(on); },
+    setPreview(on) {
+      if (on === previewing) return;
+      previewing = on;
+      if (on) { closeDwell(); arm(false); }
+      else { watchStart = performance.now(); arm(autoAdvance); }
+    },
     stop() {
       arm(false);
       if (!reported) {
         reported = true;
-        const dwell = performance.now() - start;
-        if (dwell > 0) ctx.report(segId(cut.asset.id, 0), dwell, cut.lenSec * 1000);
+        closeDwell();
+        if (dwellAccum > 0) ctx.report(segId(cut.asset.id, 0), dwellAccum, cut.lenSec * 1000);
       }
       img.removeAttribute('src');
       el.remove();
@@ -273,8 +338,11 @@ function createTileSlot(page, tileIndex, ctx) {
    *  Under auto-advance the advancing tile already pages away on its own error
    *  timer; every other case (manual browsing — the DEFAULT, autoAdvance is off —
    *  and non-advancing tiles) self-heals here. Capped so a mostly-broken library
-   *  settles into visible fail states rather than swap-looping. */
+   *  settles into visible fail states rather than swap-looping. Live pages only:
+   *  a preview that failed waits for promotion (setPreview re-checks then) —
+   *  swapping an off-screen page's tiles would churn the pool for nobody. */
   function scheduleErrorSwap() {
+    if (!ctx.isLive()) return;
     if (ctx.isAutoAdvance() && tile?.advances) return;
     if (errorSwaps >= MAX_ERROR_SWAPS || errSwapTimer != null) return;
     errSwapTimer = setTimeout(() => {
@@ -297,10 +365,11 @@ function createTileSlot(page, tileIndex, ctx) {
     slot.classList.toggle('blurred', !!t.blurred);
   }
 
-  function surfaceCtx(t) {
+  function surfaceCtx(t, preview) {
     return {
       advances: t.advances,
       autoAdvance: ctx.isAutoAdvance(),
+      preview: !!preview,
       onEnded: () => ctx.onAdvance(),
       onError: (cut, detail) => {
         ctx.onMediaError?.(cut.asset, detail);
@@ -311,14 +380,14 @@ function createTileSlot(page, tileIndex, ctx) {
     };
   }
 
-  function mount(t) {
+  function mount(t, preview) {
     mountGen++;
     tile = t;
     errorSwaps = 0;
     clearErrorSwap();
     applyRect(t);
     if (surface) { surface.stop(); surface = null; }
-    const s = createSurface({ ...t.cut, fit: t.fit }, surfaceCtx(t));
+    const s = createSurface({ ...t.cut, fit: t.fit }, surfaceCtx(t, preview));
     s.el.style.transform = 'translateX(0)';
     clip.appendChild(s.el);
     surface = s;
@@ -377,13 +446,19 @@ function createTileSlot(page, tileIndex, ctx) {
     slideTo(cut, dir);
   }
 
-  // Pointer drag: horizontal swap; a near-still release is a tap (audio focus).
+  // Pointer drag. The first DRAG_LOCK_PX of travel lock an axis: 'x' is the
+  // horizontal tile trade that was always here; 'y' hands the gesture to the
+  // pager (via ctx.onPageDragMove/End) so the whole track follows the pointer
+  // — half-swipe peeks the neighbour's preview, release commits or springs
+  // back (browser-FYP parity). A gesture that never locks is a tap.
   let dragId = null;
+  let dragAxis = null;   // null until locked: 'x' | 'y'
   let dragStartX = 0;
   let dragStartY = 0;
   let lastX = 0;
   let lastT = 0;
-  let velocity = 0;
+  let velocity = 0;      // instantaneous, for the 'x' trade (unchanged feel)
+  let samples = [];      // windowed, for the 'y' release (flick detection)
   slot.addEventListener('pointerdown', (e) => {
     // A press on a chevron must never start a drag: setPointerCapture below
     // retargets the whole gesture (including the compatibility `click`) to the
@@ -391,33 +466,56 @@ function createTileSlot(page, tileIndex, ctx) {
     if (e.target.closest?.('.chev')) return;
     if (e.button !== 0 || sliding || !surface) return;
     dragId = e.pointerId;
+    dragAxis = null;
     dragStartX = lastX = e.clientX;
     dragStartY = e.clientY;
     lastT = performance.now();
     velocity = 0;
+    samples = [{ t: lastT, x: e.clientX, y: e.clientY }];
     slot.setPointerCapture(e.pointerId);
   });
   slot.addEventListener('pointermove', (e) => {
     if (dragId !== e.pointerId || !surface) return;
+    // A mouse release can slip past pointer capture (a native drag or a focus
+    // steal swallows it) and plain hover moves would then steer the drag
+    // forever. No button held means the drag is over: settle with what we have.
+    if (dragAxis != null && e.pointerType !== 'touch' && e.buttons === 0) { endDrag(e); return; }
     const now = performance.now();
     const dt = now - lastT;
     if (dt > 0) velocity = (e.clientX - lastX) / dt;
     lastX = e.clientX;
     lastT = now;
+    samples.push({ t: now, x: e.clientX, y: e.clientY });
+    if (samples.length > 8) samples.shift();
     const dx = e.clientX - dragStartX;
-    if (Math.abs(dx) > 6) {
+    const dy = e.clientY - dragStartY;
+    if (dragAxis == null) {
+      if (Math.max(Math.abs(dx), Math.abs(dy)) < DRAG_LOCK_PX) return;
+      // a page slide is still animating: let it land, keep sampling
+      if (ctx.isPagerBusy?.()) return;
+      dragAxis = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y';
+    }
+    if (dragAxis === 'x') {
       surface.el.style.transition = 'none';
       surface.el.style.transform = `translateX(${dx * DRAG_RESISTANCE}px)`;
+    } else {
+      ctx.onPageDragMove(dy);
     }
   });
   const endDrag = (e) => {
     if (dragId !== e.pointerId) return;
     dragId = null;
+    const axis = dragAxis;
+    dragAxis = null;
+    if (axis === 'y') {
+      ctx.onPageDragEnd(e.clientY - dragStartY, dragVelocity(samples, 'y'));
+      return;
+    }
     if (!surface) return;
     surface.el.style.transition = '';
     const dx = e.clientX - dragStartX;
     const dy = e.clientY - dragStartY;
-    if (Math.abs(dx) > COMMIT_DIST || Math.abs(velocity) > COMMIT_VELOCITY) {
+    if (axis === 'x' && (Math.abs(dx) > COMMIT_DIST || Math.abs(velocity) > COMMIT_VELOCITY)) {
       commit(dx < 0 || (Math.abs(dx) <= COMMIT_DIST && velocity < 0) ? 'next' : 'back');
     } else if (Math.abs(dx) < 10 && Math.abs(dy) < 10) {
       springBack();
@@ -427,7 +525,14 @@ function createTileSlot(page, tileIndex, ctx) {
     }
   };
   slot.addEventListener('pointerup', endDrag);
-  slot.addEventListener('pointercancel', (e) => { if (dragId === e.pointerId) { dragId = null; springBack(); } });
+  slot.addEventListener('pointercancel', (e) => {
+    if (dragId !== e.pointerId) return;
+    dragId = null;
+    const axis = dragAxis;
+    dragAxis = null;
+    if (axis === 'y') ctx.onPageDragEnd(0, 0); // 0 travel: pager springs back
+    else springBack();
+  });
 
   // Chevrons drive the same commit path as the drag: ‹ = history-back (what a
   // rightward drag does), › = fresh pick (what a leftward drag does).
@@ -450,9 +555,18 @@ function createTileSlot(page, tileIndex, ctx) {
     get tile() { return tile; },
     get surface() { return surface; },
     get sliding() { return sliding; },
+    /** A pointer is mid-gesture on this slot. The morph checks it: removing a
+     *  slot that holds pointer capture silently kills the rest of the drag. */
+    get dragging() { return dragId != null; },
     mount,
     unmount,
     applyRect,
+    /** live ⇄ preview in place. Promotion re-checks a preview that failed
+     *  while off-screen so the self-heal swap (#562) still happens. */
+    setPreview(on) {
+      surface?.setPreview(on);
+      if (!on && surface?.failed) scheduleErrorSwap();
+    },
     /** Eye control: the exact chevron path (same guard, same cross-slide).
      *  Returns false when the slot could not act (mid-slide / not mounted). */
     commitSwap(dir) {
@@ -466,11 +580,13 @@ function createTileSlot(page, tileIndex, ctx) {
 }
 
 /**
- * One feed page. Created for every composition in the window; only mounts live
- * media while active. ctx:
+ * One feed page. Created for every composition in the window; media mounts in
+ * 'preview' (paused first frame — the pager's neighbours) or 'live' (playing).
+ * ctx:
  *   { onAdvance(compKey), onSwap(compKey, i, dir), onTapAudio(compKey, i),
  *     onAssetMeta, report, isAutoAdvance(), isMuted(), audioGlow() -> bool,
- *     audioFocus() -> index|null }
+ *     audioFocus() -> index|null, isPagerBusy() -> bool,
+ *     onPageDragMove(compKey, dy), onPageDragEnd(compKey, dy, vy) }
  */
 export function createPage(comp, ctx) {
   const el = document.createElement('div');
@@ -479,7 +595,7 @@ export function createPage(comp, ctx) {
   inner.className = 'page-inner';
   el.appendChild(inner);
 
-  let active = false;
+  let mode = 'off';      // 'off' | 'preview' | 'live'
   let slots = [];
   let morphTimer = null;
   let morphing = false;  // a morph's fade-out is in flight
@@ -491,7 +607,9 @@ export function createPage(comp, ctx) {
   }
 
   function applyAudio() {
-    const ai = audioIndex();
+    // Only the LIVE page ever speaks: previews are all-muted, no glow, so a
+    // half-swipe peek can never talk over the clip actually playing.
+    const ai = mode === 'live' ? audioIndex() : -1;
     const muted = ctx.isMuted();
     // Nothing is audible while muted (or when no tile carries audio at all) —
     // in that case no tile glows either.
@@ -505,9 +623,13 @@ export function createPage(comp, ctx) {
   function slotCtx(i) {
     return {
       isAutoAdvance: ctx.isAutoAdvance,
+      isLive: () => mode === 'live',
+      isPagerBusy: ctx.isPagerBusy,
       onAdvance: () => ctx.onAdvance(comp.key),
       onSwap: (idx, dir) => ctx.onSwap(comp.key, idx, dir),
       onTapAudio: (idx) => { ctx.onTapAudio(comp.key, idx); applyAudio(); },
+      onPageDragMove: (dy) => ctx.onPageDragMove(comp.key, dy),
+      onPageDragEnd: (dy, vy) => ctx.onPageDragEnd(comp.key, dy, vy),
       onAssetMeta: ctx.onAssetMeta,
       onMediaError: ctx.onMediaError,
       report: ctx.report,
@@ -515,11 +637,11 @@ export function createPage(comp, ctx) {
     };
   }
 
-  function mountTiles() {
+  function mountTiles(preview) {
     slots = comp.tiles.map((t, i) => {
       const slot = createTileSlot(el, i, slotCtx(i));
       inner.appendChild(slot.el);
-      slot.mount(t);
+      slot.mount(t, preview);
       return slot;
     });
     applyAudio();
@@ -533,16 +655,19 @@ export function createPage(comp, ctx) {
   /** The morph itself (fade out -> re-compose -> fade in), shared by the timer and
    *  by the eyes-closed gesture. Returns false when it could not run. */
   function runMorph() {
-    if (!active || morphing || comp.layout !== 'random') return false;
+    if (mode !== 'live' || morphing || comp.layout !== 'random') return false;
+    // A finger (or held mouse) on a slot: remounting would strip its pointer
+    // capture and strand the drag mid-air. Try again on the next tick instead.
+    if (slots.some((s) => s.dragging)) { scheduleMorph(); return false; }
     morphing = true;
     if (morphTimer != null) { clearTimeout(morphTimer); morphTimer = null; }
     inner.style.transition = `opacity ${MORPH_FADE_OUT_MS}ms ease-in`;
     inner.style.opacity = '0';
     setTimeout(() => {
       morphing = false;
-      if (!active) { inner.style.opacity = '1'; return; }
+      if (mode !== 'live') { inner.style.opacity = '1'; return; }
       const tiles = ctx.onMorph(comp.key); // feed re-composes in place
-      if (tiles) { unmountTiles(); mountTiles(); }
+      if (tiles) { unmountTiles(); mountTiles(false); }
       inner.style.transition = `opacity ${MORPH_FADE_IN_MS}ms ease-out`;
       inner.style.opacity = '1';
       scheduleMorph();
@@ -554,7 +679,7 @@ export function createPage(comp, ctx) {
   // tail of a morph would stomp the fade-in transition it was just given.
   function scheduleMorph() {
     if (morphTimer != null) { clearTimeout(morphTimer); morphTimer = null; }
-    if (!active || comp.layout !== 'random' || !ctx.mosaicAutoChange()) return;
+    if (mode !== 'live' || comp.layout !== 'random' || !ctx.mosaicAutoChange()) return;
     morphTimer = setTimeout(runMorph, Math.max(3000, ctx.mosaicChangeMs()));
   }
 
@@ -568,7 +693,8 @@ export function createPage(comp, ctx) {
     el,
     key: comp.key,
     comp,
-    get active() { return active; },
+    get mode() { return mode; },
+    get active() { return mode === 'live'; },
 
     // ---- eye control ----
     /** Tiles currently mounted (falls back to the model when inactive). */
@@ -594,11 +720,27 @@ export function createPage(comp, ctx) {
     /** Re-compose the whole mosaic now, with the timer's fade choreography. */
     morphNow() { return runMorph(); },
 
-    setActive(on) {
-      if (on === active) return;
-      active = on;
-      if (on) { mountTiles(); scheduleMorph(); }
-      else { cancelMorph(); unmountTiles(); }
+    /**
+     * The pager window drives this. Off→(preview|live) mounts media (paused or
+     * playing); live⇄preview flips the SAME surfaces in place — pause holds the
+     * frame and the buffer, play resumes it, and that in-place resume is what
+     * killed the black flash. Only →off tears down (reporting dwell once).
+     */
+    setMode(next) {
+      if (next === mode) return;
+      const prev = mode;
+      mode = next;
+      if (next === 'off') { cancelMorph(); unmountTiles(); return; }
+      if (prev === 'off') mountTiles(next === 'preview');
+      else for (const s of slots) s.setPreview(next === 'preview');
+      if (next === 'live') {
+        // the toggle may have flipped while this page waited in preview
+        for (const s of slots) s.surface?.setAutoAdvance(ctx.isAutoAdvance() && !!s.tile?.advances);
+        scheduleMorph();
+      } else {
+        cancelMorph();
+      }
+      applyAudio();
     },
     applyAudio,
     /** Auto-advance flipped while live: re-arm the surfaces. */


### PR DESCRIPTION
## The flash

Advancing the For You feed cold-mounted the incoming page's `<video>` elements at slide time (`goTo` → `setActive(true)` → fresh mount into an empty dark div). Until the first frame decoded, the slide revealed the page background — a black rectangle for a split second on every advance. There was also no way to half-swipe: paging was wheel/keys only, all-or-nothing.

## What the browser reference does

The browser FYP (`cclabs-web/src/components/fyp/FypFeed.tsx`, ported FROM this tree) solved this with: a poster layer under every mounting video, neighbour pages within ±2 kept mounted showing their stills, poster cache pre-warming ~6 pages ahead, a recycled preloading video pool, and follow-the-pointer drag with commit/spring-back physics.

## What this ports back (adapted to local-library realities)

Local files have no poster URLs — the cheap equivalent the task called out is *a paused element showing its first frame*, so:

- **Three-state pages** (`surfaces.js`): `live` / `preview` / `off` replaces the binary active flag. The active page's ±1 neighbours stay mounted in **preview** — loaded, seeked to their window start, paused on that frame, muted. Committing a page flips the same surfaces preview→live *in place*: `play()` resumes a warm buffer. Nothing mounts, nothing is black. The preview doubles as the **preload** (`preload='auto'` buffers while the active clip plays) and as the media a **half-swipe peeks** at. ±1 (not ±2) because a page can hold up to 4 decoders and local loads are fast.
- **Live drag** (`surfaces.js` gesture + `main.js` pager): first 8px of travel lock an axis — `x` is the existing tile trade, `y` drags the whole track under the pointer (mouse and touch). Release commits past 22% of the viewport or a 0.55 px/ms flick with ≥20px travel, else springs back; feed edges rubber-band at 0.35. **Wheel and keyboard navigation keep their exact old paths and timings.**
- **Posters where they exist**: remote (Scrolller) entries' `posterUrl` lands on `video.poster`, and posters pre-warm the image cache 6 pages ahead, one fetch per url per session (online/mixed mode only; local entries skip for free).
- **Accounting preserved**: dwell = wall-clock while playing, reported exactly once on teardown — a preview never plays so it banks nothing; promotion starts the clock. GIF dwell now counts live time, not time-since-mount. The #562 error self-heal waits for promotion instead of churning off-screen pages; a morph defers while a pointer holds capture on a slot (remounting would strand the drag).

Not broken: dwell/stats reporting, auto-advance (re-applied on promotion in case the toggle flipped mid-preview), duo/trio/mosaic layouts + morph timer, audio focus/glow, eye control (same `pageBusyUntil` gate now feeds the drag's busy check), ghost mode, attention check, online buffer plumbing.

## Verification

- `node --check` on every touched file (only `main.js` and `surfaces.js` changed; no C#, no CSS, no HTML).
- Playwright smoke test against the real page with a faked `chrome.webview` bridge and ffmpeg-generated clips — **14/14 pass, zero page errors**:
  - boot: exactly active + 1 neighbour mounted; neighbour paused, decoded (`readyState ≥ 2`)
  - wheel and arrow keys page exactly as before; window re-centres to ±1
  - mid-drag the track tracks the pointer 1:1 (`-816,-832,-848,-864,-880` for 16px steps)
  - 80px drag springs back; 250px drag commits; 40px flick commits; downward drag returns and the previous page **resumes playing**
  - horizontal drag still trades the tile, never pages (axis lock)
  - top-edge rubber-band: 80px pull gives 28px (×0.35)
  - stats still record on teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)