### PR TITLE
fix: v6.8.3 updaters can be left with a dead app by our own temp-cache prune

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -1507,6 +1507,22 @@ namespace ConditioningControlPanel
             // append-only, so without this it accumulates months of old crashes and the reporter
             // ships them all (the last 120KB), burying the real failure and polluting triage.
             RotateCrashLogForVersion(logPath);
+
+            // Before a single service starts: prove the bundled natives actually unpacked. A
+            // truncated single-file extraction cache is never repaired by the .NET host on its
+            // own, so it bricks every subsequent launch - and it surfaces as a XamlParseException
+            // blaming AmbientFxCanvas, which sends everyone hunting the wrong bug. This has to run
+            // ahead of the service block below because Skia backs the compositor, flashes,
+            // subliminals and bubbles, not just that one FX canvas. See NativeBundleGuard.
+            if (!Services.NativeBundleGuard.VerifyOrRepair(() =>
+                {
+                    try { _splash?.CloseImmediate(); } catch { }
+                    _splash = null;
+                }))
+            {
+                Shutdown();
+                return;
+            }
 
             // Surface a single-instance takeover (a prior wedged/headless process was killed so
             // this launch could proceed). Recorded here because Logger isn't up during the handshake.

--- a/ConditioningControlPanel/Services/Update/NativeBundleGuard.cs
+++ b/ConditioningControlPanel/Services/Update/NativeBundleGuard.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// Last line of defence before a missing bundled native can take startup down: prove Skia
+    /// loads, and if it does not, clear the extraction cache and relaunch.
+    ///
+    /// <para>The app publishes as <c>PublishSingleFile</c> + <c>SelfContained</c> with
+    /// <c>IncludeNativeLibrariesForSelfExtract=true</c>, so every native dependency (libSkiaSharp,
+    /// libvosk, onnxruntime, OpenCvSharpExtern, sherpa, the whole libvlc tree) lives inside the exe
+    /// and is unpacked into <c>%TEMP%\.net\ConditioningControlPanel\&lt;bundle-id&gt;\</c>.</para>
+    ///
+    /// <para><b>What the host does and does not cover.</b> Measured on .NET 8, 2026-08-20: at
+    /// process start the host verifies that folder against the bundle manifest and re-extracts
+    /// anything missing - even natives nothing ever loads. Strip the folder to three files and the
+    /// next launch silently restores all 669. So a merely incomplete cache is NOT what this guards.
+    /// Two states survive that check:</para>
+    /// <list type="bullet">
+    ///   <item>files deleted AFTER startup, mid-session - the host has already run its check and
+    ///   will not look again. This is what bricked 6.8.3 for the first users to update: our own
+    ///   <see cref="UpdateService"/> cache prune fired on a background thread and stripped the live
+    ///   folder. Fixed at the source, but installs already poisoned by the shipped build stay
+    ///   poisoned - the folder is there and the host is happy with it - so they need this to
+    ///   recover on their own;</item>
+    ///   <item>a file that is PRESENT but unloadable - truncated by a full disk, mangled or stubbed
+    ///   by antivirus. The host checks existence, not integrity, so it will never replace it.</item>
+    /// </list>
+    ///
+    /// <para><b>Why it is worth a startup probe.</b> The failure is invisible from the message the
+    /// user gets. Skia backs the compositor, flashes, subliminals and bubbles, but the first thing
+    /// to touch it is <see cref="Controls.AmbientFxCanvas"/> in MainWindow.xaml - so the dialog
+    /// blames a decorative FX control and buries "Dll was not found" at <c>SKPaint..ctor()</c> two
+    /// levels down an inner exception. MainWindow never opens, yet the dispatcher handler swallows
+    /// the throw and the process stays alive as a windowless zombie still logging barks and LibVLC
+    /// init, so it looks like it is running. Nobody is guessing "delete a hidden temp folder" from
+    /// that.</para>
+    ///
+    /// <para>The delete has to happen from OUTSIDE the process: Windows pins loaded image sections,
+    /// and we have wpfgfx_cor3.dll and PresentationNative_cor3.dll mapped out of that very folder,
+    /// so an in-process <c>Directory.Delete</c> would strip it further rather than remove it. We
+    /// hand off to a batch helper that waits for us to exit first, the same shape (and for the same
+    /// reason) as the update helper in <see cref="UpdateService"/>.</para>
+    ///
+    /// <para>Scope note: the probe is deliberately just Skia. It is the one native whose absence is
+    /// unconditionally fatal, and any damage broad enough to matter takes it out. A cache that
+    /// somehow kept Skia but lost, say, OpenCvSharpExtern degrades exactly as it always has (webcam
+    /// features no-op) rather than taking the whole app down.</para>
+    /// </summary>
+    internal static class NativeBundleGuard
+    {
+        /// <summary>
+        /// One repair attempt per version per window. A second failure inside it means the cache
+        /// was not the problem (or the delete could not land), and looping would be worse than
+        /// stopping: relaunch, fail, relaunch is indistinguishable from the app refusing to open.
+        /// </summary>
+        private static readonly TimeSpan RepairCooldown = TimeSpan.FromMinutes(10);
+
+        private const string StampFileName = "native-repair.stamp";
+
+        /// <summary>
+        /// Verifies the bundled natives are loadable. Returns true when startup may continue.
+        ///
+        /// <para>Returns false when the caller must stop: either a repair relaunch is already on
+        /// its way (the user sees the app restart itself once) or we have given up and shown a
+        /// dialog that names the folder to delete. Either way the caller should
+        /// <see cref="Application.Shutdown()"/> and return - do NOT fall through to building
+        /// MainWindow, which is the crash this exists to prevent.</para>
+        /// </summary>
+        /// <param name="beforeExit">
+        /// Runs immediately before the relaunch/dialog, while we are still the foreground app.
+        /// Used to tear the splash screen down so it cannot sit on top of the message box or
+        /// linger over the restarted instance.
+        /// </param>
+        public static bool VerifyOrRepair(Action? beforeExit = null)
+        {
+            // Fail OPEN on anything unexpected. This runs before every launch, so a bug in here
+            // would be a worse outage than the one it prevents: returning true just puts us back
+            // on the pre-guard path, where a genuinely broken cache still throws where it always
+            // did and the crash log still tells the story.
+            try
+            {
+                return VerifyOrRepairCore(beforeExit);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Error(ex, "[NATIVES] Guard failed unexpectedly — continuing startup unguarded");
+                return true;
+            }
+        }
+
+        private static bool VerifyOrRepairCore(Action? beforeExit)
+        {
+            Exception? failure = ProbeSkia();
+            if (failure == null)
+            {
+                // Healthy launch: drop any stamp so a future truncation gets its own full attempt
+                // instead of inheriting a months-old cooldown.
+                ClearStamp();
+                return true;
+            }
+
+            App.Logger?.Fatal(failure,
+                "[NATIVES] Bundled native libraries are not loadable — the single-file extraction cache is incomplete or damaged");
+
+            var cacheRoot = ResolveExtractionRoot();
+            var appExe = Environment.ProcessPath;
+
+            if (cacheRoot == null || string.IsNullOrEmpty(appExe))
+            {
+                // Not a single-file build (a dev `dotnet run`, where natives come from the output
+                // folder) or the cache is already gone. Nothing to clear, so a relaunch would just
+                // reproduce this. Whatever is wrong is a real deployment fault.
+                App.Logger?.Fatal("[NATIVES] No extraction cache to clear (root={Root}, exe={Exe}) — cannot self-repair",
+                    cacheRoot ?? "<none>", appExe ?? "<none>");
+                beforeExit?.Invoke();
+                ShowGiveUpDialog(cacheRoot, failure);
+                return false;
+            }
+
+            if (RepairedRecently())
+            {
+                App.Logger?.Fatal("[NATIVES] Already cleared {Root} for v{Version} within the last {Minutes} minutes — not looping",
+                    cacheRoot, UpdateService.AppVersion, RepairCooldown.TotalMinutes);
+                beforeExit?.Invoke();
+                ShowGiveUpDialog(cacheRoot, failure);
+                return false;
+            }
+
+            App.Logger?.Warning("[NATIVES] Clearing {Root} and relaunching to force a full re-extract", cacheRoot);
+            WriteStamp();
+
+            if (!LaunchRepairHelper(cacheRoot, appExe))
+            {
+                beforeExit?.Invoke();
+                ShowGiveUpDialog(cacheRoot, failure);
+                return false;
+            }
+
+            beforeExit?.Invoke();
+            return false;
+        }
+
+        /// <summary>
+        /// Constructs an <c>SKPaint</c>, which is what forces libSkiaSharp to load. Returns the
+        /// exception on failure, null when Skia is healthy.
+        /// </summary>
+        private static Exception? ProbeSkia()
+        {
+            try
+            {
+                using var paint = new SkiaSharp.SKPaint();
+                // Touch the instance so nothing can optimize the construction away.
+                paint.IsAntialias = true;
+                return null;
+            }
+            catch (DllNotFoundException ex) { return ex; }
+            catch (BadImageFormatException ex) { return ex; }
+            // SkiaSharp resolves its native lib from a static initializer, so on some paths the
+            // load failure surfaces wrapped the first time any Skia type is touched. Only unwrap
+            // to a verdict when the inner cause really is a missing/corrupt native — anything
+            // else is a Skia bug, not a cache problem, and clearing the cache would not fix it.
+            catch (TypeInitializationException ex)
+                when (ex.InnerException is DllNotFoundException or BadImageFormatException)
+            {
+                return ex;
+            }
+        }
+
+        /// <summary>
+        /// The <c>&lt;base&gt;\&lt;app-name&gt;</c> folder holding every bundle-id the host has
+        /// unpacked for this exe, or null when this build does not self-extract at all.
+        /// Older versions' folders are swept with ours - they are pure cache and the host
+        /// rebuilds whichever it needs.
+        /// </summary>
+        private static string? ResolveExtractionRoot()
+        {
+            try
+            {
+                // A single-file bundle reports an empty Location for its entry assembly; a normal
+                // build reports a real path and never extracts anything. IL3000 warns about
+                // exactly that empty return — here it IS the signal we want, not a mistake.
+#pragma warning disable IL3000
+                if (!string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location))
+                    return null;
+#pragma warning restore IL3000
+
+                var exe = Environment.ProcessPath;
+                if (string.IsNullOrEmpty(exe))
+                    return null;
+
+                // Same precedence the host itself uses.
+                var baseDir = Environment.GetEnvironmentVariable("DOTNET_BUNDLE_EXTRACT_BASE_DIR");
+                if (string.IsNullOrWhiteSpace(baseDir))
+                    baseDir = Path.Combine(Path.GetTempPath(), ".net");
+
+                var root = Path.Combine(baseDir, Path.GetFileNameWithoutExtension(exe));
+                return Directory.Exists(root) ? root : null;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "[NATIVES] Could not resolve the bundle extraction root");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Writes and starts the helper that waits for us to exit, deletes the cache and relaunches.
+        /// Returns false if it could not be started, in which case nothing has been deleted.
+        /// </summary>
+        private static bool LaunchRepairHelper(string cacheRoot, string appExe)
+        {
+            try
+            {
+                var helperDir = Path.Combine(Path.GetTempPath(), "ConditioningControlPanel_Repair");
+                Directory.CreateDirectory(helperDir);
+
+                var logPath = Path.Combine(App.UserDataPath, "logs", "native-repair.log");
+                try { Directory.CreateDirectory(Path.GetDirectoryName(logPath)!); } catch { }
+
+                var helperPath = Path.Combine(helperDir, "native-repair.cmd");
+                var pid = Environment.ProcessId;
+
+                // Paths are baked in as literals (no positional args) so spaces are safe — the
+                // install dir is "…\Programs\Conditioning Control Panel".
+                var lines = new[]
+                {
+                    "@echo off",
+                    "setlocal enableextensions",
+                    $"set \"LOG={logPath}\"",
+                    $"set \"APPEXE={appExe}\"",
+                    $"set \"CACHE={cacheRoot}\"",
+                    $"echo [native-repair] start pid={pid} > \"%LOG%\"",
+                    // Wait for us to exit so the loaded image sections are released; without this
+                    // the rd below silently leaves the mapped DLLs behind. Capped at ~1min so a
+                    // recycled PID cannot hang the helper forever.
+                    "set /a tries=0",
+                    ":waitloop",
+                    $"tasklist /FI \"PID eq {pid}\" /NH 2>nul | find \"{pid}\" >nul",
+                    "if errorlevel 1 goto gone",
+                    "set /a tries+=1",
+                    "if %tries% GEQ 30 (",
+                    "  echo [native-repair] wait timed out, proceeding anyway >> \"%LOG%\"",
+                    "  goto gone",
+                    ")",
+                    "ping 127.0.0.1 -n 2 >nul",
+                    "goto waitloop",
+                    ":gone",
+                    "echo [native-repair] app exited (tries=%tries%), clearing cache >> \"%LOG%\"",
+                    "rd /s /q \"%CACHE%\" 2>nul",
+                    "if exist \"%CACHE%\" (",
+                    "  echo [native-repair] WARNING cache survived the delete >> \"%LOG%\"",
+                    ") else (",
+                    "  echo [native-repair] cache cleared >> \"%LOG%\"",
+                    ")",
+                    "echo [native-repair] relaunching app >> \"%LOG%\"",
+                    "start \"\" \"%APPEXE%\"",
+                    "echo [native-repair] done >> \"%LOG%\"",
+                    "endlocal",
+                };
+
+                // UTF-8 without BOM — a BOM breaks batch parsing of the first line.
+                File.WriteAllText(helperPath, string.Join("\r\n", lines) + "\r\n",
+                    new System.Text.UTF8Encoding(false));
+
+                // A .cmd is not a PE, so it needs an explicit interpreter. The helper outlives us
+                // because WPF does not job-object its children.
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c \"{helperPath}\"",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                });
+
+                App.Logger?.Information("[NATIVES] Repair helper launched ({Helper}); log: {Log}", helperPath, logPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Fatal(ex, "[NATIVES] Could not launch the repair helper");
+                return false;
+            }
+        }
+
+        private static string StampPath => Path.Combine(App.UserDataPath, StampFileName);
+
+        /// <summary>
+        /// True when this same version already burned its repair attempt inside the cooldown.
+        /// A version bump gets a fresh attempt: the new bundle has its own extraction folder and
+        /// deserves one.
+        /// </summary>
+        private static bool RepairedRecently()
+        {
+            try
+            {
+                if (!File.Exists(StampPath))
+                    return false;
+
+                var parts = File.ReadAllText(StampPath).Trim().Split('|');
+                if (parts.Length != 2)
+                    return false;
+                if (!string.Equals(parts[0], UpdateService.AppVersion, StringComparison.Ordinal))
+                    return false;
+                if (!long.TryParse(parts[1], out var ticks))
+                    return false;
+
+                return DateTime.UtcNow - new DateTime(ticks, DateTimeKind.Utc) < RepairCooldown;
+            }
+            catch
+            {
+                // An unreadable stamp must not block the repair — that would turn a transient IO
+                // hiccup into a permanently unstartable app.
+                return false;
+            }
+        }
+
+        private static void WriteStamp()
+        {
+            try
+            {
+                Directory.CreateDirectory(App.UserDataPath);
+                File.WriteAllText(StampPath, $"{UpdateService.AppVersion}|{DateTime.UtcNow.Ticks}");
+            }
+            catch { }
+        }
+
+        private static void ClearStamp()
+        {
+            try
+            {
+                if (File.Exists(StampPath))
+                    File.Delete(StampPath);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// The dead end: tell the user what is actually wrong and the one folder to delete. Far
+        /// better than the XamlParseException naming a decorative FX control they have never
+        /// heard of.
+        /// </summary>
+        private static void ShowGiveUpDialog(string? cacheRoot, Exception failure)
+        {
+            try
+            {
+                var where = cacheRoot ?? Path.Combine(Path.GetTempPath(), ".net", "ConditioningControlPanel");
+                MessageBox.Show(
+                    "Conditioning Control Panel could not load its graphics libraries, so it can't start.\n\n" +
+                    "This is almost always a damaged temporary cache rather than a damaged install. " +
+                    "Close the app, delete this folder, then launch again:\n\n" +
+                    where + "\n\n" +
+                    "It is rebuilt automatically on the next start, so deleting it is safe and loses nothing. " +
+                    "If that doesn't help, your antivirus may be quarantining the app's files.\n\n" +
+                    "Details (also in the crash log): " + failure.Message,
+                    "Conditioning Control Panel — startup failed",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            catch { /* MessageBox can fail if the desktop is going away */ }
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Update/UpdateService.cs
+++ b/ConditioningControlPanel/Services/Update/UpdateService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -1111,10 +1111,161 @@ Stay tuned... :3";
         }
 
         /// <summary>
-        /// Cleans up stale .NET single-file extraction cache folders.
-        /// When running as a self-contained single-file app, .NET extracts native libraries to
-        /// %TEMP%\.net\ConditioningControlPanel\{hash}=\ (~200MB each). Each new build gets a
-        /// different hash, and old folders are never cleaned up automatically.
+        /// Marks a folder we are in the middle of deleting. Renaming before deleting makes the
+        /// removal all-or-nothing from the point of view of anyone still using the folder: if a
+        /// file inside is locked the rename fails outright and the folder is left completely
+        /// intact, instead of being stripped of everything that happened not to be mapped.
+        /// </summary>
+        private const string ParkedFolderSuffix = ".stale-";
+
+        private static bool IsParkedFolder(string dir) =>
+            Path.GetFileName(dir).Contains(ParkedFolderSuffix, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Returns the <c>&lt;base&gt;\&lt;hash&gt;</c> folder THIS process is running out of, or
+        /// null if it cannot be established (a normal non-bundled build, or an unreadable module
+        /// list). Null means "do not delete anything" — never "probably that one".
+        /// </summary>
+        private static string? ResolveLiveExtractionFolder(string dotnetTempBase)
+        {
+            try
+            {
+                var prefix = Path.TrimEndingDirectorySeparator(Path.GetFullPath(dotnetTempBase))
+                             + Path.DirectorySeparatorChar;
+
+                foreach (ProcessModule module in Process.GetCurrentProcess().Modules)
+                {
+                    string file;
+                    // A module can vanish between enumeration and read; skip it rather than
+                    // abandoning the whole scan.
+                    try { file = module.FileName ?? string.Empty; } catch { continue; }
+
+                    if (file.Length <= prefix.Length ||
+                        !file.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // <base>\<hash>\libSkiaSharp.dll and <base>\<hash>\libvlc\win-x64\libvlc.dll
+                    // both answer the same thing: the first segment after the base.
+                    var rest = file.Substring(prefix.Length);
+                    var sep = rest.IndexOfAny(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar });
+                    var hash = sep < 0 ? rest : rest.Substring(0, sep);
+                    if (hash.Length == 0) continue;
+
+                    return Path.Combine(Path.TrimEndingDirectorySeparator(prefix), hash);
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("Cleanup: could not read the module list: {Error}", ex.Message);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// True when another process of this same executable is alive. Fails CLOSED — if we
+        /// cannot tell, we report true and the caller prunes nothing.
+        /// </summary>
+        private static bool OtherInstancesRunning()
+        {
+            try
+            {
+                using var me = Process.GetCurrentProcess();
+                foreach (var other in Process.GetProcessesByName(me.ProcessName))
+                {
+                    using (other)
+                    {
+                        if (other.Id != me.Id) return true;
+                    }
+                }
+                return false;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Park-then-delete one stale folder. Returns true only when the folder is actually gone.
+        /// </summary>
+        private static bool TryRemoveStaleFolder(string dir, out long size)
+        {
+            size = 0;
+            try
+            {
+                size = GetDirectorySize(new DirectoryInfo(dir));
+
+                var parked = Path.Combine(
+                    Path.GetDirectoryName(dir)!,
+                    Path.GetFileName(dir) + ParkedFolderSuffix + Environment.ProcessId);
+
+                // The rename is the safety interlock: it throws (leaving the folder untouched)
+                // if anything in there is still mapped by a live process.
+                Directory.Move(dir, parked);
+                Directory.Delete(parked, true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Loud, not silent. The empty catch that used to be here is why a half-deleted
+                // live folder went unnoticed until users started reporting a dead app.
+                App.Logger?.Warning("Cleanup: could not remove stale .NET cache folder {Path}: {Error}",
+                    dir, ex.Message);
+                size = 0;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Finishes off folders a previous run parked but could not delete (a crash between the
+        /// rename and the delete, or a file that was still locked at the time).
+        /// </summary>
+        private static void SweepParkedFolders(string dotnetTempBase, ref int deletedCount, ref long freedBytes)
+        {
+            foreach (var dir in Directory.GetDirectories(dotnetTempBase))
+            {
+                if (!IsParkedFolder(dir)) continue;
+                try
+                {
+                    var size = GetDirectorySize(new DirectoryInfo(dir));
+                    Directory.Delete(dir, true);
+                    freedBytes += size;
+                    deletedCount++;
+                }
+                catch (Exception ex)
+                {
+                    App.Logger?.Debug("Cleanup: parked folder {Path} still not removable: {Error}", dir, ex.Message);
+                }
+            }
+        }
+        /// <summary>
+        /// Deletes extraction-cache folders left behind by PREVIOUS builds.
+        ///
+        /// <para>A self-contained single-file build unpacks its natives into
+        /// <c>%TEMP%\.net\ConditioningControlPanel\{hash}\</c>, one folder per build, several
+        /// hundred MB each, and the .NET host never removes the old ones. So we do - but only
+        /// ones we can PROVE are not in use.</para>
+        ///
+        /// <para><b>Why the paranoia.</b> This method used to pick the live folder by a
+        /// heuristic: the first folder whose LastWriteTime sat within five minutes of process
+        /// start. On 2026-08-20 a 6.8.2 -> 6.8.3 upgrade put two folders inside that window (the
+        /// outgoing build had been running four minutes earlier), the loop matched the WRONG one
+        /// first and broke, and every other folder - including the one this very process was
+        /// running out of - went through <c>Directory.Delete(dir, true)</c>. That delete removes
+        /// what it can and throws when it reaches a mapped image section, so the live folder was
+        /// stripped down to the only three files a running WPF app has locked
+        /// (D3DCompiler_47_cor3, PresentationNative_cor3, wpfgfx_cor3) and the throw landed in an
+        /// empty catch. libSkiaSharp was gone; three seconds later AmbientFxCanvas asked for an
+        /// SKPaint and the app died in InitializeComponent with a XamlParseException that named a
+        /// decorative FX control and nothing else.</para>
+        ///
+        /// <para>The .NET host cannot save us here: it verifies and re-extracts missing files at
+        /// process START, and this runs on a background thread well after that. Every subsequent
+        /// launch repeated the same delete, so the install stayed broken until the folder was
+        /// removed by hand. Hence the two hard rules below - identify the live folder exactly, and
+        /// when anything is uncertain delete NOTHING. Reclaiming disk is a nicety; bricking the
+        /// app is not a tradeoff worth making for it.</para>
         /// </summary>
         private static void CleanupDotNetTempCache(ref int deletedCount, ref long freedBytes)
         {
@@ -1123,63 +1274,54 @@ Stay tuned... :3";
                 var dotnetTempBase = Path.Combine(Path.GetTempPath(), ".net", "ConditioningControlPanel");
                 if (!Directory.Exists(dotnetTempBase)) return;
 
-                // Determine which folder the current process is using by checking
-                // if any loaded assembly resides inside one of these hash folders
-                var currentExePath = Process.GetCurrentProcess().MainModule?.FileName ?? "";
-                var currentFolder = "";
+                // Finish any parked folder a previous run could not fully remove (see below).
+                SweepParkedFolders(dotnetTempBase, ref deletedCount, ref freedBytes);
 
-                // For single-file apps, native libs are extracted to the hash folder.
-                // The app's own exe is NOT in the temp folder, but loaded native DLLs are.
-                // We can identify the active folder by checking which one was most recently written
-                // and matches the current process start time.
-                var processStart = Process.GetCurrentProcess().StartTime;
-
-                foreach (var dir in Directory.GetDirectories(dotnetTempBase))
+                // RULE 1: ask the loader which folder is ours, never the clock. Every native we
+                // have mapped out of the bundle lives under the active hash folder, so our own
+                // module list names it exactly. NativeBundleGuard has already loaded Skia by the
+                // time this background task runs, so there is always at least one such module to
+                // find; if there somehow is not, we bail rather than guess.
+                var liveFolder = ResolveLiveExtractionFolder(dotnetTempBase);
+                if (liveFolder == null)
                 {
-                    var dirInfo = new DirectoryInfo(dir);
-                    // The active folder's last write time should be very close to process start
-                    if (Math.Abs((dirInfo.LastWriteTime - processStart).TotalMinutes) < 5)
-                    {
-                        currentFolder = dir;
-                        break;
-                    }
+                    // Not a single-file build, or we simply could not tell. Guessing is what
+                    // caused the incident above.
+                    App.Logger?.Debug("Cleanup: could not identify the live extraction folder — skipping .NET cache prune");
+                    return;
                 }
 
-                // Fallback: if we couldn't identify current folder, keep the newest one
-                if (string.IsNullOrEmpty(currentFolder))
+                // RULE 2: another instance of this exe may be running out of a DIFFERENT hash
+                // folder (mid-update, or a second copy). We cannot see its folder from here, and
+                // half-deleting it would brick that process exactly the way we bricked ourselves.
+                // The prune is pure disk hygiene — skipping it costs nothing but a later retry.
+                if (OtherInstancesRunning())
                 {
-                    currentFolder = Directory.GetDirectories(dotnetTempBase)
-                        .OrderByDescending(d => new DirectoryInfo(d).LastWriteTime)
-                        .FirstOrDefault() ?? "";
+                    App.Logger?.Debug("Cleanup: another instance is running — skipping .NET cache prune");
+                    return;
                 }
 
                 var staleCount = 0;
                 foreach (var dir in Directory.GetDirectories(dotnetTempBase))
                 {
-                    if (string.Equals(dir, currentFolder, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(dir, liveFolder, StringComparison.OrdinalIgnoreCase))
                         continue;
+                    if (IsParkedFolder(dir))
+                        continue; // already handled by the sweep above
 
-                    try
+                    if (TryRemoveStaleFolder(dir, out var size))
                     {
-                        var dirInfo = new DirectoryInfo(dir);
-                        var dirSize = GetDirectorySize(dirInfo);
-                        Directory.Delete(dir, true);
-                        freedBytes += dirSize;
+                        freedBytes += size;
                         deletedCount++;
                         staleCount++;
-                    }
-                    catch
-                    {
-                        // Folder may be in use by another instance — skip silently
                     }
                 }
 
                 if (staleCount > 0)
                 {
-                    App.Logger?.Information("Cleanup: Deleted {Count} stale .NET cache folder(s) from {Path}",
-                        staleCount, dotnetTempBase);
+                    App.Logger?.Information("Cleanup: Deleted {Count} stale .NET cache folder(s) from {Path} (kept live folder {Live})",
+                        staleCount, dotnetTempBase, Path.GetFileName(liveFolder));
                 }
-
                 // Also clean up CCPUpdateHelper cache - this is a temp copy of our exe used during updates.
                 // It extracts to its own .NET cache folder that's never cleaned up.
                 // By the time the main app runs, the update helper has exited, so all folders are safe to delete.


### PR DESCRIPTION
## What users see

After updating to 6.8.3, the app shows this and never opens:

> An error occurred: The invocation of the constructor on type `ConditioningControlPanel.Controls.AmbientFxCanvas` that matches the specified binding constraints threw an exception.

`AmbientFxCanvas` is innocent. The real cause is two levels down in the crash log:

```
Inner Exception: Dll was not found.
   at SkiaSharp.SKPaint..ctor()
   at ConditioningControlPanel.Controls.AmbientFxCanvas..ctor()
   at ConditioningControlPanel.MainWindow.InitializeComponent()
```

`libSkiaSharp.dll` is missing. It is just the first thing in MainWindow.xaml to touch Skia; the compositor, flashes, subliminals and bubbles all sit behind it.

Worse, the process **stays alive** — the dispatcher handler swallows the throw, so it keeps logging barks, LibVLC init and `[RES]` baselines with no window. It looks like it is running. Task Manager is not evidence here.

## Root cause: we delete our own native cache

We publish single-file self-contained with `IncludeNativeLibrariesForSelfExtract`, so every native is unpacked to `%TEMP%\.net\ConditioningControlPanel\<hash>\`. `CleanupDotNetTempCache` prunes folders from old builds — and identified the live one by **guessing**: the first folder whose `LastWriteTime` fell within five minutes of process start.

An upgrade puts two folders inside that window, because the outgoing build was running minutes ago. The loop matched the wrong one and `break`'d, then passed every other folder — including ours — to `Directory.Delete(dir, true)`.

That delete removes what it can and throws when it hits a mapped image section. So the live folder was stripped down to exactly the three files a running WPF app holds locked, and the throw landed in an empty `catch`:

```
D3DCompiler_47_cor3.dll   PresentationNative_cor3.dll   wpfgfx_cor3.dll
```

3 files where there should be 669. Every other native — libSkiaSharp, libvosk, onnxruntime, OpenCvSharpExtern, sherpa, the whole libvlc tree — gone, silently.

It runs on a background thread from `OnStartup`, so it fires on **every** launch, and always *after* the point where the runtime could have helped.

## Why it never self-heals

I assumed the .NET host simply never re-checks the cache. That is wrong, and worth recording: measured on .NET 8, the host verifies the folder against the bundle manifest at process start and re-extracts anything missing — including natives nothing ever loads. Strip a folder to 3 files offline and the next launch silently restores all 669.

The host's check just runs at startup, and our prune runs after it. Hence the permanence: relaunching repeats the delete. The only cure was deleting the folder by hand.

## The fix

**1. Never delete the live folder** (`UpdateService`)

- Resolve the live folder from our own **loaded module list**, which names it exactly. Verified against a real single-file build: the scan returns the true hash folder.
- If it cannot be resolved, or **another instance of this exe is alive** (its folder is invisible to us, and half-deleting it bricks that process the same way), prune nothing.
- **Rename before deleting**, so a locked file aborts the whole removal instead of half-emptying a folder someone is using. Parked leftovers are swept next run.
- Log failures instead of swallowing them.

**2. Recover installs that are already broken** (`NativeBundleGuard`)

Shipping only the fix above leaves everyone already poisoned stuck forever — their folder exists, so the host is satisfied, and nothing puts Skia back. The same dead end is reachable whenever a native is present but unloadable, since the host checks existence and not integrity (truncated by a full disk, stubbed by antivirus).

Before any service starts, construct one `SKPaint`. On `DllNotFound`/`BadImageFormat`, hand off to a batch helper that waits for us to exit, clears the cache and relaunches. Out of process by necessity: we have `wpfgfx_cor3.dll` mapped out of that folder, so an in-process delete would strip it further rather than remove it. Same shape as the existing update helper.

Bounded and fail-open: one repair per version per 10 minutes via a stamp file, after which it stops and shows a dialog **naming the folder to delete** instead of relaunching forever; and any unexpected throw inside the guard returns "healthy", so a bug in the guard can never be worse than the crash it prevents.

## Verification

Built a single-file harness running the guard code verbatim (only `App`/`UpdateService` shimmed, and the modal swapped for a log line):

| Case | Result |
|---|---|
| Healthy launch | silent no-op, no stamp, no helper |
| `libSkiaSharp` corrupted in cache | guard fires, helper clears cache, relaunch comes up clean |
| Stamp planted, still corrupt | refuses to loop, give-up path, process exits |
| Live-folder resolution via module scan | returns the true hash folder |

Also confirmed on the affected machine that the shipped 6.8.3 **bundle is fine** — deleting the cache re-extracted all 669 files and the app opened normally. No re-ship of the installer is needed; this is a code fix for 6.8.4.

`dotnet build` clean, no new warnings.

## Support note

Anyone reporting the `AmbientFxCanvas` dialog on 6.8.3 can be unblocked right now by closing the app and deleting `%TEMP%\.net\ConditioningControlPanel`. It is pure cache and is rebuilt on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TExGg9czx5ScsWCHHAtoAS
