### PR TITLE
fix(arcademy): phone campus - ID card centred and scrollable, props to the top-left, mail to the bottom-right

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2128,9 +2128,39 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     decoration. PR #299 then built the post row around "once the card is gone the corner is
     free". The SAME node now folds into a ~185x52 tag (photo, name, number; band / stats / tier
     / chip / clip hidden by class, never by replacing the node - trap 93 still holds) and the
-    post row steps right of it (`+ 212px`). If a future small-stage rule needs the corner, fold
+    post row stepped right of it (`+ 212px`) - which parked both props across the front of The
+    Pool, so on the owner's second pass the same day the row left the bottom edge altogether
+    and took the TOP-LEFT corner instead (`.campus-crest` is already hidden up there). If a
+    future small-stage rule needs the bottom-left corner, fold
     harder; never hide. The web host's account chip (`shell/accountchip.js`) also offers "Open my
     card" from the bar, so the full ID is one tap away on a phone either way.
+102. **THE ID CARD FACE HAS EXACTLY ONE DRAWN WIDTH, AND THE PORTRAIT GATE IS WHY (owner bug
+    2026-08-25, "the card is cut off at the top and the page will not scroll to it").** Three
+    lessons, and only the first is the obvious one.
+    (a) A CENTRED FLEX CHILD TALLER THAN ITS CONTAINER OVERFLOWS THE **START** EDGE. `.arc-id`
+    centres `.arc-id-stage` with `align-items:center`; the stage measured 656px in a 390px
+    window, so the top of the card sat at y=-133 with `overflow:visible` all the way up and
+    nothing anywhere to scroll. The cure is the STAGE owning `overflow-y:auto` - never
+    `.arc-id`, because the veil, the key light and the close button live outside it and must
+    not scroll away - plus `overflow-x:hidden`, since `overflow-y:auto` alone computes the
+    OTHER axis to auto as well and the 150%-wide `.arc-id-lamp` then grows a horizontal
+    scrollbar.
+    (b) THE OBVIOUS SECOND HALF - a smaller `width` on `.arc-id-big` - IS WRONG. The face is
+    absolute percentages over fixed 22px insets and fixed 9-24px type, so at ~330px the meta
+    column overruns the body and the homeroom row falls off the bottom of the card. Nothing had
+    ever caught that because **a phone cannot reach this card at any width but 560px**: portrait
+    is refused outright by the orientation gate, so landscape is the only live phone view and
+    92vw never binds there. Scale it with `zoom` on `.arc-id-cardwrap` instead. `zoom` scales
+    the LAYOUT BOX as well as the paint, so the row and the scroller measure the card at its
+    drawn size; a `transform:scale()` would leave a 346px hole in the flow AND fight
+    `arc-id-cardin`, which animates that same transform. `zoom` takes a number and there is no
+    dividing a `dvh` by a `px` to get one, so the steps are a ladder of media queries.
+    (c) A CUSTOM PROPERTY IS HOW YOU BEAT `html.arc-mobile` WITHOUT AN `!important`.
+    `html.arc-mobile .arc-id-sheet` is (0,2,1); a bare `.arc-id-sheet` in a LATER media query
+    is (0,1,0) and loses, source order be damned. Anything that has to retune a value the
+    mobile block already sets gets published as a `--var` on a shared ancestor and READ by the
+    mobile rule (`width:var(--id-w, min(560px, 92vw))`) - only one rule ever sets the property,
+    so there is no contest to lose. Same shape as `--arc-mobile-chrome-h`.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -668,8 +668,16 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     if (fx0 == null || fy0 == null) {
       /* First run: park her bottom-right, clear of the dock's corner. A phone has
        * no room for the desktop's 24/56 standoff, so she docks tight into the
-       * corner there and leaves the middle of the glass to the board. */
-      const padX = isMobile() ? 6 : 24;
+       * bottom edge there and leaves the middle of the glass to the board.
+       * THE 72 IS THE POSTBOX. 2026-08-25 moved the campus mail chip out of the
+       * top-right cluster and into the bottom-right corner (shell/mail.css), and
+       * a 6px standoff parked her flat on top of a 44px control she would then
+       * eat every tap on - her body is the one `pointer-events:auto` thing on
+       * that layer. 6 + 44 + 14 (the chip's own bottom inset) + 8 of daylight
+       * steps her left of it and leaves the bottom edge she is meant to dock to.
+       * FIRST RUN ONLY: a stored spot never comes through here, so nobody who
+       * has ever moved her sees this number. */
+      const padX = isMobile() ? 72 : 24;
       const padY = isMobile() ? 10 : 56;
       fx0 = (vp.w - s.w - padX) / vp.w;
       fy0 = (vp.h - s.h - padY) / vp.h;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/mail.css
@@ -378,6 +378,32 @@ html.arc-mobile .arc-mail-item { padding:12px; min-height:44px; }
    one control in this file sitting under it. */
 html.arc-mobile .arc-mailchip { width:44px; height:44px; }
 
+/* THE POSTBOX MOVES TO THE THUMB (owner bug, 2026-08-25). On a phone the chip
+   was the fourth thing in the top-right cluster, at the far end of the reach
+   from a hand holding a phone in landscape, so on a small stage it leaves the
+   cluster and takes the BOTTOM-RIGHT corner. `.campus-hint` steps left by the
+   chip's width plus a gap to make room (styles.css) - the hint must never be
+   sat on, it is the only instruction on the screen.
+
+   `fixed` RATHER THAN `absolute`, and that is the whole trick: shell/campus.js
+   mints this chip INSIDE `.campus-topright`, which is itself absolute, so an
+   absolute chip would still be pinned to the cluster it is trying to leave.
+   Nothing above it carries a transform, a filter or a `will-change` (the
+   cluster's only animation is `campus-fadein`, opacity and nothing else), so
+   `fixed` resolves against the viewport the way it reads.
+
+   THE BREAKPOINT IS THE CARD'S BREAKPOINT, VERBATIM (styles.css's post-row
+   law): the corner it lands in is furniture the same query arranges, so the
+   two can never disagree about what a small stage is. No bare `display:` here
+   either - mailbox.js hides this node with the `hidden` property (trap 27). */
+@media (max-width: 760px), (max-height: 600px) {
+  .campus-topright .arc-mailchip {
+    position:fixed;
+    right:clamp(12px, 2.5vw, 40px);
+    bottom:14px;
+  }
+}
+
 /* THE CLOSE BAR IS NOT ON THE LETTER, AND THE HARNESS IS WHY THIS IS 10px.
    `.arc-exitbar` is `position:sticky; bottom:0`, which on the corkboard means a
    bar pinned over a scrolling page (corkboard.css carries that fix). Here it

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -1977,20 +1977,31 @@ g.campus-room.locked:hover { filter:brightness(1.2); }
    on the same pixel and hung them BELOW the `bottom:22px` anchor by their own
    height. On a desktop window too, which is how it reached the owner.
 
-   THE BREAKPOINT IS THE CARD'S BREAKPOINT, VERBATIM. The step-aside exists to
+   THE BREAKPOINT IS THE CARD'S BREAKPOINT, VERBATIM. The phone rule exists to
    clear `.campus-idcard`, so it has to use exactly the query that FOLDS the
    card ("small stages", further down this file). A row that dodged at 740px
    while the card folded at 760px/600px landed the props back on the
-   architecture of every landscape phone. The card no longer leaves at that
-   size (2026-08-25: it folds into a ~185px tag, because `display:none` here
-   was the owner's "I cannot see my profile card on the web"), so the row
-   steps RIGHT of the tag instead of taking the corner. */
+   architecture of every landscape phone. */
 .campus-postrow {
   position:absolute; left:calc(clamp(12px, 2.5vw, 44px) + 256px); bottom:22px;
   z-index:24; display:flex; align-items:flex-end; gap:12px;
 }
+/* THE PHONE CORNERS (owner bug, 2026-08-25). Stepping the row RIGHT of the
+   folded ID tag kept it out of the tag but parked both props across the front
+   of The Pool (room 105) at the bottom of the plan, which is where the owner
+   found them. On a small stage the props take the TOP-LEFT corner instead:
+   `.campus-crest` is already `display:none` up there, so it is the one band a
+   phone leaves genuinely empty, and the row keeps the crest's own left inset
+   so it hangs off the same margin the title would have used.
+
+   IT HAS TO STOP ABOVE EMI. She is 86x87 on a phone and the owner parks her
+   at about y=100 on an 844x390 window; the row is 70px tall, so top:12px ends
+   it at y=82 and leaves 18px of sky. Her bubble RISES off her ear into that
+   band when she talks (emi/widget.js BUBBLE_RISE), and that is fine and not a
+   collision to dodge: the whole EMI layer is #arc-emi z50 and these props are
+   z24, so she is drawn OVER the furniture, never under it. */
 @media (max-width:760px), (max-height:600px) {
-  .campus-postrow { left:calc(clamp(12px, 2.5vw, 44px) + 212px); bottom:16px; }
+  .campus-postrow { left:clamp(12px, 2.5vw, 44px); top:12px; bottom:auto; }
 }
 
 /* ---- tooltip ---- */
@@ -2356,6 +2367,11 @@ html.arc-reduced .campus-trace.fading { transition:none; opacity:.22; }
   .campus-idcard .id-name { font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .campus-idcard .id-num { margin-top:2px; white-space:nowrap; }
   .campus-crest { display:none; }
+  /* THE HINT STEPS LEFT for the envelope. shell/mail.css pins `.arc-mailchip`
+     into this corner on exactly this query, and the hint is the only
+     instruction on the screen - it may share the baseline, never the pixels.
+     44px of chip plus 12px of gap. */
+  .campus-hint { right:calc(clamp(12px, 2.5vw, 40px) + 56px); }
 }
 
 /* ============================ EXITS ======================================
@@ -4132,13 +4148,70 @@ html.ae-lite .arc-id-glint,
 /* A PHONE STACKS. The card over the sheet, the sheet two columns of whatever
    is left, and the chip at a thumb's size (owner bug C's rule). */
 html.arc-mobile .arc-id-row { flex-direction:column; gap:14px; align-items:center; }
-html.arc-mobile .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:min(560px, 92vw); }
+html.arc-mobile .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:var(--id-w, min(560px, 92vw)); }
 html.arc-mobile .arc-id-chip { min-height:44px; font-size:11px; }
 html.arc-mobile .arc-id-stage { gap:12px; }
 @media (max-width:820px) {
   .arc-id-row { flex-direction:column; align-items:center; }
-  .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:min(560px, 92vw); }
+  .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:var(--id-w, min(560px, 92vw)); }
 }
+
+/* ---- A SHORT STAGE (phone landscape) ----------------------------------
+   OWNER BUG, 2026-08-25: "the card is not centred, the top is cut off and the
+   page will not scroll to it". A CENTRED COLUMN TALLER THAN ITS WINDOW CLIPS
+   AT THE START EDGE. `.arc-id` is a flex box with `align-items:center` and the
+   stage stacks card -> stats -> placard, which measures 656px on an 844x390
+   phone; centring 656 in 390 puts the top of the card at y=-133, and there is
+   no `overflow` anywhere above it, so nothing could ever scroll up to the
+   photo. Two halves, and they are deliberately different.
+
+   THE CARD FACE SCALES, AND IT SCALES - IT DOES NOT NARROW. The obvious fix is
+   a smaller `width` on `.arc-id-big`, and it is wrong: the face is laid out in
+   absolute percentages over fixed 22px insets and fixed 9-24px type, so at
+   ~330px the meta column overruns the body and the homeroom row falls off the
+   bottom edge. Nothing had ever caught that because a phone CANNOT reach this
+   card at 330px any other way - portrait is refused outright by the
+   orientation gate, so 560px is the only width the face has ever been drawn
+   at. `zoom` on the wrapper scales the LAYOUT BOX as well as the paint, so the
+   row and the scroller measure the card at its drawn size and the whole face
+   arrives in proportion; a `transform:scale()` would leave a 346px hole in the
+   flow and would fight `arc-id-cardin`, which animates that same transform.
+   The steps are a ladder rather than a calc because `zoom` takes a number and
+   there is no dividing a vh by a px to get one.
+
+   THE STATS SCROLL. The stage becomes the scroller. The veil, the key light
+   and the close button are NOT inside it, so they stay put - which is the
+   whole reason the close stays reachable at every scroll position.
+
+   THREE THINGS THAT LOOK OPTIONAL AND ARE NOT: `overflow-x` is pinned hidden
+   because `overflow-y:auto` alone computes the OTHER axis to auto as well and
+   the 150%-wide key light would grow a horizontal scrollbar; the lamp goes
+   with it, because a radial glow that wide is a hard-edged rectangle the
+   moment a scroller clips it, and the veil's own gradient already lights the
+   middle; and the top padding is the close button's own reach
+   (clamp(10px, 3vh, 26px) + 44px, which is 62px at the top of this query) plus
+   four pixels of daylight. */
+@media (max-height:600px) {
+  .arc-id-stage {
+    --id-zoom:.86;
+    --id-w:calc(560px * var(--id-zoom));
+    max-height:100vh;
+    max-height:100dvh;
+    overflow-y:auto; overflow-x:hidden;
+    -webkit-overflow-scrolling:touch; overscroll-behavior:contain;
+    padding:66px 10px 18px;
+  }
+  .arc-id-cardwrap { zoom:var(--id-zoom); }
+  .arc-id-lamp { display:none; }
+  .arc-id-row { flex-direction:column; align-items:center; }
+  /* The sheet reads the same --id-w the mobile block reads, so a SHORT but
+     WIDE window (a resized desktop, where neither html.arc-mobile nor the
+     820px query lands) still gets a stat sheet the width of its card. */
+  .arc-id-sheet { grid-template-columns:repeat(2, 1fr); width:var(--id-w, min(560px, 92vw)); }
+}
+@media (max-height:520px) { .arc-id-stage { --id-zoom:.74; } }
+@media (max-height:450px) { .arc-id-stage { --id-zoom:.66; } }
+@media (max-height:400px) { .arc-id-stage { --id-zoom:.58; } }
 
 /* ---- THE WALL WHISPER --------------------------------------------------
    A breath of each class's spotlight identity on the pinned cards - but the


### PR DESCRIPTION
Two owner-reported landscape-phone bugs on the Arcademy hub campus (844x390 and 667x375). Both were invisible at desktop size; both are verified with the CDP screenshot rig at 844x390, 667x375 and 1600x900 per the phone-shot merge gate (CLAUDE.md §6).

## Bug 1 - the Student ID spotlight was clipped at the top and could not scroll

**Root cause.** `.arc-id` centres `.arc-id-stage` with `align-items:center`, and a centred flex child taller than its container overflows the **start** edge. The stage stacks card -> stats -> placard and measured **656px in a 390px window**, so the top of the card sat at `y=-133` with `overflow:visible` the whole way up and nothing anywhere to scroll to it. PHOTO PENDING was cut off exactly as the owner saw.

**Fix, two halves.**

- **The stats scroll.** `.arc-id-stage` becomes the scroller (`overflow-y:auto`, `-webkit-overflow-scrolling:touch`, `overscroll-behavior:contain`). Never `.arc-id` itself - the veil, the key light and the close button live outside the stage, which is precisely why the close stays reachable at every scroll position. `overflow-x` is pinned hidden because `overflow-y:auto` alone computes the other axis to auto too and the 150%-wide `.arc-id-lamp` would grow a horizontal scrollbar; the lamp is hidden on a short stage for the same reason (a radial glow that wide becomes a hard-edged rectangle once a scroller clips it, and the veil's own gradient already lights the middle).
- **The card face scales, it does not narrow.** The obvious fix - a smaller `width` on `.arc-id-big` - is wrong. The face is absolute percentages over fixed 22px insets and fixed 9-24px type, so at ~330px the meta column overruns the body and the homeroom row falls off the bottom of the card (shot taken, it is ugly). Nothing had ever caught that because **a phone cannot reach this card at any width but 560px**: portrait is refused outright by the orientation gate, so landscape is the only live phone view and `92vw` never binds there. `zoom` on `.arc-id-cardwrap` scales the layout box as well as the paint, so the row and the scroller measure the card at its drawn size; `transform:scale()` would leave a 346px hole in the flow **and** fight `arc-id-cardin`, which animates that same transform.

Measured at 844x390: card **325x200 at y=66**, entirely below the close button and horizontally centred; the stage carries 575px of content in 390px and scrolls to the six tiles and the placard. The flip to the back face still works (barcode, small print, Open Records, signature). Verified again at 667x375 and 932x430.

## Bug 2 - the props and the post swapped corners

The noticeboard and the folded Bugle leaned at the bottom of the plan, right across the front of **The Pool** (room 105); the envelope hid at the far end of the top-right cluster, the worst reach on a phone held in landscape.

- **Props to the top-left**, at the crest's own left inset. That is the one band a small stage leaves genuinely empty - `.campus-crest` is already `display:none` there. The row stops at **y=82**, which is 18px above EMI's parked head at the owner's spot (she is 86x87 and sits at about y=100 on an 844x390 window). Her bubble rises off her ear into that band when she talks, and that is not a collision to dodge: the EMI layer is `#arc-emi` z50 against the props' z24, so she is always drawn **over** the furniture, never under it. The folded ID tag keeps the bottom-left corner untouched, and The Pool's label is legible again.
- **Mail to the bottom-right corner**, `position:fixed` rather than absolute - `shell/campus.js` mints the chip inside `.campus-topright`, which is itself absolute, so an absolute chip would still be pinned to the cluster it is trying to leave. Nothing above it carries a transform or a filter (the cluster's only animation is `campus-fadein`, opacity and nothing else). The 44px touch target and the new-mail pip are untouched, and the chip hit-tests to itself at both phone sizes.
- **`.campus-hint` steps 56px left** (44 of chip + 12 of gap) so "TAP A ROOM TO STEP INSIDE" is never sat on.
- **EMI's first-run phone park steps left by 72px** (6 + 44 + 14 + 8). Her default corner was the new envelope's corner, and her body is the one `pointer-events:auto` thing on that layer, so a fresh save would have had her eating every tap on it. First run only - a stored spot never comes through that branch, so nobody who has ever moved her sees the number.

Desktop puts these props at `left: crest + 256px; bottom:22px` (bottom-left, beside the full ID card) and the envelope in the top-right cluster. **Desktop is unchanged** - it has neither overlap.

## Verification

`shoot2.mjs` on ports 9922/8822, served straight from the worktree (no stale `site/` copy). Every measured rect on the 1600x900 campus **and** in the 1600x900 spotlight is byte-identical before and after. All seven stylesheets parse with zero dropped rules. No console errors beyond the pre-existing fixture-avatar notice.

| | before | after |
|---|---|---|
| card (844x390) | `x142 y-123 560x346` | `x260 y66 325x200` |
| stage overflow-y | `visible` (656 in 656) | `auto` (575 in 390) |
| props (844x390) | `x233 y304` | `x21 y12` |
| mail chip (844x390) | `x671 y16` | `x779 y332` |
| hint (844x390) | `x614 y360` | `x558 y360` |
| desktop 1600x900 | - | unchanged, every rect |

CLAUDE.md gains **trap 102** (the start-edge clip, the one drawn width and why the portrait gate hid it, and the custom-property trick for beating `html.arc-mobile` specificity without an `!important`); trap 100's stale "the post row steps right of the tag" line is corrected.

Left for the owner: a real-device play-test, and a taste call on whether the props reading over EMI's bubble for the two seconds she speaks is worth shrinking them for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6
