### PR TITLE
EMI field trips (W2a): apparate + POI registry + CRT power-off

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -291,7 +291,26 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                call site in shell.js is one unguarded line.
   widget.css   the layer (.arc-emi, fixed, z 50), the grab/grabbing cursors, the
                x affordance, the edge dock, and the bubble's `.bubble-left` /
-               `.bubble-low` flips (right margin / top edge).
+               `.bubble-low` flips (right margin / top edge). Plus THE CRT
+               POWER-OFF (`emi-crt-off` / `emi-crt-on`, 200ms each, and the
+               `.crt-blank` frame between them) - the field trip's transition.
+  fieldtrips.js THE ONE AUTONOMOUS VERB (W2a, 2026-08-24): the POI registry and
+               the scheduler that decides she may use it. `widget.apparate()` is
+               HOW a trip happens; this is WHEN, and it is FIVE gates - never
+               before session 3, at most one a sitting, one visit per fixture
+               for ever (voice.js's own `seen` ledger via `hasSeen`/`markSeen`),
+               the right screen with the fixture actually measurable, and truly
+               idle. It owns NO timer and NO observer: it is a passive
+               `offer(name, payload)` that `index.js` calls when the voice has
+               declined a moment, and the only moment it answers to is
+               `idlePlayer` - which campus.js already fires on its attract
+               loop's own idle edge ("a mascot does not get a second idle
+               timer"). At rest the file measures nothing and costs nothing.
+               Six POIs, all campus scenery that `campus.update()` never
+               rebuilds; the Records door and every other `.facility` is OUT,
+               the same geofence voice.js keeps. The LINES are barks.js's
+               `FIELD_TRIPS` table, keyed by `lineKey`; a key with no row is a
+               POI that never travels.
 ```
 
 Each game owns its own lexicon rows; **`ArcademyHostService.NeutralLexicon` mirrors every
@@ -470,6 +489,27 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
   a hide/show/destroy flushes immediately, and `pagehide` banks the last stretch of
   `msVisible`). A drag that wrote per frame would post sixty meta-commands a second across
   the bridge.
+- **`widget.apparate(getRect, {line, face, onDone})` IS THE WHOLE FIELD TRIP, and it
+  takes a GETTER** (W2a, 2026-08-24). Power-off where she stands -> reappear beside the
+  fixture -> land the line through the ordinary say path -> power off -> home. It returns
+  a cancel function, or **null** when she refused, and she refuses over every live verb
+  she has: mid-say, mid-chain, mid-press, mid-drag, dismissed, disabled, or already
+  travelling. So a caller needs no guard of its own - `emi/fieldtrips.js` deliberately
+  tests none of them twice.
+  - **The saved spot is never written.** A trip moves `el.style.left/top` and never
+    `fx0`/`fy0`, so "come home" is just `place()`. The ONE exception is the touch cancel
+    (`{stay:true}`), which commits the spot she was actually standing on - from the trip's
+    own bookkeeping, never from `getBoundingClientRect` (trap 74).
+  - **`widget.setPoiRects(fn)`** is the other half: a function answering the live rects of
+    every registered fixture. The widget calls it ONCE per drag - never per pointermove -
+    and uses it for exactly one thing, the carried `*_*`.
+  - **The return is a MOMENT, not a callback into the script.** A completed trip fires
+    `fieldTripHome {id, lineKey}` through the ordinary `voiceMoment` path, which is what
+    lets story.js own beat `b28_first_trip` and its once-ever flag. A CANCELLED trip fires
+    nothing - she did not get home, so there is nothing to be pleased about.
+  - **`voice.hasSeen(id)` / `voice.markSeen(id)` / `voice.sessions`** are the three members
+    the scheduler borrows, and they exist so there is ONE ledger. A POI id is in the same
+    namespace as a beat id; the `trip_` prefix is what keeps them apart.
 - **The shell's EMI seams are six one-liners and every one of them is `fireMoment(...)`.**
   `shell.js` mounts once (before the first `showBoard()`, so the opening `greet` has a face to
   wear) and fires at: the board being ARRIVED at (not repainted), `startClass`, the graded
@@ -1161,6 +1201,41 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     moment call still returns `true` the instant the beat is consumed - assert on that,
     then await the lead before asserting the line. The perception suite
     (`test-perception.mjs`, session scratchpad) does exactly this for p06/b25.
+
+73. **A FIXTURE RECT CAPTURED AT SCHEDULE TIME IS A RECT THAT HAS MOVED, SO
+    `apparate` TAKES A GETTER AND NOT A RECT.** A field trip is offered on an idle
+    edge and lands two power-offs later, and in between the window can resize, the
+    campus can repaint, and the SVG plan re-solves everything on it (`campus.plan`
+    is `preserveAspectRatio="xMidYMid slice"`, so viewBox units do not map linearly
+    to the viewport and a 40px window change moves every fixture). `apparate`
+    therefore resolves the rect INSIDE the dark, one frame before she lands, and the
+    registry's `anchor` is a function returning a function for exactly that reason.
+    Two things fall out and both are deliberate: a fixture that has GONE by fire time
+    sends her straight home instead of parking her at (0,0), and a resize mid-trip
+    cancels it outright (the anchor she is standing at was solved against a viewport
+    that no longer exists). Passing a bare rect still works and is the bug this trap
+    is named for.
+74. **THE CRT KEYFRAME FILLS `forwards`, SO TAKING THE CLASS OFF IS NOT OPTIONAL -
+    AND A RECT READ MID-SQUISH IS A 1PX LINE.** `emi-crt-off`/`emi-crt-on` animate
+    `transform` on the `.emi` root, which is legal precisely because a CSS animation
+    out-ranks the dangle's inline `rotate` while it runs (trap 71). But `forwards`
+    means a class nobody removes WELDS `scaleY(1)` onto the root and the dangle
+    silently stops working for ever after - the same lesson `droop` taught `BODY_MS`.
+    Every exit from a trip goes through `crtClear()` for that reason. The twin half:
+    `getBoundingClientRect` reports the TRANSFORMED box, so a position read while the
+    squish is running is a 1px-tall line at the wrong top. The trip therefore keeps
+    its own `{left, top}` and commits THAT, and nothing in the ladder ever measures
+    her.
+75. **TOUCH ALWAYS WINS, AND "WINS" MEANS SHE STAYS WHERE SHE IS.** A pointerdown on
+    EMI at any point of a trip ends it on the spot - `onDown` cancels before it does
+    anything else, so the press carries straight on into an ordinary drag with no
+    stranded animation class, no protected say still holding the glass, and no
+    teleport. The cancel COMMITS the spot she was standing on, which is the half that
+    is easy to miss: leaving the trip's pixel position on the element without writing
+    the fractions means the next resize (or the next launch) snaps her back to where
+    the trip started, several seconds after the player put her somewhere else. The
+    other cancels - a dismiss, a disable, a destroy, a resize, the caller's own -
+    bring her HOME instead, because none of them is the player choosing a spot.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -544,4 +544,42 @@ export const TELEMETRY = Object.freeze({
   ])
 });
 
-export default { POOLS, RARE_DORK, TELEMETRY };
+/* ============================================================================
+ * D) FIELD TRIPS - one line per campus fixture, for the wave W2a trip.
+ *
+ * NOT A POOL, and the difference matters. A pool is dice: voice.js rolls odds,
+ * checks a floor and picks a line. A field trip has already been rationed by
+ * the time a line is wanted - one trip a session at most, never before the
+ * third, and every fixture is a once-ever - so the "pick" is just a lookup.
+ * `emi/fieldtrips.js` reads this table by `lineKey` and hands the string to
+ * `widget.apparate`, which lands it through the ordinary say path.
+ *
+ * A key with no row here is a POI that never travels. That is the correct
+ * failure: an unwritten line is silence, never an invented one.
+ *
+ * THE REGISTER IS SOMEBODY WHO LIVES HERE. She is not explaining the school to
+ * you; she is telling you the one thing she happens to know about something she
+ * goes past every night. Same fence as every line above: no acronym, no lab, no
+ * records room, no door.
+ *
+ * EVERY LINE BELOW IS A DRAFT. They were written at wiring time because the
+ * feature needed something in the bubble to test with, and they have not been
+ * through /emi-lines or the owner's read. Nothing here is locked the way the
+ * rows above this comment are locked.
+ * ==========================================================================*/
+export const FIELD_TRIPS = Object.freeze({
+  /* DRAFT: /emi-lines pass pending */
+  timetable: { t: "tomorrow is already up there. i had a look.", face: '(¬‿¬)' },
+  /* DRAFT: /emi-lines pass pending */
+  belltower: { t: "the bell runs four minutes fast and nobody fixes it.", face: '0_0' },
+  /* DRAFT: /emi-lines pass pending */
+  noticeboard: { t: "nobody has moved those four pins since i got here.", face: '._.' },
+  /* DRAFT: /emi-lines pass pending */
+  idcard: { t: "that photo is you on your first night here.", face: '^_^' },
+  /* DRAFT: /emi-lines pass pending */
+  homeroom: { t: "everyone starts in this room. i have watched all of them.", face: '(◠‿◠)' },
+  /* DRAFT: /emi-lines pass pending */
+  sortroom: { t: "they keep two piles in there and i would only use one.", face: '(◔_◔)' },
+});
+
+export default { POOLS, RARE_DORK, TELEMETRY, FIELD_TRIPS };

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/fieldtrips.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/fieldtrips.js
@@ -1,0 +1,412 @@
+/* ============================================================================
+ * emi/fieldtrips.js - THE POI REGISTRY AND THE SCHEDULER (wave W2a).
+ *
+ * `widget.apparate()` is HOW a trip happens. This file is WHEN, and the whole
+ * design brief for it is one sentence: a scripted rare delight, not wandering.
+ * If a player sees two of these in a night, or one on their first night, or one
+ * while a class is up, the feature has failed even though every frame of it
+ * rendered correctly.
+ *
+ * ---------------------------------------------------------------------------
+ * THE FIVE GATES, and each one is a different kind of no
+ *
+ *   1. NEVER BEFORE THE THIRD SESSION. `voice.sessions >= TRIP_FROM_SESSION`.
+ *      The counter is voice.js's - the same spine `sessionAtLeast` hangs off -
+ *      and it is read, never minted. A second counter in a second blob is how
+ *      two ledgers come to disagree about what night it is.
+ *   2. ONE TRIP PER SESSION. A module-scope count, deliberately NOT persisted:
+ *      "once a sitting" is a fact about this sitting.
+ *   3. ONE VISIT PER FIXTURE, FOR EVER. Through voice.js's `seen` ledger
+ *      (`hasSeen`/`markSeen`), which is the same map every one-shot beat uses.
+ *      A POI id is therefore in the same namespace as a beat id: keep the
+ *      `trip_` prefix and they cannot collide.
+ *   4. THE RIGHT SCREEN, AND THE FIXTURE ACTUALLY THERE. Each entry declares
+ *      the screen it lives on and answers a LIVE rect getter; the scheduler
+ *      measures at candidate time and drops anything with no box.
+ *   5. TRULY IDLE. No say, no chain, no press, not dismissed, not disabled,
+ *      page visible. Most of that is `apparate`'s own refusal - the widget owns
+ *      the truth about its own verbs - so this file asks about the two things
+ *      the widget cannot see: the document's visibility and the screen.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT WAKES IT, AND WHY IT IS NOT A TIMER
+ *
+ * There is NO interval and NO observer here, on purpose. The campus already
+ * emits the exact edge this feature wants: `campus.js` fires
+ * `fireMoment('idlePlayer', {where:'hub'})` when its attract loop decides the
+ * player has gone quiet ON THE CAMPUS, with the comment "a mascot does not get
+ * a second idle timer". So the scheduler is a passive `offer(name, payload)`
+ * that `emi/index.js` calls on that moment and nothing else. At rest this file
+ * costs nothing at all: no rects are measured, no callbacks are registered, and
+ * the registry is a frozen array nobody walks.
+ *
+ * The one thing it registers is `widget.setPoiRects` - a getter the widget
+ * calls ONCE per drag, for the carried `*_*`. That is also not a poll.
+ *
+ * ---------------------------------------------------------------------------
+ * THE REGISTRY
+ *
+ *   { id, screen, anchor(), lineKey, seenKey }
+ *
+ *   id       stable, `trip_<place>`.
+ *   screen   the shell screen this fixture lives on ('board' IS the campus).
+ *   sel      the CSS selector `anchor` is built from, carried as data so a suite
+ *            can audit what the registry actually points at (the `.facility`
+ *            audit below is the reason it exists - a closure cannot be read).
+ *   anchor   () => a LIVE rect getter, i.e. a function returning a function.
+ *            Two levels on purpose, and it is the wave's central trap (73):
+ *            `apparate` resolves the rect INSIDE the power-off, one frame
+ *            before she lands, because a rect measured when the trip was
+ *            offered has moved by the time the tube comes back on.
+ *   lineKey  a key in barks.js's FIELD_TRIPS table. No row = no trip.
+ *   seenKey  the ledger flag. Renaming one re-opens the visit. Don't.
+ *
+ * WHY THESE SIX. They are the fixtures that are always in the DOM on a campus
+ * that has booted at all: two HTML nodes the campus builds unconditionally (the
+ * timetable plaque, the student ID card), two pure-scenery SVG groups that
+ * `campus.update()` never rebuilds (the bell tower, the notice-board dressing),
+ * and the two class rooms whose `data-game` attribute campus.js declares
+ * update-stable. Everything volatile is out: the route stops are rebuilt on
+ * every update, the west-wing rooms do not exist unless Semester III opens, and
+ * a sealed wing changes class the night its semester does.
+ *
+ * AND THE ONE THAT IS OUT ON PURPOSE. Records is `g.campus-room.facility
+ * .records`, it is a perfectly stable node, and it is OFF LIMITS. voice.js's
+ * geofence (SILENT_TARGETS) has no "probably not" branch and neither does this
+ * file: EMI has no reaction to that door, so she does not go and stand next to
+ * it either. The Registrar and the Entrance Hall are the same `.facility` class
+ * with nothing to tell them apart, so they are out with it.
+ * ==========================================================================*/
+
+/* ---------------------- dials ------------------------------------------ */
+export const TRIP_DIALS = Object.freeze({
+  TRIP_FROM_SESSION: 3,     // gate 1: never on the first two sittings
+  TRIPS_PER_SESSION: 1,     // gate 2
+  TRIP_ODDS: 0.5,           // ...and even then, only half the eligible idles
+  MIN_ON_SCREEN_PX: 24,     // a fixture smaller than this is not somewhere to go
+});
+
+/** The moments this module is willing to be woken by. */
+export const TRIP_TRIGGERS = Object.freeze(['idlePlayer']);
+
+/** The moment fired when she gets HOME from a trip (story.js b28 rides it). */
+export const TRIP_HOME_MOMENT = 'fieldTripHome';
+
+/** The campus root. Present exactly while the campus screen is mounted. */
+const CAMPUS = '.campus-stage';
+
+/** One-shot `querySelector` -> rect, the house pattern (voice.js `hitTest`):
+ *  measure at event time inside a try/catch that answers null. */
+function bySelector(sel) {
+  return () => {
+    try {
+      if (typeof document === 'undefined' || !document.querySelector) return null;
+      const node = document.querySelector(sel);
+      if (!node || !node.getBoundingClientRect) return null;
+      return node.getBoundingClientRect();
+    } catch (e) { return null; }
+  };
+}
+
+/* ---------------------- the registry ----------------------------------- */
+export const POIS = Object.freeze([
+  {
+    // The hanging timetable plaque. A real <button>, built unconditionally.
+    id: 'trip_timetable',
+    screen: 'board',
+    sel: CAMPUS + ' .campus-boardtab',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'timetable',
+    seenKey: 'trip_timetable',
+  },
+  {
+    // The bell tower. Pure scenery: campus.update() never touches it.
+    id: 'trip_belltower',
+    screen: 'board',
+    sel: CAMPUS + ' g.campus-tower',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'belltower',
+    seenKey: 'trip_belltower',
+  },
+  {
+    // The Entrance Hall dressing - the felt board and its four pins. NOTE this
+    // is `campus-halldress`, the SCENERY group, and NOT the clickable hall,
+    // which is a `.facility` and geofenced.
+    id: 'trip_noticeboard',
+    screen: 'board',
+    sel: CAMPUS + ' g.campus-halldress',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'noticeboard',
+    seenKey: 'trip_noticeboard',
+  },
+  {
+    // The student ID card, bottom-left. HTML, always present.
+    id: 'trip_idcard',
+    screen: 'board',
+    sel: CAMPUS + ' .campus-idcard',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'idcard',
+    seenKey: 'trip_idcard',
+  },
+  {
+    // Room 101, Homeroom. A Semester I class, so it is dealt every night.
+    // `data-game` is the stable hook: update() rewrites the room's CLASS
+    // (open/retake/dark) and never the attribute.
+    id: 'trip_homeroom',
+    screen: 'board',
+    sel: CAMPUS + ' g.campus-room[data-game="daily_trigger"]',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'homeroom',
+    seenKey: 'trip_homeroom',
+  },
+  {
+    // Room 201, The Sorting Room. Semester II, so on a build with that semester
+    // closed the node is simply ABSENT - the rect getter answers null and the
+    // scheduler drops the entry. That is the gate working, not a bug.
+    id: 'trip_sortroom',
+    screen: 'board',
+    sel: CAMPUS + ' g.campus-room[data-game="sort"]',
+    anchor() { return bySelector(this.sel); },
+    lineKey: 'sortroom',
+    seenKey: 'trip_sortroom',
+  },
+]);
+
+/* ---------------------- helpers ---------------------------------------- */
+function isObj(v) { return !!v && typeof v === 'object' && !Array.isArray(v); }
+
+/** Is the page actually being looked at? An idle edge on a hidden tab is not
+ *  an audience, and a trip nobody saw still spends the POI for ever. */
+function pageVisible() {
+  try {
+    if (typeof document === 'undefined') return true;
+    if (typeof document.visibilityState !== 'string') return true;
+    return document.visibilityState === 'visible';
+  } catch (e) { return true; }
+}
+
+/** A rect big enough, and on screen enough, to be worth walking to. */
+function usableRect(r, minPx) {
+  if (!isObj(r)) return false;
+  const w = Number(r.width);
+  const h = Number(r.height);
+  if (!(w >= minPx) || !(h >= minPx)) return false;
+  let vw = 1280;
+  let vh = 800;
+  try {
+    if (typeof window !== 'undefined') {
+      vw = Number(window.innerWidth) || vw;
+      vh = Number(window.innerHeight) || vh;
+    }
+  } catch (e) { /* noop */ }
+  const left = Number(r.left);
+  const top = Number(r.top);
+  if (!Number.isFinite(left) || !Number.isFinite(top)) return false;
+  // Fully off one edge is not visible. Partly clipped is fine - she stands
+  // beside what IS on screen and apparate clamps her the rest of the way.
+  return left + w > 0 && top + h > 0 && left < vw && top < vh;
+}
+
+/* ============================================================================
+ * createFieldTrips
+ * ==========================================================================*/
+/**
+ * @param {Object} o
+ * @param {Object}   o.widget    the widget handle (apparate / setPoiRects / tripping)
+ * @param {Object=}  o.voice     emi/voice.js - the sessions counter and the seen ledger
+ * @param {Function=} o.screen   () => the shell's current screen name
+ * @param {Function=} o.fire     (name, payload) - how the return beat is announced
+ * @param {Object=}  o.lines     the FIELD_TRIPS table (injected; else barks.js)
+ * @param {Array=}   o.pois      the registry (injected; else POIS)
+ * @param {Function=} o.rng      () => 0..1
+ * @param {Object=}  o.dials
+ * @param {Function=} o.log
+ */
+export function createFieldTrips(o = {}) {
+  const say = typeof o.log === 'function' ? o.log : () => {};
+  const widget = o.widget;
+  if (!widget || typeof widget.apparate !== 'function') return null;
+
+  const D = Object.assign({}, TRIP_DIALS, isObj(o.dials) ? o.dials : {});
+  const rng = typeof o.rng === 'function' ? o.rng : Math.random;
+  const voice = isObj(o.voice) ? o.voice : null;
+  const fire = typeof o.fire === 'function' ? o.fire : () => false;
+  const screenOf = typeof o.screen === 'function' ? o.screen : null;
+
+  const pois = (Array.isArray(o.pois) ? o.pois : POIS).filter(
+    (p) => isObj(p) && typeof p.id === 'string' && typeof p.anchor === 'function');
+
+  /* THE LINES ARE OPTIONAL AND LATE, like every other data module in this
+   * folder (`loadOptional`'s discipline). A missing barks.js costs the trips
+   * and nothing else - a POI with no line simply never becomes a candidate. */
+  let LINES = isObj(o.lines) ? o.lines : null;
+  if (!LINES) {
+    import('./barks.js')
+      .then((m) => { if (m && isObj(m.FIELD_TRIPS)) LINES = m.FIELD_TRIPS; })
+      .catch((e) => say('emi trips: barks.js unavailable (' + ((e && e.message) || e) + ')'));
+  }
+
+  /* SESSION STATE, deliberately not persisted. "Once a sitting" is a fact about
+   * the sitting; banking it would make a reload the way to farm a second one. */
+  let tripsThisSession = 0;
+  let last = null;              // {id, at} - debug/read-only
+  let cancelLive = null;
+
+  function seen(key) {
+    if (!voice || typeof voice.hasSeen !== 'function') return false;
+    try { return !!voice.hasSeen(key); } catch (e) { return false; }
+  }
+  function bank(key) {
+    if (!voice || typeof voice.markSeen !== 'function') return false;
+    try { return !!voice.markSeen(key); } catch (e) { return false; }
+  }
+  function sessions() {
+    if (!voice) return 0;
+    const n = Number(voice.sessions);
+    return Number.isFinite(n) ? n : 0;
+  }
+  function lineFor(key) {
+    if (!LINES || typeof key !== 'string') return null;
+    const row = Object.prototype.hasOwnProperty.call(LINES, key) ? LINES[key] : null;
+    if (!isObj(row) || typeof row.t !== 'string' || !row.t.trim()) return null;
+    return row;
+  }
+
+  /** Gate 4a: is this POI's screen the one that is up? With no screen getter
+   *  the campus root itself answers - it is in the DOM exactly while it is up. */
+  function onScreen(p) {
+    if (screenOf) {
+      let cur = null;
+      try { cur = screenOf(); } catch (e) { cur = null; }
+      if (typeof cur === 'string' && cur !== p.screen) return false;
+    }
+    return true;
+  }
+
+  /**
+   * EVERY POI THAT COULD BE VISITED RIGHT NOW, measured. This is the only place
+   * that touches the DOM, and it runs only on an offered idle edge.
+   */
+  function candidates() {
+    const out = [];
+    for (const p of pois) {
+      if (seen(p.seenKey || p.id)) continue;
+      if (!lineFor(p.lineKey)) continue;
+      if (!onScreen(p)) continue;
+      let get = null;
+      try { get = p.anchor(); } catch (e) { continue; }
+      if (typeof get !== 'function') continue;
+      let r = null;
+      try { r = get(); } catch (e) { continue; }
+      if (!usableRect(r, D.MIN_ON_SCREEN_PX)) continue;
+      out.push({ poi: p, get });
+    }
+    return out;
+  }
+
+  /** Everything the WIDGET needs for the carried `*_*`: live rects, no gating.
+   *  A fixture she has already visited is still a fixture she likes. */
+  function poiRects() {
+    const out = [];
+    for (const p of pois) {
+      let get = null;
+      try { get = p.anchor(); } catch (e) { continue; }
+      if (typeof get !== 'function') continue;
+      let r = null;
+      try { r = get(); } catch (e) { continue; }
+      if (r && Number(r.width) > 0 && Number(r.height) > 0) out.push(r);
+    }
+    return out;
+  }
+  try { widget.setPoiRects(poiRects); } catch (e) { /* noop */ }
+
+  /** Force one, ignoring the dice and the session cap. Test/debug seam. */
+  function go(id) {
+    const list = candidates();
+    const pick = list.find((c) => c.poi.id === id) || null;
+    return pick ? launch(pick) : false;
+  }
+
+  function launch(c) {
+    const row = lineFor(c.poi.lineKey);
+    if (!row) return false;
+    const key = c.poi.seenKey || c.poi.id;
+    /* THE LEDGER IS BANKED ON DEPARTURE, NOT ON ARRIVAL. A trip that is
+     * cancelled half way (a finger, a resize) still SHOWED the player the
+     * power-off, and re-offering the same fixture ten seconds later would read
+     * as a stutter, not as a second chance. One offer, one fixture, for ever. */
+    const cancel = widget.apparate(c.get, {
+      line: row.t,
+      face: row.face,
+      onDone: (info) => {
+        cancelLive = null;
+        if (info && info.cancelled) return;
+        /* HOME AGAIN. The beat rides the ordinary moment path, so voice.js owns
+         * whether b28 is spent - this file never writes a story flag. */
+        try { fire(TRIP_HOME_MOMENT, { id: c.poi.id, lineKey: c.poi.lineKey }); }
+        catch (e) { /* a mascot may never break a screen transition */ }
+      },
+    });
+    if (!cancel) return false;
+    bank(key);
+    tripsThisSession += 1;
+    cancelLive = cancel;
+    last = { id: c.poi.id, at: Date.now() };
+    say('emi trips: ' + c.poi.id);
+    return true;
+  }
+
+  /**
+   * THE ONE ENTRY POINT. `emi/index.js` offers every moment; this answers true
+   * only when it actually launched a trip, which is the caller's signal that the
+   * wordless reaction for that moment should stand down (EMI is not there to
+   * make a face - she is on her way across the quad).
+   */
+  function offer(name, payload) {
+    try {
+      if (typeof name !== 'string' || TRIP_TRIGGERS.indexOf(name) < 0) return false;
+      if (tripsThisSession >= D.TRIPS_PER_SESSION) return false;
+      if (sessions() < D.TRIP_FROM_SESSION) return false;
+      if (!pageVisible()) return false;
+      // The widget refuses over any live verb of its own (say, chain, press,
+      // drag, dock, disabled, a trip already running) - one owner of that truth.
+      if (typeof widget.tripping === 'function' && widget.tripping()) return false;
+      void payload;
+      const list = candidates();
+      if (!list.length) return false;
+      if (D.TRIP_ODDS < 1 && rng() >= D.TRIP_ODDS) return false;
+      const pick = list[Math.min(list.length - 1, Math.floor(rng() * list.length))];
+      return launch(pick);
+    } catch (e) {
+      say('emi trips: offer threw (ignored) - ' + ((e && e.message) || e));
+      return false;
+    }
+  }
+
+  return {
+    offer,
+    go,
+    /** Live rects for every registered fixture (the widget's drag probe). */
+    poiRects,
+    /** Read-only: what could be visited right now, by id. */
+    candidates() { return candidates().map((c) => c.poi.id); },
+    /** Abort a trip in flight; she comes home. */
+    cancel() {
+      if (typeof cancelLive !== 'function') return false;
+      const fn = cancelLive;
+      cancelLive = null;
+      try { fn(); } catch (e) { /* noop */ }
+      return true;
+    },
+    get tripping() { return typeof widget.tripping === 'function' ? widget.tripping() : false; },
+    state() { return { trips: tripsThisSession, last: last ? Object.assign({}, last) : null }; },
+    dials: D,
+    destroy() {
+      try { if (cancelLive) cancelLive(); } catch (e) { /* noop */ }
+      cancelLive = null;
+      try { widget.setPoiRects(null); } catch (e) { /* noop */ }
+    },
+  };
+}
+
+export default createFieldTrips;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
@@ -26,6 +26,8 @@ export { DIALS, HINT_LINE, STORE_KEY, sayHoldMs, SAY_LEAD_MS };
 
 let singleton = null;
 let voice = null;
+/** emi/fieldtrips.js, once the voice it reads has landed. Null is normal. */
+let trips = null;
 let voicePending = null;
 /** () => bool: can EMI actually PERFORM right now (is her face attached). */
 let voiceGate = null;
@@ -52,6 +54,9 @@ export function getEmi() { return singleton; }
 /** The voice (emi/voice.js), once it has loaded. Null is the normal answer. */
 export function getVoice() { return voice; }
 
+/** The field-trip scheduler (emi/fieldtrips.js), once it has loaded. */
+export function getTrips() { return trips; }
+
 /**
  * ASK THE VOICE, SAFELY. `moments.js` routes every moment through here before
  * it reaches the wordless table.
@@ -65,7 +70,19 @@ export function getVoice() { return voice; }
  */
 export function voiceMoment(name, payload) {
   try {
-    if (voice && voice.ready && (!voiceGate || voiceGate())) return !!voice.onMoment(name, payload);
+    if (voice && voice.ready && (!voiceGate || voiceGate())) {
+      if (voice.onMoment(name, payload)) return true;
+      /* ...AND THEN THE FIELD TRIP (wave W2a). Asked LAST and only about the
+       * moments it declares, so a night with a line in it is never also a night
+       * she walks off in the middle of one. A launched trip answers true the
+       * same way a spoken line does: the wordless table stands down, because
+       * EMI is not there to make a face - she is on her way across the quad.
+       * The trips module is asked through the same wrapper the voice is, so a
+       * scheduler that throws can no more reach a screen transition than a
+       * decision engine that does. */
+      if (trips) return !!trips.offer(name, payload);
+      return false;
+    }
     if (singleton) voicePending = { name, payload, when: Date.now() };
   } catch (e) { /* a mascot may never break a screen transition */ }
   return false;
@@ -215,6 +232,8 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
 
     /** The decision engine, once it has loaded. A test/debug handle only. */
     get voice() { return voice; },
+    /** The field-trip scheduler (W2a), once it has loaded. Test/debug only. */
+    get trips() { return trips; },
     /** Debug: the one moment waiting on the voice + the face, by name. */
     get pendingMoment() { return voicePending ? voicePending.name : null; },
 
@@ -223,10 +242,12 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
 
     destroy() {
       try { widget.destroy(); } catch (e) { /* noop */ }
+      try { if (trips) trips.destroy(); } catch (e) { /* noop */ }
       try { if (voice) voice.destroy(); } catch (e) { /* noop */ }
       try { if (vox) vox.destroy(); } catch (e) { /* noop */ }
       vox = null;
       voice = null;
+      trips = null;
       voicePending = null;
       voiceGate = null;
       if (singleton === api) singleton = null;
@@ -255,6 +276,22 @@ export function mountEmi({ layer, store, toast, enabled = true, log } = {}) {
       log: say,
     });
     flushVoice();
+    /* THE FIELD TRIPS, ONE MORE STEP OUT (wave W2a). Loaded after the voice
+     * because it reads the voice's session counter and writes the voice's seen
+     * ledger, and optionally for the same reason everything else in this file
+     * is optional: a broken scheduler costs EMI one rare delight, never her
+     * face, her verbs or the shell's boot. */
+    import('./fieldtrips.js').then((f) => {
+      if (singleton !== api || !f || typeof f.createFieldTrips !== 'function') return;
+      trips = f.createFieldTrips({
+        widget,
+        voice,
+        // The return beat rides the ordinary moment path, so story.js owns
+        // whether b28 is spent and this module never writes a story flag.
+        fire: (n, p) => voiceMoment(n, p),
+        log: say,
+      });
+    }).catch((e) => { say('emi: fieldtrips.js unavailable (' + ((e && e.message) || e) + ')'); });
   }).catch((e) => { say('emi: voice.js unavailable (' + ((e && e.message) || e) + ')'); });
 
   return api;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
@@ -663,6 +663,26 @@ export const BEATS = deepFreeze([
   },
 
   {
+    // Beat 28. THE FIRST FIELD TRIP, and it fires on the RETURN, never on the
+    // arrival - the trip's own line is about the fixture, and this one is about
+    // having gone at all. Priority 92 sits it under the anniversary (96) and
+    // the long-absence return (95) and over every ordinary ceremony, which is
+    // the right order: a calendar year and a three-day silence are both bigger
+    // than a first walk across the quad, and everything else that night is
+    // smaller. There is deliberately no b29 - every LATER trip says only the
+    // fixture's own line, so the novelty is spent exactly once.
+    // DRAFT: /emi-lines pass pending
+    id: 'b28_first_trip',
+    phase: 'AMB',
+    on: 'fieldTripHome',
+    requires: ['b02_hello'],
+    priority: 92,
+    lead: 'wink',
+    say: 'i did not know i could leave the corner.',
+    face: '^_^'
+  },
+
+  {
     // A CALENDAR year since her first day - `calendarDaysAtLeast`, not `days`,
     // which only counts days played. Small on purpose: a party would make the
     // number feel watched, and the number is the one thing she never explains.

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
@@ -1040,6 +1040,28 @@ export function createVoice(o) {
       return blob.labSeen;
     },
     get labSeen() { return blob.labSeen; },
+
+    /* ---- THE FIELD-TRIP SEAM (wave W2a, 2026-08-24) --------------------
+     * A trip is not a moment: the line is landed by `widget.apparate`, not by
+     * the ladder in this file, so `emi/fieldtrips.js` cannot spend a one-shot
+     * through `fireBeat`. It needs the same LEDGER though - one POI, one
+     * visit, for ever - and minting a second seen-map beside this one is how
+     * two ledgers disagree. So the trips module reads and writes THIS one, by
+     * these three members and nothing else. `sessions` is exposed for the same
+     * reason: `state()` answers a deep JSON copy of the whole blob, which is a
+     * silly price for one integer a scheduler asks for on an idle edge. */
+    /** Has this id already fired? (Beat ids and POI ids share the namespace.) */
+    hasSeen(id) { return !!blob.seen[String(id)]; },
+    /** Bank one. Returns false when it was already banked - the caller's guard. */
+    markSeen(id) {
+      const k = String(id);
+      if (!k || blob.seen[k]) return false;
+      blob.seen[k] = true;
+      touch();
+      return true;
+    },
+    /** How many times EMI has been mounted, ever. The `sessionAtLeast` spine. */
+    get sessions() { return blob.sessions; },
     /** Test seams. A suite that rolls dice must not flake. */
     setRng(fn) { if (typeof fn === 'function') rng = fn; },
     setClock(fn) { if (typeof fn === 'function') clock = fn; },

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -171,3 +171,67 @@
 }
 :root.arc-reduced .arc-emi .emi-dock:hover,
 :root.arc-reduced .arc-emi .emi-dock:focus-visible { transform: none; }
+
+/* ---- THE FIELD TRIP: the CRT power-off ---------------------------------
+ * W2a (2026-08-24). EMI's one autonomous verb is a TRIP: she powers her tube
+ * off, reappears beside a campus fixture, says one line about it, powers off
+ * again and comes home. This is the transition, and it is a CRT losing its
+ * deflection: the picture squishes to a bright horizontal LINE (~140 ms), the
+ * line collapses to a DOT and flashes out (~60 ms). Power-on is the same
+ * timeline read backwards.
+ *
+ * IT IS A KEYFRAME, DELIBERATELY (trap 71 + the new trap 73). The `.emi` root's
+ * INLINE transform belongs to the dangle, so a transition or an inline
+ * transform here would fight the carry tilt for the root every time a trip and
+ * a drag overlapped. CSS animations out-rank inline styles for as long as they
+ * run, which is exactly why the squish is allowed to own the root and the
+ * dangle is not disturbed by it.
+ *
+ * THE DURATIONS BELOW ARE THE CONTRACT. `widget.js DIALS.CRT_MS` mirrors the
+ * 200 ms, the same way `BODY_MS` mirrors emi.css's body-move keyframes: this
+ * file owns the animation, that file owns how long it waits for it. Change one
+ * and change the other, or she moves before the tube has gone dark.
+ *
+ * The origin moves to the CENTRE for the collapse. `.emi` rests at 50% 100%
+ * (the body moves pivot on her feet) and a tube that collapsed to its feet
+ * would read as a trapdoor, not as a power cut. */
+@keyframes emi-crt-off {
+  0%   { transform: scaleY(1)    scaleX(1);    filter: none; opacity: 1; }
+  70%  { transform: scaleY(.008) scaleX(1.03); filter: brightness(3.2) saturate(.2); opacity: 1; }
+  85%  { transform: scaleY(.008) scaleX(.08);  filter: brightness(4.5) saturate(0);  opacity: 1; }
+  100% { transform: scaleY(.008) scaleX(0);    filter: brightness(4.5) saturate(0);  opacity: 0; }
+}
+@keyframes emi-crt-on {
+  0%   { transform: scaleY(.008) scaleX(0);    filter: brightness(4.5) saturate(0);  opacity: 0; }
+  15%  { transform: scaleY(.008) scaleX(.08);  filter: brightness(4.5) saturate(0);  opacity: 1; }
+  30%  { transform: scaleY(.008) scaleX(1.03); filter: brightness(3.2) saturate(.2); opacity: 1; }
+  100% { transform: scaleY(1)    scaleX(1);    filter: none; opacity: 1; }
+}
+.arc-emi .emi.crt-off,
+.arc-emi .emi.crt-on {
+  transform-origin: 50% 50%;
+  pointer-events: none;          /* mid-collapse she is a 1px line: nothing to grab */
+}
+.arc-emi .emi.crt-off { animation: emi-crt-off 200ms linear forwards; }
+.arc-emi .emi.crt-on  { animation: emi-crt-on  200ms linear forwards; }
+
+/* BETWEEN THE TWO she is nowhere, and `visibility` is how she gets there.
+ * NOT `display` and NOT the hidden attribute: `hidden` is the DOCK's state and
+ * widget.js reads `el.hidden` as "dismissed by the player" in five places, so
+ * borrowing it for a 40 ms teleport would make a trip look like a dismissal. */
+.arc-emi .emi.crt-blank {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* REDUCED MOTION: no squish, no flash. She is simply not there and then she is,
+ * which is the same beat with the animation taken out - the widget skips the
+ * waits to match (widget.js `reducedMotion()` in the trip ladder). */
+@media (prefers-reduced-motion: reduce) {
+  .arc-emi .emi.crt-off,
+  .arc-emi .emi.crt-on { animation: none; }
+  .arc-emi .emi.crt-off { visibility: hidden; }
+}
+:root.arc-reduced .arc-emi .emi.crt-off,
+:root.arc-reduced .arc-emi .emi.crt-on { animation: none; }
+:root.arc-reduced .arc-emi .emi.crt-off { visibility: hidden; }

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -80,6 +80,13 @@ export const DIALS = Object.freeze({
   SAY_HOLD_BASE_MS: 1400,  // ...and a long one grows: BASE + PER_CHAR x length
   SAY_HOLD_PER_CHAR_MS: 45,
 
+  /* --- the field trip (wave W2a) --------------------------------------- */
+  CRT_MS: 200,             // ONE power-off: squish to a line (~140) + flash dot (~60).
+                           // MIRRORS widget.css `emi-crt-off`/`emi-crt-on`, the way
+                           // BODY_MS mirrors emi.css. Change both or she moves in the light.
+  TRIP_GAP_PX: 14,         // px she stands off the fixture she came to look at
+  TRIP_BEAT_MS: 320,       // the pause after the line, before the tube goes dark again
+
   /* --- persistence ----------------------------------------------------- */
   SAVE_DEBOUNCE_MS: 600,   // one write per interaction, never per pointermove
 });
@@ -899,6 +906,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     dragTold = false;
     disarmHold();
     clearDangle(true);
+    poiForget();                     // W2a: the drag's fixture snapshot dies with the drag
     el.classList.remove('dragging', 'armed');
   }
 
@@ -911,6 +919,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
 
   function onDown(ev) {
     if (!enabled || hidden) return;
+    /* TOUCH ALWAYS WINS (W2a, trap 75). A finger on her at ANY point of a field
+     * trip ends it on the spot - she stays where the trip had put her, upright,
+     * and the press below carries on into a perfectly ordinary drag. */
+    cancelTrip({ stay: true });
     // The x is a real button: let it have its own click, and never start a drag
     // from it (a dismiss that could turn into a fling is a trap, not a feature).
     if (inX(ev)) return;
@@ -945,7 +957,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     el.classList.add('dragging');
     // The reaction is a raw face, not a chain: a chain would fight the next
     // frame of movement. A live SAY keeps the glass (law 3).
-    if (!saying()) { cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody(); setDragFace(DRAG_FACE); }
+    poiSnapshot();                   // W2a: measure the fixtures ONCE, not per move
+    if (!saying()) { cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody(); setDragFace(carryFace()); }
   }
 
   function onMove(ev) {
@@ -983,7 +996,19 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
         else if (t - fastSince > DIALS.FLING_MS && !saying()) { wasFling = true; setDragFace(FLING_FACE); }
       } else if (fastSince) {
         fastSince = 0;
-        if (!saying()) setDragFace(DRAG_FACE);
+        if (!saying()) setDragFace(carryFace());
+      }
+
+      /* FIELD-TRIP ANTICIPATION (W2a). Carried over a fixture she has a line
+       * about, she lights up. ENTER/LEAVE ONLY: the rects were measured once at
+       * beginDrag and the repaint rides setDragFace's dedupe, so a pointermove
+       * over open ground costs a handful of number compares and nothing else. */
+      if (poiCache) {
+        const onPoi = overPoi(left, top);
+        if (onPoi !== poiOver) {
+          poiOver = onPoi;
+          if (!saying() && dragFace !== FLING_FACE) setDragFace(carryFace());
+        }
       }
 
       // THE DANGLE: lean against the travel, clamped and smoothed. Style is
@@ -1121,6 +1146,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     // A live press has to be let go BEFORE she goes: a latched drag would let the
     // next pointerup commit a position read off a display:none element.
     endPress();
+    cancelTrip();                    // W2a: dismissed mid-trip = home first, then the dock
     cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody(); setBubble(null);
     clearApproachTimers();
     restGaze();
@@ -1295,6 +1321,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   // Seeded from the boot-time window: a page that OPENS narrow never "squished".
   let wasNarrowVp = viewport().w < DIALS.W_NARROW_VW;
   function onResize() {
+    /* A RESIZE MOVED THE FIXTURE (W2a, trap 73). The anchor she is standing at
+     * was solved against the old viewport, so the trip is over: she goes home
+     * and the scheduler may offer another one later. */
+    cancelTrip();
     refitWidth();
     if (!hidden && enabled) place();
     // THE SQUISH: crossing into the narrow-window regime, once per crossing.
@@ -1317,6 +1347,335 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   if (typeof window !== 'undefined' && window.addEventListener) {
     window.addEventListener('pagehide', onPageHide);
   }
+
+
+  /* ========================================================================
+   * THE FIELD TRIP (wave W2a, 2026-08-24) - EMI'S ONE AUTONOMOUS VERB
+   *
+   * Everything this wave adds to the widget lives between these two rules,
+   * deliberately: `feat/emi-off-channels` is editing this file at the same
+   * time. The only code outside the block is eight one-line hooks, each marked
+   * `W2a` - endPress, onDown, beginDrag, onMove, hide, onResize, setEnabled,
+   * destroy - plus three members on the handle.
+   *
+   * WHAT A TRIP IS. She powers her tube off where she stands, reappears beside
+   * a campus fixture, says one line about it, powers off again and comes back
+   * to the player's saved spot. It is a scripted rare delight and NOT wandering:
+   * WHEN it may happen is `emi/fieldtrips.js`'s problem, and it is the only
+   * caller. This file owns HOW, and the how is four laws:
+   *
+   *   1. THE RECT IS RESOLVED AT FIRE TIME, NEVER AT SCHEDULE TIME. Screens
+   *      resize, the campus repaints, the plan is `xMidYMid slice` - a rect
+   *      captured when the trip was queued is a rect that has moved by the
+   *      time she gets there. `apparate` therefore takes a GETTER and calls it
+   *      inside the dark, one frame before she lands. See trap 73.
+   *   2. TOUCH ALWAYS WINS. A pointerdown on her at any point of the ladder
+   *      ends the trip on the spot: she stays where she is, upright, with no
+   *      stranded animation class, and the press carries on into an ordinary
+   *      drag. Trap 75.
+   *   3. SHE NEVER STARTS ONE OVER HERSELF. Mid-say, mid-chain, mid-press,
+   *      dismissed, disabled or already travelling, `apparate` refuses and
+   *      answers null. The caller does not need a guard.
+   *   4. THE SAVED SPOT IS NEVER WRITTEN. The trip moves `el.style.left/top`
+   *      and never `fx0`/`fy0`, so "come home" is just `place()` and a crash,
+   *      a reload or a cancel can never lose where the player put her. The one
+   *      exception is the touch cancel, which commits the spot she was ACTUALLY
+   *      standing on - from the trip's own bookkeeping, never from
+   *      `getBoundingClientRect`, which mid-squish reports a 1px line.
+   * ======================================================================*/
+
+  /** The carried face over a registered fixture: pure delight. `*_*` is already
+   *  paired to the `pet` pose in FACE_BODY_FRAME, so the body follows for free. */
+  const POI_FACE = '*_*';
+
+  /** Normalise anything rect-shaped (a DOMRect, a plain object, a getter's
+   *  answer) into our own numbers, or null. Never throws on junk. */
+  function rectNow(src) {
+    let r = null;
+    try { r = typeof src === 'function' ? src() : src; } catch (e) { return null; }
+    if (!r || typeof r !== 'object') return null;
+    const left = num(r.left);
+    const top = num(r.top);
+    if (left === null || top === null) return null;
+    let w = num(r.width);
+    let h = num(r.height);
+    if (w === null) { const rt = num(r.right); w = rt === null ? null : rt - left; }
+    if (h === null) { const bt = num(r.bottom); h = bt === null ? null : bt - top; }
+    if (w === null || h === null || !(w > 0) || !(h > 0)) return null;
+    return { left, top, width: w, height: h, right: left + w, bottom: top + h };
+  }
+
+  /** How much of her box would sit on top of the fixture, in square px. */
+  function overlapArea(left, top, s, rect) {
+    const ox = Math.min(left + s.w, rect.right) - Math.max(left, rect.left);
+    const oy = Math.min(top + s.h, rect.bottom) - Math.max(top, rect.top);
+    return (ox > 0 && oy > 0) ? ox * oy : 0;
+  }
+
+  /**
+   * WHERE SHE STANDS TO LOOK AT SOMETHING. Four candidates - right, left, under,
+   * over - each clamped into the viewport and then scored. The clamp runs BEFORE
+   * the overlap test on purpose: against a fixture in the corner the clamp is
+   * what drags a candidate back over the very thing she came to see, and a test
+   * on the raw candidate would never notice.
+   */
+  function anchorFor(rect) {
+    const vp = viewport();
+    const s = sizePx();
+    const g = DIALS.TRIP_GAP_PX;
+    const lo = DIALS.MARGIN;
+    const maxX = Math.max(lo, vp.w - s.w - lo);
+    const maxY = Math.max(lo, vp.h - s.h - lo);
+    const midY = rect.top + rect.height / 2 - s.h / 2;
+    const midX = rect.left + rect.width / 2 - s.w / 2;
+    const cands = [
+      { left: rect.right + g, top: midY },
+      { left: rect.left - g - s.w, top: midY },
+      { left: midX, top: rect.bottom + g },
+      { left: midX, top: rect.top - g - s.h },
+    ];
+    let best = null;
+    for (const c of cands) {
+      const left = Math.round(clamp(c.left, lo, maxX));
+      const top = Math.round(clamp(c.top, lo, maxY));
+      const over = overlapArea(left, top, s, rect);
+      const pushed = Math.abs(left - c.left) + Math.abs(top - c.top);
+      // Clean beats compromised; among compromises, least overlap then least
+      // clamping. There is ALWAYS an answer - a mascot with nowhere to stand
+      // would be a trip that hangs half way through.
+      if (!best || over < best.over || (over === best.over && pushed < best.pushed)) {
+        best = { left, top, over, pushed };
+      }
+      if (over === 0 && pushed < 1) break;
+    }
+    return { left: best.left, top: best.top };
+  }
+
+  /* ---- the drag's fixture snapshot ------------------------------------ */
+  /* MEASURED ONCE PER DRAG, NEVER PER MOVE. A getBoundingClientRect for every
+   * registered fixture on every pointermove is the same mistake the drag-face
+   * dedupe exists to prevent, multiplied by the size of the registry - and a
+   * drag cannot resize the window, so one snapshot is also the correct answer. */
+  let poiRectsFn = null;
+  let poiCache = null;
+  let poiOver = false;
+
+  function poiForget() { poiCache = null; poiOver = false; }
+
+  function poiSnapshot() {
+    poiForget();
+    if (!poiRectsFn) return;
+    let list = null;
+    try { list = poiRectsFn(); } catch (e) { return; }
+    if (!Array.isArray(list) || !list.length) return;
+    const out = [];
+    for (const r of list) { const n = rectNow(r); if (n) out.push(n); }
+    if (out.length) poiCache = out;
+  }
+
+  /** Is her CENTRE inside one of the snapshotted fixtures? */
+  function overPoi(left, top) {
+    if (!poiCache) return false;
+    const s = sizePx();
+    const cx = left + s.w / 2;
+    const cy = top + s.h / 2;
+    for (const r of poiCache) {
+      if (cx >= r.left && cx <= r.right && cy >= r.top && cy <= r.bottom) return true;
+    }
+    return false;
+  }
+
+  /** The face a CARRY currently wears, fixture or not. The fling face outranks
+   *  both while it lasts; this is only what she falls back to. */
+  function carryFace() { return poiOver ? POI_FACE : DRAG_FACE; }
+
+  /* ---- the tube ------------------------------------------------------- */
+  /* THE POWER-OFF IS A KEYFRAME AND THAT IS THE WHOLE ARGUMENT (trap 71). The
+   * `.emi` root's INLINE transform belongs to the dangle; a CSS animation
+   * out-ranks an inline style for as long as it runs, which is exactly why the
+   * squish is allowed to own the root and the carry tilt is not disturbed.
+   * The reflow is trap 4's lesson: re-adding the same class without one is a
+   * keyframe the browser coalesces away. */
+  function crtClear() {
+    try {
+      el.classList.remove('crt-off');
+      el.classList.remove('crt-on');
+      el.classList.remove('crt-blank');
+    } catch (e) { /* noop */ }
+  }
+  function crt(cls) {
+    crtClear();
+    if (!cls) return;
+    try { void el.offsetWidth; el.classList.add(cls); } catch (e) { /* noop */ }
+  }
+  /** 0 under reduced motion: the CSS drops the squish, so waiting for it would
+   *  only be a pause in an empty room. */
+  function crtMs() { return reducedMotion() ? 0 : DIALS.CRT_MS; }
+
+  /* ---- the trip ------------------------------------------------------- */
+  /* {timer, left, top, onDone} - `left`/`top` are the trip's OWN bookkeeping of
+   * where it last put her, because a rect read mid-squish is a 1px line. */
+  let trip = null;
+
+  function tripping() { return !!trip; }
+
+  /** One step at a time, on a timer this trip owns. NOT `later()`: the say in
+   *  the middle goes through `play()`, and `play()` calls `killTimers()`. */
+  function tripStep(ms, fn) {
+    if (!trip) return;
+    if (trip.timer !== null) clearTimeout(trip.timer);
+    const mine = trip;
+    trip.timer = setTimeout(() => {
+      if (trip !== mine) return;
+      trip.timer = null;
+      try { fn(); }
+      catch (e) { say('emi: trip step threw - ' + ((e && e.message) || e)); cancelTrip(); }
+    }, Math.max(0, ms));
+  }
+
+  /** Move her for the TRIP only: style plus the bubble flip, never the fractions. */
+  function tripPlaceAt(left, top) {
+    const vp = viewport();
+    const s = sizePx();
+    if (trip) { trip.left = left; trip.top = top; }
+    try {
+      el.style.left = Math.round(left) + 'px';
+      el.style.top = Math.round(top) + 'px';
+    } catch (e) { /* noop */ }
+    faceBubble(left, top, s.w, vp.w);
+  }
+
+  /**
+   * END A TRIP. Two shapes and they are genuinely different:
+   *   cancelTrip()            -> she comes HOME (a dismiss, a resize, a disable,
+   *                              a destroy, the caller's own cancel)
+   *   cancelTrip({stay:true}) -> she stops WHERE SHE IS and that spot becomes
+   *                              hers (a finger landed on her: trap 75)
+   * Both clear every animation class and every protected say, so whatever
+   * happens next starts from a mascot in a known state.
+   */
+  function cancelTrip(opts) {
+    if (!trip) return false;
+    const t = trip;
+    trip = null;
+    if (t.timer !== null) { clearTimeout(t.timer); t.timer = null; }
+    /* THE FILL IS FORWARDS, SO TAKING THE CLASS OFF IS NOT OPTIONAL (trap 74).
+     * A welded `scaleY(1)` would out-rank the dangle's inline rotate for ever. */
+    crtClear();
+    cancelChain();
+    killTimers();
+    setBubble(null);
+    const stay = !!(opts && opts.stay);
+    if (stay) { commit(t.left, t.top); save(); }
+    else place();
+    if (typeof t.onDone === 'function') {
+      try { t.onDone({ cancelled: true, stay }); } catch (e) { /* noop */ }
+    }
+    idle();
+    return true;
+  }
+
+  /**
+   * APPARATE: the whole trip, as one call.
+   *
+   * @param {Function|Object} getRect  a RECT-GETTER, e.g.
+   *        `() => node.getBoundingClientRect()`. A bare rect is accepted and is
+   *        a bug waiting to happen - see law 1 and trap 73.
+   * @param {{line?:string, face?:string, onDone?:Function}=} opts
+   * @returns {Function|null} a cancel function, or null when she refused.
+   */
+  function apparate(getRect, opts) {
+    const o = opts || {};
+    if (!getRect) return null;
+    // LAW 3: she never starts one over herself.
+    if (!enabled || hidden || trip || pressing || dragging || busy() || saying()) return null;
+    if (!el || !el.classList) return null;
+    // Nothing to travel TO is not a failure, it is a fixture that is not on
+    // screen. Answer null and let the scheduler try again another night.
+    if (!rectNow(getRect)) return null;
+
+    const line = typeof o.line === 'string' && o.line.trim() ? o.line : null;
+    const face = typeof o.face === 'string' && o.face ? o.face : '^_^';
+    trip = { timer: null, left: 0, top: 0, onDone: typeof o.onDone === 'function' ? o.onDone : null };
+
+    // Where she is standing right now, in pixels, so a cancel during the very
+    // first squish still knows the spot it is being asked to keep.
+    const start = place();
+    trip.left = start.left;
+    trip.top = start.top;
+
+    stopBlink();
+    stopSway();
+    clearBody();
+    restGaze();
+
+    /* 1. THE TUBE GOES OFF. */
+    crt('crt-off');
+    tripStep(crtMs(), () => {
+      /* 2. THE DARK. The rect is resolved HERE - law 1 - and a fixture that has
+       *    gone since the trip was scheduled sends her straight home. */
+      crt('crt-blank');
+      const rect = rectNow(getRect);
+      if (!rect) { cancelTrip(); return; }
+      const spot = anchorFor(rect);
+      tripPlaceAt(spot.left, spot.top);
+      crt('crt-on');
+      tripStep(crtMs(), () => {
+        /* 3. THE LINE. Through the ordinary say path, so the bubble, the pose,
+         *    the hold and the Blipese babble are all the ones she already has
+         *    (trap 70: the voice hangs off setBubble and nowhere else). */
+        crtClear();
+        let wait = DIALS.TRIP_BEAT_MS;
+        if (line) {
+          wait = SAY_LEAD_MS + sayHoldMs(line) + DIALS.TRIP_BEAT_MS;
+          let spoke = false;
+          if (makeSay && painter) {
+            try { spoke = play(makeSay(line, face, sayHoldMs(line)), { protect: true, force: true }); }
+            catch (e) { spoke = false; }
+          }
+          // FACELESS STILL TALKS. The body png and the bubble are the half of
+          // EMI that never needed a 2d context, and the trip is worth more than
+          // the reaction frame on top of it.
+          if (!spoke) { setBubble(line); wait = sayHoldMs(line) + DIALS.TRIP_BEAT_MS; }
+        }
+        tripStep(wait, () => {
+          /* 4. HOME. The same two beats, backwards. */
+          cancelChain();
+          killTimers();
+          setBubble(null);
+          crt('crt-off');
+          tripStep(crtMs(), () => {
+            crt('crt-blank');
+            // `place()` reads the fractions the trip never touched, which IS the
+            // player's saved spot (law 4). No arithmetic, so no drift.
+            const home = place();
+            if (trip) { trip.left = home.left; trip.top = home.top; }
+            crt('crt-on');
+            tripStep(crtMs(), () => {
+              const t = trip;
+              trip = null;
+              crtClear();
+              idle();
+              if (t && typeof t.onDone === 'function') {
+                try { t.onDone({ cancelled: false, stay: false }); } catch (e) { /* noop */ }
+              }
+            });
+          });
+        });
+      });
+    });
+
+    return () => cancelTrip();
+  }
+
+  /** THE REGISTRY SEAM. `emi/fieldtrips.js` hands over a function answering the
+   *  live rects of every fixture EMI has a line about; the widget uses them for
+   *  exactly ONE thing, the carried `*_*`. Null clears it. */
+  function setPoiRects(fn) {
+    poiRectsFn = typeof fn === 'function' ? fn : null;
+    if (!poiRectsFn) poiForget();
+  }
+  /* ===================== end of the field trip ========================== */
 
   /* ---------------------- first paint ----------------------------------- */
   built = true;
@@ -1342,6 +1701,9 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     hasFace() { return !!painter; },
     saying, busy,
     setBubble,
+    /* W2a - the field trip. `apparate` takes a RECT-GETTER (trap 73), refuses
+     * over any live verb, and answers a cancel function or null. */
+    apparate, setPoiRects, tripping,
     hide, show,
     get hidden() { return hidden; },
     /** True once the first-dismiss hint has been spent (persisted). */
@@ -1368,6 +1730,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
       if (!enabled) {
         accrueVisible();
         endPress();
+        cancelTrip();                // W2a: switched off mid-trip = home first
         cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody();
         root.hidden = true;
         save(true);
@@ -1385,6 +1748,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     flush,
     destroy() {
       accrueVisible();
+      cancelTrip();                  // W2a: never leave a trip timer behind
       save(true);
       // clearBody() is the easy one to miss: `bodyTimer` outlives everything else
       // and its callback re-adds `.breath` to a node that is no longer in the page.


### PR DESCRIPTION
EMI's first autonomous verb. Occasionally, when she is truly idle on the campus, she powers her tube off, vanishes, reappears next to a point of interest, says one line about it, powers off again and returns to the player's exact saved spot.

It is a scripted rare delight, not wandering, and the whole design lives in how hard it is to see one.

## What landed

**`widget.apparate(getRect, {line, face, onDone})`** — the whole trip as one call, returning a cancel function or `null` when she refused. Power-off where she stands, reappear anchored beside the fixture (clamped on-screen, never overlapping it), land the line through the ordinary say path so vox babbles it for free, hold for the existing `sayHoldMs` formula, power off, come home.

**The CRT power-off** (`widget.css`) — squish to a bright 1px line (~140ms), collapse to a dot and flash out (~60ms), and the same timeline backwards for power-on. Keyframes on the `.emi` root, which is legal for exactly the reason trap 71 gives: a CSS animation out-ranks the dangle's inline transform for as long as it runs.

**`emi/fieldtrips.js`** (new) — the POI registry and the scheduler.

**`b28_first_trip`** in story.js — fires on the return from the very first trip, priority 92 (under the anniversary at 96 and the long-absence return at 95, over every ordinary ceremony). There is deliberately no b29: every later trip says only the fixture's own line.

**Drag anticipation** — carried over a registered fixture she wears `*_*`, on enter and leave only.

## The rules it keeps

- **The rect is resolved at FIRE time, never at schedule time.** The registry's `anchor` is a function returning a function, and `apparate` calls it inside the dark, one frame before she lands. This was the known risk in the brief: the campus SVG is `preserveAspectRatio="xMidYMid slice"`, so a 40px window change moves every fixture. A fixture that has gone by fire time sends her straight home; a resize mid-trip cancels the trip outright.
- **Touch always wins.** A pointerdown on her at any point of the ladder ends it instantly: she stays where she is, upright, with no stranded animation class and no protected say still holding the glass, and the press carries on into a perfectly ordinary drag. The cancel commits the spot she was actually standing on, so the next resize does not snap her back.
- **She never starts one over herself.** Mid-say, mid-chain, mid-press, mid-drag, dismissed, disabled or already travelling, `apparate` answers null. The scheduler tests none of it twice — the widget owns the truth about its own verbs.
- **The saved spot is never written.** A trip moves `el.style.left/top` and never the fractions, so "come home" is `place()` and a crash mid-trip cannot lose where the player put her.
- **Reduced motion** drops the squish and the widget drops the waits with it. Same beat, no animation.
- **No persistent observer.** There is no interval and no `IntersectionObserver` in this wave. `campus.js` already fires `idlePlayer {where:'hub'}` on its attract loop's own idle edge, with the comment "a mascot does not get a second idle timer" — so the scheduler is a passive `offer()` woken by that and nothing else. At rest it measures nothing at all. The drag probe measures once per drag, never per pointermove.
- **One ledger.** POIs are one-shot for ever through voice.js's existing `seen` map, via three new members (`hasSeen` / `markSeen` / `sessions`). A second counter in a second blob is how two ledgers come to disagree about what night it is. The `trip_` prefix keeps POI ids out of the beat-id namespace.
- **The Records geofence is untouched.** Records is a stable, uniquely-classed node and it is still out — along with the Registrar and the Entrance Hall, which are the same `.facility` class with nothing to tell them apart. EMI has no reaction to that door, so she does not go and stand next to it either.
- **Merge hygiene:** every widget.js addition is in ONE clearly-delimited block, plus eight one-line hooks each marked `W2a`. `feat/emi-off-channels` should resolve cleanly.

## The POIs

Six, all on the campus screen, all fixtures `campus.update()` never rebuilds:

| id | node | why it is safe |
|---|---|---|
| `trip_timetable` | `.campus-boardtab` | the hanging plaque, a real button, built unconditionally |
| `trip_belltower` | `g.campus-tower` | pure scenery, never re-classed |
| `trip_noticeboard` | `g.campus-halldress` | the felt board and its four pins — scenery, not the clickable hall |
| `trip_idcard` | `.campus-idcard` | HTML, always present |
| `trip_homeroom` | `g.campus-room[data-game="daily_trigger"]` | Semester I, dealt every night; `data-game` is update-stable |
| `trip_sortroom` | `g.campus-room[data-game="sort"]` | room 201; absent on a build with Semester II closed, and the getter simply drops it |

Each entry carries its selector as data (`sel`) so the suite can audit what the registry actually points at — a closure cannot be read, and "no POI anchors on a `.facility`" needs to be a test, not a promise.

**Deviation from the brief:** the brief named THE BANK as a POI candidate. There is no BANK fixture on the campus — the only match in the tree is a comment in `campus.js` describing a bank of drawers inside the Records office. It is replaced by the bell tower and the student ID card.

## DRAFT lines awaiting the `/emi-lines` pass

Every one is marked `/* DRAFT: /emi-lines pass pending */` in the file. Written at wiring time because the feature needed something in the bubble to test with; none has been through the pipeline or the owner's read.

`emi/barks.js` — `FIELD_TRIPS`:

- **timetable** — `tomorrow is already up there. i had a look.`
- **belltower** — `the bell runs four minutes fast and nobody fixes it.`
- **noticeboard** — `nobody has moved those four pins since i got here.`
- **idcard** — `that photo is you on your first night here.`
- **homeroom** — `everyone starts in this room. i have watched all of them.`
- **sortroom** — `they keep two piles in there and i would only use one.`

`emi/story.js` — b28:

- **b28_first_trip** — `i did not know i could leave the corner.`

All seven are screened against the banned-marker list (no em-dashes, no staccato fragments for effect, no mirrored parallelism, no knowing closers, no "little"/"somehow"), and the suite asserts the mechanical half of that: lowercase, no dashes, ≤60 chars, no fence words.

## Traps claimed

**73** — a fixture rect captured at schedule time is a rect that has moved, so `apparate` takes a getter.
**74** — the CRT keyframe fills `forwards`, so taking the class off is not optional (a welded `scaleY(1)` out-ranks the dangle for ever), and `getBoundingClientRect` mid-squish reports a 1px line.
**75** — touch always wins, and "wins" means she stays where she is — including committing that spot.

75 is the last of the three reserved for this branch; 76+ is the other branch's.

## Test results

| suite | result |
|---|---|
| `test-fieldtrip.mjs` (node) | **69/69** |
| `proof-fieldtrip.mjs` (Chromium, Playwright) | **51/51** |
| `test-perception.mjs` (W1, re-run on this branch) | **18/18**, unchanged |

The browser proof drives the real widget with real pointer input and proves, at minimum: the full trip returns her to the exact saved spot; she lands beside the fixture and never over it; the line reaches the bubble as a protected say; a drag mid-trip cancels and leaves her upright, bubble-free and immediately draggable, with the cancelled spot becoming hers across a resize; the reduced-motion path teleports with `animationName: none` and still completes; carried onto a fixture she repaints `*_*` **exactly once** on entry and `@_@` exactly once on exit (the proof instruments `ctx.fillText` and counts); and every refusal path (no rect, mid-say, mid-drag, dismissed, a second trip) answers null. Zero page errors across all five runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFYHt9c2Z2qS2EK6ovDJU
