### PR TITLE
fix(entitlement): Awareness observer + She's Listening mic + Mantra Chant stop on lapse (#1047)

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.CompanionRoom.cs
@@ -199,6 +199,20 @@ namespace ConditioningControlPanel
             if (_isLoading) return App.Settings?.Current?.AwarenessModeEnabled == true;
             if (App.Settings?.Current == null) return false;
 
+            // The entitlement bar, on the ON edge only (#1047). The engines now refuse to run without
+            // it, so without this the dial would happily read "open" over an observer that had already
+            // declined - the mirror image of the bug being fixed. Asked BEFORE the consent dialog: it
+            // is rude to walk someone through a privacy explanation for a door that will not open.
+            //
+            // Turning it OFF is deliberately never gated, and this card never wears a veil. That is
+            // what keeps the promise the padlocked Awareness tab could not: whatever her account is
+            // doing, the switch that closes her eyes is on screen and it works.
+            if (enabled && !Services.TierGate.DemandPremium(Loc.Get("tab_awareness"), "awareness"))
+            {
+                CompanionRoom?.AwarenessVm.Sync();
+                return false;
+            }
+
             if (enabled && !AwarenessConsentDialog.EnsureConsent(this, App.Settings.Current))
             {
                 // Declined (or the dialog could not open). Nothing is written, nothing starts, and the

--- a/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Patreon.cs
@@ -110,6 +110,27 @@ namespace ConditioningControlPanel
                     App.Logger?.Information("Entitlement lapsed: Awareness switched off");
                 }
 
+                // Awareness MODE - the companion's eyes: the v2 observer's one-second foreground poll
+                // and its 30-day on-disk ledger, plus the legacy 1.5s window-title watcher. A separate
+                // flag from KeywordTriggersEnabled above and NOT covered by #267, which is how #1047
+                // happened: the tab wore the padlock while the engine kept observing, and because the
+                // engine's own predicate read four settings and no entitlement there was nothing to
+                // stop it. Stop() on the legacy service chains the observer's Stop(), which flushes
+                // and closes the ledger.
+                //
+                // AwarenessConsentGiven is deliberately left ALONE. It records an answer the user gave,
+                // not a switch; clearing it would make a returning subscriber re-consent to something
+                // they already agreed to. Every readout treats "enabled AND consented" as on, so
+                // clearing the enable is enough for the state to be honest.
+                if (settings.AwarenessModeEnabled && !premium
+                    && App.DailyFree?.IsFreeToday("awareness") != true)
+                {
+                    settings.AwarenessModeEnabled = false;
+                    App.WindowAwareness?.Stop();
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: Awareness Mode switched off");
+                }
+
                 // Bambi Takeover (autonomy).
                 if (settings.AutonomyModeEnabled && !premium
                     && App.DailyFree?.IsFreeToday("takeover") != true)
@@ -130,6 +151,36 @@ namespace ConditioningControlPanel
                     App.Logger?.Information("Entitlement lapsed: She's Listening switched off");
                 }
 
+                // She's Listening - the MICROPHONE half. SpokenMantrasEnabled above is the speaking
+                // half; these two are the listening half, they persist, and AutonomyService
+                // .RefreshVoiceInputModes re-arms them from settings on every launch. #267 cleared the
+                // mouth and left the ear, so a lapsed account restarted straight back into an open
+                // wake-word loop under a veil covering its own disarm controls. Clearing the flags is
+                // what makes the Settings > Devices chips honest; the Refresh call is what actually
+                // closes the mic in this session.
+                if ((settings.SpeechWakeWordEnabled || settings.SpeechPushToTalkEnabled) && !premium
+                    && App.DailyFree?.IsFreeToday("voice") != true)
+                {
+                    settings.SpeechWakeWordEnabled = false;
+                    settings.SpeechPushToTalkEnabled = false;
+                    App.Autonomy?.RefreshVoiceInputModes();
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: She's Listening mic modes disarmed");
+                }
+
+                // Mantra Chant - her voice on a loop, armed from the Takeover tab underneath the same
+                // veil. #685 already stops it surviving a RELAUNCH (App.OnStartup clears the flag), so
+                // what is left is the mid-session lapse: the loop keeps chanting behind a padlock that
+                // covers the toggle. Stop() releases the output device as well as ending the loop.
+                if (settings.MantraChantEnabled && !premium
+                    && App.DailyFree?.IsFreeToday("takeover") != true)
+                {
+                    settings.MantraChantEnabled = false;
+                    App.MantraChant?.Stop();
+                    changed = true;
+                    App.Logger?.Information("Entitlement lapsed: Mantra Chant switched off");
+                }
+
                 // Haptics. The mixer already self-mutes live (HapticMixer.IsGateOpen), so this is
                 // about the master toggle not sitting ON underneath the veil.
                 if (settings.Haptics?.Enabled == true && !premium
@@ -148,6 +199,27 @@ namespace ConditioningControlPanel
                     // reopened, never to wrong.
                     try { SyncAwarenessTabUI(); } catch { /* tab not built yet */ }
                     try { SyncKeywordRescuePanelUi(); } catch { }
+                    // The awareness dial lives in the Companion room, which is NOT veiled - it is the
+                    // off switch a lapsed user can still reach - so it has to be told the eyes just
+                    // closed or it would keep showing them open.
+                    try { CompanionRoom?.AwarenessVm.Sync(); } catch { }
+                    try { CompanionRoom?.SyncHero(); } catch { }
+                    // The mic chips live on the She's Listening tab and mirror the two speech flags
+                    // just cleared; without this they keep claiming the wake word is armed.
+                    try { RefreshSheListeningDeviceChips(); } catch { }
+                }
+
+                // The mirror case. Awareness's runtime predicate now fails CLOSED while App.Patreon is
+                // still null, so a login completing, a tier upgrade landing or the free day rotating IN
+                // has to re-arm what the settings already say should be running - otherwise entitlement
+                // resolving late leaves an entitled user's dial on and her eyes shut until relaunch.
+                // Start() no-ops when already running and re-checks the settings itself, so this can
+                // only ever restore what the user asked for; it writes no settings.
+                if (settings.AwarenessModeEnabled && settings.AwarenessConsentGiven
+                    && Services.Awareness.AwarenessObserver.HasEntitlement
+                    && App.WindowAwareness?.IsRunning != true)
+                {
+                    App.WindowAwareness?.Start();
                 }
             }
             catch (Exception ex)
@@ -948,10 +1020,16 @@ namespace ConditioningControlPanel
             CompanionTab.SliderBubbleDurationCompanion.Value = settings.BubbleDurationSeconds;
             CompanionTab.TxtBubbleDurationCompanion.Text = $"{(int)settings.BubbleDurationSeconds}s";
 
-            // Awareness Mode settings (free for all users). The on/off checkbox became Z5's dial
-            // (design §6: "toggle superseded by Z5 dial"), which reads the same two settings; the
-            // cooldowns below are the "kept" half and still live in the Workshop.
-            var awarenessAvailable = true;
+            // Awareness Mode settings. The on/off checkbox became Z5's dial (design §6: "toggle
+            // superseded by Z5 dial"), which reads the same two settings; the cooldowns below are the
+            // "kept" half and still live in the Workshop.
+            //
+            // This used to be a hardcoded `true` under a "free for all users" comment, which was never
+            // true of the shipped product: awareness is ExclusiveFeature "awareness", Tier = 1, its own
+            // page wears the premium veil, and after #1047 the engines ask the same question. The dial
+            // itself deliberately stays reachable for everyone (it is the OFF switch), so this only
+            // governs the legacy cooldown panel below.
+            var awarenessAvailable = Services.Awareness.AwarenessObserver.HasEntitlement;
             CompanionTab.SliderAwarenessCooldown.Value = settings.AwarenessReactionCooldownSeconds;
             CompanionTab.TxtAwarenessCooldown.Text = $"{settings.AwarenessReactionCooldownSeconds}s";
             CompanionTab.SliderAwarenessCooldownMax.Value = settings.AwarenessCooldownMaxSeconds;

--- a/ConditioningControlPanel/Services/AutonomyService.Voice.cs
+++ b/ConditioningControlPanel/Services/AutonomyService.Voice.cs
@@ -66,7 +66,22 @@ namespace ConditioningControlPanel.Services
                 // arm from their own toggles + consent + an available engine, so "Hey Bambi" works
                 // even with Takeover off. Their home UI is the "She's Listening" Exclusive.
                 var s = App.Settings?.Current;
+
+                // Entitlement, in the base condition so BOTH mic modes inherit it. She's Listening is
+                // a premium feature whose tab wears the veil, but these two toggles persist and this
+                // method re-arms them from settings on EVERY launch — so before this a lapsed account
+                // came back from a restart with a wake-word loop holding the microphone open, behind a
+                // padlock covering the only controls that disarm it. Exactly the shape PR #267 was
+                // written to delete; it just never reached this file.
+                //
+                // Re-read here rather than cached: this method is the reconcile point, so a lapse that
+                // happens while the loop is up is corrected the next time anything calls it, and
+                // EnforceEntitlementLapse calls it on the day-roll / tier-change / logout funnel.
+                bool entitled = App.Patreon?.HasPremiumAccess == true
+                                || App.DailyFree?.IsFreeToday("voice") == true;
+
                 bool baseOk = !_disposed
+                              && entitled
                               && s?.MicConsentGiven == true
                               && App.Speech?.IsAvailable == true;
 

--- a/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
+++ b/ConditioningControlPanel/Services/Awareness/AwarenessObserver.cs
@@ -212,8 +212,12 @@ namespace ConditioningControlPanel.Services.Awareness
         public bool MediaSignalAvailable => _media?.IsAvailable == true;
 
         /// <summary>
-        /// Whether v2 may run at all: the kill switch, the feature toggle, the legacy consent AND the
-        /// v2 consent, all four.
+        /// Whether v2 may run at all: the ENTITLEMENT, the kill switch, the feature toggle, the legacy
+        /// consent AND the v2 consent, all five.
+        ///
+        /// <para><b>Entitlement is first on purpose</b> (see <see cref="HasEntitlement"/>). Awareness
+        /// is a tier-1 feature and this predicate used to be the one place in the chain that did not
+        /// know it, which left a lapsed account observed with no reachable off switch (#1047).</para>
         ///
         /// <para><b>Why <c>AwarenessConsentShownV2</c> is in here.</b> v1 persisted nothing; v2 keeps a
         /// 30-day on-disk record of per-app visit counts, minute totals, day streaks and a machine-wide
@@ -234,7 +238,7 @@ namespace ConditioningControlPanel.Services.Awareness
                 {
                     var s = App.Settings?.Current;
                     if (s == null) return false;
-                    return s.UseAwarenessV2 && s.AwarenessModeEnabled &&
+                    return HasEntitlement && s.UseAwarenessV2 && s.AwarenessModeEnabled &&
                            s.AwarenessConsentGiven && s.AwarenessConsentShownV2;
                 }
                 catch { return false; }
@@ -242,8 +246,47 @@ namespace ConditioningControlPanel.Services.Awareness
         }
 
         /// <summary>
-        /// Starts the ledger (which loads and prunes) and arms the poll. A no-op when awareness is off,
-        /// unconsented or the v2 kill switch is down — in which case the legacy
+        /// The entitlement half of <see cref="IsEnabled"/>, split out so the legacy
+        /// <c>WindowAwarenessService</c> poll and <c>MainWindow.EnforceEntitlementLapse</c> ask the
+        /// same question this does instead of each writing their own.
+        ///
+        /// <para><b>Why it exists at all (#1047).</b> Awareness is sold at tier 1
+        /// (<c>ExclusiveFeature</c> key <c>"awareness"</c>, <c>Tier = 1</c>) and its page carries the
+        /// premium veil, but the predicate above read four SETTINGS flags and no entitlement — so an
+        /// account whose access lapsed kept a one-second foreground poll and a 30-day on-disk ledger
+        /// running behind a padlock it could not reach through, tray-minimised included. That is the
+        /// exact shape PR #267 deleted everywhere else, and this is the same expression
+        /// <c>MainWindow.RefreshPremiumGate(AwarenessTab.AwarenessGate, "awareness")</c> paints the
+        /// veil with, so the veil and the engine can no longer disagree.</para>
+        ///
+        /// <para>"Premium" here means TIER 1, per the house rule. <c>HasPremiumAccess</c> already folds
+        /// in the whitelist, SubscribeStar and the 14-day offline grace, so a paying subscriber never
+        /// reads false during the startup window before async validation lands; only a genuinely
+        /// lapsed account does. The free-day rotation is OR'd in because the ? box can put awareness
+        /// in the window for a day.</para>
+        ///
+        /// <para>Fails CLOSED when <c>App.Patreon</c> is null (early startup, or a service that failed
+        /// to construct): a missing gate must never read as an open door. Safe here because every
+        /// start path runs after the Patreon service is constructed — the avatar tube's Loaded handler
+        /// and the companion room's dial — and <c>RefreshEntitlementVeils</c> re-arms the service if
+        /// entitlement resolves later.</para>
+        /// </summary>
+        public static bool HasEntitlement
+        {
+            get
+            {
+                try
+                {
+                    return App.Patreon?.HasPremiumAccess == true
+                           || App.DailyFree?.IsFreeToday("awareness") == true;
+                }
+                catch { return false; }
+            }
+        }
+
+        /// <summary>
+        /// Starts the ledger (which loads and prunes) and arms the poll. A no-op when the account is not
+        /// entitled, or awareness is off, unconsented or the v2 kill switch is down — in which case the legacy
         /// <c>WindowAwarenessService</c> pipeline keeps running exactly as it does today.
         /// </summary>
         public void Start()
@@ -252,7 +295,7 @@ namespace ConditioningControlPanel.Services.Awareness
 
             if (!IsEnabled)
             {
-                App.Logger?.Debug("AwarenessObserver: not starting (v2 off, awareness off, or no consent)");
+                App.Logger?.Debug("AwarenessObserver: not starting (not entitled, v2 off, awareness off, or no consent)");
                 return;
             }
 
@@ -431,6 +474,13 @@ namespace ConditioningControlPanel.Services.Awareness
             if (_disposed || !_running) return;
             if (Application.Current?.Dispatcher == null) return;
             if (Application.Current.Dispatcher.HasShutdownStarted) return;
+
+            // Re-asked EVERY tick, not only at Start(): entitlement can lapse mid-run (a free day
+            // rotating out at midnight, a subscription expiring, a logout) and a timer armed while the
+            // account was entitled would otherwise keep reading the foreground forever. #267 put the
+            // same live re-check in the keyword engine's fire paths for the same reason. It sits ahead
+            // of Observe(), so a lapsed account's window titles are never read, let alone recorded.
+            if (!IsEnabled) return;
 
             _ = TickAsync(_clock());
         }

--- a/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
+++ b/ConditioningControlPanel/Services/UI/WindowAwarenessService.cs
@@ -364,7 +364,19 @@ namespace ConditioningControlPanel.Services
         {
             if (_isRunning || _isDisposed) return;
 
-            // Check if feature is enabled and consent given
+            // Check if the account is entitled, the feature is enabled and consent was given.
+            //
+            // The entitlement term is #1047's other half: this legacy poll reads the foreground window
+            // TITLE every 1.5s and is armed by the same dial as the v2 observer, so gating only the
+            // observer would have left the older, blunter watcher running for a lapsed account.
+            // Awareness is a tier-1 feature (ExclusiveFeature "awareness", Tier = 1) and this asks the
+            // same question its page's veil does.
+            if (!Services.Awareness.AwarenessObserver.HasEntitlement)
+            {
+                App.Logger?.Debug("WindowAwareness: Not starting - no premium entitlement for awareness");
+                return;
+            }
+
             if (App.Settings?.Current?.AwarenessModeEnabled != true ||
                 App.Settings?.Current?.AwarenessConsentGiven != true)
             {
@@ -549,6 +561,12 @@ namespace ConditioningControlPanel.Services
         {
             try
             {
+                // Entitlement, re-asked live rather than trusted from Start(). A subscription that
+                // expires (or a free day that rotates out at midnight) while this timer is armed must
+                // stop the watching, not merely re-draw the padlock over it — the #267 rule. Ahead of
+                // GetActiveWindowTitle so a lapsed account's titles are never read.
+                if (!Services.Awareness.AwarenessObserver.HasEntitlement) return;
+
                 // "Not right now." Tested BEFORE the window title is read, so a pause observes
                 // nothing rather than observing and discarding.
                 //

--- a/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/AwarenessConsentTests.cs
@@ -95,16 +95,102 @@ public class AwarenessConsentTests
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        // AppSettings declares them; MainWindow.CompanionRoom.cs is the one place that flips them, and
-        // it calls EnsureConsent first. Anything else on this list is a second door.
+        // AppSettings declares them; MainWindow.CompanionRoom.cs is the one place that flips them ON,
+        // and it calls EnsureConsent first. MainWindow.Patreon.cs is the entitlement-lapse shutoff
+        // (#267's EnforceEntitlementLapse, extended for awareness in #1047) and is only allowed here
+        // because it can only ever write FALSE — asserted below, so it cannot quietly become a second
+        // door. Anything else on this list IS a second door.
         var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "AppSettings.cs", "MainWindow.CompanionRoom.cs"
+            "AppSettings.cs", "MainWindow.CompanionRoom.cs", "MainWindow.Patreon.cs"
         };
 
         var strays = writers.Where(f => !allowed.Contains(f!)).ToList();
         Assert.True(strays.Count == 0,
             "awareness is switched on outside the consent gate in: " + string.Join(", ", strays));
+    }
+
+    [Fact]
+    public void TheLapseShutoffOnlyEverClosesHerEyes()
+    {
+        // The shutoff shares the allow list above with the consent gate, so its one privilege has
+        // to be pinned: it may write the enable false, and it may never write it true.
+        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.Patreon.cs"));
+
+        // (char)10 is the line feed, spelled without an escape so the split survives however this
+        // file's own line endings land.
+        var writes = source.Split((char)10)
+            .Select(l => l.Trim())
+            .Where(l => l.Contains("AwarenessModeEnabled =", StringComparison.Ordinal)
+                        && !l.Contains("AwarenessModeEnabled ==", StringComparison.Ordinal)
+                        && !l.StartsWith("//", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(writes);
+        Assert.All(writes, w => Assert.Contains("= false", w, StringComparison.Ordinal));
+    }
+
+    // ===================== the entitlement term (#1047) =====================
+
+    [Fact]
+    public void TheObserverPredicateAsksAboutEntitlementAndNotOnlySettings()
+    {
+        // Awareness is sold at tier 1, its page wears the premium veil, and until #1047 the engine's
+        // own predicate read four settings flags and nothing else — so a lapsed account was still
+        // observed, behind a padlock that covered the only toggle on that page. A source scan rather
+        // than a call, because App.Patreon cannot be stood up headlessly and the regression this
+        // guards is a term going MISSING from an expression.
+        var source = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "Awareness", "AwarenessObserver.cs"));
+
+        Assert.Contains("HasEntitlement && s.UseAwarenessV2", source, StringComparison.Ordinal);
+        Assert.Contains("App.Patreon?.HasPremiumAccess == true", source, StringComparison.Ordinal);
+        // The free day has to be OR'd in or the ? box would advertise a door it cannot open.
+        Assert.Contains("IsFreeToday(\"awareness\")", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoEntitlementServiceMeansNoWatching()
+    {
+        // Fail closed: headless, App.Patreon and App.DailyFree are both null, and a missing gate must
+        // read as a shut door rather than an open one.
+        Assert.False(AwarenessObserver.HasEntitlement);
+        Assert.False(AwarenessObserver.IsEnabled);
+    }
+
+    [Fact]
+    public void BothAwarenessPollsReCheckEntitlementOnEveryTick()
+    {
+        // Start()-time checks are not enough: entitlement lapses mid-run (midnight rotation, an
+        // expiring subscription, a logout) and both of these timers outlive the check that armed them.
+        var observer = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "Awareness", "AwarenessObserver.cs"));
+        var legacy = File.ReadAllText(Path.Combine(SourceRoot(), "Services", "UI", "WindowAwarenessService.cs"));
+
+        var observerTick = observer[observer.IndexOf("private void OnPollTick", StringComparison.Ordinal)..];
+        Assert.Contains("if (!IsEnabled) return;", observerTick[..1400], StringComparison.Ordinal);
+
+        var legacyTick = legacy[legacy.IndexOf("private void OnPollTick", StringComparison.Ordinal)..];
+        Assert.Contains("AwarenessObserver.HasEntitlement", legacyTick[..1400], StringComparison.Ordinal);
+
+        // …and it has to be ahead of the title read, or a lapsed account is observed and then discarded.
+        var guard = legacyTick.IndexOf("AwarenessObserver.HasEntitlement", StringComparison.Ordinal);
+        var read = legacyTick.IndexOf("GetActiveWindowTitle()", StringComparison.Ordinal);
+        Assert.True(guard >= 0 && read > guard, "the entitlement guard must precede the window-title read");
+    }
+
+    [Fact]
+    public void TheLapseShutoffStopsTheEngineAndNotJustTheFlag()
+    {
+        // Flipping the setting without stopping the service would leave the poll running until the
+        // next relaunch — the half-fix that would make #1047 look repaired while the eyes stayed open.
+        // Stop() on the legacy service is what chains through to the observer's Stop() and the ledger.
+        var source = File.ReadAllText(Path.Combine(SourceRoot(), "MainWindow", "MainWindow.Patreon.cs"));
+
+        var write = source.IndexOf("settings.AwarenessModeEnabled = false;", StringComparison.Ordinal);
+        Assert.True(write > 0, "the lapse shutoff no longer switches Awareness Mode off");
+
+        var block = source.Substring(write, Math.Min(400, source.Length - write));
+        Assert.Contains("App.WindowAwareness?.Stop()", block, StringComparison.Ordinal);
+        Assert.Contains("Entitlement lapsed: Awareness Mode", block, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1047 (Sylvie): after temporary premium access lapsed, Awareness Mode kept watching and the off switch was behind the paywall.

**Why:** two features share the name. The Awareness Engine tab (keywords + OCR) was gated by PR #267; the Awareness Mode OBSERVER (`AwarenessObserver` + legacy `WindowAwarenessService`, foreground-window watcher with a 30-day on-disk ledger) had a settings-only predicate: four settings terms, zero entitlement. Awareness is sold at tier 1 (`ExclusiveFeature.cs:200`). "Runs with CCP closed" = minimise-to-tray (`Hide()`, DispatcherTimer keeps ticking); exit was already clean.

**Fix:** `HasEntitlement` (premium or free-day 'awareness', fails closed on null Patreon) as the first term of `IsEnabled`, re-checked every poll tick in both watchers ahead of the title read; `EnforceEntitlementLapse` flips the setting off AND stops the runtime (Awareness, She's Listening mic modes, Mantra Chant) with a symmetric re-arm when entitlement resolves late; the Companion-room ON edge asks `TierGate.DemandPremium` so dial and engine can never disagree. The OFF switch was already outside the veil (Companion room, ungated).

**Audit** of every tier-gated toggle (table in the agent report): fixed the three masked-only cases above; #267's cases confirmed ok; Arcademy's `DemandLab`-inside-`Launch()` is the best pattern in the codebase.

**Left for owner (not changed):** Remote Control in-session hole (#267 deliberately left it), AI effects T2 relies on a refresh-time repair, Just Drop wears a T2 badge with no gate, `Haptics.AutoConnect` is written and never read, no user-visible lapse toast (needs 9 loc files), and the product-intent check: a stale `// free for all users` comment said Awareness Mode was free; the exclusive card, veil and tagline say tier 1, so it is gated at tier 1. One-line revert if intent differs.

+5 tests; suite 3831/3831; dotnet build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW3CBGmvoftRkuuPaUQRi