### PR TITLE
feat(feel): THE BANK on XP - coalesced token flights to the counter

### DIFF
--- a/ConditioningControlPanel/Controls/AmbientFxCanvas.cs
+++ b/ConditioningControlPanel/Controls/AmbientFxCanvas.cs
@@ -87,12 +87,28 @@ namespace ConditioningControlPanel.Controls
     ///   • every tick is wrapped, and repeated faults stop the clock instead of spamming the log.
     ///
     /// All simulation state is in element-normalized (0-1) coordinates, so it is DPI- and
-    /// Viewbox-agnostic and <see cref="Burst"/> takes plain element-local coordinates.
+    /// Viewbox-agnostic, while the two one-shot entry points (<see cref="Burst"/> and
+    /// <see cref="BankTokens"/>) take plain element-local coordinates.
     /// </summary>
     public class AmbientFxCanvas : Decorator
     {
         private const int MaxBurstParticles = 150;
         private const int FaultLimit = 5;
+
+        // ---- THE BANK: guided token flight (House Book) ----
+
+        /// <summary>Hard ceiling on tokens in flight, and the size the sim array is pre-baked to.</summary>
+        private const int MaxBankTokens = BankFlightPlan.MaxTokens;
+
+        /// <summary>Core diameter band in ELEMENT pixels. The book calls for a coin, not a spark.</summary>
+        private const double BankTokenCoreMinPx = 5;
+        private const double BankTokenCoreMaxPx = 7;
+
+        /// <summary>Halo diameter as a multiple of the core. Enough to read as "lit", not as a puff.</summary>
+        private const float BankTokenGlowScale = 3.4f;
+
+        /// <summary>Fade-in after a token's stagger delay expires, so it arrives instead of popping.</summary>
+        private const float BankTokenFadeInMs = 90f;
 
         private readonly SKElement _sk;
         private readonly DispatcherTimer _timer;
@@ -129,6 +145,40 @@ namespace ConditioningControlPanel.Controls
         private Spark[]? _burst;
         private int _burstN;
         private SKColorFilter? _burstTint;
+
+        /// <summary>
+        /// One banked token. It carries its whole bezier rather than a velocity because the flight
+        /// is AUTHORED, not simulated: position is a pure function of elapsed time, so a dropped
+        /// frame moves the token further instead of bending its path, and the landing instant is
+        /// exact no matter how the clock stutters.
+        /// </summary>
+        private struct Tok
+        {
+            public float X0, Y0;      // P0, normalized
+            public float CX, CY;      // P1 (the bowed control point), normalized
+            public float X2, Y2;      // P2, normalized
+            public float X, Y;        // last evaluated position, normalized
+            public float Elapsed;     // ms since the FLIGHT started, not since this token launched
+            public float Delay, Dur;  // ms, from the flight plan
+            public float Size;        // normalized core half-size, same units as Spark.Size
+        }
+
+        private Tok[]? _tok;
+        private int _tokN;
+        private SKColorFilter? _tokTint;
+
+        /// <summary>The live flight's landing callback, plus the counters that make (index, isLast) honest.</summary>
+        private Action<int, bool>? _tokOnLand;
+        private int _tokLanded;
+        private int _tokTotal;
+
+        /// <summary>
+        /// Landing indices collected during a tick and dispatched after the sim loop has finished.
+        /// Pre-sized like everything else here - but the real reason it exists is re-entrancy: a
+        /// landing callback steps a counter and may do anything at all, including starting another
+        /// flight, and it must not be able to do that while the loop is still walking the array.
+        /// </summary>
+        private readonly int[] _tokLandBuf = new int[MaxBankTokens];
 
         private bool _running;
         private bool _paused;
@@ -213,6 +263,9 @@ namespace ConditioningControlPanel.Controls
             _running = false;
             _paused = false;
             StopClock();
+            // A live token flight is force-landed rather than dropped: its callbacks are somebody
+            // else's choreography and silently abandoning them leaves a held counter behind.
+            ForceLandTokens();
             _burst = null;
             _burstN = 0;
             _dustN = 0;
@@ -265,6 +318,153 @@ namespace ConditioningControlPanel.Controls
                 App.Logger?.Debug("AmbientFxCanvas.Burst: {E}", ex.Message);
             }
         }
+
+        /// <summary>
+        /// THE BANK (House Book): <paramref name="count"/> tokens spawn at <paramref name="origin"/>
+        /// and fly a slight arc to <paramref name="target"/> - both in element-local px - landing one
+        /// after another so the counter can tick per landing.
+        /// <paramref name="onLand"/> is invoked on the UI thread as each token arrives, with the
+        /// landing's ordinal and whether it was the last of the flight. Timings and bow come from
+        /// <see cref="BankFlightPlan"/>.
+        ///
+        /// <para><b>Arcs, not physics.</b> Each token rides a quadratic bezier whose control point
+        /// is the midpoint pushed perpendicular by the plan's signed bow, and its parameter is
+        /// eased IN - the book is explicit that tokens accelerate into the counter, which is what
+        /// makes the arrival read as being caught rather than as coasting to a stop.</para>
+        ///
+        /// <para><b>Landing ordinal, not plan index.</b> Durations vary by 150ms while the stagger
+        /// is 60-80ms, so tokens can and do land out of the order they left in. The index handed to
+        /// <paramref name="onLand"/> counts LANDINGS, which is the only thing a counter stepping
+        /// once per landing can safely divide by, and <c>isLast</c> is true exactly once.</para>
+        ///
+        /// <para><b>Safe to call while a flight is alive.</b> The old flight is force-landed first:
+        /// its outstanding callbacks fire immediately, in order, with the last carrying
+        /// <c>isLast</c>. Nothing is ever left holding a counter it was promised would be
+        /// released - which is also why a refusal (reduced motion, an unmeasured canvas, a
+        /// non-finite anchor) settles every callback on the spot instead of returning silently.
+        /// The value still arrives; only the show is skipped.</para>
+        /// </summary>
+        public void BankTokens(System.Windows.Point origin, System.Windows.Point target,
+                               int count, System.Windows.Media.Color? color, Action<int, bool>? onLand)
+        {
+            try
+            {
+                // A second flight always ends the first - THE BANK is one moment at a time.
+                ForceLandTokens();
+
+                if (count <= 0) return;
+
+                double w = ActualWidth, h = ActualHeight;
+                if (!MotionFx.AllowParticles || w <= 1 || h <= 1 ||
+                    !IsFinite(origin) || !IsFinite(target))
+                {
+                    SettleNow(count, onLand);
+                    return;
+                }
+
+                if (_particleBudget <= 0) ReadEnvironment();
+                // Budget-clamped exactly like Burst, even though seven tokens can never trouble a
+                // tier that allows particles at all: the rule is that no emitter gets to opt out.
+                count = Math.Clamp(count, 1, Math.Min(MaxBankTokens, Math.Max(1, _particleBudget)));
+
+                var plan = BankFlightPlan.Plan(count, _rng.Next());
+                if (plan.Length == 0) { SettleNow(count, onLand); return; }
+                count = plan.Length;
+
+                var c = color is { } wc ? new SKColor(wc.R, wc.G, wc.B) : _particle;
+                _tokTint?.Dispose();
+                _tokTint = SKColorFilter.CreateBlendMode(c, SKBlendMode.Modulate);
+
+                // Geometry is done in element px and normalized once at the end: normalized space is
+                // anisotropic, so a perpendicular computed in it would bow the wrong way on any
+                // canvas that is not square.
+                double dx = target.X - origin.X, dy = target.Y - origin.Y;
+                double dist = Math.Sqrt(dx * dx + dy * dy);
+                double perpX = dist > 0.001 ? -dy / dist : 0;
+                double perpY = dist > 0.001 ? dx / dist : 0;
+                double midX = (origin.X + target.X) * 0.5;
+                double midY = (origin.Y + target.Y) * 0.5;
+                float minElem = (float)Math.Min(w, h);
+
+                _tok ??= new Tok[MaxBankTokens];
+                _tokN = 0;
+                _tokOnLand = onLand;
+                _tokLanded = 0;
+                _tokTotal = count;
+
+                for (int i = 0; i < count && _tokN < MaxBankTokens; i++)
+                {
+                    var slot = plan[i];
+                    double bow = slot.ArcBow * dist;
+                    double corePx = BankTokenCoreMinPx + _rng.NextDouble() * (BankTokenCoreMaxPx - BankTokenCoreMinPx);
+
+                    _tok[_tokN++] = new Tok
+                    {
+                        X0 = (float)(origin.X / w), Y0 = (float)(origin.Y / h),
+                        CX = (float)((midX + perpX * bow) / w), CY = (float)((midY + perpY * bow) / h),
+                        X2 = (float)(target.X / w), Y2 = (float)(target.Y / h),
+                        X = (float)(origin.X / w), Y = (float)(origin.Y / h),
+                        Elapsed = 0f,
+                        Delay = (float)slot.DelayMs,
+                        Dur = (float)Math.Max(1.0, slot.DurationMs),
+                        Size = (float)(corePx / (2.0 * Math.Max(1f, minElem))),
+                    };
+                }
+
+                Evaluate();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("AmbientFxCanvas.BankTokens: {E}", ex.Message);
+                // Whatever failed, the caller is mid-choreography and is waiting on callbacks it
+                // will otherwise never get. Force-landing settles whatever was armed; if the flight
+                // never armed at all this is a no-op and the caller's own watchdog takes it.
+                try { ForceLandTokens(); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// End the live flight now: clear the sim FIRST (so a callback that starts another flight
+        /// cannot see a corpse), then fire every callback the flight still owed, in order.
+        /// </summary>
+        private void ForceLandTokens()
+        {
+            var cb = _tokOnLand;
+            int landed = _tokLanded, total = _tokTotal;
+
+            _tokOnLand = null;
+            _tokLanded = 0;
+            _tokTotal = 0;
+            _tokN = 0;
+            _tokTint?.Dispose();
+            _tokTint = null;
+
+            if (cb == null || total <= 0) return;
+            for (int i = landed; i < total; i++) InvokeLand(cb, i, i == total - 1);
+        }
+
+        /// <summary>A flight that never flew, answered instantly so nobody is left holding a counter.</summary>
+        private static void SettleNow(int count, Action<int, bool>? onLand)
+        {
+            if (onLand == null || count <= 0) return;
+            for (int i = 0; i < count; i++) InvokeLand(onLand, i, i == count - 1);
+        }
+
+        /// <summary>
+        /// Every landing callback is individually railed. A subscriber that throws on token three
+        /// must not cost tokens four through seven their callbacks - the last one is the only thing
+        /// that puts the counter back on the ledger's number.
+        /// </summary>
+        private static void InvokeLand(Action<int, bool>? cb, int index, bool isLast)
+        {
+            if (cb == null) return;
+            try { cb(index, isLast); }
+            catch (Exception ex) { App.Logger?.Debug("AmbientFxCanvas token landing: {E}", ex.Message); }
+        }
+
+        private static bool IsFinite(System.Windows.Point p)
+            => !double.IsNaN(p.X) && !double.IsNaN(p.Y) &&
+               !double.IsInfinity(p.X) && !double.IsInfinity(p.Y);
 
         // ============================== environment ==============================
 
@@ -417,13 +617,15 @@ namespace ConditioningControlPanel.Controls
 
         private bool ShouldRun()
         {
-            // A live burst outruns the ambient gates: it is a one-shot event moment, already
-            // budget-checked at emit time, and it may fire on a canvas running no ambient layers.
-            bool burstLive = _burst != null && _burstN > 0;
+            // Live one-shot work outruns the ambient gates: a burst or a token flight is an event
+            // moment, already budget-checked at emit time, and it may run on a canvas composing no
+            // ambient layers at all. A token flight counts for the extra reason that its landings
+            // drive somebody else's counter - stopping the clock under it would strand the display.
+            bool oneShotLive = (_burst != null && _burstN > 0) || _tokN > 0;
             if (_paused || _faults >= FaultLimit) return false;
-            if (!_running && !burstLive) return false;
+            if (!_running && !oneShotLive) return false;
             if (!IsLoaded || !IsVisible) return false;
-            if (!burstLive)
+            if (!oneShotLive)
             {
                 if (_targetFps <= 0) return false;
                 if (!MotionFx.AllowAmbientLoops) return false;
@@ -432,7 +634,7 @@ namespace ConditioningControlPanel.Controls
             if (w != null)
             {
                 if (w.WindowState == WindowState.Minimized) return false;
-                if (!w.IsActive && !burstLive) return false;
+                if (!w.IsActive && !oneShotLive) return false;
             }
             return true;
         }
@@ -471,6 +673,7 @@ namespace ConditioningControlPanel.Controls
                 if (!_sheenDone) _sheenT += dt;
                 StepDust(dt);
                 StepBurst(dt);
+                StepTokens(dt);
 
                 _sk.InvalidateVisual();
             }
@@ -579,6 +782,71 @@ namespace ConditioningControlPanel.Controls
             }
         }
 
+        /// <summary>
+        /// Advance the token flight. Nothing here integrates: each token's position is evaluated
+        /// straight off its bezier at the eased fraction of its own elapsed time, so a hitch costs
+        /// smoothness and never accuracy - a token that misses ten frames is simply further along.
+        ///
+        /// <para>Landings are collected and dispatched AFTER the loop, never inside it. The
+        /// callback is the shell's counter step and may do arbitrary work, up to and including
+        /// launching the next flight; letting it run mid-walk would mutate the array under the
+        /// iterator.</para>
+        /// </summary>
+        private void StepTokens(float dt)
+        {
+            if (_tok == null || _tokN == 0) return;
+
+            float dtMs = dt * 1000f;
+            int landedNow = 0;
+
+            for (int i = _tokN - 1; i >= 0; i--)
+            {
+                var t = _tok[i];
+                t.Elapsed += dtMs;
+
+                float local = t.Elapsed - t.Delay;
+                if (local <= 0f) { _tok[i] = t; continue; }   // still waiting out its stagger
+
+                float p = Math.Clamp(local / t.Dur, 0f, 1f);
+                float e = p * p;                              // ease-in: accelerate INTO the counter
+                float inv = 1f - e;
+                t.X = inv * inv * t.X0 + 2f * inv * e * t.CX + e * e * t.X2;
+                t.Y = inv * inv * t.Y0 + 2f * inv * e * t.CY + e * e * t.Y2;
+
+                if (p >= 1f)
+                {
+                    _tok[i] = _tok[--_tokN];
+                    if (landedNow < _tokLandBuf.Length) _tokLandBuf[landedNow++] = _tokLanded;
+                    _tokLanded++;
+                }
+                else
+                {
+                    _tok[i] = t;
+                }
+            }
+
+            if (landedNow == 0) return;
+
+            var cb = _tokOnLand;
+            int total = _tokTotal;
+            bool done = _tokN == 0 && _tokLanded >= _tokTotal;
+
+            if (done)
+            {
+                // Teardown before dispatch, for the same reason ForceLandTokens clears first.
+                _tokOnLand = null;
+                _tokLanded = 0;
+                _tokTotal = 0;
+                _tokTint?.Dispose();
+                _tokTint = null;
+            }
+
+            for (int k = 0; k < landedNow; k++)
+                InvokeLand(cb, _tokLandBuf[k], _tokLandBuf[k] == total - 1);
+
+            if (done) Evaluate();
+        }
+
         // ================================ paint ================================
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
@@ -601,6 +869,7 @@ namespace ConditioningControlPanel.Controls
                 if (!_fogOnly && (layers & AmbientFxLayers.DustField) != 0) DrawDust(canvas, w, h, min, intensity);
                 if (!_fogOnly && (layers & AmbientFxLayers.SheenSweep) != 0) DrawSheen(canvas, w, h, intensity);
                 DrawBurst(canvas, w, h, min);
+                DrawTokens(canvas, w, h, min);
             }
             catch (Exception ex)
             {
@@ -713,6 +982,39 @@ namespace ConditioningControlPanel.Controls
                 float size = s.Size * min * 2f * (0.6f + 0.4f * env);
                 _paint.Color = SKColors.White.WithAlpha(Alpha(a));
                 DrawSprite(canvas, Dot, s.X * w, s.Y * h, size, size);
+            }
+            _paint.ColorFilter = null;
+        }
+
+        /// <summary>
+        /// A token is a bright core sitting in a soft halo - two draws of the shared dot at
+        /// different scales, which is how everything else on this canvas gets a glow without
+        /// allocating a shader. Drawn last, over the bursts: THE BANK is the thing being read.
+        /// </summary>
+        private void DrawTokens(SKCanvas canvas, float w, float h, float min)
+        {
+            if (_tok == null || _tokN == 0) return;
+
+            _paint.ColorFilter = _tokTint;
+            for (int i = 0; i < _tokN; i++)
+            {
+                var t = _tok[i];
+                float local = t.Elapsed - t.Delay;
+                if (local <= 0f) continue;   // still staggered: it does not exist yet
+
+                float p = Math.Clamp(local / t.Dur, 0f, 1f);
+                float a = Math.Clamp(local / BankTokenFadeInMs, 0f, 1f);
+                if (a <= 0.004f) continue;
+
+                float core = t.Size * min * 2f;
+                float x = t.X * w, y = t.Y * h;
+
+                _paint.Color = SKColors.White.WithAlpha(Alpha(0.30f * a));
+                DrawSprite(canvas, Dot, x, y, core * BankTokenGlowScale, core * BankTokenGlowScale);
+
+                // The core brightens as it closes, so the last thing the eye tracks is the arrival.
+                _paint.Color = SKColors.White.WithAlpha(Alpha((0.75f + 0.25f * p) * a));
+                DrawSprite(canvas, Dot, x, y, core, core);
             }
             _paint.ColorFilter = null;
         }

--- a/ConditioningControlPanel/MainWindow/MainWindow.BankFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.BankFx.cs
@@ -1,0 +1,832 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
+using ConditioningControlPanel.Controls;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE BANK (House Book) on XP: the seventh event moment, and the only recurring one.
+    ///
+    /// <para><b>The move.</b> Value spawns at its SOURCE as 3-7 tokens, flies a slight arc to the
+    /// counter in the header, and the counter ticks up as each token lands - a mini-thud and a
+    /// scale pop on the last. The whole point is that XP stops being a number that silently
+    /// changed and becomes something that visibly arrived from somewhere.</para>
+    ///
+    /// <para><b>Why it needs a banker.</b> XP in this app does not arrive as events, it arrives as
+    /// weather: a flash, a mantra, an attention check and a bubble pop can all settle inside half a
+    /// second, and thirty call sites feed <c>AddXP</c>. Celebrating each one is noise.
+    /// <see cref="BankAccumulator"/> pools awards into rare, deliberate flights (1.5s collection
+    /// window, 3s floor between launches) and this file is only its shell: anchors, a canvas, a
+    /// counter and the rails that guarantee the display ends up on the truth no matter what.</para>
+    ///
+    /// <para><b>The counter is HELD, the ledger is not.</b> House Law I: <c>settings.PlayerXP</c>
+    /// is written the instant the award lands, exactly as before - nothing in this file touches the
+    /// ledger, reads back into it, or can delay it. What is staged is the READOUT: while a pot is
+    /// open or a flight is in the air, <see cref="TryHoldXpDisplay"/> swallows the odometer tween
+    /// and remembers the target instead, and the tokens are what release it. Every path out of that
+    /// hold ends with the display standing on the ledger's number (see
+    /// <see cref="ReleaseXpHold"/>), which is why the failsafes below are not optional decoration.</para>
+    ///
+    /// <para><b>Arming, and the one award that always leaks.</b> The hold has to be armed BEFORE
+    /// <c>OnXPChanged</c> runs, because that is what tweens the counter - so this file subscribes
+    /// <see cref="OnBankXpChanged"/> to <c>XPChanged</c> immediately ahead of the window's own
+    /// handler (see the wiring in MainWindow.xaml.cs) and resolves the arm on the
+    /// <c>XPAwarded</c> that ProgressionService always raises straight afterwards, on the same call
+    /// stack. If that ordering ever slipped, the failure is one award's worth of XP arriving early
+    /// rather than a broken counter - <see cref="BankCounterScript.Target"/> clamps a flight to the
+    /// live ledger precisely so an already-credited award cannot make the tokens overshoot.</para>
+    ///
+    /// <para><b>Rails.</b> Every hook here is fire-and-forget safe and wrapped. THE BANK is skipped
+    /// outright - the whole staging path, not just the particles - whenever
+    /// <c>EventFxAllowed</c> says no (reduced motion, no particle budget, window inactive or
+    /// minimised), so under MotionLevel Reduced/Off the XP display behaves byte-identically to how
+    /// it did before this file existed. No idle clock: the poll runs only while a pot is open or a
+    /// flight is alive, and the token canvas holds no timer between flights.</para>
+    ///
+    /// <para><b>Deliberately unstaged:</b> the profile bubble's own mini XP readout
+    /// (<c>OnBubbleXPChanged</c>, MainWindow.ProfileBubble.cs). It may briefly lead the held
+    /// counter by a pot, which is fine - it is a 20px secondary readout, not the moment - and
+    /// staging it would double this file's surface for nothing.</para>
+    /// </summary>
+    public partial class MainWindow
+    {
+        // ---- DIALS ----------------------------------------------------------------
+        // Collection window and launch cooldown are NOT here: they are BankAccumulator.WindowMs
+        // and BankAccumulator.CooldownMs, next to the logic that spends them. Token count, stagger,
+        // duration and arc bow live in BankFlightPlan for the same reason.
+
+        /// <summary>
+        /// Slack around the origin-to-target bounding box, in window pixels. The tokens' bezier
+        /// control point bows off the straight line by up to 22% of the distance travelled, and the
+        /// glow sprite is drawn ~24px wide at its largest - 80px holds both without the arc ever
+        /// clipping on the surface's edge.
+        /// </summary>
+        private const double BankBoxPadPx = 80;
+
+        /// <summary>
+        /// Hard ceiling on either edge of the token surface. Not a feel dial - a failsafe. Anchor
+        /// rectangles come out of <c>TransformToVisual</c>, and a detached or mid-layout element can
+        /// hand back coordinates in the tens of thousands; a Skia surface sized from that is a
+        /// multi-hundred-megabyte allocation. Anything past this is treated as a bad anchor.
+        /// </summary>
+        private const double BankBoxMaxPx = 2600;
+
+        /// <summary>
+        /// How far left of the XP track the neutral origin sits, in window pixels. Used only when
+        /// even the profile bubble cannot be mapped: it puts the spawn out in the header's empty
+        /// space so the tokens still travel a legible distance to the counter.
+        /// </summary>
+        private const double BankFallbackOriginDx = -180;
+
+        /// <summary>Poll interval for pot ripening, the flight watchdog and the hold self-heal.</summary>
+        private const int BankPollMs = 250;
+
+        /// <summary>
+        /// Longest the counter may stay held for one flight before the shell stops believing in it.
+        /// Generously past the worst legal envelope (7 tokens: ~480ms of stagger plus a 650ms
+        /// flight), because this is the rail that catches an outcome nobody predicted, not a timer
+        /// anything is meant to run up against.
+        /// </summary>
+        private const double BankWatchdogMs = 6000;
+
+        /// <summary>Counter pop on the last landing. Small: this is a 11px readout, not a headline.</summary>
+        private const double BankPopScale = 1.12;
+        private const double BankPopOutMs = 80;
+        private const double BankPopSpringMs = 220;
+
+        /// <summary>Mini-thud, ChaosSfx-style: the override slot ships EMPTY and the fallback carries it.</summary>
+        private const string BankThudOverride = "ui/bank_thud.mp3";
+        private const string BankThudFallback = "bubbles/Pop2.mp3";
+        private const float BankThudScale = 0.35f;
+        private const string BankThudTag = "ui-bank";
+
+        // ---- state -----------------------------------------------------------------
+
+        private BankAccumulator? _bank;
+        private DispatcherTimer? _bankPoll;
+
+        /// <summary>Monotonic clock for the accumulator and the watchdog. Never <c>DateTime.Now</c>.</summary>
+        private readonly Stopwatch _bankClock = new();
+
+        /// <summary>
+        /// THE BANK's own token surface, separate from <c>_eventBurstLayer</c>. A burst is a fixed
+        /// box centred on one anchor; a flight is a line between two, so this one is re-sized per
+        /// flight to the box it actually needs.
+        /// </summary>
+        private AmbientFxCanvas? _bankLayer;
+        private bool _bankLayerFailed;
+
+        /// <summary>Where the layer's top-left currently sits in EventFxHost coordinates.</summary>
+        private Point _bankLayerOrigin;
+
+        private ScaleTransform? _bankPopTransform;
+
+        /// <summary>
+        /// Set on the XP path (possibly off the UI thread) to say "an award is landing right now";
+        /// cleared by the <c>XPAwarded</c> that always follows. It is the ONLY thing that
+        /// distinguishes an award's display update from an ordinary refresh (a profile load, a tab
+        /// switch), which must never be held.
+        /// </summary>
+        private volatile bool _bankAwardPending;
+
+        private bool _bankHolding;
+        private double _bankHeldXp;
+        private double _bankHeldNeeded;
+        private int _bankHeldLevel;
+
+        private bool _bankFlightLive;
+        private double _bankFlightStartedMs;
+
+        /// <summary>The pot the live flight is carrying - the figure its last token must deliver.</summary>
+        private double _bankFlightPot;
+
+        /// <summary>Counter value the live flight is counting up from, and the one it is standing on.</summary>
+        private double _bankFlightFrom;
+        private double _bankFlightShown;
+        private int _bankFlightTokens;
+
+        /// <summary>
+        /// Bumped before every launch and every abort, and captured by each landing callback.
+        /// Force-landing a flight fires its outstanding callbacks immediately (AmbientFxCanvas's
+        /// contract), so without this a dying flight's tail would step the counter of the live one.
+        /// </summary>
+        private int _bankFlightId;
+
+        // ============================== lifecycle ==============================
+
+        /// <summary>
+        /// Wires THE BANK. Called from the constructor IMMEDIATELY BEFORE the window subscribes
+        /// <c>OnXPChanged</c>, and the order matters: multicast handlers run in subscription order,
+        /// so <see cref="OnBankXpChanged"/> arming the hold has to be in front of the handler that
+        /// tweens the counter. Safe to call twice.
+        /// </summary>
+        internal void InitializeBankFx()
+        {
+            try
+            {
+                if (_bank != null) return;
+
+                _bankClock.Restart();
+                _bank = new BankAccumulator(() => _bankClock.Elapsed.TotalMilliseconds);
+
+                if (App.Progression != null)
+                {
+                    App.Progression.XPChanged += OnBankXpChanged;
+                    App.Progression.XPAwarded += OnBankXpAwarded;
+                }
+
+                // Focus-state silence: a pot collected before the user walked away is dropped, not
+                // queued. Piggy-backing on the window's own events rather than ChromeFx's funnel
+                // keeps this file removable in one piece.
+                Deactivated += OnBankWindowStateish;
+                StateChanged += OnBankWindowStateish;
+            }
+            catch (Exception ex) { App.Logger?.Warning(ex, "InitializeBankFx failed - THE BANK disabled"); }
+        }
+
+        /// <summary>
+        /// Unwires THE BANK and settles anything it was holding. Called from the window's cleanup
+        /// beside the other progression unsubscribes.
+        /// </summary>
+        internal void ShutdownBankFx()
+        {
+            try
+            {
+                if (App.Progression != null)
+                {
+                    App.Progression.XPChanged -= OnBankXpChanged;
+                    App.Progression.XPAwarded -= OnBankXpAwarded;
+                }
+                Deactivated -= OnBankWindowStateish;
+                StateChanged -= OnBankWindowStateish;
+
+                _bankAwardPending = false;
+                // The window is going away, so there is nobody left to show a corrected number to:
+                // land the flight and drop the hold without touching the display.
+                AbortBankFlight(writeTruth: false);
+                _bank?.Reset();
+                StopBankPoll();
+                _bankClock.Stop();
+            }
+            catch (Exception ex) { App.Logger?.Debug("ShutdownBankFx: {E}", ex.Message); }
+        }
+
+        private void OnBankWindowStateish(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (IsActive && WindowState != WindowState.Minimized) return;
+                _bank?.Reset();
+                AbortBankFlight(writeTruth: true);
+                StopBankPoll();
+            }
+            catch (Exception ex) { App.Logger?.Debug("BankFx activation: {E}", ex.Message); }
+        }
+
+        // ============================== the XP path ==============================
+
+        /// <summary>
+        /// Arms the hold. Runs on whatever thread awarded the XP - which is why it does nothing but
+        /// set a flag: <c>IsActive</c>, <c>IsVisible</c> and the rest of the gate are DependencyObject
+        /// reads and throw off the UI thread. The real decision is taken in
+        /// <see cref="TryHoldXpDisplay"/>, which is always on the dispatcher.
+        /// </summary>
+        private void OnBankXpChanged(object? sender, double xp) => _bankAwardPending = true;
+
+        /// <summary>
+        /// The award itself, with its size, its source and whether it crossed a level. Resolves the
+        /// arm one way or the other: into a pot, or into an immediate release. Marshalled to the
+        /// dispatcher because a good half of the thirty award sites are service threads.
+        /// </summary>
+        private void OnBankXpAwarded(object? sender, ProgressionService.XpAward award)
+        {
+            try
+            {
+                if (!Dispatcher.CheckAccess())
+                {
+                    // BeginInvoke, never Invoke: this is a decoration on the end of an award and it
+                    // must not be able to block the thread that earned it.
+                    Dispatcher.BeginInvoke(new Action(() => OnBankXpAwarded(sender, award)));
+                    return;
+                }
+
+                _bankAwardPending = false;
+                // AbortBankFlight, not a bare ReleaseXpHold, on each of the three give-up paths
+                // below. Dropping the hold on its own is only honest when nothing is in the air, and
+                // none of them can promise that: a flight lives well over a second and awards arrive
+                // by the handful inside one. A flight whose hold has been released still steps the
+                // counter on every remaining landing, off a target recomputed from _lastXpShown -
+                // which the truthful write has just moved - so the readout runs BACKWARDS off the
+                // ledger and finishes on the flight's own number with nothing left to correct it.
+                if (_bank == null) { AbortBankFlight(writeTruth: true); return; }
+
+                // One burst per moment. CelebrateLevelUp will normally have ended whatever was in
+                // the air before this runs (AddXP raises LevelUp ahead of XPChanged - see
+                // MainWindow.EventFx.cs) and OnLevelUp's UpdateLevelDisplay has already written the
+                // post-level number; all that is left here is to make sure the pot this award
+                // poisoned is gone and the speculative hold from its own XPChanged is released. The
+                // abort is repeated rather than assumed: this file should not be correct only for as
+                // long as another one keeps firing in a particular order.
+                if (award.LeveledUp)
+                {
+                    _bank.OnAward(award.Amount, award.Source, true);
+                    AbortBankFlight(writeTruth: true);
+                    return;
+                }
+
+                // Focus-state silence and reduced motion: the award bypasses THE BANK entirely
+                // rather than being pooled for later. This gate is not only about the user walking
+                // away, which is the case the window events already cover - MotionFx.AllowParticles
+                // reads PerformanceProfile.CurrentTier, and that counts LIVE flash windows and
+                // bubbles, so a flash burst crossing the tier threshold can shut THE BANK off in the
+                // middle of a flight. Which is exactly why the flight is ended here rather than
+                // merely unhooked from the counter it is still driving.
+                if (!EventFxAllowed)
+                {
+                    _bank.Reset();
+                    AbortBankFlight(writeTruth: true);
+                    return;
+                }
+
+                var flight = _bank.OnAward(award.Amount, award.Source, false);
+                if (flight != null)
+                {
+                    LaunchBankFlight(flight);
+                    return;
+                }
+
+                // Nothing was opened by this award (a zero or non-finite amount is ignored outright)
+                // and nothing is in the air: there is no future event that would ever release the
+                // hold this award armed, so release it here rather than leaning on the watchdog.
+                if (!_bank.HasOpenPot && !_bankFlightLive)
+                {
+                    ReleaseXpHold(writeTruth: true);
+                    return;
+                }
+
+                StartBankPoll();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("OnBankXpAwarded: {E}", ex.Message);
+                try { AbortBankFlight(writeTruth: true); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// The hook <c>AnimateXpDisplay</c> consults before it tweens anything. Returns true when
+        /// THE BANK owns the readout right now, in which case the caller records nothing and draws
+        /// nothing - the target is remembered here and the tokens deliver it.
+        ///
+        /// <para>Three states meet in this method. An ordinary refresh (no award pending, no hold)
+        /// falls straight through and the file may as well not exist. An award landing while a pot
+        /// or a flight is live extends the existing hold with the newer target. An award landing
+        /// with no hold yet takes the gate - and this is the ONLY place the gate can be read,
+        /// because it is the only one of the three that is guaranteed to be on the UI thread.</para>
+        /// </summary>
+        /// <param name="xp">The ledger's XP for this level - the value being withheld.</param>
+        /// <param name="xpNeeded">The level's cap, for the "<c>n / cap XP</c>" format.</param>
+        /// <param name="level">The level that <paramref name="xp"/> belongs to.</param>
+        /// <returns>True if the caller should skip its tween entirely.</returns>
+        internal bool TryHoldXpDisplay(double xp, double xpNeeded, int level)
+        {
+            try
+            {
+                if (!_bankHolding)
+                {
+                    if (!_bankAwardPending) return false;
+                    if (!EventFxAllowed) { _bankAwardPending = false; return false; }
+
+                    // A level change wraps the readout; there is nothing coherent to hold across it.
+                    if (_bankHeldLevel != level && _bankFlightLive) return false;
+
+                    _bankHolding = true;
+                }
+
+                _bankHeldXp = xp;
+                _bankHeldNeeded = xpNeeded;
+                _bankHeldLevel = level;
+
+                // The poll is what heals a hold whose award never resolved into a pot.
+                StartBankPoll();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("TryHoldXpDisplay: {E}", ex.Message);
+                _bankHolding = false;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Ends the hold. When <paramref name="writeTruth"/> the display is put back on the ledger
+        /// through the ordinary path, which by then sees no hold and behaves exactly as it does for
+        /// any other award. Passing false is for the two callers who know a truthful write is
+        /// already coming (a level-up's own UpdateLevelDisplay) or that nobody will ever see one
+        /// (window teardown).
+        ///
+        /// <para>The arm is suppressed across the write, because the write has to LAND. Otherwise
+        /// <see cref="TryHoldXpDisplay"/> is free to re-arm on an award still marshalling in from a
+        /// worker thread and swallow the very refresh that puts the counter back on the ledger - and
+        /// since every caller that gives up stops the poll immediately afterwards, the readout would
+        /// be left standing on a stale number with no clock left to heal it. It is re-armed on the
+        /// way out, so a genuine award still gets its moment - re-armed and never cleared, because
+        /// an award landing on a worker thread DURING the write arms the flag itself and restoring
+        /// a remembered false would throw that arm away.</para>
+        /// </summary>
+        private void ReleaseXpHold(bool writeTruth)
+        {
+            bool wasHolding = _bankHolding;
+            _bankHolding = false;
+            if (!wasHolding || !writeTruth) return;
+
+            bool armed = _bankAwardPending;
+            _bankAwardPending = false;
+            try { UpdateLevelDisplay(); }
+            catch (Exception ex) { App.Logger?.Debug("ReleaseXpHold: {E}", ex.Message); }
+            finally { if (armed) _bankAwardPending = true; }
+        }
+
+        // ============================== the poll ==============================
+
+        /// <summary>
+        /// Starts the only clock this feature owns, and only while there is something for it to
+        /// resolve: a pot ripening, a flight to watchdog, or a hold to heal. EventFx's whole appeal
+        /// is that it costs nothing when it is not happening, and a 250ms timer parked forever on
+        /// an idle app would spend that for a feature that fires every few minutes.
+        /// </summary>
+        private void StartBankPoll()
+        {
+            try
+            {
+                _bankPoll ??= CreateBankPoll();
+                if (_bankPoll != null && !_bankPoll.IsEnabled) _bankPoll.Start();
+            }
+            catch (Exception ex) { App.Logger?.Debug("StartBankPoll: {E}", ex.Message); }
+        }
+
+        private DispatcherTimer? CreateBankPoll()
+        {
+            var timer = new DispatcherTimer(DispatcherPriority.Background)
+            {
+                Interval = TimeSpan.FromMilliseconds(BankPollMs),
+            };
+            timer.Tick += OnBankPollTick;
+            return timer;
+        }
+
+        private void StopBankPoll()
+        {
+            try { _bankPoll?.Stop(); }
+            catch (Exception ex) { App.Logger?.Debug("StopBankPoll: {E}", ex.Message); }
+        }
+
+        private void OnBankPollTick(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (_bank == null) { StopBankPoll(); return; }
+
+                // FAILSAFE - the watchdog. A flight that has not reported its last landing long
+                // after the longest legal envelope is not coming back; the counter is not allowed
+                // to wait on it.
+                if (_bankFlightLive &&
+                    _bankClock.Elapsed.TotalMilliseconds - _bankFlightStartedMs > BankWatchdogMs)
+                {
+                    App.Logger?.Debug("[BANK] watchdog fired - flight never landed, snapping the counter");
+                    AbortBankFlight(writeTruth: true);
+                }
+
+                if (!_bankFlightLive)
+                {
+                    var flight = _bank.Tick();
+                    if (flight != null) LaunchBankFlight(flight);
+                }
+
+                if (_bankFlightLive || _bank.HasOpenPot) return;
+
+                // FAILSAFE - the self-heal. Nothing is open, nothing is flying: any hold still
+                // standing belongs to an award that never became a pot.
+                ReleaseXpHold(writeTruth: true);
+                StopBankPoll();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("OnBankPollTick: {E}", ex.Message);
+                try { AbortBankFlight(writeTruth: true); StopBankPoll(); } catch { }
+            }
+        }
+
+        // ============================== the flight ==============================
+
+        /// <summary>
+        /// Launches one BANK moment: resolve the two anchors, size the surface to the line between
+        /// them, and hand the tokens to the canvas. Anything that cannot be resolved cancels the
+        /// moment and releases the counter - a flight is a decoration, and a decoration that cannot
+        /// be drawn must never cost the user their number.
+        ///
+        /// <para>Every refusal below goes out through <see cref="AbortBankFlight"/> rather than a
+        /// bare release. Almost always there is nothing in the air to abort and the two are the same
+        /// thing; the exception is the one case worth writing for, a previous flight that stalled
+        /// (its canvas stopped ticking) and is sitting on the counter waiting for the watchdog. The
+        /// accumulator's cooldown can hand this method a new pot inside that window, and letting the
+        /// stalled flight keep the readout while its successor is refused is how a stale number
+        /// survives.</para>
+        /// </summary>
+        private void LaunchBankFlight(BankAccumulator.Flight flight)
+        {
+            try
+            {
+                if (flight == null || !EventFxAllowed) { AbortBankFlight(writeTruth: true); return; }
+
+                // No hold means no withheld value, and a flight whose tokens deliver a number that
+                // is already on screen is decoration pretending to be a payout. (Also guards the
+                // "n / cap XP" denominator, which only exists once something has been held.)
+                if (!_bankHolding || _bankHeldNeeded <= 0) { AbortBankFlight(writeTruth: true); return; }
+
+                var host = EventFxHost;
+                if (host == null) { AbortBankFlight(writeTruth: true); return; }
+
+                if (!TryResolveBankTarget(host, out var target) ||
+                    !TryResolveBankOrigin(host, flight.DominantSource, out var origin))
+                {
+                    AbortBankFlight(writeTruth: true);
+                    return;
+                }
+
+                var layer = EnsureBankLayer(host, origin, target);
+                if (layer == null) { AbortBankFlight(writeTruth: true); return; }
+
+                // A second flight force-lands the first from inside BankTokens. Bumping the id here,
+                // BEFORE that happens, is what makes the dying flight's tail callbacks inert.
+                int id = ++_bankFlightId;
+
+                _bankFlightLive = true;
+                _bankFlightStartedMs = _bankClock.Elapsed.TotalMilliseconds;
+                _bankFlightPot = flight.XpSum;
+                _bankFlightTokens = Math.Max(1, flight.TokenCount);
+                _bankFlightFrom = BankCounterScript.StartValue(_lastXpShown, _lastXpLevelShown, _bankHeldLevel);
+                _bankFlightShown = _bankFlightFrom;
+
+                StartBankPoll();
+
+                layer.BankTokens(new Point(origin.X - _bankLayerOrigin.X, origin.Y - _bankLayerOrigin.Y),
+                                 new Point(target.X - _bankLayerOrigin.X, target.Y - _bankLayerOrigin.Y),
+                                 _bankFlightTokens, FxTheme.GlowColor,
+                                 (index, isLast) => OnBankTokenLanded(id, index, isLast));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("LaunchBankFlight: {E}", ex.Message);
+                try { AbortBankFlight(writeTruth: true); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// One token arriving at the counter. Steps the readout by its share of the pot; on the last
+        /// landing it puts the counter exactly on the pot's figure, thuds, pops, fills the bar and
+        /// hands the display back.
+        /// </summary>
+        private void OnBankTokenLanded(int flightId, int index, bool isLast)
+        {
+            try
+            {
+                // A force-landed predecessor settling its debts. Its callbacks are honest, they are
+                // just no longer about anything on screen.
+                if (flightId != _bankFlightId || !_bankFlightLive) return;
+
+                double truth = _bankHolding ? _bankHeldXp : _lastXpShown;
+                double target = BankCounterScript.Target(_bankFlightFrom, _bankFlightPot, truth);
+                double value = BankCounterScript.StepValue(_bankFlightFrom, target, index, _bankFlightTokens);
+
+                StepBankCounter(value, isLast);
+                if (!isLast) return;
+
+                _bankFlightLive = false;
+                PlayBankThud();
+                PopXpCounter();
+                FillXpBarTo(value, _bankHeldNeeded);
+
+                // The pot that was collecting while this flight was in the air keeps the hold: its
+                // own tokens are what will be seen to deliver it.
+                if (_bank?.HasOpenPot != true)
+                {
+                    ReleaseXpHold(writeTruth: true);
+                    StopBankPoll();
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("OnBankTokenLanded: {E}", ex.Message);
+                try { AbortBankFlight(writeTruth: true); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Ends the live flight now and, unless told otherwise, puts the counter back on the ledger.
+        /// The id is bumped first so the force-land's callbacks - which fire synchronously from
+        /// inside <c>Stop()</c> - cannot step a counter that is already being corrected.
+        /// </summary>
+        private void AbortBankFlight(bool writeTruth)
+        {
+            try
+            {
+                _bankFlightId++;
+                _bankFlightLive = false;
+                try { _bankLayer?.Stop(); }
+                catch (Exception ex) { App.Logger?.Debug("AbortBankFlight stop: {E}", ex.Message); }
+                ReleaseXpHold(writeTruth);
+            }
+            catch (Exception ex) { App.Logger?.Debug("AbortBankFlight: {E}", ex.Message); }
+        }
+
+        // ============================== the counter ==============================
+
+        /// <summary>
+        /// One tick of the odometer, on its own short clock rather than the display's 700ms one -
+        /// the House Book asks for a TICK per landing, and a 700ms tween restarted every 70ms never
+        /// reaches any of its targets. <c>_lastXpShown</c> is kept in step so that whatever writes
+        /// the display next (a release, a level-up, a tab switch) counts from where the tokens left
+        /// it instead of jumping.
+        /// </summary>
+        private void StepBankCounter(double value, bool isLast)
+        {
+            try
+            {
+                if (TxtXP == null) return;
+
+                string format = "{0:F0} / " + ((int)_bankHeldNeeded) + " XP";
+                MotionFx.Odometer(TxtXP, _bankFlightShown, value, format,
+                                  BankCounterScript.StepMs(isLast) / 1000.0);
+
+                _bankFlightShown = value;
+                _lastXpShown = value;
+                _lastXpLevelShown = _bankHeldLevel;
+            }
+            catch (Exception ex) { App.Logger?.Debug("StepBankCounter: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The catch: a small scale pop on the XP readout as the last token lands, out fast and
+        /// sprung back. TxtXP carries no transform in XAML, so one is installed on first use rather
+        /// than adding a RenderTransform to the header for a moment most launches never reach.
+        /// </summary>
+        private void PopXpCounter()
+        {
+            try
+            {
+                if (!MotionFx.AllowTransitions || TxtXP == null) return;
+
+                if (_bankPopTransform == null)
+                {
+                    if (TxtXP.RenderTransform != null && TxtXP.RenderTransform != Transform.Identity
+                        && !TxtXP.RenderTransform.Value.IsIdentity)
+                        return;   // somebody else owns it; a pop is not worth clobbering a layout
+                    _bankPopTransform = new ScaleTransform(1, 1);
+                    TxtXP.RenderTransformOrigin = new Point(0.5, 0.5);
+                    TxtXP.RenderTransform = _bankPopTransform;
+                }
+
+                var pop = new DoubleAnimationUsingKeyFrames
+                {
+                    Duration = TimeSpan.FromMilliseconds(BankPopOutMs + BankPopSpringMs),
+                };
+                pop.KeyFrames.Add(new EasingDoubleKeyFrame(BankPopScale,
+                    KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(BankPopOutMs)))
+                {
+                    EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseOut },
+                });
+                pop.KeyFrames.Add(new EasingDoubleKeyFrame(1.0,
+                    KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(BankPopOutMs + BankPopSpringMs)))
+                {
+                    EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.6 },
+                });
+                _bankPopTransform.BeginAnimation(ScaleTransform.ScaleXProperty, pop, HandoffBehavior.SnapshotAndReplace);
+                _bankPopTransform.BeginAnimation(ScaleTransform.ScaleYProperty, pop, HandoffBehavior.SnapshotAndReplace);
+            }
+            catch (Exception ex) { App.Logger?.Debug("PopXpCounter: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The mini-thud, ChaosSfx's override-then-fallback shape: drop a
+        /// <c>Resources/sounds/ui/bank_thud.mp3</c> in (or ship one in a mod) and it wins
+        /// automatically; until then the bubble pop carries it, quietly. Silent no-op on any
+        /// failure - a missing sound must never be the thing that breaks an award.
+        /// </summary>
+        private static void PlayBankThud()
+        {
+            try
+            {
+                float master = (float)(App.Settings?.Current?.MasterVolume ?? 0) / 100f;
+                float volume = Math.Clamp(master * BankThudScale, 0f, 1f);
+                if (volume <= 0f) return;
+
+                foreach (var candidate in new[] { BankThudOverride, BankThudFallback })
+                {
+                    string path;
+                    try { path = ModResourceResolver.ResolveAudioPath(candidate); }
+                    catch { continue; }
+                    if (string.IsNullOrEmpty(path) || !File.Exists(path)) continue;
+                    App.Audio?.PlayOneShot(path, volume, BankThudTag);
+                    return;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("PlayBankThud: {E}", ex.Message); }
+        }
+
+        // ============================== anchors + the surface ==============================
+
+        /// <summary>
+        /// Where the tokens are going: the middle of the XP readout itself. Mapped through
+        /// <c>TransformToVisual</c> and never by layout arithmetic - TxtXP lives inside the
+        /// 1489x901 Viewbox, so its own coordinates are design-canvas units and the transform is
+        /// what carries the scale.
+        /// </summary>
+        private bool TryResolveBankTarget(FrameworkElement host, out Point target)
+            => TryBankAnchorCenter(host, TxtXP, out target);
+
+        /// <summary>
+        /// Where the value came from, first visible wins - the same spirit as
+        /// <c>FireBurstAtFirstVisible</c>.
+        ///
+        /// <para>Only three sources have an honest on-screen home. The rest of the enum is either
+        /// an overlay the window does not contain (Flash, Subliminal, BouncingText, LockCard,
+        /// Video), a thing with no surface at all (KeywordTrigger, Mantra, AttentionCheck,
+        /// AvatarInteraction, Chaos), a separate window (Fyp) or genuinely elsewhere (Other, which
+        /// is what a settled web claim arrives as). Those spawn from the profile bubble instead:
+        /// the "you" that earned it is the only honest origin for XP with no visible source, and it
+        /// sits in the same header strip as the counter, so the flight still reads as a delivery.</para>
+        /// </summary>
+        private bool TryResolveBankOrigin(FrameworkElement host, XPSource source, out Point origin)
+        {
+            FrameworkElement? mapped = source switch
+            {
+                // The session rack. Sessions are the only feature whose XP arrives in one large,
+                // deliberate lump, and its tab is the one a subject actually looks at afterwards.
+                XPSource.Session => NavAnchorForTab("presets"),
+                // Both bubble games are Studio rack modules (HostBubblePop / HostBubbleCount), so
+                // the Studio row is the door their XP came through.
+                XPSource.Bubble or XPSource.BubbleCount => NavAnchorForTab("studio"),
+                _ => null,
+            };
+
+            if (TryBankAnchorCenter(host, mapped, out origin)) return true;
+            if (TryBankAnchorCenter(host, BtnProfileBubble, out origin)) return true;
+
+            // Last resort: a fixed point out in the header's empty space, left of the track. Better
+            // than no flight at all, and it still travels the header the way a real origin would.
+            if (TryBankAnchorBounds(host, XPBarTrack, out var track))
+            {
+                origin = new Point(track.Left + BankFallbackOriginDx, track.Top + track.Height / 2);
+                return IsFiniteBankPoint(origin);
+            }
+
+            origin = default;
+            return false;
+        }
+
+        private bool TryBankAnchorCenter(FrameworkElement host, FrameworkElement? anchor, out Point center)
+        {
+            if (TryBankAnchorBounds(host, anchor, out var bounds))
+            {
+                center = new Point(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2);
+                return IsFiniteBankPoint(center);
+            }
+            center = default;
+            return false;
+        }
+
+        private bool TryBankAnchorBounds(FrameworkElement host, FrameworkElement? anchor, out Rect bounds)
+        {
+            bounds = default;
+            try
+            {
+                if (anchor == null || !anchor.IsVisible) return false;
+                if (anchor.ActualWidth <= 0 || anchor.ActualHeight <= 0) return false;
+
+                // Throws when the two are not connected (an anchor on a detached tab) - hence the wrap.
+                bounds = anchor.TransformToVisual(host)
+                               .TransformBounds(new Rect(0, 0, anchor.ActualWidth, anchor.ActualHeight));
+                return !bounds.IsEmpty && IsFiniteBankPoint(bounds.TopLeft) && IsFiniteBankPoint(bounds.BottomRight);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("TryBankAnchorBounds: {E}", ex.Message);
+                return false;
+            }
+        }
+
+        private static bool IsFiniteBankPoint(Point p)
+            => !double.IsNaN(p.X) && !double.IsInfinity(p.X)
+            && !double.IsNaN(p.Y) && !double.IsInfinity(p.Y);
+
+        /// <summary>
+        /// Builds (once) and re-frames (per flight) the token surface: the bounding box of origin
+        /// and target plus <see cref="BankBoxPadPx"/>, moved by Margin exactly like the burst layer.
+        ///
+        /// <para>The one way it differs from <c>EnsureEventBurstLayer</c> is that its SIZE moves.
+        /// A burst is a fixed box round a single anchor; a flight is a line between two that can be
+        /// most of the window apart or barely a hand's width, and a fixed box big enough for the
+        /// worst case would raster the whole window for every flight. The price is one forced
+        /// layout pass per resize, which is affordable at a floor of one flight every three seconds
+        /// and is skipped entirely whenever the box happens to come out the same.</para>
+        /// </summary>
+        private AmbientFxCanvas? EnsureBankLayer(FrameworkElement host, Point origin, Point target)
+        {
+            if (_bankLayerFailed) return null;
+            try
+            {
+                double left = Math.Min(origin.X, target.X) - BankBoxPadPx;
+                double top = Math.Min(origin.Y, target.Y) - BankBoxPadPx;
+                double width = Math.Abs(origin.X - target.X) + BankBoxPadPx * 2;
+                double height = Math.Abs(origin.Y - target.Y) + BankBoxPadPx * 2;
+
+                // A box this big means an anchor mapped to nonsense, not a long flight.
+                if (width > BankBoxMaxPx || height > BankBoxMaxPx) return null;
+
+                if (_bankLayer == null)
+                {
+                    var created = new AmbientFxCanvas
+                    {
+                        HorizontalAlignment = HorizontalAlignment.Left,
+                        VerticalAlignment = VerticalAlignment.Top,
+                        IsHitTestVisible = false,
+                    };
+                    if (host is Panel panel) panel.Children.Add(created);
+                    else { _bankLayerFailed = true; return null; }
+                    _bankLayer = created;
+                }
+
+                bool resized = Math.Abs(_bankLayer.Width - width) > 0.5
+                            || Math.Abs(_bankLayer.Height - height) > 0.5
+                            || _bankLayer.ActualWidth <= 1 || _bankLayer.ActualHeight <= 1;
+
+                _bankLayer.Width = width;
+                _bankLayer.Height = height;
+                // Negative margins are legal and are exactly what is wanted near a window edge: the
+                // box hangs off and clips.
+                _bankLayer.Margin = new Thickness(left, top, 0, 0);
+                _bankLayerOrigin = new Point(left, top);
+
+                // BankTokens reads ActualWidth, which is stale until the new size has been arranged.
+                if (resized) _bankLayer.UpdateLayout();
+
+                return _bankLayer;
+            }
+            catch (Exception ex)
+            {
+                _bankLayerFailed = true;
+                App.Logger?.Warning(ex, "EnsureBankLayer failed - THE BANK disabled");
+                return null;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.ChromeFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.ChromeFx.cs
@@ -790,11 +790,20 @@ namespace ConditioningControlPanel
         /// The level-up flash (XPBarFlashOverlay) is deliberately NOT wired in as MotionFx's cap
         /// bloom - it already exists and is driven by the level-up path; double-driving its
         /// opacity would fight that.
+        ///
+        /// <para>THE BANK gets first refusal (MainWindow.BankFx.cs). While a pot is collecting or
+        /// tokens are in the air the readout belongs to the flight, so this returns before drawing
+        /// anything and BankFx remembers the target instead - the value is never lost, only its
+        /// arrival is staged. <see cref="TryHoldXpDisplay"/> answers false for every ordinary
+        /// refresh, and for the whole of MotionLevel Reduced/Off, which is what keeps this path
+        /// byte-identical to how it behaved before THE BANK existed.</para>
         /// </summary>
         private void AnimateXpDisplay(double xp, double xpNeeded, int level)
         {
             try
             {
+                if (TryHoldXpDisplay(xp, xpNeeded, level)) return;
+
                 if (TxtXP != null)
                 {
                     double from = (!double.IsNaN(_lastXpShown) && level == _lastXpLevelShown) ? _lastXpShown : 0;
@@ -817,23 +826,32 @@ namespace ConditioningControlPanel
                 _lastXpShown = xp;
                 _lastXpLevelShown = level;
 
-                if (XPBar != null)
-                {
-                    var container = XPBar.Parent as FrameworkElement;
-                    var available = container?.ActualWidth ?? 0;
-                    if (available > 0)
-                    {
-                        var progress = Math.Min(1.0, xpNeeded > 0 ? xp / xpNeeded : 0);
-                        double fromWidth = double.IsNaN(XPBar.Width) ? 0 : XPBar.Width;
-                        double toWidth = progress * available;
-                        MotionFx.BarFill(XPBar, fromWidth, toWidth);
-                        // Velvet Kit 2 (FX lane B): the meniscus rides the same target width on the
-                        // same clock and curve as the fill, so it sits on the surface throughout.
-                        AnimateXpMeniscus(toWidth);
-                    }
-                }
+                FillXpBarTo(xp, xpNeeded);
             }
             catch (Exception ex) { App.Logger?.Debug("AnimateXpDisplay: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The bar half of the XP display, on its own so THE BANK's last token can land the fill on
+        /// the value the tokens actually delivered rather than on the ledger's - the two differ
+        /// whenever a second pot is already collecting behind the flight. Lifted verbatim out of
+        /// <see cref="AnimateXpDisplay"/>; the only caller that passes anything but the ledger's
+        /// number is MainWindow.BankFx.cs.
+        /// </summary>
+        private void FillXpBarTo(double xp, double xpNeeded)
+        {
+            if (XPBar == null) return;
+            var container = XPBar.Parent as FrameworkElement;
+            var available = container?.ActualWidth ?? 0;
+            if (available <= 0) return;
+
+            var progress = Math.Min(1.0, xpNeeded > 0 ? xp / xpNeeded : 0);
+            double fromWidth = double.IsNaN(XPBar.Width) ? 0 : XPBar.Width;
+            double toWidth = progress * available;
+            MotionFx.BarFill(XPBar, fromWidth, toWidth);
+            // Velvet Kit 2 (FX lane B): the meniscus rides the same target width on the
+            // same clock and curve as the fill, so it sits on the surface throughout.
+            AnimateXpMeniscus(toWidth);
         }
 
         /// <summary>Slow gloss travelling along the XP fill. Three stop offsets on one 6s clock.</summary>

--- a/ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs
@@ -17,6 +17,17 @@ namespace ConditioningControlPanel
     /// nothing else is. They cost nothing when they are not happening, which is the whole appeal:
     /// high perceived polish, zero idle clock.
     ///
+    /// <para><b>The seventh moment.</b> THE BANK on XP (MainWindow.BankFx.cs) joined this list
+    /// later and breaks its shape in one way worth naming here: the six above are one-offs a
+    /// subject reaches a handful of times, while XP arrives constantly, so THE BANK is the only
+    /// event moment that has to be RATIONED. It does not burst - value flies as 3-7 tokens from
+    /// its source to the XP counter - and it does not fire per event: <see cref="BankAccumulator"/>
+    /// pools awards behind a collection window and a launch cooldown so a busy minute produces a
+    /// few deliberate flights instead of thirty. It keeps every rule below (the focus gate, the
+    /// particle gate, TransformToVisual anchoring, no idle clock) and owns a second, re-sizeable
+    /// canvas of its own, because a flight is a line between two anchors rather than a box round
+    /// one.</para>
+    ///
     /// <para><b>The shared burst layer.</b> One <see cref="AmbientFxCanvas"/> lives in
     /// <c>EventFxHost</c>, a child of RootGrid <i>outside</i> the 1489x901 Viewbox. Inside the
     /// Viewbox everything is bitmap-scaled, which is right for a fog wash and wrong for crisp
@@ -228,11 +239,18 @@ namespace ConditioningControlPanel
         /// and the reset reads as the consequence rather than the event. The bloom reuses
         /// XPBarFlashOverlay (the pre-existing pink-glow overlay sized to the fill) and the
         /// existing FlashOverlay animation, so the two never fight over the same property.
+        ///
+        /// <para>House law, one burst per moment: THE BANK yields here. Aborting first (and NOT
+        /// writing truth - UpdateLevelDisplay is the caller's very next line) both ends any flight
+        /// in the air and releases the held counter, so the bloom below still lands on a full bar
+        /// and the reset that follows is the level-up's to show. This runs before the motion gate
+        /// on purpose: a held counter has to be released at MotionLevel Off too.</para>
         /// </summary>
         internal void CelebrateLevelUp()
         {
             try
             {
+                AbortBankFlight(writeTruth: false);
                 if (!MotionFx.AllowTransitions) return;
                 FlashOverlay(XPBarFlashOverlay);
                 // Velvet Kit 2 (FX lane B): the number that changed is the one thing the burst does

--- a/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.WindowChrome.cs
@@ -210,6 +210,9 @@ namespace ConditioningControlPanel
                     App.Progression.XPChanged -= OnXPChanged;
                     App.Progression.LevelUp -= OnLevelUp;
                 }
+                // THE BANK: drops its own XPChanged/XPAwarded hooks, force-lands any flight and
+                // stops its poll (MainWindow.BankFx.cs).
+                ShutdownBankFx();
                 // Profile bubble: unsubscribes its own progression/flash/subliminal/achievement/
                 // Discord hooks and closes the hover menu (MainWindow.ProfileBubble.cs).
                 CleanupProfileBubble();

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -366,7 +366,13 @@ namespace ConditioningControlPanel
             // Initialize lockdown mode event handlers
             InitializeLockdown();
 
-            // Subscribe to progression events for real-time XP updates
+            // Subscribe to progression events for real-time XP updates.
+            //
+            // THE BANK subscribes FIRST and that is load-bearing (MainWindow.BankFx.cs): multicast
+            // handlers run in subscription order, and BankFx has to arm its hold on XPChanged
+            // BEFORE OnXPChanged tweens the counter it means to withhold. It also takes XPAwarded,
+            // the delta-and-provenance event that XPChanged deliberately is not.
+            InitializeBankFx();
             App.Progression.XPChanged += OnXPChanged;
             App.Progression.LevelUp += OnLevelUp;
 

--- a/ConditioningControlPanel/Services/BankAccumulator.cs
+++ b/ConditioningControlPanel/Services/BankAccumulator.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// THE BANKER: the thing that turns roughly thirty <c>AddXP</c> call sites into a handful of
+    /// rare, deliberate BANK moments.
+    ///
+    /// <para><b>Why this exists.</b> XP in this app does not arrive as events, it arrives as
+    /// weather - a flash burst, a mantra, an attention check and a bubble pop can all settle inside
+    /// half a second. Celebrating each one is not seven celebrations, it is noise, and noise is the
+    /// one thing a reward moment cannot survive. So awards are pooled: the first one opens a
+    /// collection window (<see cref="WindowMs"/>), everything landing inside joins the pot, and the
+    /// pot flies ONCE.</para>
+    ///
+    /// <para><b>The cooldown is the real dial.</b> A window alone would still fire every 1.5s under
+    /// sustained XP. <see cref="CooldownMs"/> is the floor between flight STARTS: while it is
+    /// running the open pot simply keeps collecting, so a busy session produces a fuller flight
+    /// every three seconds rather than a stutter of thin ones.</para>
+    ///
+    /// <para><b>A level-up poisons the pot.</b> House law, one burst per moment: if an award crossed
+    /// a level, <c>CelebrateLevelUp</c> owns that instant and THE BANK yields entirely - the pot is
+    /// abandoned rather than deferred, because a flight arriving on the far side of a level-up
+    /// celebration is a second celebration for XP the subject already watched be spent.</para>
+    ///
+    /// <para>Pure: every timestamp comes from the injected monotonic clock, there is no
+    /// <c>DateTime.Now</c>, no static state and no timer of its own. The caller owns the poll (see
+    /// <see cref="Tick"/>), which is what lets the shell keep its no-idle-clock promise.</para>
+    /// </summary>
+    public sealed class BankAccumulator
+    {
+        // ---- DIALS ----
+
+        /// <summary>How long a pot stays open for company after its first award.</summary>
+        public const double WindowMs = 1500;
+
+        /// <summary>Minimum gap between flight STARTS. Awards arriving inside it join the next pot.</summary>
+        public const double CooldownMs = 3000;
+
+        private readonly Func<double> _nowMs;
+
+        /// <summary>
+        /// The open pot, in first-seen order - which is also the tie-break for
+        /// <see cref="Flight.DominantSource"/>. A list and not a per-enum array because the order
+        /// IS the tie-break, and because a pot never holds more than a handful of distinct sources.
+        /// </summary>
+        private readonly List<Contribution> _pot = new(8);
+
+        private bool _open;
+        private double _openedMs;
+        private double _sum;
+
+        /// <summary>
+        /// When the last flight was launched. Starts at negative infinity so the first BANK moment
+        /// of a session is never held back by a cooldown that has not happened yet.
+        /// </summary>
+        private double _lastLaunchMs = double.NegativeInfinity;
+
+        private struct Contribution
+        {
+            public XPSource Source;
+            public double Xp;
+        }
+
+        /// <param name="nowMs">A monotonic millisecond clock - a <c>Stopwatch</c> in the app, a
+        /// plain variable in tests. Must never go backwards.</param>
+        public BankAccumulator(Func<double> nowMs)
+        {
+            _nowMs = nowMs ?? throw new ArgumentNullException(nameof(nowMs));
+        }
+
+        /// <summary>
+        /// One BANK moment, ready to fly. <see cref="XpSum"/> is the whole pot (the ledger figure the
+        /// counter must land on), <see cref="DominantSource"/> is the source that put the most XP in
+        /// it - the one the tokens should be seen to spawn FROM - and <see cref="TokenCount"/> is
+        /// what <see cref="BankFlightPlan.TokenCount"/> prices that sum at.
+        /// </summary>
+        public sealed record Flight(double XpSum, XPSource DominantSource, int TokenCount);
+
+        /// <summary>True while a pot is collecting. The shell polls <see cref="Tick"/> only while this holds.</summary>
+        public bool HasOpenPot => _open;
+
+        /// <summary>
+        /// Record one award. Returns null almost always; returns a <see cref="Flight"/> exactly when
+        /// this award closed a pot that was already ripe - i.e. XP is still flowing after the
+        /// previous window expired, so the award that arrives is the one that ships the pot before
+        /// opening the next one.
+        ///
+        /// <para>Non-positive, NaN and infinite amounts are ignored outright rather than opening a
+        /// pot: this sits on the live XP path, and a zero-XP award must not be able to arm a
+        /// celebration for nothing.</para>
+        /// </summary>
+        public Flight? OnAward(double amount, XPSource source, bool leveledUp)
+        {
+            // House law: the level-up owns the moment. Abandon, do not defer.
+            if (leveledUp)
+            {
+                Reset();
+                return null;
+            }
+
+            if (double.IsNaN(amount) || double.IsInfinity(amount) || amount <= 0) return null;
+
+            double now = _nowMs();
+            var ready = TryClose(now);
+
+            if (!_open)
+            {
+                _open = true;
+                _openedMs = now;
+            }
+
+            _sum += amount;
+
+            for (int i = 0; i < _pot.Count; i++)
+            {
+                if (_pot[i].Source != source) continue;
+                var c = _pot[i];
+                c.Xp += amount;
+                _pot[i] = c;
+                return ready;
+            }
+            _pot.Add(new Contribution { Source = source, Xp = amount });
+
+            return ready;
+        }
+
+        /// <summary>
+        /// The poll. Returns a <see cref="Flight"/> the first time the open pot's window has expired
+        /// AND the cooldown permits a launch; null every other time, including when there is no pot
+        /// at all. Idempotent by construction - closing a pot clears it, so a pot can only ever fly
+        /// once no matter how often this is called.
+        /// </summary>
+        public Flight? Tick() => TryClose(_nowMs());
+
+        /// <summary>
+        /// Drop the open pot silently - no flight, no callback. The shell calls this when the window
+        /// is deactivated, so a half-collected pot cannot ambush a returning user with a celebration
+        /// for XP they earned before they left (focus-state silence: not queued, just gone).
+        ///
+        /// <para>The cooldown deliberately SURVIVES a reset: abandoning a pot must not buy back a
+        /// launch slot, or a stream of level-ups would let flights fire back to back.</para>
+        /// </summary>
+        public void Reset() => ClearPot();
+
+        private Flight? TryClose(double now)
+        {
+            if (!_open) return null;
+            if (now - _openedMs < WindowMs) return null;
+            if (now - _lastLaunchMs < CooldownMs) return null;
+
+            var flight = new Flight(_sum, DominantSource(), BankFlightPlan.TokenCount(_sum));
+            _lastLaunchMs = now;
+            ClearPot();
+            return flight;
+        }
+
+        /// <summary>Strictly-greater comparison walking first-seen order, so ties go to whoever opened the pot.</summary>
+        private XPSource DominantSource()
+        {
+            if (_pot.Count == 0) return XPSource.Other;
+
+            var best = _pot[0];
+            for (int i = 1; i < _pot.Count; i++)
+            {
+                if (_pot[i].Xp > best.Xp) best = _pot[i];
+            }
+            return best.Source;
+        }
+
+        private void ClearPot()
+        {
+            _open = false;
+            _sum = 0;
+            _openedMs = 0;
+            _pot.Clear();
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/BankCounterScript.cs
+++ b/ConditioningControlPanel/Services/BankCounterScript.cs
@@ -1,0 +1,112 @@
+using System;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// THE BANK's counter arithmetic: given a held display value, a pot and a stream of landings,
+    /// what number should the XP readout be showing right now.
+    ///
+    /// <para><b>Why this is not inline in the shell.</b> Every one of these four decisions is a
+    /// place where the display can quietly start lying, which is the one thing House Law I forbids
+    /// - the ledger never lies, only its presentation is staged. A step that divides the pot into
+    /// equal slices and adds them up drifts off the true total by a fraction of an XP per landing;
+    /// a target computed from "whatever the ledger says right now" hands one flight the XP a later
+    /// flight is going to be seen to deliver; a step tween longer than the stagger leaves landings
+    /// queueing behind an animation that has not finished. None of that is visible in a play-test,
+    /// all of it is trivially assertable here.</para>
+    ///
+    /// <para>Pure and static: no clock, no WPF, no state. The shell owns the timers and the
+    /// elements; this owns only the numbers they carry.</para>
+    /// </summary>
+    public static class BankCounterScript
+    {
+        // ---- DIALS ----
+
+        /// <summary>
+        /// Longest a single step tween may last. The House Book wants a TICK per landing, not a
+        /// count-up: past about a tenth of a second the eye stops reading the step as an arrival
+        /// and starts reading it as an odometer that happens to be slow.
+        /// </summary>
+        public const double MaxStepMs = 90;
+
+        /// <summary>
+        /// Fraction of the SHORTEST possible gap between two landings that a mid-flight step is
+        /// allowed to occupy. Below 1.0 by construction: a step still running when the next token
+        /// lands is replaced mid-tween, and the counter visibly stutters instead of ticking.
+        /// </summary>
+        public const double StepSafetyFactor = 0.9;
+
+        /// <summary>
+        /// The value the counter is standing at when a flight begins - i.e. what the flight has to
+        /// count UP FROM. Mirrors <c>AnimateXpDisplay</c>'s own "from" rule deliberately: a level
+        /// change wraps the readout back to zero, so a remembered value from the previous level is
+        /// not a starting point, it is a wrong number that the first token would appear to correct.
+        /// </summary>
+        /// <param name="lastShown">The last value the odometer was driven to (NaN if never).</param>
+        /// <param name="lastLevelShown">The level that value belonged to.</param>
+        /// <param name="level">The level the flight is being staged at.</param>
+        public static double StartValue(double lastShown, int lastLevelShown, int level)
+        {
+            if (double.IsNaN(lastShown) || double.IsInfinity(lastShown) || lastShown < 0) return 0;
+            return level == lastLevelShown ? lastShown : 0;
+        }
+
+        /// <summary>
+        /// Where THIS flight's last token must land: the pot it is carrying, added to where the
+        /// counter started - never "whatever the ledger says now".
+        ///
+        /// <para>The two clamps are the honesty rails. The ceiling is the live ledger: a flight may
+        /// never show more XP than the player actually has, which is what would happen if the
+        /// display had already been credited with part of this pot (the first award of a pot lands
+        /// before the pot exists - see MainWindow.BankFx.cs). The floor is the start: a pot only
+        /// ever adds, so a counter that would run backwards simply does not move, and the release
+        /// to truth that follows the flight owns the correction.</para>
+        ///
+        /// <para>Awards that arrive mid-flight are deliberately NOT swept in. They belong to the
+        /// next pot, and the next flight is what will be seen to deliver them.</para>
+        /// </summary>
+        /// <param name="start">Where the counter stood when the flight left.</param>
+        /// <param name="potXp">The pot this flight is carrying.</param>
+        /// <param name="truthXp">The ledger's current XP for this level.</param>
+        public static double Target(double start, double potXp, double truthXp)
+        {
+            if (double.IsNaN(start) || double.IsInfinity(start)) return 0;
+            if (double.IsNaN(truthXp) || double.IsInfinity(truthXp)) return start;
+            if (double.IsNaN(potXp) || double.IsInfinity(potXp) || potXp <= 0) return start;
+
+            double ceiling = Math.Max(start, truthXp);
+            return Math.Clamp(start + potXp, start, ceiling);
+        }
+
+        /// <summary>
+        /// The number to show after the <paramref name="landingOrdinal"/>-th token of
+        /// <paramref name="count"/> has landed (ordinal counts LANDINGS from 0, not plan order -
+        /// tokens land out of order and only the arrival count is safe to divide by).
+        ///
+        /// <para>The last landing returns <paramref name="target"/> EXACTLY rather than the sum of
+        /// its own slices. Slices are floating point and the ledger is the authority; a flight that
+        /// ends on 1249.9999999 has told a lie for the sake of arithmetic tidiness.</para>
+        /// </summary>
+        public static double StepValue(double start, double target, int landingOrdinal, int count)
+        {
+            if (count <= 0) return target;
+            if (double.IsNaN(start) || double.IsInfinity(start)) return target;
+            if (double.IsNaN(target) || double.IsInfinity(target)) return start;
+
+            if (landingOrdinal < 0) landingOrdinal = 0;
+            if (landingOrdinal >= count - 1) return target;
+
+            return start + (target - start) * (landingOrdinal + 1) / count;
+        }
+
+        /// <summary>
+        /// How long one step's mini-tween may run. A mid-flight step is capped under the shortest
+        /// legal stagger so it has finished before the next token can possibly arrive; the last
+        /// step has nothing chasing it and gets the full <see cref="MaxStepMs"/>, which is also the
+        /// beat the thud and the counter pop are timed against.
+        /// </summary>
+        public static double StepMs(bool isLast)
+            => isLast ? MaxStepMs
+                      : Math.Min(MaxStepMs, BankFlightPlan.StaggerMinMs * StepSafetyFactor);
+    }
+}

--- a/ConditioningControlPanel/Services/BankFlightPlan.cs
+++ b/ConditioningControlPanel/Services/BankFlightPlan.cs
@@ -1,0 +1,122 @@
+using System;
+
+namespace ConditioningControlPanel.Services
+{
+    /// <summary>
+    /// THE BANK's flight arithmetic and nothing else: how many tokens a pot is worth, when each one
+    /// leaves, how long it flies, and how far its arc bows off the straight line to the counter.
+    ///
+    /// <para>Pure and static on purpose. The canvas half of THE BANK can only be judged by eye, but
+    /// the numbers underneath it are exactly where the House Book's feel spec can drift silently - a
+    /// stagger that creeps to 200ms reads as a queue instead of a spill, and a token count that
+    /// scales linearly with XP turns a session claim into confetti. Keeping the arithmetic here
+    /// makes the spec a test rather than a comment.</para>
+    ///
+    /// <para><b>Why the cap is 7.</b> The House Book's line is "the FEELING scales, not the particle
+    /// count": past seven the eye stops counting tokens and starts seeing a spray, so a bigger award
+    /// buys a longer, fuller flight and never a crowd.</para>
+    ///
+    /// <para>Deterministic from its seed - same seed, same flight - so a plan can be asserted
+    /// headlessly, and so nothing about the look of a moment depends on a clock.</para>
+    /// </summary>
+    public static class BankFlightPlan
+    {
+        // ---- DIALS (House Book: 3-7 tokens, 500-650ms ease-in arc, 60-80ms stagger) ----
+
+        /// <summary>Floor on the token count: fewer than three does not read as "value", it reads as a glitch.</summary>
+        public const int MinTokens = 3;
+
+        /// <summary>Ceiling on the token count. See the class remarks - this is a feel decision, not a budget one.</summary>
+        public const int MaxTokens = 7;
+
+        public const double StaggerMinMs = 60;
+        public const double StaggerMaxMs = 80;
+        public const double DurationMinMs = 500;
+        public const double DurationMaxMs = 650;
+
+        /// <summary>Smallest bow magnitude. Below this the arc is invisible and the flight reads as a straight slide.</summary>
+        public const double ArcBowMin = 0.10;
+
+        /// <summary>Largest bow magnitude. Above this the token arcs far enough to look thrown rather than drawn in.</summary>
+        public const double ArcBowMax = 0.22;
+
+        /// <summary>
+        /// How many tokens a pot of <paramref name="xpSum"/> XP spends. A step table and not a
+        /// formula: the steps are the only thing a subject can actually perceive, and a table makes
+        /// the boundaries assertable. NaN is treated as the smallest pot rather than throwing -
+        /// this sits downstream of a live XP figure and must never be the thing that breaks an award.
+        /// </summary>
+        public static int TokenCount(double xpSum)
+        {
+            if (double.IsNaN(xpSum)) return MinTokens;
+            if (xpSum < 15) return 3;
+            if (xpSum < 50) return 4;
+            if (xpSum < 120) return 5;
+            if (xpSum < 300) return 6;
+            return MaxTokens;
+        }
+
+        /// <summary>
+        /// One token's slot in a flight. <paramref name="DelayMs"/> is measured from the flight's
+        /// start, not from the previous token, so a consumer never has to accumulate.
+        /// <paramref name="ArcBow"/> is a SIGNED fraction of the origin-to-target distance that the
+        /// bezier control point sits off the straight line - the sign is which side it bows to.
+        /// </summary>
+        public readonly record struct Token(double DelayMs, double DurationMs, double ArcBow);
+
+        /// <summary>
+        /// Lay out <paramref name="count"/> tokens (clamped to <see cref="MaxTokens"/>) from
+        /// <paramref name="seed"/>. Every random draw is inside the House Book's bands, so any plan
+        /// this returns is a legal flight no matter what seed it was handed.
+        ///
+        /// <para>Bow signs ALTERNATE from a seeded start rather than being drawn independently: a
+        /// run of same-sign draws would send every token round the same side, which reads as one
+        /// thick stream instead of a spill. Alternating guarantees the fan; the seed only decides
+        /// which side it opens on.</para>
+        /// </summary>
+        public static Token[] Plan(int count, int seed)
+        {
+            if (count <= 0) return Array.Empty<Token>();
+            count = Math.Min(count, MaxTokens);
+
+            var rng = new Random(seed);
+            var plan = new Token[count];
+
+            double delay = 0;
+            int sign = rng.Next(2) == 0 ? -1 : 1;
+
+            for (int i = 0; i < count; i++)
+            {
+                double duration = DurationMinMs + rng.NextDouble() * (DurationMaxMs - DurationMinMs);
+                double bow = ArcBowMin + rng.NextDouble() * (ArcBowMax - ArcBowMin);
+
+                plan[i] = new Token(delay, duration, bow * sign);
+
+                sign = -sign;
+                delay += StaggerMinMs + rng.NextDouble() * (StaggerMaxMs - StaggerMinMs);
+            }
+
+            return plan;
+        }
+
+        /// <summary>
+        /// Milliseconds from the flight's start until the LAST token lands. A max and not
+        /// "last delay + last duration": durations vary by up to 150ms while the stagger is only
+        /// 60-80ms, so tokens genuinely can land out of order and the final token in the array is
+        /// not always the final one to arrive. Anything timing a watchdog off this needs the true
+        /// envelope, not the tail.
+        /// </summary>
+        public static double EnvelopeMs(Token[] plan)
+        {
+            if (plan == null || plan.Length == 0) return 0;
+
+            double max = 0;
+            for (int i = 0; i < plan.Length; i++)
+            {
+                double end = plan[i].DelayMs + plan[i].DurationMs;
+                if (end > max) max = end;
+            }
+            return max;
+        }
+    }
+}

--- a/ConditioningControlPanel/Services/Progression/ProgressionService.cs
+++ b/ConditioningControlPanel/Services/Progression/ProgressionService.cs
@@ -13,6 +13,27 @@ namespace ConditioningControlPanel.Services
         public event EventHandler<int>? LevelUp;
         public event EventHandler<double>? XPChanged;
 
+        /// <summary>
+        /// One XP award, post-multiplier. <see cref="LeveledUp"/> means <c>SpendXPOnLevels</c>
+        /// crossed at least one level inside this same award - which is the whole reason this
+        /// carries more than a number. A presentation layer has to be able to yield to the level-up
+        /// celebration, and once <see cref="LevelUp"/> has fired there is no way to tell from
+        /// <see cref="XPChanged"/> alone which award caused it.
+        /// </summary>
+        public readonly record struct XpAward(double Amount, XPSource Source, bool LeveledUp);
+
+        /// <summary>
+        /// Raised once per award that actually landed, AFTER <see cref="XPChanged"/> and on the same
+        /// call stack. Deliberately a second event rather than a fatter <see cref="XPChanged"/>:
+        /// XPChanged reports the ledger TOTAL and a dozen things read it, while this reports the
+        /// DELTA and its provenance, which is what a celebration needs and nothing else wants.
+        ///
+        /// <para>Presentation only, and it fires after the ledger is already settled - nothing
+        /// downstream of it may touch <c>PlayerXP</c>. A subscriber that throws is swallowed (see
+        /// <see cref="RaiseXpAwarded"/>): a decoration must never be able to break an award.</para>
+        /// </summary>
+        public event EventHandler<XpAward>? XPAwarded;
+
         /// <summary>The curve every account has always been on. See <see cref="XpForLevelV1"/>.</summary>
         public const int CurveEpochLegacy = 0;
 
@@ -99,9 +120,10 @@ namespace ConditioningControlPanel.Services
             App.Quests?.TrackXPEarned((int)amount);
 
             // Check for level up
-            SpendXPOnLevels(settings, inOfflineMode);
+            var leveledUp = SpendXPOnLevels(settings, inOfflineMode);
 
             XPChanged?.Invoke(this, settings.PlayerXP);
+            RaiseXpAwarded(adjustedAmount, source, leveledUp);
         }
 
         /// <summary>
@@ -141,9 +163,14 @@ namespace ConditioningControlPanel.Services
 
             App.Logger?.Information("Web XP claim applied: +{Amount} (was {Prev}, now {Now})", amount, previousXP, settings.PlayerXP);
 
-            SpendXPOnLevels(settings, inOfflineMode);
+            var leveledUp = SpendXPOnLevels(settings, inOfflineMode);
 
             XPChanged?.Invoke(this, settings.PlayerXP);
+
+            // XPSource.Other because that is the truth: a web claim has no in-app feature behind it,
+            // so nothing on screen is the place it came from. A presentation layer reading this will
+            // fall back to its neutral origin, which is the honest look for XP earned elsewhere.
+            RaiseXpAwarded(amount, XPSource.Other, leveledUp);
 
             AnnounceFirstWebXpClaim(amount);
         }
@@ -205,17 +232,43 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// Fire <see cref="XPAwarded"/> for one settled award. Wrapped whole: this is a decoration
+        /// hanging off the end of the XP path, and the ledger has already been written by the time
+        /// it runs, so a throwing subscriber must be logged and forgotten rather than allowed to
+        /// unwind through the caller and take the award's remaining work with it.
+        /// </summary>
+        private void RaiseXpAwarded(double amount, XPSource source, bool leveledUp)
+        {
+            try
+            {
+                XPAwarded?.Invoke(this, new XpAward(amount, source, leveledUp));
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("XPAwarded subscriber failed: {E}", ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Drains banked XP into levels for as long as the player can afford the next one, running
         /// the full level-up experience for each level gained. Shared by AddXP and AddClaimedXP so
         /// the two ways XP can arrive can never drift apart.
         /// </summary>
-        private void SpendXPOnLevels(Models.AppSettings settings, bool inOfflineMode)
+        /// <returns>
+        /// True if at least one level was gained. Reported rather than inferred: a caller cannot
+        /// work this out afterwards without re-reading the level it captured beforehand, and the
+        /// one consumer that needs it (THE BANK, which must yield to the level-up celebration)
+        /// needs it per AWARD, not per level.
+        /// </returns>
+        private bool SpendXPOnLevels(Models.AppSettings settings, bool inOfflineMode)
         {
+            var gained = false;
             var xpNeeded = GetXPForLevel(settings.PlayerLevel);
             while (settings.PlayerXP >= xpNeeded)
             {
                 settings.PlayerXP -= xpNeeded;
                 settings.PlayerLevel++;
+                gained = true;
 
                 // Track highest level ever for permanent unlocks across seasons
                 if (settings.PlayerLevel > settings.HighestLevelEver)
@@ -256,6 +309,8 @@ namespace ConditioningControlPanel.Services
                     App.Logger?.Debug("Offline mode: Skipped cloud sync for level up to {Level}", settings.PlayerLevel);
                 }
             }
+
+            return gained;
         }
 
         /// <summary>

--- a/Tests/ConditioningControlPanel.Tests/BankAccumulatorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BankAccumulatorTests.cs
@@ -1,0 +1,242 @@
+using System;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BANKER - the coalescing rules that stand between roughly thirty XP call sites and one
+/// celebration. Everything worth testing here is a timing decision, and timing decisions are
+/// exactly what cannot be verified by watching the app: "did that pot fly twice" and "did the
+/// cooldown actually hold" both look like a normal session from the outside.
+///
+/// <para>The clock is a plain field the test moves by hand, which is the whole point of the
+/// injected <c>Func&lt;double&gt;</c>: no sleeps, no flake, and a level-up landing 1ms before a
+/// window expiry is as easy to write as one landing in the middle.</para>
+/// </summary>
+public class BankAccumulatorTests
+{
+    private double _now;
+    private BankAccumulator New() { _now = 0; return new BankAccumulator(() => _now); }
+
+    [Fact]
+    public void NullClock_IsRefusedAtConstruction()
+        => Assert.Throws<ArgumentNullException>(() => new BankAccumulator(null!));
+
+    [Fact]
+    public void AwardsInsideTheWindow_JoinOnePot_AndFlyOnce()
+    {
+        var bank = New();
+
+        Assert.Null(bank.OnAward(10, XPSource.Flash, false));
+        _now = 100; Assert.Null(bank.OnAward(20, XPSource.Flash, false));
+        _now = 900; Assert.Null(bank.OnAward(30, XPSource.Mantra, false));
+
+        // Still collecting: the window has not run out.
+        _now = BankAccumulator.WindowMs - 1;
+        Assert.Null(bank.Tick());
+
+        _now = BankAccumulator.WindowMs;
+        var flight = bank.Tick();
+        Assert.NotNull(flight);
+        Assert.Equal(60, flight!.XpSum, 6);
+        Assert.Equal(BankFlightPlan.TokenCount(60), flight.TokenCount);
+
+        // And the pot is gone - a second poll must not celebrate the same XP twice.
+        _now = 10_000;
+        Assert.Null(bank.Tick());
+    }
+
+    [Fact]
+    public void NoPot_MeansNothingToPoll()
+    {
+        var bank = New();
+        _now = 50_000;
+        Assert.Null(bank.Tick());
+        Assert.False(bank.HasOpenPot);
+    }
+
+    [Fact]
+    public void CooldownDefersTheNextFlight_AndTheDeferredAwardsAllRide()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = BankAccumulator.WindowMs;
+        Assert.NotNull(bank.Tick());              // first flight leaves at 1500
+
+        _now = 1600; bank.OnAward(5, XPSource.Bubble, false);
+        _now = 1700; bank.OnAward(7, XPSource.Bubble, false);
+
+        // Window expired at 3100, but the cooldown runs to 4500. Nothing may leave yet.
+        _now = 3200; Assert.Null(bank.Tick());
+        _now = 4499; Assert.Null(bank.Tick());
+
+        _now = BankAccumulator.WindowMs + BankAccumulator.CooldownMs;   // 4500
+        var second = bank.Tick();
+        Assert.NotNull(second);
+        Assert.Equal(12, second!.XpSum, 6);
+    }
+
+    [Fact]
+    public void AwardsDuringCooldownKeepJoining_SoTheFlightGetsFullerNotMoreFrequent()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = BankAccumulator.WindowMs;
+        Assert.NotNull(bank.Tick());
+
+        // A steady drip all through the cooldown.
+        for (double t = 1600; t < 4500; t += 200)
+        {
+            _now = t;
+            Assert.Null(bank.OnAward(1, XPSource.Flash, false));
+        }
+
+        _now = 4500;
+        var flight = bank.Tick();
+        Assert.NotNull(flight);
+        Assert.Equal(15, flight!.XpSum, 6);       // 1600..4400 inclusive, every 200ms
+    }
+
+    [Fact]
+    public void AnAwardArrivingAfterTheWindow_ShipsTheRipePotAndOpensTheNext()
+    {
+        var bank = New();
+
+        bank.OnAward(40, XPSource.Session, false);
+
+        _now = 4000;
+        var flight = bank.OnAward(9, XPSource.Bubble, false);
+        Assert.NotNull(flight);
+        Assert.Equal(40, flight!.XpSum, 6);       // the arriving award did NOT join the pot it closed
+        Assert.Equal(XPSource.Session, flight.DominantSource);
+
+        // ...and it opened the next one, which flies on its own window plus the new cooldown.
+        _now = 7000;
+        var next = bank.Tick();
+        Assert.NotNull(next);
+        Assert.Equal(9, next!.XpSum, 6);
+    }
+
+    [Fact]
+    public void ALeveledUpAward_PoisonsThePot()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = 200;
+        Assert.Null(bank.OnAward(9_999, XPSource.Session, leveledUp: true));
+
+        // House law, one burst per moment: CelebrateLevelUp owns this instant, so nothing of the
+        // pot survives - not the earlier XP, and not the leveling award itself.
+        Assert.False(bank.HasOpenPot);
+        _now = 60_000;
+        Assert.Null(bank.Tick());
+    }
+
+    [Fact]
+    public void AfterALevelUp_TheNextPotIsNormal()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = 200; bank.OnAward(500, XPSource.Session, leveledUp: true);
+
+        _now = 3000; Assert.Null(bank.OnAward(25, XPSource.Bubble, false));
+        _now = 4600;
+        var flight = bank.Tick();
+        Assert.NotNull(flight);
+        Assert.Equal(25, flight!.XpSum, 6);
+    }
+
+    [Fact]
+    public void Reset_DropsThePotSilently()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = 200; bank.OnAward(10, XPSource.Flash, false);
+        bank.Reset();
+
+        Assert.False(bank.HasOpenPot);
+        _now = 30_000;
+        Assert.Null(bank.Tick());
+    }
+
+    [Fact]
+    public void Reset_DoesNotBuyBackALaunchSlot()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = BankAccumulator.WindowMs;
+        Assert.NotNull(bank.Tick());              // launched at 1500
+
+        _now = 1600; bank.OnAward(4, XPSource.Flash, false);
+        bank.Reset();                             // window deactivated, pot dropped
+        _now = 1700; bank.OnAward(4, XPSource.Flash, false);
+
+        // The cooldown from the 1500 launch still governs; a reset is not a get-out.
+        _now = 3300; Assert.Null(bank.Tick());
+        _now = 4500; Assert.NotNull(bank.Tick());
+    }
+
+    [Fact]
+    public void DominantSource_IsWhoeverPutTheMostIn()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Flash, false);
+        _now = 100; bank.OnAward(30, XPSource.Session, false);
+        _now = 200; bank.OnAward(5, XPSource.Flash, false);
+
+        _now = 2000;
+        var flight = bank.Tick();
+        Assert.NotNull(flight);
+        Assert.Equal(XPSource.Session, flight!.DominantSource);
+        Assert.Equal(45, flight.XpSum, 6);
+    }
+
+    [Fact]
+    public void DominantSource_TiesGoToWhoeverOpenedThePot()
+    {
+        var bank = New();
+
+        bank.OnAward(10, XPSource.Bubble, false);
+        _now = 100; bank.OnAward(10, XPSource.Mantra, false);
+
+        _now = 2000;
+        Assert.Equal(XPSource.Bubble, bank.Tick()!.DominantSource);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void JunkAwards_DoNotEvenOpenAPot(double amount)
+    {
+        var bank = New();
+
+        Assert.Null(bank.OnAward(amount, XPSource.Flash, false));
+        Assert.False(bank.HasOpenPot);
+
+        _now = 30_000;
+        Assert.Null(bank.Tick());
+    }
+
+    [Fact]
+    public void TokenCount_OnTheFlight_IsThePlansPriceForThePot()
+    {
+        var bank = New();
+
+        bank.OnAward(400, XPSource.Session, false);
+        _now = 2000;
+        var flight = bank.Tick();
+
+        Assert.NotNull(flight);
+        Assert.Equal(BankFlightPlan.MaxTokens, flight!.TokenCount);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BankFlightPlanTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BankFlightPlanTests.cs
@@ -1,0 +1,156 @@
+using System;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BANK's flight arithmetic. The tokens themselves can only be judged by eye, but the numbers
+/// they ride can drift silently: a stagger that creeps past 80ms turns a spill into a queue, a
+/// duration outside 500-650 breaks the "caught" feel, and a token count that keeps climbing turns
+/// a session claim into confetti. The House Book's bands are asserted here so the spec is a test
+/// rather than a comment, and determinism is asserted because a plan that varies per call cannot
+/// be reasoned about at all.
+/// </summary>
+public class BankFlightPlanTests
+{
+    [Theory]
+    // Each pair is (xpSum, tokens) on both sides of every step in the table.
+    [InlineData(0, 3)]
+    [InlineData(14.99, 3)]
+    [InlineData(15, 4)]
+    [InlineData(49.99, 4)]
+    [InlineData(50, 5)]
+    [InlineData(119.99, 5)]
+    [InlineData(120, 6)]
+    [InlineData(299.99, 6)]
+    [InlineData(300, 7)]
+    [InlineData(50_000, 7)]
+    public void TokenCount_StepsExactlyOnTheTablesEdges(double xpSum, int expected)
+        => Assert.Equal(expected, BankFlightPlan.TokenCount(xpSum));
+
+    [Fact]
+    public void TokenCount_GarbageXpIsTheSmallestPot_NotAThrow()
+    {
+        // This sits downstream of a live XP figure. A NaN multiplier upstream must cost the moment
+        // its size, never the award its completion.
+        Assert.Equal(BankFlightPlan.MinTokens, BankFlightPlan.TokenCount(double.NaN));
+        Assert.Equal(BankFlightPlan.MinTokens, BankFlightPlan.TokenCount(-500));
+    }
+
+    [Fact]
+    public void TokenCount_NeverExceedsTheCap()
+    {
+        // "The FEELING scales, not the particle count."
+        Assert.Equal(BankFlightPlan.MaxTokens, BankFlightPlan.TokenCount(double.MaxValue));
+        Assert.Equal(BankFlightPlan.MaxTokens, BankFlightPlan.TokenCount(double.PositiveInfinity));
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    public void EveryPlan_SitsInsideTheHouseBooksBands(int count)
+    {
+        // Swept over many seeds: a band violation that only shows up on one seed in fifty is
+        // exactly the kind of thing a single-seed test would ship.
+        for (int seed = 0; seed < 250; seed++)
+        {
+            var plan = BankFlightPlan.Plan(count, seed);
+            Assert.Equal(count, plan.Length);
+            Assert.Equal(0, plan[0].DelayMs);
+
+            for (int i = 0; i < plan.Length; i++)
+            {
+                Assert.InRange(plan[i].DurationMs, BankFlightPlan.DurationMinMs, BankFlightPlan.DurationMaxMs);
+                Assert.InRange(Math.Abs(plan[i].ArcBow), BankFlightPlan.ArcBowMin, BankFlightPlan.ArcBowMax);
+                if (i > 0)
+                {
+                    Assert.InRange(plan[i].DelayMs - plan[i - 1].DelayMs,
+                                   BankFlightPlan.StaggerMinMs, BankFlightPlan.StaggerMaxMs);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void BowSignsAlternate_SoTheFlightFansInsteadOfStreaming()
+    {
+        for (int seed = 0; seed < 50; seed++)
+        {
+            var plan = BankFlightPlan.Plan(BankFlightPlan.MaxTokens, seed);
+            for (int i = 1; i < plan.Length; i++)
+                Assert.True(Math.Sign(plan[i].ArcBow) != Math.Sign(plan[i - 1].ArcBow),
+                            $"seed {seed}: tokens {i - 1} and {i} bow the same way");
+        }
+    }
+
+    [Fact]
+    public void Plan_ClampsToTheCap_AndRefusesNothing()
+    {
+        Assert.Equal(BankFlightPlan.MaxTokens, BankFlightPlan.Plan(50, 1).Length);
+        Assert.Empty(BankFlightPlan.Plan(0, 1));
+        Assert.Empty(BankFlightPlan.Plan(-3, 1));
+    }
+
+    [Fact]
+    public void SameSeed_SameFlight()
+    {
+        var a = BankFlightPlan.Plan(6, 4242);
+        var b = BankFlightPlan.Plan(6, 4242);
+        Assert.Equal(a, b);   // record struct equality: every field, every token
+    }
+
+    [Fact]
+    public void DifferentSeeds_DifferentFlights()
+    {
+        // Not a distribution claim - just that the seed is actually wired to the draws, which a
+        // stray `new Random()` would quietly break while leaving every band test green.
+        var a = BankFlightPlan.Plan(7, 1);
+        var b = BankFlightPlan.Plan(7, 2);
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Envelope_IsTheLastLANDING_NotTheLastLaunch()
+    {
+        // The 150ms duration spread beats the 60-80ms stagger, so the final token in the array is
+        // not always the final one to arrive. A watchdog timed off the tail would fire early.
+        var plan = new[]
+        {
+            new BankFlightPlan.Token(0, 650, 0.12),
+            new BankFlightPlan.Token(70, 500, -0.12),
+        };
+        Assert.Equal(650, BankFlightPlan.EnvelopeMs(plan), 3);
+    }
+
+    [Fact]
+    public void Envelope_IsTheMaxOfDelayPlusDuration()
+    {
+        for (int seed = 0; seed < 100; seed++)
+        {
+            var plan = BankFlightPlan.Plan(7, seed);
+            double expected = 0;
+            foreach (var t in plan) expected = Math.Max(expected, t.DelayMs + t.DurationMs);
+            Assert.Equal(expected, BankFlightPlan.EnvelopeMs(plan), 6);
+        }
+    }
+
+    [Fact]
+    public void Envelope_OfNothingIsZero()
+    {
+        Assert.Equal(0, BankFlightPlan.EnvelopeMs(Array.Empty<BankFlightPlan.Token>()));
+        Assert.Equal(0, BankFlightPlan.EnvelopeMs(null!));
+    }
+
+    [Fact]
+    public void WholeFlight_FitsInsideTheShellsWatchdog()
+    {
+        // The shell arms a 6s failsafe around a flight. The longest legal plan has to land well
+        // inside it, or the failsafe becomes the normal path and the counter snaps every time.
+        var worst = BankFlightPlan.MaxTokens * BankFlightPlan.StaggerMaxMs + BankFlightPlan.DurationMaxMs;
+        Assert.True(worst < 6000, $"worst-case envelope {worst}ms is not comfortably inside the 6s watchdog");
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/BankFxDisplayHoldTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BankFxDisplayHoldTests.cs
@@ -1,0 +1,151 @@
+using System;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// THE BANK's counter arithmetic - the half of the shell choreography that can lie without anybody
+/// noticing. The tokens, the arcs and the pop can only be judged by eye; what cannot is whether the
+/// number the tokens deliver is the number the ledger holds. House Law I says the ledger never
+/// lies and only its presentation is staged, so every rounding, clamp and drift decision in
+/// <see cref="BankCounterScript"/> is asserted here rather than trusted.
+/// </summary>
+public class BankFxDisplayHoldTests
+{
+    // ---- StartValue: what a flight counts up FROM ----
+
+    [Fact]
+    public void StartValue_IsTheLastShownNumberWhenTheLevelHasNotMoved()
+        => Assert.Equal(412.5, BankCounterScript.StartValue(412.5, 7, 7), 6);
+
+    [Fact]
+    public void StartValue_IsZeroAcrossALevelChange()
+    {
+        // The readout wraps at a level-up. Counting up from the old level's number would make the
+        // first token look like a correction of a wrong figure.
+        Assert.Equal(0, BankCounterScript.StartValue(980, 7, 8), 6);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(-5)]
+    public void StartValue_IsZeroWhenThereIsNoHonestPreviousValue(double lastShown)
+        => Assert.Equal(0, BankCounterScript.StartValue(lastShown, 3, 3), 6);
+
+    // ---- Target: what the LAST token must deliver ----
+
+    [Fact]
+    public void Target_IsTheStartPlusThePot()
+        => Assert.Equal(160, BankCounterScript.Target(100, 60, 500), 6);
+
+    [Fact]
+    public void Target_NeverExceedsTheLedger()
+    {
+        // The first award of a pot is displayed before the pot exists (XPChanged runs ahead of
+        // XPAwarded), so a flight can be handed a pot it has already been partly credited with.
+        // Showing start+pot there would put more XP on screen than the player owns.
+        Assert.Equal(120, BankCounterScript.Target(100, 60, 120), 6);
+    }
+
+    [Fact]
+    public void Target_IgnoresXpThatArrivedMidFlight()
+    {
+        // The ledger has run on to 900; this flight is only carrying 60 and the rest belongs to the
+        // pot already collecting behind it.
+        Assert.Equal(160, BankCounterScript.Target(100, 60, 900), 6);
+    }
+
+    [Fact]
+    public void Target_NeverRunsBackwards()
+    {
+        // A level-up spends XP, so truth can sit below the counter. The flight simply does not
+        // move and the release to truth owns the correction.
+        Assert.Equal(100, BankCounterScript.Target(100, 60, 20), 6);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(0)]
+    [InlineData(-30)]
+    public void Target_IsTheStartForAPotThatIsNotAPot(double pot)
+        => Assert.Equal(100, BankCounterScript.Target(100, pot, 500), 6);
+
+    [Fact]
+    public void Target_IsTheStartWhenTheLedgerIsUnreadable()
+        => Assert.Equal(100, BankCounterScript.Target(100, 60, double.NaN), 6);
+
+    // ---- StepValue: the per-landing tick ----
+
+    [Fact]
+    public void StepValue_DividesThePotEvenlyAcrossTheLandings()
+    {
+        // 100 -> 160 over four tokens: a quarter of the pot per landing.
+        Assert.Equal(115, BankCounterScript.StepValue(100, 160, 0, 4), 6);
+        Assert.Equal(130, BankCounterScript.StepValue(100, 160, 1, 4), 6);
+        Assert.Equal(145, BankCounterScript.StepValue(100, 160, 2, 4), 6);
+    }
+
+    [Fact]
+    public void StepValue_LandsExactlyOnTheTarget()
+    {
+        // A third of a pot three times over is not the pot. The ledger is the authority, so the
+        // last landing returns the target itself rather than the sum of its slices.
+        double target = 100 + 1.0 / 3.0;
+        Assert.Equal(target, BankCounterScript.StepValue(100, target, 2, 3));
+    }
+
+    [Fact]
+    public void StepValue_IsMonotonicAndEndsOnTheTargetForEveryLegalTokenCount()
+    {
+        for (int count = BankFlightPlan.MinTokens; count <= BankFlightPlan.MaxTokens; count++)
+        {
+            double previous = 100;
+            for (int i = 0; i < count; i++)
+            {
+                double value = BankCounterScript.StepValue(100, 273.7, i, count);
+                Assert.True(value >= previous, $"count {count}, landing {i} went backwards");
+                previous = value;
+            }
+            Assert.Equal(273.7, previous, 6);
+        }
+    }
+
+    [Fact]
+    public void StepValue_ClampsALandingOrdinalOutsideTheFlight()
+    {
+        // The canvas counts LANDINGS, not plan slots, and a force-landed predecessor can settle
+        // more callbacks than this flight has tokens. Neither end may produce a stray number.
+        Assert.Equal(115, BankCounterScript.StepValue(100, 160, -3, 4), 6);
+        Assert.Equal(160, BankCounterScript.StepValue(100, 160, 9, 4), 6);
+    }
+
+    [Fact]
+    public void StepValue_SnapsToTheTargetWhenThereIsNoFlightToDivide()
+        => Assert.Equal(160, BankCounterScript.StepValue(100, 160, 0, 0), 6);
+
+    [Fact]
+    public void StepValue_SurvivesANonFiniteStart()
+        => Assert.Equal(160, BankCounterScript.StepValue(double.NaN, 160, 1, 4), 6);
+
+    // ---- StepMs: the tick has to be shorter than the gap between ticks ----
+
+    [Fact]
+    public void StepMs_FitsInsideTheShortestPossibleGapBetweenLandings()
+    {
+        double step = BankCounterScript.StepMs(isLast: false);
+        Assert.True(step < BankFlightPlan.StaggerMinMs,
+                    "a mid-flight step that outlives the stagger is replaced mid-tween and stutters");
+        Assert.True(step > 0);
+    }
+
+    [Fact]
+    public void StepMs_GivesTheLastLandingTheFullBeat()
+    {
+        Assert.Equal(BankCounterScript.MaxStepMs, BankCounterScript.StepMs(isLast: true), 6);
+        Assert.True(BankCounterScript.MaxStepMs <= 90,
+                    "House Book: a tick per landing, not an odometer that happens to be slow");
+    }
+}


### PR DESCRIPTION
## What this is

First House Book pass outside the Arcademy: **THE BANK on XP gain.** Every XP award now spawns 3-7 tokens at its source, flies them in seeded arcs to the XP counter, and the counter ticks up per landing with a mini-thud on the last. Rapid-fire awards coalesce - a 1.5s pot window plus a 3s cooldown means a flash-burst frenzy ships ONE flight for the whole pot, not a confetti hose. The feeling scales, not the particle count.

## The laws, kept

- **Law I - the ledger never lies.** `settings.PlayerXP` mutates instantly exactly as before (verified byte-identical on the write path vs main). Only the *display* is staged, and every exit path - level-up, focus loss, performance-tier flip mid-flight, 6s watchdog, window shutdown - lands the readout on ledger truth.
- **One burst per moment.** Level-up owns its moment: an open pot is poisoned, the in-flight counter snaps to truth before `CelebrateLevelUp` gets going, and the level-up celebration itself is untouched.
- **Focus-state silence.** No flights, no held counters, no queued celebrations while the window is backgrounded or minimized.
- **Reduced/Off motion = byte-identical** to the old `AnimateXpDisplay` behavior (verbatim-extracted bar fill, gated at the very first branch).

## How it works

- `ProgressionService` gains an `XpAward` struct + `XPAwarded` event (raised after `XPChanged` on the same call stack); zero ledger lines touched.
- Three new **pure, headless-tested** classes: `BankFlightPlan` (seeded token choreography: 60-80ms stagger, 500-650ms flights, alternating arc bows), `BankAccumulator` (pot window/cooldown/level-up poisoning, injected clock), `BankCounterScript` (per-landing counter steps, exact final landing).
- `AmbientFxCanvas.BankTokens`: quadratic-bezier one-shots on a lazy flight-sized layer (clamped, no idle clocks); force-land semantics guarantee callbacks can never strand a held counter.
- `MainWindow.BankFx`: hold-and-release choreography with subscription-order arming and layered failsafes (watchdog, flight-id invalidation, abort-to-truth on every give-up path).

## Owner dials (all in the DIALS block of `MainWindow.BankFx.cs` / class consts)

| Dial | Default |
|---|---|
| Pot window / cooldown | 1.5s / 3s |
| Token tiers | 3-7 by pot size (<15 -> 3 ... 300+ -> 7) |
| Thud | `sounds/ui/bank_thud.mp3` override slot, else `bubbles/Pop2.mp3` @ 0.35 |
| Origins | Session -> presets nav anchor; Bubble games -> studio anchor; everything else -> profile bubble |

## Verification

- Build: 0 errors, 0 new warnings.
- Tests: **3807/3807 green**, three consecutive runs (64 new tests across the three pure classes).
- Adversarial review pass found and fixed two display-integrity defects (mid-flight perf-tier flip running the counter backwards; a truth-write swallowable by a re-arm) - both now abort-to-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsTooYrmHrHpT6LNESqLrr