### PR TITLE
feat(arcademy): Semesters II + III - all ten classes playable

### DIFF
--- a/ConditioningControlPanel/App.xaml.cs
+++ b/ConditioningControlPanel/App.xaml.cs
@@ -2549,7 +2549,7 @@ namespace ConditioningControlPanel
             // bypassing the Play strip. Launch() applies the same T2 + AudioOnlySession gates the
             // card's click does, so this skips the UI and nothing else.
             if (e.Args.Contains("--arcademy"))
-                Services.Arcademy.ArcademyHostService.Launch();
+                Services.Arcademy.ArcademyHostService.LaunchDev();
 
             // Arm the offline mic features (wake word / push-to-talk) at startup if the user left them
             // on. They're decoupled from Takeover ("She's Listening" owns them), so they no longer wait

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -57,6 +57,8 @@ shell/peek.js      the shared hold-to-reveal verb (caps the class at A)
 shell/keybinds.js  manifest-declared verb slots, one blob, PanicKey conflict check
 shell/audio.js     THE consumer of engine 'arcademy-sfx' (WebAudio, procedural)
 games/registry.js  guarded allSettled registry + tier math + class_suspended stub
+                   + GAME_SEMESTER / OPEN_SEMESTERS (the release gate: a CLOSED semester's
+                   games are ABSENT from the pool, never stubs; isOpenSemester())
                    GAME_META here is the PARACHUTE: it must mirror each module's
                    own family/meaty/flagship/timeBudgetSec, because the timetable
                    reads a suspended class's descriptor too
@@ -81,10 +83,37 @@ games/<key>/index.js  one folder per game; games NEVER import each other
   the-deep-end/    2048 with trance-depth tiers (MEATY) - board/schedule/grade/lex/style/casino/trickster/pressure
                    the deepest tile is the heat dial; board/schedule/grade pure, casino+trickster+pressure decks
                    (pressure = the rung-by-rung CCP effects ladder + the Balatro board tremor/HUD juice)
+  -- Semesters II + III (2026-08-23; every class below ships ALL the House Rules decks from day one:
+     style (the look + the drawn class-rules sheet) / casino (THE FLOOR) / trickster (schedule-dealt
+     cards, budget 2/4/6/8 by tier) / pressure (THE SURGE, the CCP-effects ladder on the game's own
+     streak) + a lex.js <P>_LEX table; decks are dynamic-imported + null-safe so a broken deck never
+     takes the class down) --
+  misdirection/    the shell game (tracking, 120s)        - shuffle (PURE seeded plan + verifyRound = the
+                   TRACKABILITY INVARIANT: occlusion hides at most ONE link of a swap chain and every
+                   occlusion carries a tell) / grade / lex MD_LEX; keybinds pick1..pick5; md_stake_mode
+                   ask|bank|ride (greed scored UPWARD only, ride cap 5), md_shell_skin themed|minimal|contrast
+  echo/            the Simon ring (memory, 105s)          - sequence (PURE: warm start 3..6 off bestLen, decoy
+                   plan from tier 2 telegraphed) / grade / lex EC_LEX; keybinds pad1..pad6; six pads always live,
+                   the TIER restricts the alphabet; tones = engine audio_trigger 'pad' x pitch (+1 semitone per
+                   link, cap 7); a fail is NOT the class (new sequences until the bell); Encore once, auto
+  instant-recall/  the vigil (recall, 120s, MEATY)        - vigil (PURE seeded script: stops w/ FINAL-STOP
+                   GUARANTEE in the last 15s, layouts rows/mosaic/swirl, density sawtooth, plants, templates
+                   LAST_WORD/EFFECT/STING/TWO + MODE tier 4 <=10%) / montage (the stage + the L&F live-window
+                   discipline + createLedger = the TRUTH tail, aria-hidden) / grade / lex IR_LEX; ir_density
+  anomaly/         the odd-one-out grid (search, 90s)     - rounds (PURE: kinds/deltas at PERCEPTIBLE floors,
+                   relocations cap 2/round, drift) / grade / lex AN_LEX; the odd index lives in CLOSURE ONLY -
+                   never a DOM attr/class (suite asserts it); decks get a canMelt(i)/meltCandidates() oracle
+                   and nothing else; an_kinds all|gentle
+  composure/       the sliding picture (puzzle, 120s, MEATY) - board (PURE, seeded SOLVABLE scramble w/ parity)
+                   / solver (PURE baseline: optimal 3x3 IDA*, 4x4/5x5 BFS over tracked-tiles+gap - the greedy
+                   textbook solver deadlocked 1 board in 5) / grade (par from the solver) / lex CP_LEX;
+                   manifest.peek TRUE (the shell's hold-to-reveal = A-cap); cp_mode timed|zen (zen ends
+                   {zen:true} = 'pass'), cp_zen_grid; skill-floor rescue after 20s (solver hint + sGate false);
+                   locks are MARKERS never freezes (a frozen tile can make a board unsolvable)
 ```
 
 Each game owns its own lexicon rows; **`ArcademyHostService.NeutralLexicon` mirrors every
-one of them** (200 rows as of Semester 1; `de_*` + the IC House Rules wave since - the count is a
+one of them** (672 rows as of Semesters II+III, 2026-08-23 - the count is a
 floor, never a contract: a scratch script diffs every `t('key'` / lexicon table against the C#
 table, see §7) or the shell renders raw keys for the settings
 page's `label_key` / `hint_key`. Impulse Control exports its table as data
@@ -151,10 +180,14 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
    no-repeat) and no-repeat *narrows* (3→2→1→off) instead of dying, so the board still
    refuses yesterday's class. Every constraint is also a seeded weight so the preference
    survives relaxation. `day.relaxed` and `day.noRepeatWindow` report what happened.
-6. ~~**A pool with exactly one meaty game cannot be meaty every day.**~~ **CLOSED by The Deep
-   End.** no-repeat outranks meaty, so with one meaty game the meaty slot filled ~1 day in 4.
-   With two (`lost_and_found` 120s + `the_deep_end` 300s) a dealt fortnight carries exactly one
-   meaty class on all 14 days. The arithmetic never changed — the pool grew.
+6. **A pool needs FOUR meaty games to deal one meaty class EVERY night.** no-repeat outranks
+   meaty. With the five-game pool no-repeat-3 was unsatisfiable and relaxed first, so two meaty
+   games (`lost_and_found`, `the_deep_end`) filled the slot nightly "for free". The TEN-game pool
+   re-opened it: no-repeat-3 binds again (`noRepeatWindow === 3` every day) and two meaty classes
+   cannot cover a 3-day window - measured 13/28 nights with two, 21/28 with three, **28/28 with four**
+   (`scratchpad/ttcheck/check.mjs`). So `instant_recall` and `composure` are meaty too (ruled
+   2026-08-23); the flag is a timetable fact, nothing in a module branches on it. A fifth meaty game
+   changes nothing; dropping to three silently loses a quarter of the nights.
 7. **The timetable's history is an epoch walk, not a recursion.** `EPOCH = '2026-08-01'`
    and the generator walks forward to the target date, memoised. That makes it a fixed
    point (day D-1 computed as history === day D-1 computed on its own — tested). **Moving
@@ -370,6 +403,32 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     room that changes its own look twice is worse than a room that is simply lighter. With no
     `requestAnimationFrame` (node, the DOM double) the probe must **stay full**: a missing
     frame clock is not evidence of a slow machine.
+
+37. **A backtick inside a CSS comment inside a template-literal stylesheet kills the WHOLE
+    sheet.** `` /* `[data-tier]` */ `` in a `STYLE_TEXT` template ends the literal early; the page
+    dies with `ReferenceError: data is not defined` and `node --check` passes it - only a browser
+    load catches it. Three agents hit it in one day (IC stage, DE howto, MD decks). Never write a
+    backtick in a CSS comment in a `.js` stylesheet.
+38. **`applySuspend(false)` must re-assert the pause.** The shell leaves a lifted suspend behind
+    its pause card on purpose (the Resume button is the way back), but a game's `suspend(false)`
+    typically restarts its own loop - Misdirection and The Deep End both played on behind the
+    overlay. `applySuspend` now calls `instance.pause()` again when `active.paused` is set.
+39. **The spiral pool is bundled + THE LOOM.** `shell.js pickSpiralUrl(seed, settings)` appends
+    `init.settings.loomSpirals` (the host's `https://ccp.spirals/loom_<slug>.gif` list, same folder
+    DTRH exposes) at weight 20 each, cap 24, validated + de-duplicated. No Loom = byte-identical
+    picks. The host maps `ccp.spirals` for the Arcademy too (`ArcademyHostService` mappings).
+40. **`core/rng.js makeTaggedRoll` is per-tag mulberry32 now.** The first version hashed
+    `seed|tag|n` per call and the trailing counter barely avalanched through FNV-1a (~0.4%
+    near-equal consecutive pairs); every deck had worked around it with its own per-tag mulberry32.
+    Same contract (tags independent, replay exact), different stream - any golden value recorded
+    off the old stream (none were) would move.
+41. **iOS/WebKit: a `transform` whose `calc()` reads an UNREGISTERED custom property does NOT
+    transition when that property changes - the tile TELEPORTS** (owner, iPhone 13 Pro Max, the
+    Deep End web teaser, 2026-08-23). `--r`/`--c`/`--x` are the CORE<->deck contract and stay
+    unregistered (decks read them; `--r` is even an ANGLE in one casino, so a global `@property
+    --r <number>` would break it). Fix = game-scoped REGISTERED twins: CORE writes `--cp-r/--cp-c`
+    (`--md-x`, `--de-r/--de-c`) beside the contract vars and the stylesheet's transform reads the
+    twin. Chromium/WebView2 never showed it, so the desktop rigs cannot catch it - the iPhone can.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -332,6 +332,45 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     report, inject a solid test box into `.ae-front` and PrintWindow the app - if the box is
     on top, it is alpha.
 
+36. **A WEB PAGE'S FRAME BUDGET IS SPENT ON THREE THINGS, AND NONE OF THEM IS "TOO MANY
+    NODES."** Chromium trace of The Deep End, full screen, 16 live video tiles, RTX 3060 Ti:
+    the GPU process's main thread at **79% of a core**, in three roughly equal thirds.
+    - **RENDER SURFACES.** ~86 per frame. `isolation:isolate` + a `mix-blend-mode` pseudo on
+      every tile face is two surfaces *per tile*, and a blend surface must read back what is
+      under it before it can write. A `filter:` on a `<video>` is worse still: a full GPU pass
+      over a decoded 854x480 frame, per tile, per frame. **Tint with plain alpha and bake a
+      "desaturate" into the wash gradient; never put a filter on a live decode.**
+    - **PER-FRAME RE-RASTER.** `@keyframes { to { background-position: … } }` re-rasters the
+      WHOLE layer every frame; six full-screen sheets doing it is a third of the budget on
+      gradients that never changed shape. **PATTERNS DRIFT BY TRANSFORM, NEVER BY
+      BACKGROUND-POSITION** (the law is written into `the-deep-end/style.js`): oversize the
+      sheet by exactly one tile period on its trailing edge and `translate` it by exactly that
+      period, so the wrap lands on an identical pixel. One background layer per pseudo - two
+      layers with different tile sizes cannot share one transform. Corollary: a *travelling*
+      highlight needs a clipping box, and a `::before` cannot own a `::before`, so a sweep on
+      a pseudo (the old `g-de-sheen`, `g-de-scan`) either grows a real element or becomes an
+      `opacity` breathe. Prefer the breathe; a per-tile node to save raster is a bad trade.
+    - **VIDEO DECODES.** Scrolller's SMALLEST rendition IS 854x480, so asking for a smaller
+      file is not a lever - the **decoder COUNT** is the only one. Faces are frozen per TIER,
+      so a cap counted in tiles is meaningless (17 tier-1 tiles = 1 file, 17 decodes). The
+      Deep End caps **distinct animated tiers** (`FACE_CAP` 6) and keeps the numerous shallow
+      tiers on stills (`SHALLOW_STILL_MAX_TIER` 3) - *the shallows are still, depth is alive*.
+      The ENGINE shares one budget of its own: `engine/util.js` `budgetedKind('loop')` counts
+      the `<video>` nodes `mediaEl` has minted and hands `gif_rain` / `gif_burst` a **still**
+      once `VIDEO_BUDGET` (6; 2 under `.ae-lite`) is spent. Anything that mints a decoration
+      video must come through `mediaEl` and leave through `timers.release`/`kill`, or the
+      count leaks and the budget closes for the session.
+    **AND A LADDER, NOT A SWITCH:** under a 4x CPU throttle even an all-stills board fell to
+    40fps, so the whole frame has to get cheaper, not just the videos. `de_perf`
+    (`auto|full|lite`) is the pattern: `lite` = `.g-de-lite` on the game's stage **and
+    `.ae-lite` on `document.documentElement`** (the one seam a game and the engine share -
+    the engine never owns that class, it only reads it), and **both come off on destroy or
+    the lobby inherits a lit-down room**. `auto` samples rAF deltas for ~3s after the board is
+    dealt, skips the first 500ms of first-frame cost, and demotes **once, downward only** - a
+    room that changes its own look twice is worse than a room that is simply lighter. With no
+    `requestAnimationFrame` (node, the DOM double) the probe must **stay full**: a missing
+    frame clock is not evidence of a slow machine.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -422,13 +422,20 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     near-equal consecutive pairs); every deck had worked around it with its own per-tag mulberry32.
     Same contract (tags independent, replay exact), different stream - any golden value recorded
     off the old stream (none were) would move.
-41. **iOS/WebKit: a `transform` whose `calc()` reads an UNREGISTERED custom property does NOT
-    transition when that property changes - the tile TELEPORTS** (owner, iPhone 13 Pro Max, the
-    Deep End web teaser, 2026-08-23). `--r`/`--c`/`--x` are the CORE<->deck contract and stay
-    unregistered (decks read them; `--r` is even an ANGLE in one casino, so a global `@property
-    --r <number>` would break it). Fix = game-scoped REGISTERED twins: CORE writes `--cp-r/--cp-c`
-    (`--md-x`, `--de-r/--de-c`) beside the contract vars and the stylesheet's transform reads the
-    twin. Chromium/WebView2 never showed it, so the desktop rigs cannot catch it - the iPhone can.
+41. **"WebKit won't transition an unregistered custom property" is a MYTH - measure before you
+    rename.** The Deep End web teaser "teleported" tiles on an iPhone 13 Pro Max (2026-08-23) and the
+    first diagnosis was exactly that myth; registered `--cp-r/--cp-c` / `--md-x` twins were even
+    built and then reverted. The measurement (peer session, Playwright WebKit 26.5 + Chromium): all
+    four variants - unregistered var + `transition:transform`, `@property` var, transition on the
+    vars themselves, both - interpolate IDENTICALLY in both engines; on the live Deep End page WebKit
+    fires `transitionrun` on transform when `--r/--c` change (keyboard and touch) and a no-var
+    plain-transform control traced byte-identical. What reads as "the transition never fired" on a
+    phone is a 170ms transition receiving 1-3 FRAMES under load - cut per-frame cost (the
+    `html.ae-touch` rung: no blur over a live face, no blend surface, no backdrop-filter, video
+    budget 3 on coarse pointers) instead of renaming variables. What IS true: `@property` is
+    page-global, so a var name shared with mixed types (`--r` is a number here and an ANGLE in
+    misdirection/casino.js) can never be registered globally - if registration is ever genuinely
+    needed, use game-prefixed names.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -437,6 +437,42 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     misdirection/casino.js) can never be registered globally - if registration is ever genuinely
     needed, use game-prefixed names.
 
+42. **A PHONE NEEDS THE CUTS ON *FULL*, AND THE SEAM IS `html.ae-touch`.** The owner's
+    iPhone 13 Pro Max skipped frames on slide/merge and skipped harder when effects fired -
+    on the LITE rung (web teaser, 2026-08-23). de_perf's full/lite ladder is a QUALITY
+    ladder and it cannot fix this, because two of the three costs are HARDWARE ceilings, not
+    frame budget: iOS caps concurrent hardware video decode SESSIONS (three or four before
+    VideoToolbox thrashes and every stream stutters at once), and WebKit charges several ms
+    a frame for a backdrop-filter or a full-screen blend surface that a desktop GPU eats for
+    free. So The Deep End probes the device once per class - `matchMedia('(pointer: coarse)')`
+    or `navigator.maxTouchPoints > 1` - and puts **`.ae-touch` on `<html>`**, the same
+    document-root seam `.ae-lite` uses (the game sets it, the engine only reads it, and
+    BOTH come off on destroy or the lobby inherits a phone's ceiling).
+    - It is **NOT a third rung**: it applies on FULL too, and `de_perf: full` does not opt
+      out of it. There is no setting and there must never be one - the device is the setting.
+    - It **composes with the rung in the PROTECTIVE direction, and the two dials point
+      opposite ways**: `faceCap` takes the **MIN** (`FACE_CAP` 6 / `_LITE` 3 / `_TOUCH` 4 -
+      fewer decoders wins) while `shallowStillMaxTier` takes the **MAX** (3 / 5 / 4 - more
+      of the numerous shallow tiers frozen wins). A `min` on the still-line would hand a lite
+      PHONE more animated tiers than a lite desktop. `engine/util.js videoBudget()` mins the
+      same way: 6 desktop, 3 touch, 2 lite, 2 touch+lite.
+    - `engine/style.js` `.ae-touch` drops what WebKit charges most for, on every rung: the
+      drain wash's backdrop-filter, `mix-blend-mode` on the four FULL-SCREEN washes (the
+      spiral is 150vmax - over twice the viewport of read-back), the scanline's
+      `background-position` roll (per-frame re-raster of a full-screen sheet), and the two
+      filters that can land over a live decode (`ae-burst-double` on a gif_burst <video>,
+      `ae-mosh`'s blur every frame of a swap). The Deep End's own `.ae-touch` block in
+      `games/the-deep-end/style.js` does the same on the game side: no blur on `.is-gone` /
+      resurface tiles (blur over a live face), the lens loses its blend surface, the glitch
+      payload loses backdrop-filter, the merge glyph pops by transform/opacity only.
+    - Low Power Mode caps rAF to 30fps and the auto probe demotes to lite on that. That is
+      CORRECT, not a bug: iOS Safari caps rAF to 60 even on ProMotion, so the PASS-5
+      thresholds (median 20ms / 25ms x 40%) mean the same thing on a phone as on a desktop.
+    - Caveat, accepted deliberately: a Windows touchscreen laptop reports
+      `maxTouchPoints: 10` with a fine pointer and therefore also gets the ceiling. It is
+      hardware-protective and cheap; do not "fix" it by dropping the maxTouchPoints probe,
+      which is the only signal a webview that answers no media query has.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -56,6 +56,7 @@ export const DEFAULT_LEXICON = Object.freeze({
   /* families (timetable chips) */
   family_word: 'word', family_memory: 'memory', family_search: 'search',
   family_tracking: 'tracking', family_reflex: 'reflex', family_comfort: 'comfort',
+  family_recall: 'recall', family_puzzle: 'puzzle',
 
   /* verbs / chrome */
   peek: 'Peek',
@@ -96,6 +97,17 @@ export const DEFAULT_LEXICON = Object.freeze({
   campus_desc_impulse_control: 'Hands on the desk. Move only when told - the room will lie to you.',
   campus_desc_lost_and_found: 'Things went missing in a wall of moving pictures. Find them before they move again.',
   campus_desc_the_deep_end: 'Sink tile into tile. The deeper you go, the harder the board is to read.',
+  /* Semesters II / III (2026-08-23) */
+  campus_room_misdirection: 'The Parlour',
+  campus_room_echo: 'Music Room',
+  campus_room_instant_recall: 'Lecture Hall',
+  campus_room_anomaly: 'Darkroom',
+  campus_room_composure: 'The Studio',
+  campus_desc_misdirection: 'Keep your eyes on the one that matters. It will not make that easy.',
+  campus_desc_echo: 'It plays a line, you play it back. Then it adds one more, every time.',
+  campus_desc_instant_recall: 'Watch the whole hour, then answer for it. You never hear it coming.',
+  campus_desc_anomaly: 'Everything in here matches. One thing does not. Find it before it moves.',
+  campus_desc_composure: 'Slide the picture back together while the room does its best to blur it.',
   campus_records: 'Records',
   campus_desc_records: 'Report card, attendance ledger, grades. Your whole term, in ink.',
   campus_registrar: 'Registrar',
@@ -113,6 +125,8 @@ export const DEFAULT_LEXICON = Object.freeze({
   campus_east_wing: 'East Wing',
   campus_west_wing: 'West Wing',
   campus_desc_east: 'You can hear hammering behind the tape.',
+  campus_desc_east_open: 'The tape is down. Wet paint, three new doors, nobody at the desk.',
+  campus_desc_west_open: 'Older boards, deeper rooms. Nobody in here is in any hurry.',
   campus_desc_west: 'The boards are older here.',
   campus_sealed: 'Sealed',
   campus_opens_semester_2: 'Opens Semester II',

--- a/ConditioningControlPanel/Resources/web/arcademy/core/rng.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/rng.js
@@ -46,15 +46,24 @@ export function makeRng(seedStr) {
  * A tag-namespaced roll stream over one seed: roll('burst') advances only the
  * 'burst' namespace, so adding a new roll never shifts an existing sequence
  * (the fix reward.js applies to its kind rolls). Additive helper.
+ *
+ * Each tag owns a mulberry32 stream seeded from hash01(seed|tag). The first
+ * version hashed `seed|tag|n` per call and the trailing counter byte barely
+ * avalanches through FNV-1a, so consecutive rolls of one tag clustered (~0.4%
+ * near-equal pairs; the decks worked around it with per-tag mulberry32 - this
+ * IS that fix, in core). Same contract: tags are independent, replay is exact.
  */
 export function makeTaggedRoll(seedStr) {
   const seed = seedStr == null ? '' : String(seedStr);
-  const counts = new Map();
+  const streams = new Map();
   return function roll(tag) {
     const t = String(tag == null ? '' : tag);
-    const n = counts.get(t) || 0;
-    counts.set(t, n + 1);
-    return hash01(seed + '|' + t + '|' + n);
+    let s = streams.get(t);
+    if (!s) {
+      s = mulberry32(Math.floor(hash01(seed + '|' + t) * 0xFFFFFFFF));
+      streams.set(t, s);
+    }
+    return s();
   };
 }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -23,7 +23,7 @@ import {
   NODE_CAPS, DUCK, subFlashSpec, glitchSpec, gifBurstSpec,
   burstCountForHeat, burstOpacityForHeat,
 } from './curves.js';
-import { rand, pickFrom, hasDom, mediaEl } from './util.js';
+import { rand, pickFrom, hasDom, mediaEl, budgetedKind } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 export function createOneshots(ctx) {
@@ -168,7 +168,12 @@ export function createOneshots(ctx) {
 
     function makeNode(genLeft, atX, atY) {
       if (cleared || live[counter] >= cap) return null;
-      const url = opts.url || ctx.assetUrlSync(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still'));
+      /* THE DECODER BUDGET (util.js): a gif_burst asks for a loop, but once the
+       * shared budget is spent it is handed a still instead - the burst is the
+       * same size, the same count and the same hold, it just stops minting a
+       * 854x480 decoder per node. An explicit opts.url is the caller's own
+       * choice and is never second-guessed. */
+      const url = opts.url || ctx.assetUrlSync(budgetedKind(opts.assetKind || (kind === 'gif_burst' ? 'loop' : 'still')));
       // mediaEl: <img>, or a muted looping <video> when the pool handed us a
       // webm/mp4 loop (the only animated shape a remote provider has)
       const node = (url && mediaEl(url)) || document.createElement('div');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -145,6 +145,21 @@ export const STYLE_TEXT = `
   opacity:0;animation:ae-near 400ms ease-out forwards}
 @keyframes ae-near{0%{opacity:0}40%{opacity:var(--ae-alpha,.1)}100%{opacity:0}}
 
+/* ---- the lite rung: html.ae-lite ------------------------------------------
+   Set by whoever knows the frame budget (The Deep End's de_perf ladder today;
+   the engine never owns the class, it only reads it - the same seam
+   util.js's shared decoder budget uses). This is NOT reduced motion: the
+   effects still play, they just stop asking for the two things that cost a
+   weak machine a whole frame.
+     - a backdrop-filter is a full-screen read-back-and-blur, per frame, for as
+       long as the drain wash is up. The wash's own gradient carries the drain
+       on its own; only the blur goes.
+     - the spiral is a 150vmax square rotating forever: the biggest composited
+       layer the engine ever makes. It holds still instead of stopping, so a
+       held wash still reads as a wash. */
+.ae-lite .ae-wash-drain{backdrop-filter:none;-webkit-backdrop-filter:none}
+.ae-lite .ae-wash-spiral{animation:none}
+
 /* ---- reduced motion: neutralise EVERY animation -------------------------- */
 @media (prefers-reduced-motion: reduce){
   .ae-layer *{animation-duration:.01ms !important;animation-iteration-count:1 !important;

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -160,6 +160,33 @@ export const STYLE_TEXT = `
 .ae-lite .ae-wash-drain{backdrop-filter:none;-webkit-backdrop-filter:none}
 .ae-lite .ae-wash-spiral{animation:none}
 
+/* ---- the touch rung: html.ae-touch ----------------------------------------
+   Set the same way .ae-lite is (the game knows the device; the engine only
+   reads the class), but it is NOT a quality rung - it is a HARDWARE ceiling
+   that applies ON FULL TOO, and it stacks with lite rather than replacing it.
+   A phone pays for three things a desktop GPU eats for free, and WebKit pays
+   the most for all three:
+     - backdrop-filter, the full-screen read-back-and-blur, every frame the
+       drain wash is up. Its gradient already carries the drain; only the blur
+       goes, exactly as in lite.
+     - a BLEND SURFACE has to read what is under it before it can write, and
+       these four are FULL-SCREEN (the spiral is 150vmax, over twice the
+       viewport). On the near-black ground screen and plain alpha read almost
+       identically, so the tint stays and the read-back goes.
+     - a FILTER over a live decode is a whole GPU pass per decoded frame
+       (ae-burst-double lands on gif_burst nodes, which are <video> whenever
+       the pool hands back a webm), and ae-mosh's blur re-runs that pass every
+       frame of the swap. Both drop; datamosh keeps the transform-only shudder
+       so a swap still reads as a glitch.
+   The scanline roll is per-frame re-raster of a full-screen sheet
+   (background-position, the one pattern the perf trace named), so it holds
+   still on touch - the scanlines themselves stay. */
+.ae-touch .ae-wash-drain{backdrop-filter:none;-webkit-backdrop-filter:none}
+.ae-touch .ae-wash-pink,.ae-touch .ae-wash-spiral,.ae-touch .ae-wash-sublim,.ae-touch .ae-jackpot{mix-blend-mode:normal}
+.ae-touch .ae-crt-live{animation:none}
+.ae-touch .ae-burst-double{filter:none}
+.ae-touch .ae-glitch-datamosh{filter:none;animation:ae-shudder var(--ae-dur,600ms) steps(2,end) 1}
+
 /* ---- reduced motion: neutralise EVERY animation -------------------------- */
 @media (prefers-reduced-motion: reduce){
   .ae-layer *{animation-duration:.01ms !important;animation-iteration-count:1 !important;

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -19,7 +19,7 @@
 
 import { clamp01 } from '../core/caps.js';
 import { NODE_CAPS, washSpec, gifRainSpec, ambientSpec, driftSpec, bubbleSpec } from './curves.js';
-import { rand, hasDom, mediaEl } from './util.js';
+import { rand, hasDom, mediaEl, budgetedKind } from './util.js';
 import { createEscapeGuard } from './escape.js';
 
 /** ambient_field kinds ported from DTRH fieldFx AMBIENT_KINDS (DOM subset). */
@@ -253,7 +253,9 @@ export function createSustained(ctx) {
 
     function spawn() {
       if (live.rain >= spec.max) return;
-      const url = ctx.assetUrlSync(opts.assetKind || 'loop');
+      /* THE DECODER BUDGET (util.js): past it a 'loop' request is served a
+       * still, so the rain keeps its node count and drops its decode cost. */
+      const url = ctx.assetUrlSync(budgetedKind(opts.assetKind || 'loop'));
       const node = (url && mediaEl(url)) || document.createElement('div');   // <video> for a webm/mp4 loop
       node.className = 'ae-rain';
       node.style.setProperty('--ae-x', Math.round(rand(ctx.rng, 2, 88)) + '%');

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -42,18 +42,30 @@ export const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
  *
  * The lite rung reads `.ae-lite` on <html> (a game or the shell sets it; the
  * engine never owns that class), because a machine that cannot paint the frame
- * cannot decode six videos either. */
+ * cannot decode six videos either.
+ *
+ * THE TOUCH RUNG reads `.ae-touch` on <html>, set the same way and by the same
+ * kind of caller, and it is a HARDWARE ceiling rather than a quality level: iOS
+ * caps concurrent hardware decode SESSIONS (three or four before VideoToolbox
+ * thrashes and every stream stutters), so a phone gets 3 even on the FULL rung.
+ * The two compose the protective way - fewer decoders always wins - so
+ * touch+lite is min(2,3) = 2 and a lite phone is never handed MORE video than a
+ * lite desktop. */
 export const VIDEO_BUDGET = 6;
 export const VIDEO_BUDGET_LITE = 2;
+export const VIDEO_BUDGET_TOUCH = 3;
 let liveVideos = 0;
 /** How many decoration <video> nodes mediaEl has minted and not yet released. */
 export const liveVideoCount = () => liveVideos;
 export function videoBudget() {
+  let budget = VIDEO_BUDGET;
   try {
     const html = hasDom() ? document.documentElement : null;
-    if (html && html.classList && html.classList.contains('ae-lite')) return VIDEO_BUDGET_LITE;
+    const cl = html && html.classList ? html.classList : null;
+    if (cl && cl.contains('ae-lite')) budget = Math.min(budget, VIDEO_BUDGET_LITE);
+    if (cl && cl.contains('ae-touch')) budget = Math.min(budget, VIDEO_BUDGET_TOUCH);
   } catch { /* ignore */ }
-  return VIDEO_BUDGET;
+  return budget;
 }
 /** The asset kind decoration may actually ask for. 'loop' until the budget is
  *  spent, then 'still' - every other kind passes straight through. */

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/util.js
@@ -27,16 +27,62 @@ export function el(tag, cls, styles) {
 export const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
 export const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
 
+/* ---- THE DECODER BUDGET (perf, measured 2026-08-23) -----------------------
+ * A Chromium trace of a full-screen board with sixteen live video tiles put the
+ * GPU process's main thread at 79% of a core, and roughly a third of that was
+ * simultaneous 854x480 decodes. Scrolller's SMALLEST rendition is 854x480, so
+ * there is no cheaper file to ask for: the only lever is the decoder COUNT.
+ *
+ * Decoration therefore shares one budget. `gif_rain` and `gif_burst` ask
+ * `budgetedKind('loop')` before they ask the pool for a url, and once the
+ * budget is spent they are handed a STILL instead - the shower keeps its node
+ * count and its rhythm, it just stops minting decoders. The counter lives here
+ * because `mediaEl` is the one door a decoration video comes in through and
+ * `createTimers` release/kill is the one door it leaves by.
+ *
+ * The lite rung reads `.ae-lite` on <html> (a game or the shell sets it; the
+ * engine never owns that class), because a machine that cannot paint the frame
+ * cannot decode six videos either. */
+export const VIDEO_BUDGET = 6;
+export const VIDEO_BUDGET_LITE = 2;
+let liveVideos = 0;
+/** How many decoration <video> nodes mediaEl has minted and not yet released. */
+export const liveVideoCount = () => liveVideos;
+export function videoBudget() {
+  try {
+    const html = hasDom() ? document.documentElement : null;
+    if (html && html.classList && html.classList.contains('ae-lite')) return VIDEO_BUDGET_LITE;
+  } catch { /* ignore */ }
+  return VIDEO_BUDGET;
+}
+/** The asset kind decoration may actually ask for. 'loop' until the budget is
+ *  spent, then 'still' - every other kind passes straight through. */
+export function budgetedKind(want) {
+  if (want !== 'loop') return want;
+  return liveVideos >= videoBudget() ? 'still' : 'loop';
+}
+/** Test seam only: the harness runs many cases in one process. */
+export function resetVideoBudget() { liveVideos = 0; }
+function forgetVideo(node) {
+  if (!node || node.__aeVideo !== true) return;
+  try { node.__aeVideo = false; } catch { /* ignore */ }
+  liveVideos = liveVideos > 0 ? liveVideos - 1 : 0;
+}
+
 /** The media node for a pool url: <img> for stills/gifs, a muted, looping,
  *  inline-autoplaying <video> for mp4/webm. Same class, same `src`, same
  *  object-fit rules - callers never branch. Returns null with no DOM; never
- *  throws (a DOM double without video semantics just gets a bare element). */
+ *  throws (a DOM double without video semantics just gets a bare element).
+ *  A <video> is COUNTED against the shared decoder budget from here until the
+ *  timer registry releases it. */
 export function mediaEl(url, cls) {
   if (!hasDom()) return null;
   const video = isVideoUrl(url);
   const n = document.createElement(video ? 'video' : 'img');
   if (cls) n.className = cls;
   if (video) {
+    liveVideos += 1;
+    try { n.__aeVideo = true; } catch { /* a double may be frozen; the count still holds */ }
     try {
       n.muted = true; n.loop = true; n.autoplay = true; n.playsInline = true;
       n.setAttribute('muted', ''); n.setAttribute('loop', ''); n.setAttribute('autoplay', '');
@@ -120,13 +166,14 @@ export function createTimers() {
   function release(node) {
     if (!node) return;
     nodes.delete(node);
+    forgetVideo(node);                       // give the decoder back to the budget
     try { if (node.parentNode) node.parentNode.removeChild(node); } catch { /* ignore */ }
   }
   function kill() {
     for (const id of timeouts) clearTimeout(id);
     for (const id of intervals) clearInterval(id);
     for (const h of rafs) { try { h.cancel(); } catch { /* ignore */ } }
-    for (const n of nodes) { try { if (n.parentNode) n.parentNode.removeChild(n); } catch { /* ignore */ } }
+    for (const n of nodes) { forgetVideo(n); try { if (n.parentNode) n.parentNode.removeChild(n); } catch { /* ignore */ } }
     timeouts = new Set(); intervals = new Set(); rafs = new Set(); nodes = new Set();
   }
   return {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/casino.js
@@ -1,0 +1,856 @@
+/* ============================================================================
+ * games/anomaly/casino.js - DECK II of the House Rules for the darkroom: THE
+ * FLOOR. The grid is a contact sheet under a red safelight; the trickster
+ * (trickster.js) lies about the room, the pressure (pressure.js) is what the
+ * room does to you as your streak climbs. This file is the lighting rig and
+ * the chime rack - the enlarger lamp, the safelight, the bulb string, the
+ * payout light and the sound ladder.
+ *
+ *   DARKROOM IDENTITY  seeded per CLASS seed (Deck I): a safelight hue on the
+ *                      red->amber arc (~6% of darkrooms leave the arc for a
+ *                      green "infrared" night - a bonus round for loading in),
+ *                      the enlarger lamp's position and tilt, a breathing
+ *                      period, a drift period, the dust density, the ken-burns
+ *                      roll, the frame number the contact sheet starts at, and
+ *                      a JOURNEY of 2-4 stops through one morph space (the
+ *                      lamp swings, the dust thickens, the safelight deepens)
+ *                      walked by the class's own heat. Same seed, same room; a
+ *                      retake develops the identical print.
+ *   THE MARQUEE        a string of bulbs hugging the grid (a real node in the
+ *                      overlay, sized from the grid's rect - never a child of
+ *                      the grid, never a tile). Crawls at low heat, chases
+ *                      hungrily at high heat, flashes on a payout, goes GOLD
+ *                      for the bell and the royal, sighs out - never cuts - on
+ *                      a dim-out.
+ *   THE EXPOSURE       a correct first tap pays light in under 500ms: the
+ *                      enlarger FLASHES (the backdrop's flash layer), a ring
+ *                      blooms on the found frame (overlay, measured once), the
+ *                      marquee flashes, the chime CLIMBS (+1 semitone per link
+ *                      of the streak, capped +7 - the intake precedent). A
+ *                      wrong tap is a muted thud and a cold pulse (the
+ *                      safelight dips, the frame frosts) - never silence.
+ *   NEAR-MISS STAGING  almost(): the word ALMOST near the last tapped frame,
+ *                      the near_miss ceremony rises. A FAST find (<700ms) pings
+ *                      the word FAST. Both are staging; the ledger already
+ *                      decided. Staging only - CORE says when.
+ *   THE JACKPOT LADDER minor: a fast find at streak >= 2 may roll one (seeded,
+ *                      chance rises with heat); major: streak milestones
+ *                      (3/5/8) pay one deterministically; ROYAL: once a class,
+ *                      only when every tap was a first tap AND the streak
+ *                      reached the royal line - then the darkroom floods gold.
+ *                      A failed class still gets a DIM payout: silence is where
+ *                      people stand up.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects index.js hands it AFTER its
+ *       own accounting; writes nothing about rounds, streak, time or grade.
+ *       It NEVER reads, infers or marks the odd tile: the only tile index it
+ *       ever touches is the one the PLAYER tapped (public by then).
+ *   II  input honest  - every node here is pointer-events:none and lives in
+ *       the overlay / the backdrop, never inside the grid; .g-an-tile and
+ *       .g-an-face are never written (no class, no style, no attribute).
+ *   III never still   - the safelight breathes, the dust drifts, the lamp
+ *       swings, the marquee crawls even at heat 0.
+ *   IV  images > text - three words (ALMOST / FAST / ROYAL) through the
+ *       lexicon, each alive for < 600ms.
+ *   V   seeded        - per-tag mulberry32 off seed+'|an-casino|<tag>'
+ *       (append-only tags; a new tag never shifts an old stream).
+ *   VI  exits sacred  - capsOk false disarms every light; reduced motion keeps
+ *       a static safelight + a dim frame (no chase, no punch, no ken-burns,
+ *       blooms only); the stage's .suspended rule freezes the chase; timers
+ *       ride the game's pause-aware registry AND a local set.
+ *   VII lexicon       - an_almost / an_fast / an_royal only, through opts.t.
+ *
+ * ENGINE vs GAME-LOCAL: cues (audio_trigger) and the jackpot / near_miss
+ * ceremonies go through opts.engine (CORE's weld: clickSafe forced, audio
+ * ceiling by tier, pitch passthrough). The lights are game-local: they sit on
+ * the game's own geometry (the grid, a tapped frame), which no engine
+ * primitive knows. NODE BUDGET: backdrop layers (9) + marquee (1 + bulbs) +
+ * overlay (1) + ring + frost + word + sparks (<= 12 live). No per-frame JS.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const AN_CASINO = Object.freeze({
+  /* ---- the marquee --------------------------------------------------- */
+  BULBS: Object.freeze([20, 24, 28]),          // seeded pick (per side count scales with n)
+  MQ_T_SLOW: 3.0,                              // chase period (s) at heat 0
+  MQ_T_FAST: 0.8,                              // at heat 1
+  MQ_A_LO: 0.22,
+  MQ_A_HI: 0.85,
+  MQ_T_GOLD: 0.5,
+  MQ_A_GOLD: 0.95,
+  MQ_FLASH_MS: 520,
+  MQ_INSET_PX: 14,                             // how far outside the grid the bulbs sit
+  MQ_REMEASURE_MS: Object.freeze([16, 240]),   // after a roundStart: twice (layout settles)
+  /* ---- the payout ---------------------------------------------------- */
+  FLASH_MS: 420,                               // the enlarger exposure (outlives the CSS)
+  FLASH_A: Object.freeze([0.22, 0.6]),         // by q (streak / 8)
+  RING_MS: 480,
+  FROST_MS: 700,
+  COLD_MS: 520,
+  PUNCH_MS: 220,
+  PUNCH_SCALE: Object.freeze([0.05, 0.22]),
+  SPARKS: Object.freeze([4, 9]),               // per find, by q
+  MAX_SPARKS: 24,
+  MILESTONES: Object.freeze([3, 5, 8]),
+  /* ---- near misses --------------------------------------------------- */
+  FAST_MS: 700,
+  WORD_MS: 560,
+  NEAR_MISS_I: Object.freeze({ almost: 0.65, fast: 0.4 }),
+  /* ---- the jackpot ladder -------------------------------------------- */
+  MINOR_FROM_STREAK: 2,
+  MINOR_CHANCE: Object.freeze([0.12, 0.32]),   // fast find, by heat
+  MINOR_I: 0.35,
+  MAJOR_I: Object.freeze([0.5, 0.7, 0.95]),    // by milestone index
+  ROYAL_MIN_STREAK: 6,
+  ROYAL_I: 1,
+  ROYAL_MS: 3200,
+  END_DIM_MS: 1400,
+  /* ---- the sound ladder ---------------------------------------------- */
+  SEMITONE_CAP: 7,
+  FIND_LEVEL: Object.freeze([0.3, 0.5]),       // by min(streak,8)/8
+  MISS_LEVEL: 0.22,
+  ADVANCE_LEVEL: 0.16,
+  MOVED_LEVEL: 0.24,
+  MILESTONE_LEVEL: 0.45,
+  JACKPOT_LEVEL: 0.55,
+  NEAR_LEVEL: 0.3,
+  /* ---- identity ------------------------------------------------------ */
+  OFF_ARC: 0.06,
+  HUE_ARC: Object.freeze([352, 378]),          // red -> amber (wraps past 360)
+  HUE_OFF: Object.freeze([150, 176]),          // the green night
+  BREATH_S: Object.freeze([5.5, 9.5]),
+  DRIFT_S: Object.freeze([18, 30]),
+  KB_S: Object.freeze([22, 34]),
+  DUST: Object.freeze([0.25, 0.7]),
+  FRAME_START: 37,                             // contact sheets never start at 1
+  STOPS_MIN: 2,
+  STOPS_SPAN: 3,
+  STOP_HYST: 0.05,
+  HEAT_REPAINT_STEP: 0.03,
+});
+
+const STYLE_ID = 'g-an-casino-style';
+/* Every rule below is the casino's OWN sheet (style.js owns the room, this
+   owns the rig). No hidden-attribute rule lives here, by law. */
+const STYLE_TEXT = `
+.g-an-cs{position:absolute;inset:0;z-index:3;pointer-events:none;overflow:hidden}
+.g-an-cs *{pointer-events:none}
+/* THE MARQUEE: a rectangle of bulbs sized from the grid's rect (casino.js
+   writes left/top/width/height once per round, never per frame). */
+.g-an-mq{position:absolute;left:0;top:0;width:0;height:0;border-radius:12px;
+  --an-mq-t:3s;--an-mq-a:.22;--an-mq-hue:354;--an-mq-n:24;
+  opacity:var(--an-mq-a);transition:opacity .9s ease,left .25s ease,top .25s ease,width .25s ease,height .25s ease}
+.g-an-mq-bulb{position:absolute;width:var(--an-mq-d,7px);height:var(--an-mq-d,7px);
+  margin:calc(var(--an-mq-d,7px) * -.5);border-radius:50%;
+  background:hsl(var(--an-mq-hue) 92% 70%);
+  box-shadow:0 0 6px hsl(var(--an-mq-hue) 92% 68% / .9),0 0 14px hsl(var(--an-mq-hue) 88% 58% / .5);
+  animation:g-an-mq-chase var(--an-mq-t) linear infinite;
+  animation-delay:calc(var(--i) / var(--an-mq-n) * var(--an-mq-t) * -1)}
+@keyframes g-an-mq-chase{0%{opacity:.18;transform:scale(.8)}12%{opacity:1;transform:scale(1.15)}40%{opacity:.35;transform:scale(.92)}100%{opacity:.18;transform:scale(.8)}}
+.g-an-mq.gold{--an-mq-hue:46 !important}
+.g-an-mq.flash .g-an-mq-bulb{animation-duration:.22s;filter:brightness(1.6)}
+.g-an-mq.out{opacity:.08;transition:opacity 1.6s ease}
+/* THE RING: blooms on the found frame (rect measured at tap time). */
+.g-an-cs-ring{position:absolute;border-radius:8px;opacity:0;
+  border:2px solid hsl(var(--an-cs-hue,354) 90% 78%);
+  box-shadow:0 0 18px hsl(var(--an-cs-hue,354) 90% 70% / .8),inset 0 0 22px hsl(var(--an-cs-hue,354) 90% 70% / .35)}
+.g-an-cs-ring.on{animation:g-an-cs-ring .48s ease-out forwards}
+@keyframes g-an-cs-ring{0%{opacity:0;transform:scale(.92)}18%{opacity:1;transform:scale(1.02)}100%{opacity:0;transform:scale(1.14)}}
+/* THE FROST: a wrong frame goes cold for a beat (the frame itself is CORE's;
+   this is light laid over it). */
+.g-an-cs-frost{position:absolute;border-radius:6px;opacity:0;
+  background:radial-gradient(60% 60% at 50% 50%, rgba(190,214,255,.42), rgba(120,150,220,.12) 60%, transparent 80%);
+  border:1px solid rgba(190,214,255,.45)}
+.g-an-cs-frost.on{animation:g-an-cs-frost .7s ease-out forwards}
+@keyframes g-an-cs-frost{0%{opacity:0;transform:scale(1.04)}20%{opacity:1;transform:scale(1)}100%{opacity:0;transform:scale(.98)}}
+/* THE SPARKS: silver grains off a found frame (Deck IV - the verb pays). */
+.g-an-cs-spark{position:absolute;left:var(--x);top:var(--y);width:var(--s,4px);height:var(--s,4px);
+  border-radius:50%;opacity:0;background:hsl(var(--an-cs-hue,354) 95% 82%);
+  box-shadow:0 0 8px hsl(var(--an-cs-hue,354) 95% 75% / .9);
+  animation:g-an-cs-spark var(--d,.7s) ease-out forwards}
+@keyframes g-an-cs-spark{0%{opacity:0;transform:translate(0,0) scale(.5)}15%{opacity:1}
+  100%{opacity:0;transform:translate(var(--dx,0px),var(--dy,-40px)) scale(1.1)}}
+/* THE WORD: ALMOST / FAST / ROYAL, under 600ms, placed near the tapped frame. */
+.g-an-cs-word{position:absolute;left:var(--wx,50%);top:var(--wy,50%);transform:translate(-50%,-50%);
+  font:800 clamp(14px,2.2vmin,22px)/1 var(--disp,system-ui,sans-serif);letter-spacing:.22em;
+  color:hsl(var(--an-cs-hue,354) 90% 84%);text-shadow:0 0 12px hsl(var(--an-cs-hue,354) 90% 70% / .8);opacity:0;white-space:nowrap}
+.g-an-cs-word.on{animation:g-an-cs-word .56s ease-out forwards}
+.g-an-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-an-cs-word.gold{color:#ffe08a;text-shadow:0 0 14px rgba(240,194,75,.9)}
+@keyframes g-an-cs-word{0%{opacity:0;transform:translate(-50%,-50%) scale(.7)}18%{opacity:1;transform:translate(-50%,-50%) scale(1.08)}
+  70%{opacity:1;transform:translate(-50%,-54%) scale(1)}100%{opacity:0;transform:translate(-50%,-64%) scale(1)}}
+/* the HUD punch (transform only; the text is CORE's) */
+.g-an-cs-punch{transition:transform .22s cubic-bezier(.2,1.6,.4,1) !important;transform:scale(var(--an-cs-ps,1))}
+.g-an-cs-bloom{box-shadow:0 0 0 2px hsl(var(--an-cs-hue,354) 90% 70% / .55),0 0 22px hsl(var(--an-cs-hue,354) 90% 65% / .6) !important;transition:box-shadow .3s ease}
+/* reduced motion, both gates */
+@media (prefers-reduced-motion: reduce){
+  .g-an-mq-bulb{animation:none !important;opacity:.55}
+  .g-an-cs-spark{display:none}
+  .g-an-cs-word.on{animation:none;opacity:1}
+  .g-an-cs-ring.on{animation:none;opacity:.8}
+  .g-an-cs-frost.on{animation:none;opacity:.8}
+}
+html.arc-reduced .g-an-mq-bulb{animation:none !important;opacity:.55}
+html.arc-reduced .g-an-cs-spark{display:none}
+html.arc-reduced .g-an-cs-word.on{animation:none;opacity:1}
+html.arc-reduced .g-an-cs-ring.on{animation:none;opacity:.8}
+html.arc-reduced .g-an-cs-frost.on{animation:none;opacity:.8}
+.g-an-stage.suspended .g-an-mq-bulb,.g-an-stage.suspended .g-an-cs-spark,.g-an-stage.suspended .g-an-cs-word,
+.g-an-stage.suspended .g-an-cs-ring,.g-an-stage.suspended .g-an-cs-frost{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** The chime's pitch for a streak: +1 semitone per link, capped. Pure. */
+export function pitchForStreak(streak) {
+  const s = Math.max(0, Math.min(AN_CASINO.SEMITONE_CAP, (Number(streak) || 0) - 1));
+  return +Math.pow(2, s / 12).toFixed(4);
+}
+/** A find under the FAST line? Pure. */
+export function isFast(latencyMs) {
+  const l = Number(latencyMs);
+  return Number.isFinite(l) && l > 0 && l < AN_CASINO.FAST_MS;
+}
+/** The royal verdict: every tap a first tap, streak at the royal line. Pure. */
+export function isRoyal(end) {
+  const e = end || {};
+  if (e.royal === true) return true;
+  if (e.fail === true) return false;
+  return (Number(e.wrongTaps) || 0) === 0 && (Number(e.bestStreak) || 0) >= AN_CASINO.ROYAL_MIN_STREAK
+    && (Number(e.finds) || 0) >= AN_CASINO.ROYAL_MIN_STREAK;
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function restart(n, cls) {
+  if (!n || !n.classList) return;
+  try { n.classList.remove(cls); if (typeof n.offsetWidth === 'number') void n.offsetWidth; n.classList.add(cls); } catch (e) { /* noop */ }
+}
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+
+/**
+ * @param {Object} o
+ * @param {string}   o.seed      the class seed (retakes replay the room)
+ * @param {number}   o.tier      1..4
+ * @param {Object}   o.stage     .g-an-stage (identity props land here)
+ * @param {Object}   o.board     .g-an-grid (geometry reference - READ only)
+ * @param {Object}   o.hud       .g-an-hud element OR {root, round, clock, streak}
+ * @param {Object}   o.backdrop  .g-an-backdrop (the lighting layers)
+ * @param {Object}   o.timers    {after(ms,fn)->id, every?, clear|cancel(id)}
+ * @param {boolean}  o.reduced   reduced motion
+ * @param {boolean|Function} o.capsOk  false when bgIntensity is capped to 0
+ * @param {Function=} o.t        ctx.lexicon (English fallbacks here)
+ * @param {Object=}  o.engine    CORE's deck weld {fire, sustain, stop, ceremony?, audio?}
+ * @param {number=}  o.motionLevel
+ * @param {Function=} o.log
+ */
+export function createAnCasino(o) {
+  const opts = o || {};
+  const C = AN_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => (f == null ? k : f));
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const eng = opts.engine || {};
+  const hudRoot = opts.hud && opts.hud.nodeType ? opts.hud : (opts.hud && opts.hud.root) || null;
+  const hudChips = opts.hud && !opts.hud.nodeType ? opts.hud : {};
+  const armedBase = !!opts.stage && !!opts.timers && typeof opts.timers.after === 'function'
+    && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false && opts.capsOk != null;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'an') + '|an-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, flashes: 0, words: 0, rings: 0, frosts: 0 };
+  function cue(name, level, extra) {
+    if (!armed()) return;
+    counts.cues++;
+    try {
+      if (typeof eng.audio === 'function') eng.audio(name, level, extra || {});
+      else if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed()) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+
+  /* ---- identity (per class seed, FIXED draw order) ------------------------ */
+  const ID = (() => {
+    const offArc = roll('arc') < C.OFF_ARC;
+    const hue = offArc ? Math.round(lerp(C.HUE_OFF, roll('hue'))) : Math.round(lerp(C.HUE_ARC, roll('hue'))) % 360;
+    const lampX = 32 + Math.round(roll('lamp') * 36);                 // 32..68 %
+    const lampTilt = (roll('lamp') < 0.5 ? -1 : 1) * (4 + roll('lamp') * 10);
+    const breath = +lerp(C.BREATH_S, roll('breath')).toFixed(1);
+    const drift = +lerp(C.DRIFT_S, roll('drift')).toFixed(1);
+    const kb = +lerp(C.KB_S, roll('kb')).toFixed(1);
+    const kbX = (roll('kb') < 0.5 ? -1 : 1) * (1 + roll('kb') * 1.5);
+    const kbY = (roll('kb') < 0.5 ? -1 : 1) * (0.5 + roll('kb'));
+    const dust = +lerp(C.DUST, roll('dust')).toFixed(2);
+    const bulbs = C.BULBS[Math.floor(roll('bulbs') * C.BULBS.length)];
+    const bulbD = 6 + Math.round(roll('bulbs') * 3);
+    const frameStart = C.FRAME_START + Math.floor(roll('frame') * 60);
+    const stops = C.STOPS_MIN + Math.floor(roll('stops') * C.STOPS_SPAN);
+    const journey = [];
+    for (let i = 0; i < stops; i++) {
+      journey.push({
+        lampX: Math.max(20, Math.min(80, lampX + (roll('journey') - 0.5) * 30)),
+        lampA: +(0.35 + roll('journey') * 0.45).toFixed(2),
+        dust: +Math.min(1, dust * (0.7 + roll('journey') * 0.8)).toFixed(2),
+        deep: +(i / Math.max(1, stops - 1) * (0.5 + roll('journey') * 0.4)).toFixed(2),
+        tilt: +((roll('journey') < 0.5 ? -1 : 1) * (3 + roll('journey') * 12)).toFixed(1),
+      });
+    }
+    return { offArc, hue, lampX, lampTilt, breath, drift, kb, kbX, kbY, dust, bulbs, bulbD, frameStart, journey };
+  })();
+
+  /* ---- nodes ------------------------------------------------------------- */
+  const layers = {};
+  let cs = null, mq = null, ring = null, frost = null, word = null;
+  const props = new Set();
+  const stageClasses = new Set();
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let stopIx = -1;
+  let goldOn = false;
+  let royalOn = false;
+  let outOn = false;
+  let bellOn = false;
+  let lastTapRect = null;
+  let sparks = 0;
+  let flashTimer = 0, ringTimer = 0, frostTimer = 0, wordTimer = 0, punchTimer = 0, coldTimer = 0, royalTimer = 0, mqFlashTimer = 0;
+  let almostPending = false;
+  let almostTimer = 0;
+  const mqTimers = [];
+  let resizeFn = null;
+  let ro = null;
+  /* the tally this deck keeps for the ROYAL verdict (its own view, never the ledger) */
+  let finds = 0, wrongTaps = 0, bestStreak = 0, rounds = 0, relocations = 0;
+  const jackLog = [];
+
+  function setProp(k, v) { if (!opts.stage || !opts.stage.style) return; try { opts.stage.style.setProperty(k, String(v)); props.add(k); } catch (e) { /* noop */ } }
+  function stageClass(name, on) {
+    if (!opts.stage || !opts.stage.classList) return;
+    try { if (on) { opts.stage.classList.add(name); stageClasses.add(name); } else { opts.stage.classList.remove(name); stageClasses.delete(name); } } catch (e) { /* noop */ }
+  }
+
+  function dressRoom() {
+    const sat = ID.offArc ? 62 : 88;
+    setProp('--an-n-hue', ID.hue);
+    setProp('--an-n-sat', sat + '%');
+    setProp('--an-n-safe', 'hsl(' + ID.hue + ' ' + sat + '% 52%)');
+    setProp('--an-n-safe-a', 'hsl(' + ID.hue + ' ' + sat + '% 56% / .28)');
+    setProp('--an-n-lamp-x', ID.lampX + '%');
+    setProp('--an-n-lamp-tilt', ID.lampTilt + 'deg');
+    setProp('--an-n-breath', ID.breath + 's');
+    setProp('--an-n-drift', ID.drift + 's');
+    setProp('--an-n-kb', ID.kb + 's');
+    setProp('--an-n-kb-x', ID.kbX.toFixed(2) + '%');
+    setProp('--an-n-kb-y', ID.kbY.toFixed(2) + '%');
+    setProp('--an-n-dust', ID.dust);
+    setProp('--an-n-frame-start', ID.frameStart);
+    setProp('--an-n-deep', '0');
+    setProp('--an-cs-hue', ID.hue);
+    paintStop(0);
+    say('casino: darkroom dressed (hue ' + ID.hue + (ID.offArc ? ' OFF-ARC' : '') + ', lamp ' + ID.lampX + '%, '
+      + ID.journey.length + ' stops, frames from ' + ID.frameStart + ')');
+  }
+  function paintStop(ix) {
+    const stop = ID.journey[Math.max(0, Math.min(ID.journey.length - 1, ix))];
+    if (!stop) return;
+    stopIx = ix;
+    setProp('--an-n-lamp-x', stop.lampX.toFixed(0) + '%');
+    setProp('--an-n-lamp-a', stop.lampA);
+    setProp('--an-n-dust', stop.dust);
+    setProp('--an-n-deep', stop.deep);
+    setProp('--an-n-lamp-tilt', stop.tilt + 'deg');
+  }
+  function walkJourney(h) {
+    const n = ID.journey.length;
+    if (n < 2) return;
+    const raw = Math.min(n - 1, Math.floor(h * n));
+    if (stopIx < 0) { paintStop(raw); return; }
+    if (raw > stopIx && h >= (stopIx + 1) / n + C.STOP_HYST) paintStop(stopIx + 1);
+    else if (raw < stopIx && h <= stopIx / n - C.STOP_HYST) paintStop(stopIx - 1);
+  }
+
+  function mountBackdrop() {
+    const host = opts.backdrop;
+    if (!host || !host.appendChild) return;
+    for (const name of ['safe', 'lamp', 'strips', 'dust', 'grain', 'dark', 'flash', 'cold', 'royal', 'vig']) {
+      const n = el('div', 'g-an-bd g-an-bd-' + name);
+      if (!n) continue;
+      layers[name] = n;
+      host.appendChild(n);
+    }
+  }
+  function mountOverlay() {
+    if (cs || !opts.stage || !opts.stage.appendChild) return;
+    cs = el('div', 'g-an-cs');
+    if (!cs) return;
+    opts.stage.appendChild(cs);
+    mq = el('div', 'g-an-mq');
+    if (mq) {
+      setVar(mq, '--an-mq-hue', ID.hue);
+      setVar(mq, '--an-mq-d', ID.bulbD + 'px');
+      cs.appendChild(mq);
+    }
+    ring = el('i', 'g-an-cs-ring'); if (ring) cs.appendChild(ring);
+    frost = el('i', 'g-an-cs-frost'); if (frost) cs.appendChild(frost);
+    word = el('div', 'g-an-cs-word'); if (word) cs.appendChild(word);
+  }
+
+  /* ---- the marquee: sized from the grid, bulbs laid around the rectangle --- */
+  function layoutMarquee() {
+    if (!mq || !opts.board || !cs) return false;
+    const g = rectOf(opts.board);
+    const base = rectOf(cs);
+    if (!g || !base || !g.width || !g.height) return false;
+    const inset = C.MQ_INSET_PX;
+    const left = g.left - base.left - inset;
+    const top = g.top - base.top - inset;
+    const w = g.width + inset * 2;
+    const h = g.height + inset * 2;
+    mq.style.left = left.toFixed(0) + 'px';
+    mq.style.top = top.toFixed(0) + 'px';
+    mq.style.width = w.toFixed(0) + 'px';
+    mq.style.height = h.toFixed(0) + 'px';
+    /* bulb count follows the perimeter so a 5x5 grid is not a sparse 3x3 string */
+    const per = Math.round((w + h) * 2 / 34);
+    const n = Math.max(12, Math.min(72, Math.round(ID.bulbs * (per / 48))));
+    if (mq.childNodes && mq.childNodes.length === n) return true;
+    while (mq.firstChild) { try { mq.removeChild(mq.firstChild); } catch (e) { break; } }
+    setVar(mq, '--an-mq-n', n);
+    const perim = 2 * (w + h);
+    for (let i = 0; i < n; i++) {
+      const b = el('span', 'g-an-mq-bulb');
+      if (!b) break;
+      let d = (i / n) * perim;
+      let x, y;
+      if (d < w) { x = d; y = 0; }
+      else if (d < w + h) { x = w; y = d - w; }
+      else if (d < 2 * w + h) { x = w - (d - w - h); y = h; }
+      else { x = 0; y = h - (d - 2 * w - h); }
+      b.style.left = (x / w * 100).toFixed(2) + '%';
+      b.style.top = (y / h * 100).toFixed(2) + '%';
+      setVar(b, '--i', i);
+      mq.appendChild(b);
+    }
+    return true;
+  }
+  function scheduleLayout() {
+    for (const id of mqTimers) cancel(id);
+    mqTimers.length = 0;
+    for (const ms of C.MQ_REMEASURE_MS) mqTimers.push(after(ms, () => layoutMarquee()));
+  }
+  function watchGeometry() {
+    try {
+      if (typeof ResizeObserver === 'function' && opts.board && opts.board.nodeType) {
+        ro = new ResizeObserver(() => { if (!destroyed) layoutMarquee(); });
+        ro.observe(opts.board);
+      }
+    } catch (e) { ro = null; }
+    try {
+      if (typeof window !== 'undefined' && window.addEventListener) {
+        resizeFn = () => { if (!destroyed) layoutMarquee(); };
+        window.addEventListener('resize', resizeFn);
+      }
+    } catch (e) { resizeFn = null; }
+  }
+  function paintMarquee(force) {
+    if (!mq) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    const gold = goldOn || royalOn || bellOn;
+    const period = gold ? C.MQ_T_GOLD : (C.MQ_T_SLOW + (C.MQ_T_FAST - C.MQ_T_SLOW) * heat);
+    const alpha = outOn ? 0.08 : (gold ? C.MQ_A_GOLD : lerp([C.MQ_A_LO, C.MQ_A_HI], heat));
+    setVar(mq, '--an-mq-t', period.toFixed(2) + 's');
+    setVar(mq, '--an-mq-a', alpha.toFixed(2));
+    setCls(mq, 'gold', gold);
+  }
+  function flashMarquee(ms) {
+    if (!mq || !armed() || still) return;
+    setCls(mq, 'flash', true);
+    cancel(mqFlashTimer);
+    mqFlashTimer = after(ms || C.MQ_FLASH_MS, () => setCls(mq, 'flash', false));
+  }
+
+  /* ---- geometry helpers ---------------------------------------------------- */
+  /** The rect of a tile INDEX, read off the live grid (children in DOM order),
+   *  translated into overlay space. The index is the PLAYER's own tap. */
+  function tileRect(i) {
+    if (!opts.board || !cs || i == null) return null;
+    let tile = null;
+    try {
+      const list = opts.board.querySelectorAll ? opts.board.querySelectorAll('.g-an-tile') : null;
+      if (list && list.length) {
+        for (let k = 0; k < list.length; k++) {
+          const n = list[k];
+          let di = null;
+          try { di = n.getAttribute ? n.getAttribute('data-i') : null; } catch (e) { di = null; }
+          if (di != null && String(di) === String(i)) { tile = n; break; }
+        }
+        if (!tile && Number(i) >= 0 && Number(i) < list.length) tile = list[Number(i)];
+      }
+    } catch (e) { tile = null; }
+    const r = rectOf(tile);
+    const base = rectOf(cs);
+    if (!r || !base || !r.width) return null;
+    return { x: r.left - base.left, y: r.top - base.top, w: r.width, h: r.height, cx: r.left - base.left + r.width / 2, cy: r.top - base.top + r.height / 2 };
+  }
+  function gridCentre() {
+    const g = rectOf(opts.board);
+    const base = rectOf(cs);
+    if (!g || !base) return { cx: 0, cy: 0, w: 0, h: 0 };
+    return { cx: g.left - base.left + g.width / 2, cy: g.top - base.top + g.height / 2, w: g.width, h: g.height };
+  }
+
+  /* ---- the light ---------------------------------------------------------- */
+  function flashRoom(q, ms) {
+    const f = layers.flash;
+    if (!f || !armed()) return;
+    counts.flashes++;
+    setProp('--an-n-pay', lerp(C.FLASH_A, q).toFixed(2));
+    if (still) { setCls(f, 'on', true); cancel(flashTimer); flashTimer = after(ms || C.FLASH_MS, () => setCls(f, 'on', false)); return; }
+    restart(f, 'on');
+    cancel(flashTimer);
+    flashTimer = after(ms || C.FLASH_MS, () => setCls(f, 'on', false));
+  }
+  function coldRoom() {
+    const c = layers.cold;
+    if (!c || !armed()) return;
+    restart(c, 'on');
+    cancel(coldTimer);
+    coldTimer = after(C.COLD_MS, () => setCls(c, 'on', false));
+  }
+  function placeBox(node, r, pad) {
+    if (!node || !r) return false;
+    node.style.left = (r.x - pad).toFixed(0) + 'px';
+    node.style.top = (r.y - pad).toFixed(0) + 'px';
+    node.style.width = (r.w + pad * 2).toFixed(0) + 'px';
+    node.style.height = (r.h + pad * 2).toFixed(0) + 'px';
+    return true;
+  }
+  function ringAt(r) {
+    if (!ring || !armed() || !placeBox(ring, r, 3)) return;
+    counts.rings++;
+    restart(ring, 'on');
+    cancel(ringTimer);
+    ringTimer = after(C.RING_MS + 40, () => setCls(ring, 'on', false));
+  }
+  function frostAt(r) {
+    if (!frost || !armed() || !placeBox(frost, r, 1)) return;
+    counts.frosts++;
+    restart(frost, 'on');
+    cancel(frostTimer);
+    frostTimer = after(C.FROST_MS + 40, () => setCls(frost, 'on', false));
+  }
+  function sparksAt(r, q) {
+    if (!cs || !r || still || !armed()) return 0;
+    const n = Math.round(lerp(C.SPARKS, q));
+    let made = 0;
+    for (let i = 0; i < n; i++) {
+      if (sparks >= C.MAX_SPARKS) break;
+      const s = el('i', 'g-an-cs-spark');
+      if (!s || !s.style) break;
+      const a = roll('spark') * Math.PI * 2;
+      const dist = 18 + roll('spark') * Math.max(24, r.w * 0.6);
+      s.style.setProperty('--x', (r.cx + (roll('spark') - 0.5) * r.w * 0.5).toFixed(0) + 'px');
+      s.style.setProperty('--y', (r.cy + (roll('spark') - 0.5) * r.h * 0.5).toFixed(0) + 'px');
+      s.style.setProperty('--dx', (Math.cos(a) * dist).toFixed(0) + 'px');
+      s.style.setProperty('--dy', (Math.sin(a) * dist - 12).toFixed(0) + 'px');
+      s.style.setProperty('--s', (3 + roll('spark') * 3).toFixed(1) + 'px');
+      const d = 0.5 + roll('spark') * 0.4;
+      s.style.setProperty('--d', d.toFixed(2) + 's');
+      cs.appendChild(s);
+      sparks++; made++;
+      after(d * 1000 + 80, () => { sparks = Math.max(0, sparks - 1); try { s.remove(); } catch (e) { /* ignore */ } });
+    }
+    return made;
+  }
+  function punchChip(which, q) {
+    const chip = hudChips[which] || null;
+    if (!chip || !armed()) return;
+    if (still) {
+      setCls(chip, 'g-an-cs-bloom', true);
+      cancel(punchTimer);
+      punchTimer = after(320, () => setCls(chip, 'g-an-cs-bloom', false));
+      return;
+    }
+    setCls(chip, 'g-an-cs-punch', true);
+    setVar(chip, '--an-cs-ps', (1 + lerp(C.PUNCH_SCALE, q)).toFixed(3));
+    cancel(punchTimer);
+    punchTimer = after(C.PUNCH_MS, () => setVar(chip, '--an-cs-ps', '1'));
+  }
+  function showWord(key, fallback, tone, at) {
+    if (!word || !armed()) return;
+    counts.words++;
+    const r = at || lastTapRect || gridCentre();
+    word.textContent = t(key, fallback);
+    word.className = 'g-an-cs-word' + (tone ? ' ' + tone : '');
+    setVar(word, '--wx', (r.cx || 0).toFixed(0) + 'px');
+    setVar(word, '--wy', ((r.cy || 0) - (r.h ? r.h * 0.62 : 30)).toFixed(0) + 'px');
+    if (typeof word.offsetWidth === 'number') void word.offsetWidth;
+    setCls(word, 'on', true);
+    cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 40, () => setCls(word, 'on', false));
+  }
+
+  /* ---- the ladder --------------------------------------------------------- */
+  function jackpot(intensity, why) {
+    if (!armed()) return;
+    counts.jackpots++;
+    jackLog.push(why);
+    ceremony('jackpot', { intensity });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashMarquee(C.MQ_FLASH_MS + 300 * intensity);
+    flashRoom(intensity, C.FLASH_MS + 300);
+  }
+  function nearMiss(kind, intensity) {
+    if (!armed()) return;
+    counts.nearMisses++;
+    ceremony('near_miss', { intensity });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: kind === 'almost' ? 0.8 : 1.1 });
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      if (!armed()) { say('casino: disarmed'); return; }
+      ensureStyle();
+      mountBackdrop();
+      mountOverlay();
+      dressRoom();
+      if (!still) stageClass('g-an-kb', true);
+      layoutMarquee();
+      scheduleLayout();
+      watchGeometry();
+      paintMarquee(true);
+      say('casino: safelight on, ' + Object.keys(layers).length + ' layers, marquee ' + (mq && mq.childNodes ? mq.childNodes.length : 0) + ' bulbs');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (!started) return;
+      paintMarquee(false);
+      walkJourney(heat);
+    },
+    /** A new round is dealt: the sheet advances (a soft carriage tick) and
+     *  the marquee re-measures the grid (its size may have changed). */
+    roundStart(n, kind) {
+      if (!started || !armed()) return;
+      rounds++;
+      lastTapRect = null;
+      scheduleLayout();
+      cue('slide', C.ADVANCE_LEVEL, { pitch: 1.2 });
+      const strips = layers.strips;
+      if (strips && !still) restart(strips, 'advance');
+      void n; void kind;
+    },
+    /** Every tap, AFTER CORE's accounting. The only index read is the tap's. */
+    tap(ev) {
+      if (!started || !armed()) return;
+      const e = ev || {};
+      const streak = Math.max(0, Number(e.streak) || 0);
+      const r = tileRect(e.i);
+      if (r) lastTapRect = r;
+      if (e.correct) {
+        finds++;
+        bestStreak = Math.max(bestStreak, streak);
+        const q = clamp01(Math.min(8, streak) / 8);
+        /* THE SOUND LADDER */
+        cue('pop', lerp(C.FIND_LEVEL, q), { pitch: pitchForStreak(streak) });
+        /* THE EXPOSURE (< 500ms, all CSS) */
+        flashRoom(q);
+        if (r) { ringAt(r); sparksAt(r, q); }
+        punchChip('streak', q);
+        if (streak >= 2) flashMarquee();
+        /* NEAR-MISS STAGING: the FAST ping */
+        const fast = isFast(e.latencyMs);
+        if (fast && streak >= 2) { showWord('an_fast', 'FAST', 'lav', r); nearMiss('fast', C.NEAR_MISS_I.fast); }
+        /* THE JACKPOT LADDER */
+        const mi = C.MILESTONES.indexOf(streak);
+        if (mi >= 0) {
+          cue('streak', C.MILESTONE_LEVEL, { pitch: pitchForStreak(streak) });
+          jackpot(C.MAJOR_I[mi], 'major@' + streak);
+        } else if (fast && streak >= C.MINOR_FROM_STREAK && roll('jack-minor') < lerp(C.MINOR_CHANCE, heat)) {
+          jackpot(C.MINOR_I, 'minor@' + (e.i == null ? '?' : e.i));
+        }
+      } else {
+        wrongTaps++;
+        if (almostPending) {
+          /* CORE calls almost() BEFORE tap() on an it-moved tap: the word lands
+             on THIS tap's frame, not the last one's */
+          almostPending = false;
+          cancel(almostTimer); almostTimer = 0;
+          showWord('an_almost', 'ALMOST', 'lav', r);
+          nearMiss('almost', C.NEAR_MISS_I.almost);
+          cue('whisper', C.MISS_LEVEL, { pitch: 1.1 });      // the sting is soft: it teaches
+          if (r) ringAt(r);
+          return;
+        }
+        cue('bump', C.MISS_LEVEL, { pitch: 0.7 });         // a muted thud, never silence
+        coldRoom();
+        if (r) frostAt(r);
+      }
+    },
+    /** The anomaly relocated (CORE says so AFTER the glitch): a whisper. */
+    relocated() {
+      if (!started || !armed()) return;
+      relocations++;
+      cue('whisper', C.MOVED_LEVEL, { pitch: 0.9 });
+      const lamp = layers.lamp;
+      if (lamp && !still) restart(lamp, 'sweep');
+    },
+    /** Near-miss staging: a tap where it WAS (or an adjacent wrong tap). CORE
+     *  calls this right before the matching tap(); the word waits one beat for
+     *  that tap's frame, and falls back to the last tapped frame / the sheet
+     *  centre when no tap follows. */
+    almost() {
+      if (!started || !armed()) return;
+      almostPending = true;
+      cancel(almostTimer);
+      almostTimer = after(40, () => {
+        almostTimer = 0;
+        if (!almostPending) return;
+        almostPending = false;
+        showWord('an_almost', 'ALMOST', 'lav');
+        nearMiss('almost', C.NEAR_MISS_I.almost);
+      });
+    },
+    bell(on) {
+      bellOn = !!on;
+      goldOn = bellOn || goldOn;
+      stageClass('g-an-bell', bellOn);
+      paintMarquee(true);
+    },
+    /** The bell took the sheet. ROYAL when the class was perfect, else a dim payout. */
+    dimOut(info) {
+      const e = info || {};
+      outOn = true;
+      const royal = isRoyal(Object.assign({ wrongTaps, bestStreak, finds }, e));
+      if (royal && armed()) {
+        royalOn = true;
+        counts.royal = 1;
+        stageClass('g-an-royal', true);
+        showWord('an_royal', 'ROYAL', 'gold', gridCentre());
+        ceremony('jackpot', { intensity: C.ROYAL_I });
+        cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.2 });
+        after(260, () => cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.5 }));
+        after(520, () => cue('stamp', 0.5, { pitch: 1 }));
+        flashMarquee(C.ROYAL_MS);
+        cancel(royalTimer);
+        royalTimer = after(C.ROYAL_MS, () => { stageClass('g-an-royal', false); stageClass('g-an-out', true); setCls(mq, 'out', true); paintMarquee(true); });
+      } else if (armed()) {
+        /* losses disguised: a dim payout, never silence */
+        const q = clamp01(finds / 10);
+        flashRoom(0.1 + 0.3 * q, C.END_DIM_MS);
+        cue('wash', 0.25, { pitch: 0.9 });
+        stageClass('g-an-out', true);
+        setCls(mq, 'out', true);
+      }
+      bellOn = false;
+      paintMarquee(true);
+      return { royal };
+    },
+    stop() {
+      cancelAll();
+      for (const n of [ring, frost, word]) { if (n) n.className = n.className.split(' ')[0]; }
+      setCls(mq, 'flash', false);
+      const c = layers.cold; if (c) setCls(c, 'on', false);
+    },
+    pause() { /* the CSS freezes under .suspended; transient light simply ends on its timers */ },
+    resume() { /* nothing to re-arm: the chase is CSS */ },
+    destroy() {
+      destroyed = true;
+      cancelAll();
+      try { if (ro) ro.disconnect(); } catch (e) { /* noop */ }
+      ro = null;
+      try { if (resizeFn && typeof window !== 'undefined') window.removeEventListener('resize', resizeFn); } catch (e) { /* noop */ }
+      resizeFn = null;
+      for (const k of Object.keys(layers)) { try { layers[k].remove(); } catch (e) { /* noop */ } delete layers[k]; }
+      if (cs) { try { cs.remove(); } catch (e) { /* noop */ } }
+      cs = mq = ring = frost = word = null;
+      for (const name of Array.from(stageClasses)) stageClass(name, false);
+      if (opts.stage && opts.stage.style) for (const k of props) { try { opts.stage.style.removeProperty(k); } catch (e) { /* noop */ } }
+      props.clear();
+      for (const k of Object.keys(hudChips)) { const chip = hudChips[k]; if (chip && chip.classList) { setCls(chip, 'g-an-cs-punch', false); setCls(chip, 'g-an-cs-bloom', false); } }
+      void hudRoot;
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, heat: +heat.toFixed(3), hue: ID.hue, offArc: ID.offArc, bulbs: mq && mq.childNodes ? mq.childNodes.length : 0,
+        frameStart: ID.frameStart, journey: ID.journey.length, stop: stopIx,
+        gold: goldOn, bell: bellOn, royal: royalOn, out: outOn,
+        finds, wrongTaps, bestStreak, rounds, relocations, sparks, almostPending,
+        counts: Object.assign({}, counts), jackpots: jackLog.slice(),
+        liveTimers: live.size, layers: Object.keys(layers).length, overlay: !!cs, marquee: !!mq,
+        lexicon: ['an_almost', 'an_fast', 'an_royal'],
+      };
+    },
+  };
+  return api;
+}
+
+export default createAnCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/grade.js
@@ -1,0 +1,142 @@
+/* ============================================================================
+ * games/anomaly/grade.js - the composite ANOMALY hands to the ONE shared
+ * rubric (core/grades.js, via ctx.endClass). PURE.
+ *
+ * A game never grades itself: this file turns the class's inputs into a 0..1
+ * composite, a declared hard gate and the flavour XP, and the SHELL maps the
+ * composite to S/A/B/C (>= .92 S / .75 A / .50 B) and applies every cap.
+ *
+ * THE COMPOSITE (the dossier's four inputs, in its own order of importance):
+ *   .40 accuracy   FIRST-TAP finds / rounds offered   (the skill being trained)
+ *   .25 speed      median time-to-find against the tier's target
+ *   .20 clear      rounds cleared / rounds offered    (a whiff is not a wrong tap)
+ *   .15 tracking   recovery after a glitch_swap relocation: how many
+ *                  relocated rounds were still cleared, and how fast
+ *
+ * TRACKING WITH NO RELOCATIONS: tiers 1-2 deal none, so there is nothing to
+ * recover from. The term then MIRRORS accuracy rather than scoring 0 (which
+ * would make an S impossible below tier 3) or 1 (which would gift 15 points
+ * for a mechanic the class never showed). Same total, no free ride.
+ *
+ * HARD GATE: `sGate` is true only on a PERFECT class - every offered round
+ * found on the FIRST tap, and at least MIN_ROUNDS_FOR_S of them - which is the
+ * dossier's "S requires perfect first-tap accuracy". A failed gate caps at A.
+ * The sub-median half of the dossier's S rule is already carried by the speed
+ * term, which cannot reach .92 composite on slow finds.
+ *
+ * FLAVOUR XP: +2 per sub-second find, +1 per relocated round still cleared,
+ * cap 15 (the shell clamps to 15 as well). Game-owned, never composite; the
+ * XP table itself is C#'s.
+ * ==========================================================================*/
+
+export const GRADE = Object.freeze({
+  W_ACCURACY: 0.4,
+  W_SPEED: 0.25,
+  W_CLEAR: 0.2,
+  W_TRACK: 0.15,
+
+  /** Median time-to-find (ms) that earns the FULL speed term, per gradeTier.
+   *  Slower tiers get a bigger grid but a longer round, so the target tightens
+   *  only gently: the top tier is meant to be won by tracking, not by twitch. */
+  MEDIAN_TARGET_MS: Object.freeze({ 1: 2200, 2: 2000, 3: 1900, 4: 1800 }),
+  /** Anything at or under this is a full mark; anything at or over
+   *  target x SLOW_MULT scores nothing. */
+  FAST_MS: 900,
+  SLOW_MULT: 2.4,
+
+  /** Post-relocation recovery target (ms) - the tap AFTER the tile moved. */
+  TRACK_TARGET_MS: Object.freeze({ 1: 2600, 2: 2600, 3: 2400, 4: 2200 }),
+  TRACK_SPLIT: 0.5,                 // half "did you still find it", half "how fast"
+
+  MIN_ROUNDS_FOR_S: 5,
+  FLAVOR_SUBSECOND: 2,
+  FLAVOR_TRACK: 1,
+  FLAVOR_CAP: 15,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Number(gradeTier) || 1))); }
+function n0(v) { return Math.max(0, Number(v) || 0); }
+
+/** A latency term: FAST_MS or better = 1, target x SLOW_MULT or worse = 0. */
+export function latencyTerm(ms, targetMs) {
+  const t = n0(targetMs);
+  const v = Number(ms);
+  if (!t || !Number.isFinite(v) || v <= 0) return 0;
+  const slow = t * GRADE.SLOW_MULT;
+  if (v <= GRADE.FAST_MS) return 1;
+  if (v >= slow) return 0;
+  return clamp01((slow - v) / (slow - GRADE.FAST_MS));
+}
+
+/** The median of a list of latencies (ms). PURE; [] -> 0. */
+export function median(list) {
+  const a = (list || []).map(Number).filter((v) => Number.isFinite(v) && v > 0).sort((x, y) => x - y);
+  if (!a.length) return 0;
+  const mid = a.length >> 1;
+  return a.length % 2 ? a[mid] : Math.round((a[mid - 1] + a[mid]) / 2);
+}
+
+/**
+ * @param {Object} i
+ *   gradeTier        1..4
+ *   roundsOffered    rounds the class actually dealt (a round the bell cut
+ *                    short is NOT offered - see index.js)
+ *   roundsCleared    rounds where the odd tile was found at all
+ *   firstTapFinds    rounds found with NO wrong tap first
+ *   findTimes        [ms] time-to-find for every cleared round
+ *   relocatedRounds  rounds that carried at least one relocation
+ *   relocatedCleared relocated rounds that were still cleared
+ *   recoveryTimes    [ms] tap latency measured from the LAST relocation
+ * @returns {{composite:number, terms:Object, median:number, raw:number}}
+ */
+export function compositeFor(i = {}) {
+  const tier = tierOf(i.gradeTier);
+  const offered = n0(i.roundsOffered);
+  const cleared = Math.min(offered, n0(i.roundsCleared));
+  const first = Math.min(cleared, n0(i.firstTapFinds));
+
+  const accuracy = offered > 0 ? clamp01(first / offered) : 0;
+  const clear = offered > 0 ? clamp01(cleared / offered) : 0;
+
+  const med = median(i.findTimes);
+  const speed = latencyTerm(med, GRADE.MEDIAN_TARGET_MS[tier]);
+
+  const relocated = n0(i.relocatedRounds);
+  const relocCleared = Math.min(relocated, n0(i.relocatedCleared));
+  const recovery = median(i.recoveryTimes);
+  const track = relocated > 0
+    ? clamp01(GRADE.TRACK_SPLIT * (relocCleared / relocated)
+      + (1 - GRADE.TRACK_SPLIT) * latencyTerm(recovery, GRADE.TRACK_TARGET_MS[tier]))
+    : accuracy;
+
+  const raw = GRADE.W_ACCURACY * accuracy + GRADE.W_SPEED * speed
+    + GRADE.W_CLEAR * clear + GRADE.W_TRACK * track;
+
+  return {
+    composite: clamp01(raw),
+    raw: clamp01(raw),
+    median: med,
+    recovery,
+    terms: { accuracy, speed, clear, track },
+    target: GRADE.MEDIAN_TARGET_MS[tier],
+  };
+}
+
+/**
+ * Declared gates. A perfect class only: every offered round found on the FIRST
+ * tap, over at least MIN_ROUNDS_FOR_S rounds. Anything less caps at A.
+ */
+export function hardGates(i = {}) {
+  const offered = n0(i.roundsOffered);
+  const first = n0(i.firstTapFinds);
+  return { sGate: offered >= GRADE.MIN_ROUNDS_FOR_S && first === offered && offered > 0 };
+}
+
+/** +2 per sub-second find, +1 per relocated round still cleared, cap 15. */
+export function flavorXp(subSecondFinds, relocatedCleared) {
+  const fx = n0(subSecondFinds) * GRADE.FLAVOR_SUBSECOND + n0(relocatedCleared) * GRADE.FLAVOR_TRACK;
+  return Math.min(GRADE.FLAVOR_CAP, Math.round(fx));
+}
+
+export default { compositeFor, hardGates, flavorXp, latencyTerm, median, clamp01, GRADE };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
@@ -1,0 +1,1431 @@
+/* ============================================================================
+ * games/anomaly/index.js - ANOMALY (odd-one-out; family: search; 90s).
+ *
+ * A grid of the SAME loop, tiled N times, playing in lockstep because it IS
+ * one url in every tile - one decoder, one clock. Exactly one tile carries a
+ * delta: a hue rotation, a mirror, a size, a tilt, a softening, a light step
+ * (all on the <img>), or - only when the loop is really a <video> and the grid
+ * is 3 wide - a playbackRate or a frame offset. Find it. Tap it. Next.
+ *
+ * THE THESIS, which is also the difficulty: the Distraction Engine's effects
+ * apply UNIFORMLY TO ALL TILES. Every wash, every drift, every glitch is a
+ * global change, and a global change is noise. Only LOCAL difference is true.
+ * The class literally trains the player to stop reacting to the room.
+ *
+ * THE ROUND LOOP:
+ *   deal    one url -> every tile; every face wears the SAME inline filter and
+ *           transform SHAPE (identity values), one face wears the delta
+ *   find    a correct FIRST tap advances instantly with a sub-500ms ceremony
+ *   miss    a wrong tap burns WRONG_BURN_MS of the round and puts that tile
+ *           OUT (it desaturates - warmer/colder, ruling 3); the streak dies
+ *   move    at tier 3 the anomaly RELOCATES once mid-round under a glitch_swap,
+ *           at tier 4 twice (RELOC_CAP = 2, ruling 1). Tapping where it USED to
+ *           be draws the ghost outline - "it moved" - and refunds a second
+ *   whiff   the round times out, the answer is revealed, and two whiffs in a
+ *           row force ONE breather round (the dossier's comeback hook)
+ *   bell    the 90s budget ends the class, never a round count
+ *
+ * THE CRITIC'S TOP FIX IS LAW: the top tiers get harder through relocations,
+ * drift and decoy pressure at PERCEPTIBLE deltas - never through a delta
+ * approaching invisibility. Every magnitude lives in rounds.js DELTA and is
+ * floored by PERCEPT_FLOOR; the scratch suite asserts the whole table.
+ *
+ * THE ODD INDEX LIVES IN CLOSURE ONLY. It is never a data attribute, never a
+ * class, never an aria string, and no deck is ever handed it. What IS in the
+ * DOM is the delta itself, as an inline filter/transform on ONE .g-an-face -
+ * which is the puzzle, not the answer key. Every other face carries the same
+ * inline properties at identity values, so the odd tile is not even the only
+ * element with its own render surface (`filter:none` rasterises differently -
+ * that would be a tell in itself). The trickster's "melt a NON-odd tile" card
+ * is served by meltCandidates(), which filters here and hands out elements.
+ *
+ * LAWS THIS FILE KEEPS:
+ *   I   the ledger is honest - finds, first-tap accuracy, latencies, cleared
+ *       rounds and the clock are computed here and never routed through a deck
+ *   II  input honesty - a tile's hitbox is its own visual; row_drift moves the
+ *       tile and its hitbox together, and every engine one-shot over the grid
+ *       is decoration (fireSafe welds clickSafe/clickable off)
+ *   III nothing is still - the grid breathes even at tier 1 (the decks)
+ *   IV  images over text - the class-rules sheet is DRAWN and GO-only, and it
+ *       respects ctx.hideTutorial + gameMeta.howtoTiers
+ *   V   seeded - rounds.js deals the whole show off classSpec.seed; a retake
+ *       replays it. Relocations are SCHEDULE-DEALT, never live rng
+ *   VI  exits sacred - pause/resume/suspend/destroy (the DV discipline), the
+ *       timer registry defers, reducedMotion degrades per the dossier, and
+ *       caps.bgIntensity === 0 disarms every deck
+ *   VII every string is ctx.lexicon(key, fallback) over lex.js AN_LEX
+ *
+ * WHAT THIS FILE DOES NOT OWN: grades (core/grades.js via ctx.endClass), XP
+ * (C#), the tier (registry + meta), effect strengths (the engine's ceiling
+ * rule), the LOOK (style.js), the lighting (casino.js), the lies
+ * (trickster.js) and the CCP-effects ladder (pressure.js). The pure modules
+ * are rounds.js (the plan) and grade.js (the composite).
+ *
+ * DECK IMPORTS are NAMESPACE imports on purpose: a missing export from a deck
+ * that is still being written must not break the class (a missing FILE still
+ * would - that is the DE precedent and the registry's allSettled catches it).
+ * ==========================================================================*/
+
+import * as AN_STYLE from './style.js';
+import * as AN_CASINO from './casino.js';
+import * as AN_TRICKSTER from './trickster.js';
+import * as AN_PRESSURE from './pressure.js';
+import {
+  PLAYTEST, buildPlan, asBreather, relocationTarget, faceStyle, BASE_FACE,
+  heatFor, cadenceMs, pitchFor, clampTier,
+} from './rounds.js';
+import { compositeFor, hardGates, flavorXp, median } from './grade.js';
+import { AN_LEX } from './lex.js';
+import { makeTaggedRoll } from '../../core/rng.js';
+
+const GAME_KEY = 'anomaly';
+
+/** A url the <img> element cannot show (a webm/mp4 loop). Mirrors
+ *  engine/util.js VIDEO_URL_RE; games never import the engine, so the
+ *  two-line rule is repeated (the DE precedent). */
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+const isVideoUrl = (url) => VIDEO_URL_RE.test(String(url || ''));
+
+/** How many draws to spend looking for a tile-able url before giving up on
+ *  media entirely (a video-only pool on a 5x5 grid = plain faces, not 25
+ *  <video> elements - the L&F 30Hz lock). */
+const MEDIA_TRIES = 5;
+/** A round shorter than this cannot be offered before the bell. */
+const MIN_ROUND_MS = 2600;
+/** The shared ticker. */
+const TICK_MS = 110;
+
+/* Diagnostics seams (the DV/DE precedent): the shell never reads these. */
+let liveClass = null;
+let lastReport = null;
+let lastSnapshot = null;
+
+/** Test seam: the scratch harness compresses the clock. Production = 1.
+ *  It scales BOTH ends - a timer's real delay AND the logical time the ticker
+ *  credits for a real millisecond - so a 90s class can be played end to end in
+ *  under two seconds without the round deadlines drifting out of proportion. */
+let timeScale = 1;
+export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
+export function getTimeScale() { return timeScale; }
+function scaled(ms) { return Math.max(0, Math.round(ms * timeScale)); }
+/** Real elapsed ms -> class ms. Clamped so a stalled tab cannot jump the bell. */
+function logical(realMs) { return Math.max(0, Math.min(1000, (Number(realMs) || 0) / timeScale)); }
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** Reduced motion from the shell's projection first, then the two probes. */
+function probeReduced(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof document !== 'undefined' && document.documentElement
+      && document.documentElement.classList
+      && document.documentElement.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+function motionLevelOf(ctx) {
+  try {
+    const v = Number(ctx && ctx.motion ? ctx.motion.motionLevel : 2);
+    return Number.isFinite(v) ? v : 2;
+  } catch (e) { return 2; }
+}
+function coarseOf(ctx) {
+  try { if (ctx && ctx.platform && ctx.platform.isTouch) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(pointer: coarse)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+function mmss(sec) {
+  const s = Math.max(0, Math.round(sec));
+  return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+}
+
+export default {
+  key: GAME_KEY,
+  family: 'search',
+  meaty: false,
+  flagship: false,
+  timeBudgetSec: 90,
+  title: 'Anomaly',
+
+  manifest: {
+    /* flash_burst / gif_burst are declared ONLY as clickSafe decoration over a
+     * tap-precision grid (DECISIONS #9) - fireSafe() welds that on at every
+     * call site, so nothing decorative can ever steal a tap. */
+    effectsConsumed: [
+      'wash', 'glitch_swap', 'row_drift', 'sub_flash',
+      'audio_trigger', 'flash_burst', 'bubble_field', 'gif_burst',
+    ],
+    assetNeeds: { loops: 10, targets: 0, stills: 4, canvasSafe: false },
+    boardSizes: null,
+    keybinds: null,
+    settings: [
+      {
+        key: 'an_kinds', kind: 'enum', values: ['all', 'gentle'], default: 'all',
+        label_key: 'an_kinds', hint_key: 'an_kinds_hint',
+      },
+    ],
+    peek: false,
+  },
+
+  create(ctx) {
+    const t = (key, fallback) => {
+      const fb = fallback == null ? (AN_LEX[key] == null ? key : AN_LEX[key]) : fallback;
+      try { const v = ctx.lexicon(key, fb); return v == null ? fb : v; } catch (e) { return fb; }
+    };
+    const say = (m) => { try { ctx.log('[an] ' + m); } catch (e) { /* noop */ } };
+
+    /* ---- lifecycle flags ------------------------------------------------ */
+    let dead = false;
+    let paused = false;
+    let ended = false;
+    let reported = false;
+    let busy = true;                       // input closed until the sheet + briefing clear
+
+    /* ---- class state ---------------------------------------------------- */
+    let spec = null;
+    let seed = '';
+    let tier = 1;
+    let n = 3;
+    let plan = null;
+    let reduced = false;
+    let coarse = false;
+    let retake = false;
+    let budgetMs = 90000;
+    let pool = null;
+    let rollLocal = null;
+
+    let casino = null;
+    let trickster = null;
+    let pressure = null;
+
+    /* ---- the ledger (Law I: computed here, never by a deck) ------------- */
+    let roundsOffered = 0;
+    let roundsCleared = 0;
+    let firstTapFinds = 0;
+    let wrongTaps = 0;
+    let subSecondFinds = 0;
+    let relocatedRounds = 0;
+    let relocatedCleared = 0;
+    let ghostFinds = 0;                    // "it moved" near-misses drawn
+    let relocationsFired = 0;
+    let breathers = 0;
+    let streak = 0;
+    let bestStreak = 0;
+    let whiffStreak = 0;
+    let currentHeat = 0;
+    let bellOn = false;
+    let litOn = false;
+    let driftOn = false;
+    let washHeld = false;
+    let bubblesOn = false;
+    let subFlashes = 0;
+    let jackpots = 0;
+    let stallMs = 0;                       // ms since the player's last tap
+    let stallSinceReport = 0;              // accumulator for the ~500ms report
+    let lifetimeBefore = 0;
+    const findTimes = [];
+    const recoveryTimes = [];
+    const kindsSeen = new Map();           // kind -> {offered, cleared}
+
+    /* ---- round state ---------------------------------------------------- */
+    let roundIdx = 0;                      // plan cursor
+    let cur = null;                        // the live round
+    let mediaMode = 'plain';               // video | img | plain (stage-level, uniform)
+    let lastUrl = '';
+
+    /* ---- clock ---------------------------------------------------------- */
+    let tickId = 0;
+    let lastTick = 0;
+    let elapsedMs = 0;
+
+    /* ---- dom ------------------------------------------------------------ */
+    let stage = null; let backdrop = null; let hud = null; let gridEl = null;
+    let msgEl = null; let wellEl = null; let endEl = null;
+    let roundChip = null; let clockChip = null; let streakChip = null;
+    let howtoEl = null;
+    let msgToken = 0;
+    const tileEls = [];
+    const faceEls = [];
+    const mediaEls = [];
+    const tileHandlers = [];
+
+    /* ==================================================================== *
+     * TIMERS - every step goes through run() so a suspend freezes the class
+     * mid-round and a resume finishes it. `every` simply skips while paused.
+     * ==================================================================== */
+    const timers = new Map();
+    let nextTimerId = 1;
+    const deferred = [];
+    function run(fn) {
+      if (dead) return;
+      if (paused) { deferred.push(fn); return; }
+      try { fn(); } catch (e) { say('step failed: ' + ((e && e.message) || e)); }
+    }
+    function after(ms, fn) {
+      const id = nextTimerId++;
+      const h = setTimeout(() => { timers.delete(id); run(fn); }, scaled(ms));
+      timers.set(id, { kind: 'after', h });
+      return id;
+    }
+    function every(ms, fn) {
+      const id = nextTimerId++;
+      const h = setInterval(() => {
+        if (dead || paused) return;
+        try { fn(); } catch (e) { say('tick failed: ' + ((e && e.message) || e)); }
+      }, Math.max(4, scaled(ms)));
+      timers.set(id, { kind: 'every', h });
+      return id;
+    }
+    function clearTimer(id) {
+      const rec = timers.get(id);
+      if (!rec) return;
+      if (rec.kind === 'after') clearTimeout(rec.h); else clearInterval(rec.h);
+      timers.delete(id);
+    }
+    function clearTimers() {
+      for (const id of Array.from(timers.keys())) clearTimer(id);
+      timers.clear();
+      deferred.length = 0;
+    }
+    /** The decks' registry: this class's own pause-aware timers. */
+    const deckTimers = { after, every, clear: clearTimer };
+
+    /* ==================================================================== *
+     * ENGINE - one wrapper, the input-trust law welded on.
+     * ==================================================================== */
+    function fireSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'flash_burst' || kind === 'gif_burst') {
+        o.clickSafe = true;             // decoration only over a tap-precision grid
+        o.clickable = false;
+        delete o.onPop;
+      }
+      try { return ctx.engine.fire(kind, o) || null; } catch (e) { say('fire(' + kind + ') failed'); return null; }
+    }
+    function sustainSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'bubble_field') { o.clickSafe = true; delete o.onPop; }
+      try { return ctx.engine.sustain(kind, o) || null; } catch (e) { return null; }
+    }
+    function stopSafe(kind) { try { if (ctx.engine) ctx.engine.stop(kind); } catch (e) { /* noop */ } }
+    /** The engine as a deck sees it: three welded primitives + a READ of the
+     *  clamped channels (THE CEILING RULE - a deck asks, it never raises). */
+    const deckEngine = {
+      fire: fireSafe,
+      sustain: sustainSafe,
+      stop: stopSafe,
+      channels: () => {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+      /* the reward canon: 'jackpot' / 'near_miss' are engine-owned spectacle
+       * and are NOT kind-addressed, so they are not fenced by effectsConsumed
+       * (only fire/sustain are). The casino's ladder rides this. */
+      ceremony: (kind, o) => {
+        if (dead || paused || !ctx.engine || typeof ctx.engine.ceremony !== 'function') return null;
+        try { return ctx.engine.ceremony(kind, o || {}) || null; } catch (e) { return null; }
+      },
+    };
+    /** The player's own media, as a deck sees it. The pool lands ASYNC, so a
+     *  deck gets a LIVE reader, never the pool object. */
+    const deckAssets = {
+      next(kind) {
+        try { return (pool && typeof pool.next === 'function') ? (pool.next(kind) || null) : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** bgIntensity 0 is the player's exit: read it LIVE, never a snapshot. */
+    function capsArmed() { return !(ctx.caps && Number(ctx.caps.bgIntensity) === 0); }
+    /** A cue through the engine; level never above the tier's audio ceiling. */
+    function cue(name, level, extra) {
+      const ceil = plan ? plan.audioCeil : 0.45;
+      const lv = Math.min(ceil, level == null ? 0.4 : level);
+      fireSafe('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+    }
+
+    /* ---- the decks, null-safe ------------------------------------------- */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); } catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+
+    /* ==================================================================== *
+     * HEAT - the streak ladder, capped by the grade tier.
+     * ==================================================================== */
+    function heat() {
+      const h = heatFor(streak, tier);
+      currentHeat = h;
+      try { if (ctx.engine) ctx.engine.setHeat(h); } catch (e) { /* engine is optional */ }
+      deck('casino', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+    }
+
+    /* ==================================================================== *
+     * DOM (the contract's exact shape)
+     * ==================================================================== */
+    function setPhase(p) { if (stage) stage.setAttribute('data-phase', p); }
+
+    function buildDom() {
+      ctx.root.textContent = '';
+      stage = el('div', 'g-an-stage');
+      stage.setAttribute('data-phase', 'briefing');
+      stage.setAttribute('data-n', String(n));
+      stage.setAttribute('data-media', mediaMode);
+      if (reduced) stage.setAttribute('data-reduced', '1');
+
+      backdrop = el('div', 'g-an-backdrop');
+      stage.appendChild(backdrop);
+
+      hud = el('div', 'g-an-hud');
+      roundChip = el('span', 'g-an-chip g-an-round', '1');
+      roundChip.setAttribute('aria-label', t('an_chip_round', AN_LEX.an_chip_round));
+      clockChip = el('span', 'g-an-chip g-an-clock', mmss(budgetMs / 1000));
+      clockChip.setAttribute('aria-label', t('an_chip_clock', AN_LEX.an_chip_clock));
+      streakChip = el('span', 'g-an-chip g-an-streak', '0');
+      streakChip.setAttribute('aria-label', t('an_chip_streak', AN_LEX.an_chip_streak));
+      hud.appendChild(roundChip);
+      hud.appendChild(clockChip);
+      hud.appendChild(streakChip);
+      stage.appendChild(hud);
+
+      gridEl = el('div', 'g-an-grid');
+      gridEl.style.setProperty('--an-n', String(n));
+      for (let i = 0; i < n * n; i++) {
+        const tile = el('div', 'g-an-tile');
+        tile.setAttribute('data-i', String(i));
+        tile.setAttribute('role', 'button');
+        const face = el('div', 'g-an-face');
+        /* EVERY face wears the identity style, so the odd one is not the only
+         * element with inline filter/transform (and not the only one with its
+         * own render surface). The delta is a NUMBER change, never a shape one. */
+        face.style.filter = BASE_FACE.filter;
+        face.style.transform = BASE_FACE.transform;
+        tile.appendChild(face);
+        const handler = () => onTap(i);
+        tile.addEventListener('click', handler);
+        tileHandlers.push(handler);
+        tileEls.push(tile);
+        faceEls.push(face);
+        mediaEls.push(null);
+        gridEl.appendChild(tile);
+      }
+      stage.appendChild(gridEl);
+
+      msgEl = el('p', 'g-an-msg');
+      stage.appendChild(msgEl);
+      wellEl = el('div', 'g-an-flashwell');
+      stage.appendChild(wellEl);
+      endEl = el('div', 'g-an-end');
+      endEl.hidden = true;
+      stage.appendChild(endEl);
+
+      ctx.root.appendChild(stage);
+    }
+
+    function msg(key, fallback) {
+      if (!msgEl) return;
+      const text = key ? t(key, fallback) : '';
+      msgEl.textContent = text;
+      const mine = ++msgToken;
+      if (!text) return;
+      after(2400, () => { if (msgEl && msgToken === mine) msgEl.textContent = ''; });
+    }
+
+    function paintHud() {
+      if (roundChip) roundChip.textContent = String(Math.max(1, roundsOffered || 1));
+      if (clockChip) clockChip.textContent = mmss(secLeft());
+      if (streakChip) streakChip.textContent = String(streak);
+    }
+    /** The TRUE chip text - what the trickster's Stat Flicker restores. */
+    function chipText(which) {
+      if (which === 'round') return String(Math.max(1, roundsOffered || 1));
+      if (which === 'clock') return mmss(secLeft());
+      return String(streak);
+    }
+    function secLeft() { return Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)); }
+
+    /* ==================================================================== *
+     * MEDIA - one url, every tile. mediaEl semantics, copied not imported.
+     * ==================================================================== */
+    function makeMedia(url) {
+      const video = isVideoUrl(url);
+      const node = document.createElement(video ? 'video' : 'img');
+      node.className = 'g-an-media';
+      if (video) {
+        try {
+          node.muted = true; node.loop = true; node.autoplay = true; node.playsInline = true;
+          node.setAttribute('muted', ''); node.setAttribute('loop', '');
+          node.setAttribute('autoplay', ''); node.setAttribute('playsinline', '');
+          node.setAttribute('preload', 'auto');
+          node.disablePictureInPicture = true;
+        } catch (e) { /* ignore */ }
+      } else {
+        try { node.decoding = 'async'; node.alt = ''; node.setAttribute('draggable', 'false'); } catch (e) { /* ignore */ }
+      }
+      node.src = url;
+      if (video && typeof node.play === 'function') {
+        try { const p = node.play(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* autoplay policy */ }
+      }
+      return node;
+    }
+
+    /**
+     * Deal ONE url for the whole grid. Video is only tile-able on a small grid
+     * (the 30Hz lock); on a bigger grid a video-only draw is skipped and, if
+     * nothing else turns up, the round runs on PLAIN faces - which the delta
+     * kinds all still work on, because they are CSS on the face element.
+     */
+    function dealUrl() {
+      if (!pool || typeof pool.next !== 'function') return null;
+      const videoOk = n <= PLAYTEST.VIDEO_GRID_MAX && !reduced && !coarse && motionLevelOf(ctx) > 1;
+      let firstVideo = null;
+      for (let k = 0; k < MEDIA_TRIES; k++) {
+        let a = null;
+        try { a = pool.next(reduced || k >= 3 ? 'still' : 'loop'); } catch (e) { a = null; }
+        const url = a && a.url ? String(a.url) : '';
+        if (!url) continue;
+        if (isVideoUrl(url)) {
+          if (!firstVideo) firstVideo = url;
+          if (videoOk) return url;
+          continue;
+        }
+        return url;
+      }
+      return videoOk ? firstVideo : null;
+    }
+
+    /** Paint one url into every tile, recycling the element when the kind
+     *  matches (the L&F paintLook lesson: a <video> teardown is an IPC
+     *  round trip, and 9 of them per round would hitch the class). */
+    function paintGrid(url) {
+      const want = url ? (isVideoUrl(url) ? 'video' : 'img') : 'plain';
+      mediaMode = want;
+      lastUrl = url || '';
+      if (stage) stage.setAttribute('data-media', want);
+      for (let i = 0; i < faceEls.length; i++) {
+        const face = faceEls[i];
+        const existing = mediaEls[i];
+        if (want === 'plain') {
+          if (existing) { try { existing.remove(); } catch (e) { /* noop */ } mediaEls[i] = null; }
+          continue;
+        }
+        if (existing && existing.tagName === (want === 'video' ? 'VIDEO' : 'IMG')) {
+          try {
+            existing.src = url;
+            if (want === 'video') {
+              existing.playbackRate = 1;
+              if (existing.load) existing.load();
+              if (existing.play) { const p = existing.play(); if (p && p.catch) p.catch(() => {}); }
+            }
+            continue;
+          } catch (e) { /* fall through and replace */ }
+        }
+        if (existing) { try { existing.remove(); } catch (e) { /* noop */ } }
+        const node = makeMedia(url);
+        mediaEls[i] = node;
+        face.appendChild(node);
+      }
+    }
+
+    /* ==================================================================== *
+     * THE DELTA - inline, on ONE face. The odd index never leaves closure.
+     * ==================================================================== */
+    function clearFace(i) {
+      const face = faceEls[i];
+      if (!face) return;
+      face.style.filter = BASE_FACE.filter;
+      face.style.transform = BASE_FACE.transform;
+      const m = mediaEls[i];
+      if (m && m.tagName === 'VIDEO') {
+        try { m.playbackRate = 1; } catch (e) { /* noop */ }
+      }
+    }
+    function applyFace(i) {
+      const face = faceEls[i];
+      if (!face || !cur) return;
+      face.style.filter = cur.style.filter;
+      face.style.transform = cur.style.transform;
+      const m = mediaEls[i];
+      if (m && m.tagName === 'VIDEO') {
+        if (cur.kind === 'speed') { try { m.playbackRate = cur.style.rate; } catch (e) { /* noop */ } }
+        if (cur.kind === 'frame') {
+          const seek = () => {
+            try {
+              const dur = Number(m.duration);
+              const off = Number(cur.style.offset) || 0;
+              m.currentTime = (Number.isFinite(dur) && dur > off) ? off : off;
+            } catch (e) { /* noop */ }
+          };
+          seek();
+          try { if (typeof m.addEventListener === 'function') m.addEventListener('loadedmetadata', seek, { once: true }); }
+          catch (e) { /* noop */ }
+        }
+      }
+    }
+
+    /* ==================================================================== *
+     * ROUNDS
+     * ==================================================================== */
+    function spentNow() {
+      if (!cur) return 0;
+      if (paused || dead) return cur.spentMs;
+      return cur.spentMs + logical(Date.now() - lastTick);
+    }
+
+    function startRound() {
+      if (ended || dead) return;
+      if (budgetMs - elapsedMs <= MIN_ROUND_MS) { setPhase('verdict'); return; }
+
+      let r = plan.rounds[roundIdx % plan.rounds.length];
+      roundIdx += 1;
+      if (whiffStreak >= PLAYTEST.BREATHER_AFTER_WHIFFS) {
+        r = asBreather(r, plan);
+        whiffStreak = 0;
+        breathers += 1;
+      }
+
+      const url = dealUrl();
+      paintGrid(url);
+
+      /* THE VIDEO KINDS: the plan always deals an img-safe kind AND, on a small
+       * grid, an alternative that needs a real <video>. Only now - when the
+       * round's url is known - can we tell which one this round can wear. */
+      const canVideo = mediaMode === 'video' && n <= PLAYTEST.VIDEO_GRID_MAX && !reduced;
+      const kind = (canVideo && r.altKind) ? r.altKind : r.kind;
+      const delta = (canVideo && r.altKind) ? r.altDelta : r.delta;
+      const dir = (canVideo && r.altKind) ? r.altDir : r.dir;
+
+      /* the seeded odd index, clamped to this grid (a plan is dealt for this n
+       * already; the modulo is a belt-and-braces guard, never a re-roll) */
+      const odd = ((r.oddIndex % (n * n)) + (n * n)) % (n * n);
+
+      cur = {
+        round: r,
+        kind,
+        delta,
+        dir,
+        style: faceStyle(kind, delta, dir),
+        oddIndex: odd,
+        startOdd: odd,
+        prevOdds: new Set(),
+        eliminated: new Set(),
+        relocations: (r.relocations || []).map((x) => ({ at: x.at, order: x.order, applied: false })),
+        relocated: 0,
+        lastRelocAt: -1,
+        wrong: 0,
+        spentMs: 0,
+        remainingMs: r.durationMs,
+        done: false,
+        ghost: -1,
+      };
+
+      /* every tile back to a clean, identical slate, then the one delta */
+      for (let i = 0; i < tileEls.length; i++) {
+        tileEls[i].classList.remove('is-out', 'is-ghost', 'is-found', 'is-reveal');
+        clearFace(i);
+      }
+      applyFace(odd);
+
+      roundsOffered += 1;
+      if (cur.relocations.length) relocatedRounds += 1;
+      const kseen = kindsSeen.get(kind) || { offered: 0, cleared: 0 };
+      kseen.offered += 1;
+      kindsSeen.set(kind, kseen);
+
+      setPhase('round');
+      paintHud();
+      busy = false;
+      stallMs = 0;
+      stallSinceReport = 0;
+      deck('trickster', 'stalled', 0);
+
+      deck('casino', 'roundStart', roundsOffered, kind);
+      deck('pressure', 'beat', 'round');
+      if (r.breather) msg('an_breather', AN_LEX.an_breather);
+      else if (roundsOffered === 1) msg('an_play_hint', AN_LEX.an_play_hint);
+      say('round ' + roundsOffered + ': ' + kind + ' d=' + delta + (r.breather ? ' BREATHER' : '')
+        + ', ' + Math.round(r.durationMs / 100) / 10 + 's, ' + cur.relocations.length + ' reloc, media ' + mediaMode);
+    }
+
+    /** THE RELOCATION. Idempotent - the engine's onSwap and our own deadline
+     *  backstop both call it (trap 22: onSwap rides the ENGINE's timer
+     *  registry and a suspend kills it, so the game keeps its own). */
+    function relocate(rec) {
+      if (!cur || cur.done || ended || dead || !rec || rec.applied) return;
+      rec.applied = true;
+      const to = relocationTarget(rec.order, cur.oddIndex, cur.eliminated);
+      if (to < 0) { say('relocation had nowhere to land - skipped'); return; }
+      cur.prevOdds.add(cur.oddIndex);
+      clearFace(cur.oddIndex);
+      cur.oddIndex = to;
+      applyFace(to);
+      cur.relocated += 1;
+      cur.lastRelocAt = spentNow();
+      relocationsFired += 1;
+      deck('casino', 'relocated');
+      deck('pressure', 'beat', 'relocate');
+      cue('glitch', 0.32);
+    }
+
+    function armRelocation(rec) {
+      /* the glitch covers EVERY tile - a global change, i.e. noise (the lie) */
+      const r = fireSafe('glitch_swap', {
+        targets: tileEls.slice(),
+        seconds: 0.55,
+        onSwap: () => relocate(rec),
+        sfx: false,
+      });
+      const mid = r && Number(r.durMs) > 0 ? Math.round(Number(r.durMs) / 2) : 280;
+      /* THE BACKSTOP (trap 22): resolve it ourselves on a deadline whatever the
+       * engine's timers do. relocate() is idempotent, so both may fire. */
+      after(Math.min(900, mid + 90), () => relocate(rec));
+    }
+
+    function onTap(i) {
+      if (dead || paused || ended || busy || !cur || cur.done) return;
+      if (cur.eliminated.has(i)) return;
+      const latency = Math.max(1, Math.round(spentNow()));
+      if (i === cur.oddIndex) found(i, latency);
+      else wrong(i, latency);
+    }
+
+    function found(i, latency) {
+      cur.done = true;
+      busy = true;
+      stallMs = 0;
+      roundsCleared += 1;
+      findTimes.push(latency);
+      const clean = cur.wrong === 0;
+      if (clean) {
+        firstTapFinds += 1;
+        streak += 1;
+        bestStreak = Math.max(bestStreak, streak);
+      } else {
+        streak = 0;
+      }
+      whiffStreak = 0;
+      if (latency < PLAYTEST.SUBSECOND_MS) subSecondFinds += 1;
+      if (cur.relocated > 0) {
+        relocatedCleared += 1;
+        if (cur.lastRelocAt >= 0) recoveryTimes.push(Math.max(1, Math.round(latency - cur.lastRelocAt)));
+      }
+      const kseen = kindsSeen.get(cur.kind) || { offered: 1, cleared: 0 };
+      kseen.cleared += 1;
+      kindsSeen.set(cur.kind, kseen);
+
+      const tile = tileEls[i];
+      if (tile) tile.classList.add('is-found');
+      const roll = rollReward();
+      if (roll.jackpot) jackpots += 1;
+
+      deck('casino', 'tap', {
+        correct: true, i, latencyMs: latency, streak,
+        first: clean, jackpot: !!roll.jackpot, kind: cur.kind, relocated: cur.relocated,
+      });
+      deck('pressure', 'setStreak', streak);
+      deck('pressure', 'beat', 'find', { streak, latencyMs: latency, first: clean });
+      deck('trickster', 'afterTap', { i, correct: true, moved: false, latencyMs: latency, streak });
+      heat();
+      litCheck();
+      paintHud();
+
+      cue('chime', 0.42, { pitch: pitchFor(streak) });
+      fireSafe('flash_burst', { count: roll.jackpot ? 3 : 2, alpha: 0.45 });
+      if (roll.jackpot) fireSafe('gif_burst', { count: 3, variant: 'scatter', assetKind: 'loop', holdMs: 700 });
+      /* DECK IV, the escalation ladder: every find ticks the 10-segment meter,
+       * a streak milestone stamps, and a jackpot roll pays the full beat.
+       * All three are SHELL primitives - this game skins nothing of its own. */
+      try {
+        if (ctx.ceremonies && typeof ctx.ceremonies.streakMeter === 'function') {
+          ctx.ceremonies.streakMeter({ target: streakChip, filled: Math.min(10, streak), gold: streak >= PLAYTEST.STREAK_LIT });
+        }
+        if (ctx.ceremonies && typeof ctx.ceremonies.stamp === 'function' && clean && streak > 0 && streak % 5 === 0) {
+          ctx.ceremonies.stamp({ text: t('an_stamp_found', AN_LEX.an_stamp_found), target: hud });
+        }
+        if (roll.jackpot && ctx.ceremonies && typeof ctx.ceremonies.reward === 'function') {
+          ctx.ceremonies.reward('jackpot', { text: t('an_jackpot', AN_LEX.an_jackpot), target: tile || gridEl });
+        }
+      } catch (e) { /* noop */ }
+      msg(latency < PLAYTEST.SUBSECOND_MS ? 'an_found_fast' : 'an_found',
+        latency < PLAYTEST.SUBSECOND_MS ? AN_LEX.an_found_fast : AN_LEX.an_found);
+
+      /* SUB-500ms: the correct first tap advances instantly, by contract. */
+      after(reduced ? PLAYTEST.ADVANCE_MS_REDUCED : PLAYTEST.ADVANCE_MS, endRound);
+    }
+
+    function wrong(i, latency) {
+      cur.wrong += 1;
+      wrongTaps += 1;
+      cur.eliminated.add(i);
+      const tile = tileEls[i];
+      if (tile) tile.classList.add('is-out');
+
+      /* THE GHOST OUTLINE - "it moved". Tapping where the anomaly WAS before a
+       * relocation is a near-miss that TEACHES: outline the old tile, tick the
+       * near-miss ceremony and refund a second of the round. (The ghost marks
+       * a tile the anomaly has LEFT - it can never name the live one.) */
+      const moved = cur.prevOdds.has(i);
+      if (moved) {
+        ghostFinds += 1;
+        cur.ghost = i;
+        if (tile) tile.classList.add('is-ghost');
+        cur.remainingMs += PLAYTEST.GHOST_REFUND_MS;
+        deck('casino', 'almost');
+        deck('trickster', 'ghostOutline', i);
+        /* shell/ceremonies.js owns the beat: reward('near_miss'), never a
+         * ceremony of our own (SYNTHESIS #10 - games skin, never fork). */
+        try {
+          if (ctx.ceremonies && typeof ctx.ceremonies.reward === 'function') {
+            ctx.ceremonies.reward('near_miss', { text: t('an_moved', AN_LEX.an_moved), target: tile || gridEl });
+          }
+        } catch (e) { /* noop */ }
+        cue('near', 0.3);
+        msg('an_moved', AN_LEX.an_moved);
+      } else {
+        cur.remainingMs -= PLAYTEST.WRONG_BURN_MS;
+        cue('thud', 0.26, { pitch: 0.8 });
+        msg('an_wrong', AN_LEX.an_wrong);
+      }
+
+      if (streak !== 0) { streak = 0; deck('pressure', 'setStreak', 0); heat(); litCheck(); }
+      deck('casino', 'tap', {
+        correct: false, i, latencyMs: latency, streak,
+        first: false, jackpot: false, kind: cur.kind, moved,
+      });
+      deck('pressure', 'beat', 'miss', { moved, i });
+      deck('trickster', 'afterTap', { i, correct: false, moved, latencyMs: latency, streak: 0 });
+      paintHud();
+      if (cur.remainingMs <= 0) whiff();
+    }
+
+    function whiff() {
+      if (!cur || cur.done) return;
+      cur.done = true;
+      busy = true;
+      whiffStreak += 1;
+      streak = 0;
+      deck('pressure', 'setStreak', 0);
+      deck('pressure', 'beat', 'miss', { timeout: true });
+      heat();
+      litCheck();
+      const tile = tileEls[cur.oddIndex];
+      /* the round is OVER - revealing the answer now teaches without ever
+       * having marked the live tile (the class assertion in the suite is
+       * about a LIVE round) */
+      if (tile) tile.classList.add('is-reveal');
+      /* a round nobody touched gets the plain line; one they hunted and missed
+       * gets the answer pointed at - the reveal is the lesson either way */
+      if (cur.wrong > 0) msg('an_reveal', AN_LEX.an_reveal);
+      else msg('an_timeout', AN_LEX.an_timeout);
+      cue('thud', 0.24, { pitch: 0.7 });
+      paintHud();
+      after(reduced ? PLAYTEST.WHIFF_HOLD_MS_REDUCED : PLAYTEST.WHIFF_HOLD_MS, endRound);
+    }
+
+    function endRound() {
+      if (ended || dead) return;
+      deck('trickster', 'afterRound');
+      cur = null;
+      setPhase('verdict');
+      startRound();
+    }
+
+    function litCheck() {
+      const want = streak >= PLAYTEST.STREAK_LIT;
+      if (want === litOn || !gridEl) return;
+      litOn = want;
+      if (want) gridEl.classList.add('is-lit');
+      else gridEl.classList.remove('is-lit');
+      if (want) msg('an_streak_lit', AN_LEX.an_streak_lit);
+    }
+
+    /** The variable-ratio canon, engine first, seeded local fallback second. */
+    function rollReward() {
+      try {
+        if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') {
+          const r = ctx.engine.rewardRoll({ streak });
+          if (r && typeof r === 'object') return r;
+        }
+      } catch (e) { /* fall through */ }
+      return rollLocal ? rollLocal() : { fire: false, jackpot: false, nearMiss: false };
+    }
+
+    /* ==================================================================== *
+     * AMBIENCE - uniform over the WHOLE grid. That is the point: a global
+     * change is noise. Nothing here ever touches one tile.
+     * ==================================================================== */
+    let subTimer = 0;
+    let subIdx = 0;
+    function openAmbience() {
+      heat();
+      if (plan.washHold) {
+        const h = sustainSafe('wash', { variant: 'pink', sustainForever: true, alpha: 0.18 });
+        washHeld = !!h;
+      }
+      if (plan.bubbles) {
+        const h = sustainSafe('bubble_field', { clickSafe: true, variant: 'drift' });
+        bubblesOn = !!h;
+      }
+      if (plan.drift && !reduced) {
+        const targets = tileEls.filter((_, i) => (Math.floor(i / n) % 2) === 0);
+        const h = sustainSafe('row_drift', Object.assign({ targets, axis: 'x', stagger: false }, plan.drift));
+        driftOn = !!h;
+      }
+      armSubFlash();
+    }
+    function stopAmbience() {
+      if (subTimer) { clearTimer(subTimer); subTimer = 0; }
+      for (const k of ['wash', 'bubble_field', 'row_drift']) stopSafe(k);
+      washHeld = false; bubblesOn = false; driftOn = false;
+    }
+    /** sub_flash on the plan's cadence, heat-shortened, seed-jittered. Anchored
+     *  to the flashwell, never to a tile - it must not mark anything. */
+    function armSubFlash() {
+      if (!plan || !plan.subFlashMs || ended) return;
+      const ms = cadenceMs(plan.subFlashMs, currentHeat, plan.subJitter[subIdx % plan.subJitter.length]);
+      subTimer = after(ms, () => {
+        subTimer = 0;
+        const r = fireSafe('sub_flash', { anchor: wellEl, variant: subIdx % 2 ? 'scatter' : 'whisper' });
+        if (r) subFlashes += 1;
+        subIdx += 1;
+        armSubFlash();
+      });
+    }
+
+    /* ==================================================================== *
+     * THE CLOCK - one ticker for the class bell, the round deadline and the
+     * relocation schedule. Every step reads REAL elapsed time and a pause
+     * simply stops feeding it (Law VI).
+     * ==================================================================== */
+    function startClock() {
+      lastTick = Date.now();
+      tickId = every(TICK_MS, () => {
+        const now = Date.now();
+        const dt = logical(now - lastTick);
+        lastTick = now;
+        elapsedMs += dt;
+
+        if (cur && !cur.done) {
+          cur.spentMs += dt;
+          cur.remainingMs -= dt;
+          for (const rec of cur.relocations) {
+            if (!rec.applied && cur.spentMs >= rec.at) { armRelocation(rec); break; }
+          }
+        }
+        /* THE STALL is the player's own: ms since the last TAP, reported to the
+         * trickster on a ~500ms cadence (0 resets it). It runs during a live
+         * round - that is when a ghost cursor has something to lure. */
+        if (!ended) {
+          stallMs += dt;
+          stallSinceReport += dt;
+          if (stallSinceReport >= PLAYTEST.STALL_TICK_MS) {
+            stallSinceReport = 0;
+            deck('trickster', 'stalled', (cur && !cur.done && !busy) ? stallMs : 0);
+          }
+        }
+
+        paintHud();
+        if (!bellOn && elapsedMs >= budgetMs) { bell(); return; }
+        if (!bellOn && budgetMs - elapsedMs <= PLAYTEST.BELL_WARN_SEC * 1000) {
+          if (stage && stage.getAttribute('data-warn') !== '1') stage.setAttribute('data-warn', '1');
+        }
+        if (cur && !cur.done && cur.remainingMs <= 0) whiff();
+      });
+    }
+    function stopClock() { if (tickId) { clearTimer(tickId); tickId = 0; } }
+
+    function bell() {
+      if (ended || bellOn) return;
+      bellOn = true;
+      busy = true;
+      /* a round the bell cut short was never OFFERED - grading it would punish
+       * the player for the clock (grade.js reads roundsOffered) */
+      if (cur && !cur.done) {
+        cur.done = true;
+        roundsOffered = Math.max(0, roundsOffered - 1);
+        if (cur.relocations.length) relocatedRounds = Math.max(0, relocatedRounds - 1);
+        const kseen = kindsSeen.get(cur.kind);
+        if (kseen) kseen.offered = Math.max(0, kseen.offered - 1);
+      }
+      setPhase('verdict');
+      deck('casino', 'bell', true);
+      deck('pressure', 'beat', 'bell');
+      try {
+        if (ctx.ceremonies && typeof ctx.ceremonies.stamp === 'function') {
+          ctx.ceremonies.stamp({ text: t('an_stamp_bell', AN_LEX.an_stamp_bell), tone: 'pink', target: hud });
+        }
+      } catch (e) { /* noop */ }
+      msg('an_bell', AN_LEX.an_bell);
+      cue('stamp', 0.55);
+      after(reduced ? PLAYTEST.CEREMONY_MS_REDUCED : PLAYTEST.CEREMONY_MS, finish);
+    }
+
+    /* ==================================================================== *
+     * THE END - exactly one endClass, after the end card has been seen.
+     * ==================================================================== */
+    function finish() {
+      if (ended) return;
+      ended = true;
+      busy = true;
+      cur = null;
+      stopClock();
+      stopAmbience();
+      deck('trickster', 'stop');
+      deck('casino', 'dimOut', {
+        wrongTaps, bestStreak, finds: roundsCleared,
+        roundsOffered, roundsCleared, firstTapFinds,
+        fail: roundsOffered > 0 && roundsCleared === 0,
+      });
+      deck('casino', 'stop');
+      deck('pressure', 'stop');
+      paintHud();                       // truth on every chip, whatever the trickster left
+
+      const graded = compositeFor({
+        gradeTier: tier,
+        roundsOffered, roundsCleared, firstTapFinds,
+        findTimes, relocatedRounds, relocatedCleared, recoveryTimes,
+      });
+      const gates = hardGates({ roundsOffered, firstTapFinds });
+      const fx = flavorXp(subSecondFinds, relocatedCleared);
+
+      try {
+        const prior = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        const finds = Math.max(0, Number(prior.finds) || 0) + roundsCleared;
+        ctx.store.mergeGameMeta(GAME_KEY, {
+          finds,
+          bestStreak: Math.max(Math.max(0, Number(prior.bestStreak) || 0), bestStreak),
+          lastSeed: seed,
+          lastPlayedAt: Date.now(),
+        });
+      } catch (e) { say('meta write failed (class unaffected): ' + ((e && e.message) || e)); }
+
+      renderEnd(graded);
+      setPhase('ended');
+
+      const report = { metrics: { composite: graded.composite }, hardGates: gates, flavorXp: fx };
+      lastReport = Object.assign({}, report, {
+        inputs: {
+          tier, n, seed, retake, reduced, roundsOffered, roundsCleared, firstTapFinds, wrongTaps,
+          subSecondFinds, relocatedRounds, relocatedCleared, relocationsFired, ghostFinds,
+          breathers, bestStreak, medianFindMs: graded.median, recoveryMs: graded.recovery,
+          terms: graded.terms, elapsedMs, mediaMode,
+        },
+      });
+      try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
+      say('class over: ' + roundsCleared + '/' + roundsOffered + ' cleared, ' + firstTapFinds
+        + ' first-tap, median ' + graded.median + 'ms, streak ' + bestStreak
+        + ', relocations ' + relocationsFired + ' -> composite ' + graded.composite.toFixed(3)
+        + (gates.sGate ? ' [S gate open]' : ''));
+
+      after(reduced ? PLAYTEST.END_HOLD_MS_REDUCED : PLAYTEST.END_HOLD_MS, () => {
+        if (reported) return;
+        reported = true;
+        try { ctx.endClass(report); } catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
+      });
+    }
+
+    function renderEnd(graded) {
+      if (!endEl) return;
+      endEl.textContent = '';
+      endEl.hidden = false;
+      endEl.appendChild(el('h3', 'g-an-end-title', t('an_end_title', AN_LEX.an_end_title)));
+      const row = (cls, k, v) => {
+        const r = el('div', 'g-an-end-row' + (cls ? ' ' + cls : ''));
+        r.appendChild(el('span', 'g-an-end-k', k));
+        r.appendChild(el('span', 'g-an-end-v', v));
+        endEl.appendChild(r);
+        return r;
+      };
+      row('g-an-end-found', t('an_end_found', AN_LEX.an_end_found), String(roundsCleared));
+      row('', t('an_end_rounds', AN_LEX.an_end_rounds), String(roundsOffered));
+      row('', t('an_end_accuracy', AN_LEX.an_end_accuracy),
+        (roundsOffered > 0 ? Math.round((firstTapFinds / roundsOffered) * 100) : 0) + '%');
+      row('', t('an_end_median', AN_LEX.an_end_median),
+        graded.median > 0 ? (Math.round(graded.median / 10) / 100).toFixed(2) + 's' : t('an_end_none', AN_LEX.an_end_none));
+      row('', t('an_end_streak', AN_LEX.an_end_streak), String(bestStreak));
+      row('', t('an_end_tracked', AN_LEX.an_end_tracked),
+        relocatedRounds > 0 ? (relocatedCleared + ' / ' + relocatedRounds) : t('an_end_none', AN_LEX.an_end_none));
+      const hardest = hardestKind();
+      row('', t('an_end_kind', AN_LEX.an_end_kind),
+        hardest ? t('an_kind_' + hardest, AN_LEX['an_kind_' + hardest] || hardest) : t('an_end_none', AN_LEX.an_end_none));
+      endEl.appendChild(el('p', 'g-an-end-line', t('an_end_line', AN_LEX.an_end_line)));
+    }
+
+    /** The kind with the worst clear rate this class (>=2 offered). */
+    function hardestKind() {
+      let worst = null;
+      let worstRate = 2;
+      for (const [kind, s] of kindsSeen) {
+        if (s.offered < 2) continue;
+        const rate = s.cleared / s.offered;
+        if (rate < worstRate) { worstRate = rate; worst = kind; }
+      }
+      return worst;
+    }
+
+    /* ==================================================================== *
+     * THE CLASS-RULES SHEET (Deck VI, Law IV) - drawn, GO-only, and it
+     * respects the shell's "Skip class tutorials" contract exactly as
+     * Impulse Control does: default shows every class, with the skip on a
+     * class still explains itself ONCE per grade tier.
+     * ==================================================================== */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    function rememberHowtoTier() {
+      try {
+        const list = howtoSeenTiers();
+        if (list.indexOf(tier) < 0) {
+          list.push(tier);
+          if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+            ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+          }
+        }
+      } catch (e) { /* best effort - the sheet just shows again next time */ }
+    }
+    function hideHowto() {
+      try { if (typeof AN_STYLE.hideAnomalyHowto === 'function') AN_STYLE.hideAnomalyHowto(); } catch (e) { /* noop */ }
+      if (howtoEl) { try { howtoEl.remove(); } catch (e) { /* noop */ } howtoEl = null; }
+    }
+    /** CORE's fallback sheet: the POLICY is ours either way, the VISUALS are
+     *  style.js's. These class names are the seam - CREATIVE styles them, and
+     *  may replace the markup entirely by exporting showAnomalyHowto(). */
+    function fallbackHowto(onGo) {
+      if (!stage) return null;
+      const sheet = el('div', 'g-an-howto');
+      sheet.appendChild(el('h2', 'g-an-hw-title', t('an_howto_title', AN_LEX.an_howto_title)));
+      const row = (figCls, caption) => {
+        const r = el('div', 'g-an-hw-row');
+        const fig = el('span', 'g-an-hw-fig ' + figCls);
+        for (let k = 0; k < 4; k++) fig.appendChild(el('i', 'g-an-hw-cell' + (k === 2 ? ' odd' : '')));
+        r.appendChild(fig);
+        r.appendChild(el('p', 'g-an-hw-cap', caption));
+        sheet.appendChild(r);
+      };
+      row('same', t('an_howto_same', AN_LEX.an_howto_same));
+      row('find', t('an_howto_find', AN_LEX.an_howto_find));
+      row('lie', t('an_howto_lie', AN_LEX.an_howto_lie));
+      const go = el('button', 'g-an-hw-go', t('an_howto_go', AN_LEX.an_howto_go));
+      go.type = 'button';
+      go.setAttribute('autofocus', '');
+      go.addEventListener('click', () => { try { onGo(); } catch (e) { /* noop */ } });
+      sheet.appendChild(go);
+      stage.appendChild(sheet);
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+      return sheet;
+    }
+    function howto(onDone) {
+      const seen = howtoSeenTiers();
+      if (ctx.hideTutorial === true && seen.indexOf(tier) >= 0) { onDone(); return; }
+      let done = false;
+      const onGo = () => {
+        if (done || dead) return;
+        done = true;
+        rememberHowtoTier();
+        hideHowto();
+        onDone();
+      };
+      let node = null;
+      if (typeof AN_STYLE.showAnomalyHowto === 'function') {
+        try {
+          node = AN_STYLE.showAnomalyHowto({
+            mount: stage, onGo, coarse, t, tier, n,
+          }) || null;
+        } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); node = null; }
+      }
+      if (!node) node = fallbackHowto(onGo);
+      if (!node) { onDone(); return; }
+      howtoEl = node;
+    }
+
+    /* ==================================================================== *
+     * ASSETS
+     * ==================================================================== */
+    function claimAssets() {
+      Promise.resolve()
+        .then(() => ctx.assets.claim({ loops: 10, targets: 0, stills: 4, canvasSafe: false }))
+        .then((p) => {
+          if (dead || !p || typeof p.next !== 'function') return;
+          pool = p;
+          /* a round already on screen with plain faces gets its media now */
+          if (cur && mediaMode === 'plain') run(() => { const u = dealUrl(); if (u) { paintGrid(u); applyFace(cur.oddIndex); } });
+        })
+        .catch((e) => say('asset claim failed - plain faces: ' + ((e && e.message) || e)));
+    }
+
+    /* ==================================================================== *
+     * THE MODULE INSTANCE
+     * ==================================================================== */
+    const instance = {
+      start(classSpec) {
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 90 };
+        tier = clampTier(spec.gradeTier);
+        seed = String(spec.seed == null ? GAME_KEY : spec.seed);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 90) * 1000);
+        retake = !!spec.retake;
+        reduced = probeReduced(ctx);
+        coarse = coarseOf(ctx);
+
+        const kindsMode = String(
+          (ctx.settings && ctx.settings.an_kinds != null) ? ctx.settings.an_kinds : 'all',
+        ).trim().toLowerCase() === 'gentle' ? 'gentle' : 'all';
+
+        plan = buildPlan({
+          seed, gradeTier: tier, timeBudgetSec: budgetMs / 1000, kindsMode, reduced, coarse,
+        });
+        n = plan.n;
+
+        rollLocal = (() => {
+          const roll = makeTaggedRoll(seed + '|an-vr');
+          return () => {
+            const base = 0.30 + 0.30 * (tier - 1) / 3;
+            const chance = Math.min(1, base + Math.min(7, streak) * 0.03);
+            const r = roll('fire');
+            const fire = r < chance;
+            return { fire, jackpot: fire && roll('jack') >= 0.85, nearMiss: !fire && r < chance + 0.08 };
+          };
+        })();
+
+        try { lifetimeBefore = Math.max(0, Number((ctx.store.gameMeta(GAME_KEY) || {}).finds) || 0); }
+        catch (e) { lifetimeBefore = 0; }
+
+        try { if (typeof AN_STYLE.injectAnomalyStyle === 'function') AN_STYLE.injectAnomalyStyle(); }
+        catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
+        buildDom();
+
+        const capsOk = capsArmed();
+        if (typeof AN_CASINO.createAnCasino === 'function') {
+          try {
+            casino = createDeckSafely(() => AN_CASINO.createAnCasino({
+              seed, tier, stage, board: gridEl, backdrop,
+              hud: { root: hud, round: roundChip, clock: clockChip, streak: streakChip },
+              timers: deckTimers, reduced, motionLevel: motionLevelOf(ctx), capsOk,
+              t, engine: deckEngine, assets: deckAssets, log: say,
+            }));
+          } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+        }
+        if (typeof AN_TRICKSTER.createAnTrickster === 'function') {
+          try {
+            trickster = createDeckSafely(() => AN_TRICKSTER.createAnTrickster({
+              seed, tier, timers: deckTimers, reduced, capsOk, coarse,
+              stage, grid: gridEl, budgetSec: Math.round(budgetMs / 1000),
+              isHalted: () => dead || paused || ended || busy,
+              stats: () => ({
+                round: roundsOffered, streak, secLeft: secLeft(), cleared: roundsCleared,
+                offered: roundsOffered, phase: stage ? stage.getAttribute('data-phase') : '',
+              }),
+              chipEl: (which) => (which === 'clock' ? clockChip : which === 'streak' ? streakChip : roundChip),
+              chipText,
+              /* THE MELT: a NON-odd, still-live tile. The odd index never
+               * leaves this closure - the deck is handed ELEMENTS, not an
+               * index, and never the one that matters. */
+              meltCandidates: () => (cur && !cur.done
+                ? tileEls.filter((_, i) => i !== cur.oddIndex && !cur.eliminated.has(i))
+                : tileEls.slice()),
+              /* the same veto as a predicate (the deck's documented fallback) */
+              canMelt: (i) => !(cur && !cur.done && (Number(i) === cur.oddIndex || cur.eliminated.has(Number(i)))),
+              tiles: () => tileEls.slice(),
+              /* GLITCH-TO-ASSET lives on HUD CHROME, never on a truth node */
+              chromeEls: () => [roundChip, clockChip, streakChip, msgEl].filter(Boolean),
+              getStill: () => { const a = deckAssets.next('still'); return (a && a.url) || null; },
+              assets: deckAssets,
+              engine: deckEngine,
+              t,
+              announce: (text, ms) => {
+                if (!msgEl || !text) return;
+                msgEl.textContent = String(text);
+                const mine = ++msgToken;
+                deckTimers.after(Math.max(400, Number(ms) || 1600), () => {
+                  if (msgEl && msgToken === mine) msgEl.textContent = '';
+                });
+              },
+              log: say,
+            }));
+          } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+        }
+        if (typeof AN_PRESSURE.createAnPressure === 'function') {
+          try {
+            pressure = createDeckSafely(() => AN_PRESSURE.createAnPressure({
+              seed, gradeTier: tier, reduced, motionLevel: motionLevelOf(ctx),
+              stage, backdrop, grid: gridEl,
+              /* TREMOR RIDES CHROME, NEVER A TRUTH NODE: the grid and its tiles
+               * are hitboxes, so they are deliberately NOT in this list. */
+              chrome: [hud, roundChip, clockChip, streakChip, msgEl],
+              hud: { round: roundChip, clock: clockChip, streak: streakChip },
+              engine: deckEngine, assets: deckAssets, timers: deckTimers,
+              /* the held-wash url the deck may dress its veil with: a POOL
+               * still, read live (the claim lands after start()). CORE builds
+               * no hanging strips, so `strips` is left for the deck to find. */
+              spiralUrl: () => { const a = deckAssets.next('still'); return (a && a.url) || null; },
+              capsOk: capsArmed, t, log: say,
+            }));
+          } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+        }
+
+        claimAssets();
+        liveClass = instance;
+        lastReport = null;
+        lastSnapshot = null;
+
+        say('tier ' + tier + ' grid ' + n + 'x' + n + ', ' + plan.count + ' rounds dealt, budget '
+          + Math.round(budgetMs / 1000) + 's, kinds [' + plan.kinds.join(',') + ']'
+          + (plan.videoKinds.length ? ' +[' + plan.videoKinds.join(',') + ']' : '')
+          + ', ' + plan.relocPerRound + ' reloc/round' + (reduced ? ', reduced' : '')
+          + (coarse ? ', coarse' : '') + (retake ? ', RETAKE' : ''));
+
+        /* the sheet first, then one briefing line, then the first grid */
+        howto(() => {
+          if (dead || ended) return;
+          setPhase('briefing');
+          msg('an_brief', AN_LEX.an_brief);
+          startClock();
+          deck('casino', 'start');
+          deck('pressure', 'start');
+          deck('trickster', 'start');
+          openAmbience();
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
+            if (dead || ended) return;
+            startRound();
+          });
+        });
+      },
+
+      pause() {
+        if (paused) return;
+        paused = true;
+        deck('pressure', 'pause');
+        deck('casino', 'pause');
+        deck('trickster', 'pause');
+        if (stage) stage.classList.add('suspended');
+      },
+
+      resume() {
+        if (!paused) return;
+        paused = false;
+        if (stage) stage.classList.remove('suspended');
+        deck('pressure', 'resume');
+        deck('casino', 'resume');
+        deck('trickster', 'resume');
+        lastTick = Date.now();
+        const q = deferred.splice(0);
+        for (const fn of q) run(fn);
+      },
+
+      /** The shell owns the overlay and the engine's suspend; we just freeze. */
+      suspend(on) { if (on) instance.pause(); else instance.resume(); },
+
+      destroy() {
+        dead = true;
+        stopClock();
+        clearTimers();
+        stopAmbience();
+        hideHowto();
+        for (let i = 0; i < tileEls.length; i++) {
+          try { tileEls[i].removeEventListener('click', tileHandlers[i]); } catch (e) { /* noop */ }
+        }
+        try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
+        trickster = null;
+        try { if (casino) casino.destroy(); } catch (e) { /* noop */ }
+        casino = null;
+        try { if (pressure) pressure.destroy(); } catch (e) { /* noop */ }
+        pressure = null;
+        if (pool && typeof pool.release === 'function') { try { pool.release(); } catch (e) { /* noop */ } }
+        pool = null;
+        tileEls.length = 0;
+        faceEls.length = 0;
+        mediaEls.length = 0;
+        tileHandlers.length = 0;
+        cur = null;
+        try { ctx.root.textContent = ''; } catch (e) { /* noop */ }
+        if (liveClass === instance) liveClass = null;
+      },
+
+      /* -------- test / diagnostics seams (never read by the shell) -------- */
+      /** Tap tile i as the player would. */
+      tap(i) { onTap(i); },
+      /** Force the bell (the harness never waits 90 real seconds). */
+      ringBell() { bell(); },
+      /** The TRUE chip text - what a Stat Flicker restores. */
+      chipText(which) { return chipText(which); },
+
+      snapshot() {
+        return {
+          tier, n, seed, retake, reduced, coarse, mediaMode, lastUrl,
+          plan: plan ? {
+            count: plan.count, kinds: plan.kinds.slice(), videoKinds: plan.videoKinds.slice(),
+            relocPerRound: plan.relocPerRound, heatCap: plan.heatCap, subFlashMs: plan.subFlashMs,
+            wash: plan.wash, washHold: plan.washHold, bubbles: plan.bubbles, drift: plan.drift,
+          } : null,
+          /* DIAGNOSTICS ONLY. The DOM never carries this and no deck is ever
+           * handed it - the suite asserts both. */
+          odd: cur ? cur.oddIndex : -1,
+          kind: cur ? cur.kind : '',
+          delta: cur ? cur.delta : 0,
+          breather: !!(cur && cur.round && cur.round.breather),
+          eliminated: cur ? Array.from(cur.eliminated) : [],
+          prevOdds: cur ? Array.from(cur.prevOdds) : [],
+          relocatedThisRound: cur ? cur.relocated : 0,
+          remainingMs: cur ? Math.round(cur.remainingMs) : 0,
+          spentMs: cur ? Math.round(cur.spentMs) : 0,
+          roundsOffered, roundsCleared, firstTapFinds, wrongTaps, subSecondFinds,
+          relocatedRounds, relocatedCleared, relocationsFired, ghostFinds, breathers,
+          streak, bestStreak, whiffStreak, currentHeat, litOn, driftOn, washHeld, bubblesOn,
+          subFlashes, jackpots, findTimes: findTimes.slice(), recoveryTimes: recoveryTimes.slice(),
+          medianFindMs: median(findTimes),
+          elapsedMs, budgetMs, bellOn, ended, reported, busy, paused, dead,
+          phase: stage ? stage.getAttribute('data-phase') : null,
+          howtoUp: !!howtoEl,
+          casino: diag(casino), trickster: diag(trickster), pressure: diag(pressure),
+          stage, gridEl, msgEl, endEl, wellEl, hud, roundChip, clockChip, streakChip,
+          tiles: tileEls.slice(), faces: faceEls.slice(), media: mediaEls.slice(),
+        };
+      },
+    };
+
+    function diag(d) {
+      if (!d || typeof d.diagnostics !== 'function') return null;
+      try { return d.diagnostics(); } catch (e) { return null; }
+    }
+    /** A deck factory may answer null, an object, or throw - all three are fine. */
+    function createDeckSafely(make) {
+      const d = make();
+      return (d && typeof d === 'object') ? d : null;
+    }
+
+    return instance;
+  },
+
+  /** The live class's state, or null. Never read by the shell. */
+  diagnostics() { return liveClass ? liveClass.snapshot() : null; },
+  /** The last report handed to endClass (survives teardown). Diagnostics only. */
+  get lastReport() { return lastReport; },
+  /** The final snapshot of the last class (survives teardown). Diagnostics only. */
+  get lastSnapshot() { return lastSnapshot; },
+
+  setTimeScale,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/lex.js
@@ -1,0 +1,92 @@
+/* ============================================================================
+ * games/anomaly/lex.js - every `an_` lexicon row ANOMALY renders, with its
+ * neutral English fallback. Exported as DATA (the Impulse Control / Deep End
+ * precedent, `IC_LEX` / `DE_LEX`) so the host's `NeutralLexicon` can be
+ * mirrored key-for-key: copy the values, never re-word them.
+ *
+ * RULES (CLAUDE.md trap 26 + the Semester II/III contract): a value longer
+ * than 96 characters can never be mod-skinned, so every row here is <= 96; a
+ * row is rendered ONLY through ctx.lexicon(key, fallback) - Law VII, accents
+ * come from the lexicon, never AI. The DECKS (style/casino/trickster/pressure)
+ * may `t()` the same keys; they must not invent new ones without adding the
+ * row here, because this table is what the C# mirror is generated from.
+ *
+ * GROUND-RULES section 2 names four product words nothing Arcademy-side may
+ * use, in code, strings or comments. None appears in any row below; the
+ * scratch suite greps every file in this folder for the list.
+ *
+ * NAMING: the anomaly KINDS are internal keys (hue/mirror/scale/rotate/blur/
+ * bright/speed/frame - rounds.js compares those strings). The `an_kind_*` rows
+ * are DISPLAY ONLY, used on the reveal line and the end card; no rule ever
+ * reads a kind NAME.
+ * ==========================================================================*/
+
+export const AN_LEX = Object.freeze({
+  /* ---- setting row (manifest.settings) -------------------------------- */
+  an_kinds: 'Difference kinds',
+  an_kinds_hint: 'Gentle keeps colour, mirror and size only. Mirror is always in the pool.',
+
+  /* ---- HUD chips (aria labels; the chip TEXT is live data) ------------- */
+  an_chip_round: 'Round',
+  an_chip_clock: 'Time left',
+  an_chip_streak: 'Streak',
+
+  /* ---- the drawn class-rules sheet (Deck VI, Law IV) ------------------- */
+  an_howto_title: 'Class rules',
+  an_howto_same: 'Every tile is the same loop, playing in step.',
+  an_howto_find: 'One is not. Tap it. The first tap is the one that counts.',
+  an_howto_lie: 'The room tints, drifts and glitches every tile at once. That is noise.',
+  an_howto_go: 'Open your eyes',
+
+  /* ---- proctor lines (.g-an-msg, one at a time) ------------------------ */
+  an_brief: 'One tile is not like the others. Find it before the round runs out.',
+  an_play_hint: 'Tap the odd tile.',
+  an_found: 'Found.',
+  an_found_fast: 'Fast.',
+  an_wrong: 'Not that one. That tile is out.',
+  an_moved: 'It moved.',
+  an_timeout: 'Gone. Next grid.',
+  an_reveal: 'It was here.',
+  an_streak_lit: 'Five straight. The frame is lit.',
+  an_breather: 'Breathe. This one is easy.',
+  an_bell: 'Time.',
+  an_stamp_bell: 'Bell',
+  an_stamp_found: 'Found',
+
+  /* ---- deck lines -------------------------------------------------------
+   * casino.js renders an_almost / an_fast / an_royal (single words, < 600ms
+   * on screen); trickster.js renders an_refund / an_trick_seen /
+   * an_trick_melt. Their English here is COPIED from the decks' own
+   * fallbacks - never re-worded, or the two disagree in a mod-less build. */
+  an_almost: 'ALMOST',
+  an_fast: 'FAST',
+  an_royal: 'ROYAL',
+  an_refund: '+1s',
+  an_trick_seen: 'Did you see that?',
+  an_trick_melt: 'The frame runs like wax',
+  an_jackpot: 'Sharp eyes.',
+
+  /* ---- end card -------------------------------------------------------- */
+  an_end_title: 'Eyes up',
+  an_end_found: 'Found',
+  an_end_rounds: 'Rounds offered',
+  an_end_accuracy: 'First-tap accuracy',
+  an_end_median: 'Median find',
+  an_end_streak: 'Longest streak',
+  an_end_tracked: 'Tracked after a shift',
+  an_end_kind: 'Hardest to see',
+  an_end_none: 'None',
+  an_end_line: 'Global changes are noise. Only local difference is true.',
+
+  /* ---- kind names (display only; the logic compares the KEYS) ---------- */
+  an_kind_hue: 'colour',
+  an_kind_mirror: 'mirrored',
+  an_kind_scale: 'size',
+  an_kind_rotate: 'tilt',
+  an_kind_blur: 'focus',
+  an_kind_bright: 'light',
+  an_kind_speed: 'speed',
+  an_kind_frame: 'timing',
+});
+
+export default AN_LEX;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/pressure.js
@@ -1,0 +1,559 @@
+/* ============================================================================
+ * games/anomaly/pressure.js - DECK IV of the House Rules for the darkroom: THE
+ * SURGE. The casino lights the room, the trickster lies about it; this file is
+ * what the room DOES to you as your STREAK climbs. The rung is your current
+ * run of first-tap finds; a wrong tap drops it and the storm steps DOWN behind
+ * a hysteresis (fades, never a snap). Magnitude rides the class heat (CORE
+ * already folds streak + tier + progress into it). Same seed, same surge.
+ *
+ * THE RUNG TABLE (streak -> rung -> what switches ON; cumulative). Scaled to a
+ * 90s class of ~10 rounds: the whole ladder is reachable by a clean run, the
+ * top of it only by a perfect one.
+ *   0-1  rung 0  clean darkroom (the safelight and CORE's own class dials)
+ *   2    rung 1  BREATH     a pink wash breathes on a cadence (a FLARE over   [engine wash:pink, holdMs]
+ *                           whatever CORE holds - never sustainForever here,
+ *                           so it never ends CORE's own hold: trap 33)
+ *   3    rung 2  BURST      gif bursts ride finds, clickSafe                  [engine gif_burst]
+ *   4    rung 3  WHEEL      the spiral wash wakes at a low alpha,             [engine wash:spiral, forever]
+ *                + TREMOR   the chrome starts to shiver (HUD chips, the
+ *                           backdrop - NEVER the grid: the delta is the truth)
+ *   5    rung 4  VEIL+SUBS  the chrome glitch-shudders on finds,              [engine glitch_swap on chrome,
+ *                           the sub flash stream starts                        sub_flash alias]
+ *   6    rung 5  DECOYS     a bubble field of decoys drifts over the room     [engine bubble_field clickSafe,
+ *                + FLASHES  and flash bursts ride finds                         flash_burst]
+ *   8    rung 6  STORM      the pink flood, the swarm, flashes doubled,       [engine wash:pink hi, bubble_field
+ *                           the tremor at its cap, a whisper of row_drift       swarm, row_drift on the strips]
+ *                           on the backdrop's hanging strips
+ *
+ * THE TREMOR: written on the CSS individual `translate` of the CHROME elements
+ * CORE hands in (opts.chrome: HUD chips, the message line, the backdrop) -
+ * and NEVER on the grid, the tiles or the faces. The grid is the truth delta
+ * and it must stay readable; this file cannot even reach it (it is not handed
+ * the grid, on purpose - a deck that is not given a node cannot shake it). A
+ * rAF loop ONLY while amplitude > 0, halted by pause()/stop()/destroy().
+ * Reduced motion / motionLevel 0 -> no tremor; punches become a bloom class.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads streak/heat/beat kinds, writes nothing about
+ *       rounds, streak, time or grade, renders no text.
+ *   II  input honest  - no node of ours exists; the grid is never transformed,
+ *       never covered by anything of ours; every engine fire is clickSafe
+ *       (CORE's weld forces it too).
+ *   III never still   - from rung 1 the room breathes; from rung 3 it shivers.
+ *   V   seeded        - per-tag mulberry32 off seed+'|an-pressure|<tag>',
+ *       append-only; no Math.random.
+ *   VI  exits sacred  - capsOk false (bgIntensity 0) = zero fires, zero tremor;
+ *       pause() halts the rAF; destroy() restores every translate and whispers
+ *       the washes out.
+ *   VII lexicon       - this file renders no text.
+ *
+ * THE WASH TRAP (trap 33): engine.stop('wash') is NEVER called here - not even
+ * in destroy(). A wash is stepped DOWN by re-triggering its variant at a
+ * whisper alpha with a short hold (the spiral, which only this deck holds),
+ * or simply not re-armed (the pink breath, which is a hold-bounded flare over
+ * CORE's own pink, if any).
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const AN_PRESSURE = Object.freeze({
+  /** streak thresholds per rung (index = rung). Monotone. */
+  RUNG_STREAK: Object.freeze([0, 2, 3, 4, 5, 6, 8]),
+  RUNG_ADDS: Object.freeze([
+    Object.freeze([]),
+    Object.freeze(['breath']),
+    Object.freeze(['burst']),
+    Object.freeze(['wheel', 'tremor']),
+    Object.freeze(['veil', 'subs']),
+    Object.freeze(['decoys', 'flashes']),
+    Object.freeze(['storm']),
+  ]),
+  RUNG_CUE: Object.freeze([null, 'wash', 'burst', 'wash', 'glitch', 'burst', 'near_miss']),
+  /** Stepping DOWN waits this long and fades; stepping UP is immediate. */
+  HYST_MS: 1600,
+  HEAT_REPAINT_STEP: 0.06,
+
+  /* ---- THE TREMOR (chrome only) -------------------------------------- */
+  TREMOR_PX: Object.freeze([0, 0, 0, 0.5, 0.8, 1.2, 1.8]),
+  TREMOR_CAP_PX: 2.2,
+  TREMOR_HEAT_FLOOR: 0.5,
+  TREMOR_HZ_FAST: Object.freeze([7, 11]),
+  TREMOR_HZ_SLOW: Object.freeze([1.4, 2.6]),
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  PUNCH_PX: Object.freeze([0.8, 3]),
+  PUNCH_MS: Object.freeze([160, 340]),
+  PUNCH_MILESTONE_PX: 4,
+  PUNCH_MILESTONE_MS: 400,
+  PUNCH_MISS_PX: 3.2,
+  PUNCH_MISS_MS: 300,
+  PUNCH_CAP_PX: 5,
+  PUNCH_CAP_MS: 450,
+  MILESTONES: Object.freeze([3, 5, 8]),
+  BLOOM_MS: 320,
+
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([7500, 4500]),
+  BREATH_HOLD_MS: 2200,
+  BREATH_ALPHA: Object.freeze([0.1, 0.34]),
+  STORM_BREATH_ALPHA: Object.freeze([0.3, 0.55]),
+  BURST_CHANCE: Object.freeze([0.45, 0.9]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  BURST_HOLD_MS: Object.freeze([700, 1200]),
+  BURST_VMIN: Object.freeze([0.22, 0.4]),
+  WHEEL_ALPHA: Object.freeze([0.16, 0.42]),
+  VEIL_CHANCE: Object.freeze([0.35, 0.8]),
+  VEIL_S: Object.freeze([0.3, 0.8]),
+  VEIL_VARIANTS: Object.freeze(['rgbsplit', 'vhsroll', 'datamosh']),
+  DECOY_MAX: Object.freeze([5, 10]),
+  DECOY_ALPHA: Object.freeze([0.25, 0.5]),
+  STORM_DECOY_MAX: 16,
+  FLASH_COUNT: 2,
+  STORM_FLASH_COUNT: 4,
+  WHISPER_ALPHA: 0.01,
+  WHISPER_HOLD_MS: 900,
+  /** cue level = min(AUDIO_CEIL[tier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.22,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+});
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** streak -> rung (0..6). Pure, monotone, clamps garbage to 0. */
+export function rungFor(streak) {
+  const s = Math.max(0, Math.floor(Number(streak) || 0));
+  const T = AN_PRESSURE.RUNG_STREAK;
+  let r = 0;
+  for (let i = 0; i < T.length; i++) { if (s >= T[i]) r = i; else break; }
+  return r;
+}
+/** idle tremor amplitude in px; 0 under reduced motion / motionLevel 0. Pure. */
+export function tremorAmpPx(streak, heat01, reducedMotion, motionLevel) {
+  if (reducedMotion) return 0;
+  const m = AN_PRESSURE.MOTION_MUL[Math.max(0, Math.min(2, motionLevel == null ? 2 : Math.round(Number(motionLevel) || 0)))];
+  if (!m) return 0;
+  const base = AN_PRESSURE.TREMOR_PX[rungFor(streak)] || 0;
+  if (base <= 0) return 0;
+  const f = AN_PRESSURE.TREMOR_HEAT_FLOOR;
+  return Math.min(AN_PRESSURE.TREMOR_CAP_PX, +(base * m * (f + (1 - f) * clamp01(heat01))).toFixed(3));
+}
+/** a find punch {px, ms} from the streak's q and whether it was a milestone / a miss. Pure. */
+export function punchFor(o) {
+  const d = o || {};
+  const q = clamp01((Number(d.streak) || 0) / 8);
+  const P = AN_PRESSURE;
+  let px = lerp(P.PUNCH_PX, q);
+  let ms = lerp(P.PUNCH_MS, q);
+  if (d.milestone) { px = Math.max(px, P.PUNCH_MILESTONE_PX); ms = Math.max(ms, P.PUNCH_MILESTONE_MS); }
+  if (d.miss) { px = Math.max(px, P.PUNCH_MISS_PX); ms = Math.max(ms, P.PUNCH_MISS_MS); }
+  return { px: +Math.min(P.PUNCH_CAP_PX, px).toFixed(2), ms: Math.min(P.PUNCH_CAP_MS, Math.round(ms)) };
+}
+
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function rafFn() {
+  try { if (typeof requestAnimationFrame === 'function') return requestAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function cafFn() {
+  try { if (typeof cancelAnimationFrame === 'function') return cancelAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.cancelAnimationFrame === 'function') return globalThis.cancelAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function vmin() {
+  try {
+    if (typeof window !== 'undefined' && window) {
+      const w = Number(window.innerWidth) || 0, h = Number(window.innerHeight) || 0;
+      if (w > 0 && h > 0) return Math.min(w, h);
+    }
+  } catch (e) { /* headless */ }
+  return 720;
+}
+function setTranslate(node, x, y) {
+  try { if (node && node.style) node.style.translate = (x || y) ? (x.toFixed(2) + 'px ' + y.toFixed(2) + 'px') : ''; } catch (e) { /* noop */ }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+/** The grid and its children are off-limits, whatever CORE hands in. */
+function isGridish(node) {
+  try {
+    if (!node || !node.classList) return false;
+    if (node.classList.contains('g-an-grid') || node.classList.contains('g-an-tile') || node.classList.contains('g-an-face')) return true;
+    if (typeof node.closest === 'function' && node.closest('.g-an-grid')) return true;
+    if (node.querySelector && node.querySelector('.g-an-grid')) return true;
+  } catch (e) { /* fall */ }
+  return false;
+}
+
+/**
+ * @param {Object} o
+ *   engine {fire,sustain,stop,channels,audio?}, stage, chrome:[els] (HUD chips,
+ *   msg, backdrop - the things allowed to tremble), timers {after,every,clear},
+ *   reduced, capsOk (bool or fn), motionLevel, seed?, gradeTier?, backdrop?,
+ *   strips? (row_drift targets), log
+ */
+export function createAnPressure(o) {
+  const opts = o || {};
+  const P = AN_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const gradeTier = Math.max(1, Math.min(4, Number(opts.gradeTier) || 1));
+  const audioCeil = P.AUDIO_CEIL[gradeTier] || P.AUDIO_CEIL[1];
+  const eng = opts.engine || {};
+  /* the chrome: whatever CORE allows to tremble, MINUS anything grid-shaped */
+  const chrome = (Array.isArray(opts.chrome) ? opts.chrome : []).filter((n) => n && n.style && !isGridish(n));
+  const refused = (Array.isArray(opts.chrome) ? opts.chrome : []).length - chrome.length;
+  const armedBase = !!opts.stage && !!opts.timers && typeof opts.timers.after === 'function';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false && opts.capsOk != null;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers ------------------------------------------------------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams ----------------------------------------------------- */
+  const seedBase = String(opts.seed || 'an') + '|an-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+  const tremorPhase = { fx: roll('tremor') * 6.28, fy: roll('tremor') * 6.28, hzF: lerp(P.TREMOR_HZ_FAST, roll('tremor')), hzS: lerp(P.TREMOR_HZ_SLOW, roll('tremor')) };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.fire === 'function' ? eng.fire(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.sustain === 'function' ? eng.sustain(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function stopKind(kind) {
+    if (!armedBase || kind === 'wash') return;          // NEVER stop('wash') - trap 33
+    count('stop:' + kind);
+    try { if (typeof eng.stop === 'function') eng.stop(kind); } catch (e) { /* noop */ }
+  }
+  function cue(name, rung) {
+    if (!armed() || !name) return;
+    const level = Math.min(audioCeil, P.CUE_LEVEL_BASE + rung * P.CUE_LEVEL_STEP);
+    count('cue');
+    try {
+      if (typeof eng.audio === 'function') eng.audio(name, level, { pitch: +(0.9 + rung * 0.04).toFixed(3) });
+      else if (typeof eng.fire === 'function') eng.fire('audio_trigger', { name, level, pitch: +(0.9 + rung * 0.04).toFixed(3) });
+    } catch (e) { /* noop */ }
+  }
+
+  /* ---- state -------------------------------------------------------------- */
+  let started = false;
+  let stopped = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let streak = 0;
+  let rung = 0;              // the SHOWN rung
+  let wantRung = 0;          // what the streak says
+  let downTimer = 0;
+  let breathTimer = 0;
+  const on = new Set();
+  let spiralUrl = null;
+  const bloomTimers = new Map();
+
+  /* ---- the tremor --------------------------------------------------------- */
+  let rafId = 0;
+  let loopOn = false;
+  let amp = 0;
+  let punch = { px: 0, until: 0, ms: 1 };
+  let paused = false;
+  let translateWrites = 0;
+
+  function writeAll(x, y) {
+    for (let i = 0; i < chrome.length; i++) {
+      /* the HUD shivers full, everything else (backdrop, msg) at 60% */
+      const k = i === 0 ? 1 : 0.6;
+      setTranslate(chrome[i], x * k, y * k);
+    }
+    translateWrites++;
+  }
+  function loop() {
+    rafId = 0;
+    if (!loopOn || paused || destroyed) return;
+    const tNow = nowMs();
+    let extra = 0;
+    if (punch.px > 0) {
+      const left = punch.until - tNow;
+      if (left <= 0) punch = { px: 0, until: 0, ms: 1 };
+      else { const k = left / punch.ms; extra = punch.px * k * k; }   // quadratic ring-down
+    }
+    const a = armed() ? amp + extra : 0;
+    if (a <= 0.005) { writeAll(0, 0); loopOn = false; return; }
+    const ts = tNow / 1000;
+    const x = a * (0.7 * Math.sin(ts * tremorPhase.hzF * 6.28 + tremorPhase.fx) + 0.3 * Math.sin(ts * tremorPhase.hzS * 6.28));
+    const y = a * (0.7 * Math.cos(ts * tremorPhase.hzF * 5.9 + tremorPhase.fy) + 0.3 * Math.sin(ts * tremorPhase.hzS * 5.1 + 1.7));
+    writeAll(x, y);
+    const raf = rafFn();
+    if (raf) rafId = raf(loop);
+  }
+  function armLoop() {
+    if (loopOn || paused || destroyed || still || !chrome.length) return;
+    if (amp <= 0 && punch.px <= 0) return;
+    loopOn = true;
+    const raf = rafFn();
+    if (raf) rafId = raf(loop); else loop();
+  }
+  function haltLoop() {
+    loopOn = false;
+    const caf = cafFn();
+    if (rafId && caf) { try { caf(rafId); } catch (e) { /* noop */ } }
+    rafId = 0;
+  }
+  function retune() {
+    amp = 0;
+    if (!still && armed()) {
+      const base = P.TREMOR_PX[rung] || 0;
+      amp = base <= 0 ? 0 : Math.min(P.TREMOR_CAP_PX, base * P.MOTION_MUL[motion] * (P.TREMOR_HEAT_FLOOR + (1 - P.TREMOR_HEAT_FLOOR) * heat));
+    }
+    armLoop();
+  }
+  function bloom() {
+    /* reduced motion's whole punch: a box-shadow class on the first chrome node */
+    const n = chrome[0];
+    if (!n) return;
+    setCls(n, 'g-an-p-bloom', false);
+    try { if (typeof n.offsetWidth === 'number') void n.offsetWidth; } catch (e) { /* noop */ }
+    setCls(n, 'g-an-p-bloom', true);
+    const old = bloomTimers.get(n);
+    if (old) cancel(old);
+    bloomTimers.set(n, after(P.BLOOM_MS, () => { bloomTimers.delete(n); setCls(n, 'g-an-p-bloom', false); }));
+  }
+  function doPunch(spec) {
+    if (!armed() || stopped || !spec || spec.px <= 0) return;
+    if (still) { bloom(); return; }
+    const tNow = nowMs();
+    punch = { px: Math.max(punch.px, spec.px), until: Math.max(punch.until, tNow + spec.ms), ms: Math.max(spec.ms, 1) };
+    count('punch');
+    armLoop();
+  }
+
+  /* ---- the rungs ---------------------------------------------------------- */
+  function breathe(storm) {
+    /* a hold-bounded trigger: a FLARE over whatever pink CORE may hold, never
+       a forever hold of our own (so stepping off never ends CORE's) */
+    sustain('wash', { variant: 'pink', alpha: lerp(storm ? P.STORM_BREATH_ALPHA : P.BREATH_ALPHA, heat), holdMs: P.BREATH_HOLD_MS });
+  }
+  function armBreath() {
+    if (breathTimer) cancel(breathTimer);
+    const ms = lerp(P.BREATH_MS, heat) * (0.85 + roll('breath') * 0.3);
+    breathTimer = after(Math.round(ms), () => { breathTimer = 0; if (on.has('breath') && !stopped) { breathe(on.has('storm')); armBreath(); } });
+  }
+  function wheelOn() {
+    const o2 = { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true };
+    if (spiralUrl) o2.url = spiralUrl;
+    sustain('wash', o2);
+  }
+  function whisperOut(variant) {
+    const o2 = { variant, alpha: P.WHISPER_ALPHA, holdMs: P.WHISPER_HOLD_MS };
+    if (variant === 'spiral' && spiralUrl) o2.url = spiralUrl;
+    sustain('wash', o2);
+  }
+  function decoysOn(storm) {
+    sustain('bubble_field', {
+      max: storm ? P.STORM_DECOY_MAX : Math.round(lerp(P.DECOY_MAX, heat)),
+      alpha: lerp(P.DECOY_ALPHA, heat), clickSafe: true, media: true,
+      variant: storm ? 'swarm' : 'drift',
+    });
+  }
+  /** row_drift targets for the storm: CORE's opts.strips, else the casino's
+   *  hanging strips found under the stage - never anything grid-shaped. */
+  function stripTargets() {
+    let list = Array.isArray(opts.strips) ? opts.strips.slice() : [];
+    if (!list.length) {
+      try {
+        const host = opts.backdrop || opts.stage;
+        if (host && host.querySelectorAll) list = Array.from(host.querySelectorAll('.g-an-bd-strips'));
+      } catch (e) { list = []; }
+    }
+    return list.filter((n) => n && n.style && !isGridish(n));
+  }
+  function veil(seconds, variant) {
+    if (still || !chrome.length) return null;
+    const targets = chrome.filter((n) => n && !isGridish(n));
+    if (!targets.length) return null;
+    return fire('glitch_swap', { targets, variant, seconds, sfx: false, onSwap() { /* presentation only */ } });
+  }
+  function applyAdd(add, goingUp) {
+    if (goingUp) {
+      on.add(add);
+      if (add === 'breath') { breathe(false); armBreath(); }
+      else if (add === 'wheel') wheelOn();
+      else if (add === 'subs') sustain('sub_flash', {});
+      else if (add === 'decoys') decoysOn(false);
+      else if (add === 'storm') {
+        decoysOn(true);
+        breathe(true);
+        const strips = stripTargets();
+        if (strips.length && !still) sustain('row_drift', { targets: strips, axis: 'y', amplitudeMult: 0.5, speedMult: 0.6, variant: 'sway' });
+      }
+      /* burst / tremor / veil / flashes are event-driven: nothing to switch on */
+    } else {
+      on.delete(add);
+      if (add === 'breath') { if (breathTimer) { cancel(breathTimer); breathTimer = 0; } }   // the flare fades on its own hold
+      else if (add === 'wheel') whisperOut('spiral');
+      else if (add === 'subs') stopKind('sub_flash');
+      else if (add === 'decoys') stopKind('bubble_field');
+      else if (add === 'storm') { stopKind('row_drift'); if (on.has('decoys')) decoysOn(false); }
+    }
+  }
+  function setRung(r) {
+    if (r === rung) return;
+    const up = r > rung;
+    if (up) {
+      for (let k = rung + 1; k <= r; k++) for (const add of P.RUNG_ADDS[k]) applyAdd(add, true);
+      cue(P.RUNG_CUE[r], r);
+    } else {
+      for (let k = rung; k > r; k--) for (const add of P.RUNG_ADDS[k]) applyAdd(add, false);
+    }
+    rung = r;
+    retune();
+    say('pressure: rung ' + rung + ' (' + (up ? 'up' : 'down') + ', streak ' + streak + ') on: ' + Array.from(on).join(','));
+  }
+  function setStreak(s) {
+    streak = Math.max(0, Math.floor(Number(s) || 0));
+    wantRung = rungFor(streak);
+    if (!started || stopped || !armed()) return;
+    if (wantRung > rung) { cancel(downTimer); downTimer = 0; setRung(wantRung); }
+    else if (wantRung < rung && !downTimer) {
+      downTimer = after(P.HYST_MS, () => { downTimer = 0; if (wantRung < rung) setRung(wantRung); });
+    } else if (wantRung === rung) { cancel(downTimer); downTimer = 0; }
+  }
+  function repaintHeat() {
+    if (Math.abs(heat - lastPaintHeat) < P.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (on.has('wheel')) wheelOn();
+    if (on.has('decoys') && !on.has('storm')) decoysOn(false);
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      stopped = false;
+      lastPaintHeat = -1;
+      if (!armed()) { say('pressure: disarmed'); return; }
+      try { if (typeof opts.spiralUrl === 'function') spiralUrl = opts.spiralUrl() || null; else if (typeof opts.spiralUrl === 'string') spiralUrl = opts.spiralUrl; } catch (e) { spiralUrl = null; }
+      say('pressure: armed, chrome ' + chrome.length + (refused ? ' (' + refused + ' grid-shaped node(s) REFUSED)' : ''));
+      if (wantRung > 0) setRung(wantRung);
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started && !stopped) { repaintHeat(); retune(); }
+    },
+    /** The class's own ladder. Up is immediate, down waits HYST_MS. */
+    setStreak(n) { setStreak(n); },
+    /** CORE's beats: 'find' (a first-tap find), 'miss' (a wrong tap),
+     *  'round' (a new sheet), 'relocate' (the anomaly moved), 'bell'. */
+    beat(kind, info) {
+      if (!started || stopped || !armed()) return;
+      const e = info || {};
+      const k = String(kind || '');
+      if (k === 'find') {
+        const s = e.streak != null ? Number(e.streak) : streak;
+        const milestone = P.MILESTONES.indexOf(s) >= 0;
+        doPunch(punchFor({ streak: s, milestone }));
+        if (on.has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat)) {
+          fire('gif_burst', {
+            count: Math.round(lerp(P.BURST_COUNT, heat)), clickSafe: true, clickable: false,
+            sizePx: Math.round(vmin() * lerp(P.BURST_VMIN, heat)),
+            holdMs: Math.round(lerp(P.BURST_HOLD_MS, heat)),
+            variant: on.has('storm') ? 'scatter' : undefined,
+          });
+        }
+        if (on.has('veil') && roll('veil') < lerp(P.VEIL_CHANCE, heat)) {
+          veil(lerp(P.VEIL_S, heat), P.VEIL_VARIANTS[Math.floor(roll('veil') * P.VEIL_VARIANTS.length)]);
+        }
+        if (on.has('flashes')) fire('flash_burst', { count: on.has('storm') ? P.STORM_FLASH_COUNT : P.FLASH_COUNT, clickSafe: true, clickable: false });
+      } else if (k === 'miss') {
+        doPunch(punchFor({ streak: 0, miss: true }));
+        if (on.has('veil')) veil(0.45, 'datamosh');
+      } else if (k === 'relocate') {
+        if (on.has('veil')) veil(0.5, 'rgbsplit');
+        if (on.has('burst') && roll('burst') < 0.5) fire('gif_burst', { count: 1, clickSafe: true, clickable: false, holdMs: 600 });
+      } else if (k === 'round') {
+        if (on.has('flashes') && roll('round') < 0.4) fire('flash_burst', { count: 1, clickSafe: true, clickable: false });
+      } else if (k === 'bell') {
+        if (on.has('decoys')) decoysOn(true);
+      }
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      cancel(downTimer); downTimer = 0;
+      if (breathTimer) { cancel(breathTimer); breathTimer = 0; }
+      if (on.has('wheel')) whisperOut('spiral');
+      if (on.has('subs')) stopKind('sub_flash');
+      if (on.has('decoys') || on.has('storm')) stopKind('bubble_field');
+      if (on.has('storm')) stopKind('row_drift');
+      on.clear();
+      rung = 0;
+      amp = 0; punch = { px: 0, until: 0, ms: 1 };
+      haltLoop();
+      writeAll(0, 0);
+    },
+    pause() {
+      paused = true;
+      haltLoop();
+      writeAll(0, 0);
+    },
+    resume() {
+      paused = false;
+      if (!stopped) { retune(); setStreak(streak); if (on.has('breath') && !breathTimer) armBreath(); }
+    },
+    destroy() {
+      api.stop();
+      destroyed = true;
+      cancelAll();
+      haltLoop();
+      for (const n of chrome) { setTranslate(n, 0, 0); setCls(n, 'g-an-p-bloom', false); }
+      bloomTimers.clear();
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, paused, heat: +heat.toFixed(3), streak, rung, wantRung,
+        on: Array.from(on), tremorPx: +amp.toFixed(3), punchPx: +punch.px.toFixed(2), loopOn,
+        chrome: chrome.length, chromeRefused: refused, translateWrites,
+        fires: Object.assign({}, fires), liveTimers: live.size, nodes: 0, spiralUrl,
+      };
+    },
+  };
+  return api;
+}
+
+export default createAnPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/rounds.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/rounds.js
@@ -1,0 +1,480 @@
+/* ============================================================================
+ * games/anomaly/rounds.js - ANOMALY's seeded round plan. PURE.
+ *
+ * No DOM, no clock, no ctx. One class seed in, the whole show out: the grid
+ * size, every round's anomaly KIND and DELTA MAGNITUDE, where the odd tile
+ * starts, how long the round is, the glitch_swap RELOCATION schedule (when it
+ * moves and, in preference order, where to), the drift dial and the ambience
+ * cadences. Same seed = same show; a retake replays it exactly (Law V).
+ *
+ * DRAW ORDER IS APPEND-ONLY. New draws go at the END of buildPlan (and at the
+ * end of a round's own block) so an older seed keeps the plan it had.
+ *
+ * ---------------------------------------------------------------------------
+ * THE CRITIC'S TOP FIX IS LAW (dossier, 7/10): the top tiers get harder through
+ * RELOCATIONS, DRIFT and DECOY PRESSURE, never through a delta approaching
+ * invisibility. Every magnitude in DELTA stays at or above PERCEPT_FLOOR for
+ * its kind at every tier - the scratch suite asserts that table cell by cell.
+ * A tier-4 hue shift is still 28 degrees; what changed is that the tile now
+ * moves twice under a glitch while the rows drift and the wash tints the lot.
+ *
+ * PERCEPTIBILITY, WHERE THE FLOORS COME FROM (all conservative, i.e. well
+ * above the literature's just-noticeable difference for a ~120px tile):
+ *   hue     22 deg   (JND for a saturated patch is ~2-5 deg; 22 is obvious)
+ *   mirror  binary   (the floor kind: survives reduced motion AND colourblind)
+ *   scale   0.09     (9% linear = ~19% area)
+ *   rotate  5.5 deg  (a tilted frame edge reads at ~2 deg)
+ *   blur    1.0 px
+ *   bright  0.13     (13% luminance step)
+ *   speed   0.30     (playbackRate ratio delta - video kinds only)
+ *   frame   0.30 s   (currentTime offset - video kinds only)
+ *
+ * VIDEO KINDS (speed / frame) are dealt ONLY when the grid is <= 3 wide
+ * (VIDEO_GRID_MAX) - the L&F 30Hz lock: N playing <video> elements pin the
+ * page's compositor. index.js additionally requires the round's url to BE a
+ * video (mediaEl semantics) before it uses the round's `altKind`; the img-safe
+ * `kind` is always dealt and is always a valid answer, so a gif-only or
+ * still-only pool simply never sees a speed round.
+ *
+ * NEVER-EMPTY FLOOR (`an_kinds`): 'gentle' narrows to hue/mirror/scale and
+ * reduced motion narrows to hue/mirror; if any intersection came out empty the
+ * pool falls back to [FLOOR_KIND] = mirror. The pool can never be empty (the
+ * DTRH runVariantsOff contract, quoted by the dossier).
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+/* ------------------------------------------------------------------ dials */
+export const PLAYTEST = Object.freeze({
+  /** Grid width by grade tier (3x3 -> 5x5). Dossier: 4x4 arrives at tier 2. */
+  GRID_BY_TIER: Object.freeze({ 1: 3, 2: 4, 3: 5, 4: 5 }),
+  /** Portability: a coarse pointer caps the grid at 4x4 (64px minimum tile). */
+  GRID_MAX_COARSE: 4,
+  /** playbackRate / currentTime kinds need <video>; N videos lock the page to
+   *  30Hz (the L&F trap), so they are dealt only at or below this grid width. */
+  VIDEO_GRID_MAX: 3,
+
+  /** Round length window (ms) by tier - the 6-12s quick-fire cadence. */
+  ROUND_MS: Object.freeze({
+    1: Object.freeze([10000, 12000]),
+    2: Object.freeze([8500, 11000]),
+    3: Object.freeze([7000, 9500]),
+    4: Object.freeze([6000, 8000]),
+  }),
+  /** Reduced motion holds a static frame: give the eye a little longer. */
+  ROUND_MS_REDUCED_MULT: 1.15,
+
+  /** glitch_swap relocations per round by tier. TIER 4 CAPS AT 2 (ruling 1). */
+  RELOC_BY_TIER: Object.freeze({ 1: 0, 2: 0, 3: 1, 4: 2 }),
+  RELOC_CAP: 2,
+  RELOC_FIRST_MS: 1800,        // never before the player has looked once
+  RELOC_TAIL_MS: 1500,         // never inside the last moment of the round
+  RELOC_MIN_GAP_MS: 1400,
+  RELOC_JITTER_MS: 350,
+
+  /** A wrong tap burns round time; the ghost-outline near-miss refunds. */
+  WRONG_BURN_MS: 800,
+  GHOST_REFUND_MS: 1000,
+
+  /** The correct-first-tap ceremony is under half a second, by contract. */
+  ADVANCE_MS: 380,
+  ADVANCE_MS_REDUCED: 220,
+  /** A whiffed round shows the answer for this long before the next grid. */
+  WHIFF_HOLD_MS: 1100,
+  WHIFF_HOLD_MS_REDUCED: 600,
+
+  BRIEF_MS: 1600,
+  BRIEF_MS_REDUCED: 700,
+  END_HOLD_MS: 2600,
+  END_HOLD_MS_REDUCED: 1200,
+  CEREMONY_MS: 900,
+  CEREMONY_MS_REDUCED: 450,
+  /** The bell's last seconds go gold. */
+  BELL_WARN_SEC: 15,
+
+  /** Heat = the streak ladder, capped by the grade tier (DE/IC pattern). */
+  HEAT_CAP: Object.freeze({ 1: 0.45, 2: 0.65, 3: 0.85, 4: 1 }),
+  HEAT_FLOOR: 0.12,
+  HEAT_STEP: 0.09,
+  /** audio_trigger level ceilings by tier (the engine clamps again). */
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  /** The chime ratchet: +1 semitone per streak link, capped (the IC ladder). */
+  PITCH_CAP_SEMITONES: 7,
+
+  /** sub_flash cadence (ms) by tier at heat 0; heat shortens it. */
+  SUB_FLASH_MS: Object.freeze({ 1: 0, 2: 8000, 3: 6000, 4: 4500 }),
+  CADENCE_MIN_MULT: 0.45,
+  CADENCE_JITTER: 0.35,
+  JITTER_LEN: 48,
+
+  /** Ambience arms at these tiers. */
+  WASH_TIER: 2,               // short wash pulses
+  WASH_HOLD_TIER: 4,          // tier 4 holds a low-alpha wash instead
+  BUBBLE_TIER: 2,             // bubble_field decoys
+  DRIFT_TIER: 2,              // row_drift under the cursor
+  DRIFT: Object.freeze({
+    2: Object.freeze({ amplitudeMult: 0.35, variant: 'sway', speedMult: 0.8 }),
+    3: Object.freeze({ amplitudeMult: 0.55, variant: 'sway', speedMult: 1 }),
+    4: Object.freeze({ amplitudeMult: 0.7, variant: 'slide', speedMult: 1.15 }),
+  }),
+
+  /** Comeback hook: two whiffed rounds in a row force ONE breather round. */
+  BREATHER_AFTER_WHIFFS: 2,
+  /** The grid frame ignites at this streak. */
+  STREAK_LIT: 5,
+  /** A find under this is "fast" (and pays flavour XP). */
+  SUBSECOND_MS: 1000,
+
+  STALL_TICK_MS: 700,
+  /** Rounds dealt = what the budget can hold, padded, then capped. */
+  COUNT_PAD: 4,
+  COUNT_MAX: 24,
+  COUNT_MIN: 8,
+});
+
+/* ------------------------------------------------------------------ kinds */
+/** Kinds that work on an <img> (a gif or a still) - always dealable. */
+export const IMG_KINDS = Object.freeze(['hue', 'mirror', 'scale', 'rotate', 'blur', 'bright']);
+/** Kinds that need a <video> element (mediaEl semantics) AND a small grid. */
+export const VIDEO_KINDS = Object.freeze(['speed', 'frame']);
+/** `an_kinds: 'gentle'` - the comfort pool (no tilt, no blur, no light). */
+export const GENTLE_KINDS = Object.freeze(['hue', 'mirror', 'scale']);
+/** Reduced motion: static-frame rounds, hue/mirror only (dossier). */
+export const REDUCED_KINDS = Object.freeze(['hue', 'mirror']);
+/** The never-empty floor: it survives reduced motion and colourblindness. */
+export const FLOOR_KIND = 'mirror';
+
+/** Perceptibility floors. No DELTA cell may sit below its kind's floor. */
+export const PERCEPT_FLOOR = Object.freeze({
+  hue: 22, mirror: 1, scale: 0.09, rotate: 5.5, blur: 1, bright: 0.13, speed: 0.3, frame: 0.3,
+});
+
+/**
+ * Delta MAGNITUDE by kind and grade tier. Units:
+ *   hue     degrees of hue-rotate
+ *   mirror  binary (1 = scaleX(-1))
+ *   scale   linear offset from 1 (0.12 = 1.12x or 1/1.12)
+ *   rotate  degrees
+ *   blur    pixels (additive only - there is no negative blur)
+ *   bright  offset from 1
+ *   speed   playbackRate offset from 1
+ *   frame   currentTime offset in seconds
+ * The ladder narrows with the tier but NEVER below PERCEPT_FLOOR - that is the
+ * critic's top fix expressed as data.
+ */
+export const DELTA = Object.freeze({
+  hue: Object.freeze({ 1: 64, 2: 48, 3: 34, 4: 28 }),
+  mirror: Object.freeze({ 1: 1, 2: 1, 3: 1, 4: 1 }),
+  scale: Object.freeze({ 1: 0.22, 2: 0.18, 3: 0.14, 4: 0.12 }),
+  rotate: Object.freeze({ 1: 14, 2: 11, 3: 8.5, 4: 7 }),
+  blur: Object.freeze({ 1: 2.6, 2: 2.1, 3: 1.6, 4: 1.35 }),
+  bright: Object.freeze({ 1: 0.34, 2: 0.28, 3: 0.22, 4: 0.18 }),
+  speed: Object.freeze({ 1: 0.7, 2: 0.55, 3: 0.45, 4: 0.38 }),
+  frame: Object.freeze({ 1: 0.9, 2: 0.7, 3: 0.55, 4: 0.45 }),
+});
+
+/* --------------------------------------------------------------- helpers */
+export function clampTier(v) { return Math.max(1, Math.min(4, Math.round(Number(v) || 1))); }
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(a, b, t) { return a + (b - a) * t; }
+
+/** Grid width for a tier; a coarse pointer caps it (portability, dossier). */
+export function gridFor(gradeTier, coarse) {
+  const n = PLAYTEST.GRID_BY_TIER[clampTier(gradeTier)] || 3;
+  return coarse ? Math.min(PLAYTEST.GRID_MAX_COARSE, n) : n;
+}
+
+/**
+ * The img-safe kind pool for this class. NEVER EMPTY (FLOOR_KIND is the floor).
+ * `mode` is the `an_kinds` setting ('all' | 'gentle'); anything else = 'all'.
+ */
+export function kindPool({ mode, reduced } = {}) {
+  const gentle = String(mode || 'all').toLowerCase() === 'gentle';
+  let pool = (gentle ? GENTLE_KINDS : IMG_KINDS).slice();
+  if (reduced) pool = pool.filter((k) => REDUCED_KINDS.indexOf(k) >= 0);
+  if (!pool.length) pool = [FLOOR_KIND];
+  return pool;
+}
+
+/** The video kind pool - empty unless the grid is small and motion is allowed. */
+export function videoKindPool({ mode, reduced, n } = {}) {
+  if (reduced) return [];
+  if (String(mode || 'all').toLowerCase() === 'gentle') return [];
+  if (!(Number(n) > 0) || Number(n) > PLAYTEST.VIDEO_GRID_MAX) return [];
+  return VIDEO_KINDS.slice();
+}
+
+/** The magnitude for a kind at a tier, floored at PERCEPT_FLOOR. */
+export function deltaFor(kind, gradeTier) {
+  const row = DELTA[kind];
+  if (!row) return 0;
+  const raw = Number(row[clampTier(gradeTier)]) || 0;
+  const floor = Number(PERCEPT_FLOOR[kind]) || 0;
+  return Math.max(floor, raw);
+}
+
+/** The baseline face style EVERY tile wears - same shape, identity values, so
+ *  the odd tile is not the only element with a filter (and therefore not the
+ *  only one with its own render surface: `filter:none` rasterises differently,
+ *  which would be a tell in itself). index.js writes these inline. */
+export const BASE_FACE = Object.freeze({
+  filter: 'hue-rotate(0deg) blur(0px) brightness(1)',
+  transform: 'rotate(0deg) scale(1) scaleX(1)',
+  rate: 1,
+  offset: 0,
+});
+
+/**
+ * The odd tile's inline style for a kind/delta/direction. PURE - returns the
+ * same four fields BASE_FACE carries so the caller never branches.
+ *   dir  +1 | -1 (which way the delta leans; blur is additive either way)
+ */
+export function faceStyle(kind, delta, dir) {
+  const d = Math.abs(Number(delta) || 0);
+  const s = Number(dir) < 0 ? -1 : 1;
+  let hue = 0; let blur = 0; let bright = 1;
+  let rot = 0; let scale = 1; let mirror = 1;
+  let rate = 1; let offset = 0;
+  switch (kind) {
+    case 'hue': hue = s * d; break;
+    case 'mirror': mirror = -1; break;
+    case 'scale': scale = s > 0 ? (1 + d) : (1 / (1 + d)); break;
+    case 'rotate': rot = s * d; break;
+    case 'blur': blur = d; break;
+    case 'bright': bright = s > 0 ? (1 + d) : Math.max(0.05, 1 - d); break;
+    case 'speed': rate = s > 0 ? (1 + d) : (1 / (1 + d)); break;
+    case 'frame': offset = d; break;
+    default: break;
+  }
+  return {
+    filter: 'hue-rotate(' + round2(hue) + 'deg) blur(' + round2(blur) + 'px) brightness(' + round3(bright) + ')',
+    transform: 'rotate(' + round2(rot) + 'deg) scale(' + round3(scale) + ') scaleX(' + mirror + ')',
+    rate: round3(rate),
+    offset: round3(offset),
+  };
+}
+function round2(v) { return Math.round(Number(v) * 100) / 100; }
+function round3(v) { return Math.round(Number(v) * 1000) / 1000; }
+
+/** Heat from the class's own ladder: the streak, capped by the grade tier. */
+export function heatFor(streak, gradeTier) {
+  const tier = clampTier(gradeTier);
+  const cap = PLAYTEST.HEAT_CAP[tier];
+  const h = PLAYTEST.HEAT_FLOOR + Math.max(0, Number(streak) || 0) * PLAYTEST.HEAT_STEP;
+  return Math.max(0, Math.min(cap, h));
+}
+
+/** Heat-shortened, seed-jittered cadence (the DE schedule.js helper). */
+export function cadenceMs(baseMs, heat, jitter) {
+  const base = Math.max(0, Number(baseMs) || 0);
+  if (!base) return 0;
+  const h = clamp01(heat);
+  const shortened = base * lerp(1, PLAYTEST.CADENCE_MIN_MULT, h);
+  const j = 1 + (Number(jitter) || 0) * PLAYTEST.CADENCE_JITTER;
+  return Math.max(600, Math.round(shortened * j));
+}
+
+/** The chime pitch for a streak: +1 semitone per link, capped. */
+export function pitchFor(streak) {
+  const n = Math.max(0, Math.min(PLAYTEST.PITCH_CAP_SEMITONES, Math.round(Number(streak) || 0)));
+  return Math.round(Math.pow(2, n / 12) * 1000) / 1000;
+}
+
+/** Seeded Fisher-Yates over 0..cells-1 (the relocation preference order). */
+function shuffledIndices(cells, rng) {
+  const a = [];
+  for (let i = 0; i < cells; i++) a.push(i);
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.min(i, Math.floor(rng() * (i + 1)));
+    const t = a[i]; a[i] = a[j]; a[j] = t;
+  }
+  return a;
+}
+
+/** Relocation times inside a round: k slots, spaced, jittered, clamped. */
+function relocTimes(k, durationMs, rng) {
+  const out = [];
+  if (k <= 0) return out;
+  const first = PLAYTEST.RELOC_FIRST_MS;
+  const last = Math.max(first, durationMs - PLAYTEST.RELOC_TAIL_MS);
+  if (last <= first) return out;
+  for (let i = 0; i < k; i++) {
+    const t = lerp(first, last, (i + 1) / (k + 1));
+    const jitter = (rng() * 2 - 1) * PLAYTEST.RELOC_JITTER_MS;
+    let at = Math.round(t + jitter);
+    if (at < first) at = first;
+    if (at > last) at = last;
+    if (out.length && at - out[out.length - 1] < PLAYTEST.RELOC_MIN_GAP_MS) {
+      at = out[out.length - 1] + PLAYTEST.RELOC_MIN_GAP_MS;
+    }
+    if (at > last) break;
+    out.push(at);
+  }
+  return out;
+}
+
+/**
+ * THE PLAN.
+ * @param {Object} o
+ *   seed           the class seed (Law V)
+ *   gradeTier      1..4
+ *   timeBudgetSec  the class bell (90 by contract)
+ *   kindsMode      'all' | 'gentle'   (the `an_kinds` setting)
+ *   reduced        reducedMotion
+ *   coarse         coarse pointer (caps the grid)
+ * @returns a frozen plan; `rounds` is a plain array of frozen rounds.
+ */
+export function buildPlan(o = {}) {
+  const tier = clampTier(o.gradeTier);
+  const reduced = !!o.reduced;
+  const mode = String(o.kindsMode || 'all').toLowerCase() === 'gentle' ? 'gentle' : 'all';
+  const n = gridFor(tier, !!o.coarse);
+  const cells = n * n;
+  const seed = String(o.seed == null ? 'anomaly' : o.seed);
+  const rng = makeRng(seed + '|an-plan');
+
+  const kinds = kindPool({ mode, reduced });
+  const videoKinds = videoKindPool({ mode, reduced, n });
+
+  const win = PLAYTEST.ROUND_MS[tier];
+  const lo = Math.round(win[0] * (reduced ? PLAYTEST.ROUND_MS_REDUCED_MULT : 1));
+  const hi = Math.round(win[1] * (reduced ? PLAYTEST.ROUND_MS_REDUCED_MULT : 1));
+
+  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 90) * 1000);
+  const count = Math.max(
+    PLAYTEST.COUNT_MIN,
+    Math.min(PLAYTEST.COUNT_MAX, Math.ceil(budgetMs / lo) + PLAYTEST.COUNT_PAD),
+  );
+
+  /* relocations are OFF under reduced motion (no glitch, no drift) */
+  const relocPerRound = reduced ? 0 : Math.min(PLAYTEST.RELOC_CAP, PLAYTEST.RELOC_BY_TIER[tier] || 0);
+
+  const rounds = [];
+  let lastKind = '';
+  let lastOdd = -1;
+  for (let i = 0; i < count; i++) {
+    /* --- append-only draw order inside a round ------------------------- */
+    let kind = pickNoRepeat(kinds, lastKind, rng);
+    lastKind = kind;
+    const dir = rng() < 0.5 ? -1 : 1;
+    let oddIndex = Math.floor(rng() * cells);
+    if (cells > 1 && oddIndex === lastOdd) oddIndex = (oddIndex + 1 + Math.floor(rng() * (cells - 1))) % cells;
+    lastOdd = oddIndex;
+    const durationMs = Math.round(lerp(lo, hi, rng()));
+    const times = relocTimes(relocPerRound, durationMs, rng);
+    const order = shuffledIndices(cells, rng);
+    /* the video alternative: dealt only when the pool exists; index.js uses it
+     * ONLY when this round's url really is a <video> (mediaEl semantics). */
+    const altKind = videoKinds.length ? videoKinds[Math.floor(rng() * videoKinds.length)] : null;
+    const altDir = rng() < 0.5 ? -1 : 1;
+
+    rounds.push(Object.freeze({
+      i,
+      n,
+      cells,
+      kind,
+      delta: deltaFor(kind, tier),
+      dir,
+      altKind,
+      altDelta: altKind ? deltaFor(altKind, tier) : 0,
+      altDir,
+      oddIndex,
+      durationMs,
+      relocations: Object.freeze(times.map((at, k) => Object.freeze({
+        at,
+        /* preference order: index.js takes the first entry that is neither the
+         * current odd tile nor an eliminated tile - a plan cannot know which
+         * tiles the player has burned, and a relocation onto a dead tile would
+         * be a ledger lie (Law I). */
+        order: Object.freeze(rotate(order, k + 1)),
+      }))),
+      breather: false,
+    }));
+  }
+
+  const drift = (!reduced && tier >= PLAYTEST.DRIFT_TIER) ? PLAYTEST.DRIFT[tier] || null : null;
+  const subJitter = [];
+  for (let i = 0; i < PLAYTEST.JITTER_LEN; i++) subJitter.push(rng() * 2 - 1);
+
+  return Object.freeze({
+    seed,
+    tier,
+    n,
+    cells,
+    reduced,
+    coarse: !!o.coarse,
+    kindsMode: mode,
+    kinds: Object.freeze(kinds.slice()),
+    videoKinds: Object.freeze(videoKinds.slice()),
+    count,
+    rounds,
+    relocPerRound,
+    budgetMs,
+    heatCap: PLAYTEST.HEAT_CAP[tier],
+    audioCeil: PLAYTEST.AUDIO_CEIL[tier],
+    subFlashMs: reduced ? 0 : (PLAYTEST.SUB_FLASH_MS[tier] || 0),
+    subJitter: Object.freeze(subJitter),
+    wash: !reduced && tier >= PLAYTEST.WASH_TIER,
+    washHold: !reduced && tier >= PLAYTEST.WASH_HOLD_TIER,
+    bubbles: !reduced && tier >= PLAYTEST.BUBBLE_TIER,
+    drift,
+  });
+}
+
+/** Rotate an array by k - a per-relocation preference order off ONE shuffle. */
+function rotate(list, k) {
+  const a = list.slice();
+  const s = ((k % a.length) + a.length) % a.length;
+  return a.slice(s).concat(a.slice(0, s));
+}
+
+/** No-repeat-last pick (the engine's variant-pool law, applied to kinds). */
+function pickNoRepeat(pool, last, rng) {
+  if (!pool.length) return FLOOR_KIND;
+  if (pool.length === 1) return pool[0];
+  const usable = pool.filter((k) => k !== last);
+  const list = usable.length ? usable : pool;
+  return list[Math.min(list.length - 1, Math.floor(rng() * list.length))];
+}
+
+/**
+ * THE BREATHER (the dossier's comeback hook): two whiffed rounds in a row and
+ * the next round is dealt from the gentle pool at TIER-1 magnitude with no
+ * relocations. PURE - the caller decides when, this decides what.
+ */
+export function asBreather(round, plan) {
+  if (!round) return round;
+  const pool = kindPool({ mode: 'gentle', reduced: plan && plan.reduced });
+  const kind = pool.indexOf(round.kind) >= 0 ? round.kind : pool[0];
+  return Object.freeze(Object.assign({}, round, {
+    kind,
+    delta: deltaFor(kind, 1),
+    altKind: null,
+    altDelta: 0,
+    relocations: Object.freeze([]),
+    durationMs: Math.round(round.durationMs * 1.2),
+    breather: true,
+  }));
+}
+
+/**
+ * Which relocation target to use, given the plan's preference order and what
+ * the runtime knows. PURE. Returns -1 when nothing is eligible (the caller
+ * then simply does not relocate - a swap that cannot land is not a swap).
+ */
+export function relocationTarget(order, currentOdd, eliminated) {
+  const dead = eliminated instanceof Set ? eliminated : new Set(eliminated || []);
+  for (const i of (order || [])) {
+    if (i === currentOdd) continue;
+    if (dead.has(i)) continue;
+    return i;
+  }
+  return -1;
+}
+
+export default {
+  PLAYTEST, IMG_KINDS, VIDEO_KINDS, GENTLE_KINDS, REDUCED_KINDS, FLOOR_KIND,
+  PERCEPT_FLOOR, DELTA, BASE_FACE,
+  clampTier, clamp01, gridFor, kindPool, videoKindPool, deltaFor, faceStyle,
+  heatFor, cadenceMs, pitchFor, buildPlan, asBreather, relocationTarget,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/style.js
@@ -1,0 +1,468 @@
+/* ============================================================================
+ * games/anomaly/style.js - the game injects its OWN stylesheet from JS.
+ *
+ * THE DARKROOM. The class root is a full-viewport stage: a contact sheet (the
+ * grid) under a red safelight, an enlarger lamp throwing a cone from above,
+ * film strips hanging in the margins, dust in the beam. The casino (casino.js)
+ * paints the --an-n-* identity props and mounts the lighting layers; the
+ * fallbacks below are the plain darkroom, so a disarmed casino changes nothing
+ * but the light. Composition, exactly the DOM contract:
+ *
+ *   .g-an-stage[data-phase=briefing|round|verdict|ended][data-n=3|4|5]
+ *   .g-an-backdrop   the lighting rig (pointer-events:none, z0) - casino layers
+ *   .g-an-hud        three chips: round / clock / streak (darkroom timer LEDs)
+ *   .g-an-grid       the contact sheet; --an-n -> columns; position:relative
+ *   .g-an-tile[data-i] > .g-an-face(.g-an-media)
+ *   .g-an-msg / .g-an-flashwell / .g-an-end
+ *
+ * THE TRUTH LAW (read before touching a rule). CORE applies the anomaly as an
+ * INLINE filter / transform on .g-an-face. This sheet therefore writes NO
+ * filter, NO transform, NO opacity and NO blend on .g-an-face or .g-an-media -
+ * ever, in any state. A base filter here would be replaced by the odd tile's
+ * inline one and the difference between "mine" and "theirs" would become a
+ * second, unintended delta (a tell, or a lie to the ledger). Everything the
+ * darkroom does to a frame - the sprocket border, the frame number, the cold
+ * veil of an eliminated frame, the found ring - lives on the TILE's own
+ * pseudo-elements and box-shadow, over or around the face, never on it. The
+ * tile wrapper is never transformed either (it is the hitbox: Law II).
+ *
+ * THE FRAME is a contact-sheet frame: a film-black border with sprocket holes
+ * along the top and bottom edge (::before, a repeating radial gradient), and a
+ * frame NUMBER bottom-right in tiny mono (::after via a CSS counter that starts
+ * at the casino's seeded --an-n-frame-start - contact sheets never start at 1).
+ * ELIMINATED (.is-out / [data-out]) frames go cold: a blue-grey veil on the
+ * tile's ::after and a grey filter ON THE TILE WRAPPER (an eliminated frame is
+ * by definition not the odd one - the player just proved it). FOUND
+ * (.is-found) frames get a ring bloom in the safelight hue; the rest of the
+ * sheet dims under .g-an-grid.is-verdict. At a five-streak the sheet's frame
+ * IGNITES (.g-an-stage.g-an-lit / .g-an-grid.is-lit).
+ *
+ * NOTHING IS EVER STILL (Law III): the safelight breathes, the lamp sways, the
+ * dust drifts, the strips hang and drift, the grain crawls, the LEDs glow.
+ * REDUCED MOTION twice over (html.arc-reduced + the media query): the
+ * breathing and the drifts die, a static safelight stays. .g-an-stage.suspended
+ * freezes every animation so CORE can hold the room's breath with the class.
+ *
+ * THE CLASS-RULES SHEET (Deck VI, Law IV): drawn, not told. CORE builds
+ * .g-an-howto > .g-an-hw-title, .g-an-hw-row* > (.g-an-hw-fig + .g-an-hw-cap),
+ * .g-an-hw-go. The three figures are DRAWN HERE with pseudo-elements on the
+ * fig (by row order 1/2/3 or data-fig=same|find|lie): a mini contact sheet
+ * whose frames all glow in step; the same sheet with one frame off and a hand
+ * tapping it; the sheet with a wash sweeping over all nine - noise. No raster.
+ *
+ * THE END CARD (.g-an-end): a print in the developing tray - a dark card with
+ * a safelight rim, title, k/v rows (.g-an-end-row > .g-an-end-k + .g-an-end-v),
+ * the one line (.g-an-end-line) and the buttons (.btn).
+ * ==========================================================================*/
+
+const STYLE_ID = 'g-an-style';
+
+export const STYLE_TEXT = `
+/* ---- registered decoration props: numbers interpolate, so a var change
+   MORPHS (the journey) instead of snapping ---------------------------------- */
+@property --an-n-deep{syntax:'<number>';inherits:true;initial-value:0}
+@property --an-n-dust{syntax:'<number>';inherits:true;initial-value:.4}
+@property --an-n-lamp-a{syntax:'<number>';inherits:true;initial-value:.5}
+@property --an-n-pay{syntax:'<number>';inherits:true;initial-value:.4}
+
+/* ---- the stage: the whole window is the darkroom ------------------------- */
+.g-an-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
+  align-items:center;gap:10px;padding:72px 18px 14px;color:var(--ink);
+  --an-board:min(calc(100dvh - 232px), calc(100vw - 48px), 720px);
+  --an-gap:clamp(6px,1.2vmin,14px);
+  --an-n:3;
+  --an-hue:var(--an-n-hue,354);
+  --an-safe:var(--an-n-safe, hsl(354 88% 52%));
+  --an-safe-a:var(--an-n-safe-a, hsl(354 88% 56% / .28));
+  --an-breath:var(--an-n-breath,7.5s);
+  --an-drift:var(--an-n-drift,24s);
+  --an-kb:var(--an-n-kb,28s);
+  --an-frame:#0b0a0c;
+  --an-paper:#17131a;
+  counter-reset:an-frame var(--an-n-frame-start,37);
+  transition:--an-n-deep 1.6s ease, --an-n-dust 3.2s ease, --an-n-lamp-a 3s ease;
+  background:
+    radial-gradient(90% 60% at var(--an-n-lamp-x,50%) -10%, var(--an-safe-a), transparent 62%),
+    radial-gradient(80% 50% at 50% 112%, hsl(var(--an-hue) 60% 18% / .5), transparent 60%),
+    color-mix(in srgb, var(--ground), black 58%)}
+.g-an-stage[data-n="3"]{--an-n:3}
+.g-an-stage[data-n="4"]{--an-n:4}
+.g-an-stage[data-n="5"]{--an-n:5}
+.g-an-stage.suspended *{animation-play-state:paused !important}
+
+/* ---- the backdrop: the casino's lighting rig (decoration only) ----------- */
+.g-an-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+.g-an-backdrop *{pointer-events:none}
+.g-an-bd{position:absolute;inset:0;opacity:0}
+.g-an-bd::before{content:"";position:absolute;inset:0}
+/* the safelight: a red glow from the lamp corner, breathing */
+.g-an-bd-safe{opacity:1}
+.g-an-bd-safe::before{
+  background:radial-gradient(70% 60% at var(--an-n-lamp-x,50%) -8%, hsl(var(--an-hue) 90% 55% / .34), hsl(var(--an-hue) 80% 40% / .12) 40%, transparent 72%);
+  animation:g-an-breathe var(--an-breath) ease-in-out infinite alternate}
+@keyframes g-an-breathe{from{opacity:.55}to{opacity:1}}
+/* the enlarger lamp: a cone of light from the top, swaying a hair */
+.g-an-bd-lamp{opacity:var(--an-n-lamp-a,.5)}
+.g-an-bd-lamp::before{inset:-10% -20% 0;transform-origin:var(--an-n-lamp-x,50%) 0;
+  background:conic-gradient(from calc(180deg + var(--an-n-lamp-tilt,0deg)) at var(--an-n-lamp-x,50%) -4%,
+    transparent 0deg 154deg, hsl(var(--an-hue) 70% 70% / .10) 160deg, hsl(var(--an-hue) 80% 78% / .22) 180deg,
+    hsl(var(--an-hue) 70% 70% / .10) 200deg, transparent 206deg 360deg);
+  -webkit-mask-image:linear-gradient(to bottom, #000 0, #000 55%, transparent 92%);
+  mask-image:linear-gradient(to bottom, #000 0, #000 55%, transparent 92%);
+  animation:g-an-sway calc(var(--an-drift) * .8) ease-in-out infinite alternate}
+@keyframes g-an-sway{from{transform:rotate(-1.6deg)}to{transform:rotate(1.6deg)}}
+.g-an-bd-lamp.sweep::before{animation:g-an-sweep .9s ease-in-out 1}
+@keyframes g-an-sweep{0%{transform:rotate(-1.6deg)}50%{transform:rotate(4deg);filter:brightness(1.5)}100%{transform:rotate(1.6deg)}}
+/* hanging film strips in the margins: frames + sprockets, drifting.
+   PATTERNS DRIFT BY TRANSFORM, NEVER BY BACKGROUND-POSITION (web CLAUDE.md trap 36): the
+   sheet is oversized by exactly one 56px period on its leading edge and translated by that
+   period, so the wrap lands on an identical pixel; the vertical bars are y-invariant. */
+.g-an-bd-strips{opacity:.55}
+.g-an-bd-strips::before{inset:-56px 0 0 0;
+  background:
+    repeating-linear-gradient(180deg, transparent 0 6px, rgba(0,0,0,.55) 6px 10px, transparent 10px 56px),
+    repeating-linear-gradient(90deg, transparent 0 2.5%, rgba(10,8,12,.9) 2.5% 7.5%, transparent 7.5% 9%, transparent 9% 91%, rgba(10,8,12,.9) 91% 96%, transparent 96% 100%),
+    repeating-linear-gradient(180deg, transparent 0 12px, hsl(var(--an-hue) 30% 20% / .35) 12px 48px, transparent 48px 56px);
+  background-size:100% 100%, 100% 100%, 100% 100%;
+  -webkit-mask-image:linear-gradient(90deg, #000 0 10%, transparent 14%, transparent 86%, #000 90%);
+  mask-image:linear-gradient(90deg, #000 0 10%, transparent 14%, transparent 86%, #000 90%);
+  animation:g-an-strips var(--an-drift) linear infinite}
+@keyframes g-an-strips{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,56px,0)}}
+/* the advance (a new sheet) rides the WRAPPER so it never fights the drift's transform */
+.g-an-bd-strips.advance{animation:g-an-advance .5s ease-out 1}
+@keyframes g-an-advance{from{transform:translateY(-8px)}to{transform:translateY(0)}}
+/* dust in the beam: two sheets of motes rising through the light */
+.g-an-bd-dust{opacity:var(--an-n-dust,.4)}
+.g-an-bd-dust::before{
+  background:
+    radial-gradient(circle, hsl(var(--an-hue) 70% 82% / .7) 0 1.2px, transparent 2.2px),
+    radial-gradient(circle, rgba(240,230,220,.5) 0 .8px, transparent 1.8px);
+  background-size:170px 190px, 170px 190px;background-position:0 0, 50px 70px;
+  animation:g-an-dust calc(var(--an-drift) * 1.6) linear infinite}
+.g-an-bd-dust{-webkit-mask-image:radial-gradient(80% 70% at var(--an-n-lamp-x,50%) 10%, #000 20%, transparent 75%);
+  mask-image:radial-gradient(80% 70% at var(--an-n-lamp-x,50%) 10%, #000 20%, transparent 75%)}
+.g-an-bd-dust::before{inset:0 0 -190px 0}
+@keyframes g-an-dust{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-190px,0)}}
+/* film grain: a crawling speckle, faint */
+.g-an-bd-grain{opacity:.16;mix-blend-mode:overlay}
+.g-an-bd-grain::before{
+  background:
+    repeating-radial-gradient(circle at 20% 30%, transparent 0 1px, rgba(255,255,255,.08) 1px 2px, transparent 2px 5px),
+    repeating-radial-gradient(circle at 70% 60%, transparent 0 1px, rgba(0,0,0,.12) 1px 2px, transparent 2px 6px);
+  background-size:220px 220px, 220px 220px;inset:0 -220px 0 0;
+  animation:g-an-grain .5s steps(4) infinite}
+@keyframes g-an-grain{from{transform:translate3d(0,0,0)}to{transform:translate3d(-220px,0,0)}}
+/* the dark: the journey deepens the room */
+.g-an-bd-dark{opacity:calc(var(--an-n-deep,0) * .5);background:#000}
+/* THE EXPOSURE: the enlarger flashes on a find (white-pink, 420ms) */
+.g-an-bd-flash{opacity:0;background:radial-gradient(60% 60% at 50% 50%, hsl(var(--an-hue) 90% 86% / .9), hsl(var(--an-hue) 90% 70% / .4) 40%, transparent 72%)}
+.g-an-bd-flash.on{animation:g-an-flash .42s ease-out 1}
+@keyframes g-an-flash{0%{opacity:var(--an-n-pay,.4);transform:scale(.8)}100%{opacity:0;transform:scale(1.2)}}
+/* THE COLD: a wrong tap dips the room blue for a beat */
+.g-an-bd-cold{opacity:0;background:radial-gradient(80% 80% at 50% 50%, rgba(120,150,220,.28), rgba(60,80,140,.12) 50%, transparent 80%)}
+.g-an-bd-cold.on{animation:g-an-cold .52s ease-out 1}
+@keyframes g-an-cold{0%{opacity:1}100%{opacity:0}}
+/* the royal: the darkroom floods gold */
+.g-an-bd-royal{opacity:0;transition:opacity 1.2s ease;
+  background:radial-gradient(80% 70% at 50% 30%, color-mix(in srgb, var(--gold), transparent 40%), transparent 72%)}
+.g-an-stage.g-an-royal .g-an-bd-royal{opacity:1;animation:g-an-royal 2.2s ease-in-out infinite alternate}
+@keyframes g-an-royal{from{opacity:.7}to{opacity:1}}
+/* vignette; the bell tightens it */
+.g-an-bd-vig{opacity:1;background:radial-gradient(120% 100% at 50% 46%, transparent 50%, rgba(0,0,0,.66) 100%)}
+.g-an-stage.g-an-bell .g-an-bd-vig{animation:g-an-vig 1s ease-in-out infinite alternate}
+@keyframes g-an-vig{from{opacity:.85}to{opacity:1}}
+/* a dim-out never cuts: the rig sighs down to a whisper */
+.g-an-stage.g-an-out .g-an-bd{transition:opacity 1.6s ease;opacity:.25}
+.g-an-stage.g-an-out .g-an-bd-dark,.g-an-stage.g-an-out .g-an-bd-vig{opacity:1}
+/* ken-burns on the whole rig (casino sets .g-an-kb when motion is on) */
+.g-an-stage.g-an-kb .g-an-bd-strips,.g-an-stage.g-an-kb .g-an-bd-dust{
+  animation:g-an-kb var(--an-kb) ease-in-out infinite alternate}
+@keyframes g-an-kb{from{transform:scale(1) translate(0,0)}to{transform:scale(1.05) translate(var(--an-n-kb-x,1.2%),var(--an-n-kb-y,-.8%))}}
+
+/* ---- HUD: darkroom timer LEDs ------------------------------------------- */
+.g-an-hud{position:relative;z-index:2;display:flex;flex-wrap:wrap;align-items:center;
+  justify-content:center;gap:8px 12px;font-family:var(--mono);font-size:11px;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint);will-change:translate}
+.g-an-chip{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+  border:1px solid color-mix(in srgb, hsl(var(--an-hue) 60% 40%), var(--line) 50%);
+  background:color-mix(in srgb, #0c0a0e, transparent 20%);
+  color:hsl(var(--an-hue) 85% 72%);text-shadow:0 0 8px hsl(var(--an-hue) 90% 60% / .7);
+  font-variant-numeric:tabular-nums;will-change:transform;transform-origin:50% 50%;
+  transition:color .3s ease,border-color .3s ease,box-shadow .3s ease}
+.g-an-chip.g-an-round{color:var(--ink-dim);text-shadow:none}
+.g-an-chip.g-an-streak{border-color:hsl(var(--an-hue) 80% 55%);
+  box-shadow:0 0 12px hsl(var(--an-hue) 90% 55% / .35)}
+.g-an-stage.g-an-bell .g-an-clock,.g-an-stage[data-phase="bell"] .g-an-clock{border-color:var(--gold);color:var(--gold);
+  text-shadow:0 0 8px rgba(240,194,75,.7);animation:g-an-bellchip 1s ease-in-out infinite alternate}
+@keyframes g-an-bellchip{from{box-shadow:0 0 6px rgba(240,194,75,.3)}to{box-shadow:0 0 16px rgba(240,194,75,.7)}}
+.g-an-stage[data-warn="1"] .g-an-clock{border-color:var(--gold);color:var(--gold);text-shadow:0 0 8px rgba(240,194,75,.7);
+  animation:g-an-bellchip 1s ease-in-out infinite alternate}
+/* the pressure's reduced-motion punch: a bloom, never a move */
+.g-an-chip.g-an-p-bloom,.g-an-hud.g-an-p-bloom{
+  box-shadow:0 0 0 1px hsl(var(--an-hue) 90% 70% / .8), 0 0 22px hsl(var(--an-hue) 90% 60% / .6);transition:box-shadow .3s ease}
+
+/* ---- the grid: the contact sheet ---------------------------------------- */
+.g-an-grid{position:relative;z-index:1;flex:0 0 auto;
+  width:var(--an-board);height:var(--an-board);
+  display:grid;grid-template-columns:repeat(var(--an-n),1fr);grid-template-rows:repeat(var(--an-n),1fr);
+  gap:var(--an-gap);padding:calc(var(--an-gap) * 1.2);box-sizing:border-box;border-radius:10px;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,.03), transparent 30%),
+    var(--an-paper);
+  border:1px solid rgba(255,255,255,.07);
+  box-shadow:0 30px 70px rgba(0,0,0,.6), inset 0 0 40px rgba(0,0,0,.5), 0 0 0 1px hsl(var(--an-hue) 50% 30% / .25);
+  transition:box-shadow .6s ease,border-color .6s ease}
+/* the sheet's label strip: a faint header band with a seeded roll number */
+.g-an-grid::before{content:"";position:absolute;left:10px;right:10px;top:-7px;height:0;border-top:1px dashed hsl(var(--an-hue) 60% 55% / .28);pointer-events:none}
+/* at a five-streak the frame IGNITES */
+.g-an-stage.g-an-lit .g-an-grid,.g-an-grid.is-lit{border-color:hsl(var(--an-hue) 90% 62% / .9);
+  box-shadow:0 30px 70px rgba(0,0,0,.6), inset 0 0 40px rgba(0,0,0,.5), 0 0 0 2px hsl(var(--an-hue) 90% 62% / .55), 0 0 46px hsl(var(--an-hue) 90% 55% / .45);
+  animation:g-an-ignite 1.4s ease-in-out infinite alternate}
+@keyframes g-an-ignite{from{box-shadow:0 30px 70px rgba(0,0,0,.6), inset 0 0 40px rgba(0,0,0,.5), 0 0 0 2px hsl(var(--an-hue) 90% 62% / .45), 0 0 30px hsl(var(--an-hue) 90% 55% / .3)}
+  to{box-shadow:0 30px 70px rgba(0,0,0,.6), inset 0 0 40px rgba(0,0,0,.5), 0 0 0 2px hsl(var(--an-hue) 90% 62% / .8), 0 0 60px hsl(var(--an-hue) 90% 55% / .6)}}
+
+/* ---- the tile: one contact-sheet frame ---------------------------------- */
+.g-an-tile{position:relative;min-width:0;min-height:0;border-radius:5px;overflow:visible;
+  background:var(--an-frame);cursor:pointer;
+  padding:9% 4% 11%;box-sizing:border-box;
+  box-shadow:0 2px 6px rgba(0,0,0,.6), inset 0 0 0 1px rgba(255,255,255,.05);
+  -webkit-tap-highlight-color:transparent;user-select:none;
+  transition:box-shadow .25s ease}
+.g-an-tile:focus-visible{outline:2px solid var(--gold);outline-offset:2px}
+/* sprocket holes along the top and bottom edges (the frame's own ::before) */
+.g-an-tile::before{content:"";position:absolute;left:0;right:0;top:0;bottom:0;border-radius:5px;pointer-events:none;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 0 / 14% 9% repeat-x,
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 100% / 14% 11% repeat-x;
+  background-repeat:repeat-x;opacity:.9}
+/* the frame number, bottom-right, tiny mono (a CSS counter from the seeded start) */
+.g-an-tile::after{counter-increment:an-frame;content:counter(an-frame);position:absolute;right:5%;bottom:1.5%;
+  font:600 clamp(7px,1.05vmin,10px)/1 var(--mono);letter-spacing:.1em;color:hsl(var(--an-hue) 70% 68% / .65);
+  pointer-events:none;transition:color .3s ease,opacity .3s ease}
+/* THE FACE: the truth. CORE writes its inline filter/transform; this sheet
+   writes nothing visual on it - no filter, no transform, no opacity, no blend. */
+.g-an-face{position:relative;width:100%;height:100%;overflow:hidden;border-radius:2px;background:#000;display:block}
+.g-an-face .g-an-media,.g-an-face img,.g-an-face video{width:100%;height:100%;object-fit:cover;display:block;pointer-events:none}
+/* ELIMINATED: the frame goes cold. Grey ON THE TILE WRAPPER (the player just
+   proved it is not the odd one) + a blue veil over the whole frame. */
+.g-an-tile.is-out,.g-an-tile[data-out],.g-an-tile.is-gone,.g-an-tile.is-cold{filter:grayscale(.85) brightness(.72);cursor:default}
+.g-an-tile.is-out::before,.g-an-tile[data-out]::before,.g-an-tile.is-gone::before,.g-an-tile.is-cold::before{
+  background:
+    linear-gradient(180deg, rgba(150,175,230,.22), rgba(90,110,170,.28)),
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 0 / 14% 9% repeat-x,
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 100% / 14% 11% repeat-x;
+  background-repeat:no-repeat,repeat-x,repeat-x;opacity:1;z-index:1}
+.g-an-tile.is-out::after,.g-an-tile[data-out]::after,.g-an-tile.is-gone::after,.g-an-tile.is-cold::after{color:rgba(170,190,230,.7)}
+/* FOUND: the ring blooms in the safelight hue; the rest of the sheet dims */
+.g-an-tile.is-found,.g-an-tile[data-found]{
+  box-shadow:0 0 0 2px hsl(var(--an-hue) 90% 72%), 0 0 26px hsl(var(--an-hue) 90% 62% / .8), 0 2px 6px rgba(0,0,0,.6);
+  animation:g-an-found .45s ease-out 1}
+@keyframes g-an-found{0%{box-shadow:0 0 0 0 hsl(var(--an-hue) 90% 80%), 0 0 0 hsl(var(--an-hue) 90% 62% / 0)}
+  40%{box-shadow:0 0 0 3px hsl(var(--an-hue) 90% 80%), 0 0 40px hsl(var(--an-hue) 90% 62% / 1)}
+  100%{box-shadow:0 0 0 2px hsl(var(--an-hue) 90% 72%), 0 0 26px hsl(var(--an-hue) 90% 62% / .8)}}
+.g-an-grid.is-verdict .g-an-tile:not(.is-found):not([data-found])::before,
+.g-an-stage[data-phase="verdict"] .g-an-tile:not(.is-found):not([data-found])::before{
+  background:rgba(6,4,8,.55);opacity:1;z-index:1;transition:background .3s ease}
+/* GHOST: the tap landed where it WAS (CORE marks the tile it LEFT) - lavender, dashed */
+.g-an-tile.is-ghost{box-shadow:0 0 0 2px rgba(184,166,232,.85), 0 0 18px rgba(184,166,232,.55), 0 2px 6px rgba(0,0,0,.6);
+  filter:none}
+.g-an-tile.is-ghost::before{background:
+    linear-gradient(180deg, rgba(184,166,232,.18), rgba(184,166,232,.26)),
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 0 / 14% 9% repeat-x,
+    radial-gradient(circle at 50% 50%, rgba(40,36,44,.95) 0 28%, transparent 34%) 0 100% / 14% 11% repeat-x;
+  background-repeat:no-repeat,repeat-x,repeat-x;opacity:1;z-index:1;
+  border:1px dashed rgba(216,204,255,.9)}
+/* REVEAL (a timed-out round: CORE marks where it was) */
+.g-an-tile.is-reveal,.g-an-tile[data-reveal]{box-shadow:0 0 0 2px rgba(184,166,232,.9), 0 0 22px rgba(184,166,232,.6)}
+/* the sheet between rounds */
+.g-an-stage[data-phase="briefing"] .g-an-grid{filter:brightness(.8) saturate(.85)}
+.g-an-stage[data-phase="ended"] .g-an-grid{filter:saturate(.6) brightness(.7)}
+/* hover shimmer hint: fine pointers only (the dossier's coarse-pointer probe) */
+@media (hover:hover) and (pointer:fine){
+  .g-an-stage[data-phase="round"] .g-an-tile:not(.is-out):not([data-out]):hover{box-shadow:0 2px 6px rgba(0,0,0,.6), 0 0 0 1px hsl(var(--an-hue) 80% 60% / .6), 0 0 14px hsl(var(--an-hue) 80% 55% / .35)}
+}
+
+/* ---- the proctor line + the flash well ---------------------------------- */
+.g-an-msg{position:relative;z-index:2;margin:0;min-height:1.4em;text-align:center;
+  font-family:var(--mono);font-size:12px;letter-spacing:.08em;color:var(--ink-dim);
+  text-shadow:0 0 8px hsl(var(--an-hue) 60% 40% / .5);transition:opacity .3s ease;max-width:min(92vw,720px)}
+.g-an-msg:empty{opacity:0}
+.g-an-flashwell{position:absolute;inset:0;z-index:2;pointer-events:none;overflow:hidden}
+.g-an-flashwell *{pointer-events:none}
+
+/* ---- the end card: a print in the tray ---------------------------------- */
+.g-an-end{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:8;
+  width:min(440px,90vw);max-height:86vh;overflow:auto;padding:20px 22px 18px;border-radius:14px;
+  background:linear-gradient(180deg, rgba(24,18,26,.96), rgba(12,9,14,.97));
+  border:1px solid hsl(var(--an-hue) 60% 45% / .5);
+  box-shadow:0 30px 80px rgba(0,0,0,.6), 0 0 44px hsl(var(--an-hue) 80% 50% / .18), inset 0 0 0 1px rgba(255,255,255,.04);
+  font-family:var(--body);color:var(--ink);animation:g-an-endin .5s ease-out 1}
+@keyframes g-an-endin{from{opacity:0;transform:translate(-50%,-46%)}to{opacity:1;transform:translate(-50%,-50%)}}
+.g-an-end-title{font-family:var(--disp);font-size:16px;letter-spacing:.14em;text-transform:uppercase;
+  color:hsl(var(--an-hue) 85% 72%);text-shadow:0 0 18px hsl(var(--an-hue) 90% 60% / .5);margin:0 0 10px;text-align:center}
+.g-an-end-row{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  padding:5px 0;border-bottom:1px dashed rgba(255,255,255,.08);font-size:13px}
+.g-an-end-k{color:var(--ink-faint)}
+.g-an-end-v{color:var(--ink);font-variant-numeric:tabular-nums;font-family:var(--mono)}
+.g-an-end-streak .g-an-end-v{color:hsl(var(--an-hue) 85% 72%)}
+.g-an-end-line{margin:12px 0 0;font-size:12px;color:var(--ink-dim);text-align:center;font-style:italic}
+.g-an-end .btn{margin:12px 4px 0}
+
+/* ---- THE CLASS-RULES SHEET (Deck VI, Law IV): drawn, not told ----------- */
+.g-an-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(520px,90vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:22px 24px 20px;border-radius:16px;
+  background:linear-gradient(180deg,rgba(26,20,28,.95),rgba(12,9,14,.97));
+  border:1px solid hsl(var(--an-hue) 60% 45% / .5);
+  box-shadow:0 30px 80px rgba(0,0,0,.55), 0 0 44px hsl(var(--an-hue) 80% 50% / .14)}
+.g-an-hw-title{margin:0 0 8px;text-align:center;font-family:var(--disp);font-size:clamp(16px,2.4vmin,20px);
+  letter-spacing:.2em;text-transform:uppercase;color:hsl(var(--an-hue) 85% 72%);
+  text-shadow:0 0 22px hsl(var(--an-hue) 90% 60% / .45)}
+.g-an-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-an-hw-row + .g-an-hw-row{border-top:1px dashed rgba(255,255,255,.08)}
+.g-an-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim)}
+.g-an-hw-fig{position:relative;flex:0 0 auto;display:grid;grid-template-columns:repeat(2,1fr);gap:3px;
+  width:58px;height:58px;padding:3px;box-sizing:border-box;border-radius:5px;background:var(--an-paper);
+  border:1px solid rgba(255,255,255,.08);box-shadow:0 0 14px hsl(var(--an-hue) 90% 55% / .25);pointer-events:none;
+  --hw-cell:hsl(var(--an-hue) 80% 58%)}
+.g-an-hw-fig.nine{grid-template-columns:repeat(3,1fr)}
+/* every cell is the same loop, in step: they breathe together */
+.g-an-hw-cell{display:block;min-width:0;min-height:0;border-radius:2px;background:var(--hw-cell);
+  box-shadow:0 0 6px hsl(var(--an-hue) 90% 55% / .5);animation:g-an-hw-step 1.6s ease-in-out infinite alternate}
+@keyframes g-an-hw-step{from{filter:brightness(.7)}to{filter:brightness(1.3)}}
+/* 1 - THE SAME: nothing else. 2 - THE FIND: one cell is off (another hue) + a hand */
+.g-an-hw-fig.find .g-an-hw-cell.odd{background:hsl(calc(var(--an-hue) + 150) 80% 60%);
+  box-shadow:0 0 10px hsl(calc(var(--an-hue) + 150) 90% 60% / .9)}
+.g-an-hw-fig.same .g-an-hw-cell.odd{background:var(--hw-cell);box-shadow:0 0 6px hsl(var(--an-hue) 90% 55% / .5)}
+.g-an-hw-tap{position:absolute;left:50%;top:50%;width:15px;height:19px;margin:-4px 0 0 -2px;z-index:2;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, #fff, #d8ccff);filter:drop-shadow(0 0 6px rgba(255,255,255,.6));
+  animation:g-an-hw-tap 1.6s ease-in-out infinite}
+@keyframes g-an-hw-tap{0%,55%{transform:translate(10px,10px)}70%{transform:translate(0,0) scale(.9)}80%,100%{transform:translate(0,0)}}
+.g-an-hw-tap.finger{clip-path:none;width:12px;height:20px;border-radius:6px 6px 4px 4px;background:linear-gradient(180deg,#fff,#d8ccff)}
+/* 3 - THE LIE: a wash sweeps over every cell at once - that is noise */
+.g-an-hw-fig.lie .g-an-hw-cell.odd{background:var(--hw-cell);box-shadow:0 0 6px hsl(var(--an-hue) 90% 55% / .5)}
+.g-an-hw-fig.lie{overflow:hidden}
+/* the sweep is a 3x-wide sheet translated across the clipped figure (trap 36: never background-position) */
+.g-an-hw-wash,.g-an-hw-fig.lie::after{content:"";position:absolute;inset:0 0 0 -200%;pointer-events:none;
+  background:linear-gradient(100deg, transparent 0 20%, hsl(calc(var(--an-hue) + 60) 90% 65% / .6) 45%, hsl(calc(var(--an-hue) + 120) 90% 65% / .6) 55%, transparent 80% 100%);
+  mix-blend-mode:screen;animation:g-an-hw-wash 2.2s linear infinite}
+@keyframes g-an-hw-wash{from{transform:translate3d(0,0,0)}to{transform:translate3d(66.7%,0,0)}}
+.g-an-hw-go{pointer-events:auto;align-self:center;margin-top:14px;appearance:none;-webkit-appearance:none;cursor:pointer;
+  font:700 13px/1 var(--body);letter-spacing:.16em;text-transform:uppercase;color:#0c0a0e;
+  padding:12px 26px;border-radius:999px;border:0;
+  background:linear-gradient(180deg, hsl(var(--an-hue) 90% 72%), hsl(var(--an-hue) 85% 58%));
+  box-shadow:0 0 24px hsl(var(--an-hue) 90% 60% / .55), 0 4px 0 hsl(var(--an-hue) 70% 30%);
+  animation:g-an-hw-go 1.8s ease-in-out infinite alternate}
+.g-an-hw-go:hover{filter:brightness(1.08)}
+.g-an-hw-go:focus-visible{outline:2px solid var(--gold);outline-offset:3px}
+.g-an-hw-go:active{transform:translateY(2px);box-shadow:0 0 24px hsl(var(--an-hue) 90% 60% / .55), 0 2px 0 hsl(var(--an-hue) 70% 30%)}
+@keyframes g-an-hw-go{from{box-shadow:0 0 14px hsl(var(--an-hue) 90% 60% / .4), 0 4px 0 hsl(var(--an-hue) 70% 30%)}to{box-shadow:0 0 34px hsl(var(--an-hue) 90% 60% / .75), 0 4px 0 hsl(var(--an-hue) 70% 30%)}}
+
+/* ---- reduced motion (both gates): a static safelight, no drift ----------- */
+html.arc-reduced .g-an-stage *{animation:none !important}
+html.arc-reduced .g-an-stage{transition:none}
+html.arc-reduced .g-an-bd-safe::before{opacity:.8}
+html.arc-reduced .g-an-bd-lamp{opacity:calc(var(--an-n-lamp-a,.5) * .6)}
+html.arc-reduced .g-an-bd-dust,html.arc-reduced .g-an-bd-grain{opacity:0}
+html.arc-reduced .g-an-bd-strips{opacity:.35}
+html.arc-reduced .g-an-tile.is-found,html.arc-reduced .g-an-tile[data-found]{box-shadow:0 0 0 2px hsl(var(--an-hue) 90% 72%), 0 0 26px hsl(var(--an-hue) 90% 62% / .8)}
+html.arc-reduced .g-an-hw-tap{transform:none}
+html.arc-reduced .g-an-hw-wash,html.arc-reduced .g-an-hw-fig.lie::after{transform:translate3d(33%,0,0)}
+@media (prefers-reduced-motion: reduce){
+  .g-an-stage *{animation:none !important}
+  .g-an-stage{transition:none}
+  .g-an-bd-safe::before{opacity:.8}
+  .g-an-bd-lamp{opacity:calc(var(--an-n-lamp-a,.5) * .6)}
+  .g-an-bd-dust,.g-an-bd-grain{opacity:0}
+  .g-an-bd-strips{opacity:.35}
+  .g-an-tile.is-found,.g-an-tile[data-found]{box-shadow:0 0 0 2px hsl(var(--an-hue) 90% 72%), 0 0 26px hsl(var(--an-hue) 90% 62% / .8)}
+  .g-an-hw-tap{transform:none}
+  .g-an-hw-wash,.g-an-hw-fig.lie::after{transform:translate3d(33%,0,0)}
+}
+
+/* ---- narrow / touch -------------------------------------------------------- */
+@media (max-width:560px){
+  .g-an-stage{padding:64px 10px 10px;--an-board:min(calc(100dvh - 206px), calc(100vw - 20px))}
+  .g-an-hud{gap:6px 8px;font-size:10px}
+  .g-an-chip{padding:3px 9px}
+  .g-an-tile{padding:8% 3% 10%}
+  .g-an-tile::after{font-size:7px}
+}
+`;
+
+/** Inject once per document. No-op headless (the DOM double has no head). */
+export function injectAnomalyStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return false;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);   // harness shim
+    return true;
+  } catch (e) {
+    return false;      // a stylesheet must never be the thing that fails a class
+  }
+}
+
+/** The contract's name. */
+export const injectAnStyle = injectAnomalyStyle;
+
+/* ---------------------------------------------------------------------------
+ * THE CLASS-RULES SHEET, drawn (Deck VI, Law IV). CORE calls
+ * showAnomalyHowto({mount, onGo, coarse, t, tier, n}) and prefers this markup
+ * over its own fallback; the POLICY (when to show, hideTutorial, howtoTiers)
+ * stays CORE's. Three figures: a mini contact sheet whose nine cells breathe
+ * in step; the same sheet with ONE cell off and a hand tapping it; the sheet
+ * with a wash sweeping over all nine - noise. The GO button is the only live
+ * thing on it and the only dismissal. No raster art.
+ * ------------------------------------------------------------------------- */
+let howtoNode = null;
+function mk(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+export function showAnomalyHowto(o) {
+  const opts = o || {};
+  const mount = opts.mount;
+  const t = typeof opts.t === 'function' ? opts.t : (k, f) => (f == null ? k : f);
+  if (typeof document === 'undefined' || !mount || !mount.appendChild) return null;
+  hideAnomalyHowto();
+  const sheet = mk('div', 'g-an-howto');
+  sheet.appendChild(mk('h2', 'g-an-hw-title', t('an_howto_title', 'Class rules')));
+  const row = (kind, caption) => {
+    const r = mk('div', 'g-an-hw-row');
+    const fig = mk('span', 'g-an-hw-fig nine ' + kind);
+    fig.setAttribute('data-fig', kind);
+    fig.setAttribute('aria-hidden', 'true');
+    for (let k = 0; k < 9; k++) fig.appendChild(mk('i', 'g-an-hw-cell' + (k === 4 ? ' odd' : '')));
+    if (kind === 'find') fig.appendChild(mk('span', 'g-an-hw-tap' + (opts.coarse ? ' finger' : '')));
+    if (kind === 'lie') fig.appendChild(mk('i', 'g-an-hw-wash'));
+    r.appendChild(fig);
+    r.appendChild(mk('p', 'g-an-hw-cap', caption));
+    sheet.appendChild(r);
+  };
+  row('same', t('an_howto_same', 'Every tile is the same loop, playing in step.'));
+  row('find', t('an_howto_find', 'One is not. Tap it. The first tap is the one that counts.'));
+  row('lie', t('an_howto_lie', 'The room tints, drifts and glitches every tile at once. That is noise.'));
+  const go = mk('button', 'g-an-hw-go', t('an_howto_go', 'Open your eyes'));
+  go.type = 'button';
+  go.setAttribute('autofocus', '');
+  go.addEventListener('click', () => { try { if (typeof opts.onGo === 'function') opts.onGo(); } catch (e) { /* noop */ } });
+  sheet.appendChild(go);
+  mount.appendChild(sheet);
+  howtoNode = sheet;
+  try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+  return sheet;
+}
+export function hideAnomalyHowto() {
+  if (howtoNode) { try { howtoNode.remove(); } catch (e) { /* noop */ } howtoNode = null; }
+}
+
+export default injectAnomalyStyle;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/trickster.js
@@ -1,0 +1,845 @@
+/* ============================================================================
+ * games/anomaly/trickster.js - DECK III of the House Rules, dealt into the
+ * darkroom. A spot-the-difference room is where your own eyes stop being
+ * reliable witnesses, so every card here attacks the READING - the chrome, the
+ * clock, the hand - and NEVER the grid. This deck does not know which frame is
+ * the odd one (CORE keeps it in closure), never reads it, never infers it.
+ *
+ *   GHOST OUTLINE   "it moved": CORE tells this deck (afterTap({moved:true,i})
+ *                   or ghostOutline(i)) that the player tapped where the
+ *                   anomaly WAS before a relocation. A dashed outline blooms on
+ *                   THAT frame (the player's own tap - public by then), a "+1s"
+ *                   pip rises off it (the refund is CORE's; the pip is the
+ *                   staging; the proctor line is CORE's). Near-miss that
+ *                   teaches.
+ *   GHOST CURSOR    a faint cursor echo trails the real pointer by ~430ms;
+ *                   stall >= 2.6s and it stops trailing and drifts toward a
+ *                   frame of the house's choosing - a SEEDED frame, which is the
+ *                   point: this deck cannot know the odd one, so the lure can
+ *                   never be trusted. Pure suggestion: pointer-events none, it
+ *                   cannot click, the real cursor is never hidden, it dies on
+ *                   the next tap. Tier 2+, mouse pointers only.
+ *   STAT FLICKER    the streak or the round chip briefly reads slightly off,
+ *                   then corrects itself with a static pop to the exact text
+ *                   CORE's chipText() answers. The ledger never moves.
+ *   CROOKED CLOCK   the clock FACE bends: races through the middle (shows less
+ *                   time than you have), crawls as the bell nears, meets the
+ *                   truth at the last 15s and stays honest. A MutationObserver
+ *                   re-bends the face the instant CORE repaints the truth (a
+ *                   microtask, before the frame paints). Tier 2+.
+ *   GLITCH-TO-ASSET a piece of HUD chrome flickers into one of the player's
+ *                   own pool stills for ~130ms, then back. Tier 3+.
+ *   THE MELT        a NON-odd frame runs like wax under the safelight: a wax
+ *                   sheet slides down over it and drips, then it reforms. The
+ *                   frame is chosen by this deck's OWN seeded draw from the
+ *                   list CORE's meltCandidates() answers (ELEMENTS, never an
+ *                   index - the odd one is simply not in the list) or, failing
+ *                   that, vetoed by a canMelt(i) predicate. Neither hook -> the
+ *                   card folds, by law. The melt is an OVERLAY
+ *                   at the frame's rect: .g-an-tile / .g-an-face are never
+ *                   written, no class, no style, no attribute. Nothing is lost.
+ *
+ * DEALING RULE: flicker / clock / chrome / melt are SCHEDULE-DEALT at start()
+ * from the seeded plan - budget 2/4/6/8 by tier, at most 4 in any rolling 60s
+ * with a 9s floor (a 90s class fits ~5 at most; the budget is a ceiling), never
+ * in the first 10s, never in the last 12s. A slot whose moment arrives halted
+ * re-queues once, then folds. The ghost cursor is stall-reactive (the stall is
+ * the player's own); the ghost outline is event-reactive (CORE says when).
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - the flicker and the clock write chip TEXT and restore
+ *       it from chipText (the truth source); nothing here reads or writes the
+ *       round, streak, time budget, grade or the odd index.
+ *   II  input honest  - every node lives in the deck's own overlay layer in the
+ *       stage, pointer-events:none; the grid, the tiles and the faces are never
+ *       touched, covered in a way that steals a click, moved or resized.
+ *   IV  images over text - four short lines (it moved / +1s / did you see that
+ *       / runs like wax), every one through opts.t, under 2s on screen.
+ *   V   seeded        - per-tag mulberry32 off seed+'|an-trickster|<tag>',
+ *       append-only; a retake replays the identical deal.
+ *   VI  exits sacred  - capsOk false disarms the deck (no nodes, no listener,
+ *       no timers); reduced motion drops the ghost cursor, the flicker pop, the
+ *       chrome flicker and the melt's drip (the clock still bends - a number is
+ *       not motion; the melt becomes a plain veil); every timer rides the game's
+ *       registry AND a local set.
+ *   VII strings       - an_refund / an_trick_seen / an_trick_melt only (the
+ *       "it moved" proctor line is CORE's an_moved).
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const AN_TRICKSTER = Object.freeze({
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  FIRST_DEAL_MS: 10000,
+  TAIL_MS: 12000,
+  MIN_GAP_MS: 9000,
+  RATE_WINDOW_MS: 60000,
+  RATE_MAX: 4,
+  RETRY_MS: 1800,
+  RETRY_MAX: 2,
+
+  /** Card weights by tier (the clock is ONE slot from CLOCK_FROM_TIER). */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ flicker: 0.6, melt: 0.4, chrome: 0 }),
+    2: Object.freeze({ flicker: 0.45, melt: 0.55, chrome: 0 }),
+    3: Object.freeze({ flicker: 0.32, melt: 0.38, chrome: 0.3 }),
+    4: Object.freeze({ flicker: 0.28, melt: 0.36, chrome: 0.36 }),
+  }),
+  CLOCK_FROM_TIER: 2,
+  CHROME_FROM_TIER: 3,
+  MELT_FROM_TIER: 1,
+  GHOST_FROM_TIER: 2,
+  MELT_TRIES: 8,
+
+  /** Stat flicker: how long the wrong number stands. */
+  FLICKER_MS: 450,
+  /** Crooked clock: bend at mid-budget (fraction of budget), honest tail. */
+  CLOCK_BEND: 0.12,
+  CLOCK_HONEST_SEC: 15,
+  CLOCK_RAMP: 0.35,
+  CLOCK_POLL_MS: 250,
+  /** Glitch-to-asset: one beat of someone else's memory. */
+  CHROME_MS: 130,
+  SEEN_TAUNT_CHANCE: 0.3,
+  /** The melt: sag, drip, reform. */
+  MELT_MS: 1400,
+  MELT_FOLLOW_MS: Object.freeze([90, 220, 400, 640, 950, 1300]),
+  MELT_REFORM_MS: 500,
+  /** The ghost cursor. */
+  GHOST_TICK_MS: 90,
+  GHOST_TRAIL_MS: 430,
+  GHOST_STALL_MS: 2600,
+  GHOST_LERP: 0.14,
+  GHOST_KEEP_MS: 2200,
+  /** The ghost outline. */
+  OUTLINE_MS: 1000,
+  REFUND_MS: 900,
+});
+
+/** Every lexicon key this deck can render (CORE's lex.js mirrors them). */
+export const AN_TRICKSTER_LEX = Object.freeze(['an_refund', 'an_trick_seen', 'an_trick_melt']);
+
+const STYLE_ID = 'g-an-trickster-style';
+export const STYLE_TEXT = `
+/* THE TRICKSTER LAYER: one layer in the stage, every node pointer-events:none. */
+.g-an-tk{position:absolute;inset:0;z-index:4;pointer-events:none;overflow:hidden}
+.g-an-tk *{pointer-events:none}
+/* GHOST CURSOR */
+.g-an-tk-ghost{position:absolute;left:0;top:0;width:15px;height:19px;opacity:0;will-change:transform;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, hsl(var(--an-n-hue,354) 90% 78% / .9), rgba(184,166,232,.55));
+  filter:drop-shadow(0 0 6px hsl(var(--an-n-hue,354) 90% 70% / .6));
+  transition:transform .34s ease-out, opacity .38s ease}
+.g-an-tk-ghost.on{opacity:.3}
+.g-an-tk-ghost.lure{opacity:.52;animation:g-an-tk-ghostpulse 1.5s ease-in-out infinite}
+@keyframes g-an-tk-ghostpulse{50%{filter:drop-shadow(0 0 12px hsl(var(--an-n-hue,354) 90% 70% / .95))}}
+/* GHOST OUTLINE: it moved */
+.g-an-tk-outline{position:absolute;border-radius:6px;opacity:0;border:2px dashed rgba(184,166,232,.9);
+  box-shadow:0 0 16px rgba(184,166,232,.55),inset 0 0 16px rgba(184,166,232,.25)}
+.g-an-tk-outline.on{animation:g-an-tk-outline 1s ease-out forwards}
+@keyframes g-an-tk-outline{0%{opacity:0;transform:scale(1.06)}15%{opacity:1;transform:scale(1)}70%{opacity:.9}100%{opacity:0;transform:scale(.98)}}
+.g-an-tk-refund{position:absolute;left:var(--x,50%);top:var(--y,50%);transform:translate(-50%,-50%);opacity:0;
+  font:800 clamp(12px,1.9vmin,18px)/1 var(--mono,monospace);letter-spacing:.12em;color:#d8ccff;
+  text-shadow:0 0 10px rgba(184,166,232,.8);white-space:nowrap}
+.g-an-tk-refund.on{animation:g-an-tk-refund .9s ease-out forwards}
+@keyframes g-an-tk-refund{0%{opacity:0;transform:translate(-50%,-40%)}20%{opacity:1;transform:translate(-50%,-60%)}100%{opacity:0;transform:translate(-50%,-140%)}}
+/* STAT FLICKER: the static pop */
+.g-an-tk-flick{text-shadow:0 0 22px rgba(184,166,232,.75), 0 0 3px rgba(255,255,255,.5);
+  animation:g-an-tk-static .16s steps(3) 2}
+@keyframes g-an-tk-static{0%{filter:none}40%{filter:brightness(1.5) contrast(1.4)}100%{filter:none}}
+/* GLITCH-TO-ASSET: a pool still wearing a chrome box for a beat */
+.g-an-tk-chrome{position:absolute;overflow:hidden;border-radius:999px;opacity:.92;
+  box-shadow:0 0 0 1px rgba(184,166,232,.4);animation:g-an-tk-chrome .13s steps(2) 1}
+.g-an-tk-chrome img{width:100%;height:100%;object-fit:cover;display:block;filter:saturate(1.2) contrast(1.1)}
+@keyframes g-an-tk-chrome{0%{transform:translateX(-2px)}100%{transform:translateX(2px)}}
+/* THE MELT: a wax sheet over a NON-odd frame, at its rect, dripping */
+.g-an-tk-wax{position:absolute;border-radius:6px;opacity:0;overflow:visible;
+  background:linear-gradient(180deg, hsl(var(--an-n-hue,354) 60% 22% / .0) 0%, hsl(var(--an-n-hue,354) 70% 30% / .55) 30%, hsl(var(--an-n-hue,354) 80% 38% / .8) 100%);
+  transform-origin:50% 0}
+.g-an-tk-wax.on{animation:g-an-tk-wax 1.4s cubic-bezier(.5,.05,.7,1) forwards}
+.g-an-tk-wax.reform{animation:g-an-tk-reform .5s ease-out forwards}
+@keyframes g-an-tk-wax{0%{opacity:0;transform:scaleY(.2)}25%{opacity:.85;transform:scaleY(.6)}100%{opacity:.95;transform:scaleY(1.08)}}
+@keyframes g-an-tk-reform{from{opacity:.95;transform:scaleY(1.08)}to{opacity:0;transform:scaleY(1)}}
+.g-an-tk-wax::before,.g-an-tk-wax::after{content:"";position:absolute;top:100%;width:14%;height:0;border-radius:0 0 50% 50%;
+  background:hsl(var(--an-n-hue,354) 80% 40% / .85);box-shadow:0 2px 8px hsl(var(--an-n-hue,354) 80% 30% / .6)}
+.g-an-tk-wax::before{left:22%}
+.g-an-tk-wax::after{left:61%;width:10%}
+.g-an-tk-wax.on::before{animation:g-an-tk-drip 1.4s .3s ease-in forwards}
+.g-an-tk-wax.on::after{animation:g-an-tk-drip 1.4s .55s ease-in forwards}
+@keyframes g-an-tk-drip{from{height:0}to{height:46%}}
+@media (prefers-reduced-motion: reduce){
+  .g-an-tk-ghost{display:none}
+  .g-an-tk-flick{animation:none}
+  .g-an-tk-chrome{display:none}
+  .g-an-tk-wax.on{animation:none;opacity:.7;transform:none}
+  .g-an-tk-wax::before,.g-an-tk-wax::after{display:none}
+  .g-an-tk-outline.on{animation:none;opacity:.9}
+  .g-an-tk-refund.on{animation:none;opacity:1}
+}
+html.arc-reduced .g-an-tk-ghost{display:none}
+html.arc-reduced .g-an-tk-flick{animation:none}
+html.arc-reduced .g-an-tk-chrome{display:none}
+html.arc-reduced .g-an-tk-wax.on{animation:none;opacity:.7;transform:none}
+html.arc-reduced .g-an-tk-wax::before,html.arc-reduced .g-an-tk-wax::after{display:none}
+html.arc-reduced .g-an-tk-outline.on{animation:none;opacity:.9}
+html.arc-reduced .g-an-tk-refund.on{animation:none;opacity:1}
+.g-an-stage.suspended .g-an-tk *{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clampTier(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+
+/**
+ * The crooked face, pure: displayed seconds-left for a real seconds-left.
+ * f(B)=B, f(honest)=honest, monotonic (bend*pi < 1), honest at/after the bell.
+ */
+export function bendClock(secLeft, budgetSec, bend, honestSec) {
+  const x = Math.max(0, Number(secLeft) || 0);
+  const B = Math.max(30, Number(budgetSec) || 90);
+  const H = Number.isFinite(honestSec) ? honestSec : AN_TRICKSTER.CLOCK_HONEST_SEC;
+  if (x <= H || x >= B) return Math.round(x);
+  const A0 = Number.isFinite(bend) ? bend : AN_TRICKSTER.CLOCK_BEND;
+  const u = x / B;
+  const uh = H / B;
+  const ramp = Math.max(0, Math.min(1, (u - uh) / AN_TRICKSTER.CLOCK_RAMP));
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, Math.round(B * (u - A * Math.sin(Math.PI * u))));
+}
+
+/**
+ * The deal plan, pure: n slots over the budget, first/tail guards, the 9s
+ * floor and the 4-in-60s cap, cards by tier weight, the clock one slot.
+ * @param {Function} roll  tag -> 0..1 (the deck's seeded stream)
+ */
+export function buildDealPlan(tier, budgetSec, rollFn) {
+  const T = AN_TRICKSTER;
+  const roll = typeof rollFn === 'function' ? rollFn : () => 0.5;
+  const tr = clampTier(tier);
+  const n = T.DEALS[tr] || 2;
+  const spanMs = Math.max(45, Number(budgetSec) || 90) * 1000;
+  const usable = Math.max(15000, spanMs - T.FIRST_DEAL_MS - T.TAIL_MS);
+  let times = [];
+  for (let i = 0; i < n; i++) times.push(T.FIRST_DEAL_MS + roll('when') * usable);
+  times.sort((a, b) => a - b);
+  for (let i = 1; i < times.length; i++) if (times[i] - times[i - 1] < T.MIN_GAP_MS) times[i] = times[i - 1] + T.MIN_GAP_MS;
+  /* the rolling-window cap: drop slots that would be a 5th within 60s */
+  const kept = [];
+  for (const at of times) {
+    const inWindow = kept.filter((k) => at - k < T.RATE_WINDOW_MS).length;
+    if (inWindow >= T.RATE_MAX) continue;
+    if (at > spanMs - T.TAIL_MS) continue;
+    kept.push(at);
+  }
+  times = kept;
+  const clockSlot = tr >= T.CLOCK_FROM_TIER && times.length > 1 ? Math.floor(roll('clock-slot') * Math.ceil(times.length / 2)) : -1;
+  const w = T.WEIGHTS[tr] || T.WEIGHTS[1];
+  return times.map((at, i) => {
+    let card;
+    if (i === clockSlot) card = 'clock';
+    else {
+      const r = roll('card');
+      card = r < w.flicker ? 'flicker' : r < w.flicker + w.melt ? 'melt' : 'chrome';
+      if (card === 'chrome' && tr < T.CHROME_FROM_TIER) card = 'melt';
+      if (card === 'melt' && tr < T.MELT_FROM_TIER) card = 'flicker';
+    }
+    return { at: Math.round(at), card };
+  });
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+
+/**
+ * @param {Object} o
+ * @param {string}   o.seed        the class seed (retakes replay)
+ * @param {number}   o.tier        1..4
+ * @param {Object}   o.timers      {after(ms,fn)->id, every?(ms,fn)->id, clear|cancel(id)}
+ * @param {boolean}  o.reduced     reduced motion
+ * @param {boolean|Function} o.capsOk  false when bgIntensity is capped to 0
+ * @param {Function} o.isHalted    () => bool (dead/paused/ended/between rounds)
+ * @param {Function=} o.t          ctx.lexicon (English fallbacks here)
+ * @param {Function} o.stats       () => {round, secLeft, streak, rounds?} - the TRUTH
+ * @param {Function} o.chipEl      (which: 'round'|'clock'|'streak') => element|null
+ * @param {Function} o.chipText    (which) => the honest text (repaint source)
+ * @param {Object}   o.stage       .g-an-stage (the overlay's host)
+ * @param {Object=}  o.grid        .g-an-grid (READ: tile rects by data-i)
+ * @param {Function=} o.tiles      () => live .g-an-tile elements (else queried off grid)
+ * @param {Function=} o.meltCandidates () => HTMLElement[]  CORE's melt list (never the odd / eliminated)
+ * @param {Function=} o.canMelt    (i) => bool   the predicate form of the same veto (either hook arms the melt)
+ * @param {Function=} o.getStill   () => url|null (a pool still for the chrome flicker)
+ * @param {Object=}   o.assets     {next(kind)} CORE's live pool reader (getStill fallback)
+ * @param {Function=} o.chromeEls  () => HTMLElement[] (HUD chrome the flicker may wear; else the chips)
+ * @param {Function=} o.announce   (text, ms) => void (the proctor line)
+ * @param {number=}  o.budgetSec   class budget (default 90)
+ * @param {boolean=} o.coarse      coarse pointer (no ghost)
+ * @param {Function=} o.log
+ */
+export function createAnTrickster(o) {
+  const opts = o || {};
+  const T = AN_TRICKSTER;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : (k, f) => (f == null ? k : f);
+  const tier = clampTier(opts.tier);
+  const reduced = !!opts.reduced;
+  const coarse = !!opts.coarse;
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const chipEl = typeof opts.chipEl === 'function' ? opts.chipEl : () => null;
+  const chipText = typeof opts.chipText === 'function' ? opts.chipText : () => null;
+  const canMelt = typeof opts.canMelt === 'function' ? opts.canMelt : null;
+  const meltCandidates = typeof opts.meltCandidates === 'function' ? opts.meltCandidates : null;
+  const meltArmed = !!(meltCandidates || canMelt);
+  const getStill = typeof opts.getStill === 'function' ? opts.getStill : () => {
+    try {
+      const a = opts.assets;
+      if (!a || typeof a.next !== 'function') return null;
+      const got = a.next('still') || a.next('loop');
+      return got && got.url ? String(got.url) : null;
+    } catch (e) { return null; }
+  };
+  const chromeEls = typeof opts.chromeEls === 'function' ? opts.chromeEls
+    : () => ['round', 'clock', 'streak'].map((w) => chipEl(w)).filter(Boolean);
+  const announce = typeof opts.announce === 'function' ? opts.announce : null;
+  const budgetSec = Math.max(45, Number(opts.budgetSec) || 90);
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false && opts.capsOk != null;
+  }
+  const armedBase = !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* timers: the game's registry + a local set */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  const chains = new Set();
+  function every(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    if (typeof opts.timers.every === 'function') {
+      const id = opts.timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => { if (!handle.on || destroyed) return; try { fn(); } catch (e) { /* ignore */ } handle.id = after(ms, tick); };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+
+  const seedBase = String(opts.seed || 'an') + '|an-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  let stopped = false;
+  let paused = false;
+  let started = false;
+  const fired = { flicker: 0, clock: 0, chrome: 0, melt: 0, outline: 0, ghost: 0 };
+  const folded = { melt: 0, chrome: 0, flicker: 0 };
+  let deals = [];
+  const fireTimes = [];
+  const lexiconUsed = new Set();
+  function tt(key, fallback) { lexiconUsed.add(key); return t(key, fallback); }
+
+  /* ---- the overlay ------------------------------------------------------- */
+  let layer = null;
+  let stageEl = opts.stage || null;
+  /** The stage: CORE's opts.stage, else the closest .g-an-stage above a chip
+   *  or a tile (CORE hands this deck chips and tiles, not the stage). */
+  function hostStage() {
+    if (stageEl) return stageEl;
+    const probes = [chipEl('clock'), chipEl('round'), chipEl('streak')];
+    try { const l = tileList(); if (l.length) probes.push(l[0]); } catch (e) { /* none */ }
+    for (const p of probes) {
+      try { if (p && typeof p.closest === 'function') { const s = p.closest('.g-an-stage'); if (s) { stageEl = s; return s; } } } catch (e) { /* next */ }
+    }
+    return null;
+  }
+  function ensureLayer() {
+    if (layer) return layer;
+    const host = hostStage();
+    if (!host || !host.appendChild) return null;
+    ensureStyle();
+    layer = el('div', 'g-an-tk');
+    if (layer) host.appendChild(layer);
+    return layer;
+  }
+  function tileList() {
+    try {
+      if (typeof opts.tiles === 'function') { const l = opts.tiles(); if (l && l.length) return Array.from(l); }
+      if (opts.grid && opts.grid.querySelectorAll) return Array.from(opts.grid.querySelectorAll('.g-an-tile'));
+      if (stageEl && stageEl.querySelectorAll) return Array.from(stageEl.querySelectorAll('.g-an-tile'));
+    } catch (e) { /* fall */ }
+    return [];
+  }
+  function tileByIndex(i) {
+    const list = tileList();
+    for (const n of list) {
+      let di = null;
+      try { di = n.getAttribute ? n.getAttribute('data-i') : null; } catch (e) { di = null; }
+      if (di != null && String(di) === String(i)) return n;
+    }
+    const k = Number(i);
+    return Number.isFinite(k) && k >= 0 && k < list.length ? list[k] : null;
+  }
+  /** A tile's rect in overlay space. */
+  function tileRect(tileEl) {
+    const r = rectOf(tileEl);
+    const base = rectOf(layer);
+    if (!r || !base || !r.width) return null;
+    return { x: r.left - base.left, y: r.top - base.top, w: r.width, h: r.height, cx: r.left - base.left + r.width / 2, cy: r.top - base.top + r.height / 2 };
+  }
+  function placeBox(node, r, pad) {
+    if (!node || !r) return false;
+    node.style.left = (r.x - pad).toFixed(0) + 'px';
+    node.style.top = (r.y - pad).toFixed(0) + 'px';
+    node.style.width = (r.w + pad * 2).toFixed(0) + 'px';
+    node.style.height = (r.h + pad * 2).toFixed(0) + 'px';
+    return true;
+  }
+  function rateOk(now) {
+    while (fireTimes.length && now - fireTimes[0] > T.RATE_WINDOW_MS) fireTimes.shift();
+    if (fireTimes.length >= T.RATE_MAX) return false;
+    if (fireTimes.length && now - fireTimes[fireTimes.length - 1] < T.MIN_GAP_MS) return false;
+    return true;
+  }
+  function nowMs() { return Date.now(); }
+
+  /* ---- the deal ----------------------------------------------------------- */
+  function attempt(deal, tries) {
+    if (destroyed || stopped) return;
+    if (isHalted() || paused || !stats()) {
+      if (tries < T.RETRY_MAX) after(T.RETRY_MS, () => attempt(deal, tries + 1));
+      return;
+    }
+    if (!rateOk(nowMs())) { if (tries < T.RETRY_MAX) after(T.RETRY_MS, () => attempt(deal, tries + 1)); return; }
+    let went = false;
+    if (deal.card === 'flicker') went = dealFlicker();
+    else if (deal.card === 'clock') went = armClock();
+    else if (deal.card === 'chrome') went = dealChrome();
+    else if (deal.card === 'melt') went = dealMelt();
+    if (went) fireTimes.push(nowMs());
+  }
+
+  /* -------------------------------------------------------- stat flicker */
+  function dealFlicker() {
+    const s = stats();
+    if (!s) return false;
+    const which = roll('flick-which') < 0.5 ? 'streak' : 'round';
+    const chip = chipEl(which);
+    if (!chip || chip.textContent == null) { folded.flicker++; return false; }
+    const truth = chipText(which);
+    const real = Number(which === 'streak' ? s.streak : s.round) || 0;
+    const fake = Math.max(0, real + (roll('flick-sign') < 0.5 ? -1 : 1) * (1 + Math.floor(roll('flick-drop') * 2)));
+    const lie = (typeof truth === 'string' && /\d/.test(truth)) ? truth.replace(/\d+/, String(fake)) : String(fake);
+    if (!lie || lie === chip.textContent) { folded.flicker++; return false; }
+    try { chip.textContent = lie; } catch (e) { return false; }
+    if (!reduced) setCls(chip, 'g-an-tk-flick', true);
+    fired.flicker++;
+    after(T.FLICKER_MS, () => {
+      setCls(chip, 'g-an-tk-flick', false);
+      const now = chipText(which);
+      if (now != null) { try { chip.textContent = now; } catch (e) { /* ignore */ } }
+    });
+    say('trickster: stat flicker (' + which + ')');
+    return true;
+  }
+
+  /* ------------------------------------------------------- crooked clock */
+  let clockArmed = false;
+  let clockObs = null;
+  let clockPoll = 0;
+  let lastLie = null;
+  let budgetSeen = budgetSec;
+  let clockLies = 0;
+  function formatLike(sec, truth) {
+    const s = Math.max(0, Math.round(sec));
+    if (typeof truth === 'string' && /^\d+s$/.test(truth.trim())) return s + 's';
+    if (typeof truth === 'string' && /^\d+$/.test(truth.trim())) return String(s);
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    const padM = typeof truth === 'string' && /^\d{2}:\d{2}$/.test(truth.trim());
+    return (padM ? String(m).padStart(2, '0') : String(m)) + ':' + String(r).padStart(2, '0');
+  }
+  function bendFace() {
+    if (!clockArmed || destroyed || stopped) return;
+    const chip = chipEl('clock');
+    const s = stats();
+    if (!chip || !s || !Number.isFinite(Number(s.secLeft))) return;
+    const secLeft = Number(s.secLeft);
+    if (secLeft > budgetSeen) budgetSeen = secLeft;
+    const shown = bendClock(secLeft, budgetSeen, T.CLOCK_BEND, T.CLOCK_HONEST_SEC);
+    if (shown === Math.round(secLeft)) { lastLie = null; return; }
+    const truth = chipText('clock');
+    const text = formatLike(shown, truth);
+    if (chip.textContent === text) return;
+    lastLie = text;
+    try { chip.textContent = text; clockLies++; } catch (e) { /* ignore */ }
+  }
+  function armClock() {
+    if (clockArmed || tier < T.CLOCK_FROM_TIER) return false;
+    const chip = chipEl('clock');
+    if (!chip) return false;
+    clockArmed = true;
+    fired.clock++;
+    let hooked = false;
+    try {
+      if (typeof MutationObserver === 'function' && typeof chip.nodeType === 'number') {
+        clockObs = new MutationObserver(() => { if (chip.textContent === lastLie) return; bendFace(); });
+        clockObs.observe(chip, { childList: true, characterData: true, subtree: true });
+        hooked = true;
+      }
+    } catch (e) { clockObs = null; }
+    if (!hooked) clockPoll = every(T.CLOCK_POLL_MS, bendFace);
+    bendFace();
+    say('trickster: the clock goes crooked (' + (hooked ? 'observer' : 'poll') + ')');
+    return true;
+  }
+  function disarmClock(restore) {
+    if (clockObs) { try { clockObs.disconnect(); } catch (e) { /* ignore */ } clockObs = null; }
+    if (clockPoll) { stopEvery(clockPoll); clockPoll = 0; }
+    if (clockArmed && restore) {
+      const chip = chipEl('clock');
+      const truth = chipText('clock');
+      if (chip && truth != null) { try { chip.textContent = truth; } catch (e) { /* ignore */ } }
+    }
+    clockArmed = false;
+    lastLie = null;
+  }
+
+  /* ------------------------------------------------------ glitch-to-asset */
+  function dealChrome() {
+    if (reduced || tier < T.CHROME_FROM_TIER) { folded.chrome++; return false; }
+    let chrome = [];
+    try { chrome = Array.from(chromeEls() || []).filter((n) => n && typeof n.getBoundingClientRect === 'function'); } catch (e) { chrome = []; }
+    const host = ensureLayer();
+    if (!chrome.length || !host) { folded.chrome++; return false; }
+    const url = getStill();
+    if (!url) { folded.chrome++; return false; }
+    const target = chrome[Math.floor(roll('chrome-pick') * chrome.length)];
+    const r = tileRect(target);
+    if (!r) { folded.chrome++; return false; }
+    const node = el('div', 'g-an-tk-chrome');
+    if (!node || !placeBox(node, r, 0)) return false;
+    const img = el('img');
+    if (img) { img.alt = ''; try { img.setAttribute('draggable', 'false'); } catch (e) { /* noop */ } img.src = url; node.appendChild(img); }
+    host.appendChild(node);
+    fired.chrome++;
+    after(T.CHROME_MS, () => { try { node.remove(); } catch (e) { /* ignore */ } });
+    if (announce && roll('seen') < T.SEEN_TAUNT_CHANCE) { try { announce(tt('an_trick_seen', 'Did you see that?'), 1600); } catch (e) { /* noop */ } }
+    say('trickster: chrome flicker');
+    return true;
+  }
+
+  /* ------------------------------------------------------------- the melt */
+  let wax = null;
+  let waxTimer = 0;
+  let meltAnnounced = false;
+  function dealMelt() {
+    if (tier < T.MELT_FROM_TIER || wax) return false;
+    if (!meltArmed) { folded.melt++; say('trickster: melt folded (no meltCandidates / canMelt from CORE)'); return false; }
+    const host = ensureLayer();
+    if (!host) { folded.melt++; return false; }
+    let tile = null;
+    let idx = -1;
+    if (meltCandidates) {
+      /* CORE's list: elements that are NOT the odd one and not eliminated */
+      let list = [];
+      try { list = Array.from(meltCandidates() || []).filter((n) => n && n.getBoundingClientRect); } catch (e) { list = []; }
+      if (!list.length) { folded.melt++; return false; }
+      tile = list[Math.floor(roll('melt-pick') * list.length)] || null;
+      try { idx = tile && tile.getAttribute ? Number(tile.getAttribute('data-i')) : -1; } catch (e) { idx = -1; }
+    } else {
+      const list = tileList();
+      if (!list.length) { folded.melt++; return false; }
+      for (let k = 0; k < T.MELT_TRIES && !tile; k++) {
+        const cand = list[Math.floor(roll('melt-pick') * list.length)];
+        let i = null;
+        try { i = cand && cand.getAttribute ? cand.getAttribute('data-i') : null; } catch (e) { i = null; }
+        if (i == null) i = list.indexOf(cand);
+        let ok = false;
+        try { ok = !!canMelt(Number(i)); } catch (e) { ok = false; }
+        if (ok) { tile = cand; idx = Number(i); }
+      }
+    }
+    if (!tile) { folded.melt++; say('trickster: melt folded (veto)'); return false; }
+    const r = tileRect(tile);
+    if (!r) { folded.melt++; return false; }
+    wax = el('div', 'g-an-tk-wax');
+    if (!wax || !placeBox(wax, r, 0)) { wax = null; return false; }
+    host.appendChild(wax);
+    if (typeof wax.offsetWidth === 'number') void wax.offsetWidth;
+    setCls(wax, 'on', true);
+    fired.melt++;
+    /* THE FOLLOW: a melt dealt into a new-sheet transition measured a moving
+       frame (rig 2026-08-23: the wax sat between two tiles). Six more reads of
+       ONE tile over the melt's life keep the wax on the frame - reads, never
+       writes, and never per-frame. */
+    const waxNode = wax;
+    for (const ms of T.MELT_FOLLOW_MS) {
+      after(ms, () => { if (wax === waxNode) { const r2 = tileRect(tile); if (r2) placeBox(waxNode, r2, 0); } });
+    }
+    if (announce && !meltAnnounced && !reduced) {
+      meltAnnounced = true;
+      try { announce(tt('an_trick_melt', 'The frame runs like wax'), 2000); } catch (e) { /* noop */ }
+    }
+    cancel(waxTimer);
+    waxTimer = after(T.MELT_MS, () => {
+      if (!wax) return;
+      setCls(wax, 'on', false);
+      setCls(wax, 'reform', true);
+      waxTimer = after(T.MELT_REFORM_MS + 40, () => unmelt());
+    });
+    say('trickster: melt (frame ' + idx + ')');
+    return true;
+  }
+  function unmelt() {
+    cancel(waxTimer); waxTimer = 0;
+    if (wax) { try { wax.remove(); } catch (e) { /* ignore */ } }
+    wax = null;
+  }
+
+  /* ------------------------------------------------------ ghost outline */
+  let outline = null;
+  let refund = null;
+  let outlineTimer = 0;
+  const outlined = new Set();          // tiles already outlined this round
+  function ghostOutline(i) {
+    const host = ensureLayer();
+    if (!host || !armed()) return false;
+    const tile = tileByIndex(i);
+    const r = tile ? tileRect(tile) : null;
+    if (!r) return false;
+    if (!outline) { outline = el('i', 'g-an-tk-outline'); if (outline) host.appendChild(outline); }
+    if (!refund) { refund = el('span', 'g-an-tk-refund'); if (refund) host.appendChild(refund); }
+    if (!outline || !placeBox(outline, r, 2)) return false;
+    setCls(outline, 'on', false);
+    if (typeof outline.offsetWidth === 'number') void outline.offsetWidth;
+    setCls(outline, 'on', true);
+    if (refund) {
+      refund.textContent = tt('an_refund', '+1s');
+      setVar(refund, '--x', r.cx.toFixed(0) + 'px');
+      setVar(refund, '--y', (r.y + 4).toFixed(0) + 'px');
+      setCls(refund, 'on', false);
+      if (typeof refund.offsetWidth === 'number') void refund.offsetWidth;
+      setCls(refund, 'on', true);
+    }
+    fired.outline++;
+    cancel(outlineTimer);
+    outlineTimer = after(T.OUTLINE_MS + 60, () => { setCls(outline, 'on', false); setCls(refund, 'on', false); });
+    say('trickster: ghost outline (frame ' + i + ')');
+    return true;
+  }
+
+  /* ------------------------------------------------------------ the ghost */
+  let ghost = null;
+  let ghostTimer = 0;
+  let onMove = null;
+  const trail = [];
+  let lastMoveAt = 0;
+  let lure = null;
+  let gx = 0, gy = 0;
+  let ghostSeen = false;
+  let stallMs = 0;
+  function ghostEligible() {
+    const host = hostStage();
+    return armed() && !reduced && !coarse && tier >= T.GHOST_FROM_TIER && !!host
+      && typeof host.addEventListener === 'function' && typeof host.getBoundingClientRect === 'function';
+  }
+  function pickLure() {
+    /* a SEEDED frame - this deck cannot know the odd one, so the lure is noise
+       by construction; never an eliminated frame (a dead lure is no lure) */
+    const list = tileList().filter((n) => !(n.classList && (n.classList.contains('is-out') || n.classList.contains('is-cold'))));
+    if (!list.length) return null;
+    return list[Math.floor(roll('lure') * list.length)] || null;
+  }
+  function ghostTick() {
+    if (destroyed || stopped || !ghost) return;
+    if (isHalted() || paused || !lastMoveAt) { setCls(ghost, 'on', false); setCls(ghost, 'lure', false); return; }
+    const now = nowMs();
+    const stalled = (now - lastMoveAt > T.GHOST_STALL_MS) || stallMs >= T.GHOST_STALL_MS;
+    if (!stalled) {
+      lure = null;
+      if (!trail.length) { setCls(ghost, 'on', false); setCls(ghost, 'lure', false); return; }
+      let pt = trail[0];
+      for (const p of trail) { if (now - p.at >= T.GHOST_TRAIL_MS) pt = p; else break; }
+      gx = pt.x; gy = pt.y;
+      setCls(ghost, 'on', true); setCls(ghost, 'lure', false);
+    } else {
+      if (!lure) { lure = pickLure(); if (lure) { ghostSeen = true; fired.ghost++; } }
+      const r = lure ? tileRect(lure) : null;
+      if (r) { gx += (r.cx - gx) * T.GHOST_LERP; gy += (r.cy - gy) * T.GHOST_LERP; }
+      setCls(ghost, 'on', true); setCls(ghost, 'lure', true);
+    }
+    try { ghost.style.transform = 'translate3d(' + gx.toFixed(1) + 'px,' + gy.toFixed(1) + 'px,0)'; } catch (e) { /* noop */ }
+    while (trail.length > 1 && now - trail[0].at > T.GHOST_KEEP_MS) trail.shift();
+  }
+  function armGhost() {
+    if (!ghostEligible() || ghost) return;
+    const host = ensureLayer();
+    if (!host) return;
+    ghost = el('div', 'g-an-tk-ghost');
+    if (!ghost) return;
+    host.appendChild(ghost);
+    onMove = (e) => {
+      if (destroyed) return;
+      const base = rectOf(layer);
+      if (!base) return;
+      const x = Number(e.clientX) - base.left;
+      const y = Number(e.clientY) - base.top;
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      lastMoveAt = nowMs();
+      trail.push({ x, y, at: lastMoveAt });
+      lure = null;
+    };
+    /* a PASSIVE listener on the stage: it reads, it never preventDefaults,
+       it never stops propagation - the grid's own handlers see every event */
+    try { stageEl.addEventListener('pointermove', onMove, { passive: true }); } catch (e) { try { stageEl.addEventListener('pointermove', onMove); } catch (e2) { onMove = null; } }
+    ghostTimer = every(T.GHOST_TICK_MS, ghostTick);
+    say('trickster: ghost armed');
+  }
+  function unghost() { if (ghost) { setCls(ghost, 'on', false); setCls(ghost, 'lure', false); } lure = null; }
+
+  /* ---------------------------------------------------------------- api */
+  return {
+    /** Deal the class. Call once, when the first round is dealt. */
+    start() {
+      if (started) return;
+      started = true;
+      if (!armed()) { say('trickster: disarmed'); return; }
+      ensureLayer();
+      deals = buildDealPlan(tier, budgetSec, roll);
+      for (const deal of deals) after(deal.at, () => attempt(deal, 0));
+      try { const s = stats(); if (s && Number(s.secLeft) > budgetSeen) budgetSeen = Number(s.secLeft); } catch (e) { /* ignore */ }
+      armGhost();
+      say('trickster: dealt ' + deals.length + ' cards (' + deals.map((d) => d.card + '@' + Math.round(d.at / 1000) + 's').join(', ') + ')'
+        + (meltArmed ? '' : ' - melt DISARMED (no meltCandidates / canMelt)'));
+    },
+    /** A new round: every lie on the old sheet comes off. */
+    afterRound() {
+      if (!armed()) return;
+      unmelt();
+      unghost();
+      outlined.clear();
+      stallMs = 0;
+      setCls(outline, 'on', false); setCls(refund, 'on', false);
+    },
+    /** Every tap, after CORE's accounting. CORE marks a tap that landed where
+     *  the anomaly WAS with .is-ghost on THAT tile (a tile it has LEFT, never
+     *  the live one) - the outline + the +1s pip bloom on it. An explicit
+     *  {i, moved:true} does the same. */
+    afterTap(info) {
+      if (!armed()) return;
+      const e = info || {};
+      unghost();
+      stallMs = 0;
+      lastMoveAt = nowMs();
+      if (e.moved === true || e.ghost === true || e.reason === 'moved') { ghostOutline(e.i); return; }
+      for (const tile of tileList()) {
+        let g = false;
+        try { g = !!(tile.classList && tile.classList.contains('is-ghost')); } catch (err) { g = false; }
+        if (!g || outlined.has(tile)) continue;
+        outlined.add(tile);
+        let i = null;
+        try { i = tile.getAttribute ? tile.getAttribute('data-i') : null; } catch (err) { i = null; }
+        ghostOutline(i == null ? tileList().indexOf(tile) : i);
+        break;
+      }
+    },
+    /** CORE may call this directly for the refund staging. */
+    ghostOutline(i) { if (!armed()) return false; return ghostOutline(i); },
+    /** CORE calls every ~500ms with ms since the last tap; 0 resets. */
+    stalled(ms) {
+      if (!armed() || stopped || paused) return;
+      stallMs = Math.max(0, Number(ms) || 0);
+      if (stallMs <= 0) unghost();
+    },
+    /** CORE's pause: the deals ride CORE's pause-aware timers, so this only
+     *  hides the live lies (a melt mid-pause would read as a frozen frame). */
+    pause() {
+      if (paused) return;
+      paused = true;
+      unghost();
+      setCls(outline, 'on', false); setCls(refund, 'on', false);
+    },
+    resume() {
+      if (!paused) return;
+      paused = false;
+      stallMs = 0;
+      lastMoveAt = nowMs();
+    },
+    stop() {
+      stopped = true;
+      unmelt();
+      unghost();
+      disarmClock(true);
+      setCls(outline, 'on', false); setCls(refund, 'on', false);
+    },
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      for (const h of Array.from(chains)) stopEvery(h);
+      if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+      if (onMove && stageEl && stageEl.removeEventListener) { try { stageEl.removeEventListener('pointermove', onMove); } catch (e) { /* ignore */ } }
+      onMove = null;
+      unmelt();
+      disarmClock(true);
+      if (layer) { try { layer.remove(); } catch (e) { /* ignore */ } }
+      layer = null; ghost = null; outline = null; refund = null;
+    },
+    diagnostics() {
+      return {
+        armed: armed(), tier, deals: deals.slice(), fired: Object.assign({}, fired), folded: Object.assign({}, folded),
+        melted: !!wax, ghost: !!ghost, ghostSeen, meltVeto: meltArmed, stage: !!stageEl,
+        clock: { armed: clockArmed, lies: clockLies, budget: budgetSeen, observer: !!clockObs },
+        lexiconUsed: Array.from(lexiconUsed), lexicon: AN_TRICKSTER_LEX.slice(), layer: !!layer, liveTimers: live.size,
+      };
+    },
+  };
+}
+
+export default createAnTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/board.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/board.js
@@ -1,0 +1,309 @@
+/* ============================================================================
+ * games/composure/board.js - COMPOSURE's pure puzzle state. PURE: no DOM, no
+ * clock, no ctx, no engine, no Math.random.
+ *
+ * THE MODEL. An n x n sliding puzzle with ONE gap.
+ *   cells[pos] = tileId            0 .. n*n-2, or BLANK (-1) for the gap
+ *   home(tileId) = tileId          tile k belongs in cell k; the gap's home is
+ *                                  the last cell, so the solved board reads
+ *                                  [0, 1, 2, ... n*n-2, BLANK]
+ * A tile's HOME is also which fragment of the picture it carries - index.js
+ * turns home into the media's object offset, which is why home is an integer
+ * here and never a look.
+ *
+ * LOCKING IS COSMETIC. `homeMask` / `lockedCount` report which tiles are
+ * sitting on their own home cell so the class can snap them, ladder the heat
+ * and grade progress. A "locked" tile is NEVER frozen: freezing tiles can make
+ * a solvable board unsolvable, and Law I says the ledger is honest. Every
+ * legal slide stays legal for the whole class.
+ *
+ * SOLVABILITY IS A PARITY INVARIANT, and half of all permutations fail it.
+ *   n odd  : solvable <=> inversions(tiles) is EVEN
+ *   n even : solvable <=> inversions(tiles) + row(gap, from the top, 0-based)
+ *                         is ODD
+ * `scramble()` therefore deals a permutation, tests it, and REPAIRS an
+ * unsolvable one by transposing two tiles (which flips inversion parity and
+ * leaves the gap where it is). A board this file hands out is always solvable
+ * - the suite asserts it over 300 seeds x {3,4,5} - because a class the player
+ * mathematically cannot finish is the one failure this game may not ship.
+ *
+ * SEEDING (Law V): every draw runs off `makeRng(seed + '|<tag>')` from
+ * core/rng.js, in append-only order, so a retake deals the identical board.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+/** The gap. Never a tile id. */
+export const BLANK = -1;
+
+/** Directions a TILE travels. 'left' = the tile right of the gap moves left. */
+export const DIRS = Object.freeze(['up', 'down', 'left', 'right']);
+
+/** dir -> the delta from the gap to the tile that would fill it. */
+const FROM_BLANK = Object.freeze({
+  up: { dr: 1, dc: 0 },      // a tile BELOW the gap slides up
+  down: { dr: -1, dc: 0 },   // a tile ABOVE the gap slides down
+  left: { dr: 0, dc: 1 },    // a tile RIGHT of the gap slides left
+  right: { dr: 0, dc: -1 },  // a tile LEFT of the gap slides right
+});
+
+export function sizeOf(n) {
+  const v = Math.round(Number(n) || 0);
+  return v < 3 ? 3 : v > 5 ? 5 : v;
+}
+
+/** '4x4' | 4 | '4' -> 4. The zen setting arrives as the string. */
+export function sizeFromSetting(v, fallback) {
+  const s = String(v == null ? '' : v).trim().toLowerCase();
+  const m = /^([345])\s*x\s*\1$/.exec(s);
+  if (m) return Number(m[1]);
+  const n = Math.round(Number(s));
+  if (Number.isFinite(n) && n >= 3 && n <= 5) return n;
+  return sizeOf(fallback == null ? 3 : fallback);
+}
+
+export function rowOf(n, pos) { return Math.floor(pos / n); }
+export function colOf(n, pos) { return pos % n; }
+export function posOf(n, r, c) { return r * n + c; }
+export function inBounds(n, r, c) { return r >= 0 && c >= 0 && r < n && c < n; }
+
+/** The solved arrangement for an n x n board. */
+export function solvedCells(n) {
+  const size = sizeOf(n);
+  const out = [];
+  for (let i = 0; i < size * size - 1; i++) out.push(i);
+  out.push(BLANK);
+  return out;
+}
+
+/**
+ * Wrap a cells array as a state. `cells` is COPIED - a state never aliases the
+ * array it was built from, so a caller may keep its own.
+ */
+export function createState(n, cells) {
+  const size = sizeOf(n);
+  const src = Array.isArray(cells) && cells.length === size * size ? cells.slice() : solvedCells(size);
+  return { n: size, cells: src, blank: src.indexOf(BLANK) };
+}
+
+export function cloneState(s) {
+  return { n: s.n, cells: s.cells.slice(), blank: s.blank };
+}
+
+/** Stable text form (tests, diagnostics, the meta row). */
+export function serialize(s) {
+  return s.n + ':' + s.cells.map((v) => (v === BLANK ? '_' : v)).join(',');
+}
+
+/** Positions orthogonally adjacent to `pos`. */
+export function neighbours(n, pos) {
+  const r = rowOf(n, pos); const c = colOf(n, pos);
+  const out = [];
+  if (r > 0) out.push(pos - n);
+  if (r < n - 1) out.push(pos + n);
+  if (c > 0) out.push(pos - 1);
+  if (c < n - 1) out.push(pos + 1);
+  return out;
+}
+
+/** Every tile position that may slide right now (the gap's neighbours). */
+export function legalSlides(s) {
+  return neighbours(s.n, s.blank);
+}
+
+/** Is a slide of the tile at `pos` legal? */
+export function canSlide(s, pos) {
+  if (!Number.isFinite(pos) || pos < 0 || pos >= s.n * s.n) return false;
+  if (s.cells[pos] === BLANK) return false;
+  return neighbours(s.n, s.blank).indexOf(pos) >= 0;
+}
+
+/** The direction the tile at `pos` would travel (it always travels into the gap). */
+export function dirOfSlide(s, pos) {
+  if (!canSlide(s, pos)) return '';
+  return dirBetween(s.n, pos, s.blank);
+}
+
+/** The direction of travel from `from` to the adjacent cell `to`. */
+export function dirBetween(n, from, to) {
+  const dr = rowOf(n, to) - rowOf(n, from);
+  const dc = colOf(n, to) - colOf(n, from);
+  if (dr === -1 && dc === 0) return 'up';
+  if (dr === 1 && dc === 0) return 'down';
+  if (dr === 0 && dc === -1) return 'left';
+  if (dr === 0 && dc === 1) return 'right';
+  return '';
+}
+
+/** The tile position a direction press would slide, or -1 when that wall is solid. */
+export function slotForDir(s, dir) {
+  const d = FROM_BLANK[String(dir)];
+  if (!d) return -1;
+  const r = rowOf(s.n, s.blank) + d.dr;
+  const c = colOf(s.n, s.blank) + d.dc;
+  if (!inBounds(s.n, r, c)) return -1;
+  return posOf(s.n, r, c);
+}
+
+/**
+ * Slide the tile at `pos` into the gap. MUTATES `s`.
+ * @returns {{moved:boolean, id:number, from:number, to:number, dir:string}}
+ */
+export function slide(s, pos) {
+  if (!canSlide(s, pos)) return { moved: false, id: BLANK, from: pos, to: pos, dir: '' };
+  const id = s.cells[pos];
+  const to = s.blank;
+  const dir = dirBetween(s.n, pos, to);
+  s.cells[to] = id;
+  s.cells[pos] = BLANK;
+  s.blank = pos;
+  return { moved: true, id, from: pos, to, dir };
+}
+
+/** Slide by direction of travel. Same result shape as slide(). */
+export function slideDir(s, dir) {
+  const pos = slotForDir(s, dir);
+  if (pos < 0) return { moved: false, id: BLANK, from: -1, to: -1, dir: String(dir || '') };
+  return slide(s, pos);
+}
+
+export function isSolved(s) {
+  for (let i = 0; i < s.cells.length - 1; i++) if (s.cells[i] !== i) return false;
+  return s.cells[s.cells.length - 1] === BLANK;
+}
+
+/** Per-CELL truth: is the tile sitting there on its own home cell? */
+export function homeMask(s) {
+  const out = [];
+  for (let i = 0; i < s.cells.length; i++) out.push(s.cells[i] !== BLANK && s.cells[i] === i);
+  return out;
+}
+
+/** How many tiles are home (the gap is never counted). */
+export function lockedCount(s) {
+  let k = 0;
+  for (let i = 0; i < s.cells.length; i++) if (s.cells[i] !== BLANK && s.cells[i] === i) k += 1;
+  return k;
+}
+
+/** Tiles that could be home, i.e. n*n - 1. */
+export function tileCount(n) { const size = sizeOf(n); return size * size - 1; }
+
+/** Sum of every tile's distance from home. 0 == solved; the progress metric. */
+export function manhattan(s) {
+  let sum = 0;
+  for (let i = 0; i < s.cells.length; i++) {
+    const id = s.cells[i];
+    if (id === BLANK) continue;
+    sum += Math.abs(rowOf(s.n, i) - rowOf(s.n, id)) + Math.abs(colOf(s.n, i) - colOf(s.n, id));
+  }
+  return sum;
+}
+
+/** Inversions in the tile sequence (the gap is skipped, not counted as 0). */
+export function inversions(cells) {
+  const seq = cells.filter((v) => v !== BLANK);
+  let inv = 0;
+  for (let i = 0; i < seq.length; i++) for (let j = i + 1; j < seq.length; j++) if (seq[i] > seq[j]) inv += 1;
+  return inv;
+}
+
+/**
+ * THE PARITY INVARIANT. Half of all arrangements can never be solved; this is
+ * the test that keeps one off the board.
+ */
+export function isSolvable(cells, n) {
+  const size = sizeOf(n);
+  const inv = inversions(cells);
+  if (size % 2 === 1) return inv % 2 === 0;
+  const blankRow = Math.floor(cells.indexOf(BLANK) / size);
+  return (inv + blankRow) % 2 === 1;
+}
+
+/** Transpose the two lowest-index tiles: flips inversion parity, gap untouched. */
+export function repairParity(cells) {
+  const out = cells.slice();
+  const idx = [];
+  for (let i = 0; i < out.length && idx.length < 2; i++) if (out[i] !== BLANK) idx.push(i);
+  if (idx.length === 2) { const t = out[idx[0]]; out[idx[0]] = out[idx[1]]; out[idx[1]] = t; }
+  return out;
+}
+
+/**
+ * A seeded, ALWAYS-SOLVABLE scramble.
+ *
+ * @param {number} n
+ * @param {string} seedStr   the class seed, already scoped by the caller
+ * @param {Object=} opts
+ *   walk  0 = a full permutation (deep, tier 3-4); >0 = that many random legal
+ *         slides from solved, never undoing the slide before (shallow, tier 1-2)
+ *   minManhattan  re-walk until the board is at least this far from home
+ * @returns {number[]} cells
+ */
+export function scramble(n, seedStr, opts) {
+  const size = sizeOf(n);
+  const o = opts || {};
+  const rng = makeRng(String(seedStr == null ? '' : seedStr));
+  const walk = Math.max(0, Math.round(Number(o.walk) || 0));
+  const minMh = Number.isFinite(Number(o.minManhattan)) ? Number(o.minManhattan) : size;
+
+  let cells;
+  if (walk > 0) {
+    cells = walkScramble(size, rng, walk);
+  } else {
+    cells = permute(size, rng);
+    if (!isSolvable(cells, size)) cells = repairParity(cells);
+  }
+
+  /* A scramble that landed on (or beside) the solved board is a dead class:
+   * top it up with a seeded walk rather than re-rolling, so the draw order
+   * stays append-only. */
+  let guard = 0;
+  while (manhattan(createState(size, cells)) < minMh && guard < 8) {
+    guard += 1;
+    cells = walkScrambleFrom(size, rng, cells, size * size * 4);
+  }
+  return cells;
+}
+
+/** A seeded permutation of tiles + gap (Fisher-Yates on the whole cell array). */
+function permute(n, rng) {
+  const a = solvedCells(n);
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.min(i, Math.floor(rng() * (i + 1)));
+    const t = a[i]; a[i] = a[j]; a[j] = t;
+  }
+  return a;
+}
+
+function walkScramble(n, rng, steps) {
+  return walkScrambleFrom(n, rng, solvedCells(n), steps);
+}
+
+/** `steps` random legal slides, never immediately undoing the last one. */
+function walkScrambleFrom(n, rng, cells, steps) {
+  const s = createState(n, cells);
+  let last = -1;
+  for (let k = 0; k < steps; k++) {
+    const opts = neighbours(n, s.blank).filter((p) => p !== last);
+    const list = opts.length ? opts : neighbours(n, s.blank);
+    const pick = list[Math.min(list.length - 1, Math.floor(rng() * list.length))];
+    last = s.blank;
+    slide(s, pick);
+  }
+  return s.cells;
+}
+
+/** The class's board: scramble, then hand back a live state. */
+export function dealBoard(n, seedStr, opts) {
+  const size = sizeOf(n);
+  const cells = scramble(size, seedStr, opts);
+  return createState(size, cells);
+}
+
+export default {
+  BLANK, DIRS, sizeOf, sizeFromSetting, solvedCells, createState, cloneState, serialize,
+  neighbours, legalSlides, canSlide, dirOfSlide, dirBetween, slotForDir, slide, slideDir,
+  isSolved, homeMask, lockedCount, tileCount, manhattan, inversions, isSolvable, repairParity,
+  scramble, dealBoard, rowOf, colOf, posOf,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
@@ -1,0 +1,902 @@
+/* ============================================================================
+ * games/composure/casino.js - DECK II of the House Rules for the studio: THE
+ * FLOOR. The trickster (trickster.js) lies about the picture; the pressure
+ * (pressure.js) is what the room does to you as it comes together; this file
+ * LIGHTS the room and makes every lock pay out in light and sound.
+ *
+ *   STUDIO IDENTITY seeded per CLASS seed (Deck I): a hue pair on the
+ *                   violet->rose arc (~6% of studios leave the arc for a teal
+ *                   night), a wall archetype (plaster / linen / brick /
+ *                   velvet), a wood tone for the easel, where the lamp hangs,
+ *                   a breathing period, a drift period, a ken-burns period,
+ *                   a marquee phase. Painted as --cp-n-* props on the stage +
+ *                   a wall class; style.js consumes them with plain-studio
+ *                   fallbacks, so a disarmed floor changes nothing. Same seed,
+ *                   same studio; a retake sits in the identical room.
+ *   ASSET CHROME    (Deck VI) when a pool still is handed in (opts.assets),
+ *                   it becomes the wall's whisper (--cp-n-asset at ~.06) and
+ *                   the end card's paper - the player's own library is the
+ *                   wallpaper.
+ *   THE MARQUEE     a bulb-chase ring in the easel's WOOD band (z2 over the
+ *                   frame's ::before; the light mat swallowed it), round the canvas.
+ *                   TIMED: crawls lazily at heat 0, chases hungrily at heat 1,
+ *                   goes gold and frantic for the bell, flashes on a payout,
+ *                   sighs out on a dim-out. ZEN: no chase at all - the bulbs
+ *                   breathe together on the room's own breath (.g-cp-mq-zen).
+ *   SLIDE TICK      every legal slide pays a short whoosh (engine 'slide',
+ *                   level by heat, pitch by progress) and the easel leans a
+ *                   hair toward the move (--cp-lean-x/y on the frame, style.js
+ *                   composes + springs it back). Zen: the tick at half level,
+ *                   no lean.
+ *   PAYOUT LIGHT    a lock pays light: the marquee flashes, the lamp pulses,
+ *                   glints rise off the tile. THE STREAK: consecutive locks
+ *                   with no thrash between them climb a pitch ladder (+1
+ *                   semitone per link, cap +7 - the intake precedent) on the
+ *                   lock chime; a thrash is a muted thud and resets the
+ *                   ladder, never silence.
+ *   THE ALMOST      near-miss staging: a tile that skirts its own home - sat
+ *                   one cell off, slid, and is STILL one cell off - hums the
+ *                   canvas, shows the near-miss word (lexicon) and rises the
+ *                   near_miss cue. Cooldown 6s. Staging only; the ledger
+ *                   already decided, and no tile is ever moved by this file.
+ *   JACKPOT LADDER  MINOR when the lock count crosses a whole row of the
+ *                   board, MAJOR at half the pieces, ROYAL on the solve (the
+ *                   studio floods gold, the frame glows, a column of glints).
+ *                   Zen: the solve is a warm royal - the lamp comes up, no
+ *                   gold flood, no arpeggio stack.
+ *   DIM-OUT         the bell took the board: the rig sighs out instead of
+ *                   cutting, and a small muted wash cue plays - losses
+ *                   disguised, silence is where people stand up.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects index.js hands it AFTER its
+ *       own accounting; reads --r/--c/data-id/data-home off the tiles (never
+ *       writes them); writes nothing about moves, locks, time or grade.
+ *   II  input honest  - every node is pointer-events:none and lives on the
+ *       frame or the backdrop, never inside a tile; the lean is the frame's
+ *       (a 1.6deg perspective tilt, the Deep End precedent) and is cleared on
+ *       a deadline.
+ *   III never still   - the lamp breathes, the motes drift, the marquee crawls
+ *       (timed) or breathes (zen) even at heat 0.
+ *   IV  images > text - the only words this deck can show (the near-miss word,
+ *       the jackpot word, the solve word) come from the lexicon rows CORE
+ *       ships and live for < 700ms.
+ *   V   seeded        - per-tag mulberry32 streams off seed+'|cp-casino|<tag>'
+ *       (append-only tags; a new tag never shifts an old stream). No
+ *       Math.random anywhere.
+ *   VI  exits sacred  - capsOk false disarms the whole floor (no nodes, no
+ *       cues); reduced motion keeps a static dim lamp + marquee (style.js
+ *       kills the animations, this file skips the glints, the lean and the
+ *       flashes); the stage's .suspended rule freezes the chase; every timer
+ *       lives in the game's pause-aware registry AND a local set, so destroy()
+ *       cannot leak one.
+ *   VII strings      - cp_near_miss / cp_jackpot / cp_stamp_solved through
+ *       the t() this deck is handed; nothing else is rendered as text.
+ *
+ * ENGINE vs GAME-LOCAL: cues (audio_trigger) and the jackpot / near_miss
+ * ceremonies go through opts.engine (CORE's deckEngine weld - clickSafe
+ * forced, audio ceiling by tier, pitch passthrough; ceremony() is optional on
+ * that weld and skipped when absent). The light is game-local: it sits on the
+ * game's own geometry (the easel, the canvas), which no engine primitive
+ * knows. Node budget: backdrop layers (7) + marquee (1 + 4 bars) + overlay (1
+ * + the word) + live glints (<= MAX_GLINTS), all reused or budgeted.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const CP_CASINO = Object.freeze({
+  /* ---- the marquee --------------------------------------------------- */
+  MQ_T_SLOW: 3.0,               // chase period (s) at heat 0
+  MQ_T_FAST: 0.9,               // at heat 1
+  MQ_A_LO: 0.22,                // presence band
+  MQ_A_HI: 0.8,
+  MQ_T_BELL: 0.45,
+  MQ_A_BELL: 0.95,
+  MQ_A_ZEN: 0.34,               // zen: one calm presence, no chase
+  FLASH_MS: 700,
+  DEEP_MS: 1300,
+  /* ---- identity ------------------------------------------------------ */
+  OFF_ARC: 0.06,
+  HUE_ARC: Object.freeze([262, 345]),       // violet -> rose
+  HUE_OFF: Object.freeze([168, 200]),       // the teal night
+  WALLS: Object.freeze(['plaster', 'linen', 'brick', 'velvet']),
+  WOODS: Object.freeze(['#4a3224', '#5a3d2a', '#3a2a22', '#6b4a30', '#2f2420']),
+  BREATH_S: Object.freeze([5.5, 9.5]),
+  DRIFT_S: Object.freeze([18, 34]),
+  KB_S: Object.freeze([24, 38]),
+  LAMP_X: Object.freeze([28, 72]),          // % across the stage
+  LAMP_Y: Object.freeze([-14, -2]),
+  ASSET_ALPHA: 0.06,
+  /* ---- the payout ---------------------------------------------------- */
+  MAX_GLINTS: 36,
+  GLINT_LOCK: 5,
+  GLINT_JACK: 10,
+  GLINT_ROYAL: 26,
+  LEAN_MS: 240,
+  LEAN_MAG: 0.55,
+  /* ---- the sound ladder (engine audio_trigger, pitch = the streak) ---- */
+  SEMITONE_CAP: 7,
+  SLIDE_LEVEL: Object.freeze([0.14, 0.3]),  // by heat
+  LOCK_LEVEL: Object.freeze([0.3, 0.5]),    // by min(streak,8)/8
+  THRASH_LEVEL: 0.22,
+  ASSIST_LEVEL: 0.3,
+  JACK_LEVEL: 0.5,
+  NEAR_LEVEL: 0.3,
+  DIM_LEVEL: 0.25,
+  ZEN_MUL: 0.55,                 // zen: every cue at about half
+  /* ---- the almost ---------------------------------------------------- */
+  ALMOST_GAP_MS: 6000,
+  ALMOST_MS: 1300,
+  WORD_MS: 660,
+  /* ---- the jackpot ladder -------------------------------------------- */
+  MINOR_I: 0.35,
+  MAJOR_I: 0.65,
+  ROYAL_I: 1,
+  ROYAL_MS: 3400,
+  END_DIM_MS: 1400,
+  HEAT_REPAINT_STEP: 0.03,
+});
+
+const STYLE_ID = 'g-cp-casino-style';
+const STYLE_TEXT = `
+/* ---- CASINO (House Rules, Deck II) --------------------------------------- */
+/* THE MARQUEE: a bulb-chase frame hugging the canvas, inside the easel (on the
+   mat). Dots are gradients, the chase a background-position crawl. Pace
+   (--g-cp-mqt) and presence (--g-cp-mqa) ride the class heat from casino.js;
+   the bell and the royal turn it gold. ZEN (.g-cp-mq-zen): no chase - the bulbs
+   breathe together, slowly. pointer-events:none is LAW. */
+/* the bulb ring runs IN THE WOOD band (z2: over the easel's ::before, never over
+   the board, which is z1 and ends at the mat) - pink bulbs on dark wood read;
+   on the light mat they vanished (rig shot 04, 2026-08-23). */
+.g-cp-mq{position:absolute;left:50%;top:50%;z-index:2;pointer-events:none;
+  width:calc(var(--cp-board) + 2 * var(--cp-mat) + var(--cp-wood));height:calc(var(--cp-board) + 2 * var(--cp-mat) + var(--cp-wood));
+  transform:translate(-50%,-50%);border-radius:4px;
+  opacity:var(--g-cp-mqa,.26);transition:opacity .6s ease}
+.g-cp-mq i{position:absolute;display:block;
+  background-image:radial-gradient(circle, var(--cp-n-mq, hsl(var(--cp-hue-a),80%,74%)) 1.6px, transparent 2.6px)}
+.g-cp-mq .mq-t,.g-cp-mq .mq-b{left:0;right:0;height:6px;background-size:16px 6px;background-repeat:repeat-x}
+.g-cp-mq .mq-l,.g-cp-mq .mq-r{top:0;bottom:0;width:6px;background-size:6px 16px;background-repeat:repeat-y}
+.g-cp-mq .mq-t{top:0;animation:g-cp-mqx var(--g-cp-mqt,2s) linear infinite var(--g-cp-mqp,0s)}
+.g-cp-mq .mq-r{right:0;animation:g-cp-mqy var(--g-cp-mqt,2s) linear infinite var(--g-cp-mqp,0s)}
+.g-cp-mq .mq-b{bottom:0;animation:g-cp-mqxr var(--g-cp-mqt,2s) linear infinite var(--g-cp-mqp,0s)}
+.g-cp-mq .mq-l{left:0;animation:g-cp-mqyr var(--g-cp-mqt,2s) linear infinite var(--g-cp-mqp,0s)}
+@keyframes g-cp-mqx{to{background-position-x:16px}}
+@keyframes g-cp-mqxr{to{background-position-x:-16px}}
+@keyframes g-cp-mqy{to{background-position-y:16px}}
+@keyframes g-cp-mqyr{to{background-position-y:-16px}}
+.g-cp-mq.g-cp-mq-zen i{animation:g-cp-mqbreathe calc(var(--cp-breath) * 1.2) ease-in-out infinite alternate}
+@keyframes g-cp-mqbreathe{from{opacity:.4;filter:none}to{opacity:1;filter:drop-shadow(0 0 4px var(--cp-n-mq, hsl(var(--cp-hue-a),80%,74%)))}}
+.g-cp-mq.g-cp-mq-bell{--cp-n-mq:var(--gold);filter:drop-shadow(0 0 6px rgba(240,194,75,.75))}
+.g-cp-mq.g-cp-mq-flash{animation:g-cp-mqflash .6s ease-out 1}
+@keyframes g-cp-mqflash{
+  0%{opacity:1;filter:brightness(var(--g-cp-mqf,1.4)) drop-shadow(0 0 10px rgba(184,166,232,.9))}
+  100%{opacity:var(--g-cp-mqa,.26);filter:none}}
+.g-cp-mq.g-cp-mq-bell.g-cp-mq-flash{animation:g-cp-mqflashgold .6s ease-out 1}
+@keyframes g-cp-mqflashgold{
+  0%{opacity:1;filter:brightness(var(--g-cp-mqf,1.4)) drop-shadow(0 0 14px rgba(240,194,75,.95))}
+  100%{opacity:var(--g-cp-mqa,.26);filter:drop-shadow(0 0 6px rgba(240,194,75,.75))}}
+.g-cp-mq.g-cp-mq-out{opacity:0;transition:opacity 1.6s ease}
+/* THE OVERLAY: casino decoration above the board (glints, the word, the hum).
+   No pointer, ever. */
+.g-cp-cs{position:absolute;inset:0;z-index:5;pointer-events:none;overflow:visible}
+.g-cp-cs *{pointer-events:none}
+/* a glint: a spark born at a locked tile, rising, gone */
+.g-cp-glint{position:absolute;left:var(--x,50%);top:var(--y,50%);width:var(--s,6px);height:var(--s,6px);
+  margin:calc(var(--s,6px) * -.5) 0 0 calc(var(--s,6px) * -.5);border-radius:50%;
+  background:radial-gradient(circle, #fff, var(--cp-n-mq, hsl(var(--cp-hue-b),80%,78%)) 50%, transparent 72%);
+  box-shadow:0 0 8px var(--cp-n-mq, hsl(var(--cp-hue-b),80%,78%));
+  animation:g-cp-glint var(--d,1.1s) ease-out 1 forwards}
+@keyframes g-cp-glint{
+  0%{opacity:0;transform:translate(0,0) scale(.4)}
+  15%{opacity:1}
+  100%{opacity:0;transform:translate(var(--wx,0px), calc(var(--h,90px) * -1)) scale(1.1)}}
+/* the word: ALMOST / a jackpot line, under the canvas, gone in 600ms */
+.g-cp-cs-word{position:absolute;left:50%;top:100%;transform:translate(-50%,-40%);opacity:0;
+  font-family:var(--disp);font-weight:800;font-size:clamp(13px,2vmin,20px);letter-spacing:.22em;text-transform:uppercase;
+  color:hsl(var(--cp-hue-b),90%,84%);text-shadow:0 0 12px hsla(var(--cp-hue-b),90%,70%,.8);white-space:nowrap}
+.g-cp-cs-word.on{animation:g-cp-word .62s ease-out 1 forwards}
+.g-cp-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-cp-cs-word.gold{color:#ffe08a;text-shadow:0 0 14px rgba(240,194,75,.9)}
+@keyframes g-cp-word{0%{opacity:0;transform:translate(-50%,-30%) scale(.8)}18%{opacity:1;transform:translate(-50%,-40%) scale(1.06)}
+  70%{opacity:1;transform:translate(-50%,-44%) scale(1)}100%{opacity:0;transform:translate(-50%,-60%) scale(1)}}
+/* the hum: the canvas glows from inside for a beat (the almost / a jackpot) */
+.g-cp-cs::after{content:"";position:absolute;inset:-4px;border-radius:4px;opacity:0;
+  box-shadow:inset 0 0 60px hsla(var(--cp-hue-b),80%,70%,.55), 0 0 36px hsla(var(--cp-hue-b),80%,70%,.4)}
+.g-cp-cs.g-cp-hum::after{animation:g-cp-hum 1.3s ease-in-out 1}
+@keyframes g-cp-hum{0%{opacity:0}30%{opacity:.9}60%{opacity:.45}80%{opacity:.75}100%{opacity:0}}
+.g-cp-cs.g-cp-royal::after{opacity:1;
+  box-shadow:inset 0 0 80px color-mix(in srgb, var(--gold), transparent 40%), 0 0 60px color-mix(in srgb, var(--gold), transparent 45%);
+  animation:g-cp-royalhum 1.1s ease-in-out infinite alternate}
+@keyframes g-cp-royalhum{from{opacity:.6}to{opacity:1}}
+.g-cp-stage[data-mode="zen"] .g-cp-cs.g-cp-royal::after{
+  box-shadow:inset 0 0 60px hsla(36,80%,70%,.45), 0 0 40px hsla(36,80%,70%,.35)}
+/* reduced motion (both gates) */
+html.arc-reduced .g-cp-mq{opacity:.16}
+html.arc-reduced .g-cp-glint{opacity:0}
+html.arc-reduced .g-cp-cs-word.on{opacity:1;transition:opacity .5s ease}
+@media (prefers-reduced-motion: reduce){
+  .g-cp-mq{opacity:.16}
+  .g-cp-glint{opacity:0}
+  .g-cp-cs-word.on{opacity:1;transition:opacity .5s ease}
+}
+`;
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return true;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);
+    return true;
+  } catch (e) { return false; }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** The lock chime's pitch for a streak: +1 semitone per link, capped. Pure. */
+export function pitchForStreak(streak) {
+  const s = Math.max(0, Math.min(CP_CASINO.SEMITONE_CAP, (Number(streak) || 0) - 1));
+  return +Math.pow(2, s / 12).toFixed(4);
+}
+/** Which rung of the jackpot ladder a lock count reaches. Pure.
+ *  'minor' when the count crosses a whole row, 'major' at half the pieces,
+ *  null otherwise. The royal is the solve, not a count. */
+export function jackpotFor(prevCount, count, n) {
+  const size = Math.max(3, Math.min(5, Math.round(Number(n) || 3)));
+  const pieces = size * size - 1;
+  const a = Math.max(0, Number(prevCount) || 0);
+  const b = Math.max(0, Number(count) || 0);
+  if (b <= a) return null;
+  const half = Math.ceil(pieces / 2);
+  if (a < half && b >= half) return 'major';
+  if (Math.floor(b / size) > Math.floor(a / size) && b < pieces) return 'minor';
+  return null;
+}
+/** Did a tile skirt its home? Pure: one off before, still one off after, moved. */
+export function isAlmost(before, after, home) {
+  if (!before || !after || !home) return false;
+  if (before.r === after.r && before.c === after.c) return false;
+  const d0 = Math.abs(before.r - home.r) + Math.abs(before.c - home.c);
+  const d1 = Math.abs(after.r - home.r) + Math.abs(after.c - home.c);
+  return d0 === 1 && d1 === 1;
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+/** A tile's honest row/col, read (never written) off index's inline vars. */
+function gridOf(tile) {
+  if (!tile || !tile.style) return null;
+  try {
+    const r = parseFloat(tile.style.getPropertyValue('--r'));
+    const c = parseFloat(tile.style.getPropertyValue('--c'));
+    if (Number.isFinite(r) && Number.isFinite(c)) return { r, c };
+  } catch (e) { /* fall through */ }
+  return null;
+}
+/** A tile's home as row/col: data-home is the integer index (board.js). */
+function homeOf(tile, n) {
+  let raw = null;
+  try { raw = tile && tile.getAttribute ? tile.getAttribute('data-home') : null; } catch (e) { raw = null; }
+  if (raw == null) return null;
+  const s = String(raw);
+  if (s.indexOf(',') >= 0) {
+    const p = s.split(',');
+    const r = parseInt(p[0], 10); const c = parseInt(p[1], 10);
+    return Number.isFinite(r) && Number.isFinite(c) ? { r, c } : null;
+  }
+  const idx = parseInt(s, 10);
+  if (!Number.isFinite(idx) || !(n > 0)) return null;
+  return { r: Math.floor(idx / n), c: idx % n };
+}
+function attrNum(node, name, fallback) {
+  try { const v = Number(node.getAttribute(name)); return Number.isFinite(v) && v > 0 ? v : fallback; } catch (e) { return fallback; }
+}
+
+/**
+ * @param {Object} o
+ * @param {string}   o.seed      the class seed (retakes replay the studio)
+ * @param {number}   o.tier      1..4
+ * @param {Object}   o.stage     .g-cp-stage (identity props + classes land here)
+ * @param {Object}   o.board     .g-cp-board (geometry reference; tiles are read here)
+ * @param {Object=}  o.frame     .g-cp-frame (marquee + overlay host; board.parentNode if absent)
+ * @param {Object=}  o.hud       { moves, clock, locked, calm } chip elements (optional)
+ * @param {Object}   o.backdrop  .g-cp-backdrop (the lighting layers)
+ * @param {Object}   o.timers    {after(ms,fn)->id, every?, clear|cancel(id)} pause-aware
+ * @param {boolean}  o.reduced   reduced motion
+ * @param {boolean}  o.capsOk    false when bgIntensity is capped to 0
+ * @param {Function=} o.t        ctx.lexicon (optional; English fallbacks here)
+ * @param {Object=}  o.engine    CORE's deckEngine {fire, sustain, stop, channels, ceremony?}
+ * @param {Object=}  o.assets    {next(kind)} live reader (Deck VI asset chrome)
+ * @param {string=}  o.mode      'timed' | 'zen' (else read off stage data-mode)
+ * @param {Function=} o.log
+ */
+export function createCpCasino(o) {
+  const opts = o || {};
+  const C = CP_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : (k, f) => (f == null ? k : f);
+  const reduced = !!opts.reduced;
+  const armed = !!opts.capsOk && !!opts.stage && !!opts.board && !!opts.backdrop
+    && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  const eng = opts.engine || {};
+  const hud = opts.hud || {};
+  const frame = opts.frame || (opts.board && opts.board.parentNode) || opts.stage;
+  let mode = String(opts.mode || '').toLowerCase();
+  if (mode !== 'zen' && mode !== 'timed') {
+    try { mode = String(opts.stage.getAttribute('data-mode') || 'timed').toLowerCase() === 'zen' ? 'zen' : 'timed'; } catch (e) { mode = 'timed'; }
+  }
+  const zen = mode === 'zen';
+
+  /* timers: the game's registry (pause-aware) + a local set so destroy() can
+     drop every one of ours without knowing the registry's shape. */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+
+  const seedBase = String(opts.seed || 'cp') + '|cp-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, flashes: 0, words: 0, glints: 0, slides: 0, locks: 0, thrashes: 0, assists: 0 };
+  const jackLog = [];
+  function cue(name, level, extra) {
+    if (!armed || destroyed) return;
+    counts.cues += 1;
+    const lv = clamp01(level) * (zen ? C.ZEN_MUL : 1);
+    try {
+      if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed || destroyed) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+
+  let destroyed = false;
+  let started = false;
+  let mq = null;
+  let cs = null;
+  let word = null;
+  const layers = {};
+  const props = new Set();
+  const stageClasses = new Set();
+  let identity = null;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let bellOn = false;
+  let royalOn = false;
+  let outOn = false;
+  let streak = 0;
+  let bestStreak = 0;
+  let lastCount = 0;
+  let glints = 0;
+  let flashTimer = 0; let deepTimer = 0; let humTimer = 0; let wordTimer = 0; let leanTimer = 0; let royalTimer = 0;
+  let lastAlmostAt = -1e9;
+  let almosts = 0;
+  let assetUrl = null;
+  const pos = new Map();           // data-id -> {r,c} after the last slide (read-only snapshot)
+
+  function nowMs() {
+    try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+    return Date.now();
+  }
+
+  /* ---------------------------------------------------- the studio identity */
+  function setProp(k, v) {
+    if (!opts.stage || !opts.stage.style) return;
+    try { opts.stage.style.setProperty(k, v); props.add(k); } catch (e) { /* ignore */ }
+  }
+  function stageClass(name, on) {
+    if (!opts.stage || !opts.stage.classList) return;
+    try {
+      if (on) { opts.stage.classList.add(name); stageClasses.add(name); }
+      else { opts.stage.classList.remove(name); stageClasses.delete(name); }
+    } catch (e) { /* ignore */ }
+  }
+
+  /** Draw the identity in a FIXED order (append-only, or every studio reskins). */
+  function drawIdentity() {
+    const offArc = roll('arc') < C.OFF_ARC;
+    let hueA; let hueB;
+    if (offArc) {
+      hueA = lerp(C.HUE_OFF, roll('hue'));
+      hueB = Math.max(160, Math.min(205, hueA + (roll('hue2') < 0.5 ? -1 : 1) * (8 + roll('hue2') * 12)));
+    } else {
+      hueA = lerp(C.HUE_ARC, roll('hue'));
+      hueB = Math.max(250, Math.min(350, hueA + (roll('hue2') < 0.5 ? -1 : 1) * (16 + roll('hue2') * 24)));
+    }
+    const wall = C.WALLS[Math.min(C.WALLS.length - 1, Math.floor(roll('wall') * C.WALLS.length))];
+    const wood = C.WOODS[Math.min(C.WOODS.length - 1, Math.floor(roll('wood') * C.WOODS.length))];
+    const breath = lerp(C.BREATH_S, roll('breath'));
+    const drift = lerp(C.DRIFT_S, roll('drift'));
+    const kb = lerp(C.KB_S, roll('kb'));
+    const lampX = lerp(C.LAMP_X, roll('lamp'));
+    const lampY = lerp(C.LAMP_Y, roll('lamp'));
+    const mqPhase = roll('mq-phase') * -3;
+    const motes = 0.3 + roll('motes') * 0.35;
+    identity = {
+      offArc, hueA: Math.round(hueA), hueB: Math.round(hueB), wall, wood,
+      breath: +breath.toFixed(1), drift: +drift.toFixed(1), kb: +kb.toFixed(1),
+      lampX: Math.round(lampX), lampY: Math.round(lampY), mqPhase: +mqPhase.toFixed(2), motes: +motes.toFixed(2),
+    };
+  }
+
+  function nextAsset() {
+    const a = opts.assets;
+    if (!a || typeof a.next !== 'function') return null;
+    try {
+      const got = a.next('still') || a.next('loop');
+      return got && got.url ? String(got.url) : null;
+    } catch (e) { return null; }
+  }
+
+  function dressStudio() {
+    if (!identity) drawIdentity();
+    const id = identity;
+    setProp('--cp-n-hue-a', String(id.hueA));
+    setProp('--cp-n-hue-b', String(id.hueB));
+    setProp('--cp-n-mq', 'hsl(' + id.hueA + ',80%,74%)');
+    setProp('--cp-n-wood', id.wood);
+    setProp('--cp-n-breath', id.breath + 's');
+    setProp('--cp-n-drift', id.drift + 's');
+    setProp('--cp-n-kb', id.kb + 's');
+    setProp('--cp-n-lamp-x', id.lampX + '%');
+    setProp('--cp-n-lamp-y', id.lampY + '%');
+    setProp('--cp-n-a-motes', String(id.motes));
+    setProp('--cp-n-lamp', zen ? '0.82' : '0.7');
+    setProp('--cp-n-dark', '0');
+    stageClass('g-cp-wall-' + id.wall, true);
+    // Deck VI asset chrome: the player's own still as the wall's whisper
+    if (!assetUrl) {
+      assetUrl = nextAsset();
+      if (assetUrl) {
+        const safe = assetUrl.replace(/["\\]/g, '');
+        setProp('--cp-n-asset', 'url("' + safe + '")');
+        setProp('--cp-n-a-asset', String(C.ASSET_ALPHA));
+      }
+    }
+    say('casino: studio dressed (hue ' + id.hueA + '/' + id.hueB + (id.offArc ? ' OFF-ARC' : '')
+      + ', ' + id.wall + ' wall, lamp ' + id.lampX + '%' + (zen ? ', ZEN' : '') + (assetUrl ? ', asset chrome' : '') + ')');
+  }
+
+  /* ------------------------------------------------------------- the DOM */
+  function mountBackdrop() {
+    const host = opts.backdrop;
+    if (!host || !host.appendChild) return;
+    for (const name of ['wall', 'lamp', 'motes', 'dark', 'flash', 'royal', 'vig']) {
+      const n = el('div', 'g-cp-bd g-cp-bd-' + name);
+      if (!n) continue;
+      layers[name] = n;
+      host.appendChild(n);
+    }
+  }
+  function mountMarquee() {
+    if (mq || !frame || !frame.appendChild) return;
+    mq = el('div', 'g-cp-mq' + (zen ? ' g-cp-mq-zen' : ''));
+    if (!mq) return;
+    for (const cls of ['mq-t', 'mq-r', 'mq-b', 'mq-l']) {
+      const bar = el('i', cls);
+      if (bar) mq.appendChild(bar);
+    }
+    if (mq.style && identity) mq.style.setProperty('--g-cp-mqp', identity.mqPhase + 's');
+    // the marquee sits UNDER the board (z0 vs the board's z1): insert first
+    try { if (typeof frame.insertBefore === 'function' && frame.firstChild) frame.insertBefore(mq, frame.firstChild); else frame.appendChild(mq); }
+    catch (e) { try { frame.appendChild(mq); } catch (e2) { mq = null; } }
+  }
+  function mountOverlay() {
+    if (cs || !frame || !frame.appendChild) return;
+    cs = el('div', 'g-cp-cs');
+    if (!cs) return;
+    frame.appendChild(cs);
+    word = el('span', 'g-cp-cs-word');
+    if (word && cs.appendChild) cs.appendChild(word);
+  }
+
+  /* ------------------------------------------------------------ the light */
+  function paintMarquee(force) {
+    if (!mq || !mq.style) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    let tS; let a;
+    if (zen) { tS = C.MQ_T_SLOW; a = C.MQ_A_ZEN; }
+    else {
+      tS = bellOn ? C.MQ_T_BELL : (C.MQ_T_SLOW - (C.MQ_T_SLOW - C.MQ_T_FAST) * heat);
+      a = bellOn ? C.MQ_A_BELL : C.MQ_A_LO + (C.MQ_A_HI - C.MQ_A_LO) * heat;
+    }
+    if (outOn) a = 0;
+    mq.style.setProperty('--g-cp-mqt', tS.toFixed(2) + 's');
+    mq.style.setProperty('--g-cp-mqa', a.toFixed(2));
+  }
+  function flashMarquee(strength) {
+    if (!mq || !mq.classList || reduced) return;
+    counts.flashes += 1;
+    mq.classList.remove('g-cp-mq-flash');
+    if (typeof mq.offsetWidth === 'number') void mq.offsetWidth;
+    mq.style.setProperty('--g-cp-mqf', String(Math.max(1, Math.min(2.2, strength))));
+    mq.classList.add('g-cp-mq-flash');
+    if (flashTimer) cancel(flashTimer);
+    flashTimer = after(C.FLASH_MS, () => { flashTimer = 0; if (mq && mq.classList) mq.classList.remove('g-cp-mq-flash'); });
+  }
+  function pulseLamp(strength, deep) {
+    const f = layers.flash;
+    if (!f || !f.classList || reduced) return;
+    f.classList.remove('g-cp-on', 'g-cp-deep');
+    if (typeof f.offsetWidth === 'number') void f.offsetWidth;
+    setProp('--cp-n-pay', clamp01(strength).toFixed(2));
+    f.classList.add(deep ? 'g-cp-deep' : 'g-cp-on');
+    if (deepTimer) cancel(deepTimer);
+    deepTimer = after(deep ? C.DEEP_MS : C.FLASH_MS, () => { deepTimer = 0; if (f.classList) f.classList.remove('g-cp-on', 'g-cp-deep'); });
+  }
+  function hum() {
+    if (!cs || !cs.classList) return;
+    cs.classList.remove('g-cp-hum');
+    if (typeof cs.offsetWidth === 'number') void cs.offsetWidth;
+    cs.classList.add('g-cp-hum');
+    if (humTimer) cancel(humTimer);
+    humTimer = after(C.ALMOST_MS, () => { humTimer = 0; if (cs && cs.classList) cs.classList.remove('g-cp-hum'); });
+  }
+  function showWord(key, fallback, tone) {
+    if (!word) return;
+    counts.words += 1;
+    try { word.textContent = t(key, fallback); } catch (e) { return; }
+    word.className = 'g-cp-cs-word' + (tone ? ' ' + tone : '');
+    if (typeof word.offsetWidth === 'number') void word.offsetWidth;
+    if (word.classList) word.classList.add('on');
+    if (wordTimer) cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 40, () => { wordTimer = 0; if (word && word.classList) word.classList.remove('on'); });
+  }
+  function leanFrame(x, y, ms) {
+    if (!frame || !frame.style || reduced || zen) return;
+    try {
+      frame.style.setProperty('--cp-lean-x', x.toFixed(2));
+      frame.style.setProperty('--cp-lean-y', y.toFixed(2));
+    } catch (e) { return; }
+    if (leanTimer) cancel(leanTimer);
+    leanTimer = after(ms, () => { leanTimer = 0; clearLean(); });
+  }
+  function clearLean() {
+    if (!frame || !frame.style) return;
+    try { frame.style.removeProperty('--cp-lean-x'); frame.style.removeProperty('--cp-lean-y'); } catch (e) { /* ignore */ }
+  }
+
+  /* ------------------------------------------------------------- glints */
+  /** Frame-relative centre of a tile (or of the board when none). */
+  function anchorOf(tileEl) {
+    const fr = rectOf(frame);
+    if (!fr) return null;
+    const tr = rectOf(tileEl) || rectOf(opts.board);
+    if (!tr || !tr.width) return { x: fr.width / 2, y: fr.height / 2, w: 0, h: 0 };
+    return { x: tr.left - fr.left + tr.width / 2, y: tr.top - fr.top + tr.height / 2, w: tr.width, h: tr.height };
+  }
+  function glintsAt(x, y, count, spread, gold) {
+    if (!cs || !cs.appendChild || reduced) return 0;
+    let made = 0;
+    for (let i = 0; i < count; i++) {
+      if (glints >= C.MAX_GLINTS) break;
+      const g = el('i', 'g-cp-glint');
+      if (!g || !g.style) break;
+      const s = 3 + roll('gl-s') * 5;
+      const d = 0.8 + roll('gl-d') * 0.9;
+      const gx = x + (roll('gl-x') - 0.5) * (spread || 40);
+      const gy = y + (roll('gl-y') - 0.5) * ((spread || 40) * 0.4);
+      g.style.setProperty('--x', gx.toFixed(0) + 'px');
+      g.style.setProperty('--y', gy.toFixed(0) + 'px');
+      g.style.setProperty('--s', s.toFixed(1) + 'px');
+      g.style.setProperty('--d', d.toFixed(2) + 's');
+      g.style.setProperty('--h', (40 + roll('gl-h') * 70).toFixed(0) + 'px');
+      g.style.setProperty('--wx', ((roll('gl-w') - 0.5) * 30).toFixed(0) + 'px');
+      if (gold) g.style.setProperty('--cp-n-mq', 'var(--gold)');
+      cs.appendChild(g);
+      glints += 1; made += 1; counts.glints += 1;
+      after(d * 1000 + 120, () => { glints = Math.max(0, glints - 1); try { g.remove(); } catch (e) { /* ignore */ } });
+    }
+    return made;
+  }
+
+  /* ----------------------------------------------------------- the tiles */
+  function tileById(id) {
+    if (!opts.board || typeof opts.board.querySelector !== 'function') return null;
+    try { return opts.board.querySelector('.g-cp-tile[data-id="' + String(id).replace(/["\\]/g, '') + '"]'); } catch (e) { return null; }
+  }
+  function allTiles() {
+    if (!opts.board || typeof opts.board.querySelectorAll !== 'function') return [];
+    try { return Array.from(opts.board.querySelectorAll('.g-cp-tile')); } catch (e) { return []; }
+  }
+  function gridN() {
+    let n = 0;
+    if (opts.stage) n = attrNum(opts.stage, 'data-n', 0);
+    if (!n && opts.board && opts.board.style) { try { n = parseInt(opts.board.style.getPropertyValue('--cp-n'), 10) || 0; } catch (e) { n = 0; } }
+    return n || 3;
+  }
+  /** grid size from either shape: 3..5 = the grid, 8/15/24 (anything > 5) = the tile count. */
+  function gridSizeArg(n) {
+    const v = Math.round(Number(n) || 0);
+    if (v > 5) { const root = Math.round(Math.sqrt(v + 1)); return Math.max(3, Math.min(5, root)); }
+    if (v >= 3) return Math.min(5, v);
+    return Math.max(3, Math.min(5, gridN()));
+  }
+  function snapshot() {
+    const next = new Map();
+    for (const tile of allTiles()) {
+      let id = null;
+      try { id = tile.getAttribute('data-id'); } catch (e) { id = null; }
+      const g = gridOf(tile);
+      if (id != null && g) next.set(String(id), g);
+    }
+    pos.clear();
+    for (const [k, v] of next) pos.set(k, v);
+  }
+
+  /* ------------------------------------------------------------ the ladder */
+  function jackpot(kind, intensity, tileEl) {
+    counts.jackpots += 1;
+    jackLog.push(kind);
+    const a = anchorOf(tileEl);
+    if (zen) {
+      // zen: a warm pulse and a soft chime; no flood, no word
+      pulseLamp(0.35, false);
+      cue('streak', C.JACK_LEVEL * 0.8, { pitch: 1 });
+      if (a) glintsAt(a.x, a.y, C.GLINT_JACK, (a.w || 60) * 0.8, false);
+      return;
+    }
+    ceremony('jackpot', { intensity });
+    cue('jackpot', C.JACK_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashMarquee(1.4 + 0.6 * intensity);
+    pulseLamp(0.45 + 0.35 * intensity, kind === 'major');
+    hum();
+    showWord('cp_jackpot', 'JACKPOT', kind === 'major' ? 'gold' : '');
+    if (a) glintsAt(a.x, a.y, C.GLINT_JACK + (kind === 'major' ? 4 : 0), (a.w || 60) * 0.9, kind === 'major');
+  }
+  function nearMiss(tileEl) {
+    counts.nearMisses += 1;
+    almosts += 1;
+    ceremony('near_miss', { intensity: 0.55 });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: 0.9 });
+    hum();
+    showWord('cp_near_miss', 'SO CLOSE', 'lav');
+    const a = anchorOf(tileEl);
+    if (a && !zen) glintsAt(a.x, a.y, 3, (a.w || 60) * 0.6, false);
+  }
+
+  /* ---------------------------------------------------------------- api */
+  const api = {
+    /** Dress the studio + light the frame. Call when play arms. */
+    start() {
+      if (!armed || destroyed) { say('casino: disarmed'); return; }
+      if (started) return;
+      started = true;
+      ensureStyle();
+      drawIdentity();
+      mountBackdrop();
+      mountMarquee();
+      mountOverlay();
+      dressStudio();
+      paintMarquee(true);
+      snapshot();
+      say('casino: floor lit, ' + Object.keys(layers).length + ' layers' + (zen ? ' (zen: quiet floor)' : ''));
+    },
+
+    /** Ride the class's own heat curve. index.js calls from its heat(). */
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started) paintMarquee(false);
+    },
+
+    /**
+     * Every legal slide, AFTER index.js has written --r/--c. The tick, the
+     * lean (from the tile's own travel, read off the snapshot) and the almost.
+     */
+    slide(ev) {
+      if (!armed || destroyed || !started) return;
+      const e = ev || {};
+      counts.slides += 1;
+      const tile = e.id == null ? null : tileById(e.id);
+      const before = e.id == null ? null : pos.get(String(e.id)) || null;
+      const now = tile ? gridOf(tile) : null;
+      // the tick: a short whoosh, level by heat, pitch creeping up with progress
+      const n = gridN();
+      const locked = Math.max(0, Number(lastCount) || 0);
+      const frac = clamp01(locked / Math.max(1, n * n - 1));
+      cue('slide', lerp(C.SLIDE_LEVEL, heat), { pitch: +(0.9 + 0.25 * frac).toFixed(3) });
+      if (before && now) {
+        const dx = Math.sign(now.c - before.c);
+        const dy = Math.sign(now.r - before.r);
+        if (dx || dy) leanFrame(dx * C.LEAN_MAG, dy * C.LEAN_MAG, C.LEAN_MS);
+        // THE ALMOST: skirted its home and is still one off (and not locked)
+        if (!e.locked && tile) {
+          const home = homeOf(tile, n);
+          const tNow = nowMs();
+          if (home && isAlmost(before, now, home) && tNow - lastAlmostAt >= C.ALMOST_GAP_MS) {
+            lastAlmostAt = tNow;
+            nearMiss(tile);
+          }
+        }
+      }
+      snapshot();
+    },
+
+    /** A tile (or more) sits home: the payout, the streak ladder, the jackpot rungs. */
+    lock(count, n) {
+      if (!armed || destroyed || !started) return;
+      const cnt = Math.max(0, Number(count) || 0);
+      // index.js hands the TILE COUNT (n*n-1 = 8/15/24) as the second argument; an older
+      // caller may hand the grid size. Anything above 5 is a tile count - take its root.
+      const size = gridSizeArg(n);
+      const prev = lastCount;
+      lastCount = cnt;
+      if (cnt <= prev) return;           // a lock count that fell is not a payout
+      counts.locks += 1;
+      streak += 1;
+      bestStreak = Math.max(bestStreak, streak);
+      cue('pop', lerp(C.LOCK_LEVEL, Math.min(8, streak) / 8), { pitch: pitchForStreak(streak) });
+      flashMarquee(1 + 0.1 * Math.min(6, streak));
+      pulseLamp(0.25 + 0.06 * Math.min(6, streak), false);
+      // glints rise off the freshest locked tile (the one not yet snapshotted as home)
+      let tileEl = null;
+      try {
+        const lockedTiles = allTiles().filter((x) => x.classList && x.classList.contains('is-locked'));
+        tileEl = lockedTiles.length ? lockedTiles[lockedTiles.length - 1] : null;
+      } catch (e) { tileEl = null; }
+      const a = anchorOf(tileEl);
+      if (a) glintsAt(a.x, a.y, C.GLINT_LOCK + Math.min(4, streak), (a.w || 60) * 0.7, false);
+      if (streak >= 3 && !zen) cue('streak', 0.3, { pitch: pitchForStreak(streak) });
+      const jk = jackpotFor(prev, cnt, size);
+      if (jk === 'minor') jackpot('minor', C.MINOR_I, tileEl);
+      else if (jk === 'major') jackpot('major', C.MAJOR_I, tileEl);
+    },
+
+    /** A panic move (a backtrack or a thrash under a wash): the ladder resets. */
+    thrash() {
+      if (!armed || destroyed || !started) return;
+      counts.thrashes += 1;
+      streak = 0;
+      cue('bump', C.THRASH_LEVEL, { pitch: 0.7 });     // a muted thud, never silence
+      if (!reduced && frame && frame.style && !zen) leanFrame((roll('thrash') < 0.5 ? -1 : 1) * 0.4, 0, 160);
+    },
+
+    /** The rescue lit a piece: a soft whisper, the lamp dips and returns. */
+    assist() {
+      if (!armed || destroyed || !started) return;
+      counts.assists += 1;
+      streak = 0;
+      cue('whisper', C.ASSIST_LEVEL, { pitch: 0.85 });
+      setProp('--cp-n-lamp', zen ? '0.62' : '0.5');
+      after(900, () => setProp('--cp-n-lamp', zen ? '0.82' : '0.7'));
+    },
+
+    /** The picture is whole: THE ROYAL. Holds until dimOut/stop. */
+    solved() {
+      if (!armed || destroyed || !started) return;
+      royalOn = true;
+      counts.jackpots += 1;
+      jackLog.push('royal');
+      stageClass('g-cp-royal', true);
+      if (cs && cs.classList) cs.classList.add('g-cp-royal');
+      const b = rectOf(opts.board); const fr = rectOf(frame);
+      const cx = b && fr ? b.left - fr.left + b.width / 2 : null;
+      const cy = b && fr ? b.top - fr.top + b.height * 0.9 : null;
+      if (zen) {
+        // the warm royal: the lamp comes up, one soft chime, a few glints
+        setProp('--cp-n-lamp', '1');
+        cue('streak', C.JACK_LEVEL, { pitch: 1.1 });
+        after(320, () => cue('stamp', 0.35, { pitch: 1 }));
+        pulseLamp(0.5, true);
+        if (cx != null) glintsAt(cx, cy, 10, b.width * 0.8, false);
+        say('casino: zen royal (warm)');
+        return;
+      }
+      bellOn = true;
+      if (mq && mq.classList) mq.classList.add('g-cp-mq-bell');
+      paintMarquee(true);
+      flashMarquee(2.2);
+      pulseLamp(1, true);
+      hum();
+      ceremony('jackpot', { intensity: C.ROYAL_I });
+      cue('jackpot', C.JACK_LEVEL, { pitch: 1.2 });
+      after(260, () => cue('jackpot', C.JACK_LEVEL, { pitch: 1.5 }));
+      after(520, () => cue('stamp', 0.5, { pitch: 1 }));
+      showWord('cp_stamp_solved', 'COMPOSED', 'gold');
+      if (cx != null) glintsAt(cx, cy, C.GLINT_ROYAL, b.width, true);
+      if (royalTimer) cancel(royalTimer);
+      royalTimer = after(C.ROYAL_MS, () => { royalTimer = 0; if (cs && cs.classList) cs.classList.remove('g-cp-royal'); });
+      say('casino: ROYAL');
+    },
+
+    /** The last 20s: gold frame, frantic chase, the room darkens a stop. */
+    bell(on) {
+      bellOn = !!on;
+      if (mq && mq.classList) { if (bellOn) mq.classList.add('g-cp-mq-bell'); else mq.classList.remove('g-cp-mq-bell'); }
+      stageClass('g-cp-bell', bellOn);
+      setProp('--cp-n-dark', bellOn ? '0.35' : '0');
+      paintMarquee(true);
+    },
+
+    /** The bell took the board: the rig sighs out instead of cutting. */
+    dimOut() {
+      outOn = true;
+      bellOn = false;
+      royalOn = false;
+      clearLean();
+      if (mq && mq.classList) { mq.classList.remove('g-cp-mq-bell', 'g-cp-mq-flash'); mq.classList.add('g-cp-mq-out'); }
+      if (cs && cs.classList) cs.classList.remove('g-cp-royal', 'g-cp-hum');
+      stageClass('g-cp-royal', false);
+      stageClass('g-cp-bell', false);
+      stageClass('g-cp-out', true);
+      setProp('--cp-n-dark', '0.6');
+      // losses disguised: a dim payout, never silence
+      pulseLamp(0.2, true);
+      cue('wash', C.DIM_LEVEL, { pitch: 0.9 });
+      paintMarquee(true);
+    },
+
+    /** The class is over; nothing may pulse again. */
+    stop() {
+      for (const id of [flashTimer, deepTimer, humTimer, wordTimer, leanTimer, royalTimer]) if (id) cancel(id);
+      flashTimer = 0; deepTimer = 0; humTimer = 0; wordTimer = 0; leanTimer = 0; royalTimer = 0;
+      clearLean();
+      if (mq && mq.classList) mq.classList.remove('g-cp-mq-flash');
+      if (cs && cs.classList) cs.classList.remove('g-cp-hum');
+    },
+
+    destroy() {
+      destroyed = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      clearLean();
+      if (mq) { try { mq.remove(); } catch (e) { /* ignore */ } }
+      if (cs) { try { cs.remove(); } catch (e) { /* ignore */ } }
+      for (const k of Object.keys(layers)) { try { layers[k].remove(); } catch (e) { /* ignore */ } delete layers[k]; }
+      mq = null; cs = null; word = null; glints = 0;
+      for (const name of Array.from(stageClasses)) stageClass(name, false);
+      if (opts.stage && opts.stage.style) {
+        for (const k of props) { try { opts.stage.style.removeProperty(k); } catch (e) { /* ignore */ } }
+      }
+      props.clear();
+      pos.clear();
+    },
+
+    /** Diagnostics for the harness; not part of the module contract. */
+    diagnostics() {
+      return {
+        armed, started, zen, mode, marquee: !!mq, overlay: !!cs, layers: Object.keys(layers).length,
+        bell: bellOn, royal: royalOn, out: outOn, heat, identity, assetUrl,
+        streak, bestStreak, lastCount, glints, almosts,
+        counts: Object.assign({}, counts), jackpots: jackLog.slice(), timers: live.size,
+      };
+    },
+  };
+  return api;
+}
+
+export default createCpCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/grade.js
@@ -1,0 +1,333 @@
+/* ============================================================================
+ * games/composure/grade.js - the COMPOSURE composite, the PLAYTEST dials and
+ * the seeded class plan. PURE: no DOM, no clock, no ctx.
+ *
+ * A game never grades itself. This file turns the class's honest ledger into a
+ * 0..1 composite, one declared hard gate and the flavour XP; the SHELL maps
+ * that to S/A/B/C through core/grades.js and applies every cap (peek is the
+ * shell's, always - CLAUDE.md trap 9).
+ *
+ * THE COMPOSITE. Composure, not speed:
+ *   .45 PROGRESS   how much of the picture came back. Solved = 1. Otherwise a
+ *                  blend of distance-closed (manhattan against the scramble's
+ *                  own starting distance) and pieces-home, so a player who
+ *                  reorganised the board without locking anything still scores
+ *                  what they actually did.
+ *   .25 PACE       progress against the BASELINE SOLVER's move count (par):
+ *                  clamp(progress x par / moves). Solving in par flat = 1;
+ *                  solving in twice par = .5; being ahead of the baseline's
+ *                  rate part-way through also reads 1. There is no clock term
+ *                  anywhere - a 120s class already ends when the bell says so.
+ *   .30 CALM       1 minus the panic rate: backtracks (a slide that undoes the
+ *                  slide before it) and THRASH (a backtrack made while a wash
+ *                  was burying the board) per move. Thrash costs double - the
+ *                  whole game is "keep sliding from memory".
+ *   x .92 ^ assists   each skill-floor rescue EPISODE taxes the composite. A
+ *                  rescue also fails the declared sGate, so the shell caps the
+ *                  class at A whatever this number says. Both, deliberately:
+ *                  the tax is honest, the gate is the promise.
+ *
+ * PAR. `parMoves = ceil(baseline x PAR_MULT[tier])`, never below the baseline
+ * itself. The baseline comes from solver.js, which is OPTIMAL on 3x3 and a
+ * careful-human reduction on 4x4/5x5 - so par is a real number about this
+ * scramble, not a table someone guessed. PAR_MULT tightens with the year.
+ *
+ * ZEN never reaches any of this: `ctx.endClass({zen:true, ...})` short-circuits
+ * to 'pass' in core/grades.js (DECISIONS #1).
+ *
+ * THE PLAN. `buildPlan()` deals the class's effect schedule off the seed
+ * (Law V, append-only draw order): the wash windows that bury the board, the
+ * sub_flash cadence, the heat ceiling and the audio ceiling. Dials first,
+ * difficulty second - tiers 1-3 only raise dials; the board itself grows at
+ * tier 3 and the scramble deepens at 3-4.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+/* --------------------------------------------------------------------------
+ * THE CONSTANTS BLOCK (playtest-tunable, one place)
+ * ----------------------------------------------------------------------- */
+export const PLAYTEST = Object.freeze({
+  /* ---- the board ---- */
+  /** Timed grid by grade tier (the contract: 1-2 -> 3x3, 3-4 -> 4x4). */
+  GRID_BY_TIER: Object.freeze({ 1: 3, 2: 3, 3: 4, 4: 4 }),
+  /** Scramble depth. >0 = that many seeded legal slides (shallow); 0 = a full
+   *  seeded permutation with a parity repair (deep). Classic difficulty, so
+   *  it only moves at the top tiers. */
+  SCRAMBLE_WALK: Object.freeze({ 1: 40, 2: 90, 3: 0, 4: 0 }),
+  /** Zen is always the deep deal - a zen board the player chose is not a test. */
+  ZEN_WALK: 0,
+
+  /* ---- par ---- */
+  PAR_MULT: Object.freeze({ 1: 2.2, 2: 1.9, 3: 1.7, 4: 1.5 }),
+  /** Used only when the solver could not answer (par unknown): moves-per-tile. */
+  PAR_FALLBACK_PER_TILE: 7,
+
+  /* ---- the composite ---- */
+  W_PROGRESS: 0.45,
+  W_PACE: 0.25,
+  W_CALM: 0.30,
+  /** Inside PROGRESS: distance-closed vs pieces-home. */
+  PROGRESS_MH_SHARE: 0.65,
+  /** Panic budget: this share of moves may be backtracks before CALM hits 0. */
+  CALM_TOL: 0.35,
+  BACKTRACK_COST: 1,
+  THRASH_COST: 2,
+  /** Nobody is judged on a panic rate out of three moves. */
+  CALM_MIN_MOVES: 8,
+  ASSIST_TAX: 0.92,
+
+  /* ---- flavour XP (game-owned; the XP TABLE itself is C#'s) ---- */
+  FLAVOR_SOLVE: 5,
+  FLAVOR_BEST: 5,
+  FLAVOR_UNDER_PAR: 5,
+  FLAVOR_CAP: 15,
+
+  /* ---- heat ---- */
+  HEAT_CAP: Object.freeze({ 1: 0.45, 2: 0.65, 3: 0.85, 4: 1.0 }),
+  HEAT_FLOOR: 0.12,
+  HEAT_GAMMA: 1.1,
+  /** Zen breathes: the whole ladder is halved and never reaches the ceiling. */
+  ZEN_HEAT_MULT: 0.5,
+
+  /* ---- audio ---- */
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+
+  /* ---- the washes (the class's own effect, CORE-fired) ---- */
+  WASH_COUNT: Object.freeze({ 1: 1, 2: 3, 3: 5, 4: 7 }),
+  WASH_MS: Object.freeze({ 1: 2600, 2: 3400, 3: 4200, 4: 5000 }),
+  WASH_ALPHA: Object.freeze({ 1: 0.18, 2: 0.28, 3: 0.38, 4: 0.5 }),
+  /** DELIBERATELY NOT 'spiral'. The engine keeps ONE wash element PER VARIANT
+   *  and pressure.js holds the spiral one with `sustainForever`; a LOWER-alpha
+   *  re-trigger of that variant is the step-down idiom and would END the deck's
+   *  held wheel (CLAUDE.md trap 33). The class's own burial uses the three
+   *  variants no deck holds. */
+  WASH_VARIANTS: Object.freeze(['pink', 'drain', 'sublim']),
+  /** The whisper-out: the last slice of a wash is re-triggered at this share of
+   *  its alpha. NEVER stop('wash') mid-class (CLAUDE.md trap 33). */
+  WASH_STEPDOWN: 0.35,
+  WASH_STEPDOWN_SHARE: 0.35,
+  /** The first wash never lands before the player has had the board a while. */
+  WASH_FIRST_MS: 12000,
+  WASH_TAIL_MS: 8000,
+  ZEN_WASH_COUNT: 2,
+  ZEN_WASH_ALPHA: 0.16,
+  ZEN_WASH_MS: 4000,
+
+  /* ---- the other dials ---- */
+  SUB_FLASH_MS: Object.freeze({ 1: 0, 2: 0, 3: 7000, 4: 5200 }),
+  SUB_VARIANTS: Object.freeze(['whisper', 'centre', 'scatter']),
+  CADENCE_JITTER: 0.35,
+  CADENCE_MIN_MULT: 0.5,
+  JITTER_LEN: 48,
+  /** bubble_field arms from this tier, row_drift (on the static floor) from this one. */
+  BUBBLE_TIER: 3,
+  ROW_DRIFT_TIER: 4,
+
+  /* ---- THE SKILL-FLOOR RESCUE (the critic's top fix, and it is law) ---- */
+  /** No new piece home for this long -> light the baseline's next move. */
+  RESCUE_MS: 20000,
+  RESCUE_TICK_MS: 500,
+  /** A lit hint stays lit this long if the player does nothing with it. */
+  RESCUE_HOLD_MS: 6000,
+  /** Zen never nags: the rescue is silent there (no gate to fail either). */
+  RESCUE_IN_ZEN: false,
+
+  /* ---- tempo ---- */
+  MOVE_MS: 150,
+  MOVE_MS_REDUCED: 60,
+  QUEUE_SLOTS: 1,
+  QUEUE_DRAIN_MS: 0,
+  SWIPE_PX: 24,
+  LOCK_STREAK_CAP: 8,
+  STALL_TICK_MS: 500,
+  BELL_WARN_SEC: 20,
+  BRIEF_MS: 1600,
+  BRIEF_MS_REDUCED: 900,
+  /** The solve: seams dissolve and the clip plays clean before the end card. */
+  SOLVE_PLAY_MS: 3000,
+  SOLVE_PLAY_MS_REDUCED: 1500,
+  CEREMONY_MS: 2400,
+  CEREMONY_MS_REDUCED: 1300,
+  END_HOLD_MS: 2600,
+  END_HOLD_MS_REDUCED: 1400,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+export function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Number(gradeTier) || 1))); }
+
+/** The timed board for a year. Zen's board is the player's own setting. */
+export function gridForTier(gradeTier) { return PLAYTEST.GRID_BY_TIER[tierOf(gradeTier)] || 3; }
+
+/** Seeded slides for a tier's scramble; 0 = full permutation + parity repair. */
+export function scrambleWalkFor(gradeTier, zen) {
+  return zen ? PLAYTEST.ZEN_WALK : (PLAYTEST.SCRAMBLE_WALK[tierOf(gradeTier)] || 0);
+}
+
+/**
+ * Par, from the solver's own baseline.
+ * @param {number} baseline  solver.baselineLength(state), or <0 when unknown
+ * @param {number} gradeTier
+ * @param {number} n
+ */
+export function parFor(baseline, gradeTier, n) {
+  const tier = tierOf(gradeTier);
+  const size = Math.max(3, Math.min(5, Math.round(Number(n) || 3)));
+  const base = Number(baseline);
+  if (!Number.isFinite(base) || base <= 0) {
+    return Math.max(1, Math.round((size * size - 1) * PLAYTEST.PAR_FALLBACK_PER_TILE));
+  }
+  return Math.max(Math.round(base), Math.ceil(base * PLAYTEST.PAR_MULT[tier]));
+}
+
+/**
+ * The composite.
+ * @param {Object} i
+ *   gradeTier      1..4
+ *   solved         the picture came back whole
+ *   n              board size
+ *   moves          real slides (a press into a wall is not a move)
+ *   par            parFor(...)
+ *   manhattanStart / manhattanNow   the scramble's distance, then and now
+ *   locked / tiles                  pieces home, out of n*n-1
+ *   backtracks     slides that undid the slide before them
+ *   thrash         those of them made while a wash was up
+ *   assists        rescue EPISODES (not hint repaints)
+ * @returns {{composite:number, terms:Object, tax:number, raw:number, par:number}}
+ */
+export function compositeFor(i = {}) {
+  const solved = !!i.solved;
+  const moves = Math.max(0, Math.round(Number(i.moves) || 0));
+  const par = Math.max(1, Math.round(Number(i.par) || 1));
+  const tiles = Math.max(1, Math.round(Number(i.tiles) || 1));
+  const locked = Math.max(0, Math.min(tiles, Math.round(Number(i.locked) || 0)));
+  const mhStart = Math.max(0, Number(i.manhattanStart) || 0);
+  const mhNow = Math.max(0, Number(i.manhattanNow) || 0);
+
+  const closed = mhStart > 0 ? clamp01((mhStart - mhNow) / mhStart) : (solved ? 1 : 0);
+  const home = clamp01(locked / tiles);
+  const progress = solved
+    ? 1
+    : clamp01(PLAYTEST.PROGRESS_MH_SHARE * closed + (1 - PLAYTEST.PROGRESS_MH_SHARE) * home);
+
+  const pace = moves > 0 ? clamp01((progress * par) / moves) : 0;
+
+  const backtracks = Math.max(0, Math.round(Number(i.backtracks) || 0));
+  const thrash = Math.max(0, Math.round(Number(i.thrash) || 0));
+  const denom = Math.max(PLAYTEST.CALM_MIN_MOVES, moves);
+  const panic = (PLAYTEST.BACKTRACK_COST * backtracks + PLAYTEST.THRASH_COST * thrash) / denom;
+  const calm = clamp01(1 - panic / PLAYTEST.CALM_TOL);
+
+  const raw = PLAYTEST.W_PROGRESS * progress + PLAYTEST.W_PACE * pace + PLAYTEST.W_CALM * calm;
+  const assists = Math.max(0, Math.round(Number(i.assists) || 0));
+  const tax = Math.pow(PLAYTEST.ASSIST_TAX, assists);
+
+  return {
+    composite: clamp01(raw * tax),
+    raw: clamp01(raw),
+    tax,
+    par,
+    terms: { progress, pace, calm, closed, home },
+  };
+}
+
+/**
+ * Declared hard gates. `sGate` is the rescue promise: a class that took the
+ * skill-floor assist may not exceed A, whatever the composite says. Nothing
+ * else in this game gates - the board size is the year's, not a choice.
+ */
+export function hardGates(rescueUsed) {
+  return { sGate: !rescueUsed };
+}
+
+/** +5 solved, +5 a new personal best on this board, +5 inside par. Cap 15. */
+export function flavorXp(i = {}) {
+  if (!i.solved) return 0;
+  let xp = PLAYTEST.FLAVOR_SOLVE;
+  const before = Number(i.bestMovesBefore);
+  const moves = Math.max(1, Math.round(Number(i.moves) || 1));
+  if (!Number.isFinite(before) || before <= 0 || moves < before) xp += PLAYTEST.FLAVOR_BEST;
+  if (moves <= Math.max(1, Math.round(Number(i.par) || 1))) xp += PLAYTEST.FLAVOR_UNDER_PAR;
+  return Math.min(PLAYTEST.FLAVOR_CAP, xp);
+}
+
+/** The heat ladder: pieces home, curved, capped by the year (and halved in zen). */
+export function heatFor(lockedFrac, gradeTier, zen) {
+  const tier = tierOf(gradeTier);
+  const cap = PLAYTEST.HEAT_CAP[tier] * (zen ? PLAYTEST.ZEN_HEAT_MULT : 1);
+  const f = clamp01(lockedFrac);
+  const h = PLAYTEST.HEAT_FLOOR + (cap - PLAYTEST.HEAT_FLOOR) * Math.pow(f, PLAYTEST.HEAT_GAMMA);
+  return clamp01(Math.min(cap, h));
+}
+
+/** Heat-shortened, jittered cadence (the Deep End's shape). */
+export function cadenceMs(baseMs, heat, jitter) {
+  const base = Math.max(0, Number(baseMs) || 0);
+  if (base <= 0) return 0;
+  const h = clamp01(heat);
+  const mult = 1 - (1 - PLAYTEST.CADENCE_MIN_MULT) * h;
+  const j = 1 + (Number(jitter) || 0);
+  return Math.max(600, Math.round(base * mult * j));
+}
+
+/**
+ * The class's seeded plan. Draw order is APPEND-ONLY: a new draw goes at the
+ * END so older seeds keep the show they had.
+ *
+ * @param {Object} o {seed, gradeTier, n, zen, timeBudgetSec}
+ */
+export function buildPlan(o = {}) {
+  const tier = tierOf(o.gradeTier);
+  const zen = !!o.zen;
+  const seed = String(o.seed == null ? 'composure' : o.seed);
+  const rng = makeRng(seed + '|cp-plan');
+  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 120) * 1000);
+
+  /* 1. the wash windows - the burial the whole game is about. Dealt across the
+   *    budget between a lead-in and a tail so no wash lands on the bell. */
+  const count = zen ? PLAYTEST.ZEN_WASH_COUNT : (PLAYTEST.WASH_COUNT[tier] || 1);
+  const washMs = zen ? PLAYTEST.ZEN_WASH_MS : (PLAYTEST.WASH_MS[tier] || 2600);
+  const alpha = zen ? PLAYTEST.ZEN_WASH_ALPHA : (PLAYTEST.WASH_ALPHA[tier] || 0.2);
+  const first = PLAYTEST.WASH_FIRST_MS;
+  const span = Math.max(1000, budgetMs - first - PLAYTEST.WASH_TAIL_MS);
+  const washes = [];
+  for (let k = 0; k < count; k++) {
+    const slot = count > 1 ? (k / count) : 0;
+    const jitter = (rng() - 0.5) * (span / Math.max(1, count)) * 0.6;
+    washes.push({
+      atMs: Math.max(first, Math.round(first + slot * span + jitter)),
+      ms: Math.round(washMs * (0.85 + rng() * 0.3)),
+      alpha,
+      variant: PLAYTEST.WASH_VARIANTS[Math.floor(rng() * PLAYTEST.WASH_VARIANTS.length)],
+    });
+  }
+  washes.sort((a, b) => a.atMs - b.atMs);
+
+  /* 2. the sub_flash cadence (tier 3+, never in zen) + its jitter stream */
+  const subFlashMs = zen ? 0 : (PLAYTEST.SUB_FLASH_MS[tier] || 0);
+  const subJitter = [];
+  for (let k = 0; k < PLAYTEST.JITTER_LEN; k++) subJitter.push((rng() - 0.5) * 2 * PLAYTEST.CADENCE_JITTER);
+  const subVariants = [];
+  for (let k = 0; k < 8; k++) subVariants.push(PLAYTEST.SUB_VARIANTS[Math.floor(rng() * PLAYTEST.SUB_VARIANTS.length)]);
+
+  return Object.freeze({
+    tier,
+    zen,
+    washes: Object.freeze(washes),
+    washStepdown: PLAYTEST.WASH_STEPDOWN,
+    washStepdownShare: PLAYTEST.WASH_STEPDOWN_SHARE,
+    subFlashMs,
+    subJitter: Object.freeze(subJitter),
+    subVariants: Object.freeze(subVariants),
+    bubbles: !zen && tier >= PLAYTEST.BUBBLE_TIER,
+    rowDrift: !zen && tier >= PLAYTEST.ROW_DRIFT_TIER,
+    heatCap: PLAYTEST.HEAT_CAP[tier] * (zen ? PLAYTEST.ZEN_HEAT_MULT : 1),
+    audioCeil: PLAYTEST.AUDIO_CEIL[tier] * (zen ? 0.7 : 1),
+    bellWarnSec: PLAYTEST.BELL_WARN_SEC,
+  });
+}
+
+export default {
+  PLAYTEST, compositeFor, hardGates, flavorXp, parFor, heatFor, cadenceMs, buildPlan,
+  gridForTier, scrambleWalkFor, clamp01, tierOf,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
@@ -1,0 +1,1674 @@
+/* ============================================================================
+ * games/composure/index.js - COMPOSURE (the sliding picture; family: puzzle,
+ * Semester III). One 120s class, or an untimed Zen board.
+ *
+ * THE PITCH. A 15-puzzle whose picture never sits still: every tile is a
+ * clipped viewport into ONE looping clip (N <img> of the SAME url at different
+ * object offsets - one decoder, and the loop stays in lockstep across the whole
+ * board, which is the point). The Distraction Engine then lies to you: washes
+ * bury the board while input stays live, and the trickster deck flashes false
+ * previews of tiles in positions they are not in. The grade measures COMPOSURE,
+ * not speed - backtracks, panic moves under a wash and assists cost you; the
+ * clock does not.
+ *
+ * THE LOOP:
+ *   press  = a tap on a tile beside the gap / an arrow or WASD key / a swipe
+ *          -> slide (truth: board.js) -> backtrack + thrash check -> lock check
+ *          -> casino light, pitch-ratcheted lock chime -> heat -> solved?
+ *   LOCK     a tile sitting on its own home cell wears .is-locked and snaps.
+ *            It is a MARKER, never a freeze: freezing tiles can make a solvable
+ *            board unsolvable, and Law I does not allow the board to lie.
+ *   WASH     the class's own burial. Input stays live the whole time; a
+ *            backtrack made under a wash is THRASH and costs double.
+ *   RESCUE   the critic's top fix, and it is LAW: 20s with no new piece home
+ *            lights the baseline solver's next move (.is-hint) and fails the
+ *            declared sGate, so a C-player finishes and the class stays honest.
+ *   SOLVE    seams dissolve, the clip plays clean, the jackpot ladder rolls.
+ *   BELL     timed classes always fill their 120s or end on the solve.
+ *   ZEN      untimed, gentle, its own board size, and it ends with
+ *            endClass({zen:true}) - 'pass', no letter (core/grades.js).
+ *
+ * PEEK IS THE SHELL'S. `manifest.peek` opts into shell/peek.js, and this game
+ * only says what a reveal SHOWS (the solved reference). The A-cap is the
+ * shell's, read off peek.used at endClass - a game that implements its own
+ * peek has broken the rule (CLAUDE.md trap 9).
+ *
+ * LAWS THIS FILE KEEPS:
+ *   I    the ledger is honest - moves, locks, backtracks, thrash, the clock and
+ *        the solved test are computed here from board.js and never routed
+ *        through a deck. The trickster may lie on a chip FACE or on the
+ *        .g-cp-preview layer; tile truth (--r/--c) never moves for a lie.
+ *   II   the only live things on the board are the tiles themselves; every
+ *        engine one-shot over it is decoration (fireSafe welds clickSafe on).
+ *   III  something always breathes - the subject is a loop, and the backdrop
+ *        and the casino keep moving even on a still board.
+ *   IV   the class rules are DRAWN (.g-cp-howto, three figures + one GO), the
+ *        dismissal is GO only, and ctx.hideTutorial + gameMeta.howtoTiers mean
+ *        a skipping player still gets it once per grade tier.
+ *   V    scramble, wash windows, sub_flash cadence and every deck are scoped
+ *        off the class seed; a retake replays the identical board and show.
+ *   VI   pause/resume/suspend/destroy: the timer registry defers, the decks
+ *        ride it, no timer survives destroy, the window listener is removed,
+ *        and a suspend force-hides the peek.
+ *   VII  every string is ctx.lexicon(key, fallback) over lex.js CP_LEX.
+ *
+ * WHAT THIS FILE DOES NOT OWN: grades (core/grades.js via ctx.endClass), XP
+ * (C#), the tier (registry + meta), effect strengths (the engine's ceiling
+ * rule), the LOOK (style.js), the lighting (casino.js), the lies
+ * (trickster.js) and the CCP-effects ladder (pressure.js). The pure model is
+ * board.js, the baseline solver.js, the rubric + dials + plan grade.js.
+ *
+ * THE FOUR CREATIVE FILES ARE IMPORTED DYNAMICALLY. They are written by a
+ * parallel agent; a file that does not exist yet, or throws on import, costs
+ * this class nothing (the shell's own loadOptional posture). A CORE-only
+ * geometry stylesheet is injected ONLY when style.js did not load, so the
+ * board is playable either way.
+ *
+ * ENGINE TARGETING NOTE: glitch_swap adds `.ae-glitch{position:relative;
+ * animation}` and row_drift writes an inline transform on its targets, so
+ * neither may ever touch a .g-cp-tile (style.js owns the tile's transform).
+ * Drift targets the static .g-cp-cell floor; shimmer targets tile FACES.
+ * ==========================================================================*/
+
+import { CP_LEX } from './lex.js';
+import {
+  BLANK, cloneState, dealBoard, canSlide, slide, slotForDir, isSolved,
+  homeMask, lockedCount, tileCount, manhattan, isSolvable, sizeFromSetting,
+  rowOf, colOf, serialize,
+} from './board.js';
+import { nextMove, baselineLength } from './solver.js';
+import { makeTaggedRoll } from '../../core/rng.js';
+import {
+  PLAYTEST, buildPlan, compositeFor, hardGates, flavorXp, parFor, heatFor, cadenceMs,
+  gridForTier, scrambleWalkFor,
+} from './grade.js';
+
+const GAME_KEY = 'composure';
+
+/** A url an <img> cannot show. Mirrors engine/util.js VIDEO_URL_RE - games
+ *  never import the engine, so the two-line rule is repeated here. */
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+
+/** Keyboard -> the direction the TILE travels (a swipe reads the same way). */
+const KEY_DIRS = Object.freeze({
+  ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right',
+  KeyW: 'up', KeyS: 'down', KeyA: 'left', KeyD: 'right',
+  w: 'up', s: 'down', a: 'left', d: 'right', W: 'up', S: 'down', A: 'left', D: 'right',
+});
+
+/** Diagnostics seam (the Deep End / Deja Vu precedent). The shell never reads these. */
+let liveClass = null;
+let lastReport = null;
+let lastSnapshot = null;
+
+/** Test seam: the scratch harness compresses the clock. Production = 1. */
+let timeScale = 1;
+export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
+export function getTimeScale() { return timeScale; }
+function scaled(ms) { return Math.max(0, Math.round(ms * timeScale)); }
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** Reduced motion from the shell's projection first, then the two probes. */
+function probeReduced(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof document !== 'undefined' && document.documentElement
+      && document.documentElement.classList
+      && document.documentElement.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+/** A key press that belongs to a form control is never a move. */
+function isFormTarget(target) {
+  try {
+    if (!target) return false;
+    const tag = String(target.tagName || '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON') return true;
+    if (target.isContentEditable) return true;
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+function mmss(sec) {
+  const s = Math.max(0, sec | 0);
+  return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+}
+
+/* --------------------------------------------------------------------------
+ * THE CORE-ONLY FALLBACK SHEET. Injected ONLY when style.js could not be
+ * loaded (the creative file is written in parallel, and a missing look must
+ * never mean an unplayable board). Geometry and hit targets, nothing else -
+ * no colour story, no motion, no chrome. Deliberately carries no rule for the
+ * `hidden` attribute and no bare display on any node this file toggles with
+ * it: styles.css already owns that cascade (CLAUDE.md trap 27).
+ * ----------------------------------------------------------------------- */
+const FALLBACK_CSS = [
+  '.g-cp-stage{position:relative;display:flex;flex-direction:column;align-items:center;gap:10px;padding:10px;color:#f4eef7}',
+  '.g-cp-hud{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}',
+  '.g-cp-chip{padding:2px 10px;border:1px solid rgba(244,238,247,.35);border-radius:999px;font:600 12px/1.7 system-ui,sans-serif}',
+  '.g-cp-frame{position:relative;width:min(70vh,90vw);height:min(70vh,90vw)}',
+  '.g-cp-board{position:absolute;inset:0}',
+  '.g-cp-cell{position:absolute;left:0;top:0;box-sizing:border-box;width:calc(100% / var(--cp-n));height:calc(100% / var(--cp-n));',
+  'transform:translate(calc(var(--c) * 100%),calc(var(--r) * 100%));border:1px solid rgba(244,238,247,.06)}',
+  /* the ride is a TRANSFORM, never left/top: an animated left/top re-lays-out
+     the whole board every frame (CLAUDE.md trap 36) */
+  '.g-cp-tile{position:absolute;left:0;top:0;box-sizing:border-box;width:calc(100% / var(--cp-n));height:calc(100% / var(--cp-n));',
+  'transform:translate(calc(var(--c) * 100%),calc(var(--r) * 100%));padding:1px;cursor:pointer;',
+  'transition:transform .15s ease}',
+  '.g-cp-face{position:relative;width:100%;height:100%;overflow:hidden;border-radius:5px;background:rgba(244,238,247,.06)}',
+  '.g-cp-media{position:absolute;object-fit:cover}',
+  '.g-cp-num{position:absolute;right:4px;bottom:2px;font:700 11px/1 system-ui,sans-serif;opacity:.55}',
+  '.g-cp-tile.is-locked .g-cp-face{outline:1px solid rgba(240,194,75,.55)}',
+  '.g-cp-tile.is-hint .g-cp-face{outline:2px solid rgba(240,194,75,.95)}',
+  '.g-cp-preview{position:absolute;inset:0}',
+  '.g-cp-peeklayer{position:absolute;inset:0;overflow:hidden;border-radius:6px;background:rgba(10,8,16,.92)}',
+  '.g-cp-peeklayer .g-cp-media{position:absolute;inset:0;width:100%;height:100%}',
+  '.g-cp-msg{min-height:1.3em;text-align:center;margin:0}',
+  '.g-cp-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;max-width:min(520px,88vw);',
+  'padding:16px 18px;border-radius:12px;background:rgba(16,12,26,.96);border:1px solid rgba(244,238,247,.18)}',
+  '.g-cp-hw-row{display:flex;gap:10px;align-items:center;margin:8px 0}',
+  '.g-cp-hw-fig{position:relative;flex:0 0 64px;height:44px;border-radius:6px;background:rgba(244,238,247,.08)}',
+  '.g-cp-hw-cap{margin:0;font:400 13px/1.4 system-ui,sans-serif}',
+  '.g-cp-end{margin:0 auto;max-width:min(520px,90vw);text-align:left}',
+  '.g-cp-end-row{display:flex;justify-content:space-between;gap:12px;padding:2px 0}',
+].join('');
+
+function injectFallbackStyle() {
+  if (typeof document === 'undefined' || !document.createElement) return;
+  try {
+    if (document.getElementById && document.getElementById('g-cp-core-style')) return;
+    const s = document.createElement('style');
+    s.id = 'g-cp-core-style';
+    s.textContent = FALLBACK_CSS;
+    const head = document.head || document.documentElement;
+    if (head && head.appendChild) head.appendChild(s);
+  } catch (e) { /* a class without a stylesheet still runs */ }
+}
+
+export default {
+  key: GAME_KEY,
+  family: 'puzzle',
+  /* MEATY, and it is a TIMETABLE fact, not a claim about this class's length -
+   * the budget is still 120s. core/timetable.js ranks no-repeat-3 ABOVE the
+   * meaty preference (CLAUDE.md trap 6), so a ten-game pool with two meaty
+   * classes filled the meaty slot on only ~46% of dealt nights, and three on
+   * 75% (a cycle of four). With four (Lost & Found, The Deep End, Instant
+   * Recall and this one) a dealt fortnight carries one on 28/28 nights.
+   * NOTHING in this module branches on the flag - it is the registry's and the
+   * timetable's to read. Keep it in step with games/registry.js GAME_META,
+   * which is the parachute a suspended class is dealt from. */
+  meaty: true,
+  flagship: false,
+  timeBudgetSec: 120,
+  title: 'Composure',
+
+  manifest: {
+    /* flash_burst and gif_burst are declared ONLY as clickSafe decoration over
+     * a board whose tiles are the click targets (DECISIONS #9) - fireSafe()
+     * welds that on at every call site. glitch_swap is the trickster's False
+     * Preview and never moves a tile; row_drift rides the static cell floor. */
+    effectsConsumed: [
+      'glitch_swap', 'wash', 'sub_flash', 'audio_trigger',
+      'flash_burst', 'bubble_field', 'gif_burst', 'row_drift',
+    ],
+    /* ONE loop is the board's subject, cut into n*n viewports; the decoys and
+     * the reward bursts want a few more. DOM only, nothing is drawn into a
+     * canvas, so the provider may serve remote media here. */
+    assetNeeds: { loops: 4, targets: 1, stills: 2, canvasSafe: false },
+    /* The timed grid is the YEAR's (1-2 -> 3x3, 3-4 -> 4x4), so there is no
+     * below-par board to detect; zen's size is a plain enum setting. */
+    boardSizes: null,
+    /* No verb of its own: arrows/WASD slide, a tap slides, a swipe slides -
+     * and the PEEK key is the shell's shared verb, never a game keybind. */
+    keybinds: null,
+    settings: [
+      {
+        key: 'cp_mode', kind: 'enum', values: ['timed', 'zen'], default: 'timed',
+        label_key: 'cp_mode', hint_key: 'cp_mode_hint',
+      },
+      {
+        key: 'cp_zen_grid', kind: 'enum', values: ['3x3', '4x4', '5x5'], default: '3x3',
+        label_key: 'cp_zen_grid', hint_key: 'cp_zen_grid_hint',
+      },
+    ],
+    /* SYNTHESIS #6: the shared hold-to-reveal verb. The shell owns the A-cap. */
+    peek: true,
+  },
+
+  create(ctx) {
+    const t = (key, fallback) => {
+      const fb = fallback == null ? (CP_LEX[key] == null ? key : CP_LEX[key]) : fallback;
+      try { const v = ctx.lexicon(key, fb); return v == null ? fb : v; } catch (e) { return fb; }
+    };
+    const say = (m) => { try { ctx.log('[cp] ' + m); } catch (e) { /* noop */ } };
+
+    /* ---- lifecycle flags ------------------------------------------------ */
+    let dead = false;
+    let paused = false;
+    let ended = false;
+    let reported = false;
+    let busy = true;                 // input closed until the rules sheet is done
+    let opened = false;              // the board is the player's
+
+    /* ---- class state ---------------------------------------------------- */
+    let spec = null;
+    let seed = '';
+    let tier = 1;
+    let n = 3;
+    let zen = false;
+    let plan = null;
+    let state = null;                // the live puzzle (board.js)
+    let reduced = false;
+    let retake = false;
+    let budgetMs = 120000;
+    let pool = null;
+    let subjectUrl = null;
+    let rollLocal = null;
+
+    let casino = null;
+    let trickster = null;
+    let pressure = null;
+    let styleOk = false;
+
+    /* ---- the ledger (Law I: computed here, never by a deck) ------------- */
+    let moves = 0;
+    let bumps = 0;
+    let backtracks = 0;
+    let thrash = 0;
+    let lastMove = null;             // {id, from, to} of the previous real slide
+    let locked = 0;
+    let bestLocked = 0;
+    let lockStreak = 0;
+    let bestLockStreak = 0;
+    let solved = false;
+    let washOn = false;
+    let washes = 0;
+    let subFlashes = 0;
+    let jackpots = 0;
+    let rescueUsed = false;
+    let rescueActive = false;
+    let rescueEpisodes = 0;
+    let hintId = -1;
+    let lastLockAtMs = 0;
+    let mhStart = 0;
+    let baseline = -1;
+    let par = 1;
+    let currentHeat = 0;
+    let bellOn = false;
+    let finished = false;            // zen's own way out was pressed
+    let solvesBefore = 0;
+    let bestMovesBefore = 0;
+    let subIdx = 0;
+    let driftOn = false;
+    let bubblesOn = false;
+
+    /* ---- clock ---------------------------------------------------------- */
+    let clockId = 0;
+    let lastTick = 0;
+    let elapsedMs = 0;
+
+    /* ---- dom ------------------------------------------------------------ */
+    let stage = null; let backdrop = null; let hud = null; let frame = null;
+    let boardEl = null; let previewEl = null; let peekEl = null; let peekMedia = null;
+    let wellEl = null; let msgEl = null; let endEl = null; let howtoEl = null;
+    let movesChip = null; let clockChip = null; let lockedChip = null; let calmChip = null;
+    let peekBtn = null; let finishBtn = null;
+    const cellEls = [];
+    const tileEls = new Map();       // tile id -> element
+    let queued = null;               // THE QUEUE: one slot, last press wins
+    let queueTimer = 0;
+    let subTimer = 0;
+    let bumpTimer = 0;
+    let msgTimer = 0;
+    let grab = null;                 // the live swipe
+
+    /* ==================================================================== *
+     * TIMERS - every step goes through run() so a suspend freezes the class
+     * mid-move and a resume finishes it. `every` simply skips while paused.
+     * ==================================================================== */
+    const timers = new Map();
+    let nextTimerId = 1;
+    const deferred = [];
+    function run(fn) {
+      if (dead) return;
+      if (paused) { deferred.push(fn); return; }
+      try { fn(); } catch (e) { say('step failed: ' + ((e && e.message) || e)); }
+    }
+    function after(ms, fn) {
+      const id = nextTimerId++;
+      const h = setTimeout(() => { timers.delete(id); run(fn); }, scaled(ms));
+      timers.set(id, { kind: 'after', h });
+      return id;
+    }
+    function every(ms, fn) {
+      const id = nextTimerId++;
+      const h = setInterval(() => {
+        if (dead || paused) return;
+        try { fn(); } catch (e) { say('tick failed: ' + ((e && e.message) || e)); }
+      }, Math.max(4, scaled(ms)));
+      timers.set(id, { kind: 'every', h });
+      return id;
+    }
+    function clearTimer(id) {
+      const rec = timers.get(id);
+      if (!rec) return;
+      if (rec.kind === 'after') clearTimeout(rec.h); else clearInterval(rec.h);
+      timers.delete(id);
+    }
+    function clearTimers() {
+      for (const id of Array.from(timers.keys())) clearTimer(id);
+      timers.clear();
+      deferred.length = 0;
+    }
+    /** The decks' registry: this class's own pause-aware timers. */
+    const deckTimers = { after, every, clear: clearTimer };
+
+    /* ==================================================================== *
+     * ENGINE - one wrapper, the input-trust law welded on.
+     * ==================================================================== */
+    function fireSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'flash_burst' || kind === 'gif_burst') {
+        o.clickSafe = true;              // the tiles are the click targets
+        o.clickable = false;
+        delete o.onPop;
+      }
+      try { return ctx.engine.fire(kind, o) || null; } catch (e) { say('fire(' + kind + ') failed'); return null; }
+    }
+    function sustainSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      try { return ctx.engine.sustain(kind, opts || {}) || null; } catch (e) { return null; }
+    }
+    function stopSafe(kind) { try { if (ctx.engine) ctx.engine.stop(kind); } catch (e) { /* noop */ } }
+    /** The engine, as a deck sees it: the three welded primitives plus a READ
+     *  of the clamped channel vector (THE CEILING RULE - a deck asks, it never
+     *  raises). Every member is null-safe and may answer null. */
+    const deckEngine = {
+      fire: fireSafe,
+      sustain: sustainSafe,
+      stop: stopSafe,
+      channels: () => {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** The player's own media, as a deck sees it: the pool lands ASYNC, so a
+     *  deck gets a LIVE reader rather than the pool object. */
+    const deckAssets = {
+      next(kind) {
+        try { return (pool && typeof pool.next === 'function') ? (pool.next(kind) || null) : null; }
+        catch (e) { return null; }
+      },
+      subject() { return subjectUrl; },
+    };
+    /** bgIntensity 0 is the player's exit: read it LIVE, never a launch snapshot. */
+    function capsArmed() { return !(ctx.caps && Number(ctx.caps.bgIntensity) === 0); }
+    function motionLevelOf() {
+      try { const v = ctx.motion && ctx.motion.motionLevel; return Number.isFinite(Number(v)) ? Number(v) : 2; }
+      catch (e) { return 2; }
+    }
+    /** A cue through the engine; level never above the tier's audio ceiling. */
+    function tick(name, level, extra) {
+      const ceil = plan ? plan.audioCeil : 0.45;
+      const lv = Math.min(ceil, level == null ? 0.4 : level);
+      fireSafe('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+    }
+
+    /* ---- the decks, null-safe ------------------------------------------- */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); }
+      catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+
+    /* ==================================================================== *
+     * HEAT - the locked fraction is the ladder (the class's own progress is
+     * its difficulty dial), capped by the year and halved in zen.
+     * ==================================================================== */
+    function lockedFrac() {
+      const tiles = tileCount(n);
+      return tiles > 0 ? locked / tiles : 0;
+    }
+    function heat() {
+      const f = lockedFrac();
+      const h = heatFor(f, tier, zen);
+      currentHeat = h;
+      try { if (ctx.engine) ctx.engine.setHeat(h); } catch (e) { /* the engine is optional */ }
+      deck('casino', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+      deck('pressure', 'setProgress', f);
+    }
+
+    /* ==================================================================== *
+     * DOM (the contract's exact shape)
+     * ==================================================================== */
+    function setPhase(p) { if (stage) stage.setAttribute('data-phase', p); }
+    function msg(key, fallback, holdMs) {
+      if (!msgEl) return;
+      msgEl.textContent = t(key, fallback);
+      if (msgTimer) { clearTimer(msgTimer); msgTimer = 0; }
+      if (holdMs > 0) {
+        const mine = msgEl.textContent;
+        msgTimer = after(holdMs, () => {
+          msgTimer = 0;
+          if (msgEl && msgEl.textContent === mine) msgEl.textContent = '';
+        });
+      }
+    }
+
+    function buildDom() {
+      const root = ctx.root;
+      root.textContent = '';
+      stage = el('div', 'g-cp-stage');
+      stage.setAttribute('data-phase', 'briefing');
+      stage.setAttribute('data-mode', zen ? 'zen' : 'timed');
+      stage.setAttribute('data-n', String(n));
+      if (reduced) stage.setAttribute('data-reduced', '1');
+
+      backdrop = el('div', 'g-cp-backdrop');
+      backdrop.setAttribute('aria-hidden', 'true');
+      backdrop.style.pointerEvents = 'none';
+      stage.appendChild(backdrop);
+
+      hud = el('div', 'g-cp-hud');
+      movesChip = el('span', 'g-cp-chip g-cp-moves', '0');
+      movesChip.setAttribute('aria-label', t('cp_chip_moves', CP_LEX.cp_chip_moves));
+      clockChip = el('span', 'g-cp-chip g-cp-clock', clockText());
+      clockChip.setAttribute('aria-label', zen
+        ? t('cp_end_time', CP_LEX.cp_end_time)
+        : t('cp_chip_clock', CP_LEX.cp_chip_clock));
+      lockedChip = el('span', 'g-cp-chip g-cp-locked', lockedText());
+      lockedChip.setAttribute('aria-label', t('cp_chip_locked', CP_LEX.cp_chip_locked));
+      calmChip = el('span', 'g-cp-chip g-cp-calm', '');
+      calmChip.setAttribute('aria-label', t('cp_chip_calm', CP_LEX.cp_chip_calm));
+      calmChip.hidden = true;
+      hud.appendChild(movesChip);
+      hud.appendChild(clockChip);
+      hud.appendChild(lockedChip);
+      hud.appendChild(calmChip);
+
+      /* THE PEEK CONTROL. The node is built here and OWNED by the shell: it is
+       * handed to ctx.peek.attach() and this file never tracks the A-cap.
+       * `arc-peekbtn` is the shell's own chrome class (Lost & Found's foot
+       * button wears the same one) so the control reads right before style.js
+       * has an opinion about it. */
+      peekBtn = el('button', 'g-cp-peek arc-peekbtn', t('peek', 'Peek'));
+      peekBtn.setAttribute('type', 'button');
+      try { peekBtn.type = 'button'; } catch (e) { /* the DOM double has no button semantics */ }
+      hud.appendChild(peekBtn);
+
+      /* ZEN's own way out. An untimed class has no bell, so it needs a real,
+       * tab-reachable button (the window keydown handler ignores a BUTTON
+       * target, so pressing it is never eaten as a slide). */
+      if (zen) {
+        finishBtn = el('button', 'g-cp-chip g-cp-finish', t('cp_finish', CP_LEX.cp_finish));
+        finishBtn.setAttribute('type', 'button');
+        try { finishBtn.type = 'button'; } catch (e) { /* noop */ }
+        finishBtn.addEventListener('click', onFinishPressed);
+        hud.appendChild(finishBtn);
+      }
+      if (retake) hud.appendChild(el('span', 'g-cp-chip g-cp-retake', t('cp_retake', CP_LEX.cp_retake)));
+      stage.appendChild(hud);
+
+      frame = el('div', 'g-cp-frame');
+      boardEl = el('div', 'g-cp-board');
+      boardEl.style.setProperty('--cp-n', String(n));
+      boardEl.style.touchAction = 'none';       // a swipe is a slide, never a scroll
+      boardEl.setAttribute('role', 'application');
+      boardEl.setAttribute('aria-label', t('game_composure', 'Composure'));
+      cellEls.length = 0;
+      for (let i = 0; i < n * n; i++) {
+        const cell = el('div', 'g-cp-cell');
+        cell.setAttribute('data-i', String(i));
+        cell.style.setProperty('--r', String(rowOf(n, i)));
+        cell.style.setProperty('--cp-r', String(rowOf(n, i)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+        cell.style.setProperty('--c', String(colOf(n, i)));
+        cell.style.setProperty('--cp-c', String(colOf(n, i)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+        boardEl.appendChild(cell);
+        cellEls.push(cell);
+      }
+      frame.appendChild(boardEl);
+
+      /* The trickster's lie layer. CORE builds it, never draws on it. */
+      previewEl = el('div', 'g-cp-preview');
+      previewEl.setAttribute('aria-hidden', 'true');
+      previewEl.style.pointerEvents = 'none';
+      frame.appendChild(previewEl);
+
+      /* THE PEEK REVEAL: the solved reference, one unclipped copy of the
+       * subject. Hidden until the shell's verb says otherwise. */
+      peekEl = el('div', 'g-cp-peeklayer');
+      peekEl.setAttribute('aria-hidden', 'true');
+      peekEl.style.pointerEvents = 'none';
+      peekEl.hidden = true;
+      peekMedia = null;
+      peekEl.appendChild(el('span', 'g-cp-peek-cap', t('cp_peek_ref', CP_LEX.cp_peek_ref)));
+      frame.appendChild(peekEl);
+
+      stage.appendChild(frame);
+
+      msgEl = el('p', 'g-cp-msg');
+      msgEl.setAttribute('aria-live', 'polite');
+      stage.appendChild(msgEl);
+
+      wellEl = el('div', 'g-cp-flashwell');
+      wellEl.setAttribute('aria-hidden', 'true');
+      wellEl.style.pointerEvents = 'none';
+      stage.appendChild(wellEl);
+
+      endEl = el('div', 'g-cp-end');
+      endEl.hidden = true;
+      stage.appendChild(endEl);
+
+      root.appendChild(stage);
+      paintTiles(true);
+    }
+
+    /** One element per tile, positioned ONLY through --r / --c (style.js owns
+     *  the transform). --hr / --hc carry the tile's HOME, which is also which
+     *  fragment of the picture it wears. */
+    function tileElFor(id) {
+      let node = tileEls.get(id);
+      if (node) return node;
+      node = el('div', 'g-cp-tile');
+      node.setAttribute('data-id', String(id));
+      node.setAttribute('data-home', String(id));
+      node.style.setProperty('--hr', String(rowOf(n, id)));
+      node.style.setProperty('--hc', String(colOf(n, id)));
+      const face = el('span', 'g-cp-face');
+      face.appendChild(el('span', 'g-cp-num', String(id + 1)));
+      node.appendChild(face);
+      node.addEventListener('click', () => onTileClick(id));
+      tileEls.set(id, node);
+      boardEl.appendChild(node);
+      return node;
+    }
+
+    /** Write every tile's --r/--c from the model. `fresh` also builds them. */
+    function paintTiles(fresh) {
+      if (!state || !boardEl) return;
+      for (let pos = 0; pos < state.cells.length; pos++) {
+        const id = state.cells[pos];
+        if (id === BLANK) continue;
+        const node = fresh ? tileElFor(id) : (tileEls.get(id) || tileElFor(id));
+        node.style.setProperty('--r', String(rowOf(n, pos)));
+        node.style.setProperty('--cp-r', String(rowOf(n, pos)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+        node.style.setProperty('--c', String(colOf(n, pos)));
+        node.style.setProperty('--cp-c', String(colOf(n, pos)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+      }
+    }
+
+    /** The clipped viewport: ONE url, n*n offsets, one decoder. */
+    function dressTiles() {
+      if (!subjectUrl || !state) return;
+      for (const [id, node] of tileEls) {
+        const face = firstChildWith(node, 'g-cp-face');
+        if (!face) continue;
+        let media = firstChildWith(face, 'g-cp-media');
+        if (!media) {
+          media = el('img', 'g-cp-media');
+          try {
+            media.setAttribute('alt', '');
+            media.setAttribute('draggable', 'false');
+            media.draggable = false;
+            media.decoding = 'async';
+            media.addEventListener('load', () => { if (!dead) node.classList.add('is-loaded'); });
+            media.addEventListener('error', () => { if (!dead) mediaBroken(); });
+          } catch (e) { /* the double has no img semantics; fine */ }
+          face.insertBefore ? face.insertBefore(media, face.children[0] || null) : face.appendChild(media);
+        }
+        /* THE CLIP. The media is n times the tile in both axes and offset by
+         * the tile's HOME, so every tile is a window onto the same running
+         * loop at a different place - which is what makes the board move. */
+        try {
+          media.style.width = (n * 100) + '%';
+          media.style.height = (n * 100) + '%';
+          media.style.left = (-100 * colOf(n, id)) + '%';
+          media.style.top = (-100 * rowOf(n, id)) + '%';
+          media.src = subjectUrl;
+        } catch (e) { /* ignore */ }
+      }
+      if (peekEl && !peekMedia) {
+        peekMedia = el('img', 'g-cp-media');
+        try {
+          peekMedia.setAttribute('alt', '');
+          peekMedia.decoding = 'async';
+          peekMedia.src = subjectUrl;
+        } catch (e) { /* ignore */ }
+        peekEl.appendChild(peekMedia);
+      }
+    }
+
+    /** The subject url failed: the board goes to numbered faces for the class. */
+    function mediaBroken() {
+      if (!subjectUrl) return;
+      say('subject media failed - the board wears numbered faces for this class');
+      subjectUrl = null;
+      for (const [, node] of tileEls) {
+        node.classList.remove('is-loaded');
+        const face = firstChildWith(node, 'g-cp-face');
+        const media = face && firstChildWith(face, 'g-cp-media');
+        if (media && typeof media.remove === 'function') { try { media.remove(); } catch (e) { /* noop */ } }
+      }
+    }
+
+    function firstChildWith(node, cls) {
+      try { for (const k of node.children || []) if (k.classList && k.classList.contains(cls)) return k; }
+      catch (e) { /* ignore */ }
+      return null;
+    }
+
+    /* ---- HUD paint (truth) ---------------------------------------------- */
+    function secLeft() { return zen ? 0 : Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)); }
+    function secElapsed() { return Math.max(0, Math.floor(elapsedMs / 1000)); }
+    /** THE TRUTH on the clock chip; the trickster restores exactly this string. */
+    function clockText() { return zen ? mmss(secElapsed()) : mmss(secLeft()); }
+    function movesText() { return String(moves); }
+    function lockedText() { return locked + '/' + tileCount(n); }
+    function chipText(which) {
+      if (which === 'clock') return clockText();
+      if (which === 'moves') return movesText();
+      return lockedText();
+    }
+    function paintHud() {
+      if (clockChip) clockChip.textContent = clockText();
+      if (movesChip) movesChip.textContent = movesText();
+      if (lockedChip) lockedChip.textContent = lockedText();
+      paintCalm();
+    }
+    function paintCalm() {
+      if (!calmChip) return;
+      if (lockStreak < 2) { calmChip.hidden = true; calmChip.textContent = 'x ' + lockStreak; return; }
+      calmChip.hidden = false;
+      calmChip.textContent = 'x ' + lockStreak;
+      /* The meter is the SHELL's primitive (10 segments); it rides inside the
+       * chip so the contract's DOM gains no extra node. */
+      try {
+        const meter = ctx.ceremonies.streakMeter({
+          filled: Math.min(PLAYTEST.LOCK_STREAK_CAP, lockStreak),
+          gold: lockStreak >= PLAYTEST.LOCK_STREAK_CAP,
+        });
+        if (meter) calmChip.appendChild(meter);
+      } catch (e) { /* a ceremony must never be the thing that fails */ }
+    }
+
+    /* ==================================================================== *
+     * INPUT - a tap on a tile beside the gap, window keydown (arrows / WASD,
+     * form targets ignored), and a swipe on the board. THE QUEUE: one slot,
+     * last press wins, drained on the next tick after the move lock releases.
+     * ==================================================================== */
+    function onTileClick(id) {
+      if (!state) return;
+      const pos = state.cells.indexOf(id);
+      press('pos', pos);
+    }
+    function onKeyDown(e) {
+      if (!e || e.repeat || e.ctrlKey || e.altKey || e.metaKey) return;
+      if (isFormTarget(e.target)) return;
+      const dir = KEY_DIRS[String(e.key || '')] || KEY_DIRS[String(e.code || '')];
+      if (!dir) return;
+      try { e.preventDefault(); } catch (err) { /* noop */ }
+      press('dir', dir);
+    }
+    function onPointerDown(e) {
+      if (!e || !boardEl || dead || paused || ended) return;
+      grab = { id: e.pointerId == null ? null : e.pointerId, x: Number(e.clientX) || 0, y: Number(e.clientY) || 0, captured: false };
+      try {
+        if (typeof boardEl.setPointerCapture === 'function' && grab.id != null) {
+          boardEl.setPointerCapture(grab.id);
+          grab.captured = true;
+        }
+      } catch (err) { grab.captured = false; }
+      /* THE HAND: a press marks the board so style.js can lift the tiles. It is
+       * a look, not a verb - the slide still happens on release (or on the
+       * tile's own click), so nothing about input moved. */
+      try { boardEl.classList.add('g-cp-held'); } catch (err) { /* noop */ }
+    }
+    function samePointer(e) {
+      if (!grab) return false;
+      if (e && e.pointerId != null && grab.id != null) return e.pointerId === grab.id;
+      return true;
+    }
+    function onPointerUp(e) {
+      if (!e || !grab || !samePointer(e)) return;
+      const dx = (Number(e.clientX) || 0) - grab.x;
+      const dy = (Number(e.clientY) || 0) - grab.y;
+      clearGrab();
+      const ax = Math.abs(dx); const ay = Math.abs(dy);
+      if (Math.max(ax, ay) < PLAYTEST.SWIPE_PX) return;      // a tap: the tile's own click handles it
+      press('dir', ax >= ay ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up'));
+    }
+    function onPointerCancel(e) { if (!grab || samePointer(e)) clearGrab(); }
+    function onPointerLeave(e) { if (grab && !grab.captured) onPointerCancel(e); }
+    function clearGrab() {
+      const g = grab;
+      grab = null;
+      try { if (boardEl) boardEl.classList.remove('g-cp-held'); } catch (e) { /* noop */ }
+      if (g && g.captured && g.id != null && boardEl) {
+        try { if (typeof boardEl.releasePointerCapture === 'function') boardEl.releasePointerCapture(g.id); }
+        catch (e) { /* the pointer is already gone */ }
+      }
+    }
+    function bindInput() {
+      try { if (typeof window !== 'undefined') window.addEventListener('keydown', onKeyDown); }
+      catch (e) { say('keydown bind failed: ' + ((e && e.message) || e)); }
+      try {
+        boardEl.addEventListener('pointerdown', onPointerDown);
+        boardEl.addEventListener('pointerup', onPointerUp);
+        boardEl.addEventListener('pointercancel', onPointerCancel);
+        boardEl.addEventListener('lostpointercapture', onPointerCancel);
+        boardEl.addEventListener('pointerleave', onPointerLeave);
+      } catch (e) { say('pointer bind failed: ' + ((e && e.message) || e)); }
+    }
+    function unbindInput() {
+      try { if (typeof window !== 'undefined') window.removeEventListener('keydown', onKeyDown); } catch (e) { /* noop */ }
+      try {
+        if (boardEl) {
+          boardEl.removeEventListener('pointerdown', onPointerDown);
+          boardEl.removeEventListener('pointerup', onPointerUp);
+          boardEl.removeEventListener('pointercancel', onPointerCancel);
+          boardEl.removeEventListener('lostpointercapture', onPointerCancel);
+          boardEl.removeEventListener('pointerleave', onPointerLeave);
+        }
+      } catch (e) { /* noop */ }
+    }
+
+    function clearQueue() {
+      queued = null;
+      if (queueTimer) { clearTimer(queueTimer); queueTimer = 0; }
+    }
+    /** The lock is off: hand the slot back to the pipeline, one tick later. */
+    function release() {
+      busy = false;
+      if (!queued || dead || paused || ended || !state) { clearQueue(); return; }
+      if (queueTimer) clearTimer(queueTimer);
+      queueTimer = after(PLAYTEST.QUEUE_DRAIN_MS, () => {
+        queueTimer = 0;
+        const q = queued;                 // read late: a pause in between drops it
+        queued = null;
+        if (!q || dead || paused || ended || busy || !state) return;
+        const pos = q.kind === 'dir' ? slotForDir(state, q.v) : q.v;
+        /* A queued POSITION can be stale (the board moved under it). A stale
+         * one is dropped in silence - it is not a wall the player hit. */
+        if (pos < 0 || !canSlide(state, pos)) return;
+        applyMove(pos);
+      });
+    }
+
+    /** Every press funnels here. Returns true when a real slide happened. */
+    function press(kind, v) {
+      if (dead || paused || ended || !state || !opened) return false;
+      if (busy) { if (PLAYTEST.QUEUE_SLOTS > 0) queued = { kind, v }; return false; }
+      const pos = kind === 'dir' ? slotForDir(state, v) : v;
+      if (pos < 0 || !canSlide(state, pos)) { bump(); return false; }
+      return applyMove(pos);
+    }
+
+    /** A press that slides nothing: the board bumps, a muted thud, never silence. */
+    function bump() {
+      bumps += 1;
+      if (boardEl && boardEl.classList) {
+        boardEl.classList.remove('is-bump');
+        try { if (typeof boardEl.offsetWidth === 'number') void boardEl.offsetWidth; } catch (e) { /* ignore */ }
+        boardEl.classList.add('is-bump');
+        if (bumpTimer) clearTimer(bumpTimer);
+        bumpTimer = after(240, () => { bumpTimer = 0; if (boardEl) boardEl.classList.remove('is-bump'); });
+      }
+      tick('bump', 0.26);
+    }
+
+    /* ==================================================================== *
+     * THE MOVE PIPELINE
+     * ==================================================================== */
+    function applyMove(pos) {
+      const res = slide(state, pos);
+      if (!res.moved) { bump(); return false; }
+      busy = true;
+      moves += 1;
+
+      /* 1. the tile rides to its new cell (vars only - style.js owns the ride) */
+      const node = tileEls.get(res.id);
+      if (node) {
+        node.style.setProperty('--r', String(rowOf(n, res.to)));
+        node.style.setProperty('--cp-r', String(rowOf(n, res.to)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+        node.style.setProperty('--c', String(colOf(n, res.to)));
+        node.style.setProperty('--cp-c', String(colOf(n, res.to)));  // registered twin (iOS: unregistered vars in calc() do not transition)
+        node.classList.add('is-moving');
+        after(moveMs() + 40, () => { if (node) node.classList.remove('is-moving'); });
+      }
+
+      /* 2. BACKTRACK / THRASH - the composure ledger. A slide that puts the
+       *    same tile back where the slide before it took it from is a
+       *    backtrack; one made while a wash is burying the board is THRASH,
+       *    and thrash is what the whole class is about. */
+      const isBack = !!lastMove && lastMove.id === res.id && lastMove.from === res.to && lastMove.to === res.from;
+      if (isBack) {
+        backtracks += 1;
+        lockStreak = 0;
+        if (washOn) {
+          thrash += 1;
+          deck('casino', 'thrash');
+          deck('pressure', 'beat', 'thrash');
+          msg('cp_backtrack_line', CP_LEX.cp_backtrack_line, 1600);
+        }
+      }
+      lastMove = { id: res.id, from: res.from, to: res.to };
+
+      /* 3. locks (cosmetic truth: a tile home wears .is-locked, and is still
+       *    perfectly free to slide again - Law I) */
+      applyLockClasses(homeMask(state));
+      const prevLocked = locked;
+      locked = lockedCount(state);
+      bestLocked = Math.max(bestLocked, locked);
+      if (locked > prevLocked) {
+        lockStreak += 1;
+        bestLockStreak = Math.max(bestLockStreak, lockStreak);
+        lastLockAtMs = elapsedMs;
+        clearHint();
+        rescueActive = false;
+        deck('casino', 'lock', locked, tileCount(n));
+        deck('pressure', 'beat', 'lock');
+        // one chime family, a semitone UP per link: you hear the picture settling
+        tick('streak', 0.28 + 0.03 * Math.min(8, lockStreak),
+          { pitch: Math.pow(2, Math.min(7, lockStreak - 1) / 12) });
+        if (locked >= tileCount(n) - 1) msg('cp_lock_line', CP_LEX.cp_lock_line, 1400);
+      }
+
+      /* 4. the decks see the truth AFTER the ledger moved */
+      deck('casino', 'slide', { id: res.id, locked: locked > prevLocked, moves });
+      deck('trickster', 'afterSlide');
+      tick('slide', 0.13 + 0.05 * Math.min(1, lockedFrac()), { pitch: 1 + 0.12 * lockedFrac() });
+
+      paintHud();
+      heat();
+      rewardBeatMaybe(locked > prevLocked);
+
+      /* 5. the board's verdict */
+      if (isSolved(state)) { onSolved(); return true; }
+      if (rescueActive) showHint();
+      after(moveMs(), release);
+      return true;
+    }
+
+    function moveMs() { return reduced ? PLAYTEST.MOVE_MS_REDUCED : PLAYTEST.MOVE_MS; }
+
+    function applyLockClasses(mask) {
+      for (let i = 0; i < mask.length; i++) {
+        const id = state.cells[i];
+        if (id === BLANK) continue;
+        const node = tileEls.get(id);
+        if (!node) continue;
+        if (mask[i]) node.classList.add('is-locked'); else node.classList.remove('is-locked');
+      }
+    }
+
+    /** The variable-ratio canon: the engine's roll, else a seeded local one. */
+    function rewardBeatMaybe(gotLock) {
+      if (!gotLock || solved || ended) return;
+      let r = null;
+      try {
+        if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') {
+          r = ctx.engine.rewardRoll({ streak: lockStreak, success: true }) || null;
+        }
+      } catch (e) { r = null; }
+      if (!r) r = rollLocal();
+      if (r.jackpot) {
+        jackpots += 1;
+        try { ctx.ceremonies.reward('jackpot', { target: boardEl, text: t('cp_jackpot', CP_LEX.cp_jackpot) }); }
+        catch (e) { /* noop */ }
+        fireSafe('flash_burst', { count: 2, alpha: 0.4 });
+        tick('jackpot', 0.65);
+        return;
+      }
+      if (r.nearMiss) {
+        try { ctx.ceremonies.reward('near_miss', { target: boardEl, text: t('cp_near_miss', CP_LEX.cp_near_miss) }); }
+        catch (e) { /* noop */ }
+        tick('near_miss', 0.3);
+      }
+    }
+
+    /* ==================================================================== *
+     * THE SKILL-FLOOR RESCUE (the critic's top fix; LAW)
+     * 20s with no new piece home lights the baseline solver's next move and
+     * fails the declared sGate. The class never ends because of it, and the
+     * board is never played for the player: one cell, lit.
+     * ==================================================================== */
+    function rescueEnabled() { return zen ? PLAYTEST.RESCUE_IN_ZEN : true; }
+    function checkRescue() {
+      if (!rescueEnabled() || solved || ended || !opened || rescueActive || !state) return;
+      if ((elapsedMs - lastLockAtMs) < PLAYTEST.RESCUE_MS) return;
+      rescueActive = true;
+      rescueEpisodes += 1;
+      if (!rescueUsed) {
+        rescueUsed = true;
+        say('skill-floor rescue armed - the class is capped at A from here');
+        try { ctx.ceremonies.stamp({ text: t('cp_stamp_assist', CP_LEX.cp_stamp_assist), tone: 'pink', target: frame }); }
+        catch (e) { /* noop */ }
+      }
+      deck('casino', 'assist');
+      msg('cp_rescue_line', CP_LEX.cp_rescue_line, 3200);
+      tick('whisper', 0.28);
+      showHint();
+    }
+    function showHint() {
+      clearHint();
+      if (!state || solved || ended) return;
+      let mv = null;
+      try { mv = nextMove(state); } catch (e) { mv = null; }
+      if (!mv) { say('rescue: the baseline solver had no answer - no hint this time'); return; }
+      const node = tileEls.get(mv.id);
+      if (!node) return;
+      hintId = mv.id;
+      node.classList.add('is-hint');
+    }
+    function clearHint() {
+      if (hintId >= 0) {
+        const node = tileEls.get(hintId);
+        if (node) node.classList.remove('is-hint');
+      }
+      hintId = -1;
+    }
+
+    /* ==================================================================== *
+     * THE WASHES (the class's own effect) + the other dials
+     * ==================================================================== */
+    function armWashes() {
+      if (!plan || !plan.washes.length) return;
+      for (const w of plan.washes) after(w.atMs, () => runWash(w));
+    }
+    function runWash(w) {
+      if (dead || ended || solved) return;
+      washes += 1;
+      washOn = true;
+      if (stage) stage.setAttribute('data-wash', '1');
+      deck('trickster', 'washOn', true);
+      deck('pressure', 'beat', 'wash');
+      const alpha = w.alpha * (reduced ? 0.6 : 1);
+      sustainSafe('wash', { variant: reduced ? 'pink' : w.variant, alpha, holdMs: w.ms });
+      tick('wash', 0.3);
+      msg('cp_wash_line', CP_LEX.cp_wash_line, 2200);
+      /* THE WHISPER-OUT. NEVER stop('wash') mid-class (CLAUDE.md trap 33):
+       * a LOWER-alpha re-trigger is the step-down and ends the hold cleanly. */
+      const stepAt = Math.max(200, Math.round(w.ms * (1 - plan.washStepdownShare)));
+      after(stepAt, () => {
+        if (dead || ended) return;
+        sustainSafe('wash', {
+          variant: reduced ? 'pink' : w.variant,
+          alpha: alpha * plan.washStepdown,
+          holdMs: Math.max(300, w.ms - stepAt),
+        });
+      });
+      after(w.ms + 250, () => {
+        washOn = false;
+        if (stage) stage.removeAttribute('data-wash');
+        deck('trickster', 'washOn', false);
+      });
+    }
+
+    /** sub_flash on the plan's cadence (tier 3+), heat-shortened, seed-jittered. */
+    function armSubFlash() {
+      if (!plan || plan.subFlashMs <= 0 || ended) return;
+      const ms = cadenceMs(plan.subFlashMs, currentHeat, plan.subJitter[subIdx % plan.subJitter.length]);
+      subTimer = after(ms, () => {
+        subTimer = 0;
+        const r = fireSafe('sub_flash', {
+          anchor: wellEl,
+          variant: plan.subVariants[subIdx % plan.subVariants.length],
+        });
+        if (r) subFlashes += 1;
+        subIdx += 1;
+        armSubFlash();
+      });
+    }
+
+    function openAmbience() {
+      heat();
+      if (plan.bubbles && !reduced) {
+        bubblesOn = !!sustainSafe('bubble_field', { clickSafe: true, variant: 'drift', max: 8, alpha: 0.3 });
+      }
+      if (plan.rowDrift && !reduced && cellEls.length) {
+        const targets = cellEls.filter((c) => (Number(c.getAttribute('data-i')) % n) === 0);
+        driftOn = !!sustainSafe('row_drift', { targets, axis: 'x', variant: 'sway', amplitudeMult: 0.4, stagger: false });
+      }
+      armSubFlash();
+      armWashes();
+    }
+    function stopAmbience() {
+      if (subTimer) { clearTimer(subTimer); subTimer = 0; }
+      if (driftOn) { stopSafe('row_drift'); driftOn = false; }
+      if (bubblesOn) { stopSafe('bubble_field'); bubblesOn = false; }
+    }
+
+    /* ==================================================================== *
+     * THE ENDINGS - solve / bell / zen's own button. Exactly one endClass.
+     * ==================================================================== */
+    function onSolved() {
+      if (solved || ended) return;
+      solved = true;
+      busy = true;
+      clearQueue();
+      clearHint();
+      rescueActive = false;
+      stopClock();
+      setPhase('solved');
+      if (boardEl) boardEl.classList.add('is-solved');
+      if (stage) stage.setAttribute('data-solved', '1');
+      paintHud();
+      deck('casino', 'solved');
+      deck('pressure', 'beat', 'solved');
+      try { ctx.ceremonies.reward('jackpot', { intensity: 1, target: boardEl, text: t('cp_stamp_solved', CP_LEX.cp_stamp_solved) }); }
+      catch (e) { /* noop */ }
+      try { ctx.ceremonies.stamp({ text: t('cp_stamp_solved', CP_LEX.cp_stamp_solved), target: frame }); }
+      catch (e) { /* noop */ }
+      msg(zen ? 'cp_zen_done' : 'cp_solved_line', zen ? CP_LEX.cp_zen_done : CP_LEX.cp_solved_line);
+      tick('jackpot', 0.8);
+      fireSafe('flash_burst', { count: 3, alpha: 0.45 });
+      const playMs = reduced ? PLAYTEST.SOLVE_PLAY_MS_REDUCED : PLAYTEST.SOLVE_PLAY_MS;
+      after(playMs, () => finish('solved'));
+    }
+
+    function bell() {
+      if (dead || ended || solved) return;
+      busy = true;
+      clearQueue();
+      clearGrab();
+      clearHint();
+      bellOn = true;
+      setPhase('ended');
+      deck('casino', 'bell', true);
+      deck('casino', 'dimOut');
+      deck('pressure', 'dimOut');
+      deck('pressure', 'beat', 'bell');
+      try { ctx.ceremonies.stamp({ text: t('cp_stamp_bell', CP_LEX.cp_stamp_bell), tone: 'pink', target: frame }); }
+      catch (e) { /* noop */ }
+      msg('cp_bell_line', CP_LEX.cp_bell_line);
+      tick('stamp', 0.55);
+      after(reduced ? PLAYTEST.CEREMONY_MS_REDUCED : PLAYTEST.CEREMONY_MS, () => finish('bell'));
+    }
+
+    /** ZEN's own way out. Exactly once - the button disables itself. */
+    function onFinishPressed() {
+      if (dead || ended || finished || !zen) return;
+      finished = true;
+      try { if (finishBtn) finishBtn.disabled = true; } catch (e) { /* noop */ }
+      stopClock();
+      finish('left');
+    }
+
+    function finish(reason) {
+      if (ended) return;
+      ended = true;
+      busy = true;
+      stopClock();
+      stopAmbience();
+      clearQueue();
+      clearGrab();
+      clearHint();
+      deck('trickster', 'stop');
+      deck('casino', 'stop');
+      deck('pressure', 'stop');
+      paintHud();                                  // truth on every chip, whatever the trickster left
+
+      const tiles = tileCount(n);
+      const mhNow = manhattan(state);
+      const graded = compositeFor({
+        gradeTier: tier, solved, n, moves, par,
+        manhattanStart: mhStart, manhattanNow: mhNow,
+        locked, tiles, backtracks, thrash, assists: rescueEpisodes,
+      });
+      const gates = hardGates(rescueUsed);
+      const fx = flavorXp({ solved, moves, par, bestMovesBefore });
+
+      /* meta: the standing dare per board size, and how many pictures came back */
+      const bestKey = 'bestMoves' + n;
+      try {
+        const patch = { solves: solvesBefore + (solved ? 1 : 0), lastSeed: seed, lastPlayedAt: Date.now() };
+        if (solved && (!(bestMovesBefore > 0) || moves < bestMovesBefore)) patch[bestKey] = moves;
+        ctx.store.mergeGameMeta(GAME_KEY, patch);
+      } catch (e) { say('meta write failed (class unaffected): ' + ((e && e.message) || e)); }
+
+      renderEnd();
+      setPhase('ended');
+
+      /* ZEN is a PASS, not a letter (DECISIONS #1): no gates, no S, and the
+       * composite rides along only so the report card has something honest to
+       * draw. TIMED carries the composite, the declared gate and the flavour. */
+      const report = zen
+        ? { zen: true, metrics: { composite: graded.composite }, flavorXp: fx }
+        : { metrics: { composite: graded.composite }, hardGates: gates, flavorXp: fx };
+
+      lastReport = Object.assign({}, report, {
+        inputs: {
+          tier, n, zen, seed, retake, reason, solved, moves, bumps, par, baseline,
+          locked, tiles, backtracks, thrash, assists: rescueEpisodes, rescueUsed,
+          manhattanStart: mhStart, manhattanNow: mhNow, elapsedMs, washes, subFlashes,
+          jackpots, bestLockStreak, terms: graded.terms, tax: graded.tax,
+        },
+      });
+      try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
+      say('class over (' + reason + '): ' + (solved ? 'SOLVED' : locked + '/' + tiles + ' home') + ' in '
+        + moves + ' moves (par ' + par + ', baseline ' + baseline + '), '
+        + backtracks + ' backtracks / ' + thrash + ' panic'
+        + (rescueUsed ? ', RESCUE' : '') + (zen ? ' -> zen pass' : ' -> composite ' + graded.composite.toFixed(3)));
+
+      after(reduced ? PLAYTEST.END_HOLD_MS_REDUCED : PLAYTEST.END_HOLD_MS, () => {
+        if (reported) return;
+        reported = true;
+        try { ctx.endClass(report); } catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
+      });
+    }
+
+    function renderEnd() {
+      if (!endEl) return;
+      endEl.textContent = '';
+      endEl.hidden = false;
+      endEl.appendChild(el('h3', 'g-cp-end-title', zen
+        ? t('cp_end_title_zen', CP_LEX.cp_end_title_zen)
+        : t('cp_end_title', CP_LEX.cp_end_title)));
+      const row = (cls, k, v) => {
+        const r = el('div', 'g-cp-end-row' + (cls ? ' ' + cls : ''));
+        r.appendChild(el('span', 'g-cp-end-k', k));
+        r.appendChild(el('span', 'g-cp-end-v', v));
+        endEl.appendChild(r);
+        return r;
+      };
+      const yes = t('cp_end_yes', CP_LEX.cp_end_yes);
+      const no = t('cp_end_no', CP_LEX.cp_end_no);
+      row('g-cp-end-solved', t('cp_end_solved', CP_LEX.cp_end_solved), solved ? yes : no);
+      row('', t('cp_end_locked', CP_LEX.cp_end_locked), locked + '/' + tileCount(n));
+      row('', t('cp_end_moves', CP_LEX.cp_end_moves), String(moves));
+      row('', t('cp_end_par', CP_LEX.cp_end_par), String(par));
+      row('', t('cp_end_backtracks', CP_LEX.cp_end_backtracks), String(backtracks));
+      row('', t('cp_end_thrash', CP_LEX.cp_end_thrash), String(thrash));
+      if (rescueEpisodes > 0) row('g-cp-end-assist', t('cp_end_assists', CP_LEX.cp_end_assists), String(rescueEpisodes));
+      row('', t('cp_end_time', CP_LEX.cp_end_time), mmss(secElapsed()));
+
+      const bestNow = solved && (!(bestMovesBefore > 0) || moves < bestMovesBefore) ? moves : bestMovesBefore;
+      const dare = el('div', 'g-cp-end-dare');
+      dare.appendChild(el('span', 'g-cp-end-k', t('cp_end_best', CP_LEX.cp_end_best)));
+      dare.appendChild(el('span', 'g-cp-end-v', bestNow > 0 ? String(bestNow) : '--'));
+      dare.appendChild(el('p', 'g-cp-end-line', bestMovesBefore > 0
+        ? t('cp_end_best_line', CP_LEX.cp_end_best_line)
+        : t('cp_end_best_first', CP_LEX.cp_end_best_first)));
+      endEl.appendChild(dare);
+    }
+
+    /* ---- clock ----------------------------------------------------------- */
+    function startClock() {
+      lastTick = Date.now();
+      clockId = every(250, () => {
+        if (ended) return;
+        const now = Date.now();
+        const dt = now - lastTick;
+        lastTick = now;
+        elapsedMs += dt / Math.max(0.0001, timeScale);
+        if (clockChip) clockChip.textContent = clockText();
+        checkRescue();
+        deck('trickster', 'stalled', Math.max(0, elapsedMs - lastLockAtMs));
+        if (zen) return;                       // an untimed class has no bell
+        const left = secLeft();
+        if (!bellOn && left <= plan.bellWarnSec && elapsedMs < budgetMs) {
+          bellOn = true;
+          deck('casino', 'bell', true);
+          msg('cp_bell_warn', CP_LEX.cp_bell_warn, 2200);
+          tick('sting', 0.36);
+        }
+        if (elapsedMs >= budgetMs) { stopClock(); run(bell); }
+      });
+    }
+    function stopClock() { if (clockId) { clearTimer(clockId); clockId = 0; } }
+
+    /* ==================================================================== *
+     * THE PEEK (the shell's verb; this file only says what a reveal SHOWS)
+     * ==================================================================== */
+    function wirePeek() {
+      if (!ctx.peek || typeof ctx.peek.setHandlers !== 'function') return;
+      try {
+        ctx.peek.setHandlers({
+          onReveal: () => {
+            if (!peekEl) return;
+            peekEl.hidden = false;
+            if (stage) stage.setAttribute('data-peek', '1');
+          },
+          onHide: () => {
+            if (!peekEl) return;
+            peekEl.hidden = true;
+            if (stage) stage.removeAttribute('data-peek');
+          },
+          onFirstUse: () => {
+            msg('peek_hint', 'Hold to peek. Using it caps this class at A.', 2400);
+          },
+        });
+      } catch (e) { say('peek handlers refused: ' + ((e && e.message) || e)); }
+      try { if (peekBtn && typeof ctx.peek.attach === 'function') ctx.peek.attach(peekBtn); }
+      catch (e) { /* noop */ }
+      /* The manifest declares no keybinds, so this binds nothing today; it
+       * costs nothing and it is the ONE line that would have to change if the
+       * shell ever gives peek a verb slot of its own. */
+      try { if (typeof ctx.peek.bindKeys === 'function') ctx.peek.bindKeys(ctx.keys, 'peek'); }
+      catch (e) { /* noop */ }
+    }
+
+    /* ==================================================================== *
+     * THE DRAWN CLASS-RULES SHEET (Deck VI, Law IV)
+     * Three figures and ONE way out. Policy is the shell's "Skip class
+     * tutorials" contract: on by default every class; with the skip on, a
+     * class still explains itself once per grade tier. CORE builds the
+     * structure and owns the policy; style.js draws it.
+     * ==================================================================== */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function') ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    function howto(onDone) {
+      const seen = howtoSeenTiers();
+      if (ctx.hideTutorial === true && seen.indexOf(tier) >= 0) { onDone(); return; }
+      if (!stage) { onDone(); return; }
+      let done = false;
+      howtoEl = el('div', 'g-cp-howto');
+      howtoEl.appendChild(el('h2', 'g-cp-hw-title', t('cp_howto_title', CP_LEX.cp_howto_title)));
+      const figRow = (figCls, caption) => {
+        const r = el('div', 'g-cp-hw-row');
+        const fig = el('span', 'g-cp-hw-fig ' + figCls);
+        fig.setAttribute('aria-hidden', 'true');
+        fig.style.pointerEvents = 'none';
+        // the drawn parts style.js hangs its gradients and borders off
+        fig.appendChild(el('i', 'g-cp-hw-a'));
+        fig.appendChild(el('i', 'g-cp-hw-b'));
+        fig.appendChild(el('i', 'g-cp-hw-c'));
+        r.appendChild(fig);
+        r.appendChild(el('p', 'g-cp-hw-cap', caption));
+        howtoEl.appendChild(r);
+      };
+      figRow('g-cp-hw-slide', t('cp_howto_slide', CP_LEX.cp_howto_slide));
+      figRow('g-cp-hw-lock', t('cp_howto_lock', CP_LEX.cp_howto_lock));
+      figRow('g-cp-hw-wash', t('cp_howto_wash', CP_LEX.cp_howto_wash));
+      const go = el('button', 'g-cp-hw-go', t('cp_howto_go', CP_LEX.cp_howto_go));
+      go.setAttribute('type', 'button');
+      try { go.type = 'button'; } catch (e) { /* noop */ }
+      go.setAttribute('autofocus', '');
+      go.addEventListener('click', () => {
+        if (done || dead) return;
+        done = true;
+        try {
+          const list = howtoSeenTiers();
+          if (list.indexOf(tier) < 0) {
+            list.push(tier);
+            if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+              ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+            }
+          }
+        } catch (e) { /* best effort - the sheet just shows again next time */ }
+        hideHowto();
+        onDone();
+      });
+      howtoEl.appendChild(go);
+      stage.appendChild(howtoEl);
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+    }
+    function hideHowto() {
+      if (!howtoEl) return;
+      try { howtoEl.remove(); } catch (e) { /* noop */ }
+      howtoEl = null;
+    }
+
+    /* ==================================================================== *
+     * ASSETS - never block a draw. ONE subject, and never a <video>: N tile
+     * viewports would mean N decoders, and 2+ playing videos lock the page to
+     * 30Hz (the Lost & Found trap). A video-only pool simply means the board
+     * wears its numbered faces, which is still a complete puzzle.
+     * ==================================================================== */
+    function pickSubject() {
+      if (!pool || typeof pool.next !== 'function') return null;
+      for (const kind of ['target', 'loop', 'loop', 'loop', 'still', 'still']) {
+        let got = null;
+        try { got = pool.next(kind); } catch (e) { got = null; }
+        const url = got && got.url ? String(got.url) : '';
+        if (url && !VIDEO_URL_RE.test(url)) return url;
+      }
+      say('asset pool served only video loops - numbered faces this class (N viewports would be N decoders)');
+      return null;
+    }
+    function claimAssets() {
+      Promise.resolve()
+        .then(() => ctx.assets.claim({ loops: 4, targets: 1, stills: 2, canvasSafe: false }))
+        .then((p) => {
+          if (dead || !p || typeof p.next !== 'function') return;
+          pool = p;
+          subjectUrl = pickSubject();
+          run(dressTiles);
+        })
+        .catch((e) => say('asset claim failed - numbered faces: ' + ((e && e.message) || e)));
+    }
+
+    /* ==================================================================== *
+     * THE DECKS - written by a parallel agent, so every import is DYNAMIC and
+     * every failure is survivable. The class opens whether they land or not.
+     * ==================================================================== */
+    function loadDecks() {
+      const opt = (path) => import(path).then((m) => m, (e) => {
+        say(path + ' not loaded (' + ((e && e.message) || e) + ')');
+        return null;
+      });
+      return Promise.all([
+        opt('./style.js'), opt('./casino.js'), opt('./trickster.js'), opt('./pressure.js'),
+      ]).then(([styleMod, casinoMod, tricksterMod, pressureMod]) => {
+        if (dead) return;
+        try {
+          if (styleMod && typeof styleMod.injectComposureStyle === 'function') {
+            styleMod.injectComposureStyle();
+            styleOk = true;
+          }
+        } catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
+        if (!styleOk) injectFallbackStyle();
+
+        const capsOk = capsArmed();
+        try {
+          if (casinoMod && typeof casinoMod.createCpCasino === 'function') {
+            casino = casinoMod.createCpCasino({
+              seed, tier, stage, frame, board: boardEl, hud, backdrop,
+              timers: deckTimers, reduced, capsOk, t, engine: deckEngine, assets: deckAssets,
+              mode: zen ? 'zen' : 'timed', log: say,
+            }) || null;
+          }
+        } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+        try {
+          if (tricksterMod && typeof tricksterMod.createCpTrickster === 'function') {
+            trickster = tricksterMod.createCpTrickster({
+              seed, tier, timers: deckTimers, reduced, capsOk,
+              mode: zen ? 'zen' : 'timed',
+              budgetSec: zen ? 0 : Math.round(budgetMs / 1000),
+              isHalted: () => dead || paused || ended || busy,
+              t,
+              stats: () => ({
+                moves, locked, tiles: tileCount(n), n, lockedFrac: lockedFrac(),
+                secLeft: secLeft(), budgetSec: zen ? 0 : Math.round(budgetMs / 1000),
+                mode: zen ? 'zen' : 'timed', backtracks, thrash, washOn, solved,
+              }),
+              chipEl: (which) => (which === 'clock' ? clockChip : which === 'moves' ? movesChip : lockedChip),
+              chipText,
+              /* the ONE surface a lie may be drawn on; tile truth never moves */
+              preview: previewEl,
+              tiles: () => Array.from(tileEls.values()),
+              engine: deckEngine,
+              assets: deckAssets,
+              announce: (text, ms) => {
+                if (!msgEl || !text) return;
+                msgEl.textContent = String(text);
+                const mine = msgEl.textContent;
+                deckTimers.after(Math.max(400, Number(ms) || 1600), () => {
+                  if (msgEl && msgEl.textContent === mine) msgEl.textContent = '';
+                });
+              },
+              log: say,
+            }) || null;
+          }
+        } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+        try {
+          if (pressureMod && typeof pressureMod.createCpPressure === 'function') {
+            pressure = pressureMod.createCpPressure({
+              seed, gradeTier: tier, reduced, motionLevel: motionLevelOf(),
+              stage, frame, board: boardEl,
+              hud: { moves: movesChip, clock: clockChip, locked: lockedChip, calm: calmChip },
+              engine: deckEngine, assets: deckAssets, timers: deckTimers, capsOk: capsArmed,
+              mode: zen ? 'zen' : 'timed', log: say,
+            }) || null;
+          }
+        } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+
+        /* The decks may land after the board opened (two dynamic imports); if
+         * they did, start them where they are. */
+        if (opened && !ended) {
+          deck('casino', 'start');
+          deck('pressure', 'start');
+          deck('trickster', 'start');
+          heat();
+        }
+      });
+    }
+
+    /* ==================================================================== *
+     * OPEN - the rules sheet is done, the board is the player's.
+     * ==================================================================== */
+    function openClass() {
+      if (dead || ended || opened) return;
+      setPhase('play');
+      msg('cp_play_hint', CP_LEX.cp_play_hint, 3000);
+      opened = true;
+      busy = false;
+      lastLockAtMs = 0;
+      elapsedMs = 0;
+      deck('casino', 'start');
+      deck('pressure', 'start');
+      deck('trickster', 'start');
+      openAmbience();
+      startClock();
+    }
+
+    /* ==================================================================== *
+     * THE MODULE INSTANCE
+     * ==================================================================== */
+    const instance = {
+      start(classSpec) {
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
+        tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
+        seed = String(spec.seed == null ? GAME_KEY : spec.seed);
+        retake = !!spec.retake;
+        reduced = probeReduced(ctx);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
+
+        const mode = String((ctx.settings && ctx.settings.cp_mode) != null ? ctx.settings.cp_mode : 'timed')
+          .trim().toLowerCase();
+        zen = mode === 'zen';
+        n = zen
+          ? sizeFromSetting(ctx.settings && ctx.settings.cp_zen_grid, 3)
+          : gridForTier(tier);
+
+        plan = buildPlan({ seed, gradeTier: tier, n, zen, timeBudgetSec: budgetMs / 1000 });
+
+        /* THE BOARD. Seeded, and SOLVABLE by construction (board.js repairs a
+         * bad parity). The assertion below is belt and braces: a board that
+         * cannot be solved is the one thing this class may never deal. */
+        const scrambleSeed = seed + '|cp-scramble|' + n + (zen ? '|zen' : '');
+        state = dealBoard(n, scrambleSeed, { walk: scrambleWalkFor(tier, zen) });
+        if (!isSolvable(state.cells, n)) {
+          say('FATAL-ish: the dealt board failed the parity test - re-dealing solved-adjacent');
+          state = dealBoard(n, scrambleSeed + '|repair', { walk: Math.max(20, n * n * 2) });
+        }
+        mhStart = manhattan(state);
+        locked = lockedCount(state);
+        bestLocked = locked;
+
+        /* THE BASELINE. par is derived from a real solve of THIS scramble, not
+         * a table someone guessed (dossier open question 3). A solver that
+         * cannot answer leaves par on the per-tile fallback and the rescue
+         * without a hint - never a throw inside a live class. */
+        baseline = -1;
+        try { baseline = baselineLength(cloneState(state)); } catch (e) { baseline = -1; }
+        par = parFor(baseline, tier, n);
+
+        /* Law V: even the FALLBACK reward roll (used only when the engine is
+         * absent) runs off the class seed, in its own append-only namespace. */
+        rollLocal = (() => {
+          const roll = makeTaggedRoll(seed + '|cp-vr');
+          return () => {
+            const chance = Math.min(1, 0.28 + 0.3 * currentHeat + Math.min(8, lockStreak) * 0.03);
+            const r = roll('fire');
+            const fire = r < chance;
+            return { fire, jackpot: fire && roll('jack') >= 0.85, nearMiss: !fire && r < chance + 0.08 };
+          };
+        })();
+
+        try {
+          const m = (ctx.store && typeof ctx.store.gameMeta === 'function') ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+          solvesBefore = Math.max(0, Number(m.solves) || 0);
+          bestMovesBefore = Math.max(0, Number(m['bestMoves' + n]) || 0);
+        } catch (e) { solvesBefore = 0; bestMovesBefore = 0; }
+
+        buildDom();
+        wirePeek();
+        bindInput();
+        claimAssets();
+        applyLockClasses(homeMask(state));
+        paintHud();
+
+        /* The decks (and the look) land asynchronously; the class does not wait
+         * on them. The rules sheet runs first either way. */
+        try { loadDecks(); } catch (e) { injectFallbackStyle(); }
+
+        msg(zen ? 'cp_brief_zen' : 'cp_brief', zen ? CP_LEX.cp_brief_zen : CP_LEX.cp_brief);
+        howto(() => {
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, openClass);
+        });
+
+        liveClass = instance;
+        lastReport = null;
+        lastSnapshot = null;
+        say('tier ' + tier + ' ' + n + 'x' + n + ' ' + (zen ? 'ZEN' : Math.round(budgetMs / 1000) + 's')
+          + ', scramble mh ' + mhStart + ', baseline ' + baseline + ', par ' + par
+          + (reduced ? ', reduced' : '') + (retake ? ', RETAKE' : ''));
+      },
+
+      pause() {
+        if (paused) return;
+        paused = true;
+        clearGrab();
+        clearQueue();
+        try { if (ctx.peek && typeof ctx.peek.forceHide === 'function') ctx.peek.forceHide(); } catch (e) { /* noop */ }
+        deck('pressure', 'pause');
+        deck('casino', 'pause');
+        if (stage) stage.classList.add('suspended');
+      },
+
+      resume() {
+        if (!paused) return;
+        paused = false;
+        if (stage) stage.classList.remove('suspended');
+        deck('pressure', 'resume');
+        deck('casino', 'resume');
+        lastTick = Date.now();
+        const q = deferred.splice(0);
+        for (const fn of q) run(fn);
+      },
+
+      /** The shell owns the overlay and the engine's suspend; we just freeze. */
+      suspend(on) { if (on) instance.pause(); else instance.resume(); },
+
+      destroy() {
+        dead = true;
+        clearQueue();
+        clearGrab();
+        clearHint();
+        opened = false;
+        stopClock();
+        clearTimers();
+        stopAmbience();
+        unbindInput();
+        hideHowto();
+        try { if (ctx.peek && typeof ctx.peek.forceHide === 'function') ctx.peek.forceHide(); } catch (e) { /* noop */ }
+        try { if (finishBtn) finishBtn.removeEventListener('click', onFinishPressed); } catch (e) { /* noop */ }
+        finishBtn = null;
+        peekBtn = null;
+        try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
+        trickster = null;
+        try { if (casino) casino.destroy(); } catch (e) { /* noop */ }
+        casino = null;
+        try { if (pressure) pressure.destroy(); } catch (e) { /* noop */ }
+        pressure = null;
+        if (pool && typeof pool.release === 'function') { try { pool.release(); } catch (e) { /* noop */ } }
+        pool = null;
+        tileEls.clear();
+        cellEls.length = 0;
+        try { ctx.root.textContent = ''; } catch (e) { /* noop */ }
+        if (liveClass === instance) liveClass = null;
+      },
+
+      /* -------- test / diagnostics seams (never read by the shell) -------- */
+      /** Press as the player would: ('dir','left') or ('pos', 7). */
+      press(kind, v) { return press(kind, v); },
+      /** Click a tile by its id, as the pointer would. */
+      tap(id) { onTileClick(id); },
+      /** The live puzzle model (the harness stages boards on it). */
+      state() { return state; },
+      /** The TRUE chip text - what the trickster restores after a lie. */
+      chipText(which) { return chipText(which); },
+      /** Re-sync every tile element to the model after the harness staged a board. */
+      resync() {
+        if (!state) return;
+        paintTiles(true);
+        locked = lockedCount(state);
+        applyLockClasses(homeMask(state));
+        paintHud();
+        heat();
+      },
+      /** Open the board without waiting on the rules sheet (harness only). */
+      open() { hideHowto(); openClass(); },
+      /** Arm the rescue as the stall timer would (harness only). */
+      forceRescue() { lastLockAtMs = elapsedMs - PLAYTEST.RESCUE_MS - 1; checkRescue(); },
+      /** Run a wash window now (harness only). */
+      forceWash(ms) { runWash({ atMs: 0, ms: Math.max(200, Number(ms) || 1200), alpha: 0.3, variant: 'pink' }); },
+      /** End as the bell would (harness only). */
+      forceBell() { stopClock(); bell(); },
+
+      snapshot() {
+        return {
+          tier, n, zen, seed, retake, reduced, styleOk,
+          plan: plan ? {
+            washes: plan.washes.length, subFlashMs: plan.subFlashMs, heatCap: plan.heatCap,
+            audioCeil: plan.audioCeil, bubbles: plan.bubbles, rowDrift: plan.rowDrift,
+          } : null,
+          board: state ? serialize(state) : '',
+          cells: state ? state.cells.slice() : [],
+          blank: state ? state.blank : -1,
+          solvable: state ? isSolvable(state.cells, n) : false,
+          manhattan: state ? manhattan(state) : 0,
+          mhStart, baseline, par,
+          moves, bumps, backtracks, thrash, locked, bestLocked, tiles: tileCount(n),
+          lockStreak, bestLockStreak, solved, washOn, washes, subFlashes, jackpots,
+          rescueUsed, rescueActive, rescueEpisodes, hintId,
+          currentHeat, bellOn, finished, elapsedMs, budgetMs,
+          ended, reported, busy, paused, dead, opened, queued,
+          phase: stage ? stage.getAttribute('data-phase') : null,
+          peekOpen: !!(peekEl && peekEl.hidden === false),
+          howtoUp: !!howtoEl,
+          liveTileEls: tileEls.size,
+          subjectUrl,
+          stage, frame, boardEl, previewEl, peekEl, wellEl, msgEl, endEl, howtoEl,
+          movesChip, clockChip, lockedChip, calmChip, peekBtn, finishBtn,
+          casino: casino && typeof casino.diagnostics === 'function' ? (() => { try { return casino.diagnostics(); } catch (e) { return null; } })() : null,
+          trickster: trickster && typeof trickster.diagnostics === 'function' ? (() => { try { return trickster.diagnostics(); } catch (e) { return null; } })() : null,
+          pressure: pressure && typeof pressure.diagnostics === 'function' ? (() => { try { return pressure.diagnostics(); } catch (e) { return null; } })() : null,
+        };
+      },
+    };
+    return instance;
+  },
+
+  /** The live class's state, or null. Never read by the shell. */
+  diagnostics() { return liveClass ? liveClass.snapshot() : null; },
+
+  /** The last report handed to endClass (survives teardown). Diagnostics only. */
+  get lastReport() { return lastReport; },
+
+  /** The final snapshot of the last class (survives teardown). Diagnostics only. */
+  get lastSnapshot() { return lastSnapshot; },
+
+  setTimeScale,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
@@ -536,9 +536,7 @@ export default {
         const cell = el('div', 'g-cp-cell');
         cell.setAttribute('data-i', String(i));
         cell.style.setProperty('--r', String(rowOf(n, i)));
-        cell.style.setProperty('--cp-r', String(rowOf(n, i)));  // registered twin (iOS: unregistered vars in calc() do not transition)
         cell.style.setProperty('--c', String(colOf(n, i)));
-        cell.style.setProperty('--cp-c', String(colOf(n, i)));  // registered twin (iOS: unregistered vars in calc() do not transition)
         boardEl.appendChild(cell);
         cellEls.push(cell);
       }
@@ -607,9 +605,7 @@ export default {
         if (id === BLANK) continue;
         const node = fresh ? tileElFor(id) : (tileEls.get(id) || tileElFor(id));
         node.style.setProperty('--r', String(rowOf(n, pos)));
-        node.style.setProperty('--cp-r', String(rowOf(n, pos)));  // registered twin (iOS: unregistered vars in calc() do not transition)
         node.style.setProperty('--c', String(colOf(n, pos)));
-        node.style.setProperty('--cp-c', String(colOf(n, pos)));  // registered twin (iOS: unregistered vars in calc() do not transition)
       }
     }
 
@@ -845,9 +841,7 @@ export default {
       const node = tileEls.get(res.id);
       if (node) {
         node.style.setProperty('--r', String(rowOf(n, res.to)));
-        node.style.setProperty('--cp-r', String(rowOf(n, res.to)));  // registered twin (iOS: unregistered vars in calc() do not transition)
         node.style.setProperty('--c', String(colOf(n, res.to)));
-        node.style.setProperty('--cp-c', String(colOf(n, res.to)));  // registered twin (iOS: unregistered vars in calc() do not transition)
         node.classList.add('is-moving');
         after(moveMs() + 40, () => { if (node) node.classList.remove('is-moving'); });
       }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/lex.js
@@ -1,0 +1,88 @@
+/* ============================================================================
+ * games/composure/lex.js - every `cp_` lexicon row COMPOSURE renders, with its
+ * neutral English fallback. Exported as DATA (the Impulse Control / Deep End
+ * precedent, IC_LEX / DE_LEX) so the host's `NeutralLexicon` can be mirrored
+ * key-for-key: copy the values, never re-word them.
+ *
+ * RULES (CLAUDE.md trap 26 + the build contract): a value longer than 96
+ * characters can never be mod-skinned, so every row here is <= 96; a row is
+ * rendered ONLY through ctx.lexicon(key, fallback) (Law VII - accents come
+ * from the lexicon, never AI).
+ *
+ * TWO ROWS THIS GAME DELIBERATELY DOES NOT MINT: `peek` and `peek_hint` are
+ * the SHELL's shared rows (Lost & Found renders the same two). Peek is one
+ * verb across the campus - see shell/peek.js - so its label is one string.
+ *
+ * The `cp_trick_*` rows are the trickster deck's (CREATIVE owns trickster.js;
+ * CORE ships the rows so the mirror script sees them). A deck that needs a
+ * string this table does not carry must ask for the row, never invent one.
+ * ==========================================================================*/
+
+export const CP_LEX = Object.freeze({
+  /* ---- setting rows (manifest.settings) -------------------------------- */
+  cp_mode: 'Mode',
+  cp_mode_hint: 'Timed is one graded class. Zen is untimed, gentle, and always a pass.',
+  cp_zen_grid: 'Zen board',
+  cp_zen_grid_hint: 'Zen only. A timed class plays the board your year has earned.',
+
+  /* ---- HUD chips (aria labels; the chip TEXT is live data) -------------- */
+  cp_chip_moves: 'Moves',
+  cp_chip_clock: 'Time left',
+  cp_chip_locked: 'Pieces home',
+  cp_chip_calm: 'Composure',
+
+  /* ---- the drawn class-rules sheet (Deck VI, Law IV) -------------------- */
+  cp_howto_title: 'Class rules',
+  cp_howto_slide: 'Tap a piece beside the gap and it slides in. Arrows, WASD and swipes do the same.',
+  cp_howto_lock: 'A piece that reaches its own place locks with a snap. It can still be slid.',
+  cp_howto_wash: 'The room will bury the board. Keep sliding - the picture underneath never moved.',
+  cp_howto_go: 'Start the picture',
+
+  /* ---- proctor lines (.g-cp-msg, one at a time) ------------------------- */
+  cp_brief: 'One picture, cut apart and still moving. Put it back together.',
+  cp_brief_zen: 'No clock tonight. Slide until it is whole again.',
+  cp_play_hint: 'Tap a piece beside the gap. Arrows, WASD or swipe.',
+  cp_lock_line: 'That one is home.',
+  cp_backtrack_line: 'Back where it was. Breathe.',
+  cp_wash_line: 'Keep sliding. The board is still exactly where you left it.',
+  cp_rescue_line: 'Take the lit piece. The grade eases; the class does not end.',
+  cp_solved_line: 'Whole. Watch it play.',
+  cp_bell_warn: 'Twenty seconds.',
+  cp_bell_line: 'The bell. Hands off the board.',
+  cp_zen_done: 'Whole, in your own time.',
+  cp_retake: 'Retake',
+  cp_finish: 'Finish',
+  cp_peek_ref: 'The finished picture',
+
+  /* ---- stamps + ceremonies ---------------------------------------------- */
+  cp_stamp_solved: 'COMPOSED',
+  cp_stamp_lock: 'HOME',
+  cp_stamp_bell: 'BELL',
+  cp_stamp_assist: 'ASSIST',
+  cp_jackpot: 'JACKPOT',
+  cp_near_miss: 'SO CLOSE',
+
+  /* ---- the end card (.g-cp-end) ----------------------------------------- */
+  cp_end_title: 'Composure report',
+  cp_end_title_zen: 'Zen board',
+  cp_end_solved: 'Solved',
+  cp_end_moves: 'Moves',
+  cp_end_par: 'Baseline',
+  cp_end_locked: 'Pieces home',
+  cp_end_backtracks: 'Backtracks',
+  cp_end_thrash: 'Panic moves',
+  cp_end_assists: 'Assists',
+  cp_end_time: 'Time',
+  cp_end_yes: 'Yes',
+  cp_end_no: 'No',
+  cp_end_best: 'Best solve',
+  cp_end_best_line: 'Your standing mark on this board. Beat it next class.',
+  cp_end_best_first: 'Your first finished picture on this board.',
+
+  /* ---- the trickster deck's taunts (trickster.js, via announce) ---------- */
+  cp_trick_preview: 'Did it move?',
+  cp_trick_seen: 'That is not where that piece is.',
+  cp_trick_melt: 'One of them is running.',
+});
+
+export default CP_LEX;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/pressure.js
@@ -1,0 +1,795 @@
+/* ============================================================================
+ * games/composure/pressure.js - DECK IV of the House Rules for the studio: THE
+ * SURGE. The casino lights the room, the trickster lies about the picture;
+ * this file is what the room DOES to you as the picture comes together. The
+ * ladder is PROGRESS-driven: the rung is the fraction of pieces sitting home
+ * (index.js calls setProgress after its own accounting); a piece pulled back
+ * out steps the storm DOWN behind a hysteresis (fades, never a snap).
+ * Magnitude rides the class heat. Same seed, same surge.
+ *
+ * THE RUNG TABLE (locked fraction -> rung -> what switches ON; cumulative):
+ *   < .15   rung 0  clean studio (the casino's lamp is all there is)
+ *   .15     rung 1  BREATH      a pink wash breathes on a cadence         [engine wash:pink]
+ *   .30     rung 2  BUBBLES     a slow bubble field drifts over the room  [engine bubble_field]
+ *   .45     rung 3  DRIFT       the HUD chips sway + THE TREMOR wakes     [engine row_drift:sway]
+ *                               + the haze comes up under the washes     [local .g-cp-p-haze]
+ *   .60     rung 4  BURST       gif bursts ride locks                    [engine gif_burst]
+ *   .75     rung 5  WHEEL       the spiral wash wakes (a real image)     [engine wash:spiral url]
+ *                               + the easel shudders on locks            [engine glitch_swap]
+ *   .90     rung 6  SUBS        sub flash stream + flash bursts on locks [engine sub_flash, flash_burst]
+ *   solve   rung 7  ROYAL       the pink flood, three flash bursts, the  [engine wash:pink, flash_burst,
+ *                               easel rolls, the ring goes gold           glitch_swap]
+ * ZEN plays ONLY the lowest two rungs (breath + bubbles): no tremor, no
+ * drift, no bursts, no wheel, no subs; the solve is a warm pink breath.
+ *
+ * THE TREMOR: the easel (.g-cp-frame) and the HUD vibrate from rung 3 - a
+ * continuous low tremor whose amplitude grows with the rung, a PUNCH on every
+ * lock sized by the streak, heavier on the solve. Extend-not-stack with a
+ * quadratic ring-down (dtrh screenShake posture), written on the frame's and
+ * the hud's individual CSS `translate` (nothing else transforms them) - NEVER
+ * on a tile: the tiles are the tap targets and --r/--c is index.js's. A rAF
+ * loop ONLY while something moves; pause()/stop()/destroy() halt it.
+ *
+ * THE HAZE (trap 35): the clip under the engine's screen-blended washes is
+ * bright; a dimmer over the canvas (opacity by rung x heat, a FLARE under
+ * every burst) is what puts the effects in FRONT without touching the
+ * engine's ceilings. Opacity only. THE RING: a box-shadow bloom around the
+ * canvas - the reduced-motion body of every punch, gold for the bell.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the numbers index.js hands it, writes nothing
+ *       about moves, locks, time or grade; chip TEXT is never touched.
+ *   II  input honest  - the frame's translate is sub-3px (the gesture surface
+ *       is the whole tile); every node is pointer-events:none; no tile is
+ *       transformed, covered or written.
+ *   III never still   - from rung 1 the room breathes; from rung 3 it shakes.
+ *   V   seeded        - per-tag mulberry32 off seed+'|cp-pressure|' (append-
+ *       only tags); the engine's own rng is separate and fine.
+ *   VI  exits sacred  - capsOk false (bgIntensity 0) = zero fires, zero
+ *       tremor, no nodes; reduced motion / motionLevel 0 = no tremor (punches
+ *       become the ring bloom), no shudder; every timer lives in the game's
+ *       pause-aware registry AND a local set; pause() halts the loop.
+ *   VII strings      - this file renders no text at all.
+ *
+ * NEVER: engine.stop('wash'). It blacks out EVERY wash kind at once (trap 33).
+ * A wash is stepped down by re-triggering its variant at a whisper alpha with
+ * a short hold (the engine's own transition carries it out) - including on
+ * stop() and destroy(). The one spiral gif is chosen once per class (sp6/sp7
+ * weighted, sp5 never).
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const CP_PRESSURE = Object.freeze({
+  /** locked fraction thresholds per rung (index = rung). Monotone. */
+  RUNG_FRAC: Object.freeze([0, 0.15, 0.3, 0.45, 0.6, 0.75, 0.9, 1.01]),
+  RUNG_MAX: 7,
+  ZEN_RUNG_MAX: 2,
+  LADDER: Object.freeze([
+    Object.freeze({ rung: 0, adds: Object.freeze([]), cue: null }),
+    Object.freeze({ rung: 1, adds: Object.freeze(['breath']), cue: 'wash' }),
+    Object.freeze({ rung: 2, adds: Object.freeze(['bubbles']), cue: 'whisper' }),
+    Object.freeze({ rung: 3, adds: Object.freeze(['drift', 'haze']), cue: 'whisper' }),
+    Object.freeze({ rung: 4, adds: Object.freeze(['burst']), cue: 'burst' }),
+    Object.freeze({ rung: 5, adds: Object.freeze(['wheel']), cue: 'wash' }),
+    Object.freeze({ rung: 6, adds: Object.freeze(['subs']), cue: 'glitch' }),
+    Object.freeze({ rung: 7, adds: Object.freeze(['royal']), cue: 'near_miss' }),
+  ]),
+  HYST_MS: 1800,
+  HEAT_REPAINT_STEP: 0.08,
+  /* ---- THE TREMOR ------------------------------------------------------ */
+  TREMOR_RUNG: 3,
+  TREMOR_PX: Object.freeze([0, 0, 0, 0.45, 0.7, 1.0, 1.5, 2.2]),
+  TREMOR_CAP_PX: 3,
+  TREMOR_HEAT_FLOOR: 0.5,
+  TREMOR_HZ_FAST: Object.freeze([7, 11]),
+  TREMOR_HZ_SLOW: Object.freeze([1.6, 2.8]),
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  HUD_MUL: 0.6,
+  PUNCH_PX_BASE: 1.2,
+  PUNCH_PX_STREAK: 0.5,
+  PUNCH_PX_CAP: 7,
+  PUNCH_MS_BASE: 200,
+  PUNCH_MS_STREAK: 25,
+  PUNCH_MS_CAP: 450,
+  PUNCH_SLIDE_PX: 0.6,
+  PUNCH_SLIDE_MS: 120,
+  PUNCH_THRASH_PX: 2.2,
+  PUNCH_THRASH_MS: 260,
+  PUNCH_ROYAL_PX: 7,
+  PUNCH_ROYAL_MS: 450,
+  CHIP_PUNCH_SCALE: Object.freeze([1.06, 1.26]),
+  BLOOM_MS: 320,
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([8500, 5200]),
+  BREATH_HOLD_MS: 2400,
+  BREATH_ALPHA: Object.freeze([0.12, 0.4]),
+  BUBBLE_MAX: Object.freeze([6, 14]),
+  BUBBLE_ALPHA: Object.freeze([0.25, 0.5]),
+  HAZE_A: Object.freeze([0.12, 0.3]),
+  HAZE_FLARE: 0.6,
+  BURST_CHANCE: Object.freeze([0.4, 0.9]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  BURST_HOLD_MS: 900,
+  WHEEL_ALPHA: Object.freeze([0.18, 0.42]),   // a shade under DE (.22-.55): the picture must stay legible under the wheel
+  SHUDDER_CHANCE: Object.freeze([0.35, 0.8]),
+  SHUDDER_S: 0.45,
+  SUB_VARIANT: 'scatter',
+  ROYAL_FLOOD_MS: 3200,
+  ROYAL_FLOOD_A: 0.65,
+  ZEN_SOLVE_A: 0.35,
+  /** cue level = min(AUDIO_CEIL[gradeTier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.25,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  /* ---- the one spiral image per class ---------------------------------- */
+  SPIRAL_DIR: '../../../dtrh/assets/bubbles/effects/spirals/',
+  SPIRALS: Object.freeze([
+    Object.freeze({ file: 'sp6.gif', w: 4 }),
+    Object.freeze({ file: 'sp7.gif', w: 4 }),
+    Object.freeze({ file: 'sp1.gif', w: 1 }),
+    Object.freeze({ file: 'sp2.webp', w: 1 }),
+    Object.freeze({ file: 'sp3.gif', w: 1 }),
+    Object.freeze({ file: 'sp4.webp', w: 1 }),
+  ]),
+  NODE_BUDGET: 2,
+});
+
+const STYLE_ID = 'g-cp-pressure-style';
+const STYLE_TEXT = `
+/* ---- PRESSURE (House Rules, Deck IV) --------------------------------------- */
+/* THE TREMOR is not here: pressure.js writes the frame's and the HUD's
+   individual translate from one rAF loop, never a tile. What IS here: the haze
+   (a dimmer over the canvas whose opacity climbs with the rung, so the engine's
+   screen-blended washes read over a bright clip), the ring (the reduced-motion
+   body of a punch) and the chip bloom. Every layer pointer-events:none. */
+.g-cp-p-haze{position:absolute;inset:0;z-index:3;pointer-events:none;opacity:0;
+  background:radial-gradient(80% 80% at 50% 50%, rgba(10,4,16,.2), rgba(10,4,16,.7) 100%);
+  transition:opacity .8s ease}
+.g-cp-p-haze.is-on{opacity:var(--cp-p-ha,.25)}
+.g-cp-p-haze.is-flare{transition-duration:.08s}
+.g-cp-p-ring{position:absolute;inset:-8px;z-index:4;pointer-events:none;display:block;border-radius:6px;opacity:0;
+  transition:opacity .5s ease;--cp-p-rc:var(--pink);
+  box-shadow:0 0 0 2px color-mix(in srgb, var(--cp-p-rc), transparent 30%), 0 0 34px color-mix(in srgb, var(--cp-p-rc), transparent 45%),
+    inset 0 0 40px color-mix(in srgb, var(--cp-p-rc), transparent 60%)}
+.g-cp-p-ring.is-hit{opacity:.75;transition-duration:.04s}
+.g-cp-p-ring.is-deep{opacity:1;
+  box-shadow:0 0 0 3px color-mix(in srgb, var(--cp-p-rc), transparent 15%), 0 0 60px color-mix(in srgb, var(--cp-p-rc), transparent 30%),
+    inset 0 0 70px color-mix(in srgb, var(--cp-p-rc), transparent 45%)}
+.g-cp-p-ring.is-gold{--cp-p-rc:var(--gold)}
+.g-cp-chip.g-cp-p-bloom{transition-duration:.3s,.3s,.05s;
+  box-shadow:0 0 0 1px color-mix(in srgb, var(--pink), transparent 20%), 0 0 22px color-mix(in srgb, var(--pink), transparent 35%)}
+/* reduced motion (both gates) */
+html.arc-reduced .g-cp-p-haze.is-on{opacity:calc(var(--cp-p-ha,.25) * .7)}
+@media (prefers-reduced-motion: reduce){
+  .g-cp-p-haze.is-on{opacity:calc(var(--cp-p-ha,.25) * .7)}
+}
+`;
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return true;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);
+    return true;
+  } catch (e) { return false; }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** locked fraction (0..1) -> rung (0..6; 7 is the solve, entered by beat). Pure. */
+export function rungFor(frac, zen) {
+  const f = clamp01(frac);
+  let r = 0;
+  const T = CP_PRESSURE.RUNG_FRAC;
+  for (let i = 1; i < T.length; i++) { if (f >= T[i]) r = i; }
+  r = Math.min(r, CP_PRESSURE.RUNG_MAX - 1);
+  if (zen) r = Math.min(r, CP_PRESSURE.ZEN_RUNG_MAX);
+  return r;
+}
+/** The idle tremor amplitude in px. 0 under reduced motion; heat scales it. Pure. */
+export function tremorAmpPx(rung, heat01, reducedMotion) {
+  if (reducedMotion) return 0;
+  const base = CP_PRESSURE.TREMOR_PX[Math.max(0, Math.min(CP_PRESSURE.RUNG_MAX, Math.round(Number(rung) || 0)))] || 0;
+  if (base <= 0) return 0;
+  const f = CP_PRESSURE.TREMOR_HEAT_FLOOR;
+  const amp = base * (f + (1 - f) * clamp01(heat01));
+  return Math.min(CP_PRESSURE.TREMOR_CAP_PX, +amp.toFixed(3));
+}
+/** A lock punch: { px, ms, scale } from the streak. Pure, capped. */
+export function punchFor(streak) {
+  const s = Math.max(0, Math.min(8, Number(streak) || 0));
+  const P = CP_PRESSURE;
+  const px = Math.min(P.PUNCH_PX_CAP, P.PUNCH_PX_BASE + P.PUNCH_PX_STREAK * s);
+  const ms = Math.min(P.PUNCH_MS_CAP, Math.round(P.PUNCH_MS_BASE + P.PUNCH_MS_STREAK * s));
+  const scale = +lerp(P.CHIP_PUNCH_SCALE, s / 8).toFixed(3);
+  return { px: +px.toFixed(2), ms, scale };
+}
+
+function pickSpiral(roll) {
+  const list = CP_PRESSURE.SPIRALS;
+  let total = 0;
+  for (const s of list) total += s.w;
+  let r = roll * total;
+  let file = list[0].file;
+  for (const s of list) { r -= s.w; if (r <= 0) { file = s.file; break; } }
+  let href = CP_PRESSURE.SPIRAL_DIR + file;
+  try { href = new URL(CP_PRESSURE.SPIRAL_DIR + file, import.meta.url).href; } catch (e) { /* relative is fine */ }
+  return { file, href };
+}
+function el(tag, cls) {
+  try { const n = document.createElement(tag); if (cls) n.className = cls; return n; } catch (e) { return null; }
+}
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function rafFn() {
+  try { if (typeof requestAnimationFrame === 'function') return requestAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function cafFn() {
+  try { if (typeof cancelAnimationFrame === 'function') return cancelAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.cancelAnimationFrame === 'function') return globalThis.cancelAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+
+/**
+ * @param {Object} o
+ *   seed, gradeTier, reduced, motionLevel, stage, frame, board,
+ *   hud:{moves,clock,locked,calm} (elements), engine:{fire,sustain,stop,channels},
+ *   assets:{next(kind)}, timers:{after,every,clear}, capsOk:()=>bool|boolean,
+ *   mode?: 'timed'|'zen' (else read off stage data-mode), log
+ */
+export function createCpPressure(o) {
+  const opts = o || {};
+  const P = CP_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const gradeTier = Math.max(1, Math.min(4, Number(opts.gradeTier) || 1));
+  const audioCeil = P.AUDIO_CEIL[gradeTier] || P.AUDIO_CEIL[1];
+  const hud = opts.hud || {};
+  const eng = opts.engine || {};
+  const frame = opts.frame || (opts.board && opts.board.parentNode) || null;
+  const armedBase = !!opts.stage && !!frame && !!opts.timers && typeof opts.timers.after === 'function'
+    && typeof document !== 'undefined';
+  let mode = String(opts.mode || '').toLowerCase();
+  if (mode !== 'zen' && mode !== 'timed') {
+    try { mode = String(opts.stage.getAttribute('data-mode') || 'timed').toLowerCase() === 'zen' ? 'zen' : 'timed'; } catch (e) { mode = 'timed'; }
+  }
+  const zen = mode === 'zen';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk === true;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers ------------------------------------------------------------ */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+
+  /* ---- seeded streams ---------------------------------------------------- */
+  const seedBase = String(opts.seed || 'cp') + '|cp-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ---------------------------------------------- */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.fire !== 'function') return null;
+    try { return eng.fire(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.sustain !== 'function') return null;
+    try { return eng.sustain(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  /** stop() for kinds that are NOT wash (trap 33: wash is never stopped). */
+  function stopKind(kind) {
+    if (!armedBase || destroyed || kind === 'wash') return;
+    count('stop:' + kind);
+    if (typeof eng.stop !== 'function') return;
+    try { eng.stop(kind); } catch (e) { /* ignore */ }
+  }
+  function cue(name, rung) {
+    if (!name) return;
+    fire('audio_trigger', { name, level: Math.min(audioCeil, P.CUE_LEVEL_BASE + P.CUE_LEVEL_STEP * rung) * (zen ? 0.6 : 1) });
+  }
+
+  /* ---- state -------------------------------------------------------------- */
+  let started = false; let stopped = false; let paused = false;
+  let heat = 0; let lastPaintHeat = -1;
+  let frac = 0; let rung = 0;
+  let hystTimer = 0; let hystTarget = -1;
+  let bellOn = false; let royalOn = false; let outOn = false;
+  let streak = 0;
+  const present = new Set();
+  const spiral = pickSpiral(roll('spiral'));
+  let preload = null;
+  let haze = null; let ring = null;
+  let breathTimer = 0; let ringTimer = 0; let flareTimer = 0;
+  const chipBloomTimers = new Map();
+
+  /* the tremor */
+  const fq = {
+    fx: lerp(P.TREMOR_HZ_FAST, roll('tremor-f')), fy: lerp(P.TREMOR_HZ_FAST, roll('tremor-f')),
+    sx: lerp(P.TREMOR_HZ_SLOW, roll('tremor-f')), sy: lerp(P.TREMOR_HZ_SLOW, roll('tremor-f')),
+    px: roll('tremor-f') * 6.283, py: roll('tremor-f') * 6.283, qx: roll('tremor-f') * 6.283, qy: roll('tremor-f') * 6.283,
+  };
+  let tremorAmp = 0;
+  let punchPeak = 0; let punchEnd = 0; let punchSpan = 1;
+  let translateWrites = 0; let translateOn = false;
+  let rafId = 0; let loopOn = false; let pausedAt = 0;
+  const chips = {
+    moves: { el: hud.moves || null, a: 0, at: 0, ms: 1, last: '', writes: 0 },
+    locked: { el: hud.locked || null, a: 0, at: 0, ms: 1, last: '', writes: 0 },
+    calm: { el: hud.calm || null, a: 0, at: 0, ms: 1, last: '', writes: 0 },
+  };
+  const hudEl = (hud.moves && hud.moves.parentNode) || null;
+
+  /* ---- helpers ----------------------------------------------------------- */
+  const has = (k) => present.has(k);
+  function setVar(node, k, v) { if (!node || !node.style) return; try { node.style.setProperty(k, v); } catch (e) { /* ignore */ } }
+  function cls(node, name, on) {
+    if (!node || !node.classList) return;
+    try { if (on) node.classList.add(name); else node.classList.remove(name); } catch (e) { /* ignore */ }
+  }
+  function restart(node, name) {
+    if (!node || !node.classList) return;
+    try { node.classList.remove(name); if (typeof node.offsetWidth === 'number') void node.offsetWidth; node.classList.add(name); } catch (e) { /* ignore */ }
+  }
+  function pctOf(node) {
+    const r = rectOf(node);
+    let w = 0; let h = 0;
+    try { w = typeof window !== 'undefined' ? Number(window.innerWidth) || 0 : 0; h = typeof window !== 'undefined' ? Number(window.innerHeight) || 0 : 0; } catch (e) { /* none */ }
+    if (!r || !r.width || !w || !h) return null;
+    return { x: Math.round((r.left + r.width / 2) / w * 100), y: Math.round((r.top + r.height / 2) / h * 100), size: Math.round(r.width) };
+  }
+  function hudChips() {
+    const list = [];
+    for (const k of Object.keys(chips)) if (chips[k].el) list.push(chips[k].el);
+    if (hud.clock) list.push(hud.clock);
+    return list;
+  }
+
+  /* ---- mounting ---------------------------------------------------------- */
+  function mount() {
+    if (haze || !frame || !frame.appendChild) return;
+    haze = el('div', 'g-cp-p-haze');
+    if (haze) frame.appendChild(haze);
+    ring = el('i', 'g-cp-p-ring');
+    if (ring) frame.appendChild(ring);
+    try { if (typeof Image === 'function') { preload = new Image(); preload.src = spiral.href; } } catch (e) { preload = null; }
+  }
+
+  /* ---- the loop ------------------------------------------------------------ */
+  function needsLoop() {
+    if (tremorAmp > 0.005) return true;
+    if (punchPeak > 0) return true;
+    const t = nowMs();
+    for (const k of Object.keys(chips)) { const c = chips[k]; if (c.a > 0 && t - c.at < c.ms) return true; }
+    return false;
+  }
+  function armLoop() {
+    if (loopOn || paused || destroyed || stopped) return;
+    if (!needsLoop()) return;
+    const r = rafFn();
+    if (!r) return;
+    loopOn = true;
+    rafId = r(frameFn) || 1;
+  }
+  function haltLoop() {
+    if (rafId) { const c = cafFn(); if (c) { try { c(rafId); } catch (e) { /* ignore */ } } }
+    rafId = 0; loopOn = false;
+  }
+  function frameFn() {
+    rafId = 0;
+    if (!loopOn || paused || destroyed) { loopOn = false; return; }
+    step(nowMs());
+    if (needsLoop()) { const r = rafFn(); if (r) { rafId = r(frameFn) || 1; return; } }
+    loopOn = false;
+    rest();
+  }
+  function writeTranslate(x, y) {
+    try { if (frame && frame.style) { frame.style.translate = x.toFixed(2) + 'px ' + y.toFixed(2) + 'px'; translateWrites += 1; translateOn = true; } } catch (e) { /* ignore */ }
+    try { if (hudEl && hudEl.style) hudEl.style.translate = (x * P.HUD_MUL).toFixed(2) + 'px ' + (y * P.HUD_MUL).toFixed(2) + 'px'; } catch (e) { /* ignore */ }
+  }
+  function clearTranslate() {
+    for (const n of [frame, hudEl]) {
+      if (!n || !n.style) continue;
+      try { n.style.translate = ''; if (typeof n.style.removeProperty === 'function') n.style.removeProperty('translate'); } catch (e) { /* ignore */ }
+    }
+    translateOn = false;
+  }
+  function writeChip(c, value) {
+    if (!c.el || !c.el.style || c.last === value) return;
+    try { c.el.style.transform = value; c.last = value; c.writes += 1; } catch (e) { /* ignore */ }
+  }
+  function rest() {
+    if (translateOn) clearTranslate();
+    for (const k of Object.keys(chips)) writeChip(chips[k], '');
+  }
+  function step(t) {
+    const s = t / 1000;
+    let x = 0; let y = 0; let moving = false;
+    if (tremorAmp > 0.005) {
+      x = tremorAmp * (0.62 * Math.sin(6.283 * fq.fx * s + fq.px) + 0.38 * Math.sin(6.283 * fq.sx * s + fq.qx));
+      y = tremorAmp * (0.62 * Math.sin(6.283 * fq.fy * s + fq.py) + 0.38 * Math.sin(6.283 * fq.sy * s + fq.qy));
+      moving = true;
+    }
+    if (punchPeak > 0) {
+      const left = punchEnd - t;
+      if (left <= 0) { punchPeak = 0; punchEnd = 0; }
+      else {
+        const decay = clamp01(left / punchSpan);
+        const a = punchPeak * decay * decay;
+        x += (roll('jolt') * 2 - 1) * a;
+        y += (roll('jolt') * 2 - 1) * a;
+        moving = true;
+      }
+    }
+    if (moving) writeTranslate(x, y);
+    else if (translateOn) clearTranslate();
+    for (const k of Object.keys(chips)) {
+      const c = chips[k];
+      if (!c.el) continue;
+      let sc = 1;
+      if (c.a > 0) {
+        const p = (t - c.at) / c.ms;
+        if (p >= 1) c.a = 0;
+        else sc = 1 + c.a * (1 - p) * (1 - p) * Math.cos(p * Math.PI * 2.2);
+      }
+      if (sc === 1) writeChip(c, '');
+      else writeChip(c, 'scale(' + sc.toFixed(3) + ')');
+    }
+  }
+  function punchFrame(px, ms) {
+    if (!armed() || stopped) return;
+    if (still || zen) { bloomRing(false); return; }
+    const a = Math.min(P.PUNCH_PX_CAP, Math.max(0, Number(px) || 0)) * P.MOTION_MUL[motion];
+    if (a < 0.1) return;
+    const t = nowMs();
+    const dur = Math.max(60, Math.min(P.PUNCH_MS_CAP, Number(ms) || 260));
+    const left = Math.max(0, punchEnd - t);
+    const decay = punchSpan > 0 ? clamp01(left / punchSpan) : 0;
+    punchPeak = Math.max(a, punchPeak * decay);
+    punchEnd = Math.max(punchEnd, t + dur);
+    punchSpan = Math.max(dur, punchEnd - t);
+    armLoop();
+  }
+  function punchChip(which, scale, ms) {
+    const c = chips[which];
+    if (!c || !c.el || !armed() || stopped) return;
+    if (still) { bloomChip(which); return; }
+    const a = Math.min(1.3, Math.max(1, Number(scale) || 1)) - 1;
+    if (a <= 0.001) return;
+    const t = nowMs();
+    const left = c.a > 0 ? Math.max(0, 1 - (t - c.at) / c.ms) : 0;
+    c.a = Math.max(a, c.a * left);
+    c.at = t;
+    c.ms = Math.max(120, Math.min(P.PUNCH_MS_CAP, Number(ms) || 240));
+    armLoop();
+  }
+  function bloomChip(which) {
+    const c = chips[which];
+    if (!c || !c.el) return;
+    restart(c.el, 'g-cp-p-bloom');
+    const old = chipBloomTimers.get(which);
+    if (old) cancel(old);
+    chipBloomTimers.set(which, after(P.BLOOM_MS, () => { chipBloomTimers.delete(which); cls(c.el, 'g-cp-p-bloom', false); }));
+  }
+  function bloomRing(deep) {
+    if (!ring) return;
+    cls(ring, 'is-deep', !!deep);
+    restart(ring, 'is-hit');
+    if (ringTimer) cancel(ringTimer);
+    ringTimer = after(deep ? P.BLOOM_MS * 2 : P.BLOOM_MS, () => { ringTimer = 0; cls(ring, 'is-hit', false); cls(ring, 'is-deep', false); });
+  }
+  /** THE FLARE: the haze snaps up under a burst for its hold, eases back. */
+  function flare(ms) {
+    if (!haze || !has('haze')) return;
+    cls(haze, 'is-flare', true);
+    setVar(haze, '--cp-p-ha', P.HAZE_FLARE.toFixed(2));
+    if (flareTimer) cancel(flareTimer);
+    flareTimer = after(Math.max(200, ms | 0), () => { flareTimer = 0; cls(haze, 'is-flare', false); setVar(haze, '--cp-p-ha', lerp(P.HAZE_A, heat).toFixed(2)); });
+  }
+
+  /* ---- the rungs ----------------------------------------------------------- */
+  function retune() {
+    const base = tremorAmpPx(rung, heat, reduced) * P.MOTION_MUL[motion];
+    tremorAmp = (stopped || outOn || zen || !armed()) ? 0 : Math.min(P.TREMOR_CAP_PX, base);
+    if (haze && !flareTimer) setVar(haze, '--cp-p-ha', lerp(P.HAZE_A, heat).toFixed(2));
+    if (Math.abs(heat - lastPaintHeat) >= P.HEAT_REPAINT_STEP) {
+      if (has('wheel')) wheelWash();
+      lastPaintHeat = heat;
+    }
+    if (tremorAmp > 0) armLoop();
+  }
+  function breathe() { sustain('wash', { variant: 'pink', alpha: lerp(P.BREATH_ALPHA, heat) * (zen ? 0.7 : 1), holdMs: P.BREATH_HOLD_MS }); }
+  function armBreath() {
+    if (breathTimer) cancel(breathTimer);
+    const ms = lerp(P.BREATH_MS, heat) * (zen ? 1.5 : 1) * (0.85 + roll('breath') * 0.3);
+    breathTimer = after(Math.round(ms), () => { breathTimer = 0; if (has('breath') && !stopped) { breathe(); armBreath(); } });
+  }
+  function wheelWash() { sustain('wash', { variant: 'spiral', url: spiral.href, alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true }); }
+  /** NEVER stop('wash'): a whisper alpha + a short hold lets the engine's own transition carry it out. */
+  function fadeWash(variant, extra) { sustain('wash', Object.assign({ variant, alpha: 0.01, holdMs: 120 }, extra || {})); }
+  function frameRoll(seconds) {
+    if (still || !frame) return null;
+    return fire('glitch_swap', { targets: frame, variant: 'vhsroll', seconds: seconds || 0.5, onSwap() {}, sfx: false });
+  }
+  function burstAt(node, n) {
+    const at = pctOf(node);
+    const o2 = { count: Math.max(1, n | 0), holdMs: P.BURST_HOLD_MS, clickSafe: true, clickable: false };
+    if (at) { o2.x = at.x; o2.y = at.y; o2.sizePx = Math.max(90, Math.round(at.size * 0.9)); }
+    flare(P.BURST_HOLD_MS);
+    return fire('gif_burst', o2);
+  }
+  function flashes(n, holdMs) {
+    flare(holdMs || 700);
+    return fire('flash_burst', { count: Math.max(1, n | 0), holdMs: holdMs || 700, clickSafe: true, clickable: false });
+  }
+
+  const FEATURES = {
+    breath: { on() { breathe(); armBreath(); }, off() { if (breathTimer) { cancel(breathTimer); breathTimer = 0; } } },
+    bubbles: {
+      on() { sustain('bubble_field', { max: Math.round(lerp(P.BUBBLE_MAX, heat)), alpha: lerp(P.BUBBLE_ALPHA, heat), clickSafe: true, variant: 'drift' }); },
+      off() { stopKind('bubble_field'); },
+    },
+    drift: {
+      on() { const targets = hudChips(); if (targets.length) sustain('row_drift', { targets, axis: 'y', variant: 'sway', amplitudeMult: 0.6 }); },
+      off() { stopKind('row_drift'); },
+    },
+    haze: { on() { cls(haze, 'is-on', true); }, off() { cls(haze, 'is-on', false); } },
+    burst: { on() { burstAt(null, 1); }, off() {} },
+    wheel: { on() { wheelWash(); }, off() { fadeWash('spiral', { url: spiral.href }); } },
+    subs: { on() { sustain('sub_flash', { variant: P.SUB_VARIANT }); flashes(1, 600); }, off() { stopKind('sub_flash'); } },
+    royal: {
+      on() {
+        sustain('wash', { variant: 'pink', alpha: P.ROYAL_FLOOD_A, holdMs: P.ROYAL_FLOOD_MS });
+        frameRoll(0.9);
+        flashes(3, 900);
+        cls(ring, 'is-gold', true);
+      },
+      off() { if (!bellOn) cls(ring, 'is-gold', false); },
+    },
+  };
+  function enterRung(k) {
+    const row = P.LADDER[k];
+    if (!row) return;
+    for (const key of row.adds) {
+      if (present.has(key)) continue;
+      present.add(key);
+      try { FEATURES[key].on(k); } catch (e) { say('pressure: ' + key + '.on threw: ' + ((e && e.message) || e)); }
+    }
+  }
+  function leaveRung(k, dest) {
+    const row = P.LADDER[k];
+    if (!row) return;
+    for (let i = row.adds.length - 1; i >= 0; i--) {
+      const key = row.adds[i];
+      if (!present.has(key)) continue;
+      present.delete(key);
+      try { FEATURES[key].off(dest); } catch (e) { say('pressure: ' + key + '.off threw: ' + ((e && e.message) || e)); }
+    }
+  }
+  function climb(r) {
+    if (r <= rung) return;
+    const from = rung;
+    for (let k = from + 1; k <= r; k++) enterRung(k);
+    rung = r;
+    cue(P.LADDER[r] && P.LADDER[r].cue, r);
+    lastPaintHeat = heat;
+    retune();
+    say('pressure: rung ' + from + ' -> ' + r + ' (frac ' + frac.toFixed(2) + ') on: ' + Array.from(present).join(','));
+  }
+  function descend(r) {
+    if (r >= rung) return;
+    const from = rung;
+    for (let k = from; k > r; k--) leaveRung(k, r);
+    rung = r;
+    retune();
+    say('pressure: rung ' + from + ' -> ' + r + ' (fade)');
+  }
+  function cancelHyst() { if (hystTimer) { cancel(hystTimer); hystTimer = 0; } hystTarget = -1; }
+  function stepTo(r, immediate) {
+    if (!started || stopped) return;
+    if (r > rung) { cancelHyst(); climb(r); return; }
+    if (r < rung) {
+      if (immediate) { cancelHyst(); descend(r); return; }
+      if (hystTimer && hystTarget === r) return;
+      cancelHyst();
+      hystTarget = r;
+      hystTimer = after(P.HYST_MS, () => { hystTimer = 0; const tgt = hystTarget; hystTarget = -1; if (tgt >= 0) descend(tgt); });
+      return;
+    }
+    cancelHyst();
+  }
+  function everythingOff() {
+    cancelHyst();
+    descend(0);
+    if (ringTimer) { cancel(ringTimer); ringTimer = 0; }
+    if (flareTimer) { cancel(flareTimer); flareTimer = 0; }
+    cls(ring, 'is-hit', false); cls(ring, 'is-deep', false);
+    cls(haze, 'is-on', false); cls(haze, 'is-flare', false);
+    for (const [which, id] of chipBloomTimers) { cancel(id); const c = chips[which]; if (c) cls(c.el, 'g-cp-p-bloom', false); }
+    chipBloomTimers.clear();
+    punchPeak = 0; punchEnd = 0;
+    for (const k of Object.keys(chips)) chips[k].a = 0;
+  }
+
+  /* ---- api ----------------------------------------------------------------- */
+  const api = {
+    start() {
+      if (!armed()) { say('pressure: disarmed'); return; }
+      if (started) return;
+      started = true;
+      ensureStyle();
+      mount();
+      retune();
+      say('pressure: mounted ' + [haze, ring].filter(Boolean).length + ' layers, wheel ' + spiral.file + (zen ? ' (zen: rungs 0-2 only)' : ''));
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (!started) return;
+      retune();
+    },
+    /** Presence rides the locked fraction. index.js calls after every lock/unlock. */
+    setProgress(lockedFrac) {
+      frac = clamp01(lockedFrac);
+      if (!started || stopped || royalOn) return;
+      stepTo(rungFor(frac, zen), false);
+      retune();
+    },
+    /**
+     * The class's beats: 'slide' | 'lock' | 'thrash' | 'assist' | 'solved' |
+     * 'bell' | 'wash' | 'unwash' (+ {streak?, tileEl?} as a second arg). Unknown
+     * kinds are ignored.
+     */
+    beat(kind, info) {
+      if (!started || stopped || !armed()) return;
+      const k = String(kind || '');
+      const d = info || {};
+      if (k === 'slide') {
+        streak = Math.max(0, Number(d.streak) || streak);
+        if (rung >= P.TREMOR_RUNG) punchFrame(P.PUNCH_SLIDE_PX, P.PUNCH_SLIDE_MS);
+        if (has('wheel') && roll('slide-g') < lerp(P.SHUDDER_CHANCE, heat) * 0.4) frameRoll(0.35);
+      } else if (k === 'lock') {
+        streak = Number.isFinite(Number(d.streak)) ? Math.max(0, Number(d.streak)) : streak + 1;
+        const p = punchFor(streak);
+        punchFrame(p.px, p.ms);
+        punchChip('locked', p.scale, p.ms + 60);
+        if (has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat)) burstAt(d.tileEl || opts.board, Math.round(lerp(P.BURST_COUNT, heat)));
+        if (has('wheel') && roll('shudder') < lerp(P.SHUDDER_CHANCE, heat)) frameRoll(P.SHUDDER_S);
+        if (has('subs')) flashes(1 + (streak >= 3 ? 1 : 0), 700);
+        if (still || zen) bloomRing(false);
+      } else if (k === 'thrash') {
+        streak = 0;
+        punchFrame(P.PUNCH_THRASH_PX, P.PUNCH_THRASH_MS);
+        punchChip('calm', 1.12, 260);
+        if (has('wheel')) frameRoll(0.4);
+      } else if (k === 'assist') {
+        streak = 0;
+        punchChip('calm', 1.08, 240);
+      } else if (k === 'solved') {
+        royalOn = true;
+        if (zen) {
+          sustain('wash', { variant: 'pink', alpha: P.ZEN_SOLVE_A, holdMs: P.ROYAL_FLOOD_MS });
+          bloomRing(true);
+          cue('wash', 2);
+        } else {
+          cancelHyst();
+          climb(P.RUNG_MAX);
+          punchFrame(P.PUNCH_ROYAL_PX, P.PUNCH_ROYAL_MS);
+          punchChip('locked', 1.3, 420);
+          punchChip('calm', 1.3, 420);
+          bloomRing(true);
+        }
+      } else if (k === 'bell') {
+        bellOn = d.on !== false;
+        cls(ring, 'is-gold', bellOn || royalOn);
+      } else if (k === 'wash') {
+        flare(Number(d.ms) || 1200);
+      } else if (k === 'unwash') {
+        if (flareTimer) { cancel(flareTimer); flareTimer = 0; cls(haze, 'is-flare', false); setVar(haze, '--cp-p-ha', lerp(P.HAZE_A, heat).toFixed(2)); }
+      }
+    },
+    /** The bell took the board: everything sighs out. */
+    dimOut() {
+      outOn = true; bellOn = false; royalOn = false;
+      if (!started) return;
+      everythingOff();
+      cls(ring, 'is-gold', false);
+      retune();
+    },
+    pause() {
+      if (paused) return;
+      paused = true; pausedAt = nowMs();
+      haltLoop();
+    },
+    resume() {
+      if (!paused) return;
+      paused = false;
+      const gap = Math.max(0, nowMs() - pausedAt);
+      if (punchPeak > 0) punchEnd += gap;
+      for (const k of Object.keys(chips)) { if (chips[k].a > 0) chips[k].at += gap; }
+      armLoop();
+    },
+    /** The class is over: fade everything, never snap; nothing may punch again. */
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      if (started) everythingOff();
+      tremorAmp = 0;
+      haltLoop();
+      rest();
+    },
+    destroy() {
+      if (destroyed) return;
+      api.stop();
+      destroyed = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      haltLoop();
+      clearTranslate();
+      for (const k of Object.keys(chips)) { const c = chips[k]; if (c.el) { cls(c.el, 'g-cp-p-bloom', false); try { c.el.style.transform = ''; } catch (e) { /* ignore */ } } }
+      for (const node of [haze, ring]) { if (node) { try { node.remove(); } catch (e) { /* ignore */ } } }
+      haze = null; ring = null; preload = null;
+      present.clear();
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, paused, zen, mode, out: outOn, bell: bellOn, royal: royalOn,
+        rung, hystPending: !!hystTimer, hystTarget, frac, heat, streak,
+        features: Array.from(present),
+        tremorPx: +tremorAmp.toFixed(3), punchPx: +punchPeak.toFixed(2), punchLive: punchPeak > 0,
+        loop: loopOn, translateWrites, translateOn,
+        chips: { moves: { writes: chips.moves.writes }, locked: { writes: chips.locked.writes }, calm: { writes: chips.calm.writes } },
+        liveNodes: [haze, ring].filter(Boolean).length,
+        hazeOn: !!(haze && haze.classList && haze.classList.contains('is-on')),
+        spiral: spiral.file, spiralUrl: spiral.href,
+        fires: Object.assign({}, fires), timers: live.size,
+      };
+    },
+  };
+  return api;
+}
+
+export default createCpPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/solver.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/solver.js
@@ -1,0 +1,398 @@
+/* ============================================================================
+ * games/composure/solver.js - COMPOSURE's baseline solver. PURE: no DOM, no
+ * clock, no ctx, no rng.
+ *
+ * IT EXISTS FOR TWO REASONS, and neither of them is playing the game for you:
+ *   1. THE PAR TABLE. grade.js scores moves against a baseline, and a baseline
+ *      pulled out of the air is a rubric that lies. `solve(state).length` is
+ *      the number the par table is derived from (dossier open question 3,
+ *      closed by the contract: CORE owns the baseline solver).
+ *   2. THE SKILL-FLOOR RESCUE. The critic's top fix is law - after 20 stuck
+ *      seconds the class lights the solver's next move and caps its own grade
+ *      (hardGates.sGate = false). `nextMove(state)` is that light.
+ *
+ * TWO SOLVERS, chosen by size:
+ *   3x3   OPTIMAL. IDA* on manhattan + linear conflict, with a bidirectional
+ *         BFS backstop (the 8-puzzle's whole state space is 181440, so the
+ *         backstop is bounded and cannot hang). The par table for the 3x3
+ *         board is therefore the true god number for that scramble.
+ *   4x4   HUMAN. Row-by-row / column-by-column reduction to a 3x3, which is
+ *   5x5   then solved optimally. Not optimal overall - it is a BASELINE, the
+ *         move count a careful player would actually spend - and it always
+ *         terminates, which matters more here than optimality.
+ *
+ * THE REDUCTION walks a line's tiles home one at a time and its LAST TWO
+ * together, each walk a complete BFS over (tracked tile positions + gap
+ * position) inside the unlocked region - which is what makes it immune to the
+ * dead-end deadlock a greedy placer walks into. See the long note above
+ * `route()`. After each line the region shrinks; at 3x3 the optimal solver
+ * finishes the job.
+ *
+ * A MOVE, everywhere in this file, is the POSITION OF THE TILE THAT SLIDES -
+ * which is exactly what a click on the board is, so a hint is a cell, not a
+ * gesture. `toMoves()` re-plays a path to hand back {pos, id, dir}.
+ *
+ * EVERY entry point is null-safe and total: a solver that cannot answer
+ * returns null, and the class then runs with no par and no hint rather than
+ * throwing inside a class the player is in the middle of.
+ * ==========================================================================*/
+
+import {
+  BLANK, cloneState, createState, isSolved, neighbours, rowOf, colOf, posOf, dirBetween,
+} from './board.js';
+
+/** IDA* abort ceiling. A random 8-puzzle finishes four orders of magnitude
+ *  under this; crossing it means something is wrong, not that we should hang. */
+const NODE_CAP = 4000000;
+/** The 8-puzzle's reachable half-space. The BFS backstop can never exceed it. */
+const BFS_CAP = 200000;
+/** Loop guard - a reduction that runs past this is a bug, not a puzzle. */
+const LINE_GUARD = 64;
+
+/* ==========================================================================
+ * small helpers over a raw cells array
+ * ======================================================================== */
+function solvedArr(cells) {
+  for (let i = 0; i < cells.length - 1; i++) if (cells[i] !== i) return false;
+  return cells[cells.length - 1] === BLANK;
+}
+
+/* ==========================================================================
+ * THE OPTIMAL 3x3
+ * ======================================================================== */
+const N3 = 3;
+const NB3 = (() => {
+  const out = [];
+  for (let i = 0; i < 9; i++) out.push(neighbours(N3, i));
+  return out;
+})();
+
+/** manhattan + 2 x linear conflicts (an admissible, much sharper heuristic). */
+function h3(cells) {
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    const id = cells[i];
+    if (id === BLANK) continue;
+    sum += Math.abs(rowOf(N3, i) - rowOf(N3, id)) + Math.abs(colOf(N3, i) - colOf(N3, id));
+  }
+  let conflicts = 0;
+  for (let line = 0; line < N3; line++) {
+    for (let a = 0; a < N3; a++) {
+      for (let b = a + 1; b < N3; b++) {
+        const ra = cells[posOf(N3, line, a)]; const rb = cells[posOf(N3, line, b)];
+        if (ra !== BLANK && rb !== BLANK
+          && rowOf(N3, ra) === line && rowOf(N3, rb) === line
+          && colOf(N3, ra) > colOf(N3, rb)) conflicts += 1;
+        const ca = cells[posOf(N3, a, line)]; const cb = cells[posOf(N3, b, line)];
+        if (ca !== BLANK && cb !== BLANK
+          && colOf(N3, ca) === line && colOf(N3, cb) === line
+          && rowOf(N3, ca) > rowOf(N3, cb)) conflicts += 1;
+      }
+    }
+  }
+  return sum + 2 * conflicts;
+}
+
+/** IDA*. Returns the optimal path (tile positions) or null if it aborted. */
+function ida3(start) {
+  const state = start.slice();
+  if (solvedArr(state)) return [];
+  let blank = state.indexOf(BLANK);
+  const path = [];
+  let nodes = 0;
+  let aborted = false;
+
+  function dfs(g, bound, prevBlank) {
+    const f = g + h3(state);
+    if (f > bound) return f;
+    if (solvedArr(state)) return -1;
+    nodes += 1;
+    if (nodes > NODE_CAP) { aborted = true; return -1e9; }
+    let min = Infinity;
+    for (const nb of NB3[blank]) {
+      if (nb === prevBlank) continue;
+      const pb = blank;
+      const tile = state[nb];
+      state[pb] = tile; state[nb] = BLANK; blank = nb;
+      path.push(nb);
+      const r = dfs(g + 1, bound, pb);
+      if (r === -1) return -1;
+      if (r === -1e9) return -1e9;
+      if (r < min) min = r;
+      path.pop();
+      state[nb] = tile; state[pb] = BLANK; blank = pb;
+    }
+    return min;
+  }
+
+  let bound = h3(state);
+  for (let round = 0; round < 64; round++) {
+    const r = dfs(0, bound, -1);
+    if (r === -1) return path.slice();
+    if (aborted) return null;
+    if (!Number.isFinite(r)) return null;
+    bound = r;
+  }
+  return null;
+}
+
+/** The bounded backstop: plain BFS over the reachable half-space (<= 181440). */
+function bfs3(start) {
+  if (solvedArr(start)) return [];
+  const key = (a) => a.join(',');
+  const seen = new Map();
+  seen.set(key(start), null);
+  const q = [start.slice()];
+  let head = 0;
+  while (head < q.length && seen.size < BFS_CAP) {
+    const cur = q[head++];
+    const blank = cur.indexOf(BLANK);
+    for (const nb of NB3[blank]) {
+      const next = cur.slice();
+      next[blank] = next[nb];
+      next[nb] = BLANK;
+      const k = key(next);
+      if (seen.has(k)) continue;
+      seen.set(k, { from: key(cur), pos: nb });
+      if (solvedArr(next)) {
+        const out = [];
+        let step = seen.get(k);
+        let at = k;
+        while (step) { out.push(step.pos); at = step.from; step = seen.get(at); }
+        return out.reverse();
+      }
+      q.push(next);
+    }
+  }
+  return null;
+}
+
+/** The 3x3, optimally. `cells` is a 9-length array of ids 0..7 + BLANK. */
+export function solve3x3(cells) {
+  if (!Array.isArray(cells) || cells.length !== 9) return null;
+  const fast = ida3(cells);
+  if (fast) return fast;
+  return bfs3(cells);
+}
+
+/* ==========================================================================
+ * THE REDUCTION (4x4 / 5x5)
+ *
+ * Line by line - top row, left column, top row, left column - until a 3x3 is
+ * left, which the optimal solver finishes. Placed cells are LOCKED: the gap
+ * never enters one, so a finished line is never disturbed.
+ *
+ * HOW A TILE IS WALKED, and why it is a search rather than a heuristic. The
+ * obvious method is greedy: BFS the tile toward its home, BFS the gap to the
+ * next step of that route, slide, repeat. It reads well and it DEADLOCKS.
+ * Locking a line leaves DEAD-END cells (hold the end of a row and the cell
+ * beside it has exactly one free neighbour), and a gap parked in one can only
+ * leave through the very tile it is pushing - while every way of pushing that
+ * tile back out puts the gap straight back in. The two shuffle forever. It cost
+ * one board in five, and a board this game cannot solve is a board it must not
+ * deal.
+ *
+ * So the walk is a BFS over the state that actually matters: the positions of
+ * the TILES BEING TRACKED plus the position of the GAP. Every other tile in the
+ * region is interchangeable - nothing downstream cares which anonymous tile
+ * ends up where - so one tile is at worst 25x24 states, and the LAST TWO of a
+ * line (searched together, straight to their homes, with no staging dance at
+ * all) is at worst 25x24x23. Both are nothing, both are complete, and both are
+ * optimal for their sub-problem. A configuration with no answer says so instead
+ * of spinning.
+ * ======================================================================== */
+function work(state) {
+  return { n: state.n, cells: state.cells.slice(), blank: state.blank, path: [] };
+}
+
+/** Slide the tile at `pos` (which MUST be adjacent to the gap) into the gap. */
+function step(w, pos) {
+  w.cells[w.blank] = w.cells[pos];
+  w.cells[pos] = BLANK;
+  w.blank = pos;
+  w.path.push(pos);
+}
+
+/**
+ * Walk one or more TRACKED tiles to their targets without ever moving the gap
+ * through `blocked`. BFS over (tracked positions..., gap position).
+ *
+ * @param {Object} w
+ * @param {Array<{id:number,target:number}>} tracked
+ * @param {Set<number>} blocked
+ */
+function route(w, tracked, blocked) {
+  const n = w.n;
+  const startPos = tracked.map((t) => w.cells.indexOf(t.id));
+  const goal = tracked.map((t) => t.target);
+  if (startPos.some((p) => p < 0)) throw new Error('cp-solver: a tracked tile is not on the board');
+  const done = (list) => list.every((p, i) => p === goal[i]);
+  if (done(startPos)) return;
+
+  const key = (list, gap) => list.join(',') + '|' + gap;
+  const prev = new Map();
+  prev.set(key(startPos, w.blank), null);
+  const queue = [[startPos, w.blank]];
+  let head = 0;
+  let found = null;
+
+  while (head < queue.length && found === null) {
+    const cur = queue[head++];
+    const list = cur[0];
+    const gap = cur[1];
+    for (const next of neighbours(n, gap)) {
+      if (blocked.has(next)) continue;
+      const moved = list.slice();
+      const which = list.indexOf(next);
+      if (which >= 0) moved[which] = gap;          // the gap swapped with a tracked tile
+      const k = key(moved, next);
+      if (prev.has(k)) continue;
+      prev.set(k, { from: key(list, gap), move: next });
+      if (done(moved)) { found = k; break; }
+      queue.push([moved, next]);
+    }
+  }
+  if (found === null) throw new Error('cp-solver: no route for tile ' + tracked.map((t) => t.id).join('+'));
+
+  const seq = [];
+  let at = found;
+  let node = prev.get(at);
+  while (node) { seq.push(node.move); at = node.from; node = prev.get(at); }
+  seq.reverse();
+  for (const pos of seq) step(w, pos);
+}
+
+/** Solve row `r` of the region whose left edge is `c0`. Marks the row locked. */
+function solveRow(w, r, c0, locked) {
+  const n = w.n;
+  for (let c = c0; c <= n - 3; c++) {
+    const home = posOf(n, r, c);
+    route(w, [{ id: home, target: home }], locked);
+    locked.add(home);
+  }
+  /* The last two go home TOGETHER - the pair is one search state, so the
+   * staging rotation every naive solver needs (and the dead end it creates)
+   * is simply not part of this solver. */
+  const p1 = posOf(n, r, n - 2);
+  const p2 = posOf(n, r, n - 1);
+  route(w, [{ id: p1, target: p1 }, { id: p2, target: p2 }], locked);
+  locked.add(p1);
+  locked.add(p2);
+}
+
+/** Solve column `c` of the region whose top edge is `r0`. Mirrors solveRow. */
+function solveCol(w, c, r0, locked) {
+  const n = w.n;
+  for (let r = r0; r <= n - 3; r++) {
+    const home = posOf(n, r, c);
+    route(w, [{ id: home, target: home }], locked);
+    locked.add(home);
+  }
+  const p1 = posOf(n, n - 2, c);
+  const p2 = posOf(n, n - 1, c);
+  route(w, [{ id: p1, target: p1 }, { id: p2, target: p2 }], locked);
+  locked.add(p1);
+  locked.add(p2);
+}
+
+/** The remaining 3x3 at (r0,c0), relabelled into its own coordinates. */
+function finish3x3(w, r0, c0) {
+  const n = w.n;
+  const sub = [];
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const id = w.cells[posOf(n, r0 + r, c0 + c)];
+      if (id === BLANK) { sub.push(BLANK); continue; }
+      const hr = rowOf(n, id) - r0;
+      const hc = colOf(n, id) - c0;
+      if (hr < 0 || hc < 0 || hr > 2 || hc > 2) throw new Error('cp-solver: a placed tile escaped the region');
+      sub.push(hr * 3 + hc);
+    }
+  }
+  const path = solve3x3(sub);
+  if (!path) return false;
+  for (const sp of path) step(w, posOf(n, r0 + Math.floor(sp / 3), c0 + (sp % 3)));
+  return true;
+}
+
+/** The row/column reduction, then the optimal 3x3. Returns a path or null. */
+function reduce(state) {
+  const w = work(state);
+  const locked = new Set();
+  let r0 = 0;
+  let c0 = 0;
+  let guard = 0;
+  while ((w.n - r0) > 3 || (w.n - c0) > 3) {
+    guard += 1;
+    if (guard > LINE_GUARD) return null;
+    if ((w.n - r0) >= (w.n - c0)) { solveRow(w, r0, c0, locked); r0 += 1; }
+    else { solveCol(w, c0, r0, locked); c0 += 1; }
+  }
+  if (!finish3x3(w, r0, c0)) return null;
+  return w.path;
+}
+
+/* ==========================================================================
+ * PUBLIC SURFACE
+ * ======================================================================== */
+/** Re-play a path of tile positions into {pos, id, dir} moves. */
+export function toMoves(state, path) {
+  const s = cloneState(state);
+  const out = [];
+  for (const pos of (path || [])) {
+    const id = s.cells[pos];
+    const dir = dirBetween(s.n, pos, s.blank);
+    s.cells[s.blank] = id;
+    s.cells[pos] = BLANK;
+    s.blank = pos;
+    out.push({ pos, id, dir });
+  }
+  return out;
+}
+
+/**
+ * The baseline solution for a board.
+ * @returns {Array<{pos:number,id:number,dir:string}>|null} null = no answer
+ *          (an aborted search or a board this file could not reduce); the
+ *          class then runs with no par and no hint, never with a throw.
+ */
+export function solve(state) {
+  if (!state || !Array.isArray(state.cells)) return null;
+  try {
+    if (isSolved(state)) return [];
+    const n = state.n;
+    const path = (n === 3) ? solve3x3(state.cells.slice()) : reduce(state);
+    if (!path) return null;
+    const moves = toMoves(state, path);
+    /* Never hand back a "solution" that does not solve: replay it and check. */
+    const check = cloneState(state);
+    for (const m of moves) {
+      if (check.cells[m.pos] !== m.id) return null;
+      check.cells[check.blank] = m.id;
+      check.cells[m.pos] = BLANK;
+      check.blank = m.pos;
+    }
+    return isSolved(check) ? moves : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/** The one move the rescue lights up, or null. */
+export function nextMove(state) {
+  const moves = solve(state);
+  return (moves && moves.length) ? moves[0] : null;
+}
+
+/** The baseline move count par is derived from; -1 when there is no answer. */
+export function baselineLength(state) {
+  const moves = solve(state);
+  return moves ? moves.length : -1;
+}
+
+/** Convenience for tests: a baseline straight off a raw cells array. */
+export function baselineFor(n, cells) {
+  return baselineLength(createState(n, cells));
+}
+
+export default { solve, nextMove, baselineLength, baselineFor, solve3x3, toMoves };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
@@ -1,0 +1,621 @@
+/* ============================================================================
+ * games/composure/style.js - the class injects its OWN stylesheet from JS.
+ *
+ * THE STUDIO. A painter's room after hours: one lamp, a plaster wall, an easel
+ * carrying a framed canvas that has been cut into tiles and shuffled. The clip
+ * lives on the canvas; the frame, the wall and the lamp are the furniture the
+ * decks play with. Composition, exactly the DOM contract (index.js builds it,
+ * this file paints it):
+ *
+ *   .g-cp-stage[data-phase][data-mode][data-n]  absolute inset:0; explicit
+ *                 ground; padded under the shell's proctor strip; --cp-board
+ *                 is the one square every frame-level thing is sized from.
+ *                 [data-mode=zen] is the warm room, [data-mode=timed] the cool.
+ *   .g-cp-backdrop  the casino's lighting rig (pointer-events:none, z 0):
+ *                 wall / lamp / motes / dark / flash / royal / vig layers
+ *   .g-cp-hud     four chips: moves, clock, locked, calm
+ *   .g-cp-frame   THE EASEL: the wooden frame + mat around the board, the
+ *                 stand drawn under it (::after), the marquee + the casino's
+ *                 overlay (.g-cp-cs) and the trickster's .g-cp-preview live
+ *                 here, around and above the board
+ *   .g-cp-board   the gesture surface (the canvas); --cp-n (3|4|5) ->
+ *                 --cp-tile / --cp-step
+ *   .g-cp-tile    ABSOLUTE, positioned ONLY by its transform from --r / --c
+ *   .g-cp-face    the clipped viewport (overflow hidden) holding .g-cp-media
+ *   .g-cp-preview the lie layer (pointer-events:none, over the board)
+ *   .g-cp-flashwell / .g-cp-msg / .g-cp-end
+ *
+ * THE TRANSFORM LAW. index.js writes --r / --c and nothing else about a
+ * tile's position; this file owns the transform and its 190ms slide (a quick
+ * start and a soft SETTLE - the tile has weight, it does not teleport). The
+ * transform is positional ONLY: every lift, pulse, sag and shimmer lives on
+ * the tile's ::before (the body), ::after (the ring) or its children, never on
+ * the tile's own transform, so index's slide is never fought. Decoration vars
+ * composed INTO the frame's transform (never a tile's):
+ *   --cp-lean-x / --cp-lean-y   -1..1 easel lean toward a move (casino.slide)
+ * and into every tile's transform:
+ *   --cp-grab-x / --cp-grab-y   -1..1 grab vector on the BOARD (optional; a
+ *                               core that writes them on pointermove gets THE
+ *                               HAND for free, one that does not loses nothing)
+ *
+ * THE VIEWPORT. Every tile shows ONE url: .g-cp-media is sized to the whole
+ * board and shifted by the tile's HOME row/col (--hr / --hc on the tile, set
+ * by index.js) so the face clips exactly its own square of the picture, gaps
+ * included - one decoder, N viewports. A core that positions the media with
+ * inline object-position instead simply wins the cascade (inline beats this
+ * sheet); nothing here is !important on the media.
+ *
+ * LOCKS AND THE SOLVE. .is-locked dissolves the SEAM: the face grows by half
+ * the gap on every side, the body's bevel fades, a one-beat chroma ring runs,
+ * and a slow varnish sheen settles on it (Law III). Two locked neighbours
+ * close their seam entirely; a locked tile beside a loose one keeps a hair of
+ * it. [data-phase=solved] (and the board's own .is-solved, which outlives a
+ * phase change) closes every seam, drops every shadow and sends one light
+ * sweep across the canvas while the clip plays clean.
+ *
+ * THE OTHER CORE HOOKS. .g-cp-board.is-bump (240ms, an illegal press) knocks
+ * the whole canvas against the easel - chrome, never a tile. The stage's
+ * data-wash="1" (a burial wash is up) dips the lamp through --cp-wash-k,
+ * freezes the motes, cools the canvas and hides the numerals so the picture is
+ * all there is; data-peek="1" (the shell's reveal is held) drops the board a
+ * step under the peek sheet and quietens the HUD. There is no .is-stuck:
+ * CORE never emits it.
+ *
+ * THE RESCUE. .is-hint is the skill-floor assist: the tile the baseline solver
+ * would move next breathes a lavender ring and lifts a little. Grade-capped by
+ * index.js; this file only makes it visible.
+ *
+ * THE SHEET (Deck VI, Law IV): .g-cp-howto is drawn, not told. index.js
+ * builds three rows, each a .g-cp-hw-fig.g-cp-hw-slide|lock|wash span holding
+ * three blank parts (i.g-cp-hw-a/-b/-c); this sheet makes the span a mini 3x3
+ * board out of gradients and the parts its moving pieces: a tile sliding into
+ * the gap under a finger, a tile snapping home with its seam lighting up and
+ * closing, a pink wash breathing over a board where a tile keeps sliding.
+ * index.js owns the policy and the captions; the GO button is the only live
+ * thing on the sheet.
+ *
+ * THE END CARD: .g-cp-end is the panel; rows are .g-cp-end-row > .g-cp-end-k
+ * + .g-cp-end-v; the grade arrives as an OBJECT - .g-cp-end-seal[data-grade]
+ * is a wax seal pressed into the card (Deck VI), the shell's stamp ceremony
+ * runs over it. [data-zen] on the seal is the pass seal (no letter).
+ *
+ * DECK CHROME: this sheet paints the STAGE-level hooks the decks toggle
+ * (.g-cp-bd-* backdrop layers, .g-cp-bell / .g-cp-royal / .g-cp-out on the
+ * stage, the --cp-n-* identity props with plain-studio fallbacks). Each deck
+ * injects its OWN sheet for its own nodes (the House Rules law):
+ *   casino.js    g-cp-casino-style    .g-cp-mq marquee, .g-cp-cs overlay,
+ *                                     glints, the word, the hum
+ *   trickster.js g-cp-trickster-style .g-cp-preview ghosts + shudder variants,
+ *                                     .g-cp-statlie, .g-cp-melt, .g-cp-ghost
+ *   pressure.js  g-cp-pressure-style  .g-cp-p-haze, .g-cp-p-ring, .g-cp-p-bloom
+ *
+ * NOTHING IS EVER STILL (Law III): the lamp breathes, the motes drift, locked
+ * tiles carry a varnish sheen, the marquee crawls (timed) or breathes (zen).
+ * REDUCED MOTION twice over (html.arc-reduced + the media query): the slide
+ * transition survives, everything else becomes a fade. .g-cp-stage.suspended
+ * freezes every animation so index.js can hold the room with the class.
+ * ==========================================================================*/
+
+const STYLE_ID = 'g-cp-style';
+
+export const STYLE_TEXT = `
+/* ---- registered decoration props: numbers interpolate, so a var change
+   glides (the lamp warms, the lean springs) instead of snapping ------------- */
+/* iOS/WebKit TRAP: a transform whose calc() reads an UNREGISTERED custom property does
+   not transition when that property changes - the tile TELEPORTS. --r/--c stay the
+   CORE contract (unregistered, read by decks); the transform reads these registered
+   twins that CORE writes alongside them. */
+@property --cp-r{syntax:'<number>';inherits:false;initial-value:0}
+@property --cp-c{syntax:'<number>';inherits:false;initial-value:0}
+@property --cp-lean-x{syntax:'<number>';inherits:false;initial-value:0}
+@property --cp-lean-y{syntax:'<number>';inherits:false;initial-value:0}
+@property --cp-grab-x{syntax:'<number>';inherits:true;initial-value:0}
+@property --cp-grab-y{syntax:'<number>';inherits:true;initial-value:0}
+@property --cp-n-warm{syntax:'<number>';inherits:true;initial-value:0}
+@property --cp-n-lamp{syntax:'<number>';inherits:true;initial-value:.7}
+@property --cp-n-dark{syntax:'<number>';inherits:true;initial-value:0}
+@property --cp-pv-a{syntax:'<number>';inherits:true;initial-value:.82}
+
+/* ---- the stage: the studio after hours ----------------------------------- */
+.g-cp-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
+  align-items:center;gap:10px;padding:72px 18px 16px;color:var(--ink);
+  --cp-board:min(calc(100dvh - 262px), calc(100vw - 120px), 620px);
+  --cp-gap:clamp(3px,.7vmin,8px);
+  --cp-mat:clamp(10px,2.2vmin,24px);
+  --cp-wood:clamp(8px,1.6vmin,16px);
+  --cp-n:3;
+  --cp-hue-a:var(--cp-n-hue-a,292);
+  --cp-hue-b:var(--cp-n-hue-b,330);
+  --cp-lamp-x:var(--cp-n-lamp-x,38%);
+  --cp-lamp-y:var(--cp-n-lamp-y,-8%);
+  --cp-breath:var(--cp-n-breath,7s);
+  --cp-drift:var(--cp-n-drift,26s);
+  --cp-la:hsla(var(--cp-hue-a),60%,74%,.30);
+  --cp-lb:hsla(var(--cp-hue-b),70%,70%,.20);
+  --cp-warmc:hsla(36,80%,70%,.22);
+  transition:--cp-n-warm 2.4s ease, --cp-n-lamp 2s ease, --cp-n-dark 1.6s ease;
+  background:
+    radial-gradient(70% 55% at var(--cp-lamp-x) var(--cp-lamp-y), var(--cp-la), transparent 62%),
+    radial-gradient(90% 60% at 50% 112%, var(--cp-lb), transparent 64%),
+    color-mix(in srgb, var(--ground), black 34%)}
+.g-cp-stage[data-n="3"]{--cp-n:3}
+.g-cp-stage[data-n="4"]{--cp-n:4}
+.g-cp-stage[data-n="5"]{--cp-n:5}
+/* the two moods: zen is warm (amber lamp, slower breath), timed is cool */
+.g-cp-stage[data-mode="zen"]{--cp-n-warm:1;--cp-breath:calc(var(--cp-n-breath,7s) * 1.6);
+  --cp-la:hsla(34,70%,72%,.30);--cp-lb:hsla(var(--cp-hue-b),55%,66%,.16)}
+.g-cp-stage[data-mode="timed"]{--cp-n-warm:0}
+.g-cp-stage.suspended *{animation-play-state:paused !important}
+
+/* ---- the backdrop: the casino's lighting rig (decoration only) ----------- */
+.g-cp-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+.g-cp-backdrop *{pointer-events:none}
+.g-cp-bd{position:absolute;inset:-6%;opacity:0;
+  animation:g-cp-kb var(--cp-n-kb,30s) ease-in-out infinite alternate}
+.g-cp-bd::before{content:"";position:absolute;inset:0}
+@keyframes g-cp-kb{from{transform:scale(1) translate(0,0)}to{transform:scale(1.05) translate(1.2%,-.9%)}}
+/* the wall: plaster by default; the casino picks an archetype per class */
+.g-cp-bd-wall{opacity:var(--cp-n-a-wall,.5);animation:none;inset:0}
+.g-cp-bd-wall::before{
+  background:
+    repeating-linear-gradient(0deg, transparent 0 3px, rgba(255,255,255,.012) 3px 4px),
+    repeating-linear-gradient(90deg, transparent 0 3px, rgba(255,255,255,.012) 3px 4px),
+    radial-gradient(120% 80% at 50% 0%, rgba(255,255,255,.05), transparent 60%)}
+.g-cp-stage.g-cp-wall-linen .g-cp-bd-wall::before{
+  background:
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(255,255,255,.02) 2px 3px),
+    repeating-linear-gradient(90deg, transparent 0 2px, rgba(255,255,255,.02) 2px 3px)}
+.g-cp-stage.g-cp-wall-brick .g-cp-bd-wall::before{
+  background:
+    repeating-linear-gradient(0deg, transparent 0 26px, rgba(0,0,0,.16) 26px 28px),
+    repeating-linear-gradient(90deg, transparent 0 58px, rgba(0,0,0,.12) 58px 60px);
+  opacity:.7}
+.g-cp-stage.g-cp-wall-velvet .g-cp-bd-wall::before{
+  background:
+    repeating-linear-gradient(135deg, transparent 0 9px, hsla(var(--cp-hue-b),40%,60%,.05) 9px 18px),
+    radial-gradient(80% 60% at 50% 0%, hsla(var(--cp-hue-a),40%,60%,.08), transparent 70%)}
+/* an asset-chrome wash (Deck VI): a pool still at a whisper, luminosity only */
+.g-cp-bd-wall::after{content:"";position:absolute;inset:0;opacity:var(--cp-n-a-asset,0);
+  background-image:var(--cp-n-asset,none);background-size:cover;background-position:center;
+  mix-blend-mode:luminosity;filter:blur(2px) saturate(.2)}
+/* the lamp: one light from above; it BREATHES (Law III) */
+.g-cp-bd-lamp{opacity:calc(var(--cp-n-lamp,.7) * var(--cp-wash-k,1));transition:opacity .8s ease}
+.g-cp-bd-lamp::before{
+  background:
+    radial-gradient(55% 46% at var(--cp-lamp-x) var(--cp-lamp-y), color-mix(in srgb, hsla(var(--cp-hue-a),70%,80%,.55), var(--cp-warmc) calc(var(--cp-n-warm,0) * 100%)), transparent 70%),
+    conic-gradient(from 160deg at var(--cp-lamp-x) var(--cp-lamp-y), transparent 0 10deg, rgba(255,255,255,.05) 14deg 20deg, transparent 24deg 40deg, rgba(255,255,255,.04) 44deg 47deg, transparent 50deg);
+  animation:g-cp-breathe var(--cp-breath) ease-in-out infinite alternate}
+@keyframes g-cp-breathe{from{opacity:.62;transform:scale(1)}to{opacity:1;transform:scale(1.04)}}
+/* motes: dust turning in the lamplight */
+.g-cp-bd-motes{opacity:var(--cp-n-a-motes,.45)}
+.g-cp-bd-motes::before{
+  background:
+    radial-gradient(circle, rgba(255,255,255,.55) 0 1px, transparent 2px),
+    radial-gradient(circle, hsla(var(--cp-hue-a),70%,85%,.5) 0 .8px, transparent 1.8px);
+  background-size:120px 140px, 170px 190px;background-position:0 0, 50px 70px;
+  -webkit-mask-image:radial-gradient(70% 60% at var(--cp-lamp-x) 20%, #000 20%, transparent 80%);
+  mask-image:radial-gradient(70% 60% at var(--cp-lamp-x) 20%, #000 20%, transparent 80%);
+  animation:g-cp-motes calc(var(--cp-drift) * 1.3) linear infinite}
+@keyframes g-cp-motes{to{background-position:14px -140px, 70px -190px}}
+/* the dark: the bell / a dim-out deepens it; a payout flash */
+.g-cp-bd-dark{inset:0;opacity:calc(var(--cp-n-dark,0) * .6);background:#000;animation:none}
+.g-cp-bd-flash{inset:0;opacity:0;animation:none;
+  background:radial-gradient(55% 50% at 50% 50%, hsla(var(--cp-hue-b),80%,78%,.8), transparent 70%)}
+.g-cp-bd-flash.g-cp-on{animation:g-cp-pay .6s ease-out 1}
+@keyframes g-cp-pay{0%{opacity:var(--cp-n-pay,.45);transform:scale(.8)}100%{opacity:0;transform:scale(1.2)}}
+.g-cp-bd-flash.g-cp-deep{animation:g-cp-paydeep 1.2s ease-out 1}
+@keyframes g-cp-paydeep{0%{opacity:.75;transform:scale(.6)}45%{opacity:.4}100%{opacity:0;transform:scale(1.35)}}
+/* the royal: the studio floods gold for the solve */
+.g-cp-bd-royal{inset:0;opacity:0;animation:none;transition:opacity 1.2s ease;
+  background:radial-gradient(80% 70% at 50% 40%, color-mix(in srgb, var(--gold), transparent 50%), transparent 72%)}
+.g-cp-stage.g-cp-royal .g-cp-bd-royal{opacity:1;animation:g-cp-royal 2.2s ease-in-out infinite alternate}
+@keyframes g-cp-royal{from{opacity:.65}to{opacity:1}}
+/* zen royal: warm, not gold - the lamp simply comes up */
+.g-cp-stage[data-mode="zen"].g-cp-royal .g-cp-bd-royal{
+  background:radial-gradient(80% 70% at 50% 40%, hsla(36,80%,72%,.5), transparent 72%)}
+/* vignette; the bell tightens it */
+.g-cp-bd-vig{inset:0;opacity:1;animation:none;
+  background:radial-gradient(120% 100% at 50% 46%, transparent 50%, rgba(0,0,0,.62) 100%)}
+.g-cp-stage.g-cp-bell .g-cp-bd-vig{animation:g-cp-vig 1s ease-in-out infinite alternate}
+@keyframes g-cp-vig{from{opacity:.85}to{opacity:1}}
+/* a dim-out never cuts: the room sighs down to a whisper */
+.g-cp-stage.g-cp-out .g-cp-bd{transition:opacity 1.6s ease;opacity:.22}
+.g-cp-stage.g-cp-out .g-cp-bd-dark,.g-cp-stage.g-cp-out .g-cp-bd-vig{opacity:1}
+
+/* ---- HUD: four chips above the easel ------------------------------------- */
+.g-cp-hud{position:relative;z-index:2;display:flex;flex-wrap:wrap;align-items:center;
+  justify-content:center;gap:8px 12px;font-family:var(--mono);font-size:11px;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint)}
+.g-cp-chip{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+  border:1px solid color-mix(in srgb, var(--lav), var(--line) 55%);
+  background:color-mix(in srgb, var(--panel), transparent 40%);
+  color:color-mix(in srgb, var(--ink-dim), var(--lav) 30%);
+  font-variant-numeric:tabular-nums;will-change:transform;transform-origin:50% 50%;
+  transition:color .3s ease,border-color .3s ease,box-shadow .3s ease}
+.g-cp-chip.g-cp-moves{color:var(--ink)}
+.g-cp-chip.g-cp-locked{border-color:var(--lav);color:var(--lav);
+  box-shadow:0 0 12px color-mix(in srgb, var(--lav), transparent 70%)}
+.g-cp-chip.g-cp-calm{border-color:var(--pink);color:var(--pink);position:relative;overflow:hidden;
+  box-shadow:0 0 12px color-mix(in srgb, var(--pink), transparent 62%)}
+/* the composure meter: index.js may set --cp-calm (0..1) on the chip; the
+   fill rides under the text */
+.g-cp-chip.g-cp-calm::before{content:"";position:absolute;left:0;top:0;bottom:0;z-index:-1;
+  width:calc(var(--cp-calm,1) * 100%);background:color-mix(in srgb, var(--pink), transparent 82%);
+  transition:width .5s ease}
+.g-cp-stage[data-mode="zen"] .g-cp-chip.g-cp-clock{opacity:.7}
+.g-cp-stage.g-cp-bell .g-cp-chip.g-cp-clock{border-color:var(--gold);color:var(--gold);
+  animation:g-cp-bellchip 1s ease-in-out infinite alternate}
+@keyframes g-cp-bellchip{from{box-shadow:0 0 6px rgba(240,194,75,.3)}to{box-shadow:0 0 16px rgba(240,194,75,.7)}}
+
+/* ---- the frame: THE EASEL ------------------------------------------------- */
+/* the frame node holds the board and the preview; the wood is its ::before
+   (under the board), the stand its ::after (behind, below). The lean from
+   casino.slide rides --cp-lean-x/y and springs back. */
+.g-cp-frame{position:relative;z-index:1;flex:0 0 auto;
+  width:calc(var(--cp-board) + 2 * (var(--cp-mat) + var(--cp-wood)));
+  height:calc(var(--cp-board) + 2 * (var(--cp-mat) + var(--cp-wood)));
+  padding:calc(var(--cp-mat) + var(--cp-wood));
+  box-sizing:border-box;
+  transform:perspective(1300px) rotateY(calc(var(--cp-lean-x,0) * 1.6deg)) rotateX(calc(var(--cp-lean-y,0) * -1.6deg))
+    translate3d(calc(var(--cp-lean-x,0) * 3px), calc(var(--cp-lean-y,0) * 3px), 0);
+  transition:transform .38s cubic-bezier(.2,1.5,.35,1)}
+/* the wood + the mat */
+.g-cp-frame::before{content:"";position:absolute;inset:0;z-index:0;border-radius:6px;
+  background:
+    linear-gradient(120deg, rgba(255,255,255,.08), transparent 40%, rgba(0,0,0,.18) 100%),
+    repeating-linear-gradient(92deg, transparent 0 7px, rgba(0,0,0,.07) 7px 9px, transparent 9px 15px),
+    linear-gradient(160deg, color-mix(in srgb, var(--cp-n-wood, #4a3224), black 10%), color-mix(in srgb, var(--cp-n-wood, #4a3224), black 42%));
+  box-shadow:0 22px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.06) inset, 0 0 0 var(--cp-wood) transparent;
+  /* the mat: a lighter card inside the wood */
+  padding:var(--cp-wood);background-clip:border-box}
+.g-cp-frame > .g-cp-board::before{content:"";position:absolute;inset:calc(-1 * var(--cp-mat));z-index:-1;
+  border-radius:3px;background:linear-gradient(170deg, color-mix(in srgb, var(--ink), var(--panel) 55%), color-mix(in srgb, var(--ink), var(--panel) 70%));
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.35), inset 0 2px 6px rgba(0,0,0,.35)}
+/* the stand: a back leg and a ledge, drawn behind the frame */
+.g-cp-frame::after{content:"";position:absolute;left:50%;top:70%;z-index:-1;width:16%;height:60%;
+  transform:translateX(-50%) perspective(600px) rotateX(18deg);transform-origin:50% 0;
+  background:
+    linear-gradient(90deg, transparent 0 42%, color-mix(in srgb, var(--cp-n-wood, #4a3224), black 30%) 42% 58%, transparent 58%),
+    linear-gradient(180deg, transparent 0 72%, color-mix(in srgb, var(--cp-n-wood, #4a3224), black 40%) 72% 80%, transparent 80%);
+  opacity:.9;filter:drop-shadow(0 10px 14px rgba(0,0,0,.5))}
+/* the easel glows for the bell and the royal */
+.g-cp-stage.g-cp-bell .g-cp-frame::before{box-shadow:0 22px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.06) inset, 0 0 34px color-mix(in srgb, var(--gold), transparent 60%)}
+.g-cp-stage.g-cp-royal .g-cp-frame::before{box-shadow:0 22px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.06) inset, 0 0 54px color-mix(in srgb, var(--gold), transparent 40%)}
+
+/* ---- the board: the canvas ------------------------------------------------ */
+.g-cp-board{position:relative;z-index:1;width:var(--cp-board);height:var(--cp-board);
+  --cp-tile:calc((var(--cp-board) - (var(--cp-n,3) - 1) * var(--cp-gap)) / var(--cp-n,3));
+  --cp-step:calc(var(--cp-tile) + var(--cp-gap));
+  --cp-grab-max:calc(var(--cp-step) * .1);
+  --cp-grab-k:1;
+  border-radius:3px;touch-action:none;-webkit-user-select:none;user-select:none;
+  /* the bare canvas shows through the gap and the blank: raw linen, dark */
+  background:
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(255,255,255,.025) 2px 3px),
+    repeating-linear-gradient(90deg, transparent 0 2px, rgba(255,255,255,.025) 2px 3px),
+    color-mix(in srgb, var(--ground), black 30%);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.5), inset 0 3px 12px rgba(0,0,0,.55);
+  transition:filter .8s ease,opacity .8s ease}
+.g-cp-board.g-cp-held .g-cp-tile{transition-duration:60ms,.22s,.22s}
+.g-cp-board.g-cp-grab-blocked{--cp-grab-k:.33}
+
+/* ---- the cells: the canvas floor under the tiles ------------------------- */
+/* index.js lays one .g-cp-cell per square (--r/--c); the one with no tile on
+   it is the gap - a recess in the linen. Drift (row_drift) targets these. */
+.g-cp-cell{position:absolute;left:0;top:0;width:var(--cp-tile);height:var(--cp-tile);z-index:0;border-radius:2px;
+  transform:translate3d(calc(var(--cp-c,0) * var(--cp-step)), calc(var(--cp-r,0) * var(--cp-step)), 0);
+  background:color-mix(in srgb, var(--ground), black 22%);
+  box-shadow:inset 0 2px 8px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.03);pointer-events:none}
+
+/* ---- tiles: positioned by transform ONLY ---------------------------------- */
+.g-cp-tile{position:absolute;left:0;top:0;width:var(--cp-tile);height:var(--cp-tile);
+  pointer-events:auto;cursor:pointer;will-change:transform;z-index:2;
+  transform:translate3d(
+    calc(var(--cp-c,0) * var(--cp-step) + var(--cp-grab-x,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)),
+    calc(var(--cp-r,0) * var(--cp-step) + var(--cp-grab-y,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)), 0);
+  transition:transform 190ms cubic-bezier(.22,.9,.3,1.04),opacity .22s ease,filter .22s ease}
+/* the body: weight. A bevel and a shadow that deepen in flight. */
+.g-cp-tile::before{content:"";position:absolute;inset:0;z-index:-1;border-radius:2px;
+  background:color-mix(in srgb, var(--panel), black 20%);
+  box-shadow:0 2px 6px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.14), inset 0 -1px 0 rgba(0,0,0,.4);
+  transition:box-shadow .2s ease,transform .2s ease,opacity .6s ease}
+/* the ring: the lock's chroma pulse, the hint's breath */
+.g-cp-tile::after{content:"";position:absolute;inset:0;border-radius:2px;opacity:0;pointer-events:none;
+  border:2px solid var(--lav)}
+.g-cp-tile.is-moving{z-index:3}
+.g-cp-tile.is-moving::before{box-shadow:0 10px 22px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.2);
+  transform:translateY(-1px)}
+/* the face: the clipped viewport */
+.g-cp-face{position:absolute;inset:0;z-index:0;border-radius:2px;overflow:hidden;isolation:isolate;
+  pointer-events:none;transition:inset .5s ease,border-radius .5s ease}
+.g-cp-media{display:block;position:absolute;left:calc(var(--hc,0) * -1 * var(--cp-step));top:calc(var(--hr,0) * -1 * var(--cp-step));
+  width:var(--cp-board);height:var(--cp-board);max-width:none;object-fit:cover;pointer-events:none}
+/* a varnish: every face carries a hair of gloss from the lamp */
+.g-cp-face::after{content:"";position:absolute;inset:0;z-index:2;pointer-events:none;opacity:.35;
+  background:linear-gradient(160deg, rgba(255,255,255,.14), transparent 45%, rgba(0,0,0,.12) 100%)}
+/* LOCKED: the seam dissolves - the face grows by half the gap, the bevel
+   fades, one chroma ring runs, then a slow varnish sheen (Law III) */
+.g-cp-tile.is-locked{z-index:1;cursor:default}
+.g-cp-tile.is-locked .g-cp-face{inset:calc(var(--cp-gap) * -.5 - .5px);border-radius:0}
+.g-cp-tile.is-locked::before{opacity:0}
+.g-cp-tile.is-locked::after{animation:g-cp-lockring .7s ease-out 1;
+  border-color:hsla(var(--cp-hue-b),90%,78%,1);inset:calc(var(--cp-gap) * -.5)}
+@keyframes g-cp-lockring{0%{opacity:.9;transform:scale(1.05);box-shadow:-2px 0 rgba(255,60,120,.7),2px 0 rgba(60,230,220,.7)}
+  60%{opacity:.4;box-shadow:-1px 0 rgba(255,60,120,.3),1px 0 rgba(60,230,220,.3)}
+  100%{opacity:0;transform:scale(1);box-shadow:none}}
+.g-cp-tile.is-locked .g-cp-face::after{opacity:.5;
+  background:linear-gradient(115deg, transparent 30%, rgba(255,255,255,.1) 45%, transparent 60%);
+  background-size:260% 100%;animation:g-cp-sheen 7s ease-in-out infinite}
+@keyframes g-cp-sheen{0%{background-position:130% 0}100%{background-position:-60% 0}}
+/* THE RESCUE: the next baseline move breathes lavender and lifts */
+.g-cp-tile.is-hint{z-index:3}
+.g-cp-tile.is-hint::after{opacity:1;border-color:var(--lav);inset:-2px;border-radius:3px;
+  box-shadow:0 0 16px color-mix(in srgb, var(--lav), transparent 40%), inset 0 0 14px color-mix(in srgb, var(--lav), transparent 60%);
+  animation:g-cp-hint 1.2s ease-in-out infinite alternate}
+.g-cp-tile.is-hint::before{transform:translateY(-1px);box-shadow:0 8px 18px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.2)}
+@keyframes g-cp-hint{from{opacity:.45;box-shadow:0 0 8px color-mix(in srgb, var(--lav), transparent 60%)}
+  to{opacity:1;box-shadow:0 0 22px color-mix(in srgb, var(--lav), transparent 30%), inset 0 0 14px color-mix(in srgb, var(--lav), transparent 50%)}}
+/* THE BUMP: a press into a wall. index.js holds .is-bump on the BOARD for
+   240ms; the whole canvas knocks once against the easel - chrome moves, the
+   tiles never do (their --r/--c are untouched, the board carries them). */
+.g-cp-board.is-bump{animation:g-cp-refuse .24s ease-out 1}
+@keyframes g-cp-refuse{0%{transform:none}30%{transform:translate(-3px,0)}60%{transform:translate(3px,0)}80%{transform:translate(-1px,0)}100%{transform:none}}
+
+/* the numeral: a dim mono badge index.js sets on every face; it fades on a
+   lock and goes with the seams on the solve (the picture is the point) */
+.g-cp-num{position:absolute;right:5%;bottom:5%;z-index:3;font-family:var(--mono);font-weight:700;
+  font-size:clamp(8px, calc(var(--cp-tile) * .1), 13px);line-height:1;padding:.25em .5em;border-radius:999px;
+  background:rgba(8,6,22,.55);color:color-mix(in srgb, var(--lav), white 40%);opacity:.55;pointer-events:none;
+  transition:opacity .6s ease}
+.g-cp-tile.is-locked .g-cp-num{opacity:.22}
+.g-cp-stage[data-phase="solved"] .g-cp-num{opacity:0}
+.g-cp-stage[data-mode="zen"] .g-cp-num{opacity:.4}
+/* THE PEEK REVEAL: the shell's verb toggles the hidden attribute on this
+   layer (no display rule here, ever - the shell's own reset owns that); it
+   sits over the canvas inside the easel and holds one unclipped copy of the
+   subject + a caption. */
+.g-cp-peeklayer{position:absolute;inset:calc(var(--cp-mat) + var(--cp-wood));z-index:6;overflow:hidden;border-radius:2px;
+  background:rgba(10,8,16,.94);pointer-events:none;box-shadow:0 0 0 1px rgba(255,255,255,.08), 0 0 40px rgba(0,0,0,.6)}
+.g-cp-peeklayer .g-cp-media{position:absolute;left:0;top:0;width:100%;height:100%;max-width:none;object-fit:cover;opacity:.96}
+.g-cp-peek-cap{position:absolute;left:0;right:0;bottom:0;z-index:2;padding:6px 10px;text-align:center;
+  font-family:var(--mono);font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--ink-dim);
+  background:linear-gradient(to top, rgba(10,8,16,.85), transparent)}
+/* the HUD's live buttons: the shell's peek verb (arc-peekbtn is the shell's
+   class) and zen's Finish; both wear the chip skin and keep a focus ring */
+.g-cp-hud .g-cp-peek,.g-cp-hud .g-cp-finish{appearance:none;-webkit-appearance:none;font:inherit;letter-spacing:inherit;
+  text-transform:inherit;cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+  border:1px solid var(--lav);color:color-mix(in srgb, var(--lav), var(--ink) 30%);
+  background:color-mix(in srgb, var(--panel), var(--lav) 10%);
+  box-shadow:0 0 10px color-mix(in srgb, var(--lav), transparent 78%);transition:box-shadow .3s ease,color .3s ease}
+.g-cp-hud .g-cp-finish{border-color:var(--pink);color:color-mix(in srgb, var(--pink), var(--ink) 30%);
+  background:color-mix(in srgb, var(--panel), var(--pink) 12%);animation:g-cp-finishchip 3.4s ease-in-out infinite alternate}
+@keyframes g-cp-finishchip{from{box-shadow:0 0 8px color-mix(in srgb, var(--pink), transparent 82%)}to{box-shadow:0 0 18px color-mix(in srgb, var(--pink), transparent 58%)}}
+.g-cp-hud .g-cp-peek:hover,.g-cp-hud .g-cp-finish:hover{color:var(--ink);border-color:var(--gold)}
+.g-cp-hud .g-cp-peek:focus-visible,.g-cp-hud .g-cp-finish:focus-visible{outline:2px solid var(--gold);outline-offset:3px}
+.g-cp-hud .g-cp-peek:active,.g-cp-hud .g-cp-finish:active{transform:translateY(1px)}
+.g-cp-hud .g-cp-peek.is-held,.g-cp-hud .g-cp-peek.is-on,.g-cp-hud .g-cp-peek:active{color:var(--ink);border-color:var(--gold);
+  box-shadow:0 0 16px color-mix(in srgb, var(--gold), transparent 50%)}
+.g-cp-chip.g-cp-retake{border-color:var(--gold);color:var(--gold);opacity:.8}
+
+/* ---- the solve: seams evaporate, the clip plays clean ---------------------- */
+/* two hooks, one look: index.js sets data-phase="solved" on the stage AND
+   .is-solved on the board (the board class outlives a phase change). */
+.g-cp-stage[data-phase="solved"] .g-cp-tile,.g-cp-board.is-solved .g-cp-tile{cursor:default}
+.g-cp-stage[data-phase="solved"] .g-cp-tile .g-cp-face,.g-cp-board.is-solved .g-cp-tile .g-cp-face{inset:calc(var(--cp-gap) * -.5);border-radius:0;
+  transition:inset 1.2s ease .2s,border-radius 1.2s ease}
+.g-cp-stage[data-phase="solved"] .g-cp-tile::before,.g-cp-board.is-solved .g-cp-tile::before{opacity:0;transition:opacity 1.2s ease}
+.g-cp-stage[data-phase="solved"] .g-cp-tile .g-cp-face::after,.g-cp-board.is-solved .g-cp-tile .g-cp-face::after{opacity:.25;animation:none}
+.g-cp-stage[data-phase="solved"] .g-cp-num,.g-cp-board.is-solved .g-cp-num{opacity:0}
+.g-cp-stage[data-phase="solved"] .g-cp-board,.g-cp-board.is-solved{box-shadow:inset 0 0 0 1px rgba(0,0,0,.5), 0 0 40px hsla(var(--cp-hue-b),80%,70%,.35)}
+.g-cp-stage[data-phase="solved"] .g-cp-board::after,.g-cp-board.is-solved::after{content:"";position:absolute;inset:0;z-index:5;pointer-events:none;
+  background:linear-gradient(115deg, transparent 30%, rgba(255,255,255,.26) 50%, transparent 70%);background-size:300% 100%;
+  animation:g-cp-solvesweep 1.8s ease-out .3s 1 both}
+@keyframes g-cp-solvesweep{0%{opacity:1;background-position:140% 0}100%{opacity:0;background-position:-40% 0}}
+
+/* ---- the burial (data-wash="1" while a wash is up) --------------------------
+   The engine's wash buries the board from its own fixed layer; the studio
+   answers from underneath: the lamp dips, the motes freeze, the canvas cools
+   toward the wash hue and the numerals hide so the picture is all there is.
+   Nothing here touches a tile's place. */
+.g-cp-stage[data-wash="1"]{--cp-wash-k:.62}
+.g-cp-stage[data-wash="1"] .g-cp-bd-motes{animation-play-state:paused;opacity:.3}
+.g-cp-stage[data-wash="1"] .g-cp-board{filter:saturate(.9) brightness(.96);transition:filter .6s ease}
+.g-cp-stage[data-wash="1"] .g-cp-num{opacity:0;transition:opacity .3s ease}
+.g-cp-stage[data-wash="1"] .g-cp-frame::before{box-shadow:0 22px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.06) inset, 0 0 40px hsla(var(--cp-hue-a),70%,60%,.35);transition:box-shadow .6s ease}
+/* ---- the peek (data-peek="1" while the reveal is held) ----------------------
+   shell/peek.js lifts the whole picture over the board (.g-cp-peeklayer, not
+   hidden); under it the board falls back a step so the reveal reads as a
+   sheet laid on the easel, and the HUD quietens. */
+.g-cp-stage[data-peek="1"] .g-cp-board{filter:brightness(.55) saturate(.7);transition:filter .25s ease}
+.g-cp-stage[data-peek="1"] .g-cp-hud{opacity:.55;transition:opacity .25s ease}
+.g-cp-stage[data-peek="1"] .g-cp-peek{border-color:var(--gold);color:var(--gold);box-shadow:0 0 14px color-mix(in srgb, var(--gold), transparent 55%)}
+/* ---- phases ----------------------------------------------------------------- */
+.g-cp-stage[data-phase="briefing"] .g-cp-board{filter:brightness(.78) saturate(.85)}
+.g-cp-stage[data-phase="ended"] .g-cp-board{filter:saturate(.6) brightness(.7)}
+.g-cp-stage[data-phase="ended"] .g-cp-tile::before,.g-cp-stage[data-phase="ended"] .g-cp-tile::after{animation:none}
+
+/* ---- the shell's stamp, when index.js targets the frame ------------------- */
+.g-cp-frame > .arc-stamp{position:absolute;left:0;right:0;top:44%;margin:0 auto;width:max-content;
+  max-width:90%;z-index:7;text-align:center}
+
+/* ---- the flash well: engine one-shots over the board, never a pointer ----- */
+.g-cp-flashwell{position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:6}
+.g-cp-flashwell *{pointer-events:none}
+
+/* ---- proctor line + end card ---------------------------------------------- */
+.g-cp-msg{position:relative;z-index:2;margin:0;min-height:1.4em;text-align:center;
+  font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ink-dim);transition:opacity .3s ease}
+.g-cp-msg:empty{opacity:0}
+.g-cp-end{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:8;
+  width:min(460px, 92%);box-sizing:border-box;padding:18px 20px 16px;
+  border-radius:6px;background:color-mix(in srgb, var(--navy), transparent 4%);
+  border:1px solid color-mix(in srgb, var(--lav), var(--line) 50%);
+  box-shadow:0 18px 50px rgba(0,0,0,.55), 0 0 34px color-mix(in srgb, var(--lav), transparent 72%);
+  animation:g-cp-endin .5s ease-out 1;overflow:hidden}
+/* asset chrome (Deck VI): the pool still the casino chose, as the card's paper */
+.g-cp-end::before{content:"";position:absolute;inset:0;z-index:-1;opacity:calc(var(--cp-n-a-asset,0) * 1.4);
+  background-image:var(--cp-n-asset,none);background-size:cover;background-position:center;
+  mix-blend-mode:luminosity;filter:blur(3px) saturate(.1)}
+@keyframes g-cp-endin{from{opacity:0;transform:translate(-50%,-46%)}to{opacity:1;transform:translate(-50%,-50%)}}
+.g-cp-end-title{font-family:var(--disp);font-size:16px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;color:var(--ink);text-align:center;text-shadow:0 0 18px color-mix(in srgb, var(--pink), transparent 60%)}
+.g-cp-end-row{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);
+  padding:5px 0;border-bottom:1px dashed color-mix(in srgb, var(--line), transparent 20%)}
+.g-cp-end-k{color:var(--ink-faint)}
+.g-cp-end-v{color:var(--ink);font-variant-numeric:tabular-nums}
+.g-cp-end-line{margin:2px 0 0;font-size:12px;color:var(--ink-dim)}
+.g-cp-end-solved .g-cp-end-v{color:var(--gold)}
+.g-cp-end-dare{margin-top:12px;padding:10px 12px;border-radius:6px;text-align:center;
+  border:1px solid color-mix(in srgb, var(--gold), transparent 55%);
+  background:color-mix(in srgb, var(--gold), transparent 92%)}
+.g-cp-end-dare .g-cp-end-k{display:block;font-family:var(--mono);font-size:10px;letter-spacing:.22em;
+  text-transform:uppercase;color:var(--gold)}
+.g-cp-end-dare .g-cp-end-v{display:block;font-family:var(--disp);font-size:22px;letter-spacing:.08em;margin:4px 0 2px;
+  color:var(--gold);text-shadow:0 0 16px color-mix(in srgb, var(--gold), transparent 55%)}
+.g-cp-end .btn,.g-cp-end button{margin:10px 4px 0}
+/* the grade as an OBJECT: a wax seal pressed into the card */
+.g-cp-end-seal{position:relative;width:64px;height:64px;margin:4px auto 8px;border-radius:50%;
+  display:flex;align-items:center;justify-content:center;font-family:var(--disp);font-size:26px;font-weight:700;
+  color:color-mix(in srgb, var(--ink), transparent 10%);
+  --cp-seal:var(--pink-deep);
+  background:radial-gradient(circle at 38% 32%, color-mix(in srgb, var(--cp-seal), white 25%), var(--cp-seal) 45%, color-mix(in srgb, var(--cp-seal), black 35%) 100%);
+  box-shadow:0 4px 10px rgba(0,0,0,.55), inset 0 0 0 3px color-mix(in srgb, var(--cp-seal), black 25%), inset 0 0 0 5px color-mix(in srgb, var(--cp-seal), white 10%);
+  text-shadow:0 1px 0 rgba(0,0,0,.5);transform:rotate(-8deg);
+  animation:g-cp-sealin .6s cubic-bezier(.2,1.4,.3,1) 1}
+.g-cp-end-seal::before{content:"";position:absolute;inset:-6px;border-radius:50%;z-index:-1;
+  background:radial-gradient(circle, color-mix(in srgb, var(--cp-seal), transparent 30%) 55%, transparent 72%);
+  clip-path:polygon(50% 0,60% 8%,72% 3%,78% 14%,92% 14%,92% 28%,100% 38%,94% 50%,100% 62%,92% 72%,92% 86%,78% 86%,72% 97%,60% 92%,50% 100%,40% 92%,28% 97%,22% 86%,8% 86%,8% 72%,0 62%,6% 50%,0 38%,8% 28%,8% 14%,22% 14%,28% 3%,40% 8%)}
+.g-cp-end-seal[data-grade="S"]{--cp-seal:var(--gold);color:color-mix(in srgb, var(--ground), black 20%)}
+.g-cp-end-seal[data-grade="A"]{--cp-seal:var(--pink)}
+.g-cp-end-seal[data-grade="B"]{--cp-seal:var(--lav);color:color-mix(in srgb, var(--ground), black 20%)}
+.g-cp-end-seal[data-grade="C"]{--cp-seal:var(--slate)}
+.g-cp-end-seal[data-zen]{--cp-seal:hsl(34,70%,56%);font-size:18px;letter-spacing:.1em}
+@keyframes g-cp-sealin{0%{opacity:0;transform:rotate(-8deg) scale(1.6)}60%{opacity:1;transform:rotate(-8deg) scale(.94)}100%{transform:rotate(-8deg) scale(1)}}
+
+/* ---- THE CLASS RULES SHEET (Deck VI, Law IV) ------------------------------- */
+/* Drawn, not told. The sheet takes no pointer events; the GO button re-enables
+   them for itself alone. Each figure is ONE span with three blank parts; the mini board
+   is a gradient grid, the parts are its moving pieces. */
+.g-cp-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(520px,90vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:22px 24px 20px;border-radius:8px;
+  background:linear-gradient(180deg,rgba(26,26,54,.95),rgba(14,14,32,.97));
+  border:1px solid var(--line);
+  box-shadow:0 30px 80px rgba(0,0,0,.55), 0 0 44px rgba(184,166,232,.12)}
+.g-cp-hw-title{margin:0 0 8px;text-align:center;font-family:var(--disp);font-size:clamp(16px,2.4vmin,20px);
+  letter-spacing:.2em;text-transform:uppercase;color:var(--lav);text-shadow:0 0 22px rgba(184,166,232,.45)}
+.g-cp-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-cp-hw-row + .g-cp-hw-row{border-top:1px dashed rgba(58,58,94,.6)}
+.g-cp-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim)}
+.g-cp-hw-fig{position:relative;flex:0 0 auto;display:block;width:72px;height:72px;pointer-events:none;
+  --hw-c:22px;--hw-g:3px;--hw-s:calc(var(--hw-c) + var(--hw-g));border-radius:3px;overflow:visible;
+  background:
+    linear-gradient(90deg, transparent 0 var(--hw-c), rgba(0,0,0,.55) var(--hw-c) var(--hw-s), transparent 0),
+    linear-gradient(0deg, transparent 0 var(--hw-c), rgba(0,0,0,.55) var(--hw-c) var(--hw-s), transparent 0),
+    linear-gradient(135deg, hsl(292,40%,48%), hsl(330,55%,52%) 50%, hsl(262,45%,42%));
+  background-size:var(--hw-s) 100%, 100% var(--hw-s), 100% 100%;
+  box-shadow:0 4px 14px rgba(0,0,0,.5), inset 0 0 0 1px rgba(255,255,255,.08)}
+/* index.js drops three blank parts into every figure: .g-cp-hw-a / -b / -c.
+   Each figure decides what they are. All absolute, all one cell by default. */
+.g-cp-hw-fig i{position:absolute;display:block;width:var(--hw-c);height:var(--hw-c);border-radius:2px;box-sizing:border-box}
+/* 1 - SLIDE: a = the gap (bottom-right), b = the tile beside it sliding in
+   and back, c = the finger that taps it */
+.g-cp-hw-slide .g-cp-hw-a{right:0;bottom:0;background:rgba(10,8,20,.92);box-shadow:inset 0 2px 6px rgba(0,0,0,.8)}
+.g-cp-hw-slide .g-cp-hw-b{right:var(--hw-s);bottom:0;
+  background:linear-gradient(135deg, hsl(330,55%,56%), hsl(300,45%,48%));
+  box-shadow:0 3px 8px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.2);
+  animation:g-cp-hwslide 2.6s ease-in-out infinite}
+@keyframes g-cp-hwslide{0%,30%{transform:translateX(0)}45%,70%{transform:translateX(var(--hw-s))}85%,100%{transform:translateX(0)}}
+.g-cp-hw-slide .g-cp-hw-c{right:calc(var(--hw-s) + 4px);bottom:-8px;width:12px;height:18px;border-radius:6px 6px 4px 4px;
+  background:linear-gradient(180deg, var(--lav), #6E5F9B);box-shadow:0 0 8px rgba(184,166,232,.4);
+  animation:g-cp-hwtap 2.6s ease-in-out infinite}
+@keyframes g-cp-hwtap{0%,22%{transform:translate(0,0);opacity:.7}30%{transform:translate(0,-4px) scale(.92);opacity:1}
+  45%,70%{transform:translate(var(--hw-s),-2px);opacity:.9}85%,100%{transform:translate(0,0);opacity:.7}}
+/* 2 - LOCK: a = the centre tile snapping home from the right, b = the ring
+   that runs when it lands, c = the seam light that closes and fades */
+.g-cp-hw-lock .g-cp-hw-a{left:var(--hw-s);top:var(--hw-s);
+  background:linear-gradient(135deg, hsl(310,50%,54%), hsl(330,55%,50%));
+  animation:g-cp-hwlock 2.6s ease-out infinite}
+@keyframes g-cp-hwlock{0%,20%{transform:translateX(var(--hw-s));box-shadow:0 3px 8px rgba(0,0,0,.6)}
+  38%{transform:translateX(0);box-shadow:0 3px 8px rgba(0,0,0,.6)}
+  46%{box-shadow:0 0 0 2px hsl(330,90%,78%), 0 0 14px hsla(330,90%,70%,.8)}
+  60%,88%{transform:translateX(0);box-shadow:0 0 0 0 transparent}
+  100%{transform:translateX(var(--hw-s))}}
+.g-cp-hw-lock .g-cp-hw-b{left:var(--hw-s);top:var(--hw-s);border:2px solid hsl(330,90%,78%);opacity:0;
+  animation:g-cp-hwring 2.6s ease-out infinite}
+@keyframes g-cp-hwring{0%,38%{opacity:0;transform:scale(1)}44%{opacity:.9;transform:scale(1.08)}70%,100%{opacity:0;transform:scale(1.3)}}
+.g-cp-hw-lock .g-cp-hw-c{left:calc(var(--hw-s) - var(--hw-g));top:var(--hw-s);width:var(--hw-g);height:var(--hw-c);border-radius:0;
+  background:hsl(330,90%,82%);opacity:0;animation:g-cp-hwseam 2.6s ease-out infinite}
+@keyframes g-cp-hwseam{0%,40%{opacity:0}48%{opacity:1}75%,100%{opacity:0}}
+/* 3 - WASH: a = the pink wash veil over the whole board (breathing), b = a
+   tile still sliding under it, c = the gap it slides into */
+.g-cp-hw-wash .g-cp-hw-c{right:0;top:var(--hw-s);background:rgba(10,8,20,.92);box-shadow:inset 0 2px 6px rgba(0,0,0,.8)}
+.g-cp-hw-wash .g-cp-hw-b{right:var(--hw-s);top:var(--hw-s);
+  background:linear-gradient(135deg, hsl(330,55%,56%), hsl(300,45%,48%));
+  box-shadow:0 3px 8px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.2);
+  animation:g-cp-hwslide 3s ease-in-out infinite}
+.g-cp-hw-wash .g-cp-hw-a{inset:-6px;width:auto;height:auto;border-radius:5px;z-index:2;
+  background:radial-gradient(70% 70% at 50% 40%, hsla(330,90%,70%,.75), hsla(292,70%,55%,.55) 60%, hsla(262,60%,40%,.4));
+  mix-blend-mode:screen;filter:blur(1px);animation:g-cp-hwwash 3s ease-in-out infinite}
+@keyframes g-cp-hwwash{0%,25%{opacity:0}40%,75%{opacity:.9}90%,100%{opacity:0}}
+.g-cp-hw-go{pointer-events:auto;align-self:center;margin-top:14px;padding:10px 26px;border-radius:999px;cursor:pointer;
+  font-family:var(--disp);font-size:13px;letter-spacing:.18em;text-transform:uppercase;color:var(--ground);
+  background:linear-gradient(180deg, color-mix(in srgb, var(--lav), white 15%), var(--lav));
+  border:1px solid color-mix(in srgb, var(--lav), white 30%);
+  box-shadow:0 0 22px color-mix(in srgb, var(--lav), transparent 45%), 0 3px 0 color-mix(in srgb, var(--lav), black 35%);
+  animation:g-cp-gopulse 1.8s ease-in-out infinite alternate}
+.g-cp-hw-go:hover,.g-cp-hw-go:focus-visible{outline:2px solid var(--gold);outline-offset:3px;filter:brightness(1.08)}
+.g-cp-hw-go:active{transform:translateY(2px);box-shadow:0 0 22px color-mix(in srgb, var(--lav), transparent 45%), 0 1px 0 color-mix(in srgb, var(--lav), black 35%)}
+@keyframes g-cp-gopulse{from{box-shadow:0 0 12px color-mix(in srgb, var(--lav), transparent 60%), 0 3px 0 color-mix(in srgb, var(--lav), black 35%)}
+  to{box-shadow:0 0 30px color-mix(in srgb, var(--lav), transparent 30%), 0 3px 0 color-mix(in srgb, var(--lav), black 35%)}}
+
+/* ---- reduced motion: the mechanic survives, the motion does not ---------- */
+html.arc-reduced .g-cp-stage *{animation:none !important}
+html.arc-reduced .g-cp-stage{transition:none}
+html.arc-reduced .g-cp-bd-motes{opacity:0}
+html.arc-reduced .g-cp-bd-lamp{opacity:calc(var(--cp-n-lamp,.7) * var(--cp-wash-k,1) * .8)}
+html.arc-reduced .g-cp-tile{transition:transform 80ms linear,opacity .2s ease}
+html.arc-reduced .g-cp-frame{transform:none;transition:none}
+html.arc-reduced .g-cp-board,html.arc-reduced .g-cp-board.g-cp-grab-blocked{--cp-grab-k:0}
+html.arc-reduced .g-cp-tile.is-hint::after{opacity:1}
+@media (prefers-reduced-motion: reduce){
+  .g-cp-stage *{animation:none !important}
+  .g-cp-stage{transition:none}
+  .g-cp-bd-motes{opacity:0}
+  .g-cp-bd-lamp{opacity:calc(var(--cp-n-lamp,.7) * var(--cp-wash-k,1) * .8)}
+  .g-cp-tile{transition:transform 80ms linear,opacity .2s ease}
+  .g-cp-frame{transform:none;transition:none}
+  .g-cp-board,.g-cp-board.g-cp-grab-blocked{--cp-grab-k:0}
+  .g-cp-tile.is-hint::after{opacity:1}
+}
+
+/* ---- narrow / touch ----------------------------------------------------------- */
+@media (max-width:560px){
+  .g-cp-stage{padding:64px 8px 10px;--cp-board:min(calc(100dvh - 230px), calc(100vw - 56px));--cp-mat:8px;--cp-wood:7px}
+  .g-cp-hud{gap:6px 8px;font-size:10px}
+  .g-cp-chip{padding:3px 9px}
+  .g-cp-frame::after{display:none}
+}
+`;
+
+/** Inject once per document. No-op headless (the DOM double has no head). */
+export function injectComposureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return false;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);   // harness shim
+    return true;
+  } catch (e) {
+    return false;      // a stylesheet must never be the thing that fails a class
+  }
+}
+
+export default injectComposureStyle;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
@@ -101,12 +101,6 @@ const STYLE_ID = 'g-cp-style';
 export const STYLE_TEXT = `
 /* ---- registered decoration props: numbers interpolate, so a var change
    glides (the lamp warms, the lean springs) instead of snapping ------------- */
-/* iOS/WebKit TRAP: a transform whose calc() reads an UNREGISTERED custom property does
-   not transition when that property changes - the tile TELEPORTS. --r/--c stay the
-   CORE contract (unregistered, read by decks); the transform reads these registered
-   twins that CORE writes alongside them. */
-@property --cp-r{syntax:'<number>';inherits:false;initial-value:0}
-@property --cp-c{syntax:'<number>';inherits:false;initial-value:0}
 @property --cp-lean-x{syntax:'<number>';inherits:false;initial-value:0}
 @property --cp-lean-y{syntax:'<number>';inherits:false;initial-value:0}
 @property --cp-grab-x{syntax:'<number>';inherits:true;initial-value:0}
@@ -303,7 +297,7 @@ export const STYLE_TEXT = `
 /* index.js lays one .g-cp-cell per square (--r/--c); the one with no tile on
    it is the gap - a recess in the linen. Drift (row_drift) targets these. */
 .g-cp-cell{position:absolute;left:0;top:0;width:var(--cp-tile);height:var(--cp-tile);z-index:0;border-radius:2px;
-  transform:translate3d(calc(var(--cp-c,0) * var(--cp-step)), calc(var(--cp-r,0) * var(--cp-step)), 0);
+  transform:translate3d(calc(var(--c,0) * var(--cp-step)), calc(var(--r,0) * var(--cp-step)), 0);
   background:color-mix(in srgb, var(--ground), black 22%);
   box-shadow:inset 0 2px 8px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.03);pointer-events:none}
 
@@ -311,8 +305,8 @@ export const STYLE_TEXT = `
 .g-cp-tile{position:absolute;left:0;top:0;width:var(--cp-tile);height:var(--cp-tile);
   pointer-events:auto;cursor:pointer;will-change:transform;z-index:2;
   transform:translate3d(
-    calc(var(--cp-c,0) * var(--cp-step) + var(--cp-grab-x,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)),
-    calc(var(--cp-r,0) * var(--cp-step) + var(--cp-grab-y,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)), 0);
+    calc(var(--c,0) * var(--cp-step) + var(--cp-grab-x,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)),
+    calc(var(--r,0) * var(--cp-step) + var(--cp-grab-y,0) * var(--cp-grab-k,1) * var(--cp-grab-max,0px)), 0);
   transition:transform 190ms cubic-bezier(.22,.9,.3,1.04),opacity .22s ease,filter .22s ease}
 /* the body: weight. A bevel and a shadow that deepen in flight. */
 .g-cp-tile::before{content:"";position:absolute;inset:0;z-index:-1;border-radius:2px;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
@@ -1,0 +1,870 @@
+/* ============================================================================
+ * games/composure/trickster.js - DECK III of the House Rules: the cards the
+ * floor map deals the studio. A sliding picture is where your eyes stop being
+ * reliable witnesses of where things ARE, so every card here attacks the
+ * mental model, never the board.
+ *
+ *   THE FALSE PREVIEW (native, the signature) a glitch_swap-style shudder -
+ *                   rgbsplit / vhsroll / datamosh, seeded - paints GHOSTS of
+ *                   real tiles in WRONG slots on the .g-cp-preview lie layer
+ *                   (cloned faces, --pr/--pc, pointer-events:none) for half a
+ *                   second, then they dissolve and the truth is exactly where
+ *                   it always was. A dealt preview ARMS and plays on the next
+ *                   afterSlide() or washOn(true) - the lie rides the move or
+ *                   hides under the wash - and folds into playing on its own
+ *                   if neither comes. TIER 4: one deal per class is THE FAKE
+ *                   SOLVED BOARD - every loose tile ghosted at its HOME, seams
+ *                   evaporating, a sweep of light - and it was a lie. The
+ *                   engine's own glitch_swap is fired ON THE PREVIEW LAYER for
+ *                   its sfx + dressing (targets = the lie layer, never a tile);
+ *                   the ghosts are CSS. Truth --r/--c are READ, never written.
+ *                   Reduced motion: a plain crossfade ghost at half presence,
+ *                   no shudder (style.js .is-plain).
+ *   STAT FLICKER    the moves chip reads a few off, then corrects itself with
+ *                   a static pop. The ledger never moves; confidence does.
+ *   CROOKED CLOCK   (timed, tier 2+) the clock FACE bends: it races through
+ *                   the boring middle and crawls as the bell nears, honest for
+ *                   the last 20s. The real budget is index.js's and exact. A
+ *                   MutationObserver re-bends the face the moment truth lands
+ *                   (the Deep End posture); no observer -> a 250ms poll.
+ *   THE MELT        stall >= 3s and one LOOSE tile visibly drips (.g-cp-melt;
+ *                   the body and the face deform, never the transform). Snaps
+ *                   back on the next move. Nothing is lost.
+ *   GHOST CURSOR    stall >= 4.5s (tier 2+) and a faint hand suggests the
+ *                   WORST slide: of the tiles beside the gap, the one whose
+ *                   move pulls a LOCKED piece out of its home, else the one
+ *                   that lands farthest from its own. Pure decoration in the
+ *                   preview layer; it cannot input; it dies on the next move.
+ *
+ * DEALING RULE: previews, flickers and the clock are dealt by the seeded plan
+ * (budget 2/4/6/8 per tier, never more than ~6 a minute, never in the first
+ * 10s or the last 20s of a timed class; zen halves the budget, drops the
+ * clock and cycles the plan); a deal whose moment is wrong (halted) re-queues
+ * politely, then folds. The melt and the ghost are stall-reactive - the stall
+ * is the player's own - but WHICH tile melts and WHICH worst slide the ghost
+ * takes are the seed's choice.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - the flicker / the clock write chip TEXT and restore
+ *       via chipText (the truth source); the preview writes only its own
+ *       ghosts (--pr/--pc on nodes it owns); nothing reads or writes moves,
+ *       locks, the clock budget or the board.
+ *   II  input honest  - no card is clickable; every node lives in the
+ *       pointer-events:none preview layer; a tile's --r/--c, data-home and
+ *       data-id are read, never written.
+ *   V   seeded        - per-tag mulberry32 streams off seed+'|cp-trickster|'.
+ *       A retake replays the identical deal.
+ *   VI  exits sacred  - bgIntensity 0 disarms the deck; reduced motion makes
+ *       the preview a plain crossfade ghost, drops the flicker pop, the melt's
+ *       drip and the ghost cursor (the clock still bends: a number is not
+ *       motion); every timer lives in the game's registry AND a local set, so
+ *       destroy() cannot leak one.
+ *   VII strings      - cp_trick_preview / cp_trick_seen / cp_trick_melt (rows
+ *       CORE ships in lex.js) through the t() this deck is handed. This file
+ *       invents no text.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const CP_TRICKSTER = Object.freeze({
+  /** Dealt card events per class, by tier (the House budget: 2 -> 8). */
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  MIN_GAP_MS: 9000,
+  FIRST_DEAL_MS: 10000,
+  TAIL_MS: 20000,
+  BUDGET_MS: 120000,
+  RETRY_MS: 2000,
+  RETRY_MAX: 8,
+  /** Card weights by tier (preview / flicker; the clock is one slot). */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ preview: 0.65, flicker: 0.35 }),
+    2: Object.freeze({ preview: 0.6, flicker: 0.4 }),
+    3: Object.freeze({ preview: 0.62, flicker: 0.38 }),
+    4: Object.freeze({ preview: 0.66, flicker: 0.34 }),
+  }),
+  CLOCK_FROM_TIER: 2,
+  SOLVED_FROM_TIER: 4,
+  GHOST_FROM_TIER: 2,
+  MELT_FROM_TIER: 1,
+  /** The false preview. */
+  PREVIEW_MS: Object.freeze({ 1: 420, 2: 480, 3: 560, 4: 640 }),
+  PREVIEW_TILES: Object.freeze({ 1: 2, 2: 3, 3: 3, 4: 4 }),
+  PREVIEW_FOLD_MS: 8000,
+  PREVIEW_FADE_MS: 240,
+  PREVIEW_ALPHA: 0.82,
+  SOLVED_MS: 720,
+  SOLVED_MIN_FRAC: 0.4,
+  SOLVED_FOLD_MS: 14000,
+  VARIANTS: Object.freeze(['rgb', 'vhs', 'mosh']),
+  ENGINE_VARIANT: Object.freeze({ rgb: 'rgbsplit', vhs: 'vhsroll', mosh: 'datamosh' }),
+  TAUNT_CHANCE: 0.3,
+  /** Stat flicker. */
+  FLICKER_MS: 450,
+  /** Crooked clock. */
+  CLOCK_BEND: 0.12,
+  CLOCK_HONEST_SEC: 20,
+  CLOCK_RAMP: 0.35,
+  CLOCK_POLL_MS: 250,
+  /** The melt / the ghost: stall thresholds. */
+  MELT_STALL_MS: 3000,
+  GHOST_STALL_MS: 4500,
+  /** Zen: half the deals, the plan cycles, no clock card. */
+  ZEN_BUDGET_MUL: 0.5,
+});
+
+const STYLE_ID = 'g-cp-trickster-style';
+const STYLE_TEXT = `
+/* ---- THE LIE LAYER (trickster) --------------------------------------------
+@property --pr{syntax:'<number>';inherits:false;initial-value:0}
+@property --pc{syntax:'<number>';inherits:false;initial-value:0}
+   Over the board, never a pointer. Ghost tiles (.g-cp-pv) carry --pr/--pc and
+   a cloned face; the layer's variant class is the engine's glitch look redrawn
+   here (rgbsplit / vhsroll / datamosh), .is-plain is the reduced-motion
+   crossfade ghost. Truth tiles are never touched. */
+.g-cp-preview{position:absolute;inset:0;z-index:4;pointer-events:none;overflow:visible;
+  --cp-tile:calc((var(--cp-board) - (var(--cp-n,3) - 1) * var(--cp-gap)) / var(--cp-n,3));
+  --cp-step:calc(var(--cp-tile) + var(--cp-gap))}
+.g-cp-frame > .g-cp-preview{inset:calc(var(--cp-mat) + var(--cp-wood))}
+.g-cp-preview *{pointer-events:none}
+.g-cp-pv{position:absolute;left:0;top:0;width:var(--cp-tile);height:var(--cp-tile);opacity:0;
+  transform:translate3d(calc(var(--pc,0) * var(--cp-step)), calc(var(--pr,0) * var(--cp-step)), 0);
+  transition:opacity .18s ease;will-change:opacity,transform;overflow:hidden;border-radius:2px;
+  background:color-mix(in srgb, var(--panel), black 20%);
+  box-shadow:0 2px 6px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.14)}
+/* a ghost is pictorial: its cloned numeral is hidden so the lie never doubles a number */
+.g-cp-pv .g-cp-num{visibility:hidden}
+.g-cp-pv .g-cp-face{inset:0;border-radius:2px}
+.g-cp-preview.is-on .g-cp-pv{opacity:var(--cp-pv-a,.82)}
+.g-cp-preview.is-on.g-cp-pv-rgb .g-cp-pv{animation:g-cp-pvrgb var(--cp-pv-ms,520ms) steps(2,end) 1;
+  filter:contrast(1.15);box-shadow:-3px 0 rgba(255,0,80,.7),3px 0 rgba(0,255,220,.7)}
+@keyframes g-cp-pvrgb{0%,100%{transform:translate3d(calc(var(--pc,0) * var(--cp-step)), calc(var(--pr,0) * var(--cp-step)), 0)}
+  25%{transform:translate3d(calc(var(--pc,0) * var(--cp-step) - 2px), calc(var(--pr,0) * var(--cp-step) + 1px), 0)}
+  50%{transform:translate3d(calc(var(--pc,0) * var(--cp-step) + 2px), calc(var(--pr,0) * var(--cp-step) - 1px), 0)}
+  75%{transform:translate3d(calc(var(--pc,0) * var(--cp-step) - 1px), calc(var(--pr,0) * var(--cp-step) - 2px), 0)}}
+.g-cp-preview.is-on.g-cp-pv-vhs{animation:g-cp-pvvhs var(--cp-pv-ms,520ms) linear 1}
+@keyframes g-cp-pvvhs{0%{clip-path:inset(0 0 0 0)}30%{clip-path:inset(18% 0 42% 0);transform:translateX(6px)}
+  60%{clip-path:inset(52% 0 12% 0);transform:translateX(-5px)}100%{clip-path:inset(0 0 0 0);transform:none}}
+.g-cp-preview.is-on.g-cp-pv-mosh .g-cp-pv{animation:g-cp-pvmosh var(--cp-pv-ms,520ms) steps(3,end) 1}
+@keyframes g-cp-pvmosh{0%{filter:saturate(1.6) hue-rotate(0)}50%{filter:saturate(2.2) hue-rotate(40deg) blur(1px)}100%{filter:none}}
+/* the fake-solved board: every ghost at home, the seams evaporating, a sweep */
+.g-cp-preview.g-cp-pv-solved .g-cp-pv{border-radius:0;box-shadow:none;width:calc(var(--cp-tile) + var(--cp-gap));height:calc(var(--cp-tile) + var(--cp-gap))}
+.g-cp-preview.g-cp-pv-solved::after{content:"";position:absolute;inset:0;opacity:0;
+  background:linear-gradient(115deg, transparent 30%, rgba(255,255,255,.22) 50%, transparent 70%);background-size:300% 100%}
+.g-cp-preview.is-on.g-cp-pv-solved::after{animation:g-cp-pvsweep var(--cp-pv-ms,520ms) ease-out 1}
+@keyframes g-cp-pvsweep{0%{opacity:.9;background-position:140% 0}100%{opacity:0;background-position:-40% 0}}
+/* reduced: a plain crossfade ghost, half presence, no shudder */
+.g-cp-preview.is-plain .g-cp-pv{transition:opacity .35s ease}
+.g-cp-preview.is-plain.is-on .g-cp-pv{opacity:calc(var(--cp-pv-a,.82) * .55);animation:none;filter:none;box-shadow:none}
+.g-cp-preview.is-plain{animation:none !important}
+/* GHOST CURSOR: a faint hand suggesting the worst slide - from the tile's
+   cell (--gr0/--gc0) toward the gap (--gr1/--gc1), over and over until the
+   player moves. Grid units, so it lands headless too. It cannot input. */
+.g-cp-ghost{position:absolute;width:18px;height:18px;border-radius:50%;opacity:0;
+  left:calc((var(--gc0,0) + .5) * var(--cp-step) - 9px);top:calc((var(--gr0,0) + .5) * var(--cp-step) - 9px);
+  --gdx:calc((var(--gc1,0) - var(--gc0,0)) * var(--cp-step));
+  --gdy:calc((var(--gr1,0) - var(--gr0,0)) * var(--cp-step));
+  background:radial-gradient(circle, rgba(255,255,255,.9), color-mix(in srgb, var(--lav), transparent 30%) 50%, transparent 72%);
+  box-shadow:0 0 14px color-mix(in srgb, var(--lav), transparent 40%);
+  animation:g-cp-ghost 1.6s ease-in-out infinite}
+.g-cp-ghost::before{content:"";position:absolute;left:50%;top:50%;width:calc(var(--cp-step) * .5);height:3px;
+  margin-top:-1.5px;transform-origin:0 50%;transform:rotate(calc(var(--ga,0) * 1deg + 180deg));
+  background:linear-gradient(90deg, color-mix(in srgb, var(--lav), transparent 25%), transparent);border-radius:2px}
+.g-cp-ghost::after{content:"";position:absolute;left:50%;top:50%;width:10px;height:10px;margin:-5px 0 0 -5px;
+  border-right:2px solid var(--ink);border-top:2px solid var(--ink);opacity:.8;
+  transform:rotate(calc(var(--ga,0) * 1deg - 45deg))}
+@keyframes g-cp-ghost{
+  0%{opacity:0;transform:translate3d(0,0,0)}
+  20%{opacity:.75}
+  70%{opacity:.6}
+  100%{opacity:0;transform:translate3d(var(--gdx,0px), var(--gdy,0px), 0)}}
+
+/* ---- TRICKSTER (Deck III) dressing --------------------------------------- */
+/* STAT FLICKER: one beat of chromatic static on the lying chip */
+.g-cp-chip.g-cp-statlie{color:var(--lav);text-shadow:-1.5px 0 var(--pink),1.5px 0 #6EE8E0;
+  animation:g-cp-statlie .45s steps(3) 1}
+@keyframes g-cp-statlie{0%{opacity:1}50%{opacity:.55}100%{opacity:1}}
+/* CROOKED CLOCK: no class at all - a number is not motion */
+/* THE MELT: a loose tile sags and drips while the player stalls; the body and
+   the face deform (transform-origin bottom), a drip forms under it. Snaps back
+   on the next move (class removed, the .2s transition). */
+.g-cp-tile.g-cp-melt{z-index:3}
+.g-cp-tile.g-cp-melt .g-cp-face,.g-cp-tile.g-cp-melt::before{transform-origin:50% 100%;
+  animation:g-cp-meltbody 2.4s ease-in-out infinite alternate}
+.g-cp-tile.g-cp-melt .g-cp-face{filter:saturate(.85) brightness(.95)}
+@keyframes g-cp-meltbody{from{transform:scaleY(1) skewX(0)}to{transform:scaleY(1.08) skewX(-3deg) translateY(3%);
+  border-radius:2px 2px 12px 14px}}
+.g-cp-tile.g-cp-melt::after{opacity:.85;border:0;inset:auto auto -1.1em 50%;width:.45em;height:1.4em;margin-left:-.2em;
+  font-size:clamp(8px, calc(var(--cp-tile) * .16), 22px);border-radius:40% 40% 50% 50%;
+  background:hsla(var(--cp-hue-b),50%,60%,.8);animation:g-cp-drip 2.4s ease-in infinite}
+@keyframes g-cp-drip{0%{transform:scaleY(.2) translateY(0);opacity:0}40%{opacity:.85}100%{transform:scaleY(1.3) translateY(120%);opacity:0}}
+/* reduced motion (both gates) */
+html.arc-reduced .g-cp-ghost{opacity:0}
+html.arc-reduced .g-cp-tile.g-cp-melt .g-cp-face{transform:scaleY(1.03);filter:saturate(.85)}
+html.arc-reduced .g-cp-tile.g-cp-melt::after{opacity:0}
+html.arc-reduced .g-cp-preview .g-cp-pv{animation:none !important;filter:none;box-shadow:none}
+@media (prefers-reduced-motion: reduce){
+  .g-cp-ghost{opacity:0}
+  .g-cp-tile.g-cp-melt .g-cp-face{transform:scaleY(1.03);filter:saturate(.85)}
+  .g-cp-tile.g-cp-melt::after{opacity:0}
+  .g-cp-preview .g-cp-pv{animation:none !important;filter:none;box-shadow:none}
+}
+`;
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return true;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);
+    return true;
+  } catch (e) { return false; }
+}
+
+function clampTier(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+function hasClass(node, cls) {
+  try { return !!(node && node.classList && node.classList.contains(cls)); } catch (e) { return false; }
+}
+/** A tile's honest row/col, read (never written) off index's inline vars. */
+function gridOf(tile) {
+  if (!tile || !tile.style) return null;
+  try {
+    const r = parseFloat(tile.style.getPropertyValue('--r'));
+    const c = parseFloat(tile.style.getPropertyValue('--c'));
+    if (Number.isFinite(r) && Number.isFinite(c)) return { r, c };
+  } catch (e) { /* fall through */ }
+  return null;
+}
+/** A tile's home as row/col: data-home is the integer index (board.js). */
+function homeOf(tile, n) {
+  let raw = null;
+  try { raw = tile && tile.getAttribute ? tile.getAttribute('data-home') : null; } catch (e) { raw = null; }
+  if (raw == null) return null;
+  const s = String(raw);
+  if (s.indexOf(',') >= 0) {
+    const p = s.split(',');
+    const r = parseInt(p[0], 10); const c = parseInt(p[1], 10);
+    return Number.isFinite(r) && Number.isFinite(c) ? { r, c } : null;
+  }
+  const idx = parseInt(s, 10);
+  if (!Number.isFinite(idx) || !(n > 0)) return null;
+  return { r: Math.floor(idx / n), c: idx % n };
+}
+function idOf(tile) { try { return tile.getAttribute('data-id'); } catch (e) { return null; } }
+function dist(a, b) { return Math.abs(a.r - b.r) + Math.abs(a.c - b.c); }
+
+/**
+ * The crooked face, pure: displayed seconds-left for a real seconds-left.
+ * f(B)=B, f(honest)=honest, monotonic (bend*pi < 1), honest at/after the
+ * bell. Ahead through the middle (less time shown than real), crawling as
+ * the bell nears, so the face meets the truth instead of snapping to it.
+ */
+export function bendClock(secLeft, budgetSec, bend, honestSec) {
+  const x = Math.max(0, Number(secLeft) || 0);
+  const B = Math.max(30, Number(budgetSec) || 120);
+  const H = Number.isFinite(honestSec) ? honestSec : CP_TRICKSTER.CLOCK_HONEST_SEC;
+  if (x <= H || x >= B) return Math.round(x);
+  const A0 = Number.isFinite(bend) ? bend : CP_TRICKSTER.CLOCK_BEND;
+  const u = x / B;
+  const uh = H / B;
+  const ramp = Math.max(0, Math.min(1, (u - uh) / CP_TRICKSTER.CLOCK_RAMP));
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, Math.round(B * (u - A * Math.sin(Math.PI * u))));
+}
+
+/**
+ * The house-preferred WORST slide, pure. `tiles` = [{id, r, c, home:{r,c},
+ * locked}], `blank` = {r,c}. Returns {id, from:{r,c}, to:{r,c}, score} for the
+ * tile beside the gap whose move hurts most (a locked piece leaving home is
+ * worst; else the biggest growth in distance-from-home), or null. `pick` is a
+ * 0..1 roll that breaks ties deterministically.
+ */
+export function worstSlide(tiles, blank, pick) {
+  if (!blank || !Array.isArray(tiles)) return null;
+  const cands = [];
+  for (const tl of tiles) {
+    if (!tl || !tl.home) continue;
+    if (dist(tl, blank) !== 1) continue;
+    const d0 = dist(tl, tl.home);
+    const d1 = dist(blank, tl.home);
+    const score = (tl.locked ? 10 : 0) + (d1 - d0);
+    cands.push({ id: tl.id, from: { r: tl.r, c: tl.c }, to: { r: blank.r, c: blank.c }, score });
+  }
+  if (!cands.length) return null;
+  let best = -Infinity;
+  for (const c of cands) best = Math.max(best, c.score);
+  const top = cands.filter((c) => c.score === best);
+  const ix = Math.min(top.length - 1, Math.floor((Number(pick) || 0) * top.length));
+  return top[ix];
+}
+
+/**
+ * @param {Object} o
+ * @param {string}   o.seed        the class seed (retakes replay)
+ * @param {number}   o.tier        1..4
+ * @param {Object}   o.timers      {after(ms,fn)->id, every?(ms,fn)->id, clear|cancel(id)}
+ * @param {boolean}  o.reduced     reduced motion
+ * @param {boolean}  o.capsOk      false when bgIntensity is capped to 0
+ * @param {Function} o.isHalted    () => bool (dead/paused/ended/busy)
+ * @param {Function} o.stats       () => {moves, locked, n, secLeft, budgetSec?, mode?, lockedFrac?} - the TRUTH
+ * @param {Function} o.chipEl      (which: 'moves'|'clock'|'locked'|'calm') => element|null
+ * @param {Function} o.chipText    (which) => the honest text (repaint source)
+ * @param {Object|Function} o.preview  the .g-cp-preview lie layer (or () => it)
+ * @param {Function} o.tiles       () => HTMLElement[] (live tiles)
+ * @param {Function=} o.announce   (text, ms) => void (optional proctor line)
+ * @param {Object=}  o.engine      CORE's deckEngine (fire used for glitch_swap on the lie layer)
+ * @param {Function=} o.t          ctx.lexicon (optional; English fallbacks here)
+ * @param {number=}  o.budgetSec   class budget (else stats().budgetSec, else 120)
+ * @param {string=}  o.mode        'timed'|'zen' (else stats().mode, else 'timed')
+ * @param {Function=} o.log
+ */
+export function createCpTrickster(o) {
+  const opts = o || {};
+  const T = CP_TRICKSTER;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : (k, f) => (f == null ? k : f);
+  const tier = clampTier(opts.tier);
+  const reduced = !!opts.reduced;
+  const armed = !!opts.capsOk && !!opts.timers && typeof opts.timers.after === 'function'
+    && typeof document !== 'undefined';
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const chipEl = typeof opts.chipEl === 'function' ? opts.chipEl : () => null;
+  const chipText = typeof opts.chipText === 'function' ? opts.chipText : () => null;
+  const tilesOf = typeof opts.tiles === 'function' ? opts.tiles : () => [];
+  const announce = typeof opts.announce === 'function' ? opts.announce : null;
+  const eng = opts.engine || null;
+  function previewEl() {
+    try { return typeof opts.preview === 'function' ? opts.preview() : opts.preview || null; } catch (e) { return null; }
+  }
+  function modeNow() {
+    if (opts.mode === 'zen' || opts.mode === 'timed') return opts.mode;
+    try { const s = stats(); if (s && (s.mode === 'zen' || s.mode === 'timed')) return s.mode; } catch (e) { /* ignore */ }
+    // index.js's stats() carries no mode: read the stage's data-mode through the lie layer's ancestry
+    try {
+      let el = previewEl();
+      for (let i = 0; el && i < 6; i++) {
+        const m = typeof el.getAttribute === 'function' ? el.getAttribute('data-mode') : null;
+        if (m === 'zen' || m === 'timed') return m;
+        el = el.parentNode || null;
+      }
+    } catch (e) { /* ignore */ }
+    return 'timed';
+  }
+
+  /* timers: the game's registry + a local set. */
+  const live = new Set();
+  const chains = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function every(ms, fn) {
+    if (!armed) return 0;
+    if (typeof opts.timers.every === 'function') {
+      const id = opts.timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => { if (!handle.on || destroyed) return; try { fn(); } catch (e) { /* ignore */ } handle.id = after(ms, tick); };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+
+  const seedBase = String(opts.seed || 'cp') + '|cp-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  let destroyed = false;
+  let stopped = false;
+  let started = false;
+  const fired = { preview: 0, solved: 0, flicker: 0, clock: 0, melt: 0, ghost: 0 };
+  let deals = [];
+  let cycle = 0;
+  let solvedPlayed = false;
+  let washIsOn = false;
+  const lexiconUsed = new Set();
+  function say_t(key, fallback) { lexiconUsed.add(key); return t(key, fallback); }
+
+  /* ------------------------------------------------------------- the deal */
+  function budgetMs() {
+    let b = Number(opts.budgetSec) || 0;
+    if (!b) { try { const s = stats(); b = Number(s && s.budgetSec) || 0; } catch (e) { b = 0; } }
+    return Math.max(40000, (b || 120) * 1000);
+  }
+  function buildDeals(cyc) {
+    const zen = modeNow() === 'zen';
+    let n = T.DEALS[tier] || 2;
+    if (zen) n = Math.max(1, Math.ceil(n * T.ZEN_BUDGET_MUL));
+    const span = zen ? T.BUDGET_MS : budgetMs();
+    const usable = Math.max(20000, span - T.FIRST_DEAL_MS - T.TAIL_MS);
+    const base = cyc * T.BUDGET_MS;
+    const times = [];
+    for (let i = 0; i < n; i++) times.push(T.FIRST_DEAL_MS + roll('when') * usable);
+    times.sort((a, b) => a - b);
+    for (let i = 1; i < times.length; i++) {
+      if (times[i] - times[i - 1] < T.MIN_GAP_MS) times[i] = times[i - 1] + T.MIN_GAP_MS;
+    }
+    const clockSlot = (!zen && cyc === 0 && tier >= T.CLOCK_FROM_TIER && n > 1)
+      ? Math.floor(roll('clock-slot') * Math.ceil(n / 2)) : -1;
+    const w = T.WEIGHTS[tier] || T.WEIGHTS[1];
+    const out = times.map((at, i) => {
+      let card;
+      if (i === clockSlot) card = 'clock';
+      else card = roll('card') < w.preview ? 'preview' : 'flicker';
+      return { at: Math.round(base + at), card };
+    });
+    // tier 4: the LAST preview of the first cycle is the fake-solved board
+    if (tier >= T.SOLVED_FROM_TIER && cyc === 0) {
+      for (let i = out.length - 1; i >= 0; i--) { if (out[i].card === 'preview') { out[i].card = 'solved'; break; } }
+    }
+    return out;
+  }
+  function scheduleDeals(list) {
+    const base = cycle * T.BUDGET_MS;
+    for (const deal of list) after(Math.max(0, deal.at - base), () => attempt(deal, 0));
+  }
+  function attempt(deal, tries) {
+    if (destroyed || stopped) return;
+    if (deal.card === 'preview') { armPreview('wrong'); return; }
+    if (deal.card === 'solved') { armPreview('solved'); return; }
+    if (isHalted() || !stats()) {
+      if (tries < T.RETRY_MAX) after(T.RETRY_MS, () => attempt(deal, tries + 1));
+      return;
+    }
+    if (deal.card === 'flicker') dealFlicker();
+    else if (deal.card === 'clock') armClock();
+  }
+
+  /* --------------------------------------------------------- the tiles */
+  function liveTiles() {
+    let list = [];
+    try { list = Array.from(tilesOf() || []); } catch (e) { list = []; }
+    return list.filter((n) => n && n.style);
+  }
+  function gridN(list) {
+    try { const s = stats(); if (s && Number(s.n) >= 3) return Math.round(Number(s.n)); } catch (e) { /* ignore */ }
+    const k = (list || liveTiles()).length + 1;
+    const n = Math.round(Math.sqrt(k));
+    return n >= 3 ? n : 3;
+  }
+  function model() {
+    const list = liveTiles();
+    const n = gridN(list);
+    const tiles = [];
+    const occ = new Set();
+    for (const el of list) {
+      const g = gridOf(el);
+      const home = homeOf(el, n);
+      if (!g) continue;
+      occ.add(g.r * n + g.c);
+      tiles.push({ el, id: idOf(el), r: g.r, c: g.c, home, locked: hasClass(el, 'is-locked') });
+    }
+    let blank = null;
+    for (let p = 0; p < n * n; p++) { if (!occ.has(p)) { blank = { r: Math.floor(p / n), c: p % n }; break; } }
+    return { n, tiles, blank };
+  }
+  function lockedFrac(m) {
+    try { const s = stats(); if (s && Number.isFinite(Number(s.lockedFrac))) return Number(s.lockedFrac); } catch (e) { /* ignore */ }
+    const mm = m || model();
+    const total = Math.max(1, mm.n * mm.n - 1);
+    let k = 0;
+    for (const tl of mm.tiles) if (tl.locked) k += 1;
+    return k / total;
+  }
+
+  /* -------------------------------------------------- the false preview */
+  let previewArmed = null;          // 'wrong' | 'solved' | null
+  let previewFold = 0;
+  let previewOn = false;
+  let previewTimer = 0;
+  let previewClear = 0;
+  let ghosts = [];
+  let previewVariant = null;
+
+  function armPreview(kind) {
+    if (previewArmed === 'solved') return;         // the big one keeps its slot
+    previewArmed = kind;
+    if (previewFold) cancel(previewFold);
+    const fold = kind === 'solved' ? T.SOLVED_FOLD_MS : T.PREVIEW_FOLD_MS;
+    previewFold = after(fold, () => {
+      previewFold = 0;
+      // nobody moved, no wash came: the lie plays on its own
+      if (previewArmed && !isHalted()) playPreview();
+    });
+    say('trickster: preview armed (' + kind + ')');
+  }
+  function cloneFace(tile) {
+    let face = null;
+    try { face = tile.querySelector ? tile.querySelector('.g-cp-face') : null; } catch (e) { face = null; }
+    if (!face || typeof face.cloneNode !== 'function') return null;
+    let copy = null;
+    try { copy = face.cloneNode(true); } catch (e) { return null; }
+    // a VIDEO face never gets a second decoder (the 30Hz trap): the ghost is a plate
+    try {
+      const vids = copy.querySelectorAll ? copy.querySelectorAll('video') : [];
+      for (const v of Array.from(vids || [])) { try { v.remove(); } catch (e) { /* ignore */ } }
+    } catch (e) { /* ignore */ }
+    return copy;
+  }
+  function clearGhosts() {
+    for (const g of ghosts) { try { g.remove(); } catch (e) { /* ignore */ } }
+    ghosts = [];
+    const pv = previewEl();
+    if (pv && pv.classList) {
+      pv.classList.remove('is-on', 'is-plain', 'g-cp-pv-solved', 'g-cp-pv-rgb', 'g-cp-pv-vhs', 'g-cp-pv-mosh');
+    }
+    previewOn = false;
+  }
+  function playPreview() {
+    const kind = previewArmed;
+    previewArmed = null;
+    if (previewFold) { cancel(previewFold); previewFold = 0; }
+    if (!kind || destroyed || stopped || previewOn) return false;
+    const pv = previewEl();
+    if (!pv || !pv.appendChild) return false;
+    const m = model();
+    if (!m.tiles.length) return false;
+    let solved = kind === 'solved' && !solvedPlayed && lockedFrac(m) >= T.SOLVED_MIN_FRAC;
+    if (kind === 'solved' && !solved && solvedPlayed) return false;
+    // stage the ghosts: {tile, r, c}
+    const plan = [];
+    if (solved) {
+      for (const tl of m.tiles) if (!tl.locked && tl.home) plan.push({ tl, r: tl.home.r, c: tl.home.c });
+      if (!plan.length) return false;
+    } else {
+      const loose = m.tiles.filter((tl) => !tl.locked);
+      const pool = loose.length >= 2 ? loose : m.tiles.slice();
+      if (pool.length < 2) return false;
+      const k = Math.min(pool.length, T.PREVIEW_TILES[tier] || 2);
+      // seeded pick of k tiles, then a cyclic shift of their slots (a derangement)
+      const picked = [];
+      const bag = pool.slice();
+      for (let i = 0; i < k; i++) {
+        const ix = Math.min(bag.length - 1, Math.floor(roll('pv-pick') * bag.length));
+        picked.push(bag.splice(ix, 1)[0]);
+      }
+      for (let i = 0; i < picked.length; i++) {
+        const dst = picked[(i + 1) % picked.length];
+        plan.push({ tl: picked[i], r: dst.r, c: dst.c });
+      }
+      // sometimes the blank is the lie: one more ghost sits in the gap
+      if (m.blank && roll('pv-blank') < 0.5) {
+        const extra = loose.find((tl) => picked.indexOf(tl) < 0) || null;
+        if (extra) plan.push({ tl: extra, r: m.blank.r, c: m.blank.c });
+      }
+    }
+    clearGhosts();
+    let staged = 0;
+    for (const p of plan) {
+      let g = null;
+      try { g = document.createElement('div'); g.className = 'g-cp-pv'; } catch (e) { g = null; }
+      if (!g || !g.style) continue;
+      g.style.setProperty('--pr', String(p.r));
+      g.style.setProperty('--pc', String(p.c));
+      // carry the tile's own viewport vars so the ghost clips the same square
+      try {
+        const hr = p.tl.el.style.getPropertyValue('--hr'); const hc = p.tl.el.style.getPropertyValue('--hc');
+        if (hr) g.style.setProperty('--hr', hr);
+        if (hc) g.style.setProperty('--hc', hc);
+      } catch (e) { /* ignore */ }
+      const face = cloneFace(p.tl.el);
+      if (face) g.appendChild(face);
+      pv.appendChild(g);
+      ghosts.push(g);
+      staged += 1;
+    }
+    if (!staged) return false;
+    const variant = T.VARIANTS[Math.min(T.VARIANTS.length - 1, Math.floor(roll('pv-variant') * T.VARIANTS.length))];
+    previewVariant = variant;
+    const ms = solved ? T.SOLVED_MS : (T.PREVIEW_MS[tier] || 480);
+    if (pv.style) { pv.style.setProperty('--cp-pv-ms', ms + 'ms'); pv.style.setProperty('--cp-pv-a', String(T.PREVIEW_ALPHA)); }
+    if (pv.classList) {
+      if (reduced) pv.classList.add('is-plain'); else pv.classList.add('g-cp-pv-' + variant);
+      if (solved) pv.classList.add('g-cp-pv-solved');
+      if (typeof pv.offsetWidth === 'number') void pv.offsetWidth;   // the ghosts start at 0 and fade in
+      pv.classList.add('is-on');
+    }
+    previewOn = true;
+    // the engine's own glitch on the LIE LAYER: its sfx + dressing, never a tile
+    if (eng && typeof eng.fire === 'function' && !reduced) {
+      try {
+        eng.fire('glitch_swap', {
+          targets: pv, variant: T.ENGINE_VARIANT[variant] || 'rgbsplit', seconds: Math.min(1.2, ms / 1000),
+          strength: solved ? 0.7 : 0.45, onSwap() {}, sfx: true,
+        });
+      } catch (e) { /* a refused fire is not an error */ }
+    }
+    if (solved) { fired.solved += 1; solvedPlayed = true; } else fired.preview += 1;
+    if (previewTimer) cancel(previewTimer);
+    previewTimer = after(ms, () => {
+      previewTimer = 0;
+      if (pv.classList) pv.classList.remove('is-on');
+      if (previewClear) cancel(previewClear);
+      previewClear = after(T.PREVIEW_FADE_MS, () => { previewClear = 0; clearGhosts(); });
+    });
+    if (announce && !isHalted()) {
+      if (solved) { try { announce(say_t('cp_trick_seen', 'That is not where that piece is.'), 1800); } catch (e) { /* ignore */ } }
+      else if (roll('taunt') < T.TAUNT_CHANCE) { try { announce(say_t('cp_trick_preview', 'Did it move?'), 1400); } catch (e) { /* ignore */ } }
+    }
+    say('trickster: false preview (' + (solved ? 'FAKE SOLVED, ' : '') + staged + ' ghosts, ' + variant + ')');
+    return true;
+  }
+
+  /* -------------------------------------------------------- stat flicker */
+  function dealFlicker() {
+    const s = stats();
+    if (!s) return;
+    const chip = chipEl('moves');
+    if (!chip || chip.textContent == null) return;
+    const truth = chipText('moves');
+    const n = Number(s.moves) || 0;
+    const delta = (roll('flick-sign') < 0.5 ? -1 : 1) * (1 + Math.floor(roll('flick-drop') * 4));
+    const fake = Math.max(0, n + delta);
+    const lie = (typeof truth === 'string' && /\d/.test(truth)) ? truth.replace(/\d[\d,\s]*/, String(fake)) : String(fake);
+    if (!lie || lie === chip.textContent) return;
+    try { chip.textContent = lie; } catch (e) { return; }
+    if (!reduced && chip.classList) chip.classList.add('g-cp-statlie');
+    fired.flicker += 1;
+    after(T.FLICKER_MS, () => {
+      try { if (chip.classList) chip.classList.remove('g-cp-statlie'); } catch (e) { /* ignore */ }
+      const now = chipText('moves');
+      if (now != null) { try { chip.textContent = now; } catch (e) { /* ignore */ } }
+    });
+    say('trickster: stat flicker (moves ' + n + ' -> ' + fake + ')');
+  }
+
+  /* ------------------------------------------------------- crooked clock */
+  let clockArmed = false;
+  let clockObs = null;
+  let clockPoll = 0;
+  let lastLie = null;
+  let budgetSeen = Number(opts.budgetSec) || 0;
+  let clockLies = 0;
+
+  function formatLike(sec, truth) {
+    const s = Math.max(0, Math.round(sec));
+    if (typeof truth === 'string' && /^\d+s$/.test(truth.trim())) return s + 's';
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    const padM = typeof truth === 'string' && /^\d{2}:\d{2}$/.test(truth.trim());
+    return (padM ? String(m).padStart(2, '0') : String(m)) + ':' + String(r).padStart(2, '0');
+  }
+  function bendFace() {
+    if (!clockArmed || destroyed || stopped) return;
+    const chip = chipEl('clock');
+    const s = stats();
+    if (!chip || !s || !Number.isFinite(Number(s.secLeft))) return;
+    const secLeft = Number(s.secLeft);
+    if (secLeft > budgetSeen) budgetSeen = secLeft;
+    const shown = bendClock(secLeft, budgetSeen, T.CLOCK_BEND, T.CLOCK_HONEST_SEC);
+    if (shown === Math.round(secLeft)) { lastLie = null; return; }
+    const truth = chipText('clock');
+    const text = formatLike(shown, truth);
+    if (chip.textContent === text) return;
+    lastLie = text;
+    try { chip.textContent = text; clockLies += 1; } catch (e) { /* ignore */ }
+  }
+  function armClock() {
+    if (clockArmed || tier < T.CLOCK_FROM_TIER || modeNow() === 'zen') return;
+    const chip = chipEl('clock');
+    if (!chip) return;
+    clockArmed = true;
+    fired.clock += 1;
+    let hooked = false;
+    try {
+      if (typeof MutationObserver === 'function' && typeof chip.nodeType === 'number') {
+        clockObs = new MutationObserver(() => { if (chip.textContent === lastLie) return; bendFace(); });
+        clockObs.observe(chip, { childList: true, characterData: true, subtree: true });
+        hooked = true;
+      }
+    } catch (e) { clockObs = null; }
+    if (!hooked) clockPoll = every(T.CLOCK_POLL_MS, bendFace);
+    bendFace();
+    say('trickster: the clock goes crooked (' + (hooked ? 'observer' : 'poll') + ')');
+  }
+  function disarmClock(restore) {
+    if (clockObs) { try { clockObs.disconnect(); } catch (e) { /* ignore */ } clockObs = null; }
+    if (clockPoll) { stopEvery(clockPoll); clockPoll = 0; }
+    if (clockArmed && restore) {
+      const chip = chipEl('clock');
+      const truth = chipText('clock');
+      if (chip && truth != null) { try { chip.textContent = truth; } catch (e) { /* ignore */ } }
+    }
+    clockArmed = false;
+    lastLie = null;
+  }
+
+  /* ------------------------------------------------------------- the melt */
+  let melted = null;
+  let meltAnnounced = false;
+  function dealMelt() {
+    if (melted || tier < T.MELT_FROM_TIER) return;
+    const m = model();
+    const loose = m.tiles.filter((tl) => !tl.locked);
+    if (!loose.length) return;
+    const pick = loose[Math.min(loose.length - 1, Math.floor(roll('melt-pick') * loose.length))];
+    if (!pick || !pick.el.classList) return;
+    try { pick.el.classList.add('g-cp-melt'); } catch (e) { return; }
+    melted = pick.el;
+    fired.melt += 1;
+    if (announce && !meltAnnounced && !reduced) {
+      meltAnnounced = true;
+      try { announce(say_t('cp_trick_melt', 'One of them is running.'), 2000); } catch (e) { /* ignore */ }
+    }
+    say('trickster: melt (tile ' + pick.id + ')');
+  }
+  function unmelt() {
+    if (!melted) return;
+    try { melted.classList.remove('g-cp-melt'); } catch (e) { /* ignore */ }
+    melted = null;
+  }
+
+  /* ------------------------------------------------------------ the ghost */
+  let ghost = null;
+  let lastWorst = null;
+  function dealGhost() {
+    if (ghost || reduced || tier < T.GHOST_FROM_TIER) return;
+    const pv = previewEl();
+    if (!pv || !pv.appendChild) return;
+    const m = model();
+    const worst = worstSlide(m.tiles, m.blank, roll('ghost-pick'));
+    if (!worst) return;
+    let node = null;
+    try { node = document.createElement('i'); node.className = 'g-cp-ghost'; } catch (e) { return; }
+    if (!node.style) return;
+    node.style.setProperty('--gr0', String(worst.from.r));
+    node.style.setProperty('--gc0', String(worst.from.c));
+    node.style.setProperty('--gr1', String(worst.to.r));
+    node.style.setProperty('--gc1', String(worst.to.c));
+    const dx = worst.to.c - worst.from.c; const dy = worst.to.r - worst.from.r;
+    node.style.setProperty('--ga', String(dx > 0 ? 0 : dx < 0 ? 180 : dy > 0 ? 90 : 270));
+    pv.appendChild(node);
+    ghost = node;
+    lastWorst = worst;
+    fired.ghost += 1;
+    say('trickster: ghost cursor (tile ' + worst.id + ', score ' + worst.score + ')');
+  }
+  function unghost() {
+    if (!ghost) return;
+    try { ghost.remove(); } catch (e) { /* ignore */ }
+    ghost = null;
+  }
+
+  /* ------------------------------------------------------------------ api */
+  return {
+    /** Deal the class. Call once, when play begins. */
+    start() {
+      if (!armed || destroyed) { say('trickster: disarmed'); return; }
+      if (started) return;
+      started = true;
+      ensureStyle();
+      deals = buildDeals(0);
+      scheduleDeals(deals);
+      try { const s = stats(); if (s && Number(s.secLeft) > budgetSeen) budgetSeen = Number(s.secLeft); } catch (e) { /* ignore */ }
+      // zen cycles the plan (the class has no bell); timed deals once
+      if (modeNow() === 'zen') {
+        const recycle = () => {
+          if (destroyed || stopped) return;
+          cycle += 1;
+          const more = buildDeals(cycle);
+          deals = deals.concat(more);
+          scheduleDeals(more);
+          after(T.BUDGET_MS, recycle);
+        };
+        after(T.BUDGET_MS, recycle);
+      }
+      say('trickster: dealt ' + deals.length + ' cards ('
+        + deals.map((d) => d.card + '@' + Math.round(d.at / 1000) + 's').join(', ') + ')');
+    },
+
+    /**
+     * index.js calls after every legal slide, after it has written --r/--c and
+     * the state classes. Stall theatre ends; an armed preview plays (the lie
+     * rides the move).
+     */
+    afterSlide() {
+      if (!armed || destroyed) return;
+      unmelt();
+      unghost();
+      if (!stopped && previewArmed) playPreview();
+    },
+
+    /** index.js calls every ~500ms with ms since the last move; 0 resets. */
+    stalled(ms) {
+      if (!armed || destroyed || stopped) return;
+      const n = Number(ms) || 0;
+      if (n <= 0) { unmelt(); unghost(); return; }
+      if (isHalted()) return;
+      if (n >= T.MELT_STALL_MS) dealMelt();
+      if (n >= T.GHOST_STALL_MS) dealGhost();
+    },
+
+    /** A wash is landing (on) or lifting (off). An armed preview hides under it. */
+    washOn(on) {
+      if (!armed || destroyed) return;
+      washIsOn = !!on;
+      if (washIsOn && !stopped && previewArmed && !isHalted()) playPreview();
+    },
+
+    /** The class is over: no card may fire again, every lie comes off. */
+    stop() {
+      stopped = true;
+      previewArmed = null;
+      if (previewFold) { cancel(previewFold); previewFold = 0; }
+      if (previewTimer) { cancel(previewTimer); previewTimer = 0; }
+      if (previewClear) { cancel(previewClear); previewClear = 0; }
+      clearGhosts();
+      unmelt();
+      unghost();
+      disarmClock(true);
+    },
+
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      for (const h of Array.from(chains)) stopEvery(h);
+      clearGhosts();
+      unmelt();
+      unghost();
+      disarmClock(true);
+    },
+
+    /** Diagnostics for the harness; not part of the module contract. */
+    diagnostics() {
+      return {
+        armed, tier, started, deals: deals.slice(), fired: Object.assign({}, fired),
+        previewArmed, previewOn, previewVariant, ghostsLive: ghosts.length, solvedPlayed,
+        melted: !!melted, ghost: !!ghost, lastWorst, washOn: washIsOn,
+        clock: { armed: clockArmed, lies: clockLies, budget: budgetSeen, observer: !!clockObs },
+        lexicon: Array.from(lexiconUsed), timers: live.size,
+      };
+    },
+  };
+}
+
+export default createCpTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
@@ -115,8 +115,6 @@ export const CP_TRICKSTER = Object.freeze({
 const STYLE_ID = 'g-cp-trickster-style';
 const STYLE_TEXT = `
 /* ---- THE LIE LAYER (trickster) --------------------------------------------
-@property --pr{syntax:'<number>';inherits:false;initial-value:0}
-@property --pc{syntax:'<number>';inherits:false;initial-value:0}
    Over the board, never a pointer. Ghost tiles (.g-cp-pv) carry --pr/--pc and
    a cloned face; the layer's variant class is the engine's glitch look redrawn
    here (rgbsplit / vhsroll / datamosh), .is-plain is the reduced-motion

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
@@ -781,6 +781,135 @@ export default {
       catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
     }
 
+    /* ---------------------- class rules sheet ---------------------------- */
+    /**
+     * THE SHEET (Deck VI, Law IV - the rules are DRAWN, the words only caption).
+     * Three vignettes in this class's own language: the letterboard taking a
+     * typed word, the three marks a committed row wears, and the six-row budget
+     * with the rung strip that climbs beside it. Every figure is CSS - cells,
+     * glyphs and pips - so it costs no media and reads at any size.
+     */
+    let howtoEl = null;
+
+    /** Tiers this player has already had the rules sheet for (persisted). */
+    function howtoSeenTiers() {
+      const m = readMeta();
+      return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+    }
+
+    function hideHowto() {
+      if (howtoEl) { try { howtoEl.remove(); } catch (e) { /* noop */ } }
+      howtoEl = null;
+    }
+
+    function buildHowto(onGo) {
+      const sheet = el('div', 'g-dt-howto');
+      sheet.appendChild(el('h2', 'g-dt-hw-title', t('dt_howto_title', 'Class rules')));
+
+      const row = (build, caption) => {
+        const r = el('div', 'g-dt-hw-row');
+        const fig = el('span', 'g-dt-hw-fig');
+        fig.setAttribute('aria-hidden', 'true');
+        try { build(fig); } catch (e) { /* a caption alone still teaches */ }
+        r.appendChild(fig);
+        r.appendChild(el('p', 'g-dt-hw-cap', caption));
+        sheet.appendChild(r);
+        return r;
+      };
+
+      /* 1 - THE ROW. Letters land in the board one cell at a time and the last
+         cell holds the caret; the commit key sits beside it, pressing itself. */
+      row((fig) => {
+        const line = el('span', 'g-dt-hw-line');
+        const glyphs = ['G', 'O', 'O', 'D'];
+        for (let i = 0; i < glyphs.length; i++) {
+          const c = el('span', 'g-dt-hw-cell typed', glyphs[i]);
+          c.style.setProperty('--dt-hw-i', String(i));
+          line.appendChild(c);
+        }
+        const caret = el('span', 'g-dt-hw-cell caret');
+        caret.style.setProperty('--dt-hw-i', String(glyphs.length));
+        line.appendChild(caret);
+        fig.appendChild(line);
+        fig.appendChild(el('span', 'g-dt-hw-key' + (coarse ? ' wide' : ''),
+          coarse ? t('dt_commit', 'COMMIT ROW') : t('dt_enter', 'ENTER')));
+      }, t('dt_howto_type', 'Type a word into the row, then Enter. One answer a day, the same for everyone.'));
+
+      /* 2 - THE MARKS. The three faces a committed cell can wear, in the order
+         the caption names them. Same tokens as the board, same glyph badges. */
+      row((fig) => {
+        const line = el('span', 'g-dt-hw-line');
+        const marks = ['hit', 'near', 'miss'];
+        const glyphs = ['G', 'O', 'O'];
+        for (let i = 0; i < marks.length; i++) {
+          const c = el('span', 'g-dt-hw-cell flip ' + marks[i], glyphs[i]);
+          c.style.setProperty('--dt-hw-i', String(i));
+          line.appendChild(c);
+        }
+        fig.appendChild(line);
+      }, t('dt_howto_marks', 'Star: right letter, right place. Half: right letter, elsewhere. Cross: not in it.'));
+
+      /* 3 - THE BUDGET. Six slabs, two already spent, and the rung strip that
+         climbs one notch with each of them. */
+      row((fig) => {
+        const stack = el('span', 'g-dt-hw-stack');
+        for (let i = 0; i < ROWS; i++) {
+          const slab = el('span', 'g-dt-hw-slab' + (i < 2 ? ' spent' : i === 2 ? ' next' : ''));
+          slab.style.setProperty('--dt-hw-i', String(i));
+          stack.appendChild(slab);
+        }
+        fig.appendChild(stack);
+        const rungs = el('span', 'g-dt-hw-rungs');
+        for (let i = 0; i < 5; i++) {
+          const pip = el('i', i < 2 ? 'on' : null);
+          pip.style.setProperty('--dt-hw-i', String(i));
+          rungs.appendChild(pip);
+        }
+        fig.appendChild(rungs);
+      }, t('dt_howto_rows', 'Six rows is the whole budget. Every wrong row turns the room up one notch.'));
+
+      const go = el('button', 'g-dt-hw-go', t('dt_howto_go', 'Start homeroom'));
+      go.type = 'button';
+      go.addEventListener('click', () => { try { onGo(); } catch (e) { say('howto go: ' + ((e && e.message) || e)); } });
+      sheet.appendChild(go);
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+      return sheet;
+    }
+
+    /**
+     * Policy is the shell's "Skip class tutorials" contract: by default the
+     * sheet shows EVERY class; with the skip on, homeroom still explains itself
+     * ONCE per grade tier (the tier is what changes the room). Dismissal is the
+     * sheet's own button and nothing else - every letter key is already a verb
+     * here, so a keyboard shortcut would type into the board it is covering.
+     */
+    function howto(onDone) {
+      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      if (!wrap) { onDone(); return; }
+      let done = false;
+      let sheet = null;
+      try {
+        sheet = buildHowto(() => {
+          if (done || finished) return;
+          done = true;
+          try {
+            const seen = howtoSeenTiers();
+            if (seen.indexOf(tier) < 0) {
+              seen.push(tier);
+              if (ctx.store && ctx.store.mergeGameMeta) {
+                ctx.store.mergeGameMeta('daily_trigger', { howtoTiers: seen });
+              }
+            }
+          } catch (e) { /* best effort - the sheet just shows again next time */ }
+          hideHowto();
+          onDone();
+        });
+      } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); sheet = null; }
+      if (!sheet) { onDone(); return; }
+      howtoEl = sheet;
+      wrap.appendChild(sheet);
+    }
+
     /* ---------------------- lifecycle ------------------------------------ */
     return {
       start(classSpec) {
@@ -837,8 +966,6 @@ export default {
             onGlitchSwap: swapGlyphs,
           },
         });
-        ladder.open();
-
         /* The House decks (House Rules floor map: homeroom's three cards +
          * the lighting rig). Both disarm themselves when bgIntensity is
          * capped to 0; both replay identically on a retake. */
@@ -869,10 +996,6 @@ export default {
           t,
           log: say,
         });
-        casino.start();
-        trickster.start();
-        casino.setHeat(ladder.heat);
-
         consumeStudyHint();
         paintCurrentRow();
         paintKeys();
@@ -883,27 +1006,41 @@ export default {
           msg(t('revision_day_hint', 'Revision: you have met this one before.'));
         }
 
-        startMs = Date.now();
-        const clock = () => {
+        /* THE SHEET FIRST (Deck VI). Nothing that measures the player runs
+           until GO: the ladder is still shut, the decks are dark, no key is
+           bound and startMs has not been taken, so a class read at leisure
+           grades exactly like one that skipped the sheet. */
+        const beginClass = () => {
           if (finished) return;
-          if (!paused && !suspended) {
-            elapsedSec = Math.max(0, Math.round((Date.now() - startMs) / 1000));
-            if (clockChip) {
-              const budget = Number(spec.timeBudgetSec) || 90;
-              // CROOKED CLOCK (House Rules): the FACE may bend from rung 3;
-              // elapsedSec itself - the composite input, the warn state, the
-              // log line - is exact and never routes through the trickster.
-              const face = trickster ? trickster.clockFace(elapsedSec, budget) : elapsedSec;
-              clockChip.textContent = face + 's';
-              if (elapsedSec >= budget) clockChip.className = 'chip num warn';
-            }
-          }
-          later(1000, clock);
-        };
-        later(1000, clock);
+          ladder.open();
+          casino.start();
+          trickster.start();
+          casino.setHeat(ladder.heat);
+          paintHud();                      // the opening rung, now that it exists
 
-        try { if (typeof window !== 'undefined') window.addEventListener('keydown', onKeyDown); }
-        catch (e) { say('keydown bind failed: ' + ((e && e.message) || e)); }
+          startMs = Date.now();
+          const clock = () => {
+            if (finished) return;
+            if (!paused && !suspended) {
+              elapsedSec = Math.max(0, Math.round((Date.now() - startMs) / 1000));
+              if (clockChip) {
+                const budget = Number(spec.timeBudgetSec) || 90;
+                // CROOKED CLOCK (House Rules): the FACE may bend from rung 3;
+                // elapsedSec itself - the composite input, the warn state, the
+                // log line - is exact and never routes through the trickster.
+                const face = trickster ? trickster.clockFace(elapsedSec, budget) : elapsedSec;
+                clockChip.textContent = face + 's';
+                if (elapsedSec >= budget) clockChip.className = 'chip num warn';
+              }
+            }
+            later(1000, clock);
+          };
+          later(1000, clock);
+
+          try { if (typeof window !== 'undefined') window.addEventListener('keydown', onKeyDown); }
+          catch (e) { say('keydown bind failed: ' + ((e && e.message) || e)); }
+        };
+        howto(beginClass);
 
         say('board ' + entry.dateUtc + ' #' + entry.puzzleNumber + ' ' + entry.kind
           + ' letters ' + entry.letters + ' tier ' + tier
@@ -934,6 +1071,7 @@ export default {
 
       destroy() {
         finished = true;
+        hideHowto();
         clearTimers();
         if (ladder) ladder.stopAll();
         try { if (trickster) trickster.destroy(); } catch (e) { /* ignore */ }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/styles.js
@@ -294,6 +294,118 @@ html.arc-reduced .g-dt-mq{opacity:.16}
 .arc-reduced .g-dt-row.solved::after{transform:scaleX(1)}
 .arc-reduced .g-dt-almostline{display:none}
 
+/* ---- THE CLASS RULES SHEET (Deck VI, Law IV: drawn, not told) ------------ */
+/* Three vignettes on a chalk-dusted card over the lesson wall. The sheet takes
+   NO pointer events - the keyboard under it is not bound yet and a stray click
+   must never count as "read" - and the GO button takes its own back. It sits at
+   z 9: above the room (1), the stage zone (4) and the HUD (5), and far below the
+   shell's suspend treatment (35), which must always be able to cover it. */
+.g-dt-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(520px,92vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:20px 22px 18px;border-radius:14px;
+  color:var(--ink,#F2EBDD);
+  background:linear-gradient(180deg,
+    color-mix(in srgb, var(--navy,#1A1A2E), transparent 4%),
+    color-mix(in srgb, var(--ground,#14142B), transparent 2%));
+  border:1px solid var(--line,#3A3A5E);
+  box-shadow:0 28px 74px rgba(0,0,0,.58), 0 0 40px rgba(255,105,180,.10);
+  animation:g-dt-hw-in .34s ease-out 1}
+@keyframes g-dt-hw-in{from{opacity:0;transform:translate(-50%,-46%)}
+  to{opacity:1;transform:translate(-50%,-50%)}}
+.g-dt-hw-title{margin:0 0 8px;text-align:center;font-family:var(--disp,serif);
+  font-size:clamp(15px,2.3vmin,19px);letter-spacing:.22em;text-transform:uppercase;
+  color:var(--pink,#FF69B4);text-shadow:0 0 20px rgba(255,105,180,.45)}
+.g-dt-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-dt-hw-row + .g-dt-hw-row{border-top:1px dashed rgba(58,58,94,.6)}
+.g-dt-hw-fig{flex:0 0 auto;display:flex;align-items:center;gap:10px;pointer-events:none}
+.g-dt-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim,#B9B3CE)}
+
+/* the two mini letterboards: same tokens, same glyph badges as the real cells */
+.g-dt-hw-line{display:flex;gap:4px}
+.g-dt-hw-cell{position:relative;width:26px;height:26px;border-radius:4px;flex:0 0 auto;
+  display:flex;align-items:center;justify-content:center;
+  font-family:var(--disp,serif);font-size:13px;line-height:1;
+  border:2px solid var(--line,#3A3A5E);color:var(--ink-faint,#8A84A8);
+  background:rgba(20,20,43,.5)}
+.g-dt-hw-cell.typed{border-color:var(--lav,#B8A6E8);color:var(--lav,#B8A6E8);
+  opacity:0;animation:g-dt-hw-type 3.4s ease-out infinite;
+  animation-delay:calc(var(--dt-hw-i,0) * .22s)}
+@keyframes g-dt-hw-type{0%{opacity:0;transform:translateY(-4px)}
+  9%,86%{opacity:1;transform:translateY(0)}100%{opacity:0;transform:translateY(0)}}
+.g-dt-hw-cell.caret{border-color:var(--pink,#FF69B4);
+  animation:g-dt-hw-caret 1.1s steps(2) infinite}
+@keyframes g-dt-hw-caret{0%,49%{box-shadow:inset 0 -3px 0 var(--pink,#FF69B4)}
+  50%,100%{box-shadow:none}}
+.g-dt-hw-cell.hit{background:var(--dt-hit,#FF69B4);border-color:var(--dt-hit,#FF69B4);
+  color:var(--ground,#14142B)}
+.g-dt-hw-cell.near{background:var(--dt-near,#B8A6E8);border-color:var(--dt-near,#B8A6E8);
+  color:var(--ground,#14142B)}
+.g-dt-hw-cell.miss{background:var(--dt-miss,#3A3A5E);border-color:var(--dt-miss,#3A3A5E);
+  color:var(--ink-faint,#8A84A8)}
+.g-dt-hw-cell.hit::after,.g-dt-hw-cell.near::after,.g-dt-hw-cell.miss::after{
+  position:absolute;right:2px;bottom:0;font-size:8px;line-height:1;opacity:.85}
+.g-dt-hw-cell.hit::after{content:"\\2605"}
+.g-dt-hw-cell.near::after{content:"\\25D0"}
+.g-dt-hw-cell.miss::after{content:"\\2715";color:var(--ink-faint,#8A84A8)}
+.g-dt-hw-cell.flip{animation:g-dt-hw-flip 3.4s ease-in-out infinite;
+  animation-delay:calc(var(--dt-hw-i,0) * .3s)}
+@keyframes g-dt-hw-flip{0%,6%{transform:rotateX(90deg)}16%,88%{transform:rotateX(0)}
+  100%{transform:rotateX(90deg)}}
+
+/* the keycap that commits the row */
+.g-dt-hw-key{flex:0 0 auto;min-width:52px;text-align:center;padding:7px 10px;border-radius:7px;
+  font-family:var(--mono,monospace);font-size:10px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ink,#F2EBDD);background:linear-gradient(180deg,var(--panel2,#2E2E55),#1A1A32);
+  border:1px solid var(--line,#3A3A5E);border-bottom-width:3px;
+  box-shadow:0 2px 0 rgba(0,0,0,.45);animation:g-dt-hw-press 3.4s ease-in-out infinite}
+.g-dt-hw-key.wide{min-width:74px}
+@keyframes g-dt-hw-press{0%,84%{transform:translateY(0)}
+  90%{transform:translateY(2px);box-shadow:0 0 0 rgba(0,0,0,.45)}100%{transform:translateY(0)}}
+
+/* the budget: six slabs, two spent, and the rung strip climbing beside them */
+.g-dt-hw-stack{display:flex;flex-direction:column;gap:3px}
+.g-dt-hw-slab{display:block;width:46px;height:7px;border-radius:2px;
+  border:1px solid rgba(58,58,94,.9);background:rgba(20,20,43,.55)}
+.g-dt-hw-slab.spent{background:var(--dt-miss,#3A3A5E);border-color:var(--dt-miss,#3A3A5E)}
+.g-dt-hw-slab.next{border-color:var(--pink,#FF69B4);
+  animation:g-dt-hw-nextrow 1.8s ease-in-out infinite}
+@keyframes g-dt-hw-nextrow{0%,100%{box-shadow:0 0 0 rgba(255,105,180,0)}
+  50%{box-shadow:0 0 10px rgba(255,105,180,.55)}}
+.g-dt-hw-rungs{display:flex;flex-direction:column-reverse;gap:3px}
+.g-dt-hw-rungs i{display:block;width:16px;height:6px;border-radius:2px;
+  background:var(--line,#3A3A5E)}
+.g-dt-hw-rungs i.on{background:var(--pink,#FF69B4);box-shadow:0 0 8px rgba(255,105,180,.65);
+  animation:g-dt-hw-climb 3.4s ease-in-out infinite;
+  animation-delay:calc(var(--dt-hw-i,0) * .5s)}
+@keyframes g-dt-hw-climb{0%,20%{opacity:.25}34%,88%{opacity:1}100%{opacity:.25}}
+
+/* the ONE live thing on the sheet, and the only way past it */
+.g-dt-hw-go{align-self:center;margin-top:8px;padding:9px 30px;cursor:pointer;
+  pointer-events:auto;border-radius:9px;font-family:var(--disp,serif);font-size:13px;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--ground,#14142B);
+  background:linear-gradient(180deg,var(--pink,#FF69B4),var(--pink-deep,#D4488F));
+  border:1px solid var(--pink,#FF69B4);box-shadow:0 0 22px rgba(255,105,180,.4)}
+.g-dt-hw-go:hover{box-shadow:0 0 32px rgba(255,105,180,.6)}
+.g-dt-hw-go:focus-visible{outline:2px solid var(--gold,#F0C24B);outline-offset:2px}
+
+.arc-reduced .g-dt-howto,.arc-reduced .g-dt-hw-cell,.arc-reduced .g-dt-hw-key,
+.arc-reduced .g-dt-hw-slab,.arc-reduced .g-dt-hw-rungs i{animation:none !important}
+.arc-reduced .g-dt-hw-cell.typed{opacity:1}
+@media (prefers-reduced-motion: reduce){
+  .g-dt-howto,.g-dt-hw-cell,.g-dt-hw-key,.g-dt-hw-slab,.g-dt-hw-rungs i{animation:none !important}
+  .g-dt-hw-cell.typed{opacity:1}
+}
+@media (max-width:560px),(pointer:coarse){
+  .g-dt-howto{padding:16px 14px 14px;gap:0}
+  .g-dt-hw-row{gap:11px;padding:9px 0}
+  .g-dt-hw-cap{font-size:11.5px}
+  .g-dt-hw-cell{width:22px;height:22px;font-size:11px}
+}
+@media (max-height:560px){
+  .g-dt-hw-row{padding:7px 2px}
+  .g-dt-hw-title{margin-bottom:4px}
+}
+
 /* ---- coarse pointer / narrow: bigger tiles, full-width commit ----------- */
 @media (max-width:560px),(pointer:coarse){
   .g-dt{--dt-cell:clamp(34px,11vw,52px)}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -1187,6 +1187,130 @@ export default {
         .catch((e) => say('asset claim failed - glyph faces stand: ' + ((e && e.message) || e)));
     }
 
+    /* ---- the class rules sheet (Deck VI, Law IV: drawn, not told) --------- */
+    /**
+     * Three vignettes in this lab's own language: the pair turning face-up and
+     * locking, the settled board trading two slides AFTER its shudder (law 2 +
+     * law 3 of this file, drawn rather than told), and the whole board
+     * re-dealing without losing a pair. Every figure is CSS on the same slide
+     * chrome the board uses, so the sheet costs no media.
+     */
+    let howtoEl = null;
+
+    /** Tiers this player has already had the rules sheet for (persisted). */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta('deja_vu') || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+
+    function hideHowto() {
+      if (howtoEl) { try { howtoEl.remove(); } catch (e) { /* noop */ } }
+      howtoEl = null;
+    }
+
+    function buildHowto(onGo) {
+      const sheet = el('div', 'g-dv-howto');
+      sheet.appendChild(el('h2', 'g-dv-hw-title', t('dv_howto_title', 'Class rules')));
+
+      const row = (build, caption) => {
+        const r = el('div', 'g-dv-hw-row');
+        const fig = el('span', 'g-dv-hw-fig');
+        fig.setAttribute('aria-hidden', 'true');
+        try { build(fig); } catch (e) { /* a caption alone still teaches */ }
+        r.appendChild(fig);
+        r.appendChild(el('p', 'g-dv-hw-cap', caption));
+        sheet.appendChild(r);
+        return r;
+      };
+
+      const slide = (cls, glyph) => {
+        const card = el('span', 'g-dv-hw-card' + (cls ? ' ' + cls : ''));
+        card.appendChild(el('span', 'g-dv-hw-back'));
+        card.appendChild(el('span', 'g-dv-hw-face', glyph == null ? '' : glyph));
+        return card;
+      };
+
+      /* 1 - THE PAIR. Two slides turn over, match, and stay lit. */
+      row((fig) => {
+        const line = el('span', 'g-dv-hw-line');
+        line.appendChild(slide('turn a', GLYPHS[0]));
+        line.appendChild(slide('turn b', GLYPHS[0]));
+        fig.appendChild(line);
+        fig.appendChild(el('span', 'g-dv-hw-lock'));
+      }, t('dv_howto_flip', 'Turn two slides. A matching pair stays lit. Anything else turns back over.'));
+
+      /* 2 - THE SWAP. It shudders BEFORE it moves, and only while the board is
+         settled - the tell always precedes (law 2). */
+      row((fig) => {
+        const line = el('span', 'g-dv-hw-line');
+        line.appendChild(slide('down'));
+        line.appendChild(slide('down tell left'));
+        line.appendChild(slide('down tell right'));
+        line.appendChild(slide('down'));
+        fig.appendChild(line);
+      }, t('dv_howto_swap', 'The board only moves while nothing is face up, and it always shudders first.'));
+
+      /* 3 - THE RE-DEAL. The whole board goes down and comes back; the pairs
+         are the same pairs, only the seats changed. */
+      row((fig) => {
+        const grid6 = el('span', 'g-dv-hw-grid');
+        for (let i = 0; i < 6; i++) {
+          const c = slide('down redeal');
+          c.style.setProperty('--dv-hw-i', String(i));
+          grid6.appendChild(c);
+        }
+        grid6.appendChild(el('span', 'g-dv-hw-sweep'));
+        fig.appendChild(grid6);
+      }, t('dv_howto_redeal', 'Sometimes the whole board re-deals. Same pairs - only the seats change.'));
+
+      const go = el('button', 'g-dv-hw-go', t('dv_howto_go', 'Deal the board'));
+      go.type = 'button';
+      go.addEventListener('click', () => { try { onGo(); } catch (e) { say('howto go: ' + ((e && e.message) || e)); } });
+      sheet.appendChild(go);
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+      return sheet;
+    }
+
+    /**
+     * Policy is the shell's "Skip class tutorials" contract: by default the
+     * sheet shows EVERY class; with the skip on, the lab still explains itself
+     * ONCE per grade tier. Dismissal is the sheet's own button and nothing
+     * else - Cram Assist is bound to a key the moment the board deals, and a
+     * key shortcut here would spend the player's A-cap on a tutorial.
+     */
+    function howto(onDone) {
+      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(dials ? dials.tier : 1) >= 0) {
+        onDone(); return;
+      }
+      if (!stage) { onDone(); return; }
+      const tierNow = dials ? dials.tier : 1;
+      let done = false;
+      let sheet = null;
+      try {
+        sheet = buildHowto(() => {
+          if (done || dead || ended) return;
+          done = true;
+          try {
+            const seen = howtoSeenTiers();
+            if (seen.indexOf(tierNow) < 0) {
+              seen.push(tierNow);
+              if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+                ctx.store.mergeGameMeta('deja_vu', { howtoTiers: seen });
+              }
+            }
+          } catch (e) { /* best effort - the sheet just shows again next time */ }
+          hideHowto();
+          onDone();
+        });
+      } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); sheet = null; }
+      if (!sheet) { onDone(); return; }
+      howtoEl = sheet;
+      stage.appendChild(sheet);
+    }
+
     /* ==================================================================== *
      * THE MODULE INSTANCE
      * ==================================================================== */
@@ -1248,10 +1372,18 @@ export default {
           log: say,
         });
 
-        wireCram();
         claimAssets();
-        startClock();
-        deal();
+
+        /* THE SHEET FIRST (Deck VI). Nothing that measures the player runs
+           until GO: the clock is not ticking, the board has not dealt and Cram
+           Assist is not bound to a key, so a class read at leisure grades
+           exactly like one that skipped the sheet. */
+        howto(() => {
+          if (dead || ended) return;
+          wireCram();
+          startClock();
+          deal();
+        });
 
         liveClass = instance;
         lastReport = null;
@@ -1287,6 +1419,7 @@ export default {
 
       destroy() {
         dead = true;
+        hideHowto();
         stopClock();
         clearTimers();
         stopAmbience();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/style.js
@@ -346,6 +346,113 @@ html.arc-reduced .g-dv-kb .g-dv-card.locked .g-dv-face:not(.g-dv-glyph){animatio
   .g-dv-cell{min-height:64px}
   .g-dv-rack{display:none}
 }
+
+/* ---- THE CLASS RULES SHEET (Deck VI, Law IV: drawn, not told) ------------ */
+/* A lab card over the bench: three vignettes cut from the same slide chrome the
+   board uses. The sheet takes NO pointer events (the cards under it have not
+   dealt and a stray click must never count as "read"); the GO button takes its
+   own back and is the ONLY dismissal. z 9 keeps it above the lab (0) and the
+   HUD (3) and far below the shell's suspend treatment (35), which must always
+   be able to cover it. */
+.g-dv-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(520px,92vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:20px 22px 18px;border-radius:14px;
+  color:var(--ink,#F2EBDD);
+  background:linear-gradient(180deg,
+    color-mix(in srgb, var(--navy,#1A1A2E), transparent 4%),
+    color-mix(in srgb, var(--ground,#14142B), transparent 2%));
+  border:1px solid var(--line,#3A3A5E);
+  box-shadow:0 28px 74px rgba(0,0,0,.58), 0 0 40px rgba(184,166,232,.12);
+  animation:g-dv-hw-in .34s ease-out 1}
+@keyframes g-dv-hw-in{from{opacity:0;transform:translate(-50%,-46%)}
+  to{opacity:1;transform:translate(-50%,-50%)}}
+.g-dv-hw-title{margin:0 0 8px;text-align:center;font-family:var(--disp,serif);
+  font-size:clamp(15px,2.3vmin,19px);letter-spacing:.22em;text-transform:uppercase;
+  color:var(--lav,#B8A6E8);text-shadow:0 0 20px rgba(184,166,232,.45)}
+.g-dv-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-dv-hw-row + .g-dv-hw-row{border-top:1px dashed rgba(58,58,94,.6)}
+.g-dv-hw-fig{flex:0 0 auto;display:flex;align-items:center;gap:9px;pointer-events:none}
+.g-dv-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim,#B9B3CE)}
+
+/* one mini slide: an etched back and a lightbox face, the board's two states */
+.g-dv-hw-line{display:flex;gap:5px;align-items:center;perspective:420px}
+.g-dv-hw-card{position:relative;display:block;width:28px;height:36px;border-radius:4px;
+  flex:0 0 auto;transform-style:preserve-3d}
+.g-dv-hw-back,.g-dv-hw-face{position:absolute;inset:0;border-radius:4px;
+  display:flex;align-items:center;justify-content:center;
+  backface-visibility:hidden;-webkit-backface-visibility:hidden}
+.g-dv-hw-back{border:1px solid rgba(184,166,232,.32);
+  background:linear-gradient(150deg, color-mix(in srgb, var(--panel2,#2E2E55), black 12%),
+    color-mix(in srgb, var(--navy,#1A1A2E), black 8%))}
+.g-dv-hw-face{transform:rotateY(180deg);font-size:14px;color:var(--ground,#14142B);
+  border:1px solid var(--lav,#B8A6E8);
+  background:radial-gradient(90% 90% at 50% 30%, #FFFFFF, var(--lav,#B8A6E8))}
+
+/* 1 - the pair: both turn, both match, both stay lit */
+.g-dv-hw-card.turn{animation:g-dv-hw-turn 3.6s ease-in-out infinite}
+.g-dv-hw-card.turn.b{animation-delay:.4s}
+@keyframes g-dv-hw-turn{0%,10%{transform:rotateY(0)}
+  26%,88%{transform:rotateY(180deg)}100%{transform:rotateY(0)}}
+.g-dv-hw-lock{display:block;width:16px;height:16px;border-radius:50%;flex:0 0 auto;
+  border:2px solid var(--pink,#FF69B4);opacity:0;
+  box-shadow:0 0 12px rgba(255,105,180,.6);
+  animation:g-dv-hw-lock 3.6s ease-out infinite}
+@keyframes g-dv-hw-lock{0%,40%{opacity:0;transform:scale(.5)}
+  50%{opacity:1;transform:scale(1)}88%{opacity:1}100%{opacity:0}}
+
+/* 2 - the swap: the tell (a 600ms shudder) always precedes the move */
+.g-dv-hw-card.tell{animation:g-dv-hw-tell 3.6s ease-in-out infinite}
+.g-dv-hw-card.tell.left{--dv-hw-d:33px}
+.g-dv-hw-card.tell.right{--dv-hw-d:-33px}
+@keyframes g-dv-hw-tell{
+  0%,24%{transform:translateX(0) rotate(0)}
+  28%{transform:translateX(0) rotate(-4deg)}
+  32%{transform:translateX(0) rotate(4deg)}
+  36%{transform:translateX(0) rotate(-3deg)}
+  40%{transform:translateX(0) rotate(0)}
+  62%,92%{transform:translateX(var(--dv-hw-d,0)) rotate(0)}
+  100%{transform:translateX(0) rotate(0)}}
+
+/* 3 - the re-deal: the whole board goes down and comes back, same pairs */
+.g-dv-hw-grid{position:relative;display:grid;grid-template-columns:repeat(3,1fr);perspective:420px;
+  gap:4px;padding:4px;border-radius:6px;overflow:hidden;
+  border:1px solid rgba(58,58,94,.75);background:rgba(20,20,43,.45)}
+.g-dv-hw-grid .g-dv-hw-card{width:22px;height:28px}
+.g-dv-hw-card.redeal{animation:g-dv-hw-redeal 3.6s ease-in-out infinite;
+  animation-delay:calc(var(--dv-hw-i,0) * .07s)}
+@keyframes g-dv-hw-redeal{0%,42%{opacity:1;transform:translateY(0) scale(1)}
+  52%{opacity:0;transform:translateY(7px) scale(.86)}
+  64%{opacity:1;transform:translateY(0) scale(1)}
+  100%{opacity:1;transform:translateY(0) scale(1)}}
+.g-dv-hw-sweep{position:absolute;left:-40%;top:0;bottom:0;width:36%;
+  background:linear-gradient(90deg, transparent, rgba(184,166,232,.4), transparent);
+  animation:g-dv-hw-sweep 3.6s ease-in-out infinite}
+@keyframes g-dv-hw-sweep{0%,40%{left:-40%}58%{left:104%}100%{left:104%}}
+
+/* the ONE live thing on the sheet, and the only way past it */
+.g-dv-hw-go{align-self:center;margin-top:8px;padding:9px 30px;cursor:pointer;
+  pointer-events:auto;border-radius:9px;font-family:var(--disp,serif);font-size:13px;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--ground,#14142B);
+  background:linear-gradient(180deg,var(--lav,#B8A6E8),#7E6BC0);
+  border:1px solid var(--lav,#B8A6E8);box-shadow:0 0 22px rgba(184,166,232,.4)}
+.g-dv-hw-go:hover{box-shadow:0 0 32px rgba(184,166,232,.62)}
+.g-dv-hw-go:focus-visible{outline:2px solid var(--gold,#F0C24B);outline-offset:2px}
+
+html.arc-reduced .g-dv-howto,html.arc-reduced .g-dv-hw-card,
+html.arc-reduced .g-dv-hw-lock,html.arc-reduced .g-dv-hw-sweep{animation:none !important}
+html.arc-reduced .g-dv-hw-card.turn{transform:rotateY(180deg)}
+html.arc-reduced .g-dv-hw-lock{opacity:1}
+@media (prefers-reduced-motion: reduce){
+  .g-dv-howto,.g-dv-hw-card,.g-dv-hw-lock,.g-dv-hw-sweep{animation:none !important}
+  .g-dv-hw-card.turn{transform:rotateY(180deg)}
+  .g-dv-hw-lock{opacity:1}
+}
+@media (max-width:640px),(pointer:coarse){
+  .g-dv-howto{padding:16px 14px 14px}
+  .g-dv-hw-row{gap:11px;padding:9px 0}
+  .g-dv-hw-cap{font-size:11.5px}
+  .g-dv-hw-card{width:23px;height:30px}
+}
 `;
 
 /** Inject once per document. No-op headless (the DOM double has no head). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/casino.js
@@ -1,0 +1,900 @@
+/* ============================================================================
+ * games/echo/casino.js - DECK II of the House Rules for the music room: THE
+ * FLOOR. The pads' tones and the combo ratchet are index.js's (one engine
+ * recipe, six pitches, +1 semitone a link); this file is the LIGHT that rides
+ * the tune, and the ladder of payouts that makes a long echo feel like a win.
+ *
+ *   ROOM IDENTITY   seeded per CLASS seed (Deck I): the six pad hues rotate as
+ *                   a set around the wheel (they never collapse onto each
+ *                   other - the rotation is one number on the stage), ~6% of
+ *                   rooms leave the house arc for a cold night (the rotation
+ *                   lands the pink on teal), the halo's bulb count and size,
+ *                   its chase phase, the spotlight's breath, the media's
+ *                   ken-burns period, and the direction the remix runs. Same
+ *                   seed, same room; a retake walks into the identical show.
+ *   THE HALO        a ring of bulbs hugging the chalk circle (the board is
+ *                   round, so the marquee is a halo, not a box). Crawls lazily
+ *                   at heat 0, chases hungrily as the sequence lengthens,
+ *                   flashes on a payout, turns amber and slow for an ENCORE,
+ *                   gold and frantic for the bell and the ROYAL, sighs out -
+ *                   never cuts - on a dim-out.
+ *   THE FLOOR POOLS six pools of light on the boards, one under each pad,
+ *                   that take the pad's light when it plays (playback) and
+ *                   PAY it back brighter when it is pressed right (payout
+ *                   light, scaled by the link of the streak). The pools decay
+ *                   at the lamp's own rate - they never remember the sequence
+ *                   for the player.
+ *   PAYOUT LIGHT    a correct press: the pool under the pad blooms, the halo
+ *                   flashes by the link, the streak chip punches (transform
+ *                   only; the TEXT is index.js's). A cleared sequence: a sweep
+ *                   of all six pools around the ring, the room tint pulses,
+ *                   an arpeggio pitched by the length.
+ *   THE ALMOST      near-miss staging: a wrong press on the pad NEXT to the
+ *                   right one (ring-adjacent) is staged as a near miss - the
+ *                   pool under the pad you needed hums, the word comes up,
+ *                   the near_miss ceremony rises. A wrong press anywhere else
+ *                   is a muted thud and a cold flash, never silence.
+ *   THE JACKPOT LADDER   minor / major / ROYAL on sequence milestones. Minor: a
+ *                   cleared sequence may roll one (seeded, chance rises with
+ *                   heat) - a flash and a chime. Major: every even length from
+ *                   six, deterministic - THE REMIX: the player's own sequence
+ *                   (recorded from the playback this deck was shown) replays
+ *                   as a light show at double tempo around the ring, forward,
+ *                   as a palindrome or rotated (the seed picks), each step a
+ *                   pool bloom + a bulb sector + a soft blip at the pad's own
+ *                   pitch. ROYAL: once a class, at the tier's royal length -
+ *                   the hall floods gold, the halo goes gold, the remix runs
+ *                   twice, the word comes up. A failed class still gets a dim
+ *                   payout on dim-out: silence is where people stand up.
+ *   ENCORE          the same sequence at half tempo: the room goes warm and
+ *                   slow - amber halo at the calm pace, warm pools, a longer
+ *                   breath - and comes back when the encore ends.
+ *   RESISTED        a decoy let pass: a glint runs the chalk circle once and a
+ *                   tiny tick sounds. The trap you dodged is acknowledged.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects index.js hands it AFTER its
+ *       own accounting; writes nothing about the sequence, the streak, the
+ *       length, accuracy or the grade; the streak chip is moved by transform
+ *       only, its text is never touched. The sequence this deck records from
+ *       padLit is used ONLY for the remix light show after the player has
+ *       already cleared it.
+ *   II  input honest  - every node here is pointer-events:none, lives inside
+ *       the ring UNDER the pads (z 0 vs the pads' z 1) or in the backdrop;
+ *       data-pad / data-state / the pads' own nodes are never written; no
+ *       pad is ever moved, covered, resized or delayed.
+ *   III never still   - the halo crawls at heat 0, the pools ember, the
+ *       spotlight breathes (style.js), the media drifts.
+ *   IV  images > text - three words this deck can show (ec_near_miss,
+ *       ec_jackpot, ec_royal), through the lexicon, for < 700ms.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ec-casino|<tag>'
+ *       (append-only tags; a new tag never shifts an old stream); no
+ *       Math.random anywhere.
+ *   VI  exits sacred  - capsOk false (bgIntensity 0) disarms every light;
+ *       reduced motion keeps a static dim halo and the pools' glow (no chase,
+ *       no sweep, no remix travel, no punch; blooms become fades); the stage's
+ *       .suspended rule freezes the chase; every timer rides the game's
+ *       pause-aware registry AND a local set so destroy() cannot leak one.
+ *   VII lexicon       - ec_near_miss / ec_jackpot / ec_royal only, via opts.t.
+ *
+ * ENGINE vs GAME-LOCAL: cues, the jackpot / near_miss ceremonies and nothing
+ * else go through opts.engine (index.js's null-safe weld: audio ceiling by
+ * tier, clickSafe forced, pitch passthrough). The halo, the pools, the word,
+ * the room pulse and the chip punch are game-local: they sit on the game's
+ * own geometry (the ring), which no engine primitive knows.
+ * NODE BUDGET: halo (1 + bulbs), overlay (1 + 6 pools + glint + word), room
+ * pulse + royal flood in the backdrop. All reused; nothing per event.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+import { pitchFor } from './sequence.js';
+
+export const EC_CASINO = Object.freeze({
+  /* ---- the halo ------------------------------------------------------- */
+  BULBS: Object.freeze([24, 30, 36]),          // seeded pick
+  MQ_T_SLOW: 3.4,                              // chase period (s) at heat 0
+  MQ_T_FAST: 0.9,                              // at heat 1
+  MQ_A_LO: 0.22,                               // presence (opacity) band
+  MQ_A_HI: 0.84,
+  MQ_T_GOLD: 0.48,
+  MQ_A_GOLD: 0.95,
+  MQ_ENCORE_MUL: 1.7,                          // the encore's calm pace
+  MQ_FLASH_MS: 540,
+  MQ_DIP_MS: 900,
+  /* ---- the pools -------------------------------------------------------- */
+  POOL_LIT: 0.62,                              // playback level
+  POOL_PAY: Object.freeze([0.8, 1.0]),         // payout level by link/8
+  POOL_DECAY_MS: 620,                          // the lamp's own rate (style.js)
+  POOL_HUM_MS: 1400,                           // the almost: the needed pool hums
+  SWEEP_STEP_MS: 58,
+  /* ---- payout ----------------------------------------------------------- */
+  FLASH_LINK_STEP: 0.1,                        // halo flash strength per link
+  ROOM_PULSE_MS: 680,
+  ROOM_PULSE_A: Object.freeze([0.12, 0.34]),   // by len/12
+  PUNCH_SCALE: Object.freeze([0.04, 0.22]),    // streak chip by link/8
+  PUNCH_MS: 220,
+  /* ---- the near miss ---------------------------------------------------- */
+  WORD_MS: 640,
+  NEAR_MISS_I: 0.55,
+  /* ---- the jackpot ladder ----------------------------------------------- */
+  MINOR_FROM_LEN: 4,
+  MINOR_CHANCE: Object.freeze([0.18, 0.5]),    // by heat
+  MINOR_I: 0.35,
+  MAJOR_FROM_LEN: 6,                           // every even length from here
+  MAJOR_I: Object.freeze([0.5, 0.85]),         // by len/14
+  ROYAL_LEN: Object.freeze({ 1: 9, 2: 10, 3: 11, 4: 12 }),
+  ROYAL_I: 1,
+  ROYAL_MS: 3600,
+  END_DIM_MS: 1400,
+  /* ---- the remix -------------------------------------------------------- */
+  REMIX_STEP_MS: 170,
+  REMIX_ROYAL_STEP_MS: 150,
+  REMIX_MAX_STEPS: 28,
+  REMIX_LEVEL: 0.28,
+  /* ---- sound (light's companions; the pad tones are index.js's) -------- */
+  MILESTONE_LEVEL: 0.42,
+  JACKPOT_LEVEL: 0.5,
+  NEAR_LEVEL: 0.3,
+  THUD_LEVEL: 0.24,
+  RESIST_LEVEL: 0.22,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  /* ---- identity ----------------------------------------------------------- */
+  OFF_ARC: 0.06,
+  ROT_SPAN: 40,                                // the set rotates 0..40deg
+  ROT_OFF: 150,                                // the cold night: pink lands near teal
+  BREATH: Object.freeze([5.8, 8.6]),           // s
+  KB: Object.freeze([20, 32]),                 // s
+  SPOT: Object.freeze([0.6, 0.95]),           // spotlight presence by heat
+  HEAT_REPAINT_STEP: 0.03,
+});
+
+const STYLE_ID = 'g-ec-casino-style';
+const STYLE_TEXT = `
+/* THE HALO: bulbs on the chalk circle, inside the ring, under the pads */
+.g-ec-mq{position:absolute;inset:-7%;border-radius:50%;pointer-events:none;z-index:0;
+  --ec-mq-t:3.4s;--ec-mq-a:.22;--ec-mq-hue:330;--ec-mq-f:1;
+  opacity:var(--ec-mq-a);transition:opacity .9s ease}
+.g-ec-mq *{pointer-events:none}
+.g-ec-mq-bulb{position:absolute;width:var(--ec-mq-d,7px);height:var(--ec-mq-d,7px);margin:calc(var(--ec-mq-d,7px) * -.5);
+  border-radius:50%;background:hsl(var(--ec-mq-hue) 95% 74%);
+  box-shadow:0 0 6px hsl(var(--ec-mq-hue) 95% 70% / .9),0 0 14px hsl(var(--ec-mq-hue) 90% 60% / .5);
+  animation:g-ec-mq-chase var(--ec-mq-t) linear infinite;
+  animation-delay:calc(var(--i) / var(--n) * var(--ec-mq-t) * -1 + var(--ec-mq-p,0s))}
+@keyframes g-ec-mq-chase{0%{opacity:.18;transform:scale(.8)}12%{opacity:1;transform:scale(1.15)}40%{opacity:.35;transform:scale(.92)}100%{opacity:.18;transform:scale(.8)}}
+.g-ec-mq.gold{--ec-mq-hue:46 !important}
+.g-ec-mq.amber{--ec-mq-hue:36 !important}
+.g-ec-mq.flash .g-ec-mq-bulb{animation-duration:.22s;filter:brightness(calc(1.2 + .5 * var(--ec-mq-f,1)))}
+.g-ec-mq.dip{opacity:calc(var(--ec-mq-a) * .35);transition:opacity .12s ease}
+.g-ec-mq.out{opacity:0 !important;transition:opacity 1.6s ease}
+/* a bulb sector lit for the remix: the bulbs nearest a pad flare */
+.g-ec-mq-bulb.sec{animation:none;opacity:1;transform:scale(1.35);filter:brightness(1.7)}
+
+/* THE OVERLAY: the pools, the glint and the word, under the pads */
+.g-ec-cs{position:absolute;inset:0;border-radius:50%;pointer-events:none;z-index:0;overflow:visible}
+.g-ec-cs *{pointer-events:none}
+.g-ec-cs-pool{position:absolute;left:calc(50% + var(--px) * 1%);top:calc(50% + var(--py) * 1%);
+  width:44%;height:44%;border-radius:50%;transform:translate(-50%,-50%) scale(calc(.8 + .35 * var(--ec-cs-l,0)));
+  --ec-h:calc(var(--ec-h-base,330) + var(--ec-n-rot,0));
+  background:radial-gradient(circle, hsl(var(--ec-h) 92% 70% / .55) 0%, hsl(var(--ec-h) 90% 62% / .22) 32%, transparent 66%);
+  opacity:calc(.05 + .95 * var(--ec-cs-l,0));
+  transition:opacity .62s ease-out, transform .62s ease-out;
+  animation:g-ec-pool-ember 7s ease-in-out infinite alternate;animation-delay:calc(var(--i) * -1.15s)}
+@keyframes g-ec-pool-ember{from{filter:brightness(.9)}to{filter:brightness(1.25)}}
+.g-ec-cs-pool.up{transition:opacity .07s ease-out, transform .09s cubic-bezier(.2,1.4,.4,1)}
+.g-ec-cs-pool.cold{--ec-h:196 !important;filter:saturate(.4)}
+.g-ec-cs-pool.hum{animation:g-ec-pool-hum .7s ease-in-out infinite alternate}
+@keyframes g-ec-pool-hum{from{opacity:.35;transform:translate(-50%,-50%) scale(.95)}to{opacity:.95;transform:translate(-50%,-50%) scale(1.18)}}
+.g-ec-cs-pool.warm{filter:sepia(.45) saturate(1.1)}
+/* THE GLINT: one lap of the chalk circle for a decoy let pass */
+.g-ec-cs-glint{position:absolute;inset:0;border-radius:50%;opacity:0;
+  background:conic-gradient(from 0deg, transparent 0 300deg, hsl(46 95% 75% / .9) 345deg, transparent 360deg);
+  -webkit-mask:radial-gradient(circle, transparent 0 calc(50% - 6px), #000 calc(50% - 5px) calc(50% - 1px), transparent 50%);
+  mask:radial-gradient(circle, transparent 0 calc(50% - 6px), #000 calc(50% - 5px) calc(50% - 1px), transparent 50%)}
+.g-ec-cs-glint.on{animation:g-ec-glint .9s linear 1}
+@keyframes g-ec-glint{0%{opacity:0;transform:rotate(0deg)}15%{opacity:1}85%{opacity:1}100%{opacity:0;transform:rotate(360deg)}}
+/* THE WORD: the centre of the ring, for under a second */
+.g-ec-cs-word{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);opacity:0;
+  font:800 clamp(13px,2.1vmin,20px)/1 var(--disp,system-ui,sans-serif);letter-spacing:.18em;text-transform:uppercase;
+  white-space:nowrap;color:hsl(var(--ec-cs-hue,330) 90% 84%);text-shadow:0 0 12px hsl(var(--ec-cs-hue,330) 90% 70% / .85)}
+.g-ec-cs-word.on{animation:g-ec-cs-word .64s ease-out forwards}
+.g-ec-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-ec-cs-word.gold{color:#ffe08a;text-shadow:0 0 14px rgba(240,194,75,.9)}
+@keyframes g-ec-cs-word{0%{opacity:0;transform:translate(-50%,-50%) scale(.7)}18%{opacity:1;transform:translate(-50%,-50%) scale(1.08)}
+  70%{opacity:1;transform:translate(-50%,-50%) scale(1)}100%{opacity:0;transform:translate(-50%,-46%) scale(1)}}
+/* the streak chip's punch: transform only */
+.g-ec-cs-punch{transition:transform .22s cubic-bezier(.2,1.6,.4,1) !important;transform:scale(var(--ec-cs-ps,1))}
+.g-ec-cs-bloom{box-shadow:0 0 0 2px hsl(var(--ec-cs-hue,330) 90% 70% / .55),0 0 22px hsl(var(--ec-cs-hue,330) 90% 65% / .6) !important;transition:box-shadow .3s ease}
+
+/* THE ROOM: the tint pulse and the royal flood live in the backdrop */
+.g-ec-bd-pulse{position:absolute;inset:0;opacity:0;
+  background:radial-gradient(circle at 50% 56%, hsl(var(--ec-cs-hue,330) 90% 70% / .7) 0%, hsl(var(--ec-cs-hue,330) 90% 60% / .25) 30%, transparent 68%);
+  transition:opacity .5s ease-out}
+.g-ec-bd-pulse.on{opacity:var(--ec-cs-pay,.2);transition:opacity .08s ease-in}
+.g-ec-bd-royal{position:absolute;inset:0;opacity:0;
+  background:radial-gradient(circle at 50% 56%, hsl(46 100% 72% / .9) 0%, hsl(46 100% 60% / .4) 34%, hsl(46 100% 50% / .12) 70%, transparent 100%);
+  transition:opacity .9s ease}
+.g-ec-bd-royal.on{opacity:.85;transition:opacity .35s ease-out}
+.g-ec-stage.g-ec-encore .g-ec-bd-pulse{background:radial-gradient(circle at 50% 56%, hsl(36 90% 70% / .6) 0%, transparent 66%)}
+.g-ec-stage.g-ec-out .g-ec-cs-pool{opacity:.03;transition:opacity 1.6s ease}
+
+@media (prefers-reduced-motion: reduce){
+  .g-ec-mq-bulb{animation:none !important;opacity:.55}
+  .g-ec-cs-pool{animation:none !important;transition:opacity .4s ease}
+  .g-ec-cs-pool.hum{animation:none !important;opacity:.8}
+  .g-ec-cs-glint.on{animation:none;opacity:.7}
+  .g-ec-cs-word.on{animation:none;opacity:1}
+}
+html.arc-reduced .g-ec-mq-bulb{animation:none !important;opacity:.55}
+html.arc-reduced .g-ec-cs-pool{animation:none !important;transition:opacity .4s ease;transform:translate(-50%,-50%)}
+html.arc-reduced .g-ec-cs-pool.hum{animation:none !important;opacity:.8}
+html.arc-reduced .g-ec-cs-glint.on{animation:none;opacity:.7}
+html.arc-reduced .g-ec-cs-word.on{animation:none;opacity:1}
+.g-ec-stage.suspended .g-ec-mq-bulb,.g-ec-stage.suspended .g-ec-cs-pool,.g-ec-stage.suspended .g-ec-cs-word,
+.g-ec-stage.suspended .g-ec-cs-glint{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (host && host.appendChild) host.appendChild(s);
+    if (document._register) document._register(STYLE_ID, s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+const PAD_HUES = Object.freeze([330, 46, 178, 264, 20, 205]);
+
+/** Ring-adjacent pads (the near miss): |a-b| == 1 on a ring of n. Pure. */
+export function isAdjacent(a, b, n) {
+  const m = Math.max(2, Math.floor(Number(n) || 6));
+  const x = Math.floor(Number(a));
+  const y = Math.floor(Number(b));
+  if (!Number.isFinite(x) || !Number.isFinite(y) || x === y) return false;
+  const d = Math.abs(x - y);
+  return d === 1 || d === m - 1;
+}
+/** The royal length for a tier. Pure. */
+export function royalLenFor(tier) {
+  const t = Math.max(1, Math.min(4, Math.round(Number(tier) || 1)));
+  return EC_CASINO.ROYAL_LEN[t] || 12;
+}
+/** Is a cleared length a major milestone? Every even length from six. Pure. */
+export function isMajorLen(len) {
+  const l = Math.floor(Number(len) || 0);
+  return l >= EC_CASINO.MAJOR_FROM_LEN && l % 2 === 0;
+}
+/** The remix plan for a sequence: a list of pad indices in show order. Pure.
+ *  variant 0 = forward, 1 = palindrome (forward then back, the turn shared),
+ *  2 = rotated (starts a third in, wraps). Capped at REMIX_MAX_STEPS. */
+export function remixPlan(seq, variant) {
+  const s = Array.isArray(seq) ? seq.filter((x) => Number.isFinite(Number(x))).map((x) => Math.floor(Number(x))) : [];
+  if (!s.length) return [];
+  const v = Math.floor(Number(variant) || 0) % 3;
+  let out;
+  if (v === 1) out = s.concat(s.slice(0, -1).reverse());
+  else if (v === 2 && s.length > 2) { const k = Math.floor(s.length / 3); out = s.slice(k).concat(s.slice(0, k)); }
+  else out = s.slice();
+  return out.slice(0, EC_CASINO.REMIX_MAX_STEPS);
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function restart(n, cls) {
+  if (!n || !n.classList) return;
+  try { n.classList.remove(cls); if (typeof n.offsetWidth === 'number') void n.offsetWidth; n.classList.add(cls); } catch (e) { /* noop */ }
+}
+function qsa(root, sel) {
+  try { if (root && typeof root.querySelectorAll === 'function') return Array.from(root.querySelectorAll(sel)); } catch (e) { /* fall */ }
+  return [];
+}
+function qs(root, sel) {
+  try { if (root && typeof root.querySelector === 'function') return root.querySelector(sel) || null; } catch (e) { /* fall */ }
+  return null;
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier (1..4), stage (.g-ec-stage), board (.g-ec-ring), hud (the
+ *   .g-ec-hud element OR {len, clock, streak, best}), backdrop (.g-ec-backdrop),
+ *   timers {after, every?, clear|cancel}, reduced, capsOk (bool or () => bool),
+ *   t (key, fallback) => string, engine {fire, ceremony?, channels?}, log,
+ *   optional: pads () => Element[] (else read off the board), padCount
+ */
+export function createEcCasino(o) {
+  const opts = o || {};
+  const C = EC_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const reduced = !!opts.reduced;
+  const tier = Math.max(1, Math.min(4, Math.round(Number(opts.tier) || 1)));
+  const audioCeil = C.AUDIO_CEIL[tier] || C.AUDIO_CEIL[1];
+  const eng = opts.engine || {};
+  const armedBase = !!opts.stage && !!opts.board && !!opts.timers && typeof opts.timers.after === 'function'
+    && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'ec') + '|ec-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, pulses: 0, words: 0, remixSteps: 0, resisted: 0 };
+  function cue(name, level, extra) {
+    if (!armed()) return;
+    counts.cues++;
+    const lv = Math.min(audioCeil, Math.max(0, Number(level) || 0));
+    try {
+      if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed()) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+
+  /* ---- identity (per class seed; FIXED draw order) ------------------------ */
+  const ID = (() => {
+    const offArc = roll('arc') < C.OFF_ARC;
+    const rot = offArc ? C.ROT_OFF + Math.round(roll('rot') * 20) : Math.round(roll('rot') * C.ROT_SPAN);
+    const bulbs = C.BULBS[Math.floor(roll('bulbs') * C.BULBS.length)];
+    const bulbD = 6 + Math.round(roll('bulbs') * 3);            // 6..9 px
+    const phase = -(roll('mq-phase') * 3.4);                     // s
+    const breath = lerp(C.BREATH, roll('breath'));
+    const kb = lerp(C.KB, roll('kb'));
+    const remixDir = roll('remix-dir') < 0.5 ? -1 : 1;
+    return { offArc, rot, bulbs, bulbD, phase, breath: +breath.toFixed(1), kb: +kb.toFixed(1), remixDir };
+  })();
+  const hueOf = (i) => ((PAD_HUES[Math.max(0, Math.min(5, i | 0))] + ID.rot) % 360);
+  const mqHue = hueOf(0);
+
+  /* ---- nodes ------------------------------------------------------------- */
+  let halo = null; let bulbs = [];
+  let cs = null; const pools = []; let glint = null; let word = null;
+  let pulse = null; let royal = null;
+  const props = new Set();
+  const stageClasses = new Set();
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let bellOn = false; let encoreOn = false; let royalOn = false; let outOn = false;
+  let padCount = 6;
+  const poolTimers = new Array(6).fill(0);
+  let flashTimer = 0; let dipTimer = 0; let wordTimer = 0; let pulseTimer = 0; let punchTimer = 0;
+  let royalTimer = 0; let glintTimer = 0; let humTimer = 0; let humPool = -1;
+  const sweepTimers = new Set();
+  const remixTimers = new Set();
+  let remixing = false;
+  let seq = [];                 // the LAST playback this deck was shown (for the remix)
+  let bestLen = 0;
+  const jackLog = [];
+  let almostSeen = 0;
+
+  function streakChip() {
+    const h = opts.hud;
+    if (!h) return null;
+    if (h.streak) return h.streak;
+    return qs(h, '.g-ec-streak');
+  }
+  function livePads() {
+    if (typeof opts.pads === 'function') { try { const p = opts.pads(); if (p && p.length) return Array.from(p); } catch (e) { /* fall */ } }
+    return qsa(opts.board, '.g-ec-pad');
+  }
+  function countPads() {
+    const n = Number(opts.padCount) || livePads().length || 6;
+    padCount = Math.max(2, Math.min(6, n));
+    return padCount;
+  }
+  function angleOf(i) {
+    const n = padCount;
+    const step = n === 4 ? 90 : 60;
+    return (-90 + step * i) * Math.PI / 180;
+  }
+
+  function setProp(k, v) { setVar(opts.stage, k, v); props.add(k); }
+  function stageClass(name, on) {
+    setCls(opts.stage, name, on);
+    if (on) stageClasses.add(name); else stageClasses.delete(name);
+  }
+
+  function mount() {
+    if (halo || !armedBase || !capsOk()) return;      // bgIntensity 0: the floor stays dark
+    ensureStyle();
+    countPads();
+    /* the room's identity on the stage: style.js reads these */
+    setProp('--ec-n-rot', String(ID.rot));
+    setProp('--ec-n-breath', ID.breath + 's');
+    setProp('--ec-n-kb', ID.kb + 's');
+    setProp('--ec-cs-hue', String(mqHue));
+    if (ID.offArc) {
+      setProp('--ec-n-la', 'hsl(190 60% 70% / .18)');
+      setProp('--ec-n-lb', 'hsl(210 60% 60% / .14)');
+    }
+    /* THE HALO, first child of the ring so it paints under the pads */
+    halo = el('div', 'g-ec-mq');
+    if (halo) {
+      setVar(halo, '--ec-mq-hue', mqHue);
+      setVar(halo, '--ec-mq-d', ID.bulbD + 'px');
+      setVar(halo, '--n', ID.bulbs);
+      setVar(halo, '--ec-mq-p', ID.phase.toFixed(2) + 's');
+      for (let i = 0; i < ID.bulbs; i++) {
+        const b = el('span', 'g-ec-mq-bulb');
+        if (!b) break;
+        const a = (i / ID.bulbs) * Math.PI * 2 - Math.PI / 2;
+        try {
+          b.style.left = (50 + 50 * Math.cos(a)).toFixed(2) + '%';
+          b.style.top = (50 + 50 * Math.sin(a)).toFixed(2) + '%';
+        } catch (e) { /* shim */ }
+        setVar(b, '--i', i);
+        bulbs.push(b);
+        halo.appendChild(b);
+      }
+      try {
+        if (typeof opts.board.insertBefore === 'function' && opts.board.firstChild) opts.board.insertBefore(halo, opts.board.firstChild);
+        else opts.board.appendChild(halo);
+      } catch (e) { halo = null; bulbs = []; }
+    }
+    /* THE OVERLAY: pools, glint, word */
+    cs = el('div', 'g-ec-cs');
+    if (cs) {
+      for (let i = 0; i < 6; i++) {
+        const p = el('i', 'g-ec-cs-pool');
+        if (!p) break;
+        const a = angleOf(i);
+        setVar(p, '--i', i);
+        setVar(p, '--px', (35.5 * Math.cos(a)).toFixed(2));
+        setVar(p, '--py', (35.5 * Math.sin(a)).toFixed(2));
+        setVar(p, '--ec-h-base', PAD_HUES[i]);
+        setVar(p, '--ec-cs-l', '0');
+        if (i >= padCount) { try { p.style.opacity = '0'; } catch (e) { /* shim */ } }
+        pools.push(p);
+        cs.appendChild(p);
+      }
+      glint = el('i', 'g-ec-cs-glint');
+      if (glint) cs.appendChild(glint);
+      word = el('div', 'g-ec-cs-word');
+      if (word) cs.appendChild(word);
+      try {
+        if (halo && typeof opts.board.insertBefore === 'function' && halo.nextSibling) opts.board.insertBefore(cs, halo.nextSibling);
+        else if (typeof opts.board.insertBefore === 'function' && opts.board.firstChild && !halo) opts.board.insertBefore(cs, opts.board.firstChild);
+        else opts.board.appendChild(cs);
+      } catch (e) { cs = null; }
+    }
+    /* THE ROOM: pulse + royal flood in the backdrop */
+    if (opts.backdrop && opts.backdrop.appendChild) {
+      pulse = el('div', 'g-ec-bd-pulse');
+      if (pulse) opts.backdrop.appendChild(pulse);
+      royal = el('div', 'g-ec-bd-royal');
+      if (royal) opts.backdrop.appendChild(royal);
+    }
+    paintHeat(true);
+  }
+
+  function paintHeat(force) {
+    if (!halo && !opts.stage) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (halo) {
+      const gold = bellOn || royalOn;
+      let period = gold ? C.MQ_T_GOLD : (C.MQ_T_SLOW + (C.MQ_T_FAST - C.MQ_T_SLOW) * heat);
+      if (encoreOn && !gold) period *= C.MQ_ENCORE_MUL;
+      const alpha = outOn ? 0 : (gold ? C.MQ_A_GOLD : lerp([C.MQ_A_LO, C.MQ_A_HI], heat));
+      setVar(halo, '--ec-mq-t', period.toFixed(2) + 's');
+      setVar(halo, '--ec-mq-a', alpha.toFixed(2));
+    }
+    setProp('--ec-n-spot', lerp(C.SPOT, heat).toFixed(2));
+  }
+
+  /* ---- the light ---------------------------------------------------------- */
+  function flashHalo(strength, ms) {
+    if (!halo || !armed() || reduced) return;
+    setVar(halo, '--ec-mq-f', Math.max(1, Math.min(2.2, Number(strength) || 1)).toFixed(2));
+    restart(halo, 'flash');
+    cancel(flashTimer);
+    flashTimer = after(ms || C.MQ_FLASH_MS, () => { flashTimer = 0; setCls(halo, 'flash', false); });
+  }
+  function dipHalo() {
+    if (!halo || !armed()) return;
+    setCls(halo, 'flash', false);
+    setCls(halo, 'dip', true);
+    cancel(dipTimer);
+    dipTimer = after(C.MQ_DIP_MS, () => { dipTimer = 0; setCls(halo, 'dip', false); });
+  }
+  /** A pool takes a level and decays back at the lamp's rate. */
+  function poolUp(i, level, holdMs, extraCls) {
+    const p = pools[i];
+    if (!p || !armed()) return;
+    setCls(p, 'up', true);
+    setCls(p, 'cold', extraCls === 'cold');
+    setVar(p, '--ec-cs-l', clamp01(level).toFixed(2));
+    if (poolTimers[i]) cancel(poolTimers[i]);
+    poolTimers[i] = after(holdMs || C.POOL_DECAY_MS, () => {
+      poolTimers[i] = 0;
+      setCls(p, 'up', false);
+      setCls(p, 'cold', false);
+      setVar(p, '--ec-cs-l', '0');
+    });
+  }
+  function poolsDown() {
+    for (let i = 0; i < pools.length; i++) {
+      if (poolTimers[i]) { cancel(poolTimers[i]); poolTimers[i] = 0; }
+      setCls(pools[i], 'up', false);
+      setCls(pools[i], 'cold', false);
+      setVar(pools[i], '--ec-cs-l', '0');
+    }
+  }
+  function clearHum() {
+    if (humTimer) { cancel(humTimer); humTimer = 0; }
+    if (humPool >= 0 && pools[humPool]) setCls(pools[humPool], 'hum', false);
+    humPool = -1;
+  }
+  function hum(i) {
+    clearHum();
+    const p = pools[i];
+    if (!p || !armed()) return;
+    humPool = i;
+    setCls(p, 'hum', true);
+    humTimer = after(C.POOL_HUM_MS, () => { humTimer = 0; setCls(p, 'hum', false); humPool = -1; });
+  }
+  /** The sweep: every pool around the ring, one after another, the remix's direction. */
+  function sweep(level, stepMs) {
+    if (!armed()) return;
+    if (reduced) { for (let i = 0; i < padCount; i++) poolUp(i, level, 900); return; }
+    for (let k = 0; k < padCount; k++) {
+      const i = ((ID.remixDir > 0 ? k : padCount - k) % padCount + padCount) % padCount;
+      let id = 0;
+      id = after(k * (stepMs || C.SWEEP_STEP_MS), () => { sweepTimers.delete(id); poolUp(i, level, C.POOL_DECAY_MS); });
+      if (id) sweepTimers.add(id);
+    }
+  }
+  function pulseRoom(q, ms) {
+    if (!pulse || !armed()) return;
+    counts.pulses++;
+    setVar(pulse, '--ec-cs-pay', lerp(C.ROOM_PULSE_A, q).toFixed(2));
+    setCls(pulse, 'on', true);
+    cancel(pulseTimer);
+    pulseTimer = after(ms || C.ROOM_PULSE_MS, () => { pulseTimer = 0; setCls(pulse, 'on', false); });
+  }
+  function punchStreak(q) {
+    const chip = streakChip();
+    if (!chip || !armed()) return;
+    if (reduced) {
+      setCls(chip, 'g-ec-cs-bloom', true);
+      cancel(punchTimer);
+      punchTimer = after(320, () => { punchTimer = 0; setCls(chip, 'g-ec-cs-bloom', false); });
+      return;
+    }
+    setCls(chip, 'g-ec-cs-punch', true);
+    setVar(chip, '--ec-cs-ps', (1 + lerp(C.PUNCH_SCALE, q)).toFixed(3));
+    cancel(punchTimer);
+    punchTimer = after(C.PUNCH_MS, () => { punchTimer = 0; setVar(chip, '--ec-cs-ps', '1'); });
+  }
+  function showWord(key, fallback, tone) {
+    if (!word || !armed()) return;
+    counts.words++;
+    try { word.textContent = t(key, fallback); } catch (e) { return; }
+    word.className = 'g-ec-cs-word' + (tone ? ' ' + tone : '');
+    restart(word, 'on');
+    cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 60, () => { wordTimer = 0; setCls(word, 'on', false); });
+  }
+  /** The bulbs nearest a pad flare for a beat (the remix's sector). */
+  function sector(i, ms) {
+    if (!bulbs.length || reduced) return;
+    const n = bulbs.length;
+    const centre = Math.round(((angleOf(i) + Math.PI / 2) / (Math.PI * 2)) * n);
+    const span = Math.max(1, Math.round(n / padCount / 2) - 1);
+    const lit = [];
+    for (let d = -span; d <= span; d++) {
+      const b = bulbs[((centre + d) % n + n) % n];
+      if (b) { setCls(b, 'sec', true); lit.push(b); }
+    }
+    let id = 0;
+    id = after(ms, () => { remixTimers.delete(id); for (const b of lit) setCls(b, 'sec', false); });
+    if (id) remixTimers.add(id);
+  }
+
+  /* ---- the ladder --------------------------------------------------------- */
+  function killRemix() {
+    for (const id of Array.from(remixTimers)) cancel(id);
+    remixTimers.clear();
+    for (const b of bulbs) setCls(b, 'sec', false);
+    remixing = false;
+  }
+  /** THE REMIX: the player's own sequence as a light show at double tempo. */
+  function remix(stepMs, level, twice) {
+    if (!armed() || !seq.length) return 0;
+    killRemix();
+    const plan = remixPlan(seq, Math.floor(roll('remix') * 3));
+    const show = twice ? plan.concat(plan) : plan;
+    remixing = true;
+    const ratchet = Math.min(7, Math.max(0, seq.length - 3));
+    for (let k = 0; k < show.length; k++) {
+      const pad = show[k];
+      let id = 0;
+      id = after(k * stepMs, () => {
+        remixTimers.delete(id);
+        counts.remixSteps++;
+        poolUp(pad, 1, C.POOL_DECAY_MS);
+        sector(pad, stepMs);
+        cue('blip', level, { pitch: pitchFor(pad, ratchet) });
+        if (k === show.length - 1) remixing = false;
+      });
+      if (id) remixTimers.add(id);
+    }
+    return show.length;
+  }
+  function jackpot(intensity, why) {
+    if (!armed()) return;
+    counts.jackpots++;
+    jackLog.push(why);
+    /* the engine's jackpot forces a full-screen drain|spiral garnish (trap 33)
+       - in a room where the NEXT thing is watching six pads, that wash lands
+       on the playback and competes with the sequence; the remix IS the minor
+       and major show, so only the ROYAL keeps the forced garnish */
+    ceremony('jackpot', { intensity, garnish: /^royal/.test(String(why || '')) });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashHalo(1.3 + intensity * 0.8, C.MQ_FLASH_MS + 300 * intensity);
+    pulseRoom(0.4 + 0.6 * intensity, C.ROOM_PULSE_MS + 320);
+  }
+  function nearMiss(intensity) {
+    if (!armed()) return;
+    counts.nearMisses++;
+    ceremony('near_miss', { intensity });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: 1.1 });
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      if (!armedBase || !capsOk()) { say('casino: disarmed'); return; }
+      mount();
+      say('casino: floor lit (rot ' + ID.rot + (ID.offArc ? ' off-arc' : '') + ', ' + ID.bulbs + ' bulbs, '
+        + padCount + ' pads, breath ' + ID.breath + 's)');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started) paintHeat(false);
+    },
+
+    /** Playback: pad i lights as item idx of len. The pool under it takes the light. */
+    padLit(i, idx, len) {
+      const pad = Math.floor(Number(i));
+      if (!Number.isFinite(pad)) return;
+      const k = Math.floor(Number(idx));
+      if (Number.isFinite(k) && k >= 0) {
+        if (k === 0) seq = [];
+        seq[k] = pad;
+        if (Number(len) > 0 && seq.length > Number(len)) seq.length = Math.floor(Number(len));
+      }
+      if (!armed() || !started) return;
+      poolUp(pad, C.POOL_LIT, C.POOL_DECAY_MS);
+    },
+
+    /** Input: a press. Correct pays light by its link; wrong is a cold flash + a thud. */
+    padPressed(i, correct, link) {
+      if (!armed() || !started) return;
+      const pad = Math.floor(Number(i));
+      const l = Math.max(1, Math.min(12, Number(link) || 1));
+      if (correct) {
+        poolUp(pad, lerp(C.POOL_PAY, Math.min(8, l) / 8), C.POOL_DECAY_MS);
+        if (l >= 2) flashHalo(1 + C.FLASH_LINK_STEP * Math.min(8, l), C.MQ_FLASH_MS * 0.6);
+        punchStreak(Math.min(8, l) / 8);
+        if (l >= 3) pulseRoom(0.1 + 0.04 * Math.min(8, l), 420);
+      } else {
+        poolUp(pad, 0.7, 380, 'cold');
+        dipHalo();
+      }
+    },
+
+    /** A cleared sequence: the sweep, the arpeggio, and the jackpot ladder. */
+    sequenceDone(len) {
+      if (!armed() || !started) return null;
+      const l = Math.max(1, Math.floor(Number(len) || 0));
+      bestLen = Math.max(bestLen, l);
+      sweep(0.9, C.SWEEP_STEP_MS);
+      pulseRoom(Math.min(1, l / 12), C.ROOM_PULSE_MS);
+      flashHalo(1.2 + 0.05 * l, C.MQ_FLASH_MS);
+      cue('streak', C.MILESTONE_LEVEL, { pitch: +(Math.pow(2, Math.min(7, Math.max(0, l - 3)) / 12)).toFixed(4) });
+      /* THE JACKPOT LADDER */
+      let kind = null;
+      if (!royalOn && l >= royalLenFor(tier)) {
+        kind = 'royal';
+        royalOn = true;
+        counts.royal = 1;
+        stageClass('g-ec-royal', true);
+        setCls(halo, 'gold', true);
+        setCls(royal, 'on', true);
+        showWord('ec_royal', 'The whole melody', 'gold');
+        jackpot(C.ROYAL_I, 'royal@' + l);
+        after(260, () => cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.5 }));
+        after(520, () => cue('stamp', 0.45, { pitch: 1 }));
+        remix(C.REMIX_ROYAL_STEP_MS, C.REMIX_LEVEL, true);
+        cancel(royalTimer);
+        royalTimer = after(C.ROYAL_MS, () => {
+          royalTimer = 0;
+          setCls(royal, 'on', false);
+          if (!bellOn) setCls(halo, 'gold', false);
+          paintHeat(true);
+        });
+        paintHeat(true);
+      } else if (isMajorLen(l)) {
+        kind = 'major';
+        const q = clamp01(l / 14);
+        jackpot(lerp(C.MAJOR_I, q), 'major@' + l);
+        showWord('ec_jackpot', 'Perfect pitch', '');
+        remix(C.REMIX_STEP_MS, C.REMIX_LEVEL, false);
+      } else if (l >= C.MINOR_FROM_LEN && roll('jack-minor') < lerp(C.MINOR_CHANCE, heat)) {
+        kind = 'minor';
+        jackpot(C.MINOR_I, 'minor@' + l);
+      }
+      return { kind, len: l };
+    },
+
+    /** A fail at pad i where `expected` was due: a thud, a cold dip; next door = THE ALMOST. */
+    fail(i, expected) {
+      if (!armed() || !started) return null;
+      const pad = Math.floor(Number(i));
+      const exp = Math.floor(Number(expected));
+      killRemix();
+      dipHalo();
+      if (Number.isFinite(pad) && pad >= 0) poolUp(pad, 0.7, 420, 'cold');
+      cue('bump', C.THUD_LEVEL, { pitch: 0.7 });               // a muted thud, never silence
+      let almost = false;
+      if (Number.isFinite(pad) && Number.isFinite(exp) && isAdjacent(pad, exp, padCount)) {
+        almost = true;
+        almostSeen++;
+        hum(exp);
+        showWord('ec_near_miss', 'So nearly', 'lav');
+        nearMiss(C.NEAR_MISS_I);
+      }
+      return { almost };
+    },
+
+    /** A decoy let pass: the glint laps the circle, a tiny tick. */
+    decoyResisted() {
+      if (!armed() || !started) return;
+      counts.resisted++;
+      if (glint) {
+        restart(glint, 'on');
+        cancel(glintTimer);
+        glintTimer = after(950, () => { glintTimer = 0; setCls(glint, 'on', false); });
+      }
+      flashHalo(1.1, 260);
+      cue('streak', C.RESIST_LEVEL, { pitch: 1.4 });
+    },
+
+    /** Encore: the room goes warm and slow; back when it ends. */
+    encore(on) {
+      encoreOn = !!on;
+      stageClass('g-ec-encore', encoreOn);
+      setCls(halo, 'amber', encoreOn && !bellOn && !royalOn);
+      for (const p of pools) setCls(p, 'warm', encoreOn);
+      paintHeat(true);
+    },
+
+    /** The bell (the last stretch): gold and fast. */
+    bell(on) {
+      bellOn = !!on;
+      setCls(halo, 'gold', bellOn || royalOn);
+      if (bellOn) setCls(halo, 'amber', false);
+      paintHeat(true);
+    },
+
+    /** The bell took the room: the rig sighs out, a dim payout on a plain class. */
+    dimOut() {
+      outOn = true;
+      const wasRoyal = royalOn;
+      bellOn = false;
+      encoreOn = false;
+      killRemix();
+      clearHum();
+      for (const id of Array.from(sweepTimers)) cancel(id);
+      sweepTimers.clear();
+      setCls(halo, 'flash', false);
+      setCls(halo, 'dip', false);
+      setCls(halo, 'amber', false);
+      setCls(halo, 'out', true);
+      stageClass('g-ec-encore', false);
+      stageClass('g-ec-out', true);
+      if (armed()) {
+        /* losses disguised: a dim payout, never silence. After a ROYAL the
+           hall is already gold, so only the cue (a shade brighter) plays. */
+        if (!wasRoyal) pulseRoom(0.1 + 0.25 * clamp01(bestLen / 12), C.END_DIM_MS);
+        cue('wash', 0.25, { pitch: wasRoyal ? 1.15 : 0.9 });
+      }
+      paintHeat(true);
+    },
+
+    pause() { /* transient light simply ends on its own timers (the registry is pause-aware) */ },
+    resume() { /* the chase is CSS; the stage's .suspended rule released it */ },
+
+    /** The class is over; nothing may pulse again. */
+    stop() {
+      cancelAll();
+      flashTimer = dipTimer = wordTimer = pulseTimer = punchTimer = royalTimer = glintTimer = humTimer = 0;
+      sweepTimers.clear();
+      killRemix();
+      clearHum();
+      poolsDown();
+      setCls(halo, 'flash', false);
+      setCls(halo, 'dip', false);
+      setCls(pulse, 'on', false);
+      setCls(word, 'on', false);
+      setCls(glint, 'on', false);
+      const chip = streakChip();
+      if (chip) { setCls(chip, 'g-ec-cs-punch', false); setCls(chip, 'g-ec-cs-bloom', false); setVar(chip, '--ec-cs-ps', '1'); }
+    },
+
+    destroy() {
+      if (destroyed) return;
+      api.stop();
+      destroyed = true;
+      cancelAll();
+      for (const n of [halo, cs, pulse, royal]) {
+        try { if (n && typeof n.remove === 'function') n.remove(); else if (n && n.parentNode) n.parentNode.removeChild(n); } catch (e) { /* noop */ }
+      }
+      halo = cs = pulse = royal = glint = word = null;
+      bulbs = []; pools.length = 0;
+      for (const name of Array.from(stageClasses)) stageClass(name, false);
+      if (opts.stage && opts.stage.style) {
+        for (const k of props) { try { opts.stage.style.removeProperty(k); } catch (e) { /* ignore */ } }
+      }
+      props.clear();
+    },
+
+    diagnostics() {
+      return {
+        armed: armed(), started, heat: +heat.toFixed(3), rot: ID.rot, offArc: ID.offArc, bulbs: ID.bulbs, pads: padCount,
+        bell: bellOn, encore: encoreOn, royal: royalOn, out: outOn, bestLen, seq: seq.slice(), almost: almostSeen,
+        remixing, counts: Object.assign({}, counts), jackpots: jackLog.slice(),
+        liveTimers: live.size, nodes: [halo, cs, pulse, royal].filter(Boolean).length,
+      };
+    },
+  };
+  return api;
+}
+
+export default createEcCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/grade.js
@@ -1,0 +1,115 @@
+/* ============================================================================
+ * games/echo/grade.js - the composite ECHO hands to the ONE shared rubric
+ * (core/grades.js via ctx.endClass). PURE.
+ *
+ * A game never grades itself: this file turns the class's inputs into a 0..1
+ * composite, a declared hard gate and the flavour XP, and the SHELL maps the
+ * composite to S / A / B / C (>= .92 S / .75 A / .50 B) and applies every cap.
+ *
+ * THE COMPOSITE (the dossier's grading inputs, weighted per the contract):
+ *   .50 length     the LONGEST CLEARED echo against the tier's S length
+ *                  ({1:8, 2:10, 3:12, 4:14}) - the primary input
+ *   .20 accuracy   correct presses / total presses
+ *   .15 tempo      mean per-press latency normalised to the playback step; at
+ *                  or under the step it is full marks, at TEMPO_FLOOR steps it
+ *                  is zero. `echoPlaybackTempo` never shipped as a setting, so
+ *                  there is no tempo_assist A-cap to raise here.
+ *   .15 decoys     decoys resisted / decoys presented; NEUTRAL (a full term)
+ *                  when the tier presented none, so a tier-1 class is never
+ *                  quietly graded against a mechanic it has not met.
+ *
+ * HARD GATE: `sGate` is false when the ENCORE was used. The dossier's rule is
+ * "S requires no encore"; a failed declared gate caps the class at A in
+ * core/grades.js, which is exactly that rule and nothing harsher.
+ *
+ * FLAVOUR XP: +3 per cleared length above the tier's par, cap 15. Game-owned,
+ * never part of the composite (the XP table itself is C#'s).
+ * ==========================================================================*/
+
+export const GRADE = Object.freeze({
+  W_LENGTH: 0.50,
+  W_ACCURACY: 0.20,
+  W_TEMPO: 0.15,
+  W_DECOY: 0.15,
+
+  /** Longest cleared echo that earns the full length term, per gradeTier. */
+  S_LEN: Object.freeze({ 1: 8, 2: 10, 3: 12, 4: 14 }),
+  /** The tier's par length - flavour XP starts above this. */
+  PAR_LEN: Object.freeze({ 1: 6, 2: 7, 3: 9, 4: 11 }),
+  /** The length term is measured from here (the shortest sequence dealt). */
+  LEN_BASE: 3,
+
+  /** Mean latency / step at or under this = the full tempo term. */
+  TEMPO_TARGET: 1.0,
+  /** ... and at or over this = zero. */
+  TEMPO_FLOOR: 2.4,
+
+  FLAVOR_PER_LEN: 3,
+  FLAVOR_CAP: 15,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Number(gradeTier) || 1))); }
+
+/**
+ * @param {Object} i
+ *   gradeTier         1..4
+ *   bestLen           longest sequence CLEARED this class (0 if none)
+ *   correct           correct presses this class
+ *   presses           total presses this class (correct + wrong)
+ *   meanLatencyMs     mean gap between presses inside an input turn
+ *   stepMs            the tier's playback step (the normaliser)
+ *   decoysPresented   decoys the player actually reached
+ *   decoysResisted    of those, the ones not taken
+ * @returns {{composite:number, terms:Object, sLen:number}}
+ */
+export function compositeFor(i = {}) {
+  const tier = tierOf(i.gradeTier);
+  const sLen = GRADE.S_LEN[tier];
+  const best = Math.max(0, Math.floor(Number(i.bestLen) || 0));
+  const span = Math.max(1, sLen - GRADE.LEN_BASE);
+  const length = clamp01((best - GRADE.LEN_BASE) / span);
+
+  const presses = Math.max(0, Math.floor(Number(i.presses) || 0));
+  const correct = Math.max(0, Math.min(presses, Math.floor(Number(i.correct) || 0)));
+  const accuracy = presses > 0 ? clamp01(correct / presses) : 0;
+
+  const stepMs = Math.max(1, Number(i.stepMs) || 1);
+  const mean = Number(i.meanLatencyMs);
+  let tempo = 0;
+  if (!Number.isFinite(mean) || mean <= 0) {
+    // No timed press at all (a class that never got an input turn in): the
+    // term is zero, not a free pass - the length term already carries that.
+    tempo = 0;
+  } else {
+    const r = mean / stepMs;
+    tempo = clamp01((GRADE.TEMPO_FLOOR - r) / Math.max(0.0001, GRADE.TEMPO_FLOOR - GRADE.TEMPO_TARGET));
+  }
+
+  const shown = Math.max(0, Math.floor(Number(i.decoysPresented) || 0));
+  const kept = Math.max(0, Math.min(shown, Math.floor(Number(i.decoysResisted) || 0)));
+  const decoys = shown > 0 ? clamp01(kept / shown) : 1;
+
+  const composite = clamp01(
+    GRADE.W_LENGTH * length
+    + GRADE.W_ACCURACY * accuracy
+    + GRADE.W_TEMPO * tempo
+    + GRADE.W_DECOY * decoys,
+  );
+  return { composite, terms: { length, accuracy, tempo, decoys }, sLen };
+}
+
+/** Declared gates: an S requires a class with no encore (the dossier's rule). */
+export function hardGates(encoreUsed) {
+  return { sGate: !encoreUsed };
+}
+
+/** +3 per cleared length above the tier's par, cap 15. */
+export function flavorXp(bestLen, gradeTier) {
+  const tier = tierOf(gradeTier);
+  const par = GRADE.PAR_LEN[tier];
+  const best = Math.max(0, Math.floor(Number(bestLen) || 0));
+  return Math.min(GRADE.FLAVOR_CAP, Math.max(0, best - par) * GRADE.FLAVOR_PER_LEN);
+}
+
+export default { compositeFor, hardGates, flavorXp, GRADE, clamp01 };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
@@ -1,0 +1,1620 @@
+/* ============================================================================
+ * games/echo/index.js - ECHO (Simon; family: memory; Semester II, 105s).
+ *
+ * Six pads in a ring. The room plays a sequence - each pad lights and sounds
+ * its own note - and you play it back. Clear it and the sequence grows by one.
+ * Miss and the room simply deals another one: ONE FAIL IS NOT THE CLASS. The
+ * class ends on the bell, and it is graded on the longest echo you held, how
+ * clean you were, how well you kept tempo, and how many lies you refused.
+ *
+ * THE ROUND (pinned by the Semester II/III contract):
+ *   deal      a sequence of `len` from this attempt's seeded stream
+ *   echo      the ring plays it: pad lights + ONE engine audio_trigger recipe
+ *             at the pad's own pitch; a DECOY may light at a seam (tier 2+)
+ *   seam      the interference beat - engine.beat(), sub_flash word blips,
+ *             the input pressure comes up (tier 2+)
+ *   input     tap or the declared pad1..pad6 verbs; every clean press ratchets
+ *             the pitch +1 semitone (cap 7) so a good run becomes a melody
+ *   clear     len + 1, a reward roll, the streak meter
+ *   fail      the correct pad shows itself, then EITHER the ENCORE (once per
+ *             class: the SAME sequence again at half tempo) or a new sequence
+ *             at max(startLen, len - 2)
+ *   bell      the real budget. Dim out, end card, endClass exactly once.
+ *
+ * THE WARM START (the critic's top fix, contract ruling 5). Simon's structural
+ * flaw is that every class restarts at 3. Echo opens at
+ * clamp(3 + floor(gameMeta.bestLen / 4), 3, 6) + a per-tier bonus, so a
+ * veteran never plays the trivial opening and a first class still opens at 3.
+ *
+ * LAWS THIS FILE KEEPS:
+ *   I    the ledger is honest - length, presses, latency, decoys and the clock
+ *        are computed HERE and never routed through a deck. The trickster may
+ *        lie on a chip FACE or a pad's WORD; the pad's GLYPH and its data-pad
+ *        are truth and are repainted.
+ *   II   a pad's hitbox never moves and the key under the finger never moves;
+ *        every engine one-shot over the ring is decoration (fireSafe() welds
+ *        clickSafe on, bubbles are never poppable here).
+ *   III  something always breathes: the ambient field runs from the first beat.
+ *   IV   the class-rules sheet is DRAWN, GO-only, and honours ctx.hideTutorial
+ *        with a once-per-grade-tier memory in gameMeta.howtoTiers (IC's policy).
+ *   V    stream, decoy plan, casino, trickster and pressure are all scoped off
+ *        the class seed; a retake replays the identical class.
+ *   VI   pause / resume / suspend / destroy: the timer registry defers, the
+ *        decks ride it, no timer survives destroy, every listener is removed.
+ *   VII  every visible string is ctx.lexicon(key, fallback) over lex.js EC_LEX.
+ *
+ * ctx.audioAudible === false is a FIRST-CLASS MODE here, not an afterthought:
+ * Echo is the one class that can be played by ear, so when the ear is gone the
+ * LIGHT has to carry the whole signal - pads light SILENT_LIT_MULT longer, the
+ * stage wears data-audible="0" for the creative's stronger tell, and the
+ * proctor says so once.
+ *
+ * WHAT THIS FILE DOES NOT OWN: grades (core/grades.js via ctx.endClass), XP
+ * (C#), the tier (registry + meta), effect strengths (the engine's ceiling
+ * rule), the LOOK (style.js), the lighting (casino.js), the lies
+ * (trickster.js) and the CCP-effects ladder (pressure.js). The pure model is
+ * sequence.js and the composite grade.js.
+ *
+ * ENGINE TARGETING NOTE: glitch_swap adds `.ae-glitch{position:relative;
+ * animation}` to its targets, so it may never touch a `.g-ec-pad` (style.js
+ * owns the pad's transform and the ring's geometry). The decoy shudder targets
+ * the pad's FACE nodes (`.g-ec-face` children), never the pad itself.
+ * ==========================================================================*/
+
+import { injectEchoStyle } from './style.js';
+import { createEcCasino } from './casino.js';
+import { createEcTrickster } from './trickster.js';
+import { createEcPressure } from './pressure.js';
+import { EC_LEX } from './lex.js';
+import {
+  PLAYTEST, alphabetFor, warmStartLen, nextLenAfterFail, stepMsFor, litMsFor,
+  audioCeilFor, pitchFor, ratchetAfterMiss, isNearMiss, heatFor, buildRound,
+} from './sequence.js';
+import { compositeFor, hardGates, flavorXp } from './grade.js';
+import { makeRng, makeTaggedRoll, shuffled } from '../../core/rng.js';
+
+const GAME_KEY = 'echo';
+
+/** A url an <img> cannot show (a webm/mp4 loop). Mirrors engine/util.js
+ *  VIDEO_URL_RE; games never import the engine, so the rule is repeated. */
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+
+/** The truthful pad glyphs (Law IV: the glyph never lies, the word may).
+ *  Six shapes that read at a glance and carry no meaning of their own. */
+const GLYPHS = Object.freeze(['◆', '●', '▲', '■', '★', '✦']);
+
+/** The pad tone. ONE recipe, six pitches (sequence.js PAD_SEMIS).
+ *  `sting` is shell/audio.js's triangle 440->520 / 140ms - musical enough to
+ *  ratchet. If the orchestrator lands the requested dedicated `pad` recipe,
+ *  this ONE line adopts it (an unknown name degrades to `blip`, never to
+ *  silence - web CLAUDE.md trap 18). */
+const PAD_SFX = 'pad';
+/** The decoy's own cue at the TELEGRAPHED tiers only. At tier 3+ a decoy
+ *  sounds exactly like a real step - that is the whole point of the trap. */
+const DECOY_SFX = 'glitch';
+const FAIL_SFX = 'bump';
+const CLEAR_SFX = 'streak';
+
+/** The pad-face setting. */
+const FACE_MODES = Object.freeze(['words', 'glyphs']);
+
+/** How often the honest window ring repaints (the trickster polls it). */
+const WINDOW_TICK_MS = 60;
+
+/* Diagnostics seams (the DV / DE precedent): the live class, the last report,
+ * the final snapshot. The shell never reads these; the harness does. */
+let liveClass = null;
+let lastReport = null;
+let lastSnapshot = null;
+
+/** Test seam: the scratch harness compresses the clock. Production = 1. */
+let timeScale = 1;
+export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
+export function getTimeScale() { return timeScale; }
+function scaled(ms) { return Math.max(0, Math.round(ms * timeScale)); }
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** Reduced motion from the shell's projection first, then the two probes. */
+function probeReduced(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof document !== 'undefined' && document.documentElement
+      && document.documentElement.classList
+      && document.documentElement.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+function mmss(secLeft) {
+  const s = Math.max(0, secLeft | 0);
+  return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+}
+
+/** A pool word, trimmed to something a pad can wear. Never a lexicon row. */
+function padWordOf(raw) {
+  const s = String(raw == null ? '' : raw).trim();
+  if (!s) return '';
+  return s.length > 12 ? s.slice(0, 12) : s;
+}
+
+export default {
+  key: GAME_KEY,
+  family: 'memory',
+  meaty: false,
+  flagship: false,
+  timeBudgetSec: 105,
+  title: 'Echo',
+
+  manifest: {
+    /* audio_trigger is the mechanic here, not a garnish: the pad tones ARE the
+     * second half of the signal. Everything else is the tier's dials. */
+    effectsConsumed: [
+      'audio_trigger', 'wash', 'sub_flash', 'glitch_swap',
+      'flash_burst', 'ambient_field', 'bubble_field', 'gif_burst',
+    ],
+    /* Six loops (one pad face each) + six stills; pads are DOM and nothing is
+     * drawn into a canvas, so the provider may serve remote media here. */
+    assetNeeds: { loops: 6, targets: 0, stills: 6, canvasSafe: false },
+    boardSizes: null,
+    /* SYNTHESIS #7: the game DECLARES the verb slots, the shell owns the UI,
+     * the storage and the panic-key conflict check. ctx.keys.on('pad3', fn). */
+    keybinds: [
+      { verb: 'pad1', label_key: 'ec_key_pad1', default: '1' },
+      { verb: 'pad2', label_key: 'ec_key_pad2', default: '2' },
+      { verb: 'pad3', label_key: 'ec_key_pad3', default: '3' },
+      { verb: 'pad4', label_key: 'ec_key_pad4', default: '4' },
+      { verb: 'pad5', label_key: 'ec_key_pad5', default: '5' },
+      { verb: 'pad6', label_key: 'ec_key_pad6', default: '6' },
+    ],
+    settings: [
+      {
+        key: 'ec_pad_words', kind: 'enum', values: FACE_MODES.slice(), default: 'words',
+        label_key: 'ec_pad_words', hint_key: 'ec_pad_words_hint',
+      },
+    ],
+    peek: false,
+  },
+
+  create(ctx) {
+    const t = (key, fallback) => {
+      const fb = fallback == null ? (EC_LEX[key] == null ? key : EC_LEX[key]) : fallback;
+      try { const v = ctx.lexicon(key, fb); return v == null ? fb : v; } catch (e) { return fb; }
+    };
+    const say = (m) => { try { ctx.log('[ec] ' + m); } catch (e) { /* noop */ } };
+
+    /* ---- lifecycle flags ------------------------------------------------ */
+    let dead = false;
+    let paused = false;
+    let ended = false;
+    let reported = false;
+    let busy = true;                    // input closed (briefing / playback / holds)
+
+    /* ---- class state ---------------------------------------------------- */
+    let spec = null;
+    let seed = '';
+    let tier = 1;
+    let reduced = false;
+    let retake = false;
+    let audible = true;
+    let budgetMs = 105000;
+    let pool = null;
+    let rollLocal = null;
+    let subRoll = null;                 // the seeded sub_flash word stream
+
+    let casino = null;
+    let trickster = null;
+    let pressure = null;
+
+    /* ---- the round ------------------------------------------------------ */
+    let attempt = 0;                    // the seeded stream index
+    let startLen = 3;
+    let curLen = 3;
+    let round = null;                   // sequence.js buildRound() output
+    let stepIdx = 0;                    // playback cursor
+    let expectIdx = 0;                  // input cursor
+    let inputOpen = false;
+    let encoreArmed = true;             // once per class
+    let encoreUsed = false;
+    let inEncore = false;
+    let ratchet = 0;
+
+    /* ---- the ledger (Law I) --------------------------------------------- */
+    let bestLen = 0;                    // longest CLEARED echo this class
+    let bestReach = 0;                  // deepest correct index in any sequence
+    let lifetimeBefore = 0;
+    let sequencesDealt = 0;
+    let sequencesCleared = 0;
+    let fails = 0;
+    let timeouts = 0;
+    let presses = 0;
+    let correctPresses = 0;
+    let pressStreak = 0;                // clean presses in a row (the ratchet)
+    let bestStreak = 0;
+    let clearStreak = 0;
+    let decoysPresented = 0;
+    let decoysResisted = 0;
+    let decoysTaken = 0;
+    let latencySum = 0;
+    let latencyCount = 0;
+    let jackpots = 0;
+    let nearMisses = 0;
+    let subFlashes = 0;
+    let currentHeat = 0;
+    let bellOn = false;
+    let stallMs = 0;
+    let lastPressAt = 0;
+    let newRecord = false;
+
+    /* ---- pads / faces --------------------------------------------------- */
+    let faceMode = 'words';             // ec_pad_words, after the empty-pool rule
+    const padWords = [];                // index -> the word a pad wears (truth)
+    const faceUrls = new Map();         // pad -> {url, kind} | {broken:true}
+    let faceKind = 'loop';
+    let faceLogged = false;
+
+    /* ---- dom ------------------------------------------------------------ */
+    let stage = null; let backdrop = null; let hud = null; let ring = null;
+    let msgEl = null; let well = null; let endEl = null; let howtoEl = null;
+    let lenChip = null; let clockChip = null; let streakChip = null; let bestChip = null;
+    /* THE WINDOW RING: the honest face of the soft input timer (tier 3+ only).
+     * CORE writes `--ec-k` 1 -> 0 on it and NOTHING else; the trickster's
+     * Crooked Clock paints a BENT twin over it and the real one underneath is
+     * never touched (Law I). At the untimed tiers the node simply never
+     * appears and the card folds itself. */
+    let timerEl = null;
+    const padEls = [];
+    const padTimers = new Map();        // pad -> the timer that un-lights it
+
+    /* ---- clock ---------------------------------------------------------- */
+    let clockId = 0;
+    let lastTick = 0;
+    let elapsedMs = 0;
+
+    /* ---- ambience ------------------------------------------------------- */
+    let washOn = false;
+    let bubblesOn = false;
+    let ambientOn = false;
+
+    /* ==================================================================== *
+     * TIMERS - every step goes through run() so a suspend freezes the class
+     * mid-playback and a resume finishes it. `every` simply skips while paused.
+     * (The Deep End's registry, verbatim in shape - the decks ride it too.)
+     * ==================================================================== */
+    const timers = new Map();
+    let nextTimerId = 1;
+    const deferred = [];
+    function run(fn) {
+      if (dead) return;
+      if (paused) { deferred.push(fn); return; }
+      try { fn(); } catch (e) { say('step failed: ' + ((e && e.message) || e)); }
+    }
+    function after(ms, fn) {
+      const id = nextTimerId++;
+      const h = setTimeout(() => { timers.delete(id); run(fn); }, scaled(ms));
+      timers.set(id, { kind: 'after', h });
+      return id;
+    }
+    function every(ms, fn) {
+      const id = nextTimerId++;
+      const h = setInterval(() => {
+        if (dead || paused) return;
+        try { fn(); } catch (e) { say('tick failed: ' + ((e && e.message) || e)); }
+      }, Math.max(4, scaled(ms)));
+      timers.set(id, { kind: 'every', h });
+      return id;
+    }
+    function clearTimer(id) {
+      const rec = timers.get(id);
+      if (!rec) return;
+      if (rec.kind === 'after') clearTimeout(rec.h); else clearInterval(rec.h);
+      timers.delete(id);
+    }
+    function clearTimers() {
+      for (const id of Array.from(timers.keys())) clearTimer(id);
+      timers.clear();
+      deferred.length = 0;
+    }
+    /** The decks' registry: this class's own pause-aware timers. */
+    const deckTimers = { after, every, clear: clearTimer };
+
+    /* ==================================================================== *
+     * ENGINE - one wrapper, the input-trust law and the tier's audio ceiling
+     * welded on (the contract's deckEngine weld).
+     * ==================================================================== */
+    function fireSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'flash_burst' || kind === 'gif_burst') {
+        /* DECISIONS #9: the ring is a tap-precision surface, so every burst
+         * over it is pointer-events:none decoration and never poppable. */
+        o.clickSafe = true;
+        o.clickable = false;
+        delete o.onPop;
+      }
+      if (kind === 'audio_trigger') {
+        const ceil = audioCeilFor(tier);
+        o.level = Math.min(ceil, o.level == null ? 0.4 : Number(o.level) || 0);
+        /* `pitch` is a pass-through (engine/oneshots.js forwards it and
+         * shell/audio.js owns the 0.5..2 clamp) - we never clamp it twice. */
+      }
+      try { return ctx.engine.fire(kind, o) || null; } catch (e) { say('fire(' + kind + ') failed'); return null; }
+    }
+    function sustainSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'bubble_field') { o.clickSafe = true; delete o.onPop; }
+      try { return ctx.engine.sustain(kind, o) || null; } catch (e) { return null; }
+    }
+    function stopSafe(kind) { try { if (ctx.engine) ctx.engine.stop(kind); } catch (e) { /* noop */ } }
+    function beatSafe(opts) { try { if (ctx.engine && ctx.engine.beat) ctx.engine.beat(opts || {}); } catch (e) { /* noop */ } }
+    function ceremonySafe(kind, opts) {
+      if (dead || !ctx.engine || typeof ctx.engine.ceremony !== 'function') return null;
+      try { return ctx.engine.ceremony(kind, opts || {}) || null; } catch (e) { return null; }
+    }
+    /** The engine, as a deck sees it: the welded primitives plus a READ of the
+     *  clamped channel vector (THE CEILING RULE - a deck asks, never raises). */
+    const deckEngine = {
+      fire: fireSafe,
+      sustain: sustainSafe,
+      stop: stopSafe,
+      beat: beatSafe,
+      ceremony: ceremonySafe,
+      channels: () => {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** The player's own media, as a deck sees it. The pool lands ASYNC, so a
+     *  deck gets a LIVE reader rather than the pool object. */
+    const deckAssets = {
+      next(kind) {
+        try { return (pool && typeof pool.next === 'function') ? (pool.next(kind) || null) : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** bgIntensity 0 is the player's exit: read it LIVE, never a snapshot. */
+    function capsArmed() { return !(ctx.caps && Number(ctx.caps.bgIntensity) === 0); }
+
+    /** A pad tone (or any cue) through the engine, at the tier's ceiling. */
+    function tone(name, level, pitch, extra) {
+      return fireSafe('audio_trigger', Object.assign(
+        { name, level: level == null ? 0.4 : level },
+        pitch != null ? { pitch } : {},
+        extra || {},
+      ));
+    }
+    /** Deck IV's haptics hook: one call per rung, silent where there is no hardware. */
+    function haptic(ms) {
+      try {
+        if (!ctx.platform || !ctx.platform.hasHaptics) return;
+        if (typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') return;
+        navigator.vibrate(Math.max(4, Math.min(40, Number(ms) || 10)));
+      } catch (e) { /* a haptic must never be the thing that fails */ }
+    }
+
+    /* ---- the decks, null-safe ------------------------------------------- */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); }
+      catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+
+    /* ==================================================================== *
+     * HEAT - the class's own ladder is the sequence length; gradeTier caps it.
+     * ==================================================================== */
+    function heat() {
+      const h = heatFor(curLen, tier, startLen, pressStreak);
+      currentHeat = h;
+      try { if (ctx.engine) ctx.engine.setHeat(h); } catch (e) { /* engine is optional */ }
+      deck('casino', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+      /* The RUNG rides the ladder (the sequence length), the MAGNITUDE rides
+       * heat - and this is the one place both are known. The second argument
+       * is additive: a deck that declared setStreak(n) simply ignores it. */
+      deck('pressure', 'setStreak', curLen, { links: pressStreak, cleared: clearStreak, heat: h });
+    }
+
+    /* ==================================================================== *
+     * DOM (the contract's exact shape)
+     * ==================================================================== */
+    function setPhase(p) { if (stage) stage.setAttribute('data-phase', p); }
+    function phase() { return stage ? stage.getAttribute('data-phase') : null; }
+    function msg(key, fallback) {
+      if (!msgEl) return;
+      msgEl.textContent = t(key, fallback);
+    }
+
+    function buildDom() {
+      const root = ctx.root;
+      root.textContent = '';
+      stage = el('div', 'g-ec-stage');
+      stage.setAttribute('data-phase', 'briefing');
+      stage.setAttribute('data-tier', String(tier));
+      stage.setAttribute('data-faces', faceMode);
+      /* The audio tell is a STAGE attribute so style.js can make the light
+       * carry the whole signal when the ear cannot (ctx.audioAudible). */
+      stage.setAttribute('data-audible', audible ? '1' : '0');
+      if (reduced) stage.setAttribute('data-reduced', '1');
+
+      backdrop = el('div', 'g-ec-backdrop');
+      backdrop.setAttribute('aria-hidden', 'true');
+      backdrop.style.pointerEvents = 'none';
+      stage.appendChild(backdrop);
+
+      hud = el('div', 'g-ec-hud');
+      lenChip = el('span', 'g-ec-chip g-ec-len', '0');
+      lenChip.setAttribute('aria-label', t('ec_chip_len', EC_LEX.ec_chip_len));
+      clockChip = el('span', 'g-ec-chip g-ec-clock', clockText());
+      clockChip.setAttribute('aria-label', t('ec_chip_clock', EC_LEX.ec_chip_clock));
+      streakChip = el('span', 'g-ec-chip g-ec-streak', 'x 0');
+      streakChip.setAttribute('aria-label', t('ec_chip_streak', EC_LEX.ec_chip_streak));
+      streakChip.hidden = true;
+      bestChip = el('span', 'g-ec-chip g-ec-best', '0');
+      bestChip.setAttribute('aria-label', t('ec_chip_best', EC_LEX.ec_chip_best));
+      hud.appendChild(lenChip);
+      hud.appendChild(clockChip);
+      hud.appendChild(streakChip);
+      hud.appendChild(bestChip);
+      timerEl = el('span', 'g-ec-chip g-ec-timer');
+      timerEl.setAttribute('aria-hidden', 'true');
+      timerEl.hidden = true;
+      hud.appendChild(timerEl);
+      if (retake) hud.appendChild(el('span', 'g-ec-chip g-ec-retake', t('ec_retake', EC_LEX.ec_retake)));
+      stage.appendChild(hud);
+
+      ring = el('div', 'g-ec-ring');
+      ring.setAttribute('role', 'group');
+      ring.setAttribute('aria-label', t('ec_ring_aria', EC_LEX.ec_ring_aria));
+      ring.style.setProperty('--ec-n', String(PLAYTEST.PADS));
+      padEls.length = 0;
+      for (let i = 0; i < PLAYTEST.PADS; i++) {
+        const pad = el('button', 'g-ec-pad');
+        pad.setAttribute('type', 'button');
+        try { pad.type = 'button'; } catch (e) { /* the DOM double has no button semantics */ }
+        pad.setAttribute('data-pad', String(i));
+        pad.setAttribute('data-state', 'idle');
+        pad.setAttribute('data-glyph', String(i));
+        pad.setAttribute('aria-label', t('ec_pad_aria', EC_LEX.ec_pad_aria).replace('{n}', String(i + 1)));
+        /* GEOMETRY IS THE CREATIVE'S. index.js only ever writes the vars: the
+         * pad's index, the ring's size and the unit-circle position of the
+         * slot. style.js owns every transform and transition. */
+        const ang = (-90 + (360 / PLAYTEST.PADS) * i);
+        pad.style.setProperty('--i', String(i));
+        pad.style.setProperty('--ang', String(ang) + 'deg');
+        pad.style.setProperty('--x', Math.cos(ang * Math.PI / 180).toFixed(4));
+        pad.style.setProperty('--y', Math.sin(ang * Math.PI / 180).toFixed(4));
+
+        const face = el('span', 'g-ec-face');
+        const media = el('img', 'g-ec-media');
+        armMedia(media, pad, false);
+        face.appendChild(media);
+        /* THE TRUTH NODE (Law IV + the Unreliable Label card): the glyph is
+         * what a pad IS. The word below it is decoration the trickster may
+         * borrow; the glyph never moves and is never re-written. */
+        face.appendChild(el('span', 'g-ec-glyph', GLYPHS[i] || ''));
+        pad.appendChild(face);
+        pad.appendChild(el('span', 'g-ec-word', ''));
+
+        pad.addEventListener('pointerdown', onPadDown);
+        pad.addEventListener('pointerup', onPadUp);
+        pad.addEventListener('pointerleave', onPadUp);
+        pad.addEventListener('pointercancel', onPadUp);
+        ring.appendChild(pad);
+        padEls.push(pad);
+      }
+      stage.appendChild(ring);
+
+      msgEl = el('p', 'g-ec-msg');
+      msgEl.setAttribute('aria-live', 'polite');
+      stage.appendChild(msgEl);
+
+      well = el('div', 'g-ec-flashwell');
+      well.setAttribute('aria-hidden', 'true');
+      well.style.pointerEvents = 'none';
+      stage.appendChild(well);
+
+      endEl = el('div', 'g-ec-end');
+      endEl.hidden = true;
+      stage.appendChild(endEl);
+
+      root.appendChild(stage);
+    }
+
+    /* ---- pad faces (Deck VI asset chrome) -------------------------------- */
+    function armMedia(node, pad, video) {
+      if (!node) return;
+      try {
+        node.setAttribute('alt', '');
+        node.setAttribute('draggable', 'false');
+        node.draggable = false;
+        if (video) {
+          node.muted = true; node.loop = true; node.autoplay = true; node.playsInline = true;
+          node.setAttribute('muted', ''); node.setAttribute('loop', ''); node.setAttribute('autoplay', '');
+          node.setAttribute('playsinline', ''); node.setAttribute('preload', 'auto');
+          node.addEventListener('loadeddata', () => {
+            if (dead) return;
+            pad.classList.add('is-loaded');
+            try { const p = node.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* ignore */ }
+          });
+        } else {
+          node.decoding = 'async';
+          node.addEventListener('load', () => { if (!dead) pad.classList.add('is-loaded'); });
+        }
+        node.addEventListener('error', () => { if (!dead) faceBroken(pad); });
+      } catch (e) { /* the double has no img semantics; fine */ }
+    }
+    function childOf(node, cls) {
+      try { for (const k of node.children || []) if (k.classList && k.classList.contains(cls)) return k; } catch (e) { /* ignore */ }
+      return null;
+    }
+    function faceNodeOf(pad) { return childOf(pad, 'g-ec-face'); }
+    function mediaOf(pad) { const f = faceNodeOf(pad); return f ? childOf(f, 'g-ec-media') : null; }
+    function wordNodeOf(pad) { return childOf(pad, 'g-ec-word'); }
+    function glyphNodeOf(pad) { const f = faceNodeOf(pad); return f ? childOf(f, 'g-ec-glyph') : null; }
+    /** The glitch_swap target set for a pad: the FACE's children, never the pad. */
+    function faceTargets(pad) {
+      const f = faceNodeOf(pad);
+      if (!f) return [];
+      const out = [];
+      try { for (const k of f.children || []) out.push(k); } catch (e) { /* ignore */ }
+      return out;
+    }
+    function mediaNodeFor(pad, url) {
+      const face = faceNodeOf(pad);
+      if (!face) return null;
+      const cur = childOf(face, 'g-ec-media');
+      const wantVideo = VIDEO_URL_RE.test(String(url || ''));
+      const isVideo = !!(cur && String(cur.tagName || '').toUpperCase() === 'VIDEO');
+      if (cur && wantVideo === isVideo) return cur;
+      const next = el(wantVideo ? 'video' : 'img', 'g-ec-media');
+      armMedia(next, pad, wantVideo);
+      try {
+        if (cur && typeof face.replaceChild === 'function') face.replaceChild(next, cur);
+        else face.appendChild(next);
+      } catch (e) { try { face.appendChild(next); } catch (e2) { /* ignore */ } }
+      return next;
+    }
+    function faceBroken(pad) {
+      const i = Number(pad && pad.getAttribute('data-pad'));
+      pad.classList.remove('is-loaded');
+      if (i >= 0) {
+        faceUrls.set(i, { broken: true });
+        say('faces: pad ' + i + ' media failed - plain face for the class');
+      }
+    }
+    /** One url per pad, dealt once and frozen for the class. */
+    function dressFaces() {
+      if (!pool || typeof pool.next !== 'function') return;
+      for (let i = 0; i < padEls.length; i++) {
+        const have = faceUrls.get(i);
+        if (have) continue;
+        let got = null;
+        try { got = pool.next(faceKind); } catch (e) { got = null; }
+        const url = got && got.url ? String(got.url) : null;
+        if (!url) continue;
+        faceUrls.set(i, { url, kind: faceKind });
+        const pad = padEls[i];
+        const media = mediaNodeFor(pad, url) || mediaOf(pad);
+        pad.classList.remove('is-loaded');
+        try { if (media) media.src = url; } catch (e) { /* ignore */ }
+      }
+      if (!faceLogged && faceUrls.size) {
+        faceLogged = true;
+        say('faces: ' + faceKind + ' on ' + faceUrls.size + ' pads');
+      }
+    }
+
+    /* ---- pad words (may be EMPTY - the glyph fallback is designed in) ---- */
+    function assignWords() {
+      padWords.length = 0;
+      const want = String(ctx.settings && ctx.settings.ec_pad_words != null ? ctx.settings.ec_pad_words : 'words')
+        .trim().toLowerCase();
+      faceMode = FACE_MODES.indexOf(want) >= 0 ? want : 'words';
+      let words = [];
+      try {
+        const src = Array.isArray(ctx.words) ? ctx.words : [];
+        const seen = new Set();
+        for (const w of src) {
+          const s = padWordOf(w);
+          if (!s || seen.has(s.toLowerCase())) continue;
+          seen.add(s.toLowerCase());
+          words.push(s);
+        }
+      } catch (e) { words = []; }
+      /* THE MAY-BE-EMPTY CONTRACT (the dossier's mod-agnosticism proof): with
+       * fewer than six distinct words the pads wear glyphs only, and the whole
+       * mechanic still runs. No half-worded ring - that reads as a bug. */
+      if (faceMode === 'words' && words.length < PLAYTEST.PADS) {
+        faceMode = 'glyphs';
+        say('pad words: only ' + words.length + ' in the pool - glyph faces (the mechanic is unchanged)');
+      }
+      if (faceMode === 'words') {
+        const picked = shuffled(words, makeRng(seed + '|ec-words')).slice(0, PLAYTEST.PADS);
+        for (let i = 0; i < PLAYTEST.PADS; i++) padWords.push(picked[i] || '');
+      } else {
+        for (let i = 0; i < PLAYTEST.PADS; i++) padWords.push('');
+      }
+      if (stage) stage.setAttribute('data-faces', faceMode);
+      paintWords();
+    }
+    /** THE TRUTH on every pad word (the trickster's Unreliable Label restores
+     *  exactly this string; the glyph it can never touch). */
+    function paintWords() {
+      for (let i = 0; i < padEls.length; i++) {
+        const w = wordNodeOf(padEls[i]);
+        if (w && w.textContent !== (padWords[i] || '')) w.textContent = padWords[i] || '';
+      }
+    }
+    function padWordText(i) { return padWords[i] || ''; }
+
+    /* ---- HUD paint (truth) ---------------------------------------------- */
+    function secLeft() { return Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)); }
+    function clockText() { return mmss(secLeft()); }
+    function lenText() { return String(curLen); }
+    function bestText() { return String(Math.max(bestLen, lifetimeBefore)); }
+    /** What the trickster's Stat Flicker restores after a lie. */
+    function chipText(which) {
+      if (which === 'clock') return clockText();
+      if (which === 'best') return bestText();
+      if (which === 'streak') return 'x ' + pressStreak;
+      return lenText();
+    }
+    function paintHud() {
+      if (clockChip) clockChip.textContent = clockText();
+      if (lenChip) lenChip.textContent = lenText();
+      if (bestChip) bestChip.textContent = bestText();
+      paintStreak();
+    }
+    function paintStreak() {
+      if (!streakChip) return;
+      if (pressStreak < PLAYTEST.STREAK_VISIBLE) {
+        streakChip.hidden = true;
+        streakChip.textContent = 'x ' + pressStreak;
+        return;
+      }
+      streakChip.hidden = false;
+      streakChip.textContent = 'x ' + pressStreak;
+      /* The meter is the SHELL's primitive (10 segments, always); it rides
+       * inside the chip so the contract's DOM gains no extra node. */
+      try {
+        const meter = ctx.ceremonies.streakMeter({
+          filled: Math.min(PLAYTEST.STREAK_CAP, pressStreak),
+          gold: ratchet >= PLAYTEST.RATCHET_CAP,
+        });
+        if (meter) streakChip.appendChild(meter);
+      } catch (e) { /* a ceremony must never be the thing that fails */ }
+    }
+
+    /* ==================================================================== *
+     * THE PADS - lighting and state. `data-state` is the contract's enum:
+     * idle | lit | pressed | decoy. Nothing else is ever written to it.
+     * ==================================================================== */
+    function padState(i, state, holdMs) {
+      const pad = padEls[i];
+      if (!pad) return;
+      const prev = padTimers.get(i);
+      if (prev) { clearTimer(prev); padTimers.delete(i); }
+      pad.setAttribute('data-state', state);
+      if (holdMs > 0) {
+        const id = after(holdMs, () => {
+          padTimers.delete(i);
+          const p = padEls[i];
+          if (p && p.getAttribute('data-state') === state) p.setAttribute('data-state', 'idle');
+        });
+        padTimers.set(i, id);
+      }
+    }
+    function clearPads() {
+      for (const id of Array.from(padTimers.values())) clearTimer(id);
+      padTimers.clear();
+      for (const pad of padEls) if (pad) pad.setAttribute('data-state', 'idle');
+    }
+
+    /* ==================================================================== *
+     * INPUT - tap or the declared pad verbs. Law II: the hitbox is the pad's
+     * own, nothing decorative sits over it, and a press outside an input turn
+     * is IGNORED (never a fail: the player is not being punished for a reflex
+     * during the machine's own turn).
+     * ==================================================================== */
+    const keyOffs = [];
+    let heldByKey = new Set();
+
+    function padIndexOf(node) {
+      let n = node;
+      let guard = 0;
+      while (n && guard < 6) {
+        try {
+          if (n.classList && n.classList.contains('g-ec-pad')) {
+            const i = Number(n.getAttribute('data-pad'));
+            return Number.isFinite(i) ? i : -1;
+          }
+        } catch (e) { /* ignore */ }
+        n = n.parentNode;
+        guard += 1;
+      }
+      return -1;
+    }
+    function onPadDown(e) {
+      const i = padIndexOf(e && (e.currentTarget || e.target));
+      if (i < 0) return;
+      try { if (e && typeof e.preventDefault === 'function') e.preventDefault(); } catch (err) { /* noop */ }
+      press(i, 'tap');
+    }
+    function onPadUp(e) {
+      const i = padIndexOf(e && (e.currentTarget || e.target));
+      if (i < 0) return;
+      releaseVisual(i);
+    }
+    /** A press that is not a sequence step still pays a tick (Deck IV: a verb
+     *  with no sensory echo is a broken slot handle) - but it moves nothing. */
+    function press(i, how) {
+      if (dead || paused || ended) return;
+      if (!inputOpen) {
+        padState(i, 'pressed', reduced ? 90 : 130);
+        tone(PAD_SFX, 0.16, pitchFor(i, 0));
+        return;
+      }
+      commit(i, how);
+    }
+    function releaseVisual(i) {
+      const pad = padEls[i];
+      if (!pad) return;
+      if (pad.getAttribute('data-state') === 'pressed' && !padTimers.has(i)) {
+        pad.setAttribute('data-state', 'idle');
+      }
+    }
+
+    function bindInput() {
+      /* SYNTHESIS #7: never a raw key - the shell owns the binding, the
+       * conflict check and the panic key. The ':up' twin only clears the
+       * pressed LOOK, so a held key cannot double-commit. */
+      for (let i = 0; i < PLAYTEST.PADS; i++) {
+        const verb = 'pad' + (i + 1);
+        const idx = i;
+        try {
+          keyOffs.push(ctx.keys.on(verb, () => {
+            if (heldByKey.has(idx)) return;
+            heldByKey.add(idx);
+            press(idx, 'key');
+          }));
+          keyOffs.push(ctx.keys.on(verb + ':up', () => {
+            heldByKey.delete(idx);
+            releaseVisual(idx);
+          }));
+        } catch (e) { say('keybind ' + verb + ' refused: ' + ((e && e.message) || e)); }
+      }
+    }
+    function unbindInput() {
+      for (const off of keyOffs.splice(0)) { try { off(); } catch (e) { /* noop */ } }
+      heldByKey = new Set();
+      for (const pad of padEls) {
+        if (!pad) continue;
+        try {
+          pad.removeEventListener('pointerdown', onPadDown);
+          pad.removeEventListener('pointerup', onPadUp);
+          pad.removeEventListener('pointerleave', onPadUp);
+          pad.removeEventListener('pointercancel', onPadUp);
+        } catch (e) { /* noop */ }
+      }
+    }
+
+    /* ==================================================================== *
+     * THE ROUND
+     * ==================================================================== */
+    function dealSequence(len) {
+      if (dead || ended) return;
+      const want = Math.max(PLAYTEST.WARM_MIN, Math.min(PLAYTEST.MAX_LEN, Math.floor(len)));
+      curLen = want;
+      inEncore = false;
+      if (stage) stage.removeAttribute('data-encore');
+      round = buildRound({ seed, gradeTier: tier, attempt, len: want, encore: false });
+      sequencesDealt += 1;
+      expectIdx = 0;
+      stepIdx = 0;
+      clearPads();
+      paintWords();
+      paintHud();
+      heat();
+      setPhase('play');
+      /* TIER 2 TELEGRAPHS THE DECOY (SYNTHESIS #2 - the signature twist enters
+       * at tier 2, announced; tier 3+ says nothing at all). */
+      const telegraphed = round.decoys.some((d) => d.telegraph);
+      if (telegraphed) {
+        msg('ec_msg_decoy_warn', EC_LEX.ec_msg_decoy_warn);
+        if (stage) stage.setAttribute('data-telegraph', '1');
+      } else {
+        if (stage) stage.removeAttribute('data-telegraph');
+        msg('ec_msg_watch', EC_LEX.ec_msg_watch);
+      }
+      after(telegraphed ? (reduced ? 600 : 900) : (reduced ? 240 : 380), () => startPlayback());
+    }
+
+    /** Replay the SAME sequence at half tempo. Once per class (ruling 5). */
+    function startEncore() {
+      if (dead || ended) return;
+      encoreArmed = false;
+      encoreUsed = true;
+      inEncore = true;
+      round = buildRound({ seed, gradeTier: tier, attempt, len: curLen, encore: true });
+      expectIdx = 0;
+      stepIdx = 0;
+      clearPads();
+      paintHud();
+      setPhase('encore');
+      if (stage) stage.setAttribute('data-encore', '1');
+      msg('ec_msg_encore', EC_LEX.ec_msg_encore);
+      deck('casino', 'encore', true);
+      after(reduced ? 500 : 800, () => startPlayback());
+    }
+
+    function startPlayback() {
+      if (dead || ended || !round) return;
+      busy = true;
+      inputOpen = false;
+      stepIdx = 0;
+      setPhase(inEncore ? 'encore' : 'echo');
+      if (!audible && sequencesDealt <= 1) msg('ec_msg_silent', EC_LEX.ec_msg_silent);
+      else if (!inEncore) msg('ec_msg_watch', EC_LEX.ec_msg_watch);
+      playStep();
+    }
+
+    function playStep() {
+      if (dead || ended || !round) return;
+      if (stepIdx >= round.steps.length) { after(round.stepMs, () => seam()); return; }
+      const step = round.steps[stepIdx];
+      const i = stepIdx;
+      stepIdx += 1;
+      const lit = litMsFor(round.stepMs, { silent: !audible });
+      if (step.decoy) {
+        padState(step.pad, 'decoy', lit);
+        /* THE DECOY. At the telegraphed tiers it wears its own cue and a
+         * shudder so the player can learn the shape of the trap; at tier 3+ it
+         * is indistinguishable from a real step - same state class, same tone,
+         * same length - and only the SEQUENCE tells you it does not belong. */
+        if (step.telegraph) {
+          tone(DECOY_SFX, 0.3, 1);
+          if (!reduced) {
+            const targets = faceTargets(padEls[step.pad]);
+            if (targets.length) fireSafe('glitch_swap', { targets, seconds: 0.4, sfx: false, onSwap: () => {} });
+          }
+        } else {
+          tone(PAD_SFX, 0.34, pitchFor(step.pad, ratchet));
+        }
+        deck('casino', 'padLit', step.pad, i, round.len);
+      } else {
+        padState(step.pad, 'lit', lit);
+        tone(PAD_SFX, 0.34, pitchFor(step.pad, ratchet));
+        deck('casino', 'padLit', step.pad, step.index, round.len);
+      }
+      after(round.stepMs, () => playStep());
+    }
+
+    /** THE INTERFERENCE BEAT: the seam between playback and input is the
+     *  Distraction Engine's, and only the engine's - it never moves a hitbox. */
+    function seam() {
+      if (dead || ended || !round) return;
+      beatSafe();
+      deck('trickster', 'afterPlayback');
+      deck('pressure', 'beat', 'seam');
+      /* Tier 2+: sub_flash word blips, deliberately drawn from the PAD words
+       * so the distraction is semantically confusable with the signal. The
+       * engine owns the alpha; we only choose the text. */
+      if (tier >= 2 && capsArmed()) {
+        const w = padWords.filter(Boolean);
+        const pick = w.length && subRoll ? w[Math.floor(subRoll('word') * w.length) % w.length] : null;
+        const r = fireSafe('sub_flash', Object.assign(
+          { anchor: well, variant: tier >= 3 ? 'scatter' : 'whisper' },
+          pick ? { text: pick } : {},
+        ));
+        if (r) subFlashes += 1;
+      }
+      after(reduced ? PLAYTEST.SEAM_MS_REDUCED : PLAYTEST.SEAM_MS, () => openInput());
+    }
+
+    function openInput() {
+      if (dead || ended || !round) return;
+      setPhase('input');
+      msg('ec_msg_input', EC_LEX.ec_msg_input);
+      busy = false;
+      inputOpen = true;
+      /* A key whose ':up' never arrived (focus loss, a suspend mid-hold) must
+       * never lock its pad out of the next turn. */
+      try { heldByKey.clear(); } catch (e) { heldByKey = new Set(); }
+      stallMs = 0;
+      lastPressAt = Date.now();
+      armInputWindow();
+      /* Tier 2+ pressure DURING the input turn (the dossier's ladder). Every
+       * one of these is decoration over a tap surface (fireSafe / sustainSafe
+       * weld clickSafe on) - Law II is never spent for a garnish. */
+      if (capsArmed()) {
+        if (tier >= 2 && !bubblesOn) { bubblesOn = !!sustainSafe('bubble_field', { variant: 'drift', max: 8 }); }
+        if (tier >= 3 && !reduced) { sustainSafe('wash', { variant: 'pink', holdMs: 900 }); washOn = true; }
+      }
+    }
+
+    let windowTimer = 0;
+    let windowTick = 0;
+    let windowUntil = 0;
+    function armInputWindow() {
+      if (windowTimer) { clearTimer(windowTimer); windowTimer = 0; }
+      if (!round || !round.windowMs) return;
+      windowUntil = Date.now() + round.windowMs;
+      if (timerEl) {
+        timerEl.hidden = false;
+        try { timerEl.style.setProperty('--ec-k', '1'); } catch (e) { /* noop */ }
+      }
+      if (!windowTick) windowTick = every(WINDOW_TICK_MS, paintWindow);
+      windowTimer = after(round.windowMs, () => {
+        windowTimer = 0;
+        if (!inputOpen || dead || ended) return;
+        timeouts += 1;
+        fail(-1, 'timeout');
+      });
+    }
+    /** The TRUE remaining share of the window, 1 -> 0. The only writer. */
+    function paintWindow() {
+      if (!timerEl || !round || !round.windowMs || !inputOpen) return;
+      const k = Math.max(0, Math.min(1, (windowUntil - Date.now()) / round.windowMs));
+      try { timerEl.style.setProperty('--ec-k', k.toFixed(3)); } catch (e) { /* noop */ }
+    }
+    function disarmInputWindow() {
+      if (windowTimer) { clearTimer(windowTimer); windowTimer = 0; }
+      if (windowTick) { clearTimer(windowTick); windowTick = 0; }
+      windowUntil = 0;
+      if (timerEl) {
+        timerEl.hidden = true;
+        try { timerEl.style.setProperty('--ec-k', ''); } catch (e) { /* noop */ }
+      }
+    }
+
+    /** ONE press against the truth. Everything here is the ledger (Law I). */
+    function commit(i, how) {
+      if (!round || !inputOpen) return;
+      const now = Date.now();
+      const dt = Math.max(0, now - lastPressAt);
+      lastPressAt = now;
+      stallMs = 0;
+      presses += 1;
+      latencySum += dt;
+      latencyCount += 1;
+
+      /* THE DECOY TRAP: a decoy at this seam, and the finger landed on it. */
+      const bait = round.decoys.find((d) => d.afterIndex === expectIdx);
+      if (bait && bait.pad === i) {
+        decoysPresented += 1;
+        decoysTaken += 1;
+        padState(i, 'decoy', reduced ? 260 : 420);
+        deck('casino', 'padPressed', i, false, pressStreak);
+        fail(i, 'decoy');
+        return;
+      }
+
+      const want = round.seq[expectIdx];
+      if (want === i) {
+        correctPresses += 1;
+        pressStreak += 1;
+        bestStreak = Math.max(bestStreak, pressStreak);
+        ratchet = Math.min(PLAYTEST.RATCHET_CAP, ratchet + 1);
+        padState(i, 'pressed', reduced ? 140 : 200);
+        tone(PAD_SFX, 0.42, pitchFor(i, ratchet));
+        haptic(8);
+        deck('casino', 'padPressed', i, true, pressStreak);
+        /* The decoy at this seam was PRESENTED and REFUSED. The game says so:
+         * the dossier's resist-sparkle acknowledges the trap you dodged. */
+        if (bait) {
+          decoysPresented += 1;
+          decoysResisted += 1;
+          deck('casino', 'decoyResisted');
+          deck('trickster', 'afterInput');
+          if (decoysResisted === 1) msg('ec_msg_resisted', EC_LEX.ec_msg_resisted);
+        }
+        expectIdx += 1;
+        bestReach = Math.max(bestReach, expectIdx);
+        paintStreak();
+        deck('pressure', 'setStreak', curLen, { links: pressStreak, cleared: clearStreak, heat: currentHeat });
+        if (expectIdx >= round.seq.length) { clearRound(); return; }
+        armInputWindow();
+        deck('trickster', 'afterInput');
+        return;
+      }
+      padState(i, 'pressed', reduced ? 200 : 300);
+      deck('casino', 'padPressed', i, false, pressStreak);
+      fail(i, how === 'timeout' ? 'timeout' : 'wrong');
+    }
+
+    function clearRound() {
+      if (!round) return;
+      inputOpen = false;
+      busy = true;
+      disarmInputWindow();
+      const len = round.seq.length;
+      if (len > bestLen) { bestLen = len; if (bestLen > lifetimeBefore) newRecord = true; }
+      sequencesCleared += 1;
+      clearStreak += 1;
+      paintHud();
+      deck('casino', 'sequenceDone', len);
+      deck('pressure', 'beat', 'clear');
+      tone(CLEAR_SFX, 0.5, pitchFor(PLAYTEST.PADS - 1, ratchet));
+      haptic(18);
+      msg(inEncore ? 'ec_msg_encore_clear' : 'ec_msg_clear',
+        inEncore ? EC_LEX.ec_msg_encore_clear : EC_LEX.ec_msg_clear);
+      rewardBeat();
+      stopInputPressure();
+      const hold = reduced ? PLAYTEST.CLEAR_HOLD_MS_REDUCED : PLAYTEST.CLEAR_HOLD_MS;
+      after(hold, () => { if (!ended) dealSequence(len + 1); });
+    }
+
+    function fail(pressedPad, why) {
+      if (!round) return;
+      inputOpen = false;
+      busy = true;
+      disarmInputWindow();
+      fails += 1;
+      const len = round.seq.length;
+      const near = isNearMiss(expectIdx, len);
+      ratchet = ratchetAfterMiss(ratchet, expectIdx, len);
+      pressStreak = 0;
+      clearStreak = 0;
+      paintStreak();
+      deck('casino', 'fail', pressedPad, round.seq[expectIdx]);
+      deck('pressure', 'beat', 'fail');
+      deck('pressure', 'setStreak', curLen, { links: 0, cleared: 0, heat: currentHeat });
+      tone(FAIL_SFX, 0.4, 1);
+      stopInputPressure();
+      if (near) { nearMisses += 1; ceremonySafe('near_miss', {}); }
+      msg(why === 'timeout' ? 'ec_msg_timeout' : near ? 'ec_msg_near' : 'ec_msg_fail',
+        why === 'timeout' ? EC_LEX.ec_msg_timeout : near ? EC_LEX.ec_msg_near : EC_LEX.ec_msg_fail);
+      /* THE REVEAL: the pad you needed shows itself, softly, AFTER the commit -
+       * never during input (that would be a colour tell). */
+      const wanted = round.seq[expectIdx];
+      if (wanted != null) {
+        after(reduced ? 160 : 260, () => {
+          padState(wanted, 'lit', PLAYTEST.REVEAL_MS);
+          tone(PAD_SFX, 0.26, pitchFor(wanted, 0));
+        });
+      }
+      const hold = reduced ? PLAYTEST.FAIL_HOLD_MS_REDUCED : PLAYTEST.FAIL_HOLD_MS;
+      after(hold, () => {
+        if (ended || dead) return;
+        /* ONE FAIL IS NOT THE CLASS. The encore is the comeback hook (once),
+         * then the room simply deals a shorter one and keeps going. */
+        if (encoreArmed && !inEncore) { startEncore(); return; }
+        if (inEncore) {
+          msg('ec_msg_encore_fail', EC_LEX.ec_msg_encore_fail);
+          inEncore = false;
+          if (stage) stage.removeAttribute('data-encore');
+          deck('casino', 'encore', false);
+        } else {
+          msg('ec_msg_new', EC_LEX.ec_msg_new);
+        }
+        attempt += 1;                       // a fresh stream: a new melody
+        dealSequence(nextLenAfterFail(len, startLen));
+      });
+    }
+
+    /** The variable-ratio canon on a clear (the engine's, with a seeded local
+     *  fallback so a null engine still paces the class). */
+    function rewardBeat() {
+      let r = null;
+      try {
+        if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') r = ctx.engine.rewardRoll({}) || null;
+      } catch (e) { r = null; }
+      if (!r && rollLocal) r = rollLocal();
+      if (!r || !r.fire) return;
+      if (r.jackpot) {
+        jackpots += 1;
+        ceremonySafe('jackpot', {});
+        if (capsArmed()) fireSafe('flash_burst', { variant: 'scatter' });
+      } else {
+        if (capsArmed()) fireSafe('gif_burst', { variant: 'single' });
+      }
+    }
+
+    function stopInputPressure() {
+      if (bubblesOn) { stopSafe('bubble_field'); bubblesOn = false; }
+      /* NEVER stop('wash') mid-class (trap 33): a held wash is stepped DOWN by
+       * re-triggering it at a lower alpha, and the deadline does the rest. */
+      if (washOn && capsArmed()) { sustainSafe('wash', { variant: 'pink', alpha: 0.08, holdMs: 300 }); }
+    }
+
+    /* ==================================================================== *
+     * AMBIENCE (Law III: something always breathes)
+     * ==================================================================== */
+    function openAmbience() {
+      heat();
+      if (!capsArmed()) return;
+      if (!ambientOn) ambientOn = !!sustainSafe('ambient_field', { kind: tier >= 3 ? 'motes' : 'specks' });
+    }
+    function stopAmbience() {
+      for (const k of ['ambient_field', 'bubble_field', 'wash']) stopSafe(k);
+      ambientOn = false; bubblesOn = false; washOn = false;
+    }
+
+    /* ==================================================================== *
+     * THE CLASS-RULES SHEET (Law IV / Deck VI) - drawn, GO-only, and the
+     * shell's "Skip class tutorials" contract: with the skip ON a class still
+     * explains itself ONCE PER GRADE TIER, and that memory is the GAME's
+     * (gameMeta.howtoTiers), never the shell's. Impulse Control's policy.
+     * ==================================================================== */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    function rememberHowto() {
+      try {
+        const list = howtoSeenTiers();
+        if (list.indexOf(tier) >= 0) return;
+        list.push(tier);
+        if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+          ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+        }
+      } catch (e) { /* best effort - the sheet just shows again next time */ }
+    }
+    function hideHowto() {
+      if (!howtoEl) return;
+      try { howtoEl.remove(); } catch (e) { /* noop */ }
+      howtoEl = null;
+    }
+    function howto(onDone) {
+      const seen = howtoSeenTiers();
+      const skip = (ctx.dev === true && spec && spec.devSkipHowto === true)
+        || (ctx.hideTutorial === true && seen.indexOf(tier) >= 0);
+      if (skip) { onDone(); return; }
+      howtoEl = el('div', 'g-ec-howto');
+      howtoEl.setAttribute('role', 'dialog');
+      howtoEl.appendChild(el('h3', 'g-ec-howto-title', t('ec_howto_title', EC_LEX.ec_howto_title)));
+      const rows = el('div', 'g-ec-howto-rows');
+      const drawRow = (art, key, fallback) => {
+        const row = el('div', 'g-ec-howto-row');
+        const cell = el('span', 'g-ec-howto-art');
+        cell.setAttribute('data-art', art);
+        cell.setAttribute('aria-hidden', 'true');
+        row.appendChild(cell);
+        row.appendChild(el('p', 'g-ec-howto-line', t(key, fallback)));
+        rows.appendChild(row);
+      };
+      drawRow('watch', 'ec_howto_watch', EC_LEX.ec_howto_watch);
+      drawRow('repeat', 'ec_howto_repeat', EC_LEX.ec_howto_repeat);
+      /* The decoy line only appears at the tiers that deal decoys - a rule
+       * sheet that explains a mechanic the class cannot show is noise. */
+      if ((PLAYTEST.DECOY_MAX[tier] || 0) > 0) drawRow('decoy', 'ec_howto_decoy', EC_LEX.ec_howto_decoy);
+      howtoEl.appendChild(rows);
+      const go = el('button', 'g-ec-howto-go', t('ec_howto_go', EC_LEX.ec_howto_go));
+      go.setAttribute('type', 'button');
+      try { go.type = 'button'; } catch (e) { /* the double has no button semantics */ }
+      let done = false;
+      go.addEventListener('click', () => {
+        if (done || dead) return;
+        done = true;
+        rememberHowto();
+        hideHowto();
+        onDone();
+      });
+      howtoEl.appendChild(go);
+      stage.appendChild(howtoEl);
+      try { go.focus(); } catch (e) { /* noop */ }
+    }
+
+    /* ==================================================================== *
+     * THE CLOCK + THE BELL
+     * ==================================================================== */
+    function startClock() {
+      lastTick = Date.now();
+      clockId = every(250, () => {
+        if (ended) return;
+        const now = Date.now();
+        const dt = now - lastTick;
+        lastTick = now;
+        elapsedMs += dt / Math.max(0.0001, timeScale);
+        if (clockChip) clockChip.textContent = clockText();
+        const left = secLeft();
+        if (!bellOn && left <= PLAYTEST.BELL_WARN_SEC && elapsedMs < budgetMs) {
+          bellOn = true;
+          deck('casino', 'bell', true);
+          deck('pressure', 'beat', 'bell');
+          msg('ec_msg_bell_warn', EC_LEX.ec_msg_bell_warn);
+          tone('sting', 0.4, 1);
+        }
+        if (elapsedMs >= budgetMs) { stopClock(); run(bell); }
+      });
+    }
+    function stopClock() { if (clockId) { clearTimer(clockId); clockId = 0; } }
+
+    function bell() {
+      if (ended || dead) return;
+      finish();
+    }
+
+    /* ==================================================================== *
+     * THE END - endClass exactly once, and never with a grade of our own.
+     * ==================================================================== */
+    function finish() {
+      if (ended) return;
+      ended = true;
+      inputOpen = false;
+      busy = true;
+      disarmInputWindow();
+      stopClock();
+      clearPads();
+      stopAmbience();
+      setPhase('ended');
+      deck('casino', 'dimOut');
+      deck('pressure', 'stop');
+      deck('trickster', 'stop');
+      try { if (ctx.engine) ctx.engine.setHeat(0); } catch (e) { /* noop */ }
+
+      const meanLatencyMs = latencyCount > 0 ? (latencySum / latencyCount) : 0;
+      const stepMs = stepMsFor(tier, 1);
+      const graded = compositeFor({
+        gradeTier: tier,
+        bestLen,
+        correct: correctPresses,
+        presses,
+        meanLatencyMs,
+        stepMs,
+        decoysPresented,
+        decoysResisted,
+      });
+      const gates = hardGates(encoreUsed);
+      const fx = flavorXp(bestLen, tier);
+
+      const lifetimeAfter = Math.max(lifetimeBefore, bestLen);
+      try {
+        if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+          const prior = (typeof ctx.store.gameMeta === 'function' ? (ctx.store.gameMeta(GAME_KEY) || {}) : {});
+          ctx.store.mergeGameMeta(GAME_KEY, {
+            bestLen: lifetimeAfter,
+            plays: Math.max(0, Number(prior.plays) || 0) + 1,
+            lastLen: bestLen,
+            lastSeed: seed,
+            lastPlayedAt: Date.now(),
+            decoysResisted: Math.max(0, Number(prior.decoysResisted) || 0) + decoysResisted,
+            sequencesCleared: Math.max(0, Number(prior.sequencesCleared) || 0) + sequencesCleared,
+          });
+        }
+      } catch (e) { say('meta merge failed (the class still grades): ' + ((e && e.message) || e)); }
+
+      renderEnd(graded, meanLatencyMs, stepMs, lifetimeAfter);
+
+      const report = { metrics: { composite: graded.composite }, hardGates: gates, flavorXp: fx };
+      lastReport = Object.assign({}, report, {
+        inputs: {
+          tier, seed, retake, startLen, bestLen, bestReach, lifetimeBefore, lifetimeAfter,
+          sequencesDealt, sequencesCleared, fails, timeouts, presses, correctPresses,
+          bestStreak, decoysPresented, decoysResisted, decoysTaken,
+          meanLatencyMs, stepMs, encoreUsed, elapsedMs, terms: graded.terms, sLen: graded.sLen,
+        },
+      });
+      try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
+      say('class over: best echo ' + bestLen + ' (lifetime ' + lifetimeAfter + '), '
+        + sequencesCleared + '/' + sequencesDealt + ' held, ' + correctPresses + '/' + presses + ' presses, '
+        + 'decoys ' + decoysResisted + '/' + decoysPresented + (encoreUsed ? ', ENCORE' : '')
+        + ' -> composite ' + graded.composite.toFixed(3));
+
+      after(reduced ? PLAYTEST.END_HOLD_MS_REDUCED : PLAYTEST.END_HOLD_MS, () => {
+        if (reported) return;
+        reported = true;
+        try { ctx.endClass(report); } catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
+      });
+    }
+
+    function renderEnd(graded, meanLatencyMs, stepMs, lifetimeAfter) {
+      if (!endEl) return;
+      endEl.textContent = '';
+      endEl.hidden = false;
+      endEl.appendChild(el('h3', 'g-ec-end-title', t('ec_end_title', EC_LEX.ec_end_title)));
+      const row = (cls, k, v) => {
+        const r = el('div', 'g-ec-end-row' + (cls ? ' ' + cls : ''));
+        r.appendChild(el('span', 'g-ec-end-k', k));
+        r.appendChild(el('span', 'g-ec-end-v', v));
+        endEl.appendChild(r);
+        return r;
+      };
+      const best = row('g-ec-end-best', t('ec_end_best', EC_LEX.ec_end_best), String(bestLen));
+      best.setAttribute('data-len', String(bestLen));
+      row('', t('ec_end_sequences', EC_LEX.ec_end_sequences), sequencesCleared + ' / ' + sequencesDealt);
+      row('', t('ec_end_accuracy', EC_LEX.ec_end_accuracy),
+        Math.round((presses > 0 ? correctPresses / presses : 0) * 100) + '%');
+      row('', t('ec_end_tempo', EC_LEX.ec_end_tempo), Math.round(graded.terms.tempo * 100) + '%');
+      row('', t('ec_end_streak', EC_LEX.ec_end_streak), String(bestStreak));
+      if (decoysPresented > 0) {
+        row('', t('ec_end_decoys', EC_LEX.ec_end_decoys), decoysResisted + ' / ' + decoysPresented);
+      }
+      if (encoreUsed) {
+        row('g-ec-end-encore', t('ec_end_encore', EC_LEX.ec_end_encore), t('ec_end_yes', EC_LEX.ec_end_yes));
+      }
+      const tail = el('div', 'g-ec-end-tail');
+      tail.setAttribute('data-len', String(lifetimeAfter));
+      if (newRecord) tail.appendChild(el('span', 'g-ec-end-record', t('ec_end_record', EC_LEX.ec_end_record)));
+      tail.appendChild(el('p', 'g-ec-end-line', t('ec_end_line', EC_LEX.ec_end_line)));
+      endEl.appendChild(tail);
+    }
+
+    /* ---- assets (never block a draw) ------------------------------------ */
+    function claimAssets() {
+      Promise.resolve()
+        .then(() => ctx.assets.claim({ loops: 6, targets: 0, stills: 6, canvasSafe: false }))
+        .then((p) => {
+          if (dead || !p || typeof p.next !== 'function') return;
+          pool = p;
+          run(dressFaces);
+        })
+        .catch((e) => say('asset claim failed - plain pad faces: ' + ((e && e.message) || e)));
+    }
+
+    /* ==================================================================== *
+     * THE MODULE INSTANCE
+     * ==================================================================== */
+    const instance = {
+      start(classSpec) {
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 105 };
+        tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
+        seed = String(spec.seed == null ? GAME_KEY : spec.seed);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 105) * 1000);
+        retake = !!spec.retake;
+        reduced = probeReduced(ctx);
+        audible = ctx.audioAudible !== false;
+        attempt = 0;
+        encoreArmed = true;
+        encoreUsed = false;
+        inEncore = false;
+        ratchet = 0;
+        newRecord = false;
+        faceUrls.clear();
+        faceKind = (reduced || motionLevelOf() <= 1) ? 'still' : 'loop';
+
+        try {
+          lifetimeBefore = Math.max(0, Math.floor(Number((ctx.store.gameMeta(GAME_KEY) || {}).bestLen) || 0));
+        } catch (e) { lifetimeBefore = 0; }
+        startLen = warmStartLen(lifetimeBefore, tier);
+        curLen = startLen;
+
+        subRoll = makeTaggedRoll(seed + '|ec-sub');
+        rollLocal = (() => {
+          const roll = makeTaggedRoll(seed + '|ec-vr');
+          return () => {
+            const base = 0.30 + 0.30 * currentHeat;
+            const chance = Math.min(1, base + Math.min(PLAYTEST.STREAK_CAP, clearStreak) * 0.03);
+            const r = roll('fire');
+            const fire = r < chance;
+            return { fire, jackpot: fire && roll('jack') >= 0.85, nearMiss: !fire && r < chance + 0.08 };
+          };
+        })();
+
+        try { injectEchoStyle(); } catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
+        buildDom();
+        assignWords();
+        paintHud();
+
+        const capsOk = capsArmed();
+        try {
+          casino = createEcCasino({
+            seed, tier, stage, board: ring, ring, hud, backdrop,
+            timers: deckTimers, reduced, capsOk, t, engine: deckEngine, assets: deckAssets,
+            padEl: (i) => padEls[i] || null,
+            pads: () => padEls.slice(),
+            padCount: PLAYTEST.PADS,
+            log: say,
+          }) || null;
+        } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+        try {
+          trickster = createEcTrickster({
+            seed, tier, timers: deckTimers, reduced, capsOk,
+            stage, board: ring, hud, backdrop, engine: deckEngine, assets: deckAssets,
+            budgetSec: Math.round(budgetMs / 1000),
+            coarse: !!(ctx.platform && ctx.platform.isTouch),
+            isHalted: () => dead || paused || ended || busy,
+            /* READ-ONLY views of the truth. A deck may READ the ledger (the
+             * Ghost Cursor lures to a pad ADJACENT to the due one, which is
+             * only a lie worth telling if it knows the truth); it may never
+             * write one. Law I is kept because nothing here is a setter. */
+            phase: () => phase(),
+            nextPad: () => ((inputOpen && round && round.seq[expectIdx] != null) ? round.seq[expectIdx] : -1),
+            wordsOn: () => faceMode === 'words',
+            t,
+            stats: () => ({
+              len: curLen, best: Math.max(bestLen, lifetimeBefore), streak: pressStreak,
+              secLeft: secLeft(), sequences: sequencesDealt, expect: expectIdx, inputOpen,
+            }),
+            chipEl: (which) => (which === 'clock' ? clockChip
+              : which === 'best' ? bestChip
+                : which === 'streak' ? streakChip
+                  : which === 'ring' ? timerEl : lenChip),
+            chipText,
+            /* THE LIE TARGET (Unreliable Label): a pad's WORD may briefly wear
+             * another pad's word. The GLYPH is the truth and the deck is never
+             * handed it; paintWords() restores the truth on every deal. */
+            padEl: (i) => padEls[i] || null,
+            pads: () => padEls.slice(),
+            wordEl: (i) => wordNodeOf(padEls[i] || null),
+            wordText: padWordText,
+            restoreWords: paintWords,
+            ring,
+            announce: (text, ms) => {
+              if (!msgEl || !text) return;
+              msgEl.textContent = String(text);
+              const mine = msgEl.textContent;
+              deckTimers.after(Math.max(400, Number(ms) || 1600), () => {
+                if (msgEl && msgEl.textContent === mine) msgEl.textContent = '';
+              });
+            },
+            log: say,
+          }) || null;
+        } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+        try {
+          pressure = createEcPressure({
+            seed,
+            gradeTier: tier,
+            tier,
+            reduced,
+            motionLevel: motionLevelOf(),
+            stage,
+            ring,
+            backdrop,
+            /* CHROME ONLY (Law I/II): the tremor rides the HUD and the stage
+             * frame, never a pad - a pad that moves is a moved hitbox. */
+            chrome: [hud, lenChip, clockChip, streakChip, bestChip].filter(Boolean),
+            hud: { len: lenChip, clock: clockChip, streak: streakChip, best: bestChip },
+            engine: deckEngine,
+            assets: deckAssets,
+            timers: deckTimers,
+            capsOk: capsArmed,
+            log: say,
+          }) || null;
+        } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+
+        bindInput();
+        claimAssets();
+        startClock();
+
+        every(PLAYTEST.STALL_TICK_MS, () => {
+          if (ended || !inputOpen) return;
+          stallMs += PLAYTEST.STALL_TICK_MS;
+          if (stallMs >= PLAYTEST.STALL_MS) deck('trickster', 'stalled', stallMs);
+        });
+
+        msg('ec_brief', EC_LEX.ec_brief);
+        howto(() => {
+          if (dead || ended) return;
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
+            if (dead || ended) return;
+            deck('casino', 'start');
+            deck('pressure', 'start');
+            deck('trickster', 'start');
+            openAmbience();
+            busy = false;
+            dealSequence(startLen);
+          });
+        });
+
+        liveClass = instance;
+        lastReport = null;
+        lastSnapshot = null;
+        say('tier ' + tier + ', ' + alphabetFor(tier) + ' of ' + PLAYTEST.PADS + ' pads in play, warm start '
+          + startLen + ' (lifetime best ' + lifetimeBefore + '), budget ' + Math.round(budgetMs / 1000) + 's'
+          + (reduced ? ', reduced' : '') + (audible ? '' : ', SILENT (visual tells)')
+          + (retake ? ', RETAKE' : '') + ', faces ' + faceMode);
+      },
+
+      pause() {
+        if (paused) return;
+        paused = true;
+        deck('pressure', 'pause');
+        deck('trickster', 'pause');
+        deck('casino', 'pause');
+        if (stage) stage.classList.add('suspended');
+      },
+
+      resume() {
+        if (!paused) return;
+        paused = false;
+        if (stage) stage.classList.remove('suspended');
+        deck('pressure', 'resume');
+        deck('trickster', 'resume');
+        deck('casino', 'resume');
+        lastTick = Date.now();
+        lastPressAt = Date.now();
+        const q = deferred.splice(0);
+        for (const fn of q) run(fn);
+      },
+
+      /** The shell owns the overlay and the engine's suspend; we just freeze. */
+      suspend(on) { if (on) instance.pause(); else instance.resume(); },
+
+      destroy() {
+        dead = true;
+        stopClock();
+        disarmInputWindow();
+        clearTimers();
+        stopAmbience();
+        unbindInput();
+        hideHowto();
+        try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
+        trickster = null;
+        try { if (casino) casino.destroy(); } catch (e) { /* noop */ }
+        casino = null;
+        try { if (pressure) pressure.destroy(); } catch (e) { /* noop */ }
+        pressure = null;
+        if (pool && typeof pool.release === 'function') { try { pool.release(); } catch (e) { /* noop */ } }
+        pool = null;
+        padTimers.clear();
+        padEls.length = 0;
+        timerEl = null;
+        try { ctx.root.textContent = ''; } catch (e) { /* noop */ }
+        if (liveClass === instance) liveClass = null;
+      },
+
+      /* -------- test / diagnostics seams (never read by the shell) -------- */
+      /** Press a pad exactly as the finger would. */
+      press(i) { press(i, 'tap'); },
+      /** The TRUE chip text - what the trickster restores after a lie. */
+      chipText(which) { return chipText(which); },
+      /** The live round (the suite asserts the dealt plan against sequence.js). */
+      round() { return round; },
+      /** End the class as the bell would (the suite never waits 105s). */
+      ringBell() { run(bell); },
+
+      snapshot() {
+        return {
+          tier, seed, retake, reduced, audible, faceMode,
+          startLen, curLen, attempt, expectIdx, stepIdx, inputOpen, busy, paused, dead, ended, reported,
+          phase: phase(),
+          encoreArmed, encoreUsed, inEncore, ratchet,
+          bestLen, bestReach, lifetimeBefore,
+          sequencesDealt, sequencesCleared, fails, timeouts,
+          presses, correctPresses, pressStreak, bestStreak, clearStreak,
+          decoysPresented, decoysResisted, decoysTaken,
+          latencySum, latencyCount, jackpots, nearMisses, subFlashes,
+          currentHeat, bellOn, elapsedMs, budgetMs, secLeft: secLeft(),
+          padStates: padEls.map((p) => (p ? p.getAttribute('data-state') : null)),
+          padWords: padWords.slice(),
+          faces: faceUrls.size,
+          round: round ? {
+            len: round.len, seq: round.seq.slice(), decoys: round.decoys.slice(),
+            steps: round.steps.length, stepMs: round.stepMs, windowMs: round.windowMs, encore: round.encore,
+          } : null,
+          howtoUp: !!howtoEl,
+          stage, ring, hud, well, msgEl, endEl, lenChip, clockChip, streakChip, bestChip,
+          pads: padEls.slice(),
+          casino: casino && typeof casino.diagnostics === 'function' ? (() => { try { return casino.diagnostics(); } catch (e) { return null; } })() : null,
+          trickster: trickster && typeof trickster.diagnostics === 'function' ? (() => { try { return trickster.diagnostics(); } catch (e) { return null; } })() : null,
+          pressure: pressure && typeof pressure.diagnostics === 'function' ? (() => { try { return pressure.diagnostics(); } catch (e) { return null; } })() : null,
+        };
+      },
+    };
+
+    function motionLevelOf() {
+      try { const v = ctx.motion && ctx.motion.motionLevel; return Number.isFinite(Number(v)) ? Number(v) : 2; }
+      catch (e) { return 2; }
+    }
+
+    return instance;
+  },
+
+  /** The live class's state, or null. Never read by the shell. */
+  diagnostics() { return liveClass ? liveClass.snapshot() : null; },
+
+  /** The last report handed to endClass (survives teardown). Diagnostics only. */
+  get lastReport() { return lastReport; },
+
+  /** The final snapshot of the last class (survives teardown). Diagnostics only. */
+  get lastSnapshot() { return lastSnapshot; },
+
+  setTimeScale,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/lex.js
@@ -1,0 +1,95 @@
+/* ============================================================================
+ * games/echo/lex.js - every `ec_` lexicon row ECHO renders, with its neutral
+ * English fallback. Exported as DATA (the Impulse Control / Deep End
+ * precedent, IC_LEX / DE_LEX) so the host's `NeutralLexicon` can be mirrored
+ * key-for-key: copy the values, never re-word them.
+ *
+ * RULES (web CLAUDE.md trap 26 + the Semester II/III contract): a value longer
+ * than 96 characters can never be mod-skinned, so every row here is <= 96; a
+ * row is rendered ONLY through ctx.lexicon(key, fallback) (Law VII - accents
+ * come from the lexicon, never AI). The DECKS (style/casino/trickster/
+ * pressure) t() the same keys - this table is the union of index.js's rows and
+ * the deck rows the contract pins for Echo.
+ *
+ * NOTHING here is load-bearing for the mechanic: sequences are stored,
+ * compared and graded over pad INDICES 0..5, never over a word or a string
+ * (the dossier's mod-agnosticism proof). A pad's word is decoration the
+ * trickster is allowed to lie on; the pad's GLYPH is the truth.
+ *
+ * GROUND-RULES §2 names four product words the Arcademy may never reuse. None
+ * appears in any row below; the scratch suite holds the list and greps every
+ * CORE file in this folder for it.
+ * ==========================================================================*/
+
+export const EC_LEX = Object.freeze({
+  /* ---- keybind slot labels (shell/settings.js label_key) ---------------- */
+  ec_key_pad1: 'Pad 1',
+  ec_key_pad2: 'Pad 2',
+  ec_key_pad3: 'Pad 3',
+  ec_key_pad4: 'Pad 4',
+  ec_key_pad5: 'Pad 5',
+  ec_key_pad6: 'Pad 6',
+
+  /* ---- the per-game setting -------------------------------------------- */
+  ec_pad_words: 'Pad faces',
+  ec_pad_words_hint: 'Pads wear a word from your pool, or a plain glyph only.',
+
+  /* ---- HUD chips (aria labels; the numbers themselves are not strings) -- */
+  ec_chip_len: 'Sequence length',
+  ec_chip_clock: 'Time left',
+  ec_chip_streak: 'Streak',
+  ec_chip_best: 'Longest echo',
+  ec_retake: 'Retake',
+  ec_ring_aria: 'The pads',
+  ec_pad_aria: 'Pad {n}',
+
+  /* ---- the drawn class-rules sheet (Deck VI, GO-only dismissal) --------- */
+  ec_howto_title: 'Class rules',
+  ec_howto_watch: 'The pads play a sequence. Watch it. Listen to it.',
+  ec_howto_repeat: 'Then repeat it back, in order, by tap or by key.',
+  ec_howto_decoy: 'A pad may light out of turn. Leave that one alone.',
+  ec_howto_go: 'Begin',
+
+  /* ---- the proctor line (one at a time) -------------------------------- */
+  ec_brief: 'Sit down. Listen first.',
+  ec_msg_watch: 'Watch.',
+  ec_msg_input: 'Your turn.',
+  ec_msg_clear: 'Clean. One longer now.',
+  ec_msg_fail: 'Broken. Listen again.',
+  ec_msg_timeout: 'Too slow. Listen again.',
+  ec_msg_near: 'One short of it.',
+  ec_msg_new: 'A new one, then.',
+  ec_msg_encore: 'Again. Slower this time.',
+  ec_msg_encore_clear: 'Held. Keep going.',
+  ec_msg_encore_fail: 'Gone. A new one, then.',
+  ec_msg_decoy_warn: 'One of them lies tonight. Do not echo it.',
+  ec_msg_resisted: 'You let it pass. Good.',
+  ec_msg_bell_warn: 'Last of the class.',
+  ec_msg_silent: 'No sound tonight. Watch the light.',
+
+  /* ---- the end card ----------------------------------------------------- */
+  ec_end_title: 'Class dismissed',
+  ec_end_best: 'Longest echo',
+  ec_end_sequences: 'Sequences held',
+  ec_end_accuracy: 'Accuracy',
+  ec_end_tempo: 'Tempo held',
+  ec_end_decoys: 'Decoys resisted',
+  ec_end_streak: 'Best run of pads',
+  ec_end_encore: 'Encore used',
+  ec_end_yes: 'Yes',
+  ec_end_no: 'No',
+  ec_end_record: 'A new personal best',
+  ec_end_line: 'The room keeps the length. You keep the tune.',
+
+  /* ---- the decks (casino / trickster) ----------------------------------- */
+  ec_decoy_tell: 'Not this one',
+  ec_jackpot: 'Perfect pitch',
+  ec_royal: 'The whole melody',
+  ec_near_miss: 'So nearly',
+  ec_taunt_stall: 'Still there?',
+  ec_taunt_slow: 'Slower than you were.',
+  ec_taunt_ghost: 'This one. Surely this one.',
+  ec_taunt_label: 'Read it again. Or do not.',
+});
+
+export default EC_LEX;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/pressure.js
@@ -1,0 +1,631 @@
+/* ============================================================================
+ * games/echo/pressure.js - the music room's effects ladder: THE SURGE. The
+ * casino (casino.js) lights the room, the trickster (trickster.js) lies about
+ * it; this file is what the room DOES to you as the echo gets LONGER. The
+ * ladder is LENGTH-DRIVEN: the rung is the sequence length the class is
+ * currently dealing (the game's own ladder - a fail sets the next deal back
+ * two and the storm steps DOWN behind a hysteresis, with fades, never a snap);
+ * the MAGNITUDE rides the class heat (which index.js folds length, tier cap
+ * and the clean-press streak into). A 105-second class reaches length 8-12,
+ * so the whole ladder fits inside a real class. Same seed, same surge.
+ *
+ * THE RUNG TABLE (sequence length -> rung -> what switches ON; cumulative):
+ *   3-4   rung 0  clean room (the casino's halo and the core's own ambience)
+ *   5     rung 1  BREATH      a pink wash breathes on a cadence          [engine wash:pink]
+ *   6     rung 2  BURST       gif bursts ride cleared sequences (28-42   [engine gif_burst sizePx]
+ *                             vmin) + THE TREMOR wakes on the chrome
+ *   7     rung 3  WHEEL       the full-screen spiral wash wakes (the     [engine wash:spiral]
+ *                             shell's real image through the provider)
+ *   8     rung 4  VEIL+GIANT  the backdrop glitch-shudders on clears and  [engine glitch_swap on the
+ *                             fails; a clear may drop ONE near-fullscreen  backdrop, gif_burst ~0.9vmin]
+ *                             gif
+ *   9     rung 5  SUBS        the sub-flash stream runs between turns    [engine sub_flash alias]
+ *   10    rung 6  FLASHES     flash bursts ride clears                   [engine flash_burst]
+ *   12    rung 7  STORM       embers, the pink flood, the tremor at its  [engine ambient_field, wash:pink]
+ *                             cap
+ *
+ * THE TREMOR: the CHROME vibrates with the length, Balatro style - a
+ * continuous low tremor whose amplitude grows with the rung, a PUNCH on every
+ * cleared sequence sized by the length, a JOLT on a fail. Written on the CSS
+ * individual `translate` of the HUD (the top-level chrome nodes index.js hands
+ * in; a chip inside a trembling HUD is not moved twice), and NEVER on the
+ * ring or a pad: the pads are the tap targets (Law II), and a memory test
+ * cannot have moving targets. The chips themselves scale-punch (len on a
+ * clear, streak on a long link) - transform only, the TEXT is index.js's. A
+ * rAF loop ONLY while amplitude > 0; stopped by pause()/stop()/destroy(),
+ * re-armed by resume(). Reduced motion / motionLevel 0 -> no tremor at all,
+ * punches become a brief bloom on the chip.
+ *
+ * ENGINE vs GAME-LOCAL (audit): EVERYTHING visual goes through opts.engine
+ * (index.js's null-safe weld: clickSafe forced, audio ceiling, capsOk,
+ * effectsConsumed). Game-local: the tremor (translate writes on the chrome)
+ * and the chip punches (transform writes on the chips). This file creates NO
+ * nodes. Node budget: 0.
+ *
+ * SHARED KINDS (the core's own ambience rides the same engine): the core holds
+ * ambient_field (specks / motes) for the class and pulses wash:pink itself at
+ * tier 3; this deck therefore NEVER stop()s ambient_field (the storm's off
+ * hand re-sustains the core's kind instead) and steps every wash DOWN by
+ * re-triggering its variant at a whisper alpha (trap 33), never stop('wash').
+ * bubble_field is the core's input-turn pressure and is not touched here.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event arguments (len / links / heat / beat
+ *       kind), writes nothing about the sequence, the streak or the grade,
+ *       renders no text; chip TEXT is never touched.
+ *   II  input honest  - no node of ours exists; the ring and the pads are never
+ *       transformed or covered; every engine fire is clickSafe by the weld.
+ *   III never still   - from rung 1 the room breathes; from rung 2 it shakes.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ec-pressure|<tag>',
+ *       append-only; no Math.random.
+ *   VI  exits sacred  - capsOk() false = zero fires, zero tremor; reduced
+ *       motion = no tremor, no veil; pause() halts the rAF and drops transient
+ *       timers; destroy() restores every translate and whispers every wash out.
+ *   VII lexicon       - this file renders no text.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const EC_PRESSURE = Object.freeze({
+  /** sequence length thresholds per rung (index = rung). Monotone. */
+  RUNG_LEN: Object.freeze([0, 5, 6, 7, 8, 9, 10, 12]),
+  RUNG_ADDS: Object.freeze([
+    Object.freeze([]),
+    Object.freeze(['breath']),
+    Object.freeze(['burst', 'tremor']),
+    Object.freeze(['wheel']),
+    Object.freeze(['veil', 'giant']),
+    Object.freeze(['subs']),
+    Object.freeze(['flashes']),
+    Object.freeze(['storm']),
+  ]),
+  RUNG_CUE: Object.freeze([null, 'wash', 'burst', 'wash', 'glitch', 'whisper', 'burst', 'near_miss']),
+  /** Stepping DOWN waits this long and fades; stepping UP is immediate. */
+  HYST_MS: 1800,
+  HEAT_REPAINT_STEP: 0.06,
+
+  /* ---- THE TREMOR ------------------------------------------------------ */
+  TREMOR_PX: Object.freeze([0, 0, 0.35, 0.5, 0.7, 0.95, 1.3, 1.8]),
+  TREMOR_CAP_PX: 2.2,
+  TREMOR_HEAT_FLOOR: 0.5,
+  TREMOR_HZ_FAST: Object.freeze([7, 11]),
+  TREMOR_HZ_SLOW: Object.freeze([1.4, 2.6]),
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  /** a clear punch: px / ms from q = len/14; a fail jolt; hard caps. */
+  PUNCH_PX: Object.freeze([0.9, 3.4]),
+  PUNCH_MS: Object.freeze([170, 380]),
+  JOLT_PX: 4.2,
+  JOLT_MS: 360,
+  PUNCH_CAP_PX: 6,
+  PUNCH_CAP_MS: 450,
+  /** chip punches (scale) */
+  LEN_PUNCH: Object.freeze([1.08, 1.26]),
+  STREAK_PUNCH_PER_LINK: 0.025,
+  STREAK_PUNCH_CAP: 1.22,
+  CHIP_MS: 240,
+  BLOOM_MS: 320,
+
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([8200, 5000]),
+  BREATH_HOLD_MS: 2400,
+  BREATH_ALPHA: Object.freeze([0.1, 0.36]),
+  STORM_BREATH_ALPHA: Object.freeze([0.28, 0.52]),
+  BURST_CHANCE: Object.freeze([0.45, 0.9]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  BURST_VMIN: Object.freeze([0.28, 0.42]),
+  BURST_HOLD_MS: Object.freeze([750, 1250]),
+  GIANT_CHANCE: Object.freeze([0.28, 0.6]),
+  GIANT_VMIN: 0.9,
+  GIANT_HOLD_MS: Object.freeze([1000, 1600]),
+  VEIL_CHANCE: Object.freeze([0.35, 0.8]),
+  VEIL_S: Object.freeze([0.35, 0.85]),
+  VEIL_VARIANTS: Object.freeze(['rgbsplit', 'vhsroll', 'datamosh']),
+  WHEEL_ALPHA: Object.freeze([0.18, 0.44]),
+  SUB_VARIANT: 'scatter',
+  FLASH_COUNT: 2,
+  STORM_EMBERS: Object.freeze([0.3, 0.7]),
+  WHISPER_ALPHA: 0.01,
+  WHISPER_HOLD_MS: 900,
+  /** cue level = min(AUDIO_CEIL[tier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.22,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  /** the core's ambient kind by tier (re-sustained when the storm leaves) */
+  AMBIENT_OF_TIER: Object.freeze({ 1: 'specks', 2: 'specks', 3: 'motes', 4: 'motes' }),
+});
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** sequence length -> rung (0..7). Pure, monotone, clamps garbage to 0. */
+export function rungFor(len) {
+  const l = Math.max(0, Math.floor(Number(len) || 0));
+  const T = EC_PRESSURE.RUNG_LEN;
+  let r = 0;
+  for (let i = 0; i < T.length; i++) { if (l >= T[i]) r = i; else break; }
+  return r;
+}
+/** idle tremor amplitude in px; 0 under reduced motion / motionLevel 0. Pure. */
+export function tremorAmpPx(len, heat01, reducedMotion, motionLevel) {
+  if (reducedMotion) return 0;
+  const m = EC_PRESSURE.MOTION_MUL[Math.max(0, Math.min(2, motionLevel == null ? 2 : Math.round(Number(motionLevel) || 0)))];
+  if (!m) return 0;
+  const base = EC_PRESSURE.TREMOR_PX[rungFor(len)] || 0;
+  if (base <= 0) return 0;
+  const f = EC_PRESSURE.TREMOR_HEAT_FLOOR;
+  return Math.min(EC_PRESSURE.TREMOR_CAP_PX, +(base * m * (f + (1 - f) * clamp01(heat01))).toFixed(3));
+}
+/** a punch {px, ms} from a cleared length, or a fail jolt. Pure. */
+export function punchFor(o) {
+  const d = o || {};
+  const P = EC_PRESSURE;
+  const q = clamp01((Number(d.len) || 0) / 14);
+  let px = lerp(P.PUNCH_PX, q);
+  let ms = lerp(P.PUNCH_MS, q);
+  if (d.fail) { px = Math.max(px, P.JOLT_PX); ms = Math.max(ms, P.JOLT_MS); }
+  return { px: +Math.min(P.PUNCH_CAP_PX, px).toFixed(2), ms: Math.min(P.PUNCH_CAP_MS, Math.round(ms)) };
+}
+
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function rafFn() {
+  try { if (typeof requestAnimationFrame === 'function') return requestAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function cafFn() {
+  try { if (typeof cancelAnimationFrame === 'function') return cancelAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.cancelAnimationFrame === 'function') return globalThis.cancelAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function restart(n, cls) {
+  if (!n || !n.classList) return;
+  try { n.classList.remove(cls); if (typeof n.offsetWidth === 'number') void n.offsetWidth; n.classList.add(cls); } catch (e) { /* noop */ }
+}
+function vmin() {
+  try {
+    if (typeof window !== 'undefined') {
+      const w = Number(window.innerWidth) || 0; const h = Number(window.innerHeight) || 0;
+      if (w && h) return Math.min(w, h);
+    }
+  } catch (e) { /* fall */ }
+  return 800;
+}
+/** Of a list of nodes, those not contained by another in the list. */
+function topLevel(nodes) {
+  const list = (nodes || []).filter(Boolean);
+  return list.filter((n) => !list.some((m) => m !== n && contains(m, n)));
+}
+function contains(a, b) {
+  try { if (typeof a.contains === 'function') return a.contains(b); } catch (e) { /* fall */ }
+  let p = null;
+  try { p = b.parentNode; } catch (e) { p = null; }
+  while (p) { if (p === a) return true; try { p = p.parentNode; } catch (e) { p = null; } }
+  return false;
+}
+
+/**
+ * @param {Object} o
+ *   seed, gradeTier|tier, reduced, motionLevel, stage, ring, backdrop,
+ *   chrome:[els] (the tremor rides the top-level ones), hud:{len,clock,streak,best},
+ *   engine {fire, sustain, stop, channels}, assets {next}, timers {after,every,clear|cancel},
+ *   capsOk (fn or bool), log
+ */
+export function createEcPressure(o) {
+  const opts = o || {};
+  const P = EC_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const tier = Math.max(1, Math.min(4, Math.round(Number(opts.gradeTier != null ? opts.gradeTier : opts.tier) || 1)));
+  const audioCeil = P.AUDIO_CEIL[tier] || P.AUDIO_CEIL[1];
+  const eng = opts.engine || {};
+  const hud = opts.hud || {};
+  const armedBase = !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk === true;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers ------------------------------------------------------------ */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams ---------------------------------------------------- */
+  const seedBase = String(opts.seed || 'ec') + '|ec-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.fire !== 'function') return null;
+    try { return eng.fire(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.sustain !== 'function') return null;
+    try { return eng.sustain(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  function stopKind(kind) {
+    if (!armedBase || destroyed) return;
+    count('stop:' + kind);
+    if (typeof eng.stop !== 'function') return;
+    try { eng.stop(kind); } catch (e) { /* ignore */ }
+  }
+  function cue(name, r) {
+    if (!name) return;
+    fire('audio_trigger', { name, level: Math.min(audioCeil, P.CUE_LEVEL_BASE + P.CUE_LEVEL_STEP * r) });
+  }
+
+  /* ---- state ------------------------------------------------------------ */
+  let started = false; let stopped = false; let paused = false;
+  let heat = 0; let lastPaintHeat = -1;
+  let len = 0; let links = 0;
+  let rung = 0; let wantRung = 0; let downTimer = 0;
+  let bellOn = false;
+  const on = new Set();
+  let breathTimer = 0;
+
+  /* the tremor + the juice */
+  const chrome = topLevel(Array.isArray(opts.chrome) ? opts.chrome : []);
+  const fq = {
+    fx: lerp(P.TREMOR_HZ_FAST, roll('tremor')), fy: lerp(P.TREMOR_HZ_FAST, roll('tremor')),
+    sx: lerp(P.TREMOR_HZ_SLOW, roll('tremor')), sy: lerp(P.TREMOR_HZ_SLOW, roll('tremor')),
+    px: roll('tremor') * 6.283, py: roll('tremor') * 6.283, qx: roll('tremor') * 6.283, qy: roll('tremor') * 6.283,
+  };
+  let amp = 0;
+  let punch = { px: 0, until: 0, ms: 1 };
+  let rafId = 0; let loopOn = false; let pausedAt = 0;
+  let translateWrites = 0; let translateOn = false;
+  const chips = {
+    len: { el: hud.len || null, a: 0, at: 0, ms: 1, last: '', writes: 0 },
+    streak: { el: hud.streak || null, a: 0, at: 0, ms: 1, last: '', writes: 0 },
+  };
+  const chipBloomTimers = new Map();
+
+  function writeTranslate(x, y) {
+    for (const n of chrome) {
+      if (!n || !n.style) continue;
+      try { n.style.translate = x.toFixed(2) + 'px ' + y.toFixed(2) + 'px'; } catch (e) { /* ignore */ }
+    }
+    translateWrites += 1; translateOn = true;
+  }
+  function clearTranslate() {
+    for (const n of chrome) {
+      if (!n || !n.style) continue;
+      try { n.style.translate = ''; if (typeof n.style.removeProperty === 'function') n.style.removeProperty('translate'); } catch (e) { /* ignore */ }
+    }
+    translateOn = false;
+  }
+  function writeChip(c, value) {
+    if (!c.el || !c.el.style || c.last === value) return;
+    try { c.el.style.transform = value; c.last = value; c.writes += 1; } catch (e) { /* ignore */ }
+  }
+  function needsLoop() {
+    if (amp > 0.005) return true;
+    if (punch.px > 0 && punch.until > nowMs()) return true;
+    const t = nowMs();
+    for (const k of Object.keys(chips)) { const c = chips[k]; if (c.a > 0 && t - c.at < c.ms) return true; }
+    return false;
+  }
+  function armLoop() {
+    if (loopOn || paused || destroyed || stopped || still) return;
+    if (!needsLoop()) return;
+    const r = rafFn();
+    if (!r) return;
+    loopOn = true;
+    rafId = r(frame) || 1;
+  }
+  function haltLoop() {
+    if (rafId) { const c = cafFn(); if (c) { try { c(rafId); } catch (e) { /* ignore */ } } }
+    rafId = 0; loopOn = false;
+  }
+  function rest() {
+    if (translateOn) clearTranslate();
+    for (const k of Object.keys(chips)) writeChip(chips[k], '');
+  }
+  function frame() {
+    rafId = 0;
+    if (!loopOn || paused || destroyed) { loopOn = false; return; }
+    step(nowMs());
+    if (needsLoop()) { const r = rafFn(); if (r) { rafId = r(frame) || 1; return; } }
+    loopOn = false;
+    rest();
+  }
+  function step(t) {
+    const s = t / 1000;
+    let x = 0; let y = 0; let moving = false;
+    if (amp > 0.005) {
+      x = amp * (0.62 * Math.sin(6.283 * fq.fx * s + fq.px) + 0.38 * Math.sin(6.283 * fq.sx * s + fq.qx));
+      y = amp * (0.62 * Math.sin(6.283 * fq.fy * s + fq.py) + 0.38 * Math.sin(6.283 * fq.sy * s + fq.qy));
+      moving = true;
+    }
+    if (punch.px > 0) {
+      const left = punch.until - t;
+      if (left <= 0) { punch = { px: 0, until: 0, ms: 1 }; }
+      else {
+        const decay = clamp01(left / punch.ms);
+        const a = punch.px * decay * decay;                  // quadratic ring-down
+        x += (roll('jolt') * 2 - 1) * a;
+        y += (roll('jolt') * 2 - 1) * a;
+        moving = true;
+      }
+    }
+    if (moving) writeTranslate(x, y);
+    else if (translateOn) clearTranslate();
+    for (const k of Object.keys(chips)) {
+      const c = chips[k];
+      if (!c.el) continue;
+      let sc = 1;
+      if (c.a > 0) {
+        const p = (t - c.at) / c.ms;
+        if (p >= 1) c.a = 0;
+        else sc = 1 + c.a * (1 - p) * (1 - p) * Math.cos(p * Math.PI * 2.2);   // overshoot, dip, settle
+      }
+      writeChip(c, sc === 1 ? '' : 'scale(' + sc.toFixed(3) + ')');
+    }
+  }
+  function doPunch(spec) {
+    if (!armed() || stopped || !spec || spec.px <= 0) return;
+    if (still) { bloomChip('len'); return; }
+    const tNow = nowMs();
+    const a = spec.px * P.MOTION_MUL[motion];
+    punch = { px: Math.max(punch.px, a), until: Math.max(punch.until, tNow + spec.ms), ms: Math.max(spec.ms, 1) };
+    count('punch');
+    armLoop();
+  }
+  function punchChip(which, scale, ms) {
+    const c = chips[which];
+    if (!c || !c.el || !armed() || stopped) return;
+    if (still) { bloomChip(which); return; }
+    const a = Math.max(1, Number(scale) || 1) - 1;
+    if (a <= 0.001) return;
+    const t = nowMs();
+    const left = c.a > 0 ? Math.max(0, 1 - (t - c.at) / c.ms) : 0;
+    c.a = Math.max(a, c.a * left);
+    c.at = t;
+    c.ms = Math.max(120, Math.min(P.PUNCH_CAP_MS, Number(ms) || P.CHIP_MS));
+    armLoop();
+  }
+  function bloomChip(which) {
+    const c = chips[which];
+    if (!c || !c.el) return;
+    restart(c.el, 'g-ec-p-bloom');
+    const old = chipBloomTimers.get(which);
+    if (old) cancel(old);
+    chipBloomTimers.set(which, after(P.BLOOM_MS, () => { chipBloomTimers.delete(which); setCls(c.el, 'g-ec-p-bloom', false); }));
+  }
+
+  /* ---- the rungs -------------------------------------------------------- */
+  function retune() {
+    amp = (stopped || !armed() || still) ? 0
+      : Math.min(P.TREMOR_CAP_PX, (P.TREMOR_PX[rung] || 0) * P.MOTION_MUL[motion] * (P.TREMOR_HEAT_FLOOR + (1 - P.TREMOR_HEAT_FLOOR) * heat));
+    if (amp > 0) armLoop();
+  }
+  function breathe(storm) {
+    sustain('wash', { variant: 'pink', alpha: lerp(storm ? P.STORM_BREATH_ALPHA : P.BREATH_ALPHA, heat), holdMs: P.BREATH_HOLD_MS });
+  }
+  function armBreath() {
+    if (breathTimer) cancel(breathTimer);
+    const ms = lerp(P.BREATH_MS, heat) * (0.85 + roll('breath') * 0.3);
+    breathTimer = after(Math.round(ms), () => { breathTimer = 0; if (on.has('breath') && !stopped) { breathe(on.has('storm')); armBreath(); } });
+  }
+  function whisperOut(variant) {
+    /* step a wash DOWN: a whisper alpha + a short hold - it fades on its own
+       deadline (never stop('wash'); the core may hold one too) */
+    sustain('wash', { variant, alpha: P.WHISPER_ALPHA, holdMs: P.WHISPER_HOLD_MS });
+  }
+  function wheel() { sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true }); }
+  function ambientBack() { sustain('ambient_field', { kind: P.AMBIENT_OF_TIER[tier] || 'specks' }); }
+  function veil(variant, seconds) {
+    if (still || !opts.backdrop) return null;
+    return fire('glitch_swap', { targets: opts.backdrop, variant, seconds: seconds || 0.5, sfx: false, onSwap() { /* presentation only */ } });
+  }
+  function applyAdd(add, goingUp) {
+    if (goingUp) {
+      on.add(add);
+      if (add === 'breath') { breathe(false); armBreath(); }
+      else if (add === 'wheel') wheel();
+      else if (add === 'subs') sustain('sub_flash', { variant: P.SUB_VARIANT });
+      else if (add === 'storm') {
+        sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
+        breathe(true);
+        fire('flash_burst', { count: P.FLASH_COUNT, clickSafe: true });
+      }
+      /* burst / tremor / veil / giant / flashes are event-driven: nothing to switch on */
+    } else {
+      on.delete(add);
+      if (add === 'breath') { if (breathTimer) { cancel(breathTimer); breathTimer = 0; } whisperOut('pink'); }
+      else if (add === 'wheel') whisperOut('spiral');
+      else if (add === 'subs') stopKind('sub_flash');
+      else if (add === 'storm') { ambientBack(); if (on.has('breath')) breathe(false); }
+    }
+  }
+  function setRung(r) {
+    if (r === rung) return;
+    const up = r > rung;
+    if (up) {
+      for (let k = rung + 1; k <= r; k++) for (const add of P.RUNG_ADDS[k]) applyAdd(add, true);
+      cue(P.RUNG_CUE[r], r);
+    } else {
+      for (let k = rung; k > r; k--) for (const add of P.RUNG_ADDS[k]) applyAdd(add, false);
+    }
+    rung = r;
+    retune();
+    say('pressure: rung ' + rung + ' (' + (up ? 'up' : 'down') + ', len ' + len + ')');
+  }
+  function setLen(l) {
+    len = Math.max(0, Math.floor(Number(l) || 0));
+    wantRung = rungFor(len);
+    if (!started || stopped) return;
+    if (wantRung > rung) { cancel(downTimer); downTimer = 0; setRung(wantRung); }
+    else if (wantRung < rung && !downTimer) {
+      downTimer = after(P.HYST_MS, () => { downTimer = 0; if (wantRung < rung) setRung(wantRung); });
+    } else if (wantRung === rung) { cancel(downTimer); downTimer = 0; }
+  }
+  function repaintHeat() {
+    if (Math.abs(heat - lastPaintHeat) < P.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (on.has('wheel')) wheel();
+    if (on.has('storm')) sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
+  }
+
+  /* ---- the riders (on a clear) ------------------------------------------ */
+  function ridersOnClear(l) {
+    if (!armed() || stopped) return;
+    if (on.has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat)) {
+      fire('gif_burst', {
+        count: Math.round(lerp(P.BURST_COUNT, heat)), clickSafe: true,
+        sizePx: Math.round(vmin() * lerp(P.BURST_VMIN, heat)),
+        holdMs: Math.round(lerp(P.BURST_HOLD_MS, heat)),
+      });
+    }
+    if (on.has('giant') && roll('giant') < lerp(P.GIANT_CHANCE, heat)) {
+      fire('gif_burst', { count: 1, clickSafe: true, x: 50, y: 50, sizePx: Math.round(vmin() * P.GIANT_VMIN), holdMs: Math.round(lerp(P.GIANT_HOLD_MS, heat)), variant: 'single' });
+    }
+    if (on.has('veil') && roll('veil') < lerp(P.VEIL_CHANCE, heat)) {
+      veil(P.VEIL_VARIANTS[Math.floor(roll('veil') * P.VEIL_VARIANTS.length)], lerp(P.VEIL_S, heat));
+    }
+    if (on.has('flashes')) fire('flash_burst', { count: P.FLASH_COUNT, clickSafe: true });
+    void l;
+  }
+
+  /* ---------------------------------------------------------------- api */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      if (!armed()) { say('pressure: disarmed'); return; }
+      setLen(len);
+      retune();
+      say('pressure: armed (' + chrome.length + ' chrome, tier ' + tier + ')');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (!started || stopped) return;
+      retune();
+      repaintHeat();
+    },
+    /** The rung: the sequence length the class is dealing. The second argument
+     *  is index.js's additive context ({links, cleared, heat}). */
+    setStreak(l, ctx2) {
+      const c = ctx2 || {};
+      if (c.links != null) links = Math.max(0, Math.floor(Number(c.links) || 0));
+      if (c.heat != null) { heat = clamp01(c.heat); }
+      setLen(l);
+      if (started && !stopped) { retune(); repaintHeat(); }
+    },
+    /** index.js's beats: 'seam' (playback ended, the turn opens), 'clear',
+     *  'fail', 'bell'; anything else is a small punch. */
+    beat(kind) {
+      if (!started || stopped) return;
+      const k = String(kind || '');
+      if (k === 'clear') {
+        doPunch(punchFor({ len }));
+        punchChip('len', lerp(P.LEN_PUNCH, clamp01(len / 14)), P.CHIP_MS + 60);
+        if (links >= 3) punchChip('streak', Math.min(P.STREAK_PUNCH_CAP, 1 + P.STREAK_PUNCH_PER_LINK * Math.min(8, links)), 220);
+        ridersOnClear(len);
+      } else if (k === 'fail') {
+        doPunch(punchFor({ len, fail: true }));
+        if (on.has('veil')) veil('datamosh', 0.5);
+      } else if (k === 'seam') {
+        if (on.has('breath')) breathe(on.has('storm'));
+      } else if (k === 'bell') {
+        bellOn = true;
+      } else {
+        doPunch({ px: 0.8, ms: 160 });
+      }
+    },
+    pause() {
+      paused = true;
+      pausedAt = nowMs();
+      cancelAll(); downTimer = 0; breathTimer = 0;
+      for (const [, id] of chipBloomTimers) cancel(id);
+      chipBloomTimers.clear();
+      haltLoop();
+      rest();
+    },
+    resume() {
+      if (!paused) return;
+      paused = false;
+      const gap = Math.max(0, nowMs() - pausedAt);
+      if (punch.px > 0) punch.until += gap;
+      for (const k of Object.keys(chips)) { if (chips[k].a > 0) chips[k].at += gap; }
+      if (!stopped && started) { retune(); if (on.has('breath')) armBreath(); setLen(len); }
+    },
+    /** The class is over: everything sighs out (fades are the engine's), nothing punches again. */
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      cancel(downTimer); downTimer = 0;
+      if (breathTimer) { cancel(breathTimer); breathTimer = 0; }
+      if (on.has('breath') || on.has('storm')) whisperOut('pink');
+      if (on.has('wheel')) whisperOut('spiral');
+      if (on.has('subs')) stopKind('sub_flash');
+      if (on.has('storm')) ambientBack();
+      on.clear();
+      rung = 0;
+      amp = 0; punch = { px: 0, until: 0, ms: 1 };
+      for (const k of Object.keys(chips)) chips[k].a = 0;
+      haltLoop();
+      rest();
+    },
+    destroy() {
+      if (destroyed) return;
+      api.stop();
+      destroyed = true;
+      cancelAll();
+      for (const [which, id] of chipBloomTimers) { cancel(id); const c = chips[which]; if (c) setCls(c.el, 'g-ec-p-bloom', false); }
+      chipBloomTimers.clear();
+      haltLoop();
+      clearTranslate();
+      for (const k of Object.keys(chips)) { const c = chips[k]; if (c.el) { setCls(c.el, 'g-ec-p-bloom', false); try { c.el.style.transform = ''; } catch (e) { /* ignore */ } } }
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, paused, bell: bellOn,
+        rung, wantRung, hystPending: !!downTimer, len, links, heat: +heat.toFixed(3),
+        features: Array.from(on),
+        tremorPx: +amp.toFixed(3), punchPx: +punch.px.toFixed(2), punchLive: punch.px > 0 && punch.until > nowMs(),
+        loop: loopOn, translateWrites, translateOn, chrome: chrome.length,
+        chips: { len: { writes: chips.len.writes, last: chips.len.last }, streak: { writes: chips.streak.writes, last: chips.streak.last } },
+        fires: Object.assign({}, fires),
+        timers: live.size,
+      };
+    },
+  };
+  return api;
+}
+
+export default createEcPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/sequence.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/sequence.js
@@ -1,0 +1,379 @@
+/* ============================================================================
+ * games/echo/sequence.js - ECHO's seeded sequence, decoy plan and tier dials.
+ * PURE: no DOM, no clock, no ctx, no engine.
+ *
+ * WHAT THIS FILE IS. Echo is Simon: one growing stream per ATTEMPT, and the
+ * sequence at length L is the first L items of that stream (a cleared round
+ * APPENDS, it never reshuffles - that is what makes the melody feel like one
+ * melody). The stream, the decoy plan and every dial are functions of the
+ * class seed, so a retake replays the identical class (Law V).
+ *
+ * SEEDING (append-only, Law V):
+ *   stream   makeRng(seed + '|ec-seq|'   + attempt)   - drawn once per attempt
+ *   decoys   makeTaggedRoll(seed + '|ec-decoy|' + attempt) - tag-namespaced, so
+ *            adding a new decoy roll never shifts an existing sequence
+ * Neither ever calls Math.random.
+ *
+ * THE WARM START (contract ruling 5, the critic's top fix). Simon's structural
+ * flaw is that every class restarts at 3 and the first 40 seconds are filler.
+ * Echo opens at clamp(3 + floor(lifetime bestLen / 4), 3, 6) + a per-tier
+ * bonus, capped at START_MAX. A veteran skips the trivial opening; a first
+ * class still opens at 3.
+ *
+ * THE DECOY ECHO (contract ruling 2, SYNTHESIS #2 - the signature twist enters
+ * at tier 2). A decoy is a pad that LIGHTS DURING PLAYBACK and is NOT part of
+ * the sequence; the player must not echo it. It sits at a SEAM: `afterIndex`
+ * real items have played before it, so the temptation is to press it as the
+ * afterIndex-th press. Tier 2 telegraphs it (the sheet says so and the pad
+ * wears a tell); tier 3+ does not. Decoy pads are drawn from the tier's own
+ * alphabet - a pad that could never appear in a sequence would be a free tell.
+ *
+ * ONE FAIL IS NOT THE CLASS (contract ruling 6). After a fail the next
+ * sequence deals at max(startLen, failedLen - FAIL_SETBACK) - a setback, never
+ * a reset to 3 - and the class keeps dealing until the bell.
+ *
+ * THE PITCH LADDER. Six pads, ONE engine recipe, six pitches: a pentatonic
+ * ladder spanning exactly one octave, PAD_SEMIS semitones from the recipe's
+ * own pitch. The combo ratchet adds +1 semitone per streak link, cap 7 (the
+ * Impulse Control shape). The ladder is chosen so that the TOP pad at the FULL
+ * ratchet lands on 2.0 and the BOTTOM pad at zero ratchet on ~0.67 - inside
+ * shell/audio.js's 0.5..2 clamp at both ends, so nothing in the ladder ever
+ * silently flattens against the clamp.
+ * ==========================================================================*/
+
+import { makeRng, makeTaggedRoll } from '../../core/rng.js';
+
+/* ----------------------------------------------------------------------------
+ * THE PLAYTEST BLOCK - every number a playtest might touch, in one place.
+ * -------------------------------------------------------------------------- */
+export const PLAYTEST = Object.freeze({
+  /** Pads on the ring. Always six; the TIER picks how many of them a sequence
+   *  may draw from (all six stay live and pressable at every tier). */
+  PADS: 6,
+  ALPHABET: Object.freeze({ 1: 4, 2: 5, 3: 6, 4: 6 }),
+
+  /** THE WARM START: clamp(BASE + floor(bestLen / DIV), MIN, MAX) + bonus. */
+  WARM_BASE: 3,
+  WARM_DIV: 4,
+  WARM_MIN: 3,
+  WARM_MAX: 6,
+  WARM_TIER_BONUS: Object.freeze({ 1: 0, 2: 1, 3: 1, 4: 2 }),
+  START_MAX: 8,
+  /** The longest stream a class ever deals (a 105s class never reaches it). */
+  MAX_LEN: 24,
+  /** A fail costs this much length, never more (floor = the warm start). */
+  FAIL_SETBACK: 2,
+
+  /** PLAYBACK TEMPO: ms per step by tier, and the lit share of a step. */
+  STEP_MS: Object.freeze({ 1: 620, 2: 560, 3: 500, 4: 440 }),
+  LIT_RATIO: 0.62,
+  /** The floor a lit pad never goes under, however tight the tempo runs. */
+  LIT_MIN_MS: 150,
+  /** ENCORE: the same sequence at half tempo (contract ruling 5). */
+  ENCORE_TEMPO_MULT: 2,
+  /** The interference beat: playback ends -> this gap -> the input turn. */
+  SEAM_MS: 560,
+  SEAM_MS_REDUCED: 360,
+
+  /** THE DECOY PLAN. Chance is per candidate slot; MAX is the ceiling. */
+  DECOY_CHANCE: Object.freeze({ 1: 0, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  DECOY_MAX: Object.freeze({ 1: 0, 2: 1, 3: 1, 4: 2 }),
+  /** No decoy under this sequence length (there is no seam worth using). */
+  DECOY_MIN_LEN: 4,
+  /** Tiers at or below this TELEGRAPH the decoy; above it, they do not. */
+  DECOY_TELEGRAPH_MAX_TIER: 2,
+
+  /** SOFT INPUT TIMER (dossier: tier 3 soft, tier 4 strict). 0 = untimed. */
+  INPUT_WINDOW_MS: Object.freeze({ 1: 0, 2: 0, 3: 4200, 4: 3200 }),
+
+  /** audio_trigger level ceilings by tier (the engine clamps again). */
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+
+  /** HEAT: the class's own ladder is the sequence length; the tier caps it. */
+  HEAT_CAP: Object.freeze({ 1: 0.45, 2: 0.65, 3: 0.85, 4: 1 }),
+  HEAT_FLOOR: 0.12,
+  /** Sequence length that reaches the tier's heat cap. */
+  HEAT_TOP: Object.freeze({ 1: 8, 2: 10, 3: 12, 4: 14 }),
+
+  /** THE COMBO RATCHET: +1 semitone per clean press, capped. */
+  RATCHET_CAP: 7,
+  /** A miss at or past this fraction of the sequence is a NEAR MISS: the
+   *  ratchet drops by NEAR_MISS_DROP instead of resetting (dossier). */
+  NEAR_MISS_FRAC: 0.8,
+  NEAR_MISS_DROP: 2,
+
+  /** The pentatonic pad ladder, in semitones off the recipe's own pitch. */
+  PAD_SEMIS: Object.freeze([-7, -5, -2, 0, 3, 5]),
+  PITCH_MIN: 0.5,
+  PITCH_MAX: 2,
+
+  /** Class rhythm. */
+  BELL_WARN_SEC: 15,
+  BRIEF_MS: 1500,
+  BRIEF_MS_REDUCED: 800,
+  CLEAR_HOLD_MS: 950,
+  CLEAR_HOLD_MS_REDUCED: 520,
+  FAIL_HOLD_MS: 1250,
+  FAIL_HOLD_MS_REDUCED: 700,
+  REVEAL_MS: 620,
+  END_HOLD_MS: 2400,
+  END_HOLD_MS_REDUCED: 1300,
+  STALL_TICK_MS: 500,
+  /** The trickster is told about a stall at this many ms of silence. */
+  STALL_MS: 3500,
+
+  /** ctx.audioAudible === false: the cue is mixed but inaudible, so the LIGHT
+   *  has to carry the whole signal - pads light longer and brighter. */
+  SILENT_LIT_MULT: 1.35,
+
+  /** The streak chip appears from this many clean presses. */
+  STREAK_VISIBLE: 2,
+  /** The 10-segment shell meter fills to here. */
+  STREAK_CAP: 10,
+});
+
+/* ----------------------------------------------------------------------------
+ * SMALL PURE HELPERS
+ * -------------------------------------------------------------------------- */
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+export function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Number(gradeTier) || 1))); }
+
+/** How many of the six pads a sequence at this tier may draw from. */
+export function alphabetFor(gradeTier) {
+  const n = PLAYTEST.ALPHABET[tierOf(gradeTier)] || PLAYTEST.PADS;
+  return Math.max(2, Math.min(PLAYTEST.PADS, n));
+}
+
+/**
+ * THE WARM START. `bestLen` is the player's LIFETIME longest cleared echo
+ * (gameMeta.bestLen); a first class passes 0 and opens at 3.
+ */
+export function warmStartLen(bestLen, gradeTier) {
+  const t = tierOf(gradeTier);
+  const best = Math.max(0, Math.floor(Number(bestLen) || 0));
+  const base = PLAYTEST.WARM_BASE + Math.floor(best / PLAYTEST.WARM_DIV);
+  const clamped = Math.max(PLAYTEST.WARM_MIN, Math.min(PLAYTEST.WARM_MAX, base));
+  const bonus = PLAYTEST.WARM_TIER_BONUS[t] || 0;
+  return Math.max(PLAYTEST.WARM_MIN, Math.min(PLAYTEST.START_MAX, clamped + bonus));
+}
+
+/** The next sequence length after a fail: a setback, never a reset. */
+export function nextLenAfterFail(failedLen, startLen) {
+  const failed = Math.max(1, Math.floor(Number(failedLen) || 1));
+  const floorLen = Math.max(PLAYTEST.WARM_MIN, Math.floor(Number(startLen) || PLAYTEST.WARM_MIN));
+  return Math.max(floorLen, failed - PLAYTEST.FAIL_SETBACK);
+}
+
+/** ms per playback step. `tempoMult` is the encore's half tempo (2). */
+export function stepMsFor(gradeTier, tempoMult) {
+  const base = PLAYTEST.STEP_MS[tierOf(gradeTier)] || PLAYTEST.STEP_MS[1];
+  const mult = Number.isFinite(Number(tempoMult)) && Number(tempoMult) > 0 ? Number(tempoMult) : 1;
+  return Math.round(base * mult);
+}
+
+/** How long a pad stays lit inside a step of `stepMs`. */
+export function litMsFor(stepMs, opts = {}) {
+  const mult = opts.silent ? PLAYTEST.SILENT_LIT_MULT : 1;
+  const raw = Math.round(Math.max(1, Number(stepMs) || 0) * PLAYTEST.LIT_RATIO * mult);
+  return Math.max(PLAYTEST.LIT_MIN_MS, Math.min(Math.max(1, Number(stepMs) || 0), raw));
+}
+
+/** The soft input window (ms) for a tier. 0 = untimed. */
+export function inputWindowMs(gradeTier, tempoMult) {
+  const base = PLAYTEST.INPUT_WINDOW_MS[tierOf(gradeTier)] || 0;
+  if (!base) return 0;
+  const mult = Number.isFinite(Number(tempoMult)) && Number(tempoMult) > 0 ? Number(tempoMult) : 1;
+  return Math.round(base * mult);
+}
+
+/** The tier's audio ceiling (the engine clamps again on top of this). */
+export function audioCeilFor(gradeTier) {
+  return PLAYTEST.AUDIO_CEIL[tierOf(gradeTier)] || PLAYTEST.AUDIO_CEIL[1];
+}
+
+/**
+ * THE PAD PITCH. One recipe, six pitches, plus the combo ratchet.
+ * @param {number} pad     0..5
+ * @param {number} ratchet 0..RATCHET_CAP semitones
+ */
+export function pitchFor(pad, ratchet) {
+  const i = Math.max(0, Math.min(PLAYTEST.PADS - 1, Math.floor(Number(pad) || 0)));
+  const r = Math.max(0, Math.min(PLAYTEST.RATCHET_CAP, Math.floor(Number(ratchet) || 0)));
+  const semis = PLAYTEST.PAD_SEMIS[i] + r;
+  const p = Math.pow(2, semis / 12);
+  return Math.max(PLAYTEST.PITCH_MIN, Math.min(PLAYTEST.PITCH_MAX, Number(p.toFixed(4))));
+}
+
+/** The ratchet after a miss: a NEAR miss only drops it, a plain miss resets. */
+export function ratchetAfterMiss(ratchet, reachedIndex, len) {
+  const total = Math.max(1, Math.floor(Number(len) || 1));
+  const reached = Math.max(0, Math.floor(Number(reachedIndex) || 0));
+  if (reached / total >= PLAYTEST.NEAR_MISS_FRAC) {
+    return Math.max(0, (Math.floor(Number(ratchet) || 0)) - PLAYTEST.NEAR_MISS_DROP);
+  }
+  return 0;
+}
+
+/** Was a miss at `reachedIndex` of `len` a near miss? (the tease + the tick) */
+export function isNearMiss(reachedIndex, len) {
+  const total = Math.max(1, Math.floor(Number(len) || 1));
+  return (Math.max(0, Math.floor(Number(reachedIndex) || 0)) / total) >= PLAYTEST.NEAR_MISS_FRAC;
+}
+
+/**
+ * HEAT: the class's own ladder is the sequence length, and gradeTier caps it
+ * (the DE / IC shape). A clean-press streak nudges it, never past the cap.
+ */
+export function heatFor(len, gradeTier, startLen, streakLinks) {
+  const t = tierOf(gradeTier);
+  const cap = PLAYTEST.HEAT_CAP[t] || 1;
+  const top = PLAYTEST.HEAT_TOP[t] || 10;
+  const from = Math.max(PLAYTEST.WARM_MIN, Math.floor(Number(startLen) || PLAYTEST.WARM_MIN));
+  const cur = Math.max(from, Math.floor(Number(len) || from));
+  const span = Math.max(1, top - from);
+  const p = clamp01((cur - from) / span);
+  const links = Math.max(0, Math.floor(Number(streakLinks) || 0));
+  const nudge = Math.min(0.08, links * 0.01);
+  const h = PLAYTEST.HEAT_FLOOR + (1 - PLAYTEST.HEAT_FLOOR) * p + nudge;
+  return Math.min(cap, clamp01(h));
+}
+
+/* ----------------------------------------------------------------------------
+ * THE STREAM
+ * -------------------------------------------------------------------------- */
+/**
+ * One attempt's whole stream. The sequence at length L is `stream.slice(0, L)`,
+ * so growth APPENDS and a retake replays the same melody.
+ *
+ * The one shaping rule: never three of the same pad in a row (that reads as a
+ * rendering fault rather than as a sequence). The fix-up consumes the stream
+ * deterministically, so it is still a pure function of the seed.
+ *
+ * @returns {{stream:number[], n:number, attempt:number}}
+ */
+export function buildAttempt({ seed, gradeTier = 1, attempt = 0, maxLen = PLAYTEST.MAX_LEN } = {}) {
+  const n = alphabetFor(gradeTier);
+  const len = Math.max(1, Math.min(256, Math.floor(Number(maxLen) || PLAYTEST.MAX_LEN)));
+  const rng = makeRng(String(seed == null ? '' : seed) + '|ec-seq|' + Math.max(0, Math.floor(Number(attempt) || 0)));
+  const stream = [];
+  for (let i = 0; i < len; i++) {
+    let p = Math.floor(rng() * n);
+    if (p >= n) p = n - 1;
+    if (p < 0) p = 0;
+    if (i >= 2 && stream[i - 1] === p && stream[i - 2] === p) {
+      p = (p + 1 + Math.floor(rng() * (n - 1))) % n;
+    }
+    stream.push(p);
+  }
+  return { stream, n, attempt: Math.max(0, Math.floor(Number(attempt) || 0)) };
+}
+
+/** The sequence dealt at length `len` for this attempt. */
+export function sequenceFor({ seed, gradeTier = 1, attempt = 0, len = 3 } = {}) {
+  const want = Math.max(1, Math.min(PLAYTEST.MAX_LEN, Math.floor(Number(len) || 1)));
+  const { stream } = buildAttempt({ seed, gradeTier, attempt, maxLen: PLAYTEST.MAX_LEN });
+  return stream.slice(0, want);
+}
+
+/* ----------------------------------------------------------------------------
+ * THE DECOY PLAN
+ * -------------------------------------------------------------------------- */
+/**
+ * The decoys for ONE sequence. Deterministic, tier-gated, at most one per seam.
+ *
+ * @returns {Array<{pad:number, afterIndex:number, telegraph:boolean}>} sorted
+ *   by afterIndex. `afterIndex` = how many REAL items played before the decoy,
+ *   so the trap is pressing `pad` when the input is at index afterIndex.
+ */
+export function decoysFor({ seed, gradeTier = 1, attempt = 0, len = 3 } = {}) {
+  const t = tierOf(gradeTier);
+  const max = PLAYTEST.DECOY_MAX[t] || 0;
+  const want = Math.max(1, Math.min(PLAYTEST.MAX_LEN, Math.floor(Number(len) || 1)));
+  if (max <= 0 || want < PLAYTEST.DECOY_MIN_LEN) return [];
+  const chance = PLAYTEST.DECOY_CHANCE[t] || 0;
+  const n = alphabetFor(t);
+  const seq = sequenceFor({ seed, gradeTier: t, attempt, len: want });
+  const roll = makeTaggedRoll(String(seed == null ? '' : seed) + '|ec-decoy|' + Math.max(0, Math.floor(Number(attempt) || 0)));
+  const telegraph = t <= PLAYTEST.DECOY_TELEGRAPH_MAX_TIER;
+  const out = [];
+  const taken = new Set();
+  for (let k = 0; k < max; k++) {
+    if (roll('fire|' + want + '|' + k) >= chance) continue;
+    /* The seam sits BETWEEN two real items: 1 .. len-1. */
+    const slots = Math.max(1, want - 1);
+    let afterIndex = 1 + Math.floor(roll('pos|' + want + '|' + k) * slots);
+    if (afterIndex > want - 1) afterIndex = want - 1;
+    if (taken.has(afterIndex)) continue;              // one decoy per seam
+    /* The pad must be in the tier's own alphabet (a pad that could never be
+     * part of a sequence would be a free tell), and it must not be either of
+     * the two real items it sits between - that would be indistinguishable
+     * from a legitimate repeat rather than a lie. */
+    let pad = Math.floor(roll('pad|' + want + '|' + k) * n);
+    if (pad >= n) pad = n - 1;
+    const banned = new Set([seq[afterIndex - 1], seq[afterIndex]]);
+    let guard = 0;
+    while (banned.has(pad) && guard < n) { pad = (pad + 1) % n; guard += 1; }
+    if (banned.has(pad)) continue;                    // a 2-pad alphabet has no room
+    taken.add(afterIndex);
+    out.push({ pad, afterIndex, telegraph });
+  }
+  out.sort((a, b) => a.afterIndex - b.afterIndex);
+  return out;
+}
+
+/**
+ * PLAYBACK: the flat step list the ring walks, real items and decoys woven
+ * together in play order.
+ * @returns {Array<{pad:number, decoy:boolean, index:number, telegraph:boolean}>}
+ *   `index` is the REAL sequence index for a real step, and the seam's
+ *   afterIndex for a decoy.
+ */
+export function playbackSteps(seq, decoys) {
+  const items = Array.isArray(seq) ? seq : [];
+  const plan = Array.isArray(decoys) ? decoys.slice().sort((a, b) => a.afterIndex - b.afterIndex) : [];
+  const out = [];
+  let d = 0;
+  for (let i = 0; i < items.length; i++) {
+    while (d < plan.length && plan[d].afterIndex === i) {
+      out.push({ pad: plan[d].pad, decoy: true, index: i, telegraph: !!plan[d].telegraph });
+      d += 1;
+    }
+    out.push({ pad: items[i], decoy: false, index: i, telegraph: false });
+  }
+  while (d < plan.length) {                            // a seam past the end (never dealt, kept safe)
+    out.push({ pad: plan[d].pad, decoy: true, index: items.length, telegraph: !!plan[d].telegraph });
+    d += 1;
+  }
+  return out;
+}
+
+/**
+ * THE WHOLE ROUND, in one pure call - what the suite asserts against and what
+ * index.js walks. Nothing here touches a clock or a node.
+ */
+export function buildRound({ seed, gradeTier = 1, attempt = 0, len = 3, encore = false } = {}) {
+  const t = tierOf(gradeTier);
+  const want = Math.max(1, Math.min(PLAYTEST.MAX_LEN, Math.floor(Number(len) || 1)));
+  const seq = sequenceFor({ seed, gradeTier: t, attempt, len: want });
+  const decoys = decoysFor({ seed, gradeTier: t, attempt, len: want });
+  const tempoMult = encore ? PLAYTEST.ENCORE_TEMPO_MULT : 1;
+  const stepMs = stepMsFor(t, tempoMult);
+  return {
+    seq,
+    len: seq.length,
+    decoys,
+    steps: playbackSteps(seq, decoys),
+    stepMs,
+    litMs: litMsFor(stepMs),
+    windowMs: inputWindowMs(t, tempoMult),
+    encore: !!encore,
+    tier: t,
+    attempt: Math.max(0, Math.floor(Number(attempt) || 0)),
+  };
+}
+
+export default {
+  PLAYTEST, alphabetFor, warmStartLen, nextLenAfterFail, stepMsFor, litMsFor,
+  inputWindowMs, audioCeilFor, pitchFor, ratchetAfterMiss, isNearMiss, heatFor,
+  buildAttempt, sequenceFor, decoysFor, playbackSteps, buildRound, tierOf, clamp01,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/style.js
@@ -1,0 +1,528 @@
+/* ============================================================================
+ * games/echo/style.js - the game injects its OWN stylesheet from JS.
+ *
+ * THE MUSIC ROOM AFTER HOURS. The class root is a full-viewport stage: a dark
+ * rehearsal room, one warm spotlight from above, and SIX PADS standing in a
+ * ring on the floor like lit instruments - each its own colour, each a drum
+ * head of glass over a lamp. When a pad plays it does not just change colour:
+ * the lamp comes up, the glass blooms, and the light FALLS OFF onto the floor
+ * around it (a spill pseudo twice the pad's size, a floor pool under it) so
+ * the room itself reads the sequence. Composition, exactly the DOM contract:
+ *
+ *   .g-ec-stage[data-phase=briefing|play|echo|input|encore|ended]
+ *                   absolute inset:0, explicit ground, padded under the shell's
+ *                   proctor strip; --ec-ring is the one circle everything on
+ *                   the floor is sized from
+ *   .g-ec-backdrop  the casino's lighting rig (pointer-events:none, z 0)
+ *   .g-ec-hud       four chips: len (big, the score of this class), clock,
+ *                   streak (pink), best (gold)
+ *   .g-ec-ring      the floor circle; the pads hang off its centre
+ *   .g-ec-pad[data-pad=0..5][data-state=idle|lit|pressed|decoy]
+ *                   ABSOLUTE, positioned ONLY by its transform from --ec-a
+ *                   (its angle on the ring) and --ec-r (the ring radius); the
+ *                   transform is positional ONLY - every bloom, squash, ripple
+ *                   and shiver lives on .g-ec-face, the ::before (the ripple)
+ *                   or the ::after (the spill), never on the pad's own
+ *                   transform, so the hitbox never moves (Law II)
+ *     .g-ec-face    the glass: lamp gradient + rim; inside it .g-ec-media
+ *                   wears the player's own pool media at LOW alpha (Deck VI
+ *                   asset chrome; shown only once the pad is .is-loaded),
+ *                   screen-blended, ken-burns drifting, and .g-ec-glyph - the
+ *                   TRUTH NODE: the pad's mark, in the pad's colour, never
+ *                   re-written by anyone
+ *     .g-ec-word    the pad's word on a dark plate at the rim (empty under
+ *                   data-faces=glyphs) - the ONE node a trickster may lie on;
+ *                   the glyph, the colour and the place on the ring are the
+ *                   truth (Law IV)
+ *   .g-ec-msg / .g-ec-flashwell / .g-ec-end (the core toggles .g-ec-end and
+ *                   the streak chip with the hidden attribute, so NEITHER
+ *                   carries a display: here - trap 27)
+ *   .g-ec-howto     the drawn class-rules sheet (Deck VI): three vignettes
+ *                   DRAWN ENTIRELY IN CSS on an empty span (.g-ec-howto-art
+ *                   [data-art=watch|repeat|decoy] - box-shadow lamps on the
+ *                   ::before, a keycap / a cold pad with a bar through it on
+ *                   the ::after) - and one GO
+ *
+ * STAGE ATTRIBUTES the core writes and this file reads: data-phase,
+ * data-tier, data-faces (words|glyphs), data-audible (1|0 - the audio tell),
+ * data-reduced, data-telegraph (tier 2's decoy warning), data-encore.
+ *
+ * PAD STATES (the lamp ladder): idle = a dim ember that breathes; lit = the
+ * lamp full on, glass bloom, spill and floor pool up, a 90ms attack and a
+ * slow 600ms decay so a fast playback still reads as separate notes; pressed =
+ * the same light plus the face squashes (scale .94 on the FACE) and a ripple
+ * ring runs out from the point of contact; decoy = a COLD light - the hue
+ * rolls toward cyan, saturation drops, the glass flickers in steps and the
+ * spill goes grey-blue - the telegraphed tell of tier 2 (tier 3+ the core
+ * simply marks the decoy lit, and nothing here can tell the difference,
+ * which is the point).
+ *
+ * AUDIO-INAUDIBLE TELL: .g-ec-stage[data-audible="0"] makes lit/pressed pads
+ * flash brighter and hold longer (the contract's mandatory visual tell when
+ * ctx.audioAudible === false). The core sets the attribute; we size it.
+ *
+ * PALETTE: six pad hues spread around the wheel so no two neighbours rhyme
+ * (pink, gold, teal, violet, coral, sky); the casino may rotate the whole set
+ * with --ec-n-rot on the stage (seeded identity) and retint the room with
+ * --ec-n-la / --ec-n-lb / --ec-n-spot. Every other colour is a shell token
+ * mix, so init.palette reskins the room.
+ *
+ * NOTHING IS EVER STILL (Law III): the spotlight breathes, idle pads ember,
+ * the media drifts, the casino's halo crawls. REDUCED MOTION twice over
+ * (html.arc-reduced + the media query): transitions only, no keyframes.
+ * .g-ec-stage.suspended freezes every animation so the core can hold the
+ * room's breath with the class.
+ *
+ * The rule of this file: NO `display:` on a node the shell toggles with the
+ * hidden attribute, and NEVER the bracketed hidden selector (trap 27).
+ * ==========================================================================*/
+
+const STYLE_ID = 'g-ec-style';
+
+/* the six pads, their hues and their angles on the ring: generated so the
+   numbers live in one place. Six pads = 60deg steps from the top; a ring
+   that carries only four pads (no data-pad=4) sits them on the diamond. */
+const PAD_HUES = Object.freeze([330, 46, 178, 264, 20, 205]);
+function padRules() {
+  let css = '';
+  for (let i = 0; i < 6; i++) {
+    css += '.g-ec-pad[data-pad="' + i + '"]{--ec-h-base:' + PAD_HUES[i] + ';--ec-a:var(--ang,' + (-90 + 60 * i) + 'deg)}\n';
+  }
+  for (let i = 0; i < 4; i++) {
+    css += '.g-ec-ring:not(:has(.g-ec-pad[data-pad="4"])) .g-ec-pad[data-pad="' + i + '"]{--ec-a:var(--ang,' + (-90 + 90 * i) + 'deg)}\n';
+  }
+  return css;
+}
+
+export const STYLE_TEXT = `
+/* ---- registered decoration props: numbers interpolate, so a var change
+   TWEENS instead of snapping --------------------------------------------- */
+@property --ec-n-rot{syntax:'<number>';inherits:true;initial-value:0}
+@property --ec-n-spot{syntax:'<number>';inherits:true;initial-value:.7}
+@property --ec-lamp{syntax:'<number>';inherits:true;initial-value:0}
+
+/* ---- the stage: the whole window is the room ---------------------------- */
+.g-ec-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
+  align-items:center;gap:8px;padding:72px 18px 14px;color:var(--ink);
+  --ec-ring:min(calc(100dvh - 250px), calc(100vw - 60px), 640px);
+  --ec-pad:calc(var(--ec-ring) * .255);
+  --ec-r:calc(var(--ec-ring) * .355);
+  --ec-la:var(--ec-n-la, color-mix(in srgb, var(--gold), transparent 82%));
+  --ec-lb:var(--ec-n-lb, color-mix(in srgb, var(--pink), transparent 84%));
+  --ec-breath:var(--ec-n-breath,7s);
+  --ec-kb:var(--ec-n-kb,26s);
+  --ec-n-rot:0;
+  transition:--ec-n-rot 2.4s ease, --ec-n-spot 2s ease;
+  background:
+    radial-gradient(60% 46% at 50% 2%, var(--ec-la), transparent 70%),
+    radial-gradient(90% 50% at 50% 112%, var(--ec-lb), transparent 64%),
+    linear-gradient(180deg, color-mix(in srgb, var(--navy), black 30%) 0%, color-mix(in srgb, var(--ground), black 46%) 100%)}
+.g-ec-stage.suspended *{animation-play-state:paused !important}
+.g-ec-stage,.g-ec-stage *{box-sizing:border-box}
+
+/* the floorboards: a faint plank grain under everything, perspective-squashed */
+.g-ec-stage::before{content:"";position:absolute;left:-20%;right:-20%;top:46%;bottom:-4%;z-index:0;
+  pointer-events:none;opacity:.22;transform:perspective(700px) rotateX(58deg);transform-origin:50% 100%;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 58px, color-mix(in srgb, var(--ink), transparent 86%) 58px 60px),
+    repeating-linear-gradient(0deg, transparent 0 7px, color-mix(in srgb, var(--ink), transparent 94%) 7px 8px);
+  -webkit-mask-image:radial-gradient(60% 70% at 50% 40%, #000 20%, transparent 100%);
+  mask-image:radial-gradient(60% 70% at 50% 40%, #000 20%, transparent 100%)}
+/* the wall line: a picture rail where the wall meets the dark */
+.g-ec-stage::after{content:"";position:absolute;left:0;right:0;top:calc(46% - 1px);height:2px;z-index:0;
+  pointer-events:none;background:linear-gradient(90deg, transparent, color-mix(in srgb, var(--gold), transparent 70%) 30% 70%, transparent);
+  opacity:.35}
+
+/* ---- the backdrop: the casino's lighting rig (decoration only) ---------- */
+.g-ec-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+.g-ec-backdrop *{pointer-events:none}
+/* the spotlight cone: ALWAYS there (style-owned, so a disarmed casino still
+   lights the room), breathing on the seed's period */
+.g-ec-backdrop::before{content:"";position:absolute;left:50%;top:-6%;width:150%;height:120%;
+  transform:translateX(-50%);
+  background:
+    conic-gradient(from 164deg at 50% 0%, transparent 0 9deg, var(--ec-la) 13deg 19deg, transparent 23deg 32deg),
+    radial-gradient(46% 40% at 50% 4%, color-mix(in srgb, var(--gold), transparent 70%), transparent 70%);
+  opacity:var(--ec-n-spot,.7);
+  animation:g-ec-breathe var(--ec-breath) ease-in-out infinite alternate;
+  -webkit-mask-image:linear-gradient(to bottom, #000 0, #000 55%, transparent 92%);
+  mask-image:linear-gradient(to bottom, #000 0, #000 55%, transparent 92%)}
+@keyframes g-ec-breathe{from{opacity:calc(var(--ec-n-spot,.7) * .72);transform:translateX(-50%) scaleX(1)}
+  to{opacity:var(--ec-n-spot,.7);transform:translateX(-50%) scaleX(1.05)}}
+/* dust in the beam */
+.g-ec-backdrop::after{content:"";position:absolute;inset:0;opacity:.5;
+  background:
+    radial-gradient(1.5px 1.5px at 22% 18%, color-mix(in srgb, var(--ink), transparent 55%), transparent 70%),
+    radial-gradient(1px 1px at 61% 32%, color-mix(in srgb, var(--ink), transparent 60%), transparent 70%),
+    radial-gradient(1.5px 1.5px at 44% 52%, color-mix(in srgb, var(--gold), transparent 60%), transparent 70%),
+    radial-gradient(1px 1px at 72% 61%, color-mix(in srgb, var(--ink), transparent 65%), transparent 70%),
+    radial-gradient(1px 1px at 33% 74%, color-mix(in srgb, var(--ink), transparent 68%), transparent 70%),
+    radial-gradient(1.5px 1.5px at 84% 22%, color-mix(in srgb, var(--gold), transparent 66%), transparent 70%);
+  background-size:420px 380px;
+  animation:g-ec-dust calc(var(--ec-kb) * 1.4) linear infinite}
+@keyframes g-ec-dust{to{background-position:-60px 380px}}
+
+/* ---- the HUD --------------------------------------------------------------- */
+.g-ec-hud{position:relative;z-index:4;display:flex;gap:10px;align-items:stretch;justify-content:center;
+  flex-wrap:wrap;width:min(100%, 760px);font-family:var(--mono);font-size:12px;letter-spacing:.12em;
+  text-transform:uppercase;color:var(--ink-dim)}
+.g-ec-chip{position:relative;text-align:center;line-height:1.2;
+  min-width:86px;padding:7px 14px 6px;border-radius:11px;
+  background:color-mix(in srgb, var(--panel), transparent 22%);
+  border:1px solid color-mix(in srgb, var(--line), transparent 20%);
+  box-shadow:0 6px 18px rgba(0,0,0,.35), inset 0 1px 0 color-mix(in srgb, var(--ink), transparent 88%);
+  transition:box-shadow .3s ease, border-color .3s ease}
+.g-ec-chip::before{content:attr(aria-label);display:block;font-size:9px;letter-spacing:.22em;color:var(--ink-faint);margin-bottom:2px;font-family:var(--mono)}
+/* the shell's 10-segment meter rides inside the streak chip */
+.g-ec-chip.g-ec-streak > *{margin-top:4px}
+/* pressure.js's reduced-motion punch: a bloom, never a move */
+.g-ec-chip.g-ec-p-bloom{box-shadow:0 0 0 2px color-mix(in srgb, var(--pink), transparent 45%), 0 0 22px color-mix(in srgb, var(--pink), transparent 40%) !important;transition:box-shadow .3s ease}
+.g-ec-chip.g-ec-len{min-width:118px;font-family:var(--disp);font-size:26px;letter-spacing:.06em;color:var(--ink);
+  border-color:color-mix(in srgb, var(--pink), transparent 55%);
+  text-shadow:0 0 16px color-mix(in srgb, var(--pink), transparent 45%)}
+.g-ec-chip.g-ec-len::before{font-family:var(--mono);letter-spacing:.22em}
+.g-ec-chip.g-ec-clock{font-variant-numeric:tabular-nums;font-size:15px;color:var(--ink)}
+.g-ec-chip.g-ec-streak{color:var(--pink)}
+.g-ec-chip.g-ec-best{color:var(--gold)}
+.g-ec-chip.g-ec-retake{color:var(--lav);border-style:dashed}
+/* the input-window ring: a chip-sized conic face, --ec-k 1 -> 0 (index.js
+   writes the var and toggles the chip hidden; no display: here - trap 27) */
+.g-ec-chip.g-ec-timer{min-width:0;width:40px;height:40px;padding:0;border-radius:50%;vertical-align:middle;
+  background:
+    radial-gradient(circle, color-mix(in srgb, var(--panel), transparent 10%) 0 58%, transparent 60%),
+    conic-gradient(from -90deg, var(--lav) 0deg, var(--lav) calc(var(--ec-k,1) * 360deg), color-mix(in srgb, var(--line), transparent 40%) calc(var(--ec-k,1) * 360deg));
+  box-shadow:0 6px 18px rgba(0,0,0,.35), 0 0 14px color-mix(in srgb, var(--lav), transparent 70%)}
+.g-ec-chip.g-ec-timer::before{content:none}
+.g-ec-stage[data-phase="input"] .g-ec-chip.g-ec-clock{border-color:color-mix(in srgb, var(--lav), transparent 50%)}
+
+/* ---- the ring: the floor circle ----------------------------------------- */
+.g-ec-ring{position:relative;z-index:3;flex:0 0 auto;width:var(--ec-ring);height:var(--ec-ring);
+  margin:auto 0;border-radius:50%;
+  /* a chalk circle on the boards, and the pool of spotlight inside it */
+  background:
+    radial-gradient(circle at 50% 46%, color-mix(in srgb, var(--gold), transparent 88%) 0%, transparent 58%),
+    radial-gradient(circle, transparent 0 calc(50% - 3px), color-mix(in srgb, var(--ink), transparent 84%) calc(50% - 2px) calc(50% - 1px), transparent 50%);
+  touch-action:manipulation}
+/* the centre mark: where the playback sits */
+.g-ec-ring::before{content:"";position:absolute;left:50%;top:50%;width:14%;height:14%;border-radius:50%;
+  transform:translate(-50%,-50%);pointer-events:none;opacity:.55;
+  background:radial-gradient(circle, color-mix(in srgb, var(--ink), transparent 80%) 0 28%, transparent 30% 60%,
+    color-mix(in srgb, var(--ink), transparent 88%) 62% 64%, transparent 66%);
+  animation:g-ec-centre calc(var(--ec-breath) * 1.3) ease-in-out infinite alternate}
+@keyframes g-ec-centre{from{opacity:.35;transform:translate(-50%,-50%) scale(.92)}to{opacity:.7;transform:translate(-50%,-50%) scale(1.04)}}
+.g-ec-stage[data-phase="echo"] .g-ec-ring::before{animation-duration:1.2s}
+.g-ec-stage[data-phase="input"] .g-ec-ring::before{opacity:.25;animation:none}
+
+/* ---- the pads: six lit instruments -------------------------------------- */
+${padRules()}
+.g-ec-pad{position:absolute;left:50%;top:50%;width:var(--ec-pad);height:var(--ec-pad);margin:0;padding:0;
+  border:0;border-radius:50%;background:transparent;cursor:pointer;color:var(--ink);
+  -webkit-appearance:none;appearance:none;-webkit-tap-highlight-color:transparent;user-select:none;
+  --ec-h:calc(var(--ec-h-base,330) + var(--ec-n-rot,0));
+  --ec-lamp:0;
+  --ec-sat:88%;
+  transform:translate(-50%,-50%) rotate(var(--ec-a,0deg)) translate(var(--ec-r)) rotate(calc(-1 * var(--ec-a,0deg)));
+  transition:--ec-lamp .6s ease-out;
+  outline:none;z-index:1}
+.g-ec-pad:focus-visible .g-ec-face{box-shadow:0 0 0 3px color-mix(in srgb, var(--ink), transparent 40%), 0 10px 28px rgba(0,0,0,.5)}
+/* THE FACE: a drum head of glass over a lamp. The lamp var drives everything. */
+.g-ec-face{position:absolute;inset:0;border-radius:50%;overflow:hidden;pointer-events:none;
+  background:
+    radial-gradient(circle at 50% 38%, hsl(var(--ec-h) var(--ec-sat) 82% / calc(.25 + .75 * var(--ec-lamp))) 0%,
+      hsl(var(--ec-h) var(--ec-sat) 62% / calc(.18 + .62 * var(--ec-lamp))) 34%,
+      hsl(var(--ec-h) var(--ec-sat) 30% / calc(.55 + .35 * var(--ec-lamp))) 72%,
+      hsl(var(--ec-h) 40% 10% / .95) 100%),
+    color-mix(in srgb, var(--ground), black 30%);
+  border:2px solid hsl(var(--ec-h) 70% calc(40% + 35% * var(--ec-lamp)) / .85);
+  box-shadow:
+    0 10px 28px rgba(0,0,0,.5),
+    inset 0 -10px 22px rgba(0,0,0,.55),
+    inset 0 2px 0 hsl(var(--ec-h) 80% 90% / calc(.25 + .5 * var(--ec-lamp))),
+    0 0 calc(10px + 34px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / calc(.15 + .7 * var(--ec-lamp)));
+  transform:scale(1);
+  transition:transform .14s cubic-bezier(.2,1.4,.4,1), box-shadow .16s ease-out, border-color .16s ease-out, filter .3s ease}
+/* the glass highlight: a crescent that brightens with the lamp */
+.g-ec-face::before{content:"";position:absolute;left:14%;top:8%;width:58%;height:34%;border-radius:50%;
+  background:linear-gradient(180deg, rgba(255,255,255,calc(.14 + .3 * var(--ec-lamp))), transparent);
+  filter:blur(1px)}
+/* the idle ember: every pad breathes a little on its own phase (Law III) */
+.g-ec-face::after{content:"";position:absolute;inset:28%;border-radius:50%;
+  background:radial-gradient(circle, hsl(var(--ec-h) 90% 72% / .5), transparent 70%);
+  opacity:.35;
+  animation:g-ec-ember calc(var(--ec-breath) * .9) ease-in-out infinite alternate;
+  animation-delay:calc(var(--ec-a,0deg) / 360deg * -7s)}
+@keyframes g-ec-ember{from{opacity:.18;transform:scale(.86)}to{opacity:.5;transform:scale(1.08)}}
+/* THE SPILL: the light falls off the pad onto the floor (a pseudo twice the
+   pad, pointer-events:none so the hitbox stays the pad) */
+.g-ec-pad::after{content:"";position:absolute;left:50%;top:50%;width:240%;height:240%;border-radius:50%;
+  transform:translate(-50%,-46%);pointer-events:none;z-index:-1;
+  background:radial-gradient(circle, hsl(var(--ec-h) 95% 70% / .58) 0%, hsl(var(--ec-h) 90% 60% / .22) 28%, transparent 62%);
+  opacity:calc(.06 + .94 * var(--ec-lamp));
+  transition:opacity .6s ease-out}
+/* THE RIPPLE: runs out from the face on a press (the ::before of the pad) */
+.g-ec-pad::before{content:"";position:absolute;inset:0;border-radius:50%;pointer-events:none;
+  border:2px solid hsl(var(--ec-h) 95% 78% / .9);opacity:0;transform:scale(1)}
+/* the media: the player's own pool at LOW alpha (Deck VI asset chrome),
+   screen-blended into the lamp, drifting (ken-burns), tinted by the pad */
+.g-ec-media{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;border-radius:50%;
+  opacity:0;mix-blend-mode:screen;transition:opacity .8s ease;
+  filter:saturate(.7) sepia(.2) hue-rotate(calc(var(--ec-h) * 1deg - 40deg));
+  animation:g-ec-kb var(--ec-kb) ease-in-out infinite alternate;
+  animation-delay:calc(var(--ec-a,0deg) / 360deg * -26s)}
+@keyframes g-ec-kb{from{transform:scale(1.02) translate(0,0)}to{transform:scale(1.1) translate(2%,-1.6%)}}
+.g-ec-pad.is-loaded .g-ec-media{opacity:calc(.16 + .16 * var(--ec-lamp))}
+/* THE GLYPH: the truth node. A drawn mark in the pad's colour, centred on the
+   glass; under word faces it rides a little higher to leave the rim to the word */
+.g-ec-glyph{position:absolute;left:50%;top:50%;transform:translate(-50%,-52%);pointer-events:none;
+  font:400 clamp(20px, calc(var(--ec-pad) * .36), 46px)/1 var(--body,system-ui,sans-serif);
+  color:hsl(var(--ec-h) 90% calc(84% + 10% * var(--ec-lamp)));
+  text-shadow:0 0 calc(4px + 14px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / .9), 0 1px 0 rgba(0,0,0,.5);
+  transition:transform .3s ease}
+.g-ec-stage[data-faces="words"] .g-ec-glyph{top:44%;font-size:clamp(16px, calc(var(--ec-pad) * .28), 36px)}
+/* THE WORD: a lit letter on a dark plate at the rim. The ONE node a trickster
+   may lie on. Empty under glyph faces: it simply is not there to read. */
+.g-ec-word{position:absolute;left:50%;bottom:11%;transform:translate(-50%,0);pointer-events:none;
+  max-width:84%;padding:2px 8px;border-radius:7px;
+  font-family:var(--disp);font-size:clamp(10px, calc(var(--ec-pad) * .13), 18px);letter-spacing:.08em;
+  text-transform:uppercase;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  color:hsl(var(--ec-h) 90% calc(84% + 10% * var(--ec-lamp)));
+  background:rgba(8,6,22,calc(.55 - .2 * var(--ec-lamp)));
+  text-shadow:0 0 calc(4px + 12px * var(--ec-lamp)) hsl(var(--ec-h) 95% 70% / .9);
+  transition:color .2s ease, background .3s ease, opacity .3s ease}
+.g-ec-word:empty{opacity:0}
+/* ---- the lamp ladder: states ------------------------------------------- */
+.g-ec-pad[data-state="lit"]{--ec-lamp:1;transition:--ec-lamp .09s ease-out}
+.g-ec-pad[data-state="lit"] .g-ec-face{transform:scale(1.04);filter:brightness(1.08)}
+.g-ec-pad[data-state="lit"] .g-ec-face::after{opacity:.9;animation:none;transform:scale(1.3)}
+.g-ec-pad[data-state="pressed"]{--ec-lamp:1;transition:--ec-lamp .05s ease-out}
+.g-ec-pad[data-state="pressed"] .g-ec-face{transform:scale(.94);filter:brightness(1.18)}
+.g-ec-pad[data-state="pressed"] .g-ec-face::after{opacity:1;animation:none;transform:scale(1.4)}
+.g-ec-pad[data-state="pressed"]::before{animation:g-ec-ripple .55s ease-out 1}
+@keyframes g-ec-ripple{0%{opacity:.9;transform:scale(.9)}100%{opacity:0;transform:scale(1.7)}}
+/* hover/active on the hitbox itself: a breath of light, never a move */
+.g-ec-stage[data-phase="input"] .g-ec-pad:hover{--ec-lamp:.32;transition:--ec-lamp .12s ease-out}
+.g-ec-pad:active .g-ec-face{transform:scale(.95)}
+/* THE DECOY: a cold light. Tier 2's telegraphed tell - the hue rolls to the
+   cold side, the saturation drops, the glass flickers in steps, the spill is
+   grey-blue. Tier 3+ the core marks decoys lit and this rule never fires. */
+.g-ec-pad[data-state="decoy"]{--ec-lamp:.85;--ec-sat:30%;--ec-h:196;transition:--ec-lamp .09s ease-out}
+.g-ec-pad[data-state="decoy"] .g-ec-face{filter:saturate(.5) contrast(1.15);
+  animation:g-ec-decoyflick .26s steps(3) infinite}
+.g-ec-pad[data-state="decoy"] .g-ec-face::after{opacity:.7;animation:none;transform:scale(1.2);
+  background:radial-gradient(circle, hsl(196 40% 72% / .5), transparent 70%)}
+.g-ec-pad[data-state="decoy"]::after{background:radial-gradient(circle, hsl(196 30% 70% / .4) 0%, hsl(200 20% 55% / .16) 30%, transparent 62%)}
+.g-ec-pad[data-state="decoy"] .g-ec-word{color:hsl(196 30% 82%);text-shadow:-1px 0 hsl(330 90% 70% / .6), 1px 0 hsl(178 80% 60% / .6)}
+@keyframes g-ec-decoyflick{0%{opacity:1}50%{opacity:.72}100%{opacity:.92}}
+/* the audio-inaudible tell (ctx.audioAudible false): brighter, longer */
+.g-ec-stage[data-audible="0"] .g-ec-pad[data-state="lit"] .g-ec-face,
+.g-ec-stage[data-audible="0"] .g-ec-pad[data-state="pressed"] .g-ec-face{filter:brightness(1.35) saturate(1.2)}
+.g-ec-stage[data-audible="0"] .g-ec-pad{transition:--ec-lamp 1s ease-out}
+.g-ec-stage[data-audible="0"] .g-ec-pad[data-state="lit"],
+.g-ec-stage[data-audible="0"] .g-ec-pad[data-state="pressed"]{transition:--ec-lamp .05s ease-out}
+/* tier 2 telegraphs the decoy: the proctor line wears a cold edge while it says so */
+.g-ec-stage[data-telegraph="1"] .g-ec-msg{border-color:hsl(196 40% 60% / .6);box-shadow:0 8px 24px rgba(0,0,0,.4), 0 0 18px hsl(196 50% 60% / .25)}
+
+/* ---- phases ------------------------------------------------------------- */
+/* playback: the room leans in - the spotlight narrows a hair, the HUD dims */
+.g-ec-stage[data-phase="echo"] .g-ec-hud{opacity:.72}
+.g-ec-stage[data-phase="echo"] .g-ec-pad{cursor:default}
+/* your turn: the ring's chalk line wakes */
+.g-ec-stage[data-phase="input"] .g-ec-ring{
+  box-shadow:0 0 0 1px color-mix(in srgb, var(--lav), transparent 70%), 0 0 40px color-mix(in srgb, var(--lav), transparent 88%)}
+/* encore: the room goes warm and slow (casino.encore sets the pace; this is the tint) */
+.g-ec-stage[data-phase="encore"],.g-ec-stage[data-encore="1"]{--ec-la:color-mix(in srgb, var(--gold), transparent 70%);
+  --ec-lb:color-mix(in srgb, var(--gold), transparent 86%)}
+.g-ec-stage[data-phase="encore"] .g-ec-pad,.g-ec-stage[data-encore="1"] .g-ec-pad{transition:--ec-lamp 1.2s ease-out}
+.g-ec-stage[data-phase="encore"] .g-ec-pad[data-state="lit"],.g-ec-stage[data-encore="1"] .g-ec-pad[data-state="lit"],
+.g-ec-stage[data-phase="encore"] .g-ec-pad[data-state="pressed"],.g-ec-stage[data-encore="1"] .g-ec-pad[data-state="pressed"]{transition:--ec-lamp .2s ease-out}
+/* ended: the lamps go down, the spotlight stays on the empty ring */
+.g-ec-stage[data-phase="ended"] .g-ec-pad{--ec-lamp:0 !important;cursor:default;opacity:.55;transition:opacity 1.2s ease, --ec-lamp 1.2s ease}
+.g-ec-stage[data-phase="ended"] .g-ec-face::after{animation:none;opacity:.1}
+.g-ec-stage[data-phase="ended"] .g-ec-ring{box-shadow:none}
+.g-ec-stage[data-phase="briefing"] .g-ec-pad{--ec-lamp:0}
+
+/* ---- the proctor line, the flashwell, the end card --------------------- */
+.g-ec-msg{position:absolute;left:50%;bottom:22px;transform:translateX(-50%);z-index:6;
+  max-width:min(92vw, 640px);padding:8px 16px;border-radius:10px;text-align:center;
+  font-family:var(--body);font-size:14px;line-height:1.4;color:var(--ink);
+  background:color-mix(in srgb, var(--panel), transparent 20%);
+  border:1px solid color-mix(in srgb, var(--line), transparent 30%);
+  box-shadow:0 8px 24px rgba(0,0,0,.4);pointer-events:none;
+  transition:opacity .3s ease}
+.g-ec-msg:empty{opacity:0}
+.g-ec-flashwell{position:absolute;inset:0;pointer-events:none;z-index:5;overflow:hidden}
+.g-ec-flashwell *{pointer-events:none}
+/* the class report: the core appends a title, k/v rows (.g-ec-end-row > .g-ec-end-k
+   + .g-ec-end-v) and a closing line straight into .g-ec-end, so the node IS
+   the card. The grade itself is the shell's stamp - an object, never a string. */
+.g-ec-end{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:8;overflow:auto;max-height:calc(100% - 90px);
+  width:min(92vw, 380px);padding:20px 22px 18px;border-radius:16px;text-align:left;
+  color:var(--ink);font-family:var(--body);font-size:14px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel), transparent 4%), color-mix(in srgb, var(--navy), transparent 4%)),
+    var(--panel);
+  border:1px solid color-mix(in srgb, var(--gold), transparent 55%);
+  box-shadow:0 24px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(0,0,0,.4), inset 0 1px 0 color-mix(in srgb, var(--ink), transparent 86%);
+  animation:g-ec-endin .5s ease-out 1}
+.g-ec-end:empty{opacity:0;pointer-events:none}
+@keyframes g-ec-endin{from{opacity:0;transform:translate(-50%,-46%)}to{opacity:1;transform:translate(-50%,-50%)}}
+/* a neon rule under the title, the pad hues strung along it like a strip of lamps */
+.g-ec-end-title{font-family:var(--disp);font-size:16px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 12px;padding-bottom:10px;color:var(--gold);
+  border-bottom:1px solid color-mix(in srgb, var(--line), transparent 20%);position:relative}
+.g-ec-end-title::after{content:"";position:absolute;left:0;right:0;bottom:-2px;height:3px;border-radius:2px;opacity:.8;
+  background:linear-gradient(90deg, hsl(330 90% 70%), hsl(46 90% 70%), hsl(178 80% 65%), hsl(264 80% 72%), hsl(20 90% 68%), hsl(205 85% 68%))}
+.g-ec-end-row{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  padding:4px 0;border-bottom:1px dashed color-mix(in srgb, var(--line), transparent 55%)}
+.g-ec-end-row:last-of-type{border-bottom:0}
+.g-ec-end-k{color:var(--ink-faint)}
+.g-ec-end-v{color:var(--ink);font-variant-numeric:tabular-nums}
+.g-ec-end-best .g-ec-end-v{font-family:var(--disp);font-size:22px;color:var(--pink);
+  text-shadow:0 0 14px color-mix(in srgb, var(--pink), transparent 40%)}
+.g-ec-end-tail{margin-top:10px}
+.g-ec-end-record{display:block;margin:2px 0 4px;font-family:var(--disp);font-size:13px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--gold);text-shadow:0 0 12px color-mix(in srgb, var(--gold), transparent 40%)}
+.g-ec-end-line{margin:4px 0 0;font-size:12px;color:var(--ink-dim);font-style:italic}
+.g-ec-end .btn{margin:10px 4px 0}
+/* the melody strip: the core may append .g-ec-end-strip > i[data-pad] - a
+   spoiler-free tick row of the run's colours */
+.g-ec-end-strip{display:flex;gap:4px;margin:10px 0 2px;flex-wrap:wrap}
+.g-ec-end-strip i{display:block;width:10px;height:14px;border-radius:3px;
+  --ec-h:calc(var(--ec-h-base,330) + var(--ec-n-rot,0));
+  background:hsl(var(--ec-h) 85% 65%);box-shadow:0 0 6px hsl(var(--ec-h) 90% 65% / .7)}
+.g-ec-end-strip i[data-pad="0"]{--ec-h-base:330}.g-ec-end-strip i[data-pad="1"]{--ec-h-base:46}
+.g-ec-end-strip i[data-pad="2"]{--ec-h-base:178}.g-ec-end-strip i[data-pad="3"]{--ec-h-base:264}
+.g-ec-end-strip i[data-pad="4"]{--ec-h-base:20}.g-ec-end-strip i[data-pad="5"]{--ec-h-base:205}
+
+/* ---- the drawn class-rules sheet (Deck VI, Law IV) --------------------- */
+/* The core builds .g-ec-howto > h3.g-ec-howto-title + .g-ec-howto-rows > N x
+   (.g-ec-howto-row > span.g-ec-howto-art[data-art] + p.g-ec-howto-line) +
+   button.g-ec-howto-go. The art span is EMPTY: every figure is drawn here on
+   its two pseudo-elements. The ::before is a point that casts three lamps as
+   box-shadows (a disc each, a glow each - box-shadow lists interpolate, so the
+   lamps light in sequence on one keyframe); the ::after is the second actor. */
+.g-ec-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(92vw, 440px);padding:18px 20px 16px;border-radius:16px;color:var(--ink);
+  background:linear-gradient(180deg, color-mix(in srgb, var(--panel), transparent 2%), var(--navy));
+  border:1px solid color-mix(in srgb, var(--lav), transparent 55%);
+  box-shadow:0 24px 60px rgba(0,0,0,.6), inset 0 1px 0 color-mix(in srgb, var(--ink), transparent 86%);
+  animation:g-ec-endin .45s ease-out 1}
+.g-ec-howto-title{margin:0 0 6px;font-family:var(--disp);font-size:15px;letter-spacing:.16em;text-transform:uppercase;color:var(--lav)}
+.g-ec-howto-rows{display:flex;flex-direction:column}
+.g-ec-howto-row{display:flex;align-items:center;gap:14px;padding:9px 0;
+  border-top:1px dashed color-mix(in srgb, var(--line), transparent 50%)}
+.g-ec-howto-line{margin:0;font-family:var(--body);font-size:13px;line-height:1.4;color:var(--ink-dim)}
+.g-ec-howto-art{position:relative;flex:0 0 auto;width:96px;height:64px;pointer-events:none;
+  --l1:330;--l2:46;--l3:178}
+/* the three lamps: the ::before IS lamp one (a 20px disc), lamps two and three
+   are its zero-spread shadows, and each lamp's glow is a blurred shadow of
+   its own - box-shadow lists and background-color both interpolate, so the
+   lamps light in sequence on one keyframe */
+.g-ec-howto-art::before{content:"";position:absolute;left:11px;top:20px;width:20px;height:20px;border-radius:50%;
+  background:hsl(var(--l1) 60% 38%);
+  box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0);
+  animation:g-ec-hw-lamps 2.6s ease-in-out infinite}
+@keyframes g-ec-hw-lamps{
+  0%,64%,100%{background:hsl(var(--l1) 60% 38%);box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0)}
+  8%{background:hsl(var(--l1) 95% 78%);box-shadow:
+    0 0 14px 4px hsl(var(--l1) 95% 70% / .85),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0)}
+  18%{background:hsl(var(--l1) 60% 38%);box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0)}
+  28%{background:hsl(var(--l1) 60% 38%);box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 95% 78%), 27px 0 14px 4px hsl(var(--l2) 95% 70% / .85),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0)}
+  38%{background:hsl(var(--l1) 60% 38%);box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 60% 38%), 54px 0 10px 2px hsl(var(--l3) 95% 70% / 0)}
+  48%{background:hsl(var(--l1) 60% 38%);box-shadow:
+    0 0 10px 2px hsl(var(--l1) 95% 70% / 0),
+    27px 0 0 0 hsl(var(--l2) 60% 38%), 27px 0 10px 2px hsl(var(--l2) 95% 70% / 0),
+    54px 0 0 0 hsl(var(--l3) 95% 78%), 54px 0 14px 4px hsl(var(--l3) 95% 70% / .85)}}
+/* WATCH: an ear listens beside the lamps */
+.g-ec-howto-art[data-art="watch"]::after{content:"";position:absolute;right:0;top:14px;width:16px;height:28px;
+  border-radius:50% 50% 50% 50% / 40% 40% 60% 60%;
+  border:2px solid color-mix(in srgb, var(--ink), transparent 40%);border-left-color:transparent;opacity:.7;
+  animation:g-ec-hw-ear 2.6s ease-in-out infinite}
+@keyframes g-ec-hw-ear{0%,100%{transform:scale(1);opacity:.5}8%,28%,48%{transform:scale(1.12);opacity:.95}}
+/* REPEAT: the lamps light a beat later, under a keycap that taps them in order */
+.g-ec-howto-art[data-art="repeat"]::before{animation-delay:.35s}
+.g-ec-howto-art[data-art="repeat"]::after{content:"";position:absolute;left:13px;top:2px;width:16px;height:14px;border-radius:4px;
+  background:var(--panel2,#2E2E55);border:1px solid var(--line);box-shadow:0 2px 0 rgba(0,0,0,.6);
+  animation:g-ec-hw-tap 2.6s ease-in-out infinite}
+@keyframes g-ec-hw-tap{0%,3%{transform:translate(0,0)}8%{transform:translate(0,8px)}14%{transform:translate(0,0)}
+  23%{transform:translate(27px,0)}28%{transform:translate(27px,8px)}34%{transform:translate(27px,0)}
+  43%{transform:translate(54px,0)}48%{transform:translate(54px,8px)}54%{transform:translate(54px,0)}
+  64%,100%{transform:translate(0,0)}}
+/* DECOY: a fourth lamp, cold, flickers out of turn below the row - a bar through it */
+.g-ec-howto-art[data-art="decoy"]::after{content:"";position:absolute;left:38px;top:42px;width:20px;height:20px;border-radius:50%;
+  background:
+    linear-gradient(-35deg, transparent 44%, var(--pink) 46% 54%, transparent 56%),
+    radial-gradient(circle at 50% 38%, hsl(196 30% 82%) 0%, hsl(196 30% 55%) 45%, hsl(200 20% 16%) 100%);
+  border:1px solid hsl(196 30% 60% / .8);
+  animation:g-ec-hw-cold 2.6s steps(3) infinite}
+@keyframes g-ec-hw-cold{0%,12%,100%{opacity:.45;box-shadow:none}16%{opacity:1;box-shadow:0 0 14px 3px hsl(196 40% 70% / .8)}22%{opacity:.6}26%{opacity:.45}}
+.g-ec-howto-go{display:block;width:100%;margin:14px 0 0;padding:11px 14px;border-radius:12px;cursor:pointer;
+  font:700 14px/1.2 var(--body);letter-spacing:.08em;text-transform:uppercase;color:var(--ground);
+  background:linear-gradient(180deg, var(--pink), var(--pink-deep));border:0;
+  box-shadow:0 6px 18px color-mix(in srgb, var(--pink), transparent 55%), inset 0 1px 0 rgba(255,255,255,.3);
+  animation:g-ec-hw-pulse 1.8s ease-in-out infinite}
+.g-ec-howto-go:hover,.g-ec-howto-go:focus-visible{filter:brightness(1.08);outline:2px solid color-mix(in srgb, var(--ink), transparent 40%);outline-offset:2px}
+@keyframes g-ec-hw-pulse{50%{box-shadow:0 6px 26px color-mix(in srgb, var(--pink), transparent 30%), inset 0 1px 0 rgba(255,255,255,.3)}}
+
+/* ---- reduced motion: transitions only, no keyframes -------------------- */
+html.arc-reduced .g-ec-stage *{animation:none !important}
+html.arc-reduced .g-ec-stage::before,html.arc-reduced .g-ec-backdrop::before,html.arc-reduced .g-ec-backdrop::after,
+html.arc-reduced .g-ec-ring::before,html.arc-reduced .g-ec-face::after,html.arc-reduced .g-ec-media{animation:none !important}
+html.arc-reduced .g-ec-face{transition:box-shadow .2s ease, border-color .2s ease}
+html.arc-reduced .g-ec-pad[data-state="lit"] .g-ec-face,html.arc-reduced .g-ec-pad[data-state="pressed"] .g-ec-face{transform:none}
+html.arc-reduced .g-ec-pad[data-state="decoy"] .g-ec-face{animation:none !important;opacity:.85}
+html.arc-reduced .g-ec-media{opacity:.14}
+html.arc-reduced .g-ec-howto-go{animation:none !important}
+html.arc-reduced .g-ec-howto-art::before,html.arc-reduced .g-ec-howto-art::after{animation:none !important}
+@media (prefers-reduced-motion: reduce){
+  .g-ec-stage *{animation:none !important}
+  .g-ec-stage::before,.g-ec-backdrop::before,.g-ec-backdrop::after,.g-ec-ring::before,.g-ec-face::after,.g-ec-media{animation:none !important}
+  .g-ec-pad[data-state="lit"] .g-ec-face,.g-ec-pad[data-state="pressed"] .g-ec-face{transform:none}
+}
+
+/* ---- small screens: the ring shrinks, the HUD tightens ------------------ */
+@media (max-width: 560px){
+  .g-ec-stage{padding:64px 10px 10px;--ec-ring:min(calc(100dvh - 230px), calc(100vw - 28px), 640px)}
+  .g-ec-chip{min-width:64px;padding:6px 9px 5px;font-size:11px}
+  .g-ec-chip.g-ec-len{min-width:88px;font-size:22px}
+  .g-ec-msg{font-size:13px;bottom:12px}
+}
+`;
+
+/** Inject once per document. No-op headless (the DOM double has no head). */
+export function injectEchoStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return false;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);   // harness shim
+    return true;
+  } catch (e) {
+    return false;      // a stylesheet must never be the thing that fails a class
+  }
+}
+
+export { PAD_HUES };
+export default injectEchoStyle;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/trickster.js
@@ -1,0 +1,824 @@
+/* ============================================================================
+ * games/echo/trickster.js - DECK III of the House Rules, dealt into the music
+ * room. A memory game is where your own reading stops being a reliable
+ * witness, so every card here attacks what the player READS between the
+ * playback and the press - never the sequence, never the pads' places, never
+ * the key under the finger. (The DECOY ECHO - the signature twist - is NATIVE:
+ * index.js deals it from the seeded plan and lights the pad; this deck only
+ * deals the floor-map cards around it.)
+ *
+ *   STAT FLICKER     the LEN chip briefly reads one longer than the truth -
+ *                    wishful reading - then corrects with a static pop. The
+ *                    ledger never moves; confidence does. Tier 1+.
+ *   CROOKED CLOCK    the class clock's FACE bends: it races through the
+ *                    boring middle (shows less time than you really have) and
+ *                    crawls as the bell nears, meeting the truth exactly at the
+ *                    last 15s and staying honest from there. The real budget
+ *                    - the bell, the grade - is index.js's and exact. A
+ *                    MutationObserver on the chip re-bends the face the moment
+ *                    truth lands (before the frame paints); no observer (DOM
+ *                    double) and a 250ms poll does the same. If the core hands
+ *                    a between-turns timer ring (chipEl('ring') returning a
+ *                    node with --ec-k 0..1 - index.js's .g-ec-timer chip), the
+ *                    SAME bend is painted onto a twin ring of this deck's at
+ *                    the centre of the pad ring for the input window, and the
+ *                    honest chip steps aside (.g-ec-tk-bent) while the twin is
+ *                    up. Tier 2+.
+ *   UNRELIABLE LABEL a pad's .g-ec-word wears ANOTHER pad's word for ~600ms
+ *                    during the input turn. The pad's colour, its place on
+ *                    the ring and its tone are the truth (Law IV) - the card
+ *                    trains the player to stop reading and start looking.
+ *                    Dealt ONLY when the pads carry words (a glyph-only face
+ *                    is the truth itself and is never lied on). Tier 2+.
+ *   GHOST CURSOR     a faint cursor echo trails the real pointer by ~430ms
+ *                    during the input turn, and on a stall it stops trailing
+ *                    and DRIFTS to a WRONG pad - ring-adjacent to the one that
+ *                    is due, so the lure is the near miss the casino stages -
+ *                    pulsing, the house leaning on your hand. Pure suggestion:
+ *                    pointer-events none, it cannot click, it never hides the
+ *                    real cursor, and it dies on the next press. Tier 3+,
+ *                    mouse pointers only.
+ *
+ * DEALING RULE: card slots are dealt at start() from the seeded plan over the
+ * class budget - 2/4/6/8 by tier, at least 9s apart (under the House's
+ * 4-a-minute cap; a rolling-minute guard enforces it directly too), never in
+ * the first 10s, never in the last 15s (the bell's honest zone). The flicker
+ * and the label need an INPUT turn to land on: a slot whose moment arrives
+ * outside one waits for the next afterPlayback() (at most RETRY_MAX polite
+ * re-queues), then folds. The clock latches once and stays. The ghost's
+ * slot ARMS it for the rest of the class; the lure itself is stall-reactive
+ * (the stall is the player's own) but WHICH wrong pad it drifts to is the
+ * seed's choice.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - the flicker and the clock write chip TEXT and restore
+ *       via chipText (the truth source) and stand down if a real repaint lands
+ *       mid-lie; the label writes .g-ec-word only and restores the exact
+ *       string it read; nothing reads or writes the sequence, the streak,
+ *       the length, the clock budget or the grade; nothing can change WHEN
+ *       index.js's own timers fire.
+ *   II  input honest  - no card is clickable; the ghost and the twin ring are
+ *       pointer-events:none in this deck's own layer over the ring; no pad is
+ *       ever moved, covered, resized or delayed; data-state is never written.
+ *   III never still   - the ghost pulses on the lure; the flicker pops.
+ *   IV  images > text - the two taunts this deck can say (ec_taunt_ghost on
+ *       a lure, ec_taunt_label once per class on the first label) come through
+ *       the lexicon and land on the ONE proctor line via opts.announce, and
+ *       only when the core offers that line.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ec-trickster|<tag>',
+ *       append-only tags; no Math.random.
+ *   VI  exits sacred  - capsOk false disarms the whole deck; reduced motion
+ *       drops the ghost and the twin ring entirely (the flicker is a number,
+ *       the label is a word, the clock still bends: none of those is motion);
+ *       every timer rides the game's registry AND a local set; pause()
+ *       restores every live lie; destroy() leaves no node, timer, observer
+ *       or listener.
+ *   VII lexicon       - ec_taunt_ghost / ec_taunt_label via opts.t.
+ *
+ * ENGINE PLACEMENT: entirely game-local. Every card is addressed to this
+ * class's own nodes; the deck asks the engine for nothing. `opts.engine` is
+ * accepted for interface symmetry and unused.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const EC_TRICKSTER = Object.freeze({
+  /** Dealt card slots per class, by tier (the House budget: 2 -> 8). */
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  /** The plan's window: never the first 10s, never the honest tail. */
+  FIRST_DEAL_MS: 10000,
+  TAIL_MS: 15000,
+  MIN_GAP_MS: 9000,
+  /** The House's per-minute cap, stated as the law says it. */
+  RATE_WINDOW_MS: 60000,
+  RATE_MAX: 4,
+  /** A slot that lands outside an input turn waits for the next one. */
+  RETRY_MAX: 3,
+  RETRY_MS: 2500,
+
+  /** Card gates. */
+  FLICK_FROM_TIER: 1,
+  LABEL_FROM_TIER: 2,
+  CLOCK_FROM_TIER: 2,
+  GHOST_FROM_TIER: 3,
+  /** Slot weights per tier over the eligible cards (renormalised). The clock
+   *  and the ghost are ONE slot each (they latch); the rest fill the plan. */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ flick: 1, label: 0 }),
+    2: Object.freeze({ flick: 0.5, label: 0.5 }),
+    3: Object.freeze({ flick: 0.45, label: 0.55 }),
+    4: Object.freeze({ flick: 0.4, label: 0.6 }),
+  }),
+
+  /** Stat flicker: how long the wrong number stands. */
+  FLICK_MS: 460,
+  /** Crooked clock: the bend at mid-budget (fraction of the budget), the
+   *  honest zone (the bell's last 15s are true), the ramp, the poll. */
+  CLOCK_BEND: 0.14,
+  CLOCK_HONEST_SEC: 15,
+  CLOCK_RAMP: 0.35,
+  CLOCK_POLL_MS: 250,
+  /** The twin ring's bend (same pure function, the input window as budget). */
+  RING_BEND: 0.16,
+  RING_HONEST: 0.15,
+  RING_STEPS: 12,
+  /** Unreliable label: how long the lie is worn; the taunt chance. */
+  LABEL_MS: 600,
+  LABEL_TAUNT_CHANCE: 0.5,
+  /** The ghost: the trail, the stall that turns it into a lure, its lerp. */
+  GHOST_TICK_MS: 90,
+  GHOST_TRAIL_MS: 430,
+  GHOST_STALL_MS: 1200,
+  GHOST_LERP: 0.16,
+  GHOST_TRAIL_KEEP_MS: 2200,
+  GHOST_TAUNT_CHANCE: 0.35,
+});
+
+const STYLE_ID = 'g-ec-trickster-style';
+const STYLE_TEXT = `
+/* this deck's layer: inside the ring, over the pads, pointer-events:none */
+.g-ec-tk{position:absolute;inset:0;pointer-events:none;z-index:3;overflow:visible}
+.g-ec-tk *{pointer-events:none}
+/* GHOST CURSOR: a will-o-wisp echo of the player's own hand */
+.g-ec-tk-ghost{position:absolute;left:0;top:0;width:15px;height:19px;opacity:0;will-change:transform;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, rgba(255,105,180,.9), rgba(184,166,232,.55));
+  filter:drop-shadow(0 0 6px rgba(255,105,180,.6));
+  transition:transform .34s ease-out, opacity .38s ease}
+.g-ec-tk-ghost.on{opacity:.32}
+.g-ec-tk-ghost.lure{opacity:.55;animation:g-ec-tk-ghostpulse 1.4s ease-in-out infinite}
+@keyframes g-ec-tk-ghostpulse{50%{filter:drop-shadow(0 0 12px rgba(255,105,180,.95))}}
+/* THE TWIN RING: the crooked face of an input-window ring, over the real one */
+.g-ec-tk-ring{position:absolute;left:50%;top:50%;width:16%;height:16%;border-radius:50%;
+  transform:translate(-50%,-50%);opacity:0;
+  background:conic-gradient(from -90deg, hsl(264 80% 78% / .9) 0deg, hsl(264 80% 78% / .9) calc(var(--ec-tk-k,1) * 360deg), transparent calc(var(--ec-tk-k,1) * 360deg));
+  -webkit-mask:radial-gradient(circle, transparent 0 calc(50% - 4px), #000 calc(50% - 3px) calc(50% - 1px), transparent 50%);
+  mask:radial-gradient(circle, transparent 0 calc(50% - 4px), #000 calc(50% - 3px) calc(50% - 1px), transparent 50%);
+  transition:opacity .18s ease}
+.g-ec-tk-ring.on{opacity:.85}
+/* the real face steps aside while ours is up - and only while ours is up */
+.g-ec-tk-bent{opacity:0 !important}
+/* STAT FLICKER: the static pop the wrong number corrects itself with */
+.g-ec-chip.g-ec-tk-flick{text-shadow:0 0 22px rgba(184,166,232,.75), 0 0 3px rgba(255,255,255,.5) !important;
+  animation:g-ec-tk-static .16s steps(3) 2}
+@keyframes g-ec-tk-static{0%{filter:none}40%{filter:brightness(1.5) contrast(1.4)}100%{filter:none}}
+/* UNRELIABLE LABEL: the word shivers while it lies */
+.g-ec-word.g-ec-tk-lie{animation:g-ec-tk-lie .6s steps(4) 1}
+@keyframes g-ec-tk-lie{0%{opacity:1}25%{opacity:.6;letter-spacing:.2em}50%{opacity:1}75%{opacity:.7}100%{opacity:.9}}
+@media (prefers-reduced-motion: reduce){
+  .g-ec-tk-ghost,.g-ec-tk-ring{display:none}
+  .g-ec-chip.g-ec-tk-flick{animation:none}
+  .g-ec-word.g-ec-tk-lie{animation:none}
+}
+html.arc-reduced .g-ec-tk-ghost,html.arc-reduced .g-ec-tk-ring{display:none}
+html.arc-reduced .g-ec-chip.g-ec-tk-flick{animation:none}
+html.arc-reduced .g-ec-word.g-ec-tk-lie{animation:none}
+.g-ec-stage.suspended .g-ec-tk-ghost{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (host && host.appendChild) host.appendChild(s);
+    if (document._register) document._register(STYLE_ID, s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clampTier(v) { return Math.max(1, Math.min(4, Math.round(Number(v) || 1))); }
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function qsa(root, sel) {
+  try { if (root && typeof root.querySelectorAll === 'function') return Array.from(root.querySelectorAll(sel)); } catch (e) { /* fall */ }
+  return [];
+}
+function qs(root, sel) {
+  try { if (root && typeof root.querySelector === 'function') return root.querySelector(sel) || null; } catch (e) { /* fall */ }
+  return null;
+}
+function padIndexOf(node) {
+  try { const n = Number(node.getAttribute('data-pad')); return Number.isFinite(n) ? n : -1; } catch (e) { return -1; }
+}
+
+/**
+ * The crooked face, pure: displayed seconds-left for a real seconds-left.
+ * f(B)=B, f(honest)=honest, monotonic (bend*pi < 1), honest at/after the
+ * bell. Ahead through the middle (less time shown than real), crawling as
+ * the bell nears, so the face meets the truth instead of snapping to it.
+ */
+export function bendClock(secLeft, budgetSec, bend, honestSec) {
+  const x = Math.max(0, Number(secLeft) || 0);
+  const B = Math.max(30, Number(budgetSec) || 105);
+  const H = Number.isFinite(honestSec) ? honestSec : EC_TRICKSTER.CLOCK_HONEST_SEC;
+  if (x <= H || x >= B) return Math.round(x);
+  const A0 = Number.isFinite(bend) ? bend : EC_TRICKSTER.CLOCK_BEND;
+  const u = x / B;
+  const uh = H / B;
+  const ramp = Math.max(0, Math.min(1, (u - uh) / EC_TRICKSTER.CLOCK_RAMP));
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, Math.round(B * (u - A * Math.sin(Math.PI * u))));
+}
+/** The twin ring's bend: shown fraction-left k' for a true fraction-left k
+ *  (ahead through the middle, honest in the last RING_HONEST). Pure. */
+export function bendRing(k01, bend, honest) {
+  const k = Math.max(0, Math.min(1, Number(k01) || 0));
+  const H = Number.isFinite(honest) ? honest : EC_TRICKSTER.RING_HONEST;
+  if (k <= H || k >= 1) return k;
+  const A0 = Number.isFinite(bend) ? bend : EC_TRICKSTER.RING_BEND;
+  const ramp = Math.max(0, Math.min(1, (k - H) / 0.32));
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, Math.min(1, k - A * Math.sin(Math.PI * k)));
+}
+/** A wrong pad next to the due one (ring-adjacent), seeded between the two. Pure. */
+export function wrongNeighbour(due, n, roll01) {
+  const m = Math.max(2, Math.floor(Number(n) || 6));
+  const d = Math.floor(Number(due));
+  if (!Number.isFinite(d) || d < 0) return Math.floor((Number(roll01) || 0) * m) % m;
+  const left = (d - 1 + m) % m;
+  const right = (d + 1) % m;
+  return (Number(roll01) || 0) < 0.5 ? left : right;
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier, timers {after, every?, clear|cancel}, reduced, capsOk (bool or fn),
+ *   isHalted () => bool, t, stats () => {len, secLeft, streak, best, phase?, budgetSec?},
+ *   chipEl (which: 'len'|'clock'|'streak'|'best'|'ring') => el|null,
+ *   chipText (which) => honest text, log,
+ *   game hooks (optional, every one null-safe; index.js passes the first six):
+ *     ring | board   .g-ec-ring (the deck's layer mounts here; the ghost listens
+ *                    for pointermove on stage || ring.parentNode || ring)
+ *     pads           () => Element[]  (else read off the ring)
+ *     padEl          (i) => Element | null
+ *     wordEl         (i) => the pad's .g-ec-word (the ONE lie target)
+ *     wordText       (i) => the truth string for pad i
+ *     restoreWords   () => void  (the core repaints every word from the truth)
+ *     announce       (text, ms) => void  (the proctor line)
+ *     stats().inputOpen  true while the input turn is open (the flicker / the
+ *                    label / the ghost only act then); stats().expect = the index
+ *                    due next; stats().expectPad (if ever offered) = the pad due,
+ *                    which the lure then avoids - without it the lure's pad is a
+ *                    seeded uniform pick (pure noise, no information either way)
+ *     stage          .g-ec-stage (optional; phase read off data-phase as a fallback)
+ *     nextPad        () => 0..5 | -1 (optional alias of expectPad)
+ *     coarse         bool (touch pointer - no ghost)
+ *     budgetSec      number
+ */
+export function createEcTrickster(o) {
+  const opts = o || {};
+  const T = EC_TRICKSTER;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : (k, f) => (f == null ? k : f);
+  const tier = clampTier(opts.tier);
+  const reduced = !!opts.reduced;
+  const coarse = !!opts.coarse;
+  const armedBase = !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  function capsOkNow() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  const armed = armedBase && capsOkNow();
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const chipEl = typeof opts.chipEl === 'function' ? opts.chipEl : () => null;
+  const chipText = typeof opts.chipText === 'function' ? opts.chipText : () => null;
+  const announce = typeof opts.announce === 'function' ? opts.announce : null;
+  const boardEl = opts.board || opts.ring || null;
+  const wordElOf = typeof opts.wordEl === 'function' ? opts.wordEl : null;
+  const wordTextOf = typeof opts.wordText === 'function' ? opts.wordText : null;
+  const restoreWords = typeof opts.restoreWords === 'function' ? opts.restoreWords : null;
+  function duePad() {
+    try {
+      if (typeof opts.nextPad === 'function') { const v = Math.floor(Number(opts.nextPad())); if (Number.isFinite(v)) return v; }
+      const s = stats();
+      if (s && s.expectPad != null) { const v = Math.floor(Number(s.expectPad)); if (Number.isFinite(v)) return v; }
+    } catch (e) { /* fall */ }
+    return -1;
+  }
+  function pointerHost() {
+    if (opts.stage && typeof opts.stage.addEventListener === 'function') return opts.stage;
+    try { if (boardEl && boardEl.parentNode && typeof boardEl.parentNode.addEventListener === 'function') return boardEl.parentNode; } catch (e) { /* fall */ }
+    return boardEl && typeof boardEl.addEventListener === 'function' ? boardEl : null;
+  }
+
+  /* timers: the game's registry + a local set */
+  const live = new Set();
+  const chains = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  let destroyed = false;
+  let stopped = false;
+  let paused = false;
+  function after(ms, fn) {
+    if (!armed || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function every(ms, fn) {
+    if (!armed || destroyed) return 0;
+    if (typeof opts.timers.every === 'function') {
+      const id = opts.timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => { if (!handle.on || destroyed) return; try { fn(); } catch (e) { /* ignore */ } handle.id = after(ms, tick); };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+
+  const seedBase = String(opts.seed || 'ec') + '|ec-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  const fired = { flick: 0, label: 0, clock: 0, ghost: 0, lure: 0 };
+  let deals = [];
+  const fireTimes = [];         // rolling-minute guard
+  const lexiconUsed = new Set();
+  const say_t = (k, f) => { lexiconUsed.add(k); return t(k, f); };
+  let labelTaunted = false;
+
+  /* ------------------------------------------------------------ helpers */
+  function phaseNow() {
+    if (typeof opts.phase === 'function') { try { const p = opts.phase(); if (p) return String(p); } catch (e) { /* fall */ } }
+    try { const s = stats(); if (s && s.phase) return String(s.phase); } catch (e) { /* fall */ }
+    const host = opts.stage || (boardEl && boardEl.parentNode) || null;
+    try { if (host && typeof host.getAttribute === 'function') return String(host.getAttribute('data-phase') || ''); } catch (e) { /* fall */ }
+    return '';
+  }
+  function inInput() {
+    try { const s = stats(); if (s && s.inputOpen != null) return !!s.inputOpen; } catch (e) { /* fall */ }
+    const p = phaseNow();
+    return p === 'input' || p === 'encore';
+  }
+  function livePads() {
+    if (typeof opts.pads === 'function') { try { const p = opts.pads(); if (p && p.length) return Array.from(p); } catch (e) { /* fall */ } }
+    return qsa(boardEl, '.g-ec-pad');
+  }
+  function wordNode(pad, i) {
+    if (wordElOf) { try { const w = wordElOf(i); if (w) return w; } catch (e) { /* fall */ } }
+    return qs(pad, '.g-ec-word');
+  }
+  function truthWord(pad, i) {
+    if (wordTextOf) { try { return String(wordTextOf(i) || ''); } catch (e) { return ''; } }
+    const w = qs(pad, '.g-ec-word');
+    return w ? String(w.textContent || '') : '';
+  }
+  function wordsOn() {
+    if (typeof opts.wordsOn === 'function') { try { return !!opts.wordsOn(); } catch (e) { return false; } }
+    /* inferred: every pad carries a word of 2+ characters and the words differ */
+    const pads = livePads();
+    const words = pads.map((p) => truthWord(p, padIndexOf(p)).trim());
+    if (!words.length) return false;
+    const set = new Set(words);
+    return words.every((w) => w.length >= 2) && set.size === words.length;
+  }
+  function rateOk() {
+    const now = nowMs();
+    while (fireTimes.length && now - fireTimes[0] > T.RATE_WINDOW_MS) fireTimes.shift();
+    return fireTimes.length < T.RATE_MAX;
+  }
+  function markFire() { fireTimes.push(nowMs()); }
+
+  /* ------------------------------------------------------------- the deal */
+  function buildDeals() {
+    const n = T.DEALS[tier] || 2;
+    const spanMs = Math.max(40, Number(opts.budgetSec) || 105) * 1000;
+    const usable = Math.max(15000, spanMs - T.FIRST_DEAL_MS - T.TAIL_MS);
+    const times = [];
+    for (let i = 0; i < n; i++) times.push(T.FIRST_DEAL_MS + roll('when') * usable);
+    times.sort((a, b) => a - b);
+    /* MIN_GAP between cards, and the whole hand still inside the window: a
+       gap pass can push the last card into the TAIL, so the hand is slid
+       back (the gap shrinks only when n cards cannot fit the window at all) */
+    const end = T.FIRST_DEAL_MS + usable;
+    const gap = Math.min(T.MIN_GAP_MS, n > 1 ? usable / (n - 1) : T.MIN_GAP_MS);
+    for (let i = 1; i < times.length; i++) {
+      if (times[i] - times[i - 1] < gap) times[i] = times[i - 1] + gap;
+    }
+    const over = times.length ? times[times.length - 1] - end : 0;
+    if (over > 0) {
+      for (let i = 0; i < times.length; i++) times[i] = Math.max(T.FIRST_DEAL_MS, times[i] - over);
+      for (let i = 1; i < times.length; i++) {
+        if (times[i] - times[i - 1] < gap) times[i] = times[i - 1] + gap;
+      }
+    }
+    const clockSlot = tier >= T.CLOCK_FROM_TIER && n > 1 ? Math.floor(roll('clock-slot') * Math.ceil(n / 2)) : -1;
+    let ghostSlot = -1;
+    if (tier >= T.GHOST_FROM_TIER && n > 2) {
+      ghostSlot = Math.floor(roll('ghost-slot') * n);
+      if (ghostSlot === clockSlot) ghostSlot = (ghostSlot + 1) % n;
+    }
+    const w = T.WEIGHTS[tier] || T.WEIGHTS[1];
+    return times.map((at, i) => {
+      let card;
+      if (i === clockSlot) card = 'clock';
+      else if (i === ghostSlot) card = 'ghost';
+      else {
+        const r = roll('card');
+        card = r < w.flick ? 'flick' : 'label';
+        if (card === 'label' && tier < T.LABEL_FROM_TIER) card = 'flick';
+      }
+      return { at: Math.round(at), card };
+    });
+  }
+
+  function attempt(deal, tries) {
+    if (destroyed || stopped) return;
+    if (deal.card === 'clock') { armClock(); return; }
+    if (deal.card === 'ghost') { armGhost(); return; }
+    /* the flicker and the label want an input turn; otherwise wait politely */
+    if (isHalted() || !inInput() || !rateOk()) {
+      if (tries < T.RETRY_MAX) { deal.pending = true; after(T.RETRY_MS, () => attempt(deal, tries + 1)); }
+      else { deal.pending = false; deal.folded = true; }
+      return;
+    }
+    deal.pending = false;
+    if (deal.card === 'flick') dealFlick();
+    else if (deal.card === 'label') dealLabel();
+  }
+
+  /* -------------------------------------------------------- stat flicker */
+  let flickTimer = 0; let flickChip = null; let flickLie = null;
+  function dealFlick() {
+    if (tier < T.FLICK_FROM_TIER) return;
+    const chip = chipEl('len');
+    const s = stats();
+    if (!chip || !s || chip.textContent == null) return;
+    const truth = chipText('len');
+    const n = Math.max(0, Math.floor(Number(s.len) || 0));
+    const fake = n + 1;
+    let lie;
+    if (typeof truth === 'string' && /\d/.test(truth)) lie = truth.replace(/\d+/, String(fake));
+    else lie = String(fake);
+    if (lie === chip.textContent) return;
+    try { chip.textContent = lie; } catch (e) { return; }
+    flickChip = chip; flickLie = lie;
+    if (!reduced) setCls(chip, 'g-ec-tk-flick', true);
+    fired.flick += 1;
+    markFire();
+    cancel(flickTimer);
+    flickTimer = after(T.FLICK_MS, () => { flickTimer = 0; endFlick(); });
+    say('trickster: stat flicker (len ' + n + ' reads ' + fake + ')');
+  }
+  function endFlick() {
+    if (!flickChip) return;
+    setCls(flickChip, 'g-ec-tk-flick', false);
+    try {
+      /* stand down if a real repaint already landed */
+      if (flickChip.textContent === flickLie) {
+        const now = chipText('len');
+        if (now != null) flickChip.textContent = now;
+      }
+    } catch (e) { /* noop */ }
+    flickChip = null; flickLie = null;
+  }
+
+  /* ------------------------------------------------------- crooked clock */
+  let clockArmed = false; let clockObs = null; let clockPoll = 0; let lastLie = null;
+  let budgetSeen = Number(opts.budgetSec) || 0; let clockLies = 0;
+  function formatLike(sec, truth) {
+    const s = Math.max(0, Math.round(sec));
+    if (typeof truth === 'string' && /^\d+s$/.test(truth.trim())) return s + 's';
+    if (typeof truth === 'string' && /^\d+$/.test(truth.trim())) return String(s);
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    const padM = typeof truth === 'string' && /^\d{2}:\d{2}$/.test(truth.trim());
+    return (padM ? String(m).padStart(2, '0') : String(m)) + ':' + String(r).padStart(2, '0');
+  }
+  function bendFace() {
+    if (!clockArmed || destroyed || stopped || paused) return;
+    const chip = chipEl('clock');
+    const s = stats();
+    if (!chip || !s || !Number.isFinite(Number(s.secLeft))) return;
+    const secLeft = Number(s.secLeft);
+    if (secLeft > budgetSeen) budgetSeen = secLeft;
+    const shown = bendClock(secLeft, budgetSeen, T.CLOCK_BEND, T.CLOCK_HONEST_SEC);
+    if (shown === Math.round(secLeft)) { lastLie = null; return; }
+    const truth = chipText('clock');
+    const text = formatLike(shown, truth);
+    if (chip.textContent === text) return;
+    lastLie = text;
+    try { chip.textContent = text; clockLies += 1; } catch (e) { /* ignore */ }
+  }
+  function armClock() {
+    if (clockArmed || tier < T.CLOCK_FROM_TIER) return;
+    const chip = chipEl('clock');
+    if (!chip) return;
+    clockArmed = true;
+    fired.clock += 1;
+    markFire();
+    let hooked = false;
+    try {
+      if (typeof MutationObserver === 'function' && typeof chip.nodeType === 'number') {
+        clockObs = new MutationObserver(() => { if (chip.textContent === lastLie) return; bendFace(); });
+        clockObs.observe(chip, { childList: true, characterData: true, subtree: true });
+        hooked = true;
+      }
+    } catch (e) { clockObs = null; }
+    if (!hooked) clockPoll = every(T.CLOCK_POLL_MS, bendFace);
+    bendFace();
+    armRing();
+    say('trickster: the clock goes crooked (' + (hooked ? 'observer' : 'poll') + ')');
+  }
+  function disarmClock(restore) {
+    if (clockObs) { try { clockObs.disconnect(); } catch (e) { /* ignore */ } clockObs = null; }
+    if (clockPoll) { stopEvery(clockPoll); clockPoll = 0; }
+    if (clockArmed && restore) {
+      const chip = chipEl('clock');
+      const truth = chipText('clock');
+      if (chip && truth != null) { try { chip.textContent = truth; } catch (e) { /* ignore */ } }
+    }
+    clockArmed = false;
+    lastLie = null;
+    disarmRing();
+  }
+  /* the twin ring: only when the core offers a between-turns ring node */
+  let ringEl = null; let ringPoll = 0; let ringReal = null; let ringLies = 0;
+  function armRing() {
+    if (reduced || ringEl) return;
+    const real = chipEl('ring');
+    if (!real || !layer) return;
+    ringReal = real;
+    ringEl = el('i', 'g-ec-tk-ring');
+    if (!ringEl) return;
+    /* the twin sits at the CENTRE of the ring (where the playback lives) and
+       the real chip's honest face steps aside while the twin is up; the real
+       chip keeps painting --ec-k, which is the truth the twin bends */
+    layer.appendChild(ringEl);
+    ringPoll = every(Math.round(1000 / T.RING_STEPS / 2), tickRing);
+  }
+  function tickRing() {
+    if (!ringEl || !ringReal || destroyed || stopped || paused) return;
+    let k = NaN;
+    try { k = parseFloat(ringReal.style.getPropertyValue('--ec-k')); } catch (e) { k = NaN; }
+    if (!Number.isFinite(k) || !inInput()) { setCls(ringEl, 'on', false); setCls(ringReal, 'g-ec-tk-bent', false); return; }
+    const shown = bendRing(k, T.RING_BEND, T.RING_HONEST);
+    setVar(ringEl, '--ec-tk-k', shown.toFixed(3));
+    if (Math.abs(shown - k) > 0.002) ringLies += 1;
+    setCls(ringEl, 'on', true);
+    setCls(ringReal, 'g-ec-tk-bent', true);
+  }
+  function disarmRing() {
+    if (ringPoll) { stopEvery(ringPoll); ringPoll = 0; }
+    if (ringReal) setCls(ringReal, 'g-ec-tk-bent', false);
+    if (ringEl) { try { ringEl.remove(); } catch (e) { /* ignore */ } }
+    ringEl = null; ringReal = null;
+  }
+
+  /* ---------------------------------------------------- unreliable label */
+  let labelTimer = 0; let labelNode = null; let labelWas = null; let labelLie = null;
+  function dealLabel() {
+    if (tier < T.LABEL_FROM_TIER || labelNode) return;
+    if (!wordsOn()) { say('trickster: label folds (glyph faces)'); return; }
+    const pads = livePads().filter((p) => wordNode(p, padIndexOf(p)));
+    if (pads.length < 2) return;
+    const a = pads[Math.floor(roll('label-pick') * pads.length)];
+    let b = pads[Math.floor(roll('label-pick') * pads.length)];
+    if (b === a) b = pads[(pads.indexOf(a) + 1) % pads.length];
+    const wa = wordNode(a, padIndexOf(a));
+    if (!wa) return;
+    const was = truthWord(a, padIndexOf(a));
+    const lie = truthWord(b, padIndexOf(b));
+    if (!lie || lie === was) return;
+    try { wa.textContent = lie; } catch (e) { return; }
+    labelNode = wa; labelWas = was; labelLie = lie;
+    if (!reduced) setCls(wa, 'g-ec-tk-lie', true);
+    fired.label += 1;
+    markFire();
+    cancel(labelTimer);
+    labelTimer = after(T.LABEL_MS, () => { labelTimer = 0; endLabel(); });
+    if (announce && !labelTaunted && roll('label-taunt') < T.LABEL_TAUNT_CHANCE) {
+      labelTaunted = true;
+      try { announce(say_t('ec_taunt_label', 'Read it again. Or do not.'), 1600); } catch (e) { /* ignore */ }
+    }
+    say('trickster: unreliable label (pad ' + padIndexOf(a) + ' wears pad ' + padIndexOf(b) + ')');
+  }
+  function endLabel() {
+    if (!labelNode) return;
+    setCls(labelNode, 'g-ec-tk-lie', false);
+    try { if (labelNode.textContent === labelLie) labelNode.textContent = labelWas; } catch (e) { /* ignore */ }
+    /* and the core's own truth repaint, when it offers one (belt and braces) */
+    if (restoreWords) { try { restoreWords(); } catch (e) { /* ignore */ } }
+    labelNode = null; labelWas = null; labelLie = null;
+  }
+
+  /* --------------------------------------------------------- ghost cursor */
+  let layer = null; let ghostEl = null; let ghostTimer = 0; let onMove = null;
+  const trail = []; let lastMoveAt = 0; let gx = 0; let gy = 0;
+  let ghostMode = 'off'; let ghostArmed = false; let lurePad = -1; let stallMs = 0;
+  let pointerNode = null;
+  function ghostEligible() {
+    return armed && !reduced && !coarse && tier >= T.GHOST_FROM_TIER && !!pointerHost() && !!layer;
+  }
+  function padPoint(i) {
+    const pads = livePads();
+    const pad = pads.find((p) => padIndexOf(p) === i) || null;
+    if (!pad) return null;
+    try {
+      const r = pad.getBoundingClientRect();
+      const b = layer.getBoundingClientRect();
+      if (!r || !b || !r.width) return null;
+      return { x: r.left + r.width / 2 - b.left, y: r.top + r.height / 2 - b.top };
+    } catch (e) { return null; }
+  }
+  function ghostOff() {
+    if (ghostMode === 'off') return;
+    setCls(ghostEl, 'on', false);
+    setCls(ghostEl, 'lure', false);
+    ghostMode = 'off';
+    lurePad = -1;
+  }
+  function ghostTick() {
+    if (!ghostEl || destroyed || stopped || paused) return;
+    if (!capsOkNow() || isHalted() || !inInput()) { ghostOff(); return; }
+    const now = nowMs();
+    const stalled = (lastMoveAt > 0 && now - lastMoveAt >= T.GHOST_STALL_MS) || stallMs >= T.GHOST_STALL_MS;
+    if (stalled) {
+      if (lurePad < 0) {
+        lurePad = wrongNeighbour(duePad(), livePads().length || 6, roll('lure'));
+        fired.lure += 1;
+        if (announce && roll('ghost-taunt') < T.GHOST_TAUNT_CHANCE) {
+          try { announce(say_t('ec_taunt_ghost', 'This one. Surely this one.'), 1400); } catch (e) { /* ignore */ }
+        }
+      }
+      const p = padPoint(lurePad);
+      if (p) { gx += (p.x - gx) * T.GHOST_LERP; gy += (p.y - gy) * T.GHOST_LERP; }
+      ghostMode = 'lure';
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', true);
+    } else {
+      if (!trail.length || !lastMoveAt) { ghostOff(); return; }
+      let pt = trail[0];
+      for (const q of trail) { if (now - q.at >= T.GHOST_TRAIL_MS) pt = q; else break; }
+      gx = pt.x; gy = pt.y;
+      ghostMode = 'trail';
+      lurePad = -1;
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', false);
+    }
+    try { ghostEl.style.transform = 'translate3d(' + gx.toFixed(1) + 'px,' + gy.toFixed(1) + 'px,0)'; } catch (e) { /* noop */ }
+    while (trail.length > 1 && now - trail[0].at > T.GHOST_TRAIL_KEEP_MS) trail.shift();
+  }
+  function armGhost() {
+    if (ghostArmed || !ghostEligible()) return;
+    ghostEl = el('i', 'g-ec-tk-ghost');
+    if (!ghostEl) return;
+    layer.appendChild(ghostEl);
+    ghostArmed = true;
+    fired.ghost += 1;
+    onMove = (ev) => {
+      if (destroyed) return;
+      try {
+        const b = layer.getBoundingClientRect();
+        const x = Number(ev && ev.clientX) - b.left;
+        const y = Number(ev && ev.clientY) - b.top;
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+        lastMoveAt = nowMs();
+        trail.push({ x, y, at: lastMoveAt });
+      } catch (e) { /* no rects under the DOM double */ }
+    };
+    pointerNode = pointerHost();
+    try { if (pointerNode) pointerNode.addEventListener('pointermove', onMove); } catch (e) { /* noop */ }
+    ghostTimer = every(T.GHOST_TICK_MS, ghostTick);
+    say('trickster: ghost armed');
+  }
+  function disarmGhost() {
+    if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+    try { if (onMove && pointerNode && pointerNode.removeEventListener) pointerNode.removeEventListener('pointermove', onMove); } catch (e) { /* noop */ }
+    onMove = null; pointerNode = null;
+    ghostOff();
+    if (ghostEl) { try { ghostEl.remove(); } catch (e) { /* ignore */ } }
+    ghostEl = null;
+    ghostArmed = false;
+  }
+
+  function mountLayer() {
+    if (layer || !boardEl || !boardEl.appendChild) return;
+    ensureStyle();
+    layer = el('div', 'g-ec-tk');
+    if (layer) boardEl.appendChild(layer);
+  }
+
+  /* ------------------------------------------------------------------ api */
+  const api = {
+    /** Deal the class. Call once, when play begins. */
+    start() {
+      if (!armed || destroyed) { say('trickster: disarmed'); return; }
+      mountLayer();
+      deals = buildDeals();
+      for (const deal of deals) after(deal.at, () => attempt(deal, 0));
+      try { const s = stats(); if (s && Number(s.secLeft) > budgetSeen) budgetSeen = Number(s.secLeft); } catch (e) { /* ignore */ }
+      say('trickster: dealt ' + deals.length + ' cards ('
+        + deals.map((d) => d.card + '@' + Math.round(d.at / 1000) + 's').join(', ') + ')');
+    },
+
+    /** index.js calls when a playback ends and the input turn opens. */
+    afterPlayback() {
+      if (!armed || destroyed || stopped) return;
+      stallMs = 0;
+      lurePad = -1;
+      /* a pending flicker/label gets its turn now */
+      for (const deal of deals) {
+        if (deal.pending && !deal.folded && (deal.card === 'flick' || deal.card === 'label')) {
+          deal.pending = false;
+          after(300 + Math.round(roll('late') * 400), () => attempt(deal, T.RETRY_MAX));
+        }
+      }
+    },
+
+    /** index.js calls after the input turn ends (clear or fail): every lie comes off. */
+    afterInput() {
+      if (!armed || destroyed) return;
+      endLabel();
+      endFlick();
+      ghostOff();
+      stallMs = 0;
+    },
+
+    /** index.js calls every 500ms with ms since the last press; 0 resets. */
+    stalled(ms) {
+      if (!armed || destroyed || stopped) return;
+      const n = Number(ms) || 0;
+      stallMs = n;
+      if (n <= 0) { ghostOff(); return; }
+    },
+
+    pause() {
+      paused = true;
+      endLabel();
+      endFlick();
+      ghostOff();
+    },
+    resume() { paused = false; if (clockArmed) bendFace(); },
+
+    /** The class is over: no card may fire again, every lie comes off. */
+    stop() {
+      stopped = true;
+      for (const d of deals) { if (d.pending) { d.pending = false; d.folded = true; } }
+      endLabel();
+      endFlick();
+      disarmGhost();
+      disarmClock(true);
+    },
+
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      for (const h of Array.from(chains)) stopEvery(h);
+      endLabel();
+      endFlick();
+      disarmGhost();
+      disarmClock(true);
+      if (layer) { try { layer.remove(); } catch (e) { /* ignore */ } }
+      layer = null;
+    },
+
+    diagnostics() {
+      return {
+        armed, tier, deals: deals.map((d) => ({ at: d.at, card: d.card, pending: !!d.pending, folded: !!d.folded })),
+        fired: Object.assign({}, fired),
+        clock: { armed: clockArmed, lies: clockLies, budget: budgetSeen, observer: !!clockObs, ring: !!ringEl, ringLies },
+        ghost: { armed: ghostArmed, mode: ghostMode, lurePad, trail: trail.length },
+        label: !!labelNode, flick: !!flickChip, lexicon: Array.from(lexiconUsed),
+        rateWindow: fireTimes.length,
+      };
+    },
+  };
+  return api;
+}
+
+export default createEcTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/casino.js
@@ -1,0 +1,761 @@
+/* ============================================================================
+ * games/instant-recall/casino.js - DECK II of the House Rules for the vigil:
+ * THE FLOOR. The montage is CORE's (the screen, its tiles, its channels); this
+ * file lights the HALL around the screen and makes every stop and every answer
+ * pay out in light and sound. The trickster (trickster.js) lies about the
+ * slip; the pressure (pressure.js) is what the room DOES to you as the surge
+ * climbs. This file is the lighting rig and the chime rack.
+ *
+ *   HALL IDENTITY     seeded per CLASS seed (Deck I): a hue pair on the
+ *                     violet->rose arc (~6% of halls leave the arc for a teal
+ *                     night), the beam's breath, the dust density, the bulb
+ *                     pitch of the marquee, and a JOURNEY of 2-3 stops the
+ *                     hall walks as heat climbs (the beam swaps its hue pair,
+ *                     the glow behind the screen deepens). Same seed, same
+ *                     hall; a retake sits in the identical room.
+ *   MARQUEE           a bezel of bulbs around the screen (drift-by-transform,
+ *                     trap 36 - never background-position). Crawls at low heat,
+ *                     chases hungrily at high heat, flashes on a payout, goes
+ *                     GOLD for the bell and the royal, HOLDS for a stop (the
+ *                     reel stops with the montage) and sighs out on a dim-out.
+ *   THE STOP          is the slot-pull: a lever at the screen's edge drops on
+ *                     every stop; a drawn bell swings and RINGS only when the
+ *                     stop is announced (tier 1 every stop, tier 3+ none) - a
+ *                     bell that is not always rung is the whole class.
+ *   PAYOUT LIGHT      a correct answer floods the hall in the identity hue,
+ *                     flashes the marquee and chimes the SOUND LADDER: +1
+ *                     semitone per link of the streak, capped +7 (the intake
+ *                     precedent). A miss is a muted thud, a timeout a soft
+ *                     exhale - never silence.
+ *   THE ALMOST        near-miss staging: on a wrong pick the TRUE option ghosts
+ *                     through - a pulse of light on its rectangle (an overlay
+ *                     node over the slip, pointer-events:none, never a write
+ *                     on the option) while the word lands and the near_miss
+ *                     ceremony rises. The ledger already decided.
+ *   THE JACKPOT LADDER minor (a seeded roll on a 2-link, chance rising with
+ *                     heat), major (3 and 5 links, deterministic), ROYAL (once
+ *                     a class, a streak that reaches the royal line - the hall
+ *                     floods gold and the marquee stays gold). A failed class
+ *                     still gets a dim payout on dimOut(): silence is where
+ *                     people stand up.
+ *   THE REEL CHANGE   a layout change sweeps a band of projector light down
+ *                     the screen; a density peak flares the beam.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects CORE hands it AFTER its own
+ *       accounting; writes nothing about the ledger, the stops, the streak,
+ *       the options' order or the grade.
+ *   II  input honest  - every node here is pointer-events:none; nothing is
+ *       mounted inside, over (with hit-testing) or around an option; the
+ *       almost ghost is a decoration positioned from the option's rect.
+ *   III never still   - the marquee crawls at heat 0, the dust drifts, the
+ *       beam breathes (style.js), the lever glints.
+ *   IV  images > text - three words (ALMOST / RESISTED / ROYAL) through the
+ *       lexicon, under 700ms each.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ir-casino|<tag>' (append-
+ *       only tags; a new tag never shifts an old stream). No Math.random.
+ *   VI  exits sacred  - capsOk false disarms every light (no nodes, no cues);
+ *       reduced motion keeps a static dim bezel (no chase, no sweep, no ghost
+ *       pulse - a flood is a fade and survives); the stage's .suspended rule
+ *       freezes the chase; timers ride the game's pause-aware registry AND a
+ *       local set so destroy() cannot leak one.
+ *   VII lexicon       - ir_almost / ir_resisted / ir_royal only, through opts.t.
+ *   PERF LAW          - zero per-frame JS; zero writes on .g-ir-tile or its
+ *       media; every animation is CSS on chrome nodes this deck owns.
+ *
+ * ENGINE vs GAME-LOCAL: cues and the jackpot / near_miss ceremonies go through
+ * opts.engine (CORE's null-safe weld: audio ceiling, clickSafe, pitch pass-
+ * through). The bezel, the flood, the lever, the bell, the words and the ghost
+ * are game-local: they sit on the game's own geometry (the screen, the slip).
+ * ==========================================================================*/
+
+import { makeRng, hash01 } from '../../core/rng.js';
+
+export const IR_CASINO = Object.freeze({
+  /* ---- the marquee ------------------------------------------------------ */
+  MQ_T_SLOW: 3.4,                              // chase period (s) at heat 0
+  MQ_T_FAST: 0.9,                              // at heat 1
+  MQ_A_LO: 0.22,                               // presence (opacity) band
+  MQ_A_HI: 0.84,
+  MQ_T_GOLD: 0.5,
+  MQ_A_GOLD: 0.95,
+  MQ_FLASH_MS: 560,
+  /** tonight only: three bulb temperatures, the UTC date picks one. */
+  TONIGHT_HUES: Object.freeze([38, 330, 268]),
+  /* ---- the payout ------------------------------------------------------- */
+  FLOOD_MS: 700,
+  FLOOD_A: Object.freeze([0.16, 0.5]),         // by streak/6
+  WORD_MS: 640,
+  /* ---- the stop --------------------------------------------------------- */
+  LEVER_MS: 900,
+  BELL_MS: 1400,
+  BELL_LEVEL: 0.42,
+  BELL_PITCH: 1.5,
+  LEVER_LEVEL: 0.18,
+  /* ---- the ladders ------------------------------------------------------ */
+  SEMITONE_CAP: 7,
+  HIT_LEVEL: Object.freeze([0.3, 0.52]),        // by min(streak,6)/6
+  MISS_LEVEL: 0.24,
+  TIMEOUT_LEVEL: 0.22,
+  MILESTONE_LEVEL: 0.45,
+  JACKPOT_LEVEL: 0.55,
+  NEAR_LEVEL: 0.3,
+  MINOR_STREAK: 2,
+  MINOR_CHANCE: Object.freeze([0.25, 0.6]),    // by heat
+  MINOR_I: 0.35,
+  MAJOR_STREAKS: Object.freeze([3, 5]),
+  MAJOR_I: Object.freeze([0.6, 0.85]),
+  ROYAL_MIN_STREAK: 4,                         // a perfect tier-3+ class (tier 1-2 cannot reach it)
+  ROYAL_I: 1,
+  ROYAL_MS: 3200,
+  END_DIM_MS: 1500,
+  ALMOST_MS: 1300,
+  NEAR_MISS_I: 0.65,
+  /* ---- reel / peak ------------------------------------------------------ */
+  REEL_MS: 720,
+  PEAK_MS: 1100,
+  /* ---- identity --------------------------------------------------------- */
+  OFF_ARC: 0.06,
+  HUE_ARC: Object.freeze([262, 345]),          // violet -> rose
+  HUE_OFF: 182,                                // the teal night
+  JOURNEY_MIN: 2,
+  JOURNEY_SPAN: 2,                             // 2..3 stops
+  STOP_HYST: 0.06,
+  HEAT_REPAINT_STEP: 0.03,
+  DUST_MIN: 8,
+  DUST_SPAN: 10,                               // 8..17 motes
+});
+
+const STYLE_ID = 'g-ir-casino-style';
+const STYLE_TEXT = `
+/* the bezel: four bars of bulbs INSIDE the screen's edge (the montage clips, so
+   the bulbs live on the rim, above the tiles, below the veil). THE DRIFT LAW
+   (trap 36): each bar is a CLIP and the dots live on its ::before, oversized by
+   one dot pitch (20px) at both ends and translated by exactly that pitch - a
+   compositor-only chase with an invisible wrap; never background-position, and
+   no per-bulb filter (a glow is baked into the gradient). Pace and presence
+   ride heat; a stop HOLDS the chase (animation-play-state), gold for the bell. */
+.g-ir-mq{position:absolute;inset:0;z-index:6;pointer-events:none;border-radius:inherit;
+  --ir-mqt:3.4s;--ir-mqa:.22;--ir-mqhue:330;opacity:var(--ir-mqa);transition:opacity .8s ease}
+.g-ir-mq i{position:absolute;display:block;overflow:hidden}
+.g-ir-mq i::before{content:"";position:absolute;
+  background-image:radial-gradient(circle, hsl(var(--ir-mqhue) 95% 80%) 1.6px, hsl(var(--ir-mqhue) 92% 70% / .9) 2.4px, hsl(var(--ir-mqhue) 90% 65% / .35) 3.4px, transparent 4.6px)}
+.g-ir-mq .mq-t,.g-ir-mq .mq-b{left:0;right:0;height:9px}
+.g-ir-mq .mq-l,.g-ir-mq .mq-r{top:0;bottom:0;width:9px}
+.g-ir-mq .mq-t::before,.g-ir-mq .mq-b::before{top:0;bottom:0;left:-20px;right:-20px;background-size:20px 9px;background-repeat:repeat-x}
+.g-ir-mq .mq-l::before,.g-ir-mq .mq-r::before{left:0;right:0;top:-20px;bottom:-20px;background-size:9px 20px;background-repeat:repeat-y}
+.g-ir-mq .mq-t{top:0}.g-ir-mq .mq-r{right:0}.g-ir-mq .mq-b{bottom:0}.g-ir-mq .mq-l{left:0}
+.g-ir-mq .mq-t::before{animation:g-ir-mqx var(--ir-mqt) linear infinite var(--ir-mqp,0s)}
+.g-ir-mq .mq-r::before{animation:g-ir-mqy var(--ir-mqt) linear infinite var(--ir-mqp,0s)}
+.g-ir-mq .mq-b::before{animation:g-ir-mqxr var(--ir-mqt) linear infinite var(--ir-mqp,0s)}
+.g-ir-mq .mq-l::before{animation:g-ir-mqyr var(--ir-mqt) linear infinite var(--ir-mqp,0s)}
+@keyframes g-ir-mqx{from{transform:translate3d(0,0,0)}to{transform:translate3d(20px,0,0)}}
+@keyframes g-ir-mqxr{from{transform:translate3d(0,0,0)}to{transform:translate3d(-20px,0,0)}}
+@keyframes g-ir-mqy{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,20px,0)}}
+@keyframes g-ir-mqyr{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-20px,0)}}
+.g-ir-mq.is-held i::before{animation-play-state:paused}
+.g-ir-mq.is-gold{--ir-mqhue:46 !important}
+/* the flash is an opacity breathe on the bezel itself - never a filter on the bars */
+.g-ir-mq.is-flash{animation:g-ir-mqflash .56s ease-out 1}
+@keyframes g-ir-mqflash{0%{opacity:1}100%{opacity:var(--ir-mqa)}}
+.g-ir-mq.is-out{opacity:.08;transition:opacity 1.6s ease}
+
+/* the lever: a slot handle on the screen's right rim; it drops on every stop */
+.g-ir-cs-lever{position:absolute;right:14px;top:50%;z-index:7;width:10px;height:84px;margin-top:-42px;pointer-events:none;
+  transform-origin:50% 90%;opacity:.55;transition:opacity .6s ease}
+.g-ir-cs-lever::before{content:"";position:absolute;left:3px;top:0;bottom:10px;width:4px;border-radius:2px;
+  background:linear-gradient(180deg, rgba(255,255,255,.8), rgba(184,166,232,.45));box-shadow:0 0 8px rgba(184,166,232,.5)}
+.g-ir-cs-lever::after{content:"";position:absolute;left:-6px;top:-8px;width:22px;height:22px;border-radius:50%;
+  background:radial-gradient(circle at 35% 30%, #ffd1ea, var(--pink) 55%, #8d2c64);box-shadow:0 0 12px rgba(255,105,180,.7)}
+.g-ir-cs-lever.is-pulled{animation:g-ir-cs-pull .9s cubic-bezier(.3,1.4,.4,1) 1}
+@keyframes g-ir-cs-pull{0%{transform:rotate(0)}30%{transform:rotate(150deg)}55%{transform:rotate(150deg)}100%{transform:rotate(0)}}
+
+/* the bell: a drawn bell at the screen's top rim - it swings only when rung */
+.g-ir-cs-bell{position:absolute;left:50%;top:10px;z-index:7;width:26px;height:26px;margin-left:-13px;pointer-events:none;
+  opacity:.35;transform-origin:50% 0;transition:opacity .5s ease}
+.g-ir-cs-bell::before{content:"";position:absolute;left:3px;top:2px;width:20px;height:18px;border-radius:10px 10px 3px 3px;
+  background:linear-gradient(180deg, #ffe9a8, var(--gold) 60%, #9a7a1e);box-shadow:0 0 10px rgba(240,194,75,.5)}
+.g-ir-cs-bell::after{content:"";position:absolute;left:10px;top:18px;width:6px;height:6px;border-radius:50%;background:#ffe9a8}
+.g-ir-cs-bell.is-rung{opacity:1;animation:g-ir-cs-ring 1.4s ease-in-out 1}
+@keyframes g-ir-cs-ring{0%{transform:rotate(0)}15%{transform:rotate(28deg)}35%{transform:rotate(-24deg)}55%{transform:rotate(16deg)}
+  75%{transform:rotate(-9deg)}100%{transform:rotate(0)}}
+
+/* the reel change: a band of projector light sweeps down the screen */
+.g-ir-cs-reel{position:absolute;left:0;right:0;top:-18%;height:18%;z-index:6;pointer-events:none;opacity:0;
+  background:linear-gradient(180deg, transparent, rgba(255,255,255,.22) 45%, rgba(255,255,255,.32) 50%, rgba(255,255,255,.22) 55%, transparent)}
+.g-ir-cs-reel.is-on{animation:g-ir-cs-sweep .72s ease-in-out 1}
+@keyframes g-ir-cs-sweep{0%{opacity:0;transform:translateY(0)}15%{opacity:1}85%{opacity:1}100%{opacity:0;transform:translateY(660%)}}
+
+/* the flood: payout light over the whole hall, in the identity hue */
+.g-ir-cs-flood{position:absolute;inset:0;z-index:4;pointer-events:none;opacity:0;
+  background:radial-gradient(70% 60% at 50% 50%, hsl(var(--ir-cs-hue,330) 90% 70% / .7) 0%, hsl(var(--ir-cs-hue,330) 90% 60% / .25) 40%, transparent 72%);
+  transition:opacity .16s ease-out}
+.g-ir-cs-flood.is-on{opacity:var(--ir-cs-pay,.3);transition:opacity .06s ease-in}
+.g-ir-cs-flood.is-royal{background:radial-gradient(80% 70% at 50% 50%, hsl(46 100% 72% / .95) 0%, hsl(46 100% 60% / .45) 35%, hsl(46 100% 50% / .12) 70%, transparent 100%);
+  opacity:.9;transition:opacity .35s ease-out}
+/* the glow behind the screen (identity hue, deepens on the journey) */
+.g-ir-cs-glow{position:absolute;left:50%;top:50%;z-index:0;pointer-events:none;width:min(110%,1240px);height:70%;
+  transform:translate(-50%,-48%);border-radius:40%;
+  background:radial-gradient(60% 60% at 50% 50%, hsl(var(--ir-cs-hue,330) 80% 62% / calc(.10 + var(--ir-cs-deep,0) * .16)), transparent 70%);
+  animation:g-ir-cs-glow var(--ir-n-breath,9s) ease-in-out infinite alternate}
+@keyframes g-ir-cs-glow{from{transform:translate(-50%,-48%) scale(1)}to{transform:translate(-50%,-50%) scale(1.06)}}
+.g-ir-stage.g-ir-cs-peak .g-ir-cs-glow{animation-duration:1.2s}
+/* the dust: motes in the beam, each on its own slow rise */
+.g-ir-cs-dust{position:absolute;inset:0;z-index:0;pointer-events:none;overflow:hidden}
+.g-ir-cs-mote{position:absolute;left:var(--x,50%);top:var(--y,50%);width:var(--s,3px);height:var(--s,3px);border-radius:50%;
+  background:hsl(var(--ir-cs-hue,330) 60% 88% / .55);box-shadow:0 0 6px hsl(var(--ir-cs-hue,330) 70% 80% / .5);
+  animation:g-ir-cs-mote var(--d,14s) linear infinite;animation-delay:var(--dl,0s);opacity:0}
+@keyframes g-ir-cs-mote{0%{opacity:0;transform:translate(0,0)}10%{opacity:.8}90%{opacity:.6}100%{opacity:0;transform:translate(var(--dx,10px),var(--dy,-60px))}}
+
+/* the words: ALMOST / RESISTED / ROYAL, on the stage under the slip's foot */
+.g-ir-cs-word{position:absolute;left:50%;top:calc(50% + 150px);z-index:8;transform:translate(-50%,-50%);
+  pointer-events:none;font:800 clamp(14px,2.2vmin,22px)/1 var(--disp);letter-spacing:.24em;
+  color:hsl(var(--ir-cs-hue,330) 90% 82%);text-shadow:0 0 12px hsl(var(--ir-cs-hue,330) 90% 70% / .8);opacity:0}
+.g-ir-cs-word.is-on{animation:g-ir-cs-word .64s ease-out forwards}
+.g-ir-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-ir-cs-word.gold{color:#ffe08a;text-shadow:0 0 14px rgba(240,194,75,.9)}
+@keyframes g-ir-cs-word{0%{opacity:0;transform:translate(-50%,-50%) scale(.7)}18%{opacity:1;transform:translate(-50%,-50%) scale(1.08)}
+  70%{opacity:1;transform:translate(-50%,-54%) scale(1)}100%{opacity:0;transform:translate(-50%,-64%) scale(1)}}
+
+/* the almost ghost: the TRUE option's rectangle pulses through a wrong pick.
+   An overlay in the stage, placed from the option's rect; never a write on it. */
+.g-ir-cs-ghost{position:absolute;z-index:8;pointer-events:none;border-radius:9px;opacity:0;
+  left:var(--x,0);top:var(--y,0);width:var(--w,100px);height:var(--h,50px);
+  box-shadow:0 0 0 2px rgba(240,194,75,.85), 0 0 22px rgba(240,194,75,.6), inset 0 0 18px rgba(240,194,75,.35)}
+.g-ir-cs-ghost.is-on{animation:g-ir-cs-ghost 1.3s ease-out 1}
+@keyframes g-ir-cs-ghost{0%{opacity:0}12%{opacity:1}30%{opacity:.25}48%{opacity:1}66%{opacity:.3}84%{opacity:.9}100%{opacity:0}}
+
+@media (prefers-reduced-motion: reduce){
+  .g-ir-mq i::before,.g-ir-mq.is-flash,.g-ir-cs-glow,.g-ir-cs-mote,.g-ir-cs-lever.is-pulled,.g-ir-cs-bell.is-rung,.g-ir-cs-reel.is-on{animation:none !important}
+  .g-ir-cs-mote{opacity:.5}
+  .g-ir-cs-bell.is-rung{opacity:1}
+  .g-ir-cs-word.is-on{animation:none;opacity:1}
+  .g-ir-cs-ghost.is-on{animation:none;opacity:.9}
+}
+html.arc-reduced .g-ir-mq i::before,html.arc-reduced .g-ir-mq.is-flash,html.arc-reduced .g-ir-cs-glow,html.arc-reduced .g-ir-cs-mote{animation:none !important}
+html.arc-reduced .g-ir-cs-mote{opacity:.5}
+html.arc-reduced .g-ir-cs-word.is-on{animation:none;opacity:1}
+html.arc-reduced .g-ir-cs-ghost.is-on{animation:none;opacity:.9}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** The chime's pitch for a streak: +1 semitone per link, capped. Pure. */
+export function pitchForStreak(streak) {
+  const s = Math.max(0, Math.min(IR_CASINO.SEMITONE_CAP, (Number(streak) || 0) - 1));
+  return +Math.pow(2, s / 12).toFixed(4);
+}
+/** Tonight's bulb hue from the UTC date string alone (shared by everyone). Pure. */
+export function tonightHue(utcDate) {
+  const h = hash01('ir-tonight|' + String(utcDate || ''));
+  const list = IR_CASINO.TONIGHT_HUES;
+  return list[Math.min(list.length - 1, Math.floor(h * list.length))];
+}
+/** The jackpot rung a streak pays, or null. Pure. minor is a ROLL (caller). */
+export function jackpotFor(streak) {
+  const s = Number(streak) || 0;
+  if (s >= IR_CASINO.ROYAL_MIN_STREAK) return 'royal';
+  const mi = IR_CASINO.MAJOR_STREAKS.indexOf(s);
+  if (mi >= 0) return 'major';
+  if (s === IR_CASINO.MINOR_STREAK) return 'minor';
+  return null;
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function restart(n, cls) {
+  if (!n || !n.classList) return;
+  try { n.classList.remove(cls); if (typeof n.offsetWidth === 'number') void n.offsetWidth; n.classList.add(cls); } catch (e) { /* noop */ }
+}
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier, stage (.g-ir-stage), montage|board (.g-ir-montage), hud (the .g-ir-hud), stopEl (.g-ir-stop),
+ *   backdrop (.g-ir-backdrop), timers {after,every,clear}, reduced, capsOk (bool | () => bool),
+ *   t (k, fallback) => string, engine {fire, ceremony?}, log, utcDate?, motionLevel?
+ */
+export function createIrCasino(o) {
+  const opts = o || {};
+  const C = IR_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const eng = opts.engine || {};
+  const stage = opts.stage || null;
+  const board = opts.montage || opts.board || null;     // CORE passes `montage`; `board` = the contract's name
+  const armedBase = !!stage && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'ir') + '|ir-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, floods: 0, words: 0, bells: 0, levers: 0, reels: 0, peaks: 0 };
+  function cue(name, level, extra) {
+    if (!armed()) return;
+    counts.cues++;
+    try {
+      if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed()) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+
+  /* ---- identity (per class seed) ------------------------------------------ */
+  const ID = (() => {
+    const offArc = roll('hue') < C.OFF_ARC;
+    const hueA = offArc ? C.HUE_OFF : Math.round(lerp(C.HUE_ARC, roll('hue')));
+    const hueB = offArc ? Math.max(160, Math.min(205, hueA + 14))
+      : Math.max(250, Math.min(350, hueA + (roll('hue2') < 0.5 ? -1 : 1) * (16 + Math.round(roll('hue2') * 24))));
+    const breath = +(7 + roll('breath') * 5).toFixed(1);             // 7..12s
+    const dust = C.DUST_MIN + Math.floor(roll('dust') * C.DUST_SPAN);
+    const stops = C.JOURNEY_MIN + Math.floor(roll('journey') * C.JOURNEY_SPAN);
+    const journey = [];
+    for (let i = 0; i < stops; i++) {
+      journey.push({
+        hue: i === 0 ? hueA : (i % 2 ? hueB : Math.round((hueA + hueB) / 2)),
+        deep: +(i / Math.max(1, stops - 1)).toFixed(2),
+        beam: +(0.55 + 0.3 * (i / Math.max(1, stops - 1))).toFixed(2),
+      });
+    }
+    const mqPhase = (roll('mq-phase') * -3.4).toFixed(2) + 's';
+    return { offArc, hueA, hueB, breath, dust, journey, mqPhase };
+  })();
+  const mqHue = tonightHue(opts.utcDate);
+
+  /* ---- nodes ------------------------------------------------------------- */
+  let mq = null; let lever = null; let bellEl = null; let reel = null;
+  let flood = null; let glow = null; let dust = null; let word = null; let ghost = null; let veil = null;
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let stopIx = -1;
+  let goldOn = false;
+  let royalOn = false;
+  let outOn = false;
+  let heldOn = false;
+  let bestStreakSeen = 0;
+  let stopsSeen = 0;
+  let answersSeen = 0;
+  let flashTimer = 0; let floodTimer = 0; let wordTimer = 0; let leverTimer = 0; let bellTimer = 0;
+  let reelTimer = 0; let peakTimer = 0; let ghostTimer = 0; let royalTimer = 0;
+  const jackLog = [];
+
+  function mount() {
+    if (mq || !armedBase || !capsOk()) return;     // bgIntensity 0: the hall stays dark
+    ensureStyle();
+    setVar(stage, '--ir-cs-hue', ID.hueA);
+    setVar(stage, '--ir-n-hue-a', ID.hueA);
+    setVar(stage, '--ir-n-hue-b', ID.hueB);
+    setVar(stage, '--ir-n-breath', ID.breath + 's');
+    /* the hall layers in the backdrop: glow + dust */
+    const bd = opts.backdrop || stage;
+    glow = el('div', 'g-ir-cs-glow');
+    dust = el('div', 'g-ir-cs-dust');
+    try {
+      if (glow) bd.appendChild(glow);
+      if (dust) {
+        for (let i = 0; i < ID.dust; i++) {
+          const m = el('i', 'g-ir-cs-mote');
+          if (!m) break;
+          setVar(m, '--x', (18 + roll('mote') * 64).toFixed(1) + '%');
+          setVar(m, '--y', (10 + roll('mote') * 70).toFixed(1) + '%');
+          setVar(m, '--s', (2 + roll('mote') * 2.5).toFixed(1) + 'px');
+          setVar(m, '--d', (11 + roll('mote') * 12).toFixed(1) + 's');
+          setVar(m, '--dl', (-roll('mote') * 20).toFixed(1) + 's');
+          setVar(m, '--dx', ((roll('mote') - 0.5) * 40).toFixed(0) + 'px');
+          setVar(m, '--dy', (-(30 + roll('mote') * 70)).toFixed(0) + 'px');
+          dust.appendChild(m);
+        }
+        bd.appendChild(dust);
+      }
+    } catch (e) { /* partial mounts are fine */ }
+    /* the veil (the held breath) - style.js styles it; mount one if CORE did not */
+    try {
+      const have = stage.querySelector ? stage.querySelector('.g-ir-veil') : null;
+      if (!have) { veil = el('div', 'g-ir-veil'); if (veil) stage.appendChild(veil); }
+    } catch (e) { veil = null; }
+    /* the flood over the hall, the word and the ghost on the stage */
+    flood = el('div', 'g-ir-cs-flood');
+    word = el('div', 'g-ir-cs-word');
+    ghost = el('div', 'g-ir-cs-ghost');
+    try { if (flood) stage.appendChild(flood); } catch (e) { flood = null; }
+    try { if (word) stage.appendChild(word); } catch (e) { word = null; }
+    /* the ghost rides INSIDE the slip when CORE hands it over (so it follows the
+       slip's own transform and a relayout), else on the stage */
+    try { if (ghost) ((opts.stopEl && opts.stopEl.appendChild) ? opts.stopEl : stage).appendChild(ghost); } catch (e) { ghost = null; }
+    /* the bezel, the lever, the bell and the reel band live INSIDE the screen */
+    const host = board && board.appendChild ? board : stage;
+    mq = el('div', 'g-ir-mq');
+    if (mq) {
+      setVar(mq, '--ir-mqhue', mqHue);
+      setVar(mq, '--ir-mqp', ID.mqPhase);
+      for (const cls of ['mq-t', 'mq-r', 'mq-b', 'mq-l']) { const bar = el('i', cls); if (bar) mq.appendChild(bar); }
+      try { host.appendChild(mq); } catch (e) { mq = null; }
+    }
+    lever = el('i', 'g-ir-cs-lever');
+    bellEl = el('i', 'g-ir-cs-bell');
+    reel = el('i', 'g-ir-cs-reel');
+    try { if (lever) host.appendChild(lever); } catch (e) { lever = null; }
+    try { if (bellEl) host.appendChild(bellEl); } catch (e) { bellEl = null; }
+    try { if (reel) host.appendChild(reel); } catch (e) { reel = null; }
+    paintStop(0);
+    paintHeat(true);
+  }
+
+  /** One journey stop: hue + depth + beam, painted as props (style.js tweens). */
+  function paintStop(ix) {
+    const stop = ID.journey[Math.max(0, Math.min(ID.journey.length - 1, ix))];
+    if (!stop) return;
+    stopIx = ix;
+    setVar(stage, '--ir-cs-hue', stop.hue);
+    setVar(stage, '--ir-cs-deep', stop.deep);
+    setVar(stage, '--ir-n-beam', stop.beam);
+  }
+  function walkJourney(h) {
+    const n = ID.journey.length;
+    if (n < 2) return;
+    const raw = Math.min(n - 1, Math.floor(h * n));
+    if (stopIx < 0) { paintStop(raw); return; }
+    if (raw > stopIx && h >= (stopIx + 1) / n + C.STOP_HYST) paintStop(stopIx + 1);
+    else if (raw < stopIx && h <= stopIx / n - C.STOP_HYST) paintStop(stopIx - 1);
+  }
+  function paintHeat(force) {
+    if (!mq) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    const gold = goldOn || royalOn;
+    const period = gold ? C.MQ_T_GOLD : (C.MQ_T_SLOW + (C.MQ_T_FAST - C.MQ_T_SLOW) * heat);
+    const alpha = outOn ? 0.08 : (gold ? C.MQ_A_GOLD : lerp([C.MQ_A_LO, C.MQ_A_HI], heat));
+    setVar(mq, '--ir-mqt', period.toFixed(2) + 's');
+    setVar(mq, '--ir-mqa', alpha.toFixed(2));
+    walkJourney(heat);
+  }
+
+  /* ---- the light ---------------------------------------------------------- */
+  function flashMarquee(ms) {
+    if (!mq || !armed() || still) return;
+    setCls(mq, 'is-flash', true);
+    cancel(flashTimer);
+    flashTimer = after(ms || C.MQ_FLASH_MS, () => setCls(mq, 'is-flash', false));
+  }
+  function floodHall(q, ms) {
+    if (!flood || !armed()) return;
+    counts.floods++;
+    setVar(flood, '--ir-cs-pay', lerp(C.FLOOD_A, q).toFixed(2));
+    setCls(flood, 'is-on', true);
+    cancel(floodTimer);
+    floodTimer = after(ms || C.FLOOD_MS, () => setCls(flood, 'is-on', false));
+  }
+  function showWord(key, fallback, tone) {
+    if (!word || !armed()) return;
+    counts.words++;
+    try { word.textContent = t(key, fallback); } catch (e) { /* noop */ }
+    word.className = 'g-ir-cs-word' + (tone ? ' ' + tone : '');
+    try { if (typeof word.offsetWidth === 'number') void word.offsetWidth; } catch (e) { /* noop */ }
+    setCls(word, 'is-on', true);
+    cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 40, () => setCls(word, 'is-on', false));
+  }
+  function pullLever() {
+    if (!lever || !armed()) return;
+    counts.levers++;
+    if (still) return;
+    restart(lever, 'is-pulled');
+    cancel(leverTimer);
+    leverTimer = after(C.LEVER_MS + 40, () => setCls(lever, 'is-pulled', false));
+  }
+  function ringBell() {
+    if (!armed()) return;
+    counts.bells++;
+    cue('sting', C.BELL_LEVEL, { pitch: C.BELL_PITCH });
+    after(150, () => cue('sting', C.BELL_LEVEL * 0.8, { pitch: C.BELL_PITCH }));
+    if (bellEl) {
+      restart(bellEl, 'is-rung');
+      cancel(bellTimer);
+      bellTimer = after(C.BELL_MS + 40, () => setCls(bellEl, 'is-rung', false));
+    }
+  }
+  /** The true option ghosts through: an overlay placed from its rect. */
+  function ghostOption(optEl) {
+    if (!ghost || !armed() || !optEl) return false;
+    const r = rectOf(optEl);
+    const s = rectOf(ghost.parentNode || stage);
+    if (!r || !s || !r.width) return false;
+    setVar(ghost, '--x', (r.left - s.left).toFixed(0) + 'px');
+    setVar(ghost, '--y', (r.top - s.top).toFixed(0) + 'px');
+    setVar(ghost, '--w', r.width.toFixed(0) + 'px');
+    setVar(ghost, '--h', r.height.toFixed(0) + 'px');
+    restart(ghost, 'is-on');
+    cancel(ghostTimer);
+    ghostTimer = after(C.ALMOST_MS + 40, () => setCls(ghost, 'is-on', false));
+    return true;
+  }
+  /** Find the true option after a verdict: the event says, or CORE marked it. */
+  function truthOption(e) {
+    let idx = null;
+    for (const k of ['truth', 'trueIndex', 'truthIndex', 'correctIndex']) {
+      if (e && Number.isFinite(Number(e[k])) && e[k] != null) { idx = Number(e[k]); break; }
+    }
+    if (!stage || typeof stage.querySelectorAll !== 'function') return null;
+    let opts2 = [];
+    try { opts2 = Array.from(stage.querySelectorAll('.g-ir-opt')); } catch (err) { opts2 = []; }
+    if (!opts2.length) return null;
+    if (idx != null) {
+      for (const n of opts2) { try { if (Number(n.getAttribute('data-i')) === idx) return n; } catch (err) { /* noop */ } }
+    }
+    for (const n of opts2) {
+      try {
+        if ((n.classList && (n.classList.contains('is-true') || n.classList.contains('is-correct') || n.classList.contains('is-truth')))
+          || n.getAttribute('data-verdict') === 'correct' || n.getAttribute('data-truth') === '1') return n;
+      } catch (err) { /* noop */ }
+    }
+    return null;
+  }
+
+  /* ---- the ladder --------------------------------------------------------- */
+  function jackpot(intensity, why) {
+    if (!armed()) return;
+    counts.jackpots++;
+    jackLog.push(why);
+    ceremony('jackpot', { intensity });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashMarquee(C.MQ_FLASH_MS + 300 * intensity);
+    floodHall(intensity, C.FLOOD_MS + 300);
+  }
+  function nearMiss(intensity, pitch) {
+    if (!armed()) return;
+    counts.nearMisses++;
+    ceremony('near_miss', { intensity });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: pitch || 0.8 });
+  }
+  function royal() {
+    if (royalOn || !armed()) return;
+    royalOn = true;
+    counts.royal = 1;
+    setCls(mq, 'is-gold', true);
+    setCls(flood, 'is-royal', true);
+    showWord('ir_royal', 'ROYAL', 'gold');
+    ceremony('jackpot', { intensity: C.ROYAL_I });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.2 });
+    after(260, () => cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.5 }));
+    after(520, () => cue('stamp', 0.5, { pitch: 1 }));
+    flashMarquee(C.ROYAL_MS);
+    cancel(royalTimer);
+    royalTimer = after(C.ROYAL_MS, () => { setCls(flood, 'is-royal', false); paintHeat(true); });
+    paintHeat(true);
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      mount();
+      say('casino: hall lit (hue ' + ID.hueA + '/' + ID.hueB + (ID.offArc ? ' off-arc' : '') + ', journey '
+        + ID.journey.length + ', dust ' + ID.dust + ', tonight ' + mqHue + ')');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started) paintHeat(false);
+    },
+    /** The reel change: a band of light sweeps the screen. */
+    layoutChange(kind) {
+      if (!armed() || !started) return;
+      counts.reels++;
+      cue('slide', 0.14, { pitch: kind === 'swirl' ? 0.8 : kind === 'mosaic' ? 1.1 : 1 });
+      if (still || !reel) return;
+      restart(reel, 'is-on');
+      cancel(reelTimer);
+      reelTimer = after(C.REEL_MS + 40, () => setCls(reel, 'is-on', false));
+    },
+    /** A density peak: the beam flares, the bezel flashes. */
+    densityPeak() {
+      if (!armed() || !started) return;
+      counts.peaks++;
+      cue('whisper', 0.2, { pitch: 1.2 });
+      flashMarquee(C.MQ_FLASH_MS);
+      setCls(stage, 'g-ir-cs-peak', true);
+      cancel(peakTimer);
+      peakTimer = after(C.PEAK_MS, () => setCls(stage, 'g-ir-cs-peak', false));
+    },
+    /** THE STOP is the slot-pull: the chase holds, the lever drops, the bell
+     *  rings only when the stop is announced. CORE calls stopBeat(n, announced);
+     *  the contract's name, stop(n, announced), is honoured below when called
+     *  WITH a numeric first argument. */
+    stopBeat(n, announced) {
+      if (!armed() || !started) return;
+      stopsSeen++;
+      heldOn = true;
+      setCls(mq, 'is-held', true);
+      pullLever();
+      if (announced) ringBell();
+      else cue('slide', C.LEVER_LEVEL, { pitch: 0.75 });
+      void n;
+    },
+    /** Every answer, after the ledger: the chime ladder, the payout light,
+     *  the almost, the jackpot ladder. The chase is released. */
+    answer(ev) {
+      if (!armed() || !started) return;
+      const e = ev || {};
+      answersSeen++;
+      heldOn = false;
+      setCls(mq, 'is-held', false);
+      const streak = Math.max(0, Number(e.streak) || 0);
+      bestStreakSeen = Math.max(bestStreakSeen, streak);
+      if (e.correct) {
+        /* THE SOUND LADDER + PAYOUT LIGHT */
+        const q = clamp01(Math.min(6, streak) / 6);
+        cue('sting', lerp(C.HIT_LEVEL, q), { pitch: pitchForStreak(streak) });
+        floodHall(q);
+        flashMarquee();
+        /* THE JACKPOT LADDER */
+        const rung = jackpotFor(streak);
+        if (rung === 'royal') { royal(); }
+        else if (rung === 'major') {
+          const mi = C.MAJOR_STREAKS.indexOf(streak);
+          cue('streak', C.MILESTONE_LEVEL, { pitch: pitchForStreak(streak) });
+          jackpot(C.MAJOR_I[Math.max(0, mi)], 'major@' + streak);
+        } else if (rung === 'minor' && roll('jack-minor') < lerp(C.MINOR_CHANCE, heat)) {
+          jackpot(C.MINOR_I, 'minor@' + streak);
+        }
+        return;
+      }
+      if (e.timedOut) {
+        cue('whisper', C.TIMEOUT_LEVEL, { pitch: 0.85 });      // the soft exhale
+        floodHall(0.05, 400);
+        return;
+      }
+      /* a miss: a muted thud, never silence - and THE ALMOST if the truth shows */
+      cue('bump', C.MISS_LEVEL, { pitch: 0.7 });
+      const truth = truthOption(e);
+      if (truth && !still && ghostOption(truth)) {
+        showWord('ir_almost', 'ALMOST', 'lav');
+        nearMiss(C.NEAR_MISS_I, 0.8);
+      }
+    },
+    /** A planted decoy went unanswered: a lavender glint, a soft word. */
+    plantResisted() {
+      if (!armed() || !started) return;
+      cue('whisper', 0.25, { pitch: 1.3 });
+      floodHall(0.12, 500);
+      showWord('ir_resisted', 'RESISTED', 'lav');
+    },
+    /** The last stretch / the final stop: gold bezel, frantic chase. */
+    bell(on) {
+      goldOn = !!on;
+      setCls(mq, 'is-gold', goldOn || royalOn);
+      paintHeat(true);
+    },
+    /** The class ended short of the royal: a dim payout, never silence. */
+    dimOut() {
+      outOn = true;
+      goldOn = false;
+      heldOn = false;
+      setCls(mq, 'is-held', false);
+      setCls(mq, 'is-flash', false);
+      if (!royalOn) setCls(mq, 'is-gold', false);
+      setCls(mq, 'is-out', true);
+      if (armed() && started) {
+        floodHall(0.15, C.END_DIM_MS);
+        cue('wash', 0.25, { pitch: 0.9 });
+      }
+      paintHeat(true);
+    },
+    pause() { /* CSS chases are frozen by the stage's .suspended rule; timers are the game's */ },
+    resume() { /* nothing to rebuild: transient light simply ended */ },
+    /** The class is over: no light may pulse again. (Called with a numeric
+     *  first argument it is the contract's `stop(n, announced)` event instead.) */
+    stop(n, announced) {
+      if (typeof n === 'number') { api.stopBeat(n, announced); return; }
+      cancelAll();
+      setCls(mq, 'is-flash', false);
+      setCls(flood, 'is-on', false);
+      setCls(ghost, 'is-on', false);
+      setCls(stage, 'g-ir-cs-peak', false);
+    },
+    destroy() {
+      destroyed = true;
+      cancelAll();
+      for (const n of [mq, lever, bellEl, reel, flood, glow, dust, word, ghost, veil]) {
+        try { if (n && typeof n.remove === 'function') n.remove(); else if (n && n.parentNode) n.parentNode.removeChild(n); } catch (e) { /* noop */ }
+      }
+      mq = lever = bellEl = reel = flood = glow = dust = word = ghost = veil = null;
+      setCls(stage, 'g-ir-cs-peak', false);
+      if (stage && stage.style) {
+        for (const k of ['--ir-cs-hue', '--ir-cs-deep', '--ir-n-hue-a', '--ir-n-hue-b', '--ir-n-breath', '--ir-n-beam']) {
+          try { stage.style.removeProperty(k); } catch (e) { /* noop */ }
+        }
+      }
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, heat: +heat.toFixed(3), hueA: ID.hueA, hueB: ID.hueB, offArc: ID.offArc,
+        journey: ID.journey.length, stop: stopIx, dust: ID.dust, tonightHue: mqHue,
+        gold: goldOn, royal: royalOn, out: outOn, held: heldOn,
+        stops: stopsSeen, answers: answersSeen, bestStreak: bestStreakSeen,
+        counts: Object.assign({}, counts), jackpots: jackLog.slice(),
+        liveTimers: live.size, nodes: [mq, lever, bellEl, reel, flood, glow, dust, word, ghost].filter(Boolean).length,
+      };
+    },
+  };
+  return api;
+}
+
+export default createIrCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/grade.js
@@ -1,0 +1,160 @@
+/* ============================================================================
+ * games/instant-recall/grade.js - the composite INSTANT RECALL hands to the ONE
+ * shared rubric (core/grades.js, via ctx.endClass). PURE.
+ *
+ * A game never grades itself: this file turns the vigil's inputs into a 0..1
+ * composite, a declared hard gate and the flavour XP, and the SHELL maps the
+ * composite to S/A/B/C (>= .92 S / .75 A / .50 B) and applies every cap.
+ *
+ * THE COMPOSITE (dossier "Grading", contract "template-level accuracy weighted
+ * by window, decoy resistance, latency"):
+ *   .55  accuracy   per-question credit, WEIGHTED BY WINDOW - a 4s question is
+ *                   worth 1.5x a 6s one, so a tier-4 class is not silently
+ *                   easier to ace than a tier-1 one. Library-agnostic: it scores
+ *                   TEMPLATES, never which asset the provider happened to deal.
+ *   .20  latency    mean commit time as a fraction of the question's own window.
+ *                   TIMEOUTS ARE EXCLUDED FROM THE MEAN (a 6s non-answer would
+ *                   otherwise read as a slow answer) and scored as misses above.
+ *   .15  resistance fraction of decoy-plant exposures NOT taken. Scored 1.0 when
+ *                   plants are disabled by tier or reduced motion, so
+ *                   accessibility never costs a grade.
+ *   .10  streak     longest run of fully-correct stops / total stops.
+ *
+ * HARD RULES the dossier pins, and where each one lives:
+ *   "S requires every stop fully correct"  -> hardGates.sGate (the shell caps a
+ *                                             failed gate at A).
+ *   "any timed-out question caps at B"     -> TIMEOUT_CEIL here. core/grades.js
+ *                                             only knows A-caps, so the honest
+ *                                             way to express a B ceiling is to
+ *                                             clamp the composite just under the
+ *                                             A threshold. It never PROMOTES.
+ *   "a voided stop scores C for that stop, -> VOID_CREDIT (partial credit, never
+ *    but never fails the class"                zero, never a fail).
+ *   comeback hook                          -> `correctedWeight`: ONE missed stop
+ *                                             per class may be restored to full
+ *                                             credit by getting the NEXT stop
+ *                                             fully right. It cannot launder an
+ *                                             S: a corrected stop was still not
+ *                                             fully correct, so sGate stays down.
+ *
+ * FLAVOUR XP: a small tick per bait dodged plus one per clean stop, cap 15
+ * (the shell clamps at 15 too - BUILD-CONTRACT §8). Never composite.
+ * ==========================================================================*/
+
+export const GRADE = Object.freeze({
+  W_ACCURACY: 0.55,
+  W_LATENCY: 0.20,
+  W_RESIST: 0.15,
+  W_STREAK: 0.10,
+
+  /** Latency anchors, as a fraction of the question's own window. */
+  LAT_FAST: 0.35,     // at or under -> full marks
+  LAT_SLOW: 0.95,     // at or over  -> nothing
+
+  /** Any timed-out question clamps the class here (just under the A threshold). */
+  TIMEOUT_CEIL: 0.74,
+  /** An escape-guard-voided question: C for that question, never zero. */
+  VOID_CREDIT: 0.4,
+
+  FLAVOR_PER_PLANT: 2,
+  FLAVOR_PER_CLEAN_STOP: 1,
+  FLAVOR_CAP: 15,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+
+/**
+ * @param {Object} i
+ *   gradeTier        1..4
+ *   questions        [{ correct, weight, windowMs, latencyMs, timedOut, voided }]
+ *   stops            [{ fullyCorrect, voided }]
+ *   plantExposures   how many plants actually fired at the player
+ *   plantsResisted   how many of those did not take
+ *   plantsEnabled    false when tier / reduced motion disabled them (=> 1.0)
+ *   correctedWeight  weighted credit restored by the comeback hook
+ *   bestRun          longest run of fully-correct stops
+ * @returns {{composite:number, raw:number, terms:Object, capped:boolean, weight:number}}
+ */
+export function compositeFor(i = {}) {
+  const qs = Array.isArray(i.questions) ? i.questions : [];
+  const stops = Array.isArray(i.stops) ? i.stops : [];
+
+  /* ---- accuracy: weighted by window ---------------------------------- */
+  let wSum = 0;
+  let credit = 0;
+  let timeouts = 0;
+  let voids = 0;
+  for (const q of qs) {
+    const w = Math.max(0, Number(q.weight) || 0);
+    if (!w) continue;
+    wSum += w;
+    if (q.voided) { credit += w * GRADE.VOID_CREDIT; voids += 1; continue; }
+    if (q.timedOut) { timeouts += 1; continue; }
+    if (q.correct) credit += w;
+  }
+  const restored = Math.max(0, Number(i.correctedWeight) || 0);
+  const accuracy = wSum > 0 ? clamp01((credit + restored) / wSum) : 0;
+
+  /* ---- latency: mean fraction of the window, timeouts excluded -------- */
+  let latSum = 0;
+  let latN = 0;
+  for (const q of qs) {
+    if (q.timedOut || q.voided) continue;
+    const win = Math.max(1, Number(q.windowMs) || 1);
+    const ms = Math.max(0, Number(q.latencyMs) || 0);
+    latSum += Math.min(1.5, ms / win);
+    latN += 1;
+  }
+  const meanF = latN > 0 ? latSum / latN : 1;
+  const latency = latN > 0
+    ? clamp01((GRADE.LAT_SLOW - meanF) / (GRADE.LAT_SLOW - GRADE.LAT_FAST))
+    : 0;
+
+  /* ---- decoy resistance ---------------------------------------------- */
+  const exposures = Math.max(0, Math.round(Number(i.plantExposures) || 0));
+  const resistedN = Math.max(0, Math.round(Number(i.plantsResisted) || 0));
+  const resistance = (i.plantsEnabled === false || exposures === 0)
+    ? 1
+    : clamp01(resistedN / exposures);
+
+  /* ---- vigil streak --------------------------------------------------- */
+  const totalStops = stops.length;
+  const best = Math.max(0, Math.round(Number(i.bestRun) || 0));
+  const streak = totalStops > 0 ? clamp01(best / totalStops) : 0;
+
+  const raw = GRADE.W_ACCURACY * accuracy + GRADE.W_LATENCY * latency
+    + GRADE.W_RESIST * resistance + GRADE.W_STREAK * streak;
+
+  let composite = clamp01(raw);
+  let capped = false;
+  if (timeouts > 0 && composite > GRADE.TIMEOUT_CEIL) { composite = GRADE.TIMEOUT_CEIL; capped = true; }
+
+  return {
+    composite,
+    raw: clamp01(raw),
+    capped,
+    weight: wSum,
+    terms: { accuracy, latency, resistance, streak },
+    counts: { questions: qs.length, timeouts, voids, stops: totalStops, exposures, resisted: resistedN },
+  };
+}
+
+/**
+ * Declared gates. The dossier's S rule: every stop fully correct at the class's
+ * tier. A class with no stops (impossible under the final-stop guarantee, but
+ * the gate must still answer) cannot earn an S.
+ */
+export function hardGates(stops) {
+  const list = Array.isArray(stops) ? stops : [];
+  const clean = list.length > 0 && list.every((s) => s && s.fullyCorrect && !s.voided);
+  return { sGate: clean };
+}
+
+/** A tick per bait dodged plus one per clean stop, cap 15. */
+export function flavorXp(plantsResisted, cleanStops) {
+  const p = Math.max(0, Math.round(Number(plantsResisted) || 0));
+  const c = Math.max(0, Math.round(Number(cleanStops) || 0));
+  return Math.min(GRADE.FLAVOR_CAP, p * GRADE.FLAVOR_PER_PLANT + c * GRADE.FLAVOR_PER_CLEAN_STOP);
+}
+
+export default { compositeFor, hardGates, flavorXp, GRADE };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
@@ -1,0 +1,1803 @@
+/* ============================================================================
+ * games/instant-recall/index.js - INSTANT RECALL, "the vigil" (family: recall).
+ *
+ * One class is ONE continuous 120-second montage. The stage rotates through
+ * rows / mosaic / swirl, the Distraction Engine fires trigger channels over it
+ * denser and denser - and then, without warning, everything FREEZES and a quiz
+ * card asks what just happened. There is nothing to memorise, only a present to
+ * inhabit: the stop can land at any moment and it only ever asks about the last
+ * thing that happened, so sustained attention is the only strategy.
+ *
+ * THE VIGIL LOOP:
+ *   montage  -> emissions on the density sawtooth, every one of them written to
+ *               the LEDGER (the truth tail) with what the engine ACTUALLY did
+ *   stop     -> freeze (the class clock keeps running), quiz card, 6s/5s/4s
+ *               window by tier, answer by tap or number key
+ *   verdict  -> the truth replay proves it ("it really did flash that"), then
+ *   resume   -> a NEW layout, density relaxed ONE band, never back to the floor
+ *   FINAL    -> the seeded schedule ALWAYS puts a stop inside the last 15s, so
+ *               the class ends on a quiz and never on a fade-out.
+ *
+ * ---------------------------------------------------------------------------
+ * LAWS THIS FILE KEEPS
+ *   I    THE LEDGER IS THE TRUTH. Every question is instantiated from the tail
+ *        of `ledger`, and every ledger entry is written HERE from the engine's
+ *        own return value - never from what we asked for. The decks may lie on
+ *        a chip face or an option label; the truth is repainted and the answer
+ *        key never comes from a deck. The montage's own seat maintenance (the
+ *        frame governor, the density band, a layout rebuild) never writes an
+ *        entry, so shedding a gif seat under a frame lock cannot change an
+ *        answer.
+ *   II   INPUT HONEST. The montage is decoration end to end (every burst over
+ *        it is welded clickSafe); the only real hitboxes in the class are the
+ *        option buttons, the how-to GO button, and the audition button inside a
+ *        sting option - which never selects.
+ *   III  NEVER STILL. The stream runs the whole class; the only still frame is
+ *        the freeze, and the freeze IS the mechanic.
+ *   IV   IMAGES OVER TEXT. The class-rules sheet is drawn (style.js) and
+ *        dismissed by GO only, once per grade tier under `ctx.hideTutorial`.
+ *   V    SEEDED. vigil.js deals the whole show off the class seed before a
+ *        frame renders. The only Math.random in this game is the frame
+ *        governor's (montage.js), which never consumes the seeded stream.
+ *   VI   EXITS SACRED. pause/resume/suspend/destroy follow Deja Vu's discipline
+ *        (a pause-aware timer registry, nothing survives destroy); the answer
+ *        window is an ANSWER, never a lock - it times out, it can be voided by
+ *        the escape guard, and reduced motion / a zeroed caps vector disarm the
+ *        decks and the plants.
+ *   VII  LEXICON. Every visible string is ctx.lexicon(key, fallback) over
+ *        lex.js IR_LEX. No AI, anywhere.
+ *
+ * WHAT THIS FILE DOES NOT OWN: grades (core/grades.js via ctx.endClass), XP
+ * (C#), the tier (registry + meta), effect strengths (the engine's CEILING
+ * RULE), the whole look (style.js), the lighting (casino.js), the lies
+ * (trickster.js) and the CCP-effects ladder (pressure.js).
+ *
+ * ---------------------------------------------------------------------------
+ * THE CREATIVE SEAM. style.js / casino.js / trickster.js / pressure.js belong
+ * to the parallel creative agent. They are loaded with a DYNAMIC import +
+ * Promise.allSettled (the shell's own loadOptional posture for engine/provider)
+ * so this module is importable before they land and the class still runs -
+ * silent - if one of them throws. Every deck method is called through `deck()`,
+ * which is null-safe and try/catch'd.
+ *
+ *   injectInstantRecallStyle()
+ *   createIrCasino({ seed, tier, stage, montage, hud, backdrop, stopEl, timers,
+ *                    reduced, capsOk, t, engine, log })
+ *      start stop destroy setHeat diagnostics
+ *      layoutChange(kind) densityPeak() stopBeat(n, announced)
+ *      answer({correct, latencyMs, streak}) plantResisted() bell(on) dimOut()
+ *   createIrTrickster({ seed, tier, stopEl, timers, reduced, capsOk, isHalted, t,
+ *                       stats, chipEl, chipText, optEls, optText, windowLeft,
+ *                       announce, log })
+ *      start stop destroy diagnostics  afterStop() afterAnswer() stalled(ms)
+ *   createIrPressure({ seed, gradeTier, reduced, motionLevel, stage, montage,
+ *                      chrome, hud, engine, assets, timers, capsOk, log })
+ *      start stop destroy setHeat diagnostics setProgress(p01) setStreak(n)
+ *      beat(kind)  - every emission kind, plus 'hit' / 'miss' on a commit and
+ *                    the two structural beats 'stop' and 'layout'
+ *      pause() resume()   (the class's pause-aware registry already defers timers;
+ *                          these let a deck drop a held look while the class is frozen)
+ *
+ * NOTE on the casino's stop event: the contract names it `stop(n, announced)`
+ * and the common deck method is also `stop()`. CORE prefers `stopBeat(n,
+ * announced)` and only falls back to calling `stop(n, announced)` when the deck
+ * exports no `stopBeat` - so a casino should export `stopBeat`.
+ *
+ * ENGINE TARGETING NOTE: glitch_swap writes its own filter/animation onto its
+ * targets and style.js owns `.g-ir-tile`'s transform (the swirl orbit IS a
+ * transform), so the engine is always handed the inner `.g-ir-face`, never a
+ * tile. The swirl's spiral is `sustain('wash', {variant:'spiral',
+ * sustainForever:true})` and is NEVER stopped mid-class (trap 33) - leaving
+ * swirl steps it down by re-triggering at a lower alpha.
+ * ==========================================================================*/
+
+import { IR_LEX } from './lex.js';
+import {
+  buildVigil, assertPlan, densityAt, heatFor, cadenceMs, resolveTemplate,
+  densityMultFor, PLAYTEST, EFFECT_VOCAB, STINGS,
+} from './vigil.js';
+import { createMontage, createLedger, hideTruthNode } from './montage.js';
+import { compositeFor, hardGates, flavorXp } from './grade.js';
+import { makeTaggedRoll } from '../../core/rng.js';
+
+const GAME_KEY = 'instant_recall';
+
+/** Keys that belong to the shell (or to a focused button), never to the guard. */
+const CHROME_KEYS = Object.freeze(['Escape', 'Tab', 'Shift', 'Control', 'Alt', 'Meta',
+  'Enter', ' ', 'CapsLock', 'F5', 'F11', 'F12']);
+
+/** Diagnostics seams (the DV/DE precedent). The shell never reads these. */
+let liveClass = null;
+let lastReport = null;
+let lastSnapshot = null;
+
+/** Test seam: the scratch harness compresses the clock. Production = 1. */
+let timeScale = 1;
+export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
+export function getTimeScale() { return timeScale; }
+function scaled(ms) { return Math.max(0, Math.round(ms * timeScale)); }
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** Reduced motion from the shell's projection first, then the two probes. */
+function probeReduced(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof document !== 'undefined' && document.documentElement
+      && document.documentElement.classList
+      && document.documentElement.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+/**
+ * A key press that belongs to a form control is never an answer - with ONE
+ * documented exception. Daily Trigger's window-keydown guard also ignores
+ * BUTTON, because its letters would fight the shell's chrome. Ours cannot: the
+ * answer surface IS a row of buttons and the first one holds focus, so a
+ * blanket BUTTON ignore would eat every number key. The exception is therefore
+ * narrow and explicit - our OWN `g-ir-*` buttons are answerable, every other
+ * form target (including any button the shell or a deck owns) is not.
+ */
+function isFormTarget(target) {
+  try {
+    if (!target) return false;
+    const tag = String(target.tagName || '').toUpperCase();
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    if (target.isContentEditable) return true;
+    if (tag === 'BUTTON') return !isOurs(target);
+  } catch (e) { /* ignore */ }
+  return false;
+}
+/** Is this one of the class's own controls? */
+function isOurs(node) {
+  try { return String((node && node.className) || '').indexOf('g-ir-') >= 0; }
+  catch (e) { return false; }
+}
+
+function mmss(secLeft) {
+  const s = Math.max(0, secLeft | 0);
+  return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+}
+
+/** The four creative modules, loaded optionally. Never a hard import. */
+function loadDecks() {
+  return Promise.allSettled([
+    import('./style.js'),
+    import('./casino.js'),
+    import('./trickster.js'),
+    import('./pressure.js'),
+  ]).then((r) => ({
+    style: r[0].status === 'fulfilled' ? r[0].value : null,
+    casino: r[1].status === 'fulfilled' ? r[1].value : null,
+    trickster: r[2].status === 'fulfilled' ? r[2].value : null,
+    pressure: r[3].status === 'fulfilled' ? r[3].value : null,
+  }));
+}
+
+export default {
+  key: GAME_KEY,
+  family: 'recall',
+  /* MEATY (owner ruling). Not because 120s is long - it is not - but because
+   * the ten-game pool re-opened web CLAUDE.md trap 6: no-repeat-3 outranks the
+   * meaty preference, so TWO meaty classes left roughly a third of dealt nights
+   * with no meaty slot filled at all. A third meaty class closes the gap. The
+   * budget, the family and the flagship flag are unchanged - and this file's
+   * behaviour does not branch on `meaty` anywhere: it is a timetable fact, not
+   * a difficulty one. `games/registry.js` GAME_META must mirror it (the
+   * parachute is read for a suspended class too). */
+  meaty: true,
+  flagship: false,
+  timeBudgetSec: 120,
+  title: 'Instant Recall',
+
+  manifest: {
+    /* The emission channels ARE the game: every kind below writes a ledger
+     * entry a question can be asked about (or is the atmosphere those
+     * questions happen inside). flash_burst / gif_burst are declared ONLY as
+     * clickSafe decoration over the montage - fireSafe() welds that on. */
+    effectsConsumed: [
+      'sub_flash', 'bubble_field', 'wash', 'glitch_swap', 'row_drift',
+      'gif_rain', 'flash_burst', 'gif_burst', 'audio_trigger', 'ambient_field',
+      /* tier 4's dressing: the scanline/chroma degrade the dossier asks for. */
+      'crt',
+    ],
+    /* 24 loops + 12 stills for the montage wall; everything renders DOM-layer
+     * (img/video tiles, CSS-transform orbits, never canvas), so the provider
+     * may serve remote media here. */
+    assetNeeds: { loops: 24, targets: 0, stills: 12, canvasSafe: false },
+    boardSizes: null,
+    /* Answers are tap or the number keys 1-4 on a window keydown (the Daily
+     * Trigger pattern) - no verb slots, so nothing to declare or rebind. */
+    keybinds: null,
+    settings: [
+      {
+        key: 'ir_density', kind: 'enum', values: ['calm', 'standard', 'dense'], default: 'standard',
+        label_key: 'ir_density', hint_key: 'ir_density_hint',
+      },
+    ],
+    peek: false,
+  },
+
+  create(ctx) {
+    const t = (key, fallback) => {
+      const fb = fallback == null ? (IR_LEX[key] == null ? key : IR_LEX[key]) : fallback;
+      try { const v = ctx.lexicon(key, fb); return v == null ? fb : v; } catch (e) { return fb; }
+    };
+    const say = (m) => { try { ctx.log('[ir] ' + m); } catch (e) { /* noop */ } };
+
+    /* ---- lifecycle ------------------------------------------------------ */
+    let dead = false;
+    let paused = false;
+    let ended = false;
+    let reported = false;
+    let halted = true;                 // emissions closed until the vigil opens
+
+    /* ---- class state ---------------------------------------------------- */
+    let spec = null;
+    let seed = '';
+    let tier = 1;
+    let plan = null;
+    let reduced = false;
+    let retake = false;
+    let budgetMs = 120000;
+    let pool = null;
+    let montage = null;
+    let ledger = null;
+    let qroll = null;
+    let rewardLocal = null;
+
+    let casino = null;
+    let trickster = null;
+    let pressure = null;
+
+    /* ---- the vigil's own bookkeeping ------------------------------------ */
+    let elapsedMs = 0;
+    let clockId = 0;
+    let lastTick = 0;
+    let bellOn = false;
+    let stopIdx = 0;                   // the next stop to fire
+    let stopsResolved = 0;
+    let segStartMs = 0;                // when the current density segment opened
+    let easedNext = false;             // comeback hook: the last stop was missed
+    let band = 0;
+    let currentHeat = 0;
+    let layout = 'rows';
+    let bellArmed = -1;                // which stop has already had its warning
+    let stallMs = 0;
+    let lastStallFire = 0;
+
+    /* the live stop (null between stops) */
+    let live = null;
+
+    /* results (Law I: computed here, never by a deck) */
+    const results = { questions: [], stops: [] };
+    let streak = 0;
+    let bestRun = 0;
+    let plantExposures = 0;
+    let plantsResisted = 0;
+    let plantsFired = 0;
+    let correctedWeight = 0;
+    let correctionPending = 0;         // weight a fully-correct NEXT stop restores
+    let correctionUsed = false;
+    let voidedStops = 0;
+    let timeouts = 0;
+    let emissions = 0;
+    let jackpots = 0;
+
+    /* escape guard (a frozen quiz card is never a trap) */
+    let guardHits = 0;
+    let guardSince = 0;
+
+    /* ---- dom ------------------------------------------------------------ */
+    let stage = null; let backdrop = null; let hud = null; let montageEl = null;
+    let ledgerEl = null; let stopEl = null; let qEl = null; let optsEl = null;
+    let timerEl = null; let truthEl = null; let msgEl = null; let well = null;
+    let endEl = null; let howtoEl = null;
+    let clockChip = null; let stopsChip = null; let densityChip = null;
+    let optEls = [];
+
+    /* channel timers, by kind */
+    const channelTimers = new Map();
+    let driftOn = false;
+    let spiralOn = false;
+
+    /* ==================================================================== *
+     * TIMERS - every step goes through run(), so a suspend freezes the class
+     * mid-beat and a resume finishes it (the Deep End registry).
+     * ==================================================================== */
+    const timers = new Map();
+    let nextTimerId = 1;
+    const deferred = [];
+    function run(fn) {
+      if (dead) return;
+      if (paused) { deferred.push(fn); return; }
+      try { fn(); } catch (e) { say('step failed: ' + ((e && e.message) || e)); }
+    }
+    function after(ms, fn) {
+      const id = nextTimerId++;
+      const h = setTimeout(() => { timers.delete(id); run(fn); }, scaled(ms));
+      timers.set(id, { kind: 'after', h });
+      return id;
+    }
+    function every(ms, fn) {
+      const id = nextTimerId++;
+      const h = setInterval(() => {
+        if (dead || paused) return;
+        try { fn(); } catch (e) { say('tick failed: ' + ((e && e.message) || e)); }
+      }, Math.max(4, scaled(ms)));
+      timers.set(id, { kind: 'every', h });
+      return id;
+    }
+    function clearTimer(id) {
+      const rec = timers.get(id);
+      if (!rec) return;
+      if (rec.kind === 'after') clearTimeout(rec.h); else clearInterval(rec.h);
+      timers.delete(id);
+    }
+    function clearTimers() {
+      for (const id of Array.from(timers.keys())) clearTimer(id);
+      timers.clear();
+      deferred.length = 0;
+    }
+    /** The decks' registry: this class's own pause-aware timers. */
+    const deckTimers = { after, every, clear: clearTimer };
+
+    /* ==================================================================== *
+     * ENGINE - one wrapper, the input-trust law and the audio ceiling welded.
+     * ==================================================================== */
+    function fireSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'flash_burst' || kind === 'gif_burst') {
+        o.clickSafe = true;              // decoration only over the stream
+        o.clickable = false;
+        delete o.onPop;
+      }
+      if (kind === 'audio_trigger') {
+        const ceil = plan ? plan.audioCeil : 0.4;
+        o.level = Math.min(ceil, o.level == null ? 0.35 : o.level);
+      }
+      try { return ctx.engine.fire(kind, o) || null; }
+      catch (e) { say('fire(' + kind + ') failed'); return null; }
+    }
+    function sustainSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'bubble_field' || kind === 'gif_rain') {
+        o.clickSafe = true;
+        delete o.onPop;
+      }
+      try { return ctx.engine.sustain(kind, o) || null; } catch (e) { return null; }
+    }
+    function stopSafe(kind) { try { if (ctx.engine) ctx.engine.stop(kind); } catch (e) { /* noop */ } }
+    /** The engine, as a deck sees it: welded primitives plus a READ of the
+     *  clamped channel vector (a deck spends a channel, it never raises one).
+     *  `pitch` passes straight through to shell/audio.js. */
+    const deckEngine = {
+      fire: fireSafe,
+      sustain: sustainSafe,
+      stop: stopSafe,
+      ceremony: (kind, opts) => {
+        try { return (ctx.engine && ctx.engine.ceremony) ? ctx.engine.ceremony(kind, opts || {}) : null; }
+        catch (e) { return null; }
+      },
+      channels: () => {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** The player's own media, as a deck sees it: a LIVE reader, because the
+     *  pool lands async and a captured null stays null forever. */
+    const deckAssets = {
+      next(kind) {
+        try { return (pool && typeof pool.next === 'function') ? (pool.next(kind) || null) : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** bgIntensity 0 is the player's exit: read it LIVE, never a snapshot. */
+    function capsArmed() { return !(ctx.caps && Number(ctx.caps.bgIntensity) === 0); }
+    /** A cue through the engine, under the tier's audio ceiling, pitched by streak. */
+    function tick(name, level, extra) {
+      const semis = Math.min(PLAYTEST.PITCH_CAP, streak);
+      const o = Object.assign({ name, level, pitch: 1 + semis * PLAYTEST.PITCH_STEP }, extra || {});
+      return fireSafe('audio_trigger', o);
+    }
+
+    /** Every deck call: null-safe, try/catch'd, never able to break the class. */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); }
+      catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+
+    /* ==================================================================== *
+     * THE LEDGER - the ONE way an emission becomes truth.
+     * ==================================================================== */
+    function note(channel, payload, variant) {
+      if (!ledger) return null;
+      emissions += 1;
+      return ledger.append({ t: Math.round(elapsedMs), channel, payload: payload || {}, variant, mode: layout });
+    }
+
+    /* ==================================================================== *
+     * HEAT + DENSITY
+     * ==================================================================== */
+    function progress01() { return Math.max(0, Math.min(1, elapsedMs / Math.max(1, budgetMs))); }
+    function recomputeHeat() {
+      if (!plan) return;
+      const h = heatFor(plan, progress01() * 0.55 + band * 0.45, streak);
+      currentHeat = h;
+      try { if (ctx.engine) ctx.engine.setHeat(h); } catch (e) { /* engine is optional */ }
+      deck('casino', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+    }
+    /** THE DENSITY, PUBLISHED. `--ir-density` (0..1) rides the density chip AND
+     *  the stage, so a deck's meter can read it wherever it chooses to draw -
+     *  it is the same number the chip's percentage renders, so the meter and
+     *  the text can never disagree. Presentation only: the SCHEDULE is never
+     *  meter-derived (a meter that could be read as a countdown would hand the
+     *  player the one thing the vigil refuses to tell them). */
+    function paintDensity() {
+      const v = band.toFixed(3);
+      if (densityChip && densityChip.style) densityChip.style.setProperty('--ir-density', v);
+      if (stage && stage.style) stage.style.setProperty('--ir-density', v);
+    }
+    function recomputeBand() {
+      if (!plan) return;
+      const b = densityAt(plan, elapsedMs - segStartMs, stopsResolved, easedNext);
+      const changed = Math.abs(b - band) > 0.02;
+      band = b;
+      if (montage && changed) montage.setBand(band);
+      paintDensity();
+      if (densityChip) densityChip.textContent = Math.round(band * 100) + '%';
+      deck('pressure', 'setProgress', progress01());
+      if (changed && band >= plan.densityCeil * 0.96) deck('casino', 'densityPeak');
+    }
+
+    /* ==================================================================== *
+     * DOM (the contract's exact shape)
+     * ==================================================================== */
+    function setPhase(p) { if (stage) stage.setAttribute('data-phase', p); }
+    function msg(key, fallback) { if (msgEl) msgEl.textContent = t(key, fallback); }
+    function chipText(which) {
+      if (which === 'clock') return mmss(Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)));
+      if (which === 'stops') return stopsResolved + '/' + (plan ? plan.stopCount : 0);
+      return Math.round(band * 100) + '%';
+    }
+    function paintHud() {
+      if (clockChip) clockChip.textContent = chipText('clock');
+      if (stopsChip) stopsChip.textContent = chipText('stops');
+      if (densityChip) densityChip.textContent = chipText('density');
+      paintDensity();
+    }
+
+    function buildDom() {
+      const root = ctx.root;
+      root.textContent = '';
+      stage = el('div', 'g-ir-stage');
+      stage.setAttribute('data-phase', 'briefing');
+      stage.setAttribute('data-layout', 'rows');
+      stage.setAttribute('data-tier', String(tier));
+      if (reduced) stage.setAttribute('data-reduced', '1');
+
+      backdrop = el('div', 'g-ir-backdrop');
+      backdrop.setAttribute('aria-hidden', 'true');
+      if (backdrop.style) backdrop.style.setProperty('pointer-events', 'none');
+      stage.appendChild(backdrop);
+
+      hud = el('div', 'g-ir-hud');
+      clockChip = el('span', 'g-ir-chip g-ir-clock', mmss(budgetMs / 1000));
+      clockChip.setAttribute('aria-label', t('ir_chip_clock', IR_LEX.ir_chip_clock));
+      stopsChip = el('span', 'g-ir-chip g-ir-stops', '0/' + (plan ? plan.stopCount : 0));
+      stopsChip.setAttribute('aria-label', t('ir_chip_stops', IR_LEX.ir_chip_stops));
+      densityChip = el('span', 'g-ir-chip g-ir-density', '0%');
+      densityChip.setAttribute('aria-label', t('ir_chip_density', IR_LEX.ir_chip_density));
+      hud.appendChild(clockChip);
+      hud.appendChild(stopsChip);
+      hud.appendChild(densityChip);
+      stage.appendChild(hud);
+
+      montageEl = el('div', 'g-ir-montage');
+      montageEl.setAttribute('aria-hidden', 'true');
+      stage.appendChild(montageEl);
+
+      /* THE TRUTH TAIL. In the DOM (so a screenshot and the suite can read it),
+       * out of the accessibility tree, and never painted - inline, because this
+       * file injects no stylesheet and must never write a bare display rule. */
+      ledgerEl = el('div', 'g-ir-ledger');
+      hideTruthNode(ledgerEl);
+      stage.appendChild(ledgerEl);
+
+      stopEl = el('div', 'g-ir-stop');
+      stopEl.hidden = true;
+      qEl = el('div', 'g-ir-q', '');
+      optsEl = el('div', 'g-ir-opts');
+      timerEl = el('div', 'g-ir-timer');
+      timerEl.setAttribute('aria-hidden', 'true');
+      truthEl = el('div', 'g-ir-truth');
+      truthEl.hidden = true;
+      stopEl.appendChild(qEl);
+      stopEl.appendChild(optsEl);
+      stopEl.appendChild(timerEl);
+      stopEl.appendChild(truthEl);
+      stage.appendChild(stopEl);
+
+      msgEl = el('div', 'g-ir-msg', '');
+      stage.appendChild(msgEl);
+      well = el('div', 'g-ir-flashwell');
+      well.setAttribute('aria-hidden', 'true');
+      stage.appendChild(well);
+      endEl = el('div', 'g-ir-end');
+      endEl.hidden = true;
+      stage.appendChild(endEl);
+
+      root.appendChild(stage);
+    }
+
+    /* ==================================================================== *
+     * THE CLASS-RULES SHEET (Law IV: drawn, GO-only, once per tier)
+     * ==================================================================== */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    function rememberHowto() {
+      try {
+        const list = howtoSeenTiers();
+        if (list.indexOf(tier) < 0) {
+          list.push(tier);
+          if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+            ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+          }
+        }
+      } catch (e) { /* best effort - the sheet just shows again next time */ }
+    }
+    /**
+     * The sheet: three drawn panels and a GO button. Policy is the shell's
+     * "Skip class tutorials" contract - default shows every class; with the
+     * skip on, a class still explains itself ONCE per grade tier. Dismissal is
+     * the sheet's own button only.
+     */
+    function howto(onDone) {
+      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      howtoEl = el('div', 'g-ir-howto');
+      howtoEl.appendChild(el('h3', 'g-ir-howto-title', t('ir_howto_title', IR_LEX.ir_howto_title)));
+      const cards = [
+        ['stream', t('ir_howto_1', IR_LEX.ir_howto_1)],
+        ['freeze', t('ir_howto_2', IR_LEX.ir_howto_2)],
+        ['answer', t('ir_howto_3', IR_LEX.ir_howto_3)],
+      ];
+      const rowEl = el('div', 'g-ir-howto-row');
+      for (const [art, cap] of cards) {
+        const card = el('div', 'g-ir-howto-card');
+        const artEl = el('div', 'g-ir-howto-art');
+        artEl.setAttribute('data-art', art);
+        artEl.setAttribute('aria-hidden', 'true');
+        card.appendChild(artEl);
+        card.appendChild(el('p', 'g-ir-howto-cap', cap));
+        rowEl.appendChild(card);
+      }
+      howtoEl.appendChild(rowEl);
+      howtoEl.appendChild(el('p', 'g-ir-howto-note', tier === 1
+        ? t('ir_howto_bell', IR_LEX.ir_howto_bell)
+        : t('ir_howto_nobell', IR_LEX.ir_howto_nobell)));
+      const go = el('button', 'g-ir-go', t('ir_howto_go', IR_LEX.ir_howto_go));
+      go.setAttribute('type', 'button');
+      let done = false;
+      go.addEventListener('click', () => {
+        if (done || dead) return;
+        done = true;
+        rememberHowto();
+        hideHowto();
+        onDone();
+      });
+      howtoEl.appendChild(go);
+      stage.appendChild(howtoEl);
+      try { if (go.focus) go.focus(); } catch (e) { /* noop */ }
+    }
+    function hideHowto() {
+      if (!howtoEl) return;
+      try { howtoEl.remove(); } catch (e) { /* noop */ }
+      howtoEl = null;
+    }
+
+    /* ==================================================================== *
+     * THE STAGE - layouts, drift, the spiral
+     * ==================================================================== */
+    function applyLayout(kind) {
+      layout = String(kind || 'rows');
+      if (stage) stage.setAttribute('data-layout', layout);
+      if (montage) montage.setLayout(layout);
+      /* row_drift belongs to the rows layout and to nothing else. */
+      if (layout === 'rows') armDrift(); else stopDrift();
+      /* THE SPIRAL: swirl holds a spiral wash forever. Never stop('wash')
+       * mid-class (trap 33) - leaving swirl re-triggers it at a LOW alpha,
+       * which is the whisper-out step-down the engine understands. */
+      if (layout === 'swirl' && !reduced) {
+        const h = sustainSafe('wash', { variant: 'spiral', sustainForever: true, alpha: 0.34 });
+        if (h) { spiralOn = true; note('wash', { color: 'spiral' }, 'spiral'); }
+      } else if (spiralOn) {
+        sustainSafe('wash', { variant: 'spiral', alpha: 0.05, holdMs: 700 });
+        spiralOn = false;
+      }
+      note('layout', { layout }, layout);
+      deck('casino', 'layoutChange', layout);
+      deck('pressure', 'beat', 'layout');
+      return layout;
+    }
+    function armDrift() {
+      if (driftOn || reduced || !montage) return;
+      const rows = montage.rows();
+      if (!rows.length) return;
+      const h = sustainSafe('row_drift', {
+        targets: rows, axis: 'x', variant: 'slide', stagger: true,
+      });
+      if (h) { driftOn = true; note('row_drift', {}, 'slide'); }
+    }
+    function stopDrift() { if (driftOn) { stopSafe('row_drift'); driftOn = false; } }
+
+    /* ==================================================================== *
+     * THE EMISSION CHANNELS - the game itself.
+     * Each channel re-arms itself on its own heat-scaled cadence with the
+     * seeded jitter ring vigil.js dealt. A stop clears them; a resume re-arms.
+     * ==================================================================== */
+    function armChannel(ch, i) {
+      if (!plan || dead || ended) return;
+      const idx = (i | 0);
+      const ms = cadenceMs(ch.kind, band, ch.jitter[idx % ch.jitter.length]);
+      if (!Number.isFinite(ms)) return;
+      const id = after(ms, () => {
+        channelTimers.delete(ch.kind);
+        if (!halted) emit(ch, idx);
+        armChannel(ch, idx + 1);
+      });
+      channelTimers.set(ch.kind, id);
+    }
+    function armAllChannels() {
+      clearChannels();
+      if (!plan) return;
+      for (const ch of plan.channels) armChannel(ch, 0);
+      for (const ch of plan.dressing) armChannel(ch, 0);
+    }
+    function clearChannels() {
+      for (const id of channelTimers.values()) clearTimer(id);
+      channelTimers.clear();
+    }
+
+    /** ONE emission. Whatever the engine ACTUALLY returned is what the ledger
+     *  records - a refused or capped-to-zero primitive writes nothing at all,
+     *  which is exactly why a question can never desync from the show. */
+    function emit(ch, i) {
+      const variant = ch.variants[i % ch.variants.length];
+      const kind = ch.kind;
+      let r = null;
+      switch (kind) {
+        case 'sub_flash': {
+          const hasWords = wordPool().length > 0;
+          r = fireSafe('sub_flash', { variant, anchor: well, image: hasWords ? false : true });
+          if (r) note('sub_flash', r.text ? { word: String(r.text) } : { assetId: 'card' }, r.variant || variant);
+          break;
+        }
+        case 'bubble_field': {
+          r = sustainSafe('bubble_field', { variant, max: Math.round(6 + 10 * band) });
+          if (r) note('bubble_field', {}, variant);
+          break;
+        }
+        case 'glitch_swap': {
+          if (!montage) break;
+          const turned = montage.turn(Math.max(1, Math.round(1 + 3 * band)));
+          const faces = montage.facesOf(turned);
+          if (!faces.length) break;
+          /* trap 22: the content swap has ALREADY happened (montage.turn), so
+           * onSwap is the nicety it is meant to be and a suspend mid-transition
+           * cannot lose the turn. */
+          r = fireSafe('glitch_swap', { targets: faces, variant, seconds: 0.5, sfx: false, onSwap: () => {} });
+          if (r) note('glitch_swap', { assetId: 'tiles:' + faces.length }, r.variant || variant);
+          break;
+        }
+        case 'flash_burst': {
+          r = fireSafe('flash_burst', { variant, count: Math.max(1, Math.round(1 + 3 * band)) });
+          if (r) note('flash_burst', {}, r.variant || variant);
+          break;
+        }
+        case 'gif_burst': {
+          r = fireSafe('gif_burst', { variant, count: Math.max(1, Math.round(1 + 2 * band)) });
+          if (r) note('gif_burst', {}, r.variant || variant);
+          break;
+        }
+        case 'audio_trigger': {
+          r = tick(variant, 0.3 + 0.18 * band);
+          if (r) note('audio_trigger', { sting: variant }, variant);
+          break;
+        }
+        case 'wash': {
+          r = sustainSafe('wash', { variant, alpha: 0.10 + 0.22 * band, holdMs: 2200 });
+          if (r) note('wash', { color: variant }, variant);
+          break;
+        }
+        case 'gif_rain': {
+          r = sustainSafe('gif_rain', { variant, durationMs: 3200 });
+          if (r) note('gif_rain', {}, variant);
+          break;
+        }
+        case 'ambient_field': {
+          r = sustainSafe('ambient_field', { kind: variant, density: 0.25 + 0.5 * band });
+          if (r) note('ambient_field', {}, variant);
+          break;
+        }
+        case 'crt': {
+          r = sustainSafe('crt', { variant, level: 0.25 + 0.4 * band });
+          if (r) note('crt', {}, variant);
+          break;
+        }
+        default: break;
+      }
+      deck('pressure', 'beat', kind);
+      return r;
+    }
+
+    /** The day pool plus anything this vigil has already flashed. */
+    function wordPool() {
+      const out = [];
+      const seen = new Set();
+      try {
+        for (const w of (ctx.words || [])) {
+          const s = String(w || '').trim();
+          if (s && !seen.has(s)) { seen.add(s); out.push(s); }
+        }
+      } catch (e) { /* ignore */ }
+      return out;
+    }
+
+    /* ==================================================================== *
+     * THE STOP
+     * ==================================================================== */
+    function nextStop() { return plan && stopIdx < plan.stops.length ? plan.stops[stopIdx] : null; }
+
+    function warnStop(stop) {
+      if (bellArmed === stop.n) return;
+      bellArmed = stop.n;
+      msg('ir_stop_incoming', IR_LEX.ir_stop_incoming);
+      tick('sting', 0.34);
+    }
+
+    function beginStop() {
+      const stop = nextStop();
+      if (!stop || live) return;
+      stopIdx += 1;
+      halted = true;
+      clearChannels();
+      if (montage) montage.freeze(true);
+      setPhase('stop');
+      msg('ir_stop_now', IR_LEX.ir_stop_now);
+      guardHits = 0;
+      guardSince = elapsedMs;
+      stallMs = 0;
+      lastStallFire = 0;
+      live = {
+        stop,
+        qIdx: -1,
+        question: null,
+        windowLeft: 0,
+        elapsedInWindow: 0,
+        windowTimer: 0,
+        answeredWeight: 0,
+        correctCount: 0,
+        askedCount: 0,
+        voided: false,
+        plantEntry: null,
+        plantMatch: -1,
+        plantTimer: 0,
+      };
+      /* the casino's stop beat: `stopBeat` if the deck exports it, else the
+       * contract's `stop(n, announced)` shape. */
+      if (casino && typeof casino.stopBeat === 'function') deck('casino', 'stopBeat', stop.n, stop.announced);
+      else deck('casino', 'stop', stop.n, stop.announced);
+      deck('pressure', 'beat', 'stop');
+      deck('trickster', 'afterStop');
+      if (!stop.announced && tier === 2) {
+        /* SYNTHESIS #2: the taste of the twist is DEBRIEFED, once. */
+        after(1200, () => { if (live) msg('ir_nobell_debrief', IR_LEX.ir_nobell_debrief); });
+      }
+      after(240, () => { if (live) dealQuestion(0); });
+    }
+
+    /* ---- what the tail can be asked ------------------------------------ */
+    function availability() {
+      /* A PLANT IS NEVER A TRUTH. It fired, it is in the ledger, and the
+       * gotcha replay reads it - but it lives on its own `plant` channel and is
+       * filtered out of every truth read, so a false memory can never become
+       * the answer key to the question it was planted against. */
+      const words = ledger.recent((r) => r.channel !== 'plant' && r.payload && r.payload.word, 24);
+      const stings = ledger.recent((r) => r.channel === 'audio_trigger' && r.payload.sting, 12);
+      const effects = ledger.recent((r) => EFFECT_VOCAB.indexOf(r.channel) >= 0, 12);
+      const excl = PLAYTEST.DISTRACTOR_EXCLUDE;
+
+      const recentWords = new Set(words.slice(0, excl).map((r) => r.payload.word));
+      const wordDistractors = new Set();
+      for (const r of words) if (!recentWords.has(r.payload.word)) wordDistractors.add(r.payload.word);
+      for (const w of wordPool()) if (!recentWords.has(w)) wordDistractors.add(w);
+
+      const recentStings = new Set(stings.slice(0, excl).map((r) => r.payload.sting));
+      const stingDistractors = STINGS.filter((s) => !recentStings.has(s));
+
+      const recentFx = new Set(effects.slice(0, excl).map((r) => r.channel));
+      const fxDistractors = EFFECT_VOCAB.filter((k) => !recentFx.has(k));
+
+      return {
+        words: wordDistractors.size,
+        wordList: Array.from(wordDistractors),
+        hasWord: words.length >= 1,
+        hasTwoWords: words.length >= 2,
+        wordTail: words,
+        stings: stingDistractors.length,
+        stingList: stingDistractors,
+        stingTail: stings,
+        hasSting: stings.length >= 1,
+        audible: ctx.audioAudible !== false,
+        effects: fxDistractors.length,
+        fxList: fxDistractors,
+        fxTail: effects,
+        hasEffect: effects.length >= 1,
+        layouts: plan ? plan.layoutPool.length : 1,
+        hasLayout: true,
+      };
+    }
+
+    function pickN(list, n, tag) {
+      const src = list.slice();
+      const out = [];
+      while (out.length < n && src.length) {
+        const i = Math.floor(qroll(tag) * src.length);
+        out.push(src.splice(Math.min(src.length - 1, i), 1)[0]);
+      }
+      return out;
+    }
+    function shuffleSeeded(list, tag) {
+      const a = list.slice();
+      for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.min(i, Math.floor(qroll(tag) * (i + 1)));
+        const tmp = a[i]; a[i] = a[j]; a[j] = tmp;
+      }
+      return a;
+    }
+
+    /**
+     * Instantiate a question from the LEDGER TAIL. The truth is read here and
+     * nowhere else; distractors are drawn from the day's pool / the class's own
+     * vocabulary and NEVER from the last-N tail entries, so "the last one" is
+     * always unambiguous.
+     */
+    function buildQuestion(template, avail) {
+      const mk = (textKey, fb, opts, trueValue, meta) => {
+        const shuffled = shuffleSeeded(opts, 'shuffle');
+        const trueIndex = shuffled.findIndex((o) => o.value === trueValue);
+        return {
+          template,
+          text: t(textKey, fb),
+          options: shuffled,
+          trueIndex,
+          meta: meta || {},
+        };
+      };
+      if (template === 'LAST_WORD') {
+        const truth = avail.wordTail[0].payload.word;
+        const ds = pickN(avail.wordList, 3, 'word');
+        if (ds.length < 3) return null;
+        const opts = [{ value: truth, label: truth }].concat(ds.map((w) => ({ value: w, label: w })));
+        return mk('ir_q_last_word', IR_LEX.ir_q_last_word, opts, truth, { kind: 'word' });
+      }
+      if (template === 'LAST_TWO') {
+        const a = avail.wordTail[1].payload.word;
+        const b = avail.wordTail[0].payload.word;
+        const arrow = ' → ';
+        const truth = a + '|' + b;
+        const opts = [
+          { value: truth, label: a + arrow + b },
+          { value: b + '|' + a, label: b + arrow + a },
+        ];
+        const outs = pickN(avail.wordList, 4, 'two');
+        for (let i = 0; i + 1 < outs.length && opts.length < 4; i += 2) {
+          const v = outs[i] + '|' + outs[i + 1];
+          if (opts.some((o) => o.value === v)) continue;
+          opts.push({ value: v, label: outs[i] + arrow + outs[i + 1] });
+        }
+        while (opts.length < 4 && outs.length) {
+          const v = outs[0] + '|' + a;
+          if (opts.some((o) => o.value === v)) break;
+          opts.push({ value: v, label: outs[0] + arrow + a });
+        }
+        if (opts.length < 4) return null;
+        return mk('ir_q_last_two', IR_LEX.ir_q_last_two, opts, truth, { kind: 'pair' });
+      }
+      if (template === 'LAST_EFFECT') {
+        const truth = avail.fxTail[0].channel;
+        const ds = pickN(avail.fxList.filter((k) => k !== truth), 3, 'fx');
+        if (ds.length < 3) return null;
+        const label = (k) => t('ir_fx_' + k, IR_LEX['ir_fx_' + k] || k);
+        const opts = [{ value: truth, label: label(truth) }].concat(ds.map((k) => ({ value: k, label: label(k) })));
+        return mk('ir_q_last_effect', IR_LEX.ir_q_last_effect, opts, truth, { kind: 'effect' });
+      }
+      if (template === 'LAST_STING') {
+        const truth = avail.stingTail[0].payload.sting;
+        const ds = pickN(avail.stingList.filter((s) => s !== truth), 3, 'sting');
+        if (ds.length < 3) return null;
+        const label = (s) => t('ir_sting_' + s, IR_LEX['ir_sting_' + s] || s);
+        const opts = [{ value: truth, label: label(truth), sting: truth }]
+          .concat(ds.map((s) => ({ value: s, label: label(s), sting: s })));
+        return mk('ir_q_last_sting', IR_LEX.ir_q_last_sting, opts, truth, { kind: 'sting' });
+      }
+      if (template === 'MODE') {
+        const lastLayout = ledger.lastOf('layout');
+        const truth = lastLayout ? lastLayout.payload.layout : layout;
+        const label = (k) => t('ir_layout_' + k, IR_LEX['ir_layout_' + k] || k);
+        /* Exactly three stage layouts exist, so MODE is an mc3: a fourth option
+         * would have to be a layout that does not exist, which a player could
+         * eliminate by construction. Every other template is mc4. */
+        const opts = plan.layoutPool.map((k) => ({ value: k, label: label(k) }));
+        if (opts.length < 3) return null;
+        return mk('ir_q_mode', IR_LEX.ir_q_mode, opts, truth, { kind: 'layout' });
+      }
+      return null;
+    }
+
+    function dealQuestion(qi) {
+      if (!live || dead || ended) return;
+      const stop = live.stop;
+      if (qi >= stop.questions.length) { resolveStop(); return; }
+      live.qIdx = qi;
+      const dealtQ = stop.questions[qi];
+      const avail = availability();
+      const template = resolveTemplate(dealtQ.template, avail, tier);
+      const question = template ? buildQuestion(template, avail) : null;
+      if (!question || question.trueIndex < 0) {
+        /* The tail can answer nothing: a question is NEVER invented. The stop
+         * simply resumes, uncounted - it cannot cost a grade it never asked. */
+        say('stop ' + stop.n + ' q' + qi + ': the tail could answer nothing - skipped');
+        after(400, () => { if (live) dealQuestion(qi + 1); });
+        return;
+      }
+      question.dealtTemplate = dealtQ.template;
+      /* The weight rides the template that was actually ASKED, not the one that
+       * was dealt: a MODE question that fell back to LAST_WORD is a full-weight
+       * trigger question, and a fallback INTO MODE (impossible today, but the
+       * walk allows it at tier 4) is down-weighted like any other MODE. */
+      question.weight = (6000 / stop.windowMs) * (question.template === 'MODE' ? PLAYTEST.MODE_WEIGHT : 1);
+      question.windowMs = stop.windowMs;
+      live.question = question;
+      live.askedCount += 1;
+      renderQuestion(question);
+      startWindow(question);
+      if (qi === 0) armPlant(stop, question);
+    }
+
+    function renderQuestion(question) {
+      stopEl.hidden = false;
+      truthEl.hidden = true;
+      truthEl.textContent = '';
+      qEl.textContent = question.text;
+      optsEl.textContent = '';
+      optEls = [];
+      question.options.forEach((opt, i) => {
+        const b = el('button', 'g-ir-opt');
+        b.setAttribute('type', 'button');
+        b.setAttribute('data-i', String(i));
+        const num = el('span', 'g-ir-opt-n', String(i + 1));
+        num.setAttribute('aria-hidden', 'true');
+        b.appendChild(num);
+        b.appendChild(el('span', 'g-ir-opt-t', opt.label));
+        if (opt.sting && ctx.audioAudible !== false) {
+          const hear = el('button', 'g-ir-hear', t('ir_hear', IR_LEX.ir_hear));
+          hear.setAttribute('type', 'button');
+          hear.setAttribute('data-sting', opt.sting);
+          /* Law II: this is a real button that auditions and NEVER selects. */
+          hear.addEventListener('click', (e) => {
+            try { if (e && e.stopPropagation) e.stopPropagation(); } catch (err) { /* noop */ }
+            try { if (e && e.preventDefault) e.preventDefault(); } catch (err) { /* noop */ }
+            fireSafe('audio_trigger', { name: opt.sting, level: 0.42 });
+          });
+          b.appendChild(hear);
+        }
+        b.addEventListener('click', () => answer(i, 'tap'));
+        optsEl.appendChild(b);
+        optEls.push(b);
+      });
+      msg(question.options.length >= 4 ? 'ir_answer_hint' : 'ir_answer_hint3',
+        question.options.length >= 4 ? IR_LEX.ir_answer_hint : IR_LEX.ir_answer_hint3);
+      try { if (optEls[0] && optEls[0].focus) optEls[0].focus(); } catch (e) { /* noop */ }
+    }
+
+    /** The REAL window. It counts accumulated, pause-aware ticks - never wall
+     *  clock - so a suspend mid-question freezes it honestly. The trickster's
+     *  crooked ring may lie on the FACE; this is the truth underneath. */
+    function startWindow(question) {
+      live.windowLeft = question.windowMs;
+      live.elapsedInWindow = 0;
+      if (timerEl) {
+        timerEl.style.setProperty('--ir-win', question.windowMs + 'ms');
+        timerEl.style.setProperty('--ir-left', '1');
+        timerEl.textContent = Math.ceil(question.windowMs / 1000) + '';
+      }
+      const step = 100;
+      live.windowTimer = every(step, () => {
+        if (!live || !live.question) return;
+        live.elapsedInWindow += step;
+        live.windowLeft = Math.max(0, question.windowMs - live.elapsedInWindow);
+        if (timerEl) {
+          timerEl.style.setProperty('--ir-left', (live.windowLeft / question.windowMs).toFixed(3));
+          timerEl.textContent = Math.ceil(live.windowLeft / 1000) + '';
+        }
+        if (live.windowLeft <= 0) commit(-1, 'timeout');
+      });
+    }
+    function stopWindow() {
+      if (live && live.windowTimer) { clearTimer(live.windowTimer); live.windowTimer = 0; }
+    }
+
+    /* ---- the decoy plant (tier 3+, SetPiece-gated) ---------------------- */
+    /**
+     * The freeze is the one moment the player relaxes their vigilance - which
+     * is exactly when a false memory lands hardest. The plant fires a REAL
+     * emission over the dimmed freeze, deliberately matching a WRONG option.
+     *
+     * It is written to the ledger under its own `plant` channel, never under
+     * `sub_flash` / `audio_trigger`: the ledger stays honest about what
+     * happened (Law I) while the plant can never become the truth of a later
+     * question. If the question has no option a plant could match (an effect or
+     * a layout question), the plant is not armed at all - a plant that matches
+     * nothing is noise, and noise is not a decoy, so it is never scored.
+     */
+    function armPlant(stop, question) {
+      if (!stop.plant || reduced || !capsArmed()) return;
+      const wrong = [];
+      question.options.forEach((o, i) => { if (i !== question.trueIndex) wrong.push({ o, i }); });
+      const kind = question.meta.kind;
+      const usable = wrong.filter(({ o }) => (
+        stop.plant.channel === 'audio_trigger' ? !!o.sting : (kind === 'word' || kind === 'pair')
+      ));
+      if (!usable.length) return;
+      const pick = usable[Math.floor(qroll('plant') * usable.length)];
+      live.plantTimer = after(stop.plant.atMs, () => {
+        if (!live || !live.question || dead || ended) return;
+        live.plantTimer = 0;
+        let r = null;
+        let payload = null;
+        if (stop.plant.channel === 'audio_trigger') {
+          r = fireSafe('audio_trigger', { name: pick.o.sting, level: 0.4 });
+          payload = { sting: pick.o.sting, plant: true, matched: pick.i };
+        } else {
+          const word = String(pick.o.value).split('|')[0];
+          r = fireSafe('sub_flash', { text: word, image: false, variant: 'centre', anchor: stopEl });
+          payload = { word, plant: true, matched: pick.i };
+        }
+        if (!r) return;                      // the caps refused it: no exposure
+        plantsFired += 1;
+        plantExposures += 1;
+        live.plantMatch = pick.i;
+        live.plantEntry = note('plant', payload, stop.plant.channel);
+      });
+    }
+
+    /* ---- answering ------------------------------------------------------ */
+    function answer(i, how) {
+      if (!live || !live.question) return;
+      const n = Number(i);
+      if (!Number.isFinite(n) || n < 0 || n >= live.question.options.length) return;
+      commit(n, how || 'tap');
+    }
+
+    function commit(index, how) {
+      if (!live || !live.question) return;
+      stopWindow();
+      if (live.plantTimer) { clearTimer(live.plantTimer); live.plantTimer = 0; }
+      const q = live.question;
+      const timedOut = index < 0 && how === 'timeout';
+      const voided = how === 'void';
+      const correct = !timedOut && !voided && index === q.trueIndex;
+      const latencyMs = Math.max(0, live.elapsedInWindow || 0);
+      const decoyHit = live.plantMatch >= 0 && index === live.plantMatch;
+
+      if (live.plantMatch >= 0) { if (!decoyHit) plantsResisted += 1; }
+      if (timedOut) timeouts += 1;
+
+      results.questions.push({
+        stop: live.stop.n,
+        template: q.template,
+        dealt: q.dealtTemplate,
+        correct,
+        timedOut,
+        voided,
+        decoyHit,
+        latencyMs,
+        windowMs: q.windowMs,
+        weight: q.weight,
+      });
+      if (correct) live.correctCount += 1;
+      if (voided) live.voided = true;
+
+      /* the option buttons stop being buttons the moment one is committed */
+      for (const b of optEls) { try { b.disabled = true; } catch (e) { /* noop */ } }
+      optEls.forEach((b, k) => {
+        try {
+          if (k === q.trueIndex) b.classList.add('is-true');
+          else if (k === index) b.classList.add('is-wrong');
+        } catch (e) { /* noop */ }
+      });
+
+      deck('casino', 'answer', { correct, latencyMs, streak });
+      deck('trickster', 'afterAnswer');
+      deck('pressure', 'beat', correct ? 'hit' : 'miss');
+      if (live.plantMatch >= 0 && !decoyHit) deck('casino', 'plantResisted');
+
+      renderVerdict(q, index, { correct, timedOut, voided, decoyHit });
+
+      const hold = reduced ? PLAYTEST.VERDICT_MS_REDUCED : PLAYTEST.VERDICT_MS;
+      live.plantMatch = -1;
+      live.question = null;
+      after(hold, () => {
+        if (!live || dead || ended) return;
+        dealQuestion(live.qIdx + 1);
+      });
+    }
+
+    /* ---- the truth replay ----------------------------------------------- */
+    /**
+     * Every answer resolves against the ledger, and the reveal PROVES it: the
+     * last few entries are pinned on a ribbon with the answer's own moment
+     * marked. Default posture is the dossier's `on-miss` - a miss gets the full
+     * ribbon, a hit gets the short confirmation - because the rewind is a
+     * learning aid on a miss and a pacing drag when it is always shown.
+     */
+    function renderVerdict(q, index, how) {
+      const tone = how.correct ? 'good' : 'bad';
+      const label = how.timedOut ? t('ir_timeout', IR_LEX.ir_timeout)
+        : how.voided ? t('ir_voided', IR_LEX.ir_voided)
+          : how.correct ? t('ir_correct', IR_LEX.ir_correct) : t('ir_wrong', IR_LEX.ir_wrong);
+      try { ctx.ceremonies.stamp({ text: label, tone, target: stopEl }); } catch (e) { /* noop */ }
+      tick(how.correct ? 'stamp' : 'stamp_bad', 0.4);
+
+      truthEl.textContent = '';
+      truthEl.hidden = false;
+      const ribbon = el('div', 'g-ir-ribbon');
+      ribbon.setAttribute('aria-hidden', 'true');
+      const tail = ledger.tail(7);
+      const pin = answerMoment(q, tail);
+      for (const rec of tail) {
+        const bead = el('span', 'g-ir-bead');
+        bead.setAttribute('data-ch', rec.channel);
+        const p = rec.payload || {};
+        bead.textContent = p.word != null ? p.word
+          : p.sting != null ? t('ir_sting_' + p.sting, IR_LEX['ir_sting_' + p.sting] || p.sting)
+            : p.layout != null ? t('ir_layout_' + p.layout, IR_LEX['ir_layout_' + p.layout] || p.layout)
+              : t('ir_fx_' + rec.channel, IR_LEX['ir_fx_' + rec.channel] || rec.channel);
+        if (p.plant) bead.classList.add('is-plant');
+        if (rec === pin) bead.classList.add('is-pin');
+        ribbon.appendChild(bead);
+      }
+      truthEl.appendChild(ribbon);
+
+      let line = t('ir_truth', IR_LEX.ir_truth);
+      if (how.decoyHit) line = t('ir_gotcha', IR_LEX.ir_gotcha);
+      else if (!how.correct && !how.timedOut && !how.voided && isNearMiss(q, index)) line = t('ir_near', IR_LEX.ir_near);
+      else if (how.voided) line = t('ir_voided', IR_LEX.ir_voided);
+      truthEl.appendChild(el('p', 'g-ir-truth-line', line));
+      if (msgEl) msgEl.textContent = line;
+    }
+    /** The ledger entry the question was actually about. */
+    function answerMoment(q, tail) {
+      const kind = q.meta.kind;
+      for (let i = tail.length - 1; i >= 0; i--) {
+        const r = tail[i];
+        if (r.payload && r.payload.plant) continue;
+        if (kind === 'word' || kind === 'pair') { if (r.payload && r.payload.word) return r; }
+        else if (kind === 'sting') { if (r.channel === 'audio_trigger') return r; }
+        else if (kind === 'layout') { if (r.channel === 'layout') return r; }
+        else if (EFFECT_VOCAB.indexOf(r.channel) >= 0) return r;
+      }
+      return null;
+    }
+    /** The classic recency error: the chosen word DID flash - just earlier. */
+    function isNearMiss(q, index) {
+      if (index < 0 || !q.options[index]) return false;
+      const kind = q.meta.kind;
+      if (kind !== 'word' && kind !== 'pair') return false;
+      const word = String(q.options[index].value).split('|')[0];
+      return !!ledger.lastOf((r) => r.payload && r.payload.word === word && !r.payload.plant);
+    }
+
+    /* ---- resolving a stop ----------------------------------------------- */
+    function resolveStop() {
+      if (!live) return;
+      const stop = live.stop;
+      const asked = live.askedCount;
+      const fullyCorrect = asked > 0 && live.correctCount === asked && !live.voided;
+      /* A stop whose tail could answer NOTHING asked nothing, so it scores
+       * nothing - in either direction. It is not a miss, it is not a streak
+       * link, and it never reaches the rubric: a class cannot be marked down
+       * for a question it never asked (the may-be-empty word contract). */
+      if (asked > 0) results.stops.push({ n: stop.n, fullyCorrect, voided: live.voided, asked });
+      else say('stop ' + stop.n + ' asked nothing - uncounted');
+      if (live.voided) voidedStops += 1;
+
+      /* THE COMEBACK HOOK. One blown stop is recoverable: the missed stop's
+       * weight is restored if the very NEXT stop is fully correct. Once per
+       * class - it can never launder an S, because the S gate reads the stops
+       * themselves and a corrected stop was still not fully correct. */
+      if (correctionPending > 0) {
+        if (fullyCorrect) {
+          correctedWeight += correctionPending;
+          msg('ir_corrected', IR_LEX.ir_corrected);
+        }
+        correctionPending = 0;
+      } else if (!fullyCorrect && !correctionUsed && asked > 0) {
+        correctionUsed = true;
+        let lost = 0;
+        for (const r of results.questions) if (r.stop === stop.n && !r.correct && !r.voided) lost += r.weight;
+        correctionPending = lost;
+      }
+
+      if (asked > 0) {
+        if (fullyCorrect) {
+          streak += 1;
+          bestRun = Math.max(bestRun, streak);
+          rewardBeat();
+        } else {
+          streak = 0;
+        }
+      }
+      deck('pressure', 'setStreak', streak);
+      try { ctx.ceremonies.streakMeter({ filled: Math.min(10, streak), gold: streak >= 3, target: hud }); }
+      catch (e) { /* noop */ }
+
+      easedNext = asked > 0 && !fullyCorrect;
+      stopsResolved += 1;
+      live = null;
+      stopEl.hidden = true;
+      truthEl.hidden = true;
+      optEls = [];
+
+      if (stopsResolved >= plan.stopCount || stopIdx >= plan.stops.length) {
+        after(reduced ? 400 : 900, () => finish(false));
+        return;
+      }
+      resumeVigil();
+    }
+
+    function resumeVigil() {
+      if (dead || ended) return;
+      const nextLayout = plan.layouts[Math.min(plan.layouts.length - 1, stopsResolved)];
+      segStartMs = elapsedMs;
+      if (montage) montage.freeze(false);
+      applyLayout(nextLayout.kind);
+      recomputeBand();
+      recomputeHeat();
+      setPhase('vigil');
+      msg('ir_resume', IR_LEX.ir_resume);
+      /* THE RUN ADVERTISES ITSELF. At a 2-stop streak the resumed stream takes
+       * a golden grain, so the whole montage wears the run (dossier: combo
+       * feedback). It is a declared kind and it writes to the ledger like any
+       * other emission - a question may name it. */
+      if (streak >= 2) {
+        const g = sustainSafe('ambient_field', { kind: 'goldleaf', density: 0.3 + 0.3 * band });
+        if (g) note('ambient_field', {}, 'goldleaf');
+      }
+      halted = false;
+      armAllChannels();
+    }
+
+    /* ---- variable ratio (the shared canon, with a local fallback) -------- */
+    function rewardBeat() {
+      let outcome = null;
+      try {
+        if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') outcome = ctx.engine.rewardRoll({}) || null;
+      } catch (e) { outcome = null; }
+      if (!outcome && rewardLocal) outcome = rewardLocal();
+      if (!outcome) return;
+      if (outcome.jackpot) {
+        jackpots += 1;
+        try { ctx.ceremonies.reward('jackpot', { target: stage, text: t('ir_jackpot', IR_LEX.ir_jackpot) }); }
+        catch (e) { /* noop */ }
+        /* "Photographic Memory": the vigil's OWN media rains back down. */
+        const got = deckAssets.next('loop');
+        fireSafe('gif_burst', { count: 4, variant: 'scatter', url: got ? got.url : undefined });
+        tick('jackpot', 0.5);
+      } else if (outcome.fire) {
+        tick('streak', 0.42);
+      }
+    }
+
+    /* ==================================================================== *
+     * THE ESCAPE GUARD - the freeze never traps.
+     * Six impatient interactions inside five seconds while a card is up void
+     * the stop: it scores as a miss for that question, the vigil resumes at
+     * once, and the class is never failed by it (friction, never lockout).
+     * ==================================================================== */
+    function guardPoke() {
+      if (!live || !live.question) return;
+      if (elapsedMs - guardSince > PLAYTEST.ESCAPE_MS) { guardHits = 0; guardSince = elapsedMs; }
+      guardHits += 1;
+      if (guardHits >= PLAYTEST.ESCAPE_TAPS) {
+        guardHits = 0;
+        say('escape guard: stop ' + live.stop.n + ' voided');
+        commit(-1, 'void');
+      }
+    }
+
+    /* ==================================================================== *
+     * INPUT - tap, or the number keys, on a window keydown (Daily Trigger).
+     * ==================================================================== */
+    function onKeyDown(e) {
+      if (dead || ended || paused) return;
+      if (!e || e.ctrlKey || e.altKey || e.metaKey) return;
+      if (isFormTarget(e.target)) return;
+      const k = String(e.key || '');
+      if (!live || !live.question) return;
+      /* the exits and the chrome keys are never impatience */
+      if (CHROME_KEYS.indexOf(k) >= 0) return;
+      if (/^[1-9]$/.test(k)) {
+        const i = Number(k) - 1;
+        if (i < live.question.options.length) {
+          try { if (e.preventDefault) e.preventDefault(); } catch (err) { /* noop */ }
+          answer(i, 'key');
+          return;
+        }
+      }
+      /* anything else, while a card is up, is impatience */
+      guardPoke();
+    }
+    function onStagePointer() { guardPoke(); }
+    function bindInput() {
+      try { if (typeof window !== 'undefined') window.addEventListener('keydown', onKeyDown); }
+      catch (e) { say('keydown bind failed: ' + ((e && e.message) || e)); }
+      try { if (stopEl) stopEl.addEventListener('pointerdown', onStagePointer); } catch (e) { /* noop */ }
+    }
+    function unbindInput() {
+      try { if (typeof window !== 'undefined') window.removeEventListener('keydown', onKeyDown); }
+      catch (e) { /* noop */ }
+      try { if (stopEl) stopEl.removeEventListener('pointerdown', onStagePointer); } catch (e) { /* noop */ }
+    }
+
+    /* ==================================================================== *
+     * THE CLOCK
+     * ==================================================================== */
+    function startClock() {
+      lastTick = Date.now();
+      clockId = every(PLAYTEST.CLOCK_TICK_MS, () => {
+        if (ended) return;
+        const now = Date.now();
+        const dt = now - lastTick;
+        lastTick = now;
+        /* THE CLASS CLOCK KEEPS RUNNING THROUGH A FREEZE. The montage stops;
+         * the budget does not. That is what makes the final-stop guarantee a
+         * guarantee rather than a hope. */
+        elapsedMs += dt / Math.max(0.0001, timeScale);
+        paintHud();
+        if (!live) {
+          recomputeBand();
+          recomputeHeat();
+          stallMs += PLAYTEST.CLOCK_TICK_MS;
+          if (stallMs - lastStallFire >= PLAYTEST.STALL_TICK_MS) {
+            lastStallFire = stallMs;
+            deck('trickster', 'stalled', stallMs);
+          }
+        }
+        const left = Math.max(0, (budgetMs - elapsedMs) / 1000);
+        if (!bellOn && left <= PLAYTEST.BELL_WARN_SEC) {
+          bellOn = true;
+          deck('casino', 'bell', true);
+          if (!live) msg('ir_bell_warn', IR_LEX.ir_bell_warn);
+        }
+        const stop = nextStop();
+        if (stop && !live) {
+          if (stop.announced && elapsedMs >= stop.atMs - PLAYTEST.BELL_LEAD_MS) warnStop(stop);
+          if (elapsedMs >= stop.atMs) { run(beginStop); return; }
+        }
+        /* The budget can only run out with no stop pending when the schedule
+         * was degenerate (a harness budget shorter than one window). The class
+         * still ends warm rather than hanging. */
+        if (elapsedMs >= budgetMs && !live && stopIdx >= plan.stops.length) { run(() => finish(true)); }
+      });
+    }
+    function stopClock() { if (clockId) { clearTimer(clockId); clockId = 0; } }
+
+    /* ==================================================================== *
+     * THE END
+     * ==================================================================== */
+    function stopAmbience() {
+      stopDrift();
+      for (const k of ['bubble_field', 'gif_rain', 'ambient_field', 'crt']) stopSafe(k);
+      /* trap 33: a held spiral is stepped DOWN, never stopped, so a ceremony's
+       * forced garnish can never take the wheel with it. */
+      if (spiralOn) { sustainSafe('wash', { variant: 'spiral', alpha: 0.04, holdMs: 500 }); spiralOn = false; }
+    }
+
+    function finish(viaBell) {
+      if (ended) return;
+      ended = true;
+      halted = true;
+      stopClock();
+      clearChannels();
+      stopWindow();
+      stopAmbience();
+      if (montage) { montage.stopGovernor(); montage.freeze(true); }
+      deck('trickster', 'stop');
+      deck('casino', 'dimOut');
+      deck('casino', 'stop');
+      deck('pressure', 'stop');
+      paintHud();                       // truth on every chip, whatever the trickster left
+      stopEl.hidden = true;
+      setPhase('ended');
+
+      const plantsEnabled = !reduced && tier >= 3 && plan.plantCount > 0;
+      const graded = compositeFor({
+        gradeTier: tier,
+        questions: results.questions,
+        stops: results.stops,
+        plantExposures,
+        plantsResisted,
+        plantsEnabled,
+        correctedWeight,
+        bestRun,
+      });
+      const gates = hardGates(results.stops);
+      const cleanStops = results.stops.filter((s) => s.fullyCorrect).length;
+      const fx = flavorXp(plantsResisted, cleanStops);
+
+      try {
+        const prior = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        ctx.store.mergeGameMeta(GAME_KEY, {
+          vigils: Math.max(0, Number(prior.vigils) || 0) + 1,
+          bestRun: Math.max(Math.max(0, Number(prior.bestRun) || 0), bestRun),
+          plantsTaken: Math.max(0, Number(prior.plantsTaken) || 0) + (plantExposures - plantsResisted),
+          lastSeed: seed,
+          lastPlayedAt: Date.now(),
+        });
+      } catch (e) { say('meta write failed (class unaffected): ' + ((e && e.message) || e)); }
+
+      renderEnd(graded);
+
+      const report = { metrics: { composite: graded.composite }, hardGates: gates, flavorXp: fx };
+      lastReport = Object.assign({}, report, {
+        inputs: {
+          tier, seed, retake, reduced, viaBell: !!viaBell,
+          stops: results.stops.slice(), questions: results.questions.slice(),
+          plantExposures, plantsResisted, plantsFired, plantsEnabled,
+          correctedWeight, bestRun, timeouts, voidedStops, emissions, jackpots,
+          terms: graded.terms, capped: graded.capped, elapsedMs,
+        },
+      });
+      try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
+      say('vigil over: ' + cleanStops + '/' + results.stops.length + ' clean stops, '
+        + results.questions.filter((q) => q.correct).length + '/' + results.questions.length + ' correct, '
+        + timeouts + ' blanked, plants ' + plantsResisted + '/' + plantExposures
+        + ' -> composite ' + graded.composite.toFixed(3) + (graded.capped ? ' (timeout cap)' : ''));
+
+      after(reduced ? PLAYTEST.END_HOLD_MS_REDUCED : PLAYTEST.END_HOLD_MS, () => {
+        if (reported) return;
+        reported = true;
+        try { ctx.endClass(report); } catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
+      });
+    }
+
+    function renderEnd(graded) {
+      if (!endEl) return;
+      endEl.textContent = '';
+      endEl.hidden = false;
+      endEl.appendChild(el('h3', 'g-ir-end-title', t('ir_end_title', IR_LEX.ir_end_title)));
+      const row = (k, v, cls) => {
+        const r = el('div', 'g-ir-end-row' + (cls ? ' ' + cls : ''));
+        r.appendChild(el('span', 'g-ir-end-k', k));
+        r.appendChild(el('span', 'g-ir-end-v', v));
+        endEl.appendChild(r);
+        return r;
+      };
+      const clean = results.stops.filter((s) => s.fullyCorrect).length;
+      row(t('ir_end_stops', IR_LEX.ir_end_stops), clean + ' / ' + results.stops.length);
+      row(t('ir_end_accuracy', IR_LEX.ir_end_accuracy), Math.round(graded.terms.accuracy * 100) + '%');
+      const answered = results.questions.filter((q) => !q.timedOut && !q.voided);
+      const meanMs = answered.length
+        ? Math.round(answered.reduce((n, q) => n + q.latencyMs, 0) / answered.length) : 0;
+      row(t('ir_end_latency', IR_LEX.ir_end_latency), meanMs ? (meanMs / 1000).toFixed(1) + 's' : t('ir_end_none', IR_LEX.ir_end_none));
+      row(t('ir_end_streak', IR_LEX.ir_end_streak), String(bestRun));
+      if (plantExposures > 0) row(t('ir_end_plants', IR_LEX.ir_end_plants), plantsResisted + ' / ' + plantExposures, 'g-ir-end-plants');
+      if (timeouts > 0) row(t('ir_end_timeouts', IR_LEX.ir_end_timeouts), String(timeouts), 'g-ir-end-blank');
+      endEl.appendChild(el('p', 'g-ir-end-line', t('ir_end_line', IR_LEX.ir_end_line)));
+    }
+
+    /* ---- assets (never block a draw) ------------------------------------ */
+    function claimAssets() {
+      Promise.resolve()
+        .then(() => ctx.assets.claim({ loops: 24, targets: 0, stills: 12, canvasSafe: false }))
+        .then((p) => {
+          if (dead || !p || typeof p.next !== 'function') return;
+          pool = p;
+          run(() => { if (montage) { montage.dress(pool); montage.setBand(band); } });
+        })
+        .catch((e) => say('asset claim failed - the stream runs on the placeholder floor: ' + ((e && e.message) || e)));
+    }
+
+    /* ---- the decks ------------------------------------------------------ */
+    function buildDecks(mods) {
+      if (dead) return;
+      const capsOk = capsArmed();
+      try {
+        if (mods.style && typeof mods.style.injectInstantRecallStyle === 'function') {
+          mods.style.injectInstantRecallStyle();
+        }
+      } catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
+      try {
+        if (mods.casino && typeof mods.casino.createIrCasino === 'function') {
+          casino = mods.casino.createIrCasino({
+            seed, tier, stage, montage: montageEl, hud, backdrop, stopEl,
+            timers: deckTimers, reduced, capsOk, t, engine: deckEngine, log: say,
+          }) || null;
+        }
+      } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+      try {
+        if (mods.trickster && typeof mods.trickster.createIrTrickster === 'function') {
+          trickster = mods.trickster.createIrTrickster({
+            seed, tier, stopEl, timers: deckTimers, reduced, capsOk,
+            isHalted: () => dead || paused || ended,
+            t,
+            stats: () => ({
+              stops: stopsResolved, total: plan ? plan.stopCount : 0, streak,
+              band, secLeft: Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)),
+              frozen: !!live, layout,
+            }),
+            chipEl: (which) => (which === 'clock' ? clockChip : which === 'stops' ? stopsChip
+              : which === 'timer' ? timerEl : densityChip),
+            chipText,
+            /* THE OPTION LABELS are the trickster's Unreliable Label surface -
+             * it may wear another option's text and must snap back to truth
+             * before the window's last 40%. The VALUES never move (Law I/II):
+             * these accessors read and repaint TEXT only. */
+            optEls: () => optEls.slice(),
+            optText: (i) => {
+              const q = live && live.question;
+              return q && q.options[i] ? q.options[i].label : '';
+            },
+            windowLeft: () => (live ? live.windowLeft : 0),
+            announce: (text, ms) => {
+              if (!msgEl || !text) return;
+              msgEl.textContent = String(text);
+              const mine = msgEl.textContent;
+              deckTimers.after(Math.max(400, Number(ms) || 1600), () => {
+                if (msgEl && msgEl.textContent === mine) msgEl.textContent = '';
+              });
+            },
+            log: say,
+          }) || null;
+        }
+      } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+      try {
+        if (mods.pressure && typeof mods.pressure.createIrPressure === 'function') {
+          pressure = mods.pressure.createIrPressure({
+            seed, gradeTier: tier, reduced,
+            motionLevel: (ctx.motion && Number.isFinite(ctx.motion.motionLevel)) ? ctx.motion.motionLevel : 2,
+            stage, montage: montageEl, hud,
+            chrome: [hud, clockChip, stopsChip, densityChip, msgEl].filter(Boolean),
+            engine: deckEngine, assets: deckAssets, timers: deckTimers,
+            capsOk: capsArmed, log: say,
+          }) || null;
+        }
+      } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+
+      if (!ended && !dead) {
+        deck('casino', 'start');
+        deck('pressure', 'start');
+        deck('trickster', 'start');
+        deck('casino', 'layoutChange', layout);
+        recomputeHeat();
+      }
+    }
+
+    /* ==================================================================== *
+     * THE MODULE INSTANCE
+     * ==================================================================== */
+    const instance = {
+      start(classSpec) {
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
+        tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
+        seed = String(spec.seed == null ? GAME_KEY : spec.seed);
+        retake = !!spec.retake;
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
+        reduced = probeReduced(ctx);
+        const densityValue = ctx.settings ? ctx.settings.ir_density : 'standard';
+
+        plan = buildVigil({
+          seed, gradeTier: tier, timeBudgetSec: budgetMs / 1000,
+          density: densityValue, reduced,
+        });
+        const broken = assertPlan(plan);
+        if (broken.length) say('PLAN INVARIANT BROKEN: ' + broken.join('; '));
+
+        qroll = makeTaggedRoll(seed + '|ir-quiz');
+        rewardLocal = (() => {
+          const roll = makeTaggedRoll(seed + '|ir-vr');
+          return () => {
+            const chance = Math.min(1, 0.30 + 0.30 * currentHeat + Math.min(3, streak) * 0.04);
+            const r = roll('fire');
+            const fire = r < chance;
+            return { fire, jackpot: fire && roll('jack') >= 0.85, nearMiss: !fire && r < chance + 0.08 };
+          };
+        })();
+
+        buildDom();
+        ledger = createLedger({ node: ledgerEl });
+
+        montage = createMontage({
+          mount: montageEl,
+          seed, tier, reduced,
+          coarse: !!(ctx.platform && ctx.platform.isTouch),
+          lite: !!(ctx.motion && Number(ctx.motion.motionLevel) <= 1),
+          density: densityMultFor(densityValue),
+          log: say,
+        });
+        applyLayout(plan.layouts[0].kind);
+        band = plan.densityFloor;
+        montage.setBand(band);
+        paintHud();
+
+        bindInput();
+        claimAssets();
+        loadDecks().then((mods) => run(() => buildDecks(mods)))
+          .catch((e) => say('decks unavailable (class runs plain): ' + ((e && e.message) || e)));
+
+        msg(tier === 1 ? 'ir_brief_bell' : 'ir_brief',
+          tier === 1 ? IR_LEX.ir_brief_bell : IR_LEX.ir_brief);
+
+        /* the class-rules sheet first, then the vigil opens */
+        howto(() => {
+          if (dead || ended) return;
+          setPhase('vigil');
+          msg('ir_vigil_hint', IR_LEX.ir_vigil_hint);
+          segStartMs = 0;
+          elapsedMs = 0;
+          halted = false;
+          armAllChannels();
+          startClock();
+          montage.startGovernor();
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
+            if (msgEl && !live) msgEl.textContent = '';
+          });
+        });
+
+        liveClass = instance;
+        lastReport = null;
+        lastSnapshot = null;
+        say('tier ' + tier + ', ' + plan.stopCount + ' stops (' + plan.stops.map((s) => Math.round(s.atMs / 1000) + 's'
+          + (s.announced ? '' : '!')).join(' ') + '), ' + plan.windowMs + 'ms windows, '
+          + plan.qPerStop + ' q/stop, density ' + densityValue + ' ceiling ' + plan.densityCeil.toFixed(2)
+          + ', plants ' + plan.plantCount + (reduced ? ', reduced' : '') + (retake ? ', RETAKE' : ''));
+      },
+
+      pause() {
+        if (paused) return;
+        paused = true;
+        deck('pressure', 'pause');
+        if (stage) stage.classList.add('suspended');
+      },
+
+      resume() {
+        if (!paused) return;
+        paused = false;
+        if (stage) stage.classList.remove('suspended');
+        deck('pressure', 'resume');
+        lastTick = Date.now();
+        const q = deferred.splice(0);
+        for (const fn of q) run(fn);
+      },
+
+      /** The shell owns the overlay and the engine's suspend; we just freeze. */
+      suspend(on) { if (on) instance.pause(); else instance.resume(); },
+
+      destroy() {
+        dead = true;
+        stopClock();
+        clearChannels();
+        clearTimers();
+        stopAmbience();
+        unbindInput();
+        hideHowto();
+        try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
+        trickster = null;
+        try { if (casino) casino.destroy(); } catch (e) { /* noop */ }
+        casino = null;
+        try { if (pressure) pressure.destroy(); } catch (e) { /* noop */ }
+        pressure = null;
+        try { if (montage) montage.destroy(); } catch (e) { /* noop */ }
+        montage = null;
+        if (pool && typeof pool.release === 'function') { try { pool.release(); } catch (e) { /* noop */ } }
+        pool = null;
+        live = null;
+        optEls = [];
+        try { ctx.root.textContent = ''; } catch (e) { /* noop */ }
+        if (liveClass === instance) liveClass = null;
+      },
+
+      /* -------- test / diagnostics seams (never read by the shell) -------- */
+      /** Answer as the player would. */
+      answer(i) { return answer(i, 'tap'); },
+      /** Drive the class clock forward without a wall clock (the harness). */
+      advance(ms) {
+        elapsedMs += Math.max(0, Number(ms) || 0);
+        paintHud();
+        if (!live) { recomputeBand(); recomputeHeat(); }
+        const stop = nextStop();
+        if (stop && !live && elapsedMs >= stop.atMs) beginStop();
+      },
+      /** Emit one channel as the schedule would (the harness fills the tail). */
+      emitKind(kind, i) {
+        const ch = (plan.channels.concat(plan.dressing)).find((c) => c.kind === kind);
+        return ch ? emit(ch, i || 0) : null;
+      },
+      ledger() { return ledger; },
+      plan() { return plan; },
+      montage() { return montage; },
+      liveQuestion() { return live ? live.question : null; },
+      chipText(which) { return chipText(which); },
+      forceEnd() { finish(false); },
+
+      snapshot() {
+        return {
+          tier, seed, retake, reduced, budgetMs, elapsedMs,
+          phase: stage ? stage.getAttribute('data-phase') : null,
+          layout, band, heat: currentHeat, halted, paused, ended, reported, dead,
+          stopIdx, stopsResolved, streak, bestRun, easedNext,
+          plan: plan ? {
+            stopCount: plan.stopCount, windowMs: plan.windowMs, qPerStop: plan.qPerStop,
+            stops: plan.stops.map((s) => ({ n: s.n, atMs: s.atMs, announced: s.announced, plant: !!s.plant })),
+            layouts: plan.layouts.map((l) => l.kind),
+            densityCeil: plan.densityCeil, densityFloor: plan.densityFloor,
+            channels: plan.channels.map((c) => c.kind), dressing: plan.dressing.map((c) => c.kind),
+            plantCount: plan.plantCount,
+          } : null,
+          ledger: ledger ? ledger.all() : [],
+          emissions,
+          questions: results.questions.slice(),
+          stops: results.stops.slice(),
+          plantExposures, plantsResisted, plantsFired, timeouts, voidedStops,
+          correctedWeight, correctionPending, jackpots,
+          live: live ? {
+            stop: live.stop.n, qIdx: live.qIdx, asked: live.askedCount,
+            correct: live.correctCount, windowLeft: live.windowLeft,
+            template: live.question ? live.question.template : null,
+            trueIndex: live.question ? live.question.trueIndex : -1,
+            options: live.question ? live.question.options.map((o) => o.label) : [],
+            plantMatch: live.plantMatch,
+          } : null,
+          montage: montage ? montage.diagnostics() : null,
+          casino: casino && typeof casino.diagnostics === 'function' ? (() => { try { return casino.diagnostics(); } catch (e) { return null; } })() : null,
+          trickster: trickster && typeof trickster.diagnostics === 'function' ? (() => { try { return trickster.diagnostics(); } catch (e) { return null; } })() : null,
+          pressure: pressure && typeof pressure.diagnostics === 'function' ? (() => { try { return pressure.diagnostics(); } catch (e) { return null; } })() : null,
+          stage, montageEl, ledgerEl, stopEl, qEl, optsEl, timerEl, msgEl, endEl, hud,
+          clockChip, stopsChip, densityChip, optEls: optEls.slice(),
+        };
+      },
+    };
+    return instance;
+  },
+
+  /** The live class's state, or null. Never read by the shell. */
+  diagnostics() { return liveClass ? liveClass.snapshot() : null; },
+  get lastReport() { return lastReport; },
+  get lastSnapshot() { return lastSnapshot; },
+  setTimeScale,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/lex.js
@@ -1,0 +1,109 @@
+/* ============================================================================
+ * games/instant-recall/lex.js - every `ir_` lexicon row INSTANT RECALL renders,
+ * with its neutral English fallback. Exported as DATA (the Impulse Control /
+ * Deep End precedent, `IC_LEX` / `DE_LEX`) so the host's `NeutralLexicon` can
+ * be mirrored key-for-key: copy the values, never re-word them.
+ *
+ * RULES (web CLAUDE.md trap 26 + the build contract): a value longer than 96
+ * characters can never be mod-skinned (`MergeModTable` drops it), so every row
+ * here is <= 96; a row is rendered ONLY through ctx.lexicon(key, fallback)
+ * (Law VII - accents come from the lexicon, never AI). The DECKS (casino /
+ * trickster / pressure) may `t()` the same keys; they never mint their own.
+ *
+ * The question TEXT is a lexicon row; the ANSWER text is data (a word from the
+ * day pool, an effect name, a sting name, a layout name) - the effect / sting /
+ * layout NAMES are rows too, because they are the only words the option chrome
+ * ever shows and a mod must be able to re-voice the whole quiz card.
+ * ==========================================================================*/
+
+export const IR_LEX = Object.freeze({
+  /* ---- setting row (manifest.settings) -------------------------------- */
+  ir_density: 'Montage density',
+  ir_density_hint: 'How thick the stream gets between stops. Calm eases the ceiling, dense rides it.',
+
+  /* ---- HUD chips (aria labels; the chip TEXT is live data) ------------- */
+  ir_chip_clock: 'Time left',
+  ir_chip_stops: 'Stops',
+  ir_chip_density: 'Density',
+
+  /* ---- the class-rules sheet (Law IV: drawn, GO-only dismissal) -------- */
+  ir_howto_title: 'The vigil',
+  ir_howto_1: 'A montage plays. Triggers fire over it.',
+  ir_howto_2: 'Without warning, everything freezes.',
+  ir_howto_3: 'Answer what just happened.',
+  ir_howto_bell: 'A bell warns you first. For now.',
+  ir_howto_nobell: 'No bell. It just stops.',
+  ir_howto_go: 'GO',
+
+  /* ---- the vigil ------------------------------------------------------- */
+  ir_brief: 'Watch. It stops without warning and asks what you just saw.',
+  ir_brief_bell: 'Watch. A bell warns you before every stop.',
+  ir_vigil_hint: 'Eyes up. Nothing to click until it freezes.',
+  ir_stop_incoming: 'Stop incoming.',
+  ir_stop_now: 'FREEZE.',
+  ir_answer_hint: 'Tap an answer, or press 1-4.',
+  ir_answer_hint3: 'Tap an answer, or press 1-3.',
+  ir_resume: 'Resume. Denser now.',
+  ir_bell_warn: 'Last stretch.',
+  ir_nobell_debrief: 'That one had no bell. From Year 3, none of them do.',
+
+  /* ---- question templates --------------------------------------------- */
+  ir_q_last_word: 'What was the last word to flash?',
+  ir_q_last_effect: 'What was the last effect?',
+  ir_q_last_sting: 'Which sting just played?',
+  ir_q_last_two: 'The last two words, in order?',
+  ir_q_mode: 'Which layout were you watching?',
+  ir_hear: 'Hear it',
+
+  /* ---- effect names (the LAST_EFFECT options) -------------------------- */
+  ir_fx_bubble_field: 'Bubbles',
+  ir_fx_wash: 'Wash',
+  ir_fx_glitch_swap: 'Glitch',
+  ir_fx_gif_rain: 'Rain',
+  ir_fx_flash_burst: 'Flash',
+  ir_fx_gif_burst: 'Burst',
+  ir_fx_ambient_field: 'Grain',
+  ir_fx_crt: 'Scanlines',
+  ir_fx_row_drift: 'Drift',
+
+  /* ---- sting names (the LAST_STING options) ---------------------------- */
+  ir_sting_blip: 'Tick',
+  ir_sting_sting: 'Chime',
+  ir_sting_pop: 'Pop',
+  ir_sting_bump: 'Thud',
+  ir_sting_glitch: 'Static',
+
+  /* ---- stage layouts (the MODE options) -------------------------------- */
+  ir_layout_rows: 'Rows',
+  ir_layout_mosaic: 'Mosaic',
+  ir_layout_swirl: 'Swirl',
+
+  /* ---- verdicts + the truth replay ------------------------------------- */
+  ir_correct: 'VERIFIED',
+  ir_wrong: 'MISSED',
+  /* the decks t() these three: the casino's near-miss staging, its
+   * plant-resisted light, and the top rung of the jackpot ladder. */
+  ir_almost: 'ALMOST',
+  ir_resisted: 'RESISTED',
+  ir_royal: 'ROYAL',
+  ir_timeout: 'BLANKED',
+  ir_truth: 'It really did.',
+  ir_near: 'So close. That one flashed, but earlier.',
+  ir_jackpot: 'Photographic Memory',
+  ir_gotcha: 'That one flashed while the screen was FROZEN.',
+  ir_voided: 'Stop voided. The vigil goes on.',
+  ir_corrected: 'Corrected memory.',
+
+  /* ---- end card -------------------------------------------------------- */
+  ir_end_title: 'Vigil over',
+  ir_end_stops: 'Stops answered',
+  ir_end_accuracy: 'Accuracy',
+  ir_end_latency: 'Average answer',
+  ir_end_streak: 'Best run',
+  ir_end_plants: 'Baits dodged',
+  ir_end_timeouts: 'Blanked',
+  ir_end_none: 'None',
+  ir_end_line: 'The stream never stopped. Only you did.',
+});
+
+export default IR_LEX;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/montage.js
@@ -1,0 +1,865 @@
+/* ============================================================================
+ * games/instant-recall/montage.js - THE STREAM, and THE TRUTH TAIL.
+ *
+ * Two things live here, and they are deliberately in the same file because one
+ * is only honest if the other is:
+ *
+ *   THE MONTAGE   a DOM-only wall of pool media on three rotating stage
+ *                 layouts (rows / mosaic / swirl), built on the LIVE WINDOW
+ *                 discipline Lost & Found paid for in blood.
+ *   THE LEDGER    the append-only truth tail every stop's question reads. Only
+ *                 the emitter (index.js) appends, and it appends what the
+ *                 ENGINE ACTUALLY RETURNED - never what it asked for. The
+ *                 montage's own seat maintenance (the governor, the density
+ *                 band, a layout rebuild) NEVER writes a ledger entry, which is
+ *                 why shedding a gif seat under a frame lock can never change
+ *                 the answer to a question.
+ *
+ * ---------------------------------------------------------------------------
+ * THE LIVE WINDOW (the pattern is L&F's; games never import each other, so the
+ * physics are restated here and the numbers are re-tuned for this stage).
+ *
+ * Chromium keeps ONE decoder and ONE animation clock per image RESOURCE. So the
+ * expensive unit is a DISTINCT ANIMATED URL, not a tile: N distinct animated
+ * urls = N main-thread gif decodes per frame. Two tiles on the SAME url cost
+ * one decoder - and cannot be desynchronised, because there is one clock.
+ *
+ * Therefore: at most `liveCap` distinct animated urls are on the wall at once,
+ * drawn NO-REPEAT so nothing is ever in lockstep; every other seat wears a
+ * STILL (or parks, for free, on a url the wall already animates); <video> is
+ * budgeted a second time in ELEMENTS, because 2+ playing videos lock the whole
+ * page to 30Hz; the media element is RECYCLED on a repaint (src swap) rather
+ * than re-minted, because minting a media player is an IPC round trip; and a
+ * frame GOVERNOR watches the achieved rAF cadence and sheds live seats (video
+ * first, then gifs) when the page sits at half-rate.
+ *
+ * The governor uses Math.random ON PURPOSE: a frame-timing-driven choice can
+ * never be deterministic, so it must not consume the class's seeded stream
+ * (Law V). It only ever changes what a SLEEPER seat is showing.
+ *
+ * ---------------------------------------------------------------------------
+ * NO WRAP CLONES. L&F's rows are toroidal marquees and every tile exists 2-3
+ * times over; ours are engine `row_drift` targets with a bounded sway, so a
+ * tile is exactly one element. That makes `maxReps` 1 and the element ceilings
+ * collapse onto the url ceilings - strictly cheaper than the board that taught
+ * us the lesson.
+ *
+ * ENGINE TARGETING NOTE: `glitch_swap` writes its own filter/animation onto its
+ * targets, and style.js owns `.g-ir-tile`'s transform (the swirl orbit is a
+ * transform). So the engine is ALWAYS handed the inner `.g-ir-face`, never the
+ * tile - the same rule The Deep End keeps for its tile faces.
+ * ==========================================================================*/
+
+import { makeTaggedRoll } from '../../core/rng.js';
+
+export const MONTAGE = Object.freeze({
+  /** Tile count by tier, before the density multiplier. The tile COUNT is a
+   *  tuned dial; the tile SIZE breathes with the window (style.js). */
+  TILES: Object.freeze({ 1: 18, 2: 26, 3: 34, 4: 44 }),
+  TILES_COARSE: Object.freeze({ 1: 12, 2: 16, 3: 22, 4: 28 }),
+  TILES_MIN: 8,
+  TILES_MAX: 56,
+
+  /** Ceiling on DISTINCT animated urls on the wall at once. THE dial. */
+  LIVE_LOOP_CAP: 20,
+  LIVE_LOOP_CAP_LITE: 10,
+  /** Gifs ignore prefers-reduced-motion, so the only honest answer is none. */
+  LIVE_LOOP_CAP_REDUCED: 0,
+  LIVE_LOOP_SHARE: 0.55,
+  LIVE_LOOP_MIN: 6,
+  LIVE_ELEMENT_CEIL: 44,
+  LIVE_DRAW_TRIES: 4,
+
+  /** <video>: 2+ playing lock the page to 30Hz. Gifs carry this wall. */
+  VIDEO_TILE_CAP: 4,
+  VIDEO_TILE_CAP_LITE: 2,
+  VIDEO_ELEMENT_CEIL: 24,
+
+  /** A turn burst applies at most this many tiles per tick; the rest follow on
+   *  frame-spaced ticks (one synchronous batch is half a frame budget). */
+  SWAP_APPLY_CHUNK: 3,
+
+  /** Progressive dressing: the decoders start in a queue, not a stampede, and
+   *  every animated tile starts its clock on its own tick. */
+  DRESS_WINDOW_MS: 1500,
+  DRESS_JITTER_MS: 800,
+
+  /** Rows layout. */
+  ROWS_MIN: 3,
+  ROWS_MAX: 7,
+  /** Mosaic layout: columns solved from the tile count. */
+  MOSAIC_COLS_MIN: 4,
+  MOSAIC_COLS_MAX: 9,
+  /** Swirl layout: how many turns of the spiral the tiles are spread over. */
+  SWIRL_TURNS: 2.4,
+  SWIRL_RAD_MIN: 0.16,
+  SWIRL_RAD_MAX: 0.92,
+
+  /** THE FRAME GOVERNOR. */
+  GOVERNOR: true,
+  GOV_LOCK_X: 1.6,
+  GOV_BAD_MS: 2200,
+  GOV_SETTLE_MS: 1600,
+  GOV_SHED_VIDEO_MIN_GIFS: 4,
+  GOV_VIDEO_FLOOR: 0,
+  GOV_GIF_SHED_STEP: 2,
+  GOV_GIF_FLOOR: 6,
+  GOV_GROW_MS: 9000,
+  GOV_SAMPLES: 48,
+
+  /** The truth tail: entries kept in memory, and nodes kept in the DOM. */
+  LEDGER_CAP: 128,
+  LEDGER_NODES: 24,
+});
+
+/* ----------------------------------------------------------------------------
+ * MEDIA
+ * -------------------------------------------------------------------------- */
+const VIDEO_EXT_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+const GIF_RE = /\.gif(\?|#|$)/i;
+
+export function isVideoUrl(url) { return VIDEO_EXT_RE.test(String(url || '')); }
+export function isGifUrl(url) { return GIF_RE.test(String(url || '')); }
+/** Does this url cost a decoder and an animation clock? THE budget question. */
+export function isAnimatedUrl(url) { return isVideoUrl(url) || isGifUrl(url); }
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls && n) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+
+/** Build the media element for a url. Never throws; broken media self-removes. */
+export function mediaElFor(url) {
+  if (!url) return null;
+  if (isVideoUrl(url)) {
+    const v = el('video', 'g-ir-media');
+    if (!v) return null;
+    v.muted = true; v.loop = true; v.autoplay = true; v.playsInline = true;
+    try {
+      v.setAttribute('muted', '');
+      v.setAttribute('loop', '');
+      v.setAttribute('playsinline', '');
+      v.setAttribute('preload', 'metadata');
+      v.setAttribute('disablepictureinpicture', '');
+    } catch (e) { /* DOM double */ }
+    try { v.disableRemotePlayback = true; } catch (e) { /* not everywhere */ }
+    if (typeof v.addEventListener === 'function') {
+      v.addEventListener('error', () => {
+        try { v.removeAttribute('src'); if (v.load) v.load(); } catch (e) { /* ignore */ }
+        try { if (v.parentNode) v.remove(); } catch (e) { /* ignore */ }
+      });
+    }
+    v.src = url;
+    if (typeof v.play === 'function') {
+      try { const p = v.play(); if (p && p.catch) p.catch(() => {}); } catch (e) { /* autoplay policy */ }
+    }
+    return v;
+  }
+  const img = el('img', 'g-ir-media');
+  if (!img) return null;
+  img.alt = '';
+  try {
+    img.setAttribute('draggable', 'false');
+    img.setAttribute('decoding', 'async');
+  } catch (e) { /* DOM double */ }
+  if (typeof img.addEventListener === 'function') {
+    img.addEventListener('error', () => { try { if (img.parentNode) img.remove(); } catch (e) { /* ignore */ } });
+  }
+  img.src = url;
+  return img;
+}
+
+/** Paint a url into a face, RECYCLING the existing element when the kind
+ *  matches (a re-mint per repaint is an allocation storm for <img> and a whole
+ *  media-player teardown for <video>). */
+export function paintFace(face, url) {
+  if (!face || !face.appendChild) return null;
+  const kids = face.children || [];
+  const existing = kids.length ? kids[0] : null;
+  if (existing && existing._irUrl === url) return existing;
+  if (!url) {
+    if (existing) { try { existing.remove(); } catch (e) { /* ignore */ } }
+    return null;
+  }
+  if (existing) {
+    const wantVid = isVideoUrl(url);
+    const isVid = String(existing.tagName || '').toUpperCase() === 'VIDEO';
+    if (wantVid === isVid) {
+      existing._irUrl = url;
+      try {
+        existing.src = url;
+        if (isVid) {
+          if (existing.load) existing.load();
+          if (existing.play) { const p = existing.play(); if (p && p.catch) p.catch(() => {}); }
+        }
+        return existing;
+      } catch (e) { /* fall through to replace */ }
+    }
+    try { existing.remove(); } catch (e) { /* ignore */ }
+  }
+  const media = mediaElFor(url);
+  if (media) { media._irUrl = url; face.appendChild(media); }
+  return media;
+}
+
+/* ============================================================================
+ * THE LEDGER - the append-only truth tail.
+ *
+ * Entry shape (the dossier's): { t, channel, payload, variant, mode, seq }
+ *   t        ms since the vigil opened (the class clock, not wall time)
+ *   channel  'sub_flash' | 'audio_trigger' | 'bubble_field' | 'wash' | ...
+ *            plus the pseudo-channel 'layout' (a stage change is a real event
+ *            and MODE questions read it), which is NOT in EFFECT_VOCAB and so
+ *            can never be a LAST_EFFECT answer.
+ *   payload  { word } | { sting } | { color } | { assetId } | { layout }
+ *   variant  the engine variant that actually rendered
+ *   mode     the stage layout at the moment of emission
+ *
+ * The `.g-ir-ledger` node is aria-hidden and visually hidden with INLINE styles
+ * (this file injects no CSS and must never write a bare `display:` rule).
+ * ==========================================================================*/
+export function createLedger(o = {}) {
+  const node = o.node || null;
+  const cap = Math.max(8, Number(o.cap) || MONTAGE.LEDGER_CAP);
+  const nodeCap = Math.max(1, Number(o.nodeCap) || MONTAGE.LEDGER_NODES);
+  const rows = [];
+  let seq = 0;
+
+  function render(entry) {
+    if (!node || !node.appendChild) return;
+    const line = el('span', 'g-ir-led');
+    if (!line) return;
+    const p = entry.payload || {};
+    const what = p.word != null ? p.word
+      : p.sting != null ? p.sting
+        : p.layout != null ? p.layout
+          : p.color != null ? p.color
+            : p.assetId != null ? p.assetId : '';
+    line.textContent = entry.t + ' ' + entry.channel + (what ? ' ' + what : '');
+    try { line.setAttribute('data-ch', entry.channel); } catch (e) { /* DOM double */ }
+    node.appendChild(line);
+    /* re-read `children` every pass: it is a LIVE collection, and a snapshot
+     * that never shrinks is an infinite loop wearing a trim's clothes. */
+    for (let guard = 0; guard < 64; guard++) {
+      const kids = node.children || [];
+      if (kids.length <= nodeCap) break;
+      const first = kids[0];
+      if (!first || !first.remove) break;
+      try { first.remove(); } catch (e) { break; }
+    }
+  }
+
+  const api = {
+    /** THE only way in. Returns the frozen entry (or null if it was refused). */
+    append(entry) {
+      if (!entry || !entry.channel) return null;
+      const rec = Object.freeze({
+        seq: seq++,
+        t: Math.max(0, Math.round(Number(entry.t) || 0)),
+        channel: String(entry.channel),
+        payload: Object.freeze(Object.assign({}, entry.payload || {})),
+        variant: entry.variant == null ? '' : String(entry.variant),
+        mode: entry.mode == null ? '' : String(entry.mode),
+      });
+      rows.push(rec);
+      while (rows.length > cap) rows.shift();
+      render(rec);
+      return rec;
+    },
+    /** The last N entries, oldest first. */
+    tail(n) {
+      const k = Math.max(0, Math.round(Number(n) || 0));
+      return k ? rows.slice(Math.max(0, rows.length - k)) : rows.slice();
+    },
+    /** The most recent entry matching a channel name or a predicate. */
+    lastOf(match) {
+      const test = typeof match === 'function' ? match : (r) => r.channel === match;
+      for (let i = rows.length - 1; i >= 0; i--) if (test(rows[i])) return rows[i];
+      return null;
+    },
+    /** The most recent entries matching, newest first, up to `n`. */
+    recent(match, n) {
+      const test = typeof match === 'function' ? match : (r) => r.channel === match;
+      const out = [];
+      const k = Math.max(1, Math.round(Number(n) || 1));
+      for (let i = rows.length - 1; i >= 0 && out.length < k; i--) if (test(rows[i])) out.push(rows[i]);
+      return out;
+    },
+    all() { return rows.slice(); },
+    get size() { return rows.length; },
+    clear() {
+      rows.length = 0;
+      if (node) { try { node.textContent = ''; } catch (e) { /* ignore */ } }
+    },
+  };
+  return api;
+}
+
+/** Visually hide a node without a stylesheet and without the toggle attribute
+ *  the shell owns: inline, screen-reader-hidden, never painted, never hit. */
+export function hideTruthNode(node) {
+  if (!node || !node.style) return node;
+  const s = node.style;
+  try {
+    s.setProperty('position', 'absolute');
+    s.setProperty('width', '1px');
+    s.setProperty('height', '1px');
+    s.setProperty('overflow', 'hidden');
+    s.setProperty('clip-path', 'inset(50%)');
+    s.setProperty('white-space', 'nowrap');
+    s.setProperty('opacity', '0');
+    s.setProperty('pointer-events', 'none');
+  } catch (e) { /* DOM double */ }
+  try { node.setAttribute('aria-hidden', 'true'); } catch (e) { /* DOM double */ }
+  return node;
+}
+
+/* ============================================================================
+ * THE MONTAGE
+ * ==========================================================================*/
+
+/**
+ * @param {Object} o
+ *   mount     the `.g-ir-montage` element
+ *   seed      the class seed (tile signatures + the seeded draw order)
+ *   tier      1..4
+ *   reduced   reduced motion (no live loops, no swirl)
+ *   coarse    coarse pointer (fewer, bigger tiles)
+ *   lite      low-power / motionLevel <= 1 (tighter budgets)
+ *   density   the density MULTIPLIER from `ir_density` (scales the tile count)
+ *   log       ctx.log
+ */
+export function createMontage(o = {}) {
+  const mount = o.mount || null;
+  const seed = String(o.seed == null ? 'instant_recall' : o.seed);
+  const tier = Math.max(1, Math.min(4, Math.round(Number(o.tier) || 1)));
+  const reduced = !!o.reduced;
+  const coarse = !!o.coarse;
+  const lite = !!o.lite;
+  const say = typeof o.log === 'function' ? o.log : () => {};
+  const roll = makeTaggedRoll(seed + '|ir-montage');
+
+  const densityMult = Number.isFinite(o.density) ? o.density : 1;
+  const baseCount = (coarse ? MONTAGE.TILES_COARSE : MONTAGE.TILES)[tier];
+  const count = Math.max(MONTAGE.TILES_MIN,
+    Math.min(MONTAGE.TILES_MAX, Math.round(baseCount * densityMult)));
+
+  /** Budgets - solved once, from the dealt tile count. */
+  const liveCap = reduced ? MONTAGE.LIVE_LOOP_CAP_REDUCED
+    : Math.max(0, Math.min(
+      lite ? MONTAGE.LIVE_LOOP_CAP_LITE : MONTAGE.LIVE_LOOP_CAP,
+      Math.max(MONTAGE.LIVE_LOOP_MIN, Math.round(count * MONTAGE.LIVE_LOOP_SHARE)),
+      MONTAGE.LIVE_ELEMENT_CEIL,
+    ));
+  const videoCap = Math.max(0, Math.min(
+    lite ? MONTAGE.VIDEO_TILE_CAP_LITE : MONTAGE.VIDEO_TILE_CAP,
+    MONTAGE.VIDEO_ELEMENT_CEIL,
+    liveCap,
+  ));
+
+  /* logical tiles - they OUTLIVE a layout rebuild (the look is the tile's, the
+   * element is the layout's), so the live ledger stays correct across a swirl. */
+  const tiles = [];
+  for (let i = 0; i < count; i++) {
+    tiles.push({
+      i,
+      url: null, remote: false, live: false, isVideo: false,
+      seq: 0, node: null, face: null, _liveUrl: null,
+      sig: 1 + Math.floor(roll('sig') * 6),
+      hue: Math.round(roll('hue') * 300),
+    });
+  }
+  const liveUse = new Map();
+  let videoTiles = 0;
+  let destroyed = false;
+  let frozen = false;
+  let layout = '';
+  let containers = [];
+  let rowEls = [];
+  let pool = null;
+  let band = 0;
+  const dressTimers = new Set();
+  const chunkTimers = new Set();
+
+  /* ---------------------------------------------------------------- ledger */
+  function releaseLive(tile) {
+    const url = tile._liveUrl;
+    if (!url) return;
+    tile._liveUrl = null;
+    const rec = liveUse.get(url);
+    if (!rec) return;
+    if (rec.n <= 1) liveUse.delete(url); else rec.n -= 1;
+  }
+  function acquireLive(tile, url) {
+    tile._liveUrl = url;
+    const rec = liveUse.get(url);
+    if (rec) rec.n += 1; else liveUse.set(url, { n: 1 });
+  }
+  /** Would giving this tile `url` mint a decoder we cannot afford? Adopting a
+   *  url the wall already animates is free - same resource, same clock. */
+  function liveBlocked(tile, url) {
+    if (liveUse.has(url)) return false;
+    const rec = tile._liveUrl ? liveUse.get(tile._liveUrl) : null;
+    const freeing = rec && rec.n <= 1 ? 1 : 0;
+    return (liveUse.size - freeing) >= liveCap;
+  }
+
+  /* ----------------------------------------------------------------- paint */
+  function repaint(tile) {
+    if (!tile || !tile.face) return;
+    paintFace(tile.face, tile.url);
+  }
+
+  /**
+   * Give a tile a url. Returns true if the look took. Two budgets can refuse
+   * it (the decoder window, the video element ceiling); a refusal is not a
+   * failure - the caller rests the seat on a still instead.
+   */
+  function setUrl(tile, draw, opts) {
+    if (!tile || destroyed) return false;
+    const url = draw && draw.url ? draw.url : null;
+    const isVid = isVideoUrl(url);
+    const anim = isAnimatedUrl(url);
+    if (anim && liveBlocked(tile, url)) return false;
+    if (isVid && !tile.isVideo && videoTiles >= videoCap) return false;
+
+    releaseLive(tile);
+    if (tile.isVideo && !isVid) videoTiles = Math.max(0, videoTiles - 1);
+    if (!tile.isVideo && isVid) videoTiles += 1;
+    tile.isVideo = isVid;
+    tile.live = anim;
+    tile.url = url;
+    tile.remote = !!(draw && draw.remote);
+    if (anim) acquireLive(tile, url);
+    tile.seq = (tile.seq | 0) + 1;
+
+    const wait = opts && opts.paintDelayMs > 0 ? (opts.paintDelayMs | 0) : 0;
+    if (!wait) { repaint(tile); return true; }
+    const mySeq = tile.seq;
+    const h = setTimeout(() => {
+      dressTimers.delete(h);
+      if (destroyed || tile.seq !== mySeq) return;   // a turn got here first
+      repaint(tile);
+    }, wait);
+    dressTimers.add(h);
+    return true;
+  }
+
+  /* ------------------------------------------------------------------ draw */
+  function poolNext(kind) {
+    try { return pool && typeof pool.next === 'function' ? (pool.next(kind) || null) : null; }
+    catch (e) { return null; }
+  }
+  /** An ANIMATED url the wall is not already animating (no-repeat = no lockstep). */
+  function drawLive() {
+    if (liveCap <= 0) return null;
+    for (let i = 0; i < MONTAGE.LIVE_DRAW_TRIES; i++) {
+      const got = poolNext('loop');
+      if (got && got.url && isAnimatedUrl(got.url) && !liveUse.has(got.url)) return got;
+    }
+    return null;
+  }
+  /** Something that costs no decoder: a real still, else park on a live gif. */
+  function drawSleeper() {
+    const got = poolNext('still');
+    if (got && got.url && !isAnimatedUrl(got.url)) return got;
+    const parks = [];
+    for (const url of liveUse.keys()) if (!isVideoUrl(url)) parks.push(url);
+    if (parks.length) return { url: parks[Math.floor(Math.random() * parks.length)], remote: false };
+    return null;
+  }
+
+  /** How many live seats the current density band wants. */
+  function liveWant() {
+    if (liveCap <= 0) return 0;
+    return Math.max(0, Math.min(liveCap, Math.round(liveCap * (0.42 + 0.58 * band))));
+  }
+  function liveSeats() { return tiles.filter((t) => t.live).length; }
+
+  /** Grow / shed live seats toward the band's appetite, a few at a time. */
+  function applyBand() {
+    if (destroyed || !pool) return 0;
+    const want = liveWant();
+    let moved = 0;
+    let have = liveSeats();
+    if (have < want) {
+      const sleepers = tiles.filter((t) => !t.live);
+      for (const tile of sleepers) {
+        if (have >= want || moved >= MONTAGE.SWAP_APPLY_CHUNK) break;
+        const got = drawLive();
+        if (!got) break;
+        if (setUrl(tile, got)) { have += 1; moved += 1; }
+      }
+    } else if (have > want) {
+      const lives = tiles.filter((t) => t.live);
+      for (const tile of lives) {
+        if (have <= want || moved >= MONTAGE.SWAP_APPLY_CHUNK) break;
+        const got = drawSleeper();
+        if (setUrl(tile, got || { url: null })) { have -= 1; moved += 1; }
+      }
+    }
+    return moved;
+  }
+
+  /* ------------------------------------------------------------- structure */
+  function clearContainers() {
+    for (const h of chunkTimers) { try { clearTimeout(h); } catch (e) { /* ignore */ } }
+    chunkTimers.clear();
+    for (const c of containers) { try { c.remove(); } catch (e) { /* ignore */ } }
+    containers = [];
+    rowEls = [];
+    for (const tile of tiles) { tile.node = null; tile.face = null; }
+  }
+
+  function buildTileEl(tile) {
+    const node = el('div', 'g-ir-tile');
+    if (!node) return null;
+    try {
+      node.setAttribute('data-i', String(tile.i));
+      node.setAttribute('aria-hidden', 'true');
+    } catch (e) { /* DOM double */ }
+    /* Seeded look vars for style.js. THEY ARE NOT A FILTER BUDGET (web CLAUDE.md
+     * trap 36): a `filter:` on a face that may hold a live <video> decode is a
+     * full GPU pass over every decoded frame, per tile, per frame. Tint with
+     * plain alpha over the face, never with hue-rotate on the media. */
+    if (node.style) {
+      node.style.setProperty('--ir-i', String(tile.i));
+      node.style.setProperty('--ir-sig', String(tile.sig));
+      node.style.setProperty('--ir-hue', tile.hue + 'deg');
+    }
+    const face = el('div', 'g-ir-face');
+    if (face) node.appendChild(face);
+    tile.node = node;
+    tile.face = face;
+    return node;
+  }
+
+  /** Rebuild the stage for a layout, re-dressing every tile from its own look. */
+  function setLayout(kind) {
+    if (destroyed || !mount) return layout;
+    const want = String(kind || 'rows');
+    clearContainers();
+    layout = want;
+    try { mount.setAttribute('data-layout', layout); } catch (e) { /* DOM double */ }
+
+    if (layout === 'rows') {
+      const rows = Math.max(MONTAGE.ROWS_MIN,
+        Math.min(MONTAGE.ROWS_MAX, Math.round(Math.sqrt(count / 1.4))));
+      if (mount.style) mount.style.setProperty('--ir-rows', String(rows));
+      const per = Math.ceil(count / rows);
+      for (let r = 0; r < rows; r++) {
+        const row = el('div', 'g-ir-row' + (r % 2 ? ' g-ir-rev' : ''));
+        if (!row) break;
+        try { row.setAttribute('data-r', String(r)); } catch (e) { /* DOM double */ }
+        if (row.style) row.style.setProperty('--ir-r', String(r));
+        for (let k = 0; k < per; k++) {
+          const i = r * per + k;
+          if (i >= count) break;
+          const node = buildTileEl(tiles[i]);
+          if (node) row.appendChild(node);
+        }
+        mount.appendChild(row);
+        containers.push(row);
+        rowEls.push(row);
+      }
+    } else if (layout === 'mosaic') {
+      const cols = Math.max(MONTAGE.MOSAIC_COLS_MIN,
+        Math.min(MONTAGE.MOSAIC_COLS_MAX, Math.round(Math.sqrt(count * 1.5))));
+      const grid = el('div', 'g-ir-mosaic');
+      if (grid) {
+        if (grid.style) grid.style.setProperty('--ir-cols', String(cols));
+        for (let i = 0; i < count; i++) {
+          const node = buildTileEl(tiles[i]);
+          if (!node) continue;
+          if (node.style) {
+            node.style.setProperty('--ir-col', String(i % cols));
+            node.style.setProperty('--ir-row', String(Math.floor(i / cols)));
+          }
+          grid.appendChild(node);
+        }
+        mount.appendChild(grid);
+        containers.push(grid);
+      }
+    } else {
+      /* SWIRL: tiles ride a spiral. CORE sets --ir-ang / --ir-rad / --ir-orbit;
+       * style.js owns the transform that reads them (and the engine's spiral
+       * wash sits behind, held by index.js). */
+      const swirl = el('div', 'g-ir-swirl');
+      if (swirl) {
+        for (let i = 0; i < count; i++) {
+          const node = buildTileEl(tiles[i]);
+          if (!node) continue;
+          const f = count > 1 ? i / (count - 1) : 0;
+          const ang = f * 360 * MONTAGE.SWIRL_TURNS;
+          const rad = MONTAGE.SWIRL_RAD_MIN + (MONTAGE.SWIRL_RAD_MAX - MONTAGE.SWIRL_RAD_MIN) * f;
+          if (node.style) {
+            node.style.setProperty('--ir-ang', ang.toFixed(2) + 'deg');
+            node.style.setProperty('--ir-rad', (rad * 100).toFixed(2) + '%');
+            node.style.setProperty('--ir-orbit', f.toFixed(3));
+          }
+          swirl.appendChild(node);
+        }
+        mount.appendChild(swirl);
+        containers.push(swirl);
+      }
+    }
+
+    for (const tile of tiles) repaint(tile);
+    if (frozen) applyFreeze();
+    return layout;
+  }
+
+  /* ----------------------------------------------------------------- dress */
+  /** The pool landed: dress the wall, staggered, live seats first. */
+  function dress(p) {
+    pool = p || null;
+    if (!pool || destroyed) return 0;
+    const want = liveWant();
+    let live = 0;
+    let dressed = 0;
+    for (let i = 0; i < tiles.length; i++) {
+      const tile = tiles[i];
+      const delay = Math.round((MONTAGE.DRESS_WINDOW_MS * i) / Math.max(1, tiles.length)
+        + roll('dress') * MONTAGE.DRESS_JITTER_MS);
+      let got = null;
+      if (live < want) { got = drawLive(); if (got) live += 1; }
+      if (!got) got = drawSleeper();
+      if (got && setUrl(tile, got, { paintDelayMs: delay })) dressed += 1;
+    }
+    say('montage dressed: ' + dressed + '/' + tiles.length + ' tiles, live cap ' + liveCap
+      + ', video cap ' + videoCap + (reduced ? ' (reduced motion)' : ''));
+    return dressed;
+  }
+
+  /* ------------------------------------------------------------------ turn */
+  /**
+   * THE TURN - the montage's one content primitive (the mosaic's turnover, the
+   * rows' churn). Seeded choice, chunked apply: the pick is deterministic, the
+   * paint is spread over frames so a burst never eats half a frame budget.
+   *
+   * @returns {Array} the tiles chosen (their FACES are what the engine dresses)
+   */
+  function turn(n) {
+    if (destroyed || !pool || !tiles.length) return [];
+    const k = Math.max(1, Math.min(tiles.length, Math.round(Number(n) || 1)));
+    const chosen = [];
+    const used = new Set();
+    for (let i = 0; i < k * 3 && chosen.length < k; i++) {
+      const idx = Math.floor(roll('turn') * tiles.length);
+      if (used.has(idx)) continue;
+      used.add(idx);
+      chosen.push(tiles[idx]);
+    }
+    const apply = (from) => {
+      if (destroyed) return;
+      const stop = Math.min(chosen.length, from + MONTAGE.SWAP_APPLY_CHUNK);
+      for (let i = from; i < stop; i++) {
+        const tile = chosen[i];
+        const got = tile.live ? (drawLive() || drawSleeper()) : (drawSleeper() || drawLive());
+        if (got) setUrl(tile, got);
+      }
+      if (stop < chosen.length) {
+        const h = setTimeout(() => { chunkTimers.delete(h); apply(stop); }, 24);
+        chunkTimers.add(h);
+      }
+    };
+    apply(0);
+    return chosen;
+  }
+
+  /* ---------------------------------------------------------------- freeze */
+  function applyFreeze() {
+    if (!mount) return;
+    try {
+      if (frozen) mount.classList.add('is-frozen'); else mount.classList.remove('is-frozen');
+      if (mount.setAttribute) mount.setAttribute('data-frozen', frozen ? '1' : '0');
+    } catch (e) { /* DOM double */ }
+    for (const tile of tiles) {
+      const kids = (tile.face && tile.face.children) || [];
+      const m = kids.length ? kids[0] : null;
+      if (!m || String(m.tagName || '').toUpperCase() !== 'VIDEO') continue;
+      try {
+        if (frozen) { if (m.pause) m.pause(); }
+        else if (m.play) { const p = m.play(); if (p && p.catch) p.catch(() => {}); }
+      } catch (e) { /* ignore */ }
+    }
+  }
+  /** THE FREEZE: the stream stops dead. The class clock does not (Law I). */
+  function freeze(on) {
+    const want = !!on;
+    if (want === frozen) return frozen;
+    frozen = want;
+    applyFreeze();
+    return frozen;
+  }
+
+  /* ------------------------------------------------------------- governor */
+  const gov = {
+    on: false, raf: 0, base: Infinity, med: 0,
+    badSince: 0, lastShed: 0, healthySince: 0,
+    shedVideos: 0, shedGifs: 0, regrown: 0,
+  };
+  const gaps = [];
+  let govLast = 0;
+
+  /** Rest a seat on something free. Never a ledger write - only pixels. */
+  function restSeat(tile) {
+    if (!tile) return false;
+    const got = drawSleeper();
+    return setUrl(tile, got || { url: null });
+  }
+  function shedVideoSeat() {
+    const vids = tiles.filter((t) => t.isVideo);
+    if (vids.length <= MONTAGE.GOV_VIDEO_FLOOR) return false;
+    const gifLive = tiles.reduce((n, t) => n + ((t.live && !t.isVideo) ? 1 : 0), 0);
+    if (gifLive < MONTAGE.GOV_SHED_VIDEO_MIN_GIFS) return false;
+    return restSeat(vids[Math.floor(Math.random() * vids.length)]);
+  }
+  function shedGifSeat() {
+    const urlTiles = new Map();
+    const gifUrls = new Set();
+    for (const t of tiles) {
+      if (!t.live || t.isVideo || !t.url) continue;
+      gifUrls.add(t.url);
+      urlTiles.set(t.url, (urlTiles.get(t.url) | 0) + 1);
+    }
+    if (gifUrls.size <= MONTAGE.GOV_GIF_FLOOR) return false;
+    const lives = tiles.filter((t) => t.live && !t.isVideo && t.url);
+    if (!lives.length) return false;
+    /* a decoder only dies with its LAST tile, so shed sole holders first */
+    const solo = lives.filter((t) => (urlTiles.get(t.url) | 0) === 1);
+    const from = solo.length ? solo : lives;
+    return restSeat(from[Math.floor(Math.random() * from.length)]);
+  }
+  function growGifSeat() {
+    const sleepers = tiles.filter((t) => !t.live);
+    if (!sleepers.length) return false;
+    const got = drawLive();
+    if (!got || !got.url || isVideoUrl(got.url) || !isAnimatedUrl(got.url)) return false;
+    return setUrl(sleepers[Math.floor(Math.random() * sleepers.length)], got);
+  }
+
+  function govTick(ts) {
+    if (!gov.on) return;
+    try { gov.raf = requestAnimationFrame(govTick); } catch (e) { gov.on = false; return; }
+    if (govLast) {
+      const gap = ts - govLast;
+      const hidden = (typeof document !== 'undefined' && document.hidden);
+      if (gap > 0 && gap < 500 && !frozen && !hidden) {
+        gaps.push(gap);
+        if (gaps.length > 90) gaps.shift();
+      } else {
+        gaps.length = 0;
+      }
+    }
+    govLast = ts;
+    if (gaps.length < MONTAGE.GOV_SAMPLES) return;
+    const s = gaps.slice().sort((x, y) => x - y);
+    const med = s[s.length >> 1];
+    gov.med = med;
+    if (med < gov.base) gov.base = med;
+    const locked = med >= gov.base * MONTAGE.GOV_LOCK_X;
+    if (!locked) {
+      gov.badSince = 0;
+      if (!gov.healthySince) gov.healthySince = ts;
+      if (gov.shedGifs > 0 && !frozen && ts - gov.healthySince > MONTAGE.GOV_GROW_MS) {
+        gov.healthySince = ts;
+        if (growGifSeat()) { gov.shedGifs -= 1; gov.regrown += 1; }
+      }
+      return;
+    }
+    gov.healthySince = 0;
+    if (!gov.badSince) { gov.badSince = ts; return; }
+    if (ts - gov.badSince < MONTAGE.GOV_BAD_MS) return;
+    if (ts - gov.lastShed < MONTAGE.GOV_SETTLE_MS) return;
+    if (frozen || destroyed) return;
+    gov.lastShed = ts;
+    if (shedVideoSeat()) {
+      gov.shedVideos += 1;
+      say('governor: shed a video seat (median ' + med.toFixed(1) + 'ms vs base ' + gov.base.toFixed(1) + 'ms)');
+      return;
+    }
+    let g = 0;
+    for (let i = 0; i < MONTAGE.GOV_GIF_SHED_STEP; i++) { if (shedGifSeat()) g += 1; }
+    if (g) {
+      gov.shedGifs += g;
+      say('governor: shed ' + g + ' gif seat(s) (median ' + med.toFixed(1) + 'ms vs base ' + gov.base.toFixed(1) + 'ms)');
+    }
+  }
+
+  const api = {
+    /* ---- structure ---- */
+    setLayout,
+    layout() { return layout; },
+    rows() { return rowEls.slice(); },
+    /** The engine's ONLY legal targets on this stage (never `.g-ir-tile`). */
+    faces() { return tiles.map((t) => t.face).filter(Boolean); },
+    facesOf(list) { return (list || []).map((t) => t && t.face).filter(Boolean); },
+    tiles() { return tiles.slice(); },
+    mountEl() { return mount; },
+
+    /* ---- media ---- */
+    dress,
+    turn,
+    /** The density band drives how many seats are alive. */
+    setBand(b) {
+      const v = Number(b);
+      band = !Number.isFinite(v) ? 0 : v < 0 ? 0 : v > 1 ? 1 : v;
+      return applyBand();
+    },
+    band() { return band; },
+
+    /* ---- lifecycle ---- */
+    freeze,
+    frozen() { return frozen; },
+    startGovernor() {
+      if (!MONTAGE.GOVERNOR || gov.on || reduced) return false;
+      if (typeof requestAnimationFrame !== 'function') return false;   // headless
+      gov.on = true;
+      govLast = 0;
+      try { gov.raf = requestAnimationFrame(govTick); } catch (e) { gov.on = false; return false; }
+      return true;
+    },
+    stopGovernor() {
+      gov.on = false;
+      if (gov.raf && typeof cancelAnimationFrame === 'function') {
+        try { cancelAnimationFrame(gov.raf); } catch (e) { /* ignore */ }
+      }
+      gov.raf = 0;
+    },
+    destroy() {
+      destroyed = true;
+      api.stopGovernor();
+      for (const h of dressTimers) { try { clearTimeout(h); } catch (e) { /* ignore */ } }
+      dressTimers.clear();
+      clearContainers();
+      liveUse.clear();
+      videoTiles = 0;
+      pool = null;
+    },
+
+    /* ---- diagnostics (never read by the shell) ---- */
+    diagnostics() {
+      return {
+        layout, frozen, band, count, liveCap, videoCap,
+        live: liveSeats(),
+        liveUrls: liveUse.size,
+        videoTiles,
+        want: liveWant(),
+        rows: rowEls.length,
+        containers: containers.length,
+        dressed: tiles.filter((t) => !!t.url).length,
+        governor: {
+          on: gov.on, base: Number.isFinite(gov.base) ? gov.base : 0, med: gov.med,
+          shedVideos: gov.shedVideos, shedGifs: gov.shedGifs, regrown: gov.regrown,
+        },
+      };
+    },
+  };
+  return api;
+}
+
+export default { createMontage, createLedger, MONTAGE, isAnimatedUrl, isVideoUrl, paintFace, hideTruthNode };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/pressure.js
@@ -1,0 +1,556 @@
+/* ============================================================================
+ * games/instant-recall/pressure.js - DECK IV of the House Rules for the vigil:
+ * THE SURGE. The casino lights the hall, the trickster lies about the slip;
+ * this file is what the ROOM does to you as the vigil climbs. In THIS class
+ * the montage's own channels (sub_flash words, bubbles, rain, glitch swaps,
+ * row drift, the swirl's wheel) are CORE's - they ARE the quiz material and
+ * the ledger reads them. This deck is the weather AROUND the screen: it never
+ * fires a channel the ledger records as quiz truth (no sub_flash, no
+ * audio_trigger stings, no gif_rain / glitch_swap on the montage), so a
+ * pressure rung can never plant a false memory. What it spends:
+ *
+ *   THE LADDER   the surge = 0.6 * progress + 0.4 * min(streak,4)/4 - rising
+ *                with the class and with the player's own run. Rung by rung
+ *                (cumulative; a lower rung is stepped DOWN behind a hysteresis,
+ *                never snapped):
+ *     rung 0  clean hall
+ *     rung 1  BREATH      pink wash breathes on a cadence             [engine wash:pink]
+ *     rung 2  MOTES+CRT   ambient motes in the beam + scanline whisper [engine ambient_field, crt]
+ *     rung 3  TREMOR      the chrome (HUD chips, proctor line) carries a
+ *                         CSS tremor whose amplitude rides heat; a correct
+ *                         answer pays a gif burst over the hall         [CSS + engine gif_burst]
+ *     rung 4  GLITCH      the HUD glitches (vhsroll) on stops + a flash
+ *                         burst; crt turns chroma                      [engine glitch_swap, flash_burst, crt]
+ *     rung 5  SURGE       the breath deepens to a flood on every correct
+ *                         answer, the tremor peaks, bursts double      [engine wash:pink, gif_burst]
+ *   THE PUNCH    every verdict punches the chrome (extend-not-stack: a CSS
+ *                class with a bigger amplitude for 300ms); reduced motion /
+ *                motionLevel 0 turn every punch into a bloom (a transition).
+ *
+ * ENGINE vs GAME-LOCAL (audit): everything the engine can do goes through
+ * opts.engine (CORE's weld: clickSafe forced, AUDIO_CEIL, capsOk). Game-local
+ * is ONLY the tremor / punch / bloom: classes + two custom props on the chrome
+ * nodes CORE hands us - no nodes of our own, no per-frame JS (the tremor is a
+ * CSS steps() keyframe; the PERF LAW's 8Hz ceiling is respected by having no
+ * JS paint at all).
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads nothing, writes nothing about the ledger, the
+ *       stops, the streak or the grade; the chips' TEXT is never touched.
+ *   II  input honest  - the tremor is applied to chrome only (never the slip,
+ *       never an option, never a tile); every engine fire is clickSafe.
+ *   III never still   - the breath and the tremor ride the rung.
+ *   V   seeded        - per-tag mulberry32 off seed+'|ir-pressure|' (append-
+ *       only tags); the engine's own rng is separate and fine.
+ *   VI  exits sacred  - capsOk() false disarms everything (no fires, no
+ *       classes); reduced motion / motionLevel 0 = tremor 0, punches bloom;
+ *       every timer lives in the game's pause-aware registry AND a local set.
+ *   VII strings      - this file renders no text at all.
+ *   PERF LAW         - zero per-frame JS; zero touches on .g-ir-tile or the
+ *       montage container; CSS animations on chrome only.
+ *
+ * NEVER: engine.stop('wash') - it blacks out EVERY wash kind, including the
+ * swirl wheel CORE holds. A wash is stepped down by re-triggering the same
+ * variant with a tiny alpha and a 120ms hold.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const IR_PRESSURE = Object.freeze({
+  /** surge (0..1) thresholds for rungs 1..5 (rung 0 below the first). */
+  RUNG_AT: Object.freeze([0.18, 0.36, 0.54, 0.72, 0.88]),
+  RUNG_MAX: 5,
+  SURGE_FROM_PROGRESS: 0.6,
+  SURGE_FROM_STREAK: 0.4,
+  STREAK_CAP: 4,
+  /** The ladder: what each rung ADDS (feature keys, cumulative), the cue it
+   *  announces itself with (one per rung CHANGE, never per frame). */
+  LADDER: Object.freeze([
+    Object.freeze({ rung: 0, adds: Object.freeze([]), cue: null }),
+    Object.freeze({ rung: 1, adds: Object.freeze(['breath']), cue: 'wash' }),
+    Object.freeze({ rung: 2, adds: Object.freeze(['motes', 'crt']), cue: 'whisper' }),
+    Object.freeze({ rung: 3, adds: Object.freeze(['tremor', 'burst']), cue: 'burst' }),
+    Object.freeze({ rung: 4, adds: Object.freeze(['glitch', 'chroma']), cue: 'glitch' }),
+    Object.freeze({ rung: 5, adds: Object.freeze(['surge']), cue: 'near_miss' }),
+  ]),
+  /** Stepping DOWN waits this long (a dip in the surge never snaps the storm). */
+  HYST_MS: 1600,
+  /** Forever-ish things are repainted when heat moved at least this much. */
+  HEAT_REPAINT_STEP: 0.08,
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([9000, 5200]),
+  BREATH_HOLD_MS: 2400,
+  BREATH_ALPHA: Object.freeze([0.1, 0.36]),
+  SURGE_ALPHA: Object.freeze([0.3, 0.55]),
+  SURGE_HOLD_MS: 1600,
+  MOTES_DENSITY: Object.freeze([0.25, 0.7]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  BURST_HOLD_MS: 900,
+  BURST_CHANCE: Object.freeze([0.45, 0.95]),
+  FLASH_COUNT: Object.freeze([1, 2]),
+  FLASH_HOLD_MS: 700,
+  GLITCH_S: 0.55,
+  GLITCH_CHANCE: Object.freeze([0.5, 1]),
+  /* ---- the tremor (CSS on chrome) ------------------------------------- */
+  TREMOR_PX: Object.freeze([0, 0, 0, 0.6, 1.0, 1.6]),      // by rung, at heat 1
+  TREMOR_FLOOR: 0.5,                                        // heat 0 still shivers at half
+  TREMOR_CAP_PX: 2,
+  TREMOR_T_MS: Object.freeze([140, 90]),                    // steps() period by heat
+  PUNCH_PX: Object.freeze({ correct: 2.2, wrong: 3.2, timeout: 1.8, stop: 2.6, layout: 1.2, peak: 1.4 }),
+  PUNCH_MS: 300,
+  BLOOM_MS: 320,
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  /** cue level = min(AUDIO_CEIL[gradeTier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.22,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.32, 2: 0.38, 3: 0.44, 4: 0.5 }),
+});
+
+const STYLE_ID = 'g-ir-pressure-style';
+const STYLE_TEXT = `
+/* THE TREMOR: chrome only. A steps() keyframe on translate, amplitude from
+   --ir-p-ta (px), period from --ir-p-tt. The punch is the same keyframe at a
+   bigger amplitude for a beat. Never on the slip, an option or a tile. */
+.g-ir-p-tremor{animation:g-ir-p-tremor var(--ir-p-tt,.12s) steps(2,jump-none) infinite}
+@keyframes g-ir-p-tremor{0%{translate:calc(var(--ir-p-ta,0px) * -1) calc(var(--ir-p-ta,0px) * .6)}
+  33%{translate:var(--ir-p-ta,0px) calc(var(--ir-p-ta,0px) * -.4)}
+  66%{translate:calc(var(--ir-p-ta,0px) * .5) var(--ir-p-ta,0px)}
+  100%{translate:calc(var(--ir-p-ta,0px) * -.7) calc(var(--ir-p-ta,0px) * -.8)}}
+.g-ir-p-punch{animation:g-ir-p-punch .3s steps(3,jump-none) 1}
+@keyframes g-ir-p-punch{0%{translate:calc(var(--ir-p-pa,2px) * -1) calc(var(--ir-p-pa,2px) * .5)}
+  40%{translate:var(--ir-p-pa,2px) calc(var(--ir-p-pa,2px) * -.6)}
+  75%{translate:calc(var(--ir-p-pa,2px) * -.4) var(--ir-p-pa,2px)}100%{translate:0 0}}
+/* THE BLOOM: reduced motion's whole punch - a box-shadow transition. */
+.g-ir-p-bloom{box-shadow:0 0 0 2px rgba(255,105,180,.55), 0 0 22px rgba(255,105,180,.6) !important;transition:box-shadow .3s ease}
+@media (prefers-reduced-motion: reduce){
+  .g-ir-p-tremor,.g-ir-p-punch{animation:none !important;translate:0 0}
+}
+html.arc-reduced .g-ir-p-tremor,html.arc-reduced .g-ir-p-punch{animation:none !important;translate:0 0}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+/** progress + streak -> surge 0..1. Pure. */
+export function surgeFor(progress01, streak) {
+  const P = IR_PRESSURE;
+  const s = Math.max(0, Math.min(P.STREAK_CAP, Number(streak) || 0)) / P.STREAK_CAP;
+  return clamp01(P.SURGE_FROM_PROGRESS * clamp01(progress01) + P.SURGE_FROM_STREAK * s);
+}
+/** surge -> rung 0..5. Pure, monotone. */
+export function rungFor(surge01) {
+  const s = clamp01(surge01);
+  let r = 0;
+  for (const at of IR_PRESSURE.RUNG_AT) { if (s >= at) r += 1; else break; }
+  return Math.min(IR_PRESSURE.RUNG_MAX, r);
+}
+/** The idle tremor amplitude in px for a rung at a heat. 0 under reduced motion. Pure. */
+export function tremorAmpPx(rung, heat01, reducedMotion) {
+  if (reducedMotion) return 0;
+  const base = IR_PRESSURE.TREMOR_PX[Math.max(0, Math.min(IR_PRESSURE.RUNG_MAX, rung | 0))] || 0;
+  if (base <= 0) return 0;
+  const f = IR_PRESSURE.TREMOR_FLOOR;
+  return Math.min(IR_PRESSURE.TREMOR_CAP_PX, +(base * (f + (1 - f) * clamp01(heat01))).toFixed(3));
+}
+
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function delVar(n, k) { try { if (n && n.style && n.style.removeProperty) n.style.removeProperty(k); } catch (e) { /* noop */ } }
+function restart(n, cls) {
+  if (!n || !n.classList) return;
+  try { n.classList.remove(cls); if (typeof n.offsetWidth === 'number') void n.offsetWidth; n.classList.add(cls); } catch (e) { /* noop */ }
+}
+
+/**
+ * @param {Object} o
+ *   seed, gradeTier, reduced, motionLevel, stage, montage (untouched), chrome:[els], hud,
+ *   engine {fire, sustain, stop, channels}, assets (unused), timers {after,every,clear},
+ *   capsOk (fn | bool), log
+ */
+export function createIrPressure(o) {
+  const opts = o || {};
+  const P = IR_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const gradeTier = Math.max(1, Math.min(4, Number(opts.gradeTier) || 1));
+  const audioCeil = P.AUDIO_CEIL[gradeTier] || P.AUDIO_CEIL[1];
+  const eng = opts.engine || {};
+  const armedBase = !!opts.stage && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk === true;
+  }
+  let destroyed = false;
+  /* THE STAGE WATCH. CORE sends beat('hit'|'miss') and the montage's own effect
+   * kinds, but not 'stop' or 'layout' - those are READ off the stage's
+   * data-phase / data-layout attributes (one MutationObserver on one node, no
+   * polling). An explicit beat of the same kind within DEDUPE_MS is folded. */
+  let stageWatch = null;
+  let lastPhase = null;
+  let lastLayout = null;
+  const lastBeatAt = { stop: -1e9, layout: -1e9 };
+  const DEDUPE_MS = 320;
+  function nowMs() {
+    try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+    return Date.now();
+  }
+  function watchStage() {
+    if (stageWatch || typeof MutationObserver === 'undefined' || !opts.stage) return;
+    try {
+      lastPhase = opts.stage.getAttribute ? opts.stage.getAttribute('data-phase') : null;
+      lastLayout = opts.stage.getAttribute ? opts.stage.getAttribute('data-layout') : null;
+      stageWatch = new MutationObserver(() => {
+        if (destroyed || stopped) return;
+        let ph = null; let ly = null;
+        try { ph = opts.stage.getAttribute('data-phase'); ly = opts.stage.getAttribute('data-layout'); } catch (e) { return; }
+        if (ph !== lastPhase) { lastPhase = ph; if (ph === 'stop') api.beat('stop'); }
+        if (ly !== lastLayout) { const was = lastLayout; lastLayout = ly; if (was != null && ly) api.beat('layout'); }
+      });
+      stageWatch.observe(opts.stage, { attributes: true, attributeFilter: ['data-phase', 'data-layout'] });
+    } catch (e) { stageWatch = null; }
+  }
+  function unwatchStage() {
+    if (!stageWatch) return;
+    try { stageWatch.disconnect(); } catch (e) { /* noop */ }
+    stageWatch = null;
+  }
+  const armed = () => armedBase && !destroyed && capsOk();
+  /* the chrome: what we may tremble. Never the montage, never the slip. */
+  const chrome = [];
+  try {
+    for (const n of (Array.isArray(opts.chrome) ? opts.chrome : [])) if (n && n.classList) chrome.push(n);
+    const hud = opts.hud || {};
+    for (const k of ['clock', 'stops', 'density']) if (hud[k] && hud[k].classList && chrome.indexOf(hud[k]) < 0) chrome.push(hud[k]);
+  } catch (e) { /* none */ }
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'ir') + '|ir-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+  /* ---- the engine, counted ------------------------------------------------ */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.fire !== 'function') return null;
+    try { return eng.fire(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    const v = o2 && o2.variant ? kind + ':' + o2.variant : kind;
+    count(kind); if (v !== kind) count(v);
+    if (typeof eng.sustain !== 'function') return null;
+    try { return eng.sustain(kind, o2 || {}) || null; } catch (e) { return null; }
+  }
+  function stopKind(kind) {
+    if (!armedBase || destroyed || kind === 'wash') return;     // NEVER stop('wash')
+    count('stop:' + kind);
+    if (typeof eng.stop !== 'function') return;
+    try { eng.stop(kind); } catch (e) { /* ignore */ }
+  }
+  function cue(name, rung) {
+    if (!name) return;
+    fire('audio_trigger', { name, level: Math.min(audioCeil, P.CUE_LEVEL_BASE + P.CUE_LEVEL_STEP * rung) });
+  }
+
+  /* ---- state ------------------------------------------------------------ */
+  let started = false;
+  let stopped = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let progress = 0;
+  let streak = 0;
+  let rung = 0;
+  let hystTimer = 0;
+  let hystTarget = -1;
+  let outOn = false;
+  const present = new Set();
+  let breathTimer = 0;
+  let punchTimer = 0;
+  let bloomTimer = 0;
+  let tremorAmp = 0;
+  let beats = 0;
+
+  /* ------------------------------------------------------------- chrome */
+  function paintTremor() {
+    tremorAmp = (stopped || outOn || !armed() || !present.has('tremor')) ? 0
+      : tremorAmpPx(rung, heat, still) * P.MOTION_MUL[motion];
+    const on = tremorAmp > 0.05;
+    const tt = (lerp(P.TREMOR_T_MS, heat) | 0) + 'ms';
+    for (const n of chrome) {
+      if (on) { setVar(n, '--ir-p-ta', tremorAmp.toFixed(2) + 'px'); setVar(n, '--ir-p-tt', tt); setCls(n, 'g-ir-p-tremor', true); }
+      else { setCls(n, 'g-ir-p-tremor', false); delVar(n, '--ir-p-ta'); }
+    }
+  }
+  let punches = 0;
+  function punch(kind) {
+    if (!armed() || stopped || !chrome.length) return;
+    punches += 1;
+    if (still) {
+      for (const n of chrome) restart(n, 'g-ir-p-bloom');
+      cancel(bloomTimer);
+      bloomTimer = after(P.BLOOM_MS, () => { bloomTimer = 0; for (const n of chrome) setCls(n, 'g-ir-p-bloom', false); });
+      return;
+    }
+    const px = Math.min(4, (P.PUNCH_PX[kind] || 1.5) * P.MOTION_MUL[motion] * (0.6 + 0.4 * heat));
+    for (const n of chrome) { setVar(n, '--ir-p-pa', px.toFixed(2) + 'px'); restart(n, 'g-ir-p-punch'); }
+    cancel(punchTimer);
+    punchTimer = after(P.PUNCH_MS + 20, () => { punchTimer = 0; for (const n of chrome) setCls(n, 'g-ir-p-punch', false); });
+  }
+  function clearChrome() {
+    for (const n of chrome) {
+      setCls(n, 'g-ir-p-tremor', false); setCls(n, 'g-ir-p-punch', false); setCls(n, 'g-ir-p-bloom', false);
+      delVar(n, '--ir-p-ta'); delVar(n, '--ir-p-tt'); delVar(n, '--ir-p-pa');
+    }
+  }
+
+  /* ------------------------------------------------------------ the rungs */
+  const has = (k) => present.has(k);
+  function breathe(alphaBand, hold) {
+    sustain('wash', { variant: 'pink', alpha: lerp(alphaBand, heat), holdMs: hold });
+  }
+  function armBreath() {
+    if (breathTimer) cancel(breathTimer);
+    const ms = lerp(P.BREATH_MS, heat) * (0.85 + roll('breath') * 0.3);
+    breathTimer = after(Math.round(ms), () => { breathTimer = 0; if (has('breath') && !stopped) { breathe(P.BREATH_ALPHA, P.BREATH_HOLD_MS); armBreath(); } });
+  }
+  function fadeWash(variant) {
+    // NEVER stop('wash'): a tiny alpha + a short hold lets the engine's own
+    // transition carry it out - and a held wheel elsewhere stays held.
+    sustain('wash', { variant, alpha: 0.01, holdMs: 120 });
+  }
+  function motes() {
+    sustain('ambient_field', { kind: 'motes', density: lerp(P.MOTES_DENSITY, heat) });
+  }
+  function crtOn(variant, restartIt) {
+    const o2 = { variant };
+    if (restartIt) o2.restart = true;
+    return sustain('crt', o2);
+  }
+  function burst(n) {
+    return fire('gif_burst', { count: Math.max(1, n | 0), holdMs: P.BURST_HOLD_MS, clickSafe: true, clickable: false });
+  }
+  function flash(n) {
+    return fire('flash_burst', { count: Math.max(1, n | 0), holdMs: P.FLASH_HOLD_MS, clickSafe: true, clickable: false });
+  }
+  function hudGlitch() {
+    if (still || !opts.hud) return null;
+    const targets = [];
+    try {
+      const hud = opts.hud;
+      if (hud && hud.classList) targets.push(hud);
+      else for (const k of ['clock', 'stops', 'density']) if (hud[k]) targets.push(hud[k]);
+    } catch (e) { /* none */ }
+    if (!targets.length) return null;
+    return fire('glitch_swap', { targets, variant: 'vhsroll', seconds: P.GLITCH_S, onSwap() {}, sfx: false });
+  }
+  const FEATURES = {
+    breath: { on() { breathe(P.BREATH_ALPHA, P.BREATH_HOLD_MS); armBreath(); }, off() { if (breathTimer) { cancel(breathTimer); breathTimer = 0; } fadeWash('pink'); } },
+    motes: { on() { motes(); }, off() { stopKind('ambient_field'); } },
+    crt: { on() { crtOn('scanline', false); }, off() { stopKind('crt'); } },
+    tremor: { on() { paintTremor(); }, off() { paintTremor(); } },
+    burst: { on() { burst(1); }, off() {} },
+    glitch: { on() { hudGlitch(); }, off() {} },
+    chroma: { on() { crtOn('chroma', true); }, off(dest) { if (dest >= 2) crtOn('scanline', true); } },
+    surge: { on() { breathe(P.SURGE_ALPHA, P.SURGE_HOLD_MS); burst(2); }, off() {} },
+  };
+  function enterRung(k) {
+    const row = P.LADDER[k];
+    if (!row) return;
+    for (const key of row.adds) {
+      if (present.has(key)) continue;
+      present.add(key);
+      try { FEATURES[key].on(k); } catch (e) { say('pressure: ' + key + '.on threw: ' + ((e && e.message) || e)); }
+    }
+  }
+  function leaveRung(k, dest) {
+    const row = P.LADDER[k];
+    if (!row) return;
+    for (let i = row.adds.length - 1; i >= 0; i--) {
+      const key = row.adds[i];
+      if (!present.has(key)) continue;
+      present.delete(key);
+      try { FEATURES[key].off(dest); } catch (e) { say('pressure: ' + key + '.off threw: ' + ((e && e.message) || e)); }
+    }
+  }
+  function climb(r) {
+    if (r <= rung) return;
+    const from = rung;
+    for (let k = from + 1; k <= r; k++) enterRung(k);
+    rung = r;
+    cue(P.LADDER[r] && P.LADDER[r].cue, r);
+    lastPaintHeat = heat;
+    paintTremor();
+    say('pressure: rung ' + from + ' -> ' + r + ' on: ' + Array.from(present).join(','));
+  }
+  function descend(r) {
+    if (r >= rung) return;
+    const from = rung;
+    for (let k = from; k > r; k--) leaveRung(k, r);
+    rung = r;
+    paintTremor();
+    say('pressure: rung ' + from + ' -> ' + r + ' (fade)');
+  }
+  function cancelHyst() { if (hystTimer) { cancel(hystTimer); hystTimer = 0; } hystTarget = -1; }
+  function stepTo(r, immediate) {
+    if (!started || stopped) return;
+    if (r > rung) { cancelHyst(); climb(r); return; }
+    if (r < rung) {
+      if (immediate) { cancelHyst(); descend(r); return; }
+      if (hystTimer && hystTarget === r) return;
+      cancelHyst();
+      hystTarget = r;
+      hystTimer = after(P.HYST_MS, () => { hystTimer = 0; const tgt = hystTarget; hystTarget = -1; if (tgt >= 0) descend(tgt); });
+      return;
+    }
+    cancelHyst();
+  }
+  function retune() {
+    paintTremor();
+    if (Math.abs(heat - lastPaintHeat) >= P.HEAT_REPAINT_STEP) {
+      if (has('motes')) motes();
+      lastPaintHeat = heat;
+    }
+  }
+  function reconsider() {
+    if (!started || stopped) return;
+    stepTo(rungFor(surgeFor(progress, streak)), false);
+  }
+  function everythingOff() {
+    cancelHyst();
+    descend(0);
+    if (punchTimer) { cancel(punchTimer); punchTimer = 0; }
+    if (bloomTimer) { cancel(bloomTimer); bloomTimer = 0; }
+    clearChrome();
+  }
+
+  /* ---------------------------------------------------------------- api */
+  const api = {
+    start() {
+      if (!armed()) { say('pressure: disarmed'); return; }
+      if (started) return;
+      started = true;
+      ensureStyle();
+      paintTremor();
+      watchStage();
+      say('pressure: armed (' + chrome.length + ' chrome nodes)');
+    },
+    /** Magnitude rides heat. */
+    setHeat(h) {
+      heat = clamp01(h);
+      if (!started) return;
+      retune();
+    },
+    /** Presence rides the surge: progress through the class... */
+    setProgress(p) {
+      progress = clamp01(p);
+      reconsider();
+    },
+    /** ...and the player's own run. */
+    setStreak(n) {
+      streak = Math.max(0, Number(n) || 0);
+      reconsider();
+    },
+    /** A beat: 'stop' | 'answer' | 'correct' | 'wrong' | 'timeout' | 'layout' | 'peak' | 'plant'. */
+    beat(kind) {
+      if (!started || stopped || !armed()) return;
+      beats += 1;
+      let k = String(kind || '');
+      if (k === 'hit') k = 'correct';                     // CORE's beat names
+      else if (k === 'miss') k = 'wrong';
+      if (k === 'stop' || k === 'layout') {
+        const now = nowMs();
+        if (now - lastBeatAt[k] < DEDUPE_MS) return;      // the stage watch + an explicit beat = one beat
+        lastBeatAt[k] = now;
+      }
+      if (k === 'correct') {
+        punch('correct');
+        if (has('surge')) breathe(P.SURGE_ALPHA, P.SURGE_HOLD_MS);
+        if (has('burst') && roll('burst') < lerp(P.BURST_CHANCE, heat)) burst(Math.round(lerp(P.BURST_COUNT, heat)) + (has('surge') ? 1 : 0));
+      } else if (k === 'wrong' || k === 'timeout') {
+        punch(k);
+      } else if (k === 'stop') {
+        punch('stop');
+        if (has('glitch') && roll('glitch') < lerp(P.GLITCH_CHANCE, heat)) { hudGlitch(); flash(Math.round(lerp(P.FLASH_COUNT, heat))); }
+      } else if (k === 'layout') {
+        punch('layout');
+        if (has('glitch')) hudGlitch();
+      } else if (k === 'peak') {
+        punch('peak');
+        if (has('breath')) breathe(P.BREATH_ALPHA, P.BREATH_HOLD_MS);
+      }
+    },
+    /** The last stretch: nothing new climbs past where it is. */
+    bell(on) { void on; },
+    /** The class ended: everything sighs out. */
+    dimOut() {
+      outOn = true;
+      if (!started) return;
+      everythingOff();
+    },
+    pause() { /* CSS tremor freezes with the stage's .suspended rule; timers are the game's */ },
+    resume() { /* nothing to rebuild */ },
+    /** The class is over: fade everything, never snap; nothing may punch again. */
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      unwatchStage();
+      if (started) everythingOff();
+    },
+    destroy() {
+      if (destroyed) return;
+      api.stop();
+      destroyed = true;
+      unwatchStage();
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      clearChrome();
+      present.clear();
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, out: outOn, rung, hystPending: !!hystTimer, hystTarget,
+        heat, progress, streak, surge: +surgeFor(progress, streak).toFixed(3),
+        features: Array.from(present), tremorPx: +tremorAmp.toFixed(3), chrome: chrome.length,
+        beats, punches, fires: Object.assign({}, fires), timers: live.size, stageWatch: !!stageWatch,
+      };
+    },
+  };
+  return api;
+}
+
+export default createIrPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/style.js
@@ -1,0 +1,416 @@
+/* ============================================================================
+ * games/instant-recall/style.js - the game injects its OWN stylesheet from JS.
+ *
+ * THE LECTURE HALL AT NIGHT. The class root is a full-viewport stage: a dark
+ * hall, rows of empty seats sketched along the bottom, one projector beam
+ * falling from above onto THE SCREEN - and the screen IS the montage. Nothing
+ * here decorates a tile: the montage is CORE's live window (many animated
+ * tiles) and the PERF LAW for this class is absolute - no filter, no animation,
+ * no per-frame paint on `.g-ir-tile` or its media. Everything that breathes
+ * lives on chrome: the beam, the dust, the seats, the frame, the slip.
+ *
+ * Composition, exactly the DOM contract (CORE builds, this file styles):
+ *
+ *   .g-ir-stage[data-phase=briefing|vigil|stop|verdict|ended]
+ *               [data-layout=rows|mosaic|swirl]   absolute inset:0, explicit
+ *               ground, padded under the shell's proctor strip
+ *   .g-ir-backdrop   the hall (pointer-events:none, z 0) - the casino hangs its
+ *                    beam / dust / seat layers here
+ *   .g-ir-hud        three chips: clock, stops, density (the density chip is a
+ *                    METER: it reads --ir-density 0..1 when CORE paints it,
+ *                    and degrades to a plain chip when it does not)
+ *   .g-ir-montage    THE SCREEN: flex:1, the lit rectangle; children are rows
+ *                    (.g-ir-row > .g-ir-tile > .g-ir-face > .g-ir-media) or a
+ *                    .g-ir-mosaic grid or a .g-ir-swirl field (montage.js writes
+ *                    --ir-ang / --ir-rad / --ir-orbit; this file owns the swirl
+ *                    transform, with CSS trig - no JS moves a tile, ever)
+ *   .g-ir-ledger     the truth tail - VISUALLY hidden, aria-hidden (CORE)
+ *   .g-ir-stop       THE EXAM SLIP: a paper card that arrives from the desk
+ *                    while the screen holds its breath; .g-ir-q the question,
+ *                    .g-ir-opts > .g-ir-opt[data-i] four real buttons (1-4
+ *                    keycaps drawn from data-i), .g-ir-timer the answer ring
+ *                    (reads --ir-left 1..0 from CORE; --ir-t is the old name)
+ *   .g-ir-msg / .g-ir-flashwell / .g-ir-end   proctor line, engine anchor, the
+ *                    end card (title + k/v rows, DE's shape)
+ *   .g-ir-howto      the drawn class-rules sheet (Deck VI, Law IV): three
+ *                    vignettes (the screen flickers / the freeze and the slip /
+ *                    the four keycaps) and ONE live button, .g-ir-go - all
+ *                    CORE class names (.g-ir-howto-*), art = pure CSS pseudos
+ *
+ * THE FREEZE IS A HELD BREATH. [data-phase="stop"]: the montage's own opacity
+ * drops (no filter - a composited opacity on the container is free), the
+ * hall's veil (.g-ir-veil, a sibling of the screen, not a filter) darkens, the
+ * beam narrows, the slip slides up with a paper tilt. [data-phase="verdict"]
+ * keeps the slip and lets the picked option settle. Resume releases all of it
+ * on the same transitions, so the breath goes out as it came in.
+ *
+ * REDUCED MOTION twice over (html.arc-reduced + the media query): every
+ * keyframe dies, transitions survive (a fade is not motion).
+ * .g-ir-stage.suspended freezes every animation (animation-play-state) so
+ * CORE can hold the hall with the class.
+ *
+ * DECK STYLES live in their own sheets: casino.js (g-ir-casino-style),
+ * trickster.js (g-ir-trickster-style), pressure.js (g-ir-pressure-style).
+ * This file is the hall; they are the lights, the lies and the weather.
+ * ==========================================================================*/
+
+const STYLE_ID = 'g-ir-style';
+
+export const STYLE_TEXT = `
+/* ---- registered decoration props: numbers interpolate, so the casino's
+   identity MORPHS instead of snapping ------------------------------------- */
+@property --ir-n-beam{syntax:'<number>';inherits:true;initial-value:.55}
+@property --ir-n-veil{syntax:'<number>';inherits:true;initial-value:0}
+@property --ir-density{syntax:'<number>';inherits:true;initial-value:0}
+@property --ir-t{syntax:'<number>';inherits:false;initial-value:1}
+@property --ir-left{syntax:'<number>';inherits:false;initial-value:1}
+@property --ir-hw-k{syntax:'<angle>';inherits:false;initial-value:300deg}
+
+/* ---- the stage: the whole window is the hall ------------------------------ */
+.g-ir-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
+  align-items:center;gap:8px;padding:72px 18px 14px;color:var(--ink);
+  --ir-hue-a:var(--ir-n-hue-a,292);
+  --ir-hue-b:var(--ir-n-hue-b,330);
+  --ir-la:hsla(var(--ir-hue-a),55%,70%,.18);
+  --ir-lb:hsla(var(--ir-hue-b),70%,68%,.14);
+  --ir-breath:var(--ir-n-breath,9s);
+  --ir-screen-w:min(100%, 1120px);
+  background:
+    radial-gradient(80% 46% at 50% 0%, var(--ir-la), transparent 70%),
+    radial-gradient(120% 40% at 50% 108%, var(--ir-lb), transparent 64%),
+    color-mix(in srgb, var(--ground), black 46%)}
+.g-ir-stage.suspended *{animation-play-state:paused !important}
+
+/* ---- the backdrop: the hall itself (decoration only) ---------------------- */
+.g-ir-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+.g-ir-backdrop *{pointer-events:none}
+/* the projector beam: a cone from the ceiling, breathing; narrows for a stop */
+.g-ir-backdrop::before{content:"";position:absolute;left:50%;top:-6%;width:140%;height:92%;
+  transform:translateX(-50%);
+  background:conic-gradient(from 180deg at 50% 0%, transparent 0deg, transparent 156deg,
+    hsla(var(--ir-hue-a),70%,82%,calc(var(--ir-n-beam) * .4)) 164deg,
+    hsla(var(--ir-hue-b),80%,88%,calc(var(--ir-n-beam) * .62)) 180deg,
+    hsla(var(--ir-hue-a),70%,82%,calc(var(--ir-n-beam) * .4)) 196deg,
+    transparent 204deg, transparent 360deg);
+  -webkit-mask:linear-gradient(180deg, #000 0%, rgba(0,0,0,.7) 55%, transparent 100%);
+  mask:linear-gradient(180deg, #000 0%, rgba(0,0,0,.7) 55%, transparent 100%);
+  opacity:.9;animation:g-ir-beam var(--ir-breath) ease-in-out infinite alternate;
+  transition:transform 1.4s ease, opacity 1.4s ease}
+@keyframes g-ir-beam{from{opacity:.72;transform:translateX(-50%) scaleX(1)}to{opacity:1;transform:translateX(-50%) scaleX(1.08)}}
+/* the seats: tiered arcs of dim silhouettes along the floor */
+.g-ir-backdrop::after{content:"";position:absolute;left:-10%;right:-10%;bottom:-2%;height:34%;
+  background:
+    repeating-radial-gradient(ellipse 120% 200% at 50% 130%,
+      rgba(0,0,0,0) 0 6.2%, rgba(0,0,0,.55) 6.2% 7.2%, rgba(40,36,70,.35) 7.2% 7.6%, rgba(0,0,0,0) 7.6% 9%),
+    linear-gradient(180deg, transparent, rgba(0,0,0,.62));
+  opacity:.85}
+
+/* ---- the HUD: three chips on the lectern ---------------------------------- */
+.g-ir-hud{position:relative;z-index:2;display:flex;flex-wrap:wrap;align-items:center;justify-content:center;
+  gap:8px;width:var(--ir-screen-w)}
+.g-ir-chip{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+  font-family:var(--mono);font-size:11.5px;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ink-dim);background:color-mix(in srgb, var(--panel), transparent 20%);
+  border:1px solid color-mix(in srgb, var(--line), transparent 20%);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.04), 0 4px 14px rgba(0,0,0,.35);
+  font-variant-numeric:tabular-nums;white-space:nowrap;position:relative;overflow:hidden}
+.g-ir-clock{color:var(--ink)}
+.g-ir-stops{color:var(--lav)}
+/* the density METER: a bar that fills behind the chip's text from --ir-density
+   (CORE paints it on the chip or the stage); plain chip when it is never set */
+.g-ir-density{padding-left:30px}
+.g-ir-density::before{content:"";position:absolute;left:10px;top:50%;width:14px;height:14px;margin-top:-7px;
+  border-radius:50%;background:conic-gradient(var(--pink) calc(var(--ir-density) * 360deg), rgba(255,255,255,.08) 0);
+  -webkit-mask:radial-gradient(circle, transparent 3.5px, #000 4px);mask:radial-gradient(circle, transparent 3.5px, #000 4px);
+  transition:--ir-density .6s ease}
+.g-ir-density::after{content:"";position:absolute;left:0;bottom:0;height:2px;width:calc(var(--ir-density) * 100%);
+  background:linear-gradient(90deg, var(--lav), var(--pink));opacity:.8;transition:width .6s ease}
+
+/* ---- THE SCREEN: the montage is the lit rectangle --------------------------- */
+.g-ir-montage{position:relative;z-index:1;flex:1;min-height:0;width:var(--ir-screen-w);
+  display:flex;flex-direction:column;gap:6px;padding:6px;border-radius:14px;overflow:hidden;
+  background:color-mix(in srgb, var(--ground), black 30%);
+  border:1px solid color-mix(in srgb, var(--lav), transparent 72%);
+  box-shadow:0 0 0 1px rgba(0,0,0,.6), 0 24px 60px rgba(0,0,0,.55),
+    0 0 60px hsla(var(--ir-hue-b),80%,70%,.12);
+  opacity:1;transition:opacity .55s ease, box-shadow .8s ease}
+/* the screen's own vignette + scanline whisper - on the CONTAINER's pseudo, never a tile */
+.g-ir-montage::after{content:"";position:absolute;inset:0;pointer-events:none;z-index:5;border-radius:inherit;
+  background:radial-gradient(120% 90% at 50% 50%, transparent 62%, rgba(0,0,0,.45) 100%)}
+/* ROWS: montage.js builds .g-ir-row (odd rows .g-ir-rev) > .g-ir-tile; the
+   engine's row_drift writes the row transform, so this file never does */
+.g-ir-row{position:relative;display:flex;gap:6px;flex:1 1 0;min-height:0;will-change:transform}
+.g-ir-row.g-ir-rev{flex-direction:row-reverse}
+/* MOSAIC: a grid solved from --ir-cols (montage.js) */
+.g-ir-mosaic{position:relative;flex:1;min-height:0;display:grid;gap:6px;
+  grid-template-columns:repeat(var(--ir-cols,6), minmax(0,1fr));grid-auto-rows:minmax(0,1fr)}
+/* SWIRL: montage.js writes --ir-ang (deg) / --ir-rad (% of the half-screen) /
+   --ir-orbit (0 centre .. 1 rim) on every tile; THIS FILE owns the transform.
+   Positioned with CSS trig so no JS ever moves a tile; the wheel wash behind
+   (engine, held by CORE) is the motion. Tiles shrink toward the centre. */
+.g-ir-swirl{position:relative;flex:1;min-height:0;overflow:hidden;--ir-swirl-tile:clamp(64px, 13%, 160px)}
+.g-ir-swirl .g-ir-tile{position:absolute;flex:none;
+  left:calc(50% + cos(var(--ir-ang,0deg)) * var(--ir-rad,50%) * .5);
+  top:calc(50% + sin(var(--ir-ang,0deg)) * var(--ir-rad,50%) * .5);
+  width:calc(var(--ir-swirl-tile) * (.55 + .55 * var(--ir-orbit,.5)));aspect-ratio:1;height:auto;
+  transform:translate(-50%,-50%) rotate(calc(var(--ir-ang,0deg) * .08))}
+.g-ir-tile{position:relative;flex:1 1 0;min-width:0;min-height:0;border-radius:8px;overflow:hidden;
+  background:color-mix(in srgb, var(--panel), black 40%);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.04)}
+/* the face + the media fill the tile; NO filter, NO animation, NO transition
+   on any of the three (PERF LAW). .g-ir-face is the engine's only legal target. */
+.g-ir-face{position:absolute;inset:0;overflow:hidden;border-radius:inherit}
+.g-ir-tile img,.g-ir-tile video,.g-ir-media{display:block;position:absolute;inset:0;width:100%;height:100%;
+  object-fit:cover;pointer-events:none}
+.g-ir-montage.is-frozen{opacity:.42}
+
+/* the truth tail: in the tree for the harness, never on the glass */
+.g-ir-ledger{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);
+  white-space:nowrap;opacity:0;pointer-events:none}
+
+/* the veil: the hall's held breath. A sibling the casino mounts in the stage
+   (it never filters the screen - it lies OVER it). Styled here so the phase
+   rule can drive it even when the casino is disarmed (CORE may mount one too). */
+.g-ir-veil{position:absolute;inset:0;z-index:3;pointer-events:none;opacity:0;
+  background:radial-gradient(70% 60% at 50% 45%, rgba(8,6,20,.25), rgba(8,6,20,.82) 100%);
+  transition:opacity .6s ease}
+
+/* ---- THE EXAM SLIP ---------------------------------------------------------- */
+.g-ir-stop{position:absolute;left:50%;top:50%;z-index:7;width:min(560px, 92%);
+  transform:translate(-50%,-44%) rotate(.6deg);opacity:0;pointer-events:none;
+  display:flex;flex-direction:column;gap:12px;padding:20px 22px 18px;border-radius:6px;
+  color:#1d1a2e;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,.35), transparent 30%),
+    repeating-linear-gradient(180deg, transparent 0 26px, rgba(90,60,140,.08) 26px 27px),
+    linear-gradient(160deg, #f6efe2, #ece2d2 70%, #e2d6c4);
+  border:1px solid rgba(60,40,90,.25);
+  box-shadow:0 30px 70px rgba(0,0,0,.6), 0 2px 0 rgba(255,255,255,.5) inset,
+    0 0 0 3px rgba(255,255,255,.06)}
+/* CORE shows the slip by flipping .hidden (the shell's own rule), so the arrival
+   is an ANIMATION, not a transition - it plays fresh every time the node returns */
+@keyframes g-ir-slipin{from{opacity:0;transform:translate(-50%,-44%) rotate(.6deg)}to{opacity:1;transform:translate(-50%,-50%) rotate(-.4deg)}}
+/* the tape + the seal are decoration: pointer-events:none and UNDER the options
+   (Law II - nothing decorative may sit between a finger and a button) */
+.g-ir-stop::before{content:"";position:absolute;left:14px;top:-7px;width:54px;height:14px;border-radius:2px;z-index:0;pointer-events:none;
+  background:rgba(255,105,180,.55);transform:rotate(-4deg);box-shadow:0 1px 3px rgba(0,0,0,.25)}
+.g-ir-stop::after{content:"";position:absolute;right:16px;bottom:14px;width:54px;height:54px;border-radius:50%;z-index:0;pointer-events:none;
+  border:2px dashed rgba(212,72,143,.45);opacity:.55;transform:rotate(-12deg)}
+.g-ir-stage[data-phase="stop"] .g-ir-stop,.g-ir-stage[data-phase="verdict"] .g-ir-stop{
+  opacity:1;pointer-events:auto;transform:translate(-50%,-50%) rotate(-.4deg);
+  animation:g-ir-slipin .42s cubic-bezier(.2,.9,.25,1.05) 1}
+.g-ir-stage[data-phase="stop"] .g-ir-montage,.g-ir-stage[data-phase="verdict"] .g-ir-montage{opacity:.42;
+  box-shadow:0 0 0 1px rgba(0,0,0,.6), 0 24px 60px rgba(0,0,0,.7)}
+.g-ir-stage[data-phase="stop"] .g-ir-veil,.g-ir-stage[data-phase="verdict"] .g-ir-veil{opacity:1}
+.g-ir-stage[data-phase="stop"] .g-ir-backdrop::before,.g-ir-stage[data-phase="verdict"] .g-ir-backdrop::before{
+  transform:translateX(-50%) scaleX(.55);opacity:.5}
+.g-ir-q{position:relative;z-index:1;margin:0;font-family:var(--disp);font-size:clamp(15px,2.3vmin,21px);letter-spacing:.04em;line-height:1.3;
+  color:#2a2144;text-shadow:0 1px 0 rgba(255,255,255,.6)}
+.g-ir-q::before{content:"";display:inline-block;width:10px;height:10px;margin:0 10px 1px 0;border-radius:50%;
+  background:var(--pink);box-shadow:0 0 10px rgba(255,105,180,.6)}
+.g-ir-opts{position:relative;z-index:1;display:grid;grid-template-columns:1fr 1fr;gap:10px;margin:0;padding:0;list-style:none}
+.g-ir-opt{position:relative;display:flex;align-items:center;gap:12px;min-height:52px;padding:10px 12px 10px 52px;
+  border-radius:8px;text-align:left;cursor:pointer;font:600 14px/1.3 var(--body);color:#241d3a;
+  background:linear-gradient(180deg, rgba(255,255,255,.55), rgba(255,255,255,.18));
+  border:1px solid rgba(60,40,90,.28);box-shadow:0 2px 0 rgba(60,40,90,.18);
+  transition:transform .14s ease, box-shadow .2s ease, background .2s ease}
+.g-ir-opt:hover{transform:translateY(-1px);box-shadow:0 4px 10px rgba(60,40,90,.22)}
+.g-ir-opt:focus-visible{outline:2px solid var(--pink);outline-offset:2px}
+.g-ir-opt:active{transform:translateY(1px);box-shadow:0 0 0 rgba(0,0,0,0)}
+/* the keycap is CORE's .g-ir-opt-n span (1-4) drawn as a key - Law IV, the glyph
+   is the truth; .g-ir-opt-t is the label the trickster may repaint */
+.g-ir-opt-n{position:absolute;left:10px;top:50%;width:30px;height:30px;margin-top:-15px;
+  display:flex;align-items:center;justify-content:center;border-radius:7px;
+  font:800 13px/1 var(--mono);color:var(--ink);
+  background:linear-gradient(180deg, var(--panel2), var(--navy));
+  border:1px solid var(--line);border-bottom-width:3px;box-shadow:0 2px 0 rgba(0,0,0,.45);pointer-events:none}
+.g-ir-opt-t{flex:1 1 auto;min-width:0}
+/* the audition button for sting options: a real button that NEVER selects */
+.g-ir-hear{flex:0 0 auto;margin-left:auto;padding:5px 9px;border-radius:999px;cursor:pointer;
+  font:700 10px/1 var(--mono);letter-spacing:.12em;text-transform:uppercase;color:#3b2a5a;
+  background:rgba(184,166,232,.35);border:1px solid rgba(90,60,140,.35)}
+.g-ir-hear:hover{background:rgba(184,166,232,.55)}
+.g-ir-hear:focus-visible{outline:2px solid var(--pink);outline-offset:1px}
+.g-ir-opt img,.g-ir-opt video{display:block;width:44px;height:44px;object-fit:cover;border-radius:6px;pointer-events:none}
+.g-ir-opt.is-picked,.g-ir-opt[aria-pressed="true"]{background:linear-gradient(180deg, rgba(255,105,180,.28), rgba(255,105,180,.12));
+  border-color:rgba(212,72,143,.6)}
+.g-ir-opt.is-true,.g-ir-opt.is-correct,.g-ir-opt.is-truth,.g-ir-opt[data-verdict="correct"]{
+  background:linear-gradient(180deg, rgba(240,194,75,.4), rgba(240,194,75,.14));border-color:rgba(200,150,40,.7);
+  box-shadow:0 0 0 2px rgba(240,194,75,.35), 0 0 18px rgba(240,194,75,.35)}
+.g-ir-opt.is-wrong,.g-ir-opt[data-verdict="wrong"]{background:linear-gradient(180deg, rgba(120,60,90,.28), rgba(120,60,90,.1));
+  border-color:rgba(120,60,90,.5);color:#5b4a6d;text-decoration:line-through}
+.g-ir-opt:disabled,.g-ir-opt.is-dead{cursor:default;opacity:.85}
+/* the answer ring: a conic face that reads --ir-left (CORE, 1 full -> 0 out;
+   --ir-t is the older name) with the seconds digit on a paper disc in the middle */
+.g-ir-timer{position:absolute;right:-14px;top:-14px;width:44px;height:44px;border-radius:50%;z-index:2;
+  display:flex;align-items:center;justify-content:center;font:800 13px/1 var(--mono);color:#2a2144;
+  background:
+    radial-gradient(circle, #f6efe2 13px, transparent 14px),
+    conic-gradient(var(--pink) calc(var(--ir-left, var(--ir-t)) * 360deg), rgba(60,40,90,.18) 0);
+  box-shadow:0 0 14px rgba(255,105,180,.35);transition:--ir-left .2s linear, --ir-t .2s linear}
+.g-ir-timer:empty{font-size:0}
+.g-ir-timer.is-low,.g-ir-timer[data-low="1"]{animation:g-ir-timer-low .5s ease-in-out infinite alternate}
+@keyframes g-ir-timer-low{from{box-shadow:0 0 10px rgba(255,105,180,.35)}to{box-shadow:0 0 22px rgba(255,105,180,.9)}}
+/* the truth replay: the ledger's last beads on a ribbon, the answer's own moment
+   pinned in gold, a planted decoy struck through - proof, not decoration */
+.g-ir-truth{position:relative;z-index:1;margin:2px 0 0;padding-top:10px;border-top:1px dashed rgba(60,40,90,.3)}
+.g-ir-ribbon{display:flex;flex-wrap:wrap;gap:5px;align-items:center}
+.g-ir-bead{display:inline-flex;align-items:center;max-width:100%;padding:3px 8px;border-radius:999px;
+  font:700 10.5px/1.2 var(--mono);letter-spacing:.08em;text-transform:uppercase;color:#3b2a5a;
+  background:rgba(90,60,140,.12);border:1px solid rgba(90,60,140,.25);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.g-ir-bead[data-ch="sub_flash"],.g-ir-bead[data-ch="word"]{background:rgba(255,105,180,.16);border-color:rgba(212,72,143,.4)}
+.g-ir-bead[data-ch="audio_trigger"],.g-ir-bead[data-ch="sting"]{background:rgba(184,166,232,.22);border-color:rgba(120,100,190,.4)}
+.g-ir-bead[data-ch="layout"]{background:rgba(60,40,90,.1);border-style:dashed}
+.g-ir-bead.is-pin{color:#2a2144;background:linear-gradient(180deg, rgba(240,194,75,.55), rgba(240,194,75,.25));
+  border-color:rgba(200,150,40,.8);box-shadow:0 0 0 2px rgba(240,194,75,.3), 0 0 12px rgba(240,194,75,.4)}
+.g-ir-bead.is-plant{text-decoration:line-through;opacity:.8;border-style:dashed}
+.g-ir-truth-line{margin:8px 0 0;font-size:12px;font-style:italic;color:#4b3f66}
+/* the SHARED shell stamp (.arc-stamp) is inline-block, so appended to the slip it
+   lands as the last flex row. Pin it over the slip's centre instead (no transform:
+   the shell's .pop keyframe owns that property; pointer-events:none is the shell's). */
+.g-ir-stop > .arc-stamp{position:absolute;left:0;right:0;top:42%;margin:0 auto;width:max-content;
+  max-width:90%;z-index:3;text-align:center}
+
+/* ---- proctor line + end card ---------------------------------------------- */
+.g-ir-flashwell{position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:6}
+.g-ir-flashwell *{pointer-events:none}
+.g-ir-msg{position:relative;z-index:2;margin:0;min-height:1.4em;text-align:center;
+  font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ink-dim);transition:opacity .3s ease}
+.g-ir-msg:empty{opacity:0}
+/* the end card: a title + k/v rows (.g-ir-end-row > .g-ir-end-k + .g-ir-end-v);
+   the node IS the panel, centred over the dimmed hall */
+.g-ir-end{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:8;
+  width:min(460px, 92%);display:flex;flex-direction:column;gap:4px;padding:18px 20px 16px;
+  border-radius:16px;background:color-mix(in srgb, var(--navy), transparent 6%);
+  border:1px solid color-mix(in srgb, var(--lav), var(--line) 50%);
+  box-shadow:0 18px 50px rgba(0,0,0,.55), 0 0 34px hsla(var(--ir-hue-b),70%,70%,.25);
+  animation:g-ir-endin .5s ease-out 1}
+@keyframes g-ir-endin{from{opacity:0;transform:translate(-50%,-46%)}to{opacity:1;transform:translate(-50%,-50%)}}
+.g-ir-end-title{font-family:var(--disp);font-size:16px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;color:var(--ink);text-align:center;text-shadow:0 0 18px color-mix(in srgb, var(--pink), transparent 60%)}
+.g-ir-end-row{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);
+  padding:5px 0;border-bottom:1px dashed color-mix(in srgb, var(--line), transparent 20%)}
+.g-ir-end-k{color:var(--ink-faint)}
+.g-ir-end-v{color:var(--ink);font-variant-numeric:tabular-nums}
+.g-ir-end-best .g-ir-end-v,.g-ir-end-perfect .g-ir-end-v{color:var(--gold);text-shadow:0 0 12px rgba(240,194,75,.45)}
+.g-ir-end-plants .g-ir-end-v{color:var(--lav)}
+.g-ir-end-blank .g-ir-end-v{color:var(--ink-faint);font-style:italic}
+.g-ir-end-line{margin:2px 0 0;font-size:12px;color:var(--ink-dim)}
+.g-ir-end .btn{margin:10px 4px 0}
+
+/* ---- phases ----------------------------------------------------------------- */
+.g-ir-stage[data-phase="briefing"] .g-ir-montage{opacity:.55}
+.g-ir-stage[data-phase="ended"] .g-ir-montage{opacity:.3}
+.g-ir-stage[data-phase="ended"] .g-ir-veil{opacity:1}
+.g-ir-stage[data-phase="ended"] .g-ir-backdrop::before{opacity:.35}
+
+/* ----------------------------------------------------- THE CLASS RULES SHEET */
+/* Deck VI, Law IV: drawn, not told. CORE mounts .g-ir-howto > .g-ir-howto-title,
+   .g-ir-howto-row > 3x .g-ir-howto-card (> .g-ir-howto-art[data-art] + .g-ir-howto-cap),
+   .g-ir-howto-note, .g-ir-go. Every vignette is PURE CSS on the empty art box -
+   no image, no text, nothing to translate. The sheet takes NO pointer events;
+   only the GO button re-enables them for itself. */
+.g-ir-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(640px,92vw);max-height:88vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:6px;padding:22px 24px 20px;border-radius:16px;
+  background:linear-gradient(180deg,rgba(26,26,54,.94),rgba(14,14,32,.96));
+  border:1px solid var(--line);
+  box-shadow:0 30px 80px rgba(0,0,0,.55), 0 0 44px rgba(255,105,180,.10)}
+.g-ir-howto-title{margin:0 0 10px;text-align:center;font-family:var(--disp);font-size:clamp(16px,2.4vmin,20px);
+  letter-spacing:.2em;text-transform:uppercase;color:var(--pink);
+  text-shadow:0 0 22px rgba(255,105,180,.45)}
+.g-ir-howto-row{display:grid;grid-template-columns:repeat(3, minmax(0,1fr));gap:14px}
+.g-ir-howto-card{display:flex;flex-direction:column;gap:8px;min-width:0}
+.g-ir-howto-cap{margin:0;font-size:12px;line-height:1.45;color:var(--ink-dim);text-align:center}
+.g-ir-howto-note{margin:8px 0 0;text-align:center;font-family:var(--mono);font-size:11px;letter-spacing:.12em;
+  text-transform:uppercase;color:var(--lav)}
+/* the little screen: a lit rectangle every vignette is set on */
+.g-ir-howto-art{position:relative;width:100%;aspect-ratio:5/3;border-radius:8px;overflow:hidden;
+  background:#0c0b1c;border:1px solid rgba(184,166,232,.35);box-shadow:0 0 14px rgba(184,166,232,.18)}
+.g-ir-howto-art::before,.g-ir-howto-art::after{content:"";position:absolute;pointer-events:none}
+/* 1 - the stream: six tiles breathing on their own beat, a flash popping over them */
+.g-ir-howto-art[data-art="stream"]::before,.g-ir-howto-art[data-art="freeze"]::before{inset:8px 10px;
+  background:linear-gradient(135deg, var(--pink), var(--lav) 55%, var(--gold));
+  -webkit-mask:linear-gradient(#000 0 0) 0 0/31% 46% space;mask:linear-gradient(#000 0 0) 0 0/31% 46% space;
+  animation:g-ir-hw-blink 2.4s ease-in-out infinite}
+@keyframes g-ir-hw-blink{0%,100%{opacity:.45}50%{opacity:.95}}
+.g-ir-howto-art[data-art="stream"]::after{left:50%;top:50%;width:46%;height:28%;transform:translate(-50%,-50%) scale(.8);border-radius:4px;
+  background:linear-gradient(90deg, transparent, rgba(255,255,255,.95) 20% 80%, transparent);
+  -webkit-mask:repeating-linear-gradient(90deg, #000 0 9%, transparent 9% 13%);mask:repeating-linear-gradient(90deg, #000 0 9%, transparent 9% 13%);
+  box-shadow:0 0 16px var(--pink);opacity:0;animation:g-ir-hw-word 2.4s ease-out infinite}
+@keyframes g-ir-hw-word{0%,62%{opacity:0;transform:translate(-50%,-50%) scale(.8)}68%{opacity:1;transform:translate(-50%,-50%) scale(1.05)}
+  80%{opacity:1}90%,100%{opacity:0}}
+/* 2 - the freeze: the tiles go dark and a slip rises from the desk */
+.g-ir-howto-art[data-art="freeze"]::before{animation:g-ir-hw-dim 3s ease-in-out infinite}
+@keyframes g-ir-hw-dim{0%,35%{opacity:.9}50%,100%{opacity:.25}}
+.g-ir-howto-art[data-art="freeze"]::after{left:50%;bottom:-6px;width:46%;height:52%;transform:translate(-50%,60%) rotate(2deg);
+  border-radius:3px;border:1px solid rgba(60,40,90,.3);box-shadow:0 8px 18px rgba(0,0,0,.6);
+  background:
+    linear-gradient(rgba(42,33,68,.55) 0 0) 14% 28%/46% 8% no-repeat,
+    linear-gradient(rgba(42,33,68,.3) 0 0) 14% 52%/62% 8% no-repeat,
+    linear-gradient(rgba(42,33,68,.3) 0 0) 14% 74%/40% 8% no-repeat,
+    linear-gradient(160deg,#f6efe2,#e2d6c4);
+  opacity:0;animation:g-ir-hw-slip 3s cubic-bezier(.2,.9,.25,1.05) infinite}
+@keyframes g-ir-hw-slip{0%,38%{opacity:0;transform:translate(-50%,60%) rotate(2deg)}52%{opacity:1;transform:translate(-50%,6%) rotate(-1deg)}
+  92%{opacity:1;transform:translate(-50%,6%) rotate(-1deg)}100%{opacity:0}}
+/* 3 - the answer: four keycaps, one lit, the slip's ring running down */
+.g-ir-howto-art[data-art="answer"]::before{left:12%;top:22%;width:44%;height:56%;
+  background:
+    radial-gradient(circle at 25% 25%, rgba(255,105,180,.9) 0 14%, transparent 15%) 0 0/100% 100% no-repeat,
+    linear-gradient(180deg, var(--panel2), var(--navy));
+  -webkit-mask:linear-gradient(#000 0 0) 0 0/44% 44% space;mask:linear-gradient(#000 0 0) 0 0/44% 44% space;
+  border-radius:4px;animation:g-ir-hw-press 2.6s ease-in-out infinite}
+@keyframes g-ir-hw-press{0%,60%{transform:translateY(0)}68%{transform:translateY(2px)}82%,100%{transform:translateY(0)}}
+.g-ir-howto-art[data-art="answer"]::after{right:12%;top:50%;width:30%;aspect-ratio:1;transform:translateY(-50%);border-radius:50%;
+  background:conic-gradient(var(--pink) 0deg, var(--pink) var(--ir-hw-k), rgba(255,255,255,.08) 0);
+  -webkit-mask:radial-gradient(circle, transparent 38%, #000 42%);mask:radial-gradient(circle, transparent 38%, #000 42%);
+  animation:g-ir-hw-ring 2.6s linear infinite}
+@keyframes g-ir-hw-ring{from{--ir-hw-k:360deg}to{--ir-hw-k:0deg}}
+.g-ir-go{margin:14px auto 0;pointer-events:auto;cursor:pointer;padding:10px 26px;border-radius:999px;
+  font:700 13px/1 var(--body);letter-spacing:.14em;text-transform:uppercase;color:#1a1028;
+  background:linear-gradient(180deg, #ffd1ea, var(--pink));border:1px solid rgba(255,255,255,.35);
+  box-shadow:0 0 22px rgba(255,105,180,.5), 0 6px 16px rgba(0,0,0,.45);
+  animation:g-ir-hw-gopulse 1.8s ease-in-out infinite}
+.g-ir-go:focus-visible{outline:2px solid #fff;outline-offset:3px}
+@keyframes g-ir-hw-gopulse{50%{box-shadow:0 0 34px rgba(255,105,180,.85), 0 6px 16px rgba(0,0,0,.45)}}
+@media (max-width: 560px){.g-ir-howto-row{grid-template-columns:1fr}.g-ir-howto-art{max-width:220px;margin:0 auto}}
+
+/* ---- reduced motion (both gates): keyframes die, transitions survive ------- */
+html.arc-reduced .g-ir-stage *{animation:none !important}
+html.arc-reduced .g-ir-howto-art::before,html.arc-reduced .g-ir-howto-art::after{animation:none !important;opacity:1}
+html.arc-reduced .g-ir-howto-art[data-art="freeze"]::after{transform:translate(-50%,6%) rotate(-1deg)}
+html.arc-reduced .g-ir-howto-art[data-art="stream"]::after{transform:translate(-50%,-50%)}
+@media (prefers-reduced-motion: reduce){
+  .g-ir-stage *{animation:none !important}
+  .g-ir-howto-art::before,.g-ir-howto-art::after{animation:none !important;opacity:1}
+  .g-ir-howto-art[data-art="freeze"]::after{transform:translate(-50%,6%) rotate(-1deg)}
+  .g-ir-howto-art[data-art="stream"]::after{transform:translate(-50%,-50%)}
+}
+/* touch: bigger options, no hover lift */
+@media (pointer: coarse){
+  .g-ir-opt{min-height:58px}
+  .g-ir-opt:hover{transform:none}
+}
+`;
+
+/** Inject once per document. No-op headless (the DOM double has no head). */
+export function injectInstantRecallStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return false;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);   // harness shim
+    return true;
+  } catch (e) {
+    return false;      // a stylesheet must never be the thing that fails a class
+  }
+}
+
+export default injectInstantRecallStyle;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/trickster.js
@@ -1,0 +1,786 @@
+/* ============================================================================
+ * games/instant-recall/trickster.js - DECK III of the House Rules, dealt into
+ * THE VIGIL. A recall game is where your own eyes stop being reliable
+ * witnesses, so every card here attacks the READING of the slip and the HUD -
+ * never the ledger, never the options' order, never the window underneath.
+ *
+ *   STAT FLICKER     the stops chip (or the clock) briefly reads one off, then
+ *                    "corrects" with a static pop to the EXACT text it had. The
+ *                    ledger never moves; confidence does. Dealt into the VIGIL
+ *                    (between stops), never onto a live slip.
+ *   CROOKED CLOCK    the answer-window ring's FACE bends: it races through the
+ *                    boring middle (shows less time left than you really have)
+ *                    and crawls as the window runs out, meeting the truth
+ *                    exactly at the last 15% and staying honest from there.
+ *                    The real window is CORE's timer and untouched; this deck
+ *                    paints an overlay ring of its own over the real face
+ *                    (.g-ir-timer wears .g-ir-tk-bent while ours is up) and
+ *                    never writes --ir-t. The bend is a PURE function, exported.
+ *                    Painted at 8Hz from the game's pause-aware timers (the
+ *                    PERF LAW's ceiling for JS-driven paint) - reads
+ *                    stats().windowLeftMs / windowMs; folds if CORE never
+ *                    reports them.
+ *   UNRELIABLE LABEL an option's TEXT briefly wears another option's text.
+ *                    The keycap (drawn from data-i by style.js) and the hitbox
+ *                    are the truth - Law IV, and the law of this card: the lie
+ *                    SNAPS TO TRUTH BEFORE THE WINDOW'S LAST 40% (it ends by
+ *                    60% of the window, with a margin), so the honest read is
+ *                    always on the glass while the ring is low. Restores the
+ *                    EXACT string it read; if CORE repainted the option under
+ *                    the lie, the restore stands down instead of stomping it.
+ *   GHOST CURSOR     (tier 3+, mouse only) a faint cursor echo trails the real
+ *                    pointer by ~430ms during a stop, and after a ~600ms stall
+ *                    it stops trailing and DRIFTS toward an option the house
+ *                    prefers - a WRONG one when CORE tells us the truth
+ *                    (stats().truth = the true data-i), else the one farthest
+ *                    from the hand. Pure suggestion: pointer-events none, it
+ *                    cannot click, the real cursor is never hidden, it dies on
+ *                    the answer.
+ *   DECOY PLANTS     are NATIVE to CORE (SetPiece-gated sub_flash / audio over
+ *                    the freeze). Nothing here; casino.plantResisted() pays the
+ *                    resist.
+ *
+ * DEALING RULE: card slots are dealt at start() from the seeded plan: budget
+ * 2/4/6/8 by tier, at most 4 in any rolling 60s, a 4s floor between two cards.
+ * A VIGIL card (flicker) is dealt at a seeded time inside the class, never in
+ * the first 8s or the last 12s, and re-queues politely (then folds) if its
+ * moment arrives halted or on a live slip. A STOP card (label / clock / ghost)
+ * is dealt to a seeded STOP ORDINAL (1-based) and plays from afterStop(); an
+ * ordinal the class never reaches simply folds. Tier 1 deals flicker only;
+ * the clock and the label from tier 2; the ghost from tier 3.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - the flicker writes chip TEXT and restores via chipText
+ *       (the truth source); the label writes .g-ir-opt TEXT and restores the
+ *       string it read (or stands down); the ring is a node this deck owns.
+ *       Nothing reads or writes the ledger, the stops, the streak, the window
+ *       timer, the options' order, data-i or the grade.
+ *   II  input honest  - no card is clickable; the ghost and the ring are
+ *       pointer-events:none; nothing is mounted inside an option; no hitbox
+ *       moves, resizes or is covered by a hit-testing node.
+ *   III never still   - the ghost pulses on the lure, the ring runs.
+ *   IV  images > text - this deck renders NO text of its own and mints no
+ *       lexicon key (the label only re-wears a string the slip already shows).
+ *   V   seeded        - per-tag mulberry32 streams off seed+'|ir-trickster|',
+ *       append-only tags. A retake replays the identical deal.
+ *   VI  exits sacred  - capsOk false disarms the whole deck (no nodes, no
+ *       listener, no timers); reduced motion drops the ghost cursor AND the
+ *       crooked ring entirely (the flicker is a number and the label a string:
+ *       neither is motion); every timer rides the game's registry via
+ *       opts.timers AND a local set; stop() restores every live lie; destroy()
+ *       leaves no node, timer or listener.
+ *   VII strings       - none. This file has no lexicon rows.
+ *   PERF LAW          - nothing here touches .g-ir-tile; the only JS-driven
+ *       paint is the ring at 8Hz and the ghost at 8Hz, both chrome.
+ *
+ * ENGINE PLACEMENT: entirely game-local. `opts.engine` is accepted for
+ * interface symmetry and deliberately unused.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const IR_TRICKSTER = Object.freeze({
+  /** Dealt card slots per class, by tier (the House budget: 2 -> 8). */
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  /** The House's per-minute cap + a floor so two cards never land in one breath. */
+  RATE_WINDOW_MS: 60000,
+  RATE_MAX: 4,
+  MIN_GAP_MS: 4000,
+  /** Vigil cards: never in the first 8s, never in the last 12s. */
+  FIRST_MS: 8000,
+  TAIL_MS: 12000,
+  /** A vigil card whose moment arrives halted / on a slip waits, then folds. */
+  RETRY_MS: 1500,
+  RETRY_MAX: 6,
+  /** Card gates. */
+  LABEL_FROM_TIER: 2,
+  CLOCK_FROM_TIER: 2,
+  GHOST_FROM_TIER: 3,
+  /** Slot weights per tier (renormalised over the eligible cards). */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ flicker: 1, label: 0, clock: 0, ghost: 0 }),
+    2: Object.freeze({ flicker: 0.34, label: 0.36, clock: 0.3, ghost: 0 }),
+    3: Object.freeze({ flicker: 0.22, label: 0.32, clock: 0.22, ghost: 0.24 }),
+    4: Object.freeze({ flicker: 0.2, label: 0.32, clock: 0.22, ghost: 0.26 }),
+  }),
+  /** Stat flicker: how long the wrong number stands. */
+  FLICKER_MS: 420,
+  /** Unreliable label: the lie starts a beat after the slip lands and MUST be
+   *  off before this fraction of the window has elapsed (Law: before the last
+   *  40% - i.e. by 60% - with a margin). */
+  LABEL_START_MS: Object.freeze([240, 600]),
+  LABEL_MS: 700,
+  LABEL_SNAP_FRAC: 0.6,
+  LABEL_SNAP_MARGIN_MS: 150,
+  /** The window fallback by tier when stats() carries no windowMs. */
+  WINDOW_FALLBACK_MS: Object.freeze({ 1: 6000, 2: 6000, 3: 5000, 4: 4000 }),
+  /** The crooked ring: how far the face runs ahead at mid-window, and the
+   *  honest tail (the last 15% is the truth, to the pixel). */
+  RING_BEND: 0.16,
+  RING_HONEST: 0.15,
+  RING_RAMP: 0.32,
+  RING_TICK_MS: 125,                          // 8Hz - the PERF LAW ceiling
+  /** The ghost: trail lag, stall before the lure, lure easing, tick (8Hz). */
+  GHOST_TRAIL_MS: 430,
+  GHOST_TRAIL_KEEP_MS: 1400,
+  GHOST_STALL_MS: 600,
+  GHOST_LERP: 0.18,
+  GHOST_TICK_MS: 125,
+});
+
+const STYLE_ID = 'g-ir-trickster-style';
+const STYLE_TEXT = `
+/* CROOKED CLOCK: an overlay ring on the slip over the real face. It reads
+   --ir-tk-k (1 full -> 0 out), written at 8Hz by the deck; the real .g-ir-timer
+   steps aside ONLY while ours is up. */
+.g-ir-tk-ring{position:absolute;right:-14px;top:-14px;width:44px;height:44px;border-radius:50%;pointer-events:none;opacity:0;
+  background:conic-gradient(var(--pink) calc(var(--ir-tk-k,1) * 360deg), rgba(60,40,90,.18) 0);
+  -webkit-mask:radial-gradient(circle, transparent 13px, #000 14px);mask:radial-gradient(circle, transparent 13px, #000 14px);
+  box-shadow:0 0 14px rgba(255,105,180,.35);z-index:3}
+.g-ir-tk-ring.is-on{opacity:1}
+.g-ir-timer.g-ir-tk-bent{opacity:0}
+
+/* GHOST CURSOR: a will-o-wisp echo of the player's own hand. It cannot click,
+   it never hides the real cursor, and it dies on the answer. */
+.g-ir-tk-ghost{position:absolute;left:0;top:0;width:15px;height:19px;opacity:0;pointer-events:none;z-index:9;
+  will-change:transform;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, rgba(255,105,180,.9), rgba(184,166,232,.55));
+  filter:drop-shadow(0 0 6px rgba(255,105,180,.6));
+  transition:transform .3s ease-out, opacity .38s ease}
+.g-ir-tk-ghost.is-on{opacity:.32}
+.g-ir-tk-ghost.is-lure{opacity:.55;animation:g-ir-tk-ghostpulse 1.5s ease-in-out infinite}
+@keyframes g-ir-tk-ghostpulse{50%{filter:drop-shadow(0 0 12px rgba(255,105,180,.95))}}
+
+/* STAT FLICKER: the static pop the wrong number corrects itself with. */
+.g-ir-chip.g-ir-tk-flick{text-shadow:0 0 22px rgba(184,166,232,.75), 0 0 3px rgba(255,255,255,.5);
+  animation:g-ir-tk-static .16s steps(3) 2}
+@keyframes g-ir-tk-static{0%{filter:none}40%{filter:brightness(1.5) contrast(1.4)}100%{filter:none}}
+/* UNRELIABLE LABEL: a shiver while the wrong words are worn (the keycap is still) */
+.g-ir-opt.g-ir-tk-lie{animation:g-ir-tk-shiver .5s ease-in-out infinite}
+@keyframes g-ir-tk-shiver{0%,100%{text-shadow:none}50%{text-shadow:0 0 8px rgba(184,166,232,.6)}}
+
+@media (prefers-reduced-motion: reduce){
+  .g-ir-tk-ring{opacity:0 !important}
+  .g-ir-timer.g-ir-tk-bent{opacity:1}
+  .g-ir-tk-ghost{opacity:0 !important;animation:none}
+  .g-ir-chip.g-ir-tk-flick,.g-ir-opt.g-ir-tk-lie{animation:none}
+}
+html.arc-reduced .g-ir-tk-ring{opacity:0 !important}
+html.arc-reduced .g-ir-timer.g-ir-tk-bent{opacity:1}
+html.arc-reduced .g-ir-tk-ghost{opacity:0 !important;animation:none}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clampTier(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/**
+ * The crooked face, pure: the SHOWN fraction-left for a TRUE fraction-left.
+ * f(1)=1, f(honest)=honest, monotonic (bend*pi < 1), honest at/after the
+ * honest tail. Ahead through the middle (less time shown than real), crawling
+ * as the window runs out, so the face meets the truth instead of snapping.
+ */
+export function bendRing(trueLeft, bend, honest) {
+  const x = clamp01(trueLeft);
+  const H = Number.isFinite(honest) ? honest : IR_TRICKSTER.RING_HONEST;
+  if (x <= H || x >= 1) return x;
+  const A0 = Number.isFinite(bend) ? bend : IR_TRICKSTER.RING_BEND;
+  const ramp = clamp01((x - H) / IR_TRICKSTER.RING_RAMP);
+  const A = A0 * ramp * ramp * (3 - 2 * ramp);
+  return Math.max(H, x - A * Math.sin(Math.PI * x));
+}
+/** When the label lie must be OFF (ms after the slip landed). Pure. */
+export function labelSnapDeadline(windowMs) {
+  const w = Math.max(1000, Number(windowMs) || 0);
+  return Math.round(w * IR_TRICKSTER.LABEL_SNAP_FRAC - IR_TRICKSTER.LABEL_SNAP_MARGIN_MS);
+}
+
+function el(tag, cls, parent) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (parent && parent.appendChild) parent.appendChild(n);
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function probeCoarse() {
+  try { return typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches; } catch (e) { return false; }
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier, timers {after,every,clear}, reduced, capsOk (bool | fn), isHalted () => bool,
+ *   t (unused - no strings), stats () => {secLeft, budgetSec?, stops, stopsTotal|total, streak,
+ *   inStop|frozen, windowMs?, windowLeftMs?, truth?}, windowLeft? () => ms (CORE's live
+ *   accessor), chipEl (which: clock|stops|density|timer) => el, chipText (which) => string,
+ *   optEls () => el[], optText (i) => string, stopEl?, stage?, announce?, log.
+ *   Without stopEl the slip is FOUND from chipEl('timer') / option 0 (CORE hands neither
+ *   stopEl nor stage).
+ */
+export function createIrTrickster(o) {
+  const opts = o || {};
+  const K = IR_TRICKSTER;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const tier = clampTier(opts.tier);
+  const reduced = !!opts.reduced;
+  const coarse = probeCoarse();
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const chipEl = typeof opts.chipEl === 'function' ? opts.chipEl : () => null;
+  const chipText = typeof opts.chipText === 'function' ? opts.chipText : () => null;
+  const optEls = typeof opts.optEls === 'function' ? opts.optEls : () => [];
+  const optText = typeof opts.optText === 'function' ? opts.optText : () => null;
+  const windowLeftFn = typeof opts.windowLeft === 'function' ? opts.windowLeft : null;
+  /** THE SLIP. CORE hands no stopEl: it is found from the handles it does hand
+   *  over - the real timer (chipEl('timer')) sits inside it, so does option 0. */
+  function stopHost() {
+    if (opts.stopEl) return opts.stopEl;
+    try { const tm = chipEl('timer'); if (tm && tm.parentNode) return tm.parentNode; } catch (e) { /* noop */ }
+    try {
+      const els = optEls() || [];
+      const b = els[0];
+      if (b && typeof b.closest === 'function') { const h = b.closest('.g-ir-stop'); if (h) return h; }
+      if (b && b.parentNode && b.parentNode.parentNode) return b.parentNode.parentNode;
+    } catch (e) { /* noop */ }
+    try {
+      const c = chipEl('clock');
+      if (c && typeof c.closest === 'function') { const st = c.closest('.g-ir-stage'); if (st && st.querySelector) { const h = st.querySelector('.g-ir-stop'); if (h) return h; } }
+    } catch (e) { /* noop */ }
+    return opts.stage || null;
+  }
+  /** ms left in the live window, from stats() or CORE's accessor; null when unknown. */
+  function winLeftMs() {
+    try { const st = stats(); if (st && Number.isFinite(Number(st.windowLeftMs))) return Number(st.windowLeftMs); } catch (e) { /* noop */ }
+    if (windowLeftFn) { try { const v = Number(windowLeftFn()); if (Number.isFinite(v)) return v; } catch (e) { /* noop */ } }
+    return null;
+  }
+  function capsOkNow() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  const armed = capsOkNow() && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+
+  /* ---- timers: the game's registry + a local set ---------------------- */
+  const live = new Set();
+  const chains = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  let destroyed = false;
+  let stopped = false;
+  function after(ms, fn) {
+    if (!armed || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function every(ms, fn) {
+    if (!armed || destroyed) return 0;
+    if (typeof opts.timers.every === 'function') {
+      const id = opts.timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => { if (!handle.on || destroyed) return; try { fn(); } catch (e) { /* ignore */ } handle.id = after(ms, tick); };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+  function cancelAll() {
+    for (const id of Array.from(live)) cancel(id);
+    live.clear();
+    for (const h of Array.from(chains)) stopEvery(h);
+  }
+
+  /* ---- seeded streams (Law V; append-only tags) ----------------------- */
+  const seedBase = String(opts.seed || 'ir') + '|ir-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  const fired = { flicker: 0, label: 0, clock: 0, ghost: 0, lure: 0, folded: 0 };
+  const fireTimes = [];                 // rolling per-minute cap
+  function rateOk() {
+    const t = nowMs();
+    while (fireTimes.length && t - fireTimes[0] > K.RATE_WINDOW_MS) fireTimes.shift();
+    if (fireTimes.length >= K.RATE_MAX) return false;
+    if (fireTimes.length && t - fireTimes[fireTimes.length - 1] < K.MIN_GAP_MS) return false;
+    return true;
+  }
+  function mark() { fireTimes.push(nowMs()); }
+
+  /* ------------------------------------------------------------- the deal */
+  let plan = [];
+  let stopOrdinal = 0;               // stops seen so far (1-based after the first)
+  let inStop = false;
+  let stopAt = 0;                    // nowMs when the slip landed
+  let windowNow = 0;
+  function windowFallback() { return K.WINDOW_FALLBACK_MS[tier] || 5000; }
+  function stopsTotalGuess() {
+    try { const s = stats(); if (s && Number(s.stopsTotal) > 0) return Number(s.stopsTotal); if (s && Number(s.total) > 0) return Number(s.total); } catch (e) { /* noop */ }
+    return ({ 1: 2, 2: 3, 3: 4, 4: 3 })[tier] || 3;
+  }
+  function budgetMs() {
+    try { const s = stats(); if (s && Number(s.budgetSec) > 0) return Number(s.budgetSec) * 1000; } catch (e) { /* noop */ }
+    return 120000;
+  }
+  function buildPlan() {
+    const n = K.DEALS[tier] || 2;
+    const w = K.WEIGHTS[tier] || K.WEIGHTS[1];
+    const eligible = [['flicker', w.flicker], ['label', tier >= K.LABEL_FROM_TIER ? w.label : 0],
+      ['clock', tier >= K.CLOCK_FROM_TIER ? w.clock : 0], ['ghost', tier >= K.GHOST_FROM_TIER && !reduced && !coarse ? w.ghost : 0]];
+    let total = 0;
+    for (const e of eligible) total += e[1];
+    const total_stops = stopsTotalGuess();
+    const span = budgetMs();
+    const usable = Math.max(10000, span - K.FIRST_MS - K.TAIL_MS);
+    const out = [];
+    const stopsUsed = {};              // ordinal -> {label, clock, ghost} one of each per stop at most
+    for (let i = 0; i < n; i++) {
+      let r = roll('card') * total;
+      let card = 'flicker';
+      for (const e of eligible) { r -= e[1]; if (r <= 0 && e[1] > 0) { card = e[0]; break; } }
+      if (card === 'flicker') {
+        out.push({ card, at: Math.round(K.FIRST_MS + roll('when') * usable), ordinal: 0, fired: false });
+      } else {
+        // a stop card: a seeded ordinal; one of each card per stop, else re-roll once then fold to flicker
+        let ord = 1 + Math.floor(roll('ord') * total_stops);
+        if (stopsUsed[ord] && stopsUsed[ord][card]) ord = 1 + Math.floor(roll('ord') * total_stops);
+        if (stopsUsed[ord] && stopsUsed[ord][card]) {
+          out.push({ card: 'flicker', at: Math.round(K.FIRST_MS + roll('when') * usable), ordinal: 0, fired: false });
+          continue;
+        }
+        stopsUsed[ord] = stopsUsed[ord] || {};
+        stopsUsed[ord][card] = true;
+        out.push({ card, at: 0, ordinal: ord, fired: false, delay: Math.round(lerp(K.LABEL_START_MS, roll('delay'))) });
+      }
+    }
+    // vigil cards: sort + enforce the floor
+    const vigil = out.filter((d) => d.card === 'flicker').sort((a, b) => a.at - b.at);
+    for (let i = 1; i < vigil.length; i++) if (vigil[i].at - vigil[i - 1].at < K.MIN_GAP_MS) vigil[i].at = vigil[i - 1].at + K.MIN_GAP_MS;
+    return out;
+  }
+
+  /* -------------------------------------------------------- stat flicker */
+  let flickTimer = 0;
+  let flickChip = null;
+  let flickPrev = null;
+  let flickLie = null;
+  function dealFlicker(deal, tries) {
+    if (destroyed || stopped) return;
+    if (isHalted() || inStop) {
+      if (tries < K.RETRY_MAX) after(K.RETRY_MS, () => dealFlicker(deal, tries + 1));
+      else fired.folded++;
+      return;
+    }
+    if (!rateOk()) { if (tries < K.RETRY_MAX) after(K.RETRY_MS, () => dealFlicker(deal, tries + 1)); else fired.folded++; return; }
+    const which = roll('flick-which') < 0.6 ? 'stops' : 'clock';
+    const chip = chipEl(which);
+    const truth = chipText(which);
+    if (!chip || typeof truth !== 'string' || !/\d/.test(truth)) { fired.folded++; return; }
+    const m = truth.match(/\d+/);
+    if (!m) { fired.folded++; return; }
+    const nval = Number(m[0]);
+    const delta = (roll('flick-sign') < 0.5 ? -1 : 1);
+    const fake = Math.max(0, nval + delta);
+    const lie = truth.replace(/\d+/, String(fake).padStart(m[0].length, '0'));
+    if (lie === truth) { fired.folded++; return; }
+    try { chip.textContent = lie; } catch (e) { return; }
+    flickChip = chip; flickPrev = truth; flickLie = lie;
+    if (!reduced) setCls(chip, 'g-ir-tk-flick', true);
+    fired.flicker++;
+    mark();
+    deal.fired = true;
+    cancel(flickTimer);
+    flickTimer = after(K.FLICKER_MS, () => { flickTimer = 0; restoreFlick(); });
+    say('trickster: stat flicker (' + which + ')');
+  }
+  function restoreFlick() {
+    if (!flickChip) return;
+    setCls(flickChip, 'g-ir-tk-flick', false);
+    try {
+      // stand down if a real repaint already landed under the lie
+      if (flickChip.textContent === flickLie) {
+        const now = chipText(flickChip === chipEl('stops') ? 'stops' : 'clock');
+        flickChip.textContent = typeof now === 'string' ? now : flickPrev;
+      }
+    } catch (e) { /* noop */ }
+    flickChip = null; flickPrev = null; flickLie = null;
+  }
+
+  /* ------------------------------------------------------- crooked clock */
+  let ring = null;
+  let ringTick = 0;
+  let ringOn = false;
+  let ringWrites = 0;
+  let lastRingK = -1;
+  function realTimer() {
+    try { const tm = chipEl('timer'); if (tm) return tm; } catch (e) { /* noop */ }
+    try {
+      const s = stopHost();
+      if (s && typeof s.querySelector === 'function') return s.querySelector('.g-ir-timer');
+    } catch (e) { /* noop */ }
+    return null;
+  }
+  function armRing() {
+    if (reduced || ringOn || destroyed || stopped) return false;
+    const face = realTimer();
+    const host = face && face.parentNode ? face.parentNode : stopHost();
+    if (!host || !host.appendChild) return false;
+    if (!ring) { ensureStyle(); ring = el('i', 'g-ir-tk-ring', host); }
+    if (!ring) return false;
+    setCls(face, 'g-ir-tk-bent', true);
+    setCls(ring, 'is-on', true);
+    ringOn = true;
+    lastRingK = -1;
+    paintRing();
+    ringTick = every(K.RING_TICK_MS, paintRing);
+    fired.clock++;
+    mark();
+    say('trickster: the ring goes crooked');
+    return true;
+  }
+  function paintRing() {
+    if (!ringOn || destroyed) return;
+    let s = null;
+    try { s = stats(); } catch (e) { s = null; }
+    let left = null;
+    const wl = winLeftMs();
+    if (s && Number.isFinite(Number(s.windowLeftMs)) && Number(s.windowMs) > 0) left = Number(s.windowLeftMs) / Number(s.windowMs);
+    else if (wl != null && windowNow > 0) left = wl / windowNow;
+    else if (windowNow > 0) left = 1 - (nowMs() - stopAt) / windowNow;
+    if (left == null) { straightenRing(); return; }
+    const k = bendRing(clamp01(left));
+    const q = Math.round(k * 200) / 200;
+    if (q === lastRingK) return;
+    lastRingK = q;
+    setVar(ring, '--ir-tk-k', q.toFixed(3));
+    ringWrites++;
+  }
+  function straightenRing() {
+    if (!ringOn) return;
+    ringOn = false;
+    if (ringTick) { stopEvery(ringTick); ringTick = 0; }
+    setCls(ring, 'is-on', false);
+    setCls(realTimer(), 'g-ir-tk-bent', false);
+  }
+
+  /* ---------------------------------------------------- unreliable label */
+  let labelTimer = 0;
+  let labelStartTimer = 0;
+  let labelEl = null;
+  let labelBtn = null;
+  let labelPrev = null;
+  let labelLie = null;
+  let lastLabel = null;              // {startedAt, endedAt, deadline, windowMs} for diagnostics
+  /** The node whose TEXT the label rewrites: CORE's .g-ir-opt-t span when the
+   *  option has one, the bare button when it has no element children, nothing
+   *  when it shows a face (img/video) - a face is never rewritten. */
+  function labelSurface(btn) {
+    try {
+      if (btn && typeof btn.querySelector === 'function') {
+        const span = btn.querySelector('.g-ir-opt-t');
+        if (span) {
+          if (span.querySelector && span.querySelector('img,video,canvas')) return null;
+          return span;
+        }
+      }
+      if (btn && btn.children && btn.children.length) return null;
+      return btn || null;
+    } catch (e) { return null; }
+  }
+  function dealLabel(deal) {
+    if (destroyed || stopped || !inStop) return;
+    const deadline0 = labelSnapDeadline(windowNow);
+    const startAt = Math.min(Math.max(Number(deal.delay) || K.LABEL_START_MS[0], K.LABEL_START_MS[0]), Math.max(0, deadline0 - 200));
+    if (Math.min(startAt + K.LABEL_MS, deadline0) - startAt < 120) { fired.folded++; deal.fired = true; return; }
+    const ordinalStart = stopOrdinal;
+    labelStartTimer = after(startAt, () => {
+      labelStartTimer = 0;
+      if (destroyed || stopped || !inStop || stopOrdinal !== ordinalStart) { fired.folded++; return; }
+      /* the window may have started AFTER the slip beat (CORE deals +240ms):
+       * bound it from the live left so the deadline is never later than truth */
+      const elapsed = nowMs() - stopAt;
+      const wl = winLeftMs();
+      if (wl != null && wl > 0) windowNow = Math.min(windowNow, wl + elapsed);
+      const deadline = labelSnapDeadline(windowNow);
+      const endAt = Math.min(elapsed + K.LABEL_MS, deadline);
+      if (endAt - elapsed < 120) { fired.folded++; return; }
+      let els = [];
+      try { els = Array.from(optEls() || []); } catch (e) { els = []; }
+      els = els.filter((n) => n && n.textContent != null);
+      if (els.length < 2) { fired.folded++; return; }
+      const a = Math.floor(roll('label-a') * els.length);
+      let b = Math.floor(roll('label-b') * (els.length - 1));
+      if (b >= a) b += 1;
+      const target = els[a];
+      const donor = els[b];
+      let truth = null; let lie = null;
+      try {
+        const ti = Number(target.getAttribute('data-i'));
+        const di = Number(donor.getAttribute('data-i'));
+        truth = optText(ti); lie = optText(di);
+      } catch (e) { /* noop */ }
+      const surface = labelSurface(target);
+      const donorSurface = labelSurface(donor);
+      if (!surface) { fired.folded++; return; }          // a media option: never rewrite a face
+      if (typeof truth !== 'string') { try { truth = surface.textContent; } catch (e) { truth = null; } }
+      if (typeof lie !== 'string') { try { lie = donorSurface ? donorSurface.textContent : null; } catch (e) { lie = null; } }
+      if (typeof truth !== 'string' || typeof lie !== 'string' || !lie || lie === truth) { fired.folded++; return; }
+      try { if (surface.textContent !== truth) { fired.folded++; return; } } catch (e) { return; }
+      try { surface.textContent = lie; } catch (e) { return; }
+      labelEl = surface; labelPrev = truth; labelLie = lie;
+      if (!reduced) setCls(target, 'g-ir-tk-lie', true);
+      labelBtn = target;
+      fired.label++;
+      mark();
+      const startedAt = nowMs() - stopAt;
+      lastLabel = { startedAt: Math.round(startedAt), deadline, windowMs: windowNow, endedAt: null };
+      cancel(labelTimer);
+      labelTimer = after(Math.max(60, endAt - elapsed), () => { labelTimer = 0; restoreLabel(); });
+      say('trickster: unreliable label (' + a + ' wears ' + b + ', off by ' + endAt + 'ms of ' + windowNow + ')');
+    });
+    deal.fired = true;
+  }
+  function restoreLabel() {
+    if (labelStartTimer) { cancel(labelStartTimer); labelStartTimer = 0; }
+    if (labelTimer) { cancel(labelTimer); labelTimer = 0; }
+    if (!labelEl) return;
+    setCls(labelBtn || labelEl, 'g-ir-tk-lie', false);
+    try {
+      // stand down if CORE repainted the option under the lie
+      if (labelEl.textContent === labelLie) labelEl.textContent = labelPrev;
+    } catch (e) { /* noop */ }
+    if (lastLabel && lastLabel.endedAt == null) lastLabel.endedAt = Math.round(nowMs() - stopAt);
+    labelEl = null; labelBtn = null; labelPrev = null; labelLie = null;
+  }
+
+  /* --------------------------------------------------------- ghost cursor */
+  let ghostEl = null;
+  let ghostTimer = 0;
+  let onMove = null;
+  const trail = [];
+  let lastMoveAt = 0;
+  let gx = 0; let gy = 0;
+  let ghostMode = 'off';
+  let ghostArmedThisStop = false;
+  function ghostHost() { return stopHost(); }
+  function ghostEligible() {
+    return armed && !reduced && !coarse && tier >= K.GHOST_FROM_TIER && !!ghostHost()
+      && typeof ghostHost().addEventListener === 'function';
+  }
+  /** The house's preferred option, in host coordinates: a WRONG one when the
+   *  truth is known, else the one farthest from the hand. */
+  function lurePoint() {
+    let els = [];
+    try { els = Array.from(optEls() || []); } catch (e) { els = []; }
+    if (!els.length) return null;
+    let truth = null;
+    try { const s = stats(); if (s && s.truth != null && Number.isFinite(Number(s.truth))) truth = Number(s.truth); } catch (e) { truth = null; }
+    const host = rectOf(ghostHost());
+    if (!host) return null;
+    const pts = [];
+    for (const n of els) {
+      const r = rectOf(n);
+      if (!r || !r.width) continue;
+      let di = NaN;
+      try { di = Number(n.getAttribute('data-i')); } catch (e) { di = NaN; }
+      pts.push({ x: r.left + r.width / 2 - host.left, y: r.top + r.height / 2 - host.top, i: di });
+    }
+    if (!pts.length) return null;
+    if (truth != null) {
+      const wrong = pts.filter((p) => p.i !== truth);
+      if (wrong.length) return wrong[Math.floor(roll('ghost-pick') * wrong.length)];
+    }
+    let best = pts[0]; let bd = -1;
+    for (const p of pts) { const d = (p.x - gx) * (p.x - gx) + (p.y - gy) * (p.y - gy); if (d > bd) { bd = d; best = p; } }
+    return best;
+  }
+  function ghostOff() {
+    if (ghostMode === 'off') return;
+    setCls(ghostEl, 'is-on', false);
+    setCls(ghostEl, 'is-lure', false);
+    ghostMode = 'off';
+  }
+  function ghostTick() {
+    if (!ghostEl || destroyed || stopped) return;
+    if (!capsOkNow() || !inStop || isHalted()) { ghostOff(); return; }
+    const t = nowMs();
+    const stalled = lastMoveAt > 0 && (t - lastMoveAt) >= K.GHOST_STALL_MS;
+    if (stalled) {
+      const p = lurePoint();
+      if (p) { gx += (p.x - gx) * K.GHOST_LERP; gy += (p.y - gy) * K.GHOST_LERP; }
+      if (ghostMode !== 'lure') { fired.lure++; ghostMode = 'lure'; }
+      setCls(ghostEl, 'is-on', true);
+      setCls(ghostEl, 'is-lure', true);
+    } else {
+      if (!trail.length || !lastMoveAt) { ghostOff(); return; }
+      let pt = trail[0];
+      for (const p of trail) { if (t - p.at >= K.GHOST_TRAIL_MS) pt = p; else break; }
+      gx = pt.x; gy = pt.y;
+      ghostMode = 'trail';
+      setCls(ghostEl, 'is-on', true);
+      setCls(ghostEl, 'is-lure', false);
+    }
+    try { ghostEl.style.transform = 'translate3d(' + gx.toFixed(1) + 'px,' + gy.toFixed(1) + 'px,0)'; } catch (e) { /* noop */ }
+    while (trail.length > 1 && t - trail[0].at > K.GHOST_TRAIL_KEEP_MS) trail.shift();
+  }
+  function armGhost() {
+    if (!ghostEligible() || ghostArmedThisStop) return false;
+    const host = ghostHost();
+    if (!ghostEl) {
+      ensureStyle();
+      ghostEl = el('i', 'g-ir-tk-ghost', host);
+      if (!ghostEl) return false;
+      onMove = (ev) => {
+        if (destroyed) return;
+        try {
+          const s = rectOf(host);
+          if (!s) return;
+          const x = Number(ev && ev.clientX) - s.left;
+          const y = Number(ev && ev.clientY) - s.top;
+          if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+          lastMoveAt = nowMs();
+          trail.push({ x, y, at: lastMoveAt });
+        } catch (e) { /* no rects under the DOM double */ }
+      };
+      try { host.addEventListener('pointermove', onMove); } catch (e) { /* noop */ }
+    }
+    ghostArmedThisStop = true;
+    lastMoveAt = nowMs();       // a stall starts counting from the slip landing
+    ghostTimer = every(K.GHOST_TICK_MS, ghostTick);
+    fired.ghost++;
+    mark();
+    say('trickster: ghost armed');
+    return true;
+  }
+  function disarmGhost() {
+    if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+    ghostOff();
+    ghostArmedThisStop = false;
+  }
+  function dropGhost() {
+    disarmGhost();
+    try {
+      const host = ghostHost();
+      if (onMove && host && host.removeEventListener) host.removeEventListener('pointermove', onMove);
+    } catch (e) { /* noop */ }
+    onMove = null;
+    if (ghostEl) { try { ghostEl.remove(); } catch (e) { /* noop */ } }
+    ghostEl = null;
+    trail.length = 0;
+  }
+
+  /* ------------------------------------------------------------------ api */
+  return {
+    /** Deal the class. Call once, when the vigil begins. */
+    start() {
+      if (!armed || destroyed) { say('trickster: disarmed'); return; }
+      plan = buildPlan();
+      for (const d of plan) if (d.card === 'flicker') after(d.at, () => dealFlicker(d, 0));
+      say('trickster: dealt ' + plan.length + ' cards ('
+        + plan.map((d) => d.card + (d.ordinal ? '@stop' + d.ordinal : '@' + Math.round(d.at / 1000) + 's')).join(', ') + ')');
+    },
+    /** The slip landed (CORE calls after the options are in the DOM). */
+    afterStop() {
+      if (!armed || destroyed || stopped) return;
+      stopOrdinal += 1;
+      inStop = true;
+      stopAt = nowMs();
+      let s = null;
+      try { s = stats(); } catch (e) { s = null; }
+      windowNow = s && Number(s.windowMs) > 0 ? Number(s.windowMs) : windowFallback();
+      for (const d of plan) {
+        if (d.fired || d.ordinal !== stopOrdinal) continue;
+        if (!rateOk()) { fired.folded++; d.fired = true; continue; }
+        if (d.card === 'label') dealLabel(d);
+        else if (d.card === 'clock') { d.fired = true; if (!armRing()) fired.folded++; }
+        else if (d.card === 'ghost') { d.fired = true; if (!armGhost()) fired.folded++; }
+      }
+    },
+    /** The answer committed (or timed out): every stop lie comes off. */
+    afterAnswer() {
+      if (!armed || destroyed) return;
+      inStop = false;
+      restoreLabel();
+      straightenRing();
+      disarmGhost();
+    },
+    /** ms since the last input; 0 resets. (Accepted for the contract; the
+     *  ghost's own stall clock runs on pointermove - this only ends theatre.) */
+    stalled(ms) {
+      if (!armed || destroyed) return;
+      if ((Number(ms) || 0) <= 0) ghostOff();
+    },
+    /** The class is over: no card may fire again, every lie comes off. */
+    stop() {
+      stopped = true;
+      inStop = false;
+      cancelAll();
+      restoreFlick();
+      restoreLabel();
+      straightenRing();
+      disarmGhost();
+    },
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      cancelAll();
+      restoreFlick();
+      restoreLabel();
+      straightenRing();
+      dropGhost();
+      if (ring) { try { ring.remove(); } catch (e) { /* noop */ } }
+      ring = null;
+    },
+    /** Diagnostics for the harness; not part of the module contract. */
+    diagnostics() {
+      return {
+        armed, tier, reduced, coarse,
+        plan: plan.map((d) => ({ card: d.card, at: d.at, ordinal: d.ordinal, fired: d.fired })),
+        fired: Object.assign({}, fired), stopOrdinal, inStop, windowMs: windowNow,
+        ring: { on: ringOn, writes: ringWrites, lastK: lastRingK },
+        label: lastLabel ? Object.assign({}, lastLabel) : null, labelLive: !!labelEl,
+        ghost: { el: !!ghostEl, mode: ghostMode, armed: ghostArmedThisStop },
+        flickLive: !!flickChip, timers: live.size,
+      };
+    },
+  };
+}
+
+export default createIrTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/vigil.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/vigil.js
@@ -1,0 +1,615 @@
+/* ============================================================================
+ * games/instant-recall/vigil.js - THE DAY'S VIGIL SCRIPT. PURE.
+ *
+ * One class = one continuous 120s montage with unpredictable freeze-and-quiz
+ * stops. Everything about the SHOW is dealt here, off the class seed, before a
+ * single frame renders: when it stops, whether a bell warns you, what the stage
+ * is doing, how thick the stream gets, which trigger channels are live and on
+ * what cadence, which template each question instantiates from, and where the
+ * decoy plants sit. Law V: seed -> plan -> events, never live rng. A retake
+ * replays the identical vigil.
+ *
+ * NOTHING HERE TOUCHES THE DOM, THE ENGINE OR THE CLOCK. index.js walks this
+ * plan; montage.js renders it; grade.js scores what actually happened. The one
+ * thing this file may NOT decide is the ANSWER to a question - that comes from
+ * the ledger tail at stop time, because the ledger is the truth (Law I) and a
+ * pre-dealt answer would be a lie waiting for a dropped frame.
+ *
+ * ---------------------------------------------------------------------------
+ * THE FINAL-STOP GUARANTEE (contract ruling 1, and the class's signature exit)
+ * The last stop ALWAYS lands inside the final 15 seconds, and always early
+ * enough inside them that its answer window plus the verdict resolve before the
+ * bell - so the vigil ends on a quiz, never on a fade-out, and never on a
+ * truncated question. `assertPlan()` re-checks it and the node suite runs it
+ * over 300 seeds x 4 tiers.
+ *
+ * ---------------------------------------------------------------------------
+ * TIER LADDER (dossier; dials first, classic difficulty second)
+ *   1  rows only; 2 trigger channels at low dials; 2 stops, 1 question, 6s,
+ *      EVERY stop belled.
+ *   2  rows + mosaic; 3 channels; wash tints enter; stings enter; 3 stops,
+ *      1 question, 6s, exactly ONE unannounced (SYNTHESIS #2 taste of the twist).
+ *   3  swirl enters; 4 channels near caps; gif_rain over flash_burst; ALL stops
+ *      unannounced; DECOY PLANTS unlock; LAST_TWO enters; 4 stops, 5s.
+ *   4  every dial at the global ceiling; crt/chroma dressing; 3-4 stops, 2
+ *      questions each, 4s, MODE spice at <= 10% of the class's question weight.
+ * ==========================================================================*/
+
+import { makeTaggedRoll } from '../../core/rng.js';
+
+/* ----------------------------------------------------------------------------
+ * PLAYTEST BLOCK - every tunable this game has, in one place.
+ * Nothing here is an absolute effect strength (the engine owns those, and the
+ * CEILING RULE means a game spends a clamped channel, never raises one). What
+ * lives here is PACE: milliseconds, counts, bands and weights.
+ * -------------------------------------------------------------------------- */
+export const PLAYTEST = Object.freeze({
+  /* --- ceremony timings ---------------------------------------------- */
+  BRIEF_MS: 2600,
+  BRIEF_MS_REDUCED: 1400,
+  END_HOLD_MS: 2600,
+  END_HOLD_MS_REDUCED: 1200,
+  /** Tier 1 / announced stops: the warning bell's lead. */
+  BELL_LEAD_MS: 1500,
+  /** The verdict + truth replay after a commit, before the vigil resumes. */
+  VERDICT_MS: 2200,
+  VERDICT_MS_REDUCED: 1100,
+  /** The bell warning at the end of the class (HUD goes gold). */
+  BELL_WARN_SEC: 20,
+
+  /* --- the stop schedule ---------------------------------------------- */
+  /** THE FINAL-STOP GUARANTEE: the last stop lands inside this tail window. */
+  FINAL_WINDOW_MS: 15000,
+  /** ...and no later than (budget - window - this), so it always resolves. */
+  RESOLVE_PAD_MS: 1200,
+  /** No stop before the vigil has had time to be a vigil. */
+  OPEN_MS: Object.freeze({ 1: 16000, 2: 14000, 3: 12000, 4: 11000 }),
+  /** Minimum gap between two stops (the schedule is jittered inside segments,
+   *  so this is a floor the segmentation already satisfies - asserted anyway). */
+  MIN_GAP_MS: Object.freeze({ 1: 22000, 2: 18000, 3: 14000, 4: 12000 }),
+  /** The answer window, by tier (contract: 6s / 6s / 5s / 4s). */
+  WINDOW_MS: Object.freeze({ 1: 6000, 2: 6000, 3: 5000, 4: 4000 }),
+  /** Stops per class. Tier 4 is dealt 3 or 4 (dossier "3-4 stops"). */
+  STOPS: Object.freeze({ 1: 2, 2: 3, 3: 4, 4: 0 }),
+  STOPS_T4: Object.freeze([3, 4]),
+  /** Questions per stop. */
+  Q_PER_STOP: Object.freeze({ 1: 1, 2: 1, 3: 1, 4: 2 }),
+
+  /* --- question templates --------------------------------------------- */
+  /** MODE is tier-4 spice: at most ONE per class, dealt on this chance, and
+   *  down-weighted so its realised share of the class's question weight can
+   *  never exceed the dossier's 10% ceiling (the suite asserts the realised
+   *  share over 300 seeds). */
+  MODE_CHANCE: 0.55,
+  MODE_WEIGHT: 0.5,
+  /** Distractors are never drawn from the last N ledger entries of the family:
+   *  a distractor that also just happened would make the answer ambiguous. */
+  DISTRACTOR_EXCLUDE: 5,
+
+  /* --- decoy plants (tier 3+, SetPiece-gated) -------------------------- */
+  PLANT_CAP: Object.freeze({ 1: 0, 2: 0, 3: 2, 4: 3 }),
+  PLANT_CHANCE: Object.freeze({ 1: 0, 2: 0, 3: 0.55, 4: 0.75 }),
+  /** Where in the answer window the plant fires (fraction of the window). */
+  PLANT_AT: Object.freeze([0.34, 0.46, 0.38, 0.52]),
+
+  /* --- density + heat --------------------------------------------------- */
+  /** `ir_density` scales the CEILING (never the floor, never the stop schedule). */
+  DENSITY_MULT: Object.freeze({ calm: 0.72, standard: 1, dense: 1.28 }),
+  DENSITY_CEIL: Object.freeze({ 1: 0.45, 2: 0.62, 3: 0.82, 4: 1 }),
+  DENSITY_FLOOR: Object.freeze({ 1: 0.12, 2: 0.16, 3: 0.20, 4: 0.26 }),
+  /** How long a segment takes to climb from its floor to its ceiling. */
+  RAMP_MS: 26000,
+  /** Partial relax after a stop - one band, sawtooth, never back to the floor. */
+  RELAX_BAND: 0.28,
+  /** Comeback hook: a missed stop eases the NEXT interval's ceiling (session
+   *  overlay only, never persisted - the SetSessionFlashRamp posture). */
+  MISS_EASE: 0.85,
+  /** The heat ladder's ceiling per grade tier (DE/IC pattern). */
+  HEAT_CAP: Object.freeze({ 1: 0.45, 2: 0.65, 3: 0.85, 4: 1 }),
+  /** Streak's contribution to heat, and progress's. */
+  HEAT_FROM_PROGRESS: 0.55,
+  HEAT_FROM_STREAK: 0.18,
+  HEAT_STREAK_CAP: 3,
+  /** Audio ceiling by tier - every cue's `level` is min()'d against it. */
+  AUDIO_CEIL: Object.freeze({ 1: 0.32, 2: 0.38, 3: 0.44, 4: 0.50 }),
+  /** Chime pitch ratchet per stop streak link, capped like IC's (+7 semitones). */
+  PITCH_STEP: 0.06,
+  PITCH_CAP: 7,
+
+  /* --- the escape guard (a frozen quiz card is never a trap) ------------ */
+  ESCAPE_TAPS: 6,
+  ESCAPE_MS: 5000,
+
+  /* --- misc ------------------------------------------------------------- */
+  STALL_TICK_MS: 1000,
+  CLOCK_TICK_MS: 200,
+});
+
+/** The three stage layouts, in the order they unlock. */
+export const LAYOUTS = Object.freeze(['rows', 'mosaic', 'swirl']);
+
+/** Layout pool by tier (reduced motion drops swirl - dossier Portability). */
+export function layoutPool(tier, reduced) {
+  const k = tierOf(tier);
+  const all = k >= 3 ? ['rows', 'mosaic', 'swirl'] : k >= 2 ? ['rows', 'mosaic'] : ['rows'];
+  return reduced ? all.filter((x) => x !== 'swirl') : all;
+}
+
+/**
+ * TRIGGER CHANNELS - the emission channels ARE the game.
+ * These are the channels that write ledger entries a question can be asked
+ * about. `DRESSING` is the per-tier atmosphere that also writes (it is a real
+ * effect and LAST_EFFECT may name it) but is held rather than pulsed.
+ */
+export const TRIGGER_CHANNELS = Object.freeze({
+  1: Object.freeze(['sub_flash', 'bubble_field']),
+  2: Object.freeze(['sub_flash', 'bubble_field', 'glitch_swap']),
+  3: Object.freeze(['sub_flash', 'bubble_field', 'glitch_swap', 'flash_burst']),
+  4: Object.freeze(['sub_flash', 'bubble_field', 'glitch_swap', 'flash_burst', 'gif_burst']),
+});
+/*
+ * Tier 4's dressing degrades the montage's legibility on purpose: the wash
+ * tints and the rain from tier 3, plus `crt` scanline/chroma. (`crt` was
+ * briefly absent from this class's pinned `effectsConsumed` - an owner ruling
+ * added it, so the dossier's tier-4 line is honoured as written. The
+ * `ambient_field` grain stays a STREAK beat rather than a dressing channel:
+ * index.js lays it over the resumed stream at a 2-stop run, so the golden
+ * grain means something rather than just being on.)
+ */
+export const DRESSING = Object.freeze({
+  1: Object.freeze([]),
+  2: Object.freeze(['wash']),
+  3: Object.freeze(['wash', 'gif_rain']),
+  4: Object.freeze(['wash', 'gif_rain', 'crt']),
+});
+/** Stings (audio_trigger) enter at tier 2 - LAST_STING is gated on them. */
+export const STING_FROM_TIER = 2;
+/** The sting vocabulary: shell/audio.js SOUNDS names with an `ir_sting_*` row. */
+export const STINGS = Object.freeze(['blip', 'sting', 'pop', 'bump', 'glitch']);
+
+/** Every channel LAST_EFFECT may name. Every one of them is in this class's
+ *  manifest AND actually reachable at some tier - an option that can never fire
+ *  is not a distractor, it is a freebie. (`row_drift` is the rows layout's own;
+ *  `ambient_field` is the streak grain; `crt` is tier 4's dressing.) */
+export const EFFECT_VOCAB = Object.freeze([
+  'bubble_field', 'wash', 'glitch_swap', 'gif_rain', 'flash_burst', 'gif_burst',
+  'ambient_field', 'crt', 'row_drift',
+]);
+
+/** Per-channel cadence band: base (cold) -> min (at full density). */
+export const CADENCE = Object.freeze({
+  sub_flash: Object.freeze({ base: 2600, min: 360 }),
+  bubble_field: Object.freeze({ base: 9000, min: 3200 }),
+  glitch_swap: Object.freeze({ base: 6000, min: 1800 }),
+  flash_burst: Object.freeze({ base: 11000, min: 4200 }),
+  gif_burst: Object.freeze({ base: 13000, min: 5200 }),
+  audio_trigger: Object.freeze({ base: 8000, min: 3000 }),
+  wash: Object.freeze({ base: 12000, min: 5200 }),
+  gif_rain: Object.freeze({ base: 16000, min: 9000 }),
+  ambient_field: Object.freeze({ base: 15000, min: 8000 }),
+  crt: Object.freeze({ base: 18000, min: 11000 }),
+});
+
+/** Variant pools per channel (no-repeat-last is the engine's; the ORDER is ours). */
+const VARIANTS = Object.freeze({
+  sub_flash: Object.freeze(['whisper', 'centre', 'scatter', 'stamp']),
+  bubble_field: Object.freeze(['drift', 'rise', 'swarm']),
+  glitch_swap: Object.freeze(['crossfade', 'rgbsplit', 'vhsroll', 'datamosh']),
+  flash_burst: Object.freeze(['single', 'scatter', 'double']),
+  gif_burst: Object.freeze(['single', 'scatter', 'double']),
+  wash: Object.freeze(['pink', 'sublim', 'drain']),
+  gif_rain: Object.freeze(['light', 'steady', 'downpour']),
+  ambient_field: Object.freeze(['motes', 'specks', 'ash', 'glints']),
+  crt: Object.freeze(['scanline', 'chroma', 'bloom']),
+  audio_trigger: STINGS,
+});
+
+/** Question templates, by the tier that unlocks them. */
+export const TEMPLATES = Object.freeze(['LAST_WORD', 'LAST_EFFECT', 'LAST_STING', 'LAST_TWO', 'MODE']);
+export const TEMPLATE_FROM_TIER = Object.freeze({
+  LAST_WORD: 1, LAST_EFFECT: 1, LAST_STING: 2, LAST_TWO: 3, MODE: 4,
+});
+/** The fallback walk when the dealt template cannot be instantiated from the
+ *  ledger tail (empty word pool, no stings, inaudible audio, single layout).
+ *  Fixed ORDER, so a fallback is as deterministic as the deal it replaces. */
+export const FALLBACK_ORDER = Object.freeze(['LAST_WORD', 'LAST_EFFECT', 'LAST_STING', 'LAST_TWO', 'MODE']);
+
+/* ----------------------------------------------------------------------------
+ * SMALL PURE HELPERS
+ * -------------------------------------------------------------------------- */
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+export function tierOf(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+function lerp(a, b, f) { return a + (b - a) * f; }
+function pickFrom(list, r) {
+  if (!list || !list.length) return undefined;
+  const f = r < 0 ? 0 : r > 0.999999 ? 0.999999 : r;
+  return list[Math.floor(f * list.length)];
+}
+
+/** The density multiplier for the `ir_density` setting (unknown -> standard). */
+export function densityMultFor(value) {
+  const k = String(value == null ? 'standard' : value).trim().toLowerCase();
+  const m = PLAYTEST.DENSITY_MULT[k];
+  return Number.isFinite(m) ? m : PLAYTEST.DENSITY_MULT.standard;
+}
+
+/**
+ * THE DENSITY SAWTOOTH. Between stops the band climbs continuously toward the
+ * segment's ceiling; each stop knocks it down ONE band (never to the floor) and
+ * raises the segment's own floor, so the class ratchets. A missed stop eases
+ * the next segment's ceiling by MISS_EASE - the comeback hook, session-only.
+ *
+ * PURE: index.js hands it the elapsed time and the segment bookkeeping, so the
+ * suite can walk the whole curve without a clock.
+ *
+ * @param {Object} p        the plan (needs densityFloor / densityCeil / rampMs)
+ * @param {number} sinceMs  ms since this segment started (a resume, or t=0)
+ * @param {number} seg      how many stops have already resolved (0-based segment)
+ * @param {boolean} eased   the previous stop was missed -> eased ceiling
+ * @returns {number} 0..1 density band
+ */
+export function densityAt(p, sinceMs, seg, eased) {
+  if (!p) return 0;
+  const segs = Math.max(1, Number(p.segments) || 1);
+  const i = Math.max(0, Math.min(segs - 1, Math.round(Number(seg) || 0)));
+  const span = Math.max(0, segs - 1);
+  /* the segment's own floor ratchets up across the class (sawtooth teeth rise) */
+  const floor = clamp01(lerp(p.densityFloor, Math.max(p.densityFloor, p.densityCeil - PLAYTEST.RELAX_BAND),
+    span ? i / span : 1));
+  let ceil = p.densityCeil;
+  if (eased) ceil *= PLAYTEST.MISS_EASE;
+  ceil = clamp01(Math.max(floor, ceil));
+  const f = clamp01(Math.max(0, Number(sinceMs) || 0) / Math.max(1, p.rampMs));
+  return clamp01(lerp(floor, ceil, f));
+}
+
+/** Heat from the class's own ladder (progress + stop streak), capped by tier. */
+export function heatFor(p, progress01, streak) {
+  if (!p) return 0;
+  const s = Math.min(PLAYTEST.HEAT_STREAK_CAP, Math.max(0, Math.round(Number(streak) || 0)));
+  const h = PLAYTEST.HEAT_FROM_PROGRESS * clamp01(progress01)
+    + PLAYTEST.HEAT_FROM_STREAK * (s / PLAYTEST.HEAT_STREAK_CAP);
+  return clamp01(Math.min(p.heatCap, h));
+}
+
+/** Heat-scaled cadence for a channel at a density band, with a seeded jitter. */
+export function cadenceMs(kind, band, jitter) {
+  const c = CADENCE[kind];
+  if (!c) return Infinity;
+  const b = clamp01(band);
+  const base = lerp(c.base, c.min, b);
+  const j = Number.isFinite(jitter) ? jitter : 0;
+  return Math.max(120, Math.round(base * (0.78 + 0.44 * j)));
+}
+
+/* ----------------------------------------------------------------------------
+ * THE PLAN
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Deal the day's vigil.
+ *
+ * @param {Object} o
+ *   seed           the class seed (UTC-dated; unchanged on a retake)
+ *   gradeTier      1..4
+ *   timeBudgetSec  the real budget (120)
+ *   density        the `ir_density` setting value
+ *   reduced        reduced motion (drops swirl and every plant)
+ * @returns {Object} the plan
+ */
+export function buildVigil(o = {}) {
+  const seed = String(o.seed == null ? 'instant_recall' : o.seed);
+  const tier = tierOf(o.gradeTier);
+  const reduced = !!o.reduced;
+  const budgetMs = Math.max(20000, Math.round((Number(o.timeBudgetSec) || 120) * 1000));
+  const roll = makeTaggedRoll(seed + '|ir');
+
+  const windowMs = PLAYTEST.WINDOW_MS[tier];
+  const qPer = PLAYTEST.Q_PER_STOP[tier];
+  const count = tier === 4
+    ? pickFrom(PLAYTEST.STOPS_T4, roll('stop-count'))
+    : PLAYTEST.STOPS[tier];
+
+  const densityMult = densityMultFor(o.density);
+  const densityCeil = clamp01(PLAYTEST.DENSITY_CEIL[tier] * densityMult);
+  const densityFloor = Math.min(densityCeil, PLAYTEST.DENSITY_FLOOR[tier]);
+
+  /* ---- stop times: segmented, jittered, final-stop guaranteed ---------- */
+  const finalLo = Math.max(0, budgetMs - PLAYTEST.FINAL_WINDOW_MS);
+  const finalHi = Math.max(finalLo, budgetMs - windowMs - PLAYTEST.RESOLVE_PAD_MS);
+  const times = [];
+  const open = Math.min(PLAYTEST.OPEN_MS[tier], Math.max(0, finalLo - 1000));
+  const minGap = PLAYTEST.MIN_GAP_MS[tier];
+  const earlier = Math.max(0, count - 1);
+  if (earlier > 0) {
+    const spanLo = open;
+    const spanHi = Math.max(spanLo, finalLo - minGap);
+    const segLen = (spanHi - spanLo) / earlier;
+    let last = -Infinity;
+    for (let i = 0; i < earlier; i++) {
+      const segStart = spanLo + segLen * i;
+      /* inside the middle 70% of the segment: never flush against a neighbour */
+      let at = Math.round(segStart + segLen * (0.15 + 0.70 * roll('stop-at')));
+      if (at - last < minGap) at = Math.round(last + minGap);
+      at = Math.min(at, Math.round(spanHi));
+      times.push(at);
+      last = at;
+    }
+  }
+  const finalAt = Math.round(finalLo + (finalHi - finalLo) * roll('stop-final'));
+  times.push(finalAt);
+
+  /* ---- the bell: tier 1 all, tier 2 exactly one silent, tier 3+ none --- */
+  const announced = times.map(() => tier === 1);
+  if (tier === 2) {
+    for (let i = 0; i < announced.length; i++) announced[i] = true;
+    /* never the FIRST stop: the ritual is taught once, then broken */
+    const idx = 1 + Math.floor(roll('nobell') * Math.max(1, announced.length - 1));
+    announced[Math.min(announced.length - 1, idx)] = false;
+  }
+
+  /* ---- template sequence ---------------------------------------------- */
+  const pool = TEMPLATES.filter((k) => TEMPLATE_FROM_TIER[k] <= tier && k !== 'MODE');
+  const totalQ = count * qPer;
+  const wantMode = tier === 4 && roll('mode') < PLAYTEST.MODE_CHANCE;
+  /* MODE never takes the very last question of the class - the vigil's exit
+   * beat is about what FIRED, not about the furniture. */
+  const modeSlot = wantMode && totalQ > 1
+    ? Math.floor(roll('mode-slot') * (totalQ - 1))
+    : -1;
+
+  const stops = [];
+  let dealt = 0;
+  let prevTemplate = '';
+  let plants = 0;
+  let plantedLast = false;
+  for (let n = 0; n < count; n++) {
+    const questions = [];
+    for (let q = 0; q < qPer; q++) {
+      let template;
+      if (dealt === modeSlot) {
+        template = 'MODE';
+      } else {
+        /* no-repeat-last across the whole class where the pool allows it */
+        const avail = pool.length > 1 ? pool.filter((k) => k !== prevTemplate) : pool.slice();
+        template = pickFrom(avail, roll('tmpl')) || pool[0];
+      }
+      const weight = (6000 / windowMs) * (template === 'MODE' ? PLAYTEST.MODE_WEIGHT : 1);
+      questions.push({ i: dealt, template, weight, windowMs });
+      if (template !== 'MODE') prevTemplate = template;
+      dealt += 1;
+    }
+
+    /* ---- decoy plants: tier 3+, never the first stop, never two in a row,
+     * capped per class, disabled entirely under reduced motion (and then
+     * scored 1.0 so accessibility never costs a grade). */
+    let plant = null;
+    const cap = PLAYTEST.PLANT_CAP[tier];
+    const chance = PLAYTEST.PLANT_CHANCE[tier];
+    const gate = !reduced && n > 0 && plants < cap && !plantedLast;
+    const r = roll('plant');
+    if (gate && r < chance) {
+      const channel = (tier >= 4 && roll('plant-ch') < 0.42) ? 'audio_trigger' : 'sub_flash';
+      const at = Math.round(windowMs * PLAYTEST.PLANT_AT[plants % PLAYTEST.PLANT_AT.length]);
+      plant = { channel, atMs: at, stop: n };
+      plants += 1;
+      plantedLast = true;
+    } else {
+      plantedLast = false;
+    }
+
+    stops.push({
+      n,
+      atMs: times[n],
+      announced: announced[n],
+      windowMs,
+      questions,
+      plant,
+      final: n === count - 1,
+    });
+  }
+
+  /* ---- layout sequence: one at the open, one at every resume ----------- */
+  const lpool = layoutPool(tier, reduced);
+  const layouts = [];
+  let prevLayout = '';
+  for (let i = 0; i <= count; i++) {
+    let kind;
+    if (i === 0) {
+      kind = 'rows';                      // the vigil always opens on rows
+    } else {
+      const avail = lpool.length > 1 ? lpool.filter((k) => k !== prevLayout) : lpool.slice();
+      kind = pickFrom(avail, roll('layout')) || lpool[0];
+    }
+    layouts.push({ index: i, kind });
+    prevLayout = kind;
+  }
+
+  /* ---- emission schedule: per channel, a seeded jitter + variant ring --- */
+  const channels = [];
+  const kinds = TRIGGER_CHANNELS[tier].slice();
+  if (tier >= STING_FROM_TIER) kinds.push('audio_trigger');
+  for (const kind of kinds) {
+    channels.push(makeChannel(kind, roll, false));
+  }
+  const dressing = [];
+  for (const kind of DRESSING[tier]) dressing.push(makeChannel(kind, roll, true));
+
+  const plan = {
+    seed,
+    tier,
+    reduced,
+    budgetMs,
+    windowMs,
+    qPerStop: qPer,
+    stopCount: count,
+    segments: count + 1,
+    stops,
+    layouts,
+    layoutPool: lpool,
+    channels,
+    dressing,
+    stings: STINGS.slice(),
+    templates: pool.concat(wantMode ? ['MODE'] : []),
+    modeSlot,
+    plantCount: plants,
+    densityMult,
+    densityCeil,
+    densityFloor,
+    rampMs: PLAYTEST.RAMP_MS,
+    heatCap: PLAYTEST.HEAT_CAP[tier],
+    audioCeil: PLAYTEST.AUDIO_CEIL[tier],
+    totalQuestions: totalQ,
+  };
+  return plan;
+}
+
+/** One channel's dealt ring: 8 jitters + 8 variants, consumed round-robin. */
+function makeChannel(kind, roll, held) {
+  const jitter = [];
+  for (let i = 0; i < 8; i++) jitter.push(roll('jit-' + kind));
+  const pool = VARIANTS[kind] || [''];
+  const variants = [];
+  let prev = '';
+  for (let i = 0; i < 8; i++) {
+    const avail = pool.length > 1 ? pool.filter((v) => v !== prev) : pool.slice();
+    const v = pickFrom(avail, roll('var-' + kind)) || pool[0];
+    variants.push(v);
+    prev = v;
+  }
+  return { kind, jitter, variants, held: !!held };
+}
+
+/* ----------------------------------------------------------------------------
+ * TEMPLATE RESOLUTION (pure) - the ledger tail decides what CAN be asked.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Can this template be instantiated right now?
+ *
+ * @param {string} template
+ * @param {Object} avail
+ *   words       distinct words available as distractors (outside the excluded tail)
+ *   hasWord     the tail carries at least one word
+ *   hasTwoWords the tail carries at least two words
+ *   stings      distinct stings available as distractors
+ *   hasSting    the tail carries at least one sting
+ *   audible     ctx.audioAudible
+ *   effects     distinct effect names available as distractors
+ *   hasEffect   the tail carries at least one effect
+ *   layouts     how many layouts this class can name
+ *   hasLayout   the stage layout at the freeze is known
+ */
+export function canAsk(template, avail) {
+  const a = avail || {};
+  switch (template) {
+    case 'LAST_WORD': return !!a.hasWord && (a.words | 0) >= 3;
+    case 'LAST_TWO': return !!a.hasTwoWords && (a.words | 0) >= 2;
+    case 'LAST_EFFECT': return !!a.hasEffect && (a.effects | 0) >= 3;
+    case 'LAST_STING': return !!a.hasSting && !!a.audible && (a.stings | 0) >= 3;
+    case 'MODE': return !!a.hasLayout && (a.layouts | 0) >= 3;
+    default: return false;
+  }
+}
+
+/** The dealt template, or the first template down the fixed fallback walk that
+ *  the tail can actually answer. Null when the tail can answer nothing at all
+ *  (the stop then resumes uncounted - a question is never invented). */
+export function resolveTemplate(want, avail, tier) {
+  const k = tierOf(tier);
+  /* the tier gate outranks the deal: a plan can only ever deal a template its
+   * tier unlocks, but this function is also the seam a harness and a future
+   * caller reach for, and a LAST_TWO at tier 2 must fall through like any other
+   * template the tail cannot serve. */
+  if (TEMPLATE_FROM_TIER[want] <= k && canAsk(want, avail)) return want;
+  for (const alt of FALLBACK_ORDER) {
+    if (alt === want) continue;
+    if (TEMPLATE_FROM_TIER[alt] > k) continue;
+    if (canAsk(alt, avail)) return alt;
+  }
+  return null;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE ASSERTIONS (the suite calls this; index.js logs its failures)
+ * -------------------------------------------------------------------------- */
+/** @returns {string[]} the list of broken invariants (empty = the plan is legal). */
+export function assertPlan(p) {
+  const bad = [];
+  if (!p || !Array.isArray(p.stops) || !p.stops.length) return ['no stops'];
+  const tier = p.tier;
+  if (p.stops.length !== p.stopCount) bad.push('stopCount mismatch');
+  const wantCount = tier === 4 ? null : PLAYTEST.STOPS[tier];
+  if (wantCount != null && p.stopCount !== wantCount) bad.push('tier ' + tier + ' must deal ' + wantCount + ' stops');
+  if (tier === 4 && PLAYTEST.STOPS_T4.indexOf(p.stopCount) < 0) bad.push('tier 4 stop count out of band');
+
+  let prev = -Infinity;
+  for (const s of p.stops) {
+    if (!(s.atMs > prev)) bad.push('stops out of order at ' + s.n);
+    if (s.n > 0 && s.atMs - prev < PLAYTEST.MIN_GAP_MS[tier]) bad.push('min gap broken at ' + s.n);
+    prev = s.atMs;
+    if (s.questions.length !== PLAYTEST.Q_PER_STOP[tier]) bad.push('question count at ' + s.n);
+    if (s.windowMs !== PLAYTEST.WINDOW_MS[tier]) bad.push('window at ' + s.n);
+  }
+
+  /* THE FINAL-STOP GUARANTEE */
+  const last = p.stops[p.stops.length - 1];
+  if (last.atMs < p.budgetMs - PLAYTEST.FINAL_WINDOW_MS) bad.push('final stop outside the last 15s');
+  if (last.atMs > p.budgetMs - last.windowMs - PLAYTEST.RESOLVE_PAD_MS) bad.push('final stop cannot resolve before the bell');
+  if (!last.final) bad.push('final stop not flagged');
+
+  /* the bell ladder */
+  const silent = p.stops.filter((s) => !s.announced).length;
+  if (tier === 1 && silent !== 0) bad.push('tier 1 must bell every stop');
+  if (tier === 2 && silent !== 1) bad.push('tier 2 must drop exactly one bell');
+  if (tier >= 3 && silent !== p.stops.length) bad.push('tier 3+ must bell nothing');
+  if (tier === 2 && !p.stops[0].announced) bad.push('tier 2 first stop must bell');
+
+  /* plants */
+  const planted = p.stops.filter((s) => !!s.plant);
+  if (p.reduced && planted.length) bad.push('reduced motion must plant nothing');
+  if (tier < 3 && planted.length) bad.push('plants before tier 3');
+  if (planted.length > PLAYTEST.PLANT_CAP[tier]) bad.push('plant cap exceeded');
+  for (const s of planted) {
+    if (s.n === 0) bad.push('plant on the first stop');
+    if (s.plant.atMs >= s.windowMs) bad.push('plant outside the answer window');
+  }
+  for (let i = 1; i < p.stops.length; i++) {
+    if (p.stops[i].plant && p.stops[i - 1].plant) bad.push('plants clumped at ' + i);
+  }
+
+  /* templates */
+  let modes = 0;
+  for (const s of p.stops) {
+    for (const q of s.questions) {
+      if (TEMPLATES.indexOf(q.template) < 0) bad.push('unknown template ' + q.template);
+      if (TEMPLATE_FROM_TIER[q.template] > tier) bad.push(q.template + ' above tier ' + tier);
+      if (q.template === 'MODE') modes += 1;
+    }
+  }
+  if (modes > 1) bad.push('more than one MODE question');
+  if (modes && tier !== 4) bad.push('MODE below tier 4');
+
+  /* layouts */
+  if (p.layouts.length !== p.stopCount + 1) bad.push('layout count');
+  if (p.layouts[0].kind !== 'rows') bad.push('vigil must open on rows');
+  for (let i = 1; i < p.layouts.length; i++) {
+    if (p.layoutPool.length > 1 && p.layouts[i].kind === p.layouts[i - 1].kind) bad.push('layout repeated at ' + i);
+    if (p.layoutPool.indexOf(p.layouts[i].kind) < 0) bad.push('layout outside the tier pool at ' + i);
+  }
+  if (p.reduced && p.layouts.some((l) => l.kind === 'swirl')) bad.push('swirl under reduced motion');
+
+  return bad;
+}
+
+/** The realised MODE share of a plan's question weight (the <=10% ruling). */
+export function modeWeightShare(p) {
+  let total = 0;
+  let mode = 0;
+  for (const s of p.stops) {
+    for (const q of s.questions) { total += q.weight; if (q.template === 'MODE') mode += q.weight; }
+  }
+  return total > 0 ? mode / total : 0;
+}
+
+export default { buildVigil, densityAt, heatFor, cadenceMs, resolveTemplate, canAsk, assertPlan, PLAYTEST };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/casino.js
@@ -1,0 +1,972 @@
+/* ============================================================================
+ * games/misdirection/casino.js - DECK II of the House Rules for the shell
+ * game: THE FLOOR. The con artist's table, lit. index.js shuffles the shells
+ * and keeps the ledger; the trickster (trickster.js) lies about what you read;
+ * the pressure (pressure.js) is what the room does to you as your pick streak
+ * climbs. This file is the lighting rig and the chime rack around the table.
+ *
+ *   TABLE IDENTITY   seeded per CLASS seed (Deck I): a felt hue pair on the
+ *                    violet -> rose arc (~6% of tables are the green baize
+ *                    night - a bonus round for loading in), a rail metal
+ *                    (brass / silver / rose-gold), a lamp sway period, a
+ *                    ken-burns period, a bulb count, and a PATTERN JOURNEY of
+ *                    2-3 stops through one weave morph space (diamond,
+ *                    herringbone, damask, pinstripe, lace) walked by the
+ *                    class's own heat. Same seed, same table; a retake sits
+ *                    down at the identical felt.
+ *   THE MARQUEE      a chase of bulbs on an ARCH over the shells (the table is
+ *                    an arc, so the frame is an arch, not a box). Crawls lazily
+ *                    at low heat, chases hungrily at high heat, flashes on a
+ *                    payout, goes GOLD for the bell and the royal, sighs out
+ *                    on a dim-out - never cuts.
+ *   THE LAMP         a hanging cone of light over the table: it swings slowly
+ *                    (Law III), slides to the revealed shell on a reveal, opens
+ *                    wide for the shuffle, narrows for the pick.
+ *   THE CHIME LADDER every correct pick chimes and the chime CLIMBS: +1
+ *                    semitone per link of the pick streak, capped +7 (the
+ *                    intake precedent). A wrong pick is a muted thud, never
+ *                    silence. Every cue is engine audio_trigger (pitch = the
+ *                    streak) through the weld index.js hands us; shell/audio.js
+ *                    stays the only audio owner (trap 18).
+ *   PAYOUT LIGHT     a correct pick floods the picked shell's slot and punches
+ *                    the pot chip (transform only; the TEXT is index.js's). A
+ *                    ride slams the pot badge and deepens the shell rims
+ *                    (--md-n-ride on the stage, style.js glows it). A BANK is
+ *                    the payout: gold flood, a coin shower into the pot chip,
+ *                    a marquee flash, the streak arpeggio + the stamp thunk.
+ *   THE SWAP TRAIL   each swap draws a felt streak between the two slots that
+ *                    traded (one reused node); a glitch swap is a static pop on
+ *                    the overlay instead. The trail never touches a shell.
+ *   THE ALMOST       near-miss staging: on a wrong pick the TRUE target ghosts
+ *                    through the picked shell and drifts home to the true slot
+ *                    while the word ALMOST rises - the truth index.js already
+ *                    revealed, staged once more. Cosmetic; the ledger decided.
+ *   JACKPOT LADDER   minor (a seeded roll on a correct pick, chance rising with
+ *                    heat) / major (streak milestones, or a bank three rides
+ *                    deep) / ROYAL (a bank at the ride cap: the table floods
+ *                    gold, the arch goes gold, a chime stack, the word ROYAL).
+ *                    A bust is the table swallowing the pot: the felt dims, the
+ *                    pot chip sinks, a low thud - dim, never silent.
+ *   DIM-OUT          the bell took the table: the rig sighs out and pays a dim
+ *                    payout light - silence is where people stand up.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads the event objects index.js hands it AFTER its own
+ *       accounting; writes nothing about pot, streak, round or grade; the chips
+ *       move by transform only, their text is never touched.
+ *   II  input honest  - every node here is pointer-events:none and lives in
+ *       the table's overlay layers under and over the arc; --slot / --x,
+ *       data-slot, the shells' own nodes and transforms are NEVER written.
+ *   III never still   - the marquee crawls at heat 0, the lamp swings, the
+ *       weave drifts, the bulbs breathe.
+ *   IV  images > text - three words (ONE OFF / SHARP / ROYAL) through the
+ *       lexicon, each alive for < 700ms.
+ *   V   seeded        - per-tag mulberry32 off seed+'|md-casino|<tag>' (append-
+ *       only tags; a new tag never shifts an old stream). No Math.random.
+ *   VI  exits sacred  - capsOk false disarms every light; reduced motion keeps
+ *       a static dim arch + lamp (no chase, no coins, no ghost drift, no punch -
+ *       a bloom instead); the stage's .suspended rule freezes the chase; every
+ *       timer rides the game's pause-aware registry AND a local set so
+ *       destroy() cannot leak one.
+ *   VII lexicon       - md_almost / md_sharp / md_royal only,
+ *       through opts.t; nothing else is rendered as text.
+ *
+ * ENGINE vs GAME-LOCAL: cues and the jackpot / near_miss ceremonies go through
+ * the engine weld (opts.engine: fire/sustain/stop/channels, ceremony when the
+ * weld carries it). The arch, the lamp, the flood, the trail, the ghost, the
+ * coins and the words are game-local: they sit on the table's own geometry,
+ * which no engine primitive knows. Node budget: arch (1 + bulbs), overlay
+ * (lamp, flood, trail, static, word) + top overlay (ghost, <= 40 coins).
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const MD_CASINO = Object.freeze({
+  /* ---- identity ------------------------------------------------------ */
+  OFF_ARC: 0.06,
+  HUE_ARC: Object.freeze([262, 342]),         // violet -> rose
+  HUE_OFF: Object.freeze([148, 168]),         // the green baize night
+  METALS: Object.freeze(['brass', 'silver', 'rosegold']),
+  WEAVES: Object.freeze(['diamond', 'herringbone', 'damask', 'pinstripe', 'lace']),
+  STOPS_MIN: 2,
+  STOPS_SPAN: 2,                               // 2..3 stops
+  STOP_HYST: 0.05,
+  BULBS: Object.freeze([18, 22, 26]),
+  /* ---- the marquee --------------------------------------------------- */
+  MQ_T_SLOW: 3.4,
+  MQ_T_FAST: 0.9,
+  MQ_A_LO: 0.62,
+  MQ_A_HI: 0.98,
+  MQ_T_BELL: 0.5,
+  MQ_A_BELL: 0.95,
+  MQ_SHUFFLE_MUL: 0.82,                        // the chase quickens while the shells move
+  MQ_FLASH_MS: 560,
+  /* ---- the lamp ------------------------------------------------------ */
+  LAMP_SWAY_S: Object.freeze([9, 15]),         // seeded sway period
+  LAMP_W_PICK: 0.34,                           // cone width as a fraction of the table
+  LAMP_W_REVEAL: 0.26,
+  LAMP_W_SHUFFLE: 0.9,
+  /* ---- the payout ---------------------------------------------------- */
+  FLOOD_MS: 620,
+  FLOOD_A: Object.freeze([0.16, 0.5]),
+  PUNCH_SCALE: Object.freeze([0.05, 0.28]),
+  PUNCH_MS: 240,
+  BANK_FLOOD_MS: 900,
+  COINS_MAX: 40,
+  COINS_BANK: Object.freeze([6, 18]),
+  COINS_ROYAL: 30,
+  COIN_MS: Object.freeze([700, 1200]),
+  /* ---- the ladder ---------------------------------------------------- */
+  MILESTONES: Object.freeze([5, 10, 15]),
+  MINOR_CHANCE: Object.freeze([0.16, 0.48]),   // correct pick, by heat
+  MINOR_I: 0.35,
+  MAJOR_I: Object.freeze([0.55, 0.75, 0.95]),  // by milestone index
+  MAJOR_RIDE: 3,
+  MAJOR_RIDE_I: 0.7,
+  ROYAL_RIDE: 5,
+  ROYAL_I: 1,
+  ROYAL_MS: 3200,
+  BUST_MS: 1100,
+  END_DIM_MS: 1400,
+  /* ---- near-miss staging --------------------------------------------- */
+  ALMOST_MS: 1200,
+  SHARP_MS: 800,                               // a pick faster than this is SHARP
+  WORD_MS: 600,
+  NEAR_MISS_I: Object.freeze({ almost: 0.7, sharp: 0.4 }),
+  /* ---- the sound ladder ---------------------------------------------- */
+  SEMITONE_CAP: 7,
+  CHIME_LEVEL: Object.freeze([0.3, 0.5]),      // by min(streak,10)/10
+  THUD_LEVEL: 0.22,
+  SWAP_LEVEL: Object.freeze([0.08, 0.2]),      // by heat
+  SWAP_GAP_MS: 170,                            // at most one swap cue this often
+  GLITCH_LEVEL: 0.18,
+  REVEAL_LEVEL: 0.22,
+  SHUFFLE_LEVEL: 0.16,
+  RIDE_LEVEL: 0.3,
+  BANK_LEVEL: 0.45,
+  JACKPOT_LEVEL: 0.55,
+  NEAR_LEVEL: 0.3,
+  BUST_LEVEL: 0.28,
+  DIM_LEVEL: 0.22,
+  /* ---- ken-burns ----------------------------------------------------- */
+  KB_T: Object.freeze([30, 16]),
+  KB_SEED_SPAN: 8,
+  HEAT_REPAINT_STEP: 0.03,
+});
+
+const STYLE_ID = 'g-md-casino-style';
+/* The stylesheet for the nodes this deck owns. Everything pointer-events:none.
+   Geometry vars: --md-cs-lx (lamp centre, % of table), --md-cs-lw (cone width,
+   fraction), --md-cs-fx (flood centre), --md-mq-t / --md-mq-a / --md-mq-hue
+   (the arch), --md-cs-pay (flood presence). */
+const STYLE_TEXT = `
+.g-md-mq{position:absolute;inset:0;pointer-events:none;z-index:3;
+  --md-mq-t:3.4s;--md-mq-a:.62;--md-mq-hue:300;opacity:var(--md-mq-a);transition:opacity .9s ease}
+.g-md-mq-bulb{position:absolute;width:var(--md-mq-d,8px);height:var(--md-mq-d,8px);margin:calc(var(--md-mq-d,8px) * -.5);
+  border-radius:50%;
+  background:radial-gradient(circle at 40% 35%, #fff8e8 0 28%, hsl(var(--md-mq-hue) 95% 78%) 62%, hsl(var(--md-mq-hue) 80% 52%) 100%);
+  box-shadow:0 0 0 1px rgba(0,0,0,.35),0 0 7px hsl(var(--md-mq-hue) 95% 76% / .95),0 0 18px hsl(var(--md-mq-hue) 90% 64% / .6),0 0 34px hsl(var(--md-mq-hue) 90% 60% / .25);
+  animation:g-md-cs-chase var(--md-mq-t) linear infinite;animation-delay:calc(var(--i) / var(--n) * var(--md-mq-t) * -1)}
+@keyframes g-md-cs-chase{0%{opacity:.42;transform:scale(.86)}12%{opacity:1;transform:scale(1.22)}40%{opacity:.6;transform:scale(.95)}100%{opacity:.42;transform:scale(.86)}}
+.g-md-mq.gold{--md-mq-hue:46 !important}
+.g-md-mq.flash .g-md-mq-bulb{animation-duration:.22s;filter:brightness(1.6)}
+.g-md-mq.out{opacity:0 !important;transition:opacity 1.6s ease}
+/* the under-overlay: lamp, flood, trail, static - below the arc */
+.g-md-cs{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden;
+  --md-cs-lx:50;--md-cs-lw:.34;--md-cs-la:.5;--md-cs-fx:50;--md-cs-pay:.3}
+.g-md-cs *{pointer-events:none}
+.g-md-cs-lamp{position:absolute;left:calc(var(--md-cs-lx) * 1%);top:-40%;width:calc(var(--md-cs-lw) * 100%);height:180%;
+  transform:translateX(-50%);opacity:var(--md-cs-la);
+  background:radial-gradient(50% 45% at 50% 45%, hsl(var(--md-n-hue-a,300) 70% 82% / .34) 0%, hsl(var(--md-n-hue-a,300) 60% 70% / .12) 45%, transparent 72%);
+  transition:left .55s cubic-bezier(.2,.9,.3,1), width .6s ease, opacity .5s ease;
+  animation:g-md-cs-sway var(--md-n-sway,12s) ease-in-out infinite alternate}
+@keyframes g-md-cs-sway{from{margin-left:-1.2%}to{margin-left:1.2%}}
+.g-md-cs-flood{position:absolute;inset:0;opacity:0;
+  background:radial-gradient(circle at calc(var(--md-cs-fx) * 1%) 60%, hsl(var(--md-n-hue-b,330) 90% 72% / .9) 0%, hsl(var(--md-n-hue-b,330) 90% 62% / .35) 18%, transparent 50%);
+  transition:opacity .14s ease-out}
+.g-md-cs-flood.on{opacity:var(--md-cs-pay);transition:opacity .06s ease-in}
+.g-md-cs-flood.gold{background:radial-gradient(circle at calc(var(--md-cs-fx) * 1%) 60%, hsl(46 100% 72% / .95) 0%, hsl(46 100% 60% / .45) 24%, hsl(46 100% 50% / .1) 60%, transparent 100%)}
+.g-md-cs-flood.royal{opacity:.9;transition:opacity .35s ease-out;
+  background:radial-gradient(circle at 50% 55%, hsl(46 100% 74% / .95) 0%, hsl(46 100% 60% / .5) 30%, hsl(46 100% 50% / .15) 70%, transparent 100%)}
+.g-md-cs-flood.dim{opacity:var(--md-cs-pay);transition:opacity .9s ease}
+.g-md-cs-trail{position:absolute;left:0;top:0;height:3px;width:0;opacity:0;transform-origin:0 50%;border-radius:2px;
+  background:linear-gradient(90deg, transparent, hsl(var(--md-n-hue-b,330) 90% 80% / .95), transparent);
+  box-shadow:0 0 10px hsl(var(--md-n-hue-b,330) 90% 70% / .7)}
+.g-md-cs-trail.on{animation:g-md-cs-trail .42s ease-out 1}
+@keyframes g-md-cs-trail{0%{opacity:0;transform:rotate(var(--md-cs-ta,0deg)) scaleX(.2)}25%{opacity:.95;transform:rotate(var(--md-cs-ta,0deg)) scaleX(1)}100%{opacity:0;transform:rotate(var(--md-cs-ta,0deg)) scaleX(1.1)}}
+.g-md-cs-static{position:absolute;inset:0;opacity:0;mix-blend-mode:screen;
+  background:repeating-linear-gradient(0deg, rgba(255,255,255,.14) 0 1px, transparent 1px 3px)}
+.g-md-cs-static.on{animation:g-md-cs-static .16s steps(3) 1}
+@keyframes g-md-cs-static{0%{opacity:.7;transform:translateY(0)}50%{opacity:.4;transform:translateY(-2px)}100%{opacity:0;transform:translateY(1px)}}
+.g-md-cs-word{position:absolute;left:50%;top:12%;transform:translate(-50%,0);pointer-events:none;
+  font:800 clamp(14px,2.4vmin,24px)/1 var(--disp,system-ui,sans-serif);letter-spacing:.24em;text-transform:uppercase;
+  color:hsl(var(--md-n-hue-b,330) 90% 84%);text-shadow:0 0 12px hsl(var(--md-n-hue-b,330) 90% 70% / .8);opacity:0}
+.g-md-cs-word.on{animation:g-md-cs-word .62s ease-out forwards}
+.g-md-cs-word.lav{color:#d8ccff;text-shadow:0 0 12px rgba(184,166,232,.8)}
+.g-md-cs-word.gold{color:#ffe08a;text-shadow:0 0 16px rgba(240,194,75,.95)}
+@keyframes g-md-cs-word{0%{opacity:0;transform:translate(-50%,10px) scale(.7)}18%{opacity:1;transform:translate(-50%,0) scale(1.08)}70%{opacity:1;transform:translate(-50%,-4px) scale(1)}100%{opacity:0;transform:translate(-50%,-16px) scale(1)}}
+/* the over-overlay: the ghost and the coins - above the arc, still no pointer */
+.g-md-cs-top{position:absolute;inset:0;pointer-events:none;z-index:5;overflow:visible}
+.g-md-cs-top *{pointer-events:none}
+.g-md-cs-ghost{position:absolute;left:0;top:0;width:var(--w,60px);height:var(--h,60px);border-radius:18%;opacity:0;
+  transform:translate(var(--x0,0px),var(--y0,0px));
+  background:hsl(var(--md-n-hue-b,330) 80% 72% / .35) center/cover no-repeat;
+  box-shadow:0 0 18px hsl(var(--md-n-hue-b,330) 90% 70% / .7), inset 0 0 0 2px hsl(var(--md-n-hue-b,330) 90% 84% / .8);
+  filter:saturate(1.2)}
+.g-md-cs-ghost.on{animation:g-md-cs-ghost 1.2s cubic-bezier(.3,.8,.3,1) 1}
+@keyframes g-md-cs-ghost{0%{opacity:0;transform:translate(var(--x0,0px),var(--y0,0px)) scale(.8)}
+  20%{opacity:.85;transform:translate(var(--x0,0px),calc(var(--y0,0px) - 10px)) scale(1.05)}
+  75%{opacity:.7;transform:translate(var(--x1,0px),calc(var(--y1,0px) - 10px)) scale(1)}
+  100%{opacity:0;transform:translate(var(--x1,0px),var(--y1,0px)) scale(.9)}}
+.g-md-cs-coin{position:absolute;left:var(--x,50%);top:var(--y,50%);width:var(--s,10px);height:var(--s,10px);border-radius:50%;opacity:0;
+  background:radial-gradient(circle at 35% 30%, #fff3c4, #f0c24b 45%, #a8771a 100%);
+  box-shadow:0 0 8px rgba(240,194,75,.8);
+  animation:g-md-cs-coin var(--d,.9s) cubic-bezier(.2,.7,.4,1) var(--dl,0s) 1 forwards}
+@keyframes g-md-cs-coin{0%{opacity:0;transform:translate(-50%,-50%) scale(.4)}
+  15%{opacity:1;transform:translate(calc(-50% + var(--dx,0px) * .3),calc(-50% - 30px)) scale(1)}
+  100%{opacity:0;transform:translate(calc(-50% + var(--dx,0px)),calc(-50% + var(--dy,-80px))) scale(.6) rotate(var(--r,180deg))}}
+.g-md-cs-punch{transition:transform .24s cubic-bezier(.2,1.6,.4,1) !important;transform:scale(var(--md-cs-ps,1)) translateY(var(--md-cs-py,0px))}
+.g-md-cs-bloom{box-shadow:0 0 0 2px hsl(var(--md-n-hue-b,330) 90% 70% / .55),0 0 22px hsl(var(--md-n-hue-b,330) 90% 65% / .6) !important;transition:box-shadow .3s ease}
+.g-md-cs-bloom.gold{box-shadow:0 0 0 2px rgba(240,194,75,.7),0 0 24px rgba(240,194,75,.7) !important}
+.g-md-cs-sink{transition:transform .5s ease-in, opacity .5s ease-in !important;transform:translateY(10px) scale(.94);opacity:.45}
+.g-md-cs-kb{animation:g-md-cs-kb var(--md-kb-t,30s) ease-in-out infinite alternate;transform-origin:var(--md-kb-o,50% 50%)}
+@keyframes g-md-cs-kb{from{transform:scale(1) translate(0,0)}to{transform:scale(1.06) translate(var(--md-kb-x,1.5%),var(--md-kb-y,-1%))}}
+@media (prefers-reduced-motion: reduce){
+  .g-md-mq-bulb{animation:none !important;opacity:.55}
+  .g-md-cs-lamp{animation:none !important}
+  .g-md-cs-kb{animation:none !important}
+  .g-md-cs-word.on{animation:none;opacity:1}
+  .g-md-cs-ghost.on{animation:none;opacity:.7}
+  .g-md-cs-coin{animation:none;opacity:0}
+}
+html.arc-reduced .g-md-mq-bulb{animation:none !important;opacity:.55}
+html.arc-reduced .g-md-cs-lamp{animation:none !important}
+html.arc-reduced .g-md-cs-kb{animation:none !important}
+html.arc-reduced .g-md-cs-ghost.on{animation:none;opacity:.7}
+.g-md-stage.suspended .g-md-mq-bulb,.g-md-stage.suspended .g-md-cs-lamp,.g-md-stage.suspended .g-md-cs-word,
+.g-md-stage.suspended .g-md-cs-ghost,.g-md-stage.suspended .g-md-cs-coin,.g-md-stage.suspended .g-md-cs-kb{animation-play-state:paused !important}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** The chime's pitch for a pick streak: +1 semitone per link, capped. Pure. */
+export function pitchForStreak(streak) {
+  const s = Math.max(0, Math.min(MD_CASINO.SEMITONE_CAP, (Number(streak) || 0) - 1));
+  return +Math.pow(2, s / 12).toFixed(4);
+}
+/** A pick under the SHARP line (ms)? Pure. */
+export function isSharp(latencyMs) {
+  const l = Number(latencyMs);
+  return Number.isFinite(l) && l > 0 && l <= MD_CASINO.SHARP_MS;
+}
+/** The jackpot rung a BANK earns from its ride depth: 'royal' | 'major' | null. Pure. */
+export function bankRung(rideDepth) {
+  const d = Math.max(0, Math.floor(Number(rideDepth) || 0));
+  if (d >= MD_CASINO.ROYAL_RIDE) return 'royal';
+  if (d >= MD_CASINO.MAJOR_RIDE) return 'major';
+  return null;
+}
+/** A pot's light, 0..1, log-ish (1 -> 0, 256+ -> 1). Pure. */
+export function potLight(pot) {
+  const p = Math.max(1, Number(pot) || 1);
+  return clamp01(Math.log2(p) / 8);
+}
+
+function el(tag, cls) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+function restart(node, cls) {
+  if (!node || !node.classList) return;
+  try {
+    node.classList.remove(cls);
+    if (typeof node.offsetWidth === 'number') void node.offsetWidth;
+    node.classList.add(cls);
+  } catch (e) { /* noop */ }
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier, stage (.g-md-stage), table (.g-md-table - the mount + geometry host; the
+ *   contract's `board` is accepted as the fallback), hud (the .g-md-hud element) + chips
+ *   {round,clock,pot,streak} (the contract's `hud` object shape is accepted too),
+ *   backdrop (.g-md-backdrop), timers {after,every,clear}, reduced, capsOk (bool|fn),
+ *   t (k, fallback) => string, engine {fire,sustain,stop,channels,ceremony?}, log
+ */
+export function createMdCasino(o) {
+  const opts = o || {};
+  const C = MD_CASINO;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const reduced = !!opts.reduced;
+  /* the chips: index.js hands `chips` (and `hud` = the strip element); the
+     contract shape hands `hud` = {pot,...}. Accept both. */
+  const hud = opts.chips || (opts.hud && !opts.hud.nodeType ? opts.hud : {}) || {};
+  /* the host: the TABLE (the arch, the lamp and the trails are sized from it);
+     `board` is the contract's name for the same seam. */
+  const host = opts.table || opts.board || null;
+  const eng = opts.engine || {};
+  const armedBase = !!opts.stage && !!host && !!opts.timers && typeof opts.timers.after === 'function'
+    && typeof document !== 'undefined';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers: the game's pause-aware registry + a local set ------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams (Law V; append-only tags) --------------------------- */
+  const seedBase = String(opts.seed || 'md') + '|md-casino|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const counts = { cues: 0, jackpots: 0, nearMisses: 0, floods: 0, words: 0, trails: 0, coins: 0 };
+  let lastSwapCueAt = -1e9;
+  function cue(name, level, extra) {
+    if (!armed()) return;
+    counts.cues++;
+    try {
+      if (typeof eng.audio === 'function') eng.audio(name, level, extra || {});
+      else if (typeof eng.fire === 'function') eng.fire('audio_trigger', Object.assign({ name, level }, extra || {}));
+    } catch (e) { /* a refused cue is not an error */ }
+  }
+  function ceremony(kind, o2) {
+    if (!armed()) return null;
+    try { return typeof eng.ceremony === 'function' ? eng.ceremony(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function nowMs() {
+    try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+    return Date.now();
+  }
+
+  /* ---- identity (per class seed; FIXED draw order, append-only) ----------- */
+  const ID = (() => {
+    const offArc = roll('arc') < C.OFF_ARC;
+    let hueA;
+    let hueB;
+    if (offArc) {
+      hueA = lerp(C.HUE_OFF, roll('hue'));
+      hueB = Math.max(140, Math.min(180, hueA + (roll('hue2') < 0.5 ? -1 : 1) * (8 + roll('hue2') * 12)));
+    } else {
+      hueA = lerp(C.HUE_ARC, roll('hue'));
+      hueB = Math.max(250, Math.min(350, hueA + (roll('hue2') < 0.5 ? -1 : 1) * (16 + roll('hue2') * 22)));
+    }
+    const metal = C.METALS[Math.floor(roll('metal') * C.METALS.length)];
+    const sway = lerp(C.LAMP_SWAY_S, roll('sway'));
+    const bulbs = C.BULBS[Math.floor(roll('bulbs') * C.BULBS.length)];
+    const bulbD = 8 + Math.round(roll('bulbs') * 3);
+    const kbExtra = roll('kb') * C.KB_SEED_SPAN;
+    const kbX = (roll('kb') < 0.5 ? -1 : 1) * (1 + roll('kb') * 1.5);
+    const kbY = (roll('kb') < 0.5 ? -1 : 1) * (0.5 + roll('kb'));
+    const kbO = (40 + Math.round(roll('kb') * 20)) + '% ' + (40 + Math.round(roll('kb') * 20)) + '%';
+    const breath = 7 + roll('breath') * 5;                                 // 7..12s
+    const drift = 18 + roll('drift') * 16;                                 // 18..34s
+    /* the journey: 2-3 distinct weave stops, genes jittered once */
+    const stops = C.STOPS_MIN + Math.floor(roll('stops') * C.STOPS_SPAN);
+    const pool = C.WEAVES.slice();
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.min(i, Math.floor(roll('shuffle') * (i + 1)));
+      const sw = pool[i]; pool[i] = pool[j]; pool[j] = sw;
+    }
+    const journey = pool.slice(0, stops).map((fam, i) => ({
+      fam,
+      alpha: 0.35 + roll('alpha') * 0.35,
+      next: pool[(i + 1) % stops],
+      nextAlpha: 0.1 + roll('next') * 0.15,
+      tilt: (roll('tilt') < 0.5 ? -1 : 1) * (4 + roll('tilt') * 26),
+      scale: 0.8 + roll('scale') * 0.6,
+    }));
+    return {
+      offArc, hueA: Math.round(hueA), hueB: Math.round(hueB), metal, sway: +sway.toFixed(1),
+      bulbs, bulbD, kbExtra, kbX, kbY, kbO, breath: +breath.toFixed(1), drift: +drift.toFixed(1), journey,
+    };
+  })();
+
+  /* ---- nodes ------------------------------------------------------------- */
+  let mq = null; let cs = null; let top = null;
+  let lamp = null; let flood = null; let trail = null; let stat = null; let word = null; let ghost = null;
+  const layers = {};
+  const props = new Set();
+  const stageClasses = new Set();
+  let started = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let stopIx = -1;
+  let bellOn = false;
+  let royalOn = false;
+  let outOn = false;
+  let shuffling = false;
+  let rideDepth = 0;
+  let bestStreak = 0;
+  let coins = 0;
+  let flashTimer = 0; let floodTimer = 0; let wordTimer = 0; let punchTimer = 0; let royalTimer = 0;
+  let ghostTimer = 0; let bustTimer = 0; let bloomTimer = 0;
+  const jackLog = [];
+
+  function setProp(k, v) { setVar(opts.stage, k, v); props.add(k); }
+  function stageClass(name, on) {
+    setCls(opts.stage, name, on);
+    if (on) stageClasses.add(name); else stageClasses.delete(name);
+  }
+
+  /* ---- the felt ----------------------------------------------------------- */
+  function dressTable() {
+    const id = ID;
+    const sat = id.offArc ? 46 : 58;
+    setProp('--md-n-hue-a', String(id.hueA));
+    setProp('--md-n-hue-b', String(id.hueB));
+    setProp('--md-n-felt', 'hsl(' + id.hueA + ',' + sat + '%,22%)');
+    setProp('--md-n-felt-deep', 'hsl(' + id.hueA + ',' + (sat + 4) + '%,12%)');
+    setProp('--md-n-felt-lit', 'hsl(' + id.hueB + ',' + (sat + 10) + '%,34%)');
+    setProp('--md-n-la', 'hsla(' + id.hueA + ',' + (sat + 10) + '%,76%,.28)');
+    setProp('--md-n-lb', 'hsla(' + id.hueB + ',' + (sat + 16) + '%,70%,.22)');
+    setProp('--md-n-glow', 'hsl(' + id.hueB + ',88%,72%)');
+    setProp('--md-n-metal', id.metal === 'brass' ? '#d4a64a' : id.metal === 'silver' ? '#c9c6d6' : '#e2a38c');
+    setProp('--md-n-metal-dk', id.metal === 'brass' ? '#7a5a1c' : id.metal === 'silver' ? '#6a6880' : '#8a5a4a');
+    setProp('--md-n-sway', id.sway + 's');
+    setProp('--md-n-breath', id.breath + 's');
+    setProp('--md-n-drift', id.drift + 's');
+    setProp('--md-n-ride', '0');
+    paintStop(0);
+    say('casino: table dressed (hue ' + id.hueA + '/' + id.hueB + (id.offArc ? ' GREEN BAIZE' : '') + ', ' + id.metal
+      + ', journey ' + id.journey.map((s) => s.fam).join('>') + ')');
+  }
+  function paintStop(ix) {
+    const stop = ID.journey[Math.max(0, Math.min(ID.journey.length - 1, ix))];
+    if (!stop) return;
+    stopIx = ix;
+    for (const fam of C.WEAVES) {
+      const a = fam === stop.fam ? stop.alpha : fam === stop.next ? stop.nextAlpha : 0;
+      setProp('--md-n-a-' + fam, a.toFixed(2));
+    }
+    setProp('--md-n-tilt', stop.tilt.toFixed(1));
+    setProp('--md-n-scale', stop.scale.toFixed(2));
+  }
+  function walkJourney(h) {
+    const n = ID.journey.length;
+    if (n < 2) return;
+    const raw = Math.min(n - 1, Math.floor(h * n));
+    if (stopIx < 0) { paintStop(raw); return; }
+    if (raw > stopIx && h >= (stopIx + 1) / n + C.STOP_HYST) paintStop(stopIx + 1);
+    else if (raw < stopIx && h <= stopIx / n - C.STOP_HYST) paintStop(stopIx - 1);
+  }
+
+  /* ---- mounting ----------------------------------------------------------- */
+  function mountBackdrop() {
+    const host = opts.backdrop;
+    if (!host || !host.appendChild) return;
+    const order = ['felt', 'diamond', 'herringbone', 'damask', 'pinstripe', 'lace', 'smoke', 'dark', 'vig'];
+    for (const name of order) {
+      const n = el('div', 'g-md-bd g-md-bd-' + name);
+      if (!n) continue;
+      layers[name] = n;
+      host.appendChild(n);
+    }
+    if (!reduced) {
+      for (const name of ['felt', 'smoke']) {
+        const n = layers[name];
+        if (!n) continue;
+        setCls(n, 'g-md-cs-kb', true);
+        setVar(n, '--md-kb-x', ID.kbX + '%');
+        setVar(n, '--md-kb-y', ID.kbY + '%');
+        setVar(n, '--md-kb-o', ID.kbO);
+      }
+    }
+  }
+  function mountMarquee() {
+    if (mq || !host.appendChild) return;
+    mq = el('div', 'g-md-mq');
+    if (!mq) return;
+    setVar(mq, '--md-mq-hue', ID.hueB);
+    setVar(mq, '--md-mq-d', ID.bulbD + 'px');
+    setVar(mq, '--n', ID.bulbs);
+    /* the arch: bulbs on the upper 200 degrees of an ellipse hugging the arc */
+    /* the rail's ellipse (style.js radius 46%/70%): centre (50%,70%), radii (49%,69%) so
+       the bulbs sit ON the brass, the chase running up one side, over, and down */
+    const span = Math.PI * 1.16;
+    for (let i = 0; i < ID.bulbs; i++) {
+      const b = el('span', 'g-md-mq-bulb');
+      if (!b) break;
+      const a = Math.PI + (Math.PI - span) / 2 + (i / (ID.bulbs - 1)) * span;   // left ... over the top ... right
+      b.style.left = (50 + 49.2 * Math.cos(a)).toFixed(2) + '%';
+      b.style.top = (70 + 69 * Math.sin(a)).toFixed(2) + '%';
+      setVar(b, '--i', i);
+      mq.appendChild(b);
+    }
+    try { host.appendChild(mq); } catch (e) { mq = null; }
+  }
+  function mountOverlay() {
+    if (cs || !host.appendChild) return;
+    cs = el('div', 'g-md-cs');
+    if (!cs) return;
+    lamp = el('div', 'g-md-cs-lamp');
+    flood = el('div', 'g-md-cs-flood');
+    trail = el('i', 'g-md-cs-trail');
+    stat = el('div', 'g-md-cs-static');
+    word = el('div', 'g-md-cs-word');
+    for (const n of [lamp, flood, trail, stat, word]) { if (n) cs.appendChild(n); }
+    try {
+      if (typeof host.insertBefore === 'function' && host.firstChild) host.insertBefore(cs, host.firstChild);
+      else host.appendChild(cs);
+    } catch (e) { cs = null; }
+    top = el('div', 'g-md-cs-top');
+    if (top) {
+      ghost = el('i', 'g-md-cs-ghost');
+      if (ghost) top.appendChild(ghost);
+      try { host.appendChild(top); } catch (e) { top = null; }
+    }
+  }
+
+  /* ---- geometry ----------------------------------------------------------- */
+  function shellOf(slot) {
+    try {
+      if (typeof opts.shells === 'function') {
+        for (const s of (opts.shells() || [])) { if (s && s.getAttribute && String(s.getAttribute('data-slot')) === String(slot)) return s; }
+      }
+      const q = host && host.querySelector ? host : opts.stage;
+      return q && q.querySelector ? q.querySelector('.g-md-shell[data-slot="' + String(slot) + '"]') : null;
+    } catch (e) { return null; }
+  }
+  /** Table-relative centre (px) and width of a slot's shell; null off-DOM. */
+  function slotPoint(slot) {
+    const b = rectOf(host);
+    const s = rectOf(shellOf(slot));
+    if (!b || !s || !b.width || !s.width) return null;
+    return { x: s.left - b.left + s.width / 2, y: s.top - b.top + s.height / 2, w: s.width, h: s.height, bw: b.width, bh: b.height };
+  }
+  function slotPct(slot, fallback) {
+    const p = slotPoint(slot);
+    if (!p) return fallback == null ? 50 : fallback;
+    return Math.max(4, Math.min(96, (p.x / p.bw) * 100));
+  }
+
+  /* ---- the light ---------------------------------------------------------- */
+  function paintHeat(force) {
+    if (!mq && !layers.felt) return;
+    if (!force && Math.abs(heat - lastPaintHeat) < C.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (mq) {
+      const gold = bellOn || royalOn;
+      let period = gold ? C.MQ_T_BELL : (C.MQ_T_SLOW + (C.MQ_T_FAST - C.MQ_T_SLOW) * heat);
+      if (shuffling && !gold) period *= C.MQ_SHUFFLE_MUL;
+      const alpha = outOn ? 0 : (gold ? C.MQ_A_BELL : lerp([C.MQ_A_LO, C.MQ_A_HI], heat));
+      setVar(mq, '--md-mq-t', period.toFixed(2) + 's');
+      setVar(mq, '--md-mq-a', alpha.toFixed(2));
+    }
+    if (!reduced) {
+      const kb = (C.KB_T[0] + (C.KB_T[1] - C.KB_T[0]) * heat + ID.kbExtra).toFixed(1) + 's';
+      for (const name of ['felt', 'smoke']) setVar(layers[name], '--md-kb-t', kb);
+    }
+  }
+  function flashArch(ms) {
+    if (!mq || !armed() || reduced) return;
+    setCls(mq, 'flash', true);
+    cancel(flashTimer);
+    flashTimer = after(ms || C.MQ_FLASH_MS, () => setCls(mq, 'flash', false));
+  }
+  function floodAt(pct, q, ms, tone) {
+    if (!flood || !armed()) return;
+    counts.floods++;
+    flood.className = 'g-md-cs-flood' + (tone ? ' ' + tone : '');
+    if (typeof flood.offsetWidth === 'number') void flood.offsetWidth;
+    setVar(cs, '--md-cs-fx', pct.toFixed(1));
+    setVar(cs, '--md-cs-pay', lerp(C.FLOOD_A, q).toFixed(2));
+    setCls(flood, 'on', true);
+    cancel(floodTimer);
+    floodTimer = after(ms || C.FLOOD_MS, () => { setCls(flood, 'on', false); });
+  }
+  function lampTo(pct, width, alpha) {
+    if (!cs) return;
+    setVar(cs, '--md-cs-lx', pct.toFixed(1));
+    setVar(cs, '--md-cs-lw', width.toFixed(2));
+    setVar(cs, '--md-cs-la', alpha.toFixed(2));
+  }
+  function punchChip(chip, q, gold) {
+    if (!chip || !armed()) return;
+    if (reduced) {
+      setCls(chip, 'g-md-cs-bloom', true);
+      setCls(chip, 'gold', !!gold);
+      cancel(bloomTimer);
+      bloomTimer = after(340, () => { setCls(chip, 'g-md-cs-bloom', false); setCls(chip, 'gold', false); });
+      return;
+    }
+    setCls(chip, 'g-md-cs-sink', false);
+    setCls(chip, 'g-md-cs-punch', true);
+    setVar(chip, '--md-cs-ps', (1 + lerp(C.PUNCH_SCALE, q)).toFixed(3));
+    setVar(chip, '--md-cs-py', '0px');
+    cancel(punchTimer);
+    punchTimer = after(C.PUNCH_MS, () => { setVar(chip, '--md-cs-ps', '1'); });
+  }
+  function showWord(key, fallback, tone) {
+    if (!word || !armed()) return;
+    counts.words++;
+    try { word.textContent = t(key, fallback); } catch (e) { return; }
+    word.className = 'g-md-cs-word' + (tone ? ' ' + tone : '');
+    if (typeof word.offsetWidth === 'number') void word.offsetWidth;
+    setCls(word, 'on', true);
+    cancel(wordTimer);
+    wordTimer = after(C.WORD_MS + 60, () => setCls(word, 'on', false));
+  }
+  /** Coins shower from a table point toward the pot chip (or just up and out). */
+  function coinsFrom(pct, count) {
+    if (!top || !top.appendChild || reduced || !armed()) return 0;
+    const b = rectOf(host);
+    const p = rectOf(hud.pot);
+    let dx = 0; let dy = -90;
+    if (b && p && b.width) {
+      dx = (p.left + p.width / 2) - (b.left + b.width * pct / 100);
+      dy = (p.top + p.height / 2) - (b.top + b.height * 0.6);
+    }
+    let made = 0;
+    for (let i = 0; i < count; i++) {
+      if (coins >= C.COINS_MAX) break;
+      const c = el('i', 'g-md-cs-coin');
+      if (!c || !c.style) break;
+      const d = lerp(C.COIN_MS, roll('coin-d')) / 1000;
+      setVar(c, '--x', (pct + (roll('coin-x') - 0.5) * 10).toFixed(1) + '%');
+      setVar(c, '--y', '60%');
+      setVar(c, '--s', (7 + roll('coin-s') * 7).toFixed(0) + 'px');
+      setVar(c, '--d', d.toFixed(2) + 's');
+      setVar(c, '--dl', (roll('coin-dl') * 0.28).toFixed(2) + 's');
+      setVar(c, '--dx', (dx + (roll('coin-sx') - 0.5) * 60).toFixed(0) + 'px');
+      setVar(c, '--dy', (dy + (roll('coin-sy') - 0.5) * 30).toFixed(0) + 'px');
+      setVar(c, '--r', ((roll('coin-r') - 0.5) * 720).toFixed(0) + 'deg');
+      top.appendChild(c);
+      coins += 1; made += 1; counts.coins += 1;
+      after(d * 1000 + 400, () => { coins = Math.max(0, coins - 1); try { c.remove(); } catch (e) { /* ignore */ } });
+    }
+    return made;
+  }
+
+  /* ---- the ladder --------------------------------------------------------- */
+  function jackpot(intensity, why) {
+    if (!armed()) return;
+    counts.jackpots++;
+    jackLog.push(why);
+    ceremony('jackpot', { intensity });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: +(0.9 + 0.3 * intensity).toFixed(3) });
+    flashArch(C.MQ_FLASH_MS + 300 * intensity);
+  }
+  function nearMiss(kind, intensity) {
+    if (!armed()) return;
+    counts.nearMisses++;
+    ceremony('near_miss', { intensity });
+    cue('near_miss', C.NEAR_LEVEL, { pitch: kind === 'almost' ? 0.8 : 1.1 });
+  }
+  function royal(pct) {
+    royalOn = true;
+    counts.royal = (counts.royal || 0) + 1;
+    stageClass('g-md-royal', true);
+    setCls(mq, 'gold', true);
+    if (flood) { flood.className = 'g-md-cs-flood royal'; setVar(cs, '--md-cs-fx', pct.toFixed(1)); }
+    showWord('md_royal', 'ROYAL', 'gold');
+    ceremony('jackpot', { intensity: C.ROYAL_I });
+    cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.2 });
+    after(260, () => cue('jackpot', C.JACKPOT_LEVEL, { pitch: 1.5 }));
+    after(520, () => cue('stamp', 0.5, { pitch: 1 }));
+    flashArch(C.ROYAL_MS);
+    coinsFrom(pct, C.COINS_ROYAL);
+    cancel(royalTimer);
+    royalTimer = after(C.ROYAL_MS, () => {
+      royalOn = false;
+      if (flood) flood.className = 'g-md-cs-flood';
+      if (!bellOn) setCls(mq, 'gold', false);
+      stageClass('g-md-royal', false);
+      paintHeat(true);
+    });
+    jackLog.push('royal');
+    counts.jackpots++;
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      if (!armed()) { say('casino: disarmed'); return; }
+      ensureStyle();
+      mountBackdrop();
+      mountMarquee();
+      mountOverlay();
+      dressTable();
+      lampTo(50, C.LAMP_W_SHUFFLE, 0.45);
+      paintHeat(true);
+      say('casino: floor lit (' + ID.bulbs + ' bulbs, ' + Object.keys(layers).length + ' layers)');
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (!started) return;
+      paintHeat(false);
+      walkJourney(heat);
+    },
+
+    /** One shell lifts and shows the target: the lamp slides over it. */
+    reveal(slot) {
+      if (!armed() || !started) return;
+      const pct = slotPct(slot, 50);
+      lampTo(pct, C.LAMP_W_REVEAL, 0.7);
+      cue('sting', C.REVEAL_LEVEL, { pitch: 0.9 });
+    },
+
+    /** The shuffle begins: the lamp opens wide, the chase quickens. */
+    shuffleStart(n) {
+      if (!armed() || !started) return;
+      shuffling = true;
+      lampTo(50, C.LAMP_W_SHUFFLE, 0.42);
+      stageClass('g-md-shuffling', true);
+      paintHeat(true);
+      cue('slide', C.SHUFFLE_LEVEL, { pitch: 0.8 + 0.05 * Math.min(6, Number(n) || 0) });
+    },
+
+    /** Two slots traded: a felt streak between them; a glitch is a static pop. */
+    swap(a, b, glitch) {
+      if (!armed() || !started) return;
+      const pa = slotPoint(a);
+      const pb = slotPoint(b);
+      if (trail && pa && pb && !reduced && !glitch) {
+        const dx = pb.x - pa.x; const dy = pb.y - pa.y;
+        const len = Math.sqrt(dx * dx + dy * dy);
+        if (len > 2) {
+          try {
+            trail.style.left = pa.x.toFixed(0) + 'px';
+            trail.style.top = pa.y.toFixed(0) + 'px';
+            trail.style.width = len.toFixed(0) + 'px';
+            setVar(trail, '--md-cs-ta', (Math.atan2(dy, dx) * 180 / Math.PI).toFixed(1) + 'deg');
+          } catch (e) { /* ignore */ }
+          restart(trail, 'on');
+          counts.trails++;
+        }
+      }
+      if (glitch && stat && !reduced) restart(stat, 'on');
+      const now = nowMs();
+      if (now - lastSwapCueAt >= C.SWAP_GAP_MS) {
+        lastSwapCueAt = now;
+        if (glitch) cue('glitch', C.GLITCH_LEVEL, { pitch: 0.9 + roll('glitch-p') * 0.3 });
+        else cue('slide', lerp(C.SWAP_LEVEL, heat), { pitch: +(0.85 + 0.3 * heat + (roll('swap-p') - 0.5) * 0.1).toFixed(3) });
+      }
+    },
+
+    /** The verdict, after the ledger. */
+    pick(ev) {
+      if (!armed() || !started) return;
+      const e = ev || {};
+      shuffling = false;
+      stageClass('g-md-shuffling', false);
+      const streak = Math.max(0, Number(e.streak) || 0);
+      bestStreak = Math.max(bestStreak, streak);
+      const pct = slotPct(e.slot, 50);
+      lampTo(pct, C.LAMP_W_PICK, 0.75);
+      if (e.correct) {
+        /* THE CHIME LADDER */
+        cue('sting', lerp(C.CHIME_LEVEL, Math.min(10, streak) / 10), { pitch: pitchForStreak(streak) });
+        /* PAYOUT LIGHT */
+        floodAt(pct, clamp01(0.35 + streak / 12), C.FLOOD_MS);
+        punchChip(hud.pot, clamp01(0.3 + streak / 12), false);
+        if (streak >= 3) flashArch();
+        /* NEAR-MISS STAGING (b): the sharp read */
+        if (isSharp(e.latencyMs)) { showWord('md_sharp', 'SHARP', 'lav'); nearMiss('sharp', C.NEAR_MISS_I.sharp); }
+        /* THE JACKPOT LADDER */
+        const mi = C.MILESTONES.indexOf(streak);
+        if (mi >= 0) {
+          cue('streak', 0.45, { pitch: pitchForStreak(streak) });
+          jackpot(C.MAJOR_I[mi], 'major@' + streak);
+        } else if (roll('jack-minor') < lerp(C.MINOR_CHANCE, heat)) {
+          jackpot(C.MINOR_I, 'minor@' + streak);
+        }
+      } else {
+        cue('bump', C.THUD_LEVEL, { pitch: 0.7 });       // a muted thud, never silence
+        floodAt(pct, 0.1, 320);
+        if (flood) setCls(flood, 'dim', true);
+      }
+      paintHeat(true);
+    },
+
+    /** The stake was taken: a ride slams the pot and deepens the rims. */
+    stake(ev) {
+      if (!armed() || !started) return;
+      const e = ev || {};
+      if (e.ride) {
+        rideDepth += 1;
+        setProp('--md-n-ride', String(Math.min(6, rideDepth)));
+        punchChip(hud.pot, clamp01(0.5 + rideDepth / 6), false);
+        flashArch();
+        // the coin-tick roll: three quick pops stepping up
+        cue('pop', C.RIDE_LEVEL, { pitch: 1 + rideDepth * 0.06 });
+        after(90, () => cue('pop', C.RIDE_LEVEL, { pitch: 1.12 + rideDepth * 0.06 }));
+        after(180, () => cue('pop', C.RIDE_LEVEL, { pitch: 1.26 + rideDepth * 0.06 }));
+      }
+    },
+
+    /** The pot is banked: the payout. Gold light, coins, the arpeggio, the thunk. */
+    bank(pot) {
+      if (!armed() || !started) return;
+      const q = potLight(pot);
+      const pct = 50;
+      const rung = bankRung(rideDepth);
+      if (rung === 'royal') {
+        royal(pct);
+      } else {
+        floodAt(pct, 0.5 + 0.5 * q, C.BANK_FLOOD_MS, 'gold');
+        flashArch(C.MQ_FLASH_MS + 200);
+        coinsFrom(pct, Math.round(lerp(C.COINS_BANK, Math.max(q, rideDepth / 5))));
+        cue('streak', C.BANK_LEVEL, { pitch: 1 + 0.04 * rideDepth });
+        after(140, () => cue('stamp', 0.4, { pitch: 1 }));
+        if (rung === 'major') jackpot(C.MAJOR_RIDE_I, 'major@ride' + rideDepth);
+      }
+      punchChip(hud.pot, clamp01(0.5 + q / 2), true);
+      if (reduced) setCls(hud.pot, 'gold', true);
+      rideDepth = 0;
+      setProp('--md-n-ride', '0');
+    },
+
+    /** The pot is lost: the table swallows it. Dim, never silent. */
+    bust() {
+      if (!armed() || !started) return;
+      rideDepth = 0;
+      setProp('--md-n-ride', '0');
+      stageClass('g-md-bust', true);
+      if (hud.pot && !reduced) { setCls(hud.pot, 'g-md-cs-punch', false); setCls(hud.pot, 'g-md-cs-sink', true); }
+      lampTo(50, C.LAMP_W_PICK, 0.25);
+      cue('stamp_bad', C.BUST_LEVEL, { pitch: 0.85 });
+      cancel(bustTimer);
+      bustTimer = after(C.BUST_MS, () => {
+        stageClass('g-md-bust', false);
+        setCls(hud.pot, 'g-md-cs-sink', false);
+        lampTo(50, C.LAMP_W_SHUFFLE, 0.45);
+      });
+    },
+
+    /** Near-miss staging: the true target ghosts through the picked shell. */
+    almost(slotPicked, slotTrue) {
+      if (!armed() || !started) return;
+      const a = slotPoint(slotPicked);
+      const b = slotPoint(slotTrue);
+      if (ghost && a && b) {
+        let url = null;
+        try {
+          const media = shellOf(slotTrue) && shellOf(slotTrue).querySelector ? shellOf(slotTrue).querySelector('.g-md-media') : null;
+          if (media && media.tagName && String(media.tagName).toLowerCase() === 'img' && media.src) url = media.src;
+          else if (media && media.poster) url = media.poster;
+        } catch (e) { url = null; }
+        const w = Math.max(24, a.w * 0.7); const h = Math.max(24, a.h * 0.7);
+        setVar(ghost, '--w', w.toFixed(0) + 'px'); setVar(ghost, '--h', h.toFixed(0) + 'px');
+        setVar(ghost, '--x0', (a.x - w / 2).toFixed(0) + 'px'); setVar(ghost, '--y0', (a.y - h / 2).toFixed(0) + 'px');
+        setVar(ghost, '--x1', (b.x - w / 2).toFixed(0) + 'px'); setVar(ghost, '--y1', (b.y - h / 2).toFixed(0) + 'px');
+        try { ghost.style.backgroundImage = url ? 'url("' + url + '")' : ''; } catch (e) { /* ignore */ }
+        restart(ghost, 'on');
+        cancel(ghostTimer);
+        ghostTimer = after(C.ALMOST_MS + 80, () => setCls(ghost, 'on', false));
+      }
+      showWord('md_almost', 'ONE OFF', 'lav');
+      nearMiss('almost', C.NEAR_MISS_I.almost);
+    },
+
+    /** The last stretch: gold arch, frantic chase. */
+    bell(on) {
+      bellOn = !!on;
+      setCls(mq, 'gold', bellOn || royalOn);
+      paintHeat(true);
+    },
+
+    /** The bell took the table: the rig sighs out and pays a dim light. */
+    dimOut() {
+      outOn = true;
+      bellOn = false;
+      setCls(mq, 'flash', false);
+      setCls(mq, 'out', true);
+      stageClass('g-md-out', true);
+      stageClass('g-md-shuffling', false);
+      if (armed() && started) {
+        /* losses disguised: a dim payout, never silence */
+        floodAt(50, 0.12 + 0.2 * clamp01(bestStreak / 10), C.END_DIM_MS, 'dim');
+        cue('wash', C.DIM_LEVEL, { pitch: 0.9 });
+        lampTo(50, C.LAMP_W_SHUFFLE, 0.2);
+      }
+      paintHeat(true);
+    },
+
+    pause() { /* transient light simply ends; the chase is CSS and .suspended freezes it */ },
+    resume() { /* nothing to re-arm: every light is event-driven */ },
+
+    stop() {
+      cancelAll();
+      for (const n of [mq]) setCls(n, 'flash', false);
+      setCls(flood, 'on', false);
+      setCls(word, 'on', false);
+      setCls(ghost, 'on', false);
+      stageClass('g-md-bust', false);
+      stageClass('g-md-shuffling', false);
+      if (hud.pot) { setCls(hud.pot, 'g-md-cs-sink', false); setVar(hud.pot, '--md-cs-ps', '1'); }
+    },
+    destroy() {
+      destroyed = true;
+      cancelAll();
+      for (const n of [mq, cs, top]) { try { if (n && n.parentNode) n.parentNode.removeChild(n); } catch (e) { /* noop */ } }
+      for (const k of Object.keys(layers)) { try { layers[k].remove(); } catch (e) { /* ignore */ } delete layers[k]; }
+      mq = cs = top = lamp = flood = trail = stat = word = ghost = null;
+      for (const name of Array.from(stageClasses)) setCls(opts.stage, name, false);
+      stageClasses.clear();
+      if (opts.stage && opts.stage.style) { for (const k of props) { try { opts.stage.style.removeProperty(k); } catch (e) { /* ignore */ } } }
+      props.clear();
+      for (const chip of [hud.pot, hud.streak]) {
+        setCls(chip, 'g-md-cs-punch', false); setCls(chip, 'g-md-cs-bloom', false); setCls(chip, 'g-md-cs-sink', false); setCls(chip, 'gold', false);
+      }
+      coins = 0;
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, heat: +heat.toFixed(3), identity: ID, stop: stopIx,
+        bell: bellOn, royal: royalOn, out: outOn, shuffling, rideDepth, bestStreak,
+        counts: Object.assign({}, counts), jackpots: jackLog.slice(),
+        liveTimers: live.size, nodes: [mq, cs, top].filter(Boolean).length, layers: Object.keys(layers).length, coins,
+      };
+    },
+  };
+  return api;
+}
+
+export default createMdCasino;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/grade.js
@@ -1,0 +1,153 @@
+/* ============================================================================
+ * games/misdirection/grade.js - the composite MISDIRECTION hands to the ONE
+ * shared rubric (core/grades.js via ctx.endClass). PURE.
+ *
+ * A game never grades itself: this file turns the table's inputs into a 0..1
+ * composite, a declared hard gate and the flavour XP, and the SHELL maps the
+ * composite to S/A/B/C and applies every cap.
+ *
+ * ---------------------------------------------------------------------------
+ * GREED IS SCORED UPWARD ONLY (the contract's ruling on the dossier's open
+ * question). The grade is BUILT out of accuracy and latency alone:
+ *
+ *   base   = .65 x occlusion-weighted accuracy  +  .35 x latency
+ *   ride   = up to +.10, scaled by the deepest ride actually BANKED
+ *   composite = clamp01(base + ride)
+ *
+ * A player who never stakes a thing can still reach 1.00 on base alone, and a
+ * player who rides five deep and busts loses NOTHING from the grade - the pot
+ * is a separate, additive economy. That is the only shape that satisfies both
+ * "confirm the rubric barrier accepts an upward-only input" and "a cautious
+ * player is not punished for caution".
+ *
+ * OCCLUSION WEIGHTING (dossier): a pick on a shuffle whose scheduled
+ * distraction load exceeded the grade baseline weighs 1.5x; a clean remedial
+ * round weighs 0.75x; everything else weighs 1. Rounds VOIDED by a suspend
+ * (panic, a mandatory video, an audio-only flip) are excluded from every
+ * denominator - they are never dealt into this file at all.
+ *
+ * HARD GATE - `sGate` is the critic's top fix, priced: if the class ever hid a
+ * link (a glitch swap or a blackout beat that actually covered the target's
+ * move) and the player never once called one of those rounds correctly, the
+ * class caps at A. S certifies tracking THROUGH deception, never a lucky
+ * guess. A tier-1 class hides nothing, so the gate passes trivially there.
+ *
+ * FLAVOUR XP: the BANKED pot, converted at a fixed rate and capped at 15
+ * (the shell's own cap). Game-owned, never composite; the XP table is C#'s.
+ * ==========================================================================*/
+
+export const GRADE = Object.freeze({
+  W_ACCURACY: 0.65,
+  W_LATENCY: 0.35,
+  /** The whole of the greed bonus. Additive, so it can only ever help. */
+  RIDE_BONUS_MAX: 0.10,
+  /** Deepest banked ride that earns the full bonus (mirrors PLAYTEST.RIDE_CAP). */
+  RIDE_BONUS_FULL: 5,
+
+  /** Weight of a pick under above-baseline distraction load. */
+  W_HEAVY: 1.5,
+  /** Weight of a pick in a clean remedial round. */
+  W_REMEDIAL: 0.75,
+  /** Weight of an ordinary pick. */
+  W_PLAIN: 1,
+
+  /** The honest pick window (ms). Anything at or past it is a timeout. */
+  WINDOW_MS: 4000,
+  /** A mean pick at or under this earns the full latency term. */
+  LATENCY_FLOOR_MS: 700,
+
+  /** Banked pot per point of flavour XP, and the shell's cap. */
+  FLAVOR_PER_XP: 2,
+  FLAVOR_CAP: 15,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+
+/** The rubric weight of one round. */
+export function weightOf(round) {
+  if (!round) return GRADE.W_PLAIN;
+  if (round.remedial) return GRADE.W_REMEDIAL;
+  if (round.heavy) return GRADE.W_HEAVY;
+  return GRADE.W_PLAIN;
+}
+
+/**
+ * @param {Object} i
+ *   rounds       [{correct, latencyMs, heavy, remedial, blind, voided}] - the
+ *                graded rounds in order. `voided` rows are ignored here as
+ *                well as by the caller, so a double-count is impossible.
+ *   deepestBanked  deepest ride depth that was actually BANKED (0..5)
+ *   gradeTier      1..4 (carried for reporting; the rubric is tier-free)
+ * @returns {{composite, base, ride, terms, counts}}
+ */
+export function compositeFor(i = {}) {
+  const rounds = (Array.isArray(i.rounds) ? i.rounds : []).filter((r) => r && !r.voided);
+
+  let wSum = 0;
+  let wHit = 0;
+  let latSum = 0;
+  let latN = 0;
+  let hits = 0;
+  let blindDealt = 0;
+  let blindHits = 0;
+  for (const r of rounds) {
+    const w = weightOf(r);
+    wSum += w;
+    if (r.correct) {
+      wHit += w;
+      hits += 1;
+      const ms = Number(r.latencyMs);
+      if (Number.isFinite(ms) && ms >= 0) { latSum += Math.min(GRADE.WINDOW_MS, ms); latN += 1; }
+    }
+    if (r.blind) {
+      blindDealt += 1;
+      if (r.correct) blindHits += 1;
+    }
+  }
+
+  const accuracy = wSum > 0 ? clamp01(wHit / wSum) : 0;
+  const meanMs = latN > 0 ? (latSum / latN) : GRADE.WINDOW_MS;
+  const span = Math.max(1, GRADE.WINDOW_MS - GRADE.LATENCY_FLOOR_MS);
+  /* No correct pick at all = no latency evidence = no latency credit. */
+  const latency = latN > 0 ? clamp01((GRADE.WINDOW_MS - meanMs) / span) : 0;
+
+  const base = GRADE.W_ACCURACY * accuracy + GRADE.W_LATENCY * latency;
+  const deepest = Math.max(0, Math.round(Number(i.deepestBanked) || 0));
+  const ride = GRADE.RIDE_BONUS_MAX * clamp01(deepest / GRADE.RIDE_BONUS_FULL);
+
+  return {
+    composite: clamp01(base + ride),
+    base: clamp01(base),
+    ride,
+    terms: { accuracy, latency },
+    counts: {
+      graded: rounds.length,
+      hits,
+      meanLatencyMs: latN > 0 ? Math.round(meanMs) : null,
+      weighted: wSum,
+      weightedHits: wHit,
+      blindDealt,
+      blindHits,
+      deepestBanked: deepest,
+    },
+  };
+}
+
+/**
+ * Declared gates. `sGate` false caps the class at A.
+ * @param {number} blindDealt rounds that actually hid a link
+ * @param {number} blindHits  those the player called correctly
+ */
+export function hardGates(blindDealt, blindHits) {
+  const dealt = Math.max(0, Math.round(Number(blindDealt) || 0));
+  const hit = Math.max(0, Math.round(Number(blindHits) || 0));
+  return { sGate: dealt === 0 ? true : hit > 0 };
+}
+
+/** The banked pot, converted and capped. Never negative, never over 15. */
+export function flavorXp(banked) {
+  const b = Math.max(0, Number(banked) || 0);
+  return Math.max(0, Math.min(GRADE.FLAVOR_CAP, Math.floor(b / GRADE.FLAVOR_PER_XP)));
+}
+
+export default { compositeFor, hardGates, flavorXp, weightOf, GRADE };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
@@ -1,0 +1,1739 @@
+/* ============================================================================
+ * games/misdirection/index.js - MISDIRECTION (family 'tracking', 120s).
+ *
+ * The shell game where the app is the con artist. One shell lifts and shows
+ * the target; the arc shuffles while the Distraction Engine attacks exactly
+ * the moments that matter; you point at the shell you followed; and then the
+ * house asks the only question it cares about - bank it, or ride it.
+ *
+ * THE ROUND (6-10s, ~10-14 per class, the class ends on the BELL):
+ *   reveal   the true shell lifts, previewMs by grade tier (1.6s -> 0.7s)
+ *   shuffle  the seeded chain runs; decoy shells lift as bait; at the top
+ *            tiers one link happens UNANIMATED under a glitch_swap inside a
+ *            wash peak, and a blackout beat rides the wash to its cap
+ *   pick     a 4s window - tap a shell, or the bound pick1..pick5 verbs
+ *   stake    a correct pick offers bank / ride (md_stake_mode may answer for
+ *            you); ride doubles the pot and raises the EFFECT tier one notch,
+ *            never the shell count, the swap rate or the preview time
+ *   remedial after two misses in a row: long look, clean shuffle, full pot,
+ *            and it can never fire twice in a row
+ *
+ * ---------------------------------------------------------------------------
+ * THE TRACKABILITY INVARIANT is this game's spine and it lives in shuffle.js
+ * (`verifyRound`): the chain is dealt from the seed BEFORE any effect is
+ * chosen, at most ONE link that actually moves the target may be occluded, a
+ * truthful tell survives every occlusion, and decoys never lift the true
+ * shell. This file's job is to keep that honest in the DOM: the tell is
+ * painted on the two shells AND cued through audio (so `ctx.audioAudible ===
+ * false` still leaves a visual), and the swap is applied to the model exactly
+ * once whether the engine's `onSwap` midpoint arrives or the backstop fires.
+ *
+ * GREED IS UPWARD ONLY (contract ruling): a busted pot costs the player
+ * nothing but the pot. grade.js builds the composite out of accuracy and
+ * latency, and the deepest BANKED ride is an additive bonus on top.
+ *
+ * LAWS THIS FILE KEEPS:
+ *   I   the ledger is honest - the target's slot, the pot, the streak, the
+ *       clock and the 4s pick window are computed here and never routed
+ *       through a deck. The trickster may lie on a `.g-md-tag`; truth is
+ *       repainted the moment the round moves on.
+ *   II  input honest - the shells are real buttons whose hitboxes only ever
+ *       move because the GAME slid them; every engine one-shot over the table
+ *       is welded clickSafe (fireSafe) and no deck may steal a tap.
+ *   III nothing is still - the arc breathes through the decks even at idle.
+ *   IV  images over text - the drawn class-rules sheet is style.js's, shown
+ *       through the shell's tutorial policy (hideTutorial + howtoTiers).
+ *   V   everything seeded - the chain, the occlusions, the decoys, the decks.
+ *       A retake replays the identical table.
+ *   VI  the exits are sacred - pause/resume/suspend/destroy freeze the round,
+ *       a suspend VOIDS the live round out of every denominator and force-
+ *       banks the pot, reducedMotion degrades, bgIntensity 0 disarms the decks.
+ *   VII every string is ctx.lexicon(key, fallback) over lex.js MD_LEX.
+ *
+ * WHAT THIS FILE DOES NOT OWN: grades (core/grades.js via ctx.endClass), XP
+ * (C#), the tier (registry + meta), effect strengths (the engine's ceiling
+ * rule), the look and the shell transforms (style.js - we only ever write
+ * --slot / --x), the lighting (casino.js), the lies (trickster.js) and the
+ * CCP-effects ladder (pressure.js). The pure model is shuffle.js and grade.js.
+ *
+ * ENGINE TARGETING NOTES:
+ *   - glitch_swap adds `.ae-glitch{position:relative;animation}` to its
+ *     targets, so it may NEVER touch a `.g-md-shell` (style.js owns that
+ *     transform). It targets the shells' `.g-md-face` nodes.
+ *   - row_drift writes an INLINE transform on its targets, so it takes
+ *     `.g-md-arc` and nothing else. style.js must not own the arc's own
+ *     transform; shells carry theirs.
+ *   - NEVER `engine.stop('wash')` (web CLAUDE.md trap 33) - a wash is stepped
+ *     down by re-triggering it at a whisper alpha.
+ *
+ * THE DECKS ARE OPTIONAL. style/casino/trickster/pressure are loaded through
+ * guarded dynamic imports (the shell's own `loadOptional` posture): a deck
+ * that is missing or throws leaves a null and the class still runs, silent.
+ * Every deck call goes through `deck()`, which is null-safe and try/catch.
+ * ==========================================================================*/
+
+import { MD_LEX } from './lex.js';
+import {
+  PLAYTEST, buildRound, simulate, verifyRound, dialsFor, potAfter, heatFor,
+  stakeModeFrom, skinFrom, clamp01,
+} from './shuffle.js';
+import { compositeFor, hardGates, flavorXp } from './grade.js';
+
+const GAME_KEY = 'misdirection';
+
+/** A url an <img> cannot show (a webm/mp4 loop). Mirrors engine/util.js
+ *  VIDEO_URL_RE; games never import the engine, so the rule is repeated. */
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
+
+/** How many decoy stills we hold before recycling (assetNeeds.stills = 6). */
+const DECOY_POOL = 6;
+
+/* ---------------------------------------------------------------------------
+ * THE DECKS - guarded optional imports. A parallel agent owns these four
+ * files; until they land (or if one throws) every hook below is null and the
+ * game runs undressed. Top-level await keeps the rest of the module fully
+ * synchronous, which is what lets start() build the decks in one breath.
+ * ------------------------------------------------------------------------ */
+const deckLoadNotes = [];
+
+async function loadModule(path) {
+  try { return await import(path); }
+  catch (e) { deckLoadNotes.push(path + ': ' + ((e && e.message) || e)); return null; }
+}
+function pickFn(mod, names) {
+  if (!mod) return null;
+  for (const n of names) { if (typeof mod[n] === 'function') return mod[n]; }
+  return null;
+}
+
+const styleMod = await loadModule('./style.js');
+const casinoMod = await loadModule('./casino.js');
+const tricksterMod = await loadModule('./trickster.js');
+const pressureMod = await loadModule('./pressure.js');
+
+/** style.js: the whole look, and (Deck VI) the drawn class-rules sheet. */
+const injectStyle = pickFn(styleMod, ['injectMisdirectionStyle', 'injectMdStyle', 'injectStyle', 'default']);
+/** The sheet BUILDER: it draws into `host` and returns the node; the POLICY
+ *  (when it shows, hideTutorial, howtoTiers) and the removal are this file's. */
+const styleBuildHowto = pickFn(styleMod, ['buildMdHowto', 'buildHowto', 'showHowto', 'showMdHowto']);
+const styleHideHowto = pickFn(styleMod, ['hideHowto', 'hideMdHowto']);
+const createMdCasino = pickFn(casinoMod, ['createMdCasino', 'createMisdirectionCasino', 'default']);
+const createMdTrickster = pickFn(tricksterMod, ['createMdTrickster', 'createMisdirectionTrickster', 'default']);
+const createMdPressure = pickFn(pressureMod, ['createMdPressure', 'createMisdirectionPressure', 'default']);
+if (styleMod && !injectStyle) deckLoadNotes.push('style.js: no inject export yet');
+if (casinoMod && !createMdCasino) deckLoadNotes.push('casino.js: no factory export yet');
+if (tricksterMod && !createMdTrickster) deckLoadNotes.push('trickster.js: no factory export yet');
+if (pressureMod && !createMdPressure) deckLoadNotes.push('pressure.js: no factory export yet');
+
+/* ---------------------------------------------------------------------------
+ * diagnostics seams (the shell never reads these; the harness does)
+ * ------------------------------------------------------------------------ */
+let liveClass = null;
+let lastReport = null;
+let lastSnapshot = null;
+
+/** Test seam: the scratch harness compresses the clock. Production = 1. */
+let timeScale = 1;
+export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
+export function getTimeScale() { return timeScale; }
+function scaled(ms) { return Math.max(0, Math.round((Number(ms) || 0) * timeScale)); }
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+
+/** Reduced motion from the shell's projection first, then the two probes. */
+function probeReduced(ctx) {
+  try { if (ctx && ctx.motion && ctx.motion.reducedMotion) return true; } catch (e) { /* ignore */ }
+  try {
+    if (typeof document !== 'undefined' && document.documentElement
+      && document.documentElement.classList
+      && document.documentElement.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+function mmss(secLeft) {
+  const s = Math.max(0, secLeft | 0);
+  return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+}
+
+export default {
+  key: GAME_KEY,
+  family: 'tracking',
+  meaty: false,
+  flagship: false,
+  timeBudgetSec: 120,
+  title: 'Misdirection',
+
+  manifest: {
+    /* flash_burst and gif_burst are declared ONLY as clickSafe decoration over
+     * a tap-precision table (DECISIONS #9) - fireSafe() welds that on at every
+     * call site, so neither can ever eat a pick. */
+    effectsConsumed: [
+      'wash', 'glitch_swap', 'row_drift', 'bubble_field', 'sub_flash',
+      'audio_trigger', 'flash_burst', 'gif_burst', 'ambient_field',
+    ],
+    /* 1 target loop + 3 loops + 6 decoy stills. Everything is DOM - nothing is
+     * ever drawn into a canvas - so the provider may serve remote media, and a
+     * missing still falls back to a CSS-FILTERED TWIN of the target. */
+    assetNeeds: { loops: 3, targets: 1, stills: 6, canvasSafe: false },
+    boardSizes: null,
+    keybinds: [
+      { verb: 'pick1', label_key: 'md_key_pick1', default: '1' },
+      { verb: 'pick2', label_key: 'md_key_pick2', default: '2' },
+      { verb: 'pick3', label_key: 'md_key_pick3', default: '3' },
+      { verb: 'pick4', label_key: 'md_key_pick4', default: '4' },
+      { verb: 'pick5', label_key: 'md_key_pick5', default: '5' },
+    ],
+    settings: [
+      {
+        key: 'md_stake_mode', kind: 'enum', values: ['ask', 'bank', 'ride'], default: 'ask',
+        label_key: 'md_stake_mode', hint_key: 'md_stake_mode_hint',
+      },
+      {
+        key: 'md_shell_skin', kind: 'enum', values: ['themed', 'minimal', 'contrast'], default: 'themed',
+        label_key: 'md_shell_skin', hint_key: 'md_shell_skin_hint',
+      },
+    ],
+    peek: false,
+  },
+
+  create(ctx) {
+    const t = (key, fallback) => {
+      const fb = fallback == null ? (MD_LEX[key] == null ? key : MD_LEX[key]) : fallback;
+      try { const v = ctx.lexicon(key, fb); return v == null ? fb : v; } catch (e) { return fb; }
+    };
+    const say = (m) => { try { ctx.log('[md] ' + m); } catch (e) { /* noop */ } };
+    const dev = ctx && ctx.dev === true;
+
+    /* ---- lifecycle flags ------------------------------------------------ */
+    let dead = false;
+    let paused = false;
+    let ended = false;
+    let reported = false;
+    let busy = true;                  // input closed until the table opens
+
+    /* ---- class state ---------------------------------------------------- */
+    let spec = null;
+    let seed = '';
+    let tier = 1;
+    let reduced = false;
+    let retake = false;
+    let budgetMs = 120000;
+    let stakeMode = 'ask';
+    let skin = 'themed';
+    let devSkipHowto = false;
+    let pool = null;
+    let capsOkNow = true;
+
+    let casino = null;
+    let trickster = null;
+    let pressure = null;
+
+    /* ---- the ledger (Law I: computed here, never by a deck) ------------- */
+    const rounds = [];                // the graded rows handed to grade.js
+    let roundIndex = -1;
+    let plan = null;                  // the live round's seeded plan
+    let roundToken = 0;               // every round timer checks this
+    let idAt = [];                    // slot -> shell id
+    let targetId = -1;
+    let pickOpenAt = 0;
+    let picked = -1;
+    let roundVoided = false;
+    let roundLive = false;
+    let awaitingStake = false;
+    let lastWasRemedial = false;
+    let consecutiveMisses = 0;
+    let streak = 0;
+    let bestStreak = 0;
+    let pot = { live: 0, rideDepth: 0, banked: 0, deepestBanked: 0, event: '' };
+    let bankedBeforeFirstMiss = false;
+    let sawFirstMiss = false;
+    let voidedRounds = 0;
+    let jackpots = 0;
+    let blindDealt = 0;
+    let blindHits = 0;
+    let currentHeat = 0;
+    let bellOn = false;
+    let driftOn = false;
+    let bubblesOn = false;
+    let ambientOn = false;
+    let stallMs = 0;
+    let subIdx = 0;
+    let rewardRoll = null;
+
+    /* ---- media ---------------------------------------------------------- */
+    let targetUrl = '';
+    let targetIsVideo = false;
+    const decoyUrls = [];
+    let decoyIdx = 0;
+    let mediaLogged = false;
+
+    /* ---- clock ---------------------------------------------------------- */
+    let clockId = 0;
+    let lastTick = 0;
+    let elapsedMs = 0;
+
+    /* ---- dom ------------------------------------------------------------ */
+    let stage = null; let backdrop = null; let hud = null; let table = null; let arc = null;
+    let stakeEl = null; let bankBtn = null; let rideBtn = null;
+    let msgEl = null; let well = null; let endEl = null;
+    let roundChip = null; let clockChip = null; let potChip = null; let streakChip = null;
+    let howtoNode = null;
+    const shellEls = [];
+    let stallTimer = 0;
+    let subTimer = 0;
+    let pickTicker = 0;
+    let keyOff = [];
+
+    /* ==================================================================== *
+     * TIMERS - every step goes through run() so a suspend freezes the round
+     * mid-shuffle and a resume finishes it. `every` simply skips while paused.
+     * ==================================================================== */
+    const timers = new Map();
+    let nextTimerId = 1;
+    const deferred = [];
+    function run(fn) {
+      if (dead) return;
+      if (paused) { deferred.push(fn); return; }
+      try { fn(); } catch (e) { say('step failed: ' + ((e && e.message) || e)); }
+    }
+    function after(ms, fn) {
+      const id = nextTimerId++;
+      const h = setTimeout(() => { timers.delete(id); run(fn); }, scaled(ms));
+      timers.set(id, { kind: 'after', h });
+      return id;
+    }
+    function every(ms, fn) {
+      const id = nextTimerId++;
+      const h = setInterval(() => {
+        if (dead || paused) return;
+        try { fn(); } catch (e) { say('tick failed: ' + ((e && e.message) || e)); }
+      }, Math.max(4, scaled(ms)));
+      timers.set(id, { kind: 'every', h });
+      return id;
+    }
+    function clearTimer(id) {
+      const rec = timers.get(id);
+      if (!rec) return;
+      if (rec.kind === 'after') clearTimeout(rec.h); else clearInterval(rec.h);
+      timers.delete(id);
+    }
+    function clearTimers() {
+      for (const id of Array.from(timers.keys())) clearTimer(id);
+      timers.clear();
+      deferred.length = 0;
+    }
+    /** The decks' registry: this class's own pause-aware timers. */
+    const deckTimers = { after, every, clear: clearTimer };
+
+    /** A round step that dies the moment its round is over (void, bell, next). */
+    function step(token, fn) {
+      return () => { if (dead || ended || token !== roundToken) return; fn(); };
+    }
+
+    /* ==================================================================== *
+     * ENGINE - one wrapper, the input-trust law welded on.
+     * ==================================================================== */
+    function fireSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'flash_burst' || kind === 'gif_burst') {
+        o.clickSafe = true;            // decoration only over a tap-precision arc
+        o.clickable = false;
+        delete o.onPop;
+      }
+      try { return ctx.engine.fire(kind, o) || null; } catch (e) { say('fire(' + kind + ') failed'); return null; }
+    }
+    function sustainSafe(kind, opts) {
+      if (dead || paused || !ctx.engine) return null;
+      const o = Object.assign({}, opts || {});
+      if (kind === 'bubble_field') { o.clickSafe = true; delete o.onPop; }
+      try { return ctx.engine.sustain(kind, o) || null; } catch (e) { return null; }
+    }
+    function stopSafe(kind) {
+      /* NEVER for 'wash' - trap 33. washDown() steps it instead. */
+      if (kind === 'wash') { washDown(); return; }
+      try { if (ctx.engine) ctx.engine.stop(kind); } catch (e) { /* noop */ }
+    }
+    /** The engine as a deck sees it: welded primitives + a READ of the clamped
+     *  channel vector (THE CEILING RULE - a deck asks, it never raises). */
+    const deckEngine = {
+      fire: fireSafe,
+      sustain: sustainSafe,
+      stop: stopSafe,
+      channels: () => {
+        try { return (ctx.engine && typeof ctx.engine.channels === 'function') ? ctx.engine.channels() : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** The player's own media, as a deck sees it. The pool lands ASYNC, so a
+     *  deck gets a LIVE reader rather than the pool object. */
+    const deckAssets = {
+      next(kind) {
+        try { return (pool && typeof pool.next === 'function') ? (pool.next(kind) || null) : null; }
+        catch (e) { return null; }
+      },
+    };
+    /** bgIntensity 0 is the player's exit: read it LIVE, never a snapshot. */
+    function capsArmed() { return !(ctx.caps && Number(ctx.caps.bgIntensity) === 0); }
+    function motionLevelOf() {
+      try { const v = Number(ctx.motion && ctx.motion.motionLevel); return Number.isFinite(v) ? v : 2; }
+      catch (e) { return 2; }
+    }
+    /** A cue through the engine; level never above the tier's audio ceiling. */
+    function tick(name, level, extra) {
+      const ceil = PLAYTEST.AUDIO_CEIL[tier] || 0.45;
+      const lv = Math.min(ceil, level == null ? 0.4 : level);
+      fireSafe('audio_trigger', Object.assign({ name, level: lv }, extra || {}));
+    }
+
+    /* ---- the decks, null-safe ------------------------------------------- */
+    function deck(which, method, ...args) {
+      const d = which === 'casino' ? casino : which === 'pressure' ? pressure : trickster;
+      if (!d || typeof d[method] !== 'function') return undefined;
+      try { return d[method](...args); } catch (e) { say(which + '.' + method + ' threw: ' + ((e && e.message) || e)); return undefined; }
+    }
+
+    /* ==================================================================== *
+     * HEAT - the class's own ladder (streak + ride depth), capped by tier
+     * ==================================================================== */
+    function heat() {
+      const h = heatFor(streak, pot.rideDepth, tier);
+      currentHeat = h;
+      try { if (ctx.engine) ctx.engine.setHeat(h); } catch (e) { /* engine is optional */ }
+      deck('casino', 'setHeat', h);
+      deck('trickster', 'setHeat', h);
+      deck('pressure', 'setHeat', h);
+      deck('pressure', 'setStreak', streak);
+    }
+
+    /* ==================================================================== *
+     * DOM (the contract's exact shape)
+     * ==================================================================== */
+    function setPhase(p) { if (stage) stage.setAttribute('data-phase', p); }
+    function setBeat(b) { if (stage) stage.setAttribute('data-beat', String(b || '')); }
+    function msg(key, fallback) { if (msgEl) msgEl.textContent = t(key, fallback); }
+
+    function buildDom(n) {
+      const root = ctx.root;
+      root.textContent = '';
+      stage = el('div', 'g-md-stage');
+      stage.setAttribute('data-phase', 'briefing');
+      stage.setAttribute('data-skin', skin);
+      stage.setAttribute('data-beat', '');
+      stage.setAttribute('data-shells', String(n));
+      if (reduced) stage.setAttribute('data-reduced', '1');
+      stage.style.setProperty('--md-n', String(n));
+
+      backdrop = el('div', 'g-md-backdrop');
+      backdrop.setAttribute('aria-hidden', 'true');
+      backdrop.style.pointerEvents = 'none';
+      stage.appendChild(backdrop);
+
+      hud = el('div', 'g-md-hud');
+      roundChip = el('span', 'g-md-chip g-md-round', '1');
+      roundChip.setAttribute('aria-label', t('md_chip_round', MD_LEX.md_chip_round));
+      clockChip = el('span', 'g-md-chip g-md-clock', mmss(budgetMs / 1000));
+      clockChip.setAttribute('aria-label', t('md_chip_clock', MD_LEX.md_chip_clock));
+      potChip = el('span', 'g-md-chip g-md-pot', '0');
+      potChip.setAttribute('aria-label', t('md_chip_pot', MD_LEX.md_chip_pot));
+      streakChip = el('span', 'g-md-chip g-md-streak', '0');
+      streakChip.setAttribute('aria-label', t('md_chip_streak', MD_LEX.md_chip_streak));
+      hud.appendChild(roundChip);
+      hud.appendChild(clockChip);
+      hud.appendChild(potChip);
+      hud.appendChild(streakChip);
+      if (retake) hud.appendChild(el('span', 'g-md-chip g-md-retake', t('md_retake', MD_LEX.md_retake)));
+      stage.appendChild(hud);
+
+      table = el('div', 'g-md-table');
+      arc = el('div', 'g-md-arc');
+      arc.style.setProperty('--n', String(n));
+      shellEls.length = 0;
+      for (let i = 0; i < n; i++) {
+        const shell = el('button', 'g-md-shell');
+        shell.setAttribute('type', 'button');
+        try { shell.type = 'button'; } catch (e) { /* the DOM double has no button semantics */ }
+        shell.setAttribute('data-id', String(i));
+        shell.setAttribute('data-slot', String(i));
+        shell.style.setProperty('--slot', String(i));
+        shell.style.setProperty('--x', n > 1 ? (i / (n - 1)).toFixed(4) : '0.5');
+        shell.style.setProperty('--md-x', n > 1 ? (i / (n - 1)).toFixed(4) : '0.5');  // registered twin (iOS: unregistered vars in calc() do not transition)
+        shell.appendChild(el('span', 'g-md-lid'));
+        const face = el('span', 'g-md-face');
+        const media = el('img', 'g-md-media');
+        armMedia(media, false);
+        face.appendChild(media);
+        shell.appendChild(face);
+        shell.appendChild(el('span', 'g-md-tag', String(i + 1)));
+        /* The handler closes over the ELEMENT, not over currentTarget: the
+         * slot is read off the node at press time, so a shell that has slid
+         * three times still answers for the slot it is standing in. */
+        const onClick = (ev) => {
+          try { if (ev && typeof ev.preventDefault === 'function') ev.preventDefault(); } catch (e) { /* noop */ }
+          const slot = Number(shell.getAttribute('data-slot'));
+          run(() => tryPick(slot));
+        };
+        shell._mdOnClick = onClick;
+        shell.addEventListener('click', onClick);
+        shellEls.push(shell);
+        arc.appendChild(shell);
+      }
+      table.appendChild(arc);
+      stage.appendChild(table);
+
+      /* THE STAKE - two real buttons, always honest, never a modal that traps
+       * the exit. They are only reachable while the stake beat is up. */
+      stakeEl = el('div', 'g-md-stake');
+      stakeEl.hidden = true;
+      bankBtn = el('button', 'g-md-btn g-md-bank', t('md_bank', MD_LEX.md_bank));
+      bankBtn.setAttribute('type', 'button');
+      try { bankBtn.type = 'button'; } catch (e) { /* noop */ }
+      bankBtn.addEventListener('click', () => run(() => resolveStake('bank', false)));
+      rideBtn = el('button', 'g-md-btn g-md-ride', t('md_ride', MD_LEX.md_ride));
+      rideBtn.setAttribute('type', 'button');
+      try { rideBtn.type = 'button'; } catch (e) { /* noop */ }
+      rideBtn.addEventListener('click', () => run(() => resolveStake('ride', false)));
+      stakeEl.appendChild(bankBtn);
+      stakeEl.appendChild(rideBtn);
+      stage.appendChild(stakeEl);
+
+      msgEl = el('p', 'g-md-msg');
+      msgEl.setAttribute('aria-live', 'polite');
+      stage.appendChild(msgEl);
+
+      well = el('div', 'g-md-flashwell');
+      well.setAttribute('aria-hidden', 'true');
+      well.style.pointerEvents = 'none';
+      stage.appendChild(well);
+
+      endEl = el('div', 'g-md-end');
+      endEl.hidden = true;
+      stage.appendChild(endEl);
+
+      root.appendChild(stage);
+    }
+
+    function shellAt(slot) {
+      for (const s of shellEls) if (Number(s.getAttribute('data-slot')) === slot) return s;
+      return null;
+    }
+    function faceOf(shell) {
+      try { for (const k of shell.children || []) if (k.classList && k.classList.contains('g-md-face')) return k; }
+      catch (e) { /* ignore */ }
+      return null;
+    }
+    function tagOf(slot) {
+      const s = shellAt(slot);
+      if (!s) return null;
+      try { for (const k of s.children || []) if (k.classList && k.classList.contains('g-md-tag')) return k; }
+      catch (e) { /* ignore */ }
+      return null;
+    }
+    /** THE TRUTH on every tag: the tag names the SLOT, which is the key that
+     *  picks it. The trickster may lie here; this puts it back. */
+    function paintTags() {
+      for (const s of shellEls) {
+        const slot = Number(s.getAttribute('data-slot')) || 0;
+        try {
+          for (const k of s.children || []) {
+            if (k.classList && k.classList.contains('g-md-tag')) {
+              const want = String(slot + 1);
+              if (k.textContent !== want) k.textContent = want;
+            }
+          }
+        } catch (e) { /* ignore */ }
+        s.setAttribute('aria-label', t('md_shell_aria', MD_LEX.md_shell_aria).replace('{n}', String(slot + 1)));
+      }
+    }
+    /** Position every shell from `idAt`. CORE writes --slot / --x; style.js
+     *  owns the transform and the transition they drive. */
+    function paintSlots() {
+      const n = idAt.length;
+      for (let slot = 0; slot < n; slot++) {
+        const id = idAt[slot];
+        const shell = shellEls[id];
+        if (!shell) continue;
+        shell.setAttribute('data-slot', String(slot));
+        shell.style.setProperty('--slot', String(slot));
+        shell.style.setProperty('--x', n > 1 ? (slot / (n - 1)).toFixed(4) : '0.5');
+        shell.style.setProperty('--md-x', n > 1 ? (slot / (n - 1)).toFixed(4) : '0.5');  // registered twin (iOS: unregistered vars in calc() do not transition)
+      }
+      paintTags();
+    }
+    function clearShellState() {
+      for (const s of shellEls) {
+        s.classList.remove('is-lifted', 'is-true', 'is-picked', 'is-tell', 'is-decoy', 'is-fake', 'is-swapping');
+      }
+    }
+    function paintHud() {
+      if (roundChip) roundChip.textContent = String(roundIndex + 1);
+      if (potChip) potChip.textContent = pot.live > 0 ? ('x' + pot.live) : String(pot.banked);
+      if (streakChip) streakChip.textContent = String(streak);
+      if (clockChip) clockChip.textContent = mmss(secLeft());
+    }
+    /** The TRUE chip text - what the trickster's Stat Flicker restores to. */
+    function chipText(which) {
+      if (which === 'round') return String(roundIndex + 1);
+      if (which === 'clock') return mmss(secLeft());
+      if (which === 'streak') return String(streak);
+      return pot.live > 0 ? ('x' + pot.live) : String(pot.banked);
+    }
+
+    /* ==================================================================== *
+     * MEDIA - ctx.assets ONLY, DOM only, never a canvas.
+     * The target is ONE loop, frozen for the class. A decoy wears a pool
+     * still; with no stills to draw the decoy wears a CSS-FILTERED TWIN of
+     * the target (hue-rotate + mirror), which is the contract's ruling and
+     * costs no canvas pass at all.
+     * ==================================================================== */
+    function armMedia(node, video) {
+      if (!node) return;
+      try {
+        node.setAttribute('alt', '');
+        node.setAttribute('draggable', 'false');
+        node.draggable = false;
+        if (video) {
+          node.muted = true; node.loop = true; node.autoplay = true; node.playsInline = true;
+          node.setAttribute('muted', ''); node.setAttribute('loop', '');
+          node.setAttribute('autoplay', ''); node.setAttribute('playsinline', '');
+          node.setAttribute('preload', 'auto');
+          node.addEventListener('loadeddata', () => {
+            if (dead) return;
+            try { const p = node.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* ignore */ }
+          });
+        } else {
+          node.decoding = 'async';
+        }
+      } catch (e) { /* the DOM double has no media semantics; fine */ }
+    }
+    /** The media node that can SHOW this url: the face's <img>, swapped for a
+     *  <video> when the url is a webm/mp4 loop (engine/util.js mediaEl
+     *  semantics, repeated - games never import the engine). */
+    function mediaNodeFor(face, url) {
+      if (!face) return null;
+      let cur = null;
+      try { for (const k of face.children || []) if (k.classList && k.classList.contains('g-md-media')) cur = k; }
+      catch (e) { /* ignore */ }
+      const wantVideo = VIDEO_URL_RE.test(String(url || ''));
+      const isVideo = !!(cur && String(cur.tagName || '').toUpperCase() === 'VIDEO');
+      if (cur && wantVideo === isVideo) return cur;
+      const next = el(wantVideo ? 'video' : 'img', 'g-md-media');
+      armMedia(next, wantVideo);
+      try {
+        if (cur && typeof face.replaceChild === 'function') face.replaceChild(next, cur);
+        else face.appendChild(next);
+      } catch (e) { try { face.appendChild(next); } catch (e2) { /* ignore */ } }
+      return next;
+    }
+    /** Dress one shell's face. `filter` is the twin's CSS lie (never canvas). */
+    function dressFace(shell, url, filter) {
+      const face = faceOf(shell);
+      if (!face) return;
+      if (!url) { clearFace(shell); return; }
+      const node = mediaNodeFor(face, url);
+      if (!node) return;
+      try {
+        if (node.getAttribute('src') !== url) node.setAttribute('src', url);
+        node.style.setProperty('filter', filter || 'none');
+        node.style.setProperty('transform', filter && filter.indexOf('mirror') >= 0 ? 'scaleX(-1)' : 'none');
+      } catch (e) { /* ignore */ }
+      face.setAttribute('data-dressed', '1');
+    }
+    function clearFace(shell) {
+      const face = faceOf(shell);
+      if (!face) return;
+      try {
+        for (const k of Array.from(face.children || [])) {
+          if (k.classList && k.classList.contains('g-md-media')) {
+            if (String(k.tagName || '').toUpperCase() === 'VIDEO') { try { k.pause(); } catch (e) { /* noop */ } }
+            k.removeAttribute('src');
+            try { k.style.setProperty('filter', 'none'); k.style.setProperty('transform', 'none'); } catch (e) { /* noop */ }
+          }
+        }
+        face.setAttribute('data-dressed', '0');
+      } catch (e) { /* ignore */ }
+    }
+    /** A decoy's face: a pool still, else the CSS-filtered twin. */
+    function decoyLook(fake) {
+      if (decoyUrls.length) {
+        const url = decoyUrls[decoyIdx % decoyUrls.length];
+        decoyIdx += 1;
+        return { url, filter: 'none' };
+      }
+      if (!targetUrl) return { url: '', filter: 'none' };
+      /* THE TWIN. A convincing fake target is a small hue shift; an ordinary
+       * decoy is turned far enough that it reads as a different thing. The
+       * mirror is applied through the transform, keyed off the filter word. */
+      return fake
+        ? { url: targetUrl, filter: 'hue-rotate(22deg) saturate(1.05)' }
+        : { url: targetUrl, filter: 'hue-rotate(155deg) saturate(0.7) mirror' };
+    }
+    function claimAssets() {
+      Promise.resolve()
+        .then(() => (ctx.assets && typeof ctx.assets.claim === 'function')
+          ? ctx.assets.claim({ loops: 3, targets: 1, stills: 6, canvasSafe: false })
+          : null)
+        .then((p) => {
+          if (dead || !p || typeof p.next !== 'function') return;
+          pool = p;
+          dealMedia();
+        })
+        .catch((e) => say('asset claim failed - shells run bare: ' + ((e && e.message) || e)));
+    }
+    /** ONE target for the class (the dossier's per-class asset bill) plus the
+     *  decoy stills. Called again if a later round still has no target. */
+    function dealMedia() {
+      if (!pool) return;
+      if (!targetUrl) {
+        try { const got = pool.next('target'); if (got && got.url) targetUrl = String(got.url); }
+        catch (e) { targetUrl = ''; }
+        targetIsVideo = VIDEO_URL_RE.test(targetUrl);
+      }
+      while (decoyUrls.length < DECOY_POOL) {
+        let url = '';
+        try { const got = pool.next('still'); url = got && got.url ? String(got.url) : ''; } catch (e) { url = ''; }
+        /* A decoy is NEVER a video: two playing <video> nodes lock the page to
+         * 30Hz (the Lost & Found measurement), and a decoy lift can overlap
+         * the target's. Stills only, twins otherwise. */
+        if (!url || VIDEO_URL_RE.test(url)) break;
+        if (decoyUrls.indexOf(url) >= 0) break;
+        decoyUrls.push(url);
+      }
+      if (!mediaLogged) {
+        mediaLogged = true;
+        say('media: target ' + (targetUrl ? (targetIsVideo ? 'loop(video)' : 'loop') : 'none')
+          + ', ' + decoyUrls.length + ' decoy stills' + (decoyUrls.length ? '' : ' - twins in use'));
+      }
+    }
+
+    /* ==================================================================== *
+     * THE WASH - never stopped, always stepped (trap 33).
+     * ==================================================================== */
+    function washTo(alpha, holdMs) {
+      if (!capsOkNow) return;
+      sustainSafe('wash', {
+        variant: 'pink',
+        alpha: clamp01(alpha),
+        strength: clamp01(alpha),
+        holdMs: Math.max(120, scaled(holdMs || 900)),
+      });
+    }
+    function washDown() {
+      /* Step DOWN by re-triggering at a whisper - the decks' documented
+       * step-down, and the only legal way out of a held wash. A room that was
+       * never armed has nothing to step down, so it asks for nothing at all. */
+      if (!capsOkNow) return;
+      sustainSafe('wash', { variant: 'pink', alpha: 0.01, strength: 0.01, holdMs: 120 });
+    }
+
+    /* ==================================================================== *
+     * THE ROUND
+     * ==================================================================== */
+    function secLeft() { return Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)); }
+
+    function nextRound() {
+      if (dead || ended) return;
+      if (elapsedMs >= budgetMs) { bell(); return; }
+      roundToken += 1;
+      const token = roundToken;
+      roundIndex += 1;
+      picked = -1;
+      roundVoided = false;
+      roundLive = true;
+      awaitingStake = false;
+      stallMs = 0;
+      busy = true;
+
+      const remedial = consecutiveMisses >= PLAYTEST.REMEDIAL_AFTER && !lastWasRemedial;
+      lastWasRemedial = remedial;
+      if (remedial) consecutiveMisses = 0;
+
+      plan = buildRound({
+        seed, gradeTier: tier, index: roundIndex,
+        rideDepth: pot.rideDepth, remedial, reduced,
+      });
+      if (dev) {
+        const bad = verifyRound(plan);
+        if (bad.length) say('DEV: round ' + roundIndex + ' violates the invariant: ' + bad.join('; '));
+      }
+      if (plan.blind) blindDealt += 1;
+
+      /* reset the arc: shell id i sits in slot i, lids down, faces bare */
+      idAt = [];
+      for (let i = 0; i < plan.shells; i++) idAt.push(i);
+      targetId = idAt[plan.startSlot];
+      clearShellState();
+      for (const s of shellEls) clearFace(s);
+      paintSlots();
+      paintHud();
+      if (!targetUrl || decoyUrls.length < 1) dealMedia();
+
+      setBeat(remedial ? 'remedial' : '');
+      if (remedial) msg('md_remedial_line', MD_LEX.md_remedial_line);
+      reveal(token);
+    }
+
+    /* ---- 1. REVEAL ------------------------------------------------------ */
+    function reveal(token) {
+      setPhase('reveal');
+      const slot = plan.startSlot;
+      const shell = shellAt(slot);
+      if (shell) {
+        shell.classList.add('is-lifted', 'is-true');
+        dressFace(shell, targetUrl, 'none');
+      }
+      deck('casino', 'reveal', slot);
+      tick('reveal', 0.34);
+      if (!plan.remedial) msg('md_reveal_line', MD_LEX.md_reveal_line);
+      after(plan.dials.previewMs, step(token, () => {
+        if (shell) shell.classList.remove('is-lifted');
+        after(PLAYTEST.SETTLE_MS, step(token, () => shuffle(token)));
+      }));
+    }
+
+    /* ---- 2. SHUFFLE ----------------------------------------------------- */
+    function shuffle(token) {
+      setPhase('shuffle');
+      setBeat('');
+      msg('md_shuffle_line', MD_LEX.md_shuffle_line);
+      const d = plan.dials;
+      deck('casino', 'shuffleStart', plan.swaps.length);
+      deck('pressure', 'beat', 'shuffle');
+
+      /* The synchronized occlusion: one wash held across the shuffle, pulsing
+       * up on the links that matter. Riding raises the alpha, never the pace. */
+      if (capsOkNow) washTo(d.washAlpha * 0.5, d.shuffleMs + 400);
+      if (capsOkNow && d.bubbles > 0 && !reduced && !bubblesOn) {
+        bubblesOn = true;
+        sustainSafe('bubble_field', { max: d.bubbles, alpha: 0.28, variant: 'drift', clickSafe: true });
+      }
+
+      for (const s of plan.swaps) {
+        after(s.at, step(token, () => applySwap(token, s)));
+      }
+      for (const dec of plan.decoys) {
+        after(dec.at, step(token, () => decoyReveal(token, dec)));
+      }
+      after(d.shuffleMs + 120, step(token, () => openPick(token)));
+    }
+
+    /**
+     * ONE LINK. The model moves exactly once, whether the engine's midpoint
+     * callback arrives or the backstop deadline does (web CLAUDE.md trap 22).
+     */
+    function applySwap(token, s) {
+      const a = s.a; const b = s.b;
+      const shellA = shellAt(a); const shellB = shellAt(b);
+      let done = false;
+      const commit = () => {
+        if (done || dead || token !== roundToken) return;
+        done = true;
+        const tmp = idAt[a]; idAt[a] = idAt[b]; idAt[b] = tmp;
+        paintSlots();
+        if (shellA) shellA.classList.remove('is-swapping');
+        if (shellB) shellB.classList.remove('is-swapping');
+        deck('casino', 'swap', a, b, !!s.glitch);
+        /* The trickster's beat: one deal per link, budgeted and capped by the
+         * deck itself (Deck III's dealing rule), never by this file. */
+        deck('trickster', 'afterSwap');
+      };
+
+      if (shellA) shellA.classList.add('is-swapping');
+      if (shellB) shellB.classList.add('is-swapping');
+
+      if (s.occluded) {
+        /* THE TELL - truthful, on both shells AND in the audio, so a blackout
+         * can never take the last recoverable piece of information with it.
+         * Every occlusion carries one, so the tell never singles out the link
+         * that actually mattered. */
+        if (shellA) shellA.classList.add('is-tell');
+        if (shellB) shellB.classList.add('is-tell');
+        tick('tell', 0.3, { pitch: s.tell && s.tell.side === 'left' ? 0.92 : 1.12 });
+        after(s.tell ? s.tell.ms : PLAYTEST.TELL_MS, step(token, () => {
+          if (shellA) shellA.classList.remove('is-tell');
+          if (shellB) shellB.classList.remove('is-tell');
+        }));
+
+        if (s.blackout) {
+          /* The blackout beat: the wash rides to the round's cap for a breath,
+           * then steps back down to the shuffle level. Reduced motion gets a
+           * STATIC occluder instead of a strobe, hiding the same information. */
+          stage.setAttribute('data-occluding', '1');
+          if (!reduced) washTo(plan.dials.washAlpha, plan.dials.blackoutMs);
+          msg('md_blind_line', MD_LEX.md_blind_line);
+          after(plan.dials.blackoutMs, step(token, () => {
+            stage.setAttribute('data-occluding', '0');
+            if (!reduced) washTo(plan.dials.washAlpha * 0.5, 700);
+          }));
+          commit();                       // unanimated: the slide never happens
+          return;
+        }
+
+        /* A glitch swap: unanimated, under the shared glitch_swap transition,
+         * targeting the FACES (never the shells - style.js owns those). */
+        const faces = [];
+        if (shellA) { const f = faceOf(shellA); if (f) faces.push(f); }
+        if (shellB) { const f = faceOf(shellB); if (f) faces.push(f); }
+        stage.setAttribute('data-occluding', '1');
+        if (!reduced && faces.length) {
+          fireSafe('glitch_swap', {
+            targets: faces,
+            seconds: 0.42,
+            onSwap: () => run(commit),
+          });
+        }
+        /* THE BACKSTOP (trap 22): the engine's midpoint rides the engine's own
+         * timer registry, and a suspend kills it. We resolve on our deadline
+         * whatever happens. */
+        after(reduced ? 60 : 220, step(token, () => {
+          commit();
+          stage.setAttribute('data-occluding', '0');
+        }));
+        return;
+      }
+
+      /* An ordinary link: the shells slide. style.js owns the transition; we
+       * move the model at the midpoint so the truth and the look agree. */
+      after(reduced ? 40 : 130, step(token, commit));
+    }
+
+    /** A decoy lift - always on a shell she is NOT under (shuffle.js law). */
+    function decoyReveal(token, dec) {
+      const shell = shellAt(dec.slot);
+      if (!shell) return;
+      const look = decoyLook(!!dec.fake);
+      shell.classList.add('is-lifted', 'is-decoy');
+      if (dec.fake) shell.classList.add('is-fake');
+      dressFace(shell, look.url, look.filter);
+      /* The misleading sting: a lift cue pitched from the WRONG side of the
+       * table (the Intake audio-gaslighting precedent). Presentation only. */
+      tick('lift', 0.26, { pitch: dec.slot < plan.shells / 2 ? 1.14 : 0.9 });
+      after(reduced ? 260 : 200, step(token, () => {
+        shell.classList.remove('is-lifted', 'is-decoy', 'is-fake');
+        clearFace(shell);
+      }));
+    }
+
+    /* ---- 3. PICK -------------------------------------------------------- */
+    function openPick(token) {
+      setPhase('pick');
+      setBeat('');
+      msg('md_pick_line', MD_LEX.md_pick_line);
+      busy = false;
+      pickOpenAt = Date.now();
+      stallMs = 0;
+      const d = plan.dials;
+
+      /* The last glance, contaminated - and welded clickSafe over a table the
+       * player is about to tap (DECISIONS #9). */
+      if (d.pickBurst && capsOkNow) fireSafe('flash_burst', { count: 2, alpha: 0.4 });
+      /* row_drift slides the whole ARC so remembered screen positions decay.
+       * It writes an inline transform, so it takes the arc and nothing else. */
+      if (d.rowDrift && capsOkNow && !reduced && arc) {
+        driftOn = true;
+        sustainSafe('row_drift', { targets: [arc], axis: 'x', variant: 'sway', amplitudeMult: 0.6 });
+      }
+
+      /* The HONEST window, published as a var so style.js can draw a ring and
+       * the trickster's Crooked Clock has a truth to lie about. */
+      if (pickTicker) clearTimer(pickTicker);
+      pickTicker = every(60, () => {
+        if (token !== roundToken || !stage) return;
+        const p = clamp01((Date.now() - pickOpenAt) / Math.max(1, scaled(d.pickMs)));
+        stage.style.setProperty('--md-pick', p.toFixed(3));
+      });
+      after(d.pickMs, step(token, () => resolvePick(token, -1, true)));
+    }
+
+    function tryPick(slot) {
+      if (dead || ended || busy || !roundLive || awaitingStake) return;
+      if (!plan || !(slot >= 0 && slot < plan.shells)) return;
+      resolvePick(roundToken, slot, false);
+    }
+
+    function resolvePick(token, slot, timedOut) {
+      if (dead || ended || token !== roundToken || !roundLive) return;
+      roundLive = false;
+      busy = true;
+      picked = slot;
+      if (pickTicker) { clearTimer(pickTicker); pickTicker = 0; }
+      if (driftOn) { stopSafe('row_drift'); driftOn = false; }
+      if (bubblesOn) { stopSafe('bubble_field'); bubblesOn = false; }
+      washDown();
+      setPhase('pick');
+
+      const latencyMs = timedOut ? plan.dials.pickMs : Math.max(0, Date.now() - pickOpenAt);
+      const trueSlot = plan.finalSlot;
+      const correct = !timedOut && slot >= 0 && idAt[slot] === targetId;
+
+      /* THE LEDGER ROW. A round voided by a suspend never reaches this line. */
+      rounds.push({
+        index: roundIndex,
+        correct,
+        latencyMs,
+        heavy: !!plan.heavy,
+        remedial: !!plan.remedial,
+        blind: !!plan.blind,
+        timedOut: !!timedOut,
+        voided: false,
+      });
+      if (plan.blind && correct) blindHits += 1;
+
+      /* lift the truth, always - the near-miss beat needs it and so does trust */
+      const trueShell = shellAt(trueSlot);
+      const pickShell = slot >= 0 ? shellAt(slot) : null;
+      if (pickShell) pickShell.classList.add('is-picked', 'is-lifted');
+      if (trueShell) {
+        trueShell.classList.add('is-true');
+        after(correct ? 0 : 260, step(token, () => {
+          trueShell.classList.add('is-lifted');
+          dressFace(trueShell, targetUrl, 'none');
+        }));
+      }
+      deck('casino', 'pick', { slot, correct, latencyMs, streak });
+      deck('trickster', 'afterPick');
+
+      if (correct) {
+        streak += 1;
+        bestStreak = Math.max(bestStreak, streak);
+        consecutiveMisses = 0;
+        setBeat('hit');
+        msg('md_hit_line', MD_LEX.md_hit_line);
+        tick('hit', 0.5, { pitch: Math.min(1.7, 1 + Math.min(7, streak) * 0.06) });
+        try { ctx.ceremonies.streakMeter({ target: null, filled: Math.min(10, streak) }); } catch (e) { /* noop */ }
+        const bankedBefore = pot.banked;
+        pot = potAfter(pot, 'win');
+
+        /* the shared variable-ratio canon: usually a plain lift, sometimes a
+         * garnish, rarely the full jackpot - which doubles the pot for free. */
+        const roll = rewardOnce();
+        if (roll && roll.jackpot) {
+          jackpots += 1;
+          pot = potAfter(pot, 'double');
+          try { ctx.ceremonies.reward('jackpot', { target: table, text: t('md_jackpot', MD_LEX.md_jackpot) }); } catch (e) { /* noop */ }
+          msg('md_scholarship', MD_LEX.md_scholarship);
+        } else if (roll && roll.fire && capsOkNow) {
+          fireSafe('gif_burst', { count: 3, alpha: 0.42 });
+        }
+
+        heat();
+        paintHud();
+
+        if (pot.event === 'forceBank') {
+          /* THE RIDE CAP: five deep force-banks with the jackpot ceremony. */
+          setBeat('forcebank');
+          /* The casino is told the AMOUNT that just landed, never the running
+           * total - its payout light is scaled by the pot, not by the bank. */
+          deck('casino', 'bank', pot.banked - bankedBefore);
+          try { ctx.ceremonies.reward('jackpot', { target: table, text: t('md_royal', MD_LEX.md_royal) }); } catch (e) { /* noop */ }
+          msg('md_ride_cap_line', MD_LEX.md_ride_cap_line);
+          if (!sawFirstMiss) bankedBeforeFirstMiss = true;
+          after(resolveMs(), step(token, () => { endRound(token); }));
+          return;
+        }
+        after(reduced ? 260 : 420, step(token, () => openStake(token)));
+        return;
+      }
+
+      /* ---- a miss ------------------------------------------------------ */
+      streak = 0;
+      consecutiveMisses += 1;
+      sawFirstMiss = true;
+      const adjacent = slot >= 0 && Math.abs(slot - trueSlot) === 1;
+      setBeat(timedOut ? 'timeout' : adjacent ? 'almost' : 'miss');
+      if (timedOut) {
+        msg('md_timeout_line', MD_LEX.md_timeout_line);
+        tick('miss', 0.24);
+      } else if (adjacent) {
+        /* COSMETIC staging only - the chain was never rigged to land next
+         * door, so `almost` reports what happened and never arranges it. */
+        deck('casino', 'almost', slot, trueSlot);
+        try { ctx.ceremonies.reward('near_miss', { target: table, text: t('md_almost', MD_LEX.md_almost) }); } catch (e) { /* noop */ }
+        msg('md_almost_line', MD_LEX.md_almost_line);
+        tick('miss', 0.3);
+      } else {
+        msg('md_miss_line', MD_LEX.md_miss_line);
+        tick('miss', 0.3);
+      }
+      if (pot.live > 0) {
+        pot = potAfter(pot, 'bust');
+        deck('casino', 'bust');
+        msg('md_bust_line', MD_LEX.md_bust_line);
+      }
+      heat();
+      paintHud();
+      after(resolveMs(), step(token, () => endRound(token)));
+    }
+
+    function resolveMs() { return reduced ? PLAYTEST.RESOLVE_MS_REDUCED : PLAYTEST.RESOLVE_MS; }
+
+    /** The reward canon, engine first, a seeded local fallback second. */
+    function rewardOnce() {
+      try {
+        if (ctx.engine && typeof ctx.engine.rewardRoll === 'function') {
+          const r = ctx.engine.rewardRoll({ heat: currentHeat, streak });
+          if (r) return r;
+        }
+      } catch (e) { /* fall through */ }
+      return rewardRoll ? rewardRoll() : null;
+    }
+
+    /* ---- 4. STAKE ------------------------------------------------------- */
+    function openStake(token) {
+      if (dead || ended || token !== roundToken) return;
+      awaitingStake = true;
+      setPhase('stake');
+      setBeat('');
+      if (stakeEl) stakeEl.hidden = false;
+      if (rideBtn) rideBtn.disabled = pot.rideDepth >= PLAYTEST.RIDE_CAP;
+      msg('md_stake_line', MD_LEX.md_stake_line);
+      deck('casino', 'stake', { ride: false, pot: pot.live });
+
+      if (stakeMode === 'bank') {
+        after(PLAYTEST.AUTO_STAKE_MS, step(token, () => resolveStake('bank', true)));
+      } else if (stakeMode === 'ride') {
+        after(PLAYTEST.AUTO_STAKE_MS, step(token, () => resolveStake('ride', true)));
+      } else {
+        /* The prompt never traps: on a timeout the SAFE answer wins, because
+         * an inattentive player must never be walked into a stake. */
+        after(PLAYTEST.STAKE_MS, step(token, () => resolveStake('bank', true)));
+      }
+    }
+
+    function resolveStake(action, auto) {
+      if (dead || ended || !awaitingStake) return;
+      awaitingStake = false;
+      const token = roundToken;
+      if (stakeEl) stakeEl.hidden = true;
+
+      if (action === 'ride' && pot.rideDepth < PLAYTEST.RIDE_CAP) {
+        pot = potAfter(pot, 'ride');
+        setBeat('ride');
+        deck('casino', 'stake', { ride: true, pot: pot.live });
+        msg(auto ? 'md_auto_ride_line' : 'md_ride_line',
+          auto ? MD_LEX.md_auto_ride_line : MD_LEX.md_ride_line);
+        tick('ride', 0.4, { pitch: 1 + Math.min(5, pot.rideDepth) * 0.08 });
+      } else {
+        const amount = pot.live;
+        pot = potAfter(pot, 'bank');
+        setBeat('bank');
+        deck('casino', 'bank', amount);
+        try { ctx.ceremonies.stamp({ text: t('md_stamp_bank', MD_LEX.md_stamp_bank), tone: 'pink', target: table }); } catch (e) { /* noop */ }
+        msg(auto && stakeMode === 'bank' ? 'md_auto_bank_line' : 'md_banked_line',
+          auto && stakeMode === 'bank' ? MD_LEX.md_auto_bank_line : MD_LEX.md_banked_line);
+        tick('bank', 0.45);
+        if (!sawFirstMiss) bankedBeforeFirstMiss = true;
+      }
+      heat();
+      paintHud();
+      after(reduced ? 320 : 520, step(token, () => endRound(token)));
+    }
+
+    /* ---- 5. END OF ROUND ------------------------------------------------ */
+    function endRound(token) {
+      if (dead || ended || token !== roundToken) return;
+      clearShellState();
+      for (const s of shellEls) clearFace(s);
+      setBeat('');
+      if (elapsedMs >= budgetMs) { bell(); return; }
+      nextRound();
+    }
+
+    /**
+     * THE VOID. A suspend (panic, a mandatory video, an audio-only flip) kills
+     * the live round: no miss is recorded, the round is excluded from every
+     * denominator, the occlusion clears and the STAKED pot force-banks - the
+     * dossier's panic rule, applied to every suspend reason.
+     */
+    function voidLiveRound(why) {
+      if (!plan || (!roundLive && !awaitingStake)) return;
+      roundToken += 1;                    // every pending step for this round dies
+      roundLive = false;
+      awaitingStake = false;
+      roundVoided = true;
+      voidedRounds += 1;
+      if (plan.blind) blindDealt = Math.max(0, blindDealt - 1);
+      if (pot.live > 0) { pot = potAfter(pot, 'bank'); }
+      if (stakeEl) stakeEl.hidden = true;
+      if (pickTicker) { clearTimer(pickTicker); pickTicker = 0; }
+      if (driftOn) { stopSafe('row_drift'); driftOn = false; }
+      if (bubblesOn) { stopSafe('bubble_field'); bubblesOn = false; }
+      washDown();
+      if (stage) stage.setAttribute('data-occluding', '0');
+      setBeat('void');
+      clearShellState();
+      for (const s of shellEls) clearFace(s);
+      paintHud();
+      say('round ' + roundIndex + ' voided (' + (why || 'suspend') + ') - excluded from the ledger');
+    }
+
+    /* ==================================================================== *
+     * THE CLOCK + THE BELL
+     * ==================================================================== */
+    function startClock() {
+      lastTick = Date.now();
+      clockId = every(250, () => {
+        if (ended) return;
+        const now = Date.now();
+        const dt = now - lastTick;
+        lastTick = now;
+        elapsedMs += dt / Math.max(0.0001, timeScale);
+        if (clockChip) clockChip.textContent = mmss(secLeft());
+        const left = secLeft();
+        if (!bellOn && left <= PLAYTEST.BELL_WARN_SEC && elapsedMs < budgetMs) {
+          bellOn = true;
+          deck('casino', 'bell', true);
+          deck('pressure', 'beat', 'bell');
+          msg('md_bell_warn', MD_LEX.md_bell_warn);
+          tick('sting', 0.4);
+        }
+        if (elapsedMs >= budgetMs) { stopClock(); run(bell); }
+      });
+    }
+    function stopClock() { if (clockId) { clearTimer(clockId); clockId = 0; } }
+
+    function bell() {
+      if (dead || ended) return;
+      busy = true;
+      /* An unfinished round at the bell was never given a fair pick, so it is
+       * simply not recorded - the same posture as a voided round. */
+      if (roundLive || awaitingStake) voidLiveRound('bell');
+      bellOn = true;
+      setPhase('ended');
+      deck('casino', 'dimOut');
+      deck('pressure', 'dimOut');
+      try { ctx.ceremonies.stamp({ text: t('md_stamp_bell', MD_LEX.md_stamp_bell), tone: 'pink', target: table }); } catch (e) { /* noop */ }
+      msg('md_bell_line', MD_LEX.md_bell_line);
+      tick('stamp', 0.6);
+      after(reduced ? 700 : 1100, () => finish());
+    }
+
+    /* ==================================================================== *
+     * THE END - exactly one endClass, after the end card has been seen
+     * ==================================================================== */
+    function finish() {
+      if (ended) return;
+      ended = true;
+      busy = true;
+      stopClock();
+      if (pickTicker) { clearTimer(pickTicker); pickTicker = 0; }
+      if (stallTimer) { clearTimer(stallTimer); stallTimer = 0; }
+      if (subTimer) { clearTimer(subTimer); subTimer = 0; }
+      if (driftOn) { stopSafe('row_drift'); driftOn = false; }
+      if (bubblesOn) { stopSafe('bubble_field'); bubblesOn = false; }
+      if (ambientOn) { stopSafe('ambient_field'); ambientOn = false; }
+      washDown();
+      deck('trickster', 'stop');
+      deck('casino', 'stop');
+      deck('pressure', 'stop');
+      paintTags();                         // truth on every tag, whatever the lie left
+      paintHud();
+
+      const graded = compositeFor({ rounds, deepestBanked: pot.deepestBanked, gradeTier: tier });
+      const gates = hardGates(graded.counts.blindDealt, graded.counts.blindHits);
+      const fx = flavorXp(pot.banked);
+
+      try {
+        const meta = (ctx.store && typeof ctx.store.gameMeta === 'function') ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        const bestBank = Math.max(Number(meta.bestBank) || 0, pot.banked);
+        const bestRide = Math.max(Number(meta.bestRide) || 0, pot.deepestBanked);
+        if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+          ctx.store.mergeGameMeta(GAME_KEY, {
+            bestBank, bestRide, lastSeed: seed, lastPlayedAt: Date.now(),
+          });
+        }
+      } catch (e) { say('meta write failed (class unaffected): ' + ((e && e.message) || e)); }
+
+      renderEnd(graded);
+      setPhase('ended');
+
+      const report = { metrics: { composite: graded.composite }, hardGates: gates, flavorXp: fx };
+      lastReport = Object.assign({}, report, {
+        inputs: {
+          tier, seed, retake, reduced, stakeMode, skin,
+          rounds: rounds.length, voided: voidedRounds,
+          banked: pot.banked, deepestBanked: pot.deepestBanked,
+          bestStreak, jackpots, bankedBeforeFirstMiss,
+          terms: graded.terms, counts: graded.counts, base: graded.base, ride: graded.ride,
+          elapsedMs,
+        },
+      });
+      try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
+      say('class over: ' + graded.counts.hits + '/' + graded.counts.graded + ' picks, '
+        + (graded.counts.meanLatencyMs == null ? '-' : graded.counts.meanLatencyMs + 'ms')
+        + ', banked ' + pot.banked + ' (deepest ride ' + pot.deepestBanked + '), blind '
+        + graded.counts.blindHits + '/' + graded.counts.blindDealt
+        + ' -> composite ' + graded.composite.toFixed(3) + (gates.sGate ? '' : ' [S GATE FAILED]'));
+
+      after(reduced ? PLAYTEST.END_HOLD_MS_REDUCED : PLAYTEST.END_HOLD_MS, () => {
+        if (reported) return;
+        reported = true;
+        try { ctx.endClass(report); } catch (e) { say('endClass threw: ' + ((e && e.message) || e)); }
+      });
+    }
+
+    function renderEnd(graded) {
+      if (!endEl) return;
+      endEl.textContent = '';
+      endEl.hidden = false;
+      endEl.appendChild(el('h3', 'g-md-end-title', t('md_end_title', MD_LEX.md_end_title)));
+      const row = (cls, k, v) => {
+        const r = el('div', 'g-md-end-row' + (cls ? ' ' + cls : ''));
+        r.appendChild(el('span', 'g-md-end-k', k));
+        r.appendChild(el('span', 'g-md-end-v', v));
+        endEl.appendChild(r);
+        return r;
+      };
+      /* The card LEADS with the banked total, not the misses (dossier). */
+      row('g-md-end-bank', t('md_end_banked', MD_LEX.md_end_banked), String(pot.banked));
+      row('', t('md_end_picks', MD_LEX.md_end_picks), graded.counts.hits + ' / ' + graded.counts.graded);
+      row('', t('md_end_latency', MD_LEX.md_end_latency),
+        graded.counts.meanLatencyMs == null ? '-' : (graded.counts.meanLatencyMs + 'ms'));
+      row('', t('md_end_deepest', MD_LEX.md_end_deepest), String(pot.deepestBanked));
+      row('', t('md_end_streak', MD_LEX.md_end_streak), String(bestStreak));
+      row('', t('md_end_rounds', MD_LEX.md_end_rounds), String(rounds.length));
+      if (graded.counts.blindDealt > 0) {
+        row('g-md-end-blind', t('md_end_blind', MD_LEX.md_end_blind),
+          graded.counts.blindHits > 0 ? t('md_end_yes', MD_LEX.md_end_yes) : t('md_end_no', MD_LEX.md_end_no));
+        if (graded.counts.blindHits > 0) {
+          try { ctx.ceremonies.stamp({ text: t('md_stamp_blind', MD_LEX.md_stamp_blind), target: endEl }); } catch (e) { /* noop */ }
+        }
+      }
+      if (bankedBeforeFirstMiss) {
+        endEl.appendChild(el('p', 'g-md-end-note', t('md_end_clean', MD_LEX.md_end_clean)));
+      }
+    }
+
+    /* ==================================================================== *
+     * THE CLASS-RULES SHEET (Deck VI). Policy is the shell's "Skip class
+     * tutorials" contract: default shows every class; with the skip on, a
+     * class still explains itself ONCE per grade tier, remembered in the
+     * game's own meta (never the shell's). Dismissal is the sheet's own GO
+     * button, nothing else - binding a pick key here would teach the player
+     * to press it at a table that has not been dealt.
+     * ==================================================================== */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+    function howto(onDone) {
+      const seen = howtoSeenTiers();
+      const skip = (dev && devSkipHowto) || (ctx.hideTutorial === true && seen.indexOf(tier) >= 0);
+      if (skip) { onDone(); return; }
+      if (typeof showHowtoFn !== 'function') { onDone(); return; }
+      let done = false;
+      let node = null;
+      try {
+        const labels = pickKeyLabels().slice(0, dialsFor({ gradeTier: tier }).shells);
+        node = showHowtoFn({
+          host: stage, stage, table, t, tier, reduced,
+          keys: labels.join(' '),
+          keyLabel: labels[Math.min(2, labels.length - 1)] || '3',
+          coarse: !!(ctx.platform && ctx.platform.isTouch),
+          onGo: () => {
+            if (done || dead) return;
+            done = true;
+            try {
+              const list = howtoSeenTiers();
+              if (list.indexOf(tier) < 0) {
+                list.push(tier);
+                if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+                  ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: list });
+                }
+              }
+            } catch (e) { /* best effort - the sheet just shows again next time */ }
+            hideHowto();
+            onDone();
+          },
+        });
+      } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); node = null; }
+      if (!node) { done = true; onDone(); return; }
+      howtoNode = node;
+    }
+    function hideHowto() {
+      try { if (typeof hideHowtoFn === 'function') hideHowtoFn(); } catch (e) { /* noop */ }
+      try { if (howtoNode && typeof howtoNode.remove === 'function') howtoNode.remove(); } catch (e) { /* noop */ }
+      howtoNode = null;
+    }
+    /** The bound pick keys, for the sheet's one line of text. */
+    function pickKeyLabels() {
+      const out = [];
+      for (let i = 1; i <= 5; i++) {
+        let lbl = String(i);
+        try { if (ctx.keys && typeof ctx.keys.labelFor === 'function') lbl = ctx.keys.labelFor('pick' + i) || String(i); }
+        catch (e) { /* noop */ }
+        out.push(lbl);
+      }
+      return out;
+    }
+    /* style.js provides these; both are optional. */
+    let showHowtoFn = null;
+    let hideHowtoFn = null;
+
+    /* ==================================================================== *
+     * INPUT
+     * ==================================================================== */
+    function bindKeys() {
+      keyOff = [];
+      if (!ctx.keys || typeof ctx.keys.on !== 'function') return;
+      for (let i = 1; i <= 5; i++) {
+        const slot = i - 1;
+        try {
+          const off = ctx.keys.on('pick' + i, () => run(() => tryPick(slot)));
+          if (typeof off === 'function') keyOff.push(off);
+        } catch (e) { /* a verb the shell refused to declare */ }
+      }
+    }
+    function unbindKeys() {
+      for (const off of keyOff) { try { off(); } catch (e) { /* noop */ } }
+      keyOff = [];
+      for (const s of shellEls) {
+        try { if (s._mdOnClick) s.removeEventListener('click', s._mdOnClick); } catch (e) { /* noop */ }
+      }
+    }
+
+    /* ==================================================================== *
+     * THE MODULE INSTANCE
+     * ==================================================================== */
+    const instance = {
+      start(classSpec) {
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
+        tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
+        seed = String(spec.seed == null ? GAME_KEY : spec.seed);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
+        retake = !!spec.retake;
+        reduced = probeReduced(ctx) || motionLevelOf() === 0;
+        stakeMode = stakeModeFrom(ctx.settings ? ctx.settings.md_stake_mode : 'ask');
+        skin = skinFrom(ctx.settings ? ctx.settings.md_shell_skin : 'themed');
+        capsOkNow = capsArmed();
+        devSkipHowto = dev && !!spec.devSkipHowto;
+
+        rounds.length = 0;
+        roundIndex = -1;
+        roundToken = 0;
+        streak = 0; bestStreak = 0;
+        pot = { live: 0, rideDepth: 0, banked: 0, deepestBanked: 0, event: '' };
+        consecutiveMisses = 0;
+        lastWasRemedial = false;
+        bankedBeforeFirstMiss = false;
+        sawFirstMiss = false;
+        voidedRounds = 0; jackpots = 0; blindDealt = 0; blindHits = 0;
+        elapsedMs = 0; bellOn = false; ended = false; reported = false; dead = false;
+        decoyUrls.length = 0; decoyIdx = 0; targetUrl = ''; targetIsVideo = false; mediaLogged = false;
+
+        /* the seeded local reward roll - the floor under engine.rewardRoll */
+        {
+          let n = 0;
+          const base = 0.30 + 0.30 * (tier - 1) / 3;
+          rewardRoll = () => {
+            n += 1;
+            const a = hash(seed + '|md-vr|fire|' + n);
+            const b = hash(seed + '|md-vr|jack|' + n);
+            const chance = Math.min(0.9, base + Math.min(8, streak) * 0.02);
+            const fire = a < chance;
+            return { fire, jackpot: fire && b >= 0.85, nearMiss: !fire && a < chance + 0.08 };
+          };
+        }
+
+        const n = dialsFor({ gradeTier: tier }).shells;
+        try { if (typeof injectStyle === 'function') injectStyle(); }
+        catch (e) { say('style inject failed (class unaffected): ' + ((e && e.message) || e)); }
+        buildDom(n);
+        idAt = []; for (let i = 0; i < n; i++) idAt.push(i);
+        paintSlots();
+        paintHud();
+
+        /* ---- the decks ---------------------------------------------------
+         * Built right after mount, each in its own try/catch. A refused deck
+         * is a null and a log line; the class runs undressed. */
+        const chips = { round: roundChip, clock: clockChip, pot: potChip, streak: streakChip };
+        const base = {
+          seed, tier, gradeTier: tier,
+          reduced, motionLevel: motionLevelOf(),
+          timers: deckTimers,
+          engine: deckEngine,
+          /* LIVE, never a launch snapshot: bgIntensity 0 is the player's exit
+           * and it disarms every deck the moment it moves. The decks accept a
+           * function or a boolean; the function is the honest one. */
+          capsOk: capsArmed,
+          budgetSec: Math.round(budgetMs / 1000),
+          t,
+          log: say,
+        };
+        try {
+          casino = (typeof createMdCasino === 'function') ? (createMdCasino(Object.assign({}, base, {
+            stage, backdrop, table, arc, board: arc, frame: table,
+            /* `hud` is the CHIP MAP (that is what a deck lights); the element
+             * itself rides along as hudEl for a deck that wants the bar. */
+            hud: chips, chips, hudEl: hud,
+            shells: () => shellEls.slice(),
+            msg: msgEl, well, stake: stakeEl,
+            assets: deckAssets,
+            utcDate: utcDateOf(seed),
+          })) || null) : null;
+        } catch (e) { casino = null; say('casino refused: ' + ((e && e.message) || e)); }
+        try {
+          trickster = (typeof createMdTrickster === 'function') ? (createMdTrickster(Object.assign({}, base, {
+            stage, arc, table, board: arc, hud: chips, hudEl: hud,
+            isHalted: () => dead || paused || ended || busy,
+            coarse: !!(ctx.platform && ctx.platform.isTouch),
+            stats: () => ({
+              round: roundIndex, phase: stage ? stage.getAttribute('data-phase') : 'ended',
+              streak, pot: pot.live, banked: pot.banked, rideDepth: pot.rideDepth,
+              secLeft: secLeft(), shells: plan ? plan.shells : n,
+            }),
+            /* the ONE node a lie may land on, plus the truth to restore */
+            tagOf,
+            chipEl: (which) => (which === 'clock' ? clockChip : which === 'pot' ? potChip
+              : which === 'streak' ? streakChip : roundChip),
+            chipText,
+            shells: () => shellEls.slice(),
+            /* THE TRUE SLOT, read-only. The Ghost Cursor lures to a shell NEXT
+             * TO her and The Melt refuses to sag the one she is under, so both
+             * cards need to know where she is - and neither may ever move her
+             * (Law I) or move a hitbox (Law II). */
+            targetSlot: () => idAt.indexOf(targetId),
+            /* We draw no ring of our own - the honest window is published as
+             * --md-pick on the stage and the deck mounts its own crooked one. */
+            ringEl: () => null,
+            /* the HONEST pick window, so the Crooked Clock has a truth to bend */
+            pickWindow: () => ({
+              open: !!(plan && roundLive && stage && stage.getAttribute('data-phase') === 'pick'),
+              elapsedMs: pickOpenAt ? Math.max(0, Date.now() - pickOpenAt) : 0,
+              totalMs: plan ? plan.dials.pickMs : PLAYTEST.PICK_MS,
+            }),
+            announce: (text, ms) => {
+              if (!msgEl || !text) return;
+              msgEl.textContent = String(text);
+              const mine = msgEl.textContent;
+              deckTimers.after(Math.max(400, Number(ms) || 1600), () => {
+                if (msgEl && msgEl.textContent === mine) msgEl.textContent = '';
+              });
+            },
+          })) || null) : null;
+        } catch (e) { trickster = null; say('trickster refused: ' + ((e && e.message) || e)); }
+        try {
+          pressure = (typeof createMdPressure === 'function') ? (createMdPressure(Object.assign({}, base, {
+            stage, backdrop, table, arc, board: arc,
+            /* THE TREMOR rides the chrome, never a truth node: the HUD bar,
+             * the proctor line and the stake buttons shake; the arc and the
+             * shells the player is tracking never do. */
+            chrome: [hud, msgEl, stakeEl].filter(Boolean),
+            hud: chips, hudEl: hud,
+            assets: deckAssets,
+          })) || null) : null;
+        } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
+
+        /* THE SHEET (Deck VI): style.js draws it, this file owns the POLICY.
+         * A casino that exports its own showHowto is the fallback seam. */
+        showHowtoFn = null; hideHowtoFn = null;
+        if (typeof styleBuildHowto === 'function') {
+          showHowtoFn = styleBuildHowto;
+          hideHowtoFn = (typeof styleHideHowto === 'function') ? styleHideHowto : null;
+        } else if (casino && typeof casino.showHowto === 'function') {
+          showHowtoFn = (o) => casino.showHowto(o);
+          hideHowtoFn = () => { try { casino.hideHowto(); } catch (e) { /* noop */ } };
+        }
+
+        bindKeys();
+        claimAssets();
+        heat();
+
+        /* the ambient floor: the table is never still (Law III) */
+        if (capsOkNow && tier >= 2 && !reduced) {
+          ambientOn = true;
+          sustainSafe('ambient_field', { kind: 'motes', density: 0.35, alpha: 0.3 });
+        }
+        /* sub_flash between rounds only - never during a pick window, which
+         * would be a lie about the thing the player is being graded on. */
+        const subMs = dialsFor({ gradeTier: tier }).subFlashMs;
+        if (subMs > 0 && capsOkNow) {
+          subTimer = every(subMs, () => {
+            if (ended || !stage) return;
+            if (stage.getAttribute('data-phase') === 'pick') return;
+            subIdx += 1;
+            fireSafe('sub_flash', { variant: subIdx % 2 ? 'whisper' : 'centre', alpha: 0.32 });
+          });
+        }
+        stallTimer = every(PLAYTEST.STALL_TICK_MS, () => {
+          if (ended || busy || !roundLive) { stallMs = 0; return; }
+          stallMs += PLAYTEST.STALL_TICK_MS;
+          deck('trickster', 'stalled', stallMs);
+        });
+
+        startClock();
+        liveClass = instance;
+        lastReport = null;
+        lastSnapshot = null;
+
+        msg('md_brief', MD_LEX.md_brief);
+        howto(() => {
+          if (dead || ended) return;
+          deck('casino', 'start');
+          deck('trickster', 'start');
+          deck('pressure', 'start');
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
+            if (dead || ended) return;
+            busy = false;
+            nextRound();
+          });
+        });
+
+        say('tier ' + tier + ', ' + n + ' shells, budget ' + Math.round(budgetMs / 1000) + 's, stake '
+          + stakeMode + ', skin ' + skin + (reduced ? ', reduced' : '') + (retake ? ', RETAKE' : '')
+          + ', decks ' + (casino ? 'casino ' : '') + (trickster ? 'trickster ' : '') + (pressure ? 'pressure' : '')
+          + (deckLoadNotes.length ? ' | ' + deckLoadNotes.join(' | ') : ''));
+      },
+
+      pause() {
+        if (paused) return;
+        paused = true;
+        deck('pressure', 'pause');
+        deck('casino', 'pause');
+        deck('trickster', 'pause');
+        if (stage) stage.classList.add('suspended');
+      },
+
+      resume() {
+        if (!paused) return;
+        paused = false;
+        if (stage) stage.classList.remove('suspended');
+        deck('pressure', 'resume');
+        deck('casino', 'resume');
+        deck('trickster', 'resume');
+        lastTick = Date.now();
+        pickOpenAt = Date.now();          // the window restarts honestly, never mid-flight
+        const q = deferred.splice(0);
+        for (const fn of q) run(fn);
+        /* A voided round is dealt again from the top the moment play resumes. */
+        if (roundVoided && !ended && !dead) {
+          roundVoided = false;
+          msg('md_voided_line', MD_LEX.md_voided_line);
+          after(reduced ? 300 : 600, () => { if (!ended && !dead) nextRound(); });
+        }
+      },
+
+      /** The shell owns the overlay and the engine's suspend; we freeze AND
+       *  void, because a round the player could not watch must never be
+       *  graded (dossier: the live round voids with no miss recorded). */
+      suspend(on) {
+        if (on) {
+          voidLiveRound('suspend');
+          instance.pause();
+        } else {
+          instance.resume();
+        }
+      },
+
+      destroy() {
+        dead = true;
+        stopClock();
+        clearTimers();
+        unbindKeys();
+        hideHowto();
+        try { if (trickster) trickster.destroy(); } catch (e) { /* noop */ }
+        trickster = null;
+        try { if (casino) casino.destroy(); } catch (e) { /* noop */ }
+        casino = null;
+        try { if (pressure) pressure.destroy(); } catch (e) { /* noop */ }
+        pressure = null;
+        if (pool && typeof pool.release === 'function') { try { pool.release(); } catch (e) { /* noop */ } }
+        pool = null;
+        shellEls.length = 0;
+        try { ctx.root.textContent = ''; } catch (e) { /* noop */ }
+        if (liveClass === instance) liveClass = null;
+      },
+
+      /* -------- test / diagnostics seams (never read by the shell) -------- */
+      /** Pick a slot as the player would. */
+      pick(slot) { run(() => tryPick(slot)); },
+      /** Answer the stake prompt as the player would. */
+      stake(action) { run(() => resolveStake(action === 'ride' ? 'ride' : 'bank', false)); },
+      /** The live round's seeded plan. */
+      plan() { return plan; },
+      /** Where she really is, right now. The suite's oracle; nothing else. */
+      trueSlot() { return idAt.indexOf(targetId); },
+      chipText(which) { return chipText(which); },
+
+      snapshot() {
+        return {
+          tier, seed, retake, reduced, stakeMode, skin, capsOk: capsOkNow,
+          roundIndex, roundToken, roundLive, awaitingStake, roundVoided, busy, paused, ended, reported, dead,
+          phase: stage ? stage.getAttribute('data-phase') : null,
+          beat: stage ? stage.getAttribute('data-beat') : null,
+          occluding: stage ? stage.getAttribute('data-occluding') : null,
+          shells: plan ? plan.shells : shellEls.length,
+          idAt: idAt.slice(),
+          targetId,
+          trueSlot: idAt.indexOf(targetId),
+          picked,
+          plan: plan ? {
+            index: plan.index, startSlot: plan.startSlot, finalSlot: plan.finalSlot,
+            swaps: plan.swaps.length, hiddenLinks: plan.hiddenLinks, blind: plan.blind,
+            heavy: plan.heavy, remedial: plan.remedial, decoys: plan.decoys.length,
+            dials: plan.dials,
+          } : null,
+          rounds: rounds.slice(),
+          voidedRounds, blindDealt, blindHits, jackpots,
+          streak, bestStreak, pot: Object.assign({}, pot),
+          bankedBeforeFirstMiss, consecutiveMisses, lastWasRemedial,
+          currentHeat, driftOn, bubblesOn, ambientOn, bellOn,
+          targetUrl, decoys: decoyUrls.slice(),
+          elapsedMs, budgetMs, secLeft: secLeft(),
+          deckLoadNotes: deckLoadNotes.slice(),
+          casino: casino && typeof casino.diagnostics === 'function' ? (() => { try { return casino.diagnostics(); } catch (e) { return null; } })() : null,
+          trickster: trickster && typeof trickster.diagnostics === 'function' ? (() => { try { return trickster.diagnostics(); } catch (e) { return null; } })() : null,
+          pressure: pressure && typeof pressure.diagnostics === 'function' ? (() => { try { return pressure.diagnostics(); } catch (e) { return null; } })() : null,
+          stage, arc, table, hud, msgEl, well, endEl, stakeEl, bankBtn, rideBtn,
+          roundChip, clockChip, potChip, streakChip,
+          shellEls: shellEls.slice(),
+        };
+      },
+    };
+
+    /** The UTC day the class was seeded on (the shell's seed opens with it). */
+    function utcDateOf(s) {
+      const m = /^(\d{4}-\d{2}-\d{2})/.exec(String(s || ''));
+      if (m) return m[1];
+      try { return new Date().toISOString().slice(0, 10); } catch (e) { return '1970-01-01'; }
+    }
+
+    /** FNV-1a 0..1 - the local reward roll's only source of randomness, and it
+     *  is seeded, so a retake rolls the identical rewards. */
+    function hash(str) {
+      let h = 2166136261 >>> 0;
+      const v = String(str);
+      for (let i = 0; i < v.length; i++) { h ^= v.charCodeAt(i); h = Math.imul(h, 16777619); }
+      return (h >>> 0) / 4294967295;
+    }
+
+    return instance;
+  },
+
+  /** The live class's state, or null. Never read by the shell. */
+  diagnostics() { return liveClass ? liveClass.snapshot() : null; },
+  /** The last report handed to endClass (survives teardown). Diagnostics only. */
+  get lastReport() { return lastReport; },
+  get lastSnapshot() { return lastSnapshot; },
+
+  setTimeScale,
+};
+
+/* Re-exported so the rig and the suite can reach the pure model through the
+ * one module they already import. Nothing in the shell reads these. */
+export { PLAYTEST, buildRound, simulate, verifyRound, dialsFor, potAfter, heatFor };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/index.js
@@ -469,7 +469,6 @@ export default {
         shell.setAttribute('data-slot', String(i));
         shell.style.setProperty('--slot', String(i));
         shell.style.setProperty('--x', n > 1 ? (i / (n - 1)).toFixed(4) : '0.5');
-        shell.style.setProperty('--md-x', n > 1 ? (i / (n - 1)).toFixed(4) : '0.5');  // registered twin (iOS: unregistered vars in calc() do not transition)
         shell.appendChild(el('span', 'g-md-lid'));
         const face = el('span', 'g-md-face');
         const media = el('img', 'g-md-media');
@@ -568,7 +567,6 @@ export default {
         shell.setAttribute('data-slot', String(slot));
         shell.style.setProperty('--slot', String(slot));
         shell.style.setProperty('--x', n > 1 ? (slot / (n - 1)).toFixed(4) : '0.5');
-        shell.style.setProperty('--md-x', n > 1 ? (slot / (n - 1)).toFixed(4) : '0.5');  // registered twin (iOS: unregistered vars in calc() do not transition)
       }
       paintTags();
     }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/lex.js
@@ -1,0 +1,117 @@
+/* ============================================================================
+ * games/misdirection/lex.js - every `md_` lexicon row MISDIRECTION renders,
+ * with its neutral English fallback. Exported as DATA (the Impulse Control /
+ * Deep End precedent, IC_LEX / DE_LEX) so the host's `NeutralLexicon` can be
+ * mirrored key-for-key: copy the values, never re-word them.
+ *
+ * RULES (web CLAUDE.md trap 26 + the contract): a value longer than 96
+ * characters can never be mod-skinned, so every row here is <= 96; a row is
+ * rendered ONLY through ctx.lexicon(key, fallback) (Law VII - accents come
+ * from the lexicon, never AI). The decks (casino / trickster / pressure) may
+ * call the same `t()` with the same keys; every key either side uses lives in
+ * THIS table.
+ *
+ * THE SHELL NOUN is the mod skin's main lever: `md_shell_noun` (cups /
+ * canisters / lockers per the mod table) and `md_shell_aria` carry it. The
+ * LOGIC never reads a name - it compares slot indices and shell ids.
+ * ==========================================================================*/
+
+export const MD_LEX = Object.freeze({
+  /* ---- the noun (mod skin: cups / canisters / lockers) ----------------- */
+  md_shell_noun: 'Shell',
+  /** {n} = the shell's number, 1-based, left to right. */
+  md_shell_aria: 'Shell {n}',
+
+  /* ---- setting rows (manifest.settings) -------------------------------- */
+  md_stake_mode: 'Stake prompt',
+  md_stake_mode_hint: 'Ask after every win, or always bank / always ride without the prompt.',
+  md_stake_mode_ask: 'Ask',
+  md_stake_mode_bank: 'Always bank',
+  md_stake_mode_ride: 'Always ride',
+  md_shell_skin: 'Shell skin',
+  md_shell_skin_hint: 'Themed shells, plain shapes, or high-contrast rims that stay readable.',
+  md_shell_skin_themed: 'Themed',
+  md_shell_skin_minimal: 'Minimal',
+  md_shell_skin_contrast: 'High contrast',
+
+  /* ---- keybind rows (manifest.keybinds) -------------------------------- */
+  md_key_pick1: 'Pick the first shell',
+  md_key_pick2: 'Pick the second shell',
+  md_key_pick3: 'Pick the third shell',
+  md_key_pick4: 'Pick the fourth shell',
+  md_key_pick5: 'Pick the fifth shell',
+
+  /* ---- HUD chips (aria labels; the chip TEXT is live data) -------------- */
+  md_chip_round: 'Round',
+  md_chip_clock: 'Time left',
+  md_chip_pot: 'Pot',
+  md_chip_streak: 'Streak',
+
+  /* ---- the drawn class-rules sheet (Deck VI, images over text) ---------- */
+  md_howto_title: 'Class rules',
+  md_howto_watch: 'One shell lifts. What is under it is the only thing you are tracking.',
+  md_howto_shuffle: 'They slide and trade places. The room will do its best to blind you.',
+  md_howto_pick: 'Point at the shell you followed. Four seconds, every round.',
+  md_howto_stake: 'Right? Bank the pot, or ride it double into a dirtier shuffle.',
+  md_howto_go: 'Open the table',
+  /** {keys} = the bound pick keys, e.g. "1 2 3 4 5". */
+  md_howto_keys: 'Keys {keys} pick a shell.',
+
+  /* ---- proctor lines (.g-md-msg, one at a time) ------------------------- */
+  md_brief: 'Watch the shell. Keep watching it. Then point at it.',
+  md_reveal_line: 'There she is.',
+  md_shuffle_line: 'Eyes on her.',
+  md_pick_line: 'Where is she?',
+  md_hit_line: 'Right where you said she was.',
+  md_miss_line: 'Empty. The true lid comes up.',
+  md_almost_line: 'One off. She was next door the whole time.',
+  md_timeout_line: 'Too slow. The lid comes up anyway.',
+  md_remedial_line: 'Slow round. Clean shuffle, full pot.',
+  md_blind_line: 'The hand comes over the table.',
+  md_bell_warn: 'Twenty seconds.',
+  md_bell_line: 'The bell. Hands off the table.',
+  md_retake: 'Retake',
+  md_voided_line: 'That round is off the books. Your bank is safe.',
+
+  /* ---- the stake prompt (.g-md-stake - real buttons, honest) ------------ */
+  md_stake_line: 'Bank it, or ride it double or nothing?',
+  md_bank: 'Bank',
+  md_ride: 'Ride',
+  md_banked_line: 'Banked. Nothing takes that back.',
+  md_ride_line: 'Riding. The table gets dirtier.',
+  md_ride_cap_line: 'Five deep. The house pays out and the table resets.',
+  md_bust_line: 'The pot goes back to the house. Your bank is untouched.',
+  md_auto_bank_line: 'Banked for you.',
+  md_auto_ride_line: 'Riding for you.',
+
+  /* ---- stamps + ceremonies (Deck II) ------------------------------------ */
+  md_stamp_bank: 'BANKED',
+  md_stamp_bell: 'BELL',
+  md_stamp_blind: 'EYES OPEN',
+  md_jackpot: 'JACKPOT',
+  md_royal: 'ROYAL',
+  md_near_miss: 'SO CLOSE',
+  md_almost: 'ONE OFF',
+  md_scholarship: 'SCHOLARSHIP ROUND',
+
+  /* ---- the trickster's lines (Deck III, via the deck's own t()) --------- */
+  md_trick_seen: 'Did you see that?',
+  md_trick_melt: 'The lids run like wax',
+  md_trick_feint: 'Nothing moved that time',
+  md_trick_hint: 'This one. Surely.',
+
+  /* ---- the end card (.g-md-end) ---------------------------------------- */
+  md_end_title: 'Table report',
+  md_end_banked: 'Banked',
+  md_end_picks: 'Picks',
+  md_end_latency: 'Average pick',
+  md_end_deepest: 'Deepest ride banked',
+  md_end_rounds: 'Rounds',
+  md_end_streak: 'Best streak',
+  md_end_blind: 'Called through a blackout',
+  md_end_clean: 'You banked a round before your first miss.',
+  md_end_yes: 'Yes',
+  md_end_no: 'No',
+});
+
+export default MD_LEX;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/pressure.js
@@ -1,0 +1,632 @@
+/* ============================================================================
+ * games/misdirection/pressure.js - the shell game's effects ladder: THE SURGE.
+ * The casino (casino.js) lights the table, the trickster (trickster.js) lies
+ * about it; this file is what the room DOES to you as your PICK STREAK climbs.
+ * The rung is your current run of correct picks; a miss drops it to zero and
+ * the storm steps DOWN behind a hysteresis (fades, never a snap). Magnitude
+ * rides the class heat (index.js folds streak + ride + progress into it, capped
+ * by the grade tier). Same seed, same surge.
+ *
+ * THE RUNG TABLE (pick streak -> rung -> what switches ON; cumulative). A
+ * 120s class deals ~10-14 rounds, so the whole ladder fits a perfect class:
+ *   0-1   rung 0  clean table (the casino's seeded felt is all there is)
+ *   2     rung 1  BREATH      a lavender wash breathes on a cadence     [engine wash:sublim]
+ *   3     rung 2  MOTES       dust drifts over the felt                 [engine ambient_field:motes]
+ *   4     rung 3  BURST+TREMOR gif bursts ride the verdicts; the chrome  [engine gif_burst]
+ *                             (HUD, arch, backdrop - never the arc) hums
+ *   5     rung 4  WHEEL       the spiral wash wakes behind the table    [engine wash:spiral]
+ *   6     rung 5  VEIL        the backdrop glitch-shudders on verdicts  [engine glitch_swap on the backdrop]
+ *   8     rung 6  SUBS        the sub flash stream                      [engine sub_flash alias]
+ *   10    rung 7  FLASHES     flash bursts ride the verdicts            [engine flash_burst clickSafe]
+ *   12    rung 8  STORM       embers, the lavender flood, the tremor cap [engine ambient_field:embers, wash:sublim]
+ *
+ * WHICH WASH: index.js owns the PINK wash (the dossier's occlusion washes and
+ * the blackout beats ride it, and a re-trigger at a lower alpha would cut a
+ * blackout short - trap 33's step-down branch). This deck therefore breathes
+ * on the SUBLIM variant (its own element) and wakes the SPIRAL; it never
+ * touches pink. bubble_field is index.js's too (the dossier's bubble decoys):
+ * not used here.
+ *
+ * WHEN THE RIDERS FIRE: ONLY on verdict beats (pick / bank / bust / ride) -
+ * never during the shuffle. The trackability invariant is index.js's law
+ * (occlusion covers at most one link of a swap chain) and this deck must never
+ * be the thing that hides the swap you needed to see: the sustains are the
+ * engine's screen-blended washes and fields, and every one-shot waits for the
+ * verdict. beat('shuffle') only retunes.
+ *
+ * THE DUSK: ONE game-local node (.g-md-p-dusk, appended to the backdrop, under
+ * the table) whose opacity climbs with the rung, so the engine's washes and
+ * gifs read IN FRONT of the felt instead of drowned by it (the IC lesson, trap
+ * 35: it was alpha, never z-order). It dims the BACKDROP only - the shells,
+ * the arc and the HUD are never under it. THE FLARE snaps it up under a burst.
+ *
+ * THE TREMOR: the chrome vibrates with the streak - a continuous low tremor
+ * whose amplitude grows with the rung, a PUNCH on every verdict (extend-not-
+ * stack, quadratic ring-down, screenShake posture), heavier on a bank, a jolt
+ * on a bust. Written on the CSS individual `translate` of the elements index.js
+ * hands us as `chrome` (HUD, backdrop, marquee host) - and NEVER on the arc or
+ * a shell: those are the pick targets (Law II) and a tracking test cannot have
+ * a trembling target. A rAF loop ONLY while amplitude > 0; stopped by pause()/
+ * stop()/destroy(), re-armed by resume(). Reduced motion / motionLevel 0 -> no
+ * tremor; the punch becomes a brief bloom class on the chrome.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - reads streak / beat kinds; writes nothing about pot,
+ *       streak, round or grade; renders no text.
+ *   II  input honest  - the arc and the shells are never transformed, never
+ *       covered; every engine fire is clickSafe; the dusk is under the table.
+ *   III never still   - from rung 1 the room breathes; from rung 3 it hums.
+ *   V   seeded        - per-tag mulberry32 off seed+'|md-pressure|<tag>',
+ *       append-only; no Math.random.
+ *   VI  exits sacred  - capsOk false (bgIntensity 0) = zero fires, zero tremor;
+ *       reduced motion = no tremor, no shudder; pause() halts the rAF and drops
+ *       transient timers; destroy() restores every translate and stops every
+ *       sustain with a fade.
+ *   VII lexicon       - this file renders no text.
+ *
+ * THE WASH TRAP (trap 33): engine.stop('wash') kills EVERY wash variant,
+ * including anything index.js holds. Two live here (sublim + spiral), so a rung
+ * is stepped DOWN by re-triggering its variant at a whisper alpha with a short
+ * hold (it fades on its own deadline). stop('wash') is NEVER called here, not
+ * even from destroy().
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const MD_PRESSURE = Object.freeze({
+  /** pick streak thresholds per rung (index = rung). Monotone. */
+  RUNG_STREAK: Object.freeze([0, 2, 3, 4, 5, 6, 8, 10, 12]),
+  RUNG_ADDS: Object.freeze([
+    Object.freeze([]),
+    Object.freeze(['breath']),
+    Object.freeze(['motes']),
+    Object.freeze(['burst', 'tremor']),
+    Object.freeze(['wheel']),
+    Object.freeze(['veil']),
+    Object.freeze(['subs']),
+    Object.freeze(['flashes']),
+    Object.freeze(['storm']),
+  ]),
+  RUNG_CUE: Object.freeze([null, 'wash', 'whisper', 'burst', 'wash', 'glitch', 'whisper', 'burst', 'near_miss']),
+  /** the dusk's opacity per rung (x (DUSK_HEAT_FLOOR + (1-floor)*heat)); 0 at rest. */
+  DUSK: Object.freeze([0, 0.1, 0.18, 0.28, 0.36, 0.42, 0.48, 0.54, 0.6]),
+  DUSK_HEAT_FLOOR: 0.75,
+  DUSK_END: 0.26,
+  FLARE_BURST: 0.78,
+  FLARE_IN_MS: 160,
+  /** Stepping DOWN waits this long and fades; stepping UP is immediate. */
+  HYST_MS: 1600,
+  HEAT_REPAINT_STEP: 0.06,
+
+  /* ---- THE TREMOR ------------------------------------------------------ */
+  TREMOR_PX: Object.freeze([0, 0, 0, 0.4, 0.6, 0.9, 1.2, 1.6, 2.2]),
+  TREMOR_CAP_PX: 2.5,
+  TREMOR_HEAT_FLOOR: 0.5,
+  TREMOR_HZ_FAST: Object.freeze([7, 11]),
+  TREMOR_HZ_SLOW: Object.freeze([1.4, 2.6]),
+  MOTION_MUL: Object.freeze([0, 0.6, 1]),
+  PUNCH_PICK_PX: Object.freeze([0.8, 3.0]),     // by min(streak,10)/10
+  PUNCH_PICK_MS: Object.freeze([160, 340]),
+  PUNCH_BANK_PX: 4.2,
+  PUNCH_BANK_MS: 420,
+  PUNCH_BUST_PX: 5,
+  PUNCH_BUST_MS: 380,
+  PUNCH_RIDE_PX: 2.4,
+  PUNCH_RIDE_MS: 260,
+  PUNCH_CAP_PX: 6,
+  PUNCH_CAP_MS: 450,
+  BLOOM_MS: 320,
+
+  /* ---- the rungs' knobs ------------------------------------------------ */
+  BREATH_MS: Object.freeze([8000, 4800]),
+  BREATH_HOLD_MS: 2400,
+  BREATH_ALPHA: Object.freeze([0.1, 0.36]),
+  STORM_BREATH_ALPHA: Object.freeze([0.3, 0.55]),
+  MOTES_DENSITY: Object.freeze([0.18, 0.45]),
+  STORM_EMBERS: Object.freeze([0.35, 0.75]),
+  BURST_CHANCE: Object.freeze([0.45, 0.9]),
+  BURST_COUNT: Object.freeze([1, 3]),
+  BURST_HOLD_MS: Object.freeze([750, 1250]),
+  BURST_VMIN: Object.freeze([0.22, 0.38]),
+  WHEEL_ALPHA: Object.freeze([0.1, 0.22]),      // quieter than IC/DE: this class is eye-tracking, the wheel rides BEHIND the shells
+  VEIL_CHANCE: Object.freeze([0.3, 0.75]),
+  VEIL_S: Object.freeze([0.35, 0.8]),
+  VEIL_VARIANTS: Object.freeze(['rgbsplit', 'vhsroll', 'datamosh']),
+  FLASH_COUNT: 2,
+  WHISPER_ALPHA: 0.01,
+  WHISPER_HOLD_MS: 900,
+  /** cue level = min(AUDIO_CEIL[tier], base + rung * step). */
+  CUE_LEVEL_BASE: 0.22,
+  CUE_LEVEL_STEP: 0.05,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+  NODE_BUDGET: 1,
+});
+
+const STYLE_ID = 'g-md-pressure-style';
+const STYLE_TEXT = `
+.g-md-p-dusk{position:absolute;inset:-2%;pointer-events:none;opacity:0;z-index:3;
+  background:radial-gradient(80% 70% at 50% 60%, rgba(6,4,16,.55), rgba(6,4,16,.92) 100%);
+  transition:opacity 1.2s ease;will-change:opacity}
+.g-md-p-bloom{box-shadow:0 0 0 2px rgba(255,105,180,.45), 0 0 18px rgba(255,105,180,.5) !important;transition:box-shadow .3s ease}
+`;
+
+function ensureStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT;
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function lerp(band, t) { return band[0] + (band[1] - band[0]) * clamp01(t); }
+
+/** pick streak -> rung (0..8). Pure, monotone, clamps garbage to 0. */
+export function rungFor(streak) {
+  const s = Math.max(0, Math.floor(Number(streak) || 0));
+  const T = MD_PRESSURE.RUNG_STREAK;
+  let r = 0;
+  for (let i = 0; i < T.length; i++) { if (s >= T[i]) r = i; else break; }
+  return r;
+}
+/** the dusk's opacity for a shown rung and heat (0..1). Pure. */
+export function duskFor(rung, heat01) {
+  const P = MD_PRESSURE;
+  const r = Math.max(0, Math.min(P.DUSK.length - 1, Math.floor(Number(rung) || 0)));
+  const base = P.DUSK[r] || 0;
+  if (base <= 0) return 0;
+  return +(base * (P.DUSK_HEAT_FLOOR + (1 - P.DUSK_HEAT_FLOOR) * clamp01(heat01))).toFixed(3);
+}
+/** idle tremor amplitude in px; 0 under reduced motion / motionLevel 0. Pure. */
+export function tremorAmpPx(streak, heat01, reducedMotion, motionLevel) {
+  if (reducedMotion) return 0;
+  const m = MD_PRESSURE.MOTION_MUL[Math.max(0, Math.min(2, motionLevel == null ? 2 : Math.round(Number(motionLevel) || 0)))];
+  if (!m) return 0;
+  const base = MD_PRESSURE.TREMOR_PX[rungFor(streak)] || 0;
+  if (base <= 0) return 0;
+  const f = MD_PRESSURE.TREMOR_HEAT_FLOOR;
+  return Math.min(MD_PRESSURE.TREMOR_CAP_PX, +(base * m * (f + (1 - f) * clamp01(heat01))).toFixed(3));
+}
+/** a verdict punch {px, ms} by beat kind + streak. Pure. */
+export function punchFor(kind, streak) {
+  const P = MD_PRESSURE;
+  const q = clamp01(Math.min(10, Number(streak) || 0) / 10);
+  let px; let ms;
+  if (kind === 'bank') { px = P.PUNCH_BANK_PX; ms = P.PUNCH_BANK_MS; }
+  else if (kind === 'bust') { px = P.PUNCH_BUST_PX; ms = P.PUNCH_BUST_MS; }
+  else if (kind === 'ride') { px = P.PUNCH_RIDE_PX; ms = P.PUNCH_RIDE_MS; }
+  else if (kind === 'pick') { px = lerp(P.PUNCH_PICK_PX, q); ms = lerp(P.PUNCH_PICK_MS, q); }
+  else if (kind === 'miss') { px = 1.6; ms = 220; }
+  else return { px: 0, ms: 0 };
+  return { px: +Math.min(P.PUNCH_CAP_PX, px).toFixed(2), ms: Math.min(P.PUNCH_CAP_MS, Math.round(ms)) };
+}
+
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && performance && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function rafFn() {
+  try { if (typeof requestAnimationFrame === 'function') return requestAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.requestAnimationFrame === 'function') return globalThis.requestAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function cafFn() {
+  try { if (typeof cancelAnimationFrame === 'function') return cancelAnimationFrame; } catch (e) { /* fall */ }
+  try { if (typeof globalThis !== 'undefined' && typeof globalThis.cancelAnimationFrame === 'function') return globalThis.cancelAnimationFrame; } catch (e) { /* none */ }
+  return null;
+}
+function vmin() {
+  try {
+    if (typeof window !== 'undefined' && window) {
+      const w = Number(window.innerWidth) || 0; const h = Number(window.innerHeight) || 0;
+      if (w > 0 && h > 0) return Math.min(w, h);
+    }
+  } catch (e) { /* headless */ }
+  return 720;
+}
+function setOpacity(node, v) {
+  try { if (node && node.style) node.style.opacity = (v == null || v === '') ? '' : String(v); } catch (e) { /* noop */ }
+}
+function setTranslate(node, x, y) {
+  try { if (node && node.style) node.style.translate = (x || y) ? (x.toFixed(2) + 'px ' + y.toFixed(2) + 'px') : ''; } catch (e) { /* noop */ }
+}
+function cls(node, name, on) { try { if (node && node.classList) node.classList[on ? 'add' : 'remove'](name); } catch (e) { /* noop */ } }
+function el(tag, c) {
+  try { const n = document.createElement(tag); if (c) n.className = c; return n; } catch (e) { return null; }
+}
+
+/**
+ * @param {Object} o
+ *   engine {fire,sustain,stop,channels}, stage (.g-md-stage), chrome [els] (HUD, backdrop,
+ *   marquee host - never the arc), timers {after,every,clear}, reduced, capsOk (bool|fn),
+ *   motionLevel 0..2, seed, gradeTier, backdrop (.g-md-backdrop, optional - the dusk's host
+ *   and the veil's glitch target; else found under the stage), log
+ */
+export function createMdPressure(o) {
+  const opts = o || {};
+  const P = MD_PRESSURE;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const reduced = !!opts.reduced;
+  const motion = Math.max(0, Math.min(2, Math.round(opts.motionLevel == null ? 2 : Number(opts.motionLevel) || 0)));
+  const still = reduced || motion <= 0;
+  const gradeTier = Math.max(1, Math.min(4, Number(opts.gradeTier) || 1));
+  const audioCeil = P.AUDIO_CEIL[gradeTier] || P.AUDIO_CEIL[1];
+  const eng = opts.engine || {};
+  /* the chrome: never a node that holds a real button (the stake strip is
+     input - Law II), never the arc. index.js hands [hud, msg, stake]; the
+     stake is dropped here. */
+  const chrome = (Array.isArray(opts.chrome) ? opts.chrome : []).filter((n) => {
+    if (!n || !n.style) return false;
+    try {
+      if (n.classList && (n.classList.contains('g-md-stake') || n.classList.contains('g-md-arc'))) return false;
+      if (typeof n.querySelector === 'function' && n.querySelector('button')) return false;
+    } catch (e) { /* keep */ }
+    return true;
+  });
+  const armedBase = !!opts.stage && !!opts.timers && typeof opts.timers.after === 'function';
+  function capsOk() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  let destroyed = false;
+  const armed = () => armedBase && !destroyed && capsOk();
+
+  /* ---- timers ------------------------------------------------------------- */
+  const live = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  function after(ms, fn) {
+    if (!armedBase || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function cancelAll() { for (const id of Array.from(live)) cancel(id); }
+
+  /* ---- seeded streams ----------------------------------------------------- */
+  const seedBase = String(opts.seed || 'md') + '|md-pressure|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+  const tremorPhase = { fx: roll('tremor') * 6.28, fy: roll('tremor') * 6.28, hzF: lerp(P.TREMOR_HZ_FAST, roll('tremor')), hzS: lerp(P.TREMOR_HZ_SLOW, roll('tremor')) };
+
+  /* ---- the engine, counted ------------------------------------------------ */
+  const fires = {};
+  function count(key) { fires[key] = (fires[key] || 0) + 1; }
+  function fire(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.fire === 'function' ? eng.fire(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function sustain(kind, o2) {
+    if (!armed()) return null;
+    count(kind); if (o2 && o2.variant) count(kind + ':' + o2.variant);
+    try { return typeof eng.sustain === 'function' ? eng.sustain(kind, o2 || {}) : null; } catch (e) { return null; }
+  }
+  function stopKind(kind) {
+    if (!armedBase || kind === 'wash') return;      // NEVER stop('wash') - trap 33
+    count('stop:' + kind);
+    try { if (typeof eng.stop === 'function') eng.stop(kind); } catch (e) { /* noop */ }
+  }
+  function cue(name, rung) {
+    if (!armed() || !name) return;
+    const level = Math.min(audioCeil, P.CUE_LEVEL_BASE + rung * P.CUE_LEVEL_STEP);
+    count('cue');
+    fire('audio_trigger', { name, level, pitch: +(0.9 + rung * 0.04).toFixed(3) });
+  }
+
+  /* ---- state -------------------------------------------------------------- */
+  let started = false;
+  let stopped = false;
+  let paused = false;
+  let heat = 0;
+  let lastPaintHeat = -1;
+  let streak = 0;
+  let rung = 0;
+  let wantRung = 0;
+  let downTimer = 0;
+  let bellOn = false;
+  let outOn = false;
+  const on = new Set();
+  let dusk = null;
+  let backdrop = opts.backdrop || null;
+  let flareUntil = 0;
+  let flareTimer = 0;
+  let bloomTimer = 0;
+  let breathTimer = 0;
+
+  /* ---- the tremor --------------------------------------------------------- */
+  let rafId = 0; let loopOn = false; let amp = 0;
+  let punch = { px: 0, until: 0, ms: 1 };
+  let translateWrites = 0;
+
+  function restChrome() { for (const n of chrome) setTranslate(n, 0, 0); }
+  function loop() {
+    rafId = 0;
+    if (!loopOn || paused || destroyed) return;
+    const tNow = nowMs();
+    let extra = 0;
+    if (punch.px > 0) {
+      const left = punch.until - tNow;
+      if (left <= 0) punch = { px: 0, until: 0, ms: 1 };
+      else { const k = left / punch.ms; extra = punch.px * k * k; }
+    }
+    const a = amp + extra;
+    if (a <= 0.005 || !armed()) { restChrome(); loopOn = false; return; }
+    const ts = tNow / 1000;
+    const x = a * (0.7 * Math.sin(ts * tremorPhase.hzF * 6.28 + tremorPhase.fx) + 0.3 * Math.sin(ts * tremorPhase.hzS * 6.28));
+    const y = a * (0.7 * Math.cos(ts * tremorPhase.hzF * 5.9 + tremorPhase.fy) + 0.3 * Math.sin(ts * tremorPhase.hzS * 5.1 + 1.7));
+    for (let i = 0; i < chrome.length; i++) { setTranslate(chrome[i], x * (i === 0 ? 1 : 0.6), y * (i === 0 ? 1 : 0.6)); }
+    translateWrites += 1;
+    const raf = rafFn();
+    if (raf) rafId = raf(loop);
+  }
+  function armLoop() {
+    if (loopOn || paused || destroyed || still || !chrome.length || !armed()) return;
+    if (amp <= 0 && punch.px <= 0) return;
+    loopOn = true;
+    const raf = rafFn();
+    if (raf) rafId = raf(loop); else loop();
+  }
+  function haltLoop() {
+    loopOn = false;
+    const caf = cafFn();
+    if (rafId && caf) { try { caf(rafId); } catch (e) { /* noop */ } }
+    rafId = 0;
+  }
+  function doPunch(spec) {
+    if (!armed() || stopped || !spec || spec.px <= 0) return;
+    if (still) { bloomChrome(); return; }
+    const tNow = nowMs();
+    punch = { px: Math.max(punch.px, spec.px), until: Math.max(punch.until, tNow + spec.ms), ms: Math.max(spec.ms, 1) };
+    count('punch');
+    armLoop();
+  }
+  function bloomChrome() {
+    const n = chrome[0];
+    if (!n) return;
+    cls(n, 'g-md-p-bloom', false);
+    if (typeof n.offsetWidth === 'number') void n.offsetWidth;
+    cls(n, 'g-md-p-bloom', true);
+    cancel(bloomTimer);
+    bloomTimer = after(P.BLOOM_MS, () => cls(n, 'g-md-p-bloom', false));
+  }
+
+  /* ---- the dusk ----------------------------------------------------------- */
+  function findBackdrop() {
+    if (backdrop) return backdrop;
+    try { backdrop = opts.stage && opts.stage.querySelector ? opts.stage.querySelector('.g-md-backdrop') : null; } catch (e) { backdrop = null; }
+    return backdrop;
+  }
+  function mount() {
+    if (dusk) return;
+    const host = findBackdrop();
+    if (!host || !host.appendChild) return;
+    ensureStyle();
+    dusk = el('div', 'g-md-p-dusk');
+    if (dusk) host.appendChild(dusk);
+  }
+  function paintDusk() {
+    if (!armedBase || destroyed || !dusk) return;
+    if (flareUntil > nowMs()) return;
+    setOpacity(dusk, stopped ? Math.min(P.DUSK_END, duskFor(rung, heat)) : (capsOk() ? duskFor(rung, heat) : 0));
+  }
+  function flare(level, holdMs) {
+    if (!armed() || stopped || !dusk) return;
+    const until = nowMs() + Math.max(120, holdMs | 0);
+    const lv = Math.max(level, duskFor(rung, heat));
+    try { dusk.style.transition = 'opacity ' + P.FLARE_IN_MS + 'ms ease-out'; setOpacity(dusk, lv); } catch (e) { /* cosmetic */ }
+    if (until > flareUntil) {
+      flareUntil = until;
+      cancel(flareTimer);
+      flareTimer = after(until - nowMs(), () => {
+        flareTimer = 0; flareUntil = 0;
+        try { dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+        paintDusk();
+      });
+    }
+    count('flare');
+  }
+  function retune() {
+    paintDusk();
+    amp = 0;
+    if (!still && !stopped && !outOn) {
+      const base = P.TREMOR_PX[rung] || 0;
+      amp = base <= 0 ? 0 : Math.min(P.TREMOR_CAP_PX, base * P.MOTION_MUL[motion] * (P.TREMOR_HEAT_FLOOR + (1 - P.TREMOR_HEAT_FLOOR) * heat));
+    }
+    armLoop();
+  }
+
+  /* ---- the rungs ---------------------------------------------------------- */
+  function breathOn(storm) {
+    sustain('wash', { variant: 'sublim', alpha: lerp(storm ? P.STORM_BREATH_ALPHA : P.BREATH_ALPHA, heat), holdMs: P.BREATH_HOLD_MS });
+  }
+  function armBreath() {
+    if (breathTimer) cancel(breathTimer);
+    const ms = lerp(P.BREATH_MS, heat) * (0.85 + roll('breath') * 0.3);
+    breathTimer = after(Math.round(ms), () => { breathTimer = 0; if (on.has('breath') && !stopped) { breathOn(on.has('storm')); armBreath(); } });
+  }
+  function whisperOut(variant) {
+    sustain('wash', { variant, alpha: P.WHISPER_ALPHA, holdMs: P.WHISPER_HOLD_MS });
+  }
+  function wheelOn() { sustain('wash', { variant: 'spiral', alpha: lerp(P.WHEEL_ALPHA, heat), sustainForever: true }); }
+  function applyAdd(add, goingUp) {
+    if (goingUp) {
+      on.add(add);
+      if (add === 'breath') { breathOn(false); armBreath(); }
+      else if (add === 'motes') sustain('ambient_field', { kind: 'motes', density: lerp(P.MOTES_DENSITY, heat) });
+      else if (add === 'wheel') wheelOn();
+      else if (add === 'subs') sustain('sub_flash', {});
+      else if (add === 'storm') {
+        sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
+        breathOn(true);
+      }
+      /* burst / tremor / veil / flashes ride the verdict beats: nothing to switch on */
+    } else {
+      on.delete(add);
+      if (add === 'breath') { if (breathTimer) { cancel(breathTimer); breathTimer = 0; } whisperOut('sublim'); }
+      else if (add === 'motes') { if (!on.has('storm')) stopKind('ambient_field'); }
+      else if (add === 'wheel') whisperOut('spiral');
+      else if (add === 'subs') stopKind('sub_flash');
+      else if (add === 'storm') {
+        stopKind('ambient_field');
+        if (on.has('motes')) sustain('ambient_field', { kind: 'motes', density: lerp(P.MOTES_DENSITY, heat) });
+        if (on.has('breath')) breathOn(false);
+      }
+    }
+  }
+  function setRung(r) {
+    if (r === rung) return;
+    const up = r > rung;
+    if (up) {
+      for (let k = rung + 1; k <= r; k++) for (const add of P.RUNG_ADDS[k]) applyAdd(add, true);
+      cue(P.RUNG_CUE[r], r);
+    } else {
+      for (let k = rung; k > r; k--) for (const add of P.RUNG_ADDS[k]) applyAdd(add, false);
+    }
+    rung = r;
+    retune();
+    say('pressure: rung ' + rung + ' (' + (up ? 'up' : 'down') + ', streak ' + streak + ')');
+  }
+  function setStreak(s) {
+    streak = Math.max(0, Math.floor(Number(s) || 0));
+    wantRung = rungFor(streak);
+    if (!started || stopped) return;
+    if (wantRung > rung) { cancel(downTimer); downTimer = 0; setRung(wantRung); }
+    else if (wantRung < rung && !downTimer) {
+      downTimer = after(P.HYST_MS, () => { downTimer = 0; if (wantRung < rung) setRung(wantRung); });
+    } else if (wantRung === rung) { cancel(downTimer); downTimer = 0; }
+  }
+  function repaintHeat() {
+    if (Math.abs(heat - lastPaintHeat) < P.HEAT_REPAINT_STEP) return;
+    lastPaintHeat = heat;
+    if (on.has('breath')) breathOn(on.has('storm'));
+    if (on.has('wheel')) wheelOn();
+    if (on.has('storm')) sustain('ambient_field', { kind: 'embers', density: lerp(P.STORM_EMBERS, heat) });
+    else if (on.has('motes')) sustain('ambient_field', { kind: 'motes', density: lerp(P.MOTES_DENSITY, heat) });
+  }
+
+  /* the riders: only on verdict beats */
+  function riders(kind) {
+    if (!armed() || stopped) return;
+    const verdict = kind === 'pick' || kind === 'bank' || kind === 'ride';
+    if (!verdict) return;
+    const heavy = kind === 'bank';
+    if (rung >= 3 && !still && (heavy || roll('burst') < lerp(P.BURST_CHANCE, heat))) {
+      const hold = Math.round(lerp(P.BURST_HOLD_MS, heat));
+      const went = fire('gif_burst', {
+        count: Math.round(lerp(P.BURST_COUNT, heat)) + (heavy ? 1 : 0), clickSafe: true, clickable: false,
+        sizePx: Math.round(vmin() * lerp(P.BURST_VMIN, heat)), holdMs: hold,
+        variant: rung >= 8 ? 'scatter' : undefined,
+      });
+      if (went) flare(P.FLARE_BURST, hold + 300);
+    }
+    if (rung >= 5 && !still && (heavy || roll('veil') < lerp(P.VEIL_CHANCE, heat))) {
+      const target = findBackdrop();
+      if (target) {
+        fire('glitch_swap', {
+          targets: target, variant: P.VEIL_VARIANTS[Math.floor(roll('veil-v') * P.VEIL_VARIANTS.length)],
+          seconds: lerp(P.VEIL_S, heat), sfx: false,
+          onSwap() { /* presentation only: the backdrop keeps its own felt */ },
+        });
+      }
+    }
+    if (rung >= 7 && !still) fire('flash_burst', { count: P.FLASH_COUNT + (heavy ? 1 : 0), clickSafe: true, clickable: false });
+  }
+
+  /* ============================================================ API ==== */
+  const api = {
+    start() {
+      if (started) return;
+      started = true;
+      stopped = false;
+      lastPaintHeat = -1;
+      if (!armed()) { say('pressure: disarmed'); return; }
+      mount();
+      if (wantRung > 0) setRung(wantRung);
+      say('pressure: mounted ' + (dusk ? 1 : 0) + ' node, chrome x' + chrome.length);
+    },
+    setHeat(h) {
+      heat = clamp01(h);
+      if (started && !stopped) { repaintHeat(); retune(); }
+    },
+    /** The pick streak, after the ledger. 0 = a miss (the storm steps down behind HYST). */
+    setStreak(n) { setStreak(n); },
+    /** index.js's beats: 'reveal' | 'shuffle' | 'swap' | 'pick' | 'miss' | 'ride' | 'bank' | 'bust' | 'bell'. */
+    beat(kind) {
+      if (!started || stopped) return;
+      const k = String(kind || '');
+      if (k === 'pick' || k === 'bank' || k === 'ride' || k === 'bust' || k === 'miss') doPunch(punchFor(k, streak));
+      if (k === 'bust' && rung >= 5 && armed() && !still) {
+        const target = findBackdrop();
+        if (target) fire('glitch_swap', { targets: target, variant: 'datamosh', seconds: 0.5, sfx: false, onSwap() {} });
+      }
+      riders(k);
+    },
+    bell(on2) { bellOn = !!on2; },
+    /** The bell took the table: everything sighs out, the dusk eases to its debrief level. */
+    dimOut() { outOn = true; api.stop(); },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      cancel(downTimer); downTimer = 0;
+      if (breathTimer) { cancel(breathTimer); breathTimer = 0; }
+      if (on.has('breath') || on.has('storm')) whisperOut('sublim');
+      if (on.has('wheel')) whisperOut('spiral');
+      if (on.has('subs')) stopKind('sub_flash');
+      if (on.has('motes') || on.has('storm')) stopKind('ambient_field');
+      cancel(flareTimer); flareTimer = 0; flareUntil = 0;
+      try { if (dusk && dusk.style) dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+      setOpacity(dusk, rung > 0 ? Math.min(P.DUSK_END, duskFor(rung, heat)) : 0);
+      on.clear();
+      rung = 0;
+      amp = 0; punch = { px: 0, until: 0, ms: 1 };
+      haltLoop();
+      restChrome();
+    },
+    pause() {
+      paused = true;
+      cancelAll(); downTimer = 0; flareTimer = 0; flareUntil = 0; breathTimer = 0; bloomTimer = 0;
+      try { if (dusk && dusk.style) dusk.style.transition = ''; } catch (e) { /* cosmetic */ }
+      haltLoop();
+      restChrome();
+    },
+    resume() {
+      paused = false;
+      if (!stopped) { retune(); setStreak(streak); if (on.has('breath')) armBreath(); }
+    },
+    destroy() {
+      api.stop();
+      destroyed = true;
+      cancelAll();
+      haltLoop();
+      restChrome();
+      for (const n of chrome) cls(n, 'g-md-p-bloom', false);
+      if (dusk) { try { dusk.remove(); } catch (e) { /* noop */ } }
+      dusk = null;
+    },
+    diagnostics() {
+      return {
+        armed: armed(), started, stopped, paused, heat: +heat.toFixed(3), streak, rung, wantRung, bell: bellOn, out: outOn,
+        on: Array.from(on), tremorPx: +amp.toFixed(3), punchPx: +punch.px.toFixed(2), loopOn, translateWrites,
+        dusk: stopped ? 0 : duskFor(rung, heat), flaring: flareUntil > nowMs(),
+        fires: Object.assign({}, fires), liveTimers: live.size, nodes: dusk ? 1 : 0, chrome: chrome.length,
+      };
+    },
+  };
+  return api;
+}
+
+export default createMdPressure;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/shuffle.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/shuffle.js
@@ -1,0 +1,522 @@
+/* ============================================================================
+ * games/misdirection/shuffle.js - MISDIRECTION's seeded shuffle plan. PURE.
+ *
+ * No DOM, no engine, no clock, no ctx. Everything here is a pure function of
+ * (seed, gradeTier, round index, ride depth, remedial). That is what makes a
+ * retake replay the identical table and what makes the TRACKABILITY INVARIANT
+ * assertable headless.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TRACKABILITY INVARIANT (the critic's top fix; the contract closes it as
+ * LAW, and `verifyRound()` below is the machine-readable form the suite runs
+ * over 200 seeds x 4 tiers):
+ *
+ *   1. THE CHAIN IS THE TRUTH. A round's swap chain is dealt from the seed
+ *      BEFORE any effect is chosen, and `simulate()` replays it to the final
+ *      slot. The plan is reconstructable in principle: nothing the player does
+ *      moves the target, and nothing the decks do is allowed to.
+ *   2. AT MOST ONE HIDDEN LINK. Of the swaps that actually MOVE THE TARGET, at
+ *      most ONE may be occluded (a glitch swap or a blackout beat). Every other
+ *      occlusion in the round lands on a swap the target is not part of - the
+ *      house looks like it blinded you three times; it only ever hid one link.
+ *   3. A TELL ALWAYS SURVIVES. Every occluded swap carries a `tell` naming the
+ *      two slots involved, emitted as a peripheral mark AND an audio cue
+ *      regardless of the blackout. Every occlusion carries one, so the tell can
+ *      never be used to spot which occlusion was the real one.
+ *   4. DECOYS NEVER LIFT THE TARGET. A decoy reveal is scheduled on a slot the
+ *      target is not under at that instant, so the bait is always a lie about
+ *      an empty shell and never a truthful accident.
+ *
+ * ---------------------------------------------------------------------------
+ * DIALS FIRST, DIFFICULTY SECOND (GROUND-RULES §6). `rideDepth` raises the
+ * EFFECT tier by one notch (decoy count, occlusion count, wash alpha) and
+ * never the shell count, the swap rate or the preview time - the dossier's
+ * "effects first" rule, made structural: `effectTier` and `classicTier` are
+ * two different numbers and only the second one touches the classic dials.
+ *
+ * REDUCED MOTION caps the swap RATE and stretches the shuffle window to keep
+ * the SAME chain length - the dossier's "difficulty is preserved via longer
+ * swap chains instead of speed", so grading stays fair.
+ *
+ * SEEDING (Law V): `seed + '|md-chain|' + index` deals the truth (start slot +
+ * chain), `seed + '|md-load|' + index` deals the presentation (which swaps are
+ * occluded, where the decoys lift). Draw order is append-only inside each.
+ * ==========================================================================*/
+
+import { makeRng, makeTaggedRoll } from '../../core/rng.js';
+
+/** Every number a playtest might touch. One place, one edit. */
+export const PLAYTEST = Object.freeze({
+  /* ---- classic dials (gradeTier ONLY - a ride never moves these) ------- */
+  /** Shells on the arc. 3 -> 3 -> 4 -> 5 (dossier). */
+  SHELLS: Object.freeze({ 1: 3, 2: 3, 3: 4, 4: 5 }),
+  /** The reveal window, grade-scaled 1.6s -> 0.7s (dossier). */
+  PREVIEW_MS: Object.freeze({ 1: 1600, 2: 1300, 3: 1000, 4: 700 }),
+  /** Nominal shuffle window; the chain length is rate x window. */
+  SHUFFLE_MS: Object.freeze({ 1: 2400, 2: 3000, 3: 3800, 4: 4600 }),
+  /** Swaps per second. */
+  SWAP_RATE: Object.freeze({ 1: 0.9, 2: 1.3, 3: 1.7, 4: 2.2 }),
+  /** The pick window. HONEST and never bent - only the drawn ring may lie. */
+  PICK_MS: 4000,
+
+  /* ---- effect dials (raised one notch by ANY ride) --------------------- */
+  /** Decoy reveals per shuffle. */
+  DECOYS: Object.freeze({ 1: 0, 2: 1, 3: 2, 4: 3 }),
+  /** Unanimated glitch swaps per shuffle. */
+  GLITCHES: Object.freeze({ 1: 0, 2: 0, 3: 1, 4: 2 }),
+  /** Blackout beats (wash rides to its cap) per shuffle. */
+  BLACKOUTS: Object.freeze({ 1: 0, 2: 0, 3: 0, 4: 1 }),
+  /** A decoy reveal shows a convincing FAKE target from this effect tier up. */
+  FAKE_TARGET_TIER: 4,
+  /** row_drift slides the whole arc during the pick window from this tier up. */
+  ROW_DRIFT_TIER: 4,
+  /** flash_burst contaminates the last glance at pick-open from this tier up. */
+  PICK_BURST_TIER: 3,
+  /** Base wash alpha by effect tier, and what one ride notch adds. */
+  WASH_ALPHA: Object.freeze({ 1: 0.18, 2: 0.32, 3: 0.48, 4: 0.62 }),
+  WASH_PER_RIDE: 0.06,
+  /** How long a blackout beat holds the wash at its cap. */
+  BLACKOUT_MS: 300,
+  /** How long an occluded swap's peripheral tell stays on the two shells. */
+  TELL_MS: 420,
+  /** Bubble decoys drifting over the arc, by effect tier. */
+  BUBBLES: Object.freeze({ 1: 0, 2: 4, 3: 6, 4: 8 }),
+
+  /* ---- the pot ---------------------------------------------------------- */
+  /** Ride cap (Intake's STREAK_CAP posture). At the cap a win force-banks. */
+  RIDE_CAP: 5,
+  /** A clean win pays this; each ride doubles the live pot. */
+  POT_BASE: 1,
+
+  /* ---- the remedial round (the comeback hook) -------------------------- */
+  /** Consecutive misses that arm it. */
+  REMEDIAL_AFTER: 2,
+  /** Extended preview, and it cannot fire twice in a row (anti-clump). */
+  REMEDIAL_PREVIEW_MULT: 1.8,
+
+  /* ---- reduced motion --------------------------------------------------- */
+  /** Swap rate ceiling; the window stretches to keep the chain length. */
+  REDUCED_RATE_CAP: 1.1,
+
+  /* ---- heat + audio ----------------------------------------------------- */
+  HEAT_CAP: Object.freeze({ 1: 0.45, 2: 0.65, 3: 0.85, 4: 1 }),
+  HEAT_FLOOR: 0.14,
+  /** Streak that reaches the top of the game's own ladder. */
+  HEAT_STREAK_FULL: 8,
+  /** How the ladder splits between streak and ride depth. */
+  HEAT_STREAK_SHARE: 0.6,
+  AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
+
+  /* ---- beats ------------------------------------------------------------ */
+  BRIEF_MS: 1700,
+  BRIEF_MS_REDUCED: 900,
+  SETTLE_MS: 380,
+  RESOLVE_MS: 1200,
+  RESOLVE_MS_REDUCED: 700,
+  STAKE_MS: 4000,
+  AUTO_STAKE_MS: 900,
+  BELL_WARN_SEC: 20,
+  END_HOLD_MS: 2600,
+  END_HOLD_MS_REDUCED: 1400,
+  /** sub_flash cadence between rounds, by effect tier (0 = off). */
+  SUB_FLASH_MS: Object.freeze({ 1: 0, 2: 9000, 3: 7000, 4: 5200 }),
+  /** The trickster's `stalled(ms)` tick. */
+  STALL_TICK_MS: 500,
+});
+
+export function clamp01(v) { const n = Number(v); return !Number.isFinite(n) ? 0 : n < 0 ? 0 : n > 1 ? 1 : n; }
+export function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Number(gradeTier) || 1))); }
+
+/** The per-game stake setting, normalised. */
+export function stakeModeFrom(v) {
+  const s = String(v == null ? '' : v).trim().toLowerCase();
+  return (s === 'bank' || s === 'ride') ? s : 'ask';
+}
+
+/** The per-game skin setting, normalised (the value lands on data-skin). */
+export function skinFrom(v) {
+  const s = String(v == null ? '' : v).trim().toLowerCase();
+  return (s === 'minimal' || s === 'contrast') ? s : 'themed';
+}
+
+/**
+ * Every dial for ONE round.
+ *
+ * `classicTier` is the grade tier and nothing else touches it. `effectTier` is
+ * the grade tier plus one notch whenever the player is riding - that is the
+ * whole of "riding raises the distraction dials before anything classical".
+ *
+ * @param {Object} o
+ *   gradeTier   1..4
+ *   rideDepth   0..RIDE_CAP - how deep the live pot is ridden
+ *   remedial    true = the comeback round (clean shuffle, longer look)
+ *   reduced     reduced motion / motionLevel 0
+ */
+export function dialsFor(o = {}) {
+  const classicTier = tierOf(o.gradeTier);
+  const rideDepth = Math.max(0, Math.min(PLAYTEST.RIDE_CAP, Math.round(Number(o.rideDepth) || 0)));
+  const remedial = !!o.remedial;
+  const reduced = !!o.reduced;
+  const effectTier = remedial ? 1 : Math.min(4, classicTier + (rideDepth > 0 ? 1 : 0));
+
+  const shells = PLAYTEST.SHELLS[classicTier];
+  const nominalRate = PLAYTEST.SWAP_RATE[classicTier];
+  const nominalMs = PLAYTEST.SHUFFLE_MS[classicTier];
+  /* THE CHAIN LENGTH is a classic dial, and reduced motion must not lower it. */
+  const chainLen = Math.max(1, Math.round(nominalRate * (nominalMs / 1000)));
+  const swapRate = reduced ? Math.min(nominalRate, PLAYTEST.REDUCED_RATE_CAP) : nominalRate;
+  const shuffleMs = Math.round((chainLen / swapRate) * 1000);
+
+  const decoys = remedial ? 0 : PLAYTEST.DECOYS[effectTier];
+  const glitches = remedial ? 0 : PLAYTEST.GLITCHES[effectTier];
+  const blackouts = remedial ? 0 : PLAYTEST.BLACKOUTS[effectTier];
+
+  return Object.freeze({
+    classicTier,
+    effectTier,
+    rideDepth,
+    remedial,
+    reduced,
+    shells,
+    chainLen,
+    swapRate,
+    shuffleMs,
+    previewMs: Math.round(PLAYTEST.PREVIEW_MS[classicTier] * (remedial ? PLAYTEST.REMEDIAL_PREVIEW_MULT : 1)),
+    pickMs: PLAYTEST.PICK_MS,
+    decoys,
+    glitches,
+    blackouts,
+    fakeTargets: !remedial && effectTier >= PLAYTEST.FAKE_TARGET_TIER,
+    rowDrift: !remedial && effectTier >= PLAYTEST.ROW_DRIFT_TIER,
+    pickBurst: !remedial && effectTier >= PLAYTEST.PICK_BURST_TIER,
+    bubbles: remedial ? 0 : PLAYTEST.BUBBLES[effectTier],
+    washAlpha: clamp01(PLAYTEST.WASH_ALPHA[effectTier] + rideDepth * PLAYTEST.WASH_PER_RIDE),
+    blackoutMs: PLAYTEST.BLACKOUT_MS,
+    tellMs: PLAYTEST.TELL_MS,
+    heatCap: PLAYTEST.HEAT_CAP[classicTier],
+    audioCeil: PLAYTEST.AUDIO_CEIL[classicTier],
+    subFlashMs: remedial ? 0 : PLAYTEST.SUB_FLASH_MS[effectTier],
+    /* The distraction LOAD of this round, and the load a clean round of this
+     * grade tier would carry. `heavy` is what the rubric weighs at 1.5x. */
+    load: loadOf(decoys, glitches, blackouts),
+    baselineLoad: loadOf(PLAYTEST.DECOYS[classicTier], PLAYTEST.GLITCHES[classicTier], PLAYTEST.BLACKOUTS[classicTier]),
+  });
+}
+
+/** One scalar for "how blinded was this shuffle". Pure bookkeeping. */
+export function loadOf(decoys, glitches, blackouts) {
+  return (Number(decoys) || 0) * 0.5 + (Number(glitches) || 0) * 1 + (Number(blackouts) || 0) * 1.5;
+}
+
+/**
+ * THE CHAIN - the truth, dealt from the seed and the round index ONLY.
+ *
+ * Two shells trade slots per link. The chain never repeats the SAME unordered
+ * pair twice in a row (a visible A<->B<->A is a wasted link and reads as a
+ * stutter), and a link always touches two different slots.
+ *
+ * @returns {{startSlot:number, swaps:Array<{a:number,b:number}>}}
+ */
+export function buildChain(seed, dials) {
+  const d = dials || dialsFor({ gradeTier: 1 });
+  const n = d.shells;
+  const rng = makeRng(String(seed));
+  const startSlot = Math.min(n - 1, Math.floor(rng() * n));
+  const swaps = [];
+  let lastKey = '';
+  let guard = 0;
+  while (swaps.length < d.chainLen && guard++ < d.chainLen * 40 + 80) {
+    const a = Math.min(n - 1, Math.floor(rng() * n));
+    let b = Math.min(n - 1, Math.floor(rng() * n));
+    if (b === a) b = (a + 1) % n;
+    const key = Math.min(a, b) + ':' + Math.max(a, b);
+    if (key === lastKey) continue;
+    lastKey = key;
+    swaps.push({ a: Math.min(a, b), b: Math.max(a, b) });
+  }
+  /* A degenerate guard exit still returns a legal chain (never an empty one). */
+  while (swaps.length < 1) swaps.push({ a: 0, b: Math.min(1, n - 1) });
+  return { startSlot, swaps };
+}
+
+/**
+ * Replay a chain. PURE and the suite's oracle: `simulate(plan).finalSlot` must
+ * equal `plan.finalSlot`, and `movesTarget` on every link must match.
+ *
+ * @returns {{finalSlot:number, order:number[], path:number[], moved:boolean[]}}
+ *   order[slot] = shell id sitting in that slot at the end.
+ */
+export function simulate(plan) {
+  const n = Math.max(2, Math.round(Number(plan && plan.shells) || 3));
+  const order = [];
+  for (let i = 0; i < n; i++) order.push(i);
+  let slot = Math.max(0, Math.min(n - 1, Math.round(Number(plan && plan.startSlot) || 0)));
+  const path = [slot];
+  const moved = [];
+  const swaps = (plan && Array.isArray(plan.swaps)) ? plan.swaps : [];
+  for (const s of swaps) {
+    const a = Math.max(0, Math.min(n - 1, Math.round(Number(s.a) || 0)));
+    const b = Math.max(0, Math.min(n - 1, Math.round(Number(s.b) || 0)));
+    const tmp = order[a]; order[a] = order[b]; order[b] = tmp;
+    const hit = (slot === a || slot === b);
+    if (hit) slot = (slot === a) ? b : a;
+    moved.push(hit);
+    path.push(slot);
+  }
+  return { finalSlot: slot, order, path, moved };
+}
+
+/**
+ * THE ROUND PLAN.
+ *
+ * Order of operations is the invariant's whole enforcement:
+ *   1. deal the chain from `seed|md-chain|index` (truth; ride depth cannot
+ *      touch it, so the ledger is a pure function of the seed);
+ *   2. simulate it to learn which links move the target;
+ *   3. choose occlusions from `seed|md-load|index` under the ONE-LINK rule:
+ *      at most one target-moving link may be hidden, everything else must
+ *      land on a link the target is not in - and if there are not enough of
+ *      those, the occlusion count DROPS rather than the invariant;
+ *   4. every occluded link gets a truthful tell;
+ *   5. decoy reveals are placed on slots the target is not under.
+ *
+ * @param {Object} o {seed, gradeTier, index, rideDepth, remedial, reduced}
+ */
+export function buildRound(o = {}) {
+  const index = Math.max(0, Math.round(Number(o.index) || 0));
+  const seed = String(o.seed == null ? '' : o.seed);
+  const dials = dialsFor(o);
+  const n = dials.shells;
+
+  /* ---- 1. the truth --------------------------------------------------- */
+  const chain = buildChain(seed + '|md-chain|' + index, dials);
+  const swaps = chain.swaps.map((s, i) => ({
+    index: i,
+    a: s.a,
+    b: s.b,
+    /** When the link lands inside the shuffle window (ms from shuffle start). */
+    at: Math.round(((i + 1) / (chain.swaps.length + 1)) * dials.shuffleMs),
+    glitch: false,
+    blackout: false,
+    occluded: false,
+    movesTarget: false,
+    tell: null,
+  }));
+
+  /* ---- 2. which links move her ---------------------------------------- */
+  const sim = simulate({ shells: n, startSlot: chain.startSlot, swaps });
+  for (let i = 0; i < swaps.length; i++) swaps[i].movesTarget = !!sim.moved[i];
+
+  /* ---- 3. the occlusions, under the ONE-LINK rule ---------------------- */
+  const roll = makeTaggedRoll(seed + '|md-load|' + index);
+  const carriers = [];                    // links that MOVE her
+  const empties = [];                     // links she is not in
+  for (const s of swaps) (s.movesTarget ? carriers : empties).push(s);
+
+  const wantHidden = dials.glitches + dials.blackouts;
+  const picked = [];
+  /* The ONE link: only ever one, and only when the round is allowed any
+   * occlusion at all. Deliberately dealt FIRST so the seeded choice of WHICH
+   * link is hidden never depends on how many decoy occlusions fit. */
+  if (wantHidden > 0 && carriers.length > 0) {
+    picked.push(carriers[Math.floor(roll('link') * carriers.length) % carriers.length]);
+  }
+  /* Everything else must land on a link she is not in. The pool is walked in a
+   * seeded order and consumed without repeats; running out lowers the count. */
+  const pool = empties.slice();
+  for (let k = pool.length - 1; k > 0; k--) {
+    const j = Math.floor(roll('shuffle') * (k + 1)) % (k + 1);
+    const tmp = pool[k]; pool[k] = pool[j]; pool[j] = tmp;
+  }
+  while (picked.length < wantHidden && pool.length) picked.push(pool.shift());
+
+  /* Blackouts are the loudest, so they take the LATE links (a blackout on the
+   * first link of a five-link chain is wasted on a shell nobody is tracking
+   * yet). Sort the chosen set by position and hand the tail the blackouts. */
+  picked.sort((x, y) => x.index - y.index);
+  const blackoutCount = Math.min(dials.blackouts, picked.length);
+  for (let i = 0; i < picked.length; i++) {
+    const s = picked[i];
+    s.occluded = true;
+    const isBlackout = i >= picked.length - blackoutCount;
+    s.blackout = isBlackout;
+    s.glitch = !isBlackout;
+    /* 3-4. THE TELL. Truthful, on both slots, and every occlusion carries one
+     * so the tell can never single out the link that mattered. */
+    s.tell = {
+      slots: [s.a, s.b],
+      /* which side of the table it comes from - the audio cue's pitch hint */
+      side: (s.a + s.b) / 2 < (n - 1) / 2 ? 'left' : 'right',
+      ms: dials.tellMs,
+    };
+  }
+
+  /* ---- 5. decoy reveals, never on her --------------------------------- */
+  const decoys = [];
+  const decoySpacing = dials.shuffleMs / (dials.decoys + 1);
+  for (let d = 0; d < dials.decoys; d++) {
+    /* Position the lift between links so it reads as a beat of its own; the
+     * seeded jitter keeps a lift off the exact frame of a slide. */
+    const at = Math.max(120, Math.min(dials.shuffleMs - 120, Math.round(
+      (d + 1) * decoySpacing + (roll('when') - 0.5) * decoySpacing * 0.4,
+    )));
+    /* Where is she at that instant? The link index she has passed so far. */
+    let passed = 0;
+    for (const s of swaps) { if (s.at <= at) passed += 1; }
+    const hereSlot = sim.path[Math.min(passed, sim.path.length - 1)];
+    const choices = [];
+    for (let i = 0; i < n; i++) if (i !== hereSlot) choices.push(i);
+    const slot = choices[Math.floor(roll('decoy') * choices.length) % choices.length];
+    decoys.push({
+      index: d,
+      at,
+      slot,
+      /* At the top effect tier the bait is a convincing FAKE target. */
+      fake: dials.fakeTargets && roll('fake') < 0.6,
+    });
+  }
+
+  const hiddenLinks = swaps.filter((s) => s.occluded && s.movesTarget).length;
+
+  return Object.freeze({
+    index,
+    seed,
+    shells: n,
+    dials,
+    startSlot: chain.startSlot,
+    swaps: Object.freeze(swaps.map((s) => Object.freeze(s))),
+    decoys: Object.freeze(decoys.map((d) => Object.freeze(d))),
+    finalSlot: sim.finalSlot,
+    path: Object.freeze(sim.path.slice()),
+    /** Occluded links that actually hid her. LAW: never more than 1. */
+    hiddenLinks,
+    /** True when the round hid a link at all - the sGate's "eyes open" test. */
+    blind: hiddenLinks > 0,
+    /** True when the round out-loaded a clean round of this grade tier. */
+    heavy: dials.load > dials.baselineLoad + 1e-9,
+    remedial: dials.remedial,
+    rideDepth: dials.rideDepth,
+    /** The whole round, end to end, in ms (the clock is the shell's). */
+    totalMs: dials.previewMs + PLAYTEST.SETTLE_MS + dials.shuffleMs + dials.pickMs,
+  });
+}
+
+/**
+ * THE INVARIANT, as an assertion. Returns a list of violations; an empty list
+ * is a legal round. The node suite runs this over 200 seeds x 4 tiers x every
+ * ride depth, and index.js runs it in `ctx.dev` builds only.
+ *
+ * @returns {string[]}
+ */
+export function verifyRound(plan) {
+  const bad = [];
+  if (!plan || !Array.isArray(plan.swaps)) return ['no plan'];
+  const n = plan.shells;
+  if (!(n >= 2 && n <= 5)) bad.push('shell count out of range: ' + n);
+  if (!plan.swaps.length) bad.push('empty chain');
+
+  /* 1. reconstructable */
+  const sim = simulate(plan);
+  if (sim.finalSlot !== plan.finalSlot) bad.push('finalSlot ' + plan.finalSlot + ' != simulated ' + sim.finalSlot);
+
+  let hidden = 0;
+  let lastKey = '';
+  for (let i = 0; i < plan.swaps.length; i++) {
+    const s = plan.swaps[i];
+    if (s.a === s.b) bad.push('link ' + i + ' swaps a slot with itself');
+    if (s.a < 0 || s.b < 0 || s.a >= n || s.b >= n) bad.push('link ' + i + ' is off the arc');
+    if (!!s.movesTarget !== !!sim.moved[i]) bad.push('link ' + i + ' movesTarget disagrees with the simulation');
+    const key = Math.min(s.a, s.b) + ':' + Math.max(s.a, s.b);
+    if (key === lastKey) bad.push('link ' + i + ' repeats the previous pair');
+    lastKey = key;
+    /* 2. at most one hidden LINK */
+    if (s.occluded && s.movesTarget) hidden += 1;
+    /* 3. a tell always survives */
+    if (s.occluded && !(s.tell && Array.isArray(s.tell.slots) && s.tell.slots.length === 2)) {
+      bad.push('link ' + i + ' is occluded with no tell');
+    }
+    if (!s.occluded && s.tell) bad.push('link ' + i + ' carries a tell it did not earn');
+    if (s.occluded && !(s.glitch || s.blackout)) bad.push('link ' + i + ' is occluded by nothing');
+  }
+  if (hidden > 1) bad.push('TRACKABILITY: ' + hidden + ' hidden links (max 1)');
+  if (hidden !== plan.hiddenLinks) bad.push('hiddenLinks ' + plan.hiddenLinks + ' != counted ' + hidden);
+
+  /* 4. decoys never lift her */
+  for (const d of (plan.decoys || [])) {
+    let passed = 0;
+    for (const s of plan.swaps) { if (s.at <= d.at) passed += 1; }
+    const here = sim.path[Math.min(passed, sim.path.length - 1)];
+    if (d.slot === here) bad.push('decoy ' + d.index + ' lifts the true shell');
+    if (d.slot < 0 || d.slot >= n) bad.push('decoy ' + d.index + ' is off the arc');
+  }
+
+  /* the honest window is never bent */
+  if (plan.dials.pickMs !== PLAYTEST.PICK_MS) bad.push('the pick window was bent');
+  return bad;
+}
+
+/**
+ * THE POT. Pure, and upward-only by construction: `banked` never falls.
+ *
+ * @param {Object} pot {live, rideDepth, banked, deepestBanked}
+ * @param {string} action 'win' | 'bank' | 'ride' | 'bust' | 'double'
+ * @returns {Object} a NEW pot state plus `event` ('forceBank' at the ride cap)
+ */
+export function potAfter(pot, action) {
+  const p = {
+    live: Math.max(0, Number(pot && pot.live) || 0),
+    rideDepth: Math.max(0, Math.min(PLAYTEST.RIDE_CAP, Math.round(Number(pot && pot.rideDepth) || 0))),
+    banked: Math.max(0, Number(pot && pot.banked) || 0),
+    deepestBanked: Math.max(0, Math.round(Number(pot && pot.deepestBanked) || 0)),
+    event: '',
+  };
+  switch (String(action)) {
+    case 'win':
+      /* A win pays the base times two per ride already taken. */
+      p.live = PLAYTEST.POT_BASE * Math.pow(2, p.rideDepth);
+      /* THE CAP: five deep force-banks with the jackpot ceremony. */
+      if (p.rideDepth >= PLAYTEST.RIDE_CAP) {
+        p.banked += p.live;
+        p.deepestBanked = Math.max(p.deepestBanked, p.rideDepth);
+        p.live = 0;
+        p.rideDepth = 0;
+        p.event = 'forceBank';
+      }
+      break;
+    case 'double':
+      /* The scholarship round: the jackpot ceremony doubles the live pot free. */
+      p.live = p.live * 2;
+      break;
+    case 'bank':
+      p.banked += p.live;
+      p.deepestBanked = Math.max(p.deepestBanked, p.rideDepth);
+      p.live = 0;
+      p.rideDepth = 0;
+      break;
+    case 'ride':
+      p.rideDepth = Math.min(PLAYTEST.RIDE_CAP, p.rideDepth + 1);
+      break;
+    case 'bust':
+      /* Only the STAKED pot burns. The bank is loss-proof by design. */
+      p.live = 0;
+      p.rideDepth = 0;
+      break;
+    default:
+      break;
+  }
+  return p;
+}
+
+/**
+ * THE HEAT LADDER. The class's own ladder is streak + ride depth; the grade
+ * tier only ever caps it (the DE/IC pattern).
+ */
+export function heatFor(streak, rideDepth, gradeTier) {
+  const cap = PLAYTEST.HEAT_CAP[tierOf(gradeTier)];
+  const s = clamp01((Number(streak) || 0) / PLAYTEST.HEAT_STREAK_FULL);
+  const r = clamp01((Number(rideDepth) || 0) / PLAYTEST.RIDE_CAP);
+  const line = clamp01(s * PLAYTEST.HEAT_STREAK_SHARE + r * (1 - PLAYTEST.HEAT_STREAK_SHARE));
+  return clamp01(cap * (PLAYTEST.HEAT_FLOOR + (1 - PLAYTEST.HEAT_FLOOR) * line));
+}
+
+export default { buildRound, simulate, verifyRound, dialsFor, potAfter, heatFor, PLAYTEST };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
@@ -1,0 +1,564 @@
+/* ============================================================================
+ * games/misdirection/style.js - the game injects its OWN stylesheet from JS.
+ *
+ * THE CON ARTIST'S TABLE. The class root is a full-viewport stage: a velvet
+ * card table under one hanging lamp, an arc of shells on the felt, the
+ * casino's arch of bulbs over it (casino.js paints the --md-n-* identity
+ * props; the fallbacks below are the plain violet felt, so a disarmed casino
+ * changes nothing). Composition, exactly the DOM contract:
+ *
+ *   .g-md-stage[data-phase][data-skin]  absolute inset:0, explicit ground,
+ *                 padded under the shell's proctor strip; --md-table is the one
+ *                 width every table-level thing is sized from
+ *   .g-md-backdrop  the casino's lighting rig (pointer-events:none, z 0)
+ *   .g-md-hud     four chips: round, clock, pot (gold), streak (pink)
+ *   .g-md-table   the felt: a perspective slab with a metal rail; the arch,
+ *                 the lamp and the casino's overlays live here
+ *   .g-md-arc     the row of shells, each positioned from --x (a FRACTION 0..1
+ *                 of the arc width, unitless: slot/(n-1)) and --slot; index.js
+ *                 writes the vars (+ --n on the arc), this file owns the
+ *                 transform + its slide transition
+ *   .g-md-shell   a real <button> - THE hitbox - > .g-md-lid (the cup body that
+ *                 lifts) .g-md-face > .g-md-media (what is under it) .g-md-tag
+ *                 (the number tag - the ONLY node the trickster may lie on)
+ *   .g-md-stake   bank / ride - real buttons, honest, never moved
+ *   .g-md-msg / .g-md-flashwell / .g-md-end / .g-md-howto
+ *
+ * THE TRANSFORM LAW. index.js writes --x / --slot and nothing else about a
+ * shell's position; this file owns the transform and its slide (the shuffle
+ * swap rides a 280ms ease; index.js's swap beats land on the same number).
+ * The transform of .g-md-shell is POSITIONAL ONLY: every lift, lean, sag,
+ * feint and breath lives on the lid / face / tag children, never on the shell
+ * node, so the hitbox never moves for a lie (Law II). Two decoration vars are
+ * composed INTO the children for the decks:
+ *   --md-feint     px lean of the cup BODY (trickster Fake Shuffle; the shell
+ *                  node and its hitbox stay put)
+ *   --md-n-ride    0..6 ride depth (casino; the rims glow deeper)
+ *
+ * SHELL STATES (index.js toggles; this file draws):
+ *   .is-lifted    the lid is up (reveal / verdict / decoy)
+ *   .is-decoy     a decoy lift (the lid only half-lifts and snaps back)
+ *   .is-fake      the decoy shows a convincing fake (NOT styled - a style
+ *                 would be a tell; the face media is index.js's lie)
+ *   .is-picked    the player's pick; .is-picked.is-true = the hit (gold bloom,
+ *                 the face pops), .is-picked:not(.is-true) = the miss (the lid
+ *                 lifts on an empty face, dims)
+ *   .is-true      the true shell; alone (after a miss) = the under-rim tease
+ *   .is-tell      an occluded swap's peripheral mark (a rim flash)
+ *   .is-swapping  mid-swap (the body leans into travel, the slide eases)
+ *   .g-md-tk-melt / .g-md-tk-feint  the trickster's wax sag / feint lean
+ * The stage wears [data-occluding="1"] during a blackout beat (the felt goes
+ * dark; the shells keep a hairline rim so a peripheral tell survives).
+ *
+ * THREE SKINS (data-skin on the stage; the shell is one DOM shape for all):
+ *   themed    velvet cups: a dome in the felt's hue with a metal rim and a
+ *             hanging brass number tag; the lid lifts with a spring overshoot
+ *   minimal   flat outlined rounded rects, one ink, no gradient
+ *   contrast  black body, thick white rims, big tags: rims stay trackable
+ *             under any wash
+ *
+ * THE SHEET (Deck VI, Law IV): .g-md-howto is drawn - four vignettes (a lid
+ * lifts / cups slide / a hand or keycap points / the coin stack splits bank
+ * or ride) and the GO button, the only live thing on it. THE END CARD: the
+ * grade arrives as an OBJECT - .g-md-end-seal is a wax seal bearing the letter.
+ *
+ * NOTHING IS EVER STILL (Law III): the lamp sways, the weave drifts, the cups
+ * breathe, the marquee crawls. REDUCED MOTION twice over (html.arc-reduced +
+ * the media query): only the slide transition and the lid lift survive.
+ * .g-md-stage.suspended freezes every animation.
+ * ==========================================================================*/
+
+const STYLE_ID = 'g-md-style';
+
+export const STYLE_TEXT = `
+/* ---- registered decoration props: numbers interpolate, so the journey
+   MORPHS instead of snapping ------------------------------------------------ */
+@property --md-n-a-diamond{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-n-a-herringbone{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-n-a-damask{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-n-a-pinstripe{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-n-a-lace{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-n-tilt{syntax:'<number>';inherits:true;initial-value:-12}
+@property --md-n-scale{syntax:'<number>';inherits:true;initial-value:1}
+@property --md-n-ride{syntax:'<number>';inherits:true;initial-value:0}
+@property --md-x{syntax:'<number>';inherits:false;initial-value:.5}
+@property --md-feint{syntax:'<number>';inherits:false;initial-value:0}
+@property --md-hw-k{syntax:'<angle>';inherits:false;initial-value:270deg}
+
+/* ---- the stage: the whole window is the parlour ---------------------------- */
+.g-md-stage{position:absolute;inset:0;overflow:hidden;display:flex;flex-direction:column;
+  align-items:center;gap:8px;padding:72px 18px 14px;color:var(--ink);
+  --md-table:min(calc(100vw - 48px), 980px);
+  --md-shell:clamp(64px, calc(var(--md-table) / 6.2), 150px);
+  --md-felt:var(--md-n-felt, color-mix(in srgb, var(--lav), #0b0618 74%));
+  --md-felt-deep:var(--md-n-felt-deep, color-mix(in srgb, var(--lav), #06030f 86%));
+  --md-felt-lit:var(--md-n-felt-lit, color-mix(in srgb, var(--pink), #1a0f2e 60%));
+  --md-la:var(--md-n-la, color-mix(in srgb, var(--lav), transparent 72%));
+  --md-lb:var(--md-n-lb, color-mix(in srgb, var(--pink), transparent 78%));
+  --md-glow:var(--md-n-glow, var(--pink));
+  --md-metal:var(--md-n-metal, #d4a64a);
+  --md-metal-dk:var(--md-n-metal-dk, #7a5a1c);
+  --md-breath:var(--md-n-breath, 9s);
+  --md-drift:var(--md-n-drift, 24s);
+  transition:--md-n-a-diamond 3.2s ease, --md-n-a-herringbone 3.2s ease, --md-n-a-damask 3.2s ease,
+    --md-n-a-pinstripe 3.2s ease, --md-n-a-lace 3.2s ease, --md-n-tilt 4s ease, --md-n-scale 4s ease, --md-n-ride .6s ease;
+  background:
+    radial-gradient(110% 60% at 50% -6%, var(--md-la), transparent 62%),
+    radial-gradient(80% 50% at 50% 112%, var(--md-lb), transparent 60%),
+    color-mix(in srgb, var(--ground), black 46%)}
+.g-md-stage.suspended *{animation-play-state:paused !important}
+
+/* ---- the backdrop: the casino's lighting rig (decoration only) ------------- */
+.g-md-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
+.g-md-backdrop *{pointer-events:none}
+.g-md-bd{position:absolute;inset:-6%;opacity:1}
+.g-md-bd::before{content:"";position:absolute;inset:0}
+/* the felt: the lamp pool over deep velvet; it breathes */
+.g-md-bd-felt::before{
+  background:radial-gradient(60% 48% at 50% 38%, var(--md-felt-lit), var(--md-felt) 55%, var(--md-felt-deep) 100%);
+  animation:g-md-breathe var(--md-breath) ease-in-out infinite alternate}
+@keyframes g-md-breathe{from{opacity:.82;transform:scale(1)}to{opacity:1;transform:scale(1.03)}}
+/* the weaves: five families, one prop each, all drifting on their own bearing */
+.g-md-bd-diamond,.g-md-bd-herringbone,.g-md-bd-damask,.g-md-bd-pinstripe,.g-md-bd-lace{mix-blend-mode:soft-light}
+.g-md-bd-diamond::before{opacity:var(--md-n-a-diamond,0);
+  background:repeating-linear-gradient(calc(45deg + var(--md-n-tilt,0) * 1deg), rgba(255,255,255,.12) 0 2px, transparent 2px calc(26px * var(--md-n-scale,1))),
+    repeating-linear-gradient(calc(-45deg + var(--md-n-tilt,0) * 1deg), rgba(255,255,255,.12) 0 2px, transparent 2px calc(26px * var(--md-n-scale,1)));
+  animation:g-md-weave var(--md-drift) linear infinite}
+.g-md-bd-herringbone::before{opacity:var(--md-n-a-herringbone,0);
+  background:repeating-linear-gradient(calc(60deg + var(--md-n-tilt,0) * 1deg), rgba(255,255,255,.1) 0 3px, transparent 3px calc(14px * var(--md-n-scale,1))),
+    repeating-linear-gradient(calc(120deg + var(--md-n-tilt,0) * 1deg), rgba(0,0,0,.18) 0 3px, transparent 3px calc(14px * var(--md-n-scale,1)));
+  animation:g-md-weave calc(var(--md-drift) * 1.3) linear infinite reverse}
+.g-md-bd-damask::before{opacity:var(--md-n-a-damask,0);
+  background:radial-gradient(circle at 25% 25%, rgba(255,255,255,.14) 0 6%, transparent 7% 30%, rgba(255,255,255,.08) 31% 34%, transparent 35%),
+    radial-gradient(circle at 75% 75%, rgba(255,255,255,.14) 0 6%, transparent 7% 30%, rgba(255,255,255,.08) 31% 34%, transparent 35%);
+  background-size:calc(120px * var(--md-n-scale,1)) calc(120px * var(--md-n-scale,1));
+  transform:rotate(calc(var(--md-n-tilt,0) * .5deg));
+  animation:g-md-weave calc(var(--md-drift) * 1.6) linear infinite}
+.g-md-bd-pinstripe::before{opacity:var(--md-n-a-pinstripe,0);
+  background:repeating-linear-gradient(calc(90deg + var(--md-n-tilt,0) * 1deg), rgba(255,255,255,.16) 0 1px, transparent 1px calc(11px * var(--md-n-scale,1)));
+  animation:g-md-weave calc(var(--md-drift) * .9) linear infinite}
+.g-md-bd-lace::before{opacity:var(--md-n-a-lace,0);
+  background:radial-gradient(circle, transparent 40%, rgba(255,255,255,.14) 41% 46%, transparent 47%);
+  background-size:calc(48px * var(--md-n-scale,1)) calc(48px * var(--md-n-scale,1));
+  transform:rotate(calc(var(--md-n-tilt,0) * 1deg));
+  animation:g-md-weave calc(var(--md-drift) * 1.15) linear infinite reverse}
+@keyframes g-md-weave{from{background-position:0 0}to{background-position:160px 90px}}
+/* the smoke: two soft blobs drifting through the lamp light */
+.g-md-bd-smoke::before{opacity:.55;
+  background:radial-gradient(30% 22% at 30% 40%, rgba(255,255,255,.07), transparent 70%),
+    radial-gradient(26% 20% at 70% 55%, rgba(255,255,255,.06), transparent 70%);
+  animation:g-md-smoke calc(var(--md-drift) * 1.4) ease-in-out infinite alternate}
+@keyframes g-md-smoke{from{transform:translate(-3%,1%) scale(1)}to{transform:translate(3%,-2%) scale(1.08)}}
+/* the dark: bust / dim-out breathe this in; the vignette is always there */
+.g-md-bd-dark{opacity:0;background:rgba(4,2,10,.7);transition:opacity .5s ease}
+.g-md-bd-vig{background:radial-gradient(80% 70% at 50% 50%, transparent 55%, rgba(2,1,8,.75) 100%)}
+.g-md-stage.g-md-bust .g-md-bd-dark{opacity:.55}
+.g-md-stage.g-md-out .g-md-bd-dark{opacity:.6;transition:opacity 1.6s ease}
+.g-md-stage.g-md-out .g-md-bd-felt::before{animation:none;opacity:.7;transition:opacity 1.6s ease}
+.g-md-stage.g-md-royal{--md-felt-lit:color-mix(in srgb, var(--gold), var(--md-felt) 55%)}
+
+/* ---- HUD: four chips above the felt --------------------------------------- */
+.g-md-hud{position:relative;z-index:2;display:flex;flex-wrap:wrap;align-items:center;
+  justify-content:center;gap:8px 12px;font-family:var(--mono);font-size:11px;
+  letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint)}
+.g-md-chip{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+  border:1px solid color-mix(in srgb, var(--lav), var(--line) 55%);
+  background:color-mix(in srgb, var(--panel), transparent 40%);
+  color:color-mix(in srgb, var(--ink-dim), var(--lav) 30%);
+  font-variant-numeric:tabular-nums;transition:color .3s ease,border-color .3s ease,box-shadow .3s ease}
+.g-md-chip.g-md-pot{border-color:color-mix(in srgb, var(--gold), var(--line) 40%);color:var(--gold);
+  box-shadow:0 0 12px color-mix(in srgb, var(--gold), transparent 72%)}
+.g-md-chip.g-md-streak{border-color:var(--pink);color:var(--pink);
+  box-shadow:0 0 12px color-mix(in srgb, var(--pink), transparent 62%)}
+.g-md-chip.g-md-clock{color:var(--ink)}
+.g-md-stage[data-phase="pick"] .g-md-clock{border-color:color-mix(in srgb, var(--ink), var(--line) 40%)}
+.g-md-chip.g-md-bell,.g-md-stage.g-md-bell .g-md-clock{border-color:var(--gold);color:var(--gold);
+  animation:g-md-bellchip 1s ease-in-out infinite alternate}
+@keyframes g-md-bellchip{from{box-shadow:0 0 6px rgba(240,194,75,.3)}to{box-shadow:0 0 16px rgba(240,194,75,.7)}}
+
+/* ---- the table: a velvet slab under the lamp -------------------------------- */
+.g-md-table > .arc-stamp{position:absolute;left:0;right:0;top:40%;margin:0 auto;width:max-content;z-index:6;
+  font-size:clamp(14px,2.2vmin,20px);padding:7px 16px}
+.g-md-table{position:relative;z-index:1;flex:1;min-height:0;width:var(--md-table);
+  max-height:calc(var(--md-table) * .52);margin:auto 0;
+  --md-rail:var(--md-metal);
+  border-radius:46% 46% 18px 18px / 70% 70% 18px 18px;
+  background:
+    radial-gradient(70% 60% at 50% 30%, color-mix(in srgb, var(--md-felt-lit), transparent 20%), transparent 70%),
+    linear-gradient(180deg, var(--md-felt) 0%, var(--md-felt-deep) 100%);
+  box-shadow:inset 0 0 0 3px color-mix(in srgb, var(--md-rail), black 30%), inset 0 0 0 6px color-mix(in srgb, var(--md-rail), transparent 45%),
+    inset 0 10px 40px rgba(0,0,0,.5), 0 26px 60px rgba(0,0,0,.6), 0 0 40px color-mix(in srgb, var(--md-glow), transparent 78%)}
+.g-md-table::before{content:"";position:absolute;inset:8px;border-radius:inherit;pointer-events:none;
+  background:radial-gradient(60% 40% at 50% 0%, rgba(255,255,255,.08), transparent 70%)}
+.g-md-stage.g-md-shuffling .g-md-table{box-shadow:inset 0 0 0 3px color-mix(in srgb, var(--md-rail), black 30%), inset 0 0 0 6px color-mix(in srgb, var(--md-rail), transparent 45%),
+    inset 0 10px 40px rgba(0,0,0,.5), 0 26px 60px rgba(0,0,0,.6), 0 0 54px color-mix(in srgb, var(--md-glow), transparent 62%)}
+
+/* ---- the arc: shells positioned from --x (percent) -------------------------- */
+.g-md-arc{position:absolute;left:9%;right:9%;top:22%;bottom:10%;z-index:2;
+  transition:transform .6s ease}
+.g-md-stage[data-occluding="1"] .g-md-arc{filter:brightness(.5) saturate(.7);transition:filter .1s ease}
+.g-md-stage[data-occluding="1"] .g-md-table{filter:brightness(.7)}
+.g-md-shell{position:absolute;left:calc(var(--md-x, .5) * 100%);top:50%;
+  width:var(--md-shell);height:calc(var(--md-shell) * 1.08);margin:0;padding:0;border:0;background:none;
+  appearance:none;-webkit-appearance:none;cursor:pointer;color:inherit;font:inherit;
+  /* POSITIONAL ONLY: the centre, the gentle arc (outer shells sit lower, nearer
+     the player) and the slide. Nothing decorative lives here. */
+  transform:translate(-50%, calc(-50% + (var(--md-x, .5) - .5) * (var(--md-x, .5) - .5) * 110px));
+  transition:left .28s cubic-bezier(.3,.7,.25,1), transform .28s cubic-bezier(.3,.7,.25,1);
+  -webkit-tap-highlight-color:transparent;touch-action:manipulation;outline:none}
+.g-md-shell:focus-visible .g-md-lid{box-shadow:0 0 0 3px color-mix(in srgb, var(--gold), transparent 20%), 0 14px 26px rgba(0,0,0,.55)}
+.g-md-shell.is-swapping{transition:left .28s cubic-bezier(.5,.1,.3,1), transform .28s cubic-bezier(.5,.1,.3,1)}
+/* the face: what is under the cup - a disc of the player's own media */
+.g-md-face{position:absolute;left:50%;bottom:12%;width:62%;aspect-ratio:1;transform:translateX(-50%) scale(.92);
+  border-radius:50%;overflow:hidden;z-index:1;opacity:0;
+  background:radial-gradient(circle at 40% 35%, color-mix(in srgb, var(--md-glow), white 20%), color-mix(in srgb, var(--md-glow), black 40%));
+  box-shadow:0 0 16px color-mix(in srgb, var(--md-glow), transparent 50%), inset 0 0 0 2px rgba(255,255,255,.25);
+  transition:opacity .22s ease, transform .3s cubic-bezier(.2,1.4,.4,1)}
+.g-md-media{display:block;width:100%;height:100%;object-fit:cover;pointer-events:none}
+.g-md-media:not([src]),.g-md-media[src=""]{visibility:hidden}
+.g-md-shell.is-lifted .g-md-face{opacity:1;transform:translateX(-50%) scale(1)}
+.g-md-shell.is-picked.is-true .g-md-face{transform:translateX(-50%) scale(1.28);
+  box-shadow:0 0 28px color-mix(in srgb, var(--gold), transparent 20%), inset 0 0 0 2px rgba(255,255,255,.5)}
+.g-md-shell.is-picked:not(.is-true) .g-md-face{opacity:.35;background:rgba(10,6,20,.6);box-shadow:none}
+.g-md-face[data-dressed="0"]{background:radial-gradient(circle at 40% 35%, rgba(255,255,255,.12), rgba(10,6,20,.6));box-shadow:inset 0 0 0 2px rgba(255,255,255,.12)}
+.g-md-shell.is-picked:not(.is-true) .g-md-media{opacity:0}
+/* the lid: the cup body that lifts. Everything decorative composes here:
+   the lift, the spring, the lean into travel, the trickster's feint + sag. */
+.g-md-lid{position:absolute;left:50%;top:0;width:82%;height:80%;z-index:2;
+  transform:translateX(calc(-50% + var(--md-feint,0) * 1px)) translateY(0) rotate(calc(var(--md-feint,0) * -.6deg));
+  transform-origin:50% 100%;
+  transition:transform .34s cubic-bezier(.2,1.5,.4,1), box-shadow .3s ease, filter .3s ease;
+  animation:g-md-cupbreath calc(var(--md-breath) * .8) ease-in-out infinite alternate;
+  animation-delay:calc(var(--slot,0) * -1.3s)}
+@keyframes g-md-cupbreath{from{translate:0 0}to{translate:0 -2px}}
+.g-md-shell.is-lifted .g-md-lid{transform:translateX(calc(-50% + var(--md-feint,0) * 1px)) translateY(-72%) rotate(-7deg)}
+.g-md-shell.is-decoy.is-lifted .g-md-lid{transform:translateX(-50%) translateY(-40%) rotate(-4deg);transition:transform .16s ease-out}
+.g-md-shell.is-swapping .g-md-lid{transform:translateX(-50%) translateY(-3%) scaleX(.96)}
+.g-md-shell.g-md-tk-feint .g-md-lid{transition:transform .13s cubic-bezier(.3,.7,.3,1)}
+.g-md-shell.g-md-tk-melt .g-md-lid{transform:translateX(-50%) translateY(6%) scaleY(.88) skewX(4deg);filter:saturate(.8) brightness(.9);transition:transform .42s ease-in}
+.g-md-shell.g-md-tk-melt .g-md-lid::after{opacity:1}
+/* the shadow on the felt under the cup (lifts with it) */
+.g-md-shell::before{content:"";position:absolute;left:50%;bottom:4%;width:78%;height:16%;transform:translateX(-50%);
+  border-radius:50%;background:radial-gradient(50% 50% at 50% 50%, rgba(0,0,0,.55), transparent 70%);
+  transition:opacity .3s ease, transform .3s ease;z-index:0}
+.g-md-shell.is-lifted::before{opacity:.35;transform:translateX(-50%) scale(1.15)}
+/* the tag: a hanging number on a thread - the ONLY node the trickster may lie on */
+.g-md-tag{position:absolute;left:50%;bottom:-6%;transform:translateX(-50%);z-index:3;min-width:1.7em;padding:2px 6px;
+  font:700 clamp(10px,1.5vmin,13px)/1.2 var(--mono);letter-spacing:.08em;text-align:center;border-radius:4px;
+  color:color-mix(in srgb, var(--md-metal), white 30%);background:color-mix(in srgb, var(--md-metal-dk), black 40%);
+  border:1px solid color-mix(in srgb, var(--md-metal), transparent 35%);box-shadow:0 2px 6px rgba(0,0,0,.5);
+  transition:color .2s ease, background .2s ease}
+.g-md-tag:empty{opacity:0}
+.g-md-shell.g-md-tk-melt .g-md-tag{transform:translateX(-50%) translateY(3px) skewX(-6deg)}
+
+/* ---- SKIN: themed (velvet cups, metal rim) ---------------------------------- */
+.g-md-stage[data-skin="themed"] .g-md-lid{border-radius:48% 48% 14% 14% / 70% 70% 10% 10%;
+  background:
+    radial-gradient(70% 40% at 35% 18%, rgba(255,255,255,.22), transparent 60%),
+    linear-gradient(90deg, color-mix(in srgb, var(--md-felt-lit), black 10%) 0%, color-mix(in srgb, var(--md-felt-lit), white 12%) 45%, color-mix(in srgb, var(--md-felt), black 25%) 100%);
+  box-shadow:inset 0 -8px 0 color-mix(in srgb, var(--md-metal-dk), black 10%), inset 0 -11px 0 var(--md-metal),
+    inset 0 0 0 1px rgba(255,255,255,.08), 0 14px 26px rgba(0,0,0,.55),
+    0 0 calc(var(--md-n-ride,0) * 6px) color-mix(in srgb, var(--md-glow), transparent calc(85% - var(--md-n-ride,0) * 9%))}
+.g-md-stage[data-skin="themed"] .g-md-lid::before{content:"";position:absolute;left:50%;top:-6%;width:26%;height:18%;transform:translateX(-50%);
+  border-radius:50%;background:radial-gradient(circle at 40% 35%, color-mix(in srgb, var(--md-metal), white 40%), var(--md-metal) 50%, var(--md-metal-dk));
+  box-shadow:0 2px 4px rgba(0,0,0,.5)}
+.g-md-stage[data-skin="themed"] .g-md-lid::after{content:"";position:absolute;left:30%;bottom:-10%;width:10%;height:18%;opacity:0;
+  border-radius:0 0 50% 50%;background:color-mix(in srgb, var(--md-felt-lit), white 10%);transition:opacity .3s ease}
+.g-md-stage[data-skin="themed"] .g-md-shell.is-picked .g-md-lid{filter:brightness(1.18)}
+.g-md-stage[data-skin="themed"] .g-md-shell.is-picked.is-true .g-md-lid{box-shadow:inset 0 -8px 0 color-mix(in srgb, var(--md-metal-dk), black 10%), inset 0 -11px 0 var(--gold),
+    0 14px 26px rgba(0,0,0,.55), 0 0 30px color-mix(in srgb, var(--gold), transparent 30%)}
+.g-md-stage[data-skin="themed"] .g-md-shell.is-true:not(.is-picked) .g-md-lid{box-shadow:inset 0 -8px 0 color-mix(in srgb, var(--md-metal-dk), black 10%), inset 0 -11px 0 var(--md-metal),
+    0 14px 26px rgba(0,0,0,.55), 0 10px 28px color-mix(in srgb, var(--md-glow), transparent 25%)}
+.g-md-stage[data-skin="themed"] .g-md-shell.is-tell .g-md-lid{box-shadow:inset 0 -8px 0 color-mix(in srgb, var(--md-metal-dk), black 10%), inset 0 -11px 0 var(--md-metal),
+    0 0 0 3px color-mix(in srgb, var(--md-glow), transparent 25%), 0 14px 26px rgba(0,0,0,.55);transition:box-shadow .08s ease}
+.g-md-stage[data-skin="themed"] .g-md-shell.is-picked:not(.is-true) .g-md-lid{filter:saturate(.6) brightness(.75)}
+
+/* ---- SKIN: minimal (flat outlines, one ink) ---------------------------------- */
+.g-md-stage[data-skin="minimal"] .g-md-lid{border-radius:14px 14px 6px 6px;background:color-mix(in srgb, var(--ground), black 20%);
+  border:2px solid color-mix(in srgb, var(--ink), transparent 30%);box-shadow:0 10px 20px rgba(0,0,0,.45);animation:none}
+.g-md-stage[data-skin="minimal"] .g-md-tag{background:transparent;border-color:transparent;color:var(--ink);box-shadow:none}
+.g-md-stage[data-skin="minimal"] .g-md-shell.is-picked .g-md-lid{border-color:var(--ink)}
+.g-md-stage[data-skin="minimal"] .g-md-shell.is-picked.is-true .g-md-lid{border-color:var(--gold)}
+.g-md-stage[data-skin="minimal"] .g-md-shell.is-true:not(.is-picked) .g-md-lid{border-color:var(--md-glow)}
+.g-md-stage[data-skin="minimal"] .g-md-shell.is-tell .g-md-lid{border-color:var(--md-glow);box-shadow:0 0 0 2px color-mix(in srgb, var(--md-glow), transparent 40%)}
+.g-md-stage[data-skin="minimal"] .g-md-shell.is-picked:not(.is-true) .g-md-lid{opacity:.55}
+.g-md-stage[data-skin="minimal"] .g-md-face{background:color-mix(in srgb, var(--ink), transparent 80%);box-shadow:inset 0 0 0 2px var(--ink)}
+
+/* ---- SKIN: contrast (black body, thick white rims, big tags) ----------------- */
+.g-md-stage[data-skin="contrast"] .g-md-lid{border-radius:46% 46% 10% 10% / 66% 66% 8% 8%;background:#05030a;
+  border:4px solid #fff;box-shadow:0 0 0 2px #000, 0 12px 24px rgba(0,0,0,.7)}
+.g-md-stage[data-skin="contrast"] .g-md-tag{font-size:clamp(12px,2vmin,16px);color:#000;background:#fff;border-color:#000;min-width:2em}
+.g-md-stage[data-skin="contrast"] .g-md-shell.is-picked .g-md-lid{border-color:#ffe08a}
+.g-md-stage[data-skin="contrast"] .g-md-shell.is-picked.is-true .g-md-lid{border-color:var(--gold);box-shadow:0 0 0 2px #000, 0 0 30px rgba(240,194,75,.7)}
+.g-md-stage[data-skin="contrast"] .g-md-shell.is-true:not(.is-picked) .g-md-lid{border-color:#ff69b4;box-shadow:0 0 0 2px #000, 0 0 24px rgba(255,105,180,.8)}
+.g-md-stage[data-skin="contrast"] .g-md-shell.is-tell .g-md-lid{border-color:#ff69b4}
+.g-md-stage[data-skin="contrast"] .g-md-shell.is-picked:not(.is-true) .g-md-lid{border-color:#777}
+.g-md-stage[data-skin="contrast"][data-occluding="1"] .g-md-arc{filter:brightness(.75)}
+.g-md-stage[data-skin="contrast"] .g-md-face{box-shadow:inset 0 0 0 3px #fff, 0 0 16px rgba(255,255,255,.5)}
+
+/* ---- the stake: two real buttons, honest, never moved ------------------------- */
+/* index.js toggles the node with the hidden attribute, so NO display here:
+   block by default, the buttons inline, centred by text-align. */
+.g-md-stake{position:relative;z-index:4;text-align:center;min-height:44px;
+  font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-dim)}
+.g-md-stake .g-md-stake-line{display:inline-block;margin:0 8px 0 0;color:var(--ink-faint)}
+.g-md-stake button,.g-md-btn{display:inline-block;margin:0 7px;appearance:none;-webkit-appearance:none;font:inherit;letter-spacing:inherit;text-transform:inherit;
+  cursor:pointer;padding:9px 18px;border-radius:999px;border:1px solid var(--line);color:var(--ink);
+  background:color-mix(in srgb, var(--panel), transparent 30%);transition:background .2s ease, border-color .2s ease, box-shadow .2s ease}
+.g-md-stake button:focus-visible,.g-md-btn:focus-visible{outline:2px solid var(--gold);outline-offset:3px}
+.g-md-stake button:active{transform:translateY(1px)}
+.g-md-btn.g-md-bank{border-color:var(--lav);color:var(--lav)}
+.g-md-btn.g-md-bank:hover{background:color-mix(in srgb, var(--panel), var(--lav) 18%);color:var(--ink)}
+.g-md-btn.g-md-ride{border-color:var(--pink);color:var(--pink);
+  box-shadow:0 0 12px color-mix(in srgb, var(--pink), transparent 70%);animation:g-md-ridepulse 1.6s ease-in-out infinite alternate}
+.g-md-btn.g-md-ride:hover{background:color-mix(in srgb, var(--panel), var(--pink) 20%);color:var(--ink)}
+@keyframes g-md-ridepulse{from{box-shadow:0 0 8px color-mix(in srgb, var(--pink), transparent 80%)}to{box-shadow:0 0 20px color-mix(in srgb, var(--pink), transparent 50%)}}
+
+/* ---- the flash well: engine one-shots over the table, never a pointer --------- */
+.g-md-flashwell{position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:6}
+.g-md-flashwell *{pointer-events:none}
+
+/* ---- proctor line + end card ----------------------------------------------------- */
+.g-md-msg{position:relative;z-index:2;margin:0;min-height:1.4em;text-align:center;
+  font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--ink-dim);transition:opacity .3s ease}
+.g-md-msg:empty{opacity:0}
+/* index.js toggles the node with the hidden attribute: NO display here. */
+.g-md-end{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:8;
+  width:min(460px, 92%);padding:18px 20px 16px;
+  border-radius:16px;background:color-mix(in srgb, var(--navy), transparent 6%);
+  border:1px solid color-mix(in srgb, var(--md-metal), var(--line) 50%);
+  box-shadow:0 18px 50px rgba(0,0,0,.55), 0 0 34px color-mix(in srgb, var(--md-glow), transparent 72%);
+  animation:g-md-endin .5s ease-out 1}
+@keyframes g-md-endin{from{opacity:0;transform:translate(-50%,-46%)}to{opacity:1;transform:translate(-50%,-50%)}}
+.g-md-end-title{font-family:var(--disp);font-size:16px;letter-spacing:.14em;text-transform:uppercase;
+  margin:0 0 8px;color:var(--ink);text-align:center;text-shadow:0 0 18px color-mix(in srgb, var(--md-glow), transparent 60%)}
+.g-md-end-row{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-dim);
+  padding:5px 0;border-bottom:1px dashed color-mix(in srgb, var(--line), transparent 20%)}
+.g-md-end-k{color:var(--ink-faint)}
+.g-md-end-v{color:var(--ink);font-variant-numeric:tabular-nums}
+.g-md-end-bank .g-md-end-v{color:var(--gold);font-size:14px;text-shadow:0 0 12px color-mix(in srgb, var(--gold), transparent 55%)}
+.g-md-end-line,.g-md-end-note{margin:6px 0 0;font-size:12px;color:var(--ink-dim);text-align:center}
+/* THE GRADE AS AN OBJECT: a wax seal pressed on the report - index.js may
+   append .g-md-end-seal[data-grade=S|A|B|C] with the letter as text */
+.g-md-end-seal{position:absolute;right:-14px;top:-18px;width:64px;height:64px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+  font:800 26px/1 var(--disp);color:rgba(20,8,14,.85);transform:rotate(-12deg);
+  --md-seal:color-mix(in srgb, var(--md-glow), #7a1040 40%);
+  background:radial-gradient(circle at 40% 35%, color-mix(in srgb, var(--md-seal), white 22%), var(--md-seal) 55%, color-mix(in srgb, var(--md-seal), black 35%));
+  box-shadow:inset 0 0 0 3px rgba(0,0,0,.18), inset 0 0 0 7px rgba(255,255,255,.08), 0 8px 18px rgba(0,0,0,.55);
+  animation:g-md-seal .55s cubic-bezier(.2,1.6,.4,1) .25s both}
+.g-md-end-seal::before{content:"";position:absolute;inset:-6px;border-radius:50%;border:1px dashed color-mix(in srgb, var(--md-seal), transparent 30%)}
+.g-md-end-seal[data-grade="S"]{--md-seal:var(--gold);color:rgba(40,24,4,.9)}
+.g-md-end-seal[data-grade="A"]{--md-seal:var(--pink)}
+.g-md-end-seal[data-grade="B"]{--md-seal:var(--lav);color:rgba(14,10,30,.85)}
+.g-md-end-seal[data-grade="C"]{--md-seal:var(--slate);color:rgba(14,10,30,.85)}
+@keyframes g-md-seal{from{opacity:0;transform:rotate(-12deg) scale(1.6)}to{opacity:1;transform:rotate(-12deg) scale(1)}}
+.g-md-end .btn,.g-md-end button{margin:10px 4px 0}
+
+/* ---- THE CLASS RULES SHEET (Deck VI, Law IV: drawn, not told) ------------------- */
+.g-md-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(540px,92vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:22px 24px 20px;border-radius:16px;
+  background:linear-gradient(180deg, color-mix(in srgb, var(--navy), transparent 6%), color-mix(in srgb, var(--ground), black 30%));
+  border:1px solid color-mix(in srgb, var(--md-metal), var(--line) 50%);
+  box-shadow:0 30px 80px rgba(0,0,0,.55), 0 0 44px color-mix(in srgb, var(--md-glow), transparent 86%)}
+.g-md-hw-title{margin:0 0 8px;text-align:center;font:700 clamp(16px,2.4vmin,20px)/1.2 var(--disp);
+  letter-spacing:.2em;text-transform:uppercase;color:var(--md-glow);text-shadow:0 0 22px color-mix(in srgb, var(--md-glow), transparent 55%)}
+.g-md-hw-row{display:flex;align-items:center;gap:16px;padding:11px 2px}
+.g-md-hw-row + .g-md-hw-row{border-top:1px dashed color-mix(in srgb, var(--line), transparent 40%)}
+.g-md-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim)}
+.g-md-hw-keys{margin:2px 0 0;font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;color:var(--ink-faint)}
+.g-md-hw-fig{flex:0 0 auto;display:flex;align-items:center;gap:9px;pointer-events:none}
+.g-md-hw-scene{position:relative;display:block;width:96px;height:58px;flex:0 0 auto;
+  border-radius:40% 40% 8px 8px / 60% 60% 8px 8px;background:linear-gradient(180deg, var(--md-felt-lit), var(--md-felt-deep));
+  box-shadow:inset 0 0 0 2px color-mix(in srgb, var(--md-metal), transparent 50%)}
+.g-md-hw-cup{position:absolute;bottom:10px;width:22px;height:20px;border-radius:48% 48% 14% 14% / 70% 70% 10% 10%;
+  background:linear-gradient(90deg, color-mix(in srgb, var(--md-felt-lit), black 10%), color-mix(in srgb, var(--md-felt-lit), white 14%) 45%, color-mix(in srgb, var(--md-felt), black 25%));
+  box-shadow:inset 0 -3px 0 var(--md-metal), 0 4px 8px rgba(0,0,0,.5);transform-origin:50% 100%}
+.g-md-hw-cup.c1{left:14px}.g-md-hw-cup.c2{left:37px}.g-md-hw-cup.c3{left:60px}
+.g-md-hw-gem{position:absolute;bottom:12px;left:41px;width:14px;height:14px;border-radius:50%;
+  background:radial-gradient(circle at 40% 35%, #fff, var(--md-glow) 45%, color-mix(in srgb, var(--md-glow), black 40%));
+  box-shadow:0 0 10px color-mix(in srgb, var(--md-glow), transparent 30%)}
+/* 1 - the reveal: the middle cup lifts, the gem glows, it drops back */
+.g-md-hw-watch .c2{animation:g-md-hw-lift 2.8s ease-in-out infinite}
+@keyframes g-md-hw-lift{0%,10%{transform:translateY(0) rotate(0)}25%,60%{transform:translateY(-16px) rotate(-8deg)}78%,100%{transform:translateY(0) rotate(0)}}
+/* 2 - the shuffle: the outer cups trade places, the middle leans */
+.g-md-hw-shuffle .c1{animation:g-md-hw-swapr 2.4s ease-in-out infinite}
+.g-md-hw-shuffle .c3{animation:g-md-hw-swapl 2.4s ease-in-out infinite}
+.g-md-hw-shuffle .c2{animation:g-md-hw-lean 2.4s ease-in-out infinite}
+.g-md-hw-shuffle .g-md-hw-gem{opacity:0}
+@keyframes g-md-hw-swapr{0%,15%{transform:translateX(0)}50%,65%{transform:translateX(46px)}100%{transform:translateX(0)}}
+@keyframes g-md-hw-swapl{0%,15%{transform:translateX(0)}50%,65%{transform:translateX(-46px)}100%{transform:translateX(0)}}
+@keyframes g-md-hw-lean{0%,15%{transform:rotate(0)}35%{transform:rotate(6deg)}55%{transform:rotate(-6deg)}80%,100%{transform:rotate(0)}}
+.g-md-hw-blind{position:absolute;inset:0;border-radius:inherit;background:rgba(4,2,10,.75);opacity:0;animation:g-md-hw-blind 2.4s ease-in-out infinite}
+@keyframes g-md-hw-blind{0%,28%{opacity:0}34%,40%{opacity:1}46%,100%{opacity:0}}
+/* 3 - the pick: a keycap or a finger presses on the third cup, the ring drains */
+.g-md-hw-tap{flex:0 0 auto;display:block}
+.g-md-hw-tap.cap{min-width:40px;text-align:center;padding:6px 9px;border-radius:7px;font:700 11px/1 var(--mono);letter-spacing:.06em;color:var(--ink);
+  background:linear-gradient(180deg, var(--panel), color-mix(in srgb, var(--panel), black 35%));
+  border:1px solid var(--line);border-bottom-width:3px;box-shadow:0 2px 0 rgba(0,0,0,.45);animation:g-md-hw-press 2.6s ease-in-out infinite}
+@keyframes g-md-hw-press{0%,72%{transform:translateY(0)}80%{transform:translateY(2px)}92%,100%{transform:translateY(0)}}
+.g-md-hw-tap.finger{position:relative;width:22px;height:32px;animation:g-md-hw-press 2.6s ease-in-out infinite}
+.g-md-hw-tap.finger::before{content:"";position:absolute;left:50%;bottom:0;width:14px;height:20px;transform:translateX(-50%);
+  border-radius:8px 8px 5px 5px;background:linear-gradient(180deg, #f1d3c0, #d9a88f);box-shadow:0 2px 6px rgba(0,0,0,.5)}
+.g-md-hw-ring{position:absolute;right:6px;top:6px;width:16px;height:16px;border-radius:50%;
+  background:conic-gradient(from -90deg, var(--md-glow) 0 var(--md-hw-k,270deg), rgba(255,255,255,.12) var(--md-hw-k,270deg));
+  -webkit-mask:radial-gradient(circle, transparent 55%, #000 58%);mask:radial-gradient(circle, transparent 55%, #000 58%);
+  animation:g-md-hw-drain 2.6s linear infinite}
+@keyframes g-md-hw-drain{from{--md-hw-k:360deg}to{--md-hw-k:0deg}}
+.g-md-hw-pick .c3{animation:g-md-hw-lift 2.6s ease-in-out infinite .8s}
+.g-md-hw-pick .g-md-hw-gem{left:64px;opacity:0;animation:g-md-hw-gem 2.6s ease-in-out infinite .8s}
+@keyframes g-md-hw-gem{0%,20%{opacity:0}30%,60%{opacity:1}78%,100%{opacity:0}}
+/* 4 - the stake: a coin stack splits - one half banks left (safe), one half doubles right */
+.g-md-hw-coin{position:absolute;bottom:10px;width:16px;height:5px;border-radius:50%;
+  background:radial-gradient(circle at 35% 30%, #fff3c4, #f0c24b 45%, #a8771a 100%);box-shadow:0 1px 2px rgba(0,0,0,.6)}
+.g-md-hw-stake .g-md-hw-coin.k1{left:40px}.g-md-hw-stake .g-md-hw-coin.k2{left:40px;bottom:15px}
+.g-md-hw-stake .g-md-hw-coin.k3{left:40px;bottom:20px;animation:g-md-hw-bank 3s ease-in-out infinite}
+.g-md-hw-stake .g-md-hw-coin.k4{left:40px;bottom:25px;animation:g-md-hw-ride 3s ease-in-out infinite}
+.g-md-hw-stake .g-md-hw-coin.k5{left:40px;bottom:25px;opacity:0;animation:g-md-hw-ride2 3s ease-in-out infinite}
+@keyframes g-md-hw-bank{0%,20%{transform:translate(0,0)}45%,100%{transform:translate(-26px,14px)}}
+@keyframes g-md-hw-ride{0%,20%{transform:translate(0,0)}45%,100%{transform:translate(26px,14px)}}
+@keyframes g-md-hw-ride2{0%,40%{opacity:0;transform:translate(26px,14px)}60%,100%{opacity:1;transform:translate(26px,8px)}}
+.g-md-hw-safe{position:absolute;left:8px;bottom:8px;width:22px;height:22px;border-radius:4px;border:2px solid var(--lav);opacity:.8}
+.g-md-hw-x2{position:absolute;right:8px;bottom:8px;font:800 12px/1 var(--mono);color:var(--pink);text-shadow:0 0 8px rgba(255,105,180,.8)}
+.g-md-hw-go{pointer-events:auto;align-self:center;margin-top:14px;appearance:none;-webkit-appearance:none;cursor:pointer;
+  font:700 12px/1 var(--mono);letter-spacing:.18em;text-transform:uppercase;color:var(--ink);
+  padding:11px 26px;border-radius:999px;border:1px solid var(--pink);background:color-mix(in srgb, var(--panel), var(--pink) 16%);
+  box-shadow:0 0 16px color-mix(in srgb, var(--pink), transparent 60%);animation:g-md-ridepulse 1.6s ease-in-out infinite alternate}
+.g-md-hw-go:hover{background:color-mix(in srgb, var(--panel), var(--pink) 28%)}
+.g-md-hw-go:focus-visible{outline:2px solid var(--gold);outline-offset:3px}
+
+/* ---- phases ----------------------------------------------------------------------- */
+.g-md-stage[data-phase="briefing"] .g-md-table{filter:brightness(.85) saturate(.9)}
+.g-md-stage[data-phase="ended"] .g-md-table{filter:saturate(.6) brightness(.7);transition:filter 1.2s ease}
+.g-md-stage[data-phase="ended"] .g-md-lid{animation:none}
+
+/* ---- reduced motion (both gates): the slide and the lift survive, nothing loops --- */
+html.arc-reduced .g-md-bd::before,html.arc-reduced .g-md-lid,html.arc-reduced .g-md-btn,html.arc-reduced .g-md-hw-go,
+html.arc-reduced .g-md-hw-cup,html.arc-reduced .g-md-hw-gem,html.arc-reduced .g-md-hw-coin,html.arc-reduced .g-md-hw-tap,
+html.arc-reduced .g-md-hw-ring,html.arc-reduced .g-md-hw-blind,html.arc-reduced .g-md-clock,html.arc-reduced .g-md-end-seal{animation:none !important}
+html.arc-reduced .g-md-stage{transition:none}
+@media (prefers-reduced-motion: reduce){
+  .g-md-bd::before,.g-md-lid,.g-md-btn,.g-md-hw-go,.g-md-hw-cup,.g-md-hw-gem,.g-md-hw-coin,.g-md-hw-tap,.g-md-hw-ring,.g-md-hw-blind,.g-md-clock,.g-md-end-seal{animation:none !important}
+  .g-md-stage{transition:none}
+}
+`;
+
+/** Inject once per document. No-op headless (the DOM double has no head). */
+export function injectMisdirectionStyle() {
+  try {
+    if (typeof document === 'undefined' || !document.createElement) return false;
+    if (document.getElementById && document.getElementById(STYLE_ID)) return false;
+    const tag = document.createElement('style');
+    tag.id = STYLE_ID;
+    tag.textContent = STYLE_TEXT;
+    const host = document.head || document.documentElement || document.body;
+    if (!host || !host.appendChild) return false;
+    host.appendChild(tag);
+    if (document._register) document._register(STYLE_ID, tag);   // harness shim
+    return true;
+  } catch (e) {
+    return false;      // a stylesheet must never be the thing that fails a class
+  }
+}
+
+/**
+ * THE DRAWN CLASS RULES SHEET (Deck VI, Law IV) - an optional helper for
+ * index.js: builds the four vignettes + the GO button into `host` and returns
+ * the sheet node (or null). No raster art; every figure is pointer-events:none;
+ * GO is the only live thing and the ONLY dismissal. index.js owns the POLICY
+ * (when to show, hideTutorial, howtoTiers) and may build its own sheet instead;
+ * the CSS above styles either, as long as the class names match.
+ * @param {Object} o  { host, t, onGo, coarse, keyLabel (e.g. '3'), keys (e.g. '1 2 3 4 5') }
+ */
+export function buildMdHowto(o) {
+  const opts = o || {};
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const host = opts.host;
+  if (!host || typeof document === 'undefined') return null;
+  const el = (tag, cls, parent) => {
+    try {
+      const n = document.createElement(tag);
+      if (cls) n.className = cls;
+      if (parent && parent.appendChild) parent.appendChild(n);
+      return n;
+    } catch (e) { return null; }
+  };
+  const sheet = el('div', 'g-md-howto', host);
+  if (!sheet) return null;
+  const h = el('h2', 'g-md-hw-title', sheet);
+  if (h) h.textContent = t('md_howto_title', 'Class rules');
+  const row = (kind, build, caption, extra) => {
+    const r = el('div', 'g-md-hw-row', sheet);
+    if (!r) return null;
+    const fig = el('span', 'g-md-hw-fig', r);
+    if (fig) { try { build(fig, kind); } catch (e) { /* a caption alone still teaches */ } }
+    const wrap = el('span', null, r);
+    if (wrap) { try { wrap.style.flex = '1 1 auto'; } catch (e) { /* noop */ } }
+    const p = el('p', 'g-md-hw-cap', wrap || r);
+    if (p) p.textContent = caption;
+    if (extra) { const k = el('p', 'g-md-hw-keys', wrap || r); if (k) k.textContent = extra; }
+    return r;
+  };
+  const scene = (fig, kind) => {
+    const s = el('span', 'g-md-hw-scene g-md-hw-' + kind, fig);
+    if (!s) return null;
+    el('span', 'g-md-hw-cup c1', s); el('span', 'g-md-hw-cup c2', s); el('span', 'g-md-hw-cup c3', s);
+    return s;
+  };
+  /* 1 - WATCH: the middle cup lifts, the gem under it glows */
+  row('watch', (fig, kind) => { const s = scene(fig, kind); if (s) el('span', 'g-md-hw-gem', s); },
+    t('md_howto_watch', 'One shell lifts. What is under it is the only thing you are tracking.'));
+  /* 2 - SHUFFLE: the outer cups trade, the hand comes over the table */
+  row('shuffle', (fig, kind) => { const s = scene(fig, kind); if (s) { el('span', 'g-md-hw-gem', s); el('span', 'g-md-hw-blind', s); } },
+    t('md_howto_shuffle', 'They slide and trade places. The room will do its best to blind you.'));
+  /* 3 - PICK: a keycap (or a finger) presses the third cup, the ring drains */
+  row('pick', (fig, kind) => {
+    const s = scene(fig, kind);
+    if (s) { el('span', 'g-md-hw-gem', s); el('span', 'g-md-hw-ring', s); }
+    const tap = el('span', 'g-md-hw-tap' + (opts.coarse ? ' finger' : ' cap'), fig);
+    if (tap && !opts.coarse) tap.textContent = String(opts.keyLabel || '3');
+  }, t('md_howto_pick', 'Point at the shell you followed. Four seconds, every round.'),
+  opts.keys ? t('md_howto_keys', 'Keys {keys} pick a shell.').replace('{keys}', String(opts.keys)) : '');
+  /* 4 - STAKE: the coin stack splits - safe left, double right */
+  row('stake', (fig) => {
+    const s = el('span', 'g-md-hw-scene g-md-hw-stake', fig);
+    if (!s) return;
+    el('span', 'g-md-hw-safe', s);
+    for (const k of ['k1', 'k2', 'k3', 'k4', 'k5']) el('span', 'g-md-hw-coin ' + k, s);
+    const x2 = el('span', 'g-md-hw-x2', s);
+    if (x2) x2.textContent = 'x2';
+  }, t('md_howto_stake', 'Right? Bank the pot, or ride it double into a dirtier shuffle.'));
+  const go = el('button', 'g-md-hw-go', sheet);
+  if (go) {
+    go.type = 'button';
+    go.textContent = t('md_howto_go', 'Open the table');
+    go.setAttribute('autofocus', '');
+    go.addEventListener('click', () => { try { if (typeof opts.onGo === 'function') opts.onGo(); } catch (e) { /* noop */ } });
+    try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+  }
+  return sheet;
+}
+
+/* index.js's seam (it picks showHowto / hideHowto off this module): the sheet
+   is appended to o.stage (or o.host), one at a time; hideHowto removes it. */
+let liveSheet = null;
+export function showHowto(o) {
+  const opts = o || {};
+  hideHowto();
+  const host = opts.host || opts.stage || opts.table;
+  const keys = Array.isArray(opts.keys) ? opts.keys : null;
+  liveSheet = buildMdHowto({
+    host, t: opts.t, onGo: opts.onGo, coarse: !!opts.coarse,
+    keyLabel: keys && keys.length >= 3 ? keys[2] : (keys && keys[0]) || '3',
+    keys: keys ? keys.join(' ') : '',
+  });
+  return liveSheet;
+}
+export function hideHowto() {
+  if (liveSheet) { try { liveSheet.remove(); } catch (e) { /* noop */ } }
+  liveSheet = null;
+}
+
+export default injectMisdirectionStyle;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/style.js
@@ -81,7 +81,6 @@ export const STYLE_TEXT = `
 @property --md-n-tilt{syntax:'<number>';inherits:true;initial-value:-12}
 @property --md-n-scale{syntax:'<number>';inherits:true;initial-value:1}
 @property --md-n-ride{syntax:'<number>';inherits:true;initial-value:0}
-@property --md-x{syntax:'<number>';inherits:false;initial-value:.5}
 @property --md-feint{syntax:'<number>';inherits:false;initial-value:0}
 @property --md-hw-k{syntax:'<angle>';inherits:false;initial-value:270deg}
 
@@ -198,12 +197,12 @@ export const STYLE_TEXT = `
   transition:transform .6s ease}
 .g-md-stage[data-occluding="1"] .g-md-arc{filter:brightness(.5) saturate(.7);transition:filter .1s ease}
 .g-md-stage[data-occluding="1"] .g-md-table{filter:brightness(.7)}
-.g-md-shell{position:absolute;left:calc(var(--md-x, .5) * 100%);top:50%;
+.g-md-shell{position:absolute;left:calc(var(--x, .5) * 100%);top:50%;
   width:var(--md-shell);height:calc(var(--md-shell) * 1.08);margin:0;padding:0;border:0;background:none;
   appearance:none;-webkit-appearance:none;cursor:pointer;color:inherit;font:inherit;
   /* POSITIONAL ONLY: the centre, the gentle arc (outer shells sit lower, nearer
      the player) and the slide. Nothing decorative lives here. */
-  transform:translate(-50%, calc(-50% + (var(--md-x, .5) - .5) * (var(--md-x, .5) - .5) * 110px));
+  transform:translate(-50%, calc(-50% + (var(--x, .5) - .5) * (var(--x, .5) - .5) * 110px));
   transition:left .28s cubic-bezier(.3,.7,.25,1), transform .28s cubic-bezier(.3,.7,.25,1);
   -webkit-tap-highlight-color:transparent;touch-action:manipulation;outline:none}
 .g-md-shell:focus-visible .g-md-lid{box-shadow:0 0 0 3px color-mix(in srgb, var(--gold), transparent 20%), 0 14px 26px rgba(0,0,0,.55)}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/misdirection/trickster.js
@@ -1,0 +1,765 @@
+/* ============================================================================
+ * games/misdirection/trickster.js - DECK III of the House Rules, dealt into the
+ * shell game. A tracking room is where your own eyes are the witness, so every
+ * card here attacks what you READ around the shells - never the shells' truth,
+ * never the pick window underneath.
+ *
+ *   STAT FLICKER     the pot or the streak chip briefly reads slightly off,
+ *                    then "corrects" with a static pop to the EXACT text the
+ *                    truth source hands back. The ledger never moves;
+ *                    confidence does.
+ *   CROOKED CLOCK    (the pick-window ring) while a pick window is open this
+ *                    deck paints a stopwatch face of its own under the arc whose
+ *                    FILL bends: it races through the boring middle (shows less
+ *                    time than you really have) and crawls at the end, meeting
+ *                    the truth exactly in the last 15% - so the hand itches
+ *                    early and the finish is never a lie. The real window is
+ *                    index.js's timer and untouched; the bend is a PURE function,
+ *                    exported. If index.js hands us its own ring (opts.ringEl)
+ *                    that face steps aside (.g-md-tk-bent) only while ours is up.
+ *   FAKE SHUFFLE     (tier 3+ cameo) during the pick window two neighbouring
+ *                    cups FEINT - the bodies lean toward each other and snap
+ *                    back - and nothing moves: --slot / --x and the hitboxes
+ *                    are never touched (the lean rides --md-feint on the cup
+ *                    BODY, style.js composes it under the lid/face, the hitbox
+ *                    is the shell node and stays put). No tell: no cue, no
+ *                    flash, no word.
+ *   THE MELT         a dealt card that plays on the next swap (the blackout
+ *                    zone of a shuffle): one NON-target cup sags like wax for
+ *                    ~600ms (a class on the shell; the lid and the tag deform,
+ *                    the transform never does) and snaps back. Which cup melts
+ *                    is the seed's choice; the target is read (never written)
+ *                    through opts.targetSlot so the melt never brands the truth.
+ *                    Without that hook the deck melts any cup - it will never
+ *                    guess.
+ *   GHOST CURSOR     a faint cursor echo trails the real pointer by ~430ms
+ *                    during the pick window, and after a ~600ms stall it stops
+ *                    trailing and DRIFTS toward a NEAR cup - the neighbour of
+ *                    the one under the hand, the seed picks the side - the house
+ *                    leaning on your hand. Pure suggestion: pointer-events none,
+ *                    it cannot click, the real cursor is never hidden, and it
+ *                    dies on the pick. Tier 2+, mouse pointers only.
+ *   DECOY REVEAL     is NATIVE - index.js's own schedule (the dossier's
+ *                    signature twist, bound by the trackability invariant).
+ *                    This deck never lifts a lid.
+ *
+ * DEALING RULE: flicker / clock / feint / melt are dealt at start() from the
+ * seeded plan against the class budget - 2/4/6/8 by tier, at least 15s apart
+ * (the House's 4-a-minute cap, stated as a gap), never in the first 10s, never
+ * in the last 15s (the bell's honest zone); a card whose moment arrives halted
+ * waits politely, then folds. The ghost is stall-reactive (the stall is the
+ * player's own) but the side it lures to is the seed's.
+ *
+ * TABLE LAW AUDIT (House Rules):
+ *   I   ledger honest - flicker writes chip TEXT and restores via chipText
+ *       (the truth source); the ring is a node this deck owns; the feint and
+ *       the melt are classes/vars on the cup BODY; nothing reads or writes
+ *       pot, streak, round, the pick window or the shuffle plan.
+ *   II  input honest  - no card is clickable; every node lives in the deck's
+ *       own layer inside the stage, pointer-events:none; the shell node (the
+ *       hitbox) is never transformed, moved, resized or delayed.
+ *   III never still   - the ghost pulses on the lure; the ring face breathes.
+ *   IV  images > text - two proctor lines only (md_trick_melt once, md_trick_seen
+ *       after a feint's verdict), through the t() this deck is handed; neutral
+ *       fallbacks here; nothing else is rendered as text.
+ *   V   seeded        - per-tag mulberry32 off seed+'|md-trickster|<tag>',
+ *       append-only tags. A retake replays the identical deal.
+ *   VI  exits sacred  - capsOk false disarms the deck (no nodes, no listener,
+ *       no timers); reduced motion drops the ghost, the feint and the melt
+ *       (motion) and keeps the flicker and the bend (a number and a fill are
+ *       not motion); every timer rides the game's registry AND a local set;
+ *       pause() restores every live lie, resume() re-arms, destroy() leaves
+ *       no node, timer, observer or listener.
+ *   VII strings       - md_trick_melt / md_trick_seen (lex.js rows), never
+ *       invented here.
+ * ==========================================================================*/
+
+import { makeRng } from '../../core/rng.js';
+
+export const MD_TRICKSTER = Object.freeze({
+  DEALS: Object.freeze({ 1: 2, 2: 4, 3: 6, 4: 8 }),
+  FIRST_DEAL_MS: 10000,
+  TAIL_MS: 15000,
+  MIN_GAP_MS: 15000,
+  MIN_GAP_FLOOR_MS: 9000,        // a short class seats its cards closer, never under this
+  RETRY_MS: 1500,
+  RETRY_MAX: 6,
+  /** Card gates. */
+  FLICK_FROM_TIER: 1,
+  MELT_FROM_TIER: 1,
+  CLOCK_FROM_TIER: 2,
+  GHOST_FROM_TIER: 2,
+  FEINT_FROM_TIER: 3,
+  /** Slot weights per tier over flicker / melt / feint (the clock is one slot). */
+  WEIGHTS: Object.freeze({
+    1: Object.freeze({ flicker: 0.45, melt: 0.55, feint: 0 }),
+    2: Object.freeze({ flicker: 0.5, melt: 0.5, feint: 0 }),
+    3: Object.freeze({ flicker: 0.36, melt: 0.34, feint: 0.3 }),
+    4: Object.freeze({ flicker: 0.32, melt: 0.3, feint: 0.38 }),
+  }),
+  /** Stat flicker. */
+  FLICK_MS: 460,
+  /** The crooked ring: bend at mid-window, honest tail, ramp, baked stops. */
+  RING_BEND: 0.16,
+  RING_HONEST: 0.15,
+  RING_RAMP: 0.32,
+  RING_STOPS: 20,
+  RING_DEFAULT_MS: 4000,
+  RING_LATCH_MS: 30000,          // an armed clock waits this long for a pick window, then folds
+  /** The feint. */
+  FEINT_MS: 260,
+  FEINT_PX: 9,
+  FEINT_LATCH_MS: 20000,
+  /** The melt. */
+  MELT_MS: 600,
+  MELT_LATCH_MS: 14000,
+  /** After a feint's verdict, the one taunt (md_trick_seen) - seeded chance. */
+  SEEN_TAUNT_CHANCE: 0.3,
+  /** The ghost. */
+  GHOST_TICK_MS: 90,
+  GHOST_TRAIL_MS: 430,
+  GHOST_STALL_MS: 600,
+  GHOST_LERP: 0.16,
+  GHOST_TRAIL_KEEP_MS: 2200,
+  PHASE_POLL_MS: 120,
+});
+
+const STYLE_ID = 'g-md-trickster-style';
+const STYLE_TEXT = `
+@property --md-tk-k{syntax:'<number>';inherits:false;initial-value:1}
+.g-md-tk{position:absolute;inset:0;pointer-events:none;z-index:7;overflow:visible}
+.g-md-tk *{pointer-events:none}
+/* THE CROOKED RING: a stopwatch face under the arc. --md-tk-k is the SHOWN
+   fraction left (1 -> 0); the keyframes bake the bend. */
+.g-md-tk-ring{position:absolute;left:50%;bottom:4%;width:54px;height:54px;transform:translateX(-50%);
+  border-radius:50%;opacity:0;--md-tk-k:1;
+  background:conic-gradient(from -90deg, hsl(var(--md-n-hue-b,330) 90% 78% / .9) 0deg, hsl(var(--md-n-hue-b,330) 90% 78% / .9) calc(var(--md-tk-k) * 360deg), rgba(255,255,255,.08) calc(var(--md-tk-k) * 360deg));
+  -webkit-mask:radial-gradient(circle, transparent 58%, #000 60%, #000 100%);mask:radial-gradient(circle, transparent 58%, #000 60%, #000 100%);
+  filter:drop-shadow(0 0 8px hsl(var(--md-n-hue-b,330) 90% 70% / .6));transition:opacity .2s ease}
+.g-md-tk-ring.on{opacity:.9;animation:g-md-tk-bend var(--md-tk-ms,4s) linear 1 forwards}
+.g-md-tk-bent{opacity:0 !important}
+/* GHOST CURSOR */
+.g-md-tk-ghost{position:absolute;left:0;top:0;width:15px;height:19px;opacity:0;will-change:transform;
+  clip-path:polygon(0 0, 0 82%, 22% 64%, 38% 100%, 50% 94%, 34% 60%, 60% 60%);
+  background:linear-gradient(160deg, rgba(255,105,180,.9), rgba(184,166,232,.55));
+  filter:drop-shadow(0 0 6px rgba(255,105,180,.6));transition:transform .34s ease-out, opacity .38s ease}
+.g-md-tk-ghost.on{opacity:.3}
+.g-md-tk-ghost.lure{opacity:.52;animation:g-md-tk-ghostpulse 1.5s ease-in-out infinite}
+@keyframes g-md-tk-ghostpulse{50%{filter:drop-shadow(0 0 12px rgba(255,105,180,.95))}}
+/* STAT FLICKER: the static pop the wrong number corrects itself with */
+.g-md-tk-flick{text-shadow:0 0 22px rgba(184,166,232,.75), 0 0 3px rgba(255,255,255,.5);animation:g-md-tk-static .16s steps(3) 2}
+@keyframes g-md-tk-static{0%{filter:none}40%{filter:brightness(1.5) contrast(1.4)}100%{filter:none}}
+@media (prefers-reduced-motion: reduce){
+  .g-md-tk-ghost{display:none}
+  .g-md-tk-flick{animation:none}
+  .g-md-tk-ring.on{animation:none;--md-tk-k:.5}
+}
+html.arc-reduced .g-md-tk-ghost{display:none}
+.g-md-stage.suspended .g-md-tk-ring.on,.g-md-stage.suspended .g-md-tk-ghost.lure{animation-play-state:paused !important}
+`;
+
+function ensureStyle(extra) {
+  try {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_TEXT + (extra || '');
+    document.head.appendChild(s);
+  } catch (e) { /* cosmetic */ }
+}
+
+/* ---------------------------------------------------------------- pure ---- */
+function clamp01(v) { const n = Number(v) || 0; return n < 0 ? 0 : n > 1 ? 1 : n; }
+function clampTier(t) { return Math.max(1, Math.min(4, Math.round(Number(t) || 1))); }
+
+/**
+ * The crooked face, pure: the SHOWN fraction left for a real fraction left
+ * (1 = window just opened, 0 = shut). Ahead through the middle (less shown than
+ * real), honest for the last `honest` of the window, f(1)=1, monotone for
+ * bend*pi < 1.
+ */
+export function bendRing(fracLeft, bend, honest, ramp) {
+  const x = clamp01(fracLeft);
+  const H = honest == null ? MD_TRICKSTER.RING_HONEST : honest;
+  if (x <= H || x >= 1) return x;
+  const A0 = bend == null ? MD_TRICKSTER.RING_BEND : bend;
+  const R = ramp == null ? MD_TRICKSTER.RING_RAMP : ramp;
+  const r = Math.max(0, Math.min(1, (x - H) / R));
+  const A = A0 * r * r * (3 - 2 * r);
+  return Math.max(H, Math.min(1, x - A * Math.sin(Math.PI * x)));
+}
+/** The bend baked into CSS keyframes (N stops), for the ring's animation. Pure. */
+export function bendKeyframes(name, stops) {
+  const n = Math.max(4, stops | 0);
+  let css = '@keyframes ' + name + '{';
+  for (let i = 0; i <= n; i++) {
+    const p = i / n;                                   // 0 = open, 1 = shut
+    css += (p * 100).toFixed(1) + '%{--md-tk-k:' + bendRing(1 - p).toFixed(4) + '}';
+  }
+  return css + '}';
+}
+/** The "near" cup for a lure: the slot beside `slot`, the seed's side. Pure. */
+export function nearSlot(slot, count, side01) {
+  const n = Math.max(2, count | 0);
+  const s = Math.max(0, Math.min(n - 1, slot | 0));
+  const right = side01 < 0.5;
+  if (s === 0) return 1;
+  if (s === n - 1) return n - 2;
+  return right ? s + 1 : s - 1;
+}
+
+function el(tag, cls, parent) {
+  try {
+    const n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (parent && parent.appendChild) parent.appendChild(n);
+    return n;
+  } catch (e) { return null; }
+}
+function setCls(n, cls, on) { try { if (n && n.classList) n.classList[on ? 'add' : 'remove'](cls); } catch (e) { /* noop */ } }
+function setVar(n, k, v) { try { if (n && n.style) n.style.setProperty(k, String(v)); } catch (e) { /* noop */ } }
+function rmVar(n, k) { try { if (n && n.style) n.style.removeProperty(k); } catch (e) { /* noop */ } }
+function rectOf(node) {
+  try { return node && typeof node.getBoundingClientRect === 'function' ? node.getBoundingClientRect() : null; }
+  catch (e) { return null; }
+}
+function slotOf(shell) {
+  try { const n = Number(shell.getAttribute('data-slot')); return Number.isFinite(n) ? n : -1; } catch (e) { return -1; }
+}
+function nowMs() {
+  try { if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now(); } catch (e) { /* fall */ }
+  return Date.now();
+}
+function isCoarse() {
+  try { return typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches; } catch (e) { return false; }
+}
+
+/**
+ * @param {Object} o
+ *   seed, tier, timers {after,every,clear}, reduced, capsOk (bool|fn), isHalted () => bool,
+ *   coarse (touch), t (the two proctor lines), stats () => {round,pot,streak,secLeft,phase,...},
+ *   pickWindow () => {open, elapsedMs, totalMs} (the HONEST window - the ring bends a copy),
+ *   chipEl (which) => el, chipText (which) => string, stage (.g-md-stage), table (.g-md-table),
+ *   shells () => HTMLElement[] (else queried), targetSlot () => number|null (truth read, optional),
+ *   ringEl () => el|null (index.js's own pick ring, optional), announce (text, ms) (optional),
+ *   budgetSec, log
+ */
+export function createMdTrickster(o) {
+  const opts = o || {};
+  const T = MD_TRICKSTER;
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const tier = clampTier(opts.tier);
+  const reduced = !!opts.reduced;
+  const coarse = opts.coarse === true || isCoarse();
+  const t = typeof opts.t === 'function' ? opts.t : ((k, f) => f);
+  const announce = typeof opts.announce === 'function' ? opts.announce : null;
+  const pickWindow = typeof opts.pickWindow === 'function' ? opts.pickWindow : () => null;
+  const lexiconUsed = new Set();
+  function say_t(key, fallback) { lexiconUsed.add(key); return t(key, fallback); }
+  const isHalted = typeof opts.isHalted === 'function' ? opts.isHalted : () => false;
+  const stats = typeof opts.stats === 'function' ? opts.stats : () => null;
+  const chipEl = typeof opts.chipEl === 'function' ? opts.chipEl : () => null;
+  const chipText = typeof opts.chipText === 'function' ? opts.chipText : () => null;
+  const targetSlot = typeof opts.targetSlot === 'function' ? opts.targetSlot : () => null;
+  const ringElOf = typeof opts.ringEl === 'function' ? opts.ringEl : () => null;
+  const stage = opts.stage || null;
+  const table = opts.table || stage;
+  function capsOkNow() {
+    if (typeof opts.capsOk === 'function') { try { return !!opts.capsOk(); } catch (e) { return false; } }
+    return opts.capsOk !== false;
+  }
+  const armed = capsOkNow() && !!opts.timers && typeof opts.timers.after === 'function' && typeof document !== 'undefined';
+
+  /* timers: the game's registry + a local set (see casino.js). */
+  const live = new Set();
+  const chains = new Set();
+  const cancelFn = opts.timers && (opts.timers.clear || opts.timers.cancel);
+  let destroyed = false;
+  let stopped = false;
+  let paused = false;
+  function after(ms, fn) {
+    if (!armed || destroyed) return 0;
+    let id = 0;
+    id = opts.timers.after(ms, () => { live.delete(id); if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+    if (id) live.add(id);
+    return id;
+  }
+  function cancel(id) {
+    if (!id) return;
+    live.delete(id);
+    try { if (typeof cancelFn === 'function') cancelFn.call(opts.timers, id); } catch (e) { /* ignore */ }
+  }
+  function every(ms, fn) {
+    if (!armed || destroyed) return 0;
+    if (typeof opts.timers.every === 'function') {
+      const id = opts.timers.every(ms, () => { if (!destroyed) { try { fn(); } catch (e) { /* ignore */ } } });
+      if (id) live.add(id);
+      return id;
+    }
+    const handle = { id: 0, on: true };
+    const tick = () => { if (!handle.on || destroyed) return; try { fn(); } catch (e) { /* ignore */ } handle.id = after(ms, tick); };
+    handle.id = after(ms, tick);
+    chains.add(handle);
+    return handle;
+  }
+  function stopEvery(h) {
+    if (!h) return;
+    if (typeof h === 'object') { h.on = false; cancel(h.id); chains.delete(h); } else cancel(h);
+  }
+
+  const seedBase = String(opts.seed || 'md') + '|md-trickster|';
+  const streams = new Map();
+  const roll = (tag) => {
+    let s = streams.get(tag);
+    if (!s) { s = makeRng(seedBase + tag); streams.set(tag, s); }
+    return s();
+  };
+
+  const fired = { flicker: 0, clock: 0, feint: 0, melt: 0, lure: 0 };
+  let deals = [];
+  let layer = null;
+  let ringEl = null;
+  let ghostEl = null;
+
+  /* ------------------------------------------------------------- helpers */
+  function shells() {
+    let list = [];
+    try {
+      if (typeof opts.shells === 'function') list = Array.from(opts.shells() || []);
+      else if (table && table.querySelectorAll) list = Array.from(table.querySelectorAll('.g-md-shell'));
+    } catch (e) { list = []; }
+    return list.filter((n) => n && n.style && slotOf(n) >= 0);
+  }
+  function phaseNow() {
+    try {
+      const s = stats();
+      if (s && s.phase) return String(s.phase);
+      if (stage && stage.getAttribute) return String(stage.getAttribute('data-phase') || '');
+    } catch (e) { /* fall */ }
+    return '';
+  }
+  function mountLayer() {
+    if (layer || !stage || !stage.appendChild) return;
+    ensureStyle(bendKeyframes('g-md-tk-bend', T.RING_STOPS));
+    layer = el('div', 'g-md-tk', stage);
+  }
+
+  /* ------------------------------------------------------------- the deal */
+  function buildDeals() {
+    const n = T.DEALS[tier] || 2;
+    const spanMs = Math.max(60, Number(opts.budgetSec) || 120) * 1000;
+    const usable = Math.max(15000, spanMs - T.FIRST_DEAL_MS - T.TAIL_MS);
+    /* the gap: 15s, or less when the budget cannot seat every card 15s apart
+       (the contract's 2/4/6/8 is the promise; the floor is 9s = under 7/min) */
+    const gap = Math.max(T.MIN_GAP_FLOOR_MS, Math.min(T.MIN_GAP_MS, n > 1 ? Math.floor(usable / (n - 1)) : T.MIN_GAP_MS));
+    const times = [];
+    for (let i = 0; i < n; i++) times.push(T.FIRST_DEAL_MS + roll('when') * usable);
+    times.sort((a, b) => a - b);
+    for (let i = 1; i < times.length; i++) {
+      if (times[i] - times[i - 1] < gap) times[i] = times[i - 1] + gap;
+    }
+    /* the walk forward can push the tail past the honest zone: walk it back */
+    const lastOk = spanMs - T.TAIL_MS;
+    if (times[times.length - 1] > lastOk) {
+      times[times.length - 1] = lastOk;
+      for (let i = times.length - 2; i >= 0; i--) if (times[i + 1] - times[i] < gap) times[i] = times[i + 1] - gap;
+      for (let i = 0; i < times.length; i++) times[i] = Math.max(T.FIRST_DEAL_MS, times[i]);
+    }
+    const clockSlot = tier >= T.CLOCK_FROM_TIER && n > 1 ? Math.floor(roll('clock-slot') * Math.ceil(n / 2)) : -1;
+    const w = T.WEIGHTS[tier] || T.WEIGHTS[1];
+    const out = [];
+    for (let i = 0; i < times.length; i++) {
+      const at = Math.round(times[i]);
+      if (at > spanMs - T.TAIL_MS) continue;                  // the gap walk pushed it into the honest zone: fold it
+      let card;
+      if (i === clockSlot) card = 'clock';
+      else {
+        const r = roll('card');
+        card = r < w.flicker ? 'flicker' : r < w.flicker + w.melt ? 'melt' : 'feint';
+        if (card === 'feint' && tier < T.FEINT_FROM_TIER) card = 'melt';
+      }
+      out.push({ at, card });
+    }
+    return out;
+  }
+  function attempt(deal, tries) {
+    if (destroyed || stopped) return;
+    /* a halted class (occlusion, blackout, pause) deals nothing: the card waits */
+    if (isHalted() || !stats()) {
+      if (tries < T.RETRY_MAX) after(T.RETRY_MS, () => attempt(deal, tries + 1));
+      return;
+    }
+    if (deal.card === 'melt') { armMelt(); return; }
+    if (deal.card === 'feint') { armFeint(); return; }
+    if (deal.card === 'clock') { armClock(); return; }
+    if (deal.card === 'flicker') dealFlicker();
+  }
+
+  /* -------------------------------------------------------- stat flicker */
+  let flickTimer = 0;
+  let flickChip = null;
+  function dealFlicker() {
+    if (tier < T.FLICK_FROM_TIER) return;
+    const s = stats();
+    if (!s) return;
+    const which = roll('flick-which') < 0.5 ? 'pot' : 'streak';
+    const chip = chipEl(which);
+    if (!chip || chip.textContent == null) return;
+    const truth = chipText(which);
+    const n = Number(which === 'pot' ? s.pot : s.streak) || 0;
+    const delta = (roll('flick-sign') < 0.5 ? -1 : 1) * (1 + Math.floor(roll('flick-drop') * (which === 'pot' ? 3 : 1)));
+    const fake = Math.max(0, n + delta);
+    const lie = (typeof truth === 'string' && /\d/.test(truth)) ? truth.replace(/\d[\d,]*/, String(fake)) : String(fake);
+    if (!lie || lie === chip.textContent) return;
+    try { chip.textContent = lie; } catch (e) { return; }
+    flickChip = chip;
+    if (!reduced) setCls(chip, 'g-md-tk-flick', true);
+    fired.flicker += 1;
+    cancel(flickTimer);
+    flickTimer = after(T.FLICK_MS, () => { flickTimer = 0; unflick(); });
+    say('trickster: stat flicker (' + which + ')');
+  }
+  function unflick() {
+    if (!flickChip) return;
+    setCls(flickChip, 'g-md-tk-flick', false);
+    const which = flickChip === chipEl('pot') ? 'pot' : 'streak';
+    const now = chipText(which);
+    if (now != null) { try { flickChip.textContent = now; } catch (e) { /* ignore */ } }
+    flickChip = null;
+  }
+
+  /* ------------------------------------------------------- crooked clock */
+  let clockArmed = false;
+  let clockFold = 0;
+  let ringOn = false;
+  let hostRing = null;
+  function armClock() {
+    if (clockArmed || tier < T.CLOCK_FROM_TIER) return;
+    clockArmed = true;
+    fired.clock += 1;
+    cancel(clockFold);
+    clockFold = after(T.RING_LATCH_MS, () => { clockFold = 0; if (!ringOn) clockArmed = false; });
+    say('trickster: the clock goes crooked (armed for the next pick window)');
+    if (phaseNow() === 'pick') openRing();
+  }
+  function openRing() {
+    if (!clockArmed || ringOn || destroyed || stopped || paused || isHalted()) return;
+    mountLayer();
+    if (!layer) return;
+    if (!ringEl) ringEl = el('i', 'g-md-tk-ring', layer);
+    if (!ringEl) return;
+    let ms = T.RING_DEFAULT_MS;
+    let elapsed = 0;
+    try {
+      const pw = pickWindow();
+      if (pw && Number(pw.totalMs) > 0) ms = Number(pw.totalMs);
+      if (pw && Number(pw.elapsedMs) > 0) elapsed = Math.min(ms, Number(pw.elapsedMs));
+    } catch (e) { /* defaults */ }
+    setVar(ringEl, '--md-tk-ms', Math.round(ms) + 'ms');
+    setCls(ringEl, 'on', false);
+    if (typeof ringEl.offsetWidth === 'number') void ringEl.offsetWidth;
+    try { ringEl.style.animationDelay = elapsed > 0 ? ('-' + Math.round(elapsed) + 'ms') : ''; } catch (e) { /* noop */ }
+    setCls(ringEl, 'on', true);
+    ringOn = true;
+    hostRing = ringElOf();
+    if (hostRing) setCls(hostRing, 'g-md-tk-bent', true);
+  }
+  function closeRing() {
+    if (!ringOn) return;
+    ringOn = false;
+    setCls(ringEl, 'on', false);
+    if (hostRing) setCls(hostRing, 'g-md-tk-bent', false);
+    hostRing = null;
+    clockArmed = false;
+    cancel(clockFold); clockFold = 0;
+  }
+
+  /* --------------------------------------------------------------- feint */
+  let feintArmed = false;
+  let feintFold = 0;
+  let feinting = [];
+  let feintTimer = 0;
+  let feintSeen = false;
+  function armFeint() {
+    if (feintArmed || tier < T.FEINT_FROM_TIER || reduced) return;
+    feintArmed = true;
+    cancel(feintFold);
+    feintFold = after(T.FEINT_LATCH_MS, () => { feintFold = 0; feintArmed = false; });
+    say('trickster: fake shuffle armed');
+    if (phaseNow() === 'pick') playFeint();
+  }
+  function playFeint() {
+    if (!feintArmed || destroyed || stopped || paused || isHalted()) return;
+    const list = shells().sort((a, b) => slotOf(a) - slotOf(b));
+    if (list.length < 2) return;
+    const i = Math.floor(roll('feint-pick') * (list.length - 1));
+    const a = list[i]; const b = list[i + 1];
+    feintArmed = false;
+    cancel(feintFold); feintFold = 0;
+    setVar(a, '--md-feint', String(T.FEINT_PX));
+    setVar(b, '--md-feint', String(-T.FEINT_PX));
+    setCls(a, 'g-md-tk-feint', true); setCls(b, 'g-md-tk-feint', true);
+    feinting = [a, b];
+    fired.feint += 1;
+    feintSeen = roll('feint-seen') < T.SEEN_TAUNT_CHANCE;   // the taunt waits for the verdict (no tell)
+    cancel(feintTimer);
+    feintTimer = after(T.FEINT_MS, () => { feintTimer = 0; unfeint(); });
+    say('trickster: fake shuffle (slots ' + slotOf(a) + '/' + slotOf(b) + ', nothing moved)');
+  }
+  function unfeint() {
+    for (const n of feinting) { rmVar(n, '--md-feint'); setCls(n, 'g-md-tk-feint', false); }
+    feinting = [];
+  }
+
+  /* ---------------------------------------------------------------- melt */
+  let meltArmed = false;
+  let meltFold = 0;
+  let melted = null;
+  let meltTimer = 0;
+  let meltAnnounced = false;
+  function armMelt() {
+    if (meltArmed || tier < T.MELT_FROM_TIER || reduced) return;
+    meltArmed = true;
+    cancel(meltFold);
+    meltFold = after(T.MELT_LATCH_MS, () => { meltFold = 0; meltArmed = false; });
+    say('trickster: melt armed (plays on the next swap)');
+  }
+  function playMelt() {
+    if (!meltArmed || destroyed || stopped || paused || melted || isHalted()) return;
+    let list = shells();
+    let tgt = null;
+    try { tgt = targetSlot(); } catch (e) { tgt = null; }
+    if (tgt != null && Number.isFinite(Number(tgt))) list = list.filter((n) => slotOf(n) !== Number(tgt));
+    if (!list.length) return;
+    const shell = list[Math.floor(roll('melt-pick') * list.length)];
+    meltArmed = false;
+    cancel(meltFold); meltFold = 0;
+    setCls(shell, 'g-md-tk-melt', true);
+    melted = shell;
+    fired.melt += 1;
+    if (announce && !meltAnnounced) {
+      meltAnnounced = true;
+      try { announce(say_t('md_trick_melt', 'The lids run like wax'), 1600); } catch (e) { /* ignore */ }
+    }
+    cancel(meltTimer);
+    meltTimer = after(T.MELT_MS, () => { meltTimer = 0; unmelt(); });
+    say('trickster: melt (slot ' + slotOf(shell) + ')');
+  }
+  function unmelt() {
+    if (!melted) return;
+    setCls(melted, 'g-md-tk-melt', false);
+    melted = null;
+  }
+
+  /* --------------------------------------------------------- ghost cursor */
+  let ghostTimer = 0;
+  let onMove = null;
+  const trail = [];
+  let lastMoveAt = 0;
+  let gx = 0; let gy = 0;
+  let ghostMode = 'off';
+  let lureSlot = -1;
+  function ghostEligible() {
+    return armed && !reduced && !coarse && tier >= T.GHOST_FROM_TIER && !!stage && typeof stage.addEventListener === 'function';
+  }
+  function ghostOff() {
+    if (ghostMode === 'off') return;
+    setCls(ghostEl, 'on', false);
+    setCls(ghostEl, 'lure', false);
+    ghostMode = 'off';
+    lureSlot = -1;
+  }
+  /** The cup nearest the hand, then its neighbour on the seed's side. */
+  function lurePoint() {
+    const list = shells();
+    if (list.length < 2) return null;
+    const s = rectOf(stage);
+    if (!s) return null;
+    let nearest = null; let best = Infinity;
+    for (const n of list) {
+      const r = rectOf(n);
+      if (!r) continue;
+      const cx = r.left + r.width / 2 - s.left; const cy = r.top + r.height / 2 - s.top;
+      const d = (cx - gx) * (cx - gx) + (cy - gy) * (cy - gy);
+      if (d < best) { best = d; nearest = n; }
+    }
+    if (!nearest) return null;
+    if (lureSlot < 0) lureSlot = nearSlot(slotOf(nearest), list.length, roll('lure-side'));
+    const tgt = list.find((n) => slotOf(n) === lureSlot) || nearest;
+    const r = rectOf(tgt);
+    if (!r) return null;
+    return { x: r.left + r.width / 2 - s.left, y: r.top + r.height / 2 - s.top };
+  }
+  function ghostTick() {
+    if (!ghostEl || destroyed || stopped || paused) return;
+    if (!capsOkNow() || phaseNow() !== 'pick' || isHalted()) { ghostOff(); return; }
+    const t = nowMs();
+    const stalled = lastMoveAt > 0 && (t - lastMoveAt) >= T.GHOST_STALL_MS;
+    if (stalled) {
+      const p = lurePoint();
+      if (p) { gx += (p.x - gx) * T.GHOST_LERP; gy += (p.y - gy) * T.GHOST_LERP; }
+      if (ghostMode !== 'lure') { fired.lure += 1; ghostMode = 'lure'; }
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', true);
+    } else {
+      if (!trail.length || !lastMoveAt) { ghostOff(); return; }
+      let pt = trail[0];
+      for (const p of trail) { if (t - p.at >= T.GHOST_TRAIL_MS) pt = p; else break; }
+      gx = pt.x; gy = pt.y;
+      ghostMode = 'trail';
+      lureSlot = -1;
+      setCls(ghostEl, 'on', true);
+      setCls(ghostEl, 'lure', false);
+    }
+    try { ghostEl.style.transform = 'translate3d(' + gx.toFixed(1) + 'px,' + gy.toFixed(1) + 'px,0)'; } catch (e) { /* noop */ }
+    while (trail.length > 1 && t - trail[0].at > T.GHOST_TRAIL_KEEP_MS) trail.shift();
+  }
+  function armGhost() {
+    if (!ghostEligible() || ghostEl) return;
+    mountLayer();
+    if (!layer) return;
+    ghostEl = el('i', 'g-md-tk-ghost', layer);
+    if (!ghostEl) return;
+    onMove = (ev) => {
+      if (destroyed) return;
+      try {
+        const s = stage.getBoundingClientRect();
+        const x = Number(ev && ev.clientX) - s.left;
+        const y = Number(ev && ev.clientY) - s.top;
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+        lastMoveAt = nowMs();
+        trail.push({ x, y, at: lastMoveAt });
+      } catch (e) { /* no rects under the DOM double: the ghost sleeps */ }
+    };
+    try { stage.addEventListener('pointermove', onMove); } catch (e) { /* noop */ }
+    ghostTimer = every(T.GHOST_TICK_MS, ghostTick);
+    say('trickster: ghost armed');
+  }
+  function disarmGhost() {
+    if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+    try { if (onMove && stage && stage.removeEventListener) stage.removeEventListener('pointermove', onMove); } catch (e) { /* noop */ }
+    onMove = null;
+    ghostOff();
+  }
+
+  /* ----------------------------------------------------- the phase watch */
+  let phaseObs = null;
+  let phasePoll = 0;
+  let lastPhase = '';
+  function onPhase(p) {
+    if (p === lastPhase) return;
+    lastPhase = p;
+    if (p === 'pick') { openRing(); playFeint(); }
+    else { closeRing(); unfeint(); ghostOff(); }
+  }
+  function watchPhase() {
+    let hooked = false;
+    try {
+      if (stage && typeof MutationObserver === 'function' && typeof stage.nodeType === 'number') {
+        phaseObs = new MutationObserver(() => onPhase(phaseNow()));
+        phaseObs.observe(stage, { attributes: true, attributeFilter: ['data-phase'] });
+        hooked = true;
+      }
+    } catch (e) { phaseObs = null; }
+    if (!hooked) phasePoll = every(T.PHASE_POLL_MS, () => onPhase(phaseNow()));
+  }
+  function unwatchPhase() {
+    if (phaseObs) { try { phaseObs.disconnect(); } catch (e) { /* ignore */ } phaseObs = null; }
+    if (phasePoll) { stopEvery(phasePoll); phasePoll = 0; }
+  }
+
+  function allHonest() {
+    unflick();
+    closeRing();
+    unfeint();
+    unmelt();
+    ghostOff();
+  }
+
+  /* ------------------------------------------------------------------ api */
+  return {
+    start() {
+      if (!armed || destroyed) { say('trickster: disarmed'); return; }
+      deals = buildDeals();
+      for (const deal of deals) after(deal.at, () => attempt(deal, 0));
+      watchPhase();
+      armGhost();
+      say('trickster: dealt ' + deals.length + ' cards (' + deals.map((d) => d.card + '@' + Math.round(d.at / 1000) + 's').join(', ') + ')');
+    },
+    /** index.js calls after every swap of the shuffle (the blackout zone). */
+    afterSwap() {
+      if (!armed || destroyed || stopped) return;
+      if (meltArmed) playMelt();
+    },
+    /** index.js calls after every pick verdict: every lie of the window comes off. */
+    afterPick() {
+      if (!armed || destroyed) return;
+      closeRing();
+      unfeint();
+      ghostOff();
+      lastMoveAt = 0;
+      /* the feint's taunt lands AFTER the verdict, never during the window */
+      if (feintSeen && announce && !stopped) {
+        feintSeen = false;
+        try { announce(say_t('md_trick_seen', 'Did you see that?'), 1400); } catch (e) { /* ignore */ }
+      }
+    },
+    /** The class heat: the deck has no magnitude dial, but index.js calls it. */
+    setHeat() { /* the lies do not scale with heat; the deal does (tier) */ },
+    /** index.js calls every ~500ms with ms since the last input; 0 resets. */
+    stalled(ms) {
+      if (!armed || destroyed || stopped) return;
+      const n = Number(ms) || 0;
+      if (n <= 0) { ghostOff(); return; }
+      /* the ghost's own stall clock (pointer) is finer; this is the coarse hook
+         for a hand that never moved at all: seed the trail at the stage centre */
+      if (n >= T.GHOST_STALL_MS && ghostEl && !lastMoveAt && phaseNow() === 'pick' && !isHalted()) {
+        const s = rectOf(stage);
+        if (s && s.width) { gx = s.width / 2; gy = s.height * 0.75; lastMoveAt = nowMs() - T.GHOST_STALL_MS; trail.push({ x: gx, y: gy, at: lastMoveAt }); }
+      }
+    },
+    pause() {
+      paused = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      flickTimer = 0; feintTimer = 0; meltTimer = 0; clockFold = 0; feintFold = 0; meltFold = 0;
+      if (ghostTimer) { stopEvery(ghostTimer); ghostTimer = 0; }
+      allHonest();
+    },
+    resume() {
+      paused = false;
+      if (!destroyed && !stopped && ghostEligible() && ghostEl && !ghostTimer) ghostTimer = every(T.GHOST_TICK_MS, ghostTick);
+    },
+    stop() {
+      stopped = true;
+      meltArmed = false; feintArmed = false; clockArmed = false;
+      allHonest();
+      disarmGhost();
+      unwatchPhase();
+    },
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      for (const id of Array.from(live)) cancel(id);
+      live.clear();
+      for (const h of Array.from(chains)) stopEvery(h);
+      allHonest();
+      disarmGhost();
+      unwatchPhase();
+      if (layer) { try { layer.remove(); } catch (e) { /* ignore */ } }
+      layer = null; ringEl = null; ghostEl = null;
+    },
+    diagnostics() {
+      return {
+        armed, tier, deals: deals.slice(), fired: Object.assign({}, fired),
+        clock: { armed: clockArmed, ringOn }, feint: { armed: feintArmed, live: feinting.length },
+        melt: { armed: meltArmed, live: !!melted },
+        ghost: { armed: !!ghostEl, mode: ghostMode, trail: trail.length, lureSlot },
+        phase: lastPhase, observer: !!phaseObs, liveTimers: live.size, lexicon: Array.from(lexiconUsed),
+      };
+    },
+  };
+}
+
+export default createMdTrickster;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
@@ -1,12 +1,19 @@
 /* ============================================================================
  * games/registry.js - the guarded registry (BUILD-CONTRACT §11).
  *
- * Imports the five shipped classes with Promise.allSettled, exactly like
- * intake/render/captcha/index.js (Semester I's four, plus The Deep End - the
- * first Semester III class brought forward): one broken module NEVER blocks the
- * others and NEVER throws. A failed import logs and leaves a STUB in its slot
- * whose class renders `class_suspended` - the shell must always be able to deal a
- * board, because a blank board is indistinguishable from a dead app.
+ * Imports every OPEN class with Promise.allSettled, exactly like
+ * intake/render/captcha/index.js (Semester I's four, Semester II's three,
+ * Semester III's three): one broken module NEVER blocks the others and NEVER
+ * throws. A failed import logs and leaves a STUB in its slot whose class renders
+ * `class_suspended` - the shell must always be able to deal a board, because a
+ * blank board is indistinguishable from a dead app.
+ *
+ * THE SEMESTER GATE. `GAME_SEMESTER` says which semester each class belongs to
+ * and `OPEN_SEMESTERS` says which semesters have opened; `loadGames` imports
+ * ONLY the open ones. A closed semester is not a suspended class - it is simply
+ * ABSENT from the pool, so the timetable never deals it and shell/campus.js
+ * keeps that wing taped shut. That is the one-line release gate: ship a semester
+ * dark by dropping its number from the set, open it by putting the number back.
  *
  * STATIC DESCRIPTORS. The timetable needs {family, meaty, flagship, timeBudgetSec}
  * for a game even when its module failed to load, so they live here as a fallback
@@ -26,6 +33,11 @@ export const GAME_PATHS = Object.freeze({
   lost_and_found: './lost-and-found/index.js',
   deja_vu: './deja-vu/index.js',
   impulse_control: './impulse-control/index.js',
+  misdirection: './misdirection/index.js',
+  echo: './echo/index.js',
+  instant_recall: './instant-recall/index.js',
+  anomaly: './anomaly/index.js',
+  composure: './composure/index.js',
   the_deep_end: './the-deep-end/index.js',
 });
 
@@ -45,7 +57,51 @@ export const GAME_META = Object.freeze({
   // The Deep End is the second meaty class (DECISIONS #3's 300s slot) and the first
   // Semester III class brought forward - family 'comfort', never a flagship.
   the_deep_end: { family: 'comfort', meaty: true, flagship: false, timeBudgetSec: 300 },
+  /* Semester II. Families per SYNTHESIS #3; 'recall' joins the list with Instant
+     Recall (core/lexicon.js has no family_recall/family_puzzle row yet, so the
+     chip degrades to the de-snaked key - readable English, never a raw token). */
+  misdirection: { family: 'tracking', meaty: false, flagship: false, timeBudgetSec: 120 },
+  echo: { family: 'memory', meaty: false, flagship: false, timeBudgetSec: 105 },
+  // MEATY (ruled 2026-08-23): the third meaty class. With ten games no-repeat-3 binds again
+  // and outranks the meaty preference, so two meaty classes left ~a third of nights with the
+  // slot unfilled (trap 6 re-opened); see composure below for the full count. Mirrors the module's own export.
+  instant_recall: { family: 'recall', meaty: true, flagship: false, timeBudgetSec: 120 },
+  /* Semester III (The Deep End above was brought forward). */
+  anomaly: { family: 'search', meaty: false, flagship: false, timeBudgetSec: 90 },
+  // MEATY (ruled 2026-08-23, same reason as instant_recall): four meaty classes (L&F, The Deep
+  // End, Instant Recall, Composure) are what it takes for a no-repeat-3 pool to deal one meaty
+  // class EVERY night (measured 28/28; three gave 21/28). Mirrors the module's own export.
+  composure: { family: 'puzzle', meaty: true, flagship: false, timeBudgetSec: 120 },
 });
+
+/**
+ * Which semester each class belongs to. A key missing from this table is treated
+ * as Semester I (open by default) - a new game is never accidentally invisible.
+ */
+export const GAME_SEMESTER = Object.freeze({
+  daily_trigger: 1,
+  lost_and_found: 1,
+  deja_vu: 1,
+  impulse_control: 1,
+  misdirection: 2,
+  echo: 2,
+  instant_recall: 2,
+  anomaly: 3,
+  composure: 3,
+  the_deep_end: 3,
+});
+
+/**
+ * The semesters that have opened. THE release gate - see the header. Drop a
+ * number and every class in it leaves the pool (no stub, no board row) and
+ * shell/campus.js re-tapes that wing; put it back and the wing opens.
+ */
+export const OPEN_SEMESTERS = new Set([1, 2, 3]);
+
+/** True when a class's semester has opened (unknown keys are Semester I). */
+export function isOpenSemester(key) {
+  return OPEN_SEMESTERS.has(GAME_SEMESTER[key] || 1);
+}
 
 export const MAX_TIER = 4;
 const PROMOTIONS_PER_TIER = 2;
@@ -149,13 +205,21 @@ function validate(mod) {
 }
 
 /**
- * Load every game. Never rejects.
+ * Load every game whose semester has opened. Never rejects.
  * @param {Function=} log
  * @returns {Promise<{list:Array, byKey:Object, ok:number, failed:string[]}>}
  */
 export async function loadGames(log) {
   const say = typeof log === 'function' ? log : () => {};
   const keys = Object.keys(GAME_PATHS);
+  /* THE SEMESTER GATE. Filtered IN PLACE so the two lines around it keep their
+   * exact shape (the scratch shell-suite harness patches this function by
+   * literal text to register its fixture class). A closed semester's games are
+   * ABSENT - never a class_suspended stub, which is reserved for a class that
+   * exists and could not open. */
+  for (let i = keys.length - 1; i >= 0; i--) {
+    if (!isOpenSemester(keys[i])) keys.splice(i, 1);
+  }
 
   const settled = await Promise.allSettled(keys.map((k) => import(GAME_PATHS[k])));
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -72,6 +72,20 @@
  * is lite from the first frame. With no requestAnimationFrame (the headless
  * double) the probe never runs and the class stays FULL.
  *
+ * PASS 6 (the owner's iPhone 13 Pro Max on the web teaser): THE TOUCH RUNG,
+ * which is NOT a third quality level - it is a hardware ceiling laid over
+ * whichever rung the class resolved to, and it applies on FULL too. A coarse
+ * pointer (or more than one touch point) puts `.ae-touch` on <html> for the
+ * life of the class: four animated tiers instead of six, stills four deep
+ * instead of three, three engine decoration videos instead of six, and
+ * engine/style.js drops the backdrop-filter, the full-screen blend surfaces,
+ * the scanline re-raster and the filters that sit over a live decode. iOS caps
+ * concurrent hardware decode sessions and WebKit charges real milliseconds for
+ * a blend or a blur, so none of that is a preference the player should have to
+ * find - there is no setting, the device is the setting. It composes with the
+ * rung in the PROTECTIVE direction (cap = min, still-line = max), so a phone on
+ * lite is still lite. It comes off on destroy, exactly like `.ae-lite`.
+ *
  * PASS 4 (the owner's third note): THE PRESSURE - the CCP effects ladder and
  * the Balatro tremor live in pressure.js, DECK III. This file owns none of
  * that look; it owns the WIRING. The deck is built after the casino and the
@@ -374,6 +388,7 @@ export default {
     let perfReason = '';                   // why (diagnostics + the log line)
     let perfProbeDone = false;             // the probe fires once per class
     let perfLogged = false;
+    let touch = false;                     // pass 6: a touch device, on any rung
     let stuckHints = 0;
     let slides = 0;
     let bumps = 0;
@@ -721,10 +736,50 @@ export default {
      * reach into the engine, but the document root is common ground). Both come
      * off on destroy, or the lobby inherits a lit-down room.
      * ==================================================================== */
-    /** The animated-tier cap and the still-shallows line, by resolved level. */
-    function faceCap() { return perf === 'lite' ? PLAYTEST.FACE_CAP_LITE : PLAYTEST.FACE_CAP; }
+    /**
+     * PASS 6 - THE TOUCH RUNG, which is not a rung at all: it is a HARDWARE
+     * ceiling laid over whichever rung the class resolved to. iOS caps
+     * concurrent hardware decode sessions (three or four in practice), and
+     * WebKit charges a phone several ms a frame for a backdrop-filter or a
+     * full-screen blend surface, so those cuts are owed even on FULL - they are
+     * orthogonal to the full/lite quality ladder and are never user-facing
+     * (there is no setting; the device is the setting). Same seam as lite:
+     * `.ae-touch` on <html>, which engine/style.js and engine/util.js's shared
+     * decoder budget read, plus this game's own stylesheet.
+     */
+    function probeTouch() {
+      try {
+        if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+          const m = window.matchMedia('(pointer: coarse)');
+          if (m && m.matches) return true;
+        }
+      } catch (e) { /* ignore */ }
+      try {
+        if (typeof navigator !== 'undefined' && Number(navigator.maxTouchPoints) > 1) return true;
+      } catch (e) { /* ignore */ }
+      return false;
+    }
+    function setTouchClass(on) {
+      /* <html> ONLY: the stage's own look hangs off `html.ae-touch .g-de-*` in
+         style.js, so there is no second class to keep in sync here. */
+      try {
+        const html = typeof document !== 'undefined' ? document.documentElement : null;
+        if (html && html.classList) html.classList[on ? 'add' : 'remove']('ae-touch');
+      } catch (e) { /* ignore */ }
+    }
+    /** The animated-tier cap and the still-shallows line: the resolved rung
+     *  COMPOSED with the touch ceiling, always in the PROTECTIVE direction. The
+     *  two dials point opposite ways - a cap wants the MIN (fewer decoders) and
+     *  a still-shallows LINE wants the MAX (more of the numerous tiers frozen)
+     *  - so a touch phone on lite keeps lite's 3 loops and lite's five-deep
+     *  shallows, and never trades one of them back for the touch number. */
+    function faceCap() {
+      const rung = perf === 'lite' ? PLAYTEST.FACE_CAP_LITE : PLAYTEST.FACE_CAP;
+      return touch ? Math.min(rung, PLAYTEST.FACE_CAP_TOUCH) : rung;
+    }
     function shallowStillMaxTier() {
-      return perf === 'lite' ? PLAYTEST.SHALLOW_STILL_MAX_TIER_LITE : PLAYTEST.SHALLOW_STILL_MAX_TIER;
+      const rung = perf === 'lite' ? PLAYTEST.SHALLOW_STILL_MAX_TIER_LITE : PLAYTEST.SHALLOW_STILL_MAX_TIER;
+      return touch ? Math.max(rung, PLAYTEST.SHALLOW_STILL_MAX_TIER_TOUCH) : rung;
     }
     /** Read the setting. Anything that is not one of the three is `auto` - the
      *  host clamps its OWN knobs, but a per-game bag is stored verbatim, so a
@@ -1928,9 +1983,16 @@ export default {
         perfProbeDone = false;
         perfLogged = false;
         setLiteClass(false);
+        /* PASS 6 - THE TOUCH RUNG: detected ONCE per class, before any node
+         * exists, and independent of de_perf. A phone's decoder ceiling is not
+         * a quality preference, so `full` does not opt out of it. */
+        touch = probeTouch();
+        setTouchClass(touch);
         if (perfSetting === 'lite') applyPerf('lite', 'setting');
         else if (perfSetting === 'auto' && (reduced || motionLevelOf() <= 1)) applyPerf('lite', 'reduced motion');
         else applyPerf('full', perfSetting === 'full' ? 'setting' : 'auto: probing');
+        if (touch) say('touch device: html.ae-touch armed - faces ' + faceCap()
+          + ' animated tiers, stills to tier ' + shallowStillMaxTier() + ' (iOS decoder ceiling)');
         n = sizeFromSetting(ctx.settings ? ctx.settings.de_board_size : '4x4');
         {
           const want = String(ctx.settings && ctx.settings.de_tile_faces != null ? ctx.settings.de_tile_faces : 'media').trim().toLowerCase();
@@ -2091,6 +2153,7 @@ export default {
         hideHowto();
         perfProbeDone = true;                // any in-flight rAF step is a no-op now
         setLiteClass(false);                 // .ae-lite is on <html>: it outlives us unless we take it off
+        setTouchClass(false);                // and so does .ae-touch - same seam, same cleanup
         clearQueue();
         clearGrab();
         opened = false;
@@ -2160,6 +2223,8 @@ export default {
           perf, perfReason, perfSetting, perfProbeDone,
           faceCap: faceCap(), shallowStillMaxTier: shallowStillMaxTier(),
           lite: !!(stage && stage.classList && stage.classList.contains('g-de-lite')),
+          /* pass 6 - THE TOUCH RUNG (composed with the rung above, not a rung) */
+          touch,
           slides, bumps, stuckHints, stuckShown,
           /* pass 3 - THE HAND + THE QUEUE */
           held: !!grab,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -37,8 +37,12 @@
  * board.js untouched). FACES - every tile wears the player's own media
  * (.g-de-face > img.g-de-media), ONE url per tier dealt lazily on the tier's
  * first appearance and frozen for the class; the setting `de_tile_faces`
- * (media | still | plain) and reduced motion / motionLevel <= 1 pick stills;
- * past FACE_CAP animated faces a new tier is dealt a still. A numeral badge
+ * (media | still | plain) and reduced motion / motionLevel <= 1 pick stills.
+ * PASS 5 re-dialled the budget: THE SHALLOWS ARE STILL, DEPTH IS ALIVE -
+ * tiers 1..SHALLOW_STILL_MAX_TIER (the numerous ones) always wear a still, a
+ * loop is dealt only from the next tier down, and only until FACE_CAP
+ * DISTINCT ANIMATED TIERS are live (tiers, not tiles: the url is frozen per
+ * tier, so every tile of a tier is a decode of the same file). A numeral badge
  * (.g-de-num) carries the tier number - numbers are not words.
  *
  * PASS 3 (owner's second playtest): THE HAND - a press on the board is now a
@@ -54,6 +58,19 @@
  * lock releases (never inside the releasing callback), and dropped whenever the
  * board is not the player's any more (pause, suspend, resurface, new dive,
  * bell, end, destroy). Fast play now flows instead of hitching.
+ *
+ * PASS 5 (the Chromium trace: GPU main thread at 79% of a core on a 3060 Ti
+ * with 16 live video tiles): THE PERF LADDER. `de_perf` = auto | full | lite.
+ * `lite` puts .g-de-lite on the stage and .ae-lite on <html> (style.js and
+ * engine/style.js read both), halves the animated-tier cap, stills the
+ * shallows five deep, stops the face ken-burns, freezes the backdrop pattern
+ * drift and drops the engine's shared video budget to 2. `auto` runs the class
+ * FULL, samples rAF deltas for ~3s once the board is dealt and demotes ONCE if
+ * the median frame is over 20ms (or a quarter of frames over 25ms) - it never
+ * promotes back mid-class, because a room that changes its own look twice is
+ * worse than a room that is simply lighter. Reduced motion / motionLevel <= 1
+ * is lite from the first frame. With no requestAnimationFrame (the headless
+ * double) the probe never runs and the class stays FULL.
  *
  * PASS 4 (the owner's third note): THE PRESSURE - the CCP effects ladder and
  * the Balatro tremor live in pressure.js, DECK III. This file owns none of
@@ -135,6 +152,9 @@ const BUMP_CLASSES = Object.freeze(['g-de-bump-up', 'g-de-bump-down', 'g-de-bump
 /** Pass 3 - THE HAND: at most one of these rides the board at a time. */
 const GRAB_CLASSES = Object.freeze(['g-de-grab-up', 'g-de-grab-down', 'g-de-grab-left', 'g-de-grab-right']);
 const FACE_MODES = Object.freeze(['media', 'still', 'plain']);
+/** PASS 5 - the perf ladder. `auto` is the default and the only value that
+ *  may change its mind mid-class (once, downward). */
+const PERF_MODES = Object.freeze(['auto', 'full', 'lite']);
 
 /**
  * PURE, LOCAL: would a slide in `dir` move anything? Reads board.tiles and
@@ -255,6 +275,13 @@ export default {
         key: 'de_tile_faces', kind: 'enum', values: FACE_MODES.slice(), default: 'media',
         label_key: 'de_tile_faces', hint_key: 'de_tile_faces_hint',
       },
+      /* PASS 5 - THE PERF LADDER. `values`, never `options` (CLAUDE.md trap 21:
+       * an `options` array renders NO row at all and the setting is stuck on
+       * its default forever). `auto` first, so an untouched install probes. */
+      {
+        key: 'de_perf', kind: 'enum', values: PERF_MODES.slice(), default: 'auto',
+        label_key: 'de_perf', hint_key: 'de_perf_hint',
+      },
     ],
     peek: false,
     /* FREE SWIM: the campus door card gains a second, secondary button and the
@@ -341,6 +368,12 @@ export default {
     let faceLogged = false;
     let capLogged = false;
     let stuckShown = false;
+    /* pass 5 - THE PERF LADDER */
+    let perfSetting = 'auto';              // de_perf: auto | full | lite
+    let perf = 'full';                     // the RESOLVED level this class runs at
+    let perfReason = '';                   // why (diagnostics + the log line)
+    let perfProbeDone = false;             // the probe fires once per class
+    let perfLogged = false;
     let stuckHints = 0;
     let slides = 0;
     let bumps = 0;
@@ -507,6 +540,9 @@ export default {
       const root = ctx.root;
       root.textContent = '';
       stage = el('div', 'g-de-stage');
+      /* pass 5: the level is resolved before any node exists, so the stage is
+         born lit-down rather than flipping a frame after the deal. */
+      if (perf === 'lite') stage.classList.add('g-de-lite');
       stage.setAttribute('data-phase', 'briefing');
       stage.setAttribute('data-size', String(n));
       if (reduced) stage.setAttribute('data-reduced', '1');
@@ -675,11 +711,107 @@ export default {
       return next;
     }
 
-    /* ---- faces (pass 2): one url per tier, dealt lazily, frozen ----------- */
-    /** How many live tiles wear an animated face right now. */
+    /* ==================================================================== *
+     * PASS 5 - THE PERF LADDER (de_perf: auto | full | lite)
+     *
+     * ONE resolved level per class, and `auto` may lower it exactly once. The
+     * level is expressed in TWO places at once: `.g-de-lite` on the stage (this
+     * game's own stylesheet reads it) and `.ae-lite` on <html> (the ENGINE's
+     * stylesheet and its shared video budget read that one - a game may not
+     * reach into the engine, but the document root is common ground). Both come
+     * off on destroy, or the lobby inherits a lit-down room.
+     * ==================================================================== */
+    /** The animated-tier cap and the still-shallows line, by resolved level. */
+    function faceCap() { return perf === 'lite' ? PLAYTEST.FACE_CAP_LITE : PLAYTEST.FACE_CAP; }
+    function shallowStillMaxTier() {
+      return perf === 'lite' ? PLAYTEST.SHALLOW_STILL_MAX_TIER_LITE : PLAYTEST.SHALLOW_STILL_MAX_TIER;
+    }
+    /** Read the setting. Anything that is not one of the three is `auto` - the
+     *  host clamps its OWN knobs, but a per-game bag is stored verbatim, so a
+     *  hand-edited blob really can arrive as 42, '' or null. */
+    function perfFromSetting(v) {
+      if (typeof v !== 'string') return 'auto';    // an array stringifies to its one item; a setting is a string
+      const want = v.trim().toLowerCase();
+      return PERF_MODES.includes(want) ? want : 'auto';
+    }
+    function setLiteClass(on) {
+      try { if (stage) stage.classList[on ? 'add' : 'remove']('g-de-lite'); } catch (e) { /* ignore */ }
+      try {
+        const html = typeof document !== 'undefined' ? document.documentElement : null;
+        if (html && html.classList) html.classList[on ? 'add' : 'remove']('ae-lite');
+      } catch (e) { /* ignore */ }
+    }
+    /** Resolve to a level. DOWNWARD ONLY: once lite, lite for the class. */
+    function applyPerf(level, reason) {
+      const want = level === 'lite' ? 'lite' : 'full';
+      if (perf === 'lite' && want === 'full') return;      // never re-promote mid-class
+      perf = want;
+      perfReason = String(reason || '');
+      setLiteClass(perf === 'lite');
+      if (!perfLogged || perf === 'lite') {
+        perfLogged = true;
+        say('perf: ' + perf + (perfReason ? ' (' + perfReason + ')' : ''));
+      }
+    }
+    /**
+     * THE AUTO PROBE. Sample rAF deltas once the board is dealt, skip the
+     * warm-up (style injection and the first decodes land there and would
+     * demote a machine that is actually fine), then judge the MEDIAN and the
+     * slow-frame share. Robustness rules, in the order they cost time:
+     *   - no requestAnimationFrame at all (node, the DOM double) -> stay FULL,
+     *     silently. A missing clock is not evidence of a slow machine.
+     *   - a hidden tab does not paint, so every delta is garbage: abandon the
+     *     probe rather than demote, and never restart it (once per class).
+     *   - a paused/suspended class is the same story (a mandatory video owns
+     *     the screen); abandon.
+     */
+    function startPerfProbe() {
+      if (perfProbeDone || perfSetting !== 'auto' || perf === 'lite') return;
+      const raf = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+        ? (fn) => window.requestAnimationFrame(fn) : null;
+      if (!raf) { perfProbeDone = true; perfReason = 'auto: no rAF, stayed full'; return; }
+      const deltas = [];
+      let t0 = 0;
+      let last = 0;
+      const hidden = () => { try { return typeof document !== 'undefined' && document.hidden === true; } catch (e) { return false; } };
+      const step = (now) => {
+        if (dead || ended || perfProbeDone) return;
+        if (paused || hidden()) { perfProbeDone = true; perfReason = 'auto: probe abandoned (not painting)'; return; }
+        const t = Number.isFinite(Number(now)) ? Number(now) : Date.now();
+        if (!t0) { t0 = t; last = t; raf(step); return; }
+        const dt = t - last;
+        last = t;
+        if (t - t0 >= PLAYTEST.PERF_WARMUP_MS) deltas.push(dt);
+        if (t - t0 < PLAYTEST.PERF_WARMUP_MS + PLAYTEST.PERF_SAMPLE_MS) { raf(step); return; }
+        perfProbeDone = true;
+        judgePerf(deltas);
+      };
+      raf(step);
+    }
+    /** The verdict on a delta sample (its own function so the harness can drive
+     *  it without a real frame clock). */
+    function judgePerf(deltas) {
+      const n = deltas.length;
+      if (n < PLAYTEST.PERF_MIN_FRAMES) { perfReason = 'auto: ' + n + ' frames sampled, stayed full'; return; }
+      const sorted = deltas.slice().sort((a, b) => a - b);
+      const median = sorted[Math.floor(n / 2)];
+      let slow = 0;
+      for (const d of deltas) if (d > PLAYTEST.PERF_SLOW_MS) slow += 1;
+      const share = slow / n;
+      if (median > PLAYTEST.PERF_MEDIAN_MS || share > PLAYTEST.PERF_SLOW_SHARE) {
+        applyPerf('lite', 'median ' + Math.round(median) + 'ms, ' + Math.round(share * 100) + '% slow');
+        return;
+      }
+      perfReason = 'auto: full (median ' + Math.round(median) + 'ms, ' + Math.round(share * 100) + '% slow)';
+    }
+
+    /* ---- faces (pass 2, re-dialled by pass 5): one url per tier, frozen ---- */
+    /** How many DISTINCT TIERS have been dealt an animated face. Tiles are the
+     *  wrong unit: a tier's url is frozen for the class, so ten tier-4 tiles are
+     *  ten decoders of ONE file and only a NEW tier buys a new decode. */
     function animatedFaces() {
       let k = 0;
-      for (const tile of board.tiles) { const f = faceUrls.get(tile.tier); if (f && !f.broken && f.kind === 'loop') k += 1; }
+      for (const f of faceUrls.values()) if (f && !f.broken && f.kind === 'loop') k += 1;
       return k;
     }
     /** The tier's face, dealing one on the tier's first appearance. null = no
@@ -690,16 +822,27 @@ export default {
       if (have) return have.broken ? null : have;
       if (!pool || typeof pool.next !== 'function') return null;
       let kind = faceKind;
-      if (kind === 'loop' && animatedFaces() >= PLAYTEST.FACE_CAP) {
+      if (kind === 'loop' && tier <= shallowStillMaxTier()) {
+        /* THE SHALLOWS ARE STILL, DEPTH IS ALIVE. Tiers 1-3 are most of every
+         * board; giving them the loops spent the whole decoder budget on the
+         * tiles nobody is looking at. */
         kind = 'still';
-        if (!capLogged) { capLogged = true; say('faces: ' + PLAYTEST.FACE_CAP + ' animated faces on the board - new tiers wear stills'); }
+      } else if (kind === 'loop' && animatedFaces() >= faceCap()) {
+        kind = 'still';
+        if (!capLogged) { capLogged = true; say('faces: ' + faceCap() + ' animated tiers live - new tiers wear stills'); }
       }
       let url = null;
       try { const got = pool.next(kind); url = got && got.url ? String(got.url) : null; } catch (e) { url = null; }
       if (!url) return null;
       const face = { url, kind };
       faceUrls.set(tier, face);
-      if (!faceLogged) { faceLogged = true; say('faces: ' + kind + ' (' + facesMode + ', motion ' + motionLevelOf() + (reduced ? ', reduced' : '') + ')'); }
+      if (!faceLogged) {
+        faceLogged = true;
+        /* the CLASS's policy, not this one deal: faceKind is what a tier past
+           the shallows gets, and the two numbers are the pass-5 budget. */
+        say('faces: ' + faceKind + ' (' + facesMode + ', motion ' + motionLevelOf() + (reduced ? ', reduced' : '')
+          + ', still to tier ' + shallowStillMaxTier() + ', cap ' + faceCap() + ')');
+      }
       return face;
     }
     /** Dress (or re-dress after a merge) a tile with its tier's face. Never
@@ -1599,6 +1742,152 @@ export default {
         .catch((e) => say('asset claim failed - plain faces, currents fall back to the engine pool: ' + ((e && e.message) || e)));
     }
 
+    /* ---- the class rules sheet (Deck VI, Law IV: drawn, not told) --------- */
+    /**
+     * Four vignettes in this pool's own language: the swipe that moves the
+     * whole board at once, two matching tiles meeting and sinking one depth,
+     * the locked board banking its depth and refilling, and the eleventh rung
+     * where the ladder simply stops. Every figure is CSS on the same tile
+     * chrome the board uses (the drawn ring glyph included), so the sheet costs
+     * no media and reads at any size.
+     */
+    let howtoEl = null;
+
+    /** Tiers this player has already had the rules sheet for (persisted). */
+    function howtoSeenTiers() {
+      try {
+        const m = (ctx.store && typeof ctx.store.gameMeta === 'function')
+          ? (ctx.store.gameMeta(GAME_KEY) || {}) : {};
+        return Array.isArray(m.howtoTiers) ? m.howtoTiers.slice() : [];
+      } catch (e) { return []; }
+    }
+
+    function hideHowto() {
+      if (howtoEl) { try { howtoEl.remove(); } catch (e) { /* noop */ } }
+      howtoEl = null;
+    }
+
+    function buildHowto(onGo) {
+      const sheet = el('div', 'g-de-howto');
+      sheet.appendChild(el('h2', 'g-de-hw-title', t('de_howto_title', DE_LEX.de_howto_title)));
+
+      const row = (build, caption) => {
+        const r = el('div', 'g-de-hw-row');
+        const fig = el('span', 'g-de-hw-fig');
+        fig.setAttribute('aria-hidden', 'true');
+        try { build(fig); } catch (e) { /* a caption alone still teaches */ }
+        r.appendChild(fig);
+        r.appendChild(el('p', 'g-de-hw-cap', caption));
+        sheet.appendChild(r);
+        return r;
+      };
+
+      /** A mini tile wearing a depth tier - the same data-tier the board uses,
+       *  so the palette and the drawn rings come from the one place. */
+      const tile = (cls, tierN) => {
+        const n2 = el('span', 'g-de-hw-tile' + (cls ? ' ' + cls : ''));
+        n2.setAttribute('data-tier', String(tierN == null ? 1 : tierN));
+        n2.appendChild(el('span', 'g-de-hw-num', String(tierN == null ? 1 : tierN)));
+        return n2;
+      };
+
+      /* 1 - THE SWIPE. Four arrows around a board whose whole row slides. */
+      row((fig) => {
+        const pad = el('span', 'g-de-hw-pad');
+        for (const d of ['up', 'right', 'down', 'left']) pad.appendChild(el('i', 'g-de-hw-arrow ' + d));
+        fig.appendChild(pad);
+        const line = el('span', 'g-de-hw-line slide');
+        for (let i = 0; i < 3; i++) {
+          const n2 = tile(null, i + 1);
+          n2.style.setProperty('--de-hw-i', String(i));
+          line.appendChild(n2);
+        }
+        fig.appendChild(line);
+      }, t('de_howto_swipe', DE_LEX.de_howto_swipe));
+
+      /* 2 - THE MERGE. Two equal tiles close on each other and come back as
+         one, a depth further down; the water darkens behind them. */
+      row((fig) => {
+        const scene = el('span', 'g-de-hw-scene');
+        scene.appendChild(tile('mrg a', 4));
+        scene.appendChild(tile('mrg b', 4));
+        scene.appendChild(tile('mrg out', 5));
+        fig.appendChild(scene);
+      }, t('de_howto_merge', DE_LEX.de_howto_merge));
+
+      /* 3 - THE RESURFACE. A jammed board drains and refills; the mark it
+         reached is banked on the gauge beside it. */
+      row((fig) => {
+        const grid4 = el('span', 'g-de-hw-grid');
+        for (let i = 0; i < 4; i++) {
+          const n2 = tile('drain', 2 + (i % 3));
+          n2.style.setProperty('--de-hw-i', String(i));
+          grid4.appendChild(n2);
+        }
+        fig.appendChild(grid4);
+        const gauge = el('span', 'g-de-hw-gauge');
+        gauge.appendChild(el('i'));
+        fig.appendChild(gauge);
+      }, t('de_howto_resurface', DE_LEX.de_howto_resurface));
+
+      /* 4 - THE CEILING. The ladder, and the rung it stops on. */
+      row((fig) => {
+        const ladder = el('span', 'g-de-hw-ladder');
+        for (let i = 1; i <= 11; i++) {
+          const rung = el('i', i === 11 ? 'top' : null);
+          rung.setAttribute('data-tier', String(i));
+          rung.style.setProperty('--de-hw-i', String(i - 1));
+          ladder.appendChild(rung);
+        }
+        fig.appendChild(ladder);
+        fig.appendChild(tile('ceil', 11));
+      }, t('de_howto_ceiling', DE_LEX.de_howto_ceiling));
+
+      const go = el('button', 'g-de-hw-go', t('de_howto_go', DE_LEX.de_howto_go));
+      go.setAttribute('type', 'button');
+      try { go.type = 'button'; } catch (e) { /* the DOM double has no button semantics */ }
+      go.addEventListener('click', () => { try { onGo(); } catch (e) { say('howto go: ' + ((e && e.message) || e)); } });
+      sheet.appendChild(go);
+      try { if (typeof go.focus === 'function') go.focus(); } catch (e) { /* noop */ }
+      return sheet;
+    }
+
+    /**
+     * Policy is the shell's "Skip class tutorials" contract: by default the
+     * sheet shows EVERY class; with the skip on, the pool still explains itself
+     * ONCE per grade tier. Dismissal is the sheet's own button and nothing
+     * else - every arrow key and the whole board are verbs here, so a key
+     * shortcut would be a move played against a board that has not dealt.
+     */
+    function howto(onDone) {
+      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      if (ctx.dev === true && spec && spec.devSkipHowto === true) { onDone(); return; }
+      if (!stage) { onDone(); return; }
+      const tierNow = tier;
+      let done = false;
+      let sheet = null;
+      try {
+        sheet = buildHowto(() => {
+          if (done || dead || ended) return;
+          done = true;
+          try {
+            const seen = howtoSeenTiers();
+            if (seen.indexOf(tierNow) < 0) {
+              seen.push(tierNow);
+              if (ctx.store && typeof ctx.store.mergeGameMeta === 'function') {
+                ctx.store.mergeGameMeta(GAME_KEY, { howtoTiers: seen });
+              }
+            }
+          } catch (e) { /* best effort - the sheet just shows again next time */ }
+          hideHowto();
+          onDone();
+        });
+      } catch (e) { say('rules sheet refused: ' + ((e && e.message) || e)); sheet = null; }
+      if (!sheet) { onDone(); return; }
+      howtoEl = sheet;
+      stage.appendChild(sheet);
+    }
+
     /* ==================================================================== *
      * THE MODULE INSTANCE
      * ==================================================================== */
@@ -1629,6 +1918,19 @@ export default {
           if (devDeepest) say('DEV: opening every dive at tier ' + devDeepest);
         }
         reduced = probeReduced(ctx);
+        /* PASS 5 - THE PERF LADDER, resolved BEFORE the first node: the stage,
+         * the face budget and the engine's video budget all read it. `full` is
+         * an explicit opt-out and is honoured even under reduced motion (the
+         * player asked for the room); `auto` is the only value that probes. */
+        perfSetting = perfFromSetting(ctx.settings ? ctx.settings.de_perf : 'auto');
+        perf = 'full';
+        perfReason = '';
+        perfProbeDone = false;
+        perfLogged = false;
+        setLiteClass(false);
+        if (perfSetting === 'lite') applyPerf('lite', 'setting');
+        else if (perfSetting === 'auto' && (reduced || motionLevelOf() <= 1)) applyPerf('lite', 'reduced motion');
+        else applyPerf('full', perfSetting === 'full' ? 'setting' : 'auto: probing');
         n = sizeFromSetting(ctx.settings ? ctx.settings.de_board_size : '4x4');
         {
           const want = String(ctx.settings && ctx.settings.de_tile_faces != null ? ctx.settings.de_tile_faces : 'media').trim().toLowerCase();
@@ -1710,37 +2012,48 @@ export default {
           });
         } catch (e) { pressure = null; say('pressure refused: ' + ((e && e.message) || e)); }
 
-        bindInput();
         claimAssets();
-        newDive();
-        startClock();
-        stallTimer = every(PLAYTEST.STALL_TICK_MS, () => {
-          if (ended || busy) return;
-          stallMs += PLAYTEST.STALL_TICK_MS;
-          deck('trickster', 'stalled', stallMs);
-          // STUCK: one pulse per stall, then silence until the next move
-          if (!stuckShown && stallMs >= PLAYTEST.STUCK_MS && board && !isLocked(board)) {
-            stuckShown = true;
-            stuckHint();
-          }
-        });
 
-        /* the briefing: one line, then the water opens */
-        if (endless) msg('de_brief_free', DE_LEX.de_brief_free);
-        else msg('de_brief', DE_LEX.de_brief);
-        after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
-          setPhase(basePhase());
-          msg('de_play_hint', DE_LEX.de_play_hint);
-          deck('casino', 'start');
-          deck('pressure', 'start');
-          deck('trickster', 'start');
-          openAmbience();
-          // the water opens: from here a press against the lock is REMEMBERED
-          // (the briefing itself is not a lock the player was playing against,
-          // so nothing it swallowed drains into the first dive)
-          opened = true;
-          busy = false;
-        });
+        /* THE SHEET FIRST (Deck VI), then the briefing, then the water
+           opens. Nothing that measures the player runs until GO: no key
+           is bound, no dive is dealt and the clock has not started, so a
+           class read at leisure grades exactly like one that skipped the
+           sheet. */
+        const beginClass = () => {
+          if (dead || ended) return;
+          bindInput();
+          newDive();
+          startPerfProbe();                    // the board is dealt: start counting frames
+          startClock();
+          stallTimer = every(PLAYTEST.STALL_TICK_MS, () => {
+            if (ended || busy) return;
+            stallMs += PLAYTEST.STALL_TICK_MS;
+            deck('trickster', 'stalled', stallMs);
+            // STUCK: one pulse per stall, then silence until the next move
+            if (!stuckShown && stallMs >= PLAYTEST.STUCK_MS && board && !isLocked(board)) {
+              stuckShown = true;
+              stuckHint();
+            }
+          });
+
+          /* the briefing: one line, then the water opens */
+          if (endless) msg('de_brief_free', DE_LEX.de_brief_free);
+          else msg('de_brief', DE_LEX.de_brief);
+          after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
+            setPhase(basePhase());
+            msg('de_play_hint', DE_LEX.de_play_hint);
+            deck('casino', 'start');
+            deck('pressure', 'start');
+            deck('trickster', 'start');
+            openAmbience();
+            // the water opens: from here a press against the lock is REMEMBERED
+            // (the briefing itself is not a lock the player was playing against,
+            // so nothing it swallowed drains into the first dive)
+            opened = true;
+            busy = false;
+          });
+        };
+        howto(beginClass);
 
         liveClass = instance;
         lastReport = null;
@@ -1775,6 +2088,9 @@ export default {
 
       destroy() {
         dead = true;
+        hideHowto();
+        perfProbeDone = true;                // any in-flight rAF step is a no-op now
+        setLiteClass(false);                 // .ae-lite is on <html>: it outlives us unless we take it off
         clearQueue();
         clearGrab();
         opened = false;
@@ -1807,6 +2123,9 @@ export default {
       surface() { onSurface(); },
       /** The TRUE chip text - what the trickster restores after a lie. */
       chipText(which) { return chipText(which); },
+      /** Pass 5: hand the auto probe a frame sample directly (the harness has no
+       *  frame clock, and a real 3s sample is not a unit test). */
+      perfJudge(deltas) { perfProbeDone = true; judgePerf(Array.isArray(deltas) ? deltas : []); return perf; },
       /** Re-sync every tile element to the model after the harness staged a board. */
       resync() {
         if (!board) return;
@@ -1836,7 +2155,11 @@ export default {
           exhaleUsed, exhalePending, exhaleOn, bellOn, ceilingReached, survived,
           jackpots, currents, subFlashes, shimmers, strains, stallMs, currentHeat, driftOn,
           endless, surfaced, ceilingCelebrated, surfaceBtn, secLeft: secLeft(), clockTruth: clockText(),
-          facesMode, faceKind, faces: faceUrls.size, animatedFaces: board ? animatedFaces() : 0,
+          facesMode, faceKind, faces: faceUrls.size, animatedFaces: animatedFaces(),
+          /* pass 5 - THE PERF LADDER */
+          perf, perfReason, perfSetting, perfProbeDone,
+          faceCap: faceCap(), shallowStillMaxTier: shallowStillMaxTier(),
+          lite: !!(stage && stage.classList && stage.classList.contains('g-de-lite')),
           slides, bumps, stuckHints, stuckShown,
           /* pass 3 - THE HAND + THE QUEUE */
           held: !!grab,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/lex.js
@@ -90,6 +90,21 @@ export const DE_LEX = Object.freeze({
   de_tile_faces_plain: 'Plain',
   de_stuck_hint: 'Nothing is locked. The lit edges still move.',
 
+  /* ---- pass 5: the performance ladder (manifest.settings de_perf) ------- */
+  de_perf: 'Performance',
+  de_perf_hint: 'Auto watches the frame rate and drops to Lite. Lite: fewer live loops, calmer water.',
+  de_perf_auto: 'Auto',
+  de_perf_full: 'Full',
+  de_perf_lite: 'Lite',
+
+  /* ---- the class rules sheet (drawn; these only caption it) ------------- */
+  de_howto_title: 'Class rules',
+  de_howto_swipe: 'Swipe, or use the arrows. Every tile on the board slides that way at once.',
+  de_howto_merge: 'Two matching tiles meet and sink one depth. The room gets heavier as you go.',
+  de_howto_resurface: 'A locked board is not a loss. Your depth is banked and the water turns fresh.',
+  de_howto_ceiling: 'The ladder ends at the eleventh depth. Reach it and the class holds you there.',
+  de_howto_go: 'Into the water',
+
   /* ---- pass 2: FREE SWIM (endless, untimed, ungraded) ------------------- */
   de_free_swim: 'Free Swim',
   de_free_swim_hint: 'No bell, no grade - swim until you surface.',

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
@@ -78,9 +78,42 @@ export const PLAYTEST = Object.freeze({
    *  direction that would move pulse once, for HINT_MS. */
   STUCK_MS: 6000,
   HINT_MS: 1100,
-  /** Pass 2 - FACES: past this many tiles wearing an animated face, a new
-   *  tier's face is dealt as a still. */
-  FACE_CAP: 16,
+  /** Pass 2 - FACES, re-dialled by PASS 5 (the perf trace). The cap counts
+   *  DISTINCT ANIMATED TIERS, not tiles: a tier's face url is frozen for the
+   *  class, so every tile of that tier shows the SAME url and (for a webm/mp4
+   *  loop) every one of them is its own decoder. Sixteen live 854x480 decodes
+   *  measured 79% of a GPU-process core on a 3060 Ti, and Scrolller's smallest
+   *  rendition IS 854x480 - the decoder COUNT is the only lever there is.
+   *  THE SHALLOWS ARE STILL, DEPTH IS ALIVE: tiers 1..SHALLOW_STILL_MAX_TIER
+   *  are the numerous ones (a board is mostly 1-3), so they always wear a
+   *  still; a loop is the reward for going deep, up to FACE_CAP tiers, and
+   *  past it the deep tiers wear stills too. */
+  FACE_CAP: 6,
+  SHALLOW_STILL_MAX_TIER: 3,
+  /** THE LITE RUNG (de_perf = lite, or auto's demote): half the loops, and the
+   *  shallows run five deep. Under a 4x CPU throttle even an all-stills board
+   *  fell to 40fps, so a weak machine needs a ladder, not a switch. */
+  FACE_CAP_LITE: 3,
+  SHALLOW_STILL_MAX_TIER_LITE: 5,
+
+  /** PASS 5 - THE AUTO PROBE. After the board is dealt we sample rAF deltas
+   *  for PERF_SAMPLE_MS, skipping PERF_WARMUP_MS of first-frame cost (style
+   *  injection, the first decodes, the opening spawn). A median over
+   *  PERF_MEDIAN_MS or more than PERF_SLOW_SHARE of frames over PERF_SLOW_MS
+   *  demotes the class to lite - ONCE, never back up: a class that flips its
+   *  own look twice is worse than a class that is simply lighter.
+   *  Dialled against a trace (0823): the deal window is the WORST window -
+   *  every new tier mints a decoder, and an RTX 3060 Ti showed 27-33% of
+   *  frames over 25ms in the first 3s of a deep test board while holding a
+   *  17ms median. A 500ms warm-up + 25% share demoted that box. So: warm up
+   *  past the decoder inits, sample longer, and demand that a share of slow
+   *  frames be a PATTERN (two in five) before it counts as evidence. */
+  PERF_WARMUP_MS: 2500,
+  PERF_SAMPLE_MS: 4000,
+  PERF_MIN_FRAMES: 20,
+  PERF_MEDIAN_MS: 20,
+  PERF_SLOW_MS: 25,
+  PERF_SLOW_SHARE: 0.4,
 
   /** Pass 3 - THE HAND: the drag distance (px) that leans the tiles all the
    *  way (--de-grab-x/y reach 1 here; style.js multiplies by --de-grab-max). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/schedule.js
@@ -95,6 +95,19 @@ export const PLAYTEST = Object.freeze({
    *  fell to 40fps, so a weak machine needs a ladder, not a switch. */
   FACE_CAP_LITE: 3,
   SHALLOW_STILL_MAX_TIER_LITE: 5,
+  /** THE TOUCH RUNG (PASS 6, the owner's iPhone 13 Pro Max, 2026-08-23), and it
+   *  is NOT a third quality level - it is a HARDWARE ceiling that applies on
+   *  FULL as well as on lite. iOS caps CONCURRENT HARDWARE VIDEO DECODE
+   *  SESSIONS (practically three or four before VideoToolbox starts thrashing
+   *  and every one of them stutters), and a phone pays several ms a frame for a
+   *  backdrop-filter or a blend surface that a desktop GPU eats for free. So a
+   *  touch device gets four animated tiers and stills five deep no matter what
+   *  rung it is on. It COMPOSES with the rung in the PROTECTIVE direction, so
+   *  touch never makes a lite board heavier: the animated-tier cap takes the
+   *  MIN (fewer decoders wins) and the still-shallows line takes the MAX (more
+   *  stills wins) - see faceCap()/shallowStillMaxTier() in index.js. */
+  FACE_CAP_TOUCH: 4,
+  SHALLOW_STILL_MAX_TIER_TOUCH: 4,
 
   /** PASS 5 - THE AUTO PROBE. After the board is dealt we sample rAF deltas
    *  for PERF_SAMPLE_MS, skipping PERF_WARMUP_MS of first-frame cost (style

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
@@ -66,10 +66,23 @@
  * cream. .g-de-depth chips share the same table.
  *
  * NOTHING IS EVER STILL (Law III): the backdrop breathes, caustics drift,
- * deep tiles shimmer, the marquee crawls. REDUCED MOTION twice over
+ * deep tiles glint, the marquee crawls. REDUCED MOTION twice over
  * (html.arc-reduced + the media query): only the slide transition survives.
  * .g-de-stage.suspended freezes every animation (animation-play-state) so A
  * can hold the pool's breath with the class.
+ *
+ * PASS 5 - THE DRIFT LAW + THE LITE RUNG (a Chromium trace: the GPU process's
+ * main thread at 79% of a core on a 3060 Ti, three roughly equal thirds - face
+ * render surfaces, full-screen re-raster, and 16 live 854x480 decodes).
+ *   PATTERNS DRIFT BY TRANSFORM, NEVER BY BACKGROUND-POSITION. A
+ *   background-position tween re-rasters the WHOLE layer every frame; a
+ *   transform is compositor-only. Every converted sheet is oversized by exactly
+ *   one tile period on its trailing edge and translated by exactly that period,
+ *   so the wrap lands on an identical pixel. Rays and vortex already rotated by
+ *   transform and were left alone.
+ *   A FACE IS FOUR BOXES AND THERE ARE 25 OF THEM: no isolation, no blend
+ *   mode, no filter on a <video>, and the ken-burns pan is for stills only.
+ *   .g-de-lite is the whole room one rung down (see the block near the bottom).
  * ==========================================================================*/
 
 const STYLE_ID = 'g-de-style';
@@ -159,8 +172,26 @@ export const STYLE_TEXT = `
 /* ---- the backdrop: the casino's lighting rig (decoration only) ----------- */
 .g-de-backdrop{position:absolute;inset:0;pointer-events:none;z-index:0;overflow:hidden}
 .g-de-backdrop *{pointer-events:none}
+/* =========================== THE DRIFT LAW (pass 5, measured) ==============
+   PATTERNS DRIFT BY TRANSFORM, NEVER BY BACKGROUND-POSITION (compositor-only;
+   a background-position tween re-rasters the whole layer every frame).
+   These sheets are full-screen. A 'to{background-position:...}' keyframe on one
+   of them is a full-viewport repaint at 60Hz, and the trace found SIX of them
+   running at once - a third of the GPU process's main thread went on nothing
+   but re-painting gradients that had not changed shape.
+   The shape every converted layer takes:
+     - one background layer per pseudo (::before / ::after). Two layers with
+       different tile sizes and different directions cannot share one transform.
+     - the pseudo is oversized by exactly one tile period IN THE DIRECTION OF
+       TRAVEL ('inset: top right bottom left'), so the vacated edge is always
+       already covered. '.g-de-backdrop' has overflow:hidden and does the clip.
+     - the keyframe translates by exactly ONE TILE PERIOD, so the wrap at 100%
+       lands on an identical pixel and the loop is seamless. An 'alternate'
+       layer is exempt (it walks back the way it came).
+   Rays and vortex already rotate by transform; they are untouched.
+   ======================================================================== */
 /* every family layer ken-burns on its own box (scale+pan), the pattern drifts
-   on its ::before (background-position / rotation) - two motions, no fight */
+   on its ::before / ::after (transform) - two motions, no fight */
 .g-de-bd{position:absolute;inset:-8%;opacity:0;
   animation:g-de-kb var(--de-n-kb,28s) ease-in-out infinite alternate}
 .g-de-bd::before{content:"";position:absolute;inset:0}
@@ -173,19 +204,25 @@ export const STYLE_TEXT = `
   animation:g-de-breathe calc(var(--de-breath) * (1 + var(--de-calm) * .8)) ease-in-out infinite alternate}
 @keyframes g-de-breathe{from{opacity:.55;transform:scaleY(1)}to{opacity:1;transform:scaleY(1.08)}}
 
-/* bands: rippling light bands at the seed's tilt, two counter-drifting sheets */
+/* bands: rippling light bands at the seed's tilt, two counter-drifting sheets.
+   THE DRIFT LAW: one sheet per pseudo, each oversized by its own tile period on
+   the trailing edges and translated by exactly that period. */
 .g-de-bd-bands{opacity:var(--de-n-a-bands,0)}
-.g-de-bd-bands::before{
-  background:
-    repeating-linear-gradient(calc(var(--de-n-tilt,-18) * 1deg), transparent 0,
-      var(--de-la) calc(18px * var(--de-n-scale,1)), transparent calc(40px * var(--de-n-scale,1)),
-      transparent calc(64px * var(--de-n-scale,1))),
-    repeating-linear-gradient(calc(var(--de-n-tilt,-18) * 1deg + 7deg), transparent 0,
-      var(--de-lb) calc(26px * var(--de-n-scale,1)), transparent calc(54px * var(--de-n-scale,1)),
-      transparent calc(92px * var(--de-n-scale,1)));
-  background-size:220px 220px, 340px 340px;
-  animation:g-de-bands var(--de-drift) linear infinite}
-@keyframes g-de-bands{to{background-position:220px 160px, -340px 240px}}
+.g-de-bd-bands::after{content:"";position:absolute}
+.g-de-bd-bands::before{inset:-220px 0 0 -220px;
+  background:repeating-linear-gradient(calc(var(--de-n-tilt,-18) * 1deg), transparent 0,
+    var(--de-la) calc(18px * var(--de-n-scale,1)), transparent calc(40px * var(--de-n-scale,1)),
+    transparent calc(64px * var(--de-n-scale,1)));
+  background-size:220px 220px;
+  animation:g-de-bands-a var(--de-drift) linear infinite}
+@keyframes g-de-bands-a{from{transform:translate3d(0,0,0)}to{transform:translate3d(220px,220px,0)}}
+.g-de-bd-bands::after{inset:-340px -340px 0 0;
+  background:repeating-linear-gradient(calc(var(--de-n-tilt,-18) * 1deg + 7deg), transparent 0,
+    var(--de-lb) calc(26px * var(--de-n-scale,1)), transparent calc(54px * var(--de-n-scale,1)),
+    transparent calc(92px * var(--de-n-scale,1)));
+  background-size:340px 340px;
+  animation:g-de-bands-b var(--de-drift) linear infinite}
+@keyframes g-de-bands-b{from{transform:translate3d(0,0,0)}to{transform:translate3d(-340px,340px,0)}}
 
 /* rays: god-rays from the surface, swaying */
 .g-de-bd-rays{opacity:var(--de-n-a-rays,0)}
@@ -198,17 +235,22 @@ export const STYLE_TEXT = `
 @keyframes g-de-sway{from{transform:rotate(-2.5deg)}to{transform:rotate(2.5deg)}}
 
 /* lens: overlapping caustic nets - two ring fields a hair out of phase, so the
-   moire reads as light on a pool floor */
+   moire reads as light on a pool floor. Both sheets ALTERNATE, so they walk
+   back the way they came and the travel need not be a whole tile period. */
 .g-de-bd-lens{opacity:var(--de-n-a-lens,0)}
-.g-de-bd-lens::before{
-  background:
-    repeating-radial-gradient(circle at 30% 40%, transparent 0 calc(22px * var(--de-n-scale,1)),
-      var(--de-la) calc(24px * var(--de-n-scale,1)), transparent calc(28px * var(--de-n-scale,1))),
-    repeating-radial-gradient(circle at 70% 60%, transparent 0 calc(25px * var(--de-n-scale,1)),
-      var(--de-lb) calc(27px * var(--de-n-scale,1)), transparent calc(31px * var(--de-n-scale,1)));
-  background-size:300px 300px, 360px 360px;mix-blend-mode:screen;
-  animation:g-de-lens var(--de-drift) ease-in-out infinite alternate}
-@keyframes g-de-lens{to{background-position:60px 40px, -50px 70px}}
+.g-de-bd-lens::after{content:"";position:absolute}
+.g-de-bd-lens::before{inset:-40px 0 0 -60px;mix-blend-mode:screen;
+  background:repeating-radial-gradient(circle at 30% 40%, transparent 0 calc(22px * var(--de-n-scale,1)),
+    var(--de-la) calc(24px * var(--de-n-scale,1)), transparent calc(28px * var(--de-n-scale,1)));
+  background-size:300px 300px;
+  animation:g-de-lens-a var(--de-drift) ease-in-out infinite alternate}
+@keyframes g-de-lens-a{from{transform:translate3d(0,0,0)}to{transform:translate3d(60px,40px,0)}}
+.g-de-bd-lens::after{inset:-70px -50px 0 0;mix-blend-mode:screen;
+  background:repeating-radial-gradient(circle at 70% 60%, transparent 0 calc(25px * var(--de-n-scale,1)),
+    var(--de-lb) calc(27px * var(--de-n-scale,1)), transparent calc(31px * var(--de-n-scale,1)));
+  background-size:360px 360px;
+  animation:g-de-lens-b var(--de-drift) ease-in-out infinite alternate}
+@keyframes g-de-lens-b{from{transform:translate3d(0,0,0)}to{transform:translate3d(-50px,70px,0)}}
 
 /* vortex: a slow turning whirl, masked to a soft disc, seed-signed spin */
 .g-de-bd-vortex{opacity:var(--de-n-a-vortex,0)}
@@ -220,15 +262,22 @@ export const STYLE_TEXT = `
   animation:g-de-spin calc(var(--de-drift) * 3) linear infinite}
 @keyframes g-de-spin{to{transform:rotate(calc(var(--de-n-spindir,1) * 360deg))}}
 
-/* motes: two drifting sheets of specks rising through the water */
+/* motes: two drifting sheets of specks rising through the water. The rise is
+   exactly one tile height per cycle (110px / 170px), which is what makes the
+   wrap invisible; the old few-pixel sideways drift is gone with the
+   background-position tween, and the two speeds still read as parallax. */
 .g-de-bd-motes{opacity:var(--de-n-a-motes,0)}
-.g-de-bd-motes::before{
-  background:
-    radial-gradient(circle, var(--de-la) 0 1.5px, transparent 2.5px),
-    radial-gradient(circle, var(--de-lb) 0 1px, transparent 2px);
-  background-size:90px 110px, 140px 170px;background-position:0 0, 40px 60px;
-  animation:g-de-motes calc(var(--de-drift) * 1.4) linear infinite}
-@keyframes g-de-motes{to{background-position:10px -110px, 60px -170px}}
+.g-de-bd-motes::after{content:"";position:absolute}
+.g-de-bd-motes::before{inset:0 0 -110px 0;
+  background:radial-gradient(circle, var(--de-la) 0 1.5px, transparent 2.5px);
+  background-size:90px 110px;
+  animation:g-de-motes-a calc(var(--de-drift) * 1.4) linear infinite}
+@keyframes g-de-motes-a{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-110px,0)}}
+.g-de-bd-motes::after{inset:0 0 -170px 0;
+  background:radial-gradient(circle, var(--de-lb) 0 1px, transparent 2px);
+  background-size:140px 170px;background-position:40px 60px;
+  animation:g-de-motes-b calc(var(--de-drift) * 1.9) linear infinite}
+@keyframes g-de-motes-b{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-170px,0)}}
 
 /* the dark: depth dims the room (newDeepest steps it), and a payout flash */
 .g-de-bd-dark{inset:0;opacity:calc(var(--de-n-depth,0) * .62);background:#000;animation:none}
@@ -417,9 +466,9 @@ export const STYLE_TEXT = `
 @keyframes g-de-traily{0%{opacity:0;transform:scaleY(.1)}35%{opacity:.75;transform:scaleY(1)}100%{opacity:0;transform:scaleY(1)}}
 .g-de-tile.is-sliding:not(.is-merged)::before{transform-origin:50% 50%}
 .g-de-tile.is-sliding-x:not(.is-merged):not(.is-silt)::before{
-  animation:g-de-sheen 5.5s ease-in-out infinite, g-de-deepbreath 2.6s ease-in-out infinite alternate, g-de-stretchx .32s cubic-bezier(.3,.7,.3,1) 1}
+  animation:g-de-deepbreath 2.6s ease-in-out infinite alternate, g-de-stretchx .32s cubic-bezier(.3,.7,.3,1) 1}
 .g-de-tile.is-sliding-y:not(.is-merged):not(.is-silt)::before{
-  animation:g-de-sheen 5.5s ease-in-out infinite, g-de-deepbreath 2.6s ease-in-out infinite alternate, g-de-stretchy .32s cubic-bezier(.3,.7,.3,1) 1}
+  animation:g-de-deepbreath 2.6s ease-in-out infinite alternate, g-de-stretchy .32s cubic-bezier(.3,.7,.3,1) 1}
 .g-de-tile.is-sliding-x.is-silt::before{animation:g-de-stretchx .32s cubic-bezier(.3,.7,.3,1) 1}
 .g-de-tile.is-sliding-y.is-silt::before{animation:g-de-stretchy .32s cubic-bezier(.3,.7,.3,1) 1}
 @keyframes g-de-stretchx{0%{transform:scale(1)}40%{transform:scale(1.07,.94)}78%{transform:scale(.965,1.03)}100%{transform:scale(1)}}
@@ -444,33 +493,58 @@ export const STYLE_TEXT = `
   box-shadow:0 13px 28px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.18),
     0 0 var(--de-t-glowr,0px) var(--de-t-glow,transparent)}
 
-/* ---- pass 2: MEDIA FACES ------------------------------------------------- */
-/* .g-de-face clips the media to the body (the tile itself stays overflow-
-   visible for the ripple and the trail); ::before darkens + vignettes by tier,
-   ::after tints in the tier hue (mix-blend-mode: color keeps the picture's
-   light and takes the tier's colour - the colour IS the clarity). index.js adds
-   .is-loaded once the <img> has a frame; until then the plain body shows. */
-.g-de-face{position:absolute;inset:0;z-index:0;border-radius:10px;overflow:hidden;isolation:isolate;
+/* ---- pass 2: MEDIA FACES (pass 5: composited cheap) ----------------------- */
+/* THE FACE COMPOSITING LAW (pass 5, measured). A face is FOUR boxes per tile
+   and there are up to 25 of them. Anything on a face that forces its own
+   render surface is paid 25x, every frame:
+     - 'isolation:isolate' made every face a surface for the sake of ONE blend.
+     - 'mix-blend-mode:color' on the tint made a SECOND one, and a blend surface
+       has to read back what is underneath it before it can write.
+     - 'filter:' on a <video> is a full GPU pass over a decoded 854x480 frame,
+       per tile, per frame - the single most expensive line in the file.
+   The trace put ~86 render surfaces on one board and a third of a GPU core on
+   compositing them. So: no isolation, no blend, no filter. The tint is now a
+   PLAIN ALPHA wash whose opacity is dialled per tier band, and the deep-tier
+   desaturate/darken is baked into the ::before wash gradient instead of being
+   computed from the picture. The colour still IS the clarity - it is just
+   painted over the picture instead of blended into it.
+   .g-de-face still clips the media to the body (border-radius + overflow is a
+   fast path, no surface of its own); the tile stays overflow-visible for the
+   ripple and the trail. index.js adds .is-loaded once the media has a frame. */
+.g-de-face{position:absolute;inset:0;z-index:0;border-radius:10px;overflow:hidden;
   pointer-events:none;opacity:0;transition:opacity .45s ease}
 .g-de-tile.is-loaded .g-de-face{opacity:1}
-.g-de-media{display:block;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;pointer-events:none;
-  animation:g-de-facekb 16s ease-in-out infinite alternate;animation-delay:calc(var(--de-kbp,0) * -16s)}
+.g-de-media{display:block;position:absolute;inset:0;width:100%;height:100%;object-fit:cover;pointer-events:none}
+/* THE KEN-BURNS IS FOR STILLS ONLY. A <video> already moves; panning it as
+   well bought nothing and cost a composited transform on a live decode. The
+   selector is 'img.g-de-media' on purpose - it beats the bare class, so the
+   <video> swap in index.js drops the animation with no extra bookkeeping. */
+img.g-de-media{animation:g-de-facekb 16s ease-in-out infinite alternate;
+  animation-delay:calc(var(--de-kbp,0) * -16s)}
 @keyframes g-de-facekb{from{transform:scale(1) translate(0,0)}to{transform:scale(1.1) translate(-2%,1.5%)}}
 /* ::before is the WASH: the shallows (1-3) get a pale tier-coloured wash that
    LIGHTENS the picture toward surface light; from tier 4 down it is a dark
-   vignette that grows with depth. ::after re-hues whatever is left. */
+   vignette that grows with depth, and from tier 8 it carries the darkening the
+   <video> filter used to do. ::after is the flat tier tint over the top. */
 .g-de-face::before{content:"";position:absolute;inset:0;z-index:1;opacity:var(--de-f-vig,.55);
   background:var(--de-f-wash, linear-gradient(160deg, var(--de-t-bg,var(--lav)), var(--de-t-bg2,var(--lav))))}
-.g-de-face::after{content:"";position:absolute;inset:0;z-index:2;mix-blend-mode:color;opacity:var(--de-f-tint,.85);
+.g-de-face::after{content:"";position:absolute;inset:0;z-index:2;opacity:var(--de-f-tint,.45);
   background:linear-gradient(160deg, var(--de-t-bg,var(--lav)), var(--de-t-bg2,var(--lav)))}
-.g-de-stage [data-tier="4"],.g-de-stage [data-tier="5"],.g-de-stage [data-tier="6"]{--de-f-vig:.38;
+/* THE TINT LADDER. A 'color' blend at .85 kept the picture's luminance; a plain
+   alpha at .85 would erase it. These are the alphas that read as the same tier
+   hue while the picture survives - shallow tiles stay legible, deep tiles drown
+   on purpose, and the step between bands is what the eye reads as depth. */
+.g-de-stage [data-tier="4"],.g-de-stage [data-tier="5"],.g-de-stage [data-tier="6"]{--de-f-vig:.38;--de-f-tint:.40;
   --de-f-wash:radial-gradient(80% 80% at 50% 45%, transparent 40%, rgba(0,0,0,.9) 100%)}
-.g-de-stage [data-tier="7"],.g-de-stage [data-tier="8"],.g-de-stage [data-tier="9"]{--de-f-vig:.55;--de-f-tint:.9;
+.g-de-stage [data-tier="7"],.g-de-stage [data-tier="8"],.g-de-stage [data-tier="9"]{--de-f-vig:.55;--de-f-tint:.50;
   --de-f-wash:radial-gradient(80% 80% at 50% 45%, transparent 35%, rgba(0,0,0,.95) 100%)}
-.g-de-stage [data-tier="10"],.g-de-stage [data-tier="11"]{--de-f-vig:.72;--de-f-tint:.95;
-  --de-f-wash:radial-gradient(80% 80% at 50% 45%, rgba(0,0,0,.2) 30%, #000 100%)}
-.g-de-tile[data-tier="8"] .g-de-media,.g-de-tile[data-tier="9"] .g-de-media,
-.g-de-tile[data-tier="10"] .g-de-media,.g-de-tile[data-tier="11"] .g-de-media{filter:saturate(.35) brightness(.62)}
+/* 8-11 used to wear filter:saturate(.35) brightness(.62) ON THE <video>. The
+   same read, for free: a heavier vignette that starts opaque at the centre
+   instead of transparent, plus more tint over it. Grey and dark, no GPU pass. */
+.g-de-stage [data-tier="8"],.g-de-stage [data-tier="9"]{--de-f-vig:.68;--de-f-tint:.56;
+  --de-f-wash:radial-gradient(80% 80% at 50% 45%, rgba(0,0,0,.34) 28%, rgba(0,0,0,.97) 100%)}
+.g-de-stage [data-tier="10"],.g-de-stage [data-tier="11"]{--de-f-vig:.8;--de-f-tint:.62;
+  --de-f-wash:radial-gradient(80% 80% at 50% 45%, rgba(0,0,0,.5) 24%, #000 100%)}
 
 /* ---- the glyph: drawn, never typed ---------------------------------------- */
 /* The per-tier ring rules are generated above (glyphRules). The base box is a
@@ -518,11 +592,19 @@ ${glyphRules()}
   text-shadow:0 0 .1em #fff, 0 0 .35em #fff, 0 0 .7em var(--de-t-rim), 0 0 1.4em var(--de-t-glow), 0 0 2.4em var(--de-t-glow);
   animation:g-de-namepulse 1.6s ease-in-out infinite alternate}
 @keyframes g-de-namepulse{from{transform:scale(1);filter:brightness(1)}to{transform:scale(1.05);filter:brightness(1.35)}}
+/* THE DRIFT LAW, name-plate edition: the CRT bar used to sweep by tweening
+   background-position over a 300%-tall gradient. Translating it instead needs a
+   clipping box, and the only candidate is .g-de-name itself - which cannot take
+   overflow:hidden, because the tier-10/11 FX ladder IS its 2.4em text-shadow
+   bloom and a clip would eat it. (A wrapper element is out too: .g-de-name is
+   the trickster's one lie target and index.js repaints it with textContent,
+   which would delete any child.) So the bar holds still and BREATHES - opacity
+   is compositor-only, the raster happens once. */
 .g-de-tile[data-tier="10"] .g-de-name::after,.g-de-tile[data-tier="11"] .g-de-name::after{content:"";position:absolute;inset:0;
   pointer-events:none;border-radius:inherit;
   background:linear-gradient(to bottom, transparent 0 42%, rgba(255,255,255,.3) 50%, transparent 58% 100%);
-  background-size:100% 300%;animation:g-de-scan 2.4s linear infinite}
-@keyframes g-de-scan{from{background-position:0 0}to{background-position:0 100%}}
+  animation:g-de-scan 2.4s ease-in-out infinite}
+@keyframes g-de-scan{0%,100%{opacity:.12}50%{opacity:1}}
 /* a merge pops the new name in scale only - readable within the first frames */
 .g-de-tile.is-merged .g-de-name{animation:g-de-namepop .42s cubic-bezier(.2,1.3,.4,1) 1}
 @keyframes g-de-namepop{0%{transform:scale(1.22)}100%{transform:scale(1)}}
@@ -554,16 +636,22 @@ ${glyphRules()}
   --de-t-ink:var(--ink);--de-t-rim:var(--pink);--de-t-glow:color-mix(in srgb, var(--pink), transparent 45%);--de-t-glowr:26px}
 .g-de-stage [data-tier="11"]{--de-t-bg:color-mix(in srgb, var(--ground) 35%, black);--de-t-bg2:#000;
   --de-t-ink:var(--ink);--de-t-rim:var(--gold);--de-t-glow:color-mix(in srgb, var(--gold), transparent 40%);--de-t-glowr:30px}
-/* deep tiles shimmer: a sheen crawls the body (Law III, tiers 8+) */
+/* deep tiles carry a glint on the body (Law III, tiers 8+).
+   THE DRIFT LAW, tile edition: this used to be 'g-de-sheen', a
+   background-position crawl across a 260%-wide highlight. On a tile the raster
+   is small, but it ran on EVERY deep body and it ran forever, and there is no
+   box here that could clip a translating layer - the body IS a ::before, and a
+   pseudo cannot own a pseudo. So the glint is now FIXED and the motion comes
+   from the animations the deep tiles already had: the deepest tile breathes
+   (g-de-deepbreath, inherited from the base .is-deepest rule now that this one
+   no longer overrides 'animation'), the name runs its own tier FX, and the face
+   moves on its own. Adding a per-tile <i> just to keep a crawl that a loaded
+   face covers anyway would have spent render objects to save raster. */
 .g-de-tile[data-tier="8"]::before,.g-de-tile[data-tier="9"]::before,
 .g-de-tile[data-tier="10"]::before,.g-de-tile[data-tier="11"]::before{
   background-image:linear-gradient(115deg, transparent 30%, rgba(255,255,255,.09) 45%, transparent 60%),
     linear-gradient(160deg, var(--de-t-bg,var(--lav)), var(--de-t-bg2,var(--lav)));
-  background-size:260% 100%, 100% 100%;animation:g-de-sheen 5.5s ease-in-out infinite}
-.g-de-tile.is-deepest[data-tier="8"]::before,.g-de-tile.is-deepest[data-tier="9"]::before,
-.g-de-tile.is-deepest[data-tier="10"]::before,.g-de-tile.is-deepest[data-tier="11"]::before{
-  animation:g-de-sheen 5.5s ease-in-out infinite, g-de-deepbreath 2.6s ease-in-out infinite alternate}
-@keyframes g-de-sheen{0%{background-position:120% 0, 0 0}100%{background-position:-60% 0, 0 0}}
+  background-size:260% 100%, 100% 100%;background-position:38% 0, 0 0}
 
 /* ---- the shell's stamp, when index.js targets the bench ---------------------
    ceremonies.stamp({target: bench}) appends the stamp IN FLOW, which in a flex
@@ -628,25 +716,39 @@ ${glyphRules()}
 /* ---- CASINO (House Rules, Deck II) --------------------------------------- */
 /* THE MARQUEE: a bulb-chase frame around the BOARD (mounted in the bench,
    sized from --de-board so it hugs the square). Dots are gradients, the chase
-   is a background-position crawl - four thin bars. pointer-events:none is
+   was a background-position crawl - four thin bars. THE DRIFT LAW: the bar is
+   now a CLIP (overflow:hidden) and the dots live on its ::before, oversized by
+   one dot pitch on the trailing edge and translated by exactly that pitch, so
+   the chase is compositor-only and the wrap is invisible. pointer-events:none is
    LAW. Pace (--g-de-mqt) and presence (--g-de-mqa) ride the class heat from
    casino.js; the bell and the ceiling turn it gold. */
 .g-de-mq{position:absolute;left:50%;top:50%;z-index:0;pointer-events:none;
   width:calc(var(--de-board) + 26px);height:calc(var(--de-board) + 26px);
   transform:translate(-50%,-50%);border-radius:20px;
   opacity:var(--g-de-mqa,.26);transition:opacity .6s ease}
-.g-de-mq i{position:absolute;display:block;
+.g-de-mq i{position:absolute;display:block;overflow:hidden}
+.g-de-mq i::before{content:"";position:absolute;
   background-image:radial-gradient(circle, var(--de-n-mq,var(--lav)) 2px, transparent 3px)}
-.g-de-mq .mq-t,.g-de-mq .mq-b{left:0;right:0;height:7px;background-size:18px 7px;background-repeat:repeat-x}
-.g-de-mq .mq-l,.g-de-mq .mq-r{top:0;bottom:0;width:7px;background-size:7px 18px;background-repeat:repeat-y}
-.g-de-mq .mq-t{top:0;animation:g-de-mqx var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
-.g-de-mq .mq-r{right:0;animation:g-de-mqy var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
-.g-de-mq .mq-b{bottom:0;animation:g-de-mqxr var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
-.g-de-mq .mq-l{left:0;animation:g-de-mqyr var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
-@keyframes g-de-mqx{to{background-position-x:18px}}
-@keyframes g-de-mqxr{to{background-position-x:-18px}}
-@keyframes g-de-mqy{to{background-position-y:18px}}
-@keyframes g-de-mqyr{to{background-position-y:-18px}}
+.g-de-mq .mq-t,.g-de-mq .mq-b{left:0;right:0;height:7px}
+.g-de-mq .mq-l,.g-de-mq .mq-r{top:0;bottom:0;width:7px}
+/* the sheet is one dot pitch (18px) longer at BOTH ends: the phase shift of a
+   whole pitch is invisible, and the extra covers the vacated end all cycle */
+.g-de-mq .mq-t::before,.g-de-mq .mq-b::before{top:0;bottom:0;left:-18px;right:-18px;
+  background-size:18px 7px;background-repeat:repeat-x}
+.g-de-mq .mq-l::before,.g-de-mq .mq-r::before{left:0;right:0;top:-18px;bottom:-18px;
+  background-size:7px 18px;background-repeat:repeat-y}
+.g-de-mq .mq-t{top:0}
+.g-de-mq .mq-r{right:0}
+.g-de-mq .mq-b{bottom:0}
+.g-de-mq .mq-l{left:0}
+.g-de-mq .mq-t::before{animation:g-de-mqx var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
+.g-de-mq .mq-r::before{animation:g-de-mqy var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
+.g-de-mq .mq-b::before{animation:g-de-mqxr var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
+.g-de-mq .mq-l::before{animation:g-de-mqyr var(--g-de-mqt,2s) linear infinite var(--g-de-mqp,0s)}
+@keyframes g-de-mqx{from{transform:translate3d(0,0,0)}to{transform:translate3d(18px,0,0)}}
+@keyframes g-de-mqxr{from{transform:translate3d(0,0,0)}to{transform:translate3d(-18px,0,0)}}
+@keyframes g-de-mqy{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,18px,0)}}
+@keyframes g-de-mqyr{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-18px,0)}}
 .g-de-mq.g-de-mq-bell{--de-n-mq:var(--gold);filter:drop-shadow(0 0 6px rgba(240,194,75,.75))}
 .g-de-mq.g-de-mq-flash{animation:g-de-mqflash .6s ease-out 1}
 @keyframes g-de-mqflash{
@@ -778,6 +880,26 @@ ${glyphRules()}
    "never moved"), then the class drops and the 110ms slide carries it home. */
 .g-de-tile.g-de-lie{transition:opacity .22s ease,filter .22s ease}
 
+/* ---- pass 5: THE LITE RUNG (.g-de-lite on the stage) ---------------------
+   'de_perf' = lite, or 'auto' after the rAF probe demoted the class, or reduced
+   motion / motionLevel <= 1. index.js also puts '.ae-lite' on <html> so the
+   ENGINE's own sheet can lighten in the same breath. This is NOT reduced
+   motion: the room still moves, it just stops asking the raster and the video
+   decoder for things a weak machine cannot pay for.
+     - the backdrop pattern sheets hold still (each one is a full-screen layer)
+     - the tile faces stop panning (a composited transform per live media node)
+     - the deep-tier glint and the name scan hold still
+   Under a 4x CPU throttle even an all-stills board fell to 40fps, so the fix
+   has to be the WHOLE frame's budget, not just the videos. */
+.g-de-lite .g-de-bd-bands::before,.g-de-lite .g-de-bd-bands::after,
+.g-de-lite .g-de-bd-lens::before,.g-de-lite .g-de-bd-lens::after,
+.g-de-lite .g-de-bd-motes::before,.g-de-lite .g-de-bd-motes::after,
+.g-de-lite .g-de-bd-rays::before,.g-de-lite .g-de-bd-vortex::before,
+.g-de-lite .g-de-bd-veil::before{animation:none}
+.g-de-lite .g-de-bd{animation:none}
+.g-de-lite img.g-de-media{animation:none}
+.g-de-lite .g-de-tile .g-de-name::after{animation:none;opacity:.35}
+
 /* ---- reduced motion: the mechanic survives, the motion does not ---------- */
 html.arc-reduced .g-de-stage *{animation:none !important}
 html.arc-reduced .g-de-stage{transition:none}
@@ -906,6 +1028,148 @@ html.arc-reduced .g-de-p-glitch.is-on{backdrop-filter:none;-webkit-backdrop-filt
 @media (prefers-reduced-motion: reduce){
   .g-de-p-pin.is-on{opacity:calc(var(--de-p-pa,.3) * .6)}
   .g-de-p-glitch.is-on{backdrop-filter:none;-webkit-backdrop-filter:none}
+}
+
+/* ---- THE CLASS RULES SHEET (Deck VI, Law IV: drawn, not told) ------------ */
+/* Four vignettes over the dark water, cut from the same tile chrome the board
+   uses: because the sheet lives INSIDE .g-de-stage, every .g-de-hw-tile picks
+   up the depth palette from the shared [data-tier] block below - one place
+   owns the colour of a depth, here included. The sheet takes NO pointer events
+   (no key is bound and no dive is dealt while it is up, and a stray click must
+   never count as "read"); the GO button takes its own back and is the ONLY
+   dismissal. z 9 sits above the bench and the HUD and far below the shell's
+   suspend treatment (35), which must always be able to cover it. */
+.g-de-howto{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:9;
+  width:min(540px,92vw);max-height:86vh;overflow:auto;pointer-events:none;
+  display:flex;flex-direction:column;gap:2px;padding:20px 22px 18px;border-radius:14px;
+  color:var(--ink);
+  background:linear-gradient(180deg, rgba(12,14,34,.95), rgba(6,8,22,.97));
+  border:1px solid color-mix(in srgb, var(--lav), transparent 68%);
+  box-shadow:0 30px 80px rgba(0,0,0,.62), 0 0 44px rgba(184,166,232,.12);
+  animation:g-de-hw-in .34s ease-out 1}
+@keyframes g-de-hw-in{from{opacity:0;transform:translate(-50%,-46%)}
+  to{opacity:1;transform:translate(-50%,-50%)}}
+.g-de-hw-title{margin:0 0 8px;text-align:center;font-family:var(--disp);
+  font-size:clamp(15px,2.3vmin,19px);letter-spacing:.2em;text-transform:uppercase;
+  color:var(--lav);text-shadow:0 0 22px rgba(184,166,232,.5)}
+.g-de-hw-row{display:flex;align-items:center;gap:16px;padding:10px 2px}
+.g-de-hw-row + .g-de-hw-row{border-top:1px dashed color-mix(in srgb, var(--line), transparent 35%)}
+.g-de-hw-fig{flex:0 0 auto;display:flex;align-items:center;gap:9px;pointer-events:none}
+.g-de-hw-cap{margin:0;flex:1 1 auto;font-size:12.5px;line-height:1.5;color:var(--ink-dim)}
+
+/* one mini tile: the board's own gradient, rim and numeral, at sheet scale */
+.g-de-hw-tile{position:relative;display:flex;align-items:center;justify-content:center;
+  width:26px;height:26px;border-radius:6px;flex:0 0 auto;
+  background:linear-gradient(160deg, var(--de-t-bg,var(--lav)), var(--de-t-bg2,var(--lav)));
+  border:1px solid color-mix(in srgb, var(--de-t-rim,var(--lav)), transparent 30%);
+  box-shadow:0 2px 8px rgba(0,0,0,.5), 0 0 var(--de-t-glowr,0px) var(--de-t-glow,transparent)}
+.g-de-hw-num{font-family:var(--disp);font-size:11px;line-height:1;
+  color:var(--de-t-ink,var(--ground))}
+
+/* 1 - the swipe: the pad points, the whole line slides the way it points */
+.g-de-hw-pad{position:relative;display:block;width:34px;height:34px;flex:0 0 auto}
+.g-de-hw-arrow{position:absolute;width:0;height:0;border:5px solid transparent}
+.g-de-hw-arrow.up{left:50%;top:0;margin-left:-5px;border-bottom-color:var(--lav)}
+.g-de-hw-arrow.down{left:50%;bottom:0;margin-left:-5px;border-top-color:var(--lav)}
+.g-de-hw-arrow.left{left:0;top:50%;margin-top:-5px;border-right-color:var(--lav)}
+.g-de-hw-arrow.right{right:0;top:50%;margin-top:-5px;border-left-color:var(--lav);
+  filter:drop-shadow(0 0 6px rgba(184,166,232,.9));
+  animation:g-de-hw-point 3.2s ease-in-out infinite}
+@keyframes g-de-hw-point{0%,14%{opacity:.45;transform:translateX(0)}
+  30%,74%{opacity:1;transform:translateX(3px)}100%{opacity:.45;transform:translateX(0)}}
+.g-de-hw-line{display:flex;gap:4px;padding:3px;border-radius:7px;
+  border:1px solid color-mix(in srgb, var(--line), transparent 30%);
+  background:rgba(6,10,26,.6);overflow:hidden}
+.g-de-hw-line.slide .g-de-hw-tile{animation:g-de-hw-slide 3.2s cubic-bezier(.22,.9,.3,1) infinite;
+  animation-delay:calc(var(--de-hw-i,0) * .05s)}
+@keyframes g-de-hw-slide{0%,18%{transform:translateX(0)}
+  40%,76%{transform:translateX(9px)}100%{transform:translateX(0)}}
+
+/* 2 - the merge: two equal tiles close, and one comes back a depth further */
+.g-de-hw-scene{position:relative;display:block;width:84px;height:34px;flex:0 0 auto}
+.g-de-hw-tile.mrg{position:absolute;top:4px}
+.g-de-hw-tile.mrg.a{left:2px;animation:g-de-hw-mrgA 3.2s ease-in-out infinite}
+.g-de-hw-tile.mrg.b{right:2px;animation:g-de-hw-mrgB 3.2s ease-in-out infinite}
+.g-de-hw-tile.mrg.out{left:50%;margin-left:-13px;opacity:0;
+  animation:g-de-hw-mrgOut 3.2s ease-out infinite}
+/* THE HAND-OFF IS SEAMLESS ON PURPOSE: at every instant either the two source
+   tiles or the merged one is on screen, so a still of this sheet (a headless
+   shot, a reduced-motion reader, a paused frame) is never a blank figure. */
+@keyframes g-de-hw-mrgA{0%,14%{transform:translateX(0);opacity:1}
+  40%,43%{transform:translateX(27px);opacity:1}
+  44%,71%{transform:translateX(27px);opacity:0}
+  71.5%,100%{transform:translateX(0);opacity:1}}
+@keyframes g-de-hw-mrgB{0%,14%{transform:translateX(0);opacity:1}
+  40%,43%{transform:translateX(-27px);opacity:1}
+  44%,71%{transform:translateX(-27px);opacity:0}
+  71.5%,100%{transform:translateX(0);opacity:1}}
+@keyframes g-de-hw-mrgOut{0%,43%{opacity:0;transform:scale(.7)}
+  50%{opacity:1;transform:scale(1.2)}58%,71%{opacity:1;transform:scale(1)}
+  71.5%,100%{opacity:0;transform:scale(1)}}
+
+/* 3 - the resurface: the jam drains, the gauge keeps the mark, water refills */
+.g-de-hw-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:4px;padding:4px;
+  border-radius:7px;border:1px solid color-mix(in srgb, var(--line), transparent 30%);
+  background:rgba(6,10,26,.6)}
+.g-de-hw-tile.drain{width:22px;height:22px;
+  animation:g-de-hw-drain 3.6s ease-in-out infinite;
+  animation-delay:calc(var(--de-hw-i,0) * .08s)}
+@keyframes g-de-hw-drain{0%,34%{opacity:1;transform:translateY(0)}
+  50%{opacity:0;transform:translateY(9px)}
+  66%,100%{opacity:1;transform:translateY(0)}}
+.g-de-hw-gauge{position:relative;display:block;width:8px;height:34px;flex:0 0 auto;
+  border-radius:4px;overflow:hidden;background:rgba(184,166,232,.14);
+  border:1px solid color-mix(in srgb, var(--lav), transparent 65%)}
+.g-de-hw-gauge i{position:absolute;left:0;right:0;bottom:0;display:block;height:38%;
+  background:linear-gradient(180deg,var(--pink),var(--lav));
+  animation:g-de-hw-bank 3.6s ease-out infinite}
+@keyframes g-de-hw-bank{0%,34%{height:38%}52%{height:62%}100%{height:62%}}
+
+/* 4 - the ceiling: eleven rungs, and the one the ladder stops on */
+.g-de-hw-ladder{display:flex;flex-direction:column-reverse;gap:2px;flex:0 0 auto}
+.g-de-hw-ladder i{display:block;width:20px;height:4px;border-radius:2px;
+  background:color-mix(in srgb, var(--de-t-rim,var(--lav)), transparent 45%);
+  opacity:.3;animation:g-de-hw-rung 4s ease-in-out infinite;
+  animation-delay:calc(var(--de-hw-i,0) * .12s)}
+@keyframes g-de-hw-rung{0%,10%{opacity:.28}40%,86%{opacity:1}100%{opacity:.28}}
+.g-de-hw-ladder i.top{height:6px;box-shadow:0 0 10px var(--de-t-glow,var(--gold))}
+.g-de-hw-tile.ceil{width:30px;height:30px;
+  animation:g-de-hw-ceil 4s ease-in-out infinite}
+@keyframes g-de-hw-ceil{0%,40%{opacity:.25;transform:scale(.86)}
+  56%,86%{opacity:1;transform:scale(1)}100%{opacity:.25;transform:scale(.86)}}
+
+/* the ONE live thing on the sheet, and the only way past it */
+.g-de-hw-go{align-self:center;margin-top:8px;padding:9px 30px;cursor:pointer;
+  pointer-events:auto;border-radius:9px;font-family:var(--disp);font-size:13px;
+  letter-spacing:.16em;text-transform:uppercase;color:var(--ground);
+  background:linear-gradient(180deg,var(--lav),#6E5F9B);
+  border:1px solid var(--lav);box-shadow:0 0 22px rgba(184,166,232,.42)}
+.g-de-hw-go:hover{box-shadow:0 0 34px rgba(184,166,232,.64)}
+.g-de-hw-go:focus-visible{outline:2px solid var(--gold);outline-offset:2px}
+
+/* REDUCED MOTION: the sheet must still TEACH as a still, so the end states of
+   the four vignettes are pinned rather than left mid-keyframe. */
+html.arc-reduced .g-de-howto,html.arc-reduced .g-de-hw-tile,html.arc-reduced .g-de-hw-arrow,
+html.arc-reduced .g-de-hw-gauge i,html.arc-reduced .g-de-hw-ladder i{animation:none !important}
+html.arc-reduced .g-de-hw-tile.mrg.a,html.arc-reduced .g-de-hw-tile.mrg.b{opacity:0}
+html.arc-reduced .g-de-hw-tile.mrg.out{opacity:1}
+html.arc-reduced .g-de-hw-ladder i{opacity:1}
+@media (prefers-reduced-motion: reduce){
+  .g-de-howto,.g-de-hw-tile,.g-de-hw-arrow,.g-de-hw-gauge i,.g-de-hw-ladder i{animation:none !important}
+  .g-de-hw-tile.mrg.a,.g-de-hw-tile.mrg.b{opacity:0}
+  .g-de-hw-tile.mrg.out{opacity:1}
+  .g-de-hw-ladder i{opacity:1}
+}
+@media (max-width:640px),(pointer:coarse){
+  .g-de-howto{padding:16px 14px 14px}
+  .g-de-hw-row{gap:11px;padding:8px 0}
+  .g-de-hw-cap{font-size:11.5px}
+  .g-de-hw-tile{width:22px;height:22px}
+  .g-de-hw-num{font-size:10px}
+}
+@media (max-height:620px){
+  .g-de-hw-row{padding:6px 2px}
+  .g-de-hw-title{margin-bottom:4px}
 }
 `;
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/style.js
@@ -83,6 +83,9 @@
  *   A FACE IS FOUR BOXES AND THERE ARE 25 OF THEM: no isolation, no blend
  *   mode, no filter on a <video>, and the ken-burns pan is for stills only.
  *   .g-de-lite is the whole room one rung down (see the block near the bottom).
+ *   THE TOUCH RUNG (html.ae-touch) is NOT that ladder: it is a hardware
+ *   ceiling that applies on FULL too and stacks with lite. No blur over a
+ *   face, no blend surface, no backdrop-filter - see the block by the lite one.
  * ==========================================================================*/
 
 const STYLE_ID = 'g-de-style';
@@ -899,6 +902,39 @@ ${glyphRules()}
 .g-de-lite .g-de-bd{animation:none}
 .g-de-lite img.g-de-media{animation:none}
 .g-de-lite .g-de-tile .g-de-name::after{animation:none;opacity:.35}
+
+/* ---- pass 5: THE TOUCH RUNG (html.ae-touch) ------------------------------
+   index.js puts '.ae-touch' on <html> from the pointer, next to '.ae-lite',
+   and engine/style.js keeps its own half of it. This is NOT the lite rung and
+   it does not stack behind one: a phone on FULL still gets every cut here,
+   because these are not quality dials, they are things a mobile GPU - WebKit's
+   most of all - cannot pay for at ANY quality. There is no setting; the device
+   is the setting, so desktop is untouched to the byte.
+   What a phone actually pays for, in this sheet:
+     - A FILTER OVER A FACE IS A GPU PASS PER DECODED FRAME. A tile face is a
+       live <video> whenever the pool hands back a webm, and blur() over one is
+       the worst of them. The two blurs here both land in a WINDOW where the
+       board is already at its busiest - the dissolve at the end of a merge and
+       the whole-board resurface - so the hitch lands exactly on the beat the
+       player is watching. Both go to opacity, which is compositor-only. The
+       resurface KEEPS its brightness lift: one filter on a settling board is
+       affordable, a blur over up to 25 decodes is not.
+     - A BLEND SURFACE HAS TO READ WHAT IS UNDER IT before it can write, and
+       the caustic nets are full-screen. On the pool's near-black ground
+       'screen' and plain alpha read almost identically, so the light stays and
+       the read-back goes (the same trade the engine makes for its washes).
+     - BACKDROP-FILTER is the full-screen read-back-and-blur, every frame the
+       pressure glitch is up. The sheet's own tint already carries the read.
+   THE DRIFT LAW is untouched: every pattern here still travels by transform. */
+html.ae-touch .g-de-tile.is-gone{filter:none}
+html.ae-touch .g-de-stage[data-phase="resurface"] .g-de-tile{filter:brightness(1.5)}
+html.ae-touch .g-de-bd-lens::before,html.ae-touch .g-de-bd-lens::after{
+  mix-blend-mode:normal;opacity:.55}
+html.ae-touch .g-de-p-glitch.is-on{backdrop-filter:none;-webkit-backdrop-filter:none}
+/* the merge ceremony, transform/opacity only: the glyph still POPS, it just
+   stops asking for a brightness pass on the frame the new name lands. */
+html.ae-touch .g-de-tile.is-merged .g-de-glyph{animation:g-de-glyphpop-t .42s ease-out 1}
+@keyframes g-de-glyphpop-t{0%{transform:scale(1.25);opacity:.72}100%{transform:none;opacity:1}}
 
 /* ---- reduced motion: the mechanic survives, the motion does not ---------- */
 html.arc-reduced .g-de-stage *{animation:none !important}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -65,6 +65,19 @@ const SOUNDS = {
      thunk - a muted loss, never silence. */
   slide:     { noise: true, hp: 260,  lp: 2600, ms: 150, gain: 0.55, attack: 0.18 },
   bump:      { type: 'sawtooth', f0: 92,  f1: 46,  ms: 150, gain: 0.85, thunk: true },
+  /* Semesters II/III (2026-08-23). `pad` is Echo's instrument: an UNSWEPT triangle
+     so `pitch` alone carries pad identity (six pads = six pitches off one recipe,
+     +1 semitone per streak link); `decoy` is the telegraphed false pad. `tell` /
+     `lift` are Misdirection's trackability tell and the decoy-lid sting; `near` the
+     Anomaly near-miss ping (distinct from the long `near_miss` riser); `chime` a
+     clean bell for the streak ladders; `shutter` the darkroom's camera click. */
+  pad:       { type: 'triangle', f0: 392, f1: 392, ms: 200, gain: 0.55 },
+  decoy:     { noise: true, hp: 600,  lp: 3800, ms: 120, gain: 0.6, bits: 5 },
+  tell:      { type: 'sine',     f0: 880, f1: 880, ms: 70,  gain: 0.5 },
+  lift:      { type: 'triangle', f0: 330, f1: 495, ms: 120, gain: 0.55 },
+  near:      { type: 'sine',     f0: 740, f1: 620, ms: 110, gain: 0.55 },
+  chime:     { type: 'sine',     f0: 1046.5, f1: 1046.5, ms: 160, gain: 0.5 },
+  shutter:   { noise: true, hp: 1800, lp: 9000, ms: 40,  gain: 0.7 },
 };
 
 const clamp01 = (v) => (Number.isFinite(+v) ? Math.max(0, Math.min(1, +v)) : 0);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -29,6 +29,8 @@
  * ==========================================================================*/
 
 import { t, tierLabel, familyLabel } from '../core/lexicon.js';
+import { makeRng } from '../core/rng.js';
+import { OPEN_SEMESTERS, isOpenSemester } from '../games/registry.js';
 
 const SVGNS = 'http://www.w3.org/2000/svg';
 
@@ -77,7 +79,131 @@ export const ROOMS = Object.freeze({
     descKey: 'campus_desc_the_deep_end',
     descEn: 'Sink tile into tile. The deeper you go, the harder the board is to read.',
   },
+  /* ---- EAST WING - Semester II ---------------------------------------------
+   * The wing hangs off the corridor's east end and its 20px alley (x 1240..1260)
+   * is the Pool's covered walk stood on its side: three rooms open on their WEST
+   * wall onto it. Three fields carry the difference, and nothing else moves:
+   *   `door` is the coordinate ALONG the wall - an x for a corridor room
+   *          (side n/s), a y for a wing room (side w/e);
+   *   `stop` pins the numbered badge in the wing alley, because the badge can no
+   *          longer stand in the Main Hall outside the door;
+   *   `via`  is the junction the route turns at - the polyline walks in off the
+   *          hall, touches the stop and walks back out.
+   * `neonX`/`neonY`/`nameY` pin the sign and the label INSIDE the room exactly
+   * the way the Pool pins its own (a wing room is small, so the label stack runs
+   * sign -> name -> room number instead of hanging off a corridor wall).
+   * THE SAFE BAND: the plan is `preserveAspectRatio slice`, so a window TALLER
+   * than 16:9 crops the LEFT AND RIGHT edges - 72 viewBox units a side at 16:10.
+   * The wings sit at those edges, so every wing room and every wing label is
+   * kept inside x 72..1368. Widen one and it clips on somebody's monitor. */
+  misdirection: {
+    rect: [1260, 358, 112, 66], side: 'w', door: 391, rm: '201', wing: 'east',
+    stop: [1250, 391], via: [1250, 470], neonX: 1316, neonY: 364, nameY: 398,
+    gameEn: 'Misdirection',
+    nameKey: 'campus_room_misdirection', nameEn: 'The Parlour',
+    descKey: 'campus_desc_misdirection',
+    descEn: 'Keep your eyes on the one that matters. It will not make that easy.',
+  },
+  echo: {
+    rect: [1260, 430, 112, 66], side: 'w', door: 463, rm: '202', wing: 'east',
+    stop: [1250, 463], via: [1250, 470], neonX: 1316, neonY: 436, nameY: 470,
+    gameEn: 'Echo',
+    nameKey: 'campus_room_echo', nameEn: 'Music Room',
+    descKey: 'campus_desc_echo',
+    descEn: 'It plays a line, you play it back. Then it adds one more, every time.',
+  },
+  instant_recall: {
+    rect: [1260, 502, 112, 66], side: 'w', door: 535, rm: '203', wing: 'east',
+    stop: [1250, 535], via: [1250, 470], neonX: 1316, neonY: 508, nameY: 542,
+    gameEn: 'Instant Recall',
+    nameKey: 'campus_room_instant_recall', nameEn: 'Lecture Hall',
+    descKey: 'campus_desc_instant_recall',
+    descEn: 'Watch the whole hour, then answer for it. You never hear it coming.',
+  },
+  /* ---- WEST WING - Semester III --------------------------------------------
+   * Same construction, mirrored: the alley is x 180..200 and the two rooms open
+   * on their EAST wall. Fewer, larger rooms - the slow end of the school. */
+  anomaly: {
+    rect: [60, 366, 120, 96], side: 'e', door: 414, rm: '301', wing: 'west',
+    stop: [190, 414], via: [190, 470], neonX: 120, neonY: 378, nameY: 424,
+    gameEn: 'Anomaly',
+    nameKey: 'campus_room_anomaly', nameEn: 'Darkroom',
+    descKey: 'campus_desc_anomaly',
+    descEn: 'Everything in here matches. One thing does not. Find it before it moves.',
+  },
+  composure: {
+    rect: [60, 478, 120, 96], side: 'e', door: 526, rm: '302', wing: 'west',
+    stop: [190, 526], via: [190, 470], neonX: 120, neonY: 490, nameY: 536,
+    gameEn: 'Composure',
+    nameKey: 'campus_room_composure', nameEn: 'The Studio',
+    descKey: 'campus_desc_composure',
+    descEn: 'Slide the picture back together while the room does its best to blur it.',
+  },
 });
+
+/* ----------------------------------------------------------------------------
+ * THE WINGS. A wing is a BLOCK, not a room: it owns a footprint, an alley and a
+ * mouth onto the Main Hall, and it holds the rooms whose `wing` names it. The
+ * tape comes off exactly when the wing's semester is in the registry's
+ * OPEN_SEMESTERS - one set, one truth, so the release gate that keeps a class
+ * out of the pool is the same one that keeps its wing sealed.
+ * -------------------------------------------------------------------------- */
+export const WINGS = Object.freeze({
+  east: {
+    semester: 2, roman: 'II', rect: [1240, 350, 160, 240],
+    alleyX: 1250, mouthX: 1240, labelX: 1316, labelY: 612, sealedTone: 'pink', din: 180,
+    nameKey: 'campus_east_wing', nameEn: 'East Wing',
+    sealedKey: 'campus_opens_semester_2', sealedEn: 'Opens Semester II',
+    sealedDescKey: 'campus_desc_east', sealedDescEn: 'You can hear hammering behind the tape.',
+    openDescKey: 'campus_desc_east_open',
+    openDescEn: 'The tape is down. Wet paint, three new doors, nobody at the desk.',
+  },
+  west: {
+    semester: 3, roman: 'III', rect: [40, 350, 160, 240],
+    alleyX: 190, mouthX: 200, labelX: 120, labelY: 612, sealedTone: 'dim', din: 210,
+    nameKey: 'campus_west_wing', nameEn: 'West Wing',
+    sealedKey: 'campus_semester_3', sealedEn: 'Semester III',
+    sealedDescKey: 'campus_desc_west', sealedDescEn: 'The boards are older here.',
+    openDescKey: 'campus_desc_west_open',
+    openDescEn: 'Older boards, deeper rooms. Nobody in here is in any hurry.',
+  },
+});
+
+/** The room keys that live in a wing, in floor order. Pure. */
+export function wingRoomKeys(wingId) {
+  return Object.keys(ROOMS).filter((k) => ROOMS[k].wing === wingId);
+}
+
+/** True when a wing's semester has opened (the tape comes off). Pure. */
+export function wingIsOpen(wingId) {
+  const w = WINGS[wingId];
+  return !!w && OPEN_SEMESTERS.has(w.semester);
+}
+
+/** Highest open semester - what the crest and the student ID call this term. */
+export function currentSemester() {
+  let n = 1;
+  try { OPEN_SEMESTERS.forEach((v) => { if (v > n) n = v; }); } catch (e) { /* noop */ }
+  return Math.max(1, Math.min(4, n));
+}
+
+const ROMAN = Object.freeze(['', 'I', 'II', 'III', 'IV']);
+
+/* ----------------------------------------------------------------------------
+ * THE IDLE ATTRACT - tunables (Deck VI: demo, don't explain).
+ * -------------------------------------------------------------------------- */
+export const ATTRACT_IDLE_MS = 25000;   // silence before the school starts showing off
+const ATTRACT_LEG_MS = 900;             // one ghost-cursor leg
+const ATTRACT_DWELL_MS = 1000;          // how long a room holds its glow
+const ATTRACT_LOOP_GAP_MS = 2600;       // dark beat before the show repeats
+const ATTRACT_TICK_MS = 50;             // cursor lerp tick (20fps - a hint, not a game)
+const ATTRACT_FLIP_MS = 70;             // one split-flap flip
+const ATTRACT_FLIPS = 8;                // flips before a sign has fully settled
+const ATTRACT_GLYPHS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const ATTRACT_GLOW = 'brightness(1.3) saturate(1.12)';
+const ATTRACT_CURSOR_ALPHA = '0.55';
+/* The cursor sprite, drawn (never an emoji, never an image): 12x18 at the origin. */
+const ATTRACT_CURSOR_D = 'M0,0 L0,17 L4.2,13 L6.9,18.4 L9.6,17.1 L7,11.8 L12,11.6 Z';
 
 /* ----------------------------------------------------------------------------
  * PURE STATE MAPPER - what tonight looks like, per room.
@@ -181,10 +307,15 @@ function el(tag, cls, text) {
  * @param {Object} o.on           {begin(gameKey), freeSwim(gameKey), records(),
  *   registrar()} - freeSwim is only ever called for a room whose state carries
  *   an `endless` declaration (the shell reads the manifest, never the campus).
+ * @param {string=} o.dateSeed  init.utcDateSeed - the idle attract is seeded off
+ *   it so every player gets the SAME show tonight (trap 8: UTC seeds content).
+ *   Omitted, it falls back to today's UTC date.
+ * @param {number=} o.attractIdleMs  test seam; defaults to ATTRACT_IDLE_MS.
  * @param {Function=} o.log
  * @returns {{root, boardMount, footMount, update, closeCard, destroy}}
  */
-export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log } = {}) {
+export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log,
+  dateSeed, attractIdleMs } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const handlers = on || {};
   const name = typeof gameName === 'function' ? gameName : (k) => String(k);
@@ -293,17 +424,96 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   floors.appendChild(svg('rect', { x: 460, y: 510, width: 480, height: 220, fill: 'url(#campusPave)' }, 'campus-pave'));
   plan.appendChild(stag(floors, 60));
 
+  /* ------------------------------ wings ---------------------------------- */
+  /* Built BEFORE the rooms so the wing floor paints under them. Two states and
+   * nothing between: taped shut (the ghost plates tease the class names) or
+   * open (the alley is paved, the rooms are real). OPEN_SEMESTERS decides. */
+  function buildWing(id) {
+    const w = WINGS[id];
+    const open = wingIsOpen(id);
+    const [x, y, ww, wh] = w.rect;
+    const keys = wingRoomKeys(id);
+    const g = svg('g', null, open ? 'campus-wing' : 'campus-room locked');
+    g.appendChild(svg('rect', { x, y, width: ww, height: wh }, 'campus-gfloor' + (open ? '' : ' striped')));
+
+    if (open) {
+      /* the wing's own alley - the spur every room in here opens onto */
+      const ax = w.alleyX - 10;
+      g.appendChild(svg('rect', { x: ax, y, width: 20, height: wh }, 'campus-ghall'));
+      g.appendChild(svg('rect', { x: ax, y, width: 20, height: wh, fill: 'url(#campusPave)' }, 'campus-pave'));
+      /* TWO LINES, not one: "EAST WING · SEMESTER II" is 184px of tracked mono
+       * and would run off the cropped edge of the plan (see THE SAFE BAND). */
+      g.appendChild(svgText(w.labelX, w.labelY, 'campus-rsub', t(w.nameKey, w.nameEn).toUpperCase()));
+      g.appendChild(svgText(w.labelX, w.labelY + 15, 'campus-rsub tiny',
+        (t('semester', 'Semester') + ' ' + w.roman).toUpperCase()));
+      /* An open wing is scenery, not a door: the ROOMS take the clicks. It keeps
+       * its hover card so the alley still says where you are. */
+      attachTip(g, () => ({
+        name: t(w.nameKey, w.nameEn),
+        status: t('semester', 'Semester') + ' ' + w.roman,
+        desc: t(w.openDescKey, w.openDescEn),
+      }));
+      plan.appendChild(stag(g, w.din));
+      return g;
+    }
+
+    keys.forEach((key) => {
+      const spec = ROOMS[key];
+      const [rx, ry, rw, rh] = spec.rect;
+      g.appendChild(svg('rect', { x: rx + 12, y: ry + 8, width: rw - 24, height: rh - 16 }, 'campus-ghost'));
+      g.appendChild(svgText(rx + rw / 2, ry + rh / 2 + 4, 'campus-ghostt',
+        t('game_' + key, spec.gameEn || spec.nameEn).toUpperCase()));
+    });
+    const mx = w.mouthX;
+    g.appendChild(svg('line', { x1: mx, y1: 446, x2: mx, y2: 474 }, 'campus-tape2'));
+    g.appendChild(svg('line', { x1: mx - 7, y1: 452, x2: mx + 7, y2: 468 }, 'campus-tape'));
+    g.appendChild(svg('line', { x1: mx + 7, y1: 452, x2: mx - 7, y2: 468 }, 'campus-tape'));
+    g.appendChild(svgText(w.labelX, w.labelY, 'campus-rsub ' + w.sealedTone,
+      t(w.sealedKey, w.sealedEn).toUpperCase()));
+    const sealedCard = () => ({
+      name: t(w.nameKey, w.nameEn),
+      status: t(w.sealedKey, w.sealedEn),
+      desc: t(w.sealedDescKey, w.sealedDescEn),
+    });
+    attachTip(g, () => {
+      const d = sealedCard();
+      return { name: d.name, status: t('campus_sealed', 'Sealed') + ' — ' + d.status, desc: d.desc };
+    });
+    g.addEventListener('click', () => openFacilityCard(Object.assign(sealedCard(), { sealed: true })));
+    plan.appendChild(stag(g, w.din));
+    return g;
+  }
+  Object.keys(WINGS).forEach(buildWing);
+
   /* route (under rooms so door arcs stay crisp) + stop badges (over, added last) */
   routePath = svg('path', { d: '' }, 'campus-route');
   plan.appendChild(routePath);
 
   /* ------------------------------ rooms ---------------------------------- */
+  /* A door is the architect's symbol: a gap in the wall plus the leaf pivoting
+   * on one jamb. `spec.door` is the coordinate ALONG that wall - an x on the
+   * corridor's north (y 430) or south (y 510) wall, a y on a wing room's own
+   * west/east wall. A wing leaf swings INTO the room, because the wing alley is
+   * only 20 wide and a 24-unit swing would cross it. */
   function doorFor(spec) {
     const d = spec.door;
     if (spec.side === 'n') {
       return [
         svg('line', { x1: d - 12, y1: 430, x2: d + 12, y2: 430 }, 'campus-gap'),
         svg('path', { d: 'M' + (d + 12) + ',430 A24,24 0 0 1 ' + (d - 12) + ',454 L' + (d - 12) + ',430' }, 'campus-door'),
+      ];
+    }
+    if (spec.side === 'w' || spec.side === 'e') {
+      const r = spec.rect || [0, 0, 0, 0];
+      const west = spec.side === 'w';
+      const wx = west ? r[0] : r[0] + r[2];
+      const tip = west ? wx + 24 : wx - 24;
+      return [
+        svg('line', { x1: wx, y1: d - 12, x2: wx, y2: d + 12 }, 'campus-gap'),
+        svg('path', {
+          d: 'M' + wx + ',' + (d + 12) + ' A24,24 0 0 ' + (west ? 0 : 1)
+            + ' ' + tip + ',' + (d - 12) + ' L' + wx + ',' + (d - 12),
+        }, 'campus-door'),
       ];
     }
     return [
@@ -347,6 +557,25 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       // diving block on the west deck
       put(svg('rect', { x: 306, y: 774, width: 20, height: 14 }, 'campus-furnf'));
       put(svg('line', { x1: 326, y1: 774, x2: 326, y2: 788 }, 'campus-furn'));
+    } else if (key === 'misdirection') {
+      // three cups on a felt line, in the band between the sign and the name
+      put(svg('line', { x1: 1288, y1: 388, x2: 1344, y2: 388 }, 'campus-furn'));
+      [1298, 1316, 1334].forEach((cx) => put(svg('circle', { cx, cy: 384, r: 3.2 }, 'campus-furn')));
+    } else if (key === 'echo') {
+      // six pads in a row
+      [1292, 1302, 1312, 1322, 1332, 1342].forEach((x) => put(svg('rect', { x, y: 456, width: 6, height: 6 }, 'campus-furnf')));
+    } else if (key === 'instant_recall') {
+      // a four-frame strip
+      put(svg('rect', { x: 1288, y: 526, width: 56, height: 9 }, 'campus-furn'));
+      [1302, 1316, 1330].forEach((x) => put(svg('line', { x1: x, y1: 526, x2: x, y2: 535 }, 'campus-furn')));
+    } else if (key === 'anomaly') {
+      // a contact sheet: eight identical frames, one of them isn't
+      [398, 407].forEach((y) => [104, 114, 124, 134].forEach((x) => put(svg('rect', { x, y, width: 6, height: 6 }, 'campus-furnf'))));
+    } else if (key === 'composure') {
+      // a sliding frame, three across
+      put(svg('rect', { x: 102, y: 510, width: 36, height: 18 }, 'campus-furn'));
+      [114, 126].forEach((x) => put(svg('line', { x1: x, y1: 510, x2: x, y2: 528 }, 'campus-furn')));
+      put(svg('line', { x1: 102, y1: 519, x2: 138, y2: 519 }, 'campus-furn'));
     }
   }
 
@@ -357,20 +586,35 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     g.appendChild(svg('rect', { x, y, width: w, height: h }, 'campus-gfloor'));
     g.appendChild(svg('rect', { x, y, width: w, height: h }, 'campus-lit'));
     furnitureFor(key, g);
-    const midY = y + h / 2 + (spec.side === 'n' ? 0 : 0);
-    const ping = svg('circle', { cx: spec.door, cy: midY, r: 12 }, 'campus-ping');
+    /* The sign's centre line: the door x for a corridor room, an explicit pin for
+     * a wing room whose `door` is a y. Unchanged for every Semester-1 room. */
+    const signX = spec.neonX != null ? spec.neonX : spec.door;
+    const ping = svg('circle', { cx: signX, cy: y + h / 2, r: 12 }, 'campus-ping');
     g.appendChild(ping);
     // A room bolted to the corridor derives its label row from `side`; a DETACHED
-    // building (the Pool) pins its own, because y + 46 would land in the lawn.
+    // building (the Pool) and a WING room pin their own, because y + 46 would land
+    // in the lawn or straight through the sign.
     const nameY = spec.nameY != null ? spec.nameY : (spec.side === 'n' ? y + 156 : y + 46);
-    g.appendChild(svgText(x + w / 2, nameY, 'campus-rname', t(spec.nameKey, spec.nameEn).toUpperCase()));
-    g.appendChild(svgText(x + w / 2, nameY + 18, 'campus-rsub',
-      (t('campus_rm', 'RM') + ' ' + spec.rm + ' · ' + name(key)).toUpperCase()));
+    const nameNode = svgText(x + w / 2, nameY, 'campus-rname', t(spec.nameKey, spec.nameEn).toUpperCase());
+    /* A wing room is half a corridor room wide, so its plate steps down a size.
+     * This is the ONE inline style the campus writes and it is a metric, never a
+     * colour - the .campus-rname rule (and every token in it) still applies. */
+    if (spec.wing) nameNode.setAttribute('style', 'font-size:11px');
+    g.appendChild(nameNode);
+    /* ...and its number row carries the ROOM NUMBER alone. "RM 203 · INSTANT
+     * RECALL" is 150px of text in a 112px room and would run straight off the
+     * cropped edge of the plan; the neon sign, the hover card, the door card and
+     * the hanging board all still name the class. */
+    g.appendChild(svgText(x + w / 2, nameY + (spec.wing ? 16 : 18),
+      spec.wing ? 'campus-rsub tiny' : 'campus-rsub',
+      (spec.wing
+        ? t('campus_rm', 'RM') + ' ' + spec.rm
+        : t('campus_rm', 'RM') + ' ' + spec.rm + ' · ' + name(key)).toUpperCase()));
     doorFor(spec).forEach((n) => g.appendChild(n));
     const neonY = spec.neonY != null ? spec.neonY : (spec.side === 'n' ? 398 : 694);
     const neon = svg('g', null, 'campus-neon');
-    const neonRect = svg('rect', { x: spec.door - 47, y: neonY, width: 94, height: 16, rx: 3 });
-    const neonText = svgText(spec.door, neonY + 11, null, '');
+    const neonRect = svg('rect', { x: signX - 47, y: neonY, width: 94, height: 16, rx: 3 });
+    const neonText = svgText(signX, neonY + 11, null, '');
     neon.appendChild(neonRect);
     neon.appendChild(neonText);
     g.appendChild(neon);
@@ -380,7 +624,11 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     plan.appendChild(g);
     return g;
   }
-  Object.keys(ROOMS).forEach((key, i) => stag(buildClassRoom(key), 250 + i * 110));
+  /* A CLOSED semester has no rooms at all - not dark ones. Its games are absent
+   * from the registry pool too (games/registry.js OPEN_SEMESTERS), so the two
+   * halves of the release gate can never disagree. */
+  Object.keys(ROOMS).filter(isOpenSemester)
+    .forEach((key, i) => stag(buildClassRoom(key), 250 + i * 110));
 
   /* ------------------------------ facilities ----------------------------- */
   function facility(rect, door, side, nameText, subText, onClick, tip) {
@@ -473,48 +721,15 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   plan.appendChild(svg('path', { d: 'M758,730 A38,38 0 0 1 720,768' }, 'campus-door'));
   plan.appendChild(svgText(720, 788, 'campus-rsub wide', t('campus_main_gate', 'Main Gate').toUpperCase()));
 
-  /* wings - Semesters II / III */
-  const east = svg('g', null, 'campus-room locked');
-  east.appendChild(svg('rect', { x: 1240, y: 350, width: 160, height: 240 }, 'campus-gfloor striped'));
-  [[368, 'game_misdirection', 'Misdirection'], [440, 'game_instant_recall', 'Instant Recall'], [512, 'game_echo', 'Echo']]
-    .forEach(([y, key, en]) => {
-      east.appendChild(svg('rect', { x: 1258, y, width: 124, height: 56 }, 'campus-ghost'));
-      east.appendChild(svgText(1320, y + 31, 'campus-ghostt', t(key, en).toUpperCase()));
-    });
-  east.appendChild(svg('line', { x1: 1240, y1: 446, x2: 1240, y2: 474 }, 'campus-tape2'));
-  east.appendChild(svg('line', { x1: 1233, y1: 452, x2: 1247, y2: 468 }, 'campus-tape'));
-  east.appendChild(svg('line', { x1: 1247, y1: 452, x2: 1233, y2: 468 }, 'campus-tape'));
-  east.appendChild(svgText(1320, 612, 'campus-rsub pink', t('campus_opens_semester_2', 'Opens Semester II').toUpperCase()));
-  attachTip(east, () => ({
-    name: t('campus_east_wing', 'East Wing'),
-    status: t('campus_sealed', 'Sealed') + ' — ' + t('campus_opens_semester_2', 'Opens Semester II'),
-    desc: t('campus_desc_east', 'You can hear hammering behind the tape.'),
-  }));
-  east.addEventListener('click', () => openFacilityCard({
-    name: t('campus_east_wing', 'East Wing'),
-    status: t('campus_opens_semester_2', 'Opens Semester II'),
-    desc: t('campus_desc_east', 'You can hear hammering behind the tape.'),
-    sealed: true,
-  }));
-  plan.appendChild(stag(east, 940));
-
-  const west = svg('g', null, 'campus-room locked');
-  west.appendChild(svg('rect', { x: 40, y: 350, width: 160, height: 240 }, 'campus-gfloor striped'));
-  [382, 418, 454, 490, 526, 562].forEach((y) => west.appendChild(svg('line', { x1: 52, y1: y, x2: 188, y2: y }, 'campus-furn')));
-  west.appendChild(svg('line', { x1: 196, y1: 440, x2: 204, y2: 480 }, 'campus-tape2'));
-  west.appendChild(svgText(120, 612, 'campus-rsub dim', t('campus_semester_3', 'Semester III').toUpperCase()));
-  attachTip(west, () => ({
-    name: t('campus_west_wing', 'West Wing'),
-    status: t('campus_sealed', 'Sealed') + ' — ' + t('campus_semester_3', 'Semester III'),
-    desc: t('campus_desc_west', 'The boards are older here.'),
-  }));
-  west.addEventListener('click', () => openFacilityCard({
-    name: t('campus_west_wing', 'West Wing'),
-    status: t('campus_semester_3', 'Semester III'),
-    desc: t('campus_desc_west', 'The boards are older here.'),
-    sealed: true,
-  }));
-  plan.appendChild(stag(west, 1020));
+  /* an OPEN wing's mouth: the corridor's end wall is cut away, same treatment as
+   * the corridor <-> entrance opening above. A sealed wing keeps its wall (and
+   * its tape). */
+  Object.keys(WINGS).forEach((id) => {
+    if (!wingIsOpen(id)) return;
+    const mx = WINGS[id].mouthX;
+    plan.appendChild(svg('line', { x1: mx, y1: 434, x2: mx, y2: 506 }, 'campus-gap'));
+    plan.appendChild(svg('line', { x1: mx, y1: 434, x2: mx, y2: 506, 'stroke-dasharray': '3 6' }, 'campus-opening'));
+  });
 
   /* stop badges live above everything in the plan */
   stopsLayer = svg('g', null, 'campus-stops');
@@ -549,8 +764,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   const crest = el('div', 'campus-crest');
   const h1 = el('h1', null, t('arcademy', 'The Arcademy'));
   crest.appendChild(h1);
+  const termRoman = ROMAN[currentSemester()] || 'I';
   crest.appendChild(el('p', null,
-    (t('campus_night_sessions', 'Night Sessions') + ' · ' + t('semester', 'Semester') + ' I').toUpperCase()));
+    (t('campus_night_sessions', 'Night Sessions') + ' · ' + t('semester', 'Semester') + ' ' + termRoman).toUpperCase()));
   crest.appendChild(el('div', 'campus-crestrule'));
   root.appendChild(crest);
 
@@ -580,7 +796,7 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   idTop.appendChild(el('div', 'id-photo'));
   const idMeta = el('div');
   idMeta.appendChild(el('div', 'id-name', t('student', 'Student')));
-  idMeta.appendChild(el('div', 'id-no', (t('semester', 'Semester') + ' I').toUpperCase()));
+  idMeta.appendChild(el('div', 'id-no', (t('semester', 'Semester') + ' ' + termRoman).toUpperCase()));
   idTier = el('span', 'id-tier', '');
   idMeta.appendChild(idTier);
   idTop.appendChild(idMeta);
@@ -802,17 +1018,41 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   }
 
   /* ------------------------------ update --------------------------------- */
+  /** THE one truth for a room's neon sign. update() paints it and the idle
+   * attract's split-flap flutter settles back onto it, so a flutter can never
+   * strand a stale word on a sign. */
+  function neonLabel(key) {
+    const r = st.rooms[key] || {};
+    if (r.mood === 'open') return t('campus_in_session', 'In Session').toUpperCase();
+    if (r.mood === 'retake') return t('retake', 'Retake').toUpperCase();
+    return '';
+  }
+
+  /* Where tonight's numbered badge stands: in the corridor just inside the door
+   * for a room bolted to the hall, in the wing alley for a wing room (which
+   * pins its own `stop`, because the Main Hall is nowhere near its door). */
   function stopAnchor(key) {
-    const spec = ROOMS[key];
+    const spec = ROOMS[key] || {};
+    if (spec.stop) return spec.stop;
     return spec.side === 'n' ? [spec.door, 447] : [spec.door, 488];
+  }
+
+  /* The legs the route walks for one stop. A corridor room is one point on the
+   * hall's centre line - byte-identical to what this drew before. A wing room
+   * turns off at its junction, touches its door and comes back out, so the next
+   * leg still starts on the centre line instead of cutting through a wall. */
+  function routeLegs(key) {
+    const spec = ROOMS[key];
+    if (!spec) return [];
+    if (spec.via) return [spec.via, stopAnchor(key), spec.via];
+    return [[spec.door, 470]];
   }
 
   function routeFor(stops) {
     if (!stops.length) return '';
     let d = 'M720,908 L720,470';
     for (const s of stops) {
-      const [x] = stopAnchor(s.gameKey);
-      d += ' L' + x + ',470';
+      for (const leg of routeLegs(s.gameKey)) d += ' L' + leg[0] + ',' + leg[1];
     }
     return d;
   }
@@ -827,16 +1067,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       const r = st.rooms[key] || { mood: 'dark' };
       ref.g.setAttribute('class', 'campus-room'
         + (r.mood === 'open' ? ' open' : r.mood === 'retake' ? ' retake' : ' dark'));
-      if (r.mood === 'open') {
-        ref.neonText.textContent = t('campus_in_session', 'In Session').toUpperCase();
-        ref.neon.setAttribute('class', 'campus-neon');
-      } else if (r.mood === 'retake') {
-        ref.neonText.textContent = t('retake', 'Retake').toUpperCase();
-        ref.neon.setAttribute('class', 'campus-neon v');
-      } else {
-        ref.neonText.textContent = '';
-        ref.neon.setAttribute('class', 'campus-neon off');
-      }
+      ref.neonText.textContent = neonLabel(key);
+      ref.neon.setAttribute('class', 'campus-neon'
+        + (r.mood === 'open' ? '' : r.mood === 'retake' ? ' v' : ' off'));
     }
 
     /* stop badges + route */
@@ -874,6 +1107,232 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     }
   }
 
+  /* ==========================================================================
+   * THE IDLE ATTRACT - Deck VI, "demo, don't explain".
+   *
+   * After ATTRACT_IDLE_MS of silence on the campus screen the school shows you
+   * what to do instead of telling you: tonight's rooms light in ROUTE order, a
+   * drawn ghost cursor walks the route between the numbered stops, and one sign
+   * re-flaps like the departure board. Four laws it keeps:
+   *   - ANY input cancels it and re-arms the timer (Law II - and the cursor is
+   *     `pointer-events:none`, so it can never take a click that was meant for a
+   *     room);
+   *   - reducedMotion degrades to a STATIC glow: tonight's rooms simply light;
+   *   - it is SEEDED off the UTC date, so it is the same show for everyone
+   *     tonight and a reload replays it (trap 8: UTC seeds content);
+   *   - it writes no colour and no stylesheet: the glow is the hover filter the
+   *     stylesheet already transitions, and the cursor borrows two token-driven
+   *     classes for its fill and its outline.
+   * destroy() tears down every timer, every listener and the glow itself.
+   * ========================================================================*/
+  const idleMs = Math.max(50, Math.round(Number(attractIdleMs) || ATTRACT_IDLE_MS));
+  const attractTimers = new Set();
+  const glowing = new Set();
+  let attractOn = false;
+  let idleTimer = 0;
+  let cursorG = null;
+  let cursorAt = [720, 900];
+  let lastInput = 0;
+
+  function utcDaySeed() {
+    try { return new Date().toISOString().slice(0, 10); } catch (e) { return '1970-01-01'; }
+  }
+  const attractSeed = String(dateSeed || utcDaySeed());
+  let arng = makeRng('arcademy|campus|attract|' + attractSeed);
+
+  function attractAfter(ms, fn) {
+    if (typeof setTimeout !== 'function') return 0;
+    const id = setTimeout(() => { attractTimers.delete(id); if (attractOn) fn(); }, ms);
+    attractTimers.add(id);
+    return id;
+  }
+  function attractEvery(ms, fn) {
+    if (typeof setInterval !== 'function') return 0;
+    const id = setInterval(fn, ms);
+    attractTimers.add(id);
+    return id;
+  }
+  function attractStop(id) {
+    try { clearInterval(id); } catch (e) { /* noop */ }
+    attractTimers.delete(id);
+  }
+  function attractClearAll() {
+    attractTimers.forEach((id) => {
+      try { clearTimeout(id); } catch (e) { /* noop */ }
+      try { clearInterval(id); } catch (e) { /* noop */ }
+    });
+    attractTimers.clear();
+  }
+
+  /* The glow IS the hover look (styles.css already transitions filter on a
+   * room), which is the honest thing to demo: this is what hovering does. */
+  function glow(key, on) {
+    const ref = roomRefs[key];
+    if (!ref) return;
+    try { ref.g.style.setProperty('filter', on ? ATTRACT_GLOW : ''); } catch (e) { /* noop */ }
+    if (on) glowing.add(key); else glowing.delete(key);
+  }
+  function unglowAll() { Array.from(glowing).forEach((k) => glow(k, false)); }
+  function resettleSigns() {
+    for (const key of Object.keys(roomRefs)) {
+      try { roomRefs[key].neonText.textContent = neonLabel(key); } catch (e) { /* noop */ }
+    }
+  }
+
+  function ensureCursor() {
+    if (cursorG) return cursorG;
+    const g = svg('g', null, 'campus-ghostcursor');
+    g.appendChild(svg('path', { d: ATTRACT_CURSOR_D }, 'campus-clockpin'));  // fill: --ink
+    g.appendChild(svg('path', { d: ATTRACT_CURSOR_D }, 'campus-door'));      // stroke: --campus-line
+    g.setAttribute('pointer-events', 'none');
+    g.setAttribute('opacity', '0');
+    cursorG = g;
+    plan.appendChild(g);
+    return g;
+  }
+  function placeCursor(x, y) {
+    cursorAt = [x, y];
+    if (!cursorG) return;
+    const r1 = Math.round(x * 10) / 10;
+    const r2 = Math.round(y * 10) / 10;
+    try { cursorG.setAttribute('transform', 'translate(' + r1 + ',' + r2 + ')'); } catch (e) { /* noop */ }
+  }
+  function showCursor(on) {
+    if (!cursorG) return;
+    try { cursorG.setAttribute('opacity', on ? ATTRACT_CURSOR_ALPHA : '0'); } catch (e) { /* noop */ }
+  }
+  function glideCursor(to, ms, done) {
+    const from = cursorAt.slice();
+    const steps = Math.max(1, Math.round(ms / ATTRACT_TICK_MS));
+    let i = 0;
+    const id = attractEvery(ATTRACT_TICK_MS, () => {
+      if (!attractOn) { attractStop(id); return; }
+      i += 1;
+      const p = Math.min(1, i / steps);
+      const e = p * p * (3 - 2 * p);                 // smoothstep: a hand, not a machine
+      placeCursor(from[0] + (to[0] - from[0]) * e, from[1] + (to[1] - from[1]) * e);
+      if (p >= 1) { attractStop(id); done(); }
+    });
+    if (!id) { placeCursor(to[0], to[1]); done(); }  // no timers at all (headless): teleport
+  }
+
+  /** Split-flap settle: the left of the row lands first, the tail keeps spinning. */
+  function flapText(truth, k) {
+    const settled = Math.floor(truth.length * (k / ATTRACT_FLIPS));
+    let out = '';
+    for (let i = 0; i < truth.length; i++) {
+      const c = truth.charAt(i);
+      out += (i < settled || c === ' ')
+        ? c
+        : ATTRACT_GLYPHS.charAt(Math.floor(arng() * ATTRACT_GLYPHS.length));
+    }
+    return out;
+  }
+  function flutterSign(key, done) {
+    const ref = roomRefs[key];
+    const truth = ref ? neonLabel(key) : '';
+    if (!ref || !truth) { done(); return; }
+    let k = 0;
+    const id = attractEvery(ATTRACT_FLIP_MS, () => {
+      if (!attractOn) { attractStop(id); return; }
+      k += 1;
+      if (k >= ATTRACT_FLIPS) {
+        attractStop(id);
+        try { ref.neonText.textContent = neonLabel(key); } catch (e) { /* noop */ }
+        done();
+        return;
+      }
+      try { ref.neonText.textContent = flapText(truth, k); } catch (e) { /* noop */ }
+    });
+    if (!id) done();
+  }
+
+  /** Route order when there is a board; otherwise a short tour of the rooms. */
+  function attractOrder() {
+    const tonight = st.stops.map((s) => s.gameKey).filter((k) => roomRefs[k]);
+    return tonight.length ? tonight : Object.keys(roomRefs).slice(0, 3);
+  }
+
+  function playLeg(order, i, flutterKey) {
+    if (!attractOn) return;
+    if (i >= order.length) {
+      showCursor(false);
+      unglowAll();
+      attractAfter(ATTRACT_LOOP_GAP_MS, () => {
+        placeCursor(720, 900);
+        showCursor(true);
+        playLeg(order, 0, flutterKey);
+      });
+      return;
+    }
+    const key = order[i];
+    glideCursor(stopAnchor(key), ATTRACT_LEG_MS, () => {
+      if (!attractOn) return;
+      glow(key, true);
+      const onward = () => attractAfter(ATTRACT_DWELL_MS, () => {
+        glow(key, false);
+        playLeg(order, i + 1, flutterKey);
+      });
+      if (key === flutterKey) flutterSign(key, onward); else onward();
+    });
+  }
+
+  function startAttract() {
+    idleTimer = 0;
+    // A card in front of the plan means the player is mid-decision, not idle.
+    if (destroyed || attractOn || cardOpen) { armIdle(); return; }
+    const order = attractOrder();
+    if (!order.length) { armIdle(); return; }
+    attractOn = true;
+    arng = makeRng('arcademy|campus|attract|' + attractSeed);   // same show, every loop
+    if (reducedMotion) { order.forEach((k) => glow(k, true)); return; }
+    ensureCursor();
+    placeCursor(720, 900);                    // in through the Main Gate, like the route
+    showCursor(true);
+    playLeg(order, 0, order[Math.floor(arng() * order.length)] || order[0]);
+  }
+
+  function armIdle() {
+    if (destroyed) return;
+    if (idleTimer) { try { clearTimeout(idleTimer); } catch (e) { /* noop */ } }
+    idleTimer = (typeof setTimeout === 'function') ? setTimeout(startAttract, idleMs) : 0;
+  }
+
+  function cancelAttract(rearm) {
+    if (attractOn) {
+      attractOn = false;
+      attractClearAll();
+      unglowAll();
+      resettleSigns();
+      showCursor(false);
+    }
+    if (rearm !== false) armIdle();
+  }
+
+  /* ANY input cancels. pointermove floods, so a re-arm is throttled - but a
+   * RUNNING attract always yields on the very first event. */
+  function onInput() {
+    const now = (typeof Date !== 'undefined' && Date.now) ? Date.now() : 0;
+    if (attractOn) { lastInput = now; cancelAttract(true); return; }
+    if (now && now - lastInput < 400) return;
+    lastInput = now;
+    armIdle();
+  }
+
+  const INPUT_EVENTS = ['pointerdown', 'pointerup', 'pointermove', 'wheel', 'touchstart', 'keydown'];
+  try { INPUT_EVENTS.forEach((n) => root.addEventListener(n, onInput, true)); } catch (e) { /* noop */ }
+  /* keydown never reaches an unfocused <div>, so the document takes that one -
+   * guarded, because the headless DOM double's document is a plain object with
+   * no event target on it at all. */
+  let docBound = false;
+  try {
+    if (typeof document !== 'undefined' && document && typeof document.addEventListener === 'function') {
+      document.addEventListener('keydown', onInput, true);
+      docBound = true;
+    }
+  } catch (e) { /* noop */ }
+  armIdle();
+
   /* ------------------------------ bell tick ------------------------------ */
   let bellTimer = 0;
   function tickBell() { try { bellText.textContent = bellLabel(bellSecondsLeft()); } catch (e) { /* noop */ } }
@@ -892,9 +1351,20 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     noteDescriptors,
     closeCard,
     openClassCard,
+    /** Test seam for the idle attract - never read by the shell. */
+    attractDiagnostics() {
+      return {
+        armed: !!idleTimer, running: attractOn, idleMs, seed: attractSeed,
+        glowing: glowing.size, cursor: !!cursorG, timers: attractTimers.size,
+      };
+    },
     destroy() {
       if (destroyed) return;
       destroyed = true;
+      cancelAttract(false);
+      if (idleTimer) { try { clearTimeout(idleTimer); } catch (e) { /* noop */ } idleTimer = 0; }
+      try { INPUT_EVENTS.forEach((n) => root.removeEventListener(n, onInput, true)); } catch (e) { /* noop */ }
+      if (docBound) { try { document.removeEventListener('keydown', onInput, true); } catch (e) { /* noop */ } }
       if (bellTimer) { try { clearInterval(bellTimer); } catch (e) { /* noop */ } bellTimer = 0; }
       if (enterTimer) { try { clearTimeout(enterTimer); } catch (e) { /* noop */ } enterTimer = 0; }
       if (document.documentElement && document.documentElement.classList) {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ceremonies.js
@@ -27,6 +27,13 @@ function el(tag, cls, text) {
   return n;
 }
 
+/* HOUSE RULES additions (Deck V / Deck VI, shell level so all ten classes get
+ * them): `gradeObject({grade,...})` mints the grade as a physical stamp instead
+ * of a bare letter string, and `payoff({grade, capped, ...})` guarantees that a
+ * C - or a class that dropped a hard gate - still gets a scaled-down beat rather
+ * than silence. Both ride the same delegate-to-the-engine floor as everything
+ * above them. */
+
 /**
  * @param {Object} o
  * @param {Object=} o.engine        the Distraction Engine facade (may be null)
@@ -132,6 +139,68 @@ export function createCeremonies({ engine, layer, reducedMotion, log } = {}) {
         target: o.target,
       });
       return true;
+    },
+
+    /* ---------------------------------------------------------------------
+     * DECK VI - GRADES AS OBJECTS. The grade arrives as a physical thing, never
+     * as a bare letter printed into a <span>: it is minted through the stamp
+     * ceremony above (so the engine gets first refusal, exactly like every other
+     * beat) and only then dressed with its grade class. Callers hand this an
+     * OBJECT - {grade, zen, target} - which is the whole point: nothing upstream
+     * gets to render the letter itself first.
+     * @returns {HTMLElement|null} the stamp node
+     * ------------------------------------------------------------------- */
+    gradeObject({ grade, zen, target, hold, label } = {}) {
+      const raw = String(grade == null ? '' : grade);
+      const g = raw.toLowerCase();
+      const text = label != null ? String(label)
+        : (g === 'pass' || zen === true ? 'PASS' : raw.toUpperCase());
+      // 'a' and 'pass' wear the pink seal, everything else the gold one - the
+      // stamp primitive's only two tones, unchanged.
+      const node = api.stamp({
+        text, target, hold,
+        tone: (g === 'a' || g === 'pass') ? 'pink' : undefined,
+      });
+      if (!node) return null;
+      try {
+        if (node.classList) {
+          node.classList.add('arc-gradeobj');
+          if (g) node.classList.add('g-' + g.replace(/[^a-z]/g, ''));
+        }
+        if (node.setAttribute) {
+          node.setAttribute('role', 'img');
+          node.setAttribute('aria-label', text);
+          node.setAttribute('data-grade', g);
+        }
+      } catch (e) { /* a decoration must never be the thing that throws */ }
+      return node;
+    },
+
+    /* ---------------------------------------------------------------------
+     * DECK V - LOSSES DISGUISED. Every finished class pays SOMETHING. A top
+     * grade gets the jackpot, the middle gets its stamp, and a C (or any class
+     * that dropped a hard gate) gets a scaled-down near-miss beat instead of
+     * silence - because silence is where people stand up. Never returns false:
+     * the worst case is the CSS stamp floor.
+     * @returns {'jackpot'|'near_miss'|'stamp'} which beat was played
+     * ------------------------------------------------------------------- */
+    payoff({ grade, zen, gated, capped, target, text, scale } = {}) {
+      const g = String(grade || '').toLowerCase();
+      const capList = Array.isArray(capped) ? capped.map((c) => String(c)) : [];
+      const failedGate = !!gated || capList.some((c) => c.indexOf('hard') >= 0);
+      const opts = { target, scale: scale == null ? 1 : scale };
+      if (!failedGate && (g === 's' || g === 'a')) {
+        api.reward('jackpot', Object.assign({ text: text || 'JACKPOT' }, opts));
+        return 'jackpot';
+      }
+      if (g === 'c' || failedGate) {
+        // Scaled DOWN, never off: half the spectacle, all of the acknowledgement.
+        api.reward('near_miss', Object.assign({ text: text || 'SO CLOSE' },
+          opts, { scale: scale == null ? 0.5 : scale }));
+        return 'near_miss';
+      }
+      api.stamp({ text: text || (g === 'pass' || zen === true ? 'PASS' : 'MARKED'), target });
+      return 'stamp';
     },
 
     /** How many segments the meter has - games must not hardcode 8 or 12. */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/keybinds.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/keybinds.js
@@ -58,6 +58,47 @@ export function keyLabel(k) {
   return s.replace(/([a-z])([A-Z])/g, '$1 $2');
 }
 
+/* ----------------------------------------------------------------------------
+ * DECK VI - VERB GLYPHS. "Every keybind gets a drawn glyph; the label string
+ * survives only in tooltips and the settings sheet." `keyGlyph` is the FACE of
+ * the drawn keycap (settings.js paints the cap itself in CSS); `keyLabel` above
+ * is untouched and stays the string the row, the tooltip and the aria-label all
+ * use. A key with no glyph of its own falls back to its label, and the caller
+ * widens the cap - a legible word beats a clever symbol nobody recognises.
+ * -------------------------------------------------------------------------- */
+const KEY_GLYPHS = Object.freeze({
+  Space: '␣',          // ␣ open box
+  Enter: '↵',          // ↵
+  NumpadEnter: '↵',
+  Backspace: '⌫',      // ⌫
+  Delete: '⌦',         // ⌦
+  Tab: '⇥',            // ⇥
+  Escape: 'Esc',
+  ArrowLeft: '←', ArrowRight: '→', ArrowUp: '↑', ArrowDown: '↓',
+  Shift: '⇧',          // ⇧
+  CapsLock: '⇪',       // ⇪
+  Home: '↖', End: '↘',
+  PageUp: '⇞', PageDown: '⇟',
+});
+
+/**
+ * The drawn face for a binding.
+ * @returns {string} one glyph where one exists, else the human label ('--' when
+ *   nothing is bound). Never an empty string, so a cap is never blank.
+ */
+export function keyGlyph(k) {
+  const s = normalizeKey(k);
+  if (!s) return '--';
+  const g = KEY_GLYPHS[s];
+  if (g) return g;
+  if (/^Numpad[0-9]$/.test(s)) return s.slice(6);      // Numpad4 -> 4 (aria says numpad)
+  if (s.length === 1) return s;                        // letters and digits draw as themselves
+  return keyLabel(s);
+}
+
+/** True when a glyph needs a wide cap (it is a word, not a symbol). */
+export function keyGlyphWide(k) { return keyGlyph(k).length > 2; }
+
 /**
  * @param {Object} o
  * @param {Object} o.init      the init projection (settings + keybinds + panic key)

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
@@ -27,7 +27,7 @@
  * ==========================================================================*/
 
 import { t } from '../core/lexicon.js';
-import { keyLabel } from './keybinds.js';
+import { keyLabel, keyGlyph, keyGlyphWide } from './keybinds.js';
 
 /* ----------------------------------------------------------------------------
  * THE KEY MAP (cross-agent contract - keep in sync with ArcademyHostService's
@@ -238,15 +238,35 @@ export function createSettingsPage({ init, bridge, games, keybinds, onClose, log
     return row;
   }
 
-  /** Keybind capture row - the shared framework's only UI (SYNTHESIS #7). */
+  /** Keybind capture row - the shared framework's only UI (SYNTHESIS #7).
+   *
+   * DECK VI (VERB GLYPHS): the cap is DRAWN - a CSS keycap wearing the key's
+   * glyph, not its name. The label string is not deleted, it MOVES: the verb's
+   * own label stays in this sheet on the left (that is the settings row), and
+   * the key's human name lives on the cap's `title` and `aria-label`, so a
+   * screen reader and a hover both still say "Space" while the eye reads ␣. */
   function keyRow(gameKey, slot) {
     const row = el('div', 'arc-row');
     const label = slot.labelKey ? t(slot.labelKey, slot.verb) : slot.verb;
     const lab = el('span', 'arc-rowlabel', label);
     const msg = el('span', 'arc-conflict', '');
     lab.appendChild(msg);
-    const cap = el('button', 'arc-keycap', keyLabel(keybinds.get(gameKey, slot.verb)));
+    const cap = el('button', 'arc-keycap arc-glyphcap');
     cap.type = 'button';
+
+    /** Paint the drawn cap for the CURRENT binding (glyph on the face, name in
+     *  the tooltip + aria). One place, so capture and cancel cannot drift. */
+    function paintCap() {
+      const bound = keybinds.get(gameKey, slot.verb);
+      const name = keyLabel(bound);
+      cap.textContent = keyGlyph(bound);
+      if (keyGlyphWide(bound)) cap.classList.add('wide'); else cap.classList.remove('wide');
+      // The label survives HERE - the glyph is for the eye, this is for
+      // everything else (SYNTHESIS #7's rebind UI must stay announceable).
+      cap.setAttribute('title', label + ': ' + name);
+      cap.setAttribute('aria-label', label + ': ' + name);
+    }
+    paintCap();
 
     let capturing = false;
     const stop = () => {
@@ -257,23 +277,25 @@ export function createSettingsPage({ init, bridge, games, keybinds, onClose, log
     const grab = (e) => {
       e.preventDefault();
       e.stopPropagation();
-      if (e.key === 'Escape') { stop(); cap.textContent = keyLabel(keybinds.get(gameKey, slot.verb)); return; }
+      if (e.key === 'Escape') { stop(); paintCap(); return; }
       const res = keybinds.bind(gameKey, slot.verb, e.code || e.key);
       if (res.ok) {
         msg.textContent = '';
-        cap.textContent = keyLabel(keybinds.get(gameKey, slot.verb));
+        paintCap();
       } else {
         const r = res.conflict && res.conflict.reason;
         msg.textContent = r === 'panic' ? ' - that is the panic key'
           : r === 'taken' ? ' - already bound to ' + res.conflict.with
             : ' - reserved key';
+        paintCap();
       }
       stop();
     };
     cap.addEventListener('click', () => {
-      if (capturing) { stop(); return; }
+      if (capturing) { stop(); paintCap(); return; }
       capturing = true;
       cap.classList.add('capturing');
+      cap.classList.add('wide');
       cap.textContent = 'press a key';
       msg.textContent = '';
       window.addEventListener('keydown', grab, true);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -31,7 +31,9 @@ import { makeRng } from '../core/rng.js';
 import { buildTimetable, dayAdd } from '../core/timetable.js';
 import { gradeClass, capsRaised } from '../core/grades.js';
 import { createStore } from '../core/store.js';
-import { loadGames, descriptors, tierFor, advance, suspendedStub } from '../games/registry.js';
+import {
+  loadGames, descriptors, tierFor, tierForPromotions, advance, suspendedStub, MAX_TIER,
+} from '../games/registry.js';
 import { createBoard } from './splitflap.js';
 import { createCampus, campusState } from './campus.js';
 import { createReportCard } from './reportcard.js';
@@ -45,6 +47,108 @@ const MEATY_MAX_SEC = 300;
 const QUICK_MAX_SEC = 180;
 /** How often the shell's own class clock repaints the time bar. */
 const CLOCK_TICK_MS = 250;
+
+/* ----------------------------------------------------------------------------
+ * DECK V - THE RAKE (house-rules.txt). Built ONCE here so all ten classes wear
+ * it, and bounded by Law VI end to end: nothing below blocks, delays or moves an
+ * exit, and the Esc ladder is untouched (escapeStep still walks exactly the
+ * rungs it walked before this landed - see trap 29's corollary).
+ *
+ *   the end card      one-more framing over the report card, never instead of it
+ *   streak jeopardy   what leaving actually costs, from the HOST-owned numbers
+ *   the sunk-cost bar cross-class progress toward the next tier promotion
+ *   the drop          a seeded ~1-in-6 surprise stamp. NO XP - C# owns XP.
+ *   losses disguised  a C still gets a beat (shell/ceremonies.js payoff)
+ * -------------------------------------------------------------------------- */
+
+/** ~1 in 6 classes mint a drop. Seeded per (UTC day, game) - see rollRakeDrop. */
+const RAKE_DROP_ODDS = 1 / 6;
+
+/** THE EASING EXPONENT. house-rules.txt asks for a bar that is "always slightly
+ *  more than half full by design of its easing curve": 0.5 ^ 0.72 = 0.606, so
+ *  one promotion of two READS as more than half without the number lying (the
+ *  label next to it always prints the honest "1 of 2"). */
+const RAKE_EASE = 0.72;
+
+/** The bonus archetypes a drop can mint. APPEND-ONLY: inserting a row would
+ *  re-deal every past seed. Names and lines are lexicon rows with English
+ *  fallbacks; nothing here is XP, a grade, or anything the ledger can see. */
+const RAKE_DROPS = Object.freeze([
+  Object.freeze({
+    id: 'gold_star',
+    nameKey: 'rake_drop_gold_star', name: 'Gold Star',
+    lineKey: 'rake_drop_line_gold_star',
+    line: 'Pinned to the board where everyone can see it.',
+  }),
+  Object.freeze({
+    id: 'hall_pass',
+    nameKey: 'rake_drop_hall_pass', name: 'Hall Pass',
+    lineKey: 'rake_drop_line_hall_pass',
+    line: 'Signed and dated. Good for exactly one wandering.',
+  }),
+  Object.freeze({
+    id: 'gold_seal',
+    nameKey: 'rake_drop_gold_seal', name: 'Gold Seal',
+    lineKey: 'rake_drop_line_gold_seal',
+    line: 'Pressed while the wax was still soft. It kept the shape.',
+  }),
+  Object.freeze({
+    id: 'merit_mark',
+    nameKey: 'rake_drop_merit_mark', name: 'Merit Mark',
+    lineKey: 'rake_drop_line_merit_mark',
+    line: 'Someone wrote your name in the good column tonight.',
+  }),
+]);
+
+/**
+ * The sunk-cost meter's fill curve. PURE and exported so the campus door card
+ * and the suite can read the same number the end card paints.
+ * @param {number} frac 0..1 honest fraction
+ * @returns {number} 0..1 eased fill (strictly greater than `frac` in between)
+ */
+export function easedFill(frac) {
+  const f = Math.max(0, Math.min(1, Number(frac) || 0));
+  if (f <= 0) return 0;
+  if (f >= 1) return 1;
+  return Math.pow(f, RAKE_EASE);
+}
+
+/** PROMOTIONS_PER_TIER is registry-private, so derive it from the one exported
+ *  fact (tier = 1 + floor(promotions / N)) instead of duplicating the constant -
+ *  a curve change there must not silently desync this bar. Memoised. */
+let promosPerTierMemo = 0;
+function promosPerTier() {
+  if (promosPerTierMemo) return promosPerTierMemo;
+  const base = tierForPromotions(0);
+  let n = 2;
+  for (let p = 1; p <= 64; p++) { if (tierForPromotions(p) > base) { n = p; break; } }
+  promosPerTierMemo = n;
+  return n;
+}
+
+/**
+ * Cross-class progress toward the next tier promotion, from a game's meta row.
+ * PURE - `shell.progressFor(gameKey)` is the same thing read off the store, and
+ * that is what the campus door card consumes.
+ * @param {Object} gameMeta  store.gameMeta(gameKey)
+ * @returns {{tier:number, nextTier:number, have:number, need:number,
+ *            frac:number, eased:number, top:boolean}}
+ */
+export function tierProgress(gameMeta) {
+  const meta = (gameMeta && typeof gameMeta === 'object') ? gameMeta : {};
+  const need = promosPerTier();
+  const tier = tierFor(meta);
+  const promotions = Math.max(0, Math.round(Number(meta.promotions) || 0));
+  if (tier >= MAX_TIER) {
+    return { tier, nextTier: MAX_TIER, have: need, need, frac: 1, eased: 1, top: true };
+  }
+  const have = need > 0 ? Math.max(0, Math.min(need, promotions % need)) : 0;
+  const frac = need > 0 ? have / need : 0;
+  return {
+    tier, nextTier: Math.min(MAX_TIER, tier + 1),
+    have, need, frac, eased: easedFill(frac), top: false,
+  };
+}
 
 /* ----------------------------------------------------------------------------
  * THE SPIRAL POOL
@@ -65,14 +169,38 @@ const SPIRAL_POOL = Object.freeze([
   ['sp6.gif', 34], ['sp7.gif', 26], ['sp1.gif', 9], ['sp2.webp', 9],
   ['sp4.webp', 9], ['sp3.gif', 8], ['sp5.gif', 5],
 ]);
-function pickSpiralUrl(seed) {
+/** THE LOOM: the player's own saved spirals ride `init.settings.loomSpirals` as
+ *  absolute `https://ccp.spirals/loom_<slug>.gif` urls (the host maps the same
+ *  folder DTRH exposes). They are APPENDED to the bundled pool at a mid weight,
+ *  so a player with no Loom gets byte-identical picks and a player with one
+ *  sees their own work in roughly a quarter of classes. Validated: string,
+ *  https:, capped, de-duplicated. */
+const LOOM_WEIGHT = 20;
+const LOOM_CAP = 24;
+function loomSpiralRows(settings) {
+  const out = [];
+  try {
+    const list = settings && Array.isArray(settings.loomSpirals) ? settings.loomSpirals : [];
+    const seen = new Set();
+    for (const u of list) {
+      if (typeof u !== 'string' || !/^https:\/\/ccp\.spirals\//.test(u) || seen.has(u)) continue;
+      seen.add(u);
+      out.push([u, LOOM_WEIGHT]);
+      if (out.length >= LOOM_CAP) break;
+    }
+  } catch (e) { /* a bad list is an empty list */ }
+  return out;
+}
+function pickSpiralUrl(seed, settings) {
   try {
     const roll = makeRng(String(seed == null ? '' : seed) + '|spiral');
+    const pool = SPIRAL_POOL.concat(loomSpiralRows(settings));
     let total = 0;
-    for (const row of SPIRAL_POOL) total += row[1];
+    for (const row of pool) total += row[1];
     let r = roll() * total;
-    let file = SPIRAL_POOL[0][0];
-    for (const row of SPIRAL_POOL) { r -= row[1]; if (r < 0) { file = row[0]; break; } }
+    let file = pool[0][0];
+    for (const row of pool) { r -= row[1]; if (r < 0) { file = row[0]; break; } }
+    if (/^https:\/\//.test(file)) return file;
     return new URL('../../dtrh/assets/bubbles/effects/spirals/' + file, import.meta.url).href;
   } catch (e) { return null; }
 }
@@ -203,6 +331,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let extrasBox = null;            // replay/report bar + yesterday strip container
   let settingsPage = null;
   let reportCard = null;
+  /** The Deck V one-more card. It sits OVER the report card, never instead of
+   *  it (see showEndCard) - `{root, destroy}` while live, null otherwise. */
+  let endCard = null;
   let active = null;               // the running class (see startClass)
   let suspendedGlobally = false;
   let destroyed = false;
@@ -470,6 +601,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
 
   function showBoard(opts) {
     const silent = !!(opts && opts.silent);
+    // Leaving the report drops the one-more card with it (a card that outlived
+    // its screen would be a second, invisible Esc rung).
+    dismissEndCard();
 
     // FAST REPAINT: a live campus is patched, never rebuilt - tearing the stage
     // down on every meta echo would restart every ambient animation mid-frame.
@@ -521,6 +655,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         banner: timetable.banner,
         stats: campusStats(),
         reducedMotion,
+        // DECK V's sunk-cost meter, for the door card. Same numbers the end card
+        // paints (shell.progressFor is the public twin) - a door that promised a
+        // different fraction than the end card would be the one lie the rake
+        // cannot afford. Optional on the campus side: an older hub ignores it.
+        progressFor,
         on: {
           begin: (gameKey) => {
             const cls = timetable.classes.find((c) => c.gameKey === gameKey);
@@ -566,6 +705,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   /* ============================ SCREEN: SETTINGS ======================== */
   function showSettings() {
     if (active) pauseClass(true);
+    dismissEndCard();
     screen = 'settings';
     clearScreen();
     renderTopbar();
@@ -597,7 +737,253 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       onDone: () => showBoard(),
     });
     dom.screen.appendChild(reportCard.root);
+    // THE END CARD OUTLIVES A REPORT REPAINT. onPayout re-renders the report on
+    // the same screen; without this the one-more card would vanish the instant
+    // the host paid out, which is the exact moment it is meant to be up.
+    if (endCard && endCard.root) dom.screen.appendChild(endCard.root);
     setStage('arc-report-on');
+  }
+
+  /* ============================ DECK V: THE RAKE ========================
+   * Everything below is ADDITIVE and bounded by Law VI. Read the three rules
+   * before touching it:
+   *   1. the report card is never replaced - the end card is an overlay on the
+   *      same screen, and the report's own Done button still works underneath;
+   *   2. nothing here handles Esc. escapeStep() below is byte-for-byte the
+   *      ladder it always was, so a suspend overlay still owns the key
+   *      (trap 29's corollary) and boot.js still gets its rung back;
+   *   3. no XP, ever. C# owns the XP table (trap 23) - a drop is a stamp and a
+   *      line of lexicon, nothing the ledger can see.
+   * ==================================================================== */
+
+  /**
+   * STREAK JEOPARDY. What leaving actually costs, in the HOST's own numbers
+   * (core/store.js reads them off `payout-result` / the blob snapshot; the page
+   * may not write them). Three honest answers and no fourth:
+   *   - today is NOT credited yet -> the streak goes cold
+   *   - today IS credited          -> say so; leaving costs nothing
+   *   - the numbers are unknown    -> say NOTHING (never invent jeopardy)
+   * @returns {?string}
+   */
+  function jeopardyLine() {
+    let s;
+    try { s = store.streak(); } catch (e) { return null; }
+    if (!s) return null;
+    const n = s.count | 0;
+    // A zero (or absent) streak is also the "we do not know" answer, and both
+    // deserve silence: a fake number here would be the shell lying about the
+    // one thing it does not own.
+    if (!Number.isFinite(n) || n <= 0) return null;
+    const credited = (s.lastLocalDate && String(s.lastLocalDate) === localDate)
+      || (s.classesToday | 0) > 0;
+    const tpl = credited
+      ? t('rake_streak_credited', 'Attendance x{n} is banked for today already.')
+      : t('rake_streak_cold', 'Attendance x{n} goes cold if today ends here.');
+    return String(tpl).replace('{n}', String(n));
+  }
+
+  /** Say the jeopardy on the way out. Never blocks, never delays, never asks. */
+  function announceJeopardy() {
+    const line = jeopardyLine();
+    if (!line) return null;
+    say('leave-class jeopardy: ' + line);
+    try { shout(line); } catch (e) { /* a toast may never hold a door */ }
+    return line;
+  }
+
+  /**
+   * THE VARIABLE-RATIO DROP. Seeded per (UTC day, game) so a retake replays the
+   * same night and two players on the same day see the same board - Law V. The
+   * caller gates it: never on a retake, never on a free swim.
+   * @returns {?Object} one RAKE_DROPS row, or null
+   */
+  function rollRakeDrop(gameKey) {
+    try {
+      const roll = makeRng(utcDateSeed + '|rake-drop|' + String(gameKey));
+      if (roll() >= RAKE_DROP_ODDS) return null;
+      const i = Math.min(RAKE_DROPS.length - 1,
+        Math.max(0, Math.floor(roll() * RAKE_DROPS.length)));
+      return RAKE_DROPS[i];
+    } catch (e) { say('rake drop roll failed (skipped): ' + ((e && e.message) || e)); return null; }
+  }
+
+  /** Progress toward this game's next promotion (the campus reads this too). */
+  function progressFor(gameKey) {
+    try { return tierProgress(store.gameMeta(gameKey)); }
+    catch (e) { return tierProgress(null); }
+  }
+
+  /** Drop the one-more card. Idempotent; every screen change funnels here. */
+  function dismissEndCard() {
+    if (!endCard) return;
+    const card = endCard;
+    endCard = null;
+    try { card.destroy(); } catch (e) { /* noop */ }
+  }
+
+  /**
+   * THE ONE-MORE END CARD (house-rules Deck V + Deck VI).
+   *
+   * Retake is LIT, pulsing and pre-focused (Enter takes it); the way out is
+   * small and dim but LIVE, honest and in a fixed slot that never moves. The
+   * grade arrives as an OBJECT through the stamp ceremony - the shell never
+   * prints the letter as a bare string first (Deck VI, "grades as objects").
+   *
+   * @param {Object} o
+   * @param {Object} o.cls        the timetable class (what a retake replays)
+   * @param {Object} o.graded     core/grades.js result {grade, zen, capped}
+   * @param {boolean} o.isRetake  this run was already a replay
+   * @param {Array=} o.capped     the A-caps the rubric raised
+   */
+  function showEndCard({ cls, graded, isRetake, capped }) {
+    dismissEndCard();
+    if (!dom || !dom.screen || !cls) return null;
+
+    const gameKey = cls.gameKey;
+    const root = el('div', 'arc-endcard');
+    const card = el('div', 'arc-endcard-card');
+    root.appendChild(card);
+
+    card.appendChild(el('p', 'arc-kicker', t('rake_class_dismissed', 'Class dismissed')));
+
+    /* --- the grade, as a thing --- */
+    const gradeHost = el('div', 'arc-endcard-grade');
+    card.appendChild(gradeHost);
+    try {
+      ceremonies.gradeObject({
+        grade: graded && graded.grade,
+        zen: !!(graded && graded.zen),
+        target: gradeHost,
+        hold: 600000,               // it is the card's subject, not a flash
+      });
+    } catch (e) { say('end card grade object failed: ' + ((e && e.message) || e)); }
+
+    card.appendChild(el('h2', 'arc-h2', gameName(gameKey)));
+
+    /* --- LOSSES DISGUISED: a C, or a dropped hard gate, still gets a beat --- */
+    try {
+      const kind = ceremonies.payoff({
+        grade: graded && graded.grade,
+        zen: !!(graded && graded.zen),
+        capped,
+        target: gradeHost,
+      });
+      say('end card payoff (' + gameKey + '): ' + kind);
+    } catch (e) { say('end card payoff failed: ' + ((e && e.message) || e)); }
+
+    /* --- THE SUNK-COST METER --- */
+    const prog = progressFor(gameKey);
+    const meter = el('div', 'arc-rake-meter');
+    const fill = el('div', 'arc-rake-meter-fill');
+    meter.appendChild(fill);
+    try { meter.style.setProperty('--arc-p', prog.eased.toFixed(4)); } catch (e) { /* noop */ }
+    meter.setAttribute('role', 'img');
+    const meterText = prog.top
+      ? t('rake_top_of_class', 'Top of the class')
+      : String(t('rake_promo_progress', '{have} of {need} to {tier}'))
+        .replace('{have}', String(prog.have))
+        .replace('{need}', String(prog.need))
+        .replace('{tier}', tierLabel(prog.nextTier));
+    meter.setAttribute('aria-label', meterText);
+    card.appendChild(meter);
+    card.appendChild(el('p', 'arc-rake-meterlabel', meterText));
+
+    /* --- THE DROP. Never on a retake (the day already paid), never endless. --- */
+    const drop = isRetake ? null : rollRakeDrop(gameKey);
+    if (drop) {
+      const box = el('div', 'arc-endcard-drop');
+      const stampHost = el('div', 'arc-endcard-dropstamp');
+      box.appendChild(stampHost);
+      try {
+        ceremonies.stamp({
+          text: t(drop.nameKey, drop.name),
+          target: stampHost,
+          hold: 600000,
+        });
+      } catch (e) { say('drop stamp failed: ' + ((e && e.message) || e)); }
+      box.appendChild(el('p', 'arc-note', t(drop.lineKey, drop.line)));
+      card.appendChild(box);
+      say('rake drop minted for ' + gameKey + ': ' + drop.id + ' (no XP - C# owns that)');
+    }
+
+    /* --- THE BUTTONS. Order is fixed: the lit one first, then the two small
+     *     dim ones in a row that never re-orders and never re-flows. --- */
+    const actions = el('div', 'arc-endcard-actions');
+    const again = el('button', 'btn primary arc-retake', t('retake', 'Retake'));
+    again.type = 'button';
+    // Pre-focused. `autofocus` is the declarative half (a fresh node inserted
+    // into a live document does not always take focus() in every engine).
+    again.setAttribute('autofocus', '');
+    again.setAttribute('data-endcard-focus', '1');
+    again.addEventListener('click', () => doRetake());
+    actions.appendChild(again);
+
+    const exits = el('div', 'arc-endcard-exits');
+    // The report card is UNDER this overlay, so the way to it is one dim press
+    // - the card may sit on top of the report, never in place of it.
+    const toReport = el('button', 'btn ghost arc-endcard-small', t('report_card', 'Report Card'));
+    toReport.type = 'button';
+    toReport.addEventListener('click', () => dismissEndCard());
+    exits.appendChild(toReport);
+
+    const out = el('button', 'btn ghost arc-endcard-small', t('rake_back_to_campus', 'Back to campus'));
+    out.type = 'button';
+    out.addEventListener('click', () => { dismissEndCard(); showBoard(); });
+    exits.appendChild(out);
+    actions.appendChild(exits);
+    card.appendChild(actions);
+
+    /* --- the honest chip (trap 23). A retake is FREE, and the day keeps the
+     *     grade it already recorded - the card says so instead of implying the
+     *     replay is worth something it is not. --- */
+    card.appendChild(el('p', 'arc-note arc-endcard-chip',
+      t('rake_retake_chip', 'Free replay. It pays nothing, and today keeps your first grade.')));
+
+    /** Enter = one more. Esc is NOT touched: it walks boot.js's ladder exactly
+     *  as it did before this card existed. */
+    function onKey(e) {
+      if (!endCard || endCard.root !== root) return;
+      if (active) return;                       // never over a live class/suspend
+      const k = e && (e.key || e.code);
+      if (k !== 'Enter' && k !== 'NumpadEnter') return;
+      const tag = e && e.target && e.target.tagName ? String(e.target.tagName).toUpperCase() : '';
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      try { e.preventDefault(); } catch (e2) { /* noop */ }
+      doRetake();
+    }
+
+    /* ONE RETAKE PER CARD. A focused <button> answers Enter with a click of its
+     * own, so the keydown path and the click path can BOTH fire from one press -
+     * without this latch that press would start the class twice (the second
+     * start tearing down the first mid-frame). */
+    let taken = false;
+    function doRetake() {
+      if (taken) return;
+      taken = true;
+      dismissEndCard();
+      // A free swim never reaches this card, so this is always a real class.
+      try { startClass(cls); }
+      catch (e) { say('retake failed to start: ' + ((e && e.message) || e)); showBoard(); }
+    }
+
+    if (typeof window !== 'undefined' && window.addEventListener) {
+      window.addEventListener('keydown', onKey);
+    }
+
+    endCard = {
+      root,
+      gameKey,
+      destroy() {
+        if (typeof window !== 'undefined' && window.removeEventListener) {
+          window.removeEventListener('keydown', onKey);
+        }
+        try { root.remove(); } catch (e) { /* noop */ }
+      },
+    };
+
+    dom.screen.appendChild(root);
+    try { if (typeof again.focus === 'function') again.focus(); } catch (e) { /* noop */ }
+    return endCard;
   }
 
   /* ============================ THE CLASS RUNNER ======================== */
@@ -797,6 +1183,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    */
   function startClass(cls, opts) {
     if (suspendedGlobally) { shout(t('class_suspended', 'Class Suspended')); return; }
+    dismissEndCard();
     if (active) teardownClass();
 
     const endless = !!(opts && opts.endless);
@@ -836,7 +1223,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
      * mid-fade. Never awaited, never preloaded here - the browser fetches it
      * when the first spiral wash actually mounts, and the CSS conic gradient
      * is still the fallback if it 404s. */
-    const classSpiral = pickSpiralUrl(seed);
+    const classSpiral = pickSpiralUrl(seed, src.settings);
     let engine;
     try {
       engine = createEngine({
@@ -1098,6 +1485,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       assists,
     };
     const graded = gradeClass(input);
+    // The A-caps the rubric RAISED, whether or not they moved the letter. The
+    // report card already prints these; the end card's payoff reads the same
+    // list so a dropped hard gate still gets its scaled-down beat even when the
+    // grade was under the cap anyway.
+    const capsList = capsRaised(input);
     const flavorXp = Math.max(0, Math.min(FLAVOR_XP_CAP, Math.round(Number(r.flavorXp) || 0)));
 
     // THE FIRST GRADE OF THE DAY IS THE ONE THAT COUNTS. A retake is a free
@@ -1113,7 +1505,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         grade: graded.grade,
         zen: graded.zen,
         composite: graded.composite,
-        capped: capsRaised(input),
+        capped: capsList,
         tier: gradeTier,
         xp: null,                   // filled by payout-result; C# owns the table
       };
@@ -1178,6 +1570,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
 
     teardownClass();
     showReport();
+    // DECK V: the one-more card lands ON the report card - after `class-ended`,
+    // over the transcript, never in place of it. A free swim returned above and
+    // never gets here, which is also why a swim can never mint a drop.
+    try {
+      showEndCard({ cls, graded, isRetake, capped: capsList });
+    } catch (e) { say('end card failed (the report card still stands): ' + ((e && e.message) || e)); }
   }
 
   /* ---------------------- pause / suspend / teardown -------------------- */
@@ -1205,6 +1603,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         leave.addEventListener('click', () => showBoard());
         bar.appendChild(resume); bar.appendChild(leave);
         overlay.appendChild(bar);
+        /* DECK V - STREAK JEOPARDY. What "Leave class" actually costs, in the
+         * HOST's own attendance numbers. It is a LINE, not a gate: the button
+         * beside it is unchanged, un-delayed and still the first thing under
+         * your hand. Unknown numbers print nothing at all. */
+        const jeopardy = jeopardyLine();
+        if (jeopardy) {
+          overlay.appendChild(el('p', 'arc-note arc-jeopardy', jeopardy));
+        }
         overlay.appendChild(el('p', 'arc-note', 'Hold Esc to leave the Arcademy.'));
         active.root.appendChild(overlay);
         active.pauseEl = overlay;
@@ -1256,6 +1662,13 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       try { active.engine.suspend(!!on); } catch (e) { say('engine.suspend threw: ' + ((e && e.message) || e)); }
       try { active.peek.forceHide(); } catch (e) { /* noop */ }
       try { active.instance.suspend(!!on); } catch (e) { say('game.suspend threw: ' + ((e && e.message) || e)); }
+      // A LIFTED SUSPEND MUST NOT UN-PAUSE THE GAME. The class stays behind its
+      // pause card (see below) but a game's suspend(false) typically restarts its
+      // own loop - so re-assert the pause the card still shows (Misdirection and
+      // the Deep End both ran on behind the overlay before this line).
+      if (!on && active.paused) {
+        try { active.instance.pause(); } catch (e) { say('game.pause threw: ' + ((e && e.message) || e)); }
+      }
       if (on) {
         pauseClass(true);
         showSuspendedOverlay(reason === 'audio-only'
@@ -1367,12 +1780,30 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       // own Resume / Leave class buttons remain the page-side way out.
       if (active && active.suspendEl) return true;
       if (active && !active.paused) { pauseClass(true); return true; }
-      if (active && active.paused) { showBoard(); return true; }
+      if (active && active.paused) {
+        // DECK V: say what it costs on the way past, then go. The rung itself
+        // is unchanged - same condition, same showBoard(), same `true`.
+        announceJeopardy();
+        showBoard();
+        return true;
+      }
       return false;
     },
 
     get screen() { return screen; },
     get inClass() { return !!active; },
+
+    /* ---------------------- DECK V, read-only seams ---------------------- */
+    /** Cross-class progress toward a game's next tier promotion (the sunk-cost
+     *  meter's numbers). `{tier, nextTier, have, need, frac, eased, top}` -
+     *  `eased` is the fill, `have`/`need` are the honest label. The campus door
+     *  card reads the same function through its `progressFor` option. */
+    progressFor,
+    /** What leaving right now would cost, or null when the shell does not know.
+     *  Sourced ONLY from the host-owned attendance numbers in the store. */
+    jeopardy() { return jeopardyLine(); },
+    /** The one-more card, while it is up (null otherwise). Test seam. */
+    get endCard() { return endCard; },
 
     /** Read-only provider diagnostics (local/remote pool sizes, placeholderFloor).
      *  The one window onto the asset seam: `placeholderFloor:true` means the host
@@ -1382,6 +1813,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     destroy() {
       if (destroyed) return;
       destroyed = true;
+      dismissEndCard();
       teardownClass();
       setStage(null);
       if (campus) { try { campus.destroy(); } catch (e) { /* noop */ } campus = null; }

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -312,6 +312,128 @@ html.arc-report-on body { overflow:hidden; }
 .arc-reportstage .arc-classbar { margin:16px 0 0; }
 .arc-reportstage .arc-sharepreview { background:color-mix(in srgb, var(--flap-well), transparent 25%); }
 
+/* ============================ DECK V: THE RAKE ===========================
+   The one-more card. It sits OVER the report stage (z 20 vs 10) and never in
+   place of it - dismissing the card reveals the transcript underneath, which is
+   why the small "Report Card" button exists at all.
+
+   Law VI is a LAYOUT rule here as much as a wiring one: the exits live in their
+   own fixed row with a fixed height, so nothing about a grade, a drop or a
+   progress label can push them around between classes. The lit button pulses;
+   the dim ones do not move.
+
+   No `display:` here belongs to a node the shell toggles with the hidden
+   attribute - the end card is REMOVED, not hidden (shell.js dismissEndCard). */
+.arc-endcard {
+  position:fixed; inset:0; z-index:20;
+  display:flex; align-items:center; justify-content:center;
+  padding:clamp(16px, 4vh, 48px);
+  overflow:auto;
+  background:
+    radial-gradient(700px 520px at 50% 40%, color-mix(in srgb, var(--pink), transparent 90%), transparent 70%),
+    color-mix(in srgb, var(--ground), transparent 8%);
+  backdrop-filter:blur(7px);
+  animation:arc-endcard-in .28s ease-out both;
+}
+@keyframes arc-endcard-in { from { opacity:0; } to { opacity:1; } }
+.arc-endcard-card {
+  width:min(520px, 92vw); margin:auto;
+  display:flex; flex-direction:column; align-items:center; gap:12px;
+  text-align:center;
+  padding:26px 28px 22px;
+  background:linear-gradient(168deg, var(--panel), var(--navy) 78%);
+  border:var(--hairline); border-radius:var(--radius);
+  box-shadow:0 30px 80px rgba(0,0,0,.7), inset 0 1px 0 rgba(255,255,255,.06);
+  animation:arc-endcard-rise .38s cubic-bezier(.2,1.2,.4,1) both;
+}
+@keyframes arc-endcard-rise {
+  from { transform:translateY(22px) scale(.97); opacity:0; }
+  to   { transform:none; opacity:1; }
+}
+.arc-endcard-card .arc-kicker { margin:0; }
+.arc-endcard-card .arc-h2 { margin:0; font-size:20px; letter-spacing:.14em; }
+/* The grade OBJECT lands here (ceremonies.gradeObject) - a minimum height so a
+   jackpot beat and a near-miss beat leave the buttons in the same place. */
+.arc-endcard-grade {
+  position:relative; min-height:64px;
+  display:flex; align-items:center; justify-content:center; gap:10px;
+}
+.arc-endcard-grade .arc-stamp { font-size:30px; padding:8px 18px; letter-spacing:.1em; }
+.arc-gradeobj.g-s { color:var(--gS); border-color:var(--gS); }
+.arc-gradeobj.g-b { color:var(--gB); border-color:var(--gB); }
+.arc-gradeobj.g-c { color:var(--gC); border-color:var(--gC); box-shadow:none; }
+.arc-gradeobj.g-pass { color:var(--gPass); border-color:var(--gPass); }
+
+/* The sunk-cost meter. The FILL is eased (shell.js easedFill); the label beside
+   it prints the honest count, so the bar flatters without the number lying. */
+.arc-rake-meter {
+  width:100%; height:9px; border-radius:999px; overflow:hidden;
+  background:var(--flap-well); border:1px solid var(--line);
+}
+.arc-rake-meter-fill {
+  height:100%; width:calc(var(--arc-p, 0) * 100%);
+  background:linear-gradient(90deg, var(--pink-deep), var(--pink) 70%, var(--gold));
+  box-shadow:0 0 12px color-mix(in srgb, var(--pink), transparent 45%);
+  transition:width .55s cubic-bezier(.2,.9,.3,1);
+}
+.arc-rake-meterlabel {
+  margin:0; font-family:var(--mono); font-size:10.5px; letter-spacing:.14em;
+  text-transform:uppercase; color:var(--ink-faint);
+}
+
+/* The variable-ratio drop. Rare by construction, so it gets to be loud. */
+.arc-endcard-drop {
+  display:flex; flex-direction:column; align-items:center; gap:7px;
+  padding:12px 14px; margin-top:2px;
+  border:1px dashed color-mix(in srgb, var(--gold), transparent 45%);
+  border-radius:10px;
+  background:radial-gradient(140% 100% at 50% 0%, color-mix(in srgb, var(--gold), transparent 88%), transparent 70%);
+}
+.arc-endcard-drop .arc-note { margin:0; font-size:12px; color:var(--ink-dim); max-width:38ch; }
+.arc-endcard-dropstamp { min-height:32px; display:flex; align-items:center; justify-content:center; }
+
+/* THE BUTTONS. One lit, pulsing, pre-focused; two small and dim in a row that
+   never re-orders. `min-height` on the exits row is deliberate - a wrapped
+   label must not shift the exit up or down between classes. */
+.arc-endcard-actions {
+  display:flex; flex-direction:column; align-items:center; gap:10px;
+  width:100%; margin-top:6px;
+}
+.arc-endcard-actions .arc-retake {
+  min-width:220px; font-size:13px; letter-spacing:.14em; padding:10px 22px;
+  animation:arc-retake-pulse 1.9s ease-in-out infinite;
+}
+.arc-endcard-actions .arc-retake:focus-visible { outline:2px solid var(--ink); outline-offset:3px; }
+@keyframes arc-retake-pulse {
+  0%, 100% { box-shadow:0 0 0 0 color-mix(in srgb, var(--pink), transparent 45%); }
+  50%      { box-shadow:0 0 22px 4px color-mix(in srgb, var(--pink), transparent 55%); }
+}
+html.arc-reduced .arc-endcard-actions .arc-retake { animation:none; box-shadow:0 0 16px rgba(255,105,180,.4); }
+@media (prefers-reduced-motion: reduce) {
+  .arc-endcard-actions .arc-retake { animation:none; box-shadow:0 0 16px rgba(255,105,180,.4); }
+}
+.arc-endcard-exits {
+  display:flex; align-items:center; justify-content:center; gap:10px;
+  min-height:30px; width:100%;
+}
+.arc-endcard-small {
+  font-size:9.5px; letter-spacing:.1em; padding:5px 11px;
+  opacity:.62;                       /* dim, never dead - Law VI */
+}
+.arc-endcard-small:hover { opacity:1; }
+.arc-endcard-small:focus-visible { opacity:1; outline:2px solid var(--pink); outline-offset:2px; }
+.arc-endcard-chip {
+  margin:2px 0 0; font-size:11px; color:var(--ink-faint); max-width:40ch;
+}
+
+/* STREAK JEOPARDY, on the pause card. A line, never a gate. */
+.arc-jeopardy {
+  color:var(--gold);
+  font-family:var(--mono); font-size:11.5px; letter-spacing:.06em;
+  border-top:1px solid color-mix(in srgb, var(--gold), transparent 72%);
+  padding-top:9px; margin-top:2px;
+}
+
 /* ============================ CEREMONIES ================================= */
 .arc-ceremony { position:fixed; inset:0; z-index:45; pointer-events:none; }
 .arc-stamp {
@@ -530,6 +652,37 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
 }
 .arc-keycap.capturing { border-color:var(--pink); color:var(--pink); animation:arc-caret 1.1s steps(2) infinite; }
 @keyframes arc-caret { 50% { border-color:var(--line); } }
+
+/* DECK VI - VERB GLYPHS. The cap is DRAWN: a square key with a moulded lip and
+   a shadow under it, wearing the key's glyph (␣, ←, P) instead of its name. The
+   name is not deleted, it moves - settings.js puts it on `title` + `aria-label`
+   and the verb's own label stays in the row beside it. `.wide` is the escape
+   hatch for keys with no symbol (F11, Numpad4) and for the capture prompt. */
+.arc-keycap.arc-glyphcap {
+  min-width:38px; width:38px; height:36px; padding:0;
+  display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--mono); font-size:15px; line-height:1;
+  background:linear-gradient(180deg, var(--panel2), color-mix(in srgb, var(--panel2), black 24%));
+  border:1px solid color-mix(in srgb, var(--line), var(--lav) 18%);
+  border-radius:7px;
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.14),
+    inset 0 -2px 0 rgba(0,0,0,.45),
+    0 3px 0 color-mix(in srgb, var(--flap-well), black 20%),
+    0 5px 10px rgba(0,0,0,.45);
+  transform:translateY(-1px);
+  transition:transform .08s, box-shadow .08s;
+}
+.arc-keycap.arc-glyphcap.wide {
+  width:auto; min-width:74px; padding:0 11px; font-size:11px; letter-spacing:.06em;
+}
+.arc-keycap.arc-glyphcap:hover { color:var(--pink); border-color:var(--pink-deep); }
+.arc-keycap.arc-glyphcap:active,
+.arc-keycap.arc-glyphcap.capturing {
+  transform:translateY(1px);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.1), inset 0 -1px 0 rgba(0,0,0,.4), 0 1px 0 rgba(0,0,0,.5);
+}
+.arc-keycap.arc-glyphcap:focus-visible { outline:2px solid var(--pink); outline-offset:3px; }
 
 /* ============================ PEEK ======================================= */
 .arc-peekbtn {

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -114,6 +114,8 @@ internal static class ArcademyHostService
     /// <remarks>static readonly, not const: a const would make the guard in <see cref="Launch"/>
     /// compile-time unreachable (CS0162), exactly as JustDropService.Withheld documents.</remarks>
     public static readonly bool DoorAvailable = false;
+    /// <summary>Whether the live instance was opened through the dev switch (recovery relaunch keeps it).</summary>
+    private static bool _devDoor;
 
     // ============================ launch / close ============================
 
@@ -123,7 +125,16 @@ internal static class ArcademyHostService
     /// switched on mid-class, which suspends the class rather than closing the window), then the
     /// gates for a FRESH launch, each failing closed: the door, T2, then AudioOnlySession.
     /// </summary>
-    public static void Launch()
+    /// <summary>
+    /// The <c>--arcademy</c> dev switch. Bypasses ONLY the door (rule 2) so an unreleased build can be
+    /// play-tested from the command line; T2 and AudioOnlySession still apply underneath. Not
+    /// reachable from any UI - the switch is parsed once in App.OnStartup.
+    /// </summary>
+    public static void LaunchDev() => Launch(devDoor: true);
+
+    public static void Launch() => Launch(devDoor: false);
+
+    private static void Launch(bool devDoor)
     {
         // 1. Idempotent: never re-launch a live class, and never strand an open window behind a
         //    gate that only applies to opening a NEW one (the mid-class AudioOnlySession flip
@@ -135,9 +146,9 @@ internal static class ArcademyHostService
         //    visible, and the house rule is that the code path which actually opens the door has
         //    to be the one that can say no (see the BtnStartArcademy_Click docs). Silent: there is
         //    no announced feature to explain a refusal about yet.
-        if (!DoorAvailable)
+        if (!DoorAvailable && !devDoor)
         {
-            App.Logger?.Debug("ArcademyHost.Launch refused: the Arcademy door is not open yet (unreleased)");
+            App.Logger?.Information("ArcademyHost.Launch refused: the Arcademy door is not open yet (unreleased)");
             return;
         }
 
@@ -155,6 +166,7 @@ internal static class ArcademyHostService
             return;
         }
 
+        _devDoor = devDoor;
         try
         {
             _exiting = false;
@@ -175,7 +187,13 @@ internal static class ArcademyHostService
                 ("ccp.assets", App.EffectiveAssetsPath, CoreWebView2HostResourceAccessKind.Allow),
                 // Downloaded audio packs (sfx/vo) mirror the ccp.game tree under their own origin.
                 ChaosWebViewHost.ContentMapping(),
+                // THE LOOM: the player's own saved spirals (the same folder DTRH exposes). The
+                // shell's spiral pool mixes them in via settings.loomSpirals; a missing folder
+                // is simply an empty list, so create it the way DtrhHostService does.
+                ("ccp.spirals", Chaos.DtrhLoomStore.SpiralsFolder, CoreWebView2HostResourceAccessKind.Allow),
             };
+            try { Directory.CreateDirectory(Chaos.DtrhLoomStore.SpiralsFolder); }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyHost: spirals dir create failed: {E}", ex.Message); }
             // Creator mods: only the mod's arcademy subfolder is mapped, keeping the rest of its
             // resources off the page. Launch-time snapshot - switching the active mod needs a
             // relaunch, exactly like DTRH.
@@ -648,6 +666,14 @@ internal static class ArcademyHostService
         var bag = ParseJsonObject(s?.ArcademySettingsJson) ?? new JObject();
         try { bag["localAssets"] = BuildLocalAssets(); }
         catch (Exception ex) { App.Logger?.Debug("ArcademyHost.BuildSettingsBag: {E}", ex.Message); }
+        // The Loom's saved spirals, as ccp.spirals urls (the DTRH shape, verbatim). The page's
+        // spiral pool appends them to the bundled set; an empty list changes nothing.
+        try
+        {
+            bag["loomSpirals"] = new JArray(Chaos.DtrhLoomStore.List()
+                .Select(sp => (object)$"https://ccp.spirals/loom_{sp.Slug}.gif").ToArray());
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.BuildSettingsBag loom: {E}", ex.Message); }
         return bag;
     }
 
@@ -1084,6 +1110,363 @@ internal static class ArcademyHostService
         ["ic_royal"] = "ROYAL",
         ["ic_streak_n"] = "chain {n}",
         ["ic_tonight"] = "tonight only",
+        // ---- Semester II/III game + family rows (2026-08-23)
+        ["family_puzzle"] = "puzzle",
+        ["family_recall"] = "recall",
+        ["game_anomaly"] = "Anomaly",
+        ["game_composure"] = "Composure",
+        // ---- campus wings: Semester II/III rooms (2026-08-23)
+        ["campus_desc_anomaly"] = "Everything in here matches. One thing does not. Find it before it moves.",
+        ["campus_desc_composure"] = "Slide the picture back together while the room does its best to blur it.",
+        ["campus_desc_east_open"] = "The tape is down. Wet paint, three new doors, nobody at the desk.",
+        ["campus_desc_echo"] = "It plays a line, you play it back. Then it adds one more, every time.",
+        ["campus_desc_instant_recall"] = "Watch the whole hour, then answer for it. You never hear it coming.",
+        ["campus_desc_misdirection"] = "Keep your eyes on the one that matters. It will not make that easy.",
+        ["campus_desc_west_open"] = "Older boards, deeper rooms. Nobody in here is in any hurry.",
+        ["campus_room_anomaly"] = "Darkroom",
+        ["campus_room_composure"] = "The Studio",
+        ["campus_room_echo"] = "Music Room",
+        ["campus_room_instant_recall"] = "Lecture Hall",
+        ["campus_room_misdirection"] = "The Parlour",
+        // ---- shell Deck V THE RAKE (2026-08-23)
+        ["rake_back_to_campus"] = "Back to campus",
+        ["rake_class_dismissed"] = "Class dismissed",
+        ["rake_drop_gold_seal"] = "Gold Seal",
+        ["rake_drop_gold_star"] = "Gold Star",
+        ["rake_drop_hall_pass"] = "Hall Pass",
+        ["rake_drop_line_gold_seal"] = "Pressed while the wax was still soft. It kept the shape.",
+        ["rake_drop_line_gold_star"] = "Pinned to the board where everyone can see it.",
+        ["rake_drop_line_hall_pass"] = "Signed and dated. Good for exactly one wandering.",
+        ["rake_drop_line_merit_mark"] = "Someone wrote your name in the good column tonight.",
+        ["rake_drop_merit_mark"] = "Merit Mark",
+        ["rake_promo_progress"] = "{have} of {need} to {tier}",
+        ["rake_retake_chip"] = "Free replay. It pays nothing, and today keeps your first grade.",
+        ["rake_streak_cold"] = "Attendance x{n} goes cold if today ends here.",
+        ["rake_streak_credited"] = "Attendance x{n} is banked for today already.",
+        ["rake_top_of_class"] = "Top of the class",
+        // ---- Daily Trigger class-rules sheet (2026-08-23)
+        ["dt_howto_go"] = "Start homeroom",
+        ["dt_howto_marks"] = "Star: right letter, right place. Half: right letter, elsewhere. Cross: not in it.",
+        ["dt_howto_rows"] = "Six rows is the whole budget. Every wrong row turns the room up one notch.",
+        ["dt_howto_title"] = "Class rules",
+        ["dt_howto_type"] = "Type a word into the row, then Enter. One answer a day, the same for everyone.",
+        // ---- Deja Vu class-rules sheet (2026-08-23)
+        ["dv_howto_flip"] = "Turn two slides. A matching pair stays lit. Anything else turns back over.",
+        ["dv_howto_go"] = "Deal the board",
+        ["dv_howto_redeal"] = "Sometimes the whole board re-deals. Same pairs - only the seats change.",
+        ["dv_howto_swap"] = "The board only moves while nothing is face up, and it always shudders first.",
+        ["dv_howto_title"] = "Class rules",
+        // ---- The Deep End class-rules sheet + perf ladder (2026-08-23)
+        ["de_howto_ceiling"] = "The ladder ends at the eleventh depth. Reach it and the class holds you there.",
+        ["de_howto_go"] = "Into the water",
+        ["de_howto_merge"] = "Two matching tiles meet and sink one depth. The room gets heavier as you go.",
+        ["de_howto_resurface"] = "A locked board is not a loss. Your depth is banked and the water turns fresh.",
+        ["de_howto_swipe"] = "Swipe, or use the arrows. Every tile on the board slides that way at once.",
+        ["de_howto_title"] = "Class rules",
+        ["de_perf"] = "Performance",
+        ["de_perf_auto"] = "Auto",
+        ["de_perf_full"] = "Full",
+        ["de_perf_hint"] = "Auto watches the frame rate and drops to Lite. Lite: fewer live loops, calmer water.",
+        ["de_perf_lite"] = "Lite",
+        // ---- MISDIRECTION (md_) - games/misdirection/lex.js MD_LEX
+        ["md_almost"] = "ONE OFF",
+        ["md_almost_line"] = "One off. She was next door the whole time.",
+        ["md_auto_bank_line"] = "Banked for you.",
+        ["md_auto_ride_line"] = "Riding for you.",
+        ["md_bank"] = "Bank",
+        ["md_banked_line"] = "Banked. Nothing takes that back.",
+        ["md_bell_line"] = "The bell. Hands off the table.",
+        ["md_bell_warn"] = "Twenty seconds.",
+        ["md_blind_line"] = "The hand comes over the table.",
+        ["md_brief"] = "Watch the shell. Keep watching it. Then point at it.",
+        ["md_bust_line"] = "The pot goes back to the house. Your bank is untouched.",
+        ["md_chip_clock"] = "Time left",
+        ["md_chip_pot"] = "Pot",
+        ["md_chip_round"] = "Round",
+        ["md_chip_streak"] = "Streak",
+        ["md_end_banked"] = "Banked",
+        ["md_end_blind"] = "Called through a blackout",
+        ["md_end_clean"] = "You banked a round before your first miss.",
+        ["md_end_deepest"] = "Deepest ride banked",
+        ["md_end_latency"] = "Average pick",
+        ["md_end_no"] = "No",
+        ["md_end_picks"] = "Picks",
+        ["md_end_rounds"] = "Rounds",
+        ["md_end_streak"] = "Best streak",
+        ["md_end_title"] = "Table report",
+        ["md_end_yes"] = "Yes",
+        ["md_hit_line"] = "Right where you said she was.",
+        ["md_howto_go"] = "Open the table",
+        ["md_howto_keys"] = "Keys {keys} pick a shell.",
+        ["md_howto_pick"] = "Point at the shell you followed. Four seconds, every round.",
+        ["md_howto_shuffle"] = "They slide and trade places. The room will do its best to blind you.",
+        ["md_howto_stake"] = "Right? Bank the pot, or ride it double into a dirtier shuffle.",
+        ["md_howto_title"] = "Class rules",
+        ["md_howto_watch"] = "One shell lifts. What is under it is the only thing you are tracking.",
+        ["md_jackpot"] = "JACKPOT",
+        ["md_key_pick1"] = "Pick the first shell",
+        ["md_key_pick2"] = "Pick the second shell",
+        ["md_key_pick3"] = "Pick the third shell",
+        ["md_key_pick4"] = "Pick the fourth shell",
+        ["md_key_pick5"] = "Pick the fifth shell",
+        ["md_miss_line"] = "Empty. The true lid comes up.",
+        ["md_near_miss"] = "SO CLOSE",
+        ["md_pick_line"] = "Where is she?",
+        ["md_remedial_line"] = "Slow round. Clean shuffle, full pot.",
+        ["md_retake"] = "Retake",
+        ["md_reveal_line"] = "There she is.",
+        ["md_ride"] = "Ride",
+        ["md_ride_cap_line"] = "Five deep. The house pays out and the table resets.",
+        ["md_ride_line"] = "Riding. The table gets dirtier.",
+        ["md_royal"] = "ROYAL",
+        ["md_scholarship"] = "SCHOLARSHIP ROUND",
+        ["md_shell_aria"] = "Shell {n}",
+        ["md_shell_noun"] = "Shell",
+        ["md_shell_skin"] = "Shell skin",
+        ["md_shell_skin_contrast"] = "High contrast",
+        ["md_shell_skin_hint"] = "Themed shells, plain shapes, or high-contrast rims that stay readable.",
+        ["md_shell_skin_minimal"] = "Minimal",
+        ["md_shell_skin_themed"] = "Themed",
+        ["md_shuffle_line"] = "Eyes on her.",
+        ["md_stake_line"] = "Bank it, or ride it double or nothing?",
+        ["md_stake_mode"] = "Stake prompt",
+        ["md_stake_mode_ask"] = "Ask",
+        ["md_stake_mode_bank"] = "Always bank",
+        ["md_stake_mode_hint"] = "Ask after every win, or always bank / always ride without the prompt.",
+        ["md_stake_mode_ride"] = "Always ride",
+        ["md_stamp_bank"] = "BANKED",
+        ["md_stamp_bell"] = "BELL",
+        ["md_stamp_blind"] = "EYES OPEN",
+        ["md_timeout_line"] = "Too slow. The lid comes up anyway.",
+        ["md_trick_feint"] = "Nothing moved that time",
+        ["md_trick_hint"] = "This one. Surely.",
+        ["md_trick_melt"] = "The lids run like wax",
+        ["md_trick_seen"] = "Did you see that?",
+        ["md_voided_line"] = "That round is off the books. Your bank is safe.",
+        // ---- ECHO (ec_) - games/echo/lex.js EC_LEX
+        ["ec_brief"] = "Sit down. Listen first.",
+        ["ec_chip_best"] = "Longest echo",
+        ["ec_chip_clock"] = "Time left",
+        ["ec_chip_len"] = "Sequence length",
+        ["ec_chip_streak"] = "Streak",
+        ["ec_decoy_tell"] = "Not this one",
+        ["ec_end_accuracy"] = "Accuracy",
+        ["ec_end_best"] = "Longest echo",
+        ["ec_end_decoys"] = "Decoys resisted",
+        ["ec_end_encore"] = "Encore used",
+        ["ec_end_line"] = "The room keeps the length. You keep the tune.",
+        ["ec_end_no"] = "No",
+        ["ec_end_record"] = "A new personal best",
+        ["ec_end_sequences"] = "Sequences held",
+        ["ec_end_streak"] = "Best run of pads",
+        ["ec_end_tempo"] = "Tempo held",
+        ["ec_end_title"] = "Class dismissed",
+        ["ec_end_yes"] = "Yes",
+        ["ec_howto_decoy"] = "A pad may light out of turn. Leave that one alone.",
+        ["ec_howto_go"] = "Begin",
+        ["ec_howto_repeat"] = "Then repeat it back, in order, by tap or by key.",
+        ["ec_howto_title"] = "Class rules",
+        ["ec_howto_watch"] = "The pads play a sequence. Watch it. Listen to it.",
+        ["ec_jackpot"] = "Perfect pitch",
+        ["ec_key_pad1"] = "Pad 1",
+        ["ec_key_pad2"] = "Pad 2",
+        ["ec_key_pad3"] = "Pad 3",
+        ["ec_key_pad4"] = "Pad 4",
+        ["ec_key_pad5"] = "Pad 5",
+        ["ec_key_pad6"] = "Pad 6",
+        ["ec_msg_bell_warn"] = "Last of the class.",
+        ["ec_msg_clear"] = "Clean. One longer now.",
+        ["ec_msg_decoy_warn"] = "One of them lies tonight. Do not echo it.",
+        ["ec_msg_encore"] = "Again. Slower this time.",
+        ["ec_msg_encore_clear"] = "Held. Keep going.",
+        ["ec_msg_encore_fail"] = "Gone. A new one, then.",
+        ["ec_msg_fail"] = "Broken. Listen again.",
+        ["ec_msg_input"] = "Your turn.",
+        ["ec_msg_near"] = "One short of it.",
+        ["ec_msg_new"] = "A new one, then.",
+        ["ec_msg_resisted"] = "You let it pass. Good.",
+        ["ec_msg_silent"] = "No sound tonight. Watch the light.",
+        ["ec_msg_timeout"] = "Too slow. Listen again.",
+        ["ec_msg_watch"] = "Watch.",
+        ["ec_near_miss"] = "So nearly",
+        ["ec_pad_aria"] = "Pad {n}",
+        ["ec_pad_words"] = "Pad faces",
+        ["ec_pad_words_hint"] = "Pads wear a word from your pool, or a plain glyph only.",
+        ["ec_retake"] = "Retake",
+        ["ec_ring_aria"] = "The pads",
+        ["ec_royal"] = "The whole melody",
+        ["ec_taunt_ghost"] = "This one. Surely this one.",
+        ["ec_taunt_label"] = "Read it again. Or do not.",
+        ["ec_taunt_slow"] = "Slower than you were.",
+        ["ec_taunt_stall"] = "Still there?",
+        // ---- INSTANT RECALL (ir_) - games/instant-recall/lex.js IR_LEX
+        ["ir_almost"] = "ALMOST",
+        ["ir_answer_hint"] = "Tap an answer, or press 1-4.",
+        ["ir_answer_hint3"] = "Tap an answer, or press 1-3.",
+        ["ir_bell_warn"] = "Last stretch.",
+        ["ir_brief"] = "Watch. It stops without warning and asks what you just saw.",
+        ["ir_brief_bell"] = "Watch. A bell warns you before every stop.",
+        ["ir_chip_clock"] = "Time left",
+        ["ir_chip_density"] = "Density",
+        ["ir_chip_stops"] = "Stops",
+        ["ir_correct"] = "VERIFIED",
+        ["ir_corrected"] = "Corrected memory.",
+        ["ir_density"] = "Montage density",
+        ["ir_density_hint"] = "How thick the stream gets between stops. Calm eases the ceiling, dense rides it.",
+        ["ir_end_accuracy"] = "Accuracy",
+        ["ir_end_latency"] = "Average answer",
+        ["ir_end_line"] = "The stream never stopped. Only you did.",
+        ["ir_end_none"] = "None",
+        ["ir_end_plants"] = "Baits dodged",
+        ["ir_end_stops"] = "Stops answered",
+        ["ir_end_streak"] = "Best run",
+        ["ir_end_timeouts"] = "Blanked",
+        ["ir_end_title"] = "Vigil over",
+        ["ir_fx_ambient_field"] = "Grain",
+        ["ir_fx_bubble_field"] = "Bubbles",
+        ["ir_fx_crt"] = "Scanlines",
+        ["ir_fx_flash_burst"] = "Flash",
+        ["ir_fx_gif_burst"] = "Burst",
+        ["ir_fx_gif_rain"] = "Rain",
+        ["ir_fx_glitch_swap"] = "Glitch",
+        ["ir_fx_row_drift"] = "Drift",
+        ["ir_fx_wash"] = "Wash",
+        ["ir_gotcha"] = "That one flashed while the screen was FROZEN.",
+        ["ir_hear"] = "Hear it",
+        ["ir_howto_1"] = "A montage plays. Triggers fire over it.",
+        ["ir_howto_2"] = "Without warning, everything freezes.",
+        ["ir_howto_3"] = "Answer what just happened.",
+        ["ir_howto_bell"] = "A bell warns you first. For now.",
+        ["ir_howto_go"] = "GO",
+        ["ir_howto_nobell"] = "No bell. It just stops.",
+        ["ir_howto_title"] = "The vigil",
+        ["ir_jackpot"] = "Photographic Memory",
+        ["ir_layout_mosaic"] = "Mosaic",
+        ["ir_layout_rows"] = "Rows",
+        ["ir_layout_swirl"] = "Swirl",
+        ["ir_near"] = "So close. That one flashed, but earlier.",
+        ["ir_nobell_debrief"] = "That one had no bell. From Year 3, none of them do.",
+        ["ir_q_last_effect"] = "What was the last effect?",
+        ["ir_q_last_sting"] = "Which sting just played?",
+        ["ir_q_last_two"] = "The last two words, in order?",
+        ["ir_q_last_word"] = "What was the last word to flash?",
+        ["ir_q_mode"] = "Which layout were you watching?",
+        ["ir_resisted"] = "RESISTED",
+        ["ir_resume"] = "Resume. Denser now.",
+        ["ir_royal"] = "ROYAL",
+        ["ir_sting_blip"] = "Tick",
+        ["ir_sting_bump"] = "Thud",
+        ["ir_sting_glitch"] = "Static",
+        ["ir_sting_pop"] = "Pop",
+        ["ir_sting_sting"] = "Chime",
+        ["ir_stop_incoming"] = "Stop incoming.",
+        ["ir_stop_now"] = "FREEZE.",
+        ["ir_timeout"] = "BLANKED",
+        ["ir_truth"] = "It really did.",
+        ["ir_vigil_hint"] = "Eyes up. Nothing to click until it freezes.",
+        ["ir_voided"] = "Stop voided. The vigil goes on.",
+        ["ir_wrong"] = "MISSED",
+        // ---- ANOMALY (an_) - games/anomaly/lex.js AN_LEX
+        ["an_almost"] = "ALMOST",
+        ["an_bell"] = "Time.",
+        ["an_breather"] = "Breathe. This one is easy.",
+        ["an_brief"] = "One tile is not like the others. Find it before the round runs out.",
+        ["an_chip_clock"] = "Time left",
+        ["an_chip_round"] = "Round",
+        ["an_chip_streak"] = "Streak",
+        ["an_end_accuracy"] = "First-tap accuracy",
+        ["an_end_found"] = "Found",
+        ["an_end_kind"] = "Hardest to see",
+        ["an_end_line"] = "Global changes are noise. Only local difference is true.",
+        ["an_end_median"] = "Median find",
+        ["an_end_none"] = "None",
+        ["an_end_rounds"] = "Rounds offered",
+        ["an_end_streak"] = "Longest streak",
+        ["an_end_title"] = "Eyes up",
+        ["an_end_tracked"] = "Tracked after a shift",
+        ["an_fast"] = "FAST",
+        ["an_found"] = "Found.",
+        ["an_found_fast"] = "Fast.",
+        ["an_howto_find"] = "One is not. Tap it. The first tap is the one that counts.",
+        ["an_howto_go"] = "Open your eyes",
+        ["an_howto_lie"] = "The room tints, drifts and glitches every tile at once. That is noise.",
+        ["an_howto_same"] = "Every tile is the same loop, playing in step.",
+        ["an_howto_title"] = "Class rules",
+        ["an_jackpot"] = "Sharp eyes.",
+        ["an_kind_blur"] = "focus",
+        ["an_kind_bright"] = "light",
+        ["an_kind_frame"] = "timing",
+        ["an_kind_hue"] = "colour",
+        ["an_kind_mirror"] = "mirrored",
+        ["an_kind_rotate"] = "tilt",
+        ["an_kind_scale"] = "size",
+        ["an_kind_speed"] = "speed",
+        ["an_kinds"] = "Difference kinds",
+        ["an_kinds_hint"] = "Gentle keeps colour, mirror and size only. Mirror is always in the pool.",
+        ["an_moved"] = "It moved.",
+        ["an_play_hint"] = "Tap the odd tile.",
+        ["an_refund"] = "+1s",
+        ["an_reveal"] = "It was here.",
+        ["an_royal"] = "ROYAL",
+        ["an_stamp_bell"] = "Bell",
+        ["an_stamp_found"] = "Found",
+        ["an_streak_lit"] = "Five straight. The frame is lit.",
+        ["an_timeout"] = "Gone. Next grid.",
+        ["an_trick_melt"] = "The frame runs like wax",
+        ["an_trick_seen"] = "Did you see that?",
+        ["an_wrong"] = "Not that one. That tile is out.",
+        // ---- COMPOSURE (cp_) - games/composure/lex.js CP_LEX
+        ["cp_backtrack_line"] = "Back where it was. Breathe.",
+        ["cp_bell_line"] = "The bell. Hands off the board.",
+        ["cp_bell_warn"] = "Twenty seconds.",
+        ["cp_brief"] = "One picture, cut apart and still moving. Put it back together.",
+        ["cp_brief_zen"] = "No clock tonight. Slide until it is whole again.",
+        ["cp_chip_calm"] = "Composure",
+        ["cp_chip_clock"] = "Time left",
+        ["cp_chip_locked"] = "Pieces home",
+        ["cp_chip_moves"] = "Moves",
+        ["cp_end_assists"] = "Assists",
+        ["cp_end_backtracks"] = "Backtracks",
+        ["cp_end_best"] = "Best solve",
+        ["cp_end_best_first"] = "Your first finished picture on this board.",
+        ["cp_end_best_line"] = "Your standing mark on this board. Beat it next class.",
+        ["cp_end_locked"] = "Pieces home",
+        ["cp_end_moves"] = "Moves",
+        ["cp_end_no"] = "No",
+        ["cp_end_par"] = "Baseline",
+        ["cp_end_solved"] = "Solved",
+        ["cp_end_thrash"] = "Panic moves",
+        ["cp_end_time"] = "Time",
+        ["cp_end_title"] = "Composure report",
+        ["cp_end_title_zen"] = "Zen board",
+        ["cp_end_yes"] = "Yes",
+        ["cp_finish"] = "Finish",
+        ["cp_howto_go"] = "Start the picture",
+        ["cp_howto_lock"] = "A piece that reaches its own place locks with a snap. It can still be slid.",
+        ["cp_howto_slide"] = "Tap a piece beside the gap and it slides in. Arrows, WASD and swipes do the same.",
+        ["cp_howto_title"] = "Class rules",
+        ["cp_howto_wash"] = "The room will bury the board. Keep sliding - the picture underneath never moved.",
+        ["cp_jackpot"] = "JACKPOT",
+        ["cp_lock_line"] = "That one is home.",
+        ["cp_mode"] = "Mode",
+        ["cp_mode_hint"] = "Timed is one graded class. Zen is untimed, gentle, and always a pass.",
+        ["cp_near_miss"] = "SO CLOSE",
+        ["cp_peek_ref"] = "The finished picture",
+        ["cp_play_hint"] = "Tap a piece beside the gap. Arrows, WASD or swipe.",
+        ["cp_rescue_line"] = "Take the lit piece. The grade eases; the class does not end.",
+        ["cp_retake"] = "Retake",
+        ["cp_solved_line"] = "Whole. Watch it play.",
+        ["cp_stamp_assist"] = "ASSIST",
+        ["cp_stamp_bell"] = "BELL",
+        ["cp_stamp_lock"] = "HOME",
+        ["cp_stamp_solved"] = "COMPOSED",
+        ["cp_trick_melt"] = "One of them is running.",
+        ["cp_trick_preview"] = "Did it move?",
+        ["cp_trick_seen"] = "That is not where that piece is.",
+        ["cp_wash_line"] = "Keep sliding. The board is still exactly where you left it.",
+        ["cp_zen_done"] = "Whole, in your own time.",
+        ["cp_zen_grid"] = "Zen board",
+        ["cp_zen_grid_hint"] = "Zen only. A timed class plays the board your year has earned.",
     };
 
     /// <summary>The mockup's owner-approved tokens (BUILD-CONTRACT §10). A mod overrides them via
@@ -1957,7 +2340,7 @@ internal static class ArcademyHostService
             if (retry)
             {
                 _relaunchedOnce = true;
-                Launch();
+                Launch(devDoor: _devDoor);
             }
         });
     }


### PR DESCRIPTION
## Summary
- The last five Arcademy classes - **Misdirection, Echo, Instant Recall, Anomaly, Composure** - each built with the full House Rules deck set from day one (style + drawn class-rules sheet / casino / trickster / pressure) and a `lex.js` table. All ten classes are now playable.
- Registry release gate: `GAME_SEMESTER` + `OPEN_SEMESTERS` (a closed semester is absent from the pool, never a stub).
- Timetable: four meaty classes (L&F, Deep End, Instant Recall, Composure) so a ten-game no-repeat-3 pool deals one meaty class every night (measured 28/28; web CLAUDE.md trap 6 rewritten).
- Campus: East Wing 201-203 and West Wing 301-302 untaped by `OPEN_SEMESTERS`, route stops across wings, seeded idle attract.
- Shell Deck V **The Rake** + Deck VI: one-more end card (grade as a stamp object, lit retake, dim-but-live exit), streak jeopardy on leave, sunk-cost meter, seeded variable-ratio drop, losses still ceremonied, keycap glyphs.
- Class-rules sheets for Daily Trigger / Deja Vu / The Deep End.
- Host: 346 `NeutralLexicon` rows mirrored (672 total), `ccp.spirals` + `loomSpirals` (the Loom's saved spirals join the spiral pool), `--arcademy` = `LaunchDev` (bypasses the DOOR only; T2 + AudioOnly still apply).
- Also: `applySuspend(false)` re-asserts the pause; new audio recipes; `core/rng.js makeTaggedRoll` per-tag mulberry32; trap 41 rewritten to the measured finding (iOS stutter = frame starvation, not an unregistered-var transition limit; the registered-var twins were built then reverted in 3f53d804b). Includes b62c41990 (Deep End perf ladder PASS 5) and cd53f9e39 (Deep End PASS 6, the `html.ae-touch` rung + trap 42) from the peer session.
- **Arcademy still ships DARK** (`DoorAvailable=false`).

## Test plan
- [x] shell suite 229 (incl. rake 44), host fixes + styles cascade tripwires
- [x] misdirection 275 + decks 725, echo 228 + 217, instant-recall 365 + 309, anomaly 287 + 283, composure 232 + 206, howto 55, campus/registry 96
- [x] `dotnet build` 0 errors; app launched `--arcademy`: registry 10/10 live, campus both wings open, owner played Deep End + Deja Vu + retake through the new end card in-app
- [ ] owner play-test of the five new classes in-app (rig shots in session scratchpad `rig/shots/<game>/`)
- [x] Deep End PASS 6 ae-touch rung (cd53f9e39) landed from the peer session; peer suite 666/666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
