### PR TITLE
fix(arcademy): the Records corkboard - paper on the cork, full text, an opaque reader

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -222,7 +222,13 @@ shell/scene.js     THE SCENE CHASSIS: a generalised point-and-click ROOM (the
                    WARNING IS WIDE-ONLY: a close-up's rects and props are free
                    to run below y=640 and are never warned about. A consumer
                    must NOT clamp a close-up host to 640 - the paper is measured
-                   from the painting or it is not measured at all
+                   from the painting or it is not measured at all.
+                   `scale()` is the chassis's one measurement seam: the stage
+                   scale as of the last `fit()`. A prop that has to reason in
+                   SCREEN pixels asks the STAGE, never its own host - the
+                   Records miniature carries a second scale of its own, so its
+                   host would answer a different number than the close-up's and
+                   the two walls would lay out differently
 shell/recordsroom.js THE RECORDS OFFICE AS A ROOM (0825), the chassis's first
                    tenant. Four rects on vn-09: the TRAY (the one breathing
                    verb - it opens records.js in a scene panel, and wears the
@@ -235,10 +241,17 @@ shell/recordsroom.js THE RECORDS OFFICE AS A ROOM (0825), the chassis's first
                    apron band and below the toasts, and the FIRST rung of this
                    room's Esc fold. It is the answer to a wall that is painted
                    at stage scale: on a phone the close-up's body copy lands
-                   near 7px and a busy term's fifth row hangs out of the
-                   window, so on `html.arc-mobile` the office cork also clips
-                   each sheet to a row's share (with a fade and a drawn lens
-                   glyph) and scrolls. Desktop keeps the ruled overhang),
+                   near 7px, so the type comes up and a drawn lens glyph says
+                   the paper can be picked up.
+                   A PRINTED SHEET SHOWS ALL OF ITSELF (owner ruling 0825):
+                   the old phone rule capped a sheet at 292px and faded it out
+                   with a `mask-image`, which dissolved a notice mid-sentence.
+                   Gone. A sheet is now exactly as tall as its copy;
+                   corkboard.js's FIT shrinks one sheet's `--note-fs` toward a
+                   floor of 10 real screen px on a phone / 11 on a desktop
+                   while that buys a row its share of the board; and the
+                   close-up host SCROLLS (both sizes now, scrollbar hidden)
+                   rather than hanging a term's worth of paper off the rail),
                    the BOOK (a close-up with deskbook.js over `ledgerPages`)
                    and the STOREROOM (`when:'ajar'`, so no flag = no rect, no
                    patch, nothing at all). THE TWO NUDGES: `.rr-fresh`, a pink
@@ -251,6 +264,16 @@ shell/recordsroom.js THE RECORDS OFFICE AS A ROOM (0825), the chassis's first
                    2px/.30 resting rim going away is not something a player can
                    see. Both are OFF under .arc-reduced (and .arm-lite gets no
                    solo ring either - static state only).
+                   THE MINIATURE hangs on `CORK_WIDE` [237,165,302,152], the
+                   PAINTED cork measured off vn-09 (frame inner edges x 236 and
+                   539, y 163 and 362, so the cork face is 237..538 x 165..361)
+                   and trimmed to stop 5px above `LAMP_SHADE_TOP` (322). It is
+                   NOT `RECTS.corkboard` - that rect is the framed OBJECT with
+                   press slack under it, and paper hung on it sat on the frame,
+                   ran onto the desk and landed on the banker's lamp (trap 105).
+                   The mini is dealt the close-up's own `fit` (same `boxH`, same
+                   stage `scale`) plus `wholeRows:true`, so it is a picture of
+                   the top of the board and never a sheet sliced along a rail.
                    THE ROOM'S FX TABLE (W2 0825) is `recordsFx()`, exported
                    beside the rects and crop-verified on the plate: the sign
                    [577,169,346,91], the lamp pool [383,433,282,42], the dust
@@ -2314,6 +2337,64 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     hold cannot be asserted on the wall clock). `before-probe.mjs` beside it is the
     before/after: point its `arc/` at main and watch "rough day?" become "you came back."
     with the chips still up.
+
+105. **`background:` IS A SHORTHAND, AND THAT IS WHY THE NOTICE READER WAS A PANE OF
+    GLASS (owner bugs 2026-08-25, three defects on one corkboard).** All three of the
+    owner's phone shots were one wave; only the first is a geometry bug and the other two
+    share a single root.
+
+    **(a) A HOTSPOT RECT IS NOT A PLACE TO HANG PAPER.** The wide shot's miniature was
+    pinned to `RECTS.corkboard` [226,153,323,226] - the rect you PRESS, which covers the
+    timber frame and carries a few pixels of slack under it so a thumb is comfortable. The
+    painted cork inside that frame is [237,165,302,197]: nine pixels lower at the top and
+    seventeen higher at the bottom. So the preview started on the frame, ended on the desk,
+    and its bottom-right sheet landed on the banker's lamp - which breaks the cork plane at
+    y=322 and reaches back to x=480, INSIDE the board's own right third. Every number here
+    was measured off `art/vn/vn-09-records-office.png` with a script, not read off
+    `records-room-spec.json`, and the constant that came out of it (`CORK_WIDE`, trimmed to
+    152 tall so the paper stops above the shade) carries the derivation in its comment. The
+    rule: **a rect you press and a rect you decorate are two different measurements of the
+    same object**, and a room that has both must name both.
+
+    **(b) A SHORTHAND RESETS WHAT IT DOES NOT MENTION.** `.arc-corknote` painted its paper
+    as `background:linear-gradient(...)`, which sets background-IMAGE and resets
+    background-COLOR to `transparent`. Every sheet was therefore one `background-image:none`
+    away from being a window - and `.arc-corknote.look-pencil { background-image: none; }`
+    is exactly that rule, shipped, for the groundskeeper's notices. On the board they read
+    as cork-through-paper. In the READER, which mounts the same `.arc-corknote` stock over
+    the dusk on `<body>`, the same sheet was a transparent rectangle with dark ink on it and
+    the whole noticeboard legible through it. Nobody had seen it because the look is dealt
+    per NOTICE and the reader is opened per SHEET: it took a specific night and a specific
+    press. The paper colour is a `background-color` now and the stocks are
+    `background-image`s over it, so a rule that turns a texture off can never take the
+    opacity with it. **Any element whose colour matters declares that colour as a colour.**
+
+    **(c) A PERCENTAGE THAT WAS SAFE ON A CAPPED SHEET IS NOT SAFE ON AN UNCAPPED ONE.**
+    Dropping the `max-height:292px` + `mask-image` fade (owner: "that is not how printed
+    paper works, we should see the full doc") let a sheet grow to its copy - and the torn
+    corner, `clip-path` at `100% 89%`, bit 11% of the height: 20px on the old sheet and 66px
+    on a 600px one, eating sentences. It is `calc(100% - var(--tear))` now, with a matching
+    `padding-bottom`, so the bite and the blank paper under the copy are the same fixed
+    number. **When you remove a cap, re-read every percentage that was measured against it.**
+
+    Three smaller things the wave settled, each of which cost a run:
+    - **THE FIT MUST UNTRIM BEFORE IT MEASURES.** A `display:none` slot measures zero, and a
+      zero-height sheet is a sheet the fit believes already fits - so a fit run over an
+      already-trimmed wall leaves everything below the cut at full type, and the next trim
+      cuts higher for that reason alone. Untrim, fit, trim, in that order, every time. Two
+      passes of the wrong order took the desktop miniature from six sheets to three.
+    - **A PROP INSIDE A SCALED ROOM CANNOT MEASURE ITS OWN SCALE** (trap 101's cousin). The
+      corkboard's type floor is 10 REAL pixels, so the fit has to divide by the stage scale
+      - and the miniature carries a second scale of its own, so `rect.width / offsetWidth`
+      on ITS host answers a fifth of the truth and prints the thumbnail in bigger type than
+      the board it is a picture of. `scene.js` exposes `scale()` (the stage's, as of the
+      last `fit()`) and both walls are handed the same one.
+    - **TWO SHEETS, ONE SELECTOR, NO WINNER.** `.rr-cork.arc-cork-wall` is written in
+      corkboard.css AND in recordsroom.css at the same (0,2,1... 0,2,0) specificity, and the
+      two files are lazy-linked by two different modules in whatever order the network
+      answers. Whichever landed last won. Every declaration on that selector now has exactly
+      one owner, and the room suite greps recordsroom.css (comments stripped - the prose
+      explaining what left names the properties) to keep it that way.
 
 ## 5. The game module contract (short version)
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.css
@@ -179,12 +179,31 @@
 .arc-cork-slot:nth-child(6) { animation-delay:.25s; }
 
 /* -------------------------------------------------------------- the sheet */
+/* PAPER IS OPAQUE, AND THE COLOUR IS A `background-color`, NOT A GRADIENT.
+   `background:` is a shorthand: it paints the stock as a background-IMAGE and
+   resets background-color to `transparent` underneath it. Every sheet was
+   therefore one `background-image:none` away from being a window, and
+   `.look-pencil` is exactly that rule - the groundskeeper's sheets rendered as
+   cork-through-paper on the wall AND as an unreadable pane of glass in the
+   READER, which mounts the same `.arc-corknote` stock over the dusk (owner
+   screenshots, 2026-08-25). So the colour is declared as a colour and the
+   stock is layered over it as an image; a sheet that loses its gradient loses
+   its texture and never its opacity.
+
+   --note-fs IS THE ONE TYPE DIAL. The three type rules below are ratios of it,
+   so a host can set the wall's size in one place and corkboard.js's fit can
+   shrink ONE sheet (see THE FIT) without touching three declarations. */
 .arc-corknote {
   position:relative;
+  --note-fs:13px;
+  /* how far up the sheet a torn corner may reach, and the blank paper the
+     sheet keeps below its copy so the tear can never eat a word */
+  --tear:20px;
   padding:20px 16px 16px;
   border-radius:2px;
   color:var(--paper-ink);
-  background:linear-gradient(184deg, var(--paper), var(--paper-lo));
+  background-color:var(--paper);
+  background-image:linear-gradient(184deg, var(--paper), var(--paper-lo));
   box-shadow:
     0 10px 22px rgba(0,0,0,.5),
     0 1px 0 rgba(255,255,255,.5) inset,
@@ -202,11 +221,23 @@
 /* THE TORN CORNER. clip-path removes a box-shadow along with the corner, so a
    torn sheet swaps its shadow for one drop-shadow pass. It is static paper -
    no live decode underneath it, nothing re-rasters per frame (trap 36).
-   THE TEAR IS A CORNER, NOT A NOTCH: it may only eat the last tenth of the
+   THE TEAR IS A CORNER, NOT A NOTCH: it may only eat the last `--tear` of the
    height and the last seventh of the width. The first pass ran the polygon up
-   to 62% and the sheets came out looking like pennants. */
+   to 62% and the sheets came out looking like pennants.
+
+   IT IS MEASURED IN PIXELS, NOT IN PERCENT, and that is a consequence of the
+   sheets growing: the polygon used to bite the last 11% of the height, which
+   is 20px on a 180px notice and 66px on a 600px one. Now that a sheet is as
+   tall as its copy (no mask, no max-height - see THE OFFICE CORK below) a
+   percentage tear would eat whole sentences off the bottom of a long notice.
+   A fixed bite plus the matching bottom padding is the pair: the corner is
+   gone and the words are all still there. */
 .arc-corknote.is-torn {
-  clip-path:polygon(0 0, 100% 0, 100% 89%, 93% 91.5%, 96.5% 94%, 90% 96%, 94% 100%, 0 100%);
+  clip-path:polygon(0 0, 100% 0,
+    100% calc(100% - var(--tear)), 93% calc(100% - var(--tear) * .77),
+    96.5% calc(100% - var(--tear) * .55), 90% calc(100% - var(--tear) * .36),
+    94% 100%, 0 100%);
+  padding-bottom:calc(16px + var(--tear));
   box-shadow:0 1px 0 rgba(255,255,255,.45) inset;
   filter:drop-shadow(0 9px 15px rgba(0,0,0,.55));
 }
@@ -244,24 +275,31 @@
 .arc-corknote.kind-notice  { --pin-hue:var(--pink); }
 .arc-corknote.kind-flyer {
   --pin-hue:var(--gold);
-  background:linear-gradient(184deg,
+  background-image:linear-gradient(184deg,
     color-mix(in srgb, var(--paper), var(--pink) 13%),
     color-mix(in srgb, var(--paper-lo), var(--pink) 9%));
 }
 .arc-corknote.kind-minutes {
   --pin-hue:var(--lav);
-  background:
+  background-image:
     repeating-linear-gradient(180deg, transparent 0 21px,
       color-mix(in srgb, var(--paper-ink), transparent 88%) 21px 22px),
     linear-gradient(184deg,
       color-mix(in srgb, var(--paper), var(--lav) 8%),
       color-mix(in srgb, var(--paper-lo), var(--lav) 6%));
 }
-.arc-corknote.kind-minutes .arc-cork-notebody { font-family:var(--mono); font-size:12px; }
+.arc-corknote.kind-minutes .arc-cork-notebody {
+  font-family:var(--mono);
+  font-size:calc(var(--note-fs) * .923);
+}
 
-/* A sheet the player has had up before sits back a little. It is a TONE, not a
-   badge: nothing on this wall is a task. */
-.arc-corknote.is-read { opacity:.9; }
+/* READ AND UNREAD ARE TOLD BY THE TAG, NEVER BY FADING THE PAPER (owner
+   ruling, 2026-08-25: "that is not how printed paper works"). `.is-read` used
+   to carry `opacity:.9`, which is a translucent sheet with cork showing
+   through it - and a wall of those reads as half-PRINTED rather than half-read.
+   The fresh sheet's KIND TAG is filled pink and a read one's is the quiet
+   stock grey; that difference is the whole signal, and it costs the paper
+   nothing. */
 .arc-corknote.is-fresh .arc-cork-kind {
   background:color-mix(in srgb, var(--pink), var(--paper) 42%);
   color:var(--paper);
@@ -270,16 +308,16 @@
 .arc-cork-kind {
   display:inline-block; margin:0 0 8px;
   padding:2px 7px; border-radius:2px;
-  font-family:var(--mono); font-size:10px; letter-spacing:.2em;
+  font-family:var(--mono); font-size:calc(var(--note-fs) * .769); letter-spacing:.2em;
   background:color-mix(in srgb, var(--paper-ink), transparent 84%);
   color:var(--paper-dim);
 }
 .arc-cork-notetitle {
-  font-family:var(--disp); font-size:15px; letter-spacing:.03em;
+  font-family:var(--disp); font-size:calc(var(--note-fs) * 1.154); letter-spacing:.03em;
   margin:0 0 8px; color:var(--paper-ink); line-height:1.25;
 }
 .arc-cork-notebody {
-  margin:0; font-size:13px; line-height:1.5;
+  margin:0; font-size:var(--note-fs); line-height:1.5;
   color:color-mix(in srgb, var(--paper-ink), var(--paper) 18%);
 }
 
@@ -508,11 +546,22 @@ html.arc-reduced .rr-cork .arc-corknote:focus-within { animation: none; }
 /* The paper itself: the SAME `.arc-corknote` stock, so a sheet in your hands is
    the sheet off the wall and not a lookalike. What changes is that it is now
    the subject - real type, a real reading measure, and it scrolls. */
+/* IT IS ALWAYS AN OPAQUE CREAM SHEET AT FULL OPACITY. Two belts, because the
+   owner's phone shot was a reader you could read the BOARD through: the paper
+   colour is a `background-color` on `.arc-corknote` now (see THE SHEET), and
+   the declarations below refuse any state a future sheet class might walk in
+   with. A sheet in the hand is off the wall - it is not read, not fresh, not
+   torn and not faded, whatever the wall thought of it. */
 .arc-cork-readnote {
   position:relative; z-index:1;
   width:min(680px, 100%);
   max-height:100%;
   overflow:auto;
+  --note-fs:15.5px;
+  opacity:1;
+  background-color:var(--paper);
+  -webkit-mask-image:none;
+          mask-image:none;
   padding:22px 24px 26px;
   transform:rotate(-.4deg);
   animation:arc-cork-reader-in .26s cubic-bezier(.2, 1.2, .4, 1) both;
@@ -524,9 +573,9 @@ html.arc-reduced .rr-cork .arc-corknote:focus-within { animation: none; }
 /* A sheet in the hand has no lifted corner and no tear: it is flat on a desk,
    and the corner fold is a shadow that only makes sense against cork. */
 .arc-cork-readnote::after { content:none; }
-.arc-cork-readnote.is-torn { clip-path:none; filter:none; }
+.arc-cork-readnote.is-torn { clip-path:none; filter:none; padding-bottom:26px; }
 .arc-cork-readnote .arc-cork-notetitle { font-size:20px; line-height:1.25; }
-.arc-cork-readnote .arc-cork-notebody { font-size:15.5px; line-height:1.6; }
+.arc-cork-readnote .arc-cork-notebody { line-height:1.6; }
 .arc-cork-readnote .arc-cork-kind { font-size:10px; }
 
 .arc-cork-readclose {
@@ -552,50 +601,58 @@ html.arc-reduced .arc-cork-readnote { animation:none; }
  * out in the plate's 1285x692 pixels and scaled with it, and a phone in
  * landscape fits that plate at about a half. So every one of these numbers is
  * a stage pixel and comes out halved - which is why the copy read as texture
- * and the bottom row of sheets hung off the frame and out of the window
- * (owner screenshot, 2026-08-25).
+ * (owner screenshot, 2026-08-25) and the type comes UP on a phone.
  *
- * Two changes, both scoped to `.rr-cork` on a phone, and neither touches the
- * hall's board or the desktop's:
- *   - the paper is CLIPPED TO THE BOARD. The wide-window ruling (pinned paper
- *     hangs off the rail rather than being cut) needs a wall under the rail to
- *     hang onto; on a phone the plate IS the window, so the overhang is simply
- *     gone. Each sheet takes a row's share of the cork and fades out at the
- *     cut, which is also how a player learns there is more of it.
- *   - the type comes UP, because a headline you can read is worth more than
- *     four paragraphs you cannot, and the rest of the sheet is one press away.
+ * A PRINTED SHEET SHOWS ALL OF ITSELF (owner ruling, 2026-08-25: "that is not
+ * how printed paper works, we should see the full doc"). The first pass at the
+ * phone gave every sheet `max-height:292px` and a `mask-image` fade, so a long
+ * notice dissolved mid-sentence and the rest of it existed only in the reader.
+ * Both are GONE. What replaces them is three rules that never cut a word:
+ *   - a sheet is exactly as tall as its copy (the grid's rows are content-
+ *     sized, so no two rows can ever overlap);
+ *   - corkboard.js's FIT shrinks one sheet's `--note-fs` toward a floor (10px
+ *     of screen on a phone, 11px on a desktop) while that buys a row its share
+ *     of the board, and stops the moment it does not;
+ *   - and whatever is still over hangs on the SCROLL, below.
  * ==========================================================================*/
-/* A BUSY TERM SCROLLS RATHER THAN HANGING OFF THE WINDOW. On a desktop the
-   plate is smaller than the window and an overrun spills onto the wall around
-   it, which is the ruling. On a phone the plate IS the window, so the same
-   overrun is simply gone - a fifth row of paper that exists and cannot be
-   reached. `start` instead of `space-between` so the rows stack from the top
-   rail, and the board itself takes the scroll. */
-html.arc-mobile .rr-cork.arc-cork-wall {
+/* THE BOARD TAKES THE SCROLL. The wide-window ruling (pinned paper hangs off
+   the rail rather than being cut) needed a wall under the rail to hang onto; a
+   term's worth of full-height sheets is three boards deep, which is not paper
+   hanging off a rail, it is paper on the floor. So the close-up host scrolls -
+   on a phone AND on a desktop - and the scrollbar is hidden, because a
+   corkboard with a scrollbar down the side of it is furniture wearing a
+   widget. `start` rather than `space-between`: the rows stack from the top
+   rail, which is the only way the MINIATURE on the wide shot can be the same
+   picture as the board you walk up to (recordsroom.js's CORK_WIDE). */
+.rr-cork.arc-cork-wall {
   overflow-y:auto;
+  overflow-x:hidden;
+  align-content:start;
+  scrollbar-width:none;
+  -ms-overflow-style:none;
+  overscroll-behavior:contain;
+  -webkit-overflow-scrolling:touch;
+}
+.rr-cork.arc-cork-wall::-webkit-scrollbar { width:0; height:0; }
+/* ...but never the MINIATURE: scenery does not scroll, and a scrollbar on a
+   thumbnail of a corkboard is a bug wearing a feature's hat. It keeps `start`
+   so its rows are the close-up's rows, and it simply ends where the painted
+   cork ends. */
+.rr-cork-mini.arc-cork-wall {
+  overflow:hidden;
   align-content:start;
 }
-/* ...but never the MINIATURE: scenery does not scroll, and a scrollbar on a
-   thumbnail of a corkboard is a bug wearing a feature's hat. */
-html.arc-mobile .rr-corkmini .rr-cork.arc-cork-wall {
-  overflow:hidden;
-  align-content:space-between;
-}
-html.arc-mobile .rr-cork .arc-corknote {
-  max-height:292px;
-  overflow:hidden;
-  -webkit-mask-image:linear-gradient(180deg, #000 78%, transparent 100%);
-          mask-image:linear-gradient(180deg, #000 78%, transparent 100%);
-}
-html.arc-mobile .rr-cork .arc-cork-notetitle { font-size:25px; line-height:1.2; }
-html.arc-mobile .rr-cork .arc-cork-notebody { font-size:20px; line-height:1.45; }
-html.arc-mobile .rr-cork .arc-cork-kind { font-size:15px; letter-spacing:.14em; }
+html.arc-mobile .rr-cork .arc-corknote { --note-fs:20px; }
+html.arc-mobile .rr-cork .arc-cork-notetitle { font-size:calc(var(--note-fs) * 1.25); line-height:1.2; }
+html.arc-mobile .rr-cork .arc-cork-notebody { line-height:1.45; }
+html.arc-mobile .rr-cork .arc-cork-kind { font-size:calc(var(--note-fs) * .75); letter-spacing:.14em; }
 
 /* THE LENS. A sheet this small has to say it can be picked up, and the school
    never bakes a word into a drawn thing (lexicon law) - so the affordance is a
-   glyph: a ring and a handle, in the pin's own pink, sitting on the corner the
-   fade opens up. Drawn on the DOOR, not on the paper, because the paper is a
-   document and this is furniture. */
+   glyph: a ring and a handle, in the pin's own pink, on the bottom corner of
+   the paper. Drawn on the DOOR, not on the paper, because the paper is a
+   document and this is furniture. (It used to sit in the gap the mask's fade
+   opened up; the fade is gone and the corner is not.) */
 html.arc-mobile .rr-cork .arc-cork-open::after {
   content:''; position:absolute; right:14px; bottom:12px;
   width:26px; height:26px; border-radius:50%;

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/corkboard.js
@@ -487,6 +487,96 @@ function sfx(name, level, extra) {
   } catch (e) { /* a cue must never be the thing that throws */ }
 }
 
+/* ----------------------------------------------------------------------------
+ * THE FIT - a sheet is as tall as its copy, and the TYPE comes down to the box
+ *
+ * The office's cork is a close-up of a painting: the sheets are laid out in the
+ * plate's own 1285x692 pixels and the whole plate is scaled to the window, so
+ * on a phone in landscape one stage pixel is about half a screen pixel. The
+ * first pass at that gave every sheet a `max-height` and a `mask-image` fade,
+ * and a long notice dissolved mid-sentence - which is not how printed paper
+ * works (owner ruling, 2026-08-25). So nothing is cut any more. What is left
+ * is an ordering problem, and this is the cheap half of the answer:
+ *
+ *   a row of the board is worth `boxH / rows`. A sheet over that budget gives
+ *   up TYPE - `--note-fs`, the one dial the three type rules are ratios of -
+ *   down to a floor of real SCREEN pixels (10 on a phone, 11 on a desktop,
+ *   divided back out by the stage scale). A sheet that is still over at the
+ *   floor keeps every word it has and the board scrolls instead.
+ *
+ * Height goes roughly with the square of the type (a smaller face fits more
+ * characters per line AND more lines per inch), so the step is a sqrt and
+ * three passes are plenty; a pass that would move the size by less than a
+ * fifth of a pixel is the end of the ladder.
+ *
+ * IT MEASURES IN LAYOUT PIXELS, WHICH IS WHAT MAKES THE MINIATURE HONEST.
+ * `offsetHeight` ignores the transform the stage rides, so a wall laid out at
+ * 1285px measures 1285px whether it is painted at half size on a phone or a
+ * fifth of that in the wide shot's thumbnail. Hand BOTH the same `boxH` and
+ * the same `scale` and they deal the same type at the same rows - which is the
+ * whole of why the preview is a picture of the board and not a second board.
+ * -------------------------------------------------------------------------- */
+
+/** The smallest type this wall will print, in SCREEN pixels. */
+export const FIT_FLOOR_PHONE = 10;
+export const FIT_FLOOR_DESK = 11;
+
+function isPhone() {
+  try {
+    const de = (typeof document !== 'undefined') ? document.documentElement : null;
+    return !!(de && de.classList && de.classList.contains('arc-mobile'));
+  } catch (e) { return false; }
+}
+
+function px(v, dflt) {
+  const n = parseFloat(v);
+  return isFinite(n) ? n : dflt;
+}
+
+/**
+ * Shrink each sheet's type until its row's share of the board holds it.
+ * @param {Object} hostEl   the wall (the grid)
+ * @param {Array} sheets    the `.arc-corknote` nodes, in DOM order
+ * @param {{boxH:number, scale:(number|Function), floorPx:number=}} fit
+ */
+export function fitSheets(hostEl, sheets, fit) {
+  if (!fit || !hostEl || !sheets || !sheets.length) return false;
+  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') return false;
+  const boxH = Number(fit.boxH) || Number(hostEl.clientHeight) || 0;
+  if (!(boxH > 80)) return false;
+  let scale = 1;
+  try { scale = (typeof fit.scale === 'function') ? Number(fit.scale()) : Number(fit.scale); }
+  catch (e) { scale = 1; }
+  if (!(scale > 0)) scale = 1;
+  const floor = (Number(fit.floorPx) || (isPhone() ? FIT_FLOOR_PHONE : FIT_FLOOR_DESK)) / scale;
+
+  const cs = window.getComputedStyle(hostEl);
+  const cols = String(cs.gridTemplateColumns || '').trim().split(/\s+/).filter(Boolean).length || 1;
+  const rows = Math.max(1, Math.ceil(sheets.length / cols));
+  const gap = px(cs.rowGap, 0);
+  const budget = (boxH - px(cs.paddingTop, 0) - px(cs.paddingBottom, 0) - gap * (rows - 1)) / rows;
+  if (!(budget > 60)) return false;
+
+  for (let i = 0; i < sheets.length; i += 1) {
+    const sheet = sheets[i];
+    if (!sheet || !sheet.style || typeof sheet.style.setProperty !== 'function') continue;
+    try { sheet.style.removeProperty('--note-fs'); } catch (e) { /* noop */ }
+    const base = px(window.getComputedStyle(sheet).getPropertyValue('--note-fs'), 0);
+    if (!(base > 0) || base <= floor + 0.25) continue;
+    let fs = base;
+    for (let pass = 0; pass < 3; pass += 1) {
+      const h = Number(sheet.offsetHeight) || 0;
+      if (!(h > budget)) break;
+      let next = fs * Math.sqrt(budget / h);
+      if (next < floor) next = floor;
+      if (next >= fs - 0.2) break;          // nothing left to give
+      fs = next;
+      sheet.style.setProperty('--note-fs', fs.toFixed(2) + 'px');
+    }
+  }
+  return true;
+}
+
 function kindLabel(kind) {
   if (kind === 'flyer') return t('board_kind_flyer', 'Flyer');
   if (kind === 'minutes') return t('board_kind_minutes', 'Minutes');
@@ -641,8 +731,22 @@ export function hasUnread(daySeed, override) {
  *                                      full-size, scrollable copy over the
  *                                      window). Off by default: the hall's
  *                                      board is a page you already scroll.
+ * @param {boolean=} opts.wholeRows    a wall that ends on a WHOLE sheet: any
+ *                                      slot that does not fit inside the host
+ *                                      is taken down, along with everything
+ *                                      after it. For the MINIATURE, whose box
+ *                                      is a painted board with a bottom rail -
+ *                                      a sheet sliced flat along that rail
+ *                                      reads as a rendering fault from across
+ *                                      the room, where a shorter wall reads as
+ *                                      a wall. Needs `fit` (it runs after it).
+ * @param {Object=} opts.fit          THE FIT (see above): {boxH, scale, floorPx}
+ *                                      in STAGE pixels. Hand the same pair to
+ *                                      a wall and to its miniature and the two
+ *                                      lay out identically. Absent = the type
+ *                                      the stylesheet asked for, untouched.
  * @param {Function=} opts.log
- * @returns {?Object} {notices, daySeed, first, closeReader(), destroy()}
+ * @returns {?Object} {notices, daySeed, first, refit(), closeReader(), destroy()}
  */
 export function mountNotices(hostEl, opts) {
   const o = opts || {};
@@ -662,6 +766,8 @@ export function mountNotices(hostEl, opts) {
   };
 
   const mounted = [];
+  const sheets = [];
+  const timers = [];
   let first = null;
   /* A MINIATURE IS SCENERY. It paints the same wall and writes nothing: no
    * `seenAt` rows, no banked visit, no focus, no pointer (the sheet's own
@@ -731,6 +837,7 @@ export function mountNotices(hostEl, opts) {
     }
 
     slot.appendChild(sheet);
+    sheets.push(sheet);
     /* THE PIN GOES THROUGH THE SLOT, NOT THROUGH THE SHEET. A torn sheet is a
      * clip-path, and clip-path clips its children too - a pin parented to the
      * paper came out as a half circle on every torn notice (caught in the
@@ -764,18 +871,111 @@ export function mountNotices(hostEl, opts) {
     persist(s, o.save);
   }
 
+  /* THE FIT, AND THE THREE TIMES IT HAS TO RUN. The first measurement races
+   * the LAZY stylesheet links (this file's and the room's): an unstyled sheet
+   * measures at the browser's own defaults and would be handed type it never
+   * needed. scene.js has the same race and answers it the same way - now, next
+   * frame, and once more after the sheets have had time to land. Resizing the
+   * window changes the stage scale, which changes the floor, which is a fourth
+   * reason to run it. */
+  const fitOpts = (o.fit && typeof o.fit === 'object') ? o.fit : null;
+  let pending = false;
+
+  /* THE WHOLE WALL GOES BACK UP BEFORE ANYTHING IS MEASURED. A hidden slot
+   * measures zero, and a zero-height sheet is a sheet THE FIT thinks already
+   * fits - so a fit run over a trimmed wall leaves every sheet below the cut
+   * at full type, and the next trim then cuts the wall higher for that reason
+   * alone. Two runs of that and the miniature is one row. Untrim, fit, trim,
+   * in that order, every time. */
+  function refit() {
+    if (!fitOpts) return false;
+    let ok = false;
+    try { untrim(); } catch (e) { /* noop */ }
+    try { ok = !!fitSheets(hostEl, sheets, fitOpts); }
+    catch (e) { say('corkboard fit: ' + ((e && e.message) || e)); }
+    try { trimWholeRows(); }
+    catch (e) { say('corkboard trim: ' + ((e && e.message) || e)); }
+    return ok;
+  }
+
+  /** Every slot back in the flow (see refit). */
+  function untrim() {
+    if (o.wholeRows !== true) return;
+    for (let i = 0; i < mounted.length; i += 1) {
+      const slot = mounted[i];
+      if (!slot || !slot.style || typeof slot.style.removeProperty !== 'function') continue;
+      try { slot.style.removeProperty('display'); } catch (e) { /* noop */ }
+    }
+  }
+
+  /* WHOLE SHEETS ONLY (the miniature's rule - see opts.wholeRows). Measure the
+   * whole standing wall first and only then take slots down: a grid re-places
+   * what is left the moment one item leaves the flow, so a one-pass "measure,
+   * hide, measure the next" walks the wall up under itself. Trailing items are
+   * the only ones taken down, so the auto-placement above the cut cannot move. */
+  function trimWholeRows() {
+    if (!fitOpts || o.wholeRows !== true) return;
+    const box = Number(hostEl.clientHeight) || 0;
+    if (!(box > 0)) return;
+    const seen = [];
+    for (let i = 0; i < mounted.length; i += 1) {
+      const slot = mounted[i];
+      if (slot && slot.style && typeof slot.style.removeProperty === 'function') seen.push(slot);
+    }
+    let cut = -1;
+    for (let i = 0; i < seen.length; i += 1) {
+      const top = Number(seen[i].offsetTop) || 0;
+      const h = Number(seen[i].offsetHeight) || 0;
+      if (top + h > box + 1) { cut = i; break; }
+    }
+    if (cut < 0) return;
+    for (let i = cut; i < seen.length; i += 1) seen[i].style.display = 'none';
+  }
+
+  function refitSoon() {
+    if (pending) return;
+    pending = true;
+    const run = () => { pending = false; refit(); };
+    if (typeof requestAnimationFrame === 'function') {
+      try { requestAnimationFrame(run); return; } catch (e) { /* noop */ }
+    }
+    timers.push(setTimeout(run, 32));
+  }
+
+  let onResize = null;
+  if (fitOpts) {
+    refit();
+    refitSoon();
+    if (typeof setTimeout === 'function') timers.push(setTimeout(refit, 420));
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+      onResize = refitSoon;
+      window.addEventListener('resize', onResize);
+    }
+  }
+
   return {
     notices: up,
     daySeed: seed,
     first: first,
+    /** The sheets, for a suite that wants to measure one. */
+    sheets: sheets,
+    /** Re-run THE FIT (the stage scale moved, or a sheet landed late). */
+    refit: refit,
     /** The Esc fold's handle: true when a reader was up and is now down. */
     closeReader() { return closeNoticeReader(); },
     destroy() {
       if (!preview) closeNoticeReader();
+      if (onResize && typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+        try { window.removeEventListener('resize', onResize); } catch (e) { /* noop */ }
+        onResize = null;
+      }
+      for (let i = 0; i < timers.length; i += 1) { try { clearTimeout(timers[i]); } catch (e) { /* noop */ } }
+      timers.length = 0;
       for (let i = 0; i < mounted.length; i += 1) {
         try { mounted[i].remove(); } catch (e) { /* noop */ }
       }
       mounted.length = 0;
+      sheets.length = 0;
     },
   };
 }

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.css
@@ -286,32 +286,41 @@ html.arc-mobile .rr-cards .arc-records-docket { min-height: 0; }
    `.arc-cork-wall{grid-template-columns:1fr}` at the same specificity, and
    which sheet linked last is not something this file gets to know. */
 .rr-cork.arc-cork-wall {
-  /* PINNED PAPER HANGS. A sheet that runs past the bottom rail of the frame is
-     hanging off the board the way pinned paper does - it is NOT cut by the
-     cork and it does NOT put a scrollbar on a corkboard (owner 2026-08-25). So
-     the host never clips; a busy term's overrun spills over the frame's
-     bottom rail onto the wall, and only the stage edge itself ever cuts it. */
-  overflow: visible;
+  /* THE SCROLL AND THE STACK ARE corkboard.css'S NOW, and this rule must not
+     take them back: `.rr-cork.arc-cork-wall` there and `.rr-cork.arc-cork-wall`
+     here are the SAME specificity (0,2,0), so whichever sheet the lazy links
+     happened to land in last would win - and the two sheets are linked by two
+     different modules, in whatever order the network answers. One owner per
+     declaration is the only stable arrangement.
+
+     What went, and why (owner ruling 2026-08-25, "we should see the full doc"):
+     `overflow:visible` hung a busy term's overrun off the bottom rail, which
+     was fine while a sheet was capped at 292px and faded out. A sheet is as
+     tall as its copy now, so the overrun is boards deep - it scrolls. And
+     `align-content:space-between` spread the rows over the host's own height,
+     which the MINIATURE on the wide shot cannot reproduce (its box is the
+     painted cork, 45 stage px shorter): `start` in both is what makes the
+     thumbnail the same picture as the board. */
   padding: 12px 18px 14px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  /* THE WALL USES ITS HEIGHT. A cork with four sheets in one band across the
-     top and 40% of bare board underneath reads as a board somebody stripped,
-     not as a board somebody pinned. Two rows, pushed to the two edges: the
-     host is the grid AND the scroller, and its height is the measured rect, so
-     `space-between` has a real box to distribute in. A busy term overruns the
-     frame and hangs below it, and `space-between` degrades to `start` on its own. */
-  align-content: space-between;
   row-gap: clamp(16px, 2vw, 30px);
 }
 .rr-cork .arc-cork-slot { animation-duration: .28s; }
 
 /* This paper is read at arm's length across a room, not on a phone in a 900px
    column: the plate is 1285 stage px wide and a third of it is a big sheet.
-   Type up to match, or the copy is technically dark and practically a texture. */
-.rr-cork .arc-cork-notetitle { font-size: 17px; margin-bottom: 6px; }
-.rr-cork .arc-cork-notebody { font-size: 14.5px; line-height: 1.5; }
-.rr-cork .arc-cork-kind { font-size: 10.5px; margin-bottom: 6px; }
-.rr-cork .arc-corknote { padding: 18px 18px 15px; }
+   Type up to match, or the copy is technically dark and practically a texture.
+
+   ONE DIAL. `--note-fs` is corkboard.css's single type size and the title and
+   the tag are ratios of it, which is what lets corkboard.js's FIT shrink one
+   sheet toward the floor without knowing anything about three rules. */
+.rr-cork .arc-corknote { --note-fs: 14.5px; padding: 18px 18px 15px; }
+.rr-cork .arc-cork-notetitle { font-size: calc(var(--note-fs) * 1.172); margin-bottom: 6px; }
+.rr-cork .arc-cork-notebody { line-height: 1.5; }
+.rr-cork .arc-cork-kind { font-size: calc(var(--note-fs) * .724); margin-bottom: 6px; }
+/* A torn corner is a fixed bite out of the bottom (corkboard.css THE TEAR), so
+   the blank paper under the copy is the same fixed number in this room too. */
+.rr-cork .arc-corknote.is-torn { padding-bottom: calc(15px + var(--tear)); }
 
 /* ------------------------------------------------------------- THE BOOK */
 

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/recordsroom.js
@@ -149,6 +149,32 @@ export function recordsFx(now) {
 /** The bare cork inside the board close-up - where the paper goes. */
 export const CORK_INNER = Object.freeze([43, 37, 1285, 692]);
 
+/* ----------------------------------------------------------------------------
+ * THE PAINTED CORK ON THE WIDE PLATE, and the lamp that stands in front of it.
+ *
+ * `RECTS.corkboard` is the HOTSPOT - the whole framed object, timber and all,
+ * with a few pixels of slack under it so the press is comfortable. It is not a
+ * place to hang paper, and hanging paper on it is exactly what the first
+ * miniature did: the sheets started 9px above the cork (on the frame), ran 17px
+ * below its bottom rail onto the desk, and the bottom-right one landed on the
+ * banker's lamp (owner screenshot, 2026-08-25).
+ *
+ * These two numbers are measured off `art/vn/vn-09-records-office.png` itself,
+ * not read off a spec sheet:
+ *   - the frame's INNER edges are the dark outline at x=236 and x=539, y=163
+ *     and y=362, so the cork face is x 237..538, y 165..361 (302 x 197);
+ *   - the lamp's shade breaks that plane at y=322 and reaches back to x=480,
+ *     which is inside the cork's own right third.
+ * So the paper stops five pixels above the shade: [237, 165, 302, 152]. The
+ * bottom band of the board is bare on purpose - it is the part of the board
+ * the lamp is standing in front of.
+ * -------------------------------------------------------------------------- */
+
+/** The painted cork on the WIDE plate, trimmed to clear the lamp shade. */
+export const CORK_WIDE = Object.freeze([237, 165, 302, 152]);
+/** The top edge of the banker's lamp shade on that plate (stage px). */
+export const LAMP_SHADE_TOP = 322;
+
 /** The two blank pages inside the book close-up. */
 export const LEDGER_PAGES = Object.freeze({
   left: Object.freeze([224, 164, 436, 492]),
@@ -505,12 +531,20 @@ export function createRecordsRoom(caps) {
    * CLOSE-UP's own width, so a sheet in the miniature is the same shape as the
    * sheet you walk up to, and the whole thing is then scaled by the ratio the
    * two rects give us. Its height is the rect divided back out by that scale,
-   * which is what lets the grid deal two rows into the board's own proportions
-   * rather than into a letterboxed strip.
+   * so the miniature is the TOP of the close-up's own board - the same grid,
+   * the same rows, the same type - ending where the painted cork ends.
+   *
+   * IT HANGS ON `CORK_WIDE`, NOT ON THE HOTSPOT. See that constant: the rect
+   * you press is the framed object and the rect paper hangs on is the cork
+   * inside it, minus the band the lamp stands in front of.
+   *
+   * AND IT IS DEALT THE CLOSE-UP'S OWN FIT. Same `boxH`, same `scale`, so the
+   * two walls shrink the same sheet by the same amount and the thumbnail is a
+   * picture of the board rather than a second, differently-typeset board.
    */
   function mountMiniCork() {
     if (dead || mini) return;
-    const rect = RECTS.corkboard;
+    const rect = CORK_WIDE;
     const scale = rect[2] / CORK_INNER[2];
     if (!(scale > 0)) return;
     const wrap = el('div', 'rr-corkmini');
@@ -526,11 +560,36 @@ export function createRecordsRoom(caps) {
     } catch (e) { /* the node double has no style box - the wall still mounts */ }
     wrap.appendChild(inner);
     miniOff = scene.mountInView('wide', wrap, rect);
-    mini = mountNotices(inner, { daySeed: c.daySeed, preview: true, log: log });
+    mini = mountNotices(inner, {
+      daySeed: c.daySeed,
+      preview: true,
+      fit: corkFit(),
+      /* The board has a bottom rail painted into it: a sheet sliced flat along
+       * that rail is a rendering fault, a shorter wall is a wall. */
+      wholeRows: true,
+      log: log,
+    });
     if (!mini) log('records room: the miniature wall could not be pinned');
   }
 
   /* ------------------------------------------------------------ THE BOARD */
+
+  /**
+   * THE FIT BOTH WALLS SHARE. `boxH` is the close-up cork's height in stage px
+   * and `scale` is the STAGE's, read live off the chassis (a window resize
+   * moves it, and corkboard.js re-runs the fit on its own resize listener).
+   * The miniature must never measure its own host for this: it carries a
+   * second scale of its own, which would answer a smaller number and print the
+   * thumbnail in bigger type than the board it is a picture of.
+   */
+  function corkFit() {
+    return {
+      boxH: CORK_INNER[3],
+      scale: function () {
+        try { return scene.scale ? scene.scale() : 1; } catch (e) { return 1; }
+      },
+    };
+  }
 
   /** Pin the night's sheets over the bare cork, once per visit to the room. */
   function mountBoard() {
@@ -548,6 +607,9 @@ export function createRecordsRoom(caps) {
        * full size over the window (corkboard.js's READER). The wall is still
        * read at a glance - this is what a glance you cannot resolve does next. */
       readable: true,
+      /* The board's own box, and the stage's own scale - the miniature above
+       * is handed this same pair on purpose. */
+      fit: corkFit(),
       log: log,
     });
     if (!paper) log('records room: the wall could not be pinned');
@@ -636,7 +698,14 @@ export function createRecordsRoom(caps) {
     escapeStep: escapeStep,
     dismissSpotlight: dismissSpotlight,
     setAjar: setAjar,
-    fit: function () { try { return scene.fit(); } catch (e) { return null; } },
+    fit: function () {
+      let s = null;
+      try { s = scene.fit(); } catch (e) { s = null; }
+      /* The stage moved, so the type floor moved with it. */
+      if (paper && paper.refit) { try { paper.refit(); } catch (e) { /* noop */ } }
+      if (mini && mini.refit) { try { mini.refit(); } catch (e) { /* noop */ } }
+      return s;
+    },
     destroy: destroy,
     /* ------------------------------------------------------- test seams */
     scene: scene,

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/scene.js
@@ -1196,6 +1196,9 @@ export function createScene(opts) {
 
   /* ---------------------------------------------------------------- fit */
 
+  /** The last scale `fit()` computed - the stage's, never a prop's own. */
+  let lastScale = 1;
+
   /** Scale to fit, then hang the apron off the painting's floor line and
    *  publish the band height. `--arm-band-h` goes on BOTH root and bar: the
    *  bar is a body-level sibling and cannot inherit a var set on root alone. */
@@ -1204,6 +1207,14 @@ export function createScene(opts) {
     const w = root.clientWidth || (root.parentNode && root.parentNode.clientWidth) || stageW;
     const h = root.clientHeight || (root.parentNode && root.parentNode.clientHeight) || stageH;
     const s = Math.min(w / stageW, h / stageH) || 1;
+    /* ONE STAGE, ONE SCALE, and a consumer may ask for it. A prop that has to
+     * reason in SCREEN pixels (the corkboard's type floor is 10 real pixels,
+     * whatever the plate is doing) cannot measure its own host: the miniature
+     * on the wide shot carries a second scale of its own, so its rect would
+     * answer a different number than the close-up's and the two walls would
+     * lay out differently. This is the stage's number, the same for every prop
+     * on it, and `scale()` below is the only way to read it. */
+    lastScale = s;
     /* THE PHONE ANCHORS THE PAINTING TO THE TOP and takes a 72px band instead
      * of 110 - room.js's change, for room.js's reasons, on the chassis that
      * shares its apron. scene.css moves the box and the origin together under
@@ -1306,6 +1317,8 @@ export function createScene(opts) {
     setFlag: setFlag,
     escapeStep: escapeStep,
     fit: fit,
+    /** Stage px -> screen px, as of the last fit. See fit(). */
+    scale: function () { return lastScale; },
     destroy: destroy,
     /* ---------------------------------------------- the alive layer's seams */
     /** {records, timers, held} - `timers` MUST be 0 after destroy(). */


### PR DESCRIPTION
Re-open of #316 rebased onto main (CLAUDE.md trap numbering conflict with #315; both traps kept).

Three owner defects from the Records-room phone shots:

1. Wide-view corkboard miniature sat on the frame, desk and lamp - it was pinned to the press rect. New `CORK_WIDE` = painted cork face measured off vn-09, trimmed to stop above the banker's lamp shade; the mini is dealt the close-up's own fit with whole rows.
2. Sheet edges faded - the 292px cap and `mask-image` are gone; a sheet is as tall as its copy, `fitSheets()` shrinks the note font toward a 10px phone floor, the close-up host scrolls.
3. Translucent paper on the wall and in the reader - `background:` shorthand reset `background-color`; paper colour is now an explicit `background-color`, the reader is opaque with `mask-image:none`.

Suites: records-room scene 253/0, room 352/0. Headless shots at 844x390 forcemobile + 1600x900. No new strings, no art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6