### PR TITLE
fix(video): in-window attention targets accept right-click

### DIFF
--- a/ConditioningControlPanel/Services/Video/VideoService.cs
+++ b/ConditioningControlPanel/Services/Video/VideoService.cs
@@ -2897,7 +2897,7 @@ namespace ConditioningControlPanel.Services
                 // child sees the press - and it swallows every one of them. The attention plane
                 // therefore has to be offered the click here, by hand, or an in-window target could
                 // never be clicked at all.
-                if (attentionLayer != null && e.ChangedButton == MouseButton.Left &&
+                if (attentionLayer != null && (e.ChangedButton == MouseButton.Left || e.ChangedButton == MouseButton.Right) &&
                     attentionLayer.TryHit(e.GetPosition(attentionLayer)))
                 {
                     e.Handled = true;


### PR DESCRIPTION
Follow-up to #294's right-click batch. Flashes and bubbles already took right-click on every path; the one gap left was the in-window (blur-mode) video attention layer, which still gated on `MouseButton.Left` while its floating-window twin already accepted both. One-line parity fix so MOBA players never have to switch hands.

- `Services/Video/VideoService.cs` PreviewMouseDown: attention layer hit-test accepts Left or Right.

Build 0 errors, Flash suite 69/69, full suite 3997/3997 on the combined quick-win build.

Suggestion thread: Bubble/Flash Image Clicks (ccp-bugs #1055).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJgzF6iGtX2cptjLTiX4Mv