### PR TITLE
fix(arcademy): web/mobile parity - props, rooms on a phone, art cold-load

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2057,6 +2057,37 @@ UI: see §6.
 
 ## 6. Verifying changes (no app UI — the owner is remote)
 
+**A PHONE VIEWPORT IS A MERGE GATE for campus props, rooms and overlays.** Any PR that
+touches the campus furniture (`.campus-postrow` and the two `.arc-*prop`s), a room chassis
+(`shell/room.js` + `rooms.css`, `shell/scene.js` + `scene.css`) or an overlay that carries a
+sticky exit bar (corkboard, mailbox, Bugle) gets a **shot at 844x390 AND at 667x375** from
+the CDP screenshot rig before it merges, plus a 1600x900 shot proving the desktop rects did
+not move. Three of the five bugs in the 2026-08-25 web/mobile wave were invisible at desktop
+size, and one of them - both post-row props stacked on a single pixel, hanging off the bottom
+of the window - had been shipping on the DESKTOP too, unseen, because nothing ever measured
+the row.
+
+The rig lives at `scratchpad/web-mobile-diag/`: `server.mjs` serves `site/` on
+127.0.0.1:8731 with stubbed `/api/arcademy/*`, and `shoot.mjs OUTDIR BASEURL shots.json
+seed.js` drives headless Chrome over raw CDP - one entry per shot (`w`, `h`, `query`,
+`script`, `probe`, `touch:true` for touch emulation). Four things it will bite you with:
+
+- **`site/` GOES STALE.** It is a COPY of the web tree, not a link, and it is the whole
+  trap: re-copy this folder into it (keeping `web/`, `web-shim.js`, `SYNC.json` and the
+  `web-shim.js` script tag in `index.html`) before every run, or you screenshot last week's
+  bug. The 2026-08-25 copy was 20 files behind and had no Records room in it at all.
+- A `pointerup` dispatched on `document` is needed to pass the knock gate, and a seeded
+  `arc-web:meta` in localStorage (`seed.js`) to skip Orientation and First Bell.
+- `?forcemobile=1` is what makes `isMobile()` true - headless reports a FINE pointer however
+  the viewport is sized, so `html.arc-mobile` never lands without it. `?dev=1` on localhost
+  enters an unscheduled painted room.
+- **MEASURE, DO NOT EYEBALL.** The `probe` expression returns `getBoundingClientRect()` and
+  `getComputedStyle` for whatever you name, and diffing a BEFORE run (the touched files
+  restored from `HEAD`) against an AFTER run is the only way to prove "desktop is
+  pixel-identical". It is also how a diagnosed fix gets refuted: the corkboard's sticky bar
+  reaches its flow position at the end of the scroll with or without content padding, so the
+  padding that was supposed to clear it bought nothing but dead cork underneath.
+
 Everything here is testable headless. The harness lives in the session scratchpad, not the
 repo: it copies this folder next to a `package.json` with `{"type":"module"}` (node treats
 bare `.js` as CommonJS, the browser loads them as modules) plus a ~130-line DOM double, then

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/bugle.css
@@ -283,19 +283,29 @@
 
 /* ============================== THE PROP ================================= */
 /* A folded paper the driver scatters on the campus. Nobody puts a newspaper
-   down straight, so it lies at an angle by default; --np-r overrides it. */
+   down straight, so it lies at an angle by default; --np-r overrides it.
+
+   RELATIVE, NOT ABSOLUTE, BY DEFAULT - the noticeboard prop's story, byte for
+   byte (corkboard.css, `.arc-boardprop`): an absolute prop is out of its
+   parent's flow, so `.campus-postrow` measured 0x0 and both props stacked on
+   one pixel a prop's height below the row's anchor. `relative` rather than
+   `static` because `.arc-bugleprop-new` is pinned inside this button and needs
+   it to stay the containing block. `.is-pinned` keeps the --np-x/--np-y API. */
 .arc-bugleprop {
   --news:      color-mix(in srgb, var(--ink) 88%, var(--slate));
   --news-lo:   color-mix(in srgb, var(--news), var(--slate) 22%);
   --news-ink:  color-mix(in srgb, var(--ground) 82%, var(--panel));
 
-  position:absolute; left:var(--np-x, 68%); top:var(--np-y, 72%);
+  position:relative; left:auto; top:auto;
   width:var(--np-w, 58px);
   display:flex; flex-direction:column; align-items:center; gap:4px;
   padding:0; margin:0; border:0; background:none;
   color:var(--campus-text, var(--ink-dim));
   cursor:pointer;
   transition:transform .16s ease;
+}
+.arc-bugleprop.is-pinned {
+  position:absolute; left:var(--np-x, 68%); top:var(--np-y, 72%);
 }
 .arc-bugleprop:hover, .arc-bugleprop:focus-visible {
   transform:translateY(-2px) scale(1.06);

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
@@ -300,18 +300,59 @@
   border-top:1px solid color-mix(in srgb, var(--cork-frame), transparent 40%);
 }
 
+/* THE BACK BAR ON A PHONE. `.arc-corkstage` is the scroller and the bar is
+   `position:sticky; bottom:0` inside the frame, so for the whole scroll it is
+   pinned to the bottom of the window with the wall running under it. On a
+   390px-tall screen that bar was 71px - an eighth of the glass - and its
+   default backing is a gradient that starts at `transparent`, so the notices
+   read THROUGH the top half of it. That is the "bar over the text" the phone
+   capture shows, and it is a backing-and-height problem, not a spacing one.
+
+   IT IS NOT FIXED WITH BOTTOM PADDING, AND THE HARNESS IS WHY THIS COMMENT IS
+   HERE. Padding the scroller is wrong twice over (a sticky bottom:0 is measured
+   against the scrollport's padding box, so it lifts the bar and opens a strip
+   of dusk under it). Padding the CONTENT WRAPPER was the next guess and it was
+   measured too: at 844x390 the bar reaches its flow position at the end of the
+   scroll either way - the last notice cleared it before the change (foot bottom
+   y268, bar top y280) - so all 68px bought was dead cork under the bar at the
+   one place the wall was already legible. Mid-scroll, which is where the
+   problem actually is, padding does nothing at all. So: keep the bar where it
+   is, make it shorter, and make it OPAQUE. */
+html.arc-mobile .arc-cork-frame .arc-exitbar {
+  margin-top:8px;
+  padding:9px 6px calc(9px + env(safe-area-inset-bottom, 0px));
+  background:linear-gradient(180deg,
+    color-mix(in srgb, var(--cork-lo), transparent 22%) 0,
+    var(--cork-lo) 30%,
+    var(--cork-lo) 100%);
+}
+
 /* ============================== THE PROP ================================= */
-/* A small board hung somewhere on the campus. The driver places it: override
-   --bp-x / --bp-y on the element, or position it from campus CSS. */
+/* A small board hung somewhere on the campus. The driver places it: put it in a
+   row (the campus post row does) and it simply leans there, or add `.is-pinned`
+   and override --bp-x / --bp-y to hang it at a spot on the plan.
+
+   RELATIVE, NOT ABSOLUTE, BY DEFAULT. The prop used to be `position:absolute`
+   unconditionally, which took it out of its parent's flow: `.campus-postrow` is
+   a flex row, so it measured 0x0, both props stacked on the same pixel and both
+   hung a prop's height BELOW the row's bottom anchor. `relative` (not `static`)
+   is deliberate - `.arc-boardprop-new`, the unread dot, is absolutely positioned
+   INSIDE the button and needs this element to stay its containing block. */
 .arc-boardprop {
   /* the tokens are up top now, on the shared THE WALL TOKENS block */
-  position:absolute; left:var(--bp-x, 12%); top:var(--bp-y, 54%);
+  position:relative; left:auto; top:auto;
   width:var(--bp-w, 74px);
   display:flex; flex-direction:column; align-items:center; gap:5px;
   padding:0; margin:0; border:0; background:none;
   color:var(--campus-text, var(--ink-dim));
   cursor:pointer;
   transition:transform .16s ease, filter .16s ease;
+}
+/* THE PIN. The documented free-placement API, kept intact and opt-in: a driver
+   that wants the board hung at a spot on the plan rather than leaning in a row
+   asks for it by name. Nothing in the shipped campus uses it today. */
+.arc-boardprop.is-pinned {
+  position:absolute; left:var(--bp-x, 12%); top:var(--bp-y, 54%);
 }
 .arc-boardprop:hover, .arc-boardprop:focus-visible { transform:translateY(-2px) scale(1.04); }
 .arc-boardprop:focus-visible { outline:2px solid var(--pink); outline-offset:4px; }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
@@ -374,7 +374,24 @@
   .arc-letter-mark { width:34px; height:34px; }
 }
 html.arc-mobile .arc-mail-item { padding:12px; min-height:44px; }
-html.arc-mobile .arc-mailchip { width:40px; height:40px; }
+/* 44px, not 40: the mobile pass's thumb floor is a floor, and the chip was the
+   one control in this file sitting under it. */
+html.arc-mobile .arc-mailchip { width:44px; height:44px; }
+
+/* THE CLOSE BAR IS NOT ON THE LETTER, AND THE HARNESS IS WHY THIS IS 10px.
+   `.arc-exitbar` is `position:sticky; bottom:0`, which on the corkboard means a
+   bar pinned over a scrolling page (corkboard.css carries that fix). Here it
+   does NOT: `.arc-mailbox` is a flex COLUMN with `overflow:hidden`, the body
+   above it has `min-height:0` and shrinks, so the bar is laid out under the
+   panes rather than over them. Measured at 844x390: paper ends at y282, the bar
+   starts at y292. What the pane actually wants at that size is a line of breath
+   at the end of a scroll, not a bar's height of it - 56px of clearance would
+   have cost a third of a 179px reading window to solve a problem that is not
+   there. If this ever DOES overlap, the fix is still here and not on
+   `.arc-mailbox`: a sticky bottom is measured against the scrollport's padding
+   box, so padding the container lifts the bar and opens a gap under it. */
+html.arc-mobile .arc-mail-list,
+html.arc-mobile .arc-mail-paper { padding-bottom:10px; }
 
 /* =========================== REDUCED MOTION ==============================
    The global freeze runs every animation once at .001s, which is the right

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/room.js
@@ -31,6 +31,8 @@
  *  - nine-broken-logos law: art resolves module-relative via import.meta.url.
  * ==========================================================================*/
 
+import { isMobile, orientation } from '../core/device.js';
+
 /** Stage plane the art was authored on (the annex's, promoted). */
 const STAGE_W = 1376;
 const STAGE_H = 768;
@@ -45,6 +47,13 @@ const STAGE_H = 768;
 const APRON_STAGE_TOP = 640;
 /** The apron never shrinks below this, even art-to-the-floor (px, real). */
 const APRON_MIN = 110;
+/* THE PHONE'S FLOOR, and why it is a different number. 110px is a quarter of a
+ * landscape phone's 390px of glass, which is a band, not an apron: the room it
+ * is the front edge OF ends up smaller than the furniture in front of it. 72px
+ * still clears the 44px thumb floor for all three slabs (rooms.css sizes them
+ * off --arm-band-h and clamps each one at 44) and hands the painting back the
+ * 38px it was eating. Desktop keeps 110 exactly. */
+const APRON_MIN_MOBILE = 72;
 
 /**
  * The fan-out table. Rects are [x, y, w, h] in stage pixels. Rects must keep
@@ -101,6 +110,25 @@ const SCENES = Object.freeze({
   }),
 });
 
+/* THE ONE MOBILE DECISION (core/device.js). JS asks the function, CSS reads the
+ * class and the `data-arc-orient` attribute it writes, and this module needs
+ * both to agree: the apron's floor and the stage's anchor are computed here and
+ * the box they move is styled there.
+ *
+ * LANDSCAPE ONLY, and that is the half that matters. Portrait is behind the
+ * rotate gate (shell/orientgate.js), so it is not designed for - but a room
+ * left standing while the phone is turned still has to render something sane,
+ * and top-anchoring a 9:19.5 frame would hand the apron two thirds of the
+ * screen. Portrait keeps the centred stage and the 110px floor it always had.
+ * rooms.css carries the SAME `[data-arc-orient="landscape"]` qualifier on the
+ * two rules that move with this flag; drift and the scale walks off-axis.
+ *
+ * Wrapped because a suite's DOM double has no matchMedia and must get `false`
+ * rather than a throw at fit() time. */
+function onPhone() {
+  try { return !!isMobile() && orientation() === 'landscape'; } catch (e) { return false; }
+}
+
 /** Does this game have a painted room? The shell's decline test. */
 export function hasRoomScene(gameKey) {
   return !!SCENES[gameKey];
@@ -109,6 +137,60 @@ export function hasRoomScene(gameKey) {
 function artUrl(file) {
   try { return new URL('../art/vn/' + file, import.meta.url).href; }
   catch (e) { return 'art/vn/' + file; }
+}
+
+/**
+ * THE PLATE'S URL, for anybody who wants it before the room is built. The one
+ * consumer is the shell's prefetch (below): the campus knows tonight's four
+ * keys, and a plate that is already in cache when the door opens is the whole
+ * difference between a painted room and a lit void. Keeps the SCENES table
+ * private - a caller gets a string or null, never the row.
+ * @param {string} gameKey
+ * @returns {?string}
+ */
+export function artUrlFor(gameKey) {
+  const scene = SCENES[gameKey];
+  return scene ? artUrl(scene.art) : null;
+}
+
+/**
+ * WARM THE ROOMS THAT ARE ON TONIGHT. Called once a boot, from the seam where
+ * the campus is shown, with the keys the timetable dealt. Every painted key
+ * gets one `<link rel=prefetch as=image>` in <head>; unpainted keys, repeats
+ * and a second call are no-ops.
+ *
+ * `prefetch`, not `preload`: this is art for a screen the player may never
+ * open, so it must ride at the lowest priority the browser has and must never
+ * warn about an unused preload. A desktop WebView2 window reads these files off
+ * the local disk, where the whole thing costs a file open that would have
+ * happened anyway - which is why this is safe to run everywhere rather than
+ * behind a "is this the web build" test the page has no business taking.
+ *
+ * @param {Array<string>} gameKeys tonight's board (any order, dupes fine)
+ * @returns {number} how many links this call actually added
+ */
+const prefetched = Object.create(null);
+export function prefetchRoomArt(gameKeys) {
+  if (!Array.isArray(gameKeys) || typeof document === 'undefined') return 0;
+  const head = document.head || document.documentElement;
+  if (!head || typeof head.appendChild !== 'function') return 0;
+  if (typeof document.createElement !== 'function') return 0;
+  let n = 0;
+  for (let i = 0; i < gameKeys.length; i += 1) {
+    const key = gameKeys[i];
+    const href = artUrlFor(key);
+    if (!href || prefetched[href]) continue;
+    prefetched[href] = true;
+    try {
+      const link = document.createElement('link');
+      link.rel = 'prefetch';
+      link.as = 'image';
+      link.href = href;
+      head.appendChild(link);
+      n += 1;
+    } catch (e) { /* a browser without prefetch loses nothing but the warm-up */ }
+  }
+  return n;
 }
 
 /* A real file (shell/rooms.css), linked once and lazily, resolved against this
@@ -335,13 +417,21 @@ export function createRoomScene(opts) {
     const w = root.clientWidth || (root.parentNode && root.parentNode.clientWidth) || STAGE_W;
     const h = root.clientHeight || (root.parentNode && root.parentNode.clientHeight) || STAGE_H;
     const s = Math.min(w / STAGE_W, h / STAGE_H) || 1;
-    stage.style.transform = 'translate(-50%,-50%) scale(' + s + ')';
+    /* THE PHONE ANCHORS THE PAINTING TO THE TOP. A centred stage splits its
+     * letterbox above and below; above is the ceiling of the room, which is the
+     * half a player reads the set from, and below is the calm floor the apron
+     * was going to cover anyway. So on a phone the whole void goes to the
+     * bottom, under the band. rooms.css moves the box (`top:0`) and the origin
+     * (`50% 0`) under the same class - the two have to agree or the scale walks
+     * the plane off-axis (lab.css's lesson). Desktop is untouched. */
+    const phone = onPhone();
+    stage.style.transform = 'translate(-50%,' + (phone ? '0' : '-50%') + ') scale(' + s + ')';
     /* The apron hugs the painting's floor line and swallows the letterbox:
-     * top = the APRON_STAGE_TOP row of the scaled, centered stage; bottom =
-     * the viewport. Never thinner than APRON_MIN, even art-to-the-floor. */
-    const artTop = (h - STAGE_H * s) / 2;
+     * top = the APRON_STAGE_TOP row of the scaled stage; bottom = the viewport.
+     * Never thinner than the floor for this frame (APRON_MIN / _MOBILE). */
+    const artTop = phone ? 0 : (h - STAGE_H * s) / 2;
     let apronTop = artTop + APRON_STAGE_TOP * s;
-    if (h - apronTop < APRON_MIN) apronTop = h - APRON_MIN;
+    if (h - apronTop < (phone ? APRON_MIN_MOBILE : APRON_MIN)) apronTop = h - (phone ? APRON_MIN_MOBILE : APRON_MIN);
     if (apronTop < 0) apronTop = 0;
     bar.style.top = apronTop + 'px';
     /* Published on both: the bar is a body-level sibling, so it cannot
@@ -358,8 +448,24 @@ export function createRoomScene(opts) {
    * Refit when the skin lands, when the art decodes, and once next frame -
    * cheap, idempotent, and the resize listener owns every later change. */
   if (cssLink) cssLink.addEventListener('load', onResize);
-  art.addEventListener('load', onResize);
+  /* THE COLD LOAD. The plate starts at opacity 0 over the stage's painted
+   * fallback (rooms.css) and is lit here, on the image's own load - the same
+   * listener that was already refitting, one class heavier. A cached plate is
+   * in on the first frame; a plate off a phone's network eases onto a lit
+   * room-shaped void instead of blinking over a black rectangle. */
+  function lightArt() {
+    try { art.classList.add('is-in'); } catch (e) { /* DOM double: nothing to light */ }
+  }
+  art.addEventListener('load', () => { lightArt(); onResize(); });
+  art.addEventListener('error', lightArt);   // a 404 must never leave a hidden img
   if (typeof requestAnimationFrame === 'function') requestAnimationFrame(onResize);
+  /* THE BELT. `load` cannot fire before this turn ends, so the listener above
+   * always sees it - but a decoded-from-cache plate in a browser that skips the
+   * event, or a suite that hands us a fake image, must not be left invisible. */
+  if (art.complete && art.naturalWidth) lightArt();
+  else if (typeof setTimeout === 'function') {
+    setTimeout(() => { if (!destroyed && art.complete) lightArt(); }, 1200);
+  }
 
   /* Focus after the caller has appended us (a fresh node not yet in the
    * document ignores focus() in some engines - the end card's lesson). */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -31,8 +31,24 @@
   transform-origin: 50% 50%;
   /* room.js sets transform: translate(-50%,-50%) scale(s); origin must stay
      center or the scale walks the stage off-axis (lab.css's lesson) */
+
+  /* THE PAINTED FALLBACK. A ~1MB plate over a phone's network takes real
+     seconds, and until it decodes the stage was flat #0B0B18 - a black
+     rectangle with a glowing rect and a marquee slab floating in it, which
+     reads as a broken room rather than a loading one. A warm dark tint with a
+     lamp high in the frame gives the same beat a LIT room-shaped void: the
+     shape is right, the light is right, only the furniture is late. It costs
+     one gradient, it is painted once, and the art covers it completely. */
+  background:
+    radial-gradient(58% 42% at 50% 18%,
+      rgba(120, 74, 106, 0.42) 0%, rgba(58, 34, 62, 0.30) 46%, transparent 78%),
+    linear-gradient(180deg, #1A1026 0%, #150E20 52%, #0D0916 100%);
 }
 
+/* THE ART FADES IN, IT DOES NOT SNAP. `is-in` is written by room.js on the
+   image's own `load` (the same listener that already refits), so a plate that
+   was in cache is lit on the first frame and a plate off a slow network eases
+   onto the fallback instead of replacing it in one jarring blink. */
 .arm-art {
   position: absolute;
   inset: 0;
@@ -42,7 +58,14 @@
   image-rendering: pixelated;
   pointer-events: none;
   user-select: none;
+  opacity: 0;
+  transition: opacity 240ms ease-out;
 }
+.arm-art.is-in { opacity: 1; }
+/* Decoration law: reduced motion gets the room, not the fade. Never a rule that
+   leaves the art at 0 - the freeze at the bottom of styles.css runs animations
+   at .001s, and a TRANSITION it does not touch, so this is the honest still. */
+.arc-reduced .arm-art, .arm-lite .arm-art { transition: none; }
 
 /* ------------------------------ hotspots -------------------------------- */
 
@@ -468,3 +491,108 @@
 }
 .arm-glyph-knobs::before { left: 3px; top: -2px; }
 .arm-glyph-knobs::after { right: 4px; top: 12px; }
+
+/* ========================= THE ROOM ON A PHONE ===========================
+ * Every rule below is gated on `html.arc-mobile` - core/device.js's one
+ * decision, the same gate the rest of the mobile pass uses (styles.css). A
+ * desktop WebView2 window never carries the class, so this block is dead code
+ * there and the app renders what it rendered before it existed. Prove it, do
+ * not trust it: the harness reads `.arm-bar` and `.arm-hero`'s computed rects
+ * at 1600x900 before and after and they must be identical.
+ *
+ * WHAT A LANDSCAPE PHONE CHANGES, AND WHY:
+ *   The band. room.js drops its floor from 110px to 72px there, because 110 on
+ *   390px of glass is 28% of the room spent on the strip in front of it.
+ *   The slabs then have to fit 72px, and every one of them still clears the
+ *   44px thumb floor - that is the constraint this block is written against,
+ *   not "smaller".
+ *   The anchor. room.js pins the painting to the top of the frame; `top` and
+ *   `transform-origin` move together here or the scale walks the plane
+ *   off-axis (rooms.css header, lab.css's lesson).
+ *
+ * PORTRAIT IS BEHIND THE ROTATE GATE (shell/orientgate.js) and is not designed
+ * for - these rules simply must not throw or hide anything there, which they
+ * cannot: they are three sizes and an anchor. */
+
+/* LANDSCAPE ONLY, and room.js's `onPhone()` carries the SAME qualifier - the
+   box and the origin move together with the JS that writes the transform, or
+   the scale walks the plane off-axis. Portrait is behind the rotate gate and
+   keeps the centred stage. */
+html.arc-mobile[data-arc-orient="landscape"] .arm-stage { top: 0; transform-origin: 50% 0; }
+
+html.arc-mobile .arm-bar {
+  gap: 10px;
+  padding: 7px calc(clamp(10px, 2.6vw, 22px) + env(safe-area-inset-right, 0px))
+           env(safe-area-inset-bottom, 0px)
+           calc(clamp(10px, 2.6vw, 22px) + env(safe-area-inset-left, 0px));
+}
+/* The route tape is a seam, not a fence: at 72px a 10px stripe is an eighth of
+   the band. */
+html.arc-mobile .arm-bar::before { height: 6px; }
+html.arc-mobile .arm-bar::after { top: 8px; }
+html.arc-mobile .arm-hero-group { gap: 10px; }
+
+/* THE HERO KEEPS ITS BULBS. It is the verb; a phone gets a smaller marquee, not
+   a plain button. The ring, the face inset and the bulb pitch all come down
+   together so the gutter still reads as bulbs rather than as a gold smear. */
+html.arc-mobile .arm-hero {
+  height: clamp(44px, calc(var(--arm-band-h, 72px) - 18px), 68px);
+  min-width: clamp(140px, 30vw, 240px);
+  padding: 7px;
+  border-radius: 12px;
+}
+html.arc-mobile .arm-hero::before, html.arc-mobile .arm-hero::after {
+  inset: 2px;
+  padding: 6px;
+  border-radius: 10px;
+  background-image: radial-gradient(circle, #FFD700 1.5px, rgba(255, 215, 0, 0.28) 2.1px, transparent 3px);
+  background-size: 15px 15px;
+  background-position: 3px 2px;
+}
+html.arc-mobile .arm-hero::after { background-position: 10px 9px; }
+html.arc-mobile .arm-hero .arm-hero-face {
+  inset: 7px;
+  border-radius: 7px;
+  font-size: clamp(14px, calc(var(--arm-band-h, 72px) * 0.26), 24px);
+  letter-spacing: 0.12em;
+}
+
+/* The side door, subordinate at any size. */
+html.arc-mobile .arm-hero-alt {
+  height: clamp(44px, calc(var(--arm-band-h, 72px) - 26px), 56px);
+  min-width: clamp(104px, 20vw, 160px);
+  padding: 6px;
+  border-radius: 11px;
+}
+html.arc-mobile .arm-hero-alt .arm-hero-face {
+  inset: 6px;
+  font-size: clamp(11px, calc(var(--arm-band-h, 72px) * 0.16), 15px);
+  letter-spacing: 0.1em;
+}
+
+/* THE SIDE SLABS STAY 44px TALL. `clamp(44px, ...)` is the floor and it is the
+   whole point of the rule - the label may ellipsis, the target may not shrink. */
+html.arc-mobile .arm-bar-ghost {
+  gap: 8px;
+  height: clamp(44px, calc(var(--arm-band-h, 72px) - 24px), 60px);
+  padding: 0 clamp(9px, 2vw, 16px);
+  border-bottom-width: 3px;
+  border-radius: 11px;
+  font-size: clamp(10px, calc(var(--arm-band-h, 72px) * 0.14), 13px);
+  letter-spacing: 0.08em;
+}
+html.arc-mobile .arm-glyph-arrow { width: 10px; height: 10px; border-width: 3px; }
+html.arc-mobile .arm-glyph-knobs { width: 18px; height: 13px; }
+
+/* The room sign, out of the way of a 390px frame's ceiling. */
+html.arc-mobile .arm-plate {
+  left: calc(10px + env(safe-area-inset-left, 0px));
+  top: calc(8px + env(safe-area-inset-top, 0px));
+  max-width: min(260px, 46vw);
+  padding: 8px 11px;
+  border-radius: 8px;
+}
+html.arc-mobile .arm-plate-name { font-size: 15px; }
+html.arc-mobile .arm-plate-room { font-size: 9px; }
+html.arc-mobile .arm-plate-status { font-size: 10px; margin-top: 4px; }
+html.arc-mobile .arm-plate-xp { font-size: 10.5px; margin-top: 5px; }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
@@ -222,3 +222,37 @@
   opacity: 1;
   transform: none;
 }
+
+/* ======================== THE SCENE ON A PHONE ===========================
+ * The apron's own phone rules are rooms.css's - this chassis wears the same
+ * `.arm-bar` and the same slabs, which is the point of the split at the top of
+ * this file - so all that belongs here is what only a SCENE has.
+ *
+ * THE ANCHOR. scene.js pins the painting to the top of the frame on a phone
+ * (room.js's change, same reasons); the box and the origin move together or
+ * the scale walks the plane off-axis. The ZOOM is untouched: it rides
+ * `.asc-slide`, one level down, and still turns about its own centre.
+ *
+ * Gated on `html.arc-mobile` - core/device.js's one decision - so a desktop
+ * window renders exactly what it rendered before. */
+html.arc-mobile[data-arc-orient="landscape"] .asc-stage { top: 0; transform-origin: 50% 0; }
+
+/* The step-back pill is a thumb target on a phone, and it shares the room's
+   ceiling with the plate. */
+html.arc-mobile .asc-back {
+  left: calc(10px + env(safe-area-inset-left, 0px));
+  top: calc(8px + env(safe-area-inset-top, 0px));
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 14px;
+  font-size: 12px;
+}
+/* A 72px band leaves the overlay more of the glass; it only wants the margins
+   back so the panel is not two words wide. */
+html.arc-mobile .asc-panel {
+  width: min(920px, 96%);
+  padding: 14px 16px 16px;
+  margin-bottom: calc(var(--arm-band-h, 72px) + 8px);
+  max-height: calc(100% - var(--arm-band-h, 72px) - 16px);
+}

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
@@ -81,6 +81,17 @@
  * ==========================================================================*/
 
 import { t as lexT } from '../core/lexicon.js';
+import { isMobile, orientation } from '../core/device.js';
+
+/* THE ONE MOBILE DECISION (core/device.js), asked the way room.js asks it, and
+ * LANDSCAPE ONLY for room.js's reason: portrait is behind the rotate gate, and
+ * top-anchoring a 9:19.5 frame would hand the apron two thirds of the screen.
+ * The apron floor and the stage anchor are computed here, the box they move is
+ * styled from `html.arc-mobile[data-arc-orient="landscape"]` in scene.css, and
+ * the two must not drift. The wrapper is for the DOM double, no matchMedia. */
+function onPhone() {
+  try { return !!isMobile() && orientation() === 'landscape'; } catch (e) { return false; }
+}
 
 /** The plane the VN art was authored on. Overridable, rarely overridden. */
 const STAGE_W = 1376;
@@ -92,6 +103,9 @@ const STAGE_H = 768;
 const APRON_FRACTION = 640 / 768;
 /** The band never shrinks below this, even art-to-the-floor (px, real). */
 const APRON_MIN = 110;
+/** The phone's floor. room.js's number and room.js's reasons - the two chassis
+ *  share rooms.css's slab sizing, so they must share the band it sizes off. */
+const APRON_MIN_MOBILE = 72;
 
 /** The zoom between slides. One number, mirrored in scene.css. */
 const ZOOM_MS = 320;
@@ -652,13 +666,22 @@ export function createScene(opts) {
     const w = root.clientWidth || (root.parentNode && root.parentNode.clientWidth) || stageW;
     const h = root.clientHeight || (root.parentNode && root.parentNode.clientHeight) || stageH;
     const s = Math.min(w / stageW, h / stageH) || 1;
-    stage.style.transform = 'translate(-50%,-50%) scale(' + s + ')';
+    /* THE PHONE ANCHORS THE PAINTING TO THE TOP and takes a 72px band instead
+     * of 110 - room.js's change, for room.js's reasons, on the chassis that
+     * shares its apron. scene.css moves the box and the origin together under
+     * `html.arc-mobile`; the origin must follow the anchor or the scale walks
+     * the plane off-axis (this file's own header). The ZOOM is untouched: it
+     * lives on `.asc-slide`, one level down, and still turns about its own
+     * centre. */
+    const phone = onPhone();
+    stage.style.transform = 'translate(-50%,' + (phone ? '0' : '-50%') + ') scale(' + s + ')';
 
     let bandH = 0;
     if (bar) {
-      const artTop = (h - stageH * s) / 2;
+      const floor = phone ? APRON_MIN_MOBILE : APRON_MIN;
+      const artTop = phone ? 0 : (h - stageH * s) / 2;
       let apronTop = artTop + apronStageTop * s;
-      if (h - apronTop < APRON_MIN) apronTop = h - APRON_MIN;
+      if (h - apronTop < floor) apronTop = h - floor;
       if (apronTop < 0) apronTop = 0;
       bandH = h - apronTop;
       bar.style.top = apronTop + 'px';

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -71,7 +71,7 @@ import { createAnnexLab } from '../annex/lab.js';
  * and a class, replacing the door card for the rooms that have art - room.js
  * owns the SCENES table and the stage; the shell keeps the walk, the launch
  * path and the Esc rung (narrow caps, records.js style). */
-import { createRoomScene, hasRoomScene } from './room.js';
+import { createRoomScene, hasRoomScene, prefetchRoomArt } from './room.js';
 /* THE PHANTOM POST: the mail engine and its three paper overlays. The engines
  * hold NO storage of their own (their STATE-NEEDS law) - the shell hands each
  * an injected blob below and banks it through the store like any page key. */
@@ -1579,6 +1579,20 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       campus.boardMount.appendChild(board.root);
       renderBoardExtras(campus.footMount);
       dom.screen.appendChild(campus.root);
+      /* WARM TONIGHT'S ROOMS. The campus is up and the player is about to spend
+       * a while looking at it; the plates behind tonight's painted doors are
+       * ~1MB each and on a phone they arrive AFTER the room does, which is how
+       * a lit room ships as a black rectangle with a glowing rect in it. One
+       * `<link rel=prefetch as=image>` per painted key, lowest priority, once
+       * per boot (room.js keeps the ledger, so the rebuild on every campus
+       * visit adds nothing the second time). Unpainted keys are skipped. A
+       * desktop WebView2 window reads these off local disk, where it costs a
+       * file open that was going to happen anyway - harmless, and not worth a
+       * "which build am I" test the page has no business taking. */
+      try {
+        const warmed = prefetchRoomArt(timetable.classes.map((c) => c.gameKey));
+        if (warmed) say('prefetched ' + warmed + ' room plate(s)');
+      } catch (e) { say('room art prefetch threw: ' + ((e && e.message) || e)); }
       /* CAMPUS PRESENCE. Built AFTER the stage is in the document and started
        * only by the campus's revealDone hook. It is its own try/catch for the
        * campus's reason: a ghost layer that throws costs the player some company,

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1923,13 +1923,28 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
 /* ---- the post row (PHANTOM POST furniture: noticeboard + folded Bugle).
    The props style themselves (corkboard.css / bugle.css); this row only says
    where they lean: beside the student ID, on the same baseline. On a phone the
-   card owns that corner, so the row steps up onto the wall above it. */
+   card owns that corner, so the row steps up onto the wall above it.
+
+   THE ROW IS THE ONLY ABSOLUTE THING HERE. Both props default to
+   `position:relative` inside it (corkboard.css / bugle.css, `.is-pinned` for a
+   driver that wants to pin one somewhere else on the plan) - an absolute child
+   is out of flow, which collapsed this flex row to 0x0, stacked the two props
+   on the same pixel and hung them BELOW the `bottom:22px` anchor by their own
+   height. On a desktop window too, which is how it reached the owner.
+
+   THE BREAKPOINT IS THE CARD'S BREAKPOINT, VERBATIM. The step-aside exists to
+   clear `.campus-idcard`, so it has to end on exactly the query that hides the
+   card ("small stages", further down this file). A row that dodged at 740px
+   while the card left at 760px/600px landed the props back on the architecture
+   of every landscape phone. Once the card is gone the corner is free, so the
+   row takes it: the old `bottom:172px` was headroom for a card that is
+   `display:none` at that size. */
 .campus-postrow {
   position:absolute; left:calc(clamp(12px, 2.5vw, 44px) + 256px); bottom:22px;
   z-index:24; display:flex; align-items:flex-end; gap:12px;
 }
-@media (max-width: 740px) {
-  .campus-postrow { left:clamp(12px, 2.5vw, 44px); bottom:172px; }
+@media (max-width:760px), (max-height:600px) {
+  .campus-postrow { left:clamp(12px, 2.5vw, 44px); bottom:22px; }
 }
 
 /* ---- tooltip ---- */


### PR DESCRIPTION
Owner-reported from app.cclabs.app/arcademy on an iPhone: props sat on top of the floor plan, rooms had no background, corkboard/paper stacked in portrait.

Root causes and fixes:
- Campus props were `position:absolute` inside a flex row (row 0x0, props stacked, 48px overhang - desktop too) with a breakpoint that missed the ID card's. Now relative in the row, breakpoint verbatim the card's.
- Room art on a cold web load = black stage until the 500KB plate arrived. Painted fallback + opacity fade + `<link rel=prefetch>` of tonight's painted rooms.
- No mobile rules for rooms: apron floor 72px on phone landscape (desktop untouched, rects byte-identical), stage anchored top, slabs 44px, scene chassis included.
- Mail chip 44px; corkboard sticky bar opaque on mobile; mailbox scroll-end breath.
- CLAUDE.md §6: phone-shot merge gate + harness recipe.

Not in scope: room screen has no rotate gate (pre-existing); lab door stays gated by design (whole school sealed).

Verified: harness before/after shots at 1600x900 / 844x390 / 667x375 / 390x844, scene suite 170/0, records suite 176/0, dotnet build 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6