### PR TITLE
fix(modcreator): mod authors can supply art for all 69 achievements, not 29

### DIFF
--- a/ConditioningControlPanel/Windows/ModCreatorWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/ModCreatorWindow.xaml.cs
@@ -74,38 +74,15 @@ namespace ConditioningControlPanel
         private readonly bool _startWithTutorial;
 
         // ─── Slot Definitions ────────────────────────────────────
-        private static readonly (string Key, string Name)[] AchievementSlots =
-        {
-            ("achievements/lv_10.png", "Plastic Initiation"),
-            ("achievements/Dumb_Bimbo.png", "Dumb Bimbo"),
-            ("achievements/lv_50.png", "Fully Synthetic"),
-            ("achievements/docile_cow.png", "Docile Cow"),
-            ("achievements/perfect_plastic_puppet.png", "Perfect Plastic Puppet"),
-            ("achievements/BrainwashedSlavedoll.png", "Brainwashed Slavedoll"),
-            ("achievements/PlatinumPuppet.png", "Platinum Puppet"),
-            ("achievements/10_hours_pink.png", "Rose-Tinted Reality"),
-            ("achievements/deep_sleep.png", "Deep Sleep Mode"),
-            ("achievements/daily_maintenance.png", "Daily Maintenance"),
-            ("achievements/retinal_burn.png", "Retinal Burn"),
-            ("achievements/morning_glory.png", "Morning Glory"),
-            ("achievements/player_2_disconnected.png", "Player 2 Disconnected"),
-            ("achievements/sofa_decor.png", "Sofa Decor"),
-            ("achievements/look_but_dont_touch.png", "Look But Don't Touch"),
-            ("achievements/spiral_eyes.png", "Spiral Eyes"),
-            ("achievements/Mathematician's_nightmare.png", "Mathematician's Nightmare"),
-            ("achievements/pop_the_Thought.png", "Pop Goes The Thought"),
-            ("achievements/typing_tutor.png", "Typing Tutor"),
-            ("achievements/obedience_reflex.png", "Obedience Reflex"),
-            ("achievements/mercy_beggar.png", "Mercy Beggar"),
-            ("achievements/clean_slate.png", "Clean Slate"),
-            ("achievements/corner_hit.png", "Corner Hit"),
-            ("achievements/Neon_obsession.png", "Neon Obsession"),
-            ("achievements/What_panic_button.png", "Panic Button?"),
-            ("achievements/relapse.png", "Relapse"),
-            ("achievements/total_lockdown.png", "Total Lockdown"),
-            ("achievements/system_overload.png", "System Overload"),
-            ("achievements/how_many.png", "How Many?"),
-        };
+        // Derived from the achievement registry instead of hand-listed. The literal that used
+        // to live here froze at 29 entries while Achievement.All grew to 69, so mod authors
+        // could not supply badge art for two thirds of the Trophy Case, and it still offered a
+        // slot for achievements/how_many.png - an achievement that no longer exists in the
+        // registry, so nothing would ever render the art an author put there.
+        //
+        // Achievement.All is built once and never mutated, so enumerating it yields insertion
+        // order, which keeps the slots in rough progression order the way the old list was.
+        private static readonly (string Key, string Name)[] AchievementSlots = ModAchievementSlots.Build();
 
         private static readonly (string Key, string Name)[] FeatureSlots =
         {
@@ -2722,6 +2699,72 @@ namespace ConditioningControlPanel
                 try { Directory.Delete(_loadedTempDir, recursive: true); } catch { }
                 _loadedTempDir = null;
             }
+        }
+    }
+
+    /// <summary>
+    /// Builds the Mod Creator's achievement art slots from <see cref="Achievement.All"/>.
+    ///
+    /// Split out of <see cref="ModCreatorWindow"/> so the derivation is testable without a
+    /// Dispatcher, and derived rather than hand-listed because the hand-listed version rotted:
+    /// it stopped at 29 of the registry's 69 achievements and still offered a slot for a badge
+    /// (how_many.png) that no achievement claims any more.
+    /// </summary>
+    internal static class ModAchievementSlots
+    {
+        /// <summary>
+        /// One slot per distinct badge file, in registry order.
+        ///
+        /// The key is the packed resource path (<c>achievements/&lt;ImageName&gt;</c>); the name is
+        /// the label printed over the art slot. Two achievements can share one badge file
+        /// (first_week_graduate reuses daily_maintenance.png) and every dictionary in the editor
+        /// is keyed by resource key, so a duplicate would collide and throw. The shared file gets
+        /// a single slot whose label names both achievements it feeds, so an author can see what
+        /// their art will be used for.
+        /// </summary>
+        public static (string Key, string Name)[] Build()
+        {
+            var slots = new List<(string Key, string Name)>();
+            // Ordinal-ignore-case because the key becomes a filename inside the .ccpmod, and two
+            // ImageNames differing only in case would be one file on disk.
+            var seen = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var achievement in Achievement.All.Values)
+            {
+                if (string.IsNullOrWhiteSpace(achievement.ImageName)) continue;
+
+                var key = $"achievements/{achievement.ImageName}";
+                var name = SlotName(achievement);
+
+                if (seen.TryGetValue(key, out var index))
+                {
+                    var existing = slots[index].Name;
+                    if (existing.IndexOf(name, StringComparison.OrdinalIgnoreCase) < 0)
+                        slots[index] = (slots[index].Key, $"{existing} / {name}");
+                    continue;
+                }
+
+                seen[key] = slots.Count;
+                slots.Add((key, name));
+            }
+
+            return slots.ToArray();
+        }
+
+        /// <summary>
+        /// The achievement's localized name, falling back to its built-in English name when the
+        /// localization key is missing - LocalizationManager echoes an unknown key straight back,
+        /// which would print a raw <c>achievement_x_name</c> over the art slot (only 40 of the 69
+        /// achievements currently carry a name key). Same rule the profile title uses in
+        /// MainWindow.ProfileCosmetics.ResolveAchievementTitle. Mod-awareness is applied later by
+        /// BuildImageSlotsSection, exactly as it is for every other slot list.
+        /// </summary>
+        private static string SlotName(Achievement achievement)
+        {
+            var localized = achievement.LocalizedName;
+            return string.IsNullOrWhiteSpace(localized) || localized == $"achievement_{achievement.Id}_name"
+                ? achievement.Name
+                : localized;
         }
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/ModAchievementSlotTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ModAchievementSlotTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using ConditioningControlPanel;
+using ConditioningControlPanel.Models;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Mod Creator's achievement art slots are derived from <see cref="Achievement.All"/>
+/// (<see cref="ModAchievementSlots.Build"/>) rather than hand-listed, because the hand-listed
+/// version rotted silently: it froze at 29 entries while the registry grew to 69, so mod authors
+/// had no way to ship badge art for two thirds of the Trophy Case, and it still offered a slot
+/// for achievements/how_many.png - a badge no achievement claims any more.
+///
+/// Nothing here needs a Dispatcher: the derivation is a pure function of the registry.
+/// </summary>
+public class ModAchievementSlotTests
+{
+    [Fact]
+    public void EveryAchievementBadgeGetsASlot()
+    {
+        var slots = ModAchievementSlots.Build();
+        var expected = Achievement.All.Values
+            .Select(a => a.ImageName)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Assert.Equal(expected.Count, slots.Length);
+        foreach (var image in expected)
+            Assert.Contains(slots, s => s.Key == $"achievements/{image}");
+    }
+
+    /// <summary>
+    /// Every dictionary in the editor (_imageSlots, _imageControls, _imageNames, _imageNameBoxes)
+    /// is keyed by resource key, so a duplicate key would throw on the second CreateImageSlot.
+    /// first_week_graduate and daily_maintenance share daily_maintenance.png, which is exactly
+    /// the case a naive one-slot-per-achievement derivation would trip over.
+    /// </summary>
+    [Fact]
+    public void SlotKeysAreUnique()
+    {
+        var slots = ModAchievementSlots.Build();
+        var distinct = slots.Select(s => s.Key).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        Assert.Equal(slots.Length, distinct);
+    }
+
+    /// <summary>A shared badge file is labelled with both achievements it feeds.</summary>
+    [Fact]
+    public void SharedBadgeFileNamesBothAchievements()
+    {
+        var slot = ModAchievementSlots.Build().Single(s => s.Key == "achievements/daily_maintenance.png");
+        Assert.Contains(Achievement.All["first_week_graduate"].Name, slot.Name);
+        Assert.Contains(Achievement.All["daily_maintenance"].Name, slot.Name);
+    }
+
+    /// <summary>
+    /// The dead slot is gone. Art dropped on it could never appear anywhere in the app.
+    /// </summary>
+    [Fact]
+    public void NoSlotForARetiredBadge()
+    {
+        Assert.DoesNotContain(ModAchievementSlots.Build(), s => s.Key == "achievements/how_many.png");
+    }
+
+    /// <summary>
+    /// Slots follow registry order, which is roughly progression order - the property the old
+    /// hand-written list had and the reason the derivation enumerates the dictionary as-is.
+    /// </summary>
+    [Fact]
+    public void SlotsFollowRegistryOrder()
+    {
+        var slots = ModAchievementSlots.Build();
+        var expected = Achievement.All.Values
+            .Select(a => $"achievements/{a.ImageName}")
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Assert.Equal(expected, slots.Select(s => s.Key).ToList());
+    }
+
+    /// <summary>
+    /// A missing localization key must never print a raw achievement_x_name over an art slot -
+    /// LocalizationManager echoes unknown keys back, and only 40 of the 69 achievements carry a
+    /// name key today.
+    /// </summary>
+    [Fact]
+    public void NoSlotLabelIsARawLocalizationKey()
+    {
+        foreach (var slot in ModAchievementSlots.Build())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(slot.Name));
+            Assert.DoesNotContain("achievement_", slot.Name, StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

The Mod Creator's Achievements panel was built from a hand-written literal in `Windows/ModCreatorWindow.xaml.cs`. It was last touched at lane F (`a6f70e61d`) and froze there at **29 slots**, while `Achievement.All` grew to **69 achievements (68 distinct badge files)**.

Two consequences, neither visible at build time:

1. **40 achievements had no slot at all.** A mod author had no way to supply badge art for two thirds of the Trophy Case - the panel simply did not offer the slot.
2. **A dead slot: `achievements/how_many.png`.** No achievement in the registry claims that file any more. Art dropped there got packed into the `.ccpmod` and rendered nowhere, forever.

## Fix

`AchievementSlots` is now derived from `Achievement.All` at type load, via a small `internal static class ModAchievementSlots` (same pattern as `ModImageSlotRules` - no Dispatcher, so it is unit-testable):

- key = `achievements/{a.ImageName}`, label = the achievement's `LocalizedName`
- **loc fallback:** `LocalizationManager` echoes an unknown key straight back and only 40 of the 69 achievements carry an `achievement_<id>_name` key, so a raw `achievement_she_remembers_name` would have been printed over the art slot. The helper falls back to the built-in English `Name` in that case - the same rule `MainWindow.ProfileCosmetics.ResolveAchievementTitle` already uses. Mod-awareness is still applied downstream by `BuildImageSlotsSection`, exactly as for every other slot list.
- **registry order preserved** (`Achievement.All` is built once and never mutated), so the panel still reads roughly as progression order
- the dead `how_many` slot is gone

### Dedupe

`first_week_graduate` reuses `daily_maintenance.png`. Every dictionary in this window (`_imageSlots`, `_imageControls`, `_imageNames`, `_imageNameBoxes`) is keyed by resource key, so a second entry would have thrown on the second `CreateImageSlot`. The shared file gets **one** slot whose label names both badges it feeds: **"First Week / Daily Maintenance"** - the label sits over the art slot, so naming both tells the author what their art will be used for. Dedupe is `OrdinalIgnoreCase` because the key becomes a filename inside the package.

## Mod-load round-trip

The load path (`BtnLoad_Click` and `LoadActiveModAsPreset`) iterates `_imageSlots.Keys` and picks up only files that exist for a known key. **A package carrying art for a file that is not in the slot list is ignored, never fatal** - loading a mod with `how_many.png` did not throw before and does not now.

What changes is how much survives a *load-then-export*, since export copies only from `_imageSlots`. Measured against our own shipped `DroneMod/drone-mode.ccpmod`, which carries 58 achievement badges:

| | before | after |
|---|---|---|
| badges that round-trip | 28 | **57** |
| silently dropped on re-export | 29 | 1 (`how_many.png`, the retired badge) |
| renamed on re-export | 1 (`Sofa_decor.png` -> `sofa_decor.png`) | 0 |

The old literal listed `sofa_decor.png` where the registry says `Sofa_decor.png`; the load lookup is case-insensitive on Windows so it loaded, but the export wrote it back under the wrong casing. Deriving from the registry makes the casing match exactly.

## Tests

New `Tests/ConditioningControlPanel.Tests/ModAchievementSlotTests.cs` (6 facts): slot count == distinct `ImageName` count, key uniqueness, the shared-badge label names both achievements, registry order, no `how_many` slot, and no label is ever a raw localization key.

- `dotnet build` green (0 errors)
- `dotnet test`: **3614 passed, 5 failed** - exactly the known nested-worktree baseline (`YouLibraryDoorTests` x4 + `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`), which fail identically on untouched `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3mrhKZQj2ehTJUhj2ueon
