### PR TITLE
fix(triage): make the #956 breadcrumb reachable, stop a test reading other branches

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -775,6 +775,10 @@ namespace ConditioningControlPanel
         /// leave one hidden.</summary>
         private readonly List<(FrameworkElement Element, Visibility Was)> _navRailAirspaceHeld = new();
 
+        /// <summary>One Information line per run, then Debug - see the log call in
+        /// <see cref="ApplyNavRailAirspace"/> for why the first one has to clear Serilog's floor.</summary>
+        private bool _navRailAirspaceLogged;
+
         /// <summary>
         /// The nav rail is <c>Panel.ZIndex=60</c> over a <c>ColumnSpan=2</c> footprint - it does
         /// not push the page aside, it flies over it. WPF z-order means nothing to a WebView2:
@@ -825,9 +829,26 @@ namespace ConditioningControlPanel
 
                 HoldOverlappingBrowsers(this, flyout);
 
-                if (_navRailAirspaceHeld.Count > 0)
+                if (_navRailAirspaceHeld.Count == 0) return;
+
+                // ONCE AT INFORMATION, THEN QUIET. Serilog's floor is Information (App.xaml.cs), so
+                // a Debug line here can never reach a user's bug report - and this is the breadcrumb
+                // that separates "the rail is behind the page" from "the rail did not open at all",
+                // which is precisely the confusion #956 and #962 arrived as. But the rail expands on
+                // every hover, and on a full-bleed page that is dozens of lines a session, so only
+                // the first hold of a run earns the floor. After that the fact is already in the log.
+                if (!_navRailAirspaceLogged)
+                {
+                    _navRailAirspaceLogged = true;
+                    App.Logger?.Information(
+                        "Nav rail flyout: yielded {Count} browser HWND(s) to uncover the rail (#956). " +
+                        "Further holds this run are logged at Debug.", _navRailAirspaceHeld.Count);
+                }
+                else
+                {
                     App.Logger?.Debug("Nav rail flyout: yielded {Count} browser HWND(s) (#956)",
                         _navRailAirspaceHeld.Count);
+                }
             }
             catch (Exception ex)
             {

--- a/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/HeaderBannerTests.cs
@@ -61,10 +61,16 @@ public class HeaderBannerTests
         // Three partials used to reach for TxtBannerTertiary by name (mod accent, lockdown
         // crimson, the rotation itself). The loc key is deliberately left in the nine language
         // files - it is inert once nothing binds it - so only the code is asserted here.
+        // .claude/worktrees/* holds OTHER BRANCHES' checkouts of this same repo. Scanning them
+        // means asserting against whatever anyone happened to leave lying around, so this test
+        // failed on a clean tree for anyone with an agent worktree still on disk. The same
+        // exclusion is already in PlayDoorRenderTests, YouLibraryDoorTests, AwarenessConsentTests
+        // and Phase8RedirectContractTests - this one was the straggler.
         var stragglers = Directory
             .EnumerateFiles(Path.Combine(RepoRoot(), "ConditioningControlPanel"), "*.cs", SearchOption.AllDirectories)
             .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
-                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                        && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                        && !f.Contains($"{Path.DirectorySeparatorChar}.claude{Path.DirectorySeparatorChar}"))
             .Where(f => File.ReadAllText(f).Contains("TxtBannerTertiary", StringComparison.Ordinal))
             .ToArray();
 


### PR DESCRIPTION
Two follow-ups from verifying the 0817 batches (#221, #222) on `main`. Neither changes the behaviour of any fix in those PRs.

## The #956 breadcrumb could never reach a bug report

`ApplyNavRailAirspace` logged its hold at `Debug`, and Serilog's minimum level is `Information` (`App.xaml.cs`, set there deliberately so nothing sensitive lands in a log). So the one line that separates **"the rail opened and the page is painting over it"** from **"the rail never opened"** was unreachable in any shipped build.

That distinction is the whole of #956/#962 - one bug, described from two angles by two people, precisely because neither could tell which of the two was happening. The triage also flagged the absence of output logging as systemic, so shipping a breadcrumb below the log floor was that same mistake in miniature.

The first hold of a run now clears the floor and says so. Every hold after it stays at `Debug`: the rail expands on every hover, so on a full-bleed page an unconditional `Information` line would write dozens of identical entries a session, and the fact is already in the log after the first one.

## A test was asserting against other branches' source

`HeaderBannerTests.NoCodeBehindStillPaintsTheRetiredBeat` enumerated `ConditioningControlPanel/**/*.cs` excluding only `obj` and `bin` - which sweeps in `.claude/worktrees/*`, i.e. **other branches' checkouts of this same repo**, left behind by agent sessions. The test was grading whatever anyone happened to have on disk.

That is the failure that has been riding along through both 0817 batches. It was never anything on those branches; it is three stale copies of `MainWindow.Marquee.cs` under `.claude/worktrees/`.

`PlayDoorRenderTests`, `YouLibraryDoorTests`, `AwarenessConsentTests` and `Phase8RedirectContractTests` all already carry this exclusion, several with comments spelling out exactly this hazard. `HeaderBannerTests` was the straggler, so this brings it in line rather than inventing a convention.

Deleting the worktree litter would also have made it pass, and would have to be done again the next time an agent leaves a worktree behind. The exclusion is the fix.

## Verification

- `dotnet build` clean, **0 errors**, no warnings in either changed file.
- Full suite: **3493 passed, 0 failed** - the first fully green run in this series.
- The three stale `MainWindow.Marquee.cs` copies are **still on disk** during that run, so the exclusion is what turned the suite green, not a tidy-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF359Vd6V8HqpwaC6z57W7
