### PR TITLE
chore(mods): repack drone + Circe archives with the 0813 art batch

### DIFF
--- a/ConditioningControlPanel/DroneMod/drone-mode.ccpmod
+++ b/ConditioningControlPanel/DroneMod/drone-mode.ccpmod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27b3c4c34b45465f26a1ad08938ecbef16ca84655f7ffc5f39f6dcd146d9f345
-size 193138515
+oid sha256:1d63643a1f58e893829ac997d1daa85f07d46b5133527b788b4d071d7aaccd5c
+size 216295123

--- a/ConditioningControlPanel/LockedMod/locked-resources.ccpmod
+++ b/ConditioningControlPanel/LockedMod/locked-resources.ccpmod
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:032e7f0de7c9f120c205be40e87cf7284f53d83c545bdec459dcd5d6b0d11d67
-size 131426524
+oid sha256:8b5443c9c6aed3ee29ebaf6ba067204f01f1bbf068c13f4e97df5015a2cb7e01
+size 147737861


### PR DESCRIPTION
﻿Repacks both built-in mod archives with the 0813 nano-banana art batch so the packs stop falling back to Bambi-pink defaults on the resolver-routed surfaces from the mod-aware sweep (PR #198).

- **drone-mode.ccpmod**: +21 override images (7 nav doors, 11 feature tiles, vault backdrop, lockdown icon, fyp banner) plus the mod.json "Drone Skill Tree" rename that had been sitting unpacked in DroneMod\ since the UX restructure.
- **locked-resources.ccpmod**: +18 override images, same slots in the Circe style (no mod.json - manifest is code-defined).

Existing entries are byte-identical to the v6.7.0-cycle archives (CRC-audited against the extracted builtin_mods trees); the drone mod.json swap is the only non-addition. Content packs rebuilt with contentVersion carry-over: the four untouched packs reproduced their published sha256 exactly, mod-drone and mod-locked bump to contentVersion 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
