### PR TITLE
fix(arcademy): Impulse Control spiral pops twice

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
@@ -297,7 +297,7 @@ export function createRender(o = {}) {
   function revealBubble(b) {
     const bub = nodes.bubble;
     if (!bub) return;
-    bub.classList.remove('pop', 'fade', 'hit');
+    bub.classList.remove('pop', 'fade', 'hit', 'gone');
     if (nodes.bubbleImg) nodes.bubbleImg.src = url(b.kind === 'denied' ? BUBBLE_SRC : (FLAVOR_SRC[b.flavor] || BUBBLE_SRC));
     setCls(nodes.x, 'on', b.kind === 'denied');
     if (nodes.holdring) {
@@ -348,6 +348,12 @@ export function createRender(o = {}) {
   function flourish() {
     if (!nodes.flourish || !doc) return;
     try {
+      /* the flourish IS the spiral bubble's pop: it wears the same spiral.png
+         and spawns at the same basin point, so if the bubble's own .pop
+         scale-out is left running the player sees a second bubble popping.
+         Snap the bubble out and let the flourish carry the whole exit. */
+      const bub = nodes.bubble;
+      if (bub) { bub.classList.remove('on', 'pop'); bub.classList.add('gone'); }
       const img = doc.createElement('img');
       img.className = 'g-ic-flourish-img';
       img.src = url(FLAVOR_SRC.spiral);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
@@ -175,6 +175,9 @@ html.arc-reduced .g-ic-dusk{transition:none}
 .g-ic-bubble.on{opacity:1;pointer-events:auto;animation:g-ic-reveal .16s cubic-bezier(.2,1.6,.4,1) forwards}
 @keyframes g-ic-reveal{from{transform:translate(-50%,-50%) scale(.24)}to{transform:translate(-50%,-50%) scale(1)}}
 .g-ic-bubble.pop{animation:g-ic-pop .32s ease-out forwards}
+/* a spiral pop hands the whole exit to the flourish (same artwork - letting
+   both play reads as TWO bubbles popping): the bubble snaps out instantly */
+.g-ic-bubble.gone{opacity:0;pointer-events:none;animation:none}
 @keyframes g-ic-pop{0%{transform:translate(-50%,-50%) scale(1);opacity:1}
   45%{transform:translate(-50%,-50%) scale(1.28);opacity:.85}
   100%{transform:translate(-50%,-50%) scale(1.55);opacity:0}}


### PR DESCRIPTION
## Bug
Popping a **spiral** bubble in Impulse Control showed a second bubble bursting under the click.

## Cause
`render.flourish()` spawns `spiral.png` at the basin, and the bubble itself (also `spiral.png`) was still running its `.pop` animation at the same spot - two spirals, one click.

## Fix
- `render.js`: `flourish()` removes `on`/`pop` from the bubble and adds `.gone`; `revealBubble()` clears `.gone` with the other state classes.
- `style.js`: `.g-ic-bubble.gone{opacity:0;pointer-events:none;animation:none}`.

Flash / sub / denied bubbles unchanged. Two files, +10/-1, `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnpDoiEJVni4xVVFyPRdUL
