### PR TITLE
feat(sessions): "Don't ask me again" on the pause XP warning

### DIFF
--- a/ConditioningControlPanel/Localization/Languages/de.json
+++ b/ConditioningControlPanel/Localization/Languages/de.json
@@ -2387,6 +2387,7 @@
   "msg_plus_pause_penalty_0": "\n(Plus {0} XP Pause-Strafe)",
   "btn_yes_stop_session": "Ja, Sitzung beenden",
   "btn_keep_going": "Weitermachen",
+  "chk_dont_ask_again": "Nicht mehr fragen",
   "title_pause_session_confirm": "\u23f8 Sitzung pausieren?",
   "msg_pause_session_body": "Pausieren kostet dich 100 XP von deiner Sitzungsbelohnung.\n\nAktuelle Strafe: -{0} XP\nNach dieser Pause: -{1} XP\n\nBist du sicher?",
   "btn_yes_pause": "Ja, pausieren",

--- a/ConditioningControlPanel/Localization/Languages/en.json
+++ b/ConditioningControlPanel/Localization/Languages/en.json
@@ -3385,6 +3385,7 @@
   "msg_plus_pause_penalty_0": "\n(Plus {0} XP pause penalty)",
   "btn_yes_stop_session": "Yes, stop session",
   "btn_keep_going": "Keep going",
+  "chk_dont_ask_again": "Don't ask me again",
   "title_pause_session_confirm": "\u23f8 Pause Session?",
   "msg_pause_session_body": "Pausing will cost you 100 XP from your session reward.\n\nCurrent penalty: -{0} XP\nAfter this pause: -{1} XP\n\nAre you sure?",
   "btn_yes_pause": "Yes, pause",

--- a/ConditioningControlPanel/Localization/Languages/es.json
+++ b/ConditioningControlPanel/Localization/Languages/es.json
@@ -2384,6 +2384,7 @@
   "msg_plus_pause_penalty_0": "\n(Más {0} XP de penalización por pausa)",
   "btn_yes_stop_session": "Sí, detener sesión",
   "btn_keep_going": "Seguir adelante",
+  "chk_dont_ask_again": "No volver a preguntar",
   "title_pause_session_confirm": "\u23f8 ¿Pausar Sesión?",
   "msg_pause_session_body": "Pausar te costará 100 XP de tu recompensa de sesión.\n\nPenalización actual: -{0} XP\nDespués de esta pausa: -{1} XP\n\n¿Estás segura?",
   "btn_yes_pause": "Sí, pausar",

--- a/ConditioningControlPanel/Localization/Languages/fr.json
+++ b/ConditioningControlPanel/Localization/Languages/fr.json
@@ -2387,6 +2387,7 @@
   "msg_plus_pause_penalty_0": "\n(Plus {0} XP de pénalité de pause)",
   "btn_yes_stop_session": "Oui, arrêter la session",
   "btn_keep_going": "Continuer",
+  "chk_dont_ask_again": "Ne plus me demander",
   "title_pause_session_confirm": "\u23f8 Mettre en Pause la Session ?",
   "msg_pause_session_body": "Mettre en pause te coûtera 100 XP de ta récompense de session.\n\nPénalité actuelle : -{0} XP\nAprès cette pause : -{1} XP\n\nEs-tu sûr ?",
   "btn_yes_pause": "Oui, pause",

--- a/ConditioningControlPanel/Localization/Languages/ja.json
+++ b/ConditioningControlPanel/Localization/Languages/ja.json
@@ -2384,6 +2384,7 @@
   "msg_plus_pause_penalty_0": "\n（さらに{0} XPの一時停止ペナルティ）",
   "btn_yes_stop_session": "はい、停止します",
   "btn_keep_going": "続ける",
+  "chk_dont_ask_again": "今後確認しない",
   "title_pause_session_confirm": "\u23f8 セッションを一時停止しますか？",
   "msg_pause_session_body": "一時停止するとセッション報酬から100 XP差し引かれます。\n\n現在のペナルティ：-{0} XP\nこの一時停止後：-{1} XP\n\nよろしいですか？",
   "btn_yes_pause": "はい、一時停止",

--- a/ConditioningControlPanel/Localization/Languages/ko.json
+++ b/ConditioningControlPanel/Localization/Languages/ko.json
@@ -2386,6 +2386,7 @@
   "msg_plus_pause_penalty_0": "\n(추가로 {0} XP 일시정지 패널티)",
   "btn_yes_stop_session": "네, 세션 정지",
   "btn_keep_going": "계속하기",
+  "chk_dont_ask_again": "다시 묻지 않기",
   "title_pause_session_confirm": "\u23f8 세션을 일시정지할까요?",
   "msg_pause_session_body": "일시정지하면 세션 보상에서 100 XP가 차감돼요.\n\n현재 패널티: -{0} XP\n이번 일시정지 후: -{1} XP\n\n확실한가요?",
   "btn_yes_pause": "네, 일시정지",

--- a/ConditioningControlPanel/Localization/Languages/pt-BR.json
+++ b/ConditioningControlPanel/Localization/Languages/pt-BR.json
@@ -2386,6 +2386,7 @@
   "msg_plus_pause_penalty_0": "\n(Mais {0} XP de penalidade por pausa)",
   "btn_yes_stop_session": "Sim, parar sessão",
   "btn_keep_going": "Continuar",
+  "chk_dont_ask_again": "Não perguntar novamente",
   "title_pause_session_confirm": "\u23f8 Pausar Sessão?",
   "msg_pause_session_body": "Pausar custará 100 XP da sua recompensa de sessão.\n\nPenalidade atual: -{0} XP\nApós esta pausa: -{1} XP\n\nTem certeza?",
   "btn_yes_pause": "Sim, pausar",

--- a/ConditioningControlPanel/Localization/Languages/ru.json
+++ b/ConditioningControlPanel/Localization/Languages/ru.json
@@ -2386,6 +2386,7 @@
   "msg_plus_pause_penalty_0": "\n(Плюс штраф за паузу {0} XP)",
   "btn_yes_stop_session": "Да, остановить",
   "btn_keep_going": "Продолжить",
+  "chk_dont_ask_again": "Больше не спрашивать",
   "title_pause_session_confirm": "\u23f8 Приостановить сессию?",
   "msg_pause_session_body": "Пауза будет стоить 100 XP из награды за сессию.\n\nТекущий штраф: -{0} XP\nПосле этой паузы: -{1} XP\n\nТы уверена?",
   "btn_yes_pause": "Да, приостановить",

--- a/ConditioningControlPanel/Localization/Languages/zh-CN.json
+++ b/ConditioningControlPanel/Localization/Languages/zh-CN.json
@@ -3108,6 +3108,7 @@
   "msg_plus_pause_penalty_0": "\n（加上 {0} XP 暂停惩罚）",
   "btn_yes_stop_session": "是，停止疗程",
   "btn_keep_going": "继续",
+  "chk_dont_ask_again": "不再询问",
   "title_pause_session_confirm": "⏸ 暂停疗程？",
   "msg_pause_session_body": "暂停将花费你疗程奖励中的 100 XP。\n\n当前惩罚：-{0} XP\n本次暂停后：-{1} XP\n\n你确定吗？",
   "btn_yes_pause": "是，暂停",

--- a/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
+++ b/ConditioningControlPanel/MainWindow/MainWindow.Presets.cs
@@ -688,7 +688,18 @@ namespace ConditioningControlPanel
         }
         
         private bool ShowStyledDialog(string title, string message, string yesText, string noText)
+            => ShowStyledDialog(title, message, yesText, noText, null, out _);
+
+        /// <summary>
+        /// Same dialog with an optional "Don't ask me again"-style checkbox between the message
+        /// and the buttons. <paramref name="checkboxChecked"/> is false when no checkbox is shown.
+        /// Callers must only act on it when this returns true - the box's state is meaningless
+        /// if the user cancelled.
+        /// </summary>
+        private bool ShowStyledDialog(string title, string message, string yesText, string noText,
+            string? checkboxText, out bool checkboxChecked)
         {
+            checkboxChecked = false;
             var dialog = new Window
             {
                 Title = title,
@@ -746,6 +757,22 @@ namespace ConditioningControlPanel
                 Margin = new Thickness(0, 0, 0, 20)
             });
             
+            // Optional "don't ask me again" checkbox
+            CheckBox? optOutBox = null;
+            if (!string.IsNullOrEmpty(checkboxText))
+            {
+                optOutBox = new CheckBox
+                {
+                    Content = checkboxText,
+                    Foreground = Brushes.White,
+                    FontSize = 12,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 0, 0, 15),
+                    Cursor = Cursors.Hand
+                };
+                mainStack.Children.Add(optOutBox);
+            }
+
             // Buttons
             var buttonPanel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Center };
             
@@ -789,6 +816,7 @@ namespace ConditioningControlPanel
             dialog.Content = border;
             dialog.ShowDialog();
 
+            checkboxChecked = optOutBox?.IsChecked == true;
             return result;
         }
 
@@ -1960,14 +1988,32 @@ namespace ConditioningControlPanel
             }
             else
             {
-                // Confirm pause (costs XP)
-                var confirmed = ShowStyledDialog(
-                    Loc.Get("title_pause_session_confirm"),
-                    Loc.GetF("msg_pause_session_body", _sessionEngine.XPPenalty, _sessionEngine.XPPenalty + 100),
-                    Loc.Get("btn_yes_pause"), Loc.Get("btn_keep_going"));
+                // Confirm pause (costs XP) - unless the user ticked "don't ask me again" on a
+                // previous pause, in which case we go straight through.
+                bool confirmed;
+                bool dontAskAgain = false;
+                if (App.Settings.Current.SkipPauseXpWarning)
+                {
+                    confirmed = true;
+                }
+                else
+                {
+                    confirmed = ShowStyledDialog(
+                        Loc.Get("title_pause_session_confirm"),
+                        Loc.GetF("msg_pause_session_body", _sessionEngine.XPPenalty, _sessionEngine.XPPenalty + 100),
+                        Loc.Get("btn_yes_pause"), Loc.Get("btn_keep_going"),
+                        Loc.Get("chk_dont_ask_again"), out dontAskAgain);
+                }
 
                 if (confirmed)
                 {
+                    // Only remember the opt-out when the pause actually happened.
+                    if (dontAskAgain)
+                    {
+                        App.Settings.Current.SkipPauseXpWarning = true;
+                        App.Settings.Save();
+                    }
+
                     _sessionEngine.PauseSession();
                     if (TxtPauseIcon != null) TxtPauseIcon.Text = "▶";
                     BtnPauseSession.ToolTip = Loc.Get("tooltip_resume_session");

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -214,6 +214,16 @@ namespace ConditioningControlPanel.Models
             }
         }
 
+        // "Don't ask me again" for the pause-costs-XP confirmation on a running session.
+        // Only ever set from the dialog itself, and only when the user actually confirmed the
+        // pause - ticking the box and then cancelling must not silently arm the skip.
+        private bool _skipPauseXpWarning = false;
+        public bool SkipPauseXpWarning
+        {
+            get => _skipPauseXpWarning;
+            set { _skipPauseXpWarning = value; OnPropertyChanged(); }
+        }
+
         // Remote-control emote slots (5 fixed, user-editable). OnDeserialized
         // pads or truncates to exactly 5 so the UI never has to defend against
         // odd counts. Default set lives in DefaultRemoteEmotePresets() below.


### PR DESCRIPTION
The pause-session confirmation (100 XP penalty warning) now has a "Don't ask me again" checkbox.

- `Models/AppSettings.cs`: new `SkipPauseXpWarning` bool (default false)
- `MainWindow.Presets.cs`: `ShowStyledDialog` gets an optional-checkbox overload; old signature forwards, all 44 other callers untouched. Pause click skips the dialog when the flag is set; flag persists only if the box is ticked AND the user confirms the pause
- `Localization/Languages/*.json`: `chk_dont_ask_again` in all 9 files (strict-JSON verified, one line each)

Build: 0 CS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnpDoiEJVni4xVVFyPRdUL