### PR TITLE
Arcademy: collapsible timetable plaque + EMI bubble positioning

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -57,7 +57,11 @@ provider/tagged.js THE TAGGED POOL: two piles, per-tag cursors, a seeded dry
                    re-serve, thin frozen at resolve / empty live (§3)
 shell/shell.js     screen router + THE class runner (ctx per §11) + THE SETUP
                    DOOR hook (§5: create -> setup() -> beginPlay)
-shell/splitflap.js departure-board reveal
+shell/splitflap.js departure-board reveal. The campus hangs it COLLAPSED behind a
+                   plaque (campus.js's .campus-boardtab - clock pulses until the
+                   first open of the day, store key boardOpenedDate); expanding
+                   rolls the flaps, which is why there is no "flip the board
+                   again" button any more
 shell/reportcard.js day summary + THE one share pipeline
 shell/settings.js  THE settings page (3 tiers) + SETTING_KEYS
 shell/ceremonies.js stamp / 10-segment meter / reward beats (engine-delegated)
@@ -257,7 +261,8 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                EMI and a dismissed EMI are all silent no-ops, which is why every
                call site in shell.js is one unguarded line.
   widget.css   the layer (.arc-emi, fixed, z 50), the grab/grabbing cursors, the
-               x affordance, the edge dock, and the bubble's `.bubble-left` flip.
+               x affordance, the edge dock, and the bubble's `.bubble-left` /
+               `.bubble-low` flips (right margin / top edge).
 ```
 
 Each game owns its own lexicon rows; **`ArcademyHostService.NeutralLexicon` mirrors every
@@ -990,14 +995,20 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     identical with and without EMI. If you ever make the renderer a STATIC import of
     `shell.js`, one browser-only line in the renderer becomes a boot failure for the whole
     school.
-61. **THE BUBBLE HANGS OFF HER RIGHT EAR AND THE VIEWPORT IS NOT INFINITE.** `emi.css` puts
-    `.emi-bubble` at `right:-5%` with `max-width:104px`, i.e. a fixed pixel box whose right
-    edge hangs past hers - and the natural resting place for a dragged mascot is the bottom-right
-    corner, where the line would be cut off by the window. `widget.js` adds `.bubble-left`
-    to the root when `left + w * 1.55 > viewportWidth` (and there is room on the other
-    side) and `widget.css` mirrors the box and its tail. Clamping her further from the edge
-    instead was the wrong fix: it would have made the corner - the place players actually
-    park her - unreachable.
+61. **THE BUBBLE HANGS UP OFF HER RIGHT EAR AND THE VIEWPORT IS NOT INFINITE.** `emi.css`
+    anchors `.emi-bubble` at `left:58%; bottom:96%` with `width:max-content; max-width:104px`:
+    off the ear and RISING, so a long line grows into the sky instead of down across the
+    glass. Two half-bugs live in that one line of geometry: an earlier `right:-5%` anchor
+    laid the whole box straight over her face, and a left-edge anchor WITHOUT
+    `width:max-content` shrink-wraps an abs-pos box against the ~42% of containing block
+    that remains right of the anchor, wrapping every bark three characters per row.
+    The viewport flips: the natural resting place for a dragged mascot is the bottom-right
+    corner, where the line would be cut off by the window - `widget.js` adds `.bubble-left`
+    when `left + w * 1.55 > viewportWidth` (and there is room on the other side), and
+    `.bubble-low` when she is parked within 96px of the TOP edge (a rising bubble has no
+    sky there - it drops below the chin, tail up). `widget.css` mirrors box + tail for all
+    four corners. Clamping her further from the edges instead was the wrong fix: it would
+    have made the corners - the places players actually park her - unreachable.
 
 62. **THE BUBBLE'S FONT IS A PIXEL GRID, SO ITS BOX CANNOT BE A PERCENTAGE.** Press
     Start 2P is an 8x8 cell face: set it at a whole pixel size or the cells land

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/emi.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/emi.css
@@ -85,10 +85,20 @@
 /* Words NEVER go on the face (talk rule, locked); they go here. */
 .emi-bubble {
   position: absolute;
-  right: -5%;
-  top: -2%;
+  /* Off the RIGHT EAR, rising: the box's left edge sits past the ear and its
+   * BOTTOM is pinned just over the head, so a longer line grows UP into the
+   * sky instead of down across the glass. (The old right:-5% anchored the
+   * box's right edge at the ear, which laid every line straight over her
+   * face.) widget.js flips this to `.bubble-left` near the right margin and
+   * to `.bubble-low` when she is parked at the very top - both in widget.css. */
+  left: 58%;
+  bottom: 96%;
   /* Absolute, not a % of EMI: the pixel face is a fixed 8px grid, so the box that holds
-   * it has to be fixed too or the 116px EMI wraps every line to four rows. */
+   * it has to be fixed too or the 116px EMI wraps every line to four rows.
+   * width:max-content matters with the left-edge anchor above - shrink-to-fit
+   * would clamp an abs-pos box to the sliver of containing block RIGHT of 58%
+   * (~49px) and wrap every bark three characters at a time. */
+  width: max-content;
   max-width: 104px;
   text-align: left;
   background: #F5F0E1;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -76,14 +76,15 @@
 .arc-emi .emi-x:focus-visible { outline: 2px solid #FFD700; outline-offset: 2px; }
 
 /* ---- the bubble, on the other ear --------------------------------------
- * emi.css hangs `.emi-bubble` off EMI's RIGHT side (right:-5%, max-width:46%),
+ * emi.css hangs `.emi-bubble` up off EMI's RIGHT ear (left:58%, bottom:96%),
  * which runs off the window once she is dragged into the right margin. widget.js
  * adds `.bubble-left` to the root when that is about to happen; this mirrors the
- * box and its tail. Nothing else about the bubble is touched — the skin stays
- * agent A's. */
+ * box and its tail. `.bubble-low` is the vertical twin: parked at the very top
+ * there is no sky for the bubble to rise into, so it drops below the chin.
+ * Nothing else about the bubble is touched — the skin stays agent A's. */
 .arc-emi .emi.bubble-left .emi-bubble {
-  right: auto;
-  left: -5%;
+  left: auto;
+  right: 58%;
   text-align: right;
   transform-origin: 100% 100%;
 }
@@ -93,6 +94,29 @@
   border-left: 0;
   border-right: 3px solid #1A1A2E;
   transform: translate(6px, 6px) skewX(-30deg);
+}
+/* Parked against the top edge: the bubble hangs UNDER her instead, tail up. */
+.arc-emi .emi.bubble-low .emi-bubble {
+  bottom: auto;
+  top: 96%;
+  transform-origin: 0 0;
+}
+.arc-emi .emi.bubble-low .emi-bubble::after {
+  bottom: auto;
+  top: -3px;
+  border-bottom: 0;
+  border-top: 3px solid #1A1A2E;
+  transform: translate(-6px, -6px) skewX(-30deg);
+}
+.arc-emi .emi.bubble-low.bubble-left .emi-bubble { transform-origin: 100% 0; }
+.arc-emi .emi.bubble-low.bubble-left .emi-bubble::after {
+  left: auto;
+  right: -3px;
+  border-left: 0;
+  border-right: 3px solid #1A1A2E;
+  border-bottom: 0;
+  border-top: 3px solid #1A1A2E;
+  transform: translate(6px, -6px) skewX(30deg);
 }
 
 /* ---- the dock -----------------------------------------------------------

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -76,10 +76,15 @@ const BODY_MS = { bounce: 800, thud: 800, shiver: 900, nod: 1900, droop: 800, sh
  * emi.css owns the keyframes and this file owns how long a move runs, so a
  * shake is SHIVER cut short. It inherits the reduced-motion refusal with it. */
 const BODY_ALIAS = { shake: 'shiver' };
-/* The bubble hangs OFF EMI's right edge (emi.css: right:-5%, max-width:104px),
- * so she needs roughly this multiple of her own width to the right of her left
- * edge or the line runs off the viewport - at which point it flips left. */
+/* The bubble hangs UP OFF EMI's right ear (emi.css: left:58%, bottom:96%,
+ * max-width:104px), so she needs roughly this multiple of her own width to the
+ * right of her left edge or the line runs off the viewport - at which point it
+ * flips to the left ear (.bubble-left). */
 const BUBBLE_REACH = 1.55;
+/* ...and it RISES, so parked within this many px of the top edge there is no
+ * sky for it: it drops below the chin instead (.bubble-low). Sized for the
+ * worst wrapped bark (~5 lines) plus the tail. */
+const BUBBLE_RISE = 96;
 
 /** The persisted blob's key in the C# meta store (core/store.js top-level). */
 export const STORE_KEY = 'emi';
@@ -336,18 +341,20 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
     el.style.width = s.w + 'px';
     el.style.left = Math.round(left) + 'px';
     el.style.top = Math.round(top) + 'px';
-    faceBubble(left, s.w, vp.w);
+    faceBubble(left, top, s.w, vp.w);
     return { left, top, s, vp };
   }
   /** THE BUBBLE HANGS OFF HER RIGHT EAR and would run off the right edge of the
    *  window there, so it flips to the left ear instead (`.bubble-left`, styled in
    *  widget.css). Decided from the position, so a drag and a resize both fix it. */
-  function faceBubble(left, w, vw) {
+  function faceBubble(left, top, w, vw) {
     const overRight = left + w * BUBBLE_REACH > vw;
     const room = left - w * (BUBBLE_REACH - 1) > 0;
     // `classList.toggle` is not in every DOM double; add/remove is.
     if (overRight && room) el.classList.add('bubble-left');
     else el.classList.remove('bubble-left');
+    if (top < BUBBLE_RISE) el.classList.add('bubble-low');
+    else el.classList.remove('bubble-low');
   }
 
   /** Record the CURRENT pixel position back into the fractions. */
@@ -634,7 +641,7 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
       const top = clamp(ev.clientY - grabY, DIALS.MARGIN, Math.max(DIALS.MARGIN, vp.h - s.h - DIALS.MARGIN));
       el.style.left = Math.round(left) + 'px';
       el.style.top = Math.round(top) + 'px';
-      faceBubble(left, s.w, vp.w);
+      faceBubble(left, top, s.w, vp.w);
 
       // FLUNG? speed over the dial, sustained. `>.<` while it lasts. setDragFace
       // swallows the repeats, so a sustained fling repaints the canvas ONCE

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -473,17 +473,23 @@ function el(tag, cls, text) {
  * @param {Object} o.stats        {streak, perfectDays, tier}
  * @param {boolean=} o.reducedMotion
  * @param {Object} o.on           {begin(gameKey), freeSwim(gameKey), records(),
- *   registrar()} - freeSwim is only ever called for a room whose state carries
- *   an `endless` declaration (the shell reads the manifest, never the campus).
+ *   registrar(), boardToggle(expanded)} - freeSwim is only ever called for a
+ *   room whose state carries an `endless` declaration (the shell reads the
+ *   manifest, never the campus). boardToggle fires AFTER the hanging board has
+ *   been shown/hidden - the shell rolls the flaps (and stamps the store) on
+ *   `true`; the campus itself never touches a flap.
  * @param {string=} o.dateSeed  init.utcDateSeed - the idle attract is seeded off
  *   it so every player gets the SAME show tonight (trap 8: UTC seeds content).
  *   Omitted, it falls back to today's UTC date.
  * @param {number=} o.attractIdleMs  test seam; defaults to ATTRACT_IDLE_MS.
+ * @param {boolean=} o.boardPulse  the timetable has NOT been opened yet today:
+ *   the collapsed plaque's clock pulses until the first expand. The shell
+ *   decides (it owns the local date + the store); the campus only wears it.
  * @param {Function=} o.log
  * @returns {{root, boardMount, footMount, update, closeCard, destroy}}
  */
 export function createCampus({ state, gameName, banner, stats, reducedMotion, on, log,
-  dateSeed, attractIdleMs } = {}) {
+  dateSeed, attractIdleMs, boardPulse } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   const handlers = on || {};
   const name = typeof gameName === 'function' ? gameName : (k) => String(k);
@@ -1175,15 +1181,40 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     });
 
   /* ------------------------------ hanging board -------------------------- */
-  const boardwrap = el('div', 'campus-boardwrap');
+  /* COLLAPSED BY DEFAULT: what hangs from the chains at first is the small
+   * plaque below - clock, "TIMETABLE", chevron. Clicking it drops the board
+   * out beneath (and the shell rolls the flaps through on.boardToggle, which
+   * is why there is no "flip the board again" button anywhere any more - the
+   * plaque IS the flip). The clock pulses until the first open of the day. */
+  const boardwrap = el('div', 'campus-boardwrap collapsed');
   const chains = el('div', 'campus-chains');
   chains.appendChild(el('div', 'campus-chain'));
   chains.appendChild(el('div', 'campus-chain'));
   boardwrap.appendChild(chains);
+  /* Everything below the chains hangs as ONE object (the sway lives on this
+   * wrapper, not per-piece - a plaque and a board rotating around different
+   * origins would shear at the seam). */
+  const boardSway = el('div', 'campus-boardsway');
+  const boardTab = el('button', 'campus-boardtab' + (boardPulse ? ' pulse' : ''));
+  boardTab.type = 'button';
+  boardTab.appendChild(el('span', 'tclock', '🕘'));
+  boardTab.appendChild(el('span', 'tlabel', t('timetable', 'Timetable').toUpperCase()));
+  boardTab.appendChild(el('span', 'tchev', '▾'));
+  boardTab.setAttribute('aria-expanded', 'false');
+  boardTab.addEventListener('click', () => {
+    const expand = boardwrap.classList.contains('collapsed');
+    boardwrap.classList.toggle('collapsed', !expand);
+    boardTab.setAttribute('aria-expanded', expand ? 'true' : 'false');
+    if (expand) boardTab.classList.remove('pulse');   // opened = the clock's job is done
+    try { if (handlers.boardToggle) handlers.boardToggle(expand); }
+    catch (e) { say('boardToggle handler threw: ' + ((e && e.message) || e)); }
+  });
+  boardSway.appendChild(boardTab);
   const boardMount = el('div', 'campus-board');
-  boardwrap.appendChild(boardMount);
+  boardSway.appendChild(boardMount);
   const footMount = el('div', 'campus-boardfoot');
-  boardwrap.appendChild(footMount);
+  boardSway.appendChild(footMount);
+  boardwrap.appendChild(boardSway);
   root.appendChild(boardwrap);
 
   /* ------------------------------ crest / bell / hint -------------------- */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -741,18 +741,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     }
     extrasBox.textContent = '';
 
-    const bar = el('div', 'arc-classbar');
-    const replay = el('button', 'btn ghost', t('replay_board', 'Flip the board again'));
-    replay.type = 'button';
-    replay.addEventListener('click', () => board && board.replay());
-    bar.appendChild(replay);
+    /* No "flip the board again" button any more: the flaps roll every time the
+     * hanging board is EXPANDED (the plaque is the flip - see boardToggle
+     * below), and the plain fallback screen still rolls them on entry. */
     if (allDone()) {
+      const bar = el('div', 'arc-classbar');
       const rc = el('button', 'btn', t('report_card', 'Report Card'));
       rc.type = 'button';
       rc.addEventListener('click', () => showReport());
       bar.appendChild(rc);
+      extrasBox.appendChild(bar);
     }
-    extrasBox.appendChild(bar);
 
     /* yesterday's strip (the mockup's report-card row) */
     const y = store.day(dayAdd(localDate, -1));
@@ -821,10 +820,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       const cls = timetable.classes.find((c) => c.gameKey === gameKey);
       if (cls) startClass(cls);
     };
+    /* Built composed, never flipping: the board is BEHIND the collapsed plaque
+     * when the campus stands up, and the reveal cascade belongs to the moment
+     * the player opens it (boardToggle below). The plain fallback screen keeps
+     * its entry roll - it has no plaque. */
     board = createBoard({
       rows: buildRows(true),
       reducedMotion,
-      animate: !silent,
+      animate: false,
       onSelect: onSelectRow,
     });
 
@@ -844,7 +847,20 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         // different fraction than the end card would be the one lie the rake
         // cannot afford. Optional on the campus side: an older hub ignores it.
         progressFor,
+        // The collapsed plaque's clock pulses until the timetable has been
+        // opened once TODAY (local date - it is attendance furniture, not
+        // content; regression #978's rule).
+        boardPulse: store.get('boardOpenedDate') !== localDate,
         on: {
+          boardToggle: (expanded) => {
+            if (!expanded) return;
+            // Opening IS the flip: roll the flaps through, and remember the
+            // open so tomorrow is the next time the clock nags.
+            try {
+              if (store.get('boardOpenedDate') !== localDate) store.set('boardOpenedDate', localDate);
+            } catch (e) { say('boardOpenedDate write failed: ' + ((e && e.message) || e)); }
+            if (board) board.replay();
+          },
           begin: (gameKey) => {
             const cls = timetable.classes.find((c) => c.gameKey === gameKey);
             if (cls) { startClass(cls); return; }

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1284,13 +1284,16 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   background:repeating-linear-gradient(var(--campus-line-dim) 0 6px, var(--campus-hall) 6px 10px);
   box-shadow:0 0 6px rgba(0,0,0,.5);
 }
+/* The sway is on the GROUP (plaque + board + foot rock as one hung object). */
+.campus-boardsway {
+  animation:campus-sway 7s ease-in-out infinite alternate;
+  transform-origin:50% -40px;
+}
 .campus-board {
   background:linear-gradient(180deg, var(--navy), color-mix(in srgb, var(--navy), black 25%));
   border:var(--hairline); border-radius:10px;
   box-shadow:0 18px 50px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.07);
   padding:10px 14px 8px;
-  animation:campus-sway 7s ease-in-out infinite alternate;
-  transform-origin:50% -40px;
 }
 @keyframes campus-sway { from { transform:rotate(-.4deg); } to { transform:rotate(.4deg); } }
 /* compact flaps inside the hanging board (the full-size ones are for the plain
@@ -1313,6 +1316,56 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
 .campus-boardfoot .reportcard { margin-top:6px; padding-top:6px; gap:7px; }
 .campus-boardfoot .rcell { font-size:10.5px; padding:3px 7px; }
 .campus-boardfoot .grade { font-size:12px; min-width:20px; height:20px; }
+
+/* ---- the plaque: the collapsed timetable -------------------------------
+   What hangs from the chains until the player opens the board. The clock
+   pulses while the timetable has not been opened yet TODAY (campus.js wears
+   `.pulse` off the shell's store read); opening rolls the flaps, so this
+   plaque replaced the old "flip the board again" button outright. */
+.campus-boardtab {
+  display:flex; align-items:center; gap:8px;
+  margin:0 auto; width:max-content;
+  background:linear-gradient(180deg, var(--navy), color-mix(in srgb, var(--navy), black 25%));
+  border:var(--hairline); border-radius:9px;
+  box-shadow:0 14px 34px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.07);
+  padding:7px 14px;
+  color:var(--ink-dim); cursor:pointer;
+  font:600 10.5px/1 var(--mono); letter-spacing:.14em;
+}
+.campus-boardtab:hover { color:var(--ink); border-color:var(--pink-deep); }
+.campus-boardtab:focus-visible { outline:2px solid var(--gold); outline-offset:2px; }
+.campus-boardtab .tclock { font-size:14px; line-height:1; }
+.campus-boardtab .tchev { color:var(--ink-faint); font-size:9px; transition:transform .2s ease; }
+.campus-boardtab.pulse .tclock {
+  animation:campus-clockpulse 1.4s ease-in-out infinite;
+  filter:drop-shadow(0 0 6px var(--pink));
+}
+@keyframes campus-clockpulse {
+  0%, 100% { transform:scale(1); }
+  50% { transform:scale(1.35); }
+}
+/* Expanded: the plaque becomes the board's header bar (click again to fold). */
+.campus-boardwrap:not(.collapsed) .campus-boardtab {
+  border-radius:9px 9px 0 0; border-bottom:0;
+  box-shadow:none;
+  width:100%; justify-content:center; box-sizing:border-box;
+  padding:6px 14px 5px;
+}
+.campus-boardwrap:not(.collapsed) .campus-boardtab .tchev { transform:rotate(180deg); }
+.campus-boardwrap.collapsed .campus-board,
+.campus-boardwrap.collapsed .campus-boardfoot { display:none; }
+.campus-boardwrap:not(.collapsed) .campus-board {
+  border-radius:0 0 10px 10px; border-top:0;
+  animation:campus-boardunfold .32s ease-out;
+}
+@keyframes campus-boardunfold {
+  from { opacity:0; transform:translateY(-10px); }
+  to { opacity:1; transform:translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .campus-boardsway, .campus-boardtab.pulse .tclock,
+  .campus-boardwrap:not(.collapsed) .campus-board { animation:none; }
+}
 
 /* ---- crest (top-left) / top-right cluster / hint ---- */
 .campus-crest {


### PR DESCRIPTION
## Timetable (owner ask, screenshot 0824)
- The hanging board starts **collapsed** behind a small chained plaque: clock + TIMETABLE + chevron.
- The **clock pulses** until the timetable has been opened once today (store key `boardOpenedDate`, local date per #978's rule).
- **Expanding rolls the split-flaps** - the plaque IS the flip, so the "Flip the board again" button is removed (campus and plain-fallback screens both).
- Plaque + board + yesterday-strip foot now sway as one hung object (`.campus-boardsway`) so nothing shears at the seam.

## EMI speech bubble (owner ask, screenshot 0824)
- The bubble was printing straight across her glass: `right:-5%` anchored the box's right edge at the ear, laying every line over her face.
- Now anchored **up off her right ear** (`left:58%; bottom:96%; width:max-content`) so longer lines grow into the sky. `width:max-content` matters: an abs-pos left anchor otherwise shrink-wraps against the sliver of containing block right of 58% and wraps barks three characters per row.
- `.bubble-left` still flips near the right margin; new `.bubble-low` drops the bubble below her chin when she is parked against the top edge (all four corner combinations styled).
- Trap 61 + file notes in `arcademy/CLAUDE.md` rewritten to match.

Verified with a static harness over the real CSS/art: all four bubble corners, plaque pulse/no-pulse, expanded rolled board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM49yuRfwECZEF6txQFkCW