### PR TITLE
feat(arcademy): Impulse Control tube pixelated (arcade-cabinet pass)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
@@ -131,7 +131,7 @@ html.arc-reduced .g-ic-dusk{transition:none}
    place from overlap alone, and this one covers the viewport. Pinned into the
    wrap's context it can never be hoisted over the shell's fx layer. The same
    line, for the same reason, is on dtrh's #sf-canvas. */
-.g-ic-tube-canvas{position:absolute;inset:0;width:100%;height:100%;display:block;z-index:0}
+.g-ic-tube-canvas{position:absolute;inset:0;width:100%;height:100%;display:block;z-index:0;image-rendering:pixelated}
 /* the last-resort static tube (no canvas at all). NEGATIVE inset on purpose:
    the same composition law as tube3d/tube2d - the spiral has to leave the frame
    rather than stop inside it. */

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
@@ -55,6 +55,10 @@
 
 import { makeRng } from '../../core/rng.js';
 
+const PIXEL = 3;           // CSS px per rendered texel - the arcade-cabinet
+                           // pass (owner 2026-08-24): the ribbon renders at
+                           // 1/PIXEL and the stylesheet's pixelated upscale
+                           // makes it chunky; matches the 3D tier's constant
 const HOLD = 0.86;         // t where the spiral stops shrinking - matches 3D
 const SQUASH = 0.8;        // the ground plane's foreshortening at this camera
 const RIM_F = 0.20;        // basin rim radius as a fraction of min(W,H)
@@ -235,10 +239,13 @@ export function createTube2D(opts = {}) {
   function resize() {
     try {
       W = mount.clientWidth || 800; H = mount.clientHeight || 600;
-      const dpr = Math.min(2, (typeof window !== 'undefined' && window.devicePixelRatio) || 1);
-      canvas.width = Math.round(W * dpr); canvas.height = Math.round(H * dpr);
+      /* the arcade-cabinet pass, this tier's cut: a 1/PIXEL backing store
+         nearest-upscaled by the stylesheet (was a 2x-dpr crisp render) */
+      canvas.width = Math.max(1, Math.round(W / PIXEL));
+      canvas.height = Math.max(1, Math.round(H / PIXEL));
       canvas.style.width = W + 'px'; canvas.style.height = H + 'px';
-      g.setTransform(dpr, 0, 0, dpr, 0, 0);
+      g.setTransform(1 / PIXEL, 0, 0, 1 / PIXEL, 0, 0);
+      g.imageSmoothingEnabled = false;    // the ghost sprite crunches too
       /* dead centre, NOT nudged down: the DOM bubble is pinned to 50%/50% and
          the crater has to be the thing it lands in */
       CX = W / 2; CY = H / 2;

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
@@ -101,8 +101,9 @@
  *
  * MOTION: reduced -> no spin, no march, no morphing or crossfading (the
  * journey's first stop is drawn once and held), no hue cycle, no ken-burns, no
- * comet, no orbit, no particles; pulses are opacity steps. perf -> pixelRatio
- * 1, antialias off, half the particles, band redraw throttled to 4Hz.
+ * comet, no orbit, no particles; pulses are opacity steps. perf -> half the
+ * particles, band redraw throttled to 4Hz (resolution is already floored for
+ * everyone by the arcade-cabinet pass below).
  *
  * TRAPS (each one cost real time): widening the crater's lit lip turns it into
  * a lit egg; nothing may run near-parallel to the chute (z-fight sawtooth);
@@ -350,15 +351,23 @@ export async function createTube3D(opts = {}) {
 
   const canvas = document.createElement('canvas');
   canvas.className = 'g-ic-tube-canvas';
+  /* THE PICTURE IS CHUNKY ON PURPOSE (the arcade-cabinet pass, owner
+     2026-08-24): the tube renders at 1/PIXEL of the viewport and the
+     stylesheet's image-rendering:pixelated does a nearest-neighbour upscale,
+     so every band, glow and particle lands as a fat screen texel. AA stays
+     OFF - it would soften the texels before the upscale and cost the look its
+     edges - and the whole thing is cheaper than the old 2x-dpr render. The
+     DOM bubble stays crisp on top, a sprite over the cabinet screen. */
+  const PIXEL = 3;                        // CSS px per rendered texel
   const renderer = new THREE.WebGLRenderer({
-    canvas, alpha: true, antialias: !perf, powerPreference: 'low-power',
+    canvas, alpha: true, antialias: false, powerPreference: 'low-power',
   });
   // Some webviews hand back a dead context without throwing; probe it.
   const gl = renderer.getContext();
   if (!gl || (typeof gl.isContextLost === 'function' && gl.isContextLost())) {
     throw new Error('webgl context unavailable');
   }
-  renderer.setPixelRatio(Math.min(perf ? 1 : 2, (typeof window !== 'undefined' && window.devicePixelRatio) || 1));
+  renderer.setPixelRatio(1 / PIXEL);
   mount.appendChild(canvas);
 
   const scene = new THREE.Scene();


### PR DESCRIPTION
The Drop Tube in Impulse Control now renders chunky on purpose.

- Both canvas tiers (three.js spiral + 2D ribbon) render at **1/3 resolution** and the stylesheet upscales nearest-neighbour (`image-rendering: pixelated` on `.g-ic-tube-canvas`) - real fat pixels, not a blur filter.
- 3D tier: antialias off (it would soften the texels before the upscale), `setPixelRatio(1/3)` replaces the old up-to-2x-dpr render - strictly cheaper on the GPU.
- 2D tier: 1/3 backing store + `imageSmoothingEnabled = false` so the ghost bubble sprite crunches too.
- The DOM reveal bubble stays crisp on top, reading as a sprite over the cabinet screen.
- `PIXEL = 3` (CSS px per texel) in both tube files is the single taste knob - bump to 4 for chunkier, 2 for subtler.
- Static-div fallback untouched (a gradient has nothing to pixelate).

Verified: full IC suite battery (ic-pure 41/0, casino 88/0, trickster 183/0, stage 183/1, pressure 96/1, ic-shell 20/2, ic-class 52/2, games-ic 3 reds) - every red reproduced **identically on a clean origin/main snapshot**; all are the documented stale fixtures, zero from this change. `dotnet build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP7VygdX4cMgNTsUwDQsRv