### PR TITLE
fix(arcademy): full-length jingle, deeper SORT warm rail, Deep End streak that survives merging

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -170,6 +170,10 @@ const INTRO_BED_WINDOW_MS = 600;
 /** After the knock (below) the splash lingers this long, so the bed's opening
  *  bar lands on the CRT and rides the exit into the campus reveal. */
 const KNOCK_EXIT_MS = 700;
+/** The bed is a 4.0s piece and MUST SAY SO: the clip governor's silent default
+ *  is 1.2s, which cut the jingle mid-phrase right as the splash exited (owner
+ *  report, 2026-08-24). Length + air; the element's own `ended` stops it. */
+const INTRO_BED_MAX_MS = 4600;
 const introTimers = new Set();
 
 /* THE KNOCK (web hosts only). `autoplayOk` is the WebView2 host's promise and
@@ -202,7 +206,7 @@ function onKnock() {
   try { if (knockHint) knockHint.classList.add('is-heard'); } catch (e) { /* noop */ }
   if (!splashIsUp()) return;         // failBoot got there first: nothing to score
   cancelIntroCues();                 // the stitched beats yield to the real bed
-  sfx('intro_bed', 0.6);
+  sfx('intro_bed', 0.6, { maxMs: INTRO_BED_MAX_MS });
   if (knockDismissQueued) setTimeout(dismissLoader, KNOCK_EXIT_MS);
 }
 
@@ -261,7 +265,7 @@ function scheduleIntroCues() {
     // hasSample is feature-detected: an older consumer simply stitches.
     const hasBed = !!(audio && typeof audio.hasSample === 'function' && audio.hasSample('intro_bed'));
     if (hasBed && src.autoplayOk === true && elapsed < INTRO_BED_WINDOW_MS) {
-      sfx('intro_bed', 0.6);
+      sfx('intro_bed', 0.6, { maxMs: INTRO_BED_MAX_MS });
       return;
     }
     for (const beat of INTRO_BEATS) {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/sort/index.js
@@ -212,13 +212,17 @@ const DECODER_CEILING = 2;
 const PREWARM = 6;
 /** Cards the WARM RAIL pulls bytes for, standing BEHIND the three-deep stack.
  *  Not a supply figure either: PREWARM buys rows (urls), this buys the bytes
- *  behind them. Four is the fast-swipe window - a player on the shortest ring
- *  clears the stack in about two seconds, and four cards is the slack that
- *  buys a phone on a slow link. */
-const WARM_AHEAD = 4;
+ *  behind them. Four was the first guess and a fast swiper beat it (owner
+ *  report, 2026-08-24: a sub-second rhythm against multi-megabyte gifs on a
+ *  phone link outran the window before the trickle refilled it). Eight is the
+ *  same idea sized to the actual burn rate: ~0.5s a card is ~4s of slack,
+ *  which is one big gif's worth of download on a bad day. */
+const WARM_AHEAD = 8;
 /** Warms in flight at once. This is a background TRICKLE and it is competing
- *  with the top card's own download, which always wins - two is plenty. */
-const WARM_INFLIGHT = 2;
+ *  with the top card's own download, which always wins - but two lanes stalled
+ *  behind one slow gif while the swiper burned the window down, so a third
+ *  lets small stills slip past a big download instead of queueing behind it. */
+const WARM_INFLIGHT = 3;
 /** The claim, when the door never resolved one for us (QUICK SORT floor).
  *  Moved 48/32 -> 72/48 with the deck (see claimOpts): a 120-card tier-4 deck
  *  fed by an 80-row claim would be repeats before the bell. */
@@ -926,9 +930,20 @@ export default {
             held.set(job.url, img);
             try {
               img.decoding = 'async';
-              img.onload = done;
-              img.onerror = () => { held.delete(job.url); done(); };
               img.src = job.url;
+              /* BYTES ARE HALF THE BILL. A cached gif still pays its DECODE on
+               * first paint, and on a phone that is the visible half of the
+               * stutter the owner reported - so a warm is not done until
+               * decode() says the first frame exists. The decoded frames live
+               * in the browser's image cache keyed by url, which is exactly
+               * where the card's own <img> will look. Fallback for engines
+               * without decode(): the old load/error pair, bytes-only. */
+              if (typeof img.decode === 'function') {
+                img.decode().then(done, () => { held.delete(job.url); done(); });
+              } else {
+                img.onload = done;
+                img.onerror = () => { held.delete(job.url); done(); };
+              }
             } catch (e) { held.delete(job.url); done(); }
           }
         }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -1281,8 +1281,19 @@ export default {
         pitch: 1 - PLAYTEST.SLIDE_PITCH_DROP * depthLineFor(boardDeepest(board)),
       });
 
-      /* 2. merges: score, chain, light, the descending chime */
-      chain = result.merges.length;
+      /* 2. merges: score, chain, light, the descending chime.
+       * THE CHAIN IS A STREAK, NOT A SNAPSHOT (owner report, 2026-08-24: "I
+       * keep merging stuff but the streak disappears"). It used to be
+       * RE-ASSIGNED to this one move's merge count, so a swipe that merged a
+       * single pair set it to 1 - under STREAK_VISIBLE - and the chip hid
+       * itself mid-run; only a double merge ever showed, which read as
+       * random. Now every merging move FEEDS it (a double feeds it twice)
+       * and only a real slide that merges NOTHING empties it. A wall bump
+       * never reaches this line, so bumping a wall is not a broken streak;
+       * the only other reset is the resurface deal, where a fresh board
+       * honestly starts a fresh chain. */
+      const burst = result.merges.length;
+      chain = burst > 0 ? chain + burst : 0;
       let deepestMergeEl = null;
       let deepestMergeTier = 0;
       /* Law I is untouched: `score` still moves in ONE place (below, by
@@ -1310,7 +1321,10 @@ export default {
         if (m.tier > deepestMergeTier) { deepestMergeTier = m.tier; deepestMergeEl = node; }
       }
       score += result.score;
-      if (chain >= 2) chainLinks += chain - 1;
+      /* chainLinks stays a CASCADE ledger (extra pairs beyond the first in a
+       * single swipe) - the report card's "links" must not inflate just
+       * because the chip above now remembers across moves. */
+      if (burst >= 2) chainLinks += burst - 1;
       maxChain = Math.max(maxChain, chain);
       paintChain();
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -63,7 +63,11 @@
  *     first (a fast sequence must not pile six whispers on top of each other);
  *     with no key the url is the slot.
  *   - `detail.maxMs` truncates playback (default CLIP_MAX_MS) with a short
- *     fade, so a 6-second phrase does not outlive the round.
+ *     fade, so a 6-second phrase does not outlive the round. An EXPLICIT
+ *     maxMs may buy more than the default - up to CLIP_REQ_MAX_MS - because
+ *     the intro bed is a 4s piece and the 1.2s governor was guillotining it
+ *     mid-phrase right as the splash exited (owner report, 2026-08-24). The
+ *     silent default is unchanged: a caller who says nothing still gets 1.2s.
  *   - a clip is never louder than a recipe at the same level: CLIP_GAIN is the
  *     same headroom the SOUNDS table's `gain` gives an oscillator.
  * A url the browser will not decode is silently dropped, exactly like a name
@@ -202,6 +206,10 @@ const clamp01 = (v) => (Number.isFinite(+v) ? Math.max(0, Math.min(1, +v)) : 0);
 /** Clip playback ceilings. MAX_MS truncates, FADE_MS is the way out, VOICES is
  *  the hard cap on simultaneous slots (Echo needs six, one per pad). */
 const CLIP_MAX_MS = 1200;
+/** What an explicit `detail.maxMs` may buy. The default above is the SILENT
+ *  ceiling; this is the spoken one - long enough for the 4s intro bed with
+ *  air to spare, short enough that no cue can annex the night. */
+const CLIP_REQ_MAX_MS = 8000;
 const CLIP_FADE_MS = 180;
 const CLIP_VOICES = 6;
 /** The headroom a recipe gets from its own `gain`, given to clips too, so a
@@ -451,7 +459,11 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
       el.src = url;
     } catch { return false; }
 
-    const maxMs = Math.max(80, Math.min(CLIP_MAX_MS, Number(d.maxMs) || CLIP_MAX_MS));
+    // Asked-for time is honoured up to CLIP_REQ_MAX_MS; silence means the
+    // 1.2s default. (The old Math.min(CLIP_MAX_MS, asked) clamped every
+    // request DOWN to the default, which cut the 4s intro bed at 1.2s.)
+    const askedMs = Number(d.maxMs) || 0;
+    const maxMs = Math.max(80, askedMs > 0 ? Math.min(askedMs, CLIP_REQ_MAX_MS) : CLIP_MAX_MS);
     const fadeMs = Math.max(0, Math.min(maxMs / 2, Number(d.fadeMs) || CLIP_FADE_MS));
     const rec = { el, gain: null, node: null, timer: 0 };
 


### PR DESCRIPTION
Three owner reports from the 0824 phone pass, one branch:

- **Jingle cut ~2s early at splash exit**: the clip governor clamped every request down to its 1.2s default, guillotining the 4.0s intro bed mid-phrase. An explicit maxMs may now buy up to 8s; silent callers still get 1.2s, so no other clip changes. CDP-verified: bed alive at t=3.17s post-knock, KNOCK-CHECK PASS.
- **SORT gifs outrun by fast swiping**: warm rail deepened 4->8 cards, 2->3 lanes, and a warm now includes img.decode() so a cached gif does not pay its first-frame decode on surface. Data Saver still skips the rail entirely.
- **Deep End streak 'random'**: chain was each move's own merge count, so single-pair merges set it to 1 (below the visibility floor) and the chip hid mid-run. Now a true cross-move streak: merging feeds it, only a merge-less slide breaks it, wall bumps and the report card's cascade ledger untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW3CBGmvoftRkuuPaUQRi