### PR TITLE
feat(arcademy): Impulse Control House Rules wave (casino floor, trickster, PRESSURE ladder, lit stage)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -64,15 +64,29 @@ games/<key>/index.js  one folder per game; games NEVER import each other
   daily-trigger/   the daily word (homeroom, flagship)  - bank/board/ladder/words-*
   lost-and-found/  the mosaic hunt (MEATY, flagship)    - board/grade/hud/util
   deja-vu/         the pair memory                      - script (the swap plan)
-  impulse-control/ the Drop Tube (pop/withhold)         - lex/schedule/scoring/render/tube3d/tube2d
+  impulse-control/ the Drop Tube (pop/withhold)         - lex/schedule/scoring/render/style/tube3d/tube2d
                    (seeded three.js chute, vendored r185 in ../vendor/; tube2d = no-WebGL ladder)
+                   + the House Rules decks casino (THE FLOOR: bulb-ring marquee, chime ladder,
+                   gate, near-miss staging, jackpot ladder + royal) / pressure (THE SURGE: the
+                   STREAK-driven CCP effects ladder + tube/HUD tremor, never the basin) /
+                   trickster (the Tell, the crooked ring, ghost cursor, stat flicker);
+                   THE LANDING: tube3d projects the middle of its VISIBLE hole into
+                   `--ic-basin-x/-y` on `.g-ic` (render.js onLanding) and the basin /
+                   ring / flourish / stamp hang off those; THE DUSK (`.g-ic-dusk`, z2 over
+                   the tube, render.js) is pressure.js's rung-driven dimmer + FLARE;
+                   render owns the drawn class-rules sheet + the lit HUD + the ticket debrief;
+                   every deck injects its OWN <style id="g-ic-<deck>-style">; render's only
+                   audio node is the grandfathered denied.mp3 sting - every other cue is engine
+                   audio_trigger (pitch = the streak)
   the-deep-end/    2048 with trance-depth tiers (MEATY) - board/schedule/grade/lex/style/casino/trickster/pressure
                    the deepest tile is the heat dial; board/schedule/grade pure, casino+trickster+pressure decks
                    (pressure = the rung-by-rung CCP effects ladder + the Balatro board tremor/HUD juice)
 ```
 
 Each game owns its own lexicon rows; **`ArcademyHostService.NeutralLexicon` mirrors every
-one of them** (200 rows as of Semester 1) or the shell renders raw keys for the settings
+one of them** (200 rows as of Semester 1; `de_*` + the IC House Rules wave since - the count is a
+floor, never a contract: a scratch script diffs every `t('key'` / lexicon table against the C#
+table, see §7) or the shell renders raw keys for the settings
 page's `label_key` / `hint_key`. Impulse Control exports its table as data
 (`impulse-control/lex.js` `IC_LEX`) - copy the values, do not re-word them.
 
@@ -233,8 +247,9 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     it will eat a test suite that boots repeatedly. `clearTimetableCache()` exists for that.
 26. **A `NeutralLexicon` value longer than 96 characters can never be mod-skinned.**
     `MergeModTable` drops any mod string over `Length > 96`, so the long Impulse Control
-    rows (the `ic_slip_*` lines, `ic_tube_rules`) always render English. If a
-    mod must re-voice one, split it into two rows rather than raising the cap.
+    rows (the `ic_slip_*` lines) always render English. If a mod must re-voice one, split
+    it into two rows rather than raising the cap. (`ic_tube_rules` is no longer rendered -
+    the class-rules sheet is drawn - but its C# row stays; the host table is append-only.)
 
 27. **`[hidden]` IS A USER-AGENT RULE, SO ANY AUTHOR `display:` BEATS IT.** `.arc-loader,
     .arc-nope { position:fixed; inset:0; display:flex }` meant `dom.loader.hidden = true` and
@@ -291,6 +306,31 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     that timer can never tick (the dispatcher is already shutting down and OnExit ends in
     TerminateProcess), so the meta flush and the WebView2 disposal it guards never ran.
     `ShutdownFlush` is the synchronous path: flush, dispose, no round trip.
+
+33. **A jackpot's forced garnish KILLED every held spiral wash (engine, fixed 2026-08-22).**
+    `ceremonies.jackpot` forces `drain|spiral`, which re-triggers the ONE wash element per kind
+    with a hold; the hold's deadline used to write `opacity:0` - and took a class's
+    `sustainForever` wheel with it (IC's rung-3 wheel vanished 3.8s after any jackpot; the Deep
+    End's was exposed the same way). `engine/sustained.js startWash` now keeps `forever` +
+    `heldAlpha` per element: a later NON-forever trigger at a HIGHER alpha is a flare that falls
+    back to the held alpha; a LOWER one is the decks' whisper-out step-down and ends the hold.
+    `stop('wash')` clears both. Do not "simplify" the three branches.
+34. **`Vector3.project(camera)` on a camera that has never rendered projects through the
+    identity.** `matrixWorldInverse` is only refreshed by a render or an explicit
+    `camera.updateMatrixWorld(true)`; tube3d's THE LANDING solve ran before the first frame,
+    got garbage, and silently fell back to 50%/50% (the bubble sat on the near coil again). Call
+    `updateMatrixWorld(true)` + `updateProjectionMatrix()` before any build-time projection, and
+    sanity-bound the result (15-85%) with an explicit fallback.
+35. **"The effects play behind the tube" was never z-order - it was alpha.** Three in-app
+    verdicts in a row (owner 2026-08-22). The CDP compositor shot AND a PrintWindow grab both
+    showed the fixed `#arc-fx` layer on top; what the eye saw was the engine's heat-gated
+    bursts (0.15-0.75 alpha, 120-270px) and `mix-blend-mode:screen` washes drowned by a
+    neon WebGL chute, and neon lines bleeding THROUGH a translucent gif read as "behind".
+    The engine's ceilings are law, so the fix is GAME-LOCAL and under the effects: the dusk
+    (rung-driven opacity on an empty div over the tube) plus THE FLARE (snap to 0.84/0.92 under
+    every gif/flash burst for its hold, ease back). Before touching z-index for a "behind"
+    report, inject a solid test box into `.ae-front` and PrintWindow the app - if the box is
+    on top, it is alpha.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -29,7 +29,10 @@ export const STYLE_TEXT = `
 .ae-wash-pink{background:radial-gradient(circle at 50% 55%,rgba(255,105,180,.55),rgba(255,105,180,.12) 60%,transparent 78%);
   mix-blend-mode:screen}
 .ae-wash-spiral{mix-blend-mode:screen;background-image:conic-gradient(from 0deg,rgba(255,105,180,.55),rgba(20,20,43,0) 25%,rgba(184,166,232,.5) 50%,rgba(20,20,43,0) 75%,rgba(255,105,180,.55));
-  animation:ae-spin 9s linear infinite}
+  animation:ae-spin 9s linear infinite;
+  /* a SQUARE wider than the viewport's diagonal (sqrt2 x vmax), centred: a
+     rotating inset:0 rectangle bares its corners every quarter turn */
+  inset:auto;left:50%;top:50%;width:150vmax;height:150vmax;margin:-75vmax 0 0 -75vmax}
 .ae-wash-drain{background:radial-gradient(circle at 50% 50%,rgba(0,0,0,.15),rgba(0,0,0,.72) 85%);
   backdrop-filter:blur(6px) saturate(.75);-webkit-backdrop-filter:blur(6px) saturate(.75)}
 .ae-wash-sublim{background:linear-gradient(0deg,rgba(184,166,232,.28),rgba(255,105,180,.18));mix-blend-mode:screen}

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -52,7 +52,7 @@ export function createSustained(ctx) {
       node.className = 'ae-wash ae-wash-' + washKind + (ctx.reduced() ? ' ae-wash-static' : '');
       ctx.layers.back.appendChild(node);
       ctx.timers.own(node);
-      h = { el: node, hideTimer: 0 };
+      h = { el: node, hideTimer: 0, forever: false, heldAlpha: 0 };
       washHolds.set(washKind, h);
     }
     return h;
@@ -81,7 +81,20 @@ export function createSustained(ctx) {
     }
     if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; }
     h.el.style.opacity = String(alpha);
-    if (opts.sustainForever !== true) {
+    /* THE HELD WASH. sustainForever HOLDS the element at alpha until a later
+       trigger says otherwise. A later trigger that is NOT forever is one of
+       two things: a FLARE (a higher alpha - a jackpot's forced garnish, a
+       ceremony's accent) that must fall back to the HELD alpha when its hold
+       ends, or a STEP-DOWN (a lower alpha - the decks' whisper-out idiom) that
+       ends the hold and fades to 0. Before this, a jackpot over a held spiral
+       fell back to 0 and silently killed the class's wheel. */
+    if (opts.sustainForever === true) {
+      h.forever = true; h.heldAlpha = alpha;
+    } else if (h.forever && alpha > (h.heldAlpha || 0)) {
+      const back = h.heldAlpha;
+      h.hideTimer = ctx.timers.after(holdMs, () => { h.el.style.opacity = String(back); h.hideTimer = 0; });
+    } else {
+      h.forever = false; h.heldAlpha = 0;
       h.hideTimer = ctx.timers.after(holdMs, () => { h.el.style.opacity = '0'; h.hideTimer = 0; });
     }
     ctx.fx('wash', washKind);
@@ -89,7 +102,7 @@ export function createSustained(ctx) {
     return {
       kind: 'wash', variant: washKind, alpha, holdMs,
       retune() { /* alpha follows the next trigger; nothing to animate */ },
-      stop() { if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; } h.el.style.opacity = '0'; },
+      stop() { if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; } h.forever = false; h.heldAlpha = 0; h.el.style.opacity = '0'; },
     };
   }
 
@@ -362,6 +375,7 @@ export function createSustained(ctx) {
     if (kind === 'wash') {
       for (const [, h] of washHolds) {
         if (h.hideTimer) { ctx.timers.cancel(h.hideTimer); h.hideTimer = 0; }
+        h.forever = false; h.heldAlpha = 0;
         h.el.style.opacity = '0';
         if (immediate) ctx.timers.release(h.el);
       }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/casino.js
@@ -1,0 +1,637 @@
+/* ============================================================================
+ * games/impulse-control/casino.js - DECK II of the House Rules for the Drop
+ * Tube: THE FLOOR. The tube (tube3d.js) is the seeded-identity flagship and
+ * stays untouched; this file lights the ROOM around it and makes every verdict
+ * pay out in sound and light. The trickster (trickster.js) lies about the
+ * room; the pressure (pressure.js) is what the room DOES to you as your chain
+ * climbs. This file is the lighting rig and the chime rack.
+ *
+ *   THE SOUND LADDER  every pop chimes, and the chime CLIMBS: +1 semitone per
+ *                     link of the streak, capped +7 (the intake precedent), so
+ *                     an eyes-busy player hears the chain rise. A drift is a
+ *                     muted thud, never silence; a survived X is a soft exhale;
+ *                     the X popped adds NOTHING here (render.js owns the real
+ *                     denied.mp3 sting). Milestones (5/10/15/20) stack an
+ *                     arpeggio on top. Every cue is engine audio_trigger, so
+ *                     shell/audio.js stays the only audio owner (trap 18).
+ *   THE MARQUEE       a ring of bulbs hugging the basin (the reveal surface is
+ *                     round, so the frame is a HALO, not a box). Crawls lazily
+ *                     at low heat, chases hungrily at high heat, flashes on a
+ *                     payout, goes GOLD for the last tenth of the class and the
+ *                     royal, sighs out at the end. Bulb colour temperature is
+ *                     TONIGHT ONLY: seeded from the UTC date alone, so every
+ *                     player on earth shares the hall tonight and it expires
+ *                     at midnight (Deck V).
+ *   PAYOUT LIGHT      a pop pays light scaled by its points: the basin floods,
+ *                     the marquee flashes, the score odometer scale-punches
+ *                     (transform only; the TEXT is index.js's and never moves).
+ *   THE GATE          on a good reveal a thin arc closes around the basin over
+ *                     the reveal window - the closing gate the player is racing.
+ *                     It never touches the bubble node and tells nothing the
+ *                     reveal did not already say (the kind is on the bubble).
+ *   NEAR-MISS STAGING (a) JUST - a pop that lands in the last 12% of its
+ *                     window: the gate flashes white at the point it nearly
+ *                     shut, the near_miss ceremony rises; (b) the RECORD PING -
+ *                     an RT within 8ms of the personal record without beating
+ *                     it: the record line pings; (c) ALMOST - the pointer sat on
+ *                     the X while it was live and the player STILL held: the
+ *                     word, a lavender exhale, a rising tone. All three are
+ *                     staging; the ledger already decided.
+ *   THE JACKPOT LADDER the reward canon, scaled by an intensity dial, no named
+ *                     tiers (jackpotSpec takes care of bursts/particles): a
+ *                     PERFECT stamp may roll a minor jackpot (seeded, chance
+ *                     rises with heat); streak milestones pay a major one
+ *                     deterministically; the ROYAL is once-a-class and only
+ *                     when the class was perfect, the gate held and the chain
+ *                     reached 10 - then the hall floods gold. A failed class
+ *                     still gets a dim payout: silence is where people stand up.
+ *   KEN-BURNS         the two backdrop <img> drift (scale 1.00 -> 1.06, slow
+ *                     pan), period seeded per class and quickening with heat.
+ *   ROOM IDENTITY     per CLASS seed (Deck I): bulb count/size, payout hue on
+ *                     the violet -> rose arc (~6% off-arc teal), ken-burns
+ *                     period and direction. Same seed, same room; a retake
+ *                     replays the identical show.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects index.js hands it AFTER its own
+ *       accounting; writes nothing about score, streak, tally or grade; the
+ *       score chip is moved by transform only, its text is never touched.
+ *   II  input honest  - the bubble is the ONE tap target; every node here is
+ *       pointer-events:none, lives INSIDE render's stage, and nothing is ever
+ *       mounted over, inside or around the bubble's own node. The hover signal
+ *       is read, never acted on.
+ *   III never still   - the marquee crawls at heat 0, the bulbs breathe, the
+ *       backdrop drifts.
+ *   IV  images > text - the three words this deck can show (JUST / ALMOST /
+ *       ROYAL, plus "record") come through the lexicon and live for <600ms.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ic-casino|<tag>' (append-
+ *       only tags; a new tag never shifts an old stream). No Math.random.
+ *       Tonight-only cosmetics come off the UTC DATE alone, by design.
+ *   VI  exits sacred  - capsOk false disarms every light; reduced motion keeps
+ *       a static dim halo (no chase, no punch, no ken-burns; bloom only);
+ *       the stage's .suspended rule freezes the chase; timers ride the game's
+ *       pause-aware registry AND a local set so destroy() cannot leak one.
+ *   VII lexicon       - ic_just / ic_almost / ic_royal / ic_record_ping only,
+ *       through opts.t; nothing else is rendered as text.
+ *
+ * ENGINE vs GAME-LOCAL: cues, the jackpot / near_miss ceremonies and nothing
+ * else go through the engine (opts.engine = index.js's null-safe wrapper with
+ * the audio ceiling and clickSafe welded on). The halo, the flood, the gate,
+ * the words and the odometer punch are game-local: they are positioned on the
+ * game's own geometry (the basin), which no engine primitive knows.
+ * NODE BUDGET: halo (1 + bulbs), flood, gate, word, that is all; all reused.
+ * ==========================================================================*/
+
+import { makeRng, hash01 } from '../../core/rng.js';
+
+export const IC_CASINO = Object.freeze({
+  /* ---- the marquee --------------------------------------------------- */
+  BULBS: Object.freeze([24, 28, 32]),          // seeded pick
+  MQ_T_SLOW: 3.2,                              // chase period (s) at heat 0
+  MQ_T_FAST: 0.8,                              // at heat 1
+  MQ_A_LO: 0.22,                               // presence (opacity) band
+  MQ_A_HI: 0.85,
+  MQ_T_GOLD: 0.5,
+  MQ_A_GOLD: 0.95,
+  MQ_FLASH_MS: 520,
+  /** tonight only: three bulb temperatures, UTC date picks one. */
+  TONIGHT_HUES: Object.freeze([38, 330, 268]), // amber / pink / lavender
+  /* ---- the payout ---------------------------------------------------- */
+  FLOOD_MS: 620,
+  FLOOD_A: Object.freeze([0.18, 0.55]),        // by pts/100
+  PUNCH_SCALE: Object.freeze([0.04, 0.26]),    // odometer scale by pts/100
+  PUNCH_MS: 220,
+  MILESTONES: Object.freeze([5, 10, 15, 20]),
+  /* ---- the gate + the near misses ------------------------------------ */
+  JUST_SHARE: 0.88,                            // pop at >= 88% of the window = JUST
+  RECORD_PING_MS: 8,                           // within 8ms of the record, not under it
+  WORD_MS: 560,
+  ALMOST_HOVER_MS: 140,                        // the pointer must SIT on the X this long
+  NEAR_MISS_I: Object.freeze({ just: 0.55, record: 0.4, almost: 0.7 }),
+  /* ---- the jackpot ladder -------------------------------------------- */
+  MINOR_CHANCE: Object.freeze([0.22, 0.55]),   // perfect stamp, by heat
+  MINOR_I: 0.35,
+  MAJOR_I: Object.freeze([0.5, 0.65, 0.8, 0.95]),  // by milestone index
+  ROYAL_MIN_STREAK: 10,
+  ROYAL_I: 1,
+  ROYAL_MS: 3200,
+  END_DIM_MS: 1400,
+  /* ---- the sound ladder ---------------------------------------------- */
+  SEMITONE_CAP: 7,
+  POP_LEVEL: Object.freeze([0.3, 0.5]),        // by min(streak,10)/10
+  DRIFT_LEVEL: 0.22,
+  PASS_LEVEL: 0.3,
+  MILESTONE_LEVEL: 0.45,
+  JACKPOT_LEVEL: 0.55,
+  NEAR_LEVEL: 0.3,
+  /* ---- ken-burns ----------------------------------------------------- */
+  KB_T: Object.freeze([30, 16]),               // seconds: heat 0 -> heat 1
+  KB_SEED_SPAN: 8,                             // +0..8s seeded
+  KB_SCALE: 1.06,
+  /* ---- identity ------------------------------------------------------ */
+  OFF_ARC: 0.06,
+  HUE_ARC: Object.freeze([268, 342]),          // violet -> rose
+  HUE_OFF: 184,                                // the teal night
+  HEAT_REPAINT_STEP: 0.03,
+});
+
+const STYLE_ID = 'g-ic-casino-style';
+const STYLE_TEXT = `
+.g-ic-cs-halo{position:absolute;inset:0;pointer-events:none;--ic-mq-t:3.2s;--ic-mq-a:.22;--ic-mq-hue:330;
+  opacity:var(--ic-mq-a);transition:opacity .9s ease}
+.g-ic-cs-bulb{position:absolute;width:var(--ic-mq-d,7px);height:var(--ic-mq-d,7px);margin:calc(var(--ic-mq-d,7px) * -.5);
+  border-radius:50%;background:hsl(var(--ic-mq-hue) 95% 72%);
+  box-shadow:0 0 6px hsl(var(--ic-mq-hue) 95% 70% / .9),0 0 14px hsl(var(--ic-mq-hue) 90% 60% / .5);
+  animation:g-ic-cs-chase var(--ic-mq-t) linear infinite;animation-delay:calc(var(--i) / var(--n) * var(--ic-mq-t) * -1)}
+@keyframes g-ic-cs-chase{0%{opacity:.18;transform:scale(.8)}12%{opacity:1;transform:scale(1.15)}40%{opacity:.35;transform:scale(.92)}100%{opacity:.18;transform:scale(.8)}}
+.g-ic-cs-halo.gold{--ic-mq-hue:46 !important}
+.g-ic-cs-halo.flash .g-ic-cs-bulb{animation-duration:.22s;filter:brightness(1.6)}
+.g-ic-cs-flood{position:absolute;inset:0;pointer-events:none;opacity:0;
+  background:radial-gradient(circle at var(--ic-basin-x,50%) var(--ic-basin-y,50%), hsl(var(--ic-cs-hue,330) 90% 70% / .9) 0%, hsl(var(--ic-cs-hue,330) 90% 60% / .35) 22%, transparent 58%);
+  transition:opacity .12s ease-out}
+.g-ic-cs-flood.on{opacity:var(--ic-cs-pay,.3);transition:opacity .06s ease-in}
+.g-ic-cs-flood.royal{background:radial-gradient(circle at var(--ic-basin-x,50%) var(--ic-basin-y,50%), hsl(46 100% 72% / .95) 0%, hsl(46 100% 60% / .45) 30%, hsl(46 100% 50% / .12) 70%, transparent 100%);
+  opacity:.9;transition:opacity .35s ease-out}
+.g-ic-cs-gate{position:absolute;inset:0;pointer-events:none;opacity:0;
+  background:conic-gradient(from -90deg, hsl(var(--ic-cs-hue,330) 90% 78% / .85) 0deg, hsl(var(--ic-cs-hue,330) 90% 78% / .85) calc(var(--ic-gate,1) * 360deg), transparent calc(var(--ic-gate,1) * 360deg));
+  -webkit-mask:radial-gradient(circle, transparent calc(var(--ic-gate-r,46%) - 3px), #000 calc(var(--ic-gate-r,46%) - 2px), #000 var(--ic-gate-r,46%), transparent calc(var(--ic-gate-r,46%) + 1px));
+  mask:radial-gradient(circle, transparent calc(var(--ic-gate-r,46%) - 3px), #000 calc(var(--ic-gate-r,46%) - 2px), #000 var(--ic-gate-r,46%), transparent calc(var(--ic-gate-r,46%) + 1px));
+  transition:opacity .18s ease}
+.g-ic-cs-gate.on{opacity:.7}
+.g-ic-cs-gate.just{opacity:1;filter:brightness(2) saturate(.2);transition:none}
+.g-ic-cs-word{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);transform:translate(-50%,-50%) translateY(calc(var(--ic-basin-d,40vmin) * .62));
+  pointer-events:none;font:800 clamp(14px,2.2vmin,22px)/1 var(--font-head,system-ui,sans-serif);letter-spacing:.22em;
+  color:hsl(var(--ic-cs-hue,330) 90% 82%);text-shadow:0 0 12px hsl(var(--ic-cs-hue,330) 90% 70% / .8);opacity:0}
+.g-ic-cs-word.on{animation:g-ic-cs-word .56s ease-out forwards}
+.g-ic-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-ic-cs-word.gold{color:#ffe08a;text-shadow:0 0 14px rgba(240,194,75,.9)}
+@keyframes g-ic-cs-word{0%{opacity:0;transform:translate(-50%,-50%) translateY(calc(var(--ic-basin-d,40vmin) * .62)) scale(.7)}
+  18%{opacity:1;transform:translate(-50%,-50%) translateY(calc(var(--ic-basin-d,40vmin) * .62)) scale(1.08)}
+  70%{opacity:1;transform:translate(-50%,-50%) translateY(calc(var(--ic-basin-d,40vmin) * .6)) scale(1)}
+  100%{opacity:0;transform:translate(-50%,-50%) translateY(calc(var(--ic-basin-d,40vmin) * .5)) scale(1)}}
+.g-ic-cs-punch{transition:transform .22s cubic-bezier(.2,1.6,.4,1) !important;transform:scale(var(--ic-cs-ps,1))}
+.g-ic-cs-bloom{box-shadow:0 0 0 2px hsl(var(--ic-cs-hue,330) 90% 70% / .55),0 0 22px hsl(var(--ic-cs-hue,330) 90% 65% / .6) !important;transition:box-shadow .3s ease}
+.g-ic-cs-kb{animation:g-ic-cs-kb var(--ic-kb-t,30s) ease-in-out infinite alternate;transform-origin:var(--ic-kb-o,50% 50%)}
+@keyframes g-ic-cs-kb{from{transform:scale(1) translate(0,0)}to{transform:scale(1.06) translate(var(--ic-kb-x,1.5%),var(--ic-kb-y,-1%))}}
+@media (prefers-reduced-motion: reduce){
+  .g-ic-cs-bulb{animation:none !important;opacity:.55}
+  .g-ic-cs-kb{animation:none !important}
+  .g-ic-cs-word.on{animation:none;opacity:1}
+}
+.g-ic.reduced .g-ic-cs-bulb{animation:none !important;opacity:.55}
+.g-ic.reduced .g-ic-cs-kb{animation:none !important}
+.g-ic.suspended .g-ic-cs-bulb,.g-ic.suspended .g-ic-cs-kb,.g-ic.suspended .g-ic-cs-word{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** The chime's pitch for a streak: +1 semitone per link, capped. Pure. */
+export function pitchForStreak(streak) {
+  const s = Math.max(0, Math.min(IC_CASINO.SEMITONE_CAP, (Number(streak) || 0) - 1));
+  return +Math.pow(2, s / 12).toFixed(4);
+}
+/** Tonight's bulb hue from the UTC date string alone (shared by everyone). Pure. */
+export function tonightHue(utcDate) {
+  const h = hash01('ic-tonight|' + String(utcDate || ''));
+  const list = IC_CASINO.TONIGHT_HUES;
+  return list[Math.min(list.length - 1, Math.floor(h * list.length))];
+}
+/** Did a pop land in the JUST band of its window? Pure. */
+export function isJust(rt, windowMs) {
+  const w = Number(windowMs) || 0;
+  if (w <= 0) return false;
+  return (Number(rt) || 0) >= w * IC_CASINO.JUST_SHARE;
+}
+/** Within the record-ping band (slower than the record, by at most N ms)? Pure. */
+export function isRecordPing(rt, recordRt) {
+  const r = Number(recordRt) || 0;
+  if (r <= 0) return false;
+  const d = (Number(rt) || 0) - r;
+  return d > 0 && d <= IC_CASINO.RECORD_PING_MS;
+}
+/** The royal verdict. Pure. */
+export function isRoyal(end) {
+  const e = end || {};
+  return !!e.perfect && !!e.sGateOk && (Number(e.bestStreak) || 0) >= IC_CASINO.ROYAL_MIN_STREAK;
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+
+/**
+ * @param {Object} o  see IC-HOUSE-RULES §3:
+ *   seed, gradeTier, reduced, motionLevel, utcDate, nodes (render.nodes),
+ *   engine {fire,sustain,stop,ceremony,channels,rewardRoll,audio}, timers {after,every,clear},
+ *   capsOk () => bool, t (k, fallback) => string, log
+ */
+export function createIcCasino(o) {
+  const opts = o || {};
+  const C = IC_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const nodes = opts.nodes || {};
+  const eng = opts.engine || {};
+  const armedBase = !!nodes.stage && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'ic') + '|ic-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, floods: 0, words: 0 };
+  function cue(name, level, extra) {
+    if (!armed()) return;
+    counts.cues++;
+    try {
+      if (typeof eng.audio === 'function') eng.audio(name, level, extra || {});
+      else if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed()) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+
+  /* ---- identity (per class seed) ------------------------------------------ */
+  const ID = (() => {
+    const offArc = roll('hue') < C.OFF_ARC;
+    const hue = offArc ? C.HUE_OFF : Math.round(lerp(C.HUE_ARC, roll('hue')));
+    const bulbs = C.BULBS[Math.floor(roll('bulbs') * C.BULBS.length)];
+    const bulbD = 6 + Math.round(roll('bulbs') * 3);            // 6..9 px
+    const kbExtra = roll('kb') * C.KB_SEED_SPAN;
+    const kbX = (roll('kb') < 0.5 ? -1 : 1) * (1 + roll('kb') * 1.5);  // 1..2.5%
+    const kbY = (roll('kb') < 0.5 ? -1 : 1) * (0.5 + roll('kb'));      // .5..1.5%
+    const kbO = (40 + Math.round(roll('kb') * 20)) + '% ' + (40 + Math.round(roll('kb') * 20)) + '%';
+    return { offArc, hue, bulbs, bulbD, kbExtra, kbX, kbY, kbO };
+  })();
+  const mqHue = tonightHue(opts.utcDate);
+
+  /* ---- nodes ------------------------------------------------------------- */
+  let halo = null, flood = null, gate = null, word = null;
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let goldOn = false;
+  let royalOn = false;
+  let endedOn = false;
+  let lastReveal = null;        // { kind, windowMs, idx, at }
+  let hoverOn = false;
+  let hoverSince = 0;
+  let tempted = false;           // the pointer sat on a live X
+  let gateTimer = 0;
+  let wordTimer = 0;
+  let floodTimer = 0;
+  let flashTimer = 0;
+  let punchTimer = 0;
+  let royalTimer = 0;
+  let bestStreakSeen = 0;
+  const jackLog = [];
+
+  function nowMs() {
+    try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+    return Date.now();
+  }
+
+  function mount() {
+    if (halo || !armedBase || !capsOk()) return;   // bgIntensity 0: the floor stays dark
+    ensureStyle();
+    const stage = nodes.stage;
+    setVar(stage, '--ic-cs-hue', ID.hue);
+    /* the halo: in STAGE's marquee slot when it exists, else on the stage
+       (centred on the basin by the slot's own CSS) */
+    const host = nodes.marqueeSlot || stage;
+    halo = el('div', 'g-ic-cs-halo');
+    if (halo) {
+      setVar(halo, '--ic-mq-hue', mqHue);
+      setVar(halo, '--ic-mq-d', ID.bulbD + 'px');
+      setVar(halo, '--n', ID.bulbs);
+      for (let i = 0; i < ID.bulbs; i++) {
+        const b = el('span', 'g-ic-cs-bulb');
+        if (!b) break;
+        const a = (i / ID.bulbs) * Math.PI * 2 - Math.PI / 2;
+        b.style.left = (50 + 50 * Math.cos(a)).toFixed(2) + '%';
+        b.style.top = (50 + 50 * Math.sin(a)).toFixed(2) + '%';
+        setVar(b, '--i', i);
+        halo.appendChild(b);
+      }
+      try { host.appendChild(halo); } catch (e) { halo = null; }
+    }
+    flood = el('div', 'g-ic-cs-flood');
+    gate = el('div', 'g-ic-cs-gate');
+    word = el('div', 'g-ic-cs-word');
+    try {
+      /* the flood under everything of ours, the gate in the marquee slot (its
+         geometry IS the basin's), the word on the stage */
+      if (flood) {
+        if (typeof stage.insertBefore === 'function' && stage.firstChild) stage.insertBefore(flood, stage.firstChild);
+        else stage.appendChild(flood);
+      }
+    } catch (e) { /* partial mounts are fine */ }
+    try { if (gate) (nodes.marqueeSlot || stage).appendChild(gate); } catch (e) { gate = null; }
+    try { if (word) stage.appendChild(word); } catch (e) { word = null; }
+    /* ken-burns on the two backdrop images */
+    if (!still) {
+      for (const img of [nodes.bgA, nodes.bgB]) {
+        if (!img) continue;
+        setCls(img, 'g-ic-cs-kb', true);
+        setVar(img, '--ic-kb-x', ID.kbX + '%');
+        setVar(img, '--ic-kb-y', ID.kbY + '%');
+        setVar(img, '--ic-kb-o', ID.kbO);
+      }
+    }
+    paintHeat(true);
+  }
+
+  function paintHeat(force) {
+    if (!halo && !nodes.bgA) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (halo) {
+      const gold = goldOn || royalOn;
+      const period = gold ? C.MQ_T_GOLD : (C.MQ_T_SLOW + (C.MQ_T_FAST - C.MQ_T_SLOW) * heat);
+      const alpha = endedOn ? 0 : (gold ? C.MQ_A_GOLD : lerp([C.MQ_A_LO, C.MQ_A_HI], heat));
+      setVar(halo, '--ic-mq-t', period.toFixed(2) + 's');
+      setVar(halo, '--ic-mq-a', alpha.toFixed(2));
+    }
+    if (!still) {
+      const kb = (C.KB_T[0] + (C.KB_T[1] - C.KB_T[0]) * heat + ID.kbExtra).toFixed(1) + 's';
+      setVar(nodes.bgA, '--ic-kb-t', kb);
+      setVar(nodes.bgB, '--ic-kb-t', kb);
+    }
+  }
+
+  /* ---- the light ---------------------------------------------------------- */
+  function flashHalo(ms) {
+    if (!halo || !armed() || still) return;
+    setCls(halo, 'flash', true);
+    cancel(flashTimer);
+    flashTimer = after(ms || C.MQ_FLASH_MS, () => setCls(halo, 'flash', false));
+  }
+  function floodBasin(q, ms) {
+    if (!flood || !armed()) { return; }
+    counts.floods++;
+    setVar(flood, '--ic-cs-pay', lerp(C.FLOOD_A, q).toFixed(2));
+    setCls(flood, 'on', true);
+    cancel(floodTimer);
+    floodTimer = after(ms || C.FLOOD_MS, () => setCls(flood, 'on', false));
+  }
+  function punchScore(q) {
+    const chip = nodes.score;
+    if (!chip || !armed()) return;
+    if (still) {
+      /* reduced motion: a bloom, never a move */
+      setCls(chip, 'g-ic-cs-bloom', true);
+      cancel(punchTimer);
+      punchTimer = after(320, () => setCls(chip, 'g-ic-cs-bloom', false));
+      return;
+    }
+    setCls(chip, 'g-ic-cs-punch', true);
+    setVar(chip, '--ic-cs-ps', (1 + lerp(C.PUNCH_SCALE, q)).toFixed(3));
+    cancel(punchTimer);
+    punchTimer = after(C.PUNCH_MS, () => { setVar(chip, '--ic-cs-ps', '1'); });
+  }
+  function showWord(key, fallback, tone) {
+    if (!word || !armed()) return;
+    counts.words++;
+    word.textContent = t(key, fallback);
+    word.className = 'g-ic-cs-word' + (tone ? ' ' + tone : '');
+    void (word.offsetWidth);
+    setCls(word, 'on', true);
+    cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 40, () => { setCls(word, 'on', false); });
+  }
+  function openGate(windowMs) {
+    if (!gate || !armed()) return;
+    gate.className = 'g-ic-cs-gate';
+    setVar(gate, '--ic-gate', '1');
+    void (gate.offsetWidth);
+    /* the arc closes over the window: a single CSS transition on the var is
+       not animatable without @property, so drive it in 5 steps from the
+       game's timers (cheap, pause-aware, and exact enough for an eye) */
+    setCls(gate, 'on', true);
+    const steps = still ? 1 : 6;
+    const stepMs = windowMs / steps;
+    let k = 0;
+    cancel(gateTimer);
+    const tick = () => {
+      k++;
+      setVar(gate, '--ic-gate', (1 - k / steps).toFixed(3));
+      if (k < steps) gateTimer = after(stepMs, tick);
+    };
+    gateTimer = after(stepMs, tick);
+  }
+  function closeGate(just) {
+    if (!gate) return;
+    cancel(gateTimer);
+    if (just && !still) {
+      setCls(gate, 'just', true);
+      after(180, () => { if (gate) { gate.className = 'g-ic-cs-gate'; } });
+    } else {
+      gate.className = 'g-ic-cs-gate';
+    }
+  }
+
+  /* ---- the ladder --------------------------------------------------------- */
+  function jackpot(intensity, why) {
+    if (!armed()) return;
+    counts.jackpots++;
+    jackLog.push(why);
+    ceremony('jackpot', { intensity });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashHalo(C.MQ_FLASH_MS + 300 * intensity);
+    floodBasin(intensity, C.FLOOD_MS + 300);
+  }
+  function nearMiss(kind, intensity) {
+    if (!armed()) return;
+    counts.nearMisses++;
+    ceremony('near_miss', { intensity });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: kind === 'almost' ? 0.8 : 1.1 });
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      mount();
+      say('casino: floor lit (hue ' + ID.hue + (ID.offArc ? ' off-arc' : '') + ', ' + ID.bulbs + ' bulbs, tonight ' + mqHue + ')');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started) paintHeat(false);
+    },
+    load(ev) {
+      /* the kind is in ev (the trickster's Tell needs it). This deck MUST NOT
+         render a tell: nothing here reads ev.kind before reveal(). */
+      const e = ev || {};
+      if (!goldOn && !royalOn && Number(e.progress) >= 0.9) {
+        goldOn = true;
+        setCls(halo, 'gold', true);
+        paintHeat(true);
+      }
+    },
+    slide() { /* the tube owns the slide; nothing to light */ },
+    reveal(ev) {
+      const e = ev || {};
+      lastReveal = { kind: e.kind, windowMs: Number(e.windowMs) || 0, idx: e.idx, at: nowMs() };
+      tempted = false;
+      if (e.kind !== 'denied') openGate(lastReveal.windowMs);
+      else closeGate(false);
+    },
+    hover(on) {
+      hoverOn = !!on;
+      if (hoverOn) hoverSince = nowMs();
+      else if (lastReveal && lastReveal.kind === 'denied' && nowMs() - hoverSince >= C.ALMOST_HOVER_MS) tempted = true;
+    },
+    pop(ev) {
+      const e = ev || {};
+      const streak = Math.max(0, Number(e.streak) || 0);
+      const q = clamp01((Number(e.pts) || 0) / 100);
+      bestStreakSeen = Math.max(bestStreakSeen, streak);
+      const just = isJust(e.rt, e.windowMs);
+      closeGate(just);
+      /* THE SOUND LADDER */
+      cue('bubble_pop', lerp(C.POP_LEVEL, Math.min(10, streak) / 10), { pitch: pitchForStreak(streak) });
+      /* PAYOUT LIGHT */
+      floodBasin(q);
+      punchScore(q);
+      if (e.stampKind === 'perfect' || e.newRecord) flashHalo();
+      /* NEAR-MISS STAGING */
+      if (just) { showWord('ic_just', 'JUST', ''); nearMiss('just', C.NEAR_MISS_I.just); }
+      else if (!e.newRecord && isRecordPing(e.rt, e.recordRt)) { showWord('ic_record_ping', 'record', 'lav'); nearMiss('record', C.NEAR_MISS_I.record); }
+      /* THE JACKPOT LADDER */
+      const mi = C.MILESTONES.indexOf(streak);
+      if (mi >= 0) {
+        cue('streak', C.MILESTONE_LEVEL, { pitch: pitchForStreak(streak) });
+        jackpot(C.MAJOR_I[mi], 'major@' + streak);
+      } else if (e.stampKind === 'perfect' && roll('jack-minor') < lerp(C.MINOR_CHANCE, heat)) {
+        jackpot(C.MINOR_I, 'minor@' + (e.idx == null ? '?' : e.idx));
+      }
+    },
+    drift() {
+      closeGate(false);
+      cue('bump', C.DRIFT_LEVEL, { pitch: 0.7 });     // a muted thud, never silence
+    },
+    denyPass(ev) {
+      const e = ev || {};
+      cue('whisper', C.PASS_LEVEL, { pitch: 0.85 });   // the soft exhale
+      floodBasin(0.15);
+      if (tempted || (hoverOn && lastReveal && nowMs() - hoverSince >= C.ALMOST_HOVER_MS)) {
+        showWord('ic_almost', 'ALMOST', 'lav');
+        nearMiss('almost', C.NEAR_MISS_I.almost);
+      }
+      tempted = false;
+      void e;
+    },
+    denyHit() {
+      /* render.js owns the sting; here the floor just dims for a beat */
+      closeGate(false);
+      tempted = false;
+      if (halo && !still) { setCls(halo, 'flash', false); }
+    },
+    end(ev) {
+      const e = ev || {};
+      endedOn = true;
+      cancel(gateTimer);
+      if (gate) gate.className = 'g-ic-cs-gate';
+      const royal = isRoyal(Object.assign({ bestStreak: bestStreakSeen }, e));
+      if (royal && armed()) {
+        royalOn = true;
+        counts.royal = 1;
+        setCls(halo, 'gold', true);
+        setCls(flood, 'royal', true);
+        showWord('ic_royal', 'ROYAL', 'gold');
+        ceremony('jackpot', { intensity: C.ROYAL_I });
+        cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.2 });
+        after(260, () => cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.5 }));
+        after(520, () => cue('stamp', 0.5, { pitch: 1 }));
+        flashHalo(C.ROYAL_MS);
+        cancel(royalTimer);
+        royalTimer = after(C.ROYAL_MS, () => { setCls(flood, 'royal', false); paintHeat(true); });
+      } else {
+        /* losses disguised: a dim payout, never silence */
+        const q = clamp01((Number(e.score) || 0) / 1500);
+        floodBasin(0.1 + 0.3 * q, C.END_DIM_MS);
+        cue('wash', 0.25, { pitch: 0.9 });
+        after(C.END_DIM_MS, () => paintHeat(true));
+      }
+      paintHeat(true);
+      return { royal };
+    },
+    pause() {
+      cancelAll();
+      if (gate) gate.className = 'g-ic-cs-gate';
+    },
+    resume() { /* transient light simply ended; the chase is CSS and the stage's .suspended rule released it */ },
+    destroy() {
+      destroyed = true;
+      cancelAll();
+      for (const n of [halo, flood, gate, word]) { try { if (n && n.parentNode) n.parentNode.removeChild(n); } catch (e) { /* noop */ } }
+      halo = flood = gate = word = null;
+      for (const img of [nodes.bgA, nodes.bgB]) setCls(img, 'g-ic-cs-kb', false);
+      if (nodes.score) { setCls(nodes.score, 'g-ic-cs-punch', false); setCls(nodes.score, 'g-ic-cs-bloom', false); }
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, heat: +heat.toFixed(3), hue: ID.hue, offArc: ID.offArc, bulbs: ID.bulbs,
+        tonightHue: mqHue, gold: goldOn, royal: royalOn, ended: endedOn, bestStreak: bestStreakSeen,
+        counts: Object.assign({}, counts), jackpots: jackLog.slice(),
+        liveTimers: live.size, nodes: [halo, flood, gate, word].filter(Boolean).length,
+      };
+    },
+  };
+  return api;
+}
+
+export default createIcCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
@@ -14,10 +14,30 @@
  * The slide ramps 2000ms -> 500ms across the class (schedule.js); the grade
  * tier tightens the reveal window and the denied share instead of the slide.
  *
+ * THE HOUSE RULES WAVE. The class opens on a DRAWN rules sheet (render.js
+ * showHowto - Deck VI, images over text), and three decks ride the room:
+ *   casino.js     the lighting rig: the marquee ring, the sound ladder pitched
+ *                 by the chain, near-miss staging, the jackpot ladder, the
+ *                 royal at the end card
+ *   pressure.js   THE SURGE: the CCP effects ladder, rung = YOUR pop streak,
+ *                 stepped down behind hysteresis when the chain breaks
+ *   trickster.js  the lies: the mouth's tell, the crooked hold ring, the ghost
+ *                 cursor, the stat flicker
+ * This file owns none of that look; it owns the WIRING. It builds all three
+ * after render.mount(), hands each a null-safe engine + a pause-aware timer
+ * registry, and routes one read-only event per moment at the SAME call sites
+ * the ledger is updated. A deck that refuses to build is null and a log line;
+ * it is never a failed class. THE HOUSE LIES TO YOUR EYES, NEVER TO YOUR
+ * LEDGER: no deck writes score, streak, tally or grade, and the bubble stays
+ * the ONE tap target at the exact size and place index.js put it.
+ *
  * FILES
  *   schedule.js  the seeded bubble plan (pure): kinds, flavors, ramp, windows
  *   scoring.js   points + composite + the dual S-gate + baseline fold (pure)
- *   render.js    every pixel: backdrop, basin, HUD, cards; picks the tube tier
+ *   render.js    every pixel: backdrop, basin, lit HUD, rules sheet, ticket
+ *   casino.js    DECK II - the lighting rig + the sound ladder (FX)
+ *   pressure.js  DECK III - the streak-driven effects ladder + the tremor
+ *   trickster.js DECK III - the dark patterns, presentation only
  *   tube3d.js    the three.js chute (vendored r185, dynamic import)
  *   tube2d.js    the canvas chute -> static css chute (no-WebGL fallbacks)
  *   style.js     the self-injected stylesheet
@@ -25,16 +45,19 @@
  *
  * THE LAWS THIS FILE KEEPS
  *   - input trust: the bubble is the ONE tap target; every engine burst this
- *     class fires passes clickSafe:true and is decoration only.
+ *     class or a deck fires passes clickSafe:true and is decoration only.
  *   - RT integrity: the reveal paint is a class toggle + src swap, and the
- *     clock starts on that same call - nothing asynchronous sits between.
+ *     clock starts on that same call - nothing asynchronous sits between it
+ *     and `revealAt` (the deck event is routed AFTER the stamp is taken).
  *   - baseline-relative scoring on the per-game meta store (SYNTHESIS #15).
  *   - the class NEVER grades itself: it reports {metrics:{composite}, hardGates}
  *     and core/grades.js does the rest.
  *   - the debrief renders BEFORE endClass, because endClass tears this DOM down.
- *   - suspend(on) freezes EVERYTHING - timers, tube loop, CSS - and the bubble
- *     in flight is dealt again from the mouth on resume (never scored across
- *     a freeze).
+ *   - suspend(on) freezes EVERYTHING - decks first, then timers, tube loop and
+ *     CSS - and the bubble in flight is dealt again from the mouth on resume
+ *     (never scored across a freeze).
+ *   - the rules sheet obeys the shell's tutorial contract: shown every class by
+ *     default, and still ONCE PER NEW TIER when "Skip class tutorials" is on.
  *
  * CLOCK. `now()` and the timer helpers resolve `performance` / `setTimeout` off
  * the global at CALL time, so the scratch harness swaps in a fake clock and
@@ -51,6 +74,9 @@ import {
 } from './scoring.js';
 import { createRender } from './render.js';
 import { IC_LEX } from './lex.js';
+import { createIcCasino } from './casino.js';
+import { createIcPressure } from './pressure.js';
+import { createIcTrickster } from './trickster.js';
 
 /* ----------------------------------------------------------------- clock -- */
 function now() {
@@ -61,17 +87,57 @@ function now() {
   } catch (e) { /* fall through */ }
   return Date.now();
 }
+/**
+ * The class's timer registry. `after` is a one-shot, `every` a self-re-arming
+ * chain (NOT setInterval: the chain resolves setTimeout off the global at call
+ * time, so the fake clock drives it too, and one cancel kills the whole run).
+ * A repeat handle is a STRING, a one-shot an integer - `cancel` takes either.
+ */
 function createTimers() {
   const live = new Set();
+  const repeats = new Map();
+  let nextRepeat = 1;
   return {
     after(ms, fn) {
       const id = setTimeout(() => { live.delete(id); try { fn(); } catch (e) { /* noop */ } }, Math.max(0, Math.round(ms) || 0));
       live.add(id);
       return id;
     },
-    cancel(id) { if (id != null) { try { clearTimeout(id); } catch (e) { /* noop */ } live.delete(id); } },
-    killAll() { for (const id of Array.from(live)) { try { clearTimeout(id); } catch (e) { /* noop */ } } live.clear(); },
-    get size() { return live.size; },
+    every(ms, fn) {
+      const key = 'ic-every-' + (nextRepeat++);
+      const period = Math.max(16, Math.round(ms) || 16);
+      const rec = { timer: 0, dead: false };
+      repeats.set(key, rec);
+      const arm = () => {
+        rec.timer = setTimeout(() => {
+          if (rec.dead) return;
+          try { fn(); } catch (e) { /* noop */ }
+          if (!rec.dead) arm();
+        }, period);
+      };
+      arm();
+      return key;
+    },
+    cancel(id) {
+      if (id == null) return;
+      if (typeof id === 'string') {
+        const rec = repeats.get(id);
+        if (rec) { rec.dead = true; try { clearTimeout(rec.timer); } catch (e) { /* noop */ } repeats.delete(id); }
+        return;
+      }
+      try { clearTimeout(id); } catch (e) { /* noop */ }
+      live.delete(id);
+    },
+    killAll() {
+      for (const id of Array.from(live)) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+      live.clear();
+      for (const [k, rec] of Array.from(repeats)) {
+        rec.dead = true;
+        try { clearTimeout(rec.timer); } catch (e) { /* noop */ }
+        repeats.delete(k);
+      }
+    },
+    get size() { return live.size + repeats.size; },
   };
 }
 function probe(query) {
@@ -83,6 +149,11 @@ function probe(query) {
   } catch (e) { /* noop */ }
   return false;
 }
+function clamp01(v) {
+  const x = Number(v);
+  if (!isFinite(x)) return 0;
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
 
 const GAME_KEY = 'impulse_control';
 const PRESS_DEDUPE_MS = 120;      // one press = one response (pointerdown + click)
@@ -90,6 +161,19 @@ const INTRO_MS = 2200;
 const TRAVEL_TICK_MS = 40;        // glow position refresh during the slide
 const AUTO_SUBMIT_MS = 45000;     // the debrief files itself if nobody clicks
 const RESUME_DELAY_MS = 600;
+
+/* THE ONE DIAL. Heat rides the class progress AND the player's live chain -
+ * the owner's spec for this room: "the room heats up with YOUR chain". A chain
+ * of STREAK_HEAT_CAP is the whole streak half of the dial. */
+const STREAK_HEAT_CAP = 12;
+/* A cue's level may never exceed the tier's ceiling. The decks ask; the ceiling
+ * answers. (shell/audio.js multiplies by the player's own levels after this.) */
+const AUDIO_CEIL = Object.freeze([0.45, 0.6, 0.75, 0.9]);
+/* The kinds that paint OVER the basin: every one is welded clickSafe, because
+ * the bubble is the single tap target and no decoration may steal its press. */
+const CLICK_SAFE_KINDS = Object.freeze({
+  flash_burst: 1, gif_burst: 1, bubble_field: 1, gif_rain: 1,
+});
 
 /** Declarative asset needs: the backdrop pool. */
 const ASSET_SPEC = Object.freeze({ loops: 12, stills: 6, targets: 0, canvasSafe: false });
@@ -106,9 +190,14 @@ export default {
   title: 'Impulse Control',
 
   manifest: {
-    /* flash pops fire flash_burst, subliminal pops fire sub_flash; the spiral
-       flourish is drawn in-game (the engine has no spiral one-shot). */
-    effectsConsumed: ['flash_burst', 'sub_flash'],
+    /* flash pops fire flash_burst, subliminal pops fire sub_flash, the spiral
+       flourish is drawn in-game; the rest of the list is the decks' ladder
+       (casino cues through audio_trigger, pressure climbs wash -> crt ->
+       gif_burst -> glitch_swap -> gif_rain -> ambient_field). */
+    effectsConsumed: [
+      'flash_burst', 'sub_flash', 'gif_burst', 'glitch_swap', 'audio_trigger',
+      'wash', 'crt', 'gif_rain', 'ambient_field',
+    ],
     assetNeeds: ASSET_SPEC,
     boardSizes: null,
     keybinds: [{ verb: 'go', label_key: 'ic_go_key', default: 'Space' }],
@@ -129,11 +218,17 @@ export default {
       catch (e) { return f == null ? (IC_LEX[k] || k) : f; }
     };
     const timers = createTimers();
-    const reduced = probe('(prefers-reduced-motion: reduce)');
+    const reduced = probe('(prefers-reduced-motion: reduce)')
+      || !!(ctx.motion && ctx.motion.reducedMotion);
+    const dev = ctx.dev === true;
 
     let S = null;
     let ended = false;
+    let devSkipHowto = false;         // the rig's bypass (ctx.dev gates it)
     let destroyed = false;
+    let casino = null;
+    let pressure = null;
+    let trickster = null;
 
     const settingOf = (key, dflt) => {
       try {
@@ -141,17 +236,125 @@ export default {
         return Object.prototype.hasOwnProperty.call(bag, key) ? bag[key] : dflt;
       } catch (e) { return dflt; }
     };
-    const fire = (kind, opts) => {
-      try {
-        const e = ctx.engine;
-        if (e && typeof e.fire === 'function') return e.fire(kind, opts);
-      } catch (err) { say('fire ' + kind + ': ' + (err && err.message)); }
-      return null;
-    };
     const setHeat = (h) => {
       try { if (ctx.engine && typeof ctx.engine.setHeat === 'function') ctx.engine.setHeat(h); }
       catch (e) { /* noop */ }
     };
+
+    /* ==================================================================== *
+     * THE DECKS' SEAMS - a frozen class runs no deck, and a deck may never
+     * raise a ceiling it did not set.
+     * ==================================================================== */
+    /** True while nothing decorative may move: dead, gone, paused or frozen. */
+    const halted = () => destroyed || !S || S.paused || S.suspended;
+    /** bgIntensity 0 is the player's own exit: read it LIVE, never a snapshot. */
+    const capsOk = () => !(ctx.caps && Number(ctx.caps.bgIntensity) === 0);
+    const motionLevel = () => {
+      try {
+        const v = Number(ctx.motion && ctx.motion.motionLevel);
+        return isFinite(v) ? v : 2;
+      } catch (e) { return 2; }
+    };
+    const audioCeil = () => AUDIO_CEIL[Math.max(0, Math.min(3, (S ? S.gradeTier : 1) - 1))];
+
+    /** INPUT TRUST welded on: a burst over the basin can never take a press. */
+    function weld(kind, opts) {
+      const o = Object.assign({}, opts || {});
+      if (CLICK_SAFE_KINDS[kind]) {
+        o.clickSafe = true;
+        o.clickable = false;
+        delete o.onPop;
+      }
+      return o;
+    }
+    /**
+     * The engine as a deck sees it. Every member is null-safe (no engine, or a
+     * frozen class, answers null) and every one READS a clamped channel rather
+     * than raising it.
+     *
+     * STOP IS GLOBAL. `stop('wash')` kills EVERY wash this class holds, not
+     * just the caller's - the engine addresses sustains by KIND. Two decks both
+     * holding a wash must therefore step theirs DOWN by re-triggering at a low
+     * alpha; a deck that calls stop() takes the other deck's wash with it.
+     * (The Deep End paid for this lesson; the note travels with the seam.)
+     */
+    const deckEngine = {
+      fire(kind, opts) {
+        if (halted() || !ctx.engine || typeof ctx.engine.fire !== 'function') return null;
+        try { return ctx.engine.fire(kind, weld(kind, opts)) || null; }
+        catch (e) { say('deck fire(' + kind + ') failed'); return null; }
+      },
+      sustain(kind, opts) {
+        if (halted() || !ctx.engine || typeof ctx.engine.sustain !== 'function') return null;
+        try { return ctx.engine.sustain(kind, weld(kind, opts)) || null; }
+        catch (e) { say('deck sustain(' + kind + ') failed'); return null; }
+      },
+      stop(kind) {
+        try { if (ctx.engine && typeof ctx.engine.stop === 'function') ctx.engine.stop(kind); }
+        catch (e) { /* noop */ }
+      },
+      ceremony(kind, opts) {
+        if (halted() || !ctx.engine || typeof ctx.engine.ceremony !== 'function') return null;
+        try { return ctx.engine.ceremony(kind, opts || {}) || null; }
+        catch (e) { return null; }
+      },
+      channels() {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+      rewardRoll(opts) {
+        try { return (ctx.engine && typeof ctx.engine.rewardRoll === 'function') ? ctx.engine.rewardRoll(opts || {}) : null; }
+        catch (e) { return null; }
+      },
+      /** A cue through the ONE audio owner. `pitch` rides `extra` untouched -
+       *  shell/audio.js multiplies every frequency in the recipe by it, so the
+       *  casino's chime ratchets UP the chain instead of speeding up. */
+      audio(name, level, extra) {
+        const lv = Math.min(audioCeil(), level == null ? 0.4 : Number(level) || 0);
+        return deckEngine.fire('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+      },
+    };
+
+    /** The decks' registry: this class's own timers, dead while frozen. */
+    const deckTimers = {
+      after(ms, fn) { return timers.after(ms, () => { if (halted()) return; fn(); }); },
+      every(ms, fn) { return timers.every(ms, () => { if (halted()) return; fn(); }); },
+      clear(id) { timers.cancel(id); },
+    };
+
+    /** Call one deck, null-safe. A deck that throws is logged, never fatal. */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); }
+      catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+    /** Every deck sees every moment. Args are plain objects and READ-ONLY. */
+    function decks(method, ...args) {
+      deck('casino', method, ...args);
+      deck('pressure', method, ...args);
+      deck('trickster', method, ...args);
+    }
+
+    /* ---- HEAT: the one dial, and the owner's chain drives it ------------- */
+    function progressNow() {
+      if (!S) return 0;
+      const b = S.bubble;
+      if (b && isFinite(b.progress)) return clamp01(b.progress);
+      const total = S.plan ? S.plan.counts.total : 0;
+      if (total <= 1) return 0;
+      return clamp01(Math.max(0, S.idx) / (total - 1));
+    }
+    function heat() {
+      if (!S) return 0;
+      const h = clamp01(0.2 + 0.35 * progressNow() + 0.45 * Math.min(1, S.streak / STREAK_HEAT_CAP));
+      S.heat = h;
+      setHeat(h);
+      deck('casino', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+      deck('trickster', 'setHeat', h);
+      return h;
+    }
 
     /* ============================================================= START */
     function start(classSpec) {
@@ -188,6 +391,7 @@ export default {
         lastPressAt: -1e9,
         paused: false, suspended: false, running: false,
         score: 0, streak: 0, bestStreak: 0, sessionBestRt: null,
+        heat: 0.2,
         tally: {
           goodShown: 0, popped: 0, drifted: 0,
           deniedShown: 0, deniedHeld: 0, xClicked: 0,
@@ -195,22 +399,26 @@ export default {
         },
         swaps: 0,
         voided: false,           // a freeze voided the bubble at the cursor
+        howtoShown: false,
         debriefed: false,
         recalibrated: false,
         result: null,
       };
 
+      /* DEV SEAM (rig only). ctx.dev is never true in the shell, so production
+         behaviour is byte-identical: the rig starts a class already on rung N
+         so a shot can show the ladder without playing it. */
+      if (dev) {
+        const ds = Math.max(0, Math.min(30, Math.round(Number(spec.devStreak) || 0)));
+        if (ds > 0) { S.streak = ds; S.bestStreak = ds; }
+      }
+
       render.mount();
+      buildDecks(seed, gradeTier);
+
       const capBg = (() => { try { return Number(ctx.caps && ctx.caps.bgIntensity); } catch (e) { return 1; } })();
       render.setBgFade(Number(settingOf('ic_bg_fade', 0.35)) * (isFinite(capBg) && capBg >= 0 ? capBg : 1));
-      render.hud({ score: 0, n: 0, total: plan.counts.total, streak: 0, subject: '#' + S.subject });
-      render.intro({
-        title: t('ic_tube_title', 'The Drop Tube'),
-        note: t('ic_tube_rules', IC_LEX.ic_tube_rules),
-        hint: goHintLine(),
-      });
-
-      bindInputs();
+      hud({ n: 0, subject: '#' + S.subject });
 
       /* the backdrop pool: never blocks, never gates a reveal */
       try {
@@ -225,12 +433,132 @@ export default {
       } catch (e) { say('asset claim failed (' + ((e && e.message) || e) + ') - gradient backdrop only'); }
 
       S.running = true;
-      setHeat(0.2);
-      S.phaseTimer = timers.after(INTRO_MS, () => { render.clearCard(); nextBubble(); });
+      heat();
+
+      /* THE CLASS RULES SHEET first (Deck VI): drawn, not told. Then the short
+         incoming beat, then the tube opens. Inputs are bound after GO - the
+         sheet's button is the only way past it, so nothing the player presses
+         at the rules can eat a bubble that has not been dealt yet. */
+      howto(() => {
+        if (!S || destroyed || S.debriefed) return;
+        render.intro({
+          title: t('ic_tube_title', 'The Drop Tube'),
+          note: '',
+          hint: goHintLine(),
+        });
+        bindInputs();
+        S.phaseTimer = timers.after(INTRO_MS, () => {
+          if (!S || destroyed) return;
+          render.clearCard();
+          decks('start');
+          nextBubble();
+        });
+      });
 
       say('class started: tier ' + gradeTier + ', ' + plan.counts.total + ' bubbles ('
         + plan.counts.good + ' good / ' + plan.counts.denied + ' denied), slide '
-        + SLIDE_START_MS + '->' + SLIDE_END_MS + 'ms');
+        + SLIDE_START_MS + '->' + SLIDE_END_MS + 'ms, decks '
+        + (casino ? 'casino ' : '') + (pressure ? 'pressure ' : '') + (trickster ? 'trickster' : ''));
+    }
+
+    /* ------------------------------------------------------------- decks */
+    /** The UTC day the class was seeded on (the shell's seed opens with it) -
+     *  the casino's "tonight only" bulb temperature is a pure function of it. */
+    function utcDateOf(seed) {
+      const m = /^(\d{4}-\d{2}-\d{2})/.exec(String(seed || ''));
+      if (m) return m[1];
+      try { return new Date().toISOString().slice(0, 10); } catch (e) { return '1970-01-01'; }
+    }
+    /** Build all three right after mount. A refused deck is null + a log line. */
+    function buildDecks(seed, gradeTier) {
+      const nodes = S.render.nodes || {};
+      const base = {
+        seed,
+        gradeTier,
+        reduced,
+        motionLevel: motionLevel(),
+        nodes,
+        engine: deckEngine,
+        timers: deckTimers,
+        capsOk,
+        log: say,
+      };
+      try {
+        casino = createIcCasino(Object.assign({}, base, {
+          utcDate: utcDateOf(seed),
+          t,
+        })) || null;
+      } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+      try {
+        pressure = createIcPressure(Object.assign({}, base, {
+          assets: ctx.assets || null,
+        })) || null;
+      } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+      try {
+        trickster = createIcTrickster(Object.assign({}, base, {
+          isHalted: halted,
+          /* the HOST's answer outranks a media probe (CLAUDE.md §5): a coarse
+             pointer gets no ghost cursor at all. */
+          coarse: !!(ctx.platform && ctx.platform.isTouch),
+          stats: () => ({
+            idx: S ? S.idx : -1,
+            total: S && S.plan ? S.plan.counts.total : 0,
+            streak: S ? S.streak : 0,
+            score: S ? S.score : 0,
+            phase: S ? S.stagePhase : 'debrief',
+          }),
+          t,
+        })) || null;
+      } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+    }
+
+    /* -------------------------------------------------------- rules sheet */
+    /** Tiers this player has already had the rules sheet for (persisted). */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    /**
+     * The sheet, ahead of the incoming beat. Policy is the shell's "Skip class
+     * tutorials" contract: default shows every class; with the skip on, a class
+     * still explains itself ONCE per grade tier. Dismissal is the sheet's own
+     * button only - binding the POP key here would teach the player to press
+     * it at a bubble that has not been dealt.
+     */
+    function howto(onDone) {
+      const seen = howtoSeenTiers();
+      const skip = (dev && devSkipHowto)
+        || (ctx.hideTutorial === true && seen.indexOf(S.gradeTier) >= 0);
+      if (skip) { onDone(); return; }
+      if (!S.render || typeof S.render.showHowto !== 'function') { onDone(); return; }
+      let done = false;
+      let node = null;
+      try {
+        node = S.render.showHowto({
+          onGo: () => {
+            if (done || !S || destroyed) return;
+            done = true;
+            try {
+              const list = howtoSeenTiers();
+              if (list.indexOf(S.gradeTier) < 0) {
+                list.push(S.gradeTier);
+                if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+                  ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+                }
+              }
+            } catch (e) { /* best effort - the sheet just shows again next time */ }
+            try { S.render.hideHowto(); } catch (e) { /* noop */ }
+            onDone();
+          },
+          keyLabel: (() => { try { return ctx.keys.labelFor('go') || 'Space'; } catch (e) { return 'Space'; } })(),
+          coarse: !!(ctx.platform && ctx.platform.isTouch),
+        });
+      } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); node = null; }
+      if (!node) { done = true; onDone(); return; }
+      S.howtoShown = true;
     }
 
     function goHintLine() {
@@ -252,6 +580,25 @@ export default {
       } catch (e) { /* keep the old one */ }
     }
 
+    /** The HUD, and the SHELL's 10-segment meter in its anchor (never forked). */
+    function hud(extra) {
+      if (!S) return;
+      const h = Object.assign({
+        score: S.score,
+        n: Math.max(0, S.idx + 1),
+        total: S.plan.counts.total,
+        streak: S.streak,
+      }, extra || {});
+      try { S.render.hud(h); } catch (e) { /* cosmetic */ }
+      try {
+        const cer = ctx.ceremonies;
+        const slot = S.render.nodes && S.render.nodes.meterSlot;
+        if (cer && typeof cer.streakMeter === 'function' && slot) {
+          cer.streakMeter({ target: slot, filled: S.streak });
+        }
+      } catch (e) { /* a ceremony must never be the thing that fails */ }
+    }
+
     /* ====================================================== INPUT SURFACE */
     let unbind = [];
     function bindInputs() {
@@ -262,6 +609,14 @@ export default {
           bub.addEventListener(evt, onPress);
           unbind.push(() => { try { bub.removeEventListener(evt, onPress); } catch (e) { /* noop */ } });
         }
+        /* HOVER is a decoration-only signal (the casino's "almost" over the X,
+           the trickster's ghost cursor). It changes no input and no ledger. */
+        const onEnter = () => decks('hover', true);
+        const onLeave = () => decks('hover', false);
+        bub.addEventListener('pointerenter', onEnter);
+        bub.addEventListener('pointerleave', onLeave);
+        unbind.push(() => { try { bub.removeEventListener('pointerenter', onEnter); } catch (e) { /* noop */ } });
+        unbind.push(() => { try { bub.removeEventListener('pointerleave', onLeave); } catch (e) { /* noop */ } });
       }
       try {
         const off = ctx.keys.on('go', () => press('key'));
@@ -286,9 +641,19 @@ export default {
       const b = S.plan.bubbles[S.idx];
       S.bubble = b;
       S.stagePhase = 'load';
-      S.render.hud({ score: S.score, n: S.idx + 1, total: S.plan.counts.total, streak: S.streak });
+      hud();
       S.render.showLoad();
-      setHeat(0.2 + 0.5 * b.progress);
+      heat();
+      /* the decks learn the KIND at the mouth - the trickster's tell needs it
+         this early. The casino and the pressure deck must render no tell. */
+      decks('load', {
+        idx: S.idx,
+        total: S.plan.counts.total,
+        progress: b.progress,
+        kind: b.kind,
+        flavor: b.flavor,
+        slideMs: b.slideMs,
+      });
       S.phaseTimer = timers.after(LOAD_MS, () => beginSlide(b));
     }
 
@@ -298,6 +663,7 @@ export default {
       S.slideStart = now();
       S.slideMs = b.slideMs;
       S.render.setTravel(0);
+      decks('slide', { idx: S.idx, slideMs: b.slideMs });
       const tick = () => {
         if (!S || S.stagePhase !== 'slide' || S.paused || S.suspended) return;
         const p = (now() - S.slideStart) / S.slideMs;
@@ -314,12 +680,23 @@ export default {
       if (b.kind === 'denied') S.tally.deniedShown++; else S.tally.goodShown++;
       S.render.revealBubble(b);
       S.revealAt = now();                       // the clock starts ON the paint call
+      /* RT INTEGRITY: the deck event is routed only AFTER the stamp is taken,
+         so no deck can ever sit between the paint and the clock. */
       S.windowTimer = timers.after(b.windowMs, () => windowEnd(b));
+      decks('reveal', {
+        idx: S.idx,
+        kind: b.kind,
+        flavor: b.flavor,
+        windowMs: b.windowMs,
+        progress: b.progress,
+        streak: S.streak,
+      });
     }
 
     function windowEnd(b) {
       if (!S || S.stagePhase !== 'reveal') return;
       S.stagePhase = 'gap';
+      const streakBefore = S.streak;
       if (b.kind === 'denied') {
         /* the X survived - restraint pays, and the backdrop turns over */
         S.score += DENIED_BONUS;
@@ -335,7 +712,10 @@ export default {
         S.render.stamp('', t('ic_missed', 'It drifted away'));
       }
       S.tally.score = S.score;
-      S.render.hud({ score: S.score, n: S.idx + 1, total: S.plan.counts.total, streak: S.streak });
+      hud();
+      heat();
+      if (b.kind === 'denied') decks('denyPass', { idx: S.idx, streak: S.streak, score: S.score });
+      else decks('drift', { idx: S.idx, streakBefore });
       S.phaseTimer = timers.after(b.gapMs, nextBubble);
     }
 
@@ -351,12 +731,18 @@ export default {
 
       if (b.kind === 'denied') {
         /* THE X. The one error in the game. */
+        const rt = Math.max(0, at - S.revealAt);
+        const streakBefore = S.streak;
         S.score -= X_PENALTY;
         S.tally.xClicked++;
         S.streak = 0;
         S.render.hitDenied();
         S.render.stamp('bad', t('ic_denied_hit', 'THAT WAS THE X'));
-        say('X clicked (' + source + ') at +' + Math.round(at - S.revealAt) + 'ms: -' + X_PENALTY);
+        S.tally.score = S.score;
+        hud();
+        heat();
+        decks('denyHit', { idx: S.idx, rt, penalty: X_PENALTY, streakBefore, score: S.score });
+        say('X clicked (' + source + ') at +' + Math.round(rt) + 'ms: -' + X_PENALTY);
       } else {
         const rt = Math.max(0, at - S.revealAt);
         const pts = popPoints(rt, b.windowMs);
@@ -380,18 +766,42 @@ export default {
         );
         beat(b.flavor);
         swapBackdrop();
-        S.render.hud({ score: S.score, n: S.idx + 1, total: S.plan.counts.total, streak: S.streak, rt });
+        S.tally.score = S.score;
+        hud({ rt });
+        heat();
+        /* the ledger has already moved: every number below is the TRUTH the
+           decks may light, and none of them may write it back. */
+        decks('pop', {
+          idx: S.idx,
+          rt,
+          pts,
+          streak: S.streak,
+          bestStreak: S.bestStreak,
+          stampKind: kind,
+          newRecord,
+          sessionBest: S.sessionBestRt,
+          recordRt: record,
+          windowMs: b.windowMs,
+          flavor: b.flavor,
+          score: S.score,
+        });
       }
-      S.tally.score = S.score;
       S.phaseTimer = timers.after(b.gapMs, nextBubble);
     }
 
     /** The pop's effect beat - one of exactly three, all decoration. */
     function beat(flavor) {
       if (flavor === 'flash') {
-        fire('flash_burst', { clickSafe: true, strength: 0.6 });
+        /* sized against the viewport (the engine's default 120-270px box is a
+           postage stamp on a chute this bright) and announced to the pressure
+           deck, which dims the tube under it for its hold (THE FLARE) */
+        let vmin = 720;
+        try { vmin = Math.min(window.innerWidth || 0, window.innerHeight || 0) || 720; } catch (e) { /* headless */ }
+        const holdMs = 900;
+        const went = deckEngine.fire('flash_burst', { clickSafe: true, strength: 0.6, sizePx: Math.round(vmin * 0.34), holdMs });
+        if (went) deck('pressure', 'beat', { flavor, holdMs });
       } else if (flavor === 'sub') {
-        fire('sub_flash', { clickSafe: true, strength: 0.6 });
+        deckEngine.fire('sub_flash', { clickSafe: true, strength: 0.6 });
       } else if (flavor === 'spiral') {
         S.render.flourish();
       }
@@ -404,6 +814,9 @@ export default {
       S.running = false;
       S.stagePhase = 'debrief';
       S.render.setTravel(null);
+      /* the ENGINE cools here, as it always has. The decks keep the heat they
+         earned until their own end()/destroy() sighs it out - zeroing them
+         first would take the casino's royal down with it. */
       setHeat(0);
 
       const sessionMedian = median(S.tally.rts);
@@ -413,6 +826,8 @@ export default {
 
       const record = Number(S.meta.bestRtMs) || 0;
       const newBest = led.bestRt != null && (record === 0 || led.bestRt < record);
+      /* a PERFECT class: the X row untouched and not one bubble left to drift */
+      const perfect = S.tally.xClicked === 0 && S.tally.drifted === 0;
 
       const line = (() => {
         if (fold && fold.established) return t('ic_baseline_new', IC_LEX.ic_baseline_new);
@@ -423,6 +838,26 @@ export default {
         if (slowSlip) return t('ic_slip_speed', IC_LEX.ic_slip_speed);
         return t('ic_slip_none', IC_LEX.ic_slip_none);
       })();
+
+      /* the casino decides the ROYAL and says so on the way out; the other two
+         get the same object and answer nothing. */
+      const endInfo = {
+        score: led.score,
+        popped: S.tally.popped,
+        goodShown: S.tally.goodShown,
+        drifted: S.tally.drifted,
+        deniedHeld: S.tally.deniedHeld,
+        xClicked: S.tally.xClicked,
+        medianRt: led.medianRt,
+        bestRt: led.bestRt,
+        newBest,
+        perfect,
+        sGateOk: !!led.sGate.ok,
+      };
+      const casinoEnd = deck('casino', 'end', endInfo);
+      deck('pressure', 'end', endInfo);
+      deck('trickster', 'end', endInfo);
+      const royal = !!(casinoEnd && casinoEnd.royal);
 
       S.render.debrief({
         subject: S.subject,
@@ -435,16 +870,39 @@ export default {
         goodShown: S.tally.goodShown,
         deniedHeld: S.tally.deniedHeld,
         xClicked: S.tally.xClicked,
+        perfect,
+        royal,
         line,
         hint: led.sGate.ok ? '' : t('ic_gate_hint', IC_LEX.ic_gate_hint),
       }, submit, recalibrate);
+
+      /* THE GRADE ARRIVES AS AN OBJECT (Deck VI): the shell's stamp, dropped
+         into the ticket's own stamp area. Null-safe - under the DOM double
+         ceremonies may not exist at all. */
+      try {
+        const cer = ctx.ceremonies;
+        const slot = S.render.nodes && S.render.nodes.ticketStamp;
+        if (cer && typeof cer.stamp === 'function' && slot) {
+          cer.stamp({
+            target: slot,
+            text: royal ? t('ic_royal', 'ROYAL')
+              : perfect ? t('ic_perfect_class', 'Perfect class')
+                : newBest ? t('ic_new_best', 'NEW BEST')
+                  : t('ic_debrief', 'Debrief'),
+            tone: (royal || perfect) ? 'gild' : 'good',
+            /* the shell's stamp self-removes after its hold: a grade that is
+               an OBJECT on the ticket has to outlive the ticket, not the hold */
+            hold: 600000,
+          });
+        }
+      } catch (e) { /* a ceremony must never be the thing that fails */ }
 
       say('debrief: score ' + led.score
         + ', median ' + (led.medianRt == null ? 'n/a' : Math.round(led.medianRt) + 'ms')
         + ', popped ' + S.tally.popped + '/' + S.tally.goodShown
         + ', X ' + S.tally.xClicked + '/' + S.tally.deniedShown
         + ', composite ' + led.composite.toFixed(3) + ', sGate ' + led.sGate.ok
-        + ', swaps ' + S.swaps);
+        + ', swaps ' + S.swaps + (perfect ? ', PERFECT' : '') + (royal ? ', ROYAL' : ''));
 
       S.autoTimer = timers.after(AUTO_SUBMIT_MS, submit);
     }
@@ -534,16 +992,22 @@ export default {
     /* =========================================================== LIFECYCLE */
     return {
       start(classSpec) {
-        try { start(classSpec); }
-        catch (e) {
+        try {
+          devSkipHowto = dev && !!(classSpec && classSpec.devSkipHowto);
+          start(classSpec);
+        } catch (e) {
           say('start failed: ' + ((e && e.message) || e));
           try { ctx.root.textContent = 'This class could not start.'; } catch (err) { /* noop */ }
         }
       },
 
+      /* THE EXITS ARE SACRED. The decks stop FIRST - a deck must never paint
+         one more frame over a class the player just froze - then the loop, then
+         the stage. Coming back is the same order reversed. */
       pause() {
         if (!S || S.paused) return;
         S.paused = true;
+        decks('pause');
         freeze();
         S.render.suspend(true);
       },
@@ -552,6 +1016,7 @@ export default {
         if (!S || !S.paused) return;
         S.paused = false;
         S.render.suspend(false);
+        if (!S.suspended) decks('resume');
         thaw();
       },
 
@@ -561,16 +1026,21 @@ export default {
         if (want === S.suspended) return;
         S.suspended = want;
         if (want) {
+          decks('pause');
           freeze();
           S.render.suspend(true);
         } else {
           S.render.suspend(false);
-          if (!S.paused) thaw();
+          /* a class the player ALSO paused stays frozen: the pause outranks
+             the host's thaw, and resume() is what wakes the decks then. */
+          if (!S.paused) { decks('resume'); thaw(); }
         }
       },
 
       destroy() {
         destroyed = true;
+        decks('destroy');
+        casino = null; pressure = null; trickster = null;
         timers.killAll();
         unbindInputs();
         if (S) {
@@ -580,7 +1050,19 @@ export default {
         S = null;
       },
 
-      /* Diagnostics for the scratch harness and a future debug overlay. */
+      /* Diagnostics for the scratch harness, the rig and a future debug
+         overlay. Never read by the shell. */
+      diagnostics() {
+        const dg = (d) => {
+          if (!d || typeof d.diagnostics !== 'function') return null;
+          try { return d.diagnostics(); } catch (e) { return null; }
+        };
+        return {
+          heat: S ? S.heat : 0,
+          streak: S ? S.streak : 0,
+          decks: { casino: dg(casino), pressure: dg(pressure), trickster: dg(trickster) },
+        };
+      },
       __state() { return S; },
       __submit() { submit(); },
     };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/lex.js
@@ -12,18 +12,39 @@
  * The whole table is exported so the C# NeutralLexicon can mirror it key-for-key
  * (the orchestrator applies the delta reported by the build - this file never
  * touches C#).
+ *
+ * HOUSE RULES WAVE. Two changes, both Deck VI (images over text):
+ *   - `ic_tube_rules` is GONE. The rules are DRAWN now: render.showHowto() draws
+ *     three vignettes and captions them with the ic_howto_* rows below, so the
+ *     150-character paragraph that no mod could ever re-voice (web CLAUDE.md
+ *     trap 26: NeutralLexicon drops a mod string over 96 chars) has no render
+ *     site left. Its C# row stays put; nothing reads it.
+ *   - the casino deck (casino.js) speaks through `t` like everything else, so
+ *     its words live HERE and not in the deck: ic_almost / ic_just / ic_royal /
+ *     ic_jackpot / ic_perfect_class / ic_tonight / ic_streak_n / ic_record_ping.
+ *     The trickster deck renders no text at all and adds no rows.
+ *
+ * EVERY VALUE IS <= 96 CHARACTERS, on purpose (trap 26). Keep it that way: a
+ * longer row is a row a mod can never skin. Split it into two rather than
+ * raising the cap.
  * ==========================================================================*/
 
 export const IC_LEX = Object.freeze({
   /* --- the fiction ------------------------------------------------------- */
   ic_tube_title: 'The Drop Tube',
   ic_subject: 'Subject',
-  ic_tube_rules: 'Pop every bubble the instant it surfaces. NEVER touch the X.',
   // {key} is substituted with the player's bound POP key.
   ic_go_hint: 'Click the bubble or press {key}. An X means hold still.',
   ic_loading: 'Priming the tube - hold still, subject.',
   ic_bubble_n: 'Bubble',
   ic_incoming: 'INCOMING',
+
+  /* --- the class rules sheet (drawn vignettes; these are the captions) ---- */
+  ic_howto_title: 'Class rules',
+  ic_howto_pop: 'A bubble lands in the dish. Pop it at once. The faster you are, the more it pays.',
+  ic_howto_x: 'A bubble wearing an X is a trap. Touch nothing until its ring runs out.',
+  ic_howto_drift: 'A bubble you miss just drifts off the dish. Nothing is taken from you.',
+  ic_howto_go: 'Start the drop',
 
   /* --- per-bubble feedback ---------------------------------------------- */
   ic_pop_perfect: 'PERFECT',
@@ -34,6 +55,17 @@ export const IC_LEX = Object.freeze({
   ic_missed: 'It drifted away',
   ic_new_best: 'NEW BEST',
   ic_streak: 'streak',
+
+  /* --- the casino deck's vocabulary (casino.js renders these through t) ---- */
+  // {n} is substituted with the current pop chain length.
+  ic_streak_n: 'chain {n}',
+  ic_almost: 'ALMOST',
+  ic_just: 'JUST',
+  ic_record_ping: 'record',
+  ic_jackpot: 'JACKPOT',
+  ic_royal: 'ROYAL',
+  ic_perfect_class: 'Perfect class',
+  ic_tonight: 'tonight only',
 
   /* --- HUD --------------------------------------------------------------- */
   ic_score: 'Score',

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/pressure.js
@@ -1,0 +1,619 @@
+/* ============================================================================
+ * games/impulse-control/pressure.js - the Drop Tube's effects ladder: THE SURGE.
+ * The casino (casino.js) lights the room, the trickster (trickster.js) lies
+ * about it; this file is what the room DOES to you as your CHAIN climbs. The
+ * owner's ruling for this class: the ladder is STREAK-DRIVEN. The rung is your
+ * current run of clean pops; an X hit or a drift drops it to zero and the storm
+ * steps DOWN behind a hysteresis (fades, never a snap); a survived X HOLDS the
+ * rung (restraint is not a break). Magnitude rides the class heat (which
+ * index.js already folds streak + progress into). Same seed, same surge.
+ *
+ * THE RUNG TABLE (streak -> rung -> what switches ON; cumulative). Re-cut
+ * 2026-08-22 after the owner's play: the spiral and the big gifs now arrive at
+ * streaks a real class reaches (4-8), not 14+; the whisper-class dressing
+ * (scan, subs, chroma) moved up the ladder where it is seasoning, not the meal.
+ *   0-1   rung 0  clean room (the tube's own seeded show is all there is)
+ *   2     rung 1  BREATH      a pink wash breathes on a cadence        [engine wash:pink]
+ *   4     rung 2  BURST       big gif bursts ride pops (30-46vmin)     [engine gif_burst sizePx]
+ *   6     rung 3  WHEEL       the full-screen spiral wash wakes (the   [engine wash:spiral]
+ *                             shell's real image through the provider) +
+ *                             THE TREMOR wakes (tube + HUD, never the basin)
+ *   8     rung 4  VEIL+GIANT  the backdrop glitch-shudders on pops;    [engine glitch_swap on bgA/bgB,
+ *                             a pop may drop ONE near-fullscreen gif     gif_burst sizePx ~0.92vmin]
+ *   11    rung 5  RAIN+SCAN   gif rain on pops, scanline whisper        [engine gif_rain, crt:scanline]
+ *   14    rung 6  SUBS+CHROMA sub flash stream + the crt turns chroma  [engine sub_flash alias, crt:chroma]
+ *   18    rung 7  FLASHES     flash bursts ride pops                   [engine flash_burst]
+ *   22    rung 8  STORM       embers, downpour, the pink flood,        [engine ambient_field, gif_rain,
+ *                             the tremor at its cap                      wash:pink]
+ *
+ * THE DUSK (render.js nodes.dusk): the ONE game-local surface of this file -
+ * an empty dimmer laid over the tube and under the basin/HUD whose opacity
+ * climbs with the rung (duskFor). The chute out-shone the engine's washes
+ * and gifs (they are screen-blended and heat-gated), which read as "the
+ * effects play behind the tube"; dimming the tube under them is what puts
+ * them in front without touching the engine's ceilings. Opacity only.
+ *
+ * THE TREMOR: the whole machine room vibrates with the chain - a continuous
+ * low tremor whose amplitude grows with the rung, a PUNCH on every pop sized
+ * by its points (extend-not-stack, quadratic ring-down, screenShake posture),
+ * a heavier punch on a milestone. Written on the CSS individual `translate`
+ * of render's `tubewrap` (the chute canvas) and `hud` (at 60%), which nothing
+ * else transforms - and NEVER on the basin or the bubble: that is the one tap
+ * target in the game (Law II), and a reflex test cannot have a moving target.
+ * A rAF loop ONLY while amplitude > 0; stopped by pause()/stop()/destroy(),
+ * re-armed by resume(). Reduced motion / motionLevel 0 -> no tremor at all.
+ *
+ * ENGINE vs GAME-LOCAL (audit): EVERYTHING visual goes through opts.engine
+ * (index.js's null-safe wrapper: clickSafe welded, ceiling rule, capsOk,
+ * effectsConsumed). Game-local: the tremor (two transform writes on render's
+ * own layers) and the dusk's opacity (one style write on render's own node).
+ * This file creates NO nodes. Node budget: 0.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects (streak / pts / progress),
+ *       writes nothing about score, streak, tally or grade, renders no text.
+ *   II  input honest  - no node of ours exists; the basin and the bubble are
+ *       never transformed, never covered; every engine fire is clickSafe.
+ *   III never still   - from rung 1 the room breathes; from rung 3 it shakes.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ic-pressure|<tag>',
+ *       append-only; no Math.random.
+ *   VI  exits sacred  - capsOk false (bgIntensity 0) = zero fires, zero
+ *       tremor; reduced motion = no tremor (the engine gates its own kinds);
+ *       pause() halts the rAF and drops transient timers; destroy() restores
+ *       the translate and stops every sustain with a fade.
+ *   VII lexicon       - this file renders no text.
+ *
+ * THE WASH TRAP (Deep End, pass 4): engine.stop('wash') kills EVERY wash
+ * variant. Two live here (pink + spiral), so a rung is stepped DOWN by
+ * re-triggering its variant at a whisper alpha with a short hold (it fades on
+ * its own deadline) - stop('wash') is called ONLY from stop()/destroy().
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const IC_PRESSURE = Object.freeze({
+  /** streak thresholds per rung (index = rung). Monotone. */
+  RUNG_STREAK: Object.freeze([0, 2, 4, 6, 8, 11, 14, 18, 22]),
+  RUNG_ADDS: Object.freeze([
+    Object.freeze([]),
+    Object.freeze(['breath']),
+    Object.freeze(['burst']),
+    Object.freeze(['wheel', 'tremor']),
+    Object.freeze(['veil', 'giant']),
+    Object.freeze(['rain', 'scan']),
+    Object.freeze(['subs', 'chroma']),
+    Object.freeze(['flashes']),
+    Object.freeze(['storm']),
+  ]),
+  RUNG_CUE: Object.freeze([null, 'wash', 'burst', 'wash', 'glitch', 'burst', 'whisper', 'burst', 'near_miss']),
+  /** the dusk's opacity per rung (x (DUSK_HEAT_FLOOR + (1-floor)*heat)); 0 at rest. */
+  DUSK: Object.freeze([0, 0.14, 0.26, 0.38, 0.46, 0.52, 0.56, 0.6, 0.64]),
+  DUSK_HEAT_FLOOR: 0.75,
+  DUSK_END: 0.3,
+  /** THE FLARE: under a gif burst the dusk snaps UP for the burst's hold so a
+      translucent gif (the engine caps bursts at ~0.75 alpha) reads OPAQUE and
+      IN FRONT - neon lines bleeding through a gif read as "behind the tube"
+      (owner 2026-08-22, twice). Snaps up in FLARE_IN_MS, eases back on the
+      dusk's own transition. */
+  FLARE_BURST: 0.84,
+  FLARE_GIANT: 0.92,
+  FLARE_IN_MS: 160,
+  BURST_HOLD_MS: Object.freeze([750, 1250]),
+  /** Stepping DOWN waits this long and fades; stepping UP is immediate. */
+  HYST_MS: 1600,
+  HEAT_REPAINT_STEP: 0.06,
+
+  /* ---- THE TREMOR ------------------------------------------------------ */
+  TREMOR_PX: Object.freeze([0, 0, 0, 0.4, 0.6, 0.9, 1.3, 1.8, 2.2]),
+  TREMOR_CAP_PX: 2.5,
+  TREMOR_HEAT_FLOOR: 0.5,
+  TREMOR_HZ_FAST: Object.freeze([7, 11]),
+  TREMOR_HZ_SLOW: Object.freeze([1.4, 2.6]),
+  HUD_SHARE: 0.6,
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  /** a pop punch: px / ms from q = pts/100; milestones heavier; hard cap. */
+  PUNCH_PX: Object.freeze([0.8, 3.2]),
+  PUNCH_MS: Object.freeze([160, 360]),
+  PUNCH_MILESTONE_PX: 4.5,
+  PUNCH_MILESTONE_MS: 420,
+  PUNCH_HIT_PX: 5,                 // the X popped: the room jolts (render shakes the stage; we jolt the tube)
+  PUNCH_HIT_MS: 380,
+  PUNCH_CAP_PX: 6,
+  PUNCH_CAP_MS: 450,
+  MILESTONES: Object.freeze([5, 10, 15, 20]),
+
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([8000, 4800]),
+  BREATH_HOLD_MS: 2400,
+  BREATH_ALPHA: Object.freeze([0.1, 0.38]),
+  STORM_BREATH_ALPHA: Object.freeze([0.3, 0.55]),
+  SCAN_LEVEL: Object.freeze([0.18, 0.5]),
+  CHROMA_LEVEL: Object.freeze([0.35, 0.7]),
+  BURST_CHANCE: Object.freeze([0.45, 0.9]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  /** burst box edge as a fraction of vmin (the engine's default 120-270px is a
+      postage stamp against the chute); the engine still jitters it 0.8-1.2x. */
+  BURST_VMIN: Object.freeze([0.3, 0.46]),
+  /** THE GIANT: one near-fullscreen gif dropped on the landing, by chance. */
+  GIANT_CHANCE: Object.freeze([0.3, 0.65]),
+  GIANT_VMIN: 0.92,
+  GIANT_HOLD_MS: Object.freeze([1100, 1700]),
+  VEIL_CHANCE: Object.freeze([0.3, 0.75]),
+  VEIL_S: Object.freeze([0.35, 0.9]),
+  VEIL_VARIANTS: Object.freeze(['rgbsplit', 'vhsroll', 'datamosh']),
+  RAIN_CHANCE: Object.freeze([0.4, 0.9]),
+  RAIN_MS: Object.freeze([2200, 4600]),
+  WHEEL_ALPHA: Object.freeze([0.3, 0.52]),
+  STORM_RAIN_MS: 6000,
+  STORM_EMBERS: Object.freeze([0.3, 0.7]),
+  STORM_FLASH_COUNT: 2,
+  WHISPER_ALPHA: 0.01,
+  WHISPER_HOLD_MS: 900,
+  /** cue level = min(AUDIO_CEIL[tier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.22,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+});
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** streak -> rung (0..8). Pure, monotone, clamps garbage to 0. */
+export function rungFor(streak) {
+  const s = Math.max(0, Math.floor(Number(streak) || 0));
+  const T = IC_PRESSURE.RUNG_STREAK;
+  let r = 0;
+  for (let i = 0; i < T.length; i++) { if (s >= T[i]) r = i; else break; }
+  return r;
+}
+/** the dusk's opacity for a shown rung and heat (0..1). Pure. */
+export function duskFor(rung, heat01) {
+  const P = IC_PRESSURE;
+  const r = Math.max(0, Math.min(P.DUSK.length - 1, Math.floor(Number(rung) || 0)));
+  const base = P.DUSK[r] || 0;
+  if (base <= 0) return 0;
+  return +(base * (P.DUSK_HEAT_FLOOR + (1 - P.DUSK_HEAT_FLOOR) * clamp01(heat01))).toFixed(3);
+}
+/** idle tremor amplitude in px; 0 under reduced motion / motionLevel 0. Pure. */
+export function tremorAmpPx(streak, heat01, reducedMotion, motionLevel) {
+  if (reducedMotion) return 0;
+  const m = IC_PRESSURE.MOTION_MUL[Math.max(0, Math.min(2, motionLevel == null ? 2 : Math.round(Number(motionLevel) || 0)))];
+  if (!m) return 0;
+  const base = IC_PRESSURE.TREMOR_PX[rungFor(streak)] || 0;
+  if (base <= 0) return 0;
+  const f = IC_PRESSURE.TREMOR_HEAT_FLOOR;
+  return Math.min(IC_PRESSURE.TREMOR_CAP_PX, +(base * m * (f + (1 - f) * clamp01(heat01))).toFixed(3));
+}
+/** a pop punch {px, ms} from pts (0..100) and whether it was a milestone. Pure. */
+export function punchFor(o) {
+  const d = o || {};
+  const q = clamp01((Number(d.pts) || 0) / 100);
+  const P = IC_PRESSURE;
+  let px = lerp(P.PUNCH_PX, q);
+  let ms = lerp(P.PUNCH_MS, q);
+  if (d.milestone) { px = Math.max(px, P.PUNCH_MILESTONE_PX); ms = Math.max(ms, P.PUNCH_MILESTONE_MS); }
+  if (d.hit) { px = Math.max(px, P.PUNCH_HIT_PX); ms = Math.max(ms, P.PUNCH_HIT_MS); }
+  return { px: +Math.min(P.PUNCH_CAP_PX, px).toFixed(2), ms: Math.min(P.PUNCH_CAP_MS, Math.round(ms)) };
+}
+
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function rafFn() {
+  try { if (typeof requestAnimationFrame === 'function') return requestAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function cafFn() {
+  try { if (typeof cancelAnimationFrame === 'function') return cancelAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.cancelAnimationFrame === 'function') return globalThis.cancelAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function vmin() {
+  try {
+    if (typeof window !== 'undefined' && window) {
+      const w = Number(window.innerWidth) || 0, h = Number(window.innerHeight) || 0;
+      if (w > 0 && h > 0) return Math.min(w, h);
+    }
+  } catch (e) { /* headless */ }
+  return 720;
+}
+function setOpacity(node, v) {
+  try { if (node && node.style) node.style.opacity = (v == null || v === '') ? '' : String(v); } catch (e) { /* noop */ }
+}
+function setTranslate(node, x, y) {
+  try { if (node && node.style) node.style.translate = (x || y) ? (x.toFixed(2) + 'px ' + y.toFixed(2) + 'px') : ''; } catch (e) { /* noop */ }
+}
+
+/**
+ * @param {Object} o  see IC-HOUSE-RULES §4:
+ *   seed, gradeTier, reduced, motionLevel, nodes (render.nodes), engine
+ *   {fire,sustain,stop,channels,audio}, assets, timers {after,every,clear},
+ *   capsOk () => bool, log
+ */
+export function createIcPressure(o) {
+  const opts = o || {};
+  const P = IC_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const gradeTier = Math.max(1, Math.min(4, Number(opts.gradeTier) || 1));
+  const audioCeil = P.AUDIO_CEIL[gradeTier] || P.AUDIO_CEIL[1];
+  const nodes = opts.nodes || {};
+  const eng = opts.engine || {};
+  const armedBase = !!nodes.stage && !!opts.timers && typeof opts.timers.after === 'function';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers ------------------------------------------------------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams ----------------------------------------------------- */
+  const seedBase = String(opts.seed || 'ic') + '|ic-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+  const tremorPhase = { fx: roll('tremor') * 6.28, fy: roll('tremor') * 6.28, hzF: lerp(P.TREMOR_HZ_FAST, roll('tremor')), hzS: lerp(P.TREMOR_HZ_SLOW, roll('tremor')) };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.fire === 'function' ? eng.fire(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.sustain === 'function' ? eng.sustain(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function stop(kind) {
+    if (!armedBase) return;
+    count('stop:' + kind);
+    try { if (typeof eng.stop === 'function') eng.stop(kind); } catch (e) { /* noop */ }
+  }
+  function cue(name, rung) {
+    if (!armed() || !name) return;
+    const level = Math.min(audioCeil, P.CUE_LEVEL_BASE + rung * P.CUE_LEVEL_STEP);
+    count('cue');
+    try {
+      if (typeof eng.audio === 'function') eng.audio(name, level, { pitch: +(0.9 + rung * 0.04).toFixed(3) });
+      else if (typeof eng.fire === 'function') eng.fire('audio_trigger', { name, level, pitch: +(0.9 + rung * 0.04).toFixed(3) });
+    } catch (e) { /* noop */ }
+  }
+
+  /* ---- state -------------------------------------------------------------- */
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let streak = 0;
+  let rung = 0;              // the SHOWN rung
+  let wantRung = 0;          // what the streak says
+  let downTimer = 0;
+  const on = new Set();      // adds currently live
+  let stopped = false;
+
+  /* ---- the tremor --------------------------------------------------------- */
+  let rafId = 0;
+  let loopOn = false;
+  let amp = 0;               // idle amplitude (px)
+  let punch = { px: 0, until: 0, ms: 1 };
+  let paused = false;
+
+  function loop() {
+    rafId = 0;
+    if (!loopOn || paused || destroyed) return;
+    const tNow = nowMs();
+    let extra = 0;
+    if (punch.px > 0) {
+      const left = punch.until - tNow;
+      if (left <= 0) punch = { px: 0, until: 0, ms: 1 };
+      else { const k = left / punch.ms; extra = punch.px * k * k; }   // quadratic ring-down
+    }
+    const a = amp + extra;
+    if (a <= 0.005) {
+      setTranslate(nodes.tubewrap, 0, 0);
+      setTranslate(nodes.hud, 0, 0);
+      loopOn = false;
+      return;
+    }
+    const ts = tNow / 1000;
+    const x = a * (0.7 * Math.sin(ts * tremorPhase.hzF * 6.28 + tremorPhase.fx) + 0.3 * Math.sin(ts * tremorPhase.hzS * 6.28));
+    const y = a * (0.7 * Math.cos(ts * tremorPhase.hzF * 5.9 + tremorPhase.fy) + 0.3 * Math.sin(ts * tremorPhase.hzS * 5.1 + 1.7));
+    setTranslate(nodes.tubewrap, x, y);
+    setTranslate(nodes.hud, x * P.HUD_SHARE, y * P.HUD_SHARE);
+    const raf = rafFn();
+    if (raf) rafId = raf(loop);
+  }
+  function armLoop() {
+    if (loopOn || paused || destroyed || still) return;
+    if (amp <= 0 && punch.px <= 0) return;
+    loopOn = true;
+    const raf = rafFn();
+    if (raf) rafId = raf(loop); else loop();
+  }
+  function haltLoop() {
+    loopOn = false;
+    const caf = cafFn();
+    if (rafId && caf) { try { caf(rafId); } catch (e) { /* noop */ } }
+    rafId = 0;
+  }
+  let flareUntil = 0;
+  let flareTimer = 0;
+  function paintDusk() {
+    if (!armedBase || destroyed) return;
+    if (flareUntil > nowMs()) return;           // a flare is holding the dusk up
+    setOpacity(nodes.dusk, stopped ? Math.min(P.DUSK_END, duskFor(rung, heat)) : (capsOk() ? duskFor(rung, heat) : 0));
+  }
+  /* snap the dusk up under a burst, then let it ease back to the rung's level */
+  function flare(level, holdMs) {
+    if (!armed() || stopped || !nodes.dusk) return;
+    const until = nowMs() + Math.max(120, holdMs | 0);
+    const lv = Math.max(level, duskFor(rung, heat));
+    try {
+      nodes.dusk.style.transition = 'opacity ' + P.FLARE_IN_MS + 'ms ease-out';
+      setOpacity(nodes.dusk, lv);
+    } catch (e) { /* cosmetic */ }
+    if (until > flareUntil) {
+      flareUntil = until;
+      cancel(flareTimer);
+      flareTimer = after(until - nowMs(), () => {
+        flareTimer = 0; flareUntil = 0;
+        try { nodes.dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+        paintDusk();
+      });
+    }
+    count('flare');
+  }
+  function retune() {
+    paintDusk();
+    amp = still ? 0 : tremorAmpPx(streak, heat, reduced, motion);
+    /* the SHOWN rung drives the idle tremor (a hysteresis step-down keeps it
+       humming for the grace period too) */
+    if (!still) {
+      const base = P.TREMOR_PX[rung] || 0;
+      amp = base <= 0 ? 0 : Math.min(P.TREMOR_CAP_PX, base * P.MOTION_MUL[motion] * (P.TREMOR_HEAT_FLOOR + (1 - P.TREMOR_HEAT_FLOOR) * heat));
+    }
+    armLoop();
+  }
+  function doPunch(spec) {
+    if (still || !armed() || !spec || spec.px <= 0) return;
+    const tNow = nowMs();
+    /* extend-not-stack: keep the louder amplitude, push the deadline */
+    punch = { px: Math.max(punch.px, spec.px), until: Math.max(punch.until, tNow + spec.ms), ms: Math.max(spec.ms, 1) };
+    count('punch');
+    armLoop();
+  }
+
+  /* ---- the rungs ---------------------------------------------------------- */
+  function breathOn(storm) {
+    sustain('wash', {
+      variant: 'pink',
+      alpha: lerp(storm ? P.STORM_BREATH_ALPHA : P.BREATH_ALPHA, heat),
+      holdMs: P.BREATH_HOLD_MS,
+      sustainForever: true,
+    });
+  }
+  function whisperOut(variant) {
+    /* step a wash DOWN: re-trigger at a whisper with a short hold - it fades on
+       its own deadline (never stop('wash'), see the header) */
+    sustain('wash', { variant, alpha: P.WHISPER_ALPHA, holdMs: P.WHISPER_HOLD_MS });
+  }
+  function applyAdd(add, goingUp) {
+    if (goingUp) {
+      on.add(add);
+      if (add === 'breath') breathOn(false);
+      else if (add === 'scan') sustain('crt', { level: lerp(P.SCAN_LEVEL, heat), variant: 'scanline' });
+      else if (add === 'wheel') sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true });
+      else if (add === 'subs') sustain('sub_flash', {});
+      else if (add === 'chroma') sustain('crt', { level: lerp(P.CHROMA_LEVEL, heat), variant: 'chroma' });
+      else if (add === 'storm') {
+        sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
+        sustain('gif_rain', { durationMs: P.STORM_RAIN_MS, variant: 'downpour', strength: heat, clickSafe: true });
+        breathOn(true);
+      }
+      /* burst / giant / veil / rain / flashes / tremor are event-driven: nothing to switch on */
+    } else {
+      on.delete(add);
+      if (add === 'breath') whisperOut('pink');
+      else if (add === 'scan') { if (!on.has('chroma')) stop('crt'); }
+      else if (add === 'wheel') whisperOut('spiral');
+      else if (add === 'subs') stop('sub_flash');
+      else if (add === 'chroma') { stop('crt'); if (on.has('scan')) sustain('crt', { level: lerp(P.SCAN_LEVEL, heat), variant: 'scanline' }); }
+      else if (add === 'storm') { stop('ambient_field'); stop('gif_rain'); if (on.has('breath')) breathOn(false); }
+    }
+  }
+  function setRung(r) {
+    if (r === rung) return;
+    const up = r > rung;
+    if (up) {
+      for (let k = rung + 1; k <= r; k++) for (const add of P.RUNG_ADDS[k]) applyAdd(add, true);
+      cue(P.RUNG_CUE[r], r);
+    } else {
+      for (let k = rung; k > r; k--) for (const add of P.RUNG_ADDS[k]) applyAdd(add, false);
+    }
+    rung = r;
+    retune();
+    say('pressure: rung ' + rung + ' (' + (up ? 'up' : 'down') + ', streak ' + streak + ')');
+  }
+  function setStreak(s) {
+    streak = Math.max(0, Math.floor(Number(s) || 0));
+    wantRung = rungFor(streak);
+    if (!started || stopped) return;
+    if (wantRung > rung) { cancel(downTimer); downTimer = 0; setRung(wantRung); }
+    else if (wantRung < rung && !downTimer) {
+      downTimer = after(P.HYST_MS, () => { downTimer = 0; if (wantRung < rung) setRung(wantRung); });
+    } else if (wantRung === rung) { cancel(downTimer); downTimer = 0; }
+  }
+  function repaintHeat() {
+    if (Math.abs(heat - lastPaintHeat) < P.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (on.has('breath')) breathOn(on.has('storm'));
+    if (on.has('wheel')) sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true });
+    if (on.has('chroma')) sustain('crt', { level: lerp(P.CHROMA_LEVEL, heat), variant: 'chroma' });
+    else if (on.has('scan')) sustain('crt', { level: lerp(P.SCAN_LEVEL, heat), variant: 'scanline' });
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      stopped = false;
+      lastPaintHeat = -1;
+      /* a dev streak may already be set: show its rung now */
+      if (wantRung > 0) setRung(wantRung);
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started && !stopped) { repaintHeat(); retune(); }
+    },
+    load(ev) {
+      const e = ev || {};
+      if (e.streak != null) setStreak(e.streak);
+    },
+    slide() { /* the tube owns the slide */ },
+    reveal(ev) { const e = ev || {}; if (e.streak != null) setStreak(e.streak); },
+    pop(ev) {
+      const e = ev || {};
+      const milestone = P.MILESTONES.indexOf(Number(e.streak) || 0) >= 0;
+      setStreak(e.streak);
+      doPunch(punchFor({ pts: e.pts, milestone }));
+      if (!armed() || stopped) return;
+      if (on.has('burst') || rung >= 2) {
+        if (roll('burst') < lerp(P.BURST_CHANCE, heat)) {
+          const hold = Math.round(lerp(P.BURST_HOLD_MS, heat));
+          const went = fire('gif_burst', {
+            count: Math.round(lerp(P.BURST_COUNT, heat)), clickSafe: true,
+            sizePx: Math.round(vmin() * lerp(P.BURST_VMIN, heat)),
+            holdMs: hold,
+            variant: rung >= 8 ? 'scatter' : undefined,
+          });
+          if (went) flare(P.FLARE_BURST, hold + 300);
+        }
+      }
+      if ((on.has('giant') || rung >= 4) && roll('giant') < lerp(P.GIANT_CHANCE, heat)) {
+        /* ONE near-fullscreen gif on the landing; the engine's heat alpha and
+           the clickSafe weld still rule it (it is decoration over a dimmed tube) */
+        const hold = Math.round(lerp(P.GIANT_HOLD_MS, heat));
+        const went = fire('gif_burst', {
+          count: 1, clickSafe: true, x: 50, y: 50,
+          sizePx: Math.round(vmin() * P.GIANT_VMIN),
+          holdMs: hold,
+          variant: 'single',
+        });
+        if (went) flare(P.FLARE_GIANT, hold + 400);
+      }
+      if (rung >= 4 && roll('veil') < lerp(P.VEIL_CHANCE, heat)) {
+        const targets = [nodes.bgA, nodes.bgB].filter(Boolean);
+        if (targets.length) {
+          fire('glitch_swap', {
+            targets,
+            variant: P.VEIL_VARIANTS[Math.floor(roll('veil') * P.VEIL_VARIANTS.length)],
+            seconds: lerp(P.VEIL_S, heat),
+            sfx: false,
+            onSwap() { /* presentation only: the backdrop keeps its own image */ },
+          });
+        }
+      }
+      if (rung >= 5 && roll('rain') < lerp(P.RAIN_CHANCE, heat)) {
+        sustain('gif_rain', { durationMs: Math.round(lerp(P.RAIN_MS, heat)), clickSafe: true, strength: heat, variant: rung >= 8 ? 'downpour' : 'steady' });
+      }
+      if (on.has('flashes') || rung >= 7) fire('flash_burst', { count: P.STORM_FLASH_COUNT, clickSafe: true });
+    },
+    drift() { setStreak(0); },
+    denyPass(ev) { const e = ev || {}; if (e.streak != null) setStreak(e.streak); /* restraint HOLDS the rung */ },
+    denyHit() {
+      doPunch(punchFor({ pts: 0, hit: true }));
+      if (rung >= 4 && armed() && !stopped) {
+        const targets = [nodes.bgA, nodes.bgB].filter(Boolean);
+        if (targets.length) fire('glitch_swap', { targets, variant: 'datamosh', seconds: 0.5, sfx: false, onSwap() {} });
+      }
+      setStreak(0);
+    },
+    hover() { /* nothing to do with a hover here */ },
+    /** index.js's per-pop effect beat: a 'flash' beat gets the flare too. */
+    beat(ev) {
+      const e = ev || {};
+      if (e.flavor === 'flash' && rung >= 1) flare(P.FLARE_BURST, (Number(e.holdMs) || 900) + 300);
+    },
+    end() { api.stop(); },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      cancel(downTimer); downTimer = 0;
+      /* everything sighs out: whisper the washes, stop the rest (fades are the engine's) */
+      if (on.has('breath') || on.has('storm')) whisperOut('pink');
+      if (on.has('wheel')) whisperOut('spiral');
+      if (on.has('scan') || on.has('chroma')) stop('crt');
+      if (on.has('subs')) stop('sub_flash');
+      if (on.has('storm')) { stop('ambient_field'); stop('gif_rain'); }
+      /* the dusk eases to its debrief level (never a snap back to a blazing tube) */
+      cancel(flareTimer); flareTimer = 0; flareUntil = 0;
+      try { if (nodes.dusk && nodes.dusk.style) nodes.dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+      setOpacity(nodes.dusk, rung > 0 ? Math.min(P.DUSK_END, duskFor(rung, heat)) : 0);
+      on.clear();
+      rung = 0;
+      amp = 0; punch = { px: 0, until: 0, ms: 1 };
+      haltLoop();
+      setTranslate(nodes.tubewrap, 0, 0);
+      setTranslate(nodes.hud, 0, 0);
+    },
+    pause() {
+      paused = true;
+      cancelAll(); downTimer = 0; flareTimer = 0; flareUntil = 0;
+      try { if (nodes.dusk && nodes.dusk.style) nodes.dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+      haltLoop();
+      setTranslate(nodes.tubewrap, 0, 0);
+      setTranslate(nodes.hud, 0, 0);
+    },
+    resume() {
+      paused = false;
+      if (!stopped) { retune(); setStreak(streak); }
+    },
+    destroy() {
+      api.stop();
+      destroyed = true;
+      cancelAll();
+      haltLoop();
+      setOpacity(nodes.dusk, '');
+      try { stop('wash'); } catch (e) { /* noop */ }
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, paused, heat: +heat.toFixed(3), streak, rung, wantRung,
+        on: Array.from(on), tremorPx: +amp.toFixed(3), punchPx: +punch.px.toFixed(2), loopOn,
+        dusk: stopped ? 0 : duskFor(rung, heat), flaring: flareUntil > nowMs(),
+        fires: Object.assign({}, fires), liveTimers: live.size, nodes: 0,
+      };
+    },
+  };
+  return api;
+}
+
+export default createIcPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
@@ -7,14 +7,60 @@
  *                   a gradient that is ALWAYS painted - an empty pool still
  *                   looks dressed)
  *   canvas          the tube body (tube3d -> tube2d -> static, chosen here)
+ *   .g-ic-marquee-slot  an EMPTY square ring anchor hugging the basin. The
+ *                   casino deck mounts its bulb chase in here; this file only
+ *                   sizes and places the box (--ic-basin-d) and swears it will
+ *                   never take a pointer.
  *   .g-ic-flourish  the spiral pop flourish (pointer-events:none)
  *   .g-ic-basin     the reveal surface: THE bubble (the one interactive node)
- *   .g-ic-hud       score / streak / progress, pinned to the bottom edge
- *   .g-ic-break     intro card · .g-ic-debrief  the report
+ *   .g-ic-hud       THE LIT MACHINE, pinned to the bottom edge
+ *   .g-ic-howto     the class rules SHEET · .g-ic-break intro card
+ *   .g-ic-debrief   the machine TICKET
  *
- * INPUT TRUST: the bubble is the single tap target; every decorative layer is
- * pointer-events:none. The reveal is class-toggle + src swap only - nothing
- * ever delays the reveal paint (RT integrity).
+ * HOUSE RULES WAVE - what this file gained, and why it is here and not in a
+ * deck:
+ *   THE SHEET (Deck VI, Law IV - drawn, not told). showHowto() draws three
+ *     vignettes in pure CSS - the mouth dropping a bubble into the dish under a
+ *     racing speed bar, the X bubble with its ring running out beside a hand
+ *     that must not move, a pale bubble drifting off the rim and costing
+ *     nothing - and captions them from the lexicon. The 150-character
+ *     ic_tube_rules paragraph it replaces is gone from lex.js. The sheet is
+ *     STAGE's because the shapes it draws are the stage's own furniture; a deck
+ *     drawing the game's rules would be a deck teaching the class.
+ *   THE LIT MACHINE (Deck IV/VI). The score is an ODOMETER: one <i> per digit
+ *     in a fixed-width slot, so the casino's scale punch (transform only) can
+ *     never reflow a number. The bubble counter is a thread whose head glows;
+ *     the topline wears a slow sweep; the HUD's own rail breathes. All of it is
+ *     CSS on pseudo-elements and pointer-events:none, so a deck animating
+ *     .g-ic-score itself never fights this file.
+ *   THE METER SLOT. `nodes.meterSlot` is an empty anchor and stays empty: the
+ *     10-segment streak meter is a SHELL primitive (SYNTHESIS #10) that
+ *     index.js mounts through ctx.ceremonies.streakMeter. The old private
+ *     5-pip meter that used to live here is DELETED - it was a fork.
+ *   THE TICKET (Deck V + VI). debrief() prints a receipt: perforated edges, a
+ *     slow light sweep, the backdrop still breathing behind it, the grade
+ *     arriving as an OBJECT in `nodes.ticketStamp` (index.js drops the shell's
+ *     stamp ceremony there). Submit is lit, pulsing and pre-focused; recal is a
+ *     ghost. A class that went badly still gets light: `is-dim`, never dark.
+ *
+ * AUDIO. This file used to synthesise its own chirps off its own AudioContext.
+ * That was a straight violation of web CLAUDE.md trap 18 - shell/audio.js is
+ * the only thing in the Arcademy that may hold an audio node, and the engine's
+ * `audio_trigger` is the sanctioned road to it. Every oscillator is GONE; the
+ * casino deck owns the cue ladder now. The ONE survivor is deniedSting():
+ * assets/denied.mp3 is a real, owner-approved sample fired on the X-hit, it is
+ * grandfathered, and it is deliberately the only <Audio> in this folder.
+ *
+ * INPUT TRUST (Law II): the bubble is the single tap target; every decorative
+ * layer, slot and sheet figure is pointer-events:none. The reveal is
+ * class-toggle + src swap only - nothing ever delays the reveal paint (RT
+ * integrity).
+ *
+ * NEVER STILL (Law III): the lamps breathe, the thread head pulses, the topline
+ * sweeps, the ticket's light crawls. Every one of those is a CSS animation, so
+ * `.suspended` (animation-play-state:paused, pseudo-elements included) and
+ * prefers-reduced-motion both freeze the whole room from the stylesheet, even
+ * if a JS path forgets.
  *
  * All methods are throw-guarded: a cosmetic failure may never take the class
  * down. Under the DOM double the tube resolves to its static tier and audio
@@ -66,28 +112,15 @@ export function createRender(o = {}) {
   let lastMood = null;   // replayed onto the 3d tube when its async import lands
   let bgActive = 0;
   let bgFade = 0.35;
-  let audioCtx = null;
   let deniedAudio = null;
   let onResize = null;
+  let scoreText = null;  // the odometer's last painted string
 
   /* ------------------------------------------------------------------ sfx */
-  function chirp(freq, ms, gain) {
-    if (reduced && gain > 0.1) gain = 0.1;
-    try {
-      const AC = (typeof AudioContext === 'function') ? AudioContext
-        : (typeof webkitAudioContext === 'function' ? webkitAudioContext : null);
-      if (!AC) return;
-      if (!audioCtx) audioCtx = new AC();
-      const osc = audioCtx.createOscillator();
-      const g = audioCtx.createGain();
-      osc.frequency.value = freq;
-      osc.type = 'sine';
-      g.gain.setValueAtTime(gain, audioCtx.currentTime);
-      g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + ms / 1000);
-      osc.connect(g); g.connect(audioCtx.destination);
-      osc.start(); osc.stop(audioCtx.currentTime + ms / 1000 + 0.02);
-    } catch (e) { /* silence is legal */ }
-  }
+  /* THE ONE SURVIVING SOUND. Every synthesised chirp this file used to make is
+     gone (trap 18: shell/audio.js owns audio, the engine's audio_trigger is the
+     road, and casino.js drives the ladder). denied.mp3 is a real sample the
+     owner approved for the X-hit and is grandfathered in place. */
   function deniedSting() {
     try {
       if (typeof Audio !== 'function') return;
@@ -105,6 +138,7 @@ export function createRender(o = {}) {
     nodes.stage = stage;
 
     const bg = el('div', 'g-ic-bg', stage);
+    nodes.bg = bg;
     nodes.bgA = el('img', 'g-ic-bg-img', bg);
     nodes.bgB = el('img', 'g-ic-bg-img', bg);
     /* depth: melts the media's EDGES into atmosphere (centre stays legible),
@@ -113,6 +147,16 @@ export function createRender(o = {}) {
     nodes.veil = el('div', 'g-ic-bg-veil', bg);
 
     nodes.tubewrap = el('div', 'g-ic-tubewrap', stage);
+    /* THE DUSK: a dimmer laid OVER the tube and under everything the player
+       reads. pressure.js drives its opacity with the rung: the brighter the
+       fullscreen effects get, the darker the tube under them, so the engine's
+       washes and gifs read IN FRONT of a chute that would otherwise out-shine
+       them (owner 2026-08-22: "effects still behind the tube" - they were not;
+       they were drowned). Empty, pointer-events:none, opacity 0 at rest. */
+    nodes.dusk = el('div', 'g-ic-dusk', stage);
+    /* the casino's ring hangs here: a square --ic-basin-d box centred on the
+       basin, empty, and pointer-events:none forever */
+    nodes.marqueeSlot = el('div', 'g-ic-marquee-slot', stage);
     nodes.flourish = el('div', 'g-ic-flourish', stage);
 
     const basin = el('div', 'g-ic-basin', stage);
@@ -131,6 +175,7 @@ export function createRender(o = {}) {
     nodes.stamp = el('div', 'g-ic-stamp', stage);
 
     const topline = el('div', 'g-ic-topline', stage);
+    nodes.topline = topline;
     nodes.title = el('span', 'g-ic-topname', topline);
     if (nodes.title) nodes.title.textContent = t('ic_tube_title', 'The Drop Tube');
     nodes.subject = el('span', 'g-ic-topsub', topline);
@@ -145,13 +190,14 @@ export function createRender(o = {}) {
     nodes.scoreLabel = el('div', 'g-ic-score-label', mid);
     if (nodes.scoreLabel) nodes.scoreLabel.textContent = t('ic_score', 'Score');
     nodes.score = el('div', 'g-ic-score', mid);
-    if (nodes.score) nodes.score.textContent = '0';
+    paintScore(0);
     nodes.rt = el('div', 'g-ic-rt', mid);
     const right = el('div', 'g-ic-hud-cell g-ic-hud-right', hud);
     nodes.streakLabel = el('div', 'g-ic-streak-label', right);
     if (nodes.streakLabel) nodes.streakLabel.textContent = t('ic_streak', 'streak');
-    nodes.pips = el('div', 'g-ic-pips', right);
-    if (nodes.pips) for (let i = 0; i < 5; i++) el('i', 'g-ic-pip', nodes.pips);
+    /* EMPTY ON PURPOSE. ctx.ceremonies.streakMeter({target: meterSlot}) fills
+       it from the shell; this class does not own a streak meter. */
+    nodes.meterSlot = el('div', 'g-ic-meter-slot', right);
 
     root.appendChild(stage);
 
@@ -173,7 +219,20 @@ export function createRender(o = {}) {
     };
     let p = null;
     try {
-      p = import('./tube3d.js').then((m) => m.createTube3D({ mount: nodes.tubewrap, reduced, perf, seed }));
+      p = import('./tube3d.js').then((m) => m.createTube3D({
+        mount: nodes.tubewrap, reduced, perf, seed,
+        /* THE LANDING: the 3D tube says where its visible hole is; the basin,
+           the marquee ring, the flourish and the stamp all hang off these two
+           custom properties (style.js). tube2d never calls it: 50%/50% stands. */
+        onLanding(pt) {
+          try {
+            const st = nodes.stage;
+            if (!st || !st.style || !pt) return;
+            st.style.setProperty('--ic-basin-x', (Number(pt.x) || 50).toFixed(2) + '%');
+            st.style.setProperty('--ic-basin-y', (Number(pt.y) || 50).toFixed(2) + '%');
+          } catch (e) { /* cosmetic */ }
+        },
+      }));
     } catch (e) { p = null; }
     if (p && typeof p.then === 'function') {
       p.then((t3) => {
@@ -239,14 +298,12 @@ export function createRender(o = {}) {
     }
     bub.classList.add('on');
     tubeCall('reveal');
-    if (!reduced) chirp(b.kind === 'denied' ? 190 : 620, 90, 0.05);
   }
 
   function popBubble(good) {
     const bub = nodes.bubble;
     if (bub) { bub.classList.remove('on'); bub.classList.add('pop'); }
     tubeCall('pop', good);
-    chirp(good ? 880 : 240, 140, 0.12);
   }
   function fadeBubble() {
     const bub = nodes.bubble;
@@ -256,7 +313,6 @@ export function createRender(o = {}) {
     const bub = nodes.bubble;
     if (bub) { bub.classList.remove('on'); bub.classList.add('fade'); }
     tubeCall('denyPass');
-    chirp(520, 160, 0.08);
   }
   function hitDenied() {
     const bub = nodes.bubble;
@@ -295,6 +351,27 @@ export function createRender(o = {}) {
     s.className = 'g-ic-stamp on ' + (kind || '');
     void (s.offsetWidth);
   }
+
+  /* THE ODOMETER. One element per digit in a fixed-width slot: the casino
+     punches .g-ic-score with a transform and the number never reflows, and a
+     trickster that writes over .g-ic-score's textContent is repaired by the
+     next hud() (the digit children are gone, so the string is repainted). */
+  function paintScore(v) {
+    const host = nodes.score;
+    if (!host) return;
+    const txt = String(Math.max(0, Math.round(Number(v) || 0)));
+    const kids = (host.children && host.children.length) || 0;
+    if (txt === scoreText && kids === txt.length) return;
+    scoreText = txt;
+    try {
+      host.textContent = '';
+      for (let i = 0; i < txt.length; i++) {
+        const d = el('i', 'g-ic-dig', host);
+        if (d) d.textContent = txt.charAt(i);
+      }
+    } catch (e) { /* a plain string is still a score */ }
+  }
+
   function hud(h) {
     /* the living material follows the class: progress + streak drive the
        tube's pattern, spin and tint (setMood is cosmetic and throw-guarded) */
@@ -302,7 +379,7 @@ export function createRender(o = {}) {
       lastMood = { progress: Math.min(1, h.n / h.total), streak: h.streak || 0 };
       tubeCall('setMood', lastMood);
     }
-    if (nodes.score && h.score != null) nodes.score.textContent = String(Math.max(0, Math.round(h.score)));
+    if (h.score != null) paintScore(h.score);
     if (nodes.rt) nodes.rt.textContent = (showRt && h.rt != null) ? Math.round(h.rt) + 'ms' : '';
     if (nodes.counter && h.n != null) {
       nodes.counter.textContent = t('ic_bubble_n', 'Bubble') + ' ' + h.n + ' / ' + h.total;
@@ -310,13 +387,87 @@ export function createRender(o = {}) {
     if (nodes.threadFill && h.n != null && h.total) {
       nodes.threadFill.style.setProperty('--ic-prog', String(Math.min(1, h.n / h.total)));
     }
-    if (nodes.pips && h.streak != null) {
-      const kids = nodes.pips.children || [];
-      for (let i = 0; i < kids.length; i++) {
-        setCls(kids[i], 'on', i < (h.streak % 5 === 0 && h.streak > 0 ? 5 : h.streak % 5));
-      }
-    }
+    /* the streak meter is the SHELL's (ceremonies.streakMeter into meterSlot);
+       this class never draws one of its own */
     if (nodes.subject && h.subject) nodes.subject.textContent = h.subject;
+  }
+
+  /* ------------------------------------------------------ class rules sheet */
+  /* DECK VI, LAW IV. Three drawn vignettes and one way out. No raster art: the
+     mouth, the dish, the bubbles, the ring, the hand and the speed bar are all
+     gradients and borders, so the sheet costs nothing and reads at any size.
+     Every figure is pointer-events:none; the GO button is the only live thing
+     on it and the ONLY dismissal (index.js binds no key to the sheet). */
+  function showHowto(opts) {
+    const o2 = opts || {};
+    hideHowto();
+    if (!nodes.stage) return null;
+    const sheet = el('div', 'g-ic-howto', nodes.stage);
+    if (!sheet) return null;
+    nodes.howto = sheet;
+
+    const h = el('h2', 'g-ic-hw-title', sheet);
+    if (h) h.textContent = t('ic_howto_title', 'Class rules');
+
+    const row = (build, caption) => {
+      const r = el('div', 'g-ic-hw-row', sheet);
+      if (!r) return null;
+      const fig = el('span', 'g-ic-hw-fig', r);
+      if (fig) { try { build(fig); } catch (e) { /* a caption alone still teaches */ } }
+      const p = el('p', 'g-ic-hw-cap', r);
+      if (p) p.textContent = caption;
+      return r;
+    };
+
+    /* 1 - THE DROP. The mouth spits a pink bubble into the dish, a tap lands on
+       it, and the speed bar races down beside it: pop fast, speed is the score. */
+    row((fig) => {
+      const scene = el('span', 'g-ic-hw-scene', fig);
+      el('span', 'g-ic-hw-mouth', scene);
+      el('span', 'g-ic-hw-spark', scene);
+      const dish = el('span', 'g-ic-hw-dish', scene);
+      el('span', 'g-ic-hw-bub', dish);
+      el('span', 'g-ic-hw-ping', dish);
+      const tap = el('span', 'g-ic-hw-tap' + (o2.coarse ? ' finger' : ' cap'), fig);
+      if (tap && !o2.coarse) tap.textContent = String(o2.keyLabel || '');
+      const bar = el('span', 'g-ic-hw-speed', fig);
+      el('i', null, bar);
+    }, t('ic_howto_pop', 'A bubble lands in the dish. Pop it at once. The faster you are, the more it pays.'));
+
+    /* 2 - THE X. The ring drains around a crossed bubble; the hand beside it
+       wears a bar through it. Touch nothing for two seconds. */
+    row((fig) => {
+      const scene = el('span', 'g-ic-hw-scene', fig);
+      const xb = el('span', 'g-ic-hw-xbub', scene);
+      el('span', 'g-ic-hw-ring', xb);
+      const cross = el('span', 'g-ic-hw-cross', xb);
+      if (cross) { el('i', 'g-ic-hw-xa', cross); el('i', 'g-ic-hw-xb', cross); }
+      el('span', 'g-ic-hw-nohand', fig);
+    }, t('ic_howto_x', 'A bubble wearing an X is a trap. Touch nothing until its ring runs out.'));
+
+    /* 3 - THE DRIFT. A pale bubble slides off the rim and simply stops being
+       there. Deliberately NO penalty glyph: the absence is the lesson. */
+    row((fig) => {
+      const scene = el('span', 'g-ic-hw-scene', fig);
+      const dish = el('span', 'g-ic-hw-dish', scene);
+      el('span', 'g-ic-hw-pale', dish);
+    }, t('ic_howto_drift', 'A bubble you miss just drifts off the dish. Nothing is taken from you.'));
+
+    const go = el('button', 'g-ic-hw-go', sheet);
+    if (go) {
+      go.type = 'button';
+      go.textContent = t('ic_howto_go', 'Start the drop');
+      go.setAttribute('autofocus', '');
+      go.addEventListener('click', () => {
+        try { if (typeof o2.onGo === 'function') o2.onGo(); } catch (e) { /* noop */ }
+      });
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+    }
+    return sheet;
+  }
+
+  function hideHowto() {
+    if (nodes.howto) { try { nodes.howto.remove(); } catch (e) { /* noop */ } nodes.howto = null; }
   }
 
   /* ------------------------------------------------------------ big cards */
@@ -336,14 +487,29 @@ export function createRender(o = {}) {
     if (nodes.card) { try { nodes.card.remove(); } catch (e) { /* noop */ } nodes.card = null; }
   }
 
+  /* THE TICKET (Deck V + Deck VI). Same signature, same fields, plus the two
+     optional flags the casino decides: d.perfect (no X popped, nothing drifted)
+     and d.royal. The grade arrives as an OBJECT: index.js drops the shell's
+     stamp ceremony into nodes.ticketStamp. Nothing here grades anything - every
+     number on this receipt was handed to it. */
   function debrief(d, onSubmit, onRecal) {
     clearCard();
+    hideHowto();
     if (nodes.hud) nodes.hud.classList.add('off');
     if (nodes.bubble) nodes.bubble.classList.remove('on');
     const wrap = el('div', 'g-ic-debrief', nodes.stage);
     if (!wrap) return;
     nodes.card = wrap;
-    const paper = el('div', 'g-ic-paper', wrap);
+
+    const royal = !!d.royal;
+    const perfect = !!d.perfect;
+    /* losses disguised: a bad class is DIM, never dark - the machine does not
+       go silent on you, because silence is where people stand up */
+    const dim = !royal && !perfect && (d.xClicked > 0);
+    const paper = el('div', 'g-ic-paper g-ic-ticket'
+      + (royal ? ' is-royal' : '') + (perfect ? ' is-perfect' : '') + (dim ? ' is-dim' : ''), wrap);
+    el('i', 'g-ic-ticket-sweep', paper);
+
     const head = el('div', 'g-ic-paper-head', paper);
     const ttl = el('h2', null, head);
     if (ttl) ttl.textContent = t('ic_debrief', 'Debrief');
@@ -355,6 +521,8 @@ export function createRender(o = {}) {
     if (sv) sv.textContent = String(Math.max(0, d.score));
     const sl = el('span', null, scoreRow);
     if (sl) sl.textContent = t('ic_score', 'Score');
+    /* the stamp bed: empty, pointer-events:none, waiting for the ceremony */
+    nodes.ticketStamp = el('div', 'g-ic-ticket-stamp', scoreRow);
 
     const grid = el('div', 'g-ic-paper-grid', paper);
     const cell = (label, value, cls) => {
@@ -378,15 +546,21 @@ export function createRender(o = {}) {
       if (hint) hint.textContent = d.hint;
     }
 
+    /* one-more framing (Deck V): submit is lit, pulsing and pre-focused; the
+       ghost beside it is honest, live and never moves */
     const row = el('div', 'g-ic-paper-actions', paper);
     const submitBtn = el('button', 'btn g-ic-submit', row);
     if (submitBtn) {
+      submitBtn.type = 'button';
       submitBtn.textContent = t('ic_submit', 'Submit report');
+      submitBtn.setAttribute('autofocus', '');
       submitBtn.addEventListener('click', () => { try { onSubmit(); } catch (e) { /* noop */ } });
+      try { if (typeof submitBtn.focus === 'function') submitBtn.focus(); } catch (e) { /* noop */ }
     }
     if (onRecal) {
       const rec = el('button', 'btn ghost g-ic-recal', row);
       if (rec) {
+        rec.type = 'button';
         rec.textContent = t('ic_recalibrate', 'Recalibrate baseline');
         let armed = false;
         rec.addEventListener('click', () => {
@@ -411,13 +585,15 @@ export function createRender(o = {}) {
     try {
       if (onResize && typeof window !== 'undefined' && window.removeEventListener) window.removeEventListener('resize', onResize);
     } catch (e) { /* noop */ }
-    try { if (audioCtx && audioCtx.close) audioCtx.close(); } catch (e) { /* noop */ }
+    try { if (deniedAudio && deniedAudio.pause) deniedAudio.pause(); } catch (e) { /* noop */ }
+    deniedAudio = null;
     try { if (nodes.stage) nodes.stage.remove(); } catch (e) { /* noop */ }
   }
 
   return {
     nodes,
     mount, intro, clearCard, debrief,
+    showHowto, hideHowto,
     showLoad, setTravel, revealBubble, popBubble, fadeBubble, deniedPassed, hitDenied,
     flourish, stamp, hud, swapBg, setBgFade,
     suspend, destroy,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
@@ -10,12 +10,64 @@
  * its opacity is runtime-set from the ic_bg_fade setting x caps.bgIntensity,
  * never hardcoded here.
  *
- * INPUT TRUST: only .g-ic-bubble takes pointer events. Every other layer is
- * pointer-events:none, including the flourish and the stamp.
+ * ONE NUMBER SIZES THE MIDDLE OF THE ROOM. `--ic-basin-d` is the reveal
+ * diameter; the bubble IS it, the stamp rides at 0.79 of it above centre, the
+ * casino's marquee slot is a 2x square centred on the same point, its ALMOST
+ * word rides 0.62 of it below, and the trickster's crooked ring is the bubble's
+ * box grown 1.28x. Change that one token and the whole basin furniture moves
+ * together (and only together with tube3d's TUBE_R - see .g-ic-bubble). Nobody
+ * may re-type its value: read the token, fall back to the token.
  *
- * MOTION: all animation is also neutralised under prefers-reduced-motion, and
- * .suspended pauses every animation via animation-play-state - the CSS denies
- * a strobe even when a JS path forgets.
+ * THE STAGE IS A BACKDROP ROOT. `.g-ic-bg` carries `isolation:isolate` so the
+ * depth ring's backdrop-filter cannot reach past the media it exists to melt -
+ * see the note on .g-ic-bg-depth.
+ *
+ * THE HOUSE RULES WAVE added three rooms to this sheet:
+ *   THE SHEET   `.g-ic-howto` - the drawn class rules (Deck VI). Three
+ *               vignettes built out of gradients, borders and masks: a chute
+ *               mouth dropping a pink bubble into a dish beside a draining
+ *               speed bar, an X bubble with its hold ring running out beside a
+ *               barred hand, a pale bubble sliding off the rim. No raster art,
+ *               no glyph font, and it reads correctly FROZEN.
+ *   THE MACHINE the HUD is lit now: a rail that breathes across its top edge
+ *               (--ic-lamp), a thread whose head pulses, a topline with a slow
+ *               sweep (--ic-sweep), and the score as an ODOMETER (.g-ic-dig,
+ *               one fixed-width slot per digit). The score's glow is driven
+ *               from --ic-gleam on the CELL, never on .g-ic-score itself, so
+ *               the casino deck owns that element's transform and animation
+ *               outright and the two never collide.
+ *   THE TICKET  `.g-ic-ticket` - the debrief as a printed receipt: punched
+ *               perforations top and bottom, one slow light crawling the face
+ *               (--ic-tk), a stamp bed for the grade-as-object, a lit pulsing
+ *               submit and a ghost recal. `.is-royal` / `.is-perfect` gild it;
+ *               `.is-dim` is the losing class - less light, never none.
+ *
+ * THE SLOTS ARE A CONTRACT. `.g-ic-marquee-slot`, `.g-ic-meter-slot` and
+ * `.g-ic-ticket-stamp` are sized and placed HERE and filled by somebody else
+ * (casino.js, the shell's 10-segment meter, the shell's stamp ceremony). Their
+ * CONTENTS are never this file's business; their box and their
+ * pointer-events:none promise always are.
+ *
+ * INPUT TRUST: only .g-ic-bubble takes pointer events. Every other layer is
+ * pointer-events:none, including the flourish, the stamp, both slots and the
+ * rules sheet - on which the single GO button re-enables them for itself,
+ * because it is the one and only way off that sheet.
+ *
+ * NOTHING IS EVER STILL (Law III), AND THE STYLESHEET IS WHERE THAT IS SAFE:
+ * every breathing lamp, sweep and pulse is a CSS animation, so `.suspended`
+ * pauses all of them (elements AND pseudo-elements - the blanket covers both)
+ * and prefers-reduced-motion neutralises them, even when a JS path forgets.
+ *
+ * NO hidden-ATTRIBUTE RULE LIVES HERE, EVER (web CLAUDE.md trap 27): the
+ * attribute selector is a user-agent rule and any author `display:` beats it.
+ * styles.css owns the one display:none!important reset for it; a competing
+ * rule in a game sheet is how two opaque overlays once ate a whole playtest.
+ * (The shell suite greps every game .js for the literal selector - that is
+ * why this comment spells it out instead of writing it.)
+ *
+ * REGISTER WHAT YOU KEYFRAME. An unregistered custom property is a token, not
+ * a value: animating it is a silent no-op. Every animatable prop below is
+ * declared with @property (that is why --ic-k, the hold ring, works).
  * ==========================================================================*/
 
 const STYLE_ID = 'g-ic-style';
@@ -24,11 +76,27 @@ export const STYLE_TEXT = `
 .g-ic{--ic-pink:var(--pink,#FF69B4);--ic-lav:var(--lav,#B8A6E8);--ic-gold:var(--gold,#F0C24B);
   --ic-ink:var(--ink,#F2EBDD);--ic-dim:var(--ink-dim,#B9B3CE);--ic-faint:var(--ink-faint,#8A84A8);
   --ic-panel:var(--panel,#252542);--ic-line:var(--line,#3A3A5E);--ic-ground:var(--ground,#14142B);
+  --ic-basin-d:clamp(132px,17.5vmin,238px);
   position:absolute;inset:0;overflow:hidden;color:var(--ic-ink);
   background:radial-gradient(circle at 50% 46%, #1E1E3C, var(--ic-ground) 74%)}
 
+/* the animatable custom props, registered so keyframes can actually move them */
+@property --ic-lamp { syntax: '<number>'; initial-value: .55; inherits: false; }
+@property --ic-gleam { syntax: '<number>'; initial-value: .22; inherits: true; }
+@property --ic-sweep { syntax: '<percentage>'; initial-value: -45%; inherits: false; }
+@property --ic-hk { syntax: '<number>'; initial-value: 1; inherits: false; }
+@property --ic-tk { syntax: '<percentage>'; initial-value: -30%; inherits: false; }
+
 /* ------------------------------------------------------------ the backdrop */
+/* isolation:isolate is LOAD-BEARING, not decoration. It makes this box the
+   BACKDROP ROOT for .g-ic-bg-depth below: without it the depth ring's
+   backdrop-filter walks the ancestor chain to the document root (nothing
+   between here and <html> declares one), which is how a full-viewport,
+   always-on blur ends up hoisting its render surface over the shell's fx layer
+   in an accelerated webview and every engine effect reads as BEHIND the tube.
+   The ring only ever wanted the two media <img>s under it. */
 .g-ic-bg{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden;
+  isolation:isolate;
   background:
     radial-gradient(120% 90% at 50% 40%, transparent 40%, rgba(6,6,16,.7) 100%),
     conic-gradient(from 210deg at 50% 46%, #191934, #222244 30%, #14142B 62%, #1d1d3a 100%)}
@@ -36,7 +104,10 @@ export const STYLE_TEXT = `
   opacity:0;transition:opacity .9s ease;filter:saturate(.9) blur(2px);transform:scale(1.07)}
 .g-ic-bg-img.on{animation:g-ic-kenburns 26s ease-in-out infinite alternate}
 @keyframes g-ic-kenburns{from{transform:scale(1.07)}to{transform:scale(1.15) translateY(-1.5%)}}
-/* the depth ring: media edges melt into atmosphere, the centre stays legible */
+/* the depth ring: media edges melt into atmosphere, the centre stays legible.
+   Its backdrop is the two <img>s above it and NOTHING ELSE - .g-ic-bg isolates
+   (see there). Blurring the whole document was never the intent and cost the
+   engine's layer its place on top. */
 .g-ic-bg-depth{position:absolute;inset:0;pointer-events:none;
   backdrop-filter:blur(14px) saturate(.85);
   -webkit-mask:radial-gradient(72% 58% at 50% 46%, transparent 34%, #000 78%);
@@ -48,7 +119,19 @@ export const STYLE_TEXT = `
 
 /* ------------------------------------------------------------ tube canvas */
 .g-ic-tubewrap{position:absolute;inset:0;pointer-events:none;z-index:1}
-.g-ic-tube-canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
+/* THE DUSK (render.js nodes.dusk, driven by pressure.js): over the tube (z1),
+   under the ring / basin / HUD. Opacity only - never a filter, never a
+   backdrop-filter (a backdrop root here would re-sort the canvas, see trap 26). */
+.g-ic-dusk{position:absolute;inset:0;pointer-events:none;z-index:2;opacity:0;
+  transition:opacity 1.1s ease;
+  background:radial-gradient(75% 68% at var(--ic-basin-x,50%) var(--ic-basin-y,50%), rgba(7,6,18,.66) 0%, rgba(7,6,18,.86) 55%, rgba(7,6,18,.94) 100%)}
+html.arc-reduced .g-ic-dusk{transition:none}
+/* z-index:0 is deliberate on a canvas that is already the only child: an
+   ACCELERATED WebGL surface at z-index:auto leaves the compositor to infer its
+   place from overlap alone, and this one covers the viewport. Pinned into the
+   wrap's context it can never be hoisted over the shell's fx layer. The same
+   line, for the same reason, is on dtrh's #sf-canvas. */
+.g-ic-tube-canvas{position:absolute;inset:0;width:100%;height:100%;display:block;z-index:0}
 /* the last-resort static tube (no canvas at all). NEGATIVE inset on purpose:
    the same composition law as tube3d/tube2d - the spiral has to leave the frame
    rather than stop inside it. */
@@ -61,15 +144,32 @@ export const STYLE_TEXT = `
   animation:g-ic-static-spin 80s linear infinite}
 @keyframes g-ic-static-spin{to{transform:rotate(360deg)}}
 
+/* ------------------------------------------------------- the marquee slot */
+/* EMPTY BY CONTRACT. casino.js hangs its bulb ring in here; this file only
+   guarantees the box - a 2x --ic-basin-d square centred on the basin, under
+   the reveal (z 2 against the basin's z 3) and never a pointer target. */
+.g-ic-marquee-slot{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);z-index:2;pointer-events:none;
+  width:calc(var(--ic-basin-d) * 2);height:calc(var(--ic-basin-d) * 2);
+  transform:translate(-50%,-50%)}
+
 /* -------------------------------------------------------------- the basin */
 /* THE BUBBLE MUST FIT THE BORE. It travelled inside the chute, so a reveal
    WIDER than the tube's projected bore breaks the fiction on sight. At the
    camera tube3d.js pins, the bore (dia 1.7 world) lands ~0.18 x viewport-height
-   near the basin; 14vmin keeps the reveal at ~0.8 of that on any sane window
-   while the 106px floor keeps the game's ONE tap target thumb-sized. Move this
-   ONLY together with TUBE_R. */
-.g-ic-basin{position:absolute;left:50%;top:50%;width:0;height:0;z-index:3}
-.g-ic-bubble{position:absolute;left:0;top:0;width:clamp(106px,14vmin,190px);height:clamp(106px,14vmin,190px);
+   near the basin, and the crater's own mouth (R_IN 2.5, dia 5.0 world) lands
+   ~0.53 of it - so the DISH has room to spare and the BORE is the tight one.
+   OWNER CALL 2026-08-22: the reveal reads 25% bigger, so the token went
+   14vmin -> 17.5vmin (floor 106 -> 132px, ceiling 190 -> 238px). That puts the
+   reveal at ~0.97 of the projected bore instead of ~0.8: still inside the
+   crater on every sane window, but the bore no longer has visible margin around
+   it. To buy the margin back the TUBE has to grow with it - TUBE_R 0.80 -> 1.00
+   with R_OUT 14.0 -> 14.2 (the camera clearance law wants R_OUT - TUBE_R >=
+   13.15), and tube2d's BORE_F 0.64 -> 0.80. Those are tube3d/tube2d's to make.
+   Move this token ONLY together with them. */
+/* THE LANDING: --ic-basin-x/-y are set on .g-ic by tube3d (render.js onLanding)
+   to the middle of the tube's VISIBLE hole; 50%/50% is tube2d's answer. */
+.g-ic-basin{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);width:0;height:0;z-index:3}
+.g-ic-bubble{position:absolute;left:0;top:0;width:var(--ic-basin-d);height:var(--ic-basin-d);
   transform:translate(-50%,-50%) scale(.2);margin:0;cursor:pointer;border-radius:50%;
   opacity:0;pointer-events:none;transition:none}
 .g-ic-bubble.on{opacity:1;pointer-events:auto;animation:g-ic-reveal .16s cubic-bezier(.2,1.6,.4,1) forwards}
@@ -103,8 +203,8 @@ export const STYLE_TEXT = `
 @property --ic-k { syntax: '<number>'; initial-value: 1; inherits: false; }
 .g-ic-holdring{position:absolute;inset:-14%;border-radius:50%;display:none;pointer-events:none;
   background:conic-gradient(var(--ic-lav) calc(var(--ic-k,1)*360deg), rgba(184,166,232,.14) 0);
-  -webkit-mask:radial-gradient(circle, transparent 0 82%, #000 84%);
-  mask:radial-gradient(circle, transparent 0 82%, #000 84%)}
+  -webkit-mask:radial-gradient(circle closest-side, transparent 0 82%, #000 84%);
+  mask:radial-gradient(circle closest-side, transparent 0 82%, #000 84%)}
 .g-ic-holdring.on{display:block;animation:g-ic-hold var(--ic-hold,2000ms) linear forwards}
 @keyframes g-ic-hold{from{--ic-k:1}to{--ic-k:0}}
 @supports not (background:conic-gradient(red calc(var(--x)*360deg),blue 0)){
@@ -112,7 +212,7 @@ export const STYLE_TEXT = `
   @keyframes g-ic-holdfade{from{opacity:1}to{opacity:.15}}}
 
 /* ------------------------------------------------------------ the flourish */
-.g-ic-flourish{position:absolute;inset:0;pointer-events:none;z-index:4;display:grid;place-items:center;overflow:hidden}
+.g-ic-flourish{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);width:0;height:0;pointer-events:none;z-index:4;display:grid;place-items:center;overflow:visible}
 .g-ic-flourish-img{width:34vmin;height:34vmin;object-fit:contain;opacity:0;
   animation:g-ic-spiralout 1s ease-out forwards}
 @keyframes g-ic-spiralout{0%{opacity:.9;transform:scale(.3) rotate(0)}
@@ -120,7 +220,7 @@ export const STYLE_TEXT = `
 
 /* --------------------------------------------------------------- the stamp */
 /* tracks the bubble: just clear of its crown, still inside the crater's mouth */
-.g-ic-stamp{position:absolute;left:50%;top:calc(50% - clamp(86px,11vmin,150px));transform:translateX(-50%);
+.g-ic-stamp{position:absolute;left:var(--ic-basin-x,50%);top:calc(var(--ic-basin-y,50%) - var(--ic-basin-d) * .79);transform:translateX(-50%);
   z-index:5;pointer-events:none;font-weight:800;letter-spacing:.14em;font-size:clamp(15px,2vmin,22px);
   color:var(--ic-ink);opacity:0;text-transform:uppercase}
 .g-ic-stamp.on{animation:g-ic-stampin .9s ease-out forwards}
@@ -132,9 +232,17 @@ export const STYLE_TEXT = `
 .g-ic-stamp.bad{color:#FF5A78;text-shadow:0 0 18px rgba(255,64,96,.6)}
 .g-ic-stamp.calm{color:var(--ic-lav)}
 
-/* -------------------------------------------------------------- the chrome */
-.g-ic-topline{position:absolute;left:18px;top:64px;z-index:5;pointer-events:none;
-  display:flex;gap:10px;align-items:baseline;opacity:.85}
+/* --------------------------------------------------------- THE LIT MACHINE */
+/* The topline: a small plate with a slow light crossing it, so the machine's
+   nameplate is never a dead label. */
+.g-ic-topline{position:absolute;left:18px;top:64px;z-index:5;pointer-events:none;overflow:hidden;
+  display:flex;gap:10px;align-items:baseline;opacity:.85;padding:3px 10px;border-radius:7px;
+  background:linear-gradient(180deg,rgba(20,20,44,.44),rgba(20,20,44,.14));
+  border:1px solid rgba(58,58,94,.5)}
+.g-ic-topline::after{content:"";position:absolute;top:0;bottom:0;width:34%;left:var(--ic-sweep,-45%);
+  pointer-events:none;background:linear-gradient(90deg,transparent,rgba(255,255,255,.11),transparent);
+  animation:g-ic-sweep 8s linear infinite}
+@keyframes g-ic-sweep{0%{--ic-sweep:-45%}55%,100%{--ic-sweep:135%}}
 .g-ic-topname{font-weight:700;letter-spacing:.12em;text-transform:uppercase;font-size:12px;color:var(--ic-lav)}
 .g-ic-topsub{font-size:11px;color:var(--ic-faint);letter-spacing:.06em}
 
@@ -143,20 +251,171 @@ export const STYLE_TEXT = `
   padding:14px 22px 16px;
   background:linear-gradient(180deg, transparent, rgba(8,8,20,.72) 60%)}
 .g-ic-hud.off{display:none}
+/* the machine's edge lamp: one hairline that breathes across the bottom strip */
+.g-ic-hud::before{content:"";position:absolute;left:22px;right:22px;top:0;height:1px;pointer-events:none;
+  background:linear-gradient(90deg,transparent,
+    rgba(184,166,232,calc(.10 + var(--ic-lamp,.55) * .45)) 20%,
+    rgba(255,105,180,calc(.16 + var(--ic-lamp,.55) * .62)) 50%,
+    rgba(184,166,232,calc(.10 + var(--ic-lamp,.55) * .45)) 80%, transparent);
+  animation:g-ic-lamp 4.6s ease-in-out infinite}
+@keyframes g-ic-lamp{0%,100%{--ic-lamp:.28}50%{--ic-lamp:1}}
 .g-ic-hud-cell{display:flex;flex-direction:column;gap:6px;min-width:120px}
-.g-ic-hud-mid{align-items:center;flex:1}
+/* the gleam rides the CELL, never .g-ic-score: casino.js owns that element's
+   transform and animation, and two owners on one node is a fight */
+.g-ic-hud-mid{align-items:center;flex:1;animation:g-ic-gleam 5.4s ease-in-out infinite}
+@keyframes g-ic-gleam{0%,100%{--ic-gleam:.16}50%{--ic-gleam:.44}}
 .g-ic-hud-right{align-items:flex-end}
 .g-ic-score-label,.g-ic-streak-label{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--ic-faint)}
-.g-ic-score{font-size:clamp(26px,4vmin,40px);font-weight:800;color:var(--ic-ink);
-  font-variant-numeric:tabular-nums;line-height:1;text-shadow:0 0 22px rgba(255,105,180,.3)}
+/* THE ODOMETER: one fixed-width slot per digit, so a transform punch on the
+   score can never reflow the number underneath it. BLOCK + text-align, not
+   flex, on purpose: the trickster deck writes a bare string over this node for
+   its stat flicker and reads the truth back, and a block box lays a raw text
+   node out in exactly the same place as the digit slots. */
+.g-ic-score{display:block;text-align:center;
+  font-size:clamp(26px,4vmin,40px);font-weight:800;color:var(--ic-ink);
+  font-variant-numeric:tabular-nums;line-height:1;
+  text-shadow:0 0 calc(12px + var(--ic-gleam,.22) * 30px) rgba(255,105,180,var(--ic-gleam,.22))}
+.g-ic-dig{display:inline-block;width:.62em;text-align:center;font-style:normal;
+  font-variant-numeric:tabular-nums}
 .g-ic-rt{font-size:11px;color:var(--ic-dim);font-variant-numeric:tabular-nums;min-height:14px}
 .g-ic-counter{font-size:11px;color:var(--ic-dim);letter-spacing:.06em}
-.g-ic-thread{width:150px;height:3px;border-radius:2px;background:rgba(184,166,232,.18);overflow:hidden}
-.g-ic-thread-fill{display:block;height:100%;border-radius:2px;background:var(--ic-pink);
+/* the film-strip thread: the fill advances, and its HEAD is a live lamp */
+.g-ic-thread{position:relative;width:150px;height:3px;border-radius:2px;background:rgba(184,166,232,.18)}
+.g-ic-thread-fill{display:block;position:relative;height:100%;border-radius:2px;background:var(--ic-pink);
   width:calc(var(--ic-prog,0)*100%);transition:width .4s ease}
-.g-ic-pips{display:flex;gap:6px}
-.g-ic-pip{width:9px;height:9px;border-radius:50%;background:rgba(184,166,232,.18);border:1px solid rgba(184,166,232,.3)}
-.g-ic-pip.on{background:var(--ic-pink);box-shadow:0 0 8px rgba(255,105,180,.7)}
+.g-ic-thread-fill::after{content:"";position:absolute;right:-2px;top:50%;width:6px;height:6px;
+  border-radius:50%;background:var(--ic-ink);pointer-events:none;
+  box-shadow:0 0 10px rgba(255,105,180,.95), 0 0 3px rgba(255,255,255,.8);
+  animation:g-ic-head 1.9s ease-in-out infinite}
+@keyframes g-ic-head{0%,100%{opacity:.55;transform:translateY(-50%) scale(.75)}
+  50%{opacity:1;transform:translateY(-50%) scale(1.25)}}
+/* THE METER SLOT: empty, and it stays empty. ctx.ceremonies.streakMeter fills
+   it with the SHELL's 10-segment meter (SYNTHESIS #10 - games skin it, never
+   fork it). The dashed rail is only what an unfilled slot looks like. */
+.g-ic-meter-slot{display:flex;align-items:center;justify-content:flex-end;
+  min-width:118px;min-height:12px;pointer-events:none}
+.g-ic-meter-slot:empty::after{content:"";display:block;width:112px;height:6px;border-radius:3px;
+  border:1px dashed rgba(184,166,232,.28);animation:g-ic-slotwait 3.6s ease-in-out infinite}
+@keyframes g-ic-slotwait{0%,100%{opacity:.35}50%{opacity:.8}}
+
+/* ----------------------------------------------------- THE CLASS RULES SHEET */
+/* Deck VI, Law IV: drawn, not told. Three vignettes, one way out. The sheet
+   itself takes NO pointer events (the bubble under it is not live yet, and
+   index.js binds inputs only after GO); the GO button re-enables them for
+   itself alone. */
+.g-ic-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(520px,90vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:22px 24px 20px;border-radius:16px;
+  background:linear-gradient(180deg,rgba(26,26,54,.94),rgba(14,14,32,.96));
+  border:1px solid var(--ic-line);
+  box-shadow:0 30px 80px rgba(0,0,0,.55), 0 0 44px rgba(255,105,180,.10)}
+.g-ic-hw-title{margin:0 0 8px;text-align:center;font-size:clamp(16px,2.4vmin,20px);
+  letter-spacing:.2em;text-transform:uppercase;color:var(--ic-pink);
+  text-shadow:0 0 22px rgba(255,105,180,.45)}
+.g-ic-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-ic-hw-row + .g-ic-hw-row{border-top:1px dashed rgba(58,58,94,.6)}
+.g-ic-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ic-dim)}
+.g-ic-hw-fig{flex:0 0 auto;display:flex;align-items:center;gap:9px;pointer-events:none}
+.g-ic-hw-scene{position:relative;display:block;width:74px;height:56px;flex:0 0 auto}
+
+/* 1 - the drop: mouth, falling light, dish, the pink bubble, the pop ring */
+.g-ic-hw-mouth{position:absolute;left:50%;top:0;width:30px;height:13px;transform:translateX(-50%);
+  border-radius:50%;background:linear-gradient(180deg,#0A0A1C,#2A2A50);
+  border:1px solid rgba(184,166,232,.35);
+  box-shadow:inset 0 -3px 6px rgba(0,0,0,.8), 0 0 12px rgba(184,166,232,.25)}
+.g-ic-hw-spark{position:absolute;left:50%;top:9px;width:9px;height:9px;border-radius:50%;
+  background:var(--ic-pink);opacity:0;box-shadow:0 0 12px rgba(255,105,180,.9);
+  animation:g-ic-hw-fall 2.6s cubic-bezier(.4,.1,.7,1) infinite}
+@keyframes g-ic-hw-fall{0%{opacity:0;transform:translate(-50%,0) scale(.4)}
+  12%{opacity:1;transform:translate(-50%,6px) scale(.7)}
+  40%{opacity:1;transform:translate(-50%,26px) scale(.85)}
+  46%,100%{opacity:0;transform:translate(-50%,28px) scale(.9)}}
+.g-ic-hw-dish{position:absolute;left:50%;bottom:2px;width:56px;height:20px;transform:translateX(-50%);
+  border-radius:50%;border:1px solid rgba(184,166,232,.3);
+  background:radial-gradient(60% 100% at 50% 0%, rgba(40,40,78,.95), rgba(14,14,32,.95));
+  box-shadow:inset 0 4px 10px rgba(0,0,0,.6)}
+.g-ic-hw-bub{position:absolute;left:50%;top:-6px;width:20px;height:20px;border-radius:50%;
+  box-shadow:0 0 14px rgba(255,105,180,.6);
+  background:radial-gradient(35% 32% at 36% 30%, rgba(255,255,255,.9), rgba(255,105,180,.95) 46%, rgba(190,50,120,.9));
+  animation:g-ic-hw-land 2.6s ease-out infinite}
+@keyframes g-ic-hw-land{0%,40%{opacity:0;transform:translate(-50%,0) scale(.2)}
+  48%{opacity:1;transform:translate(-50%,0) scale(1.12)}
+  74%{opacity:1;transform:translate(-50%,0) scale(1)}
+  84%,100%{opacity:0;transform:translate(-50%,0) scale(1.5)}}
+.g-ic-hw-ping{position:absolute;left:50%;top:-6px;width:20px;height:20px;border-radius:50%;
+  border:2px solid var(--ic-pink);opacity:0;animation:g-ic-hw-ping 2.6s ease-out infinite}
+@keyframes g-ic-hw-ping{0%,78%{opacity:0;transform:translate(-50%,0) scale(.9)}
+  82%{opacity:.9;transform:translate(-50%,0) scale(1)}
+  100%{opacity:0;transform:translate(-50%,0) scale(2.2)}}
+.g-ic-hw-tap{flex:0 0 auto;display:block}
+.g-ic-hw-tap.cap{min-width:42px;text-align:center;padding:6px 9px;border-radius:7px;
+  font-size:11px;letter-spacing:.06em;color:var(--ic-ink);
+  background:linear-gradient(180deg,var(--ic-panel),#1A1A32);
+  border:1px solid var(--ic-line);border-bottom-width:3px;box-shadow:0 2px 0 rgba(0,0,0,.45);
+  animation:g-ic-hw-press 2.6s ease-in-out infinite}
+@keyframes g-ic-hw-press{0%,72%{transform:translateY(0)}
+  80%{transform:translateY(2px)}92%,100%{transform:translateY(0)}}
+.g-ic-hw-tap.finger{position:relative;width:22px;height:32px}
+.g-ic-hw-tap.finger::before{content:"";position:absolute;left:50%;bottom:0;width:14px;height:20px;
+  transform:translateX(-50%);border-radius:8px 8px 5px 5px;
+  background:linear-gradient(180deg,var(--ic-lav),#6E5F9B);box-shadow:0 0 10px rgba(184,166,232,.35)}
+.g-ic-hw-tap.finger::after{content:"";position:absolute;left:50%;top:0;width:8px;height:8px;
+  border-radius:50%;background:var(--ic-ink);
+  animation:g-ic-hw-tapdot 2.6s ease-in-out infinite}
+@keyframes g-ic-hw-tapdot{0%,72%{opacity:.5;transform:translate(-50%,0) scale(.9)}
+  82%{opacity:1;transform:translate(-50%,5px) scale(1)}
+  92%,100%{opacity:.5;transform:translate(-50%,0) scale(.9)}}
+/* the speed bar: it drains while the bubble sits there. Speed IS the score. */
+.g-ic-hw-speed{position:relative;flex:0 0 auto;width:7px;height:44px;border-radius:4px;overflow:hidden;
+  background:rgba(184,166,232,.16);border:1px solid rgba(184,166,232,.3)}
+.g-ic-hw-speed i{position:absolute;left:0;right:0;top:0;display:block;
+  background:linear-gradient(180deg,var(--ic-gold),var(--ic-pink));
+  animation:g-ic-hw-drain 2.6s linear infinite}
+@keyframes g-ic-hw-drain{0%,10%{height:100%}70%{height:6%}72%,100%{height:0}}
+
+/* 2 - the X: the ring runs out and the hand does not move */
+.g-ic-hw-xbub{position:absolute;left:50%;top:50%;width:38px;height:38px;transform:translate(-50%,-50%);
+  border-radius:50%;box-shadow:0 0 16px rgba(255,64,96,.35);
+  background:radial-gradient(35% 32% at 36% 30%, rgba(255,255,255,.75), rgba(150,140,190,.7) 48%, rgba(60,55,100,.85))}
+.g-ic-hw-ring{position:absolute;inset:-6px;border-radius:50%;
+  background:conic-gradient(var(--ic-lav) calc(var(--ic-hk,1)*360deg), rgba(184,166,232,.14) 0);
+  -webkit-mask:radial-gradient(circle, transparent 0 78%, #000 80%);
+  mask:radial-gradient(circle, transparent 0 78%, #000 80%);
+  animation:g-ic-hw-hold 2.8s linear infinite}
+@keyframes g-ic-hw-hold{0%{--ic-hk:1}86%,100%{--ic-hk:0}}
+.g-ic-hw-cross{position:absolute;inset:16%;filter:drop-shadow(0 0 8px rgba(255,64,96,.8))}
+.g-ic-hw-cross i{position:absolute;left:50%;top:50%;width:74%;height:15%;border-radius:5px;
+  background:linear-gradient(180deg,#FF5A78,#D22B4E);border:1px solid rgba(255,255,255,.5)}
+.g-ic-hw-xa{transform:translate(-50%,-50%) rotate(45deg)}
+.g-ic-hw-xb{transform:translate(-50%,-50%) rotate(-45deg)}
+.g-ic-hw-nohand{position:relative;flex:0 0 auto;width:28px;height:32px}
+.g-ic-hw-nohand::before{content:"";position:absolute;left:50%;bottom:2px;width:14px;height:22px;
+  transform:translateX(-50%);border-radius:8px 8px 5px 5px;opacity:.72;
+  background:linear-gradient(180deg,#5A5480,#3A3560)}
+.g-ic-hw-nohand::after{content:"";position:absolute;left:50%;top:50%;width:32px;height:3px;border-radius:2px;
+  transform:translate(-50%,-50%) rotate(-38deg);background:#FF5A78;
+  box-shadow:0 0 10px rgba(255,64,96,.8);animation:g-ic-hw-bar 2.8s ease-in-out infinite}
+@keyframes g-ic-hw-bar{0%,100%{opacity:.55}50%{opacity:1}}
+
+/* 3 - the drift: it slides off the rim and costs nothing. No penalty glyph, on
+   purpose - the absence IS the lesson. */
+.g-ic-hw-pale{position:absolute;left:50%;top:-6px;width:19px;height:19px;border-radius:50%;
+  box-shadow:0 0 10px rgba(184,166,232,.28);
+  background:radial-gradient(35% 32% at 36% 30%, rgba(255,255,255,.55), rgba(184,166,232,.5) 48%, rgba(80,74,120,.5));
+  animation:g-ic-hw-drift 3.4s ease-in infinite}
+@keyframes g-ic-hw-drift{0%{opacity:0;transform:translate(-50%,0) scale(.3)}
+  14%,46%{opacity:1;transform:translate(-50%,0) scale(1)}
+  100%{opacity:0;transform:translate(calc(-50% + 30px),12px) scale(.7)}}
+
+/* the ONE way off the sheet */
+.g-ic-hw-go{align-self:center;margin-top:10px;padding:11px 34px;cursor:pointer;pointer-events:auto;
+  border-radius:999px;font-size:12.5px;font-weight:700;letter-spacing:.18em;text-transform:uppercase;
+  color:#fff;background:linear-gradient(135deg,var(--ic-pink),#B8367E);
+  border:1px solid var(--ic-pink);animation:g-ic-hw-go 2.2s ease-in-out infinite}
+@keyframes g-ic-hw-go{0%,100%{box-shadow:0 0 18px rgba(255,105,180,.32);transform:scale(1)}
+  50%{box-shadow:0 0 34px rgba(255,105,180,.62);transform:scale(1.03)}}
+.g-ic-hw-go:hover{box-shadow:0 0 40px rgba(255,105,180,.7)}
+.g-ic-hw-go:focus-visible{outline:2px solid var(--ic-ink);outline-offset:3px}
 
 /* --------------------------------------------------------------- the cards */
 .g-ic-break{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:6;
@@ -168,28 +427,65 @@ export const STYLE_TEXT = `
 .g-ic-break-note{margin:0 0 6px;color:var(--ic-ink);font-size:15px}
 .g-ic-break-hint{margin:0;color:var(--ic-faint);font-size:12.5px}
 
+/* ------------------------------------------------------------- THE TICKET */
+/* Deck V + VI: the debrief prints. Punched perforations top and bottom, one
+   slow light crawling the face, the backdrop still breathing behind it (the
+   scrim is translucent on purpose), and a bed where the grade lands as an
+   object. .is-dim is the losing class: less light, never none. */
 .g-ic-debrief{position:absolute;inset:0;z-index:7;display:grid;place-items:center;
   background:radial-gradient(80% 70% at 50% 42%, rgba(10,10,24,.55), rgba(8,8,20,.9));overflow:auto}
 .g-ic-paper{width:min(680px,92vw);border-radius:14px;padding:26px 30px;
   background:linear-gradient(180deg,#20203E,#1A1A32);border:1px solid var(--ic-line);
   box-shadow:0 30px 80px rgba(0,0,0,.5)}
+.g-ic-ticket{position:relative;overflow:hidden;
+  background:
+    repeating-linear-gradient(180deg, rgba(255,255,255,.022) 0 2px, transparent 2px 5px),
+    linear-gradient(180deg,#20203E,#1A1A32)}
+.g-ic-ticket::before,.g-ic-ticket::after{content:"";position:absolute;left:0;right:0;height:8px;
+  pointer-events:none;
+  background:radial-gradient(circle at 6px 4px, rgba(10,10,26,1) 3.4px, transparent 3.6px) 0 0/12px 8px repeat-x}
+.g-ic-ticket::before{top:0}
+.g-ic-ticket::after{bottom:0;transform:scaleY(-1)}
+.g-ic-ticket-sweep{position:absolute;top:0;bottom:0;width:26%;left:var(--ic-tk,-30%);
+  pointer-events:none;
+  background:linear-gradient(100deg,transparent,rgba(255,255,255,.055),transparent);
+  animation:g-ic-tsweep 9s linear infinite}
+@keyframes g-ic-tsweep{0%{--ic-tk:-30%}62%,100%{--ic-tk:130%}}
+.g-ic-ticket.is-dim .g-ic-ticket-sweep{opacity:.45}
+.g-ic-ticket.is-dim .g-ic-paper-score b{color:var(--ic-dim);text-shadow:0 0 14px rgba(255,105,180,.16)}
+.g-ic-ticket.is-perfect{border-color:rgba(240,194,75,.5);
+  box-shadow:0 30px 80px rgba(0,0,0,.5), 0 0 40px rgba(240,194,75,.16)}
+.g-ic-ticket.is-royal{border-color:var(--ic-gold);
+  box-shadow:0 30px 80px rgba(0,0,0,.5), 0 0 60px rgba(240,194,75,.34)}
+.g-ic-ticket.is-royal .g-ic-paper-score b{color:var(--ic-gold);text-shadow:0 0 30px rgba(240,194,75,.6)}
 .g-ic-paper-head{display:flex;align-items:baseline;justify-content:space-between;gap:12px;
   border-bottom:1px dashed var(--ic-line);padding-bottom:10px;margin-bottom:14px}
 .g-ic-paper-head h2{margin:0;font-size:18px;letter-spacing:.14em;text-transform:uppercase;color:var(--ic-lav)}
 .g-ic-paper-sub{color:var(--ic-faint);font-size:12px}
-.g-ic-paper-score{display:flex;align-items:baseline;gap:10px;margin-bottom:14px}
+.g-ic-paper-score{position:relative;display:flex;align-items:baseline;gap:10px;margin-bottom:14px}
 .g-ic-paper-score b{font-size:44px;color:var(--ic-ink);font-variant-numeric:tabular-nums;line-height:1;
   text-shadow:0 0 24px rgba(255,105,180,.35)}
 .g-ic-paper-score span{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--ic-faint)}
+/* THE STAMP BED: empty by contract - index.js drops ctx.ceremonies.stamp here */
+.g-ic-ticket-stamp{align-self:center;margin-left:auto;position:relative;pointer-events:none;
+  min-width:118px;min-height:46px;display:flex;align-items:center;justify-content:center;
+  border:1px dashed rgba(184,166,232,.26);border-radius:9px}
+.g-ic-ticket-stamp:empty{opacity:.5;animation:g-ic-slotwait 3.6s ease-in-out infinite}
 .g-ic-paper-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:14px}
 .g-ic-cell{background:rgba(10,10,26,.55);border:1px solid var(--ic-line);border-radius:10px;
   padding:10px 12px;display:flex;flex-direction:column;gap:3px}
 .g-ic-cell b{font-size:18px;color:var(--ic-ink);font-variant-numeric:tabular-nums}
 .g-ic-cell span{font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--ic-faint)}
 .g-ic-cell.good b{color:#7BD88F}.g-ic-cell.bad b{color:#FF5A78}.g-ic-cell.gold b{color:var(--ic-gold)}
-.g-ic-paper-line{margin:0 0 4px;color:var(--ic-dim);font-size:13px}
-.g-ic-paper-hint{margin:0 0 10px;color:var(--ic-faint);font-size:12px}
-.g-ic-paper-actions{display:flex;gap:10px;justify-content:flex-end;margin-top:8px;flex-wrap:wrap}
+.g-ic-paper-line{position:relative;margin:0 0 4px;color:var(--ic-dim);font-size:13px}
+.g-ic-paper-hint{position:relative;margin:0 0 10px;color:var(--ic-faint);font-size:12px}
+.g-ic-paper-actions{position:relative;display:flex;gap:10px;justify-content:flex-end;margin-top:8px;flex-wrap:wrap}
+/* one-more framing: submit is lit and breathing, the ghost is honest and live */
+.g-ic-submit{position:relative;animation:g-ic-submit 2.4s ease-in-out infinite}
+@keyframes g-ic-submit{0%,100%{box-shadow:0 0 16px rgba(255,105,180,.3)}
+  50%{box-shadow:0 0 32px rgba(255,105,180,.65)}}
+.g-ic-recal{opacity:.72}
+.g-ic-recal:hover{opacity:1}
 
 /* --------------------------------------------------------------- the shake */
 .g-ic.shake{animation:g-ic-shake .42s cubic-bezier(.36,.07,.19,.97)}
@@ -201,7 +497,11 @@ export const STYLE_TEXT = `
 @keyframes g-ic-redwash{from{opacity:1}to{opacity:0}}
 
 /* --------------------------------------------------- suspend + motion law */
+/* the blanket covers pseudo-elements too - half of the lit machine lives on
+   ::before / ::after, and a bare star selector would leave every one running */
 .g-ic.suspended *{animation-play-state:paused !important;transition:none !important}
+.g-ic.suspended,.g-ic.suspended::before,.g-ic.suspended::after,
+.g-ic.suspended *::before,.g-ic.suspended *::after{animation-play-state:paused !important}
 @media (prefers-reduced-motion: reduce){
   .g-ic-bg-img.on{animation:none}
   .g-ic-bubble.on{animation:none;transform:translate(-50%,-50%) scale(1)}
@@ -210,6 +510,21 @@ export const STYLE_TEXT = `
   .g-ic-flourish-img{animation-duration:.24s}
   .g-ic-stamp.on{animation-duration:.5s}
   .g-ic-tube-static{animation:none}
+  /* the lit machine and the ticket hold their pose */
+  .g-ic-hud::before,.g-ic-hud-mid,.g-ic-topline::after,.g-ic-thread-fill::after,
+  .g-ic-meter-slot:empty::after,.g-ic-ticket-sweep,.g-ic-ticket-stamp:empty,
+  .g-ic-submit{animation:none}
+  /* the sheet must still READ frozen: everything that only exists mid-keyframe
+     gets an explicit resting pose */
+  .g-ic-hw-spark,.g-ic-hw-bub,.g-ic-hw-ping,.g-ic-hw-tap.cap,.g-ic-hw-tap.finger::after,
+  .g-ic-hw-speed i,.g-ic-hw-ring,.g-ic-hw-nohand::after,.g-ic-hw-pale,
+  .g-ic-hw-go{animation:none}
+  .g-ic-hw-spark,.g-ic-hw-ping{opacity:0}
+  .g-ic-hw-bub,.g-ic-hw-pale{opacity:1;transform:translate(-50%,0) scale(1)}
+  .g-ic-hw-tap.finger::after{opacity:.85;transform:translate(-50%,0)}
+  .g-ic-hw-speed i{height:46%}
+  .g-ic-hw-ring{--ic-hk:.62}
+  .g-ic-hw-nohand::after{opacity:1}
 }
 `;
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/trickster.js
@@ -1,0 +1,906 @@
+/* ============================================================================
+ * games/impulse-control/trickster.js - DECK III of the House Rules, dealt into
+ * THE DROP TUBE. A reflex room has exactly one target and exactly one clock,
+ * so every card here attacks what the player READS on the way to that target -
+ * never the target, never the clock underneath.
+ *
+ *   THE TELL        (Fake Shuffle) the mouth's load glow takes a colour that
+ *                   HINTS the kind while the bubble is still inside the chute:
+ *                   pink for a good bubble, gold for the X. Tier 1-2 the tell
+ *                   is TRUTHFUL on every deal - the class teaches by telling
+ *                   the truth until you trust it. Tier 3+ the seeded plan
+ *                   spends card slots on LIES: the lamp shows the other
+ *                   colour. Never on the first two deals (schedule.js's
+ *                   TEACH_GOOD bubbles), never two lies back to back. The
+ *                   reveal, the window and the ledger are index.js's and
+ *                   exact; only the lamp lies.
+ *   THE CROOKED RING (Crooked Clock skin) on a denied reveal the visible hold
+ *                   ring's FACE bends: it races through the boring middle
+ *                   (shows less time left than you really have) and crawls as
+ *                   the two seconds run out, meeting the truth exactly at the
+ *                   last 15% and staying honest from there - so the hand
+ *                   itches early and the finish is never a lie. The real
+ *                   windowMs is index.js's timer and is untouched; this deck
+ *                   paints an overlay ring of its own over a hidden face and
+ *                   never writes `--ic-hold` or `--ic-k` (style.js's own
+ *                   semantics). The bend is a PURE function, exported.
+ *   GHOST CURSOR    a faint cursor echo trails the real pointer by ~430ms
+ *                   during a reveal, and on a DENIED reveal after a ~600ms
+ *                   stall it stops trailing and DRIFTS toward the bubble - the
+ *                   house leaning on your hand to pop the X. Pure suggestion:
+ *                   pointer-events none, it cannot click, the real cursor is
+ *                   never hidden, and it dies on the next event. Tier 2+,
+ *                   mouse pointers only (nothing to echo on a touch screen).
+ *   STAT FLICKER    the score chip briefly reads a few points off, then
+ *                   "corrects" with a static pop to the EXACT text it had.
+ *                   The ledger never moves; confidence does. Tier 3+. The
+ *                   casino's payout punch on the same chip is transform-only,
+ *                   so the two never collide - and if a real hud() repaint
+ *                   lands mid-lie, the restore stands down instead of
+ *                   stomping the truth.
+ *
+ * DEALING RULE: card slots are dealt at start() from the seeded plan against
+ * stats().total - budget 2/4/6/8 by tier, at least 4 bubbles apart (this class
+ * runs ~3.8s a bubble, so 4 apart is under the House's 4-a-minute cap; a wall
+ * clock guard enforces the minute directly as well), never in the first two
+ * deals, never during the debrief. A slot whose moment arrives halted is
+ * re-queued once and then folds. Tier 1 deals NOTHING: every card gates at
+ * tier 2 or 3, which is the point - the truthful tell is the whole of the
+ * first year.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - the tell paints a lamp this deck owns; the ring paints
+ *       a ring this deck owns; the flicker writes .g-ic-score TEXT and puts
+ *       back the exact string it read. Nothing here reads or writes score,
+ *       streak, the tally, the reveal window, the plan or the grade, and no
+ *       card can change WHEN index.js's window timer fires.
+ *   II  input honest  - the bubble is the one tap target and this deck never
+ *       touches it: every node lives in the deck's own layer inside
+ *       nodes.stage, pointer-events:none, and the layer is a sibling of the
+ *       basin, so nothing decorative can ever sit between a finger and the
+ *       bubble. The ghost cannot click. No card moves, resizes or delays it.
+ *   III never still   - the lamp breathes, the ghost pulses on the lure.
+ *   IV  images over text - this deck renders NO text and invents no lexicon
+ *       key (the flicker only re-digits a number the HUD already showed).
+ *   V   seeded        - per-tag mulberry32 streams off seed+'|ic-trickster',
+ *       append-only tags (a new tag never shifts an old stream; see the
+ *       lost-and-found header for why makeTaggedRoll clusters here). A retake
+ *       replays the identical deal.
+ *   VI  exits sacred  - capsOk false disarms the whole deck (no nodes, no
+ *       listener, no timers); reduced motion drops the ghost cursor AND the
+ *       crooked ring entirely (the tell is a colour and the flicker is a
+ *       number: neither is motion); every timer rides the game's registry via
+ *       opts.timers AND a local set, pause() cancels and restores every live
+ *       lie, resume() re-arms, destroy() leaves no node, timer or listener.
+ *   VII strings       - none. This file has no lexicon rows.
+ *
+ * ENGINE PLACEMENT: entirely game-local. All four cards are addressed to this
+ * class's own nodes (the chute mouth, the hold ring, the score chip, the
+ * basin's centre); the engine has no target contract for any of them, and the
+ * deck asks the engine for nothing. `opts.engine` is accepted for interface
+ * symmetry with casino.js / pressure.js and deliberately unused.
+ *
+ * THE STYLESHEET is a document-level singleton (`<style id="g-ic-trickster-
+ * style">`, style.js's ensureStyle pattern): injected once, never removed on
+ * destroy, exactly like the class's own sheet.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const IC_TRICKSTER = Object.freeze({
+  /** Dealt card slots per class, by tier (the House budget: 2 -> 8). */
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  /** Never in the first two deals - schedule.js's TEACH_GOOD bubbles. */
+  FIRST_DEAL_IDX: 2,
+  /** At least this many bubbles between cards (11-15s at this class's pace).
+   *  With ~22 bubbles in a 90s class this alone clips the tier-4 budget of 8
+   *  down to the ~5 slots that actually fit, which is the point. */
+  MIN_GAP_IDX: 4,
+  /** The House's per-minute cap, stated as the law says it: at most 4 fires in
+   *  any rolling 60s, plus a floor so two cards never land in one breath. */
+  RATE_WINDOW_MS: 60000,
+  RATE_MAX: 4,
+  MIN_GAP_MS: 4000,
+  /** A slot whose moment arrives halted waits for one more, then folds. */
+  RETRY_MAX: 1,
+
+  /** Card gates. The tell is truthful below LIE_FROM_TIER, never absent. */
+  RING_FROM_TIER: 2,
+  LIE_FROM_TIER: 3,
+  FLICK_FROM_TIER: 3,
+
+  /** Slot weights per tier, over the eligible cards only (renormalised). */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ lie: 0, ring: 0, flick: 0 }),
+    2: Object.freeze({ lie: 0, ring: 1, flick: 0 }),
+    3: Object.freeze({ lie: 0.4, ring: 0.32, flick: 0.28 }),
+    4: Object.freeze({ lie: 0.42, ring: 0.3, flick: 0.28 }),
+  }),
+
+  /** The crooked ring: how far the face runs ahead at mid-window, and the
+   *  honest tail (the last 15% is the truth, to the pixel). */
+  RING_BEND: 0.16,
+  RING_HONEST: 0.15,
+  RING_RAMP: 0.32,
+  /** How many stops the bend is baked into as CSS keyframes. */
+  RING_STOPS: 20,
+
+  /** Stat flicker: how long the wrong number stands, and how far off it is. */
+  FLICK_MS: 460,
+  FLICK_DELAY_MS: 140,
+  FLICK_MIN: 12,
+  FLICK_SPAN: 30,
+
+  /** The ghost: tier 2+, mouse only. */
+  GHOST_FROM_TIER: 2,
+  GHOST_TICK_MS: 90,
+  GHOST_TRAIL_MS: 430,
+  GHOST_STALL_MS: 600,
+  GHOST_LERP: 0.16,
+  GHOST_TRAIL_KEEP_MS: 2200,
+});
+
+const STYLE_ID = 'g-ic-trickster-style';
+
+/* ---------------------------------------------------------------- the bend */
+/**
+ * THE CROOKED RING'S FACE, pure.
+ *
+ * Given the TRUE remaining fraction of the hold window (1 at the reveal, 0 at
+ * the end), answer the fraction to PAINT. Properties, all asserted by the
+ * suite:
+ *   f(1) = 1, f(0) = 0                       - the ends never lie
+ *   f(r) = r for r <= honest                 - the last 15% is the truth
+ *   f(r) < r for honest < r < 1              - the middle races ahead
+ *   monotone non-decreasing in r             - the ring never runs backwards
+ * The bend fades IN above the honest zone (smoothstep ramp) so there is no
+ * seam where the face visibly re-joins the truth: it arrives, it does not snap.
+ * Monotonicity needs bend * pi < 1; the shipped 0.16 leaves plenty of room.
+ *
+ * @param {number} remain 0..1 true remaining fraction
+ * @param {number=} honest honest tail fraction (default RING_HONEST)
+ * @param {number=} bend   bend amplitude (default RING_BEND)
+ * @returns {number} 0..1 fraction to paint
+ */
+export function bendHoldFace(remain, honest, bend) {
+  const r = Number(remain);
+  if (!Number.isFinite(r)) return 0;
+  const x = r < 0 ? 0 : r > 1 ? 1 : r;
+  const H = Number.isFinite(honest) ? Math.max(0, Math.min(0.9, honest)) : IC_TRICKSTER.RING_HONEST;
+  if (x <= H || x >= 1) return x;
+  const A0 = Number.isFinite(bend) ? bend : IC_TRICKSTER.RING_BEND;
+  const ramp = Math.max(0, Math.min(1, (x - H) / IC_TRICKSTER.RING_RAMP));
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, x - A * Math.sin(Math.PI * x));
+}
+
+/** The bend, baked into CSS keyframes: elapsed 0..100% -> painted fraction. */
+function ringKeyframes() {
+  const n = IC_TRICKSTER.RING_STOPS;
+  const rows = [];
+  for (let i = 0; i <= n; i++) {
+    const e = i / n;                       // elapsed fraction
+    const k = bendHoldFace(1 - e);         // painted remaining fraction
+    rows.push(Math.round(e * 10000) / 100 + '%{--ic-tk-k:' + (Math.round(k * 1000) / 1000) + '}');
+  }
+  return '@keyframes g-ic-tk-hold{' + rows.join('') + '}';
+}
+
+export const STYLE_TEXT = `
+/* THE TRICKSTER LAYER. One layer, three nodes, all pointer-events:none, all
+   inside .g-ic so the class's own .suspended blanket freezes them. */
+@property --ic-tk-k { syntax: '<number>'; initial-value: 1; inherits: false; }
+@property --ic-tk-heat { syntax: '<number>'; initial-value: 0.2; inherits: true; }
+.g-ic-tk{position:absolute;inset:0;z-index:4;pointer-events:none;
+  --ic-tk-heat:.2;--ic-tk-lamp:rgba(255,105,180,.55)}
+.g-ic-tk *{pointer-events:none}
+
+/* THE TELL: the chute mouth is off-frame at the top, so its load glow spills
+   in over the frame's crown. Pink means a good bubble is coming. Gold means
+   the X. One of those two statements is sometimes a lie. */
+/* the bar at the very top edge is the lamp itself; the radial under it is the
+   light it throws into the room. A haze alone loses to a pink tube - the bar
+   is what makes pink-versus-gold readable at a glance. */
+.g-ic-tk-tell{position:absolute;left:50%;top:0;width:min(130vw,150vmin);height:38vmin;
+  transform:translateX(-50%);opacity:0;transition:opacity .3s ease;
+  background:
+    linear-gradient(180deg, var(--ic-tk-lamp) 0 1.2%, transparent 17%),
+    radial-gradient(58% 100% at 50% 0%, var(--ic-tk-lamp) 0%, transparent 76%);
+  filter:blur(5px)}
+.g-ic-tk-tell.on{animation:g-ic-tk-lamp 2.4s ease-in-out infinite alternate}
+@keyframes g-ic-tk-lamp{
+  from{opacity:calc(.42 + .30*var(--ic-tk-heat,.2))}
+  to{opacity:calc(.62 + .38*var(--ic-tk-heat,.2))}}
+
+/* THE CROOKED RING: the same geometry as .g-ic-holdring (the bubble's box
+   grown by its -14% inset), painted over a face that has been hidden. Its
+   keyframes ARE the bend function, sampled - so the face is CSS, freezes with
+   .suspended and costs no per-frame javascript. */
+/* CLOSEST-SIDE IS LOAD BEARING. A bare radial-gradient(circle, ...) sizes
+   itself farthest-corner, so on a SQUARE box the 82% stop lands at 0.82 of the
+   DIAGONAL - about 116% of the box's own radius - and the whole annulus falls
+   outside the element: the ring paints four invisible corner slivers and
+   nothing else. closest-side pins the gradient to the box's radius, which is
+   what a ring wants. (style.js's own .g-ic-holdring has the bare form; that is
+   STAGE's file and STAGE's call.) */
+.g-ic-tk-ring{position:absolute;left:var(--ic-basin-x,50%);top:var(--ic-basin-y,50%);
+  width:calc(var(--ic-basin-d, clamp(132px,17.5vmin,238px)) * 1.28);
+  height:calc(var(--ic-basin-d, clamp(132px,17.5vmin,238px)) * 1.28);
+  transform:translate(-50%,-50%);border-radius:50%;display:none;
+  background:conic-gradient(var(--ic-lav,#B8A6E8) calc(var(--ic-tk-k,1)*360deg), rgba(184,166,232,.16) 0);
+  -webkit-mask:radial-gradient(circle closest-side, transparent 0 82%, #000 84%);
+  mask:radial-gradient(circle closest-side, transparent 0 82%, #000 84%)}
+.g-ic-tk-ring.on{display:block;animation:g-ic-tk-hold var(--ic-tk-dur,2000ms) linear forwards}
+${ringKeyframes()}
+@supports not (background:conic-gradient(red calc(var(--x)*360deg),blue 0)){
+  .g-ic-tk-ring.on{display:none}}
+/* the real face steps aside while ours is up - and only while ours is up */
+.g-ic-holdring.g-ic-tk-bent{opacity:0}
+
+/* GHOST CURSOR: a will-o-wisp echo of the player's own hand. It cannot click,
+   it never hides the real cursor, and it dies on the next event. */
+.g-ic-tk-ghost{position:absolute;left:0;top:0;width:15px;height:19px;opacity:0;
+  will-change:transform;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, rgba(255,105,180,.9), rgba(184,166,232,.55));
+  filter:drop-shadow(0 0 6px rgba(255,105,180,.6));
+  transition:transform .34s ease-out, opacity .38s ease}
+.g-ic-tk-ghost.on{opacity:.3}
+.g-ic-tk-ghost.lure{opacity:.52;animation:g-ic-tk-ghostpulse 1.5s ease-in-out infinite}
+@keyframes g-ic-tk-ghostpulse{50%{filter:drop-shadow(0 0 12px rgba(255,105,180,.95))}}
+
+/* STAT FLICKER: the static pop the wrong number corrects itself with. */
+.g-ic-score.g-ic-tk-flick{text-shadow:0 0 22px rgba(184,166,232,.75), 0 0 3px rgba(255,255,255,.5);
+  animation:g-ic-tk-static .16s steps(3) 2}
+@keyframes g-ic-tk-static{0%{filter:none}40%{filter:brightness(1.5) contrast(1.4)}100%{filter:none}}
+
+@media (prefers-reduced-motion: reduce){
+  .g-ic-tk-tell.on{animation:none;opacity:calc(.5 + .34*var(--ic-tk-heat,.2))}
+  .g-ic-tk-ring.on{animation:none;display:none}
+  .g-ic-tk-ghost{display:none}
+  .g-ic-score.g-ic-tk-flick{animation:none}
+}
+`;
+
+/** Inject the deck's sheet once per document (style.js's pattern). */
+export function ensureTricksterStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head || !document.getElementById) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* an unstyled deck simply never shows */ }
+}
+
+/* ------------------------------------------------------------------ clock */
+/** Resolved at CALL time so the scratch harness's fake clock is honoured. */
+function nowMs() {
+  try {
+    if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') {
+      return performance.now();
+    }
+  } catch (e) { /* fall through */ }
+  return Date.now();
+}
+
+function clampTier(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+
+/** Coarse pointer probe (there is no cursor to echo on a touch screen). */
+function probeCoarse() {
+  try {
+    if (typeof window !== 'undefined' && window && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(pointer: coarse)');
+      return !!(m && m.matches);
+    }
+  } catch (e) { /* noop */ }
+  return false;
+}
+
+/**
+ * @param {Object} o
+ * @param {string}   o.seed        the class seed (retakes replay the deal)
+ * @param {number}   o.gradeTier   1..4
+ * @param {boolean}  o.reduced     reduced motion (ghost + ring off)
+ * @param {number=}  o.motionLevel 0..2 (0 is treated as reduced)
+ * @param {Object}   o.nodes       render.nodes (stage, basin, holdring, score...)
+ * @param {Object=}  o.engine      the deckEngine - accepted, deliberately unused
+ * @param {Object}   o.timers      deckTimers {after(ms,fn)->id, every(ms,fn)->id, clear(id)}
+ * @param {boolean|Function} o.capsOk  false (or ()=>false) disarms everything
+ * @param {Function} o.isHalted    () => bool (paused / suspended / ended)
+ * @param {Function} o.stats       () => {idx, total, streak, score, phase}
+ * @param {boolean=} o.coarse      touch pointer (else probed from matchMedia)
+ * @param {Function=} o.t          unused: this deck renders no text
+ * @param {Function=} o.log
+ */
+export function createIcTrickster(o) {
+  const opts = o || {};
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const nodes = opts.nodes || {};
+  const tier = clampTier(opts.gradeTier);
+  const motionOff = Number(opts.motionLevel) === 0;
+  const reduced = !!opts.reduced || motionOff;
+  const coarse = opts.coarse == null ? probeCoarse() : !!opts.coarse;
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const capsFn = typeof opts.capsOk === 'function' ? opts.capsOk : () => opts.capsOk !== false;
+  const capsOkNow = () => { try { return !!capsFn(); } catch (e) { return false; } };
+
+  const timers = opts.timers || null;
+  const armed = capsOkNow() && !!nodes.stage && !!timers && typeof timers.after === 'function'
+    && typeof document !== 'undefined';
+
+  /* timers: the game's registry (pause-aware, killed with the class) AND a
+     local set, so destroy() can never leak one the registry outlived. */
+  const live = new Set();
+  const chains = new Set();
+  const cancelFn = timers && (timers.clear || timers.cancel);
+  function after(ms, fn) {
+    if (!armed || destroyed) return 0;
+    let id = 0;
+    id = timers.after(ms, () => {
+      live.delete(id);
+      if (!destroyed) { try { fn(); } catch (e) { /* a cosmetic throw is not a class failure */ } }
+    });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(timers, id); } catch (e) { /* noop */ }
+  }
+  /** every(): the registry's if it has one, else a chain of after()s. */
+  function every(ms, fn) {
+    if (!armed || destroyed) return 0;
+    if (typeof timers.every === 'function') {
+      const id = timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* noop */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => {
+      if (!handle.on || destroyed) return;
+      try { fn(); } catch (e) { /* noop */ }
+      handle.id = after(ms, tick);
+    };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+
+  /* per-tag mulberry32 streams, append-only tags (Law V) */
+  const seedBase = String(opts.seed == null ? 'ic' : opts.seed) + '|ic-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  let destroyed = false;
+  let stopped = false;
+  let paused = false;
+  let started = false;
+  let heat = 0.2;
+  let plan = [];
+  let folded = 0;
+  let lastFireAt = -1e9;
+  const fires = [];             // wall times of spent cards (rolling minute)
+  const fired = { lie: 0, ring: 0, flick: 0, lure: 0, tell: 0 };
+
+  let layer = null;
+  let tellEl = null;
+  let ringEl = null;
+  let ghostEl = null;
+
+  /* ------------------------------------------------------------- the nodes */
+  const el = (tag, cls, parent) => {
+    try {
+      const n = document.createElement(tag);
+      if (!n) return null;
+      if (cls) n.className = cls;
+      if (parent && parent.appendChild) parent.appendChild(n);
+      return n;
+    } catch (e) { return null; }
+  };
+  const setCls = (n, cls, on) => {
+    try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ }
+  };
+
+  function build() {
+    ensureTricksterStyle();
+    layer = el('div', 'g-ic-tk', nodes.stage);
+    if (!layer) return false;
+    tellEl = el('i', 'g-ic-tk-tell', layer);
+    if (!reduced && tier >= IC_TRICKSTER.RING_FROM_TIER) ringEl = el('i', 'g-ic-tk-ring', layer);
+    return true;
+  }
+
+  /* ---------------------------------------------------------------- the plan */
+  function eligible() {
+    const out = [];
+    if (tier >= IC_TRICKSTER.LIE_FROM_TIER) out.push('lie');
+    if (tier >= IC_TRICKSTER.RING_FROM_TIER && !reduced) out.push('ring');
+    if (tier >= IC_TRICKSTER.FLICK_FROM_TIER) out.push('flick');
+    return out;
+  }
+
+  function pickCard(cards) {
+    const w = IC_TRICKSTER.WEIGHTS[tier] || IC_TRICKSTER.WEIGHTS[1];
+    let total = 0;
+    for (const c of cards) total += Math.max(0, Number(w[c]) || 0);
+    if (total <= 0) return cards[Math.floor(roll('card') * cards.length)] || cards[0];
+    let x = roll('card') * total;
+    for (const c of cards) {
+      x -= Math.max(0, Number(w[c]) || 0);
+      if (x <= 0) return c;
+    }
+    return cards[cards.length - 1];
+  }
+
+  /**
+   * Slots are BUBBLE INDICES, not wall times: this class is a metronome of
+   * deals, and an index is the only moment a card can attach to. Spacing is
+   * MIN_GAP_IDX bubbles (~15s here), which is also what keeps two tell lies
+   * from ever landing back to back.
+   */
+  function buildPlan() {
+    const cards = eligible();
+    const s = stats() || {};
+    const total = Math.max(0, Math.round(Number(s.total) || 0));
+    const budget = IC_TRICKSTER.DEALS[tier] || 0;
+    if (!cards.length || !budget || total <= IC_TRICKSTER.FIRST_DEAL_IDX) return [];
+    const first = IC_TRICKSTER.FIRST_DEAL_IDX;
+    const last = total - 1;
+    const span = last - first;
+    if (span < 0) return [];
+    const at = [];
+    for (let i = 0; i < budget; i++) at.push(first + Math.floor(roll('when') * (span + 1)));
+    at.sort((a, b) => a - b);
+    for (let i = 1; i < at.length; i++) {
+      if (at[i] - at[i - 1] < IC_TRICKSTER.MIN_GAP_IDX) at[i] = at[i - 1] + IC_TRICKSTER.MIN_GAP_IDX;
+    }
+    const out = [];
+    for (const a of at) {
+      if (a > last) break;
+      out.push({ at: a, card: pickCard(cards), used: false, tries: 0 });
+    }
+    /* belt and braces on "never two lies in a row": the spacing already makes
+       adjacent indices impossible, so this only ever fires if MIN_GAP_IDX is
+       ever tuned below 2. */
+    for (let i = 1; i < out.length; i++) {
+      if (out[i].card === 'lie' && out[i - 1].card === 'lie' && out[i].at - out[i - 1].at < 2) {
+        out[i].card = cards.indexOf('ring') >= 0 ? 'ring' : cards.indexOf('flick') >= 0 ? 'flick' : 'lie';
+      }
+    }
+    return out;
+  }
+
+  /** The first unused slot for this card at (exactly / at or before) an index. */
+  function slotFor(card, idx, atOrBefore) {
+    for (const slot of plan) {
+      if (slot.used || slot.card !== card) continue;
+      if (atOrBefore ? slot.at <= idx : slot.at === idx) return slot;
+    }
+    return null;
+  }
+
+  /** The House's gates on any card, at the moment it would fire. */
+  function canFire() {
+    if (!armed || destroyed || stopped || paused) return false;
+    if (!capsOkNow()) return false;
+    const s = stats();
+    if (s && s.phase === 'debrief') return false;
+    const t = nowMs();
+    if (t - lastFireAt < IC_TRICKSTER.MIN_GAP_MS) return false;
+    while (fires.length && t - fires[0] > IC_TRICKSTER.RATE_WINDOW_MS) fires.shift();
+    if (fires.length >= IC_TRICKSTER.RATE_MAX) return false;
+    return true;
+  }
+
+  /** A slot whose moment is wrong waits for one more, then folds. */
+  function requeue(slot, why) {
+    slot.tries += 1;
+    if (slot.tries > IC_TRICKSTER.RETRY_MAX) {
+      slot.used = true;
+      folded += 1;
+      say('trickster: ' + slot.card + '@' + slot.at + ' folded (' + why + ')');
+    }
+  }
+
+  function spend(slot) {
+    slot.used = true;
+    lastFireAt = nowMs();
+    fires.push(lastFireAt);
+  }
+
+  /* ------------------------------------------------------------- THE TELL */
+  let tellOn = false;
+  let tellLying = false;
+  let tellKind = null;      // the colour SHOWN, not the truth
+
+  function showTell(kindShown, lying) {
+    if (!tellEl || !capsOkNow()) return;
+    tellKind = kindShown;
+    tellLying = !!lying;
+    try {
+      tellEl.style.setProperty('--ic-tk-lamp',
+        kindShown === 'denied' ? 'rgba(247,201,78,.82)' : 'rgba(255,105,180,.8)');
+    } catch (e) { /* noop */ }
+    setCls(tellEl, 'on', true);
+    tellOn = true;
+    fired.tell += 1;
+  }
+  function hideTell() {
+    if (!tellOn) return;
+    setCls(tellEl, 'on', false);
+    tellOn = false;
+    tellLying = false;
+    tellKind = null;
+  }
+
+  /* ------------------------------------------------------ THE CROOKED RING */
+  let ringOn = false;
+
+  function bendRing(windowMs) {
+    if (!ringEl || reduced || !capsOkNow()) return false;
+    const ms = Math.max(200, Math.round(Number(windowMs) || 0) || 2000);
+    try {
+      ringEl.style.setProperty('--ic-tk-dur', ms + 'ms');
+      setCls(nodes.holdring, 'g-ic-tk-bent', true);
+      setCls(ringEl, 'on', false);
+      void (ringEl.offsetWidth);            // restart the baked bend
+      setCls(ringEl, 'on', true);
+    } catch (e) { return false; }
+    ringOn = true;
+    fired.ring += 1;
+    return true;
+  }
+  /** The face always comes back honest - on the outcome, a pause or a death. */
+  function straightenRing() {
+    if (!ringOn) return;
+    setCls(ringEl, 'on', false);
+    setCls(nodes.holdring, 'g-ic-tk-bent', false);
+    ringOn = false;
+  }
+
+  /* -------------------------------------------------------- STAT FLICKER */
+  let flickTimer = 0;
+  let flickPrev = null;     // the exact string the chip had
+  let flickLie = null;      // the exact string we wrote
+
+  function dealFlicker() {
+    const chip = nodes.score;
+    if (!chip || !capsOkNow()) return false;
+    let truth = null;
+    try { truth = chip.textContent; } catch (e) { return false; }
+    if (truth == null || !/\d/.test(String(truth))) return false;
+    const n = parseInt(String(truth).replace(/[^\d-]/g, ''), 10);
+    if (!Number.isFinite(n)) return false;
+    const sign = roll('flick-sign') < 0.5 ? -1 : 1;
+    const delta = sign * (IC_TRICKSTER.FLICK_MIN + Math.floor(roll('flick-mag') * IC_TRICKSTER.FLICK_SPAN));
+    const fake = Math.max(0, n + delta);
+    const lie = String(truth).replace(/\d[\d,\s]*/, String(fake));
+    if (lie === truth) return false;
+    try { chip.textContent = lie; } catch (e) { return false; }
+    flickPrev = String(truth);
+    flickLie = lie;
+    if (!reduced) setCls(chip, 'g-ic-tk-flick', true);
+    fired.flick += 1;
+    cancel(flickTimer);
+    flickTimer = after(IC_TRICKSTER.FLICK_MS, restoreFlicker);
+    return true;
+  }
+
+  /** The static pop. Restores the EXACT text read - and stands down if a real
+   *  hud() repaint already put the truth back while the lie was up. */
+  function restoreFlicker() {
+    flickTimer = 0;
+    const chip = nodes.score;
+    if (!chip) { flickPrev = null; flickLie = null; return; }
+    setCls(chip, 'g-ic-tk-flick', false);
+    try {
+      if (flickLie != null && chip.textContent === flickLie && flickPrev != null) {
+        chip.textContent = flickPrev;
+      }
+    } catch (e) { /* noop */ }
+    flickPrev = null;
+    flickLie = null;
+  }
+
+  /* --------------------------------------------------------- GHOST CURSOR */
+  let ghostTimer = 0;
+  let onMove = null;
+  let onLeave = null;
+  const trail = [];
+  let lastMoveAt = 0;
+  let gx = 0;
+  let gy = 0;
+  let ghostMode = 'off';      // off | trail | lure
+  let revealKind = null;      // the LIVE reveal's true kind, or null
+  let hovering = false;
+
+  function ghostEligible() {
+    return armed && !reduced && !coarse && tier >= IC_TRICKSTER.GHOST_FROM_TIER
+      && !!nodes.stage && typeof nodes.stage.addEventListener === 'function';
+  }
+
+  /** The bubble's centre, in stage coordinates. */
+  function basinPoint() {
+    try {
+      const target = nodes.basin || nodes.bubble;
+      const b = target.getBoundingClientRect();
+      const s = nodes.stage.getBoundingClientRect();
+      if (!b || !s) return null;
+      const x = b.left + b.width / 2 - s.left;
+      const y = b.top + b.height / 2 - s.top;
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+      return { x, y };
+    } catch (e) { return null; }
+  }
+
+  function ghostOff() {
+    if (ghostMode === 'off') return;
+    setCls(ghostEl, 'on', false);
+    setCls(ghostEl, 'lure', false);
+    ghostMode = 'off';
+  }
+
+  function ghostTick() {
+    if (!ghostEl || destroyed || stopped || paused) return;
+    if (!capsOkNow() || !revealKind || isHalted()) { ghostOff(); return; }
+    const t = nowMs();
+    const stalled = lastMoveAt > 0 && (t - lastMoveAt) >= IC_TRICKSTER.GHOST_STALL_MS;
+    const lure = revealKind === 'denied' && stalled && !hovering;
+    if (lure) {
+      const p = basinPoint();
+      if (p) {
+        gx += (p.x - gx) * IC_TRICKSTER.GHOST_LERP;
+        gy += (p.y - gy) * IC_TRICKSTER.GHOST_LERP;
+      }
+      if (ghostMode !== 'lure') { fired.lure += 1; ghostMode = 'lure'; }
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', true);
+    } else {
+      if (!trail.length || !lastMoveAt) { ghostOff(); return; }
+      let pt = trail[0];
+      for (const p of trail) { if (t - p.at >= IC_TRICKSTER.GHOST_TRAIL_MS) pt = p; else break; }
+      gx = pt.x; gy = pt.y;
+      ghostMode = 'trail';
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', false);
+    }
+    try {
+      ghostEl.style.transform = 'translate3d(' + gx.toFixed(1) + 'px,' + gy.toFixed(1) + 'px,0)';
+    } catch (e) { /* noop */ }
+    /* prune, but always keep the newest point: a stall must not erase the
+       hand's last known position out from under the lure handoff */
+    while (trail.length > 1 && t - trail[0].at > IC_TRICKSTER.GHOST_TRAIL_KEEP_MS) trail.shift();
+  }
+
+  function armGhost() {
+    if (!ghostEligible()) return;
+    ghostEl = el('i', 'g-ic-tk-ghost', layer);
+    if (!ghostEl) return;
+    onMove = (ev) => {
+      if (destroyed) return;
+      try {
+        const s = nodes.stage.getBoundingClientRect();
+        const x = Number(ev && ev.clientX) - s.left;
+        const y = Number(ev && ev.clientY) - s.top;
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+        lastMoveAt = nowMs();
+        trail.push({ x, y, at: lastMoveAt });
+      } catch (e) { /* no rects under the DOM double: the ghost simply sleeps */ }
+    };
+    onLeave = () => { hovering = false; };
+    try {
+      nodes.stage.addEventListener('pointermove', onMove);
+      nodes.stage.addEventListener('pointerleave', onLeave);
+    } catch (e) { /* noop */ }
+    ghostTimer = every(IC_TRICKSTER.GHOST_TICK_MS, ghostTick);
+    say('trickster: ghost armed');
+  }
+
+  function disarmGhost() {
+    if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+    try {
+      if (onMove && nodes.stage && nodes.stage.removeEventListener) {
+        nodes.stage.removeEventListener('pointermove', onMove);
+      }
+      if (onLeave && nodes.stage && nodes.stage.removeEventListener) {
+        nodes.stage.removeEventListener('pointerleave', onLeave);
+      }
+    } catch (e) { /* noop */ }
+    onMove = null;
+    onLeave = null;
+    ghostOff();
+  }
+
+  /** The reveal's theatre ends: the ring straightens, the ghost dies. The
+   *  flicker is NOT touched here - it runs on the slide, where the score chip
+   *  is static, and index.js's own next hud() repaint is what ends it. */
+  function endReveal() {
+    straightenRing();
+    ghostOff();
+    revealKind = null;
+  }
+
+  /** Everything honest, right now. pause / end / destroy only. */
+  function allHonest() {
+    endReveal();
+    if (flickTimer) { cancel(flickTimer); flickTimer = 0; }
+    restoreFlicker();
+  }
+
+  /** Every outcome ends the reveal's theatre. The flicker is dealt at the
+   *  LOAD (see load()), because the slide is the only stretch of this class
+   *  where the score chip stands still long enough to be misread. */
+  function outcome() {
+    if (!armed || destroyed || stopped || paused) return;
+    endReveal();
+    hideTell();
+  }
+
+  /* ------------------------------------------------------------------ api */
+  return {
+    /** Deal the class. index.js calls once, at the first deal. */
+    start() {
+      if (!armed || destroyed || started) { if (!armed) say('trickster: disarmed'); return; }
+      started = true;
+      if (!build()) { say('trickster: no layer'); return; }
+      plan = buildPlan();
+      armGhost();
+      say('trickster: dealt ' + plan.length + ' cards'
+        + (plan.length ? ' (' + plan.map((d) => d.card + '@' + d.at).join(', ') + ')' : '')
+        + ' tier ' + tier + (reduced ? ' reduced' : '') + (coarse ? ' coarse' : ''));
+    },
+
+    /** The one dial. Rides the lamp's brightness, nothing else. */
+    setHeat(h) {
+      const v = Number(h);
+      heat = Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : heat;
+      try { if (layer) layer.style.setProperty('--ic-tk-heat', String(Math.round(heat * 100) / 100)); }
+      catch (e) { /* noop */ }
+    },
+
+    /** A bubble is at the mouth: the tell lights, truthfully or not - and the
+     *  slide is where a stat flicker gets its quiet moment. */
+    load(e) {
+      if (!armed || destroyed || stopped || paused) return;
+      endReveal();
+      hideTell();
+      const ev = e || {};
+      const kind = ev.kind === 'denied' ? 'denied' : 'good';
+      const idx = Math.round(Number(ev.idx) || 0);
+      let lying = false;
+      if (tier >= IC_TRICKSTER.LIE_FROM_TIER && idx >= IC_TRICKSTER.FIRST_DEAL_IDX) {
+        const slot = slotFor('lie', idx, false);
+        if (slot) {
+          if (!canFire() || isHalted()) requeue(slot, 'halted');
+          else { spend(slot); lying = true; fired.lie += 1; say('trickster: the tell lies at ' + idx); }
+        }
+      }
+      showTell(lying ? (kind === 'denied' ? 'good' : 'denied') : kind, lying);
+
+      if (tier >= IC_TRICKSTER.FLICK_FROM_TIER && idx >= IC_TRICKSTER.FIRST_DEAL_IDX) {
+        const slot = slotFor('flick', idx, false);
+        if (slot) {
+          if (!canFire() || isHalted()) requeue(slot, 'halted');
+          else {
+            spend(slot);
+            /* let index.js's own deal-time hud() repaint land first, then lie
+               about the number it just wrote */
+            after(IC_TRICKSTER.FLICK_DELAY_MS, () => {
+              if (destroyed || stopped || paused || !capsOkNow() || isHalted()) return;
+              if (dealFlicker()) say('trickster: stat flicker at ' + idx);
+            });
+          }
+        }
+      }
+    },
+
+    /** The slide: the tell holds through it. Nothing else to do. */
+    slide() { /* the lamp is already lit; the chute keeps its own secret */ },
+
+    /** The reveal: the truth arrives, the lamp dies, the ring may bend. */
+    reveal(e) {
+      if (!armed || destroyed || stopped || paused) return;
+      const ev = e || {};
+      hideTell();
+      revealKind = ev.kind === 'denied' ? 'denied' : 'good';
+      hovering = false;
+      if (revealKind === 'denied') {
+        const idx = Math.round(Number(ev.idx) || 0);
+        const slot = slotFor('ring', idx, true);
+        if (slot) {
+          if (!canFire() || isHalted()) requeue(slot, 'halted');
+          else if (bendRing(ev.windowMs)) { spend(slot); say('trickster: crooked ring at ' + idx); }
+        }
+      }
+    },
+
+    pop() { outcome(); },
+    drift() { outcome(); },
+    denyPass() { outcome(); },
+    denyHit() { outcome(); },
+
+    /** The pointer is over the one target: the lure has done its work. */
+    hover(on) {
+      if (!armed || destroyed) return;
+      hovering = !!on;
+      if (hovering) lastMoveAt = nowMs();
+    },
+
+    /** The class is over: no card fires again, every lie comes off. */
+    end() {
+      stopped = true;
+      hideTell();
+      allHonest();
+      disarmGhost();
+    },
+
+    pause() {
+      if (paused) return;
+      paused = true;
+      if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+      hideTell();
+      allHonest();
+    },
+
+    resume() {
+      if (!paused) return;
+      paused = false;
+      if (!destroyed && !stopped && ghostEligible() && ghostEl && !ghostTimer) {
+        ghostTimer = every(IC_TRICKSTER.GHOST_TICK_MS, ghostTick);
+      }
+    },
+
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      for (const h of Array.from(chains)) stopEvery(h);
+      chains.clear();
+      /* the truth goes back on nodes this deck does not own, before it dies */
+      try { setCls(nodes.holdring, 'g-ic-tk-bent', false); } catch (e) { /* noop */ }
+      try {
+        const chip = nodes.score;
+        if (chip) {
+          setCls(chip, 'g-ic-tk-flick', false);
+          if (flickLie != null && chip.textContent === flickLie && flickPrev != null) chip.textContent = flickPrev;
+        }
+      } catch (e) { /* noop */ }
+      flickPrev = null; flickLie = null;
+      disarmGhost();
+      try { if (layer) layer.remove(); } catch (e) { /* noop */ }
+      layer = null; tellEl = null; ringEl = null; ghostEl = null;
+      trail.length = 0;
+      plan = [];
+    },
+
+    /** Diagnostics for the harness and the rig; not part of the contract. */
+    diagnostics() {
+      return {
+        armed, tier, reduced, coarse, heat,
+        plan: plan.map((d) => ({ at: d.at, card: d.card, used: d.used, tries: d.tries })),
+        fired: Object.assign({}, fired),
+        folded,
+        tell: { on: tellOn, shown: tellKind, lying: tellLying },
+        ring: { on: ringOn },
+        ghost: { armed: !!ghostEl, mode: ghostMode, trail: trail.length, lures: fired.lure },
+        flicker: { live: flickLie != null },
+        revealKind, paused, stopped, destroyed,
+      };
+    },
+  };
+}
+
+export default createIcTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
@@ -4,11 +4,33 @@
  * Same contract as tube3d.js, drawn on a 2D canvas: an opaque spiral ribbon
  * winding into a concave basin, a soft glow travelling the path, ring pulses on
  * reveal/pop. The 3D tier's living-material pass has a proportionate echo here:
- * the whole spiral slowly ROTATES (hypnotic by design), a dashed energy pass
- * marches along the ribbon toward the basin, good pops burst 2D particles, a
- * denyHit jolts the spin, flashes the ribbon red and briefly reverses the
- * march, and setMood() drifts the ribbon's lit color pink -> lavender (gold on
- * a hot streak) while speeding both motions up with class progress.
+ * the whole spiral slowly ROTATES (hypnotic by design), a NEON pass marches
+ * along the ribbon toward the basin, good pops burst 2D particles, a denyHit
+ * jolts the spin, flashes the ribbon red and briefly reverses the march, and
+ * setMood() pushes the pattern journey and quickens the hue cycle with the
+ * streak while speeding both motions up with class progress.
+ *
+ * THE PATTERN IS THE LIGHT, here too (House Rules pass, parity in spirit with
+ * tube3d.js): the ribbon body stays dark resin; the decoration riding it is
+ * bright saturated palette colour with a white-hot core. The same three
+ * FAMILIES exist at this tier's fidelity, every one of them built from dash
+ * trains on the ribbon's centre line and its two shoulders (one Path2D each,
+ * traced once per frame; Path2D absent = traced per stroke):
+ *   VEIN   a coloured dash train (rings / candy = long dashes / zigzag = the
+ *          train alternates shoulders / lace + runes = a bead train beside it /
+ *          eyes = big beads with a white pupil)
+ *   FIELD  dot trains on all three lines (polka = solid, bubbles = a dark dot
+ *          punched into each, sparkle = small dots with a twinkle)
+ *   GRID   staggered dash trains on the shoulders (fishnet = thin + a hairline
+ *          spine, diamond = thick + knots, checker = on == off blocks with the
+ *          two shoulders in opposite phase)
+ * The journey (4-6 stops, at least one FIELD/GRID, progress walks it, streak
+ * milestones push it, a broken streak pulls it back) and the palettes (seeded
+ * bold triads/quads, ~28% the classic violet->rose pair made bright) follow the
+ * 3D tier's rules. Within a family the parameters lerp; across families the
+ * two family passes crossfade by alpha over a seeded 1.8-2.8s. The hue cycle is
+ * a per-frame hue offset on the palette (bold palettes spin, the classic pair
+ * sways); colours are hsla() strings, so no colour math runs per frame.
  *
  * It carries the 3D tier's composition law too (see tube3d.js' header):
  *   MOUTH  the outer end is sized OFF-CANVAS from the viewport itself, so the
@@ -19,14 +41,16 @@
  *          It still never spirals into the centre: the opening halts short of
  *          it, the crater is what lives there, and the DOM bubble nests in it.
  *
- * SEEDED, like the 3D tier: the class seed picks this ribbon's hue pair (on
- * the violet->rose arc; gold/red stay semantic), its spin direction, its dash
- * temperament, and the period of a small COMET that forever patrols the ribbon
- * mouth->basin, dimming while a real load travels. Same seed, same ribbon.
+ * SEEDED, like the 3D tier: the class seed picks this ribbon's hue pair, its
+ * spin direction, its dash temperament, the period of a small COMET that
+ * forever patrols the ribbon mouth->basin (dimming while a real load travels),
+ * and - appended after those draws, so every ribbon keeps its Semester-1 base
+ * - its palette, cycle and journey. Same seed, same ribbon.
  *
  * When even a 2D context is unavailable (the DOM double, a hostile webview) it
  * degrades once more to a STATIC conic-gradient div - every method stays
- * callable and silent.
+ * callable and silent - and that div at least wears the seed's palette as
+ * inline spokes over style.js's dark conic base.
  * ==========================================================================*/
 
 import { makeRng } from '../../core/rng.js';
@@ -34,8 +58,9 @@ import { makeRng } from '../../core/rng.js';
 const HOLD = 0.86;         // t where the spiral stops shrinking - matches 3D
 const SQUASH = 0.8;        // the ground plane's foreshortening at this camera
 const RIM_F = 0.20;        // basin rim radius as a fraction of min(W,H)
-const BORE_F = 0.64;       // ribbon width as a fraction of the rim radius -
+const BORE_F = 0.80;       // ribbon width as a fraction of the rim radius -
                            // the same bore/rim ratio the 3D tier is built on
+                           // (TUBE_R 1.0 / R_IN 2.5; was 0.64 for the 0.8 bore)
 const GAP_F = 1.5;         // minimum coil pitch, in ribbon widths
 const OUT_F = 1.35;        // how far past the frame corner the mouth reaches
 
@@ -58,32 +83,100 @@ const SPIN_MAX = 0.17;
 const FLOW_BASE = 30;      // dash-march px/s at SCALE 1
 const FLOW_MAX = 85;
 
+/* THE PATTERN SPACE at this tier: dash trains. on/off are in ribbon widths;
+   shoulder 0 = centre line only, 1 = both shoulders, alternate = the colours
+   take turns between shoulders; beads = a dot train beside the main one. */
+const ARCHETYPES = {
+  rings:   { fam: 'vein', on: 0.30, off: 0.70, w: 0.20, shoulder: 0, alt: 0, bead: 0,    eye: 0 },
+  chevron: { fam: 'vein', on: 0.34, off: 0.66, w: 0.18, shoulder: 1, alt: 0, bead: 0,    eye: 0 },
+  lace:    { fam: 'vein', on: 0.22, off: 0.78, w: 0.14, shoulder: 0, alt: 0, bead: 0.16, eye: 0 },
+  waves:   { fam: 'vein', on: 0.40, off: 0.60, w: 0.16, shoulder: 1, alt: 1, bead: 0,    eye: 0 },
+  eyes:    { fam: 'vein', on: 0.16, off: 0.84, w: 0.12, shoulder: 0, alt: 0, bead: 0,    eye: 0.34 },
+  runes:   { fam: 'vein', on: 0.18, off: 0.50, w: 0.16, shoulder: 0, alt: 0, bead: 0.10, eye: 0 },
+  candy:   { fam: 'vein', on: 0.85, off: 0.85, w: 0.30, shoulder: 0, alt: 0, bead: 0,    eye: 0 },
+  zigzag:  { fam: 'vein', on: 0.26, off: 0.52, w: 0.15, shoulder: 1, alt: 1, bead: 0,    eye: 0 },
+  polka:   { fam: 'field', dot: 0.26, gap: 0.9, hollow: 0, twinkle: 0 },
+  bubbles: { fam: 'field', dot: 0.24, gap: 1.0, hollow: 1, twinkle: 0 },
+  sparkle: { fam: 'field', dot: 0.13, gap: 0.6, hollow: 0, twinkle: 1 },
+  fishnet: { fam: 'grid', on: 0.35, off: 0.35, w: 0.07, knot: 0,    spine: 1 },
+  diamond: { fam: 'grid', on: 0.45, off: 0.45, w: 0.12, knot: 0.14, spine: 0 },
+  checker: { fam: 'grid', on: 0.60, off: 0.60, w: 0.30, knot: 0,    spine: 0 },
+};
+const FAM_KEYS = {
+  vein:  ['on', 'off', 'w', 'shoulder', 'alt', 'bead', 'eye'],
+  field: ['dot', 'gap', 'hollow', 'twinkle'],
+  grid:  ['on', 'off', 'w', 'knot', 'spine'],
+};
+/* the same bold pool as tube3d.js ([hue, sat, light]); index 0 leads */
+const PALETTES = [
+  { name: 'neon',   cols: [[312, 1, 0.58], [186, 1, 0.56], [84, 1, 0.58]] },
+  { name: 'royal',  cols: [[46, 1, 0.60], [268, 1, 0.66], [0, 0, 0.96]] },
+  { name: 'sunset', cols: [[338, 1, 0.62], [168, 0.9, 0.56], [36, 1, 0.60]] },
+  { name: 'candy',  cols: [[326, 1, 0.60], [222, 1, 0.62], [0, 0, 0.95]] },
+  { name: 'acid',   cols: [[76, 1, 0.55], [276, 1, 0.62], [336, 1, 0.58]] },
+  { name: 'ice',    cols: [[188, 1, 0.66], [262, 1, 0.80], [0, 0, 0.97]] },
+  { name: 'ember',  cols: [[22, 1, 0.58], [46, 1, 0.60], [312, 1, 0.58]] },
+  { name: 'ultra',  cols: [[282, 1, 0.62], [150, 1, 0.55], [52, 1, 0.62], [196, 1, 0.60]] },
+];
+const ARC_CHANCE = 0.28;
+
 export function createTube2D(opts = {}) {
   const mount = opts.mount;
   const reduced = !!opts.reduced;
 
-  /* the ribbon's seeded identity - mirrors the 3D tier's ranges */
+  /* the ribbon's seeded identity - mirrors the 3D tier's ranges. Draws in a
+     FIXED order: the Semester-1 six first, the House Rules draws appended. */
   const rng = makeRng(String(opts.seed == null ? 'tube' : opts.seed) + '|tube2d');
-  const hsl2rgb = (h, s, l) => {
-    const f = (n) => {
-      const k = (n + h / 30) % 12;
-      const a = s * Math.min(l, 1 - l);
-      return Math.round(255 * (l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))));
-    };
-    return f(0) + ',' + f(8) + ',' + f(4);
-  };
   const ID = (() => {
     const hue = 285 + rng() * 55;
     const hue2 = Math.max(262, Math.min(345, hue + (rng() < 0.5 ? -1 : 1) * (18 + rng() * 22)));
-    return {
-      rgbA: hsl2rgb(hue, 0.92, 0.67),           // class-open pole
-      rgbB: hsl2rgb(hue2, 0.62, 0.72),          // class-close pole
-      spinSign: rng() < 0.3 ? -1 : 1,
-      dashOn: 0.24 + rng() * 0.2,               // dash/gap temperament (of BORE)
-      dashOff: 0.5 + rng() * 0.35,
-      cometPeriod: 7 + rng() * 4,
-    };
+    const spinSign = rng() < 0.3 ? -1 : 1;
+    const dashOn = 0.24 + rng() * 0.2;            // legacy temperament (scales on/off)
+    const dashOff = 0.5 + rng() * 0.35;
+    const cometPeriod = 7 + rng() * 4;
+    /* ---- APPENDED (House Rules pass) ---- */
+    let palette, cycleMode;
+    if (rng() < ARC_CHANCE) {
+      palette = [[hue, 1, 0.66], [hue2, 1, 0.70], [0, 0, 0.96]]; cycleMode = 'sway';
+    } else {
+      const p = PALETTES[Math.min(PALETTES.length - 1, Math.floor(rng() * PALETTES.length))];
+      palette = p.cols.map((c) => c.slice()); cycleMode = 'spin';
+    }
+    const rot = Math.floor(rng() * palette.length) % palette.length;
+    palette = palette.slice(rot).concat(palette.slice(0, rot));
+    const cycleBase = 6.2832 / (45 + rng() * 40);
+    const cycleSign = rng() < 0.5 ? -1 : 1;
+    const nStops = 4 + Math.floor(rng() * 3);
+    const pool = Object.keys(ARCHETYPES).sort();
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.min(i, Math.floor(rng() * (i + 1)));
+      const sw = pool[i]; pool[i] = pool[j]; pool[j] = sw;
+    }
+    const picked = pool.slice(0, nStops);
+    if (!picked.some((k) => ARCHETYPES[k].fam !== 'vein')) {
+      const alt = pool.slice(nStops).find((k) => ARCHETYPES[k].fam !== 'vein');
+      if (alt) picked[nStops - 1] = alt;
+    }
+    const tempo = (dashOn + dashOff) / 0.975;     // the legacy temperament, ~0.76..1.1
+    const stops = picked.map((k) => {
+      const base = ARCHETYPES[k];
+      const out = { key: k, fam: base.fam };
+      for (const f of FAM_KEYS[base.fam]) out[f] = base[f];
+      const j1 = rng(), j2 = rng();
+      if (base.fam === 'vein' || base.fam === 'grid') {
+        out.on *= tempo * (0.85 + j1 * 0.3);
+        out.off *= tempo * (0.85 + j2 * 0.3);
+      } else {
+        out.dot *= 0.85 + j1 * 0.3;
+        out.gap *= tempo * (0.85 + j2 * 0.3);
+      }
+      return out;
+    });
+    const morphT = 4.5 + rng() * 2.5;
+    const xfadeT = 1.8 + rng() * 1.0;
+    return { spinSign, cometPeriod, palette, cycleMode, cycleBase, cycleSign, stops, morphT, xfadeT };
   })();
+  const PAL = ID.palette, PAL_N = PAL.length;
 
   /* ------------------------------------------------ static (last resort) */
   function staticTube() {
@@ -91,6 +184,20 @@ export function createTube2D(opts = {}) {
       if (mount && typeof document !== 'undefined' && document.createElement) {
         const div = document.createElement('div');
         div.className = 'g-ic-tube-static';
+        /* the palette at least: thin bright spokes over the dark conic base
+           style.js paints (inline beats the stylesheet; the mask stays) */
+        try {
+          const spoke = (c) => 'hsl(' + Math.round(c[0]) + ',' + Math.round(c[1] * 100) + '%,' + Math.round(c[2] * 100) + '%)';
+          let conic = 'repeating-conic-gradient(from 0deg';
+          const step = 36 / PAL_N;
+          for (let k = 0; k < PAL_N; k++) {
+            const a0 = k * step;
+            conic += ', ' + spoke(PAL[k]) + ' ' + a0.toFixed(1) + 'deg ' + (a0 + 2.2).toFixed(1) + 'deg'
+              + ', rgba(30,30,58,.9) ' + (a0 + 2.2).toFixed(1) + 'deg ' + (a0 + step).toFixed(1) + 'deg';
+          }
+          conic += ')';
+          div.style.background = 'radial-gradient(circle at 50% 50%, rgba(8,8,22,.95) 0 12%, transparent 13%), ' + conic;
+        } catch (e) { /* the stylesheet's base look is fine */ }
         mount.appendChild(div);
       }
     } catch (e) { /* noop */ }
@@ -111,6 +218,7 @@ export function createTube2D(opts = {}) {
     if (!g) return staticTube();
     mount.appendChild(canvas);
   } catch (e) { return staticTube(); }
+  const HAS_P2D = (typeof Path2D === 'function');
 
   /* Ghost sprite (best effort). */
   let ghostImg = null;
@@ -152,15 +260,17 @@ export function createTube2D(opts = {}) {
      Radius falls LINEARLY to the rim then HOLDS, so the last stretch is a level
      ring around the basin instead of a dive into the centre. `spin` rotates the
      whole spiral; the ghost uses the same at() so the load stays sealed to the
-     ribbon under rotation. */
+     ribbon under rotation. `dr` offsets the radius - the ribbon's shoulders. */
   let spin = 0;
-  function at(t) {
+  function at(t, dr) {
+    dr = dr || 0;
     const aEnd = -Math.PI * 0.5 + spin + TURNS * Math.PI * 2;
     if (t > MOUTH_T) {
       /* the peel: one cubic Hermite from the ring's pose (position + its own
          tangent, so no kink) to the opening's pose (just inside the rim, tangent
          pointing dead at the centre). The s->u ease keeps the ribbon's speed
-         continuous across the seam and lets the load settle into the mouth. */
+         continuous across the seam and lets the load settle into the mouth.
+         The shoulders converge into the opening (dr fades out over the peel). */
       const s = Math.min(1, (t - MOUTH_T) / (1 - MOUTH_T));
       const u = s * (2 - s);
       const u2 = u * u, u3 = u2 * u;
@@ -169,18 +279,39 @@ export function createTube2D(opts = {}) {
       const aM = aEnd + MOUTH_SWEEP;
       const cE = Math.cos(aEnd), sE = Math.sin(aEnd);
       const cM = Math.cos(aM), sM = Math.sin(aM);
-      const px = h00 * (cE * RIM) + h10 * (-sE * RIM * MOUTH_L0)
+      const R0 = RIM + dr * (1 - u);
+      const px = h00 * (cE * R0) + h10 * (-sE * RIM * MOUTH_L0)
                + h01 * (cM * RIM * MOUTH_F) + h11 * (-cM * RIM * MOUTH_L1);
-      const py = h00 * (sE * RIM) + h10 * (cE * RIM * MOUTH_L0)
+      const py = h00 * (sE * R0) + h10 * (cE * RIM * MOUTH_L0)
                + h01 * (sM * RIM * MOUTH_F) + h11 * (-sM * RIM * MOUTH_L1);
       return { x: CX + px, y: CY + py * SQUASH + RIM * MOUTH_DIP * u };
     }
     const tt = t / MOUTH_T;
     const a = -Math.PI * 0.5 + spin + tt * TURNS * Math.PI * 2;
     const k = Math.min(1, tt / HOLD);
-    const r = RIM + (ROUT - RIM) * (1 - k);
+    const r = RIM + (ROUT - RIM) * (1 - k) + dr;
     const lift = Math.pow(1 - k, 1.8) * RIM * 0.55;   // the outer coils ride high
     return { x: CX + Math.cos(a) * r, y: CY + Math.sin(a) * r * SQUASH - lift };
+  }
+
+  /* the ribbon's three lines, traced ONCE per frame (Path2D) and stroked as
+     many times as the pattern needs. shoulder k = -1 / 0 / +1. */
+  const pathCache = [null, null, null];
+  function trace(target, k) {
+    const dr = k * BORE * 0.27;
+    for (let i = 0; i <= 220; i++) {
+      const q = at(i / 220, dr);
+      if (i === 0) target.moveTo(q.x, q.y); else target.lineTo(q.x, q.y);
+    }
+  }
+  function strokeLine(k) {
+    if (HAS_P2D) {
+      let p = pathCache[k + 1];
+      if (!p) { p = new Path2D(); trace(p, k); pathCache[k + 1] = p; }
+      g.stroke(p);
+    } else {
+      g.beginPath(); trace(g, k); g.stroke();
+    }
   }
 
   let travel = null, rimBoost = 0, mouthBoost = 0, clock = 0;
@@ -200,11 +331,127 @@ export function createTube2D(opts = {}) {
   let cometT = rng();      // start mid-patrol, seeded
   let cometLevel = 0;
 
-  function litColor(alpha) {
+  /* the journey walk + the hue wheel (same rules as tube3d.js) */
+  const STOPS_N = ID.stops.length;
+  let jPos = 0, jTarget = 0, advance = 0, milestone = 0, lastStreak = 0;
+  let hueAng = 0, swayPh = 0;   // degrees; swayPh = the sway's own phase
+  const P_CUR = {};
+  const smooth = (u) => (u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u));
+  function retarget() {
+    const raw = mood.progress * (STOPS_N - 1) + advance;
+    jTarget = Math.max(0, Math.min(STOPS_N - 1, Math.round(raw)));
+  }
+
+  /* colours: hsla strings off the palette + the hue offset; gold on a hot
+     streak and red on a denyHit are semantic overrides, like the 3D tier */
+  function ink(k, alpha) {
     if (redFlash > 0.12) return 'rgba(255,64,96,' + alpha + ')';
-    if (mood.streak >= 5) return 'rgba(240,194,75,' + alpha + ')';
-    /* the seed's two poles trade places across the class, like the 3D tier */
-    return 'rgba(' + (mood.progress > 0.5 ? ID.rgbB : ID.rgbA) + ',' + alpha + ')';
+    const c = PAL[((k % PAL_N) + PAL_N) % PAL_N];
+    const h = (((c[0] + hueAng) % 360) + 360) % 360;
+    return 'hsla(' + h.toFixed(0) + ',' + Math.round(c[1] * 100) + '%,' + Math.round(c[2] * 100) + '%,' + alpha + ')';
+  }
+  /* the white-hot cores turn GOLD on a hot streak - the 2D echo of the 3D
+     tier's gold tint; the palette colours themselves stay honest */
+  const WHITE_HOT = (a) => (mood.streak >= 5 ? 'rgba(255,214,90,' : 'rgba(255,255,255,') + a + ')';
+  function litColor(alpha) { return ink(0, alpha); }
+
+  /* ------------------------------------------------ the pattern painters
+     Every painter strokes dash trains over the ribbon lines. period = on+off
+     in px; a train of PAL_N colours is PAL_N strokes with the dash phase
+     stepped by one period each, so the colours take turns along the line. */
+  function dashTrain(k, onPx, offPx, width, alpha, phase, whiteCore) {
+    const period = onPx + offPx;
+    const full = period * PAL_N;
+    for (let c = 0; c < PAL_N; c++) {
+      g.setLineDash([onPx, full - onPx]);
+      g.lineDashOffset = flowOff + phase + c * period;
+      g.strokeStyle = ink(c, alpha); g.lineWidth = width;
+      strokeLine(k);
+    }
+    if (whiteCore > 0) {
+      g.setLineDash([onPx, offPx]);
+      g.lineDashOffset = flowOff + phase;
+      g.strokeStyle = WHITE_HOT(alpha * whiteCore); g.lineWidth = Math.max(1, width * 0.34);
+      strokeLine(k);
+    }
+    g.setLineDash([]);
+  }
+  function dotTrain(k, radPx, gapPx, alpha, phase, hollow, twinkle, colShift) {
+    const period = radPx * 2 + gapPx;
+    const full = period * PAL_N;
+    for (let c = 0; c < PAL_N; c++) {
+      const tw = twinkle > 0 ? 1 - twinkle * 0.5 * (0.5 + 0.5 * Math.sin(clock * 5 + c * 2.1 + k)) : 1;
+      g.setLineDash([0.01, full - 0.01]);
+      g.lineDashOffset = flowOff + phase + c * period;
+      g.strokeStyle = ink(c + colShift, alpha * tw); g.lineWidth = radPx * 2;
+      strokeLine(k);
+      if (hollow > 0.01) {
+        g.strokeStyle = 'rgba(24,24,50,' + (alpha * hollow) + ')'; g.lineWidth = radPx * 1.1;
+        strokeLine(k);
+      }
+      g.strokeStyle = WHITE_HOT(alpha * tw * 0.85 * (1 - hollow * 0.6)); g.lineWidth = Math.max(1, radPx * 0.5);
+      strokeLine(k);
+    }
+    g.setLineDash([]);
+  }
+  function paintVein(P, a) {
+    const on = BORE * P.on, off = BORE * P.off, w = BORE * P.w + 1.5;
+    if (P.shoulder < 0.5) {
+      dashTrain(0, on, off, w, a, 0, 0.8);
+    } else if (P.alt > 0.5) {
+      /* the train alternates shoulders: colour c rides +1 when c is even */
+      const period = on + off, full = period * PAL_N;
+      for (let c = 0; c < PAL_N; c++) {
+        g.setLineDash([on, full - on]); g.lineDashOffset = flowOff + c * period;
+        g.strokeStyle = ink(c, a); g.lineWidth = w;
+        strokeLine((c & 1) ? -1 : 1);
+        g.strokeStyle = WHITE_HOT(a * 0.7); g.lineWidth = Math.max(1, w * 0.34);
+        strokeLine((c & 1) ? -1 : 1);
+      }
+      g.setLineDash([]);
+    } else {
+      dashTrain(1, on, off, w, a, 0, 0.7);
+      dashTrain(-1, on, off, w, a, (on + off) * 0.5, 0.7);
+    }
+    if (P.bead > 0.01) dotTrain(1, BORE * P.bead * 0.5 + 1, on + off - BORE * P.bead, a, (on + off) * 0.5, 0, 0, 2);
+    if (P.eye > 0.01) dotTrain(0, BORE * P.eye * 0.5, on + off, a, on * 0.5, 0, 0, 1);
+  }
+  function paintField(P, a) {
+    const rad = BORE * P.dot * 0.5 + 1, gap = BORE * P.gap;
+    const period = rad * 2 + gap;
+    dotTrain(0, rad, gap, a, 0, P.hollow, P.twinkle, 0);
+    dotTrain(1, rad * 0.85, gap, a, period * 0.5, P.hollow, P.twinkle, 1);
+    dotTrain(-1, rad * 0.85, gap, a, period * 0.5, P.hollow, P.twinkle, 2);
+  }
+  function paintGrid(P, a) {
+    const on = BORE * P.on, off = BORE * P.off, w = BORE * P.w + 1;
+    dashTrain(1, on, off, w, a, 0, P.w > 0.1 ? 0.6 : 0);
+    dashTrain(-1, on, off, w, a, on, P.w > 0.1 ? 0.6 : 0);
+    if (P.spine > 0.01) {
+      g.strokeStyle = ink(2, a * P.spine * 0.7); g.lineWidth = Math.max(1, w * 0.6);
+      strokeLine(0);
+    }
+    if (P.knot > 0.01) dotTrain(0, BORE * P.knot * 0.5 + 1, on + off - BORE * P.knot, a, on * 0.5, 0, 0, 2);
+  }
+  function paintStop(S, P, a) {
+    if (S.fam === 'vein') paintVein(P, a);
+    else if (S.fam === 'field') paintField(P, a);
+    else paintGrid(P, a);
+  }
+  function paintPattern(alphaBase) {
+    const n = STOPS_N;
+    let i = Math.floor(jPos);
+    if (i >= n - 1) i = n - 2;
+    if (i < 0) i = 0;
+    const A = ID.stops[i], B = ID.stops[Math.min(n - 1, i + 1)];
+    const ws = n > 1 ? smooth(Math.max(0, Math.min(1, jPos - i))) : 0;
+    if (A.fam === B.fam) {
+      for (const f of FAM_KEYS[A.fam]) P_CUR[f] = A[f] + (B[f] - A[f]) * ws;
+      paintStop(A, P_CUR, alphaBase);
+    } else {
+      if (ws < 0.995) paintStop(A, A, alphaBase * (1 - ws));
+      if (ws > 0.005) paintStop(B, B, alphaBase * ws);
+    }
   }
 
   function draw(dt) {
@@ -215,6 +462,25 @@ export function createTube2D(opts = {}) {
     flowOff -= flowSpeed * SCALE * 0.12 * flowDir * dt;
     redFlash *= Math.pow(0.02, dt);
     shakeT = Math.max(0, shakeT - dt);
+    pathCache[0] = pathCache[1] = pathCache[2] = null;   // the spin moved
+
+    /* the journey glides toward its target stop at the pair's own pace */
+    if (!reduced && STOPS_N > 1 && jPos !== jTarget) {
+      let i = Math.floor(Math.min(jPos, jTarget));
+      if (i >= STOPS_N - 1) i = STOPS_N - 2;
+      if (i < 0) i = 0;
+      const same = ID.stops[i].fam === ID.stops[Math.min(STOPS_N - 1, i + 1)].fam;
+      const step = dt / (same ? ID.morphT : ID.xfadeT);
+      const d = jTarget - jPos;
+      jPos += Math.abs(d) <= step ? d : Math.sign(d) * step;
+    }
+    /* the hue wheel: bold palettes spin, the classic pair sways; the streak
+       quickens both */
+    if (!reduced) {
+      const rate = ID.cycleBase * (1 + Math.min(3, mood.streak / 4)) * 57.2958;   // deg/s
+      if (ID.cycleMode === 'sway') { swayPh += rate * 2.2 * dt / 57.2958; hueAng = 29 * Math.sin(swayPh * ID.cycleSign); }
+      else hueAng = (hueAng + rate * ID.cycleSign * dt) % 360;
+    }
 
     g.clearRect(0, 0, W, H);
     g.save();
@@ -241,39 +507,27 @@ export function createTube2D(opts = {}) {
     g.strokeStyle = litColor(0.55 + rimBoost * 0.4);
     g.lineWidth = BORE * 0.06 + 2 + rimBoost * 3; g.stroke();
 
-    /* chute body: dark underlay pass then a lit top edge pass */
+    /* chute body: dark underlay pass then the resin, then a faint lit top
+       edge - the centre line stroked three times with a vertical nudge */
+    g.lineCap = 'round'; g.lineJoin = 'round';
     const passes = [
       { w: BORE * 1.14, c: 'rgba(16,16,36,.96)', dy: BORE * 0.04 },
-      { w: BORE, c: 'rgba(42,42,78,.98)', dy: 0 },
-      { w: BORE * 0.34, c: litColor(0.22 + redFlash * 0.4), dy: -BORE * 0.055 },
+      { w: BORE, c: 'rgba(36,36,74,.98)', dy: 0 },
+      { w: BORE * 0.34, c: litColor(0.10 + redFlash * 0.4), dy: -BORE * 0.055 },
     ];
     for (const p of passes) {
-      g.beginPath();
-      for (let i = 0; i <= 220; i++) {
-        const q = at(i / 220);
-        if (i === 0) g.moveTo(q.x, q.y + p.dy); else g.lineTo(q.x, q.y + p.dy);
-      }
-      g.strokeStyle = p.c; g.lineWidth = p.w; g.lineCap = 'round'; g.stroke();
+      g.save(); g.translate(0, p.dy);
+      g.strokeStyle = p.c; g.lineWidth = p.w;
+      strokeLine(0);
+      g.restore();
     }
 
-    /* the energy march: a dashed pass flowing toward the basin. mouthBoost is
-       the load entering off-canvas, so it brightens the march rather than
-       ringing a mouth nobody can see any more. */
-    if (flowSpeed > 0) {
-      g.beginPath();
-      for (let i = 0; i <= 220; i++) {
-        const q = at(i / 220);
-        if (i === 0) g.moveTo(q.x, q.y); else g.lineTo(q.x, q.y);
-      }
-      g.setLineDash([BORE * ID.dashOn, BORE * ID.dashOff]);
-      g.lineDashOffset = flowOff;
-      g.strokeStyle = litColor(0.3 + Math.sin(clock * 0.9) * 0.08 + redFlash * 0.4 + mouthBoost * 0.3);
-      g.lineWidth = BORE * 0.16 + 2;
-      g.stroke();
-      g.setLineDash([]);
-    }
+    /* THE PATTERN: the neon riding the ribbon. mouthBoost is the load entering
+       off-canvas, so it brightens the pattern rather than ringing a mouth
+       nobody can see any more. */
+    paintPattern(0.82 + Math.sin(clock * 0.9) * 0.08 + redFlash * 0.2 + mouthBoost * 0.2);
 
-    /* THE OPENING. Drawn AFTER the ribbon and the march, so both stop at it
+    /* THE OPENING. Drawn AFTER the ribbon and the pattern, so both stop at it
        rather than running over it: a dark bore with one thin lit lip. The 3D
        tier gets this from a recessed cone; here a filled ellipse is the whole
        trick, and it is enough because the ribbon around it is already opaque. */
@@ -417,6 +671,16 @@ export function createTube2D(opts = {}) {
           spinVel = SPIN_BASE + (SPIN_MAX - SPIN_BASE) * mood.progress;
           flowSpeed = FLOW_BASE + (FLOW_MAX - FLOW_BASE) * mood.progress;
         }
+        /* the streak pushes the journey (milestones 5/10/15/20 advance it 0.6
+           of a stop; a chain of 4+ breaking to 0 pulls it 0.6 back) */
+        const rung = mood.streak >= 20 ? 4 : mood.streak >= 15 ? 3 : mood.streak >= 10 ? 2 : mood.streak >= 5 ? 1 : 0;
+        if (rung > milestone) {
+          advance = Math.min(STOPS_N - 1, advance + 0.6 * (rung - milestone));
+          milestone = rung;
+        }
+        if (mood.streak === 0 && lastStreak >= 4) { advance = Math.max(0, advance - 0.6); milestone = 0; }
+        lastStreak = mood.streak;
+        if (!reduced) retarget();
       } catch (e) { /* cosmetic */ }
     },
     suspend(on) {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
@@ -27,39 +27,71 @@
  *          the opening stops short of it - and the crater is what lives there.
  *
  * THE TUBE IS GROWN, NOT BUILT. The class seed (threaded down from index.js
- * through render.js) births a TUBE IDENTITY: a hue somewhere in the app's
- * violet->pink family, a spin direction, a band pitch, a flow temperament, and
- * a three-stop PATTERN JOURNEY drawn from a pool of archetypes (rings, chevrons,
- * lace, waves, eyes, runes). Same seed, same tube - a retake replays its class
- * in the same skin; a new class grows a new one. All of it rides makeRng, never
- * Math.random, except throwaway transients (particle scatter, glitch jitter).
+ * through render.js) births a TUBE IDENTITY: a hue pair, a spin direction, a
+ * band pitch, a flow temperament, a PALETTE and a PATTERN JOURNEY. Same seed,
+ * same tube - a retake replays its class in the same skin; a new class grows a
+ * new one. All of it rides makeRng, never Math.random, except throwaway
+ * transients (particle scatter, glitch jitter).
+ *
+ * THE PATTERN IS THE LIGHT (the House Rules pass). The chute BODY stays dark
+ * opaque resin so the load's glow and the crater keep their contrast; what is
+ * bright is the decoration marching down it - and it is bright: saturated neon
+ * strokes with white-hot cores, painted in COLOUR onto the emissive canvas (the
+ * material's emissive tint is white, so the canvas IS the colour; gold and red
+ * stay semantic tints laid over it on a hot streak / a denyHit). The palette
+ * is seeded from a pool of bold triads and quads (magenta+cyan+lime,
+ * gold+violet+white, rose+teal+amber, ...) with a ~28% chance of the classic
+ * violet->rose pair made bright; the lines then HUE-CYCLE in the shader (one
+ * uniform, a gray-axis rotation on the emissive sample - no redraw): bold
+ * palettes spin the whole wheel, the classic pair only SWAYS about its arc so
+ * it stays on-brand. The cycle quickens with the streak (setMood).
+ *
+ * THREE FAMILIES, ONE JOURNEY. Every decoration is a point in ONE of three
+ * parameter spaces, and within a family the wall MORPHS (glide, never switch):
+ *   VEIN   columns of light: rings, chevron, lace, waves, eyes, runes, candy
+ *          (seamless diagonal stripes), zigzag - bend/wave/zig/slant/rails/
+ *          beads/eye/ticks, drawn as polylines.
+ *   FIELD  a dotted wall: polka, bubbles (hollow), sparkle (four-point stars) -
+ *          dotR/hollow/star/rows/cols/stagger/jitter/sizeVar. Tileable by
+ *          construction (integer rows and columns; dots near an edge are
+ *          painted again across it).
+ *   GRID   a lattice: fishnet, diamond (knotted), checker (harlequin cells) -
+ *          two diagonal line sets whose pitch and slope are integers of the
+ *          tile (nx columns, m columns per wrap) so the lattice closes around
+ *          the bore with no seam; lineW/knotR/fill morph.
+ * Across families the wall CROSSFADES (~2-3s, additive, seeded length) between
+ * two cached family canvases - never a cut. The journey is 4-6 stops drawn
+ * from all 14 archetypes (at least one FIELD or GRID stop is guaranteed), the
+ * class's progress walks it (stop k arrives at progress (k-0.5)/(n-1)), and the
+ * streak PUSHES it: every milestone (5/10/15/20 links) advances the journey
+ * 0.6 of a stop early, a broken streak (4+ down to 0) pulls it 0.6 back toward
+ * the calmer stop it came from. The band canvas is repainted at <=8Hz ONLY
+ * while a glide or a crossfade is actually moving; a held stop costs nothing.
  *
  * THE LIVING MATERIAL: the whole rig sits in one rotating group (slow hypnotic
  * spin - this is a hypno app, the spiral turning IS the aesthetic) and the
- * chute wears one 256x128 emissive canvas that marches toward the basin like a
- * slow swallow. The pattern does not SWITCH, it MORPHS: every archetype is a
- * point in one shared parameter space (bend/wave/rails/beads/eye/ticks), so a
- * ring physically bends into a chevron and sprouts beads into lace - redrawn in
- * place at <=8Hz only while the interpolation is actually moving. On top of the
- * march the texture ken-burns: the pattern rolls slowly around the bore
- * (offset.y) while its pitch breathes (repeat.x) - the wall never holds still,
- * and none of it costs a redraw. A comet light patrols mouth->basin between
- * loads (dimming while a real load travels - the load is the star), the key
- * light orbits against the spin so a specular sheen forever crawls the coils,
- * and the crater breathes: dishMat.color (unlit, so it cannot break the
- * hole-not-dome ramp) tints with the seed hue, exhales lavender on a denyPass,
- * and warms when a streak runs hot, while a faint pooled glow sprite blooms in
- * the belly at each reveal.
+ * chute wears one emissive canvas (512x256, 256x128 under perf; painted in
+ * 256x128 pattern units) that marches toward the basin like a slow swallow. On top of the march the texture ken-burns: the pattern rolls
+ * slowly around the bore (offset.y) while its pitch breathes (repeat.x) - the
+ * wall never holds still, and none of it costs a redraw. A comet light patrols
+ * mouth->basin between loads (dimming while a real load travels - the load is
+ * the star), the key light orbits against the spin so a specular sheen forever
+ * crawls the coils, and the crater breathes: dishMat.color (unlit, so it cannot
+ * break the hole-not-dome ramp) tints with the palette's lead colour, exhales
+ * lavender on a denyPass, and warms when a streak runs hot, while a faint
+ * pooled glow sprite (palette lead, hue-cycled with the lines) blooms in the
+ * belly at each reveal.
  *
  * CONTRACT WITH render.js (all methods must never throw):
  *   setTravel(p|null) · loadPulse() · reveal() · pop(good) · denyHit()
- *   denyPass() · setMood({progress,streak}) · suspend(on) · resize()
+ *   denyPass() · setMood({progress,streak}) · suspend(on) · resize() · landing()
+ *   opts.onLanding({x,y}) fires once at build with the reveal's anchor in % (THE LANDING)
  *   destroy() · kind:'3d'
  *
  * BEATS (the tube participates in every verdict):
  *   pop(true)  basin ring + particle burst + a light racing UP the coil +
- *              the swallow GULPS (band march surges, veins flare)
- *   denyHit()  spin jolt + band flash to red + flow REVERSES + the pattern
+ *              the swallow GULPS (band march surges, lines flare)
+ *   denyHit()  spin jolt + band tinted red + flow REVERSES + the pattern
  *              scrambles around the bore for half a second
  *   denyPass() lavender ring + ambient swell + the crater exhales lavender
  *
@@ -67,10 +99,17 @@
  * try/catch - any throw/reject means "use the 2D tube". Under the DOM double
  * this module is never even imported.
  *
- * MOTION: reduced -> no spin, no march, no morphing (the journey's first stop
- * is drawn once and held), no ken-burns, no comet, no orbit, no particles;
- * pulses are opacity steps. perf -> pixelRatio 1, antialias off, half the
- * particles, morph redraw throttled to 4Hz.
+ * MOTION: reduced -> no spin, no march, no morphing or crossfading (the
+ * journey's first stop is drawn once and held), no hue cycle, no ken-burns, no
+ * comet, no orbit, no particles; pulses are opacity steps. perf -> pixelRatio
+ * 1, antialias off, half the particles, band redraw throttled to 4Hz.
+ *
+ * TRAPS (each one cost real time): widening the crater's lit lip turns it into
+ * a lit egg; nothing may run near-parallel to the chute (z-fight sawtooth);
+ * the dish is MeshBasicMaterial because lit-by-scene renders as a dome; the
+ * headless rig renders on SwiftShader (slow, faithful). The band texture is
+ * sRGB now that it carries colour - a linear-tagged colour canvas washes the
+ * mid tones out.
  * ==========================================================================*/
 
 import { makeRng } from '../../core/rng.js';
@@ -85,11 +124,16 @@ const TURNS = 4.5;           // wraps before the basin (was 2.35 - too few coils
 const HOLD = 0.86;           // t where the spiral stops shrinking: the last
                              // 0.63 turns ring the basin at a CONSTANT radius,
                              // so the chute's own body is the rim it feeds
-const R_OUT = 14.0;          // helix radius at the mouth - OFF-FRAME, see above
+const R_OUT = 14.2;          // helix radius at the mouth - OFF-FRAME, see above
 const R_IN = 2.5;            // the held radius === the basin's rim circle
 const H_TOP = 4.4;           // mouth height above the basin plane
-const Y_END = 0.86;          // height of the held ring
-const TUBE_R = 0.80;         // chute body radius (opaque) - bore dia 1.6
+const Y_END = 1.06;          // height of the held ring: TUBE_R + 0.06, so the
+                             // chute's belly clears the collar's crest (0.0)
+const TUBE_R = 1.00;         // chute body radius (opaque) - bore dia 2.0. Was
+                             // 0.80 until the reveal grew x1.25 (style.js
+                             // --ic-basin-d clamp(132px,17.5vmin,238px)); the
+                             // bubble must FIT THE BORE, so the two move
+                             // together (R_OUT, Y_END, MOUTH_Y/R followed)
 const RIM_R = 0.30;          // collar cross-section (the exposed arc of rim)
 const Y_RIM = -0.30;         // collar centre: its crest (0.0) clears the chute's
                              // belly (0.06). NOTHING may intersect the chute -
@@ -114,20 +158,23 @@ const MOUTH_T = 0.965;       // t where the peel leaves the hold ring. Sized so
                              // the ease in helixAt) - a load must not brake
 const MOUTH_SWEEP = 0.55;    // extra radians the peel carries around the rim,
                              // turning the same way the spiral already turns
-const MOUTH_R = 1.75;        // the opening's centre: just inside the rim, and
+const MOUTH_R = 1.95;        // the opening's centre: just inside the rim, and
                              // never over the middle - its innermost edge still
-                             // stands ~1.2 off the axis, so the composition law
-                             // above (nothing passes over the centre) holds
-const MOUTH_Y = 0.54;        // how high the opening rides over the bowl. The dip
+                             // stands ~0.95 off the axis (was 1.75 / ~1.2 with
+                             // the 0.8 bore), so the composition law above
+                             // (nothing passes over the centre) holds
+const MOUTH_Y = 0.74;        // how high the opening rides over the bowl (0.54 +
+                             // the 0.2 the bore grew, same margins). The dip
                              // is FLAT for the first half of the peel on purpose:
                              // the peel is still crossing OVER the collar and the
                              // lit lip there, and its belly clears them by 0.066
                              // and 0.05. Drop MOUTH_Y and the drop starts sooner,
                              // and that margin is the first thing it eats
-const AIM_Y = -0.35;         // the height of the point it is aimed AT, on the
-                             // axis: a hair under the rim plane, i.e. the middle
-                             // of the crater's MOUTH - the centre of the platform
-                             // the bubble lands on. Aiming further down (the
+const AIM_Y = -0.15;         // the height of the point it is aimed AT, on the
+                             // axis: about the rim plane, i.e. the middle of the
+                             // crater's MOUTH - the centre of the platform the
+                             // bubble lands on (-0.35 with the lower 0.54 mouth;
+                             // raised with it so the tilt stays ~25deg). Aiming further down (the
                              // belly, y -1.05) is the same fiction but tips the
                              // opening 42deg over instead of 24, and this camera
                              // looks DOWN 59deg: past about 30 the opening turns
@@ -145,20 +192,56 @@ const SPIN_MAX = 0.17;       // rad/s at class end
 const FLOW_BASE = 0.22;      // band-march speed (uv/s) at class start
 const FLOW_MAX = 0.62;
 
-/* THE PATTERN SPACE. Every archetype is a point in ONE parameter space, so any
-   two of them can be lerped and the wall reads as transforming, not crossfading:
-   bend folds a ring into a chevron, beadR grows lace out of rails, eyeA opens
-   an iris mid-column. All strokes are GRAYSCALE - the emissive tint is the
-   material's, the texture is only the mask. */
-const PRESETS = {
-  rings:   { bend: 0,   wave: 0,  freq: 1.0, railA: 0.55, railGap: 26, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 6.0 },
-  chevron: { bend: -24, wave: 0,  freq: 1.0, railA: 0,    railGap: 26, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 6.0 },
-  lace:    { bend: 0,   wave: 0,  freq: 1.0, railA: 0.9,  railGap: 42, beadR: 6,   eyeA: 0,   ticks: 0,   coreW: 4.2 },
-  waves:   { bend: 0,   wave: 15, freq: 1.6, railA: 0.5,  railGap: 18, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 5.0 },
-  eyes:    { bend: 0,   wave: 5,  freq: 0.8, railA: 0,    railGap: 26, beadR: 0,   eyeA: 0.9, ticks: 0,   coreW: 4.2 },
-  runes:   { bend: -8,  wave: 0,  freq: 1.0, railA: 0,    railGap: 26, beadR: 3.5, eyeA: 0,   ticks: 0.8, coreW: 5.2 },
+/* THE PATTERN SPACE. Three families; inside a family every archetype is a point
+   in one parameter space, so any two of them lerp and the wall reads as
+   transforming; across families the wall crossfades. Strokes are painted in
+   PALETTE COLOUR with white-hot cores - the canvas is the colour, the material
+   only tints it (white at rest, gold on a hot streak, red on a denyHit). */
+const ARCHETYPES = {
+  /* VEIN - columns of light. bend folds a ring into a chevron, beadR grows lace
+     out of rails, eyeA opens an iris mid-column, slant winds the column into a
+     seamless diagonal stripe (1 = exactly one column per wrap, so the helix
+     closes on itself), zig trades the sine sway for a triangle. */
+  rings:   { fam: 'vein', bend: 0,   wave: 0,  freq: 1.0, railA: 0.55, railGap: 26, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 6.0, slant: 0,   zig: 0 },
+  chevron: { fam: 'vein', bend: -24, wave: 0,  freq: 1.0, railA: 0,    railGap: 26, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 6.0, slant: 0,   zig: 0 },
+  lace:    { fam: 'vein', bend: 0,   wave: 0,  freq: 1.0, railA: 0.9,  railGap: 42, beadR: 6,   eyeA: 0,   ticks: 0,   coreW: 4.2, slant: 0,   zig: 0 },
+  waves:   { fam: 'vein', bend: 0,   wave: 15, freq: 1.6, railA: 0.5,  railGap: 18, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 5.0, slant: 0,   zig: 0 },
+  eyes:    { fam: 'vein', bend: 0,   wave: 5,  freq: 0.8, railA: 0,    railGap: 26, beadR: 0,   eyeA: 0.9, ticks: 0,   coreW: 4.2, slant: 0,   zig: 0 },
+  runes:   { fam: 'vein', bend: -8,  wave: 0,  freq: 1.0, railA: 0,    railGap: 26, beadR: 3.5, eyeA: 0,   ticks: 0.8, coreW: 5.2, slant: 0,   zig: 0 },
+  candy:   { fam: 'vein', bend: 0,   wave: 0,  freq: 1.0, railA: 0.75, railGap: 24, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 9.0, slant: 1,   zig: 0 },
+  zigzag:  { fam: 'vein', bend: 0,   wave: 13, freq: 2.0, railA: 0.6,  railGap: 22, beadR: 0,   eyeA: 0,   ticks: 0,   coreW: 4.6, slant: 0,   zig: 1 },
+  /* FIELD - a dotted wall. hollow turns a polka dot into a bubble ring, star
+     turns it into a four-point sparkle; rows/cols stay integers (tileable). */
+  polka:   { fam: 'field', dotR: 11,  hollow: 0, star: 0, rows: 4, cols: 5, stag: 0.5, jit: 0,   sizeVar: 0 },
+  bubbles: { fam: 'field', dotR: 10,  hollow: 1, star: 0, rows: 4, cols: 5, stag: 0.5, jit: 0.7, sizeVar: 0.6 },
+  sparkle: { fam: 'field', dotR: 7,   hollow: 0, star: 1, rows: 4, cols: 6, stag: 0.5, jit: 0.9, sizeVar: 0.7 },
+  /* GRID - a lattice. The slope and pitch are the SEED's (gridNx columns per
+     tile, gridM columns crossed per wrap - integers, so the net closes around
+     the bore); the archetypes only differ in weight, knots and cell fill. */
+  fishnet: { fam: 'grid', lineW: 2.0, knotR: 0,   fill: 0 },
+  diamond: { fam: 'grid', lineW: 3.4, knotR: 3.8, fill: 0 },
+  checker: { fam: 'grid', lineW: 1.2, knotR: 0,   fill: 1 },
 };
-const P_KEYS = ['bend', 'wave', 'freq', 'railA', 'railGap', 'beadR', 'eyeA', 'ticks', 'coreW'];
+const FAM_KEYS = {
+  vein:  ['bend', 'wave', 'freq', 'railA', 'railGap', 'beadR', 'eyeA', 'ticks', 'coreW', 'slant', 'zig'],
+  field: ['dotR', 'hollow', 'star', 'rows', 'cols', 'stag', 'jit', 'sizeVar'],
+  grid:  ['lineW', 'knotR', 'fill'],
+};
+
+/* THE PALETTES - [hue, sat, light] triads and quads, all bold. Index 0 is the
+   lead (the crater tint, the pool glow, the basin light). 'arc' is built per
+   seed from the classic violet->rose pair (made bright) plus a white-hot. */
+const PALETTES = [
+  { name: 'neon',   cols: [[312, 1, 0.58], [186, 1, 0.56], [84, 1, 0.58]] },               // magenta cyan lime
+  { name: 'royal',  cols: [[46, 1, 0.60], [268, 1, 0.66], [0, 0, 0.96]] },                 // gold violet white
+  { name: 'sunset', cols: [[338, 1, 0.62], [168, 0.9, 0.56], [36, 1, 0.60]] },             // rose teal amber
+  { name: 'candy',  cols: [[326, 1, 0.60], [222, 1, 0.62], [0, 0, 0.95]] },                // hot pink electric blue white
+  { name: 'acid',   cols: [[76, 1, 0.55], [276, 1, 0.62], [336, 1, 0.58]] },               // lime violet hot pink
+  { name: 'ice',    cols: [[188, 1, 0.66], [262, 1, 0.80], [0, 0, 0.97]] },                // cyan lavender white
+  { name: 'ember',  cols: [[22, 1, 0.58], [46, 1, 0.60], [312, 1, 0.58]] },                // orange gold magenta
+  { name: 'ultra',  cols: [[282, 1, 0.62], [150, 1, 0.55], [52, 1, 0.62], [196, 1, 0.60]] }, // violet mint gold sky
+];
+const ARC_CHANCE = 0.28;     // share of seeds that keep the classic pair (bright)
 
 export async function createTube3D(opts = {}) {
   const mount = opts.mount;
@@ -168,8 +251,12 @@ export async function createTube3D(opts = {}) {
 
   /* ------------------------------------------------- the tube's identity
      One rng stream, drawn in a FIXED order (append-only, or every shipped
-     tube changes skin). The ranges are the brand fence: hue lives on the
-     violet->rose arc only, and gold/red stay semantic (streak/error). */
+     tube changes skin). Draws 1..N are the Semester-1 identity and are kept
+     in place (hue pair, spin, pitch, temperament, comet, columns, phases, and
+     the legacy three-stop journey - STILL DRAWN so the stream stays aligned,
+     but no longer the journey that ships). Everything the House Rules pass
+     added is drawn AFTER them: palette, cycle, the 4-6 stop journey, the
+     transition lengths, the lattice integers. */
   const seed = String(opts.seed == null ? 'tube' : opts.seed);
   const rng = makeRng(seed + '|tube3d');
   const ID = (() => {
@@ -181,27 +268,82 @@ export async function createTube3D(opts = {}) {
     const spinMul = 0.9 + rng() * 0.22;
     const kbV = (0.006 + rng() * 0.008) * (rng() < 0.5 ? -1 : 1);  // bore-roll uv/s
     const cometPeriod = 7 + rng() * 4;            // one mouth->basin patrol, s
-    const cols = rng() < 0.5 ? 3 : 4;             // columns per 256px wrap
+    const cols = rng() < 0.5 ? 3 : 4;             // vein columns per 256px wrap
     const colOff = rng() * 64;
     const phases = [rng() * 6.28, rng() * 6.28, rng() * 6.28, rng() * 6.28];
-    /* the journey: three DISTINCT stops through the pattern space, each with
-       its genes jittered once so two classes sharing a stop still differ */
-    const pool = Object.keys(PRESETS).sort();     // stable order under the rng
+    /* LEGACY journey draws (Semester 1): consumed so every draw after them
+       lands where it always did. Not used for the shipped journey. */
+    const legacyPool = ['chevron', 'eyes', 'lace', 'rings', 'runes', 'waves'];
+    for (let i = legacyPool.length - 1; i > 0; i--) {
+      const j = Math.min(i, Math.floor(rng() * (i + 1)));
+      const sw = legacyPool[i]; legacyPool[i] = legacyPool[j]; legacyPool[j] = sw;
+    }
+    for (let s = 0; s < 3; s++) {
+      rng(); rng(); rng(); rng();
+      if (ARCHETYPES[legacyPool[s]].beadR > 0) rng();
+    }
+
+    /* ---- APPENDED (House Rules pass) - every draw below is new ---- */
+    /* the palette: classic pair made bright, or one of the bold sets */
+    let palette, palName, cycleMode;
+    if (rng() < ARC_CHANCE) {
+      palette = [[hue, 1, 0.66], [hue2, 1, 0.70], [0, 0, 0.96]];
+      palName = 'arc'; cycleMode = 'sway';
+    } else {
+      const p = PALETTES[Math.min(PALETTES.length - 1, Math.floor(rng() * PALETTES.length))];
+      palette = p.cols.map((c) => c.slice());
+      palName = p.name; cycleMode = 'spin';
+    }
+    /* rotate which colour leads (the lead = crater / pool / basin light) */
+    const rot = Math.floor(rng() * palette.length) % palette.length;
+    palette = palette.slice(rot).concat(palette.slice(0, rot));
+    const cycleBase = 6.2832 / (45 + rng() * 40);  // rad/s: one wheel in 45-85s
+    const cycleSign = rng() < 0.5 ? -1 : 1;
+
+    /* the journey: 4-6 DISTINCT stops over all 14 archetypes, at least one of
+       them a FIELD or GRID stop (the owner asked for fishnet and polka dots,
+       so a class must be able to show one), each stop's genes jittered once */
+    const nStops = 4 + Math.floor(rng() * 3);
+    const pool = Object.keys(ARCHETYPES).sort();
     for (let i = pool.length - 1; i > 0; i--) {
       const j = Math.min(i, Math.floor(rng() * (i + 1)));
       const sw = pool[i]; pool[i] = pool[j]; pool[j] = sw;
     }
-    const journey = pool.slice(0, 3).map((k) => {
-      const base = PRESETS[k], out = {};
-      for (const f of P_KEYS) out[f] = base[f];
-      out.bend *= 0.8 + rng() * 0.5;
-      out.wave *= 0.8 + rng() * 0.5;
-      out.freq *= 0.85 + rng() * 0.4;
-      out.coreW = Math.max(3.4, out.coreW * (0.85 + rng() * 0.4));
-      if (out.beadR > 0) out.beadR *= 0.8 + rng() * 0.5;
+    const picked = pool.slice(0, nStops);
+    if (!picked.some((k) => ARCHETYPES[k].fam !== 'vein')) {
+      const alt = pool.slice(nStops).find((k) => ARCHETYPES[k].fam !== 'vein');
+      if (alt) picked[nStops - 1] = alt;
+    }
+    const stops = picked.map((k) => {
+      const base = ARCHETYPES[k];
+      const out = { key: k, fam: base.fam };
+      for (const f of FAM_KEYS[base.fam]) out[f] = base[f];
+      /* five jitter draws per stop, always five, whatever the family */
+      const j1 = rng(), j2 = rng(), j3 = rng(), j4 = rng(), j5 = rng();
+      if (base.fam === 'vein') {
+        out.bend *= 0.8 + j1 * 0.5;
+        out.wave *= 0.8 + j2 * 0.5;
+        out.freq = out.slant > 0 ? out.freq : out.freq * (0.85 + j3 * 0.4);
+        out.coreW = Math.max(3.4, out.coreW * (0.85 + j4 * 0.4));
+        if (out.beadR > 0) out.beadR *= 0.8 + j5 * 0.5;
+      } else if (base.fam === 'field') {
+        out.dotR *= 0.85 + j1 * 0.4;
+        out.jit = Math.min(1, out.jit + (j2 - 0.5) * 0.3);
+        out.sizeVar = Math.min(1, Math.max(0, out.sizeVar + (j3 - 0.5) * 0.3));
+        out.stag = j4 < 0.5 ? 0.5 : 0.33;
+      } else {
+        out.lineW *= 0.85 + j1 * 0.4;
+        if (out.knotR > 0) out.knotR *= 0.85 + j2 * 0.4;
+        out.fill = out.fill > 0 ? Math.min(1, out.fill * (0.8 + j3 * 0.25)) : 0;
+      }
       return out;
     });
-    return { hue, hue2, spinSign, pitch, flowMul, spinMul, kbV, cometPeriod, cols, colOff, phases, journey };
+    const morphT = 4.5 + rng() * 2.5;             // s, a glide within a family
+    const xfadeT = 1.8 + rng() * 1.0;             // s, a crossfade across families
+    const gridNx = 8 + 2 * Math.floor(rng() * 3); // 8 / 10 / 12 columns per tile
+    const gridM = 3 + Math.floor(rng() * 3);      // 3 / 4 / 5 columns per wrap
+    return { hue, hue2, spinSign, pitch, flowMul, spinMul, kbV, cometPeriod, cols, colOff, phases,
+             palette, palName, cycleMode, cycleBase, cycleSign, stops, morphT, xfadeT, gridNx, gridM };
   })();
 
   const THREE = await import(VENDOR);
@@ -230,6 +372,41 @@ export async function createTube3D(opts = {}) {
   const world = new THREE.Group();
   scene.add(world);
 
+  /* ------------------------------------------------------------ THE LANDING
+     Where the DOM reveal sits. Screen centre is the crater's belly by the
+     lookAt above - but this camera looks DOWN 59deg over a chute that rings
+     the crater ABOVE its rim, so the held ring's NEAR side hides the lower
+     half of the bowl: the belly projects at ~49.5% of the viewport and the
+     near coil's inner crest at ~49.0%. A bubble centred there reads as
+     sitting ON THE TUBE (owner 2026-08-22), not in the dish. The hole the
+     player actually SEES runs from the far coil's inner belly down to the
+     near coil's inner crest, and the landing is the axis point that projects
+     into the middle of it - solved, not eyeballed, so a camera tweak moves it
+     for free. NDC y is aspect-blind, so one solve at build time is enough.
+     The DOM basin follows via opts.onLanding({x,y} in %); the pool glow and
+     the pop particles land on the same point so the 2D and 3D halves agree. */
+  const LAND = (() => {
+    const fallback = { y: -0.9, pct: { x: 50, y: 50 } };
+    try {
+      /* project() reads matrixWorldInverse: a camera that has never rendered
+         still carries the identity, so update it by hand first */
+      camera.updateMatrixWorld(true);
+      camera.updateProjectionMatrix();
+      const v = new THREE.Vector3();
+      const ndcY = (x, y, z) => v.set(x, y, z).project(camera).y;
+      const farY = ndcY(0, Y_END - TUBE_R, -(R_IN - TUBE_R));   // far coil, inner belly
+      const nearY = ndcY(0, Y_END + TUBE_R, R_IN - TUBE_R);     // near coil, inner crest
+      const want = (farY + nearY) / 2;
+      let lo = -3, hi = 5;
+      for (let i = 0; i < 40; i++) { const mid = (lo + hi) / 2; if (ndcY(0, mid, 0) < want) lo = mid; else hi = mid; }
+      const y = (lo + hi) / 2;
+      const pctY = (1 - want) / 2 * 100;
+      if (!Number.isFinite(y) || !Number.isFinite(pctY) || pctY < 15 || pctY > 85) return fallback;
+      return { y, pct: { x: 50, y: +pctY.toFixed(2) } };
+    } catch (e) { return fallback; }
+  })();
+  if (typeof opts.onLanding === 'function') { try { opts.onLanding({ x: LAND.pct.x, y: LAND.pct.y }); } catch (e) { /* cosmetic */ } }
+
   /* ------------------------------------------------------------ the chute */
   /* THE PEEL'S BASIS, solved once (plain numbers - helixAt is called every
      frame by three followers and must not mint anything but its result).
@@ -257,7 +434,7 @@ export async function createTube3D(opts = {}) {
   const helixAt = (t) => {
     // t 0 (mouth, off-frame) -> 1 (the OPENING over the crater). The radius
     // falls LINEARLY over the first HOLD of the run so every coil is spaced the
-    // same (11.5 / 3.87 turns = 2.97, against a bore of 1.6 - they can never
+    // same (11.7 / 3.87 turns = 3.02, against a bore of 2.0 - they can never
     // intersect), then HOLDS at R_IN: two thirds of a turn is a level ring
     // around the basin, and that ring IS the rim the chute feeds. The last
     // 1-MOUTH_T peels off it and aims into the bowl.
@@ -292,113 +469,353 @@ export async function createTube3D(opts = {}) {
      across its 90 degrees of turn, which is where the extra segments went */
   const tubeGeo = new THREE.TubeGeometry(curve, perf ? 320 : 500, TUBE_R, perf ? 10 : 16, false);
 
-  /* The band canvas: ONE 256x128 surface, redrawn in place (no re-alloc).
-     TubeGeometry maps u ALONG the path, so vertical elements here become rings
-     that march down the chute when offset.x moves. */
+  /* The band canvas: ONE surface the material samples, redrawn in place (no
+     re-alloc). TubeGeometry maps u ALONG the path, so vertical
+     elements here become rings that march down the chute when offset.x moves.
+     Two more canvases of the same size sit behind it as the CROSSFADE cache: each holds
+     one family's render of a journey stop, painted once per stop, and a
+     crossfade is two drawImages into the band - so at most ONE GPU texture and
+     three small canvases are ever alive for the pattern. */
+  const BAND_S = perf ? 1 : 2;               // canvas pixels per pattern unit
+  const BAND_W = 256 * BAND_S, BAND_H = 128 * BAND_S;
   const bandCanvas = document.createElement('canvas');
-  bandCanvas.width = 256; bandCanvas.height = 128;
+  bandCanvas.width = BAND_W; bandCanvas.height = BAND_H;
   const bandTex = new THREE.CanvasTexture(bandCanvas);
   bandTex.wrapS = THREE.RepeatWrapping;
   bandTex.wrapT = THREE.RepeatWrapping;
   bandTex.repeat.set(ID.pitch, 1);
+  try { bandTex.colorSpace = THREE.SRGBColorSpace; } catch (e) { /* older three */ }
+  const cacheCanvas = [document.createElement('canvas'), document.createElement('canvas')];
+  const cacheIdx = [-1, -1];
+  for (const cv of cacheCanvas) { cv.width = BAND_W; cv.height = BAND_H; }
+
+  /* ------------------------------------------------------ the palette ink */
+  const PAL = ID.palette;
+  const PAL_N = PAL.length;
+  const palCss = PAL.map((c) => 'hsl(' + Math.round(c[0]) + ',' + Math.round(c[1] * 100) + '%,' + Math.round(c[2] * 100) + '%)');
+  const WHITE_HOT = 'rgba(255,255,255,0.92)';
+  const ink = (k) => palCss[((k % PAL_N) + PAL_N) % PAL_N];
 
   /* ------------------------------------------------------ the morph engine
-     paramsAt(s) walks the seed's three-stop journey with PLATEAUS: hold stop
-     A, glide A->B, hold B, glide B->C. drawMorph paints whatever point of the
-     pattern space it is handed; the frame loop only calls it while the params
-     are actually moving (and never faster than the redraw throttle), so a
-     plateau costs zero redraws and a glide costs a handful of 256x128 fills. */
-  const P_CUR = {}, P_LAST = { _never: true };
-  function plateau(t) {
-    const a = 0.22, b = 0.78;
-    if (t <= a) return 0;
-    if (t >= b) return 1;
-    const u = (t - a) / (b - a);
-    return u * u * (3 - 2 * u);
-  }
-  function paramsAt(s) {
-    const J = ID.journey;
-    const half = Math.max(0, Math.min(1, s)) * 2;
-    const A = half < 1 ? J[0] : J[1];
-    const B = half < 1 ? J[1] : J[2];
-    const w = plateau(half < 1 ? half : half - 1);
-    for (const f of P_KEYS) P_CUR[f] = A[f] + (B[f] - A[f]) * w;
-    return P_CUR;
-  }
+     The journey is walked by jPos (a real number over the stop indices). The
+     pair (i, i+1) around it and the fraction w are what gets drawn: same
+     family -> params lerp (glide), different family -> crossfade between the
+     two cached family canvases. renderBand is the ONLY painter, and the frame
+     loop calls it only while jPos is moving (and never faster than MORPH_DT).
+     Every family painter paints a TILEABLE 256x128: x wraps along the chute,
+     y wraps around the bore. */
+  const P_CUR = {};
+  const smooth = (u) => (u <= 0 ? 0 : u >= 1 ? 1 : u * u * (3 - 2 * u));
   const triAt = (y) => Math.max(0, 1 - Math.abs((y - 64) / 72));
-  function drawElement(c, xc, P, phase) {
-    /* one vein: a 12-segment polyline whose x(y) folds (bend) and sways (wave).
-       Soft under-glow pass first, then the core - thin luminous veins in dark
-       resin, never plush stripes. */
-    const seg = 12;
+  /* a cheap deterministic hash for per-dot variation (NOT the rng: the tile
+     has to paint identically every time it is repainted) */
+  const h01 = (a, b) => {
+    let x = (a * 374761393 + b * 668265263) | 0;
+    x = Math.imul(x ^ (x >>> 13), 1274126177);
+    return ((x ^ (x >>> 16)) >>> 0) / 4294967296;
+  };
+
+  function veinX(P, xc, y, phase, spacing) {
+    const th = (y / 128) * P.freq * 6.283 + phase;
+    const sn = Math.sin(th);
+    const wv = P.zig > 0.001 ? sn * (1 - P.zig) + (0.6366 * Math.asin(sn)) * P.zig : sn;
+    return xc + P.bend * triAt(y) + P.wave * wv + P.slant * spacing * ((y - 64) / 128);
+  }
+  function polyline(c, P, xc, dx, phase, spacing, seg) {
     c.beginPath();
     for (let k = 0; k <= seg; k++) {
       const y = -8 + (k * 144) / seg;
-      const x = xc + P.bend * triAt(y) + P.wave * Math.sin((y / 128) * P.freq * 6.283 + phase);
+      const x = veinX(P, xc + dx, y, phase, spacing);
       if (k === 0) c.moveTo(x, y); else c.lineTo(x, y);
     }
-    c.globalAlpha = 0.22; c.lineWidth = P.coreW * 2.8; c.stroke();
-    c.globalAlpha = 0.95; c.lineWidth = P.coreW; c.stroke();
-    if (P.railA > 0.03) {
-      c.beginPath();
-      for (let k = 0; k <= seg; k++) {
-        const y = -8 + (k * 144) / seg;
-        const x = xc + P.railGap + P.bend * triAt(y) + P.wave * Math.sin((y / 128) * P.freq * 6.283 + phase);
-        if (k === 0) c.moveTo(x, y); else c.lineTo(x, y);
+  }
+  function drawVeinElement(c, xc, P, phase, ci, spacing) {
+    /* one column of light: a folding/swaying polyline in palette colour with a
+       soft under-glow and a WHITE-HOT core - thin luminous neon in dark resin,
+       never plush stripes. Three copies so bends/slants tile across x. */
+    const seg = P.zig > 0.001 ? 24 : 12;
+    const col = ink(ci);
+    for (const dx of [-256, 0, 256]) {
+      polyline(c, P, xc, dx, phase, spacing, seg);
+      c.strokeStyle = col;
+      c.globalAlpha = 0.26; c.lineWidth = P.coreW * 3.0; c.stroke();
+      c.globalAlpha = 1.0; c.lineWidth = P.coreW; c.stroke();
+      c.strokeStyle = WHITE_HOT;
+      c.globalAlpha = 0.8; c.lineWidth = Math.max(1.2, P.coreW * 0.34); c.stroke();
+      if (P.railA > 0.03) {
+        polyline(c, P, xc + P.railGap, dx, phase, spacing, seg);
+        c.strokeStyle = ink(ci + 1);
+        c.globalAlpha = P.railA * 0.95; c.lineWidth = Math.max(1.6, P.coreW * 0.55); c.stroke();
+        c.strokeStyle = WHITE_HOT;
+        c.globalAlpha = P.railA * 0.5; c.lineWidth = Math.max(1, P.coreW * 0.2); c.stroke();
       }
-      c.globalAlpha = P.railA * 0.8; c.lineWidth = Math.max(1.4, P.coreW * 0.6); c.stroke();
     }
     if (P.beadR > 0.4) {
-      c.globalAlpha = 0.9;
       for (const y of [20, 52, 84, 116]) {
         const x = xc + P.railGap * 0.5 + P.bend * triAt(y);
-        c.beginPath(); c.arc(x, y, P.beadR, 0, 6.283); c.fill();
+        for (const dx of [-256, 0, 256]) {
+          c.globalAlpha = 0.3; c.fillStyle = ink(ci + 2);
+          c.beginPath(); c.arc(x + dx, y, P.beadR * 1.8, 0, 6.283); c.fill();
+          c.globalAlpha = 1;
+          c.beginPath(); c.arc(x + dx, y, P.beadR, 0, 6.283); c.fill();
+          c.globalAlpha = 0.9; c.fillStyle = WHITE_HOT;
+          c.beginPath(); c.arc(x + dx, y, P.beadR * 0.42, 0, 6.283); c.fill();
+        }
       }
     }
     if (P.eyeA > 0.03) {
       /* an iris opening mid-column - this is a hypno app */
-      c.globalAlpha = P.eyeA * 0.85; c.lineWidth = 2.6;
-      c.beginPath(); c.ellipse(xc + P.bend * 0.4, 64, 15, 30, 0, 0, 6.283); c.stroke();
-      c.globalAlpha = P.eyeA * 0.7;
-      c.beginPath(); c.arc(xc + P.bend * 0.4, 64, 4.5, 0, 6.283); c.fill();
+      for (const dx of [-256, 0, 256]) {
+        const ex = xc + dx + P.bend * 0.4;
+        c.globalAlpha = P.eyeA * 0.95; c.lineWidth = 3; c.strokeStyle = ink(ci + 1);
+        c.beginPath(); c.ellipse(ex, 64, 15, 30, 0, 0, 6.283); c.stroke();
+        c.globalAlpha = P.eyeA * 0.55; c.lineWidth = 1.2; c.strokeStyle = WHITE_HOT;
+        c.beginPath(); c.ellipse(ex, 64, 15, 30, 0, 0, 6.283); c.stroke();
+        c.globalAlpha = P.eyeA * 0.85; c.fillStyle = ink(ci);
+        c.beginPath(); c.arc(ex, 64, 4.8, 0, 6.283); c.fill();
+        c.globalAlpha = P.eyeA * 0.9; c.fillStyle = WHITE_HOT;
+        c.beginPath(); c.arc(ex, 64, 2, 0, 6.283); c.fill();
+      }
     }
     if (P.ticks > 0.05) {
-      c.globalAlpha = P.ticks * 0.8; c.lineWidth = 2.4;
+      c.globalAlpha = P.ticks * 0.85; c.lineWidth = 2.4; c.strokeStyle = WHITE_HOT;
       for (const y of [30, 64, 98]) {
         const x = xc - 12 + P.bend * triAt(y);
-        c.beginPath(); c.moveTo(x - 6, y); c.lineTo(x + 6, y); c.stroke();
+        for (const dx of [-256, 0, 256]) {
+          c.beginPath(); c.moveTo(x + dx - 6, y); c.lineTo(x + dx + 6, y); c.stroke();
+        }
       }
     }
     c.globalAlpha = 1;
   }
-  function drawMorph(P) {
-    const c = bandCanvas.getContext('2d');
-    if (!c) return;
-    c.globalAlpha = 1;
-    c.fillStyle = '#000';
-    c.fillRect(0, 0, 256, 128);
-    c.strokeStyle = '#fff'; c.fillStyle = '#fff'; c.lineCap = 'round';
+  function drawVein(c, P) {
+    c.lineCap = 'round'; c.lineJoin = 'round';
     const spacing = 256 / ID.cols;
     for (let ci = 0; ci < ID.cols; ci++) {
       const xc = ((ci * spacing + ID.colOff) % 256 + 256) % 256;
-      /* three copies so bends/waves that spill the edge tile seamlessly */
-      drawElement(c, xc - 256, P, ID.phases[ci]);
-      drawElement(c, xc, P, ID.phases[ci]);
-      drawElement(c, xc + 256, P, ID.phases[ci]);
+      drawVeinElement(c, xc, P, ID.phases[ci], ci, spacing);
     }
-    let d = 0;
-    for (const f of P_KEYS) { d += Math.abs(P[f] - (P_LAST[f] || 0)); P_LAST[f] = P[f]; }
-    delete P_LAST._never;
-    bandTex.needsUpdate = true;
-    return d;
   }
-  drawMorph(paramsAt(0));
 
+  function starPath(c, x, y, R) {
+    c.beginPath();
+    for (let k = 0; k < 8; k++) {
+      const a = k * 0.7854 - 1.5708;
+      const r = (k & 1) ? R * 0.36 : R;
+      const px = x + Math.cos(a) * r, py = y + Math.sin(a) * r;
+      if (k === 0) c.moveTo(px, py); else c.lineTo(px, py);
+    }
+    c.closePath();
+  }
+  /* the tile is 2:1 in pixels over a ~1:1 patch of wall (6.4 units along at
+     pitch 36, 6.3 around a 1.0 bore), so a canvas circle lands ~2x tall on the
+     chute - dots and knots are painted squashed by this much to come out
+     ROUND in the world */
+  const Y_ROUND = 0.48;
+  function blobOne(c, x, y, rad, k, P) {
+    const col = ink(k);
+    c.save();
+    c.translate(x, y); c.scale(1, Y_ROUND);
+    x = 0; y = 0;
+    c.globalAlpha = 0.15; c.fillStyle = col;
+    c.beginPath(); c.arc(x, y, rad * 1.55, 0, 6.283); c.fill();
+    if (P.star > 0.01) {
+      c.globalAlpha = P.star; c.fillStyle = col;
+      starPath(c, x, y, rad * 1.6); c.fill();
+      c.globalAlpha = P.star * 0.9; c.fillStyle = WHITE_HOT;
+      starPath(c, x, y, rad * 0.75); c.fill();
+    }
+    const disc = 1 - P.star;
+    if (disc > 0.01) {
+      const solid = disc * (1 - P.hollow);
+      if (solid > 0.01) {
+        c.globalAlpha = solid; c.fillStyle = col;
+        c.beginPath(); c.arc(x, y, rad, 0, 6.283); c.fill();
+        c.globalAlpha = solid * 0.85; c.fillStyle = WHITE_HOT;
+        c.beginPath(); c.arc(x - rad * 0.18, y - rad * 0.18, rad * 0.36, 0, 6.283); c.fill();
+      }
+      const ring = disc * P.hollow;
+      if (ring > 0.01) {
+        c.globalAlpha = ring; c.strokeStyle = col; c.lineWidth = Math.max(1.5, rad * 0.42);
+        c.beginPath(); c.arc(x, y, rad * 0.82, 0, 6.283); c.stroke();
+        c.globalAlpha = ring * 0.85; c.fillStyle = WHITE_HOT;
+        c.beginPath(); c.arc(x - rad * 0.36, y - rad * 0.36, rad * 0.2, 0, 6.283); c.fill();
+      }
+    }
+    c.restore();
+  }
+  function blob(c, x, y, rad, k, P) {
+    /* paint the dot and its wrapped twins, so a dot on an edge tiles */
+    const m = rad * 2.1;
+    for (const dx of [0, 256, -256]) {
+      const xx = x + dx;
+      if (xx < -m || xx > 256 + m) continue;
+      for (const dy of [0, 128, -128]) {
+        const yy = y + dy;
+        if (yy < -m || yy > 128 + m) continue;
+        blobOne(c, xx, yy, rad, k, P);
+      }
+    }
+  }
+  function drawField(c, P) {
+    const rows = Math.max(1, Math.round(P.rows)), cols = Math.max(1, Math.round(P.cols));
+    for (let r = 0; r < rows; r++) {
+      const y0 = (r + 0.5) * (128 / rows);
+      for (let q = 0; q < cols; q++) {
+        const a = h01(r * 31 + 7, q * 17 + 3), b = h01(q * 29 + 11, r * 13 + 5);
+        const x = (((q + P.stag * (r & 1)) * (256 / cols) + ID.colOff) % 256 + 256) % 256 + P.jit * 10 * (a - 0.5);
+        const y = y0 + P.jit * 8 * (b - 0.5);
+        const rad = Math.max(1.5, P.dotR * (1 + P.sizeVar * (a * 1.3 - 0.65)));
+        blob(c, x, y, rad, r + q, P);
+      }
+    }
+    c.globalAlpha = 1;
+  }
+
+  function drawGrid(c, P) {
+    /* two diagonal line sets, x = k*gx +- s*y. nx columns per tile and m
+       columns per wrap are integers, so the net is seamless in both axes */
+    const nx = ID.gridNx, m = ID.gridM, gx = 256 / nx, s = (m * gx) / 128;
+    c.lineCap = 'butt';
+    if (P.fill > 0.01) {
+      /* harlequin: the diamond cells between the lines, alternate parity
+         filled (parity is seamless under both wraps) */
+      const u0 = Math.floor(-s * 128 / gx) - 1, u1 = Math.ceil(256 / gx) + 1;
+      const v0 = -1, v1 = Math.ceil((256 + s * 128) / gx) + 1;
+      for (let i = u0; i <= u1; i++) {
+        for (let j = v0; j <= v1; j++) {
+          const even = ((i + j) & 1) === 0;
+          c.globalAlpha = even ? P.fill * 0.9 : P.fill * 0.38;
+          c.fillStyle = even ? ink(0) : ink(1);
+          c.beginPath();
+          c.moveTo((i + j) * gx / 2, (j - i) * gx / (2 * s));
+          c.lineTo((i + 1 + j) * gx / 2, (j - i - 1) * gx / (2 * s));
+          c.lineTo((i + 1 + j + 1) * gx / 2, (j + 1 - i - 1) * gx / (2 * s));
+          c.lineTo((i + j + 1) * gx / 2, (j + 1 - i) * gx / (2 * s));
+          c.closePath(); c.fill();
+        }
+      }
+    }
+    const lineSet = (sign, col) => {
+      const k0 = sign > 0 ? -m - 1 : -1, k1 = sign > 0 ? nx + 1 : nx + m + 1;
+      c.beginPath();
+      for (let k = k0; k <= k1; k++) {
+        c.moveTo(k * gx, 0);
+        c.lineTo(k * gx + sign * s * 128, 128);
+      }
+      c.strokeStyle = col;
+      c.globalAlpha = 0.24; c.lineWidth = P.lineW * 3; c.stroke();
+      c.globalAlpha = 1; c.lineWidth = P.lineW; c.stroke();
+      if (P.lineW >= 1.8) {
+        c.strokeStyle = WHITE_HOT;
+        c.globalAlpha = 0.7; c.lineWidth = Math.max(0.8, P.lineW * 0.34); c.stroke();
+      }
+    };
+    lineSet(1, ink(0));
+    lineSet(-1, ink(1));
+    if (P.knotR > 0.4) {
+      /* knots at every crossing: x = (j+k)gx/2, y = (j-k)gx/(2s) */
+      const col = ink(2);
+      for (let k = -m - 1; k <= nx + 1; k++) {
+        for (let j = -1; j <= nx + m + 1; j++) {
+          const y = (j - k) * gx / (2 * s);
+          if (y < -P.knotR || y > 128 + P.knotR) continue;
+          const x = (j + k) * gx / 2;
+          if (x < -P.knotR || x > 256 + P.knotR) continue;
+          c.save(); c.translate(x, y); c.scale(1, Y_ROUND);
+          c.globalAlpha = 0.2; c.fillStyle = col;
+          c.beginPath(); c.arc(0, 0, P.knotR * 1.6, 0, 6.283); c.fill();
+          c.globalAlpha = 1;
+          c.beginPath(); c.arc(0, 0, P.knotR, 0, 6.283); c.fill();
+          c.globalAlpha = 0.9; c.fillStyle = WHITE_HOT;
+          c.beginPath(); c.arc(0, 0, P.knotR * 0.4, 0, 6.283); c.fill();
+          c.restore();
+        }
+      }
+    }
+    c.globalAlpha = 1;
+  }
+
+  function paintFamily(cv, fam, P) {
+    const c = cv.getContext('2d');
+    if (!c) return;
+    /* every painter works in 256x128 PATTERN UNITS; the canvas is BAND_S times
+       that so the strokes stay crisp along the long coils */
+    c.setTransform(BAND_S, 0, 0, BAND_S, 0, 0);
+    c.globalCompositeOperation = 'source-over';
+    c.globalAlpha = 1;
+    c.fillStyle = '#000';
+    c.fillRect(0, 0, 256, 128);
+    if (fam === 'vein') drawVein(c, P);
+    else if (fam === 'field') drawField(c, P);
+    else drawGrid(c, P);
+    c.globalAlpha = 1;
+  }
+  function ensureCache(slot, stopIdx) {
+    if (cacheIdx[slot] === stopIdx) return;
+    const S = ID.stops[stopIdx];
+    paintFamily(cacheCanvas[slot], S.fam, S);
+    cacheIdx[slot] = stopIdx;
+  }
+  /* paint the band for journey position jp: pair (i, i+1), fraction w */
+  function renderBand(jp) {
+    const n = ID.stops.length;
+    let i = Math.floor(jp);
+    if (i >= n - 1) i = n - 2;
+    if (i < 0) i = 0;
+    const w = n > 1 ? Math.max(0, Math.min(1, jp - i)) : 0;
+    const A = ID.stops[i], B = ID.stops[Math.min(n - 1, i + 1)];
+    const ws = smooth(w);
+    if (A.fam === B.fam || ws <= 0 || ws >= 1) {
+      const S = ws >= 1 ? B : A;
+      if (A.fam === B.fam) {
+        for (const f of FAM_KEYS[A.fam]) P_CUR[f] = A[f] + (B[f] - A[f]) * ws;
+        paintFamily(bandCanvas, A.fam, P_CUR);
+      } else {
+        paintFamily(bandCanvas, S.fam, S);
+      }
+    } else {
+      ensureCache(0, i); ensureCache(1, i + 1);
+      const c = bandCanvas.getContext('2d');
+      if (!c) return;
+      c.setTransform(1, 0, 0, 1, 0, 0);
+      c.globalCompositeOperation = 'source-over';
+      c.globalAlpha = 1; c.fillStyle = '#000'; c.fillRect(0, 0, BAND_W, BAND_H);
+      c.globalCompositeOperation = 'lighter';
+      c.globalAlpha = 1 - ws; c.drawImage(cacheCanvas[0], 0, 0);
+      c.globalAlpha = ws; c.drawImage(cacheCanvas[1], 0, 0);
+      c.globalCompositeOperation = 'source-over';
+      c.globalAlpha = 1;
+    }
+    bandTex.needsUpdate = true;
+  }
+  renderBand(0);
+
+  /* THE MATERIAL. Dark resin body; the emissive map IS the colour (white
+     emissive tint), so the palette shows through at full saturation. A hue
+     rotation rides in the shader as ONE uniform - a gray-axis rotation of the
+     emissive sample - which is how the lines cycle colour every frame without
+     a single canvas redraw. Reduced motion leaves the uniform at 0. */
+  const hueU = { value: 0 };
   const tubeMat = new THREE.MeshStandardMaterial({
-    color: 0x2a2a4e, roughness: 0.3, metalness: 0.42,
-    emissive: 0xff69b4, emissiveIntensity: 0.36,
+    color: 0x24244a, roughness: 0.3, metalness: 0.42,
+    emissive: 0xffffff, emissiveIntensity: 0.95,
     emissiveMap: bandTex,
   });
+  tubeMat.onBeforeCompile = (shader) => {
+    shader.uniforms.uIcHue = hueU;
+    shader.fragmentShader = shader.fragmentShader
+      .replace('#include <common>',
+        '#include <common>\nuniform float uIcHue;\n'
+        + 'vec3 icHueRot(vec3 c, float a){ const vec3 k = vec3(0.57735026919); float cs = cos(a); float sn = sin(a);'
+        + ' return c * cs + cross(k, c) * sn + k * dot(k, c) * (1.0 - cs); }\n')
+      .replace('#include <emissivemap_fragment>',
+        '#ifdef USE_EMISSIVEMAP\n'
+        + '\tvec4 emissiveColor = texture2D( emissiveMap, vEmissiveMapUv );\n'
+        + '\ttotalEmissiveRadiance *= clamp(icHueRot(emissiveColor.rgb, uIcHue), 0.0, 1.0);\n'
+        + '#endif\n');
+  };
+  tubeMat.customProgramCacheKey = () => 'ic-tube-hue';
   const tube = new THREE.Mesh(tubeGeo, tubeMat);
   world.add(tube);
 
@@ -579,7 +996,7 @@ export async function createTube3D(opts = {}) {
     map: haloTex, transparent: true, opacity: 0, depthWrite: false, depthTest: false,
     blending: THREE.AdditiveBlending, color: 0xffc4e4,
   }));
-  halo.scale.set(2.7, 2.7, 1);   // ~1.7x the bore: light bleeds, the load does not
+  halo.scale.set(3.3, 3.3, 1);   // ~1.65x the bore: light bleeds, the load does not
   halo.renderOrder = 10;
   world.add(halo);
 
@@ -590,7 +1007,7 @@ export async function createTube3D(opts = {}) {
       map: tex, transparent: true, opacity: 0.0, depthWrite: false, depthTest: false,
       blending: THREE.AdditiveBlending, color: 0xffd2ec,
     }));
-    ghost.scale.set(1.16, 1.16, 1);   // INSIDE the bore (dia 1.6), never over it
+    ghost.scale.set(1.45, 1.45, 1);   // INSIDE the bore (dia 2.0), never over it
     ghost.renderOrder = 11;
     world.add(ghost);
   } catch (e) { /* halo-only ghost is fine */ }
@@ -625,7 +1042,7 @@ export async function createTube3D(opts = {}) {
     blending: THREE.AdditiveBlending, color: 0xffc4e4,
   }));
   pool.scale.set(1.8, 1.8, 1);   // inside the 2.5 crater mouth, clear of the chute
-  pool.position.set(0, -0.9, 0);
+  pool.position.set(0, LAND.y, 0);   // right where the DOM bubble lands (see THE LANDING)
   pool.renderOrder = 8;
   world.add(pool);
 
@@ -648,8 +1065,8 @@ export async function createTube3D(opts = {}) {
     if (reduced) return;
     pMat.color.setHex(gold ? 0xf0c24b : 0xff8fc8);
     for (let i = 0; i < P_COUNT; i++) {
-      /* out of the CRATER, not off a plate: they start at the belly */
-      pPos[i * 3] = 0; pPos[i * 3 + 1] = -1.6; pPos[i * 3 + 2] = 0;
+      /* out from under the bubble: they start just below the landing */
+      pPos[i * 3] = 0; pPos[i * 3 + 1] = LAND.y - 0.4; pPos[i * 3 + 2] = 0;
       const a = Math.random() * Math.PI * 2;
       const up = 2.1 + Math.random() * 2.8;
       const out = 0.6 + Math.random() * 2.2;
@@ -704,13 +1121,14 @@ export async function createTube3D(opts = {}) {
   let flowDir = 1;        // denyHit reverses briefly
   let flowRevT = 0;
   let mood = { progress: 0, streak: 0 };
-  /* the seed's two colour poles; gold and red stay semantic and fixed */
-  const EMISSIVE_A = new THREE.Color().setHSL((ID.hue / 360) % 1, 0.92, 0.67);
-  const EMISSIVE_B = new THREE.Color().setHSL((ID.hue2 / 360) % 1, 0.62, 0.72);
-  const EMISSIVE_GOLD = new THREE.Color(0xf0c24b);
-  const EMISSIVE_RED = new THREE.Color(0xff3a5e);
-  const emissiveTarget = EMISSIVE_A.clone();
-  const DISH_TINT = new THREE.Color().setHSL((ID.hue / 360) % 1, 0.45, 0.82);
+  /* semantic tints laid OVER the coloured band: white at rest, gold on a hot
+     streak, red on a denyHit. The palette itself lives in the canvas. */
+  const TINT_WHITE = new THREE.Color(0xffffff);
+  const TINT_GOLD = new THREE.Color(0xffd23f);
+  const TINT_RED = new THREE.Color(0xff3a5e);
+  const tintTarget = TINT_WHITE.clone();
+  const LEAD = PAL[0];    // [h, s, l] - the palette's lead colour
+  const DISH_TINT = new THREE.Color().setHSL((LEAD[0] / 360) % 1, Math.min(0.6, LEAD[1] * 0.5), 0.82);
   const DISH_LAV = new THREE.Color(0xcabdf0);
   const DISH_WARM = new THREE.Color(0xf0d9a8);
   const WHITE = new THREE.Color(0xffffff);
@@ -719,17 +1137,31 @@ export async function createTube3D(opts = {}) {
   let surge = 0;          // pop(true) swallow-gulp, decays
   let scramT = 0;         // denyHit pattern scramble, counts down
   let dishExhale = 0;     // denyPass crater tint, decays
-  let progSmooth = 0;     // eased class progress - the morph glides, never steps
   let kbY = 0;            // accumulated ken-burns bore-roll
   let lastMorphAt = -1;   // redraw throttle clock stamp
+  let lastDrawnPos = 0;   // the jPos the band was last painted at
   const MORPH_DT = perf ? 0.25 : 0.125;
+  /* the journey walk: jPos glides toward jTarget (an integer stop index);
+     advance is the streak's push, milestone the highest rung earned since the
+     last break */
+  let jPos = 0, jTarget = 0, advance = 0, milestone = 0, lastStreak = 0;
+  const STOPS_N = ID.stops.length;
+  /* the hue wheel: angle in radians for the shader; pool/basin light follow.
+     swayPh is the sway's own phase, integrated so a streak change cannot jump it */
+  let hueAng = 0, swayPh = 0;
   /* the key light's orbit basis (its authored position, in polar form) */
   const KEY_R = Math.hypot(-4, 3);
   const KEY_A0 = Math.atan2(3, -4);
 
-  /* seed the material's own tint immediately - applyMood refines it later */
-  tubeMat.emissive.copy(EMISSIVE_A);
+  /* the palette's lead colour leads the basin light too - the coils near the
+     crater catch the same colour the lines wear */
+  basinLight.color.setHSL((LEAD[0] / 360) % 1, Math.min(1, LEAD[1]), Math.max(0.55, LEAD[2]));
 
+  function retarget() {
+    /* stop k arrives at progress (k - 0.5) / (n - 1), nudged by the streak */
+    const raw = mood.progress * (STOPS_N - 1) + advance;
+    jTarget = Math.max(0, Math.min(STOPS_N - 1, Math.round(raw)));
+  }
   function applyMood(m) {
     mood = { progress: Math.max(0, Math.min(1, Number(m && m.progress) || 0)),
              streak: Math.max(0, Math.round(Number(m && m.streak) || 0)) };
@@ -737,12 +1169,21 @@ export async function createTube3D(opts = {}) {
       spinVel = (SPIN_BASE + (SPIN_MAX - SPIN_BASE) * mood.progress) * ID.spinMul;
       flowSpeed = (FLOW_BASE + (FLOW_MAX - FLOW_BASE) * mood.progress) * ID.flowMul;
     }
-    // a hot streak turns the veins gold; otherwise the seed's own two poles
-    // trade places across the class (A opens, B closes)
-    emissiveTarget.copy(
-      mood.streak >= 5 ? EMISSIVE_GOLD
-        : scratchColor.copy(EMISSIVE_A).lerp(EMISSIVE_B, mood.progress)
-    );
+    /* the streak pushes the journey: a new milestone (5/10/15/20) advances it
+       0.6 of a stop early; a chain of 4+ breaking to 0 pulls it 0.6 back */
+    const rung = mood.streak >= 20 ? 4 : mood.streak >= 15 ? 3 : mood.streak >= 10 ? 2 : mood.streak >= 5 ? 1 : 0;
+    if (rung > milestone) {
+      advance = Math.min(STOPS_N - 1, advance + 0.6 * (rung - milestone));
+      milestone = rung;
+    }
+    if (mood.streak === 0 && lastStreak >= 4) {
+      advance = Math.max(0, advance - 0.6);
+      milestone = 0;
+    }
+    lastStreak = mood.streak;
+    if (!reduced) retarget();
+    // a hot streak warms the lines toward gold; red is the denyHit's alone
+    tintTarget.copy(TINT_WHITE).lerp(TINT_GOLD, mood.streak >= 10 ? 0.42 : mood.streak >= 5 ? 0.28 : 0);
   }
 
   function place(p) {
@@ -775,24 +1216,46 @@ export async function createTube3D(opts = {}) {
       bandTex.repeat.x = ID.pitch * (1 + 0.035 * Math.sin(clock * 0.4));
     }
 
-    /* the morph: glide progSmooth toward the class's real progress and redraw
-       the band only while the journey params are actually moving */
-    if (!reduced) {
-      progSmooth += (mood.progress - progSmooth) * Math.min(1, dt * 0.8);
-      if (clock - lastMorphAt >= MORPH_DT) {
-        const P = paramsAt(progSmooth);
-        let moved = 0;
-        for (const f of P_KEYS) moved += Math.abs(P[f] - (P_LAST[f] || 0));
-        if (moved > 0.6 || P_LAST._never) { drawMorph(P); lastMorphAt = clock; }
+    /* the journey: glide jPos toward its target stop at the pair's own pace
+       (a morph takes morphT, a crossfade xfadeT) and repaint the band only
+       while it is actually moving, never faster than MORPH_DT */
+    if (!reduced && STOPS_N > 1) {
+      if (jPos !== jTarget) {
+        let i = Math.floor(Math.min(jPos, jTarget));
+        if (i >= STOPS_N - 1) i = STOPS_N - 2;
+        if (i < 0) i = 0;
+        const same = ID.stops[i].fam === ID.stops[Math.min(STOPS_N - 1, i + 1)].fam;
+        const step = dt / (same ? ID.morphT : ID.xfadeT);
+        const d = jTarget - jPos;
+        jPos += Math.abs(d) <= step ? d : Math.sign(d) * step;
+      }
+      if (jPos !== lastDrawnPos && (clock - lastMorphAt >= MORPH_DT || jPos === jTarget)) {
+        renderBand(jPos);
+        lastDrawnPos = jPos; lastMorphAt = clock;
       }
     }
 
-    /* band color: chase the mood target, punch red on a denyHit; the gulp
-       flares the veins too */
+    /* the hue wheel: bold palettes spin it, the classic pair only sways about
+       its arc; the streak quickens both. One uniform, zero redraws. */
+    if (!reduced) {
+      const rate = ID.cycleBase * (1 + Math.min(3, mood.streak / 4));
+      if (ID.cycleMode === 'sway') {
+        swayPh += rate * 2.2 * dt;
+        hueAng = 0.5 * Math.sin(swayPh * ID.cycleSign);   // +-29 degrees about the arc
+      } else {
+        hueAng += rate * ID.cycleSign * dt;
+        if (hueAng > 6.2832) hueAng -= 6.2832;
+        if (hueAng < -6.2832) hueAng += 6.2832;
+      }
+      hueU.value = hueAng;
+    }
+
+    /* band tint: chase the mood tint, punch red on a denyHit; the gulp flares
+       the lines too */
     redFlash *= Math.pow(0.02, dt);
-    tubeMat.emissive.copy(emissiveTarget).lerp(EMISSIVE_RED, Math.min(1, redFlash));
-    const breathe = reduced ? 0 : Math.sin(clock * 0.9) * 0.09;
-    tubeMat.emissiveIntensity = 0.42 + breathe + redFlash * 0.55 + surge * 0.14;
+    tubeMat.emissive.copy(tintTarget).lerp(TINT_RED, Math.min(1, redFlash));
+    const breathe = reduced ? 0 : Math.sin(clock * 0.9) * 0.12;
+    tubeMat.emissiveIntensity = 0.95 + breathe + redFlash * 0.5 + surge * 0.22;
 
     /* the key light crawls AGAINST the spin, so a specular sheen forever
        migrates across the coils - the cheapest living-light in the scene */
@@ -810,7 +1273,7 @@ export async function createTube3D(opts = {}) {
       comet.intensity = cometLevel * (1 + 0.15 * Math.sin(clock * 3));
     }
 
-    /* the crater breathes: seed tint at rest, lavender on the exhale, warm on
+    /* the crater breathes: lead tint at rest, lavender on the exhale, warm on
        a hot streak - all through the unlit dish's free colour multiplier, so
        the hole-not-dome ramp itself is never touched */
     dishExhale *= Math.pow(0.15, dt);
@@ -820,10 +1283,15 @@ export async function createTube3D(opts = {}) {
     dishMat.color.copy(WHITE).lerp(scratchColor, dAmt);
 
     /* the pool glow in the belly: near-invisible idle, blooms on the reveal.
-       It keeps the seed's own colour - washing it toward white turns the
-       crater milky and costs the hole its darkness */
+       It wears the palette's lead colour, cycled with the lines (setHSL
+       mutates in place - no allocation) - never white, which turns the crater
+       milky and costs the hole its darkness */
     pool.material.opacity = Math.min(0.4, 0.02 + (reduced ? 0 : 0.012 * Math.sin(clock * 1.1)) + rimBoost * 0.16 + dishExhale * 0.07);
-    pool.material.color.copy(emissiveTarget);
+    const leadH = ((LEAD[0] + hueAng * 57.2958) / 360) % 1;
+    pool.material.color.setHSL(leadH < 0 ? leadH + 1 : leadH, Math.min(1, LEAD[1]), Math.max(0.6, LEAD[2]));
+    if (!reduced && ID.cycleMode === 'spin') {
+      basinLight.color.setHSL(leadH < 0 ? leadH + 1 : leadH, Math.min(1, LEAD[1]), Math.max(0.55, LEAD[2]));
+    }
 
     /* the sealed load */
     if (travel == null) {
@@ -945,6 +1413,7 @@ export async function createTube3D(opts = {}) {
       if (!want && !dead) kick();
     },
     resize,
+    landing() { return { x: LAND.pct.x, y: LAND.pct.y, worldY: LAND.y }; },
     destroy() {
       dead = true;
       try { if (rafId && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId); } catch (e) { /* noop */ }
@@ -957,6 +1426,10 @@ export async function createTube3D(opts = {}) {
         mouthLip.geometry.dispose(); mouthLipMat.dispose();
         lip.geometry.dispose(); lipMat.dispose();
         bandTex.dispose(); haloTex.dispose();
+        /* the crossfade cache is plain canvases (no GPU side) - shrink them so
+           the bitmaps go with the class, not with the GC's mood */
+        for (const cv of cacheCanvas) { cv.width = 1; cv.height = 1; }
+        bandCanvas.width = 1; bandCanvas.height = 1;
         pool.material.dispose(); poolTex.dispose();
         pGeo.dispose(); pMat.dispose();
         renderer.dispose();

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -346,7 +346,16 @@ html.arc-report-on body { overflow:hidden; }
    Games design edge-to-edge inside .arc-classroot and keep critical controls
    clear of the top ~56px, where the strip lives. */
 html.arc-class-on body { overflow:hidden; }
-.arc-classstage { position:fixed; inset:0; z-index:10; background:var(--ground); }
+/* THE STAGE IS A SEALED GROUP. z-index:10 already makes it a stacking context,
+   but a stacking context is NOT a backdrop root: a `backdrop-filter` anywhere
+   inside a game would otherwise take the DOCUMENT ROOT as its backdrop and have
+   its render surface composited against the whole page - which in an
+   accelerated webview hoists it over #arc-fx (z 40) and buries every engine
+   effect behind the class. `isolation:isolate` is the one-line fence: a game's
+   blur may sample the class and nothing above it. Never remove it, and never
+   put `isolation`/`filter`/`will-change` on .arc-fx itself - the engine's own
+   drain wash blurs the class THROUGH that layer and needs the root backdrop. */
+.arc-classstage { position:fixed; inset:0; z-index:10; background:var(--ground); isolation:isolate; }
 .arc-classroot {
   position:absolute; inset:0;
   background:var(--ground);

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1039,6 +1039,20 @@ internal static class ArcademyHostService
         ["de_free_swim"] = "Free Swim",
         ["de_free_swim_hint"] = "No bell, no grade - swim until you surface.",
         ["de_surface"] = "Surface",
+        // ---- Impulse Control - House Rules wave (casino words + class-rules sheet)
+        ["ic_almost"] = "ALMOST",
+        ["ic_howto_drift"] = "A bubble you miss just drifts off the dish. Nothing is taken from you.",
+        ["ic_howto_go"] = "Start the drop",
+        ["ic_howto_pop"] = "A bubble lands in the dish. Pop it at once. The faster you are, the more it pays.",
+        ["ic_howto_title"] = "Class rules",
+        ["ic_howto_x"] = "A bubble wearing an X is a trap. Touch nothing until its ring runs out.",
+        ["ic_jackpot"] = "JACKPOT",
+        ["ic_just"] = "JUST",
+        ["ic_perfect_class"] = "Perfect class",
+        ["ic_record_ping"] = "record",
+        ["ic_royal"] = "ROYAL",
+        ["ic_streak_n"] = "chain {n}",
+        ["ic_tonight"] = "tonight only",
     };
 
     /// <summary>The mockup's owner-approved tokens (BUILD-CONTRACT §10). A mod overrides them via


### PR DESCRIPTION
## The Drop Tube gets the House Rules playbook

- **casino.js** THE FLOOR: bulb-ring marquee (tonight's hue), streak-pitched chime, closing gate, near-miss staging (JUST / record ping / ALMOST), jackpot ladder + ROYAL, basin flood, odometer punch, ken-burns.
- **trickster.js**: the Tell, the crooked ring, ghost cursor, stat flicker.
- **pressure.js** THE SURGE: STREAK-driven CCP effects ladder (breath / big gif bursts / spiral wheel + tremor / veil + giant / rain + scan / subs + chroma / flashes / storm) + the tube/HUD tremor (never the basin), **the dusk** (rung-driven dimmer over the tube) + **the flare** under every burst.
- **STAGE** (render/style/lex): drawn Class Rules sheet + GO, lit odometer HUD with the shell's streak meter, ticket debrief with the grade as an object; reveal 25% bigger.
- **tube3d/tube2d**: 14 pattern archetypes in 3 families, 8 bold palettes + hue cycle, streak-pushed journeys; **THE LANDING** projects the visible hole into `--ic-basin-x/-y` so the bubble sits in the dish.
- **engine**: held (`sustainForever`) washes survive a jackpot's forced garnish; rotating spiral wash is a viewport-diagonal square.
- C# `NeutralLexicon` +13 `ic_*` rows; web CLAUDE.md IC decks map + traps 33-35.

Suites: ic (449/184/88/97/183) + shell 184 green; `dotnet build` 0 errors; verified in-app over CDP + PrintWindow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ATdmiDTqatS42KYsDzbi