### PR TITLE
fix(profile): link-Discord notice instead of a Rich Presence error, and stop two achievements re-popping after logout

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -775,6 +775,7 @@
   "label_not_connected": "Nicht verbunden",
   "label_login_to_unlock_exclusive_features": "Anmelden, um exklusive Funktionen freizuschalten",
   "label_link_discord_for_community_features": "Discord verknüpfen für Community-Funktionen",
+  "profile_link_discord_notice": "Verknüpfe dein Discord, um Profilfunktionen freizuschalten: deine öffentliche Karte, Showcase-Pins und Community-Sharing.",
   "label_link_accounts": "Konten verknüpfen",
   "label_link_both_providers_to_access_your_account_fr": "Verknüpfe beide Anbieter, um von beiden Anmeldemethoden auf dein Konto zuzugreifen.",
   "btn_link_patreon": "⭐ Patreon verknüpfen",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -1677,6 +1677,7 @@
   "label_not_connected": "Not Connected",
   "label_login_to_unlock_exclusive_features": "Login to unlock exclusive features",
   "label_link_discord_for_community_features": "Link Discord for community features",
+  "profile_link_discord_notice": "Link your Discord to unlock profile features: your public card, showcase pins, and community sharing.",
   "label_link_accounts": "Link Accounts",
   "label_link_both_providers_to_access_your_account_fr": "Link both providers to access your account from either login method.",
   "btn_link_patreon": "⭐ Link Patreon",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -774,6 +774,7 @@
   "label_not_connected": "No Conectado",
   "label_login_to_unlock_exclusive_features": "Inicia sesión para desbloquear funciones exclusivas",
   "label_link_discord_for_community_features": "Vincula Discord para funciones de comunidad",
+  "profile_link_discord_notice": "Vincula tu Discord para desbloquear las funciones de perfil: tu tarjeta pública, los anclajes de la vitrina y el uso compartido con la comunidad.",
   "label_link_accounts": "Vincular Cuentas",
   "label_link_both_providers_to_access_your_account_fr": "Vincula ambos proveedores para acceder a tu cuenta desde cualquier método de inicio de sesión.",
   "btn_link_patreon": "⭐ Vincular Patreon",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -775,6 +775,7 @@
   "label_not_connected": "Non Connecté",
   "label_login_to_unlock_exclusive_features": "Connecte-toi pour débloquer les fonctionnalités exclusives",
   "label_link_discord_for_community_features": "Lie Discord pour les fonctionnalités communautaires",
+  "profile_link_discord_notice": "Lie ton Discord pour débloquer les fonctionnalités de profil : ta carte publique, les épingles de la vitrine et le partage communautaire.",
   "label_link_accounts": "Lier les Comptes",
   "label_link_both_providers_to_access_your_account_fr": "Lie les deux fournisseurs pour accéder à ton compte depuis l'une ou l'autre méthode de connexion.",
   "btn_link_patreon": "⭐ Lier Patreon",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -774,6 +774,7 @@
   "label_not_connected": "未接続",
   "label_login_to_unlock_exclusive_features": "ログインして限定機能を解除",
   "label_link_discord_for_community_features": "Discordを連携してコミュニティ機能にアクセス",
+  "profile_link_discord_notice": "Discordを連携するとプロフィール機能が使えます: 公開カード、ショーケースのピン、コミュニティ共有。",
   "label_link_accounts": "アカウント連携",
   "label_link_both_providers_to_access_your_account_fr": "両方のプロバイダーを連携して、どちらのログイン方法からでもアカウントにアクセス。",
   "btn_link_patreon": "⭐ Patreon連携",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -774,6 +774,7 @@
   "label_not_connected": "연결되지 않음",
   "label_login_to_unlock_exclusive_features": "전용 기능을 잠금 해제하려면 로그인하세요",
   "label_link_discord_for_community_features": "커뮤니티 기능을 위해 Discord 연결",
+  "profile_link_discord_notice": "Discord를 연결하면 프로필 기능이 열립니다: 공개 카드, 쇼케이스 핀, 커뮤니티 공유.",
   "label_link_accounts": "계정 연결",
   "label_link_both_providers_to_access_your_account_fr": "두 제공자를 모두 연결하면 어느 로그인 방법으로든 계정에 접근할 수 있어요.",
   "btn_link_patreon": "⭐ Patreon 연결",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -774,6 +774,7 @@
   "label_not_connected": "Não Conectado",
   "label_login_to_unlock_exclusive_features": "Entre para desbloquear recursos exclusivos",
   "label_link_discord_for_community_features": "Vincular Discord para recursos da comunidade",
+  "profile_link_discord_notice": "Vincule seu Discord para desbloquear os recursos de perfil: seu cartão público, os fixados da vitrine e o compartilhamento com a comunidade.",
   "label_link_accounts": "Vincular Contas",
   "label_link_both_providers_to_access_your_account_fr": "Vincule ambos os provedores para acessar sua conta de qualquer método de login.",
   "btn_link_patreon": "⭐ Vincular Patreon",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -774,6 +774,7 @@
   "label_not_connected": "Не подключено",
   "label_login_to_unlock_exclusive_features": "Войди, чтобы открыть эксклюзивные функции",
   "label_link_discord_for_community_features": "Привяжи Discord для функций сообщества",
+  "profile_link_discord_notice": "Привяжи Discord, чтобы открыть функции профиля: публичную карточку, закреплённые награды и обмен с сообществом.",
   "label_link_accounts": "Привязка аккаунтов",
   "label_link_both_providers_to_access_your_account_fr": "Привяжи обоих провайдеров, чтобы входить с любого из них.",
   "btn_link_patreon": "⭐ Привязать Patreon",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -1459,6 +1459,7 @@
   "label_not_connected": "未连接",
   "label_login_to_unlock_exclusive_features": "登录以解锁专属功能",
   "label_link_discord_for_community_features": "关联 Discord 以使用社区功能",
+  "profile_link_discord_notice": "关联 Discord 即可解锁个人资料功能：公开卡片、展示柜置顶和社区分享。",
   "label_link_accounts": "关联账号",
   "label_link_both_providers_to_access_your_account_fr": "关联两个平台以便从任一登录方式访问你的账号。",
   "btn_link_patreon": "⭐ 关联 Patreon",

--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -1377,21 +1377,49 @@ namespace ConditioningControlPanel
                 }
             }
 
-            // Sync checkbox states
-            if (s != null)
+            // The tab's own link prompt. The Privacy panel's "Not Connected" line above is inside
+            // the Privacy dialog, so this is the only place a logged-out user is actually told
+            // why the card is empty and what to do about it.
+            if (DiscordTab.ProfileLinkNotice != null)
             {
-                if (DiscordTab.ChkDiscordTabRichPresence != null) DiscordTab.ChkDiscordTabRichPresence.IsChecked = s.DiscordRichPresenceEnabled;
-                if (DiscordTab.ChkDiscordTabShowLevel != null) DiscordTab.ChkDiscordTabShowLevel.IsChecked = s.DiscordShowLevelInPresence;
-                if (DiscordTab.ChkDiscordTabShareAchievements != null) DiscordTab.ChkDiscordTabShareAchievements.IsChecked = s.DiscordShareAchievements;
-                if (DiscordTab.ChkDiscordTabShareLevelUps != null) DiscordTab.ChkDiscordTabShareLevelUps.IsChecked = s.DiscordShareLevelUps;
-                if (DiscordTab.ChkDiscordTabAllowDm != null) DiscordTab.ChkDiscordTabAllowDm.IsChecked = s.AllowDiscordDm;
-                if (DiscordTab.ChkDiscordTabSharePfp != null) DiscordTab.ChkDiscordTabSharePfp.IsChecked = s.ShareProfilePicture;
-                if (DiscordTab.ChkDiscordTabShowOnline != null) DiscordTab.ChkDiscordTabShowOnline.IsChecked = s.ShowOnlineStatus;
-                // Goon Game sharing (all default off). The handlers no-op when the value is
-                // unchanged, so these programmatic assignments never trigger a sync push.
-                if (DiscordTab.ChkGoonShareAvatar != null) DiscordTab.ChkGoonShareAvatar.IsChecked = s.GoonShareAvatar;
-                if (DiscordTab.ChkGoonShareDiscordDm != null) DiscordTab.ChkGoonShareDiscordDm.IsChecked = s.GoonShareDiscordDm;
-                if (DiscordTab.ChkGoonRichPresence != null) DiscordTab.ChkGoonRichPresence.IsChecked = s.GoonRichPresence;
+                DiscordTab.ProfileLinkNotice.Visibility =
+                    App.Settings?.Current?.HasLinkedDiscord == true ? Visibility.Collapsed : Visibility.Visible;
+            }
+
+            // Sync checkbox states.
+            //
+            // Under _isLoading, because these are REPAINTS of stored settings, not user intent.
+            // Without the guard the very first paint of the tab raises Checked on every switch
+            // whose stored value is true, and the handlers treat that as a click:
+            // ChkDiscordRichPresence_Changed answers an unlinked account with a "Discord Rich
+            // Presence requires a linked Discord account" modal, so merely OPENING the Profile
+            // tab while logged out threw an error at the user about a toggle they never touched
+            // (logout clears HasLinkedDiscord but leaves DiscordRichPresenceEnabled standing).
+            // The previous value is saved rather than assumed false because this method is also
+            // called from inside login/link flows that are already loading.
+            var wasLoading = _isLoading;
+            _isLoading = true;
+            try
+            {
+                if (s != null)
+                {
+                    if (DiscordTab.ChkDiscordTabRichPresence != null) DiscordTab.ChkDiscordTabRichPresence.IsChecked = s.DiscordRichPresenceEnabled;
+                    if (DiscordTab.ChkDiscordTabShowLevel != null) DiscordTab.ChkDiscordTabShowLevel.IsChecked = s.DiscordShowLevelInPresence;
+                    if (DiscordTab.ChkDiscordTabShareAchievements != null) DiscordTab.ChkDiscordTabShareAchievements.IsChecked = s.DiscordShareAchievements;
+                    if (DiscordTab.ChkDiscordTabShareLevelUps != null) DiscordTab.ChkDiscordTabShareLevelUps.IsChecked = s.DiscordShareLevelUps;
+                    if (DiscordTab.ChkDiscordTabAllowDm != null) DiscordTab.ChkDiscordTabAllowDm.IsChecked = s.AllowDiscordDm;
+                    if (DiscordTab.ChkDiscordTabSharePfp != null) DiscordTab.ChkDiscordTabSharePfp.IsChecked = s.ShareProfilePicture;
+                    if (DiscordTab.ChkDiscordTabShowOnline != null) DiscordTab.ChkDiscordTabShowOnline.IsChecked = s.ShowOnlineStatus;
+                    // Goon Game sharing (all default off). The handlers no-op when the value is
+                    // unchanged, so these programmatic assignments never trigger a sync push.
+                    if (DiscordTab.ChkGoonShareAvatar != null) DiscordTab.ChkGoonShareAvatar.IsChecked = s.GoonShareAvatar;
+                    if (DiscordTab.ChkGoonShareDiscordDm != null) DiscordTab.ChkGoonShareDiscordDm.IsChecked = s.GoonShareDiscordDm;
+                    if (DiscordTab.ChkGoonRichPresence != null) DiscordTab.ChkGoonRichPresence.IsChecked = s.GoonRichPresence;
+                }
+            }
+            finally
+            {
+                _isLoading = wasLoading;
             }
 
             // Pre-fill search bar with user's unified display name (V2 auth) or fallback

--- a/ConditioningControlPanel/Services/GamificationBridge.cs
+++ b/ConditioningControlPanel/Services/GamificationBridge.cs
@@ -111,20 +111,42 @@ public class GamificationBridge : IDisposable
                 App.RemoteControl.CommandReceived += OnRemoteCommand;
             }
 
-            // Retroactive: best_friends only fires on the CompanionLevelUp *event*, so a
-            // user who already maxed their companion(s) before this achievement existed (or
-            // before the bridge subscribed) never re-triggers it (#308). Check current
-            // companion levels once at startup and unlock if the milestone is already met.
-            CheckExistingCompanionMilestone();
+            // Both calls below REPAIR an unlock the user already earned — they reconstruct it
+            // from state that outlived the achievement file (companion level, the chat turn log)
+            // rather than witnessing a fresh earn — so they run SILENTLY, exactly as the
+            // post-login cloud restore does. Celebrating a reconstruction was wrong twice over:
+            // logout deliberately wipes achievements.json (ClearProgressionData) while companion
+            // progress and the turn log survive it, so "Best Friends" and "Pleased to Meet You"
+            // popped again on EVERY launch that followed a logout — and re-posted to Discord
+            // with them. The unlock itself is still recorded, saved and cloud-synced; only the
+            // popup/sound/webhook are skipped.
+            //
+            // The prior flag value is saved rather than assumed false so a cloud restore that is
+            // already suppressing cannot be un-suppressed on the way out of this block.
+            var ach = Ach;
+            var wasSuppressed = ach?.SuppressPopups ?? false;
+            if (ach != null) ach.SuppressPopups = true;
+            try
+            {
+                // Retroactive: best_friends only fires on the CompanionLevelUp *event*, so a
+                // user who already maxed their companion(s) before this achievement existed (or
+                // before the bridge subscribed) never re-triggers it (#308). Check current
+                // companion levels once at startup and unlock if the milestone is already met.
+                CheckExistingCompanionMilestone();
 
-            // Retroactive: the companion-chat counter was fed by exactly one call site (the
-            // tube's legacy send handler), so every message that went through the modern brain
-            // funnel — and everything ever typed in Her Room — counted for nothing (#877).
-            // Long-time chatters would otherwise start over from zero, so put a BEST-EFFORT
-            // FLOOR under the counter once, from the little the companion happened to persist.
-            // It does not recover the true history (nothing on disk can) — see the method
-            // summary for exactly how far it reaches and what it cannot restore.
-            BackfillCompanionChatCount();
+                // Retroactive: the companion-chat counter was fed by exactly one call site (the
+                // tube's legacy send handler), so every message that went through the modern brain
+                // funnel — and everything ever typed in Her Room — counted for nothing (#877).
+                // Long-time chatters would otherwise start over from zero, so put a BEST-EFFORT
+                // FLOOR under the counter once, from the little the companion happened to persist.
+                // It does not recover the true history (nothing on disk can) — see the method
+                // summary for exactly how far it reaches and what it cannot restore.
+                BackfillCompanionChatCount();
+            }
+            finally
+            {
+                if (ach != null) ach.SuppressPopups = wasSuppressed;
+            }
 
             App.Logger?.Information("GamificationBridge started — achievement subscriptions wired");
         }

--- a/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml
@@ -91,6 +91,32 @@
                                 Tag="DiscordProfile"/>
                     </Grid>
 
+                    <!-- Link-your-account notice. Up only while no Discord is linked
+                         (MainWindow.Browser.cs UpdateDiscordTabUI). The Privacy panel's own
+                         "Not Connected" line cannot do this job: that panel lives inside the
+                         Privacy DIALOG, so a logged-out user opening this tab never sees it -
+                         which is how the only feedback they got was an unrelated Rich Presence
+                         modal. Inline and quiet on purpose; the tab still shows the local card
+                         underneath, so this informs rather than blocks. -->
+                    <Border x:Name="ProfileLinkNotice" x:FieldModifier="internal" Visibility="Collapsed"
+                            Background="#22212A44" BorderBrush="#5865F2" BorderThickness="1"
+                            CornerRadius="10" Padding="14,11" Margin="0,0,0,14">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" TextWrapping="Wrap"
+                                       Text="{loc:Str profile_link_discord_notice}"
+                                       Foreground="{DynamicResource TextSecondaryBrush}" FontSize="12"/>
+                            <Button Grid.Column="1" x:Name="BtnProfileLinkNotice" x:FieldModifier="internal"
+                                    Content="{loc:Str btn_link_discord_2}" Background="#5865F2"
+                                    Foreground="White" BorderThickness="0" Padding="15,8" Margin="12,0,0,0"
+                                    FontWeight="Bold" FontSize="11" Cursor="Hand"
+                                    Click="BtnDiscordTabLogin_Click"/>
+                        </Grid>
+                    </Border>
+
                     <!-- ===================== 2. the hero ===================== -->
                     <Grid x:Name="ProfileCardWrapper" x:FieldModifier="internal" Visibility="Collapsed"
                           Margin="0,0,0,14">

--- a/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml.cs
+++ b/ConditioningControlPanel/Views/Tabs/DiscordTabView.xaml.cs
@@ -101,6 +101,16 @@ namespace ConditioningControlPanel.Views.Tabs
             if (Window.GetWindow(this) is MainWindow mw)
                 mw.BtnViewMyProfile_Click(sender, e);
         }
+        /// <summary>
+        /// The link-notice button reuses the Privacy panel's login/link flow verbatim - that
+        /// handler drives BtnDiscordTabLogin (which lives on the long-lived panel instance and
+        /// is therefore addressable whether or not the dialog is open).
+        /// </summary>
+        private void BtnDiscordTabLogin_Click(object sender, RoutedEventArgs e)
+        {
+            if (Window.GetWindow(this) is MainWindow mw)
+                mw.BtnDiscordTabLogin_Click(sender, e);
+        }
         private void BtnProfilePrivacy_Click(object sender, RoutedEventArgs e)
         {
             if (Window.GetWindow(this) is MainWindow mw)


### PR DESCRIPTION
Two logged-out papercuts, both caused by state that outlives a logout.

## 1. Profile tab errored about Rich Presence

Opening the Profile tab while not logged in showed **"Discord Rich Presence requires a linked Discord account"** for a toggle the user never touched.

`UpdateDiscordTabUI` repaints ~10 switches from settings without the `_isLoading` re-entrancy guard, so the tab's first paint raises `Checked` and `ChkDiscordRichPresence_Changed` treats the repaint as a click. Logout clears `HasLinkedDiscord` but leaves `DiscordRichPresenceEnabled` standing, which is why only logged-out users hit it. The Home quick-toggle twin (`MainWindow.xaml.cs:2751`) already carried this exact guard, with a comment naming this exact scenario - the Profile-tab copy was missed.

Guarded the repaint block, saving/restoring the prior flag because login and link flows call this method while already loading.

### ...and the message that should have been there

The "Not Connected / Link Discord" line lives on `ProfilePrivacyPanel`, which sits inside the Privacy **dialog** - a logged-out user opening the tab never sees it, so the wrong modal was their only feedback. The tab now carries its own inline notice, visible only while no Discord is linked:

> Link your Discord to unlock profile features: your public card, showcase pins, and community sharing.

with a **Link Discord** button reusing the existing login/link flow. New key `profile_link_discord_notice` in all 9 language files (strict-JSON validated, one-line diffs, no line-ending churn).

## 2. Best Friends / Pleased to Meet You re-popped on every launch after a logout

From the reporter's log:

```
19:33:34  Patreon logout completed ...
20:33:07  AchievementService initialized. 0 achievements unlocked.
20:33:09  Achievement unlocked: Best Friends
20:33:11  Achievement unlocked: Pleased to Meet You
```

Logout calls `ClearProgressionData` -> `Achievements.ResetProgress()`, which is intended (achievements are per-account). But companion level and the chat turn log are **not** account data and survive it, so `GamificationBridge`'s two retroactive repair paths (`CheckExistingCompanionMilestone` for #308, `BackfillCompanionChatCount` for #877) re-derived those two unlocks on the very next launch - with popup, sound, and a Discord webhook attempt. Every other achievement needs a live event, which is why only these two ever came back. Cloud restore then silently refilled the rest, so the file looks fine afterwards and the symptom reads as "random re-triggers on rebuild".

Both repair paths now run under `SuppressPopups`, the same treatment the post-login cloud restore already gets. The unlock is still recorded, saved and cloud-synced; only the celebration and the webhook are skipped. Reconstructing an old unlock is not a fresh earn.

## Verification

`dotnet build` - 0 errors. All 9 language files parse strictly.

Not play-tested: the reporter's app was running and holding the exe lock, so the build went to a temp output dir rather than killing their session. Worth a manual pass on (a) Profile tab logged out - notice up, no modal, and (b) logout -> restart - no achievement popups.

Generated with [Claude Code](https://claude.com/claude-code)
