### PR TITLE
fix(braindrain): the blur was invisible where the driver leaves the capture's alpha byte at 0 (#960, #975)

### DIFF
--- a/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
+++ b/ConditioningControlPanel/Services/Compositor/BrainDrainCapturePump.cs
@@ -113,6 +113,52 @@ internal sealed class LatestFrameSlot<T> where T : class, IDisposable
 /// </summary>
 internal sealed class BrainDrainCapturePump
 {
+    // ================================================================================
+    //  #960 / #975 - THE ALPHA BYTE. Read this before touching the wrap below.
+    // ================================================================================
+    //
+    // The staging surface is a 32bpp BI_RGB DIB section and the capture is a GDI StretchBlt off
+    // the desktop DC. GDI defines the fourth byte of a 32bpp BI_RGB pixel as UNUSED: it is under
+    // no obligation to write anything into it, and what a device-to-DIB blt actually leaves there
+    // is up to the display driver and the blit path. Most machines leave 0xFF (the DWM's own
+    // surface carries it) and every dev box we own is one of them. Some machines leave 0x00.
+    //
+    // This code used to wrap those bits as Bgra8888 + SKAlphaType.Opaque and assume Skia would
+    // force the alpha to 1 because the type says the image is opaque. IT DOES NOT (verified
+    // against SkiaSharp 2.88.8): a Bgra8888 buffer whose alpha bytes are 0 draws as FULLY
+    // TRANSPARENT no matter what the declared alpha type says. On a machine whose driver leaves
+    // the byte at 0 the whole feature therefore rendered NOTHING while every single check passed
+    // - StretchBlt returned true, frames published, FramesPublished went up, both first-frame
+    // watchdogs stayed quiet, the audio half ran normally. That is #960/#975 exactly: "the audio
+    // plays but there is no visual", machine-dependent, no GPU-vendor pattern, nothing in the log.
+    //
+    // THE FIX: stop reading that byte at all. Rgb888x is Skia's "32bpp, fourth byte is padding,
+    // the image is opaque BY CONSTRUCTION" type, so the driver's leftovers cannot reach the
+    // output. Rgb888x is R,G,B,X in memory while GDI wrote B,G,R,X, so <see cref="SwapRedBlue"/>
+    // puts the channels back - it rides on the draw paint, which costs one extra pipeline stage
+    // and no extra offscreen. A channel swap is per-pixel and linear, so it commutes with both
+    // the gaussian and the displacement resample: applying it after the filter chain is exactly
+    // equivalent to applying it to the source.
+    //
+    // The legacy per-screen-window route never had this bug: it blts into a DDB via
+    // CreateCompatibleBitmap and hands it to CreateBitmapSourceFromHBitmap, which produces a
+    // Bgr32 BitmapSource - no alpha channel to get wrong. Only the compositor route reads the
+    // byte, which is why "turn the unified overlay renderer off" was a working workaround.
+
+    /// <summary>Colour type the capture is wrapped as. NOT Bgra8888 - see the block above.</summary>
+    internal const SKColorType CaptureColorType = SKColorType.Rgb888x;
+
+    /// <summary>Undoes the R/B transposition that reading GDI's BGRX bytes as Rgb888x introduces.
+    /// Alpha row is (0,0,0,1,0): untouched, and already 1 because the wrap is opaque. Shared and
+    /// immutable - never disposed by a pump instance.</summary>
+    internal static readonly SKColorFilter SwapRedBlue = SKColorFilter.CreateColorMatrix(new float[]
+    {
+        0, 0, 1, 0, 0,
+        0, 1, 0, 0, 0,
+        1, 0, 0, 0, 0,
+        0, 0, 0, 1, 0,
+    });
+
     /// <summary>How long the UI thread will wait for the hand-off lock before giving up and
     /// redrawing the frame it already has. The critical section is a two-field pointer swap, so
     /// this budget exists only so that "never block the UI thread" is enforced, not hoped for.</summary>
@@ -166,7 +212,7 @@ internal sealed class BrainDrainCapturePump
     public int SlotCount => _slots.Length;
 
     // Pump-thread-only state (the blur/melt chain, lifted verbatim from the old CapturePass).
-    private readonly SKPaint _blurPaint = new();
+    private readonly SKPaint _blurPaint = new() { ColorFilter = SwapRedBlue };
     private SKImageFilter? _blurFilter;
     private float _lastSigma = -1f;
     private SKImage? _meltNoiseTile;
@@ -423,7 +469,7 @@ internal sealed class BrainDrainCapturePump
                     // the warp still applies, it just warps the unblurred capture).
                     meltFilter = SKImageFilter.CreateDisplacementMapEffect(
                         SKColorChannel.R, SKColorChannel.G, amplitude, noiseFilter, _blurFilter);
-                    (_meltPaint ??= new SKPaint()).ImageFilter = meltFilter;
+                    (_meltPaint ??= new SKPaint { ColorFilter = SwapRedBlue }).ImageFilter = meltFilter;
                     // Displacement samples outside the source bleed transparent along the frame
                     // edges. Max |offset| is amplitude/2 (the map is centred on 0.5), +2px slack
                     // for the CTM scale below feeding back into the mapped displacement scale.
@@ -453,9 +499,13 @@ internal sealed class BrainDrainCapturePump
                         continue;
                     GdiFlush();
 
-                    var info = new SKImageInfo(slot.W, slot.H, SKColorType.Bgra8888, SKAlphaType.Opaque);
+                    // Opaque BY CONSTRUCTION (Rgb888x ignores the fourth byte) - see the alpha-byte
+                    // block at the top of this class. Never widen this back to Bgra8888.
+                    var info = new SKImageInfo(slot.W, slot.H, CaptureColorType, SKAlphaType.Opaque);
                     using var raw = SKImage.FromPixels(info, slot.Bits, slot.W * 4); // zero-copy wrap; consumed below
                     if (raw == null) continue;
+
+                    ReportFirstFrame(slot);
 
                     var canvas = slot.Surface.Canvas;
                     canvas.Clear(SKColors.Transparent);
@@ -471,7 +521,10 @@ internal sealed class BrainDrainCapturePump
                     }
                     else
                     {
-                        canvas.DrawImage(raw, 0, 0, _blurFilter != null ? _blurPaint : null);
+                        // ALWAYS through _blurPaint, even at sub-pixel sigma where _blurFilter is
+                        // null: the paint also carries SwapRedBlue, and a null paint here would
+                        // paint the capture with red and blue transposed.
+                        canvas.DrawImage(raw, 0, 0, _blurPaint);
                     }
                     slot.Frame.Publish(slot.Surface.Snapshot());
                     Interlocked.Increment(ref _framesPublished);
@@ -493,6 +546,96 @@ internal sealed class BrainDrainCapturePump
             noiseFilter?.Dispose();
             drift?.Dispose();
         }
+    }
+
+    // ================================================================================
+    //  #960 / #975 - say out loud what the driver actually handed us
+    // ================================================================================
+
+    private bool _firstFrameReported;
+
+    /// <summary>
+    /// One Information line per pump run describing the FIRST captured frame: the raw alpha byte
+    /// the display driver left in the DIB, and the frame's mean luminance. Both numbers were
+    /// unknowable from a bug report before, and between them they separate the three ways a
+    /// "started, frames publishing, nothing on screen" run can happen:
+    ///
+    /// <list type="bullet">
+    /// <item>rawAlpha ~0  - the #960 class. Harmless now (the wrap ignores that byte), but the
+    ///   line proves this machine is one of them and that the fix is what is carrying it.</item>
+    /// <item>luma ~0 with rawAlpha 255 - the capture came back BLACK: the desktop content is on a
+    ///   hardware overlay plane (MPO / HDR / a protected surface) and never reaches the GDI
+    ///   read-back. A blur of black IS drawn, it just looks like a dark scrim, not the effect.</item>
+    /// <item>both healthy - the pixels are fine and the problem is downstream (host window
+    ///   placement, z-order, capture affinity on an indirect display).</item>
+    /// </list>
+    ///
+    /// <para>Sampled on a sparse grid (at most <see cref="SampleGrid"/> squared points), once per
+    /// run, on the capture thread - it costs microseconds and never repeats.</para>
+    /// </summary>
+    private void ReportFirstFrame(Slot slot)
+    {
+        if (_firstFrameReported) return;
+        _firstFrameReported = true;
+        try
+        {
+            var (meanAlpha, meanLuma, minAlpha, maxAlpha) = SampleFrame(slot.Bits, slot.W, slot.H, slot.W * 4);
+            App.Logger?.Information(
+                "Brain Drain capture: first frame {W}x{H} (downscale {Downscale}, monitor {Bounds}) - " +
+                "raw GDI alpha byte mean {MeanAlpha:F1} (min {MinAlpha}, max {MaxAlpha}), mean luma {MeanLuma:F1}",
+                slot.W, slot.H, _downscale, slot.Bounds, meanAlpha, minAlpha, maxAlpha, meanLuma);
+
+            if (maxAlpha == 0)
+            {
+                App.Logger?.Warning(
+                    "Brain Drain capture: this display driver leaves the 32bpp DIB's unused byte at 0 (#960/#975). " +
+                    "Harmless now - the capture is read as Rgb888x so the byte is ignored - but a build before " +
+                    "this fix rendered NOTHING on this machine while reporting success everywhere.");
+            }
+            if (meanLuma < 1.0)
+            {
+                App.Logger?.Warning(
+                    "Brain Drain capture: the desktop read back BLACK (mean luma {MeanLuma:F2}). The screen content " +
+                    "is bypassing the GDI-visible surface (hardware overlay plane / HDR / protected content), so the " +
+                    "blur has nothing to blur and will look like a dark tint rather than the effect.", meanLuma);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("BrainDrain first-frame sample failed: {E}", ex.Message);
+        }
+    }
+
+    /// <summary>Points per axis in the first-frame sample grid.</summary>
+    private const int SampleGrid = 48;
+
+    /// <summary>
+    /// Sparse statistics over a 32bpp BGRX capture buffer: the mean/min/max of the fourth (alpha)
+    /// byte AS THE DRIVER LEFT IT, and the mean luminance of the BGR channels. Internal so the
+    /// tests can pin the numbers on synthetic buffers - production calls it once per pump run.
+    /// </summary>
+    internal static (double MeanAlpha, double MeanLuma, int MinAlpha, int MaxAlpha) SampleFrame(
+        IntPtr bits, int w, int h, int stride)
+    {
+        if (bits == IntPtr.Zero || w <= 0 || h <= 0) return (0, 0, 0, 0);
+
+        int stepX = Math.Max(1, w / SampleGrid), stepY = Math.Max(1, h / SampleGrid);
+        double sumA = 0, sumL = 0;
+        int n = 0, min = 255, max = 0;
+        for (int y = 0; y < h; y += stepY)
+        {
+            for (int x = 0; x < w; x += stepX)
+            {
+                int px = Marshal.ReadInt32(bits, y * stride + x * 4);
+                int b = px & 0xFF, g = (px >> 8) & 0xFF, r = (px >> 16) & 0xFF, a = (px >> 24) & 0xFF;
+                sumA += a;
+                sumL += 0.2126 * r + 0.7152 * g + 0.0722 * b;
+                if (a < min) min = a;
+                if (a > max) max = a;
+                n++;
+            }
+        }
+        return n == 0 ? (0, 0, 0, 0) : (sumA / n, sumL / n, min, max);
     }
 
     /// <summary>A tick that took this long on the UI thread WAS the #777 freeze. Here it is a
@@ -573,11 +716,13 @@ internal sealed class BrainDrainCapturePump
         catch { }
         try
         {
+            // ColorFilter is the SHARED static SwapRedBlue: drop the reference, never dispose it.
             _blurPaint.ImageFilter = null;
+            _blurPaint.ColorFilter = null;
             _blurFilter?.Dispose();
             _blurFilter = null;
             _blurPaint.Dispose();
-            if (_meltPaint != null) { _meltPaint.ImageFilter = null; _meltPaint.Dispose(); _meltPaint = null; }
+            if (_meltPaint != null) { _meltPaint.ImageFilter = null; _meltPaint.ColorFilter = null; _meltPaint.Dispose(); _meltPaint = null; }
             if (_meltNoisePaint != null) { _meltNoisePaint.Shader = null; _meltNoisePaint.Dispose(); _meltNoisePaint = null; }
             _meltNoiseTile?.Dispose();
             _meltNoiseTile = null;

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -2173,8 +2173,13 @@ public class OverlayService : IDisposable
         {
             var all = App.GetAllScreensCached();
             if (all.Length == 0) return "none enumerated";
+            // DPI is part of the description because the compositor host places itself in DEVICE
+            // pixels while WPF lays out in DIPs: a mixed-DPI arrangement is the one topology where
+            // "the overlay is up but you cannot see it" can be a placement bug rather than a
+            // capture bug, and a report could not tell the two apart without these numbers.
             return string.Join(" | ", all.Select(s =>
-                $"{s.DeviceName}{(s.Primary ? "*" : "")} {s.Bounds.Width}x{s.Bounds.Height}@{s.Bounds.X},{s.Bounds.Y}"));
+                $"{s.DeviceName}{(s.Primary ? "*" : "")} {s.Bounds.Width}x{s.Bounds.Height}@{s.Bounds.X},{s.Bounds.Y} " +
+                $"@{Compositor.CompositorHostWindow.GetDpiScaleForScreen(s) * 100:F0}%"));
         }
         catch { return "enumeration threw"; }
     }

--- a/Tests/ConditioningControlPanel.Tests/BrainDrainCaptureAlphaTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BrainDrainCaptureAlphaTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Runtime.InteropServices;
+using ConditioningControlPanel.Services.Compositor;
+using SkiaSharp;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// #960 / #975 - "Brain Drain plays the audio but there is no visual", machine-dependent, no GPU
+/// vendor pattern, and NOTHING in the log: the route line said COMPOSITOR, the layer armed, the
+/// pump published frames and both first-frame watchdogs stayed quiet.
+///
+/// <para>The cause was the fourth byte of the capture. <c>BrainDrainCapturePump</c> StretchBlts the
+/// desktop into a 32bpp BI_RGB DIB, where GDI defines that byte as UNUSED - whether a device-to-DIB
+/// blt leaves 0xFF or 0x00 there is the display driver's business. The pump wrapped those bits as
+/// <c>Bgra8888 + SKAlphaType.Opaque</c> on the assumption that the declared alpha type makes Skia
+/// force the alpha to 1. It does not (<see cref="ZeroAlphaBuffer_DeclaredOpaque_StillDrawsNothing"/>),
+/// so on a machine whose driver leaves 0x00 the entire effect rendered fully transparent while
+/// every check in the pipeline passed.</para>
+///
+/// <para>Why no existing test caught it: <c>BrainDrainMeltFilterTests</c> builds its source with
+/// <c>SKCanvas.Clear</c>, which writes alpha 255. Every synthetic source in the suite was opaque;
+/// the field's is only opaque by driver convention. These tests use the field's shape instead -
+/// a buffer whose alpha bytes are ZERO - and assert the production wrap survives it.</para>
+/// </summary>
+public class BrainDrainCaptureAlphaTests
+{
+    private const int W = 96, H = 64;
+    private const byte SrcB = 200, SrcG = 120, SrcR = 60;
+
+    /// <summary>A capture buffer in GDI's byte order (B,G,R,X) with <paramref name="alphaByte"/>
+    /// left in the unused slot - 0 is what the affected machines produce, 255 what ours do.</summary>
+    private static byte[] CaptureBuffer(byte alphaByte)
+    {
+        var px = new byte[W * H * 4];
+        for (int p = 0; p < W * H; p++)
+        {
+            px[p * 4 + 0] = SrcB;
+            px[p * 4 + 1] = SrcG;
+            px[p * 4 + 2] = SrcR;
+            px[p * 4 + 3] = alphaByte;
+        }
+        return px;
+    }
+
+    private sealed class Pinned : IDisposable
+    {
+        private GCHandle _h;
+        public IntPtr Ptr => _h.AddrOfPinnedObject();
+        public Pinned(byte[] buf) => _h = GCHandle.Alloc(buf, GCHandleType.Pinned);
+        public void Dispose() { if (_h.IsAllocated) _h.Free(); }
+    }
+
+    /// <summary>Centre pixel of a run, read back UNPREMULTIPLIED as B,G,R,A.</summary>
+    private static (byte B, byte G, byte R, byte A) Centre(SKImage img)
+    {
+        var info = new SKImageInfo(img.Width, img.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+        var o = new byte[info.Width * info.Height * 4];
+        using var pin = new Pinned(o);
+        Assert.True(img.ReadPixels(info, pin.Ptr, info.Width * 4, 0, 0));
+        int c = ((info.Height / 2) * info.Width + info.Width / 2) * 4;
+        return (o[c], o[c + 1], o[c + 2], o[c + 3]);
+    }
+
+    /// <summary>One capture tick, replicating <c>BrainDrainCapturePump.CaptureOnce</c>'s draw:
+    /// wrap the DIB bits, blur (and optionally melt-warp), publish. <paramref name="productionWrap"/>
+    /// false reproduces the pre-fix Bgra8888 wrap with no colour filter.</summary>
+    private static SKImage Tick(byte[] buffer, bool melt, bool productionWrap)
+    {
+        const int downscale = 4, intensity = 50;
+        float sigma = (float)(intensity * BrainDrainLayer.RadiusScale / downscale / 3.0);
+        float amplitude = (float)((1.0 + intensity * 0.045) * 4.0 / downscale);
+
+        using var pin = new Pinned(buffer);
+        var type = productionWrap ? BrainDrainCapturePump.CaptureColorType : SKColorType.Bgra8888;
+        using var raw = SKImage.FromPixels(new SKImageInfo(W, H, type, SKAlphaType.Opaque), pin.Ptr, W * 4);
+        Assert.NotNull(raw);
+
+        using var surface = SKSurface.Create(new SKImageInfo(W, H, SKColorType.Bgra8888, SKAlphaType.Premul));
+        using var blurFilter = sigma > 0.05f ? SKImageFilter.CreateBlur(sigma, sigma) : null;
+        using var paint = new SKPaint
+        {
+            ImageFilter = blurFilter,
+            ColorFilter = productionWrap ? BrainDrainCapturePump.SwapRedBlue : null,
+        };
+
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+
+        SKImageFilter? meltFilter = null;
+        SKShader? drift = null;
+        SKImageFilter? noiseFilter = null;
+        SKPaint? noisePaint = null;
+        SKImage? tile = null;
+        if (melt)
+        {
+            // Turbulence tile + displacement, as the pump composes it. Only the presence of the
+            // warp matters here; its tuning is BrainDrainMeltFilterTests' job.
+            float freq = 12f / 256f;
+            using var noise = SKShader.CreatePerlinNoiseTurbulence(freq, freq * 0.65f, 2, 7f, new SKSizeI(256, 256));
+            using var tileSurface = SKSurface.Create(new SKImageInfo(256, 256, SKColorType.Bgra8888, SKAlphaType.Premul));
+            using (var np = new SKPaint { Shader = noise })
+            {
+                tileSurface.Canvas.Clear(SKColors.Transparent);
+                tileSurface.Canvas.DrawRect(0, 0, 256, 256, np);
+            }
+            tile = tileSurface.Snapshot();
+            drift = SKShader.CreateImage(tile, SKShaderTileMode.Repeat, SKShaderTileMode.Repeat,
+                                         SKMatrix.CreateScale(3f, 3f));
+            noisePaint = new SKPaint { FilterQuality = SKFilterQuality.Low, Shader = drift };
+            noiseFilter = SKImageFilter.CreatePaint(noisePaint);
+            meltFilter = SKImageFilter.CreateDisplacementMapEffect(
+                SKColorChannel.R, SKColorChannel.G, amplitude, noiseFilter, blurFilter);
+            paint.ImageFilter = meltFilter;
+        }
+
+        canvas.DrawImage(raw, 0, 0, paint);
+        var published = surface.Snapshot();
+
+        paint.ImageFilter = null;
+        paint.ColorFilter = null;   // shared static: drop the reference, never dispose it
+        meltFilter?.Dispose();
+        noiseFilter?.Dispose();
+        noisePaint?.Dispose();
+        drift?.Dispose();
+        tile?.Dispose();
+        return published;
+    }
+
+    // ---------------------------------------------------------------- the trap itself
+
+    [Fact]
+    public void ZeroAlphaBuffer_DeclaredOpaque_StillDrawsNothing()
+    {
+        // THE bug, pinned. SKAlphaType.Opaque is a claim about the buffer, not an instruction to
+        // Skia: a Bgra8888 wrap whose alpha bytes are 0 composites to nothing. If a future Skia
+        // bump makes this assertion fail, the trap is gone - but do NOT go back to Bgra8888 on the
+        // strength of that, because the byte is still undefined at the GDI end.
+        using var img = Tick(CaptureBuffer(alphaByte: 0), melt: false, productionWrap: false);
+        var (b, g, r, a) = Centre(img);
+        Assert.Equal(0, a);
+        Assert.Equal((0, 0, 0), (b, g, r));
+    }
+
+    [Fact]
+    public void ZeroAlphaBuffer_ProductionWrap_IsOpaqueAndKeepsItsColours()
+    {
+        using var img = Tick(CaptureBuffer(alphaByte: 0), melt: false, productionWrap: true);
+        var (b, g, r, a) = Centre(img);
+        Assert.Equal(255, a);
+        Assert.InRange(b, SrcB - 2, SrcB + 2);
+        Assert.InRange(g, SrcG - 2, SrcG + 2);
+        Assert.InRange(r, SrcR - 2, SrcR + 2);
+    }
+
+    [Fact]
+    public void ZeroAlphaBuffer_ProductionWrap_SurvivesTheMeltVariantToo()
+    {
+        // Both reporters had melt ON, and the melt chain routes the capture through an extra
+        // displacement node - the one place a "force the alpha inside a filter" fix silently
+        // degraded to opaque BLACK. Ignoring the byte at the wrap has no such failure mode.
+        using var img = Tick(CaptureBuffer(alphaByte: 0), melt: true, productionWrap: true);
+        var (b, g, r, a) = Centre(img);
+        Assert.Equal(255, a);
+        Assert.InRange(b, SrcB - 8, SrcB + 8);
+        Assert.InRange(g, SrcG - 8, SrcG + 8);
+        Assert.InRange(r, SrcR - 8, SrcR + 8);
+    }
+
+    [Fact]
+    public void HealthyAlphaBuffer_ProductionWrap_IsUnchanged()
+    {
+        // The regression guard: the machines that always worked must render identically.
+        using var fixedWrap = Tick(CaptureBuffer(alphaByte: 255), melt: false, productionWrap: true);
+        using var oldWrap = Tick(CaptureBuffer(alphaByte: 255), melt: false, productionWrap: false);
+        Assert.Equal(Centre(oldWrap), Centre(fixedWrap));
+        Assert.Equal(255, Centre(fixedWrap).A);
+    }
+
+    // ---------------------------------------------------------------- the diagnostic sample
+
+    [Fact]
+    public void SampleFrame_ReportsTheRawAlphaByteTheDriverLeft()
+    {
+        var zero = CaptureBuffer(alphaByte: 0);
+        using (var pin = new Pinned(zero))
+        {
+            var s = BrainDrainCapturePump.SampleFrame(pin.Ptr, W, H, W * 4);
+            Assert.Equal(0, s.MaxAlpha);          // the line that names an affected machine
+            Assert.Equal(0.0, s.MeanAlpha, 3);
+            Assert.True(s.MeanLuma > 1.0);        // ...while the picture itself is fine
+        }
+
+        var opaque = CaptureBuffer(alphaByte: 255);
+        using (var pin = new Pinned(opaque))
+        {
+            var s = BrainDrainCapturePump.SampleFrame(pin.Ptr, W, H, W * 4);
+            Assert.Equal(255, s.MinAlpha);
+            Assert.Equal(255.0, s.MeanAlpha, 3);
+        }
+    }
+
+    [Fact]
+    public void SampleFrame_BlackCaptureIsDistinguishableFromAnInvisibleOne()
+    {
+        // MPO / HDR read-back returns a BLACK desktop with a perfectly good alpha byte. That is a
+        // different failure with a different symptom (a dark scrim, not nothing), and the two have
+        // to be separable from one log line.
+        var black = new byte[W * H * 4];
+        for (int p = 0; p < W * H; p++) black[p * 4 + 3] = 255;
+        using var pin = new Pinned(black);
+        var s = BrainDrainCapturePump.SampleFrame(pin.Ptr, W, H, W * 4);
+        Assert.Equal(255, s.MinAlpha);
+        Assert.Equal(0.0, s.MeanLuma, 3);
+    }
+
+    [Fact]
+    public void SampleFrame_RejectsNonsenseGeometryRatherThanReadingWildMemory()
+    {
+        Assert.Equal((0.0, 0.0, 0, 0), BrainDrainCapturePump.SampleFrame(IntPtr.Zero, W, H, W * 4));
+        var buf = CaptureBuffer(255);
+        using var pin = new Pinned(buf);
+        Assert.Equal((0.0, 0.0, 0, 0), BrainDrainCapturePump.SampleFrame(pin.Ptr, 0, H, W * 4));
+        Assert.Equal((0.0, 0.0, 0, 0), BrainDrainCapturePump.SampleFrame(pin.Ptr, W, -1, W * 4));
+    }
+}


### PR DESCRIPTION
## The report

"Brain drain plays the audio file if it is available but nothing visual even with every slider at 100%" — ccp-bugs #960, re-reported as #975, plus ModernSilver1 and nikkidoll on Discord. Machine-dependent, no GPU-vendor pattern (two AMD users, one works), survived two releases of diagnostics-only commits.

## Why two releases of diagnostics found nothing

Both reporters' 6.8.2 logs are **clean**:

```
Brain Drain starting - route COMPOSITOR (UnifiedOverlayHost setting is ON; ...), intensity 50%, melt true, dualMonitor true, tier "Quality", monitors [\.\DISPLAY1* 2560x1440@0,0 | \.\DISPLAY2 2560x1440@-2560,0]
Brain Drain started on compositor layer, intensity 50%, melt true
```

No `did NOT arm`, no no-frames warning from either watchdog. Every check passed because every check genuinely was passing: `StretchBlt` returned true, slots built, `FramesPublished` climbed, the layer drew its frame every tick. The frame was **fully transparent**.

## Root cause

`BrainDrainCapturePump` StretchBlts the desktop into a 32bpp `BI_RGB` DIB section. GDI defines the fourth byte of such a pixel as **unused** — what a device-to-DIB blt leaves there is up to the display driver, and it is `0xFF` on some machines and `0x00` on others.

The pump wrapped those bits as `Bgra8888 + SKAlphaType.Opaque`, assuming the declared alpha type makes Skia force alpha to 1. **It does not.** Verified against the SkiaSharp 2.88.8 we ship:

| source alpha byte | wrap | result |
|---|---|---|
| 255 | `Bgra8888` + `Opaque` | correct |
| **0** | `Bgra8888` + `Opaque` | **fully transparent** |
| 0 | `Rgb888x` + swap | correct |

So on a machine whose driver leaves `0x00`, the entire effect composited at alpha 0 while reporting success everywhere. Audio unaffected — it is a separate service.

The **legacy per-screen-window route never had this bug**: it blts into a DDB via `CreateCompatibleBitmap` and hands it to `CreateBitmapSourceFromHBitmap`, which yields a `Bgr32` BitmapSource with no alpha channel to get wrong. That is why "turn the unified overlay renderer off" was a working workaround, and why every compositor-side diagnostic added so far reported health.

## The fix

Stop reading that byte. `Rgb888x` is Skia's "32bpp, fourth byte is padding, opaque **by construction**" colour type, so the driver's leftovers cannot reach the output. `Rgb888x` is RGBX in memory while GDI wrote BGRX, so a shared colour matrix on the draw paint puts R and B back.

A channel swap is per-pixel and linear, so it commutes with the gaussian and with the melt displacement's resample — riding on the paint costs one pipeline stage and no extra offscreen. It also has no failure mode in the melt chain: forcing the alpha inside an image filter instead (the obvious alternative) silently degrades to opaque **black** through the displacement node, which is why this landed on the wrap.

## Telemetry, so the next report is readable

- **One Information line per pump run** naming what the driver actually handed us: the raw alpha byte (mean/min/max) and the frame's mean luminance. Between them they separate the three ways a "started, publishing, nothing on screen" run can happen:
  - alpha 0 → this bug,
  - luma 0 with good alpha → the desktop read back **black** (hardware overlay plane / HDR / protected content), which draws a dark scrim rather than nothing,
  - both healthy → the pixels are fine and the problem is downstream.
- A **Warning** on each of those two conditions, naming them.
- **Per-monitor DPI** on the existing route line. Mixed-DPI is the one topology where "the overlay is up but invisible" could be a placement bug rather than a capture bug, and a report could not tell them apart.

## Why the suite missed it

Every synthetic source in `BrainDrainMeltFilterTests` is built with `SKCanvas.Clear`, which writes alpha 255. The field's source is only opaque by driver convention. The new `BrainDrainCaptureAlphaTests` use the field's shape — a buffer whose alpha bytes are **zero** — and cover:

- the trap itself (`Bgra8888` + `Opaque` with alpha 0 draws nothing), pinned so a Skia bump cannot quietly change it,
- the production wrap surviving alpha 0 on the plain **and** melt paths,
- a regression guard that machines which always worked render identically,
- the diagnostic sampler, including telling a black capture apart from an invisible one.

## Verification

- `dotnet build` clean.
- Full suite: **3636 passed, 5 failed** — exactly the known nested-worktree baseline (`YouLibraryDoorTests` ×4 + `Phase8RedirectContractTests.PatreonStillRedirectsIntoTheSettingsDoorsAccountSection`).
- All 23 brain-drain tests (7 new + existing melt/hand-off) pass.

Not merged — wants a play-test, and ideally a build to Nardda (BUG-MMDM2LXEL9) and the AU reporter, whose logs will now say outright which condition their machine is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3mrhKZQj2ehTJUhj2ueon
