### PR TITLE
fix(triage): the fullscreen trap, the buried nav rail, and three more

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Browser.cs
@@ -2693,6 +2693,96 @@ namespace ConditioningControlPanel
             }
         }
 
+        // ---- rented Topmost + escape hatch for the fullscreen browser (#952) -------------------
+
+        /// <summary>Handlers armed on whichever window is carrying the fullscreen browser, so
+        /// <see cref="DisarmFullscreenEscapes"/> can take them off the SAME window later - the
+        /// popout branch reuses a window the user owns and must be left exactly as it was found.</summary>
+        private Window? _browserFsEscapeTarget;
+        private EventHandler? _browserFsActivated;
+        private EventHandler? _browserFsDeactivated;
+        private System.Windows.Input.KeyEventHandler? _browserFsKeyDown;
+
+        /// <summary>
+        /// TOPMOST IS RENTED, NOT OWNED (#905), and Esc/F11 always gets out (#952).
+        ///
+        /// A fullscreen browser has to sit over the taskbar and over the app, so the window is
+        /// Topmost - but it kept that claim after another window took focus, which is how a
+        /// session's end-of-run dialog ended up alive and modal BEHIND a fullscreen HypnoTube:
+        /// invisible, holding the input queue, with the browser itself unreachable because the
+        /// page had HTML5 fullscreen and no chrome. The reporter of #952 rebooted the machine.
+        /// Dropping the claim on deactivation lets any dialog surface, and taking it back on
+        /// activation restores the fullscreen look the moment the user comes back.
+        ///
+        /// The key handler is the second half: the window is ShowInTaskbar=false and
+        /// WindowStyle.None, so if the page swallows the double-click that normally exits, there
+        /// was no way out at all. This one is on the WINDOW, not the page, so nothing the site
+        /// does can eat it.
+        /// </summary>
+        private void ArmFullscreenEscapes(Window window)
+        {
+            DisarmFullscreenEscapes();
+
+            _browserFsEscapeTarget = window;
+            _browserFsDeactivated = (_, _) =>
+            {
+                try { if (_browserFsEscapeTarget != null) _browserFsEscapeTarget.Topmost = false; } catch { }
+            };
+            _browserFsActivated = (_, _) =>
+            {
+                // Only re-take the claim while we are still the fullscreen owner - an Activated
+                // that arrives during teardown must not put the claim back on a window we have
+                // just handed to the user.
+                try { if (_isBrowserFullscreen && _browserFsEscapeTarget != null) _browserFsEscapeTarget.Topmost = true; } catch { }
+            };
+            _browserFsKeyDown = (_, args) =>
+            {
+                if (args.Key != System.Windows.Input.Key.Escape && args.Key != System.Windows.Input.Key.F11) return;
+                args.Handled = true;
+                try { ExitBrowserFullscreen(); } catch { }
+            };
+
+            window.Deactivated += _browserFsDeactivated;
+            window.Activated += _browserFsActivated;
+            window.KeyDown += _browserFsKeyDown;
+        }
+
+        private void DisarmFullscreenEscapes()
+        {
+            var window = _browserFsEscapeTarget;
+            _browserFsEscapeTarget = null;
+            if (window == null) return;
+
+            try { if (_browserFsDeactivated != null) window.Deactivated -= _browserFsDeactivated; } catch { }
+            try { if (_browserFsActivated != null) window.Activated -= _browserFsActivated; } catch { }
+            try { if (_browserFsKeyDown != null) window.KeyDown -= _browserFsKeyDown; } catch { }
+
+            _browserFsDeactivated = null;
+            _browserFsActivated = null;
+            _browserFsKeyDown = null;
+        }
+
+        /// <summary>
+        /// Session/panic teardown hook (#952). The session ending while a video is fullscreen is
+        /// the exact shape of the trap: StopEngineCore force-closes lock cards, quizzes and the
+        /// ceremony windows, but the browser tube was not on that list, so the completion dialog
+        /// opened behind it. Safe to call unconditionally - it early-outs unless fullscreen is
+        /// actually up.
+        /// </summary>
+        internal void ExitBrowserFullscreenForTeardown()
+        {
+            if (!_isBrowserFullscreen) return;
+            try
+            {
+                ExitBrowserFullscreen();
+                App.Logger?.Information("Browser fullscreen closed by session teardown (#952)");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ExitBrowserFullscreenForTeardown failed: {Error}", ex.Message);
+            }
+        }
+
         public void EnterBrowserFullscreen()
         {
             if (_browser?.WebView == null || _isBrowserFullscreen) return;
@@ -2729,6 +2819,7 @@ namespace ConditioningControlPanel
                     _browserPopoutWindow.Topmost = true;
                     _browserPopoutWindow.Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
                     _browserPopoutWindow.WindowState = WindowState.Maximized;
+                    ArmFullscreenEscapes(_browserPopoutWindow);
                 }
                 else
                 {
@@ -2790,6 +2881,7 @@ namespace ConditioningControlPanel
                     _browserPopoutWindow.Show();
                     _browserPopoutWindow.Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
                     _browserPopoutWindow.WindowState = WindowState.Maximized;
+                    ArmFullscreenEscapes(_browserPopoutWindow);
                 }
 
                 // (Removed: ReRequestVideoFullscreenAsync.) That stacked a
@@ -2820,6 +2912,11 @@ namespace ConditioningControlPanel
         private void ExitBrowserFullscreen()
         {
             if (!_isBrowserFullscreen) return;
+
+            // Off FIRST, and off the same window they went on (#952). The popout branch below
+            // hands a window the user owns back to them, and a surviving Activated handler would
+            // keep re-claiming Topmost on it for the rest of the session.
+            DisarmFullscreenEscapes();
 
             try
             {

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -763,6 +763,107 @@ namespace ConditioningControlPanel
 
             ApplyNavDoorRows(expand, animate);
             ApplyNavRailDoorState(animate);
+            ApplyNavRailAirspace(expand);
+        }
+
+        // ================================================================================
+        //  #956 / #962 - the flyout vs a native browser HWND
+        // ================================================================================
+
+        /// <summary>Browsers this flyout is currently holding down, and what they were before.
+        /// Restored from THIS list rather than re-walked, so a tab switch mid-hover can never
+        /// leave one hidden.</summary>
+        private readonly List<(FrameworkElement Element, Visibility Was)> _navRailAirspaceHeld = new();
+
+        /// <summary>
+        /// The nav rail is <c>Panel.ZIndex=60</c> over a <c>ColumnSpan=2</c> footprint - it does
+        /// not push the page aside, it flies over it. WPF z-order means nothing to a WebView2:
+        /// it is a native child HWND and it paints over every WPF element in the same window
+        /// whatever the z-order says. On the Spiral Room, whose embed is full-bleed, that put the
+        /// entire expanded rail BEHIND the browser - the reports read "the spiral renders on top
+        /// of the side menu" (#956) and "the lateral bar is hidden behind the black background"
+        /// (#962), which is one bug seen from two angles.
+        ///
+        /// <para>So the browser yields for as long as the flyout is out. This is the same
+        /// mitigation <c>Controls/SpiralRailHost.cs</c> already makes for the rail-docked
+        /// mini ("shown ONLY while the rail is wide enough... torn down whenever the rail
+        /// collapses"), applied from the other side. <see cref="Visibility.Hidden"/> rather than
+        /// Collapsed: the browser keeps its layout rectangle, so nothing reflows and no page
+        /// state is lost - only the HWND leaves the screen, uncovering the WPF content behind it
+        /// (for the Spiral Room that is the tab's own <c>#0A0514</c> ground).</para>
+        ///
+        /// <para>Only browsers that actually INTERSECT the flyout are touched, so hovering the
+        /// rail on a page whose browser card is indented past 236px costs nothing and shows
+        /// nothing. The proper fix is to re-host the flyout in its own top-level window - the
+        /// dodge <c>Windows/SettingsPaletteWindow.xaml.cs</c> already takes for exactly this
+        /// fight - which is a much larger change than a hover state should carry.</para>
+        /// </summary>
+        private void ApplyNavRailAirspace(bool expand)
+        {
+            try
+            {
+                if (!expand)
+                {
+                    foreach (var (element, was) in _navRailAirspaceHeld)
+                    {
+                        try { element.Visibility = was; } catch { }
+                    }
+                    _navRailAirspaceHeld.Clear();
+                    return;
+                }
+
+                if (_navRailAirspaceHeld.Count > 0) return;   // already held for this expansion
+                if (NavSidebar == null || !NavSidebar.IsVisible) return;
+
+                // Measured at the FULL expanded width, not the animated one: the width tween is
+                // still running when this is called, and a browser that will be covered a
+                // heartbeat from now has to get out of the way now, not flicker halfway through.
+                var origin = NavSidebar.TranslatePoint(new Point(0, 0), this);
+                var flyout = new Rect(origin.X, origin.Y,
+                                      NavRailExpandedWidth, NavSidebar.ActualHeight);
+                if (flyout.Width <= 0 || flyout.Height <= 0) return;
+
+                HoldOverlappingBrowsers(this, flyout);
+
+                if (_navRailAirspaceHeld.Count > 0)
+                    App.Logger?.Debug("Nav rail flyout: yielded {Count} browser HWND(s) (#956)",
+                        _navRailAirspaceHeld.Count);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ApplyNavRailAirspace: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>Walks for visible WebView2s overlapping <paramref name="flyout"/> (window
+        /// coordinates) and hides them, remembering what each one was.</summary>
+        private void HoldOverlappingBrowsers(DependencyObject root, Rect flyout)
+        {
+            int count = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+
+                if (child is Microsoft.Web.WebView2.Wpf.WebView2 browser)
+                {
+                    // A hidden browser has no airspace to yield, and it has no descendants worth
+                    // walking either.
+                    if (!browser.IsVisible || browser.ActualWidth <= 0 || browser.ActualHeight <= 0) continue;
+                    try
+                    {
+                        var at = browser.TranslatePoint(new Point(0, 0), this);
+                        var rect = new Rect(at.X, at.Y, browser.ActualWidth, browser.ActualHeight);
+                        if (!rect.IntersectsWith(flyout)) continue;
+
+                        _navRailAirspaceHeld.Add((browser, browser.Visibility));
+                        browser.Visibility = Visibility.Hidden;
+                    }
+                    catch { /* not connected to this window's tree - nothing to hide */ }
+                    continue;
+                }
+
+                HoldOverlappingBrowsers(child, flyout);
+            }
         }
 
         /// <summary>

--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -379,6 +379,10 @@ namespace ConditioningControlPanel
             // the bloom starts — so panicking out of it costs a keepsake at worst and never a
             // choice, a level or an XP total.
             DescentFuseWindow.ForceCloseAll();
+            // #952: the built-in browser's forced fullscreen belongs on this list too. It is a
+            // topmost, chrome-less, taskbar-less window, so a session that ends behind one leaves
+            // the completion dialog modal and invisible - the reporter had to reboot the machine.
+            ExitBrowserFullscreenForTeardown();
 
             // Stop ramp timer and reset sliders
             StopRampTimer();

--- a/ConditioningControlPanel/Models/Program/ProgramEnrollment.cs
+++ b/ConditioningControlPanel/Models/Program/ProgramEnrollment.cs
@@ -227,6 +227,16 @@ public class ProgramEnrollment
     public DateTime? LapsedAt { get; set; }
 
     /// <summary>
+    /// This run's ledger has already been audited against the pre-6.8.0 day-clock bugs (#959).
+    /// One-shot: set whether or not the audit decided to restore anything, so a run whose lapse
+    /// was genuine is never re-examined, and a run that WAS restored cannot be restored twice.
+    ///
+    /// Additive and defaulted, so enrollments saved before it existed round-trip unchanged - and
+    /// reading false on an old save is exactly right, because those are the saves worth auditing.
+    /// </summary>
+    public bool LapseAudited { get; set; }
+
+    /// <summary>
     /// Program-date the daily nudge last fired on. Persisted rather than held in memory so a
     /// restart during the nudge hour cannot fire it a second (and third) time - the reminder is
     /// the one thing in this file the user hears whether or not they open the app.

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
@@ -159,6 +159,12 @@ internal sealed class BrainDrainCapturePump
     /// frame 2-4x more often than the pump could produce one. Any thread.</summary>
     public int FramesPublished => Volatile.Read(ref _framesPublished);
 
+    /// <summary>Capture slots actually built, which is NOT the same as monitors requested: under
+    /// GDI exhaustion <see cref="CreateSlot"/> returns null and the array comes up short. Read by
+    /// the layer's first-frame watchdog to tell "nothing to capture" from "capture is failing"
+    /// (#960). Any thread - the array reference is a volatile publish.</summary>
+    public int SlotCount => _slots.Length;
+
     // Pump-thread-only state (the blur/melt chain, lifted verbatim from the old CapturePass).
     private readonly SKPaint _blurPaint = new();
     private SKImageFilter? _blurFilter;

--- a/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainLayer.cs
@@ -109,12 +109,100 @@ public sealed class BrainDrainLayer : BaseLayer
         _lastSeenFrames = -1;   // fresh pump: its counter restarts at 0, so never match a stale one
         _dirty = true;
         SetActive(true);
+        ArmFirstFrameWatchdog(intensity, melt);
     }
 
     public void Stop()
     {
+        DisarmFirstFrameWatchdog();
         SetActive(false);
         ReleaseCaptures();
+    }
+
+    // ================================================================================
+    //  #960 - "started" has to mean something
+    // ================================================================================
+
+    /// <summary>How long to give the pump before calling a run dead. At 30 fps the first frame is
+    /// due in ~33 ms; three seconds is slow-machine slack, not a real wait.</summary>
+    private static readonly TimeSpan FirstFrameGrace = TimeSpan.FromSeconds(3);
+    private System.Windows.Threading.DispatcherTimer? _firstFrameWatchdog;
+
+    /// <summary>
+    /// The honest half of #960 ("Brain drain plays the audio file... but nothing visual even with
+    /// every slider at 100%"). Every path between the button and the pixels can fail SILENTLY and
+    /// still log <c>Brain Drain started on compositor layer</c> at Information: the pump builds no
+    /// slot when GDI refuses a DC or a DIB section, <c>GetTargetScreens</c> can hand it an empty
+    /// array during a display transition, and a slot whose bounds do not contain the host's centre
+    /// is simply never taken by Render. All three end in a layer that is Active, dirty, drawing
+    /// nothing, and claiming success in the log - which is why the triage of this report had a
+    /// start line to read and no way to tell which of those it was.
+    ///
+    /// <para>So the claim is now checked. If the pump has published no frame at all by the time
+    /// the grace is up, the log says so with the numbers that separate the three causes, and the
+    /// user is told rather than left staring at an unchanged screen. This does not FIX a
+    /// zero-frame run - it turns one into something a report can be triaged from.</para>
+    /// </summary>
+    private void ArmFirstFrameWatchdog(int intensity, bool melt)
+    {
+        DisarmFirstFrameWatchdog();
+
+        var timer = new System.Windows.Threading.DispatcherTimer(System.Windows.Threading.DispatcherPriority.Background)
+        {
+            Interval = FirstFrameGrace
+        };
+        timer.Tick += (_, _) =>
+        {
+            DisarmFirstFrameWatchdog();
+            try
+            {
+                var pump = _pump;
+                if (pump == null) return;                  // stopped in the meantime - not a failure
+                if (pump.FramesPublished > 0) return;      // it is running; nothing to say
+
+                App.Logger?.Warning(
+                    "Brain Drain produced NO frames in {Grace:F0}s (#960) - intensity {Intensity}, melt {Melt}, " +
+                    "downscale {Downscale}, screens targeted {Screens}, capture slots built {Slots}. " +
+                    "{Cause}",
+                    FirstFrameGrace.TotalSeconds, intensity, melt, _downscale,
+                    _requestedScreens.Length, pump.SlotCount,
+                    _requestedScreens.Length == 0
+                        ? "No screens were targeted - GetTargetScreens came back empty (display transition, or DualMonitorEnabled with no enumerable screens)."
+                        : pump.SlotCount == 0
+                            ? "Screens were targeted but no capture slot could be built - CreateCompatibleDC/CreateDIBSection refused (GDI exhaustion)."
+                            : "Slots exist and the capture is producing nothing - the desktop StretchBlt is failing.");
+
+                NotifyNoFrames();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("BrainDrain first-frame watchdog failed: {E}", ex.Message);
+            }
+        };
+        timer.Start();
+        _firstFrameWatchdog = timer;
+    }
+
+    private void DisarmFirstFrameWatchdog()
+    {
+        var timer = _firstFrameWatchdog;
+        _firstFrameWatchdog = null;
+        try { timer?.Stop(); } catch { }
+    }
+
+    private static void NotifyNoFrames()
+    {
+        try
+        {
+            App.Notifications?.Show(
+                "Brain Drain could not capture the screen, so there is nothing to blur. The audio half is unaffected - " +
+                "please send a bug report so we can see why.",
+                NotificationType.Warning, TimeSpan.FromSeconds(12));
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("BrainDrain no-frames notice failed: {E}", ex.Message);
+        }
     }
 
     // Blur strength per intensity point, SOURCE px per unit. The legacy constant was 0.4 (radius

--- a/ConditioningControlPanel/Services/Haptics/Core/HapticPatterns.cs
+++ b/ConditioningControlPanel/Services/Haptics/Core/HapticPatterns.cs
@@ -15,11 +15,36 @@ namespace ConditioningControlPanel.Services.Haptics.Core
     /// </summary>
     public static class HapticPatterns
     {
+        /// <summary>
+        /// THE ON-TIME FLOOR (#955, re-report of #896). A vibration motor is a physical object
+        /// with inertia: an ERM takes roughly 100-150 ms to spin up from rest to a speed anyone
+        /// can feel, and about as long to coast back down. Every discrete event in this app was
+        /// authored in software time, not motor time - <c>BouncingTextBounce</c> asked for 60 ms,
+        /// <c>BubblePop</c> and <c>VideoTargetHit</c> for 100 ms, and Pulse mode chopped whatever
+        /// it was given into 50 ms taps. The commands were correct, they reached the toy, and the
+        /// toy never actually moved. That is precisely the shape of the report: "haptics still
+        /// pretty much not working EXCEPT for constant during video play and some test buttons" -
+        /// i.e. everything long works, everything short does not.
+        ///
+        /// <para>So no rendered pulse asks the hardware for less on-time than this. It is a floor,
+        /// never a cap: a caller asking for 2 s still gets 2 s.</para>
+        ///
+        /// <para>It is also comfortably above the mixer's 100 ms evaluation period, which means a
+        /// pulse can no longer live and die inside a single tick and reach the toy as one lonely
+        /// sample of an envelope it never got to climb.</para>
+        /// </summary>
+        public const int MinFeltOnMs = 130;
+
+        /// <summary>Shortest whole pattern worth rendering - the on-time floor plus room for the
+        /// attack and decay that surround it. Anything below this is rounded UP to it.</summary>
+        public const int MinFeltDurationMs = 200;
+
         public static IReadOnlyList<HapticPulseStep> Render(
             VibrationMode mode, double intensity, int durationMs, int priority = 0, ToyRole target = ToyRole.All)
         {
             intensity = Math.Clamp(intensity, 0, 1);
-            durationMs = Math.Clamp(durationMs, 20, 60_000);
+            // Floor, not clamp-to-20 (#955): a 60 ms request is not a short buzz, it is silence.
+            durationMs = Math.Clamp(durationMs, MinFeltDurationMs, 60_000);
             var steps = new List<HapticPulseStep>();
             if (intensity <= 0) return steps;
 
@@ -27,39 +52,54 @@ namespace ConditioningControlPanel.Services.Haptics.Core
             {
                 case VibrationMode.Pulse:
                 {
-                    // Quick on/off taps — 50 ms on, 30 ms off, exactly the old intent.
-                    var count = Math.Clamp(durationMs / 80, 1, 40);
+                    // Quick on/off taps. The tap was 50 ms on / 30 ms off, which is the right
+                    // RHYTHM and an unrenderable on-time - the motor never left standstill. Same
+                    // shape, widened to the floor: MinFeltOnMs on, ~70 ms off. Still reads as
+                    // taps, now actually felt.
+                    const int gapMs = 70;
+                    var period = MinFeltOnMs + gapMs;
+                    var count = Math.Clamp(durationMs / period, 1, 40);
                     for (int i = 0; i < count; i++)
-                        steps.Add(new HapticPulseStep(i * 80, new HapticPulse(intensity, 8, 42, 20, priority, target)));
+                        steps.Add(new HapticPulseStep(i * period,
+                            new HapticPulse(intensity, 8, MinFeltOnMs, 20, priority, target)));
                     break;
                 }
 
                 case VibrationMode.Wave:
                 {
-                    // One smooth swell: half the duration up, half back down.
-                    var half = Math.Max(20, durationMs / 2);
+                    // One smooth swell: half the duration up, half back down. The floor applies to
+                    // each half so the crest is actually reached rather than skimmed.
+                    var half = Math.Max(MinFeltOnMs, durationMs / 2);
                     steps.Add(new HapticPulseStep(0, new HapticPulse(intensity, half, 0, half, priority, target)));
                     break;
                 }
 
                 case VibrationMode.Heartbeat:
                 {
-                    // ba-BUMP ... ba-BUMP: a strong beat then a lighter one, 400 ms apart.
+                    // ba-BUMP ... ba-BUMP: a strong beat then a lighter one, 400 ms apart. Both
+                    // beats were under the on-time floor (70 ms and 50 ms), so the whole pattern
+                    // was inaudible to the hardware; the 400 ms spacing and the 140 ms offset
+                    // between the two beats are what carry the rhythm, and both are untouched.
                     var beats = Math.Clamp(durationMs / 400, 1, 20);
                     for (int i = 0; i < beats; i++)
                     {
                         var t = i * 400;
-                        steps.Add(new HapticPulseStep(t, new HapticPulse(intensity, 10, 70, 30, priority, target)));
-                        steps.Add(new HapticPulseStep(t + 140, new HapticPulse(intensity * 0.7, 10, 50, 30, priority, target)));
+                        steps.Add(new HapticPulseStep(t,
+                            new HapticPulse(intensity, 10, MinFeltOnMs, 30, priority, target)));
+                        steps.Add(new HapticPulseStep(t + 140,
+                            new HapticPulse(intensity * 0.7, 10, MinFeltOnMs, 30, priority, target)));
                     }
                     break;
                 }
 
                 case VibrationMode.Escalate:
                 {
-                    // 20% -> 100% of the set intensity across the duration.
-                    const int n = 8;
-                    var slice = Math.Max(20, durationMs / n);
+                    // 20% -> 100% of the set intensity across the duration. The rung COUNT now
+                    // falls out of the duration instead of being fixed at 8: eight rungs over a
+                    // 300 ms event gave 37 ms slices, i.e. eight steps of nothing. Short events
+                    // get fewer, felt rungs; long ones still get the full eight-step climb.
+                    var n = Math.Clamp(durationMs / MinFeltOnMs, 1, 8);
+                    var slice = Math.Max(MinFeltOnMs, durationMs / n);
                     for (int i = 1; i <= n; i++)
                         steps.Add(new HapticPulseStep((i - 1) * slice,
                             new HapticPulse(intensity * (0.2 + 0.8 * (i / (double)n)), 10, slice, 20, priority, target)));
@@ -68,11 +108,15 @@ namespace ConditioningControlPanel.Services.Haptics.Core
 
                 case VibrationMode.Earthquake:
                 {
-                    // Random 30-100% jolts. Random.Shared is thread-safe (net6+).
-                    var count = Math.Clamp(durationMs / 100, 2, 60);
+                    // Random 30-100% jolts. Random.Shared is thread-safe (net6+). A "jolt" the
+                    // motor cannot reach is not a jolt, so each one holds for the floor and the
+                    // spacing widens to match.
+                    const int joltPeriodMs = MinFeltOnMs + 40;
+                    var count = Math.Clamp(durationMs / joltPeriodMs, 2, 60);
                     for (int i = 0; i < count; i++)
-                        steps.Add(new HapticPulseStep(i * 100,
-                            new HapticPulse(intensity * (0.3 + Random.Shared.NextDouble() * 0.7), 5, 60, 25, priority, target)));
+                        steps.Add(new HapticPulseStep(i * joltPeriodMs,
+                            new HapticPulse(intensity * (0.3 + Random.Shared.NextDouble() * 0.7),
+                                            5, MinFeltOnMs, 25, priority, target)));
                     break;
                 }
 

--- a/ConditioningControlPanel/Services/Program/ProgramService.cs
+++ b/ConditioningControlPanel/Services/Program/ProgramService.cs
@@ -150,6 +150,11 @@ public class ProgramService : IDisposable
         State = LoadState();
         Library = BuiltInPrograms.All();
 
+        // #959: un-lapse runs the OLD day clock condemned. Must run BEFORE the rollover below,
+        // which returns early on anything that is not Active and would otherwise leave the run
+        // sitting exactly where the bug parked it.
+        RepairSpuriousLapse();
+
         // Startup rollover check, before any UI reads Today.
         EvaluateRollover();
 
@@ -469,6 +474,146 @@ public class ProgramService : IDisposable
         RaiseTodayChanged();
 
         App.Logger?.Information("Program {Program} restarted, attempt {Attempt}", program.Id, enrollment.AttemptNumber);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // #959 - the one-shot lapse audit
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>What the audit decided about one lapsed run.</summary>
+    /// <param name="ShouldRestore">The lapse was manufactured; put the run back.</param>
+    /// <param name="CorrectedMissedDays">Absences that survive the correction.</param>
+    /// <param name="ContradictoryDays">Day indices stamped Missed AND DayCompleted.</param>
+    internal readonly record struct LapseAudit(
+        bool ShouldRestore, int CorrectedMissedDays, IReadOnlyList<int> ContradictoryDays);
+
+    /// <summary>
+    /// Decide whether a lapsed run was lapsed by the user or by the pre-6.8.0 day clock (#959).
+    ///
+    /// <para>THE SIGNATURE IS A CONTRADICTION IN THE LEDGER, not a version stamp. 57adfb174
+    /// describes exactly what the old clamp produced: "the record carried Missed and, once
+    /// finished, DayCompleted - a state that means nothing, breaks PerfectDayCount, and spent a
+    /// day off for a day still in front of the user". A day cannot be both the absence and the
+    /// day that was finished, so a lapsed ledger holding such a row was condemned by arithmetic
+    /// the user never had a say in. Runs whose ledger is self-consistent are left lapsed: they
+    /// really were missed, and quietly forgiving them would make the allowance meaningless.</para>
+    ///
+    /// <para>WHAT THIS DELIBERATELY DOES NOT CATCH. cce784b52's day-boundary bug discarded the
+    /// completion instead of filing it, so those days read as an ordinary miss and are
+    /// indistinguishable from one. Forgiving them would mean forgiving every lapse ever recorded.
+    /// A user in that position still has Restart, which keeps their banked rewards.</para>
+    ///
+    /// Pure and static so the rule can be tested without a service, a file or a clock - same
+    /// idiom as <c>ProgramClock.Evaluate</c> and <c>CornerGifService.ResolveRestoreAction</c>.
+    /// </summary>
+    internal static LapseAudit AuditLapse(ProgramEnrollment enrollment, int daysOffAllowed)
+    {
+        var contradictory = new List<int>();
+        int genuinelyMissed = 0;
+
+        foreach (var record in enrollment.Records.Values)
+        {
+            if (!record.Missed) continue;
+            if (record.DayCompleted) contradictory.Add(record.DayIndex);
+            else genuinelyMissed++;
+        }
+
+        contradictory.Sort();
+
+        // No contradiction, no manufactured lapse - leave the run exactly as the user left it.
+        if (contradictory.Count == 0) return new LapseAudit(false, genuinelyMissed, contradictory);
+
+        // Restore only if the run would have survived on the corrected count. If it would have
+        // lapsed anyway the contradiction was cosmetic, and un-lapsing would be a gift, not a fix.
+        return new LapseAudit(genuinelyMissed <= daysOffAllowed, genuinelyMissed, contradictory);
+    }
+
+    /// <summary>
+    /// Apply <see cref="AuditLapse"/> to the active run, once, at load. See that method for why
+    /// the rule is what it is.
+    /// </summary>
+    private void RepairSpuriousLapse()
+    {
+        try
+        {
+            var enrollment = State.Active;
+            if (enrollment is not { State: ProgramEnrollmentState.Lapsed }) return;
+            if (enrollment.LapseAudited) return;
+
+            var program = ActiveProgram;
+            if (program == null) return;   // unknown program id: no rules to audit against
+
+            int allowed = enrollment.StrictMode && program.Rules.StrictAvailable
+                ? 0
+                : program.Rules.DaysOffAllowed;
+
+            var audit = AuditLapse(enrollment, allowed);
+
+            // Stamped either way: a genuine lapse must never be re-examined on every launch.
+            enrollment.LapseAudited = true;
+            MarkDirty();
+
+            if (!audit.ShouldRestore)
+            {
+                Save();
+                return;
+            }
+
+            foreach (var dayIndex in audit.ContradictoryDays)
+            {
+                var record = enrollment.GetRecord(dayIndex);
+                if (record == null) continue;
+                record.Missed = false;
+                record.DayOffSpent = false;
+            }
+
+            enrollment.State = ProgramEnrollmentState.Active;
+            enrollment.LapsedAt = null;
+            enrollment.DaysOffRemaining = Math.Max(0, allowed - audit.CorrectedMissedDays);
+
+            // Re-anchor to today. The run has been sitting lapsed for however long it took the
+            // user to update, and EvaluateRollover runs immediately after this - without the
+            // re-anchor it would sweep every one of those days as an absence and lapse the run
+            // again on the same launch that just repaired it.
+            enrollment.CurrentDayDate = ProgramClock.ProgramDate(DateTime.Now, enrollment.DayBoundaryHour);
+            var today = enrollment.GetOrCreateRecord(enrollment.CurrentDay, enrollment.CurrentDayDate);
+            today.ProgramDate = enrollment.CurrentDayDate;
+
+            Save();
+            RaiseTodayChanged();
+
+            App.Logger?.Warning(
+                "Program {Program}: lapse on day {Day} reversed - {Bad} ledger row(s) were stamped Missed AND complete " +
+                "(pre-6.8.0 day clock, #959). {Left} day(s) off restored",
+                program.Id, enrollment.CurrentDay, audit.ContradictoryDays.Count, enrollment.DaysOffRemaining);
+
+            NotifyLapseReversed(program);
+        }
+        catch (Exception ex)
+        {
+            // A run that stays lapsed is recoverable by hand (Restart keeps banked rewards); a
+            // throw here would take ProgramService's whole construction down with it.
+            App.Logger?.Error(ex, "Program lapse audit failed - leaving the run as saved");
+        }
+    }
+
+    /// <summary>
+    /// Say so out loud. The reporter of #959 filed it twice precisely because the run silently
+    /// stopped and nothing ever explained it; a silent un-stop is the same failure inverted.
+    /// </summary>
+    private static void NotifyLapseReversed(ProgramDefinition program)
+    {
+        try
+        {
+            App.Notifications?.Show(
+                $"{program.Title} is running again - the run was stopped by a bug in the day counter, not by you. " +
+                "Your days off have been put back.",
+                NotificationType.Success, TimeSpan.FromSeconds(14));
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("Lapse-reversed notice failed: {E}", ex.Message);
+        }
     }
 
     // ---------------------------------------------------------------------------------------

--- a/Tests/ConditioningControlPanel.Tests/HapticOnTimeFloorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/HapticOnTimeFloorTests.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services.Haptics.Core;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #955 (re-report of #896): "Haptics still pretty much not working except for constant during
+/// video play and some test buttons." Everything LONG worked and everything SHORT did not, which
+/// is not a routing bug - it is physics. An ERM motor needs ~100-150 ms to spin up to a speed
+/// anyone can feel, and the app was asking for 50-100 ms taps. The commands were correct, they
+/// reached the toy, and the toy never moved.
+///
+/// These tests pin the on-time floor: every rendered pulse asks the hardware for at least
+/// <see cref="HapticPatterns.MinFeltOnMs"/> of hold, in every mode, at every requested duration.
+/// The systemic note from the triage still stands - haptics has no output logging - so this is the
+/// first thing in the feature with a test at all, and it guards the one property that decides
+/// whether a user feels anything.
+/// </summary>
+public class HapticOnTimeFloorTests
+{
+    private static readonly VibrationMode[] AllModes =
+    {
+        VibrationMode.Constant, VibrationMode.Pulse, VibrationMode.Wave,
+        VibrationMode.Heartbeat, VibrationMode.Escalate, VibrationMode.Earthquake,
+    };
+
+    [Theory]
+    // The three durations the event table actually used, all of them below the floor.
+    [InlineData(60)]    // BouncingTextBounce
+    [InlineData(100)]   // BubblePop, VideoTargetHit
+    [InlineData(150)]   // BlinkPulse, SubliminalTrigger, KeywordTrigger, GazeReward
+    public void EveryModeClearsTheFloorEvenWhenAskedForLess(int requestedMs)
+    {
+        foreach (var mode in AllModes)
+        {
+            var steps = HapticPatterns.Render(mode, 0.35, requestedMs);
+
+            Assert.NotEmpty(steps);
+            foreach (var step in steps)
+            {
+                // Attack + hold + decay, because that is how long the motor is actually driven.
+                // Wave is a pure triangle with no hold at all, and that is correct for a swell -
+                // what matters is that the ramp is long enough to reach a felt speed.
+                var onTime = step.Pulse.AttackMs + step.Pulse.HoldMs + step.Pulse.DecayMs;
+                Assert.True(onTime >= HapticPatterns.MinFeltOnMs,
+                    $"{mode} at {requestedMs}ms drives the motor for {onTime}ms - below its spin-up.");
+            }
+        }
+    }
+
+    [Fact]
+    public void ALongRequestIsStillHonoured_TheFloorIsAFloorNotACap()
+    {
+        // The regression this floor could plausibly cause: flattening everything to 200 ms.
+        var steps = HapticPatterns.Render(VibrationMode.Constant, 0.5, 4000);
+
+        var single = Assert.Single(steps);
+        Assert.Equal(4000, single.Pulse.HoldMs);
+    }
+
+    [Fact]
+    public void PulseKeepsItsRhythm()
+    {
+        // Widening the tap must not turn taps into one continuous buzz: a full second still
+        // renders as several discrete, separated pulses.
+        var steps = HapticPatterns.Render(VibrationMode.Pulse, 0.5, 1000);
+
+        Assert.True(steps.Count >= 4, $"a 1s Pulse rendered only {steps.Count} tap(s)");
+        var offsets = steps.Select(s => s.DelayMs).ToList();
+        for (int i = 1; i < offsets.Count; i++)
+        {
+            var gap = offsets[i] - offsets[i - 1] - steps[i - 1].Pulse.HoldMs;
+            Assert.True(gap > 0, "consecutive taps must have silence between them");
+        }
+    }
+
+    [Fact]
+    public void EscalateTradesRungsForFeelWhenTheEventIsShort()
+    {
+        // Eight rungs over 300 ms was eight steps of nothing. Fewer, felt rungs instead - and the
+        // full climb is still there when there is time for it.
+        var shortRun = HapticPatterns.Render(VibrationMode.Escalate, 0.6, 300);
+        var longRun = HapticPatterns.Render(VibrationMode.Escalate, 0.6, 4000);
+
+        Assert.True(shortRun.Count < longRun.Count);
+        Assert.Equal(8, longRun.Count);
+        Assert.All(shortRun, s => Assert.True(s.Pulse.HoldMs >= HapticPatterns.MinFeltOnMs));
+
+        // Still an escalation: each rung is stronger than the one before it.
+        for (int i = 1; i < longRun.Count; i++)
+            Assert.True(longRun[i].Pulse.Intensity > longRun[i - 1].Pulse.Intensity);
+    }
+
+    [Fact]
+    public void ASilentRequestStaysSilent()
+    {
+        // The floor is about DURATION. A slider at zero still means nothing at all (#516).
+        Assert.Empty(HapticPatterns.Render(VibrationMode.Constant, 0.0, 1000));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/ProgramLapseAuditTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProgramLapseAuditTests.cs
@@ -1,0 +1,113 @@
+using ConditioningControlPanel.Models.Program;
+using ConditioningControlPanel.Services.Program;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #959: "I do the training program, but after (i think) day 4, it gives me 'training program
+/// stopped'. The run stopped. You ran out of days off." The pre-6.8.0 day clock condemned days the
+/// user had actually finished - 57adfb174 describes the resulting ledger row as carrying "Missed
+/// and, once finished, DayCompleted", a state that means nothing. The clock is fixed for future
+/// runs, but nothing un-lapsed the saves it had already broken.
+///
+/// These tests lock the audit rule. It forgives ONLY a self-contradictory ledger, because that
+/// contradiction is the bug's fingerprint and a consistent ledger is a user who really did miss
+/// the days.
+/// </summary>
+public class ProgramLapseAuditTests
+{
+    private static ProgramEnrollment Enrollment(params (int Day, bool Missed, bool Completed)[] days)
+    {
+        var enrollment = new ProgramEnrollment { ProgramId = "test", CurrentDay = days.Length };
+        foreach (var (day, missed, completed) in days)
+        {
+            enrollment.Records[day] = new ProgramDayRecord
+            {
+                DayIndex = day,
+                Missed = missed,
+                DayCompleted = completed,
+            };
+        }
+        return enrollment;
+    }
+
+    [Fact]
+    public void ADayStampedBothMissedAndComplete_IsTheBugAndTheRunComesBack()
+    {
+        // Day 4 finished AND counted as the absence that spent the last allowance - the exact
+        // shape #959 reports.
+        var audit = ProgramService.AuditLapse(
+            Enrollment((1, false, true), (2, false, true), (3, false, true), (4, true, true)),
+            daysOffAllowed: 1);
+
+        Assert.True(audit.ShouldRestore);
+        Assert.Equal(new[] { 4 }, audit.ContradictoryDays);
+        Assert.Equal(0, audit.CorrectedMissedDays);
+    }
+
+    [Fact]
+    public void AConsistentLedgerStaysLapsed()
+    {
+        // Two real absences against one day off. Nothing contradictory, so the user genuinely
+        // ran out - forgiving this would make the allowance meaningless.
+        var audit = ProgramService.AuditLapse(
+            Enrollment((1, false, true), (2, true, false), (3, true, false)),
+            daysOffAllowed: 1);
+
+        Assert.False(audit.ShouldRestore);
+        Assert.Empty(audit.ContradictoryDays);
+        Assert.Equal(2, audit.CorrectedMissedDays);
+    }
+
+    [Fact]
+    public void AContradictionThatDoesNotChangeTheVerdict_IsCosmeticAndChangesNothing()
+    {
+        // One bogus row, but three real absences against one day off: the run lapses either way,
+        // so un-lapsing it would be a gift rather than a repair.
+        var audit = ProgramService.AuditLapse(
+            Enrollment((1, true, true), (2, true, false), (3, true, false), (4, true, false)),
+            daysOffAllowed: 1);
+
+        Assert.False(audit.ShouldRestore);
+        Assert.Equal(new[] { 1 }, audit.ContradictoryDays);
+        Assert.Equal(3, audit.CorrectedMissedDays);
+    }
+
+    [Fact]
+    public void TheCorrectedCountIsWhatTheAllowanceIsMeasuredAgainst()
+    {
+        // Four missed rows, two of which are contradictions. Two real absences against a
+        // two-day allowance survives - only just, which is the case worth pinning.
+        var audit = ProgramService.AuditLapse(
+            Enrollment((1, true, true), (2, true, true), (3, true, false), (4, true, false)),
+            daysOffAllowed: 2);
+
+        Assert.True(audit.ShouldRestore);
+        Assert.Equal(new[] { 1, 2 }, audit.ContradictoryDays);
+        Assert.Equal(2, audit.CorrectedMissedDays);
+    }
+
+    [Fact]
+    public void StrictModeHasNoAllowance_SoOnlyAFullyBogusLapseIsReversed()
+    {
+        // Strict runs carry zero days off. One surviving absence is still a lapse.
+        var survives = ProgramService.AuditLapse(
+            Enrollment((1, true, true), (2, false, true)), daysOffAllowed: 0);
+        Assert.True(survives.ShouldRestore);
+
+        var doesNot = ProgramService.AuditLapse(
+            Enrollment((1, true, true), (2, true, false)), daysOffAllowed: 0);
+        Assert.False(doesNot.ShouldRestore);
+    }
+
+    [Fact]
+    public void AnUntouchedLedgerIsNeverForgiven()
+    {
+        var audit = ProgramService.AuditLapse(Enrollment((1, false, true)), daysOffAllowed: 1);
+
+        Assert.False(audit.ShouldRestore);
+        Assert.Empty(audit.ContradictoryDays);
+        Assert.Equal(0, audit.CorrectedMissedDays);
+    }
+}


### PR DESCRIPTION
**Stacked on #221** (base `fix/triage-0817-batch`) - merge that one first. Second batch off the same 0817 sweep: the two remaining Highs that leave a user stuck, the 6.8.0 regression that should not ship to Latest, the haptics re-report, and an honesty pass on the Brain Drain report.

## #952 - the session ended behind a fullscreen browser and the machine had to be rebooted

> "I could neither use hypnotube (I can't pause, open settings, use the progress bar...) nor could I use CCP because the hypnotube was on fullscreen. [...] What did end up working was shutting down and then turning on the PC. I still have the XP from the session but I didn't recive the reward at the end."

Three things were missing, and each one alone would have been enough to get out.

**Topmost was owned, not rented.** The forced-fullscreen window is born `Topmost`, which is right - a fullscreen video has to sit over the taskbar - but it kept that claim after another window took focus. So the end-of-session dialog opened alive and modal *behind* a chrome-less, `ShowInTaskbar=false` window: invisible, holding the input queue, with nothing on screen to dismiss it. That is the same shape #905 already fixed for the Deeper player and the same fix applies verbatim - drop the claim on `Deactivated`, take it back on `Activated`. The reporter's missing end-of-session reward is that dialog.

**There was no keyboard way out.** Exiting relied on the page cooperating (the injected double-click / click-pair handlers). If the site swallows those, there is nothing left to try - the window has no chrome, no taskbar button, and the browser has the airspace. Esc and F11 now exit from the *window*, where no page can eat them.

**Session teardown did not know the tube existed.** `StopEngineCore` force-closes lock cards, quizzes, both bubble-count windows, the Descent ceremony and the fuse window. The browser's forced fullscreen was not on that list, so panic could not clear it either. It is now.

## #956 + #962 - the nav rail flyout renders behind the Spiral embed

> "In you/spiral, the spiral overlay renders on top of the side menu" / "On 'the spiral' screen, laterral bar is hidden behind the black background on the image."

One bug, two angles. `NavSidebar` is `Panel.ZIndex=60` over a `ColumnSpan=2` footprint - it does not push the page aside, it flies over it. WPF z-order means nothing to a WebView2: it is a native child HWND and it paints over every WPF element in the same window whatever the z-order says. The Spiral Room's embed is full-bleed, so the entire expanded rail went behind it and the flyout became unusable.

The browser now yields for as long as the flyout is out. `Visibility.Hidden` rather than Collapsed, so it keeps its layout rectangle - nothing reflows, no page state is lost, only the HWND leaves the screen and uncovers the WPF content behind it (for the Spiral Room, the tab's own `#0A0514` ground). Only browsers that actually **intersect** the flyout are touched, so hovering the rail on a page whose browser card is indented past 236px costs nothing.

This is the same mitigation `SpiralRailHost` already makes for the rail-docked mini ("shown ONLY while the rail is wide enough... torn down whenever the rail collapses"), applied from the other side. The proper fix is to re-host the flyout in its own top-level window - the dodge `SettingsPaletteWindow` already takes for exactly this fight - which is a much larger change than a hover state should carry, and is noted in the code.

**This is a 6.8.0 regression, so it wants to land before the promote to Latest.**

## #959 - the runs the old day clock already broke

The clock itself was fixed in `57adfb174` + `cce784b52`, but nothing un-lapsed the saves it had already condemned, and the refund path is gated on `State:Active` - so those users cannot reach it from the UI at all. The reporter has now filed this twice.

A one-shot audit runs at load, before the rollover. **It forgives only a self-contradictory ledger**: a row stamped `Missed` *and* `DayCompleted`, which is precisely the impossible state `57adfb174` describes ("the record carried Missed and, once finished, DayCompleted - a state that means nothing, breaks PerfectDayCount, and spent a day off for a day still in front of the user"). A day cannot be both the absence and the day that was finished, so a lapsed ledger holding such a row was condemned by arithmetic the user never had a say in.

- A consistent ledger stays lapsed. That user really did miss the days, and quietly forgiving them would make the allowance meaningless.
- A contradiction that does not change the verdict changes nothing - un-lapsing there would be a gift, not a repair.
- The run is re-anchored to today on the way back, because `EvaluateRollover` runs immediately afterwards and would otherwise sweep the whole wait as an absence and re-lapse the run on the same launch that just repaired it.
- The audit stamps itself either way, so a genuine lapse is never re-examined.
- The user is told. The reporter filed twice precisely because the run silently stopped and nothing explained it; a silent un-stop is the same failure inverted.

`cce784b52`'s day-boundary bug *discarded* the completion rather than filing it, so those days read as an ordinary miss and are indistinguishable from one. Deliberately not caught - forgiving them would mean forgiving every lapse ever recorded. Those users still have Restart, which keeps banked rewards.

Six tests on the rule, which is pure and static (same idiom as `ProgramClock.Evaluate`).

## #955 - haptics, and why only the long ones worked

> "Haptics still pretty much not working except for constant during video play and some test buttons. Lovense, good signal connection."

That "except" is the whole diagnosis. It is not routing - it is physics. An ERM motor takes roughly 100-150 ms to spin up from rest to a speed anyone can feel, and about as long to coast down. Every discrete event was authored in software time: `BouncingTextBounce` asked for 60 ms, `BubblePop` and `VideoTargetHit` for 100 ms, `BlinkPulse` for 150 ms, and Pulse mode chopped whatever it was given into 50 ms taps. The commands were correct, they reached the toy, and the toy never moved. Everything long worked. Everything short did not.

Every rendered pulse now clears an on-time floor, in all six modes. It is a **floor, not a cap**:

- a 2 s request still gets 2 s;
- Pulse keeps its rhythm - the tap widens to the floor with ~70 ms of silence after it, so it still reads as taps rather than one continuous buzz;
- Heartbeat keeps its 400 ms spacing and its 140 ms `ba-BUMP` offset, both untouched - only the two beats got long enough to exist;
- Escalate derives its rung count from the duration instead of a fixed 8, because eight rungs over a 300 ms event was eight steps of nothing;
- a slider at zero is still silence (#516 is not undone).

The floor is also comfortably above the mixer's 100 ms evaluation period, so a pulse can no longer live and die inside a single tick.

Five tests, which is five more than haptics had - the triage flagged "zero output logging or tests" as systemic and this at least pins the property that decides whether a user feels anything. **Not verified on hardware**; the arithmetic is checkable and the feel is not.

## #960 - not fixed, made legible

> "Brain drain play the audio file if it is available but nothing visual even with every slidder at 100%."

I could not reproduce this and I am not going to pretend a speculative tuning change is a fix. What I can fix is that the report was untriageable. Every path between the button and the pixels can fail **silently** and still log `Brain Drain started on compositor layer` at Information:

- the pump builds no capture slot when GDI refuses a DC or a DIB section;
- `GetTargetScreens` can hand it an empty array during a display transition;
- a slot whose bounds do not contain the host's centre is simply never taken by `Render`.

All three end in a layer that is Active, dirty, drawing nothing, and claiming success. A first-frame watchdog now checks the claim after a 3 s grace and, if the pump has published nothing, logs which of the three it was with the numbers that separate them - and tells the user, instead of leaving them staring at an unchanged screen with a log line that says it worked.

## Verification

- `dotnet build` clean, 0 errors, **no new warnings in any of the eight changed files**.
- Full suite: **3492 passed**, 11 of them new. The single failure, `HeaderBannerTests.NoCodeBehindStillPaintsTheRetiredBeat`, is the same pre-existing environmental one as on #221 - it matches stale copies of `MainWindow.Marquee.cs` under `ConditioningControlPanel/.claude/worktrees/` left by earlier agent sessions, not anything on this branch. Still worth clearing that litter separately.

## Wants a play-test

The two UI behaviours are the kind that read fine in a diff and land wrong on screen: the rail flyout blanking a live Spiral embed on hover, and Esc/F11 exiting fullscreen from underneath a page that thinks it owns the key. Both are cheap to check and neither is covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF359Vd6V8HqpwaC6z57W7
