### PR TITLE
feat(rail): premium star tags on locked rail entries

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -4248,6 +4248,7 @@
   "tooltip_nav_door_webapp": "Öffnet die CC Labs Web-App in deinem Browser",
   "nav_search_label": "Suche",
   "nav_search_keys": "Strg+K",
+  "nav_tag_premium_tip": "Premium-Funktion. Jede Patron-Stufe schaltet sie frei.",
   "tooltip_nav_search": "Einstellungen und Seiten durchsuchen (Strg+K)",
   "label_banner_web_xp": "Deine XP zählen jetzt kontoweit -",
   "label_banner_web_link": "sieh es dir in der Web-App an",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -4793,6 +4793,7 @@
   "tooltip_nav_door_webapp": "Open the CC Labs web app in your browser",
   "nav_search_label": "Search",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "Premium feature. Any patron tier unlocks it.",
   "tooltip_nav_search": "Search settings and screens (Ctrl+K)",
   "label_banner_web_xp": "Your XP is account-wide now -",
   "label_banner_web_link": "see it on the web app",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -4239,6 +4239,7 @@
   "tooltip_nav_door_webapp": "Abre la app web de CC Labs en tu navegador",
   "nav_search_label": "Buscar",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "Función premium. Cualquier nivel de mecenas la desbloquea.",
   "tooltip_nav_search": "Busca ajustes y pantallas (Ctrl+K)",
   "label_banner_web_xp": "Tu XP ahora vale en toda tu cuenta -",
   "label_banner_web_link": "míralo en la app web",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -4248,6 +4248,7 @@
   "tooltip_nav_door_webapp": "Ouvre l'app web CC Labs dans ton navigateur",
   "nav_search_label": "Recherche",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "Fonctionnalité premium. N'importe quel palier de mécène la débloque.",
   "tooltip_nav_search": "Cherche des paramètres et des écrans (Ctrl+K)",
   "label_banner_web_xp": "Ton XP suit désormais ton compte -",
   "label_banner_web_link": "vois-le dans l'app web",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -4239,6 +4239,7 @@
   "tooltip_nav_door_webapp": "ブラウザでCC Labsウェブアプリを開きます",
   "nav_search_label": "検索",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "プレミアム機能。どのパトロン階層でも解放されます。",
   "tooltip_nav_search": "設定や画面を検索 (Ctrl+K)",
   "label_banner_web_xp": "XPはアカウント共通になりました -",
   "label_banner_web_link": "ウェブアプリで見る",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -4246,6 +4246,7 @@
   "tooltip_nav_door_webapp": "브라우저에서 CC Labs 웹 앱을 엽니다",
   "nav_search_label": "검색",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "프리미엄 기능입니다. 후원 등급이 있으면 잠금이 해제됩니다.",
   "tooltip_nav_search": "설정과 화면 검색 (Ctrl+K)",
   "label_banner_web_xp": "XP는 이제 계정 단위로 쌓입니다 -",
   "label_banner_web_link": "웹 앱에서 확인",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -4247,6 +4247,7 @@
   "tooltip_nav_door_webapp": "Abre o app web do CC Labs no seu navegador",
   "nav_search_label": "Buscar",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "Recurso premium. Qualquer nível de apoiador o desbloqueia.",
   "tooltip_nav_search": "Busque ajustes e telas (Ctrl+K)",
   "label_banner_web_xp": "Seu XP agora vale na conta toda -",
   "label_banner_web_link": "veja no app web",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -4246,6 +4246,7 @@
   "tooltip_nav_door_webapp": "Открывает веб-приложение CC Labs в браузере",
   "nav_search_label": "Поиск",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "Премиум-функция. Открывается на любом уровне подписки.",
   "tooltip_nav_search": "Поиск настроек и экранов (Ctrl+K)",
   "label_banner_web_xp": "Твой XP теперь общий для аккаунта -",
   "label_banner_web_link": "смотри в веб-приложении",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -4706,6 +4706,7 @@
   "tooltip_nav_door_webapp": "在浏览器中打开 CC Labs 网页应用",
   "nav_search_label": "搜索",
   "nav_search_keys": "Ctrl+K",
+  "nav_tag_premium_tip": "高级功能。任意赞助等级即可解锁。",
   "tooltip_nav_search": "搜索设置和页面 (Ctrl+K)",
   "label_banner_web_xp": "XP 现已全账户通用 -",
   "label_banner_web_link": "去网页应用看看",

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavPremiumTags.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavPremiumTags.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using ConditioningControlPanel.Models;
+
+namespace ConditioningControlPanel
+{
+    /// <summary>
+    /// LAYER A of Mort's rail re-tree (community proposal, accepted 2026-08-25): the little gold
+    /// star that rides after a rail entry's label while that entry's door is closed to this
+    /// account, and disappears the moment it opens.
+    ///
+    /// <para><b>There is no second list.</b> "Which rail rows are sold" is answered by
+    /// <see cref="ExclusiveFeature.All"/> - the roster the Exclusives shelf, the Play card wall
+    /// and the dashboard's price tags already read - joined to the rail by the one identity both
+    /// sides already share, the ShowTab key. A hand-kept roster here is exactly how the Lab
+    /// smokescreen and the launch handlers drifted apart, and it would drift the same way the
+    /// first time an exclusive is added or retired: the shelf would move and the rail would not.
+    /// The only thing this file owns is the JOIN (tag control -> ShowTab key), which is a fact
+    /// about MainWindow.xaml and lives nowhere else.</para>
+    ///
+    /// <para><b>Why "locked", not "premium".</b> The tag answers "can you open this right now?",
+    /// which is what a user reads it as - so it clears for a patron, for a free account holding
+    /// an unspent weekly intake pass (Graded Intake's own probe, in the roster), and on the day
+    /// <see cref="Services.DailyFreeService"/> rotates the row's pool key in. That is the same
+    /// three-part answer the dashboard lockbands give (MainWindow.PremiumRail.cs,
+    /// RefreshRailLockbands), so a row cannot wear a star over a door that is standing open.</para>
+    ///
+    /// <para><b>Collapsed rail: no tags.</b> The 56px strip shows icons only. The pills are
+    /// nowhere near it - the nearest one starts ~63px in, after the shortest premium label in the
+    /// nine locales (zh "触觉") - so the rail's ClipToBounds already hides them, but only by 7px,
+    /// and a shorter translation would break that. So they are faded on the rail's own clock
+    /// instead, alongside the entry labels: see <see cref="NavPremiumTagElements"/> and the fade
+    /// loop in <see cref="SetNavRailExpanded"/>. The pill's inner TextBlock is ALSO in
+    /// <c>_navRailLabels</c> (CacheNavRailParts sweeps up every rail TextBlock); two clocks on
+    /// two different Opacity properties of nested elements is harmless - they agree - and it
+    /// keeps this file from having to teach CacheNavRailParts a new exception.</para>
+    /// </summary>
+    public partial class MainWindow
+    {
+        /// <summary>
+        /// The join: one premium tag control per rail entry, keyed by the entry's ShowTab key -
+        /// which is also its <see cref="ExclusiveFeature.Key"/>. Adding a rail row for a sold
+        /// feature means adding its pill in MainWindow.xaml and one row here; nothing else.
+        ///
+        /// <para>Two roster entries deliberately have no row: "fyp" and "justdrop" are window
+        /// launchers, not rail entries, so there is nothing to tag.</para>
+        ///
+        /// <para>A property rather than a static field: the tag controls are x:Named members and
+        /// do not exist until InitializeComponent has run.</para>
+        /// </summary>
+        private IEnumerable<(Border? Tag, string Key)> NavPremiumTagMap
+        {
+            get
+            {
+                yield return (TagPremiumHaptics, "haptics");
+                yield return (TagPremiumTakeover, "bambitakeover");
+                yield return (TagPremiumSheListening, "shelistening");
+                yield return (TagPremiumAwareness, "awareness");
+                yield return (TagPremiumGradedIntake, "gradedintake");
+                yield return (TagPremiumLockdown, "lockdown");
+                yield return (TagPremiumBlinkTrainer, "blinktrainer");
+                yield return (TagPremiumRemoteControl, "remotecontrol");
+            }
+        }
+
+        /// <summary>The pills, for the rail's collapse fade. Non-null only; a tag whose control
+        /// failed to resolve simply is not faded, because it is not on screen either.</summary>
+        internal IEnumerable<FrameworkElement> NavPremiumTagElements =>
+            NavPremiumTagMap.Select(t => t.Tag).Where(t => t != null)!;
+
+        // Per-service latches rather than one: the services come up in different orders (App
+        // .OnStartup builds Patreon early and IntakePass late), and a single latch set on the
+        // first call would permanently orphan whichever one was still null at that moment. Same
+        // idiom as EnsureIntakePassRailHooked in MainWindow.PremiumRail.cs.
+        private bool _navTagPatreonHooked;
+        private bool _navTagSubStarHooked;
+        private bool _navTagDailyFreeHooked;
+        private bool _navTagIntakePassHooked;
+
+        /// <summary>
+        /// Subscribes the tags to every event that can change the answer. Idempotent and
+        /// re-entrant: called once from <see cref="InitializeNavRail"/> and again at the top of
+        /// every <see cref="RefreshNavPremiumTags"/>, so a service that was still null on the
+        /// Loaded path gets picked up by the first refresh after it exists.
+        /// </summary>
+        private void HookNavPremiumTags()
+        {
+            try
+            {
+                if (!_navTagPatreonHooked && App.Patreon != null)
+                {
+                    _navTagPatreonHooked = true;
+                    App.Patreon.TierChanged += (_, __) => QueueNavPremiumTagRefresh();
+                }
+                // SubscribeStar is the second entitlement provider and raises its own TierChanged;
+                // HasPremiumAccess folds both, so both have to wake the rail or a SubscribeStar
+                // upgrade would leave eight stars standing until the next launch.
+                if (!_navTagSubStarHooked && App.SubscribeStar != null)
+                {
+                    _navTagSubStarHooked = true;
+                    App.SubscribeStar.TierChanged += (_, __) => QueueNavPremiumTagRefresh();
+                }
+                if (!_navTagDailyFreeHooked && App.DailyFree != null)
+                {
+                    _navTagDailyFreeHooked = true;
+                    App.DailyFree.TodayChanged += QueueNavPremiumTagRefresh;
+                }
+                if (!_navTagIntakePassHooked && App.IntakePass != null)
+                {
+                    _navTagIntakePassHooked = true;
+                    App.IntakePass.PassStateChanged += (_, __) => QueueNavPremiumTagRefresh();
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("HookNavPremiumTags: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Marshals a refresh onto the UI thread. Every one of the four sources above can fire
+        /// from a background poll or an HTTP continuation, and the shutdown guards are the house
+        /// pattern for a fire-and-forget callback that touches windows (CLAUDE.md, Async/Threading
+        /// §6 and §8).
+        /// </summary>
+        private void QueueNavPremiumTagRefresh()
+        {
+            try
+            {
+                if (Application.Current?.Dispatcher == null) return;
+                if (Dispatcher.HasShutdownStarted) return;
+                Dispatcher.BeginInvoke(new Action(RefreshNavPremiumTags));
+            }
+            catch (Exception ex) { App.Logger?.Debug("QueueNavPremiumTagRefresh: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// Paints every rail premium tag from the roster. Cheap enough to be unconditional:
+        /// eight dictionary-free lookups over a ten-row static list, no allocation that matters,
+        /// no clock started.
+        /// </summary>
+        internal void RefreshNavPremiumTags()
+        {
+            HookNavPremiumTags();
+            try
+            {
+                foreach (var (tag, key) in NavPremiumTagMap)
+                {
+                    if (tag == null) continue;
+                    tag.Visibility = IsNavEntryLocked(key) ? Visibility.Visible : Visibility.Collapsed;
+                }
+            }
+            catch (Exception ex) { App.Logger?.Debug("RefreshNavPremiumTags: {E}", ex.Message); }
+        }
+
+        /// <summary>
+        /// "Is this door shut to this account right now?" - three questions, all borrowed:
+        /// <list type="number">
+        /// <item>the roster's own probe (<see cref="ExclusiveFeature.GateState"/>), which is the
+        /// plain premium bar for nine of the ten entries and Graded Intake's weekly-pass check
+        /// for the tenth;</item>
+        /// <item>the daily rotation, which opens one pool door a day and is the reason
+        /// RefreshRailLockbands passes a key to TierGate rather than using the bare overload;</item>
+        /// <item>nothing else. A key with no roster row is not sold, so it wears no star - which
+        /// is the correct answer for Deeper, Available Subjects, Presets and the rest.</item>
+        /// </list>
+        /// Fails to NO TAG on anything unexpected, deliberately: an un-starred row that turns out
+        /// to be locked costs a TierGate toast the user was going to see anyway, while a starred
+        /// row that is actually open is the rail lying about what somebody already paid for.
+        /// </summary>
+        private static bool IsNavEntryLocked(string exclusiveKey)
+        {
+            try
+            {
+                var feature = ExclusiveFeature.All.FirstOrDefault(
+                    f => string.Equals(f.Key, exclusiveKey, StringComparison.Ordinal));
+                if (feature == null) return false;
+                if (feature.GateState() != ExclusiveGateState.Locked) return false;
+                if (feature.DailyFreeKey != null &&
+                    App.DailyFree?.IsFreeToday(feature.DailyFreeKey) == true) return false;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("IsNavEntryLocked({Key}): {E}", exclusiveKey, ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.NavRail.cs
@@ -276,6 +276,11 @@ namespace ConditioningControlPanel
                 // the subscription block in MainWindow.xaml.cs.
                 ApplyDoorArt();
 
+                // LAYER A: the gold stars on the sold rows, and the four subscriptions that take
+                // them away again. Authored Collapsed, so a rail that never got here shows none
+                // rather than all - see the style in MainWindow.xaml.
+                RefreshNavPremiumTags();
+
                 NavSidebar.MouseEnter += (_, __) => SetNavRailExpanded(true);
 
                 // No timer, by owner call (NavRailCollapseAnimMs): leaving the rail IS the
@@ -826,6 +831,12 @@ namespace ConditioningControlPanel
                     expand ? ms : ms / 2));
                 foreach (var label in _navRailLabels)
                     label.BeginAnimation(UIElement.OpacityProperty, fade);
+                // LAYER A: the premium pills ride the same clock. They are PLATES, not text, so
+                // the label sweep above does not reach them - and the nearest one starts only
+                // ~63px in (after ja "認識", the shortest premium label shipped), which the 56px
+                // strip's ClipToBounds covers by 7px and one shorter translation would not.
+                foreach (var tag in NavPremiumTagElements)
+                    tag.BeginAnimation(UIElement.OpacityProperty, fade);
             }
             else
             {
@@ -835,6 +846,11 @@ namespace ConditioningControlPanel
                 {
                     label.BeginAnimation(UIElement.OpacityProperty, null);
                     label.Opacity = expand ? 1 : 0;
+                }
+                foreach (var tag in NavPremiumTagElements)
+                {
+                    tag.BeginAnimation(UIElement.OpacityProperty, null);
+                    tag.Opacity = expand ? 1 : 0;
                 }
             }
 

--- a/ConditioningControlPanel/MainWindow/MainWindow.xaml
+++ b/ConditioningControlPanel/MainWindow/MainWindow.xaml
@@ -221,6 +221,58 @@
             <Setter Property="BorderBrush" Value="#FF424D"/>
             <Setter Property="Foreground" Value="#FF8A91"/>
         </Style>
+
+        <!-- ============ the PREMIUM tag on a rail entry (Mort's re-tree, LAYER A) ============
+             A ~26px gold pill that rides after an entry's label and says "this door is sold".
+             MainWindow.NavPremiumTags.cs owns WHICH rows wear one and when it goes away; this
+             is only the shape.
+
+             WHY A GLYPH AND NOT THE WORD "PREMIUM". An entry row spends 21 (left padding) + 14
+             (icon) + 6 (icon margin) + 8 (right padding) = 49px before its text starts, and the
+             open rail is 236 (NavRailExpandedWidth) - so the tag has to fit in 187px MINUS the
+             label. The worst premium label in the nine shipped locales is es "Entrenador de
+             Parpadeo" at ~122px, which leaves ~65. A word pill at FontSize 8 costs ~52 of that,
+             i.e. ~13px of headroom against font metrics and the next translation; the star costs
+             ~26 and clears every locale with room to spare. Rail rows measure at INFINITE width
+             (see NavRailExpandedWidth's note on why TextTrimming cannot save one), so an overrun
+             is not a wider rail - it is a tag silently cut off by the rail's ClipToBounds, which
+             is precisely the failure a tag must not have.
+
+             The star is also already the rail's premium mark: BtnPatreonExclusives has led with
+             one since Phase 1, and these rows ARE that shelf's roster (Models/ExclusiveFeature.cs).
+
+             Gold is LITERAL, exactly like Tier1GoldBorderBrush in Resources/Theme/Brushes.xaml
+             and for the same two reasons: a tier mark is commerce and must not take colour from
+             the mod chain, and a Window.Resources StaticResource reaching into a merged App
+             dictionary is the BAML EndOfStream trap. -->
+        <Style x:Key="NavEntryPremiumTag" TargetType="Border">
+            <Setter Property="Background" Value="#26F0C24B"/>
+            <Setter Property="BorderBrush" Value="#66F0C24B"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="3"/>
+            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="Margin" Value="6,0,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <!-- The ToolTip is NOT here. It is the only place the tag gets to explain itself,
+                 so it has to be the localized one that re-reads on a language switch - and
+                 {loc:Str} in a Setter.Value is a Binding in a Style setter: legal WPF, but
+                 with no precedent anywhere in this codebase, and the rail (which has blanked
+                 itself before) is not where to go find out. Each pill carries it as an
+                 ordinary attribute instead - the path this file already uses hundreds of
+                 times. -->
+            <!-- Collapsed AS AUTHORED: a rail whose Loaded hook never ran (InitializeNavRail
+                 catches and degrades to the authored state) must show no tags at all rather
+                 than tag every row - "locked" is the one thing a rail may not say wrongly. -->
+            <Setter Property="Visibility" Value="Collapsed"/>
+        </Style>
+
+        <Style x:Key="NavEntryPremiumTagText" TargetType="TextBlock">
+            <Setter Property="Text" Value="★"/>
+            <Setter Property="FontSize" Value="9"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="Foreground" Value="#F0C24B"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
     </Window.Resources>
 
     <!-- Root grid allows browser fullscreen overlay without reparenting WebView across HWNDs -->
@@ -752,6 +804,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='📳', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_haptics}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumHaptics" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                             </StackPanel>
@@ -813,6 +869,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='💫', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_takeover}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumTakeover" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="BtnNavSheListening" Tag="SheListening" Style="{StaticResource NavEntryButton}"
@@ -821,6 +881,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='🎙️', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_shelistening}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumSheListening" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <!-- Awareness finally gets a real button: BtnAwareness_Click has been an
@@ -831,6 +895,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='👁️', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_awareness}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumAwareness" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                             </StackPanel>
@@ -919,6 +987,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='📝', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_gradedintake}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumGradedIntake" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="BtnNavLockdown" Tag="Lockdown" Style="{StaticResource NavEntryButton}"
@@ -927,6 +999,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='🔒', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_lockdown_mode}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumLockdown" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="BtnNavBlinkTrainer" Tag="BlinkTrainer" Style="{StaticResource NavEntryButton}"
@@ -935,6 +1011,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='👀', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_blink_trainer}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumBlinkTrainer" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="BtnNavRemoteControl" Tag="RemoteControl" Style="{StaticResource NavEntryButton}"
@@ -943,6 +1023,10 @@
                                         <Image Width="14" Height="14" Margin="0,0,6,0" VerticalAlignment="Center"
                                                Source="{Binding Source='📱', Converter={StaticResource EmojiToImageSource}}"/>
                                         <TextBlock Text="{loc:Str tab_remote_control}" VerticalAlignment="Center"/>
+                                        <Border x:Name="TagPremiumRemoteControl" Style="{StaticResource NavEntryPremiumTag}"
+                                                ToolTip="{loc:Str nav_tag_premium_tip}">
+                                            <TextBlock Style="{StaticResource NavEntryPremiumTagText}"/>
+                                        </Border>
                                     </StackPanel>
                                 </Button>
                                 <Button x:Name="BtnAvailableSubjects" Tag="AvailableSubjects"


### PR DESCRIPTION
The cheap slice of Mort's rail thread (ccp-bugs #1056): premium features on the rail are not marked as such.

- `MainWindow/MainWindow.NavPremiumTags.cs` (new): joins rail pills to `ExclusiveFeature.All` by ShowTab key, so the roster is the single source; lock state borrows `RefreshRailLockbands`' three answers (`GateState() != Locked`, `DailyFreeService.IsFreeToday`, no roster row = no tag). Fails to *no tag* on any surprise. Re-evaluates on Patreon / SubscribeStar `TierChanged`, `DailyFree.TodayChanged`, `IntakePass.PassStateChanged`.
- `MainWindow.xaml`: `NavEntryPremiumTag` style; gold star pills on Haptics, Takeover, She's Listening, Awareness, Graded Intake, Lockdown, Blink Trainer, Remote Control. Star not word: measured with `FormattedText` at the real typeface, "PREMIUM" leaves 12px on the worst row (es Blink Trainer) before `ClipToBounds` silently cuts it; the star leaves 42px. Gold is literal per the tier-mark rule (commerce takes no colour from the mod chain).
- Pills ride the label fade clock so the collapsed 56px strip never shows a stray star.
- 1 loc key x 9 languages. Nav suite 58/58, full suite 3997/3997 on the combined build.

**Mort's full re-tree deliberately not attempted**: it needs a new "Play Together" door with medallion art, 8 reparents, and points at four surfaces that do not exist as pages (Goon Game has no ShowTab key; For You / Just Drop are launchers; Workshop / Engine Room are drawers inside Companion with no focus contract; AI Effects has no page), and it drops the "you" door entirely. That is a design wave; worth going back to Mort on the missing pages first.

Needs one look from a free-tier account before release: the owner account is whitelisted, so every tag correctly renders hidden there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJgzF6iGtX2cptjLTiX4Mv