### PR TITLE
fix(auth): heal a diverged auth token instead of retrying the dead one

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -74,6 +74,9 @@ namespace ConditioningControlPanel
         private SplashScreen? _splash;
         private static Thread? _showSignalThread;
         private readonly TaskCompletionSource _patreonInitDone = new();
+        // Serializes the startup auth-token upgrade (see EnsureAuthTokenAsync). Patreon and Discord
+        // init run as parallel background tasks and both used to mint a token unconditionally.
+        private readonly SemaphoreSlim _authUpgradeGate = new(1, 1);
 
         // "Open with CCP" handoff: --play / --edit args parsed at startup.
         // First instance routes directly after MainWindow loads; second instance
@@ -2936,6 +2939,69 @@ namespace ConditioningControlPanel
 
 
         /// <summary>
+        /// Mints a V2 identity + auth token for a provider that is signed in but has no usable
+        /// unified session yet, at most once per launch.
+        ///
+        /// InitializePatreonAndSyncAsync and InitializeDiscordAsync are two parallel background
+        /// tasks, and each used to run its own /v2/auth/&lt;provider&gt; upgrade under the identical
+        /// "no unified id OR no auth token" condition. Both calls mint a token server-side, the
+        /// server keeps the last write and the client keeps whichever response landed second, so
+        /// roughly half the time a dual-linked account ended up holding a token the server no
+        /// longer recognised and every authed request 401'd from then on. The gate serializes the
+        /// two, and the condition is re-checked INSIDE it so the loser sees the freshly minted
+        /// token and no-ops. Still fully async — nothing on the startup path blocks on this.
+        /// </summary>
+        private async Task EnsureAuthTokenAsync(
+            string provider,
+            Func<string?> getAccessToken,
+            Func<V2AuthService, string, Task<V2AuthService.V2AuthResponse>> authenticate)
+        {
+            if (!NeedsAuthTokenUpgrade()) return;
+
+            await _authUpgradeGate.WaitAsync();
+            try
+            {
+                if (!NeedsAuthTokenUpgrade())
+                {
+                    Logger?.Debug("{Provider} auto-upgrade skipped — another provider already minted the auth token", provider);
+                    return;
+                }
+
+                var accessToken = getAccessToken();
+                if (string.IsNullOrEmpty(accessToken)) return;
+
+                Logger?.Information("Auto-upgrading {Provider} user to V2...", provider);
+                var v2Auth = new V2AuthService();
+                var result = await authenticate(v2Auth, accessToken);
+                if (result.Success && result.User != null)
+                {
+                    v2Auth.ApplyUserDataToSettings(result.User, result.AuthToken);
+                    UnifiedUserId = result.User.UnifiedId;
+                    Logger?.Information("Auto-upgrade complete: {Id}", UnifiedUserId);
+                }
+                else if (result.NeedsRegistration)
+                {
+                    Logger?.Information("{Provider} auto-upgrade: needs registration (new user), skipping", provider);
+                }
+                else
+                {
+                    Logger?.Warning("{Provider} auto-upgrade failed: {Error}", provider, result.Error);
+                }
+            }
+            catch (Exception upgradeEx)
+            {
+                Logger?.Warning(upgradeEx, "{Provider} auto-upgrade failed (non-fatal, will retry next launch)", provider);
+            }
+            finally
+            {
+                _authUpgradeGate.Release();
+            }
+
+            static bool NeedsAuthTokenUpgrade() =>
+                string.IsNullOrEmpty(UnifiedUserId) || string.IsNullOrEmpty(Settings?.Current?.AuthToken);
+        }
+
+        /// <summary>
         /// Initialize Patreon and load cloud profile if authenticated
         /// </summary>
         private async Task InitializePatreonAndSyncAsync()
@@ -2949,37 +3015,8 @@ namespace ConditioningControlPanel
                 if (Patreon.IsAuthenticated)
                 {
                     // Auto-upgrade: if Patreon is authenticated but no V2 identity, migrate via /v2/auth/patreon
-                    if (string.IsNullOrEmpty(UnifiedUserId) || string.IsNullOrEmpty(Settings?.Current?.AuthToken))
-                    {
-                        try
-                        {
-                            var accessToken = Patreon.GetAccessToken();
-                            if (!string.IsNullOrEmpty(accessToken))
-                            {
-                                Logger?.Information("Auto-upgrading Patreon user to V2...");
-                                var v2Auth = new V2AuthService();
-                                var result = await v2Auth.AuthenticateWithPatreonAsync(accessToken);
-                                if (result.Success && result.User != null)
-                                {
-                                    v2Auth.ApplyUserDataToSettings(result.User, result.AuthToken);
-                                    UnifiedUserId = result.User.UnifiedId;
-                                    Logger?.Information("Auto-upgrade complete: {Id}", UnifiedUserId);
-                                }
-                                else if (result.NeedsRegistration)
-                                {
-                                    Logger?.Information("Patreon auto-upgrade: needs registration (new user), skipping");
-                                }
-                                else
-                                {
-                                    Logger?.Warning("Patreon auto-upgrade failed: {Error}", result.Error);
-                                }
-                            }
-                        }
-                        catch (Exception upgradeEx)
-                        {
-                            Logger?.Warning(upgradeEx, "Patreon auto-upgrade failed (non-fatal, will retry next launch)");
-                        }
-                    }
+                    await EnsureAuthTokenAsync("Patreon", () => Patreon.GetAccessToken(),
+                        (v2Auth, accessToken) => v2Auth.AuthenticateWithPatreonAsync(accessToken));
 
                     Logger?.Information("Patreon authenticated, loading cloud profile...");
                     await ProfileSync.LoadProfileAsync();
@@ -3045,37 +3082,8 @@ namespace ConditioningControlPanel
                     // Auto-upgrade: if Discord is authenticated but no V2 identity OR no auth token, migrate via /v2/auth/discord
                     // (legacy users created before Feb 2026 may have a UnifiedUserId but no auth_token_hash on the server —
                     // re-running /v2/auth/discord bootstraps a fresh token for them)
-                    if (string.IsNullOrEmpty(UnifiedUserId) || string.IsNullOrEmpty(Settings?.Current?.AuthToken))
-                    {
-                        try
-                        {
-                            var accessToken = Discord.GetAccessToken();
-                            if (!string.IsNullOrEmpty(accessToken))
-                            {
-                                Logger?.Information("Auto-upgrading Discord user to V2...");
-                                var v2Auth = new V2AuthService();
-                                var result = await v2Auth.AuthenticateWithDiscordAsync(accessToken);
-                                if (result.Success && result.User != null)
-                                {
-                                    v2Auth.ApplyUserDataToSettings(result.User, result.AuthToken);
-                                    UnifiedUserId = result.User.UnifiedId;
-                                    Logger?.Information("Auto-upgrade complete: {Id}", UnifiedUserId);
-                                }
-                                else if (result.NeedsRegistration)
-                                {
-                                    Logger?.Information("Discord auto-upgrade: needs registration (new user), skipping");
-                                }
-                                else
-                                {
-                                    Logger?.Warning("Discord auto-upgrade failed: {Error}", result.Error);
-                                }
-                            }
-                        }
-                        catch (Exception upgradeEx)
-                        {
-                            Logger?.Warning(upgradeEx, "Discord auto-upgrade failed (non-fatal, will retry next launch)");
-                        }
-                    }
+                    await EnsureAuthTokenAsync("Discord", () => Discord.GetAccessToken(),
+                        (v2Auth, accessToken) => v2Auth.AuthenticateWithDiscordAsync(accessToken));
 
                     // Wait for Patreon init to finish (up to 10s) before deciding whether to load profile
                     // This prevents a race where Discord init finishes first and calls LoadProfileAsync

--- a/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
+++ b/ConditioningControlPanel/Services/Settings/ProfileSyncService.cs
@@ -229,7 +229,16 @@ namespace ConditioningControlPanel.Services
         private bool _disposed;
         private bool _syncEnabled = true;
         private bool _pendingQuestResetClear;
-        private DateTime _lastAuthRecoveryAttempt = DateTime.MinValue;
+        // Per-strategy recovery cooldowns. restore-session is a single cheap proxy call, so it may
+        // retry often; a provider re-validate walks the Patreon/Discord API and is rate-limited
+        // upstream, so it gets a longer leash. One shared 5-minute cooldown used to cover both,
+        // which meant a diverged token kept 401ing for five minutes before the only strategy that
+        // can actually fix it was even tried.
+        private static readonly TimeSpan RestoreSessionCooldown = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan ProviderRevalidateCooldown = TimeSpan.FromMinutes(2);
+        private DateTime _lastRestoreSessionAttempt = DateTime.MinValue;
+        private DateTime _lastProviderRevalidateAttempt = DateTime.MinValue;
+        private readonly SemaphoreSlim _authRecoveryGate = new(1, 1);
         private bool _hasLoadedProfile; // true after first successful LoadProfileAsync/SyncProfileAsync round-trip
         private readonly SemaphoreSlim _syncGate = new(1, 1);
 
@@ -3492,8 +3501,9 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
-        /// Handles a 401 Unauthorized response. Attempts token recovery via restore-session with a
-        /// 5-minute cooldown between attempts. The token is preserved on failure.
+        /// Handles a 401 Unauthorized response. Attempts token recovery (see
+        /// <see cref="TryRecoverAuthTokenAsync"/>) under per-strategy cooldowns. The token is
+        /// preserved on failure.
         ///
         /// Returns TRUE only when the session was actually recovered and it is safe to carry on
         /// with the request that 401'd. It used to return true for any 401 - including "recovery
@@ -3511,33 +3521,77 @@ namespace ConditioningControlPanel.Services
             if (response.StatusCode != HttpStatusCode.Unauthorized)
                 return false;
 
-            // Attempt recovery with a 5-minute cooldown to prevent concurrent 401s from spam-recovering
-            // while still allowing retry if a transient server issue resolves later.
-            if (DateTime.Now - _lastAuthRecoveryAttempt > TimeSpan.FromMinutes(5))
+            // One recovery at a time: a burst of concurrent 401s must not fire a burst of
+            // re-validates. Waiters re-enter TryRecoverAuthTokenAsync and fall straight out on the
+            // per-strategy cooldowns the winner just claimed, so they cost nothing.
+            await _authRecoveryGate.WaitAsync();
+            try
             {
-                _lastAuthRecoveryAttempt = DateTime.Now;
-                App.Logger?.Information("[Auth] 401 received — attempting token recovery via restore-session");
-                var recovered = await TryRecoverAuthTokenAsync();
-                if (recovered)
+                App.Logger?.Information("[Auth] 401 received — attempting token recovery");
+                if (await TryRecoverAuthTokenAsync())
                 {
                     App.Logger?.Information("[Auth] Token recovered successfully");
                     StartHeartbeat();
                     return true;
                 }
             }
+            finally
+            {
+                _authRecoveryGate.Release();
+            }
 
             // Don't clear the auth token — it may still be valid for other endpoints or after
-            // a transient server issue. The 5-minute cooldown prevents recovery spam.
+            // a transient server issue. The per-strategy cooldowns prevent recovery spam.
             App.Logger?.Warning("[Auth] 401 — recovery failed or on cooldown, token kept for retry");
             return false;
         }
 
         /// <summary>
-        /// Attempts to recover the auth token by calling /v2/auth/restore-session.
+        /// Attempts to recover the auth token, cheapest strategy first.
+        ///
+        /// 1. /v2/auth/restore-session — confirms the stored token is still the server's. It can
+        ///    only ever clear a TRANSIENT 401, because the endpoint authenticates with the very
+        ///    token we are trying to replace: if the client and server copies have diverged it
+        ///    answers 401 forever, which is why recovery alone never healed a divergence.
+        /// 2. Provider re-validate — /patreon/validate and /discord/validate both re-issue the
+        ///    auth token when the one we present doesn't match (BUG-7DCJHDP3JZ), and the provider
+        ///    OAuth token (not the CCP one) authenticates the call. This is the ONLY client path
+        ///    that can mint a fresh token, so a divergence has to fall through to it.
+        ///
         /// Returns true if the token was successfully recovered.
-        /// Must NOT call HandleUnauthorizedAsync on the response (would recurse).
+        /// Must NOT call HandleUnauthorizedAsync on any response here (would recurse).
         /// </summary>
         private async Task<bool> TryRecoverAuthTokenAsync()
+        {
+            if (string.IsNullOrEmpty(App.Settings?.Current?.UnifiedId))
+                return false;
+
+            if (TryClaimCooldown(ref _lastRestoreSessionAttempt, RestoreSessionCooldown)
+                && await TryRestoreSessionAsync())
+                return true;
+
+            if (TryClaimCooldown(ref _lastProviderRevalidateAttempt, ProviderRevalidateCooldown)
+                && await TryProviderRevalidateAsync())
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Marks a recovery strategy as attempted now, or returns false if it is still cooling down.
+        /// </summary>
+        private static bool TryClaimCooldown(ref DateTime lastAttempt, TimeSpan cooldown)
+        {
+            if (DateTime.Now - lastAttempt <= cooldown)
+                return false;
+            lastAttempt = DateTime.Now;
+            return true;
+        }
+
+        /// <summary>
+        /// Recovery strategy 1: ask the server to confirm the stored token.
+        /// </summary>
+        private async Task<bool> TryRestoreSessionAsync()
         {
             try
             {
@@ -3587,6 +3641,54 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Warning("[Auth] restore-session recovery failed: {Error}", ex.Message);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Recovery strategy 2: force the signed-in provider to re-validate, which makes the server
+        /// re-issue the auth token when the stored one no longer matches its hash. Reuses the
+        /// services' own validate entry points — both already persist a re-issued token — so a
+        /// change in <see cref="AppSettings.AuthToken"/> across the call is the success signal.
+        /// </summary>
+        private static async Task<bool> TryProviderRevalidateAsync()
+        {
+            var before = App.Settings?.Current?.AuthToken;
+            try
+            {
+                var patreon = App.Patreon;
+                var discord = App.Discord;
+                if (patreon?.IsAuthenticated == true)
+                {
+                    App.Logger?.Information("[Auth] Re-validating Patreon to have the server re-issue the auth token");
+                    await patreon.ValidateSubscriptionAsync(forceRefresh: true);
+                }
+                else if (discord?.IsAuthenticated == true)
+                {
+                    App.Logger?.Information("[Auth] Re-validating Discord to have the server re-issue the auth token");
+                    await discord.ValidateAndRefreshUserAsync(forceRefresh: true);
+                }
+                else
+                {
+                    // Invite-code / email-only sessions have no provider to mint from; nothing left
+                    // to try short of the user signing in again.
+                    App.Logger?.Warning("[Auth] No provider session available to re-issue the auth token");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning("[Auth] Provider re-validate failed: {Error}", ex.Message);
+                return false;
+            }
+
+            var after = App.Settings?.Current?.AuthToken;
+            if (!string.IsNullOrEmpty(after) && after != before)
+            {
+                App.Logger?.Information("[Auth] Provider re-validate issued a fresh auth token");
+                return true;
+            }
+
+            App.Logger?.Warning("[Auth] Provider re-validate returned no new auth token — token still diverged");
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Client-side half of the auth-token divergence problem (the server race is being fixed separately). Two defects made a divergence permanent for the affected account.

## 1. Recovery could never fix a divergence — `ProfileSyncService`

`TryRecoverAuthTokenAsync` only ever called `/v2/auth/restore-session`, presenting the same stored token. That endpoint authenticates with the very token we are trying to replace, so once the client and server copies disagree it 401s forever: recovery was structurally incapable of healing the thing it existed to heal.

Recovery is now two ordered strategies:

1. **restore-session** (unchanged behaviour, now `TryRestoreSessionAsync`) — clears a *transient* 401 and confirms the stored token.
2. **provider re-validate** (new, `TryProviderRevalidateAsync`) — forces `PatreonService.ValidateSubscriptionAsync(forceRefresh: true)` or, failing that, `DiscordService.ValidateAndRefreshUserAsync(forceRefresh: true)`. Both endpoints are authenticated by the *provider* OAuth token, not the CCP one, and both already re-issue and persist a fresh auth token when the presented one does not match (BUG-7DCJHDP3JZ). This is the only client path that can mint a new token, so a divergence has to fall through to it. Success is detected as a changed stored token; a session with no provider login (invite code / email only) logs and gives up.

Both services are reached through their existing `App.*` statics and public entry points — no new coupling, no new events.

**Cooldown**, previously one shared 5 minutes: now per strategy — 30s for the cheap restore-session call, 2 minutes for the rate-limited provider round trip — plus a `SemaphoreSlim` so a burst of concurrent 401s produces one recovery pass rather than a storm. Net effect: a diverged token heals on the **first** 401 instead of after five minutes of retries that could not have worked.

## 2. Two startup blocks raced to mint the token — `App.xaml.cs`

`InitializePatreonAndSyncAsync` and `InitializeDiscordAsync` run as parallel background tasks and each auto-upgraded an empty `AuthToken` under the identical `no unified id OR no auth token` condition. Both calls mint a token server-side, the server keeps the last write and the client keeps whichever response landed second — so a dual-linked account had roughly a 50% chance of finishing launch already diverged.

Both now funnel through one `EnsureAuthTokenAsync(provider, getAccessToken, authenticate)` helper that re-checks the condition **inside** a shared `SemaphoreSlim`, so the second provider sees the freshly minted token and no-ops. Logging is parameterised by provider; the startup path stays fully async and non-blocking.

## Verification

- `dotnet build`: 0 errors, no new warnings in either touched file (CA1416 platform warnings pre-existing).
- `dotnet test`: 3641 passed, 0 failed.

No settings, no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
