### PR TITLE
feat(descent): forward the raw descent block to the spiral embed (§9 v2)

### DIFF
--- a/ConditioningControlPanel/Controls/SpiralEmbedView.cs
+++ b/ConditioningControlPanel/Controls/SpiralEmbedView.cs
@@ -25,10 +25,16 @@ namespace ConditioningControlPanel.Controls
     /// the desktop's X-Auth-Token never enters a browser, because the browser is never
     /// in a position to need one.
     ///
-    /// PROTOCOL (§9, exact):
+    /// PROTOCOL (§9 v2, exact):
     ///   host → page   { type: 'spiral:state', devotion_days, stage, relapse_multiplier?,
-    ///                   vat_fill_pct?, lit_station_ids?, reduced_motion?, perf_tier? }
+    ///                   vat_fill_pct?, lit_station_ids?, reduced_motion?, perf_tier?,
+    ///                   descent? }
     ///   page → host   { type: 'spiral:ready' }
+    /// v2 ADDS ONE OPTIONAL FIELD and changes nothing else. `descent` is the server's
+    /// own block, forwarded VERBATIM (DescentBlock.RawJson), and it is present only when
+    /// one exists. Absent is the v1 contract and stays legal in both directions: an old
+    /// embed drops the unknown key, and a new embed against a v1 host simply never sees
+    /// it. See BuildState for why the forward is raw rather than re-authored.
     /// State posted before 'spiral:ready' is QUEUED, not dropped — the canvas's boot and
     /// the descent block's arrival race every launch, and whichever wins, the last state
     /// posted is the state drawn. Note the handshake is 'spiral:ready', NOT the bare
@@ -224,7 +230,11 @@ namespace ConditioningControlPanel.Controls
             if (_disposed) return;
             try
             {
-                var json = JsonConvert.SerializeObject(BuildState(block));
+                // ToString, not JsonConvert.SerializeObject: the state is already a JObject
+                // and the `descent` branch under it is the server's own tokens, so writing
+                // the tree straight out is the one serialisation with nothing in the middle
+                // that could re-shape a value on the way to the wire.
+                var json = BuildState(block).ToString(Formatting.None);
                 if (IsReady && _web?.CoreWebView2 != null)
                 {
                     _web.CoreWebView2.PostWebMessageAsJson(json);
@@ -246,23 +256,71 @@ namespace ConditioningControlPanel.Controls
         /// two host-owned signals the canvas cannot know: how much motion this user
         /// allows, and how much GPU the app currently has to spare.
         ///
-        /// `lit_station_ids` is DELIBERATELY ABSENT. The station registry lives in
+        /// `descent` (v2) IS THE SERVER'S BLOCK, UNTOUCHED. The reader parses a subset —
+        /// devotion, stage, relapse, vat — and drops the rest on the floor, which is why
+        /// the map window drew a naked spiral: day_fill, day_quest, stations, breaks,
+        /// dates and thresholds never left this process. Rather than teach desktop to
+        /// re-author them (three clients, three chances to author them differently), the
+        /// original node is re-emitted byte-faithfully from DescentBlock.RawJson and the
+        /// embed runs its OWN strict validation on it. THE APP AUTHORS NOTHING HERE:
+        /// every number under this key is a number the server stated. Do not "helpfully"
+        /// merge, default or patch a field into it — the moment desktop writes into this
+        /// object, the canvas is drawing a record the server never agreed to.
+        ///
+        /// PRESENCE IS THE CONTRACT, not null-ness. With no block (or a hand-built one
+        /// with no raw), the key is ABSENT — that is v1 exactly, which is what an embed
+        /// deployed before v2 expects. A null-valued `descent` would be a third state
+        /// nobody specified.
+        ///
+        /// `lit_station_ids` remains DELIBERATELY ABSENT. The station registry lives in
         /// cclabs-web (lib/descent/stations.ts); desktop has no copy and must not invent
         /// one — a client-authored list of lit stations is a client deciding what it has
         /// earned. The canvas treats the field as optional and lights nothing without it.
+        /// When `descent` IS present it supersedes the question entirely: the block
+        /// carries the server's own stations, so the canvas resolves what is lit from
+        /// the record instead of from a list this side would have had to make up.
         /// </summary>
-        private static object BuildState(DescentBlock? block)
+        internal static JObject BuildState(DescentBlock? block)
         {
-            return new
+            var state = new JObject
             {
-                type = "spiral:state",
-                devotion_days = block?.DevotionDays ?? 0,
-                stage = block?.Stage?.N ?? 0,
-                relapse_multiplier = block?.Relapse?.Multiplier ?? 1.0,
-                vat_fill_pct = block?.Vat?.FillPct ?? 0.0,
-                reduced_motion = MotionFx.Level != Models.MotionLevel.Full,
-                perf_tier = PerfTier(),
+                ["type"] = "spiral:state",
+                ["devotion_days"] = block?.DevotionDays ?? 0,
+                ["stage"] = block?.Stage?.N ?? 0,
+                ["relapse_multiplier"] = block?.Relapse?.Multiplier ?? 1.0,
+                ["vat_fill_pct"] = block?.Vat?.FillPct ?? 0.0,
+                ["reduced_motion"] = MotionFx.Level != Models.MotionLevel.Full,
+                ["perf_tier"] = PerfTier(),
             };
+
+            // Re-parsed with date coercion OFF for the same reason DescentReader.ParseWire
+            // turns it off: the default rewrites every ISO-8601-shaped STRING into a
+            // DateTime, and re-serialising that emits an invented offset. The whole point
+            // of this field is that what arrives at the canvas is what the server sent,
+            // so the round trip has to be lossless or it is not a verbatim forward.
+            var raw = ParseVerbatim(block?.RawJson);
+            if (raw is not null) state["descent"] = raw;
+
+            return state;
+        }
+
+        /// <summary>Re-parse a stored block with date coercion off. Null on anything unusable.</summary>
+        private static JToken? ParseVerbatim(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            try
+            {
+                return JsonConvert.DeserializeObject<JToken>(
+                    json, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
+            }
+            catch (Exception ex)
+            {
+                // The block already parsed once to exist at all, so this is unreachable in
+                // practice — and if it ever is reached, the field drops out and the canvas
+                // gets a clean v1 payload rather than a half-forwarded one.
+                App.Logger?.Debug("[Spiral] raw descent re-parse failed: {E}", ex.Message);
+                return null;
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/Services/Descent/DescentModels.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentModels.cs
@@ -137,5 +137,23 @@ namespace ConditioningControlPanel.Services.Descent
         /// <summary>Where recorded history begins — the backfill boundary. Never read
         /// DayFill.Count as the user's whole history.</summary>
         public string? HistoryFrom { get; init; }
+
+        /// <summary>
+        /// THE SERVER'S BLOCK, VERBATIM — the compact re-serialisation of the exact
+        /// `descent` node this instance was parsed from, kept for §9 v2 forwarding to
+        /// the spiral embed (see SpiralEmbedView.BuildState).
+        ///
+        /// NEVER CLIENT-AUTHORED. Nothing in this app composes, patches or tops up this
+        /// string: it is the wire node and only the wire node, so that what the embed
+        /// validates is what the server said and not what a desktop reader made of it.
+        /// The typed fields above are this client's READING of that node; they are not
+        /// its source. Do not rebuild this from them.
+        ///
+        /// Non-null on every block that came off a payload — the reader sets it at the
+        /// same moment it decides the block is well-formed, so "block exists" and "raw
+        /// exists" are the same fact. Null ONLY in hand-built blocks (tests, and any
+        /// future local construction), which is exactly why the forward is conditional.
+        /// </summary>
+        public string? RawJson { get; init; }
     }
 }

--- a/ConditioningControlPanel/Services/Descent/DescentReader.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentReader.cs
@@ -129,6 +129,24 @@ namespace ConditioningControlPanel.Services.Descent
                 DayFillStart = Str(block["day_fill_start"]),
                 DayFillStartDayN = ReadStartDayN(block["day_fill_start_day_n"], dayFill.Count, days),
                 HistoryFrom = Str(block["history_from"]),
+
+                // THE WHOLE NODE, KEPT. Everything above is this reader's opinion of a
+                // subset; the fields it does not model (day_quest, stations, breaks,
+                // anchor, chapter, cycle, a ladder it declined) are dropped on the floor,
+                // and the spiral embed needs them to draw more than a naked coil. So the
+                // node is re-serialised compactly and forwarded byte-faithfully by §9 v2
+                // — the app authors nothing, the embed validates for itself.
+                //
+                // Captured HERE, past the well-formed bar, and nowhere else: a malformed
+                // payload has already returned null above and therefore carries no raw
+                // either. The tri-state law holds unchanged — no block, no raw.
+                //
+                // ToString(Formatting.None) re-emits what ParseWire read, and ParseWire
+                // reads with DateParseHandling.None, so date-shaped strings are still
+                // strings and come back out exactly as sent. Run this over a token from a
+                // coercing parse instead and every day string would re-emit as an
+                // invented midnight instant.
+                RawJson = block.ToString(Formatting.None),
             };
         }
 

--- a/Tests/ConditioningControlPanel.Tests/SpiralEmbedStateV2Tests.cs
+++ b/Tests/ConditioningControlPanel.Tests/SpiralEmbedStateV2Tests.cs
@@ -1,0 +1,194 @@
+using ConditioningControlPanel.Controls;
+using ConditioningControlPanel.Services.Descent;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// §9 v2 — THE VERBATIM FORWARD, pinned end to end.
+///
+/// v1 shipped six numbers to the spiral canvas and the canvas drew a naked coil,
+/// because DescentReader models a SUBSET of the block: day_fill, day_quest, stations,
+/// breaks, dates and thresholds were parsed past and thrown away. v2 fixes that the
+/// only way three clients can be fixed at once — by forwarding the server's own node
+/// untouched and letting the embed validate it — so these tests are about FIDELITY and
+/// PRESENCE, not about the block's meaning, which is the server's business.
+///
+/// Two properties, and both are load-bearing:
+///   1. What comes out is byte-for-byte what went in. The date-coercion trap
+///      (DescentBlockReaderTests) bites twice as hard here: a day string that
+///      round-trips through a DateTime re-emits as an invented midnight instant, and
+///      the canvas would draw a record the server never sent.
+///   2. `descent` is ABSENT, never null, when there is nothing to forward. Absence IS
+///      the v1 contract; an embed deployed before v2 must not be able to tell the
+///      difference.
+/// </summary>
+public class SpiralEmbedStateV2Tests
+{
+    /// <summary>
+    /// A full-fat block, including every section the typed reader does NOT model —
+    /// day_quest, stations, breaks, anchor, chapter — because those are precisely the
+    /// ones v2 exists to carry. If the forward ever narrows to "the fields we parse",
+    /// this payload is what catches it.
+    /// </summary>
+    private const string FullFatBlock = """
+    {
+      "devotion_days": 142,
+      "devotion_last_day": "2026-08-12",
+      "anchor": { "date": "2026-03-23T00:00:00.000Z", "source": "migration", "day_n": 142 },
+      "stage": { "n": 5, "key": "stage_5", "banked_days": 142, "next_at": 180,
+                 "days_to_next": 38, "thresholds": [1,7,21,50,100,180,300] },
+      "relapse": { "multiplier": 1.2, "days_away": 3, "surge_active": true,
+                   "surge_ends_at": "2026-08-15T00:00:00.000Z", "surge_multiplier": 1.5 },
+      "chapter": { "id": "2026-08", "xp": 91234, "ends_at": "2026-08-31T23:59:59.000Z", "rank": null },
+      "vat": { "cap": 5200, "today_xp": 3016, "fill_pct": 58, "fill_lip_pct": 125 },
+      "day_fill": [22, 100, 118, 47],
+      "day_fill_start": "2026-08-09",
+      "day_fill_start_day_n": 139,
+      "day_quest": { "id": "bank_the_day", "done": false, "progress": 0.4 },
+      "stations": [{ "id": "st_first_pour", "lit": true, "day_n": 1 },
+                   { "id": "st_first_week", "lit": true, "day_n": 7 },
+                   { "id": "st_hundred", "lit": false, "day_n": 100 }],
+      "breaks": [{ "after_day": 140, "len": 2 }],
+      "history_from": "2026-08-09"
+    }
+    """;
+
+    /// <summary>Read a block the way the fetch path does — date coercion off.</summary>
+    private static JObject Wire(string json) => DescentReader.ParseWire(json)!;
+
+    // ======================================================= the reader keeps it
+
+    [Fact]
+    public void Reader_KeepsTheServersBlock_Verbatim()
+    {
+        var node = Wire(FullFatBlock);
+        var block = DescentReader.Parse(node)!;
+
+        Assert.NotNull(block.RawJson);
+        // Not "equivalent" — the SAME tree, including the five sections the typed
+        // reader has no property for.
+        Assert.True(JToken.DeepEquals(DescentReader.ParseWire(block.RawJson), node));
+    }
+
+    /// <summary>
+    /// The date-coercion trap, on the forwarding side. Re-serialising a token that a
+    /// coercing parse turned into a DateTime emits "2026-08-12T00:00:00" with an
+    /// invented offset, so this asserts against the STRING the reader stored rather
+    /// than against a re-parse that could hide the damage.
+    /// </summary>
+    [Fact]
+    public void Reader_RawJson_KeepsDateShapedStringsAsStrings()
+    {
+        var block = DescentReader.Parse(Wire(FullFatBlock))!;
+
+        Assert.NotNull(block.RawJson);
+        Assert.Contains("\"devotion_last_day\":\"2026-08-12\"", block.RawJson!);
+        Assert.Contains("\"day_fill_start\":\"2026-08-09\"", block.RawJson!);
+        Assert.Contains("\"surge_ends_at\":\"2026-08-15T00:00:00.000Z\"", block.RawJson!);
+
+        var reread = DescentReader.ParseWire(block.RawJson)!;
+        Assert.Equal(JTokenType.String, reread["devotion_last_day"]!.Type);
+        Assert.Equal(JTokenType.String, reread["day_fill_start"]!.Type);
+        Assert.Equal(JTokenType.String, reread["relapse"]!["surge_ends_at"]!.Type);
+    }
+
+    /// <summary>
+    /// The tri-state law is not weakened by adding a field to carry: no block means no
+    /// raw, because the raw is only ever captured past the well-formed bar.
+    /// </summary>
+    [Fact]
+    public void Reader_MalformedBlock_IsStillNothing_AndCarriesNoRaw()
+    {
+        Assert.Null(DescentReader.Parse(null));
+        Assert.Null(DescentReader.Parse(new JArray()));
+        Assert.Null(DescentReader.Parse(Wire("{ \"vat\": { \"cap\": 5000 } }")));
+        Assert.Null(DescentReader.Parse(Wire("{ \"devotion_days\": \"142\" }")));
+        Assert.Null(DescentReader.Parse(Wire("{ \"devotion_days\": -1 }")));
+    }
+
+    // ==================================================== the payload forwards it
+
+    [Fact]
+    public void BuildState_ForwardsTheBlockUnchanged()
+    {
+        var node = Wire(FullFatBlock);
+        var state = SpiralEmbedView.BuildState(DescentReader.Parse(node));
+
+        Assert.True(JToken.DeepEquals(state["descent"], node));
+    }
+
+    /// <summary>The same, through the serialisation PostState actually writes to the wire.</summary>
+    [Fact]
+    public void BuildState_SurvivesSerialisationToTheWire()
+    {
+        var node = Wire(FullFatBlock);
+        var json = SpiralEmbedView.BuildState(DescentReader.Parse(node)).ToString(Formatting.None);
+
+        var onTheWire = DescentReader.ParseWire(json)!;
+        Assert.True(JToken.DeepEquals(onTheWire["descent"], node));
+        Assert.Equal("spiral:state", (string?)onTheWire["type"]);
+    }
+
+    /// <summary>
+    /// ABSENT, NOT NULL. A null-valued key is a third state nobody specified, and an
+    /// embed deployed before v2 must see exactly the v1 message.
+    /// </summary>
+    [Fact]
+    public void BuildState_OmitsDescent_WhenThereIsNoBlock()
+    {
+        var state = SpiralEmbedView.BuildState(null);
+
+        Assert.False(state.ContainsKey("descent"));
+        Assert.DoesNotContain("descent", state.ToString(Formatting.None));
+    }
+
+    /// <summary>
+    /// A hand-built block — a test fixture, or any future local construction — has no
+    /// server node behind it, so it forwards nothing. This is the whole reason the
+    /// forward is conditional rather than assumed.
+    /// </summary>
+    [Fact]
+    public void BuildState_OmitsDescent_WhenTheBlockWasNotParsedFromAPayload()
+    {
+        var state = SpiralEmbedView.BuildState(new DescentBlock { DevotionDays = 9 });
+
+        Assert.False(state.ContainsKey("descent"));
+        Assert.Equal(9, (int)state["devotion_days"]!);
+    }
+
+    // ============================================== v1 fields, unchanged by v2
+
+    [Fact]
+    public void BuildState_V1Fields_AreUnchanged_WithABlock()
+    {
+        var state = SpiralEmbedView.BuildState(DescentReader.Parse(Wire(FullFatBlock)));
+
+        Assert.Equal("spiral:state", (string?)state["type"]);
+        Assert.Equal(142, (int)state["devotion_days"]!);
+        Assert.Equal(5, (int)state["stage"]!);
+        Assert.Equal(1.2, (double)state["relapse_multiplier"]!, 6);
+        Assert.Equal(58.0, (double)state["vat_fill_pct"]!, 6);
+        Assert.NotNull(state["reduced_motion"]);
+        Assert.True((string?)state["perf_tier"] is "low" or "mid" or "high");
+
+        // The station list stays desktop-silent even in v2 — what the block carries is
+        // the server's stations, not a list this side composed.
+        Assert.False(state.ContainsKey("lit_station_ids"));
+    }
+
+    [Fact]
+    public void BuildState_V1Fields_AreUnchanged_WithNoBlock()
+    {
+        var state = SpiralEmbedView.BuildState(null);
+
+        Assert.Equal("spiral:state", (string?)state["type"]);
+        Assert.Equal(0, (int)state["devotion_days"]!);
+        Assert.Equal(0, (int)state["stage"]!);
+        Assert.Equal(1.0, (double)state["relapse_multiplier"]!, 6);
+        Assert.Equal(0.0, (double)state["vat_fill_pct"]!, 6);
+        Assert.True((string?)state["perf_tier"] is "low" or "mid" or "high");
+    }
+}


### PR DESCRIPTION
## What

The §9 host→page state message gains **one additive optional field**: `descent`, carrying the server's `descent` block verbatim. Nothing else in the protocol changes.

- `DescentBlock.RawJson` — the original node, re-serialised compact, captured in `DescentReader.Parse` at the exact point the block is judged well-formed.
- `SpiralEmbedView.BuildState` now builds a `JObject` and attaches `descent` when `block?.RawJson` is non-null.

## Why

`DescentReader` models a **subset** of the block: `day_fill`, `day_quest`, `stations`, `breaks`, `anchor`, `chapter`, the dates and a ladder it declined are all parsed past and thrown away. That is why the map window renders a naked spiral — the data the canvas needs never left this process.

The fix is not to teach desktop to re-author those fields. Three clients re-authoring one wire contract is three chances to author it differently. The server's node is forwarded byte-faithfully and the web embed does its own strict validation, so **every number under that key is a number the server stated**.

`lit_station_ids` remains deliberately absent for the same reason it always was — desktop has no station registry and must not invent one. When `descent` is present it supersedes the question outright: the block carries the server's own stations.

## The presence/absence contract

| state | `descent` |
|---|---|
| well-formed server block | **present**, DeepEquals the original node |
| no block (the common case — staged rollout) | **absent** |
| hand-built block, no `RawJson` (tests, future local construction) | **absent** |

Absent, never null-valued. Absence *is* the v1 message, so an embed deployed before v2 cannot tell the difference, and a null-valued key would be a third state nobody specified.

Malformed payload behaviour is unchanged — the raw is captured only past the well-formed bar, so **no block, no raw**. The tri-state law is intact.

## The date trap, again

The re-parse in `BuildState` runs with `DateParseHandling.None`, matching `DescentReader.ParseWire`. Newtonsoft's default rewrites every ISO-8601-shaped **string** into a `DateTime`, and re-serialising that emits an invented midnight and an invented offset — which would make "verbatim" a lie for `devotion_last_day`, `day_fill_start`, `history_from` and `relapse.surge_ends_at`. `PostState` now writes the tree with `ToString(Formatting.None)` so nothing sits between the server's tokens and the wire.

## Tests

9 new (`Tests/ConditioningControlPanel.Tests/SpiralEmbedStateV2Tests.cs`), against a full-fat block that includes the five sections the typed reader has no property for:

- reader retains `RawJson`; `JToken.DeepEquals` round-trip against the original node
- date-shaped strings survive — asserted on the stored string *and* on the re-parse
- malformed → null, carrying no raw (tri-state still pinned)
- `BuildState` forwards unchanged, and survives serialisation to the wire
- `descent` absent with a null block, and with a hand-built block
- v1 fields unchanged in both cases

**3120 passed / 0 failed** (baseline 3111 + 9). `dotnet build`: **0 errors, 338 warnings** — identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
