### PR TITLE
Mod art framing: two frames were declared as card plates and are not

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -2065,10 +2065,12 @@ namespace ConditioningControlPanel
                 {
                     ("features/lab_gaze_hero.png",      PlayTab?.PlayGazeHeroBrush,     512, ModArtFramingRegistry.SurfacePlayCard),
                     ("features/lab_focusgaze_hero.png", PlayTab?.PlayFocusHeroBrush,    512, ModArtFramingRegistry.SurfacePlayCard),
-                    ("features/goon_game.png",          PlayTab?.PlayGoonHeroBrush,     512, ModArtFramingRegistry.SurfacePlayCard),
+                    ("features/goon_game.png",          PlayTab?.PlayGoonHeroBrush,     512, ModArtFramingRegistry.SurfacePlayCardTall),
                     ("features/lab_quiz_hero.png",      PlayTab?.PlayIntakeHeroBrush,   512, ModArtFramingRegistry.SurfacePlayCard),
                     ("features/blink_trainer.png",      PlayTab?.PlayBlinkHeroBrush,    512, ModArtFramingRegistry.SurfacePlayCard),
-                    ("features/remote_control.png",     PlayTab?.PlayRemoteHeroBrush,   768, ModArtFramingRegistry.SurfacePlayCard),
+                    // Its art plate overrides PlayCardArtPlate's 138 to 168, so it frames against
+                    // the tall variant - a 138-shaped window would be re-cropped ~18% narrower.
+                    ("features/remote_control.png",     PlayTab?.PlayRemoteHeroBrush,   768, ModArtFramingRegistry.SurfacePlayCardTall),
                     ("features/fyp.png",                PlayTab?.PlayFypHeroBrush,      512, ModArtFramingRegistry.SurfacePlayCard),
                     ("lockdown_icon.png",               PlayTab?.PlayLockdownHeroBrush, 1024, ModArtFramingRegistry.SurfacePlayCard),
                     // The page hero and the Loom strip. Both brushes were named and left mutable
@@ -2079,7 +2081,12 @@ namespace ConditioningControlPanel
                     // dtrh is the full-width banner at the top of the wall, not a card header, so
                     // it frames against a much wider box (playHero).
                     ("features/dtrh.png",               PlayTab?.PlayDtrhHeroBrush,     1024, ModArtFramingRegistry.SurfacePlayHero),
-                    ("features/loom.png",               PlayTab?.PlayLoomHeroBrush,     512, ModArtFramingRegistry.SurfacePlayCard),
+                    // The Loom strip is a FIXED 216-wide column, not a card plate. Framed as a
+                    // 2.85:1 plate, an author's 16:9 file was cropped to a 2.85 window and then
+                    // re-cropped by UniformToFill to the column's 1.83 - about 64% x 62% of their
+                    // image, where before framing existed a bare UniformToFill showed nearly all of
+                    // it. Making mod art WORSE was the exact opposite of the point.
+                    ("features/loom.png",               PlayTab?.PlayLoomHeroBrush,     512, ModArtFramingRegistry.SurfaceLoomStrip),
                     // Named and left mutable by the 0812 remake but never fed, so a .ccpmod
                     // overriding features/justdrop.png repainted the dashboard tile and left this
                     // card on the embedded art. Found by the review, which spotted that the card was

--- a/ConditioningControlPanel/Services/ModArtFraming.cs
+++ b/ConditioningControlPanel/Services/ModArtFraming.cs
@@ -158,8 +158,24 @@ namespace ConditioningControlPanel.Services
         /// Same 69 width, ~62 tall once the stepper row is in.</summary>
         public const string SurfaceRailCard = "railCard";
 
-        /// <summary>Play door card header plate: full card width, ~135 tall.</summary>
+        /// <summary>Play door card header plate: full card width, 138 tall (PlayCardArtPlate).</summary>
         public const string SurfacePlayCard = "playCard";
+
+        /// <summary>
+        /// Same plate with its height overridden to 168 — the Remote Control and Goon cards do this
+        /// inline (<c>Style="{StaticResource PlayCardArtPlate}" Height="168"</c>). Its own surface
+        /// rather than a shared 138 because the 30 DIP difference is ~18% of the frame's width once
+        /// UniformToFill re-crops, which is a visibly worse crop and a preview ~20% too wide.
+        /// </summary>
+        public const string SurfacePlayCardTall = "playCardTall";
+
+        /// <summary>
+        /// The Loom strip's art column: a FIXED 216 wide against a MinHeight 118 card
+        /// (PlayTabView.xaml ~1305), so ~1.83:1 — nothing like a card plate. Its art also fades out
+        /// to the RIGHT under a horizontal scrim so a busy illustration never runs into the title;
+        /// that is cosmetic and costs the framing nothing.
+        /// </summary>
+        public const string SurfaceLoomStrip = "loomStrip";
 
         /// <summary>Play door full-width hero banner at the top of the wall.</summary>
         public const string SurfacePlayHero = "playHero";
@@ -190,12 +206,17 @@ namespace ConditioningControlPanel.Services
             // bottom. Its art also fades out to the left under an OpacityMask, which the preview
             // does not reproduce — the framing consequence is nil, the left edge is simply softer.
             new(SurfaceIntakeStrip, "Intake strip",   240.0 / 68.0,  16, ArtScrim.None),
+            // 216 wide is FIXED, so this one is exact in the width that matters. The card's height is
+            // a MinHeight rather than a Height, so a taller card would make it slightly wider-looking
+            // than 1.83:1 — the opposite direction from an over-crop, and not worth a fluid marker.
+            new(SurfaceLoomStrip,  "Loom strip",      216.0 / 118.0, 15, ArtScrim.None),
 
             // Fluid-width surfaces: height is fixed, width follows the window, so these aspects are
             // REPRESENTATIVE and the runtime centre-crops the remainder. See ArtSurface.FluidWidth.
             // playCard: a 138-tall plate whose negative margin bleeds it ~44 past the card, in a
             // 3-column zone at the design width (~350 card + 44). A 2-column zone is nearer 4.3:1.
             new(SurfacePlayCard,   "Play card header", 394.0 / 138.0, 16, ArtScrim.FootBand, FluidWidth: true),
+            new(SurfacePlayCardTall, "Play card header (tall)", 394.0 / 168.0, 16, ArtScrim.FootBand, FluidWidth: true),
             // playHero: the descent portal spans the wall and has no fixed height at all.
             new(SurfacePlayHero,   "Play hero banner", 1100.0 / 240.0, 16, ArtScrim.FootBand, FluidWidth: true),
             // pageHeader: 138 tall, full card width plus the 40 its negative margin reclaims.
@@ -230,16 +251,21 @@ namespace ConditioningControlPanel.Services
             // Play door cards — PlayTabView.xaml. Only Goon carried a rect; the rest were a bare
             // UniformToFill, which is the full-image window and is what Rect(0,0,1,1) means.
             // Goon keeps its rect for OUR art but is not framable: Stretch=Uniform over a plate.
-            new("features/goon_game.png",           SurfacePlayCard, new Rect(0.03, 0.22, 0.94, 0.68), Framable: false),
+            // Its plate is one of the two overridden to 168, hence playCardTall — the aspect is moot
+            // for a non-framable pair (the shipped rect is used verbatim and mod art gets the whole
+            // image), but a row that lies about its own shape is a trap for whoever reads it next.
+            new("features/goon_game.png",           SurfacePlayCardTall, new Rect(0.03, 0.22, 0.94, 0.68), Framable: false),
             new("features/lab_gaze_hero.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
             new("features/lab_focusgaze_hero.png",  SurfacePlayCard, new Rect(0, 0, 1, 1)),
             new("features/lab_quiz_hero.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
             new("features/blink_trainer.png",       SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/remote_control.png",      SurfacePlayCard, new Rect(0, 0, 1, 1)),
+            // Remote's plate overrides the style height to 168 (PlayTabView.xaml:645).
+            new("features/remote_control.png",      SurfacePlayCardTall, new Rect(0, 0, 1, 1)),
             new("features/fyp.png",                 SurfacePlayCard, new Rect(0, 0, 1, 1)),
             new("lockdown_icon.png",                SurfacePlayCard, new Rect(0, 0, 1, 1)),
             new("features/justdrop.png",            SurfacePlayCard, new Rect(0, 0, 1, 1)),
-            new("features/loom.png",                SurfacePlayCard, new Rect(0, 0, 1, 1)),
+            // NOT a card plate at all: a fixed 216-wide column in the Loom strip.
+            new("features/loom.png",                SurfaceLoomStrip, new Rect(0, 0, 1, 1)),
 
             // Play hero banner.
             new("features/dtrh.png", SurfacePlayHero, new Rect(0, 0, 1, 1)),

--- a/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModArtFramingTests.cs
@@ -375,9 +375,65 @@ public class ModArtFramingTests
         Assert.NotNull(literal);
 
         var shipped = ModArtFramingRegistry.ShippedViewbox("features/goon_game.png",
-                                                           ModArtFramingRegistry.SurfacePlayCard);
+                                                           ModArtFramingRegistry.SurfacePlayCardTall);
         Assert.NotNull(shipped);
         AssertRectsMatch(shipped!.Value, literal!.Value, "PlayGoonHeroBrush");
+    }
+
+    // ─── The declared shape has to be the REAL frame's shape ─────────
+    //
+    // A binding pointed at a surface whose aspect does not match its actual frame does not merely
+    // preview wrong: UniformToFill re-crops the stored window down to the real frame, so the author
+    // loses image on BOTH passes. The second review caught two of these, and in the Loom case the
+    // result was mod art cropped harder than before framing existed at all.
+
+    [Theory]
+    // 16:9 is what the editor's own slot labels ask authors to supply (1376x768).
+    [InlineData("features/loom.png", ModArtFramingRegistry.SurfaceLoomStrip, 216.0 / 118.0)]
+    [InlineData("features/remote_control.png", ModArtFramingRegistry.SurfacePlayCardTall, 394.0 / 168.0)]
+    [InlineData("features/fyp.png", ModArtFramingRegistry.SurfacePlayCard, 394.0 / 138.0)]
+    [InlineData("features/lab_quiz_hero.png", ModArtFramingRegistry.SurfaceIntakeStrip, 240.0 / 68.0)]
+    public void ABindingsSurfaceAspectIsTheOneItsRealFrameHas(string path, string surfaceId, double realAspect)
+    {
+        // Guards the binding table against the class of mistake the review found: the surface a path
+        // is bound to must be the shape of the box the art is actually painted into.
+        var surface = ModArtFramingRegistry.FindSurface(surfaceId);
+        Assert.NotNull(surface);
+        Assert.Equal(realAspect, surface!.AspectRatio, 1e-9);
+        Assert.Contains(ModArtFramingRegistry.BindingsFor(path), b => b.SurfaceId == surfaceId);
+    }
+
+    [Fact]
+    public void TheLoomStrip_DoesNotOverCropSixteenNineModArt()
+    {
+        // THE regression this file exists to prevent a second time. The strip is ~1.83:1 and a 16:9
+        // source is 1.78:1, so an un-framed author should keep essentially their whole image - which
+        // is what a bare UniformToFill gave them before framing existed. Bound to the 2.85:1 card
+        // plate it kept about 62% of the height, and then UniformToFill took another bite.
+        const double sixteenNine = 1376.0 / 768.0;
+        var rect = ModArtFramingRegistry.ResolveViewbox(
+            "features/loom.png", ModArtFramingRegistry.SurfaceLoomStrip,
+            isModSupplied: true, sourceAspect: sixteenNine, framing: null);
+
+        Assert.Equal(1.0, rect.Width, 1e-9);
+        Assert.True(rect.Height > 0.95,
+            $"the Loom strip is keeping only {rect.Height:P0} of the height of a 16:9 image; " +
+            "it is a ~1.83:1 frame, so an un-framed author should lose almost nothing");
+    }
+
+    [Fact]
+    public void NoFramableBindingIsPointedAtAFrameShapeItDoesNotHave()
+    {
+        // Every framable pair must resolve to a surface, and no framable pair may sit on the plain
+        // 138 playCard while its plate is one of the two overridden to 168.
+        foreach (var b in ModArtFramingRegistry.Bindings.Where(x => x.Framable))
+        {
+            Assert.NotNull(ModArtFramingRegistry.FindSurface(b.SurfaceId));
+            if (b.ResourcePath is "features/remote_control.png" or "features/goon_game.png")
+                Assert.NotEqual(ModArtFramingRegistry.SurfacePlayCard, b.SurfaceId);
+            if (b.ResourcePath == "features/loom.png")
+                Assert.Equal(ModArtFramingRegistry.SurfaceLoomStrip, b.SurfaceId);
+        }
     }
 
     [Fact]
@@ -387,9 +443,8 @@ public class ModArtFramingTests
         // cropping. A crop preview would be lying about the one surface this registry exists to keep
         // honest, so the editor must never offer it - while the shipped rect above is still needed.
         Assert.False(ModArtFramingRegistry.IsFramable("features/goon_game.png",
-                                                      ModArtFramingRegistry.SurfacePlayCard));
-        Assert.DoesNotContain(ModArtFramingRegistry.FramableBindingsFor("features/goon_game.png"),
-                              b => b.SurfaceId == ModArtFramingRegistry.SurfacePlayCard);
+                                                      ModArtFramingRegistry.SurfacePlayCardTall));
+        Assert.Empty(ModArtFramingRegistry.FramableBindingsFor("features/goon_game.png"));
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #224. Its post-merge review found framing making mod art **worse than it was before framing existed**, in two slots. Both are fixed here.

## Why a wrong aspect costs the author twice

A binding pointed at a surface whose aspect is not its real frame's does not merely preview wrong. The stored window is cut to the *declared* aspect, and then `UniformToFill` re-crops that window down to the *actual* frame — so the author loses image on both passes.

## 1. The Loom strip is not a card plate at all (the regression)

`PlayLoomHeroBrush` fills a **fixed 216-wide column** of a `MinHeight="118"` card (`PlayTabView.xaml` ~1305), about 1.83:1. It was bound to `playCard` at 2.855:1, so a mod's 16:9 file was cut to a 2.855 window keeping ~62% of its height, then re-cropped to the column's 1.83 — roughly **64% x 62%** of the author's picture. Before framing existed, a bare `UniformToFill` of a 1.78 image into a 1.83 frame showed essentially all of it.

The editor was also mocking it at 2.855:1 *with* the "width follows the window, so this shape is representative" note. Both false for a fixed column — precisely the lying preview the registry exists to prevent.

It now has its own fixed `loomStrip` surface.

## 2. Remote Control's plate overrides its own height

`PlayTabView.xaml:645` is `Style="{StaticResource PlayCardArtPlate}" Height="168"`, overriding the style's 138. So the real frame is 2.345:1, not 2.855:1: about **18% of the width** lost to the second crop, and the author frames against a mock ~20% wider than the card they are aiming at.

New `playCardTall` surface. The Goon plate is also 168 and moves with it — moot there, since it is non-framable and its shipped rect is used verbatim, but a row that lies about its own shape is a trap for whoever reads it next.

## Guarded, not just fixed

- A theory pins each binding's surface aspect to the measured geometry of the box its art is really painted into, so this class of mistake fails a test rather than reaching a creator.
- `TheLoomStrip_DoesNotOverCropSixteenNineModArt` asserts an un-framed 16:9 image keeps **>95%** of its height there — the property that was actually broken, stated in the terms an author would notice rather than as an aspect-ratio identity.

## Testing

`dotnet build`: **0 Error(s)**. Suite: **3594 passed, 0 failed**.

Note the suite is now fully green: the long-standing `HeaderBannerTests.NoCodeBehindStillPaintsTheRetiredBeat` failure went away with the stale `.claude/worktrees/` copies it had been scanning. `5e5a8d7f6` on `fix/verify-followups-0817` is still the real fix for that test and is still worth merging, since the next worktree brings the failure back.

## Not addressed

Three further low findings from the same review are left deliberately, recorded but not fixed here:

- `labHeroMap` uses `ResolveImage`, which falls back to the embedded bitmap where `ResolveImageDecoded` returns null, so the "did the mod's image actually land" check can be wrong for those two rows.
- `HasActiveModOverride` inverts its own contract if an event skin and a mod both provide a path. Unreachable today — nothing arms `LiveEventService`, so `EventSkinId` is always null — but it will fire silently the first time events are armed.
- The editor matches surface ids case-sensitively while the runtime matches case-insensitively, so a hand-written `"RailChip"` works in the app, shows as unframed in the editor, and is dropped on re-export.

None change behaviour for a well-formed mod on this build; each wants a small decision rather than a mechanical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF359Vd6V8HqpwaC6z57W7