### PR TITLE
fix(programs): the You -> Programs hard freeze on a hot run (#984 #993 #996 #1001)

### DIFF
--- a/ConditioningControlPanel/Helpers/ProgramCometGate.cs
+++ b/ConditioningControlPanel/Helpers/ProgramCometGate.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace ConditioningControlPanel.Helpers
+{
+    /// <summary>What the rail comet should do on this pass.</summary>
+    public enum ProgramCometAction
+    {
+        /// <summary>A usable travel distance was measured - start (or restart) the run.</summary>
+        Run = 0,
+        /// <summary>Nothing measurable yet. Re-ask later, at a priority BELOW input.</summary>
+        Retry = 1,
+        /// <summary>Out of attempts. No comet this visit; the rest of the tab is untouched.</summary>
+        GiveUp = 2,
+    }
+
+    /// <summary>The decision, plus the width to animate over and the attempt count to store back.</summary>
+    public readonly struct ProgramCometDecision
+    {
+        public ProgramCometDecision(ProgramCometAction action, double width, int attempts)
+        {
+            Action = action;
+            Width = width;
+            Attempts = attempts;
+        }
+
+        public ProgramCometAction Action { get; }
+
+        /// <summary>Travel distance for the run. Meaningful only when <see cref="Action"/> is Run.</summary>
+        public double Width { get; }
+
+        /// <summary>The attempt counter to WRITE BACK to the caller's field after this decision.</summary>
+        public int Attempts { get; }
+    }
+
+    /// <summary>
+    /// The rail comet's "may I run yet?" gate, extracted from the FX code so the thing that once
+    /// hard-froze the app is a pure function with tests instead of a branch inside a dispatcher
+    /// callback.
+    ///
+    /// <para><b>Why this exists.</b> The comet's travel distance IS the rail's measured width, so
+    /// the effect cannot start before layout has run. The original gate read that width from a host
+    /// that is authored <c>Visibility="Collapsed"</c> and only made visible AFTER the gate, so the
+    /// width was structurally always 0; the retry then re-posted itself at
+    /// <c>DispatcherPriority.Loaded</c> (6) and cleared its own one-shot guard before recursing,
+    /// with no attempt cap. Loaded outranks Input (5), so the retry chain starved user input
+    /// forever - a silent hard freeze with no crash log, on every visit to a hot Programs tab
+    /// (ccp-bugs #984, #993, #996, #1001).</para>
+    ///
+    /// <para><b>The contract this encodes.</b> Prefer the host's own width; fall back to the rail's
+    /// when the host has not been measured yet; below <see cref="MinTravelWidth"/> retry at most
+    /// <see cref="MaxAttempts"/> times and then give up quietly. The counter is returned rather than
+    /// mutated so the caller can only ever store a bounded value - "clear the guard, then recurse"
+    /// is not expressible here.</para>
+    /// </summary>
+    public static class ProgramCometGate
+    {
+        /// <summary>
+        /// Shortest run worth animating, in DIPs. The comet head is 130 wide and enters from -140,
+        /// so anything under this is a smear inside its own clip rather than a comet.
+        /// </summary>
+        public const double MinTravelWidth = 60.0;
+
+        /// <summary>
+        /// Hard cap on re-asks. Three passes is more than layout has ever needed; past that the
+        /// honest answer is that this surface is not going to measure, and a missing cosmetic
+        /// effect is the correct failure.
+        /// </summary>
+        public const int MaxAttempts = 3;
+
+        /// <summary>
+        /// Decides what the comet should do given the two candidate widths and how many times this
+        /// run has already been deferred.
+        /// </summary>
+        /// <param name="hostWidth">ActualWidth of the comet's clip host (0 until it is measured).</param>
+        /// <param name="railWidth">ActualWidth of the day rail the host is stretched inside.</param>
+        /// <param name="attempts">Deferrals already spent on this run. Pass the stored counter.</param>
+        public static ProgramCometDecision Decide(double hostWidth, double railWidth, int attempts)
+        {
+            var width = Usable(hostWidth);
+            if (width <= 0) width = Usable(railWidth);
+
+            // A measurable rail resets the counter: the next stall gets a fresh budget rather than
+            // inheriting one spent minutes ago on a different layout.
+            if (width >= MinTravelWidth)
+                return new ProgramCometDecision(ProgramCometAction.Run, width, 0);
+
+            var spent = attempts < 0 ? 0 : attempts;
+            if (spent >= MaxAttempts)
+                return new ProgramCometDecision(ProgramCometAction.GiveUp, 0, spent);
+
+            return new ProgramCometDecision(ProgramCometAction.Retry, 0, spent + 1);
+        }
+
+        /// <summary>NaN/Infinity/negative all mean "not measured", never "animate over that".</summary>
+        private static double Usable(double width)
+        {
+            if (double.IsNaN(width) || double.IsInfinity(width) || width <= 0) return 0;
+            return width;
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.ProgramsFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ProgramsFx.cs
@@ -793,6 +793,10 @@ namespace ConditioningControlPanel
                 var canvas = new AmbientFxCanvas { IsHitTestVisible = false };
                 tab.TodayFxLayer.Children.Add(canvas);
                 _programParticles = canvas;
+                // Every other tab's ambient canvas is registered here; this one was not, so it sat
+                // outside the tab-switch park/resume governor and leaned on its own visibility
+                // watch alone. Registration is idempotent, and a Stop()ped canvas ignores Resume().
+                RegisterTabFx("programs", canvas);
                 return canvas;
             }
             catch (Exception ex)

--- a/ConditioningControlPanel/MainWindow/MainWindow.ProgramsFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ProgramsFx.cs
@@ -126,8 +126,15 @@ namespace ConditioningControlPanel
         private DropShadowEffect? _programBossGlow;
         private AmbientFxCanvas? _programParticles;
 
-        /// <summary>Set when the comet was asked to run before the rail had a measured width.</summary>
-        private bool _programCometPending;
+        /// <summary>
+        /// How many times the comet has been deferred waiting for a measured rail. Capped by
+        /// <see cref="ProgramCometGate.MaxAttempts"/>; a counter rather than the one-shot bool this
+        /// replaced, because that bool was cleared before the retry recursed and so guarded nothing
+        /// (ccp-bugs #984, #993, #996, #1001). Reset on a successful run and by
+        /// <see cref="StopProgramIgnitionLoops"/>, so an in-flight retry can never latch the comet
+        /// off for the rest of the session.
+        /// </summary>
+        private int _programCometAttempts;
 
         /// <summary>Seconds the live session sheen is currently sweeping at, so heat can retune it.</summary>
         private double _programSheenSeconds;
@@ -662,8 +669,19 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// T4: a comet runs the day rail. Skipped (and retried once at Loaded priority) while the
-        /// rail has no measured width - the travel distance IS that width.
+        /// T4: a comet runs the day rail. Skipped (and re-asked, at most
+        /// <see cref="ProgramCometGate.MaxAttempts"/> times and always BELOW input priority) while
+        /// the rail has no measured width - the travel distance IS that width.
+        ///
+        /// <para><b>This method used to hard-freeze the app</b> (ccp-bugs #984, #993, #996, #1001).
+        /// Three independent faults lined up: the width was read from a host that is authored
+        /// Collapsed and only shown further down, so it was structurally always 0; the retry
+        /// re-posted at DispatcherPriority.Loaded (6), which outranks Input (5); and it cleared its
+        /// own one-shot guard before recursing, with no cap. The result was an unbounded chain of
+        /// above-input work - a window that still rendered and never logged a crash, but accepted
+        /// no clicks, on every visit to a Programs tab at Ignited heat with Motion FX at Full. All
+        /// three are fixed below and each one alone would be enough; the effect is cosmetic, so its
+        /// worst failure must be "no comet", never "no app".</para>
         /// </summary>
         private void ApplyProgramRailComet(ProgramsTabView tab, bool ambient)
         {
@@ -675,19 +693,38 @@ namespace ConditioningControlPanel
                 {
                     tab.RailCometHost.Visibility = Visibility.Collapsed;
                     tab.RailComet.Opacity = 0;
+                    _programCometAttempts = 0;
                     return;
                 }
 
-                var width = tab.RailCometHost.ActualWidth;
-                if (width < 60)
+                // LAYER 1. Show the host BEFORE measuring it. WPF never measures a collapsed
+                // element, so reading ActualWidth while it is still Collapsed can only ever
+                // return 0 - the gate below could not pass, ever.
+                tab.RailCometHost.Visibility = Visibility.Visible;
+
+                var gate = ProgramCometGate.Decide(
+                    tab.RailCometHost.ActualWidth, tab.ProgramDayRail.ActualWidth, _programCometAttempts);
+                _programCometAttempts = gate.Attempts;
+
+                if (gate.Action != ProgramCometAction.Run)
                 {
-                    if (_programCometPending) return;
-                    _programCometPending = true;
+                    tab.RailComet.Opacity = 0;
+                    // LAYER 3: out of attempts. Park the host and leave the rail alone.
+                    if (gate.Action == ProgramCometAction.GiveUp)
+                    {
+                        tab.RailCometHost.Visibility = Visibility.Collapsed;
+                        return;
+                    }
+
                     var dispatcher = Application.Current?.Dispatcher;
                     if (dispatcher == null || dispatcher.HasShutdownStarted) return;
-                    dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Loaded, new Action(() =>
+
+                    // LAYER 2: Background (4) sits BELOW Input (5). Layout still runs first
+                    // (Render/Loaded outrank it), so the re-ask sees a measured rail - but a
+                    // pathological repeat can only ever degrade to "no comet", never to a window
+                    // that ignores the mouse. The counter is NOT cleared before recursing.
+                    dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Background, new Action(() =>
                     {
-                        _programCometPending = false;
                         try
                         {
                             var live = ProgramsTab;
@@ -698,9 +735,9 @@ namespace ConditioningControlPanel
                     return;
                 }
 
+                var width = gate.Width;
                 tab.RailComet.Fill = _programCometBrush;
                 tab.RailComet.Opacity = 1;
-                tab.RailCometHost.Visibility = Visibility.Visible;
 
                 var run = new DoubleAnimation(-140, width + 40,
                     TimeSpan.FromSeconds(ProgramHeat.CometLapSeconds(_programHeat)))
@@ -801,6 +838,9 @@ namespace ConditioningControlPanel
         private void StopProgramIgnitionLoops()
         {
             _programFxSignature = null;
+            // Re-arm the comet with a full attempt budget. Without this a tab hidden mid-retry
+            // would come back with the counter already spent and never light the rail again.
+            _programCometAttempts = 0;
             try
             {
                 _programParticles?.Stop();

--- a/ConditioningControlPanel/Services/UI/HangContext.cs
+++ b/ConditioningControlPanel/Services/UI/HangContext.cs
@@ -134,6 +134,10 @@ public static class HangContext
             sb.Append("uptime=").Append((UptimeMs / 1000.0).ToString("F0", CultureInfo.InvariantCulture)).AppendLine("s");
             sb.Append("lastUiMark=").AppendLine(Safe(() => VideoDiag.UiMarkDescription));
             sb.Append("uiStallMs=").AppendLine(Safe(() => VideoDiag.UiStallMs.ToString(CultureInfo.InvariantCulture)));
+            // Input starved while uiStallMs stays small = the thread is BUSY above Input priority,
+            // not blocked. That distinction is the whole diagnosis for a "frozen but still
+            // repainting" report (ccp-bugs #984/#993/#996/#1001).
+            sb.Append("uiInputStallMs=").AppendLine(Safe(() => VideoDiag.UiInputStallMs.ToString(CultureInfo.InvariantCulture)));
             sb.AppendLine("state:");
             foreach (var line in DescribeServices()) sb.Append("  ").AppendLine(line);
             sb.Append("activeFeatures: ").AppendLine(DescribeActive());

--- a/ConditioningControlPanel/Services/Video/VideoDiag.cs
+++ b/ConditioningControlPanel/Services/Video/VideoDiag.cs
@@ -60,12 +60,38 @@ namespace ConditioningControlPanel.Services
         private static long _lastUiBeatTicks;
         private static volatile bool _uiBeatSeen;
 
+        // The SECOND heartbeat, posted at Input priority. A Normal-priority beat is blind to the
+        // freeze the Programs rail comet caused (ccp-bugs #984/#993/#996/#1001): a callback that
+        // re-posts itself at Loaded (6) or Render (7) starves everything at Input (5) and below,
+        // which is every click and keystroke the user has - while the Normal beat, being queued
+        // below the loop, is starved too but the render thread keeps compositing, so the app looks
+        // alive and logs nothing. Watching Input separately is what lets a trace say "input is
+        // starved by higher-priority work" instead of the generic "dispatcher unresponsive", and
+        // the two ages read together name the whole class from the first log.
+        private static long _lastUiInputBeatTicks;
+
         /// <summary>Milliseconds since the UI thread last ran a posted callback (0 if never started).</summary>
         public static long UiStallMs
         {
             get
             {
                 var last = Interlocked.Read(ref _lastUiBeatTicks);
+                if (last == 0) return 0;
+                return (DateTime.UtcNow.Ticks - last) / TimeSpan.TicksPerMillisecond;
+            }
+        }
+
+        /// <summary>
+        /// Milliseconds since the UI thread last ran a callback posted at INPUT priority (0 if
+        /// never started). Large while <see cref="UiStallMs"/> stays small means the dispatcher is
+        /// busy, not blocked: something above Input is looping, and the window will ignore the
+        /// mouse while still repainting.
+        /// </summary>
+        public static long UiInputStallMs
+        {
+            get
+            {
+                var last = Interlocked.Read(ref _lastUiInputBeatTicks);
                 if (last == 0) return 0;
                 return (DateTime.UtcNow.Ticks - last) / TimeSpan.TicksPerMillisecond;
             }
@@ -271,16 +297,36 @@ namespace ConditioningControlPanel.Services
         /// thresholds keep the file quiet during normal use (one line per minute) while giving a
         /// second-resolution picture of a freeze: when it began, how deep it got, whether it ever
         /// came back.
+        ///
+        /// <para>TWO stamps go out each tick, at Normal and at Input priority, because the two
+        /// failures they detect are different and only one of them was ever visible here. A UI
+        /// thread stuck inside a native call stops running both. A UI thread being starved from
+        /// ABOVE - a callback that keeps re-posting itself at Loaded or Render - also stops running
+        /// both, but the render thread keeps compositing, so the window paints, ignores every
+        /// click, and never writes a crash log. That is the shape of the Programs rail comet freeze
+        /// (ccp-bugs #984/#993/#996/#1001), and the Input beat is what lets the trace name it
+        /// rather than describe it.</para>
         /// </summary>
         private static void HeartbeatLoop(Dispatcher dispatcher)
         {
             long lastReported = 0;
+            long inputLastReported = 0;
             long aliveMarkerTicks = 0;
 
             // Escalating stall thresholds (ms). One line each, so a 10-minute freeze costs 6 lines.
             var thresholds = new long[] { 3_000, 10_000, 30_000, 60_000, 300_000, 900_000 };
 
+            // Allocated once, not per tick: this loop runs for the life of the process.
+            var normalBeat = new Action(() =>
+            {
+                Interlocked.Exchange(ref _lastUiBeatTicks, DateTime.UtcNow.Ticks);
+                _uiBeatSeen = true;
+            });
+            var inputBeat = new Action(() =>
+                Interlocked.Exchange(ref _lastUiInputBeatTicks, DateTime.UtcNow.Ticks));
+
             Interlocked.Exchange(ref _lastUiBeatTicks, DateTime.UtcNow.Ticks);
+            Interlocked.Exchange(ref _lastUiInputBeatTicks, DateTime.UtcNow.Ticks);
 
             while (true)
             {
@@ -289,13 +335,34 @@ namespace ConditioningControlPanel.Services
                     Thread.Sleep(1000);
                     if (dispatcher.HasShutdownStarted) return;
 
-                    dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
-                    {
-                        Interlocked.Exchange(ref _lastUiBeatTicks, DateTime.UtcNow.Ticks);
-                        _uiBeatSeen = true;
-                    }));
+                    dispatcher.BeginInvoke(DispatcherPriority.Normal, normalBeat);
+                    dispatcher.BeginInvoke(DispatcherPriority.Input, inputBeat);
 
                     long stall = UiStallMs;
+                    long inputStall = UiInputStallMs;
+
+                    // Input starved while Normal still runs cannot happen by blocking - the queue is
+                    // ordered, so Normal drains only after Input. It means the reverse: work ABOVE
+                    // Input is looping and eating the thread. Reported on its own line and its own
+                    // ladder, because "the app repaints but nothing is clickable" is a distinct bug
+                    // report from "the app is frozen".
+                    if (inputStall >= 3000 && stall < 2000)
+                    {
+                        foreach (var t in thresholds)
+                        {
+                            if (inputStall >= t && inputLastReported < t)
+                            {
+                                inputLastReported = t;
+                                Log("UI", $"dispatcher STARVED at INPUT priority for {inputStall}ms while Normal still runs (ui+{stall}ms) - something above Input is re-posting itself; the window will repaint but ignore clicks - last UI mark: {UiMarkDescription}");
+                                break;
+                            }
+                        }
+                    }
+                    else if (inputStall < 2000 && inputLastReported > 0)
+                    {
+                        Log("UI", $"input priority RECOVERED after {inputLastReported}ms+ of starvation");
+                        inputLastReported = 0;
+                    }
 
                     if (stall < 2000)
                     {
@@ -323,7 +390,11 @@ namespace ConditioningControlPanel.Services
                             // "last UI mark: Compositor.Present" reads completely differently from
                             // one with "(idle)" (nothing instrumented was running - look at the
                             // slow-op tracer instead).
-                            Log("UI", $"dispatcher UNRESPONSIVE for {stall}ms (no posted callback has run) - last UI mark: {UiMarkDescription}");
+                            // The input age is carried alongside deliberately: input starved
+                            // MEASURABLY LONGER than Normal says the thread was being outranked
+                            // before it went quiet (a priority-inversion freeze), while the two
+                            // ages moving together says it is simply blocked inside a call.
+                            Log("UI", $"dispatcher UNRESPONSIVE for {stall}ms (input+{inputStall}ms, no posted callback has run) - last UI mark: {UiMarkDescription}");
                             break;
                         }
                     }

--- a/Tests/ConditioningControlPanel.Tests/ProgramCometGateTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/ProgramCometGateTests.cs
@@ -1,0 +1,176 @@
+using ConditioningControlPanel.Helpers;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Programs rail comet's layout gate - the decision that used to hard-freeze the app.
+///
+/// <para><b>Why this is worth a suite.</b> The bug behind ccp-bugs #984 / #993 / #996 / #1001 was
+/// not a wrong pixel: the comet's host is authored Collapsed, so its ActualWidth was structurally
+/// always 0, the gate never passed, and the retry re-posted itself forever at a dispatcher priority
+/// ABOVE input - a window that kept rendering and never logged a crash but accepted no clicks, on
+/// every visit to a hot Programs tab. Nothing about that is visible in a screenshot, and the effect
+/// is cosmetic, so the property that actually matters is the one pinned here: this gate always
+/// terminates, and its worst outcome is a missing comet.</para>
+/// </summary>
+public class ProgramCometGateTests
+{
+    // =====================================================================================
+    //  the measured path
+    // =====================================================================================
+
+    [Theory]
+    [InlineData(320.0)]
+    [InlineData(60.0)]
+    [InlineData(1920.0)]
+    public void A_measured_host_runs_over_its_own_width(double width)
+    {
+        var gate = ProgramCometGate.Decide(width, 999.0, 0);
+
+        Assert.Equal(ProgramCometAction.Run, gate.Action);
+        Assert.Equal(width, gate.Width);
+    }
+
+    /// <summary>A run always hands back a spent budget of zero, so the next stall starts fresh.</summary>
+    [Fact]
+    public void A_run_resets_the_attempt_budget()
+    {
+        var gate = ProgramCometGate.Decide(400.0, 400.0, ProgramCometGate.MaxAttempts);
+
+        Assert.Equal(ProgramCometAction.Run, gate.Action);
+        Assert.Equal(0, gate.Attempts);
+    }
+
+    // =====================================================================================
+    //  the collapsed-host fallback (LAYER 1)
+    // =====================================================================================
+
+    /// <summary>
+    /// The exact shape of the ship-blocker: a host that has never been measured because it was
+    /// still collapsed when it was read. The rail it lives inside HAS been measured, and its width
+    /// is the same travel distance, so the comet runs instead of deferring.
+    /// </summary>
+    [Fact]
+    public void A_collapsed_host_falls_back_to_the_rail_width()
+    {
+        var gate = ProgramCometGate.Decide(hostWidth: 0.0, railWidth: 420.0, attempts: 0);
+
+        Assert.Equal(ProgramCometAction.Run, gate.Action);
+        Assert.Equal(420.0, gate.Width);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(-10.0)]
+    public void A_nonsense_host_width_falls_back_rather_than_animating_over_it(double host)
+    {
+        var gate = ProgramCometGate.Decide(host, 300.0, 0);
+
+        Assert.Equal(ProgramCometAction.Run, gate.Action);
+        Assert.Equal(300.0, gate.Width);
+    }
+
+    /// <summary>A rail that is nonsense too is simply "not measured yet" - never a NaN duration.</summary>
+    [Fact]
+    public void Two_nonsense_widths_defer_instead_of_producing_a_NaN_run()
+    {
+        var gate = ProgramCometGate.Decide(double.NaN, double.NaN, 0);
+
+        Assert.Equal(ProgramCometAction.Retry, gate.Action);
+    }
+
+    /// <summary>
+    /// Below the floor is not "a short comet", it is "no measurement yet". 59 DIPs of travel for a
+    /// 130-wide head entering from -140 is a smear inside its own clip.
+    /// </summary>
+    [Fact]
+    public void A_rail_narrower_than_the_floor_is_treated_as_unmeasured()
+    {
+        var gate = ProgramCometGate.Decide(40.0, 59.0, 0);
+
+        Assert.Equal(ProgramCometAction.Retry, gate.Action);
+    }
+
+    // =====================================================================================
+    //  the attempt cap (LAYER 3)
+    // =====================================================================================
+
+    /// <summary>
+    /// The load-bearing property. Feed the gate a surface that never measures and drive it exactly
+    /// as the call site does - store back what it returns - and it must stop asking. This is the
+    /// test that would have failed against the shipped code, whose retry cleared its own guard
+    /// before recursing and so looped without bound.
+    /// </summary>
+    [Fact]
+    public void An_unmeasurable_rail_terminates_instead_of_retrying_forever()
+    {
+        var attempts = 0;
+        var retries = 0;
+
+        for (var pass = 0; pass < 1000; pass++)
+        {
+            var gate = ProgramCometGate.Decide(0.0, 0.0, attempts);
+            attempts = gate.Attempts;
+
+            if (gate.Action == ProgramCometAction.GiveUp) break;
+
+            Assert.Equal(ProgramCometAction.Retry, gate.Action);
+            retries++;
+        }
+
+        Assert.Equal(ProgramCometGate.MaxAttempts, retries);
+        Assert.Equal(ProgramCometGate.MaxAttempts, attempts);
+    }
+
+    /// <summary>
+    /// Each deferral must SPEND budget. The old bool guard was cleared inside the retry callback
+    /// before it recursed, so every pass looked like the first one - which is precisely how an
+    /// unbounded chain of above-input work got started.
+    /// </summary>
+    [Fact]
+    public void Every_retry_spends_budget_rather_than_clearing_it()
+    {
+        Assert.Equal(1, ProgramCometGate.Decide(0, 0, 0).Attempts);
+        Assert.Equal(2, ProgramCometGate.Decide(0, 0, 1).Attempts);
+        Assert.Equal(3, ProgramCometGate.Decide(0, 0, 2).Attempts);
+    }
+
+    [Fact]
+    public void A_spent_budget_gives_up_and_stays_spent()
+    {
+        var gate = ProgramCometGate.Decide(0, 0, ProgramCometGate.MaxAttempts);
+
+        Assert.Equal(ProgramCometAction.GiveUp, gate.Action);
+        Assert.Equal(ProgramCometGate.MaxAttempts, gate.Attempts);
+
+        // Giving up is stable: re-asking a parked comet does not re-open the retry chain.
+        var again = ProgramCometGate.Decide(0, 0, gate.Attempts);
+        Assert.Equal(ProgramCometAction.GiveUp, again.Action);
+    }
+
+    /// <summary>A counter that somehow went negative must not buy extra retries.</summary>
+    [Fact]
+    public void A_negative_counter_is_clamped_rather_than_trusted()
+    {
+        var gate = ProgramCometGate.Decide(0, 0, -50);
+
+        Assert.Equal(ProgramCometAction.Retry, gate.Action);
+        Assert.Equal(1, gate.Attempts);
+    }
+
+    /// <summary>
+    /// Give-up is not permanent damage: the tab-hide path zeroes the counter, and the gate must
+    /// then behave exactly as it does on a first visit.
+    /// </summary>
+    [Fact]
+    public void A_reset_counter_re_arms_the_comet()
+    {
+        Assert.Equal(ProgramCometAction.GiveUp,
+            ProgramCometGate.Decide(0, 0, ProgramCometGate.MaxAttempts).Action);
+
+        // StopProgramIgnitionLoops sets the field back to 0.
+        Assert.Equal(ProgramCometAction.Run, ProgramCometGate.Decide(0, 500.0, 0).Action);
+    }
+}


### PR DESCRIPTION
Fixes the You -> Programs hard freeze reported in ccp-bugs #984, #993, #996, #1001. Introduced by cae9438d5 (v6.8.0).

## Root cause

`MainWindow/MainWindow.ProgramsFx.cs` -> `ApplyProgramRailComet`. The Programs tab's T4 rail comet animates over the rail's measured width, so it must wait for layout. Three faults in that wait lined up, and each one alone was survivable:

1. **The width could never be non-zero.** `RailCometHost` is authored `Visibility="Collapsed"` (`Views/Tabs/ProgramsTabView.xaml:515`), and WPF never measures a collapsed element. The gate read `tab.RailCometHost.ActualWidth` while it was still collapsed, so it was structurally always `0`. The `Visibility.Visible` that would have fixed it sat ~20 lines further down, **after** the gate.
2. **The retry outranked user input.** It re-posted at `DispatcherPriority.Loaded` (6). Input is 5.
3. **The one-shot guard guarded nothing.** The retry callback set `_programCometPending = false` *before* recursing, and there was no attempt cap.

Together that is an unbounded chain of above-Input dispatcher work, entered on every visit to a Programs tab at Ignited heat (>= 0.80, and boss days 7/14/21/28 pin heat to 1.0) with Motion FX at Full.

Why it presented the way it did in the reports:

- **No crash log.** Nothing throws. The render thread keeps compositing, so the window paints normally and simply stops accepting clicks.
- **"It freezes every time I open Programs."** Hiding the tab calls `StopProgramIgnitionLoops`, which re-collapses the host and nulls the FX signature, so the next visit re-arms the whole thing.
- **#993's "closing it only minimizes, and then it's responsive."** WM_CLOSE goes to `MainWindow.WindowChrome.cs:316`, which `Hide()`s rather than closes. That falsifies the `IsVisible` guard inside the retry, the chain stops, and the app comes back.

## The fix: three layers

The comet is cosmetic. Its worst failure has to be "no comet", never "no app", so all three faults are fixed independently:

1. **Measure a measurable host.** `RailCometHost.Visibility = Visible` now happens *before* the width read, and a host still reporting nothing falls back to `tab.ProgramDayRail.ActualWidth` (same travel distance, and the rail is measured).
2. **Demote the retry to `Background` (4).** Below Input (5), above nothing that matters. Layout still runs first (Render/Loaded outrank Background), so the re-ask still sees a measured rail - but a pathological repeat now degrades to a missing comet instead of an unclickable window.
3. **Attempt counter capped at 3.** Replaces the bool. Budget is spent *before* the retry is posted and never cleared inside it. `StopProgramIgnitionLoops` resets it, so a tab hidden mid-retry cannot latch the comet off for the rest of the session.

The decision itself is extracted to `Helpers/ProgramCometGate.cs` as a pure function (`Decide(hostWidth, railWidth, attempts)` -> Run / Retry / GiveUp + width + the counter to store back), so the logic that froze the app is unit-testable instead of living inside a dispatcher callback. Returning the counter rather than mutating it means "clear the guard, then recurse" is not expressible any more.

The healthy path is visually unchanged, and the reduced-motion gate (`MotionFx.AllowAmbientLoops`) is untouched.

## The heartbeat blind spot (second commit)

`Services/Video/VideoDiag.cs` posted its dispatcher heartbeat only at `DispatcherPriority.Normal`, which cannot see this bug's shape. Work looping above Input starves the Normal beat too, so the trace said `dispatcher UNRESPONSIVE` - the same line a UI thread blocked inside a native call produces. Two very different bugs, one indistinguishable log line, which is why four reports of this arrived with nothing to go on.

Now a second beat posts at `DispatcherPriority.Input` each tick:

- Input starved while Normal still runs is impossible by blocking (the queue drains in priority order), so it can only mean something above Input is re-posting itself. That gets its own escalating line: `dispatcher STARVED at INPUT priority for Nms while Normal still runs ... the window will repaint but ignore clicks`, with the last UI mark.
- When both are stalled, the existing `UNRESPONSIVE` line now carries the input age too, so input starving measurably *earlier* than Normal (priority inversion) is distinguishable from the two ages moving together (a blocking call).
- `HangContext.Describe()` reports `uiInputStallMs`, so the hang watchdog carries the distinction into a bug attachment.

Cost is one extra `BeginInvoke` per second; both beat delegates are hoisted out of the loop, so the tick allocates less than it did before.

## Third commit (small, adjacent)

`_programParticles` was the only ambient canvas in the app never handed to `RegisterTabFx`, so the Today card's Skia sim sat outside the tab-switch park/resume governor. One line, matching every other tab. Registration is idempotent and a `Stop()`ped canvas ignores `Resume()`, so `StopProgramIgnitionLoops` still wins.

## Verification

- `dotnet build`: clean, 0 errors (warning count unchanged).
- Full suite: **3629 passed, 5 failed** - exactly the known nested-worktree baseline (`YouLibraryDoorTests.EachLibraryLauncherIsOneRowBoundToOneExistingHandler` x4 + `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`). Nothing new.
- New `ProgramCometGateTests` (15 tests, all passing): collapsed-host width falls back to the rail; NaN/Infinity/negative widths never become an animation duration; a sub-floor rail defers rather than smearing; the cap terminates when driven exactly as the call site drives it; every retry *spends* budget instead of clearing it; give-up is stable; a reset counter re-arms.

### Human play-test recipe

1. Enroll in a program (Kept or Takeover).
2. Set `CurrentDay` to a boss day (7 / 14 / 21 / 28) - that pins heat to 1.0, i.e. Ignited.
3. Settings -> Motion FX -> **Full**.
4. Bounce You -> Programs -> You -> Programs repeatedly, ~10 times.

Expected: the tab opens every time, the rail comet runs, and the window stays clickable throughout. Before this change, step 4 wedged the app on the first visit.

Worth also confirming at Reduced motion (comet should not start at all) and on a non-boss early day (Cold/Warm tiers, no comet by design).

DO NOT MERGE until that play-test is done.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3mrhKZQj2ehTJUhj2ueon
