### PR TITLE
feat(arcademy): class-length wave - ruled durations, multi-board Composure/Deja Vu, sheet law

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -96,9 +96,13 @@ games/registry.js  guarded allSettled registry + tier math + class_suspended stu
                    own family/meaty/flagship/timeBudgetSec, because the timetable
                    reads a suspended class's descriptor too
 games/<key>/index.js  one folder per game; games NEVER import each other
-  daily-trigger/   the daily word (homeroom, flagship)  - bank/board/ladder/words-*
-  lost-and-found/  the mosaic hunt (MEATY, flagship)    - board/grade/hud/util
-  deja-vu/         the pair memory                      - script (the swap plan)
+  daily-trigger/   the daily word (homeroom, flagship, CLOCKLESS - no seconds chip, no time bar;
+                   the ~1-min wordle is the ruled shape, trap 81) - bank/board/ladder/words-*
+  lost-and-found/  the mosaic hunt (MEATY, flagship, 300s; finds are PER-TIER 26/22/16/13
+                   via findsForTier, and every gate that was a count is now a rate - trap 83) - board/grade/hud/util
+  deja-vu/         the pair memory (300s, MULTI-BOARD:  - script (the swap plan)
+                   clear -> fresh seeded board (classSeed|bN) with one-notch escalation, bell = the
+                   only end and the NORMAL end, timeout auto-C removed - trap 82)
   impulse-control/ the Drop Tube (pop/withhold)         - lex/schedule/scoring/render/style/tube3d/tube2d
                    (seeded three.js chute, vendored r185 in ../vendor/; tube2d = no-WebGL ladder)
                    + the House Rules decks casino (THE FLOOR: bulb-ring marquee, chime ladder,
@@ -125,14 +129,14 @@ games/<key>/index.js  one folder per game; games NEVER import each other
                    TRACKABILITY INVARIANT: occlusion hides at most ONE link of a swap chain and every
                    occlusion carries a tell) / grade / lex MD_LEX; keybinds pick1..pick5; md_stake_mode
                    ask|bank|ride (greed scored UPWARD only, ride cap 5), md_shell_skin themed|minimal|contrast
-  sort/            the two-pile swipe (tracking, 120s)   - room 201, The Sorting Room, built
+  sort/            the two-pile swipe (tracking, 180s)   - room 201, The Sorting Room, built
                    on the Entrance Hall's west span after Misdirection's retirement (lot 2
                    gave the old parlour to the front office). Right = TARGET, left = NOISE, and
                    the piles are the PLAYER'S OWN NICHES, picked at a setup DOOR that runs
                    BEFORE the class clock (`manifest.setup` + `instance.setup()`, §5). Truth is
                    the `tag` the host stamped on the row, never pixels; the deck comes from
                    `ctx.assets.claimTagged` (§3), never `claim()`
-  echo/            the Simon ring (memory, 105s)          - sequence (PURE: warm start 3..6 off bestLen, decoy
+  echo/            the Simon ring (memory, 120s)          - sequence (PURE: warm start 3..6 off bestLen, decoy
                    plan from tier 2 telegraphed) / grade / lex EC_LEX; keybinds pad1..pad6; six pads always live,
                    the TIER restricts the alphabet; tones = engine audio_trigger 'pad' x pitch (+1 semitone per
                    link, cap 7); a fail is NOT the class (new sequences until the bell); Encore once, auto
@@ -160,9 +164,10 @@ games/<key>/index.js  one folder per game; games NEVER import each other
                    largest that wraps every dealt phrase into three lines AND spells every word
                    whole; measured with a hidden 100px RULER (`.g-ec-ruler`) because a centred word
                    box reports `scrollWidth === clientWidth` even while the word hangs out of it
-  instant-recall/  the vigil (recall, 120s, MEATY)        - vigil (PURE seeded script: stops w/ FINAL-STOP
+  instant-recall/  the vigil (recall, 180s, MEATY)        - vigil (PURE seeded script: stops w/ FINAL-STOP
                    GUARANTEE in the last 15s, density sawtooth, plants, templates LAST_WORD/EFFECT/STING/TWO,
-                   THE CADENCE (owner 2026-08-23, "about 5 rounds per minute"): 9-11 stops a 120s class at
+                   THE CADENCE (owner 2026-08-23, "about 5 rounds per minute"): a RATE, not a count -
+                   scaleStops holds every budget inside 4.4-5.6/min, so 180s deals 14-16 stops at
                    EVERY tier, ONE question each - tier moves the window (6/6/5/4s) and the template pool,
                    never the rate. MIN_GAP_MS is DERIVED, not tasted: window + VERDICT_MS + DEAL_BEAT_MS +
                    FRESH_MS + slop, so even a fully blanked stop leaves >= 4s of live wall, and seedDues
@@ -212,11 +217,12 @@ games/<key>/index.js  one folder per game; games NEVER import each other
                    Sub words are HELD, not brightened: `fire('sub_flash', {holdMs: SUB_HOLD_MS[tier]})` plus a
                    game-local plate on `.g-ir-stage .ae-sub-word` (the alpha is still the engine's clamped
                    channel); `CADENCE.subliminal.min` 1000 -> 1400 so two held words cannot overlap.
-  anomaly/         the odd-one-out grid (search, 90s)     - rounds (PURE: kinds/deltas at PERCEPTIBLE floors,
+  anomaly/         the odd-one-out grid (search, 300s)    - rounds (PURE: kinds/deltas at PERCEPTIBLE floors,
                    relocations cap 2/round, drift) / grade / lex AN_LEX; the odd index lives in CLOSURE ONLY -
                    never a DOM attr/class (suite asserts it); decks get a canMelt(i)/meltCandidates() oracle
                    and nothing else; an_kinds all|gentle
-  composure/       the sliding picture (puzzle, 120s, MEATY) - board (PURE, seeded SOLVABLE scramble w/ parity)
+  composure/       the sliding picture (puzzle, 300s, MEATY, MULTI-BOARD: a solve BANKS and
+                   re-deals seeded scrambles until the bell, trap 82) - board (PURE, seeded SOLVABLE scramble w/ parity)
                    / solver (PURE baseline: optimal 3x3 IDA*, 4x4/5x5 BFS over tracked-tiles+gap - the greedy
                    textbook solver deadlocked 1 board in 5) / grade (par from the solver) / lex CP_LEX;
                    manifest.peek TRUE (the shell's hold-to-reveal = A-cap); cp_mode timed|zen (zen ends
@@ -1389,6 +1395,66 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     The Esc ladder is byte-for-byte the ladder it was (boot.js's outer rungs,
     shell.js's inner ones, the host's panic rung above both). If you ever need to
     branch on a key here, do not: put it in the ladder that already owns keys.
+
+81. **CLASS LENGTH IS A RULED QUANTITY, AND MEATY IS NOT THE LENGTH FLAG (2026-08-24).**
+    The owner ruled a per-class length table (L&F/anomaly/composure/deja-vu/deep-end 300s,
+    sort/instant-recall 180s, echo 120s, daily-trigger and impulse-control deliberately short;
+    daily-trigger is also `clockless` - no seconds chip, no time bar, the flag rides the
+    descriptor through normalizePool/classFrom and the registry parachute). Do NOT "fix" a
+    long non-meaty class by flipping `meaty: true`: `meatyOk` deals EXACTLY ONE meaty class
+    per day, so the flag is the anchor-slot marker and flipping it for length would cap long
+    classes at one per night and starve the quick slots. Both clamp ceilings are 300
+    (`QUICK_MAX_SEC` == `MEATY_MAX_SEC`); the per-module `timeBudgetSec` is the real number,
+    and the registry row must mirror it byte-for-byte (the parachute law). Consequence the
+    meaty cap no longer covers: a night can legally deal two or three 300s classes (~16.5 min
+    worst of 28 simulated) - a total-minutes ceiling would be a NEW timetable rule.
+
+82. **IN A MULTI-BOARD CLASS THE BELL IS THE ONLY END, AND THE LOOP NEEDS A LATCH.**
+    Composure and deja-vu clear-and-re-deal until the bell: `onSolved()`/`win()` BANK and
+    deal the next seeded board (`classSeed|bN` - board 1 must stay byte-identical to the
+    single-board era), they never call finish. Exactly-one-endClass survives only because a
+    `closing`/`belled` latch is set FIRST by every terminal path and checked by every
+    callback that could re-enter (tap, settle, mutate, deal, howto, trickster). When you add
+    any async beat (celebration, deal cascade), assume the bell WILL fire inside it and test
+    that seam. Class-level things stay class-level: deja-vu's casino lights ONCE (`start()`
+    re-rolls its identity - calling it per board re-skins the room), ambience retunes rather
+    than restarts, and composure's pressure deck needs its `deal()` hook or the effects
+    ladder freezes at RUNG_MAX after the first bank.
+
+83. **EVERYTHING SIZED AS A COUNT WAS CALIBRATED TO THE OLD BUDGET - STRETCH THE CLASS AND
+    EVERY COUNT MUST BECOME A RATE.** The 0824 length wave found the same bug in five
+    shapes: anomaly's round plan capped at 24 and looped its seeded deal (now sized off a
+    fast-player 2.4s round, COUNT_MAX 140); sort's trickster window covered cards 8..60
+    whatever the budget (now a span of expectedCards); L&F's S-gate allowed 1 misclick
+    against 26 finds (mathematically unreachable - now a rate per find, and streak/peek/par
+    gates scale too, with run-length statistics rather than linear ratios where the quantity
+    is an unbroken run); sort's deck dealt 1.6 passes at 120s and would have dealt 2.5+
+    (deck +50%, wall cap 120); composure's wash count was a flat count (now scaled to
+    budget with a 34% burial cap). When a budget moves, grep the game for every literal that
+    was tuned against the old seconds and ask "count or rate?" - the count answers are bugs.
+
+84. **`node --check` PARSES style.js AS A SCRIPT, SO A STRAY BACKTICK INSIDE A TEMPLATE-
+    LITERAL STYLESHEET SAILS THROUGH.** The composure rebuild hit it: the file still parses
+    (the backtick just re-opens a template) and only an ESM `import()` smoke run finds the
+    break. Any edit to a `STYLE_TEXT`-style sheet must be smoke-imported, not just checked.
+
+85. **THE CLASS-RULES SHEET IS FREE OF THE CLOCK, AND IT AUTO-SKIPS ONCE SEEN (owner ruling
+    2026-08-24, uniform across every open class).** Two halves, and both are per-game code -
+    the shell owns neither. (a) THE GATE: the sheet SHOWS the first time a player meets that
+    class at that grade tier and AUTO-SKIPS every later class at that tier, off the game's own
+    `gameMeta.howtoTiers` set. `ctx.hideTutorial` ("Skip class tutorials") no longer *narrows*
+    a show-every-class default - it now means "skip even the first showing", so every gate reads
+    `hideTutorial === true || seen.indexOf(tier) >= 0` where it used to read `&&`. The tier is
+    recorded on the GO press and NOWHERE else, so a class left before GO still explains itself
+    next time; no meta at all = an empty list = the sheet shows, which is the fallback we want.
+    (b) THE CLOCK: every class arms its clock inside the GO callback, never above it - echo was
+    the offender (`startClock()` sat beside `bindInput()/claimAssets()`, so a 120s class charged
+    the player for reading, and a slow reader could hear the bell over the sheet). What may stay
+    on the clock is a GAME beat after GO: instant-recall's and echo's BRIEF line, deja-vu's
+    per-board deal+preview. What is deliberately OUTSIDE it: sort's setup DOOR (§5) and the
+    sheet itself. Impulse Control has no wall clock at all (the plan is the length), so its sheet
+    is free either way. THE SKIP PATH MUST EQUAL AN INSTANT DISMISS: whatever the GO callback
+    ran, the auto-skip runs - which is why every game routes both through the same `onDone`.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/core/timetable.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/timetable.js
@@ -68,9 +68,22 @@ export const HOMEROOM_KEY = 'daily_trigger';
 export const CLASSES_PER_DAY = 4;
 /** GROUND-RULES §3 amendment 3 + DECISIONS #3. */
 export const FAMILIES = Object.freeze(['word', 'memory', 'search', 'tracking', 'reflex', 'comfort']);
-/** DECISIONS #3, at the four-class pace: "one meaty (<=300s) + three quick". */
+/* THE CEILINGS ARE BOTH 300 NOW, AND `meaty` NO LONGER MEANS "LONG" (owner
+ * ruling, the class-length wave). DECISIONS #3 used to read "one meaty (<=300s)
+ * + three quick (<=180s)", and the two constants were the two halves of that
+ * sentence. They are not any more:
+ *   - THE BUDGET IS PER-MODULE. Each game's own `timeBudgetSec` is the class
+ *     length; the timetable never shortens a class to fit a slot. So a
+ *     non-meaty class may legitimately run 300s (Anomaly, Deja Vu) and a meaty
+ *     one may be shorter than a quick one (Instant Recall's 180s).
+ *   - `meaty` IS THE ANCHOR-SLOT FLAG. It says "this class is the one the night
+ *     is built around", which is what meatyOk/meatyCapOk below deal - exactly
+ *     one anchor a day, never two. Nothing about it is a duration any more.
+ * Both constants therefore hold the SAME number and clampBudget's `meaty`
+ * argument is a no-op today; they stay separate so a future ruling can move one
+ * ceiling without hunting every call site. */
 export const MEATY_MAX_SEC = 300;
-export const QUICK_MAX_SEC = 180;
+export const QUICK_MAX_SEC = 300;
 export const MIN_BUDGET_SEC = 30;
 /** Mockup's departure-board periods. */
 export const PERIOD_LABELS = Object.freeze(['09:00', '09:05', '09:10', '09:15']);
@@ -128,6 +141,14 @@ export function daysBetween(a, b) {
 /* ----------------------------------------------------------------------------
  * POOL NORMALIZATION
  * -------------------------------------------------------------------------- */
+/**
+ * A budget is the MODULE's to declare; this only fences it into the legal band.
+ * Both ceilings are 300 (see the TUNABLES note), so `meaty` changes nothing
+ * today - it is kept because the ceiling is per class TYPE by contract, not
+ * because an anchor class is allowed to be longer than a quick one.
+ * A missing / junk / non-positive value falls back to 120s, the ordinary class
+ * length, rather than to whatever the ceiling happens to be.
+ */
 function clampBudget(v, meaty) {
   const max = meaty ? MEATY_MAX_SEC : QUICK_MAX_SEC;
   const n = Number(v);
@@ -156,6 +177,13 @@ function normalizePool(registry) {
       meaty,
       flagship: !!g.flagship,
       timeBudgetSec: clampBudget(g.timeBudgetSec, meaty),
+      /* CLOCKLESS (owner ruling, the class-length wave). A class that keeps a
+       * budget for its own bell but shows NO seconds anywhere: no board chip,
+       * no room-card chip, no proctor chip, and no time bar. Daily Trigger is
+       * the only one today - a one-minute wordle whose ritual is the board, not
+       * the countdown. It is a DESCRIPTOR fact carried through to the dealt
+       * class (classFrom) because the shell reads the class, never the module. */
+      clockless: !!g.clockless,
     }));
   }
   out.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
@@ -189,8 +217,13 @@ function daysAgo(history, date, window, key) {
  * -------------------------------------------------------------------------- */
 /**
  * NEVER TWO MEATY CLASSES ON ONE BOARD. This is the half of DECISIONS #3 that
- * does NOT relax: a night is one meaty plus quick ones, and two 300-second
- * classes back to back is a different night than the one that was designed.
+ * does NOT relax: a night is built around exactly ONE anchor class, and two
+ * anchors back to back is a different night than the one that was designed.
+ * NOTE WHAT IT NO LONGER GUARANTEES (the class-length wave): the cap counts
+ * ANCHORS, not seconds, and since budgets went per-module a board can carry two
+ * or three 300s classes as long as only one of them is flagged. If the night's
+ * total length ever needs a ceiling, that is a NEW rule to write here - this
+ * one was never it, it only used to look like it when meaty meant long.
  *
  * It has to be separate from meatyOk below because relaxation drops a whole
  * hard filter, and the old single predicate carried BOTH halves - so the moment
@@ -253,6 +286,7 @@ function classFrom(g, slot) {
     flagship: g.flagship,
     homeroom: slot === 1,
     timeBudgetSec: g.timeBudgetSec,
+    clockless: !!g.clockless,          // see normalizePool: no chip, no bar
     timeLabel: PERIOD_LABELS[slot - 1] || PERIOD_LABELS[PERIOD_LABELS.length - 1],
     missing: false,
   };
@@ -278,9 +312,13 @@ function fromOverride(date, entry, pool) {
       // Calendar names a game this build does not ship: keep the row (the day is
       // verbatim) but flag it so the shell renders class_suspended instead of
       // blanking the board.
+      /* 120, LITERALLY, not QUICK_MAX_SEC. The ceiling is 300 now, and a
+       * class that could not open must not advertise the longest chip on the
+       * board - the row exists only so the shell can render class_suspended.
+       * 120s is the ordinary class length, the same floor clampBudget uses. */
       classes.push({
         slot, gameKey: key, family: 'misc', meaty: false, flagship: false,
-        homeroom: slot === 1, timeBudgetSec: QUICK_MAX_SEC,
+        homeroom: slot === 1, timeBudgetSec: 120, clockless: false,
         timeLabel: PERIOD_LABELS[slot - 1] || PERIOD_LABELS[PERIOD_LABELS.length - 1],
         missing: true,
       });
@@ -376,7 +414,7 @@ const walkCache = new Map();
 const WALK_CACHE_MAX = 8;
 
 function signature(pool, calendar) {
-  const p = pool.map((g) => `${g.key}:${g.family}:${g.meaty ? 1 : 0}${g.flagship ? 'F' : ''}:${g.timeBudgetSec}`).join(',');
+  const p = pool.map((g) => `${g.key}:${g.family}:${g.meaty ? 1 : 0}${g.flagship ? 'F' : ''}${g.clockless ? 'C' : ''}:${g.timeBudgetSec}`).join(',');
   // Contents, not just date keys: two calendars naming the same date must not
   // share a memo entry (a key-only signature served the first one's board).
   const c = calendar
@@ -428,7 +466,8 @@ export function clearTimetableCache() { walkCache.clear(); }
  *
  * @param {Object}  o
  * @param {string}  o.dateSeed          init.utcDateSeed ('YYYY-MM-DD')
- * @param {Array|Object} o.registry     game descriptors {key, family, meaty, flagship, timeBudgetSec}
+ * @param {Array|Object} o.registry     game descriptors {key, family, meaty, flagship,
+ *                                      timeBudgetSec, clockless}
  * @param {Object=} o.overrideCalendar  {'2026-09-01': {classes:[...], banner:'...'}} or null
  * @returns {{dateSeed:string, source:'seed'|'override', banner:?string,
  *            relaxed:string[], classes:Array<Object>}}

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/index.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * games/anomaly/index.js - ANOMALY (odd-one-out; family: search; 90s).
+ * games/anomaly/index.js - ANOMALY (odd-one-out; family: search; 300s).
  *
  * A grid of the SAME loop, tiled N times, playing in lockstep because it IS
  * one url in every tile - one decoder, one clock. Exactly one tile carries a
@@ -23,7 +23,9 @@
  *           be draws the ghost outline - "it moved" - and refunds a second
  *   whiff   the round times out, the answer is revealed, and two whiffs in a
  *           row force ONE breather round (the dossier's comeback hook)
- *   bell    the 90s budget ends the class, never a round count
+ *   bell    the 300s budget ends the class, never a round count. The plan is
+ *           sized for a FAST player (rounds.js FAST_ROUND_MS), so five minutes
+ *           of clean tapping still never runs out of seeded rounds
  *
  * THE CRITIC'S TOP FIX IS LAW: the top tiers get harder through relocations,
  * drift and decoy pressure at PERCEPTIBLE deltas - never through a delta
@@ -46,8 +48,9 @@
  *       tile and its hitbox together, and every engine one-shot over the grid
  *       is decoration (fireSafe welds clickSafe/clickable off)
  *   III nothing is still - the grid breathes even at tier 1 (the decks)
- *   IV  images over text - the class-rules sheet is DRAWN and GO-only, and it
- *       respects ctx.hideTutorial + gameMeta.howtoTiers
+ *   IV  images over text - the class-rules sheet is DRAWN, GO-only and FREE OF
+ *       THE CLOCK; it shows ONCE per grade tier (gameMeta.howtoTiers) and
+ *       ctx.hideTutorial skips even that first showing
  *   V   seeded - rounds.js deals the whole show off classSpec.seed; a retake
  *       replays it. Relocations are SCHEDULE-DEALT, never live rng
  *   VI  exits sacred - pause/resume/suspend/destroy (the DV discipline), the
@@ -102,7 +105,7 @@ let lastSnapshot = null;
 
 /** Test seam: the scratch harness compresses the clock. Production = 1.
  *  It scales BOTH ends - a timer's real delay AND the logical time the ticker
- *  credits for a real millisecond - so a 90s class can be played end to end in
+ *  credits for a real millisecond - so a full class can be played end to end in
  *  under two seconds without the round deadlines drifting out of proportion. */
 let timeScale = 1;
 export function setTimeScale(f) { const v = Number(f); timeScale = Number.isFinite(v) && v > 0 ? v : 1; }
@@ -161,7 +164,15 @@ export default {
   family: 'search',
   meaty: false,
   flagship: false,
-  timeBudgetSec: 90,
+  /* 300s (owner ruling, the class-length wave; it was 90). Still not an anchor
+   * class: `meaty` is the timetable's one-per-night flag and has nothing to do
+   * with length any more, which is why the longest class on the board is not
+   * the flagged one. Grading is ratios over rounds OFFERED, and the bell was
+   * always the end rather than a round count, so the only thing five minutes
+   * needed was a plan deep enough to cover it - see rounds.js FAST_ROUND_MS /
+   * COUNT_MAX, which size the deal off a fast player rather than off the slow
+   * end of the round window. */
+  timeBudgetSec: 300,
   title: 'Anomaly',
 
   manifest: {
@@ -207,7 +218,7 @@ export default {
     let reduced = false;
     let coarse = false;
     let retake = false;
-    let budgetMs = 90000;
+    let budgetMs = 300000;
     let pool = null;
     let rollLocal = null;
 
@@ -608,6 +619,12 @@ export default {
       if (ended || dead) return;
       if (budgetMs - elapsedMs <= MIN_ROUND_MS) { setPhase('verdict'); return; }
 
+      /* THE MODULO IS A BACKSTOP, NOT THE DEAL. rounds.js sizes the plan off a
+       * FAST player (FAST_ROUND_MS), so a 300s class cannot walk off the end of
+       * it and start replaying the seeded rounds it has already shown. This
+       * stays because a plan is a pure function of its inputs and a caller may
+       * always hand a budget nobody sized for; wrapping is a better failure
+       * than a crash on `undefined`. */
       let r = plan.rounds[roundIdx % plan.rounds.length];
       roundIdx += 1;
       if (whiffStreak >= PLAYTEST.BREATHER_AFTER_WHIFFS) {
@@ -1108,10 +1125,14 @@ export default {
     }
 
     /* ==================================================================== *
-     * THE CLASS-RULES SHEET (Deck VI, Law IV) - drawn, GO-only, and it
-     * respects the shell's "Skip class tutorials" contract exactly as
-     * Impulse Control does: default shows every class, with the skip on a
-     * class still explains itself ONCE per grade tier.
+     * THE CLASS-RULES SHEET (Deck VI, Law IV) - drawn, GO-only, and FREE OF
+     * THE CLOCK (startClock() lives in the GO callback, never above it).
+     * THE LAW, uniform across every open class (owner ruling 2026-08-24): the
+     * sheet SHOWS the first time this player meets this class at this grade
+     * tier and AUTO-SKIPS every later class at that tier, whatever the setting
+     * says. The shell's "Skip class tutorials" switch (ctx.hideTutorial) now
+     * means "skip even the first showing". No meta = no memory = the sheet
+     * shows, which is the fallback we want.
      * ==================================================================== */
     function howtoSeenTiers() {
       try {
@@ -1164,7 +1185,11 @@ export default {
     }
     function howto(onDone) {
       const seen = howtoSeenTiers();
-      if (ctx.hideTutorial === true && seen.indexOf(tier) >= 0) { onDone(); return; }
+      /* AUTO-SKIP once this tier is on the record; hideTutorial skips the
+       * first showing too. The skip path is an instant dismiss: the tier is
+       * already banked (or deliberately never wanted), nothing is mounted to
+       * hide, and the GO cue belongs to a press that did not happen. */
+      if (ctx.hideTutorial === true || seen.indexOf(tier) >= 0) { onDone(); return; }
       let done = false;
       const onGo = () => {
         if (done || dead) return;
@@ -1209,10 +1234,10 @@ export default {
      * ==================================================================== */
     const instance = {
       start(classSpec) {
-        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 90 };
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 300 };
         tier = clampTier(spec.gradeTier);
         seed = String(spec.seed == null ? GAME_KEY : spec.seed);
-        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 90) * 1000);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 300) * 1000);
         retake = !!spec.retake;
         reduced = probeReduced(ctx);
         coarse = coarseOf(ctx);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/rounds.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/anomaly/rounds.js
@@ -8,7 +8,11 @@
  * cadences. Same seed = same show; a retake replays it exactly (Law V).
  *
  * DRAW ORDER IS APPEND-ONLY. New draws go at the END of buildPlan (and at the
- * end of a round's own block) so an older seed keeps the plan it had.
+ * end of a round's own block) so an older seed keeps the plan it had. One thing
+ * that rule cannot protect: `count` is part of the INPUT, so a budget change
+ * (90s -> 300s, the class-length wave) lengthens the round loop and every draw
+ * made AFTER it - subJitter today - moves. Same seed + same budget is still the
+ * same show, which is all a retake needs (Law V).
  *
  * ---------------------------------------------------------------------------
  * THE CRITIC'S TOP FIX IS LAW (dossier, 7/10): the top tiers get harder through
@@ -126,9 +130,37 @@ export const PLAYTEST = Object.freeze({
   SUBSECOND_MS: 1000,
 
   STALL_TICK_MS: 700,
-  /** Rounds dealt = what the budget can hold, padded, then capped. */
+
+  /* ---- HOW MANY ROUNDS THE PLAN HOLDS -------------------------------------
+   * THE PLAN IS SIZED FOR THE FASTEST PLAYER, NOT FOR THE ROUND WINDOW.
+   *
+   * It used to be `ceil(budgetMs / lo) + COUNT_PAD`, where `lo` is the SLOW end
+   * of ROUND_MS (6-12s) - i.e. how long a round lasts when nobody finds the
+   * tile. But a round ENDS on the first correct tap, and a competent player
+   * taps in ~2.4-2.9s including the ADVANCE_MS ceremony, so the plan was always
+   * three to four times too short and index.js's `roundIdx % rounds.length`
+   * quietly wrapped: the class re-dealt the same seeded rounds, in the same
+   * order, with the same odd tiles. At 90s that was a curiosity at the very end
+   * of a flawless run; at 300s a fast tier-1 player would see round 0 again
+   * before the halfway bell (~125 rounds played against a 24-round plan).
+   *
+   * So the divisor is FAST_ROUND_MS - the floor of what a round can cost - and
+   * COUNT_MAX is raised to cover a full-length class at that rate:
+   *     300000 / 2400 = 125, + COUNT_PAD 4 = 129   (cap 140, comfortable)
+   *      90000 / 2400 =  38, + COUNT_PAD 4 =  42
+   * A round is a handful of numbers plus one rotated index list (<= 25 ints,
+   * and only when the tier relocates at all), and NOTHING in the plan holds a
+   * url or preloads media - index.js claims a fixed {loops:10, stills:4} pool
+   * off ctx.assets regardless of `count` - so a 129-round plan costs a few tens
+   * of kilobytes and one build-time loop, not a download.
+   * ------------------------------------------------------------------------ */
+  /** The floor of what one round can cost a fast player: find + tap + the
+   *  sub-500ms advance ceremony. Deliberately BELOW the observed 2.4-2.9s so
+   *  the plan is never the thing that runs out. */
+  FAST_ROUND_MS: 2400,
+  /** Rounds dealt = what a fast player can get through, padded, then capped. */
   COUNT_PAD: 4,
-  COUNT_MAX: 24,
+  COUNT_MAX: 140,
   COUNT_MIN: 8,
 });
 
@@ -318,7 +350,7 @@ function relocTimes(k, durationMs, rng) {
  * @param {Object} o
  *   seed           the class seed (Law V)
  *   gradeTier      1..4
- *   timeBudgetSec  the class bell (90 by contract)
+ *   timeBudgetSec  the class bell (300 by contract)
  *   kindsMode      'all' | 'gentle'   (the `an_kinds` setting)
  *   reduced        reducedMotion
  *   coarse         coarse pointer (caps the grid)
@@ -340,10 +372,16 @@ export function buildPlan(o = {}) {
   const lo = Math.round(win[0] * (reduced ? PLAYTEST.ROUND_MS_REDUCED_MULT : 1));
   const hi = Math.round(win[1] * (reduced ? PLAYTEST.ROUND_MS_REDUCED_MULT : 1));
 
-  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 90) * 1000);
+  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 300) * 1000);
+  /* FAST_ROUND_MS, never `lo`: the plan has to outlast the fastest player the
+   * budget allows, not the slowest round the tier deals. See the dial's own
+   * note for the arithmetic and for why a deep plan is cheap. `count` is still
+   * a pure function of (budget, tier-independent dials), so the whole deal
+   * below stays byte-identical for a given seed AND budget. */
   const count = Math.max(
     PLAYTEST.COUNT_MIN,
-    Math.min(PLAYTEST.COUNT_MAX, Math.ceil(budgetMs / lo) + PLAYTEST.COUNT_PAD),
+    Math.min(PLAYTEST.COUNT_MAX,
+      Math.ceil(budgetMs / PLAYTEST.FAST_ROUND_MS) + PLAYTEST.COUNT_PAD),
   );
 
   /* relocations are OFF under reduced motion (no glitch, no drift) */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/casino.js
@@ -845,6 +845,32 @@ export function createCpCasino(o) {
       say('casino: ROYAL');
     },
 
+    /**
+     * THE BANK (multi-board, 2026-08-24). The royal was a beat, not the end of
+     * the night: the class deals a fresh scramble and runs on. Take the royal
+     * dressing back down and restore the marquee to whatever the REAL bell
+     * warning is doing - `solved()` borrows `bellOn` for its own flash, so
+     * without this the rig would sit in bell mode from the first bank onward.
+     * `info.bell` is index.js's own bell-warning flag; it is the truth.
+     */
+    deal(info) {
+      if (!started) return;
+      const stillBell = !!(info && info.bell);
+      royalOn = false;
+      bellOn = stillBell;
+      if (royalTimer) { cancel(royalTimer); royalTimer = 0; }
+      if (mq && mq.classList) {
+        mq.classList.remove('g-cp-mq-flash');
+        if (stillBell) mq.classList.add('g-cp-mq-bell'); else mq.classList.remove('g-cp-mq-bell');
+      }
+      if (cs && cs.classList) cs.classList.remove('g-cp-royal');
+      stageClass('g-cp-royal', false);
+      stageClass('g-cp-bell', stillBell);
+      setProp('--cp-n-dark', stillBell ? '0.35' : '0');
+      paintMarquee(true);
+      say('casino: deal (royal cleared)');
+    },
+
     /** The last 20s: gold frame, frantic chase, the room darkens a stop. */
     bell(on) {
       bellOn = !!on;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/grade.js
@@ -7,39 +7,89 @@
  * that to S/A/B/C through core/grades.js and applies every cap (peek is the
  * shell's, always - CLAUDE.md trap 9).
  *
+ * THE CLASS IS MULTI-BOARD (owner ruling 2026-08-24, the class-length wave).
+ * A solve BANKS the picture and deals a fresh scramble; the BELL is the one
+ * thing that ends a timed class. So the rubric no longer asks "did the one
+ * board come back" - it asks "how many pictures did you put back in five
+ * minutes", normalised per tier so the S bar means the same thing at every
+ * year. See EXPECTED BOARDS below for the gate arithmetic.
+ *
  * THE COMPOSITE. Composure, not speed:
- *   .45 PROGRESS   how much of the picture came back. Solved = 1. Otherwise a
- *                  blend of distance-closed (manhattan against the scramble's
- *                  own starting distance) and pieces-home, so a player who
- *                  reorganised the board without locking anything still scores
- *                  what they actually did.
- *   .25 PACE       progress against the BASELINE SOLVER's move count (par):
- *                  clamp(progress x par / moves). Solving in par flat = 1;
- *                  solving in twice par = .5; being ahead of the baseline's
- *                  rate part-way through also reads 1. There is no clock term
- *                  anywhere - a 120s class already ends when the bell says so.
+ *   .45 PROGRESS   how many BOARDS' worth of picture came back, against what
+ *                  this tier is expected to fill the bell with:
+ *                    boardsDone = banked + (the live board's own progress)
+ *                    progress   = clamp01(boardsDone / expectedBoards)
+ *                  The live board's own progress is the old blend of
+ *                  distance-closed (manhattan against the scramble's own
+ *                  starting distance) and pieces-home, so a player who
+ *                  reorganised the board without locking anything still
+ *                  scores what they actually did. A board already BANKED is
+ *                  worth zero as a live board - counting both would pay for
+ *                  the same picture twice.
+ *   .25 PACE       moves against the BASELINE SOLVER's move count (par):
+ *                  clamp(parEarned / moves), where parEarned is every banked
+ *                  board's own par plus the live board's par pro-rated by how
+ *                  much of it came back. Identical in meaning to the
+ *                  single-board rubric it replaces: solving in par flat = 1,
+ *                  in twice par = .5, and being ahead of the baseline's rate
+ *                  part-way through also reads 1. There is no clock term
+ *                  anywhere - the class already ends when the bell says so.
  *   .30 CALM       1 minus the panic rate: backtracks (a slide that undoes the
  *                  slide before it) and THRASH (a backtrack made while a wash
  *                  was burying the board) per move. Thrash costs double - the
- *                  whole game is "keep sliding from memory".
+ *                  whole game is "keep sliding from memory". CLASS-cumulative:
+ *                  the panic rate is one number for the whole five minutes.
  *   x .92 ^ assists   each skill-floor rescue EPISODE taxes the composite. A
  *                  rescue also fails the declared sGate, so the shell caps the
  *                  class at A whatever this number says. Both, deliberately:
- *                  the tax is honest, the gate is the promise.
+ *                  the tax is honest, the gate is the promise. The tax has a
+ *                  FLOOR now (ASSIST_TAX_FLOOR): a 300s class can stack twice
+ *                  the episodes a 120s one could, and the tax must not quietly
+ *                  become a second gate harsher than the one we declared.
+ *
+ * EXPECTED BOARDS, and the gate arithmetic. `expectedBoardsFor(tier, budget)`
+ * is `round(budgetSec / TYPICAL_SOLVE_SEC[tier])`, so it is derived from the
+ * class's own length rather than a table pinned to one budget. At the shipped
+ * 300s budget that is 7 / 5 / 3 / 2 boards for years 1-4.
+ *
+ * With pace and calm both perfect (.25 + .30 = .55) the letter thresholds in
+ * core/grades.js (S .92, A .75) become pure progress requirements:
+ *     S needs .45 x progress >= .37  ->  progress >= .8222
+ *     A needs .45 x progress >= .20  ->  progress >= .4444
+ * which is `boardsDone >= .8222 x expected` and `>= .4444 x expected`:
+ *
+ *     tier  expected   S at boardsDone   A at boardsDone
+ *      1       7           5.76             3.11
+ *      2       5           4.11             2.22
+ *      3       3           2.47             1.33
+ *      4       2           1.64             0.89
+ *
+ * So the old "one clean 40s solve = S" at tier 1 is now SIX clean solves (or
+ * five plus three quarters of a sixth), and a year-4 S is two whole 4x4
+ * pictures. Anything short of perfect pace or calm raises those bars, which is
+ * the point: the bar is boards AND composure, never boards alone.
+ *
+ * THE BELL IS NOT A FAIL. There is no timeout gate in this file and there may
+ * never be one: a timed class ALWAYS ends on the bell now, so "the clock ran
+ * out" is the ordinary ending. A player who banked nothing simply scores what
+ * their one live board was worth.
  *
  * PAR. `parMoves = ceil(baseline x PAR_MULT[tier])`, never below the baseline
  * itself. The baseline comes from solver.js, which is OPTIMAL on 3x3 and a
  * careful-human reduction on 4x4/5x5 - so par is a real number about this
- * scramble, not a table someone guessed. PAR_MULT tightens with the year.
+ * scramble, not a table someone guessed. PAR_MULT tightens with the year, and
+ * every board of the class gets its own par (the solver runs on every deal).
  *
  * ZEN never reaches any of this: `ctx.endClass({zen:true, ...})` short-circuits
- * to 'pass' in core/grades.js (DECISIONS #1).
+ * to 'pass' in core/grades.js (DECISIONS #1). Zen banks and re-deals exactly
+ * the same way - it just has no bell and no letter.
  *
  * THE PLAN. `buildPlan()` deals the class's effect schedule off the seed
  * (Law V, append-only draw order): the wash windows that bury the board, the
  * sub_flash cadence, the heat ceiling and the audio ceiling. Dials first,
  * difficulty second - tiers 1-3 only raise dials; the board itself grows at
- * tier 3 and the scramble deepens at 3-4.
+ * tier 3 and the scramble deepens at 3-4 (and, gently, board by board at
+ * tiers 1-2 - see SCRAMBLE_WALK_STEP).
  * ==========================================================================*/
 
 import { makeRng } from '../../core/rng.js';
@@ -55,8 +105,29 @@ export const PLAYTEST = Object.freeze({
    *  seeded permutation with a parity repair (deep). Classic difficulty, so
    *  it only moves at the top tiers. */
   SCRAMBLE_WALK: Object.freeze({ 1: 40, 2: 90, 3: 0, 4: 0 }),
+  /** THE GENTLE ESCALATION (multi-board). Board 1 is the tier's own walk; each
+   *  board after it adds this many slides, capped at SCRAMBLE_WALK_MAX. It is
+   *  a pure function of the BOARD INDEX, so it is as seeded as the deal it
+   *  feeds - a retake replays the same seven boards at the same seven depths.
+   *  Tiers 3-4 are absent on purpose: they already deal a full permutation, so
+   *  there is nothing left to deepen (scrambleWalkFor short-circuits on 0). */
+  SCRAMBLE_WALK_STEP: Object.freeze({ 1: 8, 2: 12 }),
+  SCRAMBLE_WALK_MAX: Object.freeze({ 1: 80, 2: 150 }),
   /** Zen is always the deep deal - a zen board the player chose is not a test. */
   ZEN_WALK: 0,
+
+  /* ---- how many boards a class is expected to hold (the S/A normaliser) --- */
+  /** Seconds a competent player of that year takes over ONE board, measured
+   *  against the tier's own grid and scramble depth (3x3 shallow / 3x3 deep /
+   *  4x4 permutation / 4x4 permutation under the heaviest dials). The gate is
+   *  `round(budgetSec / this)`, so it tracks the class length instead of
+   *  hard-coding 300s: at 300s that is 7 / 5 / 3 / 2 boards. It is deliberately
+   *  a touch generous at tiers 1-2, where SCRAMBLE_WALK_STEP makes the later
+   *  boards of a class slower than the first. */
+  TYPICAL_SOLVE_SEC: Object.freeze({ 1: 42, 2: 58, 3: 100, 4: 140 }),
+  /** A sanity ceiling, not a dial: nothing this class deals should ever want
+   *  more than a dozen boards' worth of picture out of one bell. */
+  EXPECTED_BOARDS_MAX: 12,
 
   /* ---- par ---- */
   PAR_MULT: Object.freeze({ 1: 2.2, 2: 1.9, 3: 1.7, 4: 1.5 }),
@@ -76,8 +147,17 @@ export const PLAYTEST = Object.freeze({
   /** Nobody is judged on a panic rate out of three moves. */
   CALM_MIN_MOVES: 8,
   ASSIST_TAX: 0.92,
+  /** THE TAX FLOOR. .92^7 = .558, so this is "about seven episodes and then it
+   *  stops biting". A 300s class gives a stalling player roughly twice the
+   *  chances to trip the 20s rescue that a 120s one did, and the DECLARED gate
+   *  (sGate, an A-cap) is what we promised - the tax is flavour on top of it
+   *  and must never quietly outrank it. */
+  ASSIST_TAX_FLOOR: 0.55,
 
   /* ---- flavour XP (game-owned; the XP TABLE itself is C#'s) ---- */
+  /** +5 for banking at least one picture, +5 for a new personal best on this
+   *  board size, +5 for having taken any ONE board inside its own par. Cap 15,
+   *  exactly as it was - a five-minute class does not pay five times over. */
   FLAVOR_SOLVE: 5,
   FLAVOR_BEST: 5,
   FLAVOR_UNDER_PAR: 5,
@@ -94,7 +174,22 @@ export const PLAYTEST = Object.freeze({
   AUDIO_CEIL: Object.freeze({ 1: 0.45, 2: 0.6, 3: 0.75, 4: 0.9 }),
 
   /* ---- the washes (the class's own effect, CORE-fired) ---- */
+  /** THE COUNT IS A DENSITY, not a count. This table was tasted at a 120s
+   *  class (WASH_BASE_SEC), so buildPlan scales it by budget/120 and the
+   *  washes-per-minute a year gets stays what it was: .5 / 1.5 / 2.5 / 3.5.
+   *  At the shipped 300s budget that is 3 / 8 / 13 / 18 windows. Left
+   *  unscaled, a year-4 class would have gone from a wash every 17s to one
+   *  every 40s and the whole "the room buries the board" premise would have
+   *  thinned out at exactly the tier that needs it most. */
   WASH_COUNT: Object.freeze({ 1: 1, 2: 3, 3: 5, 4: 7 }),
+  WASH_BASE_SEC: 120,
+  /** The cap, and it is an INVARIANT rather than a taste: no more than this
+   *  share of the class may be under a wash. tier 4 at 300s wants 18 x 5000ms
+   *  = 90s of 300s = 30%, so this never binds at the shipped dials - it exists
+   *  so a future budget or a fatter WASH_MS cannot bury a whole class. */
+  WASH_LOAD_MAX: 0.34,
+  /** A hard ceiling on top of the load rule, for the same reason. */
+  WASH_COUNT_MAX: 24,
   WASH_MS: Object.freeze({ 1: 2600, 2: 3400, 3: 4200, 4: 5000 }),
   WASH_ALPHA: Object.freeze({ 1: 0.18, 2: 0.28, 3: 0.38, 4: 0.5 }),
   /** DELIBERATELY NOT 'spiral'. The engine keeps ONE wash element PER VARIANT
@@ -125,7 +220,11 @@ export const PLAYTEST = Object.freeze({
   ROW_DRIFT_TIER: 4,
 
   /* ---- THE SKILL-FLOOR RESCUE (the critic's top fix, and it is law) ---- */
-  /** No new piece home for this long -> light the baseline's next move. */
+  /** No new piece home for this long -> light the baseline's next move. It is
+   *  a rate per STUCK EPISODE, not per class, so it does not scale with the
+   *  budget - but its bookkeeping is PER BOARD: a fresh deal restarts the
+   *  stall clock, because being twenty seconds into a brand new scramble is
+   *  not being stuck. */
   RESCUE_MS: 20000,
   RESCUE_TICK_MS: 500,
   /** A lit hint stays lit this long if the player does nothing with it. */
@@ -144,9 +243,16 @@ export const PLAYTEST = Object.freeze({
   BELL_WARN_SEC: 20,
   BRIEF_MS: 1600,
   BRIEF_MS_REDUCED: 900,
-  /** The solve: seams dissolve and the clip plays clean before the end card. */
-  SOLVE_PLAY_MS: 3000,
-  SOLVE_PLAY_MS_REDUCED: 1500,
+  /** THE BANK BEAT. A solve dissolves the seams and the clip plays clean -
+   *  and then the next scramble deals, because a solve no longer ends the
+   *  class. Trimmed from 3000/1500 for exactly that reason: this beat is paid
+   *  once per SOLVE now, so at tier 1 it runs six or seven times inside one
+   *  bell and three seconds of it each time was ~7% of the class. */
+  SOLVE_PLAY_MS: 1800,
+  SOLVE_PLAY_MS_REDUCED: 900,
+  /** ...and then the fresh board settles in. Input stays closed for both. */
+  DEAL_MS: 700,
+  DEAL_MS_REDUCED: 300,
   CEREMONY_MS: 2400,
   CEREMONY_MS_REDUCED: 1300,
   END_HOLD_MS: 2600,
@@ -159,9 +265,45 @@ export function tierOf(gradeTier) { return Math.max(1, Math.min(4, Math.round(Nu
 /** The timed board for a year. Zen's board is the player's own setting. */
 export function gridForTier(gradeTier) { return PLAYTEST.GRID_BY_TIER[tierOf(gradeTier)] || 3; }
 
-/** Seeded slides for a tier's scramble; 0 = full permutation + parity repair. */
-export function scrambleWalkFor(gradeTier, zen) {
-  return zen ? PLAYTEST.ZEN_WALK : (PLAYTEST.SCRAMBLE_WALK[tierOf(gradeTier)] || 0);
+/**
+ * Seeded slides for a tier's scramble; 0 = full permutation + parity repair.
+ *
+ * `boardIndex` is 0-based and is THE gentle escalation: board 1 of a class is
+ * exactly the walk this tier always dealt, and each board after it adds
+ * SCRAMBLE_WALK_STEP, capped at SCRAMBLE_WALK_MAX. Tiers 3-4 return 0 either
+ * way - a full permutation cannot be deepened.
+ *
+ * @param {number} gradeTier
+ * @param {boolean} zen
+ * @param {number=} boardIndex  0 = the class's first board
+ */
+export function scrambleWalkFor(gradeTier, zen, boardIndex) {
+  if (zen) return PLAYTEST.ZEN_WALK;
+  const tier = tierOf(gradeTier);
+  const base = PLAYTEST.SCRAMBLE_WALK[tier] || 0;
+  if (base <= 0) return 0;
+  const i = Math.max(0, Math.round(Number(boardIndex) || 0));
+  if (i === 0) return base;
+  const step = PLAYTEST.SCRAMBLE_WALK_STEP[tier] || 0;
+  const max = PLAYTEST.SCRAMBLE_WALK_MAX[tier] || base;
+  return Math.max(base, Math.min(max, base + step * i));
+}
+
+/**
+ * How many whole boards this year is expected to fill the bell with - the
+ * normaliser the PROGRESS term divides by, and therefore the whole S/A gate.
+ * Derived from the class's own budget so a length change moves the bar with
+ * it rather than silently making S free (or impossible).
+ *
+ * @param {number} gradeTier
+ * @param {number} timeBudgetSec   the class's budget, in seconds
+ * @returns {number} >= 1
+ */
+export function expectedBoardsFor(gradeTier, timeBudgetSec) {
+  const tier = tierOf(gradeTier);
+  const sec = Math.max(20, Number(timeBudgetSec) || 0);
+  const typical = Math.max(5, PLAYTEST.TYPICAL_SOLVE_SEC[tier] || 60);
+  return Math.max(1, Math.min(PLAYTEST.EXPECTED_BOARDS_MAX, Math.round(sec / typical)));
 }
 
 /**
@@ -181,36 +323,55 @@ export function parFor(baseline, gradeTier, n) {
 }
 
 /**
- * The composite.
+ * The composite, over a WHOLE multi-board class.
+ *
  * @param {Object} i
  *   gradeTier      1..4
- *   solved         the picture came back whole
+ *   banked         pictures finished and banked this class
+ *   expectedBoards expectedBoardsFor(tier, budgetSec) - the S/A normaliser
+ *   boardSolved    the LIVE board was whole at the ending (the bell caught the
+ *                  bank beat). Its whole is already inside `banked`, so this
+ *                  only tells us to score the live board at zero, never twice.
  *   n              board size
- *   moves          real slides (a press into a wall is not a move)
- *   par            parFor(...)
- *   manhattanStart / manhattanNow   the scramble's distance, then and now
- *   locked / tiles                  pieces home, out of n*n-1
- *   backtracks     slides that undid the slide before them
- *   thrash         those of them made while a wash was up
- *   assists        rescue EPISODES (not hint repaints)
- * @returns {{composite:number, terms:Object, tax:number, raw:number, par:number}}
+ *   moves          real slides across the CLASS (a press into a wall is not one)
+ *   par            parFor(...) for the LIVE board
+ *   parBanked      the sum of every banked board's own par
+ *   manhattanStart / manhattanNow   the LIVE scramble's distance, then and now
+ *   locked / tiles                  pieces home on the LIVE board, out of n*n-1
+ *   backtracks     slides that undid the slide before them (class total)
+ *   thrash         those of them made while a wash was up (class total)
+ *   assists        rescue EPISODES across the class (not hint repaints)
+ * @returns {{composite:number, terms:Object, tax:number, raw:number, par:number,
+ *            parEarned:number, boardsDone:number, expectedBoards:number}}
  */
 export function compositeFor(i = {}) {
-  const solved = !!i.solved;
+  const banked = Math.max(0, Math.round(Number(i.banked) || 0));
+  const expected = Math.max(1, Math.round(Number(i.expectedBoards) || 1));
+  const boardSolved = !!i.boardSolved;
   const moves = Math.max(0, Math.round(Number(i.moves) || 0));
   const par = Math.max(1, Math.round(Number(i.par) || 1));
+  const parBanked = Math.max(0, Number(i.parBanked) || 0);
   const tiles = Math.max(1, Math.round(Number(i.tiles) || 1));
   const locked = Math.max(0, Math.min(tiles, Math.round(Number(i.locked) || 0)));
   const mhStart = Math.max(0, Number(i.manhattanStart) || 0);
   const mhNow = Math.max(0, Number(i.manhattanNow) || 0);
 
-  const closed = mhStart > 0 ? clamp01((mhStart - mhNow) / mhStart) : (solved ? 1 : 0);
+  const closed = mhStart > 0 ? clamp01((mhStart - mhNow) / mhStart) : 0;
   const home = clamp01(locked / tiles);
-  const progress = solved
-    ? 1
+  /* THE LIVE BOARD's own worth, 0..1. A board whose whole is already in
+   * `banked` is worth ZERO here - it has been paid for. */
+  const live = boardSolved
+    ? 0
     : clamp01(PLAYTEST.PROGRESS_MH_SHARE * closed + (1 - PLAYTEST.PROGRESS_MH_SHARE) * home);
 
-  const pace = moves > 0 ? clamp01((progress * par) / moves) : 0;
+  const boardsDone = banked + live;
+  const progress = clamp01(boardsDone / expected);
+
+  /* PACE. Every banked board's own par, plus the live board's par pro-rated by
+   * how much of it came back, against the class's real slide count. One board
+   * solved flat in par and nothing else reads exactly what it read before. */
+  const parEarned = parBanked + live * par;
+  const pace = moves > 0 ? clamp01(parEarned / moves) : 0;
 
   const backtracks = Math.max(0, Math.round(Number(i.backtracks) || 0));
   const thrash = Math.max(0, Math.round(Number(i.thrash) || 0));
@@ -220,34 +381,48 @@ export function compositeFor(i = {}) {
 
   const raw = PLAYTEST.W_PROGRESS * progress + PLAYTEST.W_PACE * pace + PLAYTEST.W_CALM * calm;
   const assists = Math.max(0, Math.round(Number(i.assists) || 0));
-  const tax = Math.pow(PLAYTEST.ASSIST_TAX, assists);
+  const tax = Math.max(PLAYTEST.ASSIST_TAX_FLOOR, Math.pow(PLAYTEST.ASSIST_TAX, assists));
 
   return {
     composite: clamp01(raw * tax),
     raw: clamp01(raw),
     tax,
     par,
-    terms: { progress, pace, calm, closed, home },
+    parEarned,
+    boardsDone,
+    expectedBoards: expected,
+    terms: { progress, pace, calm, closed, home, live, banked },
   };
 }
 
 /**
  * Declared hard gates. `sGate` is the rescue promise: a class that took the
- * skill-floor assist may not exceed A, whatever the composite says. Nothing
- * else in this game gates - the board size is the year's, not a choice.
+ * skill-floor assist may not exceed A, whatever the composite says - and it
+ * stays CLASS-sticky across the re-deals, because the promise was about the
+ * class, not about one board. Nothing else in this game gates: the board size
+ * is the year's, not a choice, and running out the bell is the normal ending
+ * of a timed class rather than a failure.
  */
 export function hardGates(rescueUsed) {
   return { sGate: !rescueUsed };
 }
 
-/** +5 solved, +5 a new personal best on this board, +5 inside par. Cap 15. */
+/**
+ * +5 for banking any picture at all, +5 for a new personal best on this board
+ * size, +5 for having taken any one board inside its own par. Cap 15.
+ *
+ * @param {Object} i {banked, bestSolveMoves, bestMovesBefore, underParSolve}
+ *   bestSolveMoves  the fewest moves any ONE banked board took this class
+ *   underParSolve   at least one banked board came in at or under its own par
+ */
 export function flavorXp(i = {}) {
-  if (!i.solved) return 0;
+  const banked = Math.max(0, Math.round(Number(i.banked) || 0));
+  if (banked <= 0) return 0;
   let xp = PLAYTEST.FLAVOR_SOLVE;
   const before = Number(i.bestMovesBefore);
-  const moves = Math.max(1, Math.round(Number(i.moves) || 1));
-  if (!Number.isFinite(before) || before <= 0 || moves < before) xp += PLAYTEST.FLAVOR_BEST;
-  if (moves <= Math.max(1, Math.round(Number(i.par) || 1))) xp += PLAYTEST.FLAVOR_UNDER_PAR;
+  const best = Math.max(1, Math.round(Number(i.bestSolveMoves) || 1));
+  if (!Number.isFinite(before) || before <= 0 || best < before) xp += PLAYTEST.FLAVOR_BEST;
+  if (i.underParSolve) xp += PLAYTEST.FLAVOR_UNDER_PAR;
   return Math.min(PLAYTEST.FLAVOR_CAP, xp);
 }
 
@@ -281,12 +456,26 @@ export function buildPlan(o = {}) {
   const zen = !!o.zen;
   const seed = String(o.seed == null ? 'composure' : o.seed);
   const rng = makeRng(seed + '|cp-plan');
-  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 120) * 1000);
+  const budgetMs = Math.max(20000, (Number(o.timeBudgetSec) || 300) * 1000);
 
   /* 1. the wash windows - the burial the whole game is about. Dealt across the
-   *    budget between a lead-in and a tail so no wash lands on the bell. */
-  const count = zen ? PLAYTEST.ZEN_WASH_COUNT : (PLAYTEST.WASH_COUNT[tier] || 1);
+   *    budget between a lead-in and a tail so no wash lands on the bell.
+   *
+   *    THE COUNT SCALES WITH THE BUDGET. WASH_COUNT was tasted at a 120s class
+   *    and the class is 300s now, so a literal count would have thinned the
+   *    burial to 40% of its old density and quietly made every year easier.
+   *    Scale by budget/WASH_BASE_SEC, then clamp by the LOAD rule (no more
+   *    than WASH_LOAD_MAX of the class under a wash) and the hard ceiling.
+   *    The spread machinery below needs no change and degrades on its own:
+   *    `span` grows with the budget and the per-slot jitter is a fraction of
+   *    span/count, so more washes across more wall stay evenly dealt. */
   const washMs = zen ? PLAYTEST.ZEN_WASH_MS : (PLAYTEST.WASH_MS[tier] || 2600);
+  const baseCount = zen ? PLAYTEST.ZEN_WASH_COUNT : (PLAYTEST.WASH_COUNT[tier] || 1);
+  const budgetScale = budgetMs / (PLAYTEST.WASH_BASE_SEC * 1000);
+  const loadCap = Math.max(1, Math.floor((budgetMs * PLAYTEST.WASH_LOAD_MAX) / Math.max(200, washMs)));
+  const count = Math.max(1, Math.min(
+    PLAYTEST.WASH_COUNT_MAX, loadCap, Math.round(baseCount * budgetScale),
+  ));
   const alpha = zen ? PLAYTEST.ZEN_WASH_ALPHA : (PLAYTEST.WASH_ALPHA[tier] || 0.2);
   const first = PLAYTEST.WASH_FIRST_MS;
   const span = Math.max(1000, budgetMs - first - PLAYTEST.WASH_TAIL_MS);
@@ -313,6 +502,7 @@ export function buildPlan(o = {}) {
   return Object.freeze({
     tier,
     zen,
+    budgetMs,
     washes: Object.freeze(washes),
     washStepdown: PLAYTEST.WASH_STEPDOWN,
     washStepdownShare: PLAYTEST.WASH_STEPDOWN_SHARE,
@@ -329,5 +519,5 @@ export function buildPlan(o = {}) {
 
 export default {
   PLAYTEST, compositeFor, hardGates, flavorXp, parFor, heatFor, cadenceMs, buildPlan,
-  gridForTier, scrambleWalkFor, clamp01, tierOf,
+  gridForTier, scrambleWalkFor, expectedBoardsFor, clamp01, tierOf,
 };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/index.js
@@ -1,6 +1,7 @@
 /* ============================================================================
  * games/composure/index.js - COMPOSURE (the sliding picture; family: puzzle,
- * Semester III). One 120s class, or an untimed Zen board.
+ * Semester III). One 300s class of as many boards as you can bank, or an
+ * untimed Zen table that banks them until you leave.
  *
  * THE PITCH. A 15-puzzle whose picture never sits still: every tile is a
  * clipped viewport into ONE looping clip (N <img> of the SAME url at different
@@ -23,10 +24,17 @@
  *   RESCUE   the critic's top fix, and it is LAW: 20s with no new piece home
  *            lights the baseline solver's next move (.is-hint) and fails the
  *            declared sGate, so a C-player finishes and the class stays honest.
- *   SOLVE    seams dissolve, the clip plays clean, the jackpot ladder rolls.
- *   BELL     timed classes always fill their 120s or end on the solve.
- *   ZEN      untimed, gentle, its own board size, and it ends with
- *            endClass({zen:true}) - 'pass', no letter (core/grades.js).
+ *   SOLVE    seams dissolve, the clip plays clean, the jackpot ladder rolls -
+ *            and then the picture BANKS and a fresh scramble deals.
+ *   BELL     THE LAW, and it replaced the old one: a timed class always fills
+ *            its bell. A solve BANKS and RE-DEALS; it never ends the class.
+ *            The bell is the single ending, and the board that was still in
+ *            progress when it rang is graded as partial progress ON TOP of
+ *            every banked solve (grade.js compositeFor).
+ *   ZEN      untimed, gentle, its own board size. It banks and re-deals the
+ *            same way - there is simply no bell, so the player's own Finish
+ *            button is the ending, and it ends with endClass({zen:true}) -
+ *            'pass', no letter (core/grades.js).
  *
  * PEEK IS THE SHELL'S. `manifest.peek` opts into shell/peek.js, and this game
  * only says what a reveal SHOWS (the solved reference). The A-cap is the
@@ -42,11 +50,18 @@
  *        engine one-shot over it is decoration (fireSafe welds clickSafe on).
  *   III  something always breathes - the subject is a loop, and the backdrop
  *        and the casino keep moving even on a still board.
- *   IV   the class rules are DRAWN (.g-cp-howto, three figures + one GO), the
- *        dismissal is GO only, and ctx.hideTutorial + gameMeta.howtoTiers mean
- *        a skipping player still gets it once per grade tier.
+ *   IV   the class rules are DRAWN (.g-cp-howto, four figures + one GO), the
+ *        dismissal is GO only, the sheet is FREE OF THE CLOCK (startClock()
+ *        runs in openClass, past GO), and gameMeta.howtoTiers means every
+ *        player gets it ONCE per grade tier - ctx.hideTutorial skips that
+ *        first showing too.
  *   V    scramble, wash windows, sub_flash cadence and every deck are scoped
- *        off the class seed; a retake replays the identical board and show.
+ *        off the class seed; a retake replays the identical boards and show.
+ *        THE BOARD SEEDS ARE INDEXED: board 1 is `<seed>|cp-scramble|<n>`,
+ *        exactly what this class always dealt, and boards 2..k append `|b2`,
+ *        `|b3` and so on. So today's opening board is byte-for-byte the one it
+ *        was before the class grew, and every re-deal after it is a function
+ *        of the seed and the board index - never of the wall clock.
  *   VI   pause/resume/suspend/destroy: the timer registry defers, the decks
  *        ride it, no timer survives destroy, the window listener is removed,
  *        and a suspend force-hides the peek.
@@ -80,7 +95,7 @@ import { nextMove, baselineLength } from './solver.js';
 import { makeTaggedRoll } from '../../core/rng.js';
 import {
   PLAYTEST, buildPlan, compositeFor, hardGates, flavorXp, parFor, heatFor, cadenceMs,
-  gridForTier, scrambleWalkFor,
+  gridForTier, scrambleWalkFor, expectedBoardsFor,
 } from './grade.js';
 
 const GAME_KEY = 'composure';
@@ -201,18 +216,24 @@ function injectFallbackStyle() {
 export default {
   key: GAME_KEY,
   family: 'puzzle',
-  /* MEATY, and it is a TIMETABLE fact, not a claim about this class's length -
-   * the budget is still 120s. core/timetable.js ranks no-repeat-3 ABOVE the
-   * meaty preference (CLAUDE.md trap 6), so a ten-game pool with two meaty
-   * classes filled the meaty slot on only ~46% of dealt nights, and three on
-   * 75% (a cycle of four). With four (Lost & Found, The Deep End, Instant
-   * Recall and this one) a dealt fortnight carries one on 28/28 nights.
-   * NOTHING in this module branches on the flag - it is the registry's and the
-   * timetable's to read. Keep it in step with games/registry.js GAME_META,
-   * which is the parachute a suspended class is dealt from. */
+  /* MEATY, and it is a TIMETABLE fact first: core/timetable.js ranks
+   * no-repeat-3 ABOVE the meaty preference (CLAUDE.md trap 6), so a ten-game
+   * pool with two meaty classes filled the meaty slot on only ~46% of dealt
+   * nights, and three on 75% (a cycle of four). With four (Lost & Found, The
+   * Deep End, Instant Recall and this one) a dealt fortnight carries one on
+   * 28/28 nights. NOTHING in this module branches on the flag - it is the
+   * registry's and the timetable's to read. Keep it in step with
+   * games/registry.js GAME_META, which is the parachute a suspended class is
+   * dealt from.
+   *
+   * As of the class-length wave (2026-08-24) the flag is ALSO honest about the
+   * length: 300s, and every tier really fills it. It used to be a 120s class
+   * that a year-1 player finished in ~35-40s on the solve, so "meaty" was a
+   * label the class did not earn; a solve now BANKS the picture and deals a
+   * fresh scramble, and only the bell ends a timed class. */
   meaty: true,
   flagship: false,
-  timeBudgetSec: 120,
+  timeBudgetSec: 300,
   title: 'Composure',
 
   manifest: {
@@ -262,6 +283,15 @@ export default {
     let reported = false;
     let busy = true;                 // input closed until the rules sheet is done
     let opened = false;              // the board is the player's
+    /* THE BANK BEAT: a solve is celebrating and the next scramble is dealing.
+     * Input is closed, and it is closed SILENTLY (see press()) - the beat is a
+     * scene the player earned, not a wall they walked into. */
+    let banking = false;
+    /* AN ENDING HAS BEGUN (the bell rang, or zen's Finish was pressed). This is
+     * the guard that keeps the file's pinned law true across the re-deal loop:
+     * a bank timer that lands after the bell must NOT deal a board under the
+     * end card, and there must still be exactly one endClass. */
+    let closing = false;
 
     /* ---- class state ---------------------------------------------------- */
     let spec = null;
@@ -283,7 +313,13 @@ export default {
     let pressure = null;
     let styleOk = false;
 
-    /* ---- the ledger (Law I: computed here, never by a deck) ------------- */
+    /* ---- the ledger (Law I: computed here, never by a deck) -------------
+     * TWO SCOPES, and mixing them up is the whole risk of the multi-board
+     * rework. CLASS-cumulative: moves, bumps, backtracks, thrash, washes,
+     * subFlashes, jackpots, rescueEpisodes, rescueUsed, banked, parBanked,
+     * bestLockStreak, elapsedMs. PER-BOARD, reset on every deal: state, par,
+     * baseline, mhStart, locked, lastMove, lockStreak, boardMoves, solved,
+     * rescueActive, hintId, lastLockAtMs. */
     let moves = 0;
     let bumps = 0;
     let backtracks = 0;
@@ -293,7 +329,17 @@ export default {
     let bestLocked = 0;
     let lockStreak = 0;
     let bestLockStreak = 0;
+    /** The LIVE board is whole. Transient now: true from the solve until the
+     *  next board deals, which is also the window the bell can catch. */
     let solved = false;
+    /* ---- THE BANK (multi-board) ---------------------------------------- */
+    let boardIndex = 0;              // 0-based; board 1 is the seed's own deal
+    let banked = 0;                  // pictures finished and banked this class
+    let boardMoves = 0;              // slides on the LIVE board only
+    let parBanked = 0;               // the sum of every banked board's own par
+    let bestSolveMoves = 0;          // fewest moves any ONE board took tonight
+    let underParSolve = false;       // any one board came in at or under its par
+    let expectedBoards = 1;          // the S/A normaliser, off tier + budget
     let washOn = false;
     let washes = 0;
     let subFlashes = 0;
@@ -325,7 +371,10 @@ export default {
     let boardEl = null; let previewEl = null; let peekEl = null; let peekMedia = null;
     let wellEl = null; let msgEl = null; let endEl = null; let howtoEl = null;
     let movesChip = null; let clockChip = null; let lockedChip = null; let calmChip = null;
+    let bankedChip = null;
     let peekBtn = null; let finishBtn = null;
+    /** The class's earned par at the ending; renderEnd draws it beside moves. */
+    let endParEarned = 0;
     const cellEls = [];
     const tileEls = new Map();       // tile id -> element
     let queued = null;               // THE QUEUE: one slot, last press wins
@@ -497,9 +546,18 @@ export default {
       calmChip = el('span', 'g-cp-chip g-cp-calm', '');
       calmChip.setAttribute('aria-label', t('cp_chip_calm', CP_LEX.cp_chip_calm));
       calmChip.hidden = true;
+      /* THE BANK COUNTER. Hidden until the first picture lands (like the calm
+       * chip) so a class that never banks one never grows a zero. It is NOT in
+       * the trickster's chipEl/chipText seam and must not be: the bank count is
+       * the class's own ledger, and a lie about how many pictures you finished
+       * is a lie about the grade, not about the board (Law I). */
+      bankedChip = el('span', 'g-cp-chip g-cp-banked', '0');
+      bankedChip.setAttribute('aria-label', t('cp_chip_banked', CP_LEX.cp_chip_banked));
+      bankedChip.hidden = true;
       hud.appendChild(movesChip);
       hud.appendChild(clockChip);
       hud.appendChild(lockedChip);
+      hud.appendChild(bankedChip);
       hud.appendChild(calmChip);
 
       /* THE PEEK CONTROL. The node is built here and OWNED by the shell: it is
@@ -685,6 +743,10 @@ export default {
       if (clockChip) clockChip.textContent = clockText();
       if (movesChip) movesChip.textContent = movesText();
       if (lockedChip) lockedChip.textContent = lockedText();
+      if (bankedChip) {
+        bankedChip.hidden = banked <= 0;
+        bankedChip.textContent = String(banked);
+      }
       paintCalm();
     }
     function paintCalm() {
@@ -811,7 +873,13 @@ export default {
       if (dead) return false;
       /* A press in a phase that cannot take one - the rules sheet, a pause, a
        * suspend, the end card - is REFUSED, and a refusal is never silent (W2). */
-      if (paused || ended || !state || !opened) { bumpCue(); return false; }
+      if (paused || ended || closing || !state || !opened) { bumpCue(); return false; }
+      /* THE BANK BEAT IS A SCENE, NOT A WALL. The picture the player just
+       * finished is playing itself whole and the next scramble is dealing; a
+       * press in that window is not a refusal, so it neither thuds nor takes
+       * the queue slot (a queued press would land on the FRESH board, which is
+       * the one thing the deal must never hand them). */
+      if (banking) return false;
       if (busy) {
         if (PLAYTEST.QUEUE_SLOTS > 0) { queued = { kind, v }; return false; }
         bumpCue();                       // no queue slot to take it: simply refused
@@ -854,7 +922,8 @@ export default {
       const res = slide(state, pos);
       if (!res.moved) { bump(); return false; }
       busy = true;
-      moves += 1;
+      moves += 1;                    // the CLASS's slide count (pace, calm)
+      boardMoves += 1;               // ...and this board's, for the standing best
 
       /* 1. the tile rides to its new cell (vars only - style.js owns the ride) */
       const node = tileEls.get(res.id);
@@ -960,10 +1029,17 @@ export default {
      * 20s with no new piece home lights the baseline solver's next move and
      * fails the declared sGate. The class never ends because of it, and the
      * board is never played for the player: one cell, lit.
+     *
+     * THE STATE IS PER BOARD (multi-board, 2026-08-24). `lastLockAtMs`,
+     * `rescueActive` and the lit hint all reset on every deal - twenty seconds
+     * into a brand new scramble is not being stuck, and a hint left over from
+     * the board before points at a tile that has moved. What does NOT reset is
+     * `rescueUsed` and the episode count: the sGate was a promise about the
+     * CLASS, and the tax is about the class too.
      * ==================================================================== */
     function rescueEnabled() { return zen ? PLAYTEST.RESCUE_IN_ZEN : true; }
     function checkRescue() {
-      if (!rescueEnabled() || solved || ended || !opened || rescueActive || !state) return;
+      if (!rescueEnabled() || solved || banking || closing || ended || !opened || rescueActive || !state) return;
       if ((elapsedMs - lastLockAtMs) < PLAYTEST.RESCUE_MS) return;
       rescueActive = true;
       rescueEpisodes += 1;
@@ -1005,7 +1081,13 @@ export default {
       for (const w of plan.washes) after(w.atMs, () => runWash(w));
     }
     function runWash(w) {
-      if (dead || ended || solved) return;
+      if (dead || ended || closing) return;
+      /* A wash that comes due DURING a bank beat waits for it rather than
+       * being dropped. The room does not bury the reward it just handed you,
+       * and the schedule is the CLASS's (one spread across the whole bell),
+       * so losing a window would quietly thin the burial every time somebody
+       * solved. The poll is a pause-aware timer like everything else here. */
+      if (banking || solved) { after(600, () => runWash(w)); return; }
       washes += 1;
       washOn = true;
       if (stage) stage.setAttribute('data-wash', '1');
@@ -1068,16 +1150,82 @@ export default {
     }
 
     /* ==================================================================== *
-     * THE ENDINGS - solve / bell / zen's own button. Exactly one endClass.
+     * THE BANK LOOP + THE ENDINGS.
+     *
+     * THE PINNED LAW IS UNCHANGED AND IT IS THE POINT: exactly one endClass,
+     * ever. What changed is that a SOLVE is no longer one of the ways out. A
+     * solve banks the picture and deals a fresh scramble; only the bell (timed)
+     * or zen's own Finish button closes the class, and both of those set
+     * `closing` FIRST, which is what a pending bank timer tests before it deals
+     * anything. So the bell landing in the middle of a celebration is safe in
+     * both orders: the deal refuses, and finish() still guards on `ended`.
      * ==================================================================== */
+
+    /** Board 1 is `<seed>|cp-scramble|<n>[|zen]` - byte-for-byte the seed this
+     *  class dealt before it grew. Every board after it appends `|b2`, `|b3`. */
+    function scrambleSeedFor(index) {
+      const base = seed + '|cp-scramble|' + n + (zen ? '|zen' : '');
+      return index <= 0 ? base : base + '|b' + (index + 1);
+    }
+
+    /**
+     * Deal the board at `boardIndex` onto the live model and reset the
+     * PER-BOARD half of the ledger. Same tier dials every board; the only
+     * thing that moves is the scramble depth at tiers 1-2 (grade.js
+     * SCRAMBLE_WALK_STEP), which is a pure function of the index.
+     *
+     * The tile ELEMENTS are never rebuilt: a re-deal is the same n*n-1 ids in
+     * new cells, so paintTiles() re-points them and the <img> viewports (which
+     * are keyed to a tile's HOME, not its cell) never even reload.
+     */
+    function dealCurrentBoard() {
+      const scrambleSeed = scrambleSeedFor(boardIndex);
+      const walk = scrambleWalkFor(tier, zen, boardIndex);
+      state = dealBoard(n, scrambleSeed, { walk });
+      if (!isSolvable(state.cells, n)) {
+        say('FATAL-ish: the dealt board failed the parity test - re-dealing solved-adjacent');
+        state = dealBoard(n, scrambleSeed + '|repair', { walk: Math.max(20, n * n * 2) });
+      }
+      mhStart = manhattan(state);
+      locked = lockedCount(state);
+      bestLocked = Math.max(bestLocked, locked);
+
+      /* THE BASELINE, per board. par is derived from a real solve of THIS
+       * scramble, not a table someone guessed (dossier open question 3). A
+       * solver that cannot answer leaves par on the per-tile fallback and the
+       * rescue without a hint - never a throw inside a live class. */
+      baseline = -1;
+      try { baseline = baselineLength(cloneState(state)); } catch (e) { baseline = -1; }
+      par = parFor(baseline, tier, n);
+
+      /* the per-board half of the ledger */
+      boardMoves = 0;
+      lastMove = null;
+      lockStreak = 0;
+      solved = false;
+      rescueActive = false;
+      lastLockAtMs = elapsedMs;
+    }
+
+    /** A picture came back whole: BANK it, celebrate, then deal the next one. */
     function onSolved() {
-      if (solved || ended) return;
+      if (solved || ended || closing) return;
       solved = true;
+      banking = true;
       busy = true;
+      /* THE BANK ITSELF, and it happens HERE rather than at the deal: the
+       * counter must tick the instant the picture lands, and if the bell rings
+       * during the celebration this solve is already paid for. Which is also
+       * why grade.js scores a `boardSolved` live board at ZERO - its whole is
+       * in `banked` and counting both would pay for it twice. */
+      banked += 1;
+      parBanked += par;
+      if (!(bestSolveMoves > 0) || boardMoves < bestSolveMoves) bestSolveMoves = boardMoves;
+      if (boardMoves <= par) underParSolve = true;
       clearQueue();
+      clearGrab();
       clearHint();
       rescueActive = false;
-      stopClock();
       setPhase('solved');
       if (boardEl) boardEl.classList.add('is-solved');
       if (stage) stage.setAttribute('data-solved', '1');
@@ -1091,17 +1239,70 @@ export default {
       msg(zen ? 'cp_zen_done' : 'cp_solved_line', zen ? CP_LEX.cp_zen_done : CP_LEX.cp_solved_line);
       tick('jackpot', 0.8);
       fireSafe('flash_burst', { count: 3, alpha: 0.45 });
+      say('BANKED board ' + (boardIndex + 1) + ' in ' + boardMoves + ' moves (par ' + par
+        + ') - ' + banked + ' this class');
+      /* The clock is NOT stopped: the bell owns the class now. */
       const playMs = reduced ? PLAYTEST.SOLVE_PLAY_MS_REDUCED : PLAYTEST.SOLVE_PLAY_MS;
-      after(playMs, () => finish('solved'));
+      after(playMs, dealNextBoard);
     }
 
+    /** The celebration is over: scatter the picture into a fresh scramble. */
+    function dealNextBoard() {
+      /* The bell (or zen's Finish) won the race. Nothing deals under an end
+       * card - this single test is what keeps "exactly one endClass" true. */
+      if (dead || ended || closing) return;
+      boardIndex += 1;
+      clearQueue();
+      clearGrab();
+      clearHint();
+      if (boardEl) boardEl.classList.remove('is-solved');
+      if (stage) stage.removeAttribute('data-solved');
+      setPhase('dealing');
+      if (boardEl) boardEl.classList.add('is-dealing');
+
+      dealCurrentBoard();
+      paintTiles(false);
+      applyLockClasses(homeMask(state));
+      paintHud();
+      heat();
+      /* The decks' own royal state has to come down with the board. Both
+       * `deal` hooks are null-safe through deck(), and pressure's is not
+       * optional polish: its setProgress() early-returns while royalOn, so
+       * without it the CCP-effects ladder would freeze after the first bank. */
+      deck('casino', 'deal', { bell: bellOn });
+      deck('pressure', 'deal');
+      deck('trickster', 'deal');
+      msg('cp_bank_line', CP_LEX.cp_bank_line, 2400);
+      tick('lift', 0.42);
+      say('dealing board ' + (boardIndex + 1) + ' (walk ' + scrambleWalkFor(tier, zen, boardIndex)
+        + ', mh ' + mhStart + ', baseline ' + baseline + ', par ' + par + ')');
+
+      after(reduced ? PLAYTEST.DEAL_MS_REDUCED : PLAYTEST.DEAL_MS, () => {
+        if (dead || ended || closing) return;
+        if (boardEl) boardEl.classList.remove('is-dealing');
+        setPhase('play');
+        banking = false;
+        busy = false;
+        clearQueue();               // nothing pressed at the celebration rides in
+        lastLockAtMs = elapsedMs;   // the stall clock starts with the new board
+      });
+    }
+
+    /**
+     * THE ONE ENDING for a timed class. It fires whatever the board is doing -
+     * mid-slide, mid-celebration, mid-deal - and `closing` is set BEFORE
+     * anything else so the pending bank timer finds it.
+     */
     function bell() {
-      if (dead || ended || solved) return;
+      if (dead || ended || closing) return;
+      closing = true;
+      banking = false;
       busy = true;
       clearQueue();
       clearGrab();
       clearHint();
       bellOn = true;
+      if (boardEl) boardEl.classList.remove('is-dealing');
       setPhase('ended');
       deck('casino', 'bell', true);
       deck('casino', 'dimOut');
@@ -1114,11 +1315,17 @@ export default {
       after(reduced ? PLAYTEST.CEREMONY_MS_REDUCED : PLAYTEST.CEREMONY_MS, () => finish('bell'));
     }
 
-    /** ZEN's own way out. Exactly once - the button disables itself. */
+    /** ZEN's own way out, and zen's ONLY way out - a zen solve banks and
+     *  re-deals exactly like a timed one, so the table keeps dealing until the
+     *  player says stop. Exactly once: the button disables itself, and
+     *  `closing` stops any bank beat in flight from dealing board k+1. */
     function onFinishPressed() {
-      if (dead || ended || finished || !zen) return;
+      if (dead || ended || finished || closing || !zen) return;
       finished = true;
+      closing = true;
+      banking = false;
       try { if (finishBtn) finishBtn.disabled = true; } catch (e) { /* noop */ }
+      if (boardEl) boardEl.classList.remove('is-dealing');
       stopClock();
       finish('left');
     }
@@ -1126,6 +1333,8 @@ export default {
     function finish(reason) {
       if (ended) return;
       ended = true;
+      closing = true;
+      banking = false;
       busy = true;
       stopClock();
       stopAmbience();
@@ -1139,19 +1348,31 @@ export default {
 
       const tiles = tileCount(n);
       const mhNow = manhattan(state);
+      /* THE WHOLE CLASS, not the last board: banked solves + whatever the live
+       * board was worth when the bell rang, normalised by what this year is
+       * expected to fill the bell with. `boardSolved` is the bell-caught-the-
+       * celebration case and tells grade.js to score the live board at zero
+       * (its whole is already inside `banked`). */
       const graded = compositeFor({
-        gradeTier: tier, solved, n, moves, par,
+        gradeTier: tier, banked, expectedBoards, boardSolved: solved,
+        n, moves, par, parBanked,
         manhattanStart: mhStart, manhattanNow: mhNow,
         locked, tiles, backtracks, thrash, assists: rescueEpisodes,
       });
       const gates = hardGates(rescueUsed);
-      const fx = flavorXp({ solved, moves, par, bestMovesBefore });
+      const fx = flavorXp({ banked, bestSolveMoves, bestMovesBefore, underParSolve });
+      endParEarned = Math.round(graded.parEarned);
 
-      /* meta: the standing dare per board size, and how many pictures came back */
+      /* meta: the standing dare per board size, and how many pictures came back
+       * across the player's whole history. The dare is a PER-BOARD number, so
+       * it is the best single board of the class that goes up against it -
+       * never the class's cumulative move count. */
       const bestKey = 'bestMoves' + n;
       try {
-        const patch = { solves: solvesBefore + (solved ? 1 : 0), lastSeed: seed, lastPlayedAt: Date.now() };
-        if (solved && (!(bestMovesBefore > 0) || moves < bestMovesBefore)) patch[bestKey] = moves;
+        const patch = { solves: solvesBefore + banked, lastSeed: seed, lastPlayedAt: Date.now() };
+        if (bestSolveMoves > 0 && (!(bestMovesBefore > 0) || bestSolveMoves < bestMovesBefore)) {
+          patch[bestKey] = bestSolveMoves;
+        }
         ctx.store.mergeGameMeta(GAME_KEY, patch);
       } catch (e) { say('meta write failed (class unaffected): ' + ((e && e.message) || e)); }
 
@@ -1167,15 +1388,19 @@ export default {
 
       lastReport = Object.assign({}, report, {
         inputs: {
-          tier, n, zen, seed, retake, reason, solved, moves, bumps, par, baseline,
+          tier, n, zen, seed, retake, reason, moves, bumps, baseline,
+          banked, boardIndex, boardsDone: graded.boardsDone, expectedBoards,
+          boardSolved: solved, boardMoves, par, parBanked, parEarned: graded.parEarned,
+          bestSolveMoves, underParSolve,
           locked, tiles, backtracks, thrash, assists: rescueEpisodes, rescueUsed,
           manhattanStart: mhStart, manhattanNow: mhNow, elapsedMs, washes, subFlashes,
           jackpots, bestLockStreak, terms: graded.terms, tax: graded.tax,
         },
       });
       try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
-      say('class over (' + reason + '): ' + (solved ? 'SOLVED' : locked + '/' + tiles + ' home') + ' in '
-        + moves + ' moves (par ' + par + ', baseline ' + baseline + '), '
+      say('class over (' + reason + '): ' + banked + ' banked of ' + expectedBoards + ' expected, '
+        + 'live board ' + (solved ? 'WHOLE' : locked + '/' + tiles + ' home') + ', '
+        + moves + ' moves (par earned ' + Math.round(graded.parEarned) + '), '
         + backtracks + ' backtracks / ' + thrash + ' panic'
         + (rescueUsed ? ', RESCUE' : '') + (zen ? ' -> zen pass' : ' -> composite ' + graded.composite.toFixed(3)));
 
@@ -1200,18 +1425,28 @@ export default {
         endEl.appendChild(r);
         return r;
       };
-      const yes = t('cp_end_yes', CP_LEX.cp_end_yes);
-      const no = t('cp_end_no', CP_LEX.cp_end_no);
-      row('g-cp-end-solved', t('cp_end_solved', CP_LEX.cp_end_solved), solved ? yes : no);
+      /* THE HEADLINE IS THE BANK. `cp_end_solved` used to be a Yes/No about
+       * the one board; a class that deals boards until the bell has a COUNT
+       * instead, so the row was re-worded rather than a new key minted (and
+       * cp_end_yes / cp_end_no went with the question they answered). The
+       * locked row underneath is the board that was still in progress. */
+      row('g-cp-end-solved', t('cp_end_solved', CP_LEX.cp_end_solved), String(banked));
       row('', t('cp_end_locked', CP_LEX.cp_end_locked), locked + '/' + tileCount(n));
       row('', t('cp_end_moves', CP_LEX.cp_end_moves), String(moves));
-      row('', t('cp_end_par', CP_LEX.cp_end_par), String(par));
+      /* ...and the baseline it is measured against is the class's EARNED par
+       * (every banked board's own, plus the live board's pro-rated), so the
+       * two numbers still read as a pair. */
+      row('', t('cp_end_par', CP_LEX.cp_end_par), String(Math.max(0, Math.round(endParEarned))));
       row('', t('cp_end_backtracks', CP_LEX.cp_end_backtracks), String(backtracks));
       row('', t('cp_end_thrash', CP_LEX.cp_end_thrash), String(thrash));
       if (rescueEpisodes > 0) row('g-cp-end-assist', t('cp_end_assists', CP_LEX.cp_end_assists), String(rescueEpisodes));
       row('', t('cp_end_time', CP_LEX.cp_end_time), mmss(secElapsed()));
 
-      const bestNow = solved && (!(bestMovesBefore > 0) || moves < bestMovesBefore) ? moves : bestMovesBefore;
+      /* The standing dare is a PER-BOARD number: the best single board of this
+       * class against the best single board of every class before it. */
+      const bestNow = (bestSolveMoves > 0 && (!(bestMovesBefore > 0) || bestSolveMoves < bestMovesBefore))
+        ? bestSolveMoves
+        : bestMovesBefore;
       const dare = el('div', 'g-cp-end-dare');
       dare.appendChild(el('span', 'g-cp-end-k', t('cp_end_best', CP_LEX.cp_end_best)));
       dare.appendChild(el('span', 'g-cp-end-v', bestNow > 0 ? String(bestNow) : '--'));
@@ -1283,10 +1518,16 @@ export default {
 
     /* ==================================================================== *
      * THE DRAWN CLASS-RULES SHEET (Deck VI, Law IV)
-     * Three figures and ONE way out. Policy is the shell's "Skip class
-     * tutorials" contract: on by default every class; with the skip on, a
-     * class still explains itself once per grade tier. CORE builds the
-     * structure and owns the policy; style.js draws it.
+     * FOUR figures and ONE way out - the fourth is the bank rule, which is a
+     * class rule and therefore belongs on the drawn sheet rather than in a
+     * proctor line the player can miss. THE LAW, uniform across every open
+     * class (owner ruling 2026-08-24): the sheet SHOWS the first time this
+     * player meets this class at this grade tier and AUTO-SKIPS every later
+     * class at that tier, whatever the setting says; the shell's "Skip class
+     * tutorials" switch (ctx.hideTutorial) means "skip even the first
+     * showing". It is also FREE OF THE CLOCK - openClass() (and startClock()
+     * inside it) is on the far side of GO. CORE builds the structure and owns
+     * the policy; style.js draws it.
      * ==================================================================== */
     function howtoSeenTiers() {
       try {
@@ -1296,7 +1537,9 @@ export default {
     }
     function howto(onDone) {
       const seen = howtoSeenTiers();
-      if (ctx.hideTutorial === true && seen.indexOf(tier) >= 0) { onDone(); return; }
+      /* AUTO-SKIP once this tier is on the record; hideTutorial skips the
+       * first showing too. No meta = an empty list = the sheet shows. */
+      if (ctx.hideTutorial === true || seen.indexOf(tier) >= 0) { onDone(); return; }
       if (!stage) { onDone(); return; }
       let done = false;
       howtoEl = el('div', 'g-cp-howto');
@@ -1317,6 +1560,10 @@ export default {
       figRow('g-cp-hw-slide', t('cp_howto_slide', CP_LEX.cp_howto_slide));
       figRow('g-cp-hw-lock', t('cp_howto_lock', CP_LEX.cp_howto_lock));
       figRow('g-cp-hw-wash', t('cp_howto_wash', CP_LEX.cp_howto_wash));
+      /* THE BANK. In zen there is no bell to promise, but the re-deal is the
+       * same, so the row is drawn either way - a zen player who solves and
+       * sees a fresh scramble has been told it was coming. */
+      figRow('g-cp-hw-bank', t('cp_howto_bank', CP_LEX.cp_howto_bank));
       const go = el('button', 'g-cp-hw-go', t('cp_howto_go', CP_LEX.cp_howto_go));
       go.setAttribute('type', 'button');
       try { go.type = 'button'; } catch (e) { /* noop */ }
@@ -1473,6 +1720,7 @@ export default {
       msg('cp_play_hint', CP_LEX.cp_play_hint, 3000);
       opened = true;
       busy = false;
+      banking = false;
       lastLockAtMs = 0;
       elapsedMs = 0;
       deck('casino', 'start');
@@ -1487,12 +1735,15 @@ export default {
      * ==================================================================== */
     const instance = {
       start(classSpec) {
-        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 300 };
         tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
         seed = String(spec.seed == null ? GAME_KEY : spec.seed);
         retake = !!spec.retake;
         reduced = probeReduced(ctx);
-        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
+        /* The shell's budget is the truth; the module's own timeBudgetSec (and
+         * registry.js's mirror of it) is the 300s parachute. Min-clamped only,
+         * so a shell that hands us a longer class simply gets more boards. */
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 300) * 1000);
 
         const mode = String((ctx.settings && ctx.settings.cp_mode) != null ? ctx.settings.cp_mode : 'timed')
           .trim().toLowerCase();
@@ -1503,26 +1754,20 @@ export default {
 
         plan = buildPlan({ seed, gradeTier: tier, n, zen, timeBudgetSec: budgetMs / 1000 });
 
-        /* THE BOARD. Seeded, and SOLVABLE by construction (board.js repairs a
-         * bad parity). The assertion below is belt and braces: a board that
-         * cannot be solved is the one thing this class may never deal. */
-        const scrambleSeed = seed + '|cp-scramble|' + n + (zen ? '|zen' : '');
-        state = dealBoard(n, scrambleSeed, { walk: scrambleWalkFor(tier, zen) });
-        if (!isSolvable(state.cells, n)) {
-          say('FATAL-ish: the dealt board failed the parity test - re-dealing solved-adjacent');
-          state = dealBoard(n, scrambleSeed + '|repair', { walk: Math.max(20, n * n * 2) });
-        }
-        mhStart = manhattan(state);
-        locked = lockedCount(state);
-        bestLocked = locked;
+        /* How many whole boards this year is expected to hold in this budget -
+         * the number the PROGRESS term is divided by, and therefore the whole
+         * S/A bar. 7 / 5 / 3 / 2 at 300s; grade.js's header carries the
+         * arithmetic behind those four numbers. */
+        expectedBoards = expectedBoardsFor(tier, budgetMs / 1000);
 
-        /* THE BASELINE. par is derived from a real solve of THIS scramble, not
-         * a table someone guessed (dossier open question 3). A solver that
-         * cannot answer leaves par on the per-tile fallback and the rescue
-         * without a hint - never a throw inside a live class. */
-        baseline = -1;
-        try { baseline = baselineLength(cloneState(state)); } catch (e) { baseline = -1; }
-        par = parFor(baseline, tier, n);
+        /* BOARD 1. Seeded, and SOLVABLE by construction (board.js repairs a
+         * bad parity); the deal, the parity belt-and-braces and the per-board
+         * baseline all live in dealCurrentBoard() now, because every bank runs
+         * them again. boardIndex 0 is the UN-SUFFIXED seed, so tonight's
+         * opening board is exactly the one this class dealt before it grew. */
+        boardIndex = 0;
+        bestLocked = 0;
+        dealCurrentBoard();
 
         /* Law V: even the FALLBACK reward roll (used only when the engine is
          * absent) runs off the class seed, in its own append-only namespace. */
@@ -1562,7 +1807,8 @@ export default {
         lastReport = null;
         lastSnapshot = null;
         say('tier ' + tier + ' ' + n + 'x' + n + ' ' + (zen ? 'ZEN' : Math.round(budgetMs / 1000) + 's')
-          + ', scramble mh ' + mhStart + ', baseline ' + baseline + ', par ' + par
+          + ', expect ' + expectedBoards + ' board(s), scramble mh ' + mhStart
+          + ', baseline ' + baseline + ', par ' + par + ', ' + plan.washes.length + ' washes'
           + (reduced ? ', reduced' : '') + (retake ? ', RETAKE' : ''));
       },
 
@@ -1597,6 +1843,8 @@ export default {
         clearGrab();
         clearHint();
         opened = false;
+        banking = false;
+        closing = true;
         stopClock();
         clearTimers();
         stopAmbience();
@@ -1644,6 +1892,9 @@ export default {
       forceRescue() { lastLockAtMs = elapsedMs - PLAYTEST.RESCUE_MS - 1; checkRescue(); },
       /** Run a wash window now (harness only). */
       forceWash(ms) { runWash({ atMs: 0, ms: Math.max(200, Number(ms) || 1200), alpha: 0.3, variant: 'pink' }); },
+      /** Bank the live board and deal the next one NOW, skipping the beat
+       *  (harness only - the real path is a solve). */
+      forceDeal() { dealNextBoard(); },
       /** End as the bell would (harness only). */
       forceBell() { stopClock(); bell(); },
 
@@ -1653,7 +1904,10 @@ export default {
           plan: plan ? {
             washes: plan.washes.length, subFlashMs: plan.subFlashMs, heatCap: plan.heatCap,
             audioCeil: plan.audioCeil, bubbles: plan.bubbles, rowDrift: plan.rowDrift,
+            budgetMs: plan.budgetMs,
           } : null,
+          boardIndex, banked, banking, closing, boardMoves, parBanked,
+          bestSolveMoves, underParSolve, expectedBoards,
           board: state ? serialize(state) : '',
           cells: state ? state.cells.slice() : [],
           blank: state ? state.blank : -1,
@@ -1671,7 +1925,7 @@ export default {
           liveTileEls: tileEls.size,
           subjectUrl,
           stage, frame, boardEl, previewEl, peekEl, wellEl, msgEl, endEl, howtoEl,
-          movesChip, clockChip, lockedChip, calmChip, peekBtn, finishBtn,
+          movesChip, clockChip, lockedChip, calmChip, bankedChip, peekBtn, finishBtn,
           casino: casino && typeof casino.diagnostics === 'function' ? (() => { try { return casino.diagnostics(); } catch (e) { return null; } })() : null,
           trickster: trickster && typeof trickster.diagnostics === 'function' ? (() => { try { return trickster.diagnostics(); } catch (e) { return null; } })() : null,
           pressure: pressure && typeof pressure.diagnostics === 'function' ? (() => { try { return pressure.diagnostics(); } catch (e) { return null; } })() : null,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/lex.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/lex.js
@@ -30,23 +30,26 @@ export const CP_LEX = Object.freeze({
   cp_chip_clock: 'Time left',
   cp_chip_locked: 'Pieces home',
   cp_chip_calm: 'Composure',
+  cp_chip_banked: 'Pictures done',
 
   /* ---- the drawn class-rules sheet (Deck VI, Law IV) -------------------- */
   cp_howto_title: 'Class rules',
   cp_howto_slide: 'Tap a piece beside the gap and it slides in. Arrows, WASD and swipes do the same.',
   cp_howto_lock: 'A piece that reaches its own place locks with a snap. It can still be slid.',
   cp_howto_wash: 'The room will bury the board. Keep sliding - the picture underneath never moved.',
+  cp_howto_bank: 'Finish a picture and the next one deals. The bell ends the class, not the solve.',
   cp_howto_go: 'Start the picture',
 
   /* ---- proctor lines (.g-cp-msg, one at a time) ------------------------- */
-  cp_brief: 'One picture, cut apart and still moving. Put it back together.',
-  cp_brief_zen: 'No clock tonight. Slide until it is whole again.',
+  cp_brief: 'One picture, cut apart and still moving. Put it back together, then again.',
+  cp_brief_zen: 'No clock tonight. Slide until it is whole, then again if you like.',
   cp_play_hint: 'Tap a piece beside the gap. Arrows, WASD or swipe.',
   cp_lock_line: 'That one is home.',
   cp_backtrack_line: 'Back where it was. Breathe.',
   cp_wash_line: 'Keep sliding. The board is still exactly where you left it.',
   cp_rescue_line: 'Take the lit piece. The grade eases; the class does not end.',
   cp_solved_line: 'Whole. Watch it play.',
+  cp_bank_line: 'Banked. Here is a fresh one.',
   cp_bell_warn: 'Twenty seconds.',
   cp_bell_line: 'The bell. Hands off the board.',
   cp_zen_done: 'Whole, in your own time.',
@@ -65,7 +68,10 @@ export const CP_LEX = Object.freeze({
   /* ---- the end card (.g-cp-end) ----------------------------------------- */
   cp_end_title: 'Composure report',
   cp_end_title_zen: 'Zen board',
-  cp_end_solved: 'Solved',
+  /* A COUNT since the class-length wave, not a Yes/No: the class deals boards
+   * until the bell, so what the report leads with is how many pictures came
+   * back. `cp_end_yes` / `cp_end_no` retired with the question. */
+  cp_end_solved: 'Pictures finished',
   cp_end_moves: 'Moves',
   cp_end_par: 'Baseline',
   cp_end_locked: 'Pieces home',
@@ -73,8 +79,6 @@ export const CP_LEX = Object.freeze({
   cp_end_thrash: 'Panic moves',
   cp_end_assists: 'Assists',
   cp_end_time: 'Time',
-  cp_end_yes: 'Yes',
-  cp_end_no: 'No',
   cp_end_best: 'Best solve',
   cp_end_best_line: 'Your standing mark on this board. Beat it next class.',
   cp_end_best_first: 'Your first finished picture on this board.',

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/pressure.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/pressure.js
@@ -692,6 +692,21 @@ export function createCpPressure(o) {
       retune();
     },
     /**
+     * THE BANK (multi-board, 2026-08-24). A solve no longer ends the class: it
+     * banks the picture and a fresh scramble deals, so the ROYAL is a beat and
+     * has to come back down. This is NOT optional polish - `setProgress` above
+     * early-returns while `royalOn`, so without this the whole CCP-effects
+     * ladder would freeze at RUNG_MAX from the first bank to the bell.
+     */
+    deal() {
+      if (!started || stopped) return;
+      royalOn = false;
+      streak = 0;
+      cls(ring, 'is-gold', bellOn);
+      stepTo(rungFor(frac, zen), false);
+      retune();
+    },
+    /**
      * The class's beats: 'slide' | 'lock' | 'thrash' | 'assist' | 'solved' |
      * 'bell' | 'wash' | 'unwash' (+ {streak?, tileEl?} as a second arg). Unknown
      * kinds are ignored.

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/style.js
@@ -13,7 +13,8 @@
  *                 [data-mode=zen] is the warm room, [data-mode=timed] the cool.
  *   .g-cp-backdrop  the casino's lighting rig (pointer-events:none, z 0):
  *                 wall / lamp / motes / dark / flash / royal / vig layers
- *   .g-cp-hud     four chips: moves, clock, locked, calm
+ *   .g-cp-hud     five chips: moves, clock, locked, BANKED (the multi-board
+ *                 counter, hidden until the first picture lands), calm
  *   .g-cp-frame   THE EASEL: the wooden frame + mat around the board, the
  *                 stand drawn under it (::after), the marquee + the casino's
  *                 overlay (.g-cp-cs) and the trickster's .g-cp-preview live
@@ -51,7 +52,10 @@
  * close their seam entirely; a locked tile beside a loose one keeps a hair of
  * it. [data-phase=solved] (and the board's own .is-solved, which outlives a
  * phase change) closes every seam, drops every shadow and sends one light
- * sweep across the canvas while the clip plays clean.
+ * sweep across the canvas while the clip plays clean - and then, since the
+ * class-length wave, the DEAL BEAT takes it away again: a solve BANKS the
+ * picture and a fresh scramble deals ([data-phase=dealing] / .is-dealing),
+ * because only the bell ends a timed class now.
  *
  * THE OTHER CORE HOOKS. .g-cp-board.is-bump (240ms, an illegal press) knocks
  * the whole canvas against the easel - chrome, never a tile. The stage's
@@ -66,13 +70,15 @@
  * index.js; this file only makes it visible.
  *
  * THE SHEET (Deck VI, Law IV): .g-cp-howto is drawn, not told. index.js
- * builds three rows, each a .g-cp-hw-fig.g-cp-hw-slide|lock|wash span holding
- * three blank parts (i.g-cp-hw-a/-b/-c); this sheet makes the span a mini 3x3
- * board out of gradients and the parts its moving pieces: a tile sliding into
- * the gap under a finger, a tile snapping home with its seam lighting up and
- * closing, a pink wash breathing over a board where a tile keeps sliding.
- * index.js owns the policy and the captions; the GO button is the only live
- * thing on the sheet.
+ * builds four rows, each a .g-cp-hw-fig.g-cp-hw-slide|lock|wash|bank span
+ * holding three blank parts (i.g-cp-hw-a/-b/-c); this sheet makes the span a
+ * mini 3x3 board out of gradients and the parts its moving pieces: a tile
+ * sliding into the gap under a finger, a tile snapping home with its seam
+ * lighting up and closing, a pink wash breathing over a board where a tile
+ * keeps sliding, and the finished picture flashing gold and dropping away as
+ * a fresh scramble deals in behind it (THE BANK - a solve does not end the
+ * class any more, the bell does). index.js owns the policy and the captions;
+ * the GO button is the only live thing on the sheet.
  *
  * THE END CARD: .g-cp-end is the panel; rows are .g-cp-end-row > .g-cp-end-k
  * + .g-cp-end-v; the grade arrives as an OBJECT - .g-cp-end-seal[data-grade]
@@ -236,6 +242,13 @@ export const STYLE_TEXT = `
 .g-cp-chip.g-cp-calm::before{content:"";position:absolute;left:0;top:0;bottom:0;z-index:-1;
   width:calc(var(--cp-calm,1) * 100%);background:color-mix(in srgb, var(--pink), transparent 82%);
   transition:width .5s ease}
+/* THE BANK COUNTER. Gold, because it is the one chip that only ever goes up -
+   index.js keeps it hidden until the first picture banks. */
+.g-cp-chip.g-cp-banked{border-color:var(--gold);color:var(--gold);
+  box-shadow:0 0 12px color-mix(in srgb, var(--gold), transparent 68%)}
+.g-cp-stage[data-phase="solved"] .g-cp-chip.g-cp-banked,.g-cp-stage[data-phase="dealing"] .g-cp-chip.g-cp-banked{
+  animation:g-cp-bankchip 620ms ease-out 1 both}
+@keyframes g-cp-bankchip{0%{transform:scale(1)}35%{transform:scale(1.22)}100%{transform:scale(1)}}
 .g-cp-stage[data-mode="zen"] .g-cp-chip.g-cp-clock{opacity:.7}
 .g-cp-stage.g-cp-bell .g-cp-chip.g-cp-clock{border-color:var(--gold);color:var(--gold);
   animation:g-cp-bellchip 1s ease-in-out infinite alternate}
@@ -406,6 +419,25 @@ export const STYLE_TEXT = `
   animation:g-cp-solvesweep 1.8s ease-out .3s 1 both}
 @keyframes g-cp-solvesweep{0%{opacity:1;background-position:140% 0}100%{opacity:0;background-position:-40% 0}}
 
+/* ---- THE DEAL BEAT (multi-board, 2026-08-24) ------------------------------
+   A solve BANKS the picture and a fresh scramble deals; the bell is the only
+   thing that ends a timed class. Same two hooks as the solve, one board apart:
+   index.js sets data-phase="dealing" on the stage AND .is-dealing on the
+   board, holds both for DEAL_MS with input closed, then hands play back.
+   The whole beat is ONE board-level animation on purpose - a per-tile stagger
+   over n*n elements is a lot of compositing for something the player sees six
+   or seven times in a class, and the tiles are already mid-transform from the
+   solve's dissolve. The html.arc-reduced rule at the foot of this sheet kills
+   it for free; the phase attribute stays readable. (NO BACKTICKS ANYWHERE IN
+   HERE - this whole sheet is one template literal, and a backtick in a comment
+   closes it. node --check will not catch that, because the file then still
+   parses as a script; only importing it as a MODULE does.)                  */
+.g-cp-stage[data-phase="dealing"] .g-cp-tile,.g-cp-board.is-dealing .g-cp-tile{cursor:default}
+.g-cp-stage[data-phase="dealing"] .g-cp-board,.g-cp-board.is-dealing{animation:g-cp-deal 640ms cubic-bezier(.2,.7,.3,1) both}
+@keyframes g-cp-deal{0%{opacity:.2;filter:brightness(1.6) saturate(.7);transform:scale(1.035)}
+  50%{opacity:1;filter:brightness(1.05) saturate(1)}
+  100%{opacity:1;filter:none;transform:none}}
+
 /* ---- the burial (data-wash="1" while a wash is up) --------------------------
    The engine's wash buries the board from its own fixed layer; the studio
    answers from underneath: the lamp dips, the motes freeze, the canvas cools
@@ -554,6 +586,22 @@ export const STYLE_TEXT = `
   background:radial-gradient(70% 70% at 50% 40%, hsla(330,90%,70%,.75), hsla(292,70%,55%,.55) 60%, hsla(262,60%,40%,.4));
   mix-blend-mode:screen;filter:blur(1px);animation:g-cp-hwwash 3s ease-in-out infinite}
 @keyframes g-cp-hwwash{0%,25%{opacity:0}40%,75%{opacity:.9}90%,100%{opacity:0}}
+/* 4 - BANK (multi-board): a = the finished picture filling the whole figure
+   and flashing gold, then dropping away; b + c = the fresh scramble dealing
+   in behind it. One 3.4s loop, same grammar as the three rows above.        */
+.g-cp-hw-bank .g-cp-hw-a{inset:0;width:auto;height:auto;border-radius:3px;z-index:3;
+  background:linear-gradient(135deg, hsl(330,60%,58%), hsl(292,50%,50%) 55%, hsl(262,55%,46%));
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.18);animation:g-cp-hwbank 3.4s ease-in-out infinite}
+.g-cp-hw-bank .g-cp-hw-b{left:0;top:0;background:linear-gradient(135deg, hsl(262,45%,42%), hsl(292,40%,38%));
+  box-shadow:0 3px 8px rgba(0,0,0,.6);animation:g-cp-hwdealt 3.4s ease-in-out infinite}
+.g-cp-hw-bank .g-cp-hw-c{left:var(--hw-s);top:var(--hw-s);
+  background:linear-gradient(135deg, hsl(292,40%,38%), hsl(262,45%,42%));
+  box-shadow:0 3px 8px rgba(0,0,0,.6);animation:g-cp-hwdealt 3.4s ease-in-out .12s infinite}
+@keyframes g-cp-hwbank{0%,22%{opacity:1;transform:scale(1);filter:none}
+  34%{opacity:1;transform:scale(1.04);filter:brightness(1.7) saturate(1.3)}
+  48%,100%{opacity:0;transform:scale(.92);filter:none}}
+@keyframes g-cp-hwdealt{0%,44%{opacity:0;transform:scale(1.3)}58%,88%{opacity:1;transform:scale(1)}
+  100%{opacity:0;transform:scale(1)}}
 .g-cp-hw-go{pointer-events:auto;align-self:center;margin-top:14px;padding:10px 26px;border-radius:999px;cursor:pointer;
   font-family:var(--disp);font-size:13px;letter-spacing:.18em;text-transform:uppercase;color:var(--ground);
   background:linear-gradient(180deg, color-mix(in srgb, var(--lav), white 15%), var(--lav));

--- a/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/composure/trickster.js
@@ -854,6 +854,24 @@ export function createCpTrickster(o) {
       if (washIsOn && !stopped && previewArmed && !isHalted()) playPreview();
     },
 
+    /**
+     * THE BANK (multi-board, 2026-08-24). The board under the lies has just
+     * been replaced, so any lie still on screen points at a tile that moved.
+     * Take them all off - but do NOT touch `deals`, `stopped` or the clock:
+     * the card schedule is the CLASS's (dealt against the bell), not the
+     * board's, and a re-deal is not the end of anything.
+     */
+    deal() {
+      if (!armed || destroyed) return;
+      previewArmed = null;
+      if (previewFold) { cancel(previewFold); previewFold = 0; }
+      if (previewTimer) { cancel(previewTimer); previewTimer = 0; }
+      if (previewClear) { cancel(previewClear); previewClear = 0; }
+      clearGhosts();
+      unmelt();
+      unghost();
+    },
+
     /** The class is over: no card may fire again, every lie comes off. */
     stop() {
       stopped = true;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
@@ -103,6 +103,16 @@ export default {
   meaty: false,
   flagship: true,
   timeBudgetSec: 90,
+  /* CLOCKLESS (owner ruling, the class-length wave). Homeroom keeps its budget
+   * - the bell is real and still ends the class - but the SECONDS are never
+   * drawn: no chip on the departure board, none on the campus room card, none
+   * in the proctor strip, and no time bar over the stage. A wordle is a board
+   * and six rows, and a draining hairline made a one-minute ritual read like a
+   * timed exam. It is a DESCRIPTOR flag: core/timetable.js carries it onto the
+   * dealt class and shell/shell.js + shell/campus.js are the only readers, so
+   * nothing in this file branches on it. games/registry.js GAME_META mirrors it
+   * (the parachute is read for a suspended class too). */
+  clockless: true,
   title: 'Daily Trigger',
 
   manifest: {
@@ -931,14 +941,18 @@ export default {
     }
 
     /**
-     * Policy is the shell's "Skip class tutorials" contract: by default the
-     * sheet shows EVERY class; with the skip on, homeroom still explains itself
-     * ONCE per grade tier (the tier is what changes the room). Dismissal is the
-     * sheet's own button and nothing else - every letter key is already a verb
-     * here, so a keyboard shortcut would type into the board it is covering.
+     * THE LAW, uniform across every open class (owner ruling 2026-08-24): the
+     * sheet SHOWS the first time this player meets homeroom at this grade tier
+     * (the tier is what changes the room) and AUTO-SKIPS every later class at
+     * that tier, whatever the setting says. The shell's "Skip class tutorials"
+     * switch (ctx.hideTutorial) means "skip even the first showing". No meta =
+     * no memory = the sheet shows. Dismissal is the sheet's own button and
+     * nothing else - every letter key is already a verb here, so a keyboard
+     * shortcut would type into the board it is covering. The sheet is also
+     * free of the clock: startMs is taken in beginClass, past GO.
      */
     function howto(onDone) {
-      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      if (ctx.hideTutorial === true || howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
       if (!wrap) { onDone(); return; }
       let done = false;
       let sheet = null;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/casino.js
@@ -174,7 +174,12 @@ export function createDvCasino(o) {
 
   /* ---------------------------------------------------------------- api */
   return {
-    /** Dress the lab + light the frame. Call when play arms. */
+    /**
+     * Dress the lab + light the frame. Call ONCE A CLASS, at the first board's
+     * armPlay - `dressLab()` re-rolls the seeded lab identity off its own
+     * stream, so a second call would re-skin the room mid-class. index.js keeps
+     * the `casinoLit` latch for exactly that reason (class-length wave).
+     */
     start() {
       if (!armed || destroyed) { say('casino: disarmed'); return; }
       dressLab();
@@ -190,7 +195,8 @@ export function createDvCasino(o) {
       paint();
     },
 
-    /** The last pair: gold frame, frantic chase, until the class ends. */
+    /** The last pair: gold frame, frantic chase, until the BOARD clears (a
+     *  class is a run of boards now, and win() drops the frame again). */
     bell(on) {
       if (!mq || !mq.classList) return;
       bellOn = !!on;
@@ -249,7 +255,8 @@ export function createDvCasino(o) {
       }
     },
 
-    /** The class is over; nothing may pulse again. */
+    /** The class is over; nothing may pulse again. (A board ending is NOT this
+     *  call - the marquee is the room's and outlives every board.) */
     stop() {
       if (flashTimer) { timers.cancel(flashTimer); flashTimer = 0; }
       if (mq && mq.classList) mq.classList.remove('g-dv-mq-flash');

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -1,6 +1,19 @@
 /* ============================================================================
  * games/deja-vu/index.js - DEJA VU (memory / pairs; family: memory).
  *
+ * THE CLASS IS MANY BOARDS (owner ruling, the class-length wave 2026-08-24).
+ * The one-board law this header used to carry is GONE: clear a board, take a
+ * short breath, and the machine deals a fresh one - new seeded shuffle, new
+ * face draw, the tricksters re-armed - until the 300s bell. The BELL IS THE
+ * NORMAL END of a class now, not a punishment; it truncates whatever is live
+ * (deal, preview, a flip, a mutation, a celebration), locks input and grades.
+ * The grade is boards cleared + accuracy + mutation survival, normalised
+ * against what the tier could clear in the budget (script.js, THE ARITHMETIC).
+ * Two clocks, and keeping them apart is the whole trick: ONE class-level bell
+ * clock (`elapsedMs` vs `budgetMs`, never reset) and a PER-BOARD play window
+ * (`boardPlayMs`, re-stamped every time input opens) so a board's own accuracy
+ * and clear time are measurable without the bell ever restarting.
+ *
  * Pairs matching where the board gaslights you - but HONESTLY. Three laws hold
  * the whole design together (dossier + SYNTHESIS rulings):
  *
@@ -38,18 +51,35 @@
 import { injectDejaVuStyle } from './style.js';
 import {
   TIMING, scaled, setTimeScale, getTimeScale,
-  dialsFor, buildLayout, buildSwapSchedule, buildDriftSchedule,
+  dialsForBoard, buildLayout, buildSwapSchedule, buildDriftSchedule,
   neighborsOf, isAdjacent, lineCells, plainShareFor, heatFor,
   matchedLoopPolicy, compositeFor, flavorXpFor, createReward,
+  expectedClears, boardCostSec,
   BOARD_SIZES, BOARD_PAR,
 } from './script.js';
 import { createDvCasino } from './casino.js';
 import { createDvTrickster, DV_TRICKSTER } from './trickster.js';
-import { makeTaggedRoll } from '../../core/rng.js';
+import { makeTaggedRoll, makeRng, shuffled } from '../../core/rng.js';
 
 /** Distinct glyphs so a class is fully playable with ZERO media (the floor
- *  under the poster-frame-only floor). Deliberately font-safe, no emoji. */
+ *  under the poster-frame-only floor). Deliberately font-safe, no emoji.
+ *  PER BOARD the order is re-shuffled (seeded) so two glyph boards in a row do
+ *  not wear the same twelve faces in the same twelve places. */
 const GLYPHS = ['◆', '●', '▲', '■', '✦', '◇', '○', '△', '□', '✥', '✲', '✹'];
+
+/** The specimen rack keeps filling across boards; past this many chips the
+ *  oldest is retired so the aside cannot overflow its frame. */
+const RACK_MAX = 24;
+
+/** How many distinct faces the class claims ONCE and then re-deals per board.
+ *  Must not exceed manifest.assetNeeds.loops (16) - that is the real ceiling on
+ *  distinct faces, and a board only ever wears `pairs` of them. */
+const FACE_POOL_WANT = 16;
+
+/** The class-level last call: the final `TIMING.lastCallMs` gets a three-note
+ *  drum so the bell is heard coming. Wires TIMING.endgameDrumMs, which was a
+ *  dead constant until this wave. */
+const LAST_CALL_NOTES = 3;
 
 /** THE TIER AUDIO CEILING (House Book): every cue this class requests is
  *  clamped to its grade tier's ceiling, indexed by gradeTier-1. The clamp
@@ -104,7 +134,11 @@ export default {
   family: 'memory',
   meaty: false,
   flagship: false,
-  timeBudgetSec: 90,
+  /* THE CLASS LENGTH (class-length wave 2026-08-24). 90 -> 300: at 90s this
+   * class was exactly one board and the bell was a failure state. At 300 it is
+   * a run of boards and the bell is the whistle. `games/registry.js` GAME_META
+   * mirrors this number (the parachute) - the two must move together. */
+  timeBudgetSec: 300,
   title: 'Deja Vu',
 
   manifest: {
@@ -157,7 +191,12 @@ export default {
 
     /* ---- class state ---------------------------------------------------- */
     let spec = null;
-    let dials = null;
+    let dials = null;            // BOARD N's dials (dialsForBoard, re-derived per board)
+    let baseDials = null;        // BOARD 1's dials - the grade's stable reference
+    let classSeed = '';          // the class seed; every board is classSeed + '|b<N>'
+    let classTier = 1;
+    let chosenPairs = null;      // the player's board-size override, or null
+    let expectClears = 1;        // the S gate, in boards (script.js expectedClears)
     let layout = null;
     let swaps = [];
     let drifts = [];
@@ -165,11 +204,26 @@ export default {
     let roll = null;
     let rollReward = null;
     let pool = null;
-    let pairUrls = [];
+    let facePool = [];           // up to FACE_POOL_WANT distinct urls, claimed ONCE
+    let facesDirty = false;      // BREADCRUMB ONLY (diagnostics): the pool landed
+                                 // mid-board, so this board played on glyphs.
+                                 // Nothing gates on it - dealFaces() runs for
+                                 // every board regardless and clears it.
+    let facesLocked = false;     // a preview has started: nothing may re-face this board
+    let pairUrls = [];           // THIS board's pairId -> url (re-drawn per board)
+    let boardGlyphs = GLYPHS.slice();   // THIS board's glyph order (re-shuffled per board)
     let reduced = false;
     let posterOnly = false;
     let loopPolicy = { play: true, reason: 'auto' };
     let retake = false;
+    let ambienceKey = '';        // the sustained-dial signature, so a restart is rare
+
+    /* ---- THE BOARD LOOP -------------------------------------------------- */
+    let boardNo = 0;             // 1-based; 0 = nothing dealt yet
+    let boardsCleared = 0;       // the class's score, and the grade's main term
+    let belled = false;          // the bell has taken the board (one-way)
+    let lastCallDone = false;    // the last-ten-seconds drum has beaten
+    const boardLog = [];         // {board, pairs, attempts, clearSec} per cleared board
 
     let casino = null;                  // House Rules Deck II (marquee / almost / ken-burns)
     let trickster = null;               // House Rules Deck III (shuffle / re-deal / flicker)
@@ -178,16 +232,25 @@ export default {
     let watchLie = -1;                  // cell index: flip the liar NEXT and it pays
     let calledLies = 0;
 
+    /* PER BOARD (reset by startBoard) */
     let attempts = 0;
     let matched = 0;
-    let combo = 0;
-    let maxCombo = 0;
     let mismatchStreak = 0;
+    let settledWindow = 0;
+    let swapsFired = 0;              // THIS board's, so the chip reads x/budget
+    /* CLASS-LEVEL (never reset). `totalAttempts` / `totalMatched` bank the
+     * finished boards; the live board's own two counters are added on top
+     * wherever a class total is wanted, so nothing is ever double-counted. */
+    let totalAttempts = 0;
+    let totalMatched = 0;
+    let totalSwaps = 0;              // swaps survived across every finished board
+    let casinoLit = false;           // the lab identity is rolled once (see armPlay)
+    let combo = 0;              // deliberately CARRIED across boards: clearing a
+                                // board is not a reason to break your streak
+    let maxCombo = 0;
     let tracked = 0;
-    let swapsFired = 0;
     let driftsFired = 0;
     let bubblesPopped = 0;
-    let settledWindow = 0;
     let jackpots = 0;
     const faceUp = [];
     let flipping = 0;                   // cards mid-flip (a third tap must not land)
@@ -198,13 +261,18 @@ export default {
     /* ---- clock ---------------------------------------------------------- */
     let clockId = 0;
     let lastTick = 0;
+    /* ONE CLASS-LEVEL BELL CLOCK. `elapsedMs` counts the whole class, across
+     * every board, and is never reset - it is the only thing `budgetMs` is ever
+     * compared against. The two play stamps below are GRADE clocks and have
+     * nothing to do with the bell. */
     let elapsedMs = 0;
-    let playStartedMs = 0;              // measured AFTER the preview (clear time)
-    let budgetMs = 90000;
+    let classPlayMs = -1;               // the FIRST board's play start (total live play)
+    let boardPlayMs = 0;                // THIS board's play start (its own clear time)
+    let budgetMs = 300000;
 
     /* ---- dom ------------------------------------------------------------ */
     let stage = null; let grid = null; let well = null; let hint = null; let bench = null;
-    let meterWrap = null; let swapChip = null; let clockChip = null;
+    let meterWrap = null; let swapChip = null; let clockChip = null; let boardChip = null;
     let peekBtn = null; let cramRow = null; let rack = null;
 
     /* ==================================================================== *
@@ -274,11 +342,23 @@ export default {
       lastBumpAt = now;
       tick('bump', 0.3);
     }
+    /** Class progress, 0..1 - the engine's heat curve and the plain-share ramp
+     *  both ride it. It is a CLASS number now (boards done against the tier's
+     *  expectation), not a board number: a per-board progress would have reset
+     *  the heat to nothing every time the player cleared something. */
     function progress() {
       if (!dials) return 0;
-      const byPairs = matched / Math.max(1, dials.pairs);
+      const done = boardsCleared + (matched / Math.max(1, dials.pairs));
+      const byBoards = done / Math.max(1, expectClears);
       const byTime = budgetMs > 0 ? elapsedMs / budgetMs : 0;
-      return Math.max(0, Math.min(1, Math.max(byPairs, byTime)));
+      return Math.max(0, Math.min(1, Math.max(byBoards, byTime)));
+    }
+
+    /** THIS board's glyph, from the board's own seeded glyph order. */
+    function glyphFor(pairId) {
+      const n = boardGlyphs.length || 1;
+      const i = Math.round(Number(pairId) || 0);
+      return boardGlyphs[((i % n) + n) % n];
     }
 
     /* ==================================================================== *
@@ -306,10 +386,16 @@ export default {
       const meterHost = el('span', 'g-dv-meterhost');
       meterWrap.appendChild(meterHost);
       hud.appendChild(meterWrap);
-      if (dials.swapBudget > 0) {
-        swapChip = el('span', 'chip num', swapChipText());
-        hud.appendChild(swapChip);
-      }
+      /* THE BOARD COUNTER is the class's running score now, so it is always
+       * there. The swap chip is ALWAYS MINTED too and merely hidden while the
+       * budget is zero: the escalation ladder can hand a tier-1 player a swap
+       * on board 2, and a chip that only existed if board 1 had a budget would
+       * have left that swap silently unaccounted for. */
+      boardChip = el('span', 'chip num', boardChipText());
+      hud.appendChild(boardChip);
+      swapChip = el('span', 'chip num', swapChipText());
+      swapChip.hidden = !(dials.swapBudget > 0);
+      hud.appendChild(swapChip);
       clockChip = el('span', 'chip num', clockText());
       hud.appendChild(clockChip);
       if (retake) {
@@ -335,8 +421,11 @@ export default {
       stage.appendChild(wrap);
       bench = wrap;                       // the casino's marquee frames the bench
 
+      /* THE CELLS ARE NOT BUILT HERE any more - `startBoard()` mints them, and
+       * mints them again for every board. buildDom owns the CHROME (the lab,
+       * the HUD, the empty grid, the rack, the hint) and that chrome lives for
+       * the whole class. */
       cells = [];
-      for (let i = 0; i < dials.cells; i++) cells.push(buildCell(i));
 
       /* Cram Assist = the shared peek verb, skinned. */
       cramRow = el('div', 'g-dv-cram');
@@ -361,12 +450,17 @@ export default {
       root.appendChild(stage);
     }
 
-    /** File a matched pair into the rack (decoration; must never throw). */
+    /** File a matched pair into the rack (decoration; must never throw).
+     *  The rack is CLASS-LEVEL - it keeps filling across boards, because a
+     *  growing shelf of specimens is the nicest read on "how far did I get".
+     *  It is capped at RACK_MAX chips (a 7-board tier-1 class files 42) and the
+     *  oldest slide is retired rather than letting the aside overflow. */
     function rackAdd(pairId) {
       if (!rack) return;
       try {
-        const glyph = GLYPHS[((pairId % GLYPHS.length) + GLYPHS.length) % GLYPHS.length];
-        rack.appendChild(el('span', 'g-dv-slide', glyph));
+        rack.appendChild(el('span', 'g-dv-slide', glyphFor(pairId)));
+        const slides = rack.querySelectorAll ? rack.querySelectorAll('.g-dv-slide') : null;
+        if (slides && slides.length > RACK_MAX) slides[0].remove();
       } catch (e) { /* the rack is scenery */ }
     }
 
@@ -392,8 +486,8 @@ export default {
     /** One media node per card, created once and never re-created on a flip. */
     function applyMedia(cell) {
       const url = pairUrls[cell.pairId];
-      const glyph = GLYPHS[((cell.pairId % GLYPHS.length) + GLYPHS.length) % GLYPHS.length];
-      if (cell.face && cell.face._url === url) return;
+      const glyph = glyphFor(cell.pairId);
+      if (cell.face && cell.face._url === url && cell.face._glyph === glyph) return;
       if (cell.face) { try { cell.face.remove(); } catch (e) { /* noop */ } cell.face = null; }
       let node;
       if (url && isVideoUrl(url) && !posterOnly) {
@@ -430,6 +524,10 @@ export default {
     function swapChipText() {
       return t('dv_swaps', 'swaps') + ' ' + swapsFired + '/' + dials.swapBudget;
     }
+    /** The class's score: boards cleared. Same shape as the swap chip. */
+    function boardChipText() {
+      return t('dv_boards', 'boards') + ' ' + boardsCleared;
+    }
     function clockText() {
       const left = Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000));
       const m = Math.floor(left / 60);
@@ -437,7 +535,12 @@ export default {
       return (m > 0 ? m + ':' + String(s).padStart(2, '0') : left + 's');
     }
     function paintHud() {
-      if (swapChip) swapChip.textContent = swapChipText();
+      if (boardChip) boardChip.textContent = boardChipText();
+      if (swapChip) {
+        swapChip.textContent = swapChipText();
+        // the ladder can open a budget mid-class, so visibility is repainted too
+        swapChip.hidden = !(dials && dials.swapBudget > 0);
+      }
       if (clockChip) clockChip.textContent = clockText();
     }
     function paintMeter() {
@@ -456,6 +559,118 @@ export default {
     }
 
     /* ==================================================================== *
+     * THE BOARD LOOP - the class's spine.
+     *
+     * startBoard(n) -> deal -> preview -> armPlay -> the attempt loop -> win()
+     * -> a short celebration -> startBoard(n+1) -> ... until bell().
+     *
+     * EVERY BOARD IS ITS OWN SEEDED DEAL. The board seed is
+     * `classSeed + '|b<N>'`, which re-rolls the layout, the deal cascade, the
+     * swap schedule, the drift schedule, the face draw AND the glyph order - so
+     * two boards in a row never wear the same face-to-position map even when
+     * the face pool is small enough that the FACES themselves repeat (the pool
+     * is 16 and a board wears at most 10 of them). The whole night is still one
+     * pure function of the class seed, so a retake replays board for board.
+     * ==================================================================== */
+
+    /** This board's seed. Board 1 included: '|b1' is part of the contract. */
+    function boardSeed(n) { return classSeed + '|b' + n; }
+
+    /**
+     * Draw THIS board's faces and glyphs off the board seed.
+     * The urls come from the class's single claimed pool (`facePool`, up to 16
+     * distinct); each board shuffles that pool and takes the first `pairs`, so
+     * the SUBSET and its pairing both move every board. Short pool = the
+     * leftovers play on their glyph face, which is always distinct - the same
+     * legibility floor claimAssets has always kept.
+     */
+    function dealFaces(n) {
+      const want = dials.pairs;
+      boardGlyphs = shuffled(GLYPHS.slice(), makeRng(classSeed + '|dv|glyphs|b' + n));
+      const draw = facePool.length
+        ? shuffled(facePool.slice(), makeRng(classSeed + '|dv|faces|b' + n))
+        : [];
+      pairUrls = [];
+      for (let pid = 0; pid < want; pid++) pairUrls[pid] = draw[pid] || null;
+      facesDirty = false;
+    }
+
+    /** Mint this board's cells into the (emptied) grid. */
+    function buildCells() {
+      if (!grid) return;
+      try { grid.textContent = ''; } catch (e) { /* noop */ }
+      grid.style.setProperty('--g-dv-cols', String(dials.cols));
+      grid.style.setProperty('--g-dv-rows', String(dials.rows));
+      grid.classList.remove('jiggle', 'scanning', 'rewind');
+      cells = [];
+      for (let i = 0; i < dials.cells; i++) cells.push(buildCell(i));
+    }
+
+    /**
+     * Deal board `n`. Also the ONE place the escalation ladder is applied and
+     * the ONE place the House tricksters are re-armed.
+     * @param {number} n 1-based board number
+     */
+    function startBoard(n) {
+      if (dead || ended || belled) return;
+      /* A CLEAN SLATE. Every timer still in flight belongs to the board that
+       * just ended (a casino flash, a trickster flicker); none of them may land
+       * on the new board. This call is safe from inside a run() step because
+       * after() removes its own id before it runs the step. */
+      clearTimers();
+
+      boardNo = n;
+      /* THE LADDER: board N's dials are the player's tier bumped one gentle
+       * notch per CLEARED board, capped at roughly one tier above (see
+       * script.js ESCALATION). The pair count never moves - the player's
+       * board-size choice is the board all night. */
+      dials = dialsForBoard(classTier, boardsCleared, { pairs: chosenPairs });
+
+      const bseed = boardSeed(n);
+      layout = buildLayout(bseed, dials);
+      swaps = buildSwapSchedule(bseed, dials);
+      drifts = buildDriftSchedule(bseed, dials, swaps);
+
+      /* per-board counters (the class totals were banked by the caller) */
+      attempts = 0;
+      matched = 0;
+      mismatchStreak = 0;
+      settledWindow = 0;
+      swapsFired = 0;
+      flipping = 0;
+      faceUp.length = 0;
+      revealed.length = 0;
+      swapAttempt.clear();
+      drumrolled = false;
+      watchLie = -1;
+      clearLie();
+      busy = true;                       // input is closed until this preview is over
+      facesLocked = false;
+
+      dealFaces(n);
+      buildCells();
+
+      /* THE TRICKSTERS RE-ARM PER BOARD. The deck's cards are per-class by
+       * construction (one fake shuffle, one re-deal, N flickers), so a class of
+       * seven boards with one class-level deck would have shown its signature
+       * once in five minutes. A fresh deck per board, seeded on the BOARD seed,
+       * deals a fresh shuffle/re-deal window every time - and on the ladder's
+       * own deckTier, so the House cards climb with the honest dials and stop
+       * at the same cap. The old deck is destroyed first: its pending timers
+       * are already cancelled above, and destroy() makes any survivor a no-op. */
+      if (trickster) { try { trickster.destroy(); } catch (e) { /* noop */ } }
+      trickster = makeTrickster(bseed, dials.deckTier);
+
+      paintHud();
+      setHint('dv_deal_hint', 'Dealing the board.');
+      say('board ' + n + ': ' + dials.cols + 'x' + dials.rows + ' (' + dials.pairs
+        + ' pairs), preview ' + dials.previewMs + 'ms, swaps ' + dials.swapBudget
+        + (dials.drift ? ', drift ' + dials.drift : '') + ', bump ' + dials.bump
+        + ', deck tier ' + dials.deckTier);
+      deal();
+    }
+
+    /* ==================================================================== *
      * PHASE 0 - deal & preview (with the first poison beat)
      * ==================================================================== */
     function deal() {
@@ -471,6 +686,11 @@ export default {
     }
 
     function preview() {
+      /* THE MEMORIZE BEAT IS PER BOARD and it is kept deliberately: it is the
+       * whole encoding moment, and it is tier- (and ladder-) dialled, shrinking
+       * a notch per cleared board toward tier 4's own floor. It spends bell
+       * time; that is priced into the grade's board cost (script.js). */
+      facesLocked = true;      // nothing may re-face a board the player is reading
       setHint('dv_preview_hint', 'Memorize the board.');
       if (grid) grid.classList.add('scanning');       // the machine shows you
       for (const c of cells) {
@@ -511,10 +731,20 @@ export default {
     }
 
     function armPlay() {
-      playStartedMs = elapsedMs;
+      /* THE TWO CLOCKS. `boardPlayMs` is re-stamped every board (this board's
+       * own accuracy window and clear time); `classPlayMs` is stamped ONCE, on
+       * the first board, and is the class's total live-play figure. Neither
+       * touches `elapsedMs`, which is the bell's and only the bell's. */
+      boardPlayMs = elapsedMs;
+      if (classPlayMs < 0) classPlayMs = elapsedMs;
       setHint('dv_play_hint', 'Find the pairs.');
       openAmbience();
-      if (casino) casino.start();          // the lab dresses + the marquee lights
+      /* THE LAB IS DRESSED ONCE A CLASS. casino.start() re-rolls the seeded lab
+       * identity (hue, monogram, sweep) off its own stream, so calling it at
+       * every board would have re-skinned the room seven times in five minutes
+       * and read as seven different classes. The marquee's mount is already
+       * self-guarded; the dressing is not. */
+      if (casino && !casinoLit) { casinoLit = true; casino.start(); }
       if (trickster) trickster.start();
       const open = () => { busy = false; settled(true); };
       /* FAKE SHUFFLE (House Rules): the pantomime rides the tail of the
@@ -527,7 +757,7 @@ export default {
      * PHASE 1 - the attempt loop
      * ==================================================================== */
     function onTap(i) {
-      if (dead || paused || ended) return;                // shell states, not a refusal
+      if (dead || paused || ended || belled) return;      // shell states, not a refusal
       const cell = cells[i];
       // Everything below IS a refused press - a locked or already-turned
       // slide, a third tap while two are up, or a filler seat. One knock.
@@ -685,7 +915,7 @@ export default {
      * THE SETTLED BOARD - the one window where the board may lie
      * ==================================================================== */
     function settled(first) {
-      if (dead || ended) return;
+      if (dead || ended || belled) return;
       heat();
       endgameCheck();
       if (first) { busy = false; return; }
@@ -697,7 +927,7 @@ export default {
     }
 
     function mutate() {
-      if (dead || ended) return;
+      if (dead || ended || belled) return;
       const open = unmatchedCells();
       const enough = open.length > 2;
       /* DEJA RE-DEAL (House Rules, the native signature) outranks the smaller
@@ -705,7 +935,8 @@ export default {
        * they are, and it consumes the window the same way. */
       if (trickster && trickster.redealDue(settledWindow, open.length)) { runRedeal(); return; }
       // `<=` not `===`: a window the player raced past is not a spent budget,
-      // it simply fires at the next settled board (the budget is per class).
+      // it simply fires at the next settled board. THE BUDGET IS PER BOARD now
+      // (a 300s class is many boards); an unspent one dies with its board.
       const swap = swaps.find((s) => !s.done && s.window <= settledWindow);
       if (swap && enough) { runSwap(swap); return; }
       const drift = drifts.find((d) => !d.done && d.window <= settledWindow);
@@ -721,7 +952,7 @@ export default {
      *  card's REAL face and pairId never change; only the shown frame lies. */
     function wearLie(cell, wearPairId) {
       const url = pairUrls[wearPairId];
-      const glyph = GLYPHS[((wearPairId % GLYPHS.length) + GLYPHS.length) % GLYPHS.length];
+      const glyph = glyphFor(wearPairId);
       const node = el('div', 'g-dv-lie');
       if (url && !isVideoUrl(url)) {
         const img = el('img');
@@ -794,7 +1025,8 @@ export default {
     /**
      * The scheduled candidates are tried first; if the player has locked all of
      * them (locked pairs are exempt, forever) the budget must NOT silently
-     * evaporate - SYNTHESIS #2 promises one swap per class from tier 2. This walk
+     * evaporate - SYNTHESIS #2 promises one swap per BOARD from tier 2 (it read
+     * "per class" when a class was one board). This walk
      * is a pure function of (schedule entry, board state), so it stays
      * deterministic and a retake still replays the same script.
      */
@@ -957,7 +1189,7 @@ export default {
      * PHASE 2 - endgame, the bell, the ceremony
      * ==================================================================== */
     function endgameCheck() {
-      if (dead || ended) return;
+      if (dead || ended || belled) return;
       const left = unmatchedCells();
       if (left.length !== 2) return;
       for (const i of left) cells[i].card.classList.add('spot');
@@ -988,26 +1220,81 @@ export default {
       sustainSafe('wash', { variant });
     }
 
+    /**
+     * A BOARD IS CLEAR. Not the class - the class ends at the bell and nowhere
+     * else. Bank the board's numbers, take one short celebration beat, deal the
+     * next one. The ambience is NOT stopped here (it is class-level dressing and
+     * a gap between boards would read as a fault) and the combo deliberately
+     * survives the handover.
+     */
     function win() {
-      if (ended) return;
-      stopAmbience();
+      if (dead || ended || belled) return;
+      busy = true;                          // the board is over; nothing may land
+      boardsCleared += 1;
+      const clearSec = Math.max(0, (elapsedMs - boardPlayMs) / 1000);
+      boardLog.push({
+        board: boardNo, pairs: dials.pairs, attempts, clearSec: Math.round(clearSec * 10) / 10,
+      });
+      totalAttempts += attempts;
+      totalMatched += matched;
+      totalSwaps += swapsFired;
       if (casino) { casino.payout(10); casino.bell(false); }
       setHint('dv_clear', 'Board clear.', true);
       try { ctx.ceremonies.stamp({ text: t('dv_stamp_clear', 'CLEAR'), target: grid }); } catch (e) { /* noop */ }
       tick('stamp', 0.8);
-      after(TIMING.ceremonyMs, () => finish(false));
+      paintHud();
+      say('board ' + boardNo + ' clear in ' + clearSec.toFixed(1) + 's ('
+        + attempts + ' attempts) - ' + boardsCleared + ' cleared, '
+        + Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)) + 's left');
+      /* The next board is dealt on a plain timer, NOT on a "is there time?"
+       * test: a board that only half-fits still earns its partial credit, and
+       * the bell truncating a fresh deal is a beat this class is built for. */
+      after(TIMING.boardClearMs, () => startBoard(boardNo + 1));
     }
 
+    /** The last ten seconds: a three-note drum so the bell is heard coming.
+     *  Audio plus one hint line - no CSS, so reduced motion loses nothing and a
+     *  0-capped bgIntensity still hears it. */
+    function lastCall() {
+      if (lastCallDone || dead || ended || belled) return;
+      lastCallDone = true;
+      setHint('dv_last_call', 'Last ten seconds.', true);
+      for (let n = 0; n < LAST_CALL_NOTES; n++) {
+        after(n * TIMING.endgameDrumMs, () => tick('near_miss', 0.4 + 0.08 * n, { pitch: 0.9 - 0.06 * n }));
+      }
+    }
+
+    /**
+     * THE BELL. It is the class's normal end and it may fall on ANYTHING - a
+     * deal cascade, a preview, a flip mid-air, a swap tell, a re-deal, a clear
+     * celebration. So it truncates rather than waits: input is locked first,
+     * every pending step is cancelled, the board is left exactly where it stood
+     * (its partial progress is worth real credit) and the ceremony is the only
+     * timer left alive.
+     */
     function bell() {
-      if (ended) return;
+      if (ended || belled) return;
+      belled = true;
+      busy = true;                           // 1. input is shut BEFORE anything else
+      stopClock();
+      clearTimers();                         // 2. truncate: no step from the live board runs
+      flipping = 0;
+      faceUp.length = 0;
+      clearLie();
+      watchLie = -1;
+      if (grid) grid.classList.remove('scanning', 'rewind', 'jiggle');
+      for (const c of cells) { try { c.card.classList.remove('flipping', 'judge', 'tell'); } catch (e) { /* noop */ } }
+      if (trickster) { try { trickster.stop(); } catch (e) { /* noop */ } }
       stopAmbience();
       if (casino) casino.dimOut();           // the bell is never silence
-      setHint('dv_bell', 'The bell. Time is up.', true);
+      setHint('dv_bell', 'The bell. Class over.', true);
       try { ctx.ceremonies.stamp({ text: t('dv_stamp_bell', 'BELL'), tone: 'pink', target: grid }); } catch (e) { /* noop */ }
       tick('stamp_bad', 0.6);
-      after(TIMING.ceremonyMs, () => finish(true));
+      after(TIMING.ceremonyMs, () => finish(true));   // 3. the ONE surviving timer
     }
 
+    /** THE ONE endClass. bell() is its only caller now - a board clear deals the
+     *  next board instead of ending the class - and `ended` makes it idempotent. */
     function finish(timeout) {
       if (ended) return;
       ended = true;
@@ -1016,14 +1303,21 @@ export default {
       if (trickster) trickster.stop();
       if (casino) casino.stop();
       busy = true;
-      const elapsedSec = Math.max(0.001, (elapsedMs - playStartedMs) / 1000);
+      /* Total live play (deals and previews included), against the CLASS clock.
+       * `classPlayMs` is -1 if the bell somehow beat the first armPlay, in which
+       * case the whole class was its opening and elapsedMs is the honest read. */
+      const elapsedSec = Math.max(0.001, (elapsedMs - Math.max(0, classPlayMs)) / 1000);
+      const livePairs = playablePairs();
       const scoreIn = {
-        tier: dials.tier,
-        pairs: playablePairs(),
-        matched,
-        attempts,
-        elapsedSec,
-        parSec: dials.parSec,
+        tier: baseDials ? baseDials.tier : dials.tier,
+        /* THE CLASS TOTALS: banked boards plus the live board. The live board's
+         * own two numbers ride separately so its partial can be priced once. */
+        matched: totalMatched + matched,
+        attempts: totalAttempts + attempts,
+        boardsCleared,
+        livePairs,
+        liveMatched: matched,
+        expectedClears: expectClears,
         maxCombo,
         tracked,
         timeout: !!timeout,
@@ -1052,9 +1346,16 @@ export default {
           game: 'deja_vu',
           retake,
           grade_inputs: {
-            tier: dials.tier, pairs: playablePairs(), matched, attempts,
-            clearTimeSec: Math.round(elapsedSec), maxCombo, tracked, calledLies,
-            swapsFired, driftsFired, bubblesPopped, jackpots,
+            tier: scoreIn.tier,
+            pairs: baseDials ? baseDials.pairs : dials.pairs,
+            boardsCleared,
+            expectedClears: expectClears,
+            livePairs, liveMatched: matched,
+            matched: scoreIn.matched, attempts: scoreIn.attempts,
+            playTimeSec: Math.round(elapsedSec), maxCombo, tracked, calledLies,
+            swapsFired: totalSwaps + swapsFired,   // CLASS total, not the live board's
+            driftsFired, bubblesPopped, jackpots,
+            boards: boardLog.slice(),
             timeout: !!timeout,
             peekHold: peekHoldMult(),
           },
@@ -1062,10 +1363,12 @@ export default {
       };
       lastReport = report;
       try { lastSnapshot = instance.snapshot(); } catch (e) { /* diagnostics only */ }
-      say('class over: ' + matched + '/' + playablePairs() + ' pairs, ' + attempts + ' attempts, '
-        + Math.round(elapsedSec) + 's (par ' + dials.parSec + 's), combo ' + maxCombo
+      say('class over: ' + boardsCleared + '/' + expectClears + ' boards'
+        + (livePairs ? ' + ' + matched + '/' + livePairs + ' on the live one' : '')
+        + ', ' + scoreIn.matched + ' pairs in ' + scoreIn.attempts + ' attempts ('
+        + (score.accuracy * 100).toFixed(0) + '%, par ' + (score.accuracyScore * 100).toFixed(0) + '%)'
+        + ', ' + Math.round(elapsedSec) + 's live, combo ' + maxCombo
         + ', tracked ' + tracked + (calledLies ? ', called ' + calledLies + ' lies' : '')
-        + ', swaps ' + swapsFired + '/' + dials.swapBudget
         + (timeout ? ', BELL' : '') + ' -> composite ' + score.composite.toFixed(3));
       try {
         ctx.endClass(report);
@@ -1075,10 +1378,23 @@ export default {
     /* ==================================================================== *
      * AMBIENCE (the tier dials that are not mutations)
      * ==================================================================== */
+    /**
+     * Called at every board's armPlay, not once a class.
+     *
+     * THE RESTART RULE: `engine/sustained.js` answers a repeat sustain of a live
+     * kind with the SAME handle and a retune - it does not read the new options.
+     * The escalation ladder can raise crt / bubbles / ambient between boards, so
+     * when (and only when) that signature actually moves we ask for a restart.
+     * Every other board re-uses what is already lit, which is what keeps the
+     * room continuous instead of blinking off and on at every handover.
+     */
     function openAmbience() {
       heat();
-      if (dials.ambient) sustainSafe('ambient_field', { kind: 'motes', density: dials.ambient });
-      if (dials.crt) sustainSafe('crt', { level: dials.crt, variant: dials.tier >= 4 ? 'chroma' : 'scanline' });
+      const key = [dials.ambient, dials.crt, dials.bubbles, dials.tier >= 4 ? 'chroma' : 'scanline'].join('|');
+      const restart = ambienceKey !== '' && ambienceKey !== key;
+      ambienceKey = key;
+      if (dials.ambient) sustainSafe('ambient_field', { kind: 'motes', density: dials.ambient, restart });
+      if (dials.crt) sustainSafe('crt', { level: dials.crt, variant: dials.tier >= 4 ? 'chroma' : 'scanline', restart });
       if (dials.bubbles) {
         /* The dossier's poppable decoys: popping one costs ~300ms of jiggle and
          * NEVER counts as a flip or touches the grade (the rubric already prices
@@ -1086,6 +1402,7 @@ export default {
         sustainSafe('bubble_field', {
           max: dials.bubbles,
           variant: 'drift',
+          restart,
           onPop: () => {
             bubblesPopped += 1;
             tick('bubble_pop', 0.4);
@@ -1176,50 +1493,91 @@ export default {
         if (paused) return;
         elapsedMs += dt / Math.max(0.0001, getTimeScale());
         paintHud();
+        // the drum first: it must beat BEFORE the bell it is announcing
+        if (!lastCallDone && (budgetMs - elapsedMs) <= TIMING.lastCallMs) run(lastCall);
         if (elapsedMs >= budgetMs) { stopClock(); run(bell); }
       }, scaled(250));
     }
     function stopClock() { if (clockId) { clearInterval(clockId); clockId = 0; } }
 
     /* ---- assets --------------------------------------------------------- */
+    /**
+     * ONE CLAIM A CLASS, many boards off it. The class draws up to
+     * FACE_POOL_WANT distinct urls into `facePool` and every board shuffles that
+     * pool for its own subset (dealFaces). Faces MAY repeat across a long class
+     * - the pool is 16 and a tier-1 night is seven 6-pair boards - but WHICH six
+     * and where they sit is a fresh seeded draw every time.
+     *
+     * PAIRS MUST STAY LEGIBLE. Two pairs wearing the same art is an unwinnable
+     * board, so the pool holds only DISTINCT urls and a board that runs short
+     * plays the leftovers on their glyph faces (always distinct) rather than
+     * repeating someone else's clip.
+     */
     function claimAssets() {
       // NEVER block a draw: the board is already dealing on glyph faces and the
       // urls drop in when the pool resolves (empty remote -> local, silently).
       Promise.resolve()
         .then(() => ctx.assets.claim({
-          loops: Math.max(12, dials.pairs + 6), stills: 4, targets: 0, canvasSafe: false,
+          loops: FACE_POOL_WANT, stills: 4, targets: 0, canvasSafe: false,
         }))
         .then((p) => {
           if (dead || !p || typeof p.next !== 'function') return;
           pool = p;
-          /* PAIRS MUST STAY LEGIBLE. Two different pairs wearing the same art is
-           * an unwinnable board, so a pair only ever gets a url no other pair
-           * has; when the pool runs short the leftovers play on their glyph
-           * face (always distinct) instead of repeating someone else's clip. */
-          const distinct = [];
-          const want = dials.pairs;
-          for (let n = 0; n < want * 4 && distinct.length < want; n++) {
+          for (let n = 0; n < FACE_POOL_WANT * 3 && facePool.length < FACE_POOL_WANT; n++) {
             const got = p.next('loop');
             const u = got && got.url;
-            if (u && distinct.indexOf(u) < 0) distinct.push(u);
+            if (u && facePool.indexOf(u) < 0) facePool.push(u);
           }
-          for (let pid = 0; pid < want; pid++) pairUrls[pid] = distinct[pid] || null;
+          say('asset pool ready (' + facePool.length + ' distinct loops; a board wears '
+            + (dials ? dials.pairs : '?') + ')');
+          /* THE LATE POOL. If the player is already reading a preview or a live
+           * board, re-facing it would be a lie the tell system never promised -
+           * so the draw is banked and the NEXT board is the first with media.
+           * Only a board still dealing (nothing memorised yet) is re-faced in
+           * place, which is the old behaviour where it was honest. */
+          if (facesLocked || faceUp.length || matched > 0) {
+            facesDirty = true;
+            say('asset pool landed mid-board - the next board is the first with faces');
+            return;
+          }
+          dealFaces(boardNo || 1);
           for (const c of cells) applyMedia(c);
-          say(distinct.length >= want
-            ? 'asset pool ready (' + distinct.length + ' distinct loops for ' + want + ' pairs)'
-            : 'asset pool short (' + distinct.length + '/' + want
-              + ' distinct loops) - the rest play on glyph faces');
         })
         .catch((e) => say('asset claim failed - glyph faces stand: ' + ((e && e.message) || e)));
     }
 
+    /* ---- the House tricksters, minted per BOARD -------------------------- *
+     * One factory so board 1 and board 7 are wired identically. `tier` is the
+     * LADDER's deckTier, not the player's raw tier (see startBoard).
+     * ---------------------------------------------------------------------- */
+    function makeTrickster(seed, tier) {
+      const capsOk = !(ctx.caps && Number(ctx.caps.bgIntensity) === 0);
+      return createDvTrickster({
+        seed, tier,
+        timers: deckTimers,
+        reduced, capsOk,
+        cue: tick,                     // THE CUE ROAD - clamped, never capsOk-gated
+        isHalted: () => dead || paused || ended || belled,
+        stats: () => ({
+          swaps: swapsFired,
+          budget: dials.swapBudget,
+          secLeft: Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)),
+        }),
+        chipEl: (which) => (which === 'swaps' ? swapChip : clockChip),
+        chipText: (which) => (which === 'swaps' ? swapChipText() : clockText()),
+        log: say,
+      });
+    }
+
     /* ---- the class rules sheet (Deck VI, Law IV: drawn, not told) --------- */
     /**
-     * Three vignettes in this lab's own language: the pair turning face-up and
+     * FOUR vignettes in this lab's own language: the pair turning face-up and
      * locking, the settled board trading two slides AFTER its shudder (law 2 +
-     * law 3 of this file, drawn rather than told), and the whole board
-     * re-dealing without losing a pair. Every figure is CSS on the same slide
-     * chrome the board uses, so the sheet costs no media.
+     * law 3 of this file, drawn rather than told), the whole board re-dealing
+     * without losing a pair, and THE RUN - a clear followed by a fresh board,
+     * which is the class-length rule drawn instead of announced. Every figure
+     * is CSS on the same slide chrome the board uses, so the sheet costs no
+     * media and the fourth row added no CSS at all.
      */
     let howtoEl = null;
 
@@ -1292,6 +1650,25 @@ export default {
         fig.appendChild(grid6);
       }, t('dv_howto_redeal', 'Sometimes the whole board re-deals. Same pairs - only the seats change.'));
 
+      /* 4 - THE RUN. A pair locks, and behind it a fresh board drops in. Built
+         entirely from the chrome the three rows above already use (turn + lock
+         + redeal), so the class length is DRAWN like everything else on this
+         sheet and style.js grows nothing. */
+      row((fig) => {
+        const line = el('span', 'g-dv-hw-line');
+        line.appendChild(slide('turn a', GLYPHS[0]));
+        line.appendChild(slide('turn b', GLYPHS[0]));
+        fig.appendChild(line);
+        fig.appendChild(el('span', 'g-dv-hw-lock'));
+        const fresh = el('span', 'g-dv-hw-grid');
+        for (let i = 0; i < 6; i++) {
+          const c = slide('down redeal');
+          c.style.setProperty('--dv-hw-i', String(i));
+          fresh.appendChild(c);
+        }
+        fig.appendChild(fresh);
+      }, t('dv_howto_boards', 'Clear the board and a fresh one deals. The bell ends class.'));
+
       const go = el('button', 'g-dv-hw-go', t('dv_howto_go', 'Deal the board'));
       go.type = 'button';
       go.addEventListener('click', () => {
@@ -1307,14 +1684,16 @@ export default {
     }
 
     /**
-     * Policy is the shell's "Skip class tutorials" contract: by default the
-     * sheet shows EVERY class; with the skip on, the lab still explains itself
-     * ONCE per grade tier. Dismissal is the sheet's own button and nothing
+     * THE LAW, uniform across every open class (owner ruling 2026-08-24): the
+     * sheet SHOWS the first time this player meets the lab at this grade tier
+     * and AUTO-SKIPS every later class at that tier, whatever the setting says;
+     * the skip means "skip even the first showing" (owner ruling 2026-08-24).
+     * No meta = no memory = the sheet shows. Dismissal is its own button and nothing
      * else - Cram Assist is bound to a key the moment the board deals, and a
      * key shortcut here would spend the player's A-cap on a tutorial.
      */
     function howto(onDone) {
-      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(dials ? dials.tier : 1) >= 0) {
+      if (ctx.hideTutorial === true || howtoSeenTiers().indexOf(dials ? dials.tier : 1) >= 0) {
         onDone(); return;
       }
       if (!stage) { onDone(); return; }
@@ -1348,19 +1727,34 @@ export default {
      * ==================================================================== */
     const instance = {
       start(classSpec) {
-        spec = classSpec || { gradeTier: 1, seed: 'deja_vu|none', timeBudgetSec: 90 };
+        spec = classSpec || { gradeTier: 1, seed: 'deja_vu|none', timeBudgetSec: 300 };
         const tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
         const seed = String(spec.seed == null ? 'deja_vu' : spec.seed);
-        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 90) * 1000);
+        classSeed = seed;
+        classTier = tier;
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 300) * 1000);
         reduced = probeReduced();
         posterOnly = reduced;
 
+        /* THE BOARD SIZE is the player's for the WHOLE class - the escalation
+         * ladder never touches the grid, so a below-par choice is still exactly
+         * one A-cap the shell computes from the manifest, not a per-board one. */
         const chosen = ctx.settings ? ctx.settings.boardSize : null;
         const pairs = Number(chosen);
-        dials = dialsFor(tier, { pairs: Number.isFinite(pairs) ? pairs : null });
-        layout = buildLayout(seed, dials);
-        swaps = buildSwapSchedule(seed, dials);
-        drifts = buildDriftSchedule(seed, dials, swaps);
+        chosenPairs = Number.isFinite(pairs) ? pairs : null;
+        /* Board 1's dials are also the GRADE's reference: `expectedClears` is
+         * computed off them once, before the ladder has moved anything, because
+         * S_PACE is already the allowance for the ladder making later boards
+         * dearer (script.js, THE ARITHMETIC). */
+        baseDials = dialsForBoard(tier, 0, { pairs: chosenPairs });
+        dials = baseDials;
+        expectClears = expectedClears(baseDials, budgetMs / 1000);
+        layout = buildLayout(boardSeed(1), dials);
+        swaps = buildSwapSchedule(boardSeed(1), dials);
+        drifts = buildDriftSchedule(boardSeed(1), dials, swaps);
+        /* Class-level streams: the variable-ratio reward and the garnish rolls
+         * are the CLASS's, not a board's, so a long run keeps one honest
+         * schedule instead of restarting its luck every board. */
         roll = makeTaggedRoll(seed + '|dv|play');
         rollReward = createReward(seed);
         loopPolicy = matchedLoopPolicy(ctx.settings && ctx.settings.dv_matched_loops, tier, posterOnly);
@@ -1381,28 +1775,19 @@ export default {
 
         /* The House decks (House Rules floor map: the memory lies + the
          * lighting rig). Both disarm on a 0-capped bgIntensity; both replay
-         * identically on a retake (same seed, same streams). */
+         * identically on a retake (same seed, same streams).
+         *
+         * TWO LIFETIMES, deliberately. The CASINO is the room - one lab
+         * identity, one marquee, lit once and never re-dressed, because a class
+         * that changed its own hue every board would read as a different class.
+         * The TRICKSTER is the deal, and startBoard mints a fresh one per board
+         * (see makeTrickster) so its once-a-class cards land once a BOARD. */
         const capsOk = !(ctx.caps && Number(ctx.caps.bgIntensity) === 0);
         casino = createDvCasino({
           seed, stage, bench, grid,
           timers: deckTimers,
           reduced, capsOk,
           cue: tick,                     // THE CUE ROAD - clamped, never capsOk-gated
-          log: say,
-        });
-        trickster = createDvTrickster({
-          seed, tier,
-          timers: deckTimers,
-          reduced, capsOk,
-          cue: tick,                     // THE CUE ROAD - clamped, never capsOk-gated
-          isHalted: () => dead || paused || ended,
-          stats: () => ({
-            swaps: swapsFired,
-            budget: dials.swapBudget,
-            secLeft: Math.max(0, Math.ceil((budgetMs - elapsedMs) / 1000)),
-          }),
-          chipEl: (which) => (which === 'swaps' ? swapChip : clockChip),
-          chipText: (which) => (which === 'swaps' ? swapChipText() : clockText()),
           log: say,
         });
 
@@ -1413,18 +1798,19 @@ export default {
            Assist is not bound to a key, so a class read at leisure grades
            exactly like one that skipped the sheet. */
         howto(() => {
-          if (dead || ended) return;
+          if (dead || ended || belled) return;
           wireCram();
-          startClock();
-          deal();
+          startClock();                  // THE bell clock: one per class, never reset
+          startBoard(1);
         });
 
         liveClass = instance;
         lastReport = null;
         lastSnapshot = null;
-        say('tier ' + tier + ' board ' + dials.cols + 'x' + dials.rows + ' (' + dials.pairs
-          + ' pairs), preview ' + dials.previewMs + 'ms, swap budget ' + dials.swapBudget
-          + (dials.drift ? ', drift ' + dials.drift : '') + (retake ? ', RETAKE' : ''));
+        say('tier ' + tier + ': ' + Math.round(budgetMs / 1000) + 's, ' + dials.cols + 'x'
+          + dials.rows + ' (' + dials.pairs + ' pairs) a board, ~'
+          + boardCostSec(baseDials).toFixed(0) + 's a board -> S at ' + expectClears
+          + ' cleared' + (retake ? ', RETAKE' : ''));
       },
 
       pause() {
@@ -1475,7 +1861,14 @@ export default {
         return {
           tier: dials ? dials.tier : null,
           dials: dials ? Object.assign({}, dials) : null,
+          baseDials: baseDials ? Object.assign({}, baseDials) : null,
           seed: spec ? spec.seed : null,
+          boardSeed: boardNo ? boardSeed(boardNo) : null,
+          boardNo, boardsCleared, expectClears, belled, lastCallDone,
+          boards: boardLog.slice(),
+          totalAttempts, totalMatched, totalSwaps, casinoLit,
+          facePool: facePool.slice(),
+          facesDirty, facesLocked,
           retake,
           cols: dials ? dials.cols : 0,
           rows: dials ? dials.rows : 0,
@@ -1499,7 +1892,7 @@ export default {
           casino: casino ? casino.diagnostics() : null,
           faceUp: faceUp.slice(),
           revealed: revealed.slice(),
-          elapsedMs, budgetMs, ended, busy, paused,
+          elapsedMs, budgetMs, classPlayMs, boardPlayMs, ended, busy, paused,
           loopPolicy: Object.assign({}, loopPolicy),
           posterOnly, reduced,
           pairUrls: pairUrls.slice(),

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/script.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/script.js
@@ -9,17 +9,29 @@
  * per-game rulings). Keeping the whole script in pure functions is what makes
  * that testable headless and impossible to drift by accident.
  *
- *   dialsFor(tier, opts)            tier -> every difficulty dial
+ *   dialsFor(tier, opts)            tier -> every difficulty dial (BOARD 1)
+ *   dialsForBoard(tier, cleared, o) THE LADDER: board N's dials (see ESCALATION)
  *   buildLayout(seed, dials)        deal order + pair-per-cell assignment
  *   buildSwapSchedule(seed, dials)  the glitch_swap script (settled windows)
  *   buildDriftSchedule(seed, dials) the row_drift script (tier 4)
+ *   boardCostSec(dials)             preview + deal + a typical clear + ceremony
+ *   expectedClears(dials, budget)   the S gate, in boards (see THE ARITHMETIC)
  *   compositeFor(inputs)            the game's inputs to the SHARED rubric
  *   flavorXpFor(tracked)            the capped flavor bonus (SYNTHESIS #4)
+ *
+ * THE CLASS IS MANY BOARDS (owner ruling, class-length wave 2026-08-24). Clear a
+ * board and the machine deals a fresh one; the 300s bell is the NORMAL end of
+ * the class, not a punishment. Every board re-derives from the CLASS seed plus
+ * '|b<N>', so the whole night is still one pure function of (seed, tier,
+ * settings) and a retake replays every board identically.
  *
  * EFFECTS ARE THE DIFFICULTY (GROUND-RULES §6): tier 2 raises effects on the
  * SAME 4x3 grid as tier 1, and only tiers 3/4 grow the board. The one grid the
  * player may choose (boardSizes) is a per-game setting whose below-par values
- * cap the class at A - the shell computes that cap, never this file.
+ * cap the class at A - the shell computes that cap, never this file. THE BOARD
+ * NEVER GROWS ACROSS BOARDS either: escalation moves the EFFECT dials and the
+ * preview, never the pair count, so the player's chosen grid is the grid all
+ * night and the grade's per-board arithmetic stays honest.
  * ==========================================================================*/
 
 import { makeRng, makeTaggedRoll, shuffled } from '../../core/rng.js';
@@ -57,8 +69,17 @@ export const TIMING = Object.freeze({
   driftTellMs: 520,
   cramRevealMs: 800,        // ghost reveal (the shared peek verb's window)
   settleMs: 140,            // pause before a settled-board mutation window
+  /* THE LAST CALL (this constant was dead until the class-length wave - it is
+   * wired now rather than deleted). In the final `lastCallMs` of the class the
+   * room beats a three-note drum, one note every `endgameDrumMs`, so the bell
+   * is HEARD coming instead of arriving. Audio + one hint line only: no CSS, so
+   * it survives reduced motion and a 0-capped bgIntensity intact. */
   endgameDrumMs: 620,
+  lastCallMs: 10000,
   ceremonyMs: 420,          // stamp before the class hands over to the report card
+  /* The clear celebration between boards. Deliberately short - the beat is a
+   * breath, not a cutscene, because the bell is spending real seconds on it. */
+  boardClearMs: 700,
 });
 
 /* ----------------------------------------------------------------------------
@@ -126,6 +147,107 @@ export function dialsFor(tier, opts = {}) {
     parSec: Math.round(pairs * base.parPerPair),
     belowTierPar: pairs < (BOARD_PAR[t] || base.pairs),
   });
+}
+
+/* ----------------------------------------------------------------------------
+ * THE ESCALATION LADDER - one gentle notch per CLEARED board.
+ *
+ * A 300s class is many boards, so a board 6 that plays exactly like board 1
+ * would be a treadmill. Every clear bumps the EFFECT dials one notch; the pair
+ * count never moves (see the header). Two rules hold it honest:
+ *
+ *   THE CAP. Nothing may ever exceed the dials of ONE TIER ABOVE the player's
+ *   own (plus a single extra swap at the very top, which is the only place the
+ *   ladder has nowhere left to climb). A tier-1 player who clears six boards is
+ *   playing a hard tier 1, never a tier 3.
+ *   THE STOP. The ladder stops climbing at `maxBump` cleared boards. Board 5
+ *   and board 9 are the same room, so a long clean run is rewarded with pace,
+ *   not with an unwinnable board at minute five.
+ *
+ * The ladder is PURE (cleared -> dials); nothing here is random, so the seeded
+ * schedules built on top of these dials still replay exactly on a retake.
+ * -------------------------------------------------------------------------- */
+export const ESCALATION = Object.freeze({
+  maxBump: 4,             // the ladder stops climbing after 4 cleared boards
+  swapPerBoard: 0.5,      // +1 swap every 2 clears (ceil), capped below
+  swapOverCeil: 1,        // the cap: (tier+1)'s budget, plus this one extra
+  driftFromBump: 3,       // a drift joins from the 3rd clear - and only at t>=3
+  loosenFromBump: 4,      // adjacent-only relaxes this late, and only if t+1 does
+  effectsFromBump: 2,     // sub_flash / wash / bubbles / crt adopt (t+1)'s values
+  previewStepMs: 250,     // the memorize beat shrinks a notch a board...
+  previewFloorMs: 2500,   // ...never below tier 4's own floor
+  heatPerBoard: 0.04,     // the engine's heat scalar creeps
+  heatCeil: 0.95,
+});
+
+/**
+ * Board N's dials.  `cleared` is how many boards the player has ALREADY cleared
+ * this class (0 for the first board, which is exactly `dialsFor`).
+ *
+ * WORKED EXAMPLES (the comment is the spec):
+ *   tier 1, cleared 1 -> swapBudget 1 (a first taste of the twist), preview
+ *                        4750ms, effects still off (effectsFromBump is 2)
+ *   tier 1, cleared 2 -> swapBudget 1, sub_flash + wash + crt 0.25 on (tier 2's
+ *                        own values), preview 4500ms
+ *   tier 1, cleared 4+-> swapBudget 2 = tier 2's budget (1) + swapOverCeil (1).
+ *                        That is the ceiling; board 9 is board 5.
+ *   tier 4, cleared 1+-> swapBudget 7 = tier 4's 6 + swapOverCeil. Drift 3 from
+ *                        the 3rd clear. Preview already at the floor.
+ *
+ * @param {number} tier 1..4
+ * @param {number} cleared boards already cleared this class
+ * @param {Object=} opts {pairs} - the player's board-size choice, board 1's and
+ *        every later board's alike (escalation never touches the grid).
+ */
+export function dialsForBoard(tier, cleared, opts = {}) {
+  const base = dialsFor(tier, opts);
+  const done = Math.max(0, Math.round(Number(cleared) || 0));
+  const bump = Math.min(ESCALATION.maxBump, done);
+  if (bump <= 0) return Object.assign({}, base, { board: 1, bump: 0, deckTier: base.tier });
+
+  const t = base.tier;
+  const ceilTier = Math.min(4, t + 1);          // THE CAP, in one number
+  const ceil = TIER_TABLE[ceilTier];
+  const on = bump >= ESCALATION.effectsFromBump;   // the effect dials unlock together
+
+  const swapBudget = Math.min(
+    ceil.swapBudget + ESCALATION.swapOverCeil,
+    base.swapBudget + Math.ceil(bump * ESCALATION.swapPerBoard),
+  );
+  // Drift is a tier-3/4 verb. Handing a tier-1 player a sliding row because they
+  // played well is a different game, not a harder one.
+  const drift = t >= 3
+    ? Math.min(ceil.drift + (t === 4 ? 1 : 0), base.drift + (bump >= ESCALATION.driftFromBump ? 1 : 0))
+    : base.drift;
+
+  const out = Object.assign({}, base, {
+    board: done + 1,
+    bump,
+    swapBudget,
+    drift,
+    previewMs: Math.max(
+      ESCALATION.previewFloorMs,
+      base.previewMs - bump * ESCALATION.previewStepMs,
+    ),
+    heat: Math.min(ESCALATION.heatCeil, Math.max(base.heat, base.heat + ESCALATION.heatPerBoard * bump)),
+    subFlash: base.subFlash || (on && ceil.subFlash),
+    wash: base.wash || (on && ceil.wash),
+    bubbles: on ? Math.max(base.bubbles, ceil.bubbles) : base.bubbles,
+    crt: on ? Math.max(base.crt, ceil.crt) : base.crt,
+    burstPressure: base.burstPressure || (on && ceil.burstPressure),
+    ambient: on ? Math.max(base.ambient, ceil.ambient) : base.ambient,
+    plainFloor: on ? Math.min(base.plainFloor, ceil.plainFloor) : base.plainFloor,
+    // adjacent-only is the gentlest law there is, so it relaxes LAST and only
+    // where the tier above would already have relaxed it (t>=3).
+    adjacentOnly: base.adjacentOnly
+      && !(bump >= ESCALATION.loosenFromBump && ceil.adjacentOnly === false),
+    /* THE DECKS RIDE THE SAME CAP. trickster.js gates the fake shuffle, the
+     * re-deal and the lie on a TIER, so a ladder that never moved that number
+     * would leave the House cards frozen at board 1 while the honest dials
+     * climbed. It moves exactly one notch and never further. */
+    deckTier: on ? ceilTier : t,
+  });
+  return out;
 }
 
 /* ----------------------------------------------------------------------------
@@ -298,50 +420,149 @@ export function matchedLoopPolicy(setting, tier, posterOnly) {
 
 /* ----------------------------------------------------------------------------
  * GRADING INPUTS (the shared rubric owns the letters - core/grades.js)
+ *
+ * THE CLASS IS BOARDS NOW, so the composite is boards-cleared + accuracy +
+ * combo + mutation survival. There is no time term any more and NO timeout
+ * clamp: the bell is how a 300s class ends, and clamping it to an automatic C
+ * would have graded every single class C. What replaces it is a per-tier
+ * EXPECTATION - how many boards a good player clears in the budget - so the
+ * bell is scored against what the tier could reasonably have done with it.
+ *
+ * -------- THE ARITHMETIC (300s budget; the work is shown) -------------------
+ * A board costs: preview + the deal cascade + a typical clear + the ceremony.
+ *   CLEAR_SEC_PER_PAIR is anchored on the two MEASURED clears we have (tier 1
+ *   ~30s for 6 pairs = 5.0s/pair; tier 4 ~73s for 10 pairs = 7.3s/pair) and the
+ *   middle two are interpolated.
+ *
+ *   tier 1: 5.00 preview + 12 x .12 deal + 6 x 5.0 clear + .42 = 36.9s
+ *   tier 2: 4.00 preview + 12 x .12 deal + 6 x 5.6 clear + .42 = 39.4s
+ *   tier 3: 3.00 preview + 16 x .12 deal + 8 x 6.8 clear + .42 = 59.8s
+ *   tier 4: 2.50 preview + 20 x .12 deal + 10 x 7.3 clear + .42 = 78.3s
+ *
+ * Raw capacity in 300s is 300/cost = 8.1 / 7.6 / 5.0 / 3.8 boards. Nobody plays
+ * a whole class at their own typical pace with the ladder climbing under them,
+ * so the S gate is that capacity x S_PACE (0.82), rounded:
+ *
+ *   tier 1: 8.13 x .82 = 6.67 -> 7 boards
+ *   tier 2: 7.61 x .82 = 6.24 -> 6 boards
+ *   tier 3: 5.02 x .82 = 4.11 -> 4 boards
+ *   tier 4: 3.83 x .82 = 3.14 -> 3 boards
+ *
+ * `boardCostSec` reads the DIALS, not the tier, so a player who chose a 6-pair
+ * board at tier 4 is expected to clear MORE of them - which is what stops the
+ * board-size setting being a way to farm clears (the below-par A-cap is the
+ * shell's separate, unchanged answer to the same setting).
+ *
+ * -------- THE GATES ---------------------------------------------------------
+ * composite = .58 clears + .30 accuracy + .12 combo (+ .03 per tracked, max 3)
+ * against grades.js's S .92 / A .75 / B .50.
+ *
+ *   S at tier 1: 7/7 boards (.58) + accuracy at or above par (.30) + a combo of
+ *                8 (.12) = 1.00. Miss one board and 6/7 (.497) needs both the
+ *                full combo and the tracked bonus to reach .92 - which is the
+ *                point: an S is a clean night, not a lucky one.
+ *   A at tier 4: 2/3 boards (.387) + accuracy .40 against par .46 (.261) +
+ *                combo 6 (.09) = .738, and two tracked-through-the-static
+ *                matches (+.06) carry it to .798 = A.
+ *   B          : roughly "half the expected boards at a competent accuracy" -
+ *                4/7 at tier 1 with accuracy .42 lands .579.
+ *
+ * ACCURACY IS SCORED AGAINST PAR, not against 1.0. Concentration accuracy has a
+ * ceiling a human cannot reach (a 6-pair board is 6 attempts only if you
+ * memorised all twelve faces in five seconds), so a raw pairs/attempts term
+ * would have made the accuracy weight unearnable and quietly turned the whole
+ * grade into a clears counter.
+ *
+ * PARTIAL PROGRESS ON THE LIVE BOARD COUNTS, linearly: the bell falling on 5 of
+ * 6 pairs is worth .833 of a board. Linear is deliberate - it is the same
+ * fraction of the same work, and any curve would only be a second opinion about
+ * how hard the last pair is.
  * -------------------------------------------------------------------------- */
+
+/** Anchored on the two measured clears; the middle two are interpolated. */
+export const CLEAR_SEC_PER_PAIR = Object.freeze({ 1: 5.0, 2: 5.6, 3: 6.8, 4: 7.3 });
+/** The S gate is this fraction of raw capacity (the ladder is climbing). */
+export const S_PACE = 0.82;
+/** Achievable pairs/attempts for a strong player at each tier. Bigger boards
+ *  and more mutations mean a lower reachable accuracy, not a worse player. */
+export const PAR_ACCURACY = Object.freeze({ 1: 0.62, 2: 0.58, 3: 0.52, 4: 0.46 });
+
+/** Seconds one whole board costs: preview + deal cascade + clear + ceremony. */
+export function boardCostSec(dials) {
+  const d = dials || dialsFor(1);
+  const preview = Math.max(0, Number(d.previewMs) || 0) / 1000;
+  const deal = (Number(d.cells) || 12) * (TIMING.dealStaggerMs / 1000);
+  const perPair = CLEAR_SEC_PER_PAIR[d.tier] || CLEAR_SEC_PER_PAIR[1];
+  const clear = (Number(d.pairs) || 6) * perPair;
+  return preview + deal + clear + (TIMING.ceremonyMs / 1000);
+}
+
+/**
+ * Boards a good player clears in `budgetSec` - the S gate, in boards.
+ * ALWAYS pass BOARD 1's dials: the ladder makes later boards dearer, and that
+ * is exactly what S_PACE is already paying for.
+ */
+export function expectedClears(dials, budgetSec) {
+  const budget = Math.max(1, Number(budgetSec) || 300);
+  const cost = Math.max(1, boardCostSec(dials));
+  return Math.max(1, Math.round((budget / cost) * S_PACE));
+}
+
 export const COMPOSITE_WEIGHTS = Object.freeze({
-  accuracy: 0.46,     // pairs / attempts
-  time: 0.30,         // par / elapsed
-  combo: 0.16,        // max combo against the shared cap of 8
-  trackedEach: 0.03,  // "tracked through the static", max 3 instances
+  clears: 0.58,       // boards cleared (+ the live board's fraction) vs expectation
+  accuracy: 0.30,     // class-wide pairs / attempts, against the tier's par
+  combo: 0.12,        // best combo against the shared cap of 8
+  trackedEach: 0.03,  // "tracked through the static", max 3 instances (a bonus)
 });
 export const TRACKED_CAP = 3;
 export const COMBO_CAP = 8;
 
 /**
- * @param {Object} i {tier, pairs, matched, attempts, elapsedSec, maxCombo,
- *                    tracked, timeout, parSec}
- * @returns {{composite:number, accuracy:number, timeScore:number,
- *            comboScore:number, trackedBonus:number, timeout:boolean}}
+ * @param {Object} i {tier, boardsCleared, livePairs, liveMatched, matched,
+ *                    attempts, maxCombo, tracked, expectedClears, timeout}
+ *   `matched` / `attempts` are the CLASS totals (every board summed); the live
+ *   board's own two numbers ride `liveMatched` / `livePairs` so the partial can
+ *   be priced without double-counting.
+ * @returns {{composite:number, clears:number, clearScore:number,
+ *            accuracy:number, accuracyScore:number, comboScore:number,
+ *            trackedBonus:number, expected:number, timeout:boolean}}
  */
 export function compositeFor(i) {
   const src = i || {};
-  const pairs = Math.max(1, Math.round(Number(src.pairs) || 1));
-  const matched = Math.max(0, Math.min(pairs, Math.round(Number(src.matched) || 0)));
-  const attempts = Math.max(matched, Math.round(Number(src.attempts) || 0));
-  const parSec = Math.max(1, Number(src.parSec) || pairs * 7);
-  const elapsed = Math.max(0.001, Number(src.elapsedSec) || 0);
-  const timeout = !!src.timeout;
+  const tier = Math.max(1, Math.min(4, Math.round(Number(src.tier) || 1)));
+  const expected = Math.max(1, Math.round(Number(src.expectedClears) || 1));
 
+  const cleared = Math.max(0, Math.round(Number(src.boardsCleared) || 0));
+  const livePairs = Math.max(0, Math.round(Number(src.livePairs) || 0));
+  const liveMatched = Math.max(0, Math.min(livePairs, Math.round(Number(src.liveMatched) || 0)));
+  const partial = livePairs > 0 ? liveMatched / livePairs : 0;
+  const clears = cleared + partial;
+  const clearScore = Math.max(0, Math.min(1, clears / expected));
+
+  const matched = Math.max(0, Math.round(Number(src.matched) || 0));
+  const attempts = Math.max(matched, Math.round(Number(src.attempts) || 0));
   const accuracy = attempts > 0 ? matched / attempts : 0;
-  // an unfinished board can never score full accuracy: unmatched pairs count as
-  // outstanding attempts, so bailing at 1/10 pairs does not read as 100%
-  const completion = matched / pairs;
-  const timeScore = Math.max(0, Math.min(1, parSec / elapsed));
+  const par = PAR_ACCURACY[tier] || PAR_ACCURACY[1];
+  const accuracyScore = Math.max(0, Math.min(1, accuracy / par));
+
   const comboScore = Math.max(0, Math.min(1, (Number(src.maxCombo) || 0) / COMBO_CAP));
   const trackedBonus = Math.min(TRACKED_CAP, Math.max(0, Math.round(Number(src.tracked) || 0)))
     * COMPOSITE_WEIGHTS.trackedEach;
 
-  let composite = (COMPOSITE_WEIGHTS.accuracy * accuracy * completion)
-    + (COMPOSITE_WEIGHTS.time * timeScore * completion)
+  let composite = (COMPOSITE_WEIGHTS.clears * clearScore)
+    + (COMPOSITE_WEIGHTS.accuracy * accuracyScore)
     + (COMPOSITE_WEIGHTS.combo * comboScore)
     + trackedBonus;
   composite = Math.max(0, Math.min(1, composite));
-  // Dossier: the 90s bell without a clear is an automatic C. The rubric's C band
-  // is "below B", so the timeout clamps under the B threshold rather than
-  // inventing a letter here (grades.js owns letters).
-  if (timeout) composite = Math.min(composite, 0.49);
-  return { composite, accuracy, completion, timeScore, comboScore, trackedBonus, timeout };
+  /* NO TIMEOUT CLAMP. The bell is the class's normal end (owner ruling, the
+   * class-length wave): it is reported for the share payload and the log, and
+   * it changes NOTHING about the letter. The old `Math.min(composite, 0.49)`
+   * lived here and would now grade an S run C. */
+  return {
+    composite, clears, clearScore, expected, partial,
+    accuracy, accuracyScore, comboScore, trackedBonus,
+    timeout: !!src.timeout,
+  };
 }
 
 /** +3 XP per tracked-through-a-swap match, capped 3/class (=9, under the 15 cap). */
@@ -372,4 +593,7 @@ export function createReward(seed) {
   };
 }
 
-export default { dialsFor, buildLayout, buildSwapSchedule, buildDriftSchedule, compositeFor };
+export default {
+  dialsFor, dialsForBoard, buildLayout, buildSwapSchedule, buildDriftSchedule,
+  boardCostSec, expectedClears, compositeFor,
+};

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/trickster.js
@@ -10,7 +10,7 @@
  *                   which is exactly what the playbook wants the card to
  *                   teach. (Law 1 of index.js is untouched: no mutation, so
  *                   no settled-board window is even consumed.)
- *   DEJA RE-DEAL    the native signature. Once a class, at a seeded settled
+ *   DEJA RE-DEAL    the native signature. Once a BOARD, at a seeded settled
  *                   window, the machine re-shows the whole board - a second
  *                   preview, free - except from tier 3 exactly ONE unmatched
  *                   card wears a LIE face borrowed from another pair. Flip the
@@ -45,6 +45,14 @@
  * lost-and-found's fallbackSwapPair does - deterministic given board state.
  * ==========================================================================*/
 
+/* ONE DECK PER BOARD (class-length wave 2026-08-24). A 300s class is a RUN of
+ * boards, and every card in this file is a once-per-instance card (one fake
+ * shuffle, one re-deal, N flickers). So `index.js startBoard()` destroys this
+ * deck and mints a fresh one for every board, seeded on the BOARD seed
+ * (`<classSeed>|b<N>`) and dealt at the escalation ladder's `deckTier` rather
+ * than the player's raw tier. Nothing in here changed to make that work - the
+ * module was already a pure per-instance dealer - but a reader who assumes one
+ * deck per CLASS will mis-read every window number in it. */
 import { makeRng } from '../../core/rng.js';
 
 export const DV_TRICKSTER = Object.freeze({
@@ -55,7 +63,9 @@ export const DV_TRICKSTER = Object.freeze({
   /** How far toward each other the feint slides (fraction of the gap). */
   SHUFFLE_REACH: 0.58,
 
-  /** Re-deal: from tier 2; the lie face from tier 3. Board must be mid-game. */
+  /** Re-deal: from tier 2; the lie face from tier 3. Board must be mid-game.
+   *  These windows are counted in THIS board's settled windows, not the
+   *  class's - the counter resets with every fresh deal. */
   REDEAL_FROM_TIER: 2,
   LIE_FROM_TIER: 3,
   /** Seeded settled-window slot for the re-deal (min + spread). */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/echo/index.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * games/echo/index.js - ECHO (Simon; family: memory; Semester II, 105s).
+ * games/echo/index.js - ECHO (Simon; family: memory; Semester II, 120s).
  *
  * Six pads in a ring. The room plays a sequence - each pad lights and sounds
  * its own note - and you play it back. Clear it and the sequence grows by one.
@@ -87,8 +87,9 @@
  *        every engine one-shot over the ring is decoration (fireSafe() welds
  *        clickSafe on, bubbles are never poppable here).
  *   III  something always breathes: the ambient field runs from the first beat.
- *   IV   the class-rules sheet is DRAWN, GO-only, and honours ctx.hideTutorial
- *        with a once-per-grade-tier memory in gameMeta.howtoTiers (IC's policy).
+ *   IV   the class-rules sheet is DRAWN, GO-only and FREE OF THE CLOCK: it
+ *        shows ONCE per grade tier (gameMeta.howtoTiers) and ctx.hideTutorial
+ *        skips even that first showing. startClock() runs in the GO callback.
  *   V    stream, decoy plan, the per-round face deal, the clip roll, casino,
  *        trickster and pressure are all scoped off the class seed; a retake
  *        replays the identical class. Nothing here calls Math.random.
@@ -239,7 +240,10 @@ export default {
   family: 'memory',
   meaty: false,
   flagship: false,
-  timeBudgetSec: 105,
+  /* 120s (owner ruling, the class-length wave; it was 105). Nothing in the
+   * class is a count - the room deals sequences until the bell and a fail is
+   * not the class - so the extra fifteen seconds are simply more rounds. */
+  timeBudgetSec: 120,
   title: 'Echo',
 
   manifest: {
@@ -293,7 +297,7 @@ export default {
     let reduced = false;
     let retake = false;
     let audible = true;
-    let budgetMs = 105000;
+    let budgetMs = 120000;
     let pool = null;
     let rollLocal = null;
     let subRoll = null;                 // the seeded sub_flash word stream
@@ -1784,10 +1788,13 @@ export default {
     }
 
     /* ==================================================================== *
-     * THE CLASS-RULES SHEET (Law IV / Deck VI) - drawn, GO-only, and the
-     * shell's "Skip class tutorials" contract: with the skip ON a class still
-     * explains itself ONCE PER GRADE TIER, and that memory is the GAME's
-     * (gameMeta.howtoTiers), never the shell's. Impulse Control's policy.
+     * THE CLASS-RULES SHEET (Law IV / Deck VI) - drawn, GO-only and FREE OF
+     * THE CLOCK. THE LAW, uniform across every open class (owner ruling
+     * 2026-08-24): the sheet SHOWS the first time this player meets this class
+     * at this grade tier and AUTO-SKIPS every later class at that tier,
+     * whatever the setting says; the shell's "Skip class tutorials" switch
+     * means "skip even the first showing". The memory is the GAME's
+     * (gameMeta.howtoTiers), never the shell's, and no meta = the sheet shows.
      * ==================================================================== */
     function howtoSeenTiers() {
       try {
@@ -1814,7 +1821,8 @@ export default {
     function howto(onDone) {
       const seen = howtoSeenTiers();
       const skip = (ctx.dev === true && spec && spec.devSkipHowto === true)
-        || (ctx.hideTutorial === true && seen.indexOf(tier) >= 0);
+        || ctx.hideTutorial === true
+        || seen.indexOf(tier) >= 0;
       if (skip) { onDone(); return; }
       howtoEl = el('div', 'g-ec-howto');
       howtoEl.setAttribute('role', 'dialog');
@@ -2013,10 +2021,10 @@ export default {
      * ==================================================================== */
     const instance = {
       start(classSpec) {
-        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 105 };
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
         tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
         seed = String(spec.seed == null ? GAME_KEY : spec.seed);
-        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 105) * 1000);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
         retake = !!spec.retake;
         reduced = probeReduced(ctx);
         audible = ctx.audioAudible !== false;
@@ -2144,7 +2152,6 @@ export default {
 
         bindInput();
         claimAssets();
-        startClock();
         /* THE FIT has to run once the pads have a real width, and again whenever
          * the window changes it. Law VI: the listener comes off in destroy(). */
         scheduleFit();
@@ -2165,6 +2172,12 @@ export default {
         msg('ec_brief', EC_LEX.ec_brief);
         howto(() => {
           if (dead || ended) return;
+          /* THE CLOCK STARTS AT GO AND NOWHERE ELSE (owner ruling 2026-08-24).
+           * It used to be armed above, beside bindInput/claimAssets, which
+           * charged the player for reading the rules sheet - the one thing the
+           * class asks them to read. The BRIEF beat below IS on the clock: it
+           * is a game beat, not the sheet, exactly as Instant Recall's is. */
+          startClock();
           after(reduced ? PLAYTEST.BRIEF_MS_REDUCED : PLAYTEST.BRIEF_MS, () => {
             if (dead || ended) return;
             deck('casino', 'start');
@@ -2252,7 +2265,7 @@ export default {
       chipText(which) { return chipText(which); },
       /** The live round (the suite asserts the dealt plan against sequence.js). */
       round() { return round; },
-      /** End the class as the bell would (the suite never waits 105s). */
+      /** End the class as the bell would (the suite never waits the budget). */
       ringBell() { run(bell); },
       /** Deal the NEXT round's faces, as a cleared sequence would. Diagnostics
        *  only - the shell never calls it; the suite uses it to walk a pool

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
@@ -56,8 +56,9 @@
  *   - suspend(on) freezes EVERYTHING - decks first, then timers, tube loop and
  *     CSS - and the bubble in flight is dealt again from the mouth on resume
  *     (never scored across a freeze).
- *   - the rules sheet obeys the shell's tutorial contract: shown every class by
- *     default, and still ONCE PER NEW TIER when "Skip class tutorials" is on.
+ *   - the rules sheet obeys the school's tutorial law: shown the FIRST class at
+ *     a new grade tier and auto-skipped at that tier ever after, with "Skip
+ *     class tutorials" skipping even that first showing.
  *
  * CLOCK. `now()` and the timer helpers resolve `performance` / `setTimeout` off
  * the global at CALL time, so the scratch harness swaps in a fake clock and
@@ -554,16 +555,22 @@ export default {
       } catch (e) { return []; }
     }
     /**
-     * The sheet, ahead of the incoming beat. Policy is the shell's "Skip class
-     * tutorials" contract: default shows every class; with the skip on, a class
-     * still explains itself ONCE per grade tier. Dismissal is the sheet's own
+     * The sheet, ahead of the incoming beat. THE LAW, uniform across every open
+     * class (owner ruling 2026-08-24): the sheet SHOWS the first time this
+     * player meets the tube at this grade tier and AUTO-SKIPS every later class
+     * at that tier, whatever the setting says; the shell's "Skip class
+     * tutorials" switch (ctx.hideTutorial) means "skip even the first showing".
+     * No meta = no memory = the sheet shows. Dismissal is the sheet's own
      * button only - binding the POP key here would teach the player to press
-     * it at a bubble that has not been dealt.
+     * it at a bubble that has not been dealt. The sheet costs the class nothing
+     * either way: this class has no wall clock at all (the plan is the length),
+     * so there is no budget for a reader to burn.
      */
     function howto(onDone) {
       const seen = howtoSeenTiers();
       const skip = (dev && devSkipHowto)
-        || (ctx.hideTutorial === true && seen.indexOf(S.gradeTier) >= 0);
+        || ctx.hideTutorial === true
+        || seen.indexOf(S.gradeTier) >= 0;
       if (skip) { onDone(); return; }
       if (!S.render || typeof S.render.showHowto !== 'function') { onDone(); return; }
       let done = false;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
@@ -1,7 +1,7 @@
 /* ============================================================================
  * games/instant-recall/index.js - INSTANT RECALL, "the vigil" (family: recall).
  *
- * One class is ONE continuous 120-second WALL. A full-bleed mosaic of the
+ * One class is ONE continuous 180-second WALL. A full-bleed mosaic of the
  * player's own media fills the stage and every tile keeps changing itself on
  * its own beat (the FYP look, the Just Drop backdrop); CCP's own classic
  * effects fire over it denser and denser - and then, without warning,
@@ -14,7 +14,8 @@
  *   the wall -> effect emissions on the density sawtooth, every one of them
  *               written to the LEDGER (the truth tail) with what the engine
  *               ACTUALLY did. THE WALL'S OWN SWAPS ARE NEVER LEDGER ENTRIES.
- *   (five of those a minute now - vigil.js THE CADENCE. The gap between two
+ *   (five of those a minute now - vigil.js THE CADENCE, which is a RATE and
+ *    not a count: 180s deals 14-16 stops at every tier. The gap between two
  *    stops is DERIVED from the freeze it has to outlast, so however long the
  *    player takes there are always >= 4s of live wall and >= 2 fresh ledger
  *    entries before the next freeze: a question always has something new.)
@@ -53,8 +54,10 @@
  *   III  NEVER STILL. The wall turns over the whole class - at any moment some
  *        tile is mid-swap; the only still frame is the freeze, and the freeze
  *        IS the mechanic.
- *   IV   IMAGES OVER TEXT. The class-rules sheet is drawn (style.js) and
- *        dismissed by GO only, once per grade tier under `ctx.hideTutorial`.
+ *   IV   IMAGES OVER TEXT. The class-rules sheet is drawn (style.js), is
+ *        dismissed by GO only, shows ONCE per grade tier and is FREE OF THE
+ *        CLOCK - `ctx.hideTutorial` skips even that first showing, and
+ *        startClock() runs inside the GO callback.
  *   V    SEEDED. vigil.js deals the whole show off the class seed before a
  *        frame renders. The only Math.random in this game is the frame
  *        governor's (montage.js), which never consumes the seeded stream.
@@ -226,17 +229,23 @@ function loadDecks() {
 export default {
   key: GAME_KEY,
   family: 'recall',
-  /* MEATY (owner ruling). Not because 120s is long - it is not - but because
-   * the ten-game pool re-opened web CLAUDE.md trap 6: no-repeat-3 outranks the
-   * meaty preference, so TWO meaty classes left roughly a third of dealt nights
-   * with no meaty slot filled at all. A third meaty class closes the gap. The
-   * budget, the family and the flagship flag are unchanged - and this file's
-   * behaviour does not branch on `meaty` anywhere: it is a timetable fact, not
-   * a difficulty one. `games/registry.js` GAME_META must mirror it (the
-   * parachute is read for a suspended class too). */
+  /* MEATY = THE ANCHOR SLOT, not a length. The ten-game pool re-opened web
+   * CLAUDE.md trap 6: no-repeat-3 outranks the anchor preference, so TWO anchor
+   * classes left roughly a third of dealt nights with no anchor at all. A third
+   * closes the gap. This file's behaviour does not branch on `meaty` anywhere -
+   * it is a timetable fact, not a difficulty one - and it says nothing about
+   * seconds: the vigil runs 180s while Anomaly, a non-anchor class, runs 300.
+   * `games/registry.js` GAME_META must mirror both fields (the parachute is
+   * read for a suspended class too).
+   *
+   * THE BUDGET IS 180s (owner ruling, the class-length wave; it was 120). The
+   * cadence is a RATE, so nothing else moved: vigil.js scales the per-120s
+   * STOPS_BAND by budget and then holds it inside STOPS_PER_MIN {4.4, 5.6},
+   * which deals 14-15 stops at tiers 1-2 and 15-16 at tiers 3-4, all of them
+   * inside maxStopsFor()'s legal fit for 180s (15/15/16/18). */
   meaty: true,
   flagship: false,
-  timeBudgetSec: 120,
+  timeBudgetSec: 180,
   title: 'Instant Recall',
 
   manifest: {
@@ -291,7 +300,7 @@ export default {
     let plan = null;
     let reduced = false;
     let retake = false;
-    let budgetMs = 120000;
+    let budgetMs = 180000;
     let pool = null;
     let montage = null;
     let ledger = null;
@@ -647,7 +656,8 @@ export default {
     }
 
     /* ==================================================================== *
-     * THE CLASS-RULES SHEET (Law IV: drawn, GO-only, once per tier)
+     * THE CLASS-RULES SHEET (Law IV: drawn, GO-only, once per tier, and never
+     * on the clock - startClock() is inside the GO callback)
      * ==================================================================== */
     function howtoSeenTiers() {
       try {
@@ -668,13 +678,16 @@ export default {
       } catch (e) { /* best effort - the sheet just shows again next time */ }
     }
     /**
-     * The sheet: three drawn panels and a GO button. Policy is the shell's
-     * "Skip class tutorials" contract - default shows every class; with the
-     * skip on, a class still explains itself ONCE per grade tier. Dismissal is
-     * the sheet's own button only.
+     * The sheet: three drawn panels and a GO button. THE LAW, uniform across
+     * every open class (owner ruling 2026-08-24): it SHOWS the first time this
+     * player meets the vigil at this grade tier and AUTO-SKIPS every later
+     * class at that tier, whatever the setting says; the shell's "Skip class
+     * tutorials" switch (ctx.hideTutorial) means "skip even the first showing".
+     * No meta = no memory = the sheet shows. Dismissal is the sheet's own
+     * button only, and the clock is armed past GO, never over the sheet.
      */
     function howto(onDone) {
-      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      if (ctx.hideTutorial === true || howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
       howtoEl = el('div', 'g-ir-howto');
       howtoEl.appendChild(el('h3', 'g-ir-howto-title', t('ir_howto_title', IR_LEX.ir_howto_title)));
       /* THREE FIGURES (Law IV, drawn): the wall / the freeze / the pick. The
@@ -2253,11 +2266,11 @@ export default {
      * ==================================================================== */
     const instance = {
       start(classSpec) {
-        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 120 };
+        spec = classSpec || { gradeTier: 1, seed: GAME_KEY + '|none', timeBudgetSec: 180 };
         tier = Math.max(1, Math.min(4, Math.round(Number(spec.gradeTier) || 1)));
         seed = String(spec.seed == null ? GAME_KEY : spec.seed);
         retake = !!spec.retake;
-        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 120) * 1000);
+        budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 180) * 1000);
         reduced = probeReduced(ctx);
         const densityValue = ctx.settings ? ctx.settings.ir_density : 'standard';
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/casino.js
@@ -215,14 +215,22 @@ export function createCasino(o) {
 
     /**
      * A find pays light: one bright pulse over the frame, brighter up the
-     * ladder (n = the find just claimed, 1..5). The class flag self-clears.
+     * ladder. `n` is the find just claimed and `total` the finds this class is
+     * asking for - the ladder is still FIVE rungs of light, but it is now spread
+     * across the whole class instead of being spent in the first five finds of a
+     * 13-26 find one (the class-length wave, 2026-08-24). An absent `total`
+     * keeps the original behaviour, one rung a find.
      */
-    payout(n) {
+    payout(n, total) {
       if (!mq || !mq.classList) return;
+      const of = Math.max(1, Math.round(Number(total) || 5));
+      const rung = of > 1
+        ? 1 + 4 * clamp((Math.max(1, Number(n) || 1) - 1) / (of - 1), 0, 1)
+        : 5;
       mq.classList.remove('g-lf-mq-flash');
       // restart the CSS animation even on back-to-back finds
       if (typeof mq.offsetWidth === 'number') void mq.offsetWidth;
-      mq.style.setProperty('--g-lf-mqf', String(1 + 0.16 * clamp(n, 1, 5)));
+      mq.style.setProperty('--g-lf-mqf', String(1 + 0.16 * clamp(rung, 1, 5)));
       mq.classList.add('g-lf-mq-flash');
       if (flashTimer) timers.cancel(flashTimer);
       flashTimer = timers.after(CASINO.FLASH_MS, () => {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/constants.js
@@ -12,10 +12,57 @@
  * near-twin share) follows.
  * ==========================================================================*/
 
-/** The arc is five finds. SYNTHESIS ruling: find 3 = modifier, find 5 = bell. */
-export const FINDS_PER_CLASS = 5;
-export const MODIFIER_AFTER_FIND = 3;      // "the board wakes up"
-export const FINAL_BELL_FIND = 5;          // guaranteed clutch cinematics
+/* ----------------------------------------------------------------------------
+ * THE ARC, AND IT IS PER-TIER NOW (owner ruling 2026-08-24, the class-length
+ * wave). The class used to be FIVE finds against a 120s bell at every tier,
+ * which meant a competent tier-1 player was done in ~50s of a two-minute class
+ * and the bell was decoration. The budget is 300s now (see index.js's module
+ * descriptor) and the COUNT is what makes every tier land in the same place.
+ *
+ * THE TARGET: ~4:00-4:30 (240-270s) of typical competent play, whatever the
+ * tier. The bell at 300s stays a HARD cap and a par player may ride it.
+ *
+ * THE ARITHMETIC (one tile wall, the target relocates between finds, so more
+ * finds cost NO new tiles - density and the look-signature pool are untouched):
+ *
+ *   hunt seconds per find, typical competent play, medium density:
+ *     t1  7.8s   (48 tiles)   t2  9.8s   (62 tiles)
+ *     t3 13.8s   (92 tiles)   t4 17.8s  (123 tiles)
+ *   ...+ FOUND_CEREMONY_MS (1.8s) of ceremony per find, which is dead clock:
+ *     cycle  t1 9.6s   t2 11.6s   t3 15.6s   t4 19.6s
+ *   ...and the briefing is NOT on the clock (index.js starts the clock in
+ *   briefing's own onDone), so the whole budget is n x cycle:
+ *     t1 26 x 9.6  = 249.6s     t2 22 x 11.6 = 255.2s
+ *     t3 16 x 15.6 = 249.8s     t4 13 x 19.6 = 254.8s
+ *   Every tier lands ~250s, ~50s under the bell - which is the headroom the
+ *   MISCLICK_TIME_PENALTY_SEC (3s a miss) eats into, deliberately.
+ *
+ * (t2/t3 hunt seconds are interpolated from the two MEASURED tiers through the
+ * game's own par formula: measured hunt / uncapped parSecFor is 0.551 at t1 and
+ * 0.535 at t4, so 0.543 x par is the tier-fair estimate in between.)
+ * -------------------------------------------------------------------------- */
+export const FINDS_BY_TIER = Object.freeze({ 1: 26, 2: 22, 3: 16, 4: 13 });
+
+/** The modifier ("the board wakes up") lands about a THIRD of the way in - the
+ *  same shape as the old find 3 of 5, never a fixed find number. */
+export const MODIFIER_FIND_RATIO = 1 / 3;
+
+/** How many finds this tier's class is. Anything unusable answers tier 1. */
+export function findsForTier(tier) {
+  const t = Math.round(Number(tier));
+  return FINDS_BY_TIER[t >= 1 && t <= 4 ? t : 1] || FINDS_BY_TIER[1];
+}
+
+/** The find that turns the modifier on, per tier (>= 2, so it is never find 1). */
+export function modifierFindForTier(tier) {
+  return Math.max(2, Math.round(findsForTier(tier) * MODIFIER_FIND_RATIO));
+}
+
+/** The final bell = the tier's last find. Kept as its own verb because the bell
+ *  is an ARC beat (announced, guaranteed clutch), not merely "the end". */
+export function finalBellFindForTier(tier) {
+  return findsForTier(tier);
+}
 
 /* ----------------------------------------------------------------------------
  * PLAYTEST BLOCK - flagged for tuning by the dossier / synthesis rulings.
@@ -157,7 +204,12 @@ export const PLAYTEST = Object.freeze({
    *  plenty of motion of its own by then. */
   SHEEN_MAX_DENSITY: 64,
 
-  /** Found ceremony length; the hunt resumes after it. */
+  /** Found ceremony length; the hunt resumes after it. NOTE it is DEAD CLOCK:
+   *  the class timer runs through it, so at the per-tier find counts this is
+   *  23s (t4) to 47s (t1) of the 300s budget. Both the pace arithmetic at the
+   *  top of this file and RUBRIC.PAR_CEREMONY_SEC account for it. Shortening it
+   *  is the obvious lever if a 4-minute class feels ceremony-heavy in play-test
+   *  - it is an owner call, not one this wave made. */
   FOUND_CEREMONY_MS: 1800,
   FOUND_CEREMONY_MS_REDUCED: 900,
 
@@ -253,29 +305,76 @@ export const RUBRIC = Object.freeze({
   PAR_PER_DRIFT_SEC: 4.0,
   /** A class can never be graded against a par it has no time to reach. */
   PAR_BUDGET_SHARE: 0.9,
+  /** ...and "time to reach" is HUNTING time. Every find spends a found ceremony
+   *  the player cannot hunt through, and at 13-26 finds that is 23-47s of the
+   *  budget, not the 9s it was at five. The clamp subtracts it before dividing,
+   *  or par would be a bar a par player physically cannot clear. Callers may
+   *  override with `ceremonySec` (reduced motion runs the 900ms ceremony). */
+  PAR_CEREMONY_SEC: 1.8,
 
   /** timeScore anchors: .6*par -> 1.0, par -> .78, 1.6*par -> .44, 2.4*par -> 0 */
   TIME_ZERO_MULT: 2.4,
   TIME_SPAN_MULT: 1.8,
 
-  /** one misclick per find zeroes the accuracy term. */
+  /** one misclick per find zeroes the accuracy term. A RATE - it needed no
+   *  rescaling when the class grew (missScore already divides by the finds). */
   MISS_TOLERANCE: 1.0,
-  /** three peeks zero the peek term (each one is a soft tax, never a fail). */
-  PEEK_TAX: 0.34,
+  /** The peek tax zeroes the term at this SHARE of the class's finds (floored
+   *  at 3, which is exactly the old flat "three peeks" on a five-find class).
+   *  A flat count would have been a fixed -0.10 on any 4-minute class the
+   *  moment the player peeked twice, i.e. not a graded tax at all. The hard
+   *  part of peek was never this term - it is the shell's flat A-cap. */
+  PEEK_ZERO_RATIO: 0.35,
+  PEEK_ZERO_MIN: 3,
 
   WEIGHTS: Object.freeze({ time: 0.40, miss: 0.25, peek: 0.10, streak: 0.25 }),
 
-  /** S needs a clean streak, sub-par median AND near-perfect accuracy (§14 gate). */
-  S_GATE_CLEAN_STREAK: 3,
-  S_GATE_MAX_MISCLICKS: 1,
+  /** S needs a clean streak, sub-par median AND near-perfect accuracy (§14 gate).
+   *  Both halves are RATIOS of the class now, with floors that reproduce the old
+   *  3-and-1 exactly at five finds. The streak ratio is 0.32 rather than the old
+   *  3/5 = 0.60 because an unbroken run does NOT scale linearly: at a competent
+   *  85% clean-find rate the chance of ever running 60% of a 26-find class is a
+   *  few percent, where 3-of-5 was ~80%. Measured (exact run DP): a 0.32 ratio
+   *  gives 8/7/5/4 by tier and pass rates 0.82/0.85/0.93/0.96 against today's
+   *  0.798 - i.e. the gate stays a gate instead of quietly becoming impossible. */
+  S_GATE_CLEAN_STREAK_RATIO: 0.32,
+  S_GATE_CLEAN_STREAK_MIN: 3,
+  /** Misclicks ARE linear, so this one is a plain per-find rate: 1-in-5, the old
+   *  number restated. 5/4/3/3 by tier; binomial P(pass) at a 15% miss rate is
+   *  0.82/0.77/0.79/0.88 against today's 0.835. */
+  S_GATE_MISCLICK_RATE: 0.2,
+  S_GATE_MISCLICKS_MIN: 1,
 
-  /** Timed round timeout with fewer than 5 finds = C floor with partial credit. */
-  TIMEOUT_COMPOSITE_CEIL: 0.49,
+  /** The best clean streak that scores a full 1.0 on the streak term, as
+   *  BASE + PER_FIND x finds. It is AFFINE, not a ratio, and that is the whole
+   *  point: the longest run in n tries grows like log(n), so a flat ratio would
+   *  deflate the term at long classes and inflate it at short ones. Fitted to
+   *  hold typical competent play (85% clean) at the ~0.76 it scores today:
+   *  divisors 15/14/11/10 by tier -> 0.78/0.77/0.81/0.78. */
+  STREAK_FULL_BASE: 5,
+  STREAK_FULL_PER_FIND: 0.4,
+  STREAK_FULL_MIN: 3,
 
-  /** flavorXp (shell clamps at 15 too - BUILD-CONTRACT §8). */
+  /** THE BELL WITH PARTIAL FINDS IS A NORMAL OUTCOME NOW, not a fail.
+   *  At five finds "the bell caught you" meant you never finished a 5-find
+   *  class in two minutes, so the old rule (composite x finds/5, hard-capped at
+   *  0.49 = a guaranteed C) was fair. At 13-26 finds a 12/13 bell run is a good
+   *  class, and a flat C would be a lie. So completion is a CREDIT LINE: find
+   *  this share of the class and the composite is untouched, below it credit
+   *  falls away proportionally (and reaches zero at zero finds). S is still out
+   *  of reach on a timeout - grade.js's sGate requires `complete`, which caps
+   *  the class at A - and the ceiling below is belt-and-braces for that. */
+  TIMEOUT_FULL_CREDIT_RATIO: 0.85,
+  TIMEOUT_COMPOSITE_CEIL: 0.90,
+
+  /** flavorXp (shell clamps at 15 too - BUILD-CONTRACT §8). DELIBERATELY NOT
+   *  rescaled with the find count: the XP economy is app-wide and this class
+   *  must not start paying 2-5x what its neighbours do. The consequence is that
+   *  the cap SATURATES mid-class - find 8 of 13-26 tops it out and every find
+   *  after it is worth no XP - which is intended, not an oversight. */
   XP_PER_FIND: 2,
   XP_PER_JACKPOT: 2,
   XP_CAP: 15,
 });
 
-export default { FINDS_PER_CLASS, TIERS, PLAYTEST, RUBRIC };
+export default { FINDS_BY_TIER, findsForTier, TIERS, PLAYTEST, RUBRIC };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/grade.js
@@ -13,34 +13,89 @@
  *   2. misclick rate (misclicks / finds);
  *   3. peek count (a soft tax - the hard part of peek is the shell's flat A-cap);
  *   4. best clean streak (no misclick, no peek) as the S differentiator, which is
- *      expressed as a HARD GATE rather than as weight, because "S requires a 3+
- *      clean streak plus sub-par median and 0-1 misclicks" is a gate, not a curve
- *      (SYNTHESIS #14 blesses per-game hard gates).
+ *      expressed as a HARD GATE rather than as weight, because "S requires a
+ *      clean streak plus sub-par median and near-perfect accuracy" is a gate,
+ *      not a curve (SYNTHESIS #14 blesses per-game hard gates).
  *
  * Pity pulses are deliberately absent from every term: they are a comeback aid,
  * not a tax.
+ *
+ * NOTHING HERE KNOWS WHAT A TIER IS (2026-08-24, the class-length wave). The
+ * class is 13-26 finds depending on grade tier now, so every threshold that used
+ * to be a flat count is derived from ONE number the caller passes, `findsTarget`
+ * - which keeps this file tier-agnostic exactly the way it is density-agnostic.
+ * A caller that omits it is graded against tier 1's class, never against 5.
  * ==========================================================================*/
 
-import { FINDS_PER_CLASS, RUBRIC } from './constants.js';
+import { findsForTier, RUBRIC } from './constants.js';
 import { clamp01, median as medianOf } from './util.js';
+
+/** The finds this class was asking for. Junk answers tier 1's count. */
+function targetFinds(n) {
+  const v = Math.round(Number(n));
+  return Number.isFinite(v) && v > 0 ? v : findsForTier(1);
+}
+
+/** The clean streak the S gate demands of a class this long (see RUBRIC). */
+export function sGateStreakFor(findsTarget) {
+  return Math.max(
+    RUBRIC.S_GATE_CLEAN_STREAK_MIN,
+    Math.round(targetFinds(findsTarget) * RUBRIC.S_GATE_CLEAN_STREAK_RATIO)
+  );
+}
+
+/** The misclicks the S gate forgives in a class this long. */
+export function sGateMisclicksFor(findsTarget) {
+  return Math.max(
+    RUBRIC.S_GATE_MISCLICKS_MIN,
+    Math.round(targetFinds(findsTarget) * RUBRIC.S_GATE_MISCLICK_RATE)
+  );
+}
+
+/** The clean streak that scores a full 1.0 on the streak term (affine - see
+ *  RUBRIC.STREAK_FULL_BASE for why it is not a ratio). */
+export function streakFullFor(findsTarget) {
+  return Math.max(
+    RUBRIC.STREAK_FULL_MIN,
+    Math.round(RUBRIC.STREAK_FULL_BASE + RUBRIC.STREAK_FULL_PER_FIND * targetFinds(findsTarget))
+  );
+}
+
+/** The peek count that zeroes the peek term in a class this long. */
+export function peekZeroFor(findsTarget) {
+  return Math.max(
+    RUBRIC.PEEK_ZERO_MIN,
+    Math.round(targetFinds(findsTarget) * RUBRIC.PEEK_ZERO_RATIO)
+  );
+}
 
 /**
  * Seconds-per-find par. Scales with the two things that actually make a hunt
  * slower - how many candidates there are and how much the board is moving - and
  * is then clamped so a class can never be graded against a par its own time
- * budget cannot reach (the quick-slot / 60s case).
+ * budget cannot reach (the quick-slot / 60s case, and now also the ordinary
+ * case: 13-26 finds into 300s is a much tighter clamp than 5 into 120s ever
+ * was, and at every tier it is the clamp - not the density term - that wins).
+ * `finds` is the finds the class ASKED for, never the finds it got.
  */
 export function parSecFor(o) {
   const opts = o || {};
   const density = Math.max(4, Number(opts.density) || 16);
   const drift = clamp01(opts.drift);
-  const finds = Math.max(1, Number(opts.finds) || FINDS_PER_CLASS);
+  const finds = Math.max(1, Number(opts.finds) || findsForTier(1));
   let par = RUBRIC.PAR_BASE_SEC
     + RUBRIC.PAR_PER_TILE_SEC * density
     + RUBRIC.PAR_PER_DRIFT_SEC * drift;
   const budget = Number(opts.timeBudgetSec);
   if (Number.isFinite(budget) && budget > 0) {
-    par = Math.min(par, (budget * RUBRIC.PAR_BUDGET_SHARE) / finds);
+    // THE BUDGET IS NOT ALL HUNTING TIME. Every find spends a found ceremony
+    // the player cannot hunt through, so the clamp divides what is LEFT after
+    // the ceremonies - otherwise a class of 26 finds is graded against a par
+    // that a player hunting exactly at par would still miss the bell hitting.
+    const cer = Number.isFinite(Number(opts.ceremonySec))
+      ? Math.max(0, Number(opts.ceremonySec)) : RUBRIC.PAR_CEREMONY_SEC;
+    const hunting = Math.max(budget * 0.25, budget - finds * cer);
+    par = Math.min(par, (hunting * RUBRIC.PAR_BUDGET_SHARE) / finds);
   }
   return Math.max(1.5, par);
 }
@@ -58,25 +113,30 @@ export function missScore(misclicks, finds) {
   return clamp01(1 - rate / RUBRIC.MISS_TOLERANCE);
 }
 
-export function peekScore(peeks) {
-  return clamp01(1 - Math.max(0, Number(peeks) || 0) * RUBRIC.PEEK_TAX);
+/** The tax zeroes the term at peekZeroFor(findsTarget) peeks - a share of the
+ *  class, not a flat three, or a 4-minute class would be a fixed -0.10 the
+ *  moment the player peeked twice. */
+export function peekScore(peeks, findsTarget) {
+  const zero = peekZeroFor(findsTarget);
+  return clamp01(1 - Math.max(0, Number(peeks) || 0) / zero);
 }
 
-export function streakScore(bestCleanStreak) {
-  return clamp01(Math.max(0, Number(bestCleanStreak) || 0) / FINDS_PER_CLASS);
+export function streakScore(bestCleanStreak, findsTarget) {
+  return clamp01(Math.max(0, Number(bestCleanStreak) || 0) / streakFullFor(findsTarget));
 }
 
 /**
  * The declared hard gate. FALSE caps the class at A (core/grades.js), which is
  * how "S requires a clean streak, a sub-par median and near-perfect accuracy"
- * gets enforced without this file ever naming the letter S.
+ * gets enforced without this file ever naming the letter S. Both counted halves
+ * scale with the length of the class the player was actually asked to play.
  */
 export function sGateFor(o) {
   const opts = o || {};
   return !!(
-    (Number(opts.bestCleanStreak) || 0) >= RUBRIC.S_GATE_CLEAN_STREAK
+    (Number(opts.bestCleanStreak) || 0) >= sGateStreakFor(opts.findsTarget)
     && (Number(opts.medianSec) || Infinity) <= (Number(opts.par) || 0)
-    && (Number(opts.misclicks) || 0) <= RUBRIC.S_GATE_MAX_MISCLICKS
+    && (Number(opts.misclicks) || 0) <= sGateMisclicksFor(opts.findsTarget)
   );
 }
 
@@ -89,6 +149,8 @@ export function sGateFor(o) {
  * @param {number} o.bestCleanStreak
  * @param {number} o.density
  * @param {number} o.drift
+ * @param {number} o.findsTarget     the finds THIS class asked for (per tier)
+ * @param {number=} o.ceremonySec    found-ceremony length, for the par clamp
  * @param {number=} o.timeBudgetSec  omitted / null for zen (no timeout at all)
  * @param {number=} o.jackpots
  * @returns {{composite:number, hardGates:{sGate:boolean}, flavorXp:number,
@@ -98,36 +160,43 @@ export function scoreClass(o) {
   const opts = o || {};
   const times = Array.isArray(opts.findTimesSec) ? opts.findTimesSec.filter((n) => Number.isFinite(n)) : [];
   const finds = times.length;
-  const complete = finds >= FINDS_PER_CLASS;
+  const findsTarget = targetFinds(opts.findsTarget);
+  const complete = finds >= findsTarget;
   const misclicks = Math.max(0, Number(opts.misclicks) || 0);
   const peeks = Math.max(0, Number(opts.peeks) || 0);
   const bestCleanStreak = Math.max(0, Number(opts.bestCleanStreak) || 0);
 
   const par = parSecFor({
-    density: opts.density, drift: opts.drift,
-    timeBudgetSec: opts.timeBudgetSec, finds: FINDS_PER_CLASS,
+    density: opts.density, drift: opts.drift, ceremonySec: opts.ceremonySec,
+    timeBudgetSec: opts.timeBudgetSec, finds: findsTarget,
   });
   const medianSec = finds ? medianOf(times) : Infinity;
 
   const parts = {
     time: finds ? timeScore(medianSec, par) : 0,
     miss: missScore(misclicks, Math.max(1, finds)),
-    peek: peekScore(peeks),
-    streak: streakScore(bestCleanStreak),
+    peek: peekScore(peeks, findsTarget),
+    streak: streakScore(bestCleanStreak, findsTarget),
   };
   const w = RUBRIC.WEIGHTS;
   let composite = clamp01(
     w.time * parts.time + w.miss * parts.miss + w.peek * parts.peek + w.streak * parts.streak
   );
 
-  // Timed round timeout with fewer than 5 finds = C floor with partial credit.
+  /* THE BELL WITH PARTIAL FINDS. Not a fail and not a flat C - see
+     RUBRIC.TIMEOUT_FULL_CREDIT_RATIO. Above the credit line the composite is
+     untouched (the class was played, the bell merely arrived); below it, credit
+     falls away in proportion to how much of the class went unplayed. S is still
+     unreachable, because the sGate below requires `complete`. */
+  const completion = complete ? 1 : clamp01(
+    (finds / findsTarget) / Math.max(0.01, RUBRIC.TIMEOUT_FULL_CREDIT_RATIO)
+  );
   if (!complete) {
-    composite = Math.min(
-      composite * (finds / FINDS_PER_CLASS),
-      RUBRIC.TIMEOUT_COMPOSITE_CEIL
-    );
+    composite = Math.min(composite * completion, RUBRIC.TIMEOUT_COMPOSITE_CEIL);
   }
 
+  /* XP is FLAT PER FIND and capped app-wide, so it saturates part-way through a
+     13-26 find class (find 8 with no jackpots). Deliberate - see RUBRIC. */
   const flavorXp = Math.min(
     RUBRIC.XP_CAP,
     finds * RUBRIC.XP_PER_FIND + Math.max(0, Number(opts.jackpots) || 0) * RUBRIC.XP_PER_JACKPOT
@@ -135,12 +204,16 @@ export function scoreClass(o) {
 
   return {
     composite,
-    hardGates: { sGate: complete && sGateFor({ bestCleanStreak, medianSec, par, misclicks }) },
+    hardGates: {
+      sGate: complete && sGateFor({ bestCleanStreak, medianSec, par, misclicks, findsTarget }),
+    },
     flavorXp,
     medianSec: finds ? medianSec : 0,
     par,
     complete,
+    completion,
     finds,
+    findsTarget,
     parts,
   };
 }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/hud.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/hud.js
@@ -5,7 +5,8 @@
  *
  *  1. EVERY string goes through ctx.lexicon (t(key, fallback)) - the mod skin
  *     changes display strings only, and this game never reads modId. Numbers
- *     (4 / 5, 00:47) are numbers, so they need no key.
+ *     (4 / 26, 00:47) are numbers, so they need no key - but a sentence with a
+ *     number IN it still needs one, with a {n} slot the caller fills.
  *  2. The peek control is BUILT here but OWNED by the shell: we hand the node to
  *     ctx.peek.attach() and never track the A-cap ourselves (peek.js trap 9).
  *     lf_peek_input resolves auto -> tap-toggle on a coarse pointer, else hold.
@@ -16,6 +17,14 @@
 
 import { paintLook } from './board.js';
 import { el } from './util.js';
+
+/** Most tally slots the HUD chip will ever draw. Past this the strip stops
+ *  being one-dot-per-find and becomes a proportional meter of this many
+ *  segments - see setProgress(). The exact count is always in the numerals. */
+const SLOT_CAP = 10;
+/** ...and the same ceiling for the drawn rules-sheet tally, which is a PICTURE
+ *  of "several finds, and she moves between them", not a countable promise. */
+const HOWTO_SLOTS = 6;
 
 function fmtClock(sec) {
   const s = Math.max(0, Math.round(Number(sec) || 0));
@@ -132,11 +141,11 @@ export function createHud(o) {
   /**
    * The class-rules sheet (Law IV: the rules are DRAWN, the words only caption).
    * Three vignettes: her polaroid against a live mini-wall (one tile wears her
-   * exact look via the same paintLook as the board), the five-find tally, and
+   * exact look via the same paintLook as the board), the find tally, and
    * the peek keycap. All motion is CSS animation, so the shell's reduced-motion
    * rule freezes it and the sheet stays readable as a still.
    */
-  function buildHowto(look, onBegin) {
+  function buildHowto(look, onBegin, finds) {
     const node = el('div', 'g-lf-card g-lf-howto');
     if (!node) return null;
     node.appendChild(el('h4', null, t('lf_howto_title', 'Class rules')));
@@ -175,13 +184,18 @@ export function createHud(o) {
     node.appendChild(row([pol, el('span', 'g-lf-hw-eq', '→'), wall],
       t('lf_howto_find', 'She hides on a wall that never sits still. Spot the tile that matches her picture.')));
 
-    /* 2 — the tally: five finds, and she relocates after each */
+    /* 2 — the tally: she relocates after every find, and the class is however
+       many finds this TIER deals (13-26 since the class-length wave). The drawn
+       strip stays HOWTO_SLOTS wide whatever the number - it is a picture of the
+       verb, and the sentence beside it carries the actual count. */
+    const want = Math.max(3, Math.min(HOWTO_SLOTS, Math.round(Number(finds) || HOWTO_SLOTS)));
     const slots = el('span', 'g-lf-hw-slots');
-    for (let i = 0; i < 5 && slots; i++) {
+    for (let i = 0; i < want && slots; i++) {
       slots.appendChild(el('span', 'g-lf-hw-slot' + (i < 2 ? ' on' : i === 2 ? ' next' : '')));
     }
     node.appendChild(row([slots],
-      t('lf_howto_five', 'Every find, she relocates. Catch her five times.')));
+      t('lf_howto_finds_n', 'Every find, she relocates. Catch her {n} times.')
+        .replace('{n}', String(Math.max(1, Math.round(Number(finds) || 0)) || '?'))));
 
     /* 3 — the peek verb (same key label the foot button wears) */
     node.appendChild(row([el('span', 'g-lf-hw-key', coarse ? t('peek', 'Peek') : keyLabel)],
@@ -218,11 +232,29 @@ export function createHud(o) {
     streakMount,
     stampAnchor,
 
-    /** "4 / 5" - numerals need no lexicon row. The tally slots mirror it. */
+    /**
+     * "4 / 26" - numerals need no lexicon row, and THEY are the exact truth.
+     * The tally slots mirror it, but only while one slot per find still fits on
+     * a polaroid: a class is 13-26 finds now (the class-length wave), and 26
+     * slots at 11px + 4px of gap is a 476px strip nailed across the HUD chip.
+     * Above SLOT_CAP the strip becomes a SEGMENT METER of SLOT_CAP segments
+     * lit in proportion, which is why the numerals sit above it - the meter
+     * rounds, the numerals never do.
+     */
     setProgress(found, total) {
       if (tcount) tcount.textContent = found + ' / ' + total;
       if (slots) {
-        const want = Math.max(0, total | 0);
+        const n = Math.max(0, total | 0);
+        const meter = n > SLOT_CAP;
+        const want = meter ? SLOT_CAP : n;
+        // one dot = one find, or one segment = one SLOT_CAP-th of the class
+        const lit = meter
+          ? (found > 0 ? Math.max(1, Math.round((found / Math.max(1, n)) * SLOT_CAP)) : 0)
+          : found;
+        if (slots.classList) {
+          if (meter) slots.classList.add('g-lf-slots-meter');
+          else slots.classList.remove('g-lf-slots-meter');
+        }
         while (slots.children && slots.children.length > want) {
           try { slots.children[slots.children.length - 1].remove(); } catch (e) { break; }
         }
@@ -235,7 +267,7 @@ export function createHud(o) {
         for (let i = 0; i < kids.length; i++) {
           const k = kids[i];
           if (!k || !k.classList) continue;
-          if (i < found) k.classList.add('on'); else k.classList.remove('on');
+          if (i < lit) k.classList.add('on'); else k.classList.remove('on');
         }
       }
     },
@@ -282,10 +314,12 @@ export function createHud(o) {
     },
 
     /** The class-rules sheet. Dismissed ONLY by its own button (a stray click
-     *  on a tutorial must never count as read). Caller owns dim(). */
-    showHowto(look, onBegin) {
+     *  on a tutorial must never count as read). Caller owns dim().
+     *  `finds` = the finds this tier's class asks for; the sheet says the
+     *  number out loud, so it must never be guessed here. */
+    showHowto(look, onBegin, finds) {
       api.hideHowto();
-      howtoCard = buildHowto(look, onBegin);
+      howtoCard = buildHowto(look, onBegin, finds);
       if (view && howtoCard) view.appendChild(howtoCard);
       // THE SHEET ARRIVING. Its three rows paint in ONE frame with no stagger,
       // so the House Book's answer is one `slide`, not a blip ladder.

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -2,9 +2,9 @@
  * games/lost-and-found/index.js - LOST & FOUND (family: search, flagship).
  *
  * Where's Waldo, except the crowd is alive: a dense mosaic of looping tiles
- * drifts, glitches and swaps under you while you hunt one clip five times. The
- * Distraction Engine is the difficulty slider - effect dials rise FIRST, classic
- * difficulty (density, near-twin share) second (GROUND-RULES §6 ordering).
+ * drifts, glitches and swaps under you while you hunt one clip a whole class
+ * long. The Distraction Engine is the difficulty slider - effect dials rise
+ * FIRST, classic difficulty (density, near-twin share) second (§6 ordering).
  *
  * ---------------------------------------------------------------------------
  * WHERE THE RULES LIVE
@@ -17,12 +17,21 @@
  *   styles.js     this game's CSS, namespaced .g-lf-*
  *
  * ---------------------------------------------------------------------------
- * THE FIVE-FIND ARC (synthesis ruling - the class has a beginning/middle/end)
- *   finds 1-2  the tier's baseline board
- *   find  3    THE MODIFIER: the board wakes up (hotter heat, wider swap bursts),
- *              announced, for the rest of the class
- *   find  5    THE FINAL BELL: announced, and the clutch ease ("the board
+ * THE ARC, AND IT IS PER-TIER (synthesis ruling - the class has a beginning /
+ * middle / end; the class-length wave of 2026-08-24 made the LENGTH a tier dial)
+ *   the class is findsForTier(tier) finds:  t1 26  t2 22  t3 16  t4 13,
+ *              all sized to ~250s of typical competent play against a 300s bell
+ *              (constants.js carries the arithmetic)
+ *   first third  the tier's baseline board
+ *   ~1/3 in     THE MODIFIER: the board wakes up (hotter heat, wider swap
+ *              bursts), announced, for the rest of the class
+ *              (modifierFindForTier: 9 / 7 / 5 / 4)
+ *   last find  THE FINAL BELL: announced, and the clutch ease ("the board
  *              relents") is GUARANTEED rather than conditional on the clock
+ *
+ * ONE WALL, MANY FINDS. The target RELOCATES between finds on the same tile
+ * wall, so a longer class costs no extra tiles and no extra look signatures -
+ * density, DENSITY_HARD_CAP and the signature pool are untouched by the wave.
  *
  * TASTE OF THE TWIST (SYNTHESIS #2, from grade_tier 2): the first relocation of
  * the class is telegraphed and slowed once, so the player MEETS the signature
@@ -36,7 +45,7 @@
  * ==========================================================================*/
 
 import {
-  FINDS_PER_CLASS, MODIFIER_AFTER_FIND, FINAL_BELL_FIND, PLAYTEST, TIERS,
+  findsForTier, modifierFindForTier, finalBellFindForTier, PLAYTEST, TIERS,
   MOBILE_DENSITY, HEAT_BAND, MODIFIER_HEAT_STEP, BEAT_MS, TICK_MS,
   ASSEMBLE_STAGGER_MS, CLAIM_TIMEOUT_MS, POOL_OVERPROVISION, DISCRETE_STEP_MS,
   DENSITY_LEVELS, DENSITY_HARD_CAP, DENSITY_COARSE_CAP,
@@ -46,7 +55,7 @@ import { createHud } from './hud.js';
 import { createTrickster } from './trickster.js';
 import { createCasino } from './casino.js';
 import { injectStyles } from './styles.js';
-import { scoreClass } from './grade.js';
+import { scoreClass, sGateStreakFor } from './grade.js';
 import { createTimers, probeReduced, probeCoarse, clamp, clamp01, shuffle } from './util.js';
 
 /* ----------------------------------------------------------------------------
@@ -98,12 +107,18 @@ export default {
   family: 'search',
   // MEATY-ELIGIBLE (orchestrator ruling): Lost & Found fills the timetable's one
   // meaty slot in Semester 1, since The Deep End - the dossier's meaty comfort
-  // class - is not in this build. The class itself is still ~120s; `meaty` only
-  // widens the budget the shell may hand us (up to 300s, BUILD-CONTRACT §7) and
-  // we grade against whatever budget arrives (grade.js parSecFor).
+  // class - is not in this build. `meaty` is what lets the shell hand us the
+  // full 300s (BUILD-CONTRACT §7), and as of the class-length wave (2026-08-24)
+  // we ASK for all of it: the class is a per-tier find count sized to ~250s of
+  // typical competent play, so the bell is a real ceiling instead of decoration.
+  // We still grade against whatever budget actually arrives (grade.js parSecFor)
+  // and start() re-clamps it to 30..300.
+  //
+  // KEEP IN SYNC: games/registry.js GAME_META mirrors this number (it is the
+  // parachute the timetable reads for a suspended class) - CLAUDE.md §2.
   meaty: true,
   flagship: true,
-  timeBudgetSec: 120,
+  timeBudgetSec: 300,
   title: 'Lost & Found',
 
   manifest: {
@@ -156,7 +171,14 @@ export default {
     let dials = TIERS[1];
     let density = 16;
     let zen = false;
-    let budgetSec = 120;
+    let budgetSec = 300;
+    /* THE LENGTH OF THIS CLASS, resolved from the tier in start(). Every arc
+       beat below is a function of these three, never of a literal find number.
+       They are seeded with tier 1's answers so anything that reads them before
+       start() (a harness, a stray tick) sees a coherent class, never a 5. */
+    let findsTarget = findsForTier(1);
+    let modifierFind = modifierFindForTier(1);
+    let bellFind = finalBellFindForTier(1);
     let reduced = false;
     let coarse = false;
 
@@ -205,7 +227,7 @@ export default {
     /* ------------------------------------------------------- small helpers */
     const heatNow = () => clamp01(
       dials.heat
-      + HEAT_BAND * (finds / FINDS_PER_CLASS)
+      + HEAT_BAND * (finds / findsTarget)
       + (modifierOn ? MODIFIER_HEAT_STEP : 0)
       - (clutchOn ? PLAYTEST.CLUTCH_HEAT_EASE : 0)
     );
@@ -834,11 +856,15 @@ export default {
     }
 
     /**
-     * The class-rules sheet, ahead of the briefing. Policy is the shell's
-     * "Skip class tutorials" contract: default shows every class; with the
-     * skip on, a class still explains itself ONCE per grade tier. Dismissal
-     * is the sheet's own button only - peek is already bound, so any key
-     * shortcut here would spend the player's A-cap on a tutorial.
+     * The class-rules sheet, ahead of the briefing. THE LAW, uniform across
+     * every open class (owner ruling 2026-08-24): it SHOWS the first time this
+     * player meets the mosaic at this grade tier and AUTO-SKIPS every later
+     * class at that tier, whatever the setting says; the shell's "Skip class
+     * tutorials" switch (ctx.hideTutorial) means "skip even the first showing".
+     * No meta = no memory = the sheet shows. Dismissal is the sheet's own
+     * button only - peek is already bound, so any key shortcut here would spend
+     * the player's A-cap on a tutorial. The GATE lives at the call site in
+     * start(), because the skip path there is beginClass() itself.
      */
     function howto(onDone) {
       phase = 'briefing';
@@ -858,7 +884,7 @@ export default {
         hud.hideHowto();
         hud.dim(false);
         onDone();
-      });
+      }, findsTarget);        // the sheet SAYS the number, so it is handed it
       if (!cardNode) { done = true; hud.dim(false); onDone(); }
     }
 
@@ -875,8 +901,14 @@ export default {
           if (node && node.style) node.style.opacity = '';
         });
       });
-      hud.showBriefing(targetLook(), t('lf_briefing', 'Memorize her, then find her five times.'));
-      hud.setProgress(0, FINDS_PER_CLASS);
+      // The count is a NUMBER in the sentence now, so the row carries a {n} slot
+      // and a new key (the old lf_briefing row still says "five times" in every
+      // shipped lexicon - reusing it would have printed the old number).
+      hud.showBriefing(
+        targetLook(),
+        t('lf_briefing_n', 'Memorize her, then find her {n} times.').replace('{n}', String(findsTarget))
+      );
+      hud.setProgress(0, findsTarget);
       hud.setChips(0, 0);
 
       const previewMs = Math.round(dials.previewSec * 1000);
@@ -964,13 +996,13 @@ export default {
       findStartedAt = Date.now();
       findPausedBase = pausedMs;
       if (hud) {
-        hud.setProgress(finds, FINDS_PER_CLASS);
+        hud.setProgress(finds, findsTarget);
         hud.dim(false);
       }
       if (board) { board.freeze(false); board.clearMark('g-lf-found'); }
       setHeat();
       armPity();
-      if (finds + 1 === FINAL_BELL_FIND && !bellRung) {
+      if (finds + 1 === bellFind && !bellRung) {
         bellRung = true;
         if (casino) casino.bell(true);       // the frame goes gold for the last hunt
         announce(t('lf_final_bell', 'Final bell'), 2000);
@@ -1012,7 +1044,7 @@ export default {
       const left = secLeft();
       hud.setClock(left);
       if (left <= 0) { finish(false); return; }
-      if (finds === FINDS_PER_CLASS - 1 && left <= PLAYTEST.CLUTCH_SEC_LEFT) clutch();
+      if (finds === findsTarget - 1 && left <= PLAYTEST.CLUTCH_SEC_LEFT) clutch();
     }
 
     /* --------------------------------------------------------------- clicks */
@@ -1036,9 +1068,13 @@ export default {
       findTimes.push(took);
       finds += 1;
       /* THE CONFIRM: the press that lands her, on the beat of the press. The
-         pitch climbs one step per find, so the class audibly ladders up its own
-         arc (five finds = five rungs; the cap is there for a longer budget). */
-      cue('pop', 0.45, { pitch: Math.min(1.5, 1 + 0.06 * (finds - 1)) });
+         pitch climbs across the WHOLE class - first find at 1.0, last find at
+         1.5, however many finds this tier deals. It used to be a flat +0.06 a
+         find against a cap of 1.5, which at 13-26 finds pinned the ladder at the
+         top from find 9 onward and spent two thirds of the class saying the same
+         thing. */
+      const arc = findsTarget > 1 ? (finds - 1) / (findsTarget - 1) : 1;
+      cue('pop', 0.45, { pitch: Math.min(1.5, 1 + 0.5 * arc) });
       if (cleanThisFind) {
         cleanStreak += 1;
         if (cleanStreak > bestCleanStreak) bestCleanStreak = cleanStreak;
@@ -1052,25 +1088,35 @@ export default {
       /* ---- the found ceremony (board dims, target spotlights, sting) ---- */
       if (hud) {
         hud.dim(true);
-        hud.setProgress(finds, FINDS_PER_CLASS);
+        hud.setProgress(finds, findsTarget);
         hud.showSpot(targetLook(), t('lf_found', 'Found her'));
       }
       if (board) { board.freeze(true); board.mark(tile, 'g-lf-found', true); }
       // THE SPOTLIGHT: the ceremony's own sting, ducking everything under it.
-      cue('sting', clamp01(0.45 + 0.05 * cleanStreak), { duck: 'spotlight' });
+      // The streak term is WINDOWED at five, or a long class would sit pinned at
+      // 1.0 from the fifth clean find on and the sting would stop meaning it.
+      cue('sting', clamp01(0.45 + 0.05 * Math.min(cleanStreak, 5)), { duck: 'spotlight' });
       // THE CHIME LADDER (Deck II): each find stacks one more rising layer on
       // the sting, so the class gets audibly richer as it climbs. Capped at 4
-      // layers; the fifth find pays its own way (the royal jackpot below).
+      // layers; the LAST find pays its own way (the royal jackpot below). The
+      // level rides class PROGRESS, not the raw find count - a flat per-find
+      // term clipped to 1.0 two thirds of the way through a 26-find class.
       for (let L = 0; L < Math.min(finds, 4); L++) {
         timers.after(110 * (L + 1), () => {
-          cue('streak', clamp01(0.2 + 0.07 * L + 0.03 * finds));
+          cue('streak', clamp01(0.2 + 0.07 * L + 0.15 * (finds / findsTarget)));
         });
       }
-      if (casino) casino.payout(finds);   // one pulse of the frame, brighter up the ladder
+      // one pulse of the frame, brighter up the ladder - the ladder is the whole
+      // class, so the frame is told how long the class is
+      if (casino) casino.payout(finds, findsTarget);
       try { ctx.ceremonies.stamp({ text: t('lf_found', 'Found her'), target: hud && hud.stampAnchor }); } catch (e) { /* optional */ }
-      try { ctx.ceremonies.streakMeter({ target: hud && hud.streakMount, filled: cleanStreak, gold: cleanStreak >= 3 }); } catch (e) { /* optional */ }
+      // GOLD IS THE S GATE'S OWN STREAK, not a flat 3. On a 26-find class three
+      // clean finds in a row is Tuesday; the gate number (8/7/5/4 by tier) is
+      // the streak that is actually buying the player something.
+      const goldStreak = sGateStreakFor(findsTarget);
+      try { ctx.ceremonies.streakMeter({ target: hud && hud.streakMount, filled: cleanStreak, gold: cleanStreak >= goldStreak }); } catch (e) { /* optional */ }
       if (!reduced) {
-        try { ctx.engine.sustain('ambient_field', { kind: cleanStreak >= 3 ? 'goldleaf' : 'confetti' }); } catch (e) { /* optional */ }
+        try { ctx.engine.sustain('ambient_field', { kind: cleanStreak >= goldStreak ? 'goldleaf' : 'confetti' }); } catch (e) { /* optional */ }
         timers.after(900, () => { try { ctx.engine.stop('ambient_field'); } catch (e) { /* ignore */ } });
       }
 
@@ -1078,10 +1124,10 @@ export default {
       /* The LEDGER half of this block is untouched by Deck II: the roll still
          happens on every find and `jackpots` (graded, XP_PER_JACKPOT) still
          moves only when the canon says jackpot. What Deck II changes is the
-         SHOW on the fifth find: the final bell always pays a ROYAL jackpot
+         SHOW on the LAST find: the final bell always pays a ROYAL jackpot
          visual at intensity 1.0 - engine jackpotSpec's own rarity dial - and a
          same-find canon jackpot folds into it instead of playing twice. */
-      const finalFind = finds >= FINDS_PER_CLASS;
+      const finalFind = finds >= findsTarget;
       let roll = null;
       try { roll = reward.roll({ heat: heatNow(), success: true, streak: cleanStreak }); } catch (e) { roll = null; }
       if (roll && roll.jackpot) jackpots += 1;
@@ -1097,7 +1143,7 @@ export default {
       }
 
       /* ---- the arc ------------------------------------------------------- */
-      if (finds >= MODIFIER_AFTER_FIND && !modifierOn) {
+      if (finds >= modifierFind && !modifierOn) {
         modifierOn = true;
         announce(t('lf_modifier', 'The board wakes up'), 2000);
         say('modifier engaged after find ' + finds);
@@ -1107,7 +1153,7 @@ export default {
       timers.after(ceremonyMs, () => {
         if (phase === 'done') return;
         if (hud) hud.hideSpot();
-        if (finds >= FINDS_PER_CLASS) { finish(true); return; }
+        if (finds >= findsTarget) { finish(true); return; }
         relocate();
         // the churn resumes unless the board has already relented
         if (!clutchOn) churnTimer = timers.every(dials.swapMs, () => { if (!halted) noiseSwap(); });
@@ -1200,6 +1246,10 @@ export default {
         bestCleanStreak,
         density,
         drift: dials.drift,
+        // the length of THIS class - every scaled threshold in grade.js hangs
+        // off it, and the par clamp needs the ceremony overhead it implies
+        findsTarget,
+        ceremonySec: (reduced ? PLAYTEST.FOUND_CEREMONY_MS_REDUCED : PLAYTEST.FOUND_CEREMONY_MS) / 1000,
         timeBudgetSec: zen ? null : budgetSec,
         jackpots,
       });
@@ -1211,7 +1261,7 @@ export default {
         cue('stamp_bad', 0.3);
       }
 
-      say('class over: ' + finds + '/' + FINDS_PER_CLASS + ' finds, median '
+      say('class over: ' + finds + '/' + findsTarget + ' finds, median '
         + score.medianSec.toFixed(1) + 's (par ' + score.par.toFixed(1) + 's), '
         + misclicks + ' misses, ' + peeks + ' peeks, best clean ' + bestCleanStreak
         + ', ' + relocations + ' relocations, composite ' + score.composite.toFixed(3)
@@ -1266,7 +1316,15 @@ export default {
         const spec = classSpec || {};
         tier = clamp(Math.round(Number(spec.gradeTier) || 1), 1, 4);
         dials = TIERS[tier] || TIERS[1];
-        budgetSec = clamp(Number(spec.timeBudgetSec) || 120, 30, 300);
+        // THE LENGTH OF THE CLASS is the tier's, and it is resolved exactly once
+        // here so no beat below can disagree with another about how long the
+        // class is (constants.js carries the pacing arithmetic).
+        findsTarget = findsForTier(tier);
+        modifierFind = modifierFindForTier(tier);
+        bellFind = finalBellFindForTier(tier);
+        // The fallback is the module's own declared budget, not a stale 120: a
+        // spec with no budget must not deal a 26-find class two minutes.
+        budgetSec = clamp(Number(spec.timeBudgetSec) || 300, 30, 300);
         zen = !!(ctx.settings && ctx.settings.lf_zen);
         reduced = probeReduced();
         coarse = probeCoarse();
@@ -1295,7 +1353,11 @@ export default {
         trickster = createTrickster({
           seed: String(spec.seed || 'lf'),
           tier,
-          budgetSec: zen ? 180 : budgetSec,
+          // zen has no bell, so the deck is given a NOMINAL span to spread its
+          // cards across - the length of the same class played timed. It was
+          // 180s when the class was 5 finds; a zen class is the tier's full
+          // find count now, so cards would have stopped two thirds of the way in
+          budgetSec: zen ? 300 : budgetSec,
           timers, board, hud, reduced, coarse,
           // A player who capped effects off gets no trickery either (Law VI).
           capsOk: !(ctx.caps && Number(ctx.caps.bgIntensity) === 0),
@@ -1327,7 +1389,8 @@ export default {
 
         say('class start: tier ' + tier + ', density ' + density + '/' + dials.density
           + (coarse ? ' (coarse)' : '') + (reduced ? ' (reduced motion)' : '')
-          + ', budget ' + (zen ? 'zen' : budgetSec + 's'));
+          + ', budget ' + (zen ? 'zen' : budgetSec + 's')
+          + ', ' + findsTarget + ' finds (modifier ' + modifierFind + ', bell ' + bellFind + ')');
 
         // learn the display's true frame interval while the wall is still
         // cheap - the briefing frames are the cleanest baseline we ever get
@@ -1341,9 +1404,13 @@ export default {
           beginHunt();
           if (hud) hud.setClock(zen ? null : budgetSec);
         });
-        // Rules sheet first. ctx.hideTutorial is the shell's "Skip class
-        // tutorials" switch (absent on old harnesses -> falsy -> always show).
-        if (ctx.hideTutorial && howtoSeenTiers().indexOf(tier) >= 0) beginClass();
+        // Rules sheet first, and it is FREE OF THE CLOCK: clockStartedAt is
+        // taken inside beginClass, on the far side of GO and the briefing.
+        // AUTO-SKIP once this tier is on the record; ctx.hideTutorial (the
+        // shell's "Skip class tutorials" switch, absent on old harnesses ->
+        // falsy) skips the first showing too. Both skip paths are the same
+        // instant dismiss the sheet's own GO performs: beginClass().
+        if (ctx.hideTutorial || howtoSeenTiers().indexOf(tier) >= 0) beginClass();
         else howto(beginClass);
       },
 
@@ -1379,7 +1446,8 @@ export default {
       diagnostics() {
         return {
           phase, tier, density, zen, budgetSec, reduced, coarse,
-          finds, misclicks, misclickStreak, cleanStreak, bestCleanStreak,
+          finds, findsTarget, modifierFind, bellFind,
+          misclicks, misclickStreak, cleanStreak, bestCleanStreak,
           jackpots, relocations, findTimes: findTimes.slice(),
           modifierOn, bellRung, clutchOn, tasteShown,
           heat: heatNow(), secLeft: zen ? null : secLeft(),

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/styles.js
@@ -66,10 +66,15 @@ export const CSS = [
   '.g-lf-tchip small { font-size:10px; letter-spacing:.12em; text-transform:uppercase;',
   '  color:var(--pink); font-family:var(--disp); display:block; }',
   '.g-lf-tchip b { font-family:var(--mono); font-size:12px; color:var(--ink); }',
-  /* The find tally: one slot per find, stamped pink as each is claimed. */
+  /* The find tally: one slot per find, stamped pink as each is claimed - until
+     the class is longer than hud.js's SLOT_CAP (13-26 finds since the
+     class-length wave), when the same strip becomes a ten-segment METER filled
+     in proportion. Same slots, narrower and tighter, so the chip never grows. */
   '.g-lf-slots { display:flex; gap:4px; margin-top:3px; }',
   '.g-lf-slot { width:11px; height:13px; border-radius:2px; border:1px solid var(--line);',
   '  background:var(--flap-well); display:inline-block; }',
+  '.g-lf-slots-meter { gap:2px; }',
+  '.g-lf-slots-meter .g-lf-slot { width:7px; height:11px; border-radius:1px; }',
   '.g-lf-slot.on { background:var(--pink); border-color:var(--pink);',
   '  box-shadow:0 0 7px rgba(255,105,180,.7); animation:g-lf-slotpop .35s cubic-bezier(.2,1.5,.4,1) 1; }',
   '@keyframes g-lf-slotpop { 0% { transform:scale(.4); } 60% { transform:scale(1.25); } 100% { transform:scale(1); } }',

--- a/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/registry.js
@@ -15,10 +15,18 @@
  * keeps that wing taped shut. That is the one-line release gate: ship a semester
  * dark by dropping its number from the set, open it by putting the number back.
  *
- * STATIC DESCRIPTORS. The timetable needs {family, meaty, flagship, timeBudgetSec}
- * for a game even when its module failed to load, so they live here as a fallback
- * table; a module that loads successfully overrides them with its own exported
- * values (the module is the source of truth, this table is the parachute).
+ * STATIC DESCRIPTORS. The timetable needs {family, meaty, flagship, timeBudgetSec,
+ * clockless} for a game even when its module failed to load, so they live here as
+ * a fallback table; a module that loads successfully overrides them with its own
+ * exported values (the module is the source of truth, this table is the parachute).
+ *
+ * TWO OF THOSE FIVE ARE NOT WHAT THEIR NAMES SUGGEST (the class-length wave):
+ *   `meaty`     is the ANCHOR-SLOT flag, not a length. The timetable deals
+ *               exactly one anchor class a night; it says nothing about seconds
+ *               and no module branches on it.
+ *   `clockless` is a class that runs a budget but SHOWS no clock - no seconds
+ *               chip on the board, on the room card or in the proctor strip,
+ *               and no time bar over the stage. Daily Trigger only, today.
  *
  * TIER PROMOTION (shell rule, not per-game): tier = 1 + floor(promotions / 2),
  * capped at 4; a class promotes on an S or an A. Stored per game in the meta
@@ -44,40 +52,50 @@ export const GAME_PATHS = Object.freeze({
 
 /** Fallback descriptors (see header). Families per SYNTHESIS #3. */
 export const GAME_META = Object.freeze({
-  daily_trigger: { family: 'word', meaty: false, flagship: true, timeBudgetSec: 90 },
+  /* CLOCKLESS (owner ruling, the class-length wave): homeroom keeps its ~1-min
+     wordle shape and its 90s bell, but the seconds are never SHOWN - the ritual
+     is the board and the six rows, not a countdown. Mirrors the module's own
+     export, same parachute law as meaty below. */
+  daily_trigger: { family: 'word', meaty: false, flagship: true, timeBudgetSec: 90, clockless: true },
   // MEATY: mirrors the module's own export. This table is only the parachute the
   // suspended stub flies under, but the timetable reads a suspended class's
   // descriptor too, so a mismatch would quietly change the day's shape on the one
   // day the import fails.
-  lost_and_found: { family: 'search', meaty: true, flagship: true, timeBudgetSec: 120 },
-  deja_vu: { family: 'memory', meaty: false, flagship: false, timeBudgetSec: 90 },
+  lost_and_found: { family: 'search', meaty: true, flagship: true, timeBudgetSec: 300 },
+  deja_vu: { family: 'memory', meaty: false, flagship: false, timeBudgetSec: 300 },
   impulse_control: { family: 'reflex', meaty: false, flagship: false, timeBudgetSec: 90 },
   // MEATY, same law as lost_and_found above: this row must equal the module's own
   // exports, because the timetable reads a SUSPENDED class's descriptor too and a
   // mismatch would quietly reshape the day on the one day the import fails.
-  // The Deep End is the second meaty class (DECISIONS #3's 300s slot) and the first
-  // Semester III class brought forward - family 'comfort', never a flagship.
+  // The Deep End is the second ANCHOR class and the first Semester III class
+  // brought forward - family 'comfort', never a flagship. 300s is its own
+  // module's budget, not a privilege the anchor flag grants it.
   the_deep_end: { family: 'comfort', meaty: true, flagship: false, timeBudgetSec: 300 },
   /* Semester II. Families per SYNTHESIS #3; 'recall' joins the list with Instant
      Recall (core/lexicon.js has no family_recall/family_puzzle row yet, so the
      chip degrades to the de-snaked key - readable English, never a raw token). */
   misdirection: { family: 'tracking', meaty: false, flagship: false, timeBudgetSec: 120 },
   /* SORT inherited Misdirection's family AND its room number, not its room
-     (lot 2 razed the parlour; sort is room 201 by the Main Gate). Not meaty: 120s is the
-     class, and the pile-picking DOOR runs outside the clock (shell S3), so the
-     budget here is the sorting itself and nothing else. */
-  sort: { family: 'tracking', meaty: false, flagship: false, timeBudgetSec: 120 },
-  echo: { family: 'memory', meaty: false, flagship: false, timeBudgetSec: 105 },
-  // MEATY (ruled 2026-08-23): the third meaty class. With ten games no-repeat-3 binds again
-  // and outranks the meaty preference, so two meaty classes left ~a third of nights with the
-  // slot unfilled (trap 6 re-opened); see composure below for the full count. Mirrors the module's own export.
-  instant_recall: { family: 'recall', meaty: true, flagship: false, timeBudgetSec: 120 },
+     (lot 2 razed the parlour; sort is room 201 by the Main Gate). Never the
+     night's anchor class, and the pile-picking DOOR runs outside the clock
+     (shell S3), so the 180s here is the sorting itself and nothing else.
+     120 -> 180 in the class-length wave: the room is bell-driven end to end, so
+     the budget scales the clock and nothing else - the deck, the media claim and
+     the trickster window all moved with it inside the module. */
+  sort: { family: 'tracking', meaty: false, flagship: false, timeBudgetSec: 180 },
+  echo: { family: 'memory', meaty: false, flagship: false, timeBudgetSec: 120 },
+  // MEATY (ruled 2026-08-23): the third ANCHOR class. With ten games no-repeat-3 binds again
+  // and outranks the meaty preference, so two anchor classes left ~a third of nights with the
+  // slot unfilled (trap 6 re-opened); see composure below for the full count. The flag is a
+  // timetable fact and never a length - the vigil runs 180s, shorter than several non-anchor
+  // classes on the same board. Mirrors the module's own export.
+  instant_recall: { family: 'recall', meaty: true, flagship: false, timeBudgetSec: 180 },
   /* Semester III (The Deep End above was brought forward). */
-  anomaly: { family: 'search', meaty: false, flagship: false, timeBudgetSec: 90 },
-  // MEATY (ruled 2026-08-23, same reason as instant_recall): four meaty classes (L&F, The Deep
-  // End, Instant Recall, Composure) are what it takes for a no-repeat-3 pool to deal one meaty
+  anomaly: { family: 'search', meaty: false, flagship: false, timeBudgetSec: 300 },
+  // MEATY (ruled 2026-08-23, same reason as instant_recall): four ANCHOR classes (L&F, The Deep
+  // End, Instant Recall, Composure) are what it takes for a no-repeat-3 pool to deal one anchor
   // class EVERY night (measured 28/28; three gave 21/28). Mirrors the module's own export.
-  composure: { family: 'puzzle', meaty: true, flagship: false, timeBudgetSec: 120 },
+  composure: { family: 'puzzle', meaty: true, flagship: false, timeBudgetSec: 300 },
 });
 
 /**
@@ -188,6 +206,7 @@ function suspendedStub(key, reason) {
     meaty: !!(GAME_META[key] && GAME_META[key].meaty),
     flagship: !!(GAME_META[key] && GAME_META[key].flagship),
     timeBudgetSec: (GAME_META[key] && GAME_META[key].timeBudgetSec) || 90,
+    clockless: !!(GAME_META[key] && GAME_META[key].clockless),
     suspended: true,
     manifest: { effectsConsumed: [], assetNeeds: null, boardSizes: null, keybinds: null, settings: [], peek: false },
     create(ctx) {
@@ -281,6 +300,10 @@ export async function loadGames(log) {
       meaty: mod.meaty != null ? !!mod.meaty : !!fallback.meaty,
       flagship: mod.flagship != null ? !!mod.flagship : !!fallback.flagship,
       timeBudgetSec: mod.timeBudgetSec || fallback.timeBudgetSec || 90,
+      /* `clockless` is a TRISTATE read like meaty/flagship, not an `||` like the
+       * budget: a module that exports `clockless: false` must be able to say so
+       * over a parachute row that says true. */
+      clockless: mod.clockless != null ? !!mod.clockless : !!fallback.clockless,
     };
     list.push(entry);
     byKey[key] = entry;
@@ -295,7 +318,8 @@ export async function loadGames(log) {
 /** Descriptors for core/timetable.js - never the modules themselves. */
 export function descriptors(list) {
   return (Array.isArray(list) ? list : []).map((e) => ({
-    key: e.key, family: e.family, meaty: e.meaty, flagship: e.flagship, timeBudgetSec: e.timeBudgetSec,
+    key: e.key, family: e.family, meaty: e.meaty, flagship: e.flagship,
+    timeBudgetSec: e.timeBudgetSec, clockless: !!e.clockless,
   }));
 }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/casino.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/casino.js
@@ -96,7 +96,15 @@ export const CASINO = Object.freeze({
   /** THE REVEAL, and the badge's own life. */
   REVEAL_MS: 620,
   BADGE_MS: 1100,
-  /** The full jackpot show is spent after this many; the royal is exempt. */
+  /** The full jackpot show is spent after this many; the royal is exempt.
+   *  UNCHANGED at the 180s budget, on purpose. This is a SCARCITY, not a rate:
+   *  it is shared by the three MAJOR_RUNGS (chain.js: 3 / 5 / 7, which are
+   *  streak-triggered at 8 / 16 / 27 clean swipes and so still land inside the
+   *  first ~30 cards however long the class runs) and by every minor roll after
+   *  them. A longer class therefore spends the three full shows on its climb
+   *  exactly as before and pays the extra minutes in payout lights and deeper
+   *  chimes - which is the whole point of the budget. Raising it would make the
+   *  interruption the room's default rather than its ceiling. */
   FULL_SHOWS: 3,
   /** The chime STACK: an octave under from rung 3, a third over from rung 6. */
   LOW_FROM_RUNG: 3,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/deck.js
@@ -2,7 +2,7 @@
  * games/sort/deck.js - THE DECK. PURE, seeded, and the ONLY place that decides
  * which side of the room a card belongs on.
  *
- * SORT deals 60 / 70 / 80 / 80 cards by grade tier, 55% of them TARGET, the
+ * SORT deals 90 / 105 / 120 / 120 cards by grade tier, 55% of them TARGET, the
  * rest NOISE, interleaved off the class seed with a run cap of 4 (3 at tier 4)
  * so the room never turns into "press right eleven times". Loops are preferred
  * 60/40 over stills wherever a source has both, because a still stack reads as
@@ -30,8 +30,16 @@
 export const DECK = Object.freeze({
   /** Share of the deck that is TARGET (the right pile). */
   TARGET_SHARE: 0.55,
-  /** Cards dealt, by grade tier. */
-  SIZE_BY_TIER: Object.freeze({ 1: 60, 2: 70, 3: 80, 4: 80 }),
+  /** Cards dealt, by grade tier.
+   *  THE DECK IS A COUNT AND THE CLASS IS A CLOCK, so the two have to move
+   *  together. At the 180s budget (the class-length wave; it was 120s and
+   *  60/70/80/80) a competent player sees roughly 148 cards at tier 1 and 200
+   *  at tier 4, so 90/105/120/120 distinct rows is ~1.6-1.7 passes over the
+   *  deck - the same "you start meeting cards again near the end" feel the
+   *  120s class had at 60/80. Repeats are not a failure here (nextCard()
+   *  reshuffles for ever and the SEEN trickster wants them); the size is only
+   *  how long the room stays fresh. */
+  SIZE_BY_TIER: Object.freeze({ 1: 90, 2: 105, 3: 120, 4: 120 }),
   /** Longest run allowed on one side, by grade tier. */
   MAX_RUN_BY_TIER: Object.freeze({ 1: 4, 2: 4, 3: 4, 4: 3 }),
   /** Preference roll toward a loop when a source has both kinds. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/grade.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/grade.js
@@ -22,6 +22,14 @@
  * playing the game the room is about).
  *
  * FLAVOUR XP: sorted / 5, cap 15. Game-owned; the XP table itself is C#'s.
+ *
+ * THE CLASS LENGTH IS NOT IN THIS FILE. Every term above is a RATIO of the
+ * class's own ledger (correct/swipes, bestRung/rungCap, perfect/correct), so
+ * the 120 -> 180 budget move needs nothing here and cannot tilt a grade: a
+ * longer class gives a player more swipes to be accurate over, never an easier
+ * bar. The one absolute is the flavour XP cap, and it stays 15 deliberately -
+ * the XP economy is not part of the class-length wave, and a 120s class already
+ * reached the cap at 75 sorted cards.
  * ==========================================================================*/
 
 export const GRADE = Object.freeze({

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -1,5 +1,5 @@
 /* ============================================================================
- * games/sort/index.js - SORT: room 201, East Wing. Family tracking, 120s, not
+ * games/sort/index.js - SORT: room 201, East Wing. Family tracking, 180s, not
  * meaty. BUILD-CONTRACT module.
  *
  * A stack of three cards breathes centre stage. Drag right for YOURS, left for
@@ -52,7 +52,13 @@
  *
  * CLOCK. `now()` and the timer helpers resolve `performance` / `setTimeout` off
  * the global at CALL time, so a scratch harness can swap in a fake clock and
- * drive a whole 120s class in milliseconds with no test-only code in here.
+ * drive a whole 180s class in milliseconds with no test-only code in here.
+ *
+ * THE BUDGET IS THE ONLY LENGTH DIAL. This room is bell-driven end to end -
+ * `paintClock` rings at `budgetMs` and `nextCard` reshuffles for ever - so the
+ * clock scales by itself. The three things that were COUNTS sized for the old
+ * 120s bell moved with it in the class-length wave: deck.js's SIZE_BY_TIER, the
+ * media claim below, and trickster.js's deal window.
  * ==========================================================================*/
 
 import { makeRng, hash01, shuffled } from '../../core/rng.js';
@@ -177,19 +183,37 @@ function isVideoUrl(url, mime) {
   if (mime && /^video\//i.test(String(mime))) return true;
   return /\.(mp4|webm|m4v|mov)(\?|#|$)/i.test(String(url || ''));
 }
+/** m:ss for a remaining-ms figure. The HUD's opening face and every tick after
+ *  it come through here, so the chip can never disagree with the clock. */
+function clockFace(leftMs) {
+  const secs = Math.ceil(Math.max(0, Number(leftMs) || 0) / 1000);
+  return Math.floor(secs / 60) + ':' + String(secs % 60).padStart(2, '0');
+}
 
 /* -------------------------------------------------------------- the dials -- */
+/** THE CLASS LENGTH, and the ONE place this file writes it. The module export
+ *  below reads it, so does the HUD clock's opening face - a hard-coded '2:00'
+ *  on the chip was the 120s bell's last hiding place, and it sat on screen for
+ *  the whole door and rules sheet before paintClock ever ran. registry.js
+ *  GAME_META.sort mirrors the number (the parachute law). */
+const BUDGET_SEC = 180;
 const RING_TICK_MS = 50;
 const RING_TICK_MS_REDUCED = 100;
 const SPRING_MS = SWIPE.SPRING_MS;
 const INTRO_MS = 900;
 const AUTO_SUBMIT_MS = 45000;
-/** Live <video> nodes this class may hold at once (trap 36). */
+/** Live <video> nodes this class may hold at once (trap 36). A CONCURRENCY
+ *  ceiling, not a supply one: the stack is three cards deep whatever the class
+ *  is long, so a bigger claim never asks for a third decode. Stays 2. */
 const DECODER_CEILING = 2;
-/** Rows the provider preloads ahead, per tag. */
+/** Rows the provider preloads ahead, per tag. Also a look-ahead and not a
+ *  supply figure - six rows in front of a cursor is six rows whether the deck
+ *  is 60 long or 120. Stays 6. */
 const PREWARM = 6;
-/** The claim, when the door never resolved one for us (QUICK SORT floor). */
-const QUICK_CLAIM = Object.freeze({ loops: 48, stills: 32, canvasSafe: false });
+/** The claim, when the door never resolved one for us (QUICK SORT floor).
+ *  Moved 48/32 -> 72/48 with the deck (see claimOpts): a 120-card tier-4 deck
+ *  fed by an 80-row claim would be repeats before the bell. */
+const QUICK_CLAIM = Object.freeze({ loops: 72, stills: 48, canvasSafe: false });
 /** How hard a minor jackpot rolls on a PERFECT at rung 2 or above. */
 const MINOR_CHANCE = 0.16;
 /** A cue's level may never exceed the tier's ceiling. */
@@ -207,7 +231,9 @@ export default {
   family: 'tracking',
   meaty: false,
   flagship: false,
-  timeBudgetSec: 120,
+  /* 180s since the class-length wave (was 120s). registry.js GAME_META.sort
+     mirrors this - the timetable reads a SUSPENDED class's descriptor too. */
+  timeBudgetSec: BUDGET_SEC,
   title: 'Sort',
 
   manifest: {
@@ -424,7 +450,11 @@ export default {
     function claimOpts(resolved) {
       return {
         sources: (resolved && Array.isArray(resolved.sources)) ? resolved.sources : [],
-        want: { loops: 48, stills: 32 },
+        /* A HINT, and it tracks DECK.SIZE_BY_TIER: 120 rows for the 120-card
+           tier-4 deck (was 80 for the 80-card / 120s one). The provider still
+           resolves on perSourceMin per tag, so a small library is not a
+           failure - it is a THIN pile and the door already said so. */
+        want: { loops: 72, stills: 48 },
         perSourceMin: DECK.PER_SOURCE_MIN,
         /* The provider re-serves a dry tag in a SEEDED shuffle, so this string
          * has to be stable for a day or a retake would re-serve differently.
@@ -599,7 +629,8 @@ export default {
       const hud = el('div', 'g-sort-hud');
       const chipChain = chip('is-chain', t('sort_chip_chain', 'Chain'), '0');
       const chipSorted = chip('is-sorted', t('sort_chip_sorted', 'Sorted'), '0');
-      const chipClock = chip('is-clock', t('sort_chip_clock', 'Time left'), '2:00');
+      const chipClock = chip('is-clock', t('sort_chip_clock', 'Time left'),
+        clockFace(BUDGET_SEC * 1000));
       const ladder = el('div', 'g-sort-ladder');
       const rungs = [];
       for (let i = 0; i <= CHAIN.MAX_RUNG; i++) {
@@ -809,8 +840,9 @@ export default {
       if (S.cursor >= S.cards.length) {
         /* THE PASSES COME BACK FIRST, then the deck is re-shuffled and walked
          * again. Repeats are fine in a sort - they are the whole reason the
-         * SEEN trickster is free - and a 0.75s ring burns 160 cards in 120s,
-         * so a deck that could run out would be a room that stopped. */
+         * SEEN trickster is free - and a 0.75s ring burns ~200 cards in 180s
+         * against a 120-card deck, so a deck that could run out would be a room
+         * that stopped. Recycling is the design, not the shortfall. */
         if (S.passQueue.length) {
           const back = S.passQueue.splice(0, S.passQueue.length);
           S.cards = S.cards.concat(back);
@@ -1130,12 +1162,13 @@ export default {
     function paintClock() {
       if (!S || !S.nodes || !S.nodes.chipClock) return;
       const left = Math.max(0, S.budgetMs - (now() - S.startedAt));
-      const secs = Math.ceil(left / 1000);
-      const mm = Math.floor(secs / 60);
-      const ss = String(secs % 60).padStart(2, '0');
-      S.nodes.chipClock.set(mm + ':' + ss);
+      S.nodes.chipClock.set(clockFace(left));
       if (S.budgetMs > 0 && left <= 0) bell();
     }
+    /* HEAT IS A RATIO, NOT A STOPWATCH: `progress` is elapsed over the class's
+     * OWN budget and the rung term is a fraction of MAX_RUNG, so the 120 -> 180
+     * budget move stretches the same curve over a longer class rather than
+     * changing its shape. Nothing here needed a number. */
     function heat() {
       if (!S) return 0;
       const progress = S.budgetMs > 0 ? clamp01((now() - S.startedAt) / S.budgetMs) : 0;
@@ -1155,9 +1188,15 @@ export default {
 
     /* ==================================================================== *
      * THE RULES SHEET. SORT's rulebook is the ghost round at the door, so
-     * this is deliberately one drawn card between two words. Shown every
-     * class by default; with "Skip class tutorials" on, still ONCE PER TIER
-     * (the shell's contract, and the memory is the game's own).
+     * this is deliberately one drawn card between two words. THE LAW, uniform
+     * across every open class (owner ruling 2026-08-24): it SHOWS the first
+     * time this player meets the room at this grade tier and AUTO-SKIPS every
+     * later class at that tier, whatever the setting says; "Skip class
+     * tutorials" (ctx.hideTutorial) means "skip even the first showing". The
+     * memory is the game's own, and no meta = no memory = the sheet shows.
+     * The sheet is FREE OF THE CLOCK - openClass()'s GO callback is where
+     * S.startedAt is taken, and the setup door before it is outside the
+     * budget too.
      * ==================================================================== */
     function howtoSeenTiers() {
       const m = metaOf();
@@ -1165,7 +1204,7 @@ export default {
     }
     function howto(onDone) {
       const seen = howtoSeenTiers();
-      if (ctx.hideTutorial === true && seen.indexOf(S.gradeTier) >= 0) { onDone(); return; }
+      if (ctx.hideTutorial === true || seen.indexOf(S.gradeTier) >= 0) { onDone(); return; }
       const veil = el('div', 'g-sort-howto');
       const card = el('div', 'g-sort-howto-card');
       if (!veil || !card) { onDone(); return; }
@@ -1262,6 +1301,13 @@ export default {
         howtoEl: null, endEl: null, result: null,
         thin: false, hot: !!pending.hot,
       };
+
+      /* THE CHIP TELLS THE TRUTH FROM THE FIRST FRAME. mount() drew it with
+         this module's own budget; the shell may hand a class a different one
+         (a retake, a harness, a future short period), and the clock does not
+         start ticking until openRoom(), so paint the real figure now. */
+      try { if (nodes.chipClock) nodes.chipClock.set(clockFace(S.budgetMs)); }
+      catch (e) { /* a chip that will not paint is not a class */ }
 
       const fade = Number(settingOf('sort_bg_fade', 0.35));
       const capBg = (() => { try { return Number(ctx.caps && ctx.caps.bgIntensity); } catch (e) { return 1; } })();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/setup.js
@@ -2,7 +2,7 @@
  * games/sort/setup.js - THE DOOR. Room 201's setup + tutorial, and the only
  * place the player chooses what SORT means tonight.
  *
- * It runs OUTSIDE the 120s class clock (shell/shell.js calls instance.setup()
+ * It runs OUTSIDE the 180s class clock (shell/shell.js calls instance.setup()
  * after create() and before beginPlay()), so it can afford to explain itself.
  * Five steps, and every one shows before it tells:
  *

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/trickster.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/trickster.js
@@ -46,6 +46,17 @@
  * a first-sighting for the doppelganger) waits for one more card and then
  * folds. A retake replays the identical deal.
  *
+ * THE WINDOW IS THE CLASS, NOT A CONSTANT. The slots are card INDICES, and how
+ * many cards a class contains is a function of its BUDGET and its tier's ring
+ * pace - so the window has to be too. It used to be
+ * `FIRST_CARD + MIN_GAP * budget + 12`, a span sized by eye for the old 120s
+ * bell; at the 180s budget that same span covered barely the first 30% of the
+ * class and every lie in the room was spent before the halfway mark.
+ * `expectedCards` below reads the pace straight off chain.js and the plan is
+ * laid over the first WINDOW_FRAC of it. The DEAL COUNTS are deliberately
+ * unchanged: 8 lies over the first ~150 cards of a tier-4 class reads as a RATE
+ * (about one every 19 cards, ~17s), which is what a trickster deck is for.
+ *
  * TABLE LAW AUDIT (House Rules)
  *   I   ledger honest - nothing here reads or writes chain, rung, accuracy,
  *       the grade or card.tag, and no card can change WHEN the ring closes or
@@ -75,6 +86,7 @@
  * ==========================================================================*/
 
 import { makeRng } from '../../core/rng.js';
+import { capForTier, rungForStreak, ringMsFor } from './chain.js';
 
 export const TRICKSTER = Object.freeze({
   /** Dealt slots per class, by tier. Tier 1 deals nothing at all. */
@@ -85,6 +97,30 @@ export const TRICKSTER = Object.freeze({
   MIN_GAP: 5,
   /** A slot whose card cannot carry it waits this many cards, then folds. */
   RETRY_MAX: 1,
+
+  /* ----------------------------------------------------------- THE WINDOW --
+   * How much of a class may carry a lie, and the pace model that answers how
+   * long a class IS. Read only by expectedCards() and buildPlan().
+   */
+  /** The plan covers the first this-much of the class's expected card count.
+   *  Not 1.0: the last stretch is where a player is holding their best rung and
+   *  the room wants that finish clean, and a slot dealt past the last card the
+   *  class actually reaches is a lie that never happens. */
+  WINDOW_FRAC: 0.78,
+  /** The budget buildPlan assumes when a caller hands it none. Mirrors
+   *  index.js's own `timeBudgetSec` (and registry.js GAME_META.sort). */
+  DEFAULT_BUDGET_SEC: 180,
+  /** THE PACE, and it is two numbers because a card costs two things. A
+   *  competent player swipes inside the gold arc (chain.js: the last 40% of
+   *  the ring), so they spend most of a ring but never all of it... */
+  PACE_RING_FRAC: 0.85,
+  /** ...plus the part of a card that is not the ring at all: the fling, the
+   *  thud into the wall and the next card's spring. Sized off swipe.js's own
+   *  travel, and it is why a 0.75s ring is not a 0.75s card. */
+  PACE_OVERHEAD_MS: 180,
+  /** A guard rail on the pace walk, never a design number: the loop below may
+   *  not run past this many cards whatever it is handed. */
+  MAX_EXPECTED_CARDS: 900,
 
   /** The seven cards. */
   CARDS: Object.freeze(['freeze', 'glimpse', 'doppel', 'ghost', 'flicker', 'crooked', 'label']),
@@ -140,10 +176,60 @@ export function bendRingFace(remain, honest, bend) {
 }
 
 /* ============================================================================
- * THE PLAN, PURE. Slots are CARD INDICES, because a card is the only moment a
- * lie can attach to in this room. Same seed and tier, same deal, forever.
+ * HOW LONG A CLASS IS, IN CARDS. PURE, and the whole reason this file imports
+ * chain.js: the ring pace lives there and a second copy of it here would rot.
+ *
+ * THE WALK. A card costs `ring * PACE_RING_FRAC + PACE_OVERHEAD_MS`, and the
+ * ring is whatever rung the player's clean streak has earned (chain.js's
+ * RUNG_STEPS ladder, ceilinged by the tier's own cap). So the model walks the
+ * climb the way a player actually climbs it - card 1 is a 2.4s ring and card 35
+ * is a 0.75s one - instead of pretending the whole class runs at the floor
+ * ring, which would over-count a tier-4 class by about a fifth.
+ *
+ * It assumes a CLEAN run, and that is the right end of the band to model from:
+ * a player who is wrong a lot plays a SHORTER class in cards, so the plan runs
+ * out of class before it runs out of slots and the last slots simply never
+ * arrive - a case this deck already has a path for. Modelling the sloppy player
+ * instead would crowd every lie back into the opening for everybody else.
+ *
+ * WHAT IT ANSWERS at the shipped 180s budget (and at the 120s budget this room
+ * used to run, for the record):
+ *
+ *     tier   cap rung   floor ring     120s     180s
+ *       1        5         1200ms       ~95     ~143
+ *       2        6         1050ms      ~102     ~157
+ *       3        7          900ms      ~112     ~175
+ *       4        8          750ms      ~124     ~197
+ *
+ * @param {number} budgetSec  the class's own timeBudgetSec
+ * @param {number} tier       grade tier 1..4
+ * @returns {number} cards a clean, competent run of that class reaches
  * ==========================================================================*/
-export function buildPlan({ seed, tier, reduced } = {}) {
+export function expectedCards(budgetSec, tier) {
+  const tr = Math.max(1, Math.min(4, Math.round(Number(tier) || 1)));
+  const secs = Number(budgetSec);
+  const sec = isFinite(secs) && secs > 0 ? Math.min(600, secs) : TRICKSTER.DEFAULT_BUDGET_SEC;
+  const cap = capForTier(tr);
+  let left = sec * 1000;
+  let n = 0;
+  while (n < TRICKSTER.MAX_EXPECTED_CARDS) {
+    const cost = ringMsFor(rungForStreak(n, cap)) * TRICKSTER.PACE_RING_FRAC
+      + TRICKSTER.PACE_OVERHEAD_MS;
+    if (!(cost > 0) || cost > left) break;           // the bell lands mid-card
+    left -= cost;
+    n += 1;
+  }
+  return n;
+}
+
+/* ============================================================================
+ * THE PLAN, PURE. Slots are CARD INDICES, because a card is the only moment a
+ * lie can attach to in this room. Same seed and tier and BUDGET, same deal,
+ * forever - `budgetSec` joins the plan's inputs, and the room reads it off the
+ * class state it already holds, so a retake of the same class deals the same
+ * lies in the same places.
+ * ==========================================================================*/
+export function buildPlan({ seed, tier, reduced, budgetSec } = {}) {
   const tr = Math.max(1, Math.min(4, Math.round(Number(tier) || 1)));
   const budget = TRICKSTER.DEALS[tr] || 0;
   const cards = reduced ? TRICKSTER.STILL_CARDS.slice() : TRICKSTER.CARDS.slice();
@@ -151,9 +237,22 @@ export function buildPlan({ seed, tier, reduced } = {}) {
   const rWhen = makeRng(String(seed || 'sort') + '|sort-trickster|when');
   const rWhat = makeRng(String(seed || 'sort') + '|sort-trickster|what');
 
-  /* the class is roughly 60-160 cards long depending on how fast you play, so
-     the plan is laid over a window the slowest run still reaches */
-  const span = TRICKSTER.FIRST_CARD + TRICKSTER.MIN_GAP * budget + 12;
+  /* THE WINDOW. `span` is the EXCLUSIVE end of the draw below, so the last card
+     that can carry a lie is span - 1.
+       window  the first WINDOW_FRAC of the class THIS budget and tier deal
+       floorSp the old fixed span, kept as a FLOOR and nothing else: it is the
+               narrowest window `budget` slots MIN_GAP apart can fit in at all,
+               so a missing or nonsense budget can never deal a plan tighter
+               than the deck was designed to allow
+     At 180s the window always wins - tier 4 is 8 + floor(.78 * 197) = 161
+     against a floor of 60 - and the eight slots land ~19 cards apart instead
+     of ~6, which is the difference between a rate and a burst. */
+  const expect = expectedCards(budgetSec, tr);
+  /* NOT named `window`: this module is loaded in a browser and a local const by
+     that name would shadow the global for the whole function. */
+  const windowEnd = TRICKSTER.FIRST_CARD + Math.floor(TRICKSTER.WINDOW_FRAC * expect);
+  const floorSp = TRICKSTER.FIRST_CARD + TRICKSTER.MIN_GAP * budget + 12;
+  const span = Math.max(floorSp, windowEnd);
   const at = [];
   for (let i = 0; i < budget; i++) {
     at.push(TRICKSTER.FIRST_CARD + Math.floor(rWhen() * (span - TRICKSTER.FIRST_CARD)));
@@ -288,6 +387,10 @@ export function create(o) {
   let stopped = false;
   let paused = false;
   let plan = [];
+  /* what the plan above was laid over. Diagnostics only - the deal itself is
+     already frozen into `plan` and nothing reads these back. */
+  let planBudgetSec = 0;
+  let planExpected = 0;
   let folded = 0;
   let played = 0;                     // cards ARMED so far: the slot index
   let topNode = null;
@@ -612,10 +715,25 @@ export function create(o) {
       if (destroyed || started) return;
       started = true;
       stopped = false;
-      plan = buildPlan({ seed, tier, reduced });
+      /* THE BUDGET IS READ HERE, not at create(): the room owns the clock and
+         `budgetMs` is only on the state once start() has run (index.js sets it
+         in start(), and both the ordinary start and the late-build guard land
+         after that). A state that cannot answer falls back to
+         DEFAULT_BUDGET_SEC rather than to a window of nothing. */
+      const budgetSec = (() => {
+        try {
+          const ms = Number((readState() || {}).budgetMs);
+          return isFinite(ms) && ms > 0 ? ms / 1000 : TRICKSTER.DEFAULT_BUDGET_SEC;
+        } catch (e) { return TRICKSTER.DEFAULT_BUDGET_SEC; }
+      })();
+      planBudgetSec = budgetSec;
+      planExpected = expectedCards(budgetSec, tier);
+      plan = buildPlan({ seed, tier, reduced, budgetSec });
       say('trickster: dealt ' + plan.length + ' slots'
         + (plan.length ? ' (' + plan.map((s) => s.card + '@' + s.at).join(', ') + ')' : '')
-        + ' tier ' + tier + (reduced ? ' reduced' : '') + (capsOk() ? '' : ' CAPPED'));
+        + ' tier ' + tier + ', budget ' + Math.round(budgetSec) + 's over ~'
+        + planExpected + ' cards'
+        + (reduced ? ' reduced' : '') + (capsOk() ? '' : ' CAPPED'));
     },
 
     /** This deck has no heat: a lie is not louder because the room is hotter. */
@@ -646,6 +764,11 @@ export function create(o) {
         armed: armedBase && capsOk(),
         started, stopped, paused, destroyed, reduced, tier,
         budget: TRICKSTER.DEALS[tier] || 0,
+        /* the window the plan was laid over, so a harness can assert the deal
+           is a RATE over the whole class and not a burst in its opening */
+        budgetSec: planBudgetSec,
+        expectedCards: planExpected,
+        lastSlot: plan.length ? plan[plan.length - 1].at : 0,
         played, folded,
         plan: plan.map((s) => ({ at: s.at, card: s.card, used: s.used, tries: s.tries })),
         dealt: dealtCards.slice(),
@@ -670,4 +793,4 @@ export function create(o) {
   return api;
 }
 
-export default { TRICKSTER, create, buildPlan, bendRingFace };
+export default { TRICKSTER, create, buildPlan, bendRingFace, expectedCards };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/wall.js
@@ -4,9 +4,9 @@
  *
  * Every committed card THUDS into the next slot and stays there. That is the
  * whole trick: the room's decoration is your own work, so by the bell the stage
- * is wearing a hundred and twenty seconds of your taste. A WRONG card lands
- * dimmed (40%) and stays dim - the wall is an honest ledger, and the one place
- * in the room a mistake is still visible a minute later.
+ * is wearing three minutes of your taste. A WRONG card lands dimmed (40%) and
+ * stays dim - the wall is an honest ledger, and the one place in the room a
+ * mistake is still visible a minute later.
  *
  * WHEN IT APPEARS is the tier dial (pitch section 10): tier 1 sees the wall only
  * at the end card, tier 2 from rung 3, tier 3 from rung 2, tier 4 from rung 1.
@@ -35,8 +35,16 @@ export const WALL = Object.freeze({
   /** The THUD, and its reduced-motion twin. */
   THUD_MS: 340,
   THUD_MS_REDUCED: 120,
-  /** Tiles before the wall starts recycling its oldest slot. */
-  CAP: 96,
+  /** Tiles before the wall starts recycling its oldest slot.
+   *  96 -> 120 with the 180s budget (the class-length wave). The cap is a
+   *  RECYCLE RATE, not a memory: a competent tier-4 player commits ~200 cards
+   *  in 180s, which at 96 would have wiped the wall through twice over and made
+   *  the early class un-findable at the bell. 120 - the largest deck
+   *  (DECK.SIZE_BY_TIER) - keeps it to ~1.7 passes, the same feel the 120s
+   *  class had at 96, and holds the tidy invariant that the wall can show at
+   *  most one whole deck. It is 25% more <img> tiles and no more decodes: a
+   *  wall tile is always a still (see DECODER BUDGET below). */
+  CAP: 120,
   /** Column counts the layout will consider. */
   COLS: Object.freeze([6, 7, 8, 9, 10, 11, 12]),
   /** The full-bleed hold at the bell. */
@@ -84,7 +92,7 @@ export function layout(stageW, stageH, cols) {
  * Columns for a wall that has to show THIS MANY tiles at once, near square.
  * layout() solves the empty stage; it does not know how many cards landed, so a
  * long class overruns the bottom of the room once the tiles are honestly square
- * (nine columns of 176px squares is five rows, and a 120s class lands far more
+ * (nine columns of 176px squares is five rows, and a 180s class lands far more
  * than forty-five). The bell is the one moment every tile has to be on stage at
  * once, so bleed() re-solves with the count in hand. Never returns FEWER columns
  * than it was handed: the mosaic may tighten to fit, never re-inflate.

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -1948,14 +1948,18 @@ export default {
     }
 
     /**
-     * Policy is the shell's "Skip class tutorials" contract: by default the
-     * sheet shows EVERY class; with the skip on, the pool still explains itself
-     * ONCE per grade tier. Dismissal is the sheet's own button and nothing
-     * else - every arrow key and the whole board are verbs here, so a key
-     * shortcut would be a move played against a board that has not dealt.
+     * THE LAW, uniform across every open class (owner ruling 2026-08-24): the
+     * sheet SHOWS the first time this player meets the pool at this grade tier
+     * and AUTO-SKIPS every later class at that tier, whatever the setting says.
+     * The shell's "Skip class tutorials" switch (ctx.hideTutorial) means "skip
+     * even the first showing". No meta = no memory = the sheet shows.
+     * Dismissal is the sheet's own button and nothing else - every arrow key
+     * and the whole board are verbs here, so a key shortcut would be a move
+     * played against a board that has not dealt. The sheet is free of the
+     * clock: startClock() is the first thing past GO, inside beginClass.
      */
     function howto(onDone) {
-      if (ctx.hideTutorial === true && howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
+      if (ctx.hideTutorial === true || howtoSeenTiers().indexOf(tier) >= 0) { onDone(); return; }
       if (ctx.dev === true && spec && spec.devSkipHowto === true) { onDone(); return; }
       if (!stage) { onDone(); return; }
       const tierNow = tier;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -1447,7 +1447,11 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     ccChips.textContent = '';
     if (r.tier) chip(tierLabel(r.tier));
     if (r.family) chip(familyLabel(r.family));
-    if (r.timeBudgetSec) chip(r.timeBudgetSec + 's');
+    /* A CLOCKLESS ROOM WEARS NO SECONDS (the class-length wave). Daily Trigger
+     * still runs a budget and still rings; the door card just does not count it
+     * out, the same suppression the departure board and the proctor strip make.
+     * `clockless` rides in on the shell's descriptor list (noteDescriptors). */
+    if (r.timeBudgetSec && !r.clockless) chip(r.timeBudgetSec + 's');
     if (r.homeroom) chip(t('homeroom', 'Homeroom'));
     ccStamp.textContent = r.done ? String(r.grade).toUpperCase()
       : (r.unlocked ? t('punchcard_unlocked_chip', 'Unlocked') : '');
@@ -1607,6 +1611,7 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
       if (!r) continue;
       r.family = c.family;
       r.timeBudgetSec = c.timeBudgetSec;
+      r.clockless = !!c.clockless;
       r.homeroom = !!c.homeroom;
       r.tier = c.tier;
       // Only ever ADD what the descriptor knows: campusState already set this

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/settings.js
@@ -409,7 +409,7 @@ export function createSettingsPage({ init, bridge, games, keybinds, onClose, log
     gt.appendChild(switchRow({
       key: SETTING_KEYS.hideTutorial,
       label: 'Skip class tutorials',
-      hint: 'Classes still explain themselves once per grade tier.',
+      hint: 'Skips the class rules sheet, even the first time you meet a class.',
       value: !!src.hideTutorial,
     }));
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -713,7 +713,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       if (!compact) {
         if (c.homeroom) chips.push({ text: t('homeroom', 'Homeroom'), kind: 'homeroom' });
         chips.push({ text: t('family_' + c.family, c.family) });
-        chips.push({ text: c.timeBudgetSec + 's', kind: 'num' });
+        /* A CLOCKLESS CLASS SHOWS NO SECONDS, ANYWHERE (the class-length wave).
+         * The budget is still real and still rings the bell; Daily Trigger just
+         * does not wear it. Same suppression on the campus room card and in the
+         * proctor strip, and the time bar is not mounted at all. */
+        if (!c.clockless) chips.push({ text: c.timeBudgetSec + 's', kind: 'num' });
       }
       if (suspended) chips.push({ text: t('class_suspended', 'Class Suspended'), kind: 'warn' });
       if (done) {
@@ -770,6 +774,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       gameKey: c.gameKey,
       family: c.family,
       timeBudgetSec: c.timeBudgetSec,
+      clockless: !!c.clockless,          // the room card hides the seconds chip
       homeroom: !!c.homeroom,
       tier: tierFor(store.gameMeta(c.gameKey)),
       endless: endlessFor(c.gameKey),
@@ -1434,10 +1439,16 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
      * right. The shell owns the clock (see timeBar* below) because a game must
      * never be able to make the flow of time lie - and it never ENDS a class:
      * the game's own bell is authoritative, the bar just goes pink and holds.
-     * A FREE SWIM has no budget, so it has no bar (panel carries arc-endless). */
+     * A FREE SWIM has no budget, so it has no bar (panel carries arc-endless).
+     * A CLOCKLESS CLASS has a budget and still refuses one: the bar is the loud
+     * half of "you are being timed", and homeroom's minute is a ritual, not an
+     * exam. Nothing downstream needs a guard - timeBarSet / timeBarTick /
+     * timeBarPaint all return on a null `timebar`, exactly as they do for a
+     * free swim, so the clock simply never starts. */
+    const clockless = !!cls.clockless;
     let timebar = null;
     let timefill = null;
-    if (!endless) {
+    if (!endless && !clockless) {
       timebar = el('div', 'arc-timebar');
       timefill = el('div', 'arc-timebar-fill');
       timebar.appendChild(timefill);
@@ -1467,11 +1478,13 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     if (retake) bar.appendChild(el('span', 'chip', t('retake', 'Retake')));
     bar.appendChild(el('span', 'arc-spacer'));
     // A free swim is untimed, so the clock chip would be a lie. The chip that
-    // replaces it names what this is instead.
+    // replaces it names what this is instead. A CLOCKLESS class gets neither:
+    // it IS timed, it simply never says so, so there is nothing honest to put
+    // in the slot and the strip closes over it.
     const clock = endless
       ? el('span', 'chip', t('free_swim', 'Free Swim'))
-      : el('span', 'chip num', cls.timeBudgetSec + 's');
-    bar.appendChild(clock);
+      : (clockless ? null : el('span', 'chip num', cls.timeBudgetSec + 's'));
+    if (clock) bar.appendChild(clock);
     panel.appendChild(bar);
 
     return { panel, root, clock, timebar, timefill, pill };
@@ -1722,7 +1735,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     const manifest = (mod && mod.manifest) || {};
     const gameMeta = store.gameMeta(cls.gameKey);
     const gradeTier = tierFor(gameMeta);
-    // A free swim has NO budget: 0 is the contract the game reads as "no bell".
+    /* A free swim has NO budget: 0 is the contract the game reads as "no bell".
+     * Otherwise the CLASS's own budget, fenced by the ceiling for its type -
+     * and since the class-length wave both ceilings are 300 and `meaty` is the
+     * anchor-slot flag rather than a length, so this Math.min only ever bites a
+     * calendar override that asked for more than five minutes. The `||` arm is
+     * a belt: the timetable clamps every dealt budget to >= MIN_BUDGET_SEC and
+     * freeSwimClass now carries the descriptor's own, so nothing reaches here
+     * with a falsy one. */
     const timeBudgetSec = endless ? 0 : Math.min(
       cls.timeBudgetSec || QUICK_MAX_SEC,
       cls.meaty ? MEATY_MAX_SEC : QUICK_MAX_SEC
@@ -2066,16 +2086,26 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    */
   function freeSwimClass(gameKey) {
     const onBoard = timetable.classes.find((c) => c.gameKey === gameKey);
-    if (onBoard) return Object.assign({}, onBoard, { timeBudgetSec: 0 });
+    if (onBoard) return Object.assign({}, onBoard);
     const d = descriptors(games.list).find((x) => x.key === gameKey)
       || { key: gameKey, family: 'comfort', meaty: false };
     return {
       gameKey,
       family: d.family || 'comfort',
       meaty: !!d.meaty,
+      clockless: !!d.clockless,
       homeroom: false,
       timeLabel: '',
-      timeBudgetSec: 0,
+      /* THE DESCRIPTOR'S OWN BUDGET, not zero and not a ceiling. Two callers,
+       * and only one of them is a swim: `startFreeSwim` passes {endless:true}
+       * and startClass zeroes the budget itself, so an untimed swim is untimed
+       * whatever is written here - but THE EARNED DOOR and the dev door start
+       * this object as an ordinary GRADED, TIMED class, and they used to land
+       * on startClass's `|| QUICK_MAX_SEC` fallback. That was already wrong
+       * (Daily Trigger ran 180s through the unlock door) and the class-length
+       * wave made it wronger by moving the quick ceiling to 300. Budgets are
+       * per-module now, so the door runs the module's own class length. */
+      timeBudgetSec: Number(d.timeBudgetSec) > 0 ? Number(d.timeBudgetSec) : 120,
     };
   }
 

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -1343,7 +1343,9 @@ internal static class ArcademyHostService
         ["dt_whisper_3"] = "You already typed it.",
         ["dt_whisper_4"] = "The stars are lying, not me.",
         // ---- Deja Vu (games/deja-vu) --------------------------------------------------
-        ["dv_bell"] = "The bell. Time is up.",
+        ["dv_bell"] = "The bell. Class over.",
+        ["dv_boards"] = "boards",
+        ["dv_last_call"] = "Last ten seconds.",
         ["dv_called_it"] = "You called the lie.",
         ["dv_card"] = "Card",
         ["dv_clear"] = "Board clear.",
@@ -1376,7 +1378,7 @@ internal static class ArcademyHostService
         ["dv_swaps"] = "swaps",
         ["dv_tracked"] = "Tracked through the static.",
         // ---- Lost & Found (games/lost-and-found) --------------------------------------
-        ["lf_briefing"] = "Memorize her, then find her five times.",
+        ["lf_briefing_n"] = "Memorize her, then find her {n} times.",
         ["lf_clutch"] = "The board relents",
         ["lf_final_bell"] = "Final bell",
         ["lf_find_prompt"] = "Find her",
@@ -1385,7 +1387,7 @@ internal static class ArcademyHostService
         ["lf_found"] = "Found her",
         ["lf_howto_title"] = "Class rules",
         ["lf_howto_find"] = "She hides on a wall that never sits still. Spot the tile that matches her picture.",
-        ["lf_howto_five"] = "Every find, she relocates. Catch her five times.",
+        ["lf_howto_finds_n"] = "Every find, she relocates. Catch her {n} times.",
         ["lf_howto_go"] = "Start the hunt",
         ["lf_jackpot"] = "Jackpot",
         ["lf_melt"] = "The wall runs like wax",
@@ -1570,6 +1572,7 @@ internal static class ArcademyHostService
         ["dt_howto_type"] = "Type a word into the row, then Enter. One answer a day, the same for everyone.",
         // ---- Deja Vu class-rules sheet (2026-08-23)
         ["dv_howto_flip"] = "Turn two slides. A matching pair stays lit. Anything else turns back over.",
+        ["dv_howto_boards"] = "Clear the board and a fresh one deals. The bell ends class.",
         ["dv_howto_go"] = "Deal the board",
         ["dv_howto_redeal"] = "Sometimes the whole board re-deals. Same pairs - only the seats change.",
         ["dv_howto_swap"] = "The board only moves while nothing is face up, and it always shudders first.",
@@ -2000,8 +2003,10 @@ internal static class ArcademyHostService
         ["cp_backtrack_line"] = "Back where it was. Breathe.",
         ["cp_bell_line"] = "The bell. Hands off the board.",
         ["cp_bell_warn"] = "Twenty seconds.",
-        ["cp_brief"] = "One picture, cut apart and still moving. Put it back together.",
-        ["cp_brief_zen"] = "No clock tonight. Slide until it is whole again.",
+        ["cp_bank_line"] = "Banked. Here is a fresh one.",
+        ["cp_brief"] = "One picture, cut apart and still moving. Put it back together, then again.",
+        ["cp_brief_zen"] = "No clock tonight. Slide until it is whole, then again if you like.",
+        ["cp_chip_banked"] = "Pictures done",
         ["cp_chip_calm"] = "Composure",
         ["cp_chip_clock"] = "Time left",
         ["cp_chip_locked"] = "Pieces home",
@@ -2013,15 +2018,14 @@ internal static class ArcademyHostService
         ["cp_end_best_line"] = "Your standing mark on this board. Beat it next class.",
         ["cp_end_locked"] = "Pieces home",
         ["cp_end_moves"] = "Moves",
-        ["cp_end_no"] = "No",
-        ["cp_end_par"] = "Baseline",
-        ["cp_end_solved"] = "Solved",
+                ["cp_end_par"] = "Baseline",
+        ["cp_end_solved"] = "Pictures finished",
+        ["cp_howto_bank"] = "Finish a picture and the next one deals. The bell ends the class, not the solve.",
         ["cp_end_thrash"] = "Panic moves",
         ["cp_end_time"] = "Time",
         ["cp_end_title"] = "Composure report",
         ["cp_end_title_zen"] = "Zen board",
-        ["cp_end_yes"] = "Yes",
-        ["cp_finish"] = "Finish",
+                ["cp_finish"] = "Finish",
         ["cp_howto_go"] = "Start the picture",
         ["cp_howto_lock"] = "A piece that reaches its own place locks with a snap. It can still be slid.",
         ["cp_howto_slide"] = "Tap a piece beside the gap and it slides in. Arrows, WASD and swipes do the same.",


### PR DESCRIPTION
## What

The owner surveyed every class after a duration audit found 8 of 9 running 0:30-2:00 against a ~5 min target. This wave makes class length a ruled, designed quantity per class.

| class | was (typical) | now |
|---|---|---|
| lost_and_found | 120s bell, ~43s at t1 | 300s, per-tier finds 26/22/16/13, gates rescaled as rates |
| anomaly | 90s flat | 300s, plan sized off fast-player pace (no seeded-round looping) |
| composure | solve ended class (~41s at t1) | 300s multi-board: a solve banks + re-deals until the bell |
| deja_vu | clear ended class (~30-73s) | 300s multi-board, mild seeded escalation, timeout auto-C removed |
| sort | 120s | 180s + deck 90/105/120/120, trickster window spans expected cards |
| instant_recall | 120s | 180s (rate-based band deals 14-16 stops) |
| echo | 105s | 120s |
| daily_trigger | ~1 min wordle | unchanged by ruling, now clockless (no seconds chip / time bar) |
| impulse_control | 90s | unchanged by ruling |
| the_deep_end | 300s | unchanged |

## Mechanics
- QUICK_MAX_SEC 180 -> 300; meaty flags untouched: meatyOk deals exactly one meaty per day, so meaty = anchor-slot flag, never the length flag (trap 81)
- Multi-board law: the bell is the only end; closing/belled latches; exactly one endClass (trap 82); board 1 deals byte-identical to the single-board era
- Count-vs-rate sweep across every budget-calibrated constant (trap 83)
- Sheet law: class rules sheets show once per grade tier then auto-skip, and never burn class time - echo was charging the sheet to its own bell (trap 85); 'skip class tutorials' now skips even the first showing
- C# NeutralLexicon mirrored: lf_briefing_n / lf_howto_finds_n ({n} slots), dv_boards / dv_last_call / dv_howto_boards / dv_bell, cp bank rows; dead rows retired

## Verification
- node --check clean on all 38 files; ESM import smoke of all 100 game modules (0 failures)
- 800 seeded instant-recall plans at 180s: 0 assertPlan failures
- deja-vu headless bot: full 300s classes at t1-t4 + 12-run budget sweep, exactly one endClass per run, bell resolved mid-deal/mid-preview/mid-play
- composure: 8/8 staged bell-during-bank races give one endClass; zen multi-boards (204-board run, one pass)
- 28-night timetable sim: one anchor class every night, never two; nights now 8-16.5 min
- dotnet build: 0 errors

## Play-test focus
- L&F pacing model (find counts may want a flat +20% if classes end early); its S-gate misclick rate
- composure TYPICAL_SOLVE_SEC table (moves the whole S/A bar)
- tier-1 deja-vu players meet tier-2 effects from their 3rd cleared board
- night length: a night can now legally deal two 300s classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZUjZB5VGGG1CjQyB1vZv8