### PR TITLE
fix(assets): remove the Scrolller blocklist that nothing could ever feed

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4355,8 +4355,6 @@
   "label_remote_niches_shared": "Wird mit dem For-You-Feed geteilt - eine Auswahl, beide Orte.",
   "label_remote_custom_subs": "Deine eigenen Subreddits",
   "tooltip_remote_custom_sub_add": "Gib einen Subreddit-Namen ein (das r/ ist optional) oder füge den Link ein, dann drücke Hinzufügen.",
-  "label_remote_blocklist": "Blockiert",
-  "btn_remote_clear_blocklist": "Blockliste leeren",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "Der Session-Shop - Drop aussuchen und los",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -4900,8 +4900,6 @@
   "label_remote_niches_shared": "Shared with the For You feed - one selection, both places.",
   "label_remote_custom_subs": "Your own subreddits",
   "tooltip_remote_custom_sub_add": "Type a subreddit name (the r/ is optional) or paste its link, then press Add.",
-  "label_remote_blocklist": "Blocked",
-  "btn_remote_clear_blocklist": "Clear blocklist",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "The session shop - pick a drop and go",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4346,8 +4346,6 @@
   "label_remote_niches_shared": "Compartido con el feed For You - una sola selección, los dos sitios.",
   "label_remote_custom_subs": "Tus propios subreddits",
   "tooltip_remote_custom_sub_add": "Escribe el nombre de un subreddit (la r/ es opcional) o pega su enlace, y pulsa Añadir.",
-  "label_remote_blocklist": "Bloqueados",
-  "btn_remote_clear_blocklist": "Vaciar lista de bloqueo",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "La tienda de sesiones: elige un drop y a jugar",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4355,8 +4355,6 @@
   "label_remote_niches_shared": "Partagé avec le fil For You - une seule sélection, aux deux endroits.",
   "label_remote_custom_subs": "Tes propres subreddits",
   "tooltip_remote_custom_sub_add": "Saisis un nom de subreddit (le r/ est facultatif) ou colle son lien, puis appuie sur Ajouter.",
-  "label_remote_blocklist": "Bloqués",
-  "btn_remote_clear_blocklist": "Vider la liste de blocage",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "La boutique de sessions - choisis un drop et c'est parti",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4346,8 +4346,6 @@
   "label_remote_niches_shared": "For You フィードと共有されます - 選択はひとつ、どちらにも反映されます。",
   "label_remote_custom_subs": "自分のサブレディット",
   "tooltip_remote_custom_sub_add": "サブレディット名を入力するか（r/ は省略可）、リンクを貼り付けて「追加」を押してください。",
-  "label_remote_blocklist": "ブロック済み",
-  "btn_remote_clear_blocklist": "ブロックリストを消去",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "セッションショップ - ドロップを選んですぐプレイ",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4353,8 +4353,6 @@
   "label_remote_niches_shared": "For You 피드와 공유됩니다 - 선택은 하나, 두 곳 모두에 적용됩니다.",
   "label_remote_custom_subs": "내 서브레딧",
   "tooltip_remote_custom_sub_add": "서브레딧 이름을 입력하거나(r/ 는 생략 가능) 링크를 붙여넣은 뒤 추가를 누르세요.",
-  "label_remote_blocklist": "차단됨",
-  "btn_remote_clear_blocklist": "차단 목록 비우기",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "세션 상점 - 드롭을 골라 바로 시작",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4354,8 +4354,6 @@
   "label_remote_niches_shared": "Compartilhado com o feed For You - uma seleção, os dois lugares.",
   "label_remote_custom_subs": "Seus próprios subreddits",
   "tooltip_remote_custom_sub_add": "Digite o nome de um subreddit (o r/ é opcional) ou cole o link e clique em Adicionar.",
-  "label_remote_blocklist": "Bloqueados",
-  "btn_remote_clear_blocklist": "Limpar lista de bloqueio",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "A loja de sessões - escolha um drop e vá",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4353,8 +4353,6 @@
   "label_remote_niches_shared": "Общее с лентой For You - один выбор, оба места.",
   "label_remote_custom_subs": "Твои сабреддиты",
   "tooltip_remote_custom_sub_add": "Введи название сабреддита (r/ необязательно) или вставь ссылку, затем нажми «Добавить».",
-  "label_remote_blocklist": "Заблокировано",
-  "btn_remote_clear_blocklist": "Очистить список блокировки",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "Магазин сессий - выбери дроп и вперёд",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -4813,8 +4813,6 @@
   "label_remote_niches_shared": "与 For You 信息流共用 - 选一次，两处生效。",
   "label_remote_custom_subs": "你自己的子版块",
   "tooltip_remote_custom_sub_add": "输入子版块名称（r/ 可省略）或粘贴其链接，然后点击添加。",
-  "label_remote_blocklist": "已屏蔽",
-  "btn_remote_clear_blocklist": "清空屏蔽列表",
   "_comment_justdrop": "JustDrop door (2026-08-11): the web session shop, hosted in a WebView2 door",
   "jd_door_title": "Just Drop",
   "jd_door_tip": "会话商店 - 挑一个 drop 就开始",

--- a/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
@@ -2154,8 +2154,6 @@ namespace ConditioningControlPanel
                         tab.SliderRemoteRatio.ValueChanged += SliderRemoteRatio_Changed;
                     if (tab.BtnRemoteAddSub != null)
                         tab.BtnRemoteAddSub.Click += BtnRemoteAddSub_Click;
-                    if (tab.BtnRemoteClearBlocklist != null)
-                        tab.BtnRemoteClearBlocklist.Click += BtnRemoteClearBlocklist_Click;
                     if (tab.TxtRemoteCustomSub != null)
                         tab.TxtRemoteCustomSub.KeyDown += TxtRemoteCustomSub_KeyDown;
                 }
@@ -2243,15 +2241,10 @@ namespace ConditioningControlPanel
                     tab.RemoteRatioRow.Visibility = string.Equals(source, MediaSrcMixed, StringComparison.Ordinal)
                         ? Visibility.Visible : Visibility.Collapsed;
 
-                var blockedSubs = settings.RemoteMediaBlockedSubs;
-                var blockedIds = settings.RemoteMediaBlockedIds;
-
-                // Folded away while the app runs on local files only - except when there is a
-                // blocklist, which must stay reviewable whatever the source is set to.
+                // Folded away while the app runs on local files only.
                 if (tab.RemoteMediaDetails != null)
                     tab.RemoteMediaDetails.Visibility =
                         !string.Equals(source, MediaSrcLocal, StringComparison.Ordinal)
-                        || blockedSubs.Count > 0 || blockedIds.Count > 0
                             ? Visibility.Visible : Visibility.Collapsed;
 
                 var selected = new HashSet<string>(settings.FypOnlineNiches ?? new List<string>(),
@@ -2260,7 +2253,6 @@ namespace ConditioningControlPanel
                     chip.IsChecked = chip.Tag is string id && selected.Contains(id);
 
                 RebuildRemoteCustomSubChips(settings);
-                RebuildRemoteBlocklist(settings, blockedSubs, blockedIds);
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "Remote media picker refresh failed"); }
             finally { _remotePickerSyncing = false; }
@@ -2321,7 +2313,7 @@ namespace ConditioningControlPanel
                     "Pull media from Reddit?\n\n" +
                     "The app will stream images and clips from the subreddits you pick, straight from your own machine. " +
                     "Nothing is saved to your disk, nothing is uploaded, and none of it goes through our servers.\n\n" +
-                    "It is adult content and it is not curated by us - you choose the niches, and you can block anything you don't want to see again.\n\n" +
+                    "It is adult content and it is not curated by us - you choose the niches and subreddits, and only those are ever fetched.\n\n" +
                     "Turn it on?"),
                 LocOr("title_remote_media_consent", "Use Reddit media?"),
                 MessageBoxButton.YesNo, MessageBoxImage.Question);
@@ -2407,18 +2399,6 @@ namespace ConditioningControlPanel
 
                 PersistRemoteChannelChange();
                 RefreshRemoteMediaPicker();
-
-                // Adding a sub that is on the blocklist looks like the Add button doing nothing:
-                // the block wins, everywhere, by design. Say so rather than silently overriding
-                // an earlier "never show me this again".
-                if (settings.RemoteMediaBlockedSubs.Any(x => string.Equals(x, clean, StringComparison.OrdinalIgnoreCase)))
-                {
-                    MessageBox.Show(this,
-                        string.Format(LocOr("msg_remote_sub_is_blocked_0",
-                            "r/{0} is on your blocklist, so it stays hidden until you unblock it below."), clean),
-                        LocOr("title_remote_sub_is_blocked", "Still blocked"),
-                        MessageBoxButton.OK, MessageBoxImage.Information);
-                }
             }
             catch (Exception ex) { App.Logger?.Warning(ex, "Adding a custom subreddit failed"); }
         }
@@ -2436,46 +2416,7 @@ namespace ConditioningControlPanel
             RefreshRemoteMediaPicker();
         }
 
-        private void UnblockRemoteSub(string sub)
-        {
-            var settings = App.Settings?.Current;
-            if (settings == null) return;
-
-            var list = new List<string>(settings.RemoteMediaBlockedSubs);
-            list.RemoveAll(x => string.Equals(x, sub, StringComparison.OrdinalIgnoreCase));
-            settings.RemoteMediaBlockedSubs = list;
-
-            PersistRemoteChannelChange();
-            RefreshRemoteMediaPicker();
-            App.Logger?.Information("[remote media] unblocked r/{Sub}", sub);
-        }
-
-        private void BtnRemoteClearBlocklist_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                var settings = App.Settings?.Current;
-                if (settings == null) return;
-                if (settings.RemoteMediaBlockedSubs.Count == 0 && settings.RemoteMediaBlockedIds.Count == 0) return;
-
-                var confirm = MessageBox.Show(this,
-                    LocOr("msg_remote_clear_blocklist_confirm",
-                        "Unblock everything?\n\nEvery subreddit and every individual post you have blocked can show up again. This can't be undone."),
-                    LocOr("title_remote_clear_blocklist", "Clear blocklist"),
-                    MessageBoxButton.YesNo, MessageBoxImage.Warning);
-                if (confirm != MessageBoxResult.Yes) return;
-
-                settings.RemoteMediaBlockedSubs = new List<string>();
-                settings.RemoteMediaBlockedIds = new List<string>();
-
-                PersistRemoteChannelChange();
-                RefreshRemoteMediaPicker();
-                App.Logger?.Information("[remote media] blocklist cleared");
-            }
-            catch (Exception ex) { App.Logger?.Warning(ex, "Clearing the remote blocklist failed"); }
-        }
-
-        /// <summary>Niche / custom-sub / blocklist edits all land the same way: settings do not
+        /// <summary>Niche / custom-sub edits all land the same way: settings do not
         /// autosave (the lists are replaced, not observed) and every consumer's rotation state
         /// was built from the old set.</summary>
         private void PersistRemoteChannelChange()
@@ -2501,34 +2442,6 @@ namespace ConditioningControlPanel
             if (host.Children.Count == 0)
                 host.Children.Add(MutedRemoteNote(LocOr("label_remote_custom_subs_none",
                     "None yet - the niches above are plenty to start with.")));
-        }
-
-        private void RebuildRemoteBlocklist(Models.AppSettings settings, List<string> subs, List<string> ids)
-        {
-            if (AssetsTab?.TxtRemoteBlocklistSummary is TextBlock summary)
-            {
-                summary.Text = subs.Count == 0 && ids.Count == 0
-                    ? LocOr("label_remote_blocklist_empty",
-                        "Nothing blocked yet. Whatever you block here is gone from every part of the app.")
-                    : string.Format(LocOr("label_remote_blocklist_summary_0_1",
-                        "{0} subreddits and {1} individual posts blocked."), subs.Count, ids.Count);
-            }
-            if (AssetsTab?.BtnRemoteClearBlocklist != null)
-                AssetsTab.BtnRemoteClearBlocklist.IsEnabled = subs.Count > 0 || ids.Count > 0;
-
-            var host = AssetsTab?.RemoteBlockedChips;
-            if (host == null) return;
-
-            host.Children.Clear();
-            foreach (var sub in subs.ToList())
-            {
-                var name = sub;
-                host.Children.Add(BuildRemoteChip($"r/{name}",
-                    LocOr("tooltip_remote_unblock_sub", "Unblock this subreddit"),
-                    () => UnblockRemoteSub(name)));
-            }
-            // Blocked post ids have no name worth showing - they are summarised in the line
-            // above and cleared with everything else.
         }
 
         /// <summary>A removable pill. Same look as the niche toggles, with the companion tab's

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -3140,70 +3140,12 @@ namespace ConditioningControlPanel.Models
             set { _fypOnlineConsented = value; OnPropertyChanged(); }
         }
 
-        // ---- remote-media blocklist (app-wide, not FYP-only) ----
-        //
-        // The user's only content control over remote media, and deliberately the ONLY one:
-        // there is no NSFW filter and no safe-mode toggle (owner decision 2026-08-12). The
-        // niche catalog is entirely adult, so filtering on scrolller's isNsfw would empty the
-        // pool rather than shape it — that field stays fetched-and-unread on purpose.
-        //
-        // RemoteMedia* rather than FypOnline* because every consumer of the remote pool
-        // (feed, flashes, intake, DTRH) shares one blocklist, applied in FypOnlineCoordinator
-        // before entries reach any pool. Both are edited in place by the picker, so callers
-        // must App.Settings.Save() themselves — nothing here auto-persists.
-
-        private List<string> _remoteMediaBlockedSubs = new();
-        /// <summary>Subreddits the user never wants to see again (bare names, no "r/").
-        /// Excluded from every consumer's active channel set.</summary>
-        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public List<string> RemoteMediaBlockedSubs
-        {
-            get => _remoteMediaBlockedSubs;
-            set
-            {
-                var clean = new List<string>();
-                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var raw in value ?? new List<string>())
-                {
-                    var sub = ConditioningControlPanel.Services.Fyp.Online.FypOnlineCoordinator.SanitizeSub(raw);
-                    if (sub != null && seen.Add(sub)) clean.Add(sub);
-                }
-                // Over the cap the OLDEST entries go: a fresh block is the one the user just
-                // asked for, and silently dropping it would read as the button not working.
-                if (clean.Count > MaxRemoteMediaBlockedSubs)
-                    clean.RemoveRange(0, clean.Count - MaxRemoteMediaBlockedSubs);
-                _remoteMediaBlockedSubs = clean;
-                OnPropertyChanged();
-            }
-        }
-
-        private List<string> _remoteMediaBlockedIds = new();
-        /// <summary>Individual remote entries the user blocked, by entry id
-        /// ("scrolller/&lt;sub&gt;/&lt;post&gt;"). Filtered out of every fetched page.</summary>
-        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
-        public List<string> RemoteMediaBlockedIds
-        {
-            get => _remoteMediaBlockedIds;
-            set
-            {
-                var clean = new List<string>();
-                var seen = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var raw in value ?? new List<string>())
-                {
-                    if (string.IsNullOrWhiteSpace(raw)) continue;
-                    var id = raw.Trim();
-                    if (id.Length > 120) continue;   // an id this long isn't one of ours
-                    if (seen.Add(id)) clean.Add(id);
-                }
-                if (clean.Count > MaxRemoteMediaBlockedIds)
-                    clean.RemoveRange(0, clean.Count - MaxRemoteMediaBlockedIds);
-                _remoteMediaBlockedIds = clean;
-                OnPropertyChanged();
-            }
-        }
-
-        private const int MaxRemoteMediaBlockedSubs = 200;
-        private const int MaxRemoteMediaBlockedIds = 1000;
+        // NOTE: a remote-media blocklist (RemoteMediaBlockedSubs / RemoteMediaBlockedIds)
+        // lived here until 2026-08-14. Nothing in the UI could ever add to it, so it was
+        // removed rather than finished: picking the niches/subreddits IS the content control,
+        // and there is still no NSFW filter (owner decision 2026-08-12 — the catalog is
+        // entirely adult, filtering on scrolller's isNsfw would empty the pool). Stale keys
+        // in settings.json are simply ignored on load.
 
         // ---- app-wide media source ----
         //

--- a/ConditioningControlPanel/Services/Chaos/DtrhAssetManifest.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhAssetManifest.cs
@@ -354,31 +354,14 @@ internal static class DtrhAssetManifest
     }
 
     /// <summary>
-    /// Drop entries older than the TTL (a CDN url is not forever) and anything the user has
-    /// blocked SINCE it was cached. The coordinator's blocklist runs before entries ever
-    /// reach the cache, but this pool outlives the session that filled it, so a block made
-    /// today has to reach yesterday's cache too - otherwise "block this subreddit" would be
-    /// visibly ignored for up to the TTL. Caller holds <see cref="RemoteLock"/>.
+    /// Drop entries older than the TTL (a CDN url is not forever). Caller holds
+    /// <see cref="RemoteLock"/>.
     /// </summary>
     private static void PruneRemoteLocked()
     {
         if (_remoteCache == null) return;
         long cutoff = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - (long)RemoteEntryTtl.TotalSeconds;
         _remoteCache.RemoveAll(e => e.AtUnix < cutoff);
-
-        var s = App.Settings?.Current;
-        var subs = new HashSet<string>(s?.RemoteMediaBlockedSubs ?? new List<string>(),
-            StringComparer.OrdinalIgnoreCase);
-        var ids = new HashSet<string>(s?.RemoteMediaBlockedIds ?? new List<string>(), StringComparer.Ordinal);
-        if (subs.Count > 0 || ids.Count > 0)
-        {
-            _remoteCache.RemoveAll(e =>
-            {
-                if (ids.Contains(e.Id)) return true;
-                var parts = e.Id.Split('/');
-                return parts.Length >= 3 && subs.Contains(parts[1]);
-            });
-        }
 
         if (_remoteCache.Count > MaxRemoteEntries)
             _remoteCache.RemoveRange(0, _remoteCache.Count - MaxRemoteEntries);

--- a/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
+++ b/ConditioningControlPanel/Services/Fyp/Online/FypOnlineCoordinator.cs
@@ -107,8 +107,8 @@ internal sealed class FypOnlineCoordinator
         foreach (var c in all) c.Save();
     }
 
-    /// <summary>The blocklist changed (it is app-wide, unlike niche selection): drop every
-    /// tenant's rotation state so blocked subs leave the active sets immediately.</summary>
+    /// <summary>A channel-shaping setting changed app-wide (media source, niche selection,
+    /// custom subs): drop every tenant's rotation state so the new set takes effect at once.</summary>
     public static void ResetAllChannels()
     {
         List<FypOnlineCoordinator> all;
@@ -150,7 +150,7 @@ internal sealed class FypOnlineCoordinator
     }
 
     /// <summary>The subreddits this consumer's settings currently select, before the
-    /// blocklist and the dedupe cap. Never throws: a provider that fails means "no
+    /// dedupe cap. Never throws: a provider that fails means "no
     /// channels", which <see cref="ActiveChannels"/> turns into the catalog fallback.</summary>
     private IReadOnlyList<string> ProvidedChannels()
     {
@@ -186,19 +186,17 @@ internal sealed class FypOnlineCoordinator
         return ResolveChannels(s?.FypOnlineNiches, s?.FypOnlineCustomSubs);
     }
 
-    /// <summary>Channel names currently in play for this consumer (its selection minus the
-    /// user's blocked subs; the first catalog niche when nothing is selected, so "Online" can
-    /// never mean "nothing" — unless the user blocked that too, which is their call).</summary>
+    /// <summary>Channel names currently in play for this consumer (its selection, with the
+    /// first catalog niche as fallback when nothing is selected, so "Online" can never mean
+    /// "nothing").</summary>
     public List<string> ActiveChannels()
     {
-        var blocked = BlockedSubs();
         var distinct = ProvidedChannels()
-            .Where(name => !blocked.Contains(name))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Take(MaxChannels)
             .ToList();
         if (distinct.Count == 0)
-            distinct.AddRange(Catalog[0].Subs.Where(name => !blocked.Contains(name)));
+            distinct.AddRange(Catalog[0].Subs);
         return distinct;
     }
 
@@ -214,85 +212,14 @@ internal sealed class FypOnlineCoordinator
         return s.Length is >= 2 and <= 40 ? s : null;
     }
 
-    // ---- blocklist (B4) ------------------------------------------------------------
-    //
-    // The ONE choke point: blocked subs never reach an active channel set and blocked entry
-    // ids never reach a pool, so every consumer built on this class inherits the filter for
-    // free. Deliberately NOT an NSFW filter — scrolller's isNsfw is fetched by the query and
-    // read by nothing here (or in the mobile / web ports), because the whole niche catalog is
+    // There is deliberately NO content filter between the query and the pool: picking the
+    // subreddits IS the content control. Scrolller's isNsfw is fetched by the query and read
+    // by nothing here (or in the mobile / web ports), because the whole niche catalog is
     // adult: filtering on it would empty the pool rather than shape it. Owner decision
-    // 2026-08-12; leave isNsfw unread, it is not an oversight.
+    // 2026-08-12; leave isNsfw unread, it is not an oversight. (A per-sub/per-post blocklist
+    // existed here until 2026-08-14 but nothing ever fed it, so it was removed.)
 
-    private static HashSet<string> BlockedSubs()
-    {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var s in App.Settings?.Current?.RemoteMediaBlockedSubs ?? new List<string>())
-            if (!string.IsNullOrWhiteSpace(s)) set.Add(s);
-        return set;
-    }
-
-    private static HashSet<string> BlockedIds()
-    {
-        var set = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var s in App.Settings?.Current?.RemoteMediaBlockedIds ?? new List<string>())
-            if (!string.IsNullOrWhiteSpace(s)) set.Add(s);
-        return set;
-    }
-
-    /// <summary>Block a whole subreddit, everywhere, and persist immediately (settings saving
-    /// is manual). Rotation state is dropped so the sub leaves every active set at once.</summary>
-    public static void BlockSub(string? raw)
-    {
-        var sub = SanitizeSub(raw);
-        var s = App.Settings?.Current;
-        if (sub == null || s == null) return;
-        try
-        {
-            var list = new List<string>(s.RemoteMediaBlockedSubs) { sub };
-            s.RemoteMediaBlockedSubs = list;      // the setter sanitizes, dedupes and caps
-            App.Settings?.Save();
-            ResetAllChannels();
-            App.Logger?.Information("[remote media] blocked r/{Sub}", sub);
-        }
-        catch (Exception ex) { App.Logger?.Debug("FypOnline: block sub failed: {E}", ex.Message); }
-    }
-
-    /// <summary>Block one entry by id ("scrolller/&lt;sub&gt;/&lt;post&gt;") and persist. Channels
-    /// are left alone — one dud post says nothing about the rest of its subreddit.</summary>
-    public static void BlockEntry(string? entryId)
-    {
-        var s = App.Settings?.Current;
-        if (string.IsNullOrWhiteSpace(entryId) || s == null) return;
-        try
-        {
-            var list = new List<string>(s.RemoteMediaBlockedIds) { entryId.Trim() };
-            s.RemoteMediaBlockedIds = list;
-            App.Settings?.Save();
-            App.Logger?.Information("[remote media] blocked entry {Id}", entryId);
-        }
-        catch (Exception ex) { App.Logger?.Debug("FypOnline: block entry failed: {E}", ex.Message); }
-    }
-
-    /// <summary>Entry ids look like "scrolller/&lt;sub&gt;/&lt;post&gt;"; the middle segment is
-    /// re-checked against the blocked subs so an entry can't slip through on a channel that
-    /// was blocked after the page was already in flight.</summary>
-    private static List<FypAssetManifest.Entry> ApplyBlocklist(List<FypAssetManifest.Entry> entries)
-    {
-        var ids = BlockedIds();
-        var subs = BlockedSubs();
-        if (ids.Count == 0 && subs.Count == 0) return entries;
-        var kept = new List<FypAssetManifest.Entry>(entries.Count);
-        foreach (var e in entries)
-        {
-            if (ids.Contains(e.Id)) continue;
-            var parts = e.Id.Split('/');
-            if (parts.Length >= 3 && subs.Contains(parts[1])) continue;
-            kept.Add(e);
-        }
-        return kept;
-    }
-
-    /// <summary>Niche selection / custom subs / blocklist changed: drop rotation state
+    /// <summary>Niche selection / custom subs changed: drop rotation state
     /// (iterators, dead flags, backoff) but keep the learned dwell — taste survives a
     /// channel reshuffle.</summary>
     public void ResetChannels()
@@ -341,7 +268,7 @@ internal sealed class FypOnlineCoordinator
     /// <summary>
     /// Fetch the next batch of entries from the rotation, in this consumer's media kind.
     /// Returns (entries, error): a null error with zero entries means "nothing new right
-    /// now" (all channels dry, cooling down or fully blocked), a non-null error means the
+    /// now" (all channels dry or cooling down), a non-null error means the
     /// API itself is unreachable. Runs off the UI thread.
     /// </summary>
     public Task<(List<FypAssetManifest.Entry> Entries, string? Error)> FetchBatchAsync(CancellationToken ct)
@@ -389,7 +316,7 @@ internal sealed class FypOnlineCoordinator
             // A drained iterator restarts from the top: RANDOM sort deals different pages
             // and the page's cooldown machinery absorbs the occasional repeat.
             channel.Iterator = page.NextIterator;
-            var entries = ApplyBlocklist(page.Entries);
+            var entries = page.Entries;
             if (entries.Count > 0)
             {
                 App.Logger?.Information("[FYP online] +{N} entries from r/{Sub} ({Consumer})",

--- a/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/AssetsTabView.xaml
@@ -111,8 +111,7 @@
                 <WrapPanel x:Name="RemoteSourceChips" x:FieldModifier="internal"/>
 
                 <!-- Everything below is dead weight while the source is "local", so it only
-                     unfolds once remote media is actually in play (or once there is a
-                     blocklist to review — that has to stay reachable either way). -->
+                     unfolds once remote media is actually in play. -->
                 <StackPanel x:Name="RemoteMediaDetails" x:FieldModifier="internal" Visibility="Collapsed">
 
                     <!-- Mix ratio: only meaningful in "Both" -->
@@ -158,22 +157,6 @@
                                 Margin="6,0,0,0"/>
                     </StackPanel>
                     <WrapPanel x:Name="RemoteCustomSubChips" x:FieldModifier="internal"/>
-
-                    <!-- Blocklist. There is deliberately no NSFW filter (owner decision), so this
-                         is the user's only content control — which makes an inspectable list,
-                         not just a "block" button elsewhere, part of the feature. -->
-                    <Grid Margin="0,6,0,4">
-                        <TextBlock Text="{loc:Str label_remote_blocklist}" Style="{StaticResource SettingLabel}"
-                                   FontSize="12" HorizontalAlignment="Left"/>
-                        <Button x:Name="BtnRemoteClearBlocklist" x:FieldModifier="internal"
-                                Content="{loc:Str btn_remote_clear_blocklist}"
-                                Style="{StaticResource OutlineButton}" Padding="10,3" FontSize="11"
-                                HorizontalAlignment="Right"/>
-                    </Grid>
-                    <TextBlock x:Name="TxtRemoteBlocklistSummary" x:FieldModifier="internal"
-                               Foreground="{StaticResource TextMutedBrush}" FontSize="11"
-                               TextWrapping="Wrap" Margin="0,0,0,6"/>
-                    <WrapPanel x:Name="RemoteBlockedChips" x:FieldModifier="internal"/>
                 </StackPanel>
             </StackPanel>
         </Border>

--- a/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml.cs
+++ b/ConditioningControlPanel/Windows/FeatureIntroPopup.xaml.cs
@@ -520,7 +520,7 @@ namespace ConditioningControlPanel
                 Bullets = new[]
                 {
                     "You don't need a library to start. The app can pull images and clips straight from Reddit, through Scrolller.",
-                    "You choose the niches, and you can add any subreddit by name. Anything you never want to see again goes on the blocklist.",
+                    "You choose the niches, and you can add any subreddit by name - only what you picked is ever fetched.",
                     "It streams from your machine to your screen - nothing is saved, nothing is uploaded, and none of it passes through our servers.",
                     "Switch back to your own assets whenever you like. The choice lives at the top of the Assets tab."
                 },


### PR DESCRIPTION
## What

The Assets tab's remote-media picker showed a whole blocklist section — "Nothing blocked yet. Whatever you block here is gone from every part of the app.", unblock chips, a Clear button — and the consent dialog promised "you can block anything you don't want to see again". But `FypOnlineCoordinator.BlockSub` / `BlockEntry` had **zero callers**: no click anywhere in the app could ever add an entry, so the section could only ever report an empty list.

Picking the niches/subreddits is already the content control, so instead of adding a block button the blocklist is removed end to end:

- **Assets tab**: blocklist section + wiring gone; the remote-details fold now depends on the media source alone
- **Consent dialog + "remotemedia" intro card**: block promise replaced with "only what you picked is ever fetched"
- **FypOnlineCoordinator**: `BlockSub`/`BlockEntry`/`ApplyBlocklist` and blocked-sub channel filtering removed (the isNsfw owner-decision note survives as a comment)
- **AppSettings**: `RemoteMediaBlockedSubs`/`RemoteMediaBlockedIds` dropped — stale keys in existing settings.json are ignored on load
- **DtrhAssetManifest**: cache prune no longer re-checks a blocklist
- **Localization**: `label_remote_blocklist` + `btn_remote_clear_blocklist` removed from all 9 language files (all still strict-JSON valid)

## Connected repos

Checked CCPMobile and cclabs-web: their Scrolller feed ports never had a blocklist, so nothing to fix there. Server (ccp-server) is not involved (client-fetch bright line).

## Verification

- `dotnet build`: 0 errors
- All 9 language files strict-parse (`JSON.parse`)
- Repo-wide grep: no remaining references to any removed symbol or loc key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoUo556b1pUaB99gcGey8U