### PR TITLE
fix(privacy): spiral randomizer could draw from personal folders (#1053) + stale remote source (#1037)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Autonomy.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Autonomy.cs
@@ -346,6 +346,22 @@ namespace ConditioningControlPanel
             if (dlg.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
             if (string.IsNullOrWhiteSpace(dlg.SelectedPath)) return;
 
+            // #1053: every top-level image in this folder becomes a wallpaper the app puts on
+            // screen. FolderBrowserDialog opens on the Desktop by default, so "OK" without
+            // navigating is one click away from handing over a folder of personal photos.
+            if (Services.SecurityHelper.IsPersonalFolderRoot(dlg.SelectedPath))
+            {
+                MessageBox.Show(
+                    "That folder is one of Windows' own - your Desktop, Documents, Pictures, Downloads, " +
+                    "your user folder or a whole drive." + Environment.NewLine + Environment.NewLine +
+                    "Every image sitting in it would become a " +
+                    "wallpaper she can put on your screen, so pick a folder you filled with wallpapers " +
+                    "on purpose instead.",
+                    "Pick a folder of your own",
+                    MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
             s.WallpaperSourceFolder = dlg.SelectedPath;
             App.Settings?.Save();
             RefreshWallpaperFolderLabel();

--- a/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.UiUpdates.cs
@@ -2130,6 +2130,22 @@ namespace ConditioningControlPanel
             if (dialog.ShowDialog(owner) == System.Windows.Forms.DialogResult.OK)
             {
                 var selectedPath = dialog.SelectedPath;
+
+                // #1053: this folder becomes the root of every media scan in the app, and the
+                // app also writes into it (images/, videos/, .packs/, .temp/). Neither belongs
+                // on the Desktop or a drive root.
+                if (Services.SecurityHelper.IsPersonalFolderRoot(selectedPath))
+                {
+                    MessageBox.Show(
+                        "That folder is one of Windows' own - your Desktop, Documents, Pictures, " +
+                        "Downloads, your user folder or a whole drive." + Environment.NewLine + Environment.NewLine +
+                        "The app both reads and " +
+                        "writes here, so pick or make a folder that holds nothing but your assets.",
+                        "Pick a folder of your own",
+                        MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
                 var newPacksFolder = Path.Combine(selectedPath, ".packs");
                 var shouldMovePacks = false;
                 var packFoldersToMove = new List<(string SourceFolder, string PackName)>();

--- a/ConditioningControlPanel/Services/Auth/SecurityHelper.cs
+++ b/ConditioningControlPanel/Services/Auth/SecurityHelper.cs
@@ -37,6 +37,94 @@ namespace ConditioningControlPanel.Services
         }
 
         /// <summary>
+        /// True when <paramref name="directory"/> is one of Windows' personal or system roots
+        /// rather than a folder someone filled on purpose - the Desktop, Documents, Pictures,
+        /// Videos, Music, Downloads, the OneDrive root, the user profile root, or a bare drive
+        /// root. Bug #1053: a feature that takes ONE file the user browsed to and then treats
+        /// that file's whole parent folder as a content pool turns "I picked a spiral that was
+        /// sitting on my Desktop" into "the app is showing me my family photos". Picking a file
+        /// out of one of these folders is never a statement about the folder, so callers that
+        /// widen a single pick into a folder scan must refuse these roots.
+        ///
+        /// Deliberately exact-match, not prefix-match: <c>Desktop\spirals</c> IS a folder the
+        /// user made and filled, and staying usable matters. Only the bare roots are refused.
+        /// </summary>
+        public static bool IsPersonalFolderRoot(string? directory)
+        {
+            if (string.IsNullOrWhiteSpace(directory)) return true;
+
+            try
+            {
+                var dir = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+
+                // A bare drive root ("D:\") trims to "D:" - and Path.GetPathRoot of any path
+                // under it returns "D:\", so compare the trimmed forms.
+                var root = Path.GetPathRoot(dir);
+                if (!string.IsNullOrEmpty(root) &&
+                    string.Equals(dir, Path.TrimEndingDirectorySeparator(root!), StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+                foreach (var folder in new[]
+                {
+                    Environment.SpecialFolder.Desktop,
+                    Environment.SpecialFolder.DesktopDirectory,
+                    Environment.SpecialFolder.CommonDesktopDirectory,
+                    Environment.SpecialFolder.MyDocuments,
+                    Environment.SpecialFolder.MyPictures,
+                    Environment.SpecialFolder.MyVideos,
+                    Environment.SpecialFolder.MyMusic,
+                    Environment.SpecialFolder.UserProfile,
+                    Environment.SpecialFolder.CommonDocuments,
+                    Environment.SpecialFolder.CommonPictures,
+                    Environment.SpecialFolder.CommonVideos,
+                })
+                {
+                    var known = Environment.GetFolderPath(folder);
+                    if (string.IsNullOrEmpty(known)) continue;
+                    if (string.Equals(dir, Path.TrimEndingDirectorySeparator(Path.GetFullPath(known)),
+                                      StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+
+                // Downloads and OneDrive have no SpecialFolder id. Downloads is a known folder
+                // the user can relocate, but the profile-relative name catches the default, and
+                // a relocated Downloads that is not one of the roots above is rare enough to
+                // leave to the exact-match rule.
+                var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                if (!string.IsNullOrEmpty(profile))
+                {
+                    foreach (var name in new[] { "Downloads", "Desktop", "Documents", "Pictures", "Videos", "Music" })
+                    {
+                        if (string.Equals(dir, Path.Combine(profile, name), StringComparison.OrdinalIgnoreCase))
+                            return true;
+                    }
+                }
+
+                foreach (var variable in new[] { "OneDrive", "OneDriveConsumer", "OneDriveCommercial" })
+                {
+                    var oneDrive = Environment.GetEnvironmentVariable(variable);
+                    if (string.IsNullOrWhiteSpace(oneDrive)) continue;
+                    var oneDriveRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(oneDrive));
+                    if (string.Equals(dir, oneDriveRoot, StringComparison.OrdinalIgnoreCase)) return true;
+                    // OneDrive's Known Folder Move relocates Desktop/Documents/Pictures under it.
+                    foreach (var name in new[] { "Desktop", "Documents", "Pictures", "Videos", "Music" })
+                    {
+                        if (string.Equals(dir, Path.Combine(oneDriveRoot, name), StringComparison.OrdinalIgnoreCase))
+                            return true;
+                    }
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                // A path we cannot even resolve is not a path we should scan.
+                App.Logger?.Warning(ex, "IsPersonalFolderRoot check failed for: {Path}", directory);
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Sanitizes a filename to prevent directory traversal and invalid characters
         /// </summary>
         public static string SanitizeFilename(string filename)

--- a/ConditioningControlPanel/Services/Flash/FlashService.cs
+++ b/ConditioningControlPanel/Services/Flash/FlashService.cs
@@ -3029,6 +3029,13 @@ namespace ConditioningControlPanel.Services
         /// <param name="haveLocal">True when a disk or pack image is available as an alternative.</param>
         private bool ShouldDrawRemote(bool haveLocal)
         {
+            // Bug #1037. This used to read the ratio without ever re-reading the source setting,
+            // so a user who switched to "my library only" mid-run kept drawing remote stills at
+            // RemoteMediaRatio% until the warm pool drained - which is why restarting the app
+            // "fixed" it. The source setting is the gate, and it is a live one: turning remote
+            // media off has to mean the very next flash is local.
+            if (!RemoteFlashesEnabled()) return false;
+
             // Nothing local to fall back to: the remote pool is the whole library. This is the
             // onboarding case the feature exists for - a user with an empty assets folder.
             if (!haveLocal) return true;

--- a/ConditioningControlPanel/Services/Notifications/OverlayService.cs
+++ b/ConditioningControlPanel/Services/Notifications/OverlayService.cs
@@ -360,10 +360,27 @@ public class OverlayService : IDisposable
             {
                 try
                 {
+                    var library = Path.Combine(App.UserDataPath, "Spirals");
+
                     // Pool directory: folder of the configured spiral, else the user Spirals library.
                     var poolDir = !string.IsNullOrEmpty(configured)
                         ? Path.GetDirectoryName(configured)
-                        : Path.Combine(App.UserDataPath, "Spirals");
+                        : library;
+
+                    // Bug #1053. "Select spiral GIF" browses the whole disk, so `configured` can
+                    // be a file the user happened to have on their Desktop - and this branch then
+                    // widens ONE file into EVERY image in its folder, drawn fullscreen. That is
+                    // how the app showed someone a family photo it was never given. Picking a file
+                    // out of Desktop/Downloads/Pictures says nothing about the rest of that folder,
+                    // so those roots are refused and we fall back to the Spirals library, which is
+                    // the only pool the setting's tooltip ever promised.
+                    if (SecurityHelper.IsPersonalFolderRoot(poolDir))
+                    {
+                        App.Logger?.Warning(
+                            "[Overlay] Spiral randomize: refusing {Pool} as a spiral pool (personal/system folder) " +
+                            "- falling back to the Spirals library", poolDir);
+                        poolDir = library;
+                    }
 
                     if (string.IsNullOrEmpty(poolDir) || !Directory.Exists(poolDir))
                         return null;


### PR DESCRIPTION
Confirms and fixes in-app bug report #1053 ("pulled a family photo off my desktop").

**Mechanism:** the Spiral card's "Select spiral GIF" button accepts any file on disk, and `OverlayService.PickRandomSpiral` used that file's PARENT FOLDER as the randomize pool - the only image scan in the app without a containment gate (Flash/Video/BubbleCount all have `IsPathSafe`). A spiral picked from the Desktop plus "Randomize spiral" = full-screen slideshow of the Desktop. The tooltip promised the Spirals library.

**Fix:** new `SecurityHelper.IsPersonalFolderRoot` (Desktop, Documents, Pictures, Videos, Music, Downloads, profile root, OneDrive roots, drive roots; exact match so `Desktop\spirals` still works; fails closed). The pool refuses those roots and falls back to the Spirals library at READ time, so existing bad settings heal on next launch with no migration. Assets-folder and wallpaper-folder pickers refuse the same roots with a plain message (FolderBrowserDialog defaults to Desktop, so OK-without-navigating was one click from a photo folder).

**Also fixed, #1037:** `FlashService.ShouldDrawRemote` never re-read the source setting; after switching to local it kept drawing from the warm remote pool at `RemoteMediaRatio` until restart. Now off immediately.

Ruled out with evidence: Awareness engine (no capture/enumeration), Possession/Lockdown, WebView2 host mappings, wallpaper service, drop handler. Note the Brain Drain capture pump blurs the live desktop by design; if the reporter's wallpaper is the photo, that is the benign lookalike - the draft reply asks the one question that separates the two.

dotnet build green (warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW3CBGmvoftRkuuPaUQRi