### PR TITLE
perf(arcademy): mobile web perf wave - ae-touch page-wide, video caps, on-deck warm rail, shell GPU diet

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -1398,8 +1398,20 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     a frame for a backdrop-filter or a full-screen blend surface that a desktop GPU eats for
     free. So The Deep End probes the device once per class - `matchMedia('(pointer: coarse)')`
     or `navigator.maxTouchPoints > 1` - and puts **`.ae-touch` on `<html>`**, the same
-    document-root seam `.ae-lite` uses (the game sets it, the engine only reads it, and
-    BOTH come off on destroy or the lobby inherits a phone's ceiling).
+    document-root seam `.ae-lite` uses (the game sets it, the engine only reads it).
+    - **GLOBALLY ARMED SINCE 2026-08-25 (perf/arcademy-mobile-web):** `core/device.js`
+      arms `.ae-touch` page-wide at paint when `isMobile() && touchProbe()` and stamps
+      `data-ae-touch-global="1"` on `<html>` - ONCE ON, NEVER OFF (a rotate can flip
+      `isMobile()`, the GPU that needed the ceiling still needs it). The Deep End's own
+      lifecycle add/remove SKIPS when the marker is present (its destroy used to hand
+      the lobby back its desktop-cost washes); its per-class probe survives only as the
+      fallback for big tablets/touch laptops where `isMobile()` is false. The arming
+      gates on `isMobile()` too - NOT the bare probe - because desktop WebView2 on a
+      touch-screen laptop must never change visuals, and `isMobile()` (coarse PRIMARY
+      pointer, no fine pointer anywhere) is structurally false there. A phone also gets
+      the engine's lite node budgets (`curves.js` *Lite twins, `ctx.lite()` = coarse or
+      motionLevel<=1), the shell's GPU DIET block at the bottom of `styles.css`, and
+      per-game `html.ae-touch` blocks (impulse-control's blur diet among them).
     - It is **NOT a third rung**: it applies on FULL too, and `de_perf: full` does not opt
       out of it. There is no setting and there must never be one - the device is the setting.
     - It **composes with the rung in the PROTECTIVE direction, and the two dials point

--- a/ConditioningControlPanel/Resources/web/arcademy/core/device.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/core/device.js
@@ -16,6 +16,9 @@
  * them in step across a rotate or a resize. Desktop never gets the class, so
  * every mobile rule in the sheets is dead code on a desktop window and the
  * WebView2 build stays pixel-identical to what it was before this file existed.
+ * (Since 2026-08-25 the same paint also ARMS the engine's `html.ae-touch` GPU
+ * ceiling on mobile - see THE GLOBAL GPU CEILING below; it rides the same
+ * isMobile() verdict, so the desktop invariant above is untouched.)
  *
  * THE RULE (and why it is shaped like this)
  *   1. The PRIMARY pointer is coarse - `matchMedia('(pointer: coarse)')`.
@@ -50,6 +53,16 @@
 
 /** The class this module writes on <html>. CSS keys every mobile rule off it. */
 export const MOBILE_CLASS = 'arc-mobile';
+
+/** The engine's GPU-ceiling class (engine/style.js reads it, engine/util.js's
+ *  decoder budget reads it). This module may ARM it; it never removes it. */
+export const TOUCH_CLASS = 'ae-touch';
+
+/** The marker that says the ARMING WAS GLOBAL (this module's), so per-class
+ *  owners of the same seam (The Deep End) know not to toggle it on their own
+ *  lifecycle - a destroy() that removed a page-wide ceiling would hand the
+ *  lobby back its desktop-cost effects. */
+export const TOUCH_GLOBAL_ATTR = 'data-ae-touch-global';
 
 /** Short-side ceiling, in CSS px, for "this is a phone-shaped screen". */
 export const MOBILE_MAX_SHORT_SIDE = 820;
@@ -139,12 +152,65 @@ function stateKey() {
   return (isMobile() ? 'm' : 'd') + ':' + orientation();
 }
 
+/** The Deep End's own hardware probe, verbatim: coarse primary pointer OR more
+ *  than one touch point. Broader than isMobile() on purpose - it is a GPU
+ *  ceiling, not a layout verdict - but see armTouchClass() for why the arming
+ *  below still gates on isMobile() as well. */
+function touchProbe() {
+  if (mq('(pointer: coarse)')) return true;
+  try {
+    if (typeof navigator !== 'undefined' && Number(navigator.maxTouchPoints) > 1) return true;
+  } catch (e) { /* ignore */ }
+  return false;
+}
+
+/* ----------------------------------------------------------------------------
+ * THE GLOBAL GPU CEILING (mobile perf, 2026-08-25).
+ *
+ * engine/style.js's `.ae-touch` block kills what WebKit charges a phone most
+ * for (backdrop-filter, full-screen blend surfaces, the scanline re-raster,
+ * filters over live decodes) and engine/util.js drops the decoder budget 6->3
+ * under it - but the ONLY writer used to be The Deep End's class lifecycle, so
+ * nine of ten classes and the whole shell ran desktop-cost effects on phones.
+ * Arm it here instead, once, page-wide, from the same installDeviceClass()
+ * boot.js and shell.js already call.
+ *
+ * WHY `isMobile() && touchProbe()` AND NOT the probe alone: the bare probe
+ * catches a touch-screen Windows laptop, and on the desktop WebView2 host that
+ * would CHANGE DESKTOP VISUALS (blend modes off, scanline still) - desktop must
+ * stay pixel-identical. A host probe is no help either: the web shim
+ * (cclabs-web arcademy-web-ext/web-shim.js) deliberately fakes
+ * `window.chrome.webview`, so "am I the desktop app" is unanswerable from here.
+ * `isMobile()` IS provably false on desktop WebView2 - it requires a coarse
+ * PRIMARY pointer and NO fine pointer anywhere, and every desktop/laptop
+ * WebView2 window has a fine pointer (`?forcemobile=1` never appears in the
+ * host's fixed URL) - so gating on it makes desktop immunity structural.
+ * The cost of the narrower gate: a big tablet (iPad Pro 11"+) or touch laptop
+ * browser does not get the ceiling globally; The Deep End's own per-class
+ * probe still covers it there, exactly as before.
+ *
+ * ONCE ON, NEVER OFF: a rotate or resize can flip isMobile(), but a GPU that
+ * needed the ceiling a minute ago still needs it now. TOUCH_GLOBAL_ATTR is the
+ * marker that tells per-class writers the class is not theirs to toggle.
+ * -------------------------------------------------------------------------- */
+function armTouchClass(html) {
+  try {
+    html.classList.add(TOUCH_CLASS);
+    if (typeof html.setAttribute === 'function') html.setAttribute(TOUCH_GLOBAL_ATTR, '1');
+  } catch (e) { /* never fatal */ }
+}
+
 function paintRoot() {
   try {
     const html = typeof document !== 'undefined' && document.documentElement;
     if (!html || !html.classList) return;
-    if (isMobile()) html.classList.add(MOBILE_CLASS);
-    else html.classList.remove(MOBILE_CLASS);
+    if (isMobile()) {
+      html.classList.add(MOBILE_CLASS);
+      if (touchProbe()) armTouchClass(html);
+    } else {
+      html.classList.remove(MOBILE_CLASS);
+      // ae-touch stays if it was ever armed - see the block comment above.
+    }
     if (typeof html.setAttribute === 'function') html.setAttribute('data-arc-orient', orientation());
   } catch (e) { /* the DOM double has no classList - never fatal */ }
 }
@@ -207,7 +273,7 @@ export function onDeviceChange(fn) {
 }
 
 export default {
-  MOBILE_CLASS, MOBILE_MAX_SHORT_SIDE,
+  MOBILE_CLASS, MOBILE_MAX_SHORT_SIDE, TOUCH_CLASS, TOUCH_GLOBAL_ATTR,
   isMobile, orientation, orientationOk, viewportSize,
   installDeviceClass, onDeviceChange,
 };

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/curves.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/curves.js
@@ -21,9 +21,18 @@ export const BUBBLE_MS = Object.freeze({ slow: 2200, fast: 260 });
 export const FLASH_ALPHA_CEIL = 0.85;
 
 /** Node budgets. flash_burst: 20 live desktop / 3 on a coarse-pointer-or-low-motion
- *  device (DTRH FLASH_LIVE_CAP). gif_burst 10, gif_rain 14 (Intake MAX_NODES). */
+ *  device (DTRH FLASH_LIVE_CAP). gif_burst 10, gif_rain 14 (Intake MAX_NODES).
+ *  Every kind now has a *Lite twin (mobile perf, 2026-08-25), picked the same
+ *  way flashBurstLite always was - `ctx.lite()` (coarse pointer OR
+ *  motionLevel <= 1) at the consumption site - so a phone spends fewer live
+ *  nodes per effect while a desktop budget is untouched. */
 export const NODE_CAPS = Object.freeze({
-  flashBurst: 20, flashBurstLite: 3, gifBurst: 10, gifRain: 14, bubbles: 18, ambient: 24, subFlash: 6,
+  flashBurst: 20, flashBurstLite: 3,
+  gifBurst: 10, gifBurstLite: 4,
+  gifRain: 14, gifRainLite: 6,
+  bubbles: 18, bubblesLite: 8,
+  ambient: 24, ambientLite: 10,
+  subFlash: 6, subFlashLite: 3,
 });
 
 /** DTRH's sidechain duck hierarchy — one policy, emitted as duck requests. */

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/oneshots.js
@@ -8,7 +8,7 @@
  *     strobe-class terms (glitch shudder, burst alpha, sub alpha) are additionally
  *     multiplied by effectIntensity (the photosensitivity guard);
  *   - node budgets: flash_burst 20 live (3 on a coarse/low-motion device),
- *     gif_burst 10, sub_flash 6;
+ *     gif_burst 10 (4 coarse/low-motion), sub_flash 6 (3 coarse/low-motion);
  *   - INPUT TRUST: over a click/tap-precision surface the game passes
  *     clickSafe:true and every burst node renders pointer-events:none;
  *   - a clickable burst is a blocking effect, so it carries an ESCAPE GUARD
@@ -56,7 +56,12 @@ export const SUB_HOLD_MAX_MS = 1400;
 export function createOneshots(ctx) {
   const live = { flash: 0, gifBurst: 0, sub: 0 };
 
+  /* The lite twins ride the exact seam flashBurstLite always has: ctx.lite()
+   * (coarse pointer OR motionLevel <= 1), evaluated at spend time. A desktop
+   * with a fine pointer on motionLevel 2 never sees the lite number. */
   const flashCap = () => (ctx.lite() ? NODE_CAPS.flashBurstLite : NODE_CAPS.flashBurst);
+  const gifBurstCap = () => (ctx.lite() ? NODE_CAPS.gifBurstLite : NODE_CAPS.gifBurst);
+  const subCap = () => (ctx.lite() ? NODE_CAPS.subFlashLite : NODE_CAPS.subFlash);
 
   /* ---- glitch_swap ------------------------------------------------------- */
   /**
@@ -104,7 +109,7 @@ export function createOneshots(ctx) {
   /* ---- sub_flash --------------------------------------------------------- */
   function subFlash(opts = {}) {
     if (!hasDom()) return null;
-    if (live.sub >= NODE_CAPS.subFlash) return null;
+    if (live.sub >= subCap()) return null;
     const strength = ctx.ceiling('subDensity', opts.strength);
     if (strength <= 0.001) return null;       // subDensity capped off -> silent
     const spec = subFlashSpec(ctx.strobe(strength));
@@ -173,7 +178,7 @@ export function createOneshots(ctx) {
     const variant = ctx.variant(kind, strobe, ctx.reduced() ? (kind === 'flash_burst' ? 'single' : 'pop') : opts.variant);
     const ceilAlpha = burstOpacityForHeat(heat) * (0.6 + 0.4 * strobe);
     const alpha = Math.min(ceilAlpha, clamp01(opts.alpha == null ? ceilAlpha : ctx.pct(opts.alpha)));
-    const cap = kind === 'flash_burst' ? flashCap() : NODE_CAPS.gifBurst;
+    const cap = kind === 'flash_burst' ? flashCap() : gifBurstCap();
     const counter = kind === 'flash_burst' ? 'flash' : 'gifBurst';
 
     /* FULL BLEED (additive, 2026-08-23). One node covering the whole layer -

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/style.js
@@ -220,9 +220,11 @@ export const STYLE_TEXT = `
        drain wash is up. Its gradient already carries the drain; only the blur
        goes, exactly as in lite.
      - a BLEND SURFACE has to read what is under it before it can write, and
-       these four are FULL-SCREEN (the spiral is 150vmax, over twice the
-       viewport). On the near-black ground screen and plain alpha read almost
-       identically, so the tint stays and the read-back goes.
+       these five are FULL-SCREEN (the spiral is 150vmax, over twice the
+       viewport; .ae-crt is inset:0 with overlay - it was the one fullscreen
+       blend this list originally missed). On the near-black ground screen,
+       overlay and plain alpha read almost identically, so the tint stays and
+       the read-back goes.
      - a FILTER over a live decode is a whole GPU pass per decoded frame
        (ae-burst-double lands on gif_burst nodes, which are <video> whenever
        the pool hands back a webm), and ae-mosh's blur re-runs that pass every
@@ -232,10 +234,13 @@ export const STYLE_TEXT = `
    (background-position, the one pattern the perf trace named), so it holds
    still on touch - the scanlines themselves stay. */
 .ae-touch .ae-wash-drain{backdrop-filter:none;-webkit-backdrop-filter:none}
-.ae-touch .ae-wash-pink,.ae-touch .ae-wash-spiral,.ae-touch .ae-wash-sublim,.ae-touch .ae-jackpot{mix-blend-mode:normal}
+.ae-touch .ae-wash-pink,.ae-touch .ae-wash-spiral,.ae-touch .ae-wash-sublim,.ae-touch .ae-jackpot,.ae-touch .ae-crt{mix-blend-mode:normal}
 .ae-touch .ae-crt-live{animation:none}
 .ae-touch .ae-burst-double{filter:none}
 .ae-touch .ae-glitch-datamosh{filter:none;animation:ae-shudder var(--ae-dur,600ms) steps(2,end) 1}
+/* .ae-mote stays animated on touch ON PURPOSE: ae-float is transform-only
+   (compositor-cheap, no re-raster), and the phone cost of the ambient field is
+   its NODE COUNT, which the lite ladder now caps (curves.js ambientLite). */
 
 /* ---- reduced motion: neutralise EVERY animation -------------------------- */
 @media (prefers-reduced-motion: reduce){

--- a/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/engine/sustained.js
@@ -7,7 +7,8 @@
  *   - ONE reused DOM element per WASH KIND (spiral / pink / braindrain / sublim),
  *     refreshing its fade deadline — overlapping triggers never pile DOM
  *     (DTRH holdOn, verbatim posture);
- *   - node budgets: gif_rain 14, bubbles 18, ambient 24;
+ *   - node budgets: gif_rain 14 (6 coarse/low-motion), bubbles 18 (8),
+ *     ambient 24 (10) - the lite twins ride ctx.lite(), flashBurstLite's seam;
  *   - cadences come from the clamped channel vector (bubbleRate 2200->260ms,
  *     rain gap from flashRate, drift speed/amplitude from bgIntensity) and
  *     RETUNE LIVE when setHeat changes them;
@@ -182,7 +183,9 @@ export function createSustained(ctx) {
     if (rate <= 0.001) { ctx.log('bubble_field: bubbleRate is 0 at this heat/cap - no field'); return null; }
     let spec = bubbleSpec(rate);
     const variant = ctx.variant('bubble_field', spec.alpha, opts.variant);
-    const max = Math.min(NODE_CAPS.bubbles, opts.max == null ? NODE_CAPS.bubbles : opts.max | 0);
+    // the lite twin rides flashBurstLite's own seam: ctx.lite() at spend time
+    const bubbleCap = ctx.lite() ? NODE_CAPS.bubblesLite : NODE_CAPS.bubbles;
+    const max = Math.min(bubbleCap, opts.max == null ? bubbleCap : opts.max | 0);
     const clickSafe = !!opts.clickSafe;
     const clickable = !clickSafe && opts.clickable !== false && typeof opts.onPop === 'function';
     let guard = null;
@@ -263,10 +266,13 @@ export function createSustained(ctx) {
     const spec = gifRainSpec(ctx.magnitude(rate), opts.durationMult || 1);
     const clickSafe = opts.clickSafe !== false;      // rain is decoration by default
     const endAt = (opts.durationMs == null ? spec.durationMs : opts.durationMs) + Date.now();
+    // gifRainSpec is PURE (spec.max is the desktop cap); the lite twin is
+    // composed here, on flashBurstLite's own ctx.lite() seam, min = protective.
+    const rainCap = ctx.lite() ? Math.min(spec.max, NODE_CAPS.gifRainLite) : spec.max;
     let timer = 0;
 
     function spawn() {
-      if (live.rain >= spec.max) return;
+      if (live.rain >= rainCap) return;
       /* THE DECODER BUDGET (util.js): past it a 'loop' request is served a
        * still, so the rain keeps its node count and drops its decode cost. */
       const url = ctx.assetUrlSync(budgetedKind(opts.assetKind || 'loop'));
@@ -313,7 +319,11 @@ export function createSustained(ctx) {
     const spec = ambientSpec(ctx.magnitude(ctx.ceiling('bgIntensity', opts.density)), opts.count || 16);
     if (!spec.on) return null;
     const nodes = [];
-    const count = Math.max(1, Math.round(spec.count * (ctx.motion() <= 0 ? 0.4 : 1)));
+    // ambientSpec is PURE (spec.count <= NODE_CAPS.ambient); the lite twin is
+    // composed here on ctx.lite(), exactly the flashBurstLite pick. Up to 24
+    // forever-animating motes is the phone cost this trims to 10.
+    const ambientCap = ctx.lite() ? NODE_CAPS.ambientLite : NODE_CAPS.ambient;
+    const count = Math.max(1, Math.min(ambientCap, Math.round(spec.count * (ctx.motion() <= 0 ? 0.4 : 1))));
     for (let i = 0; i < count; i++) {
       const node = document.createElement('div');
       node.className = 'ae-mote' + (def.shape === 'dot' ? '' : ' ae-mote-' + def.shape);

--- a/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/deja-vu/index.js
@@ -93,6 +93,18 @@ const AUDIO_CEIL = Object.freeze([0.45, 0.6, 0.75, 0.9]);
  *  a burst. */
 const BUMP_MIN_MS = 250;
 
+/** THE TOUCH PLAY-WINDOW (mobile web, ../CLAUDE.md trap 42). On the web host
+ *  every remote loop is an mp4 <video>, and 2+ simultaneously PLAYING videos
+ *  degrade the compositor on BOTH engines (Chromium locks the page to 30Hz;
+ *  iOS caps hardware decode sessions at ~3-4 and the rest stall or fall to
+ *  CPU). A 12-20 card preview playing every face at once is the worst case in
+ *  the school. So on a coarse-touch device at most TOUCH_PLAY_CAP card videos
+ *  play at a time, and the preview ROTATES that window through the board every
+ *  TOUCH_PREVIEW_STEP_MS so every face is still seen animating. Desktop
+ *  (WebView2, fine pointer) never enters any of these paths. */
+const TOUCH_PLAY_CAP = 2;
+const TOUCH_PREVIEW_STEP_MS = 1000;
+
 /** Diagnostics seam (the engine has one too): the live class, for the scratch
  *  harness and any future "what is the board doing" debug overlay. The shell
  *  never reads this. */
@@ -128,6 +140,24 @@ function probeReduced() {
 }
 
 function isVideoUrl(url) { return /\.(mp4|m4v|webm|mov)(\?|#|$)/i.test(String(url || '')); }
+
+/** Coarse-touch probe - the canonical device test (../CLAUDE.md trap 42):
+ *  pointer:coarse OR maxTouchPoints > 1. The host's own isTouch is OR-ed in at
+ *  start() (ctx.platform is create-scope). A Windows touchscreen laptop
+ *  matching via maxTouchPoints is the trap's deliberately accepted caveat -
+ *  hardware-protective and cheap. */
+function probeTouch() {
+  try {
+    if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      const m = window.matchMedia('(pointer: coarse)');
+      if (m && m.matches) return true;
+    }
+  } catch (e) { /* ignore */ }
+  try {
+    if (typeof navigator !== 'undefined' && Number(navigator.maxTouchPoints) > 1) return true;
+  } catch (e) { /* ignore */ }
+  return false;
+}
 
 export default {
   key: 'deja_vu',
@@ -215,6 +245,7 @@ export default {
     let boardGlyphs = GLYPHS.slice();   // THIS board's glyph order (re-shuffled per board)
     let reduced = false;
     let posterOnly = false;
+    let touch = false;           // coarse-touch device: TOUCH_PLAY_CAP applies
     let loopPolicy = { play: true, reason: 'auto' };
     let retake = false;
     let ambienceKey = '';        // the sustained-dial signature, so a restart is rare
@@ -521,6 +552,49 @@ export default {
       } catch (e) { /* a poster frame is an acceptable floor */ }
     }
 
+    /* ==================================================================== *
+     * THE TOUCH PLAY-WINDOW (touch only - see TOUCH_PLAY_CAP above).
+     * The whole-board show beats (preview, re-deal) still give every card its
+     * media element and its 'up' face, but only TOUCH_PLAY_CAP of the video
+     * faces PLAY at once; the window rotates through the list on a short
+     * interval so every face gets its animated moment, then the beat's own
+     * flip-down pauses everything. The steps ride after()/run(), so a suspend
+     * defers them and clearTimers() (startBoard, bell, destroy) kills the
+     * chain outright. Never entered on desktop: every caller is touch-gated.
+     * ==================================================================== */
+    let previewing = false;      // a play-window is live (touch only, one-way per beat)
+    let previewList = null;      // the cells the window rotates over
+    let previewCursor = 0;
+
+    function videoFaces(list) {
+      const out = [];
+      for (const c of list) if (c && c.face && c.face.tagName === 'VIDEO') out.push(c);
+      return out;
+    }
+    function playWindowStart(list) {
+      previewList = list;
+      previewCursor = 0;
+      previewing = true;
+      playWindowStep();
+    }
+    function playWindowStep() {
+      if (!previewing || dead || ended || belled) return;
+      const vids = videoFaces(previewList || []);
+      const n = vids.length;
+      if (!n) return;
+      for (const c of vids) playFace(c, false);
+      for (let k = 0; k < Math.min(TOUCH_PLAY_CAP, n); k++) {
+        playFace(vids[(previewCursor + k) % n], true);
+      }
+      previewCursor = (previewCursor + TOUCH_PLAY_CAP) % n;
+      // a board with no more videos than the cap has nothing to rotate
+      if (n > TOUCH_PLAY_CAP) after(TOUCH_PREVIEW_STEP_MS, playWindowStep);
+    }
+    function playWindowStop() {
+      previewing = false;
+      previewList = null;
+    }
+
     /* ---- HUD paint ------------------------------------------------------- */
     function swapChipText() {
       return t('dv_swaps', 'swaps') + ' ' + swapsFired + '/' + dials.swapBudget;
@@ -619,6 +693,7 @@ export default {
        * on the new board. This call is safe from inside a run() step because
        * after() removes its own id before it runs the step. */
       clearTimers();
+      if (touch) playWindowStop();   // a dead board's window must not survive it
 
       boardNo = n;
       /* THE LADDER: board N's dials are the player's tier bumped one gentle
@@ -697,8 +772,11 @@ export default {
       for (const c of cells) {
         applyMedia(c);
         c.card.classList.add('up');
-        playFace(c, true);
+        if (!touch) playFace(c, true);
       }
+      /* On touch the memorize beat plays TOUCH_PLAY_CAP faces at a time and
+       * rotates; on desktop every face plays at once, exactly as before. */
+      if (touch) playWindowStart(cells.slice());
       tick('sting', 0.4);
       // THE MEMORIZE-POISON BEAT: exactly at preview end -400ms.
       const poisonAt = Math.max(0, dials.previewMs - TIMING.poisonLeadMs);
@@ -707,6 +785,7 @@ export default {
     }
 
     function previewDown() {
+      if (touch) playWindowStop();                    // the preview's window dies with it
       if (grid) grid.classList.remove('scanning');    // the machine is done showing
       for (const c of cells) {
         c.card.classList.add('flipping');
@@ -991,12 +1070,15 @@ export default {
         applyMedia(c);
         if (redealLie && c === redealLie.cell) wearLie(c, redealLie.wearPairId);
         c.card.classList.add('up');
-        playFace(c, true);
+        if (!touch) playFace(c, true);
         showing.push(c);
       }
+      /* the re-deal is the preview's beat again: same touch cap, same window */
+      if (touch) playWindowStart(showing.slice());
       say('re-deal: showing ' + showing.length + ' cards'
         + (redealLie ? ' (one is a lie)' : ' (truthful)'));
       after(trickster ? trickster.redealShowMs : 1500, () => {
+        if (touch) playWindowStop();
         for (const c of showing) { c.card.classList.add('flipping'); playFace(c, false); }
         after(reduced ? TIMING.flipReducedMs : TIMING.flipMs, () => {
           for (const c of showing) c.card.classList.remove('flipping', 'up');
@@ -1283,6 +1365,7 @@ export default {
       busy = true;                           // 1. input is shut BEFORE anything else
       stopClock();
       clearTimers();                         // 2. truncate: no step from the live board runs
+      if (touch) playWindowStop();
       flipping = 0;
       faceUp.length = 0;
       clearLie();
@@ -1740,6 +1823,9 @@ export default {
         budgetMs = Math.max(20000, (Number(spec.timeBudgetSec) || 300) * 1000);
         reduced = probeReduced();
         posterOnly = reduced;
+        /* Coarse touch: the local probe OR the host's own flag (the web shim
+         * populates ctx.platform.isTouch; the desktop host answers false). */
+        touch = probeTouch() || !!(ctx.platform && ctx.platform.isTouch);
 
         /* THE BOARD SIZE is the player's for the WHOLE class - the escalation
          * ladder never touches the grid, so a below-par choice is still exactly
@@ -1765,6 +1851,14 @@ export default {
         loopPolicy = matchedLoopPolicy(ctx.settings && ctx.settings.dv_matched_loops, tier, posterOnly);
         if (loopPolicy.reason === 'ceiling') {
           say('dv_matched_loops: "keep-playing" refused by the quality/tier ceiling - frozen');
+        }
+        /* THE TOUCH SETTLE: matchedLoopPolicy's semantics are untouched, but a
+         * phone cannot afford matched pairs looping forever - by the end of a
+         * board that is `pairs` extra live decoders under the play cap. Same
+         * "a knob may use less, never more" direction the ceiling rule takes. */
+        if (touch && loopPolicy.play) {
+          loopPolicy = { play: false, reason: 'touch' };
+          say('dv_matched_loops: matched pairs settle to poster on touch (playing-video cap)');
         }
 
         /* retake detection: the same seed already played today replays the
@@ -1845,6 +1939,7 @@ export default {
       destroy() {
         dead = true;
         hideHowto();
+        if (touch) playWindowStop();
         stopClock();
         clearTimers();
         stopAmbience();
@@ -1899,7 +1994,7 @@ export default {
           revealed: revealed.slice(),
           elapsedMs, budgetMs, classPlayMs, boardPlayMs, ended, busy, paused,
           loopPolicy: Object.assign({}, loopPolicy),
-          posterOnly, reduced,
+          posterOnly, reduced, touch,
           pairUrls: pairUrls.slice(),
           cellsDom: cells.map((c) => c.card),
           well,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/index.js
@@ -150,6 +150,18 @@ function probe(query) {
   } catch (e) { /* noop */ }
   return false;
 }
+/* THE PHONE PROBE (web CLAUDE.md trap 42's seam): coarse pointer or a real
+ * touch digitiser. The CSS side rides the shell's global html.ae-touch; JS
+ * decisions use this local probe so the module answers the same on a bare
+ * harness. A Windows touchscreen laptop also answers true - accepted
+ * deliberately, the ceiling is hardware-protective and cheap. */
+function coarseTouch() {
+  if (probe('(pointer: coarse)')) return true;
+  try {
+    if (typeof navigator !== 'undefined' && navigator && Number(navigator.maxTouchPoints) > 1) return true;
+  } catch (e) { /* noop */ }
+  return false;
+}
 function clamp01(v) {
   const x = Number(v);
   if (!isFinite(x)) return 0;
@@ -225,6 +237,7 @@ export default {
     const timers = createTimers();
     const reduced = probe('(prefers-reduced-motion: reduce)')
       || !!(ctx.motion && ctx.motion.reducedMotion);
+    const touch = coarseTouch();
     const dev = ctx.dev === true;
 
     let S = null;
@@ -390,7 +403,11 @@ export default {
         root: ctx.root,
         t,
         reduced,
-        perf: false,
+        /* the tube's cheap ladder (tube3d: fewer segments, smaller band canvas,
+           4Hz band redraw, fewer particles) arms on a coarse-pointer device -
+           a phone's GPU is the ceiling, not the frame budget. Desktop answers
+           false and renders byte-identically. */
+        perf: touch,
         showRt: settingOf('ic_show_rt', true) !== false,
         seed,                    // the tube grows its skin from the class seed
         log: say,
@@ -618,7 +635,12 @@ export default {
     function swapBackdrop() {
       if (!S || !S.pool) return;
       try {
-        const kind = S.rngFx() < 0.7 ? 'loop' : 'still';
+        /* the desktop draws loops 70% of the time (gifs, cheap in an <img>);
+           a phone flips that share to stills-first so the blurred backdrop
+           never spends one of iOS's few hardware video decode sessions. ONE
+           rng draw either way, so the seeded stream stays aligned. */
+        const roll = S.rngFx();
+        const kind = roll < 0.7 ? (touch ? 'still' : 'loop') : (touch ? 'loop' : 'still');
         const got = S.pool.next(kind);
         if (got && got.url) { S.render.swapBg(got.url); S.swaps++; }
       } catch (e) { /* keep the old one */ }

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/render.js
@@ -78,6 +78,9 @@ const FLAVOR_SRC = {
 };
 const BUBBLE_SRC = './assets/bubble.png';
 const DENIED_SFX = './assets/denied.mp3';
+/* the WEB host's 'loop' assets are mp4/webm - an <img> errors on them silently
+   and the backdrop never turns over. A url matching this gets a <video>. */
+const VIDEO_RE = /\.(mp4|webm|m4v)(\?|$)/i;
 
 function url(rel) {
   try { return new URL(rel, import.meta.url).href; } catch (e) { return rel; }
@@ -266,24 +269,73 @@ export function createRender(o = {}) {
     bgFade = Math.max(0, Math.min(0.8, Number(v) || 0));
     applyBg();
   }
+  const isVideoEl = (n) => { try { return !!n && String(n.tagName).toUpperCase() === 'VIDEO'; } catch (e) { return false; } };
+  let bgHeld = false;   // suspend(): a paused class must not keep a decoder warm
   function applyBg() {
     const act = bgActive === 0 ? nodes.bgA : nodes.bgB;
     const idle = bgActive === 0 ? nodes.bgB : nodes.bgA;
     if (act) { act.style.opacity = String(bgFade); act.classList.add('on'); }
     if (idle) { idle.style.opacity = '0'; idle.classList.remove('on'); }
+    /* a faded-out video keeps decoding unless it is told to stop */
+    if (isVideoEl(act) && !bgHeld) {
+      try { const p = act.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* noop */ }
+    }
+    if (isVideoEl(idle)) { try { idle.pause(); } catch (e) { /* noop */ } }
+  }
+  /* The two bg slots recycle: a slot holds an <img> until a video url needs it
+     to be a <video> (and back), swapped IN PLACE so the depth/veil layers above
+     keep their order. The crossfade contract is unchanged either way - same
+     class, same .on toggle, same opacity ride, so style.js and applyBg treat
+     both element kinds identically. */
+  function bgSlotFor(slot, wantVideo) {
+    const key = slot === 0 ? 'bgA' : 'bgB';
+    const cur = nodes[key];
+    if (!cur || isVideoEl(cur) === wantVideo) return cur;
+    const next = el(wantVideo ? 'video' : 'img', 'g-ic-bg-img', null);
+    if (!next) return cur;
+    if (wantVideo) {
+      try {
+        next.muted = true; next.loop = true; next.autoplay = true;
+        next.playsInline = true;
+        next.setAttribute('muted', '');
+        next.setAttribute('playsinline', '');
+        next.setAttribute('preload', 'auto');
+      } catch (e) { /* attributes are best effort */ }
+    }
+    try {
+      if (cur.parentNode) cur.parentNode.replaceChild(next, cur);
+      else if (nodes.bg) nodes.bg.appendChild(next);
+      else return cur;
+    } catch (e) { return cur; }
+    try { if (isVideoEl(cur)) { cur.pause(); cur.removeAttribute('src'); cur.load(); } } catch (e) { /* noop */ }
+    nodes[key] = next;
+    return next;
   }
   /** Swap the backdrop to a new url (crossfades when it loads). */
   function swapBg(u) {
     if (!u || !nodes.bgA) return;
-    const next = bgActive === 0 ? nodes.bgB : nodes.bgA;
-    const flip = () => { bgActive = bgActive === 0 ? 1 : 0; applyBg(); };
+    const idleSlot = bgActive === 0 ? 1 : 0;
+    const wantVideo = VIDEO_RE.test(String(u));
+    const next = bgSlotFor(idleSlot, wantVideo);
+    if (!next) return;
+    const flip = () => { bgActive = idleSlot; applyBg(); };
     try {
       let done = false;
-      next.onload = () => { if (!done) { done = true; flip(); } };
+      const ok = () => { if (!done) { done = true; flip(); } };
       next.onerror = () => { done = true; };
-      next.src = u;
-      /* a cached image may never fire onload under some webviews */
-      if (next.complete) { if (!done) { done = true; flip(); } }
+      if (wantVideo) {
+        next.onloadeddata = ok;
+        next.src = u;
+        if (!bgHeld) {
+          try { const p = next.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); } catch (e) { /* autoplay refusal keeps the old backdrop */ }
+        }
+        if (next.readyState >= 2) ok();
+      } else {
+        next.onload = ok;
+        next.src = u;
+        /* a cached image may never fire onload under some webviews */
+        if (next.complete) ok();
+      }
     } catch (e) { /* keep the old backdrop */ }
   }
 
@@ -595,10 +647,24 @@ export function createRender(o = {}) {
   /* ------------------------------------------------------------ lifecycle */
   function suspend(on) {
     setCls(nodes.stage, 'suspended', !!on);
+    /* CSS pauses the animations; a backdrop <video> needs telling by hand */
+    bgHeld = !!on;
+    const act = bgActive === 0 ? nodes.bgA : nodes.bgB;
+    if (isVideoEl(act)) {
+      try {
+        if (bgHeld) act.pause();
+        else { const p = act.play(); if (p && typeof p.catch === 'function') p.catch(() => {}); }
+      } catch (e) { /* noop */ }
+    }
     tubeCall('suspend', on);
   }
   function destroy() {
     tubeDead = true;
+    /* release any backdrop decoder before the stage goes */
+    for (const key of ['bgA', 'bgB']) {
+      const n = nodes[key];
+      try { if (isVideoEl(n)) { n.pause(); n.removeAttribute('src'); n.load(); } } catch (e) { /* noop */ }
+    }
     try { if (tube) tube.destroy(); } catch (e) { /* noop */ }
     tube = null;
     try {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/style.js
@@ -555,6 +555,48 @@ html.arc-reduced .g-ic-dusk{transition:none}
   margin:8px -30px -26px;padding:12px 30px 16px;
   background:linear-gradient(180deg,rgba(26,26,50,0),#1A1A32 42%)}
 
+/* ---- THE PHONE CEILING (html.ae-touch, web CLAUDE.md trap 42) ----
+   The shell arms .ae-touch on <html> for coarse-pointer devices at boot; the
+   desktop WebView2 never wears it, so nothing below moves a desktop pixel.
+   WebKit charges several ms a frame for a backdrop-filter, for a blur over a
+   full-bleed layer, and for an animated box-shadow (a full re-raster of the
+   layer per frame). Each rule swaps the costly half of a look for a static
+   stand-in and keeps its transform/opacity half. */
+/* the depth haze keeps its intent - media edges melting into atmosphere -
+   painted as a static gradient instead of a live backdrop blur, modeled on
+   the supports-not fallback above. The base rule's mask still shapes it
+   (masking one gradient div is cheap). */
+html.ae-touch .g-ic-bg-depth{backdrop-filter:none;-webkit-backdrop-filter:none;
+  background:radial-gradient(72% 58% at 50% 46%, transparent 40%, rgba(10,10,26,.55) 85%)}
+/* the backdrop media loses its 2px blur (a per-frame GPU pass over a
+   full-bleed decode). The ken-burns drift STAYS: its keyframe is
+   transform-only, which the compositor animates for free. */
+html.ae-touch .g-ic-bg-img{filter:saturate(.9)}
+/* the X-hit burst keeps its pop but stops ANIMATING filter (a fresh filter
+   surface every frame); the red shift rides as one static filter instead */
+html.ae-touch .g-ic-bubble.hit{animation:g-ic-hitburst-t .4s ease-out forwards;
+  filter:saturate(3) hue-rotate(-40deg)}
+@keyframes g-ic-hitburst-t{0%{transform:translate(-50%,-50%) scale(1)}
+  30%{transform:translate(-50%,-50%) scale(1.2)}
+  100%{transform:translate(-50%,-50%) scale(1.4);opacity:0}}
+/* the infinite box-shadow breathers freeze at their resting shadow (their own
+   0%/100% frame); GO keeps a transform-only pulse so the one door into the
+   class still breathes */
+html.ae-touch .g-ic-hw-go{animation:g-ic-hw-go-t 2.2s ease-in-out infinite;
+  box-shadow:0 0 18px rgba(255,105,180,.32)}
+@keyframes g-ic-hw-go-t{0%,100%{transform:scale(1)}50%{transform:scale(1.03)}}
+html.ae-touch .g-ic-submit{animation:none;box-shadow:0 0 16px rgba(255,105,180,.3)}
+html.ae-touch .g-ic-hw-nohand::after{animation:none;opacity:1}
+/* the intro card loses its backdrop blur; a deeper scrim stands in */
+html.ae-touch .g-ic-break{backdrop-filter:none;-webkit-backdrop-filter:none;
+  background:rgba(14,14,32,.92)}
+/* the two animations this block re-adds must still bow to reduced motion -
+   the media block above is out-specified by html.ae-touch, so say it again */
+html.arc-reduced.ae-touch .g-ic-hw-go,html.arc-reduced.ae-touch .g-ic-bubble.hit{animation:none}
+@media (prefers-reduced-motion: reduce){
+  html.ae-touch .g-ic-hw-go,html.ae-touch .g-ic-bubble.hit{animation:none}
+}
+
 `;
 
 export function ensureStyle() {

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube2d.js
@@ -637,8 +637,28 @@ export function createTube2D(opts = {}) {
   }
 
   let rafId = 0, last = 0;
+  /* THE VISIBILITY GUARD - same shape as tube3d.js: a hidden tab schedules no
+     frames; kick() zeroes `last` and loop() clamps dt, so no resume teleport. */
+  let hidden = false;
+  const onVis = () => {
+    try {
+      const h = !!(typeof document !== 'undefined' && document.hidden);
+      if (h === hidden) return;
+      hidden = h;
+      if (h) {
+        if (rafId && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+        rafId = 0;
+      } else if (!dead && !suspended) kick();
+    } catch (e) { /* noop */ }
+  };
+  try {
+    if (typeof document !== 'undefined' && document.addEventListener) {
+      hidden = !!document.hidden;
+      document.addEventListener('visibilitychange', onVis);
+    }
+  } catch (e) { /* noop */ }
   function loop(ts) {
-    if (dead || suspended) return;
+    if (dead || suspended || hidden) return;
     const dt = last ? Math.min(0.05, (ts - last) / 1000) : 0.016;
     last = ts;
     try { draw(dt); } catch (e) { /* never kill the loop */ }
@@ -646,6 +666,7 @@ export function createTube2D(opts = {}) {
     if (raf) rafId = raf(loop);
   }
   function kick() {
+    if (hidden) return;    // onVis kicks again when the tab comes back
     const raf = (typeof requestAnimationFrame === 'function') ? requestAnimationFrame : null;
     last = 0;
     if (raf) rafId = raf(loop); else { try { draw(0.016); } catch (e) { /* noop */ } }
@@ -700,6 +721,7 @@ export function createTube2D(opts = {}) {
     destroy() {
       dead = true;
       try { if (rafId && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId); } catch (e) { /* noop */ }
+      try { if (typeof document !== 'undefined' && document.removeEventListener) document.removeEventListener('visibilitychange', onVis); } catch (e) { /* noop */ }
       try { if (canvas && canvas.parentNode) canvas.parentNode.removeChild(canvas); } catch (e) { /* noop */ }
     },
   };

--- a/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/impulse-control/tube3d.js
@@ -1364,8 +1364,29 @@ export async function createTube3D(opts = {}) {
   /* rAF resolved at call time - absent (harness) means "render on demand". */
   let rafId = 0;
   let last = 0;
+  /* THE VISIBILITY GUARD (mobile web): a hidden tab schedules no frames at
+     all. Coming back cannot teleport the animations: kick() zeroes `last`
+     (first dt defaults to 0.016) and loop() clamps dt to 0.05 regardless. */
+  let hidden = false;
+  const onVis = () => {
+    try {
+      const h = !!(typeof document !== 'undefined' && document.hidden);
+      if (h === hidden) return;
+      hidden = h;
+      if (h) {
+        if (rafId && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+        rafId = 0;
+      } else if (!dead && !suspended) kick();
+    } catch (e) { /* noop */ }
+  };
+  try {
+    if (typeof document !== 'undefined' && document.addEventListener) {
+      hidden = !!document.hidden;
+      document.addEventListener('visibilitychange', onVis);
+    }
+  } catch (e) { /* noop */ }
   function loop(ts) {
-    if (dead || suspended) return;
+    if (dead || suspended || hidden) return;
     const dt = last ? Math.min(0.05, (ts - last) / 1000) : 0.016;
     last = ts;
     frame(dt);
@@ -1373,6 +1394,7 @@ export async function createTube3D(opts = {}) {
     if (raf) rafId = raf(loop);
   }
   function kick() {
+    if (hidden) return;    // onVis kicks again when the tab comes back
     const raf = (typeof requestAnimationFrame === 'function') ? requestAnimationFrame : null;
     last = 0;
     if (raf) rafId = raf(loop); else frame(0.016);
@@ -1426,6 +1448,7 @@ export async function createTube3D(opts = {}) {
     destroy() {
       dead = true;
       try { if (rafId && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId); } catch (e) { /* noop */ }
+      try { if (typeof document !== 'undefined' && document.removeEventListener) document.removeEventListener('visibilitychange', onVis); } catch (e) { /* noop */ }
       try {
         tubeGeo.dispose(); tubeMat.dispose();
         dish.geometry.dispose(); dishMat.dispose(); dishTex.dispose();

--- a/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/instant-recall/index.js
@@ -2333,7 +2333,15 @@ export default {
           cue: (name, level, extra) => tick(name, level, extra),
           seed, tier, reduced,
           coarse: !!(ctx.platform && ctx.platform.isTouch),
-          lite: !!(ctx.motion && Number(ctx.motion.motionLevel) <= 1),
+          /* LITE ENGAGES ON TOUCH TOO (mobile web, ../CLAUDE.md trap 42): a
+           * phone at the default motion level was getting the desktop dials
+           * (LIVE_LOOP_CAP 12 / VIDEO_TILE_CAP 4), and iOS caps hardware video
+           * decode sessions at ~3-4 - so the wall now STARTS from the 6/2 lite
+           * dials on a coarse pointer instead of the governor catching the
+           * fire late. Same signal as `coarse` above; desktop WebView2 answers
+           * isTouch false and keeps the motionLevel test byte-identical. */
+          lite: !!((ctx.motion && Number(ctx.motion.motionLevel) <= 1)
+            || (ctx.platform && ctx.platform.isTouch)),
           density: densityMultFor(densityValue),
           timeScale,
           log: say,

--- a/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/games/the-deep-end/index.js
@@ -819,10 +819,19 @@ export default {
     }
     function setTouchClass(on) {
       /* <html> ONLY: the stage's own look hangs off `html.ae-touch .g-de-*` in
-         style.js, so there is no second class to keep in sync here. */
+         style.js, so there is no second class to keep in sync here.
+         GLOBALLY ARMED (core/device.js, 2026-08-25): when the shell armed
+         `.ae-touch` page-wide it stamps `data-ae-touch-global="1"` on <html>,
+         and the class is then not ours to toggle - the add is redundant and
+         the destroy-time remove would strip the whole page's GPU ceiling on
+         the way back to the lobby. probeTouch() stays the fallback for hosts
+         where device.js never armed it (a big tablet, a touch-screen laptop
+         browser), where this lifecycle add/remove behaves exactly as before. */
       try {
         const html = typeof document !== 'undefined' ? document.documentElement : null;
-        if (html && html.classList) html.classList[on ? 'add' : 'remove']('ae-touch');
+        if (!html || !html.classList) return;
+        if (typeof html.getAttribute === 'function' && html.getAttribute('data-ae-touch-global') === '1') return;
+        html.classList[on ? 'add' : 'remove']('ae-touch');
       } catch (e) { /* ignore */ }
     }
     /** The animated-tier cap and the still-shallows line: the resolved rung

--- a/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/provider/index.js
@@ -31,8 +31,14 @@
  *  - iOS is mp4-only; formats are filtered per platform.
  *  - Remote goes through the BRIDGE ('assets-request'/'assets'), never a fetch
  *    from the page, and never at all under OfflineMode or a closed consent gate.
- *  - claim() PREWARMS (link rel=preload, else new Image()) so the first draw is
- *    already decoded.
+ *  - claim() runs an ON-DECK WARM RAIL (0825, mobile web): the pool FORECASTS
+ *    its next few draws with the very selection code next() runs, then warms
+ *    those bytes the SORT way - a detached Image()+decode() for stills/gifs,
+ *    fetch(url,{mode:'no-cors'}) for video urls (NEVER a detached <video> -
+ *    it spins a demuxer, trap 36). Remote urls only; local is the host serving
+ *    the player's own disk and warming it is waste (and what keeps the desktop
+ *    WebView2 build inert). The draw itself is still decided AT DRAW TIME by
+ *    the same seeded logic, so the served sequence never moves.
  *
  * LOCAL INVENTORY. A virtual host cannot be enumerated from JS, so SOMETHING has
  * to hand the page the list. Accepted (first non-empty wins, all merged):
@@ -61,6 +67,16 @@ function placeholderUrls() {
 }
 
 const REMOTE_CAP = 80;        // mirrors intake's REMOTE_CAP: a page never hoards media
+
+/* THE ON-DECK RAIL's dials (0825). SORT's warm rail proved the shape and the
+ * numbers' logic (games/sort/index.js WARM_AHEAD/WARM_INFLIGHT header): the
+ * deck is a LOOK-AHEAD, not a supply figure, and the warm is a background
+ * TRICKLE that must lose to whatever is already on screen. */
+export const DECK_AHEAD = 6;      // draws forecast (and byte-warmed) ahead, per kind
+export const WARM_INFLIGHT = 3;   // warms in flight at once - a third lane lets small
+                                  // stills slip past one slow multi-megabyte download
+const WARM_HELD_MAX = 24;         // decoded detached Images held against GC
+const VIDEO_URL_RE = /\.(mp4|webm|m4v)(\?|#|$)/i;
 
 /** Keys the shell/host might carry the local inventory under. A page cannot
  *  enumerate a virtual host, so SOMETHING has to hand us the list; we accept
@@ -122,6 +138,27 @@ export function createAssets(options = {}) {
   let prewarmed = new Set();
   let disposed = false;
 
+  /* ------------------------------------------------------------------------
+   * THE RAND BUFFER - the seam that lets a pool decide its draws EARLY without
+   * moving them. next() used to call rng() inline; now every draw takes its
+   * values through takeRand() (a FIFO over the same stream) and a FORECAST
+   * peeks the values a future draw WILL take via peekRand() without consuming
+   * them. Emissions are handed to real draws strictly in emission order, so
+   * for a given seed the served sequence is byte-identical to the pre-deck
+   * provider - peeking pulls values into the buffer early, never past a draw.
+   * The buffer is provider-level because the rng is (shell.js hands us
+   * makeRng(utcDateSeed + '|assets') and nothing else consumes it).
+   * --------------------------------------------------------------------- */
+  const randBuf = [];
+  const takeRand = () => (randBuf.length ? randBuf.shift() : rng());
+  const peekRand = (i) => { while (randBuf.length <= i) randBuf.push(rng()); return randBuf[i]; };
+
+  /** Data Saver is the player's word that we do not spend bytes on a guess. */
+  const saveData = (() => {
+    try { return !!(typeof navigator !== 'undefined' && navigator.connection && navigator.connection.saveData === true); }
+    catch { return false; }
+  })();
+
   function absorbRemote(entries) {
     let added = 0;
     for (const e of (entries || [])) {
@@ -140,39 +177,115 @@ export function createAssets(options = {}) {
     return added;
   }
 
-  /**
-   * Prewarm: decode-ahead without blocking anything. Silent on failure.
+  /* ------------------------------------------------------------------------
+   * THE WARM RAIL - bytes AND decode ahead of the deal, and nothing else.
    *
-   * BOUNDED, and that is load-bearing (0821, Lost & Found's dense-board pass).
-   * A `link rel=preload as=image` is a HIGH-priority fetch: firing one per
-   * manifest entry (a claim can ask for 130+ loops) puts the whole library in
-   * front of the media the player is actually looking at, and for gifs it also
-   * starts decoders the board has no budget for. A short warm queue is the
-   * point of a prewarm; a long one is a stampede that races the visible loads.
+   * The old mechanism was a `link rel=preload` at fetchPriority low: a hint
+   * that bought no decode, and it was pointed at urls the cursor+jump draw
+   * almost never actually served. Deleted in favour of the two warms SORT's
+   * rail proved on a phone (games/sort/index.js, owner report 2026-08-24):
+   *
+   *  - a still or gif warms in a DETACHED new Image() + decode(). Nothing
+   *    composites; the strong ref in warmHeld only keeps GC off the request,
+   *    and the decoded frames land in the browser's image cache keyed by url -
+   *    exactly where the game's own <img> will look.
+   *  - a video url warms with fetch(url, {mode:'no-cors'}) and the opaque
+   *    reply is thrown away unread. Deliberately NEVER a detached <video>: a
+   *    warm <video> starts a demuxer the instant it has bytes - an off-screen
+   *    decoder no ceiling ever counted (trap 36's law).
+   *
+   * BOUNDED, and that is load-bearing (0821, Lost & Found's dense-board pass):
+   * a stampede of warms races the media the player is looking at. This is a
+   * TRICKLE - WARM_INFLIGHT lanes, every url at most once per provider, only
+   * the deck HEAD may ask for 'high' priority - and under Data Saver no byte
+   * moves at all. REMOTE urls only: local (ccp.* / relative / data: / blob: /
+   * same-origin) is the host serving the player's own disk, already instant,
+   * which is what keeps the desktop WebView2 build's behaviour inert.
+   * --------------------------------------------------------------------- */
+  const warmQueue = [];
+  const warmHeld = new Map();       // url -> the detached Image holding it open
+  let warmFlight = 0;
+
+  /** Only bytes that actually travel: remote http(s), not our own origin. */
+  function warmable(url) {
+    const s = String(url || '');
+    if (!s || prewarmed.has(s)) return false;
+    if (isLocalUrl(s)) return false;             // ccp.* / relative / data: / blob:
+    if (!/^https?:\/\//i.test(s)) return false;
+    try {
+      if (typeof location !== 'undefined' && location.origin && new URL(s).origin === location.origin) return false;
+    } catch { return false; }
+    return true;
+  }
+
+  function warmDone() { warmFlight = Math.max(0, warmFlight - 1); if (!disposed) warmPump(); }
+  function warmPump() {
+    while (!disposed && warmFlight < WARM_INFLIGHT && warmQueue.length) {
+      const job = warmQueue.shift();
+      warmFlight += 1;
+      if (job.video) {
+        /* fire and forget, and swallow everything: a rejected warm is a url
+         * that will simply load the ordinary way at reveal. */
+        try {
+          if (typeof fetch !== 'function') { warmDone(); continue; }
+          const init = { mode: 'no-cors', credentials: 'omit' };
+          if (job.high) init.priority = 'high';       // Fetch Priority API; unknown keys are ignored
+          const pr = fetch(job.url, init);
+          if (pr && pr.then) pr.then(warmDone, warmDone); else warmDone();
+        } catch { warmDone(); }
+      } else {
+        let img = null;
+        try { img = new Image(); } catch { img = null; }
+        if (!img) { warmDone(); continue; }
+        warmHeld.set(job.url, img);
+        while (warmHeld.size > WARM_HELD_MAX) {
+          const oldest = warmHeld.keys().next().value;
+          if (oldest == null) break;
+          warmHeld.delete(oldest);
+        }
+        try {
+          img.decoding = 'async';
+          try { img.fetchPriority = job.high ? 'high' : 'low'; } catch { /* older engines */ }
+          img.src = job.url;
+          /* BYTES ARE HALF THE BILL: a cached gif still pays its decode on
+           * first paint, so a warm is not done until decode() says the first
+           * frame exists. Fallback for engines without decode(): load/error,
+           * bytes-only. */
+          if (typeof img.decode === 'function') {
+            img.decode().then(warmDone, () => { warmHeld.delete(job.url); warmDone(); });
+          } else {
+            img.onload = warmDone;
+            img.onerror = () => { warmHeld.delete(job.url); warmDone(); };
+          }
+        } catch { warmHeld.delete(job.url); warmDone(); }
+      }
+    }
+  }
+
+  /** Queue one url for warming. Returns true if it was actually queued. */
+  function warmUrl(url, high) {
+    if (disposed || saveData) return false;
+    if (typeof document === 'undefined') return false;   // node harness: inert
+    if (!warmable(url)) return false;
+    const s = String(url);
+    prewarmed.add(s);
+    warmQueue.push({ url: s, video: VIDEO_URL_RE.test(s), high: !!high });
+    warmPump();
+    return true;
+  }
+
+  /**
+   * prewarm(urls): the bounded warm verb (tagged.js injects it; its pool.prewarm
+   * already peeks the rows its cursor WILL serve, so its urls are honest). The
+   * first url that actually queues is the caller's own deck head - 'high'.
    */
   const PREWARM_MAX = 12;
   function prewarm(urls) {
-    if (typeof document === 'undefined') return;
     let n = 0;
-    for (const url of urls) {
+    for (const url of (urls || [])) {
       if (n >= PREWARM_MAX) break;
       if (!url || prewarmed.has(url)) continue;
-      prewarmed.add(url);
-      n += 1;
-      try {
-        const head = document.head || document.documentElement;
-        if (head) {
-          const link = document.createElement('link');
-          link.rel = 'preload';
-          link.as = /\.(mp4|webm|m4v)(\?|#|$)/i.test(url) ? 'video' : 'image';
-          // a warm-up must never outrank what is already on screen
-          try { link.fetchPriority = 'low'; } catch { /* older engines */ }
-          link.href = url;
-          head.appendChild(link);
-          continue;
-        }
-      } catch { /* fall through to Image() */ }
-      try { const img = new Image(); img.src = url; } catch { /* ignore */ }
+      if (warmUrl(url, n === 0)) n += 1;
     }
   }
 
@@ -337,11 +450,10 @@ export function createAssets(options = {}) {
     // target is never the tile the decoys are drawing from in the same frame
     const localTargets = localStills.slice().reverse();
 
-    // A HANDFUL of each kind, not the whole manifest: see prewarm()'s header.
-    // The first draws are what this is for; everything after them is dressed
-    // progressively by the game anyway.
-    prewarm(localLoops.slice(0, Math.min(6, Math.max(4, want.loop)))
-      .concat(localStills.slice(0, Math.min(6, Math.max(4, want.still + want.target)))));
+    // (The claim-time warm moved BELOW the deck machinery: it now warms the
+    //  actual first deck entries - the urls next() WILL serve - instead of a
+    //  slice of the local lists, which on the web build were placeholder SVGs
+    //  and on desktop are the host's own disk. See refreshDeck().)
 
     // --- the remote side, if the gate is open ------------------------------
     // The host's contract is "whatever is buffered NOW, and ask again after
@@ -365,7 +477,10 @@ export function createAssets(options = {}) {
         onBatch: (entries) => {
           if (released || disposed) return;
           if (absorbRemote(entries)) {
-            prewarm((remotePools[kind] || []).slice(-4));
+            /* The pool just grew, so every forecast is stale: re-deal the deck
+             * and warm ITS urls. (The old `slice(-4)` warmed the newest
+             * arrivals, which the cursor+jump draw almost never served next.) */
+            refreshDeck();
             notifyUpdate();
           }
           if ((remotePools[kind] || []).length < count && attempt < MAX_ASKS) {
@@ -385,16 +500,90 @@ export function createAssets(options = {}) {
       log('canvasSafe claim: local-only pool (CORS two-pool law)');
     }
 
-    function drawLocal(kind) {
+    /* =======================================================================
+     * THE DRAW, parameterized (THE ON-DECK RAIL, 0825).
+     *
+     * computeDraw/computeLocal are next()'s old inline selection logic MOVED,
+     * not changed: same branches, same cursor walk, same seeded jump, and the
+     * rand supplier `take` is called at exactly the code positions rng() sat.
+     * next() runs them against the LIVE cursors with takeRand() (consuming the
+     * stream in emission order - byte-identical serving); refreshDeck() runs
+     * them against CLONED cursors with peekRand() (consuming nothing) to learn
+     * which urls the next DECK_AHEAD draws of a kind WILL serve, and hands the
+     * remote ones to the warm rail - the head at 'high' priority. A forecast
+     * is exact until the pool grows; every draw and every absorbed batch
+     * re-deals it, so the deck head is always the truth.
+     * ==================================================================== */
+    function computeLocal(kind, st, take) {
       const list = kind === 'loop' ? localLoops : (kind === 'target' ? localTargets : localStills);
-      if (!list.length) return placeholders[Math.floor(rng() * placeholders.length)] || null;
-      const i = cursors[kind] % list.length;
-      cursors[kind] += 1;
+      if (!list.length) return placeholders[Math.floor(take() * placeholders.length)] || null;
+      const i = st.cursors[kind] % list.length;
+      st.cursors[kind] += 1;
       // a deterministic walk with a seeded jump keeps repeats far apart without
       // ever risking "the same tile twice in a row" on a tiny local pool
-      const jump = list.length > 2 ? Math.floor(rng() * (list.length - 1)) : 0;
+      const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
       return list[(i + jump) % list.length];
     }
+
+    function computeDraw(k, st, take) {
+      const remoteKind = k === 'target' ? 'still' : k;
+      // The ratio is a MIX dial, not a veto: on the placeholder floor (no real
+      // local media of this kind) there is nothing to mix WITH, so the remote
+      // pool serves every draw it can cover.
+      const bareLocal = !(remoteKind === 'loop' ? localPools.loop.length : localPools.still.length);
+      if (wantRemote(bareLocal ? 1 : remoteRatio, take(), (remotePools[remoteKind] || []).length > 0, canvasSafe)) {
+        const list = remotePools[remoteKind];
+        const i = st.remoteCursors[remoteKind] % list.length;
+        st.remoteCursors[remoteKind] += 1;
+        const jump = list.length > 2 ? Math.floor(take() * (list.length - 1)) : 0;
+        const url = list[(i + jump) % list.length];
+        if (url && (!canvasSafe || isLocalUrl(url))) return { url, remote: true };
+      }
+      return { url: computeLocal(k, st, take), remote: false };
+    }
+
+    const liveState = { cursors, remoteCursors };
+
+    /** The next `depth` draws of one kind, decided EARLY over cloned cursors
+     *  and peeked rand values. Mutates nothing that serving reads. */
+    function forecast(k, depth) {
+      const st = { cursors: Object.assign({}, cursors), remoteCursors: Object.assign({}, remoteCursors) };
+      let pi = 0;
+      const take = () => peekRand(pi++);
+      const out = [];
+      for (let i = 0; i < depth; i++) out.push(computeDraw(k, st, take));
+      return out;
+    }
+
+    /* Forecast only the kinds this claim actually asked for; a spec-less claim
+     * still decks the default kind. Each kind's forecast starts at peek index
+     * 0 - "the next draws are all this kind" - so whichever kind the game asks
+     * for next, that kind's deck HEAD is the url it gets. */
+    const deckKinds = [];
+    if (want.loop) deckKinds.push('loop');
+    if (want.still) deckKinds.push('still');
+    if (want.target) deckKinds.push('target');
+    if (!deckKinds.length) deckKinds.push('still');
+
+    /** Re-deal the deck and warm its remote urls. Returns how many queued. */
+    function refreshDeck(depth) {
+      if (released || disposed || saveData) return 0;
+      if (typeof document === 'undefined') return 0;
+      const d = Math.max(1, Math.min(DECK_AHEAD, (depth | 0) || DECK_AHEAD));
+      let queued = 0;
+      for (const k of deckKinds) {
+        const entries = forecast(k, d);
+        for (let i = 0; i < entries.length; i++) {
+          const e = entries[i];
+          if (e && e.url && e.remote && warmUrl(e.url, i === 0)) queued += 1;
+        }
+      }
+      return queued;
+    }
+
+    /* The claim-time warm: the actual first deck entries. On desktop (local
+     * media, remote pool empty or unused) this queues nothing - inert. */
+    refreshDeck();
 
     const pool = {
       spec: { loops: want.loop, stills: want.still, targets: want.target, canvasSafe, niches: niches || null },
@@ -406,20 +595,20 @@ export function createAssets(options = {}) {
       next(kind) {
         const k = (kind === 'loop' || kind === 'gif') ? 'loop' : (kind === 'target' ? 'target' : 'still');
         if (released) return { url: placeholders[0] || null, remote: false };
-        const remoteKind = k === 'target' ? 'still' : k;
-        // The ratio is a MIX dial, not a veto: on the placeholder floor (no real
-        // local media of this kind) there is nothing to mix WITH, so the remote
-        // pool serves every draw it can cover.
-        const bareLocal = !(remoteKind === 'loop' ? localPools.loop.length : localPools.still.length);
-        if (wantRemote(bareLocal ? 1 : remoteRatio, rng(), (remotePools[remoteKind] || []).length > 0, canvasSafe)) {
-          const list = remotePools[remoteKind];
-          const i = remoteCursors[remoteKind] % list.length;
-          remoteCursors[remoteKind] += 1;
-          const jump = list.length > 2 ? Math.floor(rng() * (list.length - 1)) : 0;
-          const url = list[(i + jump) % list.length];
-          if (url && (!canvasSafe || isLocalUrl(url))) return { url, remote: true };
-        }
-        return { url: drawLocal(k), remote: false };
+        /* Decided NOW, with the live cursors and the next rand emissions - the
+         * deck never serves, it only warmed what this call is about to pick. */
+        const res = computeDraw(k, liveState, takeRand);
+        refreshDeck();               // the window moved: warm the new tail
+        return res;
+      },
+      /**
+       * Warm the next n deck entries' bytes now (bounded by DECK_AHEAD).
+       * SORT's quick path has always called this behind a typeof guard - it
+       * was a claimTagged-only verb before 0825. Returns how many queued.
+       */
+      prewarm(n) {
+        const d = Math.round(Number(n) || 0);
+        return d > 0 ? refreshDeck(d) : 0;
       },
       /** How many candidates the pool can actually serve right now. */
       stats() {
@@ -588,6 +777,12 @@ export function createAssets(options = {}) {
       probes.clear();
       libraryCbs.clear();
       channel.dispose();
+      warmQueue.length = 0;
+      for (const img of warmHeld.values()) {
+        try { img.onload = null; img.onerror = null; } catch { /* noop */ }
+      }
+      warmHeld.clear();
+      warmFlight = 0;
       prewarmed = new Set();
     },
   };

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/campus.js
@@ -368,6 +368,24 @@ const ATTRACT_DWELL_MS = 1000;          // how long a room holds its glow
 const ATTRACT_LOOP_GAP_MS = 2600;       // dark beat before the show repeats
 const ATTRACT_TICK_MS = 50;             // cursor lerp tick (20fps - a hint, not a game)
 const ATTRACT_FLIP_MS = 70;             // one split-flap flip
+/* THE PHONE HALF-RATE (perf/arcademy-mobile-web). The attract loop is a 20Hz
+ * SVG cursor transform plus sign textContent rewritten ~14Hz inside filtered
+ * groups - polish that is invisible at phone sizes and expensive on WebKit.
+ * On a coarse pointer both tickers run at HALF rate (tick 100ms, flip 140ms);
+ * glideCursor derives its step count from the tick, so a glide still takes the
+ * same wall time. Probed ONCE at module init (trap 42's own probe pair);
+ * desktop evaluates to the untouched constants above. */
+const ATTRACT_COARSE = (() => {
+  try {
+    if (typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches) return true;
+  } catch (e) { /* noop */ }
+  try {
+    return typeof navigator !== 'undefined' && Number(navigator.maxTouchPoints) > 1;
+  } catch (e) { /* noop */ }
+  return false;
+})();
+const ATTRACT_TICK_EFF_MS = ATTRACT_COARSE ? ATTRACT_TICK_MS * 2 : ATTRACT_TICK_MS;
+const ATTRACT_FLIP_EFF_MS = ATTRACT_COARSE ? ATTRACT_FLIP_MS * 2 : ATTRACT_FLIP_MS;
 const ATTRACT_FLIPS = 8;                // flips before a sign has fully settled
 const ATTRACT_GLYPHS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 const ATTRACT_GLOW = 'brightness(1.3) saturate(1.12)';
@@ -2365,9 +2383,9 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
   }
   function glideCursor(to, ms, done) {
     const from = cursorAt.slice();
-    const steps = Math.max(1, Math.round(ms / ATTRACT_TICK_MS));
+    const steps = Math.max(1, Math.round(ms / ATTRACT_TICK_EFF_MS));
     let i = 0;
-    const id = attractEvery(ATTRACT_TICK_MS, () => {
+    const id = attractEvery(ATTRACT_TICK_EFF_MS, () => {
       if (!attractOn) { attractStop(id); return; }
       i += 1;
       const p = Math.min(1, i / steps);
@@ -2395,7 +2413,7 @@ export function createCampus({ state, gameName, banner, stats, reducedMotion, on
     const truth = ref ? neonLabel(key) : '';
     if (!ref || !truth) { done(); return; }
     let k = 0;
-    const id = attractEvery(ATTRACT_FLIP_MS, () => {
+    const id = attractEvery(ATTRACT_FLIP_EFF_MS, () => {
       if (!attractOn) { attractStop(id); return; }
       k += 1;
       if (k >= ATTRACT_FLIPS) {

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/ghosts.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/ghosts.js
@@ -55,6 +55,23 @@ const SVGNS = 'http://www.w3.org/2000/svg';
 export const PRESENCE_V = 1;
 /** Simultaneous drawn ghosts. Overflow feeds the busyness chips, never the map. */
 export const MAX_GHOSTS = 24;
+/** THE TOUCH CEILING (perf/arcademy-mobile-web). Every drawn ghost writes an
+ * SVG transform attribute per rAF frame into the campus plan, and 24 of those
+ * is a standing tax an iPhone pays whenever the campus is up. On a coarse
+ * pointer the map draws at most this many; the rest feed the busyness chips
+ * exactly the way overflow always has. Desktop keeps MAX_GHOSTS untouched. */
+export const TOUCH_MAX_GHOSTS = 8;
+/* Probed ONCE at module init (same probe as trap 42's `.ae-touch` seam):
+ * coarse pointer, or a touch digitiser on a host whose media queries lie. */
+const IS_COARSE = (() => {
+  try {
+    if (typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches) return true;
+  } catch (e) { /* noop */ }
+  try {
+    return typeof navigator !== 'undefined' && Number(navigator.maxTouchPoints) > 1;
+  } catch (e) { /* noop */ }
+  return false;
+})();
 /** Rooms with at least this many attendees wear a count chip (PRESENCE §6). */
 export const BUSY_MIN = 3;
 /** The replay window. Anything older than this is not a ghost at all. */
@@ -834,7 +851,14 @@ export function createGhosts(o) {
     const nowMs = clock.now();
     const snap = normalizeSnapshot(raw, nowMs);
     if (!snap) { say('presence: snapshot refused (shape or version)'); return; }
-    plan = buildSchedules({ snapshot: snap, nowMs, self: selfId });
+    plan = buildSchedules({
+      snapshot: snap,
+      nowMs,
+      self: selfId,
+      // The touch ceiling (see TOUCH_MAX_GHOSTS). On a fine pointer this is
+      // buildSchedules' own default, byte for byte.
+      cap: IS_COARSE ? TOUCH_MAX_GHOSTS : MAX_GHOSTS,
+    });
     planEpoch = -1;
     planBaseMs = nowMs;
     render();

--- a/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/shell/shell.js
@@ -760,6 +760,10 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
   let introToldEmi = false;
   let active = null;               // the running class (see startClass)
   let suspendedGlobally = false;
+  /* The reason the CURRENT suspend level was set with (null when lifted).
+   * Written only by applySuspend; read only by the web tab-visibility wiring
+   * below, so it can refuse to lift a suspend it did not apply itself. */
+  let suspendReason = null;
   let destroyed = false;
   // Host opened the building through the dev switch (`--arcademy`). Unlocks
   // Begin on every campus door regardless of the seed; never true for players.
@@ -4092,6 +4096,37 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
     document.addEventListener('pointermove', onExitAim, { passive: true });
   }
 
+  /* WEB TAB SUSPEND (perf/arcademy-mobile-web). On the desktop host the bridge
+   * drives applySuspend (onSuspend below); in a browser nothing ever did, so a
+   * backgrounded tab kept every loop warm. Wired ONLY when the host is not the
+   * desktop (init.platform.host), and with its own reason string so it can
+   * never be confused with - or lift - a suspend the host initiated:
+   * - hidden: refuse while ANY suspend already holds the level (trap 28: it is
+   *   a LEVEL, and whoever set it owns it), and refuse while an Orientation
+   *   Day beat is on stage - applySuspend(true) SKIPS a running beat and banks
+   *   it as seen, which must not be spent on a mere tab switch (background
+   *   throttling stills the beat anyway; the same shape as orientFreeze's
+   *   both-direction guard).
+   * - visible: lift ONLY a 'tabhidden' suspend this listener applied itself.
+   *   A mid-class return lands on the pause card with its Resume button -
+   *   applySuspend(false) deliberately leaves the class paused. */
+  const platformHost = String((src.platform && src.platform.host) || 'desktop');
+  function onTabVisibility() {
+    try {
+      if (document.visibilityState === 'hidden') {
+        if (suspendedGlobally) return;
+        try { if (orientation && orientation.active()) return; } catch (e) { /* noop */ }
+        applySuspend(true, 'tabhidden');
+      } else if (suspendedGlobally && suspendReason === 'tabhidden') {
+        applySuspend(false, 'tabhidden');
+      }
+    } catch (e) { say('tab suspend threw: ' + ((e && e.message) || e)); }
+  }
+  if (platformHost !== 'desktop'
+      && typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('visibilitychange', onTabVisibility);
+  }
+
   /* ASKS: a01's YES buys a SOFT night - comfort faces on arrival and one extra
    * line on the report card. The flag lives in the ask engine (it is
    * session-only and it is hers); this is the shell's read of it, and a page
@@ -4111,6 +4146,7 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
    */
   function applySuspend(on, reason) {
     suspendedGlobally = !!on;
+    suspendReason = on ? (reason || '') : null;
     fireMoment(on ? 'suspend' : 'resume', { reason });   // EMI SEAM
     // NO GHOSTS UNDER A MANDATORY VIDEO. The layer rides the same one funnel the
     // pause card does, and it is a LEVEL (trap 28), so both edges are written.
@@ -4146,7 +4182,11 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         pauseClass(true);
         showSuspendedOverlay(reason === 'audio-only'
           ? 'An audio-only session started. Your attendance is safe.'
-          : reason === 'panic' ? 'Stopped. Press the panic key again to leave.' : 'Paused for a video.',
+          : reason === 'panic' ? 'Stopped. Press the panic key again to leave.'
+            /* 'tabhidden' is the web wiring's own reason - the desktop host
+             * never sends it, so its three lines above are byte-identical. */
+            : reason === 'tabhidden' ? 'Paused while you were away.'
+              : 'Paused for a video.',
           { resumable: reason === 'panic' });
       } else {
         if (active.suspendEl) {
@@ -4597,9 +4637,12 @@ export async function createShell({ init, bridge, dom, toast, log } = {}) {
         annexStatsWait = null;
       }
       setStage(null);
-      /* ASKS: the exit-aim listener is the shell's, so the shell takes it. */
+      /* ASKS: the exit-aim listener is the shell's, so the shell takes it.
+       * The web tab-suspend listener is the shell's too (a no-op remove on the
+       * desktop host, where it was never added). */
       if (typeof document !== 'undefined' && document.removeEventListener) {
         try { document.removeEventListener('pointermove', onExitAim); } catch (e) { /* noop */ }
+        try { document.removeEventListener('visibilitychange', onTabVisibility); } catch (e) { /* noop */ }
       }
       if (orientation) { const ob = orientation; orientation = null; try { ob.destroy(); } catch (e) { /* noop */ } }
       if (ghosts) { try { ghosts.destroy(); } catch (e) { /* noop */ } ghosts = null; }

--- a/ConditioningControlPanel/Resources/web/arcademy/styles.css
+++ b/ConditioningControlPanel/Resources/web/arcademy/styles.css
@@ -4951,3 +4951,99 @@ html.arc-mobile .campus-bellchip {
 html.arc-mobile .campus-bellchip .ic { grid-row:1 / 3; font-size:13px; }
 html.arc-mobile .campus-bellchip .cap { display:block; font-size:7.5px; letter-spacing:.18em; line-height:1; }
 html.arc-mobile .campus-bellchip .tm { font-size:10px; line-height:1; }
+
+/* ======================= GPU DIET (html.ae-touch) ========================
+   PHONE STANDING COSTS (perf/arcademy-mobile-web). `html.ae-touch` is the
+   DEVICE seam (trap 42): boot arms it once on coarse pointers / touch
+   digitisers, the desktop WebView2 host never wears it, so every rule in
+   this block is invisible to the desktop build - byte-identical evaluation.
+   Two families of cut, both about what WebKit charges per frame:
+
+     - INFINITE KEYFRAMES ON NON-COMPOSITED PROPERTIES (stroke-dashoffset,
+       box-shadow, background-position, filter, left) freeze to their RESTING
+       frame - the lit state, never a dead one (the reduced-motion block's
+       own law: a dead sign reads as a closed room);
+     - BIG blur() FILTERS (fog 60px, room glow 22px) become soft gradients /
+       a small blur - the look survives, the surface-per-frame does not.
+
+   Transform/opacity-only loops (fog drift, room pulse, ping ring, timebar
+   head breath, glint) are composited and CHEAP - they stay, so the campus
+   still breathes. The split-flap keyframes (arc-flap) are deliberately NOT
+   here: the board reveal is beat-critical and keeps full fidelity. ------- */
+
+/* tonight's route: the marching ants rest, one halo instead of two. The
+   .done arm restates its filter because this guard outranks its bare (0,2,0);
+   the entry reveal keeps its one-shot fade and sheds only the infinite march. */
+html.ae-touch .campus-route {
+  animation:none;
+  filter:drop-shadow(0 0 4px var(--pink));
+}
+html.ae-touch .campus-route.done { filter:none; }
+html.ae-touch .campus-stage.enter .campus-route {
+  animation:campus-routein .9s 1.05s both;
+}
+
+/* neon signs: no flicker, ONE tight halo per sign (~10 filtered groups sit on
+   the plan at once). The .v and .off arms are restated because the base guard
+   outranks their bare selectors; [data-compact]'s tighter 2.5px halo already
+   outranks this and is untouched. */
+html.ae-touch .campus-neon {
+  animation:none;
+  filter:drop-shadow(0 0 5px var(--pink));
+}
+html.ae-touch .campus-neon.v { filter:drop-shadow(0 0 5px var(--lav)); }
+html.ae-touch .campus-neon.off { filter:none; }
+
+/* the bulb chase: parked lit, exactly the reduced-motion treatment. */
+html.ae-touch g.campus-room.open rect.campus-marquee { animation:none; opacity:.85; }
+
+/* the fog: blur(60px) on two 70%x44% sheets was a re-raster the campus paid
+   the whole time it was up. The same hues become one soft-edged ellipse per
+   sheet; the drift stays (transform-only, composited). */
+html.ae-touch .campus-fog { filter:none; }
+html.ae-touch .campus-fog.a {
+  background:radial-gradient(closest-side,
+    color-mix(in srgb, var(--panel2), var(--lav) 18%) 0%,
+    color-mix(in srgb, color-mix(in srgb, var(--panel2), var(--lav) 18%), transparent 45%) 40%,
+    color-mix(in srgb, color-mix(in srgb, var(--panel2), var(--lav) 18%), transparent 80%) 68%,
+    transparent 92%);
+}
+html.ae-touch .campus-fog.b {
+  background:radial-gradient(closest-side,
+    color-mix(in srgb, var(--panel2), var(--pink) 14%) 0%,
+    color-mix(in srgb, color-mix(in srgb, var(--panel2), var(--pink) 14%), transparent 45%) 40%,
+    color-mix(in srgb, color-mix(in srgb, var(--panel2), var(--pink) 14%), transparent 80%) 68%,
+    transparent 92%);
+}
+
+/* room glows: a readable bloom at a fraction of the surface. The opacity
+   pulse riding these is composited and keeps running. */
+html.ae-touch g.campus-room.open .campus-lit,
+html.ae-touch g.campus-room.retake .campus-lit,
+html.ae-touch g.campus-room.facility .campus-lit { filter:blur(8px); }
+
+/* the class time bar's travelling sheen (background-position, the whole
+   class long): parked. The head breath (::before, opacity) still moves, so
+   Law III's "never still" survives on the cheap channel. */
+html.ae-touch .arc-timebar-fill::after { animation:none; }
+
+/* the end card's retake pulse (box-shadow): the arc-reduced resting glow. */
+html.ae-touch .arc-endcard-actions .arc-retake {
+  animation:none;
+  box-shadow:0 0 16px rgba(255,105,180,.4);
+}
+
+/* the ID card sheen (animates `left`): parked off-card at its own 0% frame. */
+html.ae-touch .campus-idcard::after { animation:none; }
+
+/* the photo-rim breaths (box-shadow), furniture card and big card both:
+   parked at their shared 0% frame (no shadow - the border still tells
+   placeholder from real). */
+html.ae-touch .campus-idcard .id-photo,
+html.ae-touch .arc-id-photo { animation:none; }
+
+/* the record spotlight's star wave + slot stir: ten simultaneous filter /
+   background-color loops while the spotlight is up. Parked at their resting
+   frames; the entrance choreography (one-shot) is untouched. */
+html.ae-touch .arc-rs .arc-pc-hole.is-punched,
+html.ae-touch .arc-rs .arc-pc-hole:not(.is-punched) { animation:none; }


### PR DESCRIPTION
Fixes the owner-reported iPhone 13 Pro Max jank (skipped frames, audio landing before its visual, late Scrolller media) on app.cclabs.app/arcademy. Six scoped commits; desktop WebView2 is byte-identical by construction (every change behind html.ae-touch / coarse probe / host!=='desktop') and proven live by the phone-viewport harness: desktop probe shows no ae-touch and all original animation/filter values; phone probe shows the ceiling armed and the diet engaged.

- **ae-touch page-wide** (root cause): the engine's mobile GPU ceiling was armed only by The Deep End and removed on its destroy. core/device.js now arms it at paint (isMobile && touchProbe, add-only, data-ae-touch-global marker); .ae-crt joins the blend kill-list; every node budget gets a lite twin.
- **Impulse Control**: perf ladder arms on touch (was hardcoded off); full-stage backdrop-filter blur(14px) -> static haze; box-shadow/filter breathers frozen; tube loops stop on document.hidden; backdrop mints a muted video for mp4 urls (was silently erroring in an img on web) and draws 70% stills on touch.
- **Deja Vu**: the memorize preview played 12-20 videos at once (2+ playing videos = 30Hz compositor lock; iOS caps decode sessions ~3-4). On touch: rolling 2-video play-window, matched pairs settle to poster.
- **Instant Recall**: lite dials (6 loops / 2 videos) engage on touch, not only the motion setting.
- **Provider on-deck warm rail**: draw selection moved verbatim into computeDraw over a rand FIFO; forecasts peek the same emissions over cloned cursors, so the served sequence is byte-identical (6-case node harness) while the next 6 draws per kind warm bytes+decode ahead (SORT's proven pattern; saveData skips; remote-only so desktop stays inert).
- **Shell GPU diet**: campus SVG marches/flickers frozen at lit resting frames under ae-touch, fog blur(60px) -> radial gradients, room glows 22px -> 8px, ghosts 24 -> 8 on touch, attract tickers halved, tab-hidden suspend on web hosts only (guards for Orientation Day and host-owned suspends).

Pairs with cclabs-web PR perf/arcademy-mobile-shim (early warm + preconnect + iPadOS mp4-only) - merge the shim PR first, then this one (the sync Action vendors + deploys on this merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVfeMhCj5mqWQ1b3pPAUVN