### PR TITLE
Nav rail: bigger medallion art + mod-fx door names; Companion hero portrait crop

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
+using System.Windows.Media.Effects;
 using System.Windows.Shapes;
 using System.Windows.Threading;
 using ConditioningControlPanel.Services;
@@ -98,10 +100,14 @@ namespace ConditioningControlPanel
 
         /// <summary>The art itself - a Viewbox over the native 64px medallion, so its rounded
         /// clip scales with it and its RenderTransform stays free for ChromeFx's hover nudge.
-        /// Open shrank 44 -> 40 with the tile's 56 -> 50 (same 2026-08-13 frame note above), so
-        /// the art keeps breathing room inside the smaller plate.</summary>
-        private const double NavDoorIconCollapsed = 28;
-        private const double NavDoorIconExpanded = 40;
+        /// 2026-08-13 owner pass ("make those images bigger even when in small mode, and reduce
+        /// by about half that grey outline"): the art grew INSIDE the frozen tile sizes, because
+        /// the visible ring of tile plate around the art IS the grey outline - 28 -> 36 shut
+        /// (44px tile: 8px of plate a side became 4) and 40 -> 45 open (50px tile: 5 -> 2.5).
+        /// The tiles themselves cannot grow: 44 is the collapsed strip's breathing room and 50
+        /// is the 3px window-frame clearance the same day's earlier pass bought.</summary>
+        private const double NavDoorIconCollapsed = 36;
+        private const double NavDoorIconExpanded = 45;
 
         /// <summary>Radial hue halo behind the tile. 64 shut is exactly the 56px strip plus the
         /// 4px each side where the gradient has already reached zero alpha, so the rail's
@@ -127,6 +133,25 @@ namespace ConditioningControlPanel
         private const int NavDoorLabelFadeMs = 220;
         private const int NavDoorLabelSlideMs = 260;
         private const int NavDoorLabelStaggerMs = 30;
+
+        // Door-name fx (owner, 2026-08-13: the names got "bigger and centered and animated -
+        // something mod themed, try some cool fx"). Two layers, both built per row in
+        // BuildNavDoorLabelFx (a Style-set Effect/Transform is ONE shared instance across the
+        // rows - the same trap the label slide already dodges) and both running ONLY while the
+        // rail is open: the labels sit at Opacity 0 shut, and a Forever clock under an
+        // invisible layer is pure heat.
+        //   - a DropShadowEffect halo on the name in the mod's FxGlow colour, breathing;
+        //   - a white gloss band (an overlay TextBlock's OpacityMask) sweeping each name,
+        //     one row after another, so the rail glints top to bottom.
+        // Reduced motion: static halo at the mid opacity, no sweep - the mod colour still
+        // reads, nothing loops.
+        private const double NavDoorLabelGlowLo = 0.20;
+        private const double NavDoorLabelGlowHi = 0.70;
+        private const double NavDoorLabelGlowStatic = 0.45;
+        private const int NavDoorLabelGlowBreathMs = 1900;
+        private const int NavDoorLabelShimmerSweepMs = 1100;
+        private const int NavDoorLabelShimmerPeriodMs = 3600;
+        private const int NavDoorLabelFxStaggerMs = 140;
 
         /// <summary>Marks the label host grid in MainWindow.xaml (set by the NavDoorLabelHost
         /// style). Two jobs: it is how <see cref="CacheNavDoorRows"/> finds the host, and how
@@ -180,6 +205,14 @@ namespace ConditioningControlPanel
             internal FrameworkElement LabelHost = null!;
             internal TranslateTransform LabelSlide = null!;
             internal TextBlock? Label;
+
+            /// <summary>Mod-glow halo behind the name. Per row: the breath is staggered, and
+            /// re-tinted from ApplyDoorArt on every mod switch.</summary>
+            internal DropShadowEffect? LabelGlow;
+
+            /// <summary>The gloss band's ride: TranslateTransform on the overlay TextBlock's
+            /// OpacityMask brush, swept -1 -> 1 across the name.</summary>
+            internal TranslateTransform? ShimmerSweep;
 
             /// <summary>The door's hue, read straight back off the Button's BorderBrush - the
             /// one place MainWindow.xaml states it, and already what NavActiveBar paints.</summary>
@@ -298,6 +331,14 @@ namespace ConditioningControlPanel
                     var art = ModResourceResolver.ResolveImageDecoded(path, NavDoorArtDecodeWidth);
                     if (art != null) img.Source = art;
                 }
+
+                // This is also the rail's ModChanged repaint hook (MainWindow.xaml.cs), so the
+                // name halos re-tint with the art. Before InitializeNavRail has cached the rows
+                // the list is empty and this is a no-op, which keeps the "safe to call early"
+                // promise above.
+                var glow = FxTheme.GlowColor;
+                foreach (var row in _navDoorRows)
+                    if (row.LabelGlow != null) row.LabelGlow.Color = glow;
             }
             catch (Exception ex)
             {
@@ -367,7 +408,11 @@ namespace ConditioningControlPanel
                     Label = hostPanel.Children.OfType<Viewbox>().FirstOrDefault()?.Child as TextBlock,
                     Hue = btn.BorderBrush ?? Brushes.Transparent,
                 };
-                if (row.Label != null) _navDoorLabelTexts.Add(row.Label);
+                if (row.Label != null)
+                {
+                    _navDoorLabelTexts.Add(row.Label);
+                    BuildNavDoorLabelFx(row, hostPanel);
+                }
                 glow.Fill = BuildNavDoorGlow(btn.BorderBrush as SolidColorBrush);
 
                 // The active bar is a template part; ChromeFx flips its Visibility and nothing
@@ -380,6 +425,131 @@ namespace ConditioningControlPanel
 
                 _navDoorRows.Add(row);
                 RefreshNavDoorActive(row);
+            }
+        }
+
+        /// <summary>
+        /// Builds one door name's two fx layers onto its label host: the mod-glow halo goes
+        /// straight onto the label as its Effect, and the gloss is a SECOND Viewbox+TextBlock
+        /// stacked over the first, carrying a sweeping band as its OpacityMask. The overlay
+        /// clones the label's style and mirrors its Text with a binding: same font and string
+        /// mean the same measure, so the two DownOnly Viewboxes scale identically and the
+        /// gloss lands exactly on the glyphs, in every locale, at every flyout width. It joins
+        /// _navDoorLabelTexts so CacheNavRailParts (which walks AFTER this) leaves it out of
+        /// the global label fade - its visibility is the host's Opacity, same as the name's.
+        /// Appended last, so the "first Viewbox in the host is the label's" lookup above stays
+        /// true; and it lives INSIDE the host, so ChromeFx's NudgeNavIcon (first Viewbox among
+        /// the button content's direct children) never mistakes it for the icon.
+        /// </summary>
+        private void BuildNavDoorLabelFx(NavDoorRow row, Panel host)
+        {
+            try
+            {
+                var label = row.Label!;
+                row.LabelGlow = new DropShadowEffect
+                {
+                    Color = FxTheme.GlowColor,
+                    BlurRadius = 16,
+                    ShadowDepth = 0,
+                    Opacity = 0,
+                };
+                label.Effect = row.LabelGlow;
+
+                row.ShimmerSweep = new TranslateTransform(-1, 0);
+                var band = new LinearGradientBrush
+                {
+                    StartPoint = new Point(0, 0.5),
+                    EndPoint = new Point(1, 0.5),
+                    RelativeTransform = row.ShimmerSweep,
+                };
+                band.GradientStops.Add(new GradientStop(Color.FromArgb(0x00, 0xFF, 0xFF, 0xFF), 0.35));
+                band.GradientStops.Add(new GradientStop(Color.FromArgb(0xB4, 0xFF, 0xFF, 0xFF), 0.50));
+                band.GradientStops.Add(new GradientStop(Color.FromArgb(0x00, 0xFF, 0xFF, 0xFF), 0.65));
+
+                var gloss = new TextBlock
+                {
+                    Style = label.Style,
+                    Foreground = Brushes.White,
+                    OpacityMask = band,
+                    IsHitTestVisible = false,
+                };
+                gloss.SetBinding(TextBlock.TextProperty, new Binding("Text") { Source = label });
+                _navDoorLabelTexts.Add(gloss);
+
+                host.Children.Add(new Viewbox
+                {
+                    Stretch = Stretch.Uniform,
+                    StretchDirection = StretchDirection.DownOnly,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    IsHitTestVisible = false,
+                    Child = gloss,
+                });
+            }
+            catch (Exception ex)
+            {
+                // The name renders fine without either layer; a row whose fx failed to build
+                // is just a quieter row.
+                App.Logger?.Debug("BuildNavDoorLabelFx: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>Starts one row's open-rail name fx: the breathing halo, and the gloss
+        /// sweep once the name has finished rising. Both stagger by row so the rail ripples
+        /// instead of pulsing in lockstep. Reduced motion: static halo, no clocks.</summary>
+        private static void StartNavDoorLabelFx(NavDoorRow row, int index)
+        {
+            if (row.LabelGlow == null) return;
+
+            if (!MotionFx.AllowTransitions)
+            {
+                row.LabelGlow.BeginAnimation(DropShadowEffect.OpacityProperty, null);
+                row.LabelGlow.Opacity = NavDoorLabelGlowStatic;
+                return;
+            }
+
+            var begin = TimeSpan.FromMilliseconds(index * NavDoorLabelFxStaggerMs);
+            row.LabelGlow.BeginAnimation(DropShadowEffect.OpacityProperty,
+                new DoubleAnimation(NavDoorLabelGlowLo, NavDoorLabelGlowHi,
+                    TimeSpan.FromMilliseconds(NavDoorLabelGlowBreathMs))
+                {
+                    BeginTime = begin,
+                    AutoReverse = true,
+                    RepeatBehavior = RepeatBehavior.Forever,
+                    EasingFunction = new SineEase { EasingMode = EasingMode.EaseInOut },
+                });
+
+            if (row.ShimmerSweep == null) return;
+            var sweep = new DoubleAnimationUsingKeyFrames
+            {
+                BeginTime = begin + TimeSpan.FromMilliseconds(NavDoorLabelSlideMs),
+                RepeatBehavior = RepeatBehavior.Forever,
+            };
+            sweep.KeyFrames.Add(new DiscreteDoubleKeyFrame(-1,
+                KeyTime.FromTimeSpan(TimeSpan.Zero)));
+            sweep.KeyFrames.Add(new LinearDoubleKeyFrame(1,
+                KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(NavDoorLabelShimmerSweepMs))));
+            // The rest of the period is the band parked offscreen: sweep, breathe, sweep again.
+            sweep.KeyFrames.Add(new DiscreteDoubleKeyFrame(-1,
+                KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(NavDoorLabelShimmerPeriodMs))));
+            row.ShimmerSweep.BeginAnimation(TranslateTransform.XProperty, sweep);
+        }
+
+        /// <summary>Kills both name-fx clocks and parks the layers dark. Runs on every
+        /// collapse, BEFORE the labels finish fading: two Forever clocks per row under an
+        /// Opacity-0 host would be the exact idle heat the dashboard's motion contract
+        /// exists to prevent.</summary>
+        private static void StopNavDoorLabelFx(NavDoorRow row)
+        {
+            if (row.LabelGlow != null)
+            {
+                row.LabelGlow.BeginAnimation(DropShadowEffect.OpacityProperty, null);
+                row.LabelGlow.Opacity = 0;
+            }
+            if (row.ShimmerSweep != null)
+            {
+                row.ShimmerSweep.BeginAnimation(TranslateTransform.XProperty, null);
+                row.ShimmerSweep.X = -1;
             }
         }
 
@@ -468,6 +638,12 @@ namespace ConditioningControlPanel
                 SetNavRailSize(row.Icon, iconTo, animate);
                 SetNavRailSize(row.Glow, glowTo, animate);
                 SetNavDoorGlow(row, animate);
+
+                // The name fx follow the open state, not the animate flag: an expand that was
+                // snapped (reduced motion) still deserves its static halo, and Start gates its
+                // own clocks on MotionFx.
+                if (expand) StartNavDoorLabelFx(row, i);
+                else StopNavDoorLabelFx(row);
 
                 if (!animate)
                 {

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -100,10 +100,10 @@
              2026-08-11 emoji purge: door icons are painted art thumbnails
              (Resources/nav/door_*.png, 64x64 native). 2026-08-12 (CONTRACT.md "Nav rail
              interaction spec"): the row became a medallion tile that grows with the rail -
-             44px r12 tile with a 28px icon while the rail is shut, 56px tile with a 44px icon
-             and a big bottom-aligned name once it opens. Every size in that sentence is
-             animated from MainWindow.NavRail.cs (which also says why the open tile is 56 and
-             not the contract's 64); nothing here animates itself.
+             44px r12 tile with a 36px icon while the rail is shut, 50px tile with a 45px icon
+             and a big centred name once it opens. Every size in that sentence is animated
+             from MainWindow.NavRail.cs (which also says why the open tile is 50 and not the
+             contract's 64); nothing here animates itself.
 
              The row is a FIXED 64px tall in BOTH states on purpose: only the tile inside it
              grows. Animating the row height as well would re-layout the whole rail (and shove
@@ -155,27 +155,31 @@
         </Style>
 
         <!-- The big door name. Width 160 = the open rail (236) minus the 56px medallion column
-             minus 8 left / 12 right, and it is FIXED so the Viewbox inside never re-scales the
+             minus the 10px lead-in, and it is FIXED so the Viewbox inside never re-scales the
              text mid-flyout: the label slides up and fades in at a constant size while the
              rail's own ClipToBounds reveals it. Opacity 0 is the shut state; NavRail.cs owns
              this property (and a TranslateTransform it installs at cache time) from Loaded on.
+             Centred both ways since 2026-08-13 (owner: "bigger and centered"): the host sits
+             mid-row and the name's mod-glow/shimmer fx (built per row in CacheNavDoorRows -
+             a Style Effect would be one shared instance, the stagger's old enemy) breathe
+             around a centred baseline instead of a bottom-left one.
 
              Tag is API: CacheNavRailParts uses it to tell "a label I drive per row, with a
              stagger" apart from "a label the global collapse fade owns" (every entry label).
              No letter-spacing: WPF's TextBlock has no CharacterSpacing (that is a WinUI
              property) and faking tracking by injecting hair spaces breaks CJK shaping and the
-             9 shipped locales, so the contract's ~1.5 tracking is carried by 16px/ExtraBold. -->
+             9 shipped locales, so the contract's ~1.5 tracking is carried by 21px/ExtraBold. -->
         <Style x:Key="NavDoorLabelHost" TargetType="Grid">
             <Setter Property="Tag" Value="navdoorlabel"/>
             <Setter Property="Width" Value="160"/>
             <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="VerticalAlignment" Value="Bottom"/>
-            <Setter Property="Margin" Value="8,0,0,10"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="10,0,0,0"/>
             <Setter Property="Opacity" Value="0"/>
         </Style>
 
         <Style x:Key="NavDoorLabelText" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="FontSize" Value="21"/>
             <Setter Property="FontWeight" Value="ExtraBold"/>
             <Setter Property="Foreground" Value="{DynamicResource TextLightBrush}"/>
             <Setter Property="TextWrapping" Value="NoWrap"/>
@@ -521,7 +525,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <!-- x:Name = the handle ApplyDoorArt (MainWindow.NavRail.cs) uses to
                                          re-point the art at the active mod's override. The literal
@@ -537,7 +541,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_home}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -578,7 +582,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Image x:Name="ImgDoorStudio"
                                            Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -590,7 +594,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_studio}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -659,7 +663,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Image x:Name="ImgDoorCompanion"
                                            Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -671,7 +675,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_companion}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -737,7 +741,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Image x:Name="ImgDoorPlay"
                                            Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -749,7 +753,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_play}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -858,7 +862,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Image x:Name="ImgDoorYou"
                                            Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -870,7 +874,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_you}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -963,7 +967,7 @@
                                         HorizontalAlignment="Center" VerticalAlignment="Center"
                                         Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                         BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                                <Viewbox Grid.Column="0" Width="28" Height="28"
+                                <Viewbox Grid.Column="0" Width="36" Height="36"
                                          HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <Image x:Name="ImgDoorLibrary"
                                            Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -975,7 +979,7 @@
                                 </Viewbox>
                                 <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                     <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                             HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                             HorizontalAlignment="Center" VerticalAlignment="Center">
                                         <TextBlock Text="{loc:Str nav_door_library}"
                                                    Style="{StaticResource NavDoorLabelText}"/>
                                     </Viewbox>
@@ -1149,7 +1153,7 @@
                                     HorizontalAlignment="Center" VerticalAlignment="Center"
                                     Opacity="0.85" Background="{DynamicResource PanelAccentBrush}"
                                     BorderThickness="1" BorderBrush="{DynamicResource GlassBorderBrush}"/>
-                            <Viewbox Grid.Column="0" Width="28" Height="28"
+                            <Viewbox Grid.Column="0" Width="36" Height="36"
                                      HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <Image x:Name="ImgDoorSettings"
                                        Width="64" Height="64" RenderOptions.BitmapScalingMode="HighQuality"
@@ -1161,7 +1165,7 @@
                             </Viewbox>
                             <Grid Grid.Column="1" Style="{StaticResource NavDoorLabelHost}">
                                 <Viewbox StretchDirection="DownOnly" Stretch="Uniform"
-                                         HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                                         HorizontalAlignment="Center" VerticalAlignment="Center">
                                     <TextBlock Text="{loc:Str nav_door_settings}"
                                                Style="{StaticResource NavDoorLabelText}"/>
                                 </Viewbox>

--- a/ConditioningControlPanel/Views/Controls/Companion/CompanionHeroCard.xaml
+++ b/ConditioningControlPanel/Views/Controls/Companion/CompanionHeroCard.xaml
@@ -302,10 +302,16 @@
                                 </Ellipse>
                             </Grid>
 
-                            <!-- the real portrait, when there is one -->
+                            <!-- The real portrait, when there is one. The source is the avatar
+                                 set's pose-1 TUBE sprite (LoadPortrait) - a tall full-body
+                                 image - so UniformToFill's default centre crop framed the
+                                 torso and beheaded her (owner, 2026-08-13: "avatar preview is
+                                 off center"). AlignmentY=Top keeps the head: the fill scales
+                                 to the circle's width and the crop eats the legs instead. -->
                             <Ellipse Margin="3" Visibility="{Binding Portrait, Converter={StaticResource CmpHasContentToVis}}">
                                 <Ellipse.Fill>
-                                    <ImageBrush ImageSource="{Binding Portrait}" Stretch="UniformToFill"/>
+                                    <ImageBrush ImageSource="{Binding Portrait}" Stretch="UniformToFill"
+                                                AlignmentY="Top"/>
                                 </Ellipse.Fill>
                             </Ellipse>
 


### PR DESCRIPTION
## Nav rail (owner pass 2026-08-13)

- **Bigger door art in both states**: the medallion art grows inside the frozen tile plates - 28 -> 36 collapsed (44px tile), 40 -> 45 expanded (50px tile) - which halves the visible grey plate ring around each image. Tiles stay put: 44 is the collapsed strip spacing, 50 is the 3px window-frame clearance.
- **Door names bigger + centered**: 16 -> 21px ExtraBold, vertically centered on the row and centered in the flyout name zone. Long locales still auto-shrink through the existing DownOnly Viewbox.
- **Mod-themed name fx**, built per row (a Style-set Effect is one shared instance - same trap the label slide dodges):
  - breathing DropShadowEffect halo in the mod FxGlow colour, re-tinted on every mod switch via the existing ApplyDoorArt ModChanged hook;
  - white gloss band sweeping each name every ~3.6s, staggered row by row.
  - Clocks run ONLY while the rail is open; reduced motion gets a static halo and no sweep.

## Companion room

- The hero portrait circle reuses the full-body pose-1 tube sprite; UniformToFill default centre crop framed the torso (no head). AlignmentY=Top anchors the crop to the head and eats the legs instead.

Build: 0 errors / 338 pre-existing warnings. Play-tested live on the owner box (rail signed off on screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)