### PR TITLE
fix(arcademy): EMI asks hold the bubble until answered, a visible Send, and 35 percent more hang time

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2253,6 +2253,68 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     Sitting behind all of it: **a phone viewport is a merge gate** (section 6). Every one
     of these was invisible at 1600x900 and obvious in the first 844x390 shot.
 
+104. **AN ASK IS A BUBBLE THAT IS WAITING FOR YOU, AND THE SAY LAW ALONE CANNOT
+    PROTECT ONE (owner bug 2026-08-25: "the how can I call you prompt got removed
+    because I think I triggered another speech").** widget.js's law 3 is "a protected
+    chain refuses to be replaced by an UNPROTECTED one" - and every line EMI says is
+    protected, so a bark landing thirty seconds into a question walked straight over it.
+    The question text was replaced, the chips stayed, and the first click the player made
+    to get rid of the orphaned strip dismissed the ask for free. **An ask therefore
+    raises a second, higher fence:** `askOwnsGlass()` is true from the question's own
+    `emi.say(q, {ask:true})` until `unmountAsk()`, a later SAY is parked in ONE slot and
+    released afterwards if it is still worth saying (`ASK_QUEUE_MS`, 8s), and every other
+    reaction - a raw face, a chain, an emote, `force` and all - is refused outright.
+    Four things fall out of it and each one was its own half-bug:
+    - **THE HOLD OPENS WITH THE LINE, NOT WITH THE STRIP.** The chips land
+      `STRIP_LEAD_MS` (1560ms) after the question does, and that gap is the window the
+      owner's bug actually fell through. `mountAsk` therefore calls `dropStrip()` - the
+      half WITHOUT the release - so clearing a previous strip on the way in cannot take
+      down the question that is landing.
+    - **THE QUESTION HAS NO AUTO-HIDE AT ALL.** `GIVE_UP_MS` is **0**, which is not
+      "expire immediately" but "she waits": the hold handed to the say is an hour
+      (`DIALS.ASK_HOLD_MS`, a large FINITE number because `chains.js makeSay` does
+      `holdMs | 0` and `Infinity | 0` is a 400ms flash), and `releaseAskLine()` is the
+      only thing that ever ends it. The player cannot be trapped by that - any press
+      anywhere is a free dismiss - and there is exactly ONE carve-out: the dares still
+      leave after `DARE_GIVE_UP_MS`, because trap 97 says a strip may not be sitting over
+      a board that is about to take input.
+    - **THE 220ms LEAVE ANIMATION CANNOT RIDE `later()`.** Every resolution an ask has is
+      followed in the same tick by her reaction to it, and a reaction runs `killTimers()`.
+      The drop timer went with it, so `.out` faded the strip to opacity 0 and left a node
+      with two `pointer-events:auto` chips over the board for the rest of the sitting -
+      trap 59's failure mode, and invisible in every screenshot. It has its own handle.
+    - **AN INTERRUPTED ASK IS NOT AN ANSWERED ONE, AND `a14_name` PAID FOR THAT TWICE.**
+      A press records nothing (trap 96), so an interrupted question simply vanished; it
+      now comes back once a sitting on the next `idlePlayer` or the next firing of its own
+      trigger (`S.reask`, dares excluded for the reason above). And the name ask's window
+      was `sessions === 3` **exactly**, so one stray click on session three meant EMI
+      could never learn your name on that save. It is `>= 3` while unanswered now, held
+      off by a once-a-sitting latch the way a15's `bedAsked` is.
+    The one display string she renders (the Send button's label, `emi_ask_send`) is
+    resolved by **shell.js** and handed to `mountEmi` as `strings.askSend`: no lexicon
+    reaches EMI, and this did not change that.
+
+    Two more the phone shot found, both of them trap 61's heuristic coming due:
+    - **THE BUBBLE'S EAR TEST IS SIZED OFF HER BODY, AND THE PHONE PAIR DOES NOT FIT
+      IT.** `faceBubble`'s reach is `left + w * 1.55`, where `w` is EMI's WIDTH -
+      calibrated for the desktop pair (150px EMI, 104px box). A phone runs an 86px EMI
+      beside a box allowed `min(72vw, 168px)`, so the correct ear still left "what do i
+      call you?" 75px off the right edge at 844x390. The bubble now gets the same
+      MEASURED pull-back the strip has had (`--emi-bubble-cx`, on `left`, never on
+      `transform` - `.emi-bubble.pop` animates the transform and would out-rank an
+      inline one for its whole 280ms).
+    - **AND IT HAS TO BE MEASURED WITH `offsetWidth`, NOT WITH A RECT.** That same pop
+      is a scale keyframe, and `getBoundingClientRect` reports the TRANSFORMED box
+      (trap 74's twin half). A rect read on the frame the line lands measures the box
+      at about 60% and produces a clamp a sixth of the size it should be - which is
+      exactly what the first attempt shipped, and it looked almost right.
+
+    **The suite: `scratchpad/emihold/test-askhold.mjs`, 117 assertions**, real widget +
+    real asks.js + real chains.js over the DOM double and a VIRTUAL CLOCK (an hour-long
+    hold cannot be asserted on the wall clock). `before-probe.mjs` beside it is the
+    before/after: point its `arc/` at main and watch "rough day?" become "you came back."
+    with the chips still up.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/lexicon.js
@@ -401,6 +401,12 @@ export const DEFAULT_LEXICON = Object.freeze({
      re-voices the whole beat. The room this walks to is the Front Office and it
      is NEVER named in any of them. */
   orientation_kicker: 'Orientation Day',
+  /* EMI ASKS: the Send button on the one question with a keyboard (a14, "what
+     do i call you?"). The ONLY display string EMI renders - her questions,
+     chips and reactions are all VERBATIM content and never pass through t().
+     shell/shell.js resolves it and hands the answer to mountEmi. Her voice is
+     lowercase, so this row is too. */
+  emi_ask_send: 'send',
   emi_orientation_hi: 'a new student! i did a little spin. you missed it.',
   emi_orientation_card: "official! now you have to come back. it's the rules.",
   emi_orientation_go: "go! your first class doesn't know how lucky it is.",

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/asks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/asks.js
@@ -15,7 +15,18 @@
  *                (trap 70: the voice hangs off setBubble and nowhere else).
  *   the strip    two chips under the bubble, inside `.emi` (the widget mints
  *                and owns the node; this file only says what goes on it).
- *   the end      a chip click, a dismiss, or she gives up after 40s.
+ *   the end      a chip click or a dismiss. SHE DOES NOT GIVE UP any more
+ *                (owner, 2026-08-25): the question has no auto-hide and the
+ *                bubble stays in sight until it is answered. The one exception
+ *                is the dares, which ride `classStart` and must be off the
+ *                glass before the board takes input (trap 97).
+ *
+ * AND SHE CANNOT BE TALKED OVER. From the moment the question lands until the
+ * strip comes down, the widget holds the glass for her: a later SAY is parked
+ * in one slot and released afterwards if it is still worth saying, and every
+ * other reaction is refused. That fence is widget.js's (`askOwnsGlass`), and
+ * it is what trap 104 is about - the ask's own line carries `ask: true` and is
+ * the only thing that may cross it.
  *
  * THE IGNORED PATH IS WORDLESS AND UNIVERSAL. Chips slide out, `-_-` holds
  * 1400, the bubble says `...`, then idle. No line, ever. Silence is on-lock:
@@ -58,7 +69,7 @@
 /* THE SAY CADENCE IS THE WIDGET'S (voice.js's import, for the same reason):
  * the strip has to land WITH the line, not with the typing dots, so this file
  * needs to know how long the run-up actually is. */
-import { SAY_LEAD_MS, sanitizeAskName } from './widget.js';
+import { SAY_LEAD_MS, sanitizeAskName, DIALS as WIDGET_DIALS } from './widget.js';
 
 /* ONE SANITISER, TWO READERS. widget.js owns it because widget.js is the file
  * that reads the stored `emi` blob back on boot; re-exported here so the ask
@@ -72,8 +83,27 @@ export const ASK_DIALS = Object.freeze({
   CADENCE_MIN_SESSIONS: 2,    // ...and the short one, on a roll
   CADENCE_ROLL: 1 / 3,        // ...the roll
   ASKS_PER_SESSION: 1,        // gate 5 (the NAME ask is over and above it)
-  GIVE_UP_MS: 40000,          // she waits this long, then gives up wordlessly
-  DARE_GIVE_UP_MS: 12000,     // ...but a dare lives on the room card, not the board
+  /* SHE DOES NOT GIVE UP (owner, 2026-08-25: "when EMI asks us something we
+   * need to keep the bubble in sight till we respond"). Zero is not "expire
+   * immediately", it is NO AUTO-HIDE: the question and its chips stay on the
+   * glass until they are answered or dismissed, and the player can never be
+   * trapped by that because ANY press anywhere is a free dismiss (see the
+   * header). It was 40000 through the EMI ASKS wave. */
+  GIVE_UP_MS: 0,
+  /* ...WITH ONE CARVE-OUT, AND IT IS TRAP 97's. A dare is offered on
+   * `classStart`, one beat before a board takes input; a strip that sat there
+   * would be a pointer-active node over a live precision board (trap 59). So
+   * the dares alone still leave, and they leave fast. */
+  DARE_GIVE_UP_MS: 12000,
+  /* HOW LONG THE QUESTION ITSELF HOLDS. Not a timeout - widget.js's
+   * ASK_HOLD_MS is an hour, and `releaseAskLine()` is what actually takes it
+   * down. Read from the widget so there is one number, not two. */
+  HOLD_MS: WIDGET_DIALS.ASK_HOLD_MS,
+  /* AN INTERRUPTED ASK COMES BACK, ONCE. A press, a pet, a drag or a docking
+   * is not an answer and not a refusal, so the question is owed one more go on
+   * the next quiet moment of the same sitting. One, so a player who keeps
+   * clicking past her is never nagged into a third. */
+  REASK_MAX: 1,
   IGNORED_HOLD_MS: 1400,      // -_- , then `...` , then idle
   /* THE STRIP LANDS WITH THE LINE, not with the typing dots - so its lead IS
    * the say ladder's run-up. A dial and not a constant only so a suite can
@@ -82,7 +112,7 @@ export const ASK_DIALS = Object.freeze({
   /* HOW LONG A LANDED LINE OWNS THE GLASS, near enough. Anything this file
    * schedules AFTER one of her lines waits STRIP_LEAD_MS + this, so a follow-up
    * never lands on a bubble that is still up (trap 72s lesson). */
-  AFTER_SAY_MS: 3400,
+  AFTER_SAY_MS: 4590,         // (3400 x 1.35 - it tracks the bubble hold, 2026-08-25)
   NAME_MAX: 8,                // a14: 8 characters, sanitised
   NAME_REASK_AFTER: 10,       // a skipped name is asked once more, this many later
   BED_SKIPS_GROGGY: 3,        // three skipped "bed?"s in a row buys the groggy greet
@@ -265,11 +295,19 @@ export const ASKS = Object.freeze([
     /* NO `once` HERE, deliberately: the whole re-ask ladder (asked at 3, one
      * more try ten sittings after a skip, then never) is in `when`, and a
      * `once` gate on top of it would wall off the second try. */
-    /* Session 3 exactly; a skip re-opens it once, ten sessions later, and then
-     * never again (`n >= 2` is the wall). */
+    /* Session 3 ONWARDS while it has never been answered; a skip re-opens it
+     * once, ten sessions later, and then never again (`n >= 2` is the wall).
+     *
+     * IT WAS `=== ASK_FROM_SESSION` UNTIL 2026-08-25 AND THAT WAS THE ONE-SHOT
+     * BUG. Nothing is written to the ledger when an ask is INTERRUPTED (a
+     * press spends no cadence and records no answer - trap 96), so a name ask
+     * that a stray click took away left `answerOf` empty, session 3 never came
+     * round again, and she could never learn your name on that save. `>=` is
+     * the whole fix; the nagging it would otherwise buy is held off by
+     * `S.nameAsked`, which is once a SITTING the way a15's `bedAsked` is. */
     when: (c) => {
       const prev = c.answerOf('a14_name');
-      if (!prev) return c.sessions === ASK_DIALS.ASK_FROM_SESSION;
+      if (!prev) return c.sessions >= ASK_DIALS.ASK_FROM_SESSION;
       if (prev.a === 'yes' || intOf(prev.n) >= 2) return false;
       return c.sessions - intOf(prev.s) >= ASK_DIALS.NAME_REASK_AFTER;
     },
@@ -362,6 +400,9 @@ export function createAsks(o = {}) {
     soft: false,           // a01 yes: comfort faces + the extra report line
     softLineSpent: false,
     bedAsked: false,       // a15 is once a sitting
+    nameAsked: false,      // ...and so is a14, now that its window is open-ended
+    reask: null,           // the id of an ask a press took away, owed one more go
+    reasks: 0,             // ...and how many have been paid back (cap D.REASK_MAX)
     dare: null,            // {kind, gameKey} - flagged on the NEXT class
     dareSpent: false,      // one dare a session, win or lose
     groggySpent: false,
@@ -453,6 +494,7 @@ export function createAsks(o = {}) {
       if (a.on !== name) continue;
       if (spent(a, c)) continue;
       if (a.id === 'a15_bed' && S.bedAsked) continue;
+      if (a.id === 'a14_name' && S.nameAsked) continue;
       if (a.dareKind || (a.yes && a.yes.dare)) { if (S.dareSpent || S.dare) continue; }
       if (typeof a.when === 'function') {
         let ok = false;
@@ -493,10 +535,30 @@ export function createAsks(o = {}) {
     try { widget.unmountAsk(slide !== false); } catch (e) { /* noop */ }
   }
 
+  /**
+   * SHE IS OWED ONE MORE GO (owner, 2026-08-25). An ask that a press, a pet, a
+   * drag or a docking took off the glass was neither answered nor declined -
+   * it was INTERRUPTED - and the ledger records nothing for it (trap 96), so
+   * without this the question is simply gone for the rest of the sitting. It
+   * comes back on the next quiet moment instead.
+   *
+   * NOT THE DARES. Their whole window is the room card, one beat before a
+   * board takes input (trap 97); an idle moment is the wrong side of it, and a
+   * dare armed off a moment with no class behind it would resolve against
+   * whatever the player happened to play next.
+   */
+  function rememberReask(a) {
+    if (!a || S.reask) return;
+    if (S.reasks >= D.REASK_MAX) return;
+    if (a.on === 'classStart' || (a.yes && a.yes.dare)) return;
+    S.reask = a.id;
+  }
+
   /** THE UNIVERSAL WORDLESS END. No line, ever - see the header. */
   function ignored(a, c, opts) {
     const noSpend = !!(opts && opts.noSpend);
     unmount(true);
+    if (noSpend) rememberReask(a);
     if (!noSpend) record(keyFor(a, c), 'ignored');
     /* ...AND A PRESS IS NOT A SKIPPED BEDTIME EITHER. She only loses the sleep
      * when the question sat there unanswered; a player who was doing something
@@ -588,12 +650,14 @@ export function createAsks(o = {}) {
   function mount(a, c) {
     const chips = Array.isArray(a.chips) ? a.chips.slice(0, 2) : ['ok', 'nah'];
     const giveUp = giveUpMsFor(a);
-    /* THE LINE FIRST, AND IT HOLDS FOR THE WHOLE ASK. `sayHoldMs` treats an
-     * explicit hold as a FLOOR it may raise and never lower, so handing it the
-     * give-up window is what keeps the question on the glass under the chips
-     * instead of expiring three seconds in. */
+    /* THE LINE FIRST, AND IT DOES NOT COME DOWN ON ITS OWN. `ask: true` is the
+     * flag widget.js reads: it opens the hold that keeps every later bark off
+     * the glass (trap 104) and it hands the question a hold nothing but
+     * `unmountAsk()` can end. Until 2026-08-25 the hold was the GIVE-UP window,
+     * which meant a question with no give-up would have flashed for three
+     * seconds and a later line could walk over it at any point. */
     let spoke = false;
-    try { spoke = !!emi.say(a.q, { face: a.face || 'o_o', hold: giveUp }); }
+    try { spoke = !!emi.say(a.q, { face: a.face || 'o_o', hold: D.HOLD_MS, ask: true }); }
     catch (e) { spoke = false; }
     if (!spoke) return false;
 
@@ -620,16 +684,22 @@ export function createAsks(o = {}) {
       } catch (e) { strip = null; }
       if (!strip) { unmount(false); return; }
       live.strip = strip;
-      live.giveUp = setTimeout(() => {
-        if (!live || live.ask !== a) return;
-        live.giveUp = null;
-        ignored(a, c);
-      }, giveUp);
+      /* ZERO IS "SHE WAITS" (D.GIVE_UP_MS). Only the classStart carve-out arms
+       * a timer at all, and it is the one ask that must be off the glass
+       * before a board goes live. */
+      if (giveUp > 0) {
+        live.giveUp = setTimeout(() => {
+          if (!live || live.ask !== a) return;
+          live.giveUp = null;
+          ignored(a, c);
+        }, giveUp);
+      }
     };
     if (D.STRIP_LEAD_MS > 0) later(raise, D.STRIP_LEAD_MS); else raise();
 
     if (!a.exempt) S.asked += 1;
     if (a.id === 'a15_bed') S.bedAsked = true;
+    if (a.id === 'a14_name') S.nameAsked = true;
     say('emi asks: ' + a.id);
     return true;
   }
@@ -656,14 +726,25 @@ export function createAsks(o = {}) {
   const onDocKey = (ev) => {
     if (!live || !ev) return;
     const k = String(ev.key || '');
+    /* THE FIELD'S KEYS COME FIRST, AND THAT ORDER IS THE FIX. `1` and `2` are
+     * the chip shortcuts below, but they are also two of the eight characters
+     * a name may be made of - typing "player1" into a14's field used to SUBMIT
+     * on the last keystroke. A question with a keyboard has no chip shortcuts;
+     * it has a field, a Send button and Enter. */
+    if (live.ask && live.ask.input) {
+      if (k === 'Tab' || k === 'Enter' || k === ' ') return;
+      if (k.length === 1) return;                            // typing a name
+      if (k === 'Backspace' || k === 'Delete') return;
+      if (k === 'ArrowLeft' || k === 'ArrowRight' || k === 'Home' || k === 'End') return;
+      ignored(live.ask, live.ctx, { noSpend: true });
+      return;
+    }
     /* THE KEYBOARD REACH (spec): 1 and 2 pick the chips. Anything else is a
      * player doing something else, and that is a dismiss. */
     if (k === '1' || k === '2') {
       if (live.strip && typeof live.strip.pick === 'function') { live.strip.pick(k === '1' ? 0 : 1); return; }
     }
     if (k === 'Tab' || k === 'Enter' || k === ' ') return;   // focus + activate
-    if (live.ask && live.ask.input && k.length === 1) return; // typing a name
-    if (live.ask && live.ask.input && (k === 'Backspace' || k === 'Delete')) return;
     ignored(live.ask, live.ctx, { noSpend: true });
   };
   if (typeof document !== 'undefined' && document.addEventListener) {
@@ -675,8 +756,12 @@ export function createAsks(o = {}) {
   const unGesture = typeof widget.onGesture === 'function'
     ? widget.onGesture((kind) => {
       if (!live) return;
+      /* `gone` is the x button, an API hide and `setEnabled(false)` - the
+       * screen changes that legitimately kill her. It spends nothing, exactly
+       * like the presses, and it is what closes the ask when the question goes
+       * away with the mascot rather than with an answer. */
       if (kind === 'pet' || kind === 'petStreak3' || kind === 'drag'
-        || kind === 'fling' || kind === 'dropAt' || kind === 'hide') {
+        || kind === 'fling' || kind === 'dropAt' || kind === 'hide' || kind === 'gone') {
         ignored(live.ask, live.ctx, { noSpend: true });
       }
     })
@@ -809,6 +894,27 @@ export function createAsks(o = {}) {
 
       const c = context(name, payload);
       if (name === 'reportCard' && softLine()) return false;
+
+      /* THE INTERRUPTED ASK COMES BACK FIRST (owner, 2026-08-25). It is not a
+       * new question, so it jumps the eligibility roll and the cadence - but
+       * every LIVE gate above still had to pass, and its own `when` is
+       * re-checked, because the world moved while she was waiting. It rides
+       * the next `idlePlayer` (the quiet moment the owner asked for) or the
+       * next firing of its own trigger, whichever comes first. */
+      const back = S.reask ? (TABLE.find((a) => a.id === S.reask) || null) : null;
+      if (S.reask && !back) S.reask = null;
+      if (back && (name === 'idlePlayer' || name === back.on)) {
+        S.reask = null;
+        let ok = !spent(back, c);
+        if (ok && typeof back.when === 'function') {
+          try { ok = !!back.when(c); } catch (e) { ok = false; }
+        }
+        if (ok) {
+          S.reasks += 1;
+          say('emi asks: ' + back.id + ' comes back (interrupted)');
+          return mount(back, c);
+        }
+      }
 
       const list = eligible(name, c);
       if (!list.length) return false;

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/index.js
@@ -163,7 +163,7 @@ export function voiceMoment(name, payload) {
  * @param {Function=} o.log
  * @returns {Object|null} the controller, or null when there is nothing to mount
  */
-export function mountEmi({ layer, store, toast, enabled = true, log, assets, settings } = {}) {
+export function mountEmi({ layer, store, toast, enabled = true, log, assets, settings, strings } = {}) {
   const say = typeof log === 'function' ? log : () => {};
   if (!layer) return null;
   if (singleton) return singleton;
@@ -172,7 +172,12 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
    * is `init.settings`. NOW WATCHING is the only thing in EMI that wants
    * either, and both are optional - a host that hands neither simply plans that
    * channel out of the wheel (never a stub, never a black glass). */
-  const widget = createWidget({ root: layer, store, toast, log: say, assets, settings });
+  /* `strings` is the SHELL's resolved lexicon rows - today exactly one,
+   * `askSend`. EMI has never imported core/lexicon.js and this does not change
+   * that: the side of the page that has `t` does the resolving and hands the
+   * ANSWER down, the way shell/orientation.js already hands her three lines
+   * over as `payload.line`. */
+  const widget = createWidget({ root: layer, store, toast, log: say, assets, settings, strings });
   if (!widget) return null;
 
   /* THE OPENING BEAT LANDS LATE OR NOT AT ALL. The renderer is one dynamic
@@ -253,7 +258,7 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
      * is. `opts.hold` still wins when it asks for MORE; it can never ask for
      * less. The typing cadence is untouched.
      * @param {string} line
-     * @param {{face?:string, hold?:number, nod?:boolean}=} opts
+     * @param {{face?:string, hold?:number, nod?:boolean, ask?:boolean}=} opts
      */
     say(line, opts) {
       const o = opts || {};
@@ -280,7 +285,11 @@ export function mountEmi({ layer, store, toast, enabled = true, log, assets, set
       try { chain = make(line, o.face || '^_^', sayHoldMs(line, o.hold)); }
       catch (e) { say('emi: makeSay threw - ' + ((e && e.message) || e)); return false; }
       if (o.nod) chain = Object.assign({}, chain, { body: 'nod' });
-      return widget.play(chain, { protect: true, force: true });
+      /* `ask` IS THE ONE LINE THAT OUTRANKS A LIVE ASK, because it IS the ask
+       * (emi/asks.js is its only caller). Everything else offered while she is
+       * waiting is held or refused - see widget.js's ask-owns-the-glass block
+       * and trap 104. */
+      return widget.play(chain, { protect: true, force: true, ask: o.ask === true });
     },
 
     /** Back to the resting state (0_0 + blink + breath). */

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.css
@@ -91,11 +91,19 @@
  * counts it on both sides of its reach test, so the extra 15px can never push
  * the mirrored line back off the edge the flip exists to stay clear of. */
 .arc-emi .emi .emi-bubble {
-  left: calc(58% + var(--emi-bubble-dx, 15px));
+  /* `--emi-bubble-cx` is widget.js's MEASURED viewport clamp - the same one
+     the ask strip gets, for the same reason. The reach test that picks
+     `.bubble-left` is a heuristic sized against the desktop pair (a 150px EMI,
+     a 104px box); on a phone the pair is 86 and 168 and a long line hangs off
+     the window edge even after the flip. The clamp is on `left`, never on
+     `transform`, because `.emi-bubble.pop` animates the transform and would
+     out-rank an inline one for the whole 280ms of its landing. */
+  left: calc(58% + var(--emi-bubble-dx, 15px) + var(--emi-bubble-cx, 0px));
 }
 .arc-emi .emi.bubble-left .emi-bubble {
   left: auto;
-  right: calc(58% + var(--emi-bubble-dx, 15px));
+  /* MIRRORED, so the clamp's sign is too: this edge is anchored from the right. */
+  right: calc(58% + var(--emi-bubble-dx, 15px) - var(--emi-bubble-cx, 0px));
   text-align: right;
   transform-origin: 100% 100%;
 }
@@ -159,7 +167,11 @@
   flex-wrap: wrap;
   gap: 4px;
   width: max-content;
-  max-width: 148px;
+  /* 148 fitted the two-chip pair exactly. a14's row is THREE things now
+     (field, Send, out) and 148 broke the out chip onto a line of its own, so
+     the box gets the 48px that keeps one question on one row. A two-chip strip
+     is unchanged: the width is `max-content` and only the cap moved. */
+  max-width: 196px;
   z-index: 4;
   pointer-events: none;
   transform-origin: 0 100%;
@@ -224,6 +236,11 @@
   border-color: #FF69B4;
 }
 .arc-emi .emi .emi-chip-field:hover { background: #F5F0E1; color: #1A1A2E; }
+/* a14's SEND. It is chip ONE, so it wears chip one's pink - the `+ .emi-chip`
+   rule above would otherwise hand it the lavender that belongs to the OUT
+   chip, and the pair would read backwards. */
+.arc-emi .emi .emi-chip.emi-chip-send { border-color: #FF69B4; }
+.arc-emi .emi .emi-chip.emi-chip-send:hover { background: #FF69B4; color: #F5F0E1; }
 
 @keyframes emi-ask-in {
   from { opacity: 0; transform: translate(var(--emi-ask-dx, 0px), 6px); }
@@ -245,8 +262,23 @@
 :root.arc-reduced .arc-emi .emi .emi-ask.out { animation: none; }
 :root.arc-reduced .arc-emi .emi .emi-chip:active { transform: none; }
 
-/* The phone gets the same rope the bubble does (see THE PHONE CLAMP below). */
-:root.arc-mobile .arc-emi .emi .emi-ask { max-width: min(72vw, 200px); }
+/* The phone gets the same rope the bubble does (see THE PHONE CLAMP below) -
+   widened on 2026-08-25 because a14's row is now three things (field, send,
+   out) and 200px wrapped the out chip onto a line of its own. */
+:root.arc-mobile .arc-emi .emi .emi-ask { max-width: min(84vw, 248px); }
+/* THE 44px FLOOR IS THE ONLY REASON THIS BLOCK EXISTS. A chip is 8px Press
+   Start 2P in a 5px/7px box - about 22px tall, which is a fine mouse target
+   and half of what a thumb needs. On a phone the box grows to the platform
+   floor and the TEXT does not, because the pixel grid is absolute (trap 62):
+   the padding does the work. `box-sizing` is set here rather than inherited
+   because a border-box chip would eat the min-height with its own 2px border. */
+:root.arc-mobile .arc-emi .emi .emi-chip {
+  box-sizing: border-box;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 6px 10px;
+}
+:root.arc-mobile .arc-emi .emi .emi-chip-field { width: 88px; }
 
 /* ---- the dock -----------------------------------------------------------
  * Where a dismissed EMI lives. Semi-transparent so it never competes with the

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/widget.js
@@ -89,9 +89,32 @@ export const DIALS = Object.freeze({
   /* --- the speech bubble ------------------------------------------------ */
   BUBBLE_SHIFT_X: 15,      // px further off her ear (owner, 2026-08-24). Mirrored
                            // by `.bubble-left` and paid for in faceBubble's reach.
-  SAY_HOLD_MIN_MS: 3000,   // a landed line NEVER holds less than this...
-  SAY_HOLD_BASE_MS: 1400,  // ...and a long one grows: BASE + PER_CHAR x length
-  SAY_HOLD_PER_CHAR_MS: 45,
+  /* HOW LONG A LANDED LINE HANGS. Every one of these three was multiplied by
+   * 1.35 on 2026-08-25 (owner: "increase the persistence time of the bubble in
+   * general, +35%") - floor 3000 -> 4050, base 1400 -> 1890, per-character
+   * 45 -> 61. They are scaled HERE, at the source, because `sayHoldMs` is the
+   * one function that turns a line into a hold and every call site in the page
+   * goes through it; scaling at a call site would have moved some lines and
+   * not others. There is deliberately no ceiling: the growth is linear in the
+   * line and her longest bark is under 120 characters, so a cap would only
+   * ever fire on a line nobody has written yet. */
+  SAY_HOLD_MIN_MS: 4050,   // a landed line NEVER holds less than this...
+  SAY_HOLD_BASE_MS: 1890,  // ...and a long one grows: BASE + PER_CHAR x length
+  SAY_HOLD_PER_CHAR_MS: 61,
+  /* AN ASK IS NOT AN ORDINARY LINE AND HAS NO AUTO-HIDE AT ALL (owner,
+   * 2026-08-25: "keep the bubble in sight till we respond"). The question is
+   * handed this as its hold, and the only thing that ever takes it down is the
+   * strip's own end - an answer, a dismiss, or a screen that kills her. It is
+   * a large FINITE number and not Infinity because `chains.js makeSay` does
+   * `holdMs | 0`, which turns Infinity into 0 and the whole question into a
+   * 400ms flash. One hour is longer than any sitting and still inside int32.
+   * The timer it arms is owned: `releaseAskLine()` cancels it. */
+  ASK_HOLD_MS: 3600000,
+  /* A LINE THAT ARRIVED WHILE SHE WAS WAITING gets ONE slot and this long to
+   * be worth saying. Past it the moment has gone and the line is dropped -
+   * the same trade `index.js`'s VOICE_PENDING_MS makes for the opening beat. */
+  ASK_QUEUE_MS: 8000,
+  ASK_QUEUE_POLL_MS: 250,  // ...and how often the released line re-tries a busy glass
 
   /* --- the field trip (wave W2a) --------------------------------------- */
   CRT_MS: 200,             // ONE power-off: squish to a line (~140) + flash dot (~60).
@@ -189,8 +212,11 @@ export function frameForFace(text) {
 
 /**
  * HOW LONG A LANDED LINE STAYS UP (owner ruling 2026-08-24: "3 sec, or more
- * according to length"). The typing cadence is UNCHANGED - `. .. ...` still
- * runs 420/420/520 and the clear frame is still 200 - only the hold grows.
+ * according to length", re-scaled x1.35 on 2026-08-25). The typing cadence is
+ * UNCHANGED - `. .. ...` still runs 420/420/520 and the clear frame is still
+ * 200 - only the hold grows. Before/after, for the record: the floor is
+ * 3000 -> 4050ms, a 20-character line 3000 -> 4050 (still the floor), a
+ * 40-character line 3200 -> 4330, an 80-character line 5000 -> 6770.
  * An explicit ask from a caller wins when it is LONGER; it can never pull a
  * line back under the floor.
  */
@@ -267,6 +293,9 @@ function readStats(raw) {
  * collapse the runs -> 8 characters. An empty answer is a SKIP, never an empty
  * name - `emi.name` is either a real string or absent. */
 export const ASK_NAME_MAX = 8;
+/** The Send button's shipped English. The live label comes from the SHELL,
+ *  which resolves `emi_ask_send` through the lexicon (see createWidget). */
+export const ASK_SEND_LABEL = 'send';
 export function sanitizeAskName(raw) {
   if (typeof raw !== 'string') return '';
   let s = raw.toLowerCase().replace(/[^a-z0-9 ]+/g, '');
@@ -318,8 +347,18 @@ function readAskState(raw) {
  * @param {Function=} o.toast         the SHELL's toast (boot.js -> createShell's `shout`)
  * @param {Function=} o.log
  */
-export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, log, assets, settings } = {}) {
+export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, log, assets, settings, strings } = {}) {
   const say = typeof log === 'function' ? log : () => {};
+  /* THE ONE DISPLAY STRING EMI HAS EVER BEEN HANDED, AND IT ARRIVES RESOLVED.
+   * No lexicon reaches EMI (emi/moments.js's law, and emi/channels.js says it
+   * out loud) - the SHELL has `t` and hands the answer down, exactly the way
+   * shell/orientation.js hands her three lines over as `payload.line`. The
+   * fallback is the shipped English so a host that passes nothing still gets a
+   * labelled button rather than an empty one. */
+  const ASK_STRINGS = Object.freeze({
+    send: (strings && typeof strings.askSend === 'string' && strings.askSend.trim())
+      ? strings.askSend.trim() : ASK_SEND_LABEL,
+  });
   /* OFF CHANNELS (W3): the two things NOW WATCHING needs and nothing else in
    * this file does - the shell's provider handle (media through the HOST, the
    * only remote path this bundle has) and `init.settings` (the player's own
@@ -710,6 +749,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
      * reach test is - measured, because a strip is wider than a bark and the
      * reach heuristic above was calibrated for a 104px box. */
     clampAskStrip();
+    clampBubble();
   }
 
   /** Record the CURRENT pixel position back into the fractions. */
@@ -778,11 +818,53 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
    * cancel path in this file funnels through the `null` branch, so hanging the
    * voice here (and nowhere else) is what makes "dismiss mid-babble cuts her
    * instantly" true by construction instead of by discipline. See trap 70. */
+  /** The bubble's own MEASURED viewport clamp, in px, signed. See widget.css. */
+  function setBubbleCx(px) {
+    try {
+      if (el.style && typeof el.style.setProperty === 'function') {
+        el.style.setProperty('--emi-bubble-cx', Math.round(Number(px) || 0) + 'px');
+      }
+    } catch (e) { /* noop */ }
+  }
+  /**
+   * KEEP THE LINE INSIDE THE WINDOW. `faceBubble`'s reach test picks the EAR
+   * (trap 61) and it is a heuristic scaled off her BODY width - calibrated for
+   * the desktop pair, a 150px EMI beside a 104px box. A phone runs an 86px EMI
+   * beside a box that is allowed 168, so even the correct ear leaves the line
+   * hanging off the edge. This is the same measured pull-back `clampAskStrip`
+   * does for the strip, and it runs when a line LANDS rather than when she
+   * moves, because the width is a property of the sentence.
+   */
+  function clampBubble() {
+    try {
+      if (!bubble || bubble.hidden || !el.getBoundingClientRect) return;
+      setBubbleCx(0);
+      /* IT IS MEASURED OFF `offsetWidth`, NOT off a rect, AND THAT IS THE WHOLE
+       * TRICK. `.emi-bubble.pop` is a 280ms scale keyframe and
+       * `getBoundingClientRect` reports the TRANSFORMED box (trap 74's twin
+       * half), so a rect read on the frame the line lands is the box at ~60%
+       * and the clamp comes out about a sixth of what it should be. The
+       * offset* pair is the LAYOUT box and the pop cannot touch it. */
+      const w = Number(bubble.offsetWidth) || 0;
+      if (!w) return;
+      const er = el.getBoundingClientRect();
+      if (!er) return;
+      const left = Number(er.left) + (Number(bubble.offsetLeft) || 0);
+      const vp = viewport();
+      const pad = 4;
+      let dx = 0;
+      if (left + w > vp.w - pad) dx = Math.round((vp.w - pad) - (left + w));
+      if (left + dx < pad) dx = Math.round(pad - left);
+      setBubbleCx(dx);
+    } catch (e) { /* a clamp may never be the thing that throws */ }
+  }
+
   function setBubble(text) {
     if (text == null || text === '') {
       bubble.hidden = true;
       bubble.textContent = '';
       bubble.classList.remove('dots', 'pop');
+      setBubbleCx(0);
       if (vox) { try { vox.stop(); } catch (e) { /* a voice may never break a bubble */ } }
       return;
     }
@@ -805,6 +887,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
         if (typeof queueMicrotask === 'function') queueMicrotask(speak); else speak();
       }
     }
+    clampBubble();
   }
 
   /* BODY MOVES GO ON THE ROOT. Agent A's keyframes animate `transform` on `.emi`
@@ -856,14 +939,64 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     current = null;
   }
 
+  /* ==========================================================================
+   * AN ASK OWNS THE GLASS UNTIL IT IS ANSWERED (owner bug 2026-08-25: "the how
+   * can I call you prompt got removed because I think I triggered another
+   * speech"). A question is a bubble that is WAITING FOR YOU, and the say law
+   * one line down - a protected chain may be replaced by another protected one
+   * - let any later bark walk straight over it. So an ask raises a second,
+   * higher fence for as long as it is up:
+   *
+   *   a SAY that arrives while she is waiting is HELD (one slot, the newest
+   *   wins) and released when the ask ends, if the moment has not gone stale;
+   *   anything else - a raw face, a chain, an emote - is simply refused, the
+   *   same answer it already gets over a live say.
+   *
+   * The hold is opened by the ask's own line (`opts.ask`) rather than by the
+   * strip, because the question lands STRIP_LEAD_MS before the chips do and
+   * that gap is the window the owner's bug actually fell through. It is closed
+   * in exactly one place, `unmountAsk()`, which is the one function that ends
+   * an ask however it ended. See trap 104.
+   * ======================================================================== */
+  let askHold = false;
+  /** The one line waiting for the ask to finish: {chain, opts, at}. */
+  let heldLine = null;
+  /** Its own handle, NOT a `later()` one: `killTimers()` runs on every play. */
+  let heldTimer = null;
+  function askOwnsGlass() { return askHold || !!askLive; }
+  function dropHeldLine() {
+    heldLine = null;
+    if (heldTimer !== null) { clearTimeout(heldTimer); heldTimer = null; }
+  }
+  /** Give the held line the glass, once the glass is actually free. */
+  function pumpHeldLine() {
+    heldTimer = null;
+    if (!heldLine) return;
+    if (Date.now() - heldLine.at >= DIALS.ASK_QUEUE_MS) { heldLine = null; return; }
+    if (askOwnsGlass()) return;              // she is already waiting on the next one
+    if (busy() || saying()) {                // a reaction line landed first, and it wins
+      heldTimer = setTimeout(pumpHeldLine, DIALS.ASK_QUEUE_POLL_MS);
+      return;
+    }
+    const h = heldLine;
+    heldLine = null;
+    play(h.chain, h.opts);
+  }
+
   /**
    * Run one chain object. A protected chain (a SAY) refuses to be replaced by an
-   * unprotected one - law 3 in the header.
+   * unprotected one - law 3 in the header. A live ASK outranks both.
    * @returns {boolean} true when it started
    */
   function play(chain, opts) {
     const o = opts || {};
     if (!chain || typeof playChain !== 'function' || !painter) return false;
+    if (askOwnsGlass() && !o.ask) {
+      /* ONE SLOT, NEWEST WINS - the same trade emi/index.js makes for the one
+       * moment it buffers. A queue would replay a conversation nobody had. */
+      if (o.protect) heldLine = { chain, opts: Object.assign({}, o), at: Date.now() };
+      return false;
+    }
     if (saying() && !o.protect && !o.force) return false;
     cancelChain();
     killTimers();
@@ -891,7 +1024,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
         idle();
       },
     });
-    current = { handle, protect: !!o.protect };
+    current = { handle, protect: !!o.protect, ask: !!o.ask };
+    if (o.ask) askHold = true;
     return true;
   }
 
@@ -899,6 +1033,11 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
   function raw(text, opts) {
     const o = opts || {};
     if (!painter) return false;
+    /* A FACE IS A REACTION, AND A REACTION TO A MOMENT THAT PASSED IS WORSE
+     * THAN NO REACTION - so this one is refused outright and never queued.
+     * `force` cannot buy past a live ask; the ask engine's own `-_-` runs
+     * AFTER `unmountAsk()` has already closed the hold. */
+    if (askOwnsGlass() && !o.ask) return false;
     if (saying() && !o.force) return false;
     cancelChain();
     killTimers();
@@ -1319,6 +1458,13 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     // next pointerup commit a position read off a display:none element.
     endPress();
     cancelTrip();                    // W2a: dismissed mid-trip = home first, then the dock
+    /* ASKS: A DOCKED EMI IS A SCREEN CHANGE THAT LEGITIMATELY KILLS HER, and it
+     * is the one such change a SILENT (API) hide can make without the ask
+     * engine hearing a gesture - so the strip is taken down here rather than
+     * left hanging inside a `display:none` root. `gone` is what tells the
+     * engine the question ended, and it spends no cadence. */
+    emitGesture('gone', { reason: 'hide' });
+    unmountAsk(false); dropHeldLine();
     cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody(); setBubble(null);
     clearApproachTimers();
     restGaze();
@@ -1999,6 +2145,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
 
   /** {onChip, onDismiss, nodes} while a strip is up; null the rest of the time. */
   let askLive = null;
+  /** The leave animation's own timer - see `dropStrip`. */
+  let askDropTimer = null;
   /** The viewport clamp, in px, shared with the sheet as `--emi-ask-dx`. */
   let askDx = 0;
   function setAskDx(px) {
@@ -2054,13 +2202,15 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
 
   /**
    * MOUNT ONE STRIP. `spec` is asks.js's, and this file understands exactly
-   * five fields: {id, chips[2], input, maxLength, onChip(i, text), onDismiss}.
+   * six fields: {id, chips[2], input, maxLength, onChip(i, text), onDismiss}.
+   * `input:true` turns chip one into a FIELD plus a visible Send button; both
+   * of them, and the Enter key, call `onChip(0, text)`.
    * @returns {?Object} {el, pick(i), destroy()} - null when it could not build.
    */
   function mountAsk(spec) {
     if (!spec || !Array.isArray(spec.chips) || !spec.chips.length) return null;
     if (!enabled || hidden) return null;
-    unmountAsk(false);
+    dropStrip(false);
     try {
       askStrip.textContent = '';
       askStrip.classList.remove('out');
@@ -2089,8 +2239,28 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
         nodes.push(field);
       }
 
+      /* AND THE FIELD NEEDS A BUTTON (owner, 2026-08-25: "we need a send button
+       * visible"). Enter still submits and always did - but Enter is invisible,
+       * and on a phone it is a key on a keyboard that covers the mascot. The
+       * button IS chip one, so it carries `data-chip="0"` and goes through the
+       * same `fireChip(0, text)` the Enter key does: one submit path, and the
+       * suite can press either. It is inserted between the field and the out
+       * chip, which is the reading order the answer is given in. */
+      if (spec.input === true) {
+        const sendBtn = document.createElement('button');
+        sendBtn.className = 'emi-chip emi-chip-send';
+        sendBtn.type = 'button';
+        sendBtn.textContent = ASK_STRINGS.send;
+        if (sendBtn.setAttribute) sendBtn.setAttribute('data-chip', '0');
+        sendBtn.addEventListener('click', () => {
+          fireChip(0, field ? String(field.value || '') : '');
+        });
+        askStrip.appendChild(sendBtn);
+        nodes.push(sendBtn);
+      }
+
       spec.chips.forEach((label, i) => {
-        if (spec.input === true && i === 0) return;   // the field IS chip one
+        if (spec.input === true && i === 0) return;   // the field + send ARE chip one
         const b = document.createElement('button');
         b.className = 'emi-chip';
         b.type = 'button';
@@ -2133,8 +2303,21 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
    * reduced motion drops it to a plain hide); anything urgent passes false.
    */
   function unmountAsk(slide) {
+    /* THE HOLD IS CLOSED HERE AND NOWHERE ELSE, and BEFORE the early return -
+     * a question whose strip never managed to build still opened the hold with
+     * its line, and this is the call that ends it. `dropStrip` is the half
+     * WITHOUT that, and `mountAsk` is its one caller: clearing a previous
+     * strip on the way in must not take down the question that is landing. */
+    releaseAskLine();
+    return dropStrip(slide);
+  }
+  function dropStrip(slide) {
+    /* A PENDING LEAVE DIES HERE WHATEVER HAPPENS - `mountAsk` comes through
+     * this branch on its way in, and a 220ms drop left running would hide the
+     * strip that is replacing it. */
+    if (askDropTimer !== null) { clearTimeout(askDropTimer); askDropTimer = null; }
     if (!askLive) {
-      try { askStrip.hidden = true; askStrip.textContent = ''; } catch (e) { /* noop */ }
+      try { askStrip.hidden = true; askStrip.textContent = ''; askStrip.classList.remove('out'); } catch (e) { /* noop */ }
       return false;
     }
     askLive = null;
@@ -2143,6 +2326,7 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
       if (el.style && typeof el.style.setProperty === 'function') el.style.setProperty('--emi-ask-h', '0px');
     } catch (e) { /* noop */ }
     const drop = () => {
+      if (askDropTimer !== null) { clearTimeout(askDropTimer); askDropTimer = null; }
       try {
         askStrip.hidden = true;
         askStrip.textContent = '';
@@ -2153,11 +2337,44 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
     };
     if (slide && !reducedMotion()) {
       try { askStrip.classList.add('out'); } catch (e) { /* noop */ }
-      later(drop, 220);
+      /* ITS OWN HANDLE, NOT `later()`. Every resolution an ask has is followed
+       * within the same tick by a line or a face - her reaction to the answer,
+       * the wordless `-_-` - and both of those run `killTimers()`, which used
+       * to take this one with them. The strip then never dropped: `.out`
+       * animated it to opacity 0 and left a node with two `pointer-events:auto`
+       * chips sitting over the board for the rest of the sitting (trap 59's
+       * failure mode, and invisible in every screenshot). */
+      if (askDropTimer !== null) clearTimeout(askDropTimer);
+      askDropTimer = setTimeout(() => { askDropTimer = null; drop(); }, 220);
     } else {
       drop();
     }
     return true;
+  }
+
+  /**
+   * TAKE THE QUESTION OFF THE GLASS AND LET THE WAITING LINE THROUGH.
+   *
+   * The question's hold is an hour (DIALS.ASK_HOLD_MS) precisely so that
+   * nothing but this can end it, which means this is also the only place its
+   * timer is cancelled - `idle()` funnels through `cancelChain()` and clears
+   * the bubble, and every resolution the ask engine has (a reaction line, the
+   * wordless `-_-`) lands on the free glass a beat later.
+   *
+   * The held line is released on a TIMER and not on the spot, because an
+   * ANSWER is followed immediately by her reaction to it: giving the stale
+   * bark the glass synchronously would put it under a line that is about to
+   * replace it. `pumpHeldLine` waits for a quiet glass and gives up at
+   * ASK_QUEUE_MS, so an ask that sat for a minute drops the line instead of
+   * saying it into a room that has moved on.
+   */
+  function releaseAskLine() {
+    const was = askHold;
+    askHold = false;
+    if (was && current && current.ask) { try { idle(); } catch (e) { /* noop */ } }
+    if (!heldLine) return;
+    if (heldTimer !== null) { clearTimeout(heldTimer); heldTimer = null; }
+    heldTimer = setTimeout(pumpHeldLine, DIALS.ASK_QUEUE_POLL_MS);
   }
 
   /** MAY SHE ASK RIGHT NOW. One honest answer, owned by the file that owns the
@@ -2298,6 +2515,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
         accrueVisible();
         endPress();
         cancelTrip();                // W2a: switched off mid-trip = home first
+        emitGesture('gone', { reason: 'disabled' });   // ASKS: see hide()
+        unmountAsk(false); dropHeldLine();
         cancelChain(); killTimers(); stopBlink(); stopSway(); clearBody();
         root.hidden = true;
         save(true);
@@ -2341,6 +2560,8 @@ export function createWidget({ root, face, chains, fx, vox: vox0, store, toast, 
       accrueVisible();
       cancelTrip();                  // W2a: never leave a trip timer behind
       unmountAsk(false);             // ASKS: never leave a live chip behind
+      dropHeldLine();                // ...nor a line waiting for one to end
+      if (askDropTimer !== null) { clearTimeout(askDropTimer); askDropTimer = null; }
       save(true);
       // clearBody() is the easy one to miss: `bodyTimer` outlives everything else
       // and its callback re-adds `.breath` to a node that is no longer in the page.

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -4631,7 +4631,16 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
      * draws through the provider the same way a class does (the host fetches,
      * the page never does) and falls back to `init.settings.localAssets`. Both
      * are optional to her - absent means the channel is absent. */
-    if (emiLayer) mountEmi({ layer: emiLayer, store, toast: shout, log: say, assets, settings: src.settings });
+    /* `strings` is the ONE lexicon row EMI renders (the ask strip's Send
+     * button). Resolved HERE because this side of the page has `t` and she has
+     * never imported the lexicon - the same seam orientation.js uses for her
+     * three opening lines. */
+    if (emiLayer) {
+      mountEmi({
+        layer: emiLayer, store, toast: shout, log: say, assets, settings: src.settings,
+        strings: { askSend: t('emi_ask_send', 'send') },
+      });
+    }
   } catch (e) { say('EMI failed to mount (the shell is unaffected): ' + ((e && e.message) || e)); }
 
   /* FIRST BELL. Built here, BEFORE the first showBoard(), for the same reason

--- a/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
+++ b/ConditioningControlPanel/Services/Arcademy/ArcademyHostService.cs
@@ -2334,6 +2334,13 @@ internal static class ArcademyHostService
         ["emi_orientation_card"] = "official! now you have to come back. it's the rules.",
         ["emi_orientation_go"] = "go! your first class doesn't know how lucky it is.",
 
+        // EMI ASKS: the Send button on the one question with a keyboard (a14,
+        // "what do i call you?"). The ONLY display string EMI renders - her
+        // questions, chips and reactions are verbatim content and never pass
+        // through the lexicon. shell/shell.js resolves this one and hands the
+        // answer to mountEmi. Her voice is lowercase, so this row is too.
+        ["emi_ask_send"] = "send",
+
         // THE PHANTOM POST chrome (shell/mail.js, mailbox.js, corkboard.js,
         // bugle.js). Copy of core/lexicon.js's block - copy the values, do not
         // re-word them (the IC_LEX rule). Letter bodies, notices and newspaper


### PR DESCRIPTION
Four owner reports from the EMI ASKS playtest. One of them had a real root cause under it.

## 1. "The how can I call you prompt got removed because I think I triggered another speech."

widget.js's say law is *"a protected chain refuses to be replaced by an **unprotected** one"* - and every line EMI says is protected. So a bark landing thirty seconds into a question walked straight over it. The question text was replaced, the chips stayed, and the first click the player made to clear the orphaned strip dismissed the ask for free.

Proved before and after, same rig, same fixture:

```
BEFORE (main)                        AFTER (this branch)
question up      : "rough day?"      question up      : "rough day?"
later line landed: true              later line landed: false
bubble now       : "you came back."  bubble now       : "rough day?"
strip still up   : true              strip still up   : true
after 2 minutes  : ""  strip up:true after 2 minutes  : "rough day?"
```

**An ask now owns the glass.** From its own line until the strip comes down, a later SAY is parked in one slot and released afterwards if it is still worth saying (8s); every other reaction - a raw face, a chain, an emote, `force` and all - is refused. The hold opens with the **line**, not with the strip, because the chips land `STRIP_LEAD_MS` (1560ms) later and that gap is the window the bug actually fell through.

Two more halves of the same report:

- **An interrupted ask comes back.** A press records nothing (trap 96), so an interrupted question simply vanished for the sitting. It now returns once, on the next `idlePlayer` or the next firing of its own trigger. Dares are excluded: their window is the room card, one beat before a board takes input (trap 97).
- **The name ask was a one-shot for the wrong reason.** `a14_name`'s window was `sessions === 3` **exactly**. One stray click on session three and EMI could never learn your name on that save. It is `>= 3` while unanswered now, held off by a once-a-sitting latch the way a15's `bedAsked` is. (The headless shot against `main` picked `a01_roughday` at session 5; against this branch it picks `a14_name`.)

## 2. "We need a send button visible."

The field had Enter and nothing else, and on a phone Enter is a key on a keyboard that covers the mascot. It has a **Send** button beside it now: chip one, `data-chip="0"`, the same `onChip(0, text)` path Enter uses. Every chip is a 44px target under `html.arc-mobile`.

The label is the one display string EMI renders: `emi_ask_send`, resolved by **shell.js** (which has `t`) and handed to `mountEmi` as `strings.askSend`, mirrored verbatim in the C# `NeutralLexicon`. No lexicon reaches EMI, and this did not change that.

Also fixed while in there: typing `1` into the name field used to **submit**, because the `1`/`2` chip shortcuts were tested before the field's own keys. A question with a keyboard has no chip shortcuts.

## 3. "Keep the bubble in sight till we respond."

`GIVE_UP_MS` is **0** - not "expire immediately" but "she waits". The question's hold is an hour (`DIALS.ASK_HOLD_MS`, a large *finite* number because `chains.js makeSay` does `holdMs | 0` and `Infinity | 0` is a 400ms flash) and `releaseAskLine()` is the only thing that ends it. The player can never be trapped: any press anywhere is a free dismiss, and a dismissed yes/no is still **no answer**, never a "no".

One carve-out, and it is trap 97's: the dares still leave after 12s, because a strip may not sit over a board that is about to take input.

## 4. "+35% persistence."

Scaled at the source, in `DIALS`, because `sayHoldMs` is the one function that turns a line into a hold:

| | before | after |
|---|---|---|
| floor (`SAY_HOLD_MIN_MS`) | 3000 | **4050** |
| base (`SAY_HOLD_BASE_MS`) | 1400 | **1890** |
| per character | 45 | **61** |
| a 20-char line | 3000 | **4050** |
| a 40-char line | 3200 | **4330** |
| an 80-char line | 5000 | **6770** |

There is no ceiling to scale (the suite asserts none has appeared). `asks.js`'s `AFTER_SAY_MS` goes 3400 -> 4590 with it, so a follow-up still waits the line out instead of landing on a live bubble.

## Three bugs found on the way

- **The strip's leave animation rode `later()`.** Every resolution is followed in the same tick by a reaction, and a reaction runs `killTimers()` - which took the 220ms drop with it. `.out` faded the node to opacity 0 and left a strip with two `pointer-events:auto` chips over the board for the rest of the sitting. Trap 59's failure mode, and invisible in every screenshot. It has its own handle now.
- **The bubble's ear test is sized off her BODY.** `left + w * 1.55` is calibrated for the desktop pair (150px EMI, 104px box). A phone runs an 86px EMI beside a box allowed 168, so the correct ear still left "what do i call you?" **75px off the right edge** at 844x390. The bubble now gets the same measured pull-back the strip has had.
- **...and that clamp must read `offsetWidth`, not a rect.** `.emi-bubble.pop` is a 280ms scale keyframe and `getBoundingClientRect` reports the transformed box (trap 74's twin half), so the first attempt measured the box at 60% and clamped a sixth of what it should have.

## Verification

- **`scratchpad/emihold/test-askhold.mjs` - 117 assertions, 0 failures.** Real `emi/widget.js`, real `emi/asks.js`, real `emi/chains.js` over the DOM double and a **virtual clock** (an hour-long hold cannot be asserted on the wall clock). Covers: the hold ratio line by line against the old numbers, an ask surviving a later line, the held line released and the stale one dropped, ten minutes with no auto-hide (and the same under reduced motion), the dare carve-out, hide/`setEnabled(false)` ending an ask, the re-ask and its one-a-sitting cap, the Send button present/labelled/submitting, Enter still working, the digit fix, a14's whole ladder, and the lexicon mirror + 44px sheet rules by grep.
- **The existing shell suite is byte-identical to `main`** (same passes, same pre-existing failures).
- `dotnet build`: 0 errors.
- Headless shots at 844x390 `?forcemobile=1` and 1600x900, both showing the name ask with its Send button: `scratchpad/emishot/out/emiask-01-name-mobile-844x390.png`, `emiask-02-name-desktop-1600x900.png`.

Trap **104** is written up in `Resources/web/arcademy/CLAUDE.md`.

Not merged - owner play-test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6
