### PR TITLE
feat(arcademy): records title idioms v2 - every class name lives its own game

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1611,6 +1611,20 @@ page's `label_key` / `hint_key`. Impulse Control exports its table as data
     `clutch()` ease) rather than inventing a parallel one. The `classStart` payload
     also carries `family` now - moments.js varies the arrival face by room kind and an
     absent family falls back to the locked glance.
+91. **A SPOTLIGHT LETTER CARRIES EXACTLY TWO ANIMATIONS - [entrance, idle] - AND THE
+    ORDER IS LOAD-BEARING (title idioms, 2026-08-24).** Every `.arc-rs-l` pair in
+    styles.css is `entrance (fill both), idle (no fill, delayed, infinite)`: through the
+    idle's delay the entrance's `both` holds the finished pose, and after it the idle
+    (later in the list) owns the properties it animates. `html.ae-lite .arc-rs-name
+    .arc-rs-l { animation-play-state:running, paused; }` is what makes ae-lite
+    "entrance only": it pauses the SECOND slot by POSITION, freezing the idle in its
+    invisible pre-delay state. Add a third animation to a letter, give an idle a fill,
+    or reorder a pair, and ae-lite silently breaks (a paused mid-list idle with fill
+    would freeze the name mid-flicker). Variants ride `animation-name` overrides only
+    (sort's 2n, composure's 4n set, deja vu's dying tube 7n+3) so the pair shape never
+    changes. Idle events also budget legibility - the name is dark/displaced <=20% of
+    any cycle - and the wall whisper (`arc-rw-*`) is hover/focus-gated per card so the
+    grid never runs ten ambient loops at once.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -3176,70 +3176,130 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
 .arc-rs-close:hover { color:var(--ink); border-color:var(--lav); transform:scale(1.06); }
 .arc-rs-close:focus-visible { outline:2px solid var(--lav); outline-offset:2px; }
 
-/* THE TEN NAMES, each in its class's own idiom - one entrance, then rest.
-   Every letter is a span carrying --li; --ld staggers off it. The keyframes
-   own the hidden from-states, so animation:none (reduced motion) shows the
-   finished name. */
+/* THE TEN NAMES, each in its class's own idiom - one ENTRANCE, loud, then an
+   IDLE recurrence, whispered (owner playtest 2026-08-24: the deja-vu "gone for
+   a sec" is an ambient behaviour, not a one-shot). While the spotlight is up
+   every title occasionally lives its idiom again: long, odd-length cycles
+   (8.8s / 9.4s / 10.7s / 11s / 11.9s / 12.1s / 12.4s / 12.6s / 13.9s) plus the
+   per-letter stagger keep the recurrences from ever syncing into a metronome,
+   and every event is brief so the name stays readable >=80% of idle time.
+   Every letter is a span carrying --li; --ld staggers off it. Each letter
+   carries at most TWO comma'd animations - [entrance, idle] - which is what
+   lets ae-lite freeze every idle with the one play-state pair below. Idles
+   carry NO fill, so through their delay the entrance's `both` holds the
+   finished pose; the keyframes own the hidden from-states, so animation:none
+   (reduced motion) still shows the finished name. */
 .arc-rs-l { --ld:calc(.7s + var(--li, 0) * 55ms); display:inline-block; }
 
-/* daily_trigger - the homeroom word: board flaps turning over, tile by tile. */
+/* daily_trigger - the split-flap departure board: tiles flip over on arrival,
+   and every so often the board updates itself - one ripple of re-flaps. */
 .arc-rs-name[data-anim="daily_trigger"] .arc-rs-l {
   transform-origin:50% 0%;
-  animation:arc-rs-nm-dt .5s var(--ld) cubic-bezier(.3, 1.3, .4, 1) both;
+  animation:arc-rs-nm-dt .5s cubic-bezier(.3, 1.3, .4, 1) var(--ld) both,
+            arc-rs-nm-dt-idle 11s ease-in-out calc(var(--ld) + .55s) infinite;
 }
 @keyframes arc-rs-nm-dt {
   0%   { opacity:0; transform:rotateX(-92deg); }
   60%  { opacity:1; transform:rotateX(14deg); }
   100% { opacity:1; transform:none; }
 }
+@keyframes arc-rs-nm-dt-idle {
+  0%, 78%     { opacity:1; transform:none; }
+  79.6%       { opacity:.3; transform:rotateX(-78deg); }
+  81.2%       { opacity:1; transform:rotateX(12deg); }
+  82.6%, 100% { opacity:1; transform:none; }
+}
 /* lost_and_found - the hunt: letters sit lost in the dark until the torch
-   beam passes and finds them, one by one. */
+   finds them; idle, the beam passes back over the word - a dip of shadow,
+   then each letter caught bright for a beat. */
 .arc-rs-name[data-anim="lost_and_found"] .arc-rs-l {
-  animation:arc-rs-nm-lf .55s var(--ld) ease-out both;
+  animation:arc-rs-nm-lf .55s ease-out var(--ld) both,
+            arc-rs-nm-lf-idle 12.4s ease-in-out calc(var(--ld) + .6s) infinite;
 }
 @keyframes arc-rs-nm-lf {
   0%   { opacity:.12; filter:blur(4px); transform:none; }
   55%  { opacity:1; filter:blur(0) brightness(1.6); transform:scale(1.06); }
   100% { opacity:1; filter:none; transform:none; }
 }
-/* deja_vu - the pair memory: the name lands, ghosts, and comes back - you
-   have seen this one before. */
+@keyframes arc-rs-nm-lf-idle {
+  0%, 80%     { opacity:1; filter:none; }
+  81.6%       { opacity:.55; filter:none; }
+  83.2%       { opacity:1; filter:brightness(1.8); }
+  85.5%, 100% { opacity:1; filter:none; }
+}
+/* deja_vu - OWNER'S PICK: a failing NEON SIGN. The tube strikes on with an
+   uneven electrical stutter (near-zero stagger - a sign lights as one), then
+   idles lit under a neon halo... until the whole word cuts out for a third of
+   a second and sputters back. You saw it. Then you didn't. Then you did. One
+   deterministic letter (7n+3) is the dying tube with an extra mid-cycle
+   sputter of its own. Duty cycle stays >=92% lit - legibility is sacred. */
 .arc-rs-name[data-anim="deja_vu"] .arc-rs-l {
-  animation:arc-rs-nm-dv .95s var(--ld) ease-out both;
+  --ld:calc(.7s + var(--li, 0) * 14ms);
+  text-shadow:0 0 11px color-mix(in srgb, var(--lav), transparent 30%),
+              0 0 26px color-mix(in srgb, var(--pink), transparent 55%),
+              0 2px 10px rgba(0,0,0,.6);
+  animation:arc-rs-nm-dv .9s linear var(--ld) both,
+            arc-rs-nm-dv-idle 8.8s linear calc(var(--ld) + 1.1s) infinite;
+}
+.arc-rs-name[data-anim="deja_vu"] .arc-rs-l:nth-child(7n+3) {
+  animation-name:arc-rs-nm-dv, arc-rs-nm-dv-idle2;
 }
 @keyframes arc-rs-nm-dv {
-  0%   { opacity:0; transform:translateY(6px); text-shadow:0 0 0 transparent; }
-  30%  { opacity:1; transform:none; text-shadow:0 0 0 transparent; }
-  48%  { opacity:.35; text-shadow:6px 0 0 color-mix(in srgb, var(--lav), transparent 40%); }
-  66%  { opacity:1; text-shadow:2px 0 0 color-mix(in srgb, var(--lav), transparent 70%); }
-  100% { opacity:1; text-shadow:0 0 0 transparent; }
+  0%        { opacity:0; }
+  7%        { opacity:1; }
+  11%       { opacity:.08; }
+  19%       { opacity:.9; }
+  23%       { opacity:.2; }
+  27%, 33%  { opacity:1; }
+  36%       { opacity:.5; }
+  39%, 100% { opacity:1; }
+}
+@keyframes arc-rs-nm-dv-idle {
+  0%, 86%      { opacity:1; }
+  86.6%, 90.4% { opacity:0; }
+  91%          { opacity:1; }
+  92.2%        { opacity:.15; }
+  93.4%, 100%  { opacity:1; }
+}
+@keyframes arc-rs-nm-dv-idle2 {
+  0%, 38%      { opacity:1; }
+  38.6%        { opacity:.25; }
+  39.4%        { opacity:1; }
+  40.4%        { opacity:.5; }
+  41.2%, 86%   { opacity:1; }
+  86.6%, 90.4% { opacity:0; }
+  91%          { opacity:1; }
+  92.2%        { opacity:.15; }
+  93.4%, 100%  { opacity:1; }
 }
 /* impulse_control - the Drop Tube: every letter drops the chute and lands
-   with a squash. */
+   with a squash; idle, another drop falls - a quick lift, land, squash. */
 .arc-rs-name[data-anim="impulse_control"] .arc-rs-l {
   transform-origin:50% 100%;
-  animation:arc-rs-nm-ic .5s var(--ld) cubic-bezier(.35, 1.6, .45, 1) both;
+  animation:arc-rs-nm-ic .5s cubic-bezier(.35, 1.6, .45, 1) var(--ld) both,
+            arc-rs-nm-ic-idle 12.6s ease-in-out calc(var(--ld) + .55s) infinite;
 }
 @keyframes arc-rs-nm-ic {
   0%   { opacity:0; transform:translateY(-1em); }
   62%  { opacity:1; transform:translateY(0) scaleY(.8) scaleX(1.12); }
   100% { opacity:1; transform:none; }
 }
-/* the_deep_end - letters rise out of the deep, blur first, surface and rest. */
-.arc-rs-name[data-anim="the_deep_end"] .arc-rs-l {
-  animation:arc-rs-nm-de .8s var(--ld) ease-out both;
-}
-@keyframes arc-rs-nm-de {
-  0%   { opacity:0; transform:translateY(.9em) scale(.92); filter:blur(3px); }
-  60%  { opacity:.9; transform:translateY(-.12em); filter:blur(.5px); }
-  100% { opacity:1; transform:none; filter:none; }
+@keyframes arc-rs-nm-ic-idle {
+  0%, 88%   { transform:none; }
+  89.3%     { transform:translateY(-.24em); }
+  90.6%     { transform:translateY(0) scaleY(.84) scaleX(1.1); }
+  92%, 100% { transform:none; }
 }
 /* sort - two piles: letters deal in from the left and the right, alternating,
-   and snap straight. */
+   and snap straight; idle, they lean toward their pile again - a moment of
+   temptation - then snap their judgment back. */
 .arc-rs-name[data-anim="sort"] .arc-rs-l {
-  animation:arc-rs-nm-sortl .45s var(--ld) cubic-bezier(.25, 1.3, .4, 1) both;
+  animation:arc-rs-nm-sortl .45s cubic-bezier(.25, 1.3, .4, 1) var(--ld) both,
+            arc-rs-nm-sort-idle-l 12.1s ease-in-out calc(var(--ld) + .5s) infinite;
 }
-.arc-rs-name[data-anim="sort"] .arc-rs-l:nth-child(2n) { animation-name:arc-rs-nm-sortr; }
+.arc-rs-name[data-anim="sort"] .arc-rs-l:nth-child(2n) {
+  animation-name:arc-rs-nm-sortr, arc-rs-nm-sort-idle-r;
+}
 @keyframes arc-rs-nm-sortl {
   0%   { opacity:0; transform:translateX(-1.4em) rotate(-9deg); }
   100% { opacity:1; transform:none; }
@@ -3248,10 +3308,24 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   0%   { opacity:0; transform:translateX(1.4em) rotate(9deg); }
   100% { opacity:1; transform:none; }
 }
+@keyframes arc-rs-nm-sort-idle-l {
+  0%, 84%     { transform:none; }
+  85.8%, 88%  { transform:translateX(-.12em) rotate(-4deg); }
+  89.4%       { transform:translateX(.02em) rotate(1deg); }
+  90.6%, 100% { transform:none; }
+}
+@keyframes arc-rs-nm-sort-idle-r {
+  0%, 84%     { transform:none; }
+  85.8%, 88%  { transform:translateX(.12em) rotate(4deg); }
+  89.4%       { transform:translateX(-.02em) rotate(-1deg); }
+  90.6%, 100% { transform:none; }
+}
 /* echo - the Simon ring: each letter lights like a pad, settles, then rings
-   once more, fainter - the echo. */
+   once more, fainter; idle, the sequence replays down the word - one bright
+   ring, then its fainter echo. */
 .arc-rs-name[data-anim="echo"] .arc-rs-l {
-  animation:arc-rs-nm-ec 1s var(--ld) ease-out both;
+  animation:arc-rs-nm-ec 1s ease-out var(--ld) both,
+            arc-rs-nm-ec-idle 10.7s ease-out calc(var(--ld) + 1.05s) infinite;
 }
 @keyframes arc-rs-nm-ec {
   0%   { opacity:0; transform:scale(.6); text-shadow:0 0 0 transparent; }
@@ -3263,11 +3337,43 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   78%  { opacity:1; transform:none; text-shadow:0 0 0 transparent; }
   100% { opacity:1; transform:none; text-shadow:0 0 0 transparent; }
 }
+@keyframes arc-rs-nm-ec-idle {
+  0%, 80%   { transform:none; text-shadow:0 0 0 transparent; }
+  81.6%     { transform:scale(1.16);
+              text-shadow:0 0 14px color-mix(in srgb, var(--pink), transparent 34%); }
+  83.4%     { transform:none; text-shadow:0 0 0 transparent; }
+  86%       { transform:scale(1.07);
+              text-shadow:0 0 9px color-mix(in srgb, var(--pink), transparent 64%); }
+  88%, 100% { transform:none; text-shadow:0 0 0 transparent; }
+}
+/* the_deep_end - OWNER'S PICK: WAVY. The letters swim up out of the deep -
+   blurred, rolling - then never quite settle: a slow sine wave travels the
+   word for as long as the spotlight holds it, each letter bobbing and
+   refracting (a whisper of skew) 130ms behind the one before, the way type
+   reads through water. Amplitude stays under a tenth of an em - legible. */
+.arc-rs-name[data-anim="the_deep_end"] .arc-rs-l {
+  animation:arc-rs-nm-de .85s ease-out var(--ld) both,
+            arc-rs-nm-de-idle 3.8s ease-in-out
+              calc(var(--ld) + .85s + var(--li, 0) * 130ms) infinite;
+}
+@keyframes arc-rs-nm-de {
+  0%   { opacity:0; transform:translateY(1em) rotate(5deg) scale(.9); filter:blur(4px); }
+  45%  { opacity:.85; transform:translateY(-.16em) rotate(-3deg); filter:blur(1px); }
+  70%  { opacity:1; transform:translateY(.06em) rotate(1.5deg); filter:blur(.3px); }
+  100% { opacity:1; transform:none; filter:none; }
+}
+@keyframes arc-rs-nm-de-idle {
+  0%, 50%, 100% { transform:none; }
+  25% { transform:translateY(-.08em) skewX(2.5deg); }
+  75% { transform:translateY(.07em) skewX(-2deg); }
+}
 /* instant_recall - the vigil: the whole name flashes up at once, blanks, and
-   is recalled. No stagger - a flash is one event. */
+   is recalled (no stagger - a flash is one event); idle, the room tests you
+   again - flash, a third of a second of blank, recalled. */
 .arc-rs-name[data-anim="instant_recall"] .arc-rs-l {
   --ld:.72s;
-  animation:arc-rs-nm-ir 1.15s var(--ld) ease-out both;
+  animation:arc-rs-nm-ir 1.15s ease-out var(--ld) both,
+            arc-rs-nm-ir-idle 13.9s ease-out calc(var(--ld) + 1.2s) infinite;
 }
 @keyframes arc-rs-nm-ir {
   0%   { opacity:0; filter:none; }
@@ -3279,17 +3385,28 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   74%  { opacity:1; filter:brightness(1.3); }
   100% { opacity:1; filter:none; }
 }
+@keyframes arc-rs-nm-ir-idle {
+  0%, 87%    { opacity:1; filter:none; }
+  87.6%      { opacity:1; filter:brightness(1.9); }
+  88.8%, 91% { opacity:0; filter:none; }
+  92.4%      { opacity:1; filter:brightness(1.25); }
+  94%, 100%  { opacity:1; filter:none; }
+}
 /* anomaly - the odd one out: the letters file in tidily, except one, which
-   arrives wrong (tilted, pink) and quietly corrects itself. */
+   arrives wrong (tilted, pink) and quietly corrects itself; idle, the tidy
+   letters stay tidy - only the odd one relapses now and then, and corrects
+   itself again. The .is-odd span is records.js's deterministic pick. */
 .arc-rs-name[data-anim="anomaly"] .arc-rs-l {
-  animation:arc-rs-nm-an .5s var(--ld) ease-out both;
+  animation:arc-rs-nm-an .5s ease-out var(--ld) both;
 }
 @keyframes arc-rs-nm-an {
   0%   { opacity:0; transform:translateY(8px); }
   100% { opacity:1; transform:none; }
 }
 .arc-rs-name[data-anim="anomaly"] .arc-rs-l.is-odd {
-  animation:arc-rs-nm-anodd 1.3s var(--ld) cubic-bezier(.3, 1.2, .4, 1) both;
+  animation:arc-rs-nm-anodd 1.3s cubic-bezier(.3, 1.2, .4, 1) var(--ld) both,
+            arc-rs-nm-anodd-idle 9.4s cubic-bezier(.3, 1.2, .4, 1)
+              calc(var(--ld) + 1.4s) infinite;
 }
 @keyframes arc-rs-nm-anodd {
   0%   { opacity:0; transform:translateY(8px); color:var(--ink); }
@@ -3298,14 +3415,30 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   74%  { transform:rotate(-4deg) scale(1); color:var(--ink); }
   100% { opacity:1; transform:none; color:var(--ink); }
 }
-/* composure - the sliding picture: letters glide in from the four directions
-   like tiles crossing the gap, pause flush, and settle. */
-.arc-rs-name[data-anim="composure"] .arc-rs-l {
-  animation:arc-rs-nm-cpu .55s var(--ld) cubic-bezier(.2, .9, .25, 1) both;
+@keyframes arc-rs-nm-anodd-idle {
+  0%, 84%   { transform:none; color:var(--ink); }
+  85.6%     { transform:rotate(12deg) translateY(-2px) scale(1.1); color:var(--pink); }
+  90%       { transform:rotate(12deg) scale(1.1); color:var(--pink); }
+  91.6%     { transform:rotate(-3deg); color:var(--ink); }
+  93%, 100% { transform:none; color:var(--ink); }
 }
-.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n+2) { animation-name:arc-rs-nm-cpr; }
-.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n+3) { animation-name:arc-rs-nm-cpd; }
-.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n)   { animation-name:arc-rs-nm-cpl; }
+/* composure - the sliding picture: letters glide in from the four directions
+   like tiles crossing the gap, pause flush, and settle; idle, a provocation -
+   each letter nudged back toward the direction it came from - and then the
+   long, steady ease home. Holding the line IS the animation. */
+.arc-rs-name[data-anim="composure"] .arc-rs-l {
+  animation:arc-rs-nm-cpu .55s cubic-bezier(.2, .9, .25, 1) var(--ld) both,
+            arc-rs-nm-cpu-idle 11.9s ease-in-out calc(var(--ld) + .6s) infinite;
+}
+.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n+2) {
+  animation-name:arc-rs-nm-cpr, arc-rs-nm-cpr-idle;
+}
+.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n+3) {
+  animation-name:arc-rs-nm-cpd, arc-rs-nm-cpd-idle;
+}
+.arc-rs-name[data-anim="composure"] .arc-rs-l:nth-child(4n) {
+  animation-name:arc-rs-nm-cpl, arc-rs-nm-cpl-idle;
+}
 @keyframes arc-rs-nm-cpu {
   0%   { opacity:0; transform:translateY(-1em); }
   55%  { opacity:1; transform:translateY(.1em); }
@@ -3330,6 +3463,26 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
   75%  { transform:translateX(.08em); }
   100% { opacity:1; transform:none; }
 }
+@keyframes arc-rs-nm-cpu-idle {
+  0%, 86%   { transform:none; }
+  87.4%     { transform:translateY(-.09em); }
+  92%, 100% { transform:none; }
+}
+@keyframes arc-rs-nm-cpr-idle {
+  0%, 86%   { transform:none; }
+  87.4%     { transform:translateX(.09em); }
+  92%, 100% { transform:none; }
+}
+@keyframes arc-rs-nm-cpd-idle {
+  0%, 86%   { transform:none; }
+  87.4%     { transform:translateY(.09em); }
+  92%, 100% { transform:none; }
+}
+@keyframes arc-rs-nm-cpl-idle {
+  0%, 86%   { transform:none; }
+  87.4%     { transform:translateX(-.09em); }
+  92%, 100% { transform:none; }
+}
 
 /* REDUCED MOTION: the spotlight still works, as one plain fade. records.js
    mints .arc-rs-reduced off html.arc-reduced OR prefers-reduced-motion, and
@@ -3350,9 +3503,137 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
 .arc-rs-reduced.is-closing .arc-rs-stage,
 .arc-rs-reduced.is-closing .arc-rs-close { animation:arc-rs-out .12s ease-in both; }
 /* A lit-down room (.ae-lite) keeps the beats but sheds the per-frame extras:
-   the roaming glint and the 16s drift. */
+   the roaming glint, the 16s drift, and every title's idle recurrence. Each
+   letter's animation pair is [entrance, idle], so pausing the SECOND slot
+   freezes the idle in its pre-delay state (no fill = invisible) while the
+   entrance still plays; letters with one animation ignore the extra value. */
 html.ae-lite .arc-rs-glint,
 html.ae-lite .arc-rs .arc-pc-text { animation:none; }
+html.ae-lite .arc-rs-name .arc-rs-l { animation-play-state:running, paused; }
+
+/* ---- THE WALL WHISPER --------------------------------------------------
+   A breath of each class's spotlight identity on the pinned cards - but the
+   wall titles are baked art, so the whisper is the WHOLE face making one
+   small transform/opacity/filter gesture, and it plays ONLY under the
+   pointer (hover) or keyboard focus: ten simultaneous ambient loops would be
+   motion soup, so at rest the wall is still. cardFace stamps data-game on
+   .arc-pc, which is the per-class hook. Reduced motion / ae-lite / the OS
+   preference all silence it (the guard block below wins by file order). */
+/* the_deep_end - the card floats on the water. */
+.arc-records-slot:hover .arc-pc[data-game="the_deep_end"],
+.arc-records-slot:focus-visible .arc-pc[data-game="the_deep_end"] {
+  animation:arc-rw-float 3.6s ease-in-out infinite;
+}
+@keyframes arc-rw-float {
+  0%, 100% { transform:none; }
+  25% { transform:translateY(-3px) rotate(.4deg); }
+  75% { transform:translateY(2px) rotate(-.4deg); }
+}
+/* deja_vu - the neon stutters, briefly, mostly lit. */
+.arc-records-slot:hover .arc-pc[data-game="deja_vu"],
+.arc-records-slot:focus-visible .arc-pc[data-game="deja_vu"] {
+  animation:arc-rw-flicker 3.2s linear infinite;
+}
+@keyframes arc-rw-flicker {
+  0%, 82%   { opacity:1; }
+  83.5%     { opacity:.35; }
+  85%       { opacity:1; }
+  86.5%     { opacity:.7; }
+  88%, 100% { opacity:1; }
+}
+/* daily_trigger - the board ticks over. */
+.arc-records-slot:hover .arc-pc[data-game="daily_trigger"],
+.arc-records-slot:focus-visible .arc-pc[data-game="daily_trigger"] {
+  animation:arc-rw-tick 4.1s ease-in-out infinite;
+}
+@keyframes arc-rw-tick {
+  0%, 88%   { transform:none; filter:none; }
+  90%       { transform:translateY(-2px) scaleY(.985); filter:brightness(1.12); }
+  92%, 100% { transform:none; filter:none; }
+}
+/* lost_and_found - a torch beam passes over the card. */
+.arc-records-slot:hover .arc-pc[data-game="lost_and_found"],
+.arc-records-slot:focus-visible .arc-pc[data-game="lost_and_found"] {
+  animation:arc-rw-torch 4.6s ease-in-out infinite;
+}
+@keyframes arc-rw-torch {
+  0%, 70%, 100% { filter:none; }
+  85% { filter:brightness(1.22); }
+}
+/* impulse_control - a drop lands: lift, land, squash. */
+.arc-records-slot:hover .arc-pc[data-game="impulse_control"],
+.arc-records-slot:focus-visible .arc-pc[data-game="impulse_control"] {
+  transform-origin:50% 100%;
+  animation:arc-rw-drop 4.3s ease-in-out infinite;
+}
+@keyframes arc-rw-drop {
+  0%, 86%   { transform:none; }
+  88%       { transform:translateY(-3px); }
+  90%       { transform:translateY(0) scaleY(.985); }
+  92%, 100% { transform:none; }
+}
+/* sort - which pile? the card rocks, hesitating. */
+.arc-records-slot:hover .arc-pc[data-game="sort"],
+.arc-records-slot:focus-visible .arc-pc[data-game="sort"] {
+  animation:arc-rw-rock 3.9s ease-in-out infinite;
+}
+@keyframes arc-rw-rock {
+  0%, 78%, 100% { transform:none; }
+  83% { transform:rotate(-.8deg); }
+  89% { transform:rotate(.8deg); }
+}
+/* echo - one ring, then its fainter echo. */
+.arc-records-slot:hover .arc-pc[data-game="echo"],
+.arc-records-slot:focus-visible .arc-pc[data-game="echo"] {
+  animation:arc-rw-ring 4.4s ease-out infinite;
+}
+@keyframes arc-rw-ring {
+  0%, 80%   { transform:none; }
+  83%       { transform:scale(1.012); }
+  86%       { transform:none; }
+  89%       { transform:scale(1.006); }
+  92%, 100% { transform:none; }
+}
+/* instant_recall - flash, a blink of gone, recalled. */
+.arc-records-slot:hover .arc-pc[data-game="instant_recall"],
+.arc-records-slot:focus-visible .arc-pc[data-game="instant_recall"] {
+  animation:arc-rw-flash 4.8s ease-out infinite;
+}
+@keyframes arc-rw-flash {
+  0%, 86%   { opacity:1; filter:none; }
+  87.5%     { opacity:1; filter:brightness(1.5); }
+  89.5%     { opacity:.55; filter:none; }
+  92%, 100% { opacity:1; filter:none; }
+}
+/* anomaly - the card hangs wrong for a moment, then corrects itself. */
+.arc-records-slot:hover .arc-pc[data-game="anomaly"],
+.arc-records-slot:focus-visible .arc-pc[data-game="anomaly"] {
+  animation:arc-rw-odd 4.2s ease-in-out infinite;
+}
+@keyframes arc-rw-odd {
+  0%, 80%       { transform:none; }
+  83%, 88%      { transform:rotate(1.6deg); }
+  91.5%, 100%   { transform:none; }
+}
+/* composure - nudged off its pin, and the long steady ease back. */
+.arc-records-slot:hover .arc-pc[data-game="composure"],
+.arc-records-slot:focus-visible .arc-pc[data-game="composure"] {
+  animation:arc-rw-steady 4.7s ease-in-out infinite;
+}
+@keyframes arc-rw-steady {
+  0%, 84%   { transform:none; }
+  86%       { transform:translateX(2px); }
+  94%, 100% { transform:none; }
+}
+/* the silence: same specificity as the whispers above, later in the file. */
+html.arc-reduced .arc-records-slot:hover .arc-pc[data-game],
+html.arc-reduced .arc-records-slot:focus-visible .arc-pc[data-game],
+html.ae-lite .arc-records-slot:hover .arc-pc[data-game],
+html.ae-lite .arc-records-slot:focus-visible .arc-pc[data-game] { animation:none; }
+@media (prefers-reduced-motion: reduce) {
+  .arc-records-slot:hover .arc-pc[data-game],
+  .arc-records-slot:focus-visible .arc-pc[data-game] { animation:none; }
+}
 
 /* An unlocked room's door card wears its seal where the grade stamp goes. */
 /* An unlocked room's door card wears its seal where the grade stamp goes - but a


### PR DESCRIPTION
## What

Reworks the Records Office spotlight title animations so every class name plays a bespoke, diegetic idiom - entrance beat plus an ambient idle recurrence. Owner-directed picks:

- **The Deep End** - letters swim up out of the deep, then a continuous travelling underwater sine wave (bob + refraction skew, phase-offset per letter).
- **Deja Vu** - a failing neon sign: electrical strike-on with uneven duty cycle, neon halo, and an ~8.8s blackout sputter (whole word cuts out for a third of a second and relights); one deterministic dying-tube letter. Lit >=92% of idle time.

The other eight keep their idioms (split-flap, torch beam, drop-squash, two-pile deal, Simon ring, flash-blank-recall, odd-one-out relapse, four-direction composure) and gain idle recurrence on mutually-odd cycles (9.4-13.9s) so nothing metronomes.

Wall cards in the grid whisper the same identity **under hover/keyboard focus only** - the wall at rest stays still.

## How

- CSS only: `styles.css` +323/-42 (THE TEN NAMES block rewritten, THE WALL WHISPER block added). `records.js` untouched - existing per-letter spans / `--li` / `data-anim` / `data-game` hooks were sufficient.
- Each letter carries exactly `[entrance (fill both), idle (delayed, infinite)]` - the pair order is load-bearing: ae-lite pauses idles via the positional `animation-play-state: running, paused` pair (documented as trap 91 in the web CLAUDE.md).
- Reduced motion stays fully static; transform/opacity/filter only; idle is silent.

## Verification

- 15-check browser probe: PASS, zero page errors (wave travelling, neon cut caught live, all ten pairs, ae-lite pause, reduced-motion still, wall hover gating).
- Existing spotlight suite 18/18, campus smoke 12/12, zero page errors.
- Screenshots eyeballed for legibility (neon halo reads, blackout recovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFYHt9c2Z2qS2EK6ovDJU