### PR TITLE
fix(lockdown): Possession bughunt wave - 5 ship-blockers + 20 bugs before release

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Lab.cs
@@ -82,6 +82,11 @@ namespace ConditioningControlPanel
             warn.Append("- You CANNOT close the application (minimizing still works)\n");
             warn.Append("- The only escape is waiting for the timer to expire\n");
             warn.Append("  (or Ctrl+Alt+Del → Task Manager as a safety valve)");
+            // The Emergency Exit is a GAMBLE, and consent has to say so before the timer starts:
+            // pressing it can end the lockdown early, and it can just as easily hand back a fresh
+            // full-length one (EMERGENCY_EXIT.md, verdict `sendback`).
+            warn.Append("\n- The Emergency Exit button is a gamble: win its little game and you may leave early,\n")
+                .Append("  lose it and the timer restarts at its FULL length");
             if (cfg?.LockdownDoseKeeperEnabled == true)
                 warn.Append("\n- Nothing running? Lockdown starts the engine and picks features for you\n")
                     .Append("  (and switches them back on if you turn them all off - one more each time)");

--- a/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Possession.cs
@@ -218,15 +218,21 @@ namespace ConditioningControlPanel
         /// gets picked up before the next haunt.</summary>
         private static readonly TimeSpan PossessionCacheMaxAge = TimeSpan.FromSeconds(10);
 
-        /// <summary>Never a victim, subtree and all. The timer VALUE and the secret exit box are
-        /// POSSESSION.md hard rules; the Emergency Exit button is the friction door (EMERGENCY_EXIT.md)
-        /// and has to stay exactly where the user last saw it; the gate is the premium wall; the rung
-        /// readout and pips are the feature's own instrumentation - haunting the dial that tells you how
-        /// haunted you are is a joke that reads as a bug.</summary>
+        /// <summary>Never a victim, subtree and all - UNLESS an author hand-tagged it with an explicit
+        /// poss:Possession.Role, which is a louder statement than this list (see WalkPossession). The
+        /// timer VALUE and the secret exit box are POSSESSION.md hard rules; the Emergency Exit button is
+        /// the friction door (EMERGENCY_EXIT.md) and has to stay exactly where the user last saw it; the
+        /// gate is the premium wall; the rung readout and pips are the feature's own instrumentation -
+        /// haunting the dial that tells you how haunted you are is a joke that reads as a bug.
+        ///
+        /// <para><c>TxtXP</c> is here for a mechanical reason rather than a rule: the BANK odometer
+        /// (MainWindow.BankFx.cs, StepBankCounter) rewrites that readout roughly every 70 ms for the
+        /// length of a token flight. A text effect that took it would be a silent no-op - overwritten
+        /// before anyone could read it - while still burning a ghost slot and a 45 s target cooldown.</para></summary>
         private static readonly HashSet<string> PossessionNeverNames = new(StringComparer.Ordinal)
         {
             "TxtLockdownTimer", "TxtLockdownExit", "BtnEmergencyExit", "EERoot",
-            "LockdownGate", "TxtPossessionRung", "PossessionPips",
+            "LockdownGate", "TxtPossessionRung", "PossessionPips", "TxtXP",
         };
 
         /// <summary>Labels are the one role that can run to the hundreds on a dense tab, and a deck full
@@ -322,18 +328,35 @@ namespace ConditioningControlPanel
                 return default;
 
             FrameworkElement? fe = node as FrameworkElement;
+            var handRole = PossessionRole.None;
+
             if (fe != null)
             {
                 // A collapsed tab is a whole subtree of invisible controls; stopping here rather than
-                // filtering leaf by leaf is what keeps the walk cheap.
+                // filtering leaf by leaf is what keeps the walk cheap. These two still come first: they
+                // PRUNE, and pruning is why the walk is measured in single-digit milliseconds.
                 if (!fe.IsVisible) return default;
                 if (Services.Possession.Possession.GetExclude(fe)) return default;
-                if (!string.IsNullOrEmpty(fe.Name) && PossessionNeverNames.Contains(fe.Name)) return default;
+
+                // Hand tags win, always: an author who wrote poss:Possession.Role said something the
+                // type system cannot - and something louder than the never-names blocklist, which is
+                // therefore read AFTER it rather than before.
+                //
+                // TxtLockdownTimer is the case that made this matter. It is the first never-name (its
+                // VALUE is a POSSESSION.md hard rule) AND it carries Role="Timer", the only Timer tag in
+                // the app. Reading the blocklist first meant no Timer target ever existed, which made
+                // WobbleEffect - the only effect that declares that role - dead code, and the ladder's
+                // R2 promise "timer digits wobble (value stays TRUE)" something that never fired.
+                // Wobble rotates a TransformLease and never reads or writes the string, so the number
+                // stays true; the rule was never "do not touch the timer", it was "do not touch its
+                // value". Nothing else changes: an element with no hand tag is blocked exactly as
+                // before, and no other never-name carries a Role (TxtLockdownExit and BtnEmergencyExit
+                // additionally sit behind Possession.Exclude, which is checked above and still wins).
+                handRole = Services.Possession.Possession.GetRole(fe);
+                if (handRole == PossessionRole.None
+                    && !string.IsNullOrEmpty(fe.Name) && PossessionNeverNames.Contains(fe.Name)) return default;
             }
 
-            // Hand tags win, always: an author who wrote poss:Possession.Role said something the type
-            // system cannot.
-            var handRole = fe != null ? Services.Possession.Possession.GetRole(fe) : PossessionRole.None;
             var role = handRole;
             if (fe != null && role == PossessionRole.None) role = InferLeafRole(fe);
 
@@ -614,9 +637,25 @@ namespace ConditioningControlPanel
                     // is haunted whether or not something is playing in it; what still stops us is a
                     // window that has TAKEN OVER the screen, because an ember ripple painted on a
                     // window nobody can see is a bark about a button nobody is looking at.
+                    //
+                    // EVERY ChaosWebViewHost room, not the three that happened to exist when this was
+                    // written: the same class of window with the same posture (owned by MainWindow,
+                    // sized over it, holding the keyboard). Behind the six that were missing the haunt
+                    // went on charging, barking and burning target cooldowns at a window nobody could
+                    // see - including behind the Emergency Exit minigame, which is the one moment the
+                    // room is supposed to be listening rather than talking. Each check is a static
+                    // null-test on the service's own host field, so the whole block is a handful of
+                    // field reads on a path that runs at every pick.
                     if (DtrhHostService.IsActive) return false;
                     if (LoomHostService.IsActive) return false;
                     if (ArcademyHostService.IsActive) return false;
+                    if (Services.Bureau.BureauHostService.IsActive) return false;
+                    if (Services.GoonGame.GoonHostService.IsActive) return false;
+                    if (Services.JustDrop.JustDropHostService.IsActive) return false;
+                    if (Services.Fyp.FypHostService.IsActive) return false;
+                    if (Services.Quiz.IntakeHostService.IsActive) return false;
+                    // IsOpen rather than IsActive - same shape, older name (EMERGENCY_EXIT.md).
+                    if (Services.EmergencyExit.EmergencyExitHostService.IsOpen) return false;
                     // The Lock Card owns the user's attention (and their input) while it is up.
                     if (LockCardWindow.IsAnyOpen()) return false;
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.PremiumRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.PremiumRail.cs
@@ -285,6 +285,10 @@ namespace ConditioningControlPanel
             warn.Append("- You CANNOT close the application (minimizing still works)\n");
             warn.Append("- The only escape is waiting for the timer to expire\n");
             warn.Append("  (or Ctrl+Alt+Del → Task Manager as a safety valve)");
+            // Same gamble line as BtnActivateLockdown_Click: the Emergency Exit can end the lockdown
+            // early or restart it in full, and both consent screens have to say so.
+            warn.Append("\n- The Emergency Exit button is a gamble: win its little game and you may leave early,\n")
+                .Append("  lose it and the timer restarts at its FULL length");
             if (cfg?.LockdownDoseKeeperEnabled == true)
                 warn.Append("\n- Nothing running? Lockdown starts the engine and picks features for you\n")
                     .Append("  (and switches them back on if you turn them all off - one more each time)");

--- a/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.StartStop.cs
@@ -161,12 +161,25 @@ namespace ConditioningControlPanel
             if (!_isRunning) StartEngine();
         }
 
-        public void StartEngine()
+        /// <summary>
+        /// Starts the engine.
+        /// </summary>
+        /// <param name="systemInitiated">
+        /// True when the app started the engine on the user's behalf rather than the user pressing
+        /// START - today that is the Lockdown Dose keeper (Services/Haptics/LockdownDoseKeeper.cs),
+        /// which starts the engine at activation and again after every engine-idle grace. Those starts
+        /// are not sessions the user chose, so they skip the three side effects that only make sense
+        /// for a deliberate press: the Relapse achievement, the TotalSessions counter and the
+        /// mandatory-video enhancement prompt. Pressing Stop inside a lockdown used to farm Relapse,
+        /// inflate TotalSessions once every four seconds and pop a prompt the user could not act on.
+        /// Everything else about the start is identical.
+        /// </param>
+        public void StartEngine(bool systemInitiated = false)
         {
             SaveSettings();
 
             // Check for Relapse achievement (restart within 10s of ESC)
-            App.Achievements?.CheckRelapse();
+            if (!systemInitiated) App.Achievements?.CheckRelapse();
 
             var settings = App.Settings.Current;
 
@@ -176,7 +189,7 @@ namespace ConditioningControlPanel
             bool audioOnly = settings.AudioOnlySession;
 
             // Track session count and start skill tree service
-            settings.TotalSessions++;
+            if (!systemInitiated) settings.TotalSessions++;
             App.SkillTree?.Start();
             App.SkillTree?.TrackTimeOfDayUsage(); // For secret skill unlocks
 
@@ -254,13 +267,7 @@ namespace ConditioningControlPanel
                 App.Autonomy?.Start();
             }
 
-            // Start pop quiz if enabled
-            if (!audioOnly && settings.PopQuizEnabled)
-            {
-                App.PopQuiz?.Start();
-            }
-
-            // Start pop quiz service
+            // Start pop quiz if enabled (this block was duplicated verbatim - PopQuiz.Start() ran twice)
             if (!audioOnly && settings.PopQuizEnabled)
             {
                 App.PopQuiz?.Start();
@@ -295,8 +302,10 @@ namespace ConditioningControlPanel
             // If the mandatory video folder holds enhanced videos the current
             // settings won't fully honour (enhancement off, or webcam rules but
             // webcam not running), offer to flip the missing switch(es). Fire-and-
-            // forget: scans off the UI thread and never blocks engine start.
-            MaybePromptMandatoryVideoEnhancement();
+            // forget: scans off the UI thread and never blocks engine start. Never for a system start:
+            // a prompt that appears inside a lockdown is a dialog the user did not ask for and cannot
+            // reasonably answer.
+            if (!systemInitiated) MaybePromptMandatoryVideoEnhancement();
         }
 
         private bool _stopInProgress;

--- a/ConditioningControlPanel/Resources/web/emergency-exit/games/captcha.js
+++ b/ConditioningControlPanel/Resources/web/emergency-exit/games/captcha.js
@@ -12,6 +12,11 @@
  * Hold fills  -> api.finish("completed", meta)
  * 90 s timer  -> api.finish("failed", meta)   (the verification expired)
  *
+ * THE CLOCK is 90 s of ACTIVE play, not 90 s of wall time: it does not start
+ * until the player's first press (or space/enter) on the verify box, and it
+ * stops while the page is hidden. A `failed` here is a sendback, which restarts
+ * the whole lockdown timer, and a window nobody touched must never buy that.
+ *
  * Shell contract: EMERGENCY_EXIT.md "Shell API". Plain script: calls
  * EE.registerGame at load, self-loads games/captcha-ads.js. Pure gate math is
  * exposed as EE_CAPTCHA_LOGIC for the Node smoke test (ee-logic-tests.js in the authoring scratchpad).
@@ -218,7 +223,19 @@
       var state = { p: 0, closed: 0, gate: gateNeed(rng), popupOpen: false };
       var held = false, pointerId = null, done = false;
       var spawned = 0, threshold = nextThreshold(0, rng);
-      var t0 = performance.now(), last = t0, lastRung = -1, lastPct = -1;
+      var last = performance.now(), lastRung = -1, lastPct = -1;
+      // The active clock: banked ms of play plus the running segment. Stays at 0 until the first
+      // press on the box, and stops while the document is hidden.
+      var begun = false, running = false, banked = 0, segAt = 0;
+      function elapsed() { return begun ? banked + (running ? performance.now() - segAt : 0) : 0; }
+      function clockBegin() { if (begun || done) return; begun = true; running = true; segAt = performance.now(); }
+      function clockPause() { if (!running) return; banked += performance.now() - segAt; running = false; }
+      function clockResume() { if (!begun || running || done) return; running = true; segAt = performance.now(); }
+      function onVisibility() {
+        if (document.hidden) { clockPause(); release(); }
+        else { clockResume(); last = performance.now(); }
+      }
+      document.addEventListener('visibilitychange', onVisibility);
       var usedAds = [], usedSteal = [], usedClosed = [];
       var ads = fallbackAds();
       loadAds(function (a) { if (a && a.ads && a.ads.length) ads = a; });
@@ -242,6 +259,7 @@
         if (done) return;
         if (ev.button != null && ev.button !== 0) return;
         ev.preventDefault();
+        clockBegin();                   // a hand on the box is what starts the 90 s
         if (state.popupOpen) { setStatus('close the offer first.', true); return; }
         held = true; pointerId = ev.pointerId;
         box.classList.add('is-held');
@@ -276,6 +294,7 @@
         if (done || (ev.key !== ' ' && ev.key !== 'Enter')) return;
         if (document.activeElement !== box) return;
         ev.preventDefault();
+        clockBegin();                   // space/enter on the box counts the same as a press
         if (state.popupOpen || keyHeld) return;
         keyHeld = true; held = true; box.classList.add('is-held');
       }
@@ -288,6 +307,7 @@
       this._off = [function () {
         document.removeEventListener('keydown', onKeyDown);
         document.removeEventListener('keyup', onKeyUp);
+        document.removeEventListener('visibilitychange', onVisibility);
       }];
 
       // ---- popups -----------------------------------------------------------
@@ -409,7 +429,7 @@
 
       // ---- end states ------------------------------------------------------
       function meta() {
-        return { popupsClosed: state.closed, popupsShown: spawned, gate: state.gate, elapsedMs: Math.round(performance.now() - t0) };
+        return { popupsClosed: state.closed, popupsShown: spawned, gate: state.gate, elapsedMs: Math.round(elapsed()) };
       }
       function complete() {
         if (done) return;
@@ -436,7 +456,7 @@
       var lastShown = -1;
       var clock = setInterval(function () {
         if (!self._alive || done) return;
-        var left = TIME_LIMIT_MS - (performance.now() - t0);
+        var left = TIME_LIMIT_MS - elapsed();
         var sec = Math.max(0, Math.ceil(left / 1000));
         if (sec !== lastShown) { lastShown = sec; try { if (hud.timer) hud.timer(sec); } catch (_e) {} }
         if (left <= 0) fail();
@@ -448,7 +468,7 @@
       try {
         var q = new URLSearchParams(location.search);
         if (q.get('autopop') === '1') this._after(500, function () { state.p = 0.38; setRing(state.p); spawnPopup(); });
-        if (q.get('autohold') === '1') this._after(300, function () { held = true; box.classList.add('is-held'); });
+        if (q.get('autohold') === '1') this._after(300, function () { clockBegin(); held = true; box.classList.add('is-held'); });
         if (q.get('autodone') === '1') this._after(1500, complete);
       } catch (_e) {}
     },

--- a/ConditioningControlPanel/Resources/web/emergency-exit/games/jigsaw.js
+++ b/ConditioningControlPanel/Resources/web/emergency-exit/games/jigsaw.js
@@ -7,6 +7,13 @@
  * swap (or tap one, then tap another). Correctly placed tiles wear a thin ember
  * outline (the tell). 60 s HUD countdown.
  *
+ * THE CLOCK is 60 s of ACTIVE play, not 60 s of wall time: it does not start
+ * until the player's first press on the board, and it stops while the page is
+ * hidden (resumes when it comes back). A `failed` here is a sendback, which
+ * restarts the entire lockdown timer, so the budget must never be spent by a
+ * window that was opened and then ignored. The glitch schedule below reads the
+ * same active clock.
+ *
  * THE GLITCH: at ~40% progress or after ~12 s (whichever first) a static burst
  * (photosafe: a soft ember breath + crossfade) swaps the picture to a DIFFERENT
  * gif (tile positions kept) and two tiles trade places - preferring tiles that
@@ -219,7 +226,7 @@
       var panel = el('div', 'eejig-panel');
       panel.appendChild(el('p', 'eejig-kicker', 'emergency exit'));
       panel.appendChild(el('h2', 'eejig-title', 'Rearrange the picture'));
-      panel.appendChild(el('p', 'eejig-sub', 'Drag a tile onto another to swap them. Or tap one, then the other. Put it back the way it was.'));
+      panel.appendChild(el('p', 'eejig-sub', 'Drag a tile onto another to swap them. Or tap one, then the other. Put it back the way it was. The clock starts when you touch the board.'));
       var pips = el('div', 'eejig-pips');
       var pipEls = [];
       for (var p = 0; p < TILES; p++) { var pe = el('i', 'eejig-pip'); pips.appendChild(pe); pipEls.push(pe); }
@@ -245,7 +252,11 @@
       var tiles = [];                      // tiles[piece] = element
       var tileSize = 140, gap = 6, boardSize = 460;
       var moves = 0, glitches = 0, done = false;
-      var t0 = performance.now(), firstGlitchAt = 0, glitch1 = false, glitch2 = false;
+      // The active clock: banked ms of play plus the running segment. `begun` stays false (and
+      // elapsed() stays 0) until the first press on the board, and the segment stops whenever the
+      // document is hidden. firstGlitchAt is stamped in the same active milliseconds.
+      var begun = false, running = false, banked = 0, segAt = 0;
+      var firstGlitchAt = 0, glitch1 = false, glitch2 = false;
       var glitch2Roll = rng() < 0.75;      // the second glitch is likely, not certain
       var sel = -1;                        // selected piece (tap mode)
 
@@ -263,6 +274,14 @@
           tiles[q].style.backgroundPosition = pos.x + '% ' + pos.y + '%';
         }
       }
+      function elapsed() { return begun ? banked + (running ? performance.now() - segAt : 0) : 0; }
+      function clockBegin() { if (begun || done) return; begun = true; running = true; segAt = performance.now(); }
+      function clockPause() { if (!running) return; banked += performance.now() - segAt; running = false; }
+      function clockResume() { if (!begun || running || done) return; running = true; segAt = performance.now(); }
+      function onVisibility() { if (document.hidden) clockPause(); else clockResume(); }
+      document.addEventListener('visibilitychange', onVisibility);
+      self._off.push(function () { document.removeEventListener('visibilitychange', onVisibility); });
+
       function slotOf(piece) { return slots.indexOf(piece); }
       function slotXY(slot) {
         var r = Math.floor(slot / N), c = slot % N;
@@ -352,6 +371,7 @@
         if (!tEl || !board.contains(tEl)) return;
         if (ev.button != null && ev.button !== 0) return;
         ev.preventDefault();
+        clockBegin();                   // a hand on a tile is what starts the 60 s
         var piece = parseInt(tEl.getAttribute('data-piece'), 10);
         var r = board.getBoundingClientRect(), xy = slotXY(slotOf(piece));
         dragging = {
@@ -421,7 +441,7 @@
       // ---- the glitch ------------------------------------------------------
       function glitchNow(second) {
         glitches++;
-        firstGlitchAt = performance.now();
+        firstGlitchAt = elapsed();
         var pair = pickGlitchSwap(slots, rng);
         var nextPic = pickOtherIndex(picIdx, gifs.length, rng);
         var burstMs = photosafe ? 900 : 420;
@@ -446,26 +466,26 @@
       }
       function maybeGlitch() {
         if (done) return;
-        var now = performance.now();
+        var now = elapsed();          // active ms, so a paused game cannot glitch its way forward
         var prog = countCorrect(slots) / TILES;
         if (!glitch1) {
-          if (prog >= GLITCH_PROGRESS || now - t0 >= GLITCH_AFTER_MS) { glitch1 = true; glitchNow(false); }
+          if (prog >= GLITCH_PROGRESS || now >= GLITCH_AFTER_MS) { glitch1 = true; glitchNow(false); }
           return;
         }
-        if (!glitch2 && glitch2Roll && prog >= GLITCH2_PROGRESS && now - firstGlitchAt >= GLITCH2_MIN_GAP_MS && now - t0 < TIME_LIMIT_MS - 8000) {
+        if (!glitch2 && glitch2Roll && prog >= GLITCH2_PROGRESS && now - firstGlitchAt >= GLITCH2_MIN_GAP_MS && now < TIME_LIMIT_MS - 8000) {
           glitch2 = true; glitchNow(true);
         }
       }
 
       // ---- end states ------------------------------------------------------
       function meta() {
-        return { moves: moves, glitches: glitches, correct: countCorrect(slots), elapsedMs: Math.round(performance.now() - t0) };
+        return { moves: moves, glitches: glitches, correct: countCorrect(slots), elapsedMs: Math.round(elapsed()) };
       }
       function checkWin() {
         if (done || !isSolved(slots)) return;
         done = true;
         board.classList.add('is-done');
-        try { if (hud.timer) hud.timer(Math.max(0, Math.ceil((TIME_LIMIT_MS - (performance.now() - t0)) / 1000))); } catch (_e) {}
+        try { if (hud.timer) hud.timer(Math.max(0, Math.ceil((TIME_LIMIT_MS - elapsed()) / 1000))); } catch (_e) {}
         say('fine. it is a picture again. for now.');
         fine.textContent = 'verified: you remember what it looked like.'; fine.classList.remove('is-warn');
         self._after(700, function () { try { api.finish('completed', meta()); } catch (_e) {} });
@@ -494,10 +514,10 @@
       var lastShown = -1, glitchTimeChecked = false;
       var clock = setInterval(function () {
         if (!self._alive || done) return;
-        var left = TIME_LIMIT_MS - (performance.now() - t0);
+        var left = TIME_LIMIT_MS - elapsed();
         var sec = Math.max(0, Math.ceil(left / 1000));
         if (sec !== lastShown) { lastShown = sec; try { if (hud.timer) hud.timer(sec); } catch (_e) {} }
-        if (!glitch1 && !glitchTimeChecked && performance.now() - t0 >= GLITCH_AFTER_MS && !dragging) { glitchTimeChecked = true; maybeGlitch(); }
+        if (!glitch1 && !glitchTimeChecked && elapsed() >= GLITCH_AFTER_MS && !dragging) { glitchTimeChecked = true; maybeGlitch(); }
         if (left <= 0) fail();
       }, 200);
       this._timers.push(clock);

--- a/ConditioningControlPanel/Resources/web/emergency-exit/games/labyrinth.js
+++ b/ConditioningControlPanel/Resources/web/emergency-exit/games/labyrinth.js
@@ -13,6 +13,12 @@
  * press again near the trace tip to continue, or press the entry to restart.
  * Keyboard: focus the canvas, arrow keys step the tip one cell (walls = hit).
  *
+ * THE CLOCK: 25 s of ACTIVE play, not 25 s of wall time. It does not start until
+ * the player's first press or arrow key on the maze, and it stops whenever the
+ * page is hidden (resumes when it comes back). Opening the window and walking
+ * away must never spend the budget: a `failed` here is a sendback, which restarts
+ * the whole lockdown timer, and nobody consents to that by getting distracted.
+ *
  * Photosafe: no static burst (soft board slide + tint), no shake on hits (tint),
  * slower heartbeat. Everything via api.photosafe / the .ee-photosafe class.
  *
@@ -151,6 +157,31 @@
    * ------------------------------------------------------------------------- */
   var G = null; // live game state
 
+  /* ---- the active clock -------------------------------------------------
+   * banked = seconds of play already spent; segAt = when the running segment
+   * began. Not begun and not running both read as "no time has passed".
+   * ---------------------------------------------------------------------- */
+  function elapsed() {
+    if (!G || !G.begun) return 0;
+    return G.banked + (G.running ? (performance.now() - G.segAt) / 1000 : 0);
+  }
+  function clockBegin() {
+    if (!G || G.begun || G.done || G.locking) return;
+    G.begun = true; G.running = true; G.segAt = performance.now();
+  }
+  function clockPause() {
+    if (!G || !G.running) return;
+    G.banked += (performance.now() - G.segAt) / 1000;
+    G.running = false;
+  }
+  function clockResume() {
+    if (!G || !G.begun || G.running) return;
+    G.running = true; G.segAt = performance.now();
+  }
+  function onVisibility() {
+    if (document.hidden) clockPause(); else clockResume();
+  }
+
   function start(init, api) {
     var rng = api.rng;
     var n = 9 + Math.floor(rng() * 3);             // 9..11
@@ -178,7 +209,7 @@
     side.innerHTML =
       '<h2 class="lab-title">trace <em>the exit</em></h2>' +
       '<p class="lab-sub">Press the ember, drag to the door, do not touch the walls. ' +
-      'You have ' + TIME_LIMIT + ' seconds. The exit has been... restless lately.</p>' +
+      'You get ' + TIME_LIMIT + ' seconds, counted from your first touch. The exit has been... restless lately.</p>' +
       '<div class="lab-legend">' +
       '<div><span class="lab-dot is-entry"></span>entry: press here to begin (or to start over)</div>' +
       '<div><span class="lab-dot is-exit"></span>exit: where it is right now</div>' +
@@ -207,14 +238,15 @@
       entry: entry, entryEdge: entryEdge, exit: exit, exitEdge: exitEdge,
       trace: [], cells: [], dragging: false, pointerId: null,
       resets: 0, moves: 0, done: false,
-      t0: performance.now(), limit: TIME_LIMIT, left: TIME_LIMIT,
+      begun: false, running: false, banked: 0, segAt: 0,
+      limit: TIME_LIMIT, left: TIME_LIMIT,
       glitchAt: TIME_LIMIT * (0.45 + rng() * 0.1), glitched: false, glitchFx: 0, oldExit: null, oldExitFade: 0,
       hitFx: 0, winFx: 0, lockFx: 0, locking: false, heart: false,
       embers: [], raf: 0, tick: 0, rng: rng, photosafe: !!api.photosafe
     };
 
     api.hud.timer(TIME_LIMIT);
-    api.say('press the ember and trace your way out. the walls are not shy.');
+    api.say('press the ember and trace your way out. the clock waits for your hand. the walls are not shy.');
 
     // --- input
     canvas.addEventListener('pointerdown', onDown);
@@ -224,6 +256,7 @@
     canvas.addEventListener('lostpointercapture', onUp);
     canvas.addEventListener('keydown', onKey);
     canvas.addEventListener('contextmenu', function (e) { e.preventDefault(); });
+    document.addEventListener('visibilitychange', onVisibility);
 
     G.tick = setInterval(onSecond, 100);
     G.raf = requestAnimationFrame(frame);
@@ -308,6 +341,7 @@
 
   function onDown(e) {
     if (!G || G.done || G.locking) return;
+    clockBegin();                       // a hand on the maze is what starts the 25 s
     var p = canvasPoint(e), t = tip();
     if (t && Math.hypot(p[0] - t[0], p[1] - t[1]) < TIP_GRAB) {
       G.dragging = true;
@@ -340,10 +374,11 @@
     if (!G || G.done || G.locking) return;
     var d = e.key === 'ArrowUp' ? 0 : e.key === 'ArrowRight' ? 1 : e.key === 'ArrowDown' ? 2 : e.key === 'ArrowLeft' ? 3 : -1;
     if (d < 0) {
-      if (e.key === ' ' || e.key === 'Enter') { if (!G.trace.length) { G.trace = [cellCenter(G.entry)]; G.cells = [G.entry.slice()]; G.api.say('go.'); } e.preventDefault(); }
+      if (e.key === ' ' || e.key === 'Enter') { clockBegin(); if (!G.trace.length) { G.trace = [cellCenter(G.entry)]; G.cells = [G.entry.slice()]; G.api.say('go.'); } e.preventDefault(); }
       return;
     }
     e.preventDefault();
+    clockBegin();                       // an arrow key on the maze counts the same as a press
     if (!G.trace.length) { G.trace = [cellCenter(G.entry)]; G.cells = [G.entry.slice()]; }
     var cur = G.cells[G.cells.length - 1];
     var cell = G.grid[cur[1]][cur[0]];
@@ -419,7 +454,7 @@
 
   function onSecond() {
     if (!G || G.done || G.locking) return;
-    var el = (performance.now() - G.t0) / 1000;
+    var el = elapsed();
     G.left = Math.max(0, G.limit - el);
     G.api.hud.timer(G.left);
     if (!G.glitched && el >= G.glitchAt) doGlitch();
@@ -660,6 +695,7 @@
     if (!G) return;
     clearInterval(G.tick);
     cancelAnimationFrame(G.raf);
+    try { document.removeEventListener('visibilitychange', onVisibility); } catch (_e) {}
     try {
       G.canvas.removeEventListener('pointerdown', onDown);
       G.canvas.removeEventListener('pointermove', onMove);

--- a/ConditioningControlPanel/Services/EmergencyExit/EmergencyExitHostService.cs
+++ b/ConditioningControlPanel/Services/EmergencyExit/EmergencyExitHostService.cs
@@ -23,10 +23,11 @@ namespace ConditioningControlPanel.Services.EmergencyExit;
 /// closes it and nothing changed", which is already the `abandon` verdict.</para>
 ///
 /// <para><b>The host is authoritative.</b> The page reports what HAPPENED (completed / failed); the
-/// verdict is rolled here (<see cref="SendBackChance"/>) and applied to
-/// <see cref="LockdownService"/> the instant it is decided, BEFORE the page is told. A page that is
-/// hand-edited, reloaded or killed mid-outro therefore cannot invent an escape, and cannot dodge a
-/// sendback by never playing the outro.</para>
+/// verdict is rolled here (<see cref="SendBackChance"/>) and applied to <see cref="LockdownService"/>
+/// in the same synchronous turn it is decided. A page that is hand-edited, reloaded or killed
+/// mid-outro therefore cannot invent an escape, and cannot dodge a sendback by never playing the
+/// outro. The page is told first (<see cref="OnGameFinished"/> explains why that ordering is
+/// load-bearing) but it is never ASKED anything.</para>
 ///
 /// <para><b>Nothing here is a wall.</b> Every path out of this window is safe: the X, Esc, a dead
 /// render process and app shutdown all land on <see cref="Close"/>, which changes nothing about the
@@ -52,6 +53,12 @@ internal static class EmergencyExitHostService
     private static DispatcherTimer? _failsafe;
     private static string _game = "";
     private static bool _verdictSent;
+    /// <summary>True from the moment the verdict is posted to the page until the window is torn
+    /// down. While it is set, the LockdownDeactivated handler leaves the window ALONE: an `escape`
+    /// verdict deactivates the lockdown, and closing the window from that event would kill the page
+    /// before it ever rendered the escape card the user just earned. The outro's `outro-done` (or
+    /// <see cref="OutroFailsafe"/>) closes it a beat later instead.</summary>
+    private static bool _outroPending;
     private static bool _closing;          // reentrancy: Dispose closes the window -> Closed -> Close()
     private static bool _hooked;           // LockdownDeactivated subscription (one-shot, lazily armed)
     private static bool _preview;          // --emergency-exit-preview: verdicts logged, NEVER applied
@@ -106,6 +113,7 @@ internal static class EmergencyExitHostService
             EnsureHooked();
             _preview = preview;
             _verdictSent = false;
+            _outroPending = false;
             _closing = false;
 
             if (!preview)
@@ -208,6 +216,13 @@ internal static class EmergencyExitHostService
     /// <para>LockdownDeactivated is the single reset point: it closes a window that outlived its
     /// lockdown (the secret phrase, a panic key, the timer simply expiring while a game is open) and
     /// clears the per-lockdown attempt counter and no-repeat memory.</para>
+    ///
+    /// <para>With ONE exception, which is the whole reason <see cref="_outroPending"/> exists: an
+    /// `escape` verdict deactivates the lockdown itself, and this event fires synchronously from
+    /// inside that call. Closing here would tear the window down between the verdict being posted
+    /// and the page painting the escape card, so the player who just won would watch the window
+    /// vanish instead. The counters still reset (the lockdown IS over); only the window survives,
+    /// until `outro-done` or the failsafe closes it.</para>
     /// </summary>
     private static void EnsureHooked()
     {
@@ -215,9 +230,7 @@ internal static class EmergencyExitHostService
         _hooked = true;
         App.Lockdown.LockdownDeactivated += () =>
         {
-            // Ordering matters: close FIRST (an open window over a finished lockdown is the bug),
-            // then reset, so the next lockdown starts at attempt #1 with a free game pick.
-            Close();
+            if (!_outroPending) Close();
             _attempt = 0;
             _lastGame = "";
         };
@@ -374,8 +387,18 @@ internal static class EmergencyExitHostService
     }
 
     /// <summary>
-    /// The one decision this service exists to make. Roll, APPLY, then tell the page - in that order,
-    /// so the lockdown state is already correct no matter what the page does next.
+    /// The one decision this service exists to make. Roll, TELL THE PAGE, then apply.
+    ///
+    /// <para>The post has to come first, and the reason is not cosmetic. Applying an `escape` calls
+    /// <see cref="LockdownService.Deactivate"/>, which raises LockdownDeactivated synchronously,
+    /// which used to run <see cref="Close"/> and dispose the WebView - all before the verdict message
+    /// was ever posted, so the post landed on a null host and the winning player's window simply
+    /// disappeared. Posting first, plus the <see cref="_outroPending"/> guard on the deactivation
+    /// handler, is what lets the page show the card it has always been able to render.</para>
+    ///
+    /// <para>The apply still happens synchronously right after, and is NOT deferred onto the
+    /// dispatcher: the host is authoritative, and a verdict queued behind a dispatcher that is
+    /// shutting down is a verdict that silently never happens.</para>
     /// </summary>
     private static void OnGameFinished(JObject msg)
     {
@@ -396,6 +419,15 @@ internal static class EmergencyExitHostService
             "EmergencyExit: verdict (game {Game}, result {Result}, outcome {Outcome}, roll {Roll:0.###}/{Chance:0.###})",
             game, result, outcome, roll, chance);
 
+        // Tell the page, arm its deadline, and only then change the world. The outro is only
+        // "pending" once the failsafe that will close the window is actually on its way: without one
+        // (no window, or a dispatcher that is already shutting down) the deactivation handler stays
+        // the thing that tears it down, exactly as before.
+        var host = _host;
+        try { host?.Post(new { type = "verdict", outcome }); }
+        catch (Exception ex) { App.Logger?.Warning("EmergencyExit: posting the verdict failed: {E}", ex.Message); }
+        _outroPending = ArmOutroFailsafe(host);
+
         if (_preview)
         {
             App.Logger?.Information("EmergencyExit: PREVIEW - verdict NOT applied");
@@ -412,9 +444,6 @@ internal static class EmergencyExitHostService
             try { App.Bark?.NotifyEmergencyExitVerdict(game, outcome); }
             catch (Exception ex) { App.Logger?.Debug("EmergencyExit: verdict bark failed: {E}", ex.Message); }
         }
-
-        _host?.Post(new { type = "verdict", outcome });
-        ArmOutroFailsafe();
     }
 
     /// <summary>
@@ -434,26 +463,40 @@ internal static class EmergencyExitHostService
 
     /// <summary>The outro card gets <see cref="OutroFailsafe"/> to play and post <c>outro-done</c>.
     /// After that the window closes regardless: the verdict is already applied, so the card is
-    /// courtesy and must never be able to strand a window over the app.</summary>
-    private static void ArmOutroFailsafe()
+    /// courtesy and must never be able to strand a window over the app.
+    ///
+    /// <para>The timer belongs to the window instance that armed it. It is armed on the dispatcher
+    /// (one turn later than the verdict), and by the time it fires 8 s after that, <see cref="_host"/>
+    /// may hold a completely different window - the outro finished, the user pressed the big button
+    /// again, and the next lockdown's game is up. An untethered failsafe closes THAT one. So the host
+    /// is captured and compared, both when arming and when firing.</para></summary>
+    /// <returns>True when a failsafe is on its way, i.e. when the window is guaranteed to close
+    /// even if the page never answers.</returns>
+    private static bool ArmOutroFailsafe(ChaosWebViewHost? host)
     {
+        if (host == null) return false;
         var disp = Application.Current?.Dispatcher;
-        if (disp == null || disp.HasShutdownStarted) return;
+        if (disp == null || disp.HasShutdownStarted) return false;
         disp.BeginInvoke(new Action(() =>
         {
             try
             {
+                if (!ReferenceEquals(_host, host)) return;   // that window is already gone
                 CancelOutroFailsafe();
-                _failsafe = new DispatcherTimer { Interval = OutroFailsafe };
-                _failsafe.Tick += (_, _) =>
+                var timer = new DispatcherTimer { Interval = OutroFailsafe };
+                _failsafe = timer;
+                timer.Tick += (_, _) =>
                 {
+                    timer.Stop();
+                    if (!ReferenceEquals(_host, host)) return;
                     App.Logger?.Information("EmergencyExit: outro failsafe fired - closing");
                     Close();
                 };
-                _failsafe.Start();
+                timer.Start();
             }
             catch (Exception ex) { App.Logger?.Debug("EmergencyExit: failsafe arm failed: {E}", ex.Message); }
         }));
+        return true;
     }
 
     private static void CancelOutroFailsafe()
@@ -498,6 +541,7 @@ internal static class EmergencyExitHostService
                 App.Logger?.Information("EmergencyExit: closed (game {Game})", _game);
             }
             _verdictSent = false;
+            _outroPending = false;
             _preview = false;
         }
         catch (Exception ex) { App.Logger?.Debug("EmergencyExitHostService.Close: {E}", ex.Message); }

--- a/ConditioningControlPanel/Services/Haptics/LockdownDoseKeeper.cs
+++ b/ConditioningControlPanel/Services/Haptics/LockdownDoseKeeper.cs
@@ -68,11 +68,22 @@ public sealed class LockdownDoseKeeper : IDisposable
     /// <summary>Flags outside the wall that still mean "something is running" - the keeper must not
     /// talk over an audio-only bed, a corner GIF or a takeover just because the wall toggles are off.
     /// (Whisper audio is NOT here on purpose: SubliminalService plays it, so it is already covered by
-    /// the subliminal toggle and means nothing on its own.)</summary>
+    /// the subliminal toggle and means nothing on its own.)
+    ///
+    /// <para>Pop Quiz belongs here rather than in <see cref="Catalog"/>: <c>StartEngine</c> starts it
+    /// off <c>PopQuizEnabled</c> like any wall feature, so a lockdown with only Pop Quiz on is NOT an
+    /// empty room - but it is not a wall card, so <c>MainWindow.SetWallFeature</c> does not know its
+    /// key and it must never be conscriptable. Living outside the catalog makes that true by
+    /// construction: it counts, and it can never be picked.</para></summary>
     private static bool HasOffWallDose(AppSettings s) =>
         s.AudioOnlySession
+        || s.PopQuizEnabled
         || (s.CornerGifOverlays?.Any(o => o != null && o.Enabled) == true)
         || (s.AutonomyModeEnabled && s.AutonomyConsentGiven);
+
+    /// <summary>Test seam for the off-wall half of the census (Pop Quiz, the audio bed, corner GIFs,
+    /// takeover). Public so the suite can pin what counts without a live lockdown.</summary>
+    public static bool CountsAsOffWallDose(AppSettings s) => s != null && HasOffWallDose(s);
 
     /// <summary>True when NOTHING would run - no wall feature on and no off-wall dose either.</summary>
     public static bool DoseIsEmpty(AppSettings s)
@@ -252,16 +263,25 @@ public sealed class LockdownDoseKeeper : IDisposable
         if (!_lockdown.IsActive) { _armed = false; return; }
         if (!Enabled) return;   // turned off mid-lockdown: stand down, restore still runs at the end
         var s = App.Settings?.Current;
-        var mw = Application.Current?.MainWindow as MainWindow;
+        // App.MainWindowRef, not Application.Current.MainWindow: the latter is null while the window
+        // is hidden to tray, which is exactly where a lockdown run spends much of its time - and a
+        // null here silently no-ops the whole enforcement pass. (Same read as Warden.cs / App.xaml.cs.)
+        var mw = App.MainWindowRef ?? Application.Current?.MainWindow as MainWindow;
         if (s == null || mw == null) return;
 
         _busy = true;
         try
         {
             // A running session owns the dose (MainWindow.SessionFeatureLock rule 1). Stand down.
+            //
+            // _wasEmpty is deliberately NOT rewritten here. Rewriting it every tick consumed the empty
+            // EDGE: a session that ends with every feature off left _wasEmpty already true, so the
+            // `empty && !_wasEmpty` test below never fired and the room refilled silently, with no
+            // `starve` tripwire and no warden line. The edge is what the tripwire is made of, so it
+            // survives the stand-down and fires the moment the keeper is watching again.
             if (mw.IsSessionFeatureLockActive)
             {
-                _engineIdle = 0; _doseIdle = 0; _wasEmpty = DoseIsEmpty(s);
+                _engineIdle = 0; _doseIdle = 0;
                 return;
             }
 
@@ -351,7 +371,10 @@ public sealed class LockdownDoseKeeper : IDisposable
     {
         try
         {
-            mw.StartEngine();
+            // systemInitiated: the keeper is not the user pressing START. Without it, Stop-inside-a-
+            // lockdown farmed the Relapse achievement, TotalSessions grew once per engine-idle grace
+            // and the mandatory-video enhancement prompt could pop inside the lockdown.
+            mw.StartEngine(systemInitiated: true);
             _weStartedEngine = true;
             WriteRecoveryFile();
             App.Logger?.Information("Lockdown dose: engine started for the user");
@@ -364,6 +387,12 @@ public sealed class LockdownDoseKeeper : IDisposable
         try { App.Bark?.NotifyLockdownConscript(names ?? "", _round, engineStarted); } catch { }
     }
 
+    /// <summary>The extensions VideoService actually plays, mirrored from its refill scan
+    /// (Services/Video/VideoService.cs, <c>RefillVideoQueues</c>). Counting ANY file made round 2
+    /// conscript Mandatory Videos over a folder holding nothing but Thumbs.db, desktop.ini or the
+    /// .ccpenh.json enhancement sidecars - a feature switched on with nothing to play.</summary>
+    private static readonly string[] VideoExtensions = { ".mp4", ".mov", ".avi", ".wmv", ".mkv", ".webm" };
+
     /// <summary>Escalation features only join the pool when they would actually do something.</summary>
     private static bool AssetsExistFor(string key)
     {
@@ -372,11 +401,21 @@ public sealed class LockdownDoseKeeper : IDisposable
             if (key == "video")
             {
                 var dir = Path.Combine(App.EffectiveAssetsPath, "videos");
-                return Directory.Exists(dir) && Directory.EnumerateFiles(dir).Any();
+                if (!Directory.Exists(dir)) return false;
+                // AllDirectories to match VideoService: users organise videos into category subfolders.
+                return Directory.EnumerateFiles(dir, "*.*", SearchOption.AllDirectories)
+                                .Any(f => VideoExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()));
             }
         }
         catch { }
         return true;
+    }
+
+    /// <summary>Test seam: does this filename count as something the video feature could play?</summary>
+    public static bool IsPlayableVideoFile(string path)
+    {
+        try { return !string.IsNullOrWhiteSpace(path) && VideoExtensions.Contains(Path.GetExtension(path).ToLowerInvariant()); }
+        catch { return false; }
     }
 
     private void OnDeactivated()
@@ -384,31 +423,56 @@ public sealed class LockdownDoseKeeper : IDisposable
         try
         {
             _kickoff?.Stop();
-            if (!_armed) return;
+            if (!_armed) { DeleteRecoveryFile(); return; }   // nothing was ever borrowed this lockdown
             _armed = false;
+            // Restore OWNS the recovery file from here. It is the record of what is still switched on
+            // against the user's wishes, so it may only be deleted once the toggles are actually back -
+            // and Restore can be QUEUED to the UI thread, so deleting it here (the old `finally`) threw
+            // the record away before the restore had even run.
             Restore();
         }
         catch (Exception ex) { App.Logger?.Warning("Lockdown dose: restore failed: {Error}", ex.Message); }
-        finally { DeleteRecoveryFile(); }
     }
 
     /// <summary>Gives back what was borrowed: flipped toggles to their pre-lockdown value, and the
-    /// engine stopped if the keeper was the one who started it and it was not running before.</summary>
+    /// engine stopped if the keeper was the one who started it and it was not running before. Deletes
+    /// the recovery file only when everything was actually given back; anything left flipped stays on
+    /// disk so <see cref="RecoverIfNeeded"/> finishes the job at the next launch.</summary>
     private void Restore()
     {
-        var mw = Application.Current?.MainWindow as MainWindow;
-        if (mw == null) return;
+        // Marshal FIRST. MainWindow's Application.Current.MainWindow getter VerifyAccess-throws off the
+        // UI thread, so reading it before this check made the marshalling branch unreachable - the read
+        // threw and the whole restore was lost to OnDeactivated's catch.
         var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher != null && !dispatcher.CheckAccess()) { dispatcher.BeginInvoke(Restore); return; }
+        if (dispatcher != null && !dispatcher.CheckAccess())
+        {
+            if (dispatcher.HasShutdownStarted) return;   // recovery file kept; next launch cleans up
+            dispatcher.BeginInvoke(new Action(Restore));
+            return;
+        }
+
+        var mw = App.MainWindowRef ?? Application.Current?.MainWindow as MainWindow;
+        if (mw == null)
+        {
+            App.Logger?.Warning("Lockdown dose: no main window at restore - {Count} toggle(s) left on, "
+                + "recovery file kept for the next launch", _flipped.Count);
+            return;
+        }
 
         var gaveBack = new List<string>();
+        var stillFlipped = new List<string>();
         foreach (var key in _flipped.ToList())
         {
             if (_snapshotOn.Contains(key)) continue;   // they had it on themselves - leave it
             try { mw.SetWallFeature(key, false); gaveBack.Add(key); }
-            catch (Exception ex) { App.Logger?.Warning("Lockdown dose: could not give back {Key}: {Error}", key, ex.Message); }
+            catch (Exception ex)
+            {
+                stillFlipped.Add(key);
+                App.Logger?.Warning("Lockdown dose: could not give back {Key}: {Error}", key, ex.Message);
+            }
         }
         _flipped.Clear();
+        foreach (var key in stillFlipped) _flipped.Add(key);
 
         var stoppedEngine = false;
         if (_weStartedEngine && !_engineWasRunning && App.IsEngineRunning && !mw.IsSessionFeatureLockActive)
@@ -418,6 +482,10 @@ public sealed class LockdownDoseKeeper : IDisposable
         }
         App.Logger?.Information("Lockdown dose: released (gave back {Keys}; engine {Engine})",
             gaveBack.Count == 0 ? "nothing" : string.Join(",", gaveBack), stoppedEngine ? "stopped" : "left as is");
+
+        // Only now, and only if nothing is still flipped: the file is the recovery record.
+        if (stillFlipped.Count == 0) DeleteRecoveryFile();
+        else WriteRecoveryFile();
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/ConditioningControlPanel/Services/Haptics/LockdownService.cs
+++ b/ConditioningControlPanel/Services/Haptics/LockdownService.cs
@@ -19,7 +19,14 @@ namespace ConditioningControlPanel.Services;
 public class LockdownService : IDisposable
 {
     private bool _isActive;
+    /// <summary>When the CURRENT stretch of clock started. <see cref="RestartTimer"/> rebases it, so
+    /// the countdown and the Possession ladder both rewind with the Emergency Exit's sendback.</summary>
     private DateTime _activatedAt;
+    /// <summary>When the user was first locked in. Set ONLY by <see cref="Activate"/> and never
+    /// rebased, so <see cref="LastActiveDuration"/> reports the whole sitting even when the Emergency
+    /// Exit sent them back halfway through (45 min + sendback + 45 min is a 90-minute lockdown, and
+    /// the throw_away_the_key achievement has to be able to see that).</summary>
+    private DateTime _startedAt;
     private TimeSpan _duration;
     private DispatcherTimer? _countdownTimer;
     private bool _preStrictLock;
@@ -111,6 +118,7 @@ public class LockdownService : IDisposable
     /// This is the single source of truth for "how long did the user sit through a
     /// lockdown" — gamification reads this instead of tracking its own start time, so
     /// the value can't desync from the service. TimeSpan.Zero before the first lockdown.
+    /// Measured from <see cref="_startedAt"/>, so a sendback does not erase the time already served.
     /// </summary>
     public TimeSpan LastActiveDuration { get; private set; }
 
@@ -153,9 +161,13 @@ public class LockdownService : IDisposable
 
         _duration = duration;
         _activatedAt = DateTime.Now;
+        _startedAt = _activatedAt;
         _isActive = true;
         _escapeRepeats.Clear();
         _escapeTotal = 0;
+        // The syskey tripwire is throttled to one per 2 s. Without this reset, a lockdown started
+        // within 2 s of the previous one's end swallows its own FIRST system-key attempt.
+        _lastSysKeyAttempt = DateTime.MinValue;
         RestartCount = 0;
 
         // Start countdown timer (ticks every second)
@@ -196,7 +208,10 @@ public class LockdownService : IDisposable
         // Capture how long this lockdown ran BEFORE clearing _isActive, so gamification
         // (throw_away_the_key, "60+ minute lockdown") reads an authoritative duration
         // straight from the service rather than maintaining its own start timestamp.
-        LastActiveDuration = DateTime.Now - _activatedAt;
+        // From _startedAt, NOT _activatedAt: RestartTimer rebases _activatedAt, so measuring from
+        // it would report only the time since the last sendback and no amount of sitting through
+        // Emergency Exit restarts could ever earn the long-lockdown achievement.
+        LastActiveDuration = DateTime.Now - _startedAt;
         _isActive = false;
 
         App.Logger?.Information("Lockdown deactivated after {Minutes:F1} minutes", LastActiveDuration.TotalMinutes);
@@ -279,6 +294,10 @@ public class LockdownService : IDisposable
     /// Rewind the running lockdown to its FULL duration (the Emergency Exit's "you always come back"
     /// verdict). Escape-attempt counters are kept (friction escalates), safeties untouched, the same
     /// countdown timer keeps ticking. No-op when inactive. Raises <see cref="TimerRestarted"/>.
+    ///
+    /// <para>Only <see cref="_activatedAt"/> is rebased: the Possession ladder NEEDS the rewind (rung
+    /// back to Settle), while <see cref="_startedAt"/> keeps the time already served so
+    /// <see cref="LastActiveDuration"/> survives a sendback.</para>
     /// </summary>
     public void RestartTimer(string reason)
     {
@@ -289,9 +308,13 @@ public class LockdownService : IDisposable
             _duration.TotalMinutes, reason, RestartCount);
         Helpers.DispatcherHelper.RunOnUI(() =>
         {
-            try { CountdownTick?.Invoke(Remaining); } catch { }
+            // TimerRestarted FIRST. The elapsed fraction is already back at ~0, so a CountdownTick
+            // raised ahead of it makes the Possession director walk its ladder down to Settle and
+            // bark it, and OnTimerRestarted then resets and barks the same rung a second time.
+            // The restart is the news; the tick is only the repaint that follows it.
             try { TimerRestarted?.Invoke(reason ?? ""); }
             catch (Exception ex) { App.Logger?.Warning("Lockdown TimerRestarted handler failed: {Error}", ex.Message); }
+            try { CountdownTick?.Invoke(Remaining); } catch { }
         });
     }
 
@@ -315,12 +338,21 @@ public class LockdownService : IDisposable
     private void OnCountdownTick(object? sender, EventArgs e)
     {
         var remaining = Remaining;
-        CountdownTick?.Invoke(remaining);
 
         if (remaining <= TimeSpan.Zero)
         {
+            // The expiry tick is NOT a live tick, so it does not get raised as one. Raising it first
+            // handed every listener a lockdown that still said IsActive while it had in fact just
+            // ended, and the Dose keeper answers a tick by conscripting features and restarting the
+            // engine - all of which Deactivate tore down inside the same second. Nothing is left
+            // un-painted by skipping it either: Deactivate collapses the active panel, the badge and
+            // the rail countdown in the same dispatcher turn, so there is no surface for a final
+            // 0:00 to land on.
             Deactivate();
+            return;
         }
+
+        CountdownTick?.Invoke(remaining);
     }
 
     public void Dispose()

--- a/ConditioningControlPanel/Services/Possession/Effects/DeleteDialogEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/DeleteDialogEffect.cs
@@ -76,6 +76,7 @@ public sealed class DeleteDialogEffect : PossessionEffectBase
             if (_names.Count == 0) return;
 
             _cancelled = false;
+            _grinned = false;   // one grin per DIALOG; the reset lives here, not on the close path
             _dialog = BuildDialog(ctx, out status, out bar, out list);
             if (_dialog == null) return;
 
@@ -330,7 +331,12 @@ public sealed class DeleteDialogEffect : PossessionEffectBase
     private bool _grinned;
 
     /// <summary>Closing it does not end the joke, it lands it: a second, quieter bark under the same
-    /// PossessionEffect trigger, keyed so the packs can answer the close specifically.</summary>
+    /// PossessionEffect trigger, keyed so the packs can answer the close specifically.
+    ///
+    /// <para>ONE per dialog, however it goes: the Cancel handler grins and then closes, and closing
+    /// raises Window.Closing, which grins too. The latch is cleared when the next dialog is BUILT, never
+    /// on the way out - clearing it inside CloseDialog (as it once was) re-armed it a line before
+    /// Window.Close() and the warden said it twice.</para></summary>
     private void GrinOnTheWayOut()
     {
         if (_grinned) return;
@@ -346,7 +352,6 @@ public sealed class DeleteDialogEffect : PossessionEffectBase
 
         var dlg = _dialog;
         _dialog = null;
-        _grinned = false;
         if (dlg == null) return;
         try { dlg.Close(); }
         catch (Exception ex) { App.Logger?.Warning("Possession delete dialog close failed: {Error}", ex.Message); }

--- a/ConditioningControlPanel/Services/Possession/Effects/DodgeEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/DodgeEffect.cs
@@ -25,6 +25,24 @@ namespace ConditioningControlPanel.Services.Possession.Effects;
 /// are ordinary Button targets and CAN dodge - the POSSESSION.md rule is that their HIT-TESTING is
 /// never touched, not that they hold still. The X still closes the window; you just have to catch it
 /// first, and after three dodges it stops running.</para>
+///
+/// <para><b>Where it is allowed to land (the invariant, in one place).</b> "Inside the window" is not
+/// the same as "still visible and still clickable", and the difference is two real ways to strand a
+/// control:
+/// <list type="bullet">
+/// <item>a clipped ancestor. The nav rail is a 56 px strip with <c>ClipToBounds</c> (it grows to a
+/// 236 px flyout on hover and snaps back on leave). A door that steps sideways leaves the strip, and
+/// clipped in WPF means invisible AND un-hittable - for the whole 20 s hold. Anything inside a strip
+/// is therefore left alone entirely: it cannot leave its lane, and moving ALONG the lane only parks
+/// it under a neighbouring door.</item>
+/// <item>the title bar. The chrome sits in a 36 px row above opaque page content that paints over it,
+/// so a downward dodge puts the X somewhere the click never reaches. Chrome dodges stay in the title
+/// bar band, horizontally.</item>
+/// </list>
+/// So every dodge is clamped into an ALLOWED REGION (the layer, minus a margin, intersected with
+/// every clipping ancestor and with the chrome's band), and a step that cannot land whole inside it
+/// falls back to the proximity behaviour or does not happen at all. <see cref="DodgeRegion"/> holds
+/// the arithmetic, away from WPF, so it can be pinned by a test.</para>
 /// </summary>
 public sealed class DodgeEffect : PossessionEffectBase
 {
@@ -34,6 +52,10 @@ public sealed class DodgeEffect : PossessionEffectBase
     private const double ProximityPx = 24;
     private const double DodgeMs = 260;
     private const int MaxDodges = 3;
+
+    /// <summary>Below this a "dodge" is a twitch: not worth a charge, and not worth reading as a
+    /// move. It is also the floor a victim's allowed region has to clear to be a candidate.</summary>
+    private const double MinStepPx = 6;
 
     /// <summary>How far ahead of the cursor we look. Long enough to beat a fast flick, short enough
     /// that a hand changing its mind mid-sweep does not set the whole room running.</summary>
@@ -64,11 +86,28 @@ public sealed class DodgeEffect : PossessionEffectBase
     /// <summary>The charge fires with the FIRST dodge, not on Apply: the tell must land with the move.</summary>
     protected override bool ChargeOnApply => false;
 
+    /// <summary>
+    /// A control with nowhere legal to go is not a dodge candidate at all. Answering that HERE and
+    /// not at the first mouse move is what keeps the grammar honest: the deck picks someone else
+    /// instead of spending an ember charge and a warden line on a button that then holds still.
+    /// </summary>
     protected override bool CanApplyCore(PossessionContext ctx, PossessionTarget? target)
     {
         var el = target?.Element;
         if (el == null) return false;
-        return ctx.Host.Window != null;
+        if (ctx.Host.Window == null) return false;
+
+        var home = PossessionVisual.BoundsOf(ctx.Host, el);
+        if (home.IsEmpty || home.Width <= 0) return false;
+
+        var region = AllowedRegion(ctx, el, home);
+        if (!DodgeRegion.TryOffsetRange(home, region,
+                                        out double minX, out double maxX,
+                                        out double minY, out double maxY))
+            return false;
+
+        // Room for a step worth seeing, on either axis.
+        return (maxX - minX) >= MinStepPx || (maxY - minY) >= MinStepPx;
     }
 
     protected override Task ApplyCoreAsync(PossessionContext ctx, PossessionTarget? target, CancellationToken ct)
@@ -144,18 +183,17 @@ public sealed class DodgeEffect : PossessionEffectBase
             if (lease == null) return;
 
             // Everything here is layer space: the cursor came from the ghost layer, and so do the
-            // window edges (the layer is stretched over the whole window).
-            double layerWidth = ctx.Host.GhostLayer?.ActualWidth ?? ctx.Host.Window?.ActualWidth ?? 0;
-            double layerHeight = ctx.Host.GhostLayer?.ActualHeight ?? ctx.Host.Window?.ActualHeight ?? 0;
+            // window edges and every clip rectangle (the layer is stretched over the whole window).
+            // Measured fresh on every dodge, because the rail opens, the window resizes and a tab
+            // switch changes what is clipping the victim between one step and the next.
+            var region = AllowedRegion(ctx, el, _homeRect);
+            if (region.IsEmpty) return;
+            if (!DodgeRegion.TryOffsetRange(_homeRect, region,
+                                            out double minX, out double maxX,
+                                            out double minY, out double maxY))
+                return;
 
-            double minX = 12 - _homeRect.X;
-            double maxX = (layerWidth > 0 ? layerWidth - 12 : _homeRect.Right) - _homeRect.Right;
-            if (maxX < minX) maxX = minX;
-            double minY = 12 - _homeRect.Y;
-            double maxY = (layerHeight > 0 ? layerHeight - 12 : _homeRect.Bottom) - _homeRect.Bottom;
-            if (maxY < minY) maxY = minY;
-
-            double targetX;
+            double targetX = _offsetX;
             double targetY = _offsetY;
 
             if (approach.Length > 0.001)
@@ -177,7 +215,7 @@ public sealed class DodgeEffect : PossessionEffectBase
                 if (aMoved >= bMoved) { targetX = ax; targetY = ay; }
                 else { targetX = bx; targetY = by; }
 
-                if (aMoved < 6 && bMoved < 6)
+                if (aMoved < MinStepPx && bMoved < MinStepPx)
                 {
                     // Cornered sideways: fall back to running away along the approach instead of
                     // vibrating in place.
@@ -185,17 +223,27 @@ public sealed class DodgeEffect : PossessionEffectBase
                     targetY = Math.Clamp(_offsetY - dir.Y * distance, minY, maxY);
                 }
             }
-            else
+
+            if (Math.Abs(targetX - _offsetX) < MinStepPx && Math.Abs(targetY - _offsetY) < MinStepPx)
             {
-                // Proximity: run AWAY from the cursor, staying inside the window with a 12 px margin.
+                // Either this was a proximity trigger, or the predicted step had nowhere legal to go
+                // (a chrome button whose perpendicular is vertical, a region with no sideways slack).
+                // The safe branch: run AWAY from the cursor along X, inside the same region.
+                targetY = Math.Clamp(_offsetY, minY, maxY);
                 double distance = Amp(Rand(40, 120));
                 double away = (cursor.X < _homeRect.X + _offsetX + _homeRect.Width / 2) ? 1 : -1;
                 targetX = Math.Clamp(_offsetX + away * distance, minX, maxX);
-                if (Math.Abs(targetX - _offsetX) < 6)
+                if (Math.Abs(targetX - _offsetX) < MinStepPx)
                     targetX = Math.Clamp(_offsetX - away * distance, minX, maxX);
             }
 
             if (Math.Abs(targetX - _offsetX) < 2 && Math.Abs(targetY - _offsetY) < 2) return;
+
+            // The acceptance test, asserted rather than assumed: the control is fully inside the
+            // region it is allowed to occupy, which is where it stays visible and clickable.
+            if (!DodgeRegion.Contains(region, new Rect(_homeRect.X + targetX, _homeRect.Y + targetY,
+                                                       _homeRect.Width, _homeRect.Height)))
+                return;
 
             _offsetX = targetX;
             _offsetY = targetY;
@@ -207,6 +255,116 @@ public sealed class DodgeEffect : PossessionEffectBase
         }
         catch (Exception ex) { App.Logger?.Warning("Possession dodge failed: {Error}", ex.Message); }
         finally { _busy = false; }
+    }
+
+    // ---- where it may land ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The rectangle the victim must stay whole inside, in LAYER space. Rect.Empty means "this
+    /// control may not dodge at all", which is a perfectly good answer: friction is the point, and a
+    /// control the user cannot see or click is not friction.
+    /// </summary>
+    private static Rect AllowedRegion(PossessionContext ctx, FrameworkElement el, Rect home)
+    {
+        try
+        {
+            var host = ctx.Host;
+            var layer = host.GhostLayer;
+            double layerWidth = layer?.ActualWidth ?? host.Window?.ActualWidth ?? 0;
+            double layerHeight = layer?.ActualHeight ?? host.Window?.ActualHeight ?? 0;
+            if (layerWidth <= 0 || layerHeight <= 0) return Rect.Empty;
+
+            var region = new Rect(DodgeRegion.EdgeMarginPx, DodgeRegion.EdgeMarginPx,
+                                  Math.Max(0, layerWidth - DodgeRegion.EdgeMarginPx * 2),
+                                  Math.Max(0, layerHeight - DodgeRegion.EdgeMarginPx * 2));
+
+            for (DependencyObject? node = VisualTreeHelper.GetParent(el);
+                 node != null;
+                 node = VisualTreeHelper.GetParent(node))
+            {
+                if (node is not FrameworkElement fe) continue;
+                if (layer != null && ReferenceEquals(fe, layer)) break;
+
+                var clip = ClipRectOf(host, fe);
+                if (clip.IsEmpty) continue;
+                if (DodgeRegion.IsStrip(clip, layerWidth, layerHeight)) return Rect.Empty;
+
+                region = Rect.Intersect(region, clip);
+                if (region.IsEmpty) return Rect.Empty;
+            }
+
+            if (PossessionVisual.IsWindowChrome(el))
+            {
+                // Horizontal only, and inside the band the chrome lives in. The victim's own row IS
+                // the band's height here: an X that steps down lands under row 1's opaque content,
+                // where the click never reaches it (POSSESSION.md: it must stay clickable where it
+                // lands). The window margin is deliberately not applied vertically - the title bar
+                // starts at the top of the window, and insetting it would leave no legal row at all.
+                double x0 = region.X, x1 = region.Right;
+                var band = TitleBarBand(host, el);
+                if (!band.IsEmpty)
+                {
+                    x0 = Math.Max(x0, band.X);
+                    x1 = Math.Min(x1, band.Right);
+                }
+                if (x1 - x0 < home.Width) return Rect.Empty;
+                return new Rect(x0, home.Y, x1 - x0, home.Height);
+            }
+
+            return region;
+        }
+        catch (Exception ex)
+        {
+            App.Logger?.Warning("Possession dodge region failed: {Error}", ex.Message);
+            return Rect.Empty;
+        }
+    }
+
+    /// <summary>What this ancestor clips away, in layer space. Rect.Empty when it clips nothing.</summary>
+    private static Rect ClipRectOf(IPossessionHost host, FrameworkElement fe)
+    {
+        var result = Rect.Empty;
+        try
+        {
+            var layer = host?.GhostLayer;
+            if (layer == null) return Rect.Empty;
+
+            if (fe.ClipToBounds) result = Ghost.LayerBoundsOf(host!, fe);
+
+            var clip = fe.Clip;
+            if (clip != null)
+            {
+                var bounds = clip.Bounds;
+                if (!bounds.IsEmpty)
+                {
+                    var explicitClip = fe.TransformToVisual(layer).TransformBounds(bounds);
+                    result = result.IsEmpty ? explicitClip : Rect.Intersect(result, explicitClip);
+                }
+            }
+        }
+        catch { return Rect.Empty; }
+        return result;
+    }
+
+    /// <summary>The band the window chrome sits in, in layer space (the nearest ancestor whose name
+    /// says title bar). Empty when there is none - the caller then keeps the victim in its own row.</summary>
+    private static Rect TitleBarBand(IPossessionHost host, FrameworkElement el)
+    {
+        try
+        {
+            for (DependencyObject? node = VisualTreeHelper.GetParent(el);
+                 node != null;
+                 node = VisualTreeHelper.GetParent(node))
+            {
+                if (node is not FrameworkElement fe) continue;
+                var name = fe.Name;
+                if (string.IsNullOrEmpty(name)) continue;
+                if (name!.IndexOf("titlebar", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return Ghost.LayerBoundsOf(host, fe);
+            }
+        }
+        catch { }
+        return Rect.Empty;
     }
 
     protected override async Task UndoCoreAsync(TimeSpan duration)
@@ -232,5 +390,64 @@ public sealed class DodgeEffect : PossessionEffectBase
         _offsetY = 0;
         _dodges = 0;
         _busy = false;
+    }
+}
+
+/// <summary>
+/// The dodge's geometry, with no WPF in it: given where the control sits and where it is allowed to
+/// be, how far may it move? Split out because "the button stayed visible and clickable" is the whole
+/// acceptance test for <see cref="DodgeEffect"/> and a rectangle test can be written down.
+/// </summary>
+internal static class DodgeRegion
+{
+    /// <summary>Breathing room kept between the victim and the window edge.</summary>
+    internal const double EdgeMarginPx = 12;
+
+    /// <summary>A clip narrower (or shorter) than this fraction of the window is a LANE, not a room:
+    /// the nav rail's 56 px strip, a thumbnail host, a 22 px ticker. Nothing dodges inside one.</summary>
+    internal const double StripFraction = 0.5;
+
+    /// <summary>Sub-pixel slack, so a rectangle that is exactly flush still counts as inside.</summary>
+    internal const double Epsilon = 0.5;
+
+    /// <summary>True when this clip is a lane on either axis.</summary>
+    internal static bool IsStrip(Rect clip, double layerWidth, double layerHeight)
+    {
+        if (clip.IsEmpty) return false;
+        if (layerWidth > 0 && clip.Width < layerWidth * StripFraction) return true;
+        if (layerHeight > 0 && clip.Height < layerHeight * StripFraction) return true;
+        return false;
+    }
+
+    /// <summary>True when <paramref name="rect"/> sits whole inside <paramref name="region"/>.</summary>
+    internal static bool Contains(Rect region, Rect rect)
+    {
+        if (region.IsEmpty || rect.IsEmpty) return false;
+        return rect.X >= region.X - Epsilon
+            && rect.Y >= region.Y - Epsilon
+            && rect.Right <= region.Right + Epsilon
+            && rect.Bottom <= region.Bottom + Epsilon;
+    }
+
+    /// <summary>
+    /// The offsets (from <paramref name="home"/>) that keep the victim whole inside the region.
+    /// False when the region cannot hold it at all, which is the caller's cue not to dodge.
+    /// </summary>
+    internal static bool TryOffsetRange(Rect home, Rect region,
+                                        out double minX, out double maxX,
+                                        out double minY, out double maxY)
+    {
+        minX = maxX = minY = maxY = 0;
+        if (home.IsEmpty || region.IsEmpty) return false;
+        if (home.Width <= 0 || home.Height <= 0) return false;
+        if (region.Width + Epsilon < home.Width || region.Height + Epsilon < home.Height) return false;
+
+        minX = region.X - home.X;
+        maxX = region.Right - home.Right;
+        minY = region.Y - home.Y;
+        maxY = region.Bottom - home.Bottom;
+        if (maxX < minX) maxX = minX;
+        if (maxY < minY) maxY = minY;
+        return true;
     }
 }

--- a/ConditioningControlPanel/Services/Possession/Effects/DropEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/DropEffect.cs
@@ -35,6 +35,10 @@ public sealed class DropEffect : PossessionEffectBase
 
     private TextBlock? _tb;
     private string? _originalText;
+    /// <summary>What the TextBlock reads as while WE own it. RebuildInlines only ever changes the ink,
+    /// never the characters, so this is the original string - but reading it back is how we tell our own
+    /// handiwork from a label something else has rewritten since (see MovedOn).</summary>
+    private string? _writtenText;
     private readonly HashSet<int> _dropped = new();
     private readonly List<Glyph> _glyphs = new();
     private RenderTargetBitmap? _snapshot;
@@ -71,21 +75,22 @@ public sealed class DropEffect : PossessionEffectBase
         if (!PossessionVisual.IsRewritable(_tb, 4)) return Task.CompletedTask;
 
         _originalText = _tb!.Text;
-        if (!TryMeasureLine(_tb, out _startX, out _)) { _originalText = null; return Task.CompletedTask; }
+        _writtenText = _originalText;   // nothing rebuilt yet, and what stands there IS ours
+        if (!TryMeasureLine(_tb, out _startX, out _)) { _originalText = null; _writtenText = null; return Task.CompletedTask; }
 
         // The title lives inside the design Viewbox; the glyphs will live in the ghost layer OUTSIDE
         // it. Everything measured off the TextBlock (FormattedText widths, its own height) is design
         // space and gets scaled on the way out, and the snapshot is rendered at that same scale so the
         // falling letters are crisp instead of resampled.
         var bounds = PossessionVisual.BoundsOf(ctx.Host, _tb);
-        if (bounds.IsEmpty) { _originalText = null; return Task.CompletedTask; }
+        if (bounds.IsEmpty) { _originalText = null; _writtenText = null; return Task.CompletedTask; }
         var scale = PossessionVisual.ScaleOf(ctx.Host, _tb);
         _sx = scale.X;
         _sy = scale.Y;
 
         _dpi = VisualTreeHelper.GetDpi(_tb);
         _snapshot = Ghost.Snapshot(_tb, _dpi, _sx, _sy);
-        if (_snapshot == null) { _originalText = null; return Task.CompletedTask; }
+        if (_snapshot == null) { _originalText = null; _writtenText = null; return Task.CompletedTask; }
 
         _tbOrigin = new Point(bounds.X, bounds.Y);
         _maxDrops = Math.Max(1, (int)(CountEligible(_originalText) * 0.4));
@@ -102,6 +107,9 @@ public sealed class DropEffect : PossessionEffectBase
             {
                 if (!await PossAnim.DelayAsync(Rand(2000, 4000), ct).ConfigureAwait(true)) return;
                 if (ct.IsCancellationRequested) return;
+                // The label stopped being ours while we waited (a level-up, a counter): stop dropping
+                // rather than rebuilding it out of a string nobody is showing any more.
+                if (MovedOn()) return;
                 await DropOneAsync(ctx, ct).ConfigureAwait(true);
             }
         }
@@ -243,9 +251,13 @@ public sealed class DropEffect : PossessionEffectBase
         }
         catch (Exception ex) { App.Logger?.Warning("Possession drop undo failed: {Error}", ex.Message); }
 
+        // The exact string as one Run - but only while the word is still ours. HoldFor is Zero, so an
+        // hour can pass between the drop and the reassembly, and the only labels this effect can take
+        // are code-driven ones ({loc:Str} is a Binding, which IsRewritable declines): exactly the ones
+        // something else rewrites in the meantime. Same guard as XpDrainEffect.RestoreTheLevel.
         try
         {
-            if (_tb != null && _originalText != null) _tb.Text = _originalText;   // exact string, one Run
+            if (_tb != null && _originalText != null && !MovedOn()) _tb.Text = _originalText;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession drop text restore failed: {Error}", ex.Message); }
 
@@ -253,7 +265,22 @@ public sealed class DropEffect : PossessionEffectBase
         _dropped.Clear();
         _snapshot = null;
         _originalText = null;
+        _writtenText = null;
         _tb = null;
+    }
+
+    /// <summary>True when the TextBlock no longer reads as what we left there - something else owns the
+    /// string now and neither the next drop nor the restore may touch it. The transparent Runs keep the
+    /// characters, so "ours" is still the original string.</summary>
+    private bool MovedOn()
+    {
+        try
+        {
+            var tb = _tb;
+            if (tb == null || _writtenText == null) return true;
+            return !string.Equals(tb.Text, _writtenText, StringComparison.Ordinal);
+        }
+        catch { return true; }
     }
 
     // ---- text plumbing -------------------------------------------------------------------------

--- a/ConditioningControlPanel/Services/Possession/Effects/FallEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/FallEffect.cs
@@ -36,8 +36,21 @@ public sealed class FallEffect : PossessionEffectBase
     public override TimeSpan HoldFor => TimeSpan.FromSeconds(45);
     public override IReadOnlyList<PossessionRole> Roles => _roles;
 
+    /// <summary>
+    /// A card is dropped off the bottom of the window AND has its hit-testing turned off for 45 s, so
+    /// everything inside it goes with it. <c>Possession.Exclude</c> inherits DOWN only: the Lockdown
+    /// card is enrollable while BtnEmergencyExit and TxtLockdownExit sit inside it, and taking it
+    /// would take the exits. <see cref="PossessionOffLimits"/> is the shared rule (StealCardEffect
+    /// has carried the same one privately since wave 2).
+    /// </summary>
     protected override bool CanApplyCore(PossessionContext ctx, PossessionTarget? target)
-        => target?.Element != null && !PossessionVisual.IsWindowChrome(target.Element);
+    {
+        var el = target?.Element;
+        if (el == null) return false;
+        if (PossessionVisual.IsWindowChrome(el)) return false;
+        if (PossessionOffLimits.IsOffLimits(el)) return false;
+        return true;
+    }
 
     protected override async Task ApplyCoreAsync(PossessionContext ctx, PossessionTarget? target, CancellationToken ct)
     {

--- a/ConditioningControlPanel/Services/Possession/Effects/GlyphRotEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/GlyphRotEffect.cs
@@ -55,6 +55,10 @@ public sealed class GlyphRotEffect : PossessionEffectBase
 
     private TextBlock? _tb;
     private string? _originalText;
+    /// <summary>The LATEST string we painted. This effect walks the label through a couple of dozen
+    /// intermediate values, so "what we wrote" is a moving target; both Paint and the restore compare
+    /// against this one to tell "still ours" from "someone else owns the label now".</summary>
+    private string? _writtenText;
     private string[]? _cells;      // one display cell per original character
     private int _wordStart;
     private int _wordEnd;          // exclusive
@@ -85,9 +89,13 @@ public sealed class GlyphRotEffect : PossessionEffectBase
         if (!FindWord(_originalText, ctx.Rng, out _wordStart, out _wordEnd))
         {
             _originalText = null;
+            _writtenText = null;
             _tb = null;
             return Task.CompletedTask;
         }
+
+        // Nothing painted yet, so what stands on screen is still the original - and that IS ours.
+        _writtenText = _originalText;
 
         _cells = new string[_originalText.Length];
         for (int i = 0; i < _originalText.Length; i++) _cells[i] = _originalText[i].ToString();
@@ -135,23 +143,40 @@ public sealed class GlyphRotEffect : PossessionEffectBase
             var tb = _tb;
             var cells = _cells;
             if (tb == null || cells == null) return;
+
+            // Someone else wrote this label since our last step (a level-up, a counter tick): it is
+            // theirs now. Stop painting rather than fighting them, and leave _writtenText where it is
+            // so the restore below stands down too.
+            if (_writtenText != null && !string.Equals(tb.Text, _writtenText, StringComparison.Ordinal)) return;
+
             var sb = new StringBuilder(cells.Length + 8);
             foreach (var c in cells) sb.Append(c);
-            tb.Text = sb.ToString();
+            var painted = sb.ToString();
+            tb.Text = painted;
+            _writtenText = painted;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession glyphrot paint failed: {Error}", ex.Message); }
     }
 
+    /// <summary>
+    /// The exact original string, but only while the label still says what we last painted. The labels
+    /// this effect can take are code-driven ones ({loc:Str} is a Binding and IsRewritable declines
+    /// those), so they are exactly the ones that change underneath us; putting our snapshot back over a
+    /// fresher value would lose it. Same guard as XpDrainEffect.RestoreTheLevel.
+    /// </summary>
     protected override Task UndoCoreAsync(TimeSpan duration)
     {
         try
         {
-            if (_tb != null && _originalText != null) _tb.Text = _originalText;   // exact original string
+            if (_tb != null && _originalText != null && _writtenText != null
+                && string.Equals(_tb.Text, _writtenText, StringComparison.Ordinal))
+                _tb.Text = _originalText;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession glyphrot restore failed: {Error}", ex.Message); }
 
         _tb = null;
         _originalText = null;
+        _writtenText = null;
         _cells = null;
         return Task.CompletedTask;
     }

--- a/ConditioningControlPanel/Services/Possession/Effects/MisrouteEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/MisrouteEffect.cs
@@ -87,6 +87,18 @@ public sealed class MisrouteEffect : PossessionEffectBase
                 : _toDoor;
             if (to == null) return null;
 
+            // The destination was picked at Apply, and HoldFor is 20 s: the room has had that long to
+            // change shape underneath us (a door hidden by a tier change, a tab gated, a rail that
+            // re-rendered). Re-ask the host now, at fire time. If the door we chose is no longer a live
+            // one, this press carries on to where the user actually asked to go - a joke that lands on
+            // a missing tab is not a joke, it is a broken app. The hook stays armed, so the next press
+            // can still land if the door comes back before the hold runs out.
+            if (!DoorIsLive(to))
+            {
+                App.Logger?.Debug("Possession misroute stood down: {Door} is no longer a live door", to);
+                return null;
+            }
+
             _fired = true;
             ClearHook();
 
@@ -174,6 +186,21 @@ public sealed class MisrouteEffect : PossessionEffectBase
             return doors[Rng.Next(doors.Count)];
         }
         catch { return null; }
+    }
+
+    /// <summary>Is <paramref name="doorKey"/> a door the user could press RIGHT NOW? The host's registry
+    /// already drops anything invisible, but it is rebuilt lazily (up to 750 ms / 10 s stale), so the
+    /// element's own flags are checked as well - this runs once, on a press, and being right matters more
+    /// here than being fast.</summary>
+    private bool DoorIsLive(string doorKey)
+    {
+        try
+        {
+            var el = DoorElement(doorKey);
+            if (el == null) return false;
+            return el.IsVisible && el.IsEnabled && el.IsHitTestVisible;
+        }
+        catch { return false; }
     }
 
     private FrameworkElement? DoorElement(string doorKey)

--- a/ConditioningControlPanel/Services/Possession/Effects/RetitleEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/RetitleEffect.cs
@@ -35,6 +35,10 @@ public sealed class RetitleEffect : PossessionEffectBase
     private TextBlock? _tb;
     private string? _originalText;
 
+    /// <summary>The exact line we WROTE, so the restore can tell "still ours" from "the world moved on"
+    /// - see UndoCoreAsync. HoldFor is Zero here, so that window is the whole rest of the lockdown.</summary>
+    private string? _writtenText;
+
     public override string Id => "retitle";
     public override PossessionRung MinRung => PossessionRung.Collapse;
     public override PossessionIntensity MinIntensity => PossessionIntensity.FullDoki;
@@ -62,18 +66,29 @@ public sealed class RetitleEffect : PossessionEffectBase
             line = _lines[(Array.IndexOf(_lines, line) + 1) % _lines.Length];
 
         _tb.Text = line;
+        _writtenText = line;
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Restore only while the title still says our line. This one holds until reassembly, so an hour can
+    /// pass between the write and the restore - and the only titles it can take are code-driven ones
+    /// ({loc:Str} is a Binding, which IsRewritable declines), i.e. exactly the ones something else
+    /// rewrites. Putting an hour-old string back over a fresher one is the restore that loses something.
+    /// Same guard as XpDrainEffect.RestoreTheLevel.
+    /// </summary>
     protected override Task UndoCoreAsync(TimeSpan duration)
     {
         try
         {
-            if (_tb != null && _originalText != null) _tb.Text = _originalText;
+            if (_tb != null && _originalText != null && _writtenText != null
+                && string.Equals(_tb.Text, _writtenText, StringComparison.Ordinal))
+                _tb.Text = _originalText;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession retitle restore failed: {Error}", ex.Message); }
         _tb = null;
         _originalText = null;
+        _writtenText = null;
         return Task.CompletedTask;
     }
 }

--- a/ConditioningControlPanel/Services/Possession/Effects/RewriteEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/RewriteEffect.cs
@@ -24,9 +24,13 @@ public sealed class RewriteEffect : PossessionEffectBase
 
     private TextBlock? _tb;
     private string? _originalText;
+    /// <summary>The exact string we WROTE, so the restore can tell "still ours" from "the world moved
+    /// on" - see UndoCoreAsync.</summary>
+    private string? _writtenText;
 
     private ContentControl? _cc;
     private object? _originalContent;
+    private string? _writtenContent;
 
     public override string Id => "rewrite";
     public override PossessionRung MinRung => PossessionRung.Drift;
@@ -70,6 +74,7 @@ public sealed class RewriteEffect : PossessionEffectBase
                 _cc = cc;
                 _originalContent = cc.Content;   // the exact object, not a copy of the string
                 cc.Content = line;
+                _writtenContent = line;
                 return Task.CompletedTask;
             }
 
@@ -86,30 +91,44 @@ public sealed class RewriteEffect : PossessionEffectBase
 
             _originalText = text;
             _tb.Text = rewritten;
+            _writtenText = rewritten;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession rewrite failed: {Error}", ex.Message); }
 
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// The exact original - but only while the control still carries what WE put there. Every label
+    /// this effect can take is a code-driven one ({loc:Str} is a Binding, which IsRewritable declines),
+    /// which makes them precisely the ones something else rewrites: a level-up writing TxtLevelLabel, a
+    /// counter ticking. Restoring a three-second-old string over that would quietly undo the newer
+    /// value. Same guard as XpDrainEffect.RestoreTheLevel.
+    /// </summary>
     protected override Task UndoCoreAsync(TimeSpan duration)
     {
         try
         {
-            if (_cc != null && _originalContent != null) _cc.Content = _originalContent;
+            if (_cc != null && _originalContent != null && _writtenContent != null
+                && _cc.Content is string now && string.Equals(now, _writtenContent, StringComparison.Ordinal))
+                _cc.Content = _originalContent;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession rewrite content restore failed: {Error}", ex.Message); }
 
         try
         {
-            if (_tb != null && _originalText != null) _tb.Text = _originalText;
+            if (_tb != null && _originalText != null && _writtenText != null
+                && string.Equals(_tb.Text, _writtenText, StringComparison.Ordinal))
+                _tb.Text = _originalText;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession rewrite text restore failed: {Error}", ex.Message); }
 
         _cc = null;
         _originalContent = null;
+        _writtenContent = null;
         _tb = null;
         _originalText = null;
+        _writtenText = null;
         return Task.CompletedTask;
     }
 

--- a/ConditioningControlPanel/Services/Possession/Effects/RoomWarpEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/RoomWarpEffect.cs
@@ -58,6 +58,7 @@ public sealed class RoomWarpEffect : PossessionEffectBase
     private bool _metricsCaptured;
     private double _w0, _h0, _left0, _top0;
     private bool _wLocal, _hLocal, _leftLocal, _topLocal;
+    private SizeToContent _sizeToContent0 = SizeToContent.Manual;
 
     public override string Id => "roomwarp";
     public override PossessionRung MinRung => PossessionRung.Collapse;
@@ -310,6 +311,9 @@ public sealed class RoomWarpEffect : PossessionEffectBase
             _hLocal = w.ReadLocalValue(FrameworkElement.HeightProperty) != DependencyProperty.UnsetValue;
             _leftLocal = w.ReadLocalValue(Window.LeftProperty) != DependencyProperty.UnsetValue;
             _topLocal = w.ReadLocalValue(Window.TopProperty) != DependencyProperty.UnsetValue;
+            _sizeToContent0 = w.SizeToContent;
+            // The size the room actually HAD, whichever way it was established: a window whose Width
+            // is NaN is still some number of pixels wide, and that number is what the undo owes back.
             _w0 = double.IsNaN(w.Width) ? w.ActualWidth : w.Width;
             _h0 = double.IsNaN(w.Height) ? w.ActualHeight : w.Height;
             _left0 = w.Left;
@@ -327,8 +331,26 @@ public sealed class RoomWarpEffect : PossessionEffectBase
         {
             if (w.WindowState == WindowState.Normal)
             {
-                if (_wLocal) w.Width = _w0; else if (_shrunk > 0) w.ClearValue(FrameworkElement.WidthProperty);
-                if (_hLocal) w.Height = _h0; else if (_shrunk > 0) w.ClearValue(FrameworkElement.HeightProperty);
+                // The toll was paid in PIXELS (w.Width = ... on every escape attempt), so the refund
+                // has to be pixels too. ClearValue looks like the tidy way to hand a property that
+                // had no local value back to whoever owned it - and it is what NeutralTransform and
+                // FallEffect correctly do - but a Window is not a Border: WPF ignores a NaN width, so
+                // clearing it leaves the HWND at the shrunken size and the room simply never grows
+                // back. The one case where clearing IS the restore is a window that sizes itself to
+                // its content on that axis; then a local width is the thing that would be wrong.
+                bool contentSizesWidth = _sizeToContent0 is SizeToContent.Width or SizeToContent.WidthAndHeight;
+                bool contentSizesHeight = _sizeToContent0 is SizeToContent.Height or SizeToContent.WidthAndHeight;
+
+                if (_wLocal || _shrunk > 0)
+                {
+                    if (!_wLocal && contentSizesWidth) w.ClearValue(FrameworkElement.WidthProperty);
+                    else if (!double.IsNaN(_w0) && _w0 > 0) w.Width = _w0;
+                }
+                if (_hLocal || _shrunk > 0)
+                {
+                    if (!_hLocal && contentSizesHeight) w.ClearValue(FrameworkElement.HeightProperty);
+                    else if (!double.IsNaN(_h0) && _h0 > 0) w.Height = _h0;
+                }
                 if (!double.IsNaN(_left0) && (_leftLocal || _nudgedX > 0)) w.Left = _left0;
                 if (!double.IsNaN(_top0) && (_topLocal || _nudgedY > 0)) w.Top = _top0;
             }
@@ -336,6 +358,7 @@ public sealed class RoomWarpEffect : PossessionEffectBase
         catch (Exception ex) { App.Logger?.Warning("Possession roomwarp metric restore failed: {Error}", ex.Message); }
 
         _metricsCaptured = false;
+        _sizeToContent0 = SizeToContent.Manual;
         _shrunk = 0;
         _nudgedX = 0;
         _nudgedY = 0;

--- a/ConditioningControlPanel/Services/Possession/Effects/StealCardEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/StealCardEffect.cs
@@ -48,6 +48,9 @@ public sealed class StealCardEffect : PossessionEffectBase
     private Point _flightTarget;     // layer space, where the tube was standing
     private bool _flew;
 
+    /// <summary>True while this effect holds the warden's tube lease (see <see cref="TakeTube"/>).</summary>
+    private bool _holdsTube;
+
     public override string Id => "stealcard";
     public override PossessionRung MinRung => PossessionRung.Collapse;
     public override PossessionIntensity MinIntensity => PossessionIntensity.Gentle;
@@ -118,30 +121,39 @@ public sealed class StealCardEffect : PossessionEffectBase
                                ghost.Origin.Y + ghost.SizeDip.Height / 2.0);
         _flightTarget = centre;
 
-        var tube = AvailableTube();
-        if (tube != null)
+        var tube = TakeTube();
+        try
         {
-            _flew = await GlideBesideAsync(tube, el, ct).ConfigureAwait(true);
-            if (_flew)
+            if (tube != null)
             {
-                if (!await PossAnim.DelayAsync(BeatMs, ct).ConfigureAwait(true)) return;
-                var mouth = TubeMouthInLayer(ctx);
-                if (mouth.HasValue) _flightTarget = mouth.Value;
+                _flew = await GlideBesideAsync(tube, el, ct).ConfigureAwait(true);
+                if (_flew)
+                {
+                    if (!await PossAnim.DelayAsync(BeatMs, ct).ConfigureAwait(true)) return;
+                    var mouth = TubeMouthInLayer(ctx);
+                    if (mouth.HasValue) _flightTarget = mouth.Value;
+                }
             }
+
+            double dx = _flightTarget.X - centre.X;
+            double dy = _flightTarget.Y - centre.Y;
+
+            PossAnim.To(_scale, ScaleTransform.ScaleXProperty, TinyScale, SuckMs, PossAnim.EaseIn);
+            PossAnim.To(_scale, ScaleTransform.ScaleYProperty, TinyScale, SuckMs, PossAnim.EaseIn);
+            PossAnim.To(_tr, TranslateTransform.XProperty, dx, SuckMs, PossAnim.EaseIn);
+            PossAnim.To(_tr, TranslateTransform.YProperty, dy, SuckMs, PossAnim.EaseIn);
+            PossAnim.To(visual, UIElement.OpacityProperty, 0, SuckMs, PossAnim.EaseIn);
+            await PossAnim.DelayAsync(SuckMs + 30, ct).ConfigureAwait(true);
+
+            // The tube got what it came for; send it home rather than leaving it parked for two minutes.
+            if (_flew) SendTubeHome();
         }
-
-        double dx = _flightTarget.X - centre.X;
-        double dy = _flightTarget.Y - centre.Y;
-
-        PossAnim.To(_scale, ScaleTransform.ScaleXProperty, TinyScale, SuckMs, PossAnim.EaseIn);
-        PossAnim.To(_scale, ScaleTransform.ScaleYProperty, TinyScale, SuckMs, PossAnim.EaseIn);
-        PossAnim.To(_tr, TranslateTransform.XProperty, dx, SuckMs, PossAnim.EaseIn);
-        PossAnim.To(_tr, TranslateTransform.YProperty, dy, SuckMs, PossAnim.EaseIn);
-        PossAnim.To(visual, UIElement.OpacityProperty, 0, SuckMs, PossAnim.EaseIn);
-        await PossAnim.DelayAsync(SuckMs + 30, ct).ConfigureAwait(true);
-
-        // The tube got what it came for; send it home rather than leaving it parked for two minutes.
-        if (_flew) SendTubeHome();
+        finally
+        {
+            // Every early return above (cancelled beat, cancelled suck) must give the tube back, or the
+            // warden's busy flag stays raised for the rest of the lockdown and it never knocks again.
+            ReleaseTube();
+        }
     }
 
     protected override async Task UndoCoreAsync(TimeSpan duration)
@@ -169,7 +181,10 @@ public sealed class StealCardEffect : PossessionEffectBase
         try { ghost?.Dispose(); }
         catch (Exception ex) { App.Logger?.Warning("Possession stealcard restore failed: {Error}", ex.Message); }
 
-        if (_flew) SendTubeHome();
+        // Belt and braces - the apply already sent it home. Only re-send when the tube is actually
+        // free: SendTubeHome CLEARS the tube's captured home, so doing it during a warden knock or
+        // leave strands the tube wherever that verb left it.
+        if (_flew && TakeTube() != null) SendTubeHome();
 
         _ghost = null;
         _tr = null;
@@ -261,19 +276,38 @@ public sealed class StealCardEffect : PossessionEffectBase
 
     // ---- the tube ------------------------------------------------------------------------------
 
-    /// <summary>The warden's gates, mirrored (Warden.IsAvailable is the same list). Null means the
-    /// theft happens without a thief on screen.</summary>
-    private static AvatarTubeWindow? AvailableTube()
+    /// <summary>The warden's gates, mirrored (Warden.IsAvailable is the same list) PLUS the warden's
+    /// own busy flag, taken as a lease. Null means the theft happens without a thief on screen.
+    ///
+    /// <para><b>The lease is the whole coordination mechanism.</b> A theft and a warden verb both move
+    /// the tube and both rely on <c>AvatarTubeWindow</c>'s single captured "home"; whichever one calls
+    /// ReturnHomeAsync first clears it and strands the other. Taking the same <c>_busy</c> flag the
+    /// verbs take means only one of them is ever moving the tube, so the capture bookkeeping has
+    /// exactly one owner. Also honours the warden's cooldown-free availability gates.</para></summary>
+    private AvatarTubeWindow? TakeTube()
     {
         try
         {
+            if (_holdsTube) return App.AvatarWindow;
             if (App.Settings?.Current?.LockdownWardenEnabled != true) return null;
             var tube = App.AvatarWindow;
             if (tube == null || !tube.CanPerformPossessionMove) return null;
             if (App.Video?.IsPlaying == true) return null;
+
+            var warden = App.Possession?.Warden as Warden;
+            if (warden != null && !warden.TryTakeTube()) return null;   // a knock / stare / leave owns it
+            _holdsTube = true;
             return tube;
         }
         catch { return null; }
+    }
+
+    /// <summary>Give the tube back to the warden. Safe when the lease was never taken.</summary>
+    private void ReleaseTube()
+    {
+        if (!_holdsTube) return;
+        _holdsTube = false;
+        try { (App.Possession?.Warden as Warden)?.ReleaseTube(); } catch { }
     }
 
     private static async Task<bool> GlideBesideAsync(AvatarTubeWindow tube, FrameworkElement el,
@@ -316,14 +350,23 @@ public sealed class StealCardEffect : PossessionEffectBase
         catch { return null; }
     }
 
-    private static void SendTubeHome()
+    /// <summary>Send the tube home, and give the warden its lease back only once it has ARRIVED.
+    /// ReturnHomeAsync clears the tube's captured home in its finally, so releasing any earlier would
+    /// let a warden verb capture a home that is about to be wiped out from under it.</summary>
+    private void SendTubeHome()
     {
+        if (!_holdsTube) return;
+        _holdsTube = false;   // the homeward leg owns the lease from here; ReleaseTube() now no-ops
+
+        static void Done() { try { (App.Possession?.Warden as Warden)?.ReleaseTube(); } catch { } }
+
         try
         {
-            var tube = App.AvatarWindow;
-            if (tube == null) return;
-            _ = tube.ReturnHomeAsync(CancellationToken.None);
+            var t = App.AvatarWindow?.ReturnHomeAsync(CancellationToken.None);
+            if (t == null) { Done(); return; }
+            _ = t.ContinueWith(_ => Done(), CancellationToken.None,
+                               TaskContinuationOptions.None, TaskScheduler.Default);
         }
-        catch { }
+        catch { Done(); }
     }
 }

--- a/ConditioningControlPanel/Services/Possession/Effects/TypoEffect.cs
+++ b/ConditioningControlPanel/Services/Possession/Effects/TypoEffect.cs
@@ -26,6 +26,10 @@ public sealed class TypoEffect : PossessionEffectBase
     private TextBlock? _tb;
     private string? _originalText;
 
+    /// <summary>The exact string we last WROTE. Undo only puts the original back when the label still
+    /// says this - see the note on UndoCoreAsync.</summary>
+    private string? _writtenText;
+
     public override string Id => "typo";
     public override PossessionRung MinRung => PossessionRung.Settle;
     public override PossessionIntensity MinIntensity => PossessionIntensity.Gentle;
@@ -53,22 +57,34 @@ public sealed class TypoEffect : PossessionEffectBase
         if (typo == null || string.Equals(typo, _originalText, StringComparison.Ordinal))
         {
             _originalText = null;
+            _writtenText = null;
             return Task.CompletedTask;
         }
 
         _tb.Text = typo;
+        _writtenText = typo;
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Put the word back only if the label still says what WE made it say. The only labels this effect
+    /// can take are code-driven ones ({loc:Str} is a Binding, and IsRewritable declines those), which
+    /// makes them exactly the labels something else rewrites underneath us - a level-up writing
+    /// TxtLevelLabel, a counter ticking. Stamping a four-second-old string over that would be the one
+    /// restore that loses something instead of giving it back. Same guard as XpDrainEffect.RestoreTheLevel.
+    /// </summary>
     protected override Task UndoCoreAsync(TimeSpan duration)
     {
         try
         {
-            if (_tb != null && _originalText != null) _tb.Text = _originalText;
+            if (_tb != null && _originalText != null && _writtenText != null
+                && string.Equals(_tb.Text, _writtenText, StringComparison.Ordinal))
+                _tb.Text = _originalText;
         }
         catch (Exception ex) { App.Logger?.Warning("Possession typo restore failed: {Error}", ex.Message); }
         _tb = null;
         _originalText = null;
+        _writtenText = null;
         return Task.CompletedTask;
     }
 

--- a/ConditioningControlPanel/Services/Possession/Ghost.cs
+++ b/ConditioningControlPanel/Services/Possession/Ghost.cs
@@ -33,10 +33,19 @@ public sealed class Ghost : IDisposable
 {
     private readonly IPossessionHost _host;
     private readonly FrameworkElement _target;
-    private readonly double _originalOpacity;
-    private readonly bool _originalHitTestVisible;
     private readonly List<Image> _tiles = new();
     private readonly List<UIElement> _extras = new();
+
+    // What Hide() found before it wrote anything. "Was there a local value at all" is half of the
+    // answer: a control whose Opacity or IsHitTestVisible comes from a Style setter, a trigger or a
+    // storyboard has NO local value, and stamping one on the way back pins it forever - the hover
+    // highlight never fires again, the disabled state never greys out. See FallEffect and
+    // Ghost.NeutralTransform for the same dance.
+    private bool _opacityWasLocal;
+    private double _opacityValue = 1;
+    private bool _hitTestChanged;
+    private bool _hitTestWasLocal;
+    private bool _hitTestValue = true;
 
     private bool _hidden;
     private bool _disposed;
@@ -67,8 +76,6 @@ public sealed class Ghost : IDisposable
     {
         _host = host;
         _target = target;
-        _originalOpacity = target.Opacity;
-        _originalHitTestVisible = target.IsHitTestVisible;
         Bitmap = bmp;
         Origin = origin;
         SizeDip = size;
@@ -294,22 +301,44 @@ public sealed class Ghost : IDisposable
         if (_disposed || _hidden) return;
         try
         {
+            _opacityWasLocal = _target.ReadLocalValue(UIElement.OpacityProperty) != DependencyProperty.UnsetValue;
+            _opacityValue = _target.Opacity;
             _target.Opacity = 0;
-            if (alsoDisableHitTesting) _target.IsHitTestVisible = false;
+
+            if (alsoDisableHitTesting)
+            {
+                _hitTestWasLocal = _target.ReadLocalValue(UIElement.IsHitTestVisibleProperty) != DependencyProperty.UnsetValue;
+                _hitTestValue = _target.IsHitTestVisible;
+                _target.IsHitTestVisible = false;
+                _hitTestChanged = true;
+            }
             _hidden = true;
         }
         catch (Exception ex) { App.Logger?.Warning("Ghost.Hide failed: {Error}", ex.Message); }
     }
 
-    /// <summary>Put the real control's ORIGINAL opacity back and drop every borrowed visual.</summary>
+    /// <summary>
+    /// Put the real control's ORIGINAL opacity back and drop every borrowed visual. Original means
+    /// what it had, INCLUDING "it had no local value of its own": Hide's write is cleared rather than
+    /// overwritten in that case, so a control whose opacity or hit-testing comes from a style, a
+    /// trigger or a running storyboard is handed back still under their control. Hit-testing is only
+    /// touched when Hide actually turned it off.
+    /// </summary>
     public void Restore()
     {
         try
         {
             if (_hidden)
             {
-                _target.Opacity = _originalOpacity;
-                _target.IsHitTestVisible = _originalHitTestVisible;
+                if (_opacityWasLocal) _target.Opacity = _opacityValue;
+                else _target.ClearValue(UIElement.OpacityProperty);
+
+                if (_hitTestChanged)
+                {
+                    if (_hitTestWasLocal) _target.IsHitTestVisible = _hitTestValue;
+                    else _target.ClearValue(UIElement.IsHitTestVisibleProperty);
+                    _hitTestChanged = false;
+                }
                 _hidden = false;
             }
         }

--- a/ConditioningControlPanel/Services/Possession/POSSESSION.md
+++ b/ConditioningControlPanel/Services/Possession/POSSESSION.md
@@ -93,7 +93,11 @@ lives in a Viewbox over a 1585x901 design canvas, so `ActualWidth` is design uni
 
 Never enrolled, subtree and all: `Possession.Exclude`, the GhostLayer / RubbleFloor, and the names
 `TxtLockdownTimer`, `TxtLockdownExit`, `BtnEmergencyExit`, `EERoot`, `LockdownGate`,
-`TxtPossessionRung`, `PossessionPips`. Other windows (avatar tube, playback, content) are separate
+`TxtPossessionRung`, `PossessionPips`, `TxtXP` (THE BANK's odometer rewrites it ~every 70 ms during
+token flights, so a text effect there is a silent no-op and its undo would stamp a stale number).
+An explicit hand-tag `poss:Possession.Role` beats the name blocklist - that is what lets
+`TxtLockdownTimer` carry `Role="Timer"` for the wobble while staying auto-untouchable; `Exclude`
+and `IsVisible` still win over everything. Other windows (avatar tube, playback, content) are separate
 visual trees and are unreachable from this walk by construction; popups likewise.
 
 Names: `Possession.Name` -> string `Content` -> `ToolTip` string -> `AutomationProperties.Name` ->
@@ -166,10 +170,10 @@ clears `_barkedRungs` so every rung can announce itself again, undoes every live
 second (the reassembly path, but quick - this is a reset, not a curtain call), pulses the edge at 0.6,
 and sets `_nextDue` to a full `FirstDelay` so there is a silence to notice before it all starts again.
 
-**Open wiring:** the bark trigger `PossessionBarkTriggers.TimerRestarted` exists but its BarkService
-wrapper does not. The director probes for `NotifyPossessionTimerRestarted(string reason, int restart)`
-once and logs a Warning when it is absent; adding that wrapper is all it takes to make the moment
-speak. Replace the probe with a direct call when it lands.
+The bark wrapper `BarkService.NotifyPossessionTimerRestarted(string reason, int restart)` exists and
+the director calls it directly (the reflection probe this section once described is gone). The pack
+rules fire it only from the second restart on (`restart_gte: 2`); the first sendback is voiced by
+`ee_sendback` instead.
 
 ## Tripwires (escape attempts)
 
@@ -262,8 +266,10 @@ Hard rules for every file:
   dodge, it must stay clickable where it lands).
 - Never start an effect while `IPossessionHost.IsUsable` is false; live effects may finish. A playing
   video is NOT a reason to stop (wave 2, A3): a lockdown run is mostly video, so the old pause meant
-  the haunt spent most of its life asleep. What still stops it: minimized / not loaded, a content
-  window that has taken the screen (DTRH, Loom, Arcademy), and an open Lock Card.
+  the haunt spent most of its life asleep. What still stops it: minimized / not loaded, an open Lock
+  Card, and ANY content window that has taken the screen - every `ChaosWebViewHost` takeover host is
+  checked (DTRH, Loom, Arcademy, Bureau, Goon, JustDrop, FYP, Intake, and the Emergency Exit game
+  window itself).
 - Everything dispatcher-safe (`Application.Current?.Dispatcher`), wrapped in try/catch, logs via
   `App.Logger` at Debug for routine picks and Warning for failures. A failing effect undoes itself.
 - Photosafe + `SystemParameters.ClientAreaAnimation == false` = no flicker effects, static charge.
@@ -311,7 +317,7 @@ the shipped behaviour, not the plan.
 | B15 event-driven ghosts (FeatureOpened -> card breathes, SettingChanged -> its label retypes, hover Stop -> dodge, door click -> letter drop) | FOUNDATION | `PossessionDirector.cs` (+ an `PossessionEvents.cs` adapter) |
 | Timer restart handling (`LockdownService.TimerRestarted`): rung -> Settle, `_barkedRungs` cleared, UndoAll over 1 s, EdgePulse, bark `PossessionBarkTriggers.TimerRestarted` | FOUNDATION | `PossessionDirector.cs` |
 | B1 ghost cursor, B2 predictive dodge incl. title-bar X/min, B3 real Start/Stop swap + "Stay" relabel, B4 slider ghost-thumb creep + toggle lies, B5 label rewrite + glyph rot (per-mod line packs) | Opus EFFECTS-A | `Effects/GhostCursorEffect.cs`, `Effects/Dodge*` (edit), `Effects/Swap*` (edit), `Effects/SliderCreepEffect.cs`, `Effects/ToggleLieEffect.cs`, `Effects/RewriteEffect.cs`, `Effects/GlyphRotEffect.cs`, `Effects/PossessionEffectCatalog.WaveA.cs` |
-| B7 XP drain / level lie, B8 tube steals an ACTIVE card (a usable card on the current tab - the option is really gone until reassembly), B9 room tilt/sag/deepen + per-escape 1 px shrink/2 px nudge (self-contained service on the lockdown events), B10 tab misroute + door reorder, B11 crimson toasts, B14 scroll hijack, C1 fake "deleting your sessions" dialog (Full Doki) | Opus EFFECTS-B | `Effects/XpDrainEffect.cs`, `Effects/StealCardEffect.cs` (+ `Warden.cs` steal verb), `Services/Possession/RoomWarp.cs`, `Effects/MisrouteEffect.cs`, `Effects/ReorderDoorsEffect.cs`, `Effects/ToastEffect.cs`, `Effects/ScrollHijackEffect.cs`, `Effects/DeleteDialogEffect.cs`, `Effects/PossessionEffectCatalog.WaveB.cs`, `MainWindow/MainWindow.NavRail.cs` (misroute hook only) |
+| B7 XP drain / level lie, B8 tube steals an ACTIVE card (a usable card on the current tab - the option is really gone until reassembly), B9 room tilt/sag/deepen + per-escape 1 px shrink/2 px nudge (self-contained service on the lockdown events), B10 tab misroute + door reorder, B11 crimson toasts, B14 scroll hijack, C1 fake "deleting your sessions" dialog (Full Doki) | Opus EFFECTS-B | `Effects/XpDrainEffect.cs`, `Effects/StealCardEffect.cs` (+ `Warden.cs` steal verb), `Effects/RoomWarpEffect.cs`, `Effects/MisrouteEffect.cs`, `Effects/ReorderDoorsEffect.cs`, `Effects/ToastEffect.cs`, `Effects/ScrollHijackEffect.cs`, `Effects/DeleteDialogEffect.cs`, `Effects/PossessionEffectCatalog.WaveB.cs`, `MainWindow/MainWindow.NavRail.cs` (misroute hook only) |
 | B12 chat knows (lockdown flag in the companion prompt), B13 audio tics (ember tick SFX on big effects + 300 ms pitch-dip at rung change / tripwire repeat 3), C2 it remembers (flag + next-launch tic + line), C3 portrait glitch frames (R4, photosafe-gated), C4 Full Doki retitle at R3 + note in the empty tube | Opus COMPANION | `Services/Possession/PossessionAudio.cs`, `Effects/RetitleEffect.cs`, `Warden.cs` (note), `AvatarTubeWindow` glitch hook, companion prompt builder, `Models/AppSettings.cs` (`LockdownPossessionRemembers*`), `Effects/PossessionEffectCatalog.WaveC.cs` |
 
 REJECTED by owner: B6 name drop (sensitive userbase - never use the Windows username), D2/D3

--- a/ConditioningControlPanel/Services/Possession/PossessionDeck.cs
+++ b/ConditioningControlPanel/Services/Possession/PossessionDeck.cs
@@ -94,6 +94,18 @@ public static class PossessionDeck
         _ => 4,
     };
 
+    /// <summary>Does a haunt worth <paramref name="slots"/> still fit under the rung's cap? A single
+    /// effect is one slot; a SCENE is its beat count (POSSESSION.md: "a scene counts as its beat
+    /// count"), which is why this takes a weight instead of assuming one. The director used to elect a
+    /// scene only after checking a flat "+2", so a three-beat choreography could be waved into a Melt
+    /// room (cap 3) that already had a ghost live and push it to four.</summary>
+    public static bool FitsConcurrency(int liveSlots, int slots, PossessionRung rung)
+    {
+        if (slots <= 0) slots = 1;
+        if (liveSlots < 0) liveSlots = 0;
+        return liveSlots + slots <= MaxLive(rung);
+    }
+
     // ---------------------------------------------------------------------------------------------
     //  Cadence
     // ---------------------------------------------------------------------------------------------

--- a/ConditioningControlPanel/Services/Possession/PossessionDirector.cs
+++ b/ConditioningControlPanel/Services/Possession/PossessionDirector.cs
@@ -50,10 +50,22 @@ public sealed class PossessionDirector : IDisposable
     private DateTime _lastTripwireAt = DateTime.MinValue;
     private DateTime _lastStareAt = DateTime.MinValue;
     private DateTime _lastReactiveAt = DateTime.MinValue;
+    private DateTime _lastRestartAt = DateTime.MinValue;
     private bool _picking;
     private bool _disposed;
 
+    /// <summary>Bumped on every activation. Anything with a long tail of awaits (the reassembly exit
+    /// is three seconds of undo plus up to fifteen of warden) captures it first and bails when it has
+    /// moved: by then a NEW lockdown may own the room, and the previous one's curtain call must not
+    /// strip its outlines or reset its rung.</summary>
+    private int _generation;
+
     private static readonly TimeSpan TripwireThrottle = TimeSpan.FromSeconds(1.5);
+
+    /// <summary>How long after a timer restart a rung change counts as "the restart's own". The
+    /// restart sets the rung, pulses the edge and spends the rung bark itself; a tick landing inside
+    /// this window must not do any of it a second time, whichever of the two events arrived first.</summary>
+    private static readonly TimeSpan RestartQuiet = TimeSpan.FromSeconds(2);
 
     /// <summary>Floor between event-driven ghosts (B15). The reactive layer answers what the USER does,
     /// and a user clicking around a tab generates events far faster than the room should answer them -
@@ -133,6 +145,8 @@ public sealed class PossessionDirector : IDisposable
     {
         try
         {
+            // Release() (inside UndoGhostSync) is what owns the ledger; these two are a belt, and they
+            // are only safe HERE because there is no await above them for a new ghost to arrive in.
             foreach (var g in _live.ToArray()) UndoGhostSync(g);
             _live.Clear();
             _liveKeys.Clear();
@@ -149,6 +163,10 @@ public sealed class PossessionDirector : IDisposable
     {
         try
         {
+            // Bumped before the enabled check so a lockdown that runs WITHOUT possession still
+            // invalidates a reassembly the previous one left in flight.
+            _generation++;
+
             var s = App.Settings?.Current;
             if (s == null || !s.LockdownPossessionEnabled)
             {
@@ -162,10 +180,19 @@ public sealed class PossessionDirector : IDisposable
 
             _barkedRungs.Clear();
             _cooldowns.Clear();
-            _liveKeys.Clear();
+            // The live ledger belongs to Release(). Wiping it wholesale would orphan any ghost the
+            // PREVIOUS lockdown's reassembly is still unwinding underneath us - its control would go
+            // back into the pool while it is still possessed. Sweep it only when nothing is live,
+            // which is the case this is here for (a leaked key must never ban a control forever).
+            if (_live.Count == 0) _liveKeys.Clear();
             _lastTargetKey = null;
             _lastTripwireAt = DateTime.MinValue;
             _lastStareAt = DateTime.MinValue;
+            _lastReactiveAt = DateTime.MinValue;
+            _lastRestartAt = DateTime.MinValue;
+            // A pick that died with a torn-down window never reaches StartOneAsync's finally, and a
+            // stuck flag shuts the cadence loop for every LATER lockdown as well.
+            _picking = false;
             CurrentRung = PossessionRung.Settle;
             IsHaunting = true;
 
@@ -205,10 +232,16 @@ public sealed class PossessionDirector : IDisposable
                 App.Logger?.Information("Possession rung {From} -> {To} at {Pct:P0}", previous, rung, frac);
                 try { RungChanged?.Invoke(rung); } catch { }
 
+                // Belt for the timer restart: a restart sets the rung, pulses the edge at 0.6 and
+                // spends that rung's bark itself, so a tick landing on the same moment would flare
+                // and announce it twice. LockdownService raises TimerRestarted and CountdownTick from
+                // the same rewind; this makes the pair idempotent whichever order they arrive in.
+                var justRestarted = DateTime.Now - _lastRestartAt < RestartQuiet;
+
                 // The rung change itself is an event: the whole window flares once so the escalation is
                 // never something the user only notices in hindsight.
-                PulseAll(0.35 + 0.15 * (int)rung);
-                if (_barkedRungs.Add(rung)) { try { App.Bark?.NotifyPossessionRung((int)rung); } catch { } }
+                if (!justRestarted) PulseAll(0.35 + 0.15 * (int)rung);
+                if (_barkedRungs.Add(rung) && !justRestarted) { try { App.Bark?.NotifyPossessionRung((int)rung); } catch { } }
 
                 if (rung == PossessionRung.ItKnows && _wardenEnabled && Warden?.IsAvailable == true)
                     FireAndForget(RunWardenAsync(ct => Warden!.LeaveAsync(ct), "leave"), "warden leave");
@@ -216,7 +249,7 @@ public sealed class PossessionDirector : IDisposable
 
             if (_picking) return;
             if (DateTime.Now < _nextDue) return;
-            if (LiveSlots >= PossessionDeck.MaxLive(rung)) return;
+            if (!PossessionDeck.FitsConcurrency(LiveSlots, 1, rung)) return;
             // A3 (wave 2): the video check that used to live here is GONE. It read as "content is king",
             // but in practice a lockdown run is mostly video, so the haunt spent most of its life
             // paused and the owner's first live run felt empty. What still stops us is the host's own
@@ -433,9 +466,18 @@ public sealed class PossessionDirector : IDisposable
                 eligible.Add(sc);
             }
             if (eligible.Count == 0) return false;
-            if (LiveSlots + 2 > PossessionDeck.MaxLive(rung)) return false;
 
+            // Elect FIRST, then check the cap against what THIS scene actually costs. The old order
+            // checked a flat "+2" and then booked Math.Max(1, scene.Beats): a three-beat scene elected
+            // into a Melt room (cap 3) that already had one ghost live pushed the room to four.
             var scene = eligible[_rng.Next(eligible.Count)];
+            var slots = Math.Max(1, scene.Beats);
+            if (!PossessionDeck.FitsConcurrency(LiveSlots, slots, rung))
+            {
+                App.Logger?.Debug("Possession scene {Scene} ({Slots} slots) does not fit at rung {Rung} (live {Live}/{Max})",
+                    scene.Id, slots, rung, LiveSlots, PossessionDeck.MaxLive(rung));
+                return false;
+            }
 
             // The scene books its own victims through this callback so the director keeps ownership of
             // the ledger: everything it claims is marked live here and released (with a cooldown) when
@@ -489,7 +531,7 @@ public sealed class PossessionDirector : IDisposable
 
             var adapter = new PossessionSceneEffect(scene, Picker);
             var cts = new CancellationTokenSource();
-            ghost = new LiveGhost(adapter, null, host, cts) { Slots = Math.Max(1, scene.Beats) };
+            ghost = new LiveGhost(adapter, null, host, cts) { Slots = slots };
             ghost.OnRelease = () =>
             {
                 var until = DateTime.Now + PossessionDeck.TargetCooldown;
@@ -541,17 +583,26 @@ public sealed class PossessionDirector : IDisposable
     public void RequestReactive(string effectId, PossessionTarget? target, PossessionRung minRung = PossessionRung.Settle)
     {
         if (_disposed || !IsHaunting || string.IsNullOrEmpty(effectId)) return;
+
+        // Safe from any thread. Most callers are WPF input handlers, but the SettingChanged reaction
+        // rides AppSettings.PropertyChanged, which fires on whatever thread wrote the setter, and the
+        // body below mutates the live ledger and walks the visual tree. RunOnUI executes inline when
+        // we are already on the UI thread, so the input path is unchanged.
+        DispatcherHelper.RunOnUI(() => RequestReactiveCore(effectId, target, minRung));
+    }
+
+    private void RequestReactiveCore(string effectId, PossessionTarget? target, PossessionRung minRung)
+    {
+        // Re-checked on the UI thread: a queued request can land after the lockdown has ended.
+        if (_disposed || !IsHaunting) return;
         try
         {
-            var dispatcher = Application.Current?.Dispatcher;
-            if (dispatcher == null || dispatcher.HasShutdownStarted) return;
-
             var rung = CurrentRung;
             if (rung < minRung) return;
 
             var now = DateTime.Now;
             if (now - _lastReactiveAt < ReactiveThrottle) return;
-            if (LiveSlots >= PossessionDeck.MaxLive(rung)) return;
+            if (!PossessionDeck.FitsConcurrency(LiveSlots, 1, rung)) return;
 
             var host = _hosts.FirstOrDefault(h => SafeIsUsable(h.Host));
             if (host == null) return;
@@ -695,9 +746,8 @@ public sealed class PossessionDirector : IDisposable
             try
             {
                 var frac = _lockdown.ElapsedFraction;
-                CurrentRung = PossessionDeck.RungFor(frac, _intensity);
-                _barkedRungs.Clear();
-                _lastTargetKey = null;
+                _lastRestartAt = DateTime.Now;
+                ApplyRestartReset(PossessionDeck.RungFor(frac, _intensity));
 
                 FireAndForget(QuickUndoAsync(), "restart undo");
                 PulseAll(0.6);
@@ -718,6 +768,53 @@ public sealed class PossessionDirector : IDisposable
         try { return _lockdown.RestartCount; } catch { return 0; }
     }
 
+    /// <summary>
+    /// Everything the ladder has to FORGET when the clock is rewound to its full duration. The room is
+    /// claiming to start over, so anything that contradicts that goes with it: the rung, the rung
+    /// barks, the last victim, the reactive floor, and every per-target cooldown - 45 s of banned
+    /// controls is a memory of a lockdown that supposedly just began.
+    ///
+    /// <para>The rung the restart just set is added straight back to <c>_barkedRungs</c>: a
+    /// <c>CountdownTick</c> from the same rewind sees the new elapsed fraction and would otherwise
+    /// announce that rung a second time (the spurious Settle bark). That also makes this idempotent -
+    /// it does not matter whether the tick or the restart arrives first, or how often it is called.</para>
+    /// </summary>
+    internal void ApplyRestartReset(PossessionRung rung)
+    {
+        CurrentRung = rung;
+
+        _barkedRungs.Clear();
+        _barkedRungs.Add(rung);
+
+        _lastTargetKey = null;
+        _lastReactiveAt = DateTime.MinValue;
+
+        // A pick still in flight owns this flag through StartOneAsync's finally and will clear it
+        // again in a moment; one that died with a torn-down window never does, and the cadence loop
+        // stays shut for the rest of the lockdown. The restart hands out a full FirstDelay of quiet
+        // straight after this, so nothing can slip a second pick in behind a live one.
+        _picking = false;
+
+        _cooldowns.Clear();
+        foreach (var h in _hosts)
+        {
+            IReadOnlyList<PossessionTarget> targets;
+            try { targets = h.Host.Targets ?? Array.Empty<PossessionTarget>(); }
+            catch { continue; }
+            foreach (var t in targets)
+            {
+                // A victim that is still possessed keeps its booking; Release() gives it a fresh
+                // cooldown when its ghost finally comes down.
+                try { if (t != null && !t.IsLive) t.CooldownUntil = DateTime.MinValue; } catch { }
+            }
+        }
+    }
+
+    /// <summary>Rungs whose one-per-rung bark has already been spent. Exposed for the restart tests,
+    /// which pin that a rewind re-arms the ladder WITHOUT letting the next tick re-announce the rung
+    /// the rewind itself just set.</summary>
+    internal IReadOnlyCollection<PossessionRung> AnnouncedRungs => _barkedRungs;
+
     /// <summary>The reassembly path, but quick: everything comes back over about a second, in parallel
     /// rather than staggered, because this is a reset and not a curtain call.</summary>
     private async Task QuickUndoAsync()
@@ -731,8 +828,13 @@ public sealed class PossessionDirector : IDisposable
                 try { await UndoGhostAsync(g, TimeSpan.FromMilliseconds(500)).ConfigureAwait(true); }
                 catch (Exception ex) { App.Logger?.Warning("Possession restart undo step failed: {Error}", ex.Message); }
             }
-            _live.Clear();
-            _liveKeys.Clear();
+
+            // No Clear() here. Release() already took every ghost in the snapshot off the books, and
+            // IsHaunting stays TRUE across a restart - so the loop above is a ~2 s window in which the
+            // reactive layer can add a brand new ghost. Wiping the ledger would drop it without ever
+            // undoing it: its control stays possessed forever, the shared catalog effect's IsLive
+            // stays true so CanApply refuses it for the rest of the session, and a HoldFor==Zero
+            // effect (RoomWarp) never runs its Undo at all, leaking its event handlers with it.
         }
         catch (Exception ex) { App.Logger?.Warning("Possession restart undo failed: {Error}", ex.Message); }
     }
@@ -858,6 +960,9 @@ public sealed class PossessionDirector : IDisposable
     /// whole thing read as authored instead of broken.</summary>
     private async Task ReassembleAsync()
     {
+        // Captured before the first await: the whole tail below belongs to THIS lockdown, and the
+        // three seconds of undo plus up to fifteen of warden are long enough for the next one to start.
+        var generation = _generation;
         try
         {
             var ghosts = _live.ToArray();
@@ -872,12 +977,22 @@ public sealed class PossessionDirector : IDisposable
                 catch (Exception ex) { App.Logger?.Warning("Possession reassembly step failed: {Error}", ex.Message); }
             }
 
-            _live.Clear();
-            _liveKeys.Clear();
+            // No Clear() here either: Release() took every ghost in the snapshot off the books, so
+            // anything still on them was added underneath us and belongs to a NEW lockdown.
+            if (!ShouldFinishReassembly(generation, _generation, IsHaunting))
+            {
+                App.Logger?.Debug("Possession: reassembly tail skipped, a new lockdown started underneath it");
+                return;
+            }
+
             foreach (var h in _hosts) { try { h.Attribution.ReleaseAll(); } catch { } }
 
             if (_wardenEnabled && Warden != null)
                 await RunWardenAsync(ct => Warden.ReturnAsync(ct), "return").ConfigureAwait(true);
+
+            // The warden's return is up to 15 s of awaiting on its own, so ask again before stamping
+            // the rung: a lockdown that started inside it owns the readout now.
+            if (!ShouldFinishReassembly(generation, _generation, IsHaunting)) return;
 
             CurrentRung = PossessionRung.Settle;
             try { RungChanged?.Invoke(CurrentRung); } catch { }
@@ -885,6 +1000,15 @@ public sealed class PossessionDirector : IDisposable
         }
         catch (Exception ex) { App.Logger?.Warning("Possession reassembly failed: {Error}", ex.Message); }
     }
+
+    /// <summary>Is the reassembly that started at <paramref name="startGeneration"/> still the room's
+    /// current business? Every activation bumps the generation and turns the haunt back on, and the
+    /// reassembly tail is destructive: it strips every ember outline and the cursor ring off every
+    /// host and forces the rung display back to Settle. Run against a lockdown that started inside
+    /// those three seconds it would silently un-dress a room that is actively haunting.
+    /// Pure so the invariant can be pinned in PossessionDeckTests.</summary>
+    internal static bool ShouldFinishReassembly(int startGeneration, int currentGeneration, bool haunting)
+        => startGeneration == currentGeneration && !haunting;
 
     // ---------------------------------------------------------------------------------------------
     //  Tripwires

--- a/ConditioningControlPanel/Services/Possession/PossessionOffLimits.cs
+++ b/ConditioningControlPanel/Services/Possession/PossessionOffLimits.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace ConditioningControlPanel.Services.Possession;
+
+// =====================================================================================================
+//  POSSESSION - the one answer to "may an effect take this away from the user?".
+//  Read Services/Possession/POSSESSION.md ("Hard rules") first.
+//
+//  poss:Possession.Exclude keeps an element and its SUBTREE out of the deck, and that is the whole
+//  story for a victim that is a leaf. It is not the whole story for a CONTAINER: Exclude inherits
+//  DOWN, never UP, so a card is perfectly enrollable while the Emergency Exit button and the secret
+//  exit box sit inside it. An effect that drops that card off-screen, hides it or turns its hit-
+//  testing off takes the exits with it - for 45 s (fall) or two minutes (stealcard) - which is the
+//  one thing POSSESSION.md says may never happen.
+//
+//  So: an element is off limits when it IS excluded, when it CONTAINS anything excluded, or when it
+//  (or any ancestor) is named for a room the user has to be able to leave. StealCardEffect has
+//  carried this rule privately since wave 2; this is the same rule, shared, so the next effect that
+//  hides a victim does not have to rediscover it.
+// =====================================================================================================
+
+public static class PossessionOffLimits
+{
+    /// <summary>Same ceiling the other visual-tree walks in this folder use: a card is a handful of
+    /// levels deep, and an unbounded walk on every CanApply is a per-tick cost nobody notices until
+    /// the room is full.</summary>
+    public const int MaxDepth = 16;
+
+    /// <summary>The rooms the user must always be able to leave. Matched case-insensitively against
+    /// x:Name, so LockdownCardBorder, BtnEmergencyExit and TxtSecretExit all answer to it.</summary>
+    private static readonly string[] _reservedNameTokens = { "lockdown", "emergency", "secret" };
+
+    /// <summary>The name half of the rule, pure so it can be pinned by a test.</summary>
+    public static bool IsReservedName(string? name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        foreach (var token in _reservedNameTokens)
+        {
+            if (name!.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when no effect may drop, hide or hit-test-kill this element (or anything it contains).
+    /// A null element, or one we cannot reason about, is off limits: the failure mode of guessing
+    /// wrong here is a user who cannot end their own lockdown.
+    /// </summary>
+    public static bool IsOffLimits(FrameworkElement? el)
+    {
+        if (el == null) return true;
+        try
+        {
+            if (Possession.GetExclude(el)) return true;
+            if (ContainsExcluded(el)) return true;
+
+            for (DependencyObject? node = el; node != null; node = VisualTreeHelper.GetParent(node))
+            {
+                if (node is not FrameworkElement fe) continue;
+                if (Possession.GetExclude(fe)) return true;
+                if (IsReservedName(fe.Name)) return true;
+            }
+        }
+        catch { return true; }
+        return false;
+    }
+
+    /// <summary>True when anything BELOW this node carries Possession.Exclude. The node itself does
+    /// not count (that is the caller's own check) so a hand-excluded victim and a container full of
+    /// them stay two separate, readable answers.</summary>
+    public static bool ContainsExcluded(DependencyObject? node) => ContainsExcluded(node, 0);
+
+    private static bool ContainsExcluded(DependencyObject? node, int depth)
+    {
+        if (node == null || depth > MaxDepth) return false;
+        try
+        {
+            if (depth > 0 && node is FrameworkElement fe && Possession.GetExclude(fe)) return true;
+            int count = VisualTreeHelper.GetChildrenCount(node);
+            for (int i = 0; i < count; i++)
+            {
+                if (ContainsExcluded(VisualTreeHelper.GetChild(node, i), depth + 1)) return true;
+            }
+        }
+        catch { }
+        return false;
+    }
+}

--- a/ConditioningControlPanel/Services/Possession/Scenes/RailSweepScene.cs
+++ b/ConditioningControlPanel/Services/Possession/Scenes/RailSweepScene.cs
@@ -23,7 +23,12 @@ public sealed class RailSweepScene : PossessionSceneBase
     public override PossessionRung MinRung => PossessionRung.Melt;
     public override int Beats => 3;
 
-    private const int MaxDoors = 5;
+    /// <summary>Never more doors than this scene declares in <see cref="Beats"/>. The director books a
+    /// scene against the concurrency cap as its beat count (POSSESSION.md: "a scene counts as its beat
+    /// count"), so claiming five while declaring three would hold five controls inside a three-slot
+    /// budget - and declaring five instead would put the scene over <c>MaxLive</c> at every rung it is
+    /// allowed to run at (3 at Melt, 4 at Collapse), so it could never be elected at all.</summary>
+    internal const int MaxDoors = 3;
 
     protected override async Task RunCoreAsync(PossessionContext ctx, IPossessionHost host,
                                                Func<PossessionRole, PossessionTarget?> pick, CancellationToken ct)

--- a/ConditioningControlPanel/Services/Possession/TransformLease.cs
+++ b/ConditioningControlPanel/Services/Possession/TransformLease.cs
@@ -134,6 +134,9 @@ public sealed class TransformLease
     {
         if (_released) return;
         if (--_refCount > 0) return;
+        // Released HERE rather than after the ease-back, so a Take() during the animation gets a
+        // clean new lease instead of joining one that is on its way out. The cost is that this lease
+        // can be superseded before it lands; RestoreNow is what keeps that harmless.
         _released = true;
 
         try
@@ -161,11 +164,16 @@ public sealed class TransformLease
         RestoreNow();
     }
 
-    /// <summary>Crash-safe synchronous restore (UndoAll). No animation, no awaits.</summary>
+    /// <summary>
+    /// Crash-safe synchronous restore (UndoAll). No animation, no awaits. Refcounted like
+    /// <see cref="ReleaseAsync"/>: when a second effect is still leaning on the same control, dropping
+    /// our reference is the whole job - snapping ITS transforms back to identity and handing the
+    /// element away would undo an effect that is still live and still owns the ledger entry.
+    /// </summary>
     public void ReleaseImmediate()
     {
         if (_released) return;
-        _refCount = 0;
+        if (--_refCount > 0) return;
         _released = true;
         ZeroNow();
         RestoreNow();
@@ -173,6 +181,16 @@ public sealed class TransformLease
 
     private void RestoreNow()
     {
+        // Are we still the lease this element answers to? A release that animates back (150-600 ms
+        // for a scene beat) marks itself released the moment it starts, so a Take() in that window
+        // builds a FRESH lease around our group and registers it. When we finally land, the element
+        // belongs to that lease: restoring the origin would clobber the one it is using, and removing
+        // the table entry would delete ITS registration - after which IsLeased lies and the next
+        // effect stacks another TransformGroup on top. So a superseded lease touches neither.
+        bool stillRegistered = false;
+        try { stillRegistered = _table.TryGetValue(_el, out var current) && ReferenceEquals(current, this); }
+        catch { }
+
         try
         {
             // Only give the element back if OUR group is still the installed transform; if something
@@ -186,14 +204,18 @@ public sealed class TransformLease
                 else _el.ClearValue(UIElement.RenderTransformProperty);
             }
 
-            if (_priorOriginWasLocal) _el.RenderTransformOrigin = _priorOrigin;
-            else _el.ClearValue(UIElement.RenderTransformOriginProperty);
+            if (stillRegistered)
+            {
+                if (_priorOriginWasLocal) _el.RenderTransformOrigin = _priorOrigin;
+                else _el.ClearValue(UIElement.RenderTransformOriginProperty);
+            }
         }
         catch (Exception ex)
         {
             App.Logger?.Warning("TransformLease restore failed: {Error}", ex.Message);
         }
-        try { _table.Remove(_el); } catch { }
+
+        if (stillRegistered) { try { _table.Remove(_el); } catch { } }
     }
 }
 

--- a/ConditioningControlPanel/Services/Possession/Warden.cs
+++ b/ConditioningControlPanel/Services/Possession/Warden.cs
@@ -44,7 +44,82 @@ public sealed class Warden : IPossessionWarden
     /// only announces a "return" when there was a leaving to undo.</summary>
     private bool _hasLeft;
 
+    // The leave is the one verb the director fires and forgets while the lockdown may end underneath
+    // it: a glide takes about half a second, and ReturnAsync running in the middle of one used to
+    // clear the tube's captured home BEFORE the leave finished, which parked a detached tube at the
+    // bottom of the screen with the note up, after the lockdown was over. So the leave is tracked.
+    private readonly object _leaveGate = new();
+    private Task? _leaveTask;
+    private CancellationTokenSource? _leaveCts;
+
+    /// <summary>Bumped by every <see cref="ReturnAsync"/> / <see cref="Reset"/>. A leave captures it
+    /// when it starts and refuses to finish (no note, no bark, no _hasLeft) if it changed underneath.</summary>
+    private int _returnEpoch;
+
+    private bool _hooked;
+
     private static AvatarTubeWindow? Tube => App.AvatarWindow;
+
+    public Warden()
+    {
+        EnsureHooked();
+    }
+
+    /// <summary>True while a warden verb owns the tube. Read by other Possession effects that move the
+    /// tube themselves (StealCardEffect) so a theft and a knock can never fight over it.</summary>
+    public bool IsBusy => Volatile.Read(ref _busy) != 0;
+
+    /// <summary>Take the tube for a NON-warden mover (the steal card). False when a verb owns it. The
+    /// caller must <see cref="ReleaseTube"/> when it is done - including after its own ReturnHomeAsync,
+    /// because that call clears the capture a warden verb would otherwise need to get home.</summary>
+    public bool TryTakeTube() => Interlocked.Exchange(ref _busy, 1) == 0;
+
+    /// <summary>Give the tube back after <see cref="TryTakeTube"/>.</summary>
+    public void ReleaseTube() => Interlocked.Exchange(ref _busy, 0);
+
+    /// <summary>A new lockdown starts with a clean warden: cooldown stamps cleared (otherwise the first
+    /// verb of this lockdown is blocked by the last one's 90 s appearance stamp), no leave in flight,
+    /// and <see cref="_hasLeft"/> false so reassembly cannot announce a "return" for a leaving that
+    /// happened in a previous lockdown.
+    ///
+    /// <para>The director has no warden-lifecycle seam - it never calls into the warden on activation -
+    /// so the warden hooks LockdownActivated itself, the same shape StealCardEffect uses for its own
+    /// per-lockdown state. If a call site ever appears in PossessionDirector.OnLockdownActivated,
+    /// calling Reset() there instead is equivalent (it is idempotent).</para></summary>
+    public void Reset()
+    {
+        try
+        {
+            Interlocked.Increment(ref _returnEpoch);
+            lock (_leaveGate)
+            {
+                try { _leaveCts?.Cancel(); } catch { }
+                _leaveCts = null;
+                _leaveTask = null;
+            }
+            _lastAppearance = DateTime.MinValue;
+            _lastStare = DateTime.MinValue;
+            _hasLeft = false;
+            ClearNote();
+        }
+        catch (Exception ex) { App.Logger?.Debug("Possession warden reset failed: {Error}", ex.Message); }
+    }
+
+    /// <summary>Subscribe to LockdownActivated once. Lazy as well as constructor-driven: App.Lockdown is
+    /// assigned a line before the warden is built, but a test (or a future re-order) must not silently
+    /// lose the per-lockdown reset.</summary>
+    private void EnsureHooked()
+    {
+        if (_hooked) return;
+        try
+        {
+            var lockdown = App.Lockdown;
+            if (lockdown == null) return;
+            _hooked = true;
+            lockdown.LockdownActivated += Reset;
+        }
+        catch { /* no lockdown service yet; retried from IsAvailable */ }
+    }
 
     public bool IsAvailable
     {
@@ -52,6 +127,7 @@ public sealed class Warden : IPossessionWarden
         {
             try
             {
+                EnsureHooked();
                 if (App.Settings?.Current?.LockdownWardenEnabled != true) return false;
                 var tube = Tube;
                 if (tube == null || !tube.CanPerformPossessionMove) return false;
@@ -161,14 +237,28 @@ public sealed class Warden : IPossessionWarden
     // =================================================================================================
     //  LEAVE - R4: the companion is not in the tube any more.
     // =================================================================================================
-    public async Task LeaveAsync(CancellationToken ct)
+    public Task LeaveAsync(CancellationToken ct)
+    {
+        if (Tube == null || _hasLeft) return Task.CompletedTask;
+
+        // Publish the leave BEFORE it starts: ReturnAsync has to be able to cancel and await it, or
+        // the lockdown can end mid-glide and the leave finishes after the tube's home was cleared.
+        lock (_leaveGate)
+        {
+            if (_leaveTask is { IsCompleted: false }) return Task.CompletedTask;
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(VerbTimeout);
+            _leaveCts = cts;
+            return _leaveTask = LeaveCoreAsync(cts, Volatile.Read(ref _returnEpoch));
+        }
+    }
+
+    private async Task LeaveCoreAsync(CancellationTokenSource cts, int epoch)
     {
         var tube = Tube;
-        if (tube == null || _hasLeft) return;
-        if (Interlocked.Exchange(ref _busy, 1) != 0) return;
+        if (tube == null) { cts.Dispose(); return; }
+        if (Interlocked.Exchange(ref _busy, 1) != 0) { cts.Dispose(); return; }
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        cts.CancelAfter(VerbTimeout);
         var token = cts.Token;
         try
         {
@@ -180,12 +270,23 @@ public sealed class Warden : IPossessionWarden
             if (!tube.TryGetTubeScreenRect(out var self)) return;
             var screen = System.Windows.Forms.Screen.FromPoint(
                 new System.Drawing.Point((int)self.X, (int)self.Y));
-            var wa = screen.WorkingArea;
+
+            // Bounds, NOT WorkingArea: the working area EXCLUDES the taskbar, so parking the tube's
+            // TOP-LEFT on that line left a taskbar-height slice of her on screen - topmost - through
+            // the entire "she's gone" beat. Bounds is the whole monitor, so the frame is really empty.
+            var bottom = screen.Bounds.Bottom;
 
             _lastAppearance = DateTime.UtcNow;
-            _hasLeft = true;
-            await tube.GlideToScreenPointAsync(new Point(self.X, wa.Bottom), token, clampToWorkArea: false)
+            await tube.GlideToScreenPointAsync(new Point(self.X, bottom), token, clampToWorkArea: false)
                       .ConfigureAwait(true);
+
+            // A return (reassembly, or the knock's delayed homeward leg) that began while we were
+            // gliding owns the tube now: it has already cleared the tube's captured home, so finishing
+            // here would pin a note in a frame nobody is coming back to and leave _hasLeft true for the
+            // NEXT lockdown to announce a phantom return.
+            if (token.IsCancellationRequested || Volatile.Read(ref _returnEpoch) != epoch) return;
+
+            _hasLeft = true;
 
             // The note goes up AFTER the glide, so it appears in a frame that is already empty rather
             // than riding down the screen with her.
@@ -195,7 +296,11 @@ public sealed class Warden : IPossessionWarden
         }
         catch (OperationCanceledException) { /* lockdown ended mid-exit; ReturnAsync still restores */ }
         catch (Exception ex) { App.Logger?.Warning("Possession warden leave failed: {Error}", ex.Message); }
-        finally { Interlocked.Exchange(ref _busy, 0); }
+        finally
+        {
+            Interlocked.Exchange(ref _busy, 0);
+            try { cts.Dispose(); } catch { }
+        }
     }
 
     // =================================================================================================
@@ -203,6 +308,12 @@ public sealed class Warden : IPossessionWarden
     // =================================================================================================
     public async Task ReturnAsync(CancellationToken ct)
     {
+        // FIRST, before anything else looks at the tube: stop and drain a leave that is still in
+        // flight. ReturnHomeAsync clears the tube's captured home, so a leave finishing after this
+        // point would strand a detached tube off the bottom of the screen with the note up - after
+        // the lockdown ended - and leave _hasLeft true for the next one to bark a phantom return.
+        await CancelInFlightLeaveAsync().ConfigureAwait(true);
+
         var tube = Tube;
         if (tube == null) { _hasLeft = false; return; }
 
@@ -235,6 +346,31 @@ public sealed class Warden : IPossessionWarden
     // =================================================================================================
     //  helpers
     // =================================================================================================
+
+    /// <summary>Cancel a leave that is still gliding and wait for it to unwind, so the caller owns the
+    /// tube outright afterwards. Bumping the epoch is what stops the leave placing its note / setting
+    /// _hasLeft even if it wins the race to the line after the cancel. No-op when nothing is in flight,
+    /// and never throws (a faulted leave already logged itself).</summary>
+    private async Task CancelInFlightLeaveAsync()
+    {
+        Task? task;
+        CancellationTokenSource? cts;
+        Interlocked.Increment(ref _returnEpoch);
+        lock (_leaveGate)
+        {
+            task = _leaveTask;
+            cts = _leaveCts;
+            if (task is { IsCompleted: true }) { _leaveTask = null; _leaveCts = null; task = null; cts = null; }
+        }
+        if (task == null) return;
+
+        try { cts?.Cancel(); } catch { }
+        try { await task.ConfigureAwait(true); } catch { }
+        lock (_leaveGate)
+        {
+            if (ReferenceEquals(_leaveTask, task)) { _leaveTask = null; _leaveCts = null; }
+        }
+    }
 
     /// <summary>Send the tube home shortly after a verb that deliberately stayed put. Fire-and-forget,
     /// so it carries its own dispatcher/shutdown guard and can never surface an unobserved exception.</summary>

--- a/Tests/ConditioningControlPanel.Tests/LockdownDoseKeeperTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LockdownDoseKeeperTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using ConditioningControlPanel.Models;
 using ConditioningControlPanel.Services.Haptics;
 using Xunit;
 
@@ -126,5 +128,148 @@ public class LockdownDoseKeeperTests
         var wallKeys = new HashSet<string> { "flash", "video", "subliminal", "spiral", "pinkfilter", "bubbles",
             "lockcard", "bubblecount", "bouncingtext", "mindwipe", "braindrain" };
         Assert.All(LockdownDoseKeeper.Catalog, f => Assert.Contains(f.Key, wallKeys));
+    }
+
+    // =============================================================================================
+    //  The census - what counts as "something is running"
+    // =============================================================================================
+
+    /// <summary>A room with nothing on: every wall toggle and every off-wall dose switched off.</summary>
+    private static AppSettings QuietRoom() => new()
+    {
+        FlashEnabled = false,
+        SubliminalEnabled = false,
+        SpiralEnabled = false,
+        PinkFilterEnabled = false,
+        BouncingTextEnabled = false,
+        BubblesEnabled = false,
+        MandatoryVideosEnabled = false,
+        MindWipeEnabled = false,
+        LockCardEnabled = false,
+        BubbleCountEnabled = false,
+        BrainDrainEnabled = false,
+        PopQuizEnabled = false,
+        AudioOnlySession = false,
+        AutonomyModeEnabled = false,
+        AutonomyConsentGiven = false,
+        CornerGifOverlays = new List<CornerGifOverlaySetting>(),
+    };
+
+    [Fact]
+    public void PopQuizAlone_IsNotAnEmptyRoom()
+    {
+        // StartEngine starts PopQuiz off PopQuizEnabled like any wall feature, so a lockdown running
+        // nothing but Pop Quiz used to get a false `starve` tripwire plus a conscription on top of a
+        // feature that was genuinely running.
+        var s = QuietRoom();
+        Assert.True(LockdownDoseKeeper.DoseIsEmpty(s));
+
+        s.PopQuizEnabled = true;
+        Assert.False(LockdownDoseKeeper.DoseIsEmpty(s));
+        Assert.True(LockdownDoseKeeper.CountsAsOffWallDose(s));
+    }
+
+    [Fact]
+    public void PopQuiz_CountsButIsNeverConscriptable()
+    {
+        // It is not a wall card, so MainWindow.SetWallFeature does not know the key: a catalog entry
+        // would be a conscription that flips nothing. It lives in the off-wall census instead.
+        Assert.DoesNotContain(LockdownDoseKeeper.Catalog,
+            f => string.Equals(f.Key, "popquiz", StringComparison.OrdinalIgnoreCase));
+
+        var picks = LockdownDoseKeeper.PickConscripts(3, new[] { "popquiz" }, Starter, Escalation,
+            Array.Empty<string>(), new Random(11));
+        Assert.DoesNotContain("popquiz", picks);
+    }
+
+    [Theory]
+    [InlineData("clip.mp4", true)]
+    [InlineData("CLIP.MP4", true)]
+    [InlineData("a.mov", true)]
+    [InlineData("a.avi", true)]
+    [InlineData("a.wmv", true)]
+    [InlineData("a.mkv", true)]
+    [InlineData("a.webm", true)]
+    [InlineData("Thumbs.db", false)]
+    [InlineData("desktop.ini", false)]
+    [InlineData("clip.ccpenh.json", false)]
+    [InlineData("cover.jpg", false)]
+    [InlineData("notes", false)]
+    public void OnlyFilesVideoServiceCouldPlay_CountAsVideoAssets(string name, bool playable)
+    {
+        // Counting ANY file let round 2 conscript Mandatory Videos over a folder holding nothing but
+        // Thumbs.db and enhancement sidecars. The list mirrors VideoService.RefillVideoQueues.
+        Assert.Equal(playable, LockdownDoseKeeper.IsPlayableVideoFile(name));
+    }
+
+    // =============================================================================================
+    //  Source pins - the runtime half is WPF-bound, so these hold the shape the play-test verified
+    // =============================================================================================
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string Source(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+
+    [Fact]
+    public void Restore_MarshalsBeforeReadingTheWindow_AndOwnsTheRecoveryFile()
+    {
+        var src = Source("Services", "Haptics", "LockdownDoseKeeper.cs");
+        var start = src.IndexOf("private void Restore()", StringComparison.Ordinal);
+        Assert.True(start > 0, "Restore() not found");
+        var end = src.IndexOf("Crash recovery", start, StringComparison.Ordinal);
+        Assert.True(end > start, "end of Restore() not found");
+        var body = src[start..end];
+
+        // The thread guard has to come FIRST: MainWindow's getter VerifyAccess-throws off-thread, so
+        // reading it above the guard made the marshalling branch unreachable.
+        var guard = body.IndexOf("dispatcher.CheckAccess()", StringComparison.Ordinal);
+        var read = body.IndexOf("App.MainWindowRef", StringComparison.Ordinal);
+        Assert.True(guard > 0 && read > 0 && guard < read,
+            "Restore must marshal to the UI thread before it touches MainWindow");
+
+        // The recovery file is the record of what is still switched on: it may only go when the
+        // toggles are actually back, never in a finally that runs while the restore is still queued.
+        Assert.Contains("if (stillFlipped.Count == 0) DeleteRecoveryFile();", body, StringComparison.Ordinal);
+        Assert.Contains("else WriteRecoveryFile();", body, StringComparison.Ordinal);
+
+        var deactivate = src.IndexOf("private void OnDeactivated()", StringComparison.Ordinal);
+        var deactivateBody = src[deactivate..start];
+        Assert.DoesNotContain("finally { DeleteRecoveryFile(); }", deactivateBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AKeeperStartedEngine_SkipsTheUserOnlySideEffects()
+    {
+        var engine = Source("MainWindow", "MainWindow.StartStop.cs");
+        Assert.Contains("public void StartEngine(bool systemInitiated = false)", engine, StringComparison.Ordinal);
+        Assert.Contains("if (!systemInitiated) App.Achievements?.CheckRelapse();", engine, StringComparison.Ordinal);
+        Assert.Contains("if (!systemInitiated) settings.TotalSessions++;", engine, StringComparison.Ordinal);
+        Assert.Contains("if (!systemInitiated) MaybePromptMandatoryVideoEnhancement();", engine, StringComparison.Ordinal);
+
+        // The duplicated Pop Quiz start block: two identical blocks started the service twice.
+        Assert.Equal(1, engine.Split("App.PopQuiz?.Start();").Length - 1);
+
+        var keeper = Source("Services", "Haptics", "LockdownDoseKeeper.cs");
+        Assert.Contains("mw.StartEngine(systemInitiated: true);", keeper, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StandDown_PreservesTheEmptyEdge()
+    {
+        // A session owning the dose used to rewrite _wasEmpty every tick, consuming the edge: a
+        // session ending with everything off never fired `starve` and the room refilled silently.
+        var src = Source("Services", "Haptics", "LockdownDoseKeeper.cs");
+        var start = src.IndexOf("if (mw.IsSessionFeatureLockActive)", StringComparison.Ordinal);
+        Assert.True(start > 0, "stand-down branch not found");
+        var body = src.Substring(start, Math.Min(400, src.Length - start));
+        Assert.DoesNotContain("_wasEmpty =", body, StringComparison.Ordinal);
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/LockdownEmergencyExitTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/LockdownEmergencyExitTests.cs
@@ -1,0 +1,258 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using ConditioningControlPanel.Services;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The Emergency Exit / Lockdown seam (<c>Services/Haptics/LockdownService.cs</c>,
+/// <c>Services/EmergencyExit/EmergencyExitHostService.cs</c>, the three timed games under
+/// <c>Resources/web/emergency-exit/games/</c>). Primers: <c>Services/EmergencyExit/EMERGENCY_EXIT.md</c>
+/// and <c>Services/Possession/POSSESSION.md</c>.
+///
+/// <para>Two kinds of test live here. The first is real behaviour: a LockdownService instance is
+/// seeded through its private clock fields (Activate needs App.Settings, a DispatcherTimer and a
+/// live app, none of which a unit test has) and then driven through RestartTimer / Deactivate. That
+/// covers the bug this suite exists for - a sendback used to reset the clock that
+/// <see cref="LockdownService.LastActiveDuration"/> is measured from, so 45 minutes + a sendback +
+/// 45 more reported 45 and the long-lockdown achievement could never unlock.</para>
+///
+/// <para>The second is source-level, in the house style of <c>SessionLockMarkerTests</c>: the
+/// remaining fixes are ORDERING and LIFETIME rules inside WPF-bound or WebView2-bound code, where
+/// the regression is silent (an event raised one line too early, a verdict posted to a window that
+/// was already disposed) and there is no seam to observe it through. Pinning the source is worth
+/// more than pinning nothing.</para>
+/// </summary>
+public class LockdownEmergencyExitTests
+{
+    // ============================ behaviour ============================
+
+    private static LockdownService SeedRunningLockdown(TimeSpan duration, TimeSpan alreadyServed)
+    {
+        var svc = new LockdownService();
+        var started = DateTime.Now - alreadyServed;
+        Set(svc, "_duration", duration);
+        Set(svc, "_startedAt", started);
+        Set(svc, "_activatedAt", started);
+        Set(svc, "_isActive", true);
+        return svc;
+    }
+
+    private static void Set(object target, string field, object value)
+    {
+        var f = target.GetType().GetField(field, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.True(f != null, $"LockdownService has no field '{field}' - the clock fields were renamed");
+        f!.SetValue(target, value);
+    }
+
+    [Fact]
+    public void LastActiveDuration_CountsTheWholeSitting_AcrossASendback()
+    {
+        // 45 minutes served, then the Emergency Exit sends them back into a fresh 45.
+        var svc = SeedRunningLockdown(TimeSpan.FromMinutes(45), TimeSpan.FromMinutes(45));
+
+        svc.RestartTimer("labyrinth");
+        svc.Deactivate();
+
+        // The achievement gate (GamificationBridge, throw_away_the_key) reads this. Measured from
+        // the rebased clock it would have been ~0.
+        Assert.True(svc.LastActiveDuration >= TimeSpan.FromMinutes(44.5),
+            $"LastActiveDuration was {svc.LastActiveDuration}; a sendback must not erase time already served");
+    }
+
+    [Fact]
+    public void RestartTimer_RewindsTheCountdownAndThePossessionLadder()
+    {
+        var svc = SeedRunningLockdown(TimeSpan.FromMinutes(45), TimeSpan.FromMinutes(45));
+        Assert.True(svc.ElapsedFraction > 0.9, "seeded lockdown should be nearly over");
+
+        svc.RestartTimer("labyrinth");
+
+        // The ladder NEEDS the rebase: the director drops back to Settle off ElapsedFraction.
+        Assert.True(svc.ElapsedFraction < 0.01, $"ElapsedFraction was {svc.ElapsedFraction}, expected a full rewind");
+        Assert.True(svc.Remaining > TimeSpan.FromMinutes(44.5), $"Remaining was {svc.Remaining}, expected the full duration back");
+        Assert.Equal(1, svc.RestartCount);
+    }
+
+    [Fact]
+    public void RestartTimer_IsANoOp_WhenNoLockdownIsRunning()
+    {
+        var svc = new LockdownService();
+        svc.RestartTimer("labyrinth");
+        Assert.Equal(0, svc.RestartCount);
+    }
+
+    // ============================ source pins ============================
+
+    private static string AppDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "ConditioningControlPanel", "Services");
+            if (Directory.Exists(candidate)) return Path.Combine(dir.FullName, "ConditioningControlPanel");
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            $"Could not locate the app project walking up from {AppContext.BaseDirectory}");
+    }
+
+    private static string Source(params string[] parts)
+    {
+        var path = Path.Combine(AppDir(), Path.Combine(parts));
+        Assert.True(File.Exists(path), $"missing source file: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string LockdownSource() => Source("Services", "Haptics", "LockdownService.cs");
+    private static string HostSource() => Source("Services", "EmergencyExit", "EmergencyExitHostService.cs");
+    private static string GameSource(string id) => Source("Resources", "web", "emergency-exit", "games", id + ".js");
+
+    /// <summary>The body of a method, from its signature to the next method at the same indent.</summary>
+    private static string Body(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"could not find '{signature}'");
+        var open = source.IndexOf('{', start);
+        Assert.True(open >= 0, $"'{signature}' has no body");
+        int depth = 0, i = open;
+        for (; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) break;
+        }
+        return source.Substring(open, Math.Min(i + 1, source.Length) - open);
+    }
+
+    [Fact]
+    public void LastActiveDuration_IsMeasuredFromStartedAt_NotTheRebasedClock()
+    {
+        var deactivate = Body(LockdownSource(), "public void Deactivate()");
+        Assert.Contains("LastActiveDuration = DateTime.Now - _startedAt;", deactivate);
+
+        // ...and RestartTimer must never touch it, or the separation is decorative.
+        var restart = Body(LockdownSource(), "public void RestartTimer(string reason)");
+        Assert.DoesNotContain("_startedAt", restart);
+        Assert.Contains("_activatedAt = DateTime.Now;", restart);
+    }
+
+    [Fact]
+    public void RestartTimer_RaisesTimerRestarted_BeforeCountdownTick()
+    {
+        // A CountdownTick raised first shows the director an elapsed fraction that is already back
+        // at ~0, so it walks the ladder down to Settle and barks it, and OnTimerRestarted then
+        // resets and barks the same rung a second time. One restart, two Settles.
+        var restart = Body(LockdownSource(), "public void RestartTimer(string reason)");
+        var restarted = restart.IndexOf("TimerRestarted?.Invoke", StringComparison.Ordinal);
+        var tick = restart.IndexOf("CountdownTick?.Invoke", StringComparison.Ordinal);
+        Assert.True(restarted >= 0 && tick >= 0, "RestartTimer must raise both events");
+        Assert.True(restarted < tick, "TimerRestarted has to be raised before CountdownTick");
+    }
+
+    [Fact]
+    public void ExpiryTick_DeactivatesWithoutRaisingALiveCountdownTick()
+    {
+        // LockdownDoseKeeper.Enforce answers a tick by conscripting features and restarting the
+        // engine. On the expiry tick it used to see IsActive == true and do exactly that, one
+        // second before Deactivate tore it all down again.
+        var tickBody = Body(LockdownSource(), "private void OnCountdownTick(object? sender, EventArgs e)");
+        var expiry = tickBody.IndexOf("if (remaining <= TimeSpan.Zero)", StringComparison.Ordinal);
+        var firstInvoke = tickBody.IndexOf("CountdownTick?.Invoke", StringComparison.Ordinal);
+        Assert.True(expiry >= 0, "OnCountdownTick lost its expiry branch");
+        Assert.True(firstInvoke > expiry, "the expiry branch must be reached before any CountdownTick is raised");
+        Assert.Contains("Deactivate();", tickBody);
+    }
+
+    [Fact]
+    public void Activate_ResetsTheSystemKeyTripwireThrottle()
+    {
+        // The syskey tripwire is throttled to 1 per 2 s. Left un-reset, a back-to-back lockdown
+        // swallows its own first system-key attempt.
+        var activate = Body(LockdownSource(), "public void Activate(TimeSpan duration)");
+        Assert.Contains("_lastSysKeyAttempt = DateTime.MinValue;", activate);
+        Assert.Contains("_startedAt = _activatedAt;", activate);
+    }
+
+    [Fact]
+    public void OnGameFinished_PostsTheVerdictToThePage_BeforeApplyingIt()
+    {
+        // Applying an `escape` deactivates the lockdown, which fires LockdownDeactivated
+        // synchronously, which used to close and dispose the window - so the post landed on a null
+        // host and the winning player's window just vanished.
+        var body = Body(HostSource(), "private static void OnGameFinished(JObject msg)");
+        var post = body.IndexOf("type = \"verdict\"", StringComparison.Ordinal);
+        var deactivate = body.IndexOf("App.Lockdown?.Deactivate()", StringComparison.Ordinal);
+        var restart = body.IndexOf("App.Lockdown?.RestartTimer", StringComparison.Ordinal);
+        Assert.True(post >= 0, "the verdict is never posted to the page");
+        Assert.True(deactivate > post, "Deactivate must not run before the page has been told");
+        Assert.True(restart > post, "RestartTimer must not run before the page has been told");
+    }
+
+    [Fact]
+    public void DeactivationHook_LeavesTheWindowAloneWhileAVerdictOutroIsPending()
+    {
+        var src = HostSource();
+        var hook = Body(src, "private static void EnsureHooked()");
+        Assert.Contains("if (!_outroPending) Close();", hook);
+        // Close is the single place the flag is cleared, so a stale one cannot survive a window.
+        Assert.Contains("_outroPending = false;", Body(src, "public static void Close()"));
+    }
+
+    [Fact]
+    public void OutroFailsafe_BelongsToTheWindowItGuards()
+    {
+        // The 8 s timer used to be armed globally AFTER Close() had already cancelled it, so it
+        // could close a FRESH game window opened by the next lockdown.
+        var src = HostSource();
+        Assert.Contains("private static bool ArmOutroFailsafe(ChaosWebViewHost? host)", src);
+        var arm = Body(src, "private static bool ArmOutroFailsafe(ChaosWebViewHost? host)");
+        Assert.Equal(2, Regex.Matches(arm, @"ReferenceEquals\(_host, host\)").Count);
+    }
+
+    // ---- the three timed games -------------------------------------------------
+    // Opening the window and getting distracted used to spend the whole budget on wall time, and a
+    // `failed` game is a sendback: the FULL lockdown timer restarts with zero user action.
+
+    [Theory]
+    [InlineData("labyrinth")]
+    [InlineData("jigsaw")]
+    [InlineData("captcha")]
+    public void TimedGames_StartTheirClockOnFirstInteraction_AndPauseWhileHidden(string game)
+    {
+        var src = GameSource(game);
+
+        Assert.Contains("clockBegin", src);
+        Assert.Contains("visibilitychange", src);
+        Assert.Contains("document.hidden", src);
+        Assert.Contains("clockPause", src);
+        Assert.Contains("clockResume", src);
+
+        // The listener has to come off again: the shell reuses the page for the outro card.
+        Assert.Contains("removeEventListener('visibilitychange', onVisibility)", src);
+
+        // No survivor of the old wall-clock: every budget/schedule reads the active clock.
+        Assert.DoesNotContain("performance.now() - t0", src);
+    }
+
+    [Theory]
+    [InlineData("labyrinth", "TIME_LIMIT = 25")]
+    [InlineData("jigsaw", "TIME_LIMIT_MS = 60000")]
+    [InlineData("captcha", "TIME_LIMIT_MS = 90000")]
+    public void TimedGames_KeepTheirActiveTimeBudget(string game, string declaration)
+        => Assert.Contains(declaration, GameSource(game));
+
+    // ---- consent copy ----------------------------------------------------------
+
+    [Theory]
+    [InlineData("MainWindow.Lab.cs")]
+    [InlineData("MainWindow.PremiumRail.cs")]
+    public void BothConsentDialogs_SayTheEmergencyExitCanRestartTheTimer(string file)
+    {
+        var src = Source("MainWindow", file);
+        Assert.Contains("The Emergency Exit button is a gamble", src);
+        Assert.Contains("the timer restarts at its FULL length", src);
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/PossessionDeckTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionDeckTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ConditioningControlPanel.Services.Possession;
+using ConditioningControlPanel.Services.Possession.Scenes;
 using Xunit;
 
 namespace ConditioningControlPanel.Tests;
@@ -105,6 +106,57 @@ public class PossessionDeckTests
     [InlineData(PossessionRung.ItKnows, 4)]
     public void MaxLive_TightensEarly_LoosensLate(PossessionRung rung, int expected)
         => Assert.Equal(expected, PossessionDeck.MaxLive(rung));
+
+    [Fact]
+    public void FitsConcurrency_ChargesAHauntItsFullWeight()
+    {
+        // A single effect is one slot, and Settle's cap is two.
+        Assert.True(PossessionDeck.FitsConcurrency(0, 1, PossessionRung.Settle));
+        Assert.True(PossessionDeck.FitsConcurrency(1, 1, PossessionRung.Settle));
+        Assert.False(PossessionDeck.FitsConcurrency(2, 1, PossessionRung.Settle));
+
+        // A three-beat SCENE at Melt (cap 3) fits an empty room and nothing else. This is the row the
+        // director got wrong: it checked a flat "+2" and then booked the scene at its beat count, so
+        // one ghost plus a three-beat scene passed a three-slot cap with four slots live.
+        Assert.True(PossessionDeck.FitsConcurrency(0, 3, PossessionRung.Melt));
+        Assert.False(PossessionDeck.FitsConcurrency(1, 3, PossessionRung.Melt));
+        Assert.True(1 + 2 <= PossessionDeck.MaxLive(PossessionRung.Melt));   // what the old check asked
+    }
+
+    [Fact]
+    public void FitsConcurrency_TreatsGarbageAsOneSlotInAnEmptyRoom()
+    {
+        Assert.True(PossessionDeck.FitsConcurrency(1, 0, PossessionRung.Settle));
+        Assert.False(PossessionDeck.FitsConcurrency(2, -5, PossessionRung.Settle));
+        Assert.True(PossessionDeck.FitsConcurrency(-3, 1, PossessionRung.Settle));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //  Scenes - "a scene counts as its beat count" (POSSESSION.md)
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void EveryScene_FitsUnderTheCapAtItsOwnMinRung()
+    {
+        // A scene worth more slots than its MinRung allows can never be elected at all, which is the
+        // failure mode of "fixing" an over-claiming scene by raising its Beats.
+        foreach (var scene in PossessionSceneCatalog.CreateAll())
+        {
+            Assert.True(scene.Beats >= 1, $"{scene.Id} declares {scene.Beats} beats");
+            Assert.True(PossessionDeck.FitsConcurrency(0, scene.Beats, scene.MinRung),
+                $"{scene.Id} is worth {scene.Beats} slots but MaxLive at {scene.MinRung} is "
+                + $"{PossessionDeck.MaxLive(scene.MinRung)} - it could never run");
+        }
+    }
+
+    [Fact]
+    public void RailSweep_NeverClaimsMoreDoorsThanItDeclaresBeats()
+    {
+        var sweep = new RailSweepScene();
+        Assert.True(RailSweepScene.MaxDoors <= sweep.Beats,
+            $"scene_rail_sweep claims up to {RailSweepScene.MaxDoors} doors but is booked as {sweep.Beats} slots");
+        Assert.True(RailSweepScene.MaxDoors >= 2);   // fewer than two doors is not a sweep
+    }
 
     // ---------------------------------------------------------------------------------------------
     //  Cadence
@@ -462,5 +514,48 @@ public class PossessionDeckTests
                                        false, null, new Random(3), new[] { 1 });
         Assert.NotNull(pick);
         Assert.Equal(-1, pick!.Value.TargetIndex);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    //  The director's own invariants (the parts that need no dispatcher)
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void RestartReset_ReArmsTheLadder_ButSpendsTheRungItJustSet()
+    {
+        // No host, no dispatcher: this is the bookkeeping half of the restart handler.
+        using var lockdown = new ConditioningControlPanel.Services.LockdownService();
+        using var director = new PossessionDirector(lockdown, Array.Empty<IPossessionEffect>());
+
+        // The clock rewinds to its full duration, so the ladder drops back to Settle with it.
+        director.ApplyRestartReset(PossessionRung.Settle);
+
+        Assert.Equal(PossessionRung.Settle, director.CurrentRung);
+        // Settle is already spent: the CountdownTick from the same rewind sees the new elapsed
+        // fraction, changes rung to Settle and would otherwise bark it a second time.
+        Assert.Contains(PossessionRung.Settle, director.AnnouncedRungs);
+        Assert.Single(director.AnnouncedRungs);
+
+        // Idempotent - it does not matter which of the two events arrives first, or how often.
+        director.ApplyRestartReset(PossessionRung.Settle);
+        Assert.Single(director.AnnouncedRungs);
+
+        // ...and a rewind that lands further up the ladder re-arms every rung below it.
+        director.ApplyRestartReset(PossessionRung.Melt);
+        Assert.Equal(PossessionRung.Melt, director.CurrentRung);
+        Assert.Single(director.AnnouncedRungs);
+        Assert.Contains(PossessionRung.Melt, director.AnnouncedRungs);
+        Assert.DoesNotContain(PossessionRung.Settle, director.AnnouncedRungs);
+    }
+
+    [Fact]
+    public void ShouldFinishReassembly_OnlyWhenNoNewLockdownStartedUnderneathIt()
+    {
+        // The tail strips every ember outline and forces the rung display back to Settle, so it must
+        // only run for the lockdown that started it.
+        Assert.True(PossessionDirector.ShouldFinishReassembly(3, 3, haunting: false));
+        Assert.False(PossessionDirector.ShouldFinishReassembly(3, 4, haunting: false));  // Activate bumped it
+        Assert.False(PossessionDirector.ShouldFinishReassembly(3, 3, haunting: true));   // haunting again
+        Assert.False(PossessionDirector.ShouldFinishReassembly(3, 4, haunting: true));
     }
 }

--- a/Tests/ConditioningControlPanel.Tests/PossessionDodgeRegionTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionDodgeRegionTests.cs
@@ -1,0 +1,134 @@
+using System.Windows;
+using ConditioningControlPanel.Services.Possession.Effects;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// DodgeEffect's invariant is "friction, never lockout": the button always stays visible and
+/// clickable where it lands. Clamping it to the WINDOW was not enough for that - a nav door inside
+/// the rail's 56 px <c>ClipToBounds</c> strip dodges out of the clip (invisible AND un-hittable for
+/// the whole 20 s hold) and the title-bar X dodges down under opaque page content that paints over
+/// it. <see cref="DodgeRegion"/> is the arithmetic that answers where a step may land; this pins it.
+/// See Services/Possession/POSSESSION.md.
+/// </summary>
+public class PossessionDodgeRegionTests
+{
+    // The design canvas the main window scales, in ghost-layer units.
+    private const double LayerW = 1563;
+    private const double LayerH = 901;
+
+    // ---- lanes ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_shut_nav_rail_is_a_strip()
+        => Assert.True(DodgeRegion.IsStrip(new Rect(0, 36, 56, 865), LayerW, LayerH));
+
+    /// <summary>The flyout is the dangerous state, not the safe one: a door that dodges into the open
+    /// 236 px rail is clipped away the moment the pointer leaves and the rail snaps back to 56.</summary>
+    [Fact]
+    public void The_open_nav_rail_is_still_a_strip()
+        => Assert.True(DodgeRegion.IsStrip(new Rect(0, 36, 236, 865), LayerW, LayerH));
+
+    [Fact]
+    public void A_short_band_is_a_strip_too()
+        => Assert.True(DodgeRegion.IsStrip(new Rect(0, 0, LayerW, 36), LayerW, LayerH));
+
+    [Fact]
+    public void A_page_sized_clip_is_not_a_strip()
+        => Assert.False(DodgeRegion.IsStrip(new Rect(96, 36, 1400, 820), LayerW, LayerH));
+
+    [Fact]
+    public void An_empty_clip_is_not_a_strip()
+        => Assert.False(DodgeRegion.IsStrip(Rect.Empty, LayerW, LayerH));
+
+    // ---- how far it may go ----------------------------------------------------------------------
+
+    [Fact]
+    public void The_offset_range_is_the_slack_on_every_side()
+    {
+        var region = new Rect(12, 12, LayerW - 24, LayerH - 24);
+        var home = new Rect(100, 200, 120, 40);
+
+        Assert.True(DodgeRegion.TryOffsetRange(home, region,
+                                               out double minX, out double maxX,
+                                               out double minY, out double maxY));
+
+        Assert.Equal(12 - 100, minX, 3);
+        Assert.Equal(region.Right - home.Right, maxX, 3);
+        Assert.Equal(12 - 200, minY, 3);
+        Assert.Equal(region.Bottom - home.Bottom, maxY, 3);
+    }
+
+    /// <summary>A chrome button's band is exactly its own row, so the only legal step is sideways.</summary>
+    [Fact]
+    public void A_title_bar_band_leaves_no_vertical_room()
+    {
+        var home = new Rect(1400, 0, 46, 36);
+        var band = new Rect(12, home.Y, LayerW - 24, home.Height);
+
+        Assert.True(DodgeRegion.TryOffsetRange(home, band,
+                                               out double minX, out double maxX,
+                                               out double minY, out double maxY));
+
+        Assert.True(maxX - minX > 100);      // plenty of room to run along the bar
+        Assert.Equal(0, minY, 3);
+        Assert.Equal(0, maxY, 3);
+    }
+
+    [Fact]
+    public void A_region_that_cannot_hold_the_control_refuses_the_dodge()
+    {
+        var home = new Rect(0, 6, 44, 44);
+        var region = new Rect(0, 12, 30, 800);   // narrower than the control
+
+        Assert.False(DodgeRegion.TryOffsetRange(home, region, out _, out _, out _, out _));
+    }
+
+    [Fact]
+    public void An_empty_region_refuses_the_dodge()
+        => Assert.False(DodgeRegion.TryOffsetRange(new Rect(0, 0, 10, 10), Rect.Empty,
+                                                   out _, out _, out _, out _));
+
+    /// <summary>A control already outside its region (the rail shut under it) is pulled back in
+    /// rather than pushed further out: the range never offers an offset that leaves the region.</summary>
+    [Fact]
+    public void A_stranded_control_is_offered_only_offsets_that_come_home()
+    {
+        var home = new Rect(120, 100, 44, 44);            // sitting where the flyout used to be
+        var region = new Rect(0, 36, 56, 800);            // the rail, shut under it
+
+        Assert.True(DodgeRegion.TryOffsetRange(home, region,
+                                               out double minX, out double maxX,
+                                               out double minY, out double maxY));
+
+        // Every offset the clamp can produce puts it back inside the lane, both ends of the range.
+        foreach (var (dx, dy) in new[] { (minX, minY), (maxX, maxY), (minX, maxY), (maxX, minY) })
+        {
+            Assert.True(DodgeRegion.Contains(region,
+                new Rect(home.X + dx, home.Y + dy, home.Width, home.Height)));
+        }
+        Assert.True(maxX < 0);   // it can only come back leftward
+    }
+
+    // ---- the acceptance test --------------------------------------------------------------------
+
+    [Fact]
+    public void Contains_is_whole_rectangles_only()
+    {
+        var region = new Rect(0, 36, 56, 800);
+
+        Assert.True(DodgeRegion.Contains(region, new Rect(6, 100, 44, 44)));
+        Assert.False(DodgeRegion.Contains(region, new Rect(30, 100, 44, 44)));   // hangs out of the lane
+        Assert.False(DodgeRegion.Contains(region, new Rect(6, 800, 44, 44)));    // hangs out of the bottom
+        Assert.False(DodgeRegion.Contains(Rect.Empty, new Rect(0, 0, 1, 1)));
+    }
+
+    /// <summary>Flush against the edge still counts: a clamp lands exactly on the boundary.</summary>
+    [Fact]
+    public void Contains_accepts_a_flush_fit()
+    {
+        var region = new Rect(12, 12, 100, 50);
+        Assert.True(DodgeRegion.Contains(region, new Rect(12, 12, 100, 50)));
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/PossessionOffLimitsTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionOffLimitsTests.cs
@@ -1,0 +1,126 @@
+using System.Windows;
+using System.Windows.Controls;
+using ConditioningControlPanel.Services.Possession;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The rule that keeps the exits reachable while the room misbehaves (Services/Possession/
+/// POSSESSION.md, "Hard rules"): no effect may drop, hide or hit-test-kill a control that IS
+/// excluded, that CONTAINS something excluded, or that lives in a room the user has to be able to
+/// leave.
+///
+/// <para>The containment half is the one that had teeth. <c>poss:Possession.Exclude</c> inherits
+/// DOWN, so tagging BtnEmergencyExit protects the button and nothing above it - the Lockdown card it
+/// sits in is a perfectly ordinary Card target, and FallEffect used to be allowed to tilt that card
+/// off the bottom of the window with hit-testing off for 45 s, taking the Emergency Exit and the
+/// secret exit box with it.</para>
+/// </summary>
+[Collection(CompanionWpfRenderCollection.Name)]
+public class PossessionOffLimitsTests
+{
+    // ---- the name half (pure) --------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("LockdownCardBorder")]
+    [InlineData("BtnEmergencyExit")]
+    [InlineData("TxtSecretExitPhrase")]
+    [InlineData("lockdowngate")]            // case does not matter
+    [InlineData("PanelEMERGENCY")]
+    public void ReservedNames_are_off_limits(string name)
+        => Assert.True(PossessionOffLimits.IsReservedName(name));
+
+    [Theory]
+    [InlineData("BtnStart")]
+    [InlineData("CardFlashSettings")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Ordinary_names_are_not(string? name)
+        => Assert.False(PossessionOffLimits.IsReservedName(name));
+
+    [Fact]
+    public void A_null_element_is_off_limits()
+        => Assert.True(PossessionOffLimits.IsOffLimits(null));
+
+    // ---- the tree half ---------------------------------------------------------------------------
+
+    private static Border Realize(Border card)
+    {
+        var host = new Grid { Width = 400, Height = 300 };
+        host.Children.Add(card);
+        host.Measure(new Size(400, 300));
+        host.Arrange(new Rect(0, 0, 400, 300));
+        host.UpdateLayout();
+        return card;
+    }
+
+    /// <summary>An ordinary card full of ordinary controls is fair game - the deck would be empty
+    /// otherwise, and "everything is off limits" is the failure mode nobody would notice.</summary>
+    [Fact]
+    public void A_plain_card_is_takeable()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var card = new Border { Width = 200, Height = 120 };
+            var inner = new Grid();
+            inner.Children.Add(new Button { Content = "Save" });
+            card.Child = inner;
+
+            Assert.False(PossessionOffLimits.IsOffLimits(Realize(card)));
+        });
+    }
+
+    /// <summary>The ship-blocker: the card is not excluded, something INSIDE it is.</summary>
+    [Fact]
+    public void A_card_containing_an_excluded_control_is_off_limits()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var card = new Border { Width = 200, Height = 120 };
+            var inner = new Grid();
+            var exit = new Button { Content = "let me out" };
+            Possession.SetExclude(exit, true);
+            inner.Children.Add(exit);
+            card.Child = inner;
+
+            Assert.False(Possession.GetExclude(card));   // the tag really does not reach upward
+            Assert.True(PossessionOffLimits.IsOffLimits(Realize(card)));
+        });
+    }
+
+    [Fact]
+    public void An_excluded_card_is_off_limits()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var card = new Border { Width = 200, Height = 120 };
+            Possession.SetExclude(card, true);
+            Assert.True(PossessionOffLimits.IsOffLimits(Realize(card)));
+        });
+    }
+
+    [Fact]
+    public void A_card_named_for_the_lockdown_is_off_limits()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var card = new Border { Name = "LockdownCardBorder", Width = 200, Height = 120 };
+            Assert.True(PossessionOffLimits.IsOffLimits(Realize(card)));
+        });
+    }
+
+    /// <summary>Reading UPWARD as well: a control inside the lockdown surface is part of it.</summary>
+    [Fact]
+    public void A_control_inside_a_lockdown_ancestor_is_off_limits()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var inner = new Border { Width = 100, Height = 40 };
+            var outer = new Border { Name = "LockdownActivePanel", Width = 200, Height = 120, Child = inner };
+
+            Realize(outer);
+            Assert.True(PossessionOffLimits.IsOffLimits(inner));
+        });
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/PossessionRestoreTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionRestoreTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Threading;
+using ConditioningControlPanel.Services.Possession;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// POSSESSION.md's first hard rule: "Undo restores the control EXACTLY". Two ways that was not true.
+///
+/// <para><b>Ghost</b> stamped the opacity and hit-testing it found back as LOCAL values. A control
+/// whose opacity comes from a Style setter, a trigger or a storyboard has no local value of its own,
+/// and a local value outranks all three - so a toggle that dissolved once came back permanently
+/// pinned, its hover and disabled states dead until the app restarted. FallEffect and
+/// Ghost.NeutralTransform already did the ReadLocalValue / ClearValue dance; Ghost now does too.</para>
+///
+/// <para><b>TransformLease</b> marks itself released before it eases back, so a Take() during that
+/// window builds a fresh lease around the old group. The old lease then landed and restored
+/// RenderTransformOrigin and removed the table entry regardless - deleting the NEW lease's
+/// registration, after which IsLeased lies and the next effect stacks another TransformGroup.</para>
+/// </summary>
+[Collection(CompanionWpfRenderCollection.Name)]
+public class PossessionRestoreTests
+{
+    // ---- harness -------------------------------------------------------------------------------
+
+    /// <summary>Only the ghost layer matters here; nothing under test reaches for the window.</summary>
+    private sealed class StubHost : IPossessionHost
+    {
+        public StubHost(Canvas layer) { GhostLayer = layer; }
+        public Window Window => null!;
+        public Canvas GhostLayer { get; }
+        public Canvas RubbleFloor { get; } = new Canvas();
+        public IReadOnlyList<PossessionTarget> Targets => Array.Empty<PossessionTarget>();
+        public Point PointOf(FrameworkElement element) => default;
+        public bool IsUsable => true;
+    }
+
+    /// <summary>
+    /// A real (never shown) top-level HWND around the tree. WPF's <c>IsVisible</c> - which
+    /// Ghost.LayerBoundsOf gates on - is false for a tree that is not connected to a presentation
+    /// source, so a plain Measure/Arrange host is not enough to photograph anything.
+    /// </summary>
+    private static void WithLiveTree(Action<StubHost, Border> body)
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var layer = new Canvas { IsHitTestVisible = false };
+            var victim = new Border { Width = 120, Height = 60, Background = Brushes.SlateGray };
+            var root = new Grid { Width = 400, Height = 300 };
+            root.Children.Add(victim);
+            root.Children.Add(layer);
+
+            var source = new HwndSource(new HwndSourceParameters("possession-restore-tests")
+            {
+                Width = 400,
+                Height = 300,
+                WindowStyle = 0x00800000   // WS_BORDER only: created, never shown
+            })
+            { RootVisual = root };
+
+            try
+            {
+                root.Measure(new Size(400, 300));
+                root.Arrange(new Rect(0, 0, 400, 300));
+                root.UpdateLayout();
+                body(new StubHost(layer), victim);
+            }
+            finally { try { source.Dispose(); } catch { } }
+        });
+    }
+
+    /// <summary>Runs the dispatcher for a while, so a fire-and-forget release can actually land.</summary>
+    private static void Pump(int ms)
+    {
+        var frame = new DispatcherFrame();
+        var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(ms), DispatcherPriority.Background,
+                                        (_, __) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+        timer.Start();
+        Dispatcher.PushFrame(frame);
+        timer.Stop();
+    }
+
+    // ---- Ghost ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void Ghost_restore_hands_a_styled_opacity_back_to_its_style()
+    {
+        WithLiveTree((host, victim) =>
+        {
+            var style = new Style(typeof(Border));
+            style.Setters.Add(new Setter(UIElement.OpacityProperty, 0.6));
+            victim.Style = style;
+            victim.UpdateLayout();
+            Assert.Equal(DependencyProperty.UnsetValue, victim.ReadLocalValue(UIElement.OpacityProperty));
+
+            var ghost = Ghost.Capture(victim, host);
+            Assert.NotNull(ghost);
+
+            ghost!.Hide();
+            Assert.Equal(0, victim.Opacity, 3);
+
+            ghost.Dispose();
+
+            Assert.Equal(DependencyProperty.UnsetValue, victim.ReadLocalValue(UIElement.OpacityProperty));
+            Assert.Equal(0.6, victim.Opacity, 3);
+        });
+    }
+
+    [Fact]
+    public void Ghost_restore_keeps_a_local_opacity_local()
+    {
+        WithLiveTree((host, victim) =>
+        {
+            victim.Opacity = 0.8;
+
+            var ghost = Ghost.Capture(victim, host);
+            Assert.NotNull(ghost);
+
+            ghost!.Hide();
+            ghost.Dispose();
+
+            Assert.NotEqual(DependencyProperty.UnsetValue, victim.ReadLocalValue(UIElement.OpacityProperty));
+            Assert.Equal(0.8, victim.Opacity, 3);
+        });
+    }
+
+    /// <summary>Hide() without the hit-test flag must not touch hit-testing at all - the point of an
+    /// opacity-only ghost is that the toggle you are watching turn to ash still toggles.</summary>
+    [Fact]
+    public void Ghost_restore_does_not_touch_hit_testing_it_never_changed()
+    {
+        WithLiveTree((host, victim) =>
+        {
+            var ghost = Ghost.Capture(victim, host);
+            Assert.NotNull(ghost);
+
+            ghost!.Hide();
+            ghost.Dispose();
+
+            Assert.Equal(DependencyProperty.UnsetValue, victim.ReadLocalValue(UIElement.IsHitTestVisibleProperty));
+            Assert.True(victim.IsHitTestVisible);
+        });
+    }
+
+    [Fact]
+    public void Ghost_restore_clears_the_hit_testing_it_turned_off()
+    {
+        WithLiveTree((host, victim) =>
+        {
+            var ghost = Ghost.Capture(victim, host);
+            Assert.NotNull(ghost);
+
+            ghost!.Hide(alsoDisableHitTesting: true);
+            Assert.False(victim.IsHitTestVisible);
+
+            ghost.Dispose();
+
+            Assert.Equal(DependencyProperty.UnsetValue, victim.ReadLocalValue(UIElement.IsHitTestVisibleProperty));
+            Assert.True(victim.IsHitTestVisible);
+        });
+    }
+
+    // ---- TransformLease -------------------------------------------------------------------------
+
+    [Fact]
+    public void A_lease_gives_the_element_back_with_no_local_transform()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var el = new Border();
+            var lease = TransformLease.Take(el);
+            Assert.NotNull(lease);
+            lease!.SetOrigin(new Point(0.5, 0.5));
+
+            lease.ReleaseImmediate();
+
+            Assert.Equal(DependencyProperty.UnsetValue, el.ReadLocalValue(UIElement.RenderTransformProperty));
+            Assert.Equal(DependencyProperty.UnsetValue, el.ReadLocalValue(UIElement.RenderTransformOriginProperty));
+            Assert.False(TransformLease.IsLeased(el));
+        });
+    }
+
+    /// <summary>Two effects on one control share one wrapper; the crash-safe path must drop its own
+    /// reference and leave the other one standing, not snap the live effect home.</summary>
+    [Fact]
+    public void ReleaseImmediate_respects_a_second_holder()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var el = new Border();
+            var first = TransformLease.Take(el);
+            var second = TransformLease.Take(el);
+            Assert.Same(first, second);
+
+            first!.ReleaseImmediate();
+
+            Assert.False(first.IsReleased);
+            Assert.True(TransformLease.IsLeased(el));
+
+            second!.ReleaseImmediate();
+
+            Assert.True(first.IsReleased);
+            Assert.False(TransformLease.IsLeased(el));
+        });
+    }
+
+    /// <summary>The release race: a scene releases over 150-600 ms, another beat takes the same
+    /// control in that window, and the old lease lands afterwards. It must not delete the new lease's
+    /// registration (IsLeased would then lie and the next effect would stack a second group).</summary>
+    [Fact]
+    public void A_superseded_lease_leaves_the_new_one_registered()
+    {
+        WpfRenderHarness.OnStaThread(() =>
+        {
+            var el = new Border();
+            var old = TransformLease.Take(el);
+            Assert.NotNull(old);
+            old!.SetOrigin(new Point(1, 0));
+
+            old.Release(TimeSpan.FromMilliseconds(60));   // fire and forget, as the scenes do
+
+            var fresh = TransformLease.Take(el);
+            Assert.NotNull(fresh);
+            Assert.NotSame(old, fresh);
+            fresh!.SetOrigin(new Point(0.5, 0.5));
+
+            Pump(400);   // let the old lease's ease-back finish and its restore run
+
+            Assert.True(old.IsReleased);
+            Assert.False(fresh.IsReleased);
+            Assert.True(TransformLease.IsLeased(el));
+            Assert.Same(fresh, TransformLease.Take(el));          // joins, does not stack
+            Assert.Equal(new Point(0.5, 0.5), el.RenderTransformOrigin);
+
+            fresh.ReleaseImmediate();
+            fresh.ReleaseImmediate();
+            Assert.False(TransformLease.IsLeased(el));
+        });
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/PossessionTextRestoreTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/PossessionTextRestoreTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using ConditioningControlPanel.Services.Possession;
+using ConditioningControlPanel.Services.Possession.Effects;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// Possession's text effects and the one restore that could LOSE something.
+///
+/// <para>Every text effect snapshots the string it found and writes it back on Undo. That is correct
+/// right up until something else writes the same label in between - and the labels these effects can
+/// take are exactly the ones that do. A <c>{loc:Str}</c> label is a Binding, which
+/// <c>PossessionVisual.IsRewritable</c> declines outright, so the only takeable labels left are the
+/// CODE-DRIVEN ones: the level readout a level-up rewrites, a counter that ticks. Drop and Retitle hold
+/// until reassembly, so that window is the whole rest of the lockdown.</para>
+///
+/// <para>The rule (modelled by <c>XpDrainEffect.RestoreTheLevel</c>): put the original back only while
+/// the control still says what WE wrote. If the world moved on, leave it alone - a haunt that quietly
+/// reverts the user's own progress on screen is a bug, not a scare.</para>
+///
+/// <para>These run against the real effects on an STA thread with a bare host: the effects under test
+/// touch nothing but their victim, and the stub attribution never yields, so every await completes
+/// inline and the dispatcher is never asked to pump while a test is blocking on it.</para>
+/// </summary>
+[Collection(CompanionWpfRenderCollection.Name)]
+public class PossessionTextRestoreTests
+{
+    private static void OnStaThread(Action body) => WpfRenderHarness.OnStaThread(body);
+
+    // ---- the smallest room an effect will run in -------------------------------------------------
+
+    private sealed class BareAttribution : IPossessionAttribution
+    {
+        private sealed class Nothing : IDisposable { public void Dispose() { } }
+        public Task ChargeAsync(FrameworkElement target, CancellationToken ct, int durationMs = 400)
+            => Task.CompletedTask;
+        public IDisposable Possess(FrameworkElement target) => new Nothing();
+        public void EdgePulse(double strength) { }
+        public bool AnyPossessed => false;
+    }
+
+    private sealed class BareHost : IPossessionHost
+    {
+        /// <summary>Never read on these paths: ApplyAsync only reaches for the window when the effect
+        /// is targetless, and every effect here takes a victim.</summary>
+        public Window Window => null!;
+        public Canvas GhostLayer { get; } = new Canvas();
+        public Canvas RubbleFloor { get; } = new Canvas();
+        public IReadOnlyList<PossessionTarget> Targets => Array.Empty<PossessionTarget>();
+        public Point PointOf(FrameworkElement element) => new Point(0, 0);
+        public bool IsUsable => true;
+    }
+
+    private static PossessionContext Context() => new()
+    {
+        Host = new BareHost(),
+        Attribution = new BareAttribution(),
+        Rung = PossessionRung.Collapse,
+        Intensity = PossessionIntensity.FullDoki,
+        Photosafe = false,
+        Rng = new Random(20260825),
+        ElapsedFraction = 0.7,
+        Remaining = TimeSpan.FromMinutes(10),
+        Name = (_, _) => { },
+    };
+
+    private static PossessionTarget TargetFor(FrameworkElement el, PossessionRole role)
+        => new() { Element = el, Role = role, Key = "test", DisplayName = "the label" };
+
+    /// <summary>Safe here (and only here): nothing on these paths yields.</summary>
+    private static void Run(Task t) => t.GetAwaiter().GetResult();
+
+    // ---- typo (one write, 4 s hold) --------------------------------------------------------------
+
+    [Fact]
+    public void Typo_RestoresTheExactStringWhenNobodyElseTouchedIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Sessions" };
+            var fx = new TypoEffect();
+
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Label), CancellationToken.None));
+            Assert.NotEqual("Sessions", tb.Text);      // the letter slipped
+
+            Run(fx.UndoAsync(TimeSpan.Zero));
+            Assert.Equal("Sessions", tb.Text);
+        });
+    }
+
+    [Fact]
+    public void Typo_LeavesALabelAloneWhenSomethingElseRewroteIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Level 11" };
+            var fx = new TypoEffect();
+
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Label), CancellationToken.None));
+
+            // A level-up lands mid-hold and writes the label itself. That value is the truth now.
+            tb.Text = "Level 12";
+
+            Run(fx.UndoAsync(TimeSpan.Zero));
+            Assert.Equal("Level 12", tb.Text);
+        });
+    }
+
+    // ---- retitle (one write, held until reassembly) -----------------------------------------------
+
+    [Fact]
+    public void Retitle_RestoresTheExactStringWhenNobodyElseTouchedIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Conditioning Control Panel" };
+            var fx = new RetitleEffect();
+
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Title), CancellationToken.None));
+            Assert.NotEqual("Conditioning Control Panel", tb.Text);
+
+            Run(fx.UndoAsync(TimeSpan.Zero));
+            Assert.Equal("Conditioning Control Panel", tb.Text);
+        });
+    }
+
+    [Fact]
+    public void Retitle_LeavesATitleAloneWhenSomethingElseRewroteIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Conditioning Control Panel" };
+            var fx = new RetitleEffect();
+
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Title), CancellationToken.None));
+            tb.Text = "Session: Morning Drift";
+
+            Run(fx.UndoAsync(TimeSpan.Zero));
+            Assert.Equal("Session: Morning Drift", tb.Text);
+        });
+    }
+
+    // ---- glyphrot (many intermediate writes) ------------------------------------------------------
+
+    [Fact]
+    public void GlyphRot_RestoresTheExactStringWhenNobodyElseTouchedIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Progression" };
+            var fx = new GlyphRotEffect();
+
+            // The rot walks the word one letter per 60 ms on the dispatcher; this test never lets the
+            // dispatcher pump, so Undo lands with nothing painted yet - which is still "ours".
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Label), CancellationToken.None));
+            Run(fx.UndoAsync(TimeSpan.Zero));
+
+            Assert.Equal("Progression", tb.Text);
+        });
+    }
+
+    [Fact]
+    public void GlyphRot_LeavesALabelAloneWhenSomethingElseRewroteIt()
+    {
+        OnStaThread(() =>
+        {
+            var tb = new TextBlock { Text = "Progression" };
+            var fx = new GlyphRotEffect();
+
+            Run(fx.ApplyAsync(Context(), TargetFor(tb, PossessionRole.Label), CancellationToken.None));
+            tb.Text = "Prestige";
+
+            Run(fx.UndoAsync(TimeSpan.Zero));
+            Assert.Equal("Prestige", tb.Text);
+        });
+    }
+}

--- a/Tests/ConditioningControlPanel.Tests/WardenTests.cs
+++ b/Tests/ConditioningControlPanel.Tests/WardenTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.IO;
+using System.Linq;
+using ConditioningControlPanel.Services.Possession;
+using Xunit;
+
+namespace ConditioningControlPanel.Tests;
+
+/// <summary>
+/// The warden (Services/Possession/Warden.cs) - the companion's half of Possession. Every verb moves a
+/// layered window on its own thread, so the choreography itself is play-test territory; what is pinned
+/// here is the bookkeeping that made three bugs possible: where "off-frame" is, who owns an in-flight
+/// leave, and who owns the tube when a non-warden effect wants to move it.
+/// </summary>
+public class WardenTests
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "ConditioningControlPanel")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate the repo root from " + AppContext.BaseDirectory);
+        return dir!.FullName;
+    }
+
+    private static string Source(params string[] parts)
+        => File.ReadAllText(Path.Combine(new[] { RepoRoot(), "ConditioningControlPanel" }.Concat(parts).ToArray()));
+
+    private static string WardenSource() => Source("Services", "Possession", "Warden.cs");
+
+    [Fact]
+    public void Leave_GoesOffTheSCREEN_NotOffTheWorkingArea()
+    {
+        // WorkingArea EXCLUDES the taskbar, so parking the tube's top-left there left a taskbar-height
+        // slice of the companion visible - and topmost - through the whole R4 "she's gone" beat.
+        var src = WardenSource();
+        var start = src.IndexOf("private async Task LeaveCoreAsync", StringComparison.Ordinal);
+        Assert.True(start > 0, "LeaveCoreAsync not found");
+        var end = src.IndexOf("//  RETURN", start, StringComparison.Ordinal);
+        Assert.True(end > start);
+        var body = src[start..end];
+
+        Assert.Contains("screen.Bounds.Bottom", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("screen.WorkingArea", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("wa.Bottom", body, StringComparison.Ordinal);
+        Assert.Contains("clampToWorkArea: false", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Return_CancelsAndDrainsAnInFlightLeave_BeforeItTouchesTheTube()
+    {
+        // A lockdown ending mid-leave used to strand the tube: ReturnHomeAsync cleared the tube's
+        // captured home, then the leave finished and pinned its note in a frame nobody was coming
+        // back to, with _hasLeft still true for the next lockdown to bark a phantom return.
+        var src = WardenSource();
+        var start = src.IndexOf("public async Task ReturnAsync", StringComparison.Ordinal);
+        Assert.True(start > 0, "ReturnAsync not found");
+        var end = src.IndexOf("//  helpers", start, StringComparison.Ordinal);
+        Assert.True(end > start);
+        var body = src[start..end];
+
+        var cancel = body.IndexOf("CancelInFlightLeaveAsync", StringComparison.Ordinal);
+        var clear = body.IndexOf("ClearNote()", StringComparison.Ordinal);
+        var home = body.IndexOf("tube.ReturnHomeAsync(", StringComparison.Ordinal);
+        Assert.True(cancel > 0, "ReturnAsync must cancel an in-flight leave");
+        Assert.True(cancel < clear && cancel < home,
+            "the leave must be drained before the note is cleared and before the homeward glide");
+
+        // Every exit path leaves _hasLeft false.
+        Assert.Equal(4, body.Split("_hasLeft = false").Length - 1);
+    }
+
+    [Fact]
+    public void Leave_RefusesToFinish_OnceAReturnBegan()
+    {
+        var src = WardenSource();
+        var start = src.IndexOf("private async Task LeaveCoreAsync", StringComparison.Ordinal);
+        var end = src.IndexOf("//  RETURN", start, StringComparison.Ordinal);
+        var body = src[start..end];
+
+        // The epoch check must sit between the glide and the note, and _hasLeft is only true once she
+        // is actually off-frame.
+        var glide = body.IndexOf("GlideToScreenPointAsync", StringComparison.Ordinal);
+        var epoch = body.IndexOf("_returnEpoch) != epoch", StringComparison.Ordinal);
+        var hasLeft = body.IndexOf("_hasLeft = true", StringComparison.Ordinal);
+        var note = body.IndexOf("LeaveNote()", StringComparison.Ordinal);
+        Assert.True(glide > 0 && epoch > glide, "the epoch check must follow the glide");
+        Assert.True(hasLeft > epoch && note > epoch, "no note and no _hasLeft once a return began");
+    }
+
+    [Fact]
+    public void ANewLockdown_ClearsTheCooldownStampsAndTheLeftFlag()
+    {
+        var src = WardenSource();
+        var start = src.IndexOf("public void Reset()", StringComparison.Ordinal);
+        Assert.True(start > 0, "Reset() not found");
+        var end = src.IndexOf("private void EnsureHooked", start, StringComparison.Ordinal);
+        var body = src[start..end];
+
+        Assert.Contains("_lastAppearance = DateTime.MinValue;", body, StringComparison.Ordinal);
+        Assert.Contains("_lastStare = DateTime.MinValue;", body, StringComparison.Ordinal);
+        Assert.Contains("_hasLeft = false;", body, StringComparison.Ordinal);
+
+        // and it is actually wired to the start of a lockdown
+        Assert.Contains("lockdown.LockdownActivated += Reset;", src, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StealCard_MovesTheTubeOnlyUnderTheWardensLease()
+    {
+        // The steal card moved the tube with no busy check and no coordination, and its homeward leg
+        // (ReturnHomeAsync) clears the tube's captured home - so an undo landing during a knock left a
+        // detached tube stranded beside the card.
+        var steal = Source("Services", "Possession", "Effects", "StealCardEffect.cs");
+
+        Assert.DoesNotContain("AvailableTube()", steal, StringComparison.Ordinal);
+        Assert.Contains("warden.TryTakeTube()", steal, StringComparison.Ordinal);
+        Assert.Contains("ReleaseTube()", steal, StringComparison.Ordinal);
+
+        // The lease is given back on every path out of the apply, or the warden never knocks again.
+        var apply = steal.IndexOf("protected override async Task ApplyCoreAsync", StringComparison.Ordinal);
+        var undo = steal.IndexOf("protected override async Task UndoCoreAsync", StringComparison.Ordinal);
+        Assert.True(apply > 0 && undo > apply);
+        Assert.Contains("finally", steal[apply..undo], StringComparison.Ordinal);
+
+        // The undo only goes home when the tube is actually free.
+        Assert.Contains("if (_flew && TakeTube() != null) SendTubeHome();", steal, StringComparison.Ordinal);
+
+        // ...and the lease the warden hands out is the same flag its own verbs take.
+        var warden = WardenSource();
+        Assert.Contains("public bool TryTakeTube() => Interlocked.Exchange(ref _busy, 1) == 0;", warden, StringComparison.Ordinal);
+        Assert.Contains("public void ReleaseTube() => Interlocked.Exchange(ref _busy, 0);", warden, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Pre-release bughunt of the merged Possession/Emergency Exit/Dose stack (5 Opus finder agents, then 5 fixer agents with exclusive file ownership). Full test suite 3922 green, 92 new tests.

## Ship-blockers fixed
1. **Escape verdict never reached the page** - OnGameFinished destroyed the window synchronously before posting the verdict, so a winning player never saw the escape card (it only rendered under ?mock=1). Verdict now posts first and an _outroPending flag keeps the window alive through deactivate; the orphan 8s failsafe can no longer close the NEXT lockdown's game window.
2. **Three games failed on wall-clock from page mount** (labyrinth 25s / jigsaw 60s / captcha 90s) with no visibility pause - opening the window and getting distracted silently restarted the FULL timer. Clocks now start on first touch and pause while document.hidden; budgets unchanged.
3. **FallEffect could take the Lockdown card off-screen hit-test-dead for 45s** - with the Emergency Exit button and secret exit box inside it. New shared PossessionOffLimits guard (extracted from StealCardEffect).
4. **Predictive dodge stranded controls** - nav doors dodged out of the rail's 56px clip (invisible AND unhittable), the title-bar X dodged under opaque row-1 content. Dodge region is now the intersection of ancestor clips; chrome dodges horizontally in the title-bar band only; no legal room = no dodge.
5. **Director orphaned ghosts** - unconditional _live.Clear() after awaiting undo loops dropped ghosts added mid-loop (reachable via sendback + reactive effects, or a fast re-lock during reassembly): control permanently possessed, effect dead for the session, until-exit effects never undone. Release() is now the single authority; a generation counter fences the reassembly tail.

## Bugs fixed (highlights)
- Sendback no longer destroys LastActiveDuration (separate _startedAt) - throw_away_the_key earnable across restarts; expiry tick can no longer trigger the Dose keeper; TimerRestarted now precedes CountdownTick (no double Settle bark/pulse); restart also resets cooldowns and the wedged-pick latch that could kill the cadence loop for every later lockdown.
- Keeper-started engines skip CheckRelapse/TotalSessions++/enhancement prompt; Pop Quiz counts as a dose; video census ignores Thumbs.db-class junk; Restore marshals before touching MainWindow and owns the recovery file (survives a failed restore); stand-down no longer eats the starve edge.
- Warden leave glides past Bounds.Bottom (nothing parked on the taskbar); epoch-fenced leave/return cannot strand a detached tube or a stale note; steal-card takes the tube through the warden's lease (one owner for the captured home).
- Ghost.Restore/TransformLease restore value sources exactly (no pinned style values, no orphan TransformGroup stacks; ReleaseImmediate respects the refcount); RoomWarp returns the stolen pixels (they were never given back on the non-local path).
- Five text effects only restore text they still own; TxtXP excluded (BANK odometer rewrote it every ~70ms); WobbleEffect resurrected (hand-tag Role beats the never-names blocklist, so the R2 "digits wobble" promise fires for the first time); IsUsable now covers all nine takeover hosts including the Emergency Exit window itself; misroute re-validates its destination door at fire time; consent dialogs disclose the Emergency Exit restart gamble; DeleteDialog single bark; syskey throttle reset on activate.

## Left for the owner
- **--possession-preview rig re-run**: blocked by the live instance's single-instance mutex (never killed it). Run after closing the app, judge shots against "clarity in front".
- **The Dose live play-test** (still never done) + a normal Eerie play-test of this wave.
- POSSESSION.md updated where it had drifted (bark wrapper para, TxtXP, hand-tag rule, IsUsable list, RoomWarp path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVfeMhCj5mqWQ1b3pPAUVN
