### PR TITLE
feat(arcademy): dev pass - --arcademy door can Begin any campus room

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -213,6 +213,10 @@ const ATTRACT_CURSOR_D = 'M0,0 L0,17 L4.2,13 L6.9,18.4 L9.6,17.1 L7,11.8 L12,11.
  * @param {Array}  o.classes   timetable.classes ({gameKey, timeLabel, ...})
  * @param {Object} o.records   gameKey -> {grade} | null  (today's rows)
  * @param {boolean=} o.suspended  global suspend (mandatory video etc.)
+ * @param {boolean=} o.devPass   the host opened the DEV DOOR (`--arcademy`):
+ *   every room's door card offers Begin even off tonight's board, so an
+ *   unreleased class can be play-tested without waiting for the seed to deal
+ *   it. Graded like any class; never set on a player build.
  * @param {Object=} o.endless  gameKey -> {labelKey, hintKey} for every game that
  *   declares `manifest.endless`. The shell computes it (the campus never reads a
  *   manifest); a room without an entry simply shows no Free Swim button.
@@ -220,7 +224,7 @@ const ATTRACT_CURSOR_D = 'M0,0 L0,17 L4.2,13 L6.9,18.4 L9.6,17.1 L7,11.8 L12,11.
  *   rooms[gameKey] = { scheduled, period (1-based, 0 = not tonight), done,
  *                      grade, mood:'open'|'retake'|'dark', timeLabel, endless }
  */
-export function campusState({ classes, records, suspended, endless } = {}) {
+export function campusState({ classes, records, suspended, endless, devPass } = {}) {
   const list = Array.isArray(classes) ? classes : [];
   const recs = records || {};
   const ends = (endless && typeof endless === 'object') ? endless : {};
@@ -253,6 +257,7 @@ export function campusState({ classes, records, suspended, endless } = {}) {
     rooms,
     stops,
     suspended: !!suspended,
+    devPass: !!devPass,
     allDone: list.length > 0 && done === list.length,
   };
 }
@@ -985,6 +990,14 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     } else if (r.scheduled) {
       ccGo.textContent = (r.done ? t('retake', 'Retake') : t('begin_class', 'Begin')).toUpperCase();
       ccGo.disabled = false;
+      cardAction = () => { if (handlers.begin) handlers.begin(key); };
+    } else if (st.devPass) {
+      /* THE DEV DOOR. Off the board but the host opened the building with the
+       * dev switch: Begin anyway (the shell runs it as a graded, timed class
+       * built from the registry descriptor). Not a player path. */
+      ccGo.textContent = t('campus_dev_pass', 'Dev pass · Begin').toUpperCase();
+      ccGo.disabled = false;
+      ccXp.textContent = t('campus_dev_pass_hint', "Dev pass: off tonight's board, graded anyway.");
       cardAction = () => { if (handlers.begin) handlers.begin(key); };
     } else {
       ccGo.textContent = t('campus_not_tonight', 'Not tonight').toUpperCase();

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -337,6 +337,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let active = null;               // the running class (see startClass)
   let suspendedGlobally = false;
   let destroyed = false;
+  // Host opened the building through the dev switch (`--arcademy`). Unlocks
+  // Begin on every campus door regardless of the seed; never true for players.
+  const devPass = src.devDoor === true;
 
   /* ---------------------- registry + timetable -------------------------- */
   const games = await loadGames(say);
@@ -525,6 +528,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       classes: timetable.classes,
       records,
       suspended: suspendedGlobally,
+      devPass,
       // Free Swim is a property of the GAME, not of tonight's board: a room the
       // timetable never dealt can still be swum, so the map covers every
       // registered game and campusState keeps the ones that have a room.
@@ -663,7 +667,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         on: {
           begin: (gameKey) => {
             const cls = timetable.classes.find((c) => c.gameKey === gameKey);
-            if (cls) startClass(cls);
+            if (cls) { startClass(cls); return; }
+            // THE DEV DOOR: a room off tonight's board still opens when the host
+            // came in through `--arcademy`. Graded + timed like a dealt class,
+            // built from the registry descriptor (freeSwimClass's parachute).
+            if (devPass) {
+              say('dev pass: ' + gameKey + ' is off the board - graded run anyway');
+              startClass(freeSwimClass(gameKey));
+            }
           },
           freeSwim: (gameKey) => startFreeSwim(gameKey),
           records: () => showReport(),

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -592,6 +592,9 @@ internal static class ArcademyHostService
             // handles the panic key itself - that stays app-side.
             panicKeyEnabled = s?.PanicKeyEnabled ?? true,
             panicKey = s?.PanicKey ?? "Escape",
+            // The dev switch (`--arcademy`) is projected so the campus can offer Begin on rooms
+            // the seed did not deal tonight (shell: devPass). Always false on a player launch.
+            devDoor = _devDoor,
         };
     }
 
@@ -872,6 +875,8 @@ internal static class ArcademyHostService
         ["campus_semester_3"] = "Semester III",
         ["campus_in_session"] = "In Session",
         ["campus_not_tonight"] = "Not tonight",
+        ["campus_dev_pass"] = "Dev pass · Begin",
+        ["campus_dev_pass_hint"] = "Dev pass: off tonight's board, graded anyway.",
         ["campus_next_bell"] = "Next Bell",
         ["campus_step_inside"] = "Step inside",
         ["campus_xp_first"] = "First pass of the day pays XP.",


### PR DESCRIPTION
The seeded timetable deals 3 classes a night, so the five Semester II/III classes could not be reached in-app for play-testing unless the date drew them (owner hit this 0823 right after #247 merged).

- host: `BuildInit` projects `devDoor = _devDoor` (true only via `--arcademy` / LaunchDev)
- shell: `devPass` rides into `campusState`; `on.begin` for an off-board room starts a graded, timed class from the registry descriptor (`freeSwimClass` parachute, NOT endless - goes through the normal finishClass / class-ended / end-card path)
- campus: door card shows **DEV PASS · BEGIN** on unscheduled rooms when `st.devPass`; player builds still see *Not tonight*
- NeutralLexicon: `campus_dev_pass`, `campus_dev_pass_hint`

Shell suite 229/229 on this tip; `dotnet build` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)