### PR TITLE
feat(arcademy): EMI speaks Blipese - synthesized babble voice, warm by decree

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -247,6 +247,21 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                `glee` ((≧◡≦)) is the THREE-PETS / STREAK-STAMP beat; `love`
                ((｡♥‿♥｡)) is a different, rarer one. Do not swap them.
   fx.js        showFx(host, kind) - hearts/sparks/tears/storm/bang as pixel glyphs.
+  vox.js       HER VOICE, "Blipese". createVox() -> {speak, tick, stop, destroy}
+               + the pure, harness-testable makeScore(text, mood) and the frozen
+               VOX_DIALS. It owns NO audio node (trap 18): it turns a line into a
+               SCORE of {atMs, pitch, gain} and fires one `arcademy-sfx` per blip
+               off its own setTimeout ladder, on the `voice` bus at level 0.4 -
+               deliberately under every game one-shot, and never with a `duck`.
+               Grain is per-SYLLABLE (vowel groups, 1..4); punctuation is prosody
+               (`?` lifts the sentence's last blips, cleanly and with no jitter;
+               `!` raises and hurries the whole line; `...` sags then rests); the
+               mood is the BODY FRAME FAMILY widget.js already resolved. Seeded
+               on the LINE TEXT via core/rng.js, so a line always sounds like
+               itself. Two ceilings, MAX_BLIPS 13 and BURST_MAX_MS 1400, and a
+               long line is compressed by giving up SYLLABLES - never by speeding
+               the gaps up, because the pace is the character. See trap 70.
+               Timbre lives in `shell/audio.js` SOUNDS: `emi_blip` / `emi_tick`.
   emi.css      the SKIN: .emi / .emi-body / .emi-screen (the locked glass rect) /
                .emi-fx / .emi-bubble + the body moves (.breath .nod .shiver
                .bounce .thud .droop). Ships BOTH bundled fonts (fonts/*.woff2,
@@ -259,7 +274,8 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                exactly one thing to cancel and one place that knows a SAY is
                mid-line). It NEVER imports the renderer - face/chains/fx are
                injected through attach(), which is what keeps a broken face out
-               of the shell's boot path. DIALS at the top are the tunables.
+               of the shell's boot path (`vox` rides the same seam). DIALS at the
+               top are the tunables.
   index.js     mountEmi({layer, store, toast, enabled}) -> the ONE controller
                {emote, say, idle, hide, show, setEnabled, setWidth, stats, flush,
                destroy, el}. `toast` is the SHELL's toast, borrowed for exactly
@@ -1103,6 +1119,28 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     timers), refused input = `bump` .3 throttled 250ms. Hover sound exists in exactly
     ONE place in the school - the Lost & Found board (`tell` .12, 150ms throttle,
     hunt-phase only) - and that is an owner ruling, not an oversight to fix elsewhere.
+
+70. **EMI'S VOICE HANGS OFF `setBubble()`, AND THAT IS THE WHOLE SAFETY ARGUMENT.**
+    `emi/vox.js` babbles for as long as a landed line is up, which means something has
+    to guarantee it never outlives the bubble - a dismiss, a drag, a `setEnabled(false)`,
+    a replacement line and a `destroy()` must all cut her instantly. There is exactly
+    one place in `widget.js` that already knows the difference between typing (`.`/`..`/
+    `...`), a landed line and a cleared bubble, and EVERY cancel path in the file already
+    funnels through its `null` branch: `setBubble()`. So the voice is three one-liners
+    there (`tick` / `speak` / `stop`) and nothing anywhere else. Do NOT "improve" this by
+    calling `vox.speak()` from `play()`, from `voice.js` or from a moment - the moment a
+    second call site exists, one of the ten cancel paths stops cutting her and EMI keeps
+    talking over a screen she is no longer on. Two consequences worth knowing:
+    - the **pop branch speaks on a `queueMicrotask`**, because `playChain` hands the
+      bubble over BEFORE it hands the frame to `draw` - which is what resolves the pose
+      for a `makeSay` line. Same tick, same frame; it just reads `bodyFrame` (the mood)
+      after it exists. `chains.js` is owner-locked and stays untouched.
+    - **`stop()` is not a fade**, it clears the pending timers; the worst tail is the one
+      blip already in flight (<=56ms). That is the correct trade for an instant dismiss.
+    A cold boot is SILENT and that is also correct: `shell/audio.js` creates no context
+    before the first gesture, so the opening greet's babble is dropped. Never queue it
+    for retro-play - a mascot who talks over a beat that already passed is worse than
+    one who missed it.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
@@ -98,6 +98,8 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
 
   const PENDING_GRACE_MS = 2500;
   let pending = null;
+  /** emi/vox.js, once it lands. Null is a perfectly good answer (a silent EMI). */
+  let vox = null;
   function remember(fn) { if (!widget.hasFace()) pending = { fn: fn, when: Date.now() }; }
 
   /* THE RENDERER, LATE AND OPTIONAL. Three modules, one failure mode: EMI keeps
@@ -106,8 +108,16 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
     import('./face.js').catch((e) => { say('emi: face.js unavailable (' + ((e && e.message) || e) + ')'); return null; }),
     import('./chains.js').catch((e) => { say('emi: chains.js unavailable (' + ((e && e.message) || e) + ')'); return null; }),
     import('./fx.js').catch((e) => { say('emi: fx.js unavailable (' + ((e && e.message) || e) + ')'); return null; }),
-  ]).then(([f, c, x]) => {
-    try { widget.attach({ face: f, chains: c, fx: x }); }
+    /* HER VOICE, on the same terms as her face. `vox.js` owns no audio node -
+     * it asks shell/audio.js for blips - so a broken one costs the babble and
+     * nothing else: the bubble, the cadence and the whole wordless table stand. */
+    import('./vox.js').catch((e) => { say('emi: vox.js unavailable (' + ((e && e.message) || e) + ')'); return null; }),
+  ]).then(([f, c, x, v]) => {
+    if (v && typeof v.createVox === 'function') {
+      try { vox = v.createVox({ log: say }); }
+      catch (e) { vox = null; say('emi: createVox threw - ' + ((e && e.message) || e)); }
+    }
+    try { widget.attach({ face: f, chains: c, fx: x, vox }); }
     catch (e) { say('emi: attach threw - ' + ((e && e.message) || e)); }
     const p = pending;
     pending = null;
@@ -208,9 +218,14 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
     /** Debug: the one moment waiting on the voice + the face, by name. */
     get pendingMoment() { return voicePending ? voicePending.name : null; },
 
+    /** Her babble (emi/vox.js), once it has loaded. Test/debug handle only. */
+    get vox() { return vox; },
+
     destroy() {
       try { widget.destroy(); } catch (e) { /* noop */ }
       try { if (voice) voice.destroy(); } catch (e) { /* noop */ }
+      try { if (vox) vox.destroy(); } catch (e) { /* noop */ }
+      vox = null;
       voice = null;
       voicePending = null;
       voiceGate = null;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/vox.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/vox.js
@@ -1,0 +1,368 @@
+/* ============================================================================
+ * emi/vox.js - BLIPESE: the sound EMI makes while a line is on screen.
+ *
+ * She has no mouth and she never mouths words (the talk rule is locked in
+ * chains.js), so the voice is not speech - it is a short seeded BABBLE that
+ * plays under the landed bubble and stops when the bubble does. Think Banjo,
+ * not Undertale: a warm little instrument with a cadence, never a typewriter.
+ *
+ *   const vox = createVox({ log });
+ *   vox.tick();                        // one dot frame typed
+ *   vox.speak('nice one!', { face: 'celebration' });
+ *   vox.stop();                        // the bubble cleared - cut, no tail
+ *
+ * WHAT THIS FILE IS NOT: an audio node. CLAUDE.md trap 18 is absolute -
+ * `shell/audio.js` is the only thing in the Arcademy that may hold one. So this
+ * module is a pure EMITTER: it computes a SCORE (a list of {atMs, pitch, gain})
+ * and fires one `arcademy-sfx` CustomEvent per blip off its own setTimeout
+ * ladder, exactly the way `chains.js playChain` walks its frames. Everything
+ * downstream - the mixer, the mute, the Voice slider, the ducking - is already
+ * built and this file gets all of it for free by asking politely.
+ *
+ * WHY IT IS QUIET ON PURPOSE. The cue level is VOX_DIALS.LEVEL (0.4) on the
+ * `voice` bus and the recipe's own gain is 0.35, which puts her clearly UNDER
+ * every game one-shot (a stamp is level 1.0, a pop 0.8). A mascot MURMURS. She
+ * also never sends `duck` - the existing DUCK_TARGETS already pull the voice bus
+ * down under a whisper or a spotlight, which is the correct direction.
+ *
+ * DETERMINISM IS THE IDENTITY. The seed is the LINE TEXT (core/rng.js makeRng,
+ * the only sanctioned randomness in this codebase - never Math.random), so a
+ * line always sounds like itself: the same sentence twice in one night is the
+ * same little melody, and two different sentences are two different ones. That
+ * is what turns a bag of beeps into a voice you recognise.
+ *
+ * ONE VOICE. `speak()` cuts any babble still running. A report card and a stamp
+ * landing back to back can never stack into two EMIs talking over each other.
+ *
+ * THE NODE DOM DOUBLE drives these modules in the suites and has no
+ * `CustomEvent`, so every dispatch is wrapped: a cue must never be the thing
+ * that throws (the precedent is shell/ceremonies.js `sfx()`).
+ * ==========================================================================*/
+
+import { makeRng } from '../core/rng.js';
+
+/* ---------------------------------------------------------------------------
+ * THE DIALS. One table, so a re-tune is a number here and not a read of the
+ * machinery below. Same shape and same intent as voice.js VOICE_DIALS.
+ * ------------------------------------------------------------------------- */
+export const VOX_DIALS = Object.freeze({
+  ENABLED: true,             // the whole-voice off switch (no settings row in v1)
+  BUS: 'voice',              // the user-facing Voice slider already exists
+  LEVEL: 0.4,                // cue level per blip - deliberately under the games
+  TICK_LEVEL: 0.22,          // ...and the typing tick is quieter again
+
+  /* --- rhythm (pace is identity: compression NEVER speeds these up) ------ */
+  GAP_SYL_MS: 62,            // between two syllables of one word
+  GAP_WORD_MS: 115,          // between two words
+  GAP_SENT_MS: 160,          // ...added on top at a sentence boundary
+  TAIL_REST_MS: 180,         // ...and again after an ellipsis (the trailing off)
+  JITTER_GAP_MS: 10,         // +/- per gap, seeded - a human never lands on a grid
+  MAX_BLIPS: 13,             // hard ceiling on the burst
+  BURST_MAX_MS: 1400,        // ...and on its length. Always ends inside the 3s hold.
+
+  /* --- prosody, in semitones -------------------------------------------- */
+  BASE_PITCH: 1.0,
+  JITTER_SEMI: 1.2,          // +/- per blip (scaled by the mood's own jitter)
+  DECLINE_SEMI: 2.0,         // a sentence starts +1 and drifts down this far
+  QUESTION_RISE: 3.0,        // '?' lifts the last blips +1..+RISE, stepped and CLEAN
+  QUESTION_TAIL: 3,          // ...how many blips the lift owns
+  BANG_SEMI: 1.0,            // '!' raises the whole utterance
+  BANG_GAIN: 1.25,           // ...and leans on it
+  BANG_GAP: 0.85,            // ...and hurries it slightly
+  SAD_TAIL_SEMI: -2.0,       // an ellipsis sags before the rest
+  TAIL_GAIN: 0.8,            // ...and softens
+
+  /* --- the typing tick --------------------------------------------------- */
+  DOT_TICKS: true,           // ON by default (owner: the anticipation is the point)
+
+  /* --- the moods, keyed by BODY FRAME family (widget.js frameForFace) ----
+   * `decline` is in semitones per sentence and a NEGATIVE one rises; `tail` is
+   * added to the very last blip of the utterance; `jitter` scales JITTER_SEMI. */
+  MOODS: Object.freeze({
+    idle:        Object.freeze({ pitch: 1.00, gap: 1.00, gain: 1.00, jitter: 1.0, decline:  2.0, tail:  0.0 }),
+    celebration: Object.freeze({ pitch: 1.15, gap: 0.85, gain: 1.15, jitter: 1.4, decline: -1.5, tail:  0.0 }),
+    pet:         Object.freeze({ pitch: 1.05, gap: 1.10, gain: 0.80, jitter: 0.7, decline:  1.4, tail:  0.0 }),
+    smug:        Object.freeze({ pitch: 0.95, gap: 1.25, gain: 0.90, jitter: 0.9, decline:  2.2, tail: -1.5 }),
+    sad:         Object.freeze({ pitch: 0.85, gap: 1.30, gain: 0.75, jitter: 0.5, decline:  0.6, tail: -2.0 }),
+    shock:       Object.freeze({ pitch: 1.20, gap: 0.60, gain: 1.10, jitter: 1.6, decline:  2.0, tail:  0.0 }),
+  }),
+});
+
+/** audio.js clamps a cue's pitch to this window; we never send one outside it. */
+const PITCH_MIN = 0.5;
+const PITCH_MAX = 2;
+
+const clamp = (v, lo, hi) => (v < lo ? lo : v > hi ? hi : v);
+const semiToRatio = (s) => Math.pow(2, s / 12);
+
+/**
+ * SYLLABLES, cheaply. Vowel GROUPS, clamped 1..4 - a word always gets at least
+ * one blip and no word is ever allowed to become a solo. This is not linguistics
+ * and does not need to be: the ear reads it as pace, not as pronunciation.
+ */
+export function syllables(word) {
+  const w = String(word == null ? '' : word).toLowerCase().replace(/[^a-z]+/g, '');
+  if (!w) return 1;
+  const m = w.match(/[aeiouy]+/g);
+  return clamp(m ? m.length : 1, 1, 4);
+}
+
+/** Trailing punctuation -> the flags that shape a sentence. Never throws. */
+function tokenize(text) {
+  const words = [];
+  const raw = String(text == null ? '' : text).trim();
+  if (!raw) return words;
+  for (const chunk of raw.split(/\s+/)) {
+    const punct = (chunk.match(/[.,!?;:…)"'\]]+$/) || [''])[0];
+    const body = chunk.slice(0, chunk.length - punct.length) || chunk;
+    const ellipsis = /\.\.\.|…/.test(punct);
+    const question = punct.indexOf('?') >= 0;
+    const bang = punct.indexOf('!') >= 0;
+    words.push({
+      syl: syllables(body),
+      ends: ellipsis || question || bang || punct.indexOf('.') >= 0,
+      ellipsis, question, bang,
+    });
+  }
+  // A line with no terminator still ENDS - the last word closes its sentence.
+  if (words.length) words[words.length - 1].ends = true;
+  return words;
+}
+
+/**
+ * COMPRESSION, when a line is longer than the burst may be. Two rules, in
+ * order, and neither of them touches the gaps: the PACE is the identity and a
+ * sped-up EMI is a different character.
+ *   1. drop a word-INTERNAL syllable from the longest word (the first syllable
+ *      of every word survives, so the word count - the rhythm you hear - holds)
+ *   2. only then drop a whole word, from the MIDDLE out, never the first and
+ *      never the last (the opening and the cadence are what carry the mood)
+ * @returns {boolean} false when there is nothing left to give up
+ */
+function dropOne(words) {
+  let best = -1;
+  for (let i = 0; i < words.length; i++) {
+    if (words[i].syl > 1 && (best < 0 || words[i].syl > words[best].syl)) best = i;
+  }
+  if (best >= 0) { words[best].syl -= 1; return true; }
+  if (words.length <= 2) return false;
+  const cut = Math.floor(words.length / 2);
+  const gone = words.splice(cut, 1)[0];
+  // The removed word may have been carrying a sentence end. Hand it backwards
+  // rather than losing the rest - a dropped word must not merge two sentences.
+  if (gone.ends) {
+    const prev = words[cut - 1];
+    prev.ends = true;
+    prev.ellipsis = prev.ellipsis || gone.ellipsis;
+    prev.question = prev.question || gone.question;
+    prev.bang = prev.bang || gone.bang;
+  }
+  return true;
+}
+
+/** One pass: words (already compressed) -> the score. Fresh rng every pass. */
+function layout(words, M, bang, D, seed) {
+  const rng = makeRng('emi-vox|' + seed);
+  const gapMul = M.gap * (bang ? D.BANG_GAP : 1);
+  const jgap = (ms) => Math.max(16, ms * gapMul + (rng() * 2 - 1) * D.JITTER_GAP_MS);
+
+  /* Sentence ids, and how many blips each sentence holds - the declination
+   * curve needs to know where it is inside its own sentence. */
+  let s = 0;
+  const sentOf = [];
+  const counts = [];
+  for (const w of words) {
+    sentOf.push(s);
+    counts[s] = (counts[s] || 0) + w.syl;
+    if (w.ends) s += 1;
+  }
+
+  const blips = [];
+  let t = 0;
+  const seen = [];
+  for (let i = 0; i < words.length; i++) {
+    const w = words[i];
+    if (i > 0) {
+      const prev = words[i - 1];
+      let g = D.GAP_WORD_MS;
+      if (prev.ends) g += D.GAP_SENT_MS;
+      if (prev.ellipsis) g += D.TAIL_REST_MS;   // ...trailing off is a REST, not a rush
+      t += jgap(g);
+    }
+    for (let k = 0; k < w.syl; k++) {
+      if (k > 0) t += jgap(D.GAP_SYL_MS);
+      const si = sentOf[i];
+      const j = seen[si] || 0;
+      seen[si] = j + 1;
+      blips.push({
+        atMs: Math.round(t),
+        s: si, j, n: counts[si],
+        lastOfWord: k === w.syl - 1,
+        ellipsis: w.ellipsis,
+        question: w.question,
+      });
+    }
+  }
+  if (!blips.length) return blips;
+
+  /* Does this sentence ask a question? The flag lives on its LAST word. */
+  const asks = [];
+  for (const b of blips) if (b.question) asks[b.s] = true;
+
+  const last = blips.length - 1;
+  for (let i = 0; i <= last; i++) {
+    const b = blips[i];
+    const frac = b.n > 1 ? b.j / (b.n - 1) : 0;
+    let semi = 1 - M.decline * frac;
+    let jitter = true;
+    let lifted = false;
+
+    /* THE LIFT IS A GESTURE, SO IT IS CLEAN. A question's last blips step up
+     * +1..+QUESTION_RISE off a flat base and take NO jitter - a smeared lift
+     * reads as a wrong note, not as a question. It is also what makes the rise
+     * provable in the harness. */
+    if (asks[b.s]) {
+      const k = Math.min(D.QUESTION_TAIL, b.n);
+      const m = b.j - (b.n - k);
+      if (m >= 0) { semi = 1 + (D.QUESTION_RISE * (m + 1)) / k; jitter = false; lifted = true; }
+    }
+    if (bang) semi += D.BANG_SEMI;
+    if (b.ellipsis && b.lastOfWord) { semi += D.SAD_TAIL_SEMI; jitter = false; }
+    /* A MOOD'S SAG NEVER LANDS ON A QUESTION. `smug` and `sad` drop the last
+     * blip of an utterance, which is the drawl - but a line that ENDS on a
+     * question ends UP, and the two cancelling out is heard as a wrong note
+     * rather than as either feeling. The lift wins; it is the louder gesture. */
+    if (i === last && !lifted) semi += M.tail;
+    if (jitter) semi += (rng() * 2 - 1) * D.JITTER_SEMI * M.jitter;
+
+    let gain = D.LEVEL * M.gain * (bang ? D.BANG_GAIN : 1);
+    if ((b.ellipsis && b.lastOfWord) || (i === last && !lifted && M.tail < 0)) gain *= D.TAIL_GAIN;
+
+    b.pitch = clamp(D.BASE_PITCH * M.pitch * semiToRatio(semi), PITCH_MIN, PITCH_MAX);
+    b.gain = clamp(gain, 0.02, 1);
+    delete b.s; delete b.j; delete b.n;
+    delete b.lastOfWord; delete b.ellipsis; delete b.question;
+  }
+  return blips;
+}
+
+/**
+ * makeScore(text, mood, dials?) -> [{atMs, pitch, gain}, ...]
+ *
+ * PURE and DETERMINISTIC: same text + same mood always returns the same score,
+ * byte for byte. `gain` is the cue's `level` field (audio.js applies the sqrt
+ * curve to it); `atMs` is an offset from the start of the burst.
+ *
+ * `mood` is a BODY FRAME FAMILY - one of VOX_DIALS.MOODS' keys, which is
+ * exactly what `widget.js` already resolved for the reaction face. Anything
+ * else is `idle`, deliberately: a face nobody paired is a face she has no
+ * strong feeling about (the same rule FACE_BODY_FRAME follows).
+ */
+export function makeScore(text, mood, dials) {
+  const D = (dials && typeof dials === 'object') ? Object.assign({}, VOX_DIALS, dials) : VOX_DIALS;
+  const moods = D.MOODS || VOX_DIALS.MOODS;
+  const M = (typeof mood === 'string' && moods[mood]) ? moods[mood] : moods.idle;
+  const seed = String(text == null ? '' : text);
+
+  const words = tokenize(seed);
+  if (!words.length) return [];
+  const bang = words.some((w) => w.bang);
+
+  /* FIT THE BURST. Compress until it is inside BOTH ceilings - never by moving
+   * the clock, always by giving up a syllable. The guard is belt and braces:
+   * dropOne() bottoms out at two words and the loop returns what it has. */
+  let score = layout(words, M, bang, D, seed);
+  for (let guard = 0; guard < 240; guard++) {
+    const dur = score.length ? score[score.length - 1].atMs : 0;
+    if (score.length <= D.MAX_BLIPS && dur <= D.BURST_MAX_MS) break;
+    if (!dropOne(words)) { score = score.slice(0, D.MAX_BLIPS); break; }
+    score = layout(words, M, bang, D, seed);
+  }
+  return score;
+}
+
+/**
+ * createVox({ dials, log }) -> { speak, tick, stop, destroy }
+ * Owns nothing but timers. Every entry point is safe to call on a platform with
+ * no document, no CustomEvent and no audio at all.
+ */
+export function createVox({ dials, log } = {}) {
+  const say = typeof log === 'function' ? log : () => {};
+  const D = Object.assign({}, VOX_DIALS, (dials && typeof dials === 'object') ? dials : {});
+  const timers = new Set();
+  let dead = false;
+  const stats = { spoke: 0, blips: 0, ticks: 0, cut: 0 };
+
+  /** The ONE way a sound leaves this file. A cue may never be what throws. */
+  function cue(name, level, pitch) {
+    try {
+      if (typeof document === 'undefined' || typeof document.dispatchEvent !== 'function') return;
+      const Ctor = (typeof CustomEvent === 'function') ? CustomEvent : null;
+      if (!Ctor) return;
+      document.dispatchEvent(new Ctor('arcademy-sfx', {
+        detail: { name, level, bus: D.BUS, pitch },   // NEVER a duck: see the header
+      }));
+    } catch (e) { /* a cue must never be the thing that throws */ }
+  }
+
+  function stop() {
+    if (timers.size) stats.cut += 1;
+    for (const id of timers) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+    timers.clear();
+  }
+
+  return {
+    /** The dials this instance actually runs on (test/debug seam). */
+    dials: D,
+
+    /**
+     * ONE typing tick, for a `.`/`..`/`...` bubble frame. Very quiet and behind
+     * DOT_TICKS - this is the annoyance risk in the whole feature, so it is the
+     * one thing with its own off switch.
+     */
+    tick() {
+      if (dead || !D.ENABLED || !D.DOT_TICKS) return false;
+      stats.ticks += 1;
+      cue('emi_tick', D.TICK_LEVEL, 1);
+      return true;
+    },
+
+    /**
+     * Babble one landed line. Fires the first blip SYNCHRONOUSLY so the sound
+     * lands on the same frame as the bubble (house doctrine: <=50ms), then
+     * walks the rest on setTimeout.
+     * @param {string} text
+     * @param {{face?:string}=} opts  `face` is a body-frame family (widget.bodyFrame)
+     */
+    speak(text, opts) {
+      if (dead || !D.ENABLED) return false;
+      const line = String(text == null ? '' : text);
+      if (!line.trim()) return false;
+      stop();                                   // ONE VOICE: never two at once
+      const score = makeScore(line, (opts && opts.face) || 'idle', D);
+      if (!score.length) return false;
+      stats.spoke += 1;
+      stats.blips += score.length;
+      for (const b of score) {
+        if (b.atMs <= 0) { cue('emi_blip', b.gain, b.pitch); continue; }
+        const id = setTimeout(() => { timers.delete(id); cue('emi_blip', b.gain, b.pitch); }, b.atMs);
+        timers.add(id);
+      }
+      return true;
+    },
+
+    /** Cut. The worst tail is the one blip already in flight (<=60ms). */
+    stop,
+
+    /** Read-only, for the suite and a later Records Office beat. */
+    stats() { return Object.assign({}, stats, { pending: timers.size }); },
+
+    destroy() {
+      stop();
+      dead = true;
+      say('emi: vox down');
+    },
+  };
+}
+
+export default createVox;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -222,7 +222,7 @@ function readStats(raw) {
  * @param {Function=} o.toast         the SHELL's toast (boot.js -> createShell's `shout`)
  * @param {Function=} o.log
  */
-export function createWidget({ root, face, chains, fx, store, toast, log } = {}) {
+export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, log } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   /* THE SHELL'S TOAST, NOT A SECOND ONE. `#arc-toast` already exists, already
    * stacks above EMI (z 60 vs 50) and already expires its own nodes; minting a
@@ -422,6 +422,11 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
   let playChain = null;
   let makeSay = null;
   let showFx = null;
+  /* HER VOICE (emi/vox.js), injected the same way and just as optional. It owns
+   * no audio node - it only asks shell/audio.js for blips - so from here it is
+   * three calls hanging off setBubble(), the one place that already knows the
+   * difference between typing, a landed line and a cleared bubble. */
+  let vox = null;
   /* CONSTRUCTION-TIME ATTACH IS NOT A REPAINT. `attach({face, chains, fx})` runs
    * once from inside createWidget - a caller may hand the renderer straight to
    * the constructor instead of injecting it a tick later - and at that point the
@@ -436,6 +441,8 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
     const f = mods && mods.face;
     const c = mods && mods.chains;
     const x = mods && mods.fx;
+    const v = mods && mods.vox;
+    if (v && typeof v.speak === 'function') vox = v;
     if (!painter && f && canvas && typeof canvas.getContext === 'function') {
       const mk = typeof f === 'function' ? f : (f && typeof f.createFace === 'function' ? f.createFace : null);
       try {
@@ -459,7 +466,7 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
       if (built) idle();
     }
   }
-  attach({ face, chains, fx });
+  attach({ face, chains, fx, vox: vox0 });
 
   /* ---------------------- motion preference ----------------------------- */
   function reducedMotion() {
@@ -589,11 +596,17 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
     catch (e) { say('emi: draw threw - ' + ((e && e.message) || e)); }
   }
 
+  /* THE BUBBLE IS ALSO WHERE SHE IS AUDIBLE. This function already knows the
+   * only three states her voice cares about - typing, landed, gone - and EVERY
+   * cancel path in this file funnels through the `null` branch, so hanging the
+   * voice here (and nowhere else) is what makes "dismiss mid-babble cuts her
+   * instantly" true by construction instead of by discipline. See trap 70. */
   function setBubble(text) {
     if (text == null || text === '') {
       bubble.hidden = true;
       bubble.textContent = '';
       bubble.classList.remove('dots', 'pop');
+      if (vox) { try { vox.stop(); } catch (e) { /* a voice may never break a bubble */ } }
       return;
     }
     const s = String(text);
@@ -601,8 +614,20 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
     bubble.textContent = s;
     bubble.hidden = false;
     bubble.classList.remove('dots', 'pop');
-    if (dots) bubble.classList.add('dots');
-    else { bubble.classList.add('pop'); stats.bubblesSeen += 1; }
+    if (dots) {
+      bubble.classList.add('dots');
+      if (vox) { try { vox.tick(); } catch (e) { /* noop */ } }
+    } else {
+      bubble.classList.add('pop'); stats.bubblesSeen += 1;
+      /* THE MOOD IS DRAWN ONE LINE LATER. playChain hands us the bubble BEFORE
+       * it hands the frame to `draw`, which is what resolves `bodyFrame` for a
+       * makeSay line - so we ask on the microtask and read the pose she is
+       * actually wearing. Same tick, same frame, chains.js untouched. */
+      if (vox) {
+        const speak = () => { try { vox.speak(s, { face: bodyFrame }); } catch (e) { /* noop */ } };
+        if (typeof queueMicrotask === 'function') queueMicrotask(speak); else speak();
+      }
+    }
   }
 
   /* BODY MOVES GO ON THE ROOT. Agent A's keyframes animate `transform` on `.emi`
@@ -1143,6 +1168,8 @@ export function createWidget({ root, face, chains, fx, store, toast, log } = {})
       // clearBody() is the easy one to miss: `bodyTimer` outlives everything else
       // and its callback re-adds `.breath` to a node that is no longer in the page.
       cancelChain(); killTimers(); stopBlink(); stopSway(); disarmHold(); clearBody();
+      // Her voice is a setTimeout ladder of its own and nothing above clears it.
+      if (vox) { try { vox.stop(); } catch (e) { /* noop */ } }
       if (saveTimer !== null) { clearTimeout(saveTimer); saveTimer = null; }
       if (typeof window !== 'undefined' && window.removeEventListener) {
         window.removeEventListener('resize', onResize);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -98,6 +98,24 @@ const SOUNDS = {
   near:      { type: 'sine',     f0: 740, f1: 620, ms: 110, gain: 0.55 },
   chime:     { type: 'sine',     f0: 1046.5, f1: 1046.5, ms: 160, gain: 0.5 },
   shutter:   { noise: true, hp: 1800, lp: 9000, ms: 40,  gain: 0.7 },
+  /* EMI's VOICE, "Blipese" (2026-08-24, emi/vox.js). Two recipes and no third:
+     the mascot babbles by firing `emi_blip` many times with a per-blip `pitch`,
+     so the TIMBRE lives here, once, and the melody lives over there.
+     TRIANGLE, not square. The owner's directive is "pleasant at low volume - she
+     has to be someone you get attached to", and a square up here is a beeper.
+     The chirp falls ~a whole tone across the blip so each one reads as a little
+     syllable rather than a tone; `attack` 0.3 of the duration (~17ms of the 56)
+     is what keeps it from clicking; and gain 0.35 is HALF a game pop. A mascot
+     murmurs - she is never the loudest thing on the screen.
+     TASTE ROUND (owner): the square variant is kept here rather than in a doc so
+     the comparison is a two-line swap.
+       emi_blip:  { type: 'square', f0: 760, f1: 680, ms: 52, gain: 0.26, attack: 0.34 },
+   */
+  emi_blip:  { type: 'triangle', f0: 760, f1: 680, ms: 56, gain: 0.35, attack: 0.3 },
+  /* ...and the tick under the `.` `..` `...` typing frames: low, short, a fifth
+     of the blip's gain. It is anticipation, not a sound in its own right - the
+     moment a player NOTICES it, it is wrong (vox.js DOT_TICKS turns it off). */
+  emi_tick:  { type: 'triangle', f0: 336, f1: 322, ms: 30, gain: 0.16, attack: 0.35 },
 };
 
 const clamp01 = (v) => (Number.isFinite(+v) ? Math.max(0, Math.min(1, +v)) : 0);


### PR DESCRIPTION
EMI gets a voice without a voice actor: per-syllable synth blips that mime her lines - the Animalese/Banjo family, tuned warm per owner directive (**pleasant even at low volume; attachment is the point**).

## How she talks
- **Banjo model, not Undertale**: the locked SAY cadence pops the line whole, so the voice is a <=1.4s babble burst starting on the same frame as the pop (house <=50ms law by construction) and always ending before the 3s minimum hold. `chains.js` untouched.
- **Per-syllable blips + seeded melody**: pitch contour with per-sentence declination, `?` tails rise (jitter-free so the lift is provable), `!` punches, ellipsis gets a sighing tail + rest. Seeded from the line text via `core/rng.js` - **the same line always sounds exactly like itself**; players learn her catchphrases by ear. No `Math.random()`.
- **Mood from the face she pulls**: reads `widget.bodyFrame` (already resolved via `frameForFace`) - celebration chirps up, sad sags near-monotone, smug drawls, shock goes staccato. New rule: a drawl never cancels a question's lift.
- **Timbre**: soft triangle with a downward chirp (square variant left commented for the taste round). Typing-dots get a very quiet tick, behind `DOT_TICKS`.

## Wiring
- NEW `emi/vox.js` (+368): pure `arcademy-sfx` event emitter - owns zero audio nodes (trap 18), setTimeout ladder, one-voice (speak cuts speak), `VOX_DIALS` frozen dial block for retuning without reading machinery.
- `shell/audio.js`: exactly two recipes (`emi_blip`, `emi_tick`). Routes the existing **voice bus** - the user's Voice slider quiets her for free; she **never ducks** anything (mascot reacts, doesn't narrate).
- `emi/widget.js`: `setBubble` = the single choke-point - dots->tick, pop->speak, null->stop; every existing cancel path already funnels through null, so skip/replace/hide cut clean with no tail.
- `emi/index.js`: vox loads like the other optional emi modules - broken vox costs the voice and nothing else.
- arcademy CLAUDE.md: module docs + trap 70.

## Verified
- Harness over the real corpus (115 bark lines x 6 moods): determinism 690/690 byte-identical; blip cap 13; worst burst 1456ms; pitch 0.749-1.602 (inside clamp, no clipping); all 65 question tails strictly rise; all 108 multi-sentence lines carry the rest. Inert-not-throwing in the DOM-less node double; bus `voice` only; zero ducks.
- `node --check` green on all touched JS. WAV auditions rendered through the real gain law and delivered to the owner.
- Cold-boot note: first greet before any gesture stays silent by design (gesture-gated context; never retro-played).

Play-test checklist in the design doc; owner taste dials: triangle vs square, base pitch, chirp depth, `DOT_TICKS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW3CBGmvoftRkuuPaUQRi