### PR TITLE
feat(descent): restore preview prices the server's veteran-credit basis

### DIFF
--- a/ConditioningControlPanel/Services/Descent/DescentMigration.cs
+++ b/ConditioningControlPanel/Services/Descent/DescentMigration.cs
@@ -57,11 +57,24 @@ namespace ConditioningControlPanel.Services.Descent
     /// </summary>
     public sealed class DescentMigrationOffer
     {
-        /// <summary>Lifetime XP the SERVER holds for this account. The relevel's only input.</summary>
+        /// <summary>Lifetime XP the SERVER holds for this account. Display; the relevel prices
+        /// <see cref="RestoreBasisXp"/>.</summary>
         public double TotalXpEarned { get; init; }
 
-        /// <summary>Server-side devotion days, already backfilled. Display only.</summary>
+        /// <summary>Server-side devotion days — the backfill ESTIMATE since 2026-08-16, i.e. the
+        /// count that will actually survive the ceremony. Display only.</summary>
         public int DevotionDays { get; init; }
+
+        /// <summary>
+        /// THE NUMBER OPTION A IS DERIVED FROM: <c>total_xp_earned + 300 × devotion estimate</c>,
+        /// computed by the SERVER (the veteran credit, owner ruling 2026-08-16 — recorded XP alone
+        /// priced a historic account at level 17). Sent on the wire as <c>restore_basis_xp</c>
+        /// precisely so this client never duplicates the arithmetic: the server clamps our claimed
+        /// level to ±1 of its own answer, and a locally-recomputed credit with a stale constant
+        /// would fight that clamp forever. 0 = an older server that did not send it, and the
+        /// relevel falls back to <see cref="TotalXpEarned"/> — the exact pre-credit behaviour.
+        /// </summary>
+        public double RestoreBasisXp { get; init; }
     }
 
     /// <summary>
@@ -107,14 +120,19 @@ namespace ConditioningControlPanel.Services.Descent
         /// <summary>
         /// What a choice does to the ledger, in one place, with no side effects.
         ///
-        /// <para><b>Restore</b> re-derives level from the SERVER's lifetime figure under curve v2.
-        /// The server's number and not the client's on purpose: the server independently derives
-        /// the same value and clamps our claim to within one level of it (CONTRACTS §2.5), so
-        /// deriving from anything else is asking to be clamped.</para>
+        /// <para><b>Restore</b> re-derives level from the SERVER's restore basis (lifetime XP plus
+        /// the veteran credit, <see cref="DescentMigrationOffer.RestoreBasisXp"/>) under curve v2.
+        /// The server's number and not a locally-computed one on purpose: the server independently
+        /// derives the same value and clamps our claim to within one level of it (CONTRACTS §2.5),
+        /// so deriving from anything else is asking to be clamped. The ledger XP written is the
+        /// SAME basis — the next sync's level/XP consistency check re-derives level from xp under
+        /// curve v2, and an xp figure without the credit would demote the account right back to
+        /// the uncredited level one sync later.</para>
         ///
         /// <para><b>Cycle</b> is level 1, XP 0. Lifetime XP is carried through untouched —
         /// total_xp_earned is lifetime and never decreases, not even here (§2.5), and §6 is
-        /// explicit that a Cycle "wipes nothing else".</para>
+        /// explicit that a Cycle "wipes nothing else". The credit does not ride the Cycle door:
+        /// its ledger is a fixed destination with nothing to price.</para>
         ///
         /// <para>Both are IDEMPOTENT, which is what makes the crash-before-ack case survivable:
         /// re-running either against the same server offer produces the same ledger.</para>
@@ -127,9 +145,12 @@ namespace ConditioningControlPanel.Services.Descent
             if (choice == DescentMigrationChoices.Cycle)
                 return new DescentRelevelResult(1, 0, lifetime);
 
+            var basis = offer.RestoreBasisXp;
+            if (double.IsNaN(basis) || basis <= 0) basis = lifetime;
+
             var (level, into) = ProgressionService.DeriveLevelFromLifetimeXp(
-                lifetime, DescentEpochs.AccountDescent);
-            return new DescentRelevelResult(level, into, lifetime);
+                basis, DescentEpochs.AccountDescent);
+            return new DescentRelevelResult(level, into, basis);
         }
     }
 }

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -3996,11 +3996,12 @@ namespace ConditioningControlPanel.Services
             var offer = new DescentMigrationOffer
             {
                 TotalXpEarned = block.TotalXpEarned ?? 0,
-                DevotionDays = block.DevotionDays ?? 0
+                DevotionDays = block.DevotionDays ?? 0,
+                RestoreBasisXp = block.RestoreBasisXp ?? 0
             };
 
-            App.Logger?.Information("[Descent] Server is offering the migration ceremony (lifetime {Xp} XP, {Days} devotion days).",
-                (int)offer.TotalXpEarned, offer.DevotionDays);
+            App.Logger?.Information("[Descent] Server is offering the migration ceremony (lifetime {Xp} XP, {Days} devotion days, restore basis {Basis}).",
+                (int)offer.TotalXpEarned, offer.DevotionDays, (int)offer.RestoreBasisXp);
 
             App.DescentMigration?.OfferReceived(offer);
         }
@@ -4310,6 +4311,12 @@ namespace ConditioningControlPanel.Services
             /// <summary>Server-side devotion days, already backfilled. Display only.</summary>
             [JsonProperty("devotion_days")]
             public int? DevotionDays { get; set; }
+
+            /// <summary>The figure Option A derives from: lifetime + the veteran credit
+            /// (server-computed, 2026-08-16). Absent on older servers — the offer falls back to
+            /// <see cref="TotalXpEarned"/>.</summary>
+            [JsonProperty("restore_basis_xp")]
+            public double? RestoreBasisXp { get; set; }
 
             /// <summary>The ack. The ONLY thing that may mark this client migrated (§2.4).</summary>
             [JsonProperty("completed")]

--- a/Tests/ConditioningControlPanel.Tests/DescentMigrationChoiceTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/DescentMigrationChoiceTests.cs
@@ -120,6 +120,85 @@ public class DescentMigrationChoiceTests
         Assert.Equal(117, restore.Level);
     }
 
+    // -------------------------------------------------- the veteran credit basis
+
+    /// <summary>
+    /// THE VETERAN CREDIT (owner ruling 2026-08-16). The server prices Option A on
+    /// <c>restore_basis_xp</c> — lifetime plus 300 XP per witnessed devotion day — and the offer
+    /// carries the computed figure so this client never re-derives the credit with a constant
+    /// that could go stale. When the basis is present, it is the relevel's ONLY input.
+    /// </summary>
+    [Fact]
+    public void Restore_PricesTheServersBasisWhenItIsPresent()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(30, ProgressionService.CurveEpochLegacy);
+        var basis = ProgressionService.CumulativeXpToReachLevel(50, ProgressionService.CurveEpochDescent);
+        var offer = new DescentMigrationOffer
+            { TotalXpEarned = lifetime, DevotionDays = 180, RestoreBasisXp = basis };
+
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, offer);
+
+        Assert.Equal(50, result.Level);
+    }
+
+    /// <summary>
+    /// The ledger xp written home is the BASIS, not the raw lifetime. The next sync's level/XP
+    /// consistency check re-derives level from xp under curve v2 — a level bought by the credit
+    /// but an xp without it would be demoted right back one sync later.
+    /// </summary>
+    [Fact]
+    public void Restore_TheLedgerCarriesTheBasisSoTheNextSyncAgreesWithIt()
+    {
+        var offer = new DescentMigrationOffer
+            { TotalXpEarned = 16_343, DevotionDays = 180, RestoreBasisXp = 70_343 };
+
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore, offer);
+
+        Assert.Equal(70_343, result.LedgerXp);
+        var floor = ProgressionService.CumulativeXpToReachLevel(result.Level, ProgressionService.CurveEpochDescent);
+        Assert.Equal(70_343, floor + result.XpIntoLevel);
+    }
+
+    /// <summary>An older server sends no basis (0), and the relevel is the pre-credit arithmetic
+    /// exactly — derived from the lifetime figure alone.</summary>
+    [Fact]
+    public void Restore_FallsBackToLifetimeWhenTheServerSentNoBasis()
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(30, ProgressionService.CurveEpochLegacy);
+
+        var withBasisZero = DescentMigration.Resolve(DescentMigrationChoices.Restore,
+            new DescentMigrationOffer { TotalXpEarned = lifetime, RestoreBasisXp = 0 });
+
+        Assert.Equal(30, withBasisZero.Level);
+        Assert.Equal(lifetime, withBasisZero.LedgerXp);
+    }
+
+    /// <summary>The credit never rides the Cycle door: level 1, xp 0, lifetime carried through
+    /// RAW — a Cycle's keepsake records what was witnessed, not what a restore would have paid.</summary>
+    [Fact]
+    public void Cycle_IgnoresTheBasisEntirely()
+    {
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Cycle,
+            new DescentMigrationOffer { TotalXpEarned = 16_343, RestoreBasisXp = 70_343 });
+
+        Assert.Equal(1, result.Level);
+        Assert.Equal(16_343, result.LifetimeXp);
+    }
+
+    /// <summary>A junk basis (NaN, negative) degrades to the lifetime fallback, never to a throw
+    /// and never to level 0.</summary>
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(-500)]
+    public void Restore_TreatsAJunkBasisAsAbsent(double basis)
+    {
+        var lifetime = ProgressionService.CumulativeXpToReachLevel(30, ProgressionService.CurveEpochLegacy);
+        var result = DescentMigration.Resolve(DescentMigrationChoices.Restore,
+            new DescentMigrationOffer { TotalXpEarned = lifetime, RestoreBasisXp = basis });
+
+        Assert.Equal(30, result.Level);
+    }
+
     // ------------------------------------------------------------ hostile input
 
     [Theory]


### PR DESCRIPTION
Desktop half of the 2026-08-16 balance rulings (pairs with CC-Labs-llc/CCP-Server#47).

## What changed

- `DescentMigrationOffer` gains `RestoreBasisXp`, parsed from the sync offer's new `restore_basis_xp` (lifetime + 300 XP per witnessed devotion day, server-computed).
- `DescentMigration.Resolve` prices Option A off the basis: preview level, submitted level, and **ledger xp** all derive from the same figure, so the next sync's curve-v2 consistency check re-derives the identical standing instead of demoting the credit away.
- No basis on the wire (older server) -> exact pre-credit behaviour, pinned by the untouched existing tests.
- The Cycle door ignores the basis entirely; its keepsake still records the raw witnessed lifetime.
- The vat resize needs no desktop change - the jar renders whatever `raw / cap` the server sends, and the vessel arrives on the same field.

## Tests

3476/3476 (6 new). Build at the 336-warning baseline.

## Merge order

Either order is safe, but the credit only takes effect once server #47 deploys; until then the fallback path runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xyM4grCavzkgKLzD8MySN