### PR TITLE
fix(arcademy): records office on the phone - cards first, centred spotlight, a way back from the book, reachable door

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -206,6 +206,13 @@ shell/scene.js     THE SCENE CHASSIS: a generalised point-and-click ROOM (the
                    player walked out of. Test seams: `fxStats`, `fxCount`,
                    `fxHands`, `fxHold`. An unknown kind is LOGGED, never
                    thrown - a table is data
+                   THE STEP-BACK PILL IS THE ROOT'S, NOT THE SLIDE'S (0825): one
+                   `.asc-back` hangs off `.asc-root`, added and removed by view
+                   the way the apron's class is written, so it is SCREEN pixels
+                   on every host - a pill inside the stage rides the fit scale
+                   and lands at half size on a phone (trap 101). It runs
+                   `escapeStep()`, not `showView('wide')`, so a panel opened
+                   over a close-up folds first.
                    A ZOOM IS A ZOOM (owner ruling 0825): the apron band belongs
                    to the WIDE shot and FADES OUT on showView(non-wide) (~200ms,
                    `.asc-bar-away`; .arc-reduced cuts; visibility rides the same
@@ -221,7 +228,17 @@ shell/recordsroom.js THE RECORDS OFFICE AS A ROOM (0825), the chassis's first
                    verb - it opens records.js in a scene panel, and wears the
                    two nudges), the CORKBOARD (a close-up of the cork with
                    corkboard.js's own mountNotices pinned over `corkInner`,
-                   FULL measured rect - the band is away in a close-up),
+                   FULL measured rect - the band is away in a close-up -
+                   `readable:true`, so every sheet carries an `.arc-cork-open`
+                   door and one press lifts corkboard.js's READER: a full-size,
+                   scrollable copy of that sheet on <body> at z56, above the
+                   apron band and below the toasts, and the FIRST rung of this
+                   room's Esc fold. It is the answer to a wall that is painted
+                   at stage scale: on a phone the close-up's body copy lands
+                   near 7px and a busy term's fifth row hangs out of the
+                   window, so on `html.arc-mobile` the office cork also clips
+                   each sheet to a row's share (with a fade and a drawn lens
+                   glyph) and scrolls. Desktop keeps the ruled overhang),
                    the BOOK (a close-up with deskbook.js over `ledgerPages`)
                    and the STOREROOM (`when:'ajar'`, so no flag = no rect, no
                    patch, nothing at all). THE TWO NUDGES: `.rr-fresh`, a pink
@@ -256,6 +273,15 @@ shell/recordsroom.js THE RECORDS OFFICE AS A ROOM (0825), the chassis's first
                    bridge and EMI. AND IT MUST BE TORN DOWN IN clearScreen -
                    the apron is on <body>, so a room left standing leaves a
                    slab across the next screen. + recordsroom.css
+                   THE MINIATURE (0825): the wide shot hangs a scaled copy of
+                   the SAME night's wall in the cork rect
+                   (`mountNotices({preview:true})` inside `.rr-corkmini`), so
+                   the painted board has paper on it before you walk up to it.
+                   A preview marks nothing read and banks no visit - looking at
+                   a board is not reading it - and it takes no pointer, so the
+                   board hotspot owns every press over it. The scale is DERIVED
+                   (rect width / CORK_INNER width), never typed, so a sheet in
+                   the picture is the shape of the sheet on the wall.
 shell/deskbook.js  THE BOOK ON THE DESK: a two-page spread mounted over the two
                    painted page rects. `left`/`right` are SIDE HOSTS (.rdb-side,
                    no clip) with the paper (.rdb-page, overflow:hidden) inside:
@@ -2131,6 +2157,44 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     post row steps right of it (`+ 212px`). If a future small-stage rule needs the corner, fold
     harder; never hide. The web host's account chip (`shell/accountchip.js`) also offers "Open my
     card" from the bar, so the full ID is one tap away on a phone either way.
+
+101. **A CONTROL INSIDE A SCALED OR TRANSFORMED ROOM IS NOT MEASURED IN SCREEN PIXELS,
+    AND ON A PHONE THAT IS THE DIFFERENCE BETWEEN A CONTROL AND A SMUDGE (owner bugs
+    2026-08-25, Records Office in landscape).** A scene room is a fixed 1376x768 plane
+    scaled to fit; a phone in landscape fits it at about **0.5**. Four separate bug
+    reports came out of one arithmetic mistake, and the rule that closes all four is:
+    **paint is authored in stage pixels, chrome is authored in screen pixels, and the
+    two may not live in the same box.**
+    - **`.asc-back` was a child of the slide.** Every phone rule written for it - a 44px
+      minimum thumb target, 12px type, a safe-area inset - was multiplied by the fit and
+      landed as a 39x22 pill with 6px type. It hangs off `.asc-root` now (fixed to the
+      window, like the apron band always has been). The same arithmetic hit
+      `.arm-hot.arm-exit`'s 2px rim (one physical pixel) and its 13px tag (six).
+    - **`position:fixed` LOSES TO ANY TRANSFORMED ANCESTOR.** `.arc-rs` (the card
+      spotlight) is `fixed; inset:0` and was appended into `.arc-records` - which, inside
+      the Records room, sits in `.asc-panel`, and that panel carries a `transform` for its
+      slide-up. A transformed ancestor becomes the containing block, so the whole
+      presentation was laid out inside an 810x302 scroller parked at the bottom of the
+      phone: veil stopped at the panel edge, card centred on the panel, top of the card
+      cut off. **A modal over the window is mounted on `<body>`** - records.js's spotlight
+      and corkboard.js's notice reader both are - and anything it must clear (the apron
+      band) reaches it as a custom property `scene.js` publishes on `<html>`
+      (`--arm-band-h`, cleared in destroy()). A `padding-bottom` written against an
+      ancestor it does not actually have is not a fix; it is the same bug twice.
+    - **A HOVER-ONLY AFFORDANCE IS NOT AN AFFORDANCE ON A PHONE.** `.arm-exit` was dark
+      until `:hover`/`:focus-visible`. A thumb has neither, so the Records storeroom door
+      (the only way to the annex from the office) was 75x231 of painted wall that said
+      nothing. It carries a resting rim + its tag under `html.arc-mobile` only; the
+      desktop stays "found, not advertised".
+    - **AND THE HUB HEADER CAN COME BACK OVER A ROOM.** `.arc-topbar` is sticky at z30 and
+      a room is fixed at z10. `setStage()` hides the bar, but `renderTopbar()` guarded on
+      `campus` alone - so any unconditional repaint (`onMeta` from a host `meta` push,
+      `onPayout`) hoisted it back over the Records room, the report card and the annex,
+      swallowing the top band and the step-back pill with it. The guard is
+      `!!campus || !!stageMode` now: **a full-bleed stage owns the window.**
+
+    Sitting behind all of it: **a phone viewport is a merge gate** (section 6). Every one
+    of these was invisible at 1600x900 and obvious in the first 844x390 shot.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -428,6 +428,8 @@ export const DEFAULT_LEXICON = Object.freeze({
   board_kind_notice: 'Notice',
   board_kind_flyer: 'Flyer',
   board_kind_minutes: 'Minutes',
+  board_note_open: 'Take this one down and read it',
+  board_note_close: 'Put it back on the wall',
   bugle_issue: 'Issue',
   bugle_page: 'Page',
   bugle_pages: 'Pages',

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
@@ -41,13 +41,19 @@
    noticeboard rendered as four ghosts (caught in a capture, invisible to the
    node run, which has no cascade at all).
 
-   So the block is keyed on all three hosts. `.arc-cork-wall` nests inside
+   So the block is keyed on all FOUR hosts. `.arc-cork-wall` nests inside
    `.arc-corkstage` on the hall's overlay and simply re-declares the same
    derived values there, which costs nothing and cannot drift - they are one
-   list in one place. */
+   list in one place. The fourth is `.arc-cork-reader`, which walked into the
+   same wall from the other side: a sheet taken off the wall is mounted on
+   <body>, so it has no cork host above it at all and came out as ghost type on
+   glass (caught in a capture again, 2026-08-25). ANY host that can carry paper
+   declares the tokens - that sentence is the rule, and it is now on its second
+   demonstration. */
 .arc-corkstage,
 .arc-boardprop,
-.arc-cork-wall {
+.arc-cork-wall,
+.arc-cork-reader {
   --cork:        color-mix(in srgb, var(--gold) 26%, color-mix(in srgb, var(--navy), black 14%));
   --cork-lo:     color-mix(in srgb, var(--cork), black 30%);
   --cork-hi:     color-mix(in srgb, var(--cork), var(--ink) 14%);
@@ -461,3 +467,166 @@ html.arc-reduced .rr-cork .arc-corknote:focus-within { animation: none; }
   .rr-cork .arc-corknote:hover,
   .rr-cork .arc-corknote:focus-within { animation: none; }
 }
+
+/* ======================= THE READER (corkboard.js) =======================
+ * One sheet, off the wall and in your hands. The wall stays a wall - read at a
+ * glance, laid out in the painting's own pixels - and this is the other half
+ * of that bargain: a press takes the paper down at a size nobody squints at.
+ *
+ * z56 is not a taste: a scene room is `position:fixed` at z10 and its apron
+ * band is a <body>-level sibling at z55, so anything under 55 would be read
+ * from behind the carpet. Toasts still win at 60.
+ * ==========================================================================*/
+
+/* THE DOOR ON THE PAPER. A transparent control the exact size of the sheet, so
+   the sheet stays an <article> and the press still lands on a real button with
+   a real name. It is a child of the SLOT, never of the sheet: a torn sheet is
+   a clip-path and a clip-path clips its children (the pin learned this first). */
+.arc-cork-open {
+  position:absolute; inset:0; z-index:3;
+  padding:0; border:0; background:none;
+  border-radius:2px;
+  cursor:pointer;
+}
+.arc-cork-open:focus-visible {
+  outline:2px solid var(--pink); outline-offset:3px;
+}
+
+.arc-cork-reader {
+  position:fixed; inset:0; z-index:56;
+  display:flex; align-items:center; justify-content:center;
+  padding:clamp(10px, 3vh, 34px) clamp(10px, 3vw, 40px);
+}
+.arc-cork-reader-veil {
+  position:absolute; inset:0;
+  background:radial-gradient(ellipse at 50% 42%,
+    rgba(12, 8, 22, .72) 0%, rgba(4, 3, 10, .9) 74%);
+  animation:arc-cork-reader-fade .2s ease-out both;
+}
+@keyframes arc-cork-reader-fade { from { opacity:0; } to { opacity:1; } }
+
+/* The paper itself: the SAME `.arc-corknote` stock, so a sheet in your hands is
+   the sheet off the wall and not a lookalike. What changes is that it is now
+   the subject - real type, a real reading measure, and it scrolls. */
+.arc-cork-readnote {
+  position:relative; z-index:1;
+  width:min(680px, 100%);
+  max-height:100%;
+  overflow:auto;
+  padding:22px 24px 26px;
+  transform:rotate(-.4deg);
+  animation:arc-cork-reader-in .26s cubic-bezier(.2, 1.2, .4, 1) both;
+}
+@keyframes arc-cork-reader-in {
+  from { opacity:0; transform:rotate(-.4deg) translateY(14px) scale(.97); }
+  to   { opacity:1; transform:rotate(-.4deg); }
+}
+/* A sheet in the hand has no lifted corner and no tear: it is flat on a desk,
+   and the corner fold is a shadow that only makes sense against cork. */
+.arc-cork-readnote::after { content:none; }
+.arc-cork-readnote.is-torn { clip-path:none; filter:none; }
+.arc-cork-readnote .arc-cork-notetitle { font-size:20px; line-height:1.25; }
+.arc-cork-readnote .arc-cork-notebody { font-size:15.5px; line-height:1.6; }
+.arc-cork-readnote .arc-cork-kind { font-size:10px; }
+
+.arc-cork-readclose {
+  position:absolute; z-index:2;
+  right:clamp(10px, 3vw, 34px); top:clamp(8px, 3vh, 26px);
+  min-height:44px; padding:9px 16px;
+  display:inline-flex; align-items:center;
+  background:color-mix(in srgb, var(--navy), transparent 18%);
+  color:var(--ink);
+  border:1px solid color-mix(in srgb, var(--pink), transparent 55%);
+  border-radius:999px;
+  font-family:var(--disp); font-size:12px; font-weight:700;
+  letter-spacing:.12em; text-transform:uppercase;
+  cursor:pointer;
+}
+.arc-cork-readclose:hover { border-color:var(--pink); }
+.arc-cork-readclose:focus-visible { outline:2px solid var(--lav); outline-offset:2px; }
+html.arc-reduced .arc-cork-reader-veil,
+html.arc-reduced .arc-cork-readnote { animation:none; }
+
+/* ==================== THE OFFICE CORK, IN A HAND =========================
+ * The Records Office board is a close-up of a PAINTING: its sheets are laid
+ * out in the plate's 1285x692 pixels and scaled with it, and a phone in
+ * landscape fits that plate at about a half. So every one of these numbers is
+ * a stage pixel and comes out halved - which is why the copy read as texture
+ * and the bottom row of sheets hung off the frame and out of the window
+ * (owner screenshot, 2026-08-25).
+ *
+ * Two changes, both scoped to `.rr-cork` on a phone, and neither touches the
+ * hall's board or the desktop's:
+ *   - the paper is CLIPPED TO THE BOARD. The wide-window ruling (pinned paper
+ *     hangs off the rail rather than being cut) needs a wall under the rail to
+ *     hang onto; on a phone the plate IS the window, so the overhang is simply
+ *     gone. Each sheet takes a row's share of the cork and fades out at the
+ *     cut, which is also how a player learns there is more of it.
+ *   - the type comes UP, because a headline you can read is worth more than
+ *     four paragraphs you cannot, and the rest of the sheet is one press away.
+ * ==========================================================================*/
+/* A BUSY TERM SCROLLS RATHER THAN HANGING OFF THE WINDOW. On a desktop the
+   plate is smaller than the window and an overrun spills onto the wall around
+   it, which is the ruling. On a phone the plate IS the window, so the same
+   overrun is simply gone - a fifth row of paper that exists and cannot be
+   reached. `start` instead of `space-between` so the rows stack from the top
+   rail, and the board itself takes the scroll. */
+html.arc-mobile .rr-cork.arc-cork-wall {
+  overflow-y:auto;
+  align-content:start;
+}
+/* ...but never the MINIATURE: scenery does not scroll, and a scrollbar on a
+   thumbnail of a corkboard is a bug wearing a feature's hat. */
+html.arc-mobile .rr-corkmini .rr-cork.arc-cork-wall {
+  overflow:hidden;
+  align-content:space-between;
+}
+html.arc-mobile .rr-cork .arc-corknote {
+  max-height:292px;
+  overflow:hidden;
+  -webkit-mask-image:linear-gradient(180deg, #000 78%, transparent 100%);
+          mask-image:linear-gradient(180deg, #000 78%, transparent 100%);
+}
+html.arc-mobile .rr-cork .arc-cork-notetitle { font-size:25px; line-height:1.2; }
+html.arc-mobile .rr-cork .arc-cork-notebody { font-size:20px; line-height:1.45; }
+html.arc-mobile .rr-cork .arc-cork-kind { font-size:15px; letter-spacing:.14em; }
+
+/* THE LENS. A sheet this small has to say it can be picked up, and the school
+   never bakes a word into a drawn thing (lexicon law) - so the affordance is a
+   glyph: a ring and a handle, in the pin's own pink, sitting on the corner the
+   fade opens up. Drawn on the DOOR, not on the paper, because the paper is a
+   document and this is furniture. */
+html.arc-mobile .rr-cork .arc-cork-open::after {
+  content:''; position:absolute; right:14px; bottom:12px;
+  width:26px; height:26px; border-radius:50%;
+  border:4px solid color-mix(in srgb, var(--pink), var(--paper-ink) 22%);
+  background:color-mix(in srgb, var(--paper), transparent 30%);
+  box-shadow:0 2px 5px rgba(0,0,0,.35);
+}
+html.arc-mobile .rr-cork .arc-cork-open::before {
+  content:''; position:absolute; right:12px; bottom:6px;
+  width:5px; height:13px; border-radius:3px;
+  transform:rotate(-45deg);
+  background:color-mix(in srgb, var(--pink), var(--paper-ink) 22%);
+}
+
+/* THE MINIATURE (recordsroom.js's wide shot). The same wall, painted into the
+   cork rect in the room's own plate so the board has tonight's paper on it
+   before you walk up to it. The wrapper is the measured rect and clips; the
+   inner wall is the rect divided by the scale, so the grid lays itself out for
+   the board's own shape and then the whole thing is stood back from. Scenery:
+   it takes no pointer, so the room's board hotspot owns every press over it. */
+.rr-corkmini {
+  position:absolute;
+  overflow:hidden;
+  pointer-events:none;
+}
+.rr-corkmini .rr-cork {
+  position:absolute; left:0; top:0;
+  transform-origin:0 0;
+}
+/* No lens, no reading affordance, no flutter: from across the room it is
+   paper on a board. */
+.rr-corkmini .arc-cork-open { display:none; }
+.rr-corkmini .arc-corknote:hover,
+.rr-corkmini .arc-corknote:focus-within { animation:none; }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.js
@@ -628,8 +628,21 @@ export function hasUnread(daySeed, override) {
  * @param {Function=} opts.save         save(state) callback
  * @param {number=} opts.slots          how many sheets are up (default 4)
  * @param {Function=} opts.onRead       onRead(noticeId) per sheet marked read
+ * @param {boolean=} opts.preview       A MINIATURE, not a visit: the same wall
+ *                                      painted for a room to look alive from
+ *                                      across it. Marks nothing read, banks no
+ *                                      visit, takes no pointer and holds no
+ *                                      focus. The Records Office's WIDE shot
+ *                                      hangs one of these in the cork rect so
+ *                                      the painted board has tonight's paper on
+ *                                      it before you walk up to it.
+ * @param {boolean=} opts.readable      each sheet gets a real control over it,
+ *                                      and pressing one opens the READER (a
+ *                                      full-size, scrollable copy over the
+ *                                      window). Off by default: the hall's
+ *                                      board is a page you already scroll.
  * @param {Function=} opts.log
- * @returns {?Object} {notices, daySeed, first, destroy()} - null with no DOM
+ * @returns {?Object} {notices, daySeed, first, closeReader(), destroy()}
  */
 export function mountNotices(hostEl, opts) {
   const o = opts || {};
@@ -650,6 +663,12 @@ export function mountNotices(hostEl, opts) {
 
   const mounted = [];
   let first = null;
+  /* A MINIATURE IS SCENERY. It paints the same wall and writes nothing: no
+   * `seenAt` rows, no banked visit, no focus, no pointer (the sheet's own
+   * class does that half), and it is hidden from a reader - the real wall is
+   * one press away and announcing both would be announcing it twice. */
+  const preview = o.preview === true;
+  if (preview) attr(hostEl, 'aria-hidden', 'true');
 
   if (!up.length) {
     // A wall with nothing on it is a real state (a table trimmed to nothing),
@@ -698,6 +717,19 @@ export function mountNotices(hostEl, opts) {
       sheet.appendChild(tabs);
     }
 
+    /* THE READER'S DOOR. A transparent control the size of the paper, so the
+     * sheet keeps being an <article> (a document, which is what it is) and the
+     * press still lands on a real button with a real name. Never minted for a
+     * preview - a miniature is scenery. */
+    if (o.readable === true && !preview) {
+      const open = el('button', 'arc-cork-open');
+      open.type = 'button';
+      attr(open, 'aria-label', noticeTitle(notice));
+      open.setAttribute('title', t('board_note_open', 'Read this one'));
+      open.addEventListener('click', function () { openNoticeReader(notice, { log: say }); });
+      slot.appendChild(open);
+    }
+
     slot.appendChild(sheet);
     /* THE PIN GOES THROUGH THE SLOT, NOT THROUGH THE SHEET. A torn sheet is a
      * clip-path, and clip-path clips its children too - a pin parented to the
@@ -714,24 +746,32 @@ export function mountNotices(hostEl, opts) {
      * corkboard is read at a glance, and a click-to-expand on a paragraph of
      * copy would be a door with nothing behind it. So the visit marks every
      * sheet it actually pinned up, once. */
-    if (!seenBefore) {
+    if (!seenBefore && !preview) {
       s.notices[notice.id] = { seenAt: today };
       try { if (typeof o.onRead === 'function') o.onRead(notice.id); }
       catch (e) { say('corkboard onRead: ' + ((e && e.message) || e)); }
     }
   }
 
-  /* THE VISIT, BANKED. One write per mount, at the end, never per sheet. */
-  s.lastPinDay = seed;
-  s.openedAt = today;
-  s.visits = Math.max(0, Math.round(Number(s.visits) || 0)) + 1;
-  persist(s, o.save);
+  /* THE VISIT, BANKED. One write per mount, at the end, never per sheet - and
+   * a PREVIEW is not a visit. Looking at the board from across the room does
+   * not read the board: a miniature that banked the night would clear the
+   * prop's fresh dot for a wall the player never walked up to. */
+  if (!preview) {
+    s.lastPinDay = seed;
+    s.openedAt = today;
+    s.visits = Math.max(0, Math.round(Number(s.visits) || 0)) + 1;
+    persist(s, o.save);
+  }
 
   return {
     notices: up,
     daySeed: seed,
     first: first,
+    /** The Esc fold's handle: true when a reader was up and is now down. */
+    closeReader() { return closeNoticeReader(); },
     destroy() {
+      if (!preview) closeNoticeReader();
       for (let i = 0; i < mounted.length; i += 1) {
         try { mounted[i].remove(); } catch (e) { /* noop */ }
       }
@@ -739,6 +779,106 @@ export function mountNotices(hostEl, opts) {
     },
   };
 }
+
+/* ----------------------------------------------------------------------------
+ * THE READER - one sheet, off the wall, in your hands.
+ *
+ * The office's cork is a CLOSE-UP of a painting: the sheets are laid out in
+ * stage pixels and scaled with the plate, so on a phone in landscape (the fit
+ * is about a half) the body copy lands somewhere near seven pixels and the
+ * bottom row hangs off the frame and out of the window. The wall is still the
+ * wall - it is meant to be read at a glance - but a glance you cannot resolve
+ * is a texture. So a sheet can be TAKEN DOWN: one press lifts a full-size,
+ * scrollable copy over the window at type nobody has to squint at.
+ *
+ * The corkboard's own header said there is no per-sheet open verb, because a
+ * click-to-expand on a paragraph of copy is a door with nothing behind it.
+ * That was written for a wall you read at desk size. The owner's ruling
+ * (2026-08-25, iPhone landscape) is that on paper this small the door has the
+ * paper behind it, which is the whole of what it needs.
+ *
+ * IT HANGS OFF <body> AT z56. A room is `position:fixed` at z10 and its apron
+ * band is a body-level sibling at z55 - a reader mounted inside the room would
+ * be laid out inside the room and painted under the carpet. Above the band,
+ * under the toasts (60), and it marks nothing read: the wall already did that
+ * when it pinned the sheet up.
+ * -------------------------------------------------------------------------- */
+
+/** The one open reader, or null. Two sheets in one hand is a bug. */
+let reader = null;
+
+/**
+ * Take one notice off the wall.
+ * @param {Object} notice  a row of NOTICES (or the same shape)
+ * @param {Object=} opts   {mount, log, onClose}
+ * @returns {?Object} {root, close()} - null with no DOM
+ */
+export function openNoticeReader(notice, opts) {
+  const o = opts || {};
+  const doc = (typeof document !== 'undefined') ? document : null;
+  if (!doc || typeof doc.createElement !== 'function' || !notice) return null;
+  const mount = o.mount || doc.body;
+  if (!mount || typeof mount.appendChild !== 'function') return null;
+
+  // ONE SHEET. A second press is the first one replaced, never a second stage.
+  closeNoticeReader();
+  ensureStyles(doc);
+
+  const root = el('div', 'arc-cork-reader');
+  attr(root, 'role', 'dialog');
+  attr(root, 'aria-modal', 'true');
+  attr(root, 'aria-label', noticeTitle(notice));
+
+  const veil = el('div', 'arc-cork-reader-veil');
+  attr(veil, 'aria-hidden', 'true');
+  veil.addEventListener('click', function () { closeNoticeReader(); });
+  root.appendChild(veil);
+
+  const looks = String(notice.look || '').split(/\s+/).filter(Boolean)
+    .map(function (w) { return ' look-' + w; }).join('');
+  const sheet = el('article', 'arc-corknote arc-cork-readnote kind-' + notice.kind + looks);
+  sheet.appendChild(el('span', 'arc-cork-kind', kindLabel(notice.kind).toUpperCase()));
+  sheet.appendChild(el('h2', 'arc-cork-notetitle', noticeTitle(notice)));
+  const paras = Array.isArray(notice.body) ? notice.body : [notice.body];
+  for (let p = 0; p < paras.length; p += 1) {
+    sheet.appendChild(el('p', 'arc-cork-notebody', noticeParagraph(notice, p, paras[p])));
+  }
+  root.appendChild(sheet);
+
+  const close = el('button', 'arc-cork-readclose', t('board_note_close', 'Put it back on the wall'));
+  close.type = 'button';
+  close.addEventListener('click', function () { closeNoticeReader(); });
+  root.appendChild(close);
+
+  /* One focusable thing in here, so the trap is one line - records.js's
+   * spotlight shape. Escape is NOT bound: the shell owns the ladder and the
+   * room's escapeStep asks closeReader() first (trap 48's order). */
+  root.addEventListener('keydown', function (ev) {
+    if (!ev || ev.key !== 'Tab') return;
+    try { ev.preventDefault(); } catch (e) { /* noop */ }
+    try { close.focus(); } catch (e) { /* noop */ }
+  });
+
+  mount.appendChild(root);
+  reader = { root: root, onClose: typeof o.onClose === 'function' ? o.onClose : null };
+  focusSoon(close);
+  sfx('paper', 0.24);
+  return { root: root, close: closeNoticeReader };
+}
+
+/** Put the sheet back. Returns true when one was in hand (the Esc rung). */
+export function closeNoticeReader() {
+  if (!reader) return false;
+  const r = reader;
+  reader = null;
+  try { if (r.root && r.root.remove) r.root.remove(); } catch (e) { /* noop */ }
+  sfx('paper', 0.18);
+  try { if (r.onClose) r.onClose(); } catch (e) { /* noop */ }
+  return true;
+}
+
+/** Is a sheet in hand right now? (test seam) */
+export function readerUp() { return !!reader; }
 
 /* ----------------------------------------------------------------------------
  * THE OVERLAY

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/records.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/records.js
@@ -233,7 +233,25 @@ export function createRecords({ gameName, punchCard, log } = {}) {
       try { close.focus(); } catch (e) { /* noop */ }
     });
 
-    root.appendChild(box);
+    /* THE SPOTLIGHT HANGS OFF <body>, NOT OFF THIS WALL (owner bug 2026-08-25,
+     * "the card is cut off at the top and it is not in the middle"). It is
+     * `position:fixed; inset:0` - a modal over the WINDOW - and it used to be
+     * appended to `root`. On the standalone screen root is itself fixed and
+     * that read as viewport-sized by luck; inside the Records room root sits in
+     * `.asc-panel`, which carries a TRANSFORM, and a transformed ancestor
+     * becomes the containing block for a fixed descendant. So the whole
+     * presentation was being laid out inside a 810x302 scroller parked at the
+     * bottom of a phone: the veil stopped at the panel's edge, the card was
+     * centred on the panel rather than the screen, and its top ran off the top
+     * of the box. Body-level, it is measured against the window on every host
+     * and in every embedding. The band it must clear is `--arm-band-h`, which
+     * scene.js publishes on <html> for exactly this reason. */
+    let spotHost = root;
+    try {
+      if (typeof document !== 'undefined' && document.body
+        && typeof document.body.appendChild === 'function') spotHost = document.body;
+    } catch (e) { /* the node double may have no body - the wall is the floor */ }
+    spotHost.appendChild(box);
     spot = { el: box, timers: [], from: from || null };
     try { close.focus(); } catch (e) { /* noop */ }
 
@@ -276,7 +294,10 @@ export function createRecords({ gameName, punchCard, log } = {}) {
      * differences, both here, and OFF by default - a caller that never passes
      * the flag renders the screen byte for byte. */
     const embedded = s.embedded === true;
-    // A render empties the root, so any spotlight node is already gone with it.
+    /* A render empties the root - and the spotlight is not in the root any
+     * more (it is on <body>), so this call is now load-bearing rather than
+     * belt-and-braces: without it a repaint would strand a lit card over the
+     * wall it was lifted from. */
     dismissSpotlight(true);
     root.textContent = '';
     // The docket coming out. `shell.js showRecords()` renders once per visit, so

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
@@ -199,13 +199,76 @@ html.arc-mobile .asc-panel.rr-cards { padding-bottom: 0; }
    Records screen keeps the type it was signed off with. */
 .rr-cards .arc-pc-small .arc-pc-mastered { font-size: 8px; letter-spacing: .06em; }
 .rr-cards .arc-pc-small .arc-pc-date { font-size: 7.5px; letter-spacing: .02em; }
+/* ...and the four-up phone wall is narrower again, so the same clip comes back
+   at the same fraction. The zone is a WINDOW onto the picture and does not
+   open; the type comes down to fit it, exactly as it did at desktop width. */
+html.arc-mobile .rr-cards .arc-pc-small .arc-pc-mastered { font-size: 6px; letter-spacing: 0; }
+html.arc-mobile .rr-cards .arc-pc-small .arc-pc-date { font-size: 5.5px; letter-spacing: 0; }
 
-/* THE SPOTLIGHT STILL LIFTS A CARD, and it is `position:fixed` over the whole
-   viewport - which, inside the room's z10 stacking context, means the apron
-   band (a <body>-level sibling at z55) paints over its lower edge. fit()
-   publishes the band height on the room's root and the box inherits it down, so
-   one line of padding keeps the presentation above the carpet. */
-.rr-room .arc-rs-stage { padding-bottom: var(--arm-band-h, 0px); }
+/* THE SPOTLIGHT IS NOT THIS FILE'S ANY MORE, and the rule that used to sit
+   here (`.rr-room .arc-rs-stage { padding-bottom: var(--arm-band-h) }`) was
+   never going to be enough. It assumed the lit card was a DESCENDANT of the
+   room; it is `position:fixed`, and it was appended into the card panel, which
+   carries a transform - so it was laid out inside an 810x302 scroller and the
+   padding was clearing a band it could not even see. records.js mounts it on
+   <body> now and scene.js publishes `--arm-band-h` on <html>, so the one
+   padding line lives in styles.css beside the rest of the spotlight and works
+   from any embedding. Nothing about the spotlight belongs in this file. */
+
+/* ---------------------------------------------- THE PANEL, IN A HAND ------
+   THE CARDS COME FIRST (owner bug 2026-08-25, iPhone landscape: "I have to
+   scroll to see a single card"). A 390px window leaves the panel a 296px
+   scroller, and the office was spending 228 of it on a kicker, a display-type
+   headline, a sentence of lede and a row of tallies before the wall started.
+   The wall IS the screen; the words about the wall are not.
+
+   What goes: the kicker (you are standing in the Records Office - the room
+   said so), and the lede (one sentence of flavour, and the cards say it
+   better). What shrinks: the headline down to a label, the tallies to one
+   compact non-wrapping row, and the cards to a four-up grid so a WHOLE row
+   clears the sticky bar with the next row showing under it - which is also
+   how a player learns there is more wall below. Nothing is deleted from the
+   DOM: this is a phone layout, and the desktop panel is untouched. */
+html.arc-mobile .rr-cards .arc-kicker,
+html.arc-mobile .rr-cards .arc-lede { display: none; }
+html.arc-mobile .rr-cards .arc-records-desk { gap: 8px; }
+html.arc-mobile .rr-cards .arc-h1 {
+  margin: 0;
+  font-size: 17px;
+  letter-spacing: .16em;
+}
+html.arc-mobile .rr-cards .arc-records-tally {
+  flex-wrap: nowrap;
+  gap: 6px;
+  overflow-x: auto;
+}
+html.arc-mobile .rr-cards .arc-records-tally .chip {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  font-size: 10px;
+  white-space: nowrap;
+}
+html.arc-mobile .rr-cards .arc-records-wall {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  padding: 2px 0 0;
+}
+html.arc-mobile .rr-cards .arc-records-slot { padding: 7px 6px 6px; gap: 5px; }
+/* THE CARD FILLS ITS COLUMN. `.arc-pc-small` is a FIXED 236px and the face is
+   `background-size:cover` against an authored aspect - so in a narrower column
+   the card is squeezed horizontally and the art is cropped down both sides
+   (the four-up wall came out as four windows onto the middle of four cards).
+   The 560px media query already does this for a one-column wall; a phone in
+   landscape never trips it. */
+html.arc-mobile .rr-cards .arc-pc { --pc-w: 100%; }
+/* A SHORTER FLOOR, so a whole row of cards clears it. The bar is a bar, not a
+   button rail: 54px still holds two 44px thumb targets with air around them. */
+html.arc-mobile .rr-cards { --rr-barh: 54px; }
+html.arc-mobile .rr-cards .arc-records-slotline { font-size: 9px; letter-spacing: .08em; }
+/* The docket is the long read and it lives under the wall; on a phone the
+   spotlight is what a tap opens, so the docket keeps its place and simply
+   stops reserving 120px of empty box above the fold. */
+html.arc-mobile .rr-cards .arc-records-docket { min-height: 0; }
 
 /* ------------------------------------------------------------- THE CORK */
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.js
@@ -63,7 +63,7 @@ import { t as lexT } from '../core/lexicon.js';
 import { createScene } from './scene.js';
 import { createRecords } from './records.js';
 import { createDeskBook } from './deskbook.js';
-import { mountNotices } from './corkboard.js';
+import { mountNotices, closeNoticeReader, readerUp } from './corkboard.js';
 
 /* ----------------------------------------------------------------------------
  * THE TABLE
@@ -287,6 +287,8 @@ export function createRecordsRoom(caps) {
   let closeCards = null;       // the live panel's own close, or null
   let book = null;             // shell/deskbook.js, built on the first book view
   let paper = null;            // the corkboard's mount handle, or null
+  let mini = null;             // the WIDE shot's miniature wall, or null
+  let miniOff = null;          // its unmount
   let freshEl = null;          // the pink tab, or null
   let freshOff = null;         // its unmount
   let ajar = !!c.ajar;
@@ -344,6 +346,7 @@ export function createRecordsRoom(caps) {
 
   try { scene.root.classList.add('rr-room'); } catch (e) { /* noop */ }
   scene.setFlag('ajar', ajar);
+  mountMiniCork();
 
   /* THE ROOM TONE IS NOT WIRED, AND THAT IS A DELIBERATE ABSENCE.
    *
@@ -485,6 +488,48 @@ export function createRecordsRoom(caps) {
     });
   }
 
+  /* ------------------------------------------------------- THE MINIATURE */
+
+  /**
+   * THE BOARD HAS PAPER ON IT FROM ACROSS THE ROOM (owner ruling 2026-08-25).
+   * The plate paints bare cork, so until you walked up to it the office's
+   * noticeboard was an empty board in a room that is supposed to be lived in.
+   * This hangs the SAME night's set - one table, one state, one wall - into the
+   * cork rect on the wide shot, stood back from.
+   *
+   * IT IS A PREVIEW, AND THAT WORD IS LOAD-BEARING: `mountNotices({preview})`
+   * marks nothing read and banks no visit, so looking at the board is not
+   * reading the board and the fresh dot survives the glance.
+   *
+   * THE SCALE IS DERIVED, NEVER TYPED. The inner wall is laid out at the
+   * CLOSE-UP's own width, so a sheet in the miniature is the same shape as the
+   * sheet you walk up to, and the whole thing is then scaled by the ratio the
+   * two rects give us. Its height is the rect divided back out by that scale,
+   * which is what lets the grid deal two rows into the board's own proportions
+   * rather than into a letterboxed strip.
+   */
+  function mountMiniCork() {
+    if (dead || mini) return;
+    const rect = RECTS.corkboard;
+    const scale = rect[2] / CORK_INNER[2];
+    if (!(scale > 0)) return;
+    const wrap = el('div', 'rr-corkmini');
+    attr(wrap, 'aria-hidden', 'true');
+    /* `rr-cork` so it is laid out and inked exactly like the wall it is a
+     * picture of; `rr-cork-mini` so nothing - a sheet, a suite - can mistake
+     * the picture for the wall. */
+    const inner = el('div', 'rr-cork rr-cork-mini arc-cork-wall');
+    try {
+      inner.style.width = CORK_INNER[2] + 'px';
+      inner.style.height = Math.round(rect[3] / scale) + 'px';
+      inner.style.transform = 'scale(' + scale.toFixed(4) + ')';
+    } catch (e) { /* the node double has no style box - the wall still mounts */ }
+    wrap.appendChild(inner);
+    miniOff = scene.mountInView('wide', wrap, rect);
+    mini = mountNotices(inner, { daySeed: c.daySeed, preview: true, log: log });
+    if (!mini) log('records room: the miniature wall could not be pinned');
+  }
+
   /* ------------------------------------------------------------ THE BOARD */
 
   /** Pin the night's sheets over the bare cork, once per visit to the room. */
@@ -497,6 +542,12 @@ export function createRecordsRoom(caps) {
     paper = mountNotices(host, {
       daySeed: c.daySeed,
       onRead: typeof c.onCorkRead === 'function' ? c.onCorkRead : undefined,
+      /* EVERY SHEET COMES OFF THE WALL. The close-up is a painting scaled to
+       * the window, so on a phone its body copy lands near seven pixels and
+       * the bottom row hangs out of the frame; one press lifts the paper to
+       * full size over the window (corkboard.js's READER). The wall is still
+       * read at a glance - this is what a glance you cannot resolve does next. */
+      readable: true,
       log: log,
     });
     if (!paper) log('records room: the wall could not be pinned');
@@ -531,8 +582,16 @@ export function createRecordsRoom(caps) {
    */
   function escapeStep() {
     if (dead) return false;
+    /* A SHEET IN THE HAND IS THE THING ONE PRESS AGO, so it folds before the
+     * spotlight and before the chassis - inward-out, all the way down. */
+    if (dismissReader()) return true;
     if (dismissSpotlight()) return true;
     try { return !!scene.escapeStep(); } catch (e) { return false; }
+  }
+
+  /** The reader's own rung, kept separate so the shell can name it. */
+  function dismissReader() {
+    try { return !!closeNoticeReader(); } catch (e) { return false; }
   }
 
   /** The spotlight's own rung, kept separate so the shell can name it. */
@@ -557,6 +616,12 @@ export function createRecordsRoom(caps) {
     timers.length = 0;
     if (book) { try { book.destroy(); } catch (e) { /* noop */ } book = null; }
     if (paper) { try { paper.destroy(); } catch (e) { /* noop */ } paper = null; }
+    /* The miniature is scenery and goes with the room; its unmount is the
+     * chassis's, its sheets are corkboard.js's, and a reader left in the
+     * player's hand is a <body>-level node that would outlive both. */
+    if (mini) { try { mini.destroy(); } catch (e) { /* noop */ } mini = null; }
+    if (miniOff) { try { miniOff(); } catch (e) { /* noop */ } miniOff = null; }
+    try { closeNoticeReader(); } catch (e) { /* noop */ }
     if (recordsPage) { try { recordsPage.destroy(); } catch (e) { /* noop */ } recordsPage = null; }
     closeCards = null;
     freshEl = null;
@@ -584,6 +649,11 @@ export function createRecordsRoom(caps) {
     book: function () { return book; },
     /** The night's pinned sheets, once the cork has been visited. */
     notices: function () { return paper ? paper.notices : null; },
+    /** The wide shot's miniature wall, or null. */
+    miniNotices: function () { return mini ? mini.notices : null; },
+    /** Is a sheet in the player's hand right now? */
+    readerUp: function () { try { return !!readerUp(); } catch (e) { return false; } },
+    dismissReader: dismissReader,
     /** Was this the room's first-ever visit? */
     firstVisit: function () { return firstEver; },
     /** Is the tray wearing the first-visit solo ring right now? */

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/rooms.css
@@ -520,6 +520,38 @@
    keeps the centred stage. */
 html.arc-mobile[data-arc-orient="landscape"] .arm-stage { top: 0; transform-origin: 50% 0; }
 
+/* A HOVER-ONLY AFFORDANCE IS NOT AN AFFORDANCE ON A PHONE (owner report
+   2026-08-25, "I cannot get to the lab from the Records office"). `.arm-exit`
+   is the painted way through - dark until you find it, honest once you do -
+   and the only thing that ever lit it was `:hover` / `:focus-visible`. A thumb
+   has neither, so on a phone the storeroom door was a 75x231 rect of painted
+   wall with nothing at all to say it could be pressed.
+
+   It gets a RESTING rim on touch, and only on touch: the same quiet purple the
+   hover state uses, at the hover's own weight rather than a new colour. It
+   still never breathes and it still never out-shouts `.arm-main` - the verb
+   that pays keeps the pink and keeps the pulse. The desktop rule is untouched,
+   so a mouse still finds the door the way it was signed off.
+
+   EVERY NUMBER HERE IS A STAGE PIXEL. A hotspot lives inside the 1376x768
+   plane, and a phone fits that plane at about a half - so the desktop's 2px
+   rim would land at one physical pixel and the 13px tag at six. They are
+   doubled, and that is not a taste call, it is the same arithmetic the
+   step-back pill lost (scene.css's own note). */
+html.arc-mobile .arm-hot.arm-exit {
+  box-shadow: inset 0 0 0 5px rgba(190, 160, 255, 0.50),
+              0 0 34px 8px rgba(150, 120, 230, 0.22);
+}
+/* ...and its name, which is the other half a phone cannot hover for. The tag
+   is decoration (it takes no pointer events), so the rect under it stays one
+   unbroken press. */
+html.arc-mobile .arm-hot.arm-exit .arm-hot-tag {
+  opacity: 1;
+  bottom: -40px;
+  padding: 6px 16px;
+  font-size: 22px;
+}
+
 html.arc-mobile .arm-bar {
   gap: 10px;
   padding: 7px calc(clamp(10px, 2.6vw, 22px) + env(safe-area-inset-right, 0px))

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.css
@@ -143,7 +143,16 @@
 /* THE PILL, lifted from lab.css's .al-back. The apron's slab LEAVES THE ROOM;
    a player two clicks into a close-up needs the other verb and Esc is not a
    mouse. Warm here rather than the annex's cold green - a facility room is
-   still the school. Home never draws one. */
+   still the school. Home never draws one.
+
+   IT IS A CHILD OF `.asc-root`, NOT OF A SLIDE, and that is the whole of why
+   it is legible: a slide lives inside the SCALED stage, so a pill in there is
+   authored in stage pixels and comes out multiplied by the fit (~0.5 on a
+   phone - a 44px thumb target measured 22px and 12px type measured 6px). Root
+   is `position:fixed; inset:0`, so absolute here is screen pixels on every
+   host. z4 clears the stage (which is z:auto) and stays under the overlay
+   (z20), which is the right order: a panel opened over a close-up is the
+   thing the pill's own press closes first. */
 .asc-back {
   position: absolute;
   z-index: 4;
@@ -418,7 +427,9 @@
 html.arc-mobile[data-arc-orient="landscape"] .asc-stage { top: 0; transform-origin: 50% 0; }
 
 /* The step-back pill is a thumb target on a phone, and it shares the room's
-   ceiling with the plate. */
+   ceiling with the plate. Every number here is a SCREEN pixel now (see the
+   pill's own block above); before the pill moved out of the stage they were
+   stage pixels and this whole rule was worth about half of what it says. */
 html.arc-mobile .asc-back {
   left: calc(10px + env(safe-area-inset-left, 0px));
   top: calc(8px + env(safe-area-inset-top, 0px));

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
@@ -418,6 +418,43 @@ export function createScene(opts) {
     } catch (e) { /* noop */ }
   }
 
+  /* ---------------------------------------------------- the step-back pill */
+
+  /* THE WAY OUT OF A CLOSE-UP, and there is exactly ONE of it. lab.css's
+   * `.al-back`, promoted: the apron's slab leaves the room on the way into a
+   * close-up (A ZOOM IS A ZOOM), Esc is not a thumb, so a close-up draws a
+   * pill of its own.
+   *
+   * IT HANGS OFF THE ROOT, NEVER OFF THE SLIDE. A slide lives inside
+   * `.asc-stage`, which is the 1376x768 plane scaled to fit - so a pill in
+   * there is authored in STAGE pixels and every phone rule written for it is
+   * multiplied by the fit (~0.5 on a 844x390 window: a 44px thumb target came
+   * out 22px tall with 6px type, which is the owner's "there is no way back
+   * from the book", 2026-08-25). The apron band has been a screen-pixel
+   * sibling since it was written; the pill is the same kind of thing.
+   *
+   * It comes and goes by REMOVAL (trap 27), never by `hidden`, and it is a
+   * LEVEL keyed on the view exactly the way the apron is - every showView
+   * writes it, so an interrupted walk can never strand it over the wide shot.
+   */
+  const backPill = el('button', 'asc-back', '‹ ' + t('back', 'Back'));
+  backPill.type = 'button';
+  backPill.setAttribute('aria-label', t('back', 'Back'));
+  /* The pill runs the SAME fold Esc runs: a panel opened over a close-up is
+   * the thing one press ago, so it closes first. At the wide shot escapeStep
+   * answers false and does nothing - and the pill is not up there anyway. */
+  backPill.addEventListener('click', function () { escapeStep(); });
+  let backUp = false;
+  function backVisible(show) {
+    const want = !!show;
+    if (want === backUp) return;
+    backUp = want;
+    try {
+      if (want) root.appendChild(backPill);
+      else backPill.remove();
+    } catch (e) { /* a way out must never be the thing that throws */ }
+  }
+
   /* ------------------------------------------------------------ hotspots */
 
   function placeRect(node, rect) {
@@ -938,15 +975,12 @@ export function createScene(opts) {
       if (whenOn(opt.when)) node.appendChild(b);
     }
 
-    /* THE STEP-BACK PILL, lab.js's, on every close-up. The apron's slab LEAVES
-     * THE ROOM; a player two clicks deep needs the other verb, and Esc is not
-     * a mouse. Home has none - the apron is the way out from there. */
-    if (name !== 'wide') {
-      const pill = el('button', 'asc-back', '‹ ' + t('back', 'Back'));
-      pill.type = 'button';
-      pill.addEventListener('click', function () { showView('wide'); });
-      node.appendChild(pill);
-    }
+    /* THE STEP-BACK PILL IS NOT IN HERE ANY MORE - see backVisible(). It used
+     * to be a child of the slide, which put it inside the SCALED stage: on a
+     * phone the fit is ~0.5, so every screen pixel the phone rules asked for
+     * came out halved (a 44px thumb target measured 22px, 12px type measured
+     * 6px) and the one way out of a close-up read as a smudge. It is chrome,
+     * not paint - it hangs off the root now, in screen pixels. */
     return node;
   }
 
@@ -1040,6 +1074,9 @@ export function createScene(opts) {
      * every close-up. Written on EVERY move, not just the ones that change it,
      * so the level always matches the view that is actually up. */
     apronVisible(name === 'wide');
+    /* ...and the pill is the other half of the same law: the band and the pill
+     * are never both up, and never both away. */
+    backVisible(name !== 'wide');
     if (prevName) sfx(back ? 'door' : 'blip', back ? 0.3 : 0.16, back ? null : { pitch: 1.05 });
     /* Keyboard keeps its place: the room's own verb takes focus once the node
      * is in the document (a fresh node ignores focus() in some engines). */
@@ -1189,7 +1226,26 @@ export function createScene(opts) {
       bar.style.setProperty('--arm-band-h', bandH + 'px');
     }
     root.style.setProperty('--arm-band-h', bandH + 'px');
+    /* ...AND ON <html>, because a viewport-level modal cannot inherit it.
+     * `position:fixed` inside this room is contained by the room (root is
+     * fixed, and an overlay panel carries a transform), so anything that has
+     * to be measured against the WINDOW - the Records spotlight, a notice
+     * reader - is mounted on <body> and has no ancestor of ours to read the
+     * band off. One page-level custom property is the seam; destroy() clears
+     * it, so a screen after this one never inherits a carpet that left. */
+    setBandVar(bandH);
     return s;
+  }
+
+  /** The band height as a page fact. Defensive: the node double has no
+   *  documentElement and a page with no scene must read 0. */
+  function setBandVar(px) {
+    try {
+      const de = doc.documentElement;
+      if (de && de.style && typeof de.style.setProperty === 'function') {
+        de.style.setProperty('--arm-band-h', (Number(px) || 0) + 'px');
+      }
+    } catch (e) { /* noop */ }
   }
   function onResize() { fit(); }
 
@@ -1230,6 +1286,8 @@ export function createScene(opts) {
     if (sheetRooms && sheetRooms.removeEventListener) { try { sheetRooms.removeEventListener('load', onResize); } catch (e) { /* noop */ } }
     if (overlay) { try { overlay.layer.remove(); } catch (e) { /* noop */ } overlay = null; }
     if (bar) { try { bar.remove(); } catch (e) { /* noop */ } }
+    /* The carpet goes with the room: the next screen has no band. */
+    setBandVar(0);
     try { root.remove(); } catch (e) { /* noop */ }
     live.length = 0;
     /* The props go with the room, but they are NOT ours to destroy - the

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -617,6 +617,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let stageClear = false;
   let board = null;
   let campus = null;               // the night-campus hub (OPTIONAL - see showBoard)
+  /* WHICH FULL-BLEED STAGE IS UP, or null. setStage() is the one writer and
+   * renderTopbar() is the one reader - a stage owns the window, so the bar
+   * stays retired for as long as one is up, whoever asks for the repaint. */
+  let stageMode = null;
   // THE STUDENT BODY (PRESENCE.md). Optional in exactly the way the campus is:
   // it hangs off the campus's own ghost layer, so it lives and dies with it and
   // no other screen has ever heard of it.
@@ -1170,6 +1174,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
       html.classList.remove('arc-class-on', 'arc-report-on', 'arc-settings-on');
       if (mode) html.classList.add(mode);
     }
+    stageMode = mode || null;
     if (dom && dom.topbar) dom.topbar.hidden = !!mode;
   }
 
@@ -1199,7 +1204,14 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     // (attendance tick, EMI's voice ledger) lands here via store.onChange - the
     // old unconditional unhide resurrected the bar OVER the campus and buried
     // the hanging timetable plaque under it (owner screenshot, 0824).
-    bar.hidden = !!campus;
+    /* AND RETIRED UNDER A FULL-BLEED STAGE, for the same reason (owner bug
+     * 2026-08-25, "the hub header is sitting on top of the corkboard"). The
+     * guard read `campus` alone, so any UNCONDITIONAL repaint - a `meta` push
+     * from the host landing mid-visit, a payout frame - hoisted the bar back
+     * over the Records room, the report card and the annex. It paints at z30
+     * over a room fixed at z10, so it swallowed the close-up's whole top band,
+     * step-back pill and all. A stage owns the window until it hands it back. */
+    bar.hidden = !!campus || !!stageMode;
     bar.textContent = '';
     /* THE WORDMARK IS THE DOOR (owner ruling 2026-08-24). On the campus the
      * name is just the name - a back button pointing at the room you are

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -3286,11 +3286,18 @@ html.arc-reduced .arc-sign-chase { opacity:.55; }
 .arc-rs.is-closing .arc-rs-close { animation:arc-rs-out .18s ease-in both; }
 @keyframes arc-rs-out { to { opacity:0; } }
 
+/* THE STAGE IS CENTRED IN WHAT THE PLAYER CAN SEE, not in the window. A scene
+   room parks an opaque apron band along the bottom and publishes its height on
+   <html> as `--arm-band-h` (scene.js fit(); zero, and therefore harmless, on
+   every screen that is not a room). Padding it out of the stage is what keeps
+   the card off the carpet instead of half behind it. */
 .arc-rs-stage {
   position:relative;
   display:flex; flex-direction:column; align-items:center; gap:14px;
   max-width:96vw;
+  max-height:100%;
   padding:10px;
+  padding-bottom:calc(10px + var(--arm-band-h, 0px));
 }
 /* The key light: a warm cone behind the card, breathing very slowly. */
 .arc-rs-lamp {
@@ -4442,6 +4449,26 @@ html.arc-mobile .campus-gearbtn { width:44px; height:44px; font-size:19px; }
 html.arc-mobile .campus-boardtab { padding:12px 18px; }
 /* The room tooltip follows a cursor that does not exist on a phone. */
 html.arc-mobile .campus-tip { display:none; }
+
+/* ---- THE CARD SPOTLIGHT, IN A HAND (owner bug 2026-08-25) ----------------
+   Two things are wrong with the desktop dial on a phone in landscape. The card
+   width is capped at `(100vh - 250px) * 1.5`, and 250px of a 390px window is
+   most of it - the exhibit came out 210px wide on an 844px screen, a thumbnail
+   under a key light. And the placard's 3.6vw name is display type sized for a
+   1600px window. So the ceiling is re-derived from what is actually free: the
+   window, less the room's apron band, less the placard's own two lines. The
+   `62vw` term is the other axis (a card wider than that stops being a card
+   held up and starts being a wall), and the 720px cap is still the art's. */
+html.arc-mobile .arc-rs .arc-pc {
+  --pc-w:min(720px, 62vw, calc((100vh - var(--arm-band-h, 0px) - 128px) * 1.5));
+}
+html.arc-mobile .arc-rs-stage { gap:8px; padding:6px; padding-bottom:calc(6px + var(--arm-band-h, 0px)); }
+html.arc-mobile .arc-rs-name { font-size:clamp(15px, 2.6vw, 24px); letter-spacing:.12em; }
+html.arc-mobile .arc-rs-sub { font-size:10px; letter-spacing:.12em; }
+html.arc-mobile .arc-rs-placard { gap:3px; }
+/* The close button keeps its 44px, and it stops sharing a corner with the
+   card: on a short window the stage reaches the top of the glass. */
+html.arc-mobile .arc-rs-close { top:8px; right:10px; }
 
 /* ---- the turn-your-phone card (shell/orientgate.js) ----------------------
    Campus signage, not a browser error: the school's own sky, the school's own

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -2357,6 +2357,8 @@ internal static class ArcademyHostService
         ["board_kind_notice"] = "Notice",
         ["board_kind_flyer"] = "Flyer",
         ["board_kind_minutes"] = "Minutes",
+        ["board_note_open"] = "Take this one down and read it",
+        ["board_note_close"] = "Put it back on the wall",
         ["bugle_issue"] = "Issue",
         ["bugle_page"] = "Page",
         ["bugle_pages"] = "Pages",


### PR DESCRIPTION
Seven owner reports from one afternoon on an iPhone in landscape. Most of them are one arithmetic mistake: a scene room is a fixed 1376x768 plane scaled to fit, a phone fits it at about a half, and any **chrome** authored inside that plane comes out at half the size the rule asked for.

Every fix is gated on `html.arc-mobile` unless it is a genuine bug at every size. Desktop rects were measured before and after and are pixel-identical (card wall, slots, exit bar, spotlight card, cork close-up); the only desktop move is the step-back pill's own corner, 3px, which is what taking it out of the scaled plane costs.

## 1. The cards panel put the cards last

A 390px window leaves the panel a 296px scroller, and the office was spending 228 of it on a kicker, a display headline, a sentence of lede and a row of tallies before the wall began. Not one card was above the fold.

On a phone: the kicker and the lede go, the headline comes down to a label, the tallies become one compact non-wrapping row, and the wall deals **four-up** so a whole row of cards clears the sticky bar with the next row showing under it. The card gets `--pc-w:100%` as well: `.arc-pc-small` is a fixed 236px and a narrower column squeezed it, cropping the art down both sides.

The panel keeps **no bottom padding**. A `position:sticky; bottom:0` bar is measured inside the scroller's padding, and that trap has been paid for three times already; the suite greps for it.

## 2. The spotlight was laid out inside the panel

`.arc-rs` is `position:fixed; inset:0` and was appended into the wall it lifts a card off. Inside the room that wall sits in `.asc-panel`, which carries a `transform` for its slide-up - and **a transformed ancestor is the containing block for a fixed descendant**. So the whole presentation was being laid out inside an 810x302 scroller parked at the bottom of the phone: the veil stopped at the panel's edge, the card was centred on the panel rather than the screen, and its top ran off the top of the box.

It mounts on `<body>` now. The apron band it has to clear reaches it as `--arm-band-h`, which `scene.js fit()` publishes on `<html>` and `destroy()` clears. The phone also re-derives the card ceiling from what is actually free (window, less band, less placard) instead of a flat 250px, so the exhibit is 286px wide instead of 210.

## 3 + 5. The book and the corkboard had no way back

The pill was there. It was a child of the slide, so 44px of thumb target measured 22 and 12px of type measured 6 - a grey smudge under the header. One `.asc-back` hangs off `.asc-root` now, added and removed by view exactly the way the apron's class is written, in screen pixels on every host. It runs `escapeStep()` rather than `showView('wide')`, so a panel opened over a close-up folds first. Both close-ups are asserted.

## The hub header was sitting on top of the room

Visible in the owner's corkboard screenshot and the reason the pill was doubly unfindable. `.arc-topbar` is sticky at z30 and a room is fixed at z10. `setStage()` hides the bar on the way in, but `renderTopbar()` guarded on `campus` alone - so any **unconditional** repaint (`onMeta` from a host `meta` push, `onPayout`) hoisted it straight back over the Records room, the report card and the annex, swallowing the whole top band.

`bar.hidden = !!campus || !!stageMode`. A full-bleed stage owns the window.

## 4. The storeroom door

The rect, the flag and the wiring are all correct and reachable at both phone sizes (measured: 75x231 at 844x390, well inside the crop). What was missing is that **a hover-only affordance is not an affordance on a phone**: `.arm-exit` is the painted way through, dark until `:hover`/`:focus-visible`, and a thumb has neither - so the one route to the lab from the office was 75x231 of painted wall that said nothing. On `html.arc-mobile` only it wears a resting purple rim and its tag (both doubled, because both were stage pixels). Desktop is untouched: the door is still found, not advertised.

Nothing here touches `annexRevealSeen`, the morning-after guard or `seenFlags`.

## 6. The noticeboard was bare until you walked up to it

The wide shot now hangs a scaled copy of the same night's wall in the cork rect - one table, one state, one night - through a new `mountNotices({preview:true})` that **marks nothing read and banks no visit**, because looking at a board is not reading it (the prop's fresh dot survives the glance). The scale is derived from the two rects, never typed, so a sheet in the picture is the shape of the sheet on the wall. Scenery: no pointer events, so the board hotspot still owns every press over it.

## 7. And in the close-up the paper was a texture

At stage scale the body copy lands near seven pixels, and a busy term's fifth row hangs off the frame and out of the window (the desktop ruling - pinned paper hangs onto the wall below the rail - needs a wall below the rail, and on a phone the plate is the window).

On a phone the office cork clips each sheet to a row's share with a fade and a drawn lens glyph, stacks from the top rail and scrolls. On every host each sheet now carries a real `.arc-cork-open` control, and one press lifts **the reader**: a full-size, scrollable copy of that sheet on `<body>` at z56 - above the apron band, below the toasts - and the first rung of the room's Esc fold. `.arc-cork-reader` joins the list of hosts that declare the paper tokens; being body-level it had no cork above it and came out as ghost type on glass, which is the same trap that block already documents once.

## Lexicon

`board_note_open` / `board_note_close`, both mirrored verbatim in the C# `NeutralLexicon`.

## Verification

- **Suites**: scene chassis **253/0** (was 240/0), records office room **318/0** (was 256/0). New cases cover the pill on both close-ups and its fold order, `--arm-band-h` on `<html>` and its clearing, the miniature (placement, derived scale, and that a glance writes nothing), the reader (body-level, Esc fold, close button, teardown), plus greps for the phone panel rules, the touch rim, the topbar guard and the spotlight's mount.
- **Shots** at 844x390, 667x375 and 1600x900: cards panel, spotlight, book, corkboard close-up, an opened sheet, and the room with the door ajar. Every stylesheet was probed for `cssRules.length` in the same pass, which caught one broken comment before it shipped.
- **CLAUDE.md**: trap 101 (the family above, in one place), plus file notes for the root-level pill, the miniature and the reader.

## Not fixed, and why

The owner's `Unlocked 9/10 / 93 stamps` does **not** point at a bug in the reveal threshold. `loadGames` already filters `GAME_PATHS` through `isOpenSemester`, so `games.list` is the ten OPEN classes and `misdirection` is absent from it - from the total and from the requirement alike. Every "N of 10" the player sees counts over that same list. 9 complete + 1 card at 3 stamps = 93, so the reveal is correctly withheld: one class left. Nothing was forced, and a tripwire case now asserts the filter so a future "simplification" back to `Object.keys(GAME_PATHS)` cannot quietly make the reveal unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6
