### PR TITLE
feat(text): system font picker for Bouncing Text + Subliminals

### DIFF
--- a/ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml.cs
+++ b/ConditioningControlPanel/Dialogs/ColorEditorDialog.xaml.cs
@@ -32,6 +32,9 @@ namespace ConditioningControlPanel
             ChkTextTransparent.IsChecked = settings.SubTextTransparent;
             ChkStealsFocus.IsChecked = settings.SubliminalStealsFocus;
 
+            // Preview in the face the real subliminal will use, not a hard-coded Arial.
+            PreviewText.FontFamily = Helpers.FontPickerHelper.Resolve(settings.SubliminalFont, "Arial");
+
             UpdateColorButtons();
         }
 

--- a/ConditioningControlPanel/Features/BouncingTextFeatureControl.xaml
+++ b/ConditioningControlPanel/Features/BouncingTextFeatureControl.xaml
@@ -170,6 +170,20 @@
                                     </StackPanel>
                                 </Grid>
 
+                                <!-- Font: any family installed on Windows, plus the bundled Fredoka. -->
+                                <Grid Height="36" ToolTip="Any font installed on Windows. Applies live - no restart.">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{loc:Str label_font}" FontSize="13" FontWeight="SemiBold"
+                                               Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                    <ComboBox Grid.Column="1" x:Name="CmbFont" Height="26" MaxWidth="220"
+                                              HorizontalAlignment="Right" VerticalAlignment="Center"
+                                              Style="{DynamicResource DarkComboBoxStyle}"
+                                              SelectionChanged="CmbFont_Changed"/>
+                                </Grid>
+
                                 <Border Height="1" Margin="0,6" Background="{DynamicResource GlassBorderBrush}"/>
 
                                 <!-- Second text -->

--- a/ConditioningControlPanel/Features/BouncingTextFeatureControl.xaml.cs
+++ b/ConditioningControlPanel/Features/BouncingTextFeatureControl.xaml.cs
@@ -68,6 +68,7 @@ namespace ConditioningControlPanel.Features
                 ChkOutline.IsChecked = s.BouncingTextOutline;
                 ChkSecondText.IsChecked = s.BouncingTextSecondText;
                 ChkAlwaysOnTop.IsChecked = s.BouncingTextAlwaysOnTop;
+                Helpers.FontPickerHelper.Populate(CmbFont, s.BouncingTextFont, "Segoe UI");
                 UpdateSwatch();
                 UpdateFixedColorPanel();
             }
@@ -82,6 +83,7 @@ namespace ConditioningControlPanel.Features
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextOpacity) ||
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextColorMode) ||
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextFixedColor) ||
+                e.PropertyName == nameof(Models.AppSettings.BouncingTextFont) ||
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextFxBreathing) ||
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextFxWobble) ||
                 e.PropertyName == nameof(Models.AppSettings.BouncingTextFxSpin) ||
@@ -161,6 +163,21 @@ namespace ConditioningControlPanel.Features
             s.BouncingTextColorMode = mode;
             App.Settings?.Save();
             UpdateFixedColorPanel();
+            SafeRefresh();
+        }
+
+        // The service re-measures and pushes the family into the live windows on Refresh, so the
+        // pick applies mid-run without a restart (unlike the outline toggle, which swaps element
+        // types).
+        private void CmbFont_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            var name = Helpers.FontPickerHelper.SelectedName(CmbFont);
+            if (string.IsNullOrWhiteSpace(name) || s.BouncingTextFont == name) return;
+            s.BouncingTextFont = name;
+            App.Settings?.Save();
             SafeRefresh();
         }
 

--- a/ConditioningControlPanel/Features/SubliminalFeatureControl.xaml
+++ b/ConditioningControlPanel/Features/SubliminalFeatureControl.xaml
@@ -158,6 +158,21 @@
                                           Style="{StaticResource ToggleStyle}" VerticalAlignment="Center"
                                           Checked="ChkSolidMode_Changed" Unchecked="ChkSolidMode_Changed"/>
                             </Grid>
+
+                            <!-- Font: any family installed on Windows, plus the bundled Fredoka. -->
+                            <Grid Height="34" Background="Transparent"
+                                  ToolTip="Any font installed on Windows. Applies to the next subliminal.">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="90"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{loc:Str label_font}" FontSize="13" FontWeight="SemiBold"
+                                           Foreground="{StaticResource TextLightBrush}" VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="1" x:Name="CmbFont" Height="26" MaxWidth="220"
+                                          HorizontalAlignment="Right" VerticalAlignment="Center"
+                                          Style="{DynamicResource DarkComboBoxStyle}"
+                                          SelectionChanged="CmbFont_Changed"/>
+                            </Grid>
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/ConditioningControlPanel/Features/SubliminalFeatureControl.xaml.cs
+++ b/ConditioningControlPanel/Features/SubliminalFeatureControl.xaml.cs
@@ -61,6 +61,7 @@ namespace ConditioningControlPanel.Features
                 SliderWhisperVol.Value = s.SubAudioVolume;
                 TxtWhisperVol.Text = $"{s.SubAudioVolume}%";
                 ChkSolidMode.IsChecked = s.SubliminalSolidMode;
+                Helpers.FontPickerHelper.Populate(CmbFont, s.SubliminalFont, "Arial");
             }
             finally { _isLoading = false; }
         }
@@ -73,7 +74,8 @@ namespace ConditioningControlPanel.Features
                 e.PropertyName == nameof(Models.AppSettings.SubliminalOpacity) ||
                 e.PropertyName == nameof(Models.AppSettings.SubAudioEnabled) ||
                 e.PropertyName == nameof(Models.AppSettings.SubAudioVolume) ||
-                e.PropertyName == nameof(Models.AppSettings.SubliminalSolidMode))
+                e.PropertyName == nameof(Models.AppSettings.SubliminalSolidMode) ||
+                e.PropertyName == nameof(Models.AppSettings.SubliminalFont))
             {
                 Dispatcher.BeginInvoke(new Action(LoadFromSettings));
             }
@@ -148,6 +150,19 @@ namespace ConditioningControlPanel.Features
             App.Settings?.Save();
             // No service bounce needed: each show reads the setting, so the next subliminal
             // uses the new renderer. An in-flight card finishes out on whichever spawned it.
+        }
+
+        // No service bounce: the text blocks are built per flash, so the next subliminal picks
+        // the new face up on its own.
+        private void CmbFont_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+            var s = App.Settings?.Current;
+            if (s == null) return;
+            var name = Helpers.FontPickerHelper.SelectedName(CmbFont);
+            if (string.IsNullOrWhiteSpace(name) || s.SubliminalFont == name) return;
+            s.SubliminalFont = name;
+            App.Settings?.Save();
         }
 
         private void BtnManageMessages_Click(object sender, RoutedEventArgs e)

--- a/ConditioningControlPanel/Helpers/FontPickerHelper.cs
+++ b/ConditioningControlPanel/Helpers/FontPickerHelper.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace ConditioningControlPanel.Helpers
+{
+    /// <summary>
+    /// Shared plumbing for the "pick any font installed on Windows" pickers (Bouncing Text and
+    /// Subliminals). Three jobs:
+    /// <list type="bullet">
+    ///   <item>enumerate the installed families ONCE per session (<see cref="GetInstalledFontNames"/>),</item>
+    ///   <item>turn a stored family name back into a <see cref="FontFamily"/> that degrades to a
+    ///         sane fallback when the user uninstalls the font (<see cref="Resolve"/>),</item>
+    ///   <item>fill a <see cref="ComboBox"/> so each row previews in its own face (<see cref="Populate"/>).</item>
+    /// </list>
+    ///
+    /// <para>The bundled Fredoka face ships as a pack:// Resource rather than an installed family,
+    /// so it can never come back from <c>Fonts.SystemFontFamilies</c>. It is offered as the
+    /// sentinel <see cref="BundledFredoka"/> and resolved through the same pack URI the exclusives
+    /// header uses (MainWindow/MainWindow.Exclusives.cs).</para>
+    /// </summary>
+    public static class FontPickerHelper
+    {
+        /// <summary>Stored value that means "the Fredoka face bundled with the app".</summary>
+        public const string BundledFredoka = "Fredoka (bundled)";
+
+        /// <summary>
+        /// Last-resort list when font enumeration throws (it reads the font directory, which can
+        /// fail on a locked-down or mid-install machine). Faces every Windows install has.
+        /// </summary>
+        private static readonly string[] FallbackFonts =
+        {
+            "Arial", "Calibri", "Comic Sans MS", "Consolas", "Georgia",
+            "Impact", "Segoe UI", "Tahoma", "Times New Roman", "Verdana"
+        };
+
+        private static IReadOnlyList<string>? _cachedNames;
+        private static FontFamily? _fredoka;
+
+        /// <summary>The bundled Fredoka family, built from the pack URI (single-file safe).</summary>
+        public static FontFamily FredokaFamily =>
+            _fredoka ??= new FontFamily(new Uri("pack://application:,,,/"), "./Fonts/#Fredoka");
+
+        /// <summary>
+        /// Every font family name the user can pick, with <see cref="BundledFredoka"/> first.
+        /// Enumerated once and cached: <c>Fonts.SystemFontFamilies</c> plus the per-family
+        /// culture lookup is expensive enough to feel it if a ComboBox re-populates on every
+        /// settings reload.
+        /// </summary>
+        public static IReadOnlyList<string> GetInstalledFontNames()
+        {
+            if (_cachedNames != null) return _cachedNames;
+
+            try
+            {
+                var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var family in Fonts.SystemFontFamilies)
+                {
+                    var name = DisplayNameOf(family);
+                    if (!string.IsNullOrWhiteSpace(name)) names.Add(name);
+                }
+
+                if (names.Count == 0)
+                    foreach (var f in FallbackFonts) names.Add(f);
+
+                var sorted = names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+                sorted.Insert(0, BundledFredoka);
+                _cachedNames = sorted;
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "FontPickerHelper: font enumeration failed, using the fallback list");
+                var sorted = new List<string> { BundledFredoka };
+                sorted.AddRange(FallbackFonts);
+                _cachedNames = sorted;
+            }
+
+            return _cachedNames;
+        }
+
+        /// <summary>
+        /// The en-US family name when the font declares one, else the raw <c>Source</c>. WPF
+        /// hands localized names back for CJK faces; storing the en-US spelling keeps a settings
+        /// file portable between display languages.
+        /// </summary>
+        private static string DisplayNameOf(FontFamily family)
+        {
+            try
+            {
+                var names = family.FamilyNames;
+                if (names != null)
+                {
+                    var enUs = System.Windows.Markup.XmlLanguage.GetLanguage("en-US");
+                    if (names.TryGetValue(enUs, out var en) && !string.IsNullOrWhiteSpace(en))
+                        return en;
+                }
+            }
+            catch { /* fall through to Source */ }
+
+            return family.Source ?? string.Empty;
+        }
+
+        /// <summary>
+        /// The <see cref="FontFamily"/> for a stored picker value. Unknown/empty names and the
+        /// user uninstalling their pick both degrade to <paramref name="fallback"/> because the
+        /// family is built as a comma-separated chain - WPF walks it and takes the first face it
+        /// can actually load (same idiom as Services/Video/AttentionTargets.cs).
+        /// </summary>
+        public static FontFamily Resolve(string? name, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(fallback)) fallback = "Segoe UI";
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                    return new FontFamily(fallback);
+
+                name = name.Trim();
+                if (string.Equals(name, BundledFredoka, StringComparison.OrdinalIgnoreCase))
+                    return FredokaFamily;
+
+                // A comma in the stored name would turn into a second link in the fallback chain
+                // and silently pick a different face - drop it rather than mis-resolve.
+                if (name.Contains(',')) name = name.Split(',')[0].Trim();
+                if (string.IsNullOrWhiteSpace(name)) return new FontFamily(fallback);
+
+                return string.Equals(name, fallback, StringComparison.OrdinalIgnoreCase)
+                    ? new FontFamily(fallback)
+                    : new FontFamily($"{name}, {fallback}");
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Debug("FontPickerHelper.Resolve({N}) failed: {E}", name, ex.Message);
+                try { return new FontFamily(fallback); }
+                catch { return new FontFamily("Segoe UI"); }
+            }
+        }
+
+        /// <summary>
+        /// Fills <paramref name="cmb"/> with every installed family and selects
+        /// <paramref name="current"/> (or <paramref name="fallback"/> when the stored pick is
+        /// gone). Each row renders in its own face so the list reads as a real font preview.
+        ///
+        /// <para>Hundreds of items: the panel is forced to a virtualizing one and recycling is on,
+        /// so only the visible rows ever realize a Typeface. Items are plain
+        /// <see cref="ComboBoxItem"/>s (Content = display name, Tag = the value to store) rather
+        /// than a bound DataTemplate - the containers ARE the items here, so an ItemContainerStyle
+        /// setter could not bind the per-row family.</para>
+        /// </summary>
+        public static void Populate(ComboBox cmb, string? current, string fallback = "Segoe UI")
+        {
+            if (cmb == null) return;
+
+            try
+            {
+                var wanted = string.IsNullOrWhiteSpace(current) ? fallback : current!.Trim();
+
+                // Cheap path: the settings hook re-runs LoadFromSettings on EVERY property in the
+                // feature's chain (a slider drag included), and rebuilding several hundred
+                // ComboBoxItems each time would stutter. The list never changes mid-session, so
+                // once it is built only the selection moves.
+                if (cmb.Items.Count > 0 && ReferenceEquals(cmb.Tag, _populatedMarker))
+                {
+                    Select(cmb, wanted, fallback);
+                    ApplySelectedFamily(cmb, fallback);
+                    return;
+                }
+
+                cmb.Items.Clear();
+
+                // Realize only what is on screen - a non-virtualizing default panel would build
+                // a Typeface for every installed family on first drop-down.
+                var panel = new ItemsPanelTemplate(
+                    new FrameworkElementFactory(typeof(VirtualizingStackPanel)));
+                panel.Seal();
+                cmb.ItemsPanel = panel;
+                VirtualizingStackPanel.SetIsVirtualizing(cmb, true);
+                VirtualizingStackPanel.SetVirtualizationMode(cmb, VirtualizationMode.Recycling);
+
+                ComboBoxItem? match = null;
+                ComboBoxItem? fallbackItem = null;
+
+                foreach (var name in GetInstalledFontNames())
+                {
+                    var item = new ComboBoxItem
+                    {
+                        Content = name,
+                        Tag = name,
+                        FontFamily = Resolve(name, fallback),
+                        FontSize = 14
+                    };
+                    cmb.Items.Add(item);
+
+                    if (match == null && string.Equals(name, wanted, StringComparison.OrdinalIgnoreCase))
+                        match = item;
+                    if (fallbackItem == null && string.Equals(name, fallback, StringComparison.OrdinalIgnoreCase))
+                        fallbackItem = item;
+                }
+
+                cmb.SelectedItem = match ?? fallbackItem;
+                if (cmb.SelectedItem == null && cmb.Items.Count > 0) cmb.SelectedIndex = 0;
+                cmb.Tag = _populatedMarker;
+                ApplySelectedFamily(cmb, fallback);
+            }
+            catch (Exception ex)
+            {
+                App.Logger?.Warning(ex, "FontPickerHelper.Populate failed");
+            }
+        }
+
+        /// <summary>Marks a ComboBox this helper has already filled - see the cheap path in Populate.</summary>
+        private static readonly object _populatedMarker = new();
+
+        /// <summary>Moves the selection to <paramref name="wanted"/>, else to <paramref name="fallback"/>.</summary>
+        private static void Select(ComboBox cmb, string wanted, string fallback)
+        {
+            ComboBoxItem? fallbackItem = null;
+            foreach (var obj in cmb.Items)
+            {
+                if (obj is not ComboBoxItem item || item.Tag is not string name) continue;
+                if (string.Equals(name, wanted, StringComparison.OrdinalIgnoreCase))
+                {
+                    cmb.SelectedItem = item;
+                    return;
+                }
+                if (fallbackItem == null && string.Equals(name, fallback, StringComparison.OrdinalIgnoreCase))
+                    fallbackItem = item;
+            }
+            if (fallbackItem != null) cmb.SelectedItem = fallbackItem;
+        }
+
+        /// <summary>
+        /// Paints the CLOSED box in the picked face. The template's ContentPresenter renders
+        /// SelectionBoxItem - the item's Content string, not the item - so it inherits the
+        /// ComboBox's family; each row still wins with its own local value.
+        /// </summary>
+        private static void ApplySelectedFamily(ComboBox cmb, string fallback)
+        {
+            var name = SelectedName(cmb);
+            if (!string.IsNullOrWhiteSpace(name)) cmb.FontFamily = Resolve(name, fallback);
+        }
+
+        /// <summary>The stored value behind a ComboBox row, or null when nothing is selected.</summary>
+        public static string? SelectedName(ComboBox cmb)
+            => (cmb?.SelectedItem as ComboBoxItem)?.Tag as string;
+    }
+}

--- a/ConditioningControlPanel/Models/AppSettings.cs
+++ b/ConditioningControlPanel/Models/AppSettings.cs
@@ -1436,6 +1436,16 @@ namespace ConditioningControlPanel.Models
             set { _subTextColor = value ?? "#FF00FF"; OnPropertyChanged(); }
         }
 
+        // Family name of any font installed on Windows, or the "Fredoka (bundled)" sentinel.
+        // Read per flash by SubliminalService.CreateTextBlock via Helpers.FontPickerHelper.Resolve
+        // (chains to Arial, this feature's historical face, if the pick is gone).
+        private string _subliminalFont = "Arial";
+        public string SubliminalFont
+        {
+            get => _subliminalFont;
+            set { _subliminalFont = string.IsNullOrWhiteSpace(value) ? "Arial" : value; OnPropertyChanged(); }
+        }
+
         private bool _subTextTransparent = false;
         public bool SubTextTransparent
         {
@@ -4096,6 +4106,16 @@ namespace ConditioningControlPanel.Models
         {
             get => _bouncingTextFixedColor;
             set { _bouncingTextFixedColor = value ?? ""; OnPropertyChanged(); }
+        }
+
+        // Family name of any font installed on Windows, or the "Fredoka (bundled)" sentinel for
+        // the face that ships with the app. Resolved through Helpers.FontPickerHelper.Resolve,
+        // which chains to Segoe UI so uninstalling the pick degrades instead of throwing.
+        private string _bouncingTextFont = "Segoe UI";
+        public string BouncingTextFont
+        {
+            get => _bouncingTextFont;
+            set { _bouncingTextFont = string.IsNullOrWhiteSpace(value) ? "Segoe UI" : value; OnPropertyChanged(); }
         }
 
         private bool _bouncingTextFxBreathing = false;

--- a/ConditioningControlPanel/Resources/Theme/MainWindow.xaml
+++ b/ConditioningControlPanel/Resources/Theme/MainWindow.xaml
@@ -1289,8 +1289,15 @@
                                         BorderBrush="{DynamicResource TransparentPink20Brush}"
                                         BorderThickness="1" SnapsToDevicePixels="True"
                                         MinWidth="{TemplateBinding ActualWidth}">
+                                    <!-- CanContentScroll is what the STOCK ComboBox template sets and
+                                         this one had dropped; without it a ScrollViewer pixel-scrolls,
+                                         which silently disables item virtualization no matter what the
+                                         ItemsPanel says. The font picker (Helpers/FontPickerHelper.cs)
+                                         lists every installed family, so it needs the realized rows
+                                         capped. Cost elsewhere: rows scroll by item, not by pixel. -->
                                     <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto"
-                                                  HorizontalScrollBarVisibility="Disabled">
+                                                  HorizontalScrollBarVisibility="Disabled"
+                                                  CanContentScroll="True">
                                         <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained"/>
                                     </ScrollViewer>
                                 </Border>

--- a/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/BouncingTextService.cs
@@ -53,6 +53,12 @@ public class BouncingTextService : IDisposable
     private const int BASE_FONT_SIZE = 72;
     private int _currentFontSize = BASE_FONT_SIZE;
 
+    /// <summary>
+    /// The font family name the running logos were built/measured with, so Refresh() can spot a
+    /// mid-run change the same way it spots a size change. Empty until Start().
+    /// </summary>
+    private string _currentFont = "";
+
     // Corner hit detection - tolerance in pixels (corners are hard to hit exactly)
     private const double CORNER_TOLERANCE = 15.0;
 
@@ -137,6 +143,7 @@ public class BouncingTextService : IDisposable
 
         // Calculate font size based on settings (50-300% of base)
         _currentFontSize = (int)(BASE_FONT_SIZE * settings.BouncingTextSize / 100.0);
+        _currentFont = settings.BouncingTextFont ?? "Segoe UI";
 
         // Calculate screen bounds
         CalculateScreenBounds(settings.DualMonitorEnabled);
@@ -279,7 +286,9 @@ public class BouncingTextService : IDisposable
     {
         try
         {
-            var typeface = new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+            var typeface = new Typeface(
+                Helpers.FontPickerHelper.Resolve(App.Settings?.Current?.BouncingTextFont, "Segoe UI"),
+                FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
             // MainWindow can be null during startup/shutdown; GetDpi(null) throws an
             // NRE that the catch below swallows into a noisy [WRN] (#305). Resolve a
             // DPI source that may be null and fall back to 1.0 PixelsPerDip.
@@ -768,6 +777,20 @@ public class BouncingTextService : IDisposable
             }
         }
 
+        // Same shape for the font family: re-measure (the glyph widths change) then push the new
+        // family into every window's visuals. No restart needed - the element type is unchanged.
+        var newFont = settings.BouncingTextFont ?? "Segoe UI";
+        if (!string.Equals(newFont, _currentFont, StringComparison.OrdinalIgnoreCase))
+        {
+            _currentFont = newFont;
+            foreach (var l in _logos)
+                MeasureTextSize(l);
+
+            var family = Helpers.FontPickerHelper.Resolve(newFont, "Segoe UI");
+            foreach (var window in _windows)
+                window.UpdateFontFamily(family);
+        }
+
         // Live opacity
         foreach (var window in _windows)
             window.UpdateOpacity(settings.BouncingTextOpacity);
@@ -860,6 +883,9 @@ internal class BouncingTextWindow : Window
 
     private LogoVisual CreateLogoVisual(int fontSize, int opacity)
     {
+        // The user's pick (any installed family, or the bundled Fredoka sentinel). Resolved per
+        // visual rather than cached on the window so a mid-run Refresh sees the current setting.
+        var family = Helpers.FontPickerHelper.Resolve(App.Settings?.Current?.BouncingTextFont, "Segoe UI");
         var v = new LogoVisual
         {
             Scale = new ScaleTransform(1, 1),
@@ -873,6 +899,7 @@ internal class BouncingTextWindow : Window
         {
             v.Ot = new OutlinedText
             {
+                Family = family,
                 FontSize = fontSize,
                 FontWeight = FontWeights.Bold,
                 Fill = Brushes.HotPink,
@@ -889,6 +916,7 @@ internal class BouncingTextWindow : Window
         {
             v.Tb = new TextBlock
             {
+                FontFamily = family,
                 FontSize = fontSize,
                 FontWeight = FontWeights.Bold,
                 Foreground = Brushes.HotPink,
@@ -940,6 +968,28 @@ internal class BouncingTextWindow : Window
             {
                 v.Ot.FontSize = fontSize;
                 v.Ot.StrokeThickness = Math.Max(2.0, fontSize / 22.0);
+                v.Ot.Build();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Live font-family swap, mirroring <see cref="UpdateFontSize"/>. OutlinedText caches its
+    /// geometry on a key that includes the family, so it needs an explicit rebuild; a TextBlock
+    /// re-measures itself.
+    /// </summary>
+    public void UpdateFontFamily(FontFamily family)
+    {
+        if (family == null) return;
+        foreach (var v in _visuals)
+        {
+            if (v.Tb != null)
+            {
+                v.Tb.FontFamily = family;
+            }
+            else if (v.Ot != null)
+            {
+                v.Ot.Family = family;
                 v.Ot.Build();
             }
         }

--- a/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
+++ b/ConditioningControlPanel/Services/Subliminal/SubliminalService.cs
@@ -1241,7 +1241,10 @@ namespace ConditioningControlPanel.Services
                 Text = text,
                 FontSize = fontSize,
                 FontWeight = FontWeights.Bold,
-                FontFamily = new FontFamily("Arial"),
+                // The user's pick, read per card (they are built per flash, so a change lands on
+                // the next subliminal with no plumbing). Arial stays the fallback - it is the face
+                // this feature always used.
+                FontFamily = Helpers.FontPickerHelper.Resolve(App.Settings.Current.SubliminalFont, "Arial"),
                 Foreground = new SolidColorBrush(color),
                 TextAlignment = TextAlignment.Center,
                 IsHitTestVisible = false


### PR DESCRIPTION
Discord suggestion (WinterRose, feedback-and-suggestions 1541807265932116049): choose your own installed fonts for the text-heavy features.

- New **Font** row in the Bouncing Text and Subliminal panels, listing every font installed on Windows (plus bundled Fredoka), each row previewed in its own face
- `BouncingTextFont` (default Segoe UI) / `SubliminalFont` (default Arial) in AppSettings
- Bouncing text re-measures hitboxes and swaps the face live; subliminals use it on the next flash; Advanced-dialog preview follows
- `DarkComboBoxStyle` popup ScrollViewer now sets `CanContentScroll=True` so long item lists virtualize (rows scroll per item instead of per pixel; only lists taller than 240px are affected)
- Reuses existing `label_font` loc key, no new keys
- Mod Manager fonts not in scope (no typography channel in the manifest yet)

Build: 0 errors, warning count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnpDoiEJVni4xVVFyPRdUL