### PR TITLE
feat(arcademy): the Student ID - real photo, consent chip, front-and-centre spotlight

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -149,6 +149,21 @@ shell/records.js   THE RECORDS OFFICE screen: the wall of ten cards, the per-car
                    (recordsPage.dismissSpotlight(), trap 48's shape); reduced
                    motion (html.arc-reduced / the media query) = one plain fade,
                    no cues
+shell/idcard.js    THE STUDENT ID: the laminated card in the corner of the
+                   campus, and the spotlight it opens (records.js's shape, z 46,
+                   veil + key light + placard + Tab trap + one Esc rung above
+                   the Records one). Two halves in one file: PURE PARTS that
+                   campus.js imports (the drawn PHOTO PENDING / anon portraits
+                   as `data:` URIs, `chipRung`, `paintChip`, `studentNumber`,
+                   `runPhotoDay`) so the furniture card and the big card can
+                   never disagree, and `createIdSpotlight()` itself. The card
+                   shows name / number / term / enrolled / homeroom, a YEAR
+                   stamp that lands on punchcard.js's own thud, a six-tile stat
+                   sheet on a chime ladder, and a FLIP side (barcode, small
+                   print, the Records line, the signature). The chip under the
+                   photo IS the `presenceShare` discord rung (owner ruling, see
+                   §3) and paints only from the echo. NOT SHAREABLE by ruling -
+                   reportcard.js stays the one share pipeline (trap 13)
 shell/annexreveal.js THE NIGHT THE WALL MOVED: the once-ever reveal cinematic
                      (cut to black -> a thud from below -> EMI startled -> one
                      second of the records office at night with a wall panel
@@ -839,6 +854,33 @@ DOWN, and the page never invents a number).
   `startSwapTo` "for consistency", the blueprint becomes quiz material and a stop can ask about
   a frame the player was never meant to be tested on. `freeze(true)`, `reshuffle()` and
   `destroy()` all take it down.
+
+- **THE STUDENT ID's `profile` IS ADDITIVE, AND THE PHOTO CHIP IS THE
+  `presenceShare` DISCORD RUNG.** `init.profile` = `{name, avatarUrl,
+  discordLinked, presenceShare}`; the host pushes `{type:'profile', profile,
+  result?:'linked'|'cancelled'|'failed'}` after an OAuth completes, fails or is
+  cancelled AND after any `presenceShare` change it applies itself. The page
+  posts exactly two things: `{type:'link-discord', thenShare:'discord'}` (ONLY
+  while `discordLinked` is false) and the ordinary
+  `set-setting {key:'presenceShare'}` once it is true. A host that predates the
+  frame is a supported host: the card draws "Student", the drawn stand-in
+  portrait and the unlinked chip, nothing throws, and the page asks the network
+  for nothing (the rig asserts zero off-origin requests).
+  - **ONE SWITCH** (owner ruling): the photo toggle IS the public `discord`
+    rung, so photo on means the campus ghost wears it too, and turning it off
+    drops to `username` (the name stays). There is no second private flag.
+  - **THE SNOWFLAKE RULE HOLDS** (PRESENCE.md §10): the Discord CDN url and the
+    Discord user id NEVER reach the page. Desktop caches a 128px PNG and ships
+    it as a `data:` URI inside init; the web build sends the first-party proxy
+    url. Anything else is a leak, and `<img>` onerror falls back to the drawn
+    portrait rather than retrying.
+  - **ONE CLICK IS THE CONSENT** (owner ruling): when a link-up started from the
+    chip succeeds, the HOST applies `presenceShare:'discord'` itself and pushes
+    `profile {result:'linked'}`. The page never asks twice, and the chip's
+    label is what promised it.
+  - **THE STUDENT NUMBER IS DERIVED ON THE PAGE**, `core`-free: the presence
+    `self` opaque id hashed to `XXXX-XXXX`, or a seed off the enrolment date and
+    the name with a tiny `temp` mark until the real one lands.
 
 ## 4. Traps (each one cost real time)
 
@@ -1752,6 +1794,32 @@ DOWN, and the page never invents a number).
     changes. Idle events also budget legibility - the name is dark/displaced <=20% of
     any cycle - and the wall whisper (`arc-rw-*`) is hover/focus-gated per card so the
     grid never runs ten ambient loops at once.
+92. **A REDUCED-MOTION "ONE FADE" CANNOT BE A TRANSITION, AND IT CANNOT LIVE INSIDE THE
+    OVERLAY EITHER (the ID spotlight, 2026-08-25).** The global freeze at the bottom of
+    `styles.css` is `html.arc-reduced *, ::before, ::after { animation-duration:.001s
+    !important; animation-iteration-count:1 !important; animation-delay:0s !important;
+    transition:none !important; }` - so the obvious way to write "reduced motion is one
+    120ms fade" (a `transition:opacity` plus a class flipped on the next rAF) is dead on
+    arrival: the transition is forbidden and the overlay simply pops. It has to be an
+    ANIMATION. But the decoration law's own test is "no `animation-name` other than none
+    INSIDE the reduced overlay", which an animated veil would fail. Both hold at once only
+    because the fade sits on the OVERLAY ROOT (`.arc-id.arc-id-reduced`) while
+    `.arc-id-reduced *` is `animation:none !important` - a root is not "inside" itself.
+    Watch the specificity too: `html.arc-reduced *` is (0,1,1) and outranks
+    `.arc-id-reduced *` at (0,1,0) on `animation-duration`, but they are different
+    longhands, so `animation-name:none` still lands and the freeze still owns the duration.
+    Read `.arc-rs-reduced` the same way, and do not "simplify" either one into a transition.
+93. **THE STUDENT ID IS ONE NODE WITH THREE OWNERS, AND `data-inflight` IS THE FENCE.**
+    `campus.idCardEl()` is built once and never replaced - orientation.js animates that exact
+    element (ORIENTATION.md §3.2), `emi/fieldtrips.js` measures it by the `.campus-idcard`
+    selector, and the card is a `role=button` that opens the spotlight. Three things follow.
+    Adding children is fine; REPLACING the node is not, so `setProfile()` repaints in place
+    and never re-renders the card. Withheld is still the `hidden` PROPERTY only (trap 27), and
+    the click is refused while it is set. And the handover is refused too: orientation.js
+    stamps `data-inflight="1"` where the flight starts and `landCard()` clears it - which is
+    the ONE place every path out of the beat already funnels through, so there is exactly one
+    place it comes off. A press mid-flight would open a spotlight over a card that is still
+    travelling and hand focus back to a node the beat is about to restyle.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -488,6 +488,17 @@ bridge.on('suspend', guard('suspend', (m) => {
   log('suspend ' + (m.on ? 'ON' : 'off') + ' (' + (m.reason || '?') + ')'
     + (shell ? '' : ' [buffered until the shell exists]'));
 }));
+/* THE STUDENT ID's profile (the STUDENT ID contract). Additive and OPTIONAL on
+ * both sides: a host that never pushes one leaves the card drawing "Student"
+ * and the drawn stand-in portrait, and a shell built before this frame existed
+ * simply has no `onProfile` - hence the same `shell &&` guard `annex-stats`
+ * carries. Like `punchcard-result` it needs no buffer of its own: `bridge.on`
+ * REPLAYS anything that landed before this subscription existed (trap 11). */
+bridge.on('profile', guard('profile', (m) => {
+  if (shell && shell.onProfile) shell.onProfile(m);
+  log('profile' + (m && m.result ? ' (' + m.result + ')' : '')
+    + (m && m.profile ? (m.profile.discordLinked ? ' linked' : ' not linked') : ' [no body]'));
+}));
 bridge.on('meta', guard('meta', (m) => { if (shell) shell.onMeta(m); }));
 bridge.on('annex-stats', guard('annex-stats', (m) => { if (shell && shell.onAnnexStats) shell.onAnnexStats(m); }));
 bridge.on('fullscreen', guard('fullscreen', (m) => { fullscreen = !!m.on; }));

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -281,6 +281,49 @@ export const DEFAULT_LEXICON = Object.freeze({
   records_empty_wall: 'Nothing on the wall yet. Attend a class and the first card gets pinned.',
   records_spot_close: 'Close',
 
+  /* THE STUDENT ID (shell/campus.js's furniture card + shell/idcard.js's
+     spotlight). The card is a document, not a share: nothing here names a
+     Discord handle, an id or a url - the photo consent IS the `presenceShare`
+     discord rung the settings page owns, said in the card's own words.
+     `{n}` / `{m}` are substituted by the page. Every value is under the
+     96-char MergeModTable cap, so a mod re-voices the whole card. */
+  student_id_title: 'Student ID',
+  id_photo_pending: 'Photo pending',
+  id_photo_on: 'Discord photo on',
+  id_photo_use: 'Use my Discord photo',
+  id_photo_link: 'Link Discord for my photo',
+  id_photo_waiting: 'Waiting on Discord...',
+  id_chip_on: 'Photo on',
+  id_chip_use: 'Use Discord photo',
+  id_chip_link: 'Link Discord',
+  id_chip_wait: 'Waiting...',
+  id_photo_hint_app: 'Opens the Discord link-up in the app, then your photo goes on the card and on campus.',
+  id_photo_hint_web: 'Sends you to Connections to link Discord, then straight back here with the photo on.',
+  id_photo_hint_off: 'Your ghost on campus wears this photo too. Tap to take it down (your name stays).',
+  id_photo_failed: 'Discord did not pick up. Try again in a minute.',
+  id_photo_day: 'Photo day',
+  id_no: 'Student no.',
+  id_no_temp: 'temp',
+  id_enrolled: 'Enrolled',
+  id_homeroom: 'Homeroom',
+  id_issued_at: 'Issued at',
+  id_front_desk: 'Front desk',
+  id_stat_semester: 'Term',
+  id_stat_streak: 'Attendance streak',
+  id_stat_perfect: 'Perfect days',
+  id_stat_stamps: 'Stamps of 100',
+  id_stat_best: 'S days',
+  id_year: 'Year',
+  id_grade_tier: 'Grade tier',
+  id_to_go: '{n} to go',
+  id_reinked: 'Re-inked',
+  id_flip: 'Tap the card to turn it over. Esc to put it back.',
+  id_back_lost: 'Lost it? Ask at the front desk. The second one costs you a stamp.',
+  id_back_valid: 'Good for as long as the lights are on.',
+  id_records_line: 'Records: {n} of {m} cards mastered',
+  id_open_records: 'Open Records',
+  id_spot_close: 'Close',
+
   /* Semester II ghost labels behind the tape (unregistered games get their
    * game_<key> row here, same convention the registry uses once they ship). */
   game_misdirection: 'Misdirection',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -39,6 +39,12 @@ import { isMobile, onDeviceChange } from '../core/device.js';
  * everything arrives through the `post` option bag, and a campus built without
  * one simply has no post - the mockup, the suite and old callers all still
  * stand). */
+/* THE STUDENT ID'S PARTS. Pure helpers, shared with the spotlight so the
+ * furniture card and the big card can never disagree about what your card says
+ * (shell/idcard.js's header). Nothing here mounts anything. */
+import { genericPortrait, portraitSrc, portraitLabel, chipRung, paintChip, runPhotoDay,
+  studentNumber } from './idcard.js';
+import { thud as punchThud } from './punchcard.js';
 import { mountMailChip } from './mailbox.js';
 import { mountBoardProp } from './corkboard.js';
 import { mountBugleProp } from './bugle.js';
@@ -671,6 +677,27 @@ function el(tag, cls, text) {
   return n;
 }
 
+/** The student ID's crest: an arcade token with a star, DRAWN. The campus has
+ *  no logo file and this one is 20x20 of markup (the nine-broken-logos law). */
+function idCrestGlyph() {
+  const ns = 'http://www.w3.org/2000/svg';
+  try {
+    const s = document.createElementNS(ns, 'svg');
+    s.setAttribute('viewBox', '0 0 20 20');
+    s.setAttribute('class', 'id-crestmark');
+    s.setAttribute('aria-hidden', 'true');
+    const ring = document.createElementNS(ns, 'circle');
+    ring.setAttribute('cx', '10'); ring.setAttribute('cy', '10'); ring.setAttribute('r', '9');
+    ring.setAttribute('fill', 'none'); ring.setAttribute('stroke', 'currentColor');
+    ring.setAttribute('stroke-width', '2');
+    const star = document.createElementNS(ns, 'path');
+    star.setAttribute('fill', 'currentColor');
+    star.setAttribute('d', 'M10 5.5l1.3 2.8 3 .3-2.3 2 .7 3-2.7-1.6-2.7 1.6.7-3-2.3-2 3-.3z');
+    s.appendChild(ring); s.appendChild(star);
+    return s;
+  } catch (e) { return null; }
+}
+
 /* ============================================================================
  * THE CAMPUS
  * ==========================================================================*/
@@ -682,7 +709,12 @@ function el(tag, cls, text) {
  * @param {Object} o.stats        {streak, perfectDays, tier}
  * @param {boolean=} o.reducedMotion
  * @param {Object} o.on           {begin(gameKey), freeSwim(gameKey), records(),
- *   registrar(), boardToggle(expanded)} - freeSwim is only ever called for a
+ *   registrar(), boardToggle(expanded), idCard(), idChip()} - `idCard` is
+ *   OFFERED by the student ID's own click and Enter (the shell owns the
+ *   spotlight, shell/idcard.js, exactly as it owns the Records one) and
+ *   `idChip` is the photo consent leaving for the host; both are optional, and
+ *   a caller that hands neither gets the furniture card it has always got.
+ *   freeSwim is only ever called for a
  *   room whose state carries an `endless` declaration (the shell reads the
  *   manifest, never the campus). boardToggle fires AFTER the hanging board has
  *   been shown/hidden - the shell rolls the flaps (and stamps the store) on
@@ -775,6 +807,16 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   let idStreak = null;
   let idPerfect = null;
   let idTier = null;
+  /* THE STUDENT ID's live parts. `idProfile` is the LAST profile the shell
+   * handed down (init.profile, then every `profile` frame) - the card paints
+   * from it and derives nothing of its own. */
+  let idPhotoImg = null;
+  let idPhotoEl = null;
+  let idChip = null;
+  let idNum = null;
+  let idProfile = null;
+  let idChipState = 'link';
+  let idLastTier = 0;
   let bellText = null;
 
   /* ------------------------------ SVG plan ------------------------------- */
@@ -1604,15 +1646,69 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
    * and the sheet's `[hidden]{display:none!important}` reset - never a bare
    * `display:` on this node (trap 27). */
   if (idCardMode === 'withheld') id.hidden = true;
+  /* THE LANYARD CLIP. Pure furniture, drawn, no asset. */
+  const idClip = el('i', 'id-clip');
+  idClip.setAttribute('aria-hidden', 'true');
+  id.appendChild(idClip);
+  /* THE CREST BAND. The card says what it is, in its own words. */
+  const idBand = el('div', 'id-band');
+  const idCrest = el('span', 'id-crest');
+  const idCrestMark = idCrestGlyph();
+  if (idCrestMark) idCrest.appendChild(idCrestMark);
+  idCrest.appendChild(el('span', null, t('arcademy', 'The Arcademy').toUpperCase()));
+  idBand.appendChild(idCrest);
+  idBand.appendChild(el('span', 'id-kind', t('student_id_title', 'Student ID').toUpperCase()));
+  id.appendChild(idBand);
   const idTop = el('div', 'id-top');
-  idTop.appendChild(el('div', 'id-photo'));
-  const idMeta = el('div');
+  /* THE PHOTO WELL. ONE `<img>` carries either the host's baked avatar or the
+   * drawn stand-in; a decode failure swaps the src back to the stand-in and
+   * never reaches for the network again (ghosts.js's rule). No Discord url and
+   * no Discord id is ever on this page - the host resolves both (PRESENCE §10). */
+  const idWell = el('div', 'id-well');
+  const idPhoto = el('div', 'id-photo');
+  idPhotoImg = el('img', 'id-photo-img');
+  idPhotoImg.setAttribute('alt', '');
+  idPhotoImg.setAttribute('decoding', 'async');
+  idPhotoImg.addEventListener('error', () => {
+    try {
+      const fb = genericPortrait(idProfile && idProfile.presenceShare);
+      if (idPhotoImg.src !== fb) { idPhotoImg.src = fb; idPhoto.classList.remove('is-real'); }
+    } catch (e) { /* noop */ }
+  });
+  idPhotoImg.src = genericPortrait(null);
+  idPhoto.appendChild(idPhotoImg);
+  const idFlash = el('i', 'id-flash');
+  idFlash.setAttribute('aria-hidden', 'true');
+  idPhoto.appendChild(idFlash);
+  idWell.appendChild(idPhoto);
+  idPhotoEl = idPhoto;
+  /* THE CHIP: the photo consent, in the card's own words. It paints the rung it
+   * is HANDED and never the one its own click asked for (trap 1) - the click
+   * leaves through `handlers.idChip` and the shell waits for the echo. */
+  idChip = el('button', 'id-chip');
+  idChip.type = 'button';
+  idChip.addEventListener('click', (ev) => {
+    /* The chip is INSIDE the card's own button, so its click must not also
+     * open the spotlight - one press, one verb. */
+    try { ev.stopPropagation(); } catch (e) { /* noop */ }
+    if (id.hidden || (id.dataset && id.dataset.inflight === '1')) return;
+    if (handlers.idChip) { try { handlers.idChip(); } catch (e) { say('idChip threw: ' + ((e && e.message) || e)); } }
+  });
+  idTop.appendChild(idWell);
+  const idMeta = el('div', 'id-meta');
   idMeta.appendChild(el('div', 'id-name', t('student', 'Student')));
+  idNum = el('div', 'id-num', '');
+  idMeta.appendChild(idNum);
   idMeta.appendChild(el('div', 'id-no', (t('semester', 'Semester') + ' ' + termRoman).toUpperCase()));
   idTier = el('span', 'id-tier', '');
   idMeta.appendChild(idTier);
   idTop.appendChild(idMeta);
   id.appendChild(idTop);
+  /* THE CHIP SPANS THE CARD, not the 58px well. "Link Discord" at chip type
+   * does not fit under the photo and an ellipsis is not a consent sentence -
+   * the row still reads as the photo's own switch because it sits directly
+   * under it, and it is a 208px hit target instead of a 48px one. */
+  id.appendChild(idChip);
   const idStats = el('div', 'id-stats');
   const stat = (cls, label) => {
     const s = el('div', 'id-stat' + (cls ? ' ' + cls : ''));
@@ -1625,7 +1721,73 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   idStreak = stat('', t('attendance', 'Attendance'));
   idPerfect = stat('gp', t('perfect_attendance', 'Perfect Attendance'));
   id.appendChild(idStats);
+  const idFoil = el('i', 'id-foil');
+  idFoil.setAttribute('aria-hidden', 'true');
+  id.appendChild(idFoil);
+  paintIdChip('link');
+  /* THE CARD IS A DOOR NOW. It opens the ID spotlight (shell/idcard.js) through
+   * the shell, which owns the overlay exactly as it owns the Records one. The
+   * press is REFUSED while the card is withheld and while Orientation Day has
+   * it in the air (`data-inflight`, set and cleared by orientation.js) - a beat
+   * that is mid-flight is not a thing you can pick up. */
+  id.setAttribute('role', 'button');
+  id.tabIndex = 0;
+  id.setAttribute('aria-label', t('student_id_title', 'Student ID'));
+  const openIdCard = () => {
+    if (id.hidden || (id.dataset && id.dataset.inflight === '1')) return;
+    if (!handlers.idCard) return;
+    try { handlers.idCard(); } catch (e) { say('idCard threw: ' + ((e && e.message) || e)); }
+  };
+  id.addEventListener('click', openIdCard);
+  id.addEventListener('keydown', (ev) => {
+    if (!ev || (ev.key !== 'Enter' && ev.key !== ' ')) return;
+    try { ev.preventDefault(); } catch (e) { /* noop */ }
+    openIdCard();
+  });
   root.appendChild(id);
+
+  /** Paint the chip's rung. `pending` keeps the last label - the echo has not
+   *  landed, so there is nothing new to say (trap 1). */
+  function paintIdChip(state) {
+    idChipState = String(state || 'link');
+    paintChip(idChip, t, idChipState, true);
+  }
+
+  /**
+   * THE PROFILE LANDED. Everything the card says about YOU repaints from this
+   * one object and from nothing else: the photo, the name, the number and the
+   * chip's resting rung. A host that has never heard of `profile` simply never
+   * calls this, and the card keeps the stand-in portrait it was built with.
+   * @param {Object} p  {name, avatarUrl, discordLinked, presenceShare, selfId}
+   */
+  function setIdProfile(p) {
+    idProfile = p && typeof p === 'object' ? p : null;
+    const prof = idProfile || {};
+    try { if (idPhotoImg) idPhotoImg.src = portraitSrc(prof); } catch (e) { /* noop */ }
+    try {
+      if (idPhotoEl && idPhotoEl.classList) {
+        idPhotoEl.classList.toggle('is-real',
+          !!prof.discordLinked && String(prof.presenceShare) === 'discord' && !!prof.avatarUrl);
+      }
+    } catch (e) { /* noop */ }
+    try { if (idPhotoEl) idPhotoEl.setAttribute('aria-label', portraitLabel(t, prof)); }
+    catch (e) { /* noop */ }
+    const nameEl = id.querySelector ? id.querySelector('.id-name') : null;
+    if (nameEl) nameEl.textContent = prof.name ? String(prof.name) : t('student', 'Student');
+    if (idNum) {
+      const num = studentNumber(prof.selfId, prof.enrolled, prof.name);
+      idNum.textContent = t('id_no', 'Student no.').toUpperCase() + ' ' + num.no;
+    }
+    paintIdChip(chipRung(prof));
+  }
+
+  /** PHOTO DAY on the furniture card: the shutter, the well-only flash and the
+   *  photo developing in. Reduced motion is a plain swap (runPhotoDay's rule). */
+  function idPhotoDay() {
+    return runPhotoDay(idPhotoEl, sfx, !!reducedMotion, (ms, fn) => {
+      try { setTimeout(fn, ms); } catch (e) { fn(); }
+    });
+  }
 
   /* THE POST ROW: the noticeboard thumbnail and the folded Bugle, leaning
    * against the wall beside the student ID. Furniture only - the overlays,
@@ -2044,7 +2206,25 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     /* ID card */
     idStreak.textContent = '🔥 ' + String((stats2.streak | 0));
     idPerfect.textContent = String((stats2.perfectDays | 0));
-    idTier.textContent = tierLabel(stats2.tier || 1).toUpperCase();
+    const tierNow = stats2.tier || 1;
+    idTier.textContent = tierLabel(tierNow).toUpperCase();
+    /* RE-INKED. A card whose YEAR changed is a card the front desk stamped
+     * again, so the stamp lands with the punch card's own thud - once, on the
+     * paint that CHANGED it, and never on the first one (as far as tonight
+     * knows, the card was always this year). Reduced motion keeps the words
+     * and drops the beat, like everything else on this card. */
+    if (idLastTier && tierNow !== idLastTier && !reducedMotion) {
+      try {
+        idTier.classList.remove('is-thud');
+        void idTier.offsetWidth;
+        idTier.classList.add('is-thud');
+        idTier.setAttribute('title', t('id_reinked', 'Re-inked'));
+      } catch (e) { /* noop */ }
+      try { punchThud(1); } catch (e) { /* noop */ }
+    }
+    idLastTier = tierNow;
+    /* The card's edge warms as the streak climbs: a colour, never a bulb ring. */
+    try { id.classList.toggle('is-warm', (stats2.streak | 0) >= 7); } catch (e) { /* noop */ }
   }
 
   /* enrich class-card state with descriptor detail the shell passes on stops */
@@ -2364,6 +2544,19 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     walkMount: walkLayer,
     /** The ONE student-ID node. Orientation Day animates this, never a copy. */
     idCardEl() { return id; },
+    /**
+     * THE PROFILE SEAM (shell/idcard.js's contract). The shell hands the card
+     * `init.profile` at build and every `profile` frame after it; the card
+     * paints and derives nothing. Called with nothing at all, the card keeps
+     * the stand-in portrait and the unlinked chip it was built with.
+     */
+    setProfile: setIdProfile,
+    /** The chip's in-flight looks, which only the shell knows about:
+     *  'wait' (a link is in the air) and 'pending' (a set-setting is waiting on
+     *  its echo). Every resting rung comes from `setProfile`. */
+    setChipState: paintIdChip,
+    /** PHOTO DAY on the furniture card (the spotlight has its own). */
+    photoDay: idPhotoDay,
     /**
      * The two counters' groups, by walk-graph key. Orientation Day pulses the
      * Front Office's own neon sign on arrival (§3.3 step 3) and a beat may not

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/idcard.js
@@ -1,0 +1,948 @@
+/* ============================================================================
+ * shell/idcard.js - THE STUDENT ID, front and centre.
+ *
+ * The campus already had a laminated ID leaning in the bottom-left corner
+ * (shell/campus.js's `.campus-idcard`). It was scenery. This file is the two
+ * halves that make it a document you can pick up:
+ *
+ *   THE PARTS      the generic portraits, the chip rungs, the student number
+ *                  and the barcode - pure functions, shared with campus.js so
+ *                  the furniture card and the spotlight can never disagree
+ *                  about what your card says.
+ *   THE SPOTLIGHT  `createIdSpotlight()`, built to shell/records.js's shape:
+ *                  a fixed z46 veil + key light, the card at 560px under it,
+ *                  a six-tile stat sheet beside it, a placard, one focusable
+ *                  Close, a Tab trap, and module-local timers that a dismiss
+ *                  clears. Esc is NOT handled here - boot.js owns the key and
+ *                  shell.js's escapeStep asks `dismiss()` first (trap 48).
+ *
+ * THREE LAWS THIS FILE KEEPS, and they are the reason it looks the way it does:
+ *
+ *   1. TRAP 1, THE ECHO. Nothing here decides what the chip says. The chip
+ *      paints the rung it is HANDED (`setChipState`) and every click leaves
+ *      through `onChip()` for the shell, which posts a frame and waits for the
+ *      host to answer. The only optimistic paint is `wait`, and a "waiting"
+ *      look is not a result.
+ *   2. THE SNOWFLAKE RULE (PRESENCE.md §10). No Discord CDN url and no Discord
+ *      user id ever reaches this page. `profile.avatarUrl` is a `data:` URI the
+ *      host baked, or a first-party proxy url on the web, or null - and null
+ *      draws a generic portrait rather than fetching anything.
+ *   3. TRAP 36, TRANSFORMS ONLY. The holo foil drifts and answers the mouse by
+ *      `transform`; the name's glint is a translating strip inside a clipping
+ *      box, never an animated `background-position`. Every base state is
+ *      VISIBLE, so `animation:none` (reduced motion) is a finished still.
+ *
+ * NOT SHAREABLE, by ruling. `shell/reportcard.js` is the ONE share pipeline
+ * (trap 13) and a card wearing a real avatar is a paste-able identity; there is
+ * no copy button, no share verb and no image export anywhere below this line.
+ * ==========================================================================*/
+
+import { thud } from './punchcard.js';
+
+/* ----------------------------------------------------------------------------
+ * DOM + CUE HELPERS (records.js's, verbatim - one shape for one job)
+ * -------------------------------------------------------------------------- */
+
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+}
+
+function attr(node, name, value) {
+  try { if (node && typeof node.setAttribute === 'function') node.setAttribute(name, value); }
+  catch (e) { /* noop */ }
+}
+
+function css(node, name, value) {
+  try {
+    if (node && node.style && typeof node.style.setProperty === 'function') {
+      node.style.setProperty(name, value);
+    }
+  } catch (e) { /* noop */ }
+}
+
+/** Reduced motion, either signal: the shell's own class or the OS preference. */
+export function idReducedMotion() {
+  try {
+    const root = (typeof document !== 'undefined') && document.documentElement;
+    if (root && root.classList && typeof root.classList.contains === 'function'
+      && root.classList.contains('arc-reduced')) return true;
+  } catch (e) { /* noop */ }
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* noop */ }
+  return false;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE NUMBER
+ * -------------------------------------------------------------------------- */
+
+/** FNV-1a over a string -> uint32. Pure, `core`-free, and the same on both
+ *  surfaces (the furniture card prints the number the spotlight prints). */
+function fnv1a(str) {
+  let h = 2166136261;
+  const s = String(str == null ? '' : str);
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+function hex4(n) { return ('000' + (n >>> 0).toString(16)).slice(-4).toUpperCase(); }
+
+/**
+ * THE STUDENT NUMBER, derived on the page and nowhere else (owner ruling 3).
+ * The presence `self` opaque id when the host has pushed one - it is stable
+ * across devices and it is already an opaque token, so hashing it to eight hex
+ * digits leaks nothing it did not already say. With no `self` id yet the number
+ * is seeded off the two things a fresh card DOES know (the enrolment date and
+ * the name), and it says `temp` in tiny type until the real one lands.
+ *
+ * @param {?string} selfId    the presence snapshot's `self`, or null
+ * @param {?string} enrolled  'yyyy-mm-dd' of the earliest enrolment, or null
+ * @param {?string} name      the CCP nickname, or null
+ * @returns {{no:string, temp:boolean}}
+ */
+export function studentNumber(selfId, enrolled, name) {
+  const real = selfId != null && String(selfId) !== '';
+  const seed = real
+    ? 'arcademy-id|' + String(selfId)
+    : 'arcademy-id-temp|' + String(enrolled || '') + '|' + String(name || '');
+  const a = fnv1a(seed);
+  const b = fnv1a(seed + '|2');
+  return { no: hex4(a >>> 16) + '-' + hex4(b & 0xffff), temp: !real };
+}
+
+/* ----------------------------------------------------------------------------
+ * THE GENERIC PORTRAITS
+ *
+ * Inline SVG, encoded as a `data:` URI so ONE `<img>` carries either the real
+ * avatar or the stand-in - the fallback is an `src` swap, never a second node
+ * and never a second layout. No fetch, no asset, nothing to 404 (trap 2's
+ * neighbour: an offline webview has no network to lose).
+ *
+ * The stamp type is `monospace`: an SVG loaded through `<img>` is its own
+ * document and cannot reach the page's bundled faces, so naming one would be a
+ * silent fallback rather than a look.
+ * -------------------------------------------------------------------------- */
+
+const PENDING_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 66">'
+  + '<defs><pattern id="s" width="4" height="4" patternUnits="userSpaceOnUse">'
+  + '<rect width="4" height="2" fill="#000" opacity=".16"/></pattern></defs>'
+  + '<rect width="56" height="66" fill="#33305c"/>'
+  + '<g shape-rendering="crispEdges" fill="#8c80c4">'
+  + '<path d="M20 14h16v18H20z"/><path d="M22 12h12v2H22z"/>'
+  + '<path d="M12 42h32v24H12z"/><path d="M16 38h24v4H16z"/><path d="M24 32h8v6h-8z"/></g>'
+  + '<g shape-rendering="crispEdges" fill="#b8a6e8">'
+  + '<path d="M20 14h16v4H20z"/><path d="M12 42h4v24h-4z"/></g>'
+  + '<rect width="56" height="66" fill="url(#s)"/>'
+  + '<g transform="translate(28 34) rotate(-14) translate(-25 -11)" opacity=".95">'
+  + '<rect x="0" y="0" width="50" height="22" rx="2" fill="none" stroke="#FF69B4" stroke-width="1.8"/>'
+  + '<text x="25" y="10" text-anchor="middle" font-family="monospace" font-size="7"'
+  + ' font-weight="700" fill="#FF69B4" letter-spacing="1">PHOTO</text>'
+  + '<text x="25" y="19" text-anchor="middle" font-family="monospace" font-size="7"'
+  + ' font-weight="700" fill="#FF69B4" letter-spacing="1">PENDING</text></g>'
+  + '</svg>';
+
+const ANON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 66">'
+  + '<rect width="56" height="66" fill="#1f1d3e"/>'
+  + '<g shape-rendering="crispEdges">'
+  + '<rect x="20" y="12" width="16" height="16" fill="#e8dcc8"/>'
+  + '<rect x="18" y="10" width="20" height="6" fill="#4a3f8a"/>'
+  + '<rect x="24" y="19" width="2" height="2" fill="#1a1030"/>'
+  + '<rect x="30" y="19" width="2" height="2" fill="#1a1030"/>'
+  + '<rect x="16" y="30" width="24" height="24" fill="#b8a6e8"/>'
+  + '<rect x="22" y="30" width="12" height="8" fill="#f2ebdd"/>'
+  + '<rect x="16" y="54" width="9" height="10" fill="#2e2e55"/>'
+  + '<rect x="31" y="54" width="9" height="10" fill="#2e2e55"/></g>'
+  + '</svg>';
+
+function dataUri(svg) { return 'data:image/svg+xml,' + encodeURIComponent(svg); }
+
+const PENDING_URI = dataUri(PENDING_SVG);
+const ANON_URI = dataUri(ANON_SVG);
+
+/**
+ * The stand-in portrait for a profile that has no photo on it.
+ * The ANON rung gets the presence pixel student - at that rung "a ghost with no
+ * name or picture" is a CHOICE the player made, and their own card should show
+ * them what strangers see. Every other rung gets PHOTO PENDING, which is a gap
+ * and says so.
+ * @param {?string} share  the presenceShare rung
+ * @returns {string} a `data:` URI
+ */
+export function genericPortrait(share) {
+  return String(share) === 'anon' ? ANON_URI : PENDING_URI;
+}
+
+/** What the photo well ANNOUNCES. A drawn stand-in is a gap, and a gap that a
+ *  screen reader cannot hear is a gap that is simply missing. */
+export function portraitLabel(t, profile) {
+  const tr = typeof t === 'function' ? t : (k, fb) => fb;
+  return hasPhoto(profile) ? '' : tr('id_photo_pending', 'Photo pending');
+}
+
+/** The `src` one `<img>` should carry for this profile. Never a Discord url. */
+export function portraitSrc(profile) {
+  const p = profile || {};
+  if (hasPhoto(p) && typeof p.avatarUrl === 'string' && p.avatarUrl) return p.avatarUrl;
+  return genericPortrait(p.presenceShare);
+}
+
+/** True when the card is entitled to wear the real photo (the consent matrix). */
+export function hasPhoto(profile) {
+  const p = profile || {};
+  return !!p.discordLinked && String(p.presenceShare) === 'discord' && !!p.avatarUrl;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE CHIP
+ *
+ * ONE switch with three resting rungs and one in-flight look. The rung is
+ * derived from the profile; `wait` and `pending` are handed down by the shell
+ * and never guessed here (trap 1).
+ * -------------------------------------------------------------------------- */
+
+/** @returns {'on'|'use'|'link'} the rung this profile rests on. */
+export function chipRung(profile) {
+  const p = profile || {};
+  if (!p.discordLinked) return 'link';
+  return String(p.presenceShare) === 'discord' ? 'on' : 'use';
+}
+
+/**
+ * The chip's words. The furniture card is 64px wide and takes the SHORT form;
+ * the spotlight has room for the whole consent sentence.
+ * @param {Function} t
+ * @param {string} state  'on' | 'use' | 'link' | 'wait'
+ * @param {boolean=} short
+ */
+export function chipLabel(t, state, short) {
+  const tr = typeof t === 'function' ? t : (k, fb) => fb;
+  if (short) {
+    if (state === 'on') return tr('id_chip_on', 'Photo on');
+    if (state === 'use') return tr('id_chip_use', 'Use Discord photo');
+    if (state === 'wait') return tr('id_chip_wait', 'Waiting...');
+    return tr('id_chip_link', 'Link Discord');
+  }
+  if (state === 'on') return tr('id_photo_on', 'Discord photo on');
+  if (state === 'use') return tr('id_photo_use', 'Use my Discord photo');
+  if (state === 'wait') return tr('id_photo_waiting', 'Waiting on Discord...');
+  return tr('id_photo_link', 'Link Discord for my photo');
+}
+
+/** The consent sentence under the chip (spotlight only). Says what the click does. */
+export function chipHint(t, state, web) {
+  const tr = typeof t === 'function' ? t : (k, fb) => fb;
+  if (state === 'on') {
+    return tr('id_photo_hint_off',
+      'Your ghost on campus wears this photo too. Tap to take it down (your name stays).');
+  }
+  return web
+    ? tr('id_photo_hint_web',
+      'Sends you to Connections to link Discord, then straight back here with the photo on.')
+    : tr('id_photo_hint_app',
+      'Opens the Discord link-up in the app, then your photo goes on the card and on campus.');
+}
+
+/** The Discord glyph, as an inline `<svg>` (the chip's `link` rung wears it). */
+function discordGlyph() {
+  const ns = 'http://www.w3.org/2000/svg';
+  try {
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('class', 'id-chip-glyph');
+    svg.setAttribute('aria-hidden', 'true');
+    const path = document.createElementNS(ns, 'path');
+    path.setAttribute('fill', 'currentColor');
+    path.setAttribute('d', 'M19.5 5.3A17 17 0 0 0 15.4 4l-.5 1a15.6 15.6 0 0 0-5.8 0L8.6 4a17 17 0 0 0-4.1'
+      + ' 1.3C1.9 9.2 1.2 13 1.5 16.7A17 17 0 0 0 6.6 19l1-1.6a11 11 0 0 1-1.7-.8l.4-.3a12 12 0 0 0 11.4'
+      + ' 0l.4.3-1.7.8 1 1.6a17 17 0 0 0 5.1-2.3c.4-4.3-.7-8-3-11.4ZM8.7 14.4c-1 0-1.8-.9-1.8-2s.8-2'
+      + ' 1.8-2 1.8.9 1.8 2-.8 2-1.8 2Zm6.6 0c-1 0-1.8-.9-1.8-2s.8-2 1.8-2 1.8.9 1.8 2-.8 2-1.8 2Z');
+    svg.appendChild(path);
+    return svg;
+  } catch (e) { return null; }
+}
+
+/** The crest: an arcade token with a star. Drawn, never an asset. */
+function crestGlyph(cls) {
+  const ns = 'http://www.w3.org/2000/svg';
+  try {
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('viewBox', '0 0 20 20');
+    svg.setAttribute('class', cls || 'id-crest-mark');
+    svg.setAttribute('aria-hidden', 'true');
+    const ring = document.createElementNS(ns, 'circle');
+    ring.setAttribute('cx', '10'); ring.setAttribute('cy', '10'); ring.setAttribute('r', '9');
+    ring.setAttribute('fill', 'none'); ring.setAttribute('stroke', 'currentColor');
+    ring.setAttribute('stroke-width', '2');
+    const star = document.createElementNS(ns, 'path');
+    star.setAttribute('fill', 'currentColor');
+    star.setAttribute('d', 'M10 5.5l1.3 2.8 3 .3-2.3 2 .7 3-2.7-1.6-2.7 1.6.7-3-2.3-2 3-.3z');
+    svg.appendChild(ring); svg.appendChild(star);
+    return svg;
+  } catch (e) { return null; }
+}
+
+/**
+ * PAINT ONE CHIP. Shared by both surfaces so the furniture card and the
+ * spotlight always wear the same rung. `pending` keeps the LAST label and only
+ * greys the chip: the echo has not landed, so there is nothing new to say.
+ *
+ * @param {Element} chip
+ * @param {Function} t
+ * @param {string} state  'on'|'use'|'link'|'wait'|'pending'
+ * @param {boolean=} short
+ */
+export function paintChip(chip, t, state, short) {
+  if (!chip) return;
+  const pending = state === 'pending';
+  const rung = pending ? (chip.dataset ? (chip.dataset.rung || 'link') : 'link') : String(state || 'link');
+  try { if (chip.dataset && !pending) chip.dataset.rung = rung; } catch (e) { /* noop */ }
+  const base = short ? 'id-chip' : 'arc-id-chip id-chip';
+  const cls = base + ' is-' + rung + (pending ? ' is-pending' : '');
+  try { chip.className = cls; } catch (e) { /* noop */ }
+  try { chip.textContent = ''; } catch (e) { /* noop */ }
+  const led = el('i', 'id-chip-led');
+  attr(led, 'aria-hidden', 'true');
+  chip.appendChild(led);
+  if (rung === 'link') {
+    const g = discordGlyph();
+    if (g) chip.appendChild(g);
+  }
+  const shown = (state === 'wait') ? 'wait' : rung;
+  chip.appendChild(el('span', 'id-chip-label', chipLabel(t, shown, short)));
+  try { chip.disabled = (state === 'wait' || pending); } catch (e) { /* noop */ }
+  attr(chip, 'aria-label', chipLabel(t, shown, false));
+}
+
+/* ----------------------------------------------------------------------------
+ * PHOTO DAY - the one ceremony on this card (REVEAL tier, once per link).
+ * A shutter, a 120ms white flash on the WELL only (never the screen), and the
+ * photo developing in from grey. Reduced motion is a plain swap: the classes
+ * are simply not added, and the finished state is what was already there.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @param {Element} well      the `.id-photo` / `.arc-id-photo` box
+ * @param {Function} sfx      (name, level, extra)
+ * @param {boolean} still     reduced motion
+ * @param {Function} schedule (ms, fn) - the caller's own tracked timer
+ */
+export function runPhotoDay(well, sfx, still, schedule) {
+  const cue = typeof sfx === 'function' ? sfx : () => {};
+  const at = typeof schedule === 'function' ? schedule : (ms, fn) => { try { setTimeout(fn, ms); } catch (e) { fn(); } };
+  if (!well || !well.classList) return false;
+  if (still) return true;   // the photo is simply there - the swap already happened
+  cue('shutter', 0.22);
+  try {
+    well.classList.remove('is-flashing', 'is-developing');
+    void well.offsetWidth;                    // one forced layout, so the class re-fires
+    well.classList.add('is-flashing');
+  } catch (e) { /* noop */ }
+  at(120, () => { try { well.classList.add('is-developing'); } catch (e) { /* noop */ } });
+  at(900, () => { try { well.classList.remove('is-flashing', 'is-developing'); } catch (e) { /* noop */ } });
+  return true;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE BARCODE (the back). Seeded off the student number, so it is the same bars
+ * every night - and it is the one innocent seed on the card: the digits under it
+ * spell the number back at you, a little too long.
+ * -------------------------------------------------------------------------- */
+function paintBarcode(box, seed) {
+  if (!box) return;
+  try { box.textContent = ''; } catch (e) { return; }
+  let h = fnv1a(String(seed));
+  for (let i = 0; i < 46; i++) {
+    h = (Math.imul(h, 1103515245) + 12345) >>> 0;
+    const bar = el('i');
+    css(bar, 'width', (1 + ((h >>> 28) % 3)) + 'px');
+    css(bar, 'margin-right', (1 + ((h >>> 20) % 2)) + 'px');
+    box.appendChild(bar);
+  }
+}
+
+/* ----------------------------------------------------------------------------
+ * THE SPOTLIGHT
+ * -------------------------------------------------------------------------- */
+
+/** Milestones the streak tile ghosts when you are one short (ALMOST, honest). */
+const MILESTONES = [7, 14, 30];
+
+/** Homeroom is a ROOM NUMBER, not a display string (shell/room.js: 101). */
+const HOMEROOM_NO = '101';
+
+/**
+ * Build the ID spotlight. Nothing is on screen until `open()`.
+ *
+ * @param {Object} o
+ * @param {Function} o.t              lexicon reader
+ * @param {Function=} o.reducedMotion () -> boolean. Defaults to the page's own signals.
+ * @param {boolean=} o.lite           init.performanceMode (the lit-down room)
+ * @param {Function=} o.isMobile      () -> boolean
+ * @param {Function} o.profile        () -> {name, avatarUrl, discordLinked, presenceShare,
+ *                                            selfId, web}
+ * @param {Function} o.stats          () -> {streak, perfect, stamps, stampCap, sDays,
+ *                                            termRoman, tier, enrolled, mastered, cards}
+ * @param {Function=} o.onChip        the ONE chip verb (the shell posts the frame)
+ * @param {Function=} o.onClose       fired on EVERY path out (Esc, the veil, the
+ *                                    close button, Open Records, a teardown) -
+ *                                    the shell's EMI bracket hangs off it, and a
+ *                                    bracket with one exit it does not know about
+ *                                    is a mascot that never comes back
+ * @param {Function=} o.onRecords     "Open Records" on the back
+ * @param {Function=} o.onOpenCount   () -> how many opens INCLUDING this one (the shell
+ *                                    owns the `idOpens` meta key; the full cue sheet
+ *                                    plays only while that is under 3)
+ * @param {Function=} o.sfx           (name, level, extra) - shell/audio.js's document cue
+ * @param {Function=} o.log
+ * @returns {{open, dismiss, isOpen, setProfile, setChipState, photoDay, root}}
+ */
+export function createIdSpotlight({ t, reducedMotion, lite, isMobile, profile, stats,
+  onChip, onRecords, onClose, onOpenCount, sfx, log } = {}) {
+  const say = typeof log === 'function' ? log : () => {};
+  const tr = typeof t === 'function' ? t : (k, fb) => fb;
+  const still = typeof reducedMotion === 'function' ? reducedMotion : idReducedMotion;
+  const phone = typeof isMobile === 'function' ? isMobile : () => false;
+  const readProfile = typeof profile === 'function' ? profile : () => ({});
+  const readStats = typeof stats === 'function' ? stats : () => ({});
+  const cue = typeof sfx === 'function' ? sfx : () => {};
+  const countOpen = typeof onOpenCount === 'function' ? onOpenCount : () => 1;
+
+  /** The live spotlight, or null. {el, timers:[], from, rm, refs} */
+  let spot = null;
+
+  function schedule(ms, fn) {
+    if (!spot) return 0;
+    const box = spot.el;
+    try {
+      const id = setTimeout(() => { if (spot && spot.el === box) fn(); }, Math.max(0, ms | 0));
+      spot.timers.push(id);
+      return id;
+    } catch (e) { return 0; }
+  }
+
+  /* ------------------------------- dismiss ----------------------------- */
+
+  /**
+   * Put the card back. Returns true when one was up (the Esc rung's answer).
+   * `silent` skips the exit fade and the cue - a teardown has already taken the
+   * ground out from under it. Every queued cue dies here, so a skipped
+   * entrance lands on the SETTLED end state and never fires a beat afterwards.
+   */
+  function dismiss(silent) {
+    if (!spot) return false;
+    const s = spot;
+    spot = null;
+    for (const id of s.timers) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+    if (s.raf) { try { cancelAnimationFrame(s.raf); } catch (e) { /* noop */ } }
+    const drop = () => { try { if (s.el && s.el.remove) s.el.remove(); } catch (e) { /* noop */ } };
+    if (silent || s.rm || !(s.el && s.el.classList)) {
+      drop();
+    } else {
+      cue('whoosh', 0.1, { pitch: 0.8 });
+      try { s.el.classList.add('is-closing'); } catch (e) { /* noop */ }
+      let scheduled = false;
+      try { setTimeout(drop, 200); scheduled = true; } catch (e) { /* noop */ }
+      if (!scheduled) drop();
+    }
+    // Focus goes back to the furniture card that opened it.
+    if (!silent && s.from) { try { s.from.focus(); } catch (e) { /* noop */ } }
+    // EVERY path out is this function, which is what makes the shell's EMI
+    // bracket safe: she comes back on the same call that takes the card away.
+    try { if (typeof onClose === 'function') onClose(); }
+    catch (e) { say('id spotlight onClose threw: ' + ((e && e.message) || e)); }
+    return true;
+  }
+
+  function isOpen() { return !!spot; }
+
+  /* -------------------------------- paint ------------------------------ */
+
+  function nameFor(p) { return (p && p.name) ? String(p.name) : tr('student', 'Student'); }
+
+  /** Repaint the parts a `profile` frame or a `setting` echo can move. */
+  function setProfile() {
+    if (!spot) return;
+    const p = readProfile() || {};
+    const r = spot.refs;
+    const real = hasPhoto(p);
+    try { if (r.img) r.img.src = portraitSrc(p); } catch (e) { /* noop */ }
+    try { if (r.photo) r.photo.classList.toggle('is-real', real); } catch (e) { /* noop */ }
+    attr(r.photo, 'aria-label', portraitLabel(tr, p));
+    const nm = nameFor(p);
+    if (r.name) r.name.textContent = nm;
+    if (r.sig) r.sig.textContent = nm;
+    const rung = chipRung(p);
+    paintChip(r.chip, tr, rung, false);
+    if (r.hint) r.hint.textContent = chipHint(tr, rung, !!p.web);
+    const num = studentNumber(p.selfId, (readStats() || {}).enrolled, p.name);
+    if (r.no) r.no.textContent = num.no;
+    if (r.noTemp) r.noTemp.hidden = !num.temp;
+    if (r.foilNo) r.foilNo.textContent = num.no;
+    paintBarcode(r.barcode, num.no);
+    if (r.barcodeNo) r.barcodeNo.textContent = num.no.replace('-', '') + '00';
+  }
+
+  /** The shell hands the chip its in-flight looks (`wait` / `pending`). */
+  function setChipState(state) {
+    if (!spot) return;
+    const p = readProfile() || {};
+    paintChip(spot.refs.chip, tr, state, false);
+    if (spot.refs.hint) {
+      spot.refs.hint.textContent = chipHint(tr, state === 'wait' || state === 'pending' ? chipRung(p) : state, !!p.web);
+    }
+  }
+
+  /** PHOTO DAY, on the big well. Also re-inks the YEAR stamp (a new photo is a
+   *  new card, and the stamp is what says a card is current). */
+  function photoDay() {
+    if (!spot) return false;
+    const rm = spot.rm;
+    runPhotoDay(spot.refs.photo, cue, rm, schedule);
+    const stamp = spot.refs.stamp;
+    if (stamp && stamp.classList && !rm) {
+      schedule(450, () => {
+        try {
+          stamp.classList.remove('is-thud');
+          void stamp.offsetWidth;
+          stamp.classList.add('is-thud');
+        } catch (e) { /* noop */ }
+        try { thud(1.15); } catch (e) { /* noop */ }
+      });
+    }
+    return true;
+  }
+
+  /* --------------------------------- open ------------------------------ */
+
+  /**
+   * Lift the card to the middle of the screen under a key light.
+   *   0ms    veil + lamp, the card sweeps in                    ('whoosh')
+   *   ~400ms the YEAR stamp lands                               (the thud)
+   *   ~700ms the marquee glint crosses the name                 ('slide')
+   *   ~750ms the six tiles land 90ms apart, counting up   ('pop' + 1 semitone)
+   * Reduced motion mounts the same dialog with one fade, tiles pre-filled and
+   * no cues at all. After the third open the ladder is dropped and the tiles
+   * arrive already filled - repetition shrinks the party.
+   */
+  function open(fromEl) {
+    dismiss(true);
+    const rm = !!still();
+    const p = readProfile() || {};
+    const s = readStats() || {};
+    const opens = (function () { try { return countOpen() | 0; } catch (e) { return 99; } })();
+    const compact = opens > 3;
+    const real = hasPhoto(p);
+    const num = studentNumber(p.selfId, s.enrolled, p.name);
+    const nm = nameFor(p);
+    const tier = Math.max(1, Math.min(4, Math.round(Number(s.tier) || 1)));
+    const term = String(s.termRoman || 'I');
+
+    const box = el('div', 'arc-id' + (rm ? ' arc-id-reduced' : '') + (lite ? ' is-lite' : ''));
+    attr(box, 'role', 'dialog');
+    attr(box, 'aria-modal', 'true');
+    attr(box, 'aria-label', tr('student_id_title', 'Student ID'));
+
+    const veil = el('div', 'arc-id-veil');
+    attr(veil, 'aria-hidden', 'true');
+    veil.addEventListener('click', () => dismiss());
+    box.appendChild(veil);
+
+    const stage = el('div', 'arc-id-stage');
+    box.appendChild(stage);
+
+    const lamp = el('div', 'arc-id-lamp');
+    attr(lamp, 'aria-hidden', 'true');
+    stage.appendChild(lamp);
+
+    const row = el('div', 'arc-id-row');
+    stage.appendChild(row);
+
+    /* ------------------------------ the card --------------------------- */
+    const wrap = el('div', 'arc-id-cardwrap');
+    const big = el('div', 'arc-id-big');
+    attr(big, 'title', tr('id_flip', 'Tap the card to turn it over. Esc to put it back.'));
+    wrap.appendChild(big);
+    row.appendChild(wrap);
+
+    const front = el('div', 'arc-id-face is-front');
+    const back = el('div', 'arc-id-face is-back');
+    big.appendChild(front);
+    big.appendChild(back);
+
+    const refs = {};
+
+    function band(host, kindText) {
+      const b = el('div', 'arc-id-band');
+      const crest = el('span', 'arc-id-crest');
+      const mark = crestGlyph('arc-id-crestmark');
+      if (mark) crest.appendChild(mark);
+      crest.appendChild(el('span', null, tr('arcademy', 'The Arcademy').toUpperCase()));
+      b.appendChild(crest);
+      b.appendChild(el('span', 'arc-id-kind', kindText));
+      host.appendChild(b);
+    }
+
+    function foil(host, markText, numText) {
+      const f = el('div', 'arc-id-foil');
+      attr(f, 'aria-hidden', 'true');
+      f.appendChild(el('i', 'arc-id-rainbow'));
+      f.appendChild(el('i', 'arc-id-grid'));
+      f.appendChild(el('span', 'arc-id-foilmark', markText));
+      if (numText != null) {
+        const n = el('span', 'arc-id-foilno', numText);
+        f.appendChild(n);
+        refs.foilNo = n;
+      }
+      host.appendChild(f);
+    }
+
+    /* FRONT */
+    const lam = el('i', 'arc-id-lam');
+    attr(lam, 'aria-hidden', 'true');
+    front.appendChild(lam);
+    band(front, tr('student_id_title', 'Student ID').toUpperCase());
+
+    const body = el('div', 'arc-id-body');
+    front.appendChild(body);
+
+    const well = el('div', 'arc-id-well');
+    body.appendChild(well);
+
+    const photo = el('div', 'arc-id-photo' + (real ? ' is-real' : ''));
+    const img = el('img', 'arc-id-photo-img');
+    attr(img, 'alt', '');
+    attr(img, 'decoding', 'async');
+    img.addEventListener('error', () => {
+      /* A portrait that will not decode falls back to the drawn one - one swap,
+       * no retry storm, and never a second network attempt (ghosts.js's rule). */
+      try {
+        const fb = genericPortrait((readProfile() || {}).presenceShare);
+        if (img.src !== fb) { img.src = fb; photo.classList.remove('is-real'); }
+      } catch (e) { /* noop */ }
+    });
+    img.src = portraitSrc(p);
+    photo.appendChild(img);
+    const flash = el('i', 'arc-id-flash');
+    attr(flash, 'aria-hidden', 'true');
+    photo.appendChild(flash);
+    attr(photo, 'aria-label', portraitLabel(tr, p));
+    well.appendChild(photo);
+    refs.photo = photo;
+    refs.img = img;
+
+    const chip = el('button', 'arc-id-chip id-chip');
+    chip.type = 'button';
+    chip.addEventListener('click', (ev) => {
+      try { ev.stopPropagation(); } catch (e) { /* noop */ }
+      cue('pop', 0.1);
+      try { if (typeof onChip === 'function') onChip(); } catch (e) { say('id chip threw: ' + ((e && e.message) || e)); }
+    });
+    well.appendChild(chip);
+    refs.chip = chip;
+
+    const hint = el('div', 'arc-id-hint', chipHint(tr, chipRung(p), !!p.web));
+    well.appendChild(hint);
+    refs.hint = hint;
+
+    const meta = el('div', 'arc-id-meta');
+    body.appendChild(meta);
+
+    const nameEl = el('h3', 'arc-id-name');
+    nameEl.appendChild(el('span', 'arc-id-nametext', nm));
+    const glint = el('i', 'arc-id-glint');
+    attr(glint, 'aria-hidden', 'true');
+    nameEl.appendChild(glint);
+    meta.appendChild(nameEl);
+    refs.name = nameEl.firstChild;
+
+    const noLine = el('div', 'arc-id-num');
+    noLine.appendChild(el('span', 'arc-id-numlabel', tr('id_no', 'Student no.').toUpperCase()));
+    const noVal = el('i', 'arc-id-numval', num.no);
+    noLine.appendChild(noVal);
+    const noTemp = el('em', 'arc-id-numtemp', tr('id_no_temp', 'temp'));
+    noTemp.hidden = !num.temp;
+    noLine.appendChild(noTemp);
+    meta.appendChild(noLine);
+    refs.no = noVal;
+    refs.noTemp = noTemp;
+
+    const rows = el('dl', 'arc-id-rows');
+    const rowPair = (k, v) => {
+      rows.appendChild(el('dt', null, String(k).toUpperCase()));
+      rows.appendChild(el('dd', null, String(v)));
+    };
+    rowPair(tr('semester', 'Semester'), term);
+    rowPair(tr('id_enrolled', 'Enrolled'), s.enrolled || '--');
+    rowPair(tr('id_homeroom', 'Homeroom'), HOMEROOM_NO);
+    rowPair(tr('id_issued_at', 'Issued at'), tr('id_front_desk', 'Front desk'));
+    meta.appendChild(rows);
+
+    const stamp = el('div', 'arc-id-yearstamp');
+    stamp.appendChild(el('span', null, tr('id_year', 'Year') + ' ' + tier));
+    stamp.appendChild(el('small', null, tr('id_grade_tier', 'Grade tier').toUpperCase()));
+    meta.appendChild(stamp);
+    refs.stamp = stamp;
+
+    foil(front, tr('arcademy', 'The Arcademy').toUpperCase() + ' ' + term, num.no);
+
+    /* BACK */
+    const lam2 = el('i', 'arc-id-lam');
+    attr(lam2, 'aria-hidden', 'true');
+    back.appendChild(lam2);
+    band(back, tr('student_id_title', 'Student ID').toUpperCase());
+
+    const bbody = el('div', 'arc-id-body is-back');
+    back.appendChild(bbody);
+
+    const barBox = el('div', 'arc-id-barcode');
+    attr(barBox, 'aria-hidden', 'true');
+    bbody.appendChild(barBox);
+    refs.barcode = barBox;
+    const barNo = el('div', 'arc-id-barcodeno', num.no.replace('-', '') + '00');
+    bbody.appendChild(barNo);
+    refs.barcodeNo = barNo;
+
+    const smallPrint = el('p', 'arc-id-small');
+    smallPrint.appendChild(el('b', null, tr('id_back_lost',
+      'Lost it? Ask at the front desk. The second one costs you a stamp.')));
+    smallPrint.appendChild(document.createElement('br'));
+    smallPrint.appendChild(document.createTextNode(
+      tr('id_back_valid', 'Good for as long as the lights are on.')));
+    bbody.appendChild(smallPrint);
+
+    const mastered = Math.max(0, Math.round(Number(s.mastered) || 0));
+    const cards = Math.max(0, Math.round(Number(s.cards) || 0));
+    bbody.appendChild(el('div', 'arc-id-punchline',
+      tr('id_records_line', 'Records: {n} of {m} cards mastered')
+        .replace('{n}', String(mastered)).replace('{m}', String(cards))));
+
+    const recordsBtn = el('button', 'arc-id-recordslink', tr('id_open_records', 'Open Records'));
+    recordsBtn.type = 'button';
+    recordsBtn.addEventListener('click', (ev) => {
+      try { ev.stopPropagation(); } catch (e) { /* noop */ }
+      cue('pop', 0.1);
+      dismiss(true);
+      try { if (typeof onRecords === 'function') onRecords(); } catch (e) { say('id records threw'); }
+    });
+    bbody.appendChild(recordsBtn);
+
+    const sig = el('div', 'arc-id-sig');
+    const sigLine = el('div', 'arc-id-sigline');
+    const sigName = el('span', null, nm);
+    sigLine.appendChild(sigName);
+    sig.appendChild(sigLine);
+    bbody.appendChild(sig);
+    refs.sig = sigName;
+
+    foil(back, tr('student_id_title', 'Student ID').toUpperCase());
+
+    /* ---------------------------- the stat sheet ----------------------- */
+    const sheet = el('div', 'arc-id-sheet');
+    row.appendChild(sheet);
+
+    const streak = Math.max(0, Math.round(Number(s.streak) || 0));
+    const next = MILESTONES.find((m) => m > streak);
+    const toGo = (next && next - streak <= 3 && streak > 0) ? next - streak : 0;
+
+    const tiles = [];
+    function tile(idx, cls, value, label, almost) {
+      const box2 = el('div', 'arc-id-tile' + (cls ? ' ' + cls : ''));
+      css(box2, '--i', String(idx));
+      const b = el('b', null, '0');
+      if (typeof value === 'number') {
+        try { b.dataset.count = String(value); } catch (e) { /* noop */ }
+        tiles.push(b);
+      } else {
+        b.textContent = '';
+        b.appendChild(el('span', null, String(value.main)));
+        if (value.sub) b.appendChild(el('i', null, value.sub));
+      }
+      box2.appendChild(b);
+      box2.appendChild(el('span', null, String(label).toUpperCase()));
+      if (almost) {
+        const a = el('div', 'arc-id-almost');
+        a.appendChild(el('span', null, tr('id_to_go', '{n} to go').replace('{n}', String(almost.n)).toUpperCase()));
+        a.appendChild(el('b', null, '\u2192 ' + String(almost.at)));
+        box2.appendChild(a);
+      }
+      sheet.appendChild(box2);
+      return box2;
+    }
+
+    tile(0, '', streak, tr('id_stat_streak', 'Attendance streak'),
+      toGo ? { n: toGo, at: next } : null);
+    tile(1, 'is-gold', Math.max(0, Math.round(Number(s.perfect) || 0)),
+      tr('id_stat_perfect', 'Perfect days'));
+    tile(2, 'is-lav', Math.max(0, Math.round(Number(s.stamps) || 0)),
+      tr('id_stat_stamps', 'Stamps of 100'));
+    tile(3, 'is-gold', Math.max(0, Math.round(Number(s.sDays) || 0)),
+      tr('id_stat_best', 'S days'));
+    tile(4, 'is-text', { main: term, sub: '\u00b7 ' + tr('id_year', 'Year') + ' ' + tier },
+      tr('id_stat_semester', 'Term'));
+    tile(5, 'is-text', { main: s.enrolled || '--' }, tr('id_enrolled', 'Enrolled'));
+
+    /* ------------------------------ placard ---------------------------- */
+    const placard = el('div', 'arc-id-placard');
+    placard.appendChild(el('h2', null, tr('student_id_title', 'Student ID')));
+    placard.appendChild(el('p', null,
+      tr('id_flip', 'Tap the card to turn it over. Esc to put it back.').toUpperCase()));
+    stage.appendChild(placard);
+
+    const close = el('button', 'arc-id-close', '✕');
+    close.type = 'button';
+    attr(close, 'aria-label', tr('id_spot_close', 'Close'));
+    close.addEventListener('click', () => dismiss());
+    box.appendChild(close);
+    refs.close = close;
+
+    /* ------------------------------- the flip -------------------------- */
+    function flip() {
+      if (!spot) return;
+      const on = !big.classList.contains('is-back');
+      try {
+        if (!spot.rm) {
+          big.classList.add('is-flipping');
+          schedule(660, () => { try { big.classList.remove('is-flipping'); } catch (e) { /* noop */ } });
+        }
+        css(big, '--rx', '0deg');
+        css(big, '--ry', '0deg');
+        big.classList.toggle('is-back', on);
+      } catch (e) { /* noop */ }
+      cue('slide', 0.12, { pitch: on ? 0.9 : 1.1 });
+    }
+    big.addEventListener('click', (ev) => {
+      try {
+        const target = ev && ev.target;
+        if (target && typeof target.closest === 'function'
+          && target.closest('.id-chip, .arc-id-recordslink')) return;
+      } catch (e) { /* noop */ }
+      flip();
+    });
+
+    /* --------------------------- THE DRIFT (tilt) ---------------------- */
+    /* One pointermove on the card, rAF-throttled, writing THREE custom
+     * properties and nothing else: the laminate specular and the foil hue both
+     * hang off them, so the whole effect is one transform per frame (trap 36).
+     * Touch has no pointer to follow, so it keeps the foil's own slow drift. */
+    if (!rm && !phone()) {
+      const onMove = (ev) => {
+        if (!spot || big.classList.contains('is-back')) return;
+        let r = null;
+        try { r = big.getBoundingClientRect(); } catch (e) { return; }
+        if (!r || !(r.width > 0)) return;
+        const px = (ev.clientX - r.left) / r.width;
+        const py = (ev.clientY - r.top) / r.height;
+        if (spot.raf) return;
+        try {
+          spot.raf = requestAnimationFrame(() => {
+            if (!spot) return;
+            spot.raf = 0;
+            css(big, '--ry', ((px - 0.5) * 12).toFixed(2) + 'deg');
+            css(big, '--rx', ((0.5 - py) * 10).toFixed(2) + 'deg');
+            css(big, '--mx', (px * 100).toFixed(1) + '%');
+            css(big, '--my', (py * 100).toFixed(1) + '%');
+          });
+        } catch (e) { /* no rAF: the card simply does not tilt */ }
+      };
+      big.addEventListener('pointermove', onMove);
+      big.addEventListener('pointerleave', () => {
+        css(big, '--rx', '0deg');
+        css(big, '--ry', '0deg');
+      });
+    }
+
+    /* ------------------------------ the trap --------------------------- */
+    /* Tab cycles inside the dialog and never leaves it. Esc is NOT bound here:
+     * boot.js owns the key and shell.js's escapeStep asks dismiss() first
+     * (trap 48's shape - never a second key ladder). */
+    box.addEventListener('keydown', (ev) => {
+      if (!ev || ev.key !== 'Tab') return;
+      let list = [];
+      try { list = Array.prototype.slice.call(box.querySelectorAll('button:not([disabled])')); }
+      catch (e) { list = [close]; }
+      if (!list.length) list = [close];
+      try { ev.preventDefault(); } catch (e) { /* noop */ }
+      let i = list.indexOf(document.activeElement);
+      if (i < 0) i = 0;
+      else i = ev.shiftKey ? (i - 1 + list.length) % list.length : (i + 1) % list.length;
+      try { list[i].focus(); } catch (e) { /* noop */ }
+    });
+
+    document.body.appendChild(box);
+    spot = { el: box, timers: [], from: fromEl || null, rm, refs, raf: 0 };
+    paintBarcode(barBox, num.no);
+    paintChip(chip, tr, chipRung(p), false);
+    try { close.focus(); } catch (e) { /* noop */ }
+    if (rm && typeof requestAnimationFrame === 'function') {
+      /* THE ONE FADE. `.arc-id-reduced` owns it on the ROOT (every descendant
+       * is animation:none), so the beat is a single 120ms arrival. */
+      try { requestAnimationFrame(() => { if (spot && spot.el === box) box.classList.add('is-in'); }); }
+      catch (e) { /* noop */ }
+    }
+
+    /* ------------------------------ the cues --------------------------- */
+    /* Reduced motion plays NONE of them and the tiles carry their truth at
+     * mount; the compact cut (open 4 and up) keeps the entrance and drops the
+     * ladder. Both land on exactly the same finished sheet. */
+    if (rm || compact) {
+      for (const b of tiles) { try { b.textContent = b.dataset.count; } catch (e) { /* noop */ } }
+    }
+    if (!rm) {
+      cue('whoosh', 0.22);
+      if (!compact) {
+        schedule(400, () => { try { thud(1); } catch (e) { /* noop */ } });
+        schedule(700, () => cue('slide', 0.14));
+        tiles.forEach((b, i) => {
+          const target = Number(b.dataset.count) || 0;
+          schedule(750 + i * 90, () => {
+            cue('pop', 0.12, { pitch: 0.85 + Math.min(6, i) * 0.06 });
+            countUp(b, target, 420, box);
+          });
+        });
+      }
+    }
+    return box;
+  }
+
+  /** THE BANK, lite: the number ticks up. No particles - a document does not
+   *  pay out. Stops dead the moment the spotlight it belongs to is gone. */
+  function countUp(node, target, ms, box) {
+    if (typeof requestAnimationFrame !== 'function' || typeof performance === 'undefined') {
+      try { node.textContent = String(target); } catch (e) { /* noop */ }
+      return;
+    }
+    const t0 = performance.now();
+    const step = (now) => {
+      if (!spot || spot.el !== box) return;
+      const prog = Math.min(1, (now - t0) / ms);
+      const eased = 1 - Math.pow(1 - prog, 3);
+      try { node.textContent = String(Math.round(target * eased)); } catch (e) { return; }
+      if (prog < 1) { try { requestAnimationFrame(step); } catch (e) { /* noop */ } }
+    };
+    try { requestAnimationFrame(step); } catch (e) { node.textContent = String(target); }
+  }
+
+  return {
+    open,
+    dismiss: (silent) => dismiss(!!silent),
+    isOpen,
+    setProfile,
+    setChipState,
+    photoDay,
+    /** The live dialog node, or null. Test seam. */
+    get root() { return spot ? spot.el : null; },
+    destroy() { dismiss(true); },
+  };
+}
+
+export default createIdSpotlight;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/orientation.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/orientation.js
@@ -449,11 +449,26 @@ export function createOrientation(o) {
     return true;
   }
 
+  /** THE CARD IS IN THE AIR. campus.js refuses the ID's own click and its chip
+   *  while this attribute is set: a card that is mid-handover is a beat, not a
+   *  thing you can pick up. ONE attribute, set where the flight starts and
+   *  cleared in landCard() - which every path out of the beat already goes
+   *  through, so there is exactly one place it comes off. */
+  function markInflight(on) {
+    const card = cardEl();
+    if (!card || !card.dataset) return;
+    try {
+      if (on) card.dataset.inflight = '1';
+      else delete card.dataset.inflight;
+    } catch (e) { /* noop */ }
+  }
+
   /** LAW 3. The card is in its home slot, right now, with nothing pending. */
   function landCard() {
     const card = cardEl();
     if (!card) return false;
     try { card.hidden = false; } catch (e) { /* noop */ }
+    markInflight(false);
     dropSheen();
     setStyle(card, 'transition', '');
     setStyle(card, 'transform', '');
@@ -475,6 +490,7 @@ export function createOrientation(o) {
     at(REDUCED_FADE_MS + 60, () => {
       setStyle(card, 'transition', '');
       setStyle(card, 'opacity', '');
+      markInflight(false);
     });
     return true;
   }
@@ -546,6 +562,7 @@ export function createOrientation(o) {
     if (state !== 'running') return;
     const card = cardEl();
     try { if (card) card.hidden = false; } catch (e) { /* noop */ }
+    markInflight(true);
     const flew = flip(card);
     at(flew ? FLIP_MS : 0, () => {
       if (state !== 'running') return;
@@ -613,6 +630,7 @@ export function createOrientation(o) {
       at(REDUCED_HI_MS, () => { if (state === 'running') { moment('hi'); } });
       at(REDUCED_CARD_MS, () => {
         if (state !== 'running') return;
+        markInflight(true);
         fadeInCard();
         stampCue();
         moment('card');

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -35,17 +35,17 @@ import {
   loadGames, descriptors, tierFor, tierForPromotions, advance, suspendedStub, MAX_TIER,
 } from '../games/registry.js';
 import { createBoard } from './splitflap.js';
-import { createCampus, campusState } from './campus.js';
+import { createCampus, campusState, currentSemester } from './campus.js';
 import { createGhosts, presenceOptions } from './ghosts.js';
 import { createWalker, roomStop } from './walk.js';
 import { createOrientation, needsOrientation, orientationOptions } from './orientation.js';
 import { createReportCard } from './reportcard.js';
-import { createSettingsPage, boardSizeKey, SETTING_KEYS, isGlobalSettingKey } from './settings.js';
+import { createSettingsPage, boardSizeKey, SETTING_KEYS, isGlobalSettingKey, PRESENCE_RUNGS } from './settings.js';
 import { createCeremonies } from './ceremonies.js';
 import { createPeek } from './peek.js';
 import { createKeybinds } from './keybinds.js';
 import { campusPill, createConfirm, exitBar, sign as signExit } from './exits.js';
-import { installDeviceClass } from '../core/device.js';
+import { installDeviceClass, isMobile } from '../core/device.js';
 import { requireOrientation, clearOrientation } from './orientgate.js';
 import { createEnrollmentIntro, createPunchCeremony } from './enrollment.js';
 /* FIRST BELL - the once-ever opening (vn/). It mints its own layer, owns its own
@@ -55,6 +55,7 @@ import { createEnrollmentIntro, createPunchCeremony } from './enrollment.js';
  * player's whole experience of this import is one controller that stands down. */
 import { createFirstBell } from '../vn/index.js';
 import { createRecords } from './records.js';
+import { createIdSpotlight, idReducedMotion } from './idcard.js';
 import { createAnnexReveal } from './annexreveal.js';
 /* THE SEEP - the foreshadowing layer. ONE director, and the shell's whole
  * relationship with it is: build it, hand it read-only seams and three gate
@@ -651,6 +652,35 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let endCard = null;
   /** The Records Office screen (PUNCHCARD §6) - built lazily, kept for reuse. */
   let recordsPage = null;
+  /* ---------------------- THE STUDENT ID (shell/idcard.js) ----------------
+   * The card in the corner of the campus is a document you can pick up now.
+   * The shell owns three things about it and the card owns none of them: the
+   * PROFILE (init.profile plus every `profile` frame the host pushes), the
+   * SPOTLIGHT (minted on the first open, like the Records one) and the CHIP's
+   * one verb - which posts a frame and then waits, because only the echo moves
+   * a setting (trap 1).
+   * `idChipWait` is the ONE optimistic paint: 'wait' while a Discord link-up is
+   * in the air, 'pending' while a set-setting is waiting on its echo. Both are
+   * cleared by the frame that answers, or by the 90s timeout below. */
+  let idSpotlight = null;
+  let idEmiPrev = false;
+  let idChipWait = null;
+  let idLinkTimer = 0;
+  let profile = {
+    name: null,
+    avatarUrl: null,
+    discordLinked: false,
+    presenceShare: idRung(src.presenceShare, 'off'),
+  };
+  if (src.profile && typeof src.profile === 'object') {
+    profile = {
+      name: typeof src.profile.name === 'string' && src.profile.name ? src.profile.name : null,
+      avatarUrl: typeof src.profile.avatarUrl === 'string' && src.profile.avatarUrl
+        ? src.profile.avatarUrl : null,
+      discordLinked: !!src.profile.discordLinked,
+      presenceShare: idRung(src.profile.presenceShare, profile.presenceShare),
+    };
+  }
   /** THE LAB (ANNEX-OS.md). Built fresh per visit and destroyed on every path
    *  out - it runs a cam-wall rAF and holds EMI's bracket, neither of which
    *  may survive the screen. `annexEmiPrev` remembers whether EMI was enabled
@@ -1009,6 +1039,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       orientation = null;
       try { ob.destroy(); } catch (e) { /* noop */ }
     }
+    /* THE ID SPOTLIGHT DIES WITH ITS CAMPUS. It was lifted off a node that is
+     * about to be destroyed, so a card left up would be holding a dead `from`
+     * to hand focus back to - and EMI comes back on the same wipe (the annex
+     * bracket's discipline). */
+    dismissIdCard(true);
     if (ghosts) { try { ghosts.destroy(); } catch (e) { /* noop */ } ghosts = null; }
     if (campus) {
       try { campus.destroy(); } catch (e) { /* noop */ }
@@ -1508,10 +1543,25 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
            * topbar gear, so these two lines are the whole split. */
           registrarRoom: () => walkThen('registrar', () => showSettings()),
           registrar: () => showSettings(),
+          /* THE STUDENT ID. The card OFFERS its press here and the shell owns
+           * the spotlight, exactly the way it owns the Records one - the campus
+           * never mints an overlay. No walk: the card is in your hand, not
+           * across the quad. */
+          idCard: () => showIdCard(),
+          /* The photo consent, leaving for the host. ONE function, because
+           * there is ONE switch (owner ruling 1). */
+          idChip: () => onIdChip(),
         },
         log: say,
       });
       campus.noteDescriptors(campusDescriptors());
+      /* THE CARD KNOWS WHO YOU ARE BEFORE IT IS EVER SEEN. The campus is torn
+       * down and rebuilt on every visit, so the profile is handed over here
+       * rather than held by the card - and an in-flight chip keeps its look
+       * across the rebuild. */
+      try { if (campus.setProfile) campus.setProfile(idProfile()); }
+      catch (e) { say('id card profile seed threw: ' + ((e && e.message) || e)); }
+      if (idChipWait) setIdChipState(idChipWait);
       campus.boardMount.appendChild(board.root);
       renderBoardExtras(campus.footMount);
       dom.screen.appendChild(campus.root);
@@ -1710,6 +1760,272 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       if (lastGraded && lastGraded.fresh) lastGraded.fresh = false;
       else fireMoment('reportCard', lastGraded || { grade: null, perfect: allDone() });
     }
+  }
+
+  /* ======================= THE STUDENT ID ===============================
+   * PUNCHCARD's neighbour: the one document the school hands YOU. Three seams
+   * live here and nowhere else.
+   *
+   *   THE PROFILE   `init.profile` (additive - a host that predates it simply
+   *                 never sends one, and the card draws "Student", the drawn
+   *                 stand-in portrait and the unlinked chip) plus every
+   *                 `profile` frame. The page derives NOTHING about your
+   *                 account: no Discord handle, no snowflake and no CDN url
+   *                 ever reaches this document (PRESENCE.md §10).
+   *   THE STATS     read off the store the way every other screen reads it -
+   *                 host-owned attendance, host-owned punch cards, the page's
+   *                 own graded `days`. Nothing here counts anything twice.
+   *   THE CHIP      ONE verb. Unlinked, it asks the host to run the link-up;
+   *                 linked, it moves the `presenceShare` rung. Either way it
+   *                 paints a waiting look and then waits for the answer.
+   * ==================================================================== */
+
+  /** Roman numerals for the term line. The campus names the same one. */
+  const ID_ROMAN = ['', 'I', 'II', 'III', 'IV'];
+
+  /** Coerce anything at all to one of the four presence rungs. */
+  function idRung(value, fallback) {
+    const v = String(value == null ? '' : value);
+    return PRESENCE_RUNGS.indexOf(v) >= 0 ? v : (fallback || 'off');
+  }
+
+  /** ONE cue request on `document` - shell/audio.js owns the only audio node on
+   *  the page (trap 18). A dropped cue is not an error. */
+  function idSfx(name, level, extra) {
+    try {
+      if (typeof document === 'undefined' || typeof document.dispatchEvent !== 'function') return;
+      const Ctor = (typeof CustomEvent === 'function') ? CustomEvent : null;
+      if (!Ctor) return;
+      document.dispatchEvent(new Ctor('arcademy-sfx', {
+        detail: Object.assign(
+          { name: String(name || 'blip'), level: Number(level) || 0.5, bus: 'fx' },
+          extra || {}
+        ),
+      }));
+    } catch (e) { /* noop */ }
+  }
+
+  /** The presence layer's own opaque `self` id, when the host has pushed one.
+   *  READ, never held: the ghost layer is rebuilt with the campus under it. */
+  function idSelfId() {
+    try {
+      const d = ghosts && typeof ghosts.diagnostics === 'function' ? ghosts.diagnostics() : null;
+      return (d && d.self) ? String(d.self) : null;
+    } catch (e) { return null; }
+  }
+
+  /** The earliest date the school has on you: the first enrolment across the
+   *  ten cards, and failing that the oldest day it wrote down. */
+  function idEnrolled() {
+    let best = null;
+    for (const entry of games.list) {
+      try {
+        const at = store.punchCard(entry.key).enrolledAt;
+        if (typeof at === 'string' && at && (!best || at < best)) best = at;
+      } catch (e) { /* a card that cannot be read is not a date */ }
+    }
+    if (best) return best;
+    try {
+      const days = store.get('days') || {};
+      const keys = Object.keys(days).sort();
+      if (keys.length) return keys[0];
+    } catch (e) { /* noop */ }
+    return null;
+  }
+
+  /** Distinct local dates on which ANY class graded S. Counted off the page's
+   *  own graded view, which is the only place a grade is written down. */
+  function idSDays() {
+    let n = 0;
+    try {
+      const days = store.get('days') || {};
+      for (const key of Object.keys(days)) {
+        const classes = (days[key] && days[key].classes) || {};
+        for (const g of Object.keys(classes)) {
+          if (String((classes[g] || {}).grade).toUpperCase() === 'S') { n++; break; }
+        }
+      }
+    } catch (e) { /* noop */ }
+    return n;
+  }
+
+  /** What the card says about YOU. One object, read fresh on every paint. */
+  function idProfile() {
+    return {
+      name: profile.name,
+      avatarUrl: profile.avatarUrl,
+      discordLinked: !!profile.discordLinked,
+      presenceShare: profile.presenceShare,
+      selfId: idSelfId(),
+      enrolled: idEnrolled(),
+      // The web build sends you to Connections; the app opens the link-up in
+      // place. The chip's hint has to say which, so it has to know.
+      web: src.mediaControls === true,
+    };
+  }
+
+  /** What the card says about your ATTENDANCE. Every number is somebody else's
+   *  truth: the host's streak, the host's cards, the page's graded days. */
+  function idStats() {
+    const s = store.streak();
+    const cards = games.list.length;
+    let stamps = 0;
+    for (const entry of games.list) {
+      try { stamps += store.punchCard(entry.key).punches | 0; } catch (e) { /* noop */ }
+    }
+    let mastered = 0;
+    try { mastered = Object.keys(unlockedMap()).length; } catch (e) { mastered = 0; }
+    return {
+      streak: s.count | 0,
+      perfect: s.perfectDays | 0,
+      stamps,
+      stampCap: cards * (store.holes || 10),
+      sDays: idSDays(),
+      termRoman: ID_ROMAN[currentSemester()] || 'I',
+      tier: maxTier(),
+      enrolled: idEnrolled(),
+      mastered,
+      cards,
+    };
+  }
+
+  /** THE OPEN COUNTER, page-owned (`idOpens`). The full cue sheet plays for the
+   *  first three opens and the compact cut every time after - repetition
+   *  shrinks the party, and the sheet lands on the same numbers either way. */
+  function idOpenCount() {
+    let n = 0;
+    try { n = Math.max(0, Math.round(Number(store.get('idOpens')) || 0)); } catch (e) { n = 0; }
+    n += 1;
+    try { store.set('idOpens', n); } catch (e) { /* a counter may never hold a door */ }
+    return n;
+  }
+
+  /** Repaint both surfaces from the ONE profile. Every echo lands here. */
+  function paintIdProfile() {
+    const p = idProfile();
+    try { if (campus && campus.setProfile) campus.setProfile(p); }
+    catch (e) { say('id card repaint threw: ' + ((e && e.message) || e)); }
+    try { if (idSpotlight) idSpotlight.setProfile(); } catch (e) { /* noop */ }
+    if (idChipWait) setIdChipState(idChipWait);
+  }
+
+  /** The chip's in-flight look, on whichever surfaces exist. */
+  function setIdChipState(state) {
+    try { if (campus && campus.setChipState) campus.setChipState(state); } catch (e) { /* noop */ }
+    try { if (idSpotlight) idSpotlight.setChipState(state); } catch (e) { /* noop */ }
+  }
+
+  function clearIdLinkTimer() {
+    if (!idLinkTimer) return;
+    try { clearTimeout(idLinkTimer); } catch (e) { /* noop */ }
+    idLinkTimer = 0;
+  }
+
+  /** PHOTO DAY, on whichever surface the player is actually looking at. */
+  function runIdPhotoDay() {
+    try {
+      if (idSpotlight && idSpotlight.isOpen()) idSpotlight.photoDay();
+      else if (campus && campus.photoDay) campus.photoDay();
+    } catch (e) { say('photo day threw: ' + ((e && e.message) || e)); }
+    /* EMI's beat. There is no `photoDay` row in emi/moments.js, so this asks
+     * her for the face directly - null-safe both ways (an unmounted or a
+     * dismissed mascot is a silent no-op, moments.js's own rule). */
+    try { const emi = getEmi(); if (emi && emi.emote) emi.emote('glee'); } catch (e) { /* noop */ }
+  }
+
+  /**
+   * THE CHIP'S ONE VERB, and the ONLY place either frame is posted.
+   *   not linked  -> ask the host to run the link-up, and say we are waiting.
+   *                  90 seconds later, with no answer at all, the chip goes
+   *                  back to its rung: an OAuth flow can be abandoned in a
+   *                  browser tab the page will never hear about again.
+   *   linked      -> move the `presenceShare` rung, and paint `pending` until
+   *                  the host's `setting` echo says what actually stuck.
+   * A second press while either is in flight is refused - one frame per state.
+   */
+  function onIdChip() {
+    if (idChipWait) return;
+    if (!profile.discordLinked) {
+      idChipWait = 'wait';
+      setIdChipState('wait');
+      try { bridge.send({ type: 'link-discord', thenShare: 'discord' }); }
+      catch (e) { say('link-discord send failed: ' + ((e && e.message) || e)); }
+      try {
+        idLinkTimer = setTimeout(() => {
+          idLinkTimer = 0;
+          if (idChipWait !== 'wait') return;
+          idChipWait = null;
+          paintIdProfile();
+          say('id chip: no profile frame in 90s - the chip goes back to its rung');
+        }, 90000);
+      } catch (e) { idLinkTimer = 0; }
+      return;
+    }
+    const next = profile.presenceShare === 'discord' ? 'username' : 'discord';
+    idChipWait = 'pending';
+    setIdChipState('pending');
+    try { bridge.send({ type: 'set-setting', key: SETTING_KEYS.presenceShare, value: next }); }
+    catch (e) { say('presenceShare send failed: ' + ((e && e.message) || e)); }
+  }
+
+  /**
+   * OPEN THE ID SPOTLIGHT. Minted on the first press and kept after that, the
+   * Records page's own shape. EMI is bracketed off while it is up and restored
+   * on EVERY path out through `onClose` - the annex bracket's discipline.
+   */
+  function showIdCard() {
+    if (!idSpotlight) {
+      try {
+        idSpotlight = createIdSpotlight({
+          t,
+          reducedMotion: () => reducedMotion || idReducedMotion(),
+          lite: !!src.performanceMode,
+          isMobile,
+          profile: idProfile,
+          stats: idStats,
+          onChip: onIdChip,
+          onRecords: () => showRecords(),
+          onClose: releaseIdCard,
+          onOpenCount: idOpenCount,
+          sfx: idSfx,
+          log: say,
+        });
+      } catch (e) {
+        say('the ID spotlight is unavailable (' + ((e && e.message) || e) + ')');
+        idSpotlight = null;
+        return;
+      }
+    }
+    let from = null;
+    try { from = campus && campus.idCardEl ? campus.idCardEl() : null; } catch (e) { from = null; }
+    try {
+      const emi = getEmi();
+      if (emi && emi.setEnabled) { idEmiPrev = !!emi.enabled; emi.setEnabled(false); }
+    } catch (e) { /* noop */ }
+    try { idSpotlight.open(from); } catch (e) {
+      say('the ID spotlight refused to open (' + ((e && e.message) || e) + ')');
+      releaseIdCard();
+      return;
+    }
+    if (idChipWait) setIdChipState(idChipWait);
+  }
+
+  /** The bracket's other half. Safe to call twice, and it only ever gives EMI
+   *  back the state she held BEFORE the card came up (a player who keeps her
+   *  off in settings never sees her flicker on). */
+  function releaseIdCard() {
+    if (!idEmiPrev) return;
+    idEmiPrev = false;
+    try { const emi = getEmi(); if (emi && emi.setEnabled) emi.setEnabled(true); } catch (e) { /* noop */ }
+  }
+
+  /** Put the card back, wherever the ask came from. True when one was up. */
+  function dismissIdCard(silent) {
+    if (!idSpotlight) return false;
+    let was = false;
+    try { was = !!idSpotlight.dismiss(silent); } catch (e) { was = false; }
+    releaseIdCard();
+    return was;
   }
 
   /* ============================ SCREEN: RECORDS =========================
@@ -3697,6 +4013,61 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       }
       if (settingsPage) { settingsPage.noteEcho(m.key, m.value); settingsPage.applyEcho(m.key, m.value); }
       if (m.key === SETTING_KEYS.keybinds) keybinds.applyEcho(m.value);
+      /* THE PHOTO CHIP IS THE `presenceShare` DISCORD RUNG (owner ruling 1), so
+       * the settings page and the student ID move together whichever one was
+       * pressed - and BOTH of them paint from this echo and never from a click
+       * (trap 1). The avatar shows only at `discord`, which is the whole
+       * consent matrix in one line. */
+      if (m.key === SETTING_KEYS.presenceShare) {
+        const before = profile.presenceShare;
+        profile.presenceShare = idRung(m.value, profile.presenceShare);
+        clearIdLinkTimer();
+        idChipWait = null;
+        paintIdProfile();
+        if (profile.presenceShare === 'discord' && before !== 'discord'
+          && profile.discordLinked && profile.avatarUrl) runIdPhotoDay();
+      }
+    },
+
+    /**
+     * {type:'profile'} - the host's word on who you are (STUDENT-ID contract).
+     * ADDITIVE: a host that predates it never sends one and the card keeps the
+     * stand-in portrait it was built with. This frame is the ONLY thing that
+     * moves the name, the photo or the linked flag - the page derives none of
+     * them, and no Discord id or CDN url is ever on it (PRESENCE.md §10).
+     *
+     * `result` is what the chip was waiting for:
+     *   'linked'    the link-up succeeded and the host applied the rung itself
+     *               (owner ruling 2 - one click was the consent). PHOTO DAY.
+     *   'failed'    one toast, and the chip goes back to the rung it was on.
+     *   'cancelled' the chip goes back, silently. Nothing was promised.
+     */
+    onProfile(m) {
+      const p = (m && m.profile && typeof m.profile === 'object') ? m.profile : null;
+      if (p) {
+        profile = {
+          name: (typeof p.name === 'string' && p.name) ? p.name : null,
+          avatarUrl: (typeof p.avatarUrl === 'string' && p.avatarUrl) ? p.avatarUrl : null,
+          discordLinked: !!p.discordLinked,
+          presenceShare: idRung(p.presenceShare, profile.presenceShare),
+        };
+      }
+      clearIdLinkTimer();
+      idChipWait = null;
+      paintIdProfile();
+      const result = m && typeof m.result === 'string' ? m.result : null;
+      if (result === 'linked') {
+        runIdPhotoDay();
+        /* ONE line, once per link. The beat is on the card; the toast is what
+         * says it happened when the card is only 236px of furniture. */
+        try { shout(t('id_photo_day', 'Photo day')); } catch (e) { /* noop */ }
+      }
+      else if (result === 'failed') {
+        try { shout(t('id_photo_failed', 'Discord did not pick up. Try again in a minute.')); }
+        catch (e) { /* a toast may never hold a door */ }
+      }
+      say('profile frame' + (result ? ' (' + result + ')' : '')
+        + ': ' + (profile.discordLinked ? 'linked' : 'not linked') + ', ' + profile.presenceShare);
     },
 
     /** {type:'payout-result'} - the ONLY source of an XP number on this page. */
@@ -3882,6 +4253,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         else showBoard();
         return true;
       }
+      // THE ID SPOTLIGHT is the same shape as the Records one and sits one rung
+      // ABOVE it: the card is a modal the player opened one press ago, and it
+      // is not tied to a screen (it lifts off the campus). Trap 48's shape -
+      // one rung, and everything below it is the ladder it always was.
+      if (dismissIdCard(false)) return true;
       // THE RECORDS SPOTLIGHT is a modal the player opened one press ago (a
       // card lifted off the wall) - Esc puts the card back first and the
       // office stays put. Trap 48's shape: one rung, above the screen's own.
@@ -3950,6 +4326,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       dismissEndCard();
       dismissPunchStage();
       dismissAnnexStage();
+      dismissIdCard(true);
+      clearIdLinkTimer();
+      idSpotlight = null;
       disarmPunch();
       teardownClass();
       /* the lab (and EMI's bracket) cannot outlive the shell */

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -54,6 +54,9 @@
   /* cinema black for the Annex reveal (shell/annexreveal.js) - a breath of
      navy so the cut reads as night, not as a dead renderer */
   --annex-void:#070710;
+  /* the student ID's chip LED on its unlinked rung - the ONE place a brand
+     colour appears in this school, and it is a 6px dot (shell/idcard.js) */
+  --discord:#5865F2;
 
   /* --- semantic --- */
   --gS:var(--gold); --gA:var(--pink); --gB:var(--lav); --gC:var(--slate);
@@ -1759,7 +1762,20 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   box-shadow:0 16px 44px rgba(0,0,0,.7), inset 0 1px 0 rgba(255,255,255,.08);
   padding:12px 14px; overflow:hidden; transition:transform .3s;
 }
-.campus-idcard:hover { transform:rotate(-1deg) translateY(-4px); }
+/* THE CARD IS A DOOR NOW: it lifts under the pointer AND under the keyboard,
+   and the press dips it. Same one transition, three states. */
+.campus-idcard { cursor:pointer; text-align:left; }
+.campus-idcard:hover,
+.campus-idcard:focus-visible {
+  transform:rotate(-1deg) translateY(-4px); outline:none;
+  box-shadow:0 22px 54px rgba(0,0,0,.75),
+    0 0 22px color-mix(in srgb, var(--pink), transparent 62%),
+    inset 0 1px 0 rgba(255,255,255,.1);
+}
+.campus-idcard:active { transform:rotate(-1deg) translateY(-2px) scale(.985); }
+/* ATTENDANCE HEAT: the hairline warms from lavender to gold as the streak
+   climbs past a week. A colour, not a bulb ring - and it survives motion 0. */
+.campus-idcard.is-warm { border-color:color-mix(in srgb, var(--gold), transparent 55%); }
 .campus-idcard::after {
   content:""; position:absolute; top:0; left:-70%; width:45%; height:100%;
   transform:skewX(-18deg);
@@ -1767,23 +1783,118 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   animation:campus-sheen 5.5s ease-in-out infinite;
 }
 @keyframes campus-sheen { 0%, 60% { left:-70%; } 90%, 100% { left:130%; } }
-.campus-idcard .id-top { display:flex; gap:12px; align-items:center; }
+/* the lanyard clip, the crest band and the foil edge: the three bits of
+   printing that make a laminated card read as one */
+.campus-idcard .id-clip {
+  position:absolute; top:-2px; left:50%; transform:translateX(-50%);
+  width:34px; height:9px; border-radius:0 0 6px 6px;
+  background:linear-gradient(180deg, #10101f, var(--panel2));
+  border:1px solid color-mix(in srgb, var(--lav), transparent 75%); border-top:0;
+}
+.campus-idcard .id-band {
+  display:flex; align-items:center; justify-content:space-between;
+  margin:2px 0 9px; padding-bottom:7px; border-bottom:var(--hairline);
+}
+.campus-idcard .id-crest {
+  display:flex; align-items:center; gap:6px;
+  font-family:var(--pix); font-size:7px; color:var(--pink); letter-spacing:.04em;
+}
+.campus-idcard .id-crestmark { width:13px; height:13px; flex:none; }
+.campus-idcard .id-kind {
+  font-family:var(--mono); font-size:8px; letter-spacing:.22em; color:var(--ink-faint);
+}
+.campus-idcard .id-foil {
+  position:absolute; left:0; right:0; bottom:0; height:4px; opacity:.8;
+  background:linear-gradient(90deg, var(--pink), var(--gold), var(--lav), var(--pink));
+}
+.campus-idcard .id-top { display:flex; gap:10px; align-items:flex-start; }
+.campus-idcard .id-well { width:58px; flex:none; }
+.campus-idcard > .id-chip { margin-top:9px; }
+.campus-idcard .id-meta { flex:1; min-width:0; }
+/* THE PHOTO WELL. One <img> - the host's baked avatar or the drawn stand-in
+   (shell/idcard.js's data URIs). ONE BREATH lives on the rim, pink once the
+   photo is real, lavender while it is a placeholder. */
 .campus-idcard .id-photo {
-  width:48px; height:56px; border-radius:7px; border:var(--hairline);
-  flex:none; position:relative;
-  background:radial-gradient(circle at 50% 34%, var(--panel2) 26%, var(--campus-furn) 70%);
+  width:58px; height:66px; border-radius:7px; border:var(--hairline);
+  position:relative; overflow:hidden; background:var(--flap-well);
+  animation:id-rim 3.6s ease-in-out infinite;
 }
-.campus-idcard .id-photo::before {
-  content:""; position:absolute; left:50%; top:12px; width:17px; height:17px;
-  border-radius:50%; transform:translateX(-50%);
-  background:color-mix(in srgb, var(--lav), transparent 60%);
+.campus-idcard .id-photo.is-real {
+  border-color:color-mix(in srgb, var(--pink), transparent 40%);
+  animation-name:id-rim-pink;
 }
-.campus-idcard .id-photo::after {
-  content:""; position:absolute; left:50%; bottom:5px; width:28px; height:17px;
-  border-radius:9px 9px 0 0; transform:translateX(-50%);
-  background:color-mix(in srgb, var(--lav), transparent 60%);
+@keyframes id-rim {
+  0%, 100% { box-shadow:0 0 0 0 color-mix(in srgb, var(--lav), transparent 60%); }
+  50% { box-shadow:0 0 12px 1px color-mix(in srgb, var(--lav), transparent 58%); }
 }
-.campus-idcard .id-name { font-family:var(--disp); font-size:14px; color:var(--ink); }
+@keyframes id-rim-pink {
+  0%, 100% { box-shadow:0 0 0 0 color-mix(in srgb, var(--pink), transparent 60%); }
+  50% { box-shadow:0 0 14px 1px color-mix(in srgb, var(--pink), transparent 52%); }
+}
+.id-photo-img {
+  position:absolute; inset:0; width:100%; height:100%; display:block;
+  object-fit:cover;
+}
+/* PHOTO DAY: the flash is the WELL's, never the screen's, and the photo
+   develops in from grey. Both classes come off the moment the beat is over. */
+.id-flash { position:absolute; inset:0; background:#fff; opacity:0; pointer-events:none; }
+.is-flashing > .id-flash,
+.is-flashing > .arc-id-flash { animation:id-flash .16s ease-out both; }
+@keyframes id-flash { 0% { opacity:.9; } 100% { opacity:0; } }
+.is-developing > .id-photo-img,
+.is-developing > .arc-id-photo-img { animation:id-develop .7s ease-out both; }
+@keyframes id-develop {
+  from { filter:grayscale(1) blur(4px) brightness(1.5); }
+  to { filter:none; }
+}
+/* THE CHIP. The photo consent, in one row: an LED, the Discord glyph on the
+   unlinked rung, and the words. It is a real <button> inside the card's own
+   role=button, so its click stops there (campus.js) and never opens the card. */
+.id-chip {
+  margin-top:6px; width:100%;
+  display:flex; align-items:center; gap:5px; white-space:nowrap;
+  background:var(--flap-well); border:var(--hairline); border-radius:6px;
+  padding:4px 5px;
+  font-family:var(--mono); font-size:7px; letter-spacing:.03em; line-height:1.2;
+  color:var(--ink-dim); text-align:left; cursor:pointer;
+  transition:transform .08s ease-out, border-color .18s, box-shadow .18s, opacity .18s;
+}
+.id-chip:hover {
+  border-color:color-mix(in srgb, var(--pink), transparent 50%);
+  box-shadow:0 0 12px color-mix(in srgb, var(--pink), transparent 70%);
+}
+.id-chip:focus-visible { outline:2px solid var(--lav); outline-offset:2px; }
+.id-chip:active { transform:scale(.96); }
+.id-chip[disabled] { cursor:default; opacity:.72; }
+.id-chip .id-chip-label { overflow:hidden; text-overflow:ellipsis; }
+.id-chip-led {
+  width:6px; height:6px; border-radius:50%; flex:none;
+  background:var(--slate); box-shadow:0 0 0 1px rgba(0,0,0,.4);
+}
+.id-chip.is-on .id-chip-led { background:var(--pink); box-shadow:0 0 6px var(--pink); }
+.id-chip.is-use .id-chip-led { background:var(--lav); box-shadow:0 0 5px var(--lav); }
+.id-chip.is-link .id-chip-led { background:var(--discord); box-shadow:0 0 6px var(--discord); }
+.id-chip.is-pending .id-chip-led { background:var(--gold); box-shadow:0 0 5px var(--gold); }
+.id-chip-glyph { width:9px; height:9px; flex:none; opacity:.85; color:var(--discord); }
+/* WAITING is the ONE optimistic paint, and it looks like waiting rather than
+   like a result (trap 1). Static equivalent: the LED simply sits amber. */
+.id-chip.is-wait .id-chip-led { background:var(--gold); animation:id-blink .7s steps(2) infinite; }
+@keyframes id-blink { to { opacity:.15; } }
+.id-chip.is-shiver { animation:id-shiver .25s ease-in-out; }
+@keyframes id-shiver {
+  0%, 100% { transform:translateX(0); }
+  20% { transform:translateX(-4px); }
+  40% { transform:translateX(4px); }
+  60% { transform:translateX(-3px); }
+  80% { transform:translateX(3px); }
+}
+.campus-idcard .id-name {
+  /* --body, not --disp: the display face small-caps a nickname (see the big
+     card's own note). A name is printed as it is typed. */
+  font-family:var(--body); font-weight:700; font-size:14px; color:var(--ink);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+.campus-idcard .id-num { font-family:var(--mono); font-size:8px; letter-spacing:.14em; color:var(--ink-dim); margin-top:3px; }
 .campus-idcard .id-no { font-family:var(--mono); font-size:9px; letter-spacing:.2em; color:var(--ink-faint); margin-top:3px; }
 .campus-idcard .id-tier {
   display:inline-block; margin-top:5px; font-family:var(--mono); font-size:8.5px;
@@ -1791,6 +1902,14 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
   border:1px solid color-mix(in srgb, var(--gold), transparent 60%);
   border-radius:4px; padding:2px 5px;
   background:color-mix(in srgb, var(--gold), transparent 93%);
+  transform:rotate(-3deg);
+}
+/* RE-INKED: the YEAR stamp lands again when the tier moves (campus.js update). */
+.campus-idcard .id-tier.is-thud { animation:id-thud .34s cubic-bezier(.2, 1.5, .4, 1) both; }
+@keyframes id-thud {
+  0% { transform:rotate(-3deg) scale(2.1); filter:brightness(2.2); }
+  55% { transform:rotate(-3deg) scale(.86); }
+  100% { transform:rotate(-3deg) scale(1); filter:none; }
 }
 .campus-idcard .id-stats { display:flex; gap:7px; margin-top:10px; }
 .campus-idcard .id-stat {
@@ -3576,6 +3695,366 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
 html.ae-lite .arc-rs-glint,
 html.ae-lite .arc-rs .arc-pc-text { animation:none; }
 html.ae-lite .arc-rs-name .arc-rs-l { animation-play-state:running, paused; }
+
+/* ---- THE ID SPOTLIGHT (shell/idcard.js createIdSpotlight) ---------------
+   The Records spotlight's twin, one door down: pick up the student ID leaning
+   in the corner of the campus and the school holds it to the desk lamp. Same
+   z 46 (under the annex reveal 48, under EMI 50, under the toasts 60), same
+   veil + key light + placard + one focusable close, same "records.js only
+   mounts nodes, every frame of motion lives here".
+   Choreography (delays from mount):
+     0ms   veil + lamp + the card sweeps in         400ms  the YEAR stamp lands
+     700ms the marquee glint crosses the name       750ms  six tiles, 90ms apart
+   LAWS KEPT: the foil DRIFTS and the laminate answers the mouse by TRANSFORM,
+   never background-position (trap 36); the name's glint is a translating strip
+   inside a clipping box for the same reason; every base state is VISIBLE, so
+   animation:none is a finished still, not a blank card.
+   Reduced motion (.arc-id-reduced, minted by idcard.js off html.arc-reduced OR
+   the media query) is ONE fade on the ROOT and animation:none on every single
+   thing inside it - the tiles arrive already carrying their numbers. */
+.arc-id {
+  position:fixed; inset:0; z-index:46;
+  display:flex; align-items:center; justify-content:center;
+}
+.arc-id-veil {
+  position:absolute; inset:0;
+  /* DEEPER THAN THE RECORDS ONE, on purpose: that spotlight covers a dark
+     panel, this one covers the LIT campus plan, and the same three stops read
+     as a filter over the school rather than as the school going dark. */
+  background:radial-gradient(ellipse at 50% 40%,
+    color-mix(in srgb, var(--navy), transparent 22%) 0%,
+    rgba(5, 6, 14, .93) 62%,
+    rgba(3, 4, 10, .97) 100%);
+  animation:arc-id-fade .28s ease-out both;
+}
+@keyframes arc-id-fade { from { opacity:0; } to { opacity:1; } }
+.arc-id.is-closing { pointer-events:none; }
+.arc-id.is-closing .arc-id-veil,
+.arc-id.is-closing .arc-id-stage,
+.arc-id.is-closing .arc-id-close { animation:arc-id-out .18s ease-in both; }
+@keyframes arc-id-out { to { opacity:0; } }
+
+.arc-id-stage {
+  position:relative;
+  display:flex; flex-direction:column; align-items:center; gap:16px;
+  max-width:96vw; padding:10px;
+}
+.arc-id-lamp {
+  position:absolute; left:50%; top:40%;
+  width:150%; aspect-ratio:1.35;
+  transform:translate(-50%, -52%);
+  pointer-events:none;
+  background:radial-gradient(ellipse at 50% 46%,
+    color-mix(in srgb, var(--gold), transparent 82%) 0%,
+    color-mix(in srgb, var(--lav), transparent 90%) 44%,
+    transparent 70%);
+  animation:arc-id-fade .6s ease-out both,
+            arc-id-lamp-breathe 7s 1.5s ease-in-out infinite alternate;
+}
+@keyframes arc-id-lamp-breathe { from { opacity:1; } to { opacity:.72; } }
+.arc-id-row {
+  display:flex; gap:24px; align-items:stretch; flex-wrap:wrap; justify-content:center;
+}
+
+/* THE CARD, big. The wrapper owns the perspective and the entrance; the card
+   itself owns only the tilt and the flip, so the two never fight over one
+   transform (the arc-rs-card lesson). */
+.arc-id-cardwrap {
+  perspective:1100px;
+  animation:arc-id-cardin .55s cubic-bezier(.18, 1.2, .3, 1) both;
+}
+@keyframes arc-id-cardin {
+  from { opacity:0; transform:translateY(9vh) scale(.55) rotate(-4deg); }
+  70%  { opacity:1; transform:translateY(-.6vh) scale(1.015) rotate(.5deg); }
+  to   { opacity:1; transform:none; }
+}
+.arc-id-big {
+  --rx:0deg; --ry:0deg; --mx:50%; --my:50%;
+  position:relative; width:min(560px, 92vw); aspect-ratio:1.62;
+  border-radius:16px; cursor:pointer;
+  transform-style:preserve-3d;
+  transform:rotateX(var(--rx)) rotateY(var(--ry));
+  transition:transform .12s ease-out;
+}
+.arc-id-big.is-flipping { transition:transform .6s cubic-bezier(.2, 1.2, .35, 1); }
+.arc-id-big.is-back { transform:rotateY(180deg); }
+.arc-id-face {
+  position:absolute; inset:0; border-radius:16px; overflow:hidden;
+  backface-visibility:hidden;
+  background:linear-gradient(160deg, #2b2b52 0%, var(--panel) 40%, #171730 100%);
+  border:1px solid color-mix(in srgb, var(--lav), transparent 72%);
+  box-shadow:0 34px 84px rgba(0,0,0,.72),
+    0 0 46px color-mix(in srgb, var(--lav), transparent 78%),
+    inset 0 1px 0 rgba(255,255,255,.08);
+}
+.arc-id-face.is-back { transform:rotateY(180deg); }
+/* THE LAMINATE. A specular that follows the pointer by TRANSFORM off the two
+   custom properties the tilt handler writes - plain alpha, no blend surface
+   (trap 36's first third: a blend must read back what is under it). */
+.arc-id-lam {
+  position:absolute; inset:-60%; pointer-events:none; opacity:.5;
+  background:radial-gradient(circle at 50% 50%,
+    rgba(255,255,255,.22) 0%, rgba(255,255,255,.05) 22%, transparent 45%);
+  transform:translate(calc((var(--mx, 50%) - 50%) * .8), calc((var(--my, 50%) - 50%) * .8));
+}
+/* THE HOLO FOIL. The rainbow DRIFTS on the `translate` property and SHIFTS with
+   the tilt on `transform` - two independent transforms, one layer, and not a
+   pixel of background-position anywhere. */
+.arc-id-foil {
+  position:absolute; left:0; right:0; bottom:0; height:13%;
+  overflow:hidden; border-top:1px solid rgba(255,255,255,.12);
+}
+.arc-id-rainbow {
+  position:absolute; top:0; bottom:0; left:-50%; width:200%; display:block;
+  opacity:.85;
+  background:linear-gradient(100deg, var(--pink) 0%, var(--gold) 18%, #7ee0d6 36%,
+    var(--lav) 52%, var(--pink) 70%, var(--gold) 88%, var(--lav) 100%);
+  transform:translateX(calc((var(--mx, 50%) - 50%) * -.12));
+  animation:arc-id-foildrift 14s ease-in-out infinite alternate;
+}
+@keyframes arc-id-foildrift { from { translate:-4% 0; } to { translate:4% 0; } }
+.arc-id-grid {
+  position:absolute; inset:0; display:block; opacity:.5;
+  background:repeating-linear-gradient(90deg, transparent 0 6px, rgba(0,0,0,.35) 6px 7px),
+             repeating-linear-gradient(0deg, transparent 0 3px, rgba(0,0,0,.25) 3px 4px);
+}
+.arc-id-foilmark {
+  position:absolute; left:18px; top:50%; transform:translateY(-50%);
+  font-family:var(--pix); font-size:7.5px; letter-spacing:.08em; color:rgba(20,20,40,.9);
+}
+.arc-id-foilno {
+  position:absolute; right:18px; top:50%; transform:translateY(-50%);
+  font-family:var(--mono); font-size:9px; letter-spacing:.2em; color:rgba(20,20,40,.85);
+}
+.arc-id-band {
+  position:absolute; left:0; right:0; top:0; height:15%;
+  display:flex; align-items:center; justify-content:space-between; padding:0 22px;
+  background:linear-gradient(90deg, var(--pink-deep), var(--pink) 60%, var(--pink-deep));
+  color:#1a1030;
+}
+.arc-id-crest { display:flex; align-items:center; gap:9px; font-family:var(--pix); font-size:10px; letter-spacing:.05em; }
+.arc-id-crestmark { width:19px; height:19px; flex:none; }
+.arc-id-kind { font-family:var(--mono); font-size:10px; letter-spacing:.28em; font-weight:600; }
+
+.arc-id-body { position:absolute; left:22px; right:22px; top:19%; bottom:16%; display:flex; gap:22px; }
+.arc-id-body.is-back { flex-direction:column; gap:10px; top:17%; }
+.arc-id-well { width:31%; flex:none; display:flex; flex-direction:column; }
+/* ONE BREATH, and it is the photo rim - pink once the photo is real. */
+.arc-id-photo {
+  width:100%; aspect-ratio:56/66; border-radius:10px; position:relative; overflow:hidden;
+  border:2px solid color-mix(in srgb, var(--lav), transparent 65%);
+  background:var(--flap-well);
+  animation:arc-id-rim 3.6s ease-in-out infinite;
+}
+.arc-id-photo.is-real {
+  border-color:color-mix(in srgb, var(--pink), transparent 30%);
+  animation-name:arc-id-rim-pink;
+}
+@keyframes arc-id-rim {
+  0%, 100% { box-shadow:0 0 0 0 color-mix(in srgb, var(--lav), transparent 60%); }
+  50% { box-shadow:0 0 18px 2px color-mix(in srgb, var(--lav), transparent 55%); }
+}
+@keyframes arc-id-rim-pink {
+  0%, 100% { box-shadow:0 0 0 0 color-mix(in srgb, var(--pink), transparent 60%); }
+  50% { box-shadow:0 0 22px 2px color-mix(in srgb, var(--pink), transparent 50%); }
+}
+.arc-id-photo-img { position:absolute; inset:0; width:100%; height:100%; display:block; object-fit:cover; }
+.arc-id-flash { position:absolute; inset:0; background:#fff; opacity:0; pointer-events:none; }
+/* the chip, at reading size (the shared rungs live with .id-chip above) */
+.arc-id-chip { margin-top:9px; font-size:9.5px; gap:7px; padding:7px 8px; border-radius:7px; white-space:normal; }
+.arc-id-chip .id-chip-led { width:8px; height:8px; }
+.arc-id-chip .id-chip-glyph { width:12px; height:12px; }
+.arc-id-hint {
+  margin-top:6px; font-family:var(--mono); font-size:8.5px; line-height:1.45;
+  letter-spacing:.02em; color:var(--ink-faint);
+}
+.arc-id-meta { flex:1; min-width:0; position:relative; }
+/* THE MARQUEE. A glint strip travelling across the name inside its own
+   clipping box - a transform, never an animated background-position. */
+.arc-id-name {
+  position:relative; display:inline-block; overflow:hidden;
+  margin:2px 0 0; max-width:100%;
+  /* --body, NOT --disp: the display face falls through to Copperplate Gothic
+     on most Windows boxes and small-caps everything it is handed. A nickname's
+     casing is the nickname, so the one place the player's own name is printed
+     large gets the plain stack. */
+  font-family:var(--body); font-weight:800;
+  font-size:clamp(19px, 3.3vw, 30px); line-height:1.08; letter-spacing:.02em;
+  color:var(--ink);
+}
+.arc-id-glint {
+  position:absolute; top:-40%; bottom:-40%; left:0; width:38%; display:block;
+  pointer-events:none;
+  background:linear-gradient(100deg, transparent 0%, rgba(255,255,255,.5) 46%,
+    rgba(255,255,255,.08) 60%, transparent 100%);
+  transform:translateX(-190%) rotate(8deg);
+  animation:arc-id-glint 6s .7s ease-in-out infinite;
+}
+@keyframes arc-id-glint {
+  0%   { transform:translateX(-190%) rotate(8deg); }
+  16%  { transform:translateX(400%) rotate(8deg); }
+  100% { transform:translateX(400%) rotate(8deg); }
+}
+.arc-id-num { font-family:var(--mono); font-size:11px; letter-spacing:.2em; color:var(--ink-faint); margin-top:6px; }
+.arc-id-num .arc-id-numval { font-style:normal; color:var(--ink-dim); margin-left:6px; }
+.arc-id-num .arc-id-numtemp {
+  font-style:normal; font-size:8px; letter-spacing:.18em; margin-left:6px;
+  color:var(--gold); border:1px solid color-mix(in srgb, var(--gold), transparent 60%);
+  border-radius:3px; padding:0 4px;
+}
+.arc-id-rows {
+  margin:12px 0 0; display:grid; grid-template-columns:auto 1fr; gap:5px 14px;
+  font-family:var(--mono); font-size:10px; letter-spacing:.12em;
+}
+.arc-id-rows dt { color:var(--ink-faint); margin:0; }
+.arc-id-rows dd { color:var(--ink-dim); margin:0; }
+/* THE YEAR STAMP. It lands 400ms in with the punch card's own thud. */
+.arc-id-yearstamp {
+  position:absolute; right:-4px; bottom:2px;
+  font-family:var(--mono); font-size:13px; letter-spacing:.18em; color:var(--gold);
+  border:2px solid color-mix(in srgb, var(--gold), transparent 45%); border-radius:6px;
+  padding:6px 12px; transform:rotate(-7deg);
+  background:color-mix(in srgb, var(--gold), transparent 92%);
+  animation:arc-id-bigthud .34s .4s cubic-bezier(.2, 1.5, .4, 1) both;
+}
+.arc-id-yearstamp.is-thud { animation:arc-id-bigthud .34s cubic-bezier(.2, 1.5, .4, 1) both; }
+.arc-id-yearstamp small {
+  display:block; font-size:7.5px; letter-spacing:.28em; margin-top:2px;
+  color:color-mix(in srgb, var(--gold), transparent 30%);
+}
+@keyframes arc-id-bigthud {
+  0%   { opacity:0; transform:rotate(-7deg) scale(2.1); filter:brightness(2.2); }
+  30%  { opacity:1; }
+  55%  { opacity:1; transform:rotate(-7deg) scale(.86); }
+  100% { opacity:1; transform:rotate(-7deg) scale(1); filter:none; }
+}
+/* THE BACK: the barcode, the small print, the punch line and the signature. */
+.arc-id-barcode {
+  height:40px; width:70%; display:flex; align-items:stretch;
+  background:var(--ink); padding:4px 8px; border-radius:4px;
+}
+.arc-id-barcode i { display:block; background:#12122a; }
+.arc-id-barcodeno { font-family:var(--mono); font-size:9px; letter-spacing:.4em; color:var(--ink-dim); margin-top:4px; }
+.arc-id-small { margin:0; font-family:var(--mono); font-size:9.5px; line-height:1.55; color:var(--ink-dim); max-width:88%; }
+.arc-id-small b { color:var(--ink); font-weight:600; }
+.arc-id-punchline { font-family:var(--mono); font-size:9.5px; letter-spacing:.06em; color:var(--ink-faint); }
+.arc-id-recordslink {
+  align-self:flex-start; background:transparent; cursor:pointer;
+  border:1px solid color-mix(in srgb, var(--lav), transparent 60%); border-radius:6px;
+  padding:5px 9px;
+  font-family:var(--mono); font-size:9px; letter-spacing:.16em; color:var(--lav);
+  transition:transform .08s, box-shadow .18s;
+}
+.arc-id-recordslink:hover { box-shadow:0 0 14px color-mix(in srgb, var(--lav), transparent 60%); }
+.arc-id-recordslink:focus-visible { outline:2px solid var(--lav); outline-offset:2px; }
+.arc-id-recordslink:active { transform:scale(.96); }
+.arc-id-sig { margin-top:auto; display:flex; align-items:flex-end; gap:14px; }
+.arc-id-sigline { flex:1; border-bottom:1px solid var(--ink-faint); position:relative; height:28px; }
+.arc-id-sigline span {
+  position:absolute; left:8px; bottom:2px; transform:rotate(-2deg);
+  font-family:var(--body); font-style:italic; font-size:18px; color:var(--lav);
+}
+
+/* THE STAT SHEET. Six tiles, landing 90ms apart on a chime ladder. Base state
+   is the FINISHED tile, so animation:none is a full sheet. */
+.arc-id-sheet {
+  display:grid; grid-template-columns:repeat(2, 150px); gap:10px; align-content:start;
+  animation:arc-id-sheetin .4s .45s ease-out both;
+}
+@keyframes arc-id-sheetin {
+  from { opacity:0; transform:translateY(10px); }
+  to { opacity:1; transform:none; }
+}
+.arc-id-tile {
+  position:relative; padding:12px 12px 10px; border-radius:10px;
+  background:linear-gradient(160deg, var(--panel), var(--navy));
+  border:var(--hairline);
+  animation:arc-id-tilein .34s cubic-bezier(.2, 1.5, .4, 1) both;
+  animation-delay:calc(.75s + var(--i, 0) * 90ms);
+}
+@keyframes arc-id-tilein {
+  from { opacity:0; transform:translateY(8px) scale(.94); }
+  to { opacity:1; transform:none; }
+}
+.arc-id-tile > b {
+  display:block; font-family:var(--mono); font-size:24px; font-weight:600;
+  line-height:1; color:var(--pink); font-variant-numeric:tabular-nums;
+}
+.arc-id-tile.is-gold > b { color:var(--gold); }
+.arc-id-tile.is-lav > b { color:var(--lav); }
+.arc-id-tile.is-text > b { font-size:15px; color:var(--ink); letter-spacing:.06em; white-space:nowrap; }
+.arc-id-tile.is-text > b i { font-style:normal; font-size:10px; color:var(--ink-faint); letter-spacing:.14em; margin-left:6px; }
+.arc-id-tile > span {
+  display:block; margin-top:6px;
+  font-family:var(--mono); font-size:8px; letter-spacing:.18em; color:var(--ink-faint);
+}
+/* ALMOST: the honest distance to the next milestone, ghosted. Text, so motion
+   level 0 loses nothing at all. */
+.arc-id-almost {
+  position:absolute; right:10px; top:10px; text-align:right; line-height:1.3;
+  font-family:var(--mono); font-size:8px; letter-spacing:.12em;
+  color:color-mix(in srgb, var(--gold), transparent 30%);
+}
+.arc-id-almost b { display:block; font-size:8px; color:inherit; opacity:.6; }
+
+.arc-id-placard { text-align:center; animation:arc-id-sheetin .4s .55s ease-out both; }
+.arc-id-placard h2 {
+  margin:0; font-family:var(--disp); font-weight:800;
+  font-size:clamp(16px, 2.6vw, 22px); letter-spacing:.2em; text-transform:uppercase;
+  color:var(--ink); text-shadow:0 2px 10px rgba(0,0,0,.6);
+}
+.arc-id-placard p {
+  margin:5px 0 0; font-family:var(--mono); font-size:10px; letter-spacing:.16em;
+  color:var(--ink-faint);
+}
+.arc-id-close {
+  position:absolute; top:clamp(10px, 3vh, 26px); right:clamp(12px, 3vw, 30px);
+  width:44px; height:44px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:17px; line-height:1; color:var(--ink-dim); cursor:pointer;
+  background:color-mix(in srgb, var(--navy), transparent 28%);
+  border:var(--hairline); border-radius:999px;
+  transition:color .15s, border-color .15s, transform .15s;
+  animation:arc-id-fade .3s .25s ease-out both;
+}
+.arc-id-close:hover { color:var(--ink); border-color:var(--lav); transform:scale(1.06); }
+.arc-id-close:focus-visible { outline:2px solid var(--lav); outline-offset:2px; }
+
+/* REDUCED MOTION. The ONE fade lives on the ROOT (`.arc-id` itself), and every
+   single thing INSIDE it is animation:none - which is the assertion the rig
+   makes and the reason the fade is not on the veil. The card still flips, the
+   chip still works, and the tiles carry their numbers from the first frame
+   (idcard.js fills them at mount). */
+.arc-id.arc-id-reduced { opacity:1; animation:arc-id-fade .12s ease-out both; }
+.arc-id-reduced *, .arc-id-reduced *::before, .arc-id-reduced *::after { animation:none !important; }
+.arc-id-reduced .arc-id-big { transition:none; }
+.arc-id-reduced .arc-id-lam { display:none; }
+.arc-id-reduced .arc-id-photo { box-shadow:0 0 14px 1px color-mix(in srgb, var(--lav), transparent 60%); }
+.arc-id-reduced .arc-id-photo.is-real { box-shadow:0 0 14px 1px color-mix(in srgb, var(--pink), transparent 55%); }
+.arc-id-reduced .arc-id-glint { display:none; }
+.arc-id-reduced.is-closing { animation:arc-id-out .12s ease-in both; }
+/* A LIT-DOWN ROOM keeps the entrance and sheds the loops: the lamp's breath,
+   the foil drift, the photo rim and the roaming glint are the per-frame cost
+   and none of them is the beat. Both seams say the same thing - the engine's
+   own html.ae-lite and idcard.js's `lite` (init.performanceMode). */
+html.ae-lite .arc-id-lamp,
+.arc-id.is-lite .arc-id-lamp { animation:arc-id-fade .6s ease-out both; }
+html.ae-lite .arc-id-rainbow,
+html.ae-lite .arc-id-photo,
+html.ae-lite .arc-id-glint,
+.arc-id.is-lite .arc-id-rainbow,
+.arc-id.is-lite .arc-id-photo,
+.arc-id.is-lite .arc-id-glint { animation:none; }
+/* A PHONE STACKS. The card over the sheet, the sheet two columns of whatever
+   is left, and the chip at a thumb's size (owner bug C's rule). */
+html.arc-mobile .arc-id-row { flex-direction:column; gap:14px; align-items:center; }
+html.arc-mobile .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:min(560px, 92vw); }
+html.arc-mobile .arc-id-chip { min-height:44px; font-size:11px; }
+html.arc-mobile .arc-id-stage { gap:12px; }
+@media (max-width:820px) {
+  .arc-id-row { flex-direction:column; align-items:center; }
+  .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:min(560px, 92vw); }
+}
 
 /* ---- THE WALL WHISPER --------------------------------------------------
    A breath of each class's spotlight identity on the pinned cards - but the

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyAvatarCache.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyAvatarCache.cs
@@ -1,0 +1,279 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace ConditioningControlPanel.Services.Arcademy;
+
+/// <summary>
+/// THE STUDENT ID PHOTO, on disk. One file and one sidecar, both fixed names:
+/// <c>%LOCALAPPDATA%/ConditioningControlPanel/arcademy/avatar.png</c> plus
+/// <c>avatar.hash</c>, which records the Discord avatar hash those bytes were fetched for.
+///
+/// <para>THE SNOWFLAKE RULE (STUDENT ID contract, "Snowflake rule"). The Discord CDN url and the
+/// Discord user id NEVER reach the page: the CDN url embeds the snowflake, so this class is the
+/// only thing that ever sees it, and what crosses the bridge is a <c>data:image/png;base64,...</c>
+/// string of at most <see cref="MaxDataUriChars"/> characters. Nothing here is ever logged with a
+/// url in it, for the same reason <c>GoonAvatarCache</c> refuses to.</para>
+///
+/// <para>SELF-HEALING BY CONSTRUCTION, and the prior art next door is deliberate
+/// (<see cref="GoonGame.GoonAvatarCache"/>): every read is a try/catch that returns null, every
+/// write is a try/catch that returns false, and a truncated or corrupt file simply fails its next
+/// read and is re-fetched. A dead cache costs the card a picture - never a boot, never a class.</para>
+///
+/// <para>OFFLINE MODE NEVER LEAVES THE MACHINE. <see cref="EnsureCachedAsync"/> short-circuits with
+/// no request at all when <c>OfflineMode</c> is set; the file already on disk stays readable, so an
+/// offline player keeps the photo they last had.</para>
+/// </summary>
+internal static class ArcademyAvatarCache
+{
+    /// <summary>Fixed names. No page string, no server string and no hash ever reaches
+    /// <c>Path.Combine</c> here, so traversal is not a thing that can be attempted.</summary>
+    private const string AvatarFile = "avatar.png";
+    private const string HashFile = "avatar.hash";
+
+    /// <summary>The contract's ceiling for the data URI that rides the bridge (24 KB). It is a cap
+    /// on the STRING, not on the file, because the string is what the page is promised.</summary>
+    public const int MaxDataUriChars = 24 * 1024;
+
+    /// <summary>The prefix costs 22 of those characters and base64 costs 4 per 3 bytes, so this is
+    /// the largest PNG whose data URI still fits under the cap.</summary>
+    private static readonly int MaxPngBytes = (MaxDataUriChars - DataUriPrefix.Length) / 4 * 3;
+
+    private const string DataUriPrefix = "data:image/png;base64,";
+
+    /// <summary>What the CDN is allowed to hand back before we stop reading. An avatar is tens of
+    /// KB; anything past this is not the picture we asked for.</summary>
+    private const int MaxFetchBytes = 512 * 1024;
+
+    /// <summary>The two decode widths, in order. 128 is the card's photo well at 2x; 96 is the one
+    /// retry for an avatar whose 128px PNG will not fit the 24 KB cap (a busy animated frame). A
+    /// third rung would be a smaller picture than the well deserves, so there is not one.</summary>
+    private static readonly int[] DecodeWidths = { 128, 96 };
+
+    /// <summary>An avatar may never be on the critical path of anything (the Goon cache's rule,
+    /// with a little more room because this one runs off a window-open, not off a match).</summary>
+    private static readonly HttpClient Http = BuildHttpClient();
+
+    private static HttpClient BuildHttpClient()
+    {
+        var c = new HttpClient { Timeout = TimeSpan.FromSeconds(6) };
+        try { c.DefaultRequestHeaders.UserAgent.ParseAdd($"ConditioningControlPanel/{UpdateService.AppVersion}"); }
+        catch { /* a header we could not set is not worth failing a static ctor over */ }
+        return c;
+    }
+
+    /// <summary>Serialises the fetch: the window-open kick and a link that just completed can both
+    /// arrive at once, and two writers on one file is the only way this cache corrupts itself.</summary>
+    private static readonly SemaphoreSlim FetchGate = new(1, 1);
+
+    public static string Dir => Path.Combine(App.UserDataPath, "arcademy");
+
+    private static string? PathFor(string bare)
+    {
+        try
+        {
+            var dir = Dir;
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, bare);
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyAvatarCache.PathFor({F}): {E}", bare, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The avatar hash these bytes belong to, tagged with WHICH hash it is: the per-guild avatar
+    /// and the global one are different pictures under the same account, and
+    /// <c>DiscordService.GetAvatarUrl</c> prefers the guild one. Without the tag, a player who
+    /// leaves the server keeps a stale server picture forever.
+    /// </summary>
+    private static string? CurrentTag()
+    {
+        var d = App.Discord;
+        if (d == null || !d.IsAuthenticated) return null;
+        if (!string.IsNullOrEmpty(d.GuildAvatar)) return "g:" + d.GuildAvatar;
+        if (!string.IsNullOrEmpty(d.Avatar)) return "u:" + d.Avatar;
+        return null;   // a default avatar is not a picture we can fetch
+    }
+
+    private static string? ReadTag()
+    {
+        try
+        {
+            var p = PathFor(HashFile);
+            if (p == null || !File.Exists(p)) return null;
+            var tag = File.ReadAllText(p).Trim();
+            return tag.Length == 0 || tag.Length > 128 ? null : tag;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// The cached photo as a data URI, WITHOUT touching the network - this is what
+    /// <c>init</c> can afford to read synchronously.
+    ///
+    /// <para>It deliberately does NOT check the hash. A stale-but-real picture beats a blank well
+    /// while the refresh is in the air (and offline, the stale one is all there will ever be); the
+    /// sidecar's only job is deciding whether <see cref="EnsureCachedAsync"/> owes a fetch.</para>
+    /// </summary>
+    public static string? ReadDataUri()
+    {
+        try
+        {
+            var p = PathFor(AvatarFile);
+            if (p == null || !File.Exists(p)) return null;
+            var fi = new FileInfo(p);
+            if (fi.Length == 0 || fi.Length > MaxPngBytes) return null;
+            var bytes = File.ReadAllBytes(p);
+            if (!IsPng(bytes)) return null;
+            var uri = DataUriPrefix + Convert.ToBase64String(bytes);
+            return uri.Length > MaxDataUriChars ? null : uri;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyAvatarCache.ReadDataUri: {E}", ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetch the player's Discord avatar when the cache is missing or belongs to a different hash,
+    /// re-encode it to a small PNG and store it atomically. Returns <c>true</c> only when the bytes
+    /// on disk CHANGED, which is the caller's cue to push a <c>profile</c> frame.
+    ///
+    /// <para>Never throws and never blocks a UI thread: the decode and the encode run on whatever
+    /// thread the continuation lands on, against a frozen <see cref="BitmapImage"/>.</para>
+    /// </summary>
+    public static async Task<bool> EnsureCachedAsync()
+    {
+        try
+        {
+            var d = App.Discord;
+            if (d == null || !d.IsAuthenticated) return false;
+            var tag = CurrentTag();
+            if (tag == null) return false;                       // default avatar: nothing to fetch
+            var file = PathFor(AvatarFile);
+            if (file == null) return false;
+            if (File.Exists(file) && string.Equals(ReadTag(), tag, StringComparison.Ordinal)) return false;
+
+            // OFFLINE MODE: no request at all. The file already on disk stays usable.
+            if (App.Settings?.Current?.OfflineMode == true)
+            {
+                App.Logger?.Debug("ArcademyAvatarCache: refresh declined - offline mode");
+                return false;
+            }
+
+            var url = d.GetAvatarUrl(128);
+            if (string.IsNullOrEmpty(url)) return false;
+            // An animated avatar comes back as .gif; the card wants the still, and the contract's
+            // data URI is specified as image/png either way.
+            url = url!.Replace(".gif?", ".png?");
+
+            if (!await FetchGate.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false)) return false;
+            try
+            {
+                // Re-check under the gate: the other caller may have just fetched this exact hash.
+                if (File.Exists(file) && string.Equals(ReadTag(), tag, StringComparison.Ordinal)) return false;
+
+                byte[] raw;
+                using (var resp = await Http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead,
+                           CancellationToken.None).ConfigureAwait(false))
+                {
+                    if (!resp.IsSuccessStatusCode) return false;
+                    var ctype = resp.Content.Headers.ContentType?.MediaType ?? "";
+                    if (!ctype.StartsWith("image/", StringComparison.OrdinalIgnoreCase)) return false;
+                    var len = resp.Content.Headers.ContentLength;
+                    if (len.HasValue && len.Value > MaxFetchBytes) return false;
+                    raw = await resp.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                }
+                if (raw.Length == 0 || raw.Length > MaxFetchBytes) return false;
+
+                var png = Encode(raw);
+                if (png == null)
+                {
+                    App.Logger?.Debug("ArcademyAvatarCache: avatar would not fit {Cap} chars - no photo",
+                        MaxDataUriChars);
+                    return false;
+                }
+
+                if (!WriteAtomic(file, png)) return false;
+                try
+                {
+                    var hp = PathFor(HashFile);
+                    if (hp != null) WriteAtomic(hp, System.Text.Encoding.UTF8.GetBytes(tag));
+                }
+                catch { /* a missing sidecar only costs the next open a re-fetch */ }
+
+                App.Logger?.Information("ArcademyAvatarCache: student photo cached ({N} bytes)", png.Length);
+                return true;
+            }
+            finally { FetchGate.Release(); }
+        }
+        catch (Exception ex)
+        {
+            // NEVER the url: a Discord CDN avatar url carries the snowflake.
+            App.Logger?.Debug("ArcademyAvatarCache.EnsureCachedAsync failed: {E}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>Decode whatever the CDN sent and re-encode it as a PNG small enough for the cap,
+    /// trying <see cref="DecodeWidths"/> in order. Null when even the smallest will not fit.</summary>
+    private static byte[]? Encode(byte[] raw)
+    {
+        foreach (var width in DecodeWidths)
+        {
+            try
+            {
+                var bmp = new BitmapImage();
+                bmp.BeginInit();
+                bmp.CacheOption = BitmapCacheOption.OnLoad;      // the stream may close right after
+                bmp.CreateOptions = BitmapCreateOptions.PreservePixelFormat;
+                bmp.DecodePixelWidth = width;                    // the decoder does the resize
+                bmp.StreamSource = new MemoryStream(raw, writable: false);
+                bmp.EndInit();
+                bmp.Freeze();                                    // usable off the UI thread
+
+                var enc = new PngBitmapEncoder();
+                enc.Frames.Add(BitmapFrame.Create(bmp));
+                using var ms = new MemoryStream();
+                enc.Save(ms);
+                var bytes = ms.ToArray();
+                if (bytes.Length > 0 && bytes.Length <= MaxPngBytes) return bytes;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("ArcademyAvatarCache.Encode({W}): {E}", width, ex.Message);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Temp file then <c>File.Move(overwrite)</c>: a half-written avatar.png read by the
+    /// next <c>init</c> is exactly the corruption the self-healing read would have to eat.</summary>
+    private static bool WriteAtomic(string path, byte[] bytes)
+    {
+        var tmp = path + ".tmp";
+        try
+        {
+            File.WriteAllBytes(tmp, bytes);
+            File.Move(tmp, path, overwrite: true);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyAvatarCache.WriteAtomic: {E}", ex.Message);
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { }
+            return false;
+        }
+    }
+
+    /// <summary>The bytes decide what they are, never the label they arrived with.</summary>
+    private static bool IsPng(byte[] b) =>
+        b.Length >= 8 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47;
+}

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -397,6 +397,9 @@ internal static class ArcademyHostService
         }
 
         _panicSuspended = true;
+        // An open Discord link-up is part of what the emergency stop stops: the browser is sitting
+        // on a page this window asked for, and the chip must not be left saying "Waiting...".
+        CancelPendingLink("panic", tellPage: true);
         App.Logger?.Information("ArcademyHost: panic press 1 - suspending{Mid} (press again to leave)",
             _classActive ? " mid-class" : "");
         Suspend(true, "panic");
@@ -462,6 +465,10 @@ internal static class ArcademyHostService
             _host?.Post(BuildInit());
             if (_host != null) _host.Post(new { type = "fullscreen", on = _host.IsFullscreen });
             SeedNativeState();
+            // THE STUDENT ID PHOTO. `init` carried whatever was already on disk; this asks the CDN
+            // whether that is still the player's avatar. Fire-and-forget, never awaited, and it
+            // pushes its own `profile` frame only if the bytes actually changed.
+            KickAvatarRefresh();
             App.Logger?.Information("ArcademyHostService: sent init (protocol {P})", Protocol);
         }
         catch (Exception ex) { App.Logger?.Warning("ArcademyHostService.OnPageReady: {E}", ex.Message); }
@@ -561,6 +568,12 @@ internal static class ArcademyHostService
                 break;
             case "library-remove":
                 OnLibraryRemove(o);
+                break;
+            case "link-discord":
+                // THE STUDENT ID's photo chip, in its "Link Discord" state. Posted ONLY when
+                // discordLinked is false - a linked account moves the rung with an ordinary
+                // set-setting instead (contract trap 1).
+                OnLinkDiscord();
                 break;
             case "annex-stats":
                 // The registry link downstairs. Fire-and-forget: exactly one reply comes back,
@@ -690,7 +703,56 @@ internal static class ArcademyHostService
             // THE SUBJECT FILE (ANNEX-OS.md): the numbers the annex terminal prints about
             // this player, resolved here so the page downstairs counts nothing itself.
             subject = BuildSubject(s),
+            // THE STUDENT ID (STUDENT ID contract, "Wire contract"). Who the card is made out to,
+            // whether there is a photo on it, and the one consent rung that governs both.
+            profile = BuildProfile(s),
         };
+    }
+
+    /// <summary>
+    /// THE STUDENT ID's identity block. Four fields, and the whole body is wrapped for the same
+    /// reason <see cref="BuildSubject"/> is: a throw here would kill <c>init</c>, and a page that
+    /// never gets <c>init</c> never boots. A failure costs the card its name and its photo, never
+    /// the Arcademy.
+    ///
+    /// <para>THE NAME IS THE CCP NICKNAME, never the Discord handle (owner ruling 5).
+    /// <see cref="App.UserDisplayName"/> already resolves the offline username, the unified display
+    /// name and the provider names in the app's own order; blank reads as null and the page draws
+    /// its own "Student".</para>
+    ///
+    /// <para>THE PHOTO IS THE <c>discord</c> RUNG (owner ruling 1). One switch: the picture on the
+    /// card is the picture the campus ghost wears, so <c>avatarUrl</c> is non-null only at that rung
+    /// AND with Discord actually linked AND with bytes already cached. Anything less is null and the
+    /// page draws its PHOTO PENDING plate. The cache is read here synchronously and never fetches -
+    /// the fetch is <see cref="KickAvatarRefresh"/>, and when it lands it pushes a <c>profile</c>
+    /// frame of its own.</para>
+    /// </summary>
+    private static object BuildProfile(Models.AppSettings? s)
+    {
+        try
+        {
+            var linked = App.Discord?.IsAuthenticated == true;
+            var share = PresenceShare(s);
+            var name = App.UserDisplayName;
+            return new
+            {
+                name = string.IsNullOrWhiteSpace(name) ? null : name!.Trim(),
+                avatarUrl = (linked && share == "discord") ? ArcademyAvatarCache.ReadDataUri() : null,
+                discordLinked = linked,
+                presenceShare = share,
+            };
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Debug("ArcademyHost.BuildProfile: {E}", ex.Message);
+            return new
+            {
+                name = (string?)null,
+                avatarUrl = (string?)null,
+                discordLinked = false,
+                presenceShare = "off",
+            };
+        }
     }
 
     private static object BuildCaps(Models.AppSettings? s) => new
@@ -2384,6 +2446,45 @@ internal static class ArcademyHostService
         ["campus_annex"] = "Records Annex",
         ["campus_annex_status"] = "Stairs down",
         ["campus_desc_annex"] = "Under the office. The lights are off down there. The screens are not.",
+        // ---- THE STUDENT ID (2026-08-25): the furniture card, its photo chip and the spotlight.
+        // The chip rows are the SHORT face (under the photo); the id_photo_* rows are the long
+        // ones the spotlight prints beside it. One switch behind both - the `discord` rung.
+        ["student_id_title"] = "Student ID",
+        ["id_photo_pending"] = "Photo pending",
+        ["id_photo_on"] = "Discord photo on",
+        ["id_photo_use"] = "Use my Discord photo",
+        ["id_photo_link"] = "Link Discord for my photo",
+        ["id_photo_waiting"] = "Waiting on Discord...",
+        ["id_chip_on"] = "Photo on",
+        ["id_chip_use"] = "Use Discord photo",
+        ["id_chip_link"] = "Link Discord",
+        ["id_chip_wait"] = "Waiting...",
+        ["id_photo_hint_app"] = "Opens the Discord link-up in the app, then your photo goes on the card and on campus.",
+        ["id_photo_hint_web"] = "Sends you to Connections to link Discord, then straight back here with the photo on.",
+        ["id_photo_hint_off"] = "Your ghost on campus wears this photo too. Tap to take it down (your name stays).",
+        ["id_photo_failed"] = "Discord did not pick up. Try again in a minute.",
+        ["id_photo_day"] = "Photo day",
+        ["id_no"] = "Student no.",
+        ["id_no_temp"] = "temp",
+        ["id_enrolled"] = "Enrolled",
+        ["id_homeroom"] = "Homeroom",
+        ["id_issued_at"] = "Issued at",
+        ["id_front_desk"] = "Front desk",
+        ["id_stat_semester"] = "Term",
+        ["id_stat_streak"] = "Attendance streak",
+        ["id_stat_perfect"] = "Perfect days",
+        ["id_stat_stamps"] = "Stamps of 100",
+        ["id_stat_best"] = "S days",
+        ["id_year"] = "Year",
+        ["id_grade_tier"] = "Grade tier",
+        ["id_to_go"] = "{n} to go",
+        ["id_reinked"] = "Re-inked",
+        ["id_flip"] = "Tap the card to turn it over. Esc to put it back.",
+        ["id_back_lost"] = "Lost it? Ask at the front desk. The second one costs you a stamp.",
+        ["id_back_valid"] = "Good for as long as the lights are on.",
+        ["id_records_line"] = "Records: {n} of {m} cards mastered",
+        ["id_open_records"] = "Open Records",
+        ["id_spot_close"] = "Close",
     };
 
     /// <summary>The mockup's owner-approved tokens (BUILD-CONTRACT §10). A mod overrides them via
@@ -2870,6 +2971,193 @@ internal static class ArcademyHostService
             });
         }
         catch (Exception ex) { App.Logger?.Debug("ArcademyHost.OnPresenceSnapshot: {E}", ex.Message); }
+    }
+
+    // ============================ the student id ============================
+
+    /// <summary>One link at a time. A second <c>link-discord</c> while a browser flow is open is
+    /// IGNORED, not queued: two OAuth listeners want the same local port, and the player is already
+    /// looking at the page the first one opened.</summary>
+    private static int _linkInFlight;   // 0/1 via Interlocked
+
+    /// <summary>Set when THIS host tore the link-up down (panic, teardown, our own deadline).
+    /// Cancelling the flow makes it throw, and without this the throw would push a second, wrong
+    /// <c>failed</c> frame straight after the <c>cancelled</c> we already sent.</summary>
+    private static bool _linkCancelled;
+
+    /// <summary>Our own ceiling on a link. <see cref="Services.Account.DiscordService"/> gives up
+    /// after five minutes, which is five minutes of the chip saying "Waiting on Discord..." to
+    /// somebody who closed the tab. Two minutes and we call it cancelled, cancel the flow underneath
+    /// and let them press it again.</summary>
+    private static readonly TimeSpan LinkDeadline = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Push the identity block. <paramref name="result"/> is the outcome of a link attempt
+    /// (<c>linked</c> / <c>cancelled</c> / <c>failed</c>) and is absent on the ordinary pushes -
+    /// a rung that moved, or a photo that finished downloading. The page repaints the card and the
+    /// chip from this frame only.
+    /// </summary>
+    private static void PushProfile(string? result = null)
+    {
+        var disp = Application.Current?.Dispatcher;
+        if (disp == null || disp.HasShutdownStarted) return;
+        disp.BeginInvoke(() =>
+        {
+            try
+            {
+                if (_host == null) return;
+                _host.Post(new { type = "profile", profile = BuildProfile(App.Settings?.Current), result });
+            }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyHost.PushProfile: {E}", ex.Message); }
+        });
+    }
+
+    /// <summary>
+    /// Bring the cached student photo up to date off the UI thread, and push a <c>profile</c> frame
+    /// if - and only if - the bytes changed. Called at window open (after <c>init</c> has already
+    /// shipped whatever was on disk) and again after a link completes.
+    ///
+    /// <para>Generation-guarded like every other continuation here: a fetch that comes back after
+    /// the window closed and relaunched must not paint the NEW page's card.</para>
+    /// </summary>
+    private static void KickAvatarRefresh()
+    {
+        int epoch = Volatile.Read(ref _generation);
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (!await ArcademyAvatarCache.EnsureCachedAsync().ConfigureAwait(false)) return;
+                if (Volatile.Read(ref _generation) != epoch) return;
+                PushProfile();
+            }
+            catch (Exception ex) { App.Logger?.Debug("ArcademyHost.KickAvatarRefresh: {E}", ex.Message); }
+        });
+    }
+
+    /// <summary>
+    /// ONE CLICK IS ENOUGH (owner ruling 2). The chip asked for a Discord link; when the OAuth
+    /// succeeds the HOST applies <c>presenceShare = discord</c> itself and pushes the finished
+    /// profile, so the player never has to come back and flip a second switch.
+    ///
+    /// <para>An account that is ALREADY linked takes the short path - apply the rung, refresh the
+    /// photo, answer <c>linked</c>. The page is not supposed to send this frame in that state
+    /// (contract trap 1), but a stale page must not be able to strand its own chip.</para>
+    ///
+    /// <para>The rung is written THROUGH AppSettings, never into the projection: that is what fires
+    /// <see cref="ArcademyPresenceService"/>'s consent hook and the ordinary <c>setting</c> echo.
+    /// Writing it any other way would move the card without moving the ghost, which is exactly the
+    /// one switch the owner ruled these are.</para>
+    /// </summary>
+    private static async void OnLinkDiscord()
+    {
+        if (Interlocked.CompareExchange(ref _linkInFlight, 1, 0) != 0)
+        {
+            App.Logger?.Debug("ArcademyHost: link-discord ignored - a link is already open");
+            return;
+        }
+        _linkCancelled = false;
+        var d = App.Discord;
+        try
+        {
+            if (d == null)
+            {
+                PushProfile("failed");
+                return;
+            }
+
+            if (d.IsAuthenticated)
+            {
+                ApplyDiscordRung();
+                await ArcademyAvatarCache.EnsureCachedAsync().ConfigureAwait(true);
+                PushProfile("linked");
+                return;
+            }
+
+            App.Logger?.Information("ArcademyHost: student ID chip is opening the Discord link-up");
+            // StartOAuthFlowAsync IS the completion signal: it returns when the flow has finished
+            // end to end (tokens exchanged, user validated) and throws on cancel/timeout/failure.
+            // No polling, and no listening to AuthenticationChanged - that event also fires for a
+            // link the player started somewhere else in the app.
+            var flow = Application.Current?.Dispatcher?.InvokeAsync(() => d.StartOAuthFlowAsync())
+                .Task.Unwrap() ?? d.StartOAuthFlowAsync();
+            // Observe any future fault whichever way this race lands, so a flow that throws after
+            // our deadline cannot reach the finalizer as an UnobservedTaskException.
+            _ = flow.ContinueWith(t => { _ = t.Exception; }, TaskContinuationOptions.OnlyOnFaulted);
+
+            var done = await Task.WhenAny(flow, Task.Delay(LinkDeadline)).ConfigureAwait(true);
+            if (done != flow)
+            {
+                App.Logger?.Information("ArcademyHost: Discord link timed out after {S}s - cancelled",
+                    LinkDeadline.TotalSeconds);
+                _linkCancelled = true;
+                try { d.CancelOAuthFlow(); } catch { }
+                PushProfile("cancelled");
+                return;
+            }
+            await flow.ConfigureAwait(true);   // rethrows whatever the flow threw
+
+            if (_linkCancelled) return;        // panic/teardown already answered the page
+            if (!d.IsAuthenticated)
+            {
+                // The flow returned without linking: the service refuses a second concurrent run
+                // (IsVerifying) and returns immediately, which reads as "nothing happened".
+                PushProfile("cancelled");
+                return;
+            }
+
+            ApplyDiscordRung();
+            await ArcademyAvatarCache.EnsureCachedAsync().ConfigureAwait(true);
+            App.Logger?.Information("ArcademyHost: Discord linked from the student ID - photo rung applied");
+            PushProfile("linked");
+        }
+        catch (OperationCanceledException)
+        {
+            App.Logger?.Information("ArcademyHost: Discord link cancelled");
+            if (!_linkCancelled) PushProfile("cancelled");
+        }
+        catch (Exception ex)
+        {
+            // A flow WE cancelled surfaces as a throw too (a dead listener, or the service's own
+            // TimeoutException off the cancelled delay). That is not a failure to report twice.
+            if (_linkCancelled) App.Logger?.Debug("ArcademyHost: link-up threw after we cancelled it: {E}", ex.Message);
+            else
+            {
+                App.Logger?.Warning("ArcademyHost: Discord link failed: {E}", ex.Message);
+                PushProfile("failed");
+            }
+        }
+        finally { Interlocked.Exchange(ref _linkInFlight, 0); }
+    }
+
+    /// <summary>Raise the consent rung to <c>discord</c> the ordinary way - through AppSettings, so
+    /// the presence service's hook and the page's <c>setting</c> echo both fire - and persist it.
+    /// The property clamps unknown values itself, so this can only ever write the rung it names.</summary>
+    private static void ApplyDiscordRung()
+    {
+        try
+        {
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            if (!string.Equals(PresenceShare(s), "discord", StringComparison.Ordinal))
+            {
+                s.ArcademyPresenceShare = "discord";
+                App.Settings?.Save();
+            }
+        }
+        catch (Exception ex) { App.Logger?.Debug("ArcademyHost.ApplyDiscordRung: {E}", ex.Message); }
+    }
+
+    /// <summary>The panic key (and the teardown) close an open link-up: a browser tab left waiting
+    /// on a listener nobody is going to read is worse than a chip the player can press again.
+    /// Pushes <c>cancelled</c> only when there is still a page to hear it.</summary>
+    private static void CancelPendingLink(string why, bool tellPage)
+    {
+        if (Volatile.Read(ref _linkInFlight) == 0) return;
+        App.Logger?.Information("ArcademyHost: cancelling the open Discord link-up ({Why})", why);
+        _linkCancelled = true;
+        try { App.Discord?.CancelOAuthFlow(); } catch { }
+        if (tellPage) PushProfile("cancelled");
     }
 
     /// <summary>
@@ -4022,6 +4310,19 @@ internal static class ArcademyHostService
                 return;
             }
 
+            // THE STUDENT ID follows the rung from EVERY surface - this page's chip, the app's own
+            // Settings tab, the host applying it after an OAuth. The photo is the `discord` rung
+            // (owner ruling 1), so the card's picture can only appear or vanish on this frame; the
+            // `setting` echo below carries the rung but never the bytes. Pushed even when the page
+            // wrote it itself, which is the case where the avatar has to arrive.
+            if (e.PropertyName == nameof(Models.AppSettings.ArcademyPresenceShare))
+            {
+                PushProfile();
+                // Climbing to `discord` on a machine that has never cached the picture: ask for it
+                // now rather than at the next window open. A no-op when the cache is already current.
+                if (PresenceShare(s) == "discord") KickAvatarRefresh();
+            }
+
             if (_suppressSettingEcho) return;   // the page's own write already gets a reply
             var (key, value) = ProjectedSetting(s, e.PropertyName);
             if (key == null) return;
@@ -4204,6 +4505,9 @@ internal static class ArcademyHostService
             // Stop the presence poll BEFORE the host goes: the timer must never outlive the window
             // that armed it, and Detach also sends this session's one best-effort `campus_leave`.
             try { ArcademyPresenceService.Detach(); } catch { }
+            // A link-up the player started from the student ID belongs to THIS window. No frame:
+            // there is nothing left to paint it.
+            try { CancelPendingLink("teardown", tellPage: false); } catch { }
             try { _meta?.FlushSave(); } catch { }
             _meta = null;
             _classActive = false;


### PR DESCRIPTION
The campus student ID card, polished per the owner's 5 rulings (2026-08-25):

- **Real PFP** when `presenceShare == discord` and Discord is linked; PHOTO PENDING / anon pixel student otherwise.
- **One consent chip** under the photo = the public `presenceShare` discord rung. Unlinked: starts the Discord OAuth in-app; the host applies the rung on success (one click). Works on the website through the sibling cclabs-web PR (`link-discord` -> Connections -> `?photo=1`).
- **Front-and-centre spotlight** (`shell/idcard.js`, Records' shape, z46 under EMI): laminated front, YEAR stamp thud, stat tiles on a chime ladder, ALMOST on the streak tile, holo drift + tilt, one breath on the photo rim; flip side with barcode + small print + Records link. Reduced motion = one fade, tiles pre-filled.
- Name = CCP nickname. **Not shareable.** Snowflake rule: the Discord CDN url / user id never reach the page (host-side 128px PNG cache -> data URI).
- 36 lexicon rows, mirrored in `NeutralLexicon`; traps 92/93 added to the arcademy CLAUDE.md.

Verification: rig 41/41 (Chromium: node identity across orientation handover, chip posts one frame per state and paints from the echo, Esc rung order, reduced motion, z ladder), `dotnet build` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L63DrmfxLze24du2Jt5hXM