### PR TITLE
fix(freeze): program hard-freeze solved - corner GIF session path, animator leak, day-2 lockcard arm gap + task-kill-surviving hang diagnostics

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1211,6 +1211,41 @@ namespace ConditioningControlPanel
         }
         private System.Windows.Threading.DispatcherTimer? _hangStressTimer;
 
+        // Hang-watchdog self-test — see the `--test-ui-hang` call site in OnStartup. Blocks the UI
+        // thread outright, which is indistinguishable from a render-thread deadlock as far as the
+        // watchdog's heartbeat is concerned: no posted callback runs, so the silence grows exactly as
+        // it does in a real freeze. Default 30s (the watchdog fires at 10s + a 3s grace re-check, so
+        // this leaves ample room to observe the report landing and to task-kill mid-wedge in order to
+        // exercise the cross-session sentinel).
+        private void StartUiHangSelfTest(string[] args)
+        {
+            int seconds = 30;
+            for (int i = 0; i < args.Length - 1; i++)
+                if (args[i] == "--test-ui-hang" && int.TryParse(args[i + 1], out int parsed) && parsed > 0)
+                    seconds = Math.Min(parsed, 300);
+
+            int wedgeFor = seconds;
+            Logger?.Warning("[HANGTEST] UI-hang self-test armed - the UI thread will block for {Sec}s in 8s", wedgeFor);
+
+            var timer = new System.Windows.Threading.DispatcherTimer(System.Windows.Threading.DispatcherPriority.Normal)
+            {
+                Interval = TimeSpan.FromSeconds(8)
+            };
+            timer.Tick += (s, _) =>
+            {
+                timer.Stop();
+                // Leave a breadcrumb first so the report has something to show beyond "(none)".
+                Services.HangContext.Enter("hangtest.deliberate-wedge");
+                Services.HangContext.Note("about to block the UI thread for " + wedgeFor + "s");
+                Logger?.Warning("[HANGTEST] blocking the UI thread NOW for {Sec}s", wedgeFor);
+                System.Threading.Thread.Sleep(wedgeFor * 1000);
+                Logger?.Warning("[HANGTEST] UI thread released");
+                Services.HangContext.Leave("hangtest.deliberate-wedge");
+            };
+            timer.Start();
+            _hangStressTimer = timer;   // root it so it isn't collected
+        }
+
         protected override void OnStartup(StartupEventArgs e)
         {
             // Dump-writer mode: spawned by UiHangWatchdog in a WEDGED sibling CCP process
@@ -1497,6 +1532,12 @@ namespace ConditioningControlPanel
             // crash self-documents (with last-known context) in this session's log.
             Services.Chaos.ChaosCrashSentinel.ConsumeAndReport(Logger);
             Services.EngineCrashSentinel.ConsumeAndReport(Logger);
+
+            // Same idea for a UI FREEZE rather than a crash: if the last session wedged and the
+            // user task-killed it (the only way out of a hard freeze), the watchdog's findings are
+            // sitting in a sentinel file that nothing has read yet. Replay them here so the freeze
+            // shows up in THIS session's log tail — which is what the bug reporter attaches.
+            Services.UiHangWatchdog.ConsumeAndReportPreviousHang(Logger);
 
             // React to monitor topology / resolution changes (unplug, res change, DPI): drop the stale
             // screen cache AND pause layered-window spawns briefly so we don't create fresh surfaces
@@ -2367,6 +2408,14 @@ namespace ConditioningControlPanel
             // via env vars so the harness can dial it without a rebuild.
             if (e.Args.Contains("--stress"))
                 StartHangStressMode();
+
+            // `--test-ui-hang [seconds]`: deliberately wedge the UI thread so the hang watchdog can be
+            // verified end to end (report file, sentinel, minidump, and - if the process is killed
+            // while wedged - the "PREVIOUS SESSION HUNG" replay on the next launch). There is no other
+            // way to exercise it: a real wedge is a render-thread deadlock we cannot summon on demand.
+            // Dead code in every normal launch.
+            if (e.Args.Contains("--test-ui-hang"))
+                StartUiHangSelfTest(e.Args);
 
             // `--goon-test`: dev play-test cockpit for the Goon Game 1v1 duel — two independent
             // player panels in this one process (each with its OWN GoonGameService, never the
@@ -4411,6 +4460,10 @@ Application State:
             try { Services.Chaos.ChaosCrashSentinel.Clear(); } catch { }
             try { Services.EngineCrashSentinel.Clear(); } catch { }
             try { Services.CornerGifService.ClearSentinelOnCleanExit(); } catch { }
+            // A shutdown that takes >13s (video teardown, haptics stop, WebView2 dispose) can trip
+            // the watchdog on the way out. That is not the freeze we are hunting — disarm it so the
+            // next launch doesn't cry hang over a clean, if slow, exit.
+            try { Services.UiHangWatchdog.ClearSentinelOnCleanExit(); } catch { }
 
             // Haptics FIRST and synchronously (bounded ~2s): a Lovense level has no server-side
             // watchdog, so a toy we don't countermand keeps running after the app is gone. This

--- a/ConditioningControlPanel/Services/CornerGifService.cs
+++ b/ConditioningControlPanel/Services/CornerGifService.cs
@@ -71,6 +71,22 @@ namespace ConditioningControlPanel.Services
         private Window? _subscribedWindow;
 
         /// <summary>
+        /// How many overlay windows are live (+ how many realizations are still queued), for the
+        /// hang report. Read by <see cref="HangContext"/> on the WATCHDOG thread while the UI thread
+        /// may be wedged, so this must stay a pair of plain field reads: Dictionary/HashSet Count is
+        /// an int field, safe to read concurrently (a stale value is fine, a lock would not be — the
+        /// UI thread could be holding it, which is exactly the case we are diagnosing).
+        /// </summary>
+        internal string ActiveWindowCount
+        {
+            get
+            {
+                try { return _windows.Count + "+" + _pending.Count + "pending"; }
+                catch { return "(unavailable)"; }
+            }
+        }
+
+        /// <summary>
         /// Tears down every overlay and re-shows the ones currently enabled in settings.
         /// Safe to call from any thread; marshals to the UI thread. The teardown is synchronous but
         /// each re-show is deferred one dispatcher pass (see QueueShow). Call after any config
@@ -247,6 +263,7 @@ namespace ConditioningControlPanel.Services
 
             foreach (var w in new List<Window>(_windows.Values))
             {
+                ReleaseAnimator(w);
                 try { w.Close(); }
                 catch { /* already gone */ }
             }
@@ -269,10 +286,35 @@ namespace ConditioningControlPanel.Services
             if (_windows.TryGetValue(index, out var w))
             {
                 _windows.Remove(index);
+                ReleaseAnimator(w);
                 try { w.Close(); }
                 catch { /* already gone */ }
             }
             SyncSentinel();
+        }
+
+        /// <summary>
+        /// Clear the GIF source before closing the overlay window. RepeatBehavior.Forever installs
+        /// a clock that keeps handing the render thread native-size WriteableBitmap frames and pins
+        /// the Image for as long as the source is set; Close() alone does not tear it down. These
+        /// overlays are rebuilt on every settings edit (the size/opacity sliders refresh a slot per
+        /// debounce rest, an enable toggle or a SpiralPath change rebuilds BOTH slots), so without
+        /// this each edit leaves another live animator driving the render thread - a slow-onset
+        /// render-thread saturation that ends in the UI thread blocking inside WriteableBitmap.Lock
+        /// with no exception. Same teardown every other XamlAnimatedGif site in the app performs.
+        /// </summary>
+        private static void ReleaseAnimator(Window w)
+        {
+            try
+            {
+                if (w.Content is Image img)
+                {
+                    try { AnimationBehavior.SetSourceUri(img, null); } catch { }
+                    try { img.Source = null; } catch { }
+                }
+                w.Content = null;
+            }
+            catch { /* teardown must never throw */ }
         }
 
         private int BumpSlot(int index)
@@ -587,7 +629,13 @@ namespace ConditioningControlPanel.Services
             _windows[index] = window;
             try
             {
-                window.Show();
+                // Show() on a layered window realizes its render target synchronously; if the render
+                // thread wedges here the hang report must name this call rather than "(idle)".
+                using (VideoDiag.UiScope($"CornerGifService.ShowOne(slot {index}, layered Show)"))
+                using (HangContext.Scope($"cornerGif.show[{index}]"))
+                {
+                    window.Show();
+                }
             }
             catch (Exception ex)
             {

--- a/ConditioningControlPanel/Services/Session/SessionEngine.cs
+++ b/ConditioningControlPanel/Services/Session/SessionEngine.cs
@@ -158,6 +158,9 @@ namespace ConditioningControlPanel.Services
             // pools are actually overridden: IsOverridingPhrasePools stays false until
             // RememberPrescribedPools runs below.
             Active = this;
+            // Breadcrumb for the hang report: names the session (and, for a program day, which day
+            // via HangContext's passive program probe) that was live when the UI thread died.
+            HangContext.Enter("session:" + (session?.Name ?? "?"));
             _isPaused = false;
             _pauseCount = 0;
             _pausedElapsedTime = TimeSpan.Zero;
@@ -289,6 +292,7 @@ namespace ConditioningControlPanel.Services
             // (ElapsedTime property returns Zero when not running)
             var finalElapsedTime = ElapsedTime;
 
+            HangContext.Leave("session:" + (_currentSession?.Name ?? "?"));
             _isRunning = false;
             // Hand phrase-pool custody back to the user. Cleared here rather than at the end of
             // StopSession so nothing can read stale prescribed pools while teardown is in flight;
@@ -1553,6 +1557,9 @@ namespace ConditioningControlPanel.Services
             _savedSettings = null;
         }
         
+        /// <summary>Source GIFs beyond this many pixels are logged as a hazard - see ShowCornerGif.</summary>
+        private const long CornerGifOversizeSourcePixels = 4_000_000;   // ~2000x2000
+
         private void ShowCornerGif(SessionSettings settings)
         {
             try
@@ -1560,6 +1567,7 @@ namespace ConditioningControlPanel.Services
                 var gifPath = settings.CornerGifPath;
                 Uri? gifUri = null;
                 System.Drawing.Image? img = null;
+                System.IO.MemoryStream? imgBacking = null;   // must outlive img (see the resource branch)
 
                 if (!string.IsNullOrEmpty(gifPath) && System.IO.File.Exists(gifPath))
                 {
@@ -1593,10 +1601,14 @@ namespace ConditioningControlPanel.Services
                             var resourceInfo = Application.GetResourceStream(gifUri);
                             if (resourceInfo?.Stream != null)
                             {
-                                using (resourceInfo.Stream)
-                                {
-                                    img = System.Drawing.Image.FromStream(resourceInfo.Stream);
-                                }
+                                // GDI+ keeps reading the source stream for the Image's whole
+                                // lifetime, so the resource stream must NOT be disposed while img
+                                // is still alive - copy it into a buffer that outlives it (the same
+                                // correction CornerGifService.ShowOne carries).
+                                imgBacking = new System.IO.MemoryStream();
+                                using (var src = resourceInfo.Stream) src.CopyTo(imgBacking);
+                                imgBacking.Position = 0;
+                                img = System.Drawing.Image.FromStream(imgBacking);
                                 App.Logger?.Information("Corner GIF not set or found, defaulting to spiral.gif resource");
                             }
                         }
@@ -1610,6 +1622,8 @@ namespace ConditioningControlPanel.Services
                 if (img == null || gifUri == null)
                 {
                     App.Logger?.Warning("Could not load corner GIF image - skipping corner GIF display");
+                    img?.Dispose();
+                    imgBacking?.Dispose();
                     return;
                 }
 
@@ -1617,15 +1631,34 @@ namespace ConditioningControlPanel.Services
                 _cornerGifWidth = img.Width;
                 _cornerGifHeight = img.Height;
                 img.Dispose();
+                imgBacking?.Dispose();
 
                 double gifWidth = _cornerGifWidth;
                 double gifHeight = _cornerGifHeight;
+
+                // Bug #625: a decoded-but-degenerate image (0x0) makes the scale below divide by
+                // zero, and assigning the resulting NaN/Infinity to Window.Width/Height throws deep
+                // inside WPF layout. Bail out loudly instead of handing WPF non-finite geometry.
+                if (gifWidth <= 0 || gifHeight <= 0)
+                {
+                    App.Logger?.Warning("Corner GIF has degenerate size {W}x{H} ({Path}) - skipping overlay",
+                        gifWidth, gifHeight, gifUri);
+                    return;
+                }
 
                 // Scale based on user's size setting (default 300)
                 var targetSize = settings.CornerGifSize > 0 ? settings.CornerGifSize : 300;
                 double scale = targetSize / Math.Max(gifWidth, gifHeight);
                 double windowWidth = gifWidth * scale;
                 double windowHeight = gifHeight * scale;
+
+                if (!double.IsFinite(scale) || !double.IsFinite(windowWidth) || !double.IsFinite(windowHeight)
+                    || windowWidth <= 0 || windowHeight <= 0)
+                {
+                    App.Logger?.Warning("Corner GIF computed non-finite overlay geometry (scale={Scale}, {W}x{H}) - skipping overlay",
+                        scale, windowWidth, windowHeight);
+                    return;
+                }
 
                 // Get actual screen bounds using Forms.Screen (more reliable for DPI)
                 var screen = System.Windows.Forms.Screen.PrimaryScreen;
@@ -1689,6 +1722,31 @@ namespace ConditioningControlPanel.Services
                     Stretch = System.Windows.Media.Stretch.Uniform
                 };
 
+                // Per-frame downscale quality (#954/#958/#984). This is the SAME overlay the
+                // standalone CornerGifService draws, and it was left on the default filter when
+                // PR #221 hardened that one - so a session-scoped corner GIF (the only kind the
+                // 28-day programs raise: FW-Override, i.e. Firmware days 12-14) still ran the
+                // expensive path in v6.8.2, which is why the fix "didn't take" for the day-14
+                // reporter. XamlAnimatedGif hands the render thread a WriteableBitmap at the GIF's
+                // NATIVE size and WPF resamples it to the overlay's size on EVERY frame; the
+                // default for a downscale is the costly Fant filter. On a layered window - whose
+                // composition is a full UpdateLayeredWindow blit rather than a GPU surface flip -
+                // that resample saturates the render thread, and a saturated render thread blocks
+                // the UI thread inside WriteableBitmap.Lock (the CWGXBitmapLockState::LockRead
+                // wedge in UiHangWatchdog's dump notes). Bilinear costs a fraction and is
+                // indistinguishable on a spiral at 70-300px.
+                System.Windows.Media.RenderOptions.SetBitmapScalingMode(
+                    imageElement, System.Windows.Media.BitmapScalingMode.LowQuality);
+
+                long sourcePixels = (long)gifWidth * (long)gifHeight;
+                if (sourcePixels > CornerGifOversizeSourcePixels)
+                {
+                    App.Logger?.Warning(
+                        "Corner GIF source is {W}x{H} ({MP:F1}MP) but the overlay draws it at {TW}x{TH} - every frame is resampled at full size, which is the shape of the #954/#958 freeze. Consider a smaller GIF.",
+                        (int)gifWidth, (int)gifHeight, sourcePixels / 1_000_000.0,
+                        (int)windowWidth, (int)windowHeight);
+                }
+
                 // Catch GIF rendering errors gracefully instead of letting them crash the app.
                 // Must be attached BEFORE SetSourceUri: that starts an async load, so a fault
                 // raised in the gap would have no subscriber.
@@ -1710,7 +1768,14 @@ namespace ConditioningControlPanel.Services
                 {
                     MakeWindowClickThrough(_cornerGifWindow);
                 };
-                _cornerGifWindow.Show();
+                // Show() on a layered window realizes its render target synchronously; if the
+                // render thread wedges here the watchdog's report needs to name this call, and
+                // "(idle)" is what the day-14 reports carried. Scope it.
+                using (VideoDiag.UiScope("SessionEngine.ShowCornerGif(layered Show)"))
+                {
+                    _cornerGifWindow.Show();
+                }
+                HangContext.Enter("session.cornerGif");
 
                 App.Logger?.Information("Corner GIF shown at {Position}: {Path} (pos: {Left},{Top}, size: {Width}x{Height}px, opacity: {Opacity}%)",
                     settings.CornerGifPosition, gifUri.ToString(), left, top, (int)windowWidth, (int)windowHeight, settings.CornerGifOpacity);
@@ -1723,11 +1788,29 @@ namespace ConditioningControlPanel.Services
 
         private void CloseCornerGif()
         {
+            // Release the animator BEFORE closing the window. RepeatBehavior.Forever installs a
+            // clock that keeps pushing frames at the render thread and pins the Image (and its
+            // native-size WriteableBitmap) for as long as the source is set - Close() alone does
+            // not tear it down. Every other XamlAnimatedGif site in the app clears the source on
+            // teardown for exactly this reason (BlinkTrainerService, ChaosGifCascadeOverlay,
+            // AvatarTubeWindow, MiniPlayerWindow); the corner GIF was the one that didn't, and it
+            // is rebuilt on every size/path change mid-session (UpdateCornerGifSize/Path), so the
+            // orphaned animators accumulate across a long program day.
+            if (_cornerGifImage != null)
+            {
+                try { AnimationBehavior.SetSourceUri(_cornerGifImage, null); } catch { }
+                try { _cornerGifImage.Source = null; } catch { }
+            }
             if (_cornerGifWindow != null)
             {
-                _cornerGifWindow.Close();
+                try { _cornerGifWindow.Content = null; } catch { }
+                using (VideoDiag.UiScope("SessionEngine.CloseCornerGif(layered Close)"))
+                {
+                    _cornerGifWindow.Close();
+                }
                 _cornerGifWindow = null;
             }
+            HangContext.Leave("session.cornerGif");
             _cornerGifImage = null;
             _cornerGifWidth = 0;
             _cornerGifHeight = 0;

--- a/ConditioningControlPanel/Services/UI/HangContext.cs
+++ b/ConditioningControlPanel/Services/UI/HangContext.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+
+namespace ConditioningControlPanel.Services;
+
+/// <summary>
+/// The "what was the app doing?" half of a hang report.
+///
+/// WHY THIS EXISTS (program-freeze wave, v6.8.2 — day-14 corner GIF, day-2 lock card, #984):
+/// <see cref="UiHangWatchdog"/> already proves WHEN the dispatcher died and (via
+/// <see cref="VideoDiag.UiMarkDescription"/>) names the native call it died inside — but only for
+/// the handful of compositor/flash/overlay paths that carry a <c>UiScope</c>. Every one of the
+/// program freezes reported "(idle)", which tells us only that the wedge is somewhere
+/// uninstrumented. A stack (the minidump) without the feature state is half a diagnosis: knowing
+/// the UI thread is parked in a bitmap lock does not say whether a corner GIF, a lock card or a
+/// program day rollover put it there.
+///
+/// This class is that missing half: a passive, lock-free record of which features are live and what
+/// the app last did, cheap enough to write on ordinary code paths and safe to READ from the
+/// watchdog thread while the UI thread is wedged.
+///
+/// THREADING CONTRACT (must not regress the hang it diagnoses):
+///   * <see cref="Note"/> / <see cref="Enter"/> / <see cref="Leave"/> are enqueue-only: one
+///     interlocked increment and an array store, or one ConcurrentDictionary write. They never
+///     block, never take a lock a reader could hold, never touch the disk and never touch WPF.
+///     Safe from the UI thread, threadpool timers and native callback threads alike.
+///   * <see cref="Describe"/> runs on the WATCHDOG thread while the UI is presumed dead. It must
+///     therefore never take a lock the UI thread could be holding and never touch a
+///     DispatcherObject. It reads only bools/ints/strings off already-constructed service
+///     instances, each in its own try/catch, so one wedged or half-torn-down service cannot cost
+///     us the rest of the report.
+/// </summary>
+public static class HangContext
+{
+    /// <summary>Breadcrumbs kept. Small on purpose: the last few actions are what matter.</summary>
+    private const int RingSize = 24;
+
+    private static readonly string?[] _ring = new string[RingSize];
+    private static int _ringNext = -1;              // Interlocked.Increment => first slot is 0
+
+    /// <summary>
+    /// Process start, resolved once. Taken from the OS rather than from this type's static
+    /// initializer: HangContext is initialized lazily on its first touch, which can be minutes into
+    /// a session, and "uptime=13s" on an app that had been up for an hour would actively mislead the
+    /// person reading the report. Falls back to the static-init moment if the OS call fails.
+    /// </summary>
+    private static readonly long _startTick = ResolveStartTick();
+
+    private static long ResolveStartTick()
+    {
+        try
+        {
+            using var p = System.Diagnostics.Process.GetCurrentProcess();
+            var upMs = (DateTime.Now - p.StartTime).TotalMilliseconds;
+            if (upMs >= 0 && upMs < TimeSpan.FromDays(30).TotalMilliseconds)
+                return Environment.TickCount64 - (long)upMs;
+        }
+        catch { }
+        return Environment.TickCount64;
+    }
+
+    /// <summary>Feature name -> TickCount64 when it went active. Removal = it went inactive.</summary>
+    private static readonly ConcurrentDictionary<string, long> _active = new(StringComparer.Ordinal);
+
+    /// <summary>Milliseconds since the process started (as seen by this class).</summary>
+    public static long UptimeMs => Environment.TickCount64 - _startTick;
+
+    /// <summary>
+    /// Record one breadcrumb ("what just happened"). Cheap enough for feature start/stop, day
+    /// rollovers and dialog shows; NOT for per-frame paths (use <see cref="VideoDiag.UiScope"/>
+    /// there, which is two volatile writes and no allocation).
+    /// </summary>
+    public static void Note(string what)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(what)) return;
+            int slot = (int)((uint)Interlocked.Increment(ref _ringNext) % RingSize);
+            _ring[slot] = string.Concat(
+                DateTime.Now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture), " ", what);
+        }
+        catch { /* diagnostics must never throw into a feature path */ }
+    }
+
+    /// <summary>Mark a feature as live. Idempotent; the first Enter wins the timestamp.</summary>
+    public static void Enter(string feature)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(feature)) return;
+            _active.TryAdd(feature, Environment.TickCount64);
+            Note("+ " + feature);
+        }
+        catch { }
+    }
+
+    /// <summary>Mark a feature as no longer live. Safe to call without a matching Enter.</summary>
+    public static void Leave(string feature)
+    {
+        try
+        {
+            if (string.IsNullOrEmpty(feature)) return;
+            if (_active.TryRemove(feature, out _)) Note("- " + feature);
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// <c>using var _ = HangContext.Scope("LockCard.Show");</c> — Enter on construction, Leave on
+    /// dispose. Use for a bounded operation; use Enter/Leave directly for a feature that outlives
+    /// one call.
+    /// </summary>
+    public static FeatureScope Scope(string feature) => new(feature);
+
+    public readonly struct FeatureScope : IDisposable
+    {
+        private readonly string _feature;
+        internal FeatureScope(string feature) { _feature = feature; Enter(feature); }
+        public void Dispose() => Leave(_feature);
+    }
+
+    /// <summary>
+    /// The full state block for a hang report. Never throws, never blocks, safe from the watchdog
+    /// thread while the UI thread is wedged. Multi-line.
+    /// </summary>
+    public static string Describe()
+    {
+        var sb = new StringBuilder(1024);
+        try
+        {
+            sb.Append("uptime=").Append((UptimeMs / 1000.0).ToString("F0", CultureInfo.InvariantCulture)).AppendLine("s");
+            sb.Append("lastUiMark=").AppendLine(Safe(() => VideoDiag.UiMarkDescription));
+            sb.Append("uiStallMs=").AppendLine(Safe(() => VideoDiag.UiStallMs.ToString(CultureInfo.InvariantCulture)));
+            sb.AppendLine("state:");
+            foreach (var line in DescribeServices()) sb.Append("  ").AppendLine(line);
+            sb.Append("activeFeatures: ").AppendLine(DescribeActive());
+            sb.AppendLine("recent:");
+            foreach (var crumb in RecentBreadcrumbs()) sb.Append("  ").AppendLine(crumb);
+        }
+        catch (Exception ex)
+        {
+            try { sb.AppendLine("(hang context failed: " + ex.Message + ")"); } catch { }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>One-line form for the Serilog hang line (the log tail a bug report attaches).</summary>
+    public static string DescribeCompact()
+    {
+        try
+        {
+            return string.Concat(
+                "uptime=", (UptimeMs / 1000).ToString(CultureInfo.InvariantCulture), "s",
+                " active=[", DescribeActive(), "]",
+                " last=", LastBreadcrumb());
+        }
+        catch { return "(unavailable)"; }
+    }
+
+    private static string DescribeActive()
+    {
+        try
+        {
+            if (_active.IsEmpty) return "(none)";
+            var sb = new StringBuilder();
+            long now = Environment.TickCount64;
+            foreach (var kv in _active)
+            {
+                if (sb.Length > 0) sb.Append(", ");
+                sb.Append(kv.Key).Append('(').Append((now - kv.Value) / 1000).Append("s)");
+                if (sb.Length > 600) { sb.Append(", ..."); break; }
+            }
+            return sb.ToString();
+        }
+        catch { return "(unavailable)"; }
+    }
+
+    private static string LastBreadcrumb()
+    {
+        try
+        {
+            int next = Volatile.Read(ref _ringNext);
+            if (next < 0) return "(none)";
+            return _ring[(int)((uint)next % RingSize)] ?? "(none)";
+        }
+        catch { return "(unavailable)"; }
+    }
+
+    /// <summary>Breadcrumbs oldest-first. Tolerates a torn ring (a slot rewritten mid-read).</summary>
+    private static string[] RecentBreadcrumbs()
+    {
+        try
+        {
+            int next = Volatile.Read(ref _ringNext);
+            if (next < 0) return new[] { "(none)" };
+            int count = Math.Min(RingSize, next + 1);
+            var outp = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                int idx = (int)((uint)(next - (count - 1 - i)) % RingSize);
+                outp[i] = _ring[idx] ?? "(?)";
+            }
+            return outp;
+        }
+        catch { return new[] { "(unavailable)" }; }
+    }
+
+    /// <summary>
+    /// Passive read of the services whose state actually distinguishes the reported freezes from
+    /// each other. Every probe is independently try/caught: a service that is null (not yet
+    /// constructed, or torn down) or whose getter throws costs one line, not the report.
+    /// Deliberately reads plain fields only — no dispatcher marshalling, no locks, no I/O.
+    /// </summary>
+    private static string[] DescribeServices()
+    {
+        var lines = new System.Collections.Generic.List<string>(12);
+
+        lines.Add("sessionRunning=" + Safe(() => App.IsSessionRunning.ToString()));
+
+        // Program: the day number is the single most valuable field in these reports — "day 14"
+        // and "day 2" are the whole shape of the complaint.
+        lines.Add("program=" + Safe(() =>
+        {
+            var enrollment = App.Programs?.ActiveEnrollment;
+            if (enrollment == null) return "(none enrolled)";
+            return string.Concat(enrollment.ProgramId, " day=", enrollment.CurrentDay.ToString(CultureInfo.InvariantCulture));
+        }));
+
+        lines.Add("lockCardRunning=" + Safe(() => App.LockCard?.IsRunning.ToString() ?? "(null)"));
+        lines.Add("cornerGifWindows=" + Safe(() => App.CornerGif?.ActiveWindowCount ?? "(null)"));
+        lines.Add("compositor=" + Safe(() => App.Compositor == null ? "(off)" : "on"));
+
+        return lines.ToArray();
+    }
+
+    private static string Safe(Func<string> probe)
+    {
+        try { return probe() ?? "(null)"; }
+        catch (Exception ex) { return "(probe failed: " + ex.GetType().Name + ")"; }
+    }
+}

--- a/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
+++ b/ConditioningControlPanel/Services/UI/UiHangWatchdog.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Windows.Threading;
 using Microsoft.Win32.SafeHandles;
@@ -79,6 +80,23 @@ public static class UiHangWatchdog
         _thread.Start();
     }
 
+    /// <summary>
+    /// Which silence budget applies: the ordinary one once the dispatcher has pumped at least one
+    /// heartbeat, or the much longer startup budget before that (OnStartup runs the whole service
+    /// init synchronously on the UI thread, so pre-first-beat silence is by design — see the type
+    /// remarks and the v6.2.x "stuck on splash" wave that firing early caused).
+    /// </summary>
+    internal static long ThresholdFor(bool hasPumpedOnce)
+        => hasPumpedOnce ? HANG_THRESHOLD_MS : STARTUP_HANG_THRESHOLD_MS;
+
+    /// <summary>
+    /// The whole hang verdict, as a pure function of "how long has the dispatcher been silent" and
+    /// "has it ever pumped". Extracted so the decision is testable headlessly — the loop it came
+    /// from can only be exercised by actually wedging a real dispatcher.
+    /// </summary>
+    internal static bool IsHung(long silenceMs, bool hasPumpedOnce)
+        => silenceMs > ThresholdFor(hasPumpedOnce);
+
     private static void Loop(Dispatcher dispatcher)
     {
         CleanupOldDumps();
@@ -102,16 +120,16 @@ public static class UiHangWatchdog
                 }
 
                 bool started = Volatile.Read(ref _firstBeatSeen) == 1;
-                long threshold = started ? HANG_THRESHOLD_MS : STARTUP_HANG_THRESHOLD_MS;
+                long threshold = ThresholdFor(started);
                 long silence = Environment.TickCount64 - Volatile.Read(ref _lastBeatTick);
-                if (silence > threshold)
+                if (IsHung(silence, started))
                 {
                     // Re-check once after a short grace period: a sleep/resume gap or a debugger
                     // break also stalls the heartbeat, but those recover within one beat.
                     Thread.Sleep(3000);
                     if (dispatcher.HasShutdownStarted) return;
                     silence = Environment.TickCount64 - Volatile.Read(ref _lastBeatTick);
-                    if (silence <= threshold) continue;
+                    if (!IsHung(silence, started)) continue;
 
                     if (!_hangLogged)
                     {
@@ -121,16 +139,24 @@ public static class UiHangWatchdog
                         // "(idle)" when the wedge is somewhere uninstrumented, which is itself a
                         // useful negative — see the breadcrumb contract in VideoDiag.
                         string mark = VideoDiag.UiMarkDescription;
-                        App.Logger?.Error("[WATCHDOG] UI thread unresponsive for {Sec:F0}s{Phase} — likely render-thread deadlock; last UI mark: {Mark}",
-                            silence / 1000.0, started ? "" : " (never pumped — wedged during startup)", mark);
+                        // ...and HangContext names WHICH FEATURE was live when it happened, which the
+                        // stack alone does not (the program-freeze wave all reported mark="(idle)").
+                        string state = HangContext.DescribeCompact();
+                        App.Logger?.Error("[WATCHDOG] UI thread unresponsive for {Sec:F0}s{Phase} — likely render-thread deadlock; last UI mark: {Mark}; {State}",
+                            silence / 1000.0, started ? "" : " (never pumped — wedged during startup)", mark, state);
                         // Mirror into the video trace. These lines only ever went to the ROLLING
                         // Serilog file, which a post-freeze relaunch scrolls straight out of the
                         // 100-line tail a bug report attaches — the exact evidence loss VideoDiag
                         // exists to prevent (#750-#753). Log() is a no-op until VideoDiag.Start ran.
                         VideoDiag.Log("WATCHDOG", string.Format(
                             System.Globalization.CultureInfo.InvariantCulture,
-                            "UI thread unresponsive for {0:F0}s{1} - last UI mark: {2}",
-                            silence / 1000.0, started ? "" : " (never pumped - wedged during startup)", mark));
+                            "UI thread unresponsive for {0:F0}s{1} - last UI mark: {2}; {3}",
+                            silence / 1000.0, started ? "" : " (never pumped - wedged during startup)", mark, state));
+
+                        // Durable, human-readable report + the cross-session sentinel. Written
+                        // BEFORE the minidump because the dump can take up to 60s (or never finish)
+                        // and a task-kill during it must still leave evidence behind.
+                        WriteHangReport(silence, started, mark);
                     }
                     if (!_dumpWritten)
                     {
@@ -143,6 +169,10 @@ public static class UiHangWatchdog
                     _hangLogged = false;
                     App.Logger?.Warning("[WATCHDOG] UI thread recovered");
                     VideoDiag.Log("WATCHDOG", "UI thread recovered");
+                    // The app came back, so this session will log its own story and exit cleanly.
+                    // Disarm the sentinel: it exists ONLY to speak for a session that was
+                    // task-killed while wedged and therefore never got to say anything.
+                    ClearSentinel();
                 }
             }
             catch { }
@@ -245,6 +275,164 @@ public static class UiHangWatchdog
 
     [DllImport("kernel32.dll")]
     private static extern IntPtr GetCurrentProcess();
+
+    // ── DURABLE HANG REPORT + CROSS-SESSION SENTINEL ─────────────────────────────────────────
+    //
+    // WHY (program-freeze wave, v6.8.2 — day-14 corner GIF, day-2 lock card, #984): every one of
+    // those reports is a HARD freeze, i.e. the user task-kills the app. That kill costs us
+    // everything the watchdog just learned unless it is already on the platter:
+    //   * The Serilog line above goes to the ROLLING app log, and the relaunch the user needs in
+    //     order to FILE the report writes hundreds of startup lines over it — the freeze scrolls
+    //     out of the 100-line tail the bug reporter attaches. (Same evidence loss VideoDiag was
+    //     built for; we mirror there too, but that file rolls at 1MB.)
+    //   * The minidump is the best evidence and the least likely to arrive: it is tens of MB, the
+    //     user is never told it exists, and the bug reporter cannot attach it.
+    // So: one small, self-contained, immediately-flushed text file per hang episode, plus a
+    // sentinel that the NEXT launch consumes and re-logs loudly. After a task-kill the very first
+    // lines of the fresh session's log then say "you froze, here is what was running" — which is
+    // in the tail, so it reaches us through the ordinary bug-report path with no user effort.
+    private const int MaxReportsPerSession = 5;
+    private static int _reportsWritten;
+
+    private static string SentinelPath => Path.Combine(App.UserDataPath, "logs", "ui_hang.pending");
+
+    private static void WriteHangReport(long silenceMs, bool startedPumping, string mark)
+    {
+        try
+        {
+            if (_reportsWritten >= MaxReportsPerSession) return;
+            _reportsWritten++;
+
+            string dir = Path.Combine(App.UserDataPath, "logs");
+            Directory.CreateDirectory(dir);
+            string path = Path.Combine(dir, $"hang_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
+
+            var body = new StringBuilder(2048);
+            body.AppendLine("CCP UI-hang report");
+            body.Append("when       : ").AppendLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+            body.Append("version    : ").AppendLine(Safe(() => UpdateService.AppVersion));
+            body.Append("pid        : ").AppendLine(Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            body.Append("silence    : ").Append((silenceMs / 1000.0).ToString("F0", System.Globalization.CultureInfo.InvariantCulture)).AppendLine("s");
+            body.Append("phase      : ").AppendLine(startedPumping ? "running" : "STARTUP (dispatcher never pumped)");
+            body.Append("lastUiMark : ").AppendLine(mark);
+            body.AppendLine();
+            body.AppendLine(HangContext.Describe());
+
+            string text = body.ToString();
+
+            // WriteThrough: a hard power-off (several of these reports end that way) must not be
+            // able to take the file back with it.
+            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write,
+                       FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.WriteThrough))
+            using (var sw = new StreamWriter(fs, Encoding.UTF8))
+            {
+                sw.Write(text);
+                sw.Flush();
+                fs.Flush(true);
+            }
+
+            ArmSentinel(text);
+            CleanupOldReports();
+
+            App.Logger?.Error("[WATCHDOG] hang report written: {Path}", path);
+            VideoDiag.Log("WATCHDOG", "hang report written: " + path);
+        }
+        catch (Exception ex)
+        {
+            // Last resort: if the file could not be written, at least get the state into the log.
+            try
+            {
+                App.Logger?.Error("[WATCHDOG] hang report file failed ({E}); state inline:{NL}{State}",
+                    ex.Message, Environment.NewLine, HangContext.Describe());
+            }
+            catch { }
+        }
+    }
+
+    private static void ArmSentinel(string reportText)
+    {
+        try
+        {
+            string path = SentinelPath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            using var fs = new FileStream(path, FileMode.Create, FileAccess.Write,
+                FileShare.ReadWrite | FileShare.Delete, 4096, FileOptions.WriteThrough);
+            using var sw = new StreamWriter(fs, Encoding.UTF8);
+            sw.Write(reportText);
+            sw.Flush();
+            fs.Flush(true);
+        }
+        catch { }
+    }
+
+    private static void ClearSentinel()
+    {
+        try
+        {
+            string path = SentinelPath;
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// Clean shutdown — even a slow one — is not a hang. Called from App.OnExit next to the other
+    /// dirty-shutdown sentinels so the next launch does not false-report a freeze the user
+    /// actually sat through and then quit normally.
+    /// </summary>
+    public static void ClearSentinelOnCleanExit() => ClearSentinel();
+
+    /// <summary>
+    /// Called once at startup. If a sentinel survived, the previous session was wedged when the
+    /// process died (task-kill / hard reset) and never got to log anything more. Re-log the whole
+    /// captured state at Error level — the production Serilog floor is Information, so a Debug
+    /// line here would be invisible in the field — and consume the file so it reports once.
+    /// </summary>
+    public static void ConsumeAndReportPreviousHang(Serilog.ILogger? logger)
+    {
+        try
+        {
+            string path = SentinelPath;
+            if (!File.Exists(path)) return;
+
+            string body = "";
+            DateTime armed = DateTime.MinValue;
+            try { body = File.ReadAllText(path).Trim(); } catch { }
+            try { armed = File.GetLastWriteTime(path); } catch { }
+
+            logger?.Error(
+                "[WATCHDOG] PREVIOUS SESSION HUNG: the UI thread was unresponsive at {Armed} and the process " +
+                "died without recovering (task-kill / hard reset), so nothing else was logged. " +
+                "Captured state follows; a matching hang_*.dmp/.txt may be next to this log.{NL}{Body}",
+                armed == DateTime.MinValue ? "(unknown)" : armed.ToString("yyyy-MM-dd HH:mm:ss"),
+                Environment.NewLine,
+                string.IsNullOrWhiteSpace(body) ? "(state unavailable)" : body);
+
+            ClearSentinel();
+        }
+        catch { }
+    }
+
+    /// <summary>Keep the four newest text reports; they are tiny but should not accumulate forever.</summary>
+    private static void CleanupOldReports()
+    {
+        try
+        {
+            string dir = Path.Combine(App.UserDataPath, "logs");
+            foreach (var f in new DirectoryInfo(dir).GetFiles("hang_*.txt")
+                         .OrderByDescending(f => f.LastWriteTimeUtc).Skip(4))
+            {
+                try { f.Delete(); } catch { }
+            }
+        }
+        catch { }
+    }
+
+    private static string Safe(Func<string> probe)
+    {
+        try { return probe() ?? "(null)"; }
+        catch { return "(unavailable)"; }
+    }
 
     private static void WriteDump(long silenceMs)
     {

--- a/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/LockCardWindow.xaml.cs
@@ -110,6 +110,17 @@ namespace ConditioningControlPanel
         private static System.Threading.Thread? _watchdogThread;
         private static IntPtr[] _watchdogHwnds = Array.Empty<IntPtr>();
         private static volatile int _watchdogOpenCount;
+        // Cards whose Show() has been entered but has not returned yet. THE bug this closes (#984,
+        // "froze on the day-2 lock card"): the snapshot only counts windows that already have an
+        // hwnd, so on a POOL MISS - a freshly constructed window, i.e. the very first card of a run,
+        // which for a program is day 2 - the pre-Show snapshot counted zero, the watchdog thread
+        // never started, and the switch was disarmed across the one Show() that can actually wedge
+        // (#494's synchronous CompleteRender on a fresh WS_EX_LAYERED realization). Every LATER card
+        // is pooled, so its hwnd is already valid and the switch armed - which is exactly why the
+        // field reports single out the first card and not "any lock card". Counting shows in flight
+        // arms the switch for the fresh case too, so a wedge there gets the emergency drop and the
+        // fail-fast rung instead of leaving the user to task-kill.
+        private static volatile int _watchdogShowsInFlight;
         private static volatile bool _watchdogPongPending;
         private static volatile bool _watchdogDropped;
         // Hwnds hit by EmergencyDrop. SLWA permanently breaks WPF's layered rendering on them, so any
@@ -550,6 +561,10 @@ namespace ConditioningControlPanel
         {
             base.OnSourceInitialized(e);
             _hwnd = new WindowInteropHelper(this).Handle;
+            // Hand the hwnd to the dead-man's switch NOW: we are inside the fresh Show() and ahead of
+            // the CompleteRender that can wedge, so this is the only moment at which a pool-miss card
+            // can make itself droppable before it might stop responding.
+            PublishWatchdogHwnd(_hwnd);
 
             // Swallow WM_DPICHANGED: this window's geometry is computed manually per-monitor
             // (PositionOnScreen uses the target monitor's DPI), so WPF's automatic DPI rescale is
@@ -1228,15 +1243,63 @@ namespace ConditioningControlPanel
                     if (w._hwnd != IntPtr.Zero) hwnds.Add(w._hwnd);
                 _watchdogHwnds = hwnds.ToArray();
                 _watchdogOpenCount = hwnds.Count;
-                if (_watchdogOpenCount > 0 && (_watchdogThread == null || !_watchdogThread.IsAlive))
-                {
-                    _watchdogThread = new System.Threading.Thread(WatchdogLoop)
-                    {
-                        IsBackground = true,
-                        Name = "LockCardDeadManSwitch"
-                    };
-                    _watchdogThread.Start();
-                }
+                EnsureWatchdogThread();
+            }
+        }
+
+        /// <summary>Start the switch thread if anything is (or is about to be) covering the screen.
+        /// Caller must hold <see cref="_watchdogLock"/>.</summary>
+        private static void EnsureWatchdogThread()
+        {
+            if (_watchdogOpenCount == 0 && _watchdogShowsInFlight == 0) return;
+            if (_watchdogThread != null && _watchdogThread.IsAlive) return;
+            _watchdogThread = new System.Threading.Thread(WatchdogLoop)
+            {
+                IsBackground = true,
+                Name = "LockCardDeadManSwitch"
+            };
+            _watchdogThread.Start();
+        }
+
+        /// <summary>
+        /// Arm the switch across one <c>Show()</c> - see <see cref="_watchdogShowsInFlight"/> for why
+        /// the snapshot alone is not enough on a pool miss. Always paired with
+        /// <see cref="EndWatchdogShow"/> in a finally.
+        /// </summary>
+        private static void BeginWatchdogShow()
+        {
+            lock (_watchdogLock)
+            {
+                _watchdogShowsInFlight++;
+                EnsureWatchdogThread();
+            }
+        }
+
+        private static void EndWatchdogShow()
+        {
+            lock (_watchdogLock)
+            {
+                if (_watchdogShowsInFlight > 0) _watchdogShowsInFlight--;
+            }
+        }
+
+        /// <summary>
+        /// Publish a just-created hwnd to the watchdog's view. Called from OnSourceInitialized, which
+        /// runs synchronously INSIDE Show() and BEFORE the CompleteRender that can wedge - so the
+        /// emergency drop can still reach a window whose Show() never returned. Without this the
+        /// in-flight arming would reach the fail-fast rung with an empty hwnd array and could only
+        /// kill the process, never free the screen the gentle way.
+        /// </summary>
+        private static void PublishWatchdogHwnd(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero) return;
+            lock (_watchdogLock)
+            {
+                foreach (var h in _watchdogHwnds) if (h == hwnd) return;
+                var grown = new IntPtr[_watchdogHwnds.Length + 1];
+                Array.Copy(_watchdogHwnds, grown, _watchdogHwnds.Length);
+                grown[^1] = hwnd;
+                _watchdogHwnds = grown;
             }
         }
 
@@ -1247,7 +1310,7 @@ namespace ConditioningControlPanel
             {
                 System.Threading.Thread.Sleep(1000);
 
-                if (_watchdogOpenCount == 0)
+                if (_watchdogOpenCount == 0 && _watchdogShowsInFlight == 0)
                 {
                     // No card up: idle. Reset so a stale ping from a previous card can't count as a wedge.
                     _watchdogPongPending = false;
@@ -1299,7 +1362,7 @@ namespace ConditioningControlPanel
                     try { dispatcher.BeginInvoke(new Action(EmergencyRecoveryCleanup), DispatcherPriority.Send); }
                     catch { }
                 }
-                else if (stalled >= WATCHDOG_FAILFAST_MS && _watchdogOpenCount > 0)
+                else if (stalled >= WATCHDOG_FAILFAST_MS && (_watchdogOpenCount > 0 || _watchdogShowsInFlight > 0))
                 {
                     App.Logger?.Fatal(
                         "[WATCHDOG] LockCardWindow: UI thread still wedged {Ms}ms after the emergency drop - terminating so the screen is freed",
@@ -1577,11 +1640,24 @@ namespace ConditioningControlPanel
                 // wedge site is the show sequence itself (#494's synchronous CompleteRender on a fresh
                 // realization), and by iteration N the earlier monitors' cards are already fullscreen
                 // topmost. Pre-Show covers pooled reuse (hwnd already valid); post-Show covers a fresh
-                // window whose hwnd materialized inside Show(). Windows without an hwnd yet are skipped
-                // by the snapshot, so the pre-Show call is safe on a pool miss.
+                // window whose hwnd materialized inside Show(). A pool MISS has no hwnd yet, so the
+                // snapshot alone counts zero and would leave the switch disarmed across precisely the
+                // Show() that can wedge - BeginWatchdogShow closes that hole (see _watchdogShowsInFlight).
                 UpdateWatchdogSnapshot();
-                window.Show();
-                window.OnShown();   // per-show foreground/focus/voice (Loaded no longer re-fires on reuse)
+                BeginWatchdogShow();
+                try
+                {
+                    using (VideoDiag.UiScope("LockCardWindow.Show(fullscreen layered)"))
+                    using (HangContext.Scope("lockCard.show"))
+                    {
+                        window.Show();
+                        window.OnShown();   // per-show foreground/focus/voice (Loaded no longer re-fires on reuse)
+                    }
+                }
+                finally
+                {
+                    EndWatchdogShow();
+                }
                 UpdateWatchdogSnapshot();
             }
 

--- a/Tests/ConditioningControlPanel.Tests/UiHangWatchdogTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/UiHangWatchdogTests.cs
@@ -1,0 +1,136 @@
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The program-freeze wave (day-14 corner GIF, day-2 lock card, #984) is a HARD freeze: the UI
+/// thread stops, nothing throws, crash.log stays empty and the user task-kills. The watchdog is the
+/// only thing that can turn the NEXT one into evidence, so its verdict has to be right in both
+/// directions: it must fire on a real wedge, and it must NOT fire during the long synchronous
+/// startup init (firing there is what caused the v6.2.x "stuck on splash, relaunch a couple of
+/// times" wave, because the dump write froze the app on top of a start that was merely slow).
+///
+/// These lock the staleness rule and the state snapshot that rides along with it. The loop itself
+/// can only be exercised by wedging a real dispatcher, which is why the verdict was extracted.
+/// </summary>
+public class UiHangWatchdogTests
+{
+    // ── Staleness verdict ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShortStall_IsNotAHang()
+    {
+        // A GC pause, a slow frame, a settings save: seconds of silence are normal.
+        Assert.False(UiHangWatchdog.IsHung(silenceMs: 3_000, hasPumpedOnce: true));
+        Assert.False(UiHangWatchdog.IsHung(silenceMs: 9_999, hasPumpedOnce: true));
+    }
+
+    [Fact]
+    public void SilenceBeyondTheRunningBudget_IsAHang()
+    {
+        // Past this the app is unusable and every field report describes a task-kill.
+        Assert.True(UiHangWatchdog.IsHung(silenceMs: 10_001, hasPumpedOnce: true));
+        Assert.True(UiHangWatchdog.IsHung(silenceMs: 120_000, hasPumpedOnce: true));
+    }
+
+    [Fact]
+    public void BeforeTheFirstHeartbeat_ALongStartupIsNotAHang()
+    {
+        // OnStartup runs the whole service init synchronously on the UI thread, so it CANNOT pump a
+        // heartbeat until it finishes. A cold disk cache or a post-update AV rescan makes that take
+        // far longer than the running budget, and treating it as a wedge is the v6.2.x regression.
+        Assert.False(UiHangWatchdog.IsHung(silenceMs: 30_000, hasPumpedOnce: false));
+        Assert.False(UiHangWatchdog.IsHung(silenceMs: 119_000, hasPumpedOnce: false));
+    }
+
+    [Fact]
+    public void BeforeTheFirstHeartbeat_AnExtremeStallIsStillAHang()
+    {
+        // A genuinely dead-forever init step (a wedge inside MainWindow creation) must not get an
+        // infinite pass just because it happened before the first beat.
+        Assert.True(UiHangWatchdog.IsHung(silenceMs: 121_000, hasPumpedOnce: false));
+    }
+
+    [Fact]
+    public void TheStartupBudgetIsStrictlyMoreGenerousThanTheRunningOne()
+    {
+        Assert.True(UiHangWatchdog.ThresholdFor(hasPumpedOnce: false)
+                  > UiHangWatchdog.ThresholdFor(hasPumpedOnce: true));
+    }
+
+    // ── State snapshot (HangContext) ─────────────────────────────────────────
+    //
+    // A stack alone is half a diagnosis. The reports we have say the UI thread died with last UI
+    // mark "(idle)" — i.e. somewhere uninstrumented — so the report has to carry WHICH FEATURE was
+    // live instead. These lock that the snapshot actually records it.
+
+    [Fact]
+    public void ActiveFeaturesAppearInTheCompactSnapshot()
+    {
+        HangContext.Enter("test.cornerGif");
+        try
+        {
+            Assert.Contains("test.cornerGif", HangContext.DescribeCompact());
+        }
+        finally
+        {
+            HangContext.Leave("test.cornerGif");
+        }
+    }
+
+    [Fact]
+    public void LeavingAFeatureRemovesItFromTheSnapshot()
+    {
+        HangContext.Enter("test.lockCard");
+        HangContext.Leave("test.lockCard");
+        // Only the "active" list must drop it; the breadcrumb trail deliberately keeps the history.
+        var compact = HangContext.DescribeCompact();
+        Assert.DoesNotContain("test.lockCard(", compact);
+    }
+
+    [Fact]
+    public void ScopeLeavesTheFeatureOnDispose()
+    {
+        using (HangContext.Scope("test.scoped"))
+        {
+            Assert.Contains("test.scoped", HangContext.DescribeCompact());
+        }
+        Assert.DoesNotContain("test.scoped(", HangContext.DescribeCompact());
+    }
+
+    [Fact]
+    public void TheLastBreadcrumbIsWhatTheReportShows()
+    {
+        HangContext.Note("test.breadcrumb.marker");
+        Assert.Contains("test.breadcrumb.marker", HangContext.DescribeCompact());
+    }
+
+    [Fact]
+    public void TheBreadcrumbRingDoesNotGrowWithoutBound()
+    {
+        // The ring is written on ordinary feature paths and read while the UI is wedged, so it must
+        // stay a fixed-size buffer rather than a list that balloons during a long session.
+        for (int i = 0; i < 500; i++) HangContext.Note("test.flood." + i);
+        var compact = HangContext.DescribeCompact();
+        Assert.Contains("test.flood.499", compact);
+        Assert.DoesNotContain("test.flood.0 ", compact);
+    }
+
+    [Fact]
+    public void NoteAndLeaveAreSafeWithJunkInput()
+    {
+        // Diagnostics run on feature paths and must never be the thing that takes the app down.
+        HangContext.Note("");
+        HangContext.Note(null!);
+        HangContext.Enter("");
+        HangContext.Leave("test.never-entered");
+        Assert.NotNull(HangContext.DescribeCompact());
+    }
+
+    [Fact]
+    public void UptimeIsNonNegative()
+    {
+        Assert.True(HangContext.UptimeMs >= 0);
+    }
+}


### PR DESCRIPTION
Fixes the program hard-freeze reported by Vee (ticket 1539282547484139682, day 14 Firmware Install) and Dolly (day-2 lock card).

Three defects:
1. PR #221 fixed only CornerGifService (the mirror). SessionEngine.ShowCornerGif - the path every program day uses - never got the LowQuality-scaling / #625 geometry / GDI+ stream fixes. Applied here.
2. GIF animators were never released on teardown in either path (slow-onset render-thread wedge). Fixed.
3. The lock-card dead-man's switch never armed on a window-pool miss, i.e. the FIRST card of a run = program day 2 (the #494 deadlock window). Fixed via in-flight counting + hwnd published from OnSourceInitialized.

Plus diagnostics that survive task-kill: HangContext lock-free registry, hang_<ts>.txt (WriteThrough) + ui_hang.pending sentinel replayed at Error level on next launch. Dev flag --test-ui-hang verified E2E. 12 new tests; suite 3607 passed / 5 known nested-worktree baseline failures (identical on untouched origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3mrhKZQj2ehTJUhj2ueon