### PR TITLE
feat(emi): EMI ASKS - she asks, you answer

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -363,6 +363,12 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                is a fixed 8px/104px pixel grid, never a cqw clamp - see trap 55.
   demo.html    standalone renderer tester (no shell), loads the real modules.
   widget.js    THE FLOATING ELEMENT: mount, drag, pet, hide/dock, persistence.
+               Since EMI ASKS it also owns the CHIP STRIP (`mountAsk` /
+               `unmountAsk` / `askReady` / `asking`), the four seams an ask's
+               YES needs (`parkMirrored`, `setGazeBias`, `creditPet` and
+               `apparate`'s `stay`) and the ask LEDGER, which rides the same
+               `emi` blob and the same debounced writer (`askState` /
+               `askSave`) - see trap 96.
                Owns the pointer verbs and the ONE chain runner (so there is
                exactly one thing to cancel and one place that knows a SAY is
                mid-line). It NEVER imports the renderer - face/chains/fx are
@@ -387,6 +393,28 @@ emi/         EMI, the mascot: a living pixel CRT that FLOATS over the whole page
                `.bubble-low` flips (right margin / top edge). Plus THE CRT
                POWER-OFF (`emi-crt-off` / `emi-crt-on`, 200ms each, and the
                `.crt-blank` frame between them) - the field trip's transition.
+  asks.js      THE ASK ENGINE (EMI ASKS, 2026-08-25): the one thing she does
+               that is not a reaction - a question, and then she WAITS. An ask
+               is a bubble line plus a two-chip strip that persists until a
+               chip is clicked, the ask is dismissed, or she gives up (40s; 12s
+               for the ones that ride `classStart`). The IGNORED path is
+               universal and WORDLESS: chips out, `-_-` 1400, bubble `...`,
+               idle. No line, ever. Five gates - session 3, not mid-class, not
+               over a live verb (`widget.askReady()`), the cadence (3 sittings,
+               or 2 on a 1-in-3 roll; the NAME ask is exempt) and one ask a
+               sitting. TWO entry points and the order is the feature:
+               `note(name, payload)` runs on EVERY moment (the latches - is a
+               class up, did a dare resolve, is the gaze bias spent) and
+               `offer(name, payload)` only on the ones the voice AND the trips
+               declined. `greetIntercept()` is the third, and the only thing in
+               EMI that runs BEFORE the voice: three skipped "bed?"s replace
+               one greet with a groggy one. Effects a YES buys are all widget
+               seams (`parkMirrored` / `setGazeBias` / `creditPet`) bar two -
+               a01's `soft` night, which shell.js reads off `asks.flags`, and
+               the DARES, which flag the next class and resolve on its own
+               win/fail into `dareWon` on the payout frame. The lines are the
+               ASKS table in the file, VERBATIM from
+               `planning/arcademy/EMI-ASKS.md`.
   fieldtrips.js THE ONE AUTONOMOUS VERB (W2a, 2026-08-24): the POI registry and
                the scheduler that decides she may use it. `widget.apparate()` is
                HOW a trip happens; this is WHEN, and it is FIVE gates - never
@@ -1753,6 +1781,101 @@ DOWN, and the page never invents a number).
     any cycle - and the wall whisper (`arc-rw-*`) is hover/focus-gated per card so the
     grid never runs ten ambient loops at once.
 
+92. **THE CHIP STRIP IS THE THIRD AND LAST NODE ON THE LAYER THAT TAKES A CLICK
+    (EMI ASKS, 2026-08-25).** Trap 59's law is that `#arc-emi` is
+    `pointer-events:none` and exactly two nodes turn it back on (`.emi` and
+    `.emi-dock`). An ask adds `.emi-chip` and NOTHING else: the `.emi-ask` strip
+    that holds the chips stays inert, so the gap between two chips is still a
+    click that reaches the board underneath. Four `pointer-events:auto` rules on
+    the whole layer now, and `test-asks.mjs` counts them. The rest of trap 59
+    survives untouched and is asserted the same way: `widget.js` still makes
+    exactly ONE `preventDefault()` call (the `pointerdown` on `.emi`), the ask
+    engine's two document listeners are `{passive:true}` in the bubble phase and
+    call neither `preventDefault` nor `stopPropagation` (trap 80's shape), and
+    EMI still adds no rung to the Esc ladder - Esc dismisses an ask on its way
+    past and the ladder never notices it happened.
+93. **AN ASK MAY NEVER LAND ON TOP OF A LINE, AND THAT IS TWO SEPARATE RULES.**
+    (a) THE ORDER: `emi/index.js voiceMoment` asks the voice, then the field
+    trips, then the asks - so a night with a scripted beat in it is never also a
+    night she stops you to ask a question. (b) THE STATE: `widget.askReady()` is
+    the one honest answer to "may she ask right now" and it refuses over a say,
+    a chain, a press, a drag, a live field trip, a live off-channel, a dismissed
+    or disabled EMI, and a strip that is already up. Neither rule can carry the
+    other: the order alone would still let an ask land while a trip's power-off
+    was running, and the state alone would let a bark and a question fight over
+    the same moment. **And the latches are a third thing entirely.** `note()` is
+    called on EVERY moment, `offer()` only on the declined ones - a dare that
+    resolved only when the voice happened to stay quiet would resolve about half
+    the time. If you add a moment to the ask table, add it to `ASK_TRIGGERS` and
+    ask yourself which of the two entry points it belongs to.
+94. **`{name}` RESOLVES TO THE LINE THAT SHIPPED, NOT TO A FALLBACK NAME.** The
+    token is the ONE substitution `voice.js` performs, and the whole design is in
+    what it does when there is no name: the token AND the punctuation it brought
+    with it are removed, so `'{name}. you came back.'` is `'you came back.'` byte
+    for byte on an install that never answered a14. That is what lets a name-drop
+    be written into an existing beat (p06's anniversary line is a PREFIX, not a
+    fork) instead of doubling the pool. There is no "hey you" and no "student":
+    a token with nothing behind it is silence, which is the rule the whole voice
+    runs on. Two consequences: the ladder measures the RESOLVED line for its hold
+    (a name is longer than its token, and a `tail` scheduled against the raw text
+    would land on a live bubble - trap 72's cousin), and the ration is spent in
+    `sayIt` only when the line actually landed, at most once a sitting. New
+    name-drop lines in `barks.js` also carry `when: ['hasName']`, so an unnamed
+    player sees the pools they always had; only a line that was ALREADY there may
+    take a bare prefix.
+95. **THE BED ASK RIDES `exitAim`, NOT `exitIntent`, AND IT MAY NEVER TOUCH THE
+    DOOR.** `boot.js` fires `exitIntent` 450ms into a 1200ms Esc hold - the wrong
+    end of the gesture for a question, because the window is already closing
+    behind it (and that moment belongs to the flinch anyway). So `shell.js` mints
+    a second, earlier and much softer signal: a `{passive:true}` `pointermove` in
+    the bubble phase that fires `exitAim` ONCE a sitting when the cursor reaches
+    the top-right corner the host window's close button lives in. The fence is
+    the feature and it is asserted by source shape: no `preventDefault`, no
+    `stopPropagation`, no `beforeunload`, no refusal, no await, nothing that
+    could delay a frame - and the listener comes off in the shell's own teardown.
+    A skipped "bed?" costs HER sleep (three running buys a groggy greet), never
+    you a second click.
+96. **THERE IS EXACTLY ONE WRITER OF THE `emi` KEY, AND THE ASK LEDGER RIDES
+    IT.** `widget.js save()` does `store.set('emi', blob())` - a full replace, not
+    a merge - so an ask engine that wrote `store.merge('emi', {name})` of its own
+    would have its name eaten by the next drag. The ledger (`ask{}`, `name`,
+    `lastAskSession`, `bedSkips`) is therefore spliced into `blob()` and mutated
+    through `widget.askState()` / `widget.askSave()`, and every field is
+    re-derived defensively on the way IN (a stored name is re-sanitised, a row
+    with no `a` is dropped). Nothing is written at all for a player who has never
+    answered an ask, so an untouched install keeps the blob it always had.
+    `voice.js` reads the same ledger through `store.get('emi')` for
+    `askIs` / `askAnswered` / `sessionsSinceAsk` / `hasName` and writes none of
+    it. An IGNORED ask is deliberately NOT an answer to any of those predicates:
+    she can never reference a conversation you declined to have.
+97. **`classStart` IS EVALUATED WHILE THE MID-CLASS LATCH IS STILL OPEN, AND A
+    DARE'S CLOCK IS THE SHORT ONE.** The dares (a09/a10/a11) have to be offered
+    on `classStart`, which is also the moment that closes the "not mid-class"
+    gate - so `offer()` runs first and `note()` sets the latch, which is the
+    whole reason the module has two entry points instead of one. That places the
+    strip correctly (shell.js fires `classStart` right after `clearScreen()`, one
+    beat before the class chrome is built and long before a board takes input),
+    but it does not keep it there: a strip nobody answers would still be up when
+    the board goes live. Hence `DARE_GIVE_UP_MS` (12s, against the ordinary 40s)
+    on every `classStart` ask, plus the universal any-press cancel. If a future
+    ask wants to ride a moment that fires ON a live board, it does not - move the
+    offer to the class-rules sheet (trap 85) instead.
+
+98. **THE STRIP LIVES INSIDE `.emi`, SO EVERY CHIP PRESS HAS TO BE HANDED BACK -
+    AND ONLY A BROWSER CAN SEE THAT IT WAS NOT.** `.emi`'s `pointerdown` is the
+    drag/pet handler, and it does two things a button cannot survive:
+    `setPointerCapture` on the root (which retargets the release, so the chip's
+    own `click` never fires) and `preventDefault()` (which suppresses the
+    compatibility mouse events the click is minted from). A chip that fell
+    through to it was therefore dead on arrival AND quietly banked a head-pat.
+    `onDown` now returns early on `inAsk(ev)`, exactly as it has always done for
+    `inX(ev)` - the x button has needed the same guard since day one, and for
+    the same reason. **The node suite passed the whole time.** The DOM double has
+    no pointer capture, no compatibility events and no real click dispatch, so it
+    cannot express this failure at all; `proof-asks.mjs` (port 8753) caught it on
+    the first run. Any future affordance placed inside `.emi` needs the same
+    early return, and a browser assertion to prove it.
+
 ## 5. The game module contract (short version)
 
 ```js
@@ -1884,12 +2007,45 @@ saver exemption on the WALL clock, the reveal card's layout and its
 `pointer-events:none`, and **zero rAF calls in 1.2s at rest**. Both drive a deck
 of their own on compressed dials - the shipped widget grows no test seam.
 
+`scratchpad/askproof/proof-asks.mjs` is the ask strip's browser half (**27 assertions**,
+port 8753): the real widget over the real sheets in Chromium, reading the geometry back.
+It proves what the DOM double structurally cannot - that `widget.css` parses and all 22
+strip rules survive the cascade, that the layer is still `pointer-events:none` with only
+the CHIPS live, that the line sits clear above (or below) the strip on all three
+orientations, that a strip parked in the right margin stays inside the window, that a
+trusted click on a chip is a chip press and NOT a pet or a drag (trap 98 - it caught that
+one), that a board row 60px away is still clickable under her (trap 59), and that a14's
+field is a real 8-character input that takes focus and submits on Enter.
+
 **Browser pass, not just node.** The suites drive a DOM double, which cannot see a CSS rule
 that does not parse, a module that throws on evaluation, or trap 49. The recipe: serve the
 web root over plain http, install `window.chrome.webview` through Playwright's
 `addInitScript` (bridge.js captures the transport at module scope, so it must exist before
 the first import), post a realistic `init`, then screenshot and read `document.styleSheets`
 back. It caught trap 49 and two duplicated-copy layout bugs the node run could not.
+
+`scratchpad/asksuite/test-asks.mjs` (2026-08-25, EMI ASKS) is the ask engine's own:
+**228 assertions** over the real `emi/asks.js` against a fake widget, the real
+`emi/widget.js` strip under the DOM double, and the real `emi/voice.js`. It covers the
+five gates (session 3, mid-class, the widget's own refusal, the cadence's two doors, one
+ask a sitting), the WORDLESS ignored path and the three ways to reach it (give-up, a
+document press, a pet), the store shape and the one-writer law, the name sanitiser and the
+`{name}` fallback with its one-a-sitting ration, all four new predicates including the
+`{game}` substitution, every dare from the flag to the payout string, a15's fence, and
+every question and reaction VERBATIM against a hand-transcribed copy of `EMI-ASKS.md`. It
+also greps the seams that are not JavaScript, `test-hostfixes.mjs`-style: shell.js's
+additive `dareWon`, the passive exit-aim listener, the C# `DareBonusXp` / `XPSource.Quest`
+pair and `BankAccumulator`'s bankable row, impulse-control's additive `newBest`, and the
+count of `pointer-events:auto` rules on the EMI layer. It brings its OWN augmented
+`document` (one that takes listeners) rather than touching `domshim.mjs`, because every
+other suite depends on `audio.js` no-opping there.
+
+**`test-voice.mjs` used to crash before it finished.** `boot.js` binds a document listener
+and the shared `domshim.mjs` document is a plain object, so the file threw at its boot
+import and reported ZERO assertions while still printing three failures. It now installs
+those two methods on its own copy and runs to completion: **115 assertions, 4 failures**,
+and the same four fail identically on unmodified `main` (three stale trigger-coverage
+fixtures plus the greet-seam one).
 
 `test-hostfixes.mjs` covers the two seams that are not JavaScript. It **parses the real
 `styles.css`** and evaluates the `[hidden]` cascade for every element the shell toggles

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/asks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/asks.js
@@ -1,0 +1,874 @@
+/* ============================================================================
+ * emi/asks.js - THE ASK ENGINE (wave EMI ASKS, 2026-08-25).
+ *
+ * An ASK is the one thing EMI has never done: she puts a question on the glass
+ * and then WAITS for you. Everything else she does is a reaction. Spec (owner
+ * locked 0825): `planning/arcademy/EMI-ASKS.md`. Every `say` string in the
+ * table below is VERBATIM from it - a line that could not be wired was LEFT
+ * OUT, never re-worded.
+ *
+ * ---------------------------------------------------------------------------
+ * THE SHAPE
+ *
+ *   bubble line  through `emi.say()` - the ordinary path, so the pose, the
+ *                hold and the Blipese babble are the ones she already has
+ *                (trap 70: the voice hangs off setBubble and nowhere else).
+ *   the strip    two chips under the bubble, inside `.emi` (the widget mints
+ *                and owns the node; this file only says what goes on it).
+ *   the end      a chip click, a dismiss, or she gives up after 40s.
+ *
+ * THE IGNORED PATH IS WORDLESS AND UNIVERSAL. Chips slide out, `-_-` holds
+ * 1400, the bubble says `...`, then idle. No line, ever. Silence is on-lock:
+ * there is no guilt in words here, and a skipped "bed?" costs HER sleep.
+ *
+ * ---------------------------------------------------------------------------
+ * THE GATES (each one a different kind of no)
+ *
+ *   1. NEVER BEFORE THE THIRD SESSION - `voice.sessions`, read never minted,
+ *      the same spine `sessionAtLeast` and the field trips hang off.
+ *   2. NOT MID-CLASS. `classStart` is the one moment that fires INSIDE the
+ *      gate (the dares live there) and it is evaluated BEFORE the latch is
+ *      set, which is why `note()` runs the latches and `offer()` runs the
+ *      asks - two entry points, one order.
+ *   3. NOT OVER A LIVE VERB. A say, a chain, a press, a drag, a field trip, an
+ *      off channel, a dismissed or disabled EMI: the widget owns that truth
+ *      and answers it in one call (`askReady`).
+ *   4. THE CADENCE. `sessions - lastAskSession >= 3`, or `>= 2` on a 1-in-3
+ *      roll. The NAME ask is EXEMPT and spends nothing.
+ *   5. ONE ASK A SITTING. Session-local on purpose: banking it would make a
+ *      reload the way to farm a second one.
+ *
+ * ANY PRESS CANCELS, AND CANCELLING IS FREE. A pointerdown or a keypress that
+ * is not the strip's own ends the ask as `ignored` and spends NO cadence - the
+ * player was doing something else, and charging them three sessions for that
+ * would be the feature punishing them for playing the game. Touch always wins
+ * (trap 75's law, one level up).
+ *
+ * THE LISTENERS ARE TRAP 80's SHAPE. `document` pointerdown + keydown, both
+ * `{passive:true}`, both in the BUBBLE phase, neither ever calling
+ * `preventDefault` or `stopPropagation`, both removed on `destroy()`. EMI adds
+ * no rung to the Esc ladder here either: Esc dismisses the ask on its way past
+ * and the ladder never notices.
+ *
+ * INPUT TRUST (trap 59). `#arc-emi` is `pointer-events:none` and exactly two
+ * nodes turned it back on. The chips are the THIRD, and they are the only new
+ * pointer-active elements this wave mints. Nothing else on the layer changed.
+ * ==========================================================================*/
+
+/* THE SAY CADENCE IS THE WIDGET'S (voice.js's import, for the same reason):
+ * the strip has to land WITH the line, not with the typing dots, so this file
+ * needs to know how long the run-up actually is. */
+import { SAY_LEAD_MS, sanitizeAskName } from './widget.js';
+
+/* ONE SANITISER, TWO READERS. widget.js owns it because widget.js is the file
+ * that reads the stored `emi` blob back on boot; re-exported here so the ask
+ * table's own module is the one a caller (and the suite) reaches for. */
+export { sanitizeAskName };
+
+/* ---------------------- dials ------------------------------------------ */
+export const ASK_DIALS = Object.freeze({
+  ASK_FROM_SESSION: 3,        // gate 1
+  CADENCE_SESSIONS: 3,        // gate 4: the plain spacing
+  CADENCE_MIN_SESSIONS: 2,    // ...and the short one, on a roll
+  CADENCE_ROLL: 1 / 3,        // ...the roll
+  ASKS_PER_SESSION: 1,        // gate 5 (the NAME ask is over and above it)
+  GIVE_UP_MS: 40000,          // she waits this long, then gives up wordlessly
+  DARE_GIVE_UP_MS: 12000,     // ...but a dare lives on the room card, not the board
+  IGNORED_HOLD_MS: 1400,      // -_- , then `...` , then idle
+  /* THE STRIP LANDS WITH THE LINE, not with the typing dots - so its lead IS
+   * the say ladder's run-up. A dial and not a constant only so a suite can
+   * compress it; nothing else may ever change it. */
+  STRIP_LEAD_MS: SAY_LEAD_MS,
+  /* HOW LONG A LANDED LINE OWNS THE GLASS, near enough. Anything this file
+   * schedules AFTER one of her lines waits STRIP_LEAD_MS + this, so a follow-up
+   * never lands on a bubble that is still up (trap 72s lesson). */
+  AFTER_SAY_MS: 3400,
+  NAME_MAX: 8,                // a14: 8 characters, sanitised
+  NAME_REASK_AFTER: 10,       // a skipped name is asked once more, this many later
+  BED_SKIPS_GROGGY: 3,        // three skipped "bed?"s in a row buys the groggy greet
+  GROGGY_MS: 60000,           // ...and =_= holds that long
+  PET_ASK_ODDS: 0.25,         // a13 is rare even when it is eligible
+  LOVE_LEAD_MS: 1200,         // the `love` chain, before a13's line lands
+  DARE_XP: 15,                // DOCUMENTATION ONLY - the HOST owns the number
+});
+
+/** The moments this module is willing to be woken by. */
+export const ASK_TRIGGERS = Object.freeze([
+  'greet', 'classStart', 'idlePlayer', 'reportCard', 'streakBroken', 'exitAim',
+]);
+
+/** The three dare kinds, and the only strings the payout frame may carry. */
+export const DARE_KINDS = Object.freeze(['S', 'streak', 'fast']);
+
+/** The families a precision board belongs to - a08 is barred from both. */
+const PRECISION = Object.freeze({ tracking: true, reflex: true });
+
+/* ---------------------- helpers ---------------------------------------- */
+function isObj(v) { return !!v && typeof v === 'object' && !Array.isArray(v); }
+function intOf(v) { const n = Number(v); return Number.isFinite(n) && n > 0 ? Math.round(n) : 0; }
+
+/* ============================================================================
+ * THE TABLE
+ *
+ *   id       stable; it IS the store key under `emi.ask`. Renaming re-opens it.
+ *   on       one trigger from ASK_TRIGGERS.
+ *   q        the question, verbatim. `face` is the face it is asked with.
+ *   chips    exactly two labels, in order. Chip 1 is the YES side.
+ *   yes/no   {say, face} - the reaction, verbatim, through the ordinary say.
+ *   when(c)  every other gate this ask wants, over the context below.
+ *   once     'ever' (one answer for ever) | 'room' (once per gameKey) | null.
+ *   effect   what a YES actually does, by name; `runEffect` is the one switch.
+ *   dare     the kind flagged on the NEXT class ('S' | 'streak' | 'fast').
+ *   win/lose the dare's resolution lines, verbatim.
+ *   exempt   true = does not spend (or wait on) the cadence.
+ * ==========================================================================*/
+export const ASKS = Object.freeze([
+  /* ---- check-ins (she cares) ---------------------------------------- */
+  Object.freeze({
+    id: 'a01_roughday', on: 'greet',
+    q: 'rough day?', face: 'o_o',
+    chips: ['yeah', 'nah'],
+    yes: { say: 'ok. easy one today.', face: '^_^', effect: 'soft' },
+    no: { say: 'good. show me then.', face: '^_~' },
+    when: (c) => !c.firstSession,
+  }),
+  Object.freeze({
+    id: 'a02_sleep', on: 'greet',
+    q: 'did you sleep?', face: '(◔_◔)',
+    chips: ['yeah', 'nah'],
+    /* The YES is the humanity drop, so it spends the quirk slot the same way a
+     * `double` bark does - one a session, across every pool (voice.js's
+     * DOUBLES_PER_SESSION). `quirk:true` is how this file asks for it. */
+    yes: { say: 'good. me neither. wait.', face: '@_@', quirk: true },
+    no: { say: "same. we'll be slow together.", face: '=_=' },
+    when: (c) => c.hour < 11,
+  }),
+
+  /* ---- memory (she remembers) ---------------------------------------- */
+  Object.freeze({
+    id: 'a03_flavor', on: 'idlePlayer',
+    q: 'spiral or flash?', face: 'o_o',
+    chips: ['spiral', 'flash'],
+    /* The ANSWER is the point: `store` is the value banked under `.a`, so the
+     * callback pools in barks.js can read it back with `askIs:a03_flavor:...`. */
+    yes: { say: 'spiral. knew it.', face: '^_~', store: 'spiral' },
+    no: { say: 'flash. loud. i respect it.', face: '*_*', store: 'flash' },
+    once: 'ever',
+    when: (c) => c.where === 'hub',
+  }),
+  Object.freeze({
+    id: 'a04_room', on: 'classStart',
+    q: 'do you like it in here?', face: 'o_o',
+    chips: ['yeah', 'nah'],
+    yes: { say: "me too. it's got a hum.", face: '^_^' },
+    no: { say: 'we can leave after. one more though.', face: '._.' },
+    once: 'room',
+    when: (c) => !!c.gameKey,
+  }),
+  Object.freeze({
+    id: 'a05_morning', on: 'greet',
+    q: 'are you a morning person?', face: '(◔_◔)',
+    chips: ['yeah', 'nah'],
+    yes: { say: "i'm an all-the-time person.", face: '^___^' },
+    no: { say: 'same. mornings are a rumor.', face: '=_=' },
+    when: (c) => c.hour < 9,
+  }),
+
+  /* ---- for herself (she wants things) -------------------------------- */
+  Object.freeze({
+    id: 'a06_side', on: 'idlePlayer',
+    q: 'can i sit on the other side today?', face: '._.',
+    chips: ['ok', 'nah'],
+    yes: { say: 'thanks. new view.', face: '*_*', effect: 'mirror' },
+    no: { say: "ok. this side's fine. it's mine.", face: '-_-' },
+    when: (c) => c.where === 'hub',
+  }),
+  Object.freeze({
+    id: 'a07_onemore', on: 'reportCard',
+    q: 'one more? a small one?', face: '._.',
+    chips: ['ok', 'nah'],
+    yes: { say: 'small. i lied. pick any.', face: '^___^' },
+    no: { say: "fine. tomorrow then. i'll be here.", face: '^_^' },
+  }),
+  Object.freeze({
+    id: 'a08_watch', on: 'classStart',
+    q: 'can i watch this one up close?', face: 'o_o',
+    chips: ['ok', 'nah'],
+    yes: { say: 'front row.', face: '*_*', effect: 'watch' },
+    no: { say: "ok. i'll watch from here. i have good eyes.", face: 'o_o' },
+    when: (c) => !PRECISION[c.family],
+  }),
+
+  /* ---- dares (she is a gremlin) -------------------------------------- */
+  Object.freeze({
+    id: 'a09_dareS', on: 'classStart',
+    q: "bet you can't S this one.", face: '>_<',
+    chips: ['bet', 'nah'],
+    yes: { say: null, dare: 'S' },
+    no: { say: 'thought so.', face: '¬_¬' },
+    win: { say: "fine. you did it. i'm not sulking.", face: 'T_T', after: '^_^' },
+    lose: { say: 'told you. told you told you.', face: '^_~' },
+    when: (c) => !!c.gameKey && c.streak >= 1,
+  }),
+  Object.freeze({
+    id: 'a10_dareStreak', on: 'classStart',
+    q: "three in a row. bet you can't.", face: '>.<',
+    chips: ['bet', 'nah'],
+    yes: { say: null, dare: 'streak' },
+    no: { say: "smart. i'd have won.", face: '(¬‿¬)' },
+    win: { say: "ok that was cool. don't get used to it.", face: '*_*' },
+    lose: { say: "streak's mine now. i'm keeping it.", face: '^_~' },
+    when: (c) => c.streak === 2,
+  }),
+  Object.freeze({
+    id: 'a11_dareFast', on: 'classStart',
+    q: 'faster than last time. bet.', face: '0_0',
+    chips: ['bet', 'nah'],
+    yes: { say: null, dare: 'fast' },
+    no: { say: 'ok. no pressure. some pressure.', face: '^_~' },
+    win: { say: 'you blinked and it was over. show off.', face: '@_@' },
+    lose: { say: "slower. it's ok. i timed it wrong. probably.", face: '._.' },
+    when: (c) => c.family === 'reflex' && c.bestRt > 0,
+  }),
+
+  /* ---- shared streaks ------------------------------------------------- */
+  Object.freeze({
+    id: 'a12_goagain', on: 'streakBroken',
+    q: 'go again?', face: ';_;',
+    chips: ['yes', 'later'],
+    yes: { say: "yes. we're fixing it. right now.", face: '>_<', effect: 'timetable' },
+    no: { say: 'ok. streaks are fake anyway. mostly.', face: 'T_T' },
+  }),
+
+  /* ---- she pets back --------------------------------------------------- */
+  Object.freeze({
+    id: 'a13_pet', on: 'idlePlayer',
+    q: 'pet?', face: '._.',
+    chips: ['pet', 'nah'],
+    yes: { say: 'there it is.', face: '^___^', effect: 'pet' },
+    no: { say: "ok. i'll just sit here. pettably.", face: '-_-' },
+    when: (c) => c.pets >= 50,
+    odds: ASK_DIALS.PET_ASK_ODDS,
+  }),
+
+  /* ---- name her back --------------------------------------------------- */
+  Object.freeze({
+    id: 'a14_name', on: 'greet',
+    q: 'what do i call you?', face: 'o_o',
+    /* THE ONE ASK WITH A KEYBOARD. Chip 1 is an 8-character field (Enter
+     * submits, empty = skip); chip 2 is the ordinary out. */
+    input: true,
+    chips: ['ok', 'later'],
+    yes: { say: null, face: '^_^', effect: 'name' },
+    no: { say: "ok. 'you' works. i like you anyway.", face: '^_^' },
+    exempt: true,
+    /* NO `once` HERE, deliberately: the whole re-ask ladder (asked at 3, one
+     * more try ten sittings after a skip, then never) is in `when`, and a
+     * `once` gate on top of it would wall off the second try. */
+    /* Session 3 exactly; a skip re-opens it once, ten sessions later, and then
+     * never again (`n >= 2` is the wall). */
+    when: (c) => {
+      const prev = c.answerOf('a14_name');
+      if (!prev) return c.sessions === ASK_DIALS.ASK_FROM_SESSION;
+      if (prev.a === 'yes' || intOf(prev.n) >= 2) return false;
+      return c.sessions - intOf(prev.s) >= ASK_DIALS.NAME_REASK_AFTER;
+    },
+  }),
+
+  /* ---- bedtime ritual --------------------------------------------------- */
+  Object.freeze({
+    id: 'a15_bed', on: 'exitAim',
+    q: 'bed?', face: '=_=',
+    chips: ['yeah', 'not yet'],
+    yes: { say: "night. i'll keep the lights on.", face: 'ZzZ', effect: 'bedYes' },
+    no: { say: "ok. i'll pretend i'm not tired.", face: '=_=' },
+    /* THE FENCE. Never blocks, never delays, never cancels an exit, and there
+     * is no "don't go" anywhere in it. She just asks, and the window goes. */
+    exempt: true,
+  }),
+]);
+
+/** THE GROGGY GREET (a15's cost, three skips running). Verbatim. */
+export const GROGGY = Object.freeze({
+  say: 'morning. i think. what day is it.',
+  face: '@_@',
+  hold: '=_=',
+});
+
+/* ============================================================================
+ * createAsks
+ * ==========================================================================*/
+/**
+ * @param {Object} o
+ * @param {Object}  o.widget    the widget handle (askReady / mountAsk / the seams)
+ * @param {Object}  o.emi       the emi/index.js controller (say/emote)
+ * @param {Object=} o.voice     emi/voice.js - the sessions counter, read only
+ * @param {Object=} o.store     core/store.js - only ever read; the WIDGET writes
+ * @param {Array=}  o.table     the ASKS table (injected by the suite)
+ * @param {Function=} o.rng
+ * @param {Function=} o.now
+ * @param {Object=} o.dials
+ * @param {Function=} o.log
+ */
+export function createAsks(o = {}) {
+  const say = typeof o.log === 'function' ? o.log : () => {};
+  const widget = o.widget;
+  const emi = o.emi;
+  if (!widget || !emi || typeof emi.say !== 'function') return null;
+  if (typeof widget.askReady !== 'function' || typeof widget.mountAsk !== 'function') return null;
+
+  const D = Object.assign({}, ASK_DIALS, isObj(o.dials) ? o.dials : {});
+  const rng = typeof o.rng === 'function' ? o.rng : Math.random;
+  const clock = typeof o.now === 'function' ? o.now : Date.now;
+  const voice = isObj(o.voice) ? o.voice : null;
+  const store = o.store && typeof o.store.get === 'function' ? o.store : null;
+  const TABLE = (Array.isArray(o.table) ? o.table : ASKS)
+    .filter((a) => isObj(a) && typeof a.id === 'string' && typeof a.on === 'string');
+
+  /* ---------------------- the persisted half ---------------------------
+   * IT RIDES THE WIDGET'S `emi` BLOB AND THE WIDGET'S WRITER. There is exactly
+   * one thing on the page that writes the `emi` key, and it is widget.js's
+   * `save()` - a second writer would make every drag a race that eats a name.
+   * `widget.askState()` hands back the LIVE object; mutating it and calling
+   * `widget.askSave()` is the whole contract. */
+  const blob = widget.askState();
+
+  function answerOf(id) {
+    const row = blob.ask && blob.ask[String(id)];
+    return isObj(row) ? row : null;
+  }
+  function record(id, answer) {
+    const k = String(id);
+    const prev = answerOf(k);
+    if (!blob.ask) blob.ask = {};
+    blob.ask[k] = {
+      a: answer,
+      n: intOf(prev && prev.n) + 1,
+      s: sessions(),
+    };
+    widget.askSave(true);
+  }
+
+  function sessions() {
+    if (!voice) return 0;
+    const n = Number(voice.sessions);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  /* ---------------------- session-only state ---------------------------- */
+  const S = {
+    asked: 0,              // gate 5 (the NAME ask is not counted here)
+    midClass: false,
+    soft: false,           // a01 yes: comfort faces + the extra report line
+    softLineSpent: false,
+    bedAsked: false,       // a15 is once a sitting
+    dare: null,            // {kind, gameKey} - flagged on the NEXT class
+    dareSpent: false,      // one dare a session, win or lose
+    groggySpent: false,
+    lastWhere: null,
+  };
+
+  const timers = new Set();
+  function later(fn, ms) {
+    const id = setTimeout(() => { timers.delete(id); try { fn(); } catch (e) { /* noop */ } },
+      Math.max(0, ms | 0));
+    timers.add(id);
+    return id;
+  }
+  function killTimers() { for (const id of timers) clearTimeout(id); timers.clear(); }
+
+  /* ---------------------- the live ask ---------------------------------- */
+  /** {ask, strip, giveUp, landed} - null whenever no strip is up. */
+  let live = null;
+
+  function pageVisible() {
+    try {
+      if (typeof document === 'undefined') return true;
+      if (typeof document.visibilityState !== 'string') return true;
+      return document.visibilityState === 'visible';
+    } catch (e) { return true; }
+  }
+
+  function hourNow() {
+    try { return new Date(clock()).getHours(); } catch (e) { return 12; }
+  }
+
+  function bestRtOf(gameKey) {
+    if (!store || typeof store.gameMeta !== 'function' || !gameKey) return 0;
+    try { return intOf((store.gameMeta(gameKey) || {}).bestRtMs); } catch (e) { return 0; }
+  }
+
+  function streakNow(p) {
+    const n = Number(p && p.streak);
+    if (Number.isFinite(n)) return Math.round(n);
+    try {
+      if (store && typeof store.streak === 'function') return (store.streak().count | 0);
+    } catch (e) { /* noop */ }
+    return 0;
+  }
+
+  function petsNow() {
+    try { return intOf((emi.stats() || {}).pets); } catch (e) { return 0; }
+  }
+
+  function context(name, p) {
+    const pl = isObj(p) ? p : {};
+    const gameKey = typeof pl.gameKey === 'string' ? pl.gameKey : null;
+    return {
+      name,
+      p: pl,
+      sessions: sessions(),
+      firstSession: sessions() <= 1,
+      hour: hourNow(),
+      streak: streakNow(pl),
+      pets: petsNow(),
+      family: String(pl.family || ''),
+      gameKey,
+      where: typeof pl.where === 'string' ? pl.where : null,
+      bestRt: bestRtOf(gameKey),
+      name0: blob.name || '',
+      answerOf,
+      answered: (id) => !!answerOf(id),
+    };
+  }
+
+  /* ---------------------- eligibility ----------------------------------- */
+  /** The ONE-answer rules. `ever` = one answer for all time; `room` = one per
+   *  gameKey, which is why a04's ledger key carries the room on it. */
+  function keyFor(a, c) {
+    return a.once === 'room' && c.gameKey ? a.id + '|' + c.gameKey : a.id;
+  }
+  function spent(a, c) {
+    if (!a.once) return false;
+    const row = answerOf(keyFor(a, c));
+    /* AN IGNORED ASK IS NOT AN ANSWER. She may ask a `once` question again
+     * some other night; what she may never do is ask it again after you told
+     * her something. */
+    return !!row && row.a !== 'ignored';
+  }
+
+  function eligible(name, c) {
+    const out = [];
+    for (const a of TABLE) {
+      if (a.on !== name) continue;
+      if (spent(a, c)) continue;
+      if (a.id === 'a15_bed' && S.bedAsked) continue;
+      if (a.dareKind || (a.yes && a.yes.dare)) { if (S.dareSpent || S.dare) continue; }
+      if (typeof a.when === 'function') {
+        let ok = false;
+        try { ok = !!a.when(c); } catch (e) { ok = false; }
+        if (!ok) continue;
+      }
+      if (typeof a.odds === 'number' && a.odds < 1 && rng() >= a.odds) continue;
+      out.push(a);
+    }
+    return out;
+  }
+
+  /** GATE 4. The name ask is exempt: it neither waits on the cadence nor
+   *  spends it, which is what lets her learn your name on session three. */
+  function cadenceOpen() {
+    const last = intOf(blob.lastAskSession);
+    if (!last) return true;
+    const gap = sessions() - last;
+    if (gap >= D.CADENCE_SESSIONS) return true;
+    return gap >= D.CADENCE_MIN_SESSIONS && rng() < D.CADENCE_ROLL;
+  }
+
+  /* ---------------------- the strip ------------------------------------- */
+  function giveUpMsFor(a) {
+    /* A DARE LIVES ON THE ROOM CARD, NOT ON THE BOARD. `classStart` fires
+     * before the class chrome is built and long before a board takes input, so
+     * a dare that has not been answered by the time the player is actually
+     * playing has missed its window - it leaves rather than sitting over a
+     * precision board for another half minute. */
+    return (a.yes && a.yes.dare) || a.on === 'classStart' ? D.DARE_GIVE_UP_MS : D.GIVE_UP_MS;
+  }
+
+  function unmount(slide) {
+    if (!live) return;
+    const l = live;
+    live = null;
+    if (l.giveUp) { clearTimeout(l.giveUp); l.giveUp = null; }
+    try { widget.unmountAsk(slide !== false); } catch (e) { /* noop */ }
+  }
+
+  /** THE UNIVERSAL WORDLESS END. No line, ever - see the header. */
+  function ignored(a, c, opts) {
+    const noSpend = !!(opts && opts.noSpend);
+    unmount(true);
+    if (!noSpend) record(keyFor(a, c), 'ignored');
+    /* ...AND A PRESS IS NOT A SKIPPED BEDTIME EITHER. She only loses the sleep
+     * when the question sat there unanswered; a player who was doing something
+     * else was not saying no to bed. */
+    if (a.id === 'a15_bed' && !noSpend) {
+      blob.bedSkips = intOf(blob.bedSkips) + 1;
+      widget.askSave(true);
+    }
+    try {
+      widget.setBubble(null);
+      widget.raw('-_-', { hold: D.IGNORED_HOLD_MS, clearBubble: false, force: true });
+      widget.setBubble('...');
+    } catch (e) { /* a mascot may never break a screen transition */ }
+    say('emi asks: ' + a.id + ' ignored' + (noSpend ? ' (press - no cadence spent)' : ''));
+  }
+
+  function answer(a, c, which) {
+    const side = which === 'yes' ? a.yes : a.no;
+    if (!isObj(side)) { unmount(true); return; }
+    /* THE ANSWER IS WHAT IS STORED. Most asks bank 'yes'/'no'; a03 banks the
+     * FLAVOUR itself, because that is what the callback pools read back with
+     * `askIs:a03_flavor:spiral`. One field, `.a`, either way. */
+    const value = typeof side.store === 'string' ? side.store : which;
+    unmount(true);
+    record(keyFor(a, c), value);
+    /* THE CADENCE IS SPENT ON AN ANSWER, NOT ON AN OFFER. */
+    if (!a.exempt) { blob.lastAskSession = sessions(); }
+    widget.askSave(true);
+    if (side.quirk) { try { if (voice && typeof voice.spendQuirk === 'function') voice.spendQuirk(); } catch (e) { /* noop */ } }
+    if (which === 'yes') runEffect(a, side, c);
+    if (typeof side.say === 'string' && side.say) {
+      try { emi.say(side.say, { face: side.face || '^_^' }); } catch (e) { /* noop */ }
+    }
+    say('emi asks: ' + a.id + ' = ' + value);
+  }
+
+  /* ---------------------- the effects ----------------------------------- */
+  function runEffect(a, side, c) {
+    const kind = typeof side.effect === 'string' ? side.effect : null;
+    if (side.dare && DARE_KINDS.indexOf(side.dare) >= 0) {
+      S.dare = { kind: side.dare, gameKey: c.gameKey || null, id: a.id };
+      S.dareSpent = true;
+      say('emi asks: dare armed - ' + side.dare);
+      return;
+    }
+    if (!kind) return;
+    try {
+      if (kind === 'soft') { S.soft = true; return; }
+      if (kind === 'mirror') { widget.parkMirrored(); return; }
+      if (kind === 'watch') { widget.setGazeBias(-1); return; }
+      if (kind === 'timetable') { openTimetable(); return; }
+      if (kind === 'pet') { widget.creditPet(); return; }
+      if (kind === 'bedYes') { blob.bedSkips = 0; widget.askSave(true); return; }
+    } catch (e) { say('emi asks: effect "' + kind + '" threw (ignored)'); }
+  }
+
+  /**
+   * A12's YES OPENS THE TIMETABLE. The plaque IS the school's navigation seam
+   * (campus.js `.campus-boardtab`, whose click handler owns `boardOpenedDate`
+   * and rolls the flaps), so this presses the page's own button rather than
+   * minting a second way in. Not on the campus = nothing to open, and that is
+   * a silent no-op, never an error.
+   */
+  function openTimetable() {
+    try {
+      if (typeof document === 'undefined' || !document.querySelector) return false;
+      const tab = document.querySelector('.campus-stage .campus-boardtab');
+      if (!tab || typeof tab.click !== 'function') return false;
+      if (tab.getAttribute && tab.getAttribute('aria-expanded') === 'true') return false;
+      tab.click();
+      return true;
+    } catch (e) { return false; }
+  }
+
+  /* ---------------------- the name -------------------------------------- */
+  function submitName(a, c, raw) {
+    const clean = sanitizeAskName(raw);
+    if (!clean) { answer(a, c, 'no'); return; }
+    unmount(true);
+    blob.name = clean;
+    record(a.id, 'yes');
+    widget.askSave(true);
+    /* VERBATIM, with the one substitution the spec allows here. */
+    try { emi.say(clean + ". ok. i'm keeping that.", { face: '^_^' }); } catch (e) { /* noop */ }
+    say('emi asks: name = ' + clean);
+  }
+
+  /* ---------------------- mounting -------------------------------------- */
+  function mount(a, c) {
+    const chips = Array.isArray(a.chips) ? a.chips.slice(0, 2) : ['ok', 'nah'];
+    const giveUp = giveUpMsFor(a);
+    /* THE LINE FIRST, AND IT HOLDS FOR THE WHOLE ASK. `sayHoldMs` treats an
+     * explicit hold as a FLOOR it may raise and never lower, so handing it the
+     * give-up window is what keeps the question on the glass under the chips
+     * instead of expiring three seconds in. */
+    let spoke = false;
+    try { spoke = !!emi.say(a.q, { face: a.face || 'o_o', hold: giveUp }); }
+    catch (e) { spoke = false; }
+    if (!spoke) return false;
+
+    live = { ask: a, ctx: c, giveUp: null };
+    /* THE STRIP LANDS WITH THE LINE, not with the typing dots. A zero lead
+     * (a suite compressing the ladder) mounts on the spot rather than on a
+     * timer, so a synchronous test never has to await a 0ms setTimeout. */
+    const raise = () => {
+      if (!live || live.ask !== a) return;
+      let strip = null;
+      try {
+        strip = widget.mountAsk({
+          id: a.id,
+          chips,
+          input: a.input === true,
+          maxLength: D.NAME_MAX,
+          onChip: (i, text) => {
+            if (!live || live.ask !== a) return;
+            if (a.input && i === 0) { submitName(a, c, text); return; }
+            answer(a, c, i === 0 ? 'yes' : 'no');
+          },
+          onDismiss: () => { if (live && live.ask === a) ignored(a, c); },
+        });
+      } catch (e) { strip = null; }
+      if (!strip) { unmount(false); return; }
+      live.strip = strip;
+      live.giveUp = setTimeout(() => {
+        if (!live || live.ask !== a) return;
+        live.giveUp = null;
+        ignored(a, c);
+      }, giveUp);
+    };
+    if (D.STRIP_LEAD_MS > 0) later(raise, D.STRIP_LEAD_MS); else raise();
+
+    if (!a.exempt) S.asked += 1;
+    if (a.id === 'a15_bed') S.bedAsked = true;
+    say('emi asks: ' + a.id);
+    return true;
+  }
+
+  /* ---------------------- any press cancels ----------------------------- */
+  /* TRAP 80's SHAPE, one level up: passive, bubble phase, no preventDefault,
+   * no stopPropagation, never a rung on the Esc ladder. A press that lands on
+   * the strip itself is the ANSWER and is left alone; anything else ends the
+   * ask as ignored and spends NO cadence. */
+  function insideStrip(target) {
+    try {
+      if (!live || !live.strip || !live.strip.el || !target) return false;
+      const el = live.strip.el;
+      if (target === el) return true;
+      return !!(el.contains && el.contains(target));
+    } catch (e) { return false; }
+  }
+
+  const onDocDown = (ev) => {
+    if (!live) return;
+    if (insideStrip(ev && ev.target)) return;
+    ignored(live.ask, live.ctx, { noSpend: true });
+  };
+  const onDocKey = (ev) => {
+    if (!live || !ev) return;
+    const k = String(ev.key || '');
+    /* THE KEYBOARD REACH (spec): 1 and 2 pick the chips. Anything else is a
+     * player doing something else, and that is a dismiss. */
+    if (k === '1' || k === '2') {
+      if (live.strip && typeof live.strip.pick === 'function') { live.strip.pick(k === '1' ? 0 : 1); return; }
+    }
+    if (k === 'Tab' || k === 'Enter' || k === ' ') return;   // focus + activate
+    if (live.ask && live.ask.input && k.length === 1) return; // typing a name
+    if (live.ask && live.ask.input && (k === 'Backspace' || k === 'Delete')) return;
+    ignored(live.ask, live.ctx, { noSpend: true });
+  };
+  if (typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('pointerdown', onDocDown, { passive: true });
+    document.addEventListener('keydown', onDocKey, { passive: true });
+  }
+  /* The widget's own pointer verbs are the other half: a pet, a drag or a
+   * fling on EMI herself never reaches `document` before the widget acts. */
+  const unGesture = typeof widget.onGesture === 'function'
+    ? widget.onGesture((kind) => {
+      if (!live) return;
+      if (kind === 'pet' || kind === 'petStreak3' || kind === 'drag'
+        || kind === 'fling' || kind === 'dropAt' || kind === 'hide') {
+        ignored(live.ask, live.ctx, { noSpend: true });
+      }
+    })
+    : () => {};
+
+  /* ---------------------- the dares ------------------------------------- */
+  /**
+   * RESOLVE ON THE CLASS'S OWN END. `win` and `fail` both carry the grade, the
+   * gameKey and `perfect`; the reflex dare also needs `newBest`, which
+   * impulse-control now reports additively on `endClass` (trap 54's spirit).
+   * @returns {?string} the kind that WON, for the payout frame.
+   */
+  function resolveDare(name, p) {
+    const d = S.dare;
+    if (!d) return null;
+    S.dare = null;
+    const pl = isObj(p) ? p : {};
+    if (d.gameKey && pl.gameKey && d.gameKey !== pl.gameKey) return null;
+    const row = TABLE.find((a) => a.id === d.id) || null;
+    if (!row) return null;
+    let won = false;
+    if (d.kind === 'S') won = String(pl.grade || '').toLowerCase() === 's';
+    else if (d.kind === 'streak') won = name === 'win' && intOf(pl.streak) >= 3;
+    else if (d.kind === 'fast') won = pl.newBest === true;
+    const side = won ? row.win : row.lose;
+    if (isObj(side) && typeof side.say === 'string') {
+      try { emi.say(side.say, { face: side.face || '^_^' }); } catch (e) { /* noop */ }
+      /* a09's win resolves T_T -> ^_^: the sulk, then the smile. */
+      if (won && typeof side.after === 'string') {
+        later(() => { try { emi.emote(side.after, { hold: 1200 }); } catch (e) { /* noop */ } },
+          D.STRIP_LEAD_MS + D.AFTER_SAY_MS);
+      }
+    }
+    say('emi asks: dare ' + d.kind + ' ' + (won ? 'WON' : 'lost'));
+    return won ? d.kind : null;
+  }
+
+  /* ---------------------- the latches ----------------------------------- */
+  /**
+   * EVERY MOMENT, UNCONDITIONALLY. `offer` only sees the moments the voice and
+   * the field trips both declined; the latches below have to be right whether
+   * she spoke or not, so they live here and this is called first.
+   */
+  function note(name, p) {
+    try {
+      if (typeof name !== 'string') return;
+      if (name === 'classStart') {
+        /* The dare offer is evaluated BEFORE this latch closes (see `offer`),
+         * which is the whole reason the two entry points exist. */
+        S.midClass = true;
+        return;
+      }
+      if (name === 'win' || name === 'fail' || name === 'runLost') {
+        S.midClass = false;
+        try { widget.setGazeBias(0); } catch (e) { /* noop */ }
+        return;
+      }
+      if (name === 'reportCard' || name === 'greet' || name === 'dayDone') {
+        S.midClass = false;
+        try { widget.setGazeBias(0); } catch (e) { /* noop */ }
+        return;
+      }
+      if (name === 'idlePlayer') { S.lastWhere = (p && p.where) || null; }
+    } catch (e) { /* noop */ }
+  }
+
+  /**
+   * THE DARE'S RESOLUTION SEAM. shell.js calls this on the class's own end,
+   * before it posts `class-ended`, and puts the answer on the payout frame as
+   * `dareWon`. It is a READ of a session flag - it never blocks, and a page
+   * with no dare armed answers null on every class for ever.
+   */
+  function classResult(name, p) {
+    try { return resolveDare(name, p); } catch (e) { return null; }
+  }
+
+  /* ---------------------- the groggy greet ------------------------------ */
+  /**
+   * THREE SKIPPED "bed?"s COST HER THE MORNING (spec). This is the ONE thing in
+   * the file that runs BEFORE the voice, because it REPLACES the greet pool
+   * for exactly one greet - asking afterwards would put two lines on one beat.
+   * @returns {boolean} true when it took the moment.
+   */
+  function greetIntercept() {
+    try {
+      if (S.groggySpent) return false;
+      if (intOf(blob.bedSkips) < D.BED_SKIPS_GROGGY) return false;
+      if (!widget.askReady()) return false;
+      S.groggySpent = true;
+      blob.bedSkips = 0;
+      widget.askSave(true);
+      let spoke = false;
+      try { spoke = !!emi.say(GROGGY.say, { face: GROGGY.face }); } catch (e) { spoke = false; }
+      if (!spoke) return false;
+      /* ...and then she is just tired for a while. A plain held face, so any
+       * real reaction out-ranks it the instant one arrives. */
+      later(() => {
+        try { widget.raw(GROGGY.hold, { hold: D.GROGGY_MS }); } catch (e) { /* noop */ }
+      }, D.STRIP_LEAD_MS + D.AFTER_SAY_MS);
+      say('emi asks: groggy greet (three skipped beds)');
+      return true;
+    } catch (e) { return false; }
+  }
+
+  /* ---------------------- the comfort line ------------------------------ */
+  /** a01's YES buys ONE extra line on the report card, and only one. */
+  function softLine() {
+    if (!S.soft || S.softLineSpent) return false;
+    S.softLineSpent = true;
+    later(() => { try { emi.say('you did fine.', { face: '^_^' }); } catch (e) { /* noop */ } },
+      D.STRIP_LEAD_MS + D.AFTER_SAY_MS);
+    return true;
+  }
+
+  /* ---------------------- the one entry point --------------------------- */
+  /**
+   * `emi/index.js` offers every moment the voice AND the field trips declined.
+   * @returns {boolean} true when an ask took the moment.
+   */
+  function offer(name, payload) {
+    try {
+      if (typeof name !== 'string' || ASK_TRIGGERS.indexOf(name) < 0) return false;
+      if (live) return false;
+      if (!pageVisible()) return false;
+      if (!widget.askReady()) return false;
+      if (sessions() < D.ASK_FROM_SESSION) return false;
+      /* NOT MID-CLASS - and `classStart` is the one moment evaluated while the
+       * latch is still open, because the class has not started yet. */
+      if (S.midClass && name !== 'classStart') return false;
+
+      const c = context(name, payload);
+      if (name === 'reportCard' && softLine()) return false;
+
+      const list = eligible(name, c);
+      if (!list.length) return false;
+      /* THE EXEMPT ONE FIRST. The name ask neither waits on the cadence nor
+       * spends it, so it is picked out before the cadence is even consulted. */
+      const exempt = list.filter((a) => a.exempt === true);
+      if (exempt.length) return mount(exempt[Math.floor(rng() * exempt.length)] || exempt[0], c);
+      if (S.asked >= D.ASKS_PER_SESSION) return false;
+      if (!cadenceOpen()) return false;
+      const pick = list[Math.min(list.length - 1, Math.floor(rng() * list.length))];
+      return mount(pick, c);
+    } catch (e) {
+      say('emi asks: offer threw (ignored) - ' + ((e && e.message) || e));
+      return false;
+    }
+  }
+
+  return {
+    offer,
+    note,
+    classResult,
+    greetIntercept,
+    /** Read-only: the session flags the shell reads (a01's comfort faces). */
+    get flags() { return { soft: S.soft, midClass: S.midClass, dare: S.dare ? S.dare.kind : null }; },
+    /** The name she was given, or '' - never null, so a caller can concat. */
+    get name() { return blob.name || ''; },
+    /** Is a strip up right now? */
+    active() { return !!live; },
+    /** Test/debug: what could be asked on this moment, by id. */
+    candidates(name, payload) {
+      try { return eligible(name, context(name, payload)).map((a) => a.id); }
+      catch (e) { return []; }
+    },
+    state() {
+      return {
+        blob: JSON.parse(JSON.stringify({
+          ask: blob.ask || {}, name: blob.name || '',
+          lastAskSession: intOf(blob.lastAskSession), bedSkips: intOf(blob.bedSkips),
+        })),
+        session: Object.assign({}, S),
+        live: live ? live.ask.id : null,
+      };
+    },
+    dials: D,
+    /** Abort whatever is up. Not an answer, and it spends nothing. */
+    cancel() {
+      if (!live) return false;
+      ignored(live.ask, live.ctx, { noSpend: true });
+      return true;
+    },
+    destroy() {
+      killTimers();
+      unmount(false);
+      try { unGesture(); } catch (e) { /* noop */ }
+      if (typeof document !== 'undefined' && document.removeEventListener) {
+        document.removeEventListener('pointerdown', onDocDown);
+        document.removeEventListener('keydown', onDocKey);
+      }
+    },
+  };
+}
+
+export default createAsks;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -127,7 +127,11 @@ export const POOLS = Object.freeze({
       { t: "two days. the plants missed you. i have no plants.", face: ';_;' },
       { t: "you're back! full recap: nothing happened. i waited.", face: '^_^' },
       { t: "i practiced my hello. this was it. did it land?", face: '._.' },
-      { t: "day three was quiet. i don't recommend it.", face: ';_;', when: ['longAbsence:3'] }
+      { t: "day three was quiet. i don't recommend it.", face: ';_;', when: ['longAbsence:3'] },
+      /* EMI ASKS: the ONE greet name-drop. Gated `hasName` so an install that
+       * never answered a14 sees the pool it always had, and the token itself
+       * would collapse to the un-named variant even if it ever slipped through. */
+      { t: '{name}. you came back.', face: '^_^', when: ['hasName'] }
     ]
   },
 
@@ -551,7 +555,10 @@ export const POOLS = Object.freeze({
     lines: [
       { t: "a new best. i kept your old one. for contrast.", face: '(⌐■_■)', chain: 'cool',
         double: true },
-      { t: "new record. the old record says congrats. it's crying.", face: '\\o/' }
+      { t: "new record. the old record says congrats. it's crying.", face: '\\o/' },
+      /* EMI ASKS: the record stamp is the second of the three name-drop sites.
+       * Never in a dare, never at exit - see the spec's USE list. */
+      { t: "{name}. that's the one.", face: '*_*', when: ['hasName'] }
     ]
   },
 
@@ -687,6 +694,62 @@ export const POOLS = Object.freeze({
     lines: [
       { t: "i'm sorry dave. i'm afraid i can't do that.", face: '0_0', double: true },
       { t: "that button's on break. union rules. bulb union.", face: '-_-' }
+    ]
+  },
+
+  /* ==========================================================================
+   * THE ASK CALLBACKS (wave EMI ASKS, 2026-08-25)
+   *
+   * She asked, you answered, and some nights later she brings it up. Every one
+   * of these is gated on a STORED answer (`askIs` / `askAnswered`) and on the
+   * wait (`sessionsSinceAsk`), because a recall that lands the next evening
+   * reads as an echo and a recall three sittings later reads as memory. An
+   * IGNORED ask is not an answer and `askAnswered` refuses it, so she can
+   * never reference a conversation you declined to have.
+   * ======================================================================== */
+
+  /** a03's callback - "spiral or flash?", remembered. One line per answer, so
+   *  the pool is one line wide and noRepeat would simply mute it. */
+  askFlavorSpiral: {
+    on: 'classStart', when: ['askIs:a03_flavor:spiral', 'sessionsSinceAsk:a03_flavor:2'],
+    odds: 0.25, ceremony: false, priority: 30, noRepeat: false,
+    maxPerSession: 1, cooldownMs: 600000,
+    lines: [
+      { t: 'you said spiral. i remembered.', face: '^___^', double: true }
+    ]
+  },
+  askFlavorFlash: {
+    on: 'classStart', when: ['askIs:a03_flavor:flash', 'sessionsSinceAsk:a03_flavor:2'],
+    odds: 0.25, ceremony: false, priority: 30, noRepeat: false,
+    maxPerSession: 1, cooldownMs: 600000,
+    lines: [
+      { t: 'flash. your pick. i wrote it down.', face: '^___^', double: true }
+    ]
+  },
+
+  /** a04's callback - the room you said you liked. `askIs` carries the room on
+   *  the key (`a04_room|<gameKey>`), and voice.js has no per-game ledger of its
+   *  own, so the gate is the ROOM's own key through `gameIs`-shaped ids. */
+  askRoomLiked: {
+    on: 'classStart', when: ['askAnswered:a04_room|{game}', 'sessionsSinceAsk:a04_room|{game}:2'],
+    odds: 0.25, ceremony: false, priority: 28, noRepeat: false,
+    maxPerSession: 1, cooldownMs: 600000,
+    lines: [
+      { t: 'your room. the one you liked.', face: '^_^', when: ['askIs:a04_room|{game}:yes'] }
+    ]
+  },
+
+  /** w01 - SHE IS WRONG, on purpose. One sitting in twenty, and it shares the
+   *  humanity-quirk slot with every other `double` in the file (voice.js's
+   *  DOUBLES_PER_SESSION), which is what keeps two of them off one night. */
+  askMisremember: {
+    on: 'greet', when: ['askAnswered:a03_flavor'],
+    odds: 0.05, ceremony: false, priority: 26, noRepeat: false, maxPerSession: 1,
+    lines: [
+      { t: 'you said flash. no wait. spiral. right.', face: '@_@', double: true,
+        when: ['askIs:a03_flavor:spiral'] },
+      { t: 'you said spiral. no wait. flash. right.', face: '@_@', double: true,
+        when: ['askIs:a03_flavor:flash'] }
     ]
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
@@ -28,6 +28,8 @@ let singleton = null;
 let voice = null;
 /** emi/fieldtrips.js, once the voice it reads has landed. Null is normal. */
 let trips = null;
+/** emi/asks.js (wave EMI ASKS), on the same terms. Null is normal. */
+let asks = null;
 let voicePending = null;
 /** () => bool: can EMI actually PERFORM right now (is her face attached). */
 let voiceGate = null;
@@ -98,6 +100,9 @@ export function getVoice() { return voice; }
 /** The field-trip scheduler (emi/fieldtrips.js), once it has loaded. */
 export function getTrips() { return trips; }
 
+/** The ask engine (emi/asks.js), once it has loaded. Null is normal. */
+export function getAsks() { return asks; }
+
 /**
  * ASK THE VOICE, SAFELY. `moments.js` routes every moment through here before
  * it reaches the wordless table.
@@ -111,7 +116,21 @@ export function getTrips() { return trips; }
  */
 export function voiceMoment(name, payload) {
   try {
+    /* ASKS: THE LATCHES FIRST, AND UNCONDITIONALLY. `offer` below only ever
+     * sees the moments the voice AND the trips both declined, but the ask
+     * engine's bookkeeping - is a class up, did a dare just resolve, has the
+     * gaze bias expired - has to be right whether she spoke or not. Two entry
+     * points, one order, and this is the one that runs every time. */
+    if (asks) { try { asks.note(name, payload); } catch (e) { /* noop */ } }
     if (voice && voice.ready && (!voiceGate || voiceGate())) {
+      /* ...AND THE ONE THING THAT OUTRANKS THE VOICE. Three skipped "bed?"s
+       * buy a groggy morning, and it REPLACES the greet pool for exactly one
+       * greet - asked after the voice it would be a second line on one beat. */
+      if (name === 'greet' && asks) {
+        let took = false;
+        try { took = !!asks.greetIntercept(payload); } catch (e) { took = false; }
+        if (took) return true;
+      }
       if (voice.onMoment(name, payload)) return true;
       /* ...AND THEN THE FIELD TRIP (wave W2a). Asked LAST and only about the
        * moments it declares, so a night with a line in it is never also a night
@@ -121,7 +140,12 @@ export function voiceMoment(name, payload) {
        * The trips module is asked through the same wrapper the voice is, so a
        * scheduler that throws can no more reach a screen transition than a
        * decision engine that does. */
-      if (trips) return !!trips.offer(name, payload);
+      if (trips && trips.offer(name, payload)) return true;
+      /* ...AND THEN THE ASK (wave EMI ASKS). Last, for the same reason the
+       * trips are: a night with a line in it is never also a night she stops
+       * the player to ask a question. A launched ask answers true - the
+       * wordless table stands down because the bubble is already hers. */
+      if (asks) return !!asks.offer(name, payload);
       return false;
     }
     if (singleton) voicePending = { name, payload, when: Date.now() };
@@ -311,6 +335,10 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
     get voice() { return voice; },
     /** The field-trip scheduler (W2a), once it has loaded. Test/debug only. */
     get trips() { return trips; },
+    /** The ask engine (EMI ASKS), once it has loaded. The shell reads its
+     *  `flags` (a01's comfort faces) and its `classResult` (the dare payout);
+     *  everything else on it is a test/debug handle. */
+    get asks() { return asks; },
     /** Debug: the one moment waiting on the voice + the face, by name. */
     get pendingMoment() { return voicePending ? voicePending.name : null; },
 
@@ -331,12 +359,14 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
 
     destroy() {
       try { widget.destroy(); } catch (e) { /* noop */ }
+      try { if (asks) asks.destroy(); } catch (e) { /* noop */ }
       try { if (trips) trips.destroy(); } catch (e) { /* noop */ }
       try { if (voice) voice.destroy(); } catch (e) { /* noop */ }
       try { if (vox) vox.destroy(); } catch (e) { /* noop */ }
       vox = null;
       voice = null;
       trips = null;
+      asks = null;
       voicePending = null;
       voiceGate = null;
       if (singleton === api) singleton = null;
@@ -386,6 +416,15 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
         log: say,
       });
     }).catch((e) => { say('emi: fieldtrips.js unavailable (' + ((e && e.message) || e) + ')'); });
+    /* THE ASKS, ONE MORE STEP OUT (wave EMI ASKS, 2026-08-25). After the voice
+     * because it reads the voice's session counter and spends the voice's
+     * quirk slot, and optionally for the same reason everything else in this
+     * file is optional: a broken ask engine costs EMI her questions, never her
+     * face, her verbs or the shell's boot. */
+    import('./asks.js').then((a) => {
+      if (singleton !== api || !a || typeof a.createAsks !== 'function') return;
+      asks = a.createAsks({ widget, emi: api, voice, store, log: say });
+    }).catch((e) => { say('emi: asks.js unavailable (' + ((e && e.message) || e) + ')'); });
   }).catch((e) => { say('emi: voice.js unavailable (' + ((e && e.message) || e) + ')'); });
 
   return api;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/moments.js
@@ -99,6 +99,10 @@ export const MOMENTS = Object.freeze({
    *  locked glance, exactly as before. */
   classStart: {
     pick(p) {
+      /* EMI ASKS: a01's YES makes it a SOFT night, and a soft night is a
+       * kinder arrival - one face, over the top of the room's own. It changes
+       * nothing else: no line, no chain, no length. */
+      if (p && p.soft === true) return { face: '^_^', hold: 1400 };
       const FAMILY_FACE = {
         search: '(◔_◔)', memory: '._.', reflex: 'o_o', comfort: '=_=',
         tracking: '¬_¬', recall: '0_0', puzzle: '(◠‿◠)',

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/story.js
@@ -715,7 +715,10 @@ export const BEATS = deepFreeze([
     priority: 96,
     lead: 'wink',
     fx: 'sparks',
-    say: 'one whole year. gold star for us.',
+    /* EMI ASKS: the third and last name-drop site is a PREFIX, not a new line.
+     * With no name the `{name}` token and its punctuation are removed and this
+     * is byte for byte the line that shipped (voice.js resolveName). */
+    say: '{name}. one whole year. gold star for us.',
     face: '★★★'
   }
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
@@ -62,6 +62,10 @@
  *               off the dropAt payload (zone, zoneRow, zoneCount)
  * emi color     droppedOn:room|sealed|wing|none   what a dropAt landed on
  *               gameIs:KEY         which class fired the moment (per-game colour)
+ * emi asks      askAnswered:ID     she asked, and you told her something
+ *               askIs:ID:ANSWER    ...and this is what you said
+ *               sessionsSinceAsk:ID:N   at least N sittings since that answer
+ *               hasName            a14 landed and `emi.name` is set
  *
  * FREQUENCY FIELDS honoured on a pool or a line: odds, ceremony, priority,
  * noRepeat, cooldownMs, maxPerSession, maxPerClass, oncePerStreak, onceEver,
@@ -170,6 +174,35 @@ function gradeKey(g) {
 
 /** A line's identity for the heard counter, the no-repeat guard and onceEver. */
 function lineKey(l) { return (l && (l.id || l.t)) ? String(l.id || l.t) : ''; }
+
+/* ============================================================================
+ * THE NAME TOKEN (wave EMI ASKS, 2026-08-25)
+ *
+ * `{name}` is the ONE substitution this file performs, and the whole design is
+ * in what happens when there is no name: the token and the punctuation it
+ * brought with it are removed, and the line collapses to the variant that
+ * shipped. `'{name}. you came back.'` is `'you came back.'` on a install that
+ * never answered a14 - byte for byte the line it always was - so a name-drop
+ * can be written into an existing beat without forking it.
+ *
+ * It is never a fallback name. There is no "hey you", no "student": a token
+ * with nothing behind it is silence, which is the same rule the whole voice
+ * runs on.
+ * ==========================================================================*/
+const NAME_TOKEN = /\{name\}(\s*[.,!?:;-]\s*)?\s?/g;
+
+/** Resolve `{name}`. `name` empty/absent = the un-named variant. */
+export function resolveName(line, name) {
+  if (typeof line !== 'string' || line.indexOf('{name}') < 0) return line;
+  const n = typeof name === 'string' ? name.trim() : '';
+  if (!n) return line.replace(NAME_TOKEN, '').replace(/^\s+/, '');
+  return line.split('{name}').join(n);
+}
+
+/** Does this line ASK for the name? (A drop is rationed; a plain line is not.) */
+export function wantsName(line) {
+  return typeof line === 'string' && line.indexOf('{name}') >= 0;
+}
 
 /* ============================================================================
  * createVoice
@@ -293,6 +326,10 @@ export function createVoice(o) {
      * read as. Session-only on purpose - entering the lab and the app exit that
      * follows it are the same sitting. */
     flinchSuppress: false,
+    /* EMI ASKS: at most ONE name-drop a sitting (spec). A second line that
+     * wanted the name gets the un-named variant instead of being dropped - the
+     * beat still lands, it just does not say your name twice in a night. */
+    nameDropped: false,
   };
   S.openedBad = blob.lastSessionEnd === 'bad';
 
@@ -482,6 +519,41 @@ export function createVoice(o) {
     touch();
   }
 
+  /* ---------------------- the ask ledger (EMI ASKS) ---------------------
+   * READ-ONLY, ALWAYS. `emi/asks.js` collects the answers and widget.js is the
+   * one writer of the `emi` key; this file only ever looks. */
+  function askBlob() {
+    try {
+      const b = store && typeof store.get === 'function' ? store.get('emi') : null;
+      return isObj(b) ? b : null;
+    } catch (e) { return null; }
+  }
+  /**
+   * ONE ROW OF THE LEDGER. `{game}` in an id is substituted with the class
+   * that fired the moment, which is how the PER-ROOM ask (a04, banked as
+   * `a04_room|<gameKey>`) is asked about without minting a per-game predicate
+   * for every gate that wants one: `askIs:a04_room|{game}:yes`. No gameKey on
+   * the payload means no row, never a guess.
+   */
+  function askRow(id, c) {
+    const raw = String(id == null ? '' : id);
+    if (raw.indexOf('{game}') >= 0) {
+      const g = c && typeof c.gameKey === 'string' ? c.gameKey : '';
+      if (!g) return null;
+      return askRow(raw.split('{game}').join(g), c);
+    }
+    const b = askBlob();
+    const rows = b && isObj(b.ask) ? b.ask : null;
+    const r = rows && Object.prototype.hasOwnProperty.call(rows, raw) ? rows[raw] : null;
+    return isObj(r) ? r : null;
+  }
+  /** Her name for you, or ''. Never null: a caller may concatenate it. */
+  function playerName() {
+    const b = askBlob();
+    const n = b && typeof b.name === 'string' ? b.name.trim() : '';
+    return n;
+  }
+
   /** The punch cards, straight off the store's cache. Read-only, always. */
   function cardsBlob() {
     try {
@@ -637,6 +709,33 @@ export function createVoice(o) {
     /** Which class fired the moment - the per-game colour gate. Closed only
      *  by the payload: no gameKey, no match, never a guess. */
     gameIs: (a, c) => !!c.gameKey && c.gameKey === String(a),
+    /* --- the EMI ASKS wave (2026-08-25) --------------------------------- */
+    /** She asked and you answered - an IGNORED ask is deliberately NOT an
+     *  answer, so a callback can never reference a conversation you declined. */
+    askAnswered: (a, c) => { const r = askRow(a, c); return !!r && r.a !== 'ignored'; },
+    /** ...and this is what you said. `askIs:a03_flavor:spiral`. */
+    askIs: (a, c) => {
+      const raw = String(a == null ? '' : a);
+      const i = raw.lastIndexOf(':');
+      if (i < 0) return false;
+      const r = askRow(raw.slice(0, i), c);
+      return !!r && String(r.a) === raw.slice(i + 1);
+    },
+    /** At least N sittings since that answer - the callbacks wait, so a recall
+     *  reads as memory rather than as an echo. `sessionsSinceAsk:a03_flavor:2`. */
+    sessionsSinceAsk: (a, c) => {
+      const raw = String(a == null ? '' : a);
+      const i = raw.lastIndexOf(':');
+      if (i < 0) return false;
+      const r = askRow(raw.slice(0, i), c);
+      if (!r || r.a === 'ignored') return false;
+      const need = Number(raw.slice(i + 1)) || 0;
+      const at = Number(r.s);
+      if (!Number.isFinite(at) || at <= 0) return false;
+      return (blob.sessions - Math.round(at)) >= need;
+    },
+    /** a14 landed. The gate every name-drop line carries. */
+    hasName: () => !!playerName(),
     /** The LOCAL calendar date, MM-DD. Local on purpose: a holiday is the
      *  player's evening, not a UTC accountant's. */
     dateIs: (a) => {
@@ -700,10 +799,22 @@ export function createVoice(o) {
     return false;
   }
 
+  /**
+   * THE ONE PLACE `{name}` IS RESOLVED. The ration is spent HERE and only on a
+   * line that actually landed, so a bubble EMI could not draw never costs the
+   * night's one name-drop.
+   */
   function sayIt(line, face, nod) {
     if (typeof line !== 'string' || !line) return false;
-    try { return !!emi.say(line, { face: face || undefined, nod: nod === true }); }
+    const wants = wantsName(line);
+    const name = (wants && !S.nameDropped) ? playerName() : '';
+    const text = wants ? resolveName(line, name) : line;
+    if (!text) return false;
+    let done = false;
+    try { done = !!emi.say(text, { face: face || undefined, nod: nod === true }); }
     catch (e) { return false; }
+    if (done && wants && name) S.nameDropped = true;
+    return done;
   }
 
   /**
@@ -735,8 +846,15 @@ export function createVoice(o) {
       t += D.HELD_MS;
     }
     if (line) {
+      /* THE HOLD MEASURES THE LINE THE PLAYER WILL SEE. A `{name}` line is
+       * longer (or shorter) than the token, and a tail scheduled against the
+       * unresolved text would land on a bubble that is still up (trap 72's
+       * cousin). Resolved with the SAME ration `sayIt` will spend. */
+      const shown = wantsName(line)
+        ? resolveName(line, S.nameDropped ? '' : playerName())
+        : line;
       steps.push({ at: t, run: () => sayIt(line, entry.face, entry.nod) });
-      t += SAY_LEAD_MS + sayHoldMs(line);
+      t += SAY_LEAD_MS + sayHoldMs(shown);
     }
     if (entry.tail) steps.push({ at: t, run: () => emoteIt({ chain: entry.tail }) });
     if (!steps.length) return emoteIt(entry.emote);
@@ -1080,6 +1198,18 @@ export function createVoice(o) {
     },
     /** How many times EMI has been mounted, ever. The `sessionAtLeast` spine. */
     get sessions() { return blob.sessions; },
+
+    /* ---- THE EMI ASKS SEAM (2026-08-25) -------------------------------
+     * An ask's reaction can be a humanity drop (a02's "good. me neither.
+     * wait."), and the rarity of those is rationed ACROSS EVERY POOL by
+     * DOUBLES_PER_SESSION. A second ledger for the ask engine would let a
+     * night carry two of them, which is exactly the ratio the lock exists to
+     * hold. So the ask engine spends THIS one. */
+    spendQuirk() { const was = S.doubleSpent; S.doubleSpent = true; return !was; },
+    /** Has the quirk slot gone this sitting? Read-only. */
+    get quirkSpent() { return S.doubleSpent; },
+    /** Her name for you, or ''. Read-only - `emi/asks.js` owns the writing. */
+    get playerName() { return playerName(); },
     /** Test seams. A suite that rolls dice must not flake. */
     setRng(fn) { if (typeof fn === 'function') rng = fn; },
     setClock(fn) { if (typeof fn === 'function') clock = fn; },

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -130,6 +130,124 @@
   transform: translate(6px, -6px) skewX(30deg);
 }
 
+
+/* ---- ASKS: the chip strip (wave EMI ASKS, 2026-08-25) -------------------
+ * She asks a question and two chips hang under the line. The strip is a
+ * SIBLING of the bubble inside `.emi`, which is what makes the `.bubble-left`
+ * / `.bubble-low` flips apply to both halves off the same two root classes
+ * (trap 61) - there is no third orientation to keep in step.
+ *
+ * INPUT TRUST (trap 59). `.arc-emi` is `pointer-events:none` and exactly two
+ * nodes turned it back on. The CHIPS are the third and last; the strip that
+ * holds them stays inert, so the gap between two chips is still a click that
+ * reaches the board underneath.
+ *
+ * THE PIXEL GRID IS THE BUBBLE'S (trap 62): Press Start 2P at a WHOLE 8px, an
+ * absolute max-width, no clamp and no cqw. A chip is the same face as the line
+ * it sits under because it is the same voice.
+ *
+ * ONE NUMBER, TWO OWNERS. `--emi-ask-h` is the strip's measured height and it
+ * is what lifts the BUBBLE out of the way; `--emi-ask-dx` is widget.js's
+ * viewport clamp. The clamp is a custom property and not an inline transform
+ * because the slide keyframes below animate `transform`, and an inline one
+ * would be out-ranked for as long as they ran. */
+.arc-emi .emi .emi-ask {
+  position: absolute;
+  left: calc(58% + var(--emi-bubble-dx, 15px));
+  bottom: 96%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  width: max-content;
+  max-width: 148px;
+  z-index: 4;
+  pointer-events: none;
+  transform-origin: 0 100%;
+  transform: translateX(var(--emi-ask-dx, 0px));
+  animation: emi-ask-in 180ms ease-out both;
+}
+.arc-emi .emi .emi-ask[hidden] { display: none !important; }
+.arc-emi .emi .emi-ask.out { animation: emi-ask-out 200ms ease-in both; }
+
+/* The line moves up (or down) by exactly the strip's height plus a hair. */
+.arc-emi .emi.ask-up .emi-bubble { bottom: calc(96% + var(--emi-ask-h, 0px)); }
+.arc-emi .emi.bubble-left .emi-ask {
+  left: auto;
+  right: calc(58% + var(--emi-bubble-dx, 15px));
+  justify-content: flex-end;
+  transform-origin: 100% 100%;
+}
+.arc-emi .emi.bubble-low .emi-ask {
+  bottom: auto;
+  top: 96%;
+  transform-origin: 0 0;
+}
+.arc-emi .emi.bubble-low.bubble-left .emi-ask { transform-origin: 100% 0; }
+.arc-emi .emi.bubble-low.ask-up .emi-bubble {
+  bottom: auto;
+  top: calc(96% + var(--emi-ask-h, 0px));
+}
+
+/* ---- the chips ---------------------------------------------------------
+ * HER PALETTE: the YES chip wears the pink she is drawn in, the second wears
+ * the lavender alt, so the pair reads as a choice and not as a form. */
+.arc-emi .emi .emi-chip {
+  pointer-events: auto;
+  display: inline-block;
+  margin: 0;
+  padding: 5px 7px;
+  font-family: 'Press Start 2P', 'Noto Sans Mono', var(--mono, 'Cascadia Mono', 'Consolas', monospace);
+  font-weight: 400;
+  font-size: 8px;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-align: center;
+  color: #1A1A2E;
+  background: #F5F0E1;
+  border: 2px solid #FF69B4;
+  border-radius: 0;
+  box-shadow: 3px 3px 0 #0E0E1C;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.arc-emi .emi .emi-chip + .emi-chip { border-color: #B9A7F5; }
+.arc-emi .emi .emi-chip:hover { background: #FF69B4; color: #F5F0E1; }
+.arc-emi .emi .emi-chip + .emi-chip:hover { background: #B9A7F5; }
+.arc-emi .emi .emi-chip:active { transform: translate(1px, 1px); box-shadow: 2px 2px 0 #0E0E1C; }
+.arc-emi .emi .emi-chip:focus-visible { outline: 2px solid #FFD700; outline-offset: 2px; }
+/* a14's field: the one chip you type into. Never a chip you can press. */
+.arc-emi .emi .emi-chip-field {
+  width: 72px;
+  cursor: text;
+  text-align: left;
+  border-color: #FF69B4;
+}
+.arc-emi .emi .emi-chip-field:hover { background: #F5F0E1; color: #1A1A2E; }
+
+@keyframes emi-ask-in {
+  from { opacity: 0; transform: translate(var(--emi-ask-dx, 0px), 6px); }
+  to { opacity: 1; transform: translateX(var(--emi-ask-dx, 0px)); }
+}
+@keyframes emi-ask-out {
+  from { opacity: 1; transform: translateX(var(--emi-ask-dx, 0px)); }
+  to { opacity: 0; transform: translate(calc(var(--emi-ask-dx, 0px) + 10px), 0); }
+}
+
+/* REDUCED MOTION: no slide, in or out. widget.js drops the leave DELAY on the
+ * same reading, so the strip is simply gone rather than gone-after-220ms. */
+@media (prefers-reduced-motion: reduce) {
+  .arc-emi .emi .emi-ask,
+  .arc-emi .emi .emi-ask.out { animation: none; }
+  .arc-emi .emi .emi-chip:active { transform: none; }
+}
+:root.arc-reduced .arc-emi .emi .emi-ask,
+:root.arc-reduced .arc-emi .emi .emi-ask.out { animation: none; }
+:root.arc-reduced .arc-emi .emi .emi-chip:active { transform: none; }
+
+/* The phone gets the same rope the bubble does (see THE PHONE CLAMP below). */
+:root.arc-mobile .arc-emi .emi .emi-ask { max-width: min(72vw, 200px); }
+
 /* ---- the dock -----------------------------------------------------------
  * Where a dismissed EMI lives. Semi-transparent so it never competes with the
  * board, full strength the moment it is aimed at. */

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -260,6 +260,51 @@ function readStats(raw) {
   return s;
 }
 
+/* ASKS: THE NAME SANITISER, AND IT LIVES HERE ON PURPOSE ---------------------
+ * `emi/asks.js` collects the name and this file reads it back off the stored
+ * blob on every boot, so the rule has to be one function or the two readers
+ * drift. Her voice is lowercase: trim -> strip anything outside [a-z0-9 ] ->
+ * collapse the runs -> 8 characters. An empty answer is a SKIP, never an empty
+ * name - `emi.name` is either a real string or absent. */
+export const ASK_NAME_MAX = 8;
+export function sanitizeAskName(raw) {
+  if (typeof raw !== 'string') return '';
+  let s = raw.toLowerCase().replace(/[^a-z0-9 ]+/g, '');
+  s = s.replace(/\s+/g, ' ').trim();
+  if (s.length > ASK_NAME_MAX) s = s.slice(0, ASK_NAME_MAX).trim();
+  return s;
+}
+
+/* ASKS: THE LEDGER, READ OFF THE SAME `emi` BLOB EVERYTHING ELSE RIDES.
+ * There is exactly ONE writer of the `emi` key on this page (save() below), so
+ * the ask ledger is spliced into that blob rather than minting a second key -
+ * two writers of one key is how a drag comes to eat a name. Every field is
+ * re-derived defensively: an unreadable ledger starts clean and never throws. */
+function readAskState(raw) {
+  const src = raw && typeof raw === 'object' ? raw : {};
+  const out = { ask: {}, name: sanitizeAskName(src.name), lastAskSession: 0, bedSkips: 0 };
+  const n = Number(src.lastAskSession);
+  if (Number.isFinite(n) && n > 0) out.lastAskSession = Math.round(n);
+  const b = Number(src.bedSkips);
+  if (Number.isFinite(b) && b > 0) out.bedSkips = Math.round(b);
+  const rows = src.ask;
+  if (rows && typeof rows === 'object' && !Array.isArray(rows)) {
+    for (const k of Object.keys(rows)) {
+      const r = rows[k];
+      if (!r || typeof r !== 'object') continue;
+      if (typeof r.a !== 'string' || !r.a) continue;
+      const cnt = Number(r.n);
+      const ses = Number(r.s);
+      out.ask[k] = {
+        a: r.a.slice(0, 16),
+        n: Number.isFinite(cnt) && cnt > 0 ? Math.round(cnt) : 1,
+        s: Number.isFinite(ses) && ses > 0 ? Math.round(ses) : 0,
+      };
+    }
+  }
+  return out;
+}
+
 /* ============================================================================
  * createWidget
  * ==========================================================================*/
@@ -295,6 +340,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   } catch (e) { say('emi: store read failed - ' + ((e && e.message) || e)); }
 
   const stats = readStats(saved.stats);
+  /* ASKS: the ask ledger, on the same blob and the same writer (see above). */
+  const askState = readAskState(saved);
   /* WIDTH IS A DEFAULT UNTIL SOMEBODY SETS IT. A stored `w` only exists once a
    * resize verb has run (`setWidth`; there is no resize UI yet), so out of the
    * box she follows the window: full size on a roomy one, smaller on a narrow
@@ -343,6 +390,15 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     // viewport rule for ever after the first drag.
     if (userSized && userWidth != null) b.w = userWidth;
     if (hintShown) b.hintShown = true;
+    /* ASKS: the ledger rides out with everything else. Written only when there
+     * is something to write, so a player who has never been asked anything
+     * keeps the blob they always had. */
+    if (askState.name) b.name = askState.name;
+    if (askState.lastAskSession) b.lastAskSession = askState.lastAskSession;
+    if (askState.bedSkips) b.bedSkips = askState.bedSkips;
+    if (askState.ask && Object.keys(askState.ask).length) {
+      b.ask = JSON.parse(JSON.stringify(askState.ask));
+    }
     return b;
   }
 
@@ -392,6 +448,16 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   bubble.className = 'emi-bubble';
   bubble.hidden = true;
 
+  /* ASKS: THE STRIP. One node, minted at birth and empty at rest, so an ask
+   * costs no DOM churn and a page that never asks anything carries one hidden
+   * div. It is a SIBLING of the bubble inside `.emi`, which is what makes the
+   * `.bubble-left` / `.bubble-low` flips apply to both halves for free (the
+   * CSS mirrors them off the same root classes - trap 61). */
+  const askStrip = document.createElement('div');
+  askStrip.className = 'emi-ask';
+  askStrip.hidden = true;
+  if (askStrip.setAttribute) askStrip.setAttribute('role', 'group');
+
   const xBtn = document.createElement('button');
   xBtn.className = 'emi-x';
   xBtn.type = 'button';
@@ -412,6 +478,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   el.appendChild(canvas);
   el.appendChild(fxHost);
   el.appendChild(bubble);
+  el.appendChild(askStrip);      // ASKS
   el.appendChild(xBtn);
 
   const dock = document.createElement('button');
@@ -577,11 +644,27 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     width = next;
     return true;
   }
+  /* ASKS: a06's session-only spot, {x,y} in viewport fractions. NEVER saved. */
+  let askSpot = null;
+
   /** Place EMI from the stored fractions, clamped inside the viewport. */
   function place() {
     const vp = viewport();
     const s = sizePx();
     const m = margin();
+    /* ASKS (a06): "can i sit on the other side today?" is a SESSION move, not
+     * a new home. The fractions are never touched, so tomorrow she is back
+     * where the player left her; this override is what keeps her on the other
+     * side across a resize in the meantime, and it dies with the sitting. */
+    if (askSpot) {
+      const l2 = clamp(askSpot.x * vp.w, m, Math.max(m, vp.w - s.w - m));
+      const t2 = clamp(askSpot.y * vp.h, m, Math.max(m, vp.h - s.h - m));
+      el.style.width = s.w + 'px';
+      el.style.left = Math.round(l2) + 'px';
+      el.style.top = Math.round(t2) + 'px';
+      faceBubble(l2, t2, s.w, vp.w);
+      return { left: l2, top: t2, s, vp };
+    }
     if (fx0 == null || fy0 == null) {
       /* First run: park her bottom-right, clear of the dock's corner. A phone has
        * no room for the desktop's 24/56 standoff, so she docks tight into the
@@ -614,6 +697,11 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     else el.classList.remove('bubble-left');
     if (top < BUBBLE_RISE) el.classList.add('bubble-low');
     else el.classList.remove('bubble-low');
+    /* ASKS: the strip rides the same two flips (the CSS mirrors it off these
+     * exact root classes), and then gets the SAME viewport clamp the bubble's
+     * reach test is - measured, because a strip is wider than a bark and the
+     * reach heuristic above was calibrated for a 104px box. */
+    clampAskStrip();
   }
 
   /** Record the CURRENT pixel position back into the fractions. */
@@ -968,6 +1056,21 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     return !!(tgt.closest && tgt.closest('.emi-x'));
   }
 
+  /* ASKS: A PRESS ON A CHIP IS THE CHIP'S, NOT EMI'S. The strip lives INSIDE
+   * `.emi`, so without this every chip press would run the drag handler below -
+   * which calls `setPointerCapture` on the root and `preventDefault()`, and
+   * between them the browser retargets the release and never fires the chip's
+   * own `click` at all. Caught by the browser pass; the DOM double cannot see
+   * it, because it has neither pointer capture nor compatibility events. The
+   * x button has had exactly this guard since day one, for the same reason. */
+  function inAsk(ev) {
+    const tgt = ev && ev.target;
+    if (!tgt) return false;
+    if (tgt === askStrip) return true;
+    if (tgt.closest) return !!tgt.closest('.emi-ask');
+    return !!(askStrip.contains && askStrip.contains(tgt));
+  }
+
   function onDown(ev) {
     if (!enabled || hidden) return;
     /* TOUCH ALWAYS WINS (W2a, trap 75). A finger on her at ANY point of a field
@@ -977,6 +1080,9 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     // The x is a real button: let it have its own click, and never start a drag
     // from it (a dismiss that could turn into a fling is a trap, not a feature).
     if (inX(ev)) return;
+    // ASKS: and a chip is a real button too - see inAsk(). No drag, no pet, no
+    // capture, no preventDefault: the strip's own click is the whole event.
+    if (inAsk(ev)) return;
     pressing = true;
     dragging = false;
     wasFling = false;
@@ -1003,6 +1109,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
 
   function beginDrag() {
     dragging = true;
+    /* ASKS (a06): the player picking her up out-votes "the other side today".
+     * A session spot that survived a drag would fight the drop on every
+     * resize, and the drop is always the more recent word. */
+    askSpot = null;
     stats.drags += 1;
     touchSeen();
     el.classList.add('dragging');
@@ -1265,6 +1375,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
    * the voice hears `approach`/`hoverLinger` through the same gesture tap as
    * every pointer verb (no pools yet - wave 2b's writing slot). */
   let gazeTX = 0, gazeTY = 0, gazeX = 0, gazeY = 0, gazeRaf = null;
+  /* ASKS (a08): a standing lean toward the board, -1..1, cleared at the end of
+   * the class. It is ADDED to the cursor lean and clamped with it, so "front
+   * row" reads as a tilt she is holding, never as a face stuck off-centre. */
+  let askGaze = 0;
   let apInside = false, apCoolUntil = 0, apPets0 = 0;
   let apLingerTimer = null, apAwayTimer = null;
   let apLastX = 0, apLastY = 0, apLastT = 0;
@@ -1274,7 +1388,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   }
   function gazeStep() {
     gazeRaf = null;
-    const ax = gazeActive() ? gazeTX : 0;
+    /* ASKS: the standing bias rides the same clamp the cursor lean does, so
+     * "front row" can never push the glyph further than GAZE_MAX_PX. */
+    const bias = askGaze * DIALS.GAZE_MAX_PX;
+    const ax = gazeActive() ? clamp(gazeTX + bias, -DIALS.GAZE_MAX_PX, DIALS.GAZE_MAX_PX) : 0;
     const ay = gazeActive() ? gazeTY : 0;
     gazeX += (ax - gazeX) * DIALS.GAZE_EASE;
     gazeY += (ay - gazeY) * DIALS.GAZE_EASE;
@@ -1295,7 +1412,10 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
       gazeRaf = requestAnimationFrame(gazeStep);
     }
   }
-  /** Ease the lean home NOW (a hide, a disable, a drag taking over). */
+  /** Ease the lean home NOW (a hide, a disable, a drag taking over). The
+   *  ASKS bias is deliberately NOT cleared here: it belongs to the class, and
+   *  `gazeActive()` already parks the whole lean at 0 while anything else owns
+   *  the glass, so it simply comes back when she is idle again. */
   function restGaze() {
     gazeTX = 0; gazeTY = 0;
     nudgeGaze();
@@ -1746,7 +1866,11 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
    * @param {Function|Object} getRect  a RECT-GETTER, e.g.
    *        `() => node.getBoundingClientRect()`. A bare rect is accepted and is
    *        a bug waiting to happen - see law 1 and trap 73.
-   * @param {{line?:string, face?:string, onDone?:Function}=} opts
+   * @param {{line?:string, face?:string, stay?:boolean, onDone?:Function}=} opts
+   *        ASKS (a06): `stay` ends the trip WHERE SHE LANDED instead of walking
+   *        the two beats home. The spot is session-only (`askSpot`) and the
+   *        stored fractions are never touched, so tomorrow she is back where
+   *        the player actually put her.
    * @returns {Function|null} a cancel function, or null when she refused.
    */
   function apparate(getRect, opts) {
@@ -1804,6 +1928,20 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
           if (!spoke) { setBubble(line); wait = sayHoldMs(line) + DIALS.TRIP_BEAT_MS; }
         }
         tripStep(wait, () => {
+          /* ASKS (a06): a `stay` trip is over the moment the line is. She keeps
+           * the spot for the sitting; nothing is committed and nothing saved. */
+          if (o.stay) {
+            const t2 = trip;
+            trip = null;
+            crtClear();
+            const vp2 = viewport();
+            askSpot = { x: (t2 ? t2.left : 0) / vp2.w, y: (t2 ? t2.top : 0) / vp2.h };
+            idle();
+            if (t2 && typeof t2.onDone === 'function') {
+              try { t2.onDone({ cancelled: false, stay: true }); } catch (e) { /* noop */ }
+            }
+            return;
+          }
           /* 4. HOME. The same two beats, backwards. */
           cancelChain();
           killTimers();
@@ -1832,6 +1970,250 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
 
     return () => cancelTrip();
   }
+
+
+  /* ==========================================================================
+   * ASKS (wave EMI ASKS, 2026-08-25) - ONE BLOCK, DELIBERATELY.
+   *
+   * `emi/asks.js` decides WHEN she asks and WHAT the words are. Everything
+   * below is the HOW: the two chips, the seams the effects need, and the one
+   * honest answer to "may she ask right now".
+   *
+   * INPUT TRUST (trap 59). `#arc-emi` is `pointer-events:none` and exactly two
+   * nodes turned it back on (`.emi`, `.emi-dock`). `.emi-ask .emi-chip` is the
+   * THIRD and last, it is live only while a strip is up, and nothing else on
+   * the layer changed. `preventDefault` is still called in exactly one place
+   * (the `pointerdown` on `.emi`) and still on no document listener.
+   *
+   * THE STRIP IS NOT A CHAIN. It is plain DOM with its own lifetime, so it
+   * survives the say it hangs under and is torn down by exactly one function.
+   * ======================================================================== */
+
+  /** {onChip, onDismiss, nodes} while a strip is up; null the rest of the time. */
+  let askLive = null;
+  /** The viewport clamp, in px, shared with the sheet as `--emi-ask-dx`. */
+  let askDx = 0;
+  function setAskDx(px) {
+    try {
+      if (el.style && typeof el.style.setProperty === 'function') {
+        el.style.setProperty('--emi-ask-dx', Math.round(Number(px) || 0) + 'px');
+      }
+    } catch (e) { /* noop */ }
+  }
+
+  /** THE STRIP NEVER LEAVES THE WINDOW. The bubble's reach test (faceBubble)
+   *  is a heuristic calibrated for a 104px box; a two-chip strip is wider than
+   *  that, so it is MEASURED and pulled back in with a transform. A platform
+   *  with no getBoundingClientRect (the node DOM double) simply skips it. */
+  function clampAskStrip() {
+    if (!askLive || askStrip.hidden) return;
+    try {
+      if (!askStrip.getBoundingClientRect) return;
+      const had = askDx;
+      askDx = 0;
+      setAskDx(0);
+      const r = askStrip.getBoundingClientRect();
+      if (!r || !r.width) { askDx = had; setAskDx(had); return; }
+      const vp = viewport();
+      const pad = 4;
+      let dx = 0;
+      if (r.right > vp.w - pad) dx = Math.round((vp.w - pad) - r.right);
+      if (r.left + dx < pad) dx = Math.round(pad - r.left);
+      askDx = dx;
+      setAskDx(dx);
+    } catch (e) { /* a clamp may never be the thing that throws */ }
+  }
+
+  /** How tall the strip is, handed to the sheet so the BUBBLE can move up out
+   *  of its way. One number, one custom property - the same trick the bubble's
+   *  own `--emi-bubble-dx` uses (trap 62's lesson: whole pixels, no guessing). */
+  function askLift() {
+    let h = 0;
+    try { h = Math.round(Number(askStrip.offsetHeight) || 0); } catch (e) { h = 0; }
+    try {
+      if (el.style && typeof el.style.setProperty === 'function') {
+        el.style.setProperty('--emi-ask-h', (h > 0 ? h + 6 : 0) + 'px');
+      }
+    } catch (e) { /* noop */ }
+  }
+
+  function fireChip(i, text) {
+    if (!askLive) return;
+    const cb = askLive.onChip;
+    try { cb(Math.max(0, i | 0), typeof text === 'string' ? text : ''); }
+    catch (e) { /* a chip may never break a screen transition */ }
+  }
+
+  /**
+   * MOUNT ONE STRIP. `spec` is asks.js's, and this file understands exactly
+   * five fields: {id, chips[2], input, maxLength, onChip(i, text), onDismiss}.
+   * @returns {?Object} {el, pick(i), destroy()} - null when it could not build.
+   */
+  function mountAsk(spec) {
+    if (!spec || !Array.isArray(spec.chips) || !spec.chips.length) return null;
+    if (!enabled || hidden) return null;
+    unmountAsk(false);
+    try {
+      askStrip.textContent = '';
+      askStrip.classList.remove('out');
+      if (askStrip.setAttribute) askStrip.setAttribute('data-ask', String(spec.id || ''));
+      const nodes = [];
+      let field = null;
+
+      /* THE NAME ASK IS THE ONE WITH A KEYBOARD (a14). Chip 1 becomes an
+       * 8-character field; Enter submits it and an empty one is a skip, which
+       * asks.js decides - this file only hands the text over. */
+      if (spec.input === true) {
+        field = document.createElement('input');
+        field.className = 'emi-chip emi-chip-field';
+        if (field.setAttribute) {
+          field.setAttribute('type', 'text');
+          field.setAttribute('maxlength', String(spec.maxLength || ASK_NAME_MAX));
+          field.setAttribute('aria-label', 'your name');
+          field.setAttribute('autocomplete', 'off');
+          field.setAttribute('spellcheck', 'false');
+        }
+        field.addEventListener('keydown', (ev) => {
+          if (!ev || ev.key !== 'Enter') return;
+          fireChip(0, field.value == null ? '' : String(field.value));
+        });
+        askStrip.appendChild(field);
+        nodes.push(field);
+      }
+
+      spec.chips.forEach((label, i) => {
+        if (spec.input === true && i === 0) return;   // the field IS chip one
+        const b = document.createElement('button');
+        b.className = 'emi-chip';
+        b.type = 'button';
+        b.textContent = String(label == null ? '' : label);
+        if (b.setAttribute) b.setAttribute('data-chip', String(i));
+        b.addEventListener('click', () => {
+          fireChip(i, field && i === 0 ? String(field.value || '') : '');
+        });
+        askStrip.appendChild(b);
+        nodes.push(b);
+      });
+
+      askStrip.hidden = false;
+      askLive = {
+        onChip: typeof spec.onChip === 'function' ? spec.onChip : () => {},
+        onDismiss: typeof spec.onDismiss === 'function' ? spec.onDismiss : () => {},
+        nodes, field,
+      };
+      askLift();
+      el.classList.add('ask-up');
+      clampAskStrip();
+      /* FOCUS THE FIELD, NEVER A CHIP. Stealing focus onto a button would put
+       * a school-wide Enter on EMI; the field is the one place a keystroke is
+       * unambiguously hers. */
+      try { if (field && field.focus) field.focus(); } catch (e) { /* noop */ }
+      return {
+        el: askStrip,
+        pick(i) { fireChip(i, field ? String(field.value || '') : ''); },
+        destroy() { unmountAsk(false); },
+      };
+    } catch (e) {
+      say('emi: ask strip failed (' + ((e && e.message) || e) + ')');
+      unmountAsk(false);
+      return null;
+    }
+  }
+
+  /**
+   * TAKE IT DOWN. `slide` plays the leave animation first (the CSS owns it and
+   * reduced motion drops it to a plain hide); anything urgent passes false.
+   */
+  function unmountAsk(slide) {
+    if (!askLive) {
+      try { askStrip.hidden = true; askStrip.textContent = ''; } catch (e) { /* noop */ }
+      return false;
+    }
+    askLive = null;
+    try { el.classList.remove('ask-up'); } catch (e) { /* noop */ }
+    try {
+      if (el.style && typeof el.style.setProperty === 'function') el.style.setProperty('--emi-ask-h', '0px');
+    } catch (e) { /* noop */ }
+    const drop = () => {
+      try {
+        askStrip.hidden = true;
+        askStrip.textContent = '';
+        askStrip.classList.remove('out');
+        askDx = 0;
+        setAskDx(0);
+      } catch (e) { /* noop */ }
+    };
+    if (slide && !reducedMotion()) {
+      try { askStrip.classList.add('out'); } catch (e) { /* noop */ }
+      later(drop, 220);
+    } else {
+      drop();
+    }
+    return true;
+  }
+
+  /** MAY SHE ASK RIGHT NOW. One honest answer, owned by the file that owns the
+   *  verbs: no live say, no chain, no press, no drag, no field trip, no off
+   *  channel, not dismissed, not disabled, and no strip already up. */
+  function askReady() {
+    if (!enabled || hidden || !built) return false;
+    if (askLive || trip || pressing || dragging) return false;
+    if (busy() || saying()) return false;
+    try {
+      if (deck && typeof deck.live === 'function' && deck.live()) return false;
+    } catch (e) { /* a deck that cannot be asked is not a deck that is up */ }
+    return true;
+  }
+
+  /* ---- the effects a YES buys ----------------------------------------- */
+
+  /** a06: THE OTHER SIDE. The mirrored x, through `apparate` and its rect
+   *  GETTER (trap 73 - the rect is resolved inside the dark, one frame before
+   *  she lands, so a resize mid-trip cannot strand her). `stay` is what makes
+   *  it a move rather than a round trip. */
+  function parkMirrored() {
+    if (trip) return false;
+    const getRect = () => {
+      const vp = viewport();
+      const sz = sizePx();
+      let cur = null;
+      try { cur = el.getBoundingClientRect ? el.getBoundingClientRect() : null; } catch (e) { cur = null; }
+      const left = cur && Number.isFinite(Number(cur.left)) ? Number(cur.left) : (fx0 || 0) * vp.w;
+      const top = cur && Number.isFinite(Number(cur.top)) ? Number(cur.top) : (fy0 || 0) * vp.h;
+      const mx = clamp(vp.w - left - sz.w, DIALS.MARGIN, Math.max(DIALS.MARGIN, vp.w - sz.w - DIALS.MARGIN));
+      /* A rect she can stand BESIDE. anchorFor() puts her off the side of it,
+       * so the target is a thin sliver at the mirrored x rather than a box she
+       * would be pushed out of. */
+      return { left: mx, top, right: mx + 1, bottom: top + sz.h, width: 1, height: sz.h };
+    };
+    return !!apparate(getRect, { stay: true });
+  }
+
+  /** a08: SHE WATCHES THE BOARD. A constant added to the gaze lean for the
+   *  rest of the class - the same CSS translate on `.emi-screen` the cursor
+   *  lean already uses (trap 71), never a canvas repaint. `dir` is -1 (toward
+   *  the middle of the school, which is where every board is) or 0 to clear. */
+  function setGazeBias(dir) {
+    const d = Number(dir);
+    askGaze = Number.isFinite(d) ? clamp(d, -1, 1) : 0;
+    nudgeGaze();
+    return askGaze;
+  }
+
+  /** a13: THE CHIP IS A PET. Same counter, same ledger, same `love` beat - a
+   *  second kind of pet that did not count would be the joke not landing. */
+  function creditPet() {
+    if (!enabled || hidden) return false;
+    stats.pets += 1;
+    touchSeen();
+    const cycle = CHAINS && CHAINS.love;
+    if (cycle) play(cycle, { bodyFrame: 'pet', force: true });
+    else raw('(\u3002\u2665\u203f\u2665\u3002)', { hold: 1400, fx: 'hearts', body: 'bounce', bodyFrame: 'pet', force: true });
+    save();
+    emitGesture('pet', { fromAsk: true });
+    return true;
+  }
+  /* ===================== end of the asks ================================ */
 
   /** THE REGISTRY SEAM. `emi/fieldtrips.js` hands over a function answering the
    *  live rects of every fixture EMI has a line about; the widget uses them for
@@ -1869,6 +2251,15 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     /* W2a - the field trip. `apparate` takes a RECT-GETTER (trap 73), refuses
      * over any live verb, and answers a cancel function or null. */
     apparate, setPoiRects, tripping,
+    /* ---- ASKS (2026-08-25): the strip, and the four seams an effect needs -
+     * `emi/asks.js` is the only caller of any of them. `askState()` hands back
+     * the LIVE ledger object and `askSave()` is this file's own debounced
+     * writer, which is what keeps ONE writer on the `emi` key. */
+    mountAsk, unmountAsk, askReady, parkMirrored, setGazeBias, creditPet,
+    askState() { return askState; },
+    askSave(immediate) { save(immediate !== false); },
+    /** True while a chip strip is up. Read-only. */
+    asking() { return !!askLive; },
     hide, show,
     get hidden() { return hidden; },
     /** True once the first-dismiss hint has been spent (persisted). */
@@ -1941,6 +2332,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     destroy() {
       accrueVisible();
       cancelTrip();                  // W2a: never leave a trip timer behind
+      unmountAsk(false);             // ASKS: never leave a live chip behind
       save(true);
       // clearBody() is the easy one to miss: `bodyTimer` outlives everything else
       // and its callback re-adds `.breath` to a node that is no longer in the page.

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
@@ -882,6 +882,8 @@ export default {
 
       const record = Number(S.meta.bestRtMs) || 0;
       const newBest = led.bestRt != null && (record === 0 || led.bestRt < record);
+      // EMI ASKS: carried on the result so `submit()` can report it additively.
+      S.result.newBest = newBest;
       /* a PERFECT class: the X row untouched and not one bubble left to drift */
       const perfect = S.tally.xClicked === 0 && S.tally.drifted === 0;
 
@@ -1007,6 +1009,14 @@ export default {
       try {
         ctx.endClass({
           metrics: { composite: led ? led.composite : 0 },
+          /* ADDITIVE, and read by exactly one thing: EMI's `faster than last
+           * time. bet.` (a11). The record was already folded in by writeMeta
+           * above, so `S.result` carries the comparison this run actually made
+           * and nothing recomputes it. Every other consumer ignores the field.
+           * Trap 54's rule: a new frame field is additive or it is a
+           * regression in nine other classes. */
+          newBest: !!(S.result && S.result.newBest),
+          bestRt: led && led.bestRt != null ? Math.round(led.bestRt) : null,
           /* The dual gate survives the rework: an untouched X row AND real
              speed, or the class caps at A. */
           hardGates: { sGate: !!(led && led.sGate.ok) },

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -2785,8 +2785,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     renderTopbar();
     // EMI SEAM. `family` rides along for the place-awareness table in
     // moments.js (EMI COLOR): the arrival face knows what kind of room it is.
+    /* ASKS: `soft` is a01's YES, and it only ever softens a FACE. */
     fireMoment('classStart', { gameKey: cls.gameKey, tier: gradeTier,
-      family: manifest.family || null });
+      family: manifest.family || null, soft: askSoft() });
     const chrome = classScreenChrome(
       Object.assign({}, cls, { timeBudgetSec }), gradeTier, retake, endless);
 
@@ -3308,11 +3309,29 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
      * The payload grew gameKey + perfect: the per-game colour pools key on the
      * first, and the perfect-gated dork line was unreachable without the second. */
     lastGraded = { grade: graded.grade, perfect: allDone(), fresh: true };
-    fireMoment(/^[sab]$/i.test(String(graded.grade)) || graded.grade === 'pass' ? 'win' : 'fail',
-      { grade: graded.grade, streak: store.streak().count,
-        gameKey: cls.gameKey, perfect: allDone() });
+    /* ASKS: `newBest` is impulse-control's, reported additively on its own
+     * endClass frame (trap 54's spirit), and it is what a11's dare resolves
+     * against. Every other class simply never carries it. */
+    const endMoment = /^[sab]$/i.test(String(graded.grade)) || graded.grade === 'pass' ? 'win' : 'fail';
+    const endPayload = {
+      grade: graded.grade, streak: store.streak().count,
+      gameKey: cls.gameKey, perfect: allDone(),
+      newBest: r && r.newBest === true,
+    };
+    fireMoment(endMoment, endPayload);
 
-    bridge.send({
+    /* ASKS: THE DARE RESOLVES ON THE CLASS'S OWN END, and the answer rides the
+     * frame that already pays for the class. A read of one session flag: no
+     * dare armed answers null for ever, and the host awards nothing. */
+    let dareWon = null;
+    try {
+      const e = getEmi();
+      if (e && e.asks && typeof e.asks.classResult === 'function') {
+        dareWon = e.asks.classResult(endMoment, endPayload);
+      }
+    } catch (e) { dareWon = null; }
+
+    const endedFrame = {
       type: 'class-ended',
       gameKey: cls.gameKey,
       gradeTier,
@@ -3320,7 +3339,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       zen: graded.zen,
       flavorXp,
       dayUtc: utcDateSeed,
-    });
+    };
+    // Additive: an older host ignores it, and a page with no dare never sets it.
+    if (typeof dareWon === 'string' && dareWon) endedFrame.dareWon = dareWon;
+    bridge.send(endedFrame);
 
     /* meta writes: per-game progression, the day's row, the streak */
     try {
@@ -3555,6 +3577,55 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     overlay.appendChild(bar);
     active.root.appendChild(overlay);
     active.suspendEl = overlay;
+  }
+
+  /* ==========================================================================
+   * ASKS: THE EXIT AIM (wave EMI ASKS, 2026-08-25)
+   *
+   * a15 is "bed?", and the whole point of it is that it lands while the player
+   * is REACHING for the way out - not once they have already committed. The
+   * ladder's own `exitIntent` is 450ms into a 1200ms Esc hold (boot.js), which
+   * is the wrong end of the gesture for a question: the window is already
+   * closing behind it. So this is a second, EARLIER and much softer signal.
+   *
+   * THE FENCE, and it is the feature (EMI-VOICE-LOCK): this NEVER blocks,
+   * delays, cancels or even observes the exit. It is a `pointermove` in the
+   * BUBBLE phase with `{passive:true}` that does exactly one thing once per
+   * sitting - fire a moment when the cursor reaches the corner the host
+   * window's close button lives in. It calls no preventDefault, adds no rung
+   * to the Esc ladder, registers no `beforeunload`, and if EMI is not mounted
+   * `fireMoment` is a silent no-op like every other call site.
+   * ======================================================================== */
+  const EXIT_AIM_W = 200;         // px of the top-RIGHT corner that counts
+  const EXIT_AIM_H = 120;
+  let exitAimSpent = false;
+  function onExitAim(ev) {
+    if (exitAimSpent || !ev) return;
+    /* Not while a class is up: she may not stop a board to ask a question, and
+     * `asks.js` would refuse it anyway - this is the cheaper of the two nos. */
+    if (screen === 'class' || active) return;
+    let vw = 1280;
+    try { if (typeof window !== 'undefined') vw = Number(window.innerWidth) || vw; } catch (e) { /* noop */ }
+    const x = Number(ev.clientX);
+    const y = Number(ev.clientY);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    if (y > EXIT_AIM_H || x < vw - EXIT_AIM_W) return;
+    exitAimSpent = true;
+    try { fireMoment('exitAim', { reason: 'corner' }); } catch (e) { /* noop */ }
+  }
+  if (typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('pointermove', onExitAim, { passive: true });
+  }
+
+  /* ASKS: a01's YES buys a SOFT night - comfort faces on arrival and one extra
+   * line on the report card. The flag lives in the ask engine (it is
+   * session-only and it is hers); this is the shell's read of it, and a page
+   * with no EMI, no asks module or no answer all read the same false. */
+  function askSoft() {
+    try {
+      const e = getEmi();
+      return !!(e && e.asks && e.asks.flags && e.asks.flags.soft);
+    } catch (e) { return false; }
   }
 
   /**
@@ -3967,6 +4038,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         annexStatsWait = null;
       }
       setStage(null);
+      /* ASKS: the exit-aim listener is the shell's, so the shell takes it. */
+      if (typeof document !== 'undefined' && document.removeEventListener) {
+        try { document.removeEventListener('pointermove', onExitAim); } catch (e) { /* noop */ }
+      }
       if (orientation) { const ob = orientation; orientation = null; try { ob.destroy(); } catch (e) { /* noop */ } }
       if (ghosts) { try { ghosts.destroy(); } catch (e) { /* noop */ } ghosts = null; }
       if (campus) { try { campus.destroy(); } catch (e) { /* noop */ } campus = null; }

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -2654,6 +2654,16 @@ internal static class ArcademyHostService
     /// re-inventing the table (SYNTHESIS-NOTES #4).</summary>
     private const double FlavorXpCap = 15;
 
+    /// <summary>EMI's dare bonus (EMI ASKS, owner call 2026-08-25): "bet you can't S this one",
+    /// won. A small FIXED award, host-side like every other number on this page - the frame says
+    /// only WHICH dare was won, never what it is worth.</summary>
+    private const double DareBonusXp = 15;
+
+    /// <summary>The only three dare kinds a page may name. Anything else is dropped in silence:
+    /// the field is free text off a postMessage and it must never be able to widen the table.</summary>
+    private static readonly HashSet<string> DareKinds =
+        new(StringComparer.Ordinal) { "S", "streak", "fast" };
+
     /// <summary>
     /// <c>class-ended</c> -> the ONE XP table, the attendance/streak write, and the
     /// <c>payout-result</c> reply. Every input is re-clamped: the page reports what happened, the
@@ -2704,6 +2714,22 @@ internal static class ArcademyHostService
                 try { App.Progression?.AddXP(xp, XPSource.Other); }
                 catch (Exception ex) { App.Logger?.Debug("ArcademyHost payout AddXP: {E}", ex.Message); }
             }
+            /* EMI'S DARE (EMI ASKS, 2026-08-25). The page flags the run when the player takes the
+               bet and reports the WIN on this same frame; the host owns the number and the farm
+               guard. Gated on `firstToday` for exactly the reason the payout above is: a retake is
+               a free replay of the same script, and a dare that paid on every replay would be the
+               one way to grind XP out of a class that is deliberately free. It is its own AddXP
+               call, tagged XPSource.Quest, so THE BANK flies (BankAccumulator.IsBankable) the way
+               a quest payout does - the class XP itself stays XPSource.Other and is unchanged. */
+            var dareWon = (ReadString(o, "dareWon") ?? "").Trim();
+            if (dareWon.Length > 16) dareWon = dareWon[..16];
+            bool darePaid = firstToday && DareKinds.Contains(dareWon);
+            if (darePaid)
+            {
+                try { App.Progression?.AddXP(DareBonusXp, XPSource.Quest); }
+                catch (Exception ex) { App.Logger?.Debug("ArcademyHost dare AddXP: {E}", ex.Message); }
+            }
+
             int levelAfter = App.Settings?.Current?.PlayerLevel ?? levelBefore;
 
             // LOCAL date rolls attendance; the page's dayUtc only ever seeded the content (#978),
@@ -2760,11 +2786,16 @@ internal static class ArcademyHostService
                 classesToday,
                 // Additive: the report card reads it to explain a 0 XP line. Older pages ignore it.
                 retake = !firstToday,
+                // Additive (EMI ASKS): what the dare bonus actually paid, so the page never has
+                // to guess. 0 on every class that carried no dare, and on a retake.
+                dareXp = darePaid ? DareBonusXp : 0,
             });
             PostPunchCard(gameKey, "daily", punch);
             App.Logger?.Information(
-                "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Retake}, streak {Streak}, {Today}/4 today",
-                gameKey, tier, grade, xp, firstToday ? "" : " (retake - already paid for " + dayUtc + ")",
+                "ArcademyHost: class complete ({Game}, tier {Tier}, grade {Grade}) = {Xp:0} XP{Dare}{Retake}, streak {Streak}, {Today}/4 today",
+                gameKey, tier, grade, xp,
+                darePaid ? " +" + DareBonusXp.ToString("0", CultureInfo.InvariantCulture) + " dare (" + dareWon + ")" : "",
+                firstToday ? "" : " (retake - already paid for " + dayUtc + ")",
                 streak, classesToday);
         }
         catch (Exception ex) { App.Logger?.Warning("ArcademyHost.OnClassEnded: {E}", ex.Message); }


### PR DESCRIPTION
## What
EMI can finally be answered. A two-chip strip under her bubble, 15 asks, owner calls locked 0825: **1 ask per ~3 sessions, name input IN, dares pay a tiny bonus.**

Pitch (live demo): https://claude.ai/code/artifact/de3a59e8-4fb8-465c-ad0c-c88d38fa34e8
Spec/lines: `planning/arcademy/EMI-ASKS.md` (gitignored; lines drafted by Fable against the voice lock, all 46 wired verbatim).

### The strip (`emi/asks.js`, new)
- Chips persist until clicked / dismissed / 40s give-up. Ignored is **wordless**: `-_-`, dots, idle. Keyboard 1/2 + focus/Enter, reduced-motion safe.
- Offered LAST in `voiceMoment` (voice, then field trips, then asks) so an ask never lands on a spoken line. Gates: session 3+, not mid-class, widget idle (no say/chain/press/drag/trip/channel), cadence `>=3` sessions or `>=2` on a 1-in-3 roll, one a sitting. Any press cancels without spending cadence.
- Chips are the only new pointer-active elements (input-trust law). Fixed the strip's pointerdown being captured by the drag/pet handler (trap 98, caught by the browser pass only).

### Trigger table
| Moment | Asks |
|---|---|
| greet | rough day / did you sleep (hour<11) / morning person (hour<9) / **what do i call you?** (session 3, once + one re-ask) |
| classStart | like it in here (per room) / watch up close (not tracking/reflex) / dares: S, three-in-a-row, faster-than-last |
| idlePlayer hub | spiral or flash (once) / other side today / pet? (pets>=50, 1-in-4) |
| reportCard | one more? a small one? |
| streakBroken | go again? |
| exitAim (new passive corner seam) | bed? (never blocks, delays or cancels the close) |

### Effects
- Answers under the `emi` blob (`ask/name/lastAskSession/bedSkips`, single writer). New predicates `askIs / askAnswered / hasName / sessionsSinceAsk` drive callback pools ("you said spiral. i remembered.") and the 1-in-20 misremember drop (shares the humanity-quirk slot).
- `{name}` token substitutes only when set; shipped lines fall back byte-identical.
- a06 yes = apparate to the mirrored spot for the sitting; a08 yes = gaze bias; a12 yes = opens the plaque; a13 yes = counts as a pet; bed skipped 3 sittings = one groggy greet.
- **Dares**: flag the next class, resolve on win/fail, `dareWon` rides `class-ended`; `ArcademyHostService` pays a fixed **15 XP via `XPSource.Quest`** (whitelisted kinds, first-play only, echoes `dareXp`) so THE BANK flies.

### Deviations from spec
- a04 fires on classStart (gestures never reach `voiceMoment`).
- a03 callbacks drop the "room using that flavour" clause (no per-room flavour taxonomy exists).
- a15 uses a new `exitAim` pointer seam, not `exitIntent` (that fires 450ms into a closing Esc hold).

### Tests
- New `asks` suite **230/0**, browser proof `proof-asks.mjs` **27/27** (port 8753).
- Existing battery: 943 pass / 37 fail before and after; the 37 failures are byte-identical pre-existing fixtures.
- `node --check` clean x9, `dotnet build` 0 errors, no new warnings. Traps 92-98 added to `arcademy/CLAUDE.md`.

### Not done
- In-app play-test. Fastest way to see one: a fresh `emiVoice` blob at `sessions: 3` triggers the name ask on greet.
- Owner has not line-vetted the 46 lines individually; happy to run a picker for cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLFYHt9c2Z2qS2EK6ovDJU