### PR TITLE
feat(arcademy): video-capable media nodes (webm/mp4 loops via <video>)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -23,7 +23,7 @@ import {
   NODE_CAPS, DUCK, subFlashSpec, glitchSpec, gifBurstSpec,
   burstCountForHeat, burstOpacityForHeat,
 } from './curves.js';
-import { rand, pickFrom, hasDom } from './util.js';
+import { rand, pickFrom, hasDom, mediaEl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 export function createOneshots(ctx) {
@@ -169,8 +169,9 @@ export function createOneshots(ctx) {
     function makeNode(genLeft, atX, atY) {
       if (cleared || live[counter] >= cap) return null;
       const url = opts.url || ctx.assetUrlSync(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still'));
-      const node = document.createElement(url ? 'img' : 'div');
-      if (url) node.src = url;
+      // mediaEl: <img>, or a muted looping <video> when the pool handed us a
+      // webm/mp4 loop (the only animated shape a remote provider has)
+      const node = (url && mediaEl(url)) || document.createElement('div');
       node.className = 'ae-burst ae-burst-' + variant.name + (clickable ? ' ae-burst-clickable' : '');
       node.style.setProperty('--ae-x', (atX == null ? Math.round(rand(ctx.rng, 12, 88)) : atX) + '%');
       node.style.setProperty('--ae-y', (atY == null ? Math.round(rand(ctx.rng, 14, 86)) : atY) + '%');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -19,7 +19,7 @@
 
 import { clamp01 } from '../core/caps.js';
 import { NODE_CAPS, washSpec, gifRainSpec, ambientSpec, driftSpec, bubbleSpec } from './curves.js';
-import { rand, hasDom } from './util.js';
+import { rand, hasDom, mediaEl } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 /** ambient_field kinds ported from DTRH fieldFx AMBIENT_KINDS (DOM subset). */
@@ -254,8 +254,7 @@ export function createSustained(ctx) {
     function spawn() {
       if (live.rain >= spec.max) return;
       const url = ctx.assetUrlSync(opts.assetKind || 'loop');
-      const node = document.createElement(url ? 'img' : 'div');
-      if (url) node.src = url;
+      const node = (url && mediaEl(url)) || document.createElement('div');   // <video> for a webm/mp4 loop
       node.className = 'ae-rain';
       node.style.setProperty('--ae-x', Math.round(rand(ctx.rng, 2, 88)) + '%');
       node.style.setProperty('--ae-size', Math.round(rand(ctx.rng, 90, 190)) + 'px');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -21,6 +21,40 @@ export function el(tag, cls, styles) {
   return n;
 }
 
+/** A url the <img> element cannot show: a video container. Remote providers
+ *  (Scrolller) serve animated content ONLY as silent webm/mp4 - there is no
+ *  .gif on that side at all - so a "loop" url may well be one of these. */
+export const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+export const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
+
+/** The media node for a pool url: <img> for stills/gifs, a muted, looping,
+ *  inline-autoplaying <video> for mp4/webm. Same class, same `src`, same
+ *  object-fit rules - callers never branch. Returns null with no DOM; never
+ *  throws (a DOM double without video semantics just gets a bare element). */
+export function mediaEl(url, cls) {
+  if (!hasDom()) return null;
+  const video = isVideoUrl(url);
+  const n = document.createElement(video ? 'video' : 'img');
+  if (cls) n.className = cls;
+  if (video) {
+    try {
+      n.muted = true; n.loop = true; n.autoplay = true; n.playsInline = true;
+      n.setAttribute('muted', ''); n.setAttribute('loop', ''); n.setAttribute('autoplay', '');
+      n.setAttribute('playsinline', ''); n.setAttribute('preload', 'auto');
+      n.disablePictureInPicture = true;
+    } catch { /* ignore */ }
+  } else {
+    try { n.decoding = 'async'; } catch { /* ignore */ }
+  }
+  if (url) n.src = url;
+  if (video) {
+    // muted autoplay is allowed everywhere, but a play() nudge covers the
+    // engines that only honour the attribute on elements parsed from markup
+    try { const p = n.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch { /* ignore */ }
+  }
+  return n;
+}
+
 /** Live probes (soft degrade, never withholding). Safe with no DOM. */
 export function probeReducedMotion() {
   if (!hasWindow() || !window.matchMedia) return false;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -111,6 +111,10 @@ import { compositeFor, hardGates, flavorXp } from './grade.js';
 import { DE_LEX } from './lex.js';
 import { makeTaggedRoll } from '../../core/rng.js';
 
+/** A url the <img> element cannot show (a webm/mp4 loop). Mirrors engine/util.js
+ *  VIDEO_URL_RE; games never import the engine, so the two-line rule is repeated. */
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+
 const GAME_KEY = 'the_deep_end';
 
 const KEY_DIRS = Object.freeze({
@@ -593,14 +597,7 @@ export default {
         if (facesMode !== 'plain' && !tile.silt) {
           const face = el('span', 'g-de-face');
           const img = el('img', 'g-de-media');
-          try {
-            img.setAttribute('alt', '');
-            img.setAttribute('draggable', 'false');
-            img.decoding = 'async';
-            img.draggable = false;
-            img.addEventListener('load', () => { if (!dead) node.classList.add('is-loaded'); });
-            img.addEventListener('error', () => { if (!dead) faceBroken(node); });
-          } catch (e) { /* the double has no img semantics; fine */ }
+          armMedia(img, node, false);
           face.appendChild(img);
           node.appendChild(face);
           // seeded-enough desync of the ken-burns phase: the id is the spawn order
@@ -633,6 +630,49 @@ export default {
     function mediaOf(node) {
       const face = childOf(node, 'g-de-face');
       return face ? childOf(face, 'g-de-media') : null;
+    }
+    /** Wire a face's media node: is-loaded once it has a frame, faceBroken on
+     *  error. A <video> (a webm/mp4 loop - the only animated shape a remote
+     *  provider serves) is muted / looping / inline and nudged to play. */
+    function armMedia(img, node, video) {
+      if (!img) return;
+      try {
+        img.setAttribute('alt', '');
+        img.setAttribute('draggable', 'false');
+        img.draggable = false;
+        if (video) {
+          img.muted = true; img.loop = true; img.autoplay = true; img.playsInline = true;
+          img.setAttribute('muted', ''); img.setAttribute('loop', ''); img.setAttribute('autoplay', '');
+          img.setAttribute('playsinline', ''); img.setAttribute('preload', 'auto');
+          img.addEventListener('loadeddata', () => {
+            if (dead) return;
+            node.classList.add('is-loaded');
+            try { const p = img.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* ignore */ }
+          });
+        } else {
+          img.decoding = 'async';
+          img.addEventListener('load', () => { if (!dead) node.classList.add('is-loaded'); });
+        }
+        img.addEventListener('error', () => { if (!dead) faceBroken(node); });
+      } catch (e) { /* the double has no img semantics; fine */ }
+    }
+    /** The media node that can SHOW this url: the face's <img>, swapped for a
+     *  <video> when the tier's url is a webm/mp4 loop (and back for a still).
+     *  Same class, same place in the face; the listeners are re-armed. */
+    function mediaNodeFor(node, url) {
+      const face = childOf(node, 'g-de-face');
+      if (!face) return null;
+      const cur = childOf(face, 'g-de-media');
+      const wantVideo = VIDEO_URL_RE.test(String(url || ''));
+      const isVideo = !!(cur && String(cur.tagName || '').toUpperCase() === 'VIDEO');
+      if (cur && wantVideo === isVideo) return cur;
+      const next = el(wantVideo ? 'video' : 'img', 'g-de-media');
+      armMedia(next, node, wantVideo);
+      try {
+        if (cur && typeof face.replaceChild === 'function') face.replaceChild(next, cur);
+        else face.appendChild(next);
+      } catch (e) { try { face.appendChild(next); } catch (e2) { /* ignore */ } }
+      return next;
     }
 
     /* ---- faces (pass 2): one url per tier, dealt lazily, frozen ----------- */
@@ -681,7 +721,8 @@ export default {
       }
       node.setAttribute('data-face', String(tier));
       node.classList.remove('is-loaded');
-      try { img.src = face.url; } catch (e) { /* ignore */ }
+      const media = mediaNodeFor(node, face.url) || img;
+      try { media.src = face.url; } catch (e) { /* ignore */ }
     }
     /** A url that failed: this tier goes plain for the rest of the class (no retry storm). */
     function faceBroken(node) {


### PR DESCRIPTION
Remote providers (Scrolller) serve animated content only as silent webm/mp4 - never .gif - so a 'loop' url from a remote pool was unrenderable by the engine's and the Deep End's <img> nodes.

- engine/util.js: mediaEl(url, cls) -> <video muted loop autoplay playsinline> for mp4/webm/m4v, <img> otherwise (same class/src/object-fit; callers never branch)
- engine/oneshots.js gif_burst + engine/sustained.js gif_rain use it
- games/the-deep-end: a tile face swaps its media node to match the dealt url (loadeddata -> is-loaded, error -> faceBroken)

Inert for the app today (ArcademyHostService feeds stills / GifStill posters); first consumer is the unlisted cclabs.app/labs/deep-end/ web teaser, which copies these exact files.

DE suite 509/509 green. Not touching the foreign dirty dtrh/intake files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ATdmiDTqatS42KYsDzbi