### PR TITLE
fix(arcademy): sample sfx self-banned on first teardown

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -429,7 +429,11 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
       try { rec.el.pause(); } catch { /* ignore */ }
       // Releasing the src lets the decoder go; a MediaElementSource cannot be
       // re-created for the same element, so the element is never reused.
-      try { rec.el.src = ''; } catch { /* ignore */ }
+      // REMOVE THE ATTRIBUTE, never `src = ''`: an EMPTY string is still a
+      // resource the element goes and tries to select, so it fails and fires an
+      // `error` at us on every ordinary teardown. Attribute gone + load() aborts
+      // selection with `emptied` instead - no error, same released decoder.
+      try { rec.el.removeAttribute('src'); rec.el.load(); } catch { /* ignore */ }
       try { if (rec.node) rec.node.disconnect(); } catch { /* ignore */ }
       try { if (rec.gain) rec.gain.disconnect(); } catch { /* ignore */ }
     };
@@ -514,7 +518,18 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
     try { el.addEventListener('ended', () => { if (clips.get(key) === rec) { clips.delete(key); killClip(rec, 0); } }); } catch { /* ignore */ }
     try {
       el.addEventListener('error', () => {
-        if (clips.get(key) === rec) { clips.delete(key); killClip(rec, 0); }
+        // STILL IN THE MAP IS WHAT MAKES THIS A VERDICT ON THE FILE. Every
+        // legitimate teardown - the maxMs timer, `ended`, a re-fire on the same
+        // key, the voice-cap eviction, stopAllClips - deletes the record BEFORE
+        // it calls killClip, and killClip releases the src; a release used to
+        // fire a spurious `error` here (and, once, struck a perfectly good
+        // sample off `available` a second after its one and only play). So that
+        // ORDERING is load-bearing: a teardown path that kills first and deletes
+        // after would look exactly like a broken file. Kill the event where it
+        // is not ours and the rest of this handler reads as it always did.
+        if (clips.get(key) !== rec) return;
+        clips.delete(key);
+        killClip(rec, 0);
         // The file the host promised is not playable. Take the name back rather
         // than spending a decoder on it once a beat for the rest of the night;
         // from the next cue on it is a recipe again (or, for the sample-only


### PR DESCRIPTION
## The bug (found by the 0825 bughunt patrol, confirmed in app logs since 0824)

Every sampled sfx (bell, door, paper, stamp, stamp_bad, whoosh, flap_deal, intro_bed) played exactly ONCE per session, then struck itself off the sample roster ~1-2s later with `[audio] sample <name> will not load - falling back`. For the rest of the night every sampled cue degraded to the synth recipe - and intro_bed / flap_deal, which are SAMPLE_ONLY with no recipe, degraded to silence. The AV Club sample pass has effectively been a play-once feature since it landed.

The files were fine. `killClip`'s teardown did `el.src = ''`, which per the HTML media resource-selection algorithm runs selection to FAILURE and fires `error` on the element - and the error listener's sample-strike sat OUTSIDE its `clips.get(key) === rec` guard, so every ordinary teardown (maxMs timer, `ended`, re-fire, voice-cap eviction, stopAllClips) read as a broken file.

## The fix (audio.js only, +17/-2)

1. The strike moves inside the still-current guard: every legitimate teardown deletes the record from `clips` BEFORE calling killClip, while a genuine load/decode failure arrives with the record still mapped - "still in the map" is the discriminator (ordering now documented as load-bearing).
2. Teardown aborts selection instead of failing it: `removeAttribute('src')` + `load()` ends with `emptied`, no `error`, decoder still released.

## Evidence

- Focused node suite (4 tests, ~26 assertions) driving the real module: torn-down error strikes nothing and the next cue is still a clip; a current-clip error strikes exactly once and falls back; teardown records removeAttribute+load, never `src=''`; re-fire/stop_clips teardowns silent. Each half reverted in isolation turns the suite red.
- Live smoke on the rebuilt app: pre-fix, every boot struck intro_bed within ~20s and bell right after (log lines every session 0824-0825); post-fix boot ran 100s with zero strike lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVfeMhCj5mqWQ1b3pPAUVN
