### PR TITLE
feat(arcademy): stretch the intro splash to ~3s

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1047,7 +1047,7 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     class back to quick flattens it to 40-50 and 18-20 - an owner call, not a code fix.
 
 66. **THE LOADER IS THE INTRO SPLASH, AND ONLY THE HAPPY PATH GETS THE BEAT.** `#arc-loader`
-    plays a ~1.2s fixed CSS timeline from t0 (no init needed) and boot.js's `dismissLoader()`
+    plays a ~3s fixed CSS timeline from t0 (no init needed) and boot.js's `dismissLoader()`
     WAITS OUT `INTRO_MIN_MS` before adding `.is-done` (the fade + zoom-through exit), so an
     early boot never cuts the beat. `failBoot()` must keep snapping `hidden = true` directly -
     an error card delayed by a celebration, or a splash replaying its exit over the nope

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -113,14 +113,14 @@ function armBootDeadline() {
 }
 
 /* ----------------------------------------------------------------------------
- * THE SPLASH DISMISSAL. The loader doubles as the ~1.2s intro splash (see
+ * THE SPLASH DISMISSAL. The loader doubles as the ~3s intro splash (see
  * index.html): a boot that lands early WAITS OUT the beat instead of cutting
  * it, a boot that lands late dismisses on arrival. `.is-done` plays the CSS
  * exit (fade + zoom-through); the `hidden` attribute stays the ground truth a
  * beat later. FAILURE PATHS NEVER WAIT - failBoot below still snaps
  * `hidden = true` directly, so an error card is never delayed by a celebration.
  * -------------------------------------------------------------------------- */
-const INTRO_MIN_MS = 1150;
+const INTRO_MIN_MS = 2950;
 const INTRO_EXIT_MS = 320;
 const introT0 = Date.now();
 

--- a/ConditioningControlPanel/Resources/web/arcademy/index.html
+++ b/ConditioningControlPanel/Resources/web/arcademy/index.html
@@ -47,7 +47,7 @@
     <div id="arc-toast" class="arc-toast" role="status" aria-live="polite"></div>
 
     <!-- Loader: covers the page until init arrives and the board is dealt.
-         Doubles as THE INTRO SPLASH (~1.2s): CRT power-on -> the wordmark THUD
+         Doubles as THE INTRO SPLASH (~3s): CRT power-on -> the wordmark THUD
          (Feel Dept stamp punch) -> the pixel tail flies home -> checker rail
          chase -> sparkle burst -> zoom-through exit. Pure CSS on a fixed
          timeline, starts at t0 with no init needed; if boot runs long the tail

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -797,11 +797,11 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
 
 /* ============================================================================
  * THE INTRO SPLASH (the loader's decoration - see index.html for the beat map).
- * One ~1.2s fixed CSS timeline, Feel Dept vocabulary throughout: CRT power-on
- * (0-.3s) -> the wordmark THUD w/ chromatic settle (.12-.46s) -> marquee ray
- * burst + shockwave ring (.3s) -> the pixel tail flies home (.26-.7s) -> GLINT
- * sweep (.48s) -> checker rail deals in steps (.3-.8s) -> SPARKLE BURST + flash
- * (.95-1.1s) -> boot.js adds `.is-done` = zoom-through exit. Past 1.3s the
+ * One ~3s fixed CSS timeline, Feel Dept vocabulary throughout: CRT power-on
+ * (0-.5s) -> the wordmark THUD w/ chromatic settle (.3-.64s) -> marquee ray
+ * burst + shockwave ring (.5s) -> the pixel tail flies home (.55-1.95s) -> GLINT
+ * sweep (.9s) -> checker rail deals in steps (.55-2.25s) -> SPARKLE BURST + flash
+ * (2.35-2.65s) -> boot.js adds `.is-done` = zoom-through exit. Past 3.1s the
  * tail animations settle into an idle hold (BREATH + rail chase) for slow
  * boots. Every hue is a token; the wordmark art carries its own.
  * ==========================================================================*/
@@ -825,8 +825,8 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
     transparent 11deg 30deg);
   -webkit-mask:radial-gradient(circle, #000 0%, transparent 62%);
   mask:radial-gradient(circle, #000 0%, transparent 62%);
-  animation:arc-intro-burst-in .5s ease-out .28s both,
-            arc-intro-burst-turn 18s linear .28s infinite;
+  animation:arc-intro-burst-in .6s ease-out .5s both,
+            arc-intro-burst-turn 18s linear .5s infinite;
 }
 @keyframes arc-intro-burst-in { from { opacity:0; } to { opacity:.085; } }
 @keyframes arc-intro-burst-turn { to { transform:rotate(360deg); } }
@@ -835,9 +835,9 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
 .arc-intro-stage {
   position:relative; z-index:1; width:min(600px, 76vw);
   animation:arc-intro-stage-in .12s ease-out .08s both,
-            arc-intro-shiver .3s linear .43s,
-            arc-intro-pop .22s ease-out .98s,
-            arc-intro-breath 2.8s ease-in-out 1.45s infinite alternate;
+            arc-intro-shiver .3s linear .61s,
+            arc-intro-pop .22s ease-out 2.38s,
+            arc-intro-breath 2.8s ease-in-out 3.1s infinite alternate;
 }
 @keyframes arc-intro-stage-in { from { opacity:0; } to { opacity:1; } }
 @keyframes arc-intro-shiver {
@@ -852,7 +852,7 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
    chromatic-fringe settle - the tube snapping into focus. */
 .arc-intro-mark {
   display:block; width:100%; height:auto; user-select:none; -webkit-user-drag:none;
-  animation:arc-intro-thud .34s cubic-bezier(.2,1.5,.4,1) .12s both;
+  animation:arc-intro-thud .34s cubic-bezier(.2,1.5,.4,1) .3s both;
 }
 @keyframes arc-intro-thud {
   0% { transform:scale(2.05); opacity:0;
@@ -870,7 +870,7 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   border:2px solid color-mix(in srgb, var(--pink) 80%, white 20%);
   box-shadow:0 0 18px color-mix(in srgb, var(--pink) 45%, transparent);
   opacity:0; pointer-events:none;
-  animation:arc-intro-ringout .42s ease-out .3s;
+  animation:arc-intro-ringout .5s ease-out .62s;
 }
 @keyframes arc-intro-ringout {
   0% { opacity:.85; transform:translate(-50%,-50%) scale(.55); }
@@ -884,7 +884,7 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   mask:url('./art/arcademy-wordmark.png') center / contain no-repeat;
   background:linear-gradient(115deg, transparent 38%, rgba(255,255,255,.85) 50%, transparent 62%);
   background-size:260% 100%; background-position:120% 0;
-  animation:arc-intro-glint .42s ease-in-out .48s;
+  animation:arc-intro-glint .55s ease-in-out .9s;
 }
 @keyframes arc-intro-glint {
   0% { opacity:1; background-position:120% 0; }
@@ -897,23 +897,23 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   position:absolute; z-index:2; opacity:0; pointer-events:none;
   width:var(--s,9px); height:var(--s,9px); background:var(--c,var(--pink));
   box-shadow:0 0 8px color-mix(in srgb, var(--c,var(--pink)) 55%, transparent);
-  animation:arc-intro-bit-in .3s cubic-bezier(.2,1.1,.4,1) var(--d,.3s) both;
+  animation:arc-intro-bit-in .32s cubic-bezier(.2,1.1,.4,1) var(--d,.55s) both;
 }
 @keyframes arc-intro-bit-in {
   0% { opacity:0; transform:translate(var(--fx,60px), var(--fy,-60px)) rotate(120deg); }
   60% { opacity:1; }
   100% { opacity:1; transform:translate(0,0) rotate(0deg); }
 }
-.arc-intro-bit:nth-of-type(1)  { --s:13px; --c:var(--pink);      right:-3%;  top:-14%; --fx:90px;  --fy:-70px; --d:.26s; }
-.arc-intro-bit:nth-of-type(2)  { --s:9px;  --c:var(--gold);      right:2%;   top:-6%;  --fx:70px;  --fy:-90px; --d:.31s; }
-.arc-intro-bit:nth-of-type(3)  { --s:7px;  --c:var(--pink-deep); right:-6%;  top:6%;   --fx:110px; --fy:-30px; --d:.36s; }
-.arc-intro-bit:nth-of-type(4)  { --s:11px; --c:var(--gold);      right:-1%;  top:-22%; --fx:50px;  --fy:-110px;--d:.41s; }
-.arc-intro-bit:nth-of-type(5)  { --s:6px;  --c:var(--pink);      right:6%;   top:-16%; --fx:120px; --fy:-60px; --d:.46s; }
-.arc-intro-bit:nth-of-type(6)  { --s:8px;  --c:var(--pink);      right:-8%;  top:-4%;  --fx:80px;  --fy:20px;  --d:.5s; }
-.arc-intro-bit:nth-of-type(7)  { --s:6px;  --c:var(--gold);      right:9%;   top:-24%; --fx:40px;  --fy:-80px; --d:.55s; }
-.arc-intro-bit:nth-of-type(8)  { --s:10px; --c:var(--pink-deep); right:-5%;  top:-28%; --fx:100px; --fy:-100px;--d:.6s; }
-.arc-intro-bit:nth-of-type(9)  { --s:5px;  --c:var(--gold);      right:12%;  top:-10%; --fx:60px;  --fy:-40px; --d:.65s; }
-.arc-intro-bit:nth-of-type(10) { --s:7px;  --c:var(--pink);      right:-10%; top:-18%; --fx:130px; --fy:-80px; --d:.7s; }
+.arc-intro-bit:nth-of-type(1)  { --s:13px; --c:var(--pink);      right:-3%;  top:-14%; --fx:90px;  --fy:-70px; --d:.55s; }
+.arc-intro-bit:nth-of-type(2)  { --s:9px;  --c:var(--gold);      right:2%;   top:-6%;  --fx:70px;  --fy:-90px; --d:.67s; }
+.arc-intro-bit:nth-of-type(3)  { --s:7px;  --c:var(--pink-deep); right:-6%;  top:6%;   --fx:110px; --fy:-30px; --d:.79s; }
+.arc-intro-bit:nth-of-type(4)  { --s:11px; --c:var(--gold);      right:-1%;  top:-22%; --fx:50px;  --fy:-110px;--d:.91s; }
+.arc-intro-bit:nth-of-type(5)  { --s:6px;  --c:var(--pink);      right:6%;   top:-16%; --fx:120px; --fy:-60px; --d:1.03s; }
+.arc-intro-bit:nth-of-type(6)  { --s:8px;  --c:var(--pink);      right:-8%;  top:-4%;  --fx:80px;  --fy:20px;  --d:1.15s; }
+.arc-intro-bit:nth-of-type(7)  { --s:6px;  --c:var(--gold);      right:9%;   top:-24%; --fx:40px;  --fy:-80px; --d:1.27s; }
+.arc-intro-bit:nth-of-type(8)  { --s:10px; --c:var(--pink-deep); right:-5%;  top:-28%; --fx:100px; --fy:-100px;--d:1.39s; }
+.arc-intro-bit:nth-of-type(9)  { --s:5px;  --c:var(--gold);      right:12%;  top:-10%; --fx:60px;  --fy:-40px; --d:1.51s; }
+.arc-intro-bit:nth-of-type(10) { --s:7px;  --c:var(--pink);      right:-10%; top:-18%; --fx:130px; --fy:-80px; --d:1.63s; }
 
 /* SPARKLE BURST: six stars pop around the mark as the beat lands */
 .arc-intro-spark {
@@ -928,12 +928,12 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   45% { opacity:1; transform:scale(1.25) rotate(10deg); }
   100% { opacity:0; transform:scale(.6) rotate(25deg); }
 }
-.arc-intro-spark:nth-of-type(1) { left:-4%;  top:8%;   --s:18px; --c:var(--gold); --d:.94s; }
-.arc-intro-spark:nth-of-type(2) { right:-3%; top:64%;  --s:14px; --c:var(--pink); --d:.97s; }
-.arc-intro-spark:nth-of-type(3) { left:14%;  top:-18%; --s:12px; --c:var(--pink); --d:1s; }
-.arc-intro-spark:nth-of-type(4) { right:16%; top:-12%; --s:16px; --c:var(--gold); --d:1.02s; }
-.arc-intro-spark:nth-of-type(5) { left:-7%;  top:58%;  --s:12px; --c:var(--gold); --d:1.05s; }
-.arc-intro-spark:nth-of-type(6) { right:-8%; top:22%;  --s:13px; --c:var(--pink); --d:1.08s; }
+.arc-intro-spark:nth-of-type(1) { left:-4%;  top:8%;   --s:18px; --c:var(--gold); --d:2.35s; }
+.arc-intro-spark:nth-of-type(2) { right:-3%; top:64%;  --s:14px; --c:var(--pink); --d:2.4s; }
+.arc-intro-spark:nth-of-type(3) { left:14%;  top:-18%; --s:12px; --c:var(--pink); --d:2.45s; }
+.arc-intro-spark:nth-of-type(4) { right:16%; top:-12%; --s:16px; --c:var(--gold); --d:2.5s; }
+.arc-intro-spark:nth-of-type(5) { left:-7%;  top:58%;  --s:12px; --c:var(--gold); --d:2.55s; }
+.arc-intro-spark:nth-of-type(6) { right:-8%; top:22%;  --s:13px; --c:var(--pink); --d:2.6s; }
 
 /* ---- the checker rail: the loading bar in the wordmark's own trim -------- */
 .arc-intro-rail {
@@ -943,8 +943,8 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
     var(--pink) 0 8px, var(--flap-well) 8px 12px,
     var(--gold) 12px 20px, var(--flap-well) 20px 24px);
   transform-origin:left center;
-  animation:arc-intro-rail-deal .5s steps(11, end) .3s both,
-            arc-intro-rail-chase .7s linear .85s infinite;
+  animation:arc-intro-rail-deal 1.7s steps(11, end) .55s both,
+            arc-intro-rail-chase .7s linear 2.3s infinite;
 }
 .arc-intro-rail::before, .arc-intro-rail::after {
   content:''; position:absolute; top:50%; width:14px; height:14px;
@@ -961,7 +961,7 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   position:relative; z-index:1;
   font-family:var(--pix); font-size:9px; letter-spacing:.22em;
   text-transform:uppercase; color:var(--ink-faint);
-  animation:arc-intro-caption-in .3s ease-out .55s both;
+  animation:arc-intro-caption-in .3s ease-out .8s both;
 }
 .arc-intro-caption .arc-loader-name { font-family:inherit; color:var(--pink); letter-spacing:inherit; }
 @keyframes arc-intro-caption-in { from { opacity:0; transform:translateY(5px); } to { opacity:1; transform:none; } }
@@ -975,21 +975,21 @@ html.arc-reduced .arc-timebar-fill::before { content:none; }
   position:absolute; inset:0; z-index:5; pointer-events:none; opacity:0;
   background:radial-gradient(circle at 50% 46%,
     rgba(255,241,250,.95), color-mix(in srgb, var(--pink) 40%, transparent) 55%, transparent 78%);
-  animation:arc-intro-flash .18s ease-out .96s;
+  animation:arc-intro-flash .22s ease-out 2.38s;
 }
 @keyframes arc-intro-flash { 0% { opacity:0; } 30% { opacity:.6; } 100% { opacity:0; } }
 
 /* CRT power-on: black tube, one hot scanline blooming open, then gone */
 .arc-intro-crt {
   position:absolute; inset:0; z-index:6; pointer-events:none; background:#000;
-  animation:arc-intro-crt-off .2s ease-in .14s forwards;
+  animation:arc-intro-crt-off .24s ease-in .3s forwards;
 }
 .arc-intro-crt::before {
   content:''; position:absolute; inset:0;
   background:linear-gradient(180deg, transparent 44%,
     rgba(255,214,240,.95) 49%, #fff 50%, rgba(255,214,240,.95) 51%, transparent 56%);
   transform:scaleY(.012); filter:blur(.4px);
-  animation:arc-intro-crt-line .22s cubic-bezier(.3,0,.2,1) both;
+  animation:arc-intro-crt-line .38s cubic-bezier(.3,0,.2,1) both;
 }
 @keyframes arc-intro-crt-line {
   0% { transform:scaleY(.012) scaleX(.1); opacity:1; }


### PR DESCRIPTION
Owner call on #259's splash: same beat map, longer runway. CRT power-on holds to .5s, THUD lands .64s, pixel tail rains .55-1.95s, the checker rail deals over 1.7s (reads as real loading), sparkle burst + flash at 2.35-2.65s as the payoff right before the zoom-through. `INTRO_MIN_MS` 1150 -> 2950. No structural changes; the boot.js/div contract is untouched.

Verified: node --check green; frozen-frame rig confirms partial rail states paint (blank mid-deal frames under `--virtual-time-budget` are a capture artifact for running compositor animations, not a CSS bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM49yuRfwECZEF6txQFkCW