### PR TITLE
fix(dashboard): the ? box no longer spoils its own reveal

### DIFF
--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -1123,11 +1123,11 @@ namespace ConditioningControlPanel
         }
 
         /// <summary>
-        /// The ? box's face: the tile keeps the mystery-box art, but its title names today's
-        /// feature outright and the badge says what the box means - free users see the gift tag,
-        /// premium users (who own the whole pool) see no tag at all. Named, not teased: the box
-        /// is a daily doorbell, and a doorbell that will not say who is at the door just gets
-        /// ignored on day three.
+        /// The ? box's face: the tile keeps the mystery-box art and its title is the OFFER, never
+        /// the answer - "FREE TODAY" on the unopened box, today's feature only on the reveal face
+        /// the hover turns up (owner, 2026-08-23). The old face named the feature outright, which
+        /// spent the surprise before the plate ever turned; the doorbell still rings, it just does
+        /// not shout who is at the door through the door.
         /// </summary>
         internal void RefreshMysteryTile()
         {
@@ -1138,10 +1138,18 @@ namespace ConditioningControlPanel
             {
                 var key = App.DailyFree?.TodayKey;
                 var name = MysteryFeatureName(key);
-                dash.CardMystery.Title = name ?? Loc.Get("mosaic_daily_gift");
-                dash.CardMystery.TierBadge = App.Patreon?.HasPremiumAccess == true
-                    ? null
-                    : Loc.Get("mosaic_free_today");
+                // The unopened box says WHAT it is, not WHICH it is: the same two words every
+                // day, whoever is looking. `name` is still resolved here because the reveal face
+                // below (and only it) is where the day's feature gets named.
+                dash.CardMystery.Title = Loc.Get("mosaic_free_today");
+
+                // ...which is why the gift-tag pill is gone from this face. It carried exactly
+                // the words the title now carries, and two "FREE TODAY"s on one 12px plate is a
+                // stutter, not emphasis. Nothing is lost: the free/premium distinction the pill
+                // used to draw is drawn on the reveal face by MysteryRevealBadge's re-stamp
+                // (dimmed tier sign + FREE TODAY stamp for free accounts, no sign for premium),
+                // and the box keeps its gold ring either way.
+                dash.CardMystery.TierBadge = null;
 
                 // The flip plate's reveal face mirrors the box - same feature, said bigger.
                 // Painted on every repaint (not just at ceremony start) so a mid-day server

--- a/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
+++ b/ConditioningControlPanel/Views/Tabs/SettingsTabView.xaml
@@ -1089,9 +1089,11 @@
 
             <!-- Row 3: the ? box + the immersion pair -->
             <!-- The ? BOX: today's premium feature, free for the day (DailyFreeService).
-                 Title and the FREE TODAY badge are painted by MainWindow.RefreshMysteryTile()
-                 on every rail repaint; the literals below are design-time fallbacks. Click
-                 navigates to today's feature - the tile never launches anything itself.
+                 The title is painted by MainWindow.RefreshMysteryTile() on every rail repaint
+                 and is ALWAYS the offer ("FREE TODAY"), never the day's feature - naming it on
+                 this face would spend the reveal below before the plate ever turned. The literal
+                 is a design-time fallback. Click navigates to today's feature - the tile never
+                 launches anything itself.
 
                  The tile is a TWO-SIDED PLATE (owner spec 2026-08-11 #2, revised): HOVER turns
                  it - same ScaleX fake-spin as the intake pass card on the logo tile, one quick
@@ -1111,7 +1113,7 @@
                 </Grid.RenderTransform>
 
                 <features:FeatureCard x:Name="CardMystery" x:FieldModifier="internal"
-                                      Title="Daily Gift"
+                                      Title="FREE TODAY"
                                       Icon="pack://application:,,,/Resources/features/mysterybox.png"
                                       Click="CardMystery_Click"/>
 
@@ -1153,8 +1155,9 @@
                         <!-- The gift's price, re-stamped. On the REVEAL face only: this is the
                              side that names today's feature, so it is the side that can say what
                              the feature normally costs and that today it does not. The ? box face
-                             keeps its own gold ring and its FREE TODAY text pill - putting a tier
-                             sign on the unopened box would price a gift nobody has looked at yet.
+                             carries no sign of any kind, only its gold ring and its FREE TODAY
+                             title - putting a tier sign on the unopened box would price a gift
+                             nobody has looked at yet.
                              Painted by RefreshMysteryTile; collapsed for premium accounts, who own
                              the whole pool and are not being given anything. -->
                         <fx:TierBadge x:Name="MysteryRevealBadge" x:FieldModifier="internal"


### PR DESCRIPTION
The daily-free tile painted today's feature NAME on its unflipped face, so
the hover flip - the whole ceremony - revealed something the user had
already read. The unopened box now always says FREE TODAY (existing
mosaic_free_today key, all 9 languages) and the reveal face keeps its job
as the only side that names the feature.

The front face's FREE TODAY gift-tag pill goes with it: it carried exactly
the words the title now carries, and two of them on one 12px plate is a
stutter. The free/premium distinction it drew is still drawn on the reveal
face by MysteryRevealBadge's re-stamp, and the gold ring is untouched.

Flip mechanics, click routing and navigation are unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
