### PR TITLE
fix(arcademy): topbar stays retired while the night campus is up (plaque clip)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -630,7 +630,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   function renderTopbar() {
     if (!dom || !dom.topbar) return;
     const bar = dom.topbar;
-    bar.hidden = false;
+    // Stay retired while the night campus is up: the scene carries the bar's
+    // job diegetically (crest, ID card, bell, gear), and any store write mid-scene
+    // (attendance tick, EMI's voice ledger) lands here via store.onChange - the
+    // old unconditional unhide resurrected the bar OVER the campus and buried
+    // the hanging timetable plaque under it (owner screenshot, 0824).
+    bar.hidden = !!campus;
     bar.textContent = '';
     bar.appendChild(el('span', 'arc-title', t('arcademy', 'The Arcademy')));
     bar.appendChild(el('span', 'chip year', tierLabel(maxTier())));


### PR DESCRIPTION
Owner screenshot 0824: the TIMETABLE plaque was clipping under the top bar on the campus screen.

Root cause, not a nudge: the plaque was never mis-positioned. `renderTopbar()` unconditionally sets `bar.hidden = false`, and `store.onChange` re-renders the bar on any write while `screen === 'board'` - so the first store write mid-campus (attendance tick, EMI's voice ledger save) resurrected the bar OVER the scene, burying the plaque that hangs in the dead-sky band. The campus is designed bar-less: crest, student ID, bell chip and gear carry the bar's job diegetically (see the comment at the campus build site).

Fix: `bar.hidden = !!campus` - the bar stays retired exactly while the campus instance is alive. Content still re-renders (cheap), the plain-board fallback and every other screen unhide exactly as before, and a failed campus build (campus = null) still gets its bar back.

Verified: merged suite pack failure set is byte-identical to pristine origin/main (18 stale-fixture reds, zero new); `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvQ6Jrn29HyZo7m7KCJLA1