### PR TITLE
feat(fyp): drag-peek for the horizontal tile trade — see the swap before it commits

### DIFF
--- a/ConditioningControlPanel/Resources/web/fyp/feed.js
+++ b/ConditioningControlPanel/Resources/web/fyp/feed.js
@@ -267,6 +267,18 @@ export function createFeed(getAspect) {
   let comps = [];
   let compSeq = 0;
   const history = new Map(); // `${compKey}:${tileIndex}` -> Cut[]
+  // What a drag on one tile is showing before commit (the browser feed's
+  // peekTile map, via the mobile port). Pinned to the cut it was resolved
+  // against — every swap/morph/rebuild regenerates surfaceKeys, so a stale
+  // peek can never install. The ring and the history stack do NOT move at
+  // peek time: an unclaimed candidate rejoins the deck untouched.
+  const peeks = new Map(); // `${compKey}:${tileIndex}` -> { surfaceKey, next?: Cut, back?: { cut, stackIdx } }
+
+  function dropPeeksFor(compKey) {
+    for (const k of peeks.keys()) {
+      if (k.startsWith(compKey + ':')) peeks.delete(k);
+    }
+  }
 
   function activePool() {
     return assets.filter((a) => a.type === 'video' || (includeGifs && a.type === 'gif'));
@@ -304,11 +316,11 @@ export function createFeed(getAspect) {
   }
 
   /**
-   * Fresh weighted pick for one tile: orientation want, page-wide exclusion, and
-   * the outgoing cut pushed onto the tile's history stack. Shared by the 'next'
-   * direction and by 'back' when there is no history to replay.
+   * Fresh weighted pick for one tile: orientation want + page-wide exclusion.
+   * PURE — no ring movement, no history push — so the peek path and the commit
+   * path can share it without a peek leaving fingerprints on the deck.
    */
-  function freshSwap(comp, tileIndex, hKey) {
+  function pickFreshFor(comp, tileIndex) {
     const tile = comp.tiles[tileIndex];
     const stacked = comp.layout !== 'random' && comp.tiles.length > 1;
     let want;
@@ -319,9 +331,11 @@ export function createFeed(getAspect) {
     if (!stacked && pickPool.length < 2) pickPool = candidates;
     const exclude = new Set(comp.tiles.map((t) => t.cut.segId)); // no dupes on the page
     exclude.add(tile.cut.segId);
-    const pick = pickWithMix(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
-    if (!pick) return null;
+    return pickWithMix(pickPool, recent.ring, segCooldownFor(candidates.length), exclude);
+  }
 
+  /** The outgoing cut joins the tile's replay stack (bounded both ways). */
+  function pushHistory(hKey, cut) {
     let stack = history.get(hKey);
     if (!stack) {
       if (history.size >= HISTORY_KEYS_MAX) {
@@ -332,13 +346,8 @@ export function createFeed(getAspect) {
       stack = [];
       history.set(hKey, stack);
     }
-    stack.push(tile.cut);
+    stack.push(cut);
     if (stack.length > HISTORY_MAX) stack.splice(0, stack.length - HISTORY_MAX);
-
-    remember(recent.ring, pick.segId);
-    const cut = toCut(pick);
-    comp.tiles[tileIndex] = { ...tile, cut };
-    return cut;
   }
 
   return {
@@ -362,6 +371,7 @@ export function createFeed(getAspect) {
       if (reset) {
         recent.ring = [];
         history.clear();
+        peeks.clear();
         comps = makeCompositions(PAGE_SIZE);
         // Online ids churn every session and never enter stats (see main.js report),
         // so pruning against LOCAL ids only keeps library stats intact in online mode.
@@ -410,43 +420,121 @@ export function createFeed(getAspect) {
           for (const k of history.keys()) {
             if (k.startsWith(d.key + ':')) history.delete(k);
           }
+          dropPeeksFor(d.key);
         }
       }
       return { appended: appended.length, trimmed: excess };
     },
 
     /**
-     * Swap one tile's cut. dir 'next' = fresh weighted pick, 'back' = pop the
-     * tile's history (replaying the exact same window). A 'back' with nothing
-     * left to replay (first item, or a stack of dead assets) is NOT refused: it
-     * falls through to a fresh pick, so the gesture always yields content and
-     * the caller animates it in whichever direction the user swiped. Returns
-     * null only when the pool itself can offer nothing — the surface springs back.
+     * Resolve what a swap WOULD deal, without dealing it: the drag-peek renders
+     * this riding the strip, and swapTile installs the very same cut on commit.
+     * Cached per tile and pinned to the current cut's surfaceKey, so an aborted
+     * drag shows the same pictures next time, and any swap/morph invalidates by
+     * construction. 'back' answers the topmost alive history entry (found
+     * without popping); a dry stack falls through to a fresh deal — mirroring
+     * exactly what a committed 'back' does. Null = that side has nothing to
+     * offer; the drag rubber-bands there.
+     */
+    peekTile(compKey, tileIndex, dir) {
+      const comp = comps.find((c) => c.key === compKey);
+      const tile = comp?.tiles[tileIndex];
+      if (!comp || !tile) return null;
+      const hKey = `${compKey}:${tileIndex}`;
+      let entry = peeks.get(hKey);
+      if (entry?.surfaceKey !== tile.cut.surfaceKey) {
+        entry = { surfaceKey: tile.cut.surfaceKey };
+        peeks.set(hKey, entry);
+      }
+      if (dir === 'back') {
+        if (!entry.back) {
+          const stack = history.get(hKey);
+          if (stack?.length) {
+            const alive = new Set(candidates.map((c) => c.assetId));
+            for (let i = stack.length - 1; i >= 0; i--) {
+              if (alive.has(stack[i].asset.id)) {
+                // Fresh surfaceKey NOW, so the peeked cut and the committed one
+                // are a single identity; same segId/lenSec/seed replays the
+                // exact window the user swiped away from.
+                entry.back = { cut: { ...stack[i], surfaceKey: nextSurfaceKey() }, stackIdx: i };
+                break;
+              }
+            }
+          }
+          if (!entry.back) {
+            // nothing to go back to: 'back' deals fresh (swapTile parity), so
+            // the peek must show that same fresh deal
+            const pick = pickFreshFor(comp, tileIndex);
+            if (pick) entry.back = { cut: toCut(pick), stackIdx: -1 };
+          }
+        }
+        return entry.back?.cut ?? null;
+      }
+      if (!entry.next) {
+        const pick = pickFreshFor(comp, tileIndex);
+        if (pick) entry.next = toCut(pick);
+      }
+      return entry.next ?? null;
+    },
+
+    /**
+     * Swap one tile's cut. dir 'next' = fresh weighted pick, 'back' = replay
+     * the tile's history (the exact same window). The drag that led here
+     * normally peeked, and the contract is to install EXACTLY the peeked cut —
+     * the user lands on the picture they were looking at; the resolve paths
+     * below only cover a commit that never peeked (chevron click, eye blink).
+     * A 'back' with nothing left to replay is NOT refused: it falls through to
+     * a fresh pick, so the gesture always yields content. Ring and history
+     * move HERE, never at peek time. Returns null only when the pool itself
+     * can offer nothing — the surface springs back.
      */
     swapTile(compKey, tileIndex, dir) {
       const comp = comps.find((c) => c.key === compKey);
       const tile = comp?.tiles[tileIndex];
       if (!comp || !tile) return null;
       const hKey = `${compKey}:${tileIndex}`;
+      const peeked = peeks.get(hKey);
+      const peek = peeked?.surfaceKey === tile.cut.surfaceKey ? peeked : undefined;
+      let cut = null;
+      let fresh = true; // a fresh deal pushes the outgoing cut onto the stack
 
       if (dir === 'back') {
         const stack = history.get(hKey);
-        const alive = new Set(candidates.map((c) => c.assetId));
-        let popped = null;
-        while (stack && stack.length) {
-          const c = stack.pop();
-          if (alive.has(c.asset.id)) { popped = c; break; } // skip cuts whose asset left the pool
+        if (peek?.back) {
+          if (peek.back.stackIdx >= 0) {
+            // Cut the stack at the peeked entry (anything above it was dead at
+            // peek time); a peeked dry-stack 'back' is a fresh deal instead.
+            stack?.splice(peek.back.stackIdx);
+            fresh = false;
+          }
+          cut = peek.back.cut;
+        } else {
+          // no peek: pop as before, skipping cuts whose asset left the pool
+          const alive = new Set(candidates.map((c) => c.assetId));
+          let popped = null;
+          while (stack && stack.length) {
+            const c = stack.pop();
+            if (alive.has(c.asset.id)) { popped = c; break; }
+          }
+          // Same segId/lenSec/seed => the exact same window replays; fresh
+          // surfaceKey so the old surface unmounts (reporting its dwell).
+          if (popped) { cut = { ...popped, surfaceKey: nextSurfaceKey() }; fresh = false; }
         }
-        if (!popped) return freshSwap(comp, tileIndex, hKey); // nothing to go back to
-        // Same segId/lenSec/seed => the exact same window replays; fresh surfaceKey
-        // so the old surface unmounts (reporting its dwell).
-        const restored = { ...popped, surfaceKey: nextSurfaceKey() };
-        remember(recent.ring, restored.segId);
-        comp.tiles[tileIndex] = { ...tile, cut: restored };
-        return restored;
+      } else if (peek?.next) {
+        cut = peek.next;
       }
-
-      return freshSwap(comp, tileIndex, hKey);
+      if (!cut) {
+        const pick = pickFreshFor(comp, tileIndex);
+        if (!pick) return null;
+        cut = toCut(pick);
+      }
+      if (fresh) pushHistory(hKey, tile.cut);
+      remember(recent.ring, cut.segId);
+      // The tile is someone new now: its peeks were pinned to the old cut, so
+      // drop the entry (the pin would refuse them anyway; this frees the slot).
+      peeks.delete(hKey);
+      comp.tiles[tileIndex] = { ...tile, cut };
+      return cut;
     },
 
     /** Re-compose a random-layout page in place (fresh layout + clips). Returns
@@ -459,6 +547,7 @@ export function createFeed(getAspect) {
       for (const k of history.keys()) {
         if (k.startsWith(compKey + ':')) history.delete(k);
       }
+      dropPeeksFor(compKey); // every tile is someone new — stale peeks go too
       comp.gen++;
       comp.tiles = tiles;
       return tiles;

--- a/ConditioningControlPanel/Resources/web/fyp/main.js
+++ b/ConditioningControlPanel/Resources/web/fyp/main.js
@@ -208,6 +208,12 @@ const pageCtx = {
     if (cut && tileIndex === 0 && feed.comps[activeIdx]?.key === compKey) updateCaption();
     return cut;
   },
+  // The trade drag's face-up card: what a swap WOULD deal, resolved without
+  // moving the ring or the history. The slot renders it riding the strip;
+  // a commit installs this very cut (feed.swapTile honours the peek).
+  onPeek(compKey, tileIndex, dir) {
+    return feed.peekTile(compKey, tileIndex, dir);
+  },
   onTapAudio(compKey, tileIndex) {
     const comp = feed.comps.find((c) => c.key === compKey);
     if (comp?.tiles[tileIndex]?.cut.asset.type !== 'video') return;

--- a/ConditioningControlPanel/Resources/web/fyp/surfaces.js
+++ b/ConditioningControlPanel/Resources/web/fyp/surfaces.js
@@ -26,6 +26,9 @@ const COMMIT_VELOCITY = 0.8;  // px/ms
 // follows the pointer (browser-FYP parity).
 const DRAG_LOCK_PX = 8;
 const VELOCITY_WINDOW_MS = 120; // release velocity reads the last ~120ms only
+// Resistance on a trade drag toward a side with nothing to offer (pool too
+// small) — the same give as the pager's feed-edge rubber-band, same reason.
+const DRAG_RUBBER = 0.35;
 const ERROR_ADVANCE_MS = 1200; // never machine-gun a broken pack
 const MAX_ERROR_SWAPS = 3;     // per mounted slot; then the visible fail state stays
 const MORPH_FADE_OUT_MS = 220;
@@ -365,19 +368,60 @@ function createTileSlot(page, tileIndex, ctx) {
     slot.classList.toggle('blurred', !!t.blurred);
   }
 
-  function surfaceCtx(t, preview) {
+  function surfaceCtx(t, preview, peek) {
     return {
       advances: t.advances,
       autoAdvance: ctx.isAutoAdvance(),
       preview: !!preview,
       onEnded: () => ctx.onAdvance(),
       onError: (cut, detail) => {
+        // The host learns about every broken file (#562 strikes), but only the
+        // LIVE occupant self-heals — a broken PEEK must not swap the healthy
+        // tile it is merely riding beside (slideFromPeek re-checks on promote).
         ctx.onMediaError?.(cut.asset, detail);
-        scheduleErrorSwap();
+        if (!peek) scheduleErrorSwap();
       },
       onAssetMeta: ctx.onAssetMeta,
       report: ctx.report,
     };
+  }
+
+  // ---- trade peek (the drag strip) ----
+  // What a horizontal drag shows before it commits: the candidate each
+  // direction would deal, mounted as preview surfaces (paused first frame,
+  // muted, zero dwell) parked exactly one tile-width to each side. The feed
+  // caches the candidates per tile (pinned to the cut's surfaceKey), so the
+  // elements here survive a spring-back and the next drag shows the same
+  // pictures; a commit promotes the peeked element in place — the user lands
+  // on the very frame they were looking at.
+  let peekEls = null; // { forKey, next: { cut, surf }|null, back: { cut, surf }|null }
+
+  function clearPeekEls() {
+    if (!peekEls) return;
+    peekEls.next?.surf.stop();  // zero dwell — reports nothing
+    peekEls.back?.surf.stop();
+    peekEls = null;
+  }
+
+  /** Resolve + mount both candidates (idempotent; cheap after the first call). */
+  function ensurePeekEls() {
+    if (!tile || !surface) return;
+    if (peekEls && peekEls.forKey !== tile.cut.surfaceKey) clearPeekEls();
+    if (!peekEls) peekEls = { forKey: tile.cut.surfaceKey, next: null, back: null };
+    for (const dir of ['next', 'back']) {
+      const cut = ctx.onPeek(tileIndex, dir);
+      const held = peekEls[dir];
+      if (held && (!cut || held.cut.surfaceKey !== cut.surfaceKey)) {
+        held.surf.stop();
+        peekEls[dir] = null;
+      }
+      if (cut && !peekEls[dir]) {
+        const surf = createSurface({ ...cut, fit: tile.fit }, surfaceCtx(tile, true, true));
+        surf.el.style.transform = `translateX(${dir === 'next' ? '' : '-'}100%)`;
+        clip.insertBefore(surf.el, clip.firstChild); // under the live surface
+        peekEls[dir] = { cut, surf };
+      }
+    }
   }
 
   function mount(t, preview) {
@@ -385,6 +429,7 @@ function createTileSlot(page, tileIndex, ctx) {
     tile = t;
     errorSwaps = 0;
     clearErrorSwap();
+    clearPeekEls(); // pinned to the old cut; a remount means someone new
     applyRect(t);
     if (surface) { surface.stop(); surface = null; }
     const s = createSurface({ ...t.cut, fit: t.fit }, surfaceCtx(t, preview));
@@ -397,6 +442,7 @@ function createTileSlot(page, tileIndex, ctx) {
   function unmount() {
     mountGen++;
     clearErrorSwap();
+    clearPeekEls();
     if (surface) { surface.stop(); surface = null; }
     tile = null;
   }
@@ -433,17 +479,74 @@ function createTileSlot(page, tileIndex, ctx) {
     }, SWAP_MS + 40);
   }
 
+  /**
+   * Commit a swap whose incoming is ALREADY on the strip: the peeked preview
+   * slides the rest of the way in and is promoted in place (play() on its
+   * warm, already-seeked element) — the user lands on the exact frame the
+   * drag was showing. The sibling of slideTo, for the peeked path.
+   */
+  function slideFromPeek(cut, dir, held) {
+    const t = tile;
+    if (!t || !surface) return;
+    const gen = mountGen;
+    const w = slot.clientWidth || 1;
+    const outgoing = surface;
+    outgoing.setMuted(true); // the incoming tile carries audio from now on
+    tile = { ...t, cut };
+    const incoming = held.surf;
+    peekEls[dir] = null; // detach before clearing — the promotee must survive
+    clearPeekEls();      // the other side was pinned to the old cut
+    incoming.setPreview(false); // plays while it rides in (slideTo parity)
+    sliding = true;
+    // Two frames: the strip position is inline already; let style flushes land.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      outgoing.el.style.transition = `transform ${SWAP_MS}ms ease-out`;
+      incoming.el.style.transition = `transform ${SWAP_MS}ms ease-out`;
+      outgoing.el.style.transform = `translateX(${dir === 'next' ? -w : w}px)`;
+      incoming.el.style.transform = 'translateX(0)';
+    }));
+    // transitionend is lossy under load — settle on a timer instead.
+    setTimeout(() => {
+      outgoing.stop(); // reports the outgoing cut's dwell
+      sliding = false;
+      if (gen !== mountGen) { incoming.stop(); return; } // slot re-mounted mid-slide
+      incoming.el.style.transition = '';
+      surface = incoming;
+      // The peek was born with the flags of its resolve moment; settle on now.
+      surface.setAutoAdvance(ctx.isAutoAdvance() && !!tile.advances);
+      if (surface.failed) scheduleErrorSwap(); // promoted a dead file (#562)
+      ctx.applyAudio();
+    }, SWAP_MS + 40);
+  }
+
   function springBack() {
     if (!surface) return;
-    surface.el.style.transition = 'transform 200ms ease-out';
-    surface.el.style.transform = 'translateX(0)';
-    setTimeout(() => { if (surface) surface.el.style.transition = ''; }, 240);
+    // The whole strip goes home together: live surface to 0, peeks back to
+    // their parked edges (they stay mounted — the next drag shows the same
+    // pictures without a resolve).
+    const parts = [[surface.el, 'translateX(0)']];
+    if (peekEls?.next) parts.push([peekEls.next.surf.el, 'translateX(100%)']);
+    if (peekEls?.back) parts.push([peekEls.back.surf.el, 'translateX(-100%)']);
+    for (const [pEl, tf] of parts) {
+      pEl.style.transition = 'transform 200ms ease-out';
+      pEl.style.transform = tf;
+    }
+    setTimeout(() => { for (const [pEl] of parts) pEl.style.transition = ''; }, 240);
   }
 
   function commit(dir) {
     const cut = ctx.onSwap(tileIndex, dir);
     if (!cut) { springBack(); return; }
-    slideTo(cut, dir);
+    // The feed installs exactly what it peeked, so a held strip element with
+    // the same identity IS the incoming surface; anything else (chevron or
+    // eye-blink with no prior drag, stale pin) takes the classic cross-slide.
+    const held = peekEls?.[dir];
+    if (held && held.cut.surfaceKey === cut.surfaceKey) {
+      slideFromPeek(cut, dir, held);
+    } else {
+      clearPeekEls();
+      slideTo(cut, dir);
+    }
   }
 
   // Pointer drag. The first DRAG_LOCK_PX of travel lock an axis: 'x' is the
@@ -496,8 +599,23 @@ function createTileSlot(page, tileIndex, ctx) {
       dragAxis = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y';
     }
     if (dragAxis === 'x') {
+      // The strip: live surface + both peeked candidates ride the drag as one
+      // piece, so the trade is visible BEFORE it commits and reversible until
+      // release. A side with no candidate rubber-bands instead of revealing
+      // the tile's backing.
+      ensurePeekEls();
+      const offer = dx < 0 ? peekEls?.next : peekEls?.back;
+      const eff = offer ? dx * DRAG_RESISTANCE : dx * DRAG_RUBBER;
       surface.el.style.transition = 'none';
-      surface.el.style.transform = `translateX(${dx * DRAG_RESISTANCE}px)`;
+      surface.el.style.transform = `translateX(${eff}px)`;
+      if (peekEls?.next) {
+        peekEls.next.surf.el.style.transition = 'none';
+        peekEls.next.surf.el.style.transform = `translateX(calc(100% + ${eff}px))`;
+      }
+      if (peekEls?.back) {
+        peekEls.back.surf.el.style.transition = 'none';
+        peekEls.back.surf.el.style.transform = `translateX(calc(-100% + ${eff}px))`;
+      }
     } else {
       ctx.onPageDragMove(dy);
     }
@@ -583,9 +701,9 @@ function createTileSlot(page, tileIndex, ctx) {
  * One feed page. Created for every composition in the window; media mounts in
  * 'preview' (paused first frame — the pager's neighbours) or 'live' (playing).
  * ctx:
- *   { onAdvance(compKey), onSwap(compKey, i, dir), onTapAudio(compKey, i),
- *     onAssetMeta, report, isAutoAdvance(), isMuted(), audioGlow() -> bool,
- *     audioFocus() -> index|null, isPagerBusy() -> bool,
+ *   { onAdvance(compKey), onSwap(compKey, i, dir), onPeek(compKey, i, dir),
+ *     onTapAudio(compKey, i), onAssetMeta, report, isAutoAdvance(), isMuted(),
+ *     audioGlow() -> bool, audioFocus() -> index|null, isPagerBusy() -> bool,
  *     onPageDragMove(compKey, dy), onPageDragEnd(compKey, dy, vy) }
  */
 export function createPage(comp, ctx) {
@@ -627,6 +745,7 @@ export function createPage(comp, ctx) {
       isPagerBusy: ctx.isPagerBusy,
       onAdvance: () => ctx.onAdvance(comp.key),
       onSwap: (idx, dir) => ctx.onSwap(comp.key, idx, dir),
+      onPeek: (idx, dir) => ctx.onPeek(comp.key, idx, dir),
       onTapAudio: (idx) => { ctx.onTapAudio(comp.key, idx); applyAudio(); },
       onPageDragMove: (dy) => ctx.onPageDragMove(comp.key, dy),
       onPageDragEnd: (dy, vy) => ctx.onPageDragEnd(comp.key, dy, vy),


### PR DESCRIPTION
## What was missing

PR #200 gave the vertical pager live drag-to-peek, but a **horizontal tile trade still dealt its card face down**: the incoming surface was only mounted at commit time (`slideTo`), so nothing was visible beside the outgoing tile until after you'd already swiped. The owner tested mobile PR #7's swap-peek and wants the same on desktop.

## Reference

Browser FYP commit `a2dc138` (`FypFeed.tsx`: `peekTile` + the hDrag strip rendering candidates at `left:±100%`), as translated by mobile PR #7 (ccpmobile `36056b8`): candidates resolved when the x-axis locks, riding the drag strip; commit installs exactly the peeked cut (back-commit splices history at the peeked index); spring-back keeps the candidates; peeks pinned to the tile's `surfaceKey` so a stale peek can never install; ring/history untouched until commit.

## What this does (desktop translation)

- **`feed.js`** — `peekTile(compKey, i, dir)`: resolves what a swap *would* deal — fresh weighted pick forward; topmost **alive** history entry back, found *without popping* (a dry stack peeks the fresh deal a committed 'back' would fall through to, keeping peek and commit identical). Cached per tile, **pinned to the cut's `surfaceKey`** — every swap/morph/rebuild regenerates keys, so stale peeks are structurally uninstallable. **No ring movement, no history mutation at peek time.** `swapTile` now installs exactly the pinned peek (back-commit `splice`s the stack at the peeked index); un-peeked commits (chevron, eye blink) keep the classic resolve. `freshSwap` split into pure `pickFreshFor` + `pushHistory` so both paths share one selection brain. Peek cache cleaned up alongside history on reset/trim/morph.
- **`surfaces.js`** — the slot mounts both candidates as **preview surfaces** (PR #200's paused-first-frame machinery: loaded, seeked, muted, zero dwell) parked at `translateX(±100%)`; the x-drag moves live surface + peeks as one strip. **Commit promotes the peeked element in place** — `play()` on its warm, already-seeked frame; the user lands on the very picture they were looking at. Spring-back parks the strip and keeps the candidates mounted for the next drag. A side with nothing to offer rubber-bands at 0.35 (same give as the pager's feed edges). A broken peek reports its media-error (#562 strikes) but is barred from self-heal-swapping the healthy tile it rides beside — promotion re-checks and heals then.
- **`main.js`** — one `onPeek` passthrough in the page context.

No C#/CSS/HTML changes. Wheel/keyboard, the vertical drag, dwell-once-on-teardown, morph-defers-under-capture: all untouched.

## Verification

`node --check` on all three files. Playwright smoke harness (real page over HTTP, faked `chrome.webview` bridge, ffmpeg clips) extended from 14 to **21 checks — all pass, zero page errors**:

- peek rides the strip mid-drag as a **paused preview**, partially in view before any commit
- sub-threshold release springs back, candidates **stay mounted**, `statCount` unchanged (**zero dwell banked by an uncommitted peek**)
- the second drag shows the **same pinned candidate** (same DOM element)
- commit **promotes the literal peeked element** (marked mid-drag, found as the settled playing surface)
- back-drag peeks the history entry and installs the **exact clip swiped away** (src-identity: peeked src === installed src === original src)
- chevron trade still lands playing
- a dry 2-clip pool refuses with the **0.35 rubber-band** and no peek elements
- the original 14 pager/preview checks from PR #200 all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)