### PR TITLE
fix(entitlement): premium features left ON now switch off when access lapses

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -76,6 +76,87 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
+        /// A premium feature left ON when its entitlement lapses (the ? box's free day rotating
+        /// out at midnight, a subscription expiring) used to stay armed underneath the re-drawn
+        /// padlock veil - and the veil covers the very toggle that turns it off, so users were
+        /// stuck with the feature running and no reachable OFF switch. This flips such features
+        /// off on the same funnel that repaints the veils, restoring the invariant that a veiled
+        /// page never has its feature enabled behind it.
+        ///
+        /// Safe against the async-validation startup window on purpose: HasPremiumAccess includes
+        /// the 14-day offline grace stamp (AppSettings.HasCachedPremiumAccess), so an entitled
+        /// subscriber reads true here even before validation lands - only genuinely lapsed users
+        /// are flipped, and settings are only ever written false here, never true.
+        /// </summary>
+        private void EnforceEntitlementLapse()
+        {
+            try
+            {
+                var settings = App.Settings?.Current;
+                if (settings == null) return;
+                var premium = App.Patreon?.HasPremiumAccess == true;
+                var changed = false;
+
+                // Awareness (keyword triggers + screen OCR) - keeps its own keyboard hook and OCR
+                // scanner alive. Mirrors ChkAwarenessMaster_Changed's OFF branch.
+                if (settings.KeywordTriggersEnabled && !premium
+                    && App.DailyFree?.IsFreeToday("awareness") != true)
+                {
+                    settings.KeywordTriggersEnabled = false;
+                    App.KeywordTriggers?.Stop();
+                    App.ScreenOcr?.Stop();
+                    if (settings.PanicKeyEnabled != true) _keyboardHook?.Stop();
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: Awareness switched off");
+                }
+
+                // Bambi Takeover (autonomy).
+                if (settings.AutonomyModeEnabled && !premium
+                    && App.DailyFree?.IsFreeToday("takeover") != true)
+                {
+                    settings.AutonomyModeEnabled = false;
+                    App.Autonomy?.Stop();
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: Bambi Takeover switched off");
+                }
+
+                // She's Listening (spoken mantras). No background engine of its own to stop -
+                // the flag is what the speech pipeline consults.
+                if (settings.SpokenMantrasEnabled && !premium
+                    && App.DailyFree?.IsFreeToday("voice") != true)
+                {
+                    settings.SpokenMantrasEnabled = false;
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: She's Listening switched off");
+                }
+
+                // Haptics. The mixer already self-mutes live (HapticMixer.IsGateOpen), so this is
+                // about the master toggle not sitting ON underneath the veil.
+                if (settings.Haptics?.Enabled == true && !premium
+                    && App.DailyFree?.IsFreeToday("haptics") != true)
+                {
+                    settings.Haptics.Enabled = false;
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: Haptics switched off");
+                }
+
+                if (changed)
+                {
+                    App.Settings?.Save();
+                    // If the affected page is on screen right now, repaint its toggles too; every
+                    // page also re-syncs itself on open, so a miss here degrades to stale-until-
+                    // reopened, never to wrong.
+                    try { SyncAwarenessTabUI(); } catch { /* tab not built yet */ }
+                    try { SyncKeywordRescuePanelUi(); } catch { }
+                }
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "EnforceEntitlementLapse failed");
+            }
+        }
+
+        /// <summary>
         /// Repaints every entitlement veil that the ? box can lift, in one place, so the day-roll /
         /// server-override path and the tier-change path cannot disagree about which doors are shut.
         /// Each pool feature passes its <see cref="Models.ExclusiveFeature.DailyFreeKey"/>; Lockdown
@@ -83,6 +164,9 @@ namespace ConditioningControlPanel
         /// </summary>
         internal void RefreshEntitlementVeils()
         {
+            // Before repainting the padlocks: a feature left ON without entitlement is switched
+            // off, so a veil can never trap a running feature behind an unreachable toggle.
+            EnforceEntitlementLapse();
             // Haptics content grid - the dim-and-disable half of that page's gate. It has to ask
             // the same question HapticsGate does, or the free day lifts the veil and leaves an
             // inert page underneath.

--- a/ConditioningControlPanel/Services/AutonomyService.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.cs
@@ -913,6 +913,18 @@ namespace ConditioningControlPanel.Services
                 App.Logger?.Debug("AutonomyService: CanTakeAction=false - not enabled");
                 return false;
             }
+
+            // Entitlement is re-checked live, not just in CanStart(): the ? box's free day can
+            // rotate out (or a subscription lapse) while the timers are armed, and CanStart()
+            // never runs again after Start(). Without this the takeover kept acting from behind
+            // the re-drawn padlock veil. Same OR as CanStart, or the two gates disagree.
+            var hasEntitlement = App.Patreon?.HasPremiumAccess == true
+                                 || App.DailyFree?.IsFreeToday("takeover") == true;
+            if (!hasEntitlement)
+            {
+                App.Logger?.Debug("AutonomyService: CanTakeAction=false - premium access lapsed");
+                return false;
+            }
             if (_isOnCooldown)
             {
                 App.Logger?.Debug("AutonomyService: CanTakeAction=false - on cooldown");

--- a/ConditioningControlPanel/Services/KeywordTriggerService.cs
+++ b/ConditioningControlPanel/Services/KeywordTriggerService.cs
@@ -265,6 +265,13 @@ namespace ConditioningControlPanel.Services
             var settings = App.Settings?.Current;
             if (settings == null || !settings.KeywordTriggersEnabled) return;
 
+            // Entitlement can lapse while the hook is live (the ? box's free day rotating out at
+            // midnight, a subscription expiring mid-session). Start() checks HasAccess() once and
+            // never again, so without this per-press re-check the feature kept firing from behind
+            // the re-drawn padlock veil - which also covers the OFF toggle (the "can't turn it
+            // off after it rotated" reports). Cheap: a dictionary lookup + cached tier flags.
+            if (!HasAccess()) return;
+
             // App scope, checked before the buffer rather than before the match. Dropping the
             // keystrokes is the point: if it only refused to FIRE, a keyword typed into a blocked
             // app would still be sitting in the rolling buffer, ready to go off the moment focus
@@ -868,6 +875,10 @@ namespace ConditioningControlPanel.Services
             NeedsOcrConfirmation = false;
 
             if (!_isActive || _disposed) return;
+            // Live entitlement re-check (see OnKeyPressed). Placed ahead of the token diagnostic
+            // below on purpose: once access has lapsed, the user's screen contents are none of our
+            // business - not even at log level.
+            if (!HasAccess()) return;
             if (allWords == null || allWords.Count == 0)
             {
                 _ocrSeenCounts.Clear();
@@ -1103,6 +1114,8 @@ namespace ConditioningControlPanel.Services
         {
             if (!_isActive || _disposed) return;
             if (string.IsNullOrEmpty(text)) return;
+            // Live entitlement re-check (see OnKeyPressed).
+            if (!HasAccess()) return;
 
             var settings = App.Settings?.Current;
             if (settings == null || !settings.KeywordTriggersEnabled) return;


### PR DESCRIPTION
## Problem (from user reports)

Users who enabled a premium pool feature on its free day (or on a sub that later expired) were stuck with it **still running** after the rotation - e.g. Awareness. Two stacked causes:

1. **Engines never re-check entitlement after Start().** `KeywordTriggerService` checks `HasAccess()` once in `Start()`; the keyboard hook and OCR paths kept firing after midnight rotated the free day away. `AutonomyService` same - `CanStart()` never runs again once the timers are armed.
2. **The padlock veil traps the OFF switch.** `RefreshEntitlementVeils` re-drops the full-page gate on rotation (#978's funnel), and the master toggle sits *under* the veil - so there was no reachable way to turn the feature off.

## Fix (+109 lines, no deletions)

- **`Services/KeywordTriggerService.cs`** - live `HasAccess()` re-check in all three fire paths (`OnKeyPressed`, `CheckOcrWords`, `CheckTextForMatches`). The OCR check sits ahead of the token diagnostic so a lapsed user's screen contents are not even logged.
- **`Services/AutonomyService.cs`** - `CanTakeAction()` re-checks the same premium-OR-free-today gate as `CanStart()`, covering both idle and random ticks. (HapticMixer already self-gated live via `IsGateOpen`.)
- **`MainWindow/MainWindow.Patreon.cs`** - new `EnforceEntitlementLapse()` at the top of `RefreshEntitlementVeils()` (the funnel that already runs on rotation, TierChanged, and every login/logout path). Any pool feature left enabled without access is switched off properly: settings flag flipped, runtime stopped, saved once, open-tab UI resynced. Covers Awareness (keyword + OCR + keyboard hook, panic-key hook preserved), Bambi Takeover, She's Listening, Haptics.

**New invariant: a veiled page never has its feature enabled behind it.**

## Safety

Startup-race safe by construction: `HasPremiumAccess` includes the 14-day grace stamp (`HasCachedPremiumAccess`), so an entitled subscriber never reads false before async validation lands - only genuinely lapsed users are flipped, and this path only ever writes `false`, never `true`.

Left alone deliberately: **Remote Control** (manual per-session hosting, already hard-gated at start; killing a live remote session at midnight would be worse) and **FYP** (no background runtime).

## Testing

- `dotnet build`: 0 errors (warnings pre-existing).
- Repro path: enable Awareness on its free day, roll past midnight (or wait for `TodayChanged`) - triggers stop firing immediately, and the funnel flips the toggle off + stops OCR/hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW3CBGmvoftRkuuPaUQRi