### PR TITLE
fix: v6.8.3 papercut batch (#1000, #999, #998)

### DIFF
--- a/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
+++ b/ConditioningControlPanel/Helpers/ExplorerLauncher.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace ConditioningControlPanel.Helpers
+{
+    /// <summary>
+    /// Opens Windows Explorer on a file or folder.
+    ///
+    /// <para>Every "Reveal in Explorer" / "Open folder" button in the app used to hand-roll
+    /// <c>Process.Start("explorer.exe", $"/select,\"{path}\"")</c>. Building the command line as a
+    /// single pre-quoted string is fragile: the embedded quotes are re-parsed by the CRT before
+    /// explorer ever sees them, and on a mismatch explorer silently falls back to opening the
+    /// default folder (the desktop) instead of reporting an error - so the button looked like it
+    /// did nothing useful (ccp-bugs #998, media on D: while the app runs from C:).</para>
+    ///
+    /// <para><see cref="ProcessStartInfo.ArgumentList"/> hands the argument over as a single
+    /// pre-tokenized element and lets the runtime apply the correct Windows quoting rules, so
+    /// spaces and non-ASCII characters survive intact. It requires
+    /// <c>UseShellExecute = false</c>, which is fine - explorer.exe is a plain executable.</para>
+    /// </summary>
+    public static class ExplorerLauncher
+    {
+        /// <summary>
+        /// Opens Explorer with <paramref name="path"/> selected. If the file no longer exists,
+        /// falls back to opening its containing directory. Returns true if Explorer was launched.
+        /// Never throws.
+        /// </summary>
+        public static bool RevealInExplorer(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+
+            try
+            {
+                if (File.Exists(path))
+                {
+                    // One argument, not two: explorer expects the switch and the path glued by the
+                    // comma. ArgumentList quotes the whole token for us.
+                    return Launch($"/select,{Path.GetFullPath(path)}");
+                }
+
+                if (Directory.Exists(path))
+                    return Launch(Path.GetFullPath(path));
+
+                // File is gone (deleted / drive detached) - settle for its folder.
+                return OpenFolder(Path.GetDirectoryName(path));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ExplorerLauncher: reveal failed for {Path}", path);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Opens <paramref name="directory"/> in Explorer. Returns true if Explorer was launched.
+        /// Never throws.
+        /// </summary>
+        public static bool OpenFolder(string? directory)
+        {
+            if (string.IsNullOrWhiteSpace(directory)) return false;
+
+            try
+            {
+                if (!Directory.Exists(directory))
+                {
+                    App.Logger?.Debug("ExplorerLauncher: folder no longer exists: {Dir}", directory);
+                    return false;
+                }
+                return Launch(Path.GetFullPath(directory));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ExplorerLauncher: open folder failed for {Dir}", directory);
+                return false;
+            }
+        }
+
+        private static bool Launch(string argument)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "explorer.exe",
+                    // ArgumentList needs UseShellExecute = false; it is the whole point of this helper.
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                psi.ArgumentList.Add(argument);
+                Process.Start(psi);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "ExplorerLauncher: explorer.exe failed to start for {Arg}", argument);
+                return false;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/Helpers/PassiveToastWindow.cs
+++ b/ConditioningControlPanel/Helpers/PassiveToastWindow.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Windows;
+using System.Windows.Interop;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel.Helpers;
+
+/// <summary>
+/// Makes an auto-dismissing corner toast (Pink Rush, achievement, item unlock, announcement)
+/// incapable of stealing focus from whatever the user is actually doing.
+///
+/// <para><c>ShowActivated="False"</c> in XAML is NOT enough. It only suppresses the activation
+/// of the *initial* Show(); the window is still a normal activatable top-level window afterwards,
+/// so the moment it enters the topmost z-band Windows can hand it the foreground - which yanks
+/// mouse capture away from an exclusive/borderless fullscreen game and kills mouse-look
+/// (ccp-bugs #1000: a Pink Rush toast breaking Overwatch aiming mid-match).</para>
+///
+/// <para>The fix is the same two-part treatment the flash overlays already use
+/// (see <c>FlashService.HideFromAltTab</c> / <c>FlashService.ForceTopmost</c>):</para>
+/// <list type="number">
+/// <item><c>WS_EX_NOACTIVATE</c> so the window can never take the foreground, even when clicked -
+/// mouse messages still arrive, so click-to-dismiss keeps working.</item>
+/// <item><c>WS_EX_TOOLWINDOW</c> so it stays out of Alt+Tab.</item>
+/// <item>A <c>SetWindowPos(HWND_TOPMOST, SWP_NOACTIVATE)</c> re-assert once loaded, so the toast
+/// still wins the z-order against other topmost surfaces (e.g. the app's own fullscreen video,
+/// which was activated more recently) without activating itself.</item>
+/// </list>
+/// </summary>
+internal static class PassiveToastWindow
+{
+    /// <summary>
+    /// Applies the non-activating treatment to <paramref name="window"/>. Safe to call from the
+    /// window's constructor (right after <c>InitializeComponent</c>) - the extended styles are
+    /// applied on SourceInitialized and the z-order assert on Loaded. Never throws.
+    /// </summary>
+    public static void Apply(Window window)
+    {
+        if (window == null) return;
+
+        // Extended styles must land before the window is first shown, otherwise Windows has
+        // already decided it is activatable for this Show().
+        window.SourceInitialized += (_, _) => ApplyNoActivateStyles(window);
+
+        // Re-assert the top of the topmost band once we have a visual tree, without activating.
+        window.Loaded += (_, _) => ForceToTopMost(window);
+
+        // Defensive: if the caller wires us up after the HWND already exists, do it now too.
+        if (new WindowInteropHelper(window).Handle != IntPtr.Zero)
+            ApplyNoActivateStyles(window);
+    }
+
+    private static void ApplyNoActivateStyles(Window window)
+    {
+        try
+        {
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero) return;
+
+            var exStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE);
+            NativeMethods.SetWindowLong(hwnd, NativeMethods.GWL_EXSTYLE,
+                exStyle | NativeMethods.WS_EX_NOACTIVATE | NativeMethods.WS_EX_TOOLWINDOW);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("PassiveToastWindow: could not apply no-activate styles: {Error}", ex.Message);
+        }
+    }
+
+    private static void ForceToTopMost(Window window)
+    {
+        try
+        {
+            var hwnd = new WindowInteropHelper(window).Handle;
+            if (hwnd == IntPtr.Zero) return;
+
+            NativeMethods.SetWindowPos(hwnd, NativeMethods.HWND_TOPMOST, 0, 0, 0, 0,
+                NativeMethods.SWP_NOMOVE | NativeMethods.SWP_NOSIZE | NativeMethods.SWP_NOACTIVATE);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("PassiveToastWindow: ForceToTopMost failed: {Error}", ex.Message);
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Assets.cs
@@ -1114,18 +1114,7 @@ namespace ConditioningControlPanel
                 contextMenu.PlacementTarget is Border border &&
                 border.DataContext is AssetFileItem file)
             {
-                try
-                {
-                    var filePath = file.FullPath;
-                    if (System.IO.File.Exists(filePath))
-                    {
-                        System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{filePath}\"");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    App.Logger?.Warning(ex, "Failed to open file in Explorer");
-                }
+                Helpers.ExplorerLauncher.RevealInExplorer(file.FullPath);
             }
         }
 

--- a/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/DtrhHostService.cs
@@ -339,7 +339,7 @@ internal static class DtrhHostService
                 var path = DtrhLoomStore.GifPathFor((string?)o["slug"]);
                 if (path != null)
                 {
-                    try { System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{path}\""); }
+                    try { Helpers.ExplorerLauncher.RevealInExplorer(path); }
                     catch (Exception ex) { App.Logger?.Debug("DtrhHost: reveal failed: {E}", ex.Message); }
                 }
                 break;

--- a/ConditioningControlPanel/Services/Chaos/LoomHostService.cs
+++ b/ConditioningControlPanel/Services/Chaos/LoomHostService.cs
@@ -112,7 +112,7 @@ internal static class LoomHostService
                 var path = DtrhLoomStore.GifPathFor((string?)o["slug"]);
                 if (path != null)
                 {
-                    try { System.Diagnostics.Process.Start("explorer.exe", $"/select,\"{path}\""); }
+                    try { Helpers.ExplorerLauncher.RevealInExplorer(path); }
                     catch (Exception ex) { App.Logger?.Debug("LoomHost: reveal failed: {E}", ex.Message); }
                 }
                 break;

--- a/ConditioningControlPanel/Services/TutorialService.cs
+++ b/ConditioningControlPanel/Services/TutorialService.cs
@@ -2428,16 +2428,7 @@ namespace ConditioningControlPanel.Services
                     {
                         try
                         {
-                            var path = TutorialEventBus.LastSavedEnhancementPath;
-                            if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
-                            {
-                                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                                {
-                                    FileName = "explorer.exe",
-                                    Arguments = $"/select,\"{path}\"",
-                                    UseShellExecute = true
-                                });
-                            }
+                            Helpers.ExplorerLauncher.RevealInExplorer(TutorialEventBus.LastSavedEnhancementPath);
                         }
                         catch { }
                         try { App.Tutorial?.Skip(); } catch { }
@@ -2893,16 +2884,7 @@ namespace ConditioningControlPanel.Services
                 {
                     try
                     {
-                        var path = TutorialEventBus.LastSavedEnhancementPath;
-                        if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
-                        {
-                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                            {
-                                FileName = "explorer.exe",
-                                Arguments = $"/select,\"{path}\"",
-                                UseShellExecute = true
-                            });
-                        }
+                        Helpers.ExplorerLauncher.RevealInExplorer(TutorialEventBus.LastSavedEnhancementPath);
                     }
                     catch { }
                     try { App.Tutorial?.Skip(); } catch { }

--- a/ConditioningControlPanel/Services/TutorialService.cs
+++ b/ConditioningControlPanel/Services/TutorialService.cs
@@ -296,6 +296,13 @@ namespace ConditioningControlPanel.Services
         /// </summary>
         public void Start(TutorialType type = TutorialType.FullTour)
         {
+            // A tutorial is nothing but spotlight cut-outs positioned over MainWindow's controls.
+            // If the window is minimized, or tucked in the tray by Settings > "Start hidden", every
+            // step resolves a target with no on-screen rectangle and the tour draws its boxes over
+            // the bare desktop, pointing at nothing (ccp-bugs #999). Restore the window first -
+            // before TutorialStarted fires, so the overlay measures against a real window.
+            EnsureMainWindowVisible();
+
             _currentTutorialType = type;
             _currentSteps = GetStepsForTutorial(type);
             ApplyCallbacksToSteps();
@@ -317,6 +324,37 @@ namespace ConditioningControlPanel.Services
         public void Start()
         {
             Start(TutorialType.FullTour);
+        }
+
+        /// <summary>
+        /// Brings MainWindow back on screen if it is minimized or hidden, so the tutorial spotlight
+        /// has something to point at (ccp-bugs #999). No-op when the window is already up.
+        /// </summary>
+        private static void EnsureMainWindowVisible()
+        {
+            try
+            {
+                if (Application.Current?.MainWindow is not MainWindow mw) return;
+                if (mw.IsVisible && mw.WindowState != WindowState.Minimized) return;
+
+                // Hidden-to-tray uses Hide(), so the window must be Show()n before WindowState
+                // means anything. ShowFromTray() is the canonical restore: it does Show() first,
+                // re-centres a window whose saved position is off every live screen (#475), and
+                // takes the foreground.
+                mw.ShowFromTray();
+
+                // Belt and braces - covers a plain minimize and the case where the tray service
+                // never came up (ShowFromTray null-checks it away silently).
+                if (!mw.IsVisible) mw.Show();
+                if (mw.WindowState == WindowState.Minimized) mw.WindowState = WindowState.Normal;
+                mw.Activate();
+
+                App.Logger?.Information("Tutorial: restored MainWindow before starting the tour");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "Tutorial: could not restore MainWindow before starting the tour");
+            }
         }
 
         private void ApplyCallbacksToSteps()

--- a/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
+++ b/ConditioningControlPanel/Views/Deeper/DeeperEditorWindow.xaml.cs
@@ -4581,19 +4581,7 @@ namespace ConditioningControlPanel.Views.Deeper
         private void BtnLinkedJsonOpenFolder_Click(object sender, RoutedEventArgs e)
         {
             if (string.IsNullOrEmpty(_filePath)) return;
-            try
-            {
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "explorer.exe",
-                    Arguments = $"/select,\"{_filePath}\"",
-                    UseShellExecute = true
-                });
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Debug("DeeperEditor: open folder failed: {Error}", ex.Message);
-            }
+            ConditioningControlPanel.Helpers.ExplorerLauncher.RevealInExplorer(_filePath);
         }
 
         private void BtnLinkedJsonSwap_Click(object sender, RoutedEventArgs e)

--- a/ConditioningControlPanel/Windows/AchievementPopup.xaml.cs
+++ b/ConditioningControlPanel/Windows/AchievementPopup.xaml.cs
@@ -35,7 +35,10 @@ public partial class AchievementPopup : Window
         
         // Position in bottom-right corner of primary screen
         PositionWindow();
-        
+
+        // Never take the foreground - same focus-theft gap as the Pink Rush toast (ccp-bugs #1000).
+        Helpers.PassiveToastWindow.Apply(this);
+
         // Auto-close after 6 seconds
         _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
         _autoCloseTimer.Tick += (s, e) =>

--- a/ConditioningControlPanel/Windows/ItemUnlockedPopup.xaml.cs
+++ b/ConditioningControlPanel/Windows/ItemUnlockedPopup.xaml.cs
@@ -87,6 +87,9 @@ public partial class ItemUnlockedPopup : Window
 
         PositionWindow(stackIndex);
 
+        // Never take the foreground - same focus-theft gap as the Pink Rush toast (ccp-bugs #1000).
+        Helpers.PassiveToastWindow.Apply(this);
+
         _autoCloseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
         _autoCloseTimer.Tick += (s, e) =>
         {

--- a/ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/MediaHistoryWindow.xaml.cs
@@ -312,22 +312,8 @@ namespace ConditioningControlPanel
 
         private void RevealInExplorer(string path)
         {
-            try
-            {
-                if (File.Exists(path))
-                    Process.Start("explorer.exe", $"/select,\"{path}\"");
-                else
-                {
-                    // File gone - just open the containing folder if it still exists.
-                    var dir = Path.GetDirectoryName(path);
-                    if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
-                        Process.Start("explorer.exe", $"\"{dir}\"");
-                }
-            }
-            catch (Exception ex)
-            {
-                App.Logger?.Warning(ex, "MediaHistoryWindow: reveal in explorer failed");
-            }
+            // Helper handles the missing-file fallback to the containing folder (#998).
+            Helpers.ExplorerLauncher.RevealInExplorer(path);
         }
 
         // ---- Chrome -------------------------------------------------------

--- a/ConditioningControlPanel/Windows/PinkRushPopup.xaml.cs
+++ b/ConditioningControlPanel/Windows/PinkRushPopup.xaml.cs
@@ -26,6 +26,10 @@ public partial class PinkRushPopup : Window
 
         PositionWindow();
 
+        // Never take the foreground. ShowActivated="False" alone still leaves an activatable
+        // window, which stole mouse capture from fullscreen games mid-match (ccp-bugs #1000).
+        Helpers.PassiveToastWindow.Apply(this);
+
         // Countdown timer ticks every second
         _countdownTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _countdownTimer.Tick += CountdownTimer_Tick;

--- a/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.cs
+++ b/ConditioningControlPanel/Windows/SessionCompleteWindow.xaml.cs
@@ -178,21 +178,10 @@ namespace ConditioningControlPanel
 
             try
             {
-                if (File.Exists(path))
-                {
-                    Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{path}\"") { UseShellExecute = true });
-                    return;
-                }
+                // Selects the file, or falls back to its parent folder if the file is gone (#998).
+                if (Helpers.ExplorerLauncher.RevealInExplorer(path)) return;
 
-                // File missing: try to open the parent folder if it still exists.
-                var parent = Path.GetDirectoryName(path);
-                if (!string.IsNullOrEmpty(parent) && Directory.Exists(parent))
-                {
-                    Process.Start(new ProcessStartInfo("explorer.exe", $"\"{parent}\"") { UseShellExecute = true });
-                    App.Logger?.Information("SessionCompleteWindow: file gone, opened parent folder {Parent}", parent);
-                    return;
-                }
-
+                // Neither the file nor its folder survived - say so rather than doing nothing.
                 MessageBox.Show(this,
                     Loc.GetF("msg_file_not_found_with_path", path),
                     Loc.Get("title_error"),


### PR DESCRIPTION
Four small, independent papercuts from the v6.8.2 field reports. One commit each. Three landed; the fourth turned out to be already done and is explained below.

---

## 1. Pink Rush steals focus from fullscreen games — ccp-bugs #1000

**Root cause.** `PinkRushPopup.xaml` sets `ShowActivated="False"` + `Topmost="True"`, but that is not enough. `ShowActivated` only suppresses activation of the *initial* `Show()`; afterwards the window is still an ordinary activatable top-level window. The moment it enters the topmost z-band Windows can hand it the foreground, which yanks mouse capture away from an exclusive/borderless fullscreen game — the reporter lost mouse-look in Overwatch mid-match. There were no `WS_EX_NOACTIVATE` / `WS_EX_TOOLWINDOW` extended styles and no `SWP_NOACTIVATE` z-order assert, both of which the flash overlays have had for a while (`FlashService.HideFromAltTab` / `FlashService.ForceTopmost`).

**What changed.** New `Helpers/PassiveToastWindow.cs`:
- `WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW` on `SourceInitialized` (must land before the first `Show()`, or Windows has already decided the window is activatable).
- `SetWindowPos(HWND_TOPMOST, SWP_NOACTIVATE)` on `Loaded`, so the toast still wins z-order against other topmost surfaces (e.g. the app's own fullscreen video, activated more recently) without activating itself.

Reuses the existing `Services.NativeMethods` constants/P-Invokes rather than adding a fourth copy of the DllImports. Mouse messages still arrive under `WS_EX_NOACTIVATE`, so click-to-dismiss and the close button keep working.

### Other Topmost windows checked for the same gap

Survey of `Windows/` for `Topmost="True"` + `ShowActivated="False"` + no `NOACTIVATE`:

| Window | Verdict |
|---|---|
| `PinkRushPopup` | **fixed** |
| `AchievementPopup` | **fixed** — byte-for-byte the same passive corner toast (auto-close timer, click-anywhere-to-dismiss, bottom-right) |
| `ItemUnlockedPopup` | **fixed** — same |
| `QuestCompletePopup` | already correct — has its own `ForceToTopMost()`; left alone (it lacks the `WS_EX_*` half, but has the z-order assert, and is out of scope here) |
| `AnnouncementPopup` | **shares the gap, deliberately NOT fixed** — `CenterScreen` with a link and action buttons. It is a notice the user is meant to act on, so making it permanently non-activating is a UX decision, not a bug fix. Flagging for a call. |
| `TutorialOverlay` | **shares the gap, deliberately NOT fixed** — fully interactive surface; non-activating would be wrong. |

---

## 2. Tutorial runs over a minimized / invisible main window — ccp-bugs #999

**Root cause.** `TutorialService.Start()` fired `TutorialStarted` without ever checking that MainWindow was on screen. With Settings > "Start hidden" (`AppSettings.StartMinimized`) the window is `Hide()`n into the tray at launch (`MainWindow.xaml.cs` → `_trayIcon.MinimizeToTray()`). A tour started from that state resolved every step against a control with no on-screen rectangle, so the spotlight cut-outs rendered over the bare desktop pointing at nothing.

**What changed.** `Start()` now calls `EnsureMainWindowVisible()` first, before `TutorialStarted` fires, so the overlay measures against a real window. When the window is minimized or not visible it routes through `MainWindow.ShowFromTray()`, which is the canonical restore already used by the remote-control and second-instance paths:

- `Show()` **before** touching `WindowState` — the tray path uses `Hide()`, so a hidden window must be shown first or the state change is meaningless.
- `EnsureOnScreen()` re-centres a window whose saved position is off every live screen (the #475 fix).
- `SetForegroundWindow` + `Activate()`.

A direct `Show()` / `Normal` / `Activate()` fallback follows, covering a plain minimize and the case where the tray service never initialized (`ShowFromTray` null-checks it away silently). The no-arg `Start()` overload delegates to this one, so both entry points are covered.

---

## 3. "Reveal in Explorer" opens Desktop instead of selecting the file — ccp-bugs #998

**Root cause.** All 8 reveal buttons hand-rolled `Process.Start("explorer.exe", $"/select,\"{path}\"")`, building the command line as one pre-quoted string. The embedded quotes are re-parsed before explorer ever sees them, and on a mismatch **explorer silently falls back to opening its default folder (the Desktop) rather than reporting an error** — so the button looked like it did nothing useful. Reported with media on `D:` and the app on `C:`.

**What changed.** New `Helpers/ExplorerLauncher.cs` (`RevealInExplorer` / `OpenFolder`), sitting alongside the existing `Helpers/BrowserLauncher.cs` which solves the analogous problem for URLs. Built on `ProcessStartInfo.ArgumentList`, which takes a single pre-tokenized element and lets the runtime apply the correct Windows quoting rules, so spaces and non-ASCII survive intact. `ArgumentList` requires `UseShellExecute = false`, which is fine for a plain executable. Paths are normalized through `Path.GetFullPath`, and a missing file now falls back to opening its containing directory.

All 8 call sites repointed:

- `Windows/MediaHistoryWindow.xaml.cs`
- `MainWindow/MainWindow.Assets.cs`
- `Windows/SessionCompleteWindow.xaml.cs` (keeps its "file not found" message box for when neither the file nor its folder survives)
- `Views/Deeper/DeeperEditorWindow.xaml.cs`
- `Services/TutorialService.cs` x2
- `Services/Chaos/DtrhHostService.cs`
- `Services/Chaos/LoomHostService.cs`

**Residual edge case worth knowing:** explorer.exe splits its own command line on commas, so a path literally containing a comma can still mis-select regardless of quoting. The bulletproof answer is `SHOpenFolderAndSelectItems` via shell32. Out of scope here, but noting it rather than implying this is airtight.

---

## 4. Haptics under "Studio" vs the Effects Rack — SKIPPED, premise inverted

Not landed, and I do not think it should be landed as briefed. **Haptics is already in the Effects Rack.**

`StudioTabView.BuildRack()` declares a full `"haptics"` rack entry in the `IMMERSION` group — art `vibe.png`, tier-1 livery, live enable dot, right-click quick-toggle. It has been there since the Phase 4 rack build.

Reading the thread rather than a summary of it, Nardda's actual words were:

> "it's a bit strange to have a specific 'Haptic' button under 'Studio' and **not only** in 'Effects Rack'"

So the ask is the **inverse** of the brief: not *add* Haptics to the rack (already true), but *remove* the redundant duplicate shortcut. The nav-rail "Studio" door currently lists three entries — Effects Rack, Presets, **Haptics** — where the third is a shortcut that navigates to `ShowTab("haptics")` -> `StudioTab.FocusRackEntry("haptics")`, i.e. straight to the rack entry that already exists. Seeing "Haptics" as a *sibling* of "Effects Rack" in the rail is precisely what reads as strange.

I did not make the change, for three reasons:

1. **It is a deletion of a discoverable affordance**, i.e. a product decision on three community voices, not a bug fix — and the opposite operation from what this batch was authorized to do.
2. **It is not a clean one-liner.** `BtnNavHaptics` has 6 live wiring points: `MainWindow.xaml`, `MainWindow.ChromeFx.cs:93` (nav-entry FX list), `MainWindow.ChromeFx.cs:543` (`"haptics" => BtnNavHaptics`, the which-nav-entry-highlights map), `MainWindow.TabNavigation.cs:932` (handler), `Services/Dev/DoorShooter.cs:57` (screenshot rig), `Services/TutorialService.cs:196` (`["BtnNavHaptics"] = "haptics"` NavDoorMap), plus a comment in `StudioTabView.Haptics.cs:27`.
3. **One of those needs judgment, not deletion.** `ShowTab("haptics")` still has live callers (`MainWindow.PremiumRail.cs:331`, `MainWindow.Presets.cs:1013`), so the ChromeFx highlight map must be *repointed* to `BtnNavStudio` rather than dropped — otherwise navigating to haptics lights up no nav entry.

**Recommended follow-up, if the owner green-lights the removal:** delete the `BtnNavHaptics` `<Button>` from `DoorEntriesStudio`, delete the handler, drop it from the ChromeFx FX list, repoint `"haptics" => BtnNavStudio`, drop the TutorialService NavDoorMap row, and drop the DoorShooter row. No loc keys change — the rack entry already reuses `tab_haptics`. Worth a play-test of the Studio door and the premium rail's Haptics chip afterwards.

---

## Verify

- `dotnet build` — **0 errors**, 338 warnings (unchanged from the base commit).
- `dotnet test` — **3614 passed, 5 failed**, matching the known nested-worktree baseline exactly: `YouLibraryDoorTests.EachLibraryLauncherIsOneRowBoundToOneExistingHandler` x4 and `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`. No new failures.
- App not run (per instruction). #1 and #2 are focus/window-state behaviours that want a play-test on real hardware.
