### PR TITLE
feat(qol): quest stamp cluster on XP bar + BANK gated to completion XP

### DIFF
--- a/ConditioningControlPanel/Controls/AmbientFxCanvas.cs
+++ b/ConditioningControlPanel/Controls/AmbientFxCanvas.cs
@@ -100,12 +100,23 @@ namespace ConditioningControlPanel.Controls
         /// <summary>Hard ceiling on tokens in flight, and the size the sim array is pre-baked to.</summary>
         private const int MaxBankTokens = BankFlightPlan.MaxTokens;
 
-        /// <summary>Core diameter band in ELEMENT pixels. The book calls for a coin, not a spark.</summary>
-        private const double BankTokenCoreMinPx = 5;
-        private const double BankTokenCoreMaxPx = 7;
+        /// <summary>
+        /// Core diameter band in ELEMENT pixels. The book calls for a coin, not a spark - and since
+        /// THE BANK stopped firing for ambient XP (BankAccumulator.IsBankable) the coin is allowed
+        /// to be a fatter one. MainWindow.BankFx.cs's BankBoxPadPx is sized off the largest halo
+        /// this band can produce; the two move together.
+        /// </summary>
+        private const double BankTokenCoreMinPx = 6;
+        private const double BankTokenCoreMaxPx = 9;
 
         /// <summary>Halo diameter as a multiple of the core. Enough to read as "lit", not as a puff.</summary>
-        private const float BankTokenGlowScale = 3.4f;
+        private const float BankTokenGlowScale = 4.0f;
+
+        /// <summary>
+        /// Peak alpha of the halo. Raised with the rest of the flight: a rare payout is allowed to
+        /// be the brightest thing in the header for the third of a second it is crossing it.
+        /// </summary>
+        private const float BankTokenGlowAlpha = 0.42f;
 
         /// <summary>Fade-in after a token's stagger delay expires, so it arrives instead of popping.</summary>
         private const float BankTokenFadeInMs = 90f;
@@ -363,7 +374,7 @@ namespace ConditioningControlPanel.Controls
                 }
 
                 if (_particleBudget <= 0) ReadEnvironment();
-                // Budget-clamped exactly like Burst, even though seven tokens can never trouble a
+                // Budget-clamped exactly like Burst, even though ten tokens can never trouble a
                 // tier that allows particles at all: the rule is that no emitter gets to opt out.
                 count = Math.Clamp(count, 1, Math.Min(MaxBankTokens, Math.Max(1, _particleBudget)));
 
@@ -1009,7 +1020,7 @@ namespace ConditioningControlPanel.Controls
                 float core = t.Size * min * 2f;
                 float x = t.X * w, y = t.Y * h;
 
-                _paint.Color = SKColors.White.WithAlpha(Alpha(0.30f * a));
+                _paint.Color = SKColors.White.WithAlpha(Alpha(BankTokenGlowAlpha * a));
                 DrawSprite(canvas, Dot, x, y, core * BankTokenGlowScale, core * BankTokenGlowScale);
 
                 // The core brightens as it closes, so the last thing the eye tracks is the arrival.

--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -200,6 +200,7 @@
   "quest_complete": "ABGESCHLOSSEN! +{0} XP",
   "quest_daily": "Tägliche Quest",
   "quest_weekly": "Wöchentliche Quest",
+  "tooltip_quest_stamps": "Deine Quests. Klicke, um den Quests-Tab zu öffnen.",
   "msg_level_up": "Level {0}!",
   "msg_no_phrases": "Keine Phrasen ausgewählt.",
   "msg_enter_url": "Bitte gib eine URL ein.",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -975,6 +975,7 @@
   "quest_complete": "COMPLETE! +{0} XP",
   "quest_daily": "Daily Quest",
   "quest_weekly": "Weekly Quest",
+  "tooltip_quest_stamps": "Your quests. Click to open the Quests tab.",
   "msg_level_up": "Level {0}!",
   "msg_no_phrases": "No phrases selected.",
   "msg_enter_url": "Please enter a URL.",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -200,6 +200,7 @@
   "quest_complete": "¡COMPLETADA! +{0} XP",
   "quest_daily": "Misión Diaria",
   "quest_weekly": "Misión Semanal",
+  "tooltip_quest_stamps": "Tus misiones. Haz clic para abrir la pestaña Misiones.",
   "msg_level_up": "¡Nivel {0}!",
   "msg_no_phrases": "No hay frases seleccionadas.",
   "msg_enter_url": "Por favor ingresa una URL.",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -200,6 +200,7 @@
   "quest_complete": "TERMINÉE ! +{0} XP",
   "quest_daily": "Quête Quotidienne",
   "quest_weekly": "Quête Hebdomadaire",
+  "tooltip_quest_stamps": "Tes quêtes. Clique pour ouvrir l'onglet Quêtes.",
   "msg_level_up": "Niveau {0} !",
   "msg_no_phrases": "Aucune phrase sélectionnée.",
   "msg_enter_url": "Veuillez entrer une URL.",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -200,6 +200,7 @@
   "quest_complete": "完了！+{0} XP",
   "quest_daily": "デイリークエスト",
   "quest_weekly": "ウィークリークエスト",
+  "tooltip_quest_stamps": "あなたのクエスト。クリックでクエストタブを開きます。",
   "msg_level_up": "レベル {0}！",
   "msg_no_phrases": "フレーズが選択されていません。",
   "msg_enter_url": "URLを入力してください。",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -200,6 +200,7 @@
   "quest_complete": "완료! +{0} XP",
   "quest_daily": "일일 퀘스트",
   "quest_weekly": "주간 퀘스트",
+  "tooltip_quest_stamps": "당신의 퀵스트입니다. 클릭하면 퀵스트 탭이 열립니다.",
   "msg_level_up": "레벨 {0}!",
   "msg_no_phrases": "선택된 문구가 없어요.",
   "msg_enter_url": "URL을 입력해 주세요.",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -200,6 +200,7 @@
   "quest_complete": "COMPLETA! +{0} XP",
   "quest_daily": "Missão Diária",
   "quest_weekly": "Missão Semanal",
+  "tooltip_quest_stamps": "Suas missões. Clique para abrir a aba Missões.",
   "msg_level_up": "Nível {0}!",
   "msg_no_phrases": "Nenhuma frase selecionada.",
   "msg_enter_url": "Por favor, insira uma URL.",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -200,6 +200,7 @@
   "quest_complete": "ВЫПОЛНЕНО! +{0} XP",
   "quest_daily": "Ежедневный квест",
   "quest_weekly": "Еженедельный квест",
+  "tooltip_quest_stamps": "Твои квесты. Нажми, чтобы открыть вкладку «Квесты».",
   "msg_level_up": "Уровень {0}!",
   "msg_no_phrases": "Фразы не выбраны.",
   "msg_enter_url": "Пожалуйста, введи URL.",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -789,6 +789,7 @@
   "quest_complete": "完成！+{0} 经验值",
   "quest_daily": "每日任务",
   "quest_weekly": "每周任务",
+  "tooltip_quest_stamps": "你的任务。点击打开任务标签页。",
   "msg_level_up": "等级 {0}！",
   "msg_no_phrases": "未选择短语。",
   "msg_enter_url": "请输入URL。",

--- a/ConditioningControlPanel/MainWindow/MainWindow.BankFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.BankFx.cs
@@ -14,10 +14,10 @@ namespace ConditioningControlPanel
     /// <summary>
     /// THE BANK (House Book) on XP: the seventh event moment, and the only recurring one.
     ///
-    /// <para><b>The move.</b> Value spawns at its SOURCE as 3-7 tokens, flies a slight arc to the
-    /// counter in the header, and the counter ticks up as each token lands - a mini-thud and a
-    /// scale pop on the last. The whole point is that XP stops being a number that silently
-    /// changed and becomes something that visibly arrived from somewhere.</para>
+    /// <para><b>The move.</b> Value spawns at its SOURCE as 4-10 tokens, flies a slight arc to the
+    /// counter in the header, and the counter ticks up as each token lands - a mini-thud, a scale
+    /// pop and one flash across the XP bar on the last. The whole point is that XP stops being a
+    /// number that silently changed and becomes something that visibly arrived from somewhere.</para>
     ///
     /// <para><b>Why it needs a banker.</b> XP in this app does not arrive as events, it arrives as
     /// weather: a flash, a mantra, an attention check and a bubble pop can all settle inside half a
@@ -25,6 +25,14 @@ namespace ConditioningControlPanel
     /// <see cref="BankAccumulator"/> pools awards into rare, deliberate flights (1.5s collection
     /// window, 3s floor between launches) and this file is only its shell: anchors, a canvas, a
     /// counter and the rails that guarantee the display ends up on the truth no matter what.</para>
+    ///
+    /// <para><b>Only completions fly.</b> Pooling made the noise tidy; it did not make it rare. The
+    /// guest list is <see cref="BankAccumulator.IsBankable"/> - a quest, a session, a lock card, the
+    /// counting game - and every other source is refused at <see cref="OnBankXpAwarded"/>, where the
+    /// display hold its <c>XPChanged</c> armed is handed straight back so the ordinary odometer
+    /// tween runs. Weather gets no tokens, no thud, no hold. Because the moment now costs something
+    /// to reach, it is dialled LOUDER than it was when it fired every few seconds: more tokens, a
+    /// bigger pop, and the bar flash below.</para>
     ///
     /// <para><b>The counter is HELD, the ledger is not.</b> House Law I: <c>settings.PlayerXP</c>
     /// is written the instant the award lands, exactly as before - nothing in this file touches the
@@ -42,6 +50,13 @@ namespace ConditioningControlPanel
     /// stack. If that ordering ever slipped, the failure is one award's worth of XP arriving early
     /// rather than a broken counter - <see cref="BankCounterScript.Target"/> clamps a flight to the
     /// live ledger precisely so an already-credited award cannot make the tokens overshoot.</para>
+    ///
+    /// <para><b>The landing flourish.</b> The last token also flashes <c>XPBarFlashOverlay</c>
+    /// through <c>FlashOverlay</c> - the same overlay and the same animation the level-up bloom and
+    /// the Brain Parasite drain already use, so there is exactly one owner of that opacity and
+    /// nothing to fight. <c>XPBarSheen</c> is deliberately left alone: ChromeFx's ambient loop owns
+    /// its opacity AND its gradient stops, and a second driver would stamp on a forever-repeating
+    /// storyboard.</para>
     ///
     /// <para><b>Rails.</b> Every hook here is fire-and-forget safe and wrapped. THE BANK is skipped
     /// outright - the whole staging path, not just the particles - whenever
@@ -65,10 +80,12 @@ namespace ConditioningControlPanel
         /// <summary>
         /// Slack around the origin-to-target bounding box, in window pixels. The tokens' bezier
         /// control point bows off the straight line by up to 22% of the distance travelled, and the
-        /// glow sprite is drawn ~24px wide at its largest - 80px holds both without the arc ever
-        /// clipping on the surface's edge.
+        /// glow sprite is drawn ~36px wide at its largest (a 9px core at AmbientFxCanvas's 4.0 halo
+        /// scale) - 100px holds both without the arc ever clipping on the surface's edge. Grown
+        /// with the glow when the flight became a rare celebration; the old 80 was sized for a 24px
+        /// halo and would have shaved the fattest tokens against the box edge.
         /// </summary>
-        private const double BankBoxPadPx = 80;
+        private const double BankBoxPadPx = 100;
 
         /// <summary>
         /// Hard ceiling on either edge of the token surface. Not a feel dial - a failsafe. Anchor
@@ -90,21 +107,33 @@ namespace ConditioningControlPanel
 
         /// <summary>
         /// Longest the counter may stay held for one flight before the shell stops believing in it.
-        /// Generously past the worst legal envelope (7 tokens: ~480ms of stagger plus a 650ms
+        /// Generously past the worst legal envelope (10 tokens: ~720ms of stagger plus a 650ms
         /// flight), because this is the rail that catches an outcome nobody predicted, not a timer
         /// anything is meant to run up against.
         /// </summary>
         private const double BankWatchdogMs = 6000;
 
-        /// <summary>Counter pop on the last landing. Small: this is a 11px readout, not a headline.</summary>
-        private const double BankPopScale = 1.12;
-        private const double BankPopOutMs = 80;
-        private const double BankPopSpringMs = 220;
+        /// <summary>
+        /// Counter pop on the last landing. It used to be small (1.12) because the flight fired
+        /// every few seconds and a 11px readout jumping that often reads as a twitch. Now that only
+        /// a completion gets here it is allowed to be a catch: a bigger throw, and a longer, softer
+        /// spring so the extra travel settles instead of snapping.
+        /// </summary>
+        private const double BankPopScale = 1.28;
+        private const double BankPopOutMs = 90;
+        private const double BankPopSpringMs = 300;
+
+        /// <summary>Spring overshoot on the way back down. Rises with the pop so the settle keeps its weight.</summary>
+        private const double BankPopSpringAmplitude = 0.9;
 
         /// <summary>Mini-thud, ChaosSfx-style: the override slot ships EMPTY and the fallback carries it.</summary>
         private const string BankThudOverride = "ui/bank_thud.mp3";
         private const string BankThudFallback = "bubbles/Pop2.mp3";
-        private const float BankThudScale = 0.35f;
+        /// <summary>
+        /// Quiet on purpose. At 0.35 the thud was a recurring app noise; the flight is now a rare
+        /// completion cue and a rare cue does not have to shout to be heard.
+        /// </summary>
+        private const float BankThudScale = 0.22f;
         private const string BankThudTag = "ui-bank";
 
         // ---- state -----------------------------------------------------------------
@@ -292,6 +321,33 @@ namespace ConditioningControlPanel
                 {
                     _bank.Reset();
                     AbortBankFlight(writeTruth: true);
+                    return;
+                }
+
+                // THE GATE. This is the first line on the XP path that knows what the XP was FOR,
+                // which is why the decision is taken here and not in TryHoldXpDisplay (that runs
+                // one event earlier, with only "something is landing" to go on).
+                if (!BankAccumulator.IsBankable(award.Source))
+                {
+                    // Nothing else owns the readout: hand it straight back. The release writes the
+                    // ledger through the ordinary path, which sees no hold and tweens exactly as it
+                    // did before this file existed - no tokens, no thud, no wait. Doing it HERE and
+                    // not leaning on the poll's self-heal is the whole difference between "weather
+                    // bypasses THE BANK" and "weather stutters for up to 250ms first".
+                    if (!_bank.HasOpenPot && !_bankFlightLive)
+                    {
+                        ReleaseXpHold(writeTruth: true);
+                        return;
+                    }
+
+                    // A completion is already collecting or in the air and owns the counter. Two
+                    // things are deliberately NOT done: the hold is not released (a live flight
+                    // keeps stepping the counter off a target recomputed from _lastXpShown, so
+                    // releasing under it runs the readout BACKWARDS - see the note above), and the
+                    // award is not added to the pot (the tokens would then be seen to deliver XP
+                    // that was not the completion's). It rides out on the flight's own release to
+                    // truth, which by then includes it.
+                    StartBankPoll();
                     return;
                 }
 
@@ -554,6 +610,7 @@ namespace ConditioningControlPanel
                 PlayBankThud();
                 PopXpCounter();
                 FillXpBarTo(value, _bankHeldNeeded);
+                FlashXpBarOnBankLanding();
 
                 // The pot that was collecting while this flight was in the air keeps the hold: its
                 // own tokens are what will be seen to deliver it.
@@ -615,9 +672,9 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// The catch: a small scale pop on the XP readout as the last token lands, out fast and
-        /// sprung back. TxtXP carries no transform in XAML, so one is installed on first use rather
-        /// than adding a RenderTransform to the header for a moment most launches never reach.
+        /// The catch: a scale pop on the XP readout as the last token lands, out fast and sprung
+        /// back. TxtXP carries no transform in XAML, so one is installed on first use rather than
+        /// adding a RenderTransform to the header for a moment most launches never reach.
         /// </summary>
         private void PopXpCounter()
         {
@@ -647,12 +704,41 @@ namespace ConditioningControlPanel
                 pop.KeyFrames.Add(new EasingDoubleKeyFrame(1.0,
                     KeyTime.FromTimeSpan(TimeSpan.FromMilliseconds(BankPopOutMs + BankPopSpringMs)))
                 {
-                    EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = 0.6 },
+                    EasingFunction = new BackEase { EasingMode = EasingMode.EaseOut, Amplitude = BankPopSpringAmplitude },
                 });
                 _bankPopTransform.BeginAnimation(ScaleTransform.ScaleXProperty, pop, HandoffBehavior.SnapshotAndReplace);
                 _bankPopTransform.BeginAnimation(ScaleTransform.ScaleYProperty, pop, HandoffBehavior.SnapshotAndReplace);
             }
             catch (Exception ex) { App.Logger?.Debug("PopXpCounter: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// The bar half of the catch: one flash across the XP fill as the last token lands, so the
+        /// arrival is felt at bar scale and not only in an 11px number.
+        ///
+        /// <para>It reuses <c>FlashOverlay</c> on <c>XPBarFlashOverlay</c> - the same overlay and
+        /// the same 250ms auto-reversing opacity animation the level-up bloom and the Brain
+        /// Parasite drain already drive - precisely so that overlay keeps exactly ONE owner. The
+        /// two moments cannot collide anyway (house law: a level-up aborts the flight before its
+        /// own bloom), and if they ever did, the loser is a restarted 250ms fade rather than two
+        /// storyboards fighting over one property.</para>
+        ///
+        /// <para><c>XPBarSheen</c> is left strictly alone. ChromeFx's ambient loop owns its opacity
+        /// and its three gradient stops on a forever-repeating clock; anything this file did to it
+        /// would either be stamped on by the next sweep or kill the sweep outright.</para>
+        ///
+        /// <para>Gated on <c>MotionFx.AllowTransitions</c> like the counter pop. Reaching here at
+        /// all already required <c>EventFxAllowed</c>, so this is belt-and-braces for the one case
+        /// where the tier moved mid-flight.</para>
+        /// </summary>
+        private void FlashXpBarOnBankLanding()
+        {
+            try
+            {
+                if (!MotionFx.AllowTransitions) return;
+                FlashOverlay(XPBarFlashOverlay);
+            }
+            catch (Exception ex) { App.Logger?.Debug("FlashXpBarOnBankLanding: {E}", ex.Message); }
         }
 
         /// <summary>
@@ -697,13 +783,14 @@ namespace ConditioningControlPanel
         /// Where the value came from, first visible wins - the same spirit as
         /// <c>FireBurstAtFirstVisible</c>.
         ///
-        /// <para>Only three sources have an honest on-screen home. The rest of the enum is either
-        /// an overlay the window does not contain (Flash, Subliminal, BouncingText, LockCard,
-        /// Video), a thing with no surface at all (KeywordTrigger, Mantra, AttentionCheck,
-        /// AvatarInteraction, Chaos), a separate window (Fyp) or genuinely elsewhere (Other, which
-        /// is what a settled web claim arrives as). Those spawn from the profile bubble instead:
-        /// the "you" that earned it is the only honest origin for XP with no visible source, and it
-        /// sits in the same header strip as the counter, so the flight still reads as a delivery.</para>
+        /// <para>Since THE BANK only flies for completions, in practice this resolves one of four
+        /// sources - and three of them have an honest on-screen home. The fourth (LockCard) is its
+        /// own top-level window that this window's FX layer cannot reach into, so it spawns from the
+        /// profile bubble instead: the "you" that earned it is the only honest origin for XP with no
+        /// visible source, and it sits in the same header strip as the counter, so the flight still
+        /// reads as a delivery. The switch is left total rather than trimmed to the four - an
+        /// ineligible source can still arrive here if <c>IsBankable</c> grows, and a fallback that
+        /// already works is cheaper than a fallback that has to be remembered.</para>
         /// </summary>
         private bool TryResolveBankOrigin(FrameworkElement host, XPSource source, out Point origin)
         {
@@ -712,6 +799,9 @@ namespace ConditioningControlPanel
                 // The session rack. Sessions are the only feature whose XP arrives in one large,
                 // deliberate lump, and its tab is the one a subject actually looks at afterwards.
                 XPSource.Session => NavAnchorForTab("presets"),
+                // The quest rail, the same anchor CelebrateQuestComplete bursts on - so the tokens
+                // spill out of the card that just ticked over rather than from nowhere.
+                XPSource.Quest => NavAnchorForTab("quests"),
                 // Both bubble games are Studio rack modules (HostBubblePop / HostBubbleCount), so
                 // the Studio row is the door their XP came through.
                 XPSource.Bubble or XPSource.BubbleCount => NavAnchorForTab("studio"),

--- a/ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.EventFx.cs
@@ -20,13 +20,13 @@ namespace ConditioningControlPanel
     /// <para><b>The seventh moment.</b> THE BANK on XP (MainWindow.BankFx.cs) joined this list
     /// later and breaks its shape in one way worth naming here: the six above are one-offs a
     /// subject reaches a handful of times, while XP arrives constantly, so THE BANK is the only
-    /// event moment that has to be RATIONED. It does not burst - value flies as 3-7 tokens from
-    /// its source to the XP counter - and it does not fire per event: <see cref="BankAccumulator"/>
-    /// pools awards behind a collection window and a launch cooldown so a busy minute produces a
-    /// few deliberate flights instead of thirty. It keeps every rule below (the focus gate, the
-    /// particle gate, TransformToVisual anchoring, no idle clock) and owns a second, re-sizeable
-    /// canvas of its own, because a flight is a line between two anchors rather than a box round
-    /// one.</para>
+    /// event moment that has to be RATIONED. It does not burst - value flies as 4-10 tokens from
+    /// its source to the XP counter - and it does not fire per event: only completion-shaped awards
+    /// reach it at all (<see cref="BankAccumulator.IsBankable"/>), and those are then pooled behind
+    /// a collection window and a launch cooldown, so even a session and the quest it finishes ship
+    /// as one flight. It keeps every rule below (the focus gate, the particle gate,
+    /// TransformToVisual anchoring, no idle clock) and owns a second, re-sizeable canvas of its
+    /// own, because a flight is a line between two anchors rather than a box round one.</para>
     ///
     /// <para><b>The shared burst layer.</b> One <see cref="AmbientFxCanvas"/> lives in
     /// <c>EventFxHost</c>, a child of RootGrid <i>outside</i> the 1489x901 Viewbox. Inside the

--- a/ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.QuestStamps.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using ConditioningControlPanel.Localization;
+using ConditioningControlPanel.Models;
+using ConditioningControlPanel.Services;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// THE QUEST STAMPS: the four tilted squares that sit at the far left of the header XP row and
+    /// say, without a click, how today went - three daily slots and the week's one.
+    ///
+    /// <para><b>Why stamps.</b> The Quests tab already tells the whole story; the header only needs
+    /// the shape of it. Three slots stamped gold is "today is done", one pink square with a sliver
+    /// of fill along its bottom is "you are mid-quest", a dashed ghost is "not rolled yet". The
+    /// tilt is the point: a card that is perfectly square reads as a button, and a card knocked a
+    /// few degrees off reads as something that was stamped onto the panel.</para>
+    ///
+    /// <para><b>Layout contract - this must not cost the row a single pixel.</b> The host
+    /// (<c>QuestStampHost</c>, MainWindow.xaml) is a new <i>Auto</i> column at index 0 of the XP
+    /// bar's left grid, ahead of the LVL chip. The bar's own column is star-width, so the cluster
+    /// measuring ~71px simply shortens the bar by 71px and nothing else in the row moves - and
+    /// collapsing the host (no QuestService) hands all of it straight back. Vertically the host's
+    /// Height is PINNED at 22 in XAML: the rotated squares' bounding boxes run a couple of px past
+    /// that, and a pinned height means the overhang draws (ClipToBounds is false) without ever
+    /// entering the row's measure. A stat pill is ~23px tall, so the row's height is still decided
+    /// by the pills exactly as it was before this file existed.</para>
+    ///
+    /// <para><b>Built in code, rebuilt whole.</b> Four elements is cheaper to re-create than to
+    /// diff, and every repaint starts from live quest state rather than from the accumulation of
+    /// whatever transitions happened - the same discipline as
+    /// <see cref="RefreshSpiralRailEntry"/>. Nothing here is templated, so no converter or resource
+    /// needs to exist in Window.Resources for it.</para>
+    ///
+    /// <para><b>Rails.</b> All four subscriptions (three quest events + language) arrive off the UI
+    /// thread or during teardown, so every handler marshals to the Dispatcher, bails on
+    /// <c>HasShutdownStarted</c> (CLAUDE.md rule 8) and is wrapped. Wiring is once-only and is
+    /// released on <c>Closed</c>.</para>
+    /// </summary>
+    public partial class MainWindow
+    {
+        // ---- DIALS ----------------------------------------------------------------
+
+        /// <summary>Edge of a daily stamp, in px. Kept under the host's pinned 22 so the rotated
+        /// bounding box only just overhangs.</summary>
+        private const double QuestStampDailySize = 20;
+
+        /// <summary>The weekly stamp is deliberately a touch bigger than a daily one - the other
+        /// half of "this one is different" (the first half is the purple).</summary>
+        private const double QuestStampWeeklySize = 23;
+
+        /// <summary>Left edge of each stamp inside the host. The 16px step against a 20px stamp is
+        /// what produces the 4px overlap; the squares are meant to look dropped, not gridded.</summary>
+        private static readonly double[] QuestStampOffsets = { 0, 16, 32, 48 };
+
+        /// <summary>Tilt per stamp, degrees. Alternating signs and no two equal - a repeated angle
+        /// immediately reads as a pattern instead of as four separate stampings.</summary>
+        private static readonly double[] QuestStampAngles = { -4, 3, -2, 5 };
+
+        /// <summary>Inset of the progress sliver from the stamp's edge. A Border/Rectangle does not
+        /// clip its neighbours to a CornerRadius, so the fill has to be pulled in far enough that a
+        /// square corner cannot poke out past the rounded outline.</summary>
+        private const double QuestStampFillInset = 2.5;
+
+        private const double QuestStampFillHeight = 2.5;
+
+        // ---- PALETTE (frozen; these repaint on every quest tick) -------------------
+
+        private static readonly Brush QuestStampGoldStroke = Frozen(Color.FromArgb(0xCC, 0xFF, 0xD7, 0x00));
+        private static readonly Brush QuestStampGoldFill = Frozen(Color.FromArgb(0x30, 0xFF, 0xD7, 0x00));
+        private static readonly Brush QuestStampGoldInk = Frozen(Color.FromRgb(0xFF, 0xD7, 0x00));
+
+        private static readonly Brush QuestStampPinkStroke = Frozen(Color.FromRgb(0xFF, 0x69, 0xB4));
+        private static readonly Brush QuestStampPanelFill = Frozen(Color.FromRgb(0x25, 0x25, 0x42));
+
+        private static readonly Brush QuestStampPurpleStroke = Frozen(Color.FromRgb(0xB5, 0x7E, 0xDC));
+        private static readonly Brush QuestStampPurpleFill = Frozen(Color.FromRgb(0x2A, 0x1F, 0x3D));
+
+        private static readonly Brush QuestStampGhostStroke = Frozen(Color.FromRgb(0x3D, 0x3D, 0x60));
+        private static readonly Brush QuestStampGhostFill = Frozen(Color.FromArgb(0x22, 0x1A, 0x1A, 0x2E));
+
+        private static Brush Frozen(Color c)
+        {
+            var b = new SolidColorBrush(c);
+            b.Freeze();
+            return b;
+        }
+
+        private bool _questStampsWired;
+
+        // ---- WIRING ---------------------------------------------------------------
+
+        /// <summary>
+        /// Called once from the window's construction path (MainWindow.xaml.cs), next to the other
+        /// header surfaces. Safe to call before quests have generated: the first repaint just draws
+        /// three ghosts and hides itself if there is no service at all.
+        /// </summary>
+        private void InitializeQuestStamps()
+        {
+            if (_questStampsWired) return;
+            _questStampsWired = true;
+
+            try
+            {
+                var quests = App.Quests;
+                if (quests != null)
+                {
+                    quests.QuestCompleted += OnQuestStampsQuestCompleted;
+                    quests.QuestProgressChanged += OnQuestStampsProgressChanged;
+                    quests.QuestsRefreshed += OnQuestStampsRefreshed;
+                }
+                LocalizationManager.Instance.LanguageChanged += OnQuestStampsLanguageChanged;
+
+                // Same release pattern as MainWindow.JustDrop.cs: the events outlive the window.
+                Closed += (_, _) =>
+                {
+                    try
+                    {
+                        var q = App.Quests;
+                        if (q != null)
+                        {
+                            q.QuestCompleted -= OnQuestStampsQuestCompleted;
+                            q.QuestProgressChanged -= OnQuestStampsProgressChanged;
+                            q.QuestsRefreshed -= OnQuestStampsRefreshed;
+                        }
+                        LocalizationManager.Instance.LanguageChanged -= OnQuestStampsLanguageChanged;
+                    }
+                    catch { /* teardown */ }
+                };
+
+                RefreshQuestStamps();
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[QuestStamps] cluster could not be wired: {E}", ex.Message);
+            }
+        }
+
+        private void OnQuestStampsQuestCompleted(object? sender, QuestCompletedEventArgs e) => QueueQuestStampRepaint();
+        private void OnQuestStampsProgressChanged(object? sender, QuestProgressEventArgs e) => QueueQuestStampRepaint();
+        private void OnQuestStampsRefreshed(object? sender, EventArgs e) => QueueQuestStampRepaint();
+        private void OnQuestStampsLanguageChanged(object? sender, EventArgs e) => QueueQuestStampRepaint();
+
+        /// <summary>
+        /// Marshal + guard. Every caller is a service event that can land on a worker thread, and
+        /// quest progress in particular can tick several times a second during a session - the
+        /// repaint is four elements, so it is cheaper to just do it than to throttle it.
+        /// </summary>
+        private void QueueQuestStampRepaint()
+        {
+            try
+            {
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null || dispatcher.HasShutdownStarted) return;
+                dispatcher.BeginInvoke(new Action(RefreshQuestStamps));
+            }
+            catch { /* fire-and-forget */ }
+        }
+
+        // ---- PAINT ----------------------------------------------------------------
+
+        /// <summary>
+        /// Rebuild the four stamps from live quest state. Computed from scratch every time, so any
+        /// arrival order - a midnight roll, a reroll, a 3/3 finish, a logout wiping the service -
+        /// lands on a correct cluster.
+        /// </summary>
+        internal void RefreshQuestStamps()
+        {
+            var host = QuestStampHost;
+            if (host == null) return;
+
+            try
+            {
+                if (Application.Current?.Dispatcher?.HasShutdownStarted != false) return;
+
+                var quests = App.Quests;
+                if (quests == null)
+                {
+                    // No service: collapse so the star-width bar reclaims the whole row.
+                    host.Children.Clear();
+                    host.ToolTip = null;
+                    host.Visibility = Visibility.Collapsed;
+                    return;
+                }
+
+                host.Visibility = Visibility.Visible;
+                host.Children.Clear();
+
+                int completedToday = quests.GetDailyQuestsCompletedToday();
+                var dailyDef = quests.GetCurrentDailyDefinition();
+                var dailyActive = quests.Progress?.DailyQuest;
+                var weeklyDef = quests.GetCurrentWeeklyDefinition();
+                var weeklyActive = quests.Progress?.WeeklyQuest;
+
+                for (int slot = 0; slot < QuestService.MaxDailyQuestsPerDay; slot++)
+                {
+                    UIElement stamp;
+                    if (slot < completedToday)
+                    {
+                        // STAMPED. Gold outline, gold wash, a check - dimmed, because a finished
+                        // slot is a record rather than a thing asking for attention.
+                        stamp = BuildQuestStamp(
+                            QuestStampDailySize, QuestStampOffsets[slot], QuestStampAngles[slot],
+                            QuestStampGoldStroke, QuestStampGoldFill, dashed: false,
+                            glyph: "✓", glyphBrush: QuestStampGoldInk, glyphBold: true,
+                            fillFraction: 1.0, fillBrush: QuestStampGoldStroke, opacity: 0.8);
+                    }
+                    else if (slot == completedToday && dailyDef != null && dailyActive != null)
+                    {
+                        // LIVE. Pink outline on the panel colour, the quest's own icon, and a
+                        // sliver of pink along the bottom edge for how far in it is.
+                        stamp = BuildQuestStamp(
+                            QuestStampDailySize, QuestStampOffsets[slot], QuestStampAngles[slot],
+                            QuestStampPinkStroke, QuestStampPanelFill, dashed: false,
+                            glyph: dailyDef.Icon, glyphBrush: QuestStampPinkStroke, glyphBold: false,
+                            fillFraction: QuestStampFraction(dailyActive.CurrentProgress, dailyDef.TargetValue),
+                            fillBrush: QuestStampPinkStroke, opacity: 1.0);
+                    }
+                    else
+                    {
+                        // NOT ROLLED. A dashed ghost - present enough to say "there is a third
+                        // one", quiet enough not to look like a thing you can act on.
+                        stamp = BuildQuestStamp(
+                            QuestStampDailySize, QuestStampOffsets[slot], QuestStampAngles[slot],
+                            QuestStampGhostStroke, QuestStampGhostFill, dashed: true,
+                            glyph: null, glyphBrush: null, glyphBold: false,
+                            fillFraction: 0, fillBrush: null, opacity: 0.5);
+                    }
+                    host.Children.Add(stamp);
+                }
+
+                // The weekly: bigger, purple, and it keeps its own fill even while the dailies
+                // churn underneath it.
+                bool weeklyDone = weeklyActive?.IsCompleted == true;
+                UIElement weekly;
+                if (weeklyDef == null || weeklyActive == null)
+                {
+                    weekly = BuildQuestStamp(
+                        QuestStampWeeklySize, QuestStampOffsets[3], QuestStampAngles[3],
+                        QuestStampGhostStroke, QuestStampGhostFill, dashed: true,
+                        glyph: null, glyphBrush: null, glyphBold: false,
+                        fillFraction: 0, fillBrush: null, opacity: 0.5);
+                }
+                else if (weeklyDone)
+                {
+                    weekly = BuildQuestStamp(
+                        QuestStampWeeklySize, QuestStampOffsets[3], QuestStampAngles[3],
+                        QuestStampGoldStroke, QuestStampGoldFill, dashed: false,
+                        glyph: "✓", glyphBrush: QuestStampGoldInk, glyphBold: true,
+                        fillFraction: 1.0, fillBrush: QuestStampGoldStroke, opacity: 0.85);
+                }
+                else
+                {
+                    weekly = BuildQuestStamp(
+                        QuestStampWeeklySize, QuestStampOffsets[3], QuestStampAngles[3],
+                        QuestStampPurpleStroke, QuestStampPurpleFill, dashed: false,
+                        glyph: weeklyDef.Icon, glyphBrush: QuestStampPurpleStroke, glyphBold: false,
+                        fillFraction: QuestStampFraction(weeklyActive.CurrentProgress, weeklyDef.TargetValue),
+                        fillBrush: QuestStampPurpleStroke, opacity: 1.0);
+                }
+                host.Children.Add(weekly);
+
+                host.ToolTip = BuildQuestStampTooltip(
+                    completedToday, dailyDef, dailyActive, weeklyDef, weeklyActive);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[QuestStamps] repaint failed: {E}", ex.Message);
+            }
+        }
+
+        private static double QuestStampFraction(int current, int target)
+        {
+            if (target <= 0) return 0;
+            return Math.Max(0, Math.Min(1.0, (double)current / target));
+        }
+
+        /// <summary>
+        /// One stamp. A Grid rather than a Border because the ghost state needs a dashed outline,
+        /// and only a Shape carries StrokeDashArray - so the outline is a rounded Rectangle and the
+        /// glyph and the progress sliver are siblings stacked on top of it.
+        /// </summary>
+        private static UIElement BuildQuestStamp(
+            double size, double left, double angle,
+            Brush stroke, Brush fill, bool dashed,
+            string? glyph, Brush? glyphBrush, bool glyphBold,
+            double fillFraction, Brush? fillBrush, double opacity)
+        {
+            var cell = new Grid
+            {
+                Width = size,
+                Height = size,
+                Opacity = opacity,
+                Margin = new Thickness(left, 0, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Left,
+                VerticalAlignment = VerticalAlignment.Center,
+                RenderTransformOrigin = new Point(0.5, 0.5),
+                RenderTransform = new RotateTransform(angle),
+                IsHitTestVisible = false,   // the HOST owns the click, gaps included
+            };
+
+            var plate = new Rectangle
+            {
+                RadiusX = 3,
+                RadiusY = 3,
+                Fill = fill,
+                Stroke = stroke,
+                StrokeThickness = 1.5,
+            };
+            if (dashed)
+            {
+                plate.StrokeDashArray = new DoubleCollection { 2, 1.6 };
+                plate.StrokeThickness = 1.0;
+            }
+            cell.Children.Add(plate);
+
+            if (!string.IsNullOrWhiteSpace(glyph))
+            {
+                cell.Children.Add(new TextBlock
+                {
+                    Text = glyph,
+                    FontSize = size >= QuestStampWeeklySize ? 12 : 10.5,
+                    FontWeight = glyphBold ? FontWeights.Bold : FontWeights.Normal,
+                    Foreground = glyphBrush ?? Brushes.White,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    TextAlignment = TextAlignment.Center,
+                });
+            }
+
+            if (fillFraction > 0 && fillBrush != null)
+            {
+                double track = size - (QuestStampFillInset * 2);
+                cell.Children.Add(new Border
+                {
+                    Height = QuestStampFillHeight,
+                    Width = Math.Max(1.0, track * fillFraction),
+                    CornerRadius = new CornerRadius(1),
+                    Background = fillBrush,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    VerticalAlignment = VerticalAlignment.Bottom,
+                    Margin = new Thickness(QuestStampFillInset, 0, 0, QuestStampFillInset),
+                });
+            }
+
+            return cell;
+        }
+
+        /// <summary>
+        /// Quest names come from the definition's own loc key, which only exists for the ~20 quests
+        /// that ship in the language files - a server-rolled quest would otherwise render its raw
+        /// key. Falls back to the definition's English name, mod-aware, exactly as the Quests tab
+        /// does.
+        /// </summary>
+        private static string QuestStampName(QuestDefinition def)
+        {
+            var name = def.LocalizedName;
+            if (string.IsNullOrWhiteSpace(name) || name.StartsWith("quest_", StringComparison.Ordinal))
+                name = def.Name;
+            return App.Mods?.MakeModAware(name) ?? name;
+        }
+
+        private static string BuildQuestStampTooltip(
+            int completedToday,
+            QuestDefinition? dailyDef, ActiveQuest? dailyActive,
+            QuestDefinition? weeklyDef, ActiveQuest? weeklyActive)
+        {
+            var sb = new StringBuilder();
+            sb.Append(Loc.Get("tooltip_quest_stamps"));
+
+            sb.Append('\n').Append('\n')
+              .Append(Loc.Get("quest_daily")).Append("  ")
+              .Append(completedToday).Append('/').Append(QuestService.MaxDailyQuestsPerDay);
+            if (dailyDef != null && dailyActive != null && completedToday < QuestService.MaxDailyQuestsPerDay)
+            {
+                sb.Append('\n').Append(dailyDef.Icon).Append(' ').Append(QuestStampName(dailyDef))
+                  .Append("  ").Append(dailyActive.CurrentProgress).Append('/').Append(dailyDef.TargetValue);
+            }
+
+            sb.Append('\n').Append('\n').Append(Loc.Get("quest_weekly"));
+            if (weeklyDef != null && weeklyActive != null)
+            {
+                sb.Append('\n').Append(weeklyDef.Icon).Append(' ').Append(QuestStampName(weeklyDef))
+                  .Append("  ").Append(weeklyActive.CurrentProgress).Append('/').Append(weeklyDef.TargetValue);
+            }
+
+            return sb.ToString();
+        }
+
+        // ---- INTERACTION ----------------------------------------------------------
+
+        /// <summary>The whole cluster is one target: click goes to the Quests tab through the same
+        /// funnel the nav button uses, so bark rules and door expansion behave identically.</summary>
+        private void QuestStamps_Click(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                ShowTab("quests");
+                e.Handled = true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("[QuestStamps] navigation failed: {E}", ex.Message);
+            }
+        }
+
+        private void QuestStamps_MouseEnter(object sender, MouseEventArgs e)
+        {
+            try { MotionFx.HoverLift(QuestStampHost, true); } catch { }
+        }
+
+        private void QuestStamps_MouseLeave(object sender, MouseEventArgs e)
+        {
+            try { MotionFx.HoverLift(QuestStampHost, false); } catch { }
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -2191,14 +2191,38 @@
                 <!-- LEFT SIDE: XP Bar -->
                 <Grid Grid.Column="0">
                     <Grid.ColumnDefinitions>
+                        <!-- Quest stamp cluster (MainWindow.QuestStamps.cs). Auto-width, so the
+                             star-width bar column below simply gets shorter by however wide the
+                             cluster measures - and reclaims the full width again the moment the
+                             host collapses (no QuestService). -->
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
+                    <!-- The 4 stamps (3 daily slots + 1 weekly) are BUILT IN CODE, not here: their
+                         count is fixed but their state, tilt, fill and tooltip all come from live
+                         quest data, so there is nothing worth templating.
+
+                         Height is PINNED at 22 on purpose. The tallest thing in this row is a stat
+                         pill (~23px), and a pinned height means the tilted squares - whose rotated
+                         bounding boxes run a couple of px past 22 - overhang without ever
+                         contributing to the row's measure. ClipToBounds stays false so the
+                         overhang draws; Background is a transparent brush (NOT null) so the whole
+                         cluster, gaps included, is one hit-test target. -->
+                    <Grid x:Name="QuestStampHost" Grid.Column="0"
+                          Height="22" ClipToBounds="False"
+                          Background="Transparent" Cursor="Hand"
+                          VerticalAlignment="Center" HorizontalAlignment="Left"
+                          Margin="0,0,12,0" Visibility="Collapsed"
+                          RenderTransformOrigin="0.5,0.5"
+                          MouseLeftButtonUp="QuestStamps_Click"
+                          MouseEnter="QuestStamps_MouseEnter"
+                          MouseLeave="QuestStamps_MouseLeave"/>
                     <!-- Velvet Kit 2 (FX lane B): the LVL chip owns a scale+rotate rig so a level-up
                          can pop it. Named transforms, animated from MainWindow.HeroFx.cs via
                          BeginAnimation - nothing else drives this TextBlock's RenderTransform. -->
-                    <TextBlock x:Name="TxtLevelLabel" Grid.Column="0" Text="{loc:Str label_lvl_1_2}" Foreground="{DynamicResource PinkBrush}"
+                    <TextBlock x:Name="TxtLevelLabel" Grid.Column="1" Text="{loc:Str label_lvl_1_2}" Foreground="{DynamicResource PinkBrush}"
                                poss:Possession.Role="Label" poss:Possession.Name="the level label"
                                FontWeight="Bold" FontSize="12" VerticalAlignment="Center" Margin="0,0,10,0"
                                RenderTransformOrigin="0.5,0.5">
@@ -2211,7 +2235,7 @@
                     </TextBlock>
                     <!-- x:Name is for the PR-5 level-up burst: the TRACK is where the bar's cap
                          sits, and after a level-up the fill has already wrapped back to a sliver. -->
-                    <Border x:Name="XPBarTrack" Grid.Column="1" Background="{DynamicResource PanelAccentBrush}" CornerRadius="4" Height="8" Margin="0,0,10,0">
+                    <Border x:Name="XPBarTrack" Grid.Column="2" Background="{DynamicResource PanelAccentBrush}" CornerRadius="4" Height="8" Margin="0,0,10,0">
                         <Grid>
                             <Border x:Name="XPBar" Background="{DynamicResource PinkBrush}" CornerRadius="4"
                                     HorizontalAlignment="Left" Width="100">
@@ -2263,7 +2287,7 @@
                             </Border>
                         </Grid>
                     </Border>
-                    <TextBlock x:Name="TxtXP" Grid.Column="2" Text="{loc:Str label_0_70_xp}" Foreground="{StaticResource TextMutedBrush}"
+                    <TextBlock x:Name="TxtXP" Grid.Column="3" Text="{loc:Str label_0_70_xp}" Foreground="{StaticResource TextMutedBrush}"
                                FontSize="11" VerticalAlignment="Center" Margin="0,0,15,0"/>
                 </Grid>
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml.cs
@@ -439,6 +439,11 @@ namespace ConditioningControlPanel
                 App.Quests.QuestsRefreshed += (s, e) => Dispatcher.Invoke(() => RefreshQuestUI());
             }
 
+            // The header's four tilted quest stamps (3 daily slots + the weekly), sitting in the
+            // XP row ahead of the LVL chip. MainWindow.QuestStamps.cs owns its own subscriptions
+            // and collapses itself when there is no QuestService, so the bar keeps full width.
+            InitializeQuestStamps();
+
             // Repaint the quests tab whenever the streak-fix balance moves. StreakFixCharges is
             // written imperatively (stats tile + button caption), not bound, and it changes from four
             // places — sync adoption, the manual spend, the automatic spend and the skill purchase —

--- a/ConditioningControlPanel/Services/BankAccumulator.cs
+++ b/ConditioningControlPanel/Services/BankAccumulator.cs
@@ -14,10 +14,18 @@ namespace ConditioningControlPanel.Services
     /// collection window (<see cref="WindowMs"/>), everything landing inside joins the pot, and the
     /// pot flies ONCE.</para>
     ///
-    /// <para><b>The cooldown is the real dial.</b> A window alone would still fire every 1.5s under
-    /// sustained XP. <see cref="CooldownMs"/> is the floor between flight STARTS: while it is
-    /// running the open pot simply keeps collecting, so a busy session produces a fuller flight
-    /// every three seconds rather than a stutter of thin ones.</para>
+    /// <para><b>The gate came first.</b> Pooling alone still celebrated ambient weather, just in
+    /// tidier lumps - a flight every few seconds for XP nobody had DONE anything to earn. Only
+    /// completion-shaped awards reach a pot at all now (<see cref="IsBankable"/>); everything else
+    /// bypasses THE BANK and tweens the counter the way it did before this class existed. Rarity is
+    /// what buys the moment its weight, and it is why the flight itself could then be made louder.</para>
+    ///
+    /// <para><b>The cooldown is the second dial.</b> A window alone would still fire every 1.5s
+    /// under sustained XP. <see cref="CooldownMs"/> is the floor between flight STARTS: while it is
+    /// running the open pot simply keeps collecting, so two completions landing on top of each
+    /// other produce one fuller flight rather than a stutter of thin ones. With the gate in front of
+    /// it this rarely binds - it is kept as the backstop for a burst of completions, not as the
+    /// thing that makes THE BANK rare.</para>
     ///
     /// <para><b>A level-up poisons the pot.</b> House law, one burst per moment: if an award crossed
     /// a level, <c>CelebrateLevelUp</c> owns that instant and THE BANK yields entirely - the pot is
@@ -37,6 +45,29 @@ namespace ConditioningControlPanel.Services
 
         /// <summary>Minimum gap between flight STARTS. Awards arriving inside it join the next pot.</summary>
         public const double CooldownMs = 3000;
+
+        /// <summary>
+        /// THE BANK is a celebration for FINISHING something, and this is the whole guest list.
+        ///
+        /// <para>The four here share one shape: a fixed award, paid once, at the end of a thing the
+        /// subject chose to see through. Every other <see cref="XPSource"/> is weather - a flash
+        /// tick, a mantra, a subliminal, a bubble, an attention check - and weather arriving with
+        /// tokens and a thud is how a reward moment turns into a notification sound. Those awards
+        /// never enter a pot; their XP tweens the counter exactly as it did before THE BANK
+        /// existed (see <c>MainWindow.BankFx.cs</c>, which releases the display hold for them on
+        /// the spot).</para>
+        ///
+        /// <para>ONE list, deliberately: adding a future completion (a program graduating, an
+        /// Arcademy diploma) is a one-line change here and nowhere else.</para>
+        /// </summary>
+        public static bool IsBankable(XPSource source) => source switch
+        {
+            XPSource.Quest => true,        // a daily/weekly quest paying out
+            XPSource.Session => true,      // a session run to the end
+            XPSource.LockCard => true,     // a lock card served
+            XPSource.BubbleCount => true,  // the counting game's result screen
+            _ => false,
+        };
 
         private readonly Func<double> _nowMs;
 
@@ -90,6 +121,10 @@ namespace ConditioningControlPanel.Services
         /// <para>Non-positive, NaN and infinite amounts are ignored outright rather than opening a
         /// pot: this sits on the live XP path, and a zero-XP award must not be able to arm a
         /// celebration for nothing.</para>
+        ///
+        /// <para>The caller is expected to have asked <see cref="IsBankable"/> first - the gate
+        /// lives at the call site because that is the only place that can also hand the display
+        /// back for a source THE BANK is declining.</para>
         /// </summary>
         public Flight? OnAward(double amount, XPSource source, bool leveledUp)
         {

--- a/ConditioningControlPanel/Services/BankFlightPlan.cs
+++ b/ConditioningControlPanel/Services/BankFlightPlan.cs
@@ -12,22 +12,25 @@ namespace ConditioningControlPanel.Services
     /// scales linearly with XP turns a session claim into confetti. Keeping the arithmetic here
     /// makes the spec a test rather than a comment.</para>
     ///
-    /// <para><b>Why the cap is 7.</b> The House Book's line is "the FEELING scales, not the particle
-    /// count": past seven the eye stops counting tokens and starts seeing a spray, so a bigger award
-    /// buys a longer, fuller flight and never a crowd.</para>
+    /// <para><b>Why the cap is 10.</b> The House Book's line is "the FEELING scales, not the
+    /// particle count": past a handful the eye stops counting tokens and starts seeing a spray, so a
+    /// bigger award buys a longer, fuller flight and never a crowd. The band was 3-7 while a flight
+    /// fired every few seconds; once the gate cut it to completions only (see
+    /// <c>BankAccumulator.IsBankable</c>) the moment had to carry more weight, and the cheapest
+    /// weight in a spill is more of it. Ten is where "a payout" still stops short of confetti.</para>
     ///
     /// <para>Deterministic from its seed - same seed, same flight - so a plan can be asserted
     /// headlessly, and so nothing about the look of a moment depends on a clock.</para>
     /// </summary>
     public static class BankFlightPlan
     {
-        // ---- DIALS (House Book: 3-7 tokens, 500-650ms ease-in arc, 60-80ms stagger) ----
+        // ---- DIALS (House Book: 4-10 tokens, 500-650ms ease-in arc, 60-80ms stagger) ----
 
-        /// <summary>Floor on the token count: fewer than three does not read as "value", it reads as a glitch.</summary>
-        public const int MinTokens = 3;
+        /// <summary>Floor on the token count: fewer than four does not read as "value", it reads as a glitch.</summary>
+        public const int MinTokens = 4;
 
         /// <summary>Ceiling on the token count. See the class remarks - this is a feel decision, not a budget one.</summary>
-        public const int MaxTokens = 7;
+        public const int MaxTokens = 10;
 
         public const double StaggerMinMs = 60;
         public const double StaggerMaxMs = 80;
@@ -49,10 +52,10 @@ namespace ConditioningControlPanel.Services
         public static int TokenCount(double xpSum)
         {
             if (double.IsNaN(xpSum)) return MinTokens;
-            if (xpSum < 15) return 3;
-            if (xpSum < 50) return 4;
-            if (xpSum < 120) return 5;
-            if (xpSum < 300) return 6;
+            if (xpSum < 15) return 4;
+            if (xpSum < 50) return 6;
+            if (xpSum < 120) return 7;
+            if (xpSum < 300) return 8;
             return MaxTokens;
         }
 

--- a/ConditioningControlPanel/Services/Companion/CompanionService.cs
+++ b/ConditioningControlPanel/Services/Companion/CompanionService.cs
@@ -23,7 +23,15 @@ namespace ConditioningControlPanel.Services
         AttentionCheck,
         Chaos,
         Fyp,
-        Other
+        Other,
+
+        /// <summary>
+        /// A daily or weekly quest paying out on completion. APPENDED, never reordered, so no
+        /// stored ordinal moves. Split out of <see cref="Other"/> because it is a fixed
+        /// earned-by-finishing-something award, which is what makes it one of the four sources
+        /// THE BANK celebrates - see <c>BankAccumulator.IsBankable</c>.
+        /// </summary>
+        Quest
     }
 
     /// <summary>

--- a/ConditioningControlPanel/Services/Progression/QuestService.cs
+++ b/ConditioningControlPanel/Services/Progression/QuestService.cs
@@ -1160,8 +1160,10 @@ public class QuestService : IDisposable
         _isDirty = true;
         Save();
 
-        // Award XP (use a different source to avoid recursion with TrackXPEarned)
-        App.Progression?.AddXP(scaledXP, XPSource.Other);
+        // Award XP. XPSource.Quest, not Other: nothing branches on the source inside AddXP (the
+        // old comment's recursion worry was never about which value was passed), but THE BANK's
+        // flight only fires for completion-shaped awards and a quest payout is the archetype.
+        App.Progression?.AddXP(scaledXP, XPSource.Quest);
 
         // Check for Perfect Bimbo Week bonus (7, 14, 30 day daily quest streaks).
         // CheckPerfectWeekBonus grants the XP itself (before it writes its paid-once latch, so a

--- a/Tests/ConditioningControlPanel.Tests/BankAccumulatorTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BankAccumulatorTests.cs
@@ -239,4 +239,43 @@ public class BankAccumulatorTests
         Assert.NotNull(flight);
         Assert.Equal(BankFlightPlan.MaxTokens, flight!.TokenCount);
     }
+
+    // ---- the guest list ----
+    //
+    // THE BANK is a celebration for FINISHING something. The gate is what makes the moment rare,
+    // and rarity is what the louder flight was dialled against - so the list is asserted in both
+    // directions rather than left as a comment on a switch.
+
+    [Theory]
+    [InlineData(XPSource.Quest)]
+    [InlineData(XPSource.Session)]
+    [InlineData(XPSource.LockCard)]
+    [InlineData(XPSource.BubbleCount)]
+    public void Completions_AreBankable(XPSource source)
+        => Assert.True(BankAccumulator.IsBankable(source));
+
+    [Theory]
+    [InlineData(XPSource.Flash)]
+    [InlineData(XPSource.Video)]
+    [InlineData(XPSource.Subliminal)]
+    [InlineData(XPSource.Bubble)]
+    [InlineData(XPSource.BouncingText)]
+    [InlineData(XPSource.AvatarInteraction)]
+    [InlineData(XPSource.KeywordTrigger)]
+    [InlineData(XPSource.Mantra)]
+    [InlineData(XPSource.AttentionCheck)]
+    [InlineData(XPSource.Chaos)]
+    [InlineData(XPSource.Fyp)]
+    [InlineData(XPSource.Other)]
+    public void Weather_IsNot(XPSource source)
+        => Assert.False(BankAccumulator.IsBankable(source));
+
+    [Fact]
+    public void EveryXpSource_IsAnsweredOneWayOrTheOther()
+    {
+        // A new enum value must land on the "weather" side by default, never throw and never
+        // silently start flying. This is the test that catches an unreviewed addition.
+        foreach (XPSource source in Enum.GetValues<XPSource>())
+            _ = BankAccumulator.IsBankable(source);
+    }
 }

--- a/Tests/ConditioningControlPanel.Tests/BankFlightPlanTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/BankFlightPlanTests.cs
@@ -15,17 +15,19 @@ namespace ConditioningControlPanel.Tests;
 public class BankFlightPlanTests
 {
     [Theory]
-    // Each pair is (xpSum, tokens) on both sides of every step in the table.
-    [InlineData(0, 3)]
-    [InlineData(14.99, 3)]
-    [InlineData(15, 4)]
-    [InlineData(49.99, 4)]
-    [InlineData(50, 5)]
-    [InlineData(119.99, 5)]
-    [InlineData(120, 6)]
-    [InlineData(299.99, 6)]
-    [InlineData(300, 7)]
-    [InlineData(50_000, 7)]
+    // Each pair is (xpSum, tokens) on both sides of every step in the table. The band widened from
+    // 3-7 to 4-10 when THE BANK stopped firing for ambient XP: a flight that only happens on a
+    // completion is allowed to be a fuller spill.
+    [InlineData(0, 4)]
+    [InlineData(14.99, 4)]
+    [InlineData(15, 6)]
+    [InlineData(49.99, 6)]
+    [InlineData(50, 7)]
+    [InlineData(119.99, 7)]
+    [InlineData(120, 8)]
+    [InlineData(299.99, 8)]
+    [InlineData(300, 10)]
+    [InlineData(50_000, 10)]
     public void TokenCount_StepsExactlyOnTheTablesEdges(double xpSum, int expected)
         => Assert.Equal(expected, BankFlightPlan.TokenCount(xpSum));
 
@@ -47,11 +49,13 @@ public class BankFlightPlanTests
     }
 
     [Theory]
-    [InlineData(3)]
     [InlineData(4)]
     [InlineData(5)]
     [InlineData(6)]
     [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    [InlineData(10)]
     public void EveryPlan_SitsInsideTheHouseBooksBands(int count)
     {
         // Swept over many seeds: a band violation that only shows up on one seed in fifty is


### PR DESCRIPTION
## What

Two header QoL changes from owner feedback: the banking-XP sound was too loud and too frequent, and the XP bar row had no quest visibility.

### Quest stamps (XP bar shortened)
- New `QuestStampHost` column at the far left of the XP row: 4 slightly-tilted stamp squares (-4/+3/-2/+5 deg, slight overlap, pinned 22px so the header row cannot grow).
- 3 daily slots: gold-check stamp when completed today, pink live square with the quest icon + bottom progress sliver, dashed ghost for not-yet-rolled. 4th square is the weekly: slightly larger, purple, own sliver, gold-check variant when done.
- The XP bar is star-width, so the cluster shortens it naturally and gives the width back when the cluster collapses (QuestService absent).
- Whole cluster is one click target -> `ShowTab("quests")` (same funnel as the nav button, no ShowTab keys renamed). Tooltip shows quest names + progress. Refreshes on QuestCompleted / QuestProgressChanged / QuestsRefreshed / language change; all handlers dispatcher-marshalled and wrapped.
- One loc key (`tooltip_quest_stamps`) added to all 9 language files, strict-JSON verified, 1-line diff each.

### BANK on XP gated to completion awards
- New `BankAccumulator.IsBankable(XPSource)` - flights (tokens + thud + display hold) only for **Quest, Session, LockCard, BubbleCount**. Quest payouts were mislabeled `XPSource.Other`; a `Quest` value was appended to the enum (no reorder, source is log-only elsewhere) and QuestService retagged.
- Every other source bypasses the bank entirely: immediate hold release on the same dispatcher item, plain odometer tween, no tokens, no thud - byte-identical to pre-bank. The 1.5s pooling window stays so a session + the quest it completes fly as one flight.
- Since the moment is now rare, it got bigger: tokens 3-7 -> 4-10 with larger brighter halos (box pad 80 -> 100), counter pop 1.12 -> 1.28 with springier ease, and the final landing fires the existing `XPBarFlashOverlay` bloom via the level-up's own helper (single owner; `XPBarSheen` deliberately untouched - ChromeFx owns it on a Forever clock).
- Thud volume 0.35 -> 0.22.
- All still behind `EventFxAllowed` / reduced-motion rails.

## Tests
- BankFlightPlan step-table/band theories updated; 3 new tests assert the eligibility list both ways.
- `dotnet build`: 0 errors, no new warnings (app + test project).

## Not done
- No in-app play-test: the stamp cluster's on-screen look and the new flight feel need an eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFYHt9c2Z2qS2EK6ovDJU