### PR TITLE
fix(arcademy): the splash waits for the jingle to finish before the campus opens

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2132,6 +2132,33 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     harder; never hide. The web host's account chip (`shell/accountchip.js`) also offers "Open my
     card" from the bar, so the full ID is one tap away on a phone either way.
 
+103. **THE SPLASH EXIT IS A CHAIN OF GATES NOW, AND SILENCE HAS TO ANSWER INSTANTLY
+    (owner report 2026-08-25, "wait for the jingle to end before opening the Arcademy").**
+    `intro_bed.mp3` is 4.000s and the splash used to walk out on it on BOTH host paths - the
+    autoplay host at INTRO_MIN_MS + the fade (hidden ~3.27s from t0) and the knock host at
+    KNOCK_EXIT_MS + the fade (hidden ~1.02s after the strike). `dismissLoader()` is now
+    RE-ENTRANT and each gate is a "come back to me", never a sleep: the knock, then the bed,
+    then the INTRO_MIN_MS floor. Three things about it are load-bearing.
+    - **A CUE THAT WILL NOT SOUND MUST SAY SO INSIDE THE DISPATCH.** `shell/audio.js` answers
+      the new `detail.onEnded` hook with `'dropped'` SYNCHRONOUSLY on every road that never
+      reaches an element (mute, master 0, a zero fx bus, no AudioContext, a SAMPLE_ONLY name
+      with no file). Move one of those answers onto a timer and every muted player sits
+      through the cap staring at a loading screen for a sound they were never going to hear.
+      A muted mixer, a zero bus and a host with no `intro_bed.mp3` all dismiss on the OLD
+      timing, and that is the test that proves the hook is wired the right way round.
+    - **THE CAP IS NOT OPTIONAL AND IT IS BOOT'S OWN.** `onEnded` is a courtesy: a host with
+      no consumer on the `arcademy-sfx` bus, an older audio.js, or an element that stalls
+      forever answers NOTHING. `BED_HOLD_CAP_MS` (INTRO_BED_MAX_MS + 200) is measured from the
+      strike and ends the hold whatever the audio is doing. Never make the splash's exit
+      depend on a promise only the mixer can keep.
+    - **REDUCED MOTION MAY NEVER ACQUIRE A HOLD** (trap 66 again): it takes no cues, so it
+      strikes no bed, so there is nothing to wait for and it still dismisses at ~3.27s.
+    What makes the extra ~1.4s of cover safe is that the loader's CSS timeline ALREADY loops
+    when the beat is over (`arc-intro-breath` from 3.1s, `arc-intro-rail-chase` from 2.3s,
+    both `infinite`). Shorten those to one-shots and the splash freezes on its last frame for
+    over a second while the jingle finishes. Measured after: hidden at ~4.6s from t0 on the
+    autoplay host, and knock + ~4.4s on the browser (headless, real mp3 decode).
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -121,6 +121,19 @@ function armBootDeadline() {
  * beat later. FAILURE PATHS NEVER WAIT - failBoot below still snaps
  * `hidden = true` directly, so an error card is never delayed by a celebration.
  *
+ * THE FLOOR IS NOT THE ONLY GATE. Since 2026-08-25 there are THREE things the
+ * exit waits on, in this order, and each one is a "come back to me" rather than
+ * a sleep - `dismissLoader` is re-entrant and every gate re-calls it:
+ *     1. the KNOCK, on a gesture-gated host: no door, no campus.
+ *     2. the INTRO BED, on both hosts: the splash may not leave in the middle
+ *        of the jingle (see THE SPLASH WAITS FOR THE JINGLE below).
+ *     3. INTRO_MIN_MS from t0, the CSS beat's own floor, which by then has
+ *        almost always already passed.
+ * Measured from t0 on the autoplay host: the wordmark thuds at .64s, the bed
+ * runs about .3s to 4.3s, `.is-done` is added at ~4.3s and `hidden` lands at
+ * ~4.6s. On a knock host everything after the strike is the same, measured
+ * from the strike rather than from boot.
+ *
  * THE SPLASH-COMPLETE EDGE (FIRST BELL, 2026-08-24) hangs off the HAPPY PATH of
  * this function and nowhere else: once `hidden` has actually landed, the shell
  * is told, and it decides whether the opening has anything to play. failBoot
@@ -206,8 +219,15 @@ function onKnock() {
   try { if (knockHint) knockHint.classList.add('is-heard'); } catch (e) { /* noop */ }
   if (!splashIsUp()) return;         // failBoot got there first: nothing to score
   cancelIntroCues();                 // the stitched beats yield to the real bed
-  sfx('intro_bed', 0.6, { maxMs: INTRO_BED_MAX_MS });
-  if (knockDismissQueued) setTimeout(dismissLoader, KNOCK_EXIT_MS);
+  strikeBed();
+  /* KNOCK_EXIT_MS is now a FLOOR, not the whole wait: a bed that is still
+   * playing sends this call straight back to the queue and settleBed re-issues
+   * it. It governs on its own only for a knock whose bed never sounds (a muted
+   * mixer, an absent file), which is the timing that host has always had. */
+  if (knockDismissQueued) {
+    const id = setTimeout(() => { exitTimers.delete(id); dismissLoader(); }, KNOCK_EXIT_MS);
+    exitTimers.add(id);
+  }
 }
 
 function armKnockGate() {
@@ -245,6 +265,78 @@ function sfx(name, level, extra) {
       ),
     }));
   } catch (e) { /* never fatal */ }
+}
+
+/* ----------------------------------------------------------------------------
+ * THE SPLASH WAITS FOR THE JINGLE (owner report, 2026-08-25).
+ *
+ * `assets/sfx/intro_bed.mp3` is a 4.000s piece and the splash used to walk out
+ * on it: the autoplay host dismissed at INTRO_MIN_MS + the exit (hidden ~3.27s
+ * from t0, cutting the bed's last ~1.1s) and the knock host at KNOCK_EXIT_MS +
+ * the exit (hidden ~1.02s after the strike, cutting ~3.0s). The campus revealed
+ * mid-phrase on both. So THE STRIKE NOW OWNS THE EXIT: `dismissLoader` defers
+ * while a bed is in the air and is re-called the moment it settles - which for
+ * the knock path means the wait is measured FROM THE STRIKE, not from boot.
+ *
+ * THE HOLD IS ALWAYS RELEASED, and there are four ways out on purpose:
+ *   - the consumer answers `onEnded` (shell/audio.js's one-shot hook): 'ended'
+ *     when the element played the file out, 'cap' when its own maxMs governor
+ *     cut it, 'stopped'/'error' when the clip was taken away from it.
+ *   - 'dropped' comes back SYNCHRONOUSLY, inside the dispatch, whenever the cue
+ *     never sounded at all: a muted mixer, a zero master or fx bus, no audio
+ *     context, or no file behind the name. No sound means NO HOLD, so all of
+ *     those dismiss on precisely the timing they had before this wave.
+ *   - our own cap timer, for a consumer that answers nothing whatever (an older
+ *     shell/audio.js, a dropped event, an element that never fires anything):
+ *     BED_HOLD_CAP_MS after the strike the hold is over, whatever the audio is
+ *     doing. A stalled or blocked element can NEVER hold the splash hostage.
+ *   - failBoot and shutdown, which clear the hold with everything else.
+ *
+ * WHAT DID NOT MOVE: reduced motion gets no cues, so it strikes no bed, so it
+ * holds for nothing and dismisses exactly as before (trap 66). The campus and
+ * the first frame are still built underneath while the bed plays - only the
+ * EXIT waits; `start()` is not delayed by so much as a frame.
+ * -------------------------------------------------------------------------- */
+/** The hold's own deadline, measured from the strike. INTRO_BED_MAX_MS is
+ *  already the 4.0s piece plus air, and the consumer's governor answers us from
+ *  inside it; the slack on top is for the answer that never comes at all. */
+const BED_HOLD_CAP_MS = INTRO_BED_MAX_MS + 200;
+let bedStruck = false;        // the bed is the one cue that may never be re-fired
+let bedHolding = false;       // a bed is in the air and the exit is waiting on it
+let bedDismissQueued = false; // ...and a ready boot has already asked to leave
+let bedCapTimer = 0;
+
+function strikeBed() {
+  if (bedStruck) return;
+  bedStruck = true;
+  bedHolding = true;
+  sfx('intro_bed', 0.6, {
+    maxMs: INTRO_BED_MAX_MS,
+    onEnded: (reason) => settleBed(reason || 'ended'),
+  });
+  // A cue that was never going to sound has already answered by now, inside the
+  // dispatch above - so there is no hold to cap and no timer to mint.
+  if (!bedHolding) return;
+  bedCapTimer = setTimeout(() => {
+    bedCapTimer = 0;
+    settleBed('cap-local');
+  }, BED_HOLD_CAP_MS);
+}
+
+function settleBed(reason) {
+  if (!bedHolding) return;              // already settled, or never struck
+  bedHolding = false;
+  if (bedCapTimer) { clearTimeout(bedCapTimer); bedCapTimer = 0; }
+  log('intro bed settled (' + reason + ') at ' + (Date.now() - introT0) + 'ms');
+  if (!bedDismissQueued) return;
+  bedDismissQueued = false;
+  dismissLoader();
+}
+
+function cancelBedHold() {
+  bedHolding = false;
+  bedDismissQueued = false;
+  if (bedCapTimer) { clearTimeout(bedCapTimer); bedCapTimer = 0; }
 }
 
 /* ----------------------------------------------------------------------------
@@ -315,7 +407,7 @@ function scheduleIntroCues() {
     // hasSample is feature-detected: an older consumer simply stitches.
     const hasBed = !!(audio && typeof audio.hasSample === 'function' && audio.hasSample('intro_bed'));
     if (hasBed && src.autoplayOk === true && elapsed < INTRO_BED_WINDOW_MS) {
-      sfx('intro_bed', 0.6, { maxMs: INTRO_BED_MAX_MS });
+      strikeBed();
       return;
     }
     for (const beat of INTRO_BEATS) {
@@ -331,24 +423,40 @@ function scheduleIntroCues() {
   } catch (e) { /* the opening may never cost us the boot */ }
 }
 
+/** The two timers of the exit itself, OWNED so failBoot and shutdown can take
+ *  them back: a page that is tearing down owes nobody a fade. */
+const exitTimers = new Set();
+
+function cancelExitTimers() {
+  for (const id of Array.from(exitTimers)) { try { clearTimeout(id); } catch (e) { /* noop */ } }
+  exitTimers.clear();
+}
+
 function dismissLoader() {
   const el = dom.loader;
   if (!el || el.hidden) return;
   /* The knock outranks readiness: a booted school still waits for the door.
    * onKnock re-calls us KNOCK_EXIT_MS after the tap that struck the bed. */
   if (knockWanted && !knockDone) { knockDismissQueued = true; return; }
+  /* And the jingle outranks both: settleBed() re-calls us the moment the bed is
+   * over, or the moment the cap says it is (THE SPLASH WAITS FOR THE JINGLE). */
+  if (bedHolding) { bedDismissQueued = true; return; }
   const wait = Math.max(0, INTRO_MIN_MS - (Date.now() - introT0));
-  setTimeout(() => {
+  const id = setTimeout(() => {
+    exitTimers.delete(id);
     try {
       if (el.hidden) return;             // a failBoot got there first
       el.classList.add('is-done');
-      setTimeout(() => {
+      const done = setTimeout(() => {
+        exitTimers.delete(done);
         try { el.hidden = true; } catch (e) { /* noop */ }
         try { if (shell && shell.onSplashDone) shell.onSplashDone(); }
         catch (e) { warn('onSplashDone threw: ' + ((e && e.message) || e)); }
       }, INTRO_EXIT_MS);
+      exitTimers.add(done);
     } catch (e) { try { el.hidden = true; } catch (e2) { /* noop */ } }
   }, wait);
+  exitTimers.add(id);
 }
 
 function failBoot(msg) {
@@ -362,6 +470,8 @@ function failBoot(msg) {
   disarmKnock();
   try { if (knockHint) knockHint.remove(); } catch (e) { /* noop */ }
   cancelIntroCues();      // a clearTimeout, so the error card waits for nothing
+  cancelBedHold();        // ...and the jingle holds up an error card least of all
+  cancelExitTimers();     // a fade already in flight is abandoned, not finished
   try { if (cancelSlate) cancelSlate(); } catch (e) { /* noop */ }
   cancelSlate = null;
   if (dom.nopeMsg) dom.nopeMsg.textContent = String(msg).slice(0, 200);
@@ -514,6 +624,8 @@ bridge.on('end-run', guard('end-run', () => shutdown('host asked')));
  * -------------------------------------------------------------------------- */
 function shutdown(reason) {
   cancelIntroCues();
+  cancelBedHold();
+  cancelExitTimers();
   try { if (cancelSlate) cancelSlate(); } catch (e) { /* best effort */ }
   cancelSlate = null;
   try { if (shell) shell.destroy(); } catch (e) { /* best effort */ }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/audio.js
@@ -72,6 +72,22 @@
  *     same headroom the SOUNDS table's `gain` gives an oscillator.
  * A url the browser will not decode is silently dropped, exactly like a name
  * that is not in SOUNDS - a cue must never be the thing that throws.
+ *
+ * THE ENDED HOOK (2026-08-25). A caller may pass `detail.onEnded` and be told,
+ * EXACTLY ONCE and never fatally, what became of its cue:
+ *     'ended'   the element played the file out
+ *     'cap'     the maxMs governor cut it
+ *     'stopped' something took the slot (a re-fire, the voice cap, teardown)
+ *     'error'   the file will not load and the name has been struck off
+ *     'recipe'  the name fell back to its oscillator impression
+ *     'dropped' the cue never sounded at all - muted, zero master, zero bus,
+ *               no context, or a SAMPLE_ONLY name with no file behind it
+ * THE 'dropped' ANSWER IS SYNCHRONOUS, inside the dispatch, and that is the
+ * point of it: boot.js holds the intro splash until the 4s bed is over, so it
+ * has to learn INSTANTLY when there is no bed rather than sit out a timeout.
+ * The hook is a courtesy, not a contract - a caller that waits on it must still
+ * carry its own cap (boot.js does), because a host with no consumer at all on
+ * the `arcademy-sfx` bus will never answer anything.
  * ==========================================================================*/
 
 const BUSES = ['fx', 'voice', 'tutorial', 'drops', 'music'];
@@ -239,6 +255,18 @@ const PITCH_MAX = 2;
 const clampPitch = (v) => (
   Number.isFinite(+v) && +v > 0 ? Math.max(PITCH_MIN, Math.min(PITCH_MAX, +v)) : 1
 );
+
+/** A `detail.onEnded` callback, wrapped so it fires at most once and so a
+ *  listener that throws can never break the cue bus (header: THE ENDED HOOK). */
+function onceCb(fn) {
+  let f = (typeof fn === 'function') ? fn : null;
+  return (reason) => {
+    if (!f) return;
+    const g = f;
+    f = null;
+    try { g(String(reason || 'ended')); } catch { /* a listener may never break the bus */ }
+  };
+}
 
 /**
  * @param {Object} o
@@ -422,6 +450,10 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
 
   function killClip(rec, fadeMs) {
     if (!rec) return;
+    // Every teardown road passes through here, so this is the one place that can
+    // promise a waiting caller it will always be told (header: THE ENDED HOOK).
+    // It is a no-op for whichever path already named a more specific reason.
+    if (rec.settle) rec.settle('stopped');
     try { if (rec.timer) clearTimeout(rec.timer); } catch { /* ignore */ }
     rec.timer = 0;
     const fade = Math.max(0, Number(fadeMs) || 0);
@@ -452,8 +484,10 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
 
   /** @param {string=} sampleName  set when the url came from SAMPLES, so a file
    *   that turns out not to be playable can strike itself off `available`.
+   *  @param {Function=} settle  the one-shot `detail.onEnded` reporter. Only the
+   *   paths that TAKE the clip pay it; a `false` return leaves it to the caller.
    *  @returns {boolean} true if the clip was taken (played or scheduled). */
-  function playClip(d, bus, amp, sampleName) {
+  function playClip(d, bus, amp, sampleName, settle) {
     if (typeof Audio !== 'function') return false;
     const url = String(d.url == null ? '' : d.url);
     if (!url) return false;
@@ -486,7 +520,7 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
     const askedMs = Number(d.maxMs) || 0;
     const maxMs = Math.max(80, askedMs > 0 ? Math.min(askedMs, CLIP_REQ_MAX_MS) : CLIP_MAX_MS);
     const fadeMs = Math.max(0, Math.min(maxMs / 2, Number(d.fadeMs) || CLIP_FADE_MS));
-    const rec = { el, gain: null, node: null, timer: 0 };
+    const rec = { el, gain: null, node: null, timer: 0, settle: settle || null };
 
     let routed = false;
     try {
@@ -513,9 +547,17 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
     rec.timer = setTimeout(() => {
       rec.timer = 0;
       if (clips.get(key) === rec) clips.delete(key);
+      if (rec.settle) rec.settle('cap');
       killClip(rec, fadeMs);
     }, maxMs);
-    try { el.addEventListener('ended', () => { if (clips.get(key) === rec) { clips.delete(key); killClip(rec, 0); } }); } catch { /* ignore */ }
+    try {
+      el.addEventListener('ended', () => {
+        if (clips.get(key) !== rec) return;
+        clips.delete(key);
+        if (rec.settle) rec.settle('ended');
+        killClip(rec, 0);
+      });
+    } catch { /* ignore */ }
     try {
       el.addEventListener('error', () => {
         // STILL IN THE MAP IS WHAT MAKES THIS A VERDICT ON THE FILE. Every
@@ -529,6 +571,7 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
         // is not ours and the rest of this handler reads as it always did.
         if (clips.get(key) !== rec) return;
         clips.delete(key);
+        if (rec.settle) rec.settle('error');
         killClip(rec, 0);
         // The file the host promised is not playable. Take the name back rather
         // than spending a decoder on it once a beat for the rest of the night;
@@ -574,36 +617,41 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
   function onSfx(e) {
     const d = (e && e.detail) || {};
     stats.handled += 1;
+    /* THE ENDED HOOK (header). Wrapped once here, paid exactly once on every
+     * road out of this function - including the four early returns below, which
+     * answer 'dropped' inside the dispatch so a caller waiting on the cue is
+     * never left holding a timeout for a sound that was never going to happen. */
+    const settle = onceCb(d.onEnded);
     // The one CONTROL message on the sfx bus: the shell sends it when a class is
     // torn down so a trigger clip (<=1.2s) never leaks into the lobby. No audio
     // handle crosses into shell.js for this; the bus was already the seam.
-    if (d.name === 'stop_clips') { stopAllClips(); return; }
+    if (d.name === 'stop_clips') { stopAllClips(); settle('dropped'); return; }
     const pitch = clampPitch(d.pitch);
     stats.last = {
       name: d.name || null, level: d.level, bus: d.bus || 'fx', duck: d.duck || null, pitch,
       url: d.url || null,
     };
-    if (mute || master <= 0) { stats.dropped += 1; return; }
-    if (!ensureContext()) { stats.dropped += 1; return; }
+    if (mute || master <= 0) { stats.dropped += 1; settle('dropped'); return; }
+    if (!ensureContext()) { stats.dropped += 1; settle('dropped'); return; }
     const bus = BUSES.indexOf(d.bus) >= 0 ? d.bus : 'fx';
     // PERCEPTUAL CURVE (2026-08-24): engine levels are fractions of fractions - a 0.25
     // cue under the bus and master gains landed near -29 dB and the whole campus read
     // as silent. sqrt lifts the quiet floor (0.25 -> 0.5) while 1.0 stays 1.0, so the
     // relative loudness ladder the games ratchet is preserved, just audible.
     const amp = Math.sqrt(clamp01(d.level == null ? 0.5 : d.level));
-    if (amp <= 0 || levels[bus] <= 0) { stats.dropped += 1; return; }
+    if (amp <= 0 || levels[bus] <= 0) { stats.dropped += 1; settle('dropped'); return; }
     const name = String(d.name || '');
     try {
       // A url is a CLIP, whatever the name says. If the host cannot play one we
       // fall through to the recipe rather than going silent.
-      let took = d.url ? playClip(d, bus, amp) : false;
+      let took = d.url ? playClip(d, bus, amp, undefined, settle) : false;
       // ...and a SAMPLED name is a url the caller did not have to know about.
       // The slot is the name, so a cue that re-fires cuts its own tail instead
       // of stacking (twelve flaps in half a second is the case that matters).
       if (!took && available.has(name)) {
         took = playClip(
           Object.assign({}, d, { url: SAMPLES[name], key: d.key == null ? name : d.key }),
-          bus, amp, name
+          bus, amp, name, settle
         );
         if (took) stats.samples += 1;
       }
@@ -612,11 +660,19 @@ export function createAudio({ init, bridge, log, autoplayOk } = {}) {
         // No file, no imitation. The cue is spent, not queued (trap 70: a beat
         // played late is worse than a beat missed).
         stats.dropped += 1;
+        settle('dropped');
       } else {
         playRecipe(SOUNDS[name] || SOUNDS.blip, bus, amp, pitch);
         stats.played += 1;
+        // A recipe has no element and no `ended`: the impression is not the
+        // recording, so a caller waiting for the FILE is told so and moves on.
+        settle('recipe');
       }
-    } catch (err) { stats.dropped += 1; say('[audio] ' + (name || '?') + ' failed: ' + ((err && err.message) || err)); }
+    } catch (err) {
+      stats.dropped += 1;
+      settle('dropped');
+      say('[audio] ' + (name || '?') + ' failed: ' + ((err && err.message) || err));
+    }
     if (d.duck) duck(d.duck);
   }
 


### PR DESCRIPTION
> "We should wait for the jingle to end before opening the Arcademy."

## The bug

`assets/sfx/intro_bed.mp3` is a **4.000s** piece (ffprobe: 4.000023) and the loading screen walked out on it on **both** host paths.

| host | before | after | delta |
|---|---|---|---|
| WebView2 / autoplay (`init.autoplayOk === true`) | `hidden` at **~3.27s** from t0 (`INTRO_MIN_MS` 2950 + `INTRO_EXIT_MS` 320), cutting the last **~1.1s** | `hidden` at **~4.6s** from t0 | +1.35s |
| browser / knock | `hidden` at **knock + ~1.02s** (`KNOCK_EXIT_MS` 700 + 320), cutting **~3.0s** | `hidden` at **knock + ~4.32s** | +3.3s |
| reduced motion | `hidden` at ~3.27s | **unchanged** | 0 |

Headless measurement with a real mp3 decode: autoplay 4676ms from navigation, knock 7160ms = knock + 4432ms, reduced 3523ms.

## The change

`dismissLoader()` was already re-entrant for the knock; it now takes a second gate the same way, so the exit is a chain of "come back to me" rather than a sleep:

1. the **knock**, on a gesture-gated host
2. the **intro bed**, on both hosts
3. `INTRO_MIN_MS` from t0, the CSS beat's own floor

The strike owns the exit, so on the knock path the wait is measured **from the strike**, not from boot.

### The hook

`shell/audio.js` grows the smallest honest seam rather than a guessed `setTimeout`: an optional `detail.onEnded`, fired **exactly once** and never fatally, carrying the reason - `ended` / `cap` / `stopped` / `error` / `recipe` / `dropped`. Every teardown road already passed through `killClip`, so that is where the promise "you will always be told" is kept.

The load-bearing half is that **`dropped` comes back synchronously, inside the dispatch**, on every road that never reaches an element: a muted mixer, a zero master or fx bus, no `AudioContext`, or a `SAMPLE_ONLY` name with no file behind it. No sound means **no hold**, so all of those dismiss on exactly the timing they had before this wave.

### The safeties

- **The cap is boot's own.** `onEnded` is a courtesy, not a contract - an older `audio.js`, a dropped event or an element that stalls forever answers nothing. `BED_HOLD_CAP_MS` (`INTRO_BED_MAX_MS` + 200 = 4800ms) from the strike ends the hold whatever the audio is doing. A stalled or blocked element can never hold the splash hostage.
- **Reduced motion is untouched** (trap 66): no cues, so no bed, so nothing to wait for.
- **`failBoot` still snaps.** It clears the hold, the cap and any fade in flight; an error card is not delayed by a jingle any more than by a celebration. `shutdown()` does the same.
- **Nothing about init moved.** The campus and the first frame are still built under the splash - only the exit waits.
- Every timer the exit owns is now in `exitTimers` and cleared on both teardown paths. The two loose `setTimeout`s in `dismissLoader` / `onKnock` were not.

## Verification

**Fake-clock suite over the shipped `boot.js`** (scratchpad `splash-hold/`): the file under test is the real one with nothing rewritten but its six import specifiers, asserted line by line, so the constants and gate order are byte-for-byte the ones that ship. Each case boots a fresh module graph under a `?c=` query, with a clock that owns `setTimeout`, `clearTimeout` **and `Date.now`** - boot measures the whole splash off `Date.now`.

**42/42 checks**, seven cases: autoplay dismisses at bed end + fade (4520ms) with the shell built at 200ms underneath; knock dismisses bed-length after the strike; reduced dismisses at 3270ms with zero cues requested; a stalled element dismisses at the cap (5320ms); a muted mixer dismisses on the old timing on both hosts; `failBoot` mid-hold snaps the loader, shows the card, posts `boot-error`, leaves `clock.pending === 0` and fires nothing afterwards. Every case also asserts no timer is left behind.

**Real headless run** of `index.html` (python http.server + headless Chrome over CDP, the web host shim standing in for init) on all three paths: splash exits, campus live, no page exceptions. The only console errors are two pre-existing 404s for server endpoints a static file server does not have (`profile`, `cards mirror`), both handled by the page.

## Notes

- Trap **103** added to `arcademy/CLAUDE.md`, including the one that bites: the extra ~1.4s of cover is only safe because the loader's CSS tail animations (`arc-intro-breath`, `arc-intro-rail-chase`) already loop. Turn those into one-shots and the splash freezes on its last frame while the jingle finishes.
- `boot.js`'s splash-timing header comment now documents the three gates and the measured numbers.
- No app-side C# change: `ArcademyHostService` already lists `intro_bed` in `BuildSfxSamples` and the web vendor list already ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6
