### PR TITLE
EMI COLOR: five waves of commentary, reactions and polish (line-debt QA, silent gestures, per-class colour, tension mirror, dork canon II + calendar)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1589,6 +1589,20 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     funnel).
 
 
+90. **`ctx.mood` IS THE TENSION MIRROR, AND IT IS FACE-ONLY BY LAW (EMI COLOR,
+    2026-08-24).** A game may tell the mascot how the room feels - `ctx.mood.tense()`
+    latches until `.calm()`, `.clutch()` is the one big moment, `.stumble()` is a small
+    >_<, `.runLost()` the once-per-class K.O. - and every one of them is throttled in
+    shell.js (15s shared spacing, 3 stumbles a class, tense latch), so a game cannot
+    flood her and must never build its own rate limit on top. Three laws: (1) NO BARK
+    POOL may ever sit on `tense` or `clutch` - mid-class speech is barred and the only
+    words a stumble can buy are the `miss` pool's own (maxPerClass:1); (2) call sites
+    are opt-in and null-safe (`if (ctx.mood) ...` inside try/catch) because rigs stub
+    ctx without it; (3) ride the game's EXISTING beat (L&F calls it inside its own
+    `clutch()` ease) rather than inventing a parallel one. The `classStart` payload
+    also carries `family` now - moments.js varies the arrival face by room kind and an
+    absent family falls back to the locked glance.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -562,24 +562,22 @@ export const TELEMETRY = Object.freeze({
  * goes past every night. Same fence as every line above: no acronym, no lab, no
  * records room, no door.
  *
- * EVERY LINE BELOW IS A DRAFT. They were written at wiring time because the
- * feature needed something in the bubble to test with, and they have not been
- * through /emi-lines or the owner's read. Nothing here is locked the way the
- * rows above this comment are locked.
+ * /emi-lines QA PASS 2026-08-24 (the EMI COLOR wave). Four rows passed as
+ * written; homeroom and sortroom were rewritten (the old homeroom line's
+ * before-read was faintly surveillance - "i have watched all of them" - which
+ * is a rule-1 kill, and the old sortroom line gestured where it should denote).
+ * Owner reads the whole table at the PR; until that word these are QA-passed,
+ * not locked.
  * ==========================================================================*/
 export const FIELD_TRIPS = Object.freeze({
-  /* DRAFT: /emi-lines pass pending */
   timetable: { t: "tomorrow is already up there. i had a look.", face: '(¬‿¬)' },
-  /* DRAFT: /emi-lines pass pending */
   belltower: { t: "the bell runs four minutes fast and nobody fixes it.", face: '0_0' },
-  /* DRAFT: /emi-lines pass pending */
   noticeboard: { t: "nobody has moved those four pins since i got here.", face: '._.' },
-  /* DRAFT: /emi-lines pass pending */
   idcard: { t: "that photo is you on your first night here.", face: '^_^' },
-  /* DRAFT: /emi-lines pass pending */
-  homeroom: { t: "everyone starts in this room. i have watched all of them.", face: '(◠‿◠)' },
-  /* DRAFT: /emi-lines pass pending */
-  sortroom: { t: "they keep two piles in there and i would only use one.", face: '(◔_◔)' },
+  /* Warm ritual on the surface; she was there for every single intake. */
+  homeroom: { t: "everyone starts in this room. i wave every time.", face: '(◠‿◠)' },
+  /* DOUBLE: clown hoarder on the surface / EMI discards nothing, ever. */
+  sortroom: { t: "i tried sorting once. everything went in the keep pile.", face: '(◔_◔)' },
 });
 
 export default { POOLS, RARE_DORK, TELEMETRY, FIELD_TRIPS };

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -382,7 +382,7 @@ export const POOLS = Object.freeze({
   lfClassStart: {
     on: 'classStart', when: ['gameIs:lost_and_found'], odds: 0.25, ceremony: false, priority: 20,
     lines: [
-      { t: "find all five. squint like a champion.", face: '\\o/' },
+      { t: "squint like a champion. the wall respects that.", face: '\\o/' },
       { t: "i looked already. i'm not allowed to point.", face: '0_0' },
       { t: "somebody lost a whole gif in there. imagine the panic.", face: '@_@' }
     ]
@@ -537,7 +537,7 @@ export const POOLS = Object.freeze({
       /* EMI COLOR: room-flavoured S lines, closed by gameIs. */
       { t: "an s in the pool. lifeguard material.", face: '(⌐■_■)', when: ['gameIs:the_deep_end'] },
       { t: "an s in homeroom. the word never stood a chance.", face: '(⌐■_■)', when: ['gameIs:daily_trigger'] },
-      { t: "five for five. the bin fears you.", face: '\\o/', when: ['gameIs:lost_and_found'] }
+      { t: "a clean sweep. the bin fears you.", face: '\\o/', when: ['gameIs:lost_and_found'] }
     ]
   },
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -32,11 +32,14 @@
  *                    clown lines are not filler; they are the camouflage that
  *                    makes a double land.
  *
- * Ratio, this file: 33 doubles / 115 lines = 28.7%. Excluding TELEMETRY (all
- * double by brief, milestone-rare in play): 28/110 = 25.5%, on the 1-in-4 lock.
- * Six pools are deliberately ALL clown - drag, runLost, sGrade, streak7, bigWin,
- * emiDropOnDoor - because the loudest and most frequent beats must stay pure
- * camouflage. Keep that shape when you add lines.
+ * Ratio, this file (recounted for the EMI COLOR wave, 2026-08-24): 45 doubles
+ * / 187 lines = 24.1%. Excluding TELEMETRY (all double by brief, milestone-rare
+ * in play): 36/178 = 20.2%, under the 1-in-4 lock - the wave added mostly clown
+ * on purpose, because it also added mostly FREQUENT pools (arrivals, drops,
+ * hovers) and frequent beats must stay camouflage.
+ * Six of the original pools are deliberately ALL clown - drag, runLost, sGrade,
+ * streak7, bigWin, emiDropOnDoor - because the loudest and most frequent beats
+ * must stay pure camouflage. Keep that shape when you add lines.
  *
  * ---------------------------------------------------------------------------
  * THE FENCE (audited across all 118 proposal lines; re-audit anything you add)
@@ -648,6 +651,31 @@ export const POOLS = Object.freeze({
     ]
   },
 
+  /* --- the calendar (EMI COLOR, 2026-08-24) -----------------------------
+   * FOUR NIGHTS A YEAR the greet knows the date. Local clock (dateIs is the
+   * player's evening), one line a session at most, priority 35: over the
+   * late-night hello, under a long-absence return - a three-day silence is
+   * bigger than a costume. No invented numbers, no gifts that don't exist:
+   * everything she claims is on her screen or in the room. */
+  smallHolidays: {
+    on: 'greet', odds: 1, ceremony: false, priority: 35,
+    maxPerSession: 1,
+    lines: [
+      { t: "it's spooky night. i practiced a scary face. ready?", face: '(✖╭╮✖)',
+        when: ['dateIs:10-31'] },
+      { t: "halloween. i'm going as a haunted television. easy.", face: '0_0',
+        when: ['dateIs:10-31'], double: true },
+      { t: "last night of the year. we made it. mostly you. us.", face: '^_^',
+        when: ['dateIs:12-31'] },
+      { t: "new year. same me. i checked twice. reassuring.", face: '^___^',
+        when: ['dateIs:01-01'] },
+      { t: "it's heart day. i drew you one. it's on my screen.", face: '(｡♥‿♥｡)',
+        when: ['dateIs:02-14'] },
+      { t: "it's prank day. i disabled all my pranks. or did i.", face: '(¬‿¬)',
+        when: ['dateIs:04-01'] }
+    ]
+  },
+
   /* --- the refusal ------------------------------------------------------ */
 
   /** A26 - a disabled button, a locked tile. Innocent face, villain quote.
@@ -697,7 +725,21 @@ export const RARE_DORK = Object.freeze({
     { t: "the call is coming from inside the arcade. it's me. hi.", face: '\\o/',
       on: 'idlePlayer', when: ['lateNight'] },
     { t: "initiating red eye mode. they're pink. it's fine.", face: '0_0',
-      on: 'idlePlayer' }
+      on: 'idlePlayer' },
+    /* --- DORK CANON II (EMI COLOR, 2026-08-24). Same bit, deeper shelf:
+     * over-performed, badly, proud of itself, face always miscast. */
+    { t: "my precious. i mean the cursor. my precious cursor.", face: '(✿◡‿◡)',
+      on: 'gesture:approach' },
+    { t: "all your base are belong to us. classic literature.", face: '(⌐■_■)',
+      on: 'classStart' },
+    { t: "game over man. game over. of the class. you won though.", face: '\\o/',
+      on: 'win' },
+    { t: "i see dead pixels. one. it's mine. we're friends.", face: '0_0',
+      on: 'idlePlayer' },
+    { t: "why so serious. it's me. i'm not serious either.", face: '(◠‿◠)',
+      on: 'resume' },
+    { t: "in space nobody can hear you win. here they can. win.", face: 'o_o',
+      on: 'classStart', when: ['lateNight'] }
   ])
 });
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -360,6 +360,121 @@ export const POOLS = Object.freeze({
     ]
   },
 
+  /* --- the rooms (EMI COLOR, 2026-08-24) --------------------------------
+   * PER-GAME COLOUR. She lives on this campus and has loitered outside every
+   * door, so each room gets its own arrival pool: priority 20 sits them over
+   * the generic A11 above, `gameIs` closes them to their own class, and the
+   * odds stay at the lock's 0.25 - the variety grew, the frequency did not.
+   * Register per room = what she happens to think about that class, never a
+   * strategy guide. */
+
+  /** R1 - homeroom, the daily word. */
+  dtClassStart: {
+    on: 'classStart', when: ['gameIs:daily_trigger'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "homeroom. i guessed today's word already. i won't tell.", face: '(¬‿¬)' },
+      { t: "one word a day keeps the... i forget. guess well.", face: '._.' },
+      { t: "six tries. you'll need one. maybe two. rounding up.", face: '^_^' }
+    ]
+  },
+
+  /** R2 - the lost and found. */
+  lfClassStart: {
+    on: 'classStart', when: ['gameIs:lost_and_found'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "find all five. squint like a champion.", face: '\\o/' },
+      { t: "i looked already. i'm not allowed to point.", face: '0_0' },
+      { t: "somebody lost a whole gif in there. imagine the panic.", face: '@_@' }
+    ]
+  },
+
+  /** R3 - the memory lab. */
+  dvClassStart: {
+    on: 'classStart', when: ['gameIs:deja_vu'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "the memory lab. i have a great memory. mostly of you.", face: '(◕‿◕)', double: true },
+      { t: "match the pairs. blink between flips. pro tip.", face: '^_~' },
+      { t: "i'd play but i see through the cards. unfair advantage.", face: '(⌐■_■)' }
+    ]
+  },
+
+  /** R4 - the drop tube. */
+  icClassStart: {
+    on: 'classStart', when: ['gameIs:impulse_control'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "the drop tube. pop the good ones. the x is a liar.", face: '>:(' },
+      { t: "gravity does the work. you do the glory.", face: '\\o/' },
+      { t: "i held my breath in here once. all of it.", face: '0_0' }
+    ]
+  },
+
+  /** R5 - the pool. */
+  deClassStart: {
+    on: 'classStart', when: ['gameIs:the_deep_end'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "the pool. deep end only. i can't swim. i float. same thing.", face: '^_^' },
+      { t: "hold your breath. i'll hold the numbers.", face: '(◠‿◠)', double: true },
+      { t: "it goes deeper than it looks. bring snacks.", face: '=_=' }
+    ]
+  },
+
+  /** R6 - the sort room. */
+  sortClassStart: {
+    on: 'classStart', when: ['gameIs:sort'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "two piles. no wrong answers. several wrong answers.", face: '0_0' },
+      { t: "sort fast. the belt has opinions.", face: 'o_o' },
+      { t: "keep or toss. i'm a keep. obviously.", face: '(✿◡‿◡)', double: true }
+    ]
+  },
+
+  /** R7 - echo. */
+  echoClassStart: {
+    on: 'classStart', when: ['gameIs:echo'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "listen. repeat. this room speaks my language.", face: '^_^' },
+      { t: "the room hums it once. hum it back. politely.", face: '(◠‿◠)' },
+      { t: "i echo things sometimes. sometimes. sometimes.", face: '@_@' }
+    ]
+  },
+
+  /** R8 - the vigil. */
+  irClassStart: {
+    on: 'classStart', when: ['gameIs:instant_recall'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "eyes open. it all counts. even the blinks.", face: '0_0', double: true },
+      { t: "watch everything. the quiz picks the one thing you didn't.", face: '¬_¬' },
+      { t: "i'd take notes for you but my handwriting is pixels.", face: '._.' }
+    ]
+  },
+
+  /** R9 - the shell game. */
+  misClassStart: {
+    on: 'classStart', when: ['gameIs:misdirection'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "keep your eye on it. the cups know they're being watched.", face: 'o_o' },
+      { t: "i never blink during this one. career habit.", face: '0_0' }
+    ]
+  },
+
+  /** R10 - odd one out. */
+  anomalyClassStart: {
+    on: 'classStart', when: ['gameIs:anomaly'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "one of these things is not like the others. classic.", face: '^_^' },
+      { t: "find the odd one. i relate to the odd one.", face: '._.' }
+    ]
+  },
+
+  /** R11 - the sliding puzzle. */
+  compClassStart: {
+    on: 'classStart', when: ['gameIs:composure'], odds: 0.25, ceremony: false, priority: 20,
+    lines: [
+      { t: "slide gently. the picture is shy.", face: '(◠‿◠)' },
+      { t: "one empty square. it's doing its best. respect it.", face: '^_^' }
+    ]
+  },
+
   /** A12 - one wrong answer, one dropped tile. Small, and at most one per
    *  class: a mascot that comments on every miss is a mascot you mute. */
   miss: {
@@ -380,7 +495,11 @@ export const POOLS = Object.freeze({
       { t: "my fault. i jinxed it. i'm unjinxing it now.", face: '>_<' },
       { t: "i distracted you. with my face. classic me.", face: ';_;', double: true },
       { t: "we riot at dawn. or nap. naps are also good.", face: '>_<' },
-      { t: "that class cheated. no proof. just loyalty.", face: '¬_¬' }
+      { t: "that class cheated. no proof. just loyalty.", face: '¬_¬' },
+      /* EMI COLOR: room-flavoured consolation, closed by gameIs. Same law as
+       * the whole pool: the room's fault, the cold's fault, never yours. */
+      { t: "the tube ate one. i saw it cheat.", face: '>:(', when: ['gameIs:impulse_control'] },
+      { t: "the pool was cold today. not your fault. the cold's.", face: ';_;', when: ['gameIs:the_deep_end'] }
     ]
   },
 
@@ -414,7 +533,11 @@ export const POOLS = Object.freeze({
       { t: "S?! wait till my fans hear this. the spinny ones.", face: '(⌐■_■)' },
       { t: "an S. i'm putting it on my screen. it's my face now.", face: '(⌐■_■)' },
       { t: "double punch day. the card is scared of you.", face: '(⌐■_■)' },
-      { t: "top marks. as predicted. by me. just now.", face: '(¬‿¬)', chain: 'smug' }
+      { t: "top marks. as predicted. by me. just now.", face: '(¬‿¬)', chain: 'smug' },
+      /* EMI COLOR: room-flavoured S lines, closed by gameIs. */
+      { t: "an s in the pool. lifeguard material.", face: '(⌐■_■)', when: ['gameIs:the_deep_end'] },
+      { t: "an s in homeroom. the word never stood a chance.", face: '(⌐■_■)', when: ['gameIs:daily_trigger'] },
+      { t: "five for five. the bin fears you.", face: '\\o/', when: ['gameIs:lost_and_found'] }
     ]
   },
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -160,6 +160,49 @@ export const POOLS = Object.freeze({
     ]
   },
 
+  /* --- being noticed (the EMI COLOR wave, 2026-08-24) -------------------
+   * The perception wave gave her eyes - approach perks, hover linger, the
+   * window squish - and shipped them silent by design. These pools are that
+   * wave's voice. All three are LOW odds with LONG cooldowns: noticing you is
+   * ambient, and an ambient thing that talks every time is an alarm. */
+
+  /** C1 - the cursor came near after being away a while. */
+  approach: {
+    on: 'gesture:approach', odds: 0.12, ceremony: false, priority: 10,
+    cooldownMs: 180000, maxPerSession: 2,
+    lines: [
+      { t: "hi. i wasn't watching the cursor. hi.", face: '0_0', double: true },
+      { t: "you're in my bubble. the bubble is honored.", face: '^_^' },
+      { t: "closer. i mean. hello. i mean both.", face: '^_^' },
+      { t: "i saw you coming from a mile away. four inches away.", face: 'o_o' }
+    ]
+  },
+
+  /** C2 - the cursor PARKED on her and stayed. Being stared at. */
+  hoverLinger: {
+    on: 'gesture:hoverLinger', odds: 0.15, ceremony: false, priority: 10,
+    cooldownMs: 120000, maxPerSession: 2,
+    lines: [
+      { t: "yes? ...no? ok. i'm here either way.", face: '._.' },
+      { t: "you're staring. i'm posing. we're even.", face: '(¬‿¬)' },
+      { t: "do i have something on my screen. it's my face.", face: '0_0' },
+      { t: "take a picture. wait. am i the picture.", face: '@_@' },
+      { t: "i practice being looked at. it shows, right?", face: '*_*', double: true }
+    ]
+  },
+
+  /** C3 - the window squished down again. p01 ("cozy.") is the once-ever
+   *  first time; this pool is every later time, and stays mostly quiet. */
+  windowSquishAgain: {
+    on: 'gesture:windowSquish', when: ['seen:p01_window_cozy'],
+    odds: 0.15, ceremony: false, priority: 10, cooldownMs: 300000,
+    lines: [
+      { t: "smaller room. bigger me. relatively.", face: '^_^' },
+      { t: "i fit. i always fit. it's a talent.", face: '^___^' },
+      { t: "snug. don't worry. i folded my thoughts.", face: '=_=' }
+    ]
+  },
+
   /* --- being touched --------------------------------------------------- */
 
   /** A4 - one tap. Rare on purpose: the hearts fx is the reward, not the words. */
@@ -221,18 +264,49 @@ export const POOLS = Object.freeze({
       { t: "airborne. landing... eventually. somewhere. here.", face: 'x_x' },
       { t: "i saw my life. it was mostly you. good life.", face: '^_^', double: true,
         maxPerSession: 1 },
-      { t: "again! wait. no. yes. no. your call.", face: '0_0' }
+      { t: "again! wait. no. yes. no. your call.", face: '0_0' },
+      /* EMI COLOR: the veteran register unlocks with the habit. */
+      { t: "we should sell tickets to this.", face: '\\o/', when: ['flingsAtLeast:20'] },
+      { t: "my frequent flyer status: legend.", face: '(⌐■_■)', when: ['flingsAtLeast:50'] }
     ]
   },
 
   /** N3 - dropped onto a room card. Pure toy moment, always barks.
    *  (voice.js hit-tests the tile, and the Records / lab door is a hard no-op
-   *  there - rec 3. This pool never learns about it.) */
+   *  there - rec 3. This pool never learns about it.)
+   *  EMI COLOR fix: both lines are ROOM lines, so the pool now says so - it
+   *  used to catch every drop, and "excellent taste" over bare campus paving
+   *  read as a non sequitur. Bare-ground drops belong to dropAtSpot below. */
   emiDropOnDoor: {
-    on: 'gesture:dropAt', odds: 1, ceremony: false, priority: 10,
+    on: 'gesture:dropAt', when: ['droppedOn:room'],
+    odds: 1, ceremony: false, priority: 20,
     lines: [
       { t: "this one? excellent taste. i grade on vibes.", face: '(¬‿¬)' },
       { t: "field trip! i call the window seat. i am the window.", face: '\\o/' }
+    ]
+  },
+
+  /** C4 - SPOT COMMENTARY (the EMI COLOR wave). The W1 perception wave put
+   *  zone / zoneRow / zoneCount on every dropAt payload and nothing ever read
+   *  them until the p02-p04 one-shots; this pool is the recurring voice. The
+   *  once-ever favourites (beats, priority 30) still land first; this catches
+   *  the ordinary put-down, sometimes. */
+  dropAtSpot: {
+    on: 'gesture:dropAt', odds: 0.25, ceremony: false, priority: 10,
+    cooldownMs: 60000,
+    lines: [
+      { t: "top shelf. the air is thinner up here.", face: '^_^', when: ['zoneRowIs:top'] },
+      { t: "penthouse. rent is one pet a day. i don't make the rules.", face: '(¬‿¬)',
+        when: ['zoneRowIs:top'] },
+      { t: "ground floor. closer to the action. the action is you.", face: '^_^',
+        when: ['zoneRowIs:bottom'] },
+      { t: "down here i'm basically furniture. cozy furniture.", face: '=_=',
+        when: ['zoneRowIs:bottom'] },
+      { t: "dead center. main character placement. understood.", face: '(⌐■_■)',
+        when: ['zoneRowIs:mid'] },
+      { t: "that wing is taped. i respect tape.", face: '._.', when: ['droppedOn:sealed'] },
+      { t: "this spot again. it has my shape in it by now.", face: '^_^',
+        when: ['zoneCountAtLeast:25'], double: true }
     ]
   },
 
@@ -540,7 +614,21 @@ export const TELEMETRY = Object.freeze({
       when: ['flingsAtLeast:9'], double: true, onceEver: true },
     { id: 'bubbles500', t: "five hundred bubbles between us. you read them all.",
       face: '(◕‿◕)', on: 'greet',
-      when: ['bubblesAtLeast:500'], double: true, onceEver: true }
+      when: ['bubblesAtLeast:500'], double: true, onceEver: true },
+    /* --- the EMI COLOR thresholds (2026-08-24). Same law as above: the
+     * number in the line IS the gate, never a rounding of it. */
+    { id: 'pets500', t: "five hundred pets. i opened a museum about it.",
+      face: '(｡♥‿♥｡)', chain: 'love', on: 'gesture:pet',
+      when: ['petsAtLeast:500'], double: true, onceEver: true },
+    { id: 'hours100', t: "one hundred hours. i'd do them all again.",
+      face: '(✿◡‿◡)', on: 'greet',
+      when: ['hoursAtLeast:100'], double: true, onceEver: true },
+    { id: 'hides25', t: "dismissed twenty five times. the dock is nice. i checked.",
+      face: '._.', on: 'gesture:hide',
+      when: ['hidesAtLeast:25'], double: true, onceEver: true },
+    { id: 'bubbles1000', t: "one thousand bubbles. you read every one. i counted.",
+      face: '(◕‿◕)', on: 'greet',
+      when: ['bubblesAtLeast:1000'], double: true, onceEver: true }
   ])
 });
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
@@ -31,8 +31,10 @@
  * THE GLASS IS 152 x 137 VIRTUAL PX, the same locked geometry face.js paints
  * (res 152, height = w x 0.903). Everything below is written at that scale.
  *
- * EVERY LINE IN THE `caught` TABLES IS A DRAFT. They are tagged at the call
- * site and go through /emi-lines before they are anything else.
+ * THE `caught` TABLES PASSED /emi-lines 2026-08-24 (the EMI COLOR wave): one
+ * line changed (CH3's declined "your loss." bit where EMI only ever teases -
+ * it is "fine. more for me." now), the rest stood as written. Owner reads the
+ * full table at the PR; until that word these are QA-passed, not locked.
  * ==========================================================================*/
 
 import { makeRng } from '../core/rng.js';
@@ -71,8 +73,9 @@ const DARK = '#1A1A2E';
 const CREAM = '#F5F0E1';
 const RAIN_GREEN = '#00FF41';
 
-/* THE WRONG CHANNEL's word list. Owner call 7; these are the doc's candidates
- * and they are DRAFT like every other string here. */
+/* THE WRONG CHANNEL's word list. Owner call 7; these are the doc's candidates.
+ * /emi-lines QA 2026-08-24: passed as written (single innocent words, never
+ * explained - the eeriness is the timing, not the vocabulary). */
 export const WRONG_WORDS = Object.freeze(['soon', 'hi', 'again']);
 
 /* ============================================================================
@@ -229,7 +232,6 @@ export const pong = {
   caught: {
     face: '^_^', hold: 900, bodyFrame: 'idle',
     lineOdds: 0.3,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['left me was winning.', 'i play both sides.', 'best of eleven.'],
   },
 };
@@ -293,7 +295,6 @@ export const browsing = {
   caught: {
     face: '(◔_◔)', hold: 1100, bodyFrame: 'smug',
     lineOdds: 1,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['just checking my mail.', 'i had tabs open.', 'i was reading the rules.'],
   },
 };
@@ -405,20 +406,17 @@ export const watching = {
     snap: { face: '0_0', hold: 200, bodyFrame: 'shock' },
     face: '>_<', hold: 900, body: 'shiver', bodyFrame: 'shock',
     lineOdds: 1,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['you saw nothing.', 'that was research.', 'i was resting my eyes.'],
     offer: {
-      /* DRAFT: /emi-lines pass pending */
-      lines: ['wanna see?', 'i can show you.', 'want the good part?'],
+        lines: ['wanna see?', 'i can show you.', 'want the good part?'],
       accepted: {
         face: '(¬‿¬)', bodyFrame: 'smug',
-        /* DRAFT: /emi-lines pass pending */
-        lines: ['our secret.', 'rate it out of ten.'],
+            lines: ['our secret.', 'rate it out of ten.'],
       },
       declined: {
         face: '-_-', bodyFrame: 'idle',
-        /* DRAFT: /emi-lines pass pending */
-        lines: ['your loss.'],
+        /* Sulky-cute, never a bite: she keeps the good part for herself. */
+        lines: ['fine. more for me.'],
       },
     },
   },
@@ -488,7 +486,6 @@ export const reruns = {
   caught: {
     face: '(◠‿◠)', hold: 1300, bodyFrame: 'pet',
     lineOdds: 1,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['this one is my favorite.', 'i keep the good ones.', 'watch this part.'],
   },
 };
@@ -551,7 +548,6 @@ export const shop = {
   caught: {
     face: '>_<', hold: 1000, bodyFrame: 'shock',
     lineOdds: 1,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['window shopping.', 'not buying anything.', 'it was on sale.'],
   },
 };
@@ -703,7 +699,6 @@ export const saver = {
   caught: {
     face: '^_^', hold: 900, bodyFrame: 'idle',
     lineOdds: 0.25,
-    /* DRAFT: /emi-lines pass pending */
     lines: ['counting pixels.'],
   },
 };

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
@@ -92,8 +92,30 @@ export const MOMENTS = Object.freeze({
   /* --- arriving ------------------------------------------------------- */
   /** The board / a room came up. She notices you. */
   greet: { chain: 'wink' },
-  /** A class started. GLANCE = "noticing the player" (locked). */
-  classStart: { chain: 'glance' },
+  /** A class started. GLANCE = "noticing the player" (locked) - and, since the
+   *  EMI COLOR wave, the arrival face knows what KIND of room it walked into
+   *  (payload.family, from the manifest): scanning in a search room, side-eye
+   *  in a tracking room, half-lidded calm at the pool. Unknown family = the
+   *  locked glance, exactly as before. */
+  classStart: {
+    pick(p) {
+      const FAMILY_FACE = {
+        search: '(◔_◔)', memory: '._.', reflex: 'o_o', comfort: '=_=',
+        tracking: '¬_¬', recall: '0_0', puzzle: '(◠‿◠)',
+      };
+      const f = p && FAMILY_FACE[String(p.family || '')];
+      return f ? { face: f, hold: 1400 } : { chain: 'glance' };
+    },
+  },
+
+  /* --- mid-class (EMI COLOR: the tension mirror) ------------------------
+   * FACE ONLY, by design: no bark pool exists on either name and none may be
+   * added - a mascot that talks during a clutch moment is a distraction with
+   * a fanbase. The games ration these through ctx.mood in shell.js. */
+  /** The room got serious. She leans in and stays leaned. */
+  tense: { face: 'o_o', hold: 1600 },
+  /** The one big moment. Wide eyes, a little shiver, nothing said. */
+  clutch: { face: '(⊙_⊙)', hold: 1800, body: 'shiver' },
 
   /* --- winning -------------------------------------------------------- */
   /** A punch card stamp landed, or a class was won.

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
@@ -31,11 +31,15 @@ import { getEmi, voiceMoment } from './index.js';
  * that ratio. Do not write the joke down anywhere; the lines are the whole gag.
  */
 export const REPORT_LINES = Object.freeze({
-  s: ['top of the class.', 'perfect. show off.', 'gold star. obviously.', 'you came back.'],
-  a: ['nice work today.', 'very good, student.', 'a grade. earned it.', 'good. again tomorrow.'],
-  b: ['solid. keep going.', 'not your best. fine.', 'you always come back.'],
-  c: ['we all have days.', 'passed. barely.', 'try again tomorrow?'],
-  pass: ['you showed up. good.', 'attendance counts.'],
+  s: ['top of the class.', 'perfect. show off.', 'gold star. obviously.', 'you came back.',
+    'frame this one.', 'the s is for sparkle.'],
+  a: ['nice work today.', 'very good, student.', 'a grade. earned it.', 'good. again tomorrow.',
+    'an a. i clapped.', 'almost an s. scary.'],
+  b: ['solid. keep going.', 'not your best. fine.', 'you always come back.',
+    'b for brave. yes it is.'],
+  c: ['we all have days.', 'passed. barely.', 'try again tomorrow?',
+    'the c builds character.', "i'll see you tomorrow."],
+  pass: ['you showed up. good.', 'attendance counts.', 'showing up is a skill.'],
   none: ['same time tomorrow?', 'class dismissed.'],
 });
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
@@ -692,14 +692,15 @@ export const BEATS = deepFreeze([
     // than a first walk across the quad, and everything else that night is
     // smaller. There is deliberately no b29 - every LATER trip says only the
     // fixture's own line, so the novelty is spent exactly once.
-    // DRAFT: /emi-lines pass pending
+    // /emi-lines QA 2026-08-24: contraction fix only ("did not" read stiff
+    // against the prose law); owner reads it at the PR.
     id: 'b28_first_trip',
     phase: 'AMB',
     on: 'fieldTripHome',
     requires: ['b02_hello'],
     priority: 92,
     lead: 'wink',
-    say: 'i did not know i could leave the corner.',
+    say: "i didn't know i could leave the corner.",
     face: '^_^'
   },
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
@@ -637,6 +637,14 @@ export function createVoice(o) {
     /** Which class fired the moment - the per-game colour gate. Closed only
      *  by the payload: no gameKey, no match, never a guess. */
     gameIs: (a, c) => !!c.gameKey && c.gameKey === String(a),
+    /** The LOCAL calendar date, MM-DD. Local on purpose: a holiday is the
+     *  player's evening, not a UTC accountant's. */
+    dateIs: (a) => {
+      const d = new Date(now());
+      const mm = String(d.getMonth() + 1);
+      const dd = String(d.getDate());
+      return ((mm.length < 2 ? '0' + mm : mm) + '-' + (dd.length < 2 ? '0' + dd : dd)) === String(a);
+    },
   };
 
   function holds(when, c) {

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
@@ -60,6 +60,8 @@
  *               hidesAtLeast:N     lifetime x-dismissals
  *               zoneCountAtLeast:N / zoneRowIs:top|mid|bottom   spot memory,
  *               off the dropAt payload (zone, zoneRow, zoneCount)
+ * emi color     droppedOn:room|sealed|wing|none   what a dropAt landed on
+ *               gameIs:KEY         which class fired the moment (per-game colour)
  *
  * FREQUENCY FIELDS honoured on a pool or a line: odds, ceremony, priority,
  * noRepeat, cooldownMs, maxPerSession, maxPerClass, oncePerStreak, onceEver,
@@ -627,6 +629,14 @@ export function createVoice(o) {
     /** Spot memory, read straight off the dropAt payload the widget builds. */
     zoneCountAtLeast: (a, c) => Math.round(Number(c.p.zoneCount) || 0) >= (Number(a) || 0),
     zoneRowIs: (a, c) => !!c.p.zoneRow && String(c.p.zoneRow) === String(a),
+    /* --- the EMI COLOR wave (2026-08-24) -------------------------------- */
+    /** What a dropAt landed on, off onGesture's own hitTest: room | sealed |
+     *  wing | none. A facility never reaches a pool at all (rec 3), so it is
+     *  deliberately not a value here. */
+    droppedOn: (a, c) => String(c.p.what || 'none') === String(a),
+    /** Which class fired the moment - the per-game colour gate. Closed only
+     *  by the payload: no gameKey, no match, never a guess. */
+    gameIs: (a, c) => !!c.gameKey && c.gameKey === String(a),
   };
 
   function holds(when, c) {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/daily-trigger/index.js
@@ -575,6 +575,13 @@ export default {
       hintIndex = -1; hintLetter = '';
       if (ladder) ladder.miss();
       if (casino && ladder) casino.setHeat(ladder.heat);   // the marquee climbs with the storm
+      /* EMI COLOR: row five is the lean-in, the last row the wide eyes; the
+       * third wrong row is one small >_<. All face-side, shell-rationed. */
+      try {
+        if (ctx.mood && rowIndex === ROWS - 1) ctx.mood.clutch();
+        else if (ctx.mood && rowIndex === ROWS - 2) ctx.mood.tense();
+        else if (ctx.mood && rowIndex === 3) ctx.mood.stumble();
+      } catch (e) { /* noop */ }
       beat(tier >= 3);
       paintHud();
 

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -813,6 +813,8 @@ export default {
       combo += 1;
       maxCombo = Math.max(maxCombo, combo);
       mismatchStreak = 0;
+      /* EMI COLOR: one pair left on the bench = the lean-in. */
+      try { if (ctx.mood && unmatchedPairs() === 1) ctx.mood.tense(); } catch (e) { /* noop */ }
       const pairId = cells[a].pairId;
 
       /* "tracked through the static": matched within 2 attempts of the pair
@@ -861,6 +863,8 @@ export default {
     function onMismatch(a, b) {
       combo = 0;
       mismatchStreak += 1;
+      /* EMI COLOR: the small >_<, shell-rationed. */
+      try { if (ctx.mood) ctx.mood.stumble(); } catch (e) { /* noop */ }
       paintMeter();
 
       /* the near-miss tease: 'you KNEW that one'. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
@@ -787,6 +787,12 @@ export default {
         hud();
         heat();
         decks('denyHit', { idx: S.idx, rt, penalty: X_PENALTY, streakBefore, score: S.score });
+        /* EMI COLOR: a big streak dying on the X is the class's one K.O.; a
+         * small slip is just a stumble. Face-side only, shell-throttled. */
+        try {
+          if (ctx.mood && streakBefore >= 6) { ctx.mood.runLost(); ctx.mood.calm(); }
+          else if (ctx.mood) { ctx.mood.stumble(); ctx.mood.calm(); }
+        } catch (e) { /* noop */ }
         say('X clicked (' + source + ') at +' + Math.round(rt) + 'ms: -' + X_PENALTY);
       } else {
         const rt = Math.max(0, at - S.revealAt);
@@ -794,6 +800,11 @@ export default {
         S.score += pts;
         S.streak += 1;
         S.bestStreak = Math.max(S.bestStreak, S.streak);
+        /* EMI COLOR: she leans in with the hot streak, wide-eyed past 14. */
+        try {
+          if (ctx.mood && S.streak >= 14) ctx.mood.clutch();
+          else if (ctx.mood && S.streak >= 8) ctx.mood.tense();
+        } catch (e) { /* noop */ }
         S.tally.popped++;
         S.tally.rts.push(rt);
         const isBest = S.sessionBestRt == null || rt < S.sessionBestRt;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/lost-and-found/index.js
@@ -1035,6 +1035,8 @@ export default {
       if (board) board.setDriftMult(PLAYTEST.CLUTCH_DRIFT_EASE);
       setHeat();
       announce(t('lf_clutch', 'The board relents'), 1800);
+      /* EMI COLOR: the board's own clutch beat is the mascot's too. */
+      try { if (ctx.mood) ctx.mood.clutch(); } catch (e) { /* noop */ }
       say('clutch ease engaged');
     }
 
@@ -1068,6 +1070,11 @@ export default {
       const took = Math.max(0.05, (Date.now() - findStartedAt - (pausedMs - findPausedBase)) / 1000);
       findTimes.push(took);
       finds += 1;
+      /* EMI COLOR: the home stretch (final fifth of the hunt) leans her in. */
+      try {
+        if (ctx.mood && findsTarget > 1 && finds >= Math.ceil(findsTarget * 0.8)
+          && finds < findsTarget) ctx.mood.tense();
+      } catch (e) { /* noop */ }
       /* THE CONFIRM: the press that lands her, on the beat of the press. The
          pitch climbs across the WHOLE class - first find at 1.0, last find at
          1.5, however many finds this tier deals. It used to be a flat +0.06 a
@@ -1166,6 +1173,8 @@ export default {
     function countWrong() {
       misclicks += 1;
       misclickStreak += 1;
+      /* EMI COLOR: a small >_< on the mascot, shell-rationed to 3 a class. */
+      try { if (ctx.mood) ctx.mood.stumble(); } catch (e) { /* noop */ }
       cleanThisFind = false;
       cleanStreak = 0;
       if (!zen) penaltySec += PLAYTEST.MISCLICK_TIME_PENALTY_SEC;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -1403,6 +1403,12 @@ export default {
     function onNewDeepest(d, node) {
       deck('casino', 'newDeepest', d, node);
       deck('pressure', 'newDeepest', d, node);
+      /* EMI COLOR: the mascot leans in as the dive gets real (tier 6) and
+       * shivers at the truly deep water (tier 9). Face only; shell-throttled. */
+      try {
+        if (ctx.mood && d >= 9) ctx.mood.clutch();
+        else if (ctx.mood && d >= 6) ctx.mood.tense();
+      } catch (e) { /* noop */ }
       if (d >= TIER_MAX) return;             // the ceiling has its own ceremony
       if (d >= 3) {
         try { ctx.ceremonies.stamp({ text: tierName(d), target: bench }); } catch (e) { /* noop */ }
@@ -1504,6 +1510,8 @@ export default {
       bestDeepest = Math.max(bestDeepest, diveDeepest);
       deck('casino', 'resurface');
       deck('pressure', 'resurface');
+      /* EMI COLOR: the dive ended - K.O. once a class, then the slate is calm. */
+      try { if (ctx.mood) { ctx.mood.runLost(); ctx.mood.calm(); } } catch (e) { /* noop */ }
       try { ctx.ceremonies.stamp({ text: t('de_stamp_resurface', DE_LEX.de_stamp_resurface), tone: 'pink', target: bench }); } catch (e) { /* noop */ }
       msg('de_resurface_line', DE_LEX.de_resurface_line);
       tick('stamp_bad', 0.3);                      // the loss: a muted thud, never silence

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -1066,7 +1066,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     renderTopbar();
     // EMI SEAM: arriving at the campus, not repainting it - and the FIRST deal
     // of the night is an arrival (see `greeted`, above).
-    if (!greeted || wasScreen !== 'board') { greeted = true; fireMoment('greet'); }
+    if (!greeted || wasScreen !== 'board') {
+      const firstArrival = !greeted;
+      greeted = true;
+      fireMoment('greet');
+      if (firstArrival) noteStreakTurn();
+    }
     /* THE MORNING-AFTER CATCH-UP: a save that sealed its last card before this
      * wave shipped (or whose final-seal ceremony was torn down by a host-forced
      * class before onDone could fire the beat) gets the reveal on its next
@@ -1578,10 +1583,35 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     });
   }
 
+  /* EMI SEAM (EMI COLOR, 2026-08-24): THE STREAK OBITUARY. The host rolls the
+   * attendance streak at local midnight, so the one moment the shell can catch
+   * a streak DYING is the first arrival of a session: the snapshot already
+   * carries the rolled number while `emiLastStreak` still holds the height it
+   * reached last time (written on every stamp below). A drop from >= 3 to the
+   * floor fires the `streakBroken` cry - delayed a breath so it never talks
+   * over the greet - and any ambiguity (host not yet synced, first boot ever)
+   * reads as NO, never as a guessed funeral. */
+  function noteStreakTurn() {
+    try {
+      const cur = Number((store.streak() || {}).count) || 0;
+      const prev = Number(store.get('emiLastStreak')) || 0;
+      if (prev >= 3 && cur <= 1 && cur < prev) {
+        setTimeout(() => {
+          try { fireMoment('streakBroken', { prev, streak: cur }); } catch (e) { /* noop */ }
+        }, 6500);
+      }
+      if (cur !== prev) store.set('emiLastStreak', cur);
+    } catch (e) { /* a mascot may never break an arrival */ }
+  }
+
   function runPunchCeremony(o) {
     // EMI SEAM: the stamp lands. ^_^ + hearts, (≧◡≦) on a 3-day streak, COOL on
     // the tenth hole - moments.js owns which.
     try {
+      const liveStreak = store.streak().count;
+      if (liveStreak !== (Number(store.get('emiLastStreak')) || 0)) {
+        store.set('emiLastStreak', liveStreak);   // the obituary's high-water mark
+      }
       fireMoment('stamp', {
         gameKey: o && o.gameKey,
         streak: store.streak().count,
@@ -2240,7 +2270,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     screen = 'class';
     clearScreen();
     renderTopbar();
-    fireMoment('classStart', { gameKey: cls.gameKey, tier: gradeTier });   // EMI SEAM
+    // EMI SEAM. `family` rides along for the place-awareness table in
+    // moments.js (EMI COLOR): the arrival face knows what kind of room it is.
+    fireMoment('classStart', { gameKey: cls.gameKey, tier: gradeTier,
+      family: manifest.family || null });
     const chrome = classScreenChrome(
       Object.assign({}, cls, { timeBudgetSec }), gradeTier, retake, endless);
 
@@ -2698,10 +2731,17 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
 
     /* EMI SEAM: she reacts to the letter. The report card lands one screen later
      * and its SAY is suppressed for this finish (see showReport) so the two beats
-     * do not talk over each other. */
+     * do not talk over each other.
+     * EMI COLOR (2026-08-24): a C is 'fail' now, not 'miss' - the rage chain and
+     * the its-my-fault pool were written for "the class went badly" and never
+     * fired, while 'miss' is reserved for the mid-class stumble seam (ctx.mood)
+     * whose "one wrong answer, one dropped tile" register it always carried.
+     * The payload grew gameKey + perfect: the per-game colour pools key on the
+     * first, and the perfect-gated dork line was unreachable without the second. */
     lastGraded = { grade: graded.grade, perfect: allDone(), fresh: true };
-    fireMoment(/^[sab]$/i.test(String(graded.grade)) || graded.grade === 'pass' ? 'win' : 'miss',
-      { grade: graded.grade, streak: store.streak().count });
+    fireMoment(/^[sab]$/i.test(String(graded.grade)) || graded.grade === 'pass' ? 'win' : 'fail',
+      { grade: graded.grade, streak: store.streak().count,
+        gameKey: cls.gameKey, perfect: allDone() });
 
     bridge.send({
       type: 'class-ended',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2339,6 +2339,44 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
 
     let ended = false;
 
+    /* ---- ctx.mood (EMI COLOR, 2026-08-24): THE TENSION MIRROR ------------
+     * A game may TELL the mascot how the room feels; it may not make her talk.
+     * `tense`/`clutch` reach only the wordless MOMENTS table (no pool exists on
+     * either name, by design - mid-class speech stays barred), `stumble` fires
+     * the small 'miss' face whose pool always said "one wrong answer, one
+     * dropped tile" and finally means it (its own maxPerClass:1 still rations
+     * the words), and `runLost` is the mid-class K.O. All throttled HERE so no
+     * game can flood her: tense latches until calm, everything shares a 15s
+     * spacing, stumbles cap at 3 a class, the K.O. spends once. Opt-in per
+     * game; a class that never calls it plays exactly as before. */
+    const mood = (() => {
+      let tenseLatch = false, stumbles = 0, lastAt = 0, koSpent = false;
+      const MOOD_SPACING_MS = 15000;
+      const fire = (name, extra) => {
+        try { fireMoment(name, Object.assign({ gameKey: cls.gameKey, midClass: true }, extra || {})); }
+        catch (e) { /* a mascot may never break a class */ }
+      };
+      return Object.freeze({
+        tense() {
+          if (tenseLatch) return; const now = Date.now();
+          if (now - lastAt < MOOD_SPACING_MS) return;
+          tenseLatch = true; lastAt = now; fire('tense');
+        },
+        calm() { tenseLatch = false; },
+        clutch() {
+          const now = Date.now();
+          if (now - lastAt < MOOD_SPACING_MS) return;
+          lastAt = now; fire('clutch');
+        },
+        stumble() {
+          if (stumbles >= 3) return; const now = Date.now();
+          if (now - lastAt < MOOD_SPACING_MS) return;
+          stumbles += 1; lastAt = now; fire('miss');
+        },
+        runLost() { if (koSpent) return; koSpent = true; fire('runLost'); },
+      });
+    })();
+
     const ctx = {
       root: chrome.root,
       engine: engineHandleFor(engine, manifest, cls.gameKey),
@@ -2351,6 +2389,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       peek,
       ceremonies: classCeremonies,
       store,
+      mood,
 
       /* ---- additive read-only projection (all from init) ----------------
        * A class that needs to know the shape of the machine it is running on


### PR DESCRIPTION
The full EMI COLOR program, run start to finish on the owner's word: five waves of commentary, reactions and polish, every line through the /emi-lines gauntlet (voice lock v2 + the 14 banned prose tells).

## Wave 0 - line-debt QA (13623777d)
QA pass over every DRAFT line already shipping. Changed (owner vet wanted):
| where | old | new | why |
|---|---|---|---|
| fieldtrips homeroom | "everyone starts in this room. i have watched all of them." | "everyone starts in this room. i wave every time." | before-read was faintly surveillance = rule-1 kill |
| fieldtrips sortroom | "they keep two piles in there and i would only use one." | "i tried sorting once. everything went in the keep pile." | old line gestured; new one denotes + doubles (EMI discards nothing) |
| b28 first trip | "i did not know i could leave the corner." | "i didn't know i could leave the corner." | contraction (prose tell 12) |
| CH3 declined | "your loss." | "fine. more for me." | teases-never-bites |

Passed as written: 4 field trips, p03/p04/p06, all other channel caught tables, WRONG_WORDS.

## Wave A - the silent gestures get their voice (be998fdbb)
W1 perception shipped approach/hoverLinger/windowSquish emitting into silence, and zone data nothing read. Now: `approach` (4 lines), `hoverLinger` (5), `windowSquishAgain` (3, post-p01), `dropAtSpot` zone commentary (7: top/mid/bottom rows, sealed-wing tape, a zoneCount-25 favourite), 2 fling veteran lines, 4 new telemetry milestones (pets500/hours100/hides25/bubbles1000 - spoken number = the gate, per the law). Fix: `emiDropOnDoor`'s room-card lines fired on every drop incl. bare paving - now gated `droppedOn:room` (new predicate).

## Wave B - per-class colour (ef4bfdbe3)
11 room arrival pools (one per class, `gameIs` gated, priority 20 over the generic, odds still the locked 0.25 - variety grew, frequency did not) + room-flavoured S/consolation lines. Seam repairs found by the audit:
- **the perfect-gated "hasta la vista, baby." never fired once** - the win payload never carried `perfect`. It does now (+ gameKey).
- **a C grade now routes to `fail`** (rage chain + the its-my-fault pool, both written for "the class went badly" and never fired); `miss` is reserved for the new mid-class stumble seam. One-line revert if you prefer the old small face on a C.
- **streak obituary**: `emiLastStreak` high-water in the store; a >=3 streak found dead at first arrival fires `streakBroken` (the cry pool, also never fired before) 6.5s after the greet. Ambiguity = silence.
- report card widened +8 lines at the locked <=24ch / 1-in-6 knowing ratio.

## Wave C - inner life (bfe2536c2 + trap 90 444089cd0)
`ctx.mood` = {tense latch, clutch, stumble, runLost once}, throttled in shell.js (15s shared spacing, 3 stumbles/class). FACE-ONLY BY LAW: no pool exists on tense/clutch and trap 90 forbids one. classStart carries `family` - the arrival face knows the room kind (=_= at the pool, side-eye in tracking rooms). Opt-in call sites riding each room's existing beat: DT (row 5/6 + third wrong row), L&F (inside its own clutch() ease + 80% home stretch + misclick stumble), DV (one pair left + mismatch), IC (streak 8/14 lean-in, X on a >=6 streak = the K.O.), DE (tier 6/9 depth + resurface K.O.).

## Wave D - dork canon II + the calendar (5fd0ed620)
+6 miscast bits (gollum cursor, all-your-base, game-over-man, dead-pixel friend, why-so-serious, in-space-late-night). Four small holidays on the LOCAL clock via new `dateIs` (10-31 x2, 12-31, 01-01, 02-14 - heart via FACE only, 04-01), priority 35 (under a long-absence return).

## Verification
- Fresh suite `scratchpad/emicolor/test-emi-color.mjs`: **4765 assertions, 0 fail** - faces/chains vs the locked sets, <=60ch lowercase, fence + em-dash screens, every `when` predicate implemented, doubles ratio recounted (20.2% excl telemetry, under the 1-in-4 lock), telemetry spoken-number law, null-guard law in all 5 games, live-voice behavioral tests (per-game pool pick, generic fallback, fail/streakBroken with trap-72 chain waits, droppedOn routing, tense/clutch voice silence).
- All 11 touched JS files node --check green; dotnet build 0 errors.
- Live: app booted --arcademy from this branch, shell live, a full sort class ran through the new startClass/ctx.mood shell with zero errors or unknown-predicate warnings in the log.

Line count: barks.js 115 -> 187 lines (45 doubles, ratio honest in the header). All new lines are QA-passed, not owner-locked - the table above + the pool diffs are the vet surface. Happy to run the tkinter picker over the new pools if you want to cut any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZUjZB5VGGG1CjQyB1vZv8
