### PR TITLE
feat(arcademy): Campus Presence - the Student Body (ghost replay, fake encounters, consent rung)

### DIFF
--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -7082,6 +7082,38 @@ namespace ConditioningControlPanel.Models
             }
         }
 
+        /// <summary>The four rungs of the Campus Presence consent ladder, weakest first. The
+        /// absent rung — <c>off</c> — is this client's own word for "no consent row at all"; it is
+        /// never a wire value (see <see cref="ArcademyPresenceShare"/>).</summary>
+        internal static readonly string[] ArcademyPresenceShares = { "off", "anon", "username", "discord" };
+
+        private string _arcademyPresenceShare = "off";
+        /// <summary>
+        /// CAMPUS PRESENCE, "the Student Body" (PRESENCE.md §3): what this account shows the rest
+        /// of the school. <c>off</c> (the default) · <c>anon</c> (an opaque id and an event list)
+        /// · <c>username</c> (+ the account's display name) · <c>discord</c> (+ a picture).
+        ///
+        /// <para>OPT-IN AND DEFAULT OFF, the same posture <c>HasRemoteMediaConsent</c> takes: this
+        /// is a consent flag, so an unreadable or unknown stored value reads as <c>off</c> rather
+        /// than as the nearest rung. Watching the campus is not consenting — the ghost snapshot is
+        /// pulled whatever this says, and this gates only what leaves this machine.</para>
+        ///
+        /// <para>The server clamps DOWN silently (a <c>discord</c> rung with no linked Discord is
+        /// written as <c>username</c>), so this value is what we ASKED for, never a promise of what
+        /// the account can actually stand on.</para>
+        /// </summary>
+        [JsonProperty("arcademyPresenceShare")]
+        public string ArcademyPresenceShare
+        {
+            get => _arcademyPresenceShare;
+            set
+            {
+                var v = (value ?? "").Trim().ToLowerInvariant();
+                _arcademyPresenceShare = Array.IndexOf(ArcademyPresenceShares, v) >= 0 ? v : "off";
+                OnPropertyChanged();
+            }
+        }
+
         #endregion
 
         #region Validation

--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -502,6 +502,35 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
 - **`engine/index.js` `createEngine(opts)` / `provider/index.js` `createAssets(opts)`** are
   loaded *optionally* (intake's `loadOptional`). Missing or throwing → null object, and the
   class still runs, silent. Never make either a hard import.
+- **CAMPUS PRESENCE is TWO seams, and they are deliberately unequal** (P3, 2026-08-24;
+  `planning/arcademy/PRESENCE.md` §3, wire contract `proxy/docs/arcademy-presence-api.md`).
+  - **Down the wire to the page: `presence {self, snapshot}`.** `Services/Arcademy/ArcademyPresenceService.cs`
+    GETs the public snapshot on campus open and every ~60s ±10s while the window is up, and
+    `ArcademyHostService.OnPresenceSnapshot` posts it. **The snapshot rides through UNMODIFIED** -
+    its `now` is the SERVER's clock, which is the only reason `shell/ghosts.js` can paint the
+    server's ages rather than a skewed machine's. `self` is this account's opaque id (from the last
+    POST reply) and is ALWAYS included, because omitting it leaves the page's previous value
+    standing; `snapshot` is null on the frame that only carries a newly-learned id. The page reads
+    exactly those two fields and nothing else. **The pusher is NOT gated on the share setting** -
+    watching is not consenting, so a player at `off` still gets a populated campus.
+  - **Up the wire from the HOST: four transitions, and only with consent.** `campus_enter` at
+    launch, `room_enter` on `class-started`, `class_end` on `class-ended` (the host's CLAMPED
+    grade, so a zen `pass` rides as null), `campus_leave` in `DisposeAll`. All four are gated on
+    `AppSettings.ArcademyPresenceShare != "off"` plus an identity plus `!OfflineMode`. **The room
+    key is kebab-case and is its OWN table** (`daily-trigger`, not `daily_trigger`, not the punch
+    card's snake_case): two features, two vocabularies, no shared table to drift.
+  - **`presenceShare` is the ONE consent flag in `SETTING_KEYS`** (`off|anon|username|discord`,
+    default `off`). It clamps to an ALLOWLIST at both ends - anything unknown lands on `off`, never
+    on the nearest rung, because a consent flag degrades to "no consent". Seven `presence_share_*`
+    lexicon rows carry the copy and every option names what it shows PUBLICLY; a rung labelled only
+    "Anonymous" is not consent copy.
+  - **A downgrade owes one POST, and `off` cannot pay it.** The server's consent row only ever
+    moves on a POST, so lowering the rung posts one `campus_leave` carrying the NEW rung - which
+    retroactively hides the name and picture on rows already on disk. Turning presence fully OFF
+    posts nothing at all: `share` is validated against `anon|username|discord` and there is no
+    revoke route, so the only "off" the wire could carry would be this client asserting a consent
+    the player just withdrew. The account's prior window ages out inside 24h instead. That gap is
+    the server's to close, not the host's to fake.
 
 ## 4. Traps (each one cost real time)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -137,6 +137,18 @@ export const DEFAULT_LEXICON = Object.freeze({
   campus_main_hall: 'Main Hall',
   campus_the_quad: 'The Quad',
   campus_front_path: 'Front Path',
+
+  /* CAMPUS PRESENCE - "The Student Body" (PRESENCE.md). Six rows and not one
+     more: four BLIPS, a chip label and the layer's own name. The bubbles are
+     1-4 characters BY LAW (diegetic-prose rule: these are blips, never
+     sentences), so a mod re-voices the greeting without ever being able to put
+     a paragraph over a stranger's head. */
+  presence_student_body: 'Student Body',
+  presence_bubble_hi: 'hihi',
+  presence_bubble_dots: '...',
+  presence_bubble_wave_a: 'o/',
+  presence_bubble_wave_b: '\\o',
+  presence_here_tonight: 'here tonight',
   campus_east_wing: 'East Wing',
   campus_west_wing: 'West Wing',
   campus_desc_east: 'You can hear hammering behind the tape.',

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -149,6 +149,17 @@ export const DEFAULT_LEXICON = Object.freeze({
   presence_bubble_wave_a: 'o/',
   presence_bubble_wave_b: '\\o',
   presence_here_tonight: 'here tonight',
+  /* ...and the CONSENT ROW (P3). Every option names what it shows PUBLICLY:
+     the player is agreeing to a specific thing, and a rung called only
+     'Anonymous' is not one. Mirrored key-for-key in ArcademyHostService's
+     NeutralLexicon, or a mod skin renders raw keys here. */
+  presence_share_label: 'Show yourself on campus',
+  presence_share_hint: 'Your last 24 hours replay as a ghost. Room head counts include you at every rung.',
+  presence_share_off: 'Off - room head counts only',
+  presence_share_anon: 'Anonymous - a ghost with no name or picture',
+  presence_share_username: 'Username - your display name over the ghost',
+  presence_share_discord: 'Discord - your display name and profile picture',
+  presence_share_discord_note: 'Discord needs a linked account. Without one the school shows your name instead.',
   campus_east_wing: 'East Wing',
   campus_west_wing: 'West Wing',
   campus_desc_east: 'You can hear hammering behind the tape.',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -439,6 +439,133 @@ export function bellLabel(totalSec) {
   return p(Math.floor(s / 3600)) + ':' + p(Math.floor((s % 3600) / 60)) + ':' + p(s % 60);
 }
 
+/* ============================================================================
+ * THE WALK GRAPH - one corridor grammar, and it is THIS one.
+ *
+ * These four functions used to live inside createCampus() because the nightly
+ * route was their only caller. shell/ghosts.js (Campus Presence) walks the same
+ * geography with replayed attendees, and a SECOND pathing system is the one
+ * thing that could put a student through a wall - so they were lifted out
+ * VERBATIM instead of being copied. They are pure (they read the frozen ROOMS
+ * table and nothing else), which is also what lets the suite assert leg legality
+ * without building a DOM.
+ *
+ * THE WHOLE MAP, in three runs of floor:
+ *   MAIN HALL     x 200..1240, y 430..510   (the corridor every room opens onto)
+ *   WEST SPUR     x  62..200,  y 450..490   (the hall carrying on west)
+ *   GATE ALLEY    x 700..740,  y 510..730   + the front path down to y 920
+ * Every leg any of these functions returns stays inside that union.
+ * ==========================================================================*/
+
+/** The Main Gate, where every night's route (and every ghost) walks in. */
+export const CAMPUS_GATE = Object.freeze([720, 908]);
+/** The Main Hall's centre line - the lane the route and the ghosts walk. */
+export const CAMPUS_HALL_Y = 470;
+/** How long the entry reveal runs. Nothing may animate over it (PRESENCE §4). */
+export const CAMPUS_ENTER_MS = 4500;
+
+/**
+ * Where tonight's numbered badge stands, and where a ghost dwells: in the
+ * corridor just inside the door for a room bolted to the hall, in the wing alley
+ * for a wing room (which pins its own `stop`, because the Main Hall is nowhere
+ * near its door). Pure.
+ */
+export function stopAnchor(key) {
+  const spec = ROOMS[key] || {};
+  if (spec.stop) return spec.stop;
+  return spec.side === 'n' ? [spec.door, 447] : [spec.door, 488];
+}
+
+/**
+ * The point on the room's own wall the door symbol is drawn at - NOT a walkable
+ * spot (it is the threshold itself). Presence uses it as a keep-out radius so an
+ * encounter never stages on top of a swinging leaf. Pure; null for an unknown key.
+ */
+export function doorPoint(key) {
+  const spec = ROOMS[key];
+  if (!spec || spec.door == null) return null;
+  if (spec.side === 'n') return [spec.door, spec.wallY != null ? spec.wallY : 430];
+  if (spec.side === 'w' || spec.side === 'e') {
+    const r = spec.rect || [0, 0, 0, 0];
+    return [spec.side === 'w' ? r[0] : r[0] + r[2], spec.door];
+  }
+  return [spec.door, spec.wallY != null ? spec.wallY : 510];
+}
+
+/**
+ * The legs the route walks for one stop. A corridor room is one point on the
+ * hall's centre line - byte-identical to what this drew before. A wing room
+ * turns off at its junction, touches its door and comes back out, so the next
+ * leg still starts on the centre line instead of cutting through a wall. Pure.
+ */
+export function routeLegs(key) {
+  const spec = ROOMS[key];
+  if (!spec) return [];
+  if (spec.via) return [spec.via, stopAnchor(key), spec.via];
+  return [[spec.door, CAMPUS_HALL_Y]];
+}
+
+/** The nightly route's `d`, gate first. Pure. */
+export function routeFor(stops) {
+  if (!stops || !stops.length) return '';
+  let d = 'M' + CAMPUS_GATE[0] + ',' + CAMPUS_GATE[1]
+    + ' L' + CAMPUS_GATE[0] + ',' + CAMPUS_HALL_Y;
+  for (const s of stops) {
+    for (const leg of routeLegs(s.gameKey)) d += ' L' + leg[0] + ',' + leg[1];
+  }
+  return d;
+}
+
+/**
+ * THE GHOST'S LEG LIST: the waypoints a walker crosses getting from `from` to
+ * one room's dwell anchor, in the same corridor grammar as routeFor(). Three
+ * moves at most and every one of them axis-aligned:
+ *   1. step back onto the hall's centre line (a walker leaving a door plaque);
+ *   2. walk the centre line to the room's door coordinate;
+ *   3. step off it to the dwell anchor.
+ * A leg that would be zero-length is dropped, so a walk that is already on the
+ * line returns two points, not four. `from` may be any point on the graph -
+ * CAMPUS_GATE included, which is why step 1 walks the gate alley vertically.
+ * Pure; an unknown room key answers an empty list (the caller skips that leg).
+ */
+export function walkLegs(from, key) {
+  const spec = ROOMS[key];
+  if (!spec || !from) return [];
+  const anchor = stopAnchor(key);
+  // Already standing on the plaque (two classes running back to back in the
+  // same room): no legs at all, rather than a pointless round trip to the lane.
+  if (Math.abs(from[0] - anchor[0]) < 0.01 && Math.abs(from[1] - anchor[1]) < 0.01) return [];
+  const out = [];
+  const push = (p) => {
+    const last = out.length ? out[out.length - 1] : from;
+    if (Math.abs(last[0] - p[0]) < 0.01 && Math.abs(last[1] - p[1]) < 0.01) return;
+    out.push([p[0], p[1]]);
+  };
+  // 1. onto the lane. From the gate that is the vertical run up the gate alley;
+  //    from a door plaque it is the two dozen units back into the hall.
+  if (Math.abs(from[1] - CAMPUS_HALL_Y) > 0.01) push([from[0], CAMPUS_HALL_Y]);
+  // 2. along the lane to the room's own coordinate.
+  push([anchor[0], CAMPUS_HALL_Y]);
+  // 3. off the lane to the plaque.
+  push([anchor[0], anchor[1]]);
+  return out;
+}
+
+/** The way back out: the lane, then the gate alley, then the front path. Pure. */
+export function gateLegs(from) {
+  if (!from) return [];
+  const out = [];
+  const push = (p) => {
+    const last = out.length ? out[out.length - 1] : from;
+    if (Math.abs(last[0] - p[0]) < 0.01 && Math.abs(last[1] - p[1]) < 0.01) return;
+    out.push([p[0], p[1]]);
+  };
+  if (Math.abs(from[1] - CAMPUS_HALL_Y) > 0.01) push([from[0], CAMPUS_HALL_Y]);
+  push([CAMPUS_GATE[0], CAMPUS_HALL_Y]);
+  push([CAMPUS_GATE[0], CAMPUS_GATE[1]]);
+  return out;
+}
+
 /* ----------------------------------------------------------------------------
  * TINY BUILDERS - namespace-aware so the DOM double can host the campus.
  * -------------------------------------------------------------------------- */
@@ -514,11 +641,22 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
    * the board deals. After it has played, silent repaints must not re-run it
    * (the same law as splitflap's animate:false). */
   let enterTimer = 0;
+  let revealed = false;
+  function finishReveal() {
+    if (revealed || destroyed) return;
+    revealed = true;
+    try { root.classList.remove('enter'); } catch (e) { /* noop */ }
+    /* THE ONE HOOK THE STUDENT BODY NEEDS. PRESENCE.md §4: ghosts start AFTER
+     * the reveal, never during it - the rooms are still staggering in and a
+     * walker crossing that cascade reads as a glitch, not as a classmate. */
+    try { if (typeof handlers.revealDone === 'function') handlers.revealDone(); }
+    catch (e) { say('revealDone hook threw: ' + ((e && e.message) || e)); }
+  }
   if (typeof setTimeout === 'function') {
-    enterTimer = setTimeout(() => {
-      enterTimer = 0;
-      try { root.classList.remove('enter'); } catch (e) { /* noop */ }
-    }, 4500);
+    // Reduced motion has no cascade to wait out (the sheet refuses it), so the
+    // hook fires on the next turn rather than four and a half seconds late.
+    enterTimer = setTimeout(() => { enterTimer = 0; finishReveal(); },
+      reducedMotion ? 0 : CAMPUS_ENTER_MS);
   }
 
   /** Entry-stagger delay, per element (consumed by .campus-stage.enter rules). */
@@ -755,6 +893,17 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   /* route (under rooms so door arcs stay crisp) + stop badges (over, added last) */
   routePath = svg('path', { d: '' }, 'campus-route');
   plan.appendChild(routePath);
+
+  /* THE STUDENT BODY'S LAYER - a SIBLING of the route, mounted here and nowhere
+   * else (PRESENCE.md §4): above the floor and the carpet, UNDER the rooms and
+   * their door arcs, so a ghost walks the corridor and never over a door leaf.
+   * The campus owns the node and nothing else about the feature - shell/ghosts.js
+   * fills it, and a campus built with no presence data simply carries an empty
+   * group. It is `pointer-events:none` in the sheet (trap 59's law: a layer over
+   * the plan that took clicks would eat every room). */
+  const ghostLayer = svg('g', null, 'campus-students');
+  ghostLayer.setAttribute('aria-hidden', 'true');
+  plan.appendChild(ghostLayer);
 
   /* ------------------------------ rooms ---------------------------------- */
   /* A door is the architect's symbol: a gap in the wall plus the leaf pivoting
@@ -1521,34 +1670,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     return '';
   }
 
-  /* Where tonight's numbered badge stands: in the corridor just inside the door
-   * for a room bolted to the hall, in the wing alley for a wing room (which
-   * pins its own `stop`, because the Main Hall is nowhere near its door). */
-  function stopAnchor(key) {
-    const spec = ROOMS[key] || {};
-    if (spec.stop) return spec.stop;
-    return spec.side === 'n' ? [spec.door, 447] : [spec.door, 488];
-  }
-
-  /* The legs the route walks for one stop. A corridor room is one point on the
-   * hall's centre line - byte-identical to what this drew before. A wing room
-   * turns off at its junction, touches its door and comes back out, so the next
-   * leg still starts on the centre line instead of cutting through a wall. */
-  function routeLegs(key) {
-    const spec = ROOMS[key];
-    if (!spec) return [];
-    if (spec.via) return [spec.via, stopAnchor(key), spec.via];
-    return [[spec.door, 470]];
-  }
-
-  function routeFor(stops) {
-    if (!stops.length) return '';
-    let d = 'M720,908 L720,470';
-    for (const s of stops) {
-      for (const leg of routeLegs(s.gameKey)) d += ' L' + leg[0] + ',' + leg[1];
-    }
-    return d;
-  }
+  /* stopAnchor / routeLegs / routeFor are MODULE-LEVEL now (see THE WALK GRAPH,
+   * above): shell/ghosts.js walks the same corridor grammar and a second copy of
+   * it is exactly how a student ends up inside a wall. */
 
   function update(nextState, nextStats) {
     if (destroyed) return;
@@ -1843,6 +1967,10 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     root,
     boardMount,
     footMount,
+    /** THE STUDENT BODY'S SEAM: the one group shell/ghosts.js draws into. */
+    ghostMount: ghostLayer,
+    /** True once the entry reveal has finished (ghosts may not start before). */
+    revealDone() { return revealed; },
     update,
     noteDescriptors,
     closeCard,

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/fixtures/presence.json
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/fixtures/presence.json
@@ -1,0 +1,224 @@
+{
+  "v": 1,
+  "note": "HAND-AUTHORED PLAYTEST DAY (?presence=fixture). Every `t` is a RELATIVE offset in seconds from now (<= 0); shell/ghosts.js normalises them to now+t at load, which is what keeps this file honest a week from now. The server's real snapshot sends absolute epoch seconds and a `now` - both shapes go through the same normaliser. Deliberate edge cases live in here: a retired room key (misdirection) that must be skipped without a throw, a hyphenated room key that must canonicalise, a discord avatar that is a data: URI, a discord avatar that CANNOT load (the pixel-sprite fallback), two students inside the live window, and enough opposite-end traffic that the corridor produces crossings.",
+  "now": 0,
+  "counts": {
+    "daily_trigger": 9,
+    "deja_vu": 7,
+    "the_deep_end": 6,
+    "echo": 5,
+    "instant_recall": 4,
+    "impulse_control": 3,
+    "sort": 3,
+    "lost_and_found": 2,
+    "composure": 2,
+    "anomaly": 1
+  },
+  "students": [
+    { "id": "a1b2c3d4", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -420 },
+      { "e": "room_enter", "t": -400, "room": "deja_vu" },
+      { "e": "class_end", "t": -220, "room": "deja_vu", "grade": "A" },
+      { "e": "room_enter", "t": -200, "room": "daily_trigger" },
+      { "e": "class_end", "t": -70, "room": "daily_trigger", "grade": "S" }
+    ] },
+    { "id": "7f0e9d21", "share": "username", "name": "PinkFuse", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -390 },
+      { "e": "room_enter", "t": -360, "room": "echo" },
+      { "e": "class_end", "t": -150, "room": "echo", "grade": "B" },
+      { "e": "room_enter", "t": -120, "room": "instant_recall" }
+    ] },
+    { "id": "c4d5e6f7", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -1320 },
+      { "e": "room_enter", "t": -1290, "room": "anomaly" },
+      { "e": "class_end", "t": -1110, "room": "anomaly", "grade": "A" },
+      { "e": "room_enter", "t": -1080, "room": "composure" },
+      { "e": "class_end", "t": -840, "room": "composure", "grade": "S" },
+      { "e": "campus_leave", "t": -810 }
+    ] },
+    { "id": "11aa22bb", "share": "discord", "name": "velvetnoise", "avatar": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2016%2016%22%3E%3Crect%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23e46bb5%22%2F%3E%3Ccircle%20cx%3D%228%22%20cy%3D%226%22%20r%3D%223%22%20fill%3D%22%23fff2fb%22%2F%3E%3Crect%20x%3D%223%22%20y%3D%2210%22%20width%3D%2210%22%20height%3D%226%22%20rx%3D%223%22%20fill%3D%22%23fff2fb%22%2F%3E%3C%2Fsvg%3E", "events": [
+      { "e": "campus_enter", "t": -1500 },
+      { "e": "room_enter", "t": -1470, "room": "echo" },
+      { "e": "class_end", "t": -1260, "room": "echo", "grade": "S" },
+      { "e": "campus_leave", "t": -1220 }
+    ] },
+    { "id": "9c8b7a65", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -2160 },
+      { "e": "room_enter", "t": -2130, "room": "instant_recall" },
+      { "e": "class_end", "t": -1890, "room": "instant_recall", "grade": "B" },
+      { "e": "campus_leave", "t": -1860 }
+    ] },
+    { "id": "4d3c2b1a", "share": "username", "name": "Lumen", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -2760 },
+      { "e": "room_enter", "t": -2730, "room": "lost_and_found" },
+      { "e": "class_end", "t": -2430, "room": "lost_and_found", "grade": "C" },
+      { "e": "room_enter", "t": -2400, "room": "the_deep_end" },
+      { "e": "class_end", "t": -2100, "room": "the_deep_end", "grade": "A" },
+      { "e": "campus_leave", "t": -2070 }
+    ] },
+    { "id": "e5f60718", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -3360 },
+      { "e": "room_enter", "t": -3330, "room": "sort" },
+      { "e": "class_end", "t": -3180, "room": "sort", "grade": "A" },
+      { "e": "campus_leave", "t": -3150 }
+    ] },
+    { "id": "0a1b2c3d", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -3540 },
+      { "e": "room_enter", "t": -3500, "room": "daily_trigger" },
+      { "e": "class_end", "t": -3390, "room": "daily_trigger", "grade": "B" },
+      { "e": "room_enter", "t": -3360, "room": "impulse_control" },
+      { "e": "class_end", "t": -3180, "room": "impulse_control", "grade": "S" },
+      { "e": "campus_leave", "t": -3140 }
+    ] },
+    { "id": "55667788", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -5400 },
+      { "e": "room_enter", "t": -5370, "room": "deja_vu" },
+      { "e": "class_end", "t": -5190, "room": "deja_vu", "grade": "A" },
+      { "e": "campus_leave", "t": -5160 }
+    ] },
+    { "id": "aabbccdd", "share": "username", "name": "Static", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -7200 },
+      { "e": "room_enter", "t": -7150, "room": "composure" },
+      { "e": "class_end", "t": -6850, "room": "composure", "grade": "B" },
+      { "e": "room_enter", "t": -6820, "room": "echo" },
+      { "e": "class_end", "t": -6610, "room": "echo", "grade": "A" },
+      { "e": "campus_leave", "t": -6580 }
+    ] },
+    { "id": "13579bdf", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -9000 },
+      { "e": "room_enter", "t": -8970, "room": "the_deep_end" },
+      { "e": "class_end", "t": -8670, "room": "the_deep_end", "grade": "S" },
+      { "e": "campus_leave", "t": -8640 }
+    ] },
+    { "id": "2468ace0", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -10800 },
+      { "e": "room_enter", "t": -10770, "room": "instant-recall" },
+      { "e": "class_end", "t": -10530, "room": "instant-recall", "grade": "B" },
+      { "e": "campus_leave", "t": -10500 }
+    ] },
+    { "id": "f1e2d3c4", "share": "discord", "name": "hollowkey", "avatar": "https://cdn.example.invalid/avatars/hollowkey.png", "events": [
+      { "e": "campus_enter", "t": -12600 },
+      { "e": "room_enter", "t": -12560, "room": "daily_trigger" },
+      { "e": "class_end", "t": -12440, "room": "daily_trigger", "grade": "S" },
+      { "e": "room_enter", "t": -12400, "room": "sort" },
+      { "e": "class_end", "t": -12250, "room": "sort", "grade": "A" },
+      { "e": "campus_leave", "t": -12210 }
+    ] },
+    { "id": "8899aabb", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -14400 },
+      { "e": "room_enter", "t": -14370, "room": "anomaly" },
+      { "e": "class_end", "t": -14190, "room": "anomaly", "grade": "C" },
+      { "e": "campus_leave", "t": -14160 }
+    ] },
+    { "id": "3c3c3c3c", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -16200 },
+      { "e": "room_enter", "t": -16170, "room": "echo" },
+      { "e": "class_end", "t": -15960, "room": "echo", "grade": "B" },
+      { "e": "room_enter", "t": -15930, "room": "lost_and_found" },
+      { "e": "class_end", "t": -15630, "room": "lost_and_found", "grade": "B" },
+      { "e": "campus_leave", "t": -15600 }
+    ] },
+    { "id": "6b6b6b6b", "share": "username", "name": "Nine", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -18000 },
+      { "e": "room_enter", "t": -17960, "room": "misdirection" },
+      { "e": "class_end", "t": -17840, "room": "misdirection", "grade": "A" },
+      { "e": "room_enter", "t": -17800, "room": "deja_vu" },
+      { "e": "class_end", "t": -17620, "room": "deja_vu", "grade": "S" },
+      { "e": "campus_leave", "t": -17590 }
+    ] },
+    { "id": "d0d0d0d0", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -19800 },
+      { "e": "room_enter", "t": -19770, "room": "impulse_control" },
+      { "e": "class_end", "t": -19590, "room": "impulse_control", "grade": "A" },
+      { "e": "campus_leave", "t": -19560 }
+    ] },
+    { "id": "5a5a5a5a", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -21000 },
+      { "e": "room_enter", "t": -20970, "room": "the_deep_end" },
+      { "e": "class_end", "t": -20670, "room": "the_deep_end", "grade": "B" },
+      { "e": "campus_leave", "t": -20640 }
+    ] },
+    { "id": "90ab12cd", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -25200 },
+      { "e": "room_enter", "t": -25170, "room": "sort" },
+      { "e": "class_end", "t": -25020, "room": "sort", "grade": "C" },
+      { "e": "room_enter", "t": -24990, "room": "daily_trigger" },
+      { "e": "class_end", "t": -24870, "room": "daily_trigger", "grade": "A" },
+      { "e": "campus_leave", "t": -24840 }
+    ] },
+    { "id": "bb11ee44", "share": "username", "name": "Corvid", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -28800 },
+      { "e": "room_enter", "t": -28760, "room": "composure" },
+      { "e": "class_end", "t": -28460, "room": "composure", "grade": "S" },
+      { "e": "campus_leave", "t": -28430 }
+    ] },
+    { "id": "7c7c1a1a", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -32400 },
+      { "e": "room_enter", "t": -32370, "room": "instant_recall" },
+      { "e": "class_end", "t": -32130, "room": "instant_recall", "grade": "A" },
+      { "e": "room_enter", "t": -32100, "room": "echo" },
+      { "e": "class_end", "t": -31890, "room": "echo", "grade": "B" },
+      { "e": "campus_leave", "t": -31860 }
+    ] },
+    { "id": "44556677", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -39600 },
+      { "e": "room_enter", "t": -39570, "room": "lost_and_found" },
+      { "e": "class_end", "t": -39270, "room": "lost_and_found", "grade": "B" },
+      { "e": "campus_leave", "t": -39240 }
+    ] },
+    { "id": "eeff0011", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -43200 },
+      { "e": "room_enter", "t": -43170, "room": "deja_vu" },
+      { "e": "class_end", "t": -42990, "room": "deja_vu", "grade": "C" },
+      { "e": "campus_leave", "t": -42960 }
+    ] },
+    { "id": "22334455", "share": "discord", "name": "sugarwire", "avatar": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2016%2016%22%3E%3Crect%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%237c6ce0%22%2F%3E%3Ccircle%20cx%3D%228%22%20cy%3D%226%22%20r%3D%223%22%20fill%3D%22%23ffe9a8%22%2F%3E%3Crect%20x%3D%223%22%20y%3D%2210%22%20width%3D%2210%22%20height%3D%226%22%20rx%3D%223%22%20fill%3D%22%23ffe9a8%22%2F%3E%3C%2Fsvg%3E", "events": [
+      { "e": "campus_enter", "t": -46800 },
+      { "e": "room_enter", "t": -46760, "room": "daily_trigger" },
+      { "e": "class_end", "t": -46640, "room": "daily_trigger", "grade": "S" },
+      { "e": "room_enter", "t": -46600, "room": "the_deep_end" },
+      { "e": "class_end", "t": -46300, "room": "the_deep_end", "grade": "A" },
+      { "e": "campus_leave", "t": -46270 }
+    ] },
+    { "id": "998877aa", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -54000 },
+      { "e": "room_enter", "t": -53970, "room": "anomaly" },
+      { "e": "class_end", "t": -53790, "room": "anomaly", "grade": "B" },
+      { "e": "campus_leave", "t": -53760 }
+    ] },
+    { "id": "1a2b3c4e", "share": "username", "name": "Moth", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -61200 },
+      { "e": "room_enter", "t": -61170, "room": "impulse_control" },
+      { "e": "class_end", "t": -60990, "room": "impulse_control", "grade": "A" },
+      { "e": "room_enter", "t": -60960, "room": "sort" },
+      { "e": "class_end", "t": -60810, "room": "sort", "grade": "B" },
+      { "e": "campus_leave", "t": -60780 }
+    ] },
+    { "id": "cafebabe", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -68400 },
+      { "e": "room_enter", "t": -68370, "room": "echo" },
+      { "e": "class_end", "t": -68160, "room": "echo", "grade": "C" },
+      { "e": "campus_leave", "t": -68130 }
+    ] },
+    { "id": "0f0f0f0f", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -72000 },
+      { "e": "room_enter", "t": -71970, "room": "the_deep_end" },
+      { "e": "class_end", "t": -71670, "room": "the_deep_end", "grade": "S" },
+      { "e": "campus_leave", "t": -71640 }
+    ] },
+    { "id": "beadfeed", "share": "anon", "name": null, "avatar": null, "events": [
+      { "e": "campus_enter", "t": -75600 },
+      { "e": "room_enter", "t": -75570, "room": "composure" },
+      { "e": "class_end", "t": -75270, "room": "composure", "grade": "B" },
+      { "e": "room_enter", "t": -75240, "room": "lost_and_found" },
+      { "e": "class_end", "t": -74940, "room": "lost_and_found", "grade": "A" },
+      { "e": "campus_leave", "t": -74910 }
+    ] },
+    { "id": "5eed1234", "share": "username", "name": "Quiet", "avatar": null, "events": [
+      { "e": "campus_enter", "t": -82800 },
+      { "e": "room_enter", "t": -82770, "room": "daily_trigger" },
+      { "e": "class_end", "t": -82650, "room": "daily_trigger", "grade": "B" },
+      { "e": "campus_leave", "t": -82620 }
+    ] }
+  ]
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ghosts.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ghosts.js
@@ -1,0 +1,1249 @@
+/* ============================================================================
+ * shell/ghosts.js - CAMPUS PRESENCE, "The Student Body" (planning/arcademy/
+ * PRESENCE.md, design LOCKED 2026-08-24). P1: the renderer.
+ *
+ * Ghost cursors of the people who actually attended the Arcademy in the last
+ * 24 hours, replayed onto tonight's campus. Forty attendees today is forty
+ * students walking the corridor tonight - time-SHIFTED, never claimed as
+ * concurrent, and dimmed by how old their evening is.
+ *
+ * FOUR LAWS, and every one of them is load-bearing:
+ *
+ *  1. THE PAGE NEVER FETCHES FROM A SERVER. The WebView2 page is offline by
+ *     construction (trap 2) and the design says so twice. Data arrives ONE of
+ *     two ways: the HOST pushes a `presence` frame over the bridge (campus open,
+ *     then ~every 60s), or `?presence=fixture` reads the bundled same-origin
+ *     `shell/fixtures/presence.json`. No push and no fixture = no ghosts and no
+ *     errors: the feature is SILENTLY ABSENT, which is what lets it merge long
+ *     before the server half exists.
+ *
+ *  2. THE WALK GRAPH IS CAMPUS.JS'S. `stopAnchor` / `walkLegs` / `gateLegs`
+ *     were lifted out of `createCampus` for this module rather than copied, so
+ *     the nightly route and the student body walk ONE corridor grammar. A second
+ *     pathing system is precisely how a student ends up inside a wall.
+ *
+ *  3. NO COORDINATE EVER CAME FROM A SERVER, AND NONE EVER WILL. The wire is
+ *     rooms and timestamps (PRESENCE §1/§8, so the same snapshot can later drive
+ *     the Open Grounds 3D graph). Every position on this page is SYNTHESISED
+ *     here from the event list.
+ *
+ *  4. THE ENCOUNTERS ARE THEATRE AND THEY ARE HONEST ABOUT IT (PRESENCE §5).
+ *     Nobody picks a partner; nothing is sent anywhere; the scenes are 1-4
+ *     character blips out of the lexicon, never prose. Detection is ANALYTIC at
+ *     plan time - the scheduler already knows every polyline and its timing, so
+ *     there is no per-frame collision loop anywhere in this file.
+ *
+ * The player's own ghost is NEVER drawn (`self`): you are the camera.
+ *
+ * NODE-SAFE BY CONSTRUCTION (trap 60's discipline): every document / rAF /
+ * fetch / matchMedia touch is guarded, so the DOM double can build the whole
+ * layer and the pure halves (normalise / schedule / detect) import clean.
+ * ==========================================================================*/
+
+import { t } from '../core/lexicon.js';
+import { makeRng, hash01 } from '../core/rng.js';
+import {
+  ROOMS, CAMPUS_GATE, stopAnchor, doorPoint, walkLegs, gateLegs,
+} from './campus.js';
+
+const SVGNS = 'http://www.w3.org/2000/svg';
+
+/* ----------------------------------------------------------------------------
+ * DIALS. Everything a play-test would want to move lives here.
+ * -------------------------------------------------------------------------- */
+/** The wire version this module understands. A newer snapshot is refused. */
+export const PRESENCE_V = 1;
+/** Simultaneous drawn ghosts. Overflow feeds the busyness chips, never the map. */
+export const MAX_GHOSTS = 24;
+/** Rooms with at least this many attendees wear a count chip (PRESENCE §6). */
+export const BUSY_MIN = 3;
+/** The replay window. Anything older than this is not a ghost at all. */
+export const WINDOW_MS = 24 * 3600 * 1000;
+/** Age tiers, in ms. Order matters: the first one that fits wins. */
+export const AGE_TIERS = Object.freeze([
+  { tier: 'live', maxMs: 5 * 60 * 1000 },
+  { tier: 'fresh', maxMs: 3600 * 1000 },
+  { tier: 'dim', maxMs: 6 * 3600 * 1000 },
+  { tier: 'faint', maxMs: WINDOW_MS },
+]);
+/** Walking speed, viewBox units per second, per-ghost seeded inside the band. */
+export const SPEED_MIN = 40;
+export const SPEED_MAX = 60;
+/** A replayed class compresses into this many seconds of dwell. */
+export const DWELL_MIN_MS = 30000;
+export const DWELL_MAX_MS = 90000;
+/** The real class lengths the compression maps FROM. */
+const REAL_MIN_S = 60;
+const REAL_MAX_S = 600;
+/** Off-stage beat between one replayed evening and the next. */
+const AWAY_MIN_MS = 6000;
+const AWAY_MAX_MS = 18000;
+/** How far a dwelling student drifts around the door plaque. */
+const IDLE_DX = 10;
+const IDLE_DY = 6;
+
+/* Encounters (PRESENCE §5, owner-locked numbers). */
+export const ENCOUNTER_R = 28;
+export const ENCOUNTER_WINDOW_MS = 2000;
+export const ENCOUNTER_CHANCE = 0.25;
+export const ENCOUNTER_COOLDOWN_MS = 90000;
+export const ENCOUNTER_DOOR_CLEAR = 60;
+export const SCENE_MS = 2600;
+/** How far ahead one encounter plan reaches. Re-planned, deterministically, per epoch. */
+export const PLAN_HORIZON_MS = 240000;
+const PLAN_STEP_MS = 250;
+const PLAN_LEAD_MS = 3000;      // never inside the first beats of a plan (reveal guard)
+/** How much faster a ghost walks to catch a schedule an encounter cost it. */
+const CATCHUP_RATE = 0.35;
+/** A planned encounter is abandoned if the pair has drifted this far apart. */
+const SCENE_MAX_GAP = ENCOUNTER_R * 2.5;
+
+/** The weighted scene pool. Weights are the owner's, verbatim. */
+export const SCENE_POOL = Object.freeze([
+  Object.freeze({ kind: 'hihi', w: 0.40 }),
+  Object.freeze({ kind: 'dots', w: 0.25 }),
+  Object.freeze({ kind: 'wave', w: 0.20 }),
+  Object.freeze({ kind: 'nod', w: 0.15 }),
+]);
+
+/**
+ * THE FLOOR - every run of walkable ground on the plan, [x, y, w, h] in viewBox
+ * units, transcribed from the `campus-ghall` rects `campus.js` draws. Nothing
+ * here decides where a ghost goes (campus.js's walk graph does that); this is
+ * the ASSERTION the suite runs the whole leg list against, and the clamp that
+ * keeps an idle drift on the carpet. Change a floor in campus.js and this table
+ * has to move in the same commit or a walker leaves the building.
+ */
+export const FLOOR_RECTS = Object.freeze([
+  Object.freeze({ id: 'hall', x: 200, y: 430, w: 1040, h: 80 }),      // the Main Hall
+  Object.freeze({ id: 'west-spur', x: 62, y: 450, w: 138, h: 40 }),   // the hall, carrying on west
+  Object.freeze({ id: 'entrance', x: 460, y: 510, w: 240, h: 220 }),  // the Entrance Hall
+  Object.freeze({ id: 'gate-alley', x: 700, y: 510, w: 40, h: 220 }), // the front walk's paved run
+  Object.freeze({ id: 'front-path', x: 695, y: 730, w: 50, h: 190 }), // out through the Main Gate
+]);
+
+/* ============================================================================
+ * PURE: THE WIRE
+ * ==========================================================================*/
+
+/** Room keys are underscored on this page; a hyphenated wire key canonicalises. */
+export function canonRoom(key) {
+  if (key == null) return null;
+  const k = String(key).trim().toLowerCase().replace(/-/g, '_');
+  return Object.prototype.hasOwnProperty.call(ROOMS, k) ? k : null;
+}
+
+const SHARE_TIERS = new Set(['anon', 'username', 'discord']);
+const EVENT_KINDS = new Set(['campus_enter', 'room_enter', 'class_end', 'campus_leave']);
+const GRADES = new Set(['S', 'A', 'B', 'C', 'PASS']);
+const MAX_STUDENTS = 400;
+const MAX_EVENTS = 32;
+
+function num(v) { const n = Number(v); return Number.isFinite(n) ? n : null; }
+
+/**
+ * THE ONE DOOR THE DATA COMES THROUGH.
+ *
+ * Two timestamp shapes, one normaliser. A snapshot that carries a server clock
+ * (`now` in epoch SECONDS) is TIME-SHIFTED: an event lands at
+ * `nowMs + (t - now) * 1000`, so the ages the page paints are the SERVER's ages
+ * and a skewed client clock cannot invent a live ghost. A fixture carries
+ * `now: 0` (or nothing) and RELATIVE offsets (`t <= 0`, seconds ago), which land
+ * at `nowMs + t * 1000`. Both answer absolute local milliseconds, never later
+ * than `nowMs`.
+ *
+ * Everything is clamped, dropped or defaulted rather than thrown on: an unknown
+ * room key is skipped (the class may be retired - Misdirection has no room), an
+ * unusable share tier reads `anon`, a name on an anon row is discarded, an
+ * avatar on anything but `discord` is discarded, and a student with no usable
+ * event at all is not a student.
+ *
+ * @returns {null|{v, nowMs, students:Array, counts:Object, hash:string}}
+ */
+export function normalizeSnapshot(raw, nowMs) {
+  if (!raw || typeof raw !== 'object') return null;
+  const v = num(raw.v);
+  if (v != null && v > PRESENCE_V) return null;        // a newer wire is not ours to guess at
+  const base = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const serverNow = num(raw.now);
+  const shifted = serverNow != null && serverNow > 1e9;
+
+  const absMs = (tv) => {
+    const s = num(tv);
+    if (s == null) return null;
+    const ms = shifted ? base + (s - serverNow) * 1000 : base + s * 1000;
+    if (!Number.isFinite(ms)) return null;
+    // The future is not a memory. A clock a minute out is clamped, not dropped.
+    if (ms > base) return ms > base + 60000 ? null : base;
+    if (ms < base - WINDOW_MS) return null;
+    return ms;
+  };
+
+  const list = Array.isArray(raw.students) ? raw.students.slice(0, MAX_STUDENTS) : [];
+  const students = [];
+  const seen = new Set();
+  for (const s of list) {
+    if (!s || typeof s !== 'object') continue;
+    const id = String(s.id == null ? '' : s.id).slice(0, 64);
+    if (!id || seen.has(id)) continue;
+    let share = String(s.share || 'anon');
+    if (!SHARE_TIERS.has(share)) share = 'anon';
+    const rawEvents = Array.isArray(s.events) ? s.events.slice(0, MAX_EVENTS) : [];
+    const events = [];
+    for (const e of rawEvents) {
+      if (!e || typeof e !== 'object') continue;
+      const kind = String(e.e || '');
+      if (!EVENT_KINDS.has(kind)) continue;
+      const ms = absMs(e.t);
+      if (ms == null) continue;
+      const room = canonRoom(e.room);
+      // A room event whose key this build has no room for is SKIPPED, not fatal.
+      if ((kind === 'room_enter' || kind === 'class_end') && !room) continue;
+      const grade = (kind === 'class_end' && GRADES.has(String(e.grade))) ? String(e.grade) : null;
+      events.push({ e: kind, t: ms, room, grade });
+    }
+    if (!events.length) continue;
+    events.sort((a, b) => a.t - b.t);
+    const named = (share === 'username' || share === 'discord');
+    const name = named && s.name ? String(s.name).slice(0, 24) : null;
+    students.push({
+      id,
+      // A username tier with no resolved name is an anon row wearing a label it
+      // does not have. Demote rather than draw an empty plaque.
+      share: (named && !name) ? 'anon' : share,
+      name: (named && name) ? name : null,
+      avatar: (share === 'discord' && s.avatar) ? String(s.avatar).slice(0, 512) : null,
+      events,
+      lastMs: events[events.length - 1].t,
+    });
+    seen.add(id);
+  }
+
+  const counts = Object.create(null);
+  const rawCounts = (raw.counts && typeof raw.counts === 'object') ? raw.counts : {};
+  for (const k of Object.keys(rawCounts)) {
+    const room = canonRoom(k);
+    const n = num(rawCounts[k]);
+    if (room && n != null && n > 0) counts[room] = Math.min(9999, Math.round(n));
+  }
+
+  return { v: PRESENCE_V, nowMs: base, students, counts, hash: snapshotHash(students, counts) };
+}
+
+/**
+ * THE ETAG. A stable fingerprint of WHAT the snapshot said, never of WHEN it was
+ * read - the encounter seeds hang off it, so the same day replays the same
+ * meetings on a repaint, and a genuinely new snapshot deals new ones.
+ */
+export function snapshotHash(students, counts) {
+  const parts = [];
+  const rows = (students || []).slice().sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  for (const s of rows) {
+    // Event times are ABSOLUTE ms and would move the hash on every poll, so the
+    // fingerprint takes their ORDER and their rooms - the shape of the evening.
+    parts.push(s.id + ':' + s.share + ':' + s.events.map((e) => e.e + (e.room || '') + (e.grade || '')).join(','));
+  }
+  const cnt = counts || {};
+  for (const k of Object.keys(cnt).sort()) parts.push('#' + k + '=' + cnt[k]);
+  const body = parts.join('|');
+  // Two independent hashes concatenated: one 32-bit value collides too readily
+  // to be the only thing standing between two days and the same encounters.
+  return hash01(body).toFixed(9).slice(2) + '-' + hash01(body.length + '~' + body).toFixed(9).slice(2);
+}
+
+/* ============================================================================
+ * PURE: THE FLOOR
+ * ==========================================================================*/
+
+/** The floor rect a point stands on, or null. Pure. */
+export function floorAt(x, y, slack) {
+  const s = slack || 0;
+  for (const r of FLOOR_RECTS) {
+    if (x >= r.x - s && x <= r.x + r.w + s && y >= r.y - s && y <= r.y + r.h + s) return r;
+  }
+  return null;
+}
+
+/** Pull a drifting point back onto the floor it started on. Pure. */
+function clampToFloor(pt, home) {
+  const r = floorAt(home[0], home[1]) || FLOOR_RECTS[0];
+  const inset = 4;
+  const x = Math.max(r.x + inset, Math.min(r.x + r.w - inset, pt[0]));
+  const y = Math.max(r.y + inset, Math.min(r.y + r.h - inset, pt[1]));
+  return [x, y];
+}
+
+/* ============================================================================
+ * PURE: THE SCHEDULE
+ * ==========================================================================*/
+
+/** Which age tier an event age falls in, or null past the window. Pure. */
+export function ageTierFor(ageMs) {
+  for (const row of AGE_TIERS) if (ageMs < row.maxMs) return row.tier;
+  return null;
+}
+
+/** A real class length (seconds) compressed into a replayed dwell (ms). Pure. */
+export function scaleDwell(realSec) {
+  const s = Number(realSec);
+  if (!Number.isFinite(s) || s <= 0) return (DWELL_MIN_MS + DWELL_MAX_MS) / 2;
+  const p = Math.max(0, Math.min(1, (s - REAL_MIN_S) / (REAL_MAX_S - REAL_MIN_S)));
+  return Math.round(DWELL_MIN_MS + p * (DWELL_MAX_MS - DWELL_MIN_MS));
+}
+
+/** easeInOutSine - PRESENCE §4's easing, and the only one in this file. Pure. */
+export function easeInOutSine(p) {
+  const x = p < 0 ? 0 : p > 1 ? 1 : p;
+  return -(Math.cos(Math.PI * x) - 1) / 2;
+}
+
+/** The visits an event list describes: [{room, realSec, grade}]. Pure. */
+export function visitsOf(events) {
+  const out = [];
+  let open = null;
+  for (const e of events) {
+    if (e.e === 'room_enter') {
+      if (open) { open.realSec = Math.max(0, (e.t - open.atMs) / 1000); out.push(open); }
+      open = { room: e.room, atMs: e.t, realSec: 0, grade: null };
+    } else if (e.e === 'class_end') {
+      if (open && open.room === e.room) {
+        open.realSec = Math.max(0, (e.t - open.atMs) / 1000);
+        open.grade = e.grade;
+        out.push(open);
+        open = null;
+      }
+    } else if (e.e === 'campus_leave') {
+      if (open) { open.realSec = Math.max(0, (e.t - open.atMs) / 1000); out.push(open); open = null; }
+    }
+  }
+  if (open) out.push(open);
+  return out;
+}
+
+function seg(kind, from, to, ms, extra) {
+  return Object.assign({ kind, from, to, ms: Math.max(1, Math.round(ms)) }, extra || {});
+}
+
+/** The idle beats a dwell is made of: hold, drift, hold, drift back. Pure. */
+function dwellSegs(anchor, ms, rng, room, grade) {
+  const drift = () => clampToFloor([
+    anchor[0] + (rng() * 2 - 1) * IDLE_DX,
+    anchor[1] + (rng() * 2 - 1) * IDLE_DY,
+  ], anchor);
+  const a = drift();
+  const b = drift();
+  // 55% standing, 45% shuffling - the plaque is a place you WAIT, not pace.
+  const move = Math.round(ms * 0.45 / 4);
+  const hold = Math.round(ms * 0.55 / 3);
+  return [
+    seg('dwell', anchor, anchor, hold, { room, grade, arrive: true }),
+    seg('dwell', anchor, a, move, { room }),
+    seg('dwell', a, a, hold, { room }),
+    seg('dwell', a, b, move * 2, { room }),
+    seg('dwell', b, b, hold, { room }),
+    seg('dwell', b, anchor, move, { room }),
+  ];
+}
+
+/**
+ * ONE GHOST'S NIGHT, compressed into a loop.
+ *
+ * Gate -> walk the corridor to the first room's plaque -> dwell the scaled class
+ * -> the next room or the way out -> off stage for a beat -> round again, so the
+ * campus stays populated for as long as it is up. Every leg comes out of
+ * campus.js's walk graph; nothing here invents a coordinate.
+ */
+export function scheduleFor(student, nowMs) {
+  const rng = makeRng('arcademy|presence|' + student.id);
+  const speed = SPEED_MIN + rng() * (SPEED_MAX - SPEED_MIN);
+  const visits = visitsOf(student.events);
+  const segs = [];
+  let cur = [CAMPUS_GATE[0], CAMPUS_GATE[1]];
+
+  const walk = (legs) => {
+    for (const p of legs) {
+      const d = Math.hypot(p[0] - cur[0], p[1] - cur[1]);
+      if (d < 0.01) continue;
+      segs.push(seg('walk', [cur[0], cur[1]], [p[0], p[1]], (d / speed) * 1000));
+      cur = [p[0], p[1]];
+    }
+  };
+
+  for (const v of visits) {
+    const legs = walkLegs(cur, v.room);
+    if (!legs.length) continue;             // an unknown room: skip the leg, keep the night
+    walk(legs);
+    for (const s of dwellSegs(stopAnchor(v.room), scaleDwell(v.realSec), rng, v.room, v.grade)) {
+      segs.push(s);
+      cur = [s.to[0], s.to[1]];
+    }
+  }
+  walk(gateLegs(cur));
+  segs.push(seg('away', [CAMPUS_GATE[0], CAMPUS_GATE[1]], [CAMPUS_GATE[0], CAMPUS_GATE[1]],
+    AWAY_MIN_MS + rng() * (AWAY_MAX_MS - AWAY_MIN_MS)));
+
+  let at = 0;
+  for (const s of segs) { s.startMs = at; at += s.ms; }
+  const loopMs = Math.max(1000, at);
+  const ageMs = Math.max(0, nowMs - student.lastMs);
+
+  return {
+    id: student.id,
+    share: student.share,
+    name: student.name,
+    avatar: student.avatar,
+    tier: ageTierFor(ageMs),
+    ageMs,
+    lastMs: student.lastMs,
+    speed,
+    segs,
+    loopMs,
+    // WHERE IN THE LOOP THEY ARE AT nowMs. Seeded off the id, so a repaint
+    // never teleports a ghost and two clients replay the same evening.
+    phaseMs: rng() * loopMs,
+    rooms: visits.map((v) => v.room),
+  };
+}
+
+/**
+ * Where one ghost stands at an absolute time. `visible:false` is the off-stage
+ * beat between two replayed evenings. Pure.
+ */
+export function evalAt(sched, tMs, nowMs) {
+  const into = (((tMs - nowMs) + sched.phaseMs) % sched.loopMs + sched.loopMs) % sched.loopMs;
+  let s = sched.segs[sched.segs.length - 1];
+  let idx = sched.segs.length - 1;
+  for (let i = 0; i < sched.segs.length; i++) {
+    const c = sched.segs[i];
+    if (into < c.startMs + c.ms) { s = c; idx = i; break; }
+  }
+  const p = easeInOutSine((into - s.startMs) / s.ms);
+  const x = s.from[0] + (s.to[0] - s.from[0]) * p;
+  const y = s.from[1] + (s.to[1] - s.from[1]) * p;
+  const dx = s.to[0] - s.from[0];
+  return {
+    x, y, seg: s, segIndex: idx, into,
+    visible: s.kind !== 'away',
+    walking: s.kind === 'walk',
+    // Facing only ever changes on a real horizontal move; a vertical leg keeps
+    // whatever the walker was already showing (a sprite that spins in a doorway
+    // reads as a bug).
+    facing: Math.abs(dx) < 0.5 ? 0 : (dx > 0 ? 1 : -1),
+  };
+}
+
+/* ============================================================================
+ * PURE: THE ENCOUNTERS (PRESENCE §5)
+ * ==========================================================================*/
+
+/** Every door threshold on the plan - an encounter never stages on one. */
+const DOOR_POINTS = Object.freeze(Object.keys(ROOMS).map(doorPoint).filter(Boolean));
+
+function nearAnyDoor(x, y) {
+  for (const d of DOOR_POINTS) {
+    if (Math.hypot(x - d[0], y - d[1]) < ENCOUNTER_DOOR_CLEAR) return true;
+  }
+  return false;
+}
+
+/** Weighted draw from SCENE_POOL with one 0..1 roll. Pure. */
+export function sceneFor(roll) {
+  const r = roll < 0 ? 0 : roll >= 1 ? 0.999999 : roll;
+  let acc = 0;
+  for (const row of SCENE_POOL) { acc += row.w; if (r < acc) return row.kind; }
+  return SCENE_POOL[SCENE_POOL.length - 1].kind;
+}
+
+/**
+ * THE CROSSINGS, SOLVED ONCE PER PLAN - never per frame.
+ *
+ * The scheduler already holds every polyline and its timing, so a plan walks the
+ * next `horizonMs` at a coarse step, finds the pairs that come within R inside
+ * one 2s window, and then LETS THE SEED DECIDE which of them actually happen.
+ * The seed is the snapshot's own fingerprint plus the plan epoch plus the pair,
+ * so the same day always deals the same meetings - which is the whole reason the
+ * detection is analytic rather than a collision loop.
+ *
+ * Rules, in the order they are applied and in the order they matter:
+ *   - both ghosts on stage, at least one of them actually walking;
+ *   - clear of every door by ENCOUNTER_DOOR_CLEAR (never stage on a leaf);
+ *   - not inside the plan's own lead-in (the entry reveal owns those beats);
+ *   - ~25% of what survives fires;
+ *   - a ghost is spent for 90s afterwards, and only ONE scene is ever on screen.
+ */
+export function detectEncounters(schedules, opts) {
+  const o = opts || {};
+  const nowMs = Number.isFinite(o.nowMs) ? o.nowMs : Date.now();
+  const t0 = Number.isFinite(o.startMs) ? o.startMs : nowMs;
+  const horizon = Number.isFinite(o.horizonMs) ? o.horizonMs : PLAN_HORIZON_MS;
+  const hash = String(o.hash || '');
+  const epoch = Number.isFinite(o.epoch) ? o.epoch : 0;
+  const live = (schedules || []).filter((s) => s && s.segs && s.segs.length);
+  if (live.length < 2) return [];
+
+  const steps = Math.max(1, Math.floor(horizon / PLAN_STEP_MS));
+  // One pass of positions, then one pass of pairs over the SAME table: 24 ghosts
+  // is 276 pairs, and doing it twice a plan is cheaper than one frame of blur.
+  const pos = [];
+  for (let k = 0; k <= steps; k++) {
+    const tk = t0 + k * PLAN_STEP_MS;
+    const row = new Array(live.length);
+    for (let i = 0; i < live.length; i++) row[i] = evalAt(live[i], tk, nowMs);
+    pos.push(row);
+  }
+
+  const cands = [];
+  for (let i = 0; i < live.length; i++) {
+    for (let j = i + 1; j < live.length; j++) {
+      let openAt = -1;
+      let best = Infinity;
+      let bestK = -1;
+      const close = (k) => {
+        if (openAt < 0) return;
+        const tk = t0 + bestK * PLAN_STEP_MS;
+        if (tk >= t0 + PLAN_LEAD_MS) {
+          cands.push({ i, j, atMs: tk, k: bestK, dist: best });
+        }
+        openAt = -1; best = Infinity; bestK = -1;
+      };
+      for (let k = 0; k <= steps; k++) {
+        const a = pos[k][i];
+        const b = pos[k][j];
+        const ok = a.visible && b.visible && (a.walking || b.walking)
+          && !nearAnyDoor(a.x, a.y) && !nearAnyDoor(b.x, b.y)
+          && Math.hypot(a.x - b.x, a.y - b.y) <= ENCOUNTER_R;
+        if (ok) {
+          const d = Math.hypot(a.x - b.x, a.y - b.y);
+          if (openAt < 0) openAt = k;
+          if (d < best) { best = d; bestK = k; }
+          // One CROSSING is one candidate: a pair that stays close for longer
+          // than the window has crossed again, not gone on standing there.
+          if ((k - openAt) * PLAN_STEP_MS >= ENCOUNTER_WINDOW_MS) close(k);
+        } else if (openAt >= 0) close(k);
+      }
+      close(steps);
+    }
+  }
+
+  cands.sort((a, b) => (a.atMs - b.atMs) || (a.i - b.i) || (a.j - b.j));
+
+  const out = [];
+  const spentUntil = Object.create(null);
+  let stageFreeAt = -Infinity;
+  for (const c of cands) {
+    const a = live[c.i];
+    const b = live[c.j];
+    const pair = a.id < b.id ? a.id + '~' + b.id : b.id + '~' + a.id;
+    const rng = makeRng(hash + '|presence-meet|' + epoch + '|' + pair + '|' + c.k);
+    if (rng() >= ENCOUNTER_CHANCE) continue;
+    if (c.atMs < stageFreeAt) continue;                       // max one on screen
+    if (c.atMs < (spentUntil[a.id] || -Infinity)) continue;   // per-ghost 90s
+    if (c.atMs < (spentUntil[b.id] || -Infinity)) continue;
+    const scene = sceneFor(rng());
+    out.push({
+      aId: a.id, bId: b.id, atMs: c.atMs, scene, dist: c.dist,
+      at: [(pos[c.k][c.i].x + pos[c.k][c.j].x) / 2, (pos[c.k][c.i].y + pos[c.k][c.j].y) / 2],
+    });
+    spentUntil[a.id] = c.atMs + ENCOUNTER_COOLDOWN_MS;
+    spentUntil[b.id] = c.atMs + ENCOUNTER_COOLDOWN_MS;
+    stageFreeAt = c.atMs + SCENE_MS;
+  }
+  return out;
+}
+
+/**
+ * The whole plan for a snapshot: who is drawn, where they walk, and who meets.
+ * Pure, and the ONE place the 24-cap and the self-exclusion are applied.
+ */
+export function buildSchedules(o) {
+  const opts = o || {};
+  const snap = opts.snapshot;
+  const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+  const cap = Number.isFinite(opts.cap) ? opts.cap : MAX_GHOSTS;
+  if (!snap || !Array.isArray(snap.students)) {
+    return { schedules: [], overflow: 0, counts: {}, hash: '', nowMs };
+  }
+  const self = opts.self == null ? null : String(opts.self);
+  const eligible = snap.students
+    // YOU ARE THE CAMERA (PRESENCE §5): your own ghost is never on the map.
+    .filter((s) => s.id !== self)
+    .filter((s) => ageTierFor(Math.max(0, nowMs - s.lastMs)) !== null)
+    // NEWEST FIRST. The cap is a "who is here now" cap, not a random 24.
+    .sort((a, b) => b.lastMs - a.lastMs || (a.id < b.id ? -1 : 1));
+  const drawn = eligible.slice(0, Math.max(0, cap));
+  return {
+    schedules: drawn.map((s) => scheduleFor(s, nowMs)),
+    overflow: Math.max(0, eligible.length - drawn.length),
+    counts: snap.counts || {},
+    hash: snap.hash || '',
+    nowMs,
+  };
+}
+
+/* ============================================================================
+ * PURE: THE SPRITE
+ *
+ * A pixel student, drawn from a hash of the id: stable per person, reversible
+ * into nothing. NO IMAGE ASSET, and no hex in this file - every part wears a
+ * class and styles.css paints it off the shell's own tokens, exactly the way
+ * campus.js's rooms are painted (a mod palette reskins the student body free).
+ * ==========================================================================*/
+
+/** Deterministic look for one id. Pure - the suite pins it. */
+export function spriteTraitsFor(id) {
+  const h = hash01('arcademy|presence|look|' + id);
+  const h2 = hash01('arcademy|presence|look2|' + id);
+  const bits = Math.floor(h * 4294967296);
+  return {
+    hair: bits % 4,                              // 0 crop  1 long  2 tuft  3 bunches
+    hairHue: Math.floor(h2 * 6),                 // gh-h0..5
+    shirtHue: Math.floor(h * 8),                 // gh-s0..7
+    skin: Math.floor(h2 * 4),                    // gh-k0..3
+    tall: (bits >> 5) % 2 === 1,
+    bag: (bits >> 7) % 3 === 0,
+  };
+}
+
+/* ============================================================================
+ * THE LAYER
+ * ==========================================================================*/
+
+function svgNode(tag, attrs, cls) {
+  const n = (typeof document !== 'undefined' && document.createElementNS)
+    ? document.createElementNS(SVGNS, tag)
+    : (typeof document !== 'undefined' ? document.createElement(tag) : null);
+  if (!n) return null;
+  if (cls) n.setAttribute('class', cls);
+  if (attrs) for (const k of Object.keys(attrs)) n.setAttribute(k, String(attrs[k]));
+  return n;
+}
+
+function rect(x, y, w, h, cls) { return svgNode('rect', { x, y, width: w, height: h }, cls); }
+
+/** Build the pixel student. 10 units wide, ~16 tall, feet on the origin. */
+function buildSprite(id) {
+  const tr = spriteTraitsFor(id);
+  const g = svgNode('g', null, 'gh-sprite');
+  if (!g) return null;
+  const top = tr.tall ? -16 : -14;              // head starts here; feet at y 0
+  const skin = 'gh-skin gh-k' + tr.skin;
+  const hair = 'gh-hair gh-h' + tr.hairHue;
+  const shirt = 'gh-shirt gh-s' + tr.shirtHue;
+  const put = (n) => { if (n) g.appendChild(n); };
+
+  // head
+  put(rect(-3, top + 2, 6, 5, skin));
+  // hair, four silhouettes off the same 6-wide skull
+  if (tr.hair === 0) put(rect(-3, top, 6, 2, hair));
+  else if (tr.hair === 1) { put(rect(-3, top, 6, 2, hair)); put(rect(-4, top, 1, 7, hair)); put(rect(3, top, 1, 7, hair)); }
+  else if (tr.hair === 2) { put(rect(-3, top, 6, 2, hair)); put(rect(-1, top - 2, 2, 2, hair)); }
+  else { put(rect(-3, top, 6, 2, hair)); put(rect(-5, top + 1, 2, 3, hair)); put(rect(3, top + 1, 2, 3, hair)); }
+  // eyes - two pixels, and that is the whole face (no text is ever baked in)
+  put(rect(-2, top + 4, 1, 1, 'gh-eye'));
+  put(rect(1, top + 4, 1, 1, 'gh-eye'));
+  // body + arms
+  put(rect(-3, top + 7, 6, 6, shirt));
+  put(rect(-4, top + 8, 1, 4, shirt));
+  put(rect(3, top + 8, 1, 4, shirt));
+  if (tr.bag) put(rect(3, top + 9, 2, 3, 'gh-bag'));
+  // legs
+  put(rect(-2, top + 13, 2, tr.tall ? 3 : 1, 'gh-leg'));
+  put(rect(1, top + 13, 2, tr.tall ? 3 : 1, 'gh-leg'));
+  return g;
+}
+
+/** The discord tier's avatar chip. Falls back to the sprite on any load error. */
+function buildChip(id, url, onFail) {
+  const g = svgNode('g', null, 'gh-chip');
+  if (!g) return null;
+  const clipId = 'ghc-' + String(id).replace(/[^a-z0-9]/gi, '');
+  const defs = svgNode('defs');
+  const cp = svgNode('clipPath', { id: clipId });
+  const c = svgNode('circle', { cx: 0, cy: -8, r: 6 });
+  if (cp && c) { cp.appendChild(c); if (defs) { defs.appendChild(cp); g.appendChild(defs); } }
+  const img = svgNode('image', {
+    x: -6, y: -14, width: 12, height: 12,
+    'clip-path': 'url(#' + clipId + ')', preserveAspectRatio: 'xMidYMid slice',
+  }, 'gh-chip-img');
+  if (img) {
+    try { img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', url); } catch (e) { /* noop */ }
+    try { img.setAttribute('href', url); } catch (e) { /* noop */ }
+    // A DEAD AVATAR IS A PIXEL STUDENT, not a broken-image glyph (the lesson
+    // campus.js's logo probe paid for). One shot; a second error cannot loop.
+    try {
+      img.addEventListener('error', function once() {
+        try { img.removeEventListener('error', once); } catch (e) { /* noop */ }
+        try { onFail(); } catch (e) { /* noop */ }
+      });
+    } catch (e) { /* noop */ }
+    g.appendChild(img);
+  }
+  const ring = svgNode('circle', { cx: 0, cy: -8, r: 6.6 }, 'gh-chip-ring');
+  if (ring) g.appendChild(ring);
+  return g;
+}
+
+/** The bubble. 1-4 characters of lexicon, and never one more. */
+function buildBubble(text, lift, dx) {
+  const g = svgNode('g', null, 'gh-bubble');
+  if (!g) return null;
+  // A SHARED line hangs BETWEEN the pair, not over one of their heads.
+  if (dx) { try { g.setAttribute('transform', 'translate(' + (Math.round(dx * 10) / 10) + ',0)'); } catch (e) { /* noop */ } }
+  const s = String(text == null ? '' : text).slice(0, 4);
+  const w = 10 + s.length * 6;
+  // THE SECOND SPEAKER'S LINE RIDES HIGHER. Two ghosts standing a dozen units
+  // apart have bubbles wider than the gap between them, so the reply is lifted
+  // clear of the greeting instead of being laid over it.
+  const up = lift ? 14 : 0;
+  const box = rect(-w / 2, -32 - up, w, 13, 'gb-box');
+  if (box) box.setAttribute('rx', '3');
+  const tail = svgNode('path', {
+    d: 'M-2,' + (-19 - up) + ' L2,' + (-19 - up) + ' L0,' + (-15 - up) + ' Z',
+  }, 'gb-tail');
+  const txt = svgNode('text', { x: 0, y: -22.5 - up }, 'gb-t');
+  if (txt) txt.textContent = s;
+  if (box) g.appendChild(box);
+  if (tail) g.appendChild(tail);
+  if (txt) g.appendChild(txt);
+  return g;
+}
+
+/** A grade-S pop at a door, four strokes and gone. */
+function buildSpark(x, y) {
+  const g = svgNode('g', { transform: 'translate(' + x + ',' + y + ')' }, 'gh-spark');
+  if (!g) return null;
+  [[0, -9, 0, -3], [0, 3, 0, 9], [-9, 0, -3, 0], [3, 0, 9, 0]].forEach(([x1, y1, x2, y2]) => {
+    const l = svgNode('line', { x1, y1, x2, y2 });
+    if (l) g.appendChild(l);
+  });
+  return g;
+}
+
+/**
+ * `?presence=fixture` is the play-test path and the ONLY thing that reads a
+ * file. `presenceFast` is a dev time-scale knob for capturing an encounter; both
+ * are query-gated, so a production launch (no query string at all) sees neither.
+ */
+export function presenceOptions(search) {
+  let q = search;
+  if (q == null) {
+    try { q = (typeof location !== 'undefined' && location && location.search) || ''; }
+    catch (e) { q = ''; }
+  }
+  const s = String(q || '');
+  const mode = /(^|[?&])presence=fixture(&|$)/.test(s) ? 'fixture' : 'bridge';
+  const fast = mode === 'fixture' && /(^|[?&])presenceFast=1(&|$)/.test(s);
+  return { mode, fast };
+}
+
+/**
+ * @param {Object} o
+ * @param {Element} o.mount        campus.ghostMount - the <g> sibling of the route
+ * @param {Object=} o.bridge       the bridge module ({on}) - the host's push seam
+ * @param {string=} o.mode         'bridge' (default) | 'fixture'
+ * @param {boolean=} o.fast        the query-gated dev time-scale
+ * @param {boolean=} o.reducedMotion  static ghosts, no walking, no encounters
+ * @param {boolean=} o.lowPerf     same treatment, for a machine that asked for it
+ * @param {Function=} o.log
+ * @param {Object=} o.clock        test seam {now(), raf(fn), caf(id)}
+ * @param {string=} o.fixtureUrl   test seam
+ * @returns {{start, stop, setPaused, setSnapshot, tick, diagnostics, destroy}}
+ */
+export function createGhosts(o) {
+  const opts = o || {};
+  const say = typeof opts.log === 'function' ? opts.log : () => {};
+  const mount = opts.mount || null;
+  const still = !!(opts.reducedMotion || opts.lowPerf);
+  const timeScale = opts.fast ? 6 : 1;
+  const clock = opts.clock || {
+    now: () => Date.now(),
+    raf: (fn) => (typeof requestAnimationFrame === 'function' ? requestAnimationFrame(fn) : 0),
+    caf: (id) => { try { if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(id); } catch (e) { /* noop */ } },
+  };
+
+  let destroyed = false;
+  let started = false;
+  let paused = false;
+  let rafId = 0;
+  let unsub = null;
+  let docBound = false;
+
+  if (mount) { try { mount.setAttribute('hidden', 'hidden'); } catch (e) { /* noop */ } }
+
+  let plan = null;             // {schedules, counts, hash, nowMs, overflow}
+  let selfId = opts.self == null ? null : String(opts.self);
+  let encounters = [];
+  let planEpoch = -1;
+  let planBaseMs = 0;
+  const nodes = new Map();     // id -> {g, sprite, chip, name, bubble, lastSeg, lagMs, facing}
+  let live = null;             // the encounter currently on stage
+  let sparkTimers = [];
+
+  /* ---------------------------------------------------------------- data -- */
+
+  function setSnapshot(raw) {
+    if (destroyed) return;
+    const nowMs = clock.now();
+    const snap = normalizeSnapshot(raw, nowMs);
+    if (!snap) { say('presence: snapshot refused (shape or version)'); return; }
+    plan = buildSchedules({ snapshot: snap, nowMs, self: selfId });
+    planEpoch = -1;
+    planBaseMs = nowMs;
+    render();
+    pump();
+    say('presence: ' + plan.schedules.length + ' ghost(s)'
+      + (plan.overflow ? ' (+' + plan.overflow + ' over the cap)' : '')
+      + ', hash ' + plan.hash.slice(0, 8));
+  }
+
+  /**
+   * THE DEV TIME-SCALE, and it is QUERY-GATED. `?presence=fixture&presenceFast=1`
+   * runs the replay clock N times faster so a capture rig can catch an encounter
+   * inside one screenshot budget. With no query string it is the identity, which
+   * is what makes it harmless in production: `timeScale` is 1 and every
+   * expression below is `now`.
+   */
+  function T(wallMs) {
+    return timeScale === 1 ? wallMs : planBaseMs + (wallMs - planBaseMs) * timeScale;
+  }
+
+  function ensurePlan(nowMs) {
+    if (!plan || still) return;
+    const epoch = Math.floor((nowMs - planBaseMs) / PLAN_HORIZON_MS);
+    if (epoch === planEpoch) return;
+    planEpoch = epoch;
+    encounters = detectEncounters(plan.schedules, {
+      nowMs: plan.nowMs,
+      startMs: planBaseMs + epoch * PLAN_HORIZON_MS,
+      horizonMs: PLAN_HORIZON_MS,
+      hash: plan.hash,
+      epoch,
+    });
+    say('presence: encounter plan ' + epoch + ' -> ' + encounters.length);
+  }
+
+  /* -------------------------------------------------------------- render -- */
+
+  function clearLayer() {
+    for (const id of sparkTimers) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+    sparkTimers = [];
+    nodes.clear();
+    live = null;
+    if (mount) { try { mount.textContent = ''; } catch (e) { /* noop */ } }
+  }
+
+  function render() {
+    clearLayer();
+    if (!mount || !plan) return;
+    for (const s of plan.schedules) mountGhost(s);
+    mountBusy();
+  }
+
+  function mountGhost(s) {
+    const g = svgNode('g', { transform: 'translate(0,0)' }, 'campus-student');
+    if (!g) return;
+    g.setAttribute('data-tier', s.tier || 'faint');
+    g.setAttribute('data-share', s.share);
+    const inner = svgNode('g', null, 'gh-inner');
+    const sprite = buildSprite(s.id);
+    if (inner && sprite) inner.appendChild(sprite);
+    let chip = null;
+    if (s.share === 'discord' && s.avatar) {
+      chip = buildChip(s.id, s.avatar, () => {
+        try { if (chip && chip.parentNode) chip.parentNode.removeChild(chip); } catch (e) { /* noop */ }
+        try { if (sprite) sprite.removeAttribute('hidden'); } catch (e) { /* noop */ }
+        say('presence: avatar failed for a discord ghost - pixel student instead');
+      });
+      if (chip && inner) {
+        // The chip IS the body for this tier, so the sprite steps aside - but it
+        // stays mounted, because it is also the fallback and re-minting one on an
+        // error is a second chance to fail.
+        try { if (sprite) sprite.setAttribute('hidden', 'hidden'); } catch (e) { /* noop */ }
+        inner.appendChild(chip);
+      }
+    }
+    if (inner) g.appendChild(inner);
+    let nameNode = null;
+    if (s.name) {
+      nameNode = svgNode('text', { x: 0, y: -20 }, 'gh-name');
+      if (nameNode) { nameNode.textContent = s.name; g.appendChild(nameNode); }
+    }
+    mount.appendChild(g);
+    nodes.set(s.id, { g, inner, sprite, chip, name: nameNode, bubble: null, lastSeg: -1, lagMs: 0, facing: 1 });
+  }
+
+  /**
+   * THE BUSYNESS CHIPS (PRESENCE §6). `counts` is the SERVER's number and it
+   * includes the people who opted OUT of being drawn - which is the whole point:
+   * a room can be busy with students this layer is not allowed to show you.
+   */
+  function mountBusy() {
+    const counts = (plan && plan.counts) || {};
+    for (const room of Object.keys(counts)) {
+      const n = counts[room];
+      if (!(n >= BUSY_MIN) || !ROOMS[room]) continue;
+      /* Beside the door and HUGGING THE ROOM'S OWN WALL. Level with the stop
+       * anchor it stood shoulder to shoulder with tonight's numbered badge, and
+       * two pills of the same size touching read as one control (browser
+       * capture, 2026-08-24). It belongs to the ROOM, so it hangs off the room's
+       * wall - still in the corridor, never under the room that would cover it.
+       * A wing room pins its own stop mid-alley and keeps the level placement. */
+      const a = stopAnchor(room);
+      const cy = ROOMS[room].stop ? a[1] : a[1] + (ROOMS[room].side === 'n' ? -13 : 13);
+      const g = svgNode('g', { transform: 'translate(' + (a[0] + 24) + ',' + cy + ')' }, 'campus-busy');
+      if (!g) continue;
+      const box = rect(-11, -7, 22, 14, 'cb-box');
+      if (box) { box.setAttribute('rx', '5'); g.appendChild(box); }
+      const txt = svgNode('text', { x: 0, y: 3.6 }, 'cb-t');
+      if (txt) { txt.textContent = String(n); g.appendChild(txt); }
+      const title = svgNode('title');
+      if (title) { title.textContent = n + ' ' + t('presence_here_tonight', 'here tonight'); g.appendChild(title); }
+      mount.appendChild(g);
+    }
+  }
+
+  function bubbleFor(kind, side) {
+    // THREE ASCII DOTS, NOT AN ELLIPSIS. The bubble is set in Press Start 2P, a
+    // 96-glyph latin subset (trap 62) - U+2026 draws tofu there, and the whole
+    // beat this scene is made of is the shared silence being LEGIBLE.
+    if (kind === 'dots') return t('presence_bubble_dots', '...');
+    if (kind === 'wave') {
+      return side === 0
+        ? t('presence_bubble_wave_a', 'o/')
+        : t('presence_bubble_wave_b', '\\o');
+    }
+    if (kind === 'hihi') return t('presence_bubble_hi', 'hihi');
+    return '';
+  }
+
+  function showBubble(rec, text, lift, dx) {
+    if (!rec || !rec.g || !text) return;
+    hideBubble(rec);
+    const b = buildBubble(text, lift, dx);
+    if (b) { rec.g.appendChild(b); rec.bubble = b; }
+  }
+  function hideBubble(rec) {
+    if (rec && rec.bubble) {
+      try { if (rec.bubble.parentNode) rec.bubble.parentNode.removeChild(rec.bubble); } catch (e) { /* noop */ }
+      rec.bubble = null;
+    }
+  }
+
+  function popSpark(x, y) {
+    if (!mount || still) return;
+    const g = buildSpark(x, y);
+    if (!g) return;
+    mount.appendChild(g);
+    if (typeof setTimeout !== 'function') return;
+    const id = setTimeout(() => {
+      try { if (g.parentNode) g.parentNode.removeChild(g); } catch (e) { /* noop */ }
+      sparkTimers = sparkTimers.filter((x2) => x2 !== id);
+    }, 1000);
+    sparkTimers.push(id);
+  }
+
+  /* ----------------------------------------------------------- the scene -- */
+
+  function startScene(enc, wallMs, scaledMs) {
+    const ra = nodes.get(enc.aId);
+    const rb = nodes.get(enc.bId);
+    if (!ra || !rb) return false;
+    const sa = plan.schedules.find((s) => s.id === enc.aId);
+    const sb = plan.schedules.find((s) => s.id === enc.bId);
+    if (!sa || !sb) return false;
+    const pa = evalAt(sa, scaledMs - ra.lagMs, plan.nowMs);
+    const pb = evalAt(sb, scaledMs - rb.lagMs, plan.nowMs);
+    // THE HONESTY GUARD. The plan was solved on the un-lagged schedules; a pair
+    // that has drifted apart since (a catch-up still unwinding) does not get a
+    // scene staged between two ghosts standing nowhere near each other.
+    if (!pa.visible || !pb.visible) return false;
+    if (Math.hypot(pa.x - pb.x, pa.y - pb.y) > SCENE_MAX_GAP) return false;
+    /* THE STAGING, and it is not cosmetic. Two ghosts who meet HEAD ON are on
+     * the same lane by definition - the gate alley is one file wide and the Main
+     * Hall's centre line is one lane - so at closest approach they are drawn
+     * exactly on top of each other and the scene reads as one glitching student
+     * (caught in a browser capture, 2026-08-24). They step a dozen units apart
+     * for the beat and step back afterwards, left/right by whoever was already
+     * further left so nobody crosses through anybody, and BOTH marks are clamped
+     * to the floor they are standing on - a stand-apart can never stage a
+     * student inside a wall. */
+    const leftIsA = pa.x <= pb.x;
+    const oa = clampToFloor([pa.x + (leftIsA ? -11 : 11), pa.y - 4], [pa.x, pa.y]);
+    const ob = clampToFloor([pb.x + (leftIsA ? 11 : -11), pb.y + 4], [pb.x, pb.y]);
+    live = {
+      enc, t0: wallMs, tf: scaledMs, ra, rb, spoke: [false, false],
+      posA: oa, posB: ob,
+    };
+    // Turn to face each other - the sprite flip IS the turn.
+    ra.facing = leftIsA ? 1 : -1;
+    rb.facing = leftIsA ? -1 : 1;
+    if (enc.scene === 'nod') {
+      ra.g.setAttribute('data-scene', 'nod');
+      rb.g.setAttribute('data-scene', 'nod');
+    }
+    return true;
+  }
+
+  function stepScene(nowMs) {
+    if (!live) return;
+    const dt = nowMs - live.t0;
+    const k = live.enc.scene;
+    if (k === 'hihi' || k === 'wave') {
+      if (!live.spoke[0] && dt >= 300) { live.spoke[0] = true; showBubble(live.ra, bubbleFor(k, 0)); }
+      if (!live.spoke[1] && dt >= 700) { live.spoke[1] = true; showBubble(live.rb, bubbleFor(k, 1), true); }
+    } else if (k === 'dots') {
+      // ONE bubble BETWEEN them - the shared silence, not two of them, and it
+      // hangs off the MIDPOINT of the two marks rather than over either head.
+      if (!live.spoke[0] && dt >= 350) {
+        live.spoke[0] = true;
+        showBubble(live.ra, bubbleFor(k, 0), false, (live.posB[0] - live.posA[0]) / 2);
+      }
+    }
+    if (dt >= SCENE_MS) endScene();
+  }
+
+  function endScene() {
+    if (!live) return;
+    hideBubble(live.ra);
+    hideBubble(live.rb);
+    try { live.ra.g.removeAttribute('data-scene'); } catch (e) { /* noop */ }
+    try { live.rb.g.removeAttribute('data-scene'); } catch (e) { /* noop */ }
+    // The stop cost them the beats it lasted; the catch-up below pays it back.
+    live.ra.lagMs += SCENE_MS;
+    live.rb.lagMs += SCENE_MS;
+    live = null;
+  }
+
+  /* ------------------------------------------------------------ the loop -- */
+
+  let lastFrameMs = 0;
+
+  function tick(nowRaw) {
+    if (destroyed || !plan || !mount) return;
+    const wall = Number.isFinite(nowRaw) ? nowRaw : clock.now();
+    const scaled = T(wall);
+    const dt = lastFrameMs ? Math.min(250, wall - lastFrameMs) : 0;
+    lastFrameMs = wall;
+    ensurePlan(scaled);
+
+    // The one encounter that may be on stage right now.
+    if (!still) {
+      if (live) stepScene(wall);
+      else {
+        for (const enc of encounters) {
+          if (enc.fired || scaled < enc.atMs) continue;
+          enc.fired = true;                       // a missed cue is spent, never queued
+          if (scaled <= enc.atMs + SCENE_MS) { startScene(enc, wall, scaled); break; }
+        }
+      }
+    }
+
+    for (const s of plan.schedules) {
+      const rec = nodes.get(s.id);
+      if (!rec) continue;
+      const frozen = !!live && (live.ra === rec || live.rb === rec);
+      if (!frozen && rec.lagMs > 0 && dt > 0) {
+        // A SMALL SPEED-UP, never a teleport: the debt drains at 35% of real
+        // time, so ~7s of slightly brisk walking puts them back on schedule.
+        rec.lagMs = Math.max(0, rec.lagMs - dt * CATCHUP_RATE * timeScale);
+      }
+      const at = evalAt(s, (frozen ? live.tf : scaled) - rec.lagMs, plan.nowMs);
+      if (frozen) {
+        // Ease OUT to the mark and back again, so the step apart is a step.
+        const stand = live.ra === rec ? live.posA : live.posB;
+        const inP = easeInOutSine(Math.min(1, (wall - live.t0) / 300));
+        const outP = easeInOutSine(Math.max(0, Math.min(1, (wall - live.t0 - (SCENE_MS - 300)) / 300)));
+        const k2 = inP * (1 - outP);
+        at.x += (stand[0] - at.x) * k2;
+        at.y += (stand[1] - at.y) * k2;
+      }
+      place(rec, s, at, frozen);
+    }
+  }
+
+  function place(rec, sched, at, frozen) {
+    const g = rec.g;
+    if (!at.visible) {
+      if (!rec.hiddenNow) { try { g.setAttribute('hidden', 'hidden'); } catch (e) { /* noop */ } rec.hiddenNow = true; }
+      rec.lastSeg = at.segIndex;
+      return;
+    }
+    if (rec.hiddenNow) { try { g.removeAttribute('hidden'); } catch (e) { /* noop */ } rec.hiddenNow = false; }
+    const x = Math.round(at.x * 10) / 10;
+    const y = Math.round(at.y * 10) / 10;
+    try { g.setAttribute('transform', 'translate(' + x + ',' + y + ')'); } catch (e) { /* noop */ }
+    if (!frozen && at.facing) rec.facing = at.facing;
+    if (rec.inner && rec.facing !== rec.drawnFacing) {
+      rec.drawnFacing = rec.facing;
+      try { rec.inner.setAttribute('transform', rec.facing < 0 ? 'scale(-1,1)' : 'scale(1,1)'); } catch (e) { /* noop */ }
+      // The name plate never mirrors with the body.
+      if (rec.name) { try { rec.name.setAttribute('transform', 'scale(1,1)'); } catch (e) { /* noop */ } }
+    }
+    if (at.segIndex !== rec.lastSeg) {
+      rec.lastSeg = at.segIndex;
+      const s = at.seg;
+      // THE S FLOURISH: one pop, at the door the class was graded behind, the
+      // beat the replay actually arrives there (PRESENCE §4).
+      if (s.kind === 'dwell' && s.arrive && s.grade === 'S' && s.room) {
+        const a = stopAnchor(s.room);
+        popSpark(a[0], a[1] - 12);
+      }
+    }
+  }
+
+  function frame() {
+    if (destroyed || !started || paused) { rafId = 0; return; }
+    tick();
+    // NO FRAME CLOCK AT ALL (the DOM double, a headless run) answers 0: the
+    // layer draws its one placement and stops. A missing rAF is not a slow
+    // machine, it is not a browser (trap 36's corollary).
+    rafId = clock.raf(frame);
+  }
+
+  function pump() {
+    if (destroyed || !started || paused) return;
+    if (still) { tick(); return; }      // one placement, no walking (PRESENCE §4)
+    if (rafId) return;
+    rafId = clock.raf(frame);
+    if (!rafId) tick();
+  }
+
+  /* ----------------------------------------------------------- lifecycle -- */
+
+  function onVisibility() {
+    let hidden = false;
+    try { hidden = !!(typeof document !== 'undefined' && document && document.hidden); } catch (e) { hidden = false; }
+    setPaused(hidden);
+  }
+
+  /**
+   * THE LAYER IS HIDDEN UNTIL IT IS STARTED, and that is not a nicety.
+   * `setSnapshot` mounts its nodes the moment the data lands - which can be well
+   * before the campus reveal has finished - and an un-ticked ghost sits at
+   * translate(0,0), i.e. twenty-four students piled in the top-left corner of the
+   * plan while the rooms are still staggering in (caught in a browser capture,
+   * 2026-08-24: the node suites cannot see it, because a DOM double has no
+   * paint). Visible is `started && !paused`, expressed through the [hidden]
+   * reset (trap 27) and never a bare `display:`.
+   */
+  function applyVisibility() {
+    if (!mount) return;
+    const show = started && !paused;
+    try { if (show) mount.removeAttribute('hidden'); else mount.setAttribute('hidden', 'hidden'); }
+    catch (e) { /* noop */ }
+  }
+
+  function setPaused(on) {
+    const next = !!on;
+    if (next === paused) return;
+    paused = next;
+    applyVisibility();
+    if (paused) {
+      if (rafId) { clock.caf(rafId); rafId = 0; }
+      endScene();
+      lastFrameMs = 0;
+    } else {
+      lastFrameMs = 0;
+      pump();
+    }
+  }
+
+  function start() {
+    if (destroyed || started) return;
+    started = true;
+    applyVisibility();
+    if (!docBound) {
+      try {
+        if (typeof document !== 'undefined' && document && typeof document.addEventListener === 'function') {
+          document.addEventListener('visibilitychange', onVisibility);
+          docBound = true;
+        }
+      } catch (e) { /* noop */ }
+    }
+    onVisibility();
+    applyVisibility();
+    // The first placement is SYNCHRONOUS, so the layer is never revealed for one
+    // frame with everybody still standing on the origin.
+    pump();
+  }
+
+  function stop() {
+    started = false;
+    applyVisibility();
+    if (rafId) { clock.caf(rafId); rafId = 0; }
+    endScene();
+  }
+
+  function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+    stop();
+    if (unsub) { try { unsub(); } catch (e) { /* noop */ } unsub = null; }
+    if (docBound) {
+      try { document.removeEventListener('visibilitychange', onVisibility); } catch (e) { /* noop */ }
+      docBound = false;
+    }
+    clearLayer();
+    plan = null;
+    encounters = [];
+  }
+
+  /* -------------------------------------------------------------- intake -- */
+
+  const mode = opts.mode === 'fixture' ? 'fixture' : 'bridge';
+  if (mode === 'fixture') {
+    loadFixture();
+  } else if (opts.bridge && typeof opts.bridge.on === 'function') {
+    // THE HOST'S PUSH. Multi-subscriber by construction (trap 11), so nothing
+    // else's frames are stolen; a host that never pushes leaves the layer empty.
+    try {
+      unsub = opts.bridge.on('presence', (m) => {
+        try {
+          if (!m || destroyed) return;
+          if (m.self !== undefined) selfId = m.self == null ? null : String(m.self);
+          if (m.snapshot) setSnapshot(m.snapshot);
+        } catch (e) { say('presence frame threw: ' + ((e && e.message) || e)); }
+      });
+    } catch (e) { say('presence: no bridge subscription (' + ((e && e.message) || e) + ')'); }
+  }
+
+  function loadFixture() {
+    let url = opts.fixtureUrl;
+    if (!url) {
+      try { url = new URL('fixtures/presence.json', import.meta.url).href; }
+      catch (e) { url = 'shell/fixtures/presence.json'; }
+    }
+    if (typeof fetch !== 'function') { say('presence: fixture mode with no fetch - empty layer'); return; }
+    try {
+      fetch(url)
+        .then((r) => (r && r.ok ? r.json() : null))
+        .then((j) => { if (j && !destroyed) setSnapshot(j); else if (!j) say('presence: fixture unreadable'); })
+        .catch((e) => say('presence: fixture failed (' + ((e && e.message) || e) + ')'));
+    } catch (e) { say('presence: fixture threw (' + ((e && e.message) || e) + ')'); }
+  }
+
+  return {
+    start,
+    stop,
+    setPaused,
+    setSnapshot,
+    /** Test seam: drive one frame at an explicit wall time. */
+    tick,
+    destroy,
+    diagnostics() {
+      return {
+        started, paused, still, mode, timeScale,
+        ghosts: plan ? plan.schedules.length : 0,
+        overflow: plan ? plan.overflow : 0,
+        drawn: nodes.size,
+        hash: plan ? plan.hash : '',
+        epoch: planEpoch,
+        encounters: encounters.length,
+        onStage: !!live,
+        self: selfId,
+      };
+    },
+  };
+}
+
+export default createGhosts;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
@@ -66,6 +66,10 @@ export const SETTING_KEYS = Object.freeze({
   }),
   audioMute: 'audioMute',
   hideTutorial: 'hideTutorial',
+  /** CAMPUS PRESENCE (PRESENCE.md §3): the ONE consent flag this page may write.
+   *  `off` | `anon` | `username` | `discord`, and the host re-clamps every one of
+   *  them - an unknown value lands on `off`, never on the nearest rung. */
+  presenceShare: 'presenceShare',
   /** The whole keybind map, as an OBJECT (the host stores it as JSON itself). */
   keybinds: 'keybinds',
 });
@@ -74,6 +78,7 @@ export const SETTING_KEYS = Object.freeze({
 const GLOBAL_KEYS = new Set([
   SETTING_KEYS.masterIntensity, SETTING_KEYS.effectIntensity,
   SETTING_KEYS.audioMute, SETTING_KEYS.hideTutorial, SETTING_KEYS.keybinds,
+  SETTING_KEYS.presenceShare,
   'masterVolume', 'remoteMediaRatio',
   // WHOLE-OBJECT echoes are globals too (W0, 2026-08-24): the host answers the
   // mixer as one `{key:'audioLevels', value:{...}}` frame, and the undotted key
@@ -110,10 +115,23 @@ export const AUDIO_GROUPS = Object.freeze([
   { g: 'music', label: 'Music' },
 ]);
 
+/** CAMPUS PRESENCE's consent ladder, weakest first and `off` at the bottom. The
+ *  ORDER is the ladder's, so the select reads as a ramp rather than as a menu. */
+export const PRESENCE_RUNGS = Object.freeze(['off', 'anon', 'username', 'discord']);
+
+/** English floors for the four rungs, used only when the lexicon has no row. */
+const PRESENCE_FALLBACK = Object.freeze({
+  off: 'Off - room head counts only',
+  anon: 'Anonymous - a ghost with no name or picture',
+  username: 'Username - your display name over the ghost',
+  discord: 'Discord - your display name and profile picture',
+});
+
 /** A per-game manifest may not name any of these (they are global). */
 const GLOBAL_RESERVED = new Set(
   ['masterIntensity', 'effectIntensity', 'audioMute', 'hideTutorial', 'mediaSource',
-    'remoteMediaRatio', 'offlineMode', 'masterVolume', 'motionLevel', 'reducedMotion']
+    'remoteMediaRatio', 'offlineMode', 'masterVolume', 'motionLevel', 'reducedMotion',
+    'presenceShare']
     .concat(CAP_CHANNELS.map((c) => c.ch))
     .concat(AUDIO_GROUPS.map((a) => a.g))
 );
@@ -413,8 +431,36 @@ export function createSettingsPage({ init, bridge, games, keybinds, onClose, log
       value: !!src.hideTutorial,
     }));
 
+    /* CAMPUS PRESENCE - the consent row (PRESENCE.md §3). It sits in the GLOBAL
+     * tier and not in the read-only ceilings above, because it is the one thing
+     * on this page the player grants rather than inherits: the app has no
+     * surface for it, so this IS the surface.
+     *
+     * FOUR RUNGS AND EVERY LABEL SAYS WHAT IT SHOWS. A row called only
+     * "Anonymous" is not consent copy; "a ghost with no name or picture" is.
+     * Everything here goes through t(), the shell's whole string law, so a mod
+     * can re-voice the copy - the C# NeutralLexicon mirrors all seven rows.
+     *
+     * The value is a STRING and selectRow sends it verbatim (its Number() path
+     * only takes over for a value that round-trips as a number), which is what
+     * the host's `presenceShare` clamp expects. Only the echo moves the model,
+     * trap 1, exactly like every other row on this page. */
+    const gp = group(t('presence_student_body', 'Student Body'));
+    gp.appendChild(selectRow({
+      key: SETTING_KEYS.presenceShare,
+      label: t('presence_share_label', 'Show yourself on campus'),
+      hint: t('presence_share_hint',
+        'Your last 24 hours replay as a ghost. Room head counts include you at every rung.'),
+      value: PRESENCE_RUNGS.indexOf(String(src.presenceShare)) >= 0 ? String(src.presenceShare) : 'off',
+      options: PRESENCE_RUNGS,
+      format: (o) => t('presence_share_' + o, PRESENCE_FALLBACK[o] || String(o)),
+    }));
+    gp.appendChild(el('p', 'arc-note', t('presence_share_discord_note',
+      'Discord needs a linked account. Without one the school shows your name instead.')));
+
     const frag = document.createDocumentFragment();
     frag.appendChild(g); frag.appendChild(gc); frag.appendChild(ga); frag.appendChild(gt);
+    frag.appendChild(gp);
     return frag;
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -36,6 +36,7 @@ import {
 } from '../games/registry.js';
 import { createBoard } from './splitflap.js';
 import { createCampus, campusState } from './campus.js';
+import { createGhosts, presenceOptions } from './ghosts.js';
 import { createReportCard } from './reportcard.js';
 import { createSettingsPage, boardSizeKey, SETTING_KEYS, isGlobalSettingKey } from './settings.js';
 import { createCeremonies } from './ceremonies.js';
@@ -422,6 +423,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let greeted = false;
   let board = null;
   let campus = null;               // the night-campus hub (OPTIONAL - see showBoard)
+  // THE STUDENT BODY (PRESENCE.md). Optional in exactly the way the campus is:
+  // it hangs off the campus's own ghost layer, so it lives and dies with it and
+  // no other screen has ever heard of it.
+  let ghosts = null;
   let extrasBox = null;            // replay/report bar + yesterday strip container
   let settingsPage = null;
   let reportCard = null;
@@ -605,6 +610,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     // beside dismissEndCard() at every real screen change instead, and
     // showReport() re-seats it after a repaint (same treatment, same reason).
     // The campus owns a 1s bell interval; a screen wipe must not orphan it.
+    if (ghosts) { try { ghosts.destroy(); } catch (e) { /* noop */ } ghosts = null; }
     if (campus) { try { campus.destroy(); } catch (e) { /* noop */ } campus = null; }
     extrasBox = null;
     // Every screen switch funnels through here, so no throw path can strand
@@ -864,6 +870,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         // content; regression #978's rule).
         boardPulse: store.get('boardOpenedDate') !== localDate,
         on: {
+          /* THE STUDENT BODY STARTS HERE AND NOWHERE ELSE (PRESENCE §4): after
+           * the entry reveal, never during it. The campus fires this once; a
+           * layer that failed to build simply never answers. */
+          revealDone: () => { try { if (ghosts) ghosts.start(); } catch (e) { say('presence start threw: ' + ((e && e.message) || e)); } },
           boardToggle: (expanded) => {
             if (!expanded) return;
             // Opening IS the flip: roll the flaps through, and remember the
@@ -904,6 +914,27 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       campus.boardMount.appendChild(board.root);
       renderBoardExtras(campus.footMount);
       dom.screen.appendChild(campus.root);
+      /* CAMPUS PRESENCE. Built AFTER the stage is in the document and started
+       * only by the campus's revealDone hook. It is its own try/catch for the
+       * campus's reason: a ghost layer that throws costs the player some company,
+       * never the school. With no host push and no `?presence=fixture` it draws
+       * nothing at all and logs nothing - the feature is silently absent, which
+       * is the whole reason it can merge before the server half exists. */
+      try {
+        const pOpts = presenceOptions();
+        ghosts = createGhosts({
+          mount: campus.ghostMount,
+          bridge,
+          mode: pOpts.mode,
+          fast: pOpts.fast,
+          reducedMotion,
+          log: say,
+        });
+        if (campus.revealDone && campus.revealDone()) ghosts.start();
+      } catch (e) {
+        say('presence layer unavailable (' + ((e && e.message) || e) + ')');
+        ghosts = null;
+      }
       // The window IS the campus: the topbar's content is diegetic in-scene
       // (crest, student ID, Registrar/gear), so the bar itself steps aside.
       // Every other screen re-shows it through renderTopbar().
@@ -2316,6 +2347,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   function applySuspend(on, reason) {
     suspendedGlobally = !!on;
     fireMoment(on ? 'suspend' : 'resume', { reason });   // EMI SEAM
+    // NO GHOSTS UNDER A MANDATORY VIDEO. The layer rides the same one funnel the
+    // pause card does, and it is a LEVEL (trap 28), so both edges are written.
+    if (ghosts) { try { ghosts.setPaused(!!on); } catch (e) { /* noop */ } }
     if (active) {
       try { active.engine.suspend(!!on); } catch (e) { say('engine.suspend threw: ' + ((e && e.message) || e)); }
       try { active.peek.forceHide(); } catch (e) { /* noop */ }
@@ -2580,6 +2614,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       disarmPunch();
       teardownClass();
       setStage(null);
+      if (ghosts) { try { ghosts.destroy(); } catch (e) { /* noop */ } ghosts = null; }
       if (campus) { try { campus.destroy(); } catch (e) { /* noop */ } campus = null; }
       try { ceremonies.destroy(); } catch (e) { /* noop */ }
       if (settingsPage) { try { settingsPage.destroy(); } catch (e) { /* noop */ } }

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1821,6 +1821,139 @@ html.arc-reduced .campus-sparkle { animation:none; opacity:0; }
   .campus-sparkle { animation:none; opacity:0; }
 }
 
+
+/* ======================= THE STUDENT BODY (presence) =====================
+   shell/ghosts.js draws into `g.campus-students`, a SIBLING of `.campus-route`
+   (above the floor, under the rooms and their door arcs). Three laws hold here
+   and every one of them is inherited:
+
+     - NOT ONE HEX. Every hue below is derived from the shell's own tokens, so
+       `init.palette` reskins the student body exactly the way it reskins the
+       plan. The eight shirt hues and six hair hues are `hue-rotate` filters over
+       ONE token, which is what keeps a deterministic per-id look out of the
+       colour table entirely.
+     - `pointer-events:none` ON THE LAYER (trap 59). A full-plan layer that took
+       clicks would eat every room the way `#arc-emi` would have.
+     - NO COMPETING `[hidden]` RULE (trap 27). The reset at the top of this file
+       is what hides a ghost that is off-stage and the whole layer while a class
+       runs; nothing here writes a bare `display:`.
+
+   The age tiers are the honesty (PRESENCE §1.2): an evening that happened at
+   teatime is a firefly, not a classmate standing next to you.
+
+   THE NAMES ARE `campus-student` / `campus-students` AND THEY HAD TO CHANGE.
+   The obvious `campus-ghost` was ALREADY TAKEN - it is the sealed-wing plate
+   that teases a locked class's name, and it carries `fill:none` plus
+   `stroke-dasharray:4 5`. Both are inherited SVG presentation properties, so
+   every rect and every bubble inside a student wearing that class came out
+   hollow and dashed (browser capture, 2026-08-24; the node suites cannot see
+   it, because a DOM double never paints). `campus-ghostcursor` is the attract
+   cursor and is a third thing again.
+   ---------------------------------------------------------------------- */
+g.campus-students { pointer-events:none; }
+
+.campus-student { transition:opacity .5s ease; }
+.campus-student[data-tier="live"]  { opacity:1; }
+.campus-student[data-tier="fresh"] { opacity:.92; }
+.campus-student[data-tier="dim"]   { opacity:.55; }
+.campus-student[data-tier="faint"] { opacity:.28; }
+
+/* THE LIVE RIM - the one thing that says "this happened minutes ago". A drop
+   shadow on the group, not a stroke on every pixel: the sprite is a dozen rects
+   and stroking them would draw the seams between them. */
+.campus-student[data-tier="live"] .gh-sprite,
+.campus-student[data-tier="live"] .gh-chip {
+  filter:drop-shadow(0 0 2.5px var(--pink)) drop-shadow(0 0 6px color-mix(in srgb, var(--pink), transparent 55%));
+}
+
+/* the pixel student - shape-rendering keeps the pixels PIXELS at any zoom */
+.gh-sprite rect { shape-rendering:crispEdges; }
+.gh-skin  { fill:color-mix(in srgb, var(--ink), var(--slate) 34%); }
+.gh-k1    { fill:color-mix(in srgb, var(--ink), var(--slate) 52%); }
+.gh-k2    { fill:color-mix(in srgb, var(--ink-dim), var(--pink) 12%); }
+.gh-k3    { fill:color-mix(in srgb, var(--ink-dim), var(--slate) 40%); }
+.gh-eye   { fill:var(--ground); }
+.gh-leg   { fill:color-mix(in srgb, var(--navy), var(--lav) 22%); }
+.gh-bag   { fill:color-mix(in srgb, var(--gold), var(--navy) 30%); }
+.gh-hair  { fill:var(--lav); }
+.gh-shirt { fill:var(--pink); }
+/* ONE token, eight/six turns of it. A palette swap moves all fourteen at once
+   and a mod never has to name a colour it did not choose. */
+.gh-h0 { filter:none; }
+.gh-h1 { filter:hue-rotate(40deg); }
+.gh-h2 { filter:hue-rotate(80deg) saturate(.8); }
+.gh-h3 { filter:hue-rotate(160deg); }
+.gh-h4 { filter:hue-rotate(230deg) saturate(.7); }
+.gh-h5 { filter:hue-rotate(300deg); }
+.gh-s0 { filter:none; }
+.gh-s1 { filter:hue-rotate(35deg); }
+.gh-s2 { filter:hue-rotate(70deg) saturate(.85); }
+.gh-s3 { filter:hue-rotate(120deg); }
+.gh-s4 { filter:hue-rotate(175deg); }
+.gh-s5 { filter:hue-rotate(215deg); }
+.gh-s6 { filter:hue-rotate(265deg) saturate(.8); }
+.gh-s7 { filter:hue-rotate(320deg); }
+
+/* the discord tier's avatar chip */
+.gh-chip-ring { fill:none; stroke:var(--lav); stroke-width:1.2; opacity:.8; }
+
+/* THE NAME PLATE. An SVG <text> and NOT an abs-positioned HTML box on purpose:
+   a left-anchored abs-pos label shrink-wraps against whatever is left of its
+   containing block and wraps every name three characters per row (the plaque
+   trap, and EMI's bubble paid for it twice). A centred <text> has no box to
+   shrink and cannot regress that way. */
+.gh-name {
+  font-family:var(--pix); font-size:5.4px; letter-spacing:.04em;
+  fill:var(--campus-text); text-anchor:middle;
+  paint-order:stroke; stroke:var(--campus-sky); stroke-width:1.6; stroke-linejoin:round;
+}
+
+/* the encounter bubble - the campus's pixel face, 1-4 characters, never prose */
+.gb-box { fill:var(--panel); stroke:var(--campus-line); stroke-width:1; }
+.gb-tail { fill:var(--panel); stroke:none; }
+.gb-t {
+  font-family:var(--pix); font-size:6px; fill:var(--ink); text-anchor:middle;
+}
+.gh-bubble { animation:gh-bubblein .18s ease-out both; }
+@keyframes gh-bubblein {
+  from { opacity:0; transform:translateY(3px); }
+  to { opacity:1; transform:translateY(0); }
+}
+/* the silent nod: the sprite dips two pixels and says nothing */
+.campus-student[data-scene="nod"] .gh-inner { animation:gh-nod .7s ease-in-out 2; }
+@keyframes gh-nod { 50% { transform:translateY(2px); } }
+
+/* grade S, at the door, on the beat the replay arrives */
+.gh-spark line {
+  stroke:var(--gold); stroke-width:1.6; stroke-linecap:round;
+  transform-box:fill-box; transform-origin:center;
+  animation:gh-spark .9s ease-out both;
+}
+@keyframes gh-spark {
+  from { opacity:0; transform:scale(.2); }
+  35% { opacity:1; transform:scale(1); }
+  to { opacity:0; transform:scale(1.5); }
+}
+
+/* THE BUSYNESS CHIP (PRESENCE §6). It counts the people who opted OUT as well,
+   which is the only place on this page their attendance is ever visible. */
+.cb-box { fill:var(--campus-hall); stroke:var(--campus-line); stroke-width:1; opacity:.94; }
+.cb-t {
+  font-family:var(--pix); font-size:6px; fill:var(--lav); text-anchor:middle;
+}
+
+/* REDUCED MOTION / the lit-down rung: ghosts stand where they stand. ghosts.js
+   already refuses to walk them - this is the belt on those braces, and it takes
+   the bubble's entry and the S pop with it. */
+html.arc-reduced .gh-bubble,
+html.arc-reduced .gh-spark line,
+html.arc-reduced .campus-student[data-scene="nod"] .gh-inner { animation:none; }
+html.arc-reduced .campus-student { transition:none; }
+@media (prefers-reduced-motion: reduce) {
+  .gh-bubble, .gh-spark line, .campus-student[data-scene="nod"] .gh-inner { animation:none; }
+  .campus-student { transition:none; }
+}
+
 /* small stages: hide the flourishes before they collide with the board */
 @media (max-width:760px), (max-height:600px) {
   .campus-idcard { display:none; }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1162,6 +1162,19 @@ internal static class ArcademyHostService
         ["campus_main_hall"] = "Main Hall",
         ["campus_the_quad"] = "The Quad",
         ["campus_front_path"] = "Front Path",
+
+        // CAMPUS PRESENCE - "The Student Body" (planning/arcademy/PRESENCE.md,
+        // shell/ghosts.js). Six rows and not one more: four BLIPS a ghost may
+        // say to another ghost, the busyness chip's label, and the layer's own
+        // name. The bubbles are 1-4 characters BY LAW - a mod re-voices the
+        // greeting without ever being able to put a sentence over a stranger's
+        // head, and every one is far under the 96-char MergeModTable cap.
+        ["presence_student_body"] = "Student Body",
+        ["presence_bubble_hi"] = "hihi",
+        ["presence_bubble_dots"] = "...",
+        ["presence_bubble_wave_a"] = "o/",
+        ["presence_bubble_wave_b"] = "\\o",
+        ["presence_here_tonight"] = "here tonight",
         ["campus_east_wing"] = "East Wing",
         ["campus_west_wing"] = "West Wing",
         ["campus_desc_east"] = "You can hear hammering behind the tape.",

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -196,6 +196,14 @@ internal static class ArcademyHostService
             // exactly the same, on the cards this machine already holds.
             ArcademySyncService.Attach(_meta, OnMirrorCardsChanged);
 
+            // CAMPUS PRESENCE (PRESENCE.md §3). Two independent halves behind one Attach: the
+            // EMITTER announces `campus_enter` (only if the player has opted in - the rung is read
+            // inside), and the SNAPSHOT PUSHER starts polling the public feed and handing it to
+            // the page. The pusher is deliberately NOT gated on the share setting: watching is not
+            // consenting, so a campus is populated for everyone who is online. Nothing here is
+            // awaited and no part of the launch depends on it.
+            ArcademyPresenceService.Attach(OnPresenceSnapshot);
+
             var webRoot = Path.Combine(AppContext.BaseDirectory, "Resources", "web");
             var mappings = new List<(string, string, CoreWebView2HostResourceAccessKind)>
             {
@@ -519,6 +527,9 @@ internal static class ArcademyHostService
                 _classActive = true;
                 App.Logger?.Information("ArcademyHost: class started ({Game}, tier {Tier})",
                     (string?)o["gameKey"], (int?)o["gradeTier"] ?? 0);
+                // CAMPUS PRESENCE: a door opened. Best-effort and gated on the share rung inside;
+                // at `off`, or with no identity, this line does nothing at all.
+                try { ArcademyPresenceService.NoteRoomEnter((string?)o["gameKey"]); } catch { }
                 break;
             case "class-ended":
                 OnClassEnded(o);
@@ -641,6 +652,12 @@ internal static class ArcademyHostService
             settings = BuildSettingsBag(s),
             keybinds = ParseJsonObject(s?.ArcademyKeybindsJson),
             hideTutorial = s?.ArcademyHideTutorial ?? false,
+            // CAMPUS PRESENCE, the consent rung, projected TOP-LEVEL beside the other global-tier
+            // scalars so the settings page can draw the row it owns (PRESENCE.md §3). `off` is the
+            // default and the fallback for anything unreadable - a consent flag never degrades to
+            // the nearest neighbour. It is the rung this account ASKED for: the server clamps it
+            // down silently when the account cannot back it (no linked Discord, no display name).
+            presenceShare = PresenceShare(s),
             // The app-wide panic key, projected for ONE reason (SYNTHESIS-NOTES #7):
             // shell/keybinds.js refuses to let a game bind over it. The page never
             // handles the panic key itself - that stays app-side.
@@ -1175,6 +1192,17 @@ internal static class ArcademyHostService
         ["presence_bubble_wave_a"] = "o/",
         ["presence_bubble_wave_b"] = "\\o",
         ["presence_here_tonight"] = "here tonight",
+        // ...and the CONSENT ROW (P3, the settings page's global tier). Every option says what
+        // it shows PUBLICLY, because the player is agreeing to a specific thing and a rung named
+        // only "Anonymous" is not one. All well under the 96-char MergeModTable cap (trap 26), so
+        // a mod may re-word the consent copy in its own voice - which is why it lives here at all.
+        ["presence_share_label"] = "Show yourself on campus",
+        ["presence_share_hint"] = "Your last 24 hours replay as a ghost. Room head counts include you at every rung.",
+        ["presence_share_off"] = "Off - room head counts only",
+        ["presence_share_anon"] = "Anonymous - a ghost with no name or picture",
+        ["presence_share_username"] = "Username - your display name over the ghost",
+        ["presence_share_discord"] = "Discord - your display name and profile picture",
+        ["presence_share_discord_note"] = "Discord needs a linked account. Without one the school shows your name instead.",
         ["campus_east_wing"] = "East Wing",
         ["campus_west_wing"] = "West Wing",
         ["campus_desc_east"] = "You can hear hammering behind the tape.",
@@ -2158,6 +2186,14 @@ internal static class ArcademyHostService
             // Shared with the descent on purpose: ONE photosensitivity guard app-wide.
             case "effectIntensity": s.ChaosEffectIntensity = Num(0.85); return s.ChaosEffectIntensity;
 
+            // CAMPUS PRESENCE, the one CONSENT flag the page may write (PRESENCE.md §3). The
+            // clamp is an allowlist, not a tolerance: anything that is not one of the four rungs
+            // is stored as `off`, so a malformed frame can only ever REDUCE what the account
+            // shows. Echoed post-clamp like every other key - trap 1, only the echo moves it.
+            case "presenceShare":
+                s.ArcademyPresenceShare = (value?.Type == JTokenType.String ? (string?)value : null) ?? "off";
+                return s.ArcademyPresenceShare;
+
             case "audioMute": s.ArcademyAudioMute = Flag(false); return s.ArcademyAudioMute;
             case "hideTutorial": s.ArcademyHideTutorial = Flag(false); return s.ArcademyHideTutorial;
 
@@ -2378,6 +2414,13 @@ internal static class ArcademyHostService
             }
             catch (Exception ex) { App.Logger?.Warning("ArcademyHost punch card: {E}", ex.Message); }
 
+            // CAMPUS PRESENCE: the class ended, and the letter that rides the wire is the HOST's
+            // clamped `grade` - the same value the XP table and the S double already read - so a
+            // junk field from the page cannot mint a grade for a stranger's map. A zen `pass` is
+            // not one of S/A/B/C and rides as null, which the renderer draws as a finish with no
+            // letter. Own try/catch: nothing about company may cost the payout frame below.
+            try { ArcademyPresenceService.NoteClassEnd(gameKey, grade); } catch { }
+
             if (_meta != null) _host?.Post(_meta.SnapshotMessage());
 
             _host?.Post(new
@@ -2468,6 +2511,39 @@ internal static class ArcademyHostService
             });
         }
         catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnMirrorCardsChanged: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// CAMPUS PRESENCE: one snapshot, straight to the page. THE FRAME IS LOCKED and
+    /// <c>shell/ghosts.js</c> consumes exactly it:
+    /// <c>{type:'presence', self:&lt;opaque id|null&gt;, snapshot:&lt;the server payload&gt;}</c>.
+    ///
+    /// <para>THE SNAPSHOT IS PASSED THROUGH UNMODIFIED, and that is a rule rather than laziness.
+    /// Its <c>now</c> is the SERVER's clock, which is what lets the page compute the server's ages
+    /// for every ghost - reshaping it, or "helpfully" rewriting a timestamp into local time, is the
+    /// one edit that would let a skewed machine clock invent a live student.</para>
+    ///
+    /// <para><c>self</c> is always included, because omitting it leaves the page's previous value
+    /// standing; <c>snapshot</c> is null on the frame that only carries a newly-learned id, and the
+    /// page leaves the crowd it is drawing exactly where it is.</para>
+    /// </summary>
+    private static void OnPresenceSnapshot(string? self, JObject? snapshot)
+    {
+        try
+        {
+            var disp = Application.Current?.Dispatcher;
+            if (disp == null || disp.HasShutdownStarted) return;
+            disp.BeginInvoke(() =>
+            {
+                try
+                {
+                    if (_host == null) return;
+                    _host.Post(new { type = "presence", self, snapshot });
+                }
+                catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnPresenceSnapshot post: {E}", ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnPresenceSnapshot: {E}", ex.Message); }
     }
 
     /// <summary>
@@ -3495,6 +3571,7 @@ internal static class ArcademyHostService
         nameof(Models.AppSettings.OfflineMode),
         nameof(Models.AppSettings.MotionLevel),
         nameof(Models.AppSettings.ProtectBrowserVideoPlayback),
+        nameof(Models.AppSettings.ArcademyPresenceShare),
     };
 
     private static void OnSettingChangedInApp(object? sender, PropertyChangedEventArgs e)
@@ -3560,8 +3637,20 @@ internal static class ArcademyHostService
         nameof(Models.AppSettings.OfflineMode) => ("offlineMode", s.OfflineMode),
         nameof(Models.AppSettings.MotionLevel) => ("motionLevel", ResolvedMotionLevel()),
         nameof(Models.AppSettings.ProtectBrowserVideoPlayback) => ("protectBrowserVideo", s.ProtectBrowserVideoPlayback),
+        // CAMPUS PRESENCE. Clamped on the way out as well as on the way in: the property already
+        // refuses an unknown rung, and reading it through the same allowlist here means a
+        // hand-edited settings file can never project a rung the page has no control for.
+        nameof(Models.AppSettings.ArcademyPresenceShare) => ("presenceShare", PresenceShare(s)),
         _ => (null, null),
     };
+
+    /// <summary>The presence rung, clamped to the four we know. Anything else is <c>off</c> - a
+    /// consent flag degrades to "no consent", never to the nearest neighbour.</summary>
+    private static string PresenceShare(Models.AppSettings? s)
+    {
+        var v = (s?.ArcademyPresenceShare ?? "").Trim().ToLowerInvariant();
+        return Array.IndexOf(Models.AppSettings.ArcademyPresenceShares, v) >= 0 ? v : "off";
+    }
 
     // ============================ watchdogs / recovery ============================
 
@@ -3697,6 +3786,9 @@ internal static class ArcademyHostService
             // sent now (payload taken first, so the request outlives this window without touching
             // anything being disposed) and every reply still in the air is dropped by generation.
             try { ArcademySyncService.Detach(); } catch { }
+            // Stop the presence poll BEFORE the host goes: the timer must never outlive the window
+            // that armed it, and Detach also sends this session's one best-effort `campus_leave`.
+            try { ArcademyPresenceService.Detach(); } catch { }
             try { _meta?.FlushSave(); } catch { }
             _meta = null;
             _classActive = false;

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyPresenceService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyPresenceService.cs
@@ -1,0 +1,558 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ConditioningControlPanel.Services.Arcademy;
+
+/// <summary>
+/// CAMPUS PRESENCE, host side ("the Student Body", <c>planning/arcademy/PRESENCE.md</c> §3; wire
+/// contract <c>proxy/docs/arcademy-presence-api.md</c>). Two halves that share nothing but an
+/// HttpClient, and the split is the whole privacy story:
+///
+/// <list type="number">
+/// <item><description>THE EMITTER pushes four state transitions - <c>campus_enter</c>,
+/// <c>room_enter</c>, <c>class_end</c>, <c>campus_leave</c> - and runs ONLY while
+/// <see cref="Models.AppSettings.ArcademyPresenceShare"/> is something other than <c>off</c>. A
+/// transition is a room key and a letter grade; there is no coordinate in this file, no field for
+/// one, and none is ever computed here. Where a ghost walks is <c>shell/ghosts.js</c>'s invention
+/// from the event list.</description></item>
+/// <item><description>THE SNAPSHOT PUSHER pulls the public feed and hands it to the page. It is
+/// gated on the window being open and OfflineMode being off, and on NOTHING ELSE: watching is not
+/// consenting, so a player at <c>off</c> still gets a populated campus. The endpoint is
+/// unauthenticated for exactly that reason.</description></item>
+/// </list>
+///
+/// <para>BEST-EFFORT, ArcademySyncService's house rules verbatim: no dialog, no toast, no blocking,
+/// no retry storm. One log line per failure, bodies truncated, and a failure costs the player some
+/// company - never a class, never a grade, never a punch. The Arcademy is fully playable with this
+/// class doing nothing at all, which is what lets the setting default to off and stay there.</para>
+///
+/// <para>THE PLAYER'S OWN GHOST IS NEVER DRAWN. Each POST answers with this account's opaque id
+/// (<c>self</c>), which rides every frame we push so the page can subtract itself from the crowd.
+/// Until a POST lands - which at <c>off</c> is forever - it is null, and the page simply draws
+/// everybody.</para>
+/// </summary>
+internal static class ArcademyPresenceService
+{
+    /// <summary>The proxy, spelled the way every other service here spells it (there is no shared
+    /// constant in this codebase - ArcademySyncService, V2AuthService, ProfileSyncService and
+    /// RemoteControlService each carry their own copy).</summary>
+    private const string ProxyBaseUrl = "https://codebambi-proxy.vercel.app";
+
+    private const string EventPath = "/v2/arcademy/presence";
+    private const string SnapshotPath = "/v2/arcademy/presence/snapshot";
+
+    /// <summary>Snapshot cadence. The CDN holds the feed for 30s with a 25s Redis memo underneath,
+    /// so polling faster than this buys a cached body and nothing else. Jittered so a thousand
+    /// clients that all opened the campus at 9pm do not arrive as one wave.</summary>
+    private static readonly TimeSpan SnapshotPeriod = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan SnapshotJitter = TimeSpan.FromSeconds(10);
+
+    /// <summary>Bodies are truncated in the log the way <c>V2AuthService.TruncateForLog</c> does.</summary>
+    private const int MaxLoggedBody = 200;
+
+    /// <summary>The snapshot is public and modest (under 30 KB served at the 200-student cap), but
+    /// a body this class never asked for must not be read into memory unbounded.</summary>
+    private const int MaxSnapshotChars = 4_000_000;
+
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    static ArcademyPresenceService()
+    {
+        try
+        {
+            Http.DefaultRequestHeaders.Add("X-Client-Version", UpdateService.AppVersion);
+            Http.DefaultRequestHeaders.UserAgent.ParseAdd($"ConditioningControlPanel/{UpdateService.AppVersion}");
+        }
+        catch { /* a header we could not set is not worth failing a static ctor over */ }
+    }
+
+    /// <summary>
+    /// THE ROOM VOCABULARY, and it is deliberately its OWN table (the server says so in the same
+    /// words): the wire is kebab-case, the page's game keys are snake_case, and the punch-card
+    /// mirror next door uses a third list. Two features, two vocabularies, no shared table to
+    /// drift. A key that is not in here is not sent at all - a `room_enter` with an unknown room
+    /// is a 400, and losing one event is cheaper than teaching the server a new room by accident.
+    ///
+    /// <para><c>misdirection</c> stays listed although the room is dark in the client
+    /// (<c>RETIRED_GAMES</c>): a 24h window can still be replaying a ghost who was in it, and a
+    /// retake of a retired class through the dev door is still a real transition.</para>
+    /// </summary>
+    private static readonly HashSet<string> Rooms = new(StringComparer.Ordinal)
+    {
+        "anomaly", "composure", "daily-trigger", "deja-vu", "echo",
+        "impulse-control", "instant-recall", "lost-and-found", "misdirection",
+        "sort", "the-deep-end",
+    };
+
+    /// <summary>The four letters the wire knows. A zen finish reports <c>pass</c>, which is not a
+    /// grade and rides as null - "was here, no grade" is a fact the renderer draws.</summary>
+    private static readonly HashSet<string> Grades = new(StringComparer.Ordinal) { "S", "A", "B", "C" };
+
+    /// <summary>Rung ordering, the server's <c>SHARE_RANK</c> verbatim. Used for ONE decision: did
+    /// this change reduce what the account shows, which is the change that owes a POST.</summary>
+    private static int Rank(string? share) => share switch
+    {
+        "anon" => 1,
+        "username" => 2,
+        "discord" => 3,
+        _ => 0,       // "off", and anything unreadable
+    };
+
+    private static readonly object Gate = new();
+
+    /// <summary>Raised on a background thread with (self, snapshot) when a snapshot arrives whole.
+    /// The caller owns marshalling it to the dispatcher and posting it - this class never touches
+    /// the WebView2 and never touches the dispatcher.</summary>
+    private static Action<string?, JObject?>? _onSnapshot;
+
+    /// <summary>The poller. A <see cref="Timer"/> rather than a DispatcherTimer on purpose: it must
+    /// not ride the UI thread, and it must be disposable from <see cref="Detach"/> without caring
+    /// which thread is doing the disposing.</summary>
+    private static Timer? _poll;
+
+    /// <summary>Bumped by <see cref="Detach"/>. Every continuation captures the value it started
+    /// with and drops itself when the two disagree, so a snapshot that lands after the window
+    /// closed can never be pushed into the NEXT window's page (the same generation guard
+    /// <see cref="ArcademySyncService"/> and the host's remote batches use).</summary>
+    private static int _generation;
+
+    /// <summary>True between <see cref="Attach"/> and <see cref="Detach"/>. The snapshot half reads
+    /// it as "is there a campus to draw on".</summary>
+    private static bool _open;
+
+    /// <summary>This account's opaque id, as last answered by a POST. Null until one lands - and at
+    /// the <c>off</c> rung that is forever, which is correct: a player with no ghost has no id to
+    /// subtract.</summary>
+    private static string? _self;
+
+    /// <summary>Did this session put ANYTHING on the wire? A lone <c>campus_leave</c> from a
+    /// session that never announced itself would draw a student who only ever left.</summary>
+    private static bool _emitted;
+
+    /// <summary>The rung the last change was measured against. Seeded on the first hook so the
+    /// first change we see is compared to the truth, not to <c>off</c>.</summary>
+    private static string _lastShare = "off";
+
+    /// <summary>The settings instance we are watching. Hooked at the first <see cref="Attach"/> and
+    /// deliberately NEVER unhooked: the consent obligation below ("post one campus_leave when the
+    /// rung drops") is at its most useful when the window is already shut, and a static handler on
+    /// the settings singleton costs nothing. Re-pointed if <c>App.Settings.Current</c> is
+    /// replaced (a cloud restore), the way the host's own watch is.</summary>
+    private static Models.AppSettings? _hookedSettings;
+
+    // ============================ lifecycle ============================
+
+    /// <summary>
+    /// The campus opened. Emits <c>campus_enter</c> (if the player consents), pulls the first
+    /// snapshot immediately and arms the poller. Called from <see cref="ArcademyHostService"/>'s
+    /// launch beside <see cref="ArcademySyncService.Attach"/> - nothing here is awaited and the
+    /// launch does not depend on any of it.
+    /// </summary>
+    /// <param name="onSnapshot">Raised (on a background thread) with the account's opaque id and
+    /// the server snapshot VERBATIM. The caller marshals and posts it.</param>
+    public static void Attach(Action<string?, JObject?> onSnapshot)
+    {
+        lock (Gate)
+        {
+            _onSnapshot = onSnapshot;
+            _open = true;
+            _emitted = false;
+        }
+        HookSettings();
+        int generation = Volatile.Read(ref _generation);
+        Emit("campus_enter", null, null, generation);
+        Run(() => PullSnapshotAsync(generation), "snapshot");
+        ArmPoll(Delay());
+    }
+
+    /// <summary>
+    /// The campus closed. Stops the poller (a timer must never outlive the window that armed it),
+    /// retires the generation so anything still on the network drops itself, and sends one
+    /// best-effort <c>campus_leave</c> - only if this session ever announced itself. The server
+    /// auto-expires a silent account anyway, so a leave that never lands costs a ghost a fade
+    /// instead of a walk-out.
+    /// </summary>
+    public static void Detach()
+    {
+        bool announce;
+        lock (Gate)
+        {
+            _open = false;
+            _onSnapshot = null;
+            announce = _emitted;
+            _emitted = false;
+            try { _poll?.Dispose(); } catch { }
+            _poll = null;
+        }
+        Interlocked.Increment(ref _generation);
+        // Detached: no page to push into and no generation to belong to, so this is send-and-forget
+        // (generation -1, the same escape ArcademySyncService.Detach's flush takes).
+        if (announce) Emit("campus_leave", null, null, -1);
+    }
+
+    // ============================ the four events ============================
+
+    /// <summary>A class started: the player walked into a room. <paramref name="gameKey"/> is the
+    /// page's own snake_case key and is translated here, once.</summary>
+    public static void NoteRoomEnter(string? gameKey)
+    {
+        var room = RoomFor(gameKey);
+        if (room == null) return;
+        Emit("room_enter", room, null, Volatile.Read(ref _generation));
+    }
+
+    /// <summary>A class ended. <paramref name="grade"/> is the HOST's clamped letter (the same
+    /// value that decided the XP multiplier and the S double), so a junk field from the page cannot
+    /// reach the wire; anything that is not S/A/B/C - a zen <c>pass</c> included - rides as null,
+    /// which the renderer draws as "was here, finished, no letter".</summary>
+    public static void NoteClassEnd(string? gameKey, string? grade)
+    {
+        var room = RoomFor(gameKey);
+        if (room == null) return;
+        var g = (grade ?? "").Trim().ToUpperInvariant();
+        Emit("class_end", room, Grades.Contains(g) ? g : null, Volatile.Read(ref _generation));
+    }
+
+    /// <summary>The page's game key -> the wire's room key, or null for anything not on the
+    /// server's allowlist.</summary>
+    private static string? RoomFor(string? gameKey)
+    {
+        var k = (gameKey ?? "").Trim().ToLowerInvariant().Replace('_', '-');
+        return Rooms.Contains(k) ? k : null;
+    }
+
+    // ============================ consent ============================
+
+    /// <summary>
+    /// Watch the share rung. Hooked once, at the first campus open, and never unhooked - see
+    /// <see cref="_hookedSettings"/>. Re-points at a replaced settings instance.
+    /// </summary>
+    private static void HookSettings()
+    {
+        try
+        {
+            var s = App.Settings?.Current;
+            if (s == null || ReferenceEquals(s, _hookedSettings)) return;
+            if (_hookedSettings != null) _hookedSettings.PropertyChanged -= OnSettingChanged;
+            s.PropertyChanged += OnSettingChanged;
+            _hookedSettings = s;
+            _lastShare = Share();
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.HookSettings: {E}", ex.Message); }
+    }
+
+    /// <summary>
+    /// THE CLIENT OBLIGATION (api doc, "The one gap, stated plainly"). The server's consent row is
+    /// only ever moved by a POST, and the snapshot filters on the CURRENT row - so a player who
+    /// lowers their rung and then never plays again keeps their prior 24 hours visible at the OLD
+    /// rung. One <c>campus_leave</c> carrying the new rung closes that, retroactively, for every
+    /// row already on disk. It is sent even outside a campus session, which is exactly the case it
+    /// exists for.
+    ///
+    /// <para>ONLY A DOWNGRADE OWES A POST. Moving UP shows more, and the account has not shown it
+    /// yet: the next real event carries the new rung and that is soon enough. Sending on the way up
+    /// would spend one of the twelve hourly writes to say nothing.</para>
+    ///
+    /// <para>AND <c>off</c> CANNOT BE SENT. <c>share</c> is validated against
+    /// <c>anon|username|discord</c>; there is no <c>off</c> on the wire and no revoke route on the
+    /// server (the doc's own words: "revoking is deleting"). Posting the nearest rung instead would
+    /// be this client asserting a consent the player just withdrew, which is the one thing it must
+    /// never do - so the honest move is to send nothing and say so once in the log. The account's
+    /// prior window ages out on its own inside 24 hours.</para>
+    /// </summary>
+    private static void OnSettingChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(Models.AppSettings.ArcademyPresenceShare)) return;
+        try
+        {
+            var now = Share();
+            var was = _lastShare;
+            _lastShare = now;
+            if (Rank(now) >= Rank(was)) return;      // unchanged, or the player showing MORE
+
+            if (Rank(now) == 0)
+            {
+                App.Logger?.Information(
+                    "[ArcademyPresence] presence turned off - the wire has no 'off' rung, so the account's"
+                    + " prior 24h ages out rather than being withdrawn now");
+                return;
+            }
+
+            App.Logger?.Information("[ArcademyPresence] rung dropped {Was} -> {Now} - posting a leave to move consent",
+                was, now);
+            // Deliberately generation -1: this can fire long after the window closed, and it has
+            // nothing to push back into the page.
+            Emit("campus_leave", null, null, -1);
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.OnSettingChanged: {E}", ex.Message); }
+    }
+
+    /// <summary>The rung as stored, lowercased, with anything unreadable reading as <c>off</c>.</summary>
+    private static string Share()
+    {
+        try { return (App.Settings?.Current?.ArcademyPresenceShare ?? "off").Trim().ToLowerInvariant(); }
+        catch { return "off"; }
+    }
+
+    // ============================ the emitter ============================
+
+    /// <summary>
+    /// One transition, fire-and-forget. Gated here rather than at each call site so there is
+    /// exactly one place that can decide to put something on the wire: no consent, no identity,
+    /// offline - nothing leaves, silently.
+    /// </summary>
+    private static void Emit(string kind, string? room, string? grade, int generation)
+    {
+        var share = Share();
+        if (Rank(share) == 0) return;                       // off: the whole feature is absent
+        if (!Identity(out var unifiedId, out var token)) return;
+        lock (Gate) { _emitted = true; }
+        Run(() => PostEventAsync(kind, room, grade, share, unifiedId, token, generation), kind);
+    }
+
+    private static async Task PostEventAsync(string kind, string? room, string? grade, string share,
+        string unifiedId, string token, int generation)
+    {
+        try
+        {
+            // THE BODY IS THE WHOLE CONTRACT and it is five fields. There is no name here, no
+            // picture, no timestamp and no position: `display` is read off the account server-side,
+            // `avatar` is resolved there, and `ts` is the server clock. A field this client added
+            // would be dropped, but the point is that it is never built.
+            var body = JsonConvert.SerializeObject(new
+            {
+                @event = kind,
+                room,
+                grade,
+                share,
+                unified_id = unifiedId,
+            });
+            using var request = new HttpRequestMessage(HttpMethod.Post, $"{ProxyBaseUrl}{EventPath}")
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add("X-Auth-Token", token);
+
+            using var response = await Http.SendAsync(request).ConfigureAwait(false);
+            var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                // No retry ladder, and deliberately not even the one gentle re-arm the card mirror
+                // takes: a transition is a MOMENT. Re-sending it a minute later would write a
+                // ghost walking into a room it has already left, and the renderer would believe it.
+                App.Logger?.Information("[ArcademyPresence] {Kind} refused: {Status} {Body}",
+                    kind, (int)response.StatusCode, Truncate(text));
+                return;
+            }
+
+            var self = (string?)Parse(text)?["self"];
+            if (string.IsNullOrWhiteSpace(self)) return;
+            var known = Volatile.Read(ref _self);
+            Volatile.Write(ref _self, self);
+            App.Logger?.Debug("ArcademyPresence: {Kind} logged", kind);
+            // The FIRST id is worth a frame of its own: the page has probably already drawn a
+            // snapshot that this account is standing in, and `self` is what removes it.
+            if (known != self && !Retired(generation)) PushSelfOnly(generation);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Information("[ArcademyPresence] {Kind} failed: {E}", kind, ex.Message);
+        }
+    }
+
+    // ============================ the snapshot pusher ============================
+
+    /// <summary>The next poll delay: the period plus or minus the jitter band.</summary>
+    private static TimeSpan Delay()
+    {
+        var span = SnapshotJitter.TotalMilliseconds;
+        var offset = (Random.Shared.NextDouble() * 2 - 1) * span;
+        return TimeSpan.FromMilliseconds(Math.Max(1000, SnapshotPeriod.TotalMilliseconds + offset));
+    }
+
+    /// <summary>Arm (or re-arm) the one-shot poll timer. Never armed while closed, and every tick
+    /// re-arms itself from inside the tick, so there is no repeating timer to leak.</summary>
+    private static void ArmPoll(TimeSpan delay)
+    {
+        lock (Gate)
+        {
+            if (!_open) return;
+            try
+            {
+                if (_poll == null)
+                {
+                    _poll = new Timer(_ => OnPollElapsed(), null, delay, Timeout.InfiniteTimeSpan);
+                    return;
+                }
+                _poll.Change(delay, Timeout.InfiniteTimeSpan);
+            }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.ArmPoll: {E}", ex.Message); }
+        }
+    }
+
+    private static void OnPollElapsed()
+    {
+        int generation = Volatile.Read(ref _generation);
+        lock (Gate) { if (!_open) return; }
+        Run(async () =>
+        {
+            await PullSnapshotAsync(generation).ConfigureAwait(false);
+            // Re-armed whatever happened: a failed poll keeps the cadence, because the campus is
+            // still open and the next one may well land.
+            if (!Retired(generation)) ArmPoll(Delay());
+        }, "snapshot");
+    }
+
+    /// <summary>
+    /// GET the public feed and hand it to the page WHOLE. Unauthenticated by design (a head count
+    /// and things people explicitly turned on), so this half runs at every rung including
+    /// <c>off</c> - watching is not consenting.
+    ///
+    /// <para>NOTHING IS RESHAPED. The snapshot's own <c>now</c> is what makes the page's ages the
+    /// SERVER's ages, so a skewed client clock cannot invent a live ghost; touching a timestamp
+    /// here would be the one way to break that. We validate the envelope and pass the object
+    /// through untouched.</para>
+    /// </summary>
+    private static async Task PullSnapshotAsync(int generation)
+    {
+        if (!Watchable()) return;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{ProxyBaseUrl}{SnapshotPath}");
+            using var response = await Http.SendAsync(request).ConfigureAwait(false);
+            var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                App.Logger?.Debug("ArcademyPresence: snapshot {Status} {Body}",
+                    (int)response.StatusCode, Truncate(text));
+                return;
+            }
+            if (text.Length > MaxSnapshotChars)
+            {
+                App.Logger?.Information("[ArcademyPresence] snapshot is {N} chars - ignored", text.Length);
+                return;
+            }
+
+            // A PARTIAL SNAPSHOT IS WORSE THAN NONE. The page replaces its whole plan on every
+            // frame it accepts, so half a feed would empty the campus and then refill it on the
+            // next poll - a flicker that reads as a bug. Refuse anything that is not the shape we
+            // know: v exactly 1 (a newer wire is not ours to guess at) and students an array.
+            var snapshot = Parse(text);
+            if (snapshot == null) return;
+            if ((int?)snapshot["v"] != 1 || snapshot["students"] is not JArray students)
+            {
+                App.Logger?.Information("[ArcademyPresence] snapshot shape refused (v={V})",
+                    (string?)snapshot["v"] ?? "?");
+                return;
+            }
+            if (Retired(generation)) return;
+
+            Action<string?, JObject?>? cb;
+            lock (Gate) cb = _onSnapshot;
+            if (cb == null) return;
+            App.Logger?.Debug("ArcademyPresence: snapshot with {N} student(s)", students.Count);
+            try { cb(Volatile.Read(ref _self), snapshot); }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.push: {E}", ex.Message); }
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyPresence: snapshot failed: {E}", ex.Message);
+        }
+    }
+
+    /// <summary>Push a frame that carries the id and NO snapshot. `ghosts.js` tests `if (m.snapshot)`
+    /// before it replaces anything, so a null there leaves the crowd it is already drawing exactly
+    /// where it is - which is the whole point: this frame says "you are that one", not "here is a
+    /// new campus". An EMPTY object would not do: it normalises to a snapshot with no students and
+    /// would blank the map until the next poll.</summary>
+    private static void PushSelfOnly(int generation)
+    {
+        Action<string?, JObject?>? cb;
+        lock (Gate) cb = _onSnapshot;
+        if (cb == null || Retired(generation)) return;
+        try { cb(Volatile.Read(ref _self), null); }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.PushSelfOnly: {E}", ex.Message); }
+    }
+
+    // ============================ small guards ============================
+
+    /// <summary>The snapshot half's only two gates: a campus to draw on, and an app that is allowed
+    /// on the network at all. Note what is NOT here - the share rung and the identity.</summary>
+    private static bool Watchable()
+    {
+        try
+        {
+            lock (Gate) { if (!_open) return false; }
+            return App.Settings?.Current?.OfflineMode != true;
+        }
+        catch { return false; }
+    }
+
+    /// <summary>
+    /// The token door: <c>X-Auth-Token</c> plus this account's own <c>unified_id</c> in the body
+    /// (the door the desktop holds; the Bearer door is the web's). No identity, no traffic - and
+    /// silently so: an account that has never logged in is not a problem to report.
+    /// </summary>
+    private static bool Identity(out string unifiedId, out string token)
+    {
+        unifiedId = string.Empty;
+        token = string.Empty;
+        try
+        {
+            if (App.Settings?.Current?.OfflineMode == true) return false;
+            var id = App.Settings?.Current?.UnifiedId;
+            var auth = App.Settings?.Current?.AuthToken;
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(auth)) return false;
+            unifiedId = id;
+            token = auth;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyPresence.Identity: {E}", ex.Message);
+            return false;
+        }
+    }
+
+    private static bool Retired(int generation) =>
+        generation >= 0 && Volatile.Read(ref _generation) != generation;
+
+    /// <summary>Fire-and-forget onto the thread pool with a catch-all: every entry point here is
+    /// called from a UI-thread handler (a launch, a class end, a teardown, a settings write) and
+    /// none of them may pay for the network or die of it (CLAUDE.md async rules 6-8).</summary>
+    private static void Run(Func<Task> work, string what)
+    {
+        try
+        {
+            _ = Task.Run(async () =>
+            {
+                try { await work().ConfigureAwait(false); }
+                catch (Exception ex) { App.Logger?.Information("[ArcademyPresence] {What} failed: {E}", what, ex.Message); }
+            });
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyPresence.Run({What}): {E}", what, ex.Message); }
+    }
+
+    private static JObject? Parse(string body)
+    {
+        try { return string.IsNullOrWhiteSpace(body) ? null : JObject.Parse(body); }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyPresence: unreadable reply: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    private static string Truncate(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        return s.Length <= MaxLoggedBody ? s : s[..MaxLoggedBody] + "...";
+    }
+}

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyPresenceService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyPresenceService.cs
@@ -18,7 +18,9 @@ namespace ConditioningControlPanel.Services.Arcademy;
 /// <list type="number">
 /// <item><description>THE EMITTER pushes four state transitions - <c>campus_enter</c>,
 /// <c>room_enter</c>, <c>class_end</c>, <c>campus_leave</c> - and runs ONLY while
-/// <see cref="Models.AppSettings.ArcademyPresenceShare"/> is something other than <c>off</c>. A
+/// <see cref="Models.AppSettings.ArcademyPresenceShare"/> is something other than <c>off</c>,
+/// with exactly one exception: the REVOCATION (see <see cref="OnSettingChanged"/>), which is the
+/// one payload that has to leave BECAUSE the player turned sharing off. A
 /// transition is a room key and a letter grade; there is no coordinate in this file, no field for
 /// one, and none is ever computed here. Where a ghost walks is <c>shell/ghosts.js</c>'s invention
 /// from the event list.</description></item>
@@ -94,6 +96,10 @@ internal static class ArcademyPresenceService
     /// <summary>The four letters the wire knows. A zen finish reports <c>pass</c>, which is not a
     /// grade and rides as null - "was here, no grade" is a fact the renderer draws.</summary>
     private static readonly HashSet<string> Grades = new(StringComparer.Ordinal) { "S", "A", "B", "C" };
+
+    /// <summary>The absence of a rung. Not consent, and on the wire it is legal on exactly one
+    /// event kind - a <c>campus_leave</c>, the revocation. Spelled once, here.</summary>
+    private const string PresenceOff = "off";
 
     /// <summary>Rung ordering, the server's <c>SHARE_RANK</c> verbatim. Used for ONE decision: did
     /// this change reduce what the account shows, which is the change that owes a POST.</summary>
@@ -260,12 +266,20 @@ internal static class ArcademyPresenceService
     /// yet: the next real event carries the new rung and that is soon enough. Sending on the way up
     /// would spend one of the twelve hourly writes to say nothing.</para>
     ///
-    /// <para>AND <c>off</c> CANNOT BE SENT. <c>share</c> is validated against
-    /// <c>anon|username|discord</c>; there is no <c>off</c> on the wire and no revoke route on the
-    /// server (the doc's own words: "revoking is deleting"). Posting the nearest rung instead would
-    /// be this client asserting a consent the player just withdrew, which is the one thing it must
-    /// never do - so the honest move is to send nothing and say so once in the log. The account's
-    /// prior window ages out on its own inside 24 hours.</para>
+    /// <para>AND <c>off</c> IS A POST OF ITS OWN. It is the case the obligation exists for: a
+    /// player who turns sharing off is asking for their name to come off the map NOW, not in
+    /// twenty-four hours' time, and the current rung only ever moves on a POST. So the move to
+    /// <c>off</c> sends one <c>campus_leave</c> carrying <c>share: "off"</c> - the server's
+    /// revocation shape, accepted on that event kind and on no other (api doc, "Revoking - the
+    /// shape"). It upserts the consent row to <c>off</c>, deletes the avatar reverse index and
+    /// stores a row with no name and no picture, and the next snapshot reduces the account's whole
+    /// prior window to a head count. What is NOT sent is the nearest consenting rung: that would be
+    /// this client asserting a consent the player just withdrew, which is the one thing it must
+    /// never do.</para>
+    ///
+    /// <para>Best-effort like everything else here: if it does not land - offline, no identity, a
+    /// 429 - the account's prior window ages out on its own inside 24 hours, and the next real
+    /// event (which cannot happen at <c>off</c>) is not needed to close it.</para>
     /// </summary>
     private static void OnSettingChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -280,8 +294,11 @@ internal static class ArcademyPresenceService
             if (Rank(now) == 0)
             {
                 App.Logger?.Information(
-                    "[ArcademyPresence] presence turned off - the wire has no 'off' rung, so the account's"
-                    + " prior 24h ages out rather than being withdrawn now");
+                    "[ArcademyPresence] presence turned OFF - posting the revocation, which takes the"
+                    + " account's prior 24h off the map at once");
+                // The one payload that leaves at the off rung, and it says so explicitly rather
+                // than reading the setting: Emit's own gate would (rightly) drop anything else.
+                Emit("campus_leave", null, null, -1, PresenceOff);
                 return;
             }
 
@@ -308,12 +325,21 @@ internal static class ArcademyPresenceService
     /// exactly one place that can decide to put something on the wire: no consent, no identity,
     /// offline - nothing leaves, silently.
     /// </summary>
-    private static void Emit(string kind, string? room, string? grade, int generation)
+    /// <param name="shareOverride">THE ONE WAY PAST THE CONSENT GATE, and it has exactly one
+    /// caller: <see cref="OnSettingChanged"/> sending <see cref="PresenceOff"/> to WITHDRAW. The
+    /// rung named here is asserted on the wire, so nothing but <c>off</c> may ever be passed - an
+    /// override that RAISED the rung would be this client consenting on the player's behalf, and
+    /// the server would believe it. Null everywhere else, which is the ordinary gated path.</param>
+    private static void Emit(string kind, string? room, string? grade, int generation,
+        string? shareOverride = null)
     {
-        var share = Share();
-        if (Rank(share) == 0) return;                       // off: the whole feature is absent
+        var revoking = shareOverride == PresenceOff;
+        var share = revoking ? PresenceOff : Share();
+        if (!revoking && Rank(share) == 0) return;          // off: the whole feature is absent
         if (!Identity(out var unifiedId, out var token)) return;
-        lock (Gate) { _emitted = true; }
+        // A revocation is not an announcement: it must not arm Detach's own campus_leave, which
+        // exists to walk a ghost out that this session walked in.
+        if (!revoking) lock (Gate) { _emitted = true; }
         Run(() => PostEventAsync(kind, room, grade, share, unifiedId, token, generation), kind);
     }
 


### PR DESCRIPTION
# Campus Presence — "The Student Body"

Ghost cursors of real Arcademy attendees replayed on the 2D campus (Cursor Camp style). Design locked 2026-08-24 (owner): event-sourced, 24h time-shift replay, opt-in identity default OFF, fake client-side encounters.

## What's in here
- **`shell/ghosts.js` (new, ~1.2k lines)** — wire normaliser, replay scheduler on the campus walk graph, SVG renderer (pixel-student sprites deterministic per opaque id; circular avatar chips for the discord rung), analytic encounter engine (R≈28px/2s windows, seeded per snapshot-hash|epoch|pair, ~25% fire, 90s per-ghost cooldown, max 1 on screen; scenes: hihi/hihi 40%, shared "..." 25%, o/ + \o wave 20%, silent nod 15%). Age tiers (<1h full, <6h dim, <24h faint), live rim <5min, grade-S sparkle at the door, busyness chips, ~24-ghost cap, reduced-motion static tier. Self-ghost never rendered.
- **`shell/fixtures/presence.json`** — hand-authored 30-student day; `?presence=fixture` drives the whole feature with no server. **This is the playtest path.**
- **`shell/campus.js`** — walk graph (`stopAnchor`/`routeLegs`/`routeFor` + new `walkLegs`/`gateLegs`/`doorPoint`) lifted verbatim to module-level pure exports; `campus-students` layer minted as `campus-route`'s sibling; `on.revealDone`.
- **`Services/Arcademy/ArcademyPresenceService.cs` (new)** — best-effort emitter (`campus_enter`/`room_enter`/`class_end`/`campus_leave`, only when opted in + authed + online) and the snapshot pusher (GET every ~60s while the window is up, posted to the page verbatim as the `presence` frame). ArcademySyncService house rules: one log line per failure, no dialogs, no retry storms.
- **`ArcademyPresenceShare` setting** (`off|anon|username|discord`, default `off`) — projected as `presenceShare`, surfaced in the campus settings page global tier with per-rung consent copy. Flipping to `off` POSTs one revocation (`campus_leave` @ `off`) so the server hides the prior 24h immediately (retroactive opt-out pillar).
- 13 lexicon rows mirrored page-side + `NeutralLexicon` (all ≤96 chars, bubbles ≤4 chars).

## Privacy
Coordinates never leave the client (the server sees room keys + timestamps only). Identity is opt-in, default OFF; opted-out players feed room head-counts only. Discord avatars ride a first-party proxy URL, never a Discord CDN link.

## Verification
- Node harness (rebuilt per web CLAUDE.md §6): **presence suite 230/0**; all other suites byte-identical to pristine main's known 20 harness-drift failures — zero new.
- Browser pass (Playwright, real Chromium): 21/0, three clean runs; caught 2 real rendering bugs the DOM double could not.
- `dotnet build` 0 errors.

## Ships dark-safe
Zero data (server not deployed / user offline / feature dark) = zero ghosts, zero errors. Server half: CC-Labs-llc/CCP-Server PR `feat/arcademy-presence` — needs its migration + `PRESENCE_ID_SALT` before the emitter finds anything; until then every poll is one debug line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP7VygdX4cMgNTsUwDQsRv
