### PR TITLE
fix(arcademy): intro jingle strikes on the first frame + splash waits; phone bell chip two lines, left of the tower clock

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2396,6 +2396,26 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
       one owner, and the room suite greps recordsroom.css (comments stripped - the prose
       explaining what left names the properties) to keep it that way.
 
+106. **THE BED IS STRUCK BEFORE INIT ON THE APP HOST, OR IT IS NOT STRUCK AT ALL (owner,
+    third report, 2026-08-25: "wait for the jingle to end before entering, the jingle should
+    start sooner").** Trap 105's neighbour, THE SPLASH WAITS FOR THE JINGLE, was correct and
+    did nothing on the desktop: strikeBed sits behind the mixer, the mixer behind `init`, and
+    the WebView2 host sends init ~3s after the page (log: launched 10:28:49.686, sent init
+    10:28:52.922) - five times INTRO_BED_WINDOW_MS - so scheduleIntroCues dealt the stitched
+    beats every time and the splash walked out at INTRO_MIN_MS. boot.js now strikes
+    `assets/sfx/intro_bed.mp3` as a plain element at module evaluation (`strikeEarlyBed`) on a
+    REAL WebView2 only (`window.chrome.webview` without the web shim's `__deliver` seam), sets
+    `bedStruck` so the mixer never re-fires it and no stitched beat lands over it, and
+    `tuneEarlyBed()` on init applies the mixer's own element math (sqrt(level) * CLIP_GAIN *
+    fx * master) or STOPS it under audioMute / zero bus / reduced motion (trap 66). A refused
+    play() (a browser) hands the strike back to the knock. tuneEarlyBed runs BEFORE the audio
+    consumer import: a host whose mixer fails to load must not keep a muted school's bed
+    playing. Test seam `introBedState()`; suite in session fe888044 scratchpad
+    `bell/test-earlybed.mjs` (boot.js under a fake DOM, `?instance=n` per world; bridge.js is
+    ONE shared instance, so its webview listener belongs to the first world - keep it).
+    Same PR: the phone bell chip is two lines (grid, icon spanning both rows) stepped left
+    of the bell tower's painted clock by clamp(32px, 5vw, 48px); every rule html.arc-mobile.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/boot.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/boot.js
@@ -327,6 +327,7 @@ function settleBed(reason) {
   if (!bedHolding) return;              // already settled, or never struck
   bedHolding = false;
   if (bedCapTimer) { clearTimeout(bedCapTimer); bedCapTimer = 0; }
+  stopEarlyBed();
   log('intro bed settled (' + reason + ') at ' + (Date.now() - introT0) + 'ms');
   if (!bedDismissQueued) return;
   bedDismissQueued = false;
@@ -337,6 +338,107 @@ function cancelBedHold() {
   bedHolding = false;
   bedDismissQueued = false;
   if (bedCapTimer) { clearTimeout(bedCapTimer); bedCapTimer = 0; }
+  stopEarlyBed();
+}
+
+/* ----------------------------------------------------------------------------
+ * THE BED STRIKES ON THE FIRST FRAME (owner report, third time of asking,
+ * 2026-08-25: "wait for the jingle to end before entering, the jingle should
+ * start sooner").
+ *
+ * The hold above was right and still did nothing on the desktop, because the
+ * bed it waits for was never struck there. strikeBed lives behind the mixer,
+ * the mixer lives behind `init`, and on the WebView2 host `init` lands about
+ * three seconds after the page (log: launched 10:28:49.686, sent init
+ * 10:28:52.922) - five times INTRO_BED_WINDOW_MS. scheduleIntroCues therefore
+ * took the stitched beats every time, the splash walked out at INTRO_MIN_MS,
+ * and the one jingle in the school played late or not at all.
+ *
+ * So on the app host the bed is a plain media element struck HERE, at module
+ * evaluation, before anyone has said init - the same file, the same level, the
+ * same hold. `bedStruck` is set, so the mixer's strikeBed later declines (the
+ * bed is the one cue that may never be re-fired) and scheduleIntroCues deals no
+ * stitched beats over it. When init does land, tuneEarlyBed() applies the real
+ * levels: the mixer's own element math (sqrt(level) * CLIP_GAIN * fx * master),
+ * and a muted school, a zero bus, or reduced motion (trap 66: no cues) STOPS it
+ * and releases the hold on the spot, which is the timing those hosts had.
+ *
+ * WHICH HOST: only a real WebView2 (`window.chrome.webview` without the web
+ * shim's `__deliver` seam). The shim fakes the bridge for app.cclabs.app, where
+ * play() without a gesture is refused - and a refused play hands the strike
+ * back (bedStruck cleared) so the knock strikes the bed through the mixer as it
+ * always has. A missing file 404s into 'error', which releases the hold with
+ * nothing else changed. Nothing here can throw past its try.
+ * -------------------------------------------------------------------------- */
+const EARLY_BED_URL = './assets/sfx/intro_bed.mp3';   // shell/audio.js SAMPLES.intro_bed
+const EARLY_BED_LEVEL = 0.6;   // what strikeBed asks the mixer for
+const EARLY_BED_GAIN = 0.5;    // shell/audio.js CLIP_GAIN
+const EARLY_BED_FX = 0.85;     // shell/audio.js DEFAULT_LEVELS.fx
+let earlyBed = null;           // the element in the air, or null
+let earlyBedStruckAt = -1;     // ms from introT0, -1 = never (test seam)
+
+function clamp01(v) { v = Number(v); return v > 1 ? 1 : (v > 0 ? v : 0); }
+function earlyBedVolume(fx, master) {
+  return clamp01(Math.sqrt(EARLY_BED_LEVEL) * EARLY_BED_GAIN * clamp01(fx) * clamp01(master));
+}
+function isRealWebView2() {
+  try {
+    const wv = win && win.chrome && win.chrome.webview;
+    return !!wv && typeof wv.__deliver !== 'function';
+  } catch (e) { return false; }
+}
+
+function stopEarlyBed() {
+  const el = earlyBed;
+  if (!el) return;
+  earlyBed = null;
+  try { el.pause(); } catch (e) { /* noop */ }
+  try { el.removeAttribute('src'); el.load(); } catch (e) { /* noop */ }
+}
+
+function strikeEarlyBed() {
+  try {
+    if (bedStruck || !isRealWebView2() || !splashIsUp()) return;
+    if (typeof Audio !== 'function') return;
+    const el = new Audio(EARLY_BED_URL);
+    el.preload = 'auto';
+    el.volume = earlyBedVolume(EARLY_BED_FX, 1);
+    bedStruck = true;
+    bedHolding = true;
+    earlyBed = el;
+    earlyBedStruckAt = Date.now() - introT0;
+    const settle = (reason) => { if (earlyBed !== el) return; settleBed(reason); };
+    el.addEventListener('ended', () => settle('ended'));
+    el.addEventListener('error', () => settle('error'));
+    let p = null;
+    try { p = el.play(); } catch (e) { p = null; }
+    if (p && typeof p.catch === 'function') {
+      p.catch(() => {
+        // Refused without a gesture: this is a browser after all. Hand the
+        // strike back to the knock, which reaches the bed through the mixer.
+        if (earlyBed !== el) return;
+        settleBed('blocked');
+        bedStruck = false;
+      });
+    }
+    bedCapTimer = setTimeout(() => { bedCapTimer = 0; settleBed('cap-local'); }, BED_HOLD_CAP_MS);
+    log('intro bed struck early at ' + earlyBedStruckAt + 'ms');
+  } catch (e) { /* the opening may never cost us the boot */ }
+}
+
+/** init has landed: the early bed takes the school's real levels, or stops. */
+function tuneEarlyBed() {
+  const el = earlyBed;
+  if (!el) return;
+  try {
+    const src = initMsg || {};
+    const fx = (src.audioLevels && src.audioLevels.fx != null) ? clamp01(src.audioLevels.fx) : EARLY_BED_FX;
+    const master = src.masterVolume == null ? 1 : clamp01(src.masterVolume);
+    const quiet = !!src.audioMute || master <= 0 || fx <= 0
+      || !!src.reducedMotion || src.motionLevel === 0;
+    if (quiet) { settleBed('muted-at-init'); return; }
+    el.volume = earlyBedVolume(fx, master);
+  } catch (e) { /* a volume is not worth the boot */ }
 }
 
 /* ----------------------------------------------------------------------------
@@ -403,6 +505,7 @@ function scheduleIntroCues() {
     // The same derivation the shell uses for the class it paints on <html>.
     if (!!src.reducedMotion || src.motionLevel === 0) return;
     if (!splashIsUp()) return;
+    if (bedStruck) return;            // the early bed owns the opening: no stitched beats over it
     const elapsed = Date.now() - introT0;
     // hasSample is feature-detected: an older consumer simply stitches.
     const hasBed = !!(audio && typeof audio.hasSample === 'function' && audio.hasSample('intro_bed'));
@@ -492,6 +595,10 @@ async function start() {
      * and one that re-lays itself out the moment the school opens. Idempotent:
      * the shell calls it again for the harness case where boot never ran. */
     try { installDeviceClass(); } catch (e) { /* never worth a boot */ }
+    /* An early bed takes the school's real levels first, or stops if the school
+     * is muted - BEFORE the mixer, because it needs only `init`, and a host whose
+     * audio consumer fails to load must not keep playing at the default level. */
+    tuneEarlyBed();
     // The sfx consumer first, so a cue fired during the shell's own boot is heard.
     // OPTIONAL by construction: no audio must never cost us the page.
     try {
@@ -730,6 +837,7 @@ bridge.startHeartbeat(5000);
 armBootDeadline();
 bridge.announceReady();
 log('boot: ready posted, waiting for init');
+strikeEarlyBed();
 
 if (!bridge.isHosted) {
   // Standalone (a plain browser, e.g. a future gated web app or a dev harness):
@@ -743,6 +851,11 @@ export { dom, toast };
 
 /** Test seam: the live sfx consumer (null until init). */
 export function audioConsumer() { return audio; }
+
+/** Test seam: the opening bed - struck, holding, early element live, ms of the early strike. */
+export function introBedState() {
+  return { struck: bedStruck, holding: bedHolding, early: !!earlyBed, earlyAt: earlyBedStruckAt };
+}
 
 /** Test seam: the suspend frame buffered while the shell was still booting. */
 export function bufferedSuspend() { return pendingSuspend; }

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -4935,8 +4935,19 @@ html.arc-mobile .arc-acct-menu {
 }
 html.arc-mobile .arc-acct-item { min-height:44px; padding:12px 12px; font-size:13px; }
 
-/* The account chip made the campus top-right cluster 54px wider, and on a
-   landscape phone the bell chip was already brushing the hanging TIMETABLE
-   plaque. The bell keeps its icon and its time; the NEXT BELL caption is the
-   part a thumb never needed. */
-html.arc-mobile .campus-bellchip .cap { display:none; }
+/* THE BELL CHIP IS TWO LINES ON A PHONE (owner, 2026-08-25). One row of chip
+   (149px wide) lay straight across the bell tower's own painted clock face at
+   the top right of the plan (x ~690-720 of 844), and at 667 it brushed the
+   hanging TIMETABLE plaque. Now: the icon on the left spanning both rows, the
+   NEXT BELL caption over the time, smaller type (~90px wide), and the whole chip
+   stepped left of the tower by clamp(32px, 5vw, 48px): 33 at 667, 42 at 844,
+   47 at 932. Desktop keeps the one-row pill above; every rule here is
+   html.arc-mobile-scoped. */
+html.arc-mobile .campus-bellchip {
+  display:grid; grid-template-columns:auto auto; column-gap:7px; row-gap:2px;
+  align-items:center; padding:5px 11px 5px 9px; border-radius:14px;
+  margin-right:clamp(32px, 5vw, 48px);
+}
+html.arc-mobile .campus-bellchip .ic { grid-row:1 / 3; font-size:13px; }
+html.arc-mobile .campus-bellchip .cap { display:block; font-size:7.5px; letter-spacing:.18em; line-height:1; }
+html.arc-mobile .campus-bellchip .tm { font-size:10px; line-height:1; }


### PR DESCRIPTION
Two owner reports from 2026-08-25.

**The jingle (third ask).** The splash-waits-for-the-jingle hold was right and did nothing on the desktop: the bed is struck through the mixer, the mixer waits for `init`, and the WebView2 host sends init ~3s after the page (log: launched 10:28:49.686, sent init 10:28:52.922), five times `INTRO_BED_WINDOW_MS`. So the stitched beats played instead and the splash left at `INTRO_MIN_MS`. Now `boot.js` strikes `intro_bed.mp3` as a plain element at module evaluation on a real WebView2 only; the existing hold owns the exit, so the campus reveals when the bed ends. On init the element takes the mixer's real levels or stops under mute / zero bus / reduced motion (before the mixer import, so a failed mixer cannot leave a muted school's bed playing). A refused `play()` (browser) hands the strike back to the knock.

**The bell chip on mobile.** One-row chip sat across the bell tower's painted clock at the top right and brushed the TIMETABLE plaque at 667. Now two lines (icon spanning both rows, NEXT BELL over the time), ~127px wide, stepped left by `clamp(32px, 5vw, 48px)`. Rig shots at 667/844/932 forcemobile + 1600x900 (desktop unchanged).

Tests: `bell/test-earlybed.mjs` 13/0 (boot.js under a fake DOM: early strike, ended, refused play, shim host, muted init, retune). Trap 106 in the web CLAUDE.md. No new strings, no art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TywYSfc2Uyhabzv5vdVQ6