### PR TITLE
feat(arcademy): owner-only lab peek on web (devAnnex)

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -570,7 +570,8 @@ the voice's `labSeen` on first entry. Progress is ONE page-owned meta blob under
 metric, subject, experiment, data) are legal DOWNSTAIRS ONLY - `annex/docs.js` and the
 `annex_*` lexicon rows - and nowhere else in the school. The REGISTRY's live counts arrive
 through the host verb `annex-stats` (C# fetches the public aggregate; a null body is LINK
-DOWN, and the page never invents a number).
+DOWN, and the page never invents a number). **The web build has a third key to that door
+and it is not a third gate** - see trap 99, `init.devAnnex`.
 
 ## 3. Cross-agent seams — change these only with the other side
 
@@ -2003,6 +2004,35 @@ DOWN, and the page never invents a number).
     cannot express this failure at all; `proof-asks.mjs` (port 8753) caught it on
     the first run. Any future affordance placed inside `.emi` needs the same
     early return, and a browser assertion to prove it.
+
+99. **`init.devAnnex` IS A PEEK, NOT A REVEAL - AND THE DESKTOP CANNOT SEE IT.**
+    The owner needs to walk the Records Annex on `app.cclabs.app/arcademy` without
+    burning the once-ever reveal, so the WEB host projects one extra init boolean,
+    `devAnnex`, beside `devDoor`. `shell.js` reads it once as `annexPeek` and ORs
+    it into exactly TWO places - the campus hatch's bag (`annex:`) and the Records
+    Office's `ajar` - which is the whole feature: the lab becomes REACHABLE.
+    **It must never widen past that.** In particular:
+    - `maybeAnnexReveal` and the morning-after catch-up probe that schedules it
+      are UNTOUCHED. OR-ing `annexPeek` into the `if (!store.get('annexRevealSeen'))`
+      guard would *suppress* the real beat for good, which is the exact opposite
+      of a peek.
+    - `store.set('annexRevealSeen', ...)` still happens in ONE place and a peek is
+      not it. Nothing about a peek is persisted.
+    - `seenFlags.annex` (the postman's ctx) deliberately keeps reading the real
+      store flag. That flag gates letters, and a delivered letter *is* persisted
+      state; a peek that minted mail would be a reveal wearing a hat.
+    - `shell/seep.js`'s `postReveal()` keeps reading the real flag too, for the
+      same reason - the Seep's escalation is a story beat, not a door.
+
+    **`ArcademyHostService.cs` has never sent this field and must not start.**
+    Absent is false, so the desktop build cannot reach the branch at all; the
+    C# side of this feature is that there isn't one. The web end is
+    `cclabs-web`: `ARCADEMY_ANNEX_PEEK_EMAILS` (server allow-list) + `?annex=1`
+    on the lobby -> `arc-web:annexpeek` in localStorage -> `host/init.js`. The
+    query string alone is never enough, and the lobby REMOVES the key on any
+    visit that is not a peek. None of it is a security boundary - the web meta
+    store is localStorage, so devtools could always reach the annex - it keeps
+    the lab off the *supported* path, which is all it was ever asked to do.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -730,6 +730,19 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   // Host opened the building through the dev switch (`--arcademy`). Unlocks
   // Begin on every campus door regardless of the seed; never true for players.
   const devPass = src.devDoor === true;
+  /* THE ANNEX PEEK (web only, owner only). The web lobby stamps it for an
+   * account on the server's ARCADEMY_ANNEX_PEEK_EMAILS allow-list arriving at
+   * /arcademy?annex=1; the C# host has never sent the field and absent is
+   * false, so the desktop cannot see this branch at all.
+   *
+   * IT IS A PEEK, NOT A REVEAL. It makes the lab REACHABLE - the campus hatch
+   * and the office's ajar door - and touches nothing else. It never writes
+   * `annexRevealSeen`, so maybeAnnexReveal below is untouched and the real
+   * beat still waits for the tenth card and lands once, for real, later. It
+   * deliberately does NOT reach `seenFlags.annex` either: that flag gates the
+   * postman, and a delivered letter is persisted state a peek must not mint. */
+  const annexPeek = src.devAnnex === true;
+  if (annexPeek) say('ANNEX PEEK (owner dev): lab reachable, nothing stamped');
 
   /* ---------------------- registry + timetable -------------------------- */
   const games = await loadGames(say);
@@ -1510,7 +1523,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
          * hatch joins the plan only after the reveal AND a first visit through
          * the office panel - revisits skip the walk, discovery never does.
          * Same bag contract as `post`: campus draws, the shell keeps state. */
-        annex: (store.get('annexRevealSeen') && (store.get('annex') || {}).visited)
+        annex: (annexPeek || (store.get('annexRevealSeen') && (store.get('annex') || {}).visited))
           ? { open: () => walkThen('annex', () => showAnnex()) }
           : null,
         on: {
@@ -2115,8 +2128,9 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       daySeed: utcDateSeed,
       onCorkRead: () => { /* the read rows are the module's own; nothing owed here */ },
       // THE STOREROOM. The shell keeps the gate: the door exists only once the
-      // reveal has fired (ANNEX-OS.md §1), and the room just draws it.
-      ajar: !!store.get('annexRevealSeen'),
+      // reveal has fired (ANNEX-OS.md §1), and the room just draws it. The
+      // owner's peek is the second key to the same door and stamps nothing.
+      ajar: !!store.get('annexRevealSeen') || annexPeek,
       onBack: () => showBoard(),
       onReport: () => showReport(),
       onAnnex: () => showAnnex(),


### PR DESCRIPTION
Owner call 0825: the lab is gated behind sealing the whole school, so on app.cclabs.app it is unreachable. This adds an owner-only dev peek instead of lowering the gate.

- shell.js: `annexPeek = src.devAnnex === true` -> campus hatch + Records office door ajar in memory only; `annexRevealSeen` is never written, `maybeAnnexReveal` untouched.
- Desktop unaffected: ArcademyHostService never projects `devAnnex`.
- Web half: CodeBambi/cclabs-web PR (same branch name) - `ARCADEMY_ANNEX_PEEK_EMAILS` allow-list + `?annex=1`, handed to the shim through the lobby's `arc-web:` localStorage channel.

Verified: room suite 176/0, scene suite 170/0, new peek suite 31/0, dotnet build 0 errors. Not play-tested live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6