### PR TITLE
feat(emi): more alive - bark floor 40s, off-class odds x1.5, channels 3x sooner, idle fidget

### DIFF
--- a/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
+++ b/ConditioningControlPanel/Resources/web/arcademy/CLAUDE.md
@@ -2428,6 +2428,22 @@ and it is not a third gate** - see trap 99, `init.devAnnex`.
     Same PR: the phone bell chip is two lines (grid, icon spanning both rows) stepped left
     of the bell tower's painted clock by clamp(32px, 5vw, 48px); every rule html.arc-mobile.
 
+107. **EMI'S CADENCE IS THREE DIALS AND ONE LATCH, RETUNED 2026-08-25 (owner: "very
+    few comments and animations").** `voice.js` `BARK_FLOOR_MS` 90s -> 40s;
+    `CAMPUS_ODDS_MULT` x1.5 scales a pool's odds on every moment that is NOT in
+    `MID_CLASS_MOMENTS` (miss/fail/runLost/tense/clutch/thinking) AND not while the
+    session latch `S.inClass` is up (classStart/suspend set it, win/fail/runLost/
+    reportCard/dayDone/greet/resume clear it - `miss` does NOT, a miss is mid-class).
+    `channels.js` `SL_DIALS` 90s/20s/180s/6 -> 30s/10s/60s/14 and every per-channel
+    cooldown halved. NEW: **the fidget** - a weighted wordless chain (`FIDGET_CHAINS`,
+    glance/wink/thinking/sus/nod/smug/dizzy/wake) that rides `blinkIdle` AFTER the
+    glitch passes, `FIDGET_ODDS` per blink, campus-only, and never inside
+    `FIDGET_AFTER_SAY_MS` of a line (`S.lastSayAt` is stamped in `sayIt`, the one
+    funnel every bark/beat/ask lands through). It owns no timer: it can only fire
+    when the blink can, so the blink's own guards (busy/hidden/dragging/disabled)
+    are its guards. A pool with `maxPerSession` (idlePlayer = 2) still caps itself
+    - the multiplier moves the dice, never the ration or the doubles slot.
+
 ## 5. The game module contract (short version)
 
 ```js

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/barks.js
@@ -19,8 +19,11 @@
  * MOMENTS. A bark REPLACES that reaction, and only sometimes:
  *
  *   1. odds        - per pool, default 0.25. One time in four, roughly.
- *   2. floor       - >= 90s between any two barks, globally (BARK_FLOOR_MS in
- *                    voice.js). Pools marked `ceremony:true` are exempt: an S,
+ *   2. floor       - >= 40s between any two barks, globally (BARK_FLOOR_MS in
+ *                    voice.js; 90s until 2026-08-25). Off-class moments also
+ *                    get CAMPUS_ODDS_MULT (x1.5) on the odds below - in class
+ *                    the player is looking at the game, not at her.
+ *                    Pools marked `ceremony:true` are exempt: an S,
  *                    a mastered card, a streak milestone is rare by nature.
  *   3. no-repeat   - never the same line twice in a row from one pool. Pools of
  *                    one line carry `noRepeat:false` so they are not self-muting.

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/channels.js
@@ -43,10 +43,14 @@ import { makeRng } from '../core/rng.js';
  * Every number the wave has, in one frozen object, the way voice.js and vox.js
  * keep theirs - so the owner can retune the cadence without reading the paint. */
 export const SL_DIALS = Object.freeze({
-  THEATRE_IDLE_MS: 90000,     // the floor: no channel before this much player silence
-  ROLL_MS: 20000,             // wheel cadence while eligible
-  GLOBAL_COOLDOWN_MS: 180000, // no two takeovers closer than this (deep idle exempt)
-  PER_SESSION_CAP: 6,         // rolled channels per sitting (deep idle exempt)
+  /* RETUNED 2026-08-25 (owner: "the screen animations are entertaining, they
+   * should be frequent and used to distance the barks"). Was 90s / 20s / 180s
+   * / 6 - the lab-experiment cadence. Now a channel can roll after half a
+   * minute of silence and about once a minute after that. */
+  THEATRE_IDLE_MS: 30000,     // the floor: no channel before this much player silence
+  ROLL_MS: 10000,             // wheel cadence while eligible
+  GLOBAL_COOLDOWN_MS: 60000,  // no two takeovers closer than this (deep idle exempt)
+  PER_SESSION_CAP: 14,        // rolled channels per sitting (deep idle exempt)
   TAKEOVER_MAX_MS: 10000,     // the hard cap (the screensaver alone is exempt)
   BLIP_MS: 180,               // collapse-to-line + line-to-dot, total
   OFFER_MS: 5000,             // the "wanna see?" window
@@ -58,9 +62,9 @@ export const SL_DIALS = Object.freeze({
   WRONG_ODDS: 1 / 40,         // per rolled-channel exit, labSeen, 1/session
   WRONG_MAX_MS: 400,
   WEIGHTS: Object.freeze({ pong: 30, browsing: 30, watching: 18, reruns: 12, shop: 7 }),
-  COOLDOWN_MS: Object.freeze({
-    pong: 480000, browsing: 480000, watching: 900000,
-    reruns: 1200000, shop: 1800000,
+  COOLDOWN_MS: Object.freeze({           // per channel, halved 2026-08-25 with the cadence above
+    pong: 240000, browsing: 240000, watching: 480000,
+    reruns: 600000, shop: 900000,
   }),
 });
 

--- a/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
+++ b/ConditioningControlPanel/Resources/web/arcademy/emi/voice.js
@@ -83,7 +83,25 @@ import { sayHoldMs, SAY_LEAD_MS } from './widget.js';
 export const VOICE_DIALS = Object.freeze({
   /* --- the seldom channel ---------------------------------------------- */
   BARK_ODDS: 0.25,           // default chance a pool speaks instead of staying wordless
-  BARK_FLOOR_MS: 90000,      // no two barks closer than this (ceremony pools exempt)
+  BARK_FLOOR_MS: 40000,      // no two barks closer than this (ceremony pools exempt)
+                             // (90s until 2026-08-25; owner: "slightly more frequent")
+  /* OUT-OF-CLASS BOOST (owner, 2026-08-25). In class the player is looking at
+   * the game, not at her, so a line spent there is half-wasted. Every moment
+   * that is NOT mid-class (see MID_CLASS_MOMENTS) has its pool odds scaled by
+   * this before the dice roll; capped at 1, ceremony pools already sit at 1. */
+  CAMPUS_ODDS_MULT: 1.5,
+  /* THE FIDGET (owner, 2026-08-25): a wordless chain between barks, so the
+   * space between two lines is not just breath and blink. Rides the idle blink
+   * (BLINK_EVERY_MS, ~5.2s) like the glitch does - NO timer of its own, and it
+   * cannot fire on a page nobody is touching any more than the blink can.
+   * Odds are PER BLINK: 0.14 x 5.2s = one fidget every ~37s of campus idle. */
+  FIDGET_ODDS: 0.14,
+  FIDGET_AFTER_SAY_MS: 7000,  // never right on the heels of a bark or a beat
+  FIDGET_CHAINS: Object.freeze([
+    // weight, chain. The quiet ones lead; the loud ones are the spice.
+    [5, 'glance'], [4, 'wink'], [3, 'thinking'], [3, 'sus'], [2, 'nod'],
+    [2, 'smug'], [1, 'dizzy'], [1, 'wake'],
+  ]),
   FRESH_WEIGHT: 3,           // an unheard line is this many times likelier than a heard one
   DOUBLES_PER_SESSION: 1,    // the suspiciously-human register, capped across ALL pools
 
@@ -131,6 +149,14 @@ const BLOB_VERSION = 1;
  * to the lab door that is coming. Not a quiet one - none. It is enforced HERE,
  * in the engine, so no future data file can open it by accident. */
 const SILENT_TARGETS = Object.freeze({ records: true, lab: true });
+
+/* Moments that land while the player is INSIDE a class and looking at the
+ * game. These keep their written odds; everything else gets CAMPUS_ODDS_MULT.
+ * classStart / win / stamp / reportCard are on the room card, where she is in
+ * view, so they count as campus. */
+const MID_CLASS_MOMENTS = Object.freeze({
+  miss: true, fail: true, runLost: true, tense: true, clutch: true, thinking: true,
+});
 
 /** The seen-flag for the forced post-lab greet (owner rec 4). */
 const POST_LAB_GREET_FLAG = 'postLabGreet';
@@ -330,6 +356,11 @@ export function createVoice(o) {
      * wanted the name gets the un-named variant instead of being dropped - the
      * beat still lands, it just does not say your name twice in a night. */
     nameDropped: false,
+    /* THE FIDGET's two reads: are we in a class right now (classStart ->
+     * win/fail/runLost/reportCard/dayDone/greet/resume), and when did she last
+     * have a line up (any bark, beat or ask lands through sayIt). */
+    inClass: false,
+    lastSayAt: 0,
   };
   S.openedBad = blob.lastSessionEnd === 'bad';
 
@@ -813,6 +844,7 @@ export function createVoice(o) {
     let done = false;
     try { done = !!emi.say(text, { face: face || undefined, nod: nod === true }); }
     catch (e) { return false; }
+    if (done) S.lastSayAt = now();
     if (done && wants && name) S.nameDropped = true;
     return done;
   }
@@ -950,7 +982,8 @@ export function createVoice(o) {
     /* THE FLOOR. Ninety seconds between any two barks; a ceremony is rare by
      * nature and is exempt by DECLARATION, never by accident. */
     if (!pool.ceremony && S.lastBarkAt && (c.now - S.lastBarkAt) < D.BARK_FLOOR_MS) return false;
-    const odds = typeof pool.odds === 'number' ? pool.odds : D.BARK_ODDS;
+    let odds = typeof pool.odds === 'number' ? pool.odds : D.BARK_ODDS;
+    if (!MID_CLASS_MOMENTS[name] && !S.inClass) odds = Math.min(1, odds * D.CAMPUS_ODDS_MULT);
     if (odds < 1 && rng() >= odds) return false;
     const line = pickLine(pool, c);
     if (!line) return false;
@@ -1007,6 +1040,25 @@ export function createVoice(o) {
    * One frame, once a session at most, only after the lab, and never in the
    * first minute of the first three sessions after it - the gag must not
    * cluster near the memory of the room it leaks from. */
+  /* ---------------------- the fidget --------------------------------------
+   * Wordless, weighted, campus-only. Rides `blinkIdle`, after the glitch has
+   * passed on it. Refuses in class, while she is busy, and inside
+   * FIDGET_AFTER_SAY_MS of any line - the line is the point, the fidget is
+   * the space between two lines. */
+  function fidget() {
+    if (S.inClass) return false;
+    if (S.lastSayAt && now() - S.lastSayAt < D.FIDGET_AFTER_SAY_MS) return false;
+    if (S.lastBarkAt && now() - S.lastBarkAt < D.FIDGET_AFTER_SAY_MS) return false;
+    if (rng() >= D.FIDGET_ODDS) return false;
+    const table = D.FIDGET_CHAINS;
+    let total = 0;
+    for (const e of table) total += Number(e[0]) || 0;
+    let r = rng() * total;
+    let chain = table[table.length - 1][1];
+    for (const e of table) { r -= Number(e[0]) || 0; if (r < 0) { chain = e[1]; break; } }
+    return emoteIt({ chain });
+  }
+
   function glitch() {
     if (!blob.labSeen) return false;
     if (S.glitchCount >= D.GLITCH_PER_SESSION) return false;
@@ -1096,6 +1148,12 @@ export function createVoice(o) {
       /* THE GEOFENCE, FIRST AND UNCONDITIONAL. Not a quiet reaction: none. */
       if (name === 'lockedClick' && p && SILENT_TARGETS[String(p.what)]) return false;
 
+      /* THE CLASS LATCH, read even before the script lands. Same rungs as
+       * widget.js noteMoment minus `miss` (a miss is mid-class, not the end). */
+      if (name === 'classStart' || name === 'suspend') S.inClass = true;
+      else if (name === 'win' || name === 'fail' || name === 'runLost' || name === 'reportCard'
+        || name === 'dayDone' || name === 'greet' || name === 'resume') S.inClass = false;
+
       if (!ready || !canPerform()) {
         /* NOT YET. Either the script has not landed or the face has not, and
          * both mean the same thing: consuming a one-shot beat here would burn
@@ -1135,7 +1193,7 @@ export function createVoice(o) {
       /* THE IDLE BLINK IS THE ONE UNATTENDED "GESTURE", so it reaches the
        * GLITCH and nothing else: no beat and no bark may ever be spent by a
        * page nobody is touching (field bug, 2026-08-24). */
-      if (kind === 'blinkIdle') return glitch();
+      if (kind === 'blinkIdle') return glitch() || fidget();
       let payload = p || {};
       if (kind === 'dropAt') {
         const hit = hitTest(Number(payload.x) || 0, Number(payload.y) || 0);


### PR DESCRIPTION
## Why
Owner: EMI shows very few comments and animations across the screens. In class the player is looking at the game, so lines there are half-wasted; the screen channels are entertaining and should be frequent, spacing the barks out.

## What (all `Resources/web/arcademy/emi/`, no line text changed)
| Dial | Was | Now |
|---|---|---|
| `voice.js BARK_FLOOR_MS` | 90 s | **40 s** (owner call) |
| `voice.js CAMPUS_ODDS_MULT` (new) | - | **x1.5** on pool odds for every non-mid-class moment while the session `inClass` latch is down |
| `channels.js THEATRE_IDLE_MS / ROLL_MS / GLOBAL_COOLDOWN_MS / PER_SESSION_CAP` | 90 s / 20 s / 180 s / 6 | **30 s / 10 s / 60 s / 14** |
| `channels.js COOLDOWN_MS` per channel | 8/8/15/20/30 min | **4/4/8/10/15 min** |

**New: the fidget.** A weighted wordless chain (glance 5, wink 4, thinking 3, sus 3, nod 2, smug 2, dizzy 1, wake 1) that rides `blinkIdle` after the glitch passes, `FIDGET_ODDS` 0.14 per blink (~one every 37 s of campus idle), campus-only, never within 7 s of any landed line (`S.lastSayAt` stamped in `sayIt`). Owns no timer: it can only fire when the blink can, so busy/hidden/dragging/disabled are already its guards.

Class latch: `classStart`/`suspend` set, `win`/`fail`/`runLost`/`reportCard`/`dayDone`/`greet`/`resume` clear - `miss` does not (mid-class).

## Proof
Node harness (fixed rng + clock) over the worktree copy: floor refuses at +30 s and allows at +41 s; idlePlayer odds 0.5 pass at rng 0.6 on campus (x1.5) and mid-class `miss` 0.25 refuses at 0.3 (no mult); fidget refused in class and 1 s after a line, fires on campus. Trap 107 added to web CLAUDE.md.

## Left
Owner play-test on `--arcademy` (Debug build); dial `FIDGET_ODDS` / `CAMPUS_ODDS_MULT` by feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L63DrmfxLze24du2Jt5hXM
